### PR TITLE
Add player battle replay query API

### DIFF
--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -61,6 +61,10 @@ interface PlayerAccountApiPayload {
   };
 }
 
+interface PlayerBattleReplayListApiPayload {
+  items?: Partial<PlayerBattleReplaySummary>[];
+}
+
 function normalizePlayerDisplayName(playerId: string, displayName?: string | null): string {
   const normalizedPlayerId = playerId.trim() || "player";
   const normalizedDisplayName = displayName?.trim();
@@ -235,6 +239,25 @@ export async function loadPlayerAccountProfile(playerId: string, roomId: string)
       clearCurrentAuthSession();
     }
     return createFallbackPlayerAccountProfile(playerId, roomId, storedDisplayName);
+  }
+}
+
+export async function loadPlayerBattleReplaySummaries(playerId: string): Promise<PlayerBattleReplaySummary[]> {
+  const authSession = readStoredAuthSession();
+  const endpoint = authSession?.token
+    ? `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/battle-replays`
+    : `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/${encodeURIComponent(playerId)}/battle-replays`;
+
+  try {
+    const payload = (await fetchJson(endpoint, {
+      ...(authSession?.token ? { headers: buildAuthHeaders(authSession.token) } : {})
+    })) as PlayerBattleReplayListApiPayload;
+    return normalizePlayerBattleReplaySummaries(payload.items);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message === "player_account_request_failed:401") {
+      clearCurrentAuthSession();
+    }
+    return normalizePlayerBattleReplaySummaries();
   }
 }
 

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   createFallbackPlayerAccountProfile,
   getPlayerAccountStorageKey,
+  loadPlayerBattleReplaySummaries,
   readStoredPlayerDisplayName,
   writeStoredPlayerDisplayName
 } from "../src/player-account";
@@ -74,4 +75,136 @@ test("player account helpers can build a local fallback profile", () => {
     lastRoomId: "room-beta",
     source: "local"
   });
+});
+
+test("player replay loader normalizes remote replay summaries and keeps newest first", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(): string | null {
+          return null;
+        },
+        setItem(): void {}
+      }
+    }
+  });
+
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        items: [
+          {
+            id: "replay-older",
+            roomId: "room-alpha",
+            playerId: "player-1",
+            battleId: "battle-1",
+            battleKind: "hero",
+            playerCamp: "attacker",
+            heroId: "hero-1",
+            startedAt: "2026-03-27T11:58:00.000Z",
+            completedAt: "2026-03-27T12:00:00.000Z",
+            initialState: {
+              id: "battle-1",
+              round: 1,
+              lanes: 1,
+              activeUnitId: "unit-1",
+              turnOrder: ["unit-1"],
+              units: {
+                "unit-1": {
+                  id: "unit-1",
+                  camp: "attacker",
+                  templateId: "hero_guard_basic",
+                  lane: 0,
+                  stackName: "暮火侦骑",
+                  initiative: 4,
+                  attack: 2,
+                  defense: 2,
+                  minDamage: 1,
+                  maxDamage: 2,
+                  count: 12,
+                  currentHp: 10,
+                  maxHp: 10,
+                  hasRetaliated: false,
+                  defending: false
+                }
+              },
+              environment: [],
+              log: [],
+              rng: { seed: 7, cursor: 0 }
+            },
+            steps: [],
+            result: "attacker_victory"
+          },
+          {
+            id: "replay-newer",
+            roomId: "room-alpha",
+            playerId: "player-1",
+            battleId: "battle-2",
+            battleKind: "hero",
+            playerCamp: "attacker",
+            heroId: "hero-1",
+            startedAt: "2026-03-27T12:01:00.000Z",
+            completedAt: "2026-03-27T12:02:00.000Z",
+            initialState: {
+              id: "battle-2",
+              round: 1,
+              lanes: 1,
+              activeUnitId: "unit-1",
+              turnOrder: ["unit-1"],
+              units: {
+                "unit-1": {
+                  id: "unit-1",
+                  camp: "attacker",
+                  templateId: "hero_guard_basic",
+                  lane: 0,
+                  stackName: "暮火侦骑",
+                  initiative: 4,
+                  attack: 2,
+                  defense: 2,
+                  minDamage: 1,
+                  maxDamage: 2,
+                  count: 12,
+                  currentHp: 10,
+                  maxHp: 10,
+                  hasRetaliated: false,
+                  defending: false
+                }
+              },
+              environment: [],
+              log: [],
+              rng: { seed: 8, cursor: 0 }
+            },
+            steps: [],
+            result: "attacker_victory"
+          }
+        ]
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    )) as typeof fetch;
+
+  try {
+    const replays = await loadPlayerBattleReplaySummaries("player-1");
+    assert.deepEqual(replays.map((replay) => replay.id), ["replay-newer", "replay-older"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { normalizePlayerBattleReplaySummaries } from "../../../packages/shared/src/index";
 import { issueNextAuthSession, resolveAuthSessionFromRequest } from "./auth";
 import type { PlayerAccountProfilePatch, PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
 
@@ -52,6 +53,14 @@ function parsePlayerIdFilter(request: IncomingMessage): string | undefined {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
   const value = url.searchParams.get("playerId")?.trim();
   return value ? value : undefined;
+}
+
+function toReplayResponse(account: PlayerAccountSnapshot, limit?: number): { items: PlayerAccountSnapshot["recentBattleReplays"] } {
+  const items = normalizePlayerBattleReplaySummaries(account.recentBattleReplays);
+  const safeLimit = limit == null ? undefined : Math.max(1, Math.floor(limit));
+  return {
+    items: safeLimit == null ? items : items.slice(0, safeLimit)
+  };
 }
 
 function sendStoreUnavailable(response: ServerResponse): void {
@@ -147,6 +156,31 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.get("/api/player-accounts/me/battle-replays", async (request, response) => {
+    if (!store) {
+      sendStoreUnavailable(response);
+      return;
+    }
+
+    const authSession = resolveAuthSessionFromRequest(request);
+    if (!authSession) {
+      sendUnauthorized(response);
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      sendJson(response, 200, toReplayResponse(account, parseLimit(request)));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
   app.get("/api/player-accounts/:playerId", async (request, response) => {
     if (!store) {
       sendStoreUnavailable(response);
@@ -172,6 +206,36 @@ export function registerPlayerAccountRoutes(
       }
 
       sendJson(response, 200, { account: toPublicPlayerAccount(account) });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/:playerId/battle-replays", async (request, response) => {
+    if (!store) {
+      sendStoreUnavailable(response);
+      return;
+    }
+
+    const playerId = request.params.playerId?.trim();
+    if (!playerId) {
+      sendNotFound(response);
+      return;
+    }
+
+    try {
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_account_not_found",
+            message: `Player account not found: ${playerId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, toReplayResponse(account, parseLimit(request)));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -16,7 +16,12 @@ import type {
   RoomSnapshotStore
 } from "../src/persistence";
 import type { RoomPersistenceSnapshot } from "../src/index";
-import { createDefaultHeroLoadout, createDefaultHeroProgression, type WorldState } from "../../../packages/shared/src/index";
+import {
+  createDefaultHeroLoadout,
+  createDefaultHeroProgression,
+  type PlayerBattleReplaySummary,
+  type WorldState
+} from "../../../packages/shared/src/index";
 
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
@@ -59,6 +64,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       globalResources: existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 },
       achievements: structuredClone(existing?.achievements ?? []),
       recentEventLog: structuredClone(existing?.recentEventLog ?? []),
+      recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
@@ -132,6 +138,9 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ...existing,
       achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
       recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      recentBattleReplays: structuredClone(
+        (patch.recentBattleReplays as PlayerAccountSnapshot["recentBattleReplays"] | undefined) ?? existing.recentBattleReplays
+      ),
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId?.trim()
           ? { lastRoomId: patch.lastRoomId.trim() }
@@ -221,6 +230,69 @@ function createAccountTrackingWorldState(): WorldState {
   };
 }
 
+function createReplaySummary(id: string, completedAt: string): PlayerBattleReplaySummary {
+  return {
+    id,
+    roomId: "room-replay",
+    playerId: "player-1",
+    battleId: `${id}-battle`,
+    battleKind: "hero",
+    playerCamp: "attacker",
+    heroId: "hero-1",
+    opponentHeroId: "hero-2",
+    startedAt: "2026-03-27T11:55:00.000Z",
+    completedAt,
+    initialState: {
+      id: `${id}-battle`,
+      round: 1,
+      lanes: 2,
+      activeUnitId: "unit-1",
+      turnOrder: ["unit-1", "unit-2"],
+      units: {
+        "unit-1": {
+          id: "unit-1",
+          camp: "attacker",
+          templateId: "hero_guard_basic",
+          lane: 0,
+          stackName: "暮火侦骑",
+          initiative: 4,
+          attack: 2,
+          defense: 2,
+          minDamage: 1,
+          maxDamage: 2,
+          currentHp: 10,
+          count: 12,
+          maxHp: 10,
+          hasRetaliated: false,
+          defending: false
+        },
+        "unit-2": {
+          id: "unit-2",
+          camp: "defender",
+          templateId: "hero_guard_basic",
+          lane: 1,
+          stackName: "守军",
+          initiative: 4,
+          attack: 2,
+          defense: 2,
+          minDamage: 1,
+          maxDamage: 2,
+          currentHp: 10,
+          count: 12,
+          maxHp: 10,
+          hasRetaliated: false,
+          defending: false
+        }
+      },
+      environment: [],
+      log: [],
+      rng: { seed: 7, cursor: 0 }
+    },
+    steps: [],
+    result: "attacker_victory"
+  };
+}
+
 test("player account routes list and fetch stored accounts", async (t) => {
   const port = 40000 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
@@ -249,6 +321,76 @@ test("player account routes list and fetch stored accounts", async (t) => {
   assert.equal(detailResponse.status, 200);
   assert.equal(detailPayload.account.playerId, "player-1");
   assert.equal(detailPayload.account.lastRoomId, "room-alpha");
+});
+
+test("player account battle replay routes return normalized replay summaries with optional limit", async (t) => {
+  const port = 40050 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-1",
+    displayName: "灰烬领主",
+    globalResources: { gold: 320, wood: 5, ore: 1 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [
+      createReplaySummary("replay-older", "2026-03-27T11:58:00.000Z"),
+      createReplaySummary("replay-newer", "2026-03-27T12:02:00.000Z")
+    ],
+    lastRoomId: "room-alpha",
+    lastSeenAt: new Date("2026-03-25T09:00:00.000Z").toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const detailResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays?limit=1`
+  );
+  const detailPayload = (await detailResponse.json()) as { items: PlayerBattleReplaySummary[] };
+  assert.equal(detailResponse.status, 200);
+  assert.deepEqual(detailPayload.items.map((replay) => replay.id), ["replay-newer"]);
+
+  const missingResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/missing/battle-replays`);
+  assert.equal(missingResponse.status, 404);
+});
+
+test("player account me battle replay route resolves the current authenticated account", async (t) => {
+  const port = 42050 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-me",
+    displayName: "苍穹侦骑",
+    globalResources: { gold: 12, wood: 3, ore: 4 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [
+      createReplaySummary("replay-me-1", "2026-03-27T12:03:00.000Z"),
+      createReplaySummary("replay-me-2", "2026-03-27T12:04:00.000Z")
+    ],
+    lastRoomId: "room-old",
+    lastSeenAt: new Date("2026-03-25T11:00:00.000Z").toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-me",
+    displayName: "苍穹侦骑"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const meResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/battle-replays`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const mePayload = (await meResponse.json()) as { items: PlayerBattleReplaySummary[] };
+
+  assert.equal(meResponse.status, 200);
+  assert.deepEqual(mePayload.items.map((replay) => replay.id), ["replay-me-2", "replay-me-1"]);
 });
 
 test("player achievement tracker appends logs and unlocks milestones", () => {


### PR DESCRIPTION
## Summary
- add read-only player account battle replay endpoints for public and authenticated access
- add a client helper to fetch and normalize persisted replay summaries
- cover the new replay query surface with focused server and client tests

## Testing
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts
- npm run typecheck:server
- npm run typecheck:client:h5 (currently fails due to pre-existing unrelated errors in apps/client/src/object-visuals.ts)

Partial follow-up for #27.