### PR TITLE
feat: add world exploration achievement tracking

### DIFF
--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -71,6 +71,15 @@ test("player account helpers can build a local fallback profile", () => {
         unlocked: false
       },
       {
+        id: "world_explorer",
+        title: "踏勘全境",
+        description: "揭开整张地图的迷雾。",
+        metric: "maps_fully_explored",
+        current: 0,
+        target: 1,
+        unlocked: false
+      },
+      {
         id: "epic_collector",
         title: "史诗武装",
         description: "为同一名英雄装备全套史诗装备。",
@@ -287,7 +296,7 @@ test("player progression loader normalizes summary, achievements, and limited ev
   try {
     const snapshot = await loadPlayerProgressionSnapshot("player-1", 1);
     assert.deepEqual(snapshot.summary, {
-      totalAchievements: 4,
+      totalAchievements: 5,
       unlockedAchievements: 1,
       inProgressAchievements: 0,
       latestProgressAchievementId: "first_battle",

--- a/apps/server/src/player-achievements.ts
+++ b/apps/server/src/player-achievements.ts
@@ -2,6 +2,7 @@ import {
   appendEventLogEntries,
   applyAchievementMetricDelta,
   applyAchievementProgressValue,
+  hasFullyExploredMap,
   formatEquipmentRarityLabel,
   getEquipmentDefinition,
   type AchievementMetric,
@@ -279,6 +280,10 @@ function countBestEpicEquipmentLoadout(state: WorldState, playerId: string): num
     }, 0);
 }
 
+function countFullyExploredMaps(state: WorldState, playerId: string): number {
+  return hasFullyExploredMap(state.visibilityByPlayer[playerId], state.map.tiles.length) ? 1 : 0;
+}
+
 function createAchievementUnlockedEntry(
   state: WorldState,
   playerId: string,
@@ -341,6 +346,18 @@ export function applyPlayerEventLogAndAchievements(
   );
   achievements = epicCollectorResult.progress;
   for (const unlocked of epicCollectorResult.unlocked) {
+    sequence += 1;
+    entries.push(createAchievementUnlockedEntry(state, account.playerId, unlocked, timestamp, sequence));
+  }
+
+  const worldExplorerResult = applyAchievementProgressValue(
+    achievements,
+    "world_explorer",
+    countFullyExploredMaps(state, account.playerId),
+    timestamp
+  );
+  achievements = worldExplorerResult.progress;
+  for (const unlocked of worldExplorerResult.unlocked) {
     sequence += 1;
     entries.push(createAchievementUnlockedEntry(state, account.playerId, unlocked, timestamp, sequence));
   }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -253,6 +253,54 @@ function createEpicEquipmentTrackingWorldState(): WorldState {
   };
 }
 
+function createFullyExploredTrackingWorldState(): WorldState {
+  const base = createAccountTrackingWorldState();
+  return {
+    ...base,
+    map: {
+      width: 2,
+      height: 2,
+      tiles: [
+        {
+          position: { x: 0, y: 0 },
+          terrain: "grass",
+          walkable: true,
+          resource: undefined,
+          occupant: undefined,
+          building: undefined
+        },
+        {
+          position: { x: 1, y: 0 },
+          terrain: "grass",
+          walkable: true,
+          resource: undefined,
+          occupant: undefined,
+          building: undefined
+        },
+        {
+          position: { x: 0, y: 1 },
+          terrain: "grass",
+          walkable: true,
+          resource: undefined,
+          occupant: undefined,
+          building: undefined
+        },
+        {
+          position: { x: 1, y: 1 },
+          terrain: "grass",
+          walkable: true,
+          resource: undefined,
+          occupant: undefined,
+          building: undefined
+        }
+      ]
+    },
+    visibilityByPlayer: {
+      "player-1": ["visible", "explored", "visible", "explored"]
+    }
+  };
+}
+
 function createReplaySummary(id: string, completedAt: string): PlayerBattleReplaySummary {
   return {
     id,
@@ -378,7 +426,7 @@ test("player account routes degrade to local-mode responses when persistence is 
   const publicProgressResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-local/progression`);
   const publicProgressPayload = (await publicProgressResponse.json()) as PlayerProgressionSnapshot;
   assert.equal(publicProgressResponse.status, 200);
-  assert.equal(publicProgressPayload.summary.totalAchievements, 4);
+  assert.equal(publicProgressPayload.summary.totalAchievements, 5);
   assert.equal(publicProgressPayload.summary.unlockedAchievements, 0);
 
   const meResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me`, {
@@ -411,7 +459,7 @@ test("player account routes degrade to local-mode responses when persistence is 
   });
   const meProgressPayload = (await meProgressResponse.json()) as PlayerProgressionSnapshot;
   assert.equal(meProgressResponse.status, 200);
-  assert.equal(meProgressPayload.summary.totalAchievements, 4);
+  assert.equal(meProgressPayload.summary.totalAchievements, 5);
   assert.equal(meProgressPayload.summary.unlockedAchievements, 0);
 });
 
@@ -629,7 +677,7 @@ test("player account progression routes return a compact achievement and event r
   const publicPayload = (await publicResponse.json()) as PlayerProgressionSnapshot;
   assert.equal(publicResponse.status, 200);
   assert.deepEqual(publicPayload.summary, {
-    totalAchievements: 4,
+    totalAchievements: 5,
     unlockedAchievements: 1,
     inProgressAchievements: 1,
     latestProgressAchievementId: "enemy_slayer",
@@ -750,6 +798,29 @@ test("player achievement tracker syncs epic equipment loadout progress from worl
     "2026-03-27T12:10:00.000Z"
   );
   assert.match(updated.recentEventLog[0]?.description ?? "", /解锁成就：史诗武装/);
+});
+
+test("player achievement tracker syncs full map exploration progress from world visibility", () => {
+  const updated = applyPlayerEventLogAndAchievements(
+    {
+      playerId: "player-1",
+      displayName: "暮火侦骑",
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      recentEventLog: []
+    },
+    createFullyExploredTrackingWorldState(),
+    [],
+    "2026-03-27T12:12:00.000Z"
+  );
+
+  assert.equal(updated.achievements.find((achievement) => achievement.id === "world_explorer")?.current, 1);
+  assert.equal(updated.achievements.find((achievement) => achievement.id === "world_explorer")?.unlocked, true);
+  assert.equal(
+    updated.achievements.find((achievement) => achievement.id === "world_explorer")?.progressUpdatedAt,
+    "2026-03-27T12:12:00.000Z"
+  );
+  assert.match(updated.recentEventLog[0]?.description ?? "", /解锁成就：踏勘全境/);
 });
 
 test("player account profile updates by player id require auth and allow self-service only", async (t) => {

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -1,9 +1,14 @@
-import type { WorldEvent } from "./models";
+import type { FogState, WorldEvent } from "./models";
 
 export type EventLogCategory = "movement" | "combat" | "building" | "skill" | "achievement";
 export type EventLogRewardType = "resource" | "experience" | "skill_point" | "badge";
-export type AchievementId = "first_battle" | "enemy_slayer" | "skill_scholar" | "epic_collector";
-export type AchievementMetric = "battles_started" | "battles_won" | "skills_learned" | "epic_equipment_slots";
+export type AchievementId = "first_battle" | "enemy_slayer" | "skill_scholar" | "world_explorer" | "epic_collector";
+export type AchievementMetric =
+  | "battles_started"
+  | "battles_won"
+  | "skills_learned"
+  | "maps_fully_explored"
+  | "epic_equipment_slots";
 
 export interface EventLogReward {
   type: EventLogRewardType;
@@ -127,6 +132,13 @@ const ACHIEVEMENT_DEFINITIONS: AchievementDefinition[] = [
     target: 5
   },
   {
+    id: "world_explorer",
+    metric: "maps_fully_explored",
+    title: "踏勘全境",
+    description: "揭开整张地图的迷雾。",
+    target: 1
+  },
+  {
     id: "epic_collector",
     metric: "epic_equipment_slots",
     title: "史诗武装",
@@ -148,6 +160,19 @@ function normalizeTimestamp(value?: string | null): string | undefined {
 
 export function getAchievementDefinitions(): AchievementDefinition[] {
   return ACHIEVEMENT_DEFINITIONS.map((definition) => ({ ...definition }));
+}
+
+export function countRevealedFogTiles(visibility?: FogState[] | null): number {
+  return (visibility ?? []).filter((fog) => fog === "explored" || fog === "visible").length;
+}
+
+export function hasFullyExploredMap(visibility?: FogState[] | null, tileCount?: number): boolean {
+  const safeTileCount = Math.max(0, Math.floor(tileCount ?? visibility?.length ?? 0));
+  if (safeTileCount <= 0) {
+    return false;
+  }
+
+  return countRevealedFogTiles(visibility) >= safeTileCount;
 }
 
 export function normalizeAchievementProgress(

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -42,6 +42,7 @@ import {
   getDefaultEquipmentCatalog,
   getLatestProgressedAchievement,
   getLatestUnlockedAchievement,
+  hasFullyExploredMap,
   normalizePlayerBattleReplaySummaries,
   pauseBattleReplayPlayback,
   pickAutomatedBattleAction,
@@ -335,6 +336,12 @@ test("achievement helpers can sync progress from an absolute value", () => {
   );
 });
 
+test("exploration helpers detect when a map has been fully revealed", () => {
+  assert.equal(hasFullyExploredMap(["visible", "explored", "hidden"], 3), false);
+  assert.equal(hasFullyExploredMap(["visible", "explored", "visible"], 3), true);
+  assert.equal(hasFullyExploredMap([], 0), false);
+});
+
 test("achievement helpers return the most recently unlocked milestone", () => {
   const progress = [
     {
@@ -498,7 +505,7 @@ test("player progression snapshot summarizes unlocked achievements and recent ev
   );
 
   assert.deepEqual(snapshot.summary, {
-    totalAchievements: 4,
+    totalAchievements: 5,
     unlockedAchievements: 1,
     inProgressAchievements: 1,
     latestProgressAchievementId: "enemy_slayer",


### PR DESCRIPTION
## Summary
- add the missing full-map exploration achievement to the shared progression catalog
- add shared fog-of-war helpers and sync the achievement from server-side world visibility
- cover the new behavior with shared/server tests and update catalog-size expectations

## Testing
- npm run test:shared
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts
- npm run typecheck:shared
- npm run typecheck:client:h5

## Notes
- `npm run typecheck:server` still reports pre-existing `exactOptionalPropertyTypes` errors in `apps/server/src/player-accounts.ts`, which this slice does not modify.

refs #27
