### PR TITLE
Add battle replay playback control helpers

### DIFF
--- a/packages/shared/src/battle-replay.ts
+++ b/packages/shared/src/battle-replay.ts
@@ -1,3 +1,4 @@
+import { applyBattleAction } from "./battle";
 import type { BattleAction, BattleState } from "./models";
 
 export type BattleReplayResult = "attacker_victory" | "defender_victory";
@@ -27,6 +28,18 @@ export interface PlayerBattleReplaySummary {
   result: BattleReplayResult;
 }
 
+export type BattleReplayPlaybackStatus = "paused" | "playing" | "completed";
+
+export interface BattleReplayPlaybackState {
+  replay: PlayerBattleReplaySummary;
+  status: BattleReplayPlaybackStatus;
+  currentStepIndex: number;
+  totalSteps: number;
+  currentState: BattleState;
+  currentStep: BattleReplayStep | null;
+  nextStep: BattleReplayStep | null;
+}
+
 function normalizeTimestamp(value?: string | null): string | undefined {
   if (!value) {
     return undefined;
@@ -37,14 +50,90 @@ function normalizeTimestamp(value?: string | null): string | undefined {
 }
 
 function cloneBattleState(state: BattleState): BattleState {
+  return structuredClone(state);
+}
+
+function resolvePlaybackStatus(
+  requestedStatus: Exclude<BattleReplayPlaybackStatus, "completed">,
+  currentStepIndex: number,
+  totalSteps: number
+): BattleReplayPlaybackStatus {
+  return currentStepIndex >= totalSteps ? "completed" : requestedStatus;
+}
+
+function buildPlaybackState(
+  replay: PlayerBattleReplaySummary,
+  currentState: BattleState,
+  currentStepIndex: number,
+  status: Exclude<BattleReplayPlaybackStatus, "completed">
+): BattleReplayPlaybackState {
+  const totalSteps = replay.steps.length;
+  const boundedStepIndex = Math.max(0, Math.min(totalSteps, Math.floor(currentStepIndex)));
   return {
-    ...state,
-    units: Object.fromEntries(Object.entries(state.units).map(([unitId, unit]) => [unitId, { ...unit }])),
-    environment: state.environment.map((hazard) => ({ ...hazard })),
-    log: [...state.log],
-    rng: { ...state.rng },
-    ...(state.encounterPosition ? { encounterPosition: { ...state.encounterPosition } } : {})
+    replay,
+    status: resolvePlaybackStatus(status, boundedStepIndex, totalSteps),
+    currentStepIndex: boundedStepIndex,
+    totalSteps,
+    currentState: cloneBattleState(currentState),
+    currentStep: replay.steps[boundedStepIndex - 1] ?? null,
+    nextStep: replay.steps[boundedStepIndex] ?? null
   };
+}
+
+export function createBattleReplayPlaybackState(replay: PlayerBattleReplaySummary): BattleReplayPlaybackState {
+  return buildPlaybackState(replay, replay.initialState, 0, "paused");
+}
+
+export function playBattleReplayPlayback(playback: BattleReplayPlaybackState): BattleReplayPlaybackState {
+  if (playback.currentStepIndex >= playback.totalSteps) {
+    return {
+      ...playback,
+      status: "completed"
+    };
+  }
+
+  return {
+    ...playback,
+    status: "playing"
+  };
+}
+
+export function pauseBattleReplayPlayback(playback: BattleReplayPlaybackState): BattleReplayPlaybackState {
+  if (playback.status === "completed") {
+    return playback;
+  }
+
+  return {
+    ...playback,
+    status: "paused"
+  };
+}
+
+export function resetBattleReplayPlayback(playback: BattleReplayPlaybackState): BattleReplayPlaybackState {
+  return buildPlaybackState(playback.replay, playback.replay.initialState, 0, "paused");
+}
+
+export function stepBattleReplayPlayback(playback: BattleReplayPlaybackState): BattleReplayPlaybackState {
+  const nextStep = playback.nextStep;
+  if (!nextStep) {
+    return {
+      ...playback,
+      status: "completed"
+    };
+  }
+
+  const nextState = applyBattleAction(playback.currentState, nextStep.action);
+  const nextStepIndex = playback.currentStepIndex + 1;
+  const nextStatus = playback.status === "playing" ? "playing" : "paused";
+  return buildPlaybackState(playback.replay, nextState, nextStepIndex, nextStatus);
+}
+
+export function tickBattleReplayPlayback(playback: BattleReplayPlaybackState): BattleReplayPlaybackState {
+  if (playback.status !== "playing") {
+    return playback;
+  }
+
+  return stepBattleReplayPlayback(playback);
 }
 
 function normalizeBattleReplayStep(step: Partial<BattleReplayStep> | null | undefined, fallbackIndex: number): BattleReplayStep | null {

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -17,6 +17,7 @@ import {
   createHeroSkillTreeView,
   createHeroProgressMeterView,
   createBattleEnvironmentState,
+  createBattleReplayPlaybackState,
   createDemoBattleState,
   createEmptyBattleState,
   executeBattleSkill,
@@ -42,12 +43,17 @@ import {
   getLatestProgressedAchievement,
   getLatestUnlockedAchievement,
   normalizePlayerBattleReplaySummaries,
+  pauseBattleReplayPlayback,
   pickAutomatedBattleAction,
   planPlayerViewMovement,
+  playBattleReplayPlayback,
   predictPlayerWorldAction,
+  resetBattleReplayPlayback,
   resetRuntimeConfigs,
   simulateAutomatedBattle,
   simulateAutomatedBattles,
+  stepBattleReplayPlayback,
+  tickBattleReplayPlayback,
   resolveWorldAction,
   rollEquipmentDrop,
   setBattleBalanceConfig,
@@ -567,6 +573,82 @@ test("battle replay helpers normalize steps and keep newest unique replays first
   assert.deepEqual(merged.map((replay) => replay.id), ["replay-newer", "replay-older"]);
   assert.equal(merged[0]?.steps[0]?.index, 5);
   assert.equal(merged[1]?.steps[0]?.index, 9);
+});
+
+test("battle replay playback helpers support play pause tick and reset controls", () => {
+  const initial = createDemoBattleState();
+  const replay = normalizePlayerBattleReplaySummaries([
+    {
+      id: "replay-controls",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      battleId: initial.id,
+      battleKind: "hero",
+      playerCamp: "attacker",
+      heroId: "hero-1",
+      opponentHeroId: "hero-2",
+      startedAt: "2026-03-27T10:00:00.000Z",
+      completedAt: "2026-03-27T10:01:00.000Z",
+      initialState: initial,
+      steps: [
+        {
+          index: 1,
+          source: "automated",
+          action: {
+            type: "battle.attack",
+            attackerId: "wolf-d",
+            defenderId: "pikeman-a"
+          }
+        },
+        {
+          index: 2,
+          source: "player",
+          action: {
+            type: "battle.wait",
+            unitId: "pikeman-a"
+          }
+        }
+      ],
+      result: "attacker_victory"
+    }
+  ])[0];
+  assert.ok(replay);
+
+  const playback = createBattleReplayPlaybackState(replay);
+  assert.equal(playback.status, "paused");
+  assert.equal(playback.currentStepIndex, 0);
+  assert.equal(playback.currentStep, null);
+  assert.equal(playback.nextStep?.index, 1);
+  assert.equal(playback.currentState.activeUnitId, initial.activeUnitId);
+
+  const playing = playBattleReplayPlayback(playback);
+  assert.equal(playing.status, "playing");
+
+  const afterTick = tickBattleReplayPlayback(playing);
+  assert.equal(afterTick.status, "playing");
+  assert.equal(afterTick.currentStepIndex, 1);
+  assert.equal(afterTick.currentStep?.index, 1);
+  assert.equal(afterTick.nextStep?.index, 2);
+  assert.equal(afterTick.currentState.activeUnitId, "pikeman-a");
+
+  const paused = pauseBattleReplayPlayback(afterTick);
+  assert.equal(paused.status, "paused");
+
+  const afterManualStep = stepBattleReplayPlayback(paused);
+  assert.equal(afterManualStep.status, "completed");
+  assert.equal(afterManualStep.currentStepIndex, 2);
+  assert.equal(afterManualStep.currentStep?.index, 2);
+  assert.equal(afterManualStep.nextStep, null);
+
+  const replayingCompleted = playBattleReplayPlayback(afterManualStep);
+  assert.equal(replayingCompleted.status, "completed");
+
+  const reset = resetBattleReplayPlayback(afterManualStep);
+  assert.equal(reset.status, "paused");
+  assert.equal(reset.currentStepIndex, 0);
+  assert.equal(reset.currentStep, null);
+  assert.equal(reset.nextStep?.index, 1);
+  assert.equal(reset.currentState.activeUnitId, initial.activeUnitId);
 });
 
 test("typed-array world map payload is materially smaller than the raw tile JSON on a 32x32 map", () => {


### PR DESCRIPTION
## Summary
- add shared battle replay playback state helpers for play, pause, tick, step, and reset controls
- reuse deterministic battle action application so replay steps advance from persisted initial state without UI-specific logic
- cover the playback control flow with focused shared tests

## Testing
- node --import tsx --test ./packages/shared/test/shared-core.test.ts
- npm run typecheck:shared

refs #27