### PR TITLE
feat: make cocos the primary client runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,34 +72,37 @@
   - 战斗结束后回写世界状态，胜利移除明雷并发放奖励，失败施加英雄惩罚。
   - MySQL 持久化现已包含房间快照、玩家房间档案、`player_accounts` 全局资源仓库初版，以及 `player_hero_archives` 英雄长期档；长期档当前会携带等级成长、已学技能、装备槽位和当前带兵信息。
 - `apps/client`
-  - 客户端渲染器骨架。
-  - 当前以文本渲染示例验证“客户端只负责展示玩家可见状态”的边界。
+  - H5 调试 / 回归壳。
+  - 当前保留给浏览器内快速验证、配置联调和回归测试使用，不再作为主客户端运行时。
 - `apps/cocos-client`
-  - Cocos Creator 3.x 前端壳子。
-  - 当前已能连接现有 Colyseus 房间、显示玩家快照，并用点击屏幕验证英雄移动链路。
+  - Cocos Creator 3.x 主客户端运行时。
+  - 当前已覆盖 Lobby、地图探索、战斗、账号会话恢复和配置中心跳转的主流程。
 - `docs/phase1-design.md`
   - 更细的产品、技术与小程序部署方案。
 
 ## 建议的下一步
 
-1. 将 `apps/client` 替换为 Cocos Creator 小游戏工程外壳。
-2. 在 `apps/server` 接入 Colyseus 房间与消息协议。
-3. 补 `configs/` 目录和 JSON 校验脚本，开始数值与地图配置生产。
-4. 为共享模块添加单元测试，锁住移动和战斗结算行为。
+1. 继续把正式资源、动画和小游戏构建流程压到 `apps/cocos-client`，收口成可持续迭代的主客户端工程。
+2. 在 `apps/server` 继续扩展 Colyseus 房间与消息协议，补多人玩法和更细的同步治理。
+3. 继续完善 `configs/` 目录和 JSON 校验脚本，推进数值与地图配置生产流水线。
+4. 维持 `apps/client` 的最小 H5 调试面，专注回归验证和配置联调，而不是继续承载主体验。
 
 ## 本地运行
 
 - 安装依赖：`npm install`
 - 本地 WebSocket 服务：`npm run dev:server`
 - 终端逻辑演示：`npm run demo:flow`
+- 主客户端入口说明：`npm run client:primary`
+- Cocos 主客户端类型检查：`npm run typecheck:client`
+- H5 调试壳开发服务：`npm run dev:client:h5`
+- H5 调试壳构建验证：`npm run build:client:h5`
+- H5 调试壳类型检查：`npm run typecheck:client:h5`
 - 并发房间压测：`npm run stress:rooms -- --rooms=120 --connect-concurrency=24 --action-concurrency=24`
-- 本地 H5 开发服务：`npm run dev:client`
-- H5 构建验证：`npm run build:client`
-- Cocos 壳子类型检查：`npm run typecheck:cocos`
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
-- 当前 H5 原型已支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。
+- 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
+- 当前 H5 调试壳仍支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。
 - 当前 H5 联机体验已支持：客户端预测、断线自动重连、刷新后本地快照首帧回放，再由权威房间状态收敛。
-- 当前已补上 Cocos Creator 工程壳子：
+- 当前 Cocos Creator 主客户端已补齐：
   - 工程目录：`apps/cocos-client`
   - 入口脚本：`apps/cocos-client/assets/scripts/VeilRoot.ts`
   - 组件拆分：`VeilRoot` 负责联机流程编排，`VeilHudPanel` 负责 HUD，`VeilMapBoard` 负责地图与点击交互，`VeilBattlePanel / VeilTimelinePanel` 负责右侧信息与战斗面板
@@ -139,6 +142,7 @@
 - H5 Lobby 和游戏内都已补上“退出游客会话 / 切换游客账号”入口；当前 token 无效时会自动清掉本地会话并回到大厅。
 - Cocos Web 启动入口现在会复用和 H5 共用的 `project-veil:auth-session`：如果浏览器里已有已签名会话，那么直接访问 `?roomId=...` 就能沿用当前游客或正式账号身份进房，HUD 会标出当前是云端游客、正式账号还是本地/手动参数启动。
 - Cocos Web 现在也有真正的 Lobby 面板：没有 `roomId` 查询参数时会先进入大厅，可刷新 `/api/lobby/rooms` 活跃实例、点击字段卡片修改 `playerId / 昵称 / roomId / 登录 ID`、直接游客进入，或走“账号登录并进入”直连正式账号；Lobby 还会通过 `/api/player-accounts/me` / `GET /api/player-accounts/:playerId` 同步当前账号资料与全局仓库摘要。
+- Cocos Lobby 现在也提供“打开配置台”入口，会按当前联机目标自动跳到共享的 `config-center.html`，把配置联调从 H5 侧迁成主客户端可达链路。
 - 服务端新增 `GET /api/lobby/rooms`，会实时返回当前进程内活跃房间的 `roomId / day / seed / connectedPlayers / heroCount / activeBattles / updatedAt` 摘要，便于大厅入口和后续房间浏览器直接复用。
 - 这套账号目前仍是“轻量正式化”阶段：虽然已经有口令绑定和账号登录，但还没有刷新令牌、多端撤销、正式注册流程或第三方身份接入。
 - H5 会优先连接 `ws://127.0.0.1:2567` 的本地会话服务；若服务未启动，则自动回退到浏览器内嵌房间模式。

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -2127,8 +2127,8 @@ function render(): void {
     <main class="shell">
       <section class="hero-panel">
         <div class="eyebrow">Project Veil</div>
-        <h1>网页版原型</h1>
-        <p class="lead">当前已进入房间实例。悬停看路径，点击地图移动，靠近明雷或敌方英雄触发遭遇战。</p>
+        <h1>H5 调试壳</h1>
+        <p class="lead">这里保留给浏览器调试、配置联调和回归验证使用；主客户端运行时已切到 Cocos Creator。</p>
         <div class="session-meta-row">
           <p class="muted" data-testid="session-meta">Room: ${roomId} · Player: ${playerId}</p>
           <button class="session-link" data-return-lobby="true">返回大厅</button>

--- a/apps/cocos-client/README.md
+++ b/apps/cocos-client/README.md
@@ -1,13 +1,15 @@
-# Project Veil Cocos Creator Shell
+# Project Veil Cocos Creator Primary Runtime
 
-这个目录是 Project Veil 的 Cocos Creator 3.x 前端壳子。
+这个目录是 Project Veil 的 Cocos Creator 3.x 主客户端运行时。
 
-当前目标不是一次性把 H5 前端完全迁完，而是先把下面这条链路打通：
+当前目标已经从“先做壳子”切到“承接主体验运行时”，核心链路如下：
 
 1. Cocos Creator 工程可被正常打开
-2. 能连接现有 Colyseus / 权威房间服务
-3. 能显示玩家快照
-4. 能通过简单交互验证移动链路
+2. 通过 Cocos Lobby 进入现有 Colyseus / 权威房间服务
+3. 覆盖地图、战斗、账号会话恢复和返回大厅主流程
+4. 直接从 Cocos 入口跳到共享配置中心完成联调
+
+`apps/client` 现在只保留为 H5 调试 / 回归壳，不再承担主客户端职责。
 
 ## 当前内容
 
@@ -17,11 +19,15 @@
   - 支持把最近一次权威 `session.state` 缓存在本地，刷新或短时断线后先回放本地快照
 - `assets/scripts/VeilRoot.ts`
   - 可直接挂到场景节点上的根组件
-  - 现在主要负责会话连接、预测、重连恢复和战斗转场编排
+  - 现在负责 Lobby、账号会话恢复、房间连接、预测、重连恢复和战斗转场编排
   - HUD 和地图表现已经拆到独立组件，避免根节点继续膨胀
+- `assets/scripts/VeilLobbyPanel.ts`
+  - 负责 Cocos Lobby 主入口
+  - 支持游客进入、账号登录并进入、全局仓库摘要展示，以及跳转共享配置台
 - `assets/scripts/VeilHudPanel.ts`
   - 负责 HUD 文本面板渲染
-  - 只消费当前 `SessionUpdate + predictionStatus`
+  - 负责展示当前 `SessionUpdate + predictionStatus`
+  - 会标出当前是游客还是正式账号身份
 - `assets/scripts/VeilBattlePanel.ts`
   - 负责右侧战斗面板
   - 现已按 `战况摘要 / 待动序列 / 我方单位 / 敌方目标 / 指令操作` 分区渲染
@@ -90,11 +96,12 @@
    - 如已挂正式角色资源，可在 `VeilUnitAnimator` 上配置各状态动画名与回退时长
 6. 启动后端：`npm run dev:server`
 7. 在 Cocos 预览窗口运行场景
-8. 点击地图格子，观察 HUD 中的英雄坐标、移动力和资源变化
+8. 没有 `roomId` 查询参数时，会先进入 Cocos Lobby；可在大厅里刷新房间、游客进入、账号登录并进入，或打开配置台
+9. 进入房间后点击地图格子，观察 HUD 中的英雄坐标、移动力和资源变化
 
 ## 下一步建议
 
-- 把资源、美术占位图和对象卡片映射迁到 Cocos 资源系统
+- 把资源、美术占位图和对象卡片映射继续迁到 Cocos 资源系统
 - 把 `VeilUnitAnimator` 接到正式 Spine skeleton 和序列帧资源
 - 把 `VeilBattleTransition` 替换成正式 tween / 特效 / 音效组合
-- 再逐步替换为正式微信小游戏构建流程
+- 继续压实微信小游戏构建和发布流程

--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -19,6 +19,7 @@ const MUTED_FILL = new Color(31, 42, 57, 164);
 const ACTION_REFRESH = new Color(64, 92, 128, 234);
 const ACTION_ENTER = new Color(84, 122, 94, 234);
 const ACTION_ACCOUNT = new Color(88, 118, 164, 234);
+const ACTION_CONFIG = new Color(94, 112, 86, 234);
 const ACTION_LOGOUT = new Color(126, 92, 74, 234);
 
 export interface VeilLobbyRenderState {
@@ -43,6 +44,7 @@ export interface VeilLobbyPanelOptions {
   onRefresh?: () => void;
   onEnterRoom?: () => void;
   onLoginAccount?: () => void;
+  onOpenConfigCenter?: () => void;
   onLogout?: () => void;
   onJoinRoom?: (roomId: string) => void;
 }
@@ -62,6 +64,7 @@ export class VeilLobbyPanel extends Component {
   private onRefresh: (() => void) | undefined;
   private onEnterRoom: (() => void) | undefined;
   private onLoginAccount: (() => void) | undefined;
+  private onOpenConfigCenter: (() => void) | undefined;
   private onLogout: (() => void) | undefined;
   private onJoinRoom: ((roomId: string) => void) | undefined;
 
@@ -73,6 +76,7 @@ export class VeilLobbyPanel extends Component {
     this.onRefresh = options.onRefresh;
     this.onEnterRoom = options.onEnterRoom;
     this.onLoginAccount = options.onLoginAccount;
+    this.onOpenConfigCenter = options.onOpenConfigCenter;
     this.onLogout = options.onLogout;
     this.onJoinRoom = options.onJoinRoom;
   }
@@ -252,9 +256,23 @@ export class VeilLobbyPanel extends Component {
       state.entering ? null : this.onLoginAccount ?? null
     );
     this.renderActionButton(
-      "LobbyLogout",
+      "LobbyConfigCenter",
       leftX,
       leftCursorY - 120,
+      leftWidth,
+      28,
+      "打开配置台",
+      {
+        fill: ACTION_CONFIG,
+        stroke: new Color(234, 240, 228, 116),
+        accent: new Color(226, 236, 220, 108)
+      },
+      state.entering ? null : this.onOpenConfigCenter ?? null
+    );
+    this.renderActionButton(
+      "LobbyLogout",
+      leftX,
+      leftCursorY - 154,
       leftWidth,
       28,
       state.authMode === "account" ? "退出账号会话" : "退出游客会话",

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -20,6 +20,7 @@ import {
   loginCocosGuestAuthSession,
   readPreferredCocosDisplayName,
   rememberPreferredCocosDisplayName,
+  resolveCocosConfigCenterUrl,
   saveCocosLobbyPreferences,
   syncCurrentCocosAuthSession,
   type CocosLobbyRoomSummary,
@@ -108,7 +109,7 @@ export class VeilRoot extends Component {
   private battleTransition: VeilBattleTransition | null = null;
   private session: VeilCocosSession | null = null;
   private lastUpdate: SessionUpdate | null = null;
-  private logLines: string[] = ["Cocos 原型已就绪。"];
+  private logLines: string[] = ["Cocos 主客户端已就绪。"];
   private timelineEntries: string[] = [];
   private moveInFlight = false;
   private battleActionInFlight = false;
@@ -343,6 +344,9 @@ export class VeilRoot extends Component {
       onLoginAccount: () => {
         void this.loginLobbyAccount();
       },
+      onOpenConfigCenter: () => {
+        this.openConfigCenter();
+      },
       onLogout: () => {
         this.logoutAuthSession();
       },
@@ -511,6 +515,18 @@ export class VeilRoot extends Component {
   private formatLobbyVaultSummary(): string {
     const resources = this.lobbyAccountProfile.globalResources;
     return `全局仓库 金币 ${resources.gold} / 木材 ${resources.wood} / 矿石 ${resources.ore}`;
+  }
+
+  private openConfigCenter(): void {
+    const configCenterUrl = resolveCocosConfigCenterUrl(this.remoteUrl);
+    const openRef = globalThis.open;
+    if (typeof openRef === "function") {
+      openRef(configCenterUrl, "_blank", "noopener,noreferrer");
+      this.lobbyStatus = "已在新窗口打开配置台。";
+    } else {
+      this.lobbyStatus = `当前运行环境无法直接打开配置台，请访问 ${configCenterUrl}`;
+    }
+    this.renderView();
   }
 
   private async syncLobbyBootstrap(): Promise<void> {
@@ -1222,7 +1238,7 @@ export class VeilRoot extends Component {
 
     const promptRef = globalThis.prompt;
     if (typeof promptRef !== "function") {
-      this.lobbyStatus = "当前运行环境不支持弹出式输入，请改用 H5 Lobby 完成账号登录。";
+      this.lobbyStatus = "当前运行环境不支持弹出式输入，请先在浏览器调试壳完成账号登录，或复用已缓存会话。";
       this.renderView();
       return;
     }
@@ -1312,7 +1328,7 @@ export class VeilRoot extends Component {
   private promptForLobbyField(field: "playerId" | "displayName" | "roomId" | "loginId"): void {
     const promptRef = globalThis.prompt;
     if (typeof promptRef !== "function") {
-      this.lobbyStatus = "当前运行环境不支持弹出式输入，请改用 URL 参数或 H5 Lobby。";
+      this.lobbyStatus = "当前运行环境不支持弹出式输入，请改用 URL 参数、已缓存会话或浏览器调试壳。";
       this.renderView();
       return;
     }

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -313,6 +313,35 @@ export function resolveCocosApiBaseUrl(
   return `${protocol}://${hostname}:2567`;
 }
 
+export function resolveCocosConfigCenterUrl(
+  remoteUrl: string,
+  locationLike:
+    | Pick<Location, "protocol" | "hostname" | "port" | "origin" | "pathname">
+    | null
+    | undefined = globalThis.location
+): string {
+  if (locationLike?.pathname?.includes("config-center.html")) {
+    return new URL("/config-center.html", locationLike.origin).toString();
+  }
+
+  if (locationLike?.port === "4173" && locationLike.origin) {
+    return new URL("/config-center.html", locationLike.origin).toString();
+  }
+
+  try {
+    const apiBaseUrl = new URL(resolveCocosApiBaseUrl(remoteUrl, locationLike));
+    apiBaseUrl.port = "4173";
+    apiBaseUrl.pathname = "/config-center.html";
+    apiBaseUrl.search = "";
+    apiBaseUrl.hash = "";
+    return apiBaseUrl.toString();
+  } catch {
+    const protocol = locationLike?.protocol === "https:" ? "https" : "http";
+    const hostname = locationLike?.hostname || "127.0.0.1";
+    return `${protocol}://${hostname}:4173/config-center.html`;
+  }
+}
+
 export async function loadCocosLobbyRooms(
   remoteUrl: string,
   limit = 6,

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -10,7 +10,8 @@ import {
   loginCocosPasswordAuthSession,
   loginCocosGuestAuthSession,
   rememberPreferredCocosDisplayName,
-  resolveCocosApiBaseUrl
+  resolveCocosApiBaseUrl,
+  resolveCocosConfigCenterUrl
 } from "../assets/scripts/cocos-lobby.ts";
 
 test("createCocosLobbyPreferences reuses stored values and falls back to room-alpha", () => {
@@ -54,6 +55,29 @@ test("rememberPreferredCocosDisplayName persists normalized names with the share
 test("resolveCocosApiBaseUrl converts websocket endpoints into http api roots", () => {
   assert.equal(resolveCocosApiBaseUrl("ws://127.0.0.1:2567/ws"), "http://127.0.0.1:2567");
   assert.equal(resolveCocosApiBaseUrl("wss://veil.example.com/socket"), "https://veil.example.com");
+});
+
+test("resolveCocosConfigCenterUrl points Cocos web flows at the shared config center", () => {
+  assert.equal(
+    resolveCocosConfigCenterUrl("ws://127.0.0.1:2567/ws", {
+      protocol: "http:",
+      hostname: "127.0.0.1",
+      port: "7456",
+      origin: "http://127.0.0.1:7456",
+      pathname: "/preview/index.html"
+    }),
+    "http://127.0.0.1:4173/config-center.html"
+  );
+  assert.equal(
+    resolveCocosConfigCenterUrl("", {
+      protocol: "https:",
+      hostname: "veil.example.com",
+      port: "4173",
+      origin: "https://veil.example.com:4173",
+      pathname: "/config-center.html"
+    }),
+    "https://veil.example.com:4173/config-center.html"
+  );
 });
 
 test("loadCocosLobbyRooms queries the lobby api from the resolved remote host", async () => {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "packageManager": "pnpm@10.8.1",
   "scripts": {
     "dev:server": "node --import tsx ./apps/server/src/dev-server.ts",
-    "dev:client": "vite --config apps/client/vite.config.ts",
-    "build:client": "vite build --config apps/client/vite.config.ts",
+    "client:primary": "node --eval \"console.log('Primary runtime: open apps/cocos-client in Cocos Creator 3.8.x and preview the VeilRoot scene. H5 debug shell: npm run dev:client:h5')\"",
+    "dev:client": "npm run dev:client:h5",
+    "dev:client:h5": "vite --config apps/client/vite.config.ts",
+    "build:client": "npm run build:client:h5",
+    "build:client:h5": "vite build --config apps/client/vite.config.ts",
     "db:init:mysql": "node --import tsx ./scripts/init-mysql.ts",
     "db:snapshots:list": "node --import tsx ./scripts/manage-room-snapshots.ts list",
     "db:snapshots:delete": "node --import tsx ./scripts/manage-room-snapshots.ts delete",
@@ -27,7 +30,8 @@
     "typecheck:cocos": "tsc -p apps/cocos-client/tsconfig.json --noEmit",
     "typecheck:shared": "tsc -p packages/shared/tsconfig.json --noEmit",
     "typecheck:server": "tsc -p apps/server/tsconfig.json --noEmit",
-    "typecheck:client": "tsc -p apps/client/tsconfig.json --noEmit"
+    "typecheck:client": "npm run typecheck:cocos",
+    "typecheck:client:h5": "tsc -p apps/client/tsconfig.json --noEmit"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",


### PR DESCRIPTION
Implements issue #1.

Promotes Cocos Creator to the primary client runtime and leaves the H5 shell as debug/regression only.