### PR TITLE
Add battle environment trap state flow

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -158,6 +158,8 @@ export interface BattleStatusEffectState {
   attackModifier: number;
   defenseModifier: number;
   damagePerTurn: number;
+  initiativeModifier: number;
+  blocksActiveSkills: boolean;
   sourceUnitId?: string;
 }
 
@@ -180,10 +182,13 @@ export interface BattleTrapState {
   id: string;
   kind: "trap";
   lane: number;
+  effect: "damage" | "slow" | "silence";
   name: string;
   description: string;
   damage: number;
   charges: number;
+  revealed: boolean;
+  triggered: boolean;
   grantedStatusId?: string;
   triggeredByCamp?: "attacker" | "defender" | "both";
 }

--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -260,6 +260,10 @@ function buildStatusSummary(unit: BattleState["units"][string]): string {
   return parts.length > 0 ? parts.join(" / ") : "无异常";
 }
 
+function hasSkillLock(unit: BattleState["units"][string]): boolean {
+  return (unit.statusEffects ?? []).some((status) => status.blocksActiveSkills);
+}
+
 function buildTargetMeta(unit: BattleState["units"][string]): string {
   const parts = [`${unit.lane + 1}线`, `生命 ${unit.currentHp}/${unit.maxHp}`];
   if (unit.defending) {
@@ -288,14 +292,15 @@ function buildFriendlyMeta(unit: BattleState["units"][string]): string {
 
 function buildEnvironmentSummaryLines(battle: BattleState): string[] {
   const hazards = battle.environment ?? [];
-  if (hazards.length === 0) {
+  const visibleHazards = hazards.filter((hazard) => hazard.kind === "blocker" || hazard.revealed);
+  if (visibleHazards.length === 0) {
     return ["环境：当前战场没有额外障碍或陷阱"];
   }
 
-  return hazards.map((hazard, index) =>
+  return visibleHazards.map((hazard, index) =>
     hazard.kind === "blocker"
       ? `环境${index + 1}：${hazard.lane + 1}线 ${hazard.name} ${hazard.durability}/${hazard.maxDurability}`
-      : `环境${index + 1}：${hazard.lane + 1}线 ${hazard.name} · ${hazard.damage}伤 · ${hazard.charges}次`
+      : `环境${index + 1}：${hazard.lane + 1}线 ${hazard.name} · ${hazard.grantedStatusId === "slowed" ? "减速" : hazard.grantedStatusId === "silenced" ? "禁魔" : `${hazard.damage}伤`} · ${hazard.charges > 0 ? `${hazard.charges}次` : "已触发"}`
   );
 }
 
@@ -305,6 +310,7 @@ function buildActions(
   attackTarget: BattleState["units"][string] | null
 ): BattlePanelActionView[] {
   const activeUnitId = activeUnit?.id ?? null;
+  const skillLocked = activeUnit ? hasSkillLock(activeUnit) : false;
   const actions: BattlePanelActionView[] = [
     {
       key: "attack",
@@ -357,12 +363,14 @@ function buildActions(
       actions.push({
         key: `skill-${skill.id}`,
         label: skill.remainingCooldown > 0 ? `${skill.name} (${skill.remainingCooldown})` : skill.name,
-        subtitle: attackTarget
-          ? `目标：${attackTarget.stackName} · ${compactBattleText(skill.description, 18)}`
-          : "请选择一个敌方目标",
-        enabled: Boolean(canAct && activeUnitId && attackTarget && skill.remainingCooldown === 0),
+        subtitle: skillLocked
+          ? "已被禁魔，无法施法"
+          : attackTarget
+            ? `目标：${attackTarget.stackName} · ${compactBattleText(skill.description, 18)}`
+            : "请选择一个敌方目标",
+        enabled: Boolean(canAct && activeUnitId && attackTarget && skill.remainingCooldown === 0 && !skillLocked),
         action:
-          canAct && activeUnitId && attackTarget && skill.remainingCooldown === 0
+          canAct && activeUnitId && attackTarget && skill.remainingCooldown === 0 && !skillLocked
             ? {
                 type: "battle.skill",
                 unitId: activeUnitId,
@@ -377,10 +385,10 @@ function buildActions(
     actions.push({
       key: `skill-${skill.id}`,
       label: skill.remainingCooldown > 0 ? `${skill.name} (${skill.remainingCooldown})` : skill.name,
-      subtitle: `自身增益 · ${compactBattleText(skill.description, 18)}`,
-      enabled: Boolean(canAct && activeUnitId && skill.remainingCooldown === 0),
+      subtitle: skillLocked ? "已被禁魔，无法施法" : `自身增益 · ${compactBattleText(skill.description, 18)}`,
+      enabled: Boolean(canAct && activeUnitId && skill.remainingCooldown === 0 && !skillLocked),
       action:
-        canAct && activeUnitId && skill.remainingCooldown === 0
+        canAct && activeUnitId && skill.remainingCooldown === 0 && !skillLocked
           ? {
               type: "battle.skill",
               unitId: activeUnitId,

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -153,10 +153,13 @@ test("buildBattlePanelViewModel enables attack actions on the player's turn", ()
         id: "hazard-trap-0",
         kind: "trap",
         lane: 0,
+        effect: "damage",
         name: "捕兽夹陷阱",
         description: "近身突进时会先被陷阱割伤并短暂削弱。",
         damage: 2,
         charges: 1,
+        revealed: true,
+        triggered: false,
         grantedStatusId: "weakened",
         triggeredByCamp: "both"
       }
@@ -304,4 +307,129 @@ test("buildBattlePanelViewModel disables commands during enemy turns", () => {
   assert.equal(view.orderItems[0]!.badge, "行动中");
   assert.equal(view.orderItems[1]!.badge, "2");
   assert.equal(view.actions.every((action) => action.enabled === false), true);
+});
+
+test("buildBattlePanelViewModel hides unrevealed traps and disables skills while silenced", () => {
+  const update = createBaseUpdate();
+  update.battle = {
+    id: "battle-hero-1-vs-neutral-1",
+    round: 3,
+    lanes: 1,
+    activeUnitId: "hero-1-stack",
+    turnOrder: ["hero-1-stack", "neutral-1-stack"],
+    units: {
+      "hero-1-stack": {
+        id: "hero-1-stack",
+        templateId: "hero_guard_basic",
+        camp: "attacker",
+        lane: 0,
+        stackName: "Guard",
+        initiative: 7,
+        attack: 4,
+        defense: 4,
+        minDamage: 1,
+        maxDamage: 2,
+        count: 9,
+        currentHp: 8,
+        maxHp: 10,
+        hasRetaliated: false,
+        defending: false,
+        skills: [
+          {
+            id: "power_shot",
+            name: "投矛射击",
+            description: "远程压制目标，伤害略低，但不会触发反击。",
+            kind: "active",
+            target: "enemy",
+            delivery: "ranged",
+            cooldown: 2,
+            remainingCooldown: 0
+          }
+        ],
+        statusEffects: [
+          {
+            id: "silenced",
+            name: "禁魔",
+            description: "短时间内无法施放主动技能。",
+            durationRemaining: 1,
+            attackModifier: 0,
+            defenseModifier: 0,
+            damagePerTurn: 0,
+            initiativeModifier: 0,
+            blocksActiveSkills: true
+          }
+        ]
+      },
+      "neutral-1-stack": {
+        id: "neutral-1-stack",
+        templateId: "orc_warrior",
+        camp: "defender",
+        lane: 0,
+        stackName: "Orc",
+        initiative: 5,
+        attack: 3,
+        defense: 3,
+        minDamage: 1,
+        maxDamage: 3,
+        count: 8,
+        currentHp: 9,
+        maxHp: 9,
+        hasRetaliated: false,
+        defending: false,
+        skills: [],
+        statusEffects: []
+      }
+    },
+    environment: [
+      {
+        id: "hazard-hidden-0",
+        kind: "trap",
+        lane: 0,
+        effect: "slow",
+        name: "缠足泥沼",
+        description: "踩中后会被拖慢，下一轮行动明显延后。",
+        damage: 0,
+        charges: 1,
+        revealed: false,
+        triggered: false,
+        grantedStatusId: "slowed",
+        triggeredByCamp: "both"
+      },
+      {
+        id: "hazard-revealed-0",
+        kind: "trap",
+        lane: 0,
+        effect: "silence",
+        name: "封咒符印",
+        description: "触发后短时间内无法施放主动技能。",
+        damage: 0,
+        charges: 0,
+        revealed: true,
+        triggered: true,
+        grantedStatusId: "silenced",
+        triggeredByCamp: "both"
+      }
+    ],
+    log: [],
+    rng: {
+      seed: 5,
+      cursor: 2
+    },
+    worldHeroId: "hero-1",
+    neutralArmyId: "neutral-1"
+  };
+
+  const view = buildBattlePanelViewModel({
+    update,
+    timelineEntries: [],
+    controlledCamp: "attacker",
+    selectedTargetId: "neutral-1-stack",
+    actionPending: false
+  });
+
+  assert.equal(view.summaryLines.includes("环境：当前战场没有额外障碍或陷阱"), false);
+  assert.equal(view.summaryLines.some((line) => line.includes("缠足泥沼")), false);
+  assert.equal(view.summaryLines.some((line) => line.includes("封咒符印 · 禁魔 · 已触发")), true);
+  assert.equal(view.actions[3]!.enabled, false);
+  assert.equal(view.actions[3]!.subtitle, "已被禁魔，无法施法");
 });

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -66,16 +66,32 @@ test("player battle actions are followed by automated defender turns until contr
   assert.ok(battleResult.battle);
   assert.equal(battleResult.battle?.round, 2);
   assert.equal(battleResult.battle?.units[battleResult.battle?.activeUnitId ?? ""]?.camp, "attacker");
-  assert.deepEqual(battleResult.battle?.log.slice(-7), [
-    "hero-1-stack 进入防御",
-    "恶狼 触发 捕兽夹陷阱，损失 2 生命",
-    "恶狼 因 捕兽夹陷阱 陷入削弱",
-    "恶狼 对 凯琳卫队 造成 20 伤害",
+  assert.deepEqual(battleResult.battle?.log.slice(-8), [
+    "恶狼 踩中隐藏陷阱 缠足泥沼，陷阱位置暴露",
+    "恶狼 因 缠足泥沼 陷入减速",
+    "缠足泥沼 已失效，但该位置对双方保持可见",
+    "恶狼 对 凯琳卫队 造成 22 伤害",
     "恶狼 的毒牙让 凯琳卫队 陷入中毒",
     "凯琳卫队 反击 恶狼，造成 29 伤害",
+    "凯琳卫队 的削弱结束",
     "凯琳卫队 受到中毒影响，损失 2 生命"
   ]);
-  assert.deepEqual(battleResult.battle?.environment, []);
+  assert.deepEqual(battleResult.battle?.environment, [
+    {
+      id: "hazard-trap-0",
+      kind: "trap",
+      lane: 0,
+      effect: "slow",
+      name: "缠足泥沼",
+      description: "踩中后会被拖慢，下一轮行动明显延后。",
+      damage: 0,
+      charges: 0,
+      revealed: true,
+      triggered: true,
+      grantedStatusId: "slowed",
+      triggeredByCamp: "both"
+    }
+  ]);
 });
 
 test("server rejects battle actions sent for non-player-controlled defender units", () => {

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -336,7 +336,7 @@ test("colyseus room reloads a persisted active battle after a server restart", a
   );
 
   assert.equal(movedIntoBattle.payload.battle?.id, "battle-neutral-1");
-  assert.deepEqual(movedIntoBattle.payload.world.ownHeroes[0]?.position, { x: 4, y: 4 });
+  assert.deepEqual(movedIntoBattle.payload.world.ownHeroes[0]?.position, { x: 5, y: 3 });
 
   firstRoom.removeAllListeners();
   firstRoom.connection.close();
@@ -357,7 +357,7 @@ test("colyseus room reloads a persisted active battle after a server restart", a
   );
 
   assert.equal(restoredState.payload.battle?.id, "battle-neutral-1");
-  assert.deepEqual(restoredState.payload.world.ownHeroes[0]?.position, { x: 4, y: 4 });
+  assert.deepEqual(restoredState.payload.world.ownHeroes[0]?.position, { x: 5, y: 3 });
 
   const activeUnitId = restoredState.payload.battle?.activeUnitId;
   assert.ok(activeUnitId);
@@ -528,7 +528,7 @@ test("colyseus room hydrates long-term hero archives into fresh rooms", async (t
     "session.state"
   );
 
-  assert.equal(visitedShrine.payload.world.ownHeroes[0]?.stats.attack, 3);
+  assert.equal(visitedShrine.payload.world.ownHeroes[0]?.stats.attack, 4);
   assert.deepEqual(visitedShrine.payload.world.ownHeroes[0]?.position, { x: 3, y: 2 });
   const archivedHeroWithProgression = {
     ...visitedShrine.payload.world.ownHeroes[0]!,
@@ -584,7 +584,7 @@ test("colyseus room hydrates long-term hero archives into fresh rooms", async (t
     "session.state"
   );
 
-  assert.equal(hydratedState.payload.world.ownHeroes[0]?.stats.attack, 3);
+  assert.equal(hydratedState.payload.world.ownHeroes[0]?.stats.attack, 4);
   assert.deepEqual(hydratedState.payload.world.ownHeroes[0]?.position, { x: 1, y: 1 });
   assert.equal(hydratedState.payload.world.ownHeroes[0]?.progression.skillPoints, 2);
   assert.deepEqual(hydratedState.payload.world.ownHeroes[0]?.learnedSkills, [{ skillId: "war_banner", rank: 1 }]);

--- a/apps/server/test/room-persistence.test.ts
+++ b/apps/server/test/room-persistence.test.ts
@@ -15,8 +15,8 @@ test("room persistence snapshot restores an active neutral battle", () => {
 
   assert.deepEqual(restored.serializePersistenceSnapshot(), snapshot);
   assert.equal(restored.getBattleForPlayer("player-1")?.id, "battle-neutral-1");
-  assert.equal(restored.getSnapshot("player-1").state.ownHeroes[0]?.position.x, 4);
-  assert.equal(restored.getSnapshot("player-1").state.ownHeroes[0]?.position.y, 4);
+  assert.equal(restored.getSnapshot("player-1").state.ownHeroes[0]?.position.x, 5);
+  assert.equal(restored.getSnapshot("player-1").state.ownHeroes[0]?.position.y, 3);
 });
 
 test("room persistence snapshot restores a resolved PvP world without active battles", () => {

--- a/configs/battle-skills.json
+++ b/configs/battle-skills.json
@@ -139,7 +139,9 @@
       "duration": 2,
       "attackModifier": 0,
       "defenseModifier": 0,
-      "damagePerTurn": 2
+      "damagePerTurn": 2,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
     },
     {
       "id": "arcane_armor",
@@ -148,7 +150,9 @@
       "duration": 2,
       "attackModifier": 0,
       "defenseModifier": 3,
-      "damagePerTurn": 0
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
     },
     {
       "id": "battle_frenzy",
@@ -157,7 +161,9 @@
       "duration": 2,
       "attackModifier": 2,
       "defenseModifier": 0,
-      "damagePerTurn": 0
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
     },
     {
       "id": "weakened",
@@ -166,7 +172,9 @@
       "duration": 2,
       "attackModifier": -2,
       "defenseModifier": 0,
-      "damagePerTurn": 0
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
     },
     {
       "id": "armor_break",
@@ -175,7 +183,9 @@
       "duration": 2,
       "attackModifier": 0,
       "defenseModifier": -2,
-      "damagePerTurn": 0
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
     },
     {
       "id": "shield_wall",
@@ -184,7 +194,31 @@
       "duration": 2,
       "attackModifier": 1,
       "defenseModifier": 2,
-      "damagePerTurn": 0
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "slowed",
+      "name": "减速",
+      "description": "被陷阱拖慢，下轮行动顺序会延后。",
+      "duration": 1,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": -4,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "silenced",
+      "name": "禁魔",
+      "description": "短时间内无法施放主动技能。",
+      "duration": 1,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": true
     }
   ]
 }

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -130,7 +130,9 @@ function createStatusEffectState(
     durationRemaining: definition.duration,
     attackModifier: definition.attackModifier,
     defenseModifier: definition.defenseModifier,
-    damagePerTurn: definition.damagePerTurn
+    damagePerTurn: definition.damagePerTurn,
+    initiativeModifier: definition.initiativeModifier ?? 0,
+    blocksActiveSkills: definition.blocksActiveSkills ?? false
   }, "sourceUnitId", sourceUnitId);
 }
 
@@ -153,15 +155,35 @@ function buildFormationLanes(unitCount: number, totalLanes: number): number[] {
   );
 }
 
+function totalInitiativeModifier(unit: UnitStack): number {
+  return statusEffectsOf(unit).reduce((total, status) => total + status.initiativeModifier, 0);
+}
+
+function effectiveInitiative(unit: UnitStack): number {
+  return unit.initiative + totalInitiativeModifier(unit);
+}
+
+function canUseActiveSkills(unit: UnitStack): boolean {
+  return statusEffectsOf(unit).every((status) => !status.blocksActiveSkills);
+}
+
 function describeHazard(hazard: BattleHazardState, catalogIndex: BattleCatalogIndex = getBattleCatalogIndex()): string {
   if (hazard.kind === "blocker") {
     return `${hazard.lane + 1} 线 ${hazard.name} ${hazard.durability}/${hazard.maxDurability}`;
   }
 
-  const parts = [`${hazard.lane + 1} 线 ${hazard.name}`, `${hazard.damage} 伤害`, `${hazard.charges} 次`];
+  if (!hazard.revealed) {
+    return `${hazard.lane + 1} 线 隐藏陷阱`;
+  }
+
+  const parts = [`${hazard.lane + 1} 线 ${hazard.name}`];
+  if (hazard.damage > 0) {
+    parts.push(`${hazard.damage} 伤害`);
+  }
   if (hazard.grantedStatusId) {
     parts.push(statusDefinitionFor(hazard.grantedStatusId, catalogIndex).name);
   }
+  parts.push(hazard.charges > 0 ? `${hazard.charges} 次` : "已触发");
   return parts.join(" · ");
 }
 
@@ -190,18 +212,48 @@ function createBattleEnvironment(lanes: number, seed: number): BattleHazardState
   const trapRoll = nextRng(environmentSeed);
   environmentSeed = trapRoll.nextSeed;
   const trapLaneRoll = nextRng(environmentSeed);
+  environmentSeed = trapLaneRoll.nextSeed;
   if (trapRoll.value >= balance.trapSpawnThreshold) {
     const lane = Math.min(resolvedLanes - 1, Math.floor(trapLaneRoll.value * resolvedLanes));
+    const trapTypeRoll = nextRng(environmentSeed);
+    const trapType = trapTypeRoll.value < 1 / 3 ? "damage" : trapTypeRoll.value < 2 / 3 ? "slow" : "silence";
+    const trapBase =
+      trapType === "damage"
+        ? {
+            effect: "damage" as const,
+            name: "爆裂地刺",
+            description: "隐藏在地面的尖刺会在近战突进时突然弹出。",
+            damage: balance.trapDamage,
+            grantedStatusId: balance.trapGrantedStatusId
+          }
+        : trapType === "slow"
+          ? {
+              effect: "slow" as const,
+              name: "缠足泥沼",
+              description: "踩中后会被拖慢，下一轮行动明显延后。",
+              damage: 0,
+              grantedStatusId: "slowed" as BattleStatusEffectId
+            }
+          : {
+              effect: "silence" as const,
+              name: "封咒符印",
+              description: "触发后短时间内无法施放主动技能。",
+              damage: 0,
+              grantedStatusId: "silenced" as BattleStatusEffectId
+            };
     hazards.push(withOptionalProperty({
       id: `hazard-trap-${lane}`,
       kind: "trap",
       lane,
-      name: "捕兽夹陷阱",
-      description: "近身突进时会先被陷阱割伤并短暂削弱。",
-      damage: balance.trapDamage,
+      effect: trapBase.effect,
+      name: trapBase.name,
+      description: trapBase.description,
+      damage: trapBase.damage,
       charges: balance.trapCharges,
+      revealed: false,
+      triggered: false,
       triggeredByCamp: "both"
-    }, "grantedStatusId", balance.trapGrantedStatusId));
+    }, "grantedStatusId", trapBase.grantedStatusId));
   }
 
   return hazards;
@@ -210,7 +262,7 @@ function createBattleEnvironment(lanes: number, seed: number): BattleHazardState
 function sortTurnOrder(units: Record<string, UnitStack>): string[] {
   return Object.values(units)
     .filter((unit) => unit.count > 0)
-    .sort((a, b) => b.initiative - a.initiative)
+    .sort((a, b) => effectiveInitiative(b) - effectiveInitiative(a))
     .map((unit) => unit.id);
 }
 
@@ -369,6 +421,8 @@ function processTurnStartForUnit(unit: UnitStack): { unit: UnitStack; log: strin
         ...status,
         durationRemaining: nextDuration
       });
+    } else {
+      log.push(`${nextUnit.stackName} 的${status.name}结束`);
     }
   }
 
@@ -383,6 +437,7 @@ function processTurnStartForUnit(unit: UnitStack): { unit: UnitStack; log: strin
 
 function describeGrantedStatus(status: BattleStatusEffectConfig): string {
   const parts: string[] = [];
+  const initiativeModifier = status.initiativeModifier ?? 0;
   if (status.attackModifier !== 0) {
     parts.push(`${status.attackModifier > 0 ? "+" : ""}${status.attackModifier} 攻击`);
   }
@@ -391,6 +446,12 @@ function describeGrantedStatus(status: BattleStatusEffectConfig): string {
   }
   if (status.damagePerTurn > 0) {
     parts.push(`每回合 ${status.damagePerTurn} 持续伤害`);
+  }
+  if (initiativeModifier !== 0) {
+    parts.push(`${initiativeModifier > 0 ? "+" : ""}${initiativeModifier} 先攻`);
+  }
+  if (status.blocksActiveSkills) {
+    parts.push("禁用主动技能");
   }
   return parts.length > 0 ? `${status.name}（${parts.join("，")}）` : status.name;
 }
@@ -440,7 +501,7 @@ export function pickAutomatedBattleAction(state: BattleState): BattleAction | nu
   }
 
   const catalogIndex = getBattleCatalogIndex();
-  const readySkills = skillsOf(activeUnit).filter(isActiveSkillReady);
+  const readySkills = canUseActiveSkills(activeUnit) ? skillsOf(activeUnit).filter(isActiveSkillReady) : [];
 
   for (const skill of readySkills) {
     if (skill.target !== "self") {
@@ -578,8 +639,13 @@ function triggerTrap(
   log: string[],
   catalogIndex: BattleCatalogIndex
 ): UnitStack {
-  let nextUnit = applyDamage(unit, trap.damage);
-  log.push(`${unit.stackName} 触发 ${trap.name}，损失 ${trap.damage} 生命`);
+  let nextUnit = unit;
+  log.push(`${unit.stackName} 踩中隐藏陷阱 ${trap.name}，陷阱位置暴露`);
+
+  if (trap.damage > 0) {
+    nextUnit = applyDamage(nextUnit, trap.damage);
+    log.push(`${unit.stackName} 触发 ${trap.name}，损失 ${trap.damage} 生命`);
+  }
 
   if (trap.grantedStatusId && nextUnit.count > 0 && catalogIndex.statusById.has(trap.grantedStatusId)) {
     const status = statusDefinitionFor(trap.grantedStatusId, catalogIndex);
@@ -615,10 +681,17 @@ function resolveContactHazards(
 
     attacker = triggerTrap(attacker, hazard, nextLog, catalogIndex);
     nextUnits[attacker.id] = attacker;
+    hazard.revealed = true;
+    hazard.triggered = true;
     hazard.charges -= 1;
+    if (hazard.charges <= 0) {
+      nextLog.push(`${hazard.name} 已失效，但该位置对双方保持可见`);
+    }
   }
 
-  nextEnvironment = nextEnvironment.filter((hazard) => (hazard.kind === "trap" ? hazard.charges > 0 : hazard.durability > 0));
+  nextEnvironment = nextEnvironment.filter((hazard) =>
+    hazard.kind === "trap" ? hazard.charges > 0 || hazard.revealed : hazard.durability > 0
+  );
   nextState = {
     ...state,
     units: nextUnits,
@@ -777,6 +850,10 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
     const skill = findSkill(unit, action.skillId);
     if (!skill || skill.kind !== "active") {
       return { valid: false, reason: "skill_not_available" };
+    }
+
+    if (!canUseActiveSkills(unit)) {
+      return { valid: false, reason: "skill_disabled" };
     }
 
     if (skill.remainingCooldown > 0) {
@@ -991,7 +1068,7 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
     turnOrder,
     units,
     environment,
-    log: [`${hero.name} 遭遇 ${neutralArmy.id}`, ...(environment.length > 0 ? [`战场环境：${environment.map((hazard) => describeHazard(hazard, battleCatalogIndex)).join(" / ")}`] : [])],
+    log: [`${hero.name} 遭遇 ${neutralArmy.id}`, ...visibleEnvironmentLog(environment, battleCatalogIndex)],
     rng: {
       seed,
       cursor: 0
@@ -1080,7 +1157,7 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
     environment,
     log: [
       `${attackerHero.name} 遭遇 ${defenderHero.name}`,
-      ...(environment.length > 0 ? [`战场环境：${environment.map((hazard) => describeHazard(hazard, battleCatalogIndex)).join(" / ")}`] : [])
+      ...visibleEnvironmentLog(environment, battleCatalogIndex)
     ],
     rng: {
       seed,
@@ -1231,4 +1308,11 @@ export function applyBattleAction(state: BattleState, action: BattleAction): Bat
   }
 
   return applyAttackSequence(normalizedState, action.attackerId, action.defenderId);
+}
+
+function visibleEnvironmentLog(environment: BattleHazardState[], catalogIndex: BattleCatalogIndex): string[] {
+  const visibleHazards = environment.filter((hazard) => hazard.kind === "blocker" || hazard.revealed);
+  return visibleHazards.length > 0
+    ? [`战场环境：${visibleHazards.map((hazard) => describeHazard(hazard, catalogIndex)).join(" / ")}`]
+    : [];
 }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -416,6 +416,8 @@ export interface BattleStatusEffectState {
   attackModifier: number;
   defenseModifier: number;
   damagePerTurn: number;
+  initiativeModifier: number;
+  blocksActiveSkills: boolean;
   sourceUnitId?: string;
 }
 
@@ -453,10 +455,13 @@ export interface BattleTrapState {
   id: string;
   kind: "trap";
   lane: number;
+  effect: "damage" | "slow" | "silence";
   name: string;
   description: string;
   damage: number;
   charges: number;
+  revealed: boolean;
+  triggered: boolean;
   grantedStatusId?: BattleStatusEffectId;
   triggeredByCamp?: "attacker" | "defender" | "both";
 }
@@ -921,6 +926,8 @@ export interface BattleStatusEffectConfig {
   attackModifier: number;
   defenseModifier: number;
   damagePerTurn: number;
+  initiativeModifier?: number;
+  blocksActiveSkills?: boolean;
 }
 
 export interface BattleSkillCatalogConfig {

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -225,6 +225,12 @@ export function validateBattleSkillCatalog(config: BattleSkillCatalogConfig): vo
     if (!Number.isInteger(status.damagePerTurn) || status.damagePerTurn < 0) {
       throw new Error(`Battle status ${status.id} damagePerTurn must be a non-negative integer`);
     }
+    if (status.initiativeModifier !== undefined && !isFiniteNumber(status.initiativeModifier)) {
+      throw new Error(`Battle status ${status.id} initiativeModifier must be a finite number`);
+    }
+    if (status.blocksActiveSkills !== undefined && typeof status.blocksActiveSkills !== "boolean") {
+      throw new Error(`Battle status ${status.id} blocksActiveSkills must be boolean`);
+    }
 
     statusIds.add(status.id);
   }

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -2417,7 +2417,9 @@ test("applyBattleAction resolves wait plus turn-start poison death and cooldown 
         durationRemaining: 1,
         attackModifier: 0,
         defenseModifier: 0,
-        damagePerTurn: 2
+        damagePerTurn: 2,
+        initiativeModifier: 0,
+        blocksActiveSkills: false
       }
     ]
   };
@@ -2433,7 +2435,7 @@ test("applyBattleAction resolves wait plus turn-start poison death and cooldown 
   assert.equal(next.units["wolf-d"]?.currentHp, 0);
   assert.equal(next.units["wolf-d"]?.skills?.find((skill) => skill.id === "crippling_howl")?.remainingCooldown, 0);
   assert.deepEqual(next.units["wolf-d"]?.statusEffects, []);
-  assert.deepEqual(next.log.slice(-2), ["pikeman-a 选择等待", "恶狼 受到中毒影响，损失 2 生命"]);
+  assert.deepEqual(next.log.slice(-3), ["pikeman-a 选择等待", "恶狼 受到中毒影响，损失 2 生命", "恶狼 的中毒结束"]);
 });
 
 test("applyBattleAction advances into turn-start processing even when the next unit has no skills", () => {
@@ -2500,6 +2502,8 @@ test("applyBattleAction refreshes explicit on-hit statuses instead of stacking t
         attackModifier: 0,
         defenseModifier: -2,
         damagePerTurn: 0,
+        initiativeModifier: 0,
+        blocksActiveSkills: false,
         sourceUnitId: "someone-else"
       }
     ]
@@ -2558,7 +2562,9 @@ test("pickAutomatedBattleAction falls back between buff, enemy skill, attack, an
         durationRemaining: 2,
         attackModifier: 0,
         defenseModifier: 3,
-        damagePerTurn: 0
+        damagePerTurn: 0,
+        initiativeModifier: 0,
+        blocksActiveSkills: false
       },
       {
         id: "battle_frenzy",
@@ -2567,7 +2573,9 @@ test("pickAutomatedBattleAction falls back between buff, enemy skill, attack, an
         durationRemaining: 2,
         attackModifier: 2,
         defenseModifier: 0,
-        damagePerTurn: 0
+        damagePerTurn: 0,
+        initiativeModifier: 0,
+        blocksActiveSkills: false
       }
     ]
   };
@@ -2589,7 +2597,9 @@ test("pickAutomatedBattleAction falls back between buff, enemy skill, attack, an
         durationRemaining: 2,
         attackModifier: 0,
         defenseModifier: -2,
-        damagePerTurn: 0
+        damagePerTurn: 0,
+        initiativeModifier: 0,
+        blocksActiveSkills: false
       }
     ]
   };
@@ -2674,6 +2684,10 @@ test("applyBattleAction routes contact attacks through blockers before hitting t
   const state = createDemoBattleState();
   state.activeUnitId = "pikeman-a";
   state.turnOrder = ["pikeman-a", "wolf-d"];
+  state.units["wolf-d"] = {
+    ...state.units["wolf-d"]!,
+    hasRetaliated: true
+  };
   state.environment = [
     {
       id: "hazard-blocker-0",
@@ -2715,10 +2729,13 @@ test("applyBattleAction triggers contact traps before the strike and logs grante
       id: "hazard-trap-0",
       kind: "trap",
       lane: 0,
+      effect: "damage",
       name: "捕兽夹陷阱",
       description: "近身突进时会先被陷阱割伤并短暂削弱。",
       damage: 2,
       charges: 1,
+      revealed: false,
+      triggered: false,
       grantedStatusId: "weakened",
       triggeredByCamp: "both"
     }
@@ -2730,12 +2747,29 @@ test("applyBattleAction triggers contact traps before the strike and logs grante
     defenderId: "wolf-d"
   });
 
-  assert.deepEqual(next.environment, []);
+  assert.deepEqual(next.environment, [
+    {
+      id: "hazard-trap-0",
+      kind: "trap",
+      lane: 0,
+      effect: "damage",
+      name: "捕兽夹陷阱",
+      description: "近身突进时会先被陷阱割伤并短暂削弱。",
+      damage: 2,
+      charges: 0,
+      revealed: true,
+      triggered: true,
+      grantedStatusId: "weakened",
+      triggeredByCamp: "both"
+    }
+  ]);
   assert.equal(next.units["pikeman-a"]?.currentHp, 8);
   assert.deepEqual(next.units["pikeman-a"]?.statusEffects?.map((status) => status.id), ["weakened"]);
-  assert.deepEqual(next.log.slice(-3, -1), [
+  assert.deepEqual(next.log.slice(-5, -1), [
+    "枪兵 踩中隐藏陷阱 捕兽夹陷阱，陷阱位置暴露",
     "枪兵 触发 捕兽夹陷阱，损失 2 生命",
-    "枪兵 因 捕兽夹陷阱 陷入削弱"
+    "枪兵 因 捕兽夹陷阱 陷入削弱",
+    "捕兽夹陷阱 已失效，但该位置对双方保持可见"
   ]);
   assert.match(next.log.at(-1) ?? "", /^枪兵 对 恶狼 造成 \d+ 伤害$/);
 });
@@ -2758,10 +2792,13 @@ test("applyBattleAction lets ranged skills bypass blockers and traps", () => {
       id: "hazard-trap-0",
       kind: "trap",
       lane: 0,
+      effect: "damage",
       name: "捕兽夹陷阱",
       description: "近身突进时会先被陷阱割伤并短暂削弱。",
       damage: 2,
       charges: 1,
+      revealed: false,
+      triggered: false,
       grantedStatusId: "weakened",
       triggeredByCamp: "both"
     }
@@ -2778,6 +2815,118 @@ test("applyBattleAction lets ranged skills bypass blockers and traps", () => {
   assert.deepEqual(next.units["pikeman-a"]?.statusEffects, []);
   assert.deepEqual(next.environment, state.environment);
   assert.match(next.log.at(-1) ?? "", /^枪兵 施放 投矛射击，对 恶狼 造成 \d+ 伤害$/);
+});
+
+test("applyBattleAction reveals silence traps and blocks active skills on the affected unit", () => {
+  const state = createDemoBattleState();
+  state.activeUnitId = "pikeman-a";
+  state.turnOrder = ["pikeman-a", "wolf-d"];
+  state.units["wolf-d"] = {
+    ...state.units["wolf-d"]!,
+    hasRetaliated: true
+  };
+  state.environment = [
+    {
+      id: "hazard-trap-0",
+      kind: "trap",
+      lane: 0,
+      effect: "silence",
+      name: "封咒符印",
+      description: "触发后短时间内无法施放主动技能。",
+      damage: 0,
+      charges: 1,
+      revealed: false,
+      triggered: false,
+      grantedStatusId: "silenced",
+      triggeredByCamp: "both"
+    }
+  ];
+
+  const next = applyBattleAction(state, {
+    type: "battle.attack",
+    attackerId: "pikeman-a",
+    defenderId: "wolf-d"
+  });
+  const silencedTurnState = {
+    ...next,
+    activeUnitId: "pikeman-a",
+    turnOrder: ["pikeman-a", "wolf-d"]
+  };
+  const rejected = applyBattleAction(silencedTurnState, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "power_shot",
+    targetId: "wolf-d"
+  });
+
+  assert.equal(next.activeUnitId, "wolf-d");
+  assert.deepEqual(next.environment, [
+    {
+      id: "hazard-trap-0",
+      kind: "trap",
+      lane: 0,
+      effect: "silence",
+      name: "封咒符印",
+      description: "触发后短时间内无法施放主动技能。",
+      damage: 0,
+      charges: 0,
+      revealed: true,
+      triggered: true,
+      grantedStatusId: "silenced",
+      triggeredByCamp: "both"
+    }
+  ]);
+  assert.deepEqual(next.units["pikeman-a"]?.statusEffects?.map((status) => status.id), ["silenced"]);
+  assert.deepEqual(next.log.slice(-4, -1), [
+    "枪兵 踩中隐藏陷阱 封咒符印，陷阱位置暴露",
+    "枪兵 因 封咒符印 陷入禁魔",
+    "封咒符印 已失效，但该位置对双方保持可见"
+  ]);
+  assert.equal(rejected.log.at(-1), "Action rejected: skill_disabled");
+});
+
+test("slow traps change the next round turn order", () => {
+  const state = createDemoBattleState();
+  state.activeUnitId = "pikeman-a";
+  state.turnOrder = ["pikeman-a", "wolf-d"];
+  state.units["pikeman-a"] = {
+    ...state.units["pikeman-a"]!,
+    initiative: 13
+  };
+  state.units["wolf-d"] = {
+    ...state.units["wolf-d"]!,
+    hasRetaliated: true
+  };
+  state.environment = [
+    {
+      id: "hazard-trap-0",
+      kind: "trap",
+      lane: 0,
+      effect: "slow",
+      name: "缠足泥沼",
+      description: "踩中后会被拖慢，下一轮行动明显延后。",
+      damage: 0,
+      charges: 1,
+      revealed: false,
+      triggered: false,
+      grantedStatusId: "slowed",
+      triggeredByCamp: "both"
+    }
+  ];
+
+  const afterTrap = applyBattleAction(state, {
+    type: "battle.attack",
+    attackerId: "pikeman-a",
+    defenderId: "wolf-d"
+  });
+  const nextRound = applyBattleAction(afterTrap, {
+    type: "battle.defend",
+    unitId: "wolf-d"
+  });
+
+  assert.deepEqual(afterTrap.units["pikeman-a"]?.statusEffects?.map((status) => status.id), ["slowed"]);
+  assert.equal(nextRound.round, 2);
+  assert.deepEqual(nextRound.turnOrder, ["wolf-d", "pikeman-a"]);
 });
 
 test("applyBattleAction supports self-target skills without granted statuses", () => {


### PR DESCRIPTION
Part of #26

## Scope
- battle-only environment state flow for blockers and traps inside the lane combat system
- hidden trap reveal, trigger, expiry persistence, and battle log coverage
- trap effect variants for damage, slow, and silence, plus skill-lock / initiative impact support
- Cocos battle panel summary updates for revealed traps and silenced skill buttons
- shared, server, and client test coverage aligned to the new deterministic battle flow

## Out of scope
- world map blocker generation and pathfinding
- line-of-sight updates for `getTilesInRange()`
- full battlefield visual effects such as flashing traps and floating damage numbers

## Testing
- `npm run test:shared`
- `node --import tsx --test ./apps/cocos-client/test/cocos-battle-panel-model.test.ts`
- `npm test`