### PR TITLE
feat: tighten config-center export metadata for #31

### DIFF
--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -182,6 +182,12 @@ interface ApiErrorPayload {
   };
 }
 
+interface DownloadPayload {
+  blob: Blob;
+  fileName: string | null;
+  exportedAt: string | null;
+}
+
 interface AppState {
   items: ConfigDocumentSummary[];
   current: ConfigDocument | null;
@@ -401,7 +407,30 @@ async function requestJson<T>(input: RequestInfo, init?: RequestInit): Promise<T
   return data;
 }
 
-async function requestBlob(input: RequestInfo, init?: RequestInit): Promise<Blob> {
+function parseDownloadFileName(headerValue: string | null): string | null {
+  if (!headerValue) {
+    return null;
+  }
+
+  const utf8Match = headerValue.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch {
+      return utf8Match[1];
+    }
+  }
+
+  const quotedMatch = headerValue.match(/filename="([^"]+)"/i);
+  if (quotedMatch?.[1]) {
+    return quotedMatch[1];
+  }
+
+  const plainMatch = headerValue.match(/filename=([^;]+)/i);
+  return plainMatch?.[1]?.trim() ?? null;
+}
+
+async function requestDownload(input: RequestInfo, init?: RequestInit): Promise<DownloadPayload> {
   const response = await fetch(input, init);
   if (!response.ok) {
     let errorMessage = `Request failed: ${response.status}`;
@@ -414,7 +443,11 @@ async function requestBlob(input: RequestInfo, init?: RequestInit): Promise<Blob
     throw new Error(errorMessage);
   }
 
-  return response.blob();
+  return {
+    blob: await response.blob(),
+    fileName: parseDownloadFileName(response.headers.get("Content-Disposition")),
+    exportedAt: response.headers.get("X-Config-Exported-At")
+  };
 }
 
 function serializeDisplayValue(value: string): string {
@@ -928,13 +961,20 @@ async function exportCurrentDocument(format: "xlsx" | "jsonc" | "csv"): Promise<
   }
 
   try {
-    const blob = await requestBlob(`/api/config-center/configs/${state.current.id}/export?format=${format}`);
-    const href = URL.createObjectURL(blob);
+    const download = await requestDownload(`/api/config-center/configs/${state.current.id}/export?format=${format}`);
+    const href = URL.createObjectURL(download.blob);
     const anchor = document.createElement("a");
     anchor.href = href;
-    anchor.download = `${state.current.id}.${format}`;
+    anchor.download = download.fileName ?? `${state.current.id}.${format}`;
     anchor.click();
     URL.revokeObjectURL(href);
+    if (state.current) {
+      state.current.exportedAt = download.exportedAt ?? new Date().toISOString();
+      const item = state.items.find((entry) => entry.id === state.current?.id);
+      if (item) {
+        item.exportedAt = state.current.exportedAt;
+      }
+    }
     state.statusTone = "success";
     state.statusMessage =
       format === "xlsx" ? "已导出 Excel 工作簿" : format === "csv" ? "已导出字段清单 CSV" : "已导出 JSON 注释版";

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -209,6 +209,7 @@ export interface ConfigCenterStore {
     fileName: string;
     contentType: string;
     body: Buffer;
+    exportedAt: string;
   }>;
   importDocumentFromWorkbook(id: ConfigDocumentId, workbook: Buffer): Promise<ConfigDocument>;
   close(): Promise<void>;
@@ -260,6 +261,7 @@ interface ConfigPresetRecord {
 
 interface ConfigCenterLibraryState {
   filesystemVersions: Partial<Record<ConfigDocumentId, number>>;
+  filesystemExports: Partial<Record<ConfigDocumentId, string>>;
   snapshots: Partial<Record<ConfigDocumentId, ConfigSnapshotRecord[]>>;
   presets: Partial<Record<ConfigDocumentId, ConfigPresetRecord[]>>;
 }
@@ -542,6 +544,7 @@ const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
 function createEmptyLibraryState(): ConfigCenterLibraryState {
   return {
     filesystemVersions: {},
+    filesystemExports: {},
     snapshots: {},
     presets: {}
   };
@@ -1943,6 +1946,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
       const parsed = JSON.parse(content) as Partial<ConfigCenterLibraryState>;
       return {
         filesystemVersions: parsed.filesystemVersions ?? {},
+        filesystemExports: parsed.filesystemExports ?? {},
         snapshots: parsed.snapshots ?? {},
         presets: parsed.presets ?? {}
       };
@@ -1967,6 +1971,17 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
   protected async setFilesystemVersion(id: ConfigDocumentId, version: number): Promise<void> {
     const state = await this.readLibraryState();
     state.filesystemVersions[id] = version;
+    await this.writeLibraryState(state);
+  }
+
+  protected async getFilesystemExportedAt(id: ConfigDocumentId): Promise<string | null> {
+    const state = await this.readLibraryState();
+    return state.filesystemExports[id] ?? null;
+  }
+
+  protected async setFilesystemExportedAt(id: ConfigDocumentId, exportedAt: string): Promise<void> {
+    const state = await this.readLibraryState();
+    state.filesystemExports[id] = exportedAt;
     await this.writeLibraryState(state);
   }
 
@@ -2142,24 +2157,29 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     fileName: string;
     contentType: string;
     body: Buffer;
+    exportedAt: string;
   }> {
     const document = await this.loadDocument(id);
+    const exportedAt = await this.markDocumentExported(id);
     return format === "xlsx"
       ? {
           fileName: `${id}-v${document.version ?? 1}.xlsx`,
           contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-          body: buildWorkbookForDocument(document)
+          body: buildWorkbookForDocument(document),
+          exportedAt
         }
       : format === "csv"
         ? {
             fileName: `${id}-v${document.version ?? 1}.csv`,
             contentType: "text/csv; charset=utf-8",
-            body: buildCsvForDocument(document)
+            body: buildCsvForDocument(document),
+            exportedAt
           }
         : {
           fileName: `${id}-v${document.version ?? 1}.jsonc`,
           contentType: "application/jsonc; charset=utf-8",
-          body: buildCommentedJson(document)
+          body: buildCommentedJson(document),
+          exportedAt
         };
   }
 
@@ -2170,6 +2190,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
 
   abstract loadDocument(id: ConfigDocumentId): Promise<ConfigDocument>;
   abstract saveDocument(id: ConfigDocumentId, content: string): Promise<ConfigDocument>;
+  protected abstract markDocumentExported(id: ConfigDocumentId): Promise<string>;
   abstract close(): Promise<void>;
 }
 
@@ -2188,7 +2209,8 @@ export class FileSystemConfigCenterStore extends BaseConfigCenterStore {
 
     return this.buildDocument(definition, normalizeJsonContent(parsed), {
       updatedAt: fileStats.mtime.toISOString(),
-      version: (await this.getFilesystemVersion(id)) ?? 1
+      version: (await this.getFilesystemVersion(id)) ?? 1,
+      exportedAt: await this.getFilesystemExportedAt(id)
     });
   }
 
@@ -2215,6 +2237,12 @@ export class FileSystemConfigCenterStore extends BaseConfigCenterStore {
 
   async close(): Promise<void> {
     return;
+  }
+
+  protected async markDocumentExported(id: ConfigDocumentId): Promise<string> {
+    const exportedAt = new Date().toISOString();
+    await this.setFilesystemExportedAt(id, exportedAt);
+    return exportedAt;
   }
 }
 
@@ -2323,18 +2351,11 @@ export class MySqlConfigCenterStore extends BaseConfigCenterStore {
        VALUES (?, ?, NULL)
        ON DUPLICATE KEY UPDATE
          content_json = VALUES(content_json),
-         exported_at = NULL,
          version = version + 1`,
       [id, serialized]
     );
 
     await this.exportDocumentToFile(id, serialized);
-    await this.pool.query(
-      `UPDATE \`${MYSQL_CONFIG_DOCUMENT_TABLE}\`
-       SET exported_at = CURRENT_TIMESTAMP
-       WHERE document_id = ?`,
-      [id]
-    );
     applyRuntimeBundle(bundle);
 
     const saved = await this.loadDocument(id);
@@ -2344,6 +2365,17 @@ export class MySqlConfigCenterStore extends BaseConfigCenterStore {
 
   async close(): Promise<void> {
     await this.pool.end();
+  }
+
+  protected async markDocumentExported(id: ConfigDocumentId): Promise<string> {
+    await this.pool.query(
+      `UPDATE \`${MYSQL_CONFIG_DOCUMENT_TABLE}\`
+       SET exported_at = CURRENT_TIMESTAMP
+       WHERE document_id = ?`,
+      [id]
+    );
+    const row = await this.loadRow(id);
+    return formatTimestamp(row?.exported_at) ?? new Date().toISOString();
   }
 
   describe(): string {
@@ -2367,12 +2399,6 @@ export class MySqlConfigCenterStore extends BaseConfigCenterStore {
         [definition.id, serialized]
       );
       await this.exportDocumentToFile(definition.id, serialized);
-      await this.pool.query(
-        `UPDATE \`${MYSQL_CONFIG_DOCUMENT_TABLE}\`
-         SET exported_at = CURRENT_TIMESTAMP
-         WHERE document_id = ?`,
-        [definition.id]
-      );
     }
   }
 
@@ -2712,6 +2738,7 @@ export function registerConfigCenterRoutes(
       response.statusCode = 200;
       response.setHeader("Content-Type", exported.contentType);
       response.setHeader("Content-Disposition", `attachment; filename="${exported.fileName}"`);
+      response.setHeader("X-Config-Exported-At", exported.exportedAt);
       response.end(exported.body);
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -419,6 +419,24 @@ test("config center save creates automatic version snapshots and skips no-op sav
   assert.match(snapshots[0]?.label ?? "", /自动保存/);
 });
 
+test("config center export updates exportedAt metadata without changing version", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  const beforeExport = await store.loadDocument("world");
+  assert.equal(beforeExport.exportedAt ?? null, null);
+
+  const exported = await store.exportDocument("world", "jsonc");
+  const afterExport = await store.loadDocument("world");
+
+  assert.match(exported.fileName, /^world-v1\.jsonc$/);
+  assert.equal(typeof exported.exportedAt, "string");
+  assert.equal(afterExport.version, beforeExport.version);
+  assert.equal(afterExport.exportedAt, exported.exportedAt);
+  assert.equal((await store.listDocuments()).find((item) => item.id === "world")?.exportedAt, exported.exportedAt);
+});
+
 test("config center presets and workbook import/export roundtrip", async () => {
   const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
   await seedConfigRoot(rootDir);
@@ -438,6 +456,7 @@ test("config center presets and workbook import/export roundtrip", async () => {
   assert.deepEqual(workbook.SheetNames, ["Meta", "Schema", "Fields"]);
   const fieldRows = XLSX.utils.sheet_to_json<Record<string, string>>(workbook.Sheets.Fields);
   assert.equal(fieldRows.some((row) => row.Path === "skills[0].id" && row.Description?.includes("技能 id")), true);
+  assert.equal((await store.loadDocument("battleSkills")).exportedAt, exported.exportedAt);
 
   const csvExported = await store.exportDocument("battleSkills", "csv");
   assert.match(csvExported.fileName, /\.csv$/);


### PR DESCRIPTION
## Summary
- persist config-center export timestamps in both filesystem and MySQL-backed stores
- return export metadata headers so the web client keeps server-generated versioned filenames and refreshes recent-export state immediately
- add regression coverage for exportedAt tracking without version churn

## Delivered sub-scope for #31
This PR only advances the export-management slice of #31.
It does not close #31 because broader snapshot/preset/schema polish remains.

## Validation
- `node --import tsx --test ./apps/server/test/config-center.test.ts`
- `npm run typecheck:server`
- `npx esbuild apps/client/src/config-center.ts --bundle --format=esm --platform=browser --outfile=/tmp/project-veil-config-center.js`
- `npm test`
- `npm run typecheck:client:h5` currently fails on pre-existing unrelated errors in `apps/client/src/object-visuals.ts`