### PR TITLE
Fix player account JSON body size limit

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -28,10 +28,25 @@ function toErrorPayload(error: unknown): { code: string; message: string } {
   };
 }
 
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+const MAX_JSON_BODY_BYTES = 64 * 1024;
+
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
   for await (const chunk of request) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+    }
+    chunks.push(buffer);
   }
 
   if (chunks.length === 0) {
@@ -371,6 +386,10 @@ export function registerPlayerAccountRoutes(
         session: issueNextAuthSession(account, authSession)
       });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
   });
@@ -442,6 +461,10 @@ export function registerPlayerAccountRoutes(
         session: issueNextAuthSession(account, authSession)
       });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
   });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -747,3 +747,68 @@ test("player account me route preserves account-mode sessions and returns the gl
   assert.equal(mePayload.session.authMode, "account");
   assert.equal(mePayload.session.loginId, "veil-ranger");
 });
+
+test("player account update routes reject oversized JSON bodies with 413", async (t) => {
+  const port = 42150 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-oversized",
+    displayName: "起始名册",
+    globalResources: { gold: 0, wood: 0, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [],
+    lastRoomId: "room-start",
+    lastSeenAt: new Date("2026-03-25T12:00:00.000Z").toISOString(),
+    createdAt: new Date("2026-03-25T12:00:00.000Z").toISOString(),
+    updatedAt: new Date("2026-03-25T12:00:00.000Z").toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-oversized",
+    displayName: "起始名册"
+  });
+  const oversizedBody = JSON.stringify({
+    displayName: "x".repeat(70_000)
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const meResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: oversizedBody
+  });
+  const mePayload = (await meResponse.json()) as {
+    error: { code: string; message: string };
+  };
+
+  assert.equal(meResponse.status, 413);
+  assert.equal(mePayload.error.code, "payload_too_large");
+  assert.match(mePayload.error.message, /65536 bytes/);
+
+  const byIdResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-oversized`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: oversizedBody
+  });
+  const byIdPayload = (await byIdResponse.json()) as {
+    error: { code: string; message: string };
+  };
+
+  assert.equal(byIdResponse.status, 413);
+  assert.equal(byIdPayload.error.code, "payload_too_large");
+  assert.match(byIdPayload.error.message, /65536 bytes/);
+
+  const stored = await store.loadPlayerAccount("player-oversized");
+  assert.equal(stored?.displayName, "起始名册");
+  assert.equal(stored?.lastRoomId, "room-start");
+});


### PR DESCRIPTION
## Summary
- add a 64 KiB cap while reading JSON bodies for player account update routes
- return HTTP 413 with a structured payload when the limit is exceeded
- cover oversized payload rejection for both update endpoints and verify no account mutation occurs

Closes #63

## Testing
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- npm run typecheck:server