### PR TITLE
完成建筑交互系统（招募/神社/矿产）

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -100,7 +100,7 @@ export interface AttributeShrineBuildingView {
   kind: "attribute_shrine";
   label: string;
   bonus: HeroStatBonus;
-  visitedHeroIds: string[];
+  lastUsedDay?: number;
 }
 
 export interface ResourceMineBuildingView {
@@ -109,7 +109,7 @@ export interface ResourceMineBuildingView {
   label: string;
   resourceKind: keyof ResourceLedger;
   income: number;
-  ownerPlayerId?: string;
+  lastHarvestDay?: number;
 }
 
 export type PlayerBuildingView =

--- a/apps/cocos-client/assets/scripts/cocos-map-visuals.ts
+++ b/apps/cocos-client/assets/scripts/cocos-map-visuals.ts
@@ -200,7 +200,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
       if (buildingPosition) {
         entries.push({
           position: buildingPosition,
-          text: "MINE",
+          text: `+${event.resourceKind.toUpperCase()}`,
           durationSeconds: 0.94
         });
       }
@@ -299,7 +299,7 @@ export function buildObjectPulseEntriesFromUpdate(update: SessionUpdate, heroId?
       if (buildingPosition) {
         entries.push({
           position: buildingPosition,
-          scale: 1.2,
+          scale: 1.22,
           durationSeconds: 0.27
         });
       }

--- a/apps/cocos-client/assets/scripts/cocos-object-visuals.ts
+++ b/apps/cocos-client/assets/scripts/cocos-object-visuals.ts
@@ -52,7 +52,7 @@ export function describeCocosTileObject(tile: PlayerTileView | null): CocosTileV
     const config = objectVisuals.buildings.attribute_shrine;
     return {
       title: tile.building.label || config.title,
-      subtitle: `${formatHeroStatBonus(tile.building.bonus) || config.subtitle}${tile.building.visitedHeroIds.length > 0 ? " · 已有英雄到访" : ""}`,
+      subtitle: `${formatHeroStatBonus(tile.building.bonus) || config.subtitle}${typeof tile.building.lastUsedDay === "number" ? " · 今日冷却中" : ""}`,
       shortLabel: "神殿",
       tag: "访问",
       faction: toFactionKey(config.faction),
@@ -65,9 +65,9 @@ export function describeCocosTileObject(tile: PlayerTileView | null): CocosTileV
     const config = objectVisuals.buildings.resource_mine;
     return {
       title: tile.building.label || config.title,
-      subtitle: `${formatResourceKindLabel(tile.building.resourceKind)} +${tile.building.income}/天${tile.building.ownerPlayerId ? ` · 归属 ${tile.building.ownerPlayerId}` : " · 当前无人占领"}`,
+      subtitle: `${formatResourceKindLabel(tile.building.resourceKind)} +${tile.building.income}${typeof tile.building.lastHarvestDay === "number" ? " · 今日已采集" : " · 可立即采集"}`,
       shortLabel: "矿场",
-      tag: "占领",
+      tag: "采集",
       faction: toFactionKey(config.faction),
       rarity: toRarityKey(config.rarity),
       interactionType: toInteractionKey(config.interactionType)

--- a/apps/cocos-client/assets/scripts/cocos-prediction.ts
+++ b/apps/cocos-client/assets/scripts/cocos-prediction.ts
@@ -291,12 +291,12 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: CocosWor
       };
     }
 
-    if (building.visitedHeroIds.includes(hero.id)) {
+    if (typeof building.lastUsedDay === "number" && building.lastUsedDay >= view.meta.day) {
       return {
         world: view,
         movementPlan: null,
         reachableTiles: [],
-        reason: "building_already_visited"
+        reason: "building_on_cooldown"
       };
     }
 
@@ -329,7 +329,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: CocosWor
             building: {
               ...currentBuilding,
               bonus: { ...currentBuilding.bonus },
-              visitedHeroIds: [...currentBuilding.visitedHeroIds, hero.id]
+              lastUsedDay: view.meta.day
             }
           };
         })
@@ -373,17 +373,21 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: CocosWor
       };
     }
 
-    if (building.ownerPlayerId === hero.playerId) {
+    if (typeof building.lastHarvestDay === "number" && building.lastHarvestDay >= view.meta.day) {
       return {
         world: view,
         movementPlan: null,
         reachableTiles: [],
-        reason: "building_already_owned"
+        reason: "building_on_cooldown"
       };
     }
 
     const predictedWorld: PlayerWorldView = {
       ...view,
+      resources: {
+        ...view.resources,
+        [building.resourceKind]: view.resources[building.resourceKind] + building.income
+      },
       map: {
         ...view.map,
         tiles: view.map.tiles.map((item) => {
@@ -396,7 +400,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: CocosWor
             ...item,
             building: {
               ...currentBuilding,
-              ownerPlayerId: hero.playerId
+              lastHarvestDay: view.meta.day
             }
           };
         })

--- a/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
+++ b/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
@@ -57,7 +57,7 @@ function formatWorldEvent(event: WorldEvent): string | null {
   if (event.type === "hero.claimedMine") {
     const resourceKind = typeof event.resourceKind === "string" ? event.resourceKind : "resource";
     const income = typeof event.income === "number" ? event.income : 0;
-    return `占领资源矿场，每日产出 ${formatResourceKindLabel(resourceKind)} +${income}。`;
+    return `采集矿场，获得 ${formatResourceKindLabel(resourceKind)} +${income}。`;
   }
 
   if (event.type === "hero.skillLearned") {

--- a/apps/cocos-client/test/cocos-map-visuals.test.ts
+++ b/apps/cocos-client/test/cocos-map-visuals.test.ts
@@ -331,7 +331,7 @@ test("buildMapFeedbackEntriesFromUpdate creates tile callouts for move, collect,
     },
     {
       position: { x: 1, y: 1 },
-      text: "MINE",
+      text: "+WOOD",
       durationSeconds: 0.94
     },
     {
@@ -457,7 +457,7 @@ test("buildObjectPulseEntriesFromUpdate emits bounce targets for collection and 
     },
     {
       position: { x: 1, y: 1 },
-      scale: 1.2,
+      scale: 1.22,
       durationSeconds: 0.27
     },
     {

--- a/apps/cocos-client/test/cocos-object-visuals.test.ts
+++ b/apps/cocos-client/test/cocos-object-visuals.test.ts
@@ -93,7 +93,7 @@ test("describeCocosTileObject exposes attribute shrines as permanent stat buildi
       power: 0,
       knowledge: 0
     },
-    visitedHeroIds: []
+    lastUsedDay: undefined
   };
 
   assert.equal(describeCocosTileObject(tile)?.shortLabel, "神殿");
@@ -101,7 +101,7 @@ test("describeCocosTileObject exposes attribute shrines as permanent stat buildi
   assert.equal(buildCocosTileMarkerText(tile), ">S");
 });
 
-test("describeCocosTileObject exposes resource mines as claimable daily income buildings", () => {
+test("describeCocosTileObject exposes resource mines as harvestable daily pickups", () => {
   const tile = createTile();
   tile.building = {
     id: "mine-1",
@@ -109,11 +109,11 @@ test("describeCocosTileObject exposes resource mines as claimable daily income b
     label: "前线伐木场",
     resourceKind: "wood",
     income: 2,
-    ownerPlayerId: "player-1"
+    lastHarvestDay: 1
   };
 
   assert.equal(describeCocosTileObject(tile)?.shortLabel, "矿场");
-  assert.equal(describeCocosTileObject(tile)?.tag, "占领");
-  assert.match(describeCocosTileObject(tile)?.subtitle ?? "", /木材 \+2\/天/);
+  assert.equal(describeCocosTileObject(tile)?.tag, "采集");
+  assert.match(describeCocosTileObject(tile)?.subtitle ?? "", /木材 \+2 · 今日已采集/);
   assert.equal(buildCocosTileMarkerText(tile), ">M");
 });

--- a/apps/cocos-client/test/cocos-ui-formatters.test.ts
+++ b/apps/cocos-client/test/cocos-ui-formatters.test.ts
@@ -120,7 +120,7 @@ test("buildTimelineEntriesFromUpdate formats world events and system rejection",
     "事件：采集 金币 +300。",
     "事件：在招募所补充 hero_guard_basic x4。",
     "事件：访问属性建筑，获得 攻击 +1。",
-    "事件：占领资源矿场，每日产出 木材 +2。",
+    "事件：采集矿场，获得 木材 +2。",
     "事件：资源矿场结算 木材 +2。",
     "事件：中立守军 neutral-1 主动追击，移动到 (2,2)。",
     "事件：中立守军 neutral-1 主动发起战斗。"

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -159,7 +159,7 @@ export interface WorldConfigPreviewTile {
           power: number;
           knowledge: number;
         };
-        visitedCount: number;
+        lastUsedDay?: number;
       }
     | {
         kind: "resource_mine";
@@ -167,7 +167,7 @@ export interface WorldConfigPreviewTile {
         label: string;
         resourceKind: ResourceKind;
         income: number;
-        ownerPlayerId?: string;
+        lastHarvestDay?: number;
       }
     | undefined;
 }
@@ -1446,7 +1446,7 @@ export function createWorldConfigPreview(
                 power: tile.building.bonus.power,
                 knowledge: tile.building.bonus.knowledge
               },
-              visitedCount: tile.building.visitedHeroIds.length
+              ...(typeof tile.building.lastUsedDay === "number" ? { lastUsedDay: tile.building.lastUsedDay } : {})
             }
           : {
               kind: tile.building.kind,
@@ -1454,7 +1454,9 @@ export function createWorldConfigPreview(
               label: tile.building.label,
               resourceKind: tile.building.resourceKind,
               income: tile.building.income,
-              ...(tile.building.ownerPlayerId ? { ownerPlayerId: tile.building.ownerPlayerId } : {})
+              ...(typeof tile.building.lastHarvestDay === "number"
+                ? { lastHarvestDay: tile.building.lastHarvestDay }
+                : {})
             };
 
     return {

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -248,14 +248,14 @@ test("room allows visiting an attribute shrine once and persists the stat bonus"
       buildingId: "shrine-attack-1",
       buildingKind: "attribute_shrine",
       bonus: {
-        attack: 1,
+        attack: 2,
         defense: 0,
         power: 0,
         knowledge: 0
       }
     }
   ]);
-  assert.equal(visitResult.snapshot.state.ownHeroes[0]?.stats.attack, 3);
+  assert.equal(visitResult.snapshot.state.ownHeroes[0]?.stats.attack, 4);
 
   const revisitResult = room.dispatch("player-1", {
     type: "hero.visit",
@@ -264,10 +264,10 @@ test("room allows visiting an attribute shrine once and persists the stat bonus"
   });
 
   assert.equal(revisitResult.ok, false);
-  assert.equal(revisitResult.reason, "building_already_visited");
+  assert.equal(revisitResult.reason, "building_on_cooldown");
 });
 
-test("room allows claiming a resource mine and grants daily income after advancing the day", () => {
+test("room allows harvesting a resource mine and restores it on the next day", () => {
   const room = createRoom("room-mine", 1001);
 
   const moveResult = room.dispatch("player-1", {
@@ -293,14 +293,15 @@ test("room allows claiming a resource mine and grants daily income after advanci
       buildingId: "mine-wood-1",
       buildingKind: "resource_mine",
       resourceKind: "wood",
-      income: 2,
+      income: 5,
       ownerPlayerId: "player-1"
     }
   ]);
   assert.equal(
-    claimResult.snapshot.state.map.tiles.find((tile) => tile.position.x === 3 && tile.position.y === 1)?.building?.ownerPlayerId,
-    "player-1"
+    claimResult.snapshot.state.map.tiles.find((tile) => tile.position.x === 3 && tile.position.y === 1)?.building?.lastHarvestDay,
+    1
   );
+  assert.equal(claimResult.snapshot.state.resources.wood, 5);
 
   const nextDayResult = room.dispatch("player-1", {
     type: "turn.endDay"
@@ -313,16 +314,6 @@ test("room allows claiming a resource mine and grants daily income after advanci
       day: 2
     },
     {
-      type: "resource.produced",
-      playerId: "player-1",
-      buildingId: "mine-wood-1",
-      buildingKind: "resource_mine",
-      resource: {
-        kind: "wood",
-        amount: 2
-      }
-    },
-    {
       type: "neutral.moved",
       neutralArmyId: "neutral-1",
       from: { x: 5, y: 4 },
@@ -331,7 +322,7 @@ test("room allows claiming a resource mine and grants daily income after advanci
       targetHeroId: "hero-2"
     }
   ]);
-  assert.equal(nextDayResult.snapshot.state.resources.wood, 2);
+  assert.equal(nextDayResult.snapshot.state.resources.wood, 5);
 });
 
 test("room can create a neutral-initiated battle when end day triggers an adjacent chase", () => {

--- a/configs/phase1-map-objects.json
+++ b/configs/phase1-map-objects.json
@@ -63,7 +63,7 @@
       },
       "label": "战旗圣坛",
       "bonus": {
-        "attack": 1,
+        "attack": 2,
         "defense": 0,
         "power": 0,
         "knowledge": 0
@@ -78,7 +78,7 @@
       },
       "label": "前线伐木场",
       "resourceKind": "wood",
-      "income": 2
+      "income": 5
     }
   ]
 }

--- a/packages/shared/src/hero-progression.ts
+++ b/packages/shared/src/hero-progression.ts
@@ -68,7 +68,7 @@ function buildProgressionContribution(hero: Pick<HeroState, "progression">): Rec
 
 function buildBuildingContribution(
   world: Pick<PlayerWorldView, "map"> | null | undefined,
-  heroId: string
+  _heroId: string
 ): Record<HeroAttributeKey, number> {
   const totals = createEmptyAttributeValues();
   if (!world) {
@@ -76,7 +76,7 @@ function buildBuildingContribution(
   }
 
   for (const tile of world.map.tiles) {
-    if (tile.building?.kind !== "attribute_shrine" || !tile.building.visitedHeroIds.includes(heroId)) {
+    if (tile.building?.kind !== "attribute_shrine" || typeof tile.building.lastUsedDay !== "number") {
       continue;
     }
 

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -328,8 +328,7 @@ function createBuildingState(config: MapObjectsConfig["buildings"][number]): Map
     return {
       ...config,
       position: { ...config.position },
-      bonus: cloneHeroStatBonus(config.bonus),
-      visitedHeroIds: []
+      bonus: cloneHeroStatBonus(config.bonus)
     };
   }
 
@@ -451,7 +450,8 @@ function clonePlayerBuildingView(building: MapBuildingState): PlayerBuildingView
       unitTemplateId: building.unitTemplateId,
       recruitCount: building.recruitCount,
       availableCount: building.availableCount,
-      cost: cloneResourceLedger(building.cost)
+      cost: cloneResourceLedger(building.cost),
+      ...(typeof building.lastUsedDay === "number" ? { lastUsedDay: building.lastUsedDay } : {})
     };
   }
 
@@ -461,7 +461,7 @@ function clonePlayerBuildingView(building: MapBuildingState): PlayerBuildingView
       kind: building.kind,
       label: building.label,
       bonus: cloneHeroStatBonus(building.bonus),
-      visitedHeroIds: [...building.visitedHeroIds]
+      ...(typeof building.lastUsedDay === "number" ? { lastUsedDay: building.lastUsedDay } : {})
     };
   }
 
@@ -471,7 +471,7 @@ function clonePlayerBuildingView(building: MapBuildingState): PlayerBuildingView
     label: building.label,
     resourceKind: building.resourceKind,
     income: building.income,
-    ...(building.ownerPlayerId ? { ownerPlayerId: building.ownerPlayerId } : {})
+    ...(typeof building.lastHarvestDay === "number" ? { lastHarvestDay: building.lastHarvestDay } : {})
   };
 }
 
@@ -488,15 +488,13 @@ function cloneBuildingState(building: MapBuildingState): MapBuildingState {
     return {
       ...building,
       position: { ...building.position },
-      bonus: cloneHeroStatBonus(building.bonus),
-      visitedHeroIds: [...building.visitedHeroIds]
+      bonus: cloneHeroStatBonus(building.bonus)
     };
   }
 
   return {
     ...building,
-    position: { ...building.position },
-    ...(building.ownerPlayerId ? { ownerPlayerId: building.ownerPlayerId } : {})
+    position: { ...building.position }
   };
 }
 
@@ -511,6 +509,10 @@ function refreshBuildingForNewDay(building: MapBuildingState): MapBuildingState 
   }
 
   return cloneBuildingState(building);
+}
+
+function isBuildingOnCurrentDayCooldown(day: number, lastUsedDay: number | undefined): boolean {
+  return typeof lastUsedDay === "number" && lastUsedDay >= day;
 }
 
 function applyHeroStatBonus(hero: HeroState, bonus: HeroStatBonus): HeroState {
@@ -1522,7 +1524,8 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
                 building: {
                   ...item.building,
                   cost: cloneResourceLedger(item.building.cost),
-                  availableCount: 0
+                  availableCount: 0,
+                  lastUsedDay: view.meta.day
                 }
               }
             : item
@@ -1572,12 +1575,12 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
     }
     const building = tile.building;
 
-    if (building.visitedHeroIds.includes(hero.id)) {
+    if (isBuildingOnCurrentDayCooldown(view.meta.day, building.lastUsedDay)) {
       return {
         world: view,
         movementPlan: null,
         reachableTiles: [],
-        reason: "building_already_visited"
+        reason: "building_on_cooldown"
       };
     }
 
@@ -1595,7 +1598,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
                 building: {
                   ...item.building,
                   bonus: cloneHeroStatBonus(item.building.bonus),
-                  visitedHeroIds: [...item.building.visitedHeroIds, hero.id]
+                  lastUsedDay: view.meta.day
                 }
               }
             : item
@@ -1640,17 +1643,21 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
     }
     const building = tile.building;
 
-    if (building.ownerPlayerId === hero.playerId) {
+    if (isBuildingOnCurrentDayCooldown(view.meta.day, building.lastHarvestDay)) {
       return {
         world: view,
         movementPlan: null,
         reachableTiles: [],
-        reason: "building_already_owned"
+        reason: "building_on_cooldown"
       };
     }
 
     const predictedWorld: PlayerWorldView = {
       ...view,
+      resources: {
+        ...view.resources,
+        [building.resourceKind]: view.resources[building.resourceKind] + building.income
+      },
       map: {
         ...view.map,
         tiles: view.map.tiles.map((item) =>
@@ -1659,7 +1666,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
                 ...item,
                 building: {
                   ...item.building,
-                  ownerPlayerId: hero.playerId
+                  lastHarvestDay: view.meta.day
                 }
               }
             : item
@@ -1813,8 +1820,8 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
       return { valid: false, reason: "building_not_visitable" };
     }
 
-    if (building.visitedHeroIds.includes(hero.id)) {
-      return { valid: false, reason: "building_already_visited" };
+    if (isBuildingOnCurrentDayCooldown(state.meta.day, building.lastUsedDay)) {
+      return { valid: false, reason: "building_on_cooldown" };
     }
 
     return { valid: true };
@@ -1834,8 +1841,8 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
       return { valid: false, reason: "building_not_claimable" };
     }
 
-    if (building.ownerPlayerId === hero.playerId) {
-      return { valid: false, reason: "building_already_owned" };
+    if (isBuildingOnCurrentDayCooldown(state.meta.day, building.lastHarvestDay)) {
+      return { valid: false, reason: "building_on_cooldown" };
     }
 
     return { valid: true };
@@ -1924,32 +1931,12 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
       ...hero,
       move: { ...hero.move, remaining: hero.move.total }
     }));
-    let nextResources = state.resources;
     const buildings = Object.fromEntries(
       Object.entries(state.buildings).map(([buildingId, building]) => [
         buildingId,
         refreshBuildingForNewDay(building)
       ])
     );
-    const productionEvents: WorldEvent[] = [];
-    for (const building of Object.values(buildings)) {
-      if (building.kind !== "resource_mine" || !building.ownerPlayerId) {
-        continue;
-      }
-
-      const producedResource = {
-        kind: building.resourceKind,
-        amount: building.income
-      } as const;
-      nextResources = grantResource(nextResources, building.ownerPlayerId, producedResource);
-      productionEvents.push({
-        type: "resource.produced",
-        playerId: building.ownerPlayerId,
-        buildingId: building.id,
-        buildingKind: building.kind,
-        resource: producedResource
-      });
-    }
     let neutralArmies = normalizeNeutralArmyCollection(state.neutralArmies);
     neutralArmies = Object.fromEntries(
       Object.entries(neutralArmies).map(([neutralArmyId, army]) => [
@@ -1967,7 +1954,7 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
           ...state.meta,
           day: state.meta.day + 1
         },
-        resources: nextResources
+        resources: state.resources
       },
       heroes,
       neutralArmies,
@@ -2001,7 +1988,7 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
           ...state.meta,
           day: state.meta.day + 1
         },
-        resources: nextResources
+        resources: state.resources
       },
       heroes,
       neutralArmies,
@@ -2009,7 +1996,7 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
     );
     return {
       state: nextState,
-      events: [{ type: "turn.advanced", day: nextState.meta.day }, ...productionEvents, ...neutralEvents]
+      events: [{ type: "turn.advanced", day: nextState.meta.day }, ...neutralEvents]
     };
   }
 
@@ -2131,7 +2118,8 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
         ...building,
         position: { ...building.position },
         cost: cloneResourceLedger(building.cost),
-        availableCount: 0
+        availableCount: 0,
+        lastUsedDay: state.meta.day
       }
     };
     const nextState = buildNextWorldState(
@@ -2176,7 +2164,7 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
         ...building,
         position: { ...building.position },
         bonus: cloneHeroStatBonus(building.bonus),
-        visitedHeroIds: [...building.visitedHeroIds, hero.id]
+        lastUsedDay: state.meta.day
       }
     };
     const nextState = buildNextWorldState(state, heroes, state.neutralArmies, buildings);
@@ -2209,10 +2197,22 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
         position: { ...building.position },
         resourceKind: building.resourceKind,
         income: building.income,
-        ownerPlayerId: hero.playerId
+        lastHarvestDay: state.meta.day
       }
     };
-    const nextState = buildNextWorldState(state, state.heroes, state.neutralArmies, buildings);
+    const harvestedResource = {
+      kind: building.resourceKind,
+      amount: building.income
+    } as const;
+    const nextState = buildNextWorldState(
+      {
+        ...state,
+        resources: grantResource(state.resources, hero.playerId, harvestedResource)
+      },
+      state.heroes,
+      state.neutralArmies,
+      buildings
+    );
 
     return {
       state: nextState,

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -225,14 +225,15 @@ export type MapBuildingConfig =
 
 export interface RecruitmentBuildingState extends RecruitmentBuildingConfig {
   availableCount: number;
+  lastUsedDay?: number;
 }
 
 export interface AttributeShrineBuildingState extends AttributeShrineBuildingConfig {
-  visitedHeroIds: string[];
+  lastUsedDay?: number;
 }
 
 export interface ResourceMineBuildingState extends ResourceMineBuildingConfig {
-  ownerPlayerId?: string;
+  lastHarvestDay?: number;
 }
 
 export type MapBuildingState =
@@ -248,6 +249,7 @@ export interface RecruitmentBuildingView {
   recruitCount: number;
   availableCount: number;
   cost: ResourceLedger;
+  lastUsedDay?: number;
 }
 
 export interface AttributeShrineBuildingView {
@@ -255,7 +257,7 @@ export interface AttributeShrineBuildingView {
   kind: "attribute_shrine";
   label: string;
   bonus: HeroStatBonus;
-  visitedHeroIds: string[];
+  lastUsedDay?: number;
 }
 
 export interface ResourceMineBuildingView {
@@ -264,7 +266,7 @@ export interface ResourceMineBuildingView {
   label: string;
   resourceKind: ResourceKind;
   income: number;
-  ownerPlayerId?: string;
+  lastHarvestDay?: number;
 }
 
 export type PlayerBuildingView =

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -261,7 +261,7 @@ test("hero progression helpers expose xp meter and attribute sources", () => {
           power: 0,
           knowledge: 0
         },
-        visitedHeroIds: ["hero-1"]
+        lastUsedDay: 1
       }
     },
     tiles: [
@@ -278,7 +278,7 @@ test("hero progression helpers expose xp meter and attribute sources", () => {
             power: 0,
             knowledge: 0
           },
-          visitedHeroIds: ["hero-1"]
+          lastUsedDay: 1
         }
       }),
       createTile(0, 1),
@@ -1260,7 +1260,7 @@ test("building interactions reject missing resources, exhausted stock, wrong bui
               power: 0,
               knowledge: 0
             },
-            visitedHeroIds: []
+            lastUsedDay: undefined
           }
         })
       ]
@@ -1278,7 +1278,7 @@ test("building interactions reject missing resources, exhausted stock, wrong bui
     buildingId: "shrine-1"
   }), {
     valid: false,
-    reason: "building_already_visited"
+    reason: "building_on_cooldown"
   });
 
   const claimedState = resolveWorldAction(
@@ -1333,7 +1333,7 @@ test("building interactions reject missing resources, exhausted stock, wrong bui
               power: 0,
               knowledge: 0
             },
-            visitedHeroIds: []
+            lastUsedDay: undefined
           }
         })
       ]
@@ -1351,7 +1351,7 @@ test("building interactions reject missing resources, exhausted stock, wrong bui
     buildingId: "mine-1"
   }), {
     valid: false,
-    reason: "building_already_owned"
+    reason: "building_on_cooldown"
   });
 });
 
@@ -1378,7 +1378,7 @@ test("resolveWorldAction visits an attribute shrine once, grants permanent stats
           power: 1,
           knowledge: 0
         },
-        visitedHeroIds: []
+        lastUsedDay: undefined
       }
     },
     tiles: [
@@ -1398,7 +1398,7 @@ test("resolveWorldAction visits an attribute shrine once, grants permanent stats
             power: 1,
             knowledge: 0
           },
-          visitedHeroIds: []
+          lastUsedDay: undefined
         }
       })
     ],
@@ -1415,7 +1415,7 @@ test("resolveWorldAction visits an attribute shrine once, grants permanent stats
 
   assert.equal(visitOutcome.state.heroes[0]?.stats.attack, 3);
   assert.equal(visitOutcome.state.heroes[0]?.stats.power, 2);
-  assert.deepEqual(visitOutcome.state.buildings["shrine-1"]?.visitedHeroIds, ["hero-1"]);
+  assert.equal(visitOutcome.state.buildings["shrine-1"]?.lastUsedDay, 1);
   assert.deepEqual(visitOutcome.events, [
     {
       type: "hero.visited",
@@ -1453,19 +1453,19 @@ test("resolveWorldAction visits an attribute shrine once, grants permanent stats
     buildingId: "shrine-1"
   }), {
     valid: false,
-    reason: "building_already_visited"
+    reason: "building_on_cooldown"
   });
 
   const nextDayOutcome = resolveWorldAction(visitOutcome.state, {
     type: "turn.endDay"
   });
 
-  assert.deepEqual(nextDayOutcome.state.buildings["shrine-1"]?.visitedHeroIds, ["hero-1"]);
+  assert.equal(nextDayOutcome.state.buildings["shrine-1"]?.lastUsedDay, 1);
   assert.equal(nextDayOutcome.state.heroes[0]?.stats.attack, 3);
   assert.equal(nextDayOutcome.state.heroes[0]?.stats.power, 2);
 });
 
-test("resolveWorldAction claims a resource mine and grants daily income on end day", () => {
+test("resolveWorldAction harvests a resource mine immediately and unlocks it again on the next day", () => {
   const hero = createHero({
     id: "hero-1",
     playerId: "player-1",
@@ -1522,9 +1522,10 @@ test("resolveWorldAction claims a resource mine and grants daily income on end d
   });
   assert.equal(predictedClaim.reason, undefined);
   assert.equal(
-    predictedClaim.world.map.tiles.find((tile) => tile.position.x === 1 && tile.position.y === 1)?.building?.ownerPlayerId,
-    "player-1"
+    predictedClaim.world.map.tiles.find((tile) => tile.position.x === 1 && tile.position.y === 1)?.building?.lastHarvestDay,
+    1
   );
+  assert.equal(predictedClaim.world.resources.wood, 2);
 
   const claimOutcome = resolveWorldAction(state, {
     type: "hero.claimMine",
@@ -1532,8 +1533,9 @@ test("resolveWorldAction claims a resource mine and grants daily income on end d
     buildingId: "mine-1"
   });
 
-  assert.equal(claimOutcome.state.buildings["mine-1"]?.ownerPlayerId, "player-1");
-  assert.equal(claimOutcome.state.map.tiles[3]?.building?.ownerPlayerId, "player-1");
+  assert.equal(claimOutcome.state.buildings["mine-1"]?.lastHarvestDay, 1);
+  assert.equal(claimOutcome.state.map.tiles[3]?.building?.lastHarvestDay, 1);
+  assert.equal(claimOutcome.state.resources["player-1"]?.wood, 2);
   assert.deepEqual(claimOutcome.events, [
     {
       type: "hero.claimedMine",
@@ -1552,7 +1554,7 @@ test("resolveWorldAction claims a resource mine and grants daily income on end d
     buildingId: "mine-1"
   }), {
     valid: false,
-    reason: "building_already_owned"
+    reason: "building_on_cooldown"
   });
 
   const nextDayOutcome = resolveWorldAction(claimOutcome.state, {
@@ -1565,16 +1567,6 @@ test("resolveWorldAction claims a resource mine and grants daily income on end d
     {
       type: "turn.advanced",
       day: 2
-    },
-    {
-      type: "resource.produced",
-      playerId: "player-1",
-      buildingId: "mine-1",
-      buildingKind: "resource_mine",
-      resource: {
-        kind: "wood",
-        amount: 2
-      }
     }
   ]);
 });


### PR DESCRIPTION
## Summary
- add recruitment post, attribute shrine, and resource mine interaction handling across shared world logic and server config
- update cocos client prediction, visuals, and timeline formatting for building interactions
- extend coverage for shared, server, and cocos client interaction flows

closes #23