### PR TITLE
feat: wire cocos player account progress queries

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -6,8 +6,14 @@ import {
 } from "./cocos-session-launch.ts";
 import {
   normalizePlayerAccountReadModel,
+  normalizeEventLogEntries,
+  normalizePlayerProgressionSnapshot,
+  queryAchievementProgress,
+  type AchievementProgressQuery,
   type EventLogEntry,
+  type EventLogQuery,
   type PlayerAccountReadModel,
+  type PlayerProgressionSnapshot,
   type PlayerBattleReplaySummary,
   type PlayerAchievementProgress
 } from "../../../../packages/shared/src/index.ts";
@@ -69,6 +75,16 @@ interface LobbyRoomsApiPayload {
   items?: CocosLobbyRoomSummary[];
 }
 
+interface PlayerEventLogListApiPayload {
+  items?: Partial<EventLogEntry>[];
+}
+
+interface PlayerAchievementListApiPayload {
+  items?: Partial<PlayerAchievementProgress>[];
+}
+
+type PlayerProgressionApiPayload = Partial<PlayerProgressionSnapshot>;
+
 type FetchLike = typeof fetch;
 
 function getCocosStorage(): Storage | null {
@@ -106,6 +122,55 @@ function normalizeDisplayName(playerId: string, displayName?: string | null): st
 function normalizeLoginId(value?: string | null): string | undefined {
   const normalized = value?.trim().toLowerCase();
   return normalized ? normalized : undefined;
+}
+
+function toEventLogQueryString(query?: EventLogQuery): string {
+  if (!query) {
+    return "";
+  }
+
+  const searchParams = new URLSearchParams();
+  if (query.limit != null) {
+    searchParams.set("limit", String(query.limit));
+  }
+  if (query.category) {
+    searchParams.set("category", query.category);
+  }
+  if (query.heroId) {
+    searchParams.set("heroId", query.heroId);
+  }
+  if (query.achievementId) {
+    searchParams.set("achievementId", query.achievementId);
+  }
+  if (query.worldEventType) {
+    searchParams.set("worldEventType", query.worldEventType);
+  }
+
+  const serialized = searchParams.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+function toAchievementQueryString(query?: AchievementProgressQuery): string {
+  if (!query) {
+    return "";
+  }
+
+  const searchParams = new URLSearchParams();
+  if (query.limit != null) {
+    searchParams.set("limit", String(query.limit));
+  }
+  if (query.achievementId) {
+    searchParams.set("achievementId", query.achievementId);
+  }
+  if (query.metric) {
+    searchParams.set("metric", query.metric);
+  }
+  if (query.unlocked != null) {
+    searchParams.set("unlocked", String(query.unlocked));
+  }
+
+  const serialized = searchParams.toString();
+  return serialized ? `?${serialized}` : "";
 }
 
 function readStoredLobbyPreferencesUnsafe(storage: Pick<Storage, "getItem">): Partial<CocosLobbyPreferences> | null {
@@ -534,5 +599,110 @@ export async function loadCocosPlayerAccountProfile(
       clearStoredCocosAuthSession(storage);
     }
     return createFallbackCocosPlayerAccountProfile(playerId, roomId, storedDisplayName);
+  }
+}
+
+export async function loadCocosPlayerEventLog(
+  remoteUrl: string,
+  playerId: string,
+  query?: EventLogQuery,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "removeItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<EventLogEntry[]> {
+  const storage = options?.storage ?? getCocosStorage();
+  const authSession =
+    options && "authSession" in options ? options.authSession ?? null : readStoredCocosAuthSession(storage);
+  const queryString = toEventLogQueryString(query);
+  const endpoint = authSession?.token
+    ? `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/event-log${queryString}`
+    : `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/${encodeURIComponent(playerId)}/event-log${queryString}`;
+
+  try {
+    const payload = (await fetchJson(
+      endpoint,
+      {
+        ...(authSession?.token ? { headers: buildCocosAuthHeaders(authSession.token) } : {})
+      },
+      options?.fetchImpl
+    )) as PlayerEventLogListApiPayload;
+    return normalizeEventLogEntries(payload.items);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message === "cocos_request_failed:401" && storage) {
+      clearStoredCocosAuthSession(storage);
+    }
+    return normalizeEventLogEntries();
+  }
+}
+
+export async function loadCocosPlayerAchievementProgress(
+  remoteUrl: string,
+  playerId: string,
+  query?: AchievementProgressQuery,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "removeItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<PlayerAchievementProgress[]> {
+  const storage = options?.storage ?? getCocosStorage();
+  const authSession =
+    options && "authSession" in options ? options.authSession ?? null : readStoredCocosAuthSession(storage);
+  const queryString = toAchievementQueryString(query);
+  const endpoint = authSession?.token
+    ? `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/achievements${queryString}`
+    : `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/${encodeURIComponent(playerId)}/achievements${queryString}`;
+
+  try {
+    const payload = (await fetchJson(
+      endpoint,
+      {
+        ...(authSession?.token ? { headers: buildCocosAuthHeaders(authSession.token) } : {})
+      },
+      options?.fetchImpl
+    )) as PlayerAchievementListApiPayload;
+    return queryAchievementProgress(payload.items, query);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message === "cocos_request_failed:401" && storage) {
+      clearStoredCocosAuthSession(storage);
+    }
+    return queryAchievementProgress(undefined, query);
+  }
+}
+
+export async function loadCocosPlayerProgressionSnapshot(
+  remoteUrl: string,
+  playerId: string,
+  eventLimit?: number,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "removeItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<PlayerProgressionSnapshot> {
+  const storage = options?.storage ?? getCocosStorage();
+  const authSession =
+    options && "authSession" in options ? options.authSession ?? null : readStoredCocosAuthSession(storage);
+  const limitQuery = eventLimit != null ? `?limit=${encodeURIComponent(String(eventLimit))}` : "";
+  const endpoint = authSession?.token
+    ? `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/progression${limitQuery}`
+    : `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/${encodeURIComponent(playerId)}/progression${limitQuery}`;
+
+  try {
+    const payload = (await fetchJson(
+      endpoint,
+      {
+        ...(authSession?.token ? { headers: buildCocosAuthHeaders(authSession.token) } : {})
+      },
+      options?.fetchImpl
+    )) as PlayerProgressionApiPayload;
+    return normalizePlayerProgressionSnapshot(payload);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message === "cocos_request_failed:401" && storage) {
+      clearStoredCocosAuthSession(storage);
+    }
+    return normalizePlayerProgressionSnapshot();
   }
 }

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -5,8 +5,11 @@ import {
   createCocosLobbyPreferences,
   getCocosLobbyPreferencesStorageKey,
   getCocosPlayerAccountStorageKey,
+  loadCocosPlayerAchievementProgress,
   loadCocosLobbyRooms,
   loadCocosPlayerAccountProfile,
+  loadCocosPlayerEventLog,
+  loadCocosPlayerProgressionSnapshot,
   loginCocosPasswordAuthSession,
   loginCocosGuestAuthSession,
   rememberPreferredCocosDisplayName,
@@ -352,4 +355,143 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
   });
   assert.ok(values.get("project-veil:auth-session")?.includes("\"loginId\":\"veil-ranger\""));
   assert.equal(values.get(getCocosPlayerAccountStorageKey("account-player")), "暮潮守望");
+});
+
+test("loadCocosPlayerEventLog sends shared filters through the public query route", async () => {
+  let requestedUrl = "";
+
+  const items = await loadCocosPlayerEventLog("ws://127.0.0.1:2567/ws", "player-1", {
+    limit: 1,
+    category: "achievement",
+    heroId: "hero-1",
+    achievementId: "first_battle",
+    worldEventType: "battle.started"
+  }, {
+    fetchImpl: async (input) => {
+      requestedUrl = String(input);
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "event-older",
+              timestamp: "2026-03-27T12:01:00.000Z",
+              roomId: "room-alpha",
+              playerId: "player-1",
+              category: "achievement",
+              description: "older",
+              heroId: "hero-1",
+              achievementId: "first_battle",
+              worldEventType: "battle.started",
+              rewards: []
+            },
+            {
+              id: "event-newer",
+              timestamp: "2026-03-27T12:03:00.000Z",
+              roomId: "room-alpha",
+              playerId: "player-1",
+              category: "achievement",
+              description: "newer",
+              heroId: "hero-1",
+              achievementId: "first_battle",
+              worldEventType: "battle.started",
+              rewards: [{ type: "badge", label: "初次交锋" }]
+            }
+          ]
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+  });
+
+  assert.equal(
+    requestedUrl,
+    "http://127.0.0.1:2567/api/player-accounts/player-1/event-log?limit=1&category=achievement&heroId=hero-1&achievementId=first_battle&worldEventType=battle.started"
+  );
+  assert.deepEqual(items.map((entry) => entry.id), ["event-newer", "event-older"]);
+});
+
+test("loadCocosPlayerAchievementProgress uses /me for authenticated queries and normalizes progress", async () => {
+  let requestedUrl = "";
+
+  const items = await loadCocosPlayerAchievementProgress("http://127.0.0.1:2567", "player-1", {
+    limit: 1,
+    achievementId: "enemy_slayer",
+    metric: "battles_won",
+    unlocked: false
+  }, {
+    authSession: {
+      token: "session-token",
+      playerId: "player-1",
+      displayName: "雾林司灯",
+      authMode: "guest",
+      source: "remote"
+    },
+    fetchImpl: async (input, init) => {
+      requestedUrl = String(input);
+      assert.equal((init?.headers as Record<string, string> | undefined)?.Authorization, "Bearer session-token");
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "enemy_slayer",
+              current: 2,
+              progressUpdatedAt: "2026-03-27T12:02:00.000Z"
+            }
+          ]
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+  });
+
+  assert.equal(
+    requestedUrl,
+    "http://127.0.0.1:2567/api/player-accounts/me/achievements?limit=1&achievementId=enemy_slayer&metric=battles_won&unlocked=false"
+  );
+  assert.deepEqual(items.map((entry) => entry.id), ["enemy_slayer"]);
+  assert.equal(items[0]?.title, "猎敌者");
+  assert.equal(items[0]?.current, 2);
+});
+
+test("loadCocosPlayerProgressionSnapshot clears expired auth sessions and falls back to normalized defaults", async () => {
+  const values = new Map<string, string>([
+    [
+      "project-veil:auth-session",
+      JSON.stringify({
+        playerId: "player-1",
+        displayName: "雾林司灯",
+        authMode: "guest",
+        token: "session-token",
+        source: "remote"
+      })
+    ]
+  ]);
+  const storage = {
+    getItem(key: string): string | null {
+      return values.get(key) ?? null;
+    },
+    removeItem(key: string): void {
+      values.delete(key);
+    }
+  };
+
+  const snapshot = await loadCocosPlayerProgressionSnapshot("http://127.0.0.1:2567", "player-1", 2, {
+    storage,
+    fetchImpl: async () => new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 })
+  });
+
+  assert.equal(snapshot.summary.totalAchievements, 5);
+  assert.equal(snapshot.summary.unlockedAchievements, 0);
+  assert.deepEqual(snapshot.recentEventLog, []);
+  assert.equal(values.has("project-veil:auth-session"), false);
 });


### PR DESCRIPTION
## Summary
- add Cocos client helpers for player event-log, achievement progress, and progression snapshot queries
- reuse shared normalization/query helpers so Cocos behavior matches the existing web client filters
- cover public and authenticated request routing plus unauthorized fallback behavior in cocos lobby tests

## Testing
- corepack pnpm test apps/cocos-client/test/cocos-lobby.test.ts
- corepack pnpm typecheck:cocos

Refs #27