### PR TITLE
feat: add feathered alpha fog overlay

### DIFF
--- a/apps/cocos-client/README.md
+++ b/apps/cocos-client/README.md
@@ -46,12 +46,13 @@
   - Cocos Tilemap 渲染适配层
   - 约定读取 `terrain / fog / fogEdge / objects / overlay` 五个图层
   - 会按 tile 签名增量更新 `gid`，避免整图重刷
+  - 默认启用 `alphaFogOverlayEnabled`，会保留 Tilemap 作为主渲染路径，但把正式迷雾羽化交给 Overlay 层处理
   - `fogEdge` 可选；配置 `hiddenFogEdgeBaseGid / exploredFogEdgeBaseGid` 后会按正交邻接关系自动补迷雾边缘过渡
   - 如再配置 `hiddenFogPulseGid / exploredFogPulseGid` 与 `hiddenFogEdgePulseOffset / exploredFogEdgePulseOffset`，可得到低成本的动态迷雾脉冲效果
 - `assets/scripts/VeilFogOverlay.ts`
-  - 非 Tilemap 回退模式下的独立迷雾覆盖层
-  - 会根据 `hidden / explored / visible` 与迷雾相位切换字符遮罩和透明度
-  - 作为后续 shader / Alpha 混合前的过渡实现，避免文字网格模式下完全没有迷雾层次
+  - Tilemap 与非 Tilemap 共用的独立迷雾覆盖层
+  - 会根据 `hidden / explored / visible`、邻接 frontier 方向与迷雾相位，绘制羽化的 Alpha 混合覆盖
+  - 在未挂正式 `TiledMap` 时仍可作为回退迷雾方案，避免文字网格模式下完全没有迷雾层次
 - `assets/scripts/VeilMapBoard.ts`
   - 资源点/守军/敌方英雄的对象标签现已支持轻量回弹反馈
   - 当前会在拾取资源、接触守军或点击带对象的目标格时触发
@@ -78,6 +79,7 @@
    - 至少准备 `terrain / fog / objects / overlay` 四个 layer
    - 如果想启用迷雾边缘过渡，可额外加一个 `fogEdge` layer
    - 在 `VeilTilemapRenderer` Inspector 里把 terrain/fog/资源/高亮的 `gid` 映射到你的 tileset；如配置 `fogEdge`，可再设置 `hiddenFogEdgeBaseGid / exploredFogEdgeBaseGid`
+   - 如需正式羽化迷雾，保持 `alphaFogOverlayEnabled = true`；如果想回退到纯 Tilemap 的硬边 fog/fogEdge layer，可手动关闭它
 5. 在 Inspector 里配置：
    - `roomId`
    - `playerId`

--- a/apps/cocos-client/assets/scripts/VeilFogOverlay.ts
+++ b/apps/cocos-client/assets/scripts/VeilFogOverlay.ts
@@ -4,6 +4,10 @@ import type { FogOverlayStyle } from "./cocos-map-visuals.ts";
 const { ccclass, property } = _decorator;
 const HIDDEN_FOG = new Color(13, 19, 30, 255);
 const EXPLORED_FOG = new Color(42, 57, 76, 255);
+const NORTH_BIT = 1;
+const EAST_BIT = 2;
+const SOUTH_BIT = 4;
+const WEST_BIT = 8;
 
 @ccclass("ProjectVeilFogOverlay")
 export class VeilFogOverlay extends Component {
@@ -61,24 +65,74 @@ export class VeilFogOverlay extends Component {
       return;
     }
 
-    const width = this.tileSize - 12;
-    const height = this.tileSize - 12;
+    const width = this.tileSize - 6;
+    const height = this.tileSize - 6;
     const baseColor = style.tone === "hidden" ? HIDDEN_FOG : EXPLORED_FOG;
+    const radius = Math.max(10, Math.floor(this.tileSize * 0.18));
+    const featherWidth = Math.max(12, Math.floor(this.tileSize * 0.16));
+    const innerWidth = Math.max(12, width - featherWidth * 2);
+    const innerHeight = Math.max(12, height - featherWidth * 2);
 
     this.graphics.clear();
-    this.graphics.fillColor = new Color(baseColor.r, baseColor.g, baseColor.b, style.opacity);
+    this.graphics.fillColor = new Color(baseColor.r, baseColor.g, baseColor.b, Math.max(10, Math.floor(style.edgeOpacity * 0.4)));
+    this.graphics.roundRect(-width / 2, -height / 2, width, height, radius);
+    this.graphics.fill();
 
-    if (style.tone === "hidden") {
-      const radius = Math.max(8, Math.floor(this.tileSize * 0.18));
-      this.graphics.circle(-width * 0.18, 0, radius);
-      this.graphics.circle(width * 0.04, height * 0.1, radius * 0.95);
-      this.graphics.circle(width * 0.22, -height * 0.02, radius * 0.85);
-      this.graphics.roundRect(-width * 0.22, -height * 0.16, width * 0.46, height * 0.18, Math.max(6, radius - 2));
-      this.graphics.fill();
+    this.graphics.fillColor = new Color(baseColor.r, baseColor.g, baseColor.b, style.opacity);
+    this.graphics.roundRect(
+      -innerWidth / 2,
+      -innerHeight / 2,
+      innerWidth,
+      innerHeight,
+      Math.max(6, radius - Math.floor(featherWidth * 0.35))
+    );
+    this.graphics.fill();
+
+    this.paintFeatheredEdge(baseColor, style, "north", -width / 2, width, height / 2 - featherWidth, featherWidth);
+    this.paintFeatheredEdge(baseColor, style, "south", -width / 2, width, -height / 2, featherWidth);
+    this.paintFeatheredEdge(baseColor, style, "west", -width / 2, featherWidth, -height / 2, height);
+    this.paintFeatheredEdge(baseColor, style, "east", width / 2 - featherWidth, featherWidth, -height / 2, height);
+  }
+
+  private paintFeatheredEdge(
+    baseColor: Color,
+    style: FogOverlayStyle,
+    direction: "north" | "east" | "south" | "west",
+    x: number,
+    width: number,
+    y: number,
+    height: number
+  ): void {
+    if (!this.graphics) {
       return;
     }
 
-    this.graphics.roundRect(-width * 0.28, -height * 0.08, width * 0.56, height * 0.12, Math.max(6, Math.floor(this.tileSize * 0.1)));
-    this.graphics.fill();
+    const maskBit =
+      direction === "north"
+        ? NORTH_BIT
+        : direction === "east"
+          ? EAST_BIT
+          : direction === "south"
+            ? SOUTH_BIT
+            : WEST_BIT;
+    const frontier = (style.featherMask & maskBit) !== 0;
+    const steps = frontier ? [0.35, 0.52, 0.7, 0.88] : [1, 1, 1, 1];
+    const horizontal = direction === "north" || direction === "south";
+
+    for (let index = 0; index < steps.length; index += 1) {
+      const alpha = Math.max(8, Math.floor(style.edgeOpacity * steps[index]!));
+      this.graphics.fillColor = new Color(baseColor.r, baseColor.g, baseColor.b, alpha);
+
+      if (horizontal) {
+        const bandHeight = height / steps.length;
+        const bandY = direction === "north" ? y + bandHeight * (steps.length - index - 1) : y + bandHeight * index;
+        this.graphics.roundRect(x, bandY, width, bandHeight + 1, 0);
+      } else {
+        const bandWidth = width / steps.length;
+        const bandX = direction === "west" ? x + bandWidth * index : x + bandWidth * (steps.length - index - 1);
+        this.graphics.roundRect(bandX, y, bandWidth + 1, height, 0);
+      }
+      this.graphics.fill();
+    }
   }
 }

--- a/apps/cocos-client/assets/scripts/VeilMapBoard.ts
+++ b/apps/cocos-client/assets/scripts/VeilMapBoard.ts
@@ -150,7 +150,7 @@ export class VeilMapBoard extends Component {
       this.syncTileSprite(tileView, tile, usesTilemapRenderer);
       this.paintTileChrome(tileView.graphics, tile, isReachable, isHeroTile);
       tileView.label.string = usesTilemapRenderer ? "" : this.tileText(tile, tileLookup, isReachable, isHeroTile);
-      tileView.fogOverlay.render(buildFogOverlayStyle(tile, tileLookup, this.fogPulsePhase), !usesTilemapRenderer);
+      tileView.fogOverlay.render(buildFogOverlayStyle(tile, tileLookup, this.fogPulsePhase), true);
       this.renderObjectMarker(tile, width, height, usesTilemapRenderer);
     });
 

--- a/apps/cocos-client/assets/scripts/VeilTilemapRenderer.ts
+++ b/apps/cocos-client/assets/scripts/VeilTilemapRenderer.ts
@@ -70,6 +70,9 @@ export class VeilTilemapRenderer extends Component {
   exploredFogEdgePulseOffset = 0;
 
   @property
+  alphaFogOverlayEnabled = true;
+
+  @property
   woodResourceGid = 1;
 
   @property
@@ -127,11 +130,13 @@ export class VeilTilemapRenderer extends Component {
     for (const tile of tiles) {
       const key = this.tileKey(tile.position);
       usedKeys.add(key);
-      const baseFogGid = this.fogGidForTile(tile);
-      const baseFogEdgeGid = fogEdgeGidForTile(tile, tileLookup, {
-        hiddenFogEdgeBaseGid: this.hiddenFogEdgeBaseGid,
-        exploredFogEdgeBaseGid: this.exploredFogEdgeBaseGid
-      });
+      const baseFogGid = this.alphaFogOverlayEnabled ? 0 : this.fogGidForTile(tile);
+      const baseFogEdgeGid = this.alphaFogOverlayEnabled
+        ? 0
+        : fogEdgeGidForTile(tile, tileLookup, {
+            hiddenFogEdgeBaseGid: this.hiddenFogEdgeBaseGid,
+            exploredFogEdgeBaseGid: this.exploredFogEdgeBaseGid
+          });
 
       this.applyCachedGid(terrainLayer, this.cachedTerrainGids, tile.position, key, this.terrainGidForTile(tile));
       this.applyCachedGid(

--- a/apps/cocos-client/assets/scripts/cocos-map-visuals.ts
+++ b/apps/cocos-client/assets/scripts/cocos-map-visuals.ts
@@ -26,8 +26,10 @@ export interface TileFeedbackEntry {
 export interface FogOverlayStyle {
   text: string;
   opacity: number;
+  edgeOpacity: number;
   labelOpacity: number;
   tone: "hidden" | "explored";
+  featherMask: number;
 }
 
 export interface ObjectPulseEntry {
@@ -112,32 +114,30 @@ export function buildFogOverlayStyle(
   tileLookup: Map<string, PlayerTileView>,
   phase = 0
 ): FogOverlayStyle | null {
-  const frontierMarker = fogEdgeMarkerForTile(tile, tileLookup, phase);
-
   if (tile.fog === "hidden") {
-    if (frontierMarker === "~" || frontierMarker === "^") {
-      return {
-        text: "",
-        opacity: phase % 2 === 1 ? 74 : 92,
-        labelOpacity: 0,
-        tone: "hidden"
-      };
-    }
-
-    return null;
+    const featherMask = fogMaskAgainst(tile.position, tileLookup, ["explored", "visible"]);
+    const frontier = featherMask > 0;
+    return {
+      text: "",
+      opacity: frontier ? (phase % 2 === 1 ? 176 : 192) : phase % 2 === 1 ? 204 : 220,
+      edgeOpacity: frontier ? (phase % 2 === 1 ? 62 : 78) : phase % 2 === 1 ? 184 : 198,
+      labelOpacity: 0,
+      tone: "hidden",
+      featherMask
+    };
   }
 
   if (tile.fog === "explored") {
-    if (frontierMarker === ":" || frontierMarker === ";") {
-      return {
-        text: "",
-        opacity: phase % 2 === 1 ? 28 : 36,
-        labelOpacity: 0,
-        tone: "explored"
-      };
-    }
-
-    return null;
+    const featherMask = fogMaskAgainst(tile.position, tileLookup, ["visible"]);
+    const frontier = featherMask > 0;
+    return {
+      text: "",
+      opacity: frontier ? (phase % 2 === 1 ? 78 : 92) : phase % 2 === 1 ? 92 : 108,
+      edgeOpacity: frontier ? (phase % 2 === 1 ? 24 : 34) : phase % 2 === 1 ? 72 : 82,
+      labelOpacity: 0,
+      tone: "explored",
+      featherMask
+    };
   }
 
   return null;

--- a/apps/cocos-client/test/cocos-map-visuals.test.ts
+++ b/apps/cocos-client/test/cocos-map-visuals.test.ts
@@ -135,29 +135,69 @@ test("buildFogOverlayStyle emits quiet overlay chrome for hidden and explored fo
 
   assert.deepEqual(buildFogOverlayStyle(tiles[0]!, lookup, 0), {
     text: "",
-    opacity: 92,
+    opacity: 192,
+    edgeOpacity: 78,
     labelOpacity: 0,
-    tone: "hidden"
+    tone: "hidden",
+    featherMask: 3
   });
   assert.deepEqual(buildFogOverlayStyle(tiles[0]!, lookup, 1), {
     text: "",
-    opacity: 74,
+    opacity: 176,
+    edgeOpacity: 62,
     labelOpacity: 0,
-    tone: "hidden"
+    tone: "hidden",
+    featherMask: 3
   });
   assert.deepEqual(buildFogOverlayStyle(tiles[2]!, lookup, 0), {
     text: "",
-    opacity: 36,
+    opacity: 92,
+    edgeOpacity: 34,
     labelOpacity: 0,
-    tone: "explored"
+    tone: "explored",
+    featherMask: 1
   });
   assert.deepEqual(buildFogOverlayStyle(tiles[2]!, lookup, 1), {
     text: "",
-    opacity: 28,
+    opacity: 78,
+    edgeOpacity: 24,
     labelOpacity: 0,
-    tone: "explored"
+    tone: "explored",
+    featherMask: 1
   });
   assert.equal(buildFogOverlayStyle(tiles[4]!, lookup, 0), null);
+});
+
+test("buildFogOverlayStyle keeps interior fog tiles alpha-blended even without a frontier", () => {
+  const hiddenTiles = [
+    createTile({ x: 0, y: 0 }, "hidden"),
+    createTile({ x: 1, y: 0 }, "hidden"),
+    createTile({ x: 0, y: 1 }, "hidden"),
+    createTile({ x: 1, y: 1 }, "hidden")
+  ];
+  const exploredTiles = [
+    createTile({ x: 0, y: 0 }, "explored"),
+    createTile({ x: 1, y: 0 }, "explored"),
+    createTile({ x: 0, y: 1 }, "explored"),
+    createTile({ x: 1, y: 1 }, "explored")
+  ];
+
+  assert.deepEqual(buildFogOverlayStyle(hiddenTiles[0]!, createTileLookup(hiddenTiles), 0), {
+    text: "",
+    opacity: 220,
+    edgeOpacity: 198,
+    labelOpacity: 0,
+    tone: "hidden",
+    featherMask: 0
+  });
+  assert.deepEqual(buildFogOverlayStyle(exploredTiles[2]!, createTileLookup(exploredTiles), 0), {
+    text: "",
+    opacity: 108,
+    edgeOpacity: 82,
+    labelOpacity: 0,
+    tone: "explored",
+    featherMask: 0
+  });
 });
 
 test("buildMapFeedbackEntriesFromUpdate creates tile callouts for move, collect, xp and battle results", () => {


### PR DESCRIPTION
Implements issue #3.

Adds the feathered alpha-blended fog-of-war presentation to the Cocos client.