### PR TITLE
feat: add hero equipment inventory flow for #28

### DIFF
--- a/apps/client/src/local-session.ts
+++ b/apps/client/src/local-session.ts
@@ -5,6 +5,7 @@ import type {
   BattleAction,
   BattleState,
   ClientMessage,
+  EquipmentType,
   MovementPlan,
   PlayerWorldView,
   ServerMessage,
@@ -29,6 +30,8 @@ interface GameSession {
   moveHero(heroId: string, destination: Vec2): Promise<SessionUpdate>;
   collect(heroId: string, position: Vec2): Promise<SessionUpdate>;
   learnSkill(heroId: string, skillId: string): Promise<SessionUpdate>;
+  equipHeroItem(heroId: string, slot: EquipmentType, equipmentId: string): Promise<SessionUpdate>;
+  unequipHeroItem(heroId: string, slot: EquipmentType): Promise<SessionUpdate>;
   recruit(heroId: string, buildingId: string): Promise<SessionUpdate>;
   visitBuilding(heroId: string, buildingId: string): Promise<SessionUpdate>;
   claimMine(heroId: string, buildingId: string): Promise<SessionUpdate>;
@@ -317,6 +320,45 @@ class LocalGameSession implements GameSession {
       type: "hero.learnSkill",
       heroId,
       skillId
+    });
+    const events = this.room.filterEventsForPlayer(this.playerId, result.events ?? []);
+    const nextHeroId = result.snapshot.state.ownHeroes[0]?.id;
+    const battle = result.battle ?? this.room.getBattleForPlayer(this.playerId);
+    return {
+      world: result.snapshot.state,
+      battle,
+      events,
+      movementPlan: result.movementPlan ?? null,
+      reachableTiles: nextHeroId && !battle ? listReachableTiles(this.room.getInternalState(), nextHeroId) : [],
+      ...(result.reason ? { reason: result.reason } : {})
+    };
+  }
+
+  async equipHeroItem(heroId: string, slot: EquipmentType, equipmentId: string): Promise<SessionUpdate> {
+    const result = this.room.dispatch(this.playerId, {
+      type: "hero.equip",
+      heroId,
+      slot,
+      equipmentId
+    });
+    const events = this.room.filterEventsForPlayer(this.playerId, result.events ?? []);
+    const nextHeroId = result.snapshot.state.ownHeroes[0]?.id;
+    const battle = result.battle ?? this.room.getBattleForPlayer(this.playerId);
+    return {
+      world: result.snapshot.state,
+      battle,
+      events,
+      movementPlan: result.movementPlan ?? null,
+      reachableTiles: nextHeroId && !battle ? listReachableTiles(this.room.getInternalState(), nextHeroId) : [],
+      ...(result.reason ? { reason: result.reason } : {})
+    };
+  }
+
+  async unequipHeroItem(heroId: string, slot: EquipmentType): Promise<SessionUpdate> {
+    const result = this.room.dispatch(this.playerId, {
+      type: "hero.unequip",
+      heroId,
+      slot
     });
     const events = this.room.filterEventsForPlayer(this.playerId, result.events ?? []);
     const nextHeroId = result.snapshot.state.ownHeroes[0]?.id;
@@ -644,6 +686,45 @@ class RemoteGameSession implements GameSession {
     return update;
   }
 
+  async equipHeroItem(heroId: string, slot: EquipmentType, equipmentId: string): Promise<SessionUpdate> {
+    const response = await this.send<Extract<ServerMessage, { type: "session.state" }>>(
+      {
+        type: "world.action",
+        requestId: this.nextRequestId(),
+        action: {
+          type: "hero.equip",
+          heroId,
+          slot,
+          equipmentId
+        }
+      },
+      "session.state"
+    );
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
+    this.persistSessionReplay(update);
+    return update;
+  }
+
+  async unequipHeroItem(heroId: string, slot: EquipmentType): Promise<SessionUpdate> {
+    const response = await this.send<Extract<ServerMessage, { type: "session.state" }>>(
+      {
+        type: "world.action",
+        requestId: this.nextRequestId(),
+        action: {
+          type: "hero.unequip",
+          heroId,
+          slot
+        }
+      },
+      "session.state"
+    );
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
+    this.persistSessionReplay(update);
+    return update;
+  }
+
   async recruit(heroId: string, buildingId: string): Promise<SessionUpdate> {
     const response = await this.send<Extract<ServerMessage, { type: "session.state" }>>(
       {
@@ -941,6 +1022,14 @@ class RecoverableRemoteGameSession implements GameSession {
 
   async learnSkill(heroId: string, skillId: string): Promise<SessionUpdate> {
     return this.runWithSession((session) => session.learnSkill(heroId, skillId));
+  }
+
+  async equipHeroItem(heroId: string, slot: EquipmentType, equipmentId: string): Promise<SessionUpdate> {
+    return this.runWithSession((session) => session.equipHeroItem(heroId, slot, equipmentId));
+  }
+
+  async unequipHeroItem(heroId: string, slot: EquipmentType): Promise<SessionUpdate> {
+    return this.runWithSession((session) => session.unequipHeroItem(heroId, slot));
   }
 
   async recruit(heroId: string, buildingId: string): Promise<SessionUpdate> {

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -5,11 +5,15 @@ import {
   createHeroEquipmentLoadoutView,
   createHeroProgressMeterView,
   experienceRequiredForNextLevel,
+  formatEquipmentBonusSummary,
+  formatEquipmentRarityLabel,
   getDefaultBattleSkillCatalog,
+  getEquipmentDefinition,
   predictPlayerWorldAction,
   totalExperienceRequiredForLevel,
   type BattleAction,
   type BattleState,
+  type EquipmentType,
   type MovementPlan,
   type PlayerTileView,
   type PlayerWorldView
@@ -488,6 +492,72 @@ function renderHeroAttributePanel(
   `;
 }
 
+function formatEquipmentActionReason(reason: string): string {
+  if (reason === "equipment_not_in_inventory") {
+    return "背包里没有这件装备";
+  }
+
+  if (reason === "equipment_slot_mismatch") {
+    return "装备类型和槽位不匹配";
+  }
+
+  if (reason === "equipment_definition_missing") {
+    return "装备目录缺失，无法装备";
+  }
+
+  if (reason === "equipment_slot_empty") {
+    return "当前槽位没有可卸下的装备";
+  }
+
+  if (reason === "equipment_already_equipped") {
+    return "该装备已经穿戴中";
+  }
+
+  return reason;
+}
+
+function inventoryItemsForSlot(
+  hero: PlayerWorldView["ownHeroes"][number],
+  slot: EquipmentType
+): Array<{
+  itemId: string;
+  name: string;
+  rarityLabel: string;
+  bonusSummary: string;
+  description: string;
+  count: number;
+}> {
+  const counts = new Map<string, number>();
+
+  for (const itemId of hero.loadout.inventory) {
+    const definition = getEquipmentDefinition(itemId);
+    if (!definition || definition.type !== slot) {
+      continue;
+    }
+
+    counts.set(itemId, (counts.get(itemId) ?? 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .map(([itemId, count]) => {
+      const definition = getEquipmentDefinition(itemId);
+      if (!definition) {
+        return null;
+      }
+
+      return {
+        itemId,
+        name: definition.name,
+        rarityLabel: formatEquipmentRarityLabel(definition.rarity),
+        bonusSummary: formatEquipmentBonusSummary(definition.bonuses),
+        description: definition.description,
+        count
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
+    .sort((left, right) => left.name.localeCompare(right.name, "zh-Hans-CN"));
+}
+
 function renderHeroEquipmentPanel(hero: PlayerWorldView["ownHeroes"][number] | null): string {
   if (!hero) {
     return "";
@@ -511,7 +581,9 @@ function renderHeroEquipmentPanel(hero: PlayerWorldView["ownHeroes"][number] | n
       <div class="hero-equipment-list">
         ${loadout.slots
           .map(
-            (slot) => `
+            (slot) => {
+              const inventory = inventoryItemsForSlot(hero, slot.slot);
+              return `
               <article class="hero-equipment-item">
                 <div class="hero-equipment-meta">
                   <div>
@@ -523,8 +595,36 @@ function renderHeroEquipmentPanel(hero: PlayerWorldView["ownHeroes"][number] | n
                 <p>${escapeHtml(slot.bonusSummary)}</p>
                 ${slot.specialEffectSummary ? `<p class="hero-equipment-copy">${escapeHtml(slot.specialEffectSummary)}</p>` : ""}
                 ${slot.description ? `<p class="hero-equipment-copy">${escapeHtml(slot.description)}</p>` : ""}
+                <div class="hero-equipment-actions">
+                  <button
+                    class="hero-equipment-button secondary-button"
+                    data-hero-unequip-slot="${slot.slot}"
+                    ${slot.itemId && !state.battle ? "" : "disabled"}
+                  >卸下</button>
+                  <span class="hero-equipment-copy">背包 ${inventory.reduce((total, item) => total + item.count, 0)} 件可替换</span>
+                </div>
+                <div class="hero-equipment-inventory">
+                  ${
+                    inventory.length > 0
+                      ? inventory
+                          .map(
+                            (item) => `
+                              <button
+                                class="hero-equipment-button"
+                                data-hero-equip-slot="${slot.slot}"
+                                data-hero-equip-id="${item.itemId}"
+                                ${state.battle ? "disabled" : ""}
+                                title="${escapeHtml(`${item.bonusSummary} · ${item.description}`)}"
+                              >${escapeHtml(`${item.name} x${item.count}`)}</button>
+                            `
+                          )
+                          .join("")
+                      : `<span class="hero-equipment-copy muted">暂无可用替换装备</span>`
+                  }
+                </div>
               </article>
-            `
+            `;
+            }
           )
           .join("")}
       </div>
@@ -1604,6 +1704,86 @@ async function onLearnHeroSkill(skillId: string): Promise<void> {
   }
 }
 
+async function onEquipHeroItem(slot: EquipmentType, equipmentId: string): Promise<void> {
+  const hero = activeHero();
+  if (!hero) {
+    return;
+  }
+
+  if (state.battle) {
+    state.predictionStatus = "战斗中无法调整装备";
+    render();
+    return;
+  }
+
+  const definition = getEquipmentDefinition(equipmentId);
+  const session = await getSession();
+  const prediction = predictPlayerWorldAction(state.world, {
+    type: "hero.equip",
+    heroId: hero.id,
+    slot,
+    equipmentId
+  });
+
+  if (!prediction.reason) {
+    applyPendingPrediction({
+      world: prediction.world,
+      movementPlan: prediction.movementPlan,
+      reachableTiles: prediction.reachableTiles,
+      status: `预演中：装备 ${definition?.name ?? equipmentId}`,
+      tone: "loot"
+    });
+    render();
+  }
+
+  try {
+    applyUpdate(await session.equipHeroItem(hero.id, slot, equipmentId));
+  } catch (error) {
+    rollbackPendingPrediction(
+      error instanceof Error ? formatEquipmentActionReason(error.message) : "equip_item_failed"
+    );
+  }
+}
+
+async function onUnequipHeroItem(slot: EquipmentType): Promise<void> {
+  const hero = activeHero();
+  if (!hero) {
+    return;
+  }
+
+  if (state.battle) {
+    state.predictionStatus = "战斗中无法调整装备";
+    render();
+    return;
+  }
+
+  const session = await getSession();
+  const prediction = predictPlayerWorldAction(state.world, {
+    type: "hero.unequip",
+    heroId: hero.id,
+    slot
+  });
+
+  if (!prediction.reason) {
+    applyPendingPrediction({
+      world: prediction.world,
+      movementPlan: prediction.movementPlan,
+      reachableTiles: prediction.reachableTiles,
+      status: "预演中：卸下装备",
+      tone: "loot"
+    });
+    render();
+  }
+
+  try {
+    applyUpdate(await session.unequipHeroItem(hero.id, slot));
+  } catch (error) {
+    rollbackPendingPrediction(
+      error instanceof Error ? formatEquipmentActionReason(error.message) : "unequip_item_failed"
+    );
+  }
+}
+
 async function onBattleAction(action: BattleAction): Promise<void> {
   state.pendingBattleAction = action;
   const session = await getSession();
@@ -2586,6 +2766,29 @@ function render(): void {
       }
 
       void onLearnHeroSkill(skillId);
+    });
+  }
+
+  for (const equipButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-hero-equip-slot]"))) {
+    equipButton.addEventListener("click", () => {
+      const slot = equipButton.dataset.heroEquipSlot as EquipmentType | undefined;
+      const equipmentId = equipButton.dataset.heroEquipId;
+      if (!slot || !equipmentId) {
+        return;
+      }
+
+      void onEquipHeroItem(slot, equipmentId);
+    });
+  }
+
+  for (const unequipButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-hero-unequip-slot]"))) {
+    unequipButton.addEventListener("click", () => {
+      const slot = unequipButton.dataset.heroUnequipSlot as EquipmentType | undefined;
+      if (!slot) {
+        return;
+      }
+
+      void onUnequipHeroItem(slot);
     });
   }
 

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -552,6 +552,43 @@ h1 {
   color: var(--muted);
 }
 
+.hero-equipment-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.hero-equipment-inventory {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hero-equipment-button {
+  appearance: none;
+  border: 1px solid rgba(121, 86, 52, 0.18);
+  background: rgba(249, 244, 231, 0.9);
+  color: var(--ink);
+  border-radius: 999px;
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.hero-equipment-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(47, 110, 91, 0.32);
+  background: rgba(232, 245, 236, 0.96);
+}
+
+.hero-equipment-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .hero-skill-tree-head {
   display: flex;
   align-items: center;

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -54,6 +54,7 @@ export interface HeroEquipmentState {
 export interface HeroLoadout {
   learnedSkills: HeroBattleSkillState[];
   equipment: HeroEquipmentState;
+  inventory: string[];
 }
 
 export type HeroStatBonus = Pick<HeroStats, "attack" | "defense" | "power" | "knowledge">;

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -77,7 +77,8 @@ function toHeroSkillState(
       equipment: {
         ...hero.loadout.equipment,
         trinketIds: [...hero.loadout.equipment.trinketIds]
-      }
+      },
+      inventory: [...hero.loadout.inventory]
     },
     armyTemplateId: hero.armyTemplateId,
     armyCount: hero.armyCount,

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -109,6 +109,7 @@ interface PlayerHeroArchiveRow extends RowDataPacket {
   army_count: number | null;
   learned_skills_json: string | HeroState["loadout"]["learnedSkills"] | null;
   equipment_json: string | HeroState["loadout"]["equipment"] | null;
+  inventory_json: string | HeroState["loadout"]["inventory"] | null;
   updated_at: Date | string;
 }
 
@@ -769,6 +770,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\` (
   army_count INT NULL,
   learned_skills_json LONGTEXT NULL,
   equipment_json LONGTEXT NULL,
+  inventory_json LONGTEXT NULL,
   version BIGINT UNSIGNED NOT NULL DEFAULT 1,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -847,6 +849,24 @@ PREPARE veil_player_hero_archives_equipment_stmt FROM @veil_player_hero_archives
 EXECUTE veil_player_hero_archives_equipment_stmt;
 DEALLOCATE PREPARE veil_player_hero_archives_equipment_stmt;
 
+SET @veil_player_hero_archives_inventory_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}'
+    AND COLUMN_NAME = 'inventory_json'
+);
+
+SET @veil_player_hero_archives_inventory_sql := IF(
+  @veil_player_hero_archives_inventory_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\` ADD COLUMN \`inventory_json\` LONGTEXT NULL AFTER \`equipment_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_hero_archives_inventory_stmt FROM @veil_player_hero_archives_inventory_sql;
+EXECUTE veil_player_hero_archives_inventory_stmt;
+DEALLOCATE PREPARE veil_player_hero_archives_inventory_stmt;
+
 SET @veil_player_hero_archives_idx_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.STATISTICS
@@ -921,7 +941,11 @@ function toPlayerHeroArchiveSnapshot(row: PlayerHeroArchiveRow): PlayerHeroArchi
         equipment:
           row.equipment_json != null
             ? parseJsonColumn<HeroState["loadout"]["equipment"]>(row.equipment_json)
-            : archivedHero.loadout.equipment
+            : archivedHero.loadout.equipment,
+        inventory:
+          row.inventory_json != null
+            ? parseJsonColumn<HeroState["loadout"]["inventory"]>(row.inventory_json)
+            : archivedHero.loadout.inventory
       }
     })
   };
@@ -1043,14 +1067,15 @@ async function savePlayerHeroArchives(
   for (const archive of archives) {
     await connection.query(
       `INSERT INTO \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
-         (player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+         (player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, inventory_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          hero_json = VALUES(hero_json),
          army_template_id = VALUES(army_template_id),
          army_count = VALUES(army_count),
          learned_skills_json = VALUES(learned_skills_json),
          equipment_json = VALUES(equipment_json),
+         inventory_json = VALUES(inventory_json),
          version = version + 1`,
       [
         archive.playerId,
@@ -1059,7 +1084,8 @@ async function savePlayerHeroArchives(
         archive.hero.armyTemplateId,
         archive.hero.armyCount,
         JSON.stringify(archive.hero.loadout.learnedSkills),
-        JSON.stringify(archive.hero.loadout.equipment)
+        JSON.stringify(archive.hero.loadout.equipment),
+        JSON.stringify(archive.hero.loadout.inventory)
       ]
     );
   }
@@ -1171,6 +1197,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         army_count INT NULL,
         learned_skills_json LONGTEXT NULL,
         equipment_json LONGTEXT NULL,
+        inventory_json LONGTEXT NULL,
         version BIGINT UNSIGNED NOT NULL DEFAULT 1,
         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -1271,6 +1298,13 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       MYSQL_PLAYER_HERO_ARCHIVE_TABLE,
       "equipment_json",
       "`equipment_json` LONGTEXT NULL AFTER `learned_skills_json`"
+    );
+    await ensureColumnExists(
+      pool,
+      config.database,
+      MYSQL_PLAYER_HERO_ARCHIVE_TABLE,
+      "inventory_json",
+      "`inventory_json` LONGTEXT NULL AFTER `equipment_json`"
     );
 
     const [indexRows] = await pool.query<RowDataPacket[]>(
@@ -1766,7 +1800,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const placeholders = safePlayerIds.map(() => "?").join(", ");
     const [rows] = await this.pool.query<PlayerHeroArchiveRow[]>(
-      `SELECT player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, updated_at
+      `SELECT player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, inventory_json, updated_at
        FROM \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
        WHERE player_id IN (${placeholders})`,
       safePlayerIds

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -190,6 +190,37 @@ test("room filters event timelines per player without hiding PvP battle results 
   assert.deepEqual(room.filterEventsForPlayer("player-2", events), [events[1], events[2], events[3]]);
 });
 
+test("room equips hero items from carried inventory and emits the equipment change event", () => {
+  const room = createRoom("room-equip", 1001);
+  const state = room.getInternalState();
+  const hero = state.heroes.find((entry) => entry.id === "hero-1");
+
+  if (!hero) {
+    throw new Error("Expected hero-1 to exist");
+  }
+
+  hero.loadout.inventory = ["vanguard_blade", "padded_gambeson", "scout_compass"];
+
+  const result = room.dispatch("player-1", {
+    type: "hero.equip",
+    heroId: "hero-1",
+    slot: "weapon",
+    equipmentId: "vanguard_blade"
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.snapshot.state.ownHeroes[0]?.loadout.equipment.weaponId, "vanguard_blade");
+  assert.deepEqual(result.snapshot.state.ownHeroes[0]?.loadout.inventory, ["padded_gambeson", "scout_compass"]);
+  assert.deepEqual(result.events, [
+    {
+      type: "hero.equipmentChanged",
+      heroId: "hero-1",
+      slot: "weapon",
+      equippedItemId: "vanguard_blade"
+    }
+  ]);
+});
+
 test("room allows recruiting from a recruitment post when the hero stands on it", () => {
   const room = createRoom("room-recruit", 1001);
   const state = room.getInternalState();

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -705,7 +705,8 @@ test("colyseus room hydrates long-term hero archives into fresh rooms", async (t
           armorId: "archive_plate",
           accessoryId: "archive_charm",
           trinketIds: ["ember_token"]
-        }
+        },
+        inventory: ["sunforged_spear", "bastion_plate", "sun_medallion"]
       },
       armyCount: 19
     }
@@ -743,6 +744,11 @@ test("colyseus room hydrates long-term hero archives into fresh rooms", async (t
     accessoryId: "archive_charm",
     trinketIds: ["ember_token"]
   });
+  assert.deepEqual(hydratedState.payload.world.ownHeroes[0]?.loadout.inventory, [
+    "sunforged_spear",
+    "bastion_plate",
+    "sun_medallion"
+  ]);
 });
 
 test("colyseus room connect provisions player account metadata without overwriting custom display names", async (t) => {

--- a/apps/server/test/player-room-profiles.test.ts
+++ b/apps/server/test/player-room-profiles.test.ts
@@ -153,7 +153,8 @@ test("createPlayerHeroArchivesFromWorldState extracts one persistent hero record
         armorId: "march_guard",
         accessoryId: "trail_compass",
         trinketIds: ["wind_charm"]
-      }
+      },
+      inventory: ["sunforged_spear", "ranger_scale", "ember_talisman"]
     },
     progression: {
       ...snapshot.state.heroes[0]!.progression,
@@ -171,6 +172,11 @@ test("createPlayerHeroArchivesFromWorldState extracts one persistent hero record
     { skillId: "armor_spell", rank: 2 }
   ]);
   assert.equal(archives.find((archive) => archive.heroId === "hero-1")?.hero.loadout.equipment.weaponId, "bronze_halberd");
+  assert.deepEqual(archives.find((archive) => archive.heroId === "hero-1")?.hero.loadout.inventory, [
+    "sunforged_spear",
+    "ranger_scale",
+    "ember_talisman"
+  ]);
   assert.equal(archives.find((archive) => archive.heroId === "hero-1")?.hero.progression.skillPoints, 2);
   assert.deepEqual(archives.find((archive) => archive.heroId === "hero-1")?.hero.learnedSkills, [{ skillId: "war_banner", rank: 1 }]);
   assert.equal(archives.find((archive) => archive.heroId === "hero-1")?.hero.armyCount, 16);
@@ -221,7 +227,8 @@ test("applyPlayerHeroArchivesToWorldState restores long-term hero growth but res
             armorId: "warden_plate",
             accessoryId: "sun_medallion",
             trinketIds: ["warding_seal", "iron_branch"]
-          }
+          },
+          inventory: ["sunforged_spear", "warden_aegis", "oracle_lens"]
         },
         armyCount: 18,
         learnedSkills: [{ skillId: "war_banner", rank: 2 }]
@@ -248,6 +255,7 @@ test("applyPlayerHeroArchivesToWorldState restores long-term hero growth but res
     accessoryId: "sun_medallion",
     trinketIds: ["warding_seal", "iron_branch"]
   });
+  assert.deepEqual(hydratedHero?.loadout.inventory, ["sunforged_spear", "warden_aegis", "oracle_lens"]);
   assert.equal(hydratedHero?.progression.skillPoints, 3);
   assert.deepEqual(hydratedHero?.learnedSkills, [{ skillId: "war_banner", rank: 2 }]);
   assert.equal(hydratedHero?.armyCount, 18);
@@ -278,4 +286,5 @@ test("applyPlayerHeroArchivesToWorldState backfills default long-term build fiel
   assert.deepEqual(hydratedHero?.loadout.equipment, {
     trinketIds: []
   });
+  assert.deepEqual(hydratedHero?.loadout.inventory, []);
 });

--- a/configs/phase1-world.json
+++ b/configs/phase1-world.json
@@ -30,6 +30,14 @@
         "neutralBattlesWon": 0,
         "pvpBattlesWon": 0
       },
+      "loadout": {
+        "inventory": [
+          "militia_pike",
+          "vanguard_blade",
+          "padded_gambeson",
+          "scout_compass"
+        ]
+      },
       "armyTemplateId": "hero_guard_basic",
       "armyCount": 12
     },
@@ -60,6 +68,14 @@
         "battlesWon": 0,
         "neutralBattlesWon": 0,
         "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "oak_longbow",
+          "tower_shield_mail",
+          "scribe_charm",
+          "captains_insignia"
+        ]
       },
       "armyTemplateId": "hero_guard_basic",
       "armyCount": 10

--- a/packages/shared/src/equipment.ts
+++ b/packages/shared/src/equipment.ts
@@ -5,7 +5,8 @@ import {
   type EquipmentRarity,
   type EquipmentStatBonuses,
   type EquipmentType,
-  type HeroState
+  type HeroState,
+  type ValidationResult
 } from "./models";
 
 const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
@@ -302,8 +303,21 @@ function percentageDelta(base: number, percent: number): number {
   return Math.round(Math.max(0, base) * (percent / 100));
 }
 
-function equipmentRarityLabel(rarity: EquipmentRarity): string {
+export function formatEquipmentRarityLabel(rarity: EquipmentRarity): string {
   return rarity === "common" ? "普通" : rarity === "rare" ? "稀有" : "史诗";
+}
+
+function slotKeyForEquipmentType(type: EquipmentType): "weaponId" | "armorId" | "accessoryId" {
+  return type === "weapon" ? "weaponId" : type === "armor" ? "armorId" : "accessoryId";
+}
+
+function withoutFirstInventoryMatch(inventory: string[], equipmentId: string): string[] {
+  const index = inventory.indexOf(equipmentId);
+  if (index < 0) {
+    return inventory;
+  }
+
+  return inventory.filter((_, entryIndex) => entryIndex !== index);
 }
 
 export function formatEquipmentBonusSummary(
@@ -332,6 +346,79 @@ export function getDefaultEquipmentCatalog(): EquipmentCatalogConfig {
 
 export function getEquipmentDefinition(equipmentId: string): EquipmentDefinition | undefined {
   return resolveEquipmentDefinition(equipmentId.trim());
+}
+
+export function validateHeroEquipmentChange(
+  hero: Pick<HeroState, "loadout">,
+  slot: EquipmentType,
+  equipmentId?: string
+): ValidationResult {
+  const key = slotKeyForEquipmentType(slot);
+  const currentItemId = hero.loadout.equipment[key];
+  const normalizedEquipmentId = equipmentId?.trim();
+
+  if (!normalizedEquipmentId) {
+    return currentItemId ? { valid: true } : { valid: false, reason: "equipment_slot_empty" };
+  }
+
+  const definition = resolveEquipmentDefinition(normalizedEquipmentId);
+  if (!definition) {
+    return { valid: false, reason: "equipment_definition_missing" };
+  }
+
+  if (definition.type !== slot) {
+    return { valid: false, reason: "equipment_slot_mismatch" };
+  }
+
+  if (currentItemId === normalizedEquipmentId) {
+    return { valid: false, reason: "equipment_already_equipped" };
+  }
+
+  if (!hero.loadout.inventory.includes(normalizedEquipmentId)) {
+    return { valid: false, reason: "equipment_not_in_inventory" };
+  }
+
+  return { valid: true };
+}
+
+export function applyHeroEquipmentChange(
+  hero: HeroState,
+  slot: EquipmentType,
+  equipmentId?: string
+): {
+  hero: HeroState;
+  equippedItemId?: string;
+  unequippedItemId?: string;
+} {
+  const key = slotKeyForEquipmentType(slot);
+  const normalizedEquipmentId = equipmentId?.trim();
+  const currentItemId = hero.loadout.equipment[key];
+  let nextInventory = [...hero.loadout.inventory];
+
+  if (normalizedEquipmentId) {
+    nextInventory = withoutFirstInventoryMatch(nextInventory, normalizedEquipmentId);
+  }
+
+  if (currentItemId) {
+    nextInventory.push(currentItemId);
+  }
+
+  return {
+    hero: {
+      ...hero,
+      loadout: {
+        ...hero.loadout,
+        equipment: {
+          ...hero.loadout.equipment,
+          ...(normalizedEquipmentId ? { [key]: normalizedEquipmentId } : {}),
+          ...(!normalizedEquipmentId ? { [key]: undefined } : {})
+        },
+        inventory: nextInventory
+      }
+    },
+    ...(normalizedEquipmentId ? { equippedItemId: normalizedEquipmentId } : {}),
+    ...(currentItemId ? { unequippedItemId: currentItemId } : {})
+  };
 }
 
 export function createHeroEquipmentBonusSummary(
@@ -408,7 +495,7 @@ export function createHeroEquipmentLoadoutView(
         itemId: item.id,
         item,
         itemName: item.name,
-        rarityLabel: equipmentRarityLabel(item.rarity),
+        rarityLabel: formatEquipmentRarityLabel(item.rarity),
         description: item.description,
         bonusSummary: formatEquipmentBonusSummary(item.bonuses),
         specialEffectSummary: item.specialEffect ? `${item.specialEffect.name}: ${item.specialEffect.description}` : null

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -29,6 +29,7 @@ import type {
   WorldState
 } from "./models";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills";
+import { applyHeroEquipmentChange, validateHeroEquipmentChange } from "./equipment";
 import {
   normalizeHeroState,
   totalExperienceRequiredForLevel
@@ -1378,6 +1379,38 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
     };
   }
 
+  if (action.type === "hero.equip" || action.type === "hero.unequip") {
+    const validation = validateHeroEquipmentChange(
+      hero,
+      action.slot,
+      action.type === "hero.equip" ? action.equipmentId : undefined
+    );
+    if (!validation.valid) {
+      return {
+        world: view,
+        movementPlan: null,
+        reachableTiles: [],
+        ...(validation.reason ? { reason: validation.reason } : {})
+      };
+    }
+
+    const changed = applyHeroEquipmentChange(
+      hero,
+      action.slot,
+      action.type === "hero.equip" ? action.equipmentId : undefined
+    );
+    const predictedWorld: PlayerWorldView = {
+      ...view,
+      ownHeroes: view.ownHeroes.map((item) => (item.id === hero.id ? changed.hero : item))
+    };
+
+    return {
+      world: predictedWorld,
+      movementPlan: null,
+      reachableTiles: listReachableTilesInPlayerView(predictedWorld, hero.id)
+    };
+  }
+
   if (action.type === "hero.move") {
     const destinationTile = findPlayerTile(view, action.destination);
     if (!destinationTile) {
@@ -1807,6 +1840,14 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
     return validateHeroSkillSelection(hero, action.skillId);
   }
 
+  if (action.type === "hero.equip" || action.type === "hero.unequip") {
+    return validateHeroEquipmentChange(
+      hero,
+      action.slot,
+      action.type === "hero.equip" ? action.equipmentId : undefined
+    );
+  }
+
   if (action.type === "hero.recruit") {
     const building = state.buildings[action.buildingId];
     if (!building) {
@@ -2126,6 +2167,47 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
     };
   }
 
+  if (action.type === "hero.equip" || action.type === "hero.unequip") {
+    const hero = state.heroes.find((item) => item.id === action.heroId);
+    if (!hero) {
+      return { state, events: [] };
+    }
+
+    const validation = validateHeroEquipmentChange(
+      hero,
+      action.slot,
+      action.type === "hero.equip" ? action.equipmentId : undefined
+    );
+    if (!validation.valid) {
+      return { state, events: [] };
+    }
+
+    const changed = applyHeroEquipmentChange(
+      hero,
+      action.slot,
+      action.type === "hero.equip" ? action.equipmentId : undefined
+    );
+    const nextState = buildNextWorldState(
+      state,
+      state.heroes.map((item) => (item.id === hero.id ? changed.hero : item)),
+      state.neutralArmies,
+      state.buildings
+    );
+
+    return {
+      state: nextState,
+      events: [
+        {
+          type: "hero.equipmentChanged",
+          heroId: hero.id,
+          slot: action.slot,
+          ...(changed.equippedItemId ? { equippedItemId: changed.equippedItemId } : {}),
+          ...(changed.unequippedItemId ? { unequippedItemId: changed.unequippedItemId } : {})
+        }
+      ]
+    };
+  }
+
   if (action.type === "hero.recruit") {
     const hero = state.heroes.find((item) => item.id === action.heroId);
     const building = state.buildings[action.buildingId];
@@ -2316,6 +2398,7 @@ export function filterWorldEventsForPlayer(
       case "hero.claimedMine":
       case "hero.progressed":
       case "hero.skillLearned":
+      case "hero.equipmentChanged":
         return ownsHero(event.heroId);
       case "neutral.moved": {
         const visibility = state.visibilityByPlayer[playerId];

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -147,6 +147,7 @@ export interface HeroEquipmentState {
 export interface HeroLoadout {
   learnedSkills: HeroBattleSkillState[];
   equipment: HeroEquipmentState;
+  inventory: EquipmentId[];
 }
 
 export interface HeroState {
@@ -179,6 +180,7 @@ export interface HeroEquipmentConfig {
 export interface HeroLoadoutConfig {
   learnedSkills?: HeroBattleSkillConfig[];
   equipment?: HeroEquipmentConfig | null;
+  inventory?: EquipmentId[] | null;
 }
 
 export interface ResourceNode {
@@ -521,6 +523,17 @@ export type WorldAction =
       skillId: HeroSkillId;
     }
   | {
+      type: "hero.equip";
+      heroId: string;
+      slot: EquipmentType;
+      equipmentId: EquipmentId;
+    }
+  | {
+      type: "hero.unequip";
+      heroId: string;
+      slot: EquipmentType;
+    }
+  | {
       type: "turn.endDay";
     };
 
@@ -625,6 +638,13 @@ export type WorldEvent =
       spentPoint: number;
       remainingSkillPoints: number;
       newlyGrantedBattleSkillIds: BattleSkillId[];
+    }
+  | {
+      type: "hero.equipmentChanged";
+      heroId: string;
+      slot: EquipmentType;
+      equippedItemId?: EquipmentId;
+      unequippedItemId?: EquipmentId;
     }
   | {
       type: "battle.started";
@@ -736,8 +756,18 @@ export function normalizeHeroEquipment(
 export function createDefaultHeroLoadout(): HeroLoadout {
   return {
     learnedSkills: [],
-    equipment: createDefaultHeroEquipment()
+    equipment: createDefaultHeroEquipment(),
+    inventory: []
   };
+}
+
+export function normalizeHeroEquipmentInventory(
+  inventory?: EquipmentId[] | null
+): EquipmentId[] {
+  return (inventory ?? [])
+    .filter((itemId): itemId is string => typeof itemId === "string")
+    .map((itemId) => itemId.trim())
+    .filter((itemId) => itemId.length > 0);
 }
 
 export function normalizeHeroLearnedSkills(
@@ -794,7 +824,8 @@ export function normalizeHeroLoadout(
   return {
     ...createDefaultHeroLoadout(),
     learnedSkills: normalizeHeroBattleSkills(loadout?.learnedSkills),
-    equipment: normalizeHeroEquipment(loadout?.equipment)
+    equipment: normalizeHeroEquipment(loadout?.equipment),
+    inventory: normalizeHeroEquipmentInventory(loadout?.inventory)
   };
 }
 

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -614,6 +614,76 @@ test("hero equipment loadout view tolerates archived ids missing from the equipm
   assert.deepEqual(view.summary.resolvedItemIds, []);
 });
 
+test("hero equip and unequip actions rotate items between slots and inventory", () => {
+  const hero = createHero({
+    id: "hero-equip-action",
+    playerId: "player-1",
+    name: "装备流转测试",
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "militia_pike",
+        trinketIds: []
+      },
+      inventory: ["vanguard_blade", "padded_gambeson", "scout_compass"]
+    }
+  });
+  const state = createWorldState({
+    heroes: [hero]
+  });
+
+  assert.deepEqual(validateWorldAction(state, {
+    type: "hero.equip",
+    heroId: "hero-equip-action",
+    slot: "weapon",
+    equipmentId: "padded_gambeson"
+  }), {
+    valid: false,
+    reason: "equipment_slot_mismatch"
+  });
+
+  const equipped = resolveWorldAction(state, {
+    type: "hero.equip",
+    heroId: "hero-equip-action",
+    slot: "weapon",
+    equipmentId: "vanguard_blade"
+  });
+
+  assert.equal(equipped.state.heroes[0]?.loadout.equipment.weaponId, "vanguard_blade");
+  assert.deepEqual(equipped.state.heroes[0]?.loadout.inventory, ["padded_gambeson", "scout_compass", "militia_pike"]);
+  assert.deepEqual(equipped.events, [
+    {
+      type: "hero.equipmentChanged",
+      heroId: "hero-equip-action",
+      slot: "weapon",
+      equippedItemId: "vanguard_blade",
+      unequippedItemId: "militia_pike"
+    }
+  ]);
+
+  const unequipped = resolveWorldAction(equipped.state, {
+    type: "hero.unequip",
+    heroId: "hero-equip-action",
+    slot: "weapon"
+  });
+
+  assert.equal(unequipped.state.heroes[0]?.loadout.equipment.weaponId, undefined);
+  assert.deepEqual(unequipped.state.heroes[0]?.loadout.inventory, [
+    "padded_gambeson",
+    "scout_compass",
+    "militia_pike",
+    "vanguard_blade"
+  ]);
+  assert.deepEqual(unequipped.events, [
+    {
+      type: "hero.equipmentChanged",
+      heroId: "hero-equip-action",
+      slot: "weapon",
+      unequippedItemId: "vanguard_blade"
+    }
+  ]);
+});
+
 test("resolveWorldAction starts a battle when a hero reaches a neutral army tile", () => {
   const hero = createHero({
     id: "hero-1",


### PR DESCRIPTION
## Summary
- add a shared hero-carried equipment inventory model plus authoritative `hero.equip` / `hero.unequip` actions
- persist carried inventory alongside hero archives so equipment survives room saves and fresh-room hydration
- add a basic H5 equipment replacement UI with starter inventory seed data and focused shared/server tests

## Delivered scope for #28
This PR intentionally ships the next mergeable slice of #28 rather than closing the full issue.

Included in this slice:
- shared equipment inventory model on hero loadouts
- authoritative equip/unequip validation and state transitions
- archive persistence hooks for equipped items and carried inventory
- basic client UI hooks for equip/unequip from carried inventory
- starter inventory seed data so the flow is usable in fresh rooms
- regression coverage for world actions, room dispatch, and cross-room archive hydration

Still not included:
- battle victory random drops
- forge/disenchant building flow
- hero-to-hero equipment trading
- richer opponent-facing sync/UI beyond normal authoritative state updates

## Validation
- `node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/authoritative-room.test.ts ./apps/server/test/player-room-profiles.test.ts ./apps/server/test/colyseus-persistence-recovery.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`

## Pre-existing validation failures
- `npm run typecheck:client:h5` still fails in `apps/client/src/object-visuals.ts` because it references stale building fields (`visitedHeroIds`, `ownerPlayerId`) unrelated to this PR.

Refs #28
