### PR TITLE
test: add building interaction coverage

### DIFF
--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -896,6 +896,319 @@ test("resolveWorldAction recruits units from a recruitment post and resets stock
   assert.equal(nextDayOutcome.state.map.tiles[3]?.building?.availableCount, 4);
 });
 
+test("building interactions reject missing resources, exhausted stock, wrong building types, and duplicate claims", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 1, y: 1 },
+    armyCount: 12
+  });
+  const state = createWorldState({
+    width: 3,
+    height: 2,
+    heroes: [hero],
+    buildings: {
+      "recruit-post-1": {
+        id: "recruit-post-1",
+        kind: "recruitment_post",
+        position: { x: 1, y: 1 },
+        label: "前线招募所",
+        unitTemplateId: "hero_guard_basic",
+        recruitCount: 4,
+        availableCount: 4,
+        cost: {
+          gold: 240,
+          wood: 0,
+          ore: 0
+        }
+      },
+      "shrine-1": {
+        id: "shrine-1",
+        kind: "attribute_shrine",
+        position: { x: 2, y: 1 },
+        label: "战旗圣坛",
+        bonus: {
+          attack: 1,
+          defense: 0,
+          power: 0,
+          knowledge: 0
+        },
+        visitedHeroIds: []
+      },
+      "mine-1": {
+        id: "mine-1",
+        kind: "resource_mine",
+        position: { x: 0, y: 1 },
+        label: "前线伐木场",
+        resourceKind: "wood",
+        income: 2
+      }
+    },
+    resources: {
+      "player-1": {
+        gold: 120,
+        wood: 0,
+        ore: 0
+      }
+    },
+    tiles: [
+      createTile(0, 0),
+      createTile(1, 0),
+      createTile(2, 0),
+      createTile(0, 1, {
+        building: {
+          id: "mine-1",
+          kind: "resource_mine",
+          position: { x: 0, y: 1 },
+          label: "前线伐木场",
+          resourceKind: "wood",
+          income: 2
+        }
+      }),
+      createTile(1, 1, {
+        occupant: { kind: "hero", refId: "hero-1" },
+        building: {
+          id: "recruit-post-1",
+          kind: "recruitment_post",
+          position: { x: 1, y: 1 },
+          label: "前线招募所",
+          unitTemplateId: "hero_guard_basic",
+          recruitCount: 4,
+          availableCount: 4,
+          cost: {
+            gold: 240,
+            wood: 0,
+            ore: 0
+          }
+        }
+      }),
+      createTile(2, 1, {
+        building: {
+          id: "shrine-1",
+          kind: "attribute_shrine",
+          position: { x: 2, y: 1 },
+          label: "战旗圣坛",
+          bonus: {
+            attack: 1,
+            defense: 0,
+            power: 0,
+            knowledge: 0
+          },
+          visitedHeroIds: []
+        }
+      })
+    ],
+    visibilityByPlayer: {
+      "player-1": ["visible", "visible", "visible", "visible", "visible", "visible"]
+    }
+  });
+
+  assert.deepEqual(validateWorldAction(state, {
+    type: "hero.recruit",
+    heroId: "hero-1",
+    buildingId: "recruit-post-1"
+  }), {
+    valid: false,
+    reason: "not_enough_resources"
+  });
+  assert.equal(
+    predictPlayerWorldAction(createPlayerWorldView(state, "player-1"), {
+      type: "hero.recruit",
+      heroId: "hero-1",
+      buildingId: "recruit-post-1"
+    }).reason,
+    "not_enough_resources"
+  );
+  assert.deepEqual(validateWorldAction(state, {
+    type: "hero.visit",
+    heroId: "hero-1",
+    buildingId: "recruit-post-1"
+  }), {
+    valid: false,
+    reason: "building_not_visitable"
+  });
+  assert.deepEqual(validateWorldAction(state, {
+    type: "hero.claimMine",
+    heroId: "hero-1",
+    buildingId: "recruit-post-1"
+  }), {
+    valid: false,
+    reason: "building_not_claimable"
+  });
+
+  const stockedState = createWorldState({
+    ...state,
+    resources: {
+      "player-1": {
+        gold: 300,
+        wood: 0,
+        ore: 0
+      }
+    }
+  });
+  const recruitedState = resolveWorldAction(stockedState, {
+    type: "hero.recruit",
+    heroId: "hero-1",
+    buildingId: "recruit-post-1"
+  }).state;
+
+  assert.deepEqual(validateWorldAction(recruitedState, {
+    type: "hero.recruit",
+    heroId: "hero-1",
+    buildingId: "recruit-post-1"
+  }), {
+    valid: false,
+    reason: "building_depleted"
+  });
+
+  const visitedState = resolveWorldAction(
+    createWorldState({
+      ...state,
+      heroes: [
+        {
+          ...hero,
+          position: { x: 2, y: 1 }
+        }
+      ],
+      tiles: [
+        createTile(0, 0),
+        createTile(1, 0),
+        createTile(2, 0),
+        createTile(0, 1, {
+          building: {
+            id: "mine-1",
+            kind: "resource_mine",
+            position: { x: 0, y: 1 },
+            label: "前线伐木场",
+            resourceKind: "wood",
+            income: 2
+          }
+        }),
+        createTile(1, 1, {
+          building: {
+            id: "recruit-post-1",
+            kind: "recruitment_post",
+            position: { x: 1, y: 1 },
+            label: "前线招募所",
+            unitTemplateId: "hero_guard_basic",
+            recruitCount: 4,
+            availableCount: 4,
+            cost: {
+              gold: 240,
+              wood: 0,
+              ore: 0
+            }
+          }
+        }),
+        createTile(2, 1, {
+          occupant: { kind: "hero", refId: "hero-1" },
+          building: {
+            id: "shrine-1",
+            kind: "attribute_shrine",
+            position: { x: 2, y: 1 },
+            label: "战旗圣坛",
+            bonus: {
+              attack: 1,
+              defense: 0,
+              power: 0,
+              knowledge: 0
+            },
+            visitedHeroIds: []
+          }
+        })
+      ]
+    }),
+    {
+      type: "hero.visit",
+      heroId: "hero-1",
+      buildingId: "shrine-1"
+    }
+  ).state;
+
+  assert.deepEqual(validateWorldAction(visitedState, {
+    type: "hero.visit",
+    heroId: "hero-1",
+    buildingId: "shrine-1"
+  }), {
+    valid: false,
+    reason: "building_already_visited"
+  });
+
+  const claimedState = resolveWorldAction(
+    createWorldState({
+      ...state,
+      heroes: [
+        {
+          ...hero,
+          position: { x: 0, y: 1 }
+        }
+      ],
+      tiles: [
+        createTile(0, 0),
+        createTile(1, 0),
+        createTile(2, 0),
+        createTile(0, 1, {
+          occupant: { kind: "hero", refId: "hero-1" },
+          building: {
+            id: "mine-1",
+            kind: "resource_mine",
+            position: { x: 0, y: 1 },
+            label: "前线伐木场",
+            resourceKind: "wood",
+            income: 2
+          }
+        }),
+        createTile(1, 1, {
+          building: {
+            id: "recruit-post-1",
+            kind: "recruitment_post",
+            position: { x: 1, y: 1 },
+            label: "前线招募所",
+            unitTemplateId: "hero_guard_basic",
+            recruitCount: 4,
+            availableCount: 4,
+            cost: {
+              gold: 240,
+              wood: 0,
+              ore: 0
+            }
+          }
+        }),
+        createTile(2, 1, {
+          building: {
+            id: "shrine-1",
+            kind: "attribute_shrine",
+            position: { x: 2, y: 1 },
+            label: "战旗圣坛",
+            bonus: {
+              attack: 1,
+              defense: 0,
+              power: 0,
+              knowledge: 0
+            },
+            visitedHeroIds: []
+          }
+        })
+      ]
+    }),
+    {
+      type: "hero.claimMine",
+      heroId: "hero-1",
+      buildingId: "mine-1"
+    }
+  ).state;
+
+  assert.deepEqual(validateWorldAction(claimedState, {
+    type: "hero.claimMine",
+    heroId: "hero-1",
+    buildingId: "mine-1"
+  }), {
+    valid: false,
+    reason: "building_already_owned"
+  });
+});
+
 test("resolveWorldAction visits an attribute shrine once, grants permanent stats, and does not reset on next day", () => {
   const hero = createHero({
     id: "hero-1",

--- a/tests/e2e/map-movement.spec.ts
+++ b/tests/e2e/map-movement.spec.ts
@@ -6,6 +6,10 @@ async function pressTile(page: Page, x: number, y: number): Promise<void> {
   });
 }
 
+async function hoverTile(page: Page, x: number, y: number): Promise<void> {
+  await page.locator(`[data-x="${x}"][data-y="${y}"]`).hover();
+}
+
 test("hero can move onto the wood pile and collect it", async ({ page }) => {
   const roomId = `e2e-room-${Date.now()}`;
   await page.goto(`/?roomId=${roomId}&playerId=player-1`);
@@ -21,4 +25,76 @@ test("hero can move onto the wood pile and collect it", async ({ page }) => {
 
   await pressTile(page, 0, 0);
   await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*5/);
+});
+
+test("hero can collect gold, recruit at the recruitment post, and spend resources correctly", async ({ page }) => {
+  const roomId = `e2e-recruit-${Date.now()}`;
+  await page.goto(`/?roomId=${roomId}&playerId=player-1`);
+
+  await expect(page.getByTestId("hero-army")).toHaveText(/x 12/, { timeout: 10_000 });
+  await expect(page.getByTestId("stat-gold")).toHaveText(/Gold\s*0/);
+
+  await pressTile(page, 0, 1);
+  await expect(page.getByTestId("hero-move")).toHaveText(/Move 5\/6/);
+
+  await pressTile(page, 0, 1);
+  await expect(page.getByTestId("stat-gold")).toHaveText(/Gold\s*500/);
+  await expect(page.getByTestId("event-log")).toContainText("Collected gold +500");
+
+  await pressTile(page, 1, 3);
+  await expect(page.getByTestId("hero-move")).toHaveText(/Move 2\/6/);
+
+  await hoverTile(page, 1, 3);
+  await expect(page.locator(".object-card-value")).toContainText("招募 4/4");
+
+  await pressTile(page, 1, 3);
+  await expect(page.getByTestId("hero-army")).toHaveText(/x 16/);
+  await expect(page.getByTestId("stat-gold")).toHaveText(/Gold\s*260/);
+  await expect(page.getByTestId("event-log")).toContainText("Recruited hero_guard_basic x4");
+
+  await hoverTile(page, 1, 3);
+  await expect(page.locator(".object-card-value")).toContainText("招募 0/4");
+});
+
+test("hero can visit the shrine and gain a permanent attribute bonus", async ({ page }) => {
+  const roomId = `e2e-shrine-${Date.now()}`;
+  await page.goto(`/?roomId=${roomId}&playerId=player-1`);
+
+  await expect(page.getByTestId("hero-stats")).toHaveText("ATK 2 · DEF 2 · POW 1 · KNW 1", { timeout: 10_000 });
+
+  await pressTile(page, 3, 2);
+  await expect(page.getByTestId("hero-move")).toHaveText(/Move 3\/6/);
+
+  await pressTile(page, 3, 2);
+  await expect(page.getByTestId("hero-stats")).toHaveText("ATK 3 · DEF 2 · POW 1 · KNW 1");
+  await expect(page.getByTestId("event-log")).toContainText("Visited shrine-attack-1: 攻击 +1");
+
+  await hoverTile(page, 3, 2);
+  await expect(page.locator(".object-card-copy")).toContainText("已留下访问记录");
+});
+
+test("hero can claim a mine and receive income on successive days", async ({ page }) => {
+  const roomId = `e2e-mine-${Date.now()}`;
+  await page.goto(`/?roomId=${roomId}&playerId=player-1`);
+
+  await expect(page.getByTestId("stat-day")).toHaveText(/1/, { timeout: 10_000 });
+  await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*0/);
+
+  await pressTile(page, 3, 1);
+  await expect(page.getByTestId("hero-move")).toHaveText(/Move 4\/6/);
+
+  await pressTile(page, 3, 1);
+  await expect(page.getByTestId("event-log")).toContainText("Claimed mine: Wood +2/day");
+
+  await hoverTile(page, 3, 1);
+  await expect(page.locator(".object-card-copy")).toContainText("当前归属 player-1");
+
+  await page.locator("[data-end-day]").click();
+  await expect(page.getByTestId("stat-day")).toHaveText(/2/);
+  await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*2/);
+  await expect(page.getByTestId("event-log")).toContainText("Mine produced Wood +2");
+
+  await page.locator("[data-end-day]").click();
+  await expect(page.getByTestId("stat-day")).toHaveText(/3/);
+  await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*4/);
 });

--- a/tests/e2e/multiplayer-sync.spec.ts
+++ b/tests/e2e/multiplayer-sync.spec.ts
@@ -6,6 +6,10 @@ async function pressTile(page: Page, x: number, y: number): Promise<void> {
   });
 }
 
+async function hoverTile(page: Page, x: number, y: number): Promise<void> {
+  await page.locator(`[data-x="${x}"][data-y="${y}"]`).hover();
+}
+
 test("second player receives room push updates without leaking another player's move details", async ({ browser }) => {
   const roomId = `e2e-multi-${Date.now()}`;
   const playerOneContext = await browser.newContext();
@@ -31,6 +35,40 @@ test("second player receives room push updates without leaking another player's 
   await expect(playerTwoPage.getByTestId("event-log")).not.toContainText("Path:");
   await expect(playerTwoPage.getByTestId("timeline-panel")).not.toContainText("英雄完成移动");
   await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/);
+
+  await playerOneContext.close();
+  await playerTwoContext.close();
+});
+
+test("building ownership changes are pushed to other clients with the same visible state", async ({ browser }) => {
+  const roomId = `e2e-building-sync-${Date.now()}`;
+  const playerOneContext = await browser.newContext();
+  const playerTwoContext = await browser.newContext();
+  const playerOnePage = await playerOneContext.newPage();
+  const playerTwoPage = await playerTwoContext.newPage();
+
+  await Promise.all([
+    playerOnePage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-1`),
+    playerTwoPage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-2`)
+  ]);
+
+  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
+  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
+
+  await pressTile(playerTwoPage, 3, 3);
+  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
+
+  await hoverTile(playerTwoPage, 3, 1);
+  await expect(playerTwoPage.locator(".object-card-copy")).toContainText("当前无人占领");
+
+  await pressTile(playerOnePage, 3, 1);
+  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 4\/6/);
+  await pressTile(playerOnePage, 3, 1);
+
+  await expect(playerTwoPage.getByTestId("event-log")).toContainText("收到房间同步推送", { timeout: 10_000 });
+
+  await hoverTile(playerTwoPage, 3, 1);
+  await expect(playerTwoPage.locator(".object-card-copy")).toContainText("当前归属 player-1");
 
   await playerOneContext.close();
   await playerTwoContext.close();


### PR DESCRIPTION
## Summary
- add shared coverage for building interaction rejection paths and cooldown/depletion style edge cases
- add local Playwright coverage for recruitment, shrine, and mine interaction flows
- add multiplayer Playwright coverage for mine ownership sync between clients

## Testing
- npm run test:shared
- npx playwright test tests/e2e/map-movement.spec.ts *(blocked: missing system library libatk-bridge-2.0.so.0 in the environment)*
- npx playwright test --config=playwright.multiplayer.config.ts tests/e2e/multiplayer-sync.spec.ts *(blocked: missing system library libatk-bridge-2.0.so.0 in the environment)*

Closes #22