### PR TITLE
fix: preserve battle replay result semantics

### DIFF
--- a/apps/server/src/battle-replays.ts
+++ b/apps/server/src/battle-replays.ts
@@ -85,16 +85,6 @@ function buildPlayerReplayId(replay: CompletedBattleReplayCapture, playerId: str
   return `${replay.roomId}:${replay.battleId}:${playerId}`;
 }
 
-function playerResultForCamp(result: BattleReplayResult, camp: BattleReplayCamp): BattleReplayResult {
-  return result === "attacker_victory"
-    ? camp === "attacker"
-      ? "attacker_victory"
-      : "defender_victory"
-    : camp === "defender"
-      ? "attacker_victory"
-      : "defender_victory";
-}
-
 export function buildPlayerBattleReplaySummary(
   replay: CompletedBattleReplayCapture,
   playerId: string,
@@ -116,7 +106,7 @@ export function buildPlayerBattleReplaySummary(
     completedAt: replay.completedAt,
     initialState: replay.initialState,
     steps: replay.steps,
-    result: playerResultForCamp(replay.result, playerCamp)
+    result: replay.result
   };
 }
 

--- a/apps/server/test/room-persistence.test.ts
+++ b/apps/server/test/room-persistence.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { buildPlayerBattleReplaySummary, type CompletedBattleReplayCapture } from "../src/battle-replays";
 import { createRoom } from "../src/index";
 
 test("room persistence snapshot restores an active neutral battle", () => {
@@ -84,4 +85,183 @@ test("room persistence snapshot restores a resolved PvP world without active bat
   assert.equal(restored.getBattleForPlayer("player-2"), null);
   assert.deepEqual(restored.getSnapshot("player-1").state.ownHeroes[0], room.getSnapshot("player-1").state.ownHeroes[0]);
   assert.deepEqual(restored.getSnapshot("player-2").state.ownHeroes[0], room.getSnapshot("player-2").state.ownHeroes[0]);
+});
+
+test("player battle replay summaries preserve the global battle result for both camps", () => {
+  const replay: CompletedBattleReplayCapture = {
+    battleId: "battle-hero-1-vs-hero-2",
+    roomId: "room-persist-pvp",
+    startedAt: "2026-03-27T12:00:00.000Z",
+    completedAt: "2026-03-27T12:01:00.000Z",
+    initialState: {
+      id: "battle-hero-1-vs-hero-2",
+      heroTemplateId: "hero_knight",
+      attacker: {
+        id: "hero-1-stack",
+        camp: "attacker",
+        templateId: "hero_guard_basic",
+        count: 12,
+        attack: 4,
+        defense: 2,
+        hp: 10,
+        maxHp: 10,
+        morale: 0,
+        luck: 0,
+        speed: 4,
+        retaliationsRemaining: 1,
+        hasWaited: false,
+        position: { x: 0, y: 0 }
+      },
+      defender: {
+        id: "hero-2-stack",
+        camp: "defender",
+        templateId: "hero_guard_basic",
+        count: 8,
+        attack: 3,
+        defense: 2,
+        hp: 10,
+        maxHp: 10,
+        morale: 0,
+        luck: 0,
+        speed: 3,
+        retaliationsRemaining: 1,
+        hasWaited: false,
+        position: { x: 1, y: 0 }
+      },
+      units: {
+        "hero-1-stack": {
+          id: "hero-1-stack",
+          camp: "attacker",
+          templateId: "hero_guard_basic",
+          count: 12,
+          attack: 4,
+          defense: 2,
+          hp: 10,
+          maxHp: 10,
+          morale: 0,
+          luck: 0,
+          speed: 4,
+          retaliationsRemaining: 1,
+          hasWaited: false,
+          position: { x: 0, y: 0 }
+        },
+        "hero-2-stack": {
+          id: "hero-2-stack",
+          camp: "defender",
+          templateId: "hero_guard_basic",
+          count: 8,
+          attack: 3,
+          defense: 2,
+          hp: 10,
+          maxHp: 10,
+          morale: 0,
+          luck: 0,
+          speed: 3,
+          retaliationsRemaining: 1,
+          hasWaited: false,
+          position: { x: 1, y: 0 }
+        }
+      },
+      turnOrder: ["hero-1-stack", "hero-2-stack"],
+      activeUnitId: "hero-2-stack",
+      round: 1,
+      seed: 1001,
+      worldHeroId: "hero-1",
+      defenderHeroId: "hero-2"
+    },
+    battleState: {
+      id: "battle-hero-1-vs-hero-2",
+      heroTemplateId: "hero_knight",
+      attacker: {
+        id: "hero-1-stack",
+        camp: "attacker",
+        templateId: "hero_guard_basic",
+        count: 7,
+        attack: 4,
+        defense: 2,
+        hp: 10,
+        maxHp: 10,
+        morale: 0,
+        luck: 0,
+        speed: 4,
+        retaliationsRemaining: 0,
+        hasWaited: false,
+        position: { x: 0, y: 0 }
+      },
+      defender: {
+        id: "hero-2-stack",
+        camp: "defender",
+        templateId: "hero_guard_basic",
+        count: 0,
+        attack: 3,
+        defense: 2,
+        hp: 0,
+        maxHp: 10,
+        morale: 0,
+        luck: 0,
+        speed: 3,
+        retaliationsRemaining: 0,
+        hasWaited: false,
+        position: { x: 1, y: 0 }
+      },
+      units: {
+        "hero-1-stack": {
+          id: "hero-1-stack",
+          camp: "attacker",
+          templateId: "hero_guard_basic",
+          count: 7,
+          attack: 4,
+          defense: 2,
+          hp: 10,
+          maxHp: 10,
+          morale: 0,
+          luck: 0,
+          speed: 4,
+          retaliationsRemaining: 0,
+          hasWaited: false,
+          position: { x: 0, y: 0 }
+        },
+        "hero-2-stack": {
+          id: "hero-2-stack",
+          camp: "defender",
+          templateId: "hero_guard_basic",
+          count: 0,
+          attack: 3,
+          defense: 2,
+          hp: 0,
+          maxHp: 10,
+          morale: 0,
+          luck: 0,
+          speed: 3,
+          retaliationsRemaining: 0,
+          hasWaited: false,
+          position: { x: 1, y: 0 }
+        }
+      },
+      turnOrder: ["hero-1-stack"],
+      activeUnitId: "hero-1-stack",
+      round: 2,
+      seed: 1001,
+      worldHeroId: "hero-1",
+      defenderHeroId: "hero-2"
+    },
+    steps: [
+      {
+        index: 1,
+        source: "player",
+        action: {
+          type: "battle.attack",
+          attackerId: "hero-1-stack",
+          defenderId: "hero-2-stack"
+        }
+      }
+    ],
+    result: "attacker_victory"
+  };
+
+  const attackerReplay = buildPlayerBattleReplaySummary(replay, "player-1", "hero-1", "attacker", "hero-2");
+  const defenderReplay = buildPlayerBattleReplaySummary(replay, "player-2", "hero-2", "defender", "hero-1");
+
+  assert.equal(attackerReplay.result, "attacker_victory");
+  assert.equal(defenderReplay.result, "attacker_victory");
 });


### PR DESCRIPTION
## Summary
- preserve the global battle replay result when building per-player replay summaries
- add a regression test covering attacker and defender replay views for the same completed battle

## Testing
- node --import tsx --test ./apps/server/test/room-persistence.test.ts
- npm run typecheck:server

Refs #27