### PR TITLE
feat: add battle equipment drop foundation for #28

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1150,6 +1150,8 @@ function appendLog(update: SessionUpdate): void {
           ? `Upgraded ${event.skillName} to Rank ${event.newRank}`
           : `Learned ${event.skillName}`
       );
+    } else if (event.type === "hero.equipmentFound") {
+      state.log.unshift(`Found equipment: ${event.equipmentName}`);
     } else if (event.type === "neutral.moved") {
       state.log.unshift(
         event.reason === "chase"
@@ -1260,6 +1262,16 @@ function buildTimelineEntries(update: SessionUpdate, source: TimelineEntry["sour
         tone: "loot",
         source,
         text: `占领资源产出点，改为每日产出 ${formatDailyIncome(event.resourceKind, event.income)}`
+      });
+      return;
+    }
+
+    if (event.type === "hero.equipmentFound") {
+      items.push({
+        id: `${stamp}-equipment-${index}`,
+        tone: "loot",
+        source,
+        text: `战利品：获得 ${event.equipmentName}`
       });
       return;
     }
@@ -1442,7 +1454,8 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
       event.type === "hero.visited" ||
       event.type === "hero.claimedMine" ||
       event.type === "resource.produced" ||
-      event.type === "hero.skillLearned"
+      event.type === "hero.skillLearned" ||
+      event.type === "hero.equipmentFound"
   )
     ? "loot"
     : update.events.some(
@@ -1481,10 +1494,11 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
   if (resolved?.type === "battle.resolved") {
     const rewardEvent = update.events.find((event) => event.type === "hero.collected");
     const progressEvent = update.events.find((event) => event.type === "hero.progressed");
+    const equipmentEvent = update.events.find((event) => event.type === "hero.equipmentFound");
     const didWin = didCurrentPlayerWinBattle(resolved, update.world);
     const winBody = resolved.defenderHeroId
-      ? `你已击败敌方英雄。${progressEvent?.type === "hero.progressed" ? `获得 ${progressEvent.experienceGained} 经验${progressEvent.levelsGained > 0 ? `，升至 Lv ${progressEvent.level}，并得到 ${progressEvent.skillPointsAwarded} 点技能点` : ""}。` : ""}`
-      : `你已击败守军。${rewardEvent?.type === "hero.collected" ? `获得 ${rewardEvent.resource.kind} +${rewardEvent.resource.amount}。` : ""}${progressEvent?.type === "hero.progressed" ? `获得 ${progressEvent.experienceGained} 经验${progressEvent.levelsGained > 0 ? `，升至 Lv ${progressEvent.level}，并得到 ${progressEvent.skillPointsAwarded} 点技能点` : ""}。` : ""}`;
+      ? `你已击败敌方英雄。${equipmentEvent?.type === "hero.equipmentFound" ? `缴获 ${equipmentEvent.equipmentName}。` : ""}${progressEvent?.type === "hero.progressed" ? `获得 ${progressEvent.experienceGained} 经验${progressEvent.levelsGained > 0 ? `，升至 Lv ${progressEvent.level}，并得到 ${progressEvent.skillPointsAwarded} 点技能点` : ""}。` : ""}`
+      : `你已击败守军。${rewardEvent?.type === "hero.collected" ? `获得 ${rewardEvent.resource.kind} +${rewardEvent.resource.amount}。` : ""}${equipmentEvent?.type === "hero.equipmentFound" ? `拾取 ${equipmentEvent.equipmentName}。` : ""}${progressEvent?.type === "hero.progressed" ? `获得 ${progressEvent.experienceGained} 经验${progressEvent.levelsGained > 0 ? `，升至 Lv ${progressEvent.level}，并得到 ${progressEvent.skillPointsAwarded} 点技能点` : ""}。` : ""}`;
     openBattleModal(
       didWin ? "战斗胜利" : "战斗失败",
       didWin ? winBody : "英雄被击退，生命值下降且本日移动力清零。"
@@ -1496,7 +1510,10 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
   if (
     update.events.some(
       (event) =>
-        event.type === "battle.started" || event.type === "battle.resolved" || event.type === "hero.skillLearned"
+        event.type === "battle.started" ||
+        event.type === "battle.resolved" ||
+        event.type === "hero.skillLearned" ||
+        event.type === "hero.equipmentFound"
     )
   ) {
     void refreshAccountProfileFromServer();

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -57,6 +57,8 @@ export interface HeroLoadout {
   inventory: string[];
 }
 
+export type EquipmentRarity = "common" | "rare" | "epic";
+
 export type HeroStatBonus = Pick<HeroStats, "attack" | "defense" | "power" | "knowledge">;
 
 export interface HeroView {
@@ -363,6 +365,15 @@ export type WorldEvent =
       spentPoint: number;
       remainingSkillPoints: number;
       newlyGrantedBattleSkillIds: BattleSkillId[];
+    }
+  | {
+      type: "hero.equipmentFound";
+      heroId: string;
+      battleId: string;
+      battleKind: "neutral" | "hero";
+      equipmentId: string;
+      equipmentName: string;
+      rarity: EquipmentRarity;
     }
   | {
       type: "battle.started";

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -1708,7 +1708,10 @@ export class VeilRoot extends Component {
     if (
       update.events.some(
         (event) =>
-          event.type === "battle.started" || event.type === "battle.resolved" || event.type === "hero.skillLearned"
+          event.type === "battle.started" ||
+          event.type === "battle.resolved" ||
+          event.type === "hero.skillLearned" ||
+          event.type === "hero.equipmentFound"
       )
     ) {
       void this.refreshGameplayAccountProfile();

--- a/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
+++ b/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
@@ -66,6 +66,10 @@ function formatWorldEvent(event: WorldEvent): string | null {
       : `习得 ${event.branchName} 分支技能 ${event.skillName}。`;
   }
 
+  if (event.type === "hero.equipmentFound") {
+    return `战斗缴获 ${event.equipmentName}。`;
+  }
+
   if (event.type === "resource.produced" && isObjectRecord(event.resource)) {
     const kind = typeof event.resource.kind === "string" ? event.resource.kind : "resource";
     const amount = typeof event.resource.amount === "number" ? event.resource.amount : 0;

--- a/apps/cocos-client/test/cocos-ui-formatters.test.ts
+++ b/apps/cocos-client/test/cocos-ui-formatters.test.ts
@@ -99,6 +99,15 @@ test("buildTimelineEntriesFromUpdate formats world events and system rejection",
         battleId: "battle-1",
         path: [{ x: 0, y: 0 }, { x: 1, y: 0 }],
         moveCost: 1
+      },
+      {
+        type: "hero.equipmentFound",
+        heroId: "hero-1",
+        battleId: "battle-1",
+        battleKind: "neutral",
+        equipmentId: "tower_shield_mail",
+        equipmentName: "塔盾链甲",
+        rarity: "common"
       }
     ],
     movementPlan: {
@@ -123,7 +132,8 @@ test("buildTimelineEntriesFromUpdate formats world events and system rejection",
     "事件：采集矿场，获得 木材 +2。",
     "事件：资源矿场结算 木材 +2。",
     "事件：中立守军 neutral-1 主动追击，移动到 (2,2)。",
-    "事件：中立守军 neutral-1 主动发起战斗。"
+    "事件：中立守军 neutral-1 主动发起战斗。",
+    "事件：战斗缴获 塔盾链甲。"
   ]);
 });
 

--- a/apps/server/src/player-achievements.ts
+++ b/apps/server/src/player-achievements.ts
@@ -1,6 +1,7 @@
 import {
   appendEventLogEntries,
   applyAchievementMetricDelta,
+  formatEquipmentRarityLabel,
   type AchievementMetric,
   type EventLogEntry,
   type EventLogReward,
@@ -170,6 +171,18 @@ function createEventLogEntry(
         rewards: []
       };
     }
+    case "hero.equipmentFound":
+      return {
+        id: createEventId(playerId, timestamp, event.type, sequence),
+        timestamp,
+        roomId: state.meta.roomId,
+        playerId,
+        category: "combat",
+        description: `${hero?.name ?? event.heroId} 在战斗后获得了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}。`,
+        heroId: event.heroId,
+        worldEventType: event.type,
+        rewards: []
+      };
     case "battle.started":
       return {
         id: createEventId(playerId, timestamp, event.type, sequence),

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -292,6 +292,34 @@ test("player achievement tracker appends logs and unlocks milestones", () => {
   assert.match(updated.recentEventLog.map((entry) => entry.description).join(" "), /解锁成就：初次交锋/);
 });
 
+test("player achievement tracker records equipment drop entries for hero victories", () => {
+  const updated = applyPlayerEventLogAndAchievements(
+    {
+      playerId: "player-1",
+      displayName: "暮火侦骑",
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      recentEventLog: []
+    },
+    createAccountTrackingWorldState(),
+    [
+      {
+        type: "hero.equipmentFound",
+        heroId: "hero-1",
+        battleId: "battle-neutral-1",
+        battleKind: "neutral",
+        equipmentId: "tower_shield_mail",
+        equipmentName: "塔盾链甲",
+        rarity: "common"
+      }
+    ],
+    "2026-03-27T12:05:00.000Z"
+  );
+
+  assert.equal(updated.recentEventLog[0]?.worldEventType, "hero.equipmentFound");
+  assert.match(updated.recentEventLog[0]?.description ?? "", /塔盾链甲/);
+});
+
 test("player account routes update display names through the account store", async (t) => {
   const port = 41000 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();

--- a/packages/shared/src/equipment.ts
+++ b/packages/shared/src/equipment.ts
@@ -252,6 +252,12 @@ const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
 const DEFAULT_EQUIPMENT_BY_ID = new Map(
   DEFAULT_EQUIPMENT_CATALOG.entries.map((entry) => [entry.id, entry] as const)
 );
+const DEFAULT_EQUIPMENT_BY_RARITY: Record<EquipmentRarity, EquipmentDefinition[]> = {
+  common: DEFAULT_EQUIPMENT_CATALOG.entries.filter((entry) => entry.rarity === "common"),
+  rare: DEFAULT_EQUIPMENT_CATALOG.entries.filter((entry) => entry.rarity === "rare"),
+  epic: DEFAULT_EQUIPMENT_CATALOG.entries.filter((entry) => entry.rarity === "epic")
+};
+const EQUIPMENT_DROP_CHANCE = 0.15;
 
 export interface HeroEquipmentBonusSummary extends EquipmentStatBonuses {
   attack: number;
@@ -275,6 +281,11 @@ export interface HeroEquipmentSlotView {
 export interface HeroEquipmentLoadoutView {
   slots: HeroEquipmentSlotView[];
   summary: HeroEquipmentBonusSummary;
+}
+
+export interface RolledEquipmentDrop {
+  itemId: string;
+  item: EquipmentDefinition;
 }
 
 const EQUIPMENT_SLOT_META: Array<{
@@ -346,6 +357,30 @@ export function getDefaultEquipmentCatalog(): EquipmentCatalogConfig {
 
 export function getEquipmentDefinition(equipmentId: string): EquipmentDefinition | undefined {
   return resolveEquipmentDefinition(equipmentId.trim());
+}
+
+export function rollEquipmentDrop(
+  dropRoll: number,
+  rarityRoll: number,
+  selectionRoll: number
+): RolledEquipmentDrop | null {
+  if (dropRoll >= EQUIPMENT_DROP_CHANCE) {
+    return null;
+  }
+
+  const rarity: EquipmentRarity =
+    rarityRoll < 0.65 ? "common" : rarityRoll < 0.93 ? "rare" : "epic";
+  const pool = DEFAULT_EQUIPMENT_BY_RARITY[rarity];
+  if (pool.length === 0) {
+    return null;
+  }
+
+  const index = Math.min(pool.length - 1, Math.floor(selectionRoll * pool.length));
+  const item = pool[index]!;
+  return {
+    itemId: item.id,
+    item
+  };
 }
 
 export function validateHeroEquipmentChange(

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -29,7 +29,7 @@ import type {
   WorldState
 } from "./models";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills";
-import { applyHeroEquipmentChange, validateHeroEquipmentChange } from "./equipment";
+import { applyHeroEquipmentChange, rollEquipmentDrop, validateHeroEquipmentChange } from "./equipment";
 import {
   normalizeHeroState,
   totalExperienceRequiredForLevel
@@ -46,6 +46,14 @@ function makeRng(seed: number): () => number {
     value = (value * 1664525 + 1013904223) >>> 0;
     return value / 0x100000000;
   };
+}
+
+function hashSeed(base: number, value: string): number {
+  let hash = base >>> 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = Math.imul(hash ^ value.charCodeAt(index), 16777619) >>> 0;
+  }
+  return hash >>> 0;
 }
 
 function samePosition(a: Vec2, b: Vec2): boolean {
@@ -70,6 +78,38 @@ function tileKey(position: Vec2): string {
 
 function tileIndex(map: WorldMapState, position: Vec2): number {
   return position.y * map.width + position.x;
+}
+
+function maybeAwardBattleEquipmentDrop(
+  hero: HeroState,
+  state: WorldState,
+  battleId: string,
+  battleKind: "neutral" | "hero"
+): { hero: HeroState; event: Extract<WorldEvent, { type: "hero.equipmentFound" }> } | null {
+  const rng = makeRng(hashSeed(hashSeed(state.meta.seed, `${battleId}:${hero.id}:${battleKind}`), `${state.meta.day}`));
+  const drop = rollEquipmentDrop(rng(), rng(), rng());
+  if (!drop) {
+    return null;
+  }
+
+  return {
+    hero: {
+      ...hero,
+      loadout: {
+        ...hero.loadout,
+        inventory: [...hero.loadout.inventory, drop.itemId]
+      }
+    },
+    event: {
+      type: "hero.equipmentFound",
+      heroId: hero.id,
+      battleId,
+      battleKind,
+      equipmentId: drop.itemId,
+      equipmentName: drop.item.name,
+      rarity: drop.item.rarity
+    }
+  };
 }
 
 function createTerrainTile(position: Vec2, roll: number): TileState {
@@ -2399,6 +2439,7 @@ export function filterWorldEventsForPlayer(
       case "hero.progressed":
       case "hero.skillLearned":
       case "hero.equipmentChanged":
+      case "hero.equipmentFound":
         return ownsHero(event.heroId);
       case "neutral.moved": {
         const visibility = state.visibilityByPlayer[playerId];
@@ -2450,6 +2491,7 @@ export function applyBattleOutcomeToWorld(
 
     if (outcome.status === "defender_victory") {
       const awardedDefender = applyHeroExperience(defenderHero, heroBattleExperience(attackerHero), "hero");
+      const droppedEquipment = maybeAwardBattleEquipmentDrop(awardedDefender.hero, state, battleId, "hero");
       const heroes = state.heroes.map((hero) =>
         hero.id === attackerId
           ? {
@@ -2458,7 +2500,7 @@ export function applyBattleOutcomeToWorld(
               move: { ...hero.move, remaining: 0 }
             }
           : hero.id === defenderId
-            ? awardedDefender.hero
+            ? droppedEquipment?.hero ?? awardedDefender.hero
           : hero
       );
       return {
@@ -2482,7 +2524,8 @@ export function applyBattleOutcomeToWorld(
             levelsGained: awardedDefender.levelsGained,
             skillPointsAwarded: awardedDefender.skillPointsAwarded,
             availableSkillPoints: awardedDefender.hero.progression.skillPoints
-          }
+          },
+          ...(droppedEquipment ? [droppedEquipment.event] : [])
         ]
       };
     }
@@ -2499,10 +2542,11 @@ export function applyBattleOutcomeToWorld(
     }) ?? defenderHero.position;
 
     const awardedAttacker = applyHeroExperience(attackerHero, heroBattleExperience(defenderHero), "hero");
+    const droppedEquipment = maybeAwardBattleEquipmentDrop(awardedAttacker.hero, state, battleId, "hero");
     const heroes = state.heroes.map((hero) => {
       if (hero.id === attackerId) {
         return {
-          ...awardedAttacker.hero,
+          ...(droppedEquipment?.hero ?? awardedAttacker.hero),
           position: defenderHero.position
         };
       }
@@ -2540,7 +2584,8 @@ export function applyBattleOutcomeToWorld(
             levelsGained: awardedAttacker.levelsGained,
             skillPointsAwarded: awardedAttacker.skillPointsAwarded,
             availableSkillPoints: awardedAttacker.hero.progression.skillPoints
-          }
+          },
+          ...(droppedEquipment ? [droppedEquipment.event] : [])
         ]
       };
   }
@@ -2584,12 +2629,13 @@ export function applyBattleOutcomeToWorld(
   }
 
   const awardedAttacker = applyHeroExperience(attackerHero, neutralBattleExperience(neutralArmy), "neutral");
+  const droppedEquipment = maybeAwardBattleEquipmentDrop(awardedAttacker.hero, state, battleId, "neutral");
   const nextNeutralArmies = { ...state.neutralArmies };
   delete nextNeutralArmies[neutralArmyId];
   const heroes = state.heroes.map((hero) =>
     hero.id === heroId
       ? {
-          ...awardedAttacker.hero,
+          ...(droppedEquipment?.hero ?? awardedAttacker.hero),
           position: neutralArmy.position
         }
       : hero
@@ -2631,7 +2677,8 @@ export function applyBattleOutcomeToWorld(
               resource: neutralArmy.reward
             }
           ]
-        : [])
+        : []),
+      ...(droppedEquipment ? [droppedEquipment.event] : [])
     ]
   };
 }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -647,6 +647,15 @@ export type WorldEvent =
       unequippedItemId?: EquipmentId;
     }
   | {
+      type: "hero.equipmentFound";
+      heroId: string;
+      battleId: string;
+      battleKind: "neutral" | "hero";
+      equipmentId: EquipmentId;
+      equipmentName: string;
+      rarity: EquipmentRarity;
+    }
+  | {
       type: "battle.started";
       heroId: string;
       encounterKind: "neutral" | "hero";

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -41,6 +41,7 @@ import {
   simulateAutomatedBattle,
   simulateAutomatedBattles,
   resolveWorldAction,
+  rollEquipmentDrop,
   setBattleBalanceConfig,
   setBattleSkillCatalog,
   setUnitCatalog,
@@ -698,6 +699,57 @@ test("hero equip and unequip actions rotate items between slots and inventory", 
       heroId: "hero-equip-action",
       slot: "weapon",
       unequippedItemId: "vanguard_blade"
+    }
+  ]);
+});
+
+test("equipment drops respect rarity pools and battle victories add loot to hero inventory", () => {
+  assert.equal(rollEquipmentDrop(0.9, 0.1, 0.1), null);
+  assert.deepEqual(rollEquipmentDrop(0.01, 0.98, 0.9), {
+    itemId: "oracle_lens",
+    item: getDefaultEquipmentCatalog().entries.find((entry) => entry.id === "oracle_lens")
+  });
+
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳"
+  });
+  const neutralArmy: NeutralArmyState = {
+    id: "neutral-1",
+    position: { x: 1, y: 0 },
+    reward: { kind: "gold", amount: 100 },
+    stacks: [{ templateId: "wolf_pack", count: 4 }]
+  };
+  const state = createWorldState({
+    heroes: [hero],
+    neutralArmies: { "neutral-1": neutralArmy },
+    resources: {
+      "player-1": {
+        gold: 0,
+        wood: 0,
+        ore: 0
+      }
+    }
+  });
+  state.meta.seed = 3;
+
+  const outcome = applyBattleOutcomeToWorld(state, "battle-neutral-1", "hero-1", {
+    status: "attacker_victory",
+    survivingAttackers: ["hero-1-stack"],
+    survivingDefenders: []
+  });
+
+  assert.deepEqual(outcome.state.heroes[0]?.loadout.inventory, ["tower_shield_mail"]);
+  assert.deepEqual(outcome.events.slice(-1), [
+    {
+      type: "hero.equipmentFound",
+      heroId: "hero-1",
+      battleId: "battle-neutral-1",
+      battleKind: "neutral",
+      equipmentId: "tower_shield_mail",
+      equipmentName: "塔盾链甲",
+      rarity: "common"
     }
   ]);
 });


### PR DESCRIPTION
## Summary
- add deterministic post-battle equipment drops that feed directly into hero inventory without trying to finish the full equipment feature set
- emit and surface a new `hero.equipmentFound` world event through shared state, account event logs, the web client, and the Cocos timeline
- cover the drop runtime and messaging path with shared, server, and Cocos tests

## Validation
- `node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/player-account-routes.test.ts ./apps/cocos-client/test/cocos-ui-formatters.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `npm run typecheck:cocos`
- `npm test`

## Notes
- This PR delivers a bounded sub-scope toward `#28`; it does not close the issue.
- Remaining `#28` work still includes broader acquisition loops, forge/trade interactions, and fuller equipment management UX.
- `npm run typecheck:client:h5` still fails on pre-existing issues in `apps/client/src/object-visuals.ts` unrelated to this branch.
