### PR TITLE
Implement neutral army AI pathfinding

### DIFF
--- a/configs/phase1-map-objects.json
+++ b/configs/phase1-map-objects.json
@@ -18,9 +18,9 @@
       ],
       "behavior": {
         "mode": "patrol",
-        "patrolRadius": 2,
-        "detectionRadius": 3,
-        "chaseDistance": 6,
+        "patrolRadius": 4,
+        "detectionRadius": 5,
+        "chaseDistance": 10,
         "speed": 2
       }
     }

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -176,7 +176,7 @@ function cloneNeutralBehaviorState(behavior: NeutralArmyBehaviorState | undefine
     chaseDistance,
     speed,
     state: nextState,
-    targetHeroId: behavior?.targetHeroId
+    ...(behavior?.targetHeroId ? { targetHeroId: behavior.targetHeroId } : {})
   };
 }
 
@@ -187,7 +187,7 @@ function resetNeutralBehaviorState(behavior: NeutralArmyBehaviorState | undefine
 
   const clone = cloneNeutralBehaviorState(behavior);
   clone.state = clone.mode === "patrol" && clone.patrolPath.length > 0 ? "patrol" : "return";
-  clone.targetHeroId = undefined;
+  delete clone.targetHeroId;
   return clone;
 }
 
@@ -719,11 +719,25 @@ function fallbackNeutralStep(
   destination: Vec2,
   targetHeroId?: string
 ): Vec2 | undefined {
+  const availableExitCount = (position: Vec2): number =>
+    getNeighbors(state.map, position).filter((neighbor) => {
+      if (samePosition(neighbor, from)) {
+        return true;
+      }
+
+      return !isBlockedForNeutral(state, neutralArmyId, neighbor, destination, targetHeroId);
+    }).length;
+
   const candidates = getNeighbors(state.map, from)
     .filter((neighbor) => !isBlockedForNeutral(state, neutralArmyId, neighbor, destination, targetHeroId))
     .sort((left, right) => {
       const delta = distance(left, destination) - distance(right, destination);
-      return delta !== 0 ? delta : tileKey(left).localeCompare(tileKey(right));
+      if (delta !== 0) {
+        return delta;
+      }
+
+      const exitDelta = availableExitCount(right) - availableExitCount(left);
+      return exitDelta !== 0 ? exitDelta : tileKey(left).localeCompare(tileKey(right));
     });
   return candidates[0];
 }
@@ -976,7 +990,11 @@ function advancePatrol(
     }
 
     const steps = Math.min(stepsRemaining, path.length - 1);
-    currentPosition = path[steps];
+    const nextPosition = path[steps];
+    if (!nextPosition) {
+      break;
+    }
+    currentPosition = nextPosition;
     stepsRemaining -= steps;
     moved = moved || steps > 0;
     if (samePosition(currentPosition, target)) {
@@ -1041,6 +1059,15 @@ function resolveNeutralArmyTurn(
 
     const nextIndex = Math.min(speed, chaseTarget.path.length - 1);
     const nextPosition = chaseTarget.path[nextIndex];
+    if (!nextPosition) {
+      return {
+        army: {
+          ...neutralArmy,
+          behavior: cloneNeutralBehaviorState(behavior)
+        },
+        events: []
+      };
+    }
     const movement = moveNeutralArmy(neutralArmy, nextPosition, "chase", behavior, chaseTarget.heroId);
     return {
       army: movement.army,
@@ -1050,7 +1077,7 @@ function resolveNeutralArmyTurn(
 
   if (behavior.state === "chase") {
     behavior.state = "return";
-    behavior.targetHeroId = undefined;
+    delete behavior.targetHeroId;
     behaviorChanged = true;
   }
 
@@ -1939,13 +1966,16 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
     );
     let neutralArmies = normalizeNeutralArmyCollection(state.neutralArmies);
     neutralArmies = Object.fromEntries(
-      Object.entries(neutralArmies).map(([neutralArmyId, army]) => [
-        neutralArmyId,
-        {
-          ...army,
-          behavior: resetNeutralBehaviorState(army.behavior)
-        }
-      ])
+      Object.entries(neutralArmies).map(([neutralArmyId, army]) => {
+        const nextBehavior = resetNeutralBehaviorState(army.behavior);
+        return [
+          neutralArmyId,
+          {
+            ...army,
+            ...(nextBehavior ? { behavior: nextBehavior } : {})
+          }
+        ];
+      })
     );
     let workingState = buildNextWorldState(
       {

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1635,6 +1635,66 @@ test("resolveWorldAction advances patrolling neutral armies by one tile on end d
   assert.equal(outcome.state.neutralArmies["neutral-1"]?.behavior?.patrolIndex, 1);
 });
 
+test("resolveWorldAction keeps patrol movement deterministic across days", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 0 }
+  });
+  const initialState = createWorldState({
+    width: 5,
+    height: 3,
+    heroes: [hero],
+    neutralArmies: {
+      "neutral-1": {
+        id: "neutral-1",
+        position: { x: 2, y: 1 },
+        origin: { x: 2, y: 1 },
+        reward: { kind: "gold", amount: 300 },
+        stacks: [{ templateId: "wolf_pack", count: 8 }],
+        behavior: {
+          mode: "patrol",
+          patrolPath: [{ x: 1, y: 1 }, { x: 3, y: 1 }],
+          patrolIndex: 0,
+          detectionRadius: 0,
+          chaseDistance: 2,
+          patrolRadius: 0,
+          speed: 1,
+          state: "patrol"
+        }
+      }
+    },
+    tiles: [
+      createTile(0, 0, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(1, 0),
+      createTile(2, 0),
+      createTile(3, 0),
+      createTile(4, 0),
+      createTile(0, 1),
+      createTile(1, 1),
+      createTile(2, 1, { occupant: { kind: "neutral", refId: "neutral-1" } }),
+      createTile(3, 1),
+      createTile(4, 1),
+      createTile(0, 2),
+      createTile(1, 2),
+      createTile(2, 2),
+      createTile(3, 2),
+      createTile(4, 2)
+    ]
+  });
+
+  const dayTwo = resolveWorldAction(initialState, { type: "turn.endDay" });
+  const dayThree = resolveWorldAction(dayTwo.state, { type: "turn.endDay" });
+  const dayFour = resolveWorldAction(dayThree.state, { type: "turn.endDay" });
+  const dayFive = resolveWorldAction(dayFour.state, { type: "turn.endDay" });
+
+  assert.deepEqual(dayTwo.state.neutralArmies["neutral-1"]?.position, { x: 1, y: 1 });
+  assert.deepEqual(dayThree.state.neutralArmies["neutral-1"]?.position, { x: 2, y: 1 });
+  assert.deepEqual(dayFour.state.neutralArmies["neutral-1"]?.position, { x: 3, y: 1 });
+  assert.deepEqual(dayFive.state.neutralArmies["neutral-1"]?.position, { x: 2, y: 1 });
+});
+
 test("resolveWorldAction can start a neutral-initiated battle on end day", () => {
   const hero = createHero({
     id: "hero-1",
@@ -1693,6 +1753,273 @@ test("resolveWorldAction can start a neutral-initiated battle on end day", () =>
     }
   ]);
   assert.deepEqual(outcome.state.neutralArmies["neutral-1"]?.position, { x: 2, y: 0 });
+});
+
+test("resolveWorldAction switches neutral armies from chase back to return when heroes leave range", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 2, y: 0 }
+  });
+  const state = createWorldState({
+    width: 6,
+    height: 3,
+    heroes: [hero],
+    neutralArmies: {
+      "neutral-1": {
+        id: "neutral-1",
+        position: { x: 5, y: 0 },
+        origin: { x: 5, y: 0 },
+        reward: { kind: "gold", amount: 300 },
+        stacks: [{ templateId: "wolf_pack", count: 8 }],
+        behavior: {
+          mode: "guard",
+          patrolPath: [],
+          patrolIndex: 0,
+          detectionRadius: 3,
+          chaseDistance: 5,
+          patrolRadius: 0,
+          speed: 1,
+          state: "return"
+        }
+      }
+    },
+    tiles: [
+      createTile(0, 0),
+      createTile(1, 0),
+      createTile(2, 0, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(3, 0),
+      createTile(4, 0),
+      createTile(5, 0, { occupant: { kind: "neutral", refId: "neutral-1" } }),
+      createTile(0, 1),
+      createTile(1, 1),
+      createTile(2, 1),
+      createTile(3, 1),
+      createTile(4, 1),
+      createTile(5, 1),
+      createTile(0, 2),
+      createTile(1, 2),
+      createTile(2, 2),
+      createTile(3, 2),
+      createTile(4, 2),
+      createTile(5, 2)
+    ]
+  });
+
+  const chaseOutcome = resolveWorldAction(state, { type: "turn.endDay" });
+  assert.deepEqual(chaseOutcome.events, [
+    {
+      type: "turn.advanced",
+      day: 2
+    },
+    {
+      type: "neutral.moved",
+      neutralArmyId: "neutral-1",
+      from: { x: 5, y: 0 },
+      to: { x: 4, y: 0 },
+      reason: "chase",
+      targetHeroId: "hero-1"
+    }
+  ]);
+  assert.equal(chaseOutcome.state.neutralArmies["neutral-1"]?.behavior?.state, "chase");
+
+  const returnState: WorldState = {
+    ...chaseOutcome.state,
+    heroes: [createHero({ ...hero, position: { x: 0, y: 2 } })],
+    map: {
+      ...chaseOutcome.state.map,
+      tiles: chaseOutcome.state.map.tiles.map((tile) => {
+        if (tile.position.x === 4 && tile.position.y === 0) {
+          return createTile(4, 0, { occupant: { kind: "neutral", refId: "neutral-1" } });
+        }
+        if (tile.position.x === 0 && tile.position.y === 2) {
+          return createTile(0, 2, { occupant: { kind: "hero", refId: "hero-1" } });
+        }
+        return createTile(tile.position.x, tile.position.y, { walkable: tile.walkable });
+      })
+    }
+  };
+  const returnOutcome = resolveWorldAction(returnState, { type: "turn.endDay" });
+
+  assert.deepEqual(returnOutcome.events, [
+    {
+      type: "turn.advanced",
+      day: 3
+    },
+    {
+      type: "neutral.moved",
+      neutralArmyId: "neutral-1",
+      from: { x: 4, y: 0 },
+      to: { x: 5, y: 0 },
+      reason: "return"
+    }
+  ]);
+  assert.deepEqual(returnOutcome.state.neutralArmies["neutral-1"]?.position, { x: 5, y: 0 });
+  assert.equal(returnOutcome.state.neutralArmies["neutral-1"]?.behavior?.targetHeroId, undefined);
+});
+
+test("resolveWorldAction tracks multiple neutral chase targets independently", () => {
+  const heroOne = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 0 }
+  });
+  const heroTwo = createHero({
+    id: "hero-2",
+    playerId: "player-2",
+    name: "罗安",
+    position: { x: 6, y: 2 }
+  });
+  const state = createWorldState({
+    width: 7,
+    height: 3,
+    heroes: [heroOne, heroTwo],
+    neutralArmies: {
+      "neutral-1": {
+        id: "neutral-1",
+        position: { x: 3, y: 0 },
+        origin: { x: 3, y: 0 },
+        reward: { kind: "gold", amount: 300 },
+        stacks: [{ templateId: "wolf_pack", count: 8 }],
+        behavior: {
+          mode: "guard",
+          patrolPath: [],
+          patrolIndex: 0,
+          detectionRadius: 3,
+          chaseDistance: 6,
+          patrolRadius: 0,
+          speed: 1,
+          state: "return"
+        }
+      },
+      "neutral-2": {
+        id: "neutral-2",
+        position: { x: 4, y: 2 },
+        origin: { x: 4, y: 2 },
+        reward: { kind: "gold", amount: 300 },
+        stacks: [{ templateId: "wolf_pack", count: 8 }],
+        behavior: {
+          mode: "guard",
+          patrolPath: [],
+          patrolIndex: 0,
+          detectionRadius: 3,
+          chaseDistance: 6,
+          patrolRadius: 0,
+          speed: 1,
+          state: "return"
+        }
+      }
+    },
+    tiles: Array.from({ length: 21 }, (_, index) => {
+      const x = index % 7;
+      const y = Math.floor(index / 7);
+      if (x === 0 && y === 0) {
+        return createTile(x, y, { occupant: { kind: "hero", refId: "hero-1" } });
+      }
+      if (x === 3 && y === 0) {
+        return createTile(x, y, { occupant: { kind: "neutral", refId: "neutral-1" } });
+      }
+      if (x === 6 && y === 2) {
+        return createTile(x, y, { occupant: { kind: "hero", refId: "hero-2" } });
+      }
+      if (x === 4 && y === 2) {
+        return createTile(x, y, { occupant: { kind: "neutral", refId: "neutral-2" } });
+      }
+      return createTile(x, y);
+    })
+  });
+
+  const outcome = resolveWorldAction(state, { type: "turn.endDay" });
+
+  assert.deepEqual(outcome.events, [
+    {
+      type: "turn.advanced",
+      day: 2
+    },
+    {
+      type: "neutral.moved",
+      neutralArmyId: "neutral-1",
+      from: { x: 3, y: 0 },
+      to: { x: 2, y: 0 },
+      reason: "chase",
+      targetHeroId: "hero-1"
+    },
+    {
+      type: "neutral.moved",
+      neutralArmyId: "neutral-2",
+      from: { x: 4, y: 2 },
+      to: { x: 5, y: 2 },
+      reason: "chase",
+      targetHeroId: "hero-2"
+    }
+  ]);
+});
+
+test("resolveWorldAction routes neutral chase movement around walls instead of through them", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 1 }
+  });
+  const state = createWorldState({
+    width: 5,
+    height: 3,
+    heroes: [hero],
+    neutralArmies: {
+      "neutral-1": {
+        id: "neutral-1",
+        position: { x: 4, y: 1 },
+        origin: { x: 4, y: 1 },
+        reward: { kind: "gold", amount: 300 },
+        stacks: [{ templateId: "wolf_pack", count: 8 }],
+        behavior: {
+          mode: "guard",
+          patrolPath: [],
+          patrolIndex: 0,
+          detectionRadius: 6,
+          chaseDistance: 8,
+          patrolRadius: 0,
+          speed: 2,
+          state: "return"
+        }
+      }
+    },
+    tiles: [
+      createTile(0, 0),
+      createTile(1, 0),
+      createTile(2, 0),
+      createTile(3, 0),
+      createTile(4, 0),
+      createTile(0, 1, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(1, 1, { walkable: false, terrain: "water" }),
+      createTile(2, 1, { walkable: false, terrain: "water" }),
+      createTile(3, 1, { walkable: false, terrain: "water" }),
+      createTile(4, 1, { occupant: { kind: "neutral", refId: "neutral-1" } }),
+      createTile(0, 2),
+      createTile(1, 2),
+      createTile(2, 2),
+      createTile(3, 2),
+      createTile(4, 2)
+    ]
+  });
+
+  const outcome = resolveWorldAction(state, { type: "turn.endDay" });
+
+  assert.deepEqual(outcome.events[0], {
+    type: "turn.advanced",
+    day: 2
+  });
+  assert.deepEqual(outcome.events[1], {
+    type: "neutral.moved",
+    neutralArmyId: "neutral-1",
+    from: { x: 4, y: 1 },
+    to: outcome.events[1]?.type === "neutral.moved" && outcome.events[1].to.y === 0 ? { x: 3, y: 0 } : { x: 3, y: 2 },
+    reason: "chase",
+    targetHeroId: "hero-1"
+  });
 });
 
 test("planPlayerViewMovement stops at the tile before a visible neutral encounter", () => {


### PR DESCRIPTION
Closes #25

## Summary
- tighten neutral fallback movement and keep return/chase state handling type-safe
- align default neutral behavior config with patrol/detection/chase requirements
- add shared tests for deterministic patrol, chase-to-return transitions, independent multi-hero targeting, and wall-safe chase pathing

## Testing
- npm run test:shared
- npm run typecheck:shared
- npm test