### PR TITLE
feat: config center versioning foundation for #31

### DIFF
--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -1428,7 +1428,7 @@ function renderSnapshotSection(): string {
         <h4>版本快照</h4>
         <span class="config-meta">${state.snapshots.length} 个历史版本</span>
       </div>
-      <p class="config-hint">快照会记录版本号和时间戳。选择一个快照后可以查看与当前版本的差异，或一键回滚。</p>
+      <p class="config-hint">快照会记录版本号和时间戳。手动保存快照之外，配置保存、预设应用和 Excel 导入后的有效变更也会自动生成版本节点；选择一个快照后可以查看与当前版本的差异，或一键回滚。</p>
       <div class="history-actions">
         <button class="config-button is-secondary config-button-compact" data-action="create-snapshot">保存快照</button>
       </div>

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -547,6 +547,10 @@ function createEmptyLibraryState(): ConfigCenterLibraryState {
   };
 }
 
+function buildAutomaticSnapshotLabel(title: string, version: number): string {
+  return `${title} 自动保存 v${version}`;
+}
+
 function createId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -2029,19 +2033,31 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     const document = await this.loadDocument(id);
     parseConfigDocument(id, content);
 
-    const state = await this.readLibraryState();
-    const nextSnapshot: ConfigSnapshotRecord = {
+    return this.appendSnapshot(id, {
       id: createId("snapshot"),
       label: label?.trim() || `${document.title} v${document.version ?? 1}`,
       createdAt: new Date().toISOString(),
       version: document.version ?? 1,
       content: normalizeJsonContent(parseConfigDocument(id, content))
-    };
+    });
+  }
 
-    state.snapshots[id] = [nextSnapshot, ...(state.snapshots[id] ?? [])].slice(0, 30);
+  protected async appendSnapshot(id: ConfigDocumentId, snapshot: ConfigSnapshotRecord): Promise<ConfigSnapshotSummary> {
+    const state = await this.readLibraryState();
+    state.snapshots[id] = [snapshot, ...(state.snapshots[id] ?? [])].slice(0, 30);
     await this.writeLibraryState(state);
-    const { content: _content, ...summary } = nextSnapshot;
+    const { content: _content, ...summary } = snapshot;
     return summary;
+  }
+
+  protected async createAutomaticSnapshot(document: ConfigDocument): Promise<ConfigSnapshotSummary> {
+    return this.appendSnapshot(document.id, {
+      id: createId("snapshot"),
+      label: buildAutomaticSnapshotLabel(document.title, document.version ?? 1),
+      createdAt: new Date().toISOString(),
+      version: document.version ?? 1,
+      content: document.content
+    });
   }
 
   async rollbackToSnapshot(id: ConfigDocumentId, snapshotId: string): Promise<ConfigDocument> {
@@ -2180,13 +2196,21 @@ export class FileSystemConfigCenterStore extends BaseConfigCenterStore {
     const parsed = parseConfigDocument(id, content);
     const bundle = buildRuntimeBundleWithParsedDocument(id, parsed);
     const serialized = normalizeJsonContent(bundle[id]);
-    const nextVersion = ((await this.getFilesystemVersion(id)) ?? 1) + 1;
+    const current = await this.loadDocument(id);
+
+    if (current.content === serialized) {
+      return current;
+    }
+
+    const nextVersion = (current.version ?? 1) + 1;
 
     await this.exportDocumentToFile(id, serialized);
     await this.setFilesystemVersion(id, nextVersion);
     applyRuntimeBundle(bundle);
 
-    return this.loadDocument(id);
+    const saved = await this.loadDocument(id);
+    await this.createAutomaticSnapshot(saved);
+    return saved;
   }
 
   async close(): Promise<void> {
@@ -2288,6 +2312,11 @@ export class MySqlConfigCenterStore extends BaseConfigCenterStore {
     const parsed = parseConfigDocument(id, content);
     const bundle = buildRuntimeBundleWithParsedDocument(id, parsed);
     const serialized = normalizeJsonContent(bundle[id]);
+    const current = await this.loadDocument(id);
+
+    if (current.content === serialized) {
+      return current;
+    }
 
     await this.pool.query(
       `INSERT INTO \`${MYSQL_CONFIG_DOCUMENT_TABLE}\` (document_id, content_json, exported_at)
@@ -2308,7 +2337,9 @@ export class MySqlConfigCenterStore extends BaseConfigCenterStore {
     );
     applyRuntimeBundle(bundle);
 
-    return this.loadDocument(id);
+    const saved = await this.loadDocument(id);
+    await this.createAutomaticSnapshot(saved);
+    return saved;
   }
 
   async close(): Promise<void> {

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -393,6 +393,32 @@ test("config center snapshots support diff and rollback", async () => {
   assert.equal(JSON.parse(rolledBack.content).width, WORLD_CONFIG.width);
 });
 
+test("config center save creates automatic version snapshots and skips no-op saves", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+  await store.initializeRuntimeConfigs();
+
+  const baseline = await store.loadDocument("world");
+  const unchanged = await store.saveDocument("world", baseline.content);
+  assert.equal(unchanged.version, baseline.version);
+  assert.deepEqual(await store.listSnapshots("world"), []);
+
+  const changed = await store.saveDocument(
+    "world",
+    JSON.stringify({
+      ...WORLD_CONFIG,
+      width: 10
+    })
+  );
+  const snapshots = await store.listSnapshots("world");
+
+  assert.equal(changed.version, (baseline.version ?? 1) + 1);
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0]?.version, changed.version);
+  assert.match(snapshots[0]?.label ?? "", /自动保存/);
+});
+
 test("config center presets and workbook import/export roundtrip", async () => {
   const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
   await seedConfigRoot(rootDir);


### PR DESCRIPTION
## Summary
- add automatic config-center snapshots for meaningful persisted changes so save/apply preset/import workflows always leave a rollback point
- stop no-op saves from bumping document versions or polluting snapshot history
- update config-center coverage and UI copy to reflect the new version-node behavior

## Delivered sub-scope for #31
This PR intentionally ships a narrow foundational slice for issue #31.

Included here:
- automatic version-node creation after effective config saves
- no-op save deduplication so version numbers stay meaningful
- regression coverage for snapshot creation and no-op behavior

Not included here:
- richer snapshot metadata / timeline UI
- preset-specific version annotations
- export/import UX polish beyond the existing flows
- issue closure for #31

## Validation
- `npm test -- --test-name-pattern="config center"`
- `npm run typecheck:server`
- `npm run typecheck:client:h5` *(fails on current main due to unrelated `apps/client/src/object-visuals.ts` type errors)*