### PR TITLE
feat: ship account world event log slice for #27

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -7,6 +7,7 @@ import {
   experienceRequiredForNextLevel,
   formatEquipmentBonusSummary,
   formatEquipmentRarityLabel,
+  getLatestUnlockedAchievement,
   getDefaultBattleSkillCatalog,
   getEquipmentDefinition,
   predictPlayerWorldAction,
@@ -292,7 +293,32 @@ function formatGlobalVault(account: ClientPlayerAccountProfile): string {
 
 function formatAchievementSummary(account: ClientPlayerAccountProfile): string {
   const unlocked = account.achievements.filter((achievement) => achievement.unlocked).length;
-  return `成就 ${unlocked}/${account.achievements.length} 已解锁`;
+  const latestUnlocked = getLatestUnlockedAchievement(account.achievements);
+  return latestUnlocked
+    ? `成就 ${unlocked}/${account.achievements.length} 已解锁 · 最新 ${latestUnlocked.title}`
+    : `成就 ${unlocked}/${account.achievements.length} 已解锁`;
+}
+
+function formatEventLogCategory(category: ClientPlayerAccountProfile["recentEventLog"][number]["category"]): string {
+  switch (category) {
+    case "movement":
+      return "移动";
+    case "combat":
+      return "战斗";
+    case "building":
+      return "建筑";
+    case "skill":
+      return "养成";
+    case "achievement":
+      return "成就";
+    default:
+      return category;
+  }
+}
+
+function formatEventLogTimestamp(timestamp: string): string {
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? timestamp : date.toLocaleString();
 }
 
 function renderAchievementProgress(account: ClientPlayerAccountProfile): string {
@@ -330,7 +356,7 @@ function renderRecentAccountEvents(account: ClientPlayerAccountProfile): string 
     <strong>世界事件日志</strong>
     <div class="account-event-list">
       ${account.recentEventLog
-        .slice(0, 4)
+        .slice(0, 6)
         .map((entry) => {
           const rewards =
             entry.rewards.length > 0
@@ -338,7 +364,13 @@ function renderRecentAccountEvents(account: ClientPlayerAccountProfile): string 
                   .map((reward) => (reward.amount != null ? `${reward.label} +${reward.amount}` : reward.label))
                   .join(" / ")}`
               : "";
-          return `<p class="account-event-entry">${escapeHtml(entry.description)}${escapeHtml(rewards)}</p>`;
+          return `<div class="account-event-entry">
+            <div class="account-event-head">
+              <span class="account-badge">${escapeHtml(formatEventLogCategory(entry.category))}</span>
+              <span>${escapeHtml(formatEventLogTimestamp(entry.timestamp))}</span>
+            </div>
+            <p>${escapeHtml(entry.description)}${escapeHtml(rewards)}</p>
+          </div>`;
         })
         .join("")}
     </div>

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -349,10 +349,26 @@ h1 {
 }
 
 .account-achievement p,
-.account-event-entry {
+.account-event-entry p {
   margin: 0;
   color: var(--muted);
   font-size: 13px;
+}
+
+.account-event-entry {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(78, 58, 42, 0.05);
+}
+
+.account-event-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: var(--muted);
 }
 
 .account-binding-card {

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -2,7 +2,8 @@ import { _decorator, Color, Component, Graphics, Label, Node, Sprite, UIOpacity,
 import {
   createHeroAttributeBreakdown,
   createHeroEquipmentLoadoutView,
-  createHeroProgressMeterView
+  createHeroProgressMeterView,
+  getLatestUnlockedAchievement
 } from "../../../../packages/shared/src/index.ts";
 import { createHeroSkillTreeView } from "../../../../packages/shared/src/hero-skills.ts";
 import type { BattleSkillId, HeroState } from "../../../../packages/shared/src/models.ts";
@@ -168,7 +169,7 @@ export interface VeilHudPanelOptions {
 
 function formatAchievementSummary(account: CocosPlayerAccountProfile): string {
   const unlocked = account.achievements.filter((achievement) => achievement.unlocked).length;
-  const latestUnlocked = account.achievements.find((achievement) => achievement.unlockedAt);
+  const latestUnlocked = getLatestUnlockedAchievement(account.achievements);
   return latestUnlocked
     ? `成就 ${unlocked}/${account.achievements.length} · 最新 ${latestUnlocked.title}`
     : `成就 ${unlocked}/${account.achievements.length} · 尚未解锁`;

--- a/apps/server/src/player-achievements.ts
+++ b/apps/server/src/player-achievements.ts
@@ -11,6 +11,12 @@ import {
 import type { PlayerAccountSnapshot } from "./persistence";
 
 const RECENT_EVENT_LOG_LIMIT = 12;
+const EQUIPMENT_SLOT_LABELS: Record<"weapon" | "armor" | "accessory" | "trinket", string> = {
+  weapon: "武器",
+  armor: "护甲",
+  accessory: "饰品",
+  trinket: "宝物"
+};
 
 function findHero(state: WorldState, heroId?: string): WorldState["heroes"][number] | undefined {
   return heroId ? state.heroes.find((hero) => hero.id === heroId) : undefined;
@@ -144,6 +150,26 @@ function createEventLogEntry(
         worldEventType: event.type,
         rewards: []
       };
+    case "hero.equipmentChanged": {
+      const slotLabel = EQUIPMENT_SLOT_LABELS[event.slot] ?? event.slot;
+      const description =
+        event.equippedItemId && event.unequippedItemId
+          ? `${hero?.name ?? event.heroId} 将${slotLabel}从 ${event.unequippedItemId} 更换为 ${event.equippedItemId}。`
+          : event.equippedItemId
+            ? `${hero?.name ?? event.heroId} 装备了${slotLabel} ${event.equippedItemId}。`
+            : `${hero?.name ?? event.heroId} 卸下了${slotLabel} ${event.unequippedItemId ?? "装备"}。`;
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "skill",
+        description,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: []
+      };
+    }
     case "battle.started":
       return {
         id: createEventId(playerId, timestamp, event.type, sequence),

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -804,3 +804,84 @@ test("colyseus room connect provisions player account metadata without overwriti
   assert.ok(account?.lastSeenAt);
   assert.equal(account?.globalResources.gold, 75);
 });
+
+test("colyseus room persists world event logs and first-battle achievements into player accounts", async (t) => {
+  const roomId = `account-event-log-${Date.now()}`;
+  const port = 39100 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  const seededState = createWorldStateFromConfigs(getDefaultWorldConfig(), getDefaultMapObjectsConfig(), 1001, roomId);
+  const seededHero = seededState.heroes.find((hero) => hero.id === "hero-1");
+  if (!seededHero) {
+    throw new Error("Expected hero-1 in seeded state");
+  }
+  seededHero.loadout.inventory = ["vanguard_blade"];
+  await store.save(roomId, {
+    state: seededState,
+    battles: []
+  });
+
+  const server = await startServer(port, store);
+  let room: ColyseusRoom | null = null;
+
+  t.after(async () => {
+    configureRoomSnapshotStore(null);
+    if (room) {
+      room.removeAllListeners();
+      room.connection.close();
+    }
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  room = await joinRoomWithRetry(port, roomId, "player-1");
+
+  await sendRequest(
+    room,
+    {
+      type: "connect",
+      requestId: nextRequestId("event-log-connect"),
+      roomId,
+      playerId: "player-1"
+    },
+    "session.state"
+  );
+
+  await sendRequest(
+    room,
+    {
+      type: "world.action",
+      requestId: nextRequestId("event-log-equip"),
+      action: {
+        type: "hero.equip",
+        heroId: "hero-1",
+        slot: "weapon",
+        equipmentId: "vanguard_blade"
+      }
+    },
+    "session.state"
+  );
+
+  await sendRequest(
+    room,
+    {
+      type: "world.action",
+      requestId: nextRequestId("event-log-battle"),
+      action: {
+        type: "hero.move",
+        heroId: "hero-1",
+        destination: { x: 5, y: 4 }
+      }
+    },
+    "session.state"
+  );
+
+  const account = await store.loadPlayerAccount("player-1");
+  assert.equal(account?.lastRoomId, roomId);
+  assert.equal(account?.achievements.find((achievement) => achievement.id === "first_battle")?.unlocked, true);
+  assert.ok(
+    account?.recentEventLog.some(
+      (entry) => entry.worldEventType === "hero.equipmentChanged" && /装备了武器 vanguard_blade/.test(entry.description)
+    )
+  );
+  assert.ok(account?.recentEventLog.some((entry) => entry.category === "achievement" && entry.achievementId === "first_battle"));
+  assert.ok(account?.recentEventLog.some((entry) => entry.worldEventType === "battle.started"));
+});

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -43,6 +43,22 @@ export interface PlayerAchievementProgress {
   unlockedAt?: string;
 }
 
+export function getLatestUnlockedAchievement(
+  progress?: Partial<PlayerAchievementProgress>[] | null
+): PlayerAchievementProgress | null {
+  const unlocked = normalizeAchievementProgress(progress).filter((entry) => entry.unlocked && entry.unlockedAt);
+  if (unlocked.length === 0) {
+    return null;
+  }
+
+  return (
+    unlocked.sort((left, right) => {
+      const unlockedAtOrder = String(right.unlockedAt).localeCompare(String(left.unlockedAt));
+      return unlockedAtOrder || left.id.localeCompare(right.id);
+    })[0] ?? null
+  );
+}
+
 const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
   {
     id: "first_battle",

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -33,6 +33,7 @@ import {
   getDefaultWorldConfig,
   getBattleOutcome,
   getDefaultEquipmentCatalog,
+  getLatestUnlockedAchievement,
   pickAutomatedBattleAction,
   planPlayerViewMovement,
   predictPlayerWorldAction,
@@ -215,6 +216,23 @@ test("achievement helpers unlock milestones and preserve catalog order", () => {
     secondPass.progress.map((achievement) => achievement.id),
     getAchievementDefinitions().map((achievement) => achievement.id)
   );
+});
+
+test("achievement helpers return the most recently unlocked milestone", () => {
+  const progress = [
+    {
+      id: "first_battle" as const,
+      current: 1,
+      unlockedAt: "2026-03-27T10:00:00.000Z"
+    },
+    {
+      id: "skill_scholar" as const,
+      current: 5,
+      unlockedAt: "2026-03-27T10:05:00.000Z"
+    }
+  ];
+
+  assert.equal(getLatestUnlockedAchievement(progress)?.id, "skill_scholar");
 });
 
 test("event log helper keeps newest unique entries first", () => {


### PR DESCRIPTION
## Summary\n- persist an additional world-event-log slice for issue #27 by recording hero equipment changes alongside existing combat/building/skill timeline events\n- add a shared helper for latest unlocked achievements and surface richer recent-event/achievement summaries in the H5 and Cocos account UI hooks\n- add regression coverage proving Colyseus room actions persist account event logs and first-battle achievements end to end\n\n## Delivered scope for #27\nThis PR delivers a bounded sub-scope toward #27: account-level recent world event logging, initial achievement tracking hardening, minimal UI surfacing, and tests. It does not implement the full issue yet, especially not battle replay storage/playback or the full achievement catalog.\n\n## Validation\n- 
> project-veil@0.1.0 test
> node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/authoritative-room.test.ts ./apps/server/test/room-persistence.test.ts ./apps/server/test/player-room-profiles.test.ts ./apps/server/test/persistence-retention.test.ts ./apps/server/test/colyseus-persistence-recovery.test.ts ./apps/server/test/config-center.test.ts ./apps/server/test/player-account-routes.test.ts ./apps/server/test/lobby-routes.test.ts ./apps/server/test/auth-guest-login.test.ts ./apps/client/test/reconnection-storage.test.ts ./apps/client/test/player-account-storage.test.ts ./apps/client/test/lobby-preferences.test.ts ./apps/client/test/auth-session-storage.test.ts ./apps/cocos-client/test/unit-animation-config.test.ts ./apps/cocos-client/test/cocos-ui-formatters.test.ts ./apps/cocos-client/test/cocos-battle-panel-model.test.ts ./apps/cocos-client/test/cocos-map-visuals.test.ts ./apps/cocos-client/test/cocos-object-visuals.test.ts ./apps/cocos-client/test/cocos-session-launch.test.ts ./apps/cocos-client/test/cocos-lobby.test.ts

✔ auth session helpers use a stable storage key (0.880872ms)
✔ auth session helpers can persist and clear stored guest sessions (0.971984ms)
✔ auth session helpers default legacy payloads to guest mode (0.286002ms)
✔ lobby preferences use a stable storage key (0.877049ms)
✔ lobby preferences can create deterministic guest player ids (0.200675ms)
✔ lobby preferences honor explicit room and player overrides (0.908509ms)
✔ player account helpers use a stable player scoped storage key (0.897019ms)
✔ player account helpers persist normalized display names (0.284635ms)
✔ player account helpers can build a local fallback profile (2.97483ms)
✔ reconnection token helpers use a stable room/player scoped storage key (0.996042ms)
✔ reconnection token helpers can persist and clear tokens (0.312063ms)
✔ session replay helpers can persist and clear the latest session snapshot (1.19755ms)
✔ session replay helpers ignore malformed cached payloads (0.274792ms)
✔ buildBattlePanelViewModel keeps idle summary focused on battle state (1.827147ms)
✔ buildBattlePanelViewModel enables attack actions on the player's turn (2.836169ms)
✔ buildBattlePanelViewModel disables commands during enemy turns (0.375564ms)
✔ buildBattlePanelViewModel hides unrevealed traps and disables skills while silenced (0.498908ms)
✔ createCocosLobbyPreferences reuses stored values and falls back to room-alpha (1.874073ms)
✔ rememberPreferredCocosDisplayName persists normalized names with the shared storage key (0.337316ms)
✔ resolveCocosApiBaseUrl converts websocket endpoints into http api roots (0.421047ms)
✔ resolveCocosConfigCenterUrl points Cocos web flows at the shared config center (0.307972ms)
✔ loadCocosLobbyRooms queries the lobby api from the resolved remote host (30.157483ms)
✔ loginCocosGuestAuthSession stores remote sessions and clearCurrentCocosAuthSession removes them (1.141154ms)
✔ loginCocosPasswordAuthSession stores account sessions with loginId (0.827264ms)
✔ loadCocosPlayerAccountProfile uses /me for authenticated sessions and preserves the global vault (1.927968ms)
✔ fog edge helpers expose hidden and explored frontier masks (1.330912ms)
✔ fog pulse helpers switch to alternate gids on odd phases only (0.22166ms)
✔ buildFogOverlayStyle emits quiet overlay chrome for hidden and explored fog (1.033622ms)
✔ buildFogOverlayStyle keeps interior fog tiles alpha-blended even without a frontier (0.313862ms)
✔ buildMapFeedbackEntriesFromUpdate creates tile callouts for move, collect, xp and battle results (0.840191ms)
✔ buildObjectPulseEntriesFromUpdate emits bounce targets for collection and encounters (0.509337ms)
✔ neutral movement feedback uses destination callouts and chase pulses (0.350972ms)
✔ describeCocosTileObject maps pickup resources to config-driven descriptors (1.994336ms)
✔ describeCocosTileObject maps battle occupants to stable cocos markers (0.280899ms)
✔ buildCocosTileMarkerText hides empty walkable tiles (0.188474ms)
✔ describeCocosTileObject exposes recruitment posts as visitable buildings (0.267685ms)
✔ describeCocosTileObject exposes attribute shrines as permanent stat buildings (0.278646ms)
✔ describeCocosTileObject exposes resource mines as harvestable daily pickups (0.424673ms)
✔ readStoredCocosAuthSession parses a cached guest session (1.678439ms)
✔ resolveCocosLaunchIdentity reuses the stored guest session when only roomId is provided (0.474295ms)
✔ resolveCocosLaunchIdentity does not reuse a mismatched stored token when playerId is explicit (0.232289ms)
✔ resolveCocosLaunchIdentity opens lobby mode when roomId is omitted (0.265056ms)
✔ buildTimelineEntriesFromUpdate formats world events and system rejection (1.886935ms)
✔ buildTimelineEntriesFromUpdate keeps repeated move events readable by destination (0.288648ms)
✔ formatSystemTimelineEntry and pickRecentBattleTimeline keep timeline presentation stable (0.383918ms)
✔ resolveUnitAnimationName prefers explicit state names over prefixes (1.102964ms)
✔ resolveUnitAnimationName falls back to prefix plus state when no explicit mapping exists (0.238957ms)
✔ shouldLoopUnitAnimation only loops idle and move (0.176635ms)
✔ resolveUnitAnimationReturnDelay returns null for looping states and configured delays for one-shots (0.192994ms)
[dotenv@17.3.1] injecting env (1) from ../../../../etc/environment -- tip: ⚙️  specify custom .env file path with { path: '/custom/path/.env' }
ℹ️  optional .env file not found: .env.development, .env

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io


   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ guest auth route issues a signed session token (82.697642ms)

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ auth session route resolves a bearer token into the current guest session (19.090392ms)

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ connect message prefers auth token identity over a spoofed playerId (56.605037ms)
✔ account bind upgrades a guest session into password login and account-login restores it (131.586107ms)
✔ battle start auto-resolves defender opener before state is returned to the player (14.698056ms)
✔ player battle actions are followed by automated defender turns until control returns (3.766814ms)
✔ server rejects battle actions sent for non-player-controlled defender units (2.295169ms)
✔ room supports concurrent neutral battles and returns player-specific battle snapshots (4.133538ms)
✔ room filters event timelines per player without hiding PvP battle results from defenders (1.206981ms)
✔ room equips hero items from carried inventory and emits the equipment change event (1.100728ms)
✔ room allows recruiting from a recruitment post when the hero stands on it (1.192504ms)
✔ room allows visiting an attribute shrine once and persists the stat bonus (1.365749ms)
✔ room allows harvesting a resource mine and restores it on the next day (4.221478ms)
✔ room can create a neutral-initiated battle when end day triggers an adjacent chase (1.824289ms)
[dotenv@17.3.1] injecting env (1) from ../../../../etc/environment -- tip: ⚙️  specify custom .env file path with { path: '/custom/path/.env' }
ℹ️  optional .env file not found: .env.development, .env

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io


   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io


   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ colyseus room reloads a persisted active battle after a server restart (367.06127ms)

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ colyseus room hydrates global player resources into fresh rooms (61.753624ms)

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ colyseus room broadcasts bounded typed-array map chunks to non-source clients (1987.344223ms)

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ colyseus room hydrates long-term hero archives into fresh rooms (37.296255ms)

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ colyseus room connect provisions player account metadata without overwriting custom display names (12.458326ms)
✔ colyseus room persists world event logs and first-battle achievements into player accounts (25.131719ms)
✔ config center lists seeded config documents (18.280923ms)
✔ config center save writes file and refreshes runtime world config (13.208063ms)
✔ config center save writes battle skills file and refreshes runtime skill catalog (9.833293ms)
✔ config center rejects map objects that exceed current world bounds (6.229397ms)
✔ config center world preview summarizes generated terrain, resources and occupants (3.323585ms)
✔ config center can validate invalid world config with structured issues (5.707009ms)
✔ config center schema validation reports missing and mistyped fields (5.216524ms)
✔ config center snapshots support diff and rollback (28.882297ms)
✔ config center save creates automatic version snapshots and skips no-op saves (13.786394ms)
✔ config center export updates exportedAt metadata without changing version (9.292275ms)
✔ config center presets and workbook import/export roundtrip (75.68994ms)
[dotenv@17.3.1] injecting env (1) from ../../../../etc/environment -- tip: 🛡️ auth for agents: https://vestauth.com
ℹ️  optional .env file not found: .env.development, .env

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ lobby routes list active room summaries (212.556503ms)
✔ mysql persistence config uses default snapshot retention policy (1.029946ms)
✔ mysql persistence config allows disabling ttl and periodic cleanup (0.196723ms)
✔ snapshotHasExpired respects ttl windows (0.244914ms)
[dotenv@17.3.1] injecting env (1) from ../../../../etc/environment -- tip: ⚙️  specify custom .env file path with { path: '/custom/path/.env' }
ℹ️  optional .env file not found: .env.development, .env

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io


   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ player account routes list and fetch stored accounts (96.844742ms)
✔ player achievement tracker appends logs and unlocks milestones (21.551589ms)

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ player account routes update display names through the account store (26.291151ms)

   ___      _                                    ___   _ _____
  / __\___ | |_   _ ___  ___ _   _ ___   __   __/ _ \ / |___  |
 / /  / _ \| | | | / __|/ _ \ | | / __|  \ \ / / | | || |  / /
/ /__| (_) | | |_| \__ \  __/ |_| \__ \   \ V /| |_| || | / /
\____/\___/|_|\__, |___/\___|\__,_|___/    \_/  \___(_)_|/_/
              |___/

             · Multiplayer Framework for Node.js ·

💖 Consider becoming a Sponsor on GitHub → https://github.com/sponsors/endel
🌟 Give us a star on GitHub → https://github.com/colyseus/colyseus
☁️  Deploy and scale your project on Colyseus Cloud → https://cloud.colyseus.io

✔ player account me routes resolve and update the current authenticated account (14.42613ms)
✔ player account me route preserves account-mode sessions and returns the global vault (9.692558ms)
✔ createPlayerRoomProfiles extracts one profile per player in the room (7.609719ms)
✔ applyPlayerProfilesToWorldState overlays a single player's progress without affecting others (1.991102ms)
✔ applyPlayerProfilesToWorldState backfills default progression for legacy hero rows (1.384956ms)
✔ createPlayerAccountsFromWorldState extracts one global resource ledger per player (1.658489ms)
✔ applyPlayerAccountsToWorldState overlays global resources without replacing room heroes (1.279085ms)
✔ createPlayerHeroArchivesFromWorldState extracts one persistent hero record per hero (3.59646ms)
✔ applyPlayerHeroArchivesToWorldState restores long-term hero growth but resets room-local position and readiness (19.603651ms)
✔ applyPlayerHeroArchivesToWorldState backfills default long-term build fields for legacy hero rows (1.21692ms)
✔ room persistence snapshot restores an active neutral battle (14.607137ms)
✔ room persistence snapshot restores a resolved PvP world without active battles (5.928679ms)
✔ typed-array world map payload decodes back to the original player world view (12.178335ms)
✔ achievement helpers unlock milestones and preserve catalog order (0.925496ms)
✔ achievement helpers return the most recently unlocked milestone (11.150872ms)
✔ event log helper keeps newest unique entries first (0.516216ms)
✔ typed-array world map payload is materially smaller than the raw tile JSON on a 32x32 map (2.026766ms)
✔ typed-array world map payload can encode a bounded chunk and merge it back into the previous map (5.214308ms)
✔ bounded typed-array world map payload is materially smaller than the full encoded payload (1.196875ms)
✔ createPlayerWorldView respects fog-of-war visibility rules (0.454241ms)
✔ hero progression helpers expose xp meter and attribute sources (1.173423ms)
✔ equipment catalog exposes the minimum foundation set and resolves hero bonuses (0.62148ms)
✔ hero equipment loadout view resolves slot metadata for equipped and empty slots (0.475455ms)
✔ hero equipment loadout view tolerates archived ids missing from the equipment catalog (0.252031ms)
✔ hero equip and unequip actions rotate items between slots and inventory (1.489945ms)
✔ resolveWorldAction starts a battle when a hero reaches a neutral army tile (0.945693ms)
✔ createWorldStateFromConfigs reuses deterministic generation for preview and room startup (2.306065ms)
✔ applyBattleOutcomeToWorld grants neutral rewards and moves the hero onto the defeated army tile (0.827836ms)
✔ applyBattleOutcomeToWorld grants PvP experience to the winning hero (0.566213ms)
✔ resolveWorldAction lets heroes learn and upgrade long-term skills after leveling (4.868652ms)
✔ default hero skill tree loads the full three-branch layout (0.429229ms)
✔ hero skill tree view and resolveWorldAction advance branch prerequisites in order (2.007063ms)
✔ createHeroBattleState carries learned hero skill tree rewards into battle (2.434178ms)
✔ battle state builders fold equipped item bonuses into hero-led stacks (1.728863ms)
✔ createPlayerWorldView returns player-scoped resources after collection (0.324592ms)
✔ resolveWorldAction recruits units from a recruitment post and resets stock on next day (0.534601ms)
✔ building interactions reject missing resources, exhausted stock, wrong building types, and duplicate claims (0.673284ms)
✔ resolveWorldAction visits an attribute shrine once, grants permanent stats, and does not reset on next day (0.908954ms)
✔ resolveWorldAction harvests a resource mine immediately and unlocks it again on the next day (0.677161ms)
✔ resolveWorldAction advances patrolling neutral armies by one tile on end day (1.466665ms)
✔ resolveWorldAction keeps patrol movement deterministic across days (0.862653ms)
✔ resolveWorldAction can start a neutral-initiated battle on end day (0.40608ms)
✔ resolveWorldAction switches neutral armies from chase back to return when heroes leave range (0.851844ms)
✔ resolveWorldAction tracks multiple neutral chase targets independently (1.14357ms)
✔ resolveWorldAction routes neutral chase movement around walls instead of through them (0.454289ms)
✔ planPlayerViewMovement stops at the tile before a visible neutral encounter (0.362821ms)
✔ predictPlayerWorldAction updates the player view immediately for move and collect (0.480983ms)
✔ applyBattleOutcomeToWorld penalizes the hero on defeat and keeps the neutral army (0.357734ms)
✔ applyBattleOutcomeToWorld keeps defenderHeroId on hero-vs-hero resolution events (0.380181ms)
✔ filterWorldEventsForPlayer hides unrelated hero timelines while keeping mine income and both sides of PvP encounters (0.483482ms)
✔ applyBattleAction uses deterministic damage and retaliation flow (1.959402ms)
✔ applyBattleAction supports active ranged skills without retaliation (0.837032ms)
✔ executeBattleSkill resolves enemy and self-target skills through the shared battle path (0.869738ms)
✔ applyBattleAction supports armor spell buffs on the acting unit (0.446647ms)
✔ applyBattleAction reduces damage against defending targets (1.022491ms)
✔ pickAutomatedBattleAction prefers ready skills before default attacks (0.691731ms)
✔ validateBattleAction covers wait and skill rejection branches (0.77998ms)
✔ validateBattleAction covers attack rejection branches (0.42958ms)
✔ applyBattleAction logs rejected actions without mutating battle flow (0.270995ms)
✔ applyBattleAction resolves wait plus turn-start poison death and cooldown ticking (0.439154ms)
✔ applyBattleAction advances into turn-start processing even when the next unit has no skills (0.278329ms)
✔ applyBattleAction defend refreshes the round and clears temporary flags (0.340818ms)
✔ applyBattleAction refreshes explicit on-hit statuses instead of stacking them (0.702047ms)
✔ applyBattleAction does not attach on-hit statuses to targets defeated by the strike (0.537341ms)
✔ pickAutomatedBattleAction falls back between buff, enemy skill, attack, and null states (0.910648ms)
✔ battle outcome helpers report in-progress and both victory states (0.427659ms)
✔ createEmptyBattleState returns the minimal neutral battle shell (0.129798ms)
✔ simulateAutomatedBattle resolves a deterministic demo encounter and records skill usage (6.740291ms)
✔ simulateAutomatedBattles aggregates win rate, rounds, and skill usage across repeated auto battles (26.854935ms)
✔ battle-skills-v1.1 preset validates against the shared runtime schema (0.805498ms)
✔ applyBattleAction routes contact attacks through blockers before hitting the target (0.382397ms)
✔ applyBattleAction triggers contact traps before the strike and logs granted statuses (0.572554ms)
✔ applyBattleAction lets ranged skills bypass blockers and traps (0.437129ms)
✔ applyBattleAction reveals silence traps and blocks active skills on the affected unit (0.465962ms)
✔ slow traps change the next round turn order (0.483971ms)
✔ applyBattleAction supports self-target skills without granted statuses (0.780991ms)
✔ pickAutomatedBattleAction and applyBattleAction default enemy skill effects when omitted (1.106335ms)
✔ pickAutomatedBattleAction returns null for an empty or dead active slot (0.23957ms)
✔ pickAutomatedBattleAction still scores enemy skills against low-count targets (0.274723ms)
✔ applyBattleAction skips dead queued units before handing control to the next live stack (0.272228ms)
✔ applyBattleAction skips missing queued units before handing control to the next live stack (0.392578ms)
✔ createDemoBattleState throws when required demo templates are missing (0.809062ms)
✔ applyBattleAction describes granted statuses that have no numeric modifiers (0.753584ms)
✔ applyBattleAction describes granted statuses with negative attack and damage-over-time effects (0.857921ms)
✔ applyBattleAction describes granted statuses with positive attack and negative defense modifiers (1.085321ms)
✔ battle state builders carry stats, metadata, and missing-template guards (2.34301ms)
✔ battle state builders support empty armies and templates without battle skills (1.514439ms)
✔ battle state builders consume runtime battle balance environment config (1.223445ms)
✔ createBattleEnvironmentState deterministically generates blockers plus hidden traps from runtime config (0.360907ms)
✔ applyBattleAction consumes runtime battle balance damage config (0.710701ms)
✔ applyBattleAction throws for stale battle skills that no longer exist in runtime config (0.913146ms)
✔ applyBattleAction returns the normalized state for unknown runtime action types (0.280827ms)
✔ applyBattleAction only triggers traps for matching camps (0.457184ms)
ℹ tests 180
ℹ suites 0
ℹ pass 180
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 16373.376639\n- 
> project-veil@0.1.0 typecheck
> tsc -p tsconfig.base.json --noEmit

apps/client/src/object-visuals.ts(75,35): error TS2339: Property 'visitedHeroIds' does not exist on type 'AttributeShrineBuildingView'.
apps/client/src/object-visuals.ts(78,69): error TS2339: Property 'visitedHeroIds' does not exist on type 'AttributeShrineBuildingView'.
apps/client/src/object-visuals.ts(89,38): error TS2339: Property 'ownerPlayerId' does not exist on type 'ResourceMineBuildingView'.
apps/client/src/object-visuals.ts(89,76): error TS2339: Property 'ownerPlayerId' does not exist on type 'ResourceMineBuildingView'.
apps/cocos-client/assets/scripts/VeilBattlePanel.ts(7,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilBattlePanel.ts(8,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilBattlePanel.ts(10,73): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilBattleTransition.ts(2,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilHudPanel.ts(7,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilHudPanel.ts(8,41): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilHudPanel.ts(10,46): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilHudPanel.ts(13,73): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilHudPanel.ts(14,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilLobbyPanel.ts(3,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilMapBoard.ts(3,78): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilMapBoard.ts(4,42): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilMapBoard.ts(5,32): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilMapBoard.ts(6,37): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilMapBoard.ts(7,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilMapBoard.ts(9,34): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilMapBoard.ts(10,73): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(11,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(28,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(29,65): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(30,38): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(31,33): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(32,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(33,48): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(34,66): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(35,30): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(36,32): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(37,30): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(38,86): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(39,72): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilRoot.ts(40,35): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilTilemapRenderer.ts(3,97): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilTimelinePanel.ts(2,73): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilTimelinePanel.ts(3,31): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/VeilUnitAnimator.ts(8,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/cocos-hero-progression.ts(1,45): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/cocos-lobby.ts(6,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/assets/scripts/cocos-lobby.ts(12,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/test/cocos-battle-panel-model.test.ts(20,9): error TS2741: Property 'loadout' is missing in type '{ id: string; playerId: string; name: string; position: { x: number; y: number; }; vision: number; move: { total: number; remaining: number; }; stats: { attack: number; defense: number; power: number; knowledge: number; hp: number; maxHp: number; }; progression: { ...; }; armyCount: number; armyTemplateId: string; l...' but required in type 'HeroView'.
apps/cocos-client/test/cocos-hero-progression.test.ts(20,11): error TS2741: Property 'loadout' is missing in type '{ id: string; playerId: string; name: string; position: { x: number; y: number; }; vision: number; move: { total: number; remaining: number; }; stats: { attack: number; defense: number; power: number; knowledge: number; hp: number; maxHp: number; }; progression: { ...; }; armyCount: number; armyTemplateId: string; l...' but required in type 'HeroView'.
apps/cocos-client/test/cocos-lobby.test.ts(15,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/test/cocos-map-visuals.test.ts(41,9): error TS2741: Property 'loadout' is missing in type '{ id: string; playerId: string; name: string; position: { x: number; y: number; }; vision: number; move: { total: number; remaining: number; }; stats: { attack: number; defense: number; power: number; knowledge: number; hp: number; maxHp: number; }; progression: { ...; }; armyCount: number; armyTemplateId: string; l...' but required in type 'HeroView'.
apps/cocos-client/test/cocos-map-visuals.test.ts(219,9): error TS2353: Object literal may only specify known properties, and 'ownerPlayerId' does not exist in type 'ResourceMineBuildingView'.
apps/cocos-client/test/cocos-map-visuals.test.ts(374,9): error TS2353: Object literal may only specify known properties, and 'ownerPlayerId' does not exist in type 'ResourceMineBuildingView'.
apps/cocos-client/test/cocos-object-visuals.test.ts(86,3): error TS2322: Type '{ id: string; kind: "attribute_shrine"; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'PlayerBuildingView | undefined'.
  Type '{ id: string; kind: "attribute_shrine"; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'AttributeShrineBuildingView' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    Types of property 'lastUsedDay' are incompatible.
      Type 'undefined' is not assignable to type 'number'.
apps/cocos-client/test/cocos-session-launch.test.ts(6,8): error TS5097: An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled.
apps/cocos-client/test/cocos-ui-formatters.test.ts(131,50): error TS2379: Argument of type '{ world: { meta: { roomId: string; seed: number; day: number; }; map: { width: number; height: number; tiles: never[]; }; ownHeroes: never[]; visibleHeroes: never[]; resources: { gold: number; wood: number; ore: number; }; playerId: string; }; ... 4 more ...; reason: undefined; }' is not assignable to parameter of type 'SessionUpdate' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'reason' are incompatible.
    Type 'undefined' is not assignable to type 'string'.
apps/server/test/authoritative-room.test.ts(267,118): error TS2339: Property 'availableCount' does not exist on type 'PlayerBuildingView'.
  Property 'availableCount' does not exist on type 'AttributeShrineBuildingView'.
apps/server/test/authoritative-room.test.ts(348,116): error TS2339: Property 'lastHarvestDay' does not exist on type 'PlayerBuildingView'.
  Property 'lastHarvestDay' does not exist on type 'RecruitmentBuildingView'.
apps/server/test/authoritative-room.test.ts(383,3): error TS2322: Type '{ position: { x: number; y: number; }; origin: { x: number; y: number; }; behavior: { mode: "guard"; patrolPath: never[]; patrolIndex: number; detectionRadius: number; chaseDistance: number; patrolRadius: number; speed: number; state: "return"; }; id?: string; reward?: ResourceNode | undefined; stacks?: NeutralArmyS...' is not assignable to type 'NeutralArmyState'.
  Property 'id' is optional in type '{ position: { x: number; y: number; }; origin: { x: number; y: number; }; behavior: { mode: "guard"; patrolPath: never[]; patrolIndex: number; detectionRadius: number; chaseDistance: number; patrolRadius: number; speed: number; state: "return"; }; id?: string; reward?: ResourceNode | undefined; stacks?: NeutralArmyS...' but required in type 'NeutralArmyState'.
apps/server/test/config-center.test.ts(457,70): error TS2345: Argument of type 'WorkSheet | undefined' is not assignable to parameter of type 'WorkSheet'.
  Type 'undefined' is not assignable to type 'WorkSheet'.
apps/server/test/player-room-profiles.test.ts(121,5): error TS2741: Property 'displayName' is missing in type '{ playerId: string; achievements: never[]; globalResources: { gold: number; wood: number; ore: number; }; recentEventLog: never[]; }' but required in type 'PlayerAccountSnapshot'.
packages/shared/test/shared-core.test.ts(460,5): error TS2741: Property 'inventory' is missing in type '{ learnedSkills: never[]; equipment: { weaponId: string; armorId: string; accessoryId: string; trinketIds: never[]; }; }' but required in type 'HeroLoadout'.
packages/shared/test/shared-core.test.ts(546,5): error TS2741: Property 'inventory' is missing in type '{ learnedSkills: never[]; equipment: { weaponId: string; armorId: string; accessoryId: string; trinketIds: never[]; }; }' but required in type 'HeroLoadout'.
packages/shared/test/shared-core.test.ts(587,5): error TS2741: Property 'inventory' is missing in type '{ learnedSkills: never[]; equipment: { weaponId: string; accessoryId: string; trinketIds: never[]; }; }' but required in type 'HeroLoadout'.
packages/shared/test/shared-core.test.ts(619,5): error TS2741: Property 'inventory' is missing in type '{ learnedSkills: never[]; equipment: { weaponId: string; trinketIds: never[]; }; }' but required in type 'HeroLoadout'.
packages/shared/test/shared-core.test.ts(1197,5): error TS2741: Property 'inventory' is missing in type '{ learnedSkills: never[]; equipment: { weaponId: string; armorId: string; accessoryId: string; trinketIds: never[]; }; }' but required in type 'HeroLoadout'.
packages/shared/test/shared-core.test.ts(1219,5): error TS2741: Property 'inventory' is missing in type '{ learnedSkills: never[]; equipment: { weaponId: string; armorId: string; accessoryId: string; trinketIds: never[]; }; }' but required in type 'HeroLoadout'.
packages/shared/test/shared-core.test.ts(1370,66): error TS2339: Property 'availableCount' does not exist on type 'MapBuildingState'.
  Property 'availableCount' does not exist on type 'AttributeShrineBuildingState'.
packages/shared/test/shared-core.test.ts(1371,61): error TS2339: Property 'availableCount' does not exist on type 'MapBuildingState'.
  Property 'availableCount' does not exist on type 'AttributeShrineBuildingState'.
packages/shared/test/shared-core.test.ts(1392,66): error TS2339: Property 'availableCount' does not exist on type 'MapBuildingState'.
  Property 'availableCount' does not exist on type 'AttributeShrineBuildingState'.
packages/shared/test/shared-core.test.ts(1393,61): error TS2339: Property 'availableCount' does not exist on type 'MapBuildingState'.
  Property 'availableCount' does not exist on type 'AttributeShrineBuildingState'.
packages/shared/test/shared-core.test.ts(1434,9): error TS2353: Object literal may only specify known properties, and 'visitedHeroIds' does not exist in type 'AttributeShrineBuildingState'.
packages/shared/test/shared-core.test.ts(1495,11): error TS2353: Object literal may only specify known properties, and 'visitedHeroIds' does not exist in type 'AttributeShrineBuildingState'.
packages/shared/test/shared-core.test.ts(1603,11): error TS2322: Type '{ id: string; kind: "attribute_shrine"; position: { x: number; y: number; }; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'MapBuildingState | undefined'.
  Type '{ id: string; kind: "attribute_shrine"; position: { x: number; y: number; }; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'AttributeShrineBuildingState' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    Types of property 'lastUsedDay' are incompatible.
      Type 'undefined' is not assignable to type 'number'.
packages/shared/test/shared-core.test.ts(1676,11): error TS2322: Type '{ id: string; kind: "attribute_shrine"; position: { x: number; y: number; }; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'MapBuildingState | undefined'.
  Type '{ id: string; kind: "attribute_shrine"; position: { x: number; y: number; }; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'AttributeShrineBuildingState' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    Types of property 'lastUsedDay' are incompatible.
      Type 'undefined' is not assignable to type 'number'.
packages/shared/test/shared-core.test.ts(1721,7): error TS2322: Type '{ id: string; kind: "attribute_shrine"; position: { x: number; y: number; }; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'MapBuildingState'.
  Type '{ id: string; kind: "attribute_shrine"; position: { x: number; y: number; }; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'AttributeShrineBuildingState' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    Types of property 'lastUsedDay' are incompatible.
      Type 'undefined' is not assignable to type 'number'.
packages/shared/test/shared-core.test.ts(1741,9): error TS2322: Type '{ id: string; kind: "attribute_shrine"; position: { x: number; y: number; }; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'MapBuildingState | undefined'.
  Type '{ id: string; kind: "attribute_shrine"; position: { x: number; y: number; }; label: string; bonus: { attack: number; defense: number; power: number; knowledge: number; }; lastUsedDay: undefined; }' is not assignable to type 'AttributeShrineBuildingState' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    Types of property 'lastUsedDay' are incompatible.
      Type 'undefined' is not assignable to type 'number'.
packages/shared/test/shared-core.test.ts(1769,58): error TS2339: Property 'lastUsedDay' does not exist on type 'MapBuildingState'.
  Property 'lastUsedDay' does not exist on type 'ResourceMineBuildingState'.
packages/shared/test/shared-core.test.ts(1814,60): error TS2339: Property 'lastUsedDay' does not exist on type 'MapBuildingState'.
  Property 'lastUsedDay' does not exist on type 'ResourceMineBuildingState'.
packages/shared/test/shared-core.test.ts(1876,110): error TS2339: Property 'lastHarvestDay' does not exist on type 'PlayerBuildingView'.
  Property 'lastHarvestDay' does not exist on type 'RecruitmentBuildingView'.
packages/shared/test/shared-core.test.ts(1887,56): error TS2339: Property 'lastHarvestDay' does not exist on type 'MapBuildingState'.
  Property 'lastHarvestDay' does not exist on type 'RecruitmentBuildingState'.
packages/shared/test/shared-core.test.ts(1888,59): error TS2339: Property 'lastHarvestDay' does not exist on type 'MapBuildingState'.
  Property 'lastHarvestDay' does not exist on type 'RecruitmentBuildingState'.
packages/shared/test/shared-core.test.ts(2904,3): error TS2375: Type '{ skills: BattleSkillState[] | undefined; id: string; templateId: string; camp: "attacker" | "defender"; lane: number; stackName: string; initiative: number; attack: number; ... 8 more ...; statusEffects?: BattleStatusEffectState[]; }' is not assignable to type 'UnitStack' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'skills' are incompatible.
    Type 'BattleSkillState[] | undefined' is not assignable to type 'BattleSkillState[]'.
      Type 'undefined' is not assignable to type 'BattleSkillState[]'.
packages/shared/test/shared-core.test.ts(3107,3): error TS2375: Type '{ count: number; currentHp: number; skills: BattleSkillState[] | undefined; statusEffects: { id: string; name: string; description: string; durationRemaining: number; attackModifier: number; defenseModifier: number; damagePerTurn: number; initiativeModifier: number; blocksActiveSkills: false; }[]; ... 12 more ...; d...' is not assignable to type 'UnitStack' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'skills' are incompatible.
    Type 'BattleSkillState[] | undefined' is not assignable to type 'BattleSkillState[]'.
      Type 'undefined' is not assignable to type 'BattleSkillState[]'.
packages/shared/test/shared-core.test.ts(3147,3): error TS2375: Type '{ skills: undefined; id: string; templateId: string; camp: "attacker" | "defender"; lane: number; stackName: string; initiative: number; attack: number; defense: number; minDamage: number; ... 6 more ...; statusEffects?: BattleStatusEffectState[]; }' is not assignable to type 'UnitStack' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'skills' are incompatible.
    Type 'undefined' is not assignable to type 'BattleSkillState[]'.
packages/shared/test/shared-core.test.ts(3316,3): error TS2375: Type '{ skills: { remainingCooldown: number; id: BattleSkillId; name: string; description: string; kind: BattleSkillKind; target: BattleSkillTarget; delivery?: BattleSkillDelivery; cooldown: number; }[] | undefined; ... 15 more ...; statusEffects?: BattleStatusEffectState[]; }' is not assignable to type 'UnitStack' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'skills' are incompatible.
    Type '{ remainingCooldown: number; id: string; name: string; description: string; kind: BattleSkillKind; target: BattleSkillTarget; delivery?: BattleSkillDelivery; cooldown: number; }[] | undefined' is not assignable to type 'BattleSkillState[]'.
      Type 'undefined' is not assignable to type 'BattleSkillState[]'.
packages/shared/test/shared-core.test.ts(4147,3): error TS2322: Type '(UnitTemplateConfig | { battleSkills: undefined; id: string; stackName: string; faction: "crown" | "wild"; rarity: "common" | "elite"; initiative: number; attack: number; defense: number; minDamage: number; maxDamage: number; maxHp: number; })[]' is not assignable to type 'UnitTemplateConfig[]'.
  Type 'UnitTemplateConfig | { battleSkills: undefined; id: string; stackName: string; faction: "crown" | "wild"; rarity: "common" | "elite"; initiative: number; attack: number; defense: number; minDamage: number; maxDamage: number; maxHp: number; }' is not assignable to type 'UnitTemplateConfig' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    Type '{ battleSkills: undefined; id: string; stackName: string; faction: "crown" | "wild"; rarity: "common" | "elite"; initiative: number; attack: number; defense: number; minDamage: number; maxDamage: number; maxHp: number; }' is not assignable to type 'UnitTemplateConfig' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
      Types of property 'battleSkills' are incompatible.
        Type 'undefined' is not assignable to type 'string[]'.
packages/shared/test/shared-core.test.ts(4415,3): error TS2375: Type '{ skills: undefined; statusEffects: undefined; id: string; templateId: string; camp: "attacker" | "defender"; lane: number; stackName: string; initiative: number; attack: number; defense: number; ... 6 more ...; defending: boolean; }' is not assignable to type 'UnitStack' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'skills' are incompatible.
    Type 'undefined' is not assignable to type 'BattleSkillState[]'.
packages/shared/test/shared-core.test.ts(4465,37): error TS2339: Property 'charges' does not exist on type 'BattleHazardState'.
  Property 'charges' does not exist on type 'BattleBlockerState'.
packages/shared/test/shared-core.test.ts(4466,37): error TS2339: Property 'revealed' does not exist on type 'BattleHazardState'.
  Property 'revealed' does not exist on type 'BattleBlockerState'. *(currently fails due to pre-existing unrelated repo errors in , many Cocos  import-path checks, and several older  exact-optional-property issues)*\n