### PR TITLE
feat: add battle replay query filters

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,9 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   buildPlayerProgressionSnapshot,
+  queryPlayerBattleReplaySummaries,
   queryAchievementProgress,
   queryEventLogEntries,
-  normalizePlayerBattleReplaySummaries
+  type PlayerBattleReplaySummary
 } from "../../../packages/shared/src/index";
 import { issueNextAuthSession, resolveAuthSessionFromRequest } from "./auth";
 import type { PlayerAccountProfilePatch, PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
@@ -92,11 +93,38 @@ function parseBooleanQueryParam(request: IncomingMessage, key: string): boolean 
   return undefined;
 }
 
-function toReplayResponse(account: PlayerAccountSnapshot, limit?: number): { items: PlayerAccountSnapshot["recentBattleReplays"] } {
-  const items = normalizePlayerBattleReplaySummaries(account.recentBattleReplays);
-  const safeLimit = limit == null ? undefined : Math.max(1, Math.floor(limit));
+function toReplayResponseFromRequest(
+  account: PlayerAccountSnapshot,
+  request: IncomingMessage
+): { items: PlayerAccountSnapshot["recentBattleReplays"] } {
+  const limit = parseLimit(request);
+  const roomId = parseOptionalQueryParam(request, "roomId");
+  const battleId = parseOptionalQueryParam(request, "battleId");
+  const battleKind = parseOptionalQueryParam(request, "battleKind") as
+    | PlayerBattleReplaySummary["battleKind"]
+    | undefined;
+  const playerCamp = parseOptionalQueryParam(request, "playerCamp") as
+    | PlayerBattleReplaySummary["playerCamp"]
+    | undefined;
+  const heroId = parseOptionalQueryParam(request, "heroId");
+  const opponentHeroId = parseOptionalQueryParam(request, "opponentHeroId");
+  const neutralArmyId = parseOptionalQueryParam(request, "neutralArmyId");
+  const result = parseOptionalQueryParam(request, "result") as
+    | PlayerBattleReplaySummary["result"]
+    | undefined;
+
   return {
-    items: safeLimit == null ? items : items.slice(0, safeLimit)
+    items: queryPlayerBattleReplaySummaries(account.recentBattleReplays, {
+      ...(limit != null ? { limit } : {}),
+      ...(roomId ? { roomId } : {}),
+      ...(battleId ? { battleId } : {}),
+      ...(battleKind ? { battleKind } : {}),
+      ...(playerCamp ? { playerCamp } : {}),
+      ...(heroId ? { heroId } : {}),
+      ...(opponentHeroId ? { opponentHeroId } : {}),
+      ...(neutralArmyId ? { neutralArmyId } : {}),
+      ...(result ? { result } : {})
+    })
   };
 }
 
@@ -323,7 +351,7 @@ export function registerPlayerAccountRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
-      sendJson(response, 200, toReplayResponse(account, parseLimit(request)));
+      sendJson(response, 200, toReplayResponseFromRequest(account, request));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
@@ -499,7 +527,7 @@ export function registerPlayerAccountRoutes(
         return;
       }
 
-      sendJson(response, 200, toReplayResponse(account, parseLimit(request)));
+      sendJson(response, 200, toReplayResponseFromRequest(account, request));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -302,19 +302,24 @@ function createFullyExploredTrackingWorldState(): WorldState {
   };
 }
 
-function createReplaySummary(id: string, completedAt: string): PlayerBattleReplaySummary {
+function createReplaySummary(
+  id: string,
+  completedAt: string,
+  overrides: Partial<PlayerBattleReplaySummary> = {}
+): PlayerBattleReplaySummary {
   return {
     id,
-    roomId: "room-replay",
-    playerId: "player-1",
-    battleId: `${id}-battle`,
-    battleKind: "hero",
-    playerCamp: "attacker",
-    heroId: "hero-1",
-    opponentHeroId: "hero-2",
-    startedAt: "2026-03-27T11:55:00.000Z",
+    roomId: overrides.roomId ?? "room-replay",
+    playerId: overrides.playerId ?? "player-1",
+    battleId: overrides.battleId ?? `${id}-battle`,
+    battleKind: overrides.battleKind ?? "hero",
+    playerCamp: overrides.playerCamp ?? "attacker",
+    heroId: overrides.heroId ?? "hero-1",
+    ...(overrides.opponentHeroId !== undefined ? { opponentHeroId: overrides.opponentHeroId } : { opponentHeroId: "hero-2" }),
+    ...(overrides.neutralArmyId !== undefined ? { neutralArmyId: overrides.neutralArmyId } : {}),
+    startedAt: overrides.startedAt ?? "2026-03-27T11:55:00.000Z",
     completedAt,
-    initialState: {
+    initialState: overrides.initialState ?? {
       id: `${id}-battle`,
       round: 1,
       lanes: 2,
@@ -360,8 +365,8 @@ function createReplaySummary(id: string, completedAt: string): PlayerBattleRepla
       log: [],
       rng: { seed: 7, cursor: 0 }
     },
-    steps: [],
-    result: "attacker_victory"
+    steps: overrides.steps ?? [],
+    result: overrides.result ?? "attacker_victory"
   };
 }
 
@@ -510,6 +515,68 @@ test("player account battle replay routes return normalized replay summaries wit
 
   const missingResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/missing/battle-replays`);
   assert.equal(missingResponse.status, 404);
+});
+
+test("player account battle replay routes filter replay summaries by battle metadata", async (t) => {
+  const port = 42040 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-filtered",
+    displayName: "灰烬书记",
+    globalResources: { gold: 40, wood: 5, ore: 2 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [
+      createReplaySummary("replay-hero-loss", "2026-03-27T12:05:00.000Z", {
+        roomId: "room-hero",
+        battleId: "battle-hero-loss",
+        battleKind: "hero",
+        playerCamp: "defender",
+        heroId: "hero-3",
+        opponentHeroId: "hero-9",
+        result: "defender_victory"
+      }),
+      createReplaySummary("replay-neutral-win", "2026-03-27T12:06:00.000Z", {
+        roomId: "room-neutral",
+        battleId: "battle-neutral-win",
+        battleKind: "neutral",
+        heroId: "hero-1",
+        neutralArmyId: "neutral-1",
+        opponentHeroId: undefined,
+        result: "attacker_victory"
+      })
+    ],
+    lastRoomId: "room-neutral",
+    lastSeenAt: new Date("2026-03-27T12:06:30.000Z").toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-filtered",
+    displayName: "灰烬书记"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const publicResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-filtered/battle-replays?battleKind=neutral&heroId=hero-1&neutralArmyId=neutral-1`
+  );
+  const publicPayload = (await publicResponse.json()) as { items: PlayerBattleReplaySummary[] };
+  assert.equal(publicResponse.status, 200);
+  assert.deepEqual(publicPayload.items.map((replay) => replay.id), ["replay-neutral-win"]);
+
+  const meResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/battle-replays?roomId=room-hero&battleId=battle-hero-loss&playerCamp=defender&result=defender_victory&opponentHeroId=hero-9`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const mePayload = (await meResponse.json()) as { items: PlayerBattleReplaySummary[] };
+  assert.equal(meResponse.status, 200);
+  assert.deepEqual(mePayload.items.map((replay) => replay.id), ["replay-hero-loss"]);
 });
 
 test("player account me battle replay route resolves the current authenticated account", async (t) => {

--- a/packages/shared/src/battle-replay.ts
+++ b/packages/shared/src/battle-replay.ts
@@ -28,6 +28,18 @@ export interface PlayerBattleReplaySummary {
   result: BattleReplayResult;
 }
 
+export interface PlayerBattleReplayQuery {
+  limit?: number | undefined;
+  roomId?: string | undefined;
+  battleId?: string | undefined;
+  battleKind?: PlayerBattleReplaySummary["battleKind"] | undefined;
+  playerCamp?: PlayerBattleReplaySummary["playerCamp"] | undefined;
+  heroId?: string | undefined;
+  opponentHeroId?: string | undefined;
+  neutralArmyId?: string | undefined;
+  result?: PlayerBattleReplaySummary["result"] | undefined;
+}
+
 export type BattleReplayPlaybackStatus = "paused" | "playing" | "completed";
 
 export interface BattleReplayPlaybackState {
@@ -226,4 +238,27 @@ export function appendPlayerBattleReplaySummaries(
     ...normalizedIncoming,
     ...normalizePlayerBattleReplaySummaries(existing)
   ]).slice(0, safeLimit);
+}
+
+export function queryPlayerBattleReplaySummaries(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null,
+  query: PlayerBattleReplayQuery = {}
+): PlayerBattleReplaySummary[] {
+  const safeLimit = query.limit == null ? undefined : Math.max(1, Math.floor(query.limit));
+  const roomId = query.roomId?.trim();
+  const battleId = query.battleId?.trim();
+  const heroId = query.heroId?.trim();
+  const opponentHeroId = query.opponentHeroId?.trim();
+  const neutralArmyId = query.neutralArmyId?.trim();
+
+  return normalizePlayerBattleReplaySummaries(replays)
+    .filter((replay) => (roomId ? replay.roomId === roomId : true))
+    .filter((replay) => (battleId ? replay.battleId === battleId : true))
+    .filter((replay) => (query.battleKind ? replay.battleKind === query.battleKind : true))
+    .filter((replay) => (query.playerCamp ? replay.playerCamp === query.playerCamp : true))
+    .filter((replay) => (heroId ? replay.heroId === heroId : true))
+    .filter((replay) => (opponentHeroId ? replay.opponentHeroId === opponentHeroId : true))
+    .filter((replay) => (neutralArmyId ? replay.neutralArmyId === neutralArmyId : true))
+    .filter((replay) => (query.result ? replay.result === query.result : true))
+    .slice(0, safeLimit);
 }

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -12,6 +12,7 @@ import {
   buildPlayerProgressionSnapshot,
   queryAchievementProgress,
   queryEventLogEntries,
+  queryPlayerBattleReplaySummaries,
   createHeroAttributeBreakdown,
   createHeroEquipmentBonusSummary,
   createHeroEquipmentLoadoutView,
@@ -702,6 +703,61 @@ test("battle replay helpers normalize steps and keep newest unique replays first
   assert.deepEqual(merged.map((replay) => replay.id), ["replay-newer", "replay-older"]);
   assert.equal(merged[0]?.steps[0]?.index, 5);
   assert.equal(merged[1]?.steps[0]?.index, 9);
+});
+
+test("battle replay query helper filters normalized summaries by replay metadata", () => {
+  const battle = createEmptyBattleState();
+  const replays = normalizePlayerBattleReplaySummaries([
+    {
+      id: "replay-neutral",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      battleId: "battle-neutral-1",
+      battleKind: "neutral",
+      playerCamp: "attacker",
+      heroId: "hero-1",
+      neutralArmyId: "neutral-1",
+      startedAt: "2026-03-27T10:00:00.000Z",
+      completedAt: "2026-03-27T10:01:00.000Z",
+      initialState: battle,
+      steps: [],
+      result: "attacker_victory"
+    },
+    {
+      id: "replay-hero",
+      roomId: "room-beta",
+      playerId: "player-1",
+      battleId: "battle-hero-1",
+      battleKind: "hero",
+      playerCamp: "defender",
+      heroId: "hero-2",
+      opponentHeroId: "hero-9",
+      startedAt: "2026-03-27T10:02:00.000Z",
+      completedAt: "2026-03-27T10:03:00.000Z",
+      initialState: battle,
+      steps: [],
+      result: "defender_victory"
+    }
+  ]);
+
+  assert.deepEqual(
+    queryPlayerBattleReplaySummaries(replays, {
+      battleKind: "hero",
+      playerCamp: "defender",
+      opponentHeroId: "hero-9"
+    }).map((replay) => replay.id),
+    ["replay-hero"]
+  );
+
+  assert.deepEqual(
+    queryPlayerBattleReplaySummaries(replays, {
+      roomId: "room-alpha",
+      neutralArmyId: "neutral-1",
+      result: "attacker_victory",
+      limit: 1
+    }).map((replay) => replay.id),
+    ["replay-neutral"]
+  );
 });
 
 test("battle replay playback helpers support play pause tick and reset controls", () => {


### PR DESCRIPTION
## Summary
- add a shared battle replay query type/helper so replay read-model filtering is normalized in one place
- wire player-account battle replay routes to support replay metadata filters beyond `limit`
- cover shared filtering and route-level query behavior with focused tests

## Testing
- node --import tsx --test ./packages/shared/test/shared-core.test.ts
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- ./node_modules/.bin/tsc -p packages/shared/tsconfig.json --noEmit
- ./node_modules/.bin/tsc -p apps/server/tsconfig.json --noEmit

Refs #27