### PR TITLE
Fix duplicate same-day battle seeds

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -57,6 +57,15 @@ export interface RoomPersistenceSnapshot {
   battles: BattleState[];
 }
 
+function hashBattleSeed(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
 export class AuthoritativeWorldRoom {
   private state: WorldState;
   private readonly battles = new Map<string, BattleState>();
@@ -215,6 +224,10 @@ export class AuthoritativeWorldRoom {
     };
   }
 
+  private createBattleSeed(battleId: string): number {
+    return hashBattleSeed(`${this.state.meta.seed}:${this.state.meta.day}:${battleId}`);
+  }
+
   private resolveAutomatedBattleTurns(battleId: string): WorldEvent[] {
     const events: WorldEvent[] = [];
 
@@ -305,7 +318,11 @@ export class AuthoritativeWorldRoom {
           continue;
         }
 
-        const battle = createNeutralBattleState(hero, neutralArmy, this.state.meta.seed + this.state.meta.day);
+        const battle = createNeutralBattleState(
+          hero,
+          neutralArmy,
+          this.createBattleSeed(battleEvent.battleId)
+        );
         this.trackStartedBattle(battle);
         startedBattleIds.push(battle.id);
         continue;
@@ -317,7 +334,11 @@ export class AuthoritativeWorldRoom {
           continue;
         }
 
-        const battle = createHeroBattleState(hero, defenderHero, this.state.meta.seed + this.state.meta.day);
+        const battle = createHeroBattleState(
+          hero,
+          defenderHero,
+          this.createBattleSeed(battleEvent.battleId)
+        );
         this.trackStartedBattle(battle);
         startedBattleIds.push(battle.id);
       }

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -70,9 +70,9 @@ test("player battle actions are followed by automated defender turns until contr
     "恶狼 踩中隐藏陷阱 缠足泥沼，陷阱位置暴露",
     "恶狼 因 缠足泥沼 陷入减速",
     "缠足泥沼 已失效，但该位置对双方保持可见",
-    "恶狼 对 凯琳卫队 造成 22 伤害",
+    "恶狼 对 凯琳卫队 造成 25 伤害",
     "恶狼 的毒牙让 凯琳卫队 陷入中毒",
-    "凯琳卫队 反击 恶狼，造成 29 伤害",
+    "凯琳卫队 反击 恶狼，造成 21 伤害",
     "凯琳卫队 的削弱结束",
     "凯琳卫队 受到中毒影响，损失 2 生命"
   ]);
@@ -148,6 +148,7 @@ test("room supports concurrent neutral battles and returns player-specific battl
 
   assert.equal(playerOneResult.battle?.id, "battle-neutral-1");
   assert.equal(playerTwoResult.battle?.id, "battle-neutral-2");
+  assert.notEqual(playerOneResult.battle?.rng.seed, playerTwoResult.battle?.rng.seed);
   assert.equal(room.getActiveBattles().length, 2);
   assert.equal(room.getBattleForPlayer("player-1")?.id, "battle-neutral-1");
   assert.equal(room.getBattleForPlayer("player-2")?.id, "battle-neutral-2");


### PR DESCRIPTION
## Summary
- derive each battle seed from the room seed, day, and battle id so same-day battles no longer share RNG state
- add a regression assertion that concurrent same-day battles receive different seeds
- update the affected deterministic battle log expectation

closes #65