### PR TITLE
feat: enhance config center workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@
   - 当前支持编辑 `phase1-world.json / phase1-map-objects.json / units.json / battle-skills.json`
   - 未配置 MySQL 时走文件系统存储；配置 `VEIL_MYSQL_*` 后切换到 MySQL 主存储
   - 保存后会同时导出到 `configs/*.json`，并同步刷新服务端运行时配置，新建房间和战斗逻辑会直接读取新值
+  - 当前已补上版本快照、快照差异对比、历史回滚，以及 Easy / Normal / Hard 三档内置预设和自定义预设保存
+  - 实时校验现已带出对应配置 schema 摘要、必填根字段和逐项修复建议；非法值会阻止保存
+  - 导出除 JSON 注释版外，还支持带 `Meta / Schema / Fields` 工作表的 Excel，以及更轻量的字段清单 CSV
   - 当前编辑 `phase1-world.json` 时，右侧会即时生成一份地图样本预览；可切换预览 seed，对照查看地形、随机资源、保底资源、英雄与中立怪分布
   - 当前编辑 `battle-skills.json` 时，右侧会显示技能编辑器，可直接调整冷却、伤害倍率、目标类型、附加状态和状态持续参数，并同步回写 JSON 草稿
 - H5 战斗面板现已补上“战术情报”区，会并排展示当前行动单位和已锁定目标的技能、状态、冷却与效果说明，便于直接核对配置是否符合预期。

--- a/apps/client/src/config-center.css
+++ b/apps/client/src/config-center.css
@@ -519,6 +519,16 @@ body {
   background: rgba(178, 69, 47, 0.12);
 }
 
+.schema-card {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 14px;
+  border: 1px solid rgba(138, 90, 43, 0.12);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.84);
+}
+
 .validation-list,
 .snapshot-list,
 .diff-list,
@@ -551,6 +561,8 @@ body {
 .validation-item span,
 .validation-item small,
 .snapshot-main span,
+.schema-card span,
+.schema-card small,
 .preset-card span,
 .preset-card small,
 .diff-item span,

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -66,6 +66,15 @@ interface ValidationReport {
   valid: boolean;
   summary: string;
   issues: ValidationIssue[];
+  schema: ConfigSchemaSummary;
+}
+
+interface ConfigSchemaSummary {
+  id: string;
+  title: string;
+  version: string;
+  description: string;
+  required: string[];
 }
 
 interface ConfigSnapshotSummary {
@@ -235,6 +244,14 @@ const state: AppState = {
   historyLoading: false,
   presets: [],
   presetsLoading: false
+};
+
+const EMPTY_SCHEMA_SUMMARY: ConfigSchemaSummary = {
+  id: "project-veil.config-center.unknown",
+  title: "Unknown Schema",
+  version: "0",
+  description: "Schema 信息暂不可用。",
+  required: []
 };
 
 let previewRequestVersion = 0;
@@ -596,7 +613,8 @@ async function loadValidation(delayMs = 0): Promise<void> {
             message: error instanceof Error ? error.message : "校验失败",
             suggestion: "检查 JSON 语法和字段格式后重试。"
           }
-        ]
+        ],
+        schema: state.validation?.schema ?? EMPTY_SCHEMA_SUMMARY
       };
     } finally {
       if (requestVersion === validationRequestVersion) {
@@ -904,7 +922,7 @@ async function saveCurrentAsPreset(): Promise<void> {
   }
 }
 
-async function exportCurrentDocument(format: "xlsx" | "jsonc"): Promise<void> {
+async function exportCurrentDocument(format: "xlsx" | "jsonc" | "csv"): Promise<void> {
   if (!state.current) {
     return;
   }
@@ -918,7 +936,8 @@ async function exportCurrentDocument(format: "xlsx" | "jsonc"): Promise<void> {
     anchor.click();
     URL.revokeObjectURL(href);
     state.statusTone = "success";
-    state.statusMessage = format === "xlsx" ? "已导出 Excel" : "已导出 JSON 注释版";
+    state.statusMessage =
+      format === "xlsx" ? "已导出 Excel 工作簿" : format === "csv" ? "已导出字段清单 CSV" : "已导出 JSON 注释版";
     render();
   } catch (error) {
     state.statusTone = "error";
@@ -1323,6 +1342,12 @@ function renderValidationSection(): string {
             <strong>${validation.valid ? "校验通过" : "发现问题"}</strong>
             <span>${escapeHtml(validation.summary)}</span>
           </div>
+          <div class="schema-card">
+            <strong>${escapeHtml(validation.schema.title)}</strong>
+            <span>${escapeHtml(validation.schema.description)}</span>
+            <small>${escapeHtml(validation.schema.id)} · v${escapeHtml(validation.schema.version)}</small>
+            <small>必填根字段: ${escapeHtml(validation.schema.required.join(", ") || "无")}</small>
+          </div>
           ${
             validation.issues.length > 0
               ? `
@@ -1366,7 +1391,7 @@ function renderPresetSection(): string {
         <h4>配置预设</h4>
         <span class="config-meta">${state.presets.length} 个可用预设</span>
       </div>
-      <p class="config-hint">内置 Easy / Normal / Hard 会直接保存并刷新服务端运行时配置；自定义预设会保存当前草稿。</p>
+      <p class="config-hint">内置 Easy / Normal / Hard 会直接保存并刷新服务端运行时配置；自定义预设会保存当前草稿，方便保留专题调参版本。</p>
       <div class="preset-grid">
         ${state.presetsLoading
           ? `<div class="world-preview-empty">正在加载预设...</div>`
@@ -1429,6 +1454,7 @@ function renderSnapshotSection(): string {
       ${
         state.selectedSnapshotId && state.snapshotDiff
           ? `
+            <div class="config-hint">当前展示 ${Math.min(state.snapshotDiff.entries.length, 12)} / ${state.snapshotDiff.entries.length} 条差异。</div>
             <div class="diff-list">
               ${
                 state.snapshotDiff.entries.length === 0
@@ -1463,10 +1489,12 @@ function renderExportSection(): string {
     <section class="history-section">
       <div class="config-preview-subhead">
         <h4>导入导出</h4>
-        <span class="config-meta">Excel / JSON 注释版</span>
+        <span class="config-meta">Excel / CSV / JSON 注释版</span>
       </div>
+      <p class="config-hint">Excel 会附带 Meta / Schema / Fields 三张工作表；CSV 提供轻量字段清单，适合快速审阅或粘到外部工具。</p>
       <div class="history-actions">
         <button class="config-button is-secondary config-button-compact" data-action="export-xlsx">导出 Excel</button>
+        <button class="config-button is-secondary config-button-compact" data-action="export-csv">导出字段 CSV</button>
         <button class="config-button is-secondary config-button-compact" data-action="export-jsonc">导出 JSON 注释版</button>
         <label class="import-button">
           <input type="file" accept=".xlsx" data-role="import-workbook" />
@@ -1838,6 +1866,10 @@ function bindEvents(): void {
 
   document.querySelector<HTMLButtonElement>("[data-action='export-xlsx']")?.addEventListener("click", () => {
     void exportCurrentDocument("xlsx");
+  });
+
+  document.querySelector<HTMLButtonElement>("[data-action='export-csv']")?.addEventListener("click", () => {
+    void exportCurrentDocument("csv");
   });
 
   document.querySelector<HTMLButtonElement>("[data-action='export-jsonc']")?.addEventListener("click", () => {

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -82,6 +82,15 @@ export interface ValidationReport {
   valid: boolean;
   summary: string;
   issues: ValidationIssue[];
+  schema: ConfigSchemaSummary;
+}
+
+export interface ConfigSchemaSummary {
+  id: string;
+  title: string;
+  version: string;
+  description: string;
+  required: string[];
 }
 
 export interface ConfigSnapshotSummary {
@@ -196,7 +205,7 @@ export interface ConfigCenterStore {
   listPresets(id: ConfigDocumentId): Promise<ConfigPresetSummary[]>;
   savePreset(id: ConfigDocumentId, name: string, content: string): Promise<ConfigPresetSummary>;
   applyPreset(id: ConfigDocumentId, presetId: string): Promise<ConfigDocument>;
-  exportDocument(id: ConfigDocumentId, format: "xlsx" | "jsonc"): Promise<{
+  exportDocument(id: ConfigDocumentId, format: "xlsx" | "jsonc" | "csv"): Promise<{
     fileName: string;
     contentType: string;
     body: Buffer;
@@ -260,10 +269,275 @@ interface FlattenedConfigEntry {
   type: string;
   displayValue: string;
   jsonValue: string;
+  description?: string;
+}
+
+interface JsonSchemaNode {
+  type?: "object" | "array" | "string" | "number" | "integer" | "boolean";
+  title?: string;
+  description?: string;
+  properties?: Record<string, JsonSchemaNode>;
+  required?: string[];
+  items?: JsonSchemaNode;
+  enum?: string[];
+  minimum?: number;
+  minItems?: number;
 }
 
 const CONFIG_CENTER_LIBRARY_FILE = ".config-center-library.json";
 const BUILTIN_PRESET_IDS = ["easy", "normal", "hard"] as const;
+const CONFIG_SCHEMA_VERSION = "2026-03-26";
+
+const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
+  world: {
+    type: "object",
+    title: "World Config",
+    description: "世界生成配置，包含地图尺寸、英雄出生点和随机资源概率。",
+    required: ["width", "height", "heroes", "resourceSpawn"],
+    properties: {
+      width: { type: "integer", minimum: 1, description: "地图宽度，单位为格子。" },
+      height: { type: "integer", minimum: 1, description: "地图高度，单位为格子。" },
+      heroes: {
+        type: "array",
+        minItems: 1,
+        description: "初始英雄列表。",
+        items: {
+          type: "object",
+          required: ["id", "playerId", "name", "position", "vision", "move", "stats", "progression", "armyTemplateId", "armyCount"],
+          properties: {
+            id: { type: "string", description: "英雄唯一 id。" },
+            playerId: { type: "string", description: "所属玩家 id。" },
+            name: { type: "string", description: "英雄显示名。" },
+            position: {
+              type: "object",
+              required: ["x", "y"],
+              properties: {
+                x: { type: "integer", minimum: 0, description: "英雄初始 X 坐标。" },
+                y: { type: "integer", minimum: 0, description: "英雄初始 Y 坐标。" }
+              }
+            },
+            vision: { type: "integer", minimum: 0, description: "初始视野范围。" },
+            move: {
+              type: "object",
+              required: ["total", "remaining"],
+              properties: {
+                total: { type: "integer", minimum: 1, description: "每日总移动力。" },
+                remaining: { type: "integer", minimum: 0, description: "当前剩余移动力。" }
+              }
+            },
+            stats: {
+              type: "object",
+              required: ["attack", "defense", "power", "knowledge", "hp", "maxHp"],
+              properties: {
+                attack: { type: "integer", minimum: 0, description: "攻击属性。" },
+                defense: { type: "integer", minimum: 0, description: "防御属性。" },
+                power: { type: "integer", minimum: 0, description: "力量属性。" },
+                knowledge: { type: "integer", minimum: 0, description: "知识属性。" },
+                hp: { type: "integer", minimum: 1, description: "当前生命值。" },
+                maxHp: { type: "integer", minimum: 1, description: "最大生命值。" }
+              }
+            },
+            progression: {
+              type: "object",
+              required: ["level", "experience", "battlesWon", "neutralBattlesWon", "pvpBattlesWon"],
+              properties: {
+                level: { type: "integer", minimum: 1, description: "英雄等级。" },
+                experience: { type: "integer", minimum: 0, description: "累计经验值。" },
+                battlesWon: { type: "integer", minimum: 0, description: "总胜场。" },
+                neutralBattlesWon: { type: "integer", minimum: 0, description: "PVE 胜场。" },
+                pvpBattlesWon: { type: "integer", minimum: 0, description: "PVP 胜场。" }
+              }
+            },
+            armyTemplateId: { type: "string", description: "初始携带兵种模板 id。" },
+            armyCount: { type: "integer", minimum: 1, description: "初始部队数量。" }
+          }
+        }
+      },
+      resourceSpawn: {
+        type: "object",
+        description: "随机资源生成概率。",
+        required: ["goldChance", "woodChance", "oreChance"],
+        properties: {
+          goldChance: { type: "number", minimum: 0, description: "金币资源点生成概率。" },
+          woodChance: { type: "number", minimum: 0, description: "木材资源点生成概率。" },
+          oreChance: { type: "number", minimum: 0, description: "矿石资源点生成概率。" }
+        }
+      }
+    }
+  },
+  mapObjects: {
+    type: "object",
+    title: "Map Objects Config",
+    description: "地图物件配置，包含中立怪、保底资源和建筑。",
+    required: ["neutralArmies", "guaranteedResources", "buildings"],
+    properties: {
+      neutralArmies: {
+        type: "array",
+        description: "中立军队布置。",
+        items: {
+          type: "object",
+          required: ["id", "position", "stacks"],
+          properties: {
+            id: { type: "string", description: "中立军队 id。" },
+            position: {
+              type: "object",
+              required: ["x", "y"],
+              properties: {
+                x: { type: "integer", minimum: 0, description: "X 坐标。" },
+                y: { type: "integer", minimum: 0, description: "Y 坐标。" }
+              }
+            },
+            stacks: {
+              type: "array",
+              minItems: 1,
+              description: "守军兵堆。",
+              items: {
+                type: "object",
+                required: ["templateId", "count"],
+                properties: {
+                  templateId: { type: "string", description: "兵种模板 id。" },
+                  count: { type: "integer", minimum: 1, description: "该兵堆数量。" }
+                }
+              }
+            }
+          }
+        }
+      },
+      guaranteedResources: {
+        type: "array",
+        description: "保底资源点。",
+        items: {
+          type: "object",
+          required: ["position", "resource"],
+          properties: {
+            position: {
+              type: "object",
+              required: ["x", "y"],
+              properties: {
+                x: { type: "integer", minimum: 0, description: "X 坐标。" },
+                y: { type: "integer", minimum: 0, description: "Y 坐标。" }
+              }
+            },
+            resource: {
+              type: "object",
+              required: ["kind", "amount"],
+              properties: {
+                kind: { type: "string", enum: ["gold", "wood", "ore"], description: "资源类型。" },
+                amount: { type: "integer", minimum: 1, description: "资源数量。" }
+              }
+            }
+          }
+        }
+      },
+      buildings: {
+        type: "array",
+        description: "地图建筑配置。",
+        items: {
+          type: "object",
+          required: ["id", "kind", "position", "label"],
+          properties: {
+            id: { type: "string", description: "建筑 id。" },
+            kind: { type: "string", description: "建筑种类。" },
+            label: { type: "string", description: "建筑显示名。" },
+            position: {
+              type: "object",
+              required: ["x", "y"],
+              properties: {
+                x: { type: "integer", minimum: 0, description: "X 坐标。" },
+                y: { type: "integer", minimum: 0, description: "Y 坐标。" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  units: {
+    type: "object",
+    title: "Units Config",
+    description: "兵种模板配置，用于世界生成、招募和战斗数值。",
+    required: ["templates"],
+    properties: {
+      templates: {
+        type: "array",
+        minItems: 1,
+        description: "兵种模板列表。",
+        items: {
+          type: "object",
+          required: ["id", "stackName", "faction", "rarity", "initiative", "attack", "defense", "minDamage", "maxDamage", "maxHp"],
+          properties: {
+            id: { type: "string", description: "兵种模板 id。" },
+            stackName: { type: "string", description: "堆叠显示名。" },
+            faction: { type: "string", description: "阵营。" },
+            rarity: { type: "string", description: "品质。" },
+            initiative: { type: "integer", minimum: 1, description: "先攻值。" },
+            attack: { type: "integer", minimum: 1, description: "攻击值。" },
+            defense: { type: "integer", minimum: 1, description: "防御值。" },
+            minDamage: { type: "integer", minimum: 1, description: "最小伤害。" },
+            maxDamage: { type: "integer", minimum: 1, description: "最大伤害。" },
+            maxHp: { type: "integer", minimum: 1, description: "最大生命值。" },
+            battleSkills: {
+              type: "array",
+              description: "技能 id 列表。",
+              items: { type: "string", description: "技能 id。" }
+            }
+          }
+        }
+      }
+    }
+  },
+  battleSkills: {
+    type: "object",
+    title: "Battle Skills Config",
+    description: "战斗技能和持续状态配置。",
+    required: ["skills", "statuses"],
+    properties: {
+      skills: {
+        type: "array",
+        description: "技能列表。",
+        items: {
+          type: "object",
+          required: ["id", "name", "description", "kind", "target", "cooldown"],
+          properties: {
+            id: { type: "string", description: "技能 id。" },
+            name: { type: "string", description: "技能名称。" },
+            description: { type: "string", description: "技能描述。" },
+            kind: { type: "string", enum: ["active", "passive"], description: "技能种类。" },
+            target: { type: "string", enum: ["enemy", "self"], description: "技能目标。" },
+            cooldown: { type: "integer", minimum: 0, description: "冷却回合。" },
+            effects: {
+              type: "object",
+              description: "技能效果集合。",
+              properties: {
+                damageMultiplier: { type: "number", minimum: 0, description: "伤害倍率。" },
+                allowRetaliation: { type: "boolean", description: "是否允许反击。" },
+                grantedStatusId: { type: "string", description: "施加给自身的状态 id。" },
+                onHitStatusId: { type: "string", description: "命中附加的状态 id。" }
+              }
+            }
+          }
+        }
+      },
+      statuses: {
+        type: "array",
+        description: "状态列表。",
+        items: {
+          type: "object",
+          required: ["id", "name", "description", "duration", "attackModifier", "defenseModifier", "damagePerTurn"],
+          properties: {
+            id: { type: "string", description: "状态 id。" },
+            name: { type: "string", description: "状态名称。" },
+            description: { type: "string", description: "状态描述。" },
+            duration: { type: "integer", minimum: 1, description: "持续回合。" },
+            attackModifier: { type: "integer", description: "攻击修正。" },
+            defenseModifier: { type: "integer", description: "防御修正。" },
+            damagePerTurn: { type: "integer", minimum: 0, description: "每回合伤害。" }
+          }
+        }
+      }
+    }
+  }
+};
 
 function createEmptyLibraryState(): ConfigCenterLibraryState {
   return {
@@ -441,30 +715,290 @@ function buildConfigDiffEntries(previousContent: string, nextContent: string): C
     });
 }
 
+function typeLabelForSchema(node: JsonSchemaNode): string {
+  if (node.enum) {
+    return `enum(${node.enum.join(", ")})`;
+  }
+
+  return node.type ?? "unknown";
+}
+
+function describeSchemaRequirement(node: JsonSchemaNode): string {
+  const parts = [typeLabelForSchema(node)];
+  if (node.minimum != null) {
+    parts.push(`>= ${node.minimum}`);
+  }
+  if (node.minItems != null) {
+    parts.push(`items >= ${node.minItems}`);
+  }
+  return parts.join(" · ");
+}
+
+function buildSchemaSummary(id: ConfigDocumentId): ConfigSchemaSummary {
+  const schema = CONFIG_DOCUMENT_SCHEMAS[id];
+  return {
+    id: `project-veil.config-center.${id}`,
+    title: schema.title ?? id,
+    version: CONFIG_SCHEMA_VERSION,
+    description: schema.description ?? `${id} config schema`,
+    required: schema.required ?? []
+  };
+}
+
+function schemaNodeForPath(schema: JsonSchemaNode, path: string): JsonSchemaNode | undefined {
+  if (!path) {
+    return schema;
+  }
+
+  let current: JsonSchemaNode | undefined = schema;
+  for (const segment of parseJsonPath(path)) {
+    if (!current) {
+      return undefined;
+    }
+
+    if (typeof segment === "number") {
+      current = current.items;
+      continue;
+    }
+
+    current = current.properties?.[segment];
+  }
+
+  return current;
+}
+
+function describeSchemaPath(schema: JsonSchemaNode, path: string): string {
+  const node = schemaNodeForPath(schema, path);
+  if (!node) {
+    return "";
+  }
+
+  const parts = [node.description ?? ""];
+  const requirement = describeSchemaRequirement(node);
+  if (requirement && requirement !== "unknown") {
+    parts.push(requirement);
+  }
+
+  return parts.filter(Boolean).join(" | ");
+}
+
+function flattenConfigValueWithSchema(value: unknown, schema: JsonSchemaNode, path = ""): FlattenedConfigEntry[] {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return [
+        {
+          path,
+          type: "array",
+          displayValue: "[]",
+          jsonValue: "[]",
+          description: describeSchemaPath(schema, path)
+        }
+      ];
+    }
+
+    return value.flatMap((item, index) => flattenConfigValueWithSchema(item, schema, `${path}[${index}]`));
+  }
+
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value);
+    if (entries.length === 0) {
+      return [
+        {
+          path,
+          type: "object",
+          displayValue: "{}",
+          jsonValue: "{}",
+          description: describeSchemaPath(schema, path)
+        }
+      ];
+    }
+
+    return entries.flatMap(([key, nested]) => flattenConfigValueWithSchema(nested, schema, path ? `${path}.${key}` : key));
+  }
+
+  return [
+    {
+      path,
+      type: value === null ? "null" : typeof value,
+      displayValue: value == null ? "null" : typeof value === "string" ? value : JSON.stringify(value),
+      jsonValue: JSON.stringify(value),
+      description: describeSchemaPath(schema, path)
+    }
+  ];
+}
+
+function validateSchemaNode(value: unknown, schema: JsonSchemaNode, path: string, issues: ValidationIssue[]): void {
+  const location = path || "$";
+  const actualType = Array.isArray(value) ? "array" : value === null ? "null" : typeof value;
+
+  if (schema.type === "object") {
+    if (value == null || typeof value !== "object" || Array.isArray(value)) {
+      pushIssue(issues, {
+        path: location,
+        message: `字段需要 object，当前为 ${actualType}。`,
+        suggestion: `按 ${describeSchemaRequirement(schema)} 修正该字段结构。`
+      });
+      return;
+    }
+
+    const record = value as Record<string, unknown>;
+    for (const requiredKey of schema.required ?? []) {
+      if (!(requiredKey in record)) {
+        const childPath = path ? `${path}.${requiredKey}` : requiredKey;
+        const childSchema = schema.properties?.[requiredKey];
+        pushIssue(issues, {
+          path: childPath,
+          message: `缺少必填字段 ${requiredKey}。`,
+          suggestion: childSchema?.description ?? "补齐该字段后再保存。"
+        });
+      }
+    }
+
+    for (const [key, childValue] of Object.entries(record)) {
+      const childSchema = schema.properties?.[key];
+      if (!childSchema) {
+        continue;
+      }
+      validateSchemaNode(childValue, childSchema, path ? `${path}.${key}` : key, issues);
+    }
+    return;
+  }
+
+  if (schema.type === "array") {
+    if (!Array.isArray(value)) {
+      pushIssue(issues, {
+        path: location,
+        message: `字段需要 array，当前为 ${actualType}。`,
+        suggestion: `按 ${describeSchemaRequirement(schema)} 修正该字段结构。`
+      });
+      return;
+    }
+
+    if (schema.minItems != null && value.length < schema.minItems) {
+      pushIssue(issues, {
+        path: location,
+        message: `数组至少需要 ${schema.minItems} 项，当前只有 ${value.length} 项。`,
+        suggestion: "补齐数组项后再保存。"
+      });
+    }
+
+    value.forEach((item, index) => {
+      if (schema.items) {
+        validateSchemaNode(item, schema.items, `${path}[${index}]`, issues);
+      }
+    });
+    return;
+  }
+
+  if (schema.type === "integer") {
+    if (typeof value !== "number" || !Number.isInteger(value)) {
+      pushIssue(issues, {
+        path: location,
+        message: `字段需要 integer，当前为 ${actualType}。`,
+        suggestion: `按 ${describeSchemaRequirement(schema)} 调整为整数。`
+      });
+      return;
+    }
+  } else if (schema.type === "number") {
+    if (typeof value !== "number" || Number.isNaN(value)) {
+      pushIssue(issues, {
+        path: location,
+        message: `字段需要 number，当前为 ${actualType}。`,
+        suggestion: `按 ${describeSchemaRequirement(schema)} 调整为数值。`
+      });
+      return;
+    }
+  } else if (schema.type === "string") {
+    if (typeof value !== "string") {
+      pushIssue(issues, {
+        path: location,
+        message: `字段需要 string，当前为 ${actualType}。`,
+        suggestion: "调整为字符串。"
+      });
+      return;
+    }
+  } else if (schema.type === "boolean") {
+    if (typeof value !== "boolean") {
+      pushIssue(issues, {
+        path: location,
+        message: `字段需要 boolean，当前为 ${actualType}。`,
+        suggestion: "调整为 true 或 false。"
+      });
+      return;
+    }
+  }
+
+  if (typeof value === "number" && schema.minimum != null && value < schema.minimum) {
+    pushIssue(issues, {
+      path: location,
+      message: `字段值不能小于 ${schema.minimum}。`,
+      suggestion: `将值调到 ${schema.minimum} 或更高。`
+    });
+  }
+
+  if (schema.enum && typeof value === "string" && !schema.enum.includes(value)) {
+    pushIssue(issues, {
+      path: location,
+      message: `字段值必须是 ${schema.enum.join(" / ")} 之一。`,
+      suggestion: "改成允许的枚举值。"
+    });
+  }
+}
+
+function buildTabularRowsForDocument(document: ConfigDocument): Array<Record<string, string>> {
+  const schema = CONFIG_DOCUMENT_SCHEMAS[document.id];
+  const content = JSON.parse(document.content) as unknown;
+  return flattenConfigValueWithSchema(content, schema).map((entry) => {
+    const segments = parseJsonPath(entry.path);
+    const leaf = segments.length === 0 ? "$" : String(segments.at(-1));
+    const parent = segments.length <= 1 ? "$" : segments.slice(0, -1).join(".");
+    return {
+      Section: parent,
+      Field: leaf,
+      Path: entry.path || "$",
+      Type: entry.type,
+      Schema: describeSchemaRequirement(schemaNodeForPath(schema, entry.path) ?? {}),
+      Description: entry.description ?? "",
+      Value: entry.displayValue,
+      JSON: entry.jsonValue
+    };
+  });
+}
+
 function buildWorkbookForDocument(document: ConfigDocument): Buffer {
   const workbook = XLSX.utils.book_new();
-  const content = JSON.parse(document.content) as unknown;
-  const rows = flattenConfigValue(content).map((entry) => ({
-    Path: entry.path || "$",
-    Type: entry.type,
-    Value: entry.displayValue,
-    JSON: entry.jsonValue
-  }));
+  const schema = buildSchemaSummary(document.id);
+  const rows = buildTabularRowsForDocument(document);
   const metadataRows = [
     ["Document", document.id],
     ["Title", document.title],
     ["Version", String(document.version ?? 1)],
     ["UpdatedAt", document.updatedAt],
-    ["Summary", document.summary]
+    ["Summary", document.summary],
+    ["SchemaId", schema.id],
+    ["SchemaVersion", schema.version]
+  ];
+  const schemaRows = [
+    ["SchemaId", schema.id],
+    ["Title", schema.title],
+    ["Version", schema.version],
+    ["Description", schema.description],
+    ["RequiredRoots", schema.required.join(", ")]
   ];
 
   XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet(metadataRows), "Meta");
-  XLSX.utils.book_append_sheet(workbook, XLSX.utils.json_to_sheet(rows), "Config");
+  XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet(schemaRows), "Schema");
+  XLSX.utils.book_append_sheet(workbook, XLSX.utils.json_to_sheet(rows), "Fields");
 
   return XLSX.write(workbook, {
     bookType: "xlsx",
     type: "buffer"
   }) as Buffer;
+}
+
+function buildCsvForDocument(document: ConfigDocument): Buffer {
+  const worksheet = XLSX.utils.json_to_sheet(buildTabularRowsForDocument(document));
+  return Buffer.from(XLSX.utils.sheet_to_csv(worksheet), "utf8");
 }
 
 function buildCommentedJson(document: ConfigDocument): Buffer {
@@ -482,7 +1016,7 @@ function buildCommentedJson(document: ConfigDocument): Buffer {
 
 function parseWorkbookToContent(workbookBuffer: Buffer): string {
   const workbook = XLSX.read(workbookBuffer, { type: "buffer" });
-  const sheetName = workbook.SheetNames.find((name) => name === "Config") ?? workbook.SheetNames[0];
+  const sheetName = workbook.SheetNames.find((name) => name === "Fields" || name === "Config") ?? workbook.SheetNames[0];
   const sheet = sheetName ? workbook.Sheets[sheetName] : undefined;
   if (!sheet) {
     throw new Error("Workbook does not contain a Config sheet");
@@ -1050,7 +1584,8 @@ async function loadValidationDependencies(
   };
 }
 
-function buildValidationReportFromError(error: Error, content: string): ValidationReport {
+function buildValidationReportFromError(id: ConfigDocumentId, error: Error, content: string): ValidationReport {
+  const schema = buildSchemaSummary(id);
   const line = detectSyntaxLine(error.message, content);
   return {
     valid: false,
@@ -1063,7 +1598,8 @@ function buildValidationReportFromError(error: Error, content: string): Validati
         suggestion: "修复后再保存，必要时参考右侧摘要与历史快照。",
         ...(line != null ? { line } : {})
       }
-    ]
+    ],
+    schema
   };
 }
 
@@ -1319,22 +1855,29 @@ async function validateDocumentDetailed(
 ): Promise<ValidationReport> {
   try {
     const parsed = JSON.parse(content) as ParsedConfigDocument;
-    const dependencies = await loadValidationDependencies(store, id);
-    const issues =
-      id === "world"
-        ? validateWorldConfigDetailed(parsed as WorldGenerationConfig)
-        : id === "mapObjects"
-          ? validateMapObjectsDetailed(
-              parsed as MapObjectsConfig,
-              dependencies.world,
-              dependencies.units
-            )
-          : id === "units"
-            ? validateUnitCatalogDetailed(
-                parsed as UnitCatalogConfig,
-                dependencies.battleSkills
+    const issues: ValidationIssue[] = [];
+    validateSchemaNode(parsed, CONFIG_DOCUMENT_SCHEMAS[id], "", issues);
+    try {
+      const dependencies = await loadValidationDependencies(store, id);
+      const semanticIssues =
+        id === "world"
+          ? validateWorldConfigDetailed(parsed as WorldGenerationConfig)
+          : id === "mapObjects"
+            ? validateMapObjectsDetailed(
+                parsed as MapObjectsConfig,
+                dependencies.world,
+                dependencies.units
               )
-            : validateBattleSkillsDetailed(parsed as BattleSkillCatalogConfig);
+            : id === "units"
+              ? validateUnitCatalogDetailed(
+                  parsed as UnitCatalogConfig,
+                  dependencies.battleSkills
+                )
+              : validateBattleSkillsDetailed(parsed as BattleSkillCatalogConfig);
+      issues.push(...semanticIssues);
+    } catch {
+      // Schema issues above already explain malformed structures; skip dependent semantic checks.
+    }
 
     try {
       parseConfigDocument(id, content);
@@ -1351,10 +1894,11 @@ async function validateDocumentDetailed(
     return {
       valid: issues.length === 0,
       summary: summarizeIssues(issues),
-      issues
+      issues,
+      schema: buildSchemaSummary(id)
     };
   } catch (error) {
-    return buildValidationReportFromError(error as Error, content);
+    return buildValidationReportFromError(id, error as Error, content);
   }
 }
 
@@ -1576,7 +2120,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     return this.saveDocument(id, presetContent);
   }
 
-  async exportDocument(id: ConfigDocumentId, format: "xlsx" | "jsonc"): Promise<{
+  async exportDocument(id: ConfigDocumentId, format: "xlsx" | "jsonc" | "csv"): Promise<{
     fileName: string;
     contentType: string;
     body: Buffer;
@@ -1588,7 +2132,13 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
           contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
           body: buildWorkbookForDocument(document)
         }
-      : {
+      : format === "csv"
+        ? {
+            fileName: `${id}-v${document.version ?? 1}.csv`,
+            contentType: "text/csv; charset=utf-8",
+            body: buildCsvForDocument(document)
+          }
+        : {
           fileName: `${id}-v${document.version ?? 1}.jsonc`,
           contentType: "application/jsonc; charset=utf-8",
           body: buildCommentedJson(document)
@@ -2123,7 +2673,8 @@ export function registerConfigCenterRoutes(
 
     try {
       const requestUrl = new URL(request.url ?? "", "http://localhost");
-      const format = requestUrl.searchParams.get("format") === "jsonc" ? "jsonc" : "xlsx";
+      const requestedFormat = requestUrl.searchParams.get("format");
+      const format = requestedFormat === "jsonc" || requestedFormat === "csv" ? requestedFormat : "xlsx";
       const exported = await store.exportDocument(definition.id, format);
       response.statusCode = 200;
       response.setHeader("Content-Type", exported.contentType);

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import * as XLSX from "xlsx";
 import {
   getDefaultBattleSkillCatalog,
   getDefaultWorldConfig,
@@ -338,6 +339,34 @@ test("config center can validate invalid world config with structured issues", a
   assert.equal(report.valid, false);
   assert.match(report.summary, /发现/);
   assert.match(report.issues.map((issue) => issue.path).join(","), /width|heroes\[0\]\.position\.x/);
+  assert.equal(report.schema.id, "project-veil.config-center.world");
+  assert.match(report.schema.version, /\d{4}-\d{2}-\d{2}/);
+});
+
+test("config center schema validation reports missing and mistyped fields", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  const report = await store.validateDocument(
+    "battleSkills",
+    JSON.stringify({
+      skills: [
+        {
+          id: "broken-skill",
+          name: "坏技能",
+          description: "故意缺字段",
+          kind: "burst",
+          target: "enemy",
+          cooldown: "soon"
+        }
+      ]
+    })
+  );
+
+  assert.equal(report.valid, false);
+  assert.match(report.issues.map((issue) => issue.path).join(","), /statuses|skills\[0\]\.kind|skills\[0\]\.cooldown/);
+  assert.equal(report.schema.id, "project-veil.config-center.battleSkills");
 });
 
 test("config center snapshots support diff and rollback", async () => {
@@ -379,6 +408,14 @@ test("config center presets and workbook import/export roundtrip", async () => {
 
   const exported = await store.exportDocument("battleSkills", "xlsx");
   assert.match(exported.fileName, /\.xlsx$/);
+  const workbook = XLSX.read(exported.body, { type: "buffer" });
+  assert.deepEqual(workbook.SheetNames, ["Meta", "Schema", "Fields"]);
+  const fieldRows = XLSX.utils.sheet_to_json<Record<string, string>>(workbook.Sheets.Fields);
+  assert.equal(fieldRows.some((row) => row.Path === "skills[0].id" && row.Description?.includes("技能 id")), true);
+
+  const csvExported = await store.exportDocument("battleSkills", "csv");
+  assert.match(csvExported.fileName, /\.csv$/);
+  assert.match(csvExported.body.toString("utf8"), /Section,Field,Path,Type,Schema,Description,Value,JSON/);
 
   const imported = await store.importDocumentFromWorkbook("battleSkills", exported.body);
   assert.equal(imported.id, "battleSkills");


### PR DESCRIPTION
## Summary
- add schema-backed config validation summaries and clearer field-level export artifacts for the web config center
- improve config center UX around snapshot diff visibility and lightweight CSV export alongside xlsx/jsonc
- extend config center tests and README coverage for snapshots, presets, schema validation, and export flows

## Testing
- `node --import tsx --test ./apps/server/test/config-center.test.ts`
- `npm test` *(fails in existing persistence tests: `apps/server/test/colyseus-persistence-recovery.test.ts` and `apps/server/test/room-persistence.test.ts`)*
- `npm run typecheck:server` *(blocked by existing `packages/shared/src/map.ts` exactOptionalPropertyTypes errors)*
- `npm run typecheck:client:h5` *(blocked by the same existing `packages/shared/src/map.ts` errors)*

refs #31