### PR TITLE
feat: equipment foundation bonuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - `neutralArmies` 现已支持可选 `behavior` 字段：可配置 `guard / patrol` 模式、显式巡逻路线或 `patrolRadius` 自动巡逻圈，并可按 `detectionRadius / chaseDistance / speed` 精细调节巡逻、追击与返回节奏；中立怪会在每日推进时按路线巡逻、失位后回守，并在英雄靠近时主动追击，贴身时直接触发遭遇战。
 - 当前 MySQL 资源持久化已补上 `player_accounts`：房间保存时会同步刷新玩家全局 `gold / wood / ore` 仓库，新建房间会先回灌这份全局资源，因此同一 `playerId` 的基础资源已能跨房间继承。
 - 当前 MySQL 英雄长期档已补上 `player_hero_archives`：房间保存时会同步刷新英雄的长期成长、已学技能、装备槽位与带兵快照，新建房间会先回灌这些长期数据，因此同一 `playerId` 的英雄属性成长、build 和当前带兵已能跨房间继承；英雄的位置、剩余移动力和当前生命仍会按新局重置。
+- 装备系统的第一批基础能力现已落到 shared/core：共享层补上了 `weapon / armor / accessory` 三类装备目录、品质与特殊效果元数据，英雄长期档里的装备槽位 ID 会直接映射成可计算的属性加成，并且会在创建战斗栈时折算进攻击/防御，方便后续继续接掉落、锻造与 UI。
 - 当前玩家账号骨架也已接到 `player_accounts`：账号记录现已包含 `displayName / lastRoomId / lastSeenAt / globalResources`，并开放 `GET /api/player-accounts`、`GET /api/player-accounts/:playerId`、`PUT /api/player-accounts/:playerId` 供开发态查看与改名；房间 `connect` 时会自动建档或刷新最近活跃房间。
 - H5 左侧面板现已补上账号资料卡：会优先显示服务端账号昵称，也会在浏览器本地记住上次使用的游客昵称；远端房间首次 `connect` 时会把这份 `displayName` 一并带给服务端，用于初始化游客账号资料。`/api/player-accounts/me` 返回的 `globalResources` 也会直接显示成“全局仓库”摘要，方便确认跨房间继承的金币/木材/矿石。
 - H5 现在也有真正的 Lobby / 登录入口：当页面没有携带 `roomId / playerId` 查询参数时，会先进入大厅页，显示游客 `playerId / 昵称 / roomId` 表单和 `/api/lobby/rooms` 活跃房间列表；选房或手动输入房间后即可进入实例，游戏内也能一键返回大厅。

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -15,6 +15,7 @@ import type {
   UnitStack,
   ValidationResult
 } from "./models";
+import { createHeroEquipmentBonusSummary } from "./equipment";
 import { grantedHeroBattleSkillIds } from "./hero-skills";
 import { requireValue, withOptionalProperty } from "./invariant";
 import { getDefaultBattleSkillCatalog, getDefaultUnitCatalog } from "./world-config";
@@ -913,6 +914,7 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
   const battleCatalogIndex = getBattleCatalogIndex();
   const templateById = new Map(catalog.templates.map((template) => [template.id, template]));
   const heroTemplate = templateById.get(hero.armyTemplateId);
+  const heroEquipment = createHeroEquipmentBonusSummary(hero);
   const lanes = Math.max(1, neutralArmy.stacks.length);
   const attackerLanes = buildFormationLanes(1, lanes);
   const defenderLanes = buildFormationLanes(neutralArmy.stacks.length, lanes);
@@ -929,8 +931,8 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
       lane: attackerLanes[0] ?? 0,
       stackName: heroTemplate.stackName,
       initiative: heroTemplate.initiative,
-      attack: heroTemplate.attack + hero.stats.attack,
-      defense: heroTemplate.defense + hero.stats.defense,
+      attack: heroTemplate.attack + hero.stats.attack + heroEquipment.attack,
+      defense: heroTemplate.defense + hero.stats.defense + heroEquipment.defense,
       minDamage: heroTemplate.minDamage,
       maxDamage: heroTemplate.maxDamage,
       count: hero.armyCount,
@@ -999,6 +1001,8 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
   const templateById = new Map(catalog.templates.map((template) => [template.id, template]));
   const attackerTemplate = templateById.get(attackerHero.armyTemplateId);
   const defenderTemplate = templateById.get(defenderHero.armyTemplateId);
+  const attackerEquipment = createHeroEquipmentBonusSummary(attackerHero);
+  const defenderEquipment = createHeroEquipmentBonusSummary(defenderHero);
   const lanes = 1;
   const attackerLanes = buildFormationLanes(1, lanes);
   const defenderLanes = buildFormationLanes(1, lanes);
@@ -1021,8 +1025,8 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
         lane: attackerLanes[0] ?? 0,
         stackName: attackerTemplate.stackName,
         initiative: attackerTemplate.initiative,
-        attack: attackerTemplate.attack + attackerHero.stats.attack,
-        defense: attackerTemplate.defense + attackerHero.stats.defense,
+        attack: attackerTemplate.attack + attackerHero.stats.attack + attackerEquipment.attack,
+        defense: attackerTemplate.defense + attackerHero.stats.defense + attackerEquipment.defense,
         minDamage: attackerTemplate.minDamage,
         maxDamage: attackerTemplate.maxDamage,
         count: attackerHero.armyCount,
@@ -1042,8 +1046,8 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
         lane: defenderLanes[0] ?? 0,
         stackName: defenderTemplate.stackName,
         initiative: defenderTemplate.initiative,
-        attack: defenderTemplate.attack + defenderHero.stats.attack,
-        defense: defenderTemplate.defense + defenderHero.stats.defense,
+        attack: defenderTemplate.attack + defenderHero.stats.attack + defenderEquipment.attack,
+        defense: defenderTemplate.defense + defenderHero.stats.defense + defenderEquipment.defense,
         minDamage: defenderTemplate.minDamage,
         maxDamage: defenderTemplate.maxDamage,
         count: defenderHero.armyCount,

--- a/packages/shared/src/equipment.ts
+++ b/packages/shared/src/equipment.ts
@@ -1,0 +1,321 @@
+import {
+  createDefaultEquipmentStatBonuses,
+  type EquipmentCatalogConfig,
+  type EquipmentDefinition,
+  type EquipmentStatBonuses,
+  type HeroState
+} from "./models";
+
+const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
+  entries: [
+    {
+      id: "militia_pike",
+      name: "民兵长枪",
+      type: "weapon",
+      rarity: "common",
+      description: "朴素但趁手的制式长枪。",
+      bonuses: {
+        attackPercent: 6
+      }
+    },
+    {
+      id: "oak_longbow",
+      name: "橡木长弓",
+      type: "weapon",
+      rarity: "common",
+      description: "拉满弓弦时能更稳定地压制敌阵。",
+      bonuses: {
+        attackPercent: 4,
+        knowledge: 1
+      }
+    },
+    {
+      id: "vanguard_blade",
+      name: "先锋战刃",
+      type: "weapon",
+      rarity: "rare",
+      description: "鼓励先手突击的军团佩剑。",
+      bonuses: {
+        attackPercent: 10
+      },
+      specialEffect: {
+        id: "initiative_edge",
+        name: "抢攻",
+        description: "在开战后的第一轮拥有更强的压制力。"
+      }
+    },
+    {
+      id: "stormbreaker_halberd",
+      name: "裂风戟",
+      type: "weapon",
+      rarity: "rare",
+      description: "厚重戟锋在接战瞬间能撕开阵型。",
+      bonuses: {
+        attackPercent: 12,
+        defensePercent: 4
+      }
+    },
+    {
+      id: "sunforged_spear",
+      name: "曜铸长矛",
+      type: "weapon",
+      rarity: "epic",
+      description: "由锻火祝福的长矛，专为决斗领袖准备。",
+      bonuses: {
+        attackPercent: 16,
+        power: 1
+      },
+      specialEffect: {
+        id: "momentum",
+        name: "破阵",
+        description: "持续进攻时会不断扩大优势。"
+      }
+    },
+    {
+      id: "astral_scepter",
+      name: "星辉权杖",
+      type: "weapon",
+      rarity: "epic",
+      description: "让施法者在战场上拥有更高的掌控力。",
+      bonuses: {
+        attackPercent: 8,
+        power: 2,
+        knowledge: 1
+      },
+      specialEffect: {
+        id: "channeling",
+        name: "引导",
+        description: "为后续技能结算预留更高的法术上限。"
+      }
+    },
+    {
+      id: "padded_gambeson",
+      name: "厚绗布甲",
+      type: "armor",
+      rarity: "common",
+      description: "最基础的防护甲衣。",
+      bonuses: {
+        defensePercent: 6,
+        maxHp: 2
+      }
+    },
+    {
+      id: "tower_shield_mail",
+      name: "塔盾链甲",
+      type: "armor",
+      rarity: "common",
+      description: "链环与肩甲兼顾机动和招架。",
+      bonuses: {
+        defensePercent: 8
+      }
+    },
+    {
+      id: "ranger_scale",
+      name: "游侠鳞铠",
+      type: "armor",
+      rarity: "rare",
+      description: "轻量鳞片能在守势中保留反击空间。",
+      bonuses: {
+        attackPercent: 4,
+        defensePercent: 10,
+        maxHp: 3
+      }
+    },
+    {
+      id: "bastion_plate",
+      name: "壁垒板甲",
+      type: "armor",
+      rarity: "rare",
+      description: "给前线英雄准备的正面抗压装备。",
+      bonuses: {
+        defensePercent: 12,
+        maxHp: 4
+      },
+      specialEffect: {
+        id: "brace",
+        name: "固守",
+        description: "面对高强度交锋时更容易稳住阵线。"
+      }
+    },
+    {
+      id: "warden_aegis",
+      name: "守誓圣铠",
+      type: "armor",
+      rarity: "epic",
+      description: "铭刻誓约的圣铠，在鏖战中更显价值。",
+      bonuses: {
+        defensePercent: 16,
+        maxHp: 6
+      },
+      specialEffect: {
+        id: "ward",
+        name: "护佑",
+        description: "为整支部队提供更稳定的防线。"
+      }
+    },
+    {
+      id: "warpath_harness",
+      name: "征途战铠",
+      type: "armor",
+      rarity: "epic",
+      description: "兼顾推进与硬度的高阶胸甲。",
+      bonuses: {
+        attackPercent: 6,
+        defensePercent: 14,
+        maxHp: 5
+      }
+    },
+    {
+      id: "scout_compass",
+      name: "斥候罗盘",
+      type: "accessory",
+      rarity: "common",
+      description: "帮助英雄更快判断战场破绽。",
+      bonuses: {
+        attackPercent: 3,
+        knowledge: 1
+      }
+    },
+    {
+      id: "scribe_charm",
+      name: "书记官符坠",
+      type: "accessory",
+      rarity: "common",
+      description: "记录战报与法令的随身信物。",
+      bonuses: {
+        defensePercent: 3,
+        knowledge: 1
+      }
+    },
+    {
+      id: "captains_insignia",
+      name: "队长徽记",
+      type: "accessory",
+      rarity: "rare",
+      description: "用来稳定士气和前线节奏的军官佩章。",
+      bonuses: {
+        attackPercent: 5,
+        defensePercent: 5
+      }
+    },
+    {
+      id: "ember_talisman",
+      name: "余烬护符",
+      type: "accessory",
+      rarity: "rare",
+      description: "保持法术专注并兼顾一定防护。",
+      bonuses: {
+        power: 1,
+        defensePercent: 6
+      }
+    },
+    {
+      id: "sun_medallion",
+      name: "曜日勋章",
+      type: "accessory",
+      rarity: "epic",
+      description: "象征高阶指挥权的战场勋章。",
+      bonuses: {
+        attackPercent: 8,
+        defensePercent: 8,
+        power: 1
+      },
+      specialEffect: {
+        id: "momentum",
+        name: "破阵",
+        description: "持续进攻时会不断扩大优势。"
+      }
+    },
+    {
+      id: "oracle_lens",
+      name: "谕示透镜",
+      type: "accessory",
+      rarity: "epic",
+      description: "让施法者保持更高的战场感知。",
+      bonuses: {
+        knowledge: 2,
+        power: 1,
+        defensePercent: 4
+      },
+      specialEffect: {
+        id: "channeling",
+        name: "引导",
+        description: "为后续技能结算预留更高的法术上限。"
+      }
+    }
+  ]
+};
+
+const DEFAULT_EQUIPMENT_BY_ID = new Map(
+  DEFAULT_EQUIPMENT_CATALOG.entries.map((entry) => [entry.id, entry] as const)
+);
+
+export interface HeroEquipmentBonusSummary extends EquipmentStatBonuses {
+  attack: number;
+  defense: number;
+  resolvedItemIds: string[];
+  specialEffects: NonNullable<EquipmentDefinition["specialEffect"]>[];
+}
+
+function numericBonus(value: number | undefined): number {
+  return Number.isFinite(value) ? Number(value) : 0;
+}
+
+function resolveEquipmentDefinition(id: string | undefined): EquipmentDefinition | undefined {
+  return id ? DEFAULT_EQUIPMENT_BY_ID.get(id) : undefined;
+}
+
+function percentageDelta(base: number, percent: number): number {
+  if (percent === 0) {
+    return 0;
+  }
+
+  return Math.round(Math.max(0, base) * (percent / 100));
+}
+
+export function getDefaultEquipmentCatalog(): EquipmentCatalogConfig {
+  return {
+    entries: DEFAULT_EQUIPMENT_CATALOG.entries.map((entry) => ({
+      ...entry,
+      bonuses: { ...entry.bonuses },
+      ...(entry.specialEffect ? { specialEffect: { ...entry.specialEffect } } : {})
+    }))
+  };
+}
+
+export function getEquipmentDefinition(equipmentId: string): EquipmentDefinition | undefined {
+  return resolveEquipmentDefinition(equipmentId.trim());
+}
+
+export function createHeroEquipmentBonusSummary(
+  hero: Pick<HeroState, "stats" | "loadout">
+): HeroEquipmentBonusSummary {
+  const bonuses = createDefaultEquipmentStatBonuses();
+  const resolvedItems = [
+    resolveEquipmentDefinition(hero.loadout.equipment.weaponId),
+    resolveEquipmentDefinition(hero.loadout.equipment.armorId),
+    resolveEquipmentDefinition(hero.loadout.equipment.accessoryId)
+  ].filter((entry): entry is EquipmentDefinition => Boolean(entry));
+
+  for (const item of resolvedItems) {
+    bonuses.attackPercent += numericBonus(item.bonuses.attackPercent);
+    bonuses.defensePercent += numericBonus(item.bonuses.defensePercent);
+    bonuses.power += numericBonus(item.bonuses.power);
+    bonuses.knowledge += numericBonus(item.bonuses.knowledge);
+    bonuses.maxHp += numericBonus(item.bonuses.maxHp);
+  }
+
+  return {
+    attack: percentageDelta(hero.stats.attack, bonuses.attackPercent),
+    defense: percentageDelta(hero.stats.defense, bonuses.defensePercent),
+    attackPercent: bonuses.attackPercent,
+    defensePercent: bonuses.defensePercent,
+    power: bonuses.power,
+    knowledge: bonuses.knowledge,
+    maxHp: bonuses.maxHp,
+    resolvedItemIds: resolvedItems.map((item) => item.id),
+    specialEffects: resolvedItems
+      .flatMap((item) => (item.specialEffect ? [item.specialEffect] : []))
+      .filter((effect, index, effects) => effects.findIndex((item) => item.id === effect.id) === index)
+  };
+}

--- a/packages/shared/src/hero-progression.ts
+++ b/packages/shared/src/hero-progression.ts
@@ -1,3 +1,4 @@
+import { createHeroEquipmentBonusSummary } from "./equipment";
 import type { HeroState, PlayerWorldView } from "./models";
 import { experienceRequiredForNextLevel, totalExperienceRequiredForLevel } from "./models";
 
@@ -111,18 +112,25 @@ export function createHeroProgressMeterView(
 }
 
 export function createHeroAttributeBreakdown(
-  hero: Pick<HeroState, "id" | "stats" | "progression">,
+  hero: Pick<HeroState, "id" | "stats" | "progression" | "loadout">,
   world?: Pick<PlayerWorldView, "map"> | null
 ): HeroAttributeBreakdownRow[] {
+  const equipment = createHeroEquipmentBonusSummary(hero);
   const sources: HeroAttributeSourceSet = {
     progression: buildProgressionContribution(hero),
     buildings: buildBuildingContribution(world, hero.id),
-    equipment: createEmptyAttributeValues(),
+    equipment: {
+      attack: equipment.attack,
+      defense: equipment.defense,
+      power: equipment.power,
+      knowledge: equipment.knowledge,
+      maxHp: equipment.maxHp
+    },
     skills: createEmptyAttributeValues()
   };
 
   return ATTRIBUTE_ROWS.map(({ key, label }) => {
-    const total = heroTotalForKey(hero, key);
+    const total = heroTotalForKey(hero, key) + sources.equipment[key];
     const progression = sources.progression[key];
     const buildings = sources.buildings[key];
     const equipment = sources.equipment[key];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./battle";
+export * from "./equipment";
 export * from "./hero-skills";
 export * from "./hero-progression";
 export * from "./map";

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -24,6 +24,38 @@ export type HeroStatBonus = Pick<HeroStats, "attack" | "defense" | "power" | "kn
 
 export type HeroSkillId = string;
 export type HeroSkillBranchId = string;
+export type EquipmentId = string;
+export type EquipmentType = "weapon" | "armor" | "accessory";
+export type EquipmentRarity = "common" | "rare" | "epic";
+export type EquipmentSpecialEffectId = "initiative_edge" | "brace" | "channeling" | "momentum" | "ward";
+
+export interface EquipmentStatBonuses {
+  attackPercent: number;
+  defensePercent: number;
+  power: number;
+  knowledge: number;
+  maxHp: number;
+}
+
+export interface EquipmentSpecialEffectConfig {
+  id: EquipmentSpecialEffectId;
+  name: string;
+  description: string;
+}
+
+export interface EquipmentDefinition {
+  id: EquipmentId;
+  name: string;
+  type: EquipmentType;
+  rarity: EquipmentRarity;
+  description: string;
+  bonuses: Partial<EquipmentStatBonuses>;
+  specialEffect?: EquipmentSpecialEffectConfig;
+}
+
+export interface EquipmentCatalogConfig {
+  entries: EquipmentDefinition[];
+}
 
 export interface HeroLearnedSkillState {
   skillId: HeroSkillId;
@@ -77,11 +109,17 @@ export interface HeroBattleSkillState {
   rank: number;
 }
 
+export interface HeroEquipmentSlots {
+  weaponId?: EquipmentId;
+  armorId?: EquipmentId;
+  accessoryId?: EquipmentId;
+}
+
 export interface HeroEquipmentState {
-  weaponId?: string;
-  armorId?: string;
-  accessoryId?: string;
-  trinketIds: string[];
+  weaponId?: EquipmentId;
+  armorId?: EquipmentId;
+  accessoryId?: EquipmentId;
+  trinketIds: EquipmentId[];
 }
 
 export interface HeroLoadout {
@@ -110,10 +148,10 @@ export interface HeroBattleSkillConfig {
 }
 
 export interface HeroEquipmentConfig {
-  weaponId?: string;
-  armorId?: string;
-  accessoryId?: string;
-  trinketIds?: string[];
+  weaponId?: EquipmentId;
+  armorId?: EquipmentId;
+  accessoryId?: EquipmentId;
+  trinketIds?: EquipmentId[];
 }
 
 export interface HeroLoadoutConfig {
@@ -626,6 +664,16 @@ export function createDefaultHeroProgression(): HeroProgression {
     battlesWon: 0,
     neutralBattlesWon: 0,
     pvpBattlesWon: 0
+  };
+}
+
+export function createDefaultEquipmentStatBonuses(): EquipmentStatBonuses {
+  return {
+    attackPercent: 0,
+    defensePercent: 0,
+    power: 0,
+    knowledge: 0,
+    maxHp: 0
   };
 }
 

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -4,6 +4,7 @@ import {
   applyBattleAction,
   applyBattleOutcomeToWorld,
   createHeroAttributeBreakdown,
+  createHeroEquipmentBonusSummary,
   createHeroSkillTreeView,
   createHeroProgressMeterView,
   createDemoBattleState,
@@ -19,6 +20,7 @@ import {
   getDefaultHeroSkillTreeConfig,
   getDefaultUnitCatalog,
   getBattleOutcome,
+  getDefaultEquipmentCatalog,
   pickAutomatedBattleAction,
   planPlayerViewMovement,
   predictPlayerWorldAction,
@@ -224,6 +226,15 @@ test("hero progression helpers expose xp meter and attribute sources", () => {
       battlesWon: 1,
       neutralBattlesWon: 1,
       pvpBattlesWon: 0
+    },
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "sunforged_spear",
+        armorId: "padded_gambeson",
+        accessoryId: "sun_medallion",
+        trinketIds: []
+      }
     }
   });
   const state = createWorldState({
@@ -279,9 +290,55 @@ test("hero progression helpers expose xp meter and attribute sources", () => {
     remainingExperience: 135,
     progressRatio: 40 / 175
   });
-  assert.equal(breakdown.find((row) => row.key === "attack")?.formula, "攻击 4 = 基础 2 成长 +1 建筑 +1");
+  assert.equal(breakdown.find((row) => row.key === "attack")?.formula, "攻击 5 = 基础 2 成长 +1 建筑 +1 装备 +1");
   assert.equal(breakdown.find((row) => row.key === "defense")?.formula, "防御 3 = 基础 2 成长 +1");
-  assert.equal(breakdown.find((row) => row.key === "maxHp")?.formula, "生命上限 32 = 基础 30 成长 +2");
+  assert.equal(breakdown.find((row) => row.key === "maxHp")?.formula, "生命上限 34 = 基础 30 成长 +2 装备 +2");
+});
+
+test("equipment catalog exposes the minimum foundation set and resolves hero bonuses", () => {
+  const catalog = getDefaultEquipmentCatalog();
+  const countsByType = catalog.entries.reduce<Record<string, number>>((counts, entry) => {
+    counts[entry.type] = (counts[entry.type] ?? 0) + 1;
+    return counts;
+  }, {});
+  const hero = createHero({
+    id: "hero-equip",
+    playerId: "player-1",
+    name: "装备凯琳",
+    stats: {
+      attack: 5,
+      defense: 4,
+      power: 1,
+      knowledge: 2,
+      hp: 30,
+      maxHp: 30
+    },
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "sunforged_spear",
+        armorId: "warden_aegis",
+        accessoryId: "oracle_lens",
+        trinketIds: []
+      }
+    }
+  });
+
+  const bonuses = createHeroEquipmentBonusSummary(hero);
+
+  assert.equal(countsByType.weapon, 6);
+  assert.equal(countsByType.armor, 6);
+  assert.equal(countsByType.accessory, 6);
+  assert.equal(bonuses.attack, 1);
+  assert.equal(bonuses.defense, 1);
+  assert.equal(bonuses.power, 2);
+  assert.equal(bonuses.knowledge, 2);
+  assert.equal(bonuses.maxHp, 6);
+  assert.deepEqual(bonuses.resolvedItemIds, ["sunforged_spear", "warden_aegis", "oracle_lens"]);
+  assert.deepEqual(
+    bonuses.specialEffects.map((effect) => effect.id).sort(),
+    ["channeling", "momentum", "ward"]
+  );
 });
 
 test("resolveWorldAction starts a battle when a hero reaches a neutral army tile", () => {
@@ -761,6 +818,85 @@ test("createHeroBattleState carries learned hero skill tree rewards into battle"
   assert.ok(attackerSkills.includes("power_shot"));
   assert.ok(attackerSkills.includes("commanding_shout"));
   assert.ok(attackerSkills.includes("rending_mark"));
+});
+
+test("battle state builders fold equipped item bonuses into hero-led stacks", () => {
+  const attacker = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    stats: {
+      attack: 5,
+      defense: 4,
+      power: 1,
+      knowledge: 1,
+      hp: 30,
+      maxHp: 30
+    },
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "sunforged_spear",
+        armorId: "bastion_plate",
+        accessoryId: "captains_insignia",
+        trinketIds: []
+      }
+    }
+  });
+  const defender = createHero({
+    id: "hero-2",
+    playerId: "player-2",
+    name: "罗安",
+    stats: {
+      attack: 3,
+      defense: 5,
+      power: 1,
+      knowledge: 1,
+      hp: 30,
+      maxHp: 30
+    },
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "militia_pike",
+        armorId: "padded_gambeson",
+        accessoryId: "scribe_charm",
+        trinketIds: []
+      }
+    }
+  });
+
+  const attackerBonuses = createHeroEquipmentBonusSummary(attacker);
+  const defenderBonuses = createHeroEquipmentBonusSummary(defender);
+  const baselineBattle = createHeroBattleState(
+    {
+      ...attacker,
+      loadout: createDefaultHeroLoadout()
+    },
+    {
+      ...defender,
+      loadout: createDefaultHeroLoadout()
+    },
+    1001
+  );
+  const battle = createHeroBattleState(attacker, defender, 1001);
+
+  assert.equal(
+    battle.units["hero-1-stack"]?.attack,
+    (baselineBattle.units["hero-1-stack"]?.attack ?? 0) + attackerBonuses.attack
+  );
+  assert.equal(
+    battle.units["hero-1-stack"]?.defense,
+    (baselineBattle.units["hero-1-stack"]?.defense ?? 0) + attackerBonuses.defense
+  );
+  assert.equal(
+    battle.units["hero-2-stack"]?.attack,
+    (baselineBattle.units["hero-2-stack"]?.attack ?? 0) + defenderBonuses.attack
+  );
+  assert.equal(
+    battle.units["hero-2-stack"]?.defense,
+    (baselineBattle.units["hero-2-stack"]?.defense ?? 0) + defenderBonuses.defense
+  );
 });
 
 test("createPlayerWorldView returns player-scoped resources after collection", () => {


### PR DESCRIPTION
## Summary
- add the first shared equipment foundation with weapon/armor/accessory definitions, rarity metadata, and resolvers for equipped-item bonuses
- wire equipped item bonuses into hero attribute breakdowns and battle stack creation so equipment IDs from hero archives now have real combat impact
- add focused shared and server persistence tests plus a README note for this batch

## Scope of this batch
- covers shared data model foundation
- covers existing hero-archive persistence wiring consuming equipment slot IDs
- covers a minimal usable battle attribute bonus path
- does not cover drops, smithy/disenchant flows, trading, or UI equipment management yet

refs #28

## Validation
- `npm run test:shared`
- `node --import tsx --test ./apps/server/test/player-room-profiles.test.ts`
- `node --import tsx --test --test-name-pattern="colyseus room hydrates long-term hero archives into fresh rooms" ./apps/server/test/colyseus-persistence-recovery.test.ts`

## Notes
- `npm run typecheck:shared` / `npm run typecheck:server` are currently blocked by pre-existing `packages/shared/src/map.ts` exact-optional-property errors unrelated to this PR
- running the full paired persistence-recovery test file still hits an existing failure in `colyseus room reloads a persisted active battle after a server restart` (expected hero position mismatch)