### PR TITLE
Implement battle balance validation and v1.1 preset (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - H5 调试壳构建验证：`npm run build:client:h5`
 - H5 调试壳类型检查：`npm run typecheck:client:h5`
 - 并发房间压测：`npm run stress:rooms -- --rooms=120 --connect-concurrency=24 --action-concurrency=24`
+- 战斗平衡验证：`npm run validate:battle -- --count=1000 --scenario=all --skill-config=configs/battle-skills-v1.1.json`
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
 - 当前 H5 调试壳仍支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。

--- a/configs/battle-balance.json
+++ b/configs/battle-balance.json
@@ -7,10 +7,10 @@
     "varianceRange": 0.2
   },
   "environment": {
-    "blockerSpawnThreshold": 0.48,
+    "blockerSpawnThreshold": 0.62,
     "blockerDurability": 1,
-    "trapSpawnThreshold": 0.28,
-    "trapDamage": 2,
+    "trapSpawnThreshold": 0.58,
+    "trapDamage": 1,
     "trapCharges": 1,
     "trapGrantedStatusId": "weakened"
   }

--- a/configs/battle-skills-v1.1.json
+++ b/configs/battle-skills-v1.1.json
@@ -1,0 +1,224 @@
+{
+  "skills": [
+    {
+      "id": "power_shot",
+      "name": "投矛射击",
+      "description": "远程压制目标，伤害略低，但不会触发反击。",
+      "kind": "active",
+      "target": "enemy",
+      "delivery": "ranged",
+      "cooldown": 2,
+      "effects": {
+        "damageMultiplier": 0.9,
+        "allowRetaliation": false
+      }
+    },
+    {
+      "id": "armor_spell",
+      "name": "护甲术",
+      "description": "为自己附加护甲术，在后续回合提升防御。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 3,
+      "effects": {
+        "grantedStatusId": "arcane_armor"
+      }
+    },
+    {
+      "id": "battle_focus",
+      "name": "战意激发",
+      "description": "短暂提升自身攻击，适合在贴身缠斗前蓄势。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 3,
+      "effects": {
+        "grantedStatusId": "battle_frenzy"
+      }
+    },
+    {
+      "id": "sundering_spear",
+      "name": "破甲投枪",
+      "description": "投出破甲短枪，伤害略低，但能在数回合内撕开目标防线。",
+      "kind": "active",
+      "target": "enemy",
+      "delivery": "ranged",
+      "cooldown": 2,
+      "effects": {
+        "damageMultiplier": 0.95,
+        "onHitStatusId": "armor_break"
+      }
+    },
+    {
+      "id": "guardian_oath",
+      "name": "守誓姿态",
+      "description": "进入短暂守势，同时小幅提升攻防，适合准备接战前使用。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 4,
+      "effects": {
+        "grantedStatusId": "shield_wall"
+      }
+    },
+    {
+      "id": "commanding_shout",
+      "name": "号令突进",
+      "description": "英雄亲自发出冲锋号令，让部队在短时间内压上输出。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 3,
+      "effects": {
+        "grantedStatusId": "battle_frenzy"
+      }
+    },
+    {
+      "id": "rending_mark",
+      "name": "裂甲追击",
+      "description": "命中时追加破甲印记，让后续换血更占优势。",
+      "kind": "passive",
+      "target": "enemy",
+      "cooldown": 0,
+      "effects": {
+        "onHitStatusId": "armor_break"
+      }
+    },
+    {
+      "id": "phalanx_command",
+      "name": "持盾列阵",
+      "description": "整理阵线，短时间内进入稳固的护卫姿态。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 4,
+      "effects": {
+        "grantedStatusId": "shield_wall"
+      }
+    },
+    {
+      "id": "pinning_javelin",
+      "name": "钉锁投枪",
+      "description": "以压制为先的投枪技，伤害略低，但能削弱对手且不触发反击。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 2,
+      "effects": {
+        "damageMultiplier": 0.85,
+        "allowRetaliation": false,
+        "onHitStatusId": "weakened"
+      }
+    },
+    {
+      "id": "venomous_fangs",
+      "name": "毒牙",
+      "description": "命中后让目标陷入中毒，回合开始时持续掉血。",
+      "kind": "passive",
+      "target": "enemy",
+      "cooldown": 0,
+      "effects": {
+        "onHitStatusId": "poisoned"
+      }
+    },
+    {
+      "id": "crippling_howl",
+      "name": "裂伤嚎叫",
+      "description": "发出撕裂嚎叫，压低伤害换取削弱效果，且不触发反击。",
+      "kind": "active",
+      "target": "enemy",
+      "delivery": "ranged",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 0.6,
+        "allowRetaliation": false,
+        "onHitStatusId": "weakened"
+      }
+    }
+  ],
+  "statuses": [
+    {
+      "id": "poisoned",
+      "name": "中毒",
+      "description": "回合开始时损失生命。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 2,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "arcane_armor",
+      "name": "护甲术",
+      "description": "临时提升防御。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 2,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "battle_frenzy",
+      "name": "战意激发",
+      "description": "短暂提升攻击。",
+      "duration": 2,
+      "attackModifier": 1,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "weakened",
+      "name": "削弱",
+      "description": "暂时降低攻击力。",
+      "duration": 2,
+      "attackModifier": -2,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "armor_break",
+      "name": "破甲",
+      "description": "短时间内护甲被撕裂，防御力下降。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": -3,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "shield_wall",
+      "name": "守誓姿态",
+      "description": "短暂进入守势，同时提高攻击与防御。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 3,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "slowed",
+      "name": "减速",
+      "description": "被陷阱拖慢，下轮行动顺序会延后。",
+      "duration": 1,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": -4,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "silenced",
+      "name": "禁魔",
+      "description": "短时间内无法施放主动技能。",
+      "duration": 1,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:profiles:prune": "node --import tsx ./scripts/manage-player-room-profiles.ts prune",
     "demo:flow": "node --import tsx ./scripts/demo.ts",
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
+    "validate:battle": "node --import tsx ./scripts/validate-battle-balance.ts",
     "test": "node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/authoritative-room.test.ts ./apps/server/test/room-persistence.test.ts ./apps/server/test/player-room-profiles.test.ts ./apps/server/test/persistence-retention.test.ts ./apps/server/test/colyseus-persistence-recovery.test.ts ./apps/server/test/config-center.test.ts ./apps/server/test/player-account-routes.test.ts ./apps/server/test/lobby-routes.test.ts ./apps/server/test/auth-guest-login.test.ts ./apps/client/test/reconnection-storage.test.ts ./apps/client/test/player-account-storage.test.ts ./apps/client/test/lobby-preferences.test.ts ./apps/client/test/auth-session-storage.test.ts ./apps/cocos-client/test/unit-animation-config.test.ts ./apps/cocos-client/test/cocos-ui-formatters.test.ts ./apps/cocos-client/test/cocos-battle-panel-model.test.ts ./apps/cocos-client/test/cocos-map-visuals.test.ts ./apps/cocos-client/test/cocos-object-visuals.test.ts ./apps/cocos-client/test/cocos-session-launch.test.ts ./apps/cocos-client/test/cocos-lobby.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -564,6 +564,140 @@ export function pickAutomatedBattleAction(state: BattleState): BattleAction | nu
   };
 }
 
+export interface AutomatedBattleSkillUsageEntry {
+  skillId: BattleSkillId;
+  uses: number;
+  share: number;
+}
+
+export interface AutomatedBattleSimulationResult {
+  outcome: BattleOutcome;
+  finalState: BattleState;
+  rounds: number;
+  turns: number;
+  skillUsage: Record<BattleSkillId, number>;
+  maxActionsReached: boolean;
+}
+
+export interface AutomatedBattleMetrics {
+  battleCount: number;
+  attackerWins: number;
+  defenderWins: number;
+  unresolvedBattles: number;
+  attackerWinRate: number;
+  defenderWinRate: number;
+  unresolvedRate: number;
+  averageRounds: number;
+  averageTurns: number;
+  minRounds: number;
+  maxRounds: number;
+  totalSkillUses: number;
+  skillUsage: AutomatedBattleSkillUsageEntry[];
+}
+
+export interface AutomatedBattleSimulationOptions {
+  maxActions?: number;
+}
+
+function sortSkillUsage(skillUsage: Record<BattleSkillId, number>): AutomatedBattleSkillUsageEntry[] {
+  const totalSkillUses = Object.values(skillUsage).reduce((total, value) => total + value, 0);
+  return Object.entries(skillUsage)
+    .map(([skillId, uses]) => ({
+      skillId,
+      uses,
+      share: totalSkillUses > 0 ? uses / totalSkillUses : 0
+    }))
+    .sort((left, right) => right.uses - left.uses || left.skillId.localeCompare(right.skillId));
+}
+
+export function simulateAutomatedBattle(
+  initialState: BattleState,
+  options: AutomatedBattleSimulationOptions = {}
+): AutomatedBattleSimulationResult {
+  const maxActions = Math.max(1, options.maxActions ?? 200);
+  const skillUsage: Record<BattleSkillId, number> = {};
+  let state = structuredClone(initialState);
+  let turns = 0;
+
+  while (getBattleOutcome(state).status === "in_progress" && turns < maxActions) {
+    const action = pickAutomatedBattleAction(state);
+    if (!action) {
+      break;
+    }
+
+    if (action.type === "battle.skill") {
+      skillUsage[action.skillId] = (skillUsage[action.skillId] ?? 0) + 1;
+    }
+
+    state = applyBattleAction(state, action);
+    turns += 1;
+  }
+
+  return {
+    outcome: getBattleOutcome(state),
+    finalState: state,
+    rounds: state.round,
+    turns,
+    skillUsage,
+    maxActionsReached: turns >= maxActions && getBattleOutcome(state).status === "in_progress"
+  };
+}
+
+export function simulateAutomatedBattles(
+  createInitialState: (battleIndex: number) => BattleState,
+  battleCount: number,
+  options: AutomatedBattleSimulationOptions = {}
+): AutomatedBattleMetrics {
+  const resolvedBattleCount = Math.max(1, Math.floor(battleCount));
+  const aggregateSkillUsage: Record<BattleSkillId, number> = {};
+  let attackerWins = 0;
+  let defenderWins = 0;
+  let unresolvedBattles = 0;
+  let totalRounds = 0;
+  let totalTurns = 0;
+  let minRounds = Number.POSITIVE_INFINITY;
+  let maxRounds = 0;
+
+  for (let battleIndex = 0; battleIndex < resolvedBattleCount; battleIndex += 1) {
+    const result = simulateAutomatedBattle(createInitialState(battleIndex), options);
+
+    if (result.outcome.status === "attacker_victory") {
+      attackerWins += 1;
+    } else if (result.outcome.status === "defender_victory") {
+      defenderWins += 1;
+    } else {
+      unresolvedBattles += 1;
+    }
+
+    totalRounds += result.rounds;
+    totalTurns += result.turns;
+    minRounds = Math.min(minRounds, result.rounds);
+    maxRounds = Math.max(maxRounds, result.rounds);
+
+    for (const [skillId, uses] of Object.entries(result.skillUsage)) {
+      aggregateSkillUsage[skillId] = (aggregateSkillUsage[skillId] ?? 0) + uses;
+    }
+  }
+
+  const totalSkillUses = Object.values(aggregateSkillUsage).reduce((total, value) => total + value, 0);
+
+  return {
+    battleCount: resolvedBattleCount,
+    attackerWins,
+    defenderWins,
+    unresolvedBattles,
+    attackerWinRate: attackerWins / resolvedBattleCount,
+    defenderWinRate: defenderWins / resolvedBattleCount,
+    unresolvedRate: unresolvedBattles / resolvedBattleCount,
+    averageRounds: totalRounds / resolvedBattleCount,
+    averageTurns: totalTurns / resolvedBattleCount,
+    minRounds: Number.isFinite(minRounds) ? minRounds : 0,
+    maxRounds,
+    totalSkillUses,
+    skillUsage: sortSkillUsage(aggregateSkillUsage)
+  };
+}
+
 function advanceTurnInternal(state: BattleState, actingUnitId: string, waited: boolean): BattleState {
   const aliveIds = new Set(
     Object.values(state.units)

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   applyBattleAction,
@@ -18,15 +19,19 @@ import {
   createWorldStateFromConfigs,
   filterWorldEventsForPlayer,
   getBattleBalanceConfig,
+  getDefaultMapObjectsConfig,
   getDefaultBattleSkillCatalog,
   getDefaultHeroSkillTreeConfig,
   getDefaultUnitCatalog,
+  getDefaultWorldConfig,
   getBattleOutcome,
   getDefaultEquipmentCatalog,
   pickAutomatedBattleAction,
   planPlayerViewMovement,
   predictPlayerWorldAction,
   resetRuntimeConfigs,
+  simulateAutomatedBattle,
+  simulateAutomatedBattles,
   resolveWorldAction,
   setBattleBalanceConfig,
   setBattleSkillCatalog,
@@ -3030,6 +3035,51 @@ test("createEmptyBattleState returns the minimal neutral battle shell", () => {
       cursor: 0
     }
   });
+});
+
+test("simulateAutomatedBattle resolves a deterministic demo encounter and records skill usage", () => {
+  const result = simulateAutomatedBattle(createDemoBattleState());
+
+  assert.notEqual(result.outcome.status, "in_progress");
+  assert.ok(result.turns > 0);
+  assert.ok(result.rounds >= 1);
+  assert.ok(Object.values(result.skillUsage).reduce((total, value) => total + value, 0) > 0);
+  assert.equal(result.maxActionsReached, false);
+});
+
+test("simulateAutomatedBattles aggregates win rate, rounds, and skill usage across repeated auto battles", () => {
+  const world = createWorldStateFromConfigs(getDefaultWorldConfig(), getDefaultMapObjectsConfig(), 1001, "metrics-room");
+  const attacker = world.heroes[0]!;
+  const neutralArmy = Object.values(world.neutralArmies)[0]!;
+
+  const metrics = simulateAutomatedBattles(
+    (battleIndex) => createNeutralBattleState(attacker, neutralArmy, 5000 + battleIndex),
+    12
+  );
+
+  assert.equal(metrics.battleCount, 12);
+  assert.equal(metrics.attackerWins + metrics.defenderWins + metrics.unresolvedBattles, 12);
+  assert.ok(metrics.averageRounds >= 1);
+  assert.ok(metrics.averageTurns >= 1);
+  assert.ok(metrics.maxRounds >= metrics.minRounds);
+  assert.ok(metrics.totalSkillUses > 0);
+  assert.ok(metrics.skillUsage.length > 0);
+  assert.equal(
+    metrics.skillUsage.every((entry, index, entries) => index === 0 || entries[index - 1]!.uses >= entry.uses),
+    true
+  );
+});
+
+test("battle-skills-v1.1 preset validates against the shared runtime schema", () => {
+  const presetContent = readFileSync(
+    new URL("../../../configs/battle-skills-v1.1.json", import.meta.url),
+    "utf8"
+  );
+  const preset = JSON.parse(presetContent) as ReturnType<typeof getDefaultBattleSkillCatalog>;
+
+  assert.doesNotThrow(() => setBattleSkillCatalog(preset));
+
+  resetRuntimeConfigs();
 });
 
 test("applyBattleAction routes contact attacks through blockers before hitting the target", () => {

--- a/scripts/validate-battle-balance.ts
+++ b/scripts/validate-battle-balance.ts
@@ -1,0 +1,181 @@
+import { readFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import {
+  createHeroBattleState,
+  createNeutralBattleState,
+  createWorldStateFromConfigs,
+  getBattleBalanceConfig,
+  getDefaultBattleSkillCatalog,
+  getDefaultMapObjectsConfig,
+  getDefaultUnitCatalog,
+  getDefaultWorldConfig,
+  replaceRuntimeConfigs,
+  resetRuntimeConfigs,
+  simulateAutomatedBattles,
+  type BattleBalanceConfig,
+  type BattleSkillCatalogConfig,
+  type BattleState,
+  type HeroState,
+  type NeutralArmyState
+} from "../packages/shared/src/index";
+
+type ScenarioId = "neutral-default" | "hero-duel-default" | "all";
+
+interface CliOptions {
+  count: number;
+  scenario: ScenarioId;
+  skillConfigPath?: string;
+  balanceConfigPath?: string;
+  maxActions: number;
+  topSkills: number;
+}
+
+interface ScenarioDefinition {
+  id: Exclude<ScenarioId, "all">;
+  description: string;
+  createBattle: (battleIndex: number) => BattleState;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    count: 1000,
+    scenario: "neutral-default",
+    maxActions: 200,
+    topSkills: 8
+  };
+
+  for (const argument of argv) {
+    if (!argument.startsWith("--")) {
+      continue;
+    }
+
+    const [key, rawValue] = argument.slice(2).split("=", 2);
+    const value = rawValue ?? "";
+
+    if (key === "count" && value) {
+      options.count = Math.max(1, Math.floor(Number(value) || options.count));
+    } else if (key === "scenario" && (value === "neutral-default" || value === "hero-duel-default" || value === "all")) {
+      options.scenario = value;
+    } else if (key === "skill-config" && value) {
+      options.skillConfigPath = value;
+    } else if (key === "balance-config" && value) {
+      options.balanceConfigPath = value;
+    } else if (key === "max-actions" && value) {
+      options.maxActions = Math.max(1, Math.floor(Number(value) || options.maxActions));
+    } else if (key === "top-skills" && value) {
+      options.topSkills = Math.max(1, Math.floor(Number(value) || options.topSkills));
+    }
+  }
+
+  return options;
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const absolutePath = resolve(process.cwd(), filePath);
+  const content = await readFile(absolutePath, "utf8");
+  return JSON.parse(content) as T;
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function createScenarioDefinitions(): ScenarioDefinition[] {
+  const world = createWorldStateFromConfigs(getDefaultWorldConfig(), getDefaultMapObjectsConfig(), 1001, "battle-metrics");
+  const attacker = world.heroes[0];
+  const defender = world.heroes[1];
+  const neutralArmy: NeutralArmyState = {
+    id: "neutral-benchmark",
+    position: { x: 2, y: 2 },
+    reward: { kind: "gold", amount: 100 },
+    stacks: [{ templateId: "wolf_pack", count: 10 }]
+  };
+
+  if (!attacker || !defender) {
+    throw new Error("World config must define at least two heroes for battle validation");
+  }
+
+  return [
+    {
+      id: "neutral-default",
+      description: `${attacker.name} vs 10x 恶狼`,
+      createBattle: (battleIndex) => createNeutralBattleState(attacker, cloneNeutralArmy(neutralArmy), 1000 + battleIndex)
+    },
+    {
+      id: "hero-duel-default",
+      description: `${attacker.name} vs ${defender.name}`,
+      createBattle: (battleIndex) => createHeroBattleState(cloneHero(attacker), cloneHero(defender), 4000 + battleIndex)
+    }
+  ];
+}
+
+function cloneHero(hero: HeroState): HeroState {
+  return structuredClone(hero);
+}
+
+function cloneNeutralArmy(neutralArmy: NeutralArmyState): NeutralArmyState {
+  return structuredClone(neutralArmy);
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const world = getDefaultWorldConfig();
+  const mapObjects = getDefaultMapObjectsConfig();
+  const units = getDefaultUnitCatalog();
+  const battleSkills = options.skillConfigPath
+    ? await readJsonFile<BattleSkillCatalogConfig>(options.skillConfigPath)
+    : getDefaultBattleSkillCatalog();
+  const battleBalance = options.balanceConfigPath
+    ? await readJsonFile<BattleBalanceConfig>(options.balanceConfigPath)
+    : getBattleBalanceConfig();
+
+  replaceRuntimeConfigs({
+    world,
+    mapObjects,
+    units,
+    battleSkills,
+    battleBalance
+  });
+
+  try {
+    const definitions = createScenarioDefinitions();
+    const selectedDefinitions = options.scenario === "all"
+      ? definitions
+      : definitions.filter((definition) => definition.id === options.scenario);
+
+    console.log("Battle auto-validation");
+    console.log(`skillConfig=${options.skillConfigPath ? basename(resolve(process.cwd(), options.skillConfigPath)) : "runtime-default"}`);
+    console.log(`balanceConfig=${options.balanceConfigPath ? basename(resolve(process.cwd(), options.balanceConfigPath)) : "runtime-default"}`);
+    console.log(`battleCount=${options.count}`);
+    console.log(`maxActions=${options.maxActions}`);
+
+    for (const definition of selectedDefinitions) {
+      const metrics = simulateAutomatedBattles(definition.createBattle, options.count, {
+        maxActions: options.maxActions
+      });
+
+      console.log(`\n[${definition.id}] ${definition.description}`);
+      console.log(`attackerWinRate=${formatPercent(metrics.attackerWinRate)} (${metrics.attackerWins}/${metrics.battleCount})`);
+      console.log(`defenderWinRate=${formatPercent(metrics.defenderWinRate)} (${metrics.defenderWins}/${metrics.battleCount})`);
+      if (metrics.unresolvedBattles > 0) {
+        console.log(`unresolvedRate=${formatPercent(metrics.unresolvedRate)} (${metrics.unresolvedBattles}/${metrics.battleCount})`);
+      }
+      console.log(
+        `rounds=avg ${metrics.averageRounds.toFixed(2)} / min ${metrics.minRounds} / max ${metrics.maxRounds}`
+      );
+      console.log(`turns=avg ${metrics.averageTurns.toFixed(2)}`);
+      console.log(`skillUsageTotal=${metrics.totalSkillUses}`);
+      console.log("skillUsageDistribution=");
+      for (const entry of metrics.skillUsage.slice(0, options.topSkills)) {
+        console.log(`  ${entry.skillId}: ${entry.uses} (${formatPercent(entry.share)})`);
+      }
+    }
+  } finally {
+    resetRuntimeConfigs();
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add shared automated battle simulation metrics and a repeatable `npm run validate:battle` script for 1000-battle validation runs
- add the data preset `configs/battle-skills-v1.1.json` and tune default battlefield environment balance to reduce hazard swing
- cover the new simulation helpers and preset validation in shared tests, and document the validation command in the README

## Validation
- `npm test`
- `npm run test:shared`
- `npm run validate:battle -- --count=1000 --scenario=all`
- `npm run validate:battle -- --count=1000 --scenario=all --skill-config=configs/battle-skills-v1.1.json`

## Metrics Snapshot
- runtime default, `凯琳 vs 10x 恶狼`: attacker win rate `85.9%`, avg rounds `7.02`
- v1.1 preset, `凯琳 vs 10x 恶狼`: attacker win rate `81.6%`, avg rounds `7.14`
- runtime default, `凯琳 vs 罗安`: attacker win rate `100.0%`, avg rounds `8.38`
- v1.1 preset, `凯琳 vs 罗安`: attacker win rate `100.0%`, avg rounds `7.69`

Closes #24.
