### PR TITLE
Track achievement progress update metadata

### DIFF
--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -290,6 +290,9 @@ test("player progression loader normalizes summary, achievements, and limited ev
       totalAchievements: 4,
       unlockedAchievements: 1,
       inProgressAchievements: 0,
+      latestProgressAchievementId: "first_battle",
+      latestProgressAchievementTitle: "初次交锋",
+      latestProgressAt: "2026-03-27T12:00:00.000Z",
       latestUnlockedAchievementId: "first_battle",
       latestUnlockedAchievementTitle: "初次交锋",
       latestUnlockedAt: "2026-03-27T12:00:00.000Z",
@@ -297,6 +300,7 @@ test("player progression loader normalizes summary, achievements, and limited ev
       latestEventAt: "2026-03-27T12:03:00.000Z"
     });
     assert.equal(snapshot.achievements[0]?.title, "初次交锋");
+    assert.equal(snapshot.achievements[0]?.progressUpdatedAt, "2026-03-27T12:00:00.000Z");
     assert.deepEqual(snapshot.recentEventLog.map((entry) => entry.id), ["event-1"]);
   } finally {
     Object.defineProperty(globalThis, "window", {

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -293,6 +293,7 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         current: 1,
         target: 1,
         unlocked: true,
+        progressUpdatedAt: "2026-03-25T13:00:00.000Z",
         unlockedAt: "2026-03-25T13:00:00.000Z"
       },
       {
@@ -311,6 +312,15 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         metric: "skills_learned",
         current: 0,
         target: 5,
+        unlocked: false
+      },
+      {
+        id: "epic_collector",
+        title: "史诗武装",
+        description: "为同一名英雄装备全套史诗装备。",
+        metric: "epic_equipment_slots",
+        current: 0,
+        target: 3,
         unlocked: false
       }
     ],

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -578,6 +578,7 @@ test("player account progression routes return a compact achievement and event r
         current: 1,
         target: 99,
         unlocked: true,
+        progressUpdatedAt: "2026-03-27T12:00:00.000Z",
         unlockedAt: "2026-03-27T12:00:00.000Z"
       },
       {
@@ -587,7 +588,8 @@ test("player account progression routes return a compact achievement and event r
         metric: "battles_won",
         current: 2,
         target: 99,
-        unlocked: false
+        unlocked: false,
+        progressUpdatedAt: "2026-03-27T12:02:00.000Z"
       }
     ],
     recentEventLog: [
@@ -630,6 +632,9 @@ test("player account progression routes return a compact achievement and event r
     totalAchievements: 4,
     unlockedAchievements: 1,
     inProgressAchievements: 1,
+    latestProgressAchievementId: "enemy_slayer",
+    latestProgressAchievementTitle: "猎敌者",
+    latestProgressAt: "2026-03-27T12:02:00.000Z",
     latestUnlockedAchievementId: "first_battle",
     latestUnlockedAchievementTitle: "初次交锋",
     latestUnlockedAt: "2026-03-27T12:00:00.000Z",
@@ -648,6 +653,7 @@ test("player account progression routes return a compact achievement and event r
   assert.deepEqual(mePayload.recentEventLog.map((entry) => entry.id), ["event-newer", "event-older"]);
   assert.equal(mePayload.achievements[1]?.id, "enemy_slayer");
   assert.equal(mePayload.achievements[1]?.current, 2);
+  assert.equal(mePayload.achievements[1]?.progressUpdatedAt, "2026-03-27T12:02:00.000Z");
 });
 
 test("player achievement tracker appends logs and unlocks milestones", () => {
@@ -687,6 +693,10 @@ test("player achievement tracker appends logs and unlocks milestones", () => {
   );
 
   assert.equal(updated.achievements.find((achievement) => achievement.id === "first_battle")?.unlocked, true);
+  assert.equal(
+    updated.achievements.find((achievement) => achievement.id === "first_battle")?.progressUpdatedAt,
+    "2026-03-27T12:00:00.000Z"
+  );
   assert.equal(updated.recentEventLog[0]?.category, "achievement");
   assert.match(updated.recentEventLog.map((entry) => entry.description).join(" "), /解锁成就：初次交锋/);
 });
@@ -735,6 +745,10 @@ test("player achievement tracker syncs epic equipment loadout progress from worl
 
   assert.equal(updated.achievements.find((achievement) => achievement.id === "epic_collector")?.current, 3);
   assert.equal(updated.achievements.find((achievement) => achievement.id === "epic_collector")?.unlocked, true);
+  assert.equal(
+    updated.achievements.find((achievement) => achievement.id === "epic_collector")?.progressUpdatedAt,
+    "2026-03-27T12:10:00.000Z"
+  );
   assert.match(updated.recentEventLog[0]?.description ?? "", /解锁成就：史诗武装/);
 });
 

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -48,6 +48,7 @@ export interface PlayerAchievementProgress {
   current: number;
   target: number;
   unlocked: boolean;
+  progressUpdatedAt?: string;
   unlockedAt?: string;
 }
 
@@ -55,6 +56,9 @@ export interface PlayerProgressionSummary {
   totalAchievements: number;
   unlockedAchievements: number;
   inProgressAchievements: number;
+  latestProgressAchievementId?: AchievementId;
+  latestProgressAchievementTitle?: string;
+  latestProgressAt?: string;
   latestUnlockedAchievementId?: AchievementId;
   latestUnlockedAchievementTitle?: string;
   latestUnlockedAt?: string;
@@ -80,6 +84,22 @@ export function getLatestUnlockedAchievement(
     unlocked.sort((left, right) => {
       const unlockedAtOrder = String(right.unlockedAt).localeCompare(String(left.unlockedAt));
       return unlockedAtOrder || left.id.localeCompare(right.id);
+    })[0] ?? null
+  );
+}
+
+export function getLatestProgressedAchievement(
+  progress?: Partial<PlayerAchievementProgress>[] | null
+): PlayerAchievementProgress | null {
+  const progressed = normalizeAchievementProgress(progress).filter((entry) => entry.current > 0 && entry.progressUpdatedAt);
+  if (progressed.length === 0) {
+    return null;
+  }
+
+  return (
+    progressed.sort((left, right) => {
+      const progressOrder = String(right.progressUpdatedAt).localeCompare(String(left.progressUpdatedAt));
+      return progressOrder || left.id.localeCompare(right.id);
     })[0] ?? null
   );
 }
@@ -142,6 +162,8 @@ export function normalizeAchievementProgress(
         }
 
         const current = Math.max(0, Math.floor(entry.current ?? 0));
+        const progressUpdatedAt =
+          normalizeTimestamp(entry.progressUpdatedAt) ?? (current > 0 ? normalizeTimestamp(entry.unlockedAt) : undefined);
         const unlockedAt = normalizeTimestamp(entry.unlockedAt);
         return [
           definition.id,
@@ -153,6 +175,7 @@ export function normalizeAchievementProgress(
             current,
             target: definition.target,
             unlocked: current >= definition.target || Boolean(unlockedAt),
+            ...(progressUpdatedAt ? { progressUpdatedAt } : {}),
             ...(unlockedAt ? { unlockedAt } : {})
           }
         ] as const;
@@ -178,7 +201,7 @@ export function applyAchievementMetricDelta(
   progress: Partial<PlayerAchievementProgress>[] | null | undefined,
   metric: AchievementMetric,
   amount: number,
-  unlockedAt = new Date().toISOString()
+  recordedAt = new Date().toISOString()
 ): {
   progress: PlayerAchievementProgress[];
   unlocked: PlayerAchievementProgress[];
@@ -200,11 +223,20 @@ export function applyAchievementMetricDelta(
 
     const previousUnlocked = entry.unlocked;
     const current = Math.min(entry.target, entry.current + safeAmount);
+    if (current === entry.current) {
+      return entry;
+    }
+
     const nextEntry: PlayerAchievementProgress = {
       ...entry,
       current,
+      ...(current > 0 ? { progressUpdatedAt: recordedAt } : {}),
       unlocked: current >= entry.target,
-      ...(current >= entry.target ? { unlockedAt: entry.unlockedAt ?? unlockedAt } : entry.unlockedAt ? { unlockedAt: entry.unlockedAt } : {})
+      ...(current >= entry.target
+        ? { unlockedAt: entry.unlockedAt ?? recordedAt }
+        : entry.unlockedAt
+          ? { unlockedAt: entry.unlockedAt }
+          : {})
     };
 
     if (!previousUnlocked && nextEntry.unlocked) {
@@ -224,7 +256,7 @@ export function applyAchievementProgressValue(
   progress: Partial<PlayerAchievementProgress>[] | null | undefined,
   achievementId: AchievementId,
   current: number,
-  unlockedAt = new Date().toISOString()
+  recordedAt = new Date().toISOString()
 ): {
   progress: PlayerAchievementProgress[];
   unlocked: PlayerAchievementProgress[];
@@ -239,11 +271,20 @@ export function applyAchievementProgressValue(
 
     const previousUnlocked = entry.unlocked;
     const nextCurrent = Math.min(entry.target, safeCurrent);
+    if (nextCurrent === entry.current) {
+      return entry;
+    }
+
     const nextEntry: PlayerAchievementProgress = {
       ...entry,
       current: nextCurrent,
+      ...(nextCurrent > 0 ? { progressUpdatedAt: recordedAt } : {}),
       unlocked: nextCurrent >= entry.target,
-      ...(nextCurrent >= entry.target ? { unlockedAt: entry.unlockedAt ?? unlockedAt } : entry.unlockedAt ? { unlockedAt: entry.unlockedAt } : {})
+      ...(nextCurrent >= entry.target
+        ? { unlockedAt: entry.unlockedAt ?? recordedAt }
+        : entry.unlockedAt
+          ? { unlockedAt: entry.unlockedAt }
+          : {})
     };
 
     if (!previousUnlocked && nextEntry.unlocked) {
@@ -338,6 +379,7 @@ export function buildPlayerProgressionSnapshot(
 ): PlayerProgressionSnapshot {
   const normalizedAchievements = normalizeAchievementProgress(achievements);
   const normalizedRecentEventLog = normalizeEventLogEntries(recentEventLog).slice(0, Math.max(1, Math.floor(eventLimit)));
+  const latestProgressed = getLatestProgressedAchievement(normalizedAchievements);
   const latestUnlocked = getLatestUnlockedAchievement(normalizedAchievements);
   const unlockedAchievements = normalizedAchievements.filter((entry) => entry.unlocked).length;
 
@@ -346,6 +388,13 @@ export function buildPlayerProgressionSnapshot(
       totalAchievements: normalizedAchievements.length,
       unlockedAchievements,
       inProgressAchievements: normalizedAchievements.filter((entry) => !entry.unlocked && entry.current > 0).length,
+      ...(latestProgressed
+        ? {
+            latestProgressAchievementId: latestProgressed.id,
+            latestProgressAchievementTitle: latestProgressed.title,
+            latestProgressAt: latestProgressed.progressUpdatedAt
+          }
+        : {}),
       ...(latestUnlocked
         ? {
             latestUnlockedAchievementId: latestUnlocked.id,

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -37,6 +37,7 @@ import {
   getDefaultWorldConfig,
   getBattleOutcome,
   getDefaultEquipmentCatalog,
+  getLatestProgressedAchievement,
   getLatestUnlockedAchievement,
   normalizePlayerBattleReplaySummaries,
   pickAutomatedBattleAction,
@@ -215,9 +216,11 @@ test("achievement helpers unlock milestones and preserve catalog order", () => {
   const firstPass = applyAchievementMetricDelta([], "battles_started", 1, "2026-03-27T10:00:00.000Z");
   assert.equal(firstPass.unlocked[0]?.id, "first_battle");
   assert.equal(firstPass.progress[0]?.unlocked, true);
+  assert.equal(firstPass.progress[0]?.progressUpdatedAt, "2026-03-27T10:00:00.000Z");
 
   const secondPass = applyAchievementMetricDelta(firstPass.progress, "skills_learned", 5, "2026-03-27T10:01:00.000Z");
   assert.equal(secondPass.unlocked[0]?.id, "skill_scholar");
+  assert.equal(secondPass.progress[2]?.progressUpdatedAt, "2026-03-27T10:01:00.000Z");
   assert.deepEqual(
     secondPass.progress.map((achievement) => achievement.id),
     getAchievementDefinitions().map((achievement) => achievement.id)
@@ -227,6 +230,10 @@ test("achievement helpers unlock milestones and preserve catalog order", () => {
 test("achievement helpers can sync progress from an absolute value", () => {
   const progressSync = applyAchievementProgressValue([], "epic_collector", 2, "2026-03-27T10:00:00.000Z");
   assert.equal(progressSync.progress.find((achievement) => achievement.id === "epic_collector")?.current, 2);
+  assert.equal(
+    progressSync.progress.find((achievement) => achievement.id === "epic_collector")?.progressUpdatedAt,
+    "2026-03-27T10:00:00.000Z"
+  );
   assert.equal(progressSync.unlocked.length, 0);
 
   const unlockedSync = applyAchievementProgressValue(
@@ -237,6 +244,10 @@ test("achievement helpers can sync progress from an absolute value", () => {
   );
   assert.equal(unlockedSync.unlocked[0]?.id, "epic_collector");
   assert.equal(unlockedSync.progress.find((achievement) => achievement.id === "epic_collector")?.unlocked, true);
+  assert.equal(
+    unlockedSync.progress.find((achievement) => achievement.id === "epic_collector")?.progressUpdatedAt,
+    "2026-03-27T10:01:00.000Z"
+  );
 });
 
 test("achievement helpers return the most recently unlocked milestone", () => {
@@ -254,6 +265,23 @@ test("achievement helpers return the most recently unlocked milestone", () => {
   ];
 
   assert.equal(getLatestUnlockedAchievement(progress)?.id, "skill_scholar");
+});
+
+test("achievement helpers return the most recently progressed milestone", () => {
+  const progress = [
+    {
+      id: "first_battle" as const,
+      current: 1,
+      progressUpdatedAt: "2026-03-27T10:00:00.000Z"
+    },
+    {
+      id: "enemy_slayer" as const,
+      current: 2,
+      progressUpdatedAt: "2026-03-27T10:05:00.000Z"
+    }
+  ];
+
+  assert.equal(getLatestProgressedAchievement(progress)?.id, "enemy_slayer");
 });
 
 test("event log helper keeps newest unique entries first", () => {
@@ -352,11 +380,13 @@ test("player progression snapshot summarizes unlocked achievements and recent ev
       {
         id: "first_battle",
         current: 1,
+        progressUpdatedAt: "2026-03-27T10:00:00.000Z",
         unlockedAt: "2026-03-27T10:00:00.000Z"
       },
       {
         id: "enemy_slayer",
-        current: 2
+        current: 2,
+        progressUpdatedAt: "2026-03-27T10:04:00.000Z"
       }
     ],
     [
@@ -386,6 +416,9 @@ test("player progression snapshot summarizes unlocked achievements and recent ev
     totalAchievements: 4,
     unlockedAchievements: 1,
     inProgressAchievements: 1,
+    latestProgressAchievementId: "enemy_slayer",
+    latestProgressAchievementTitle: "猎敌者",
+    latestProgressAt: "2026-03-27T10:04:00.000Z",
     latestUnlockedAchievementId: "first_battle",
     latestUnlockedAchievementTitle: "初次交锋",
     latestUnlockedAt: "2026-03-27T10:00:00.000Z",


### PR DESCRIPTION
## Summary
- add shared achievement progress update metadata so progression can distinguish latest progress from latest unlock
- expose latest progressed achievement fields through the progression snapshot read model without changing gameplay event generation
- cover the new metadata in shared, server, client, and cocos progression/account tests

## Testing
- node --import tsx --test packages/shared/test/shared-core.test.ts
- node --import tsx --test apps/server/test/player-account-routes.test.ts
- node --import tsx --test apps/client/test/player-account-storage.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-lobby.test.ts

refs #27