### PR TITLE
fix: keep unlocked achievements sticky

### DIFF
--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -951,6 +951,24 @@ test("player achievement tracker syncs epic equipment loadout progress from worl
     "2026-03-27T12:10:00.000Z"
   );
   assert.match(updated.recentEventLog[0]?.description ?? "", /解锁成就：史诗武装/);
+
+  const regressed = applyPlayerEventLogAndAchievements(
+    updated,
+    createAccountTrackingWorldState(),
+    [],
+    "2026-03-27T12:11:00.000Z"
+  );
+
+  assert.equal(regressed.achievements.find((achievement) => achievement.id === "epic_collector")?.current, 3);
+  assert.equal(regressed.achievements.find((achievement) => achievement.id === "epic_collector")?.unlocked, true);
+  assert.equal(
+    regressed.achievements.find((achievement) => achievement.id === "epic_collector")?.progressUpdatedAt,
+    "2026-03-27T12:10:00.000Z"
+  );
+  assert.equal(
+    regressed.recentEventLog.filter((entry) => entry.achievementId === "epic_collector").length,
+    1
+  );
 });
 
 test("player achievement tracker syncs full map exploration progress from world visibility", () => {

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -302,7 +302,7 @@ export function applyAchievementProgressValue(
     }
 
     const previousUnlocked = entry.unlocked;
-    const nextCurrent = Math.min(entry.target, safeCurrent);
+    const nextCurrent = previousUnlocked ? entry.current : Math.min(entry.target, safeCurrent);
     if (nextCurrent === entry.current) {
       return entry;
     }

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -337,6 +337,20 @@ test("achievement helpers can sync progress from an absolute value", () => {
     unlockedSync.progress.find((achievement) => achievement.id === "epic_collector")?.progressUpdatedAt,
     "2026-03-27T10:01:00.000Z"
   );
+
+  const regressedSync = applyAchievementProgressValue(
+    unlockedSync.progress,
+    "epic_collector",
+    1,
+    "2026-03-27T10:02:00.000Z"
+  );
+  assert.equal(regressedSync.unlocked.length, 0);
+  assert.equal(regressedSync.progress.find((achievement) => achievement.id === "epic_collector")?.current, 3);
+  assert.equal(regressedSync.progress.find((achievement) => achievement.id === "epic_collector")?.unlocked, true);
+  assert.equal(
+    regressedSync.progress.find((achievement) => achievement.id === "epic_collector")?.progressUpdatedAt,
+    "2026-03-27T10:01:00.000Z"
+  );
 });
 
 test("exploration helpers detect when a map has been fully revealed", () => {


### PR DESCRIPTION
## Summary
- keep absolute-value achievement syncs from regressing a previously unlocked achievement
- add shared regression coverage for post-unlock sync drops
- verify the server-side event-log/achievement tracker does not emit duplicate unlock entries after unlock

## Testing
- corepack pnpm test:shared
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- corepack pnpm typecheck:shared && corepack pnpm typecheck:server

Refs #27