### PR TITLE
feat: expose hero equipment loadouts for #28

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -2,6 +2,7 @@ import "./styles.css";
 import {
   createHeroSkillTreeView,
   createHeroAttributeBreakdown,
+  createHeroEquipmentLoadoutView,
   createHeroProgressMeterView,
   experienceRequiredForNextLevel,
   getDefaultBattleSkillCatalog,
@@ -422,6 +423,50 @@ function renderHeroAttributePanel(
                 <span>技能 ${row.skills}</span>
                 ${row.other !== 0 ? `<span>其他 ${row.other}</span>` : ""}
               </div>
+            `
+          )
+          .join("")}
+      </div>
+    </section>
+  `;
+}
+
+function renderHeroEquipmentPanel(hero: PlayerWorldView["ownHeroes"][number] | null): string {
+  if (!hero) {
+    return "";
+  }
+
+  const loadout = createHeroEquipmentLoadoutView(hero);
+  const totalBonuses = [
+    loadout.summary.attack !== 0 ? `攻击 +${loadout.summary.attack}` : "",
+    loadout.summary.defense !== 0 ? `防御 +${loadout.summary.defense}` : "",
+    loadout.summary.power !== 0 ? `力量 +${loadout.summary.power}` : "",
+    loadout.summary.knowledge !== 0 ? `知识 +${loadout.summary.knowledge}` : "",
+    loadout.summary.maxHp !== 0 ? `生命上限 +${loadout.summary.maxHp}` : ""
+  ].filter(Boolean);
+
+  return `
+    <section class="hero-equipment-panel info-card" data-testid="hero-equipment-panel">
+      <div class="hero-progress-head">
+        <strong>装备配置</strong>
+        <span class="muted">${totalBonuses.join(" / ") || "当前未提供额外属性"}</span>
+      </div>
+      <div class="hero-equipment-list">
+        ${loadout.slots
+          .map(
+            (slot) => `
+              <article class="hero-equipment-item">
+                <div class="hero-equipment-meta">
+                  <div>
+                    <span class="hero-equipment-slot">${slot.label}</span>
+                    <strong>${escapeHtml(slot.itemName)}</strong>
+                  </div>
+                  ${slot.rarityLabel ? `<span class="status-pill">${slot.rarityLabel}</span>` : ""}
+                </div>
+                <p>${escapeHtml(slot.bonusSummary)}</p>
+                ${slot.specialEffectSummary ? `<p class="hero-equipment-copy">${escapeHtml(slot.specialEffectSummary)}</p>` : ""}
+                ${slot.description ? `<p class="hero-equipment-copy">${escapeHtml(slot.description)}</p>` : ""}
+              </article>
             `
           )
           .join("")}
@@ -2280,6 +2325,7 @@ function render(): void {
           <p data-testid="hero-army">Army ${hero?.armyTemplateId ?? "-"} x ${hero?.armyCount ?? 0}</p>
           <p data-testid="hero-skill-points">Skill Points ${hero?.progression.skillPoints ?? 0}</p>
           <p class="muted" data-testid="hero-preview">${state.previewPlan ? `预览消耗 ${state.previewPlan.moveCost} 步` : state.predictionStatus || "悬停地图格子查看路径"}</p>
+          ${renderHeroEquipmentPanel(hero)}
           ${renderHeroAttributePanel(hero, state.world)}
           <button class="modal-button" data-end-day="true" ${state.battle ? "disabled" : ""}>推进到下一天</button>
           ${renderHeroSkillTree(hero)}

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -387,7 +387,8 @@ h1 {
 }
 
 .hero-progress-panel,
-.hero-attribute-panel {
+.hero-attribute-panel,
+.hero-equipment-panel {
   display: grid;
   gap: 10px;
   margin-top: 12px;
@@ -461,6 +462,43 @@ h1 {
   margin-top: 14px;
   display: grid;
   gap: 12px;
+}
+
+.hero-equipment-list {
+  display: grid;
+  gap: 10px;
+}
+
+.hero-equipment-item {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid rgba(78, 58, 42, 0.08);
+}
+
+.hero-equipment-meta {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.hero-equipment-slot,
+.hero-equipment-copy {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.hero-equipment-slot {
+  display: block;
+  margin-bottom: 2px;
+}
+
+.hero-equipment-item p {
+  font-size: 12px;
+  color: var(--muted);
 }
 
 .hero-skill-tree-head {

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -39,6 +39,23 @@ export interface HeroStats {
   maxHp: number;
 }
 
+export interface HeroBattleSkillState {
+  skillId: string;
+  rank: number;
+}
+
+export interface HeroEquipmentState {
+  weaponId?: string;
+  armorId?: string;
+  accessoryId?: string;
+  trinketIds: string[];
+}
+
+export interface HeroLoadout {
+  learnedSkills: HeroBattleSkillState[];
+  equipment: HeroEquipmentState;
+}
+
 export type HeroStatBonus = Pick<HeroStats, "attack" | "defense" | "power" | "knowledge">;
 
 export interface HeroView {
@@ -53,6 +70,7 @@ export interface HeroView {
   };
   stats: HeroStats;
   progression: HeroProgression;
+  loadout: HeroLoadout;
   armyCount: number;
   armyTemplateId: string;
   learnedSkills: HeroLearnedSkillState[];

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -1,5 +1,9 @@
 import { _decorator, Color, Component, Graphics, Label, Node, Sprite, UIOpacity, UITransform } from "cc";
-import { createHeroAttributeBreakdown, createHeroProgressMeterView } from "../../../../packages/shared/src/hero-progression.ts";
+import {
+  createHeroAttributeBreakdown,
+  createHeroEquipmentLoadoutView,
+  createHeroProgressMeterView
+} from "../../../../packages/shared/src/index.ts";
 import { createHeroSkillTreeView } from "../../../../packages/shared/src/hero-skills.ts";
 import type { BattleSkillId, HeroState } from "../../../../packages/shared/src/models.ts";
 import { getDefaultBattleSkillCatalog } from "../../../../packages/shared/src/world-config.ts";
@@ -68,9 +72,10 @@ function toHeroSkillState(
     stats: { ...hero.stats },
     progression: { ...hero.progression },
     loadout: {
-      learnedSkills: [],
+      learnedSkills: hero.loadout.learnedSkills.map((skill) => ({ ...skill })),
       equipment: {
-        trinketIds: []
+        ...hero.loadout.equipment,
+        trinketIds: [...hero.loadout.equipment.trinketIds]
       }
     },
     armyTemplateId: hero.armyTemplateId,
@@ -109,6 +114,27 @@ function formatHeroLearnedSkills(hero: NonNullable<VeilHudRenderState["update"]>
   }
 
   return learnedSkills.map((skill) => `${skill.skillId} R${skill.rank}`).join(" / ");
+}
+
+function formatHeroEquipmentLines(
+  hero: NonNullable<VeilHudRenderState["update"]>["world"]["ownHeroes"][number] | null
+): string[] {
+  if (!hero) {
+    return ["装备 等待房间状态...", ""];
+  }
+
+  const loadout = createHeroEquipmentLoadoutView(toHeroSkillState(hero));
+  const equipped = loadout.slots.map((slot) => `${slot.label} ${slot.itemName}`);
+  const detail = loadout.slots
+    .filter((slot) => slot.itemId && slot.item)
+    .map((slot) => `${slot.label} ${slot.bonusSummary}`);
+  const effectLine = loadout.summary.specialEffects.map((effect) => effect.name).join(" / ");
+
+  return [
+    `装备 ${equipped.join("  ·  ")}`,
+    detail.length > 0 ? detail.join("  ·  ") : "装备效果 等待拾取或替换",
+    effectLine ? `特效 ${effectLine}` : ""
+  ];
 }
 
 export interface VeilHudRenderState {
@@ -179,6 +205,7 @@ export class VeilHudPanel extends Component {
     const learnableSkills = listLearnableHeroSkills(hero);
     const progressMeter = hero ? createHeroProgressMeterView(toHeroSkillState(hero)) : null;
     const attributeRows = hero ? createHeroAttributeBreakdown(toHeroSkillState(hero), world ?? undefined) : [];
+    const equipmentLines = formatHeroEquipmentLines(hero);
     const reachableAhead =
       state.update?.reachableTiles.filter((tile) => !hero || tile.x !== hero.position.x || tile.y !== hero.position.y).length ?? 0;
     const statusTitle = state.levelUpNotice?.title ?? "状态";
@@ -245,17 +272,20 @@ export class VeilHudPanel extends Component {
             attributeRows[0] ? `攻防公式 ${attributeRows[0].formula} / ${attributeRows[1]?.formula ?? ""}` : "",
             attributeRows[2] ? `法术公式 ${attributeRows[2].formula} / ${attributeRows[3]?.formula ?? ""}` : "",
             attributeRows[4] ? attributeRows[4].formula : "",
+            equipmentLines[0] ?? "",
+            equipmentLines[1] ?? "",
+            equipmentLines[2] ?? "",
             `兵种 ${hero.armyTemplateId}`,
             `技能 ${formatHeroLearnedSkills(hero)}`
           ]
-        : ["英雄", "等待房间状态...", "", "", "", "", "", ""],
+        : ["英雄", "等待房间状态...", "", "", "", "", "", "", "", "", ""],
       cursorY,
       14,
       18,
       cardWidth,
       leftX,
-      7,
-      182
+      10,
+      232
     );
 
     cursorY = this.renderCardBlock(

--- a/packages/shared/src/equipment.ts
+++ b/packages/shared/src/equipment.ts
@@ -2,7 +2,9 @@ import {
   createDefaultEquipmentStatBonuses,
   type EquipmentCatalogConfig,
   type EquipmentDefinition,
+  type EquipmentRarity,
   type EquipmentStatBonuses,
+  type EquipmentType,
   type HeroState
 } from "./models";
 
@@ -257,6 +259,33 @@ export interface HeroEquipmentBonusSummary extends EquipmentStatBonuses {
   specialEffects: NonNullable<EquipmentDefinition["specialEffect"]>[];
 }
 
+export interface HeroEquipmentSlotView {
+  slot: EquipmentType;
+  label: string;
+  itemId: string | null;
+  item: EquipmentDefinition | null;
+  itemName: string;
+  rarityLabel: string | null;
+  description: string | null;
+  bonusSummary: string;
+  specialEffectSummary: string | null;
+}
+
+export interface HeroEquipmentLoadoutView {
+  slots: HeroEquipmentSlotView[];
+  summary: HeroEquipmentBonusSummary;
+}
+
+const EQUIPMENT_SLOT_META: Array<{
+  slot: EquipmentType;
+  label: string;
+  key: "weaponId" | "armorId" | "accessoryId";
+}> = [
+  { slot: "weapon", label: "武器", key: "weaponId" },
+  { slot: "armor", label: "护甲", key: "armorId" },
+  { slot: "accessory", label: "饰品", key: "accessoryId" }
+];
+
 function numericBonus(value: number | undefined): number {
   return Number.isFinite(value) ? Number(value) : 0;
 }
@@ -271,6 +300,24 @@ function percentageDelta(base: number, percent: number): number {
   }
 
   return Math.round(Math.max(0, base) * (percent / 100));
+}
+
+function equipmentRarityLabel(rarity: EquipmentRarity): string {
+  return rarity === "common" ? "普通" : rarity === "rare" ? "稀有" : "史诗";
+}
+
+export function formatEquipmentBonusSummary(
+  bonuses: Partial<EquipmentStatBonuses>
+): string {
+  const parts = [
+    numericBonus(bonuses.attackPercent) !== 0 ? `攻击 +${numericBonus(bonuses.attackPercent)}%` : "",
+    numericBonus(bonuses.defensePercent) !== 0 ? `防御 +${numericBonus(bonuses.defensePercent)}%` : "",
+    numericBonus(bonuses.power) !== 0 ? `力量 +${numericBonus(bonuses.power)}` : "",
+    numericBonus(bonuses.knowledge) !== 0 ? `知识 +${numericBonus(bonuses.knowledge)}` : "",
+    numericBonus(bonuses.maxHp) !== 0 ? `生命上限 +${numericBonus(bonuses.maxHp)}` : ""
+  ].filter(Boolean);
+
+  return parts.join(" / ") || "无属性加成";
 }
 
 export function getDefaultEquipmentCatalog(): EquipmentCatalogConfig {
@@ -317,5 +364,56 @@ export function createHeroEquipmentBonusSummary(
     specialEffects: resolvedItems
       .flatMap((item) => (item.specialEffect ? [item.specialEffect] : []))
       .filter((effect, index, effects) => effects.findIndex((item) => item.id === effect.id) === index)
+  };
+}
+
+export function createHeroEquipmentLoadoutView(
+  hero: Pick<HeroState, "stats" | "loadout">
+): HeroEquipmentLoadoutView {
+  return {
+    slots: EQUIPMENT_SLOT_META.map(({ slot, label, key }) => {
+      const itemId = hero.loadout.equipment[key];
+      const item = resolveEquipmentDefinition(itemId);
+      if (!itemId) {
+        return {
+          slot,
+          label,
+          itemId: null,
+          item: null,
+          itemName: "未装备",
+          rarityLabel: null,
+          description: null,
+          bonusSummary: "等待拾取或替换",
+          specialEffectSummary: null
+        };
+      }
+
+      if (!item) {
+        return {
+          slot,
+          label,
+          itemId,
+          item: null,
+          itemName: `未知装备 (${itemId})`,
+          rarityLabel: null,
+          description: null,
+          bonusSummary: "装备目录缺失",
+          specialEffectSummary: null
+        };
+      }
+
+      return {
+        slot,
+        label,
+        itemId: item.id,
+        item,
+        itemName: item.name,
+        rarityLabel: equipmentRarityLabel(item.rarity),
+        description: item.description,
+        bonusSummary: formatEquipmentBonusSummary(item.bonuses),
+        specialEffectSummary: item.specialEffect ? `${item.specialEffect.name}: ${item.specialEffect.description}` : null
+      };
+    }),
+    summary: createHeroEquipmentBonusSummary(hero)
   };
 }

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -6,6 +6,7 @@ import {
   applyBattleOutcomeToWorld,
   createHeroAttributeBreakdown,
   createHeroEquipmentBonusSummary,
+  createHeroEquipmentLoadoutView,
   createHeroSkillTreeView,
   createHeroProgressMeterView,
   createBattleEnvironmentState,
@@ -492,6 +493,67 @@ test("equipment catalog exposes the minimum foundation set and resolves hero bon
     bonuses.specialEffects.map((effect) => effect.id).sort(),
     ["channeling", "momentum", "ward"]
   );
+});
+
+test("hero equipment loadout view resolves slot metadata for equipped and empty slots", () => {
+  const hero = createHero({
+    id: "hero-equip-view",
+    playerId: "player-1",
+    name: "装备视图测试",
+    stats: {
+      attack: 5,
+      defense: 4,
+      power: 1,
+      knowledge: 2,
+      hp: 30,
+      maxHp: 30
+    },
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "sunforged_spear",
+        accessoryId: "oracle_lens",
+        trinketIds: []
+      }
+    }
+  });
+
+  const view = createHeroEquipmentLoadoutView(hero);
+
+  assert.deepEqual(
+    view.slots.map((slot) => [slot.slot, slot.itemId, slot.rarityLabel]),
+    [
+      ["weapon", "sunforged_spear", "史诗"],
+      ["armor", null, null],
+      ["accessory", "oracle_lens", "史诗"]
+    ]
+  );
+  assert.equal(view.slots[0]?.bonusSummary, "攻击 +16% / 力量 +1");
+  assert.equal(view.slots[1]?.itemName, "未装备");
+  assert.equal(view.slots[1]?.bonusSummary, "等待拾取或替换");
+  assert.equal(view.slots[2]?.specialEffectSummary, "引导: 为后续技能结算预留更高的法术上限。");
+  assert.deepEqual(view.summary.resolvedItemIds, ["sunforged_spear", "oracle_lens"]);
+});
+
+test("hero equipment loadout view tolerates archived ids missing from the equipment catalog", () => {
+  const hero = createHero({
+    id: "hero-equip-missing",
+    playerId: "player-1",
+    name: "残缺档案",
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "missing_weapon",
+        trinketIds: []
+      }
+    }
+  });
+
+  const view = createHeroEquipmentLoadoutView(hero);
+
+  assert.equal(view.slots[0]?.itemName, "未知装备 (missing_weapon)");
+  assert.equal(view.slots[0]?.bonusSummary, "装备目录缺失");
+  assert.deepEqual(view.summary.resolvedItemIds, []);
 });
 
 test("resolveWorldAction starts a battle when a hero reaches a neutral army tile", () => {


### PR DESCRIPTION
## Summary
- add a shared hero equipment loadout view helper that resolves slot labels, rarity, bonus text, and missing archived ids
- surface equipped weapon/armor/accessory details in the H5 hero panel
- fix the Cocos HUD hero adapter so equipment-aware stat formulas use the real loadout and show equipped item summaries

## Scope delivered for #28
This PR ships a mergeable UI/state slice toward #28. It does **not** implement drops, trading, forge interactions, or runtime equip/replace actions yet, so issue #28 should remain open.

## Validation
- `npm run test:shared`
- `npm run test`
- `npx tsc -p packages/shared/tsconfig.json --noEmit`

## Notes
- `npm run typecheck` and `npx tsc -p apps/client/tsconfig.json --noEmit` still fail on pre-existing main-branch issues in `apps/client/src/object-visuals.ts` and other untouched files.