### PR TITLE
Fix issue #62: guard player profile updates by auth session

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -91,6 +91,15 @@ function sendUnauthorized(response: ServerResponse): void {
   });
 }
 
+function sendForbidden(response: ServerResponse): void {
+  sendJson(response, 403, {
+    error: {
+      code: "forbidden",
+      message: "Authenticated players may only modify their own profile"
+    }
+  });
+}
+
 function toPublicPlayerAccount(account: PlayerAccountSnapshot): Omit<PlayerAccountSnapshot, "loginId" | "credentialBoundAt"> {
   const { loginId: _loginId, credentialBoundAt: _credentialBoundAt, ...publicAccount } = account;
   return publicAccount;
@@ -372,9 +381,20 @@ export function registerPlayerAccountRoutes(
       return;
     }
 
+    const authSession = resolveAuthSessionFromRequest(request);
+    if (!authSession) {
+      sendUnauthorized(response);
+      return;
+    }
+
     const playerId = request.params.playerId?.trim();
     if (!playerId) {
       sendNotFound(response);
+      return;
+    }
+
+    if (authSession.playerId !== playerId) {
+      sendForbidden(response);
       return;
     }
 
@@ -411,10 +431,16 @@ export function registerPlayerAccountRoutes(
 
       const account =
         Object.keys(patch).length === 0
-          ? await store.ensurePlayerAccount({ playerId })
+          ? await store.ensurePlayerAccount({
+              playerId: authSession.playerId,
+              displayName: authSession.displayName
+            })
           : await store.savePlayerAccountProfile(playerId, patch);
 
-      sendJson(response, 200, { account });
+      sendJson(response, 200, {
+        account,
+        session: issueNextAuthSession(account, authSession)
+      });
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -551,7 +551,7 @@ test("player achievement tracker records equipment drop entries for hero victori
   assert.match(updated.recentEventLog[0]?.description ?? "", /塔盾链甲/);
 });
 
-test("player account routes update display names through the account store", async (t) => {
+test("player account profile updates by player id require auth and allow self-service only", async (t) => {
   const port = 41000 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
   const server = await startAccountRouteServer(port, store);
@@ -560,25 +560,78 @@ test("player account routes update display names through the account store", asy
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
-  const updateResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-2`, {
+  const unauthenticatedResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-2`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      displayName: "未授权写入",
+      lastRoomId: "room-unauth"
+    })
+  });
+  const unauthenticatedPayload = (await unauthenticatedResponse.json()) as {
+    error: { code: string; message: string };
+  };
+
+  assert.equal(unauthenticatedResponse.status, 401);
+  assert.equal(unauthenticatedPayload.error.code, "unauthorized");
+
+  const selfSession = issueGuestAuthSession({
+    playerId: "player-2",
+    displayName: "远帆旅人"
+  });
+  const updateResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-2`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${selfSession.token}`
     },
     body: JSON.stringify({
       displayName: "北境执旗官",
       lastRoomId: "room-bravo"
     })
   });
-  const updatePayload = (await updateResponse.json()) as { account: PlayerAccountSnapshot };
+  const updatePayload = (await updateResponse.json()) as {
+    account: PlayerAccountSnapshot;
+    session: { token: string; playerId: string; displayName: string };
+  };
 
   assert.equal(updateResponse.status, 200);
   assert.equal(updatePayload.account.displayName, "北境执旗官");
   assert.equal(updatePayload.account.lastRoomId, "room-bravo");
+  assert.equal(updatePayload.session.playerId, "player-2");
+  assert.equal(updatePayload.session.displayName, "北境执旗官");
 
   const stored = await store.loadPlayerAccount("player-2");
   assert.equal(stored?.displayName, "北境执旗官");
   assert.equal(stored?.lastRoomId, "room-bravo");
+
+  const otherSession = issueGuestAuthSession({
+    playerId: "player-3",
+    displayName: "陌路信使"
+  });
+  const crossPlayerResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-2`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${otherSession.token}`
+    },
+    body: JSON.stringify({
+      displayName: "越权篡改",
+      lastRoomId: "room-gamma"
+    })
+  });
+  const crossPlayerPayload = (await crossPlayerResponse.json()) as {
+    error: { code: string; message: string };
+  };
+
+  assert.equal(crossPlayerResponse.status, 403);
+  assert.equal(crossPlayerPayload.error.code, "forbidden");
+
+  const unchanged = await store.loadPlayerAccount("player-2");
+  assert.equal(unchanged?.displayName, "北境执旗官");
+  assert.equal(unchanged?.lastRoomId, "room-bravo");
 });
 
 test("player account me routes resolve and update the current authenticated account", async (t) => {


### PR DESCRIPTION
## Summary
- apply the same auth/session guard used by PUT /api/player-accounts/me to PUT /api/player-accounts/:playerId
- reject cross-player profile modifications and preserve self-service updates for the authenticated player
- add route coverage for unauthenticated rejection, authenticated self-update success, and cross-player rejection

Closes #62.
