### PR TITLE
feat: wire client battle replay query filters

### DIFF
--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -7,9 +7,10 @@ import {
 } from "./auth-session";
 import {
   type AchievementProgressQuery,
+  type PlayerBattleReplayQuery,
   normalizePlayerProgressionSnapshot,
   normalizePlayerAccountReadModel,
-  normalizePlayerBattleReplaySummaries,
+  queryPlayerBattleReplaySummaries,
   queryAchievementProgress,
   normalizeEventLogEntries,
   type EventLogQuery,
@@ -111,6 +112,44 @@ function toEventLogQueryString(query?: EventLogQuery): string {
   }
   if (query.worldEventType) {
     searchParams.set("worldEventType", query.worldEventType);
+  }
+
+  const serialized = searchParams.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+function toBattleReplayQueryString(query?: PlayerBattleReplayQuery): string {
+  if (!query) {
+    return "";
+  }
+
+  const searchParams = new URLSearchParams();
+  if (query.limit != null) {
+    searchParams.set("limit", String(query.limit));
+  }
+  if (query.roomId) {
+    searchParams.set("roomId", query.roomId);
+  }
+  if (query.battleId) {
+    searchParams.set("battleId", query.battleId);
+  }
+  if (query.battleKind) {
+    searchParams.set("battleKind", query.battleKind);
+  }
+  if (query.playerCamp) {
+    searchParams.set("playerCamp", query.playerCamp);
+  }
+  if (query.heroId) {
+    searchParams.set("heroId", query.heroId);
+  }
+  if (query.opponentHeroId) {
+    searchParams.set("opponentHeroId", query.opponentHeroId);
+  }
+  if (query.neutralArmyId) {
+    searchParams.set("neutralArmyId", query.neutralArmyId);
+  }
+  if (query.result) {
+    searchParams.set("result", query.result);
   }
 
   const serialized = searchParams.toString();
@@ -282,22 +321,26 @@ export async function loadPlayerAccountProfile(playerId: string, roomId: string)
   }
 }
 
-export async function loadPlayerBattleReplaySummaries(playerId: string): Promise<PlayerBattleReplaySummary[]> {
+export async function loadPlayerBattleReplaySummaries(
+  playerId: string,
+  query?: PlayerBattleReplayQuery
+): Promise<PlayerBattleReplaySummary[]> {
   const authSession = readStoredAuthSession();
+  const queryString = toBattleReplayQueryString(query);
   const endpoint = authSession?.token
-    ? `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/battle-replays`
-    : `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/${encodeURIComponent(playerId)}/battle-replays`;
+    ? `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/battle-replays${queryString}`
+    : `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/${encodeURIComponent(playerId)}/battle-replays${queryString}`;
 
   try {
     const payload = (await fetchJson(endpoint, {
       ...(authSession?.token ? { headers: buildAuthHeaders(authSession.token) } : {})
     })) as PlayerBattleReplayListApiPayload;
-    return normalizePlayerBattleReplaySummaries(payload.items);
+    return queryPlayerBattleReplaySummaries(payload.items, query);
   } catch (error) {
     if (authSession?.token && error instanceof Error && error.message === "player_account_request_failed:401") {
       clearCurrentAuthSession();
     }
-    return normalizePlayerBattleReplaySummaries();
+    return queryPlayerBattleReplaySummaries(undefined, query);
   }
 }
 

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -98,9 +98,10 @@ test("player account helpers can build a local fallback profile", () => {
   });
 });
 
-test("player replay loader normalizes remote replay summaries and keeps newest first", async () => {
+test("player replay loader sends shared filters and normalizes newest first", async () => {
   const originalWindow = globalThis.window;
   const originalFetch = globalThis.fetch;
+  let requestedUrl = "";
 
   Object.defineProperty(globalThis, "window", {
     configurable: true,
@@ -120,8 +121,9 @@ test("player replay loader normalizes remote replay summaries and keeps newest f
     }
   });
 
-  globalThis.fetch = (async () =>
-    new Response(
+  globalThis.fetch = (async (input) => {
+    requestedUrl = String(input);
+    return new Response(
       JSON.stringify({
         items: [
           {
@@ -172,8 +174,9 @@ test("player replay loader normalizes remote replay summaries and keeps newest f
             playerId: "player-1",
             battleId: "battle-2",
             battleKind: "hero",
-            playerCamp: "attacker",
+            playerCamp: "defender",
             heroId: "hero-1",
+            opponentHeroId: "hero-9",
             startedAt: "2026-03-27T12:01:00.000Z",
             completedAt: "2026-03-27T12:02:00.000Z",
             initialState: {
@@ -206,7 +209,7 @@ test("player replay loader normalizes remote replay summaries and keeps newest f
               rng: { seed: 8, cursor: 0 }
             },
             steps: [],
-            result: "attacker_victory"
+            result: "defender_victory"
           }
         ]
       }),
@@ -216,11 +219,95 @@ test("player replay loader normalizes remote replay summaries and keeps newest f
           "Content-Type": "application/json"
         }
       }
+    );
+  }) as typeof fetch;
+
+  try {
+    const replays = await loadPlayerBattleReplaySummaries("player-1", {
+      limit: 1,
+      roomId: "room-alpha",
+      battleKind: "hero",
+      playerCamp: "defender",
+      heroId: "hero-1",
+      opponentHeroId: "hero-9",
+      result: "defender_victory"
+    });
+    assert.equal(
+      requestedUrl,
+      "http://127.0.0.1:2567/api/player-accounts/player-1/battle-replays?limit=1&roomId=room-alpha&battleKind=hero&playerCamp=defender&heroId=hero-1&opponentHeroId=hero-9&result=defender_victory"
+    );
+    assert.deepEqual(replays.map((replay) => replay.id), ["replay-newer"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("player replay loader clears expired auth session and falls back to normalized filtered defaults", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        values: new Map<string, string>([
+          [
+            "project-veil:auth-session",
+            JSON.stringify({
+              playerId: "player-1",
+              displayName: "暮火侦骑",
+              authMode: "guest",
+              token: "expired-token",
+              source: "guest"
+            })
+          ]
+        ]),
+        getItem(key: string): string | null {
+          return this.values.get(key) ?? null;
+        },
+        setItem(key: string, value: string): void {
+          this.values.set(key, value);
+        },
+        removeItem(key: string): void {
+          this.values.delete(key);
+        }
+      }
+    }
+  });
+
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        error: {
+          code: "unauthorized",
+          message: "expired"
+        }
+      }),
+      {
+        status: 401,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
     )) as typeof fetch;
 
   try {
-    const replays = await loadPlayerBattleReplaySummaries("player-1");
-    assert.deepEqual(replays.map((replay) => replay.id), ["replay-newer", "replay-older"]);
+    const replays = await loadPlayerBattleReplaySummaries("player-1", {
+      limit: 1,
+      battleKind: "neutral"
+    });
+    assert.deepEqual(replays, []);
+    assert.equal(globalThis.window.localStorage.getItem("project-veil:auth-session"), null);
   } finally {
     Object.defineProperty(globalThis, "window", {
       configurable: true,


### PR DESCRIPTION
## Summary
- add shared `PlayerBattleReplayQuery` support to the H5 player account loader
- serialize replay filter params into the `/battle-replays` request URL
- apply shared replay query normalization on both successful responses and auth-expiry fallback paths

## Testing
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts
- corepack pnpm typecheck:client:h5

refs #27