### PR TITLE
feat: add achievement progress query api

### DIFF
--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -6,9 +6,11 @@ import {
   type StoredAuthSession
 } from "./auth-session";
 import {
+  type AchievementProgressQuery,
   normalizePlayerProgressionSnapshot,
   normalizePlayerAccountReadModel,
   normalizePlayerBattleReplaySummaries,
+  queryAchievementProgress,
   normalizeEventLogEntries,
   type EventLogQuery,
   type EventLogEntry,
@@ -59,6 +61,10 @@ interface PlayerEventLogListApiPayload {
   items?: Partial<EventLogEntry>[];
 }
 
+interface PlayerAchievementListApiPayload {
+  items?: Partial<PlayerAchievementProgress>[];
+}
+
 interface PlayerProgressionApiPayload extends Partial<PlayerProgressionSnapshot> {}
 
 function normalizePlayerDisplayName(playerId: string, displayName?: string | null): string {
@@ -105,6 +111,29 @@ function toEventLogQueryString(query?: EventLogQuery): string {
   }
   if (query.worldEventType) {
     searchParams.set("worldEventType", query.worldEventType);
+  }
+
+  const serialized = searchParams.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+function toAchievementQueryString(query?: AchievementProgressQuery): string {
+  if (!query) {
+    return "";
+  }
+
+  const searchParams = new URLSearchParams();
+  if (query.limit != null) {
+    searchParams.set("limit", String(query.limit));
+  }
+  if (query.achievementId) {
+    searchParams.set("achievementId", query.achievementId);
+  }
+  if (query.metric) {
+    searchParams.set("metric", query.metric);
+  }
+  if (query.unlocked != null) {
+    searchParams.set("unlocked", String(query.unlocked));
   }
 
   const serialized = searchParams.toString();
@@ -289,6 +318,29 @@ export async function loadPlayerEventLog(playerId: string, query?: EventLogQuery
       clearCurrentAuthSession();
     }
     return normalizeEventLogEntries();
+  }
+}
+
+export async function loadPlayerAchievementProgress(
+  playerId: string,
+  query?: AchievementProgressQuery
+): Promise<PlayerAchievementProgress[]> {
+  const authSession = readStoredAuthSession();
+  const queryString = toAchievementQueryString(query);
+  const endpoint = authSession?.token
+    ? `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/achievements${queryString}`
+    : `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/${encodeURIComponent(playerId)}/achievements${queryString}`;
+
+  try {
+    const payload = (await fetchJson(endpoint, {
+      ...(authSession?.token ? { headers: buildAuthHeaders(authSession.token) } : {})
+    })) as PlayerAchievementListApiPayload;
+    return queryAchievementProgress(payload.items, query);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message === "player_account_request_failed:401") {
+      clearCurrentAuthSession();
+    }
+    return queryAchievementProgress(undefined, query);
   }
 }
 

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   createFallbackPlayerAccountProfile,
   getPlayerAccountStorageKey,
+  loadPlayerAchievementProgress,
   loadPlayerBattleReplaySummaries,
   loadPlayerEventLog,
   loadPlayerProgressionSnapshot,
@@ -359,6 +360,131 @@ test("player event-log loader clears expired auth session and falls back to empt
   try {
     const items = await loadPlayerEventLog("player-1", {
       category: "achievement"
+    });
+
+    assert.deepEqual(items, []);
+    assert.equal(localStorageValues.has("project-veil:auth-session"), false);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("player achievement loader sends shared filters and normalizes definition-backed progress", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  let requestedUrl = "";
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(): string | null {
+          return null;
+        },
+        setItem(): void {}
+      }
+    }
+  });
+
+  globalThis.fetch = (async (input) => {
+    requestedUrl = String(input);
+    return new Response(
+      JSON.stringify({
+        items: [
+          {
+            id: "enemy_slayer",
+            current: 2,
+            progressUpdatedAt: "2026-03-27T12:02:00.000Z"
+          }
+        ]
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+  }) as typeof fetch;
+
+  try {
+    const items = await loadPlayerAchievementProgress("player-1", {
+      limit: 1,
+      achievementId: "enemy_slayer",
+      metric: "battles_won",
+      unlocked: false
+    });
+
+    assert.equal(
+      requestedUrl,
+      "http://127.0.0.1:2567/api/player-accounts/player-1/achievements?limit=1&achievementId=enemy_slayer&metric=battles_won&unlocked=false"
+    );
+    assert.deepEqual(items.map((entry) => entry.id), ["enemy_slayer"]);
+    assert.equal(items[0]?.title, "猎敌者");
+    assert.equal(items[0]?.current, 2);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("player achievement loader clears expired auth session and falls back to normalized filtered defaults", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  const localStorageValues = new Map<string, string>([
+    [
+      "project-veil:auth-session",
+      JSON.stringify({
+        playerId: "player-1",
+        displayName: "雾林司灯",
+        authMode: "guest",
+        token: "session-token",
+        source: "remote"
+      })
+    ]
+  ]);
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(key: string): string | null {
+          return localStorageValues.get(key) ?? null;
+        },
+        setItem(key: string, value: string): void {
+          localStorageValues.set(key, value);
+        },
+        removeItem(key: string): void {
+          localStorageValues.delete(key);
+        }
+      }
+    }
+  });
+
+  globalThis.fetch = (async () => new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 })) as typeof fetch;
+
+  try {
+    const items = await loadPlayerAchievementProgress("player-1", {
+      unlocked: true
     });
 
     assert.deepEqual(items, []);

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   buildPlayerProgressionSnapshot,
+  queryAchievementProgress,
   queryEventLogEntries,
   normalizePlayerBattleReplaySummaries
 } from "../../../packages/shared/src/index";
@@ -80,6 +81,17 @@ function parseOptionalQueryParam(request: IncomingMessage, key: string): string 
   return value ? value : undefined;
 }
 
+function parseBooleanQueryParam(request: IncomingMessage, key: string): boolean | undefined {
+  const value = parseOptionalQueryParam(request, key)?.toLowerCase();
+  if (value === "true") {
+    return true;
+  }
+  if (value === "false") {
+    return false;
+  }
+  return undefined;
+}
+
 function toReplayResponse(account: PlayerAccountSnapshot, limit?: number): { items: PlayerAccountSnapshot["recentBattleReplays"] } {
   const items = normalizePlayerBattleReplaySummaries(account.recentBattleReplays);
   const safeLimit = limit == null ? undefined : Math.max(1, Math.floor(limit));
@@ -111,6 +123,26 @@ function toEventLogResponse(
       ...(heroId ? { heroId } : {}),
       ...(achievementId ? { achievementId } : {}),
       ...(worldEventType ? { worldEventType } : {})
+    })
+  };
+}
+
+function toAchievementResponse(account: PlayerAccountSnapshot, request: IncomingMessage): { items: PlayerAccountSnapshot["achievements"] } {
+  const limit = parseLimit(request);
+  const achievementId = parseOptionalQueryParam(request, "achievementId") as
+    | PlayerAccountSnapshot["achievements"][number]["id"]
+    | undefined;
+  const metric = parseOptionalQueryParam(request, "metric") as
+    | PlayerAccountSnapshot["achievements"][number]["metric"]
+    | undefined;
+  const unlocked = parseBooleanQueryParam(request, "unlocked");
+
+  return {
+    items: queryAchievementProgress(account.achievements, {
+      ...(limit != null ? { limit } : {}),
+      ...(achievementId ? { achievementId } : {}),
+      ...(metric ? { metric } : {}),
+      ...(unlocked != null ? { unlocked } : {})
     })
   };
 }
@@ -333,6 +365,42 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.get("/api/player-accounts/me/achievements", async (request, response) => {
+    const authSession = resolveAuthSessionFromRequest(request);
+    if (!authSession) {
+      sendUnauthorized(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(
+        response,
+        200,
+        toAchievementResponse(
+          createLocalModeAccount({
+            playerId: authSession.playerId,
+            displayName: authSession.displayName,
+            loginId: authSession.loginId
+          }),
+          request
+        )
+      );
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      sendJson(response, 200, toAchievementResponse(account, request));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
   app.get("/api/player-accounts/me/progression", async (request, response) => {
     const authSession = resolveAuthSessionFromRequest(request);
     if (!authSession) {
@@ -471,6 +539,45 @@ export function registerPlayerAccountRoutes(
       }
 
       sendJson(response, 200, toEventLogResponse(account, request));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/:playerId/achievements", async (request, response) => {
+    const playerId = request.params.playerId?.trim();
+    if (!playerId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(
+        response,
+        200,
+        toAchievementResponse(
+          createLocalModeAccount({
+            playerId
+          }),
+          request
+        )
+      );
+      return;
+    }
+
+    try {
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_account_not_found",
+            message: `Player account not found: ${playerId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, toAchievementResponse(account, request));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -19,6 +19,7 @@ import type { RoomPersistenceSnapshot } from "../src/index";
 import {
   createDefaultHeroLoadout,
   createDefaultHeroProgression,
+  type PlayerAchievementProgress,
   type PlayerProgressionSnapshot,
   type PlayerBattleReplaySummary,
   type WorldState
@@ -423,6 +424,12 @@ test("player account routes degrade to local-mode responses when persistence is 
   assert.equal(publicReplayResponse.status, 200);
   assert.deepEqual(publicReplayPayload.items, []);
 
+  const publicAchievementResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-local/achievements`);
+  const publicAchievementPayload = (await publicAchievementResponse.json()) as { items: PlayerAchievementProgress[] };
+  assert.equal(publicAchievementResponse.status, 200);
+  assert.equal(publicAchievementPayload.items.length, 5);
+  assert.equal(publicAchievementPayload.items[0]?.id, "first_battle");
+
   const publicProgressResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-local/progression`);
   const publicProgressPayload = (await publicProgressResponse.json()) as PlayerProgressionSnapshot;
   assert.equal(publicProgressResponse.status, 200);
@@ -451,6 +458,15 @@ test("player account routes degrade to local-mode responses when persistence is 
   const meReplayPayload = (await meReplayResponse.json()) as { items: PlayerBattleReplaySummary[] };
   assert.equal(meReplayResponse.status, 200);
   assert.deepEqual(meReplayPayload.items, []);
+
+  const meAchievementResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/achievements?unlocked=false&limit=2`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const meAchievementPayload = (await meAchievementResponse.json()) as { items: PlayerAchievementProgress[] };
+  assert.equal(meAchievementResponse.status, 200);
+  assert.deepEqual(meAchievementPayload.items.map((entry) => entry.id), ["first_battle", "enemy_slayer"]);
 
   const meProgressResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/progression`, {
     headers: {
@@ -608,6 +624,76 @@ test("player account event-log routes filter recent entries without loading prog
   const mePayload = (await meResponse.json()) as { items: PlayerAccountSnapshot["recentEventLog"] };
   assert.equal(meResponse.status, 200);
   assert.deepEqual(mePayload.items.map((entry) => entry.id), ["event-achievement"]);
+});
+
+test("player account achievement routes filter normalized progress without loading event history", async (t) => {
+  const port = 42072 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-achievements",
+    displayName: "星冠检阅官",
+    globalResources: { gold: 22, wood: 7, ore: 1 },
+    achievements: [
+      {
+        id: "first_battle",
+        current: 1,
+        unlockedAt: "2026-03-27T12:00:00.000Z"
+      },
+      {
+        id: "enemy_slayer",
+        current: 2,
+        progressUpdatedAt: "2026-03-27T12:02:00.000Z"
+      },
+      {
+        id: "skill_scholar",
+        current: 5,
+        unlockedAt: "2026-03-27T12:03:00.000Z"
+      }
+    ],
+    recentEventLog: [
+      {
+        id: "event-achievement",
+        timestamp: "2026-03-27T12:03:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-achievements",
+        category: "achievement",
+        description: "achievement",
+        rewards: []
+      }
+    ],
+    recentBattleReplays: [],
+    lastRoomId: "room-alpha",
+    lastSeenAt: new Date("2026-03-27T12:04:00.000Z").toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-achievements",
+    displayName: "星冠检阅官"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const publicResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-achievements/achievements?unlocked=true&metric=skills_learned`
+  );
+  const publicPayload = (await publicResponse.json()) as { items: PlayerAchievementProgress[] };
+  assert.equal(publicResponse.status, 200);
+  assert.deepEqual(publicPayload.items.map((entry) => entry.id), ["skill_scholar"]);
+
+  const meResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/achievements?achievementId=enemy_slayer`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const mePayload = (await meResponse.json()) as { items: PlayerAchievementProgress[] };
+  assert.equal(meResponse.status, 200);
+  assert.deepEqual(mePayload.items.map((entry) => entry.id), ["enemy_slayer"]);
+  assert.equal(mePayload.items[0]?.title, "猎敌者");
 });
 
 test("player account progression routes return a compact achievement and event read model", async (t) => {

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -57,6 +57,13 @@ export interface PlayerAchievementProgress {
   unlockedAt?: string;
 }
 
+export interface AchievementProgressQuery {
+  limit?: number | undefined;
+  achievementId?: AchievementId | undefined;
+  metric?: AchievementMetric | undefined;
+  unlocked?: boolean | undefined;
+}
+
 export interface PlayerProgressionSummary {
   totalAchievements: number;
   unlockedAchievements: number;
@@ -323,6 +330,19 @@ export function applyAchievementProgressValue(
     progress: nextProgress,
     unlocked
   };
+}
+
+export function queryAchievementProgress(
+  progress?: Partial<PlayerAchievementProgress>[] | null,
+  query: AchievementProgressQuery = {}
+): PlayerAchievementProgress[] {
+  const safeLimit = query.limit == null ? undefined : Math.max(1, Math.floor(query.limit));
+
+  return normalizeAchievementProgress(progress)
+    .filter((entry) => (query.achievementId ? entry.id === query.achievementId : true))
+    .filter((entry) => (query.metric ? entry.metric === query.metric : true))
+    .filter((entry) => (query.unlocked == null ? true : entry.unlocked === query.unlocked))
+    .slice(0, safeLimit);
 }
 
 export function normalizeEventLogEntries(entries?: Partial<EventLogEntry>[] | null): EventLogEntry[] {

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -10,6 +10,7 @@ import {
   applyAchievementMetricDelta,
   applyAchievementProgressValue,
   buildPlayerProgressionSnapshot,
+  queryAchievementProgress,
   queryEventLogEntries,
   createHeroAttributeBreakdown,
   createHeroEquipmentBonusSummary,
@@ -465,6 +466,37 @@ test("event log query helper filters by category, hero, and achievement metadata
   );
 
   assert.deepEqual(queried.map((entry) => entry.id), ["achievement-entry"]);
+});
+
+test("achievement progress query helper filters by id, metric, unlocked state, and limit", () => {
+  const queried = queryAchievementProgress(
+    [
+      {
+        id: "first_battle",
+        current: 1,
+        unlockedAt: "2026-03-27T10:00:00.000Z"
+      },
+      {
+        id: "enemy_slayer",
+        current: 2,
+        progressUpdatedAt: "2026-03-27T10:04:00.000Z"
+      },
+      {
+        id: "skill_scholar",
+        current: 5,
+        unlockedAt: "2026-03-27T10:06:00.000Z"
+      }
+    ],
+    {
+      metric: "skills_learned",
+      unlocked: true,
+      limit: 1
+    }
+  );
+
+  assert.deepEqual(queried.map((entry) => entry.id), ["skill_scholar"]);
+  assert.equal(queried[0]?.title, "求知者");
+  assert.equal(queried[0]?.target, 5);
 });
 
 test("player progression snapshot summarizes unlocked achievements and recent events", () => {


### PR DESCRIPTION
## Summary
- add a shared achievement progress query helper with id, metric, unlocked, and limit filters
- expose dedicated player account achievement read routes for public and authenticated lookups
- add client loader coverage and focused shared/server/client tests for the new read API

## Testing
- node --import tsx --test ./packages/shared/test/shared-core.test.ts
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:client:h5

refs #27