### PR TITLE
feat: persist battle replay summaries for #27

### DIFF
--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -7,8 +7,10 @@ import {
 } from "./auth-session";
 import {
   normalizeAchievementProgress,
+  normalizePlayerBattleReplaySummaries,
   normalizeEventLogEntries,
   type EventLogEntry,
+  type PlayerBattleReplaySummary,
   type PlayerAchievementProgress
 } from "../../../packages/shared/src/index";
 
@@ -25,6 +27,7 @@ export interface PlayerAccountProfile {
   };
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
+  recentBattleReplays: PlayerBattleReplaySummary[];
   loginId?: string;
   credentialBoundAt?: string;
   lastRoomId?: string;
@@ -43,6 +46,7 @@ interface PlayerAccountApiPayload {
     };
     achievements?: Partial<PlayerAchievementProgress>[];
     recentEventLog?: Partial<EventLogEntry>[];
+    recentBattleReplays?: Partial<PlayerBattleReplaySummary>[];
     loginId?: string;
     credentialBoundAt?: string;
     lastRoomId?: string;
@@ -141,6 +145,7 @@ function asPlayerAccountProfile(
     globalResources: normalizeGlobalResources(account?.globalResources),
     achievements: normalizeAchievementProgress(account?.achievements),
     recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
+    recentBattleReplays: normalizePlayerBattleReplaySummaries(account?.recentBattleReplays),
     ...(loginId ? { loginId } : {}),
     ...(account?.credentialBoundAt ? { credentialBoundAt: account.credentialBoundAt } : {}),
     ...(account?.lastRoomId ? { lastRoomId: account.lastRoomId } : roomId ? { lastRoomId: roomId } : {}),
@@ -180,6 +185,7 @@ export function createFallbackPlayerAccountProfile(
     globalResources: normalizeGlobalResources(),
     achievements: normalizeAchievementProgress(),
     recentEventLog: normalizeEventLogEntries(),
+    recentBattleReplays: normalizePlayerBattleReplaySummaries(),
     ...(roomId ? { lastRoomId: roomId } : {}),
     source: "local"
   };

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -70,6 +70,7 @@ test("player account helpers can build a local fallback profile", () => {
       }
     ],
     recentEventLog: [],
+    recentBattleReplays: [],
     lastRoomId: "room-beta",
     source: "local"
   });

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -6,8 +6,10 @@ import {
 } from "./cocos-session-launch.ts";
 import {
   normalizeAchievementProgress,
+  normalizePlayerBattleReplaySummaries,
   normalizeEventLogEntries,
   type EventLogEntry,
+  type PlayerBattleReplaySummary,
   type PlayerAchievementProgress
 } from "../../../../packages/shared/src/index.ts";
 
@@ -41,6 +43,7 @@ export interface CocosPlayerAccountProfile {
   };
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
+  recentBattleReplays: PlayerBattleReplaySummary[];
   loginId?: string;
   credentialBoundAt?: string;
   lastRoomId?: string;
@@ -69,6 +72,7 @@ interface PlayerAccountApiPayload extends AuthSessionApiPayload {
     };
     achievements?: Partial<PlayerAchievementProgress>[];
     recentEventLog?: Partial<EventLogEntry>[];
+    recentBattleReplays?: Partial<PlayerBattleReplaySummary>[];
     loginId?: string;
     credentialBoundAt?: string;
     lastRoomId?: string;
@@ -179,6 +183,7 @@ function asCocosPlayerAccountProfile(
     globalResources: normalizeGlobalResources(account?.globalResources),
     achievements: normalizeAchievementProgress(account?.achievements),
     recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
+    recentBattleReplays: normalizePlayerBattleReplaySummaries(account?.recentBattleReplays),
     ...(loginId ? { loginId } : {}),
     ...(account?.credentialBoundAt ? { credentialBoundAt: account.credentialBoundAt } : {}),
     ...(account?.lastRoomId ? { lastRoomId: account.lastRoomId } : roomId ? { lastRoomId: roomId } : {}),
@@ -277,6 +282,7 @@ export function createFallbackCocosPlayerAccountProfile(
     globalResources: normalizeGlobalResources(),
     achievements: normalizeAchievementProgress(),
     recentEventLog: normalizeEventLogEntries(),
+    recentBattleReplays: normalizePlayerBattleReplaySummaries(),
     ...(roomId ? { lastRoomId: roomId } : {}),
     source: "local"
   };

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -328,6 +328,7 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         rewards: [{ type: "badge", label: "初次交锋" }]
       }
     ],
+    recentBattleReplays: [],
     source: "remote"
   });
   assert.ok(values.get("project-veil:auth-session")?.includes("\"loginId\":\"veil-ranger\""));

--- a/apps/server/src/battle-replays.ts
+++ b/apps/server/src/battle-replays.ts
@@ -1,0 +1,139 @@
+import {
+  appendPlayerBattleReplaySummaries,
+  type BattleAction,
+  type BattleOutcome,
+  type BattleReplayCamp,
+  type BattleReplayResult,
+  type BattleReplayStep,
+  type BattleState,
+  type PlayerBattleReplaySummary
+} from "../../../packages/shared/src/index";
+import type { PlayerAccountSnapshot } from "./persistence";
+
+const RECENT_BATTLE_REPLAY_LIMIT = 5;
+
+export interface OngoingBattleReplayCapture {
+  battleId: string;
+  roomId: string;
+  startedAt: string;
+  initialState: BattleState;
+  steps: BattleReplayStep[];
+}
+
+export interface CompletedBattleReplayCapture extends OngoingBattleReplayCapture {
+  completedAt: string;
+  battleState: BattleState;
+  result: BattleReplayResult;
+}
+
+function cloneBattleState(state: BattleState): BattleState {
+  return structuredClone(state);
+}
+
+function battleKindOf(battle: BattleState): "neutral" | "hero" {
+  return battle.neutralArmyId ? "neutral" : "hero";
+}
+
+export function createBattleReplayCapture(
+  roomId: string,
+  battle: BattleState,
+  startedAt = new Date().toISOString()
+): OngoingBattleReplayCapture {
+  return {
+    battleId: battle.id,
+    roomId,
+    startedAt,
+    initialState: cloneBattleState(battle),
+    steps: []
+  };
+}
+
+export function appendBattleReplayStep(
+  replay: OngoingBattleReplayCapture,
+  action: BattleAction,
+  source: BattleReplayStep["source"]
+): OngoingBattleReplayCapture {
+  return {
+    ...replay,
+    steps: replay.steps.concat({
+      index: replay.steps.length + 1,
+      source,
+      action: structuredClone(action)
+    })
+  };
+}
+
+export function finalizeBattleReplayCapture(
+  replay: OngoingBattleReplayCapture,
+  battleState: BattleState,
+  outcome: BattleOutcome,
+  completedAt = new Date().toISOString()
+): CompletedBattleReplayCapture | null {
+  if (outcome.status !== "attacker_victory" && outcome.status !== "defender_victory") {
+    return null;
+  }
+
+  return {
+    ...replay,
+    completedAt,
+    battleState: cloneBattleState(battleState),
+    result: outcome.status
+  };
+}
+
+function buildPlayerReplayId(replay: CompletedBattleReplayCapture, playerId: string): string {
+  return `${replay.roomId}:${replay.battleId}:${playerId}`;
+}
+
+function playerResultForCamp(result: BattleReplayResult, camp: BattleReplayCamp): BattleReplayResult {
+  return result === "attacker_victory"
+    ? camp === "attacker"
+      ? "attacker_victory"
+      : "defender_victory"
+    : camp === "defender"
+      ? "attacker_victory"
+      : "defender_victory";
+}
+
+export function buildPlayerBattleReplaySummary(
+  replay: CompletedBattleReplayCapture,
+  playerId: string,
+  heroId: string,
+  playerCamp: BattleReplayCamp,
+  opponentHeroId?: string
+): PlayerBattleReplaySummary {
+  return {
+    id: buildPlayerReplayId(replay, playerId),
+    roomId: replay.roomId,
+    playerId,
+    battleId: replay.battleId,
+    battleKind: battleKindOf(replay.battleState),
+    playerCamp,
+    heroId,
+    ...(opponentHeroId ? { opponentHeroId } : {}),
+    ...(replay.battleState.neutralArmyId ? { neutralArmyId: replay.battleState.neutralArmyId } : {}),
+    startedAt: replay.startedAt,
+    completedAt: replay.completedAt,
+    initialState: replay.initialState,
+    steps: replay.steps,
+    result: playerResultForCamp(replay.result, playerCamp)
+  };
+}
+
+export function appendCompletedBattleReplaysToAccount(
+  account: PlayerAccountSnapshot,
+  replays: PlayerBattleReplaySummary[]
+): PlayerAccountSnapshot {
+  if (replays.length === 0) {
+    return account;
+  }
+
+  return {
+    ...account,
+    recentBattleReplays: appendPlayerBattleReplaySummaries(
+      account.recentBattleReplays,
+      replays,
+      RECENT_BATTLE_REPLAY_LIMIT
+    )
+  };
+}

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -5,6 +5,7 @@ import {
   filterWorldEventsForPlayer,
   listReachableTiles,
   planHeroMovement,
+  type PlayerBattleReplaySummary,
   type ClientMessage,
   type MovementPlan,
   type ServerMessage,
@@ -12,6 +13,11 @@ import {
   type WorldEvent
 } from "../../../packages/shared/src/index";
 import { createRoom, type AuthoritativeWorldRoom, type RoomPersistenceSnapshot } from "./index";
+import {
+  appendCompletedBattleReplaysToAccount,
+  buildPlayerBattleReplaySummary,
+  type CompletedBattleReplayCapture
+} from "./battle-replays";
 import {
   applyPlayerAccountsToWorldState,
   applyPlayerHeroArchivesToWorldState,
@@ -226,7 +232,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         sendMessage(client, "error", { requestId: message.requestId, reason: "persistence_save_failed" });
         return;
       }
-      await this.persistPlayerAccountProgress(result.events ?? []);
+      await this.persistPlayerAccountProgress(result.events ?? [], this.worldRoom.consumeCompletedBattleReplays());
 
       this.publishLobbyRoomSummary();
       sendMessage(client, "session.state", {
@@ -261,7 +267,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         sendMessage(client, "error", { requestId: message.requestId, reason: "persistence_save_failed" });
         return;
       }
-      await this.persistPlayerAccountProgress(result.events ?? []);
+      await this.persistPlayerAccountProgress(result.events ?? [], this.worldRoom.consumeCompletedBattleReplays());
 
       this.publishLobbyRoomSummary();
       sendMessage(client, "session.state", {
@@ -328,9 +334,12 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     await configuredRoomSnapshotStore.save(this.metadata.logicalRoomId, this.worldRoom.serializePersistenceSnapshot());
   }
 
-  private async persistPlayerAccountProgress(events: WorldEvent[]): Promise<void> {
+  private async persistPlayerAccountProgress(
+    events: WorldEvent[],
+    completedReplays: CompletedBattleReplayCapture[]
+  ): Promise<void> {
     const store = configuredRoomSnapshotStore;
-    if (!store || events.length === 0) {
+    if (!store || (events.length === 0 && completedReplays.length === 0)) {
       return;
     }
 
@@ -341,7 +350,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     await Promise.all(
       playerIds.map(async (playerId) => {
         const playerEvents = filterWorldEventsForPlayer(internalState, playerId, events);
-        if (playerEvents.length === 0) {
+        const playerReplays = completedReplays.flatMap((replay) => this.buildPlayerBattleReplaysForAccount(replay, playerId));
+        if (playerEvents.length === 0 && playerReplays.length === 0) {
           return;
         }
 
@@ -351,14 +361,43 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
             playerId,
             lastRoomId: this.metadata.logicalRoomId
           }));
-        const nextAccount = applyPlayerEventLogAndAchievements(existingAccount, internalState, playerEvents);
+        const nextAccount = appendCompletedBattleReplaysToAccount(
+          applyPlayerEventLogAndAchievements(existingAccount, internalState, playerEvents),
+          playerReplays
+        );
         await store.savePlayerAccountProgress(playerId, {
           achievements: nextAccount.achievements,
           recentEventLog: nextAccount.recentEventLog,
+          ...(nextAccount.recentBattleReplays ? { recentBattleReplays: nextAccount.recentBattleReplays } : {}),
           lastRoomId: this.metadata.logicalRoomId
         });
       })
     ).catch(() => undefined);
+  }
+
+  private buildPlayerBattleReplaysForAccount(
+    replay: CompletedBattleReplayCapture,
+    playerId: string
+  ): PlayerBattleReplaySummary[] {
+    const battle = replay.battleState;
+    const attackerHero =
+      battle.worldHeroId != null
+        ? this.worldRoom.getInternalState().heroes.find((hero) => hero.id === battle.worldHeroId)
+        : undefined;
+    const defenderHero =
+      battle.defenderHeroId != null
+        ? this.worldRoom.getInternalState().heroes.find((hero) => hero.id === battle.defenderHeroId)
+        : undefined;
+
+    if (attackerHero?.playerId === playerId && battle.worldHeroId) {
+      return [buildPlayerBattleReplaySummary(replay, playerId, battle.worldHeroId, "attacker", battle.defenderHeroId)];
+    }
+
+    if (defenderHero?.playerId === playerId && battle.defenderHeroId) {
+      return [buildPlayerBattleReplaySummary(replay, playerId, battle.defenderHeroId, "defender", battle.worldHeroId)];
+    }
+
+    return [];
   }
 
   private publishLobbyRoomSummary(): void {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -16,10 +16,18 @@ import {
   type MovementPlan,
   type PlayerWorldView,
   type BattleAction,
+  type BattleOutcome,
   type WorldAction,
   type WorldEvent,
   type WorldState
 } from "../../../packages/shared/src/index";
+import {
+  appendBattleReplayStep,
+  createBattleReplayCapture,
+  finalizeBattleReplayCapture,
+  type CompletedBattleReplayCapture,
+  type OngoingBattleReplayCapture
+} from "./battle-replays";
 
 export interface RoomSnapshot {
   roomId: string;
@@ -53,6 +61,8 @@ export class AuthoritativeWorldRoom {
   private state: WorldState;
   private readonly battles = new Map<string, BattleState>();
   private readonly battleIdByHeroId = new Map<string, string>();
+  private readonly battleReplayByBattleId = new Map<string, OngoingBattleReplayCapture>();
+  private readonly completedBattleReplays: CompletedBattleReplayCapture[] = [];
 
   constructor(roomId: string, seed = 1001, snapshot?: RoomPersistenceSnapshot) {
     if (snapshot) {
@@ -88,6 +98,12 @@ export class AuthoritativeWorldRoom {
 
   getActiveBattles(): BattleState[] {
     return Array.from(this.battles.values());
+  }
+
+  consumeCompletedBattleReplays(): CompletedBattleReplayCapture[] {
+    const completed = this.completedBattleReplays.map((replay) => structuredClone(replay));
+    this.completedBattleReplays.length = 0;
+    return completed;
   }
 
   private getBattleById(battleId: string): BattleState | undefined {
@@ -151,6 +167,35 @@ export class AuthoritativeWorldRoom {
     }
   }
 
+  private trackStartedBattle(battle: BattleState): void {
+    this.setBattle(battle);
+    if (!this.battleReplayByBattleId.has(battle.id)) {
+      this.battleReplayByBattleId.set(battle.id, createBattleReplayCapture(this.state.meta.roomId, battle));
+    }
+  }
+
+  private trackBattleAction(battleId: string, action: BattleAction, source: "player" | "automated"): void {
+    const existing = this.battleReplayByBattleId.get(battleId);
+    if (!existing) {
+      return;
+    }
+
+    this.battleReplayByBattleId.set(battleId, appendBattleReplayStep(existing, action, source));
+  }
+
+  private finalizeBattleReplay(battle: BattleState, outcome: BattleOutcome): void {
+    const existing = this.battleReplayByBattleId.get(battle.id);
+    if (!existing) {
+      return;
+    }
+
+    this.battleReplayByBattleId.delete(battle.id);
+    const completed = finalizeBattleReplayCapture(existing, battle, outcome);
+    if (completed) {
+      this.completedBattleReplays.push(completed);
+    }
+  }
+
   getSnapshot(playerId: string): RoomSnapshot {
     return {
       roomId: this.state.meta.roomId,
@@ -181,6 +226,7 @@ export class AuthoritativeWorldRoom {
 
       const outcome = getBattleOutcome(battle);
       if (outcome.status !== "in_progress") {
+        this.finalizeBattleReplay(battle, outcome);
         if (battle.worldHeroId) {
           const worldOutcome = applyBattleOutcomeToWorld(
             this.state,
@@ -206,6 +252,7 @@ export class AuthoritativeWorldRoom {
         break;
       }
 
+      this.trackBattleAction(battle.id, automatedAction, "automated");
       this.setBattle(applyBattleAction(battle, automatedAction));
     }
 
@@ -259,7 +306,7 @@ export class AuthoritativeWorldRoom {
         }
 
         const battle = createNeutralBattleState(hero, neutralArmy, this.state.meta.seed + this.state.meta.day);
-        this.setBattle(battle);
+        this.trackStartedBattle(battle);
         startedBattleIds.push(battle.id);
         continue;
       }
@@ -271,7 +318,7 @@ export class AuthoritativeWorldRoom {
         }
 
         const battle = createHeroBattleState(hero, defenderHero, this.state.meta.seed + this.state.meta.day);
-        this.setBattle(battle);
+        this.trackStartedBattle(battle);
         startedBattleIds.push(battle.id);
       }
     }
@@ -329,6 +376,7 @@ export class AuthoritativeWorldRoom {
       };
     }
 
+    this.trackBattleAction(activeBattle.id, action, "player");
     const nextBattle = applyBattleAction(activeBattle, action);
     this.setBattle(nextBattle);
     const automatedEvents = this.resolveAutomatedBattleTurns(nextBattle.id);

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -1,10 +1,12 @@
 import { createConnection, createPool, type Pool, type PoolConnection, type ResultSetHeader, type RowDataPacket } from "mysql2/promise";
 import {
+  appendPlayerBattleReplaySummaries,
   normalizeAchievementProgress,
   normalizeEventLogEntries,
   normalizeHeroState,
   type EventLogEntry,
   type HeroState,
+  type PlayerBattleReplaySummary,
   type PlayerAchievementProgress,
   type ResourceLedger,
   type WorldState
@@ -85,6 +87,7 @@ interface PlayerAccountRow extends RowDataPacket {
   global_resources_json: string | ResourceLedger;
   achievements_json: string | PlayerAchievementProgress[] | null;
   recent_event_log_json: string | EventLogEntry[] | null;
+  recent_battle_replays_json: string | PlayerBattleReplaySummary[] | null;
   last_room_id: string | null;
   last_seen_at: Date | string | null;
   login_id: string | null;
@@ -135,6 +138,7 @@ export interface PlayerAccountSnapshot {
   globalResources: ResourceLedger;
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
+  recentBattleReplays?: PlayerBattleReplaySummary[];
   lastRoomId?: string;
   lastSeenAt?: string;
   loginId?: string;
@@ -171,6 +175,7 @@ export interface PlayerAccountProfilePatch {
 export interface PlayerAccountProgressPatch {
   achievements?: Partial<PlayerAchievementProgress>[] | null;
   recentEventLog?: Partial<EventLogEntry>[] | null;
+  recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null;
   lastRoomId?: string | null;
 }
 
@@ -302,6 +307,7 @@ function normalizePlayerAccountSnapshot(account: {
   globalResources?: Partial<ResourceLedger>;
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
+  recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
   loginId?: string | null | undefined;
@@ -317,6 +323,7 @@ function normalizePlayerAccountSnapshot(account: {
     globalResources: normalizeResourceLedger(account.globalResources),
     achievements: normalizeAchievementProgress(account.achievements),
     recentEventLog: normalizeEventLogEntries(account.recentEventLog),
+    recentBattleReplays: appendPlayerBattleReplaySummaries([], account.recentBattleReplays),
     ...(account.lastRoomId ? { lastRoomId: account.lastRoomId } : {}),
     ...(account.lastSeenAt ? { lastSeenAt: account.lastSeenAt } : {}),
     ...(account.loginId ? { loginId: normalizePlayerLoginId(account.loginId) } : {}),
@@ -361,7 +368,8 @@ export function createPlayerAccountsFromWorldState(state: WorldState): PlayerAcc
     displayName: normalizePlayerDisplayName(playerId),
     globalResources: normalizeResourceLedger(state.resources[playerId]),
     achievements: normalizeAchievementProgress(),
-    recentEventLog: normalizeEventLogEntries()
+    recentEventLog: normalizeEventLogEntries(),
+    recentBattleReplays: appendPlayerBattleReplaySummaries([], [])
   }));
 }
 
@@ -571,6 +579,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   global_resources_json LONGTEXT NOT NULL,
   achievements_json LONGTEXT NULL,
   recent_event_log_json LONGTEXT NULL,
+  recent_battle_replays_json LONGTEXT NULL,
   last_room_id VARCHAR(191) NULL,
   last_seen_at DATETIME NULL DEFAULT NULL,
   login_id VARCHAR(40) NULL,
@@ -636,6 +645,24 @@ PREPARE veil_player_accounts_event_log_stmt FROM @veil_player_accounts_event_log
 EXECUTE veil_player_accounts_event_log_stmt;
 DEALLOCATE PREPARE veil_player_accounts_event_log_stmt;
 
+SET @veil_player_accounts_battle_replays_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'recent_battle_replays_json'
+);
+
+SET @veil_player_accounts_battle_replays_sql := IF(
+  @veil_player_accounts_battle_replays_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`recent_battle_replays_json\` LONGTEXT NULL AFTER \`recent_event_log_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_battle_replays_stmt FROM @veil_player_accounts_battle_replays_sql;
+EXECUTE veil_player_accounts_battle_replays_stmt;
+DEALLOCATE PREPARE veil_player_accounts_battle_replays_stmt;
+
 SET @veil_player_accounts_last_room_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.COLUMNS
@@ -646,7 +673,7 @@ SET @veil_player_accounts_last_room_exists := (
 
 SET @veil_player_accounts_last_room_sql := IF(
   @veil_player_accounts_last_room_exists = 0,
-  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`last_room_id\` VARCHAR(191) NULL AFTER \`recent_event_log_json\`',
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`last_room_id\` VARCHAR(191) NULL AFTER \`recent_battle_replays_json\`',
   'SELECT 1'
 );
 
@@ -968,6 +995,10 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
       row.recent_event_log_json != null
         ? parseJsonColumn<EventLogEntry[]>(row.recent_event_log_json)
         : [],
+    recentBattleReplays:
+      row.recent_battle_replays_json != null
+        ? parseJsonColumn<PlayerBattleReplaySummary[]>(row.recent_battle_replays_json)
+        : [],
     ...(row.display_name ? { displayName: row.display_name } : {}),
     ...(row.last_room_id ? { lastRoomId: row.last_room_id } : {}),
     ...(row.login_id ? { loginId: row.login_id } : {}),
@@ -1041,20 +1072,24 @@ async function savePlayerAccounts(
          global_resources_json,
          achievements_json,
          recent_event_log_json
+         ,
+         recent_battle_replays_json
        )
-       VALUES (?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(display_name, VALUES(display_name)),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = COALESCE(achievements_json, VALUES(achievements_json)),
          recent_event_log_json = COALESCE(recent_event_log_json, VALUES(recent_event_log_json)),
+         recent_battle_replays_json = COALESCE(recent_battle_replays_json, VALUES(recent_battle_replays_json)),
          version = version + 1`,
       [
         normalizedAccount.playerId,
         normalizedAccount.displayName,
         JSON.stringify(normalizedAccount.globalResources),
         JSON.stringify(normalizedAccount.achievements),
-        JSON.stringify(normalizedAccount.recentEventLog)
+        JSON.stringify(normalizedAccount.recentEventLog),
+        JSON.stringify(normalizedAccount.recentBattleReplays)
       ]
     );
   }
@@ -1177,6 +1212,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         global_resources_json LONGTEXT NOT NULL,
         achievements_json LONGTEXT NULL,
         recent_event_log_json LONGTEXT NULL,
+        recent_battle_replays_json LONGTEXT NULL,
         last_room_id VARCHAR(191) NULL,
         last_seen_at DATETIME NULL DEFAULT NULL,
         login_id VARCHAR(40) NULL,
@@ -1240,8 +1276,15 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       pool,
       config.database,
       MYSQL_PLAYER_ACCOUNT_TABLE,
+      "recent_battle_replays_json",
+      "`recent_battle_replays_json` LONGTEXT NULL AFTER `recent_event_log_json`"
+    );
+    await ensureColumnExists(
+      pool,
+      config.database,
+      MYSQL_PLAYER_ACCOUNT_TABLE,
       "last_room_id",
-      "`last_room_id` VARCHAR(191) NULL AFTER `recent_event_log_json`"
+      "`last_room_id` VARCHAR(191) NULL AFTER `recent_battle_replays_json`"
     );
     await ensureColumnExists(
       pool,
@@ -1476,6 +1519,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          global_resources_json,
          achievements_json,
          recent_event_log_json,
+         recent_battle_replays_json,
          last_room_id,
          last_seen_at,
          login_id,
@@ -1506,6 +1550,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          global_resources_json,
          achievements_json,
          recent_event_log_json,
+         recent_battle_replays_json,
          last_room_id,
          last_seen_at,
          login_id,
@@ -1553,10 +1598,11 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          global_resources_json,
          achievements_json,
          recent_event_log_json,
+         recent_battle_replays_json,
          last_room_id,
          last_seen_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(?, display_name),
          last_room_id = COALESCE(?, last_room_id),
@@ -1568,6 +1614,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(normalizeResourceLedger()),
         JSON.stringify(normalizeAchievementProgress()),
         JSON.stringify(normalizeEventLogEntries()),
+        JSON.stringify(appendPlayerBattleReplaySummaries([], [])),
         lastRoomId,
         lastSeenAt,
         explicitDisplayName,
@@ -1583,6 +1630,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         globalResources: normalizeResourceLedger(),
         achievements: normalizeAchievementProgress(),
         recentEventLog: normalizeEventLogEntries(),
+        recentBattleReplays: appendPlayerBattleReplaySummaries([], []),
         ...(lastRoomId ? { lastRoomId } : {}),
         lastSeenAt: lastSeenAt.toISOString()
       })
@@ -1663,15 +1711,17 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          global_resources_json,
          achievements_json,
          recent_event_log_json,
+         recent_battle_replays_json,
          last_room_id,
          last_seen_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = VALUES(achievements_json),
          recent_event_log_json = VALUES(recent_event_log_json),
+         recent_battle_replays_json = VALUES(recent_battle_replays_json),
          last_room_id = VALUES(last_room_id),
          last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
          version = version + 1`,
@@ -1681,6 +1731,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.globalResources),
         JSON.stringify(nextAccount.achievements),
         JSON.stringify(nextAccount.recentEventLog),
+        JSON.stringify(nextAccount.recentBattleReplays),
         nextAccount.lastRoomId ?? null,
         existing.lastSeenAt ? new Date(existing.lastSeenAt) : null
       ]
@@ -1710,6 +1761,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       playerId: normalizedPlayerId,
       achievements: patch.achievements ?? existing.achievements,
       recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
+      recentBattleReplays: patch.recentBattleReplays ?? existing.recentBattleReplays,
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId
           ? { lastRoomId: patch.lastRoomId.trim() }
@@ -1726,15 +1778,17 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          global_resources_json,
          achievements_json,
          recent_event_log_json,
+         recent_battle_replays_json,
          last_room_id,
          last_seen_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = VALUES(achievements_json),
          recent_event_log_json = VALUES(recent_event_log_json),
+         recent_battle_replays_json = VALUES(recent_battle_replays_json),
          last_room_id = VALUES(last_room_id),
          last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
          version = version + 1`,
@@ -1744,6 +1798,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.globalResources),
         JSON.stringify(nextAccount.achievements),
         JSON.stringify(nextAccount.recentEventLog),
+        JSON.stringify(nextAccount.recentBattleReplays),
         nextAccount.lastRoomId ?? null,
         existing.lastSeenAt ? new Date(existing.lastSeenAt) : null
       ]
@@ -1776,6 +1831,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          global_resources_json,
          achievements_json,
          recent_event_log_json,
+         recent_battle_replays_json,
          last_room_id,
          last_seen_at,
          login_id,

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -81,6 +81,7 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       globalResources: structuredClone(existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 }),
       achievements: structuredClone(existing?.achievements ?? []),
       recentEventLog: structuredClone(existing?.recentEventLog ?? []),
+      recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
@@ -169,6 +170,7 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         displayName: previous?.displayName ?? account.displayName,
         achievements: structuredClone(previous?.achievements ?? account.achievements),
         recentEventLog: structuredClone(previous?.recentEventLog ?? account.recentEventLog),
+        recentBattleReplays: structuredClone(previous?.recentBattleReplays ?? account.recentBattleReplays ?? []),
         ...(previous?.loginId ? { loginId: previous.loginId } : {}),
         ...(previous?.credentialBoundAt ? { credentialBoundAt: previous.credentialBoundAt } : {}),
         ...(previous?.lastRoomId ? { lastRoomId: previous.lastRoomId } : {}),
@@ -202,6 +204,11 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       ...existing,
       achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
       recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      recentBattleReplays: structuredClone(
+        (patch.recentBattleReplays as PlayerAccountSnapshot["recentBattleReplays"] | undefined) ??
+          existing.recentBattleReplays ??
+          []
+      ),
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId?.trim()
           ? { lastRoomId: patch.lastRoomId.trim() }
@@ -222,6 +229,7 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       globalResources: structuredClone(account.globalResources),
       achievements: structuredClone(account.achievements),
       recentEventLog: structuredClone(account.recentEventLog),
+      recentBattleReplays: structuredClone(account.recentBattleReplays ?? []),
       ...(account.lastRoomId ? { lastRoomId: account.lastRoomId } : {}),
       ...(account.lastSeenAt ? { lastSeenAt: account.lastSeenAt } : {}),
       ...(account.loginId ? { loginId: account.loginId } : {}),
@@ -874,6 +882,25 @@ test("colyseus room persists world event logs and first-battle achievements into
     "session.state"
   );
 
+  for (let step = 0; step < 12; step += 1) {
+    const snapshot = await sendRequest(
+      room,
+      {
+        type: "battle.action",
+        requestId: nextRequestId(`event-log-replay-${step}`),
+        action: {
+          type: "battle.defend",
+          unitId: "hero-1-stack"
+        }
+      },
+      "session.state"
+    );
+
+    if (!snapshot.payload.battle) {
+      break;
+    }
+  }
+
   const account = await store.loadPlayerAccount("player-1");
   assert.equal(account?.lastRoomId, roomId);
   assert.equal(account?.achievements.find((achievement) => achievement.id === "first_battle")?.unlocked, true);
@@ -884,4 +911,9 @@ test("colyseus room persists world event logs and first-battle achievements into
   );
   assert.ok(account?.recentEventLog.some((entry) => entry.category === "achievement" && entry.achievementId === "first_battle"));
   assert.ok(account?.recentEventLog.some((entry) => entry.worldEventType === "battle.started"));
+  assert.equal(account?.recentBattleReplays?.length, 1);
+  assert.equal(account?.recentBattleReplays?.[0]?.battleId, "battle-neutral-1");
+  assert.equal(account?.recentBattleReplays?.[0]?.heroId, "hero-1");
+  assert.equal(account?.recentBattleReplays?.[0]?.playerCamp, "attacker");
+  assert.ok((account?.recentBattleReplays?.[0]?.steps.length ?? 0) > 0);
 });

--- a/apps/server/test/room-persistence.test.ts
+++ b/apps/server/test/room-persistence.test.ts
@@ -68,6 +68,14 @@ test("room persistence snapshot restores a resolved PvP world without active bat
   assert.ok(steps < 12);
   assert.equal(room.getBattleForPlayer("player-1"), null);
   assert.equal(room.getBattleForPlayer("player-2"), null);
+  const replays = room.consumeCompletedBattleReplays();
+  assert.equal(replays.length, 1);
+  assert.match(replays[0]?.battleId ?? "", /^battle-hero-[12]-vs-hero-[12]$/);
+  assert.equal(replays[0]?.initialState.id, replays[0]?.battleId);
+  assert.equal(replays[0]?.steps.length, steps);
+  assert.ok(
+    replays[0]?.result === "attacker_victory" || replays[0]?.result === "defender_victory"
+  );
 
   const snapshot = room.serializePersistenceSnapshot();
   const restored = createRoom("room-persist-pvp", 1001, snapshot);

--- a/packages/shared/src/battle-replay.ts
+++ b/packages/shared/src/battle-replay.ts
@@ -1,0 +1,140 @@
+import type { BattleAction, BattleState } from "./models";
+
+export type BattleReplayResult = "attacker_victory" | "defender_victory";
+export type BattleReplaySource = "player" | "automated";
+export type BattleReplayCamp = "attacker" | "defender";
+
+export interface BattleReplayStep {
+  index: number;
+  source: BattleReplaySource;
+  action: BattleAction;
+}
+
+export interface PlayerBattleReplaySummary {
+  id: string;
+  roomId: string;
+  playerId: string;
+  battleId: string;
+  battleKind: "neutral" | "hero";
+  playerCamp: BattleReplayCamp;
+  heroId: string;
+  opponentHeroId?: string;
+  neutralArmyId?: string;
+  startedAt: string;
+  completedAt: string;
+  initialState: BattleState;
+  steps: BattleReplayStep[];
+  result: BattleReplayResult;
+}
+
+function normalizeTimestamp(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+function cloneBattleState(state: BattleState): BattleState {
+  return {
+    ...state,
+    units: Object.fromEntries(Object.entries(state.units).map(([unitId, unit]) => [unitId, { ...unit }])),
+    environment: state.environment.map((hazard) => ({ ...hazard })),
+    log: [...state.log],
+    rng: { ...state.rng },
+    ...(state.encounterPosition ? { encounterPosition: { ...state.encounterPosition } } : {})
+  };
+}
+
+function normalizeBattleReplayStep(step: Partial<BattleReplayStep> | null | undefined, fallbackIndex: number): BattleReplayStep | null {
+  const action = step?.action;
+  const type = action?.type;
+  if (
+    type !== "battle.attack" &&
+    type !== "battle.wait" &&
+    type !== "battle.defend" &&
+    type !== "battle.skill"
+  ) {
+    return null;
+  }
+
+  return {
+    index: Math.max(0, Math.floor(step?.index ?? fallbackIndex)),
+    source: step?.source === "automated" ? "automated" : "player",
+    action: structuredClone(action as BattleAction)
+  };
+}
+
+export function normalizePlayerBattleReplaySummaries(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null
+): PlayerBattleReplaySummary[] {
+  return (replays ?? [])
+    .map((replay) => {
+      const id = replay?.id?.trim();
+      const roomId = replay?.roomId?.trim();
+      const playerId = replay?.playerId?.trim();
+      const battleId = replay?.battleId?.trim();
+      const heroId = replay?.heroId?.trim();
+      const startedAt = normalizeTimestamp(replay?.startedAt);
+      const completedAt = normalizeTimestamp(replay?.completedAt);
+      const initialState = replay?.initialState;
+      if (
+        !id ||
+        !roomId ||
+        !playerId ||
+        !battleId ||
+        !heroId ||
+        !startedAt ||
+        !completedAt ||
+        !initialState ||
+        (replay?.battleKind !== "neutral" && replay?.battleKind !== "hero") ||
+        (replay?.playerCamp !== "attacker" && replay?.playerCamp !== "defender") ||
+        (replay?.result !== "attacker_victory" && replay?.result !== "defender_victory")
+      ) {
+        return null;
+      }
+
+      const steps = (replay.steps ?? [])
+        .map((step, index) => normalizeBattleReplayStep(step, index + 1))
+        .filter((step): step is BattleReplayStep => Boolean(step))
+        .sort((left, right) => left.index - right.index);
+
+      return {
+        id,
+        roomId,
+        playerId,
+        battleId,
+        battleKind: replay.battleKind,
+        playerCamp: replay.playerCamp,
+        heroId,
+        ...(replay.opponentHeroId?.trim() ? { opponentHeroId: replay.opponentHeroId.trim() } : {}),
+        ...(replay.neutralArmyId?.trim() ? { neutralArmyId: replay.neutralArmyId.trim() } : {}),
+        startedAt,
+        completedAt,
+        initialState: cloneBattleState(initialState),
+        steps,
+        result: replay.result
+      };
+    })
+    .filter((replay): replay is PlayerBattleReplaySummary => Boolean(replay))
+    .sort((left, right) => right.completedAt.localeCompare(left.completedAt) || left.id.localeCompare(right.id))
+    .filter((replay, index, list) => index === list.findIndex((candidate) => candidate.id === replay.id));
+}
+
+export function appendPlayerBattleReplaySummaries(
+  existing: Partial<PlayerBattleReplaySummary>[] | null | undefined,
+  incoming: Partial<PlayerBattleReplaySummary>[] | null | undefined,
+  limit = 5
+): PlayerBattleReplaySummary[] {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  const normalizedIncoming = normalizePlayerBattleReplaySummaries(incoming);
+  if (normalizedIncoming.length === 0) {
+    return normalizePlayerBattleReplaySummaries(existing).slice(0, safeLimit);
+  }
+
+  return normalizePlayerBattleReplaySummaries([
+    ...normalizedIncoming,
+    ...normalizePlayerBattleReplaySummaries(existing)
+  ]).slice(0, safeLimit);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./battle";
+export * from "./battle-replay";
 export * from "./equipment";
 export * from "./event-log";
 export * from "./hero-skills";

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   applyBattleAction,
   appendEventLogEntries,
+  appendPlayerBattleReplaySummaries,
   applyBattleOutcomeToWorld,
   applyAchievementMetricDelta,
   createHeroAttributeBreakdown,
@@ -34,6 +35,7 @@ import {
   getBattleOutcome,
   getDefaultEquipmentCatalog,
   getLatestUnlockedAchievement,
+  normalizePlayerBattleReplaySummaries,
   pickAutomatedBattleAction,
   planPlayerViewMovement,
   predictPlayerWorldAction,
@@ -276,6 +278,66 @@ test("event log helper keeps newest unique entries first", () => {
     merged.map((entry) => entry.id),
     ["newer", "older"]
   );
+});
+
+test("battle replay helpers normalize steps and keep newest unique replays first", () => {
+  const battle = createEmptyBattleState();
+  const normalized = normalizePlayerBattleReplaySummaries([
+    {
+      id: "replay-older",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      battleId: "battle-1",
+      battleKind: "neutral",
+      playerCamp: "attacker",
+      heroId: "hero-1",
+      neutralArmyId: "neutral-1",
+      startedAt: "2026-03-27T10:00:00.000Z",
+      completedAt: "2026-03-27T10:01:00.000Z",
+      initialState: battle,
+      steps: [{ index: 2, source: "player", action: { type: "battle.wait", unitId: "hero-1-stack" } }],
+      result: "attacker_victory"
+    }
+  ]);
+
+  const merged = appendPlayerBattleReplaySummaries(normalized, [
+    {
+      id: "replay-newer",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      battleId: "battle-2",
+      battleKind: "hero",
+      playerCamp: "defender",
+      heroId: "hero-2",
+      opponentHeroId: "hero-1",
+      startedAt: "2026-03-27T10:02:00.000Z",
+      completedAt: "2026-03-27T10:03:00.000Z",
+      initialState: battle,
+      steps: [
+        { index: 5, source: "automated", action: { type: "battle.defend", unitId: "hero-2-stack" } }
+      ],
+      result: "defender_victory"
+    },
+    {
+      id: "replay-older",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      battleId: "battle-1",
+      battleKind: "neutral",
+      playerCamp: "attacker",
+      heroId: "hero-1",
+      neutralArmyId: "neutral-1",
+      startedAt: "2026-03-27T10:00:00.000Z",
+      completedAt: "2026-03-27T10:01:00.000Z",
+      initialState: battle,
+      steps: [{ index: 9, source: "player", action: { type: "battle.wait", unitId: "hero-1-stack" } }],
+      result: "attacker_victory"
+    }
+  ]);
+
+  assert.deepEqual(merged.map((replay) => replay.id), ["replay-newer", "replay-older"]);
+  assert.equal(merged[0]?.steps[0]?.index, 5);
+  assert.equal(merged[1]?.steps[0]?.index, 9);
 });
 
 test("typed-array world map payload is materially smaller than the raw tile JSON on a 32x32 map", () => {


### PR DESCRIPTION
## Summary
- add shared battle replay summary types and normalization helpers
- capture deterministic battle replay steps in the authoritative room and finalize them on battle resolution
- persist recent replay summaries onto player accounts and cover the flow with shared/server tests

## Testing
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:cocos
- node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/room-persistence.test.ts ./apps/server/test/colyseus-persistence-recovery.test.ts ./apps/client/test/player-account-storage.test.ts ./apps/cocos-client/test/cocos-lobby.test.ts

## Notes
- Partial follow-up for #27. This PR does not auto-close the issue.
- `npm run typecheck:client:h5` still fails in existing unrelated `apps/client/src/object-visuals.ts` type errors.