### PR TITLE
Add player progression read model

### DIFF
--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -6,12 +6,14 @@ import {
   type StoredAuthSession
 } from "./auth-session";
 import {
+  normalizePlayerProgressionSnapshot,
   normalizeAchievementProgress,
   normalizePlayerBattleReplaySummaries,
   normalizeEventLogEntries,
   type EventLogEntry,
   type PlayerBattleReplaySummary,
-  type PlayerAchievementProgress
+  type PlayerAchievementProgress,
+  type PlayerProgressionSnapshot
 } from "../../../packages/shared/src/index";
 
 const PLAYER_ACCOUNT_PREFIX = "project-veil:player-account";
@@ -64,6 +66,8 @@ interface PlayerAccountApiPayload {
 interface PlayerBattleReplayListApiPayload {
   items?: Partial<PlayerBattleReplaySummary>[];
 }
+
+interface PlayerProgressionApiPayload extends Partial<PlayerProgressionSnapshot> {}
 
 function normalizePlayerDisplayName(playerId: string, displayName?: string | null): string {
   const normalizedPlayerId = playerId.trim() || "player";
@@ -258,6 +262,26 @@ export async function loadPlayerBattleReplaySummaries(playerId: string): Promise
       clearCurrentAuthSession();
     }
     return normalizePlayerBattleReplaySummaries();
+  }
+}
+
+export async function loadPlayerProgressionSnapshot(playerId: string, eventLimit?: number): Promise<PlayerProgressionSnapshot> {
+  const authSession = readStoredAuthSession();
+  const limitQuery = eventLimit != null ? `?limit=${encodeURIComponent(String(eventLimit))}` : "";
+  const endpoint = authSession?.token
+    ? `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/progression${limitQuery}`
+    : `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/${encodeURIComponent(playerId)}/progression${limitQuery}`;
+
+  try {
+    const payload = (await fetchJson(endpoint, {
+      ...(authSession?.token ? { headers: buildAuthHeaders(authSession.token) } : {})
+    })) as PlayerProgressionApiPayload;
+    return normalizePlayerProgressionSnapshot(payload);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message === "player_account_request_failed:401") {
+      clearCurrentAuthSession();
+    }
+    return normalizePlayerProgressionSnapshot();
   }
 }
 

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -4,6 +4,7 @@ import {
   createFallbackPlayerAccountProfile,
   getPlayerAccountStorageKey,
   loadPlayerBattleReplaySummaries,
+  loadPlayerProgressionSnapshot,
   readStoredPlayerDisplayName,
   writeStoredPlayerDisplayName
 } from "../src/player-account";
@@ -200,6 +201,94 @@ test("player replay loader normalizes remote replay summaries and keeps newest f
   try {
     const replays = await loadPlayerBattleReplaySummaries("player-1");
     assert.deepEqual(replays.map((replay) => replay.id), ["replay-newer", "replay-older"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("player progression loader normalizes summary, achievements, and limited event history", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(): string | null {
+          return null;
+        },
+        setItem(): void {}
+      }
+    }
+  });
+
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        summary: {
+          totalAchievements: 1,
+          unlockedAchievements: 1,
+          inProgressAchievements: 0,
+          latestUnlockedAchievementId: "first_battle",
+          latestUnlockedAchievementTitle: "ignored title",
+          latestUnlockedAt: "2026-03-27T12:00:00.000Z",
+          recentEventCount: 1,
+          latestEventAt: "2026-03-27T12:03:00.000Z"
+        },
+        achievements: [
+          {
+            id: "first_battle",
+            current: 1,
+            target: 999,
+            unlocked: false,
+            unlockedAt: "2026-03-27T12:00:00.000Z"
+          }
+        ],
+        recentEventLog: [
+          {
+            id: "event-1",
+            timestamp: "2026-03-27T12:03:00.000Z",
+            roomId: "room-alpha",
+            playerId: "player-1",
+            category: "achievement",
+            description: "解锁成就：初次交锋",
+            achievementId: "first_battle",
+            rewards: [{ type: "badge", label: "初次交锋" }]
+          }
+        ]
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    )) as typeof fetch;
+
+  try {
+    const snapshot = await loadPlayerProgressionSnapshot("player-1", 1);
+    assert.deepEqual(snapshot.summary, {
+      totalAchievements: 3,
+      unlockedAchievements: 1,
+      inProgressAchievements: 0,
+      latestUnlockedAchievementId: "first_battle",
+      latestUnlockedAchievementTitle: "初次交锋",
+      latestUnlockedAt: "2026-03-27T12:00:00.000Z",
+      recentEventCount: 1,
+      latestEventAt: "2026-03-27T12:03:00.000Z"
+    });
+    assert.equal(snapshot.achievements[0]?.title, "初次交锋");
+    assert.deepEqual(snapshot.recentEventLog.map((entry) => entry.id), ["event-1"]);
   } finally {
     Object.defineProperty(globalThis, "window", {
       configurable: true,

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,5 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { normalizePlayerBattleReplaySummaries } from "../../../packages/shared/src/index";
+import {
+  buildPlayerProgressionSnapshot,
+  normalizePlayerBattleReplaySummaries
+} from "../../../packages/shared/src/index";
 import { issueNextAuthSession, resolveAuthSessionFromRequest } from "./auth";
 import type { PlayerAccountProfilePatch, PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
 
@@ -61,6 +64,13 @@ function toReplayResponse(account: PlayerAccountSnapshot, limit?: number): { ite
   return {
     items: safeLimit == null ? items : items.slice(0, safeLimit)
   };
+}
+
+function toProgressionResponse(
+  account: PlayerAccountSnapshot,
+  limit?: number
+): ReturnType<typeof buildPlayerProgressionSnapshot> {
+  return buildPlayerProgressionSnapshot(account.achievements, account.recentEventLog, limit);
 }
 
 function sendStoreUnavailable(response: ServerResponse): void {
@@ -181,6 +191,31 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.get("/api/player-accounts/me/progression", async (request, response) => {
+    if (!store) {
+      sendStoreUnavailable(response);
+      return;
+    }
+
+    const authSession = resolveAuthSessionFromRequest(request);
+    if (!authSession) {
+      sendUnauthorized(response);
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      sendJson(response, 200, toProgressionResponse(account, parseLimit(request)));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
   app.get("/api/player-accounts/:playerId", async (request, response) => {
     if (!store) {
       sendStoreUnavailable(response);
@@ -236,6 +271,36 @@ export function registerPlayerAccountRoutes(
       }
 
       sendJson(response, 200, toReplayResponse(account, parseLimit(request)));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/:playerId/progression", async (request, response) => {
+    if (!store) {
+      sendStoreUnavailable(response);
+      return;
+    }
+
+    const playerId = request.params.playerId?.trim();
+    if (!playerId) {
+      sendNotFound(response);
+      return;
+    }
+
+    try {
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_account_not_found",
+            message: `Player account not found: ${playerId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, toProgressionResponse(account, parseLimit(request)));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -19,6 +19,7 @@ import type { RoomPersistenceSnapshot } from "../src/index";
 import {
   createDefaultHeroLoadout,
   createDefaultHeroProgression,
+  type PlayerProgressionSnapshot,
   type PlayerBattleReplaySummary,
   type WorldState
 } from "../../../packages/shared/src/index";
@@ -391,6 +392,94 @@ test("player account me battle replay route resolves the current authenticated a
 
   assert.equal(meResponse.status, 200);
   assert.deepEqual(mePayload.items.map((replay) => replay.id), ["replay-me-2", "replay-me-1"]);
+});
+
+test("player account progression routes return a compact achievement and event read model", async (t) => {
+  const port = 42080 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-progress",
+    displayName: "雾林司灯",
+    globalResources: { gold: 120, wood: 6, ore: 2 },
+    achievements: [
+      {
+        id: "first_battle",
+        title: "ignored",
+        description: "ignored",
+        metric: "battles_started",
+        current: 1,
+        target: 99,
+        unlocked: true,
+        unlockedAt: "2026-03-27T12:00:00.000Z"
+      },
+      {
+        id: "enemy_slayer",
+        title: "ignored",
+        description: "ignored",
+        metric: "battles_won",
+        current: 2,
+        target: 99,
+        unlocked: false
+      }
+    ],
+    recentEventLog: [
+      {
+        id: "event-older",
+        timestamp: "2026-03-27T12:01:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-progress",
+        category: "combat",
+        description: "older",
+        rewards: []
+      },
+      {
+        id: "event-newer",
+        timestamp: "2026-03-27T12:03:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-progress",
+        category: "achievement",
+        description: "newer",
+        rewards: [{ type: "badge", label: "初次交锋" }]
+      }
+    ],
+    lastRoomId: "room-alpha",
+    lastSeenAt: new Date("2026-03-27T12:04:00.000Z").toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-progress",
+    displayName: "雾林司灯"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const publicResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-progress/progression?limit=1`);
+  const publicPayload = (await publicResponse.json()) as PlayerProgressionSnapshot;
+  assert.equal(publicResponse.status, 200);
+  assert.deepEqual(publicPayload.summary, {
+    totalAchievements: 3,
+    unlockedAchievements: 1,
+    inProgressAchievements: 1,
+    latestUnlockedAchievementId: "first_battle",
+    latestUnlockedAchievementTitle: "初次交锋",
+    latestUnlockedAt: "2026-03-27T12:00:00.000Z",
+    recentEventCount: 1,
+    latestEventAt: "2026-03-27T12:03:00.000Z"
+  });
+  assert.deepEqual(publicPayload.recentEventLog.map((entry) => entry.id), ["event-newer"]);
+
+  const meResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/progression`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const mePayload = (await meResponse.json()) as PlayerProgressionSnapshot;
+  assert.equal(meResponse.status, 200);
+  assert.deepEqual(mePayload.recentEventLog.map((entry) => entry.id), ["event-newer", "event-older"]);
+  assert.equal(mePayload.achievements[1]?.id, "enemy_slayer");
+  assert.equal(mePayload.achievements[1]?.current, 2);
 });
 
 test("player achievement tracker appends logs and unlocks milestones", () => {

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -43,6 +43,23 @@ export interface PlayerAchievementProgress {
   unlockedAt?: string;
 }
 
+export interface PlayerProgressionSummary {
+  totalAchievements: number;
+  unlockedAchievements: number;
+  inProgressAchievements: number;
+  latestUnlockedAchievementId?: AchievementId;
+  latestUnlockedAchievementTitle?: string;
+  latestUnlockedAt?: string;
+  recentEventCount: number;
+  latestEventAt?: string;
+}
+
+export interface PlayerProgressionSnapshot {
+  summary: PlayerProgressionSummary;
+  achievements: PlayerAchievementProgress[];
+  recentEventLog: EventLogEntry[];
+}
+
 export function getLatestUnlockedAchievement(
   progress?: Partial<PlayerAchievementProgress>[] | null
 ): PlayerAchievementProgress | null {
@@ -243,4 +260,40 @@ export function appendEventLogEntries(
   }
 
   return normalizeEventLogEntries([...normalizedIncoming, ...normalizeEventLogEntries(existing)]).slice(0, safeLimit);
+}
+
+export function buildPlayerProgressionSnapshot(
+  achievements?: Partial<PlayerAchievementProgress>[] | null,
+  recentEventLog?: Partial<EventLogEntry>[] | null,
+  eventLimit = 12
+): PlayerProgressionSnapshot {
+  const normalizedAchievements = normalizeAchievementProgress(achievements);
+  const normalizedRecentEventLog = normalizeEventLogEntries(recentEventLog).slice(0, Math.max(1, Math.floor(eventLimit)));
+  const latestUnlocked = getLatestUnlockedAchievement(normalizedAchievements);
+  const unlockedAchievements = normalizedAchievements.filter((entry) => entry.unlocked).length;
+
+  return {
+    summary: {
+      totalAchievements: normalizedAchievements.length,
+      unlockedAchievements,
+      inProgressAchievements: normalizedAchievements.filter((entry) => !entry.unlocked && entry.current > 0).length,
+      ...(latestUnlocked
+        ? {
+            latestUnlockedAchievementId: latestUnlocked.id,
+            latestUnlockedAchievementTitle: latestUnlocked.title,
+            latestUnlockedAt: latestUnlocked.unlockedAt
+          }
+        : {}),
+      recentEventCount: normalizedRecentEventLog.length,
+      ...(normalizedRecentEventLog[0]?.timestamp ? { latestEventAt: normalizedRecentEventLog[0].timestamp } : {})
+    },
+    achievements: normalizedAchievements,
+    recentEventLog: normalizedRecentEventLog
+  };
+}
+
+export function normalizePlayerProgressionSnapshot(
+  snapshot?: Partial<PlayerProgressionSnapshot> | null
+): PlayerProgressionSnapshot {
+  return buildPlayerProgressionSnapshot(snapshot?.achievements, snapshot?.recentEventLog, snapshot?.recentEventLog?.length ?? 12);
 }

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -7,6 +7,7 @@ import {
   appendPlayerBattleReplaySummaries,
   applyBattleOutcomeToWorld,
   applyAchievementMetricDelta,
+  buildPlayerProgressionSnapshot,
   createHeroAttributeBreakdown,
   createHeroEquipmentBonusSummary,
   createHeroEquipmentLoadoutView,
@@ -278,6 +279,57 @@ test("event log helper keeps newest unique entries first", () => {
     merged.map((entry) => entry.id),
     ["newer", "older"]
   );
+});
+
+test("player progression snapshot summarizes unlocked achievements and recent events", () => {
+  const snapshot = buildPlayerProgressionSnapshot(
+    [
+      {
+        id: "first_battle",
+        current: 1,
+        unlockedAt: "2026-03-27T10:00:00.000Z"
+      },
+      {
+        id: "enemy_slayer",
+        current: 2
+      }
+    ],
+    [
+      {
+        id: "event-older",
+        timestamp: "2026-03-27T09:55:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "combat",
+        description: "older",
+        rewards: []
+      },
+      {
+        id: "event-newer",
+        timestamp: "2026-03-27T10:05:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "achievement",
+        description: "newer",
+        rewards: []
+      }
+    ],
+    1
+  );
+
+  assert.deepEqual(snapshot.summary, {
+    totalAchievements: 3,
+    unlockedAchievements: 1,
+    inProgressAchievements: 1,
+    latestUnlockedAchievementId: "first_battle",
+    latestUnlockedAchievementTitle: "初次交锋",
+    latestUnlockedAt: "2026-03-27T10:00:00.000Z",
+    recentEventCount: 1,
+    latestEventAt: "2026-03-27T10:05:00.000Z"
+  });
+  assert.deepEqual(snapshot.recentEventLog.map((entry) => entry.id), ["event-newer"]);
+  assert.equal(snapshot.achievements[1]?.id, "enemy_slayer");
+  assert.equal(snapshot.achievements[1]?.current, 2);
 });
 
 test("battle replay helpers normalize steps and keep newest unique replays first", () => {


### PR DESCRIPTION
## Summary
- add a shared player progression snapshot helper that summarizes achievements and recent world event visibility
- add public and authenticated player account progression read endpoints with optional event limiting
- add client plumbing and focused tests for the new progression query surface

## Testing
- node --import tsx --test ./packages/shared/test/shared-core.test.ts
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts
- npm run typecheck:server
- npm run typecheck:shared
- npm run typecheck:client:h5 (fails due to pre-existing unrelated errors in apps/client/src/object-visuals.ts)

Partial follow-up for #27.