### PR TITLE
Add client event-log query loader

### DIFF
--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -9,6 +9,8 @@ import {
   normalizePlayerProgressionSnapshot,
   normalizePlayerAccountReadModel,
   normalizePlayerBattleReplaySummaries,
+  normalizeEventLogEntries,
+  type EventLogQuery,
   type EventLogEntry,
   type PlayerAccountReadModel,
   type PlayerBattleReplaySummary,
@@ -53,6 +55,10 @@ interface PlayerBattleReplayListApiPayload {
   items?: Partial<PlayerBattleReplaySummary>[];
 }
 
+interface PlayerEventLogListApiPayload {
+  items?: Partial<EventLogEntry>[];
+}
+
 interface PlayerProgressionApiPayload extends Partial<PlayerProgressionSnapshot> {}
 
 function normalizePlayerDisplayName(playerId: string, displayName?: string | null): string {
@@ -77,6 +83,32 @@ function getPlayerAccountStorage(): Storage | null {
 function resolvePlayerAccountApiBaseUrl(): string {
   const httpProtocol = window.location.protocol === "https:" ? "https" : "http";
   return `${httpProtocol}://${window.location.hostname || "127.0.0.1"}:2567`;
+}
+
+function toEventLogQueryString(query?: EventLogQuery): string {
+  if (!query) {
+    return "";
+  }
+
+  const searchParams = new URLSearchParams();
+  if (query.limit != null) {
+    searchParams.set("limit", String(query.limit));
+  }
+  if (query.category) {
+    searchParams.set("category", query.category);
+  }
+  if (query.heroId) {
+    searchParams.set("heroId", query.heroId);
+  }
+  if (query.achievementId) {
+    searchParams.set("achievementId", query.achievementId);
+  }
+  if (query.worldEventType) {
+    searchParams.set("worldEventType", query.worldEventType);
+  }
+
+  const serialized = searchParams.toString();
+  return serialized ? `?${serialized}` : "";
 }
 
 async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
@@ -237,6 +269,26 @@ export async function loadPlayerBattleReplaySummaries(playerId: string): Promise
       clearCurrentAuthSession();
     }
     return normalizePlayerBattleReplaySummaries();
+  }
+}
+
+export async function loadPlayerEventLog(playerId: string, query?: EventLogQuery): Promise<EventLogEntry[]> {
+  const authSession = readStoredAuthSession();
+  const queryString = toEventLogQueryString(query);
+  const endpoint = authSession?.token
+    ? `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/event-log${queryString}`
+    : `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/${encodeURIComponent(playerId)}/event-log${queryString}`;
+
+  try {
+    const payload = (await fetchJson(endpoint, {
+      ...(authSession?.token ? { headers: buildAuthHeaders(authSession.token) } : {})
+    })) as PlayerEventLogListApiPayload;
+    return normalizeEventLogEntries(payload.items);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message === "player_account_request_failed:401") {
+      clearCurrentAuthSession();
+    }
+    return normalizeEventLogEntries();
   }
 }
 

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -4,6 +4,7 @@ import {
   createFallbackPlayerAccountProfile,
   getPlayerAccountStorageKey,
   loadPlayerBattleReplaySummaries,
+  loadPlayerEventLog,
   loadPlayerProgressionSnapshot,
   readStoredPlayerDisplayName,
   writeStoredPlayerDisplayName
@@ -219,6 +220,149 @@ test("player replay loader normalizes remote replay summaries and keeps newest f
   try {
     const replays = await loadPlayerBattleReplaySummaries("player-1");
     assert.deepEqual(replays.map((replay) => replay.id), ["replay-newer", "replay-older"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("player event-log loader sends shared filters and normalizes newest entries first", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  let requestedUrl = "";
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(): string | null {
+          return null;
+        },
+        setItem(): void {}
+      }
+    }
+  });
+
+  globalThis.fetch = (async (input) => {
+    requestedUrl = String(input);
+    return new Response(
+      JSON.stringify({
+        items: [
+          {
+            id: "event-older",
+            timestamp: "2026-03-27T12:01:00.000Z",
+            roomId: "room-alpha",
+            playerId: "player-1",
+            category: "achievement",
+            description: "older",
+            heroId: "hero-1",
+            achievementId: "first_battle",
+            worldEventType: "battle.started",
+            rewards: []
+          },
+          {
+            id: "event-newer",
+            timestamp: "2026-03-27T12:03:00.000Z",
+            roomId: "room-alpha",
+            playerId: "player-1",
+            category: "achievement",
+            description: "newer",
+            heroId: "hero-1",
+            achievementId: "first_battle",
+            worldEventType: "battle.started",
+            rewards: [{ type: "badge", label: "初次交锋" }]
+          }
+        ]
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+  }) as typeof fetch;
+
+  try {
+    const items = await loadPlayerEventLog("player-1", {
+      limit: 1,
+      category: "achievement",
+      heroId: "hero-1",
+      achievementId: "first_battle",
+      worldEventType: "battle.started"
+    });
+
+    assert.equal(
+      requestedUrl,
+      "http://127.0.0.1:2567/api/player-accounts/player-1/event-log?limit=1&category=achievement&heroId=hero-1&achievementId=first_battle&worldEventType=battle.started"
+    );
+    assert.deepEqual(items.map((entry) => entry.id), ["event-newer", "event-older"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("player event-log loader clears expired auth session and falls back to empty items", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  const localStorageValues = new Map<string, string>([
+    [
+      "project-veil:auth-session",
+      JSON.stringify({
+        playerId: "player-1",
+        displayName: "雾林司灯",
+        authMode: "guest",
+        token: "session-token",
+        source: "remote"
+      })
+    ]
+  ]);
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(key: string): string | null {
+          return localStorageValues.get(key) ?? null;
+        },
+        setItem(key: string, value: string): void {
+          localStorageValues.set(key, value);
+        },
+        removeItem(key: string): void {
+          localStorageValues.delete(key);
+        }
+      }
+    }
+  });
+
+  globalThis.fetch = (async () => new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 })) as typeof fetch;
+
+  try {
+    const items = await loadPlayerEventLog("player-1", {
+      category: "achievement"
+    });
+
+    assert.deepEqual(items, []);
+    assert.equal(localStorageValues.has("project-veil:auth-session"), false);
   } finally {
     Object.defineProperty(globalThis, "window", {
       configurable: true,


### PR DESCRIPTION
## Summary
- add a client-side event log loader that targets the existing player account event-log routes
- serialize shared event-log query filters so web client reads can request narrow slices without fetching progression payloads
- cover query serialization, normalization ordering, and auth-expiry fallback in client tests

## Testing
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts
- npm run typecheck:client:h5

refs #27