### PR TITLE
Add asset manifest validation infrastructure

### DIFF
--- a/apps/client/src/assets.ts
+++ b/apps/client/src/assets.ts
@@ -1,5 +1,8 @@
-import assetConfig from "../../../configs/assets.json";
+import assetConfigJson from "../../../configs/assets.json";
 import unitCatalog from "../../../configs/units.json";
+import type { AssetConfig } from "../../../packages/shared/src/assets-config";
+
+const assetConfig: AssetConfig = assetConfigJson;
 
 type TerrainKey = keyof typeof assetConfig.terrain;
 type ResourceKey = keyof typeof assetConfig.resources;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "demo:flow": "node --import tsx ./scripts/demo.ts",
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
     "validate:battle": "node --import tsx ./scripts/validate-battle-balance.ts",
+    "validate:assets": "node --import tsx ./scripts/validate-assets.ts",
     "test": "node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/authoritative-room.test.ts ./apps/server/test/room-persistence.test.ts ./apps/server/test/player-room-profiles.test.ts ./apps/server/test/persistence-retention.test.ts ./apps/server/test/persistence-account-credentials.test.ts ./apps/server/test/colyseus-persistence-recovery.test.ts ./apps/server/test/config-center.test.ts ./apps/server/test/player-account-routes.test.ts ./apps/server/test/lobby-routes.test.ts ./apps/server/test/auth-guest-login.test.ts ./apps/client/test/reconnection-storage.test.ts ./apps/client/test/player-account-storage.test.ts ./apps/client/test/account-history-render.test.ts ./apps/client/test/lobby-preferences.test.ts ./apps/client/test/auth-session-storage.test.ts ./apps/cocos-client/test/unit-animation-config.test.ts ./apps/cocos-client/test/cocos-ui-formatters.test.ts ./apps/cocos-client/test/cocos-battle-panel-model.test.ts ./apps/cocos-client/test/cocos-map-visuals.test.ts ./apps/cocos-client/test/cocos-object-visuals.test.ts ./apps/cocos-client/test/cocos-session-launch.test.ts ./apps/cocos-client/test/cocos-lobby.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",

--- a/packages/shared/src/assets-config.ts
+++ b/packages/shared/src/assets-config.ts
@@ -1,0 +1,198 @@
+import type { BuildingKind, ResourceKind, TerrainType } from "./models";
+
+export type AssetState = "idle" | "selected" | "hit";
+export type MarkerKind = "hero" | "neutral";
+
+export interface TerrainAssetEntry {
+  default: string;
+  variants: string[];
+}
+
+export interface UnitAssetEntry {
+  portrait: Record<AssetState, string>;
+  frame: string;
+}
+
+export interface MarkerAssetEntry {
+  idle: string;
+  selected: string;
+  hit: string;
+}
+
+export interface AssetConfig {
+  terrain: Record<TerrainType | "unknown", TerrainAssetEntry>;
+  resources: Record<ResourceKind, string>;
+  buildings: Record<BuildingKind, string>;
+  units: Record<string, UnitAssetEntry>;
+  markers: Record<MarkerKind, MarkerAssetEntry>;
+  badges: {
+    factions: Record<string, string>;
+    rarities: Record<string, string>;
+    interactions: Record<string, string>;
+  };
+}
+
+const TERRAIN_KEYS = ["grass", "dirt", "sand", "water", "unknown"] as const;
+const RESOURCE_KEYS = ["gold", "wood", "ore"] as const;
+const BUILDING_KEYS = ["recruitment_post", "attribute_shrine", "resource_mine"] as const;
+const MARKER_KEYS = ["hero", "neutral"] as const;
+const ASSET_STATE_KEYS = ["idle", "selected", "hit"] as const;
+const BADGE_GROUP_KEYS = ["factions", "rarities", "interactions"] as const;
+
+export function getAssetConfigValidationErrors(config: unknown): string[] {
+  const errors: string[] = [];
+  if (!isRecord(config)) {
+    return ["Asset config must be an object"];
+  }
+
+  validateTerrainSection(config.terrain, errors);
+  validateStringMapSection(config.resources, RESOURCE_KEYS, "resources", errors);
+  validateStringMapSection(config.buildings, BUILDING_KEYS, "buildings", errors);
+  validateUnitsSection(config.units, errors);
+  validateMarkersSection(config.markers, errors);
+  validateBadgesSection(config.badges, errors);
+
+  return errors;
+}
+
+export function parseAssetConfig(config: unknown): AssetConfig {
+  const errors = getAssetConfigValidationErrors(config);
+  if (errors.length > 0) {
+    throw new Error(`Invalid asset config:\n- ${errors.join("\n- ")}`);
+  }
+
+  return config as AssetConfig;
+}
+
+function validateTerrainSection(section: unknown, errors: string[]): void {
+  if (!isRecord(section)) {
+    errors.push("terrain must be an object");
+    return;
+  }
+
+  for (const key of TERRAIN_KEYS) {
+    const entry = section[key];
+    if (!isRecord(entry)) {
+      errors.push(`terrain.${key} must be an object`);
+      continue;
+    }
+
+    validateAssetPath(entry.default, `terrain.${key}.default`, errors);
+    validateAssetPathArray(entry.variants, `terrain.${key}.variants`, errors);
+
+    if (Array.isArray(entry.variants) && entry.variants.length > 0 && typeof entry.default === "string") {
+      if (!entry.variants.includes(entry.default)) {
+        errors.push(`terrain.${key}.variants must include terrain.${key}.default`);
+      }
+    }
+  }
+}
+
+function validateStringMapSection(
+  section: unknown,
+  requiredKeys: readonly string[],
+  sectionName: string,
+  errors: string[]
+): void {
+  if (!isRecord(section)) {
+    errors.push(`${sectionName} must be an object`);
+    return;
+  }
+
+  for (const key of requiredKeys) {
+    validateAssetPath(section[key], `${sectionName}.${key}`, errors);
+  }
+}
+
+function validateUnitsSection(section: unknown, errors: string[]): void {
+  if (!isRecord(section)) {
+    errors.push("units must be an object");
+    return;
+  }
+
+  for (const [unitId, entry] of Object.entries(section)) {
+    if (!isRecord(entry)) {
+      errors.push(`units.${unitId} must be an object`);
+      continue;
+    }
+
+    if (!isRecord(entry.portrait)) {
+      errors.push(`units.${unitId}.portrait must be an object`);
+    } else {
+      for (const state of ASSET_STATE_KEYS) {
+        validateAssetPath(entry.portrait[state], `units.${unitId}.portrait.${state}`, errors);
+      }
+    }
+
+    validateAssetPath(entry.frame, `units.${unitId}.frame`, errors);
+  }
+}
+
+function validateMarkersSection(section: unknown, errors: string[]): void {
+  if (!isRecord(section)) {
+    errors.push("markers must be an object");
+    return;
+  }
+
+  for (const key of MARKER_KEYS) {
+    const entry = section[key];
+    if (!isRecord(entry)) {
+      errors.push(`markers.${key} must be an object`);
+      continue;
+    }
+
+    for (const state of ASSET_STATE_KEYS) {
+      validateAssetPath(entry[state], `markers.${key}.${state}`, errors);
+    }
+  }
+}
+
+function validateBadgesSection(section: unknown, errors: string[]): void {
+  if (!isRecord(section)) {
+    errors.push("badges must be an object");
+    return;
+  }
+
+  for (const group of BADGE_GROUP_KEYS) {
+    const entry = section[group];
+    if (!isRecord(entry)) {
+      errors.push(`badges.${group} must be an object`);
+      continue;
+    }
+
+    if (Object.keys(entry).length === 0) {
+      errors.push(`badges.${group} must define at least one asset`);
+      continue;
+    }
+
+    for (const [key, value] of Object.entries(entry)) {
+      validateAssetPath(value, `badges.${group}.${key}`, errors);
+    }
+  }
+}
+
+function validateAssetPathArray(value: unknown, path: string, errors: string[]): void {
+  if (!Array.isArray(value) || value.length === 0) {
+    errors.push(`${path} must be a non-empty array`);
+    return;
+  }
+
+  for (const [index, item] of value.entries()) {
+    validateAssetPath(item, `${path}[${index}]`, errors);
+  }
+}
+
+function validateAssetPath(value: unknown, path: string, errors: string[]): void {
+  if (typeof value !== "string" || value.length === 0) {
+    errors.push(`${path} must be a non-empty string`);
+    return;
+  }
+
+  if (!value.startsWith("/assets/")) {
+    errors.push(`${path} must start with /assets/`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./assets-config";
 export * from "./battle";
 export * from "./battle-replay";
 export * from "./equipment";

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import assetConfig from "../../../configs/assets.json";
 import {
   applyBattleAction,
   appendEventLogEntries,
@@ -30,6 +31,7 @@ import {
   filterWorldEventsForPlayer,
   getBattleBalanceConfig,
   getAchievementDefinitions,
+  getAssetConfigValidationErrors,
   getDefaultMapObjectsConfig,
   getDefaultBattleSkillCatalog,
   getDefaultHeroSkillTreeConfig,
@@ -210,6 +212,83 @@ test("typed-array world map payload decodes back to the original player world vi
   const view = createLargePlayerWorldView();
 
   assert.deepEqual(decodePlayerWorldView(encodePlayerWorldView(view)), view);
+});
+
+test("asset config passes schema validation", () => {
+  assert.deepEqual(getAssetConfigValidationErrors(assetConfig), []);
+});
+
+test("asset config validation reports missing terrain variants and bad asset roots", () => {
+  const errors = getAssetConfigValidationErrors({
+    terrain: {
+      grass: {
+        default: "/assets/terrain/grass-tile.svg",
+        variants: ["/assets/terrain/grass-tile.svg"]
+      },
+      dirt: {
+        default: "/assets/terrain/dirt-tile.svg",
+        variants: ["/assets/terrain/dirt-tile.svg"]
+      },
+      sand: {
+        default: "/assets/terrain/sand-tile.svg",
+        variants: ["/assets/terrain/sand-tile.svg"]
+      },
+      water: {
+        default: "/assets/terrain/water-tile.svg",
+        variants: ["/assets/terrain/water-tile.svg"]
+      },
+      unknown: {
+        default: "/assets/terrain/fog-tile.svg",
+        variants: []
+      }
+    },
+    resources: {
+      gold: "/assets/resources/gold-pile.svg",
+      wood: "assets/resources/wood-stack.svg",
+      ore: "/assets/resources/ore-crate.svg"
+    },
+    buildings: {
+      recruitment_post: "/assets/buildings/recruitment-post.svg",
+      attribute_shrine: "/assets/buildings/attribute-shrine.svg",
+      resource_mine: "/assets/buildings/resource-mine.svg"
+    },
+    units: {
+      hero_guard_basic: {
+        portrait: {
+          idle: "/assets/units/hero-guard-basic.svg",
+          selected: "/assets/units/hero-guard-basic-selected.svg",
+          hit: "/assets/units/hero-guard-basic-hit.svg"
+        },
+        frame: "/assets/frames/unit-frame-ally.svg"
+      }
+    },
+    markers: {
+      hero: {
+        idle: "/assets/markers/hero-marker.svg",
+        selected: "/assets/markers/hero-marker-selected.svg",
+        hit: "/assets/markers/hero-marker-hit.svg"
+      },
+      neutral: {
+        idle: "/assets/markers/neutral-marker.svg",
+        selected: "/assets/markers/neutral-marker-selected.svg",
+        hit: "/assets/markers/neutral-marker-hit.svg"
+      }
+    },
+    badges: {
+      factions: {
+        crown: "/assets/badges/faction-crown.svg"
+      },
+      rarities: {
+        common: "/assets/badges/rarity-common.svg"
+      },
+      interactions: {
+        move: "/assets/badges/interaction-move.svg"
+      }
+    }
+  });
+
+  assert.ok(errors.includes("terrain.unknown.variants must be a non-empty array"));
+  assert.ok(errors.includes("resources.wood must start with /assets/"));
 });
 
 test("achievement helpers unlock milestones and preserve catalog order", () => {

--- a/scripts/validate-assets.ts
+++ b/scripts/validate-assets.ts
@@ -1,0 +1,122 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import assetConfigJson from "../configs/assets.json";
+import unitCatalog from "../configs/units.json";
+import { getAssetConfigValidationErrors, parseAssetConfig } from "../packages/shared/src/assets-config";
+
+const rootDir = process.cwd();
+const publicDir = path.join(rootDir, "apps/client/public");
+
+const errors = [...getAssetConfigValidationErrors(assetConfigJson)];
+const assetConfig = parseOrNull();
+
+if (assetConfig) {
+  validateManifestCoverage(assetConfig, errors);
+  validateAssetFiles(assetConfig, errors);
+}
+
+if (errors.length > 0) {
+  console.error("Asset validation failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log(
+    `Asset validation passed: ${Object.keys(assetConfig.units).length} units, ${countAssetPaths(assetConfig)} registered files`
+  );
+}
+
+function parseOrNull() {
+  try {
+    return parseAssetConfig(assetConfigJson);
+  } catch {
+    return null;
+  }
+}
+
+function validateManifestCoverage(
+  assetConfig: ReturnType<typeof parseAssetConfig>,
+  errors: string[]
+): void {
+  const unitIds = new Set(unitCatalog.templates.map((template) => template.id));
+  const factionIds = new Set(unitCatalog.templates.map((template) => template.faction));
+  const rarityIds = new Set(unitCatalog.templates.map((template) => template.rarity));
+
+  for (const unitId of unitIds) {
+    if (!assetConfig.units[unitId]) {
+      errors.push(`units.${unitId} is missing for unit template ${unitId}`);
+    }
+  }
+
+  for (const unitId of Object.keys(assetConfig.units)) {
+    if (!unitIds.has(unitId)) {
+      errors.push(`units.${unitId} does not match any unit template id`);
+    }
+  }
+
+  for (const factionId of factionIds) {
+    if (!assetConfig.badges.factions[factionId]) {
+      errors.push(`badges.factions.${factionId} is missing for unit catalog coverage`);
+    }
+  }
+
+  for (const rarityId of rarityIds) {
+    if (!assetConfig.badges.rarities[rarityId]) {
+      errors.push(`badges.rarities.${rarityId} is missing for unit catalog coverage`);
+    }
+  }
+}
+
+function validateAssetFiles(assetConfig: ReturnType<typeof parseAssetConfig>, errors: string[]): void {
+  for (const assetPath of collectAssetPaths(assetConfig)) {
+    const filepath = path.join(publicDir, assetPath.slice(1));
+    if (!existsSync(filepath)) {
+      errors.push(`${assetPath} does not exist at ${path.relative(rootDir, filepath)}`);
+    }
+  }
+}
+
+function collectAssetPaths(assetConfig: ReturnType<typeof parseAssetConfig>): string[] {
+  const paths = new Set<string>();
+
+  for (const terrain of Object.values(assetConfig.terrain)) {
+    paths.add(terrain.default);
+    for (const variant of terrain.variants) {
+      paths.add(variant);
+    }
+  }
+
+  for (const resource of Object.values(assetConfig.resources)) {
+    paths.add(resource);
+  }
+
+  for (const building of Object.values(assetConfig.buildings)) {
+    paths.add(building);
+  }
+
+  for (const unit of Object.values(assetConfig.units)) {
+    for (const portrait of Object.values(unit.portrait)) {
+      paths.add(portrait);
+    }
+    paths.add(unit.frame);
+  }
+
+  for (const marker of Object.values(assetConfig.markers)) {
+    for (const state of Object.values(marker)) {
+      paths.add(state);
+    }
+  }
+
+  for (const badgeGroup of Object.values(assetConfig.badges)) {
+    for (const badge of Object.values(badgeGroup)) {
+      paths.add(badge);
+    }
+  }
+
+  return [...paths];
+}
+
+function countAssetPaths(assetConfig: ReturnType<typeof parseAssetConfig>): number {
+  return collectAssetPaths(assetConfig).length;
+}


### PR DESCRIPTION
## Summary
- add a shared asset manifest schema and validation helpers for `configs/assets.json`
- add a repo validator that checks manifest coverage against unit metadata and public asset files
- type the H5 client asset loader against the shared manifest contract and cover the schema with tests

## Testing
- npm run test:shared
- npm run typecheck:shared
- npm run typecheck:client:h5
- npm run validate:assets

refs #33