### PR TITLE
feat: compact typed-array map session payload transport

### DIFF
--- a/apps/client/src/local-session.ts
+++ b/apps/client/src/local-session.ts
@@ -1,5 +1,6 @@
 import { createRoom, type AuthoritativeWorldRoom } from "../../../apps/server/src/index";
 import { Client as ColyseusClient, CloseCode, type Room as ColyseusRoom } from "@colyseus/sdk";
+import { decodePlayerWorldView, listReachableTiles, planHeroMovement } from "../../../packages/shared/src/index";
 import type {
   BattleAction,
   BattleState,
@@ -11,7 +12,6 @@ import type {
   Vec2,
   WorldEvent
 } from "../../../packages/shared/src/index";
-import { listReachableTiles, planHeroMovement } from "../../../packages/shared/src/index";
 
 export interface SessionUpdate {
   world: PlayerWorldView;
@@ -59,7 +59,7 @@ interface StoredSessionReplayEnvelope {
 
 function fromPayload(payload: SessionStatePayload): SessionUpdate {
   return {
-    world: payload.world,
+    world: decodePlayerWorldView(payload.world),
     battle: payload.battle,
     events: payload.events,
     movementPlan: payload.movementPlan,

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -80,6 +80,30 @@ export interface PlayerWorldView {
   playerId: string;
 }
 
+interface EncodedPlayerMapOverlay {
+  index: number;
+  resource?: ResourceNode;
+  occupant?: OccupantState;
+  building?: PlayerBuildingView;
+}
+
+interface EncodedPlayerMapTiles {
+  format: "typed-array-v1";
+  terrain: string;
+  fog: string;
+  walkable: string;
+  overlays: EncodedPlayerMapOverlay[];
+}
+
+interface PlayerWorldViewPayload extends Omit<PlayerWorldView, "map"> {
+  map: {
+    width: number;
+    height: number;
+    tiles?: PlayerTileView[];
+    encodedTiles?: EncodedPlayerMapTiles;
+  };
+}
+
 export interface OccupantState {
   kind: OccupantKind;
   refId: string;
@@ -469,7 +493,7 @@ type ClientMessage =
     };
 
 interface SessionStatePayload {
-  world: PlayerWorldView;
+  world: PlayerWorldViewPayload;
   battle: BattleState | null;
   events: WorldEvent[];
   movementPlan: MovementPlan | null;
@@ -509,9 +533,71 @@ interface StoredSessionReplayEnvelope {
   update: SessionUpdate;
 }
 
+const TERRAIN_VALUES: TerrainType[] = ["grass", "dirt", "sand", "water", "unknown"];
+const FOG_VALUES: FogState[] = ["hidden", "explored", "visible"];
+
+function decodeBase64Bytes(encoded: string): Uint8Array {
+  if ("Buffer" in globalThis && typeof globalThis.Buffer !== "undefined") {
+    return new Uint8Array(globalThis.Buffer.from(encoded, "base64"));
+  }
+
+  const binary = globalThis.atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+function decodePlayerWorldView(payload: PlayerWorldViewPayload): PlayerWorldView {
+  if (Array.isArray(payload.map.tiles)) {
+    return payload as PlayerWorldView;
+  }
+
+  const encoded = payload.map.encodedTiles;
+  if (!encoded || encoded.format !== "typed-array-v1") {
+    throw new Error("unsupported_player_world_view_encoding");
+  }
+
+  const terrain = decodeBase64Bytes(encoded.terrain);
+  const fog = decodeBase64Bytes(encoded.fog);
+  const walkable = decodeBase64Bytes(encoded.walkable);
+  const tileCount = payload.map.width * payload.map.height;
+
+  if (terrain.length !== tileCount || fog.length !== tileCount || walkable.length !== tileCount) {
+    throw new Error("invalid_player_world_view_encoding_length");
+  }
+
+  const overlaysByIndex = new Map(encoded.overlays.map((overlay) => [overlay.index, overlay] as const));
+  const tiles: PlayerTileView[] = Array.from({ length: tileCount }, (_, index) => {
+    const overlay = overlaysByIndex.get(index);
+    return {
+      position: {
+        x: index % payload.map.width,
+        y: Math.floor(index / payload.map.width)
+      },
+      fog: FOG_VALUES[fog[index]!] ?? "hidden",
+      terrain: TERRAIN_VALUES[terrain[index]!] ?? "unknown",
+      walkable: walkable[index] === 1,
+      resource: overlay?.resource,
+      occupant: overlay?.occupant,
+      building: overlay?.building
+    };
+  });
+
+  return {
+    ...payload,
+    map: {
+      width: payload.map.width,
+      height: payload.map.height,
+      tiles
+    }
+  };
+}
+
 function fromPayload(payload: SessionStatePayload): SessionUpdate {
   return {
-    world: payload.world,
+    world: decodePlayerWorldView(payload.world),
     battle: payload.battle,
     events: payload.events,
     movementPlan: payload.movementPlan,

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -1,6 +1,7 @@
 import { Room, type Client as ColyseusClient } from "colyseus";
 import {
   createInitialWorldState,
+  encodePlayerWorldView,
   filterWorldEventsForPlayer,
   listReachableTiles,
   planHeroMovement,
@@ -320,7 +321,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       reason?: string;
     }
   ): SessionStatePayload {
-    const world = this.worldRoom.getSnapshot(playerId).state;
+    const world = encodePlayerWorldView(this.worldRoom.getSnapshot(playerId).state);
     const battle = this.worldRoom.getBattleForPlayer(playerId);
     const heroId = world.ownHeroes[0]?.id;
     const events = extras?.events ? filterWorldEventsForPlayer(this.worldRoom.getInternalState(), playerId, extras.events) : [];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./equipment";
 export * from "./hero-skills";
 export * from "./hero-progression";
 export * from "./map";
+export * from "./map-sync";
 export * from "./models";
 export * from "./protocol";
 export * from "./world-config";

--- a/packages/shared/src/map-sync.ts
+++ b/packages/shared/src/map-sync.ts
@@ -1,0 +1,160 @@
+import type {
+  FogState,
+  OccupantState,
+  PlayerBuildingView,
+  PlayerTileView,
+  PlayerWorldView,
+  ResourceNode
+} from "./models";
+
+export interface EncodedPlayerMapOverlay {
+  index: number;
+  resource?: ResourceNode;
+  occupant?: OccupantState;
+  building?: PlayerBuildingView;
+}
+
+export interface EncodedPlayerMapTiles {
+  format: "typed-array-v1";
+  terrain: string;
+  fog: string;
+  walkable: string;
+  overlays: EncodedPlayerMapOverlay[];
+}
+
+export interface PlayerWorldViewPayload extends Omit<PlayerWorldView, "map"> {
+  map: {
+    width: number;
+    height: number;
+    tiles?: PlayerTileView[];
+    encodedTiles?: EncodedPlayerMapTiles;
+  };
+}
+
+const TERRAIN_CODES: Record<PlayerTileView["terrain"], number> = {
+  grass: 0,
+  dirt: 1,
+  sand: 2,
+  water: 3,
+  unknown: 4
+};
+
+const TERRAIN_VALUES: PlayerTileView["terrain"][] = ["grass", "dirt", "sand", "water", "unknown"];
+const FOG_CODES: Record<FogState, number> = {
+  hidden: 0,
+  explored: 1,
+  visible: 2
+};
+const FOG_VALUES: FogState[] = ["hidden", "explored", "visible"];
+
+function encodeBase64(bytes: Uint8Array): string {
+  if ("Buffer" in globalThis && typeof globalThis.Buffer !== "undefined") {
+    return globalThis.Buffer.from(bytes).toString("base64");
+  }
+
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return globalThis.btoa(binary);
+}
+
+function decodeBase64(encoded: string): Uint8Array {
+  if ("Buffer" in globalThis && typeof globalThis.Buffer !== "undefined") {
+    return new Uint8Array(globalThis.Buffer.from(encoded, "base64"));
+  }
+
+  const binary = globalThis.atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+export function encodePlayerWorldView(view: PlayerWorldView): PlayerWorldViewPayload {
+  const tileCount = view.map.tiles.length;
+  const terrain = new Uint8Array(tileCount);
+  const fog = new Uint8Array(tileCount);
+  const walkable = new Uint8Array(tileCount);
+  const overlays: EncodedPlayerMapOverlay[] = [];
+
+  for (let index = 0; index < tileCount; index += 1) {
+    const tile = view.map.tiles[index]!;
+    terrain[index] = TERRAIN_CODES[tile.terrain];
+    fog[index] = FOG_CODES[tile.fog];
+    walkable[index] = tile.walkable ? 1 : 0;
+
+    if (tile.resource || tile.occupant || tile.building) {
+      overlays.push({
+        index,
+        ...(tile.resource ? { resource: tile.resource } : {}),
+        ...(tile.occupant ? { occupant: tile.occupant } : {}),
+        ...(tile.building ? { building: tile.building } : {})
+      });
+    }
+  }
+
+  return {
+    ...view,
+    map: {
+      width: view.map.width,
+      height: view.map.height,
+      encodedTiles: {
+        format: "typed-array-v1",
+        terrain: encodeBase64(terrain),
+        fog: encodeBase64(fog),
+        walkable: encodeBase64(walkable),
+        overlays
+      }
+    }
+  };
+}
+
+export function decodePlayerWorldView(view: PlayerWorldView | PlayerWorldViewPayload): PlayerWorldView {
+  if ("tiles" in view.map && Array.isArray(view.map.tiles)) {
+    return view as PlayerWorldView;
+  }
+
+  const encoded = "encodedTiles" in view.map ? view.map.encodedTiles : undefined;
+  if (!encoded || encoded.format !== "typed-array-v1") {
+    throw new Error("unsupported_player_world_view_encoding");
+  }
+
+  const terrain = decodeBase64(encoded.terrain);
+  const fog = decodeBase64(encoded.fog);
+  const walkable = decodeBase64(encoded.walkable);
+  const tileCount = view.map.width * view.map.height;
+
+  if (terrain.length !== tileCount || fog.length !== tileCount || walkable.length !== tileCount) {
+    throw new Error("invalid_player_world_view_encoding_length");
+  }
+
+  const overlaysByIndex = new Map<number, EncodedPlayerMapOverlay>(
+    encoded.overlays.map((overlay: EncodedPlayerMapOverlay) => [overlay.index, overlay] as const)
+  );
+  const tiles: PlayerTileView[] = Array.from({ length: tileCount }, (_, index) => {
+    const overlay = overlaysByIndex.get(index);
+    return {
+      position: {
+        x: index % view.map.width,
+        y: Math.floor(index / view.map.width)
+      },
+      fog: FOG_VALUES[fog[index]!] ?? "hidden",
+      terrain: TERRAIN_VALUES[terrain[index]!] ?? "unknown",
+      walkable: walkable[index] === 1,
+      resource: overlay?.resource,
+      occupant: overlay?.occupant,
+      building: overlay?.building
+    };
+  });
+
+  return {
+    ...view,
+    map: {
+      width: view.map.width,
+      height: view.map.height,
+      tiles
+    }
+  };
+}

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,7 +1,8 @@
-import type { BattleAction, BattleState, MovementPlan, PlayerWorldView, Vec2, WorldAction, WorldEvent } from "./models";
+import type { BattleAction, BattleState, MovementPlan, Vec2, WorldAction, WorldEvent } from "./models";
+import type { PlayerWorldViewPayload } from "./map-sync";
 
 export interface SessionStatePayload {
-  world: PlayerWorldView;
+  world: PlayerWorldViewPayload;
   battle: BattleState | null;
   events: WorldEvent[];
   movementPlan: MovementPlan | null;

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -18,6 +18,8 @@ import {
   createDefaultHeroProgression,
   createPlayerWorldView,
   createWorldStateFromConfigs,
+  decodePlayerWorldView,
+  encodePlayerWorldView,
   filterWorldEventsForPlayer,
   getBattleBalanceConfig,
   getDefaultMapObjectsConfig,
@@ -43,6 +45,7 @@ import {
   type BattleState,
   type HeroState,
   type NeutralArmyState,
+  type PlayerWorldView,
   type ResourceNode,
   type TileState,
   type UnitStack,
@@ -140,6 +143,71 @@ function createWorldState(options?: {
     visibilityByPlayer: options?.visibilityByPlayer ?? {}
   };
 }
+
+function createLargePlayerWorldView(): PlayerWorldView {
+  const width = 32;
+  const height = 32;
+  const playerId = "player-1";
+  const tiles = Array.from({ length: width * height }, (_, index) => {
+    const x = index % width;
+    const y = Math.floor(index / width);
+    const terrain = (["grass", "dirt", "sand", "water"] as const)[(x + y) % 4] ?? "grass";
+    const resource = index % 47 === 0 ? { kind: "wood" as const, amount: 5 } : undefined;
+    const occupant = index === width + 1 ? { kind: "hero" as const, refId: "hero-1" } : undefined;
+
+    return createTile(x, y, {
+      terrain,
+      walkable: terrain !== "water",
+      ...(resource ? { resource } : {}),
+      ...(occupant ? { occupant } : {})
+    });
+  });
+
+  const visibilityByPlayer = {
+    [playerId]: tiles.map((tile) => {
+      if (tile.position.x <= 10 && tile.position.y <= 10) {
+        return "visible" as const;
+      }
+      if (tile.position.x <= 18 && tile.position.y <= 18) {
+        return "explored" as const;
+      }
+      return "hidden" as const;
+    })
+  };
+
+  return createPlayerWorldView(
+    createWorldState({
+      width,
+      height,
+      tiles,
+      heroes: [
+        createHero({
+          id: "hero-1",
+          playerId,
+          name: "Scout",
+          position: { x: 1, y: 1 }
+        })
+      ],
+      visibilityByPlayer
+    }),
+    playerId
+  );
+}
+
+test("typed-array world map payload decodes back to the original player world view", () => {
+  const view = createLargePlayerWorldView();
+
+  assert.deepEqual(decodePlayerWorldView(encodePlayerWorldView(view)), view);
+});
+
+test("typed-array world map payload is materially smaller than the raw tile JSON on a 32x32 map", () => {
+  const view = createLargePlayerWorldView();
+  const encoded = encodePlayerWorldView(view);
+  const rawSize = JSON.stringify(view).length;
+  const encodedSize = JSON.stringify(encoded).length;
+
+  assert.ok(encodedSize < rawSize * 0.55, `expected encoded payload < 55% of raw size, got ${encodedSize}/${rawSize}`);
+});
 
 function cloneBattleState(state: BattleState): BattleState {
   return structuredClone(state);


### PR DESCRIPTION
## Summary
- deliver a bounded sub-scope of #32 by compacting `session.state` map payloads with a typed-array transport codec
- keep authoritative world state and gameplay APIs unchanged while shrinking map sync payload size on the wire
- add backward-compatible decode support for both H5 and Cocos clients

## What Changed
- added shared `encodePlayerWorldView` / `decodePlayerWorldView` helpers in `packages/shared/src/map-sync.ts`
- encoded `terrain`, `fog`, and `walkable` into base64-backed `Uint8Array` payloads and moved dynamic tile data into sparse overlays
- switched Colyseus `session.state` replies/pushes to emit the compact map transport format
- decoded the compact payload back into the existing tile-array shape inside both client session layers
- added regression tests for round-trip compatibility and payload-size reduction on a 32x32 map

## Validation
- `npm test`
- measured representative 32x32 player-view payload shrink from `82462` bytes to `4956` bytes (`94.0%` reduction)

## Scope Notes
- partially addresses #32
- this PR does **not** implement chunk partitioning / 3x3 neighborhood sync yet
- issue #32 should remain open for chunked map delivery, hero-neighborhood loading, and broader perf/bandwidth validation
