### PR TITLE
feat: 完成英雄技能树配置与 UI 集成

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -871,6 +871,25 @@ class RemoteGameSession {
     return update;
   }
 
+  async learnSkill(heroId: string, skillId: string): Promise<SessionUpdate> {
+    const response = await this.send<Extract<ServerMessage, { type: "session.state" }>>(
+      {
+        type: "world.action",
+        requestId: this.nextRequestId(),
+        action: {
+          type: "hero.learnSkill",
+          heroId,
+          skillId
+        }
+      },
+      "session.state"
+    );
+
+    const update = fromPayload(response.payload);
+    writeSessionReplay(this.roomId, this.playerId, update);
+    return update;
+  }
+
   async endDay(): Promise<SessionUpdate> {
     const response = await this.send<Extract<ServerMessage, { type: "session.state" }>>(
       {
@@ -1064,6 +1083,10 @@ class RecoverableRemoteGameSession {
     return this.runWithSession((session) => session.claimMine(heroId, buildingId));
   }
 
+  async learnSkill(heroId: string, skillId: string): Promise<SessionUpdate> {
+    return this.runWithSession((session) => session.learnSkill(heroId, skillId));
+  }
+
   async endDay(): Promise<SessionUpdate> {
     return this.runWithSession((session) => session.endDay());
   }
@@ -1192,6 +1215,10 @@ export class VeilCocosSession {
 
   async claimMine(heroId: string, buildingId: string): Promise<SessionUpdate> {
     return this.remoteSession.claimMine(heroId, buildingId);
+  }
+
+  async learnSkill(heroId: string, skillId: string): Promise<SessionUpdate> {
+    return this.remoteSession.learnSkill(heroId, skillId);
   }
 
   async endDay(): Promise<SessionUpdate> {

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -1,4 +1,7 @@
 import { _decorator, Color, Component, Graphics, Label, Node, Sprite, UIOpacity, UITransform } from "cc";
+import { createHeroSkillTreeView } from "../../../../packages/shared/src/hero-skills.ts";
+import type { BattleSkillId, HeroState } from "../../../../packages/shared/src/models.ts";
+import { getDefaultBattleSkillCatalog } from "../../../../packages/shared/src/world-config.ts";
 import type { SessionUpdate } from "./VeilCocosSession.ts";
 import { getPlaceholderSpriteAssets, loadPlaceholderSpriteAssets } from "./cocos-placeholder-sprites.ts";
 import { assignUiLayer } from "./cocos-ui-layer.ts";
@@ -20,6 +23,7 @@ const HUD_CARD_STATUS = new Color(204, 170, 106, 182);
 const TITLE_NODE_NAME = "HudTitle";
 const RESOURCE_NODE_NAME = "HudResources";
 const HERO_NODE_NAME = "HudHero";
+const SKILLS_NODE_NAME = "HudSkills";
 const STATUS_NODE_NAME = "HudStatus";
 const DEBUG_NODE_NAME = "HudDebug";
 const HEADER_ICON_NODE_NAME = "HudHeaderIcon";
@@ -29,11 +33,71 @@ const CARD_PREFIX = "HudCard";
 const CHIP_PREFIX = "HudChip";
 const BADGE_PREFIX = "HudBadge";
 const HERO_METER_PREFIX = "HudHeroMeter";
+const SKILL_BUTTON_PREFIX = "HudSkillButton";
+
+interface HudLearnableSkillState {
+  id: string;
+  name: string;
+  branchName: string;
+  nextRank: number | null;
+  grantedBattleSkillLabels: string[];
+}
 
 interface HudActionButtonState {
   name: string;
   label: string;
   callback: (() => void) | null;
+}
+
+const battleSkillNameById = new Map<BattleSkillId, string>(
+  getDefaultBattleSkillCatalog().skills.map((skill) => [skill.id, skill.name])
+);
+
+function toHeroSkillState(
+  hero: NonNullable<VeilHudRenderState["update"]>["world"]["ownHeroes"][number]
+): HeroState {
+  return {
+    id: hero.id,
+    playerId: hero.playerId,
+    name: hero.name,
+    position: { ...hero.position },
+    vision: hero.vision,
+    move: { ...hero.move },
+    stats: { ...hero.stats },
+    progression: { ...hero.progression },
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        trinketIds: []
+      }
+    },
+    armyTemplateId: hero.armyTemplateId,
+    armyCount: hero.armyCount,
+    learnedSkills: hero.learnedSkills.map((skill) => ({ ...skill }))
+  };
+}
+
+function listLearnableHeroSkills(
+  hero: NonNullable<VeilHudRenderState["update"]>["world"]["ownHeroes"][number] | null
+): HudLearnableSkillState[] {
+  if (!hero) {
+    return [];
+  }
+
+  const tree = createHeroSkillTreeView(toHeroSkillState(hero));
+  return tree.branches.flatMap((branch) =>
+    branch.skills
+      .filter((skill) => skill.canLearn)
+      .map((skill) => ({
+        id: skill.id,
+        name: skill.name,
+        branchName: branch.name,
+        nextRank: skill.nextRank,
+        grantedBattleSkillLabels: skill.nextGrantedBattleSkillIds.map(
+          (battleSkillId) => battleSkillNameById.get(battleSkillId) ?? battleSkillId
+        )
+      }))
+  );
 }
 
 function formatHeroLearnedSkills(hero: NonNullable<VeilHudRenderState["update"]>["world"]["ownHeroes"][number] | null): string {
@@ -62,6 +126,7 @@ export interface VeilHudRenderState {
 export interface VeilHudPanelOptions {
   onNewRun?: () => void;
   onRefresh?: () => void;
+  onLearnSkill?: (skillId: string) => void;
   onEndDay?: () => void;
   onReturnLobby?: () => void;
 }
@@ -71,6 +136,7 @@ export class VeilHudPanel extends Component {
   private titleLabel: Label | null = null;
   private resourceLabel: Label | null = null;
   private heroLabel: Label | null = null;
+  private skillLabel: Label | null = null;
   private statusLabel: Label | null = null;
   private debugLabel: Label | null = null;
   private headerIconSprite: Sprite | null = null;
@@ -79,12 +145,14 @@ export class VeilHudPanel extends Component {
   private requestedIcons = false;
   private onNewRun: (() => void) | undefined;
   private onRefresh: (() => void) | undefined;
+  private onLearnSkill: ((skillId: string) => void) | undefined;
   private onEndDay: (() => void) | undefined;
   private onReturnLobby: (() => void) | undefined;
 
   configure(options: VeilHudPanelOptions): void {
     this.onNewRun = options.onNewRun;
     this.onRefresh = options.onRefresh;
+    this.onLearnSkill = options.onLearnSkill;
     this.onEndDay = options.onEndDay;
     this.onReturnLobby = options.onReturnLobby;
     this.ensureActionButtons();
@@ -102,6 +170,7 @@ export class VeilHudPanel extends Component {
     const world = state.update?.world;
     const resources = world?.resources;
     const battle = state.update?.battle;
+    const learnableSkills = listLearnableHeroSkills(hero);
     const reachableAhead =
       state.update?.reachableTiles.filter((tile) => !hero || tile.x !== hero.position.x || tile.y !== hero.position.y).length ?? 0;
     const statusTitle = battle
@@ -180,6 +249,30 @@ export class VeilHudPanel extends Component {
     );
 
     cursorY = this.renderCardBlock(
+      this.skillLabel,
+      `${CARD_PREFIX}-skills`,
+      hero
+        ? learnableSkills.length > 0
+          ? [
+              `学习新技能  ${learnableSkills.length} 项`,
+              ...learnableSkills.map((skill) =>
+                `${skill.name}${skill.nextRank && skill.nextRank > 1 ? ` R${skill.nextRank}` : ""} · ${skill.branchName}${skill.grantedBattleSkillLabels.length > 0 ? ` · 解锁 ${skill.grantedBattleSkillLabels.join(" / ")}` : ""}`
+              )
+            ]
+          : hero.progression.skillPoints > 0
+            ? ["学习新技能", "当前没有满足等级或前置要求的技能。"]
+            : ["学习新技能", "英雄升级后获得技能点，可在这里学习新的战斗能力。"]
+        : ["学习新技能", "等待房间状态..."],
+      cursorY,
+      12,
+      16,
+      cardWidth,
+      leftX,
+      6,
+      learnableSkills.length > 0 ? Math.max(96, 52 + learnableSkills.length * 30) : 76
+    );
+
+    cursorY = this.renderCardBlock(
       this.statusLabel,
       `${CARD_PREFIX}-status`,
       [statusTitle, statusDetail],
@@ -202,9 +295,15 @@ export class VeilHudPanel extends Component {
       this.renderHeroBadge(`${CARD_PREFIX}-hero`, `Lv ${hero.progression.level}`);
       this.renderHeroMeters(`${CARD_PREFIX}-hero`, hero.move.remaining, hero.move.total, hero.stats.hp, hero.stats.maxHp, hero.armyCount);
       this.tightenHeroLabelLayout(leftX, cardWidth);
+      this.renderLearnableSkillButtons(`${CARD_PREFIX}-skills`, learnableSkills);
     } else {
       this.hideCardDecorations(`${CARD_PREFIX}-hero`, BADGE_PREFIX);
       this.hideCardDecorations(`${CARD_PREFIX}-hero`, `${CHIP_PREFIX}-${HERO_METER_PREFIX}`);
+      this.hideCardDecorations(`${CARD_PREFIX}-skills`, SKILL_BUTTON_PREFIX);
+    }
+
+    if (hero && learnableSkills.length === 0) {
+      this.hideCardDecorations(`${CARD_PREFIX}-skills`, SKILL_BUTTON_PREFIX);
     }
 
     this.renderStatusBadge(`${CARD_PREFIX}-status`, statusBadge);
@@ -259,6 +358,7 @@ export class VeilHudPanel extends Component {
     this.titleLabel = this.ensureLabelNode(TITLE_NODE_NAME, 22, 28, 64);
     this.resourceLabel = this.ensureLabelNode(RESOURCE_NODE_NAME, 18, 24, 72);
     this.heroLabel = this.ensureLabelNode(HERO_NODE_NAME, 18, 24, 110);
+    this.skillLabel = this.ensureLabelNode(SKILLS_NODE_NAME, 16, 22, 92);
     this.statusLabel = this.ensureLabelNode(STATUS_NODE_NAME, 17, 22, 70);
     this.debugLabel = this.ensureLabelNode(DEBUG_NODE_NAME, 14, 18, 50);
   }
@@ -614,6 +714,79 @@ export class VeilHudPanel extends Component {
     this.renderMetricChip(cardNode, `${HERO_METER_PREFIX}-army`, startX + (chipWidth + gap) * 2, y, chipWidth, chipHeight, null, "兵力", `${armyCount}`, new Color(204, 168, 92, 224));
   }
 
+  private renderLearnableSkillButtons(cardName: string, skills: HudLearnableSkillState[]): void {
+    const cardNode = this.node.getChildByName(cardName);
+    if (!cardNode) {
+      return;
+    }
+
+    if (skills.length === 0) {
+      this.hideCardDecorations(cardName, SKILL_BUTTON_PREFIX);
+      return;
+    }
+
+    const cardTransform = cardNode.getComponent(UITransform) ?? cardNode.addComponent(UITransform);
+    const buttonWidth = Math.max(120, cardTransform.width - 24);
+    const buttonHeight = 22;
+    const gap = 6;
+    const totalHeight = skills.length * buttonHeight + (skills.length - 1) * gap;
+    const startY = -cardTransform.height / 2 + 18 + totalHeight - buttonHeight / 2;
+
+    skills.forEach((skill, index) => {
+      const nodeName = `${SKILL_BUTTON_PREFIX}-${skill.id}`;
+      let buttonNode = cardNode.getChildByName(nodeName);
+      if (!buttonNode) {
+        buttonNode = new Node(nodeName);
+        buttonNode.parent = cardNode;
+      }
+      assignUiLayer(buttonNode);
+      buttonNode.active = true;
+
+      const buttonTransform = buttonNode.getComponent(UITransform) ?? buttonNode.addComponent(UITransform);
+      buttonTransform.setContentSize(buttonWidth, buttonHeight);
+      buttonNode.setPosition(0, startY - index * (buttonHeight + gap), 1);
+
+      const graphics = buttonNode.getComponent(Graphics) ?? buttonNode.addComponent(Graphics);
+      graphics.clear();
+      graphics.fillColor = new Color(92, 80, 52, 226);
+      graphics.strokeColor = new Color(244, 223, 168, 132);
+      graphics.lineWidth = 2;
+      graphics.roundRect(-buttonWidth / 2, -buttonHeight / 2, buttonWidth, buttonHeight, 8);
+      graphics.fill();
+      graphics.stroke();
+      graphics.fillColor = new Color(255, 255, 255, 18);
+      graphics.roundRect(-buttonWidth / 2 + 10, buttonHeight / 2 - 8, buttonWidth - 20, 3, 2);
+      graphics.fill();
+
+      const label = buttonNode.getComponent(Label) ?? buttonNode.addComponent(Label);
+      label.string = `学习 ${skill.name}`;
+      label.fontSize = 11;
+      label.lineHeight = 13;
+      label.horizontalAlign = H_ALIGN_CENTER;
+      label.verticalAlign = V_ALIGN_MIDDLE;
+      label.enableWrapText = false;
+      label.color = new Color(246, 248, 252, 255);
+
+      buttonNode.off(Node.EventType.TOUCH_END);
+      buttonNode.off(Node.EventType.MOUSE_UP);
+      if (this.onLearnSkill) {
+        buttonNode.on(Node.EventType.TOUCH_END, () => {
+          this.onLearnSkill?.(skill.id);
+        });
+        buttonNode.on(Node.EventType.MOUSE_UP, () => {
+          this.onLearnSkill?.(skill.id);
+        });
+      }
+    });
+
+    const childNodes = (cardNode as unknown as { children?: Node[] }).children ?? [];
+    for (const child of childNodes) {
+      if (child.name.startsWith(SKILL_BUTTON_PREFIX) && !skills.some((skill) => child.name === `${SKILL_BUTTON_PREFIX}-${skill.id}`)) {
+        child.active = false;
+      }
+    }
+  }
+
   private tightenHeroLabelLayout(centerX: number, cardWidth: number): void {
     if (!this.heroLabel) {
       return;
@@ -692,6 +865,7 @@ export class VeilHudPanel extends Component {
       TITLE_NODE_NAME,
       RESOURCE_NODE_NAME,
       HERO_NODE_NAME,
+      SKILLS_NODE_NAME,
       STATUS_NODE_NAME,
       DEBUG_NODE_NAME,
       HEADER_ICON_NODE_NAME,
@@ -700,6 +874,7 @@ export class VeilHudPanel extends Component {
       `${CARD_PREFIX}-title`,
       `${CARD_PREFIX}-resources`,
       `${CARD_PREFIX}-hero`,
+      `${CARD_PREFIX}-skills`,
       `${CARD_PREFIX}-status`,
       `${CARD_PREFIX}-debug`
     ]);

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -275,6 +275,49 @@ export class VeilRoot extends Component {
     this.renderView();
   }
 
+  async learnHeroSkill(skillId: string): Promise<void> {
+    if (this.moveInFlight || this.battleActionInFlight) {
+      return;
+    }
+
+    if (!this.session) {
+      await this.connect();
+      return;
+    }
+
+    const hero = this.activeHero();
+    if (!hero) {
+      this.pushLog("当前快照里没有可控制的英雄。");
+      this.renderView();
+      return;
+    }
+
+    if (this.lastUpdate?.battle) {
+      this.pushLog("战斗中无法调整技能树。");
+      this.predictionStatus = "战斗中无法调整技能树。";
+      this.renderView();
+      return;
+    }
+
+    this.moveInFlight = true;
+    this.predictionStatus = `正在学习技能 ${skillId}...`;
+    this.pushLog(`正在为 ${hero.name} 学习技能 ${skillId}...`);
+    this.renderView();
+
+    try {
+      await this.applySessionUpdate(await this.session.learnSkill(hero.id, skillId));
+      this.pushLog("技能学习已结算。");
+    } catch (error) {
+      const failureMessage = this.describeSessionError(error, "技能学习失败。");
+      this.pushLog(failureMessage);
+      this.predictionStatus = failureMessage;
+    } finally {
+      this.moveInFlight = false;
+    }
+
+    this.renderView();
+  }
+
   private ensureViewNodes(): void {
     assignUiLayer(this.node);
 
@@ -304,6 +347,9 @@ export class VeilRoot extends Component {
       },
       onRefresh: () => {
         void this.refreshSnapshot();
+      },
+      onLearnSkill: (skillId) => {
+        void this.learnHeroSkill(skillId);
       },
       onEndDay: () => {
         void this.advanceDay();
@@ -662,6 +708,9 @@ export class VeilRoot extends Component {
         },
         onRefresh: () => {
           void this.refreshSnapshot();
+        },
+        onLearnSkill: (skillId) => {
+          void this.learnHeroSkill(skillId);
         },
         onEndDay: () => {
           void this.advanceDay();

--- a/configs/hero-skill-trees-full.json
+++ b/configs/hero-skill-trees-full.json
@@ -1,0 +1,268 @@
+{
+  "branches": [
+    {
+      "id": "warpath",
+      "name": "战阵",
+      "description": "偏向主动压制、先手滚雪球与爆发换血。"
+    },
+    {
+      "id": "bulwark",
+      "name": "壁垒",
+      "description": "偏向接战容错、稳固阵型与防守反击。"
+    },
+    {
+      "id": "arcanum",
+      "name": "秘仪",
+      "description": "偏向法术支援、减益覆盖与持续控制。"
+    }
+  ],
+  "skills": [
+    {
+      "id": "war_banner",
+      "branchId": "warpath",
+      "name": "战旗号令",
+      "description": "英雄亲自介入战场节奏，先提振攻势，再把破甲压制纳入长期 build。",
+      "requiredLevel": 2,
+      "maxRank": 2,
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“号令突进”。",
+          "battleSkillIds": ["commanding_shout"]
+        },
+        {
+          "rank": 2,
+          "description": "追加被动技能“裂甲追击”。",
+          "battleSkillIds": ["rending_mark"]
+        }
+      ]
+    },
+    {
+      "id": "spearhead_assault",
+      "branchId": "warpath",
+      "name": "矛锋突击",
+      "description": "将前线兵力集中到第一轮接战，优先撕开目标防线。",
+      "requiredLevel": 3,
+      "maxRank": 1,
+      "prerequisites": ["war_banner"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“破甲投枪”。",
+          "battleSkillIds": ["sundering_spear"]
+        }
+      ]
+    },
+    {
+      "id": "battle_drill",
+      "branchId": "warpath",
+      "name": "战前操典",
+      "description": "把冲锋节奏训练进部队肌肉记忆，在贴身前先抬高战意。",
+      "requiredLevel": 4,
+      "maxRank": 1,
+      "prerequisites": ["spearhead_assault"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“战意激发”。",
+          "battleSkillIds": ["battle_focus"]
+        }
+      ]
+    },
+    {
+      "id": "hunter_volley",
+      "branchId": "warpath",
+      "name": "猎袭齐射",
+      "description": "用远程牵制打开击杀窗口，为前排创造更稳的收割节奏。",
+      "requiredLevel": 5,
+      "maxRank": 1,
+      "prerequisites": ["battle_drill"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“投矛射击”。",
+          "battleSkillIds": ["power_shot"]
+        }
+      ]
+    },
+    {
+      "id": "ravager_doctrine",
+      "branchId": "warpath",
+      "name": "掠战条令",
+      "description": "将压制与破甲绑定为终结套路，把爆发节奏推到极致。",
+      "requiredLevel": 6,
+      "maxRank": 1,
+      "prerequisites": ["hunter_volley"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "额外强化爆发套件，补齐“号令突进”和“破甲投枪”。",
+          "battleSkillIds": ["commanding_shout", "sundering_spear"]
+        }
+      ]
+    },
+    {
+      "id": "shield_discipline",
+      "branchId": "bulwark",
+      "name": "盾墙教范",
+      "description": "把部队阵型和投枪压制编进英雄的长期战斗套路里。",
+      "requiredLevel": 2,
+      "maxRank": 2,
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“持盾列阵”。",
+          "battleSkillIds": ["phalanx_command"]
+        },
+        {
+          "rank": 2,
+          "description": "追加主动技能“钉锁投枪”。",
+          "battleSkillIds": ["pinning_javelin"]
+        }
+      ]
+    },
+    {
+      "id": "guardian_oath_training",
+      "branchId": "bulwark",
+      "name": "守誓训练",
+      "description": "强化接战前的稳态姿态，让部队更适合扛住第一轮冲击。",
+      "requiredLevel": 3,
+      "maxRank": 1,
+      "prerequisites": ["shield_discipline"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“守誓姿态”。",
+          "battleSkillIds": ["guardian_oath"]
+        }
+      ]
+    },
+    {
+      "id": "counterweight_tactics",
+      "branchId": "bulwark",
+      "name": "衡压战术",
+      "description": "以防守换取回合优势，用更厚的前排撑出反打窗口。",
+      "requiredLevel": 4,
+      "maxRank": 1,
+      "prerequisites": ["guardian_oath_training"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“护甲术”。",
+          "battleSkillIds": ["armor_spell"]
+        }
+      ]
+    },
+    {
+      "id": "iron_screen",
+      "branchId": "bulwark",
+      "name": "铁幕阵线",
+      "description": "把护卫与守势组合成持续前压的稳态打法。",
+      "requiredLevel": 5,
+      "maxRank": 1,
+      "prerequisites": ["counterweight_tactics"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "补足“持盾列阵”和“守誓姿态”的联动。",
+          "battleSkillIds": ["phalanx_command", "guardian_oath"]
+        }
+      ]
+    },
+    {
+      "id": "fortress_drill",
+      "branchId": "bulwark",
+      "name": "堡垒操练",
+      "description": "通过阵线纪律把远近压制合为一体，形成难以撕开的防线。",
+      "requiredLevel": 6,
+      "maxRank": 1,
+      "prerequisites": ["iron_screen"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "补足“钉锁投枪”和“护甲术”的后续支撑。",
+          "battleSkillIds": ["pinning_javelin", "armor_spell"]
+        }
+      ]
+    },
+    {
+      "id": "field_alchemy",
+      "branchId": "arcanum",
+      "name": "战地炼护",
+      "description": "先学会用简化法式为部队补上最低限度的护持。",
+      "requiredLevel": 2,
+      "maxRank": 1,
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“护甲术”。",
+          "battleSkillIds": ["armor_spell"]
+        }
+      ]
+    },
+    {
+      "id": "crippling_hex",
+      "branchId": "arcanum",
+      "name": "迟滞咒压",
+      "description": "利用低成本咒式压低敌方节奏，为拉扯创造空间。",
+      "requiredLevel": 3,
+      "maxRank": 1,
+      "prerequisites": ["field_alchemy"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“裂伤嚎叫”。",
+          "battleSkillIds": ["crippling_howl"]
+        }
+      ]
+    },
+    {
+      "id": "toxin_studies",
+      "branchId": "arcanum",
+      "name": "毒性研修",
+      "description": "把持续伤害编入常规战斗节奏，让对手难以稳定换血。",
+      "requiredLevel": 4,
+      "maxRank": 1,
+      "prerequisites": ["crippling_hex"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁被动技能“毒牙”。",
+          "battleSkillIds": ["venomous_fangs"]
+        }
+      ]
+    },
+    {
+      "id": "battle_meditation",
+      "branchId": "arcanum",
+      "name": "战冥调律",
+      "description": "在复杂战况中维持施法专注，为关键回合抬高爆发。",
+      "requiredLevel": 5,
+      "maxRank": 1,
+      "prerequisites": ["toxin_studies"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "解锁主动技能“战意激发”。",
+          "battleSkillIds": ["battle_focus"]
+        }
+      ]
+    },
+    {
+      "id": "doomcraft",
+      "branchId": "arcanum",
+      "name": "厄咒编织",
+      "description": "把削弱与持续伤害叠成完整压制循环，适合拖长战线。",
+      "requiredLevel": 6,
+      "maxRank": 1,
+      "prerequisites": ["battle_meditation"],
+      "ranks": [
+        {
+          "rank": 1,
+          "description": "补足“裂伤嚎叫”和“毒牙”的持续压制组合。",
+          "battleSkillIds": ["crippling_howl", "venomous_fangs"]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -1,5 +1,5 @@
 import defaultBattleSkillsConfig from "../../../configs/battle-skills.json";
-import defaultHeroSkillsConfig from "../../../configs/hero-skills.json";
+import defaultHeroSkillTreesConfig from "../../../configs/hero-skill-trees-full.json";
 import defaultMapObjectsConfig from "../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../configs/units.json";
 import defaultWorldConfig from "../../../configs/phase1-world.json";
@@ -20,7 +20,7 @@ let runtimeWorldConfig: WorldGenerationConfig = structuredClone(defaultWorldConf
 let runtimeMapObjectsConfig: MapObjectsConfig = structuredClone(defaultMapObjectsConfig as MapObjectsConfig);
 let runtimeUnitCatalog: UnitCatalogConfig = structuredClone(defaultUnitsConfig as UnitCatalogConfig);
 let runtimeBattleSkillCatalog: BattleSkillCatalogConfig = structuredClone(defaultBattleSkillsConfig as BattleSkillCatalogConfig);
-let runtimeHeroSkillTree: HeroSkillTreeConfig = structuredClone(defaultHeroSkillsConfig as HeroSkillTreeConfig);
+let runtimeHeroSkillTree: HeroSkillTreeConfig = structuredClone(defaultHeroSkillTreesConfig as HeroSkillTreeConfig);
 
 export interface RuntimeConfigBundle {
   world: WorldGenerationConfig;
@@ -586,5 +586,5 @@ export function resetRuntimeConfigs(): void {
   runtimeMapObjectsConfig = structuredClone(defaultMapObjectsConfig as MapObjectsConfig);
   runtimeUnitCatalog = structuredClone(defaultUnitsConfig as UnitCatalogConfig);
   runtimeBattleSkillCatalog = structuredClone(defaultBattleSkillsConfig as BattleSkillCatalogConfig);
-  runtimeHeroSkillTree = structuredClone(defaultHeroSkillsConfig as HeroSkillTreeConfig);
+  runtimeHeroSkillTree = structuredClone(defaultHeroSkillTreesConfig as HeroSkillTreeConfig);
 }

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   applyBattleAction,
   applyBattleOutcomeToWorld,
+  createHeroSkillTreeView,
   createDemoBattleState,
   createEmptyBattleState,
   createHeroBattleState,
@@ -13,6 +14,7 @@ import {
   createWorldStateFromConfigs,
   filterWorldEventsForPlayer,
   getDefaultBattleSkillCatalog,
+  getDefaultHeroSkillTreeConfig,
   getDefaultUnitCatalog,
   getBattleOutcome,
   pickAutomatedBattleAction,
@@ -571,6 +573,86 @@ test("resolveWorldAction lets heroes learn and upgrade long-term skills after le
     valid: false,
     reason: "not_enough_skill_points"
   });
+});
+
+test("default hero skill tree loads the full three-branch layout", () => {
+  const config = getDefaultHeroSkillTreeConfig();
+
+  assert.equal(config.branches.length, 3);
+  assert.equal(config.skills.length, 15);
+  assert.equal(config.skills.filter((skill) => skill.branchId === "warpath").length, 5);
+  assert.equal(config.skills.filter((skill) => skill.branchId === "bulwark").length, 5);
+  assert.equal(config.skills.filter((skill) => skill.branchId === "arcanum").length, 5);
+});
+
+test("hero skill tree view and resolveWorldAction advance branch prerequisites in order", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    progression: {
+      ...createDefaultHeroProgression(),
+      level: 3,
+      experience: 240,
+      skillPoints: 2
+    }
+  });
+  const state = createWorldState({
+    width: 2,
+    height: 1,
+    heroes: [hero],
+    tiles: [
+      createTile(0, 0, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(1, 0)
+    ],
+    visibilityByPlayer: {
+      "player-1": ["visible", "visible"]
+    }
+  });
+
+  const initialView = createHeroSkillTreeView(hero);
+  const initialLearnableIds = initialView.branches.flatMap((branch) => branch.skills.filter((skill) => skill.canLearn).map((skill) => skill.id));
+  assert.ok(initialLearnableIds.includes("war_banner"));
+  assert.ok(!initialLearnableIds.includes("spearhead_assault"));
+
+  const firstLearn = resolveWorldAction(state, {
+    type: "hero.learnSkill",
+    heroId: "hero-1",
+    skillId: "war_banner"
+  });
+
+  const progressedHero = firstLearn.state.heroes[0]!;
+  const nextView = createHeroSkillTreeView(progressedHero);
+  const nextLearnableIds = nextView.branches.flatMap((branch) => branch.skills.filter((skill) => skill.canLearn).map((skill) => skill.id));
+  assert.ok(nextLearnableIds.includes("spearhead_assault"));
+
+  const secondLearn = resolveWorldAction(firstLearn.state, {
+    type: "hero.learnSkill",
+    heroId: "hero-1",
+    skillId: "spearhead_assault"
+  });
+
+  assert.deepEqual(
+    secondLearn.state.heroes[0]?.learnedSkills.slice().sort((left, right) => left.skillId.localeCompare(right.skillId)),
+    [
+      { skillId: "spearhead_assault", rank: 1 },
+      { skillId: "war_banner", rank: 1 }
+    ]
+  );
+  assert.deepEqual(secondLearn.events, [
+    {
+      type: "hero.skillLearned",
+      heroId: "hero-1",
+      skillId: "spearhead_assault",
+      branchId: "warpath",
+      skillName: "矛锋突击",
+      branchName: "战阵",
+      newRank: 1,
+      spentPoint: 1,
+      remainingSkillPoints: 0,
+      newlyGrantedBattleSkillIds: ["sundering_spear"]
+    }
+  ]);
 });
 
 test("createHeroBattleState carries learned hero skill tree rewards into battle", () => {


### PR DESCRIPTION
## Summary\n- add a full hero skill tree config with 3 branches and 15 progression nodes\n- wire shared world config to load the full hero skill tree by default\n- surface learnable hero skills in the Cocos HUD and connect learn-skill actions\n- add shared tests covering default config loading and branch prerequisite progression\n\nCloses #20