### PR TITLE
Add epic equipment achievement progress sync

### DIFF
--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -69,6 +69,15 @@ test("player account helpers can build a local fallback profile", () => {
         current: 0,
         target: 5,
         unlocked: false
+      },
+      {
+        id: "epic_collector",
+        title: "史诗武装",
+        description: "为同一名英雄装备全套史诗装备。",
+        metric: "epic_equipment_slots",
+        current: 0,
+        target: 3,
+        unlocked: false
       }
     ],
     recentEventLog: [],
@@ -278,7 +287,7 @@ test("player progression loader normalizes summary, achievements, and limited ev
   try {
     const snapshot = await loadPlayerProgressionSnapshot("player-1", 1);
     assert.deepEqual(snapshot.summary, {
-      totalAchievements: 3,
+      totalAchievements: 4,
       unlockedAchievements: 1,
       inProgressAchievements: 0,
       latestUnlockedAchievementId: "first_battle",

--- a/apps/server/src/player-achievements.ts
+++ b/apps/server/src/player-achievements.ts
@@ -1,7 +1,9 @@
 import {
   appendEventLogEntries,
   applyAchievementMetricDelta,
+  applyAchievementProgressValue,
   formatEquipmentRarityLabel,
+  getEquipmentDefinition,
   type AchievementMetric,
   type EventLogEntry,
   type EventLogReward,
@@ -260,6 +262,23 @@ function metricDeltaForEvent(state: WorldState, playerId: string, event: WorldEv
   }
 }
 
+function countBestEpicEquipmentLoadout(state: WorldState, playerId: string): number {
+  return state.heroes
+    .filter((hero) => hero.playerId === playerId)
+    .reduce((best, hero) => {
+      const epicSlots = [
+        hero.loadout.equipment.weaponId,
+        hero.loadout.equipment.armorId,
+        hero.loadout.equipment.accessoryId
+      ].filter((equipmentId) => {
+        const definition = equipmentId ? getEquipmentDefinition(equipmentId) : undefined;
+        return definition?.rarity === "epic";
+      }).length;
+
+      return Math.max(best, epicSlots);
+    }, 0);
+}
+
 function createAchievementUnlockedEntry(
   state: WorldState,
   playerId: string,
@@ -312,6 +331,18 @@ export function applyPlayerEventLogAndAchievements(
       sequence += 1;
       entries.push(createAchievementUnlockedEntry(state, account.playerId, unlocked, timestamp, sequence));
     }
+  }
+
+  const epicCollectorResult = applyAchievementProgressValue(
+    achievements,
+    "epic_collector",
+    countBestEpicEquipmentLoadout(state, account.playerId),
+    timestamp
+  );
+  achievements = epicCollectorResult.progress;
+  for (const unlocked of epicCollectorResult.unlocked) {
+    sequence += 1;
+    entries.push(createAchievementUnlockedEntry(state, account.playerId, unlocked, timestamp, sequence));
   }
 
   if (entries.length === 0 && achievements === (account.achievements ?? [])) {

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -231,6 +231,28 @@ function createAccountTrackingWorldState(): WorldState {
   };
 }
 
+function createEpicEquipmentTrackingWorldState(): WorldState {
+  const base = createAccountTrackingWorldState();
+  return {
+    ...base,
+    heroes: [
+      {
+        ...base.heroes[0]!,
+        loadout: {
+          ...createDefaultHeroLoadout(),
+          equipment: {
+            weaponId: "sunforged_spear",
+            armorId: "warden_aegis",
+            accessoryId: "sun_medallion",
+            trinketIds: []
+          },
+          inventory: []
+        }
+      }
+    ]
+  };
+}
+
 function createReplaySummary(id: string, completedAt: string): PlayerBattleReplaySummary {
   return {
     id,
@@ -356,7 +378,7 @@ test("player account routes degrade to local-mode responses when persistence is 
   const publicProgressResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-local/progression`);
   const publicProgressPayload = (await publicProgressResponse.json()) as PlayerProgressionSnapshot;
   assert.equal(publicProgressResponse.status, 200);
-  assert.equal(publicProgressPayload.summary.totalAchievements, 3);
+  assert.equal(publicProgressPayload.summary.totalAchievements, 4);
   assert.equal(publicProgressPayload.summary.unlockedAchievements, 0);
 
   const meResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me`, {
@@ -389,7 +411,7 @@ test("player account routes degrade to local-mode responses when persistence is 
   });
   const meProgressPayload = (await meProgressResponse.json()) as PlayerProgressionSnapshot;
   assert.equal(meProgressResponse.status, 200);
-  assert.equal(meProgressPayload.summary.totalAchievements, 3);
+  assert.equal(meProgressPayload.summary.totalAchievements, 4);
   assert.equal(meProgressPayload.summary.unlockedAchievements, 0);
 });
 
@@ -528,7 +550,7 @@ test("player account progression routes return a compact achievement and event r
   const publicPayload = (await publicResponse.json()) as PlayerProgressionSnapshot;
   assert.equal(publicResponse.status, 200);
   assert.deepEqual(publicPayload.summary, {
-    totalAchievements: 3,
+    totalAchievements: 4,
     unlockedAchievements: 1,
     inProgressAchievements: 1,
     latestUnlockedAchievementId: "first_battle",
@@ -618,6 +640,25 @@ test("player achievement tracker records equipment drop entries for hero victori
 
   assert.equal(updated.recentEventLog[0]?.worldEventType, "hero.equipmentFound");
   assert.match(updated.recentEventLog[0]?.description ?? "", /塔盾链甲/);
+});
+
+test("player achievement tracker syncs epic equipment loadout progress from world state", () => {
+  const updated = applyPlayerEventLogAndAchievements(
+    {
+      playerId: "player-1",
+      displayName: "暮火侦骑",
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      recentEventLog: []
+    },
+    createEpicEquipmentTrackingWorldState(),
+    [],
+    "2026-03-27T12:10:00.000Z"
+  );
+
+  assert.equal(updated.achievements.find((achievement) => achievement.id === "epic_collector")?.current, 3);
+  assert.equal(updated.achievements.find((achievement) => achievement.id === "epic_collector")?.unlocked, true);
+  assert.match(updated.recentEventLog[0]?.description ?? "", /解锁成就：史诗武装/);
 });
 
 test("player account profile updates by player id require auth and allow self-service only", async (t) => {

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -2,8 +2,8 @@ import type { WorldEvent } from "./models";
 
 export type EventLogCategory = "movement" | "combat" | "building" | "skill" | "achievement";
 export type EventLogRewardType = "resource" | "experience" | "skill_point" | "badge";
-export type AchievementId = "first_battle" | "enemy_slayer" | "skill_scholar";
-export type AchievementMetric = "battles_started" | "battles_won" | "skills_learned";
+export type AchievementId = "first_battle" | "enemy_slayer" | "skill_scholar" | "epic_collector";
+export type AchievementMetric = "battles_started" | "battles_won" | "skills_learned" | "epic_equipment_slots";
 
 export interface EventLogReward {
   type: EventLogRewardType;
@@ -97,6 +97,13 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     title: "求知者",
     description: "学习 5 个长期技能。",
     target: 5
+  },
+  {
+    id: "epic_collector",
+    metric: "epic_equipment_slots",
+    title: "史诗武装",
+    description: "为同一名英雄装备全套史诗装备。",
+    target: 3
   }
 ];
 
@@ -190,6 +197,45 @@ export function applyAchievementMetricDelta(
       current,
       unlocked: current >= entry.target,
       ...(current >= entry.target ? { unlockedAt: entry.unlockedAt ?? unlockedAt } : entry.unlockedAt ? { unlockedAt: entry.unlockedAt } : {})
+    };
+
+    if (!previousUnlocked && nextEntry.unlocked) {
+      unlocked.push(nextEntry);
+    }
+
+    return nextEntry;
+  });
+
+  return {
+    progress: nextProgress,
+    unlocked
+  };
+}
+
+export function applyAchievementProgressValue(
+  progress: Partial<PlayerAchievementProgress>[] | null | undefined,
+  achievementId: AchievementId,
+  current: number,
+  unlockedAt = new Date().toISOString()
+): {
+  progress: PlayerAchievementProgress[];
+  unlocked: PlayerAchievementProgress[];
+} {
+  const normalized = normalizeAchievementProgress(progress);
+  const safeCurrent = Math.max(0, Math.floor(current));
+  const unlocked: PlayerAchievementProgress[] = [];
+  const nextProgress = normalized.map((entry) => {
+    if (entry.id !== achievementId) {
+      return entry;
+    }
+
+    const previousUnlocked = entry.unlocked;
+    const nextCurrent = Math.min(entry.target, safeCurrent);
+    const nextEntry: PlayerAchievementProgress = {
+      ...entry,
+      current: nextCurrent,
+      unlocked: nextCurrent >= entry.target,
+      ...(nextCurrent >= entry.target ? { unlockedAt: entry.unlockedAt ?? unlockedAt } : entry.unlockedAt ? { unlockedAt: entry.unlockedAt } : {})
     };
 
     if (!previousUnlocked && nextEntry.unlocked) {

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -7,6 +7,7 @@ import {
   appendPlayerBattleReplaySummaries,
   applyBattleOutcomeToWorld,
   applyAchievementMetricDelta,
+  applyAchievementProgressValue,
   buildPlayerProgressionSnapshot,
   createHeroAttributeBreakdown,
   createHeroEquipmentBonusSummary,
@@ -222,6 +223,21 @@ test("achievement helpers unlock milestones and preserve catalog order", () => {
   );
 });
 
+test("achievement helpers can sync progress from an absolute value", () => {
+  const progressSync = applyAchievementProgressValue([], "epic_collector", 2, "2026-03-27T10:00:00.000Z");
+  assert.equal(progressSync.progress.find((achievement) => achievement.id === "epic_collector")?.current, 2);
+  assert.equal(progressSync.unlocked.length, 0);
+
+  const unlockedSync = applyAchievementProgressValue(
+    progressSync.progress,
+    "epic_collector",
+    3,
+    "2026-03-27T10:01:00.000Z"
+  );
+  assert.equal(unlockedSync.unlocked[0]?.id, "epic_collector");
+  assert.equal(unlockedSync.progress.find((achievement) => achievement.id === "epic_collector")?.unlocked, true);
+});
+
 test("achievement helpers return the most recently unlocked milestone", () => {
   const progress = [
     {
@@ -318,7 +334,7 @@ test("player progression snapshot summarizes unlocked achievements and recent ev
   );
 
   assert.deepEqual(snapshot.summary, {
-    totalAchievements: 3,
+    totalAchievements: 4,
     unlockedAchievements: 1,
     inProgressAchievements: 1,
     latestUnlockedAchievementId: "first_battle",


### PR DESCRIPTION
## Summary
- extend the shared achievement catalog with the issue-27 epic equipment milestone and an absolute-progress sync helper
- update the server player achievement tracker to derive epic loadout progress from current world state and emit unlock event log entries
- cover the new behavior in shared, server, and client progression tests

## Testing
- npm run test:shared
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts

refs #27