### PR TITLE
Add shared player account read model for event log slices

### DIFF
--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -7,10 +7,10 @@ import {
 } from "./auth-session";
 import {
   normalizePlayerProgressionSnapshot,
-  normalizeAchievementProgress,
+  normalizePlayerAccountReadModel,
   normalizePlayerBattleReplaySummaries,
-  normalizeEventLogEntries,
   type EventLogEntry,
+  type PlayerAccountReadModel,
   type PlayerBattleReplaySummary,
   type PlayerAchievementProgress,
   type PlayerProgressionSnapshot
@@ -19,21 +19,7 @@ import {
 const PLAYER_ACCOUNT_PREFIX = "project-veil:player-account";
 const PLAYER_ACCOUNT_REQUEST_TIMEOUT_MS = 1200;
 
-export interface PlayerAccountProfile {
-  playerId: string;
-  displayName: string;
-  globalResources: {
-    gold: number;
-    wood: number;
-    ore: number;
-  };
-  achievements: PlayerAchievementProgress[];
-  recentEventLog: EventLogEntry[];
-  recentBattleReplays: PlayerBattleReplaySummary[];
-  loginId?: string;
-  credentialBoundAt?: string;
-  lastRoomId?: string;
-  lastSeenAt?: string;
+export interface PlayerAccountProfile extends PlayerAccountReadModel {
   source: "remote" | "local";
 }
 
@@ -78,16 +64,6 @@ function normalizePlayerDisplayName(playerId: string, displayName?: string | nul
 function normalizeLoginId(loginId?: string | null): string | undefined {
   const normalized = loginId?.trim().toLowerCase();
   return normalized ? normalized : undefined;
-}
-
-function normalizeGlobalResources(
-  resources?: NonNullable<PlayerAccountApiPayload["account"]>["globalResources"] | null
-): PlayerAccountProfile["globalResources"] {
-  return {
-    gold: Math.max(0, Math.floor(resources?.gold ?? 0)),
-    wood: Math.max(0, Math.floor(resources?.wood ?? 0)),
-    ore: Math.max(0, Math.floor(resources?.ore ?? 0))
-  };
 }
 
 function getPlayerAccountStorage(): Storage | null {
@@ -146,18 +122,19 @@ function asPlayerAccountProfile(
   account?: PlayerAccountApiPayload["account"],
   fallbackDisplayName?: string | null
 ): PlayerAccountProfile {
-  const loginId = normalizeLoginId(account?.loginId);
   return {
-    playerId,
-    displayName: normalizePlayerDisplayName(playerId, account?.displayName ?? fallbackDisplayName),
-    globalResources: normalizeGlobalResources(account?.globalResources),
-    achievements: normalizeAchievementProgress(account?.achievements),
-    recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
-    recentBattleReplays: normalizePlayerBattleReplaySummaries(account?.recentBattleReplays),
-    ...(loginId ? { loginId } : {}),
-    ...(account?.credentialBoundAt ? { credentialBoundAt: account.credentialBoundAt } : {}),
-    ...(account?.lastRoomId ? { lastRoomId: account.lastRoomId } : roomId ? { lastRoomId: roomId } : {}),
-    ...(account?.lastSeenAt ? { lastSeenAt: account.lastSeenAt } : {}),
+    ...normalizePlayerAccountReadModel({
+      playerId,
+      displayName: normalizePlayerDisplayName(playerId, account?.displayName ?? fallbackDisplayName),
+      globalResources: account?.globalResources,
+      achievements: account?.achievements,
+      recentEventLog: account?.recentEventLog,
+      recentBattleReplays: account?.recentBattleReplays,
+      loginId: normalizeLoginId(account?.loginId),
+      credentialBoundAt: account?.credentialBoundAt,
+      lastRoomId: account?.lastRoomId ?? roomId,
+      lastSeenAt: account?.lastSeenAt
+    }),
     source
   };
 }
@@ -188,13 +165,11 @@ export function createFallbackPlayerAccountProfile(
   displayName?: string | null
 ): PlayerAccountProfile {
   return {
-    playerId,
-    displayName: normalizePlayerDisplayName(playerId, displayName),
-    globalResources: normalizeGlobalResources(),
-    achievements: normalizeAchievementProgress(),
-    recentEventLog: normalizeEventLogEntries(),
-    recentBattleReplays: normalizePlayerBattleReplaySummaries(),
-    ...(roomId ? { lastRoomId: roomId } : {}),
+    ...normalizePlayerAccountReadModel({
+      playerId,
+      displayName: normalizePlayerDisplayName(playerId, displayName),
+      lastRoomId: roomId
+    }),
     source: "local"
   };
 }

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -5,10 +5,9 @@ import {
   writeStoredCocosAuthSession
 } from "./cocos-session-launch.ts";
 import {
-  normalizeAchievementProgress,
-  normalizePlayerBattleReplaySummaries,
-  normalizeEventLogEntries,
+  normalizePlayerAccountReadModel,
   type EventLogEntry,
+  type PlayerAccountReadModel,
   type PlayerBattleReplaySummary,
   type PlayerAchievementProgress
 } from "../../../../packages/shared/src/index.ts";
@@ -33,21 +32,7 @@ export interface CocosLobbyRoomSummary {
   updatedAt: string;
 }
 
-export interface CocosPlayerAccountProfile {
-  playerId: string;
-  displayName: string;
-  globalResources: {
-    gold: number;
-    wood: number;
-    ore: number;
-  };
-  achievements: PlayerAchievementProgress[];
-  recentEventLog: EventLogEntry[];
-  recentBattleReplays: PlayerBattleReplaySummary[];
-  loginId?: string;
-  credentialBoundAt?: string;
-  lastRoomId?: string;
-  lastSeenAt?: string;
+export interface CocosPlayerAccountProfile extends PlayerAccountReadModel {
   source: "remote" | "local";
 }
 
@@ -123,16 +108,6 @@ function normalizeLoginId(value?: string | null): string | undefined {
   return normalized ? normalized : undefined;
 }
 
-function normalizeGlobalResources(
-  resources?: NonNullable<PlayerAccountApiPayload["account"]>["globalResources"] | null
-): CocosPlayerAccountProfile["globalResources"] {
-  return {
-    gold: Math.max(0, Math.floor(resources?.gold ?? 0)),
-    wood: Math.max(0, Math.floor(resources?.wood ?? 0)),
-    ore: Math.max(0, Math.floor(resources?.ore ?? 0))
-  };
-}
-
 function readStoredLobbyPreferencesUnsafe(storage: Pick<Storage, "getItem">): Partial<CocosLobbyPreferences> | null {
   const raw = storage.getItem(LOBBY_PREFERENCES_STORAGE_KEY);
   if (!raw) {
@@ -176,18 +151,19 @@ function asCocosPlayerAccountProfile(
   account?: PlayerAccountApiPayload["account"],
   fallbackDisplayName?: string | null
 ): CocosPlayerAccountProfile {
-  const loginId = normalizeLoginId(account?.loginId);
   return {
-    playerId,
-    displayName: normalizeDisplayName(playerId, account?.displayName ?? fallbackDisplayName),
-    globalResources: normalizeGlobalResources(account?.globalResources),
-    achievements: normalizeAchievementProgress(account?.achievements),
-    recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
-    recentBattleReplays: normalizePlayerBattleReplaySummaries(account?.recentBattleReplays),
-    ...(loginId ? { loginId } : {}),
-    ...(account?.credentialBoundAt ? { credentialBoundAt: account.credentialBoundAt } : {}),
-    ...(account?.lastRoomId ? { lastRoomId: account.lastRoomId } : roomId ? { lastRoomId: roomId } : {}),
-    ...(account?.lastSeenAt ? { lastSeenAt: account.lastSeenAt } : {}),
+    ...normalizePlayerAccountReadModel({
+      playerId,
+      displayName: normalizeDisplayName(playerId, account?.displayName ?? fallbackDisplayName),
+      globalResources: account?.globalResources,
+      achievements: account?.achievements,
+      recentEventLog: account?.recentEventLog,
+      recentBattleReplays: account?.recentBattleReplays,
+      loginId: normalizeLoginId(account?.loginId),
+      credentialBoundAt: account?.credentialBoundAt,
+      lastRoomId: account?.lastRoomId ?? roomId,
+      lastSeenAt: account?.lastSeenAt
+    }),
     source
   };
 }
@@ -277,13 +253,11 @@ export function createFallbackCocosPlayerAccountProfile(
   displayName?: string | null
 ): CocosPlayerAccountProfile {
   return {
-    playerId,
-    displayName: normalizeDisplayName(playerId, displayName),
-    globalResources: normalizeGlobalResources(),
-    achievements: normalizeAchievementProgress(),
-    recentEventLog: normalizeEventLogEntries(),
-    recentBattleReplays: normalizePlayerBattleReplaySummaries(),
-    ...(roomId ? { lastRoomId: roomId } : {}),
+    ...normalizePlayerAccountReadModel({
+      playerId,
+      displayName: normalizeDisplayName(playerId, displayName),
+      lastRoomId: roomId
+    }),
     source: "local"
   };
 }

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -315,6 +315,15 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         unlocked: false
       },
       {
+        id: "world_explorer",
+        title: "踏勘全境",
+        description: "揭开整张地图的迷雾。",
+        metric: "maps_fully_explored",
+        current: 0,
+        target: 1,
+        unlocked: false
+      },
+      {
         id: "epic_collector",
         title: "史诗武装",
         description: "为同一名英雄装备全套史诗装备。",

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -3,9 +3,11 @@ import {
   appendPlayerBattleReplaySummaries,
   normalizeAchievementProgress,
   normalizeEventLogEntries,
+  normalizePlayerAccountReadModel,
   normalizeHeroState,
   type EventLogEntry,
   type HeroState,
+  type PlayerAccountReadModel,
   type PlayerBattleReplaySummary,
   type PlayerAchievementProgress,
   type ResourceLedger,
@@ -132,17 +134,8 @@ export interface PlayerRoomProfileSnapshot {
   resources: ResourceLedger;
 }
 
-export interface PlayerAccountSnapshot {
-  playerId: string;
-  displayName: string;
-  globalResources: ResourceLedger;
-  achievements: PlayerAchievementProgress[];
-  recentEventLog: EventLogEntry[];
+export interface PlayerAccountSnapshot extends PlayerAccountReadModel {
   recentBattleReplays?: PlayerBattleReplaySummary[];
-  lastRoomId?: string;
-  lastSeenAt?: string;
-  loginId?: string;
-  credentialBoundAt?: string;
   createdAt?: string;
   updatedAt?: string;
 }
@@ -333,16 +326,18 @@ function normalizePlayerAccountSnapshot(account: {
   const playerId = normalizePlayerId(account.playerId);
 
   return {
-    playerId,
-    displayName: normalizePlayerDisplayName(playerId, account.displayName),
-    globalResources: normalizeResourceLedger(account.globalResources),
-    achievements: normalizeAchievementProgress(account.achievements),
-    recentEventLog: normalizeEventLogEntries(account.recentEventLog),
-    recentBattleReplays: appendPlayerBattleReplaySummaries([], account.recentBattleReplays),
-    ...(account.lastRoomId ? { lastRoomId: account.lastRoomId } : {}),
-    ...(account.lastSeenAt ? { lastSeenAt: account.lastSeenAt } : {}),
-    ...(account.loginId ? { loginId: normalizePlayerLoginId(account.loginId) } : {}),
-    ...(account.credentialBoundAt ? { credentialBoundAt: account.credentialBoundAt } : {}),
+    ...normalizePlayerAccountReadModel({
+      playerId,
+      displayName: normalizePlayerDisplayName(playerId, account.displayName),
+      globalResources: normalizeResourceLedger(account.globalResources),
+      achievements: account.achievements,
+      recentEventLog: account.recentEventLog,
+      recentBattleReplays: appendPlayerBattleReplaySummaries([], account.recentBattleReplays),
+      lastRoomId: account.lastRoomId,
+      lastSeenAt: account.lastSeenAt,
+      loginId: account.loginId ? normalizePlayerLoginId(account.loginId) : undefined,
+      credentialBoundAt: account.credentialBoundAt
+    }),
     ...(account.createdAt ? { createdAt: account.createdAt } : {}),
     ...(account.updatedAt ? { updatedAt: account.updatedAt } : {})
   };
@@ -379,12 +374,11 @@ export function createPlayerRoomProfiles(state: WorldState): PlayerRoomProfileSn
 
 export function createPlayerAccountsFromWorldState(state: WorldState): PlayerAccountSnapshot[] {
   return collectPlayerIds(state).map((playerId) => ({
-    playerId,
-    displayName: normalizePlayerDisplayName(playerId),
-    globalResources: normalizeResourceLedger(state.resources[playerId]),
-    achievements: normalizeAchievementProgress(),
-    recentEventLog: normalizeEventLogEntries(),
-    recentBattleReplays: appendPlayerBattleReplaySummaries([], [])
+    ...normalizePlayerAccountReadModel({
+      playerId,
+      displayName: normalizePlayerDisplayName(playerId),
+      globalResources: normalizeResourceLedger(state.resources[playerId])
+    })
   }));
 }
 

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -92,17 +92,25 @@ function toEventLogResponse(
   account: PlayerAccountSnapshot,
   request: IncomingMessage
 ): { items: PlayerAccountSnapshot["recentEventLog"] } {
+  const limit = parseLimit(request);
+  const category = parseOptionalQueryParam(request, "category") as
+    | PlayerAccountSnapshot["recentEventLog"][number]["category"]
+    | undefined;
+  const heroId = parseOptionalQueryParam(request, "heroId");
+  const achievementId = parseOptionalQueryParam(request, "achievementId") as
+    | PlayerAccountSnapshot["recentEventLog"][number]["achievementId"]
+    | undefined;
+  const worldEventType = parseOptionalQueryParam(request, "worldEventType") as
+    | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
+    | undefined;
+
   return {
     items: queryEventLogEntries(account.recentEventLog, {
-      limit: parseLimit(request),
-      category: parseOptionalQueryParam(request, "category") as PlayerAccountSnapshot["recentEventLog"][number]["category"] | undefined,
-      heroId: parseOptionalQueryParam(request, "heroId"),
-      achievementId: parseOptionalQueryParam(request, "achievementId") as
-        | PlayerAccountSnapshot["recentEventLog"][number]["achievementId"]
-        | undefined,
-      worldEventType: parseOptionalQueryParam(request, "worldEventType") as
-        | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
-        | undefined
+      ...(limit != null ? { limit } : {}),
+      ...(category ? { category } : {}),
+      ...(heroId ? { heroId } : {}),
+      ...(achievementId ? { achievementId } : {}),
+      ...(worldEventType ? { worldEventType } : {})
     })
   };
 }
@@ -130,11 +138,11 @@ function normalizeLoginId(loginId?: string | null): string | undefined {
 }
 
 function createLocalModeAccount(input: {
-  playerId?: string | null;
-  displayName?: string | null;
-  lastRoomId?: string | null;
-  loginId?: string | null;
-  credentialBoundAt?: string | null;
+  playerId?: string | null | undefined;
+  displayName?: string | null | undefined;
+  lastRoomId?: string | null | undefined;
+  loginId?: string | null | undefined;
+  credentialBoundAt?: string | null | undefined;
 }): PlayerAccountSnapshot {
   const playerId = normalizePlayerId(input.playerId);
   const displayName = normalizeDisplayName(playerId, input.displayName);

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -30,11 +30,11 @@ export interface EventLogEntry {
 }
 
 export interface EventLogQuery {
-  limit?: number;
-  category?: EventLogCategory;
-  heroId?: string;
-  achievementId?: AchievementId;
-  worldEventType?: WorldEvent["type"];
+  limit?: number | undefined;
+  category?: EventLogCategory | undefined;
+  heroId?: string | undefined;
+  achievementId?: AchievementId | undefined;
+  worldEventType?: WorldEvent["type"] | undefined;
 }
 
 export interface AchievementDefinition {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,4 +9,5 @@ export * from "./map";
 export * from "./map-sync";
 export * from "./models";
 export * from "./protocol";
+export * from "./player-account";
 export * from "./world-config";

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -1,0 +1,62 @@
+import {
+  normalizeEventLogEntries,
+  normalizeAchievementProgress,
+  type EventLogEntry,
+  type PlayerAchievementProgress
+} from "./event-log";
+import { normalizePlayerBattleReplaySummaries, type PlayerBattleReplaySummary } from "./battle-replay";
+import type { ResourceLedger } from "./models";
+
+export interface PlayerAccountReadModel {
+  playerId: string;
+  displayName: string;
+  globalResources: ResourceLedger;
+  achievements: PlayerAchievementProgress[];
+  recentEventLog: EventLogEntry[];
+  recentBattleReplays?: PlayerBattleReplaySummary[];
+  loginId?: string;
+  credentialBoundAt?: string;
+  lastRoomId?: string;
+  lastSeenAt?: string;
+}
+
+export interface PlayerAccountReadModelInput {
+  playerId?: string | undefined;
+  displayName?: string | undefined;
+  globalResources?: Partial<ResourceLedger> | null | undefined;
+  achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
+  recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
+  recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
+  loginId?: string | undefined;
+  credentialBoundAt?: string | undefined;
+  lastRoomId?: string | undefined;
+  lastSeenAt?: string | undefined;
+}
+
+export function normalizePlayerAccountReadModel(
+  account?: PlayerAccountReadModelInput | null
+): PlayerAccountReadModel {
+  const playerId = account?.playerId?.trim() ?? "";
+  const displayName = account?.displayName?.trim() ?? "";
+  const loginId = account?.loginId?.trim().toLowerCase();
+  const credentialBoundAt = account?.credentialBoundAt?.trim();
+  const lastRoomId = account?.lastRoomId?.trim();
+  const lastSeenAt = account?.lastSeenAt?.trim();
+
+  return {
+    playerId,
+    displayName: displayName || playerId || "player",
+    globalResources: {
+      gold: Math.max(0, Math.floor(account?.globalResources?.gold ?? 0)),
+      wood: Math.max(0, Math.floor(account?.globalResources?.wood ?? 0)),
+      ore: Math.max(0, Math.floor(account?.globalResources?.ore ?? 0))
+    },
+    achievements: normalizeAchievementProgress(account?.achievements),
+    recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
+    recentBattleReplays: normalizePlayerBattleReplaySummaries(account?.recentBattleReplays),
+    ...(loginId ? { loginId } : {}),
+    ...(credentialBoundAt ? { credentialBoundAt } : {}),
+    ...(lastRoomId ? { lastRoomId } : {}),
+    ...(lastSeenAt ? { lastSeenAt } : {})
+  };
+}

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -43,6 +43,7 @@ import {
   getLatestProgressedAchievement,
   getLatestUnlockedAchievement,
   hasFullyExploredMap,
+  normalizePlayerAccountReadModel,
   normalizePlayerBattleReplaySummaries,
   pauseBattleReplayPlayback,
   pickAutomatedBattleAction,
@@ -520,6 +521,95 @@ test("player progression snapshot summarizes unlocked achievements and recent ev
   assert.deepEqual(snapshot.recentEventLog.map((entry) => entry.id), ["event-newer"]);
   assert.equal(snapshot.achievements[1]?.id, "enemy_slayer");
   assert.equal(snapshot.achievements[1]?.current, 2);
+});
+
+test("player account read model helper normalizes progression, replays, and resource fields together", () => {
+  const account = normalizePlayerAccountReadModel({
+    playerId: " player-1 ",
+    displayName: "  ",
+    globalResources: {
+      gold: 12.9,
+      wood: -3,
+      ore: 4.1
+    },
+    achievements: [
+      {
+        id: "first_battle",
+        current: 1,
+        unlockedAt: "2026-03-27T12:00:00.000Z"
+      }
+    ],
+    recentEventLog: [
+      {
+        id: "event-older",
+        timestamp: "2026-03-27T11:59:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        category: "combat",
+        description: "older",
+        rewards: []
+      },
+      {
+        id: "event-newer",
+        timestamp: "2026-03-27T12:01:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        category: "achievement",
+        description: "newer",
+        achievementId: "first_battle",
+        rewards: []
+      }
+    ],
+    recentBattleReplays: [
+      {
+        id: "replay-1",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        battleId: "battle-1",
+        battleKind: "neutral",
+        playerCamp: "attacker",
+        heroId: "hero-1",
+        startedAt: "2026-03-27T11:58:00.000Z",
+        completedAt: "2026-03-27T12:02:00.000Z",
+        initialState: createEmptyBattleState({
+          id: "battle-1",
+          attackerHeroId: "hero-1",
+          defenderHeroId: "neutral-1"
+        }),
+        steps: [],
+        result: "attacker_victory"
+      }
+    ],
+    loginId: "  CAPTAIN ",
+    lastRoomId: " room-alpha "
+  });
+
+  assert.equal(account.playerId, "player-1");
+  assert.equal(account.displayName, "player-1");
+  assert.deepEqual(account.globalResources, {
+    gold: 12,
+    wood: 0,
+    ore: 4
+  });
+  assert.equal(account.achievements.find((achievement) => achievement.id === "first_battle")?.unlocked, true);
+  assert.deepEqual(account.recentEventLog.map((entry) => entry.id), ["event-newer", "event-older"]);
+  assert.deepEqual(account.recentBattleReplays.map((replay) => replay.id), ["replay-1"]);
+  assert.equal(account.loginId, "captain");
+  assert.equal(account.lastRoomId, "room-alpha");
+});
+
+test("player account read model helper falls back to empty progression collections", () => {
+  const account = normalizePlayerAccountReadModel();
+
+  assert.equal(account.displayName, "player");
+  assert.equal(account.achievements.length, getAchievementDefinitions().length);
+  assert.deepEqual(account.recentEventLog, []);
+  assert.deepEqual(account.recentBattleReplays, []);
+  assert.deepEqual(account.globalResources, {
+    gold: 0,
+    wood: 0,
+    ore: 0
+  });
 });
 
 test("battle replay helpers normalize steps and keep newest unique replays first", () => {


### PR DESCRIPTION
## Summary
- add a shared player-account read model and normalizer in `packages/shared`
- reuse that shared model in H5, Cocos, and server account/event-log code paths
- add focused shared and Cocos coverage for normalized achievement/event-log/account payloads

## Testing
- npm run test:shared
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:client:h5
- npm run typecheck:cocos
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts
- node --import tsx --test ./apps/cocos-client/test/cocos-lobby.test.ts
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts

refs #27