### PR TITLE
feat: add event log and achievement slice for #27

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -190,6 +190,8 @@ const state: AppState = {
   predictionStatus: ""
 };
 
+let accountRefreshPromise: Promise<void> | null = null;
+
 interface PendingPrediction {
   world: PlayerWorldView;
   battle: BattleState | null;
@@ -282,6 +284,61 @@ function formatAccountLastSeen(account: ClientPlayerAccountProfile): string {
 
 function formatGlobalVault(account: ClientPlayerAccountProfile): string {
   return `全局仓库 金币 ${account.globalResources.gold} / 木材 ${account.globalResources.wood} / 矿石 ${account.globalResources.ore}`;
+}
+
+function formatAchievementSummary(account: ClientPlayerAccountProfile): string {
+  const unlocked = account.achievements.filter((achievement) => achievement.unlocked).length;
+  return `成就 ${unlocked}/${account.achievements.length} 已解锁`;
+}
+
+function renderAchievementProgress(account: ClientPlayerAccountProfile): string {
+  if (account.achievements.length === 0) {
+    return '<p class="account-meta">暂无成就数据</p>';
+  }
+
+  return `<div class="account-subsection">
+    <strong>成就进度</strong>
+    <div class="account-achievement-list">
+      ${account.achievements
+        .map((achievement) => {
+          const ratio =
+            achievement.target > 0 ? Math.min(100, Math.round((achievement.current / achievement.target) * 100)) : 0;
+          return `<div class="account-achievement ${achievement.unlocked ? "is-unlocked" : ""}">
+            <div class="account-achievement-head">
+              <span>${escapeHtml(achievement.title)}</span>
+              <span>${achievement.current}/${achievement.target}</span>
+            </div>
+            <div class="account-achievement-bar"><span style="width:${ratio}%"></span></div>
+            <p>${escapeHtml(achievement.description)}</p>
+          </div>`;
+        })
+        .join("")}
+    </div>
+  </div>`;
+}
+
+function renderRecentAccountEvents(account: ClientPlayerAccountProfile): string {
+  if (account.recentEventLog.length === 0) {
+    return '<div class="account-subsection"><strong>世界事件日志</strong><p class="account-meta">尚未记录关键事件。</p></div>';
+  }
+
+  return `<div class="account-subsection">
+    <strong>世界事件日志</strong>
+    <div class="account-event-list">
+      ${account.recentEventLog
+        .slice(0, 4)
+        .map((entry) => {
+          const rewards =
+            entry.rewards.length > 0
+              ? ` · ${entry.rewards
+                  .map((reward) => (reward.amount != null ? `${reward.label} +${reward.amount}` : reward.label))
+                  .join(" / ")}`
+              : "";
+          return `<p class="account-event-entry">${escapeHtml(entry.description)}${escapeHtml(rewards)}</p>`;
+        })
+        .join("")}
+    </div>
+  </div>`;
 }
 
 function formatLobbyRoomUpdatedAt(updatedAt: string): string {
@@ -1304,7 +1361,35 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
     openBattleModal("战斗结束", "本场遭遇已结束。");
   }
 
+  if (
+    update.events.some(
+      (event) =>
+        event.type === "battle.started" || event.type === "battle.resolved" || event.type === "hero.skillLearned"
+    )
+  ) {
+    void refreshAccountProfileFromServer();
+  }
+
   render();
+}
+
+async function refreshAccountProfileFromServer(): Promise<void> {
+  if (accountRefreshPromise) {
+    return accountRefreshPromise;
+  }
+
+  accountRefreshPromise = (async () => {
+    const account = await loadAccountProfile(playerId, roomId);
+    state.account = account;
+    if (!state.accountSaving) {
+      state.accountDraftName = account.displayName;
+    }
+    render();
+  })().finally(() => {
+    accountRefreshPromise = null;
+  });
+
+  return accountRefreshPromise;
 }
 
 async function previewTile(x: number, y: number): Promise<void> {
@@ -2259,6 +2344,9 @@ function render(): void {
           <p class="account-meta">${escapeHtml(formatCredentialBinding(state.account))}</p>
           <p class="account-meta">${escapeHtml(formatAccountLastSeen(state.account))}</p>
           <p class="account-meta">${escapeHtml(formatGlobalVault(state.account))}</p>
+          <p class="account-meta">${escapeHtml(formatAchievementSummary(state.account))}</p>
+          ${renderAchievementProgress(state.account)}
+          ${renderRecentAccountEvents(state.account)}
           <div class="account-editor">
             <input
               class="account-input"

--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -5,6 +5,12 @@ import {
   storeAuthSession,
   type StoredAuthSession
 } from "./auth-session";
+import {
+  normalizeAchievementProgress,
+  normalizeEventLogEntries,
+  type EventLogEntry,
+  type PlayerAchievementProgress
+} from "../../../packages/shared/src/index";
 
 const PLAYER_ACCOUNT_PREFIX = "project-veil:player-account";
 const PLAYER_ACCOUNT_REQUEST_TIMEOUT_MS = 1200;
@@ -17,6 +23,8 @@ export interface PlayerAccountProfile {
     wood: number;
     ore: number;
   };
+  achievements: PlayerAchievementProgress[];
+  recentEventLog: EventLogEntry[];
   loginId?: string;
   credentialBoundAt?: string;
   lastRoomId?: string;
@@ -33,6 +41,8 @@ interface PlayerAccountApiPayload {
       wood?: number;
       ore?: number;
     };
+    achievements?: Partial<PlayerAchievementProgress>[];
+    recentEventLog?: Partial<EventLogEntry>[];
     loginId?: string;
     credentialBoundAt?: string;
     lastRoomId?: string;
@@ -129,6 +139,8 @@ function asPlayerAccountProfile(
     playerId,
     displayName: normalizePlayerDisplayName(playerId, account?.displayName ?? fallbackDisplayName),
     globalResources: normalizeGlobalResources(account?.globalResources),
+    achievements: normalizeAchievementProgress(account?.achievements),
+    recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
     ...(loginId ? { loginId } : {}),
     ...(account?.credentialBoundAt ? { credentialBoundAt: account.credentialBoundAt } : {}),
     ...(account?.lastRoomId ? { lastRoomId: account.lastRoomId } : roomId ? { lastRoomId: roomId } : {}),
@@ -166,6 +178,8 @@ export function createFallbackPlayerAccountProfile(
     playerId,
     displayName: normalizePlayerDisplayName(playerId, displayName),
     globalResources: normalizeGlobalResources(),
+    achievements: normalizeAchievementProgress(),
+    recentEventLog: normalizeEventLogEntries(),
     ...(roomId ? { lastRoomId: roomId } : {}),
     source: "local"
   };

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -304,6 +304,57 @@ h1 {
   margin-top: 12px;
 }
 
+.account-subsection {
+  margin-top: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.account-achievement-list,
+.account-event-list {
+  display: grid;
+  gap: 8px;
+}
+
+.account-achievement {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(78, 58, 42, 0.06);
+}
+
+.account-achievement.is-unlocked {
+  background: rgba(47, 110, 91, 0.1);
+}
+
+.account-achievement-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.account-achievement-bar {
+  height: 6px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(78, 58, 42, 0.12);
+}
+
+.account-achievement-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #4a7f73, #8ab49c);
+}
+
+.account-achievement p,
+.account-event-entry {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
 .account-binding-card {
   display: grid;
   gap: 10px;

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -40,6 +40,36 @@ test("player account helpers can build a local fallback profile", () => {
       wood: 0,
       ore: 0
     },
+    achievements: [
+      {
+        id: "first_battle",
+        title: "初次交锋",
+        description: "首次进入战斗。",
+        metric: "battles_started",
+        current: 0,
+        target: 1,
+        unlocked: false
+      },
+      {
+        id: "enemy_slayer",
+        title: "猎敌者",
+        description: "击败 3 名敌人或中立守军。",
+        metric: "battles_won",
+        current: 0,
+        target: 3,
+        unlocked: false
+      },
+      {
+        id: "skill_scholar",
+        title: "求知者",
+        description: "学习 5 个长期技能。",
+        metric: "skills_learned",
+        current: 0,
+        target: 5,
+        unlocked: false
+      }
+    ],
+    recentEventLog: [],
     lastRoomId: "room-beta",
     source: "local"
   });

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -8,6 +8,7 @@ import { createHeroSkillTreeView } from "../../../../packages/shared/src/hero-sk
 import type { BattleSkillId, HeroState } from "../../../../packages/shared/src/models.ts";
 import { getDefaultBattleSkillCatalog } from "../../../../packages/shared/src/world-config.ts";
 import type { SessionUpdate } from "./VeilCocosSession.ts";
+import type { CocosPlayerAccountProfile } from "./cocos-lobby.ts";
 import { getPlaceholderSpriteAssets, loadPlaceholderSpriteAssets } from "./cocos-placeholder-sprites.ts";
 import { assignUiLayer } from "./cocos-ui-layer.ts";
 
@@ -141,6 +142,7 @@ export interface VeilHudRenderState {
   roomId: string;
   playerId: string;
   displayName: string;
+  account: CocosPlayerAccountProfile;
   authMode: "guest" | "account";
   loginId: string;
   sessionSource: "remote" | "local" | "manual" | "none";
@@ -161,6 +163,19 @@ export interface VeilHudPanelOptions {
   onLearnSkill?: (skillId: string) => void;
   onEndDay?: () => void;
   onReturnLobby?: () => void;
+}
+
+function formatAchievementSummary(account: CocosPlayerAccountProfile): string {
+  const unlocked = account.achievements.filter((achievement) => achievement.unlocked).length;
+  const latestUnlocked = account.achievements.find((achievement) => achievement.unlockedAt);
+  return latestUnlocked
+    ? `成就 ${unlocked}/${account.achievements.length} · 最新 ${latestUnlocked.title}`
+    : `成就 ${unlocked}/${account.achievements.length} · 尚未解锁`;
+}
+
+function formatRecentEventLog(account: CocosPlayerAccountProfile): string {
+  const latest = account.recentEventLog[0];
+  return latest ? `日志 ${latest.description}` : "日志 尚未记录关键事件";
 }
 
 @ccclass("ProjectVeilHudPanel")
@@ -315,14 +330,14 @@ export class VeilHudPanel extends Component {
     cursorY = this.renderCardBlock(
       this.statusLabel,
       `${CARD_PREFIX}-status`,
-      [statusTitle, statusDetail],
+      [statusTitle, statusDetail, formatAchievementSummary(state.account), formatRecentEventLog(state.account)],
       cursorY,
       12,
       16,
       cardWidth,
       leftX,
-      2,
-      62
+      4,
+      98
     );
 
     if (resources) {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -133,6 +133,7 @@ export class VeilRoot extends Component {
   private lobbyEntering = false;
   private lobbyAccountProfile: CocosPlayerAccountProfile = createFallbackCocosPlayerAccountProfile("player-1", "test-room");
   private lobbyAccountEpoch = 0;
+  private gameplayAccountRefreshInFlight = false;
 
   onLoad(): void {
     this.hydrateLaunchIdentity();
@@ -542,6 +543,7 @@ export class VeilRoot extends Component {
       roomId: this.roomId,
       playerId: this.playerId,
       displayName: this.displayName || this.playerId,
+      account: this.lobbyAccountProfile,
       authMode: this.authMode,
       loginId: this.loginId,
       sessionSource: this.sessionSource,
@@ -1703,6 +1705,14 @@ export class VeilRoot extends Component {
     if (eventEntries.length > 0) {
       this.timelineEntries = collapseAdjacentEntries([...eventEntries, ...this.timelineEntries]).slice(0, 12);
     }
+    if (
+      update.events.some(
+        (event) =>
+          event.type === "battle.started" || event.type === "battle.resolved" || event.type === "hero.skillLearned"
+      )
+    ) {
+      void this.refreshGameplayAccountProfile();
+    }
     this.syncSelectedBattleTarget();
     this.playMapFeedbackForUpdate(update);
     this.maybeShowHeroProgressNotice(update);
@@ -1721,6 +1731,32 @@ export class VeilRoot extends Component {
     }
 
     this.renderView();
+  }
+
+  private async refreshGameplayAccountProfile(): Promise<void> {
+    if (this.gameplayAccountRefreshInFlight) {
+      return;
+    }
+
+    this.gameplayAccountRefreshInFlight = true;
+    try {
+      this.lobbyAccountProfile = await loadCocosPlayerAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
+        storage: this.readWebStorage(),
+        authSession: this.authToken
+          ? {
+              token: this.authToken,
+              playerId: this.playerId,
+              displayName: this.displayName || this.playerId,
+              authMode: this.authMode,
+              ...(this.loginId ? { loginId: this.loginId } : {}),
+              source: "remote"
+            }
+          : null
+      });
+      this.renderView();
+    } finally {
+      this.gameplayAccountRefreshInFlight = false;
+    }
   }
 
   private maybeShowHeroProgressNotice(update: SessionUpdate): void {

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -4,6 +4,12 @@ import {
   type CocosStoredAuthSession,
   writeStoredCocosAuthSession
 } from "./cocos-session-launch.ts";
+import {
+  normalizeAchievementProgress,
+  normalizeEventLogEntries,
+  type EventLogEntry,
+  type PlayerAchievementProgress
+} from "../../../../packages/shared/src/index.ts";
 
 const LOBBY_PREFERENCES_STORAGE_KEY = "project-veil:lobby-preferences";
 const PLAYER_ACCOUNT_PREFIX = "project-veil:player-account";
@@ -33,6 +39,8 @@ export interface CocosPlayerAccountProfile {
     wood: number;
     ore: number;
   };
+  achievements: PlayerAchievementProgress[];
+  recentEventLog: EventLogEntry[];
   loginId?: string;
   credentialBoundAt?: string;
   lastRoomId?: string;
@@ -59,6 +67,8 @@ interface PlayerAccountApiPayload extends AuthSessionApiPayload {
       wood?: number;
       ore?: number;
     };
+    achievements?: Partial<PlayerAchievementProgress>[];
+    recentEventLog?: Partial<EventLogEntry>[];
     loginId?: string;
     credentialBoundAt?: string;
     lastRoomId?: string;
@@ -167,6 +177,8 @@ function asCocosPlayerAccountProfile(
     playerId,
     displayName: normalizeDisplayName(playerId, account?.displayName ?? fallbackDisplayName),
     globalResources: normalizeGlobalResources(account?.globalResources),
+    achievements: normalizeAchievementProgress(account?.achievements),
+    recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
     ...(loginId ? { loginId } : {}),
     ...(account?.credentialBoundAt ? { credentialBoundAt: account.credentialBoundAt } : {}),
     ...(account?.lastRoomId ? { lastRoomId: account.lastRoomId } : roomId ? { lastRoomId: roomId } : {}),
@@ -263,6 +275,8 @@ export function createFallbackCocosPlayerAccountProfile(
     playerId,
     displayName: normalizeDisplayName(playerId, displayName),
     globalResources: normalizeGlobalResources(),
+    achievements: normalizeAchievementProgress(),
+    recentEventLog: normalizeEventLogEntries(),
     ...(roomId ? { lastRoomId: roomId } : {}),
     source: "local"
   };

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -231,6 +231,27 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
             displayName: "暮潮守望",
             loginId: "veil-ranger",
             lastRoomId: "room-beta",
+            achievements: [
+              {
+                id: "first_battle",
+                current: 1,
+                target: 1,
+                unlocked: true,
+                unlockedAt: "2026-03-25T13:00:00.000Z"
+              }
+            ],
+            recentEventLog: [
+              {
+                id: "account-player:2026-03-25T13:00:00.000Z:achievement:1:first_battle",
+                timestamp: "2026-03-25T13:00:00.000Z",
+                roomId: "room-beta",
+                playerId: "account-player",
+                category: "achievement",
+                description: "解锁成就：初次交锋",
+                achievementId: "first_battle",
+                rewards: [{ type: "badge", label: "初次交锋" }]
+              }
+            ],
             globalResources: {
               gold: 320,
               wood: 5,
@@ -263,8 +284,50 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
       wood: 5,
       ore: 2
     },
+    achievements: [
+      {
+        id: "first_battle",
+        title: "初次交锋",
+        description: "首次进入战斗。",
+        metric: "battles_started",
+        current: 1,
+        target: 1,
+        unlocked: true,
+        unlockedAt: "2026-03-25T13:00:00.000Z"
+      },
+      {
+        id: "enemy_slayer",
+        title: "猎敌者",
+        description: "击败 3 名敌人或中立守军。",
+        metric: "battles_won",
+        current: 0,
+        target: 3,
+        unlocked: false
+      },
+      {
+        id: "skill_scholar",
+        title: "求知者",
+        description: "学习 5 个长期技能。",
+        metric: "skills_learned",
+        current: 0,
+        target: 5,
+        unlocked: false
+      }
+    ],
     loginId: "veil-ranger",
     lastRoomId: "room-beta",
+    recentEventLog: [
+      {
+        id: "account-player:2026-03-25T13:00:00.000Z:achievement:1:first_battle",
+        timestamp: "2026-03-25T13:00:00.000Z",
+        roomId: "room-beta",
+        playerId: "account-player",
+        category: "achievement",
+        description: "解锁成就：初次交锋",
+        achievementId: "first_battle",
+        rewards: [{ type: "badge", label: "初次交锋" }]
+      }
+    ],
     source: "remote"
   });
   assert.ok(values.get("project-veil:auth-session")?.includes("\"loginId\":\"veil-ranger\""));

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -17,6 +17,7 @@ import {
   applyPlayerHeroArchivesToWorldState,
   type RoomSnapshotStore
 } from "./persistence";
+import { applyPlayerEventLogAndAchievements } from "./player-achievements";
 import { resolveGuestAuthSession } from "./auth";
 
 type MessageOfType<T extends ServerMessage["type"]> = Omit<Extract<ServerMessage, { type: T }>, "type">;
@@ -225,6 +226,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         sendMessage(client, "error", { requestId: message.requestId, reason: "persistence_save_failed" });
         return;
       }
+      await this.persistPlayerAccountProgress(result.events ?? []);
 
       this.publishLobbyRoomSummary();
       sendMessage(client, "session.state", {
@@ -259,6 +261,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         sendMessage(client, "error", { requestId: message.requestId, reason: "persistence_save_failed" });
         return;
       }
+      await this.persistPlayerAccountProgress(result.events ?? []);
 
       this.publishLobbyRoomSummary();
       sendMessage(client, "session.state", {
@@ -323,6 +326,39 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     }
 
     await configuredRoomSnapshotStore.save(this.metadata.logicalRoomId, this.worldRoom.serializePersistenceSnapshot());
+  }
+
+  private async persistPlayerAccountProgress(events: WorldEvent[]): Promise<void> {
+    const store = configuredRoomSnapshotStore;
+    if (!store || events.length === 0) {
+      return;
+    }
+
+    const internalState = this.worldRoom.getInternalState();
+    const playerIds = Array.from(new Set(internalState.heroes.map((hero) => hero.playerId)));
+    const accounts = await store.loadPlayerAccounts(playerIds);
+
+    await Promise.all(
+      playerIds.map(async (playerId) => {
+        const playerEvents = filterWorldEventsForPlayer(internalState, playerId, events);
+        if (playerEvents.length === 0) {
+          return;
+        }
+
+        const existingAccount =
+          accounts.find((account) => account.playerId === playerId) ??
+          (await store.ensurePlayerAccount({
+            playerId,
+            lastRoomId: this.metadata.logicalRoomId
+          }));
+        const nextAccount = applyPlayerEventLogAndAchievements(existingAccount, internalState, playerEvents);
+        await store.savePlayerAccountProgress(playerId, {
+          achievements: nextAccount.achievements,
+          recentEventLog: nextAccount.recentEventLog,
+          lastRoomId: this.metadata.logicalRoomId
+        });
+      })
+    ).catch(() => undefined);
   }
 
   private publishLobbyRoomSummary(): void {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -1,5 +1,14 @@
 import { createConnection, createPool, type Pool, type PoolConnection, type ResultSetHeader, type RowDataPacket } from "mysql2/promise";
-import { normalizeHeroState, type HeroState, type ResourceLedger, type WorldState } from "../../../packages/shared/src/index";
+import {
+  normalizeAchievementProgress,
+  normalizeEventLogEntries,
+  normalizeHeroState,
+  type EventLogEntry,
+  type HeroState,
+  type PlayerAchievementProgress,
+  type ResourceLedger,
+  type WorldState
+} from "../../../packages/shared/src/index";
 import type { RoomPersistenceSnapshot } from "./index";
 
 export interface RoomSnapshotStore {
@@ -15,6 +24,7 @@ export interface RoomSnapshotStore {
     input: PlayerAccountCredentialInput
   ): Promise<PlayerAccountSnapshot>;
   savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot>;
+  savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot>;
   listPlayerAccounts(options?: PlayerAccountListOptions): Promise<PlayerAccountSnapshot[]>;
   save(roomId: string, snapshot: RoomPersistenceSnapshot): Promise<void>;
   delete(roomId: string): Promise<void>;
@@ -73,6 +83,8 @@ interface PlayerAccountRow extends RowDataPacket {
   player_id: string;
   display_name: string | null;
   global_resources_json: string | ResourceLedger;
+  achievements_json: string | PlayerAchievementProgress[] | null;
+  recent_event_log_json: string | EventLogEntry[] | null;
   last_room_id: string | null;
   last_seen_at: Date | string | null;
   login_id: string | null;
@@ -120,6 +132,8 @@ export interface PlayerAccountSnapshot {
   playerId: string;
   displayName: string;
   globalResources: ResourceLedger;
+  achievements: PlayerAchievementProgress[];
+  recentEventLog: EventLogEntry[];
   lastRoomId?: string;
   lastSeenAt?: string;
   loginId?: string;
@@ -150,6 +164,12 @@ export interface PlayerAccountEnsureInput {
 
 export interface PlayerAccountProfilePatch {
   displayName?: string;
+  lastRoomId?: string | null;
+}
+
+export interface PlayerAccountProgressPatch {
+  achievements?: Partial<PlayerAchievementProgress>[] | null;
+  recentEventLog?: Partial<EventLogEntry>[] | null;
   lastRoomId?: string | null;
 }
 
@@ -279,6 +299,8 @@ function normalizePlayerAccountSnapshot(account: {
   playerId: string;
   displayName?: string | null | undefined;
   globalResources?: Partial<ResourceLedger>;
+  achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
+  recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
   loginId?: string | null | undefined;
@@ -292,6 +314,8 @@ function normalizePlayerAccountSnapshot(account: {
     playerId,
     displayName: normalizePlayerDisplayName(playerId, account.displayName),
     globalResources: normalizeResourceLedger(account.globalResources),
+    achievements: normalizeAchievementProgress(account.achievements),
+    recentEventLog: normalizeEventLogEntries(account.recentEventLog),
     ...(account.lastRoomId ? { lastRoomId: account.lastRoomId } : {}),
     ...(account.lastSeenAt ? { lastSeenAt: account.lastSeenAt } : {}),
     ...(account.loginId ? { loginId: normalizePlayerLoginId(account.loginId) } : {}),
@@ -334,7 +358,9 @@ export function createPlayerAccountsFromWorldState(state: WorldState): PlayerAcc
   return collectPlayerIds(state).map((playerId) => ({
     playerId,
     displayName: normalizePlayerDisplayName(playerId),
-    globalResources: normalizeResourceLedger(state.resources[playerId])
+    globalResources: normalizeResourceLedger(state.resources[playerId]),
+    achievements: normalizeAchievementProgress(),
+    recentEventLog: normalizeEventLogEntries()
   }));
 }
 
@@ -542,6 +568,8 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
   display_name VARCHAR(80) NULL,
   global_resources_json LONGTEXT NOT NULL,
+  achievements_json LONGTEXT NULL,
+  recent_event_log_json LONGTEXT NULL,
   last_room_id VARCHAR(191) NULL,
   last_seen_at DATETIME NULL DEFAULT NULL,
   login_id VARCHAR(40) NULL,
@@ -571,6 +599,42 @@ PREPARE veil_player_accounts_display_name_stmt FROM @veil_player_accounts_displa
 EXECUTE veil_player_accounts_display_name_stmt;
 DEALLOCATE PREPARE veil_player_accounts_display_name_stmt;
 
+SET @veil_player_accounts_achievements_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'achievements_json'
+);
+
+SET @veil_player_accounts_achievements_sql := IF(
+  @veil_player_accounts_achievements_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`achievements_json\` LONGTEXT NULL AFTER \`global_resources_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_achievements_stmt FROM @veil_player_accounts_achievements_sql;
+EXECUTE veil_player_accounts_achievements_stmt;
+DEALLOCATE PREPARE veil_player_accounts_achievements_stmt;
+
+SET @veil_player_accounts_event_log_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'recent_event_log_json'
+);
+
+SET @veil_player_accounts_event_log_sql := IF(
+  @veil_player_accounts_event_log_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`recent_event_log_json\` LONGTEXT NULL AFTER \`achievements_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_event_log_stmt FROM @veil_player_accounts_event_log_sql;
+EXECUTE veil_player_accounts_event_log_stmt;
+DEALLOCATE PREPARE veil_player_accounts_event_log_stmt;
+
 SET @veil_player_accounts_last_room_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.COLUMNS
@@ -581,7 +645,7 @@ SET @veil_player_accounts_last_room_exists := (
 
 SET @veil_player_accounts_last_room_sql := IF(
   @veil_player_accounts_last_room_exists = 0,
-  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`last_room_id\` VARCHAR(191) NULL AFTER \`global_resources_json\`',
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`last_room_id\` VARCHAR(191) NULL AFTER \`recent_event_log_json\`',
   'SELECT 1'
 );
 
@@ -872,6 +936,14 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
   return normalizePlayerAccountSnapshot({
     playerId: row.player_id,
     globalResources: parseJsonColumn<ResourceLedger>(row.global_resources_json),
+    achievements:
+      row.achievements_json != null
+        ? parseJsonColumn<PlayerAchievementProgress[]>(row.achievements_json)
+        : [],
+    recentEventLog:
+      row.recent_event_log_json != null
+        ? parseJsonColumn<EventLogEntry[]>(row.recent_event_log_json)
+        : [],
     ...(row.display_name ? { displayName: row.display_name } : {}),
     ...(row.last_room_id ? { lastRoomId: row.last_room_id } : {}),
     ...(row.login_id ? { loginId: row.login_id } : {}),
@@ -939,16 +1011,26 @@ async function savePlayerAccounts(
   for (const account of accounts) {
     const normalizedAccount = normalizePlayerAccountSnapshot(account);
     await connection.query(
-      `INSERT INTO \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (player_id, display_name, global_resources_json)
-       VALUES (?, ?, ?)
+      `INSERT INTO \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
+         player_id,
+         display_name,
+         global_resources_json,
+         achievements_json,
+         recent_event_log_json
+       )
+       VALUES (?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(display_name, VALUES(display_name)),
          global_resources_json = VALUES(global_resources_json),
+         achievements_json = COALESCE(achievements_json, VALUES(achievements_json)),
+         recent_event_log_json = COALESCE(recent_event_log_json, VALUES(recent_event_log_json)),
          version = version + 1`,
       [
         normalizedAccount.playerId,
         normalizedAccount.displayName,
-        JSON.stringify(normalizedAccount.globalResources)
+        JSON.stringify(normalizedAccount.globalResources),
+        JSON.stringify(normalizedAccount.achievements),
+        JSON.stringify(normalizedAccount.recentEventLog)
       ]
     );
   }
@@ -1067,6 +1149,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         player_id VARCHAR(191) NOT NULL,
         display_name VARCHAR(80) NULL,
         global_resources_json LONGTEXT NOT NULL,
+        achievements_json LONGTEXT NULL,
+        recent_event_log_json LONGTEXT NULL,
         last_room_id VARCHAR(191) NULL,
         last_seen_at DATETIME NULL DEFAULT NULL,
         login_id VARCHAR(40) NULL,
@@ -1115,8 +1199,22 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       pool,
       config.database,
       MYSQL_PLAYER_ACCOUNT_TABLE,
+      "achievements_json",
+      "`achievements_json` LONGTEXT NULL AFTER `global_resources_json`"
+    );
+    await ensureColumnExists(
+      pool,
+      config.database,
+      MYSQL_PLAYER_ACCOUNT_TABLE,
+      "recent_event_log_json",
+      "`recent_event_log_json` LONGTEXT NULL AFTER `achievements_json`"
+    );
+    await ensureColumnExists(
+      pool,
+      config.database,
+      MYSQL_PLAYER_ACCOUNT_TABLE,
       "last_room_id",
-      "`last_room_id` VARCHAR(191) NULL AFTER `global_resources_json`"
+      "`last_room_id` VARCHAR(191) NULL AFTER `recent_event_log_json`"
     );
     await ensureColumnExists(
       pool,
@@ -1342,6 +1440,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          player_id,
          display_name,
          global_resources_json,
+         achievements_json,
+         recent_event_log_json,
          last_room_id,
          last_seen_at,
          login_id,
@@ -1370,6 +1470,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          player_id,
          display_name,
          global_resources_json,
+         achievements_json,
+         recent_event_log_json,
          last_room_id,
          last_seen_at,
          login_id,
@@ -1415,10 +1517,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          player_id,
          display_name,
          global_resources_json,
+         achievements_json,
+         recent_event_log_json,
          last_room_id,
          last_seen_at
        )
-       VALUES (?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(?, display_name),
          last_room_id = COALESCE(?, last_room_id),
@@ -1428,6 +1532,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         playerId,
         insertDisplayName,
         JSON.stringify(normalizeResourceLedger()),
+        JSON.stringify(normalizeAchievementProgress()),
+        JSON.stringify(normalizeEventLogEntries()),
         lastRoomId,
         lastSeenAt,
         explicitDisplayName,
@@ -1441,6 +1547,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         playerId,
         displayName: insertDisplayName,
         globalResources: normalizeResourceLedger(),
+        achievements: normalizeAchievementProgress(),
+        recentEventLog: normalizeEventLogEntries(),
         ...(lastRoomId ? { lastRoomId } : {}),
         lastSeenAt: lastSeenAt.toISOString()
       })
@@ -1519,13 +1627,17 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          player_id,
          display_name,
          global_resources_json,
+         achievements_json,
+         recent_event_log_json,
          last_room_id,
          last_seen_at
        )
-       VALUES (?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          global_resources_json = VALUES(global_resources_json),
+         achievements_json = VALUES(achievements_json),
+         recent_event_log_json = VALUES(recent_event_log_json),
          last_room_id = VALUES(last_room_id),
          last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
          version = version + 1`,
@@ -1533,6 +1645,71 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         nextAccount.playerId,
         nextAccount.displayName,
         JSON.stringify(nextAccount.globalResources),
+        JSON.stringify(nextAccount.achievements),
+        JSON.stringify(nextAccount.recentEventLog),
+        nextAccount.lastRoomId ?? null,
+        existing.lastSeenAt ? new Date(existing.lastSeenAt) : null
+      ]
+    );
+
+    return (
+      (await this.loadPlayerAccount(normalizedPlayerId)) ??
+      normalizePlayerAccountSnapshot({
+        ...nextAccount,
+        ...(existing.lastSeenAt ? { lastSeenAt: existing.lastSeenAt } : {})
+      })
+    );
+  }
+
+  async savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existing =
+      (await this.loadPlayerAccount(normalizedPlayerId)) ??
+      normalizePlayerAccountSnapshot({
+        playerId: normalizedPlayerId,
+        displayName: normalizedPlayerId,
+        globalResources: normalizeResourceLedger()
+      });
+
+    const nextAccount = normalizePlayerAccountSnapshot({
+      ...existing,
+      playerId: normalizedPlayerId,
+      achievements: patch.achievements ?? existing.achievements,
+      recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
+      ...(patch.lastRoomId !== undefined
+        ? patch.lastRoomId
+          ? { lastRoomId: patch.lastRoomId.trim() }
+          : {}
+        : existing.lastRoomId
+          ? { lastRoomId: existing.lastRoomId }
+          : {})
+    });
+
+    await this.pool.query(
+      `INSERT INTO \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
+         player_id,
+         display_name,
+         global_resources_json,
+         achievements_json,
+         recent_event_log_json,
+         last_room_id,
+         last_seen_at
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         display_name = VALUES(display_name),
+         global_resources_json = VALUES(global_resources_json),
+         achievements_json = VALUES(achievements_json),
+         recent_event_log_json = VALUES(recent_event_log_json),
+         last_room_id = VALUES(last_room_id),
+         last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
+         version = version + 1`,
+      [
+        nextAccount.playerId,
+        nextAccount.displayName,
+        JSON.stringify(nextAccount.globalResources),
+        JSON.stringify(nextAccount.achievements),
+        JSON.stringify(nextAccount.recentEventLog),
         nextAccount.lastRoomId ?? null,
         existing.lastSeenAt ? new Date(existing.lastSeenAt) : null
       ]
@@ -1563,6 +1740,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          player_id,
          display_name,
          global_resources_json,
+         achievements_json,
+         recent_event_log_json,
          last_room_id,
          last_seen_at,
          login_id,

--- a/apps/server/src/player-achievements.ts
+++ b/apps/server/src/player-achievements.ts
@@ -1,0 +1,287 @@
+import {
+  appendEventLogEntries,
+  applyAchievementMetricDelta,
+  type AchievementMetric,
+  type EventLogEntry,
+  type EventLogReward,
+  type PlayerAchievementProgress,
+  type WorldEvent,
+  type WorldState
+} from "../../../packages/shared/src/index";
+import type { PlayerAccountSnapshot } from "./persistence";
+
+const RECENT_EVENT_LOG_LIMIT = 12;
+
+function findHero(state: WorldState, heroId?: string): WorldState["heroes"][number] | undefined {
+  return heroId ? state.heroes.find((hero) => hero.id === heroId) : undefined;
+}
+
+function formatResourceReward(label: string, amount: number): EventLogReward {
+  return {
+    type: "resource",
+    label,
+    amount: Math.max(0, Math.floor(amount))
+  };
+}
+
+function createEventId(playerId: string, timestamp: string, worldEventType: WorldEvent["type"], sequence: number): string {
+  return `${playerId}:${timestamp}:${worldEventType}:${sequence}`;
+}
+
+function createEventLogEntry(
+  state: WorldState,
+  playerId: string,
+  event: WorldEvent,
+  timestamp: string,
+  sequence: number
+): EventLogEntry | null {
+  const hero = "heroId" in event ? findHero(state, event.heroId) : undefined;
+
+  switch (event.type) {
+    case "hero.moved":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "movement",
+        description: `${hero?.name ?? event.heroId} 移动了 ${event.moveCost} 点行动力。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: []
+      };
+    case "hero.collected":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "building",
+        description: `${hero?.name ?? event.heroId} 收集了 ${event.resource.kind} x${event.resource.amount}。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: [formatResourceReward(event.resource.kind, event.resource.amount)]
+      };
+    case "hero.recruited":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "building",
+        description: `${hero?.name ?? event.heroId} 在 ${event.buildingId} 招募了 ${event.unitTemplateId} x${event.count}。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: []
+      };
+    case "hero.visited":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "building",
+        description: `${hero?.name ?? event.heroId} 造访了 ${event.buildingId}。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: []
+      };
+    case "hero.claimedMine":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "building",
+        description: `${hero?.name ?? event.heroId} 占领了 ${event.buildingId}，每日产出 ${event.resourceKind} +${event.income}。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: [formatResourceReward(event.resourceKind, event.income)]
+      };
+    case "resource.produced":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "building",
+        description: `${event.buildingId} 产出 ${event.resource.kind} x${event.resource.amount}。`,
+        worldEventType: event.type,
+        rewards: [formatResourceReward(event.resource.kind, event.resource.amount)]
+      };
+    case "hero.progressed":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "combat",
+        description: `${hero?.name ?? event.heroId} 获得 ${event.experienceGained} 经验，升至 ${event.level} 级。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: [
+          {
+            type: "experience",
+            label: "经验",
+            amount: event.experienceGained
+          },
+          {
+            type: "skill_point",
+            label: "技能点",
+            amount: event.skillPointsAwarded
+          }
+        ]
+      };
+    case "hero.skillLearned":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "skill",
+        description: `${hero?.name ?? event.heroId} 学会了 ${event.skillName}。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: []
+      };
+    case "battle.started":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "combat",
+        description:
+          event.encounterKind === "hero"
+            ? `${hero?.name ?? event.heroId} 与敌方英雄交战。`
+            : `${hero?.name ?? event.heroId} 遭遇中立守军。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: []
+      };
+    case "battle.resolved":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "combat",
+        description: `${hero?.name ?? event.heroId} 的战斗结果为 ${
+          event.result === "attacker_victory" ? "胜利" : "失利"
+        }。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: []
+      };
+    case "turn.advanced":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "movement",
+        description: `世界推进到第 ${event.day} 天。`,
+        worldEventType: event.type,
+        rewards: []
+      };
+    default:
+      return null;
+  }
+}
+
+function metricDeltaForEvent(state: WorldState, playerId: string, event: WorldEvent): {
+  metric: AchievementMetric;
+  amount: number;
+} | null {
+  switch (event.type) {
+    case "battle.started":
+      return {
+        metric: "battles_started",
+        amount: 1
+      };
+    case "hero.skillLearned":
+      return {
+        metric: "skills_learned",
+        amount: 1
+      };
+    case "battle.resolved": {
+      const attacker = findHero(state, event.heroId);
+      const defender = findHero(state, event.defenderHeroId);
+      const winningPlayerId =
+        event.result === "attacker_victory" ? attacker?.playerId : defender?.playerId ?? attacker?.playerId;
+      return winningPlayerId === playerId
+        ? {
+            metric: "battles_won",
+            amount: 1
+          }
+        : null;
+    }
+    default:
+      return null;
+  }
+}
+
+function createAchievementUnlockedEntry(
+  state: WorldState,
+  playerId: string,
+  achievement: PlayerAchievementProgress,
+  timestamp: string,
+  sequence: number
+): EventLogEntry {
+  return {
+    id: `${playerId}:${timestamp}:achievement:${sequence}:${achievement.id}`,
+    timestamp,
+    roomId: state.meta.roomId,
+    playerId,
+    category: "achievement",
+    description: `解锁成就：${achievement.title}`,
+    achievementId: achievement.id,
+    rewards: [
+      {
+        type: "badge",
+        label: achievement.title
+      }
+    ]
+  };
+}
+
+export function applyPlayerEventLogAndAchievements(
+  account: PlayerAccountSnapshot,
+  state: WorldState,
+  events: WorldEvent[],
+  timestamp = new Date().toISOString()
+): PlayerAccountSnapshot {
+  let achievements = account.achievements ?? [];
+  const entries: EventLogEntry[] = [];
+  let sequence = 0;
+
+  for (const event of events) {
+    sequence += 1;
+    const entry = createEventLogEntry(state, account.playerId, event, timestamp, sequence);
+    if (entry) {
+      entries.push(entry);
+    }
+
+    const delta = metricDeltaForEvent(state, account.playerId, event);
+    if (!delta) {
+      continue;
+    }
+
+    const result = applyAchievementMetricDelta(achievements, delta.metric, delta.amount, timestamp);
+    achievements = result.progress;
+    for (const unlocked of result.unlocked) {
+      sequence += 1;
+      entries.push(createAchievementUnlockedEntry(state, account.playerId, unlocked, timestamp, sequence));
+    }
+  }
+
+  if (entries.length === 0 && achievements === (account.achievements ?? [])) {
+    return account;
+  }
+
+  return {
+    ...account,
+    achievements,
+    recentEventLog: appendEventLogEntries(account.recentEventLog, entries, RECENT_EVENT_LOG_LIMIT)
+  };
+}

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -6,6 +6,7 @@ import type { ClientMessage, ServerMessage } from "../../../packages/shared/src/
 import { registerAuthRoutes, resetGuestAuthSessions, type GuestAuthSession } from "../src/auth";
 import { configureRoomSnapshotStore, VeilColyseusRoom } from "../src/colyseus-room";
 import type {
+  PlayerAccountProgressPatch,
   PlayerAccountAuthSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
@@ -55,6 +56,8 @@ class MemoryAuthStore implements RoomSnapshotStore {
       playerId,
       displayName: input.displayName?.trim() || existing?.displayName || playerId,
       globalResources: existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 },
+      achievements: structuredClone(existing?.achievements ?? []),
+      recentEventLog: structuredClone(existing?.recentEventLog ?? []),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
@@ -118,6 +121,25 @@ class MemoryAuthStore implements RoomSnapshotStore {
         });
       }
     }
+    return account;
+  }
+
+  async savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
+      recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      ...(patch.lastRoomId !== undefined
+        ? patch.lastRoomId?.trim()
+          ? { lastRoomId: patch.lastRoomId.trim() }
+          : {}
+        : existing.lastRoomId
+          ? { lastRoomId: existing.lastRoomId }
+          : {}),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(account.playerId, account);
     return account;
   }
 

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -15,6 +15,7 @@ import { configureRoomSnapshotStore, VeilColyseusRoom } from "../src/colyseus-ro
 import {
   createPlayerAccountsFromWorldState,
   MAX_PLAYER_DISPLAY_NAME_LENGTH,
+  type PlayerAccountProgressPatch,
   type PlayerAccountAuthSnapshot,
   type PlayerAccountCredentialInput,
   type PlayerAccountSnapshot,
@@ -78,6 +79,8 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       playerId,
       displayName,
       globalResources: structuredClone(existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 }),
+      achievements: structuredClone(existing?.achievements ?? []),
+      recentEventLog: structuredClone(existing?.recentEventLog ?? []),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
@@ -164,6 +167,8 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       this.accounts.set(account.playerId, {
         ...structuredClone(account),
         displayName: previous?.displayName ?? account.displayName,
+        achievements: structuredClone(previous?.achievements ?? account.achievements),
+        recentEventLog: structuredClone(previous?.recentEventLog ?? account.recentEventLog),
         ...(previous?.loginId ? { loginId: previous.loginId } : {}),
         ...(previous?.credentialBoundAt ? { credentialBoundAt: previous.credentialBoundAt } : {}),
         ...(previous?.lastRoomId ? { lastRoomId: previous.lastRoomId } : {}),
@@ -191,11 +196,32 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
 
   async close(): Promise<void> {}
 
+  async savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const nextAccount: PlayerAccountSnapshot = {
+      ...existing,
+      achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
+      recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      ...(patch.lastRoomId !== undefined
+        ? patch.lastRoomId?.trim()
+          ? { lastRoomId: patch.lastRoomId.trim() }
+          : {}
+        : existing.lastRoomId
+          ? { lastRoomId: existing.lastRoomId }
+          : {}),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(playerId.trim(), structuredClone(nextAccount));
+    return structuredClone(nextAccount);
+  }
+
   seedPlayerAccount(account: PlayerAccountSnapshot): void {
     this.accounts.set(account.playerId, {
       playerId: account.playerId,
       displayName: account.displayName,
       globalResources: structuredClone(account.globalResources),
+      achievements: structuredClone(account.achievements),
+      recentEventLog: structuredClone(account.recentEventLog),
       ...(account.lastRoomId ? { lastRoomId: account.lastRoomId } : {}),
       ...(account.lastSeenAt ? { lastSeenAt: account.lastSeenAt } : {}),
       ...(account.loginId ? { loginId: account.loginId } : {}),
@@ -730,7 +756,9 @@ test("colyseus room connect provisions player account metadata without overwriti
       gold: 75,
       wood: 1,
       ore: 0
-    }
+    },
+    achievements: [],
+    recentEventLog: []
   });
 
   let server = await startServer(port, store);

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Server, WebSocketTransport } from "colyseus";
 import { issueAccountAuthSession, issueGuestAuthSession } from "../src/auth";
+import { applyPlayerEventLogAndAchievements } from "../src/player-achievements";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import type {
+  PlayerAccountProgressPatch,
   PlayerAccountAuthSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
@@ -14,6 +16,7 @@ import type {
   RoomSnapshotStore
 } from "../src/persistence";
 import type { RoomPersistenceSnapshot } from "../src/index";
+import { createDefaultHeroLoadout, createDefaultHeroProgression, type WorldState } from "../../../packages/shared/src/index";
 
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
@@ -54,6 +57,8 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       playerId: input.playerId,
       displayName: input.displayName?.trim() || existing?.displayName || input.playerId,
       globalResources: existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 },
+      achievements: structuredClone(existing?.achievements ?? []),
+      recentEventLog: structuredClone(existing?.recentEventLog ?? []),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
@@ -121,6 +126,25 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return account;
   }
 
+  async savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
+      recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      ...(patch.lastRoomId !== undefined
+        ? patch.lastRoomId?.trim()
+          ? { lastRoomId: patch.lastRoomId.trim() }
+          : {}
+        : existing.lastRoomId
+          ? { lastRoomId: existing.lastRoomId }
+          : {}),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(playerId, account);
+    return account;
+  }
+
   async listPlayerAccounts(options: PlayerAccountListOptions = {}): Promise<PlayerAccountSnapshot[]> {
     const accounts = Array.from(this.accounts.values()).filter((account) =>
       options.playerId ? account.playerId === options.playerId : true
@@ -151,6 +175,52 @@ async function startAccountRouteServer(port: number, store: RoomSnapshotStore | 
   return server;
 }
 
+function createAccountTrackingWorldState(): WorldState {
+  return {
+    meta: {
+      roomId: "room-achievement",
+      seed: 1001,
+      day: 1
+    },
+    map: {
+      width: 1,
+      height: 1,
+      tiles: [
+        {
+          position: { x: 0, y: 0 },
+          terrain: "grass",
+          walkable: true,
+          resource: undefined,
+          occupant: undefined,
+          building: undefined
+        }
+      ]
+    },
+    heroes: [
+      {
+        id: "hero-1",
+        playerId: "player-1",
+        name: "暮火侦骑",
+        position: { x: 0, y: 0 },
+        vision: 2,
+        move: { total: 6, remaining: 6 },
+        stats: { attack: 2, defense: 2, power: 1, knowledge: 1, hp: 20, maxHp: 20 },
+        progression: createDefaultHeroProgression(),
+        loadout: createDefaultHeroLoadout(),
+        armyTemplateId: "hero_guard_basic",
+        armyCount: 12,
+        learnedSkills: []
+      }
+    ],
+    neutralArmies: {},
+    buildings: {},
+    resources: {
+      "player-1": { gold: 0, wood: 0, ore: 0 }
+    },
+    visibilityByPlayer: {}
+  };
+}
+
 test("player account routes list and fetch stored accounts", async (t) => {
   const port = 40000 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
@@ -158,6 +228,8 @@ test("player account routes list and fetch stored accounts", async (t) => {
     playerId: "player-1",
     displayName: "灰烬领主",
     globalResources: { gold: 320, wood: 5, ore: 1 },
+    achievements: [],
+    recentEventLog: [],
     lastRoomId: "room-alpha",
     lastSeenAt: new Date("2026-03-25T09:00:00.000Z").toISOString()
   });
@@ -177,6 +249,47 @@ test("player account routes list and fetch stored accounts", async (t) => {
   assert.equal(detailResponse.status, 200);
   assert.equal(detailPayload.account.playerId, "player-1");
   assert.equal(detailPayload.account.lastRoomId, "room-alpha");
+});
+
+test("player achievement tracker appends logs and unlocks milestones", () => {
+  const updated = applyPlayerEventLogAndAchievements(
+    {
+      playerId: "player-1",
+      displayName: "暮火侦骑",
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      recentEventLog: []
+    },
+    createAccountTrackingWorldState(),
+    [
+      {
+        type: "battle.started",
+        heroId: "hero-1",
+        encounterKind: "neutral",
+        battleId: "battle-1",
+        neutralArmyId: "neutral-1",
+        path: [{ x: 0, y: 0 }],
+        moveCost: 2
+      },
+      {
+        type: "hero.skillLearned",
+        heroId: "hero-1",
+        skillId: "skill-1",
+        branchId: "branch-1",
+        skillName: "远见",
+        branchName: "战略",
+        newRank: 1,
+        spentPoint: 1,
+        remainingSkillPoints: 0,
+        newlyGrantedBattleSkillIds: []
+      }
+    ],
+    "2026-03-27T12:00:00.000Z"
+  );
+
+  assert.equal(updated.achievements.find((achievement) => achievement.id === "first_battle")?.unlocked, true);
+  assert.equal(updated.recentEventLog[0]?.category, "achievement");
+  assert.match(updated.recentEventLog.map((entry) => entry.description).join(" "), /解锁成就：初次交锋/);
 });
 
 test("player account routes update display names through the account store", async (t) => {
@@ -216,6 +329,8 @@ test("player account me routes resolve and update the current authenticated acco
     playerId: "player-me",
     displayName: "苍穹侦骑",
     globalResources: { gold: 12, wood: 3, ore: 4 },
+    achievements: [],
+    recentEventLog: [],
     lastRoomId: "room-old",
     lastSeenAt: new Date("2026-03-25T11:00:00.000Z").toISOString()
   });
@@ -277,6 +392,8 @@ test("player account me route preserves account-mode sessions and returns the gl
     playerId: "account-player",
     displayName: "暮潮守望",
     globalResources: { gold: 320, wood: 5, ore: 2 },
+    achievements: [],
+    recentEventLog: [],
     loginId: "veil-ranger",
     credentialBoundAt: new Date("2026-03-25T12:00:00.000Z").toISOString(),
     lastRoomId: "room-vault",

--- a/apps/server/test/player-room-profiles.test.ts
+++ b/apps/server/test/player-room-profiles.test.ts
@@ -120,11 +120,13 @@ test("applyPlayerAccountsToWorldState overlays global resources without replacin
   const merged = applyPlayerAccountsToWorldState(snapshot.state, [
     {
       playerId: "player-1",
+      achievements: [],
       globalResources: {
         gold: 900,
         wood: 6,
         ore: 2
-      }
+      },
+      recentEventLog: []
     }
   ]);
 

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -1,0 +1,230 @@
+import type { WorldEvent } from "./models";
+
+export type EventLogCategory = "movement" | "combat" | "building" | "skill" | "achievement";
+export type EventLogRewardType = "resource" | "experience" | "skill_point" | "badge";
+export type AchievementId = "first_battle" | "enemy_slayer" | "skill_scholar";
+export type AchievementMetric = "battles_started" | "battles_won" | "skills_learned";
+
+export interface EventLogReward {
+  type: EventLogRewardType;
+  label: string;
+  amount?: number;
+}
+
+export interface EventLogEntry {
+  id: string;
+  timestamp: string;
+  roomId: string;
+  playerId: string;
+  category: EventLogCategory;
+  description: string;
+  heroId?: string;
+  worldEventType?: WorldEvent["type"];
+  achievementId?: AchievementId;
+  rewards: EventLogReward[];
+}
+
+export interface AchievementDefinition {
+  id: AchievementId;
+  metric: AchievementMetric;
+  title: string;
+  description: string;
+  target: number;
+}
+
+export interface PlayerAchievementProgress {
+  id: AchievementId;
+  title: string;
+  description: string;
+  metric: AchievementMetric;
+  current: number;
+  target: number;
+  unlocked: boolean;
+  unlockedAt?: string;
+}
+
+const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
+  {
+    id: "first_battle",
+    metric: "battles_started",
+    title: "初次交锋",
+    description: "首次进入战斗。",
+    target: 1
+  },
+  {
+    id: "enemy_slayer",
+    metric: "battles_won",
+    title: "猎敌者",
+    description: "击败 3 名敌人或中立守军。",
+    target: 3
+  },
+  {
+    id: "skill_scholar",
+    metric: "skills_learned",
+    title: "求知者",
+    description: "学习 5 个长期技能。",
+    target: 5
+  }
+];
+
+const achievementDefinitionById = new Map(ACHIEVEMENT_DEFINITIONS.map((definition) => [definition.id, definition] as const));
+
+function normalizeTimestamp(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+export function getAchievementDefinitions(): AchievementDefinition[] {
+  return ACHIEVEMENT_DEFINITIONS.map((definition) => ({ ...definition }));
+}
+
+export function normalizeAchievementProgress(
+  progress?: Partial<PlayerAchievementProgress>[] | null
+): PlayerAchievementProgress[] {
+  const progressById = new Map(
+    (progress ?? [])
+      .map((entry) => {
+        const definition = entry?.id ? achievementDefinitionById.get(entry.id) : undefined;
+        if (!definition) {
+          return null;
+        }
+
+        const current = Math.max(0, Math.floor(entry.current ?? 0));
+        const unlockedAt = normalizeTimestamp(entry.unlockedAt);
+        return [
+          definition.id,
+          {
+            id: definition.id,
+            title: definition.title,
+            description: definition.description,
+            metric: definition.metric,
+            current,
+            target: definition.target,
+            unlocked: current >= definition.target || Boolean(unlockedAt),
+            ...(unlockedAt ? { unlockedAt } : {})
+          }
+        ] as const;
+      })
+      .filter((entry): entry is readonly [AchievementId, PlayerAchievementProgress] => Boolean(entry))
+  );
+
+  return ACHIEVEMENT_DEFINITIONS.map((definition) => {
+    const existing = progressById.get(definition.id);
+    return existing ?? {
+      id: definition.id,
+      title: definition.title,
+      description: definition.description,
+      metric: definition.metric,
+      current: 0,
+      target: definition.target,
+      unlocked: false
+    };
+  });
+}
+
+export function applyAchievementMetricDelta(
+  progress: Partial<PlayerAchievementProgress>[] | null | undefined,
+  metric: AchievementMetric,
+  amount: number,
+  unlockedAt = new Date().toISOString()
+): {
+  progress: PlayerAchievementProgress[];
+  unlocked: PlayerAchievementProgress[];
+} {
+  const safeAmount = Math.max(0, Math.floor(amount));
+  const normalized = normalizeAchievementProgress(progress);
+  if (safeAmount <= 0) {
+    return {
+      progress: normalized,
+      unlocked: []
+    };
+  }
+
+  const unlocked: PlayerAchievementProgress[] = [];
+  const nextProgress = normalized.map((entry) => {
+    if (entry.metric !== metric) {
+      return entry;
+    }
+
+    const previousUnlocked = entry.unlocked;
+    const current = Math.min(entry.target, entry.current + safeAmount);
+    const nextEntry: PlayerAchievementProgress = {
+      ...entry,
+      current,
+      unlocked: current >= entry.target,
+      ...(current >= entry.target ? { unlockedAt: entry.unlockedAt ?? unlockedAt } : entry.unlockedAt ? { unlockedAt: entry.unlockedAt } : {})
+    };
+
+    if (!previousUnlocked && nextEntry.unlocked) {
+      unlocked.push(nextEntry);
+    }
+
+    return nextEntry;
+  });
+
+  return {
+    progress: nextProgress,
+    unlocked
+  };
+}
+
+export function normalizeEventLogEntries(entries?: Partial<EventLogEntry>[] | null): EventLogEntry[] {
+  return (entries ?? [])
+    .map((entry, index) => {
+      const id = entry.id?.trim();
+      const timestamp = normalizeTimestamp(entry.timestamp);
+      const roomId = entry.roomId?.trim();
+      const playerId = entry.playerId?.trim();
+      const description = entry.description?.trim();
+      const category = entry.category;
+      if (!id || !timestamp || !roomId || !playerId || !description || !category) {
+        return null;
+      }
+
+      return {
+        id,
+        timestamp,
+        roomId,
+        playerId,
+        category,
+        description,
+        ...(entry.heroId?.trim() ? { heroId: entry.heroId.trim() } : {}),
+        ...(entry.worldEventType ? { worldEventType: entry.worldEventType } : {}),
+        ...(entry.achievementId ? { achievementId: entry.achievementId } : {}),
+        rewards: (entry.rewards ?? [])
+          .map((reward) => {
+            if (!reward?.type || !reward.label?.trim()) {
+              return null;
+            }
+
+            return {
+              type: reward.type,
+              label: reward.label.trim(),
+              ...(reward.amount != null ? { amount: Math.max(0, Math.floor(reward.amount)) } : {})
+            };
+          })
+          .filter((reward): reward is EventLogReward => Boolean(reward))
+      };
+    })
+    .filter((entry): entry is EventLogEntry => Boolean(entry))
+    .sort((left, right) => right.timestamp.localeCompare(left.timestamp) || left.id.localeCompare(right.id))
+    .filter((entry, index, list) => index === list.findIndex((candidate) => candidate.id === entry.id));
+}
+
+export function appendEventLogEntries(
+  existing: Partial<EventLogEntry>[] | null | undefined,
+  incoming: Partial<EventLogEntry>[] | null | undefined,
+  limit = 12
+): EventLogEntry[] {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  const normalizedIncoming = normalizeEventLogEntries(incoming);
+  if (normalizedIncoming.length === 0) {
+    return normalizeEventLogEntries(existing).slice(0, safeLimit);
+  }
+
+  return normalizeEventLogEntries([...normalizedIncoming, ...normalizeEventLogEntries(existing)]).slice(0, safeLimit);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./battle";
 export * from "./equipment";
+export * from "./event-log";
 export * from "./hero-skills";
 export * from "./hero-progression";
 export * from "./map";

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -3,7 +3,9 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import {
   applyBattleAction,
+  appendEventLogEntries,
   applyBattleOutcomeToWorld,
+  applyAchievementMetricDelta,
   createHeroAttributeBreakdown,
   createHeroEquipmentBonusSummary,
   createHeroEquipmentLoadoutView,
@@ -23,6 +25,7 @@ import {
   encodePlayerWorldView,
   filterWorldEventsForPlayer,
   getBattleBalanceConfig,
+  getAchievementDefinitions,
   getDefaultMapObjectsConfig,
   getDefaultBattleSkillCatalog,
   getDefaultHeroSkillTreeConfig,
@@ -199,6 +202,61 @@ test("typed-array world map payload decodes back to the original player world vi
   const view = createLargePlayerWorldView();
 
   assert.deepEqual(decodePlayerWorldView(encodePlayerWorldView(view)), view);
+});
+
+test("achievement helpers unlock milestones and preserve catalog order", () => {
+  const firstPass = applyAchievementMetricDelta([], "battles_started", 1, "2026-03-27T10:00:00.000Z");
+  assert.equal(firstPass.unlocked[0]?.id, "first_battle");
+  assert.equal(firstPass.progress[0]?.unlocked, true);
+
+  const secondPass = applyAchievementMetricDelta(firstPass.progress, "skills_learned", 5, "2026-03-27T10:01:00.000Z");
+  assert.equal(secondPass.unlocked[0]?.id, "skill_scholar");
+  assert.deepEqual(
+    secondPass.progress.map((achievement) => achievement.id),
+    getAchievementDefinitions().map((achievement) => achievement.id)
+  );
+});
+
+test("event log helper keeps newest unique entries first", () => {
+  const merged = appendEventLogEntries(
+    [
+      {
+        id: "older",
+        timestamp: "2026-03-27T09:58:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "movement",
+        description: "older",
+        rewards: []
+      }
+    ],
+    [
+      {
+        id: "newer",
+        timestamp: "2026-03-27T10:00:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "achievement",
+        description: "newer",
+        rewards: []
+      },
+      {
+        id: "older",
+        timestamp: "2026-03-27T09:58:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "movement",
+        description: "older",
+        rewards: []
+      }
+    ],
+    4
+  );
+
+  assert.deepEqual(
+    merged.map((entry) => entry.id),
+    ["newer", "older"]
+  );
 });
 
 test("typed-array world map payload is materially smaller than the raw tile JSON on a 32x32 map", () => {


### PR DESCRIPTION
## Summary
- add shared event-log and achievement progress models for the first mergeable slice of #27
- persist player achievement progress and recent world event history on player accounts, then update them from existing WorldEvent streams in the room loop
- surface recent event history and achievement progress in the H5 account card and Cocos HUD/account loaders
- add focused shared/server/client tests covering normalization, tracking, persistence hooks, and client parsing

## Delivered scope for #27
This PR does **not** complete issue #27.

Delivered here:
- shared event-log types and helpers for movement / combat / building / skill / achievement slices
- server persistence hooks for account-level recent event history
- initial tracked achievements:
  - first battle
  - defeat 3 enemies or neutral guards
  - learn 5 long-term skills
- lightweight UI hooks showing achievement progress and recent world events in H5 and Cocos

Deferred to follow-up work:
- MySQL event_log table as a separate history store
- battle replay storage and play/pause/step controls
- map-exploration and full-epic-equipment achievements

## Validation
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:cocos
- node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/player-account-routes.test.ts ./apps/server/test/colyseus-persistence-recovery.test.ts ./apps/server/test/auth-guest-login.test.ts ./apps/client/test/player-account-storage.test.ts ./apps/cocos-client/test/cocos-lobby.test.ts

## Pre-existing validation issue
- npm run typecheck:client:h5 still fails on pre-existing apps/client/src/object-visuals.ts references to missing visitedHeroIds / ownerPlayerId fields; this PR does not touch that file

Refs #27
