### PR TITLE
feat: 英雄升级与属性进度可视化 (#29)

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,6 +1,8 @@
 import "./styles.css";
 import {
   createHeroSkillTreeView,
+  createHeroAttributeBreakdown,
+  createHeroProgressMeterView,
   experienceRequiredForNextLevel,
   getDefaultBattleSkillCatalog,
   predictPlayerWorldAction,
@@ -356,10 +358,76 @@ function formatHeroExperience(hero: PlayerWorldView["ownHeroes"][number] | null)
     return "XP 0/100";
   }
 
-  const currentLevelBase = totalExperienceRequiredForLevel(hero.progression.level);
-  const currentLevelXp = Math.max(0, hero.progression.experience - currentLevelBase);
-  const nextLevelXp = experienceRequiredForNextLevel(hero.progression.level);
-  return `XP ${currentLevelXp}/${nextLevelXp}`;
+  const meter = createHeroProgressMeterView(hero);
+  return `XP ${meter.currentLevelExperience}/${meter.nextLevelExperience}`;
+}
+
+function renderHeroProgressPanel(hero: PlayerWorldView["ownHeroes"][number] | null): string {
+  if (!hero) {
+    return `
+      <section class="hero-progress-panel info-card">
+        <div class="hero-progress-head">
+          <strong>升级进度</strong>
+          <span class="muted">等待英雄数据</span>
+        </div>
+      </section>
+    `;
+  }
+
+  const meter = createHeroProgressMeterView(hero);
+  return `
+    <section class="hero-progress-panel info-card" data-testid="hero-progress-panel">
+      <div class="hero-progress-head">
+        <strong>升级进度</strong>
+        <span class="status-pill">Lv ${meter.level}</span>
+      </div>
+      <div class="hero-progress-meta">
+        <span>当前 ${meter.currentLevelExperience}/${meter.nextLevelExperience} XP</span>
+        <span>还需 ${meter.remainingExperience} XP</span>
+      </div>
+      <div class="hero-progress-track" aria-label="hero experience progress">
+        <div class="hero-progress-fill" style="width:${(meter.progressRatio * 100).toFixed(1)}%"></div>
+      </div>
+      <p class="hero-progress-copy muted">总经验 ${meter.totalExperience} · 下一级阈值 ${totalExperienceRequiredForLevel(meter.level + 1)}</p>
+    </section>
+  `;
+}
+
+function renderHeroAttributePanel(
+  hero: PlayerWorldView["ownHeroes"][number] | null,
+  world: PlayerWorldView
+): string {
+  if (!hero) {
+    return "";
+  }
+
+  const rows = createHeroAttributeBreakdown(hero, world);
+  return `
+    <section class="hero-attribute-panel info-card" data-testid="hero-attribute-panel">
+      <div class="hero-progress-head">
+        <strong>属性来源</strong>
+        <span class="muted">悬停查看公式</span>
+      </div>
+      <div class="hero-attribute-list">
+        ${rows
+          .map(
+            (row) => `
+              <div class="hero-attribute-row" title="${escapeHtml(row.formula)}">
+                <strong>${row.label}</strong>
+                <span>${row.total}</span>
+                <span>基础 ${row.base}</span>
+                <span>成长 ${row.progression}</span>
+                <span>建筑 ${row.buildings}</span>
+                <span>装备 ${row.equipment}</span>
+                <span>技能 ${row.skills}</span>
+                ${row.other !== 0 ? `<span>其他 ${row.other}</span>` : ""}
+              </div>
+            `
+          )
+          .join("")}
+      </div>
+    </section>
+  `;
 }
 
 function formatHeroSkillReason(reason: string): string {
@@ -2204,6 +2272,7 @@ function render(): void {
           <h2>${hero?.name ?? "No Hero"}</h2>
           <p data-testid="hero-level">${formatHeroProgression(hero)}</p>
           <p data-testid="hero-xp">${formatHeroExperience(hero)}</p>
+          ${renderHeroProgressPanel(hero)}
           <p data-testid="hero-stats">${formatHeroCoreStats(hero)}</p>
           <p data-testid="hero-hp">HP ${hero?.stats.hp ?? 0}/${hero?.stats.maxHp ?? 0}</p>
           <p data-testid="hero-move">Move ${hero?.move.remaining ?? 0}/${hero?.move.total ?? 0}</p>
@@ -2211,6 +2280,7 @@ function render(): void {
           <p data-testid="hero-army">Army ${hero?.armyTemplateId ?? "-"} x ${hero?.armyCount ?? 0}</p>
           <p data-testid="hero-skill-points">Skill Points ${hero?.progression.skillPoints ?? 0}</p>
           <p class="muted" data-testid="hero-preview">${state.previewPlan ? `预览消耗 ${state.previewPlan.moveCost} 步` : state.predictionStatus || "悬停地图格子查看路径"}</p>
+          ${renderHeroAttributePanel(hero, state.world)}
           <button class="modal-button" data-end-day="true" ${state.battle ? "disabled" : ""}>推进到下一天</button>
           ${renderHeroSkillTree(hero)}
         </div>

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -386,6 +386,77 @@ h1 {
   margin-top: 8px;
 }
 
+.hero-progress-panel,
+.hero-attribute-panel {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+  padding: 12px;
+}
+
+.hero-progress-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hero-progress-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 8px 12px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.hero-progress-track {
+  position: relative;
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(84, 57, 35, 0.12);
+}
+
+.hero-progress-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(47, 110, 91, 0.88), rgba(193, 145, 57, 0.92));
+  box-shadow: 0 0 14px rgba(193, 145, 57, 0.18);
+}
+
+.hero-progress-copy {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.hero-attribute-list {
+  display: grid;
+  gap: 8px;
+}
+
+.hero-attribute-row {
+  display: grid;
+  grid-template-columns: minmax(68px, 1fr) repeat(6, auto);
+  gap: 8px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.64);
+  border: 1px solid rgba(78, 58, 42, 0.08);
+  font-size: 12px;
+}
+
+.hero-attribute-row strong {
+  font-size: 13px;
+}
+
+.hero-attribute-row span {
+  color: var(--muted);
+  white-space: nowrap;
+}
+
 .hero-skill-tree {
   margin-top: 14px;
   display: grid;
@@ -1175,5 +1246,9 @@ h1 {
   .session-meta-row,
   .lobby-room-card-head {
     flex-direction: column;
+  }
+
+  .hero-attribute-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -1,4 +1,5 @@
 import { _decorator, Color, Component, Graphics, Label, Node, Sprite, UIOpacity, UITransform } from "cc";
+import { createHeroAttributeBreakdown, createHeroProgressMeterView } from "../../../../packages/shared/src/hero-progression.ts";
 import { createHeroSkillTreeView } from "../../../../packages/shared/src/hero-skills.ts";
 import type { BattleSkillId, HeroState } from "../../../../packages/shared/src/models.ts";
 import { getDefaultBattleSkillCatalog } from "../../../../packages/shared/src/world-config.ts";
@@ -33,6 +34,7 @@ const CARD_PREFIX = "HudCard";
 const CHIP_PREFIX = "HudChip";
 const BADGE_PREFIX = "HudBadge";
 const HERO_METER_PREFIX = "HudHeroMeter";
+const HERO_PROGRESS_PREFIX = "HudHeroProgress";
 const SKILL_BUTTON_PREFIX = "HudSkillButton";
 
 interface HudLearnableSkillState {
@@ -121,6 +123,10 @@ export interface VeilHudRenderState {
   moveInFlight: boolean;
   predictionStatus: string;
   inputDebug: string;
+  levelUpNotice: {
+    title: string;
+    detail: string;
+  } | null;
 }
 
 export interface VeilHudPanelOptions {
@@ -171,19 +177,20 @@ export class VeilHudPanel extends Component {
     const resources = world?.resources;
     const battle = state.update?.battle;
     const learnableSkills = listLearnableHeroSkills(hero);
+    const progressMeter = hero ? createHeroProgressMeterView(toHeroSkillState(hero)) : null;
+    const attributeRows = hero ? createHeroAttributeBreakdown(toHeroSkillState(hero), world ?? undefined) : [];
     const reachableAhead =
       state.update?.reachableTiles.filter((tile) => !hero || tile.x !== hero.position.x || tile.y !== hero.position.y).length ?? 0;
-    const statusTitle = battle
-      ? "状态"
-      : hero && hero.move.remaining <= 0
-        ? "状态"
-        : "状态";
-    const statusBadge = battle
+    const statusTitle = state.levelUpNotice?.title ?? "状态";
+    const statusBadge = state.levelUpNotice
+      ? "升级!"
+      : battle
       ? "战斗中"
       : hero && hero.move.remaining <= 0
         ? "体力耗尽"
         : "待命";
-    const statusDetail = state.predictionStatus
+    const statusDetail = state.levelUpNotice?.detail
+      || state.predictionStatus
       || (state.moveInFlight
         ? "正在结算移动..."
         : hero && hero.move.remaining <= 0
@@ -233,19 +240,22 @@ export class VeilHudPanel extends Component {
         ? [
             `英雄  ${hero.name}`,
             `坐标 (${hero.position.x},${hero.position.y})`,
-            `等级 ${hero.progression.level}  经验 ${hero.progression.experience}  技能点 ${hero.progression.skillPoints ?? 0}`,
+            `等级 ${hero.progression.level}  经验 ${progressMeter?.currentLevelExperience ?? 0}/${progressMeter?.nextLevelExperience ?? 100}  技能点 ${hero.progression.skillPoints ?? 0}`,
             `攻 ${hero.stats.attack}  防 ${hero.stats.defense}  力 ${hero.stats.power}  知 ${hero.stats.knowledge}`,
+            attributeRows[0] ? `攻防公式 ${attributeRows[0].formula} / ${attributeRows[1]?.formula ?? ""}` : "",
+            attributeRows[2] ? `法术公式 ${attributeRows[2].formula} / ${attributeRows[3]?.formula ?? ""}` : "",
+            attributeRows[4] ? attributeRows[4].formula : "",
             `兵种 ${hero.armyTemplateId}`,
             `技能 ${formatHeroLearnedSkills(hero)}`
           ]
-        : ["英雄", "等待房间状态...", "", "", "", ""],
+        : ["英雄", "等待房间状态...", "", "", "", "", "", ""],
       cursorY,
       14,
       18,
       cardWidth,
       leftX,
       7,
-      132
+      182
     );
 
     cursorY = this.renderCardBlock(
@@ -293,11 +303,20 @@ export class VeilHudPanel extends Component {
 
     if (hero) {
       this.renderHeroBadge(`${CARD_PREFIX}-hero`, `Lv ${hero.progression.level}`);
+      if (progressMeter) {
+        this.renderHeroProgressBar(
+          `${CARD_PREFIX}-hero`,
+          progressMeter.progressRatio,
+          `XP ${progressMeter.currentLevelExperience}/${progressMeter.nextLevelExperience}`,
+          Boolean(state.levelUpNotice)
+        );
+      }
       this.renderHeroMeters(`${CARD_PREFIX}-hero`, hero.move.remaining, hero.move.total, hero.stats.hp, hero.stats.maxHp, hero.armyCount);
       this.tightenHeroLabelLayout(leftX, cardWidth);
       this.renderLearnableSkillButtons(`${CARD_PREFIX}-skills`, learnableSkills);
     } else {
       this.hideCardDecorations(`${CARD_PREFIX}-hero`, BADGE_PREFIX);
+      this.hideCardDecorations(`${CARD_PREFIX}-hero`, HERO_PROGRESS_PREFIX);
       this.hideCardDecorations(`${CARD_PREFIX}-hero`, `${CHIP_PREFIX}-${HERO_METER_PREFIX}`);
       this.hideCardDecorations(`${CARD_PREFIX}-skills`, SKILL_BUTTON_PREFIX);
     }
@@ -707,11 +726,65 @@ export class VeilHudPanel extends Component {
     const chipHeight = 28;
     const totalWidth = chipWidth * 3 + gap * 2;
     const startX = -totalWidth / 2 + chipWidth / 2;
-    const y = -30;
+    const y = -52;
 
     this.renderMetricChip(cardNode, `${HERO_METER_PREFIX}-move`, startX, y, chipWidth, chipHeight, null, "移动", `${moveRemaining}/${moveTotal}`, new Color(112, 152, 220, 224));
     this.renderMetricChip(cardNode, `${HERO_METER_PREFIX}-hp`, startX + chipWidth + gap, y, chipWidth, chipHeight, null, "生命", `${hp}/${maxHp}`, new Color(122, 180, 124, 224));
     this.renderMetricChip(cardNode, `${HERO_METER_PREFIX}-army`, startX + (chipWidth + gap) * 2, y, chipWidth, chipHeight, null, "兵力", `${armyCount}`, new Color(204, 168, 92, 224));
+  }
+
+  private renderHeroProgressBar(cardName: string, ratio: number, labelText: string, highlighted: boolean): void {
+    const cardNode = this.node.getChildByName(cardName);
+    if (!cardNode) {
+      return;
+    }
+
+    let barNode = cardNode.getChildByName(HERO_PROGRESS_PREFIX);
+    if (!barNode) {
+      barNode = new Node(HERO_PROGRESS_PREFIX);
+      barNode.parent = cardNode;
+    }
+    assignUiLayer(barNode);
+    barNode.active = true;
+
+    const cardTransform = cardNode.getComponent(UITransform) ?? cardNode.addComponent(UITransform);
+    const width = Math.max(120, cardTransform.width - 28);
+    const height = 18;
+    const clampedRatio = Math.max(0, Math.min(1, ratio));
+    const barTransform = barNode.getComponent(UITransform) ?? barNode.addComponent(UITransform);
+    barTransform.setContentSize(width, height);
+    barNode.setPosition(0, -22, 1);
+
+    const graphics = barNode.getComponent(Graphics) ?? barNode.addComponent(Graphics);
+    const accent = highlighted ? new Color(233, 201, 118, 236) : new Color(108, 166, 122, 228);
+    graphics.clear();
+    graphics.fillColor = new Color(28, 36, 50, 196);
+    graphics.strokeColor = new Color(accent.r, accent.g, accent.b, highlighted ? 180 : 96);
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 8);
+    graphics.fill();
+    graphics.stroke();
+    graphics.fillColor = new Color(accent.r, accent.g, accent.b, highlighted ? 212 : 168);
+    graphics.roundRect(-width / 2 + 2, -height / 2 + 2, Math.max(10, (width - 4) * clampedRatio), height - 4, 6);
+    graphics.fill();
+
+    let labelNode = barNode.getChildByName("Label");
+    if (!labelNode) {
+      labelNode = new Node("Label");
+      labelNode.parent = barNode;
+    }
+    assignUiLayer(labelNode);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(width - 8, height);
+    labelNode.setPosition(0, 0, 1);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = labelText;
+    label.fontSize = 9;
+    label.lineHeight = 11;
+    label.horizontalAlign = H_ALIGN_CENTER;
+    label.verticalAlign = V_ALIGN_MIDDLE;
+    label.enableWrapText = false;
+    label.color = new Color(246, 249, 252, 255);
   }
 
   private renderLearnableSkillButtons(cardName: string, skills: HudLearnableSkillState[]): void {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -31,6 +31,7 @@ import { VeilBattleTransition } from "./VeilBattleTransition.ts";
 import { VeilBattlePanel } from "./VeilBattlePanel.ts";
 import { assignUiLayer } from "./cocos-ui-layer.ts";
 import { buildTimelineEntriesFromUpdate } from "./cocos-ui-formatters.ts";
+import { buildHeroProgressNotice, type HeroProgressNotice } from "./cocos-hero-progression.ts";
 import { VeilHudPanel } from "./VeilHudPanel.ts";
 import { VeilLobbyPanel } from "./VeilLobbyPanel.ts";
 import { VeilMapBoard } from "./VeilMapBoard.ts";
@@ -124,6 +125,7 @@ export class VeilRoot extends Component {
   private authMode: "guest" | "account" = "guest";
   private loginId = "";
   private sessionSource: "remote" | "local" | "manual" | "none" = "none";
+  private levelUpNotice: (HeroProgressNotice & { expiresAt: number }) | null = null;
   private showLobby = false;
   private lobbyRooms: CocosLobbyRoomSummary[] = [];
   private lobbyStatus = "请选择一个房间，或手动输入新的房间 ID。";
@@ -491,6 +493,10 @@ export class VeilRoot extends Component {
   }
 
   private renderView(): void {
+    if (this.levelUpNotice && this.levelUpNotice.expiresAt <= Date.now()) {
+      this.levelUpNotice = null;
+    }
+
     this.updateLayout();
     const lobbyNode = this.node.getChildByName(LOBBY_NODE_NAME);
     const hudNode = this.node.getChildByName(HUD_NODE_NAME);
@@ -543,7 +549,8 @@ export class VeilRoot extends Component {
       update: this.lastUpdate,
       moveInFlight: this.moveInFlight,
       predictionStatus: this.predictionStatus,
-      inputDebug: this.inputDebug
+      inputDebug: this.inputDebug,
+      levelUpNotice: this.levelUpNotice ? { title: this.levelUpNotice.title, detail: this.levelUpNotice.detail } : null
     });
     this.mapBoard?.render(this.lastUpdate);
     this.battlePanel?.render({
@@ -1698,6 +1705,7 @@ export class VeilRoot extends Component {
     }
     this.syncSelectedBattleTarget();
     this.playMapFeedbackForUpdate(update);
+    this.maybeShowHeroProgressNotice(update);
 
     if (!previousBattleId && nextBattleId) {
       this.mapBoard?.playHeroAnimation("attack");
@@ -1713,6 +1721,54 @@ export class VeilRoot extends Component {
     }
 
     this.renderView();
+  }
+
+  private maybeShowHeroProgressNotice(update: SessionUpdate): void {
+    const heroId = update.world.ownHeroes[0]?.id ?? null;
+    const notice = buildHeroProgressNotice(update, heroId);
+    if (!notice) {
+      return;
+    }
+
+    this.levelUpNotice = {
+      ...notice,
+      expiresAt: Date.now() + 5000
+    };
+    this.pushLog(`${notice.title}。${notice.detail}`);
+    this.mapBoard?.playHeroAnimation("victory");
+    this.playLevelUpSound();
+  }
+
+  private playLevelUpSound(): void {
+    const audioContextCtor =
+      (globalThis as { AudioContext?: new () => AudioContext; webkitAudioContext?: new () => AudioContext }).AudioContext
+      ?? (globalThis as { webkitAudioContext?: new () => AudioContext }).webkitAudioContext;
+    if (!audioContextCtor) {
+      return;
+    }
+
+    try {
+      const audioContext = new audioContextCtor();
+      const now = audioContext.currentTime;
+      const oscillator = audioContext.createOscillator();
+      const gainNode = audioContext.createGain();
+      oscillator.type = "triangle";
+      oscillator.frequency.setValueAtTime(523.25, now);
+      oscillator.frequency.linearRampToValueAtTime(659.25, now + 0.12);
+      oscillator.frequency.linearRampToValueAtTime(783.99, now + 0.24);
+      gainNode.gain.setValueAtTime(0.0001, now);
+      gainNode.gain.linearRampToValueAtTime(0.08, now + 0.02);
+      gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 0.32);
+      oscillator.connect(gainNode);
+      gainNode.connect(audioContext.destination);
+      oscillator.start(now);
+      oscillator.stop(now + 0.34);
+      oscillator.onended = () => {
+        void audioContext.close().catch(() => undefined);
+      };
+    } catch {
+      // Ignore audio failures in runtimes that block autoplay or lack Web Audio.
+    }
   }
 
   private playMapFeedbackForUpdate(update: SessionUpdate): void {

--- a/apps/cocos-client/assets/scripts/cocos-hero-progression.ts
+++ b/apps/cocos-client/assets/scripts/cocos-hero-progression.ts
@@ -1,0 +1,40 @@
+import { createHeroProgressMeterView } from "../../../../packages/shared/src/hero-progression.ts";
+import type { SessionUpdate } from "./VeilCocosSession.ts";
+
+export interface HeroProgressNotice {
+  title: string;
+  detail: string;
+}
+
+type HeroProgressedEvent = Extract<SessionUpdate["events"][number], { type: "hero.progressed" }>;
+
+export function buildHeroProgressNotice(
+  update: SessionUpdate,
+  heroId: string | null
+): HeroProgressNotice | null {
+  if (!heroId) {
+    return null;
+  }
+
+  const progressEvent = update.events.find(
+    (event) => event.type === "hero.progressed" && event.heroId === heroId
+  ) as HeroProgressedEvent | undefined;
+  if (!progressEvent || progressEvent.levelsGained <= 0) {
+    return null;
+  }
+
+  const hero = update.world.ownHeroes.find((item) => item.id === heroId) ?? null;
+  const meter = hero ? createHeroProgressMeterView(hero) : null;
+  const nextHint = meter
+    ? `当前 ${meter.currentLevelExperience}/${meter.nextLevelExperience} XP`
+    : `总经验 ${progressEvent.totalExperience}`;
+  const skillHint =
+    progressEvent.availableSkillPoints > 0
+      ? `可立即学习新技能，剩余技能点 ${progressEvent.availableSkillPoints}。`
+      : "本次未产生可分配技能点。";
+
+  return {
+    title: `升级到 Lv ${progressEvent.level}`,
+    detail: `获得 ${progressEvent.experienceGained} XP，${nextHint}。${skillHint}`
+  };
+}

--- a/apps/cocos-client/test/cocos-hero-progression.test.ts
+++ b/apps/cocos-client/test/cocos-hero-progression.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildHeroProgressNotice } from "../assets/scripts/cocos-hero-progression";
+
+test("buildHeroProgressNotice summarizes hero level up and skill prompt", () => {
+  const notice = buildHeroProgressNotice(
+    {
+      world: {
+        meta: {
+          roomId: "room-alpha",
+          seed: 1001,
+          day: 1
+        },
+        map: {
+          width: 1,
+          height: 1,
+          tiles: []
+        },
+        ownHeroes: [
+          {
+            id: "hero-1",
+            playerId: "player-1",
+            name: "凯琳",
+            position: { x: 0, y: 0 },
+            vision: 2,
+            move: { total: 6, remaining: 6 },
+            stats: {
+              attack: 3,
+              defense: 3,
+              power: 1,
+              knowledge: 1,
+              hp: 30,
+              maxHp: 32
+            },
+            progression: {
+              level: 2,
+              experience: 140,
+              skillPoints: 1,
+              battlesWon: 1,
+              neutralBattlesWon: 1,
+              pvpBattlesWon: 0
+            },
+            armyCount: 12,
+            armyTemplateId: "hero_guard_basic",
+            learnedSkills: []
+          }
+        ],
+        visibleHeroes: [],
+        resources: {
+          gold: 0,
+          wood: 0,
+          ore: 0
+        },
+        playerId: "player-1"
+      },
+      battle: null,
+      events: [
+        {
+          type: "hero.progressed" as const,
+          heroId: "hero-1",
+          battleId: "battle-1",
+          battleKind: "neutral" as const,
+          experienceGained: 140,
+          totalExperience: 140,
+          level: 2,
+          levelsGained: 1,
+          skillPointsAwarded: 1,
+          availableSkillPoints: 1
+        }
+      ],
+      movementPlan: null,
+      reachableTiles: [],
+      reason: undefined
+    },
+    "hero-1"
+  );
+
+  assert.deepEqual(notice, {
+    title: "升级到 Lv 2",
+    detail: "获得 140 XP，当前 40/175 XP。可立即学习新技能，剩余技能点 1。"
+  });
+});

--- a/packages/shared/src/hero-progression.ts
+++ b/packages/shared/src/hero-progression.ts
@@ -1,0 +1,155 @@
+import type { HeroState, PlayerWorldView } from "./models";
+import { experienceRequiredForNextLevel, totalExperienceRequiredForLevel } from "./models";
+
+export interface HeroProgressMeterView {
+  level: number;
+  totalExperience: number;
+  currentLevelExperience: number;
+  nextLevelExperience: number;
+  remainingExperience: number;
+  progressRatio: number;
+}
+
+export type HeroAttributeKey = "attack" | "defense" | "power" | "knowledge" | "maxHp";
+
+export interface HeroAttributeBreakdownRow {
+  key: HeroAttributeKey;
+  label: string;
+  total: number;
+  base: number;
+  progression: number;
+  buildings: number;
+  equipment: number;
+  skills: number;
+  other: number;
+  formula: string;
+}
+
+interface HeroAttributeSourceSet {
+  progression: Record<HeroAttributeKey, number>;
+  buildings: Record<HeroAttributeKey, number>;
+  equipment: Record<HeroAttributeKey, number>;
+  skills: Record<HeroAttributeKey, number>;
+}
+
+const ATTRIBUTE_ROWS: Array<{ key: HeroAttributeKey; label: string }> = [
+  { key: "attack", label: "攻击" },
+  { key: "defense", label: "防御" },
+  { key: "power", label: "力量" },
+  { key: "knowledge", label: "知识" },
+  { key: "maxHp", label: "生命上限" }
+];
+
+function createEmptyAttributeValues(): Record<HeroAttributeKey, number> {
+  return {
+    attack: 0,
+    defense: 0,
+    power: 0,
+    knowledge: 0,
+    maxHp: 0
+  };
+}
+
+function heroTotalForKey(hero: Pick<HeroState, "stats">, key: HeroAttributeKey): number {
+  return key === "maxHp" ? hero.stats.maxHp : hero.stats[key];
+}
+
+function buildProgressionContribution(hero: Pick<HeroState, "progression">): Record<HeroAttributeKey, number> {
+  const gainedLevels = Math.max(0, Math.floor(hero.progression.level) - 1);
+  return {
+    attack: gainedLevels,
+    defense: gainedLevels,
+    power: 0,
+    knowledge: 0,
+    maxHp: gainedLevels * 2
+  };
+}
+
+function buildBuildingContribution(
+  world: Pick<PlayerWorldView, "map"> | null | undefined,
+  heroId: string
+): Record<HeroAttributeKey, number> {
+  const totals = createEmptyAttributeValues();
+  if (!world) {
+    return totals;
+  }
+
+  for (const tile of world.map.tiles) {
+    if (tile.building?.kind !== "attribute_shrine" || !tile.building.visitedHeroIds.includes(heroId)) {
+      continue;
+    }
+
+    totals.attack += tile.building.bonus.attack;
+    totals.defense += tile.building.bonus.defense;
+    totals.power += tile.building.bonus.power;
+    totals.knowledge += tile.building.bonus.knowledge;
+  }
+
+  return totals;
+}
+
+function formatContribution(label: string, value: number): string {
+  return `${label}${value >= 0 ? ` +${value}` : ` ${value}`}`;
+}
+
+export function createHeroProgressMeterView(
+  hero: Pick<HeroState, "progression">
+): HeroProgressMeterView {
+  const currentLevelBase = totalExperienceRequiredForLevel(hero.progression.level);
+  const currentLevelExperience = Math.max(0, hero.progression.experience - currentLevelBase);
+  const nextLevelExperience = Math.max(1, experienceRequiredForNextLevel(hero.progression.level));
+  const remainingExperience = Math.max(0, nextLevelExperience - currentLevelExperience);
+
+  return {
+    level: hero.progression.level,
+    totalExperience: hero.progression.experience,
+    currentLevelExperience,
+    nextLevelExperience,
+    remainingExperience,
+    progressRatio: Math.max(0, Math.min(1, currentLevelExperience / nextLevelExperience))
+  };
+}
+
+export function createHeroAttributeBreakdown(
+  hero: Pick<HeroState, "id" | "stats" | "progression">,
+  world?: Pick<PlayerWorldView, "map"> | null
+): HeroAttributeBreakdownRow[] {
+  const sources: HeroAttributeSourceSet = {
+    progression: buildProgressionContribution(hero),
+    buildings: buildBuildingContribution(world, hero.id),
+    equipment: createEmptyAttributeValues(),
+    skills: createEmptyAttributeValues()
+  };
+
+  return ATTRIBUTE_ROWS.map(({ key, label }) => {
+    const total = heroTotalForKey(hero, key);
+    const progression = sources.progression[key];
+    const buildings = sources.buildings[key];
+    const equipment = sources.equipment[key];
+    const skills = sources.skills[key];
+    const knownBonuses = progression + buildings + equipment + skills;
+    const base = Math.max(0, total - knownBonuses);
+    const other = total - base - knownBonuses;
+    const parts = [
+      `${label} ${total} = 基础 ${base}`,
+      progression !== 0 ? formatContribution("成长", progression) : "",
+      buildings !== 0 ? formatContribution("建筑", buildings) : "",
+      equipment !== 0 ? formatContribution("装备", equipment) : "",
+      skills !== 0 ? formatContribution("技能", skills) : "",
+      other !== 0 ? formatContribution("其他", other) : ""
+    ].filter(Boolean);
+
+    return {
+      key,
+      label,
+      total,
+      base,
+      progression,
+      buildings,
+      equipment,
+      skills,
+      other,
+      formula: parts.join(" ")
+    };
+  });
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./battle";
 export * from "./hero-skills";
+export * from "./hero-progression";
 export * from "./map";
 export * from "./models";
 export * from "./protocol";

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -3,7 +3,9 @@ import test from "node:test";
 import {
   applyBattleAction,
   applyBattleOutcomeToWorld,
+  createHeroAttributeBreakdown,
   createHeroSkillTreeView,
+  createHeroProgressMeterView,
   createDemoBattleState,
   createEmptyBattleState,
   createHeroBattleState,
@@ -200,6 +202,86 @@ test("createPlayerWorldView respects fog-of-war visibility rules", () => {
     }
   ]);
   assert.deepEqual(view.resources, { gold: 0, wood: 0, ore: 0 });
+});
+
+test("hero progression helpers expose xp meter and attribute sources", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    stats: {
+      attack: 4,
+      defense: 3,
+      power: 1,
+      knowledge: 1,
+      hp: 30,
+      maxHp: 32
+    },
+    progression: {
+      level: 2,
+      experience: 140,
+      skillPoints: 1,
+      battlesWon: 1,
+      neutralBattlesWon: 1,
+      pvpBattlesWon: 0
+    }
+  });
+  const state = createWorldState({
+    heroes: [hero],
+    buildings: {
+      shrine: {
+        id: "shrine",
+        kind: "attribute_shrine",
+        position: { x: 1, y: 0 },
+        label: "荣耀方尖碑",
+        bonus: {
+          attack: 1,
+          defense: 0,
+          power: 0,
+          knowledge: 0
+        },
+        visitedHeroIds: ["hero-1"]
+      }
+    },
+    tiles: [
+      createTile(0, 0, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(1, 0, {
+        building: {
+          id: "shrine",
+          kind: "attribute_shrine",
+          position: { x: 1, y: 0 },
+          label: "荣耀方尖碑",
+          bonus: {
+            attack: 1,
+            defense: 0,
+            power: 0,
+            knowledge: 0
+          },
+          visitedHeroIds: ["hero-1"]
+        }
+      }),
+      createTile(0, 1),
+      createTile(1, 1)
+    ],
+    visibilityByPlayer: {
+      "player-1": ["visible", "visible", "visible", "visible"]
+    }
+  });
+  const view = createPlayerWorldView(state, "player-1");
+  const meter = createHeroProgressMeterView(hero);
+  const breakdown = createHeroAttributeBreakdown(hero, view);
+
+  assert.deepEqual(meter, {
+    level: 2,
+    totalExperience: 140,
+    currentLevelExperience: 40,
+    nextLevelExperience: 175,
+    remainingExperience: 135,
+    progressRatio: 40 / 175
+  });
+  assert.equal(breakdown.find((row) => row.key === "attack")?.formula, "攻击 4 = 基础 2 成长 +1 建筑 +1");
+  assert.equal(breakdown.find((row) => row.key === "defense")?.formula, "防御 3 = 基础 2 成长 +1");
+  assert.equal(breakdown.find((row) => row.key === "maxHp")?.formula, "生命上限 32 = 基础 30 成长 +2");
 });
 
 test("resolveWorldAction starts a battle when a hero reaches a neutral army tile", () => {


### PR DESCRIPTION
## Summary
- add shared hero progression/attribute breakdown helpers for both H5 and Cocos
- add H5 debug-shell XP progress bar plus attribute source panel with formula tooltip
- add Cocos HUD XP bar, level-up notice, and skill-learning prompt/sound feedback

## Testing
- node --import tsx --test ./packages/shared/test/shared-core.test.ts
- node --import tsx --test ./apps/cocos-client/test/cocos-hero-progression.test.ts
- npm run typecheck:shared
- npm run typecheck:client:h5
- npm run typecheck:cocos
- npm run build:client:h5

Closes #29