### PR TITLE
Add player account event log query routes

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   buildPlayerProgressionSnapshot,
+  queryEventLogEntries,
   normalizePlayerBattleReplaySummaries
 } from "../../../packages/shared/src/index";
 import { issueNextAuthSession, resolveAuthSessionFromRequest } from "./auth";
@@ -73,11 +74,36 @@ function parsePlayerIdFilter(request: IncomingMessage): string | undefined {
   return value ? value : undefined;
 }
 
+function parseOptionalQueryParam(request: IncomingMessage, key: string): string | undefined {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const value = url.searchParams.get(key)?.trim();
+  return value ? value : undefined;
+}
+
 function toReplayResponse(account: PlayerAccountSnapshot, limit?: number): { items: PlayerAccountSnapshot["recentBattleReplays"] } {
   const items = normalizePlayerBattleReplaySummaries(account.recentBattleReplays);
   const safeLimit = limit == null ? undefined : Math.max(1, Math.floor(limit));
   return {
     items: safeLimit == null ? items : items.slice(0, safeLimit)
+  };
+}
+
+function toEventLogResponse(
+  account: PlayerAccountSnapshot,
+  request: IncomingMessage
+): { items: PlayerAccountSnapshot["recentEventLog"] } {
+  return {
+    items: queryEventLogEntries(account.recentEventLog, {
+      limit: parseLimit(request),
+      category: parseOptionalQueryParam(request, "category") as PlayerAccountSnapshot["recentEventLog"][number]["category"] | undefined,
+      heroId: parseOptionalQueryParam(request, "heroId"),
+      achievementId: parseOptionalQueryParam(request, "achievementId") as
+        | PlayerAccountSnapshot["recentEventLog"][number]["achievementId"]
+        | undefined,
+      worldEventType: parseOptionalQueryParam(request, "worldEventType") as
+        | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
+        | undefined
+    })
   };
 }
 
@@ -263,6 +289,42 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.get("/api/player-accounts/me/event-log", async (request, response) => {
+    const authSession = resolveAuthSessionFromRequest(request);
+    if (!authSession) {
+      sendUnauthorized(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(
+        response,
+        200,
+        toEventLogResponse(
+          createLocalModeAccount({
+            playerId: authSession.playerId,
+            displayName: authSession.displayName,
+            loginId: authSession.loginId
+          }),
+          request
+        )
+      );
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      sendJson(response, 200, toEventLogResponse(account, request));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
   app.get("/api/player-accounts/me/progression", async (request, response) => {
     const authSession = resolveAuthSessionFromRequest(request);
     if (!authSession) {
@@ -362,6 +424,45 @@ export function registerPlayerAccountRoutes(
       }
 
       sendJson(response, 200, toReplayResponse(account, parseLimit(request)));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/:playerId/event-log", async (request, response) => {
+    const playerId = request.params.playerId?.trim();
+    if (!playerId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(
+        response,
+        200,
+        toEventLogResponse(
+          createLocalModeAccount({
+            playerId
+          }),
+          request
+        )
+      );
+      return;
+    }
+
+    try {
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_account_not_found",
+            message: `Player account not found: ${playerId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, toEventLogResponse(account, request));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -485,6 +485,83 @@ test("player account me battle replay route resolves the current authenticated a
   assert.deepEqual(mePayload.items.map((replay) => replay.id), ["replay-me-2", "replay-me-1"]);
 });
 
+test("player account event-log routes filter recent entries without loading progression payloads", async (t) => {
+  const port = 42065 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-events",
+    displayName: "星炬记录官",
+    globalResources: { gold: 22, wood: 7, ore: 1 },
+    achievements: [],
+    recentEventLog: [
+      {
+        id: "event-skill",
+        timestamp: "2026-03-27T12:01:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-events",
+        category: "skill",
+        description: "skill",
+        heroId: "hero-2",
+        worldEventType: "hero.skillLearned",
+        rewards: []
+      },
+      {
+        id: "event-achievement",
+        timestamp: "2026-03-27T12:03:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-events",
+        category: "achievement",
+        description: "achievement",
+        heroId: "hero-1",
+        achievementId: "first_battle",
+        rewards: [{ type: "badge", label: "初次交锋" }]
+      },
+      {
+        id: "event-combat",
+        timestamp: "2026-03-27T12:02:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-events",
+        category: "combat",
+        description: "combat",
+        heroId: "hero-1",
+        worldEventType: "battle.started",
+        rewards: []
+      }
+    ],
+    recentBattleReplays: [],
+    lastRoomId: "room-alpha",
+    lastSeenAt: new Date("2026-03-27T12:04:00.000Z").toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-events",
+    displayName: "星炬记录官"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const publicResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-events/event-log?category=achievement&achievementId=first_battle&heroId=hero-1`
+  );
+  const publicPayload = (await publicResponse.json()) as { items: PlayerAccountSnapshot["recentEventLog"] };
+  assert.equal(publicResponse.status, 200);
+  assert.deepEqual(publicPayload.items.map((entry) => entry.id), ["event-achievement"]);
+
+  const meResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/event-log?heroId=hero-1&limit=1`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const mePayload = (await meResponse.json()) as { items: PlayerAccountSnapshot["recentEventLog"] };
+  assert.equal(meResponse.status, 200);
+  assert.deepEqual(mePayload.items.map((entry) => entry.id), ["event-achievement"]);
+});
+
 test("player account progression routes return a compact achievement and event read model", async (t) => {
   const port = 42080 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -24,6 +24,14 @@ export interface EventLogEntry {
   rewards: EventLogReward[];
 }
 
+export interface EventLogQuery {
+  limit?: number;
+  category?: EventLogCategory;
+  heroId?: string;
+  achievementId?: AchievementId;
+  worldEventType?: WorldEvent["type"];
+}
+
 export interface AchievementDefinition {
   id: AchievementId;
   metric: AchievementMetric;
@@ -306,6 +314,21 @@ export function appendEventLogEntries(
   }
 
   return normalizeEventLogEntries([...normalizedIncoming, ...normalizeEventLogEntries(existing)]).slice(0, safeLimit);
+}
+
+export function queryEventLogEntries(
+  entries?: Partial<EventLogEntry>[] | null,
+  query: EventLogQuery = {}
+): EventLogEntry[] {
+  const safeLimit = query.limit == null ? undefined : Math.max(1, Math.floor(query.limit));
+  const heroId = query.heroId?.trim();
+
+  return normalizeEventLogEntries(entries)
+    .filter((entry) => (query.category ? entry.category === query.category : true))
+    .filter((entry) => (heroId ? entry.heroId === heroId : true))
+    .filter((entry) => (query.achievementId ? entry.achievementId === query.achievementId : true))
+    .filter((entry) => (query.worldEventType ? entry.worldEventType === query.worldEventType : true))
+    .slice(0, safeLimit);
 }
 
 export function buildPlayerProgressionSnapshot(

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -9,6 +9,7 @@ import {
   applyAchievementMetricDelta,
   applyAchievementProgressValue,
   buildPlayerProgressionSnapshot,
+  queryEventLogEntries,
   createHeroAttributeBreakdown,
   createHeroEquipmentBonusSummary,
   createHeroEquipmentLoadoutView,
@@ -295,6 +296,54 @@ test("event log helper keeps newest unique entries first", () => {
     merged.map((entry) => entry.id),
     ["newer", "older"]
   );
+});
+
+test("event log query helper filters by category, hero, and achievement metadata", () => {
+  const queried = queryEventLogEntries(
+    [
+      {
+        id: "combat-entry",
+        timestamp: "2026-03-27T10:00:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "combat",
+        description: "combat",
+        heroId: "hero-1",
+        worldEventType: "battle.started",
+        rewards: []
+      },
+      {
+        id: "achievement-entry",
+        timestamp: "2026-03-27T10:05:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "achievement",
+        description: "achievement",
+        heroId: "hero-1",
+        achievementId: "first_battle",
+        rewards: []
+      },
+      {
+        id: "other-hero-entry",
+        timestamp: "2026-03-27T10:06:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "achievement",
+        description: "other hero",
+        heroId: "hero-2",
+        achievementId: "first_battle",
+        rewards: []
+      }
+    ],
+    {
+      category: "achievement",
+      heroId: "hero-1",
+      achievementId: "first_battle",
+      limit: 3
+    }
+  );
+
+  assert.deepEqual(queried.map((entry) => entry.id), ["achievement-entry"]);
 });
 
 test("player progression snapshot summarizes unlocked achievements and recent events", () => {


### PR DESCRIPTION
## Summary
- add a shared event-log query helper for filtered reads by category, hero, achievement, and world event type
- expose dedicated `/api/player-accounts/:playerId/event-log` and `/api/player-accounts/me/event-log` server routes
- cover the new query surface in shared and server tests without changing existing progression payloads

## Testing
- node --import tsx --test packages/shared/test/shared-core.test.ts
- node --import tsx --test apps/server/test/player-account-routes.test.ts

refs #27