### PR TITLE
Issue #26: expose battle environment core generator

### DIFF
--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -187,7 +187,7 @@ function describeHazard(hazard: BattleHazardState, catalogIndex: BattleCatalogIn
   return parts.join(" · ");
 }
 
-function createBattleEnvironment(lanes: number, seed: number): BattleHazardState[] {
+export function createBattleEnvironmentState(lanes: number, seed: number): BattleHazardState[] {
   const resolvedLanes = Math.max(1, lanes);
   const balance = getBattleBalanceConfig().environment;
   let environmentSeed = (seed ^ 0x9e3779b9) >>> 0;
@@ -1285,7 +1285,7 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
   }
 
   const turnOrder = sortTurnOrder(units);
-  const environment = createBattleEnvironment(lanes, seed);
+  const environment = createBattleEnvironmentState(lanes, seed);
   return {
     id: `battle-${neutralArmy.id}`,
     round: 1,
@@ -1372,7 +1372,7 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
   };
 
   const turnOrder = sortTurnOrder(units);
-  const environment = createBattleEnvironment(lanes, seed);
+  const environment = createBattleEnvironmentState(lanes, seed);
   return {
     id: `battle-${attackerHero.id}-vs-${defenderHero.id}`,
     round: 1,

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -8,6 +8,7 @@ import {
   createHeroEquipmentBonusSummary,
   createHeroSkillTreeView,
   createHeroProgressMeterView,
+  createBattleEnvironmentState,
   createDemoBattleState,
   createEmptyBattleState,
   executeBattleSkill,
@@ -3891,6 +3892,49 @@ test("battle state builders consume runtime battle balance environment config", 
   }
 });
 
+test("createBattleEnvironmentState deterministically generates blockers plus hidden traps from runtime config", () => {
+  const customBalance = getBattleBalanceConfig();
+  customBalance.environment.blockerSpawnThreshold = 0;
+  customBalance.environment.blockerDurability = 2;
+  customBalance.environment.trapSpawnThreshold = 0;
+  customBalance.environment.trapDamage = 3;
+  customBalance.environment.trapCharges = 2;
+
+  try {
+    setBattleBalanceConfig(customBalance);
+
+    const environment = createBattleEnvironmentState(3, 2027);
+
+    assert.deepEqual(environment, [
+      {
+        id: "hazard-blocker-2",
+        kind: "blocker",
+        lane: 2,
+        name: "碎石路障",
+        description: "近身接战前需要先破开这道障碍。",
+        durability: 2,
+        maxDurability: 2
+      },
+      {
+        id: "hazard-trap-2",
+        kind: "trap",
+        lane: 2,
+        effect: "damage",
+        name: "爆裂地刺",
+        description: "隐藏在地面的尖刺会在近战突进时突然弹出。",
+        damage: 3,
+        charges: 2,
+        revealed: false,
+        triggered: false,
+        grantedStatusId: "weakened",
+        triggeredByCamp: "both"
+      }
+    ]);
+  } finally {
+    resetRuntimeConfigs();
+  }
+});
+
 test("applyBattleAction consumes runtime battle balance damage config", () => {
   const state = createEmptyBattleState();
   state.id = "battle-balance-damage";
@@ -4042,4 +4086,41 @@ test("applyBattleAction returns the normalized state for unknown runtime action 
   assert.deepEqual(next.units["pikeman-a"]?.skills, []);
   assert.deepEqual(next.units["pikeman-a"]?.statusEffects, []);
   assert.deepEqual(next.log, state.log);
+});
+
+test("applyBattleAction only triggers traps for matching camps", () => {
+  const state = createDemoBattleState();
+  state.activeUnitId = "pikeman-a";
+  state.turnOrder = ["pikeman-a", "wolf-d"];
+  state.units["wolf-d"] = {
+    ...state.units["wolf-d"]!,
+    hasRetaliated: true
+  };
+  state.environment = [
+    {
+      id: "hazard-trap-defender",
+      kind: "trap",
+      lane: 0,
+      effect: "damage",
+      name: "守军地刺",
+      description: "只会对防守方的冲锋路线生效。",
+      damage: 3,
+      charges: 1,
+      revealed: false,
+      triggered: false,
+      triggeredByCamp: "defender"
+    }
+  ];
+
+  const next = applyBattleAction(state, {
+    type: "battle.attack",
+    attackerId: "pikeman-a",
+    defenderId: "wolf-d"
+  });
+
+  assert.equal(next.environment[0]?.charges, 1);
+  assert.equal(next.environment[0]?.revealed, false);
+  assert.equal(next.units["pikeman-a"]?.currentHp, 10);
+  assert.equal(next.log.some((entry) => entry.includes("守军地刺")), false);
+  assert.match(next.log.at(-1) ?? "", /^枪兵 对 恶狼 造成 \d+ 伤害$/);
 });


### PR DESCRIPTION
## Summary
- expose the shared battle environment generator so blocker and trap state creation is reusable outside the battle builders
- add deterministic shared coverage for seeded blocker/trap generation against runtime balance config
- add coverage that camp-scoped traps do not trigger for the wrong side during contact attacks

## Testing
- npm run test:shared
- node --import tsx --test ./apps/server/test/authoritative-room.test.ts

closes #26