### PR TITLE
Implement neutral army patrol/chase state machine (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@
 - Cocos 战斗面板现已补上技能摘要和目标状态提示，概要区、目标卡与动作按钮都会带出当前技能/状态信息，而不再只有基础攻击指令。
 - `phase1-map-objects.json` 现已支持配置 `buildings`，当前已接入 `recruitment_post` 招募所、`attribute_shrine` 属性神殿和 `resource_mine` 资源矿场；英雄停在建筑格上再次点击当前格即可访问或占领建筑。
 - 招募所会按库存和资源消耗补充部队，并在每日推进后自动重置；属性神殿会给当前英雄永久属性加成，并记录已访问英雄避免重复领取；资源矿场则会在占领后于“推进一天”时自动结算金币/木材/矿石产出。H5 / Cocos / 配置中心地图预览都已能显示这些建筑。
-- `neutralArmies` 现已支持可选 `behavior` 字段：可配置 `guard / patrol` 模式、巡逻路线和 `aggroRange`；中立怪会在每日推进时按路线巡逻、失位后回守，并在英雄靠近时主动追击，贴身时直接触发遭遇战。
+- `neutralArmies` 现已支持可选 `behavior` 字段：可配置 `guard / patrol` 模式、显式巡逻路线或 `patrolRadius` 自动巡逻圈，并可按 `detectionRadius / chaseDistance / speed` 精细调节巡逻、追击与返回节奏；中立怪会在每日推进时按路线巡逻、失位后回守，并在英雄靠近时主动追击，贴身时直接触发遭遇战。
 - 当前 MySQL 资源持久化已补上 `player_accounts`：房间保存时会同步刷新玩家全局 `gold / wood / ore` 仓库，新建房间会先回灌这份全局资源，因此同一 `playerId` 的基础资源已能跨房间继承。
 - 当前 MySQL 英雄长期档已补上 `player_hero_archives`：房间保存时会同步刷新英雄的长期成长、已学技能、装备槽位与带兵快照，新建房间会先回灌这些长期数据，因此同一 `playerId` 的英雄属性成长、build 和当前带兵已能跨房间继承；英雄的位置、剩余移动力和当前生命仍会按新局重置。
 - 当前玩家账号骨架也已接到 `player_accounts`：账号记录现已包含 `displayName / lastRoomId / lastSeenAt / globalResources`，并开放 `GET /api/player-accounts`、`GET /api/player-accounts/:playerId`、`PUT /api/player-accounts/:playerId` 供开发态查看与改名；房间 `connect` 时会自动建档或刷新最近活跃房间。

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -23,10 +23,10 @@ test("battle start auto-resolves defender opener before state is returned to the
         { x: 1, y: 1 },
         { x: 2, y: 1 },
         { x: 3, y: 1 },
-        { x: 3, y: 2 },
-        { x: 3, y: 3 },
-        { x: 3, y: 4 },
-        { x: 4, y: 4 }
+        { x: 4, y: 1 },
+        { x: 5, y: 1 },
+        { x: 5, y: 2 },
+        { x: 5, y: 3 }
       ],
       moveCost: 6
     }
@@ -43,7 +43,7 @@ test("battle start auto-resolves defender opener before state is returned to the
     result.battle?.units["hero-1-stack"]?.statusEffects?.map((status) => status.id).sort(),
     ["poisoned", "weakened"]
   );
-  assert.deepEqual(result.snapshot.state.ownHeroes[0]?.position, { x: 4, y: 4 });
+  assert.deepEqual(result.snapshot.state.ownHeroes[0]?.position, { x: 5, y: 3 });
 });
 
 test("player battle actions are followed by automated defender turns until control returns", () => {
@@ -326,8 +326,9 @@ test("room allows claiming a resource mine and grants daily income after advanci
       type: "neutral.moved",
       neutralArmyId: "neutral-1",
       from: { x: 5, y: 4 },
-      to: { x: 5, y: 3 },
-      reason: "patrol"
+      to: { x: 6, y: 5 },
+      reason: "chase",
+      targetHeroId: "hero-2"
     }
   ]);
   assert.equal(nextDayResult.snapshot.state.resources.wood, 2);
@@ -349,7 +350,11 @@ test("room can create a neutral-initiated battle when end day triggers an adjace
       mode: "guard",
       patrolPath: [],
       patrolIndex: 0,
-      aggroRange: 1
+      detectionRadius: 1,
+      chaseDistance: 3,
+      patrolRadius: 0,
+      speed: 1,
+      state: "return"
     }
   };
   const nextNeutralTile = state.map.tiles.find((tile) => tile.position.x === 2 && tile.position.y === 1);

--- a/configs/phase1-map-objects.json
+++ b/configs/phase1-map-objects.json
@@ -18,17 +18,10 @@
       ],
       "behavior": {
         "mode": "patrol",
-        "patrolPath": [
-          {
-            "x": 5,
-            "y": 4
-          },
-          {
-            "x": 5,
-            "y": 3
-          }
-        ],
-        "aggroRange": 2
+        "patrolRadius": 2,
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 2
       }
     }
   ],

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -158,12 +158,106 @@ function clonePosition(position: Vec2): Vec2 {
 
 function cloneNeutralBehaviorState(behavior: NeutralArmyBehaviorState | undefined): NeutralArmyBehaviorState {
   const patrolPath = behavior?.patrolPath?.map(clonePosition) ?? [];
+  const detectionRadius = Math.max(0, Math.floor(behavior?.detectionRadius ?? behavior?.patrolRadius ?? 0));
+  const chaseDistance = Math.max(
+    detectionRadius + 2,
+    Math.floor(behavior?.chaseDistance ?? detectionRadius + 2)
+  );
+  const patrolRadius = Math.max(0, Math.floor(behavior?.patrolRadius ?? 0));
+  const speed = Math.max(1, Math.floor(behavior?.speed ?? 1));
+  const nextState =
+    behavior?.state ?? (behavior?.mode === "patrol" && patrolPath.length > 0 ? "patrol" : "return");
   return {
     mode: behavior?.mode === "patrol" && patrolPath.length > 0 ? "patrol" : "guard",
     patrolPath,
     patrolIndex: patrolPath.length > 0 ? clamp(Math.floor(behavior?.patrolIndex ?? 0), 0, patrolPath.length - 1) : 0,
-    aggroRange: Math.max(0, Math.floor(behavior?.aggroRange ?? 0))
+    patrolRadius,
+    detectionRadius,
+    chaseDistance,
+    speed,
+    state: nextState,
+    targetHeroId: behavior?.targetHeroId
   };
+}
+
+function resetNeutralBehaviorState(behavior: NeutralArmyBehaviorState | undefined): NeutralArmyBehaviorState | undefined {
+  if (!behavior) {
+    return undefined;
+  }
+
+  const clone = cloneNeutralBehaviorState(behavior);
+  clone.state = clone.mode === "patrol" && clone.patrolPath.length > 0 ? "patrol" : "return";
+  clone.targetHeroId = undefined;
+  return clone;
+}
+
+function buildPatrolLoop(origin: Vec2, radius: number, mapWidth: number, mapHeight: number): Vec2[] {
+  if (radius <= 0) {
+    return [];
+  }
+
+  const minX = clamp(origin.x - radius, 0, mapWidth - 1);
+  const maxX = clamp(origin.x + radius, 0, mapWidth - 1);
+  const minY = clamp(origin.y - radius, 0, mapHeight - 1);
+  const maxY = clamp(origin.y + radius, 0, mapHeight - 1);
+  const seen = new Set<string>();
+  const path: Vec2[] = [];
+  const record = (point: Vec2): void => {
+    if (point.x < 0 || point.y < 0 || point.x >= mapWidth || point.y >= mapHeight) {
+      return;
+    }
+    if (samePosition(point, origin)) {
+      return;
+    }
+    const key = tileKey(point);
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    path.push(point);
+  };
+
+  for (let x = minX; x <= maxX; x += 1) {
+    record({ x, y: minY });
+  }
+  for (let y = minY + 1; y <= maxY; y += 1) {
+    record({ x: maxX, y });
+  }
+  if (maxY > minY) {
+    for (let x = maxX - 1; x >= minX; x -= 1) {
+      record({ x, y: maxY });
+    }
+  }
+  if (maxX > minX) {
+    for (let y = maxY - 1; y > minY; y -= 1) {
+      record({ x: minX, y });
+    }
+  }
+
+  return path;
+}
+
+function resolvePatrolPath(
+  mapWidth: number,
+  mapHeight: number,
+  origin: Vec2,
+  behavior: MapObjectsConfig["neutralArmies"][number]["behavior"] | undefined
+): Vec2[] {
+  if (!behavior) {
+    return [];
+  }
+
+  const explicitPath = behavior.patrolPath?.map(clonePosition) ?? [];
+  if (explicitPath.length > 0) {
+    return explicitPath;
+  }
+
+  const radius = Math.max(0, Math.floor(behavior.patrolRadius ?? 0));
+  if (radius <= 0) {
+    return [];
+  }
+
+  return buildPatrolLoop(origin, radius, mapWidth, mapHeight);
 }
 
 function normalizeNeutralArmyState(army: NeutralArmyState): NeutralArmyState {
@@ -185,15 +279,37 @@ function normalizeNeutralArmyCollection(
   );
 }
 
-function createNeutralArmyState(config: MapObjectsConfig["neutralArmies"][number]): NeutralArmyState {
+function createNeutralArmyState(
+  config: MapObjectsConfig["neutralArmies"][number],
+  mapWidth: number,
+  mapHeight: number
+): NeutralArmyState {
+  const behaviorConfig = config.behavior;
+  const patrolPath = resolvePatrolPath(mapWidth, mapHeight, config.position, behaviorConfig);
+  const detectionRadius = Math.max(
+    0,
+    Math.floor(behaviorConfig?.detectionRadius ?? behaviorConfig?.aggroRange ?? behaviorConfig?.patrolRadius ?? 0)
+  );
+  const chaseDistance = Math.max(
+    detectionRadius + 2,
+    Math.floor(behaviorConfig?.chaseDistance ?? detectionRadius + 2)
+  );
+  const patrolRadius = Math.max(0, Math.floor(behaviorConfig?.patrolRadius ?? 0));
+  const speed = Math.max(1, Math.floor(behaviorConfig?.speed ?? 1));
+  const mode = behaviorConfig?.mode === "patrol" && patrolPath.length > 0 ? "patrol" : "guard";
+  const initialState = mode === "patrol" && patrolPath.length > 0 ? "patrol" : "return";
   return normalizeNeutralArmyState({
     ...config,
     origin: clonePosition(config.position),
     behavior: {
-      mode: config.behavior?.mode === "patrol" && (config.behavior?.patrolPath?.length ?? 0) > 0 ? "patrol" : "guard",
-      patrolPath: config.behavior?.patrolPath?.map(clonePosition) ?? [],
+      mode,
+      patrolPath,
       patrolIndex: 0,
-      aggroRange: Math.max(0, Math.floor(config.behavior?.aggroRange ?? 0))
+      patrolRadius,
+      detectionRadius,
+      chaseDistance,
+      speed,
+      state: initialState
     }
   });
 }
@@ -594,25 +710,44 @@ function isBlockedForNeutral(
   return false;
 }
 
+function fallbackNeutralStep(
+  state: WorldState,
+  neutralArmyId: string,
+  from: Vec2,
+  destination: Vec2,
+  targetHeroId?: string
+): Vec2 | undefined {
+  const candidates = getNeighbors(state.map, from)
+    .filter((neighbor) => !isBlockedForNeutral(state, neutralArmyId, neighbor, destination, targetHeroId))
+    .sort((left, right) => {
+      const delta = distance(left, destination) - distance(right, destination);
+      return delta !== 0 ? delta : tileKey(left).localeCompare(tileKey(right));
+    });
+  return candidates[0];
+}
+
 function getNeutralMovementPath(
   state: WorldState,
   neutralArmyId: string,
   destination: Vec2,
-  targetHeroId?: string
+  targetHeroId?: string,
+  startPosition?: Vec2
 ): Vec2[] | undefined {
   const neutralArmy = state.neutralArmies[neutralArmyId];
   if (!neutralArmy) {
     return undefined;
   }
 
-  if (samePosition(neutralArmy.position, destination)) {
-    return [clonePosition(neutralArmy.position)];
+  const start = startPosition ?? neutralArmy.position;
+
+  if (samePosition(start, destination)) {
+    return [clonePosition(start)];
   }
 
-  const openSet: Vec2[] = [neutralArmy.position];
+  const openSet: Vec2[] = [start];
   const cameFrom = new Map<string, Vec2>();
-  const gScore = new Map<string, number>([[tileKey(neutralArmy.position), 0]]);
-  const fScore = new Map<string, number>([[tileKey(neutralArmy.position), distance(neutralArmy.position, destination)]]);
+  const gScore = new Map<string, number>([[tileKey(start), 0]]);
+  const fScore = new Map<string, number>([[tileKey(start), distance(start, destination)]]);
 
   while (openSet.length > 0) {
     openSet.sort(
@@ -744,64 +879,49 @@ function findHero(state: WorldState, heroId: string): HeroState | undefined {
 function findNeutralChaseTarget(
   state: WorldState,
   neutralArmy: NeutralArmyState,
-  lockedHeroIds: Set<string>
+  lockedHeroIds: Set<string>,
+  detectionRadius: number,
+  chaseDistance: number,
+  preferredHeroId?: string
 ): { heroId: string; path: Vec2[] } | null {
-  const aggroRange = neutralArmy.behavior?.aggroRange ?? 0;
-  if (aggroRange <= 0) {
-    return null;
-  }
-
-  const candidates = state.heroes
-    .filter((hero) => !lockedHeroIds.has(hero.id))
+  const heroPaths = state.heroes
     .map((hero) => ({
       heroId: hero.id,
       path: getNeutralMovementPath(state, neutralArmy.id, hero.position, hero.id)
     }))
     .filter((item): item is { heroId: string; path: Vec2[] } => Boolean(item.path && item.path.length > 0))
-    .filter((item) => item.path.length - 1 <= aggroRange)
+    .map((item) => ({
+      ...item,
+      distance: item.path.length - 1
+    }));
+
+  const preferred = heroPaths.find((item) => item.heroId === preferredHeroId);
+  if (preferred && preferred.distance <= chaseDistance) {
+    return { heroId: preferred.heroId, path: preferred.path };
+  }
+
+  if (detectionRadius <= 0) {
+    return null;
+  }
+
+  const candidates = heroPaths
+    .filter((item) => item.distance <= detectionRadius && !lockedHeroIds.has(item.heroId))
     .sort((left, right) => {
-      const pathDelta = left.path.length - right.path.length;
+      const pathDelta = left.distance - right.distance;
       return pathDelta !== 0 ? pathDelta : left.heroId.localeCompare(right.heroId);
     });
 
   return candidates[0] ?? null;
 }
 
-function nextPatrolTarget(
-  neutralArmy: NeutralArmyState
-): { target: Vec2; patrolIndex: number } | null {
-  const patrolPath = neutralArmy.behavior?.patrolPath ?? [];
-  if (patrolPath.length === 0) {
-    return null;
-  }
-
-  let patrolIndex = neutralArmy.behavior?.patrolIndex ?? 0;
-  for (let attempts = 0; attempts < patrolPath.length; attempts += 1) {
-    const target = patrolPath[patrolIndex]!;
-    if (!samePosition(neutralArmy.position, target)) {
-      return {
-        target,
-        patrolIndex
-      };
-    }
-    patrolIndex = (patrolIndex + 1) % patrolPath.length;
-  }
-
-  return null;
-}
-
 function moveNeutralArmy(
   neutralArmy: NeutralArmyState,
   nextPosition: Vec2,
   reason: NeutralMoveReason,
-  nextPatrolIndex?: number,
+  behaviorState: NeutralArmyBehaviorState,
   targetHeroId?: string
 ): { army: NeutralArmyState; event: WorldEvent } {
-  const behavior = cloneNeutralBehaviorState(neutralArmy.behavior);
-  if (typeof nextPatrolIndex === "number" && behavior.patrolPath.length > 0) {
-    behavior.patrolIndex = nextPatrolIndex;
-  }
-
+  const behavior = cloneNeutralBehaviorState(behaviorState);
   return {
     army: {
       ...neutralArmy,
@@ -820,17 +940,87 @@ function moveNeutralArmy(
   };
 }
 
+function advancePatrol(
+  state: WorldState,
+  neutralArmy: NeutralArmyState,
+  behavior: NeutralArmyBehaviorState,
+  speed: number
+): { position: Vec2; moved: boolean } {
+  let stepsRemaining = speed;
+  let currentPosition = neutralArmy.position;
+  let moved = false;
+  let patrolIndex = behavior.patrolIndex;
+
+  while (stepsRemaining > 0 && behavior.patrolPath.length > 0) {
+    const target = behavior.patrolPath[patrolIndex];
+    if (!target) {
+      break;
+    }
+    if (samePosition(currentPosition, target)) {
+      patrolIndex = (patrolIndex + 1) % behavior.patrolPath.length;
+      continue;
+    }
+
+    const path = getNeutralMovementPath(state, neutralArmy.id, target, undefined, currentPosition);
+    if (!path || path.length < 2) {
+      const fallback = fallbackNeutralStep(state, neutralArmy.id, currentPosition, target);
+      if (!fallback) {
+        break;
+      }
+      currentPosition = fallback;
+      stepsRemaining -= 1;
+      moved = true;
+      continue;
+    }
+
+    const steps = Math.min(stepsRemaining, path.length - 1);
+    currentPosition = path[steps];
+    stepsRemaining -= steps;
+    moved = moved || steps > 0;
+    if (samePosition(currentPosition, target)) {
+      patrolIndex = (patrolIndex + 1) % behavior.patrolPath.length;
+    } else {
+      break;
+    }
+  }
+
+  behavior.patrolIndex = behavior.patrolPath.length > 0 ? patrolIndex % behavior.patrolPath.length : 0;
+  return { position: currentPosition, moved };
+}
+
 function resolveNeutralArmyTurn(
   state: WorldState,
   neutralArmy: NeutralArmyState,
   lockedHeroIds: Set<string>
 ): { army?: NeutralArmyState; events: WorldEvent[]; lockedHeroId?: string } {
-  const behavior = neutralArmy.behavior;
-  const chaseTarget = findNeutralChaseTarget(state, neutralArmy, lockedHeroIds);
+  const behavior = cloneNeutralBehaviorState(neutralArmy.behavior);
+  const detectionRadius = behavior.detectionRadius;
+  const chaseDistance = Math.max(behavior.chaseDistance, detectionRadius + 2);
+  const speed = Math.max(1, behavior.speed);
+  const origin = neutralArmy.origin ?? neutralArmy.position;
+  let behaviorChanged = false;
+
+  const chaseTarget = findNeutralChaseTarget(
+    state,
+    neutralArmy,
+    lockedHeroIds,
+    detectionRadius,
+    chaseDistance,
+    behavior.targetHeroId
+  );
+
   if (chaseTarget) {
-    if (chaseTarget.path.length <= 2) {
+    behavior.state = "chase";
+    behavior.targetHeroId = chaseTarget.heroId;
+    behaviorChanged = true;
+    const stepsToHero = chaseTarget.path.length - 1;
+    if (stepsToHero <= speed) {
       const hero = findHero(state, chaseTarget.heroId);
       return {
+        army: {
+          ...neutralArmy,
+          behavior: cloneNeutralBehaviorState(behavior)
+        },
         events: [
           {
             type: "battle.started",
@@ -847,46 +1037,68 @@ function resolveNeutralArmyTurn(
       };
     }
 
-    const nextPosition = chaseTarget.path[1];
-    if (nextPosition) {
-      const movement = moveNeutralArmy(neutralArmy, nextPosition, "chase", undefined, chaseTarget.heroId);
-      return {
-        army: movement.army,
-        events: [movement.event]
-      };
-    }
+    const nextIndex = Math.min(speed, chaseTarget.path.length - 1);
+    const nextPosition = chaseTarget.path[nextIndex];
+    const movement = moveNeutralArmy(neutralArmy, nextPosition, "chase", behavior, chaseTarget.heroId);
+    return {
+      army: movement.army,
+      events: [movement.event]
+    };
   }
 
-  if (behavior?.mode === "patrol" && behavior.patrolPath.length > 0) {
-    const patrol = nextPatrolTarget(neutralArmy);
-    if (patrol) {
-      const path = getNeutralMovementPath(state, neutralArmy.id, patrol.target);
-      const nextPosition = path?.[1];
+  if (behavior.state === "chase") {
+    behavior.state = "return";
+    behavior.targetHeroId = undefined;
+    behaviorChanged = true;
+  }
+
+  if (behavior.state === "return") {
+    if (!samePosition(neutralArmy.position, origin)) {
+      const path = getNeutralMovementPath(state, neutralArmy.id, origin);
+      let nextPosition: Vec2 | undefined;
+      if (path && path.length > 1) {
+        const stepIndex = Math.min(speed, path.length - 1);
+        nextPosition = path[stepIndex];
+      } else {
+        nextPosition = fallbackNeutralStep(state, neutralArmy.id, neutralArmy.position, origin);
+      }
+
       if (nextPosition) {
-        const reachedTarget = samePosition(nextPosition, patrol.target);
-        const nextPatrolIndex = reachedTarget
-          ? (patrol.patrolIndex + 1) % behavior.patrolPath.length
-          : patrol.patrolIndex;
-        const movement = moveNeutralArmy(neutralArmy, nextPosition, "patrol", nextPatrolIndex);
+        if (samePosition(nextPosition, origin)) {
+          behavior.state = behavior.mode === "patrol" && behavior.patrolPath.length > 0 ? "patrol" : "return";
+          behaviorChanged = true;
+        }
+        const movement = moveNeutralArmy(neutralArmy, nextPosition, "return", behavior);
         return {
           army: movement.army,
           events: [movement.event]
         };
       }
+    } else if (behavior.mode === "patrol" && behavior.patrolPath.length > 0) {
+      behavior.state = "patrol";
+      behaviorChanged = true;
     }
   }
 
-  const origin = neutralArmy.origin ?? neutralArmy.position;
-  if (!samePosition(neutralArmy.position, origin)) {
-    const path = getNeutralMovementPath(state, neutralArmy.id, origin);
-    const nextPosition = path?.[1];
-    if (nextPosition) {
-      const movement = moveNeutralArmy(neutralArmy, nextPosition, "return");
+  if (behavior.state === "patrol" && behavior.patrolPath.length > 0) {
+    const patrolResult = advancePatrol(state, neutralArmy, behavior, speed);
+    if (patrolResult.moved && !samePosition(patrolResult.position, neutralArmy.position)) {
+      const movement = moveNeutralArmy(neutralArmy, patrolResult.position, "patrol", behavior);
       return {
         army: movement.army,
         events: [movement.event]
       };
     }
+  }
+
+  if (behaviorChanged) {
+    return {
+      army: {
+        ...neutralArmy,
+        behavior: cloneNeutralBehaviorState(behavior)
+      },
+      events: []
+    };
   }
 
   return {
@@ -995,15 +1207,19 @@ export function createWorldStateFromConfigs(
   const width = config.width;
   const height = config.height;
   const heroes: HeroState[] = normalizeHeroes(config.heroes);
+  const patrolWaypointKeys = mapObjects.neutralArmies.flatMap((army) =>
+    resolvePatrolPath(width, height, army.position, army.behavior).map((waypoint) => tileKey(waypoint))
+  );
   const forcedWalkableKeys = new Set<string>([
     ...heroes.map((hero) => tileKey(hero.position)),
     ...mapObjects.guaranteedResources.map((resource) => tileKey(resource.position)),
     ...mapObjects.neutralArmies.map((army) => tileKey(army.position)),
-    ...mapObjects.neutralArmies.flatMap((army) => (army.behavior?.patrolPath ?? []).map((waypoint) => tileKey(waypoint))),
+    ...patrolWaypointKeys,
     ...mapObjects.buildings.map((building) => tileKey(building.position))
   ]);
   const blockedRandomResourceKeys = new Set<string>([
     ...mapObjects.neutralArmies.map((army) => tileKey(army.position)),
+    ...patrolWaypointKeys,
     ...mapObjects.buildings.map((building) => tileKey(building.position))
   ]);
 
@@ -1030,7 +1246,7 @@ export function createWorldStateFromConfigs(
   }
 
   const neutralArmies: Record<string, NeutralArmyState> = Object.fromEntries(
-    mapObjects.neutralArmies.map((army) => [army.id, createNeutralArmyState(army)])
+    mapObjects.neutralArmies.map((army) => [army.id, createNeutralArmyState(army, width, height)])
   );
   const buildings: Record<string, MapBuildingState> = Object.fromEntries(
     mapObjects.buildings.map((building) => [building.id, createBuildingState(building)])
@@ -1735,6 +1951,15 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
       });
     }
     let neutralArmies = normalizeNeutralArmyCollection(state.neutralArmies);
+    neutralArmies = Object.fromEntries(
+      Object.entries(neutralArmies).map(([neutralArmyId, army]) => [
+        neutralArmyId,
+        {
+          ...army,
+          behavior: resetNeutralBehaviorState(army.behavior)
+        }
+      ])
+    );
     let workingState = buildNextWorldState(
       {
         ...state,

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -250,18 +250,28 @@ export interface NeutralArmyStack {
 
 export type NeutralBehaviorMode = "guard" | "patrol";
 export type NeutralMoveReason = "patrol" | "return" | "chase";
+export type NeutralAIState = "patrol" | "chase" | "return";
 
 export interface NeutralArmyBehaviorConfig {
   mode?: NeutralBehaviorMode;
   patrolPath?: Vec2[];
   aggroRange?: number;
+  patrolRadius?: number;
+  detectionRadius?: number;
+  chaseDistance?: number;
+  speed?: number;
 }
 
 export interface NeutralArmyBehaviorState {
   mode: NeutralBehaviorMode;
   patrolPath: Vec2[];
   patrolIndex: number;
-  aggroRange: number;
+  patrolRadius: number;
+  detectionRadius: number;
+  chaseDistance: number;
+  speed: number;
+  state: NeutralAIState;
+  targetHeroId?: string;
 }
 
 export interface NeutralArmyState {

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -360,6 +360,44 @@ export function validateMapObjectsConfig(
         throw new Error(`Neutral army ${army.id} aggroRange must be a non-negative integer`);
       }
 
+      if (
+        army.behavior.detectionRadius !== undefined &&
+        (!Number.isInteger(army.behavior.detectionRadius) || army.behavior.detectionRadius < 0)
+      ) {
+        throw new Error(`Neutral army ${army.id} detectionRadius must be a non-negative integer`);
+      }
+
+      if (
+        army.behavior.chaseDistance !== undefined &&
+        (!Number.isInteger(army.behavior.chaseDistance) || army.behavior.chaseDistance < 0)
+      ) {
+        throw new Error(`Neutral army ${army.id} chaseDistance must be a non-negative integer`);
+      }
+
+      const configuredDetection =
+        army.behavior.detectionRadius ?? army.behavior.aggroRange ?? undefined;
+      if (
+        army.behavior.chaseDistance !== undefined &&
+        configuredDetection !== undefined &&
+        army.behavior.chaseDistance < configuredDetection
+      ) {
+        throw new Error(`Neutral army ${army.id} chaseDistance must be >= detectionRadius`);
+      }
+
+      if (
+        army.behavior.patrolRadius !== undefined &&
+        (!Number.isInteger(army.behavior.patrolRadius) || army.behavior.patrolRadius < 0)
+      ) {
+        throw new Error(`Neutral army ${army.id} patrolRadius must be a non-negative integer`);
+      }
+
+      if (
+        army.behavior.speed !== undefined &&
+        (!Number.isInteger(army.behavior.speed) || army.behavior.speed <= 0)
+      ) {
+        throw new Error(`Neutral army ${army.id} speed must be a positive integer`);
+      }
+
       if (army.behavior.patrolPath !== undefined) {
         if (!Array.isArray(army.behavior.patrolPath)) {
           throw new Error(`Neutral army ${army.id} patrolPath must be an array`);
@@ -377,8 +415,14 @@ export function validateMapObjectsConfig(
         }
       }
 
-      if (army.behavior.mode === "patrol" && (army.behavior.patrolPath?.length ?? 0) === 0) {
-        throw new Error(`Neutral army ${army.id} patrol mode requires at least one patrol waypoint`);
+      if (
+        army.behavior.mode === "patrol" &&
+        (army.behavior.patrolPath?.length ?? 0) === 0 &&
+        (army.behavior.patrolRadius ?? 0) <= 0
+      ) {
+        throw new Error(
+          `Neutral army ${army.id} patrol mode requires patrolPath waypoints or a patrolRadius`
+        );
       }
     }
 

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1142,7 +1142,11 @@ test("resolveWorldAction advances patrolling neutral armies by one tile on end d
           mode: "patrol",
           patrolPath: [{ x: 2, y: 1 }, { x: 3, y: 1 }],
           patrolIndex: 0,
-          aggroRange: 0
+          detectionRadius: 0,
+          chaseDistance: 0,
+          patrolRadius: 0,
+          speed: 1,
+          state: "patrol"
         }
       }
     },
@@ -1201,7 +1205,11 @@ test("resolveWorldAction can start a neutral-initiated battle on end day", () =>
           mode: "guard",
           patrolPath: [],
           patrolIndex: 0,
-          aggroRange: 1
+          detectionRadius: 1,
+          chaseDistance: 3,
+          patrolRadius: 0,
+          speed: 1,
+          state: "return"
         }
       }
     },


### PR DESCRIPTION
## Summary\n- add patrol radius/detection/chase/speed knobs to neutral behavior config and docs\n- implement explicit patrol/chase/return AI with fallback pathing plus updated map objects\n- refresh shared/server tests to match new neutral movement flow and events\n\nFixes #25\n\n## Testing\n- npm run test:shared\n- node --import tsx --test ./apps/server/test/authoritative-room.test.ts