### PR TITLE
feat: chunk encoded map sync pushes for #32

### DIFF
--- a/apps/client/src/local-session.ts
+++ b/apps/client/src/local-session.ts
@@ -57,9 +57,9 @@ interface StoredSessionReplayEnvelope {
   update: SessionUpdate;
 }
 
-function fromPayload(payload: SessionStatePayload): SessionUpdate {
+function fromPayload(payload: SessionStatePayload, previousWorld?: PlayerWorldView | null): SessionUpdate {
   return {
-    world: decodePlayerWorldView(payload.world),
+    world: decodePlayerWorldView(payload.world, previousWorld),
     battle: payload.battle,
     events: payload.events,
     movementPlan: payload.movementPlan,
@@ -437,6 +437,7 @@ class RemoteGameSession implements GameSession {
   private readonly onConnectionEvent: ((event: ConnectionEvent) => void) | undefined;
   private readonly getDisplayName: (() => string | null) | undefined;
   private readonly getAuthToken: (() => string | null) | undefined;
+  private latestWorld: PlayerWorldView | null = null;
   private requestCounter = 0;
   private readonly pendingRequests = new Map<
     string,
@@ -463,7 +464,8 @@ class RemoteGameSession implements GameSession {
 
       const message = { type, ...(payload as object) } as ServerMessage;
       if (message.type === "session.state" && message.delivery === "push") {
-        const update = fromPayload(message.payload);
+        const update = fromPayload(message.payload, this.latestWorld);
+        this.latestWorld = update.world;
         this.persistSessionReplay(update);
         this.onPushUpdate?.(update);
         return;
@@ -579,7 +581,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }
@@ -597,7 +600,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }
@@ -615,7 +619,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }
@@ -633,7 +638,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }
@@ -651,7 +657,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }
@@ -669,7 +676,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }
@@ -687,7 +695,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }
@@ -703,7 +712,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }
@@ -717,7 +727,8 @@ class RemoteGameSession implements GameSession {
       },
       "session.state"
     );
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     this.persistSessionReplay(update);
     return update;
   }

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -89,6 +89,12 @@ interface EncodedPlayerMapOverlay {
 
 interface EncodedPlayerMapTiles {
   format: "typed-array-v1";
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
   terrain: string;
   fog: string;
   walkable: string;
@@ -549,7 +555,11 @@ function decodeBase64Bytes(encoded: string): Uint8Array {
   return bytes;
 }
 
-function decodePlayerWorldView(payload: PlayerWorldViewPayload): PlayerWorldView {
+function tileIndex(width: number, x: number, y: number): number {
+  return y * width + x;
+}
+
+function decodePlayerWorldView(payload: PlayerWorldViewPayload, baseView?: PlayerWorldView | null): PlayerWorldView {
   if (Array.isArray(payload.map.tiles)) {
     return payload as PlayerWorldView;
   }
@@ -562,28 +572,60 @@ function decodePlayerWorldView(payload: PlayerWorldViewPayload): PlayerWorldView
   const terrain = decodeBase64Bytes(encoded.terrain);
   const fog = decodeBase64Bytes(encoded.fog);
   const walkable = decodeBase64Bytes(encoded.walkable);
-  const tileCount = payload.map.width * payload.map.height;
+  const bounds = encoded.bounds ?? {
+    x: 0,
+    y: 0,
+    width: payload.map.width,
+    height: payload.map.height
+  };
+  const tileCount = bounds.width * bounds.height;
 
   if (terrain.length !== tileCount || fog.length !== tileCount || walkable.length !== tileCount) {
     throw new Error("invalid_player_world_view_encoding_length");
   }
 
   const overlaysByIndex = new Map(encoded.overlays.map((overlay) => [overlay.index, overlay] as const));
-  const tiles: PlayerTileView[] = Array.from({ length: tileCount }, (_, index) => {
-    const overlay = overlaysByIndex.get(index);
-    return {
-      position: {
-        x: index % payload.map.width,
-        y: Math.floor(index / payload.map.width)
-      },
-      fog: FOG_VALUES[fog[index]!] ?? "hidden",
-      terrain: TERRAIN_VALUES[terrain[index]!] ?? "unknown",
-      walkable: walkable[index] === 1,
-      resource: overlay?.resource,
-      occupant: overlay?.occupant,
-      building: overlay?.building
-    };
-  });
+  const isFullMap =
+    bounds.x === 0 && bounds.y === 0 && bounds.width === payload.map.width && bounds.height === payload.map.height;
+  const tiles: PlayerTileView[] = isFullMap
+    ? Array.from({ length: tileCount }, (_, index) => {
+        const overlay = overlaysByIndex.get(index);
+        return {
+          position: {
+            x: bounds.x + (index % bounds.width),
+            y: bounds.y + Math.floor(index / bounds.width)
+          },
+          fog: FOG_VALUES[fog[index]!] ?? "hidden",
+          terrain: TERRAIN_VALUES[terrain[index]!] ?? "unknown",
+          walkable: walkable[index] === 1,
+          resource: overlay?.resource,
+          occupant: overlay?.occupant,
+          building: overlay?.building
+        };
+      })
+    : (() => {
+        if (!baseView || baseView.map.width !== payload.map.width || baseView.map.height !== payload.map.height) {
+          throw new Error("missing_player_world_view_base");
+        }
+
+        const nextTiles = baseView.map.tiles.map((tile) => ({ ...tile, position: { ...tile.position } }));
+        for (let index = 0; index < tileCount; index += 1) {
+          const overlay = overlaysByIndex.get(index);
+          const x = bounds.x + (index % bounds.width);
+          const y = bounds.y + Math.floor(index / bounds.width);
+          nextTiles[tileIndex(payload.map.width, x, y)] = {
+            position: { x, y },
+            fog: FOG_VALUES[fog[index]!] ?? "hidden",
+            terrain: TERRAIN_VALUES[terrain[index]!] ?? "unknown",
+            walkable: walkable[index] === 1,
+            resource: overlay?.resource,
+            occupant: overlay?.occupant,
+            building: overlay?.building
+          };
+        }
+
+        return nextTiles;
+      })();
 
   return {
     ...payload,
@@ -595,9 +637,9 @@ function decodePlayerWorldView(payload: PlayerWorldViewPayload): PlayerWorldView
   };
 }
 
-function fromPayload(payload: SessionStatePayload): SessionUpdate {
+function fromPayload(payload: SessionStatePayload, previousWorld?: PlayerWorldView | null): SessionUpdate {
   return {
-    world: decodePlayerWorldView(payload.world),
+    world: decodePlayerWorldView(payload.world, previousWorld),
     battle: payload.battle,
     events: payload.events,
     movementPlan: payload.movementPlan,
@@ -765,6 +807,7 @@ function clearSessionReplay(roomId: string, playerId: string): void {
 }
 
 class RemoteGameSession {
+  private latestWorld: PlayerWorldView | null = null;
   private readonly pendingRequests = new Map<
     string,
     {
@@ -792,7 +835,8 @@ class RemoteGameSession {
 
       const message = { type, ...(payload as object) } as ServerMessage;
       if (message.type === "session.state" && message.delivery === "push") {
-        const update = fromPayload(message.payload);
+        const update = fromPayload(message.payload, this.latestWorld);
+        this.latestWorld = update.world;
         writeSessionReplay(this.roomId, this.playerId, update);
         this.options?.onPushUpdate?.(update);
         return;
@@ -862,7 +906,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }
@@ -881,7 +926,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }
@@ -900,7 +946,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }
@@ -919,7 +966,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }
@@ -938,7 +986,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }
@@ -957,7 +1006,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }
@@ -976,7 +1026,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }
@@ -993,7 +1044,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }
@@ -1008,7 +1060,8 @@ class RemoteGameSession {
       "session.state"
     );
 
-    const update = fromPayload(response.payload);
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
     writeSessionReplay(this.roomId, this.playerId, update);
     return update;
   }

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -36,6 +36,8 @@ interface JoinOptions {
 }
 
 const RECONNECTION_WINDOW_SECONDS = 20;
+const MAP_SYNC_CHUNK_SIZE = 8;
+const MAP_SYNC_CHUNK_PADDING = 1;
 let configuredRoomSnapshotStore: RoomSnapshotStore | null = null;
 const lobbyRoomSummaries = new Map<string, LobbyRoomSummary>();
 
@@ -69,6 +71,38 @@ function sendMessage<T extends ServerMessage["type"]>(
   payload: MessageOfType<T>
 ): void {
   client.send(type, payload);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function resolveFocusedMapBounds(world: SessionStatePayload["world"]): { x: number; y: number; width: number; height: number } | null {
+  if (world.map.width <= MAP_SYNC_CHUNK_SIZE && world.map.height <= MAP_SYNC_CHUNK_SIZE) {
+    return null;
+  }
+
+  if (world.ownHeroes.length === 0) {
+    return null;
+  }
+
+  const chunkXs = world.ownHeroes.map((hero) => Math.floor(hero.position.x / MAP_SYNC_CHUNK_SIZE));
+  const chunkYs = world.ownHeroes.map((hero) => Math.floor(hero.position.y / MAP_SYNC_CHUNK_SIZE));
+  const maxChunkX = Math.max(0, Math.ceil(world.map.width / MAP_SYNC_CHUNK_SIZE) - 1);
+  const maxChunkY = Math.max(0, Math.ceil(world.map.height / MAP_SYNC_CHUNK_SIZE) - 1);
+  const minChunkX = clamp(Math.min(...chunkXs) - MAP_SYNC_CHUNK_PADDING, 0, maxChunkX);
+  const maxFocusedChunkX = clamp(Math.max(...chunkXs) + MAP_SYNC_CHUNK_PADDING, 0, maxChunkX);
+  const minChunkY = clamp(Math.min(...chunkYs) - MAP_SYNC_CHUNK_PADDING, 0, maxChunkY);
+  const maxFocusedChunkY = clamp(Math.max(...chunkYs) + MAP_SYNC_CHUNK_PADDING, 0, maxChunkY);
+  const x = minChunkX * MAP_SYNC_CHUNK_SIZE;
+  const y = minChunkY * MAP_SYNC_CHUNK_SIZE;
+
+  return {
+    x,
+    y,
+    width: Math.min(world.map.width - x, (maxFocusedChunkX - minChunkX + 1) * MAP_SYNC_CHUNK_SIZE),
+    height: Math.min(world.map.height - y, (maxFocusedChunkY - minChunkY + 1) * MAP_SYNC_CHUNK_SIZE)
+  };
 }
 
 export class VeilColyseusRoom extends Room<VeilRoomOptions> {
@@ -319,9 +353,18 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       events?: WorldEvent[];
       movementPlan?: MovementPlan | null;
       reason?: string;
+    },
+    options?: {
+      mapBounds?: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      } | null;
     }
   ): SessionStatePayload {
-    const world = encodePlayerWorldView(this.worldRoom.getSnapshot(playerId).state);
+    const snapshot = this.worldRoom.getSnapshot(playerId).state;
+    const world = encodePlayerWorldView(snapshot, options?.mapBounds ? { bounds: options.mapBounds } : undefined);
     const battle = this.worldRoom.getBattleForPlayer(playerId);
     const heroId = world.ownHeroes[0]?.id;
     const events = extras?.events ? filterWorldEventsForPlayer(this.worldRoom.getInternalState(), playerId, extras.events) : [];
@@ -354,6 +397,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         continue;
       }
 
+      const fullState = this.worldRoom.getSnapshot(playerId).state;
+      const mapBounds = resolveFocusedMapBounds(fullState);
       sendMessage(client, "session.state", {
         requestId: "push",
         delivery: "push",
@@ -361,6 +406,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
           movementPlan: null,
           ...(extras?.events ? { events: extras.events } : {}),
           ...(extras?.reason ? { reason: extras.reason } : {})
+        }, {
+          mapBounds
         })
       });
     }

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -2,7 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Client, type Room as ColyseusRoom } from "@colyseus/sdk";
 import { Server, WebSocketTransport } from "colyseus";
-import type { ClientMessage, ServerMessage } from "../../../packages/shared/src/index";
+import {
+  createWorldStateFromConfigs,
+  decodePlayerWorldView,
+  getDefaultMapObjectsConfig,
+  getDefaultWorldConfig,
+  type ClientMessage,
+  type ServerMessage
+} from "../../../packages/shared/src/index";
 import type { RoomPersistenceSnapshot } from "../src/index";
 import { configureRoomSnapshotStore, VeilColyseusRoom } from "../src/colyseus-room";
 import {
@@ -286,6 +293,30 @@ async function sendRequest<T extends ServerMessage["type"]>(
   });
 }
 
+async function waitForPushState(room: ColyseusRoom): Promise<Extract<ServerMessage, { type: "session.state" }>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error("Timed out waiting for push session.state"));
+    }, 5_000);
+
+    const unsubscribe = room.onMessage("*", (type, payload) => {
+      if (type !== "session.state") {
+        return;
+      }
+
+      const incoming = { type, ...(payload as object) } as ServerMessage;
+      if (incoming.type !== "session.state" || incoming.delivery !== "push") {
+        return;
+      }
+
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(incoming);
+    });
+  });
+}
+
 test("colyseus room reloads a persisted active battle after a server restart", async (t) => {
   const roomId = `persist-restart-${Date.now()}`;
   const port = 36000 + Math.floor(Math.random() * 1000);
@@ -463,6 +494,89 @@ test("colyseus room hydrates global player resources into fresh rooms", async (t
     wood: 5,
     ore: 0
   });
+});
+
+test("colyseus room broadcasts bounded typed-array map chunks to non-source clients", async (t) => {
+  const roomId = `chunk-push-${Date.now()}`;
+  const port = 37500 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  const worldConfig = {
+    ...getDefaultWorldConfig(),
+    width: 24,
+    height: 24
+  };
+  await store.save(roomId, {
+    state: createWorldStateFromConfigs(worldConfig, getDefaultMapObjectsConfig(), 1001, roomId),
+    battles: []
+  });
+  const server = await startServer(port, store);
+  let sourceRoom: ColyseusRoom | null = null;
+  let observerRoom: ColyseusRoom | null = null;
+
+  t.after(async () => {
+    configureRoomSnapshotStore(null);
+    if (observerRoom) {
+      observerRoom.removeAllListeners();
+      observerRoom.connection.close();
+    }
+    if (sourceRoom) {
+      sourceRoom.removeAllListeners();
+      sourceRoom.connection.close();
+    }
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  sourceRoom = await joinRoomWithRetry(port, roomId, "player-1");
+  observerRoom = await joinRoomWithRetry(port, roomId, "player-2");
+
+  await sendRequest(
+    sourceRoom,
+    {
+      type: "connect",
+      requestId: nextRequestId("chunk-source-connect"),
+      roomId,
+      playerId: "player-1"
+    },
+    "session.state"
+  );
+  const observerInitial = await sendRequest(
+    observerRoom,
+    {
+      type: "connect",
+      requestId: nextRequestId("chunk-observer-connect"),
+      roomId,
+      playerId: "player-2"
+    },
+    "session.state"
+  );
+
+  const pushPromise = waitForPushState(observerRoom);
+  await sendRequest(
+    sourceRoom,
+    {
+      type: "world.action",
+      requestId: nextRequestId("chunk-move"),
+      action: {
+        type: "hero.move",
+        heroId: "hero-1",
+        destination: { x: 2, y: 1 }
+      }
+    },
+    "session.state"
+  );
+
+  const pushed = await pushPromise;
+  assert.ok(!("tiles" in pushed.payload.world.map) || !Array.isArray(pushed.payload.world.map.tiles));
+  assert.ok(pushed.payload.world.map.encodedTiles);
+  assert.deepEqual(pushed.payload.world.map.encodedTiles?.bounds, {
+    x: 0,
+    y: 0,
+    width: 16,
+    height: 16
+  });
+  const decoded = decodePlayerWorldView(pushed.payload.world, decodePlayerWorldView(observerInitial.payload.world));
+  assert.equal(decoded.ownHeroes[0]?.id, "hero-2");
+  assert.equal(decoded.map.tiles.length, 24 * 24);
 });
 
 test("colyseus room hydrates long-term hero archives into fresh rooms", async (t) => {

--- a/packages/shared/src/map-sync.ts
+++ b/packages/shared/src/map-sync.ts
@@ -14,8 +14,16 @@ export interface EncodedPlayerMapOverlay {
   building?: PlayerBuildingView;
 }
 
+export interface EncodedPlayerMapBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export interface EncodedPlayerMapTiles {
   format: "typed-array-v1";
+  bounds: EncodedPlayerMapBounds;
   terrain: string;
   fog: string;
   walkable: string;
@@ -29,6 +37,10 @@ export interface PlayerWorldViewPayload extends Omit<PlayerWorldView, "map"> {
     tiles?: PlayerTileView[];
     encodedTiles?: EncodedPlayerMapTiles;
   };
+}
+
+export interface EncodePlayerWorldViewOptions {
+  bounds?: Partial<EncodedPlayerMapBounds>;
 }
 
 const TERRAIN_CODES: Record<PlayerTileView["terrain"], number> = {
@@ -72,26 +84,80 @@ function decodeBase64(encoded: string): Uint8Array {
   return bytes;
 }
 
-export function encodePlayerWorldView(view: PlayerWorldView): PlayerWorldViewPayload {
-  const tileCount = view.map.tiles.length;
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function resolveBounds(view: PlayerWorldView, bounds?: Partial<EncodedPlayerMapBounds>): EncodedPlayerMapBounds {
+  const x = clamp(Math.floor(bounds?.x ?? 0), 0, Math.max(0, view.map.width - 1));
+  const y = clamp(Math.floor(bounds?.y ?? 0), 0, Math.max(0, view.map.height - 1));
+  const maxWidth = view.map.width - x;
+  const maxHeight = view.map.height - y;
+  const width = clamp(Math.floor(bounds?.width ?? maxWidth), 1, maxWidth);
+  const height = clamp(Math.floor(bounds?.height ?? maxHeight), 1, maxHeight);
+
+  return { x, y, width, height };
+}
+
+function tileIndex(width: number, x: number, y: number): number {
+  return y * width + x;
+}
+
+function createPatchedTile(
+  view: PlayerWorldViewPayload | PlayerWorldView,
+  bounds: EncodedPlayerMapBounds,
+  localIndex: number,
+  terrainCode: number,
+  fogCode: number,
+  walkableCode: number,
+  overlay?: EncodedPlayerMapOverlay
+): PlayerTileView {
+  const localX = localIndex % bounds.width;
+  const localY = Math.floor(localIndex / bounds.width);
+
+  return {
+    position: {
+      x: bounds.x + localX,
+      y: bounds.y + localY
+    },
+    fog: FOG_VALUES[fogCode] ?? "hidden",
+    terrain: TERRAIN_VALUES[terrainCode] ?? "unknown",
+    walkable: walkableCode === 1,
+    resource: overlay?.resource,
+    occupant: overlay?.occupant,
+    building: overlay?.building
+  };
+}
+
+export function encodePlayerWorldView(
+  view: PlayerWorldView,
+  options?: EncodePlayerWorldViewOptions
+): PlayerWorldViewPayload {
+  const bounds = resolveBounds(view, options?.bounds);
+  const tileCount = bounds.width * bounds.height;
   const terrain = new Uint8Array(tileCount);
   const fog = new Uint8Array(tileCount);
   const walkable = new Uint8Array(tileCount);
   const overlays: EncodedPlayerMapOverlay[] = [];
 
-  for (let index = 0; index < tileCount; index += 1) {
-    const tile = view.map.tiles[index]!;
-    terrain[index] = TERRAIN_CODES[tile.terrain];
-    fog[index] = FOG_CODES[tile.fog];
-    walkable[index] = tile.walkable ? 1 : 0;
+  let localIndex = 0;
+  for (let y = bounds.y; y < bounds.y + bounds.height; y += 1) {
+    for (let x = bounds.x; x < bounds.x + bounds.width; x += 1) {
+      const tile = view.map.tiles[tileIndex(view.map.width, x, y)]!;
+      terrain[localIndex] = TERRAIN_CODES[tile.terrain];
+      fog[localIndex] = FOG_CODES[tile.fog];
+      walkable[localIndex] = tile.walkable ? 1 : 0;
 
-    if (tile.resource || tile.occupant || tile.building) {
-      overlays.push({
-        index,
-        ...(tile.resource ? { resource: tile.resource } : {}),
-        ...(tile.occupant ? { occupant: tile.occupant } : {}),
-        ...(tile.building ? { building: tile.building } : {})
-      });
+      if (tile.resource || tile.occupant || tile.building) {
+        overlays.push({
+          index: localIndex,
+          ...(tile.resource ? { resource: tile.resource } : {}),
+          ...(tile.occupant ? { occupant: tile.occupant } : {}),
+          ...(tile.building ? { building: tile.building } : {})
+        });
+      }
+
+      localIndex += 1;
     }
   }
 
@@ -102,6 +168,7 @@ export function encodePlayerWorldView(view: PlayerWorldView): PlayerWorldViewPay
       height: view.map.height,
       encodedTiles: {
         format: "typed-array-v1",
+        bounds,
         terrain: encodeBase64(terrain),
         fog: encodeBase64(fog),
         walkable: encodeBase64(walkable),
@@ -111,7 +178,10 @@ export function encodePlayerWorldView(view: PlayerWorldView): PlayerWorldViewPay
   };
 }
 
-export function decodePlayerWorldView(view: PlayerWorldView | PlayerWorldViewPayload): PlayerWorldView {
+export function decodePlayerWorldView(
+  view: PlayerWorldView | PlayerWorldViewPayload,
+  baseView?: PlayerWorldView | null
+): PlayerWorldView {
   if ("tiles" in view.map && Array.isArray(view.map.tiles)) {
     return view as PlayerWorldView;
   }
@@ -124,30 +194,48 @@ export function decodePlayerWorldView(view: PlayerWorldView | PlayerWorldViewPay
   const terrain = decodeBase64(encoded.terrain);
   const fog = decodeBase64(encoded.fog);
   const walkable = decodeBase64(encoded.walkable);
-  const tileCount = view.map.width * view.map.height;
+  const bounds = encoded.bounds ?? {
+    x: 0,
+    y: 0,
+    width: view.map.width,
+    height: view.map.height
+  };
+  const tileCount = bounds.width * bounds.height;
 
   if (terrain.length !== tileCount || fog.length !== tileCount || walkable.length !== tileCount) {
     throw new Error("invalid_player_world_view_encoding_length");
   }
 
+  const isFullMap =
+    bounds.x === 0 && bounds.y === 0 && bounds.width === view.map.width && bounds.height === view.map.height;
   const overlaysByIndex = new Map<number, EncodedPlayerMapOverlay>(
     encoded.overlays.map((overlay: EncodedPlayerMapOverlay) => [overlay.index, overlay] as const)
   );
-  const tiles: PlayerTileView[] = Array.from({ length: tileCount }, (_, index) => {
-    const overlay = overlaysByIndex.get(index);
-    return {
-      position: {
-        x: index % view.map.width,
-        y: Math.floor(index / view.map.width)
-      },
-      fog: FOG_VALUES[fog[index]!] ?? "hidden",
-      terrain: TERRAIN_VALUES[terrain[index]!] ?? "unknown",
-      walkable: walkable[index] === 1,
-      resource: overlay?.resource,
-      occupant: overlay?.occupant,
-      building: overlay?.building
-    };
-  });
+  const tiles: PlayerTileView[] = isFullMap
+    ? Array.from({ length: tileCount }, (_, index) =>
+        createPatchedTile(view, bounds, index, terrain[index]!, fog[index]!, walkable[index]!, overlaysByIndex.get(index))
+      )
+    : (() => {
+        if (!baseView || baseView.map.width !== view.map.width || baseView.map.height !== view.map.height) {
+          throw new Error("missing_player_world_view_base");
+        }
+
+        const nextTiles = baseView.map.tiles.map((tile) => ({ ...tile, position: { ...tile.position } }));
+        for (let index = 0; index < tileCount; index += 1) {
+          const nextTile = createPatchedTile(
+            view,
+            bounds,
+            index,
+            terrain[index]!,
+            fog[index]!,
+            walkable[index]!,
+            overlaysByIndex.get(index)
+          );
+          nextTiles[tileIndex(view.map.width, nextTile.position.x, nextTile.position.y)] = nextTile;
+        }
+
+        return nextTiles;
+      })();
 
   return {
     ...view,

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -209,6 +209,74 @@ test("typed-array world map payload is materially smaller than the raw tile JSON
   assert.ok(encodedSize < rawSize * 0.55, `expected encoded payload < 55% of raw size, got ${encodedSize}/${rawSize}`);
 });
 
+test("typed-array world map payload can encode a bounded chunk and merge it back into the previous map", () => {
+  const previous = createLargePlayerWorldView();
+  const next: PlayerWorldView = {
+    ...previous,
+    map: {
+      ...previous.map,
+      tiles: previous.map.tiles.map((tile) =>
+        tile.position.x >= 8 && tile.position.x < 16 && tile.position.y >= 8 && tile.position.y < 16
+          ? {
+              ...tile,
+              fog: "visible",
+              terrain: tile.position.x === 10 && tile.position.y === 10 ? "water" : tile.terrain,
+              walkable: tile.position.x === 10 && tile.position.y === 10 ? false : tile.walkable,
+              resource:
+                tile.position.x === 9 && tile.position.y === 9
+                  ? {
+                      kind: "ore",
+                      amount: 7
+                    }
+                  : tile.resource,
+              occupant:
+                tile.position.x === 11 && tile.position.y === 11
+                  ? {
+                      kind: "neutral",
+                      refId: "neutral-patch"
+                    }
+                  : tile.occupant
+            }
+          : tile
+      )
+    },
+    resources: {
+      gold: previous.resources.gold + 50,
+      wood: previous.resources.wood,
+      ore: previous.resources.ore + 7
+    }
+  };
+
+  const partial = encodePlayerWorldView(next, {
+    bounds: {
+      x: 8,
+      y: 8,
+      width: 8,
+      height: 8
+    }
+  });
+
+  assert.deepEqual(decodePlayerWorldView(partial, previous), next);
+});
+
+test("bounded typed-array world map payload is materially smaller than the full encoded payload", () => {
+  const view = createLargePlayerWorldView();
+  const fullEncoded = encodePlayerWorldView(view);
+  const chunkEncoded = encodePlayerWorldView(view, {
+    bounds: {
+      x: 8,
+      y: 8,
+      width: 8,
+      height: 8
+    }
+  });
+
+  assert.ok(
+    JSON.stringify(chunkEncoded).length < JSON.stringify(fullEncoded).length * 0.3,
+    "expected 8x8 encoded chunk to be less than 30% of full encoded payload"
+  );
+});
+
 function cloneBattleState(state: BattleState): BattleState {
   return structuredClone(state);
 }


### PR DESCRIPTION
## Summary
- add bounded typed-array map encoding metadata so world payloads can carry rectangular tile chunks and merge them back into the previous full map
- switch Colyseus push updates to send hero-centered 3x3 chunk windows for maps larger than 8x8 while keeping connect/action replies full-map
- update both the H5 session client and the Cocos session client to merge partial encoded map pushes, with shared/unit coverage and a server integration test

## Delivered sub-scope for #32
This PR ships a bounded performance slice toward #32 focused on map sync payload handling:
- rectangular TypedArray map serialization
- partial-map decoding/merge on clients
- chunked push sync for non-source clients

It does not close #32 yet. Remaining work still includes broader map-state storage changes, larger-map rollout/config updates, and follow-up profiling/benchmarks.

## Validation
- `npm test`
- `npm run typecheck` *(currently fails on pre-existing repo-wide TypeScript issues unrelated to this PR, including existing Cocos import-extension errors and exact-optional-property mismatches)*
