### PR TITLE
Add explicit battle participant metadata to progression events

### DIFF
--- a/apps/server/src/battle-replays.ts
+++ b/apps/server/src/battle-replays.ts
@@ -15,6 +15,8 @@ const RECENT_BATTLE_REPLAY_LIMIT = 5;
 export interface OngoingBattleReplayCapture {
   battleId: string;
   roomId: string;
+  attackerPlayerId: string;
+  defenderPlayerId?: string;
   startedAt: string;
   initialState: BattleState;
   steps: BattleReplayStep[];
@@ -37,11 +39,14 @@ function battleKindOf(battle: BattleState): "neutral" | "hero" {
 export function createBattleReplayCapture(
   roomId: string,
   battle: BattleState,
+  participants: { attackerPlayerId: string; defenderPlayerId?: string },
   startedAt = new Date().toISOString()
 ): OngoingBattleReplayCapture {
   return {
     battleId: battle.id,
     roomId,
+    attackerPlayerId: participants.attackerPlayerId,
+    ...(participants.defenderPlayerId ? { defenderPlayerId: participants.defenderPlayerId } : {}),
     startedAt,
     initialState: cloneBattleState(battle),
     steps: []
@@ -108,6 +113,37 @@ export function buildPlayerBattleReplaySummary(
     steps: replay.steps,
     result: replay.result
   };
+}
+
+export function buildPlayerBattleReplaySummariesForPlayer(
+  replay: CompletedBattleReplayCapture,
+  playerId: string
+): PlayerBattleReplaySummary[] {
+  if (replay.attackerPlayerId === playerId && replay.battleState.worldHeroId) {
+    return [
+      buildPlayerBattleReplaySummary(
+        replay,
+        playerId,
+        replay.battleState.worldHeroId,
+        "attacker",
+        replay.battleState.defenderHeroId
+      )
+    ];
+  }
+
+  if (replay.defenderPlayerId === playerId && replay.battleState.defenderHeroId) {
+    return [
+      buildPlayerBattleReplaySummary(
+        replay,
+        playerId,
+        replay.battleState.defenderHeroId,
+        "defender",
+        replay.battleState.worldHeroId
+      )
+    ];
+  }
+
+  return [];
 }
 
 export function appendCompletedBattleReplaysToAccount(

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -15,7 +15,7 @@ import {
 import { createRoom, type AuthoritativeWorldRoom, type RoomPersistenceSnapshot } from "./index";
 import {
   appendCompletedBattleReplaysToAccount,
-  buildPlayerBattleReplaySummary,
+  buildPlayerBattleReplaySummariesForPlayer,
   type CompletedBattleReplayCapture
 } from "./battle-replays";
 import {
@@ -386,25 +386,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     replay: CompletedBattleReplayCapture,
     playerId: string
   ): PlayerBattleReplaySummary[] {
-    const battle = replay.battleState;
-    const attackerHero =
-      battle.worldHeroId != null
-        ? this.worldRoom.getInternalState().heroes.find((hero) => hero.id === battle.worldHeroId)
-        : undefined;
-    const defenderHero =
-      battle.defenderHeroId != null
-        ? this.worldRoom.getInternalState().heroes.find((hero) => hero.id === battle.defenderHeroId)
-        : undefined;
-
-    if (attackerHero?.playerId === playerId && battle.worldHeroId) {
-      return [buildPlayerBattleReplaySummary(replay, playerId, battle.worldHeroId, "attacker", battle.defenderHeroId)];
-    }
-
-    if (defenderHero?.playerId === playerId && battle.defenderHeroId) {
-      return [buildPlayerBattleReplaySummary(replay, playerId, battle.defenderHeroId, "defender", battle.worldHeroId)];
-    }
-
-    return [];
+    return buildPlayerBattleReplaySummariesForPlayer(replay, playerId);
   }
 
   private publishLobbyRoomSummary(): void {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -179,7 +179,25 @@ export class AuthoritativeWorldRoom {
   private trackStartedBattle(battle: BattleState): void {
     this.setBattle(battle);
     if (!this.battleReplayByBattleId.has(battle.id)) {
-      this.battleReplayByBattleId.set(battle.id, createBattleReplayCapture(this.state.meta.roomId, battle));
+      const attackerHero =
+        battle.worldHeroId ? this.state.heroes.find((hero) => hero.id === battle.worldHeroId) : undefined;
+      if (!attackerHero) {
+        return;
+      }
+
+      const defenderHero =
+        battle.defenderHeroId ? this.state.heroes.find((hero) => hero.id === battle.defenderHeroId) : undefined;
+      this.battleReplayByBattleId.set(
+        battle.id,
+        createBattleReplayCapture(
+          this.state.meta.roomId,
+          battle,
+          {
+            attackerPlayerId: attackerHero.playerId,
+            ...(defenderHero?.playerId ? { defenderPlayerId: defenderHero.playerId } : {})
+          }
+        )
+      );
     }
   }
 

--- a/apps/server/src/player-achievements.ts
+++ b/apps/server/src/player-achievements.ts
@@ -247,6 +247,19 @@ function metricDeltaForEvent(state: WorldState, playerId: string, event: WorldEv
         amount: 1
       };
     case "battle.resolved": {
+      if (event.result === "attacker_victory" && event.attackerPlayerId === playerId) {
+        return {
+          metric: "battles_won",
+          amount: 1
+        };
+      }
+      if (event.result === "defender_victory" && event.defenderPlayerId === playerId) {
+        return {
+          metric: "battles_won",
+          amount: 1
+        };
+      }
+
       const attacker = findHero(state, event.heroId);
       const defender = findHero(state, event.defenderHeroId);
       const winningPlayerId =

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -16,6 +16,7 @@ test("battle start auto-resolves defender opener before state is returned to the
     {
       type: "battle.started",
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       encounterKind: "neutral",
       neutralArmyId: "neutral-1",
       battleId: "battle-neutral-1",
@@ -168,7 +169,9 @@ test("room filters event timelines per player without hiding PvP battle results 
     {
       type: "battle.started" as const,
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       defenderHeroId: "hero-2",
+      defenderPlayerId: "player-2",
       encounterKind: "hero" as const,
       battleId: "battle-hero-1-vs-hero-2",
       path: [{ x: 1, y: 1 }, { x: 2, y: 1 }],
@@ -177,7 +180,9 @@ test("room filters event timelines per player without hiding PvP battle results 
     {
       type: "battle.resolved" as const,
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       defenderHeroId: "hero-2",
+      defenderPlayerId: "player-2",
       battleId: "battle-hero-1-vs-hero-2",
       result: "attacker_victory" as const
     },
@@ -415,6 +420,7 @@ test("room can create a neutral-initiated battle when end day triggers an adjace
     {
       type: "battle.started",
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       encounterKind: "neutral",
       neutralArmyId: "neutral-1",
       initiator: "neutral",

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -902,6 +902,50 @@ test("player achievement tracker appends logs and unlocks milestones", () => {
   assert.match(updated.recentEventLog.map((entry) => entry.description).join(" "), /解锁成就：初次交锋/);
 });
 
+test("player achievement tracker can award battle wins from explicit participant metadata", () => {
+  const state = {
+    ...createAccountTrackingWorldState(),
+    heroes: []
+  };
+  const updated = applyPlayerEventLogAndAchievements(
+    {
+      playerId: "player-1",
+      displayName: "暮火侦骑",
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [
+        {
+          id: "enemy_slayer",
+          title: "ignored",
+          description: "ignored",
+          metric: "battles_won",
+          current: 2,
+          target: 3,
+          unlocked: false,
+          progressUpdatedAt: "2026-03-27T11:59:00.000Z"
+        }
+      ],
+      recentEventLog: []
+    },
+    state,
+    [
+      {
+        type: "battle.resolved",
+        heroId: "hero-1",
+        attackerPlayerId: "player-1",
+        defenderHeroId: "hero-2",
+        defenderPlayerId: "player-2",
+        battleId: "battle-hero-1-vs-hero-2",
+        result: "attacker_victory"
+      }
+    ],
+    "2026-03-27T12:00:00.000Z"
+  );
+
+  assert.equal(updated.achievements.find((achievement) => achievement.id === "enemy_slayer")?.current, 3);
+  assert.equal(updated.achievements.find((achievement) => achievement.id === "enemy_slayer")?.unlocked, true);
+  assert.match(updated.recentEventLog.map((entry) => entry.description).join(" "), /解锁成就：猎敌者/);
+});
+
 test("player achievement tracker records equipment drop entries for hero victories", () => {
   const updated = applyPlayerEventLogAndAchievements(
     {

--- a/apps/server/test/room-persistence.test.ts
+++ b/apps/server/test/room-persistence.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildPlayerBattleReplaySummary, type CompletedBattleReplayCapture } from "../src/battle-replays";
+import {
+  buildPlayerBattleReplaySummariesForPlayer,
+  buildPlayerBattleReplaySummary,
+  type CompletedBattleReplayCapture
+} from "../src/battle-replays";
 import { createRoom } from "../src/index";
 
 test("room persistence snapshot restores an active neutral battle", () => {
@@ -91,6 +95,8 @@ test("player battle replay summaries preserve the global battle result for both 
   const replay: CompletedBattleReplayCapture = {
     battleId: "battle-hero-1-vs-hero-2",
     roomId: "room-persist-pvp",
+    attackerPlayerId: "player-1",
+    defenderPlayerId: "player-2",
     startedAt: "2026-03-27T12:00:00.000Z",
     completedAt: "2026-03-27T12:01:00.000Z",
     initialState: {
@@ -264,4 +270,179 @@ test("player battle replay summaries preserve the global battle result for both 
 
   assert.equal(attackerReplay.result, "attacker_victory");
   assert.equal(defenderReplay.result, "attacker_victory");
+});
+
+test("player battle replay summaries can resolve both camps from persisted participant ids", () => {
+  const replay: CompletedBattleReplayCapture = {
+    battleId: "battle-hero-1-vs-hero-2",
+    roomId: "room-persist-pvp",
+    attackerPlayerId: "player-1",
+    defenderPlayerId: "player-2",
+    startedAt: "2026-03-27T12:00:00.000Z",
+    completedAt: "2026-03-27T12:01:00.000Z",
+    initialState: {
+      id: "battle-hero-1-vs-hero-2",
+      heroTemplateId: "hero_knight",
+      attacker: {
+        id: "hero-1-stack",
+        camp: "attacker",
+        templateId: "hero_guard_basic",
+        count: 12,
+        attack: 4,
+        defense: 2,
+        hp: 10,
+        maxHp: 10,
+        morale: 0,
+        luck: 0,
+        speed: 4,
+        retaliationsRemaining: 1,
+        hasWaited: false,
+        position: { x: 0, y: 0 }
+      },
+      defender: {
+        id: "hero-2-stack",
+        camp: "defender",
+        templateId: "hero_guard_basic",
+        count: 8,
+        attack: 3,
+        defense: 2,
+        hp: 10,
+        maxHp: 10,
+        morale: 0,
+        luck: 0,
+        speed: 3,
+        retaliationsRemaining: 1,
+        hasWaited: false,
+        position: { x: 1, y: 0 }
+      },
+      units: {
+        "hero-1-stack": {
+          id: "hero-1-stack",
+          camp: "attacker",
+          templateId: "hero_guard_basic",
+          count: 12,
+          attack: 4,
+          defense: 2,
+          hp: 10,
+          maxHp: 10,
+          morale: 0,
+          luck: 0,
+          speed: 4,
+          retaliationsRemaining: 1,
+          hasWaited: false,
+          position: { x: 0, y: 0 }
+        },
+        "hero-2-stack": {
+          id: "hero-2-stack",
+          camp: "defender",
+          templateId: "hero_guard_basic",
+          count: 8,
+          attack: 3,
+          defense: 2,
+          hp: 10,
+          maxHp: 10,
+          morale: 0,
+          luck: 0,
+          speed: 3,
+          retaliationsRemaining: 1,
+          hasWaited: false,
+          position: { x: 1, y: 0 }
+        }
+      },
+      turnOrder: ["hero-1-stack", "hero-2-stack"],
+      activeUnitId: "hero-2-stack",
+      round: 1,
+      seed: 1001,
+      worldHeroId: "hero-1",
+      defenderHeroId: "hero-2"
+    },
+    battleState: {
+      id: "battle-hero-1-vs-hero-2",
+      heroTemplateId: "hero_knight",
+      attacker: {
+        id: "hero-1-stack",
+        camp: "attacker",
+        templateId: "hero_guard_basic",
+        count: 7,
+        attack: 4,
+        defense: 2,
+        hp: 10,
+        maxHp: 10,
+        morale: 0,
+        luck: 0,
+        speed: 4,
+        retaliationsRemaining: 0,
+        hasWaited: false,
+        position: { x: 0, y: 0 }
+      },
+      defender: {
+        id: "hero-2-stack",
+        camp: "defender",
+        templateId: "hero_guard_basic",
+        count: 0,
+        attack: 3,
+        defense: 2,
+        hp: 0,
+        maxHp: 10,
+        morale: 0,
+        luck: 0,
+        speed: 3,
+        retaliationsRemaining: 0,
+        hasWaited: false,
+        position: { x: 1, y: 0 }
+      },
+      units: {
+        "hero-1-stack": {
+          id: "hero-1-stack",
+          camp: "attacker",
+          templateId: "hero_guard_basic",
+          count: 7,
+          attack: 4,
+          defense: 2,
+          hp: 10,
+          maxHp: 10,
+          morale: 0,
+          luck: 0,
+          speed: 4,
+          retaliationsRemaining: 0,
+          hasWaited: false,
+          position: { x: 0, y: 0 }
+        },
+        "hero-2-stack": {
+          id: "hero-2-stack",
+          camp: "defender",
+          templateId: "hero_guard_basic",
+          count: 0,
+          attack: 3,
+          defense: 2,
+          hp: 0,
+          maxHp: 10,
+          morale: 0,
+          luck: 0,
+          speed: 3,
+          retaliationsRemaining: 0,
+          hasWaited: false,
+          position: { x: 1, y: 0 }
+        }
+      },
+      turnOrder: ["hero-1-stack"],
+      activeUnitId: "hero-1-stack",
+      round: 2,
+      seed: 1001,
+      worldHeroId: "hero-1",
+      defenderHeroId: "hero-2"
+    },
+    steps: [],
+    result: "attacker_victory"
+  };
+
+  assert.deepEqual(
+    buildPlayerBattleReplaySummariesForPlayer(replay, "player-1").map((entry) => entry.playerCamp),
+    ["attacker"]
+  );
+  assert.deepEqual(
+    buildPlayerBattleReplaySummariesForPlayer(replay, "player-2").map((entry) => entry.playerCamp),
+    ["defender"]
+  );
+  assert.deepEqual(buildPlayerBattleReplaySummariesForPlayer(replay, "player-3"), []);
 });

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -1086,6 +1086,7 @@ function resolveNeutralArmyTurn(
           {
             type: "battle.started",
             heroId: chaseTarget.heroId,
+            attackerPlayerId: hero?.playerId ?? "",
             encounterKind: "neutral",
             neutralArmyId: neutralArmy.id,
             initiator: "neutral",
@@ -2135,6 +2136,10 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
 
     if (plan.endsInEncounter) {
       const encounterRefId = plan.encounterRefId;
+      const encounterHero =
+        plan.encounterKind === "hero" && encounterRefId
+          ? state.heroes.find((item) => item.id === encounterRefId)
+          : undefined;
       return {
         state: nextState,
         movementPlan: plan,
@@ -2143,9 +2148,14 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
               {
                 type: "battle.started",
                 heroId: action.heroId,
+                attackerPlayerId: hero.playerId,
                 encounterKind: plan.encounterKind === "hero" ? "hero" : "neutral",
                 ...(plan.encounterKind === "hero"
-                  ? { defenderHeroId: encounterRefId, battleId: `battle-${action.heroId}-vs-${encounterRefId}` }
+                  ? {
+                      defenderHeroId: encounterRefId,
+                      ...(encounterHero?.playerId ? { defenderPlayerId: encounterHero.playerId } : {}),
+                      battleId: `battle-${action.heroId}-vs-${encounterRefId}`
+                    }
                   : { neutralArmyId: encounterRefId, battleId: `battle-${encounterRefId}` }),
                 path: plan.travelPath,
                 moveCost: plan.moveCost
@@ -2459,6 +2469,9 @@ export function filterWorldEventsForPlayer(
         return event.playerId === playerId;
       case "battle.started":
       case "battle.resolved":
+        if (event.attackerPlayerId === playerId || event.defenderPlayerId === playerId) {
+          return true;
+        }
         return ownsHero(event.heroId) || ownsHero(event.defenderHeroId);
       default:
         return false;
@@ -2509,8 +2522,9 @@ export function applyBattleOutcomeToWorld(
           {
             type: "battle.resolved",
             heroId,
+            attackerPlayerId: attackerHero.playerId,
             battleId,
-            ...(defenderId ? { defenderHeroId: defenderId } : {}),
+            ...(defenderId ? { defenderHeroId: defenderId, defenderPlayerId: defenderHero.playerId } : {}),
             result: "defender_victory"
           },
           {
@@ -2569,8 +2583,9 @@ export function applyBattleOutcomeToWorld(
           {
             type: "battle.resolved",
             heroId,
+            attackerPlayerId: attackerHero.playerId,
             battleId,
-            ...(defenderId ? { defenderHeroId: defenderId } : {}),
+            ...(defenderId ? { defenderHeroId: defenderId, defenderPlayerId: defenderHero.playerId } : {}),
             result: "attacker_victory"
           },
           {
@@ -2621,6 +2636,7 @@ export function applyBattleOutcomeToWorld(
         {
           type: "battle.resolved",
           heroId,
+          attackerPlayerId: attackerHero.playerId,
           battleId,
           result: "defender_victory"
         }
@@ -2654,6 +2670,7 @@ export function applyBattleOutcomeToWorld(
       {
         type: "battle.resolved",
         heroId,
+        attackerPlayerId: attackerHero.playerId,
         battleId,
         result: "attacker_victory"
       },

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -658,9 +658,11 @@ export type WorldEvent =
   | {
       type: "battle.started";
       heroId: string;
+      attackerPlayerId: string;
       encounterKind: "neutral" | "hero";
       neutralArmyId?: string;
       defenderHeroId?: string;
+      defenderPlayerId?: string;
       initiator?: "hero" | "neutral";
       battleId: string;
       path: Vec2[];
@@ -673,7 +675,9 @@ export type WorldEvent =
   | {
       type: "battle.resolved";
       heroId: string;
+      attackerPlayerId: string;
       defenderHeroId?: string;
+      defenderPlayerId?: string;
       battleId: string;
       result: "attacker_victory" | "defender_victory";
     };

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1378,6 +1378,7 @@ test("resolveWorldAction starts a battle when a hero reaches a neutral army tile
     {
       type: "battle.started",
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       encounterKind: "neutral",
       neutralArmyId: "neutral-1",
       battleId: "battle-neutral-1",
@@ -1533,6 +1534,7 @@ test("applyBattleOutcomeToWorld grants neutral rewards and moves the hero onto t
     {
       type: "battle.resolved",
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       battleId: "battle-neutral-1",
       result: "attacker_victory"
     },
@@ -1604,7 +1606,9 @@ test("applyBattleOutcomeToWorld grants PvP experience to the winning hero", () =
     {
       type: "battle.resolved",
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       defenderHeroId: "hero-2",
+      defenderPlayerId: "player-2",
       battleId: "battle-hero-1-vs-hero-2",
       result: "defender_victory"
     },
@@ -2718,6 +2722,7 @@ test("resolveWorldAction can start a neutral-initiated battle on end day", () =>
     {
       type: "battle.started",
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       encounterKind: "neutral",
       neutralArmyId: "neutral-1",
       initiator: "neutral",
@@ -3133,6 +3138,7 @@ test("applyBattleOutcomeToWorld penalizes the hero on defeat and keeps the neutr
     {
       type: "battle.resolved",
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       battleId: "battle-neutral-1",
       result: "defender_victory"
     }
@@ -3179,7 +3185,9 @@ test("applyBattleOutcomeToWorld keeps defenderHeroId on hero-vs-hero resolution 
     {
       type: "battle.resolved",
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       defenderHeroId: "hero-2",
+      defenderPlayerId: "player-2",
       battleId: "battle-hero-1-vs-hero-2",
       result: "attacker_victory"
     },
@@ -3235,7 +3243,9 @@ test("filterWorldEventsForPlayer hides unrelated hero timelines while keeping mi
     {
       type: "battle.started" as const,
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       defenderHeroId: "hero-2",
+      defenderPlayerId: "player-2",
       encounterKind: "hero" as const,
       battleId: "battle-hero-1-vs-hero-2",
       path: [{ x: 1, y: 1 }, { x: 2, y: 1 }],
@@ -3244,7 +3254,9 @@ test("filterWorldEventsForPlayer hides unrelated hero timelines while keeping mi
     {
       type: "battle.resolved" as const,
       heroId: "hero-1",
+      attackerPlayerId: "player-1",
       defenderHeroId: "hero-2",
+      defenderPlayerId: "player-2",
       battleId: "battle-hero-1-vs-hero-2",
       result: "attacker_victory" as const
     },
@@ -3293,6 +3305,45 @@ test("filterWorldEventsForPlayer hides unrelated hero timelines while keeping mi
   ]);
   assert.deepEqual(filterWorldEventsForPlayer(state, "player-2", events), [events[2], events[3], events[7]]);
   assert.deepEqual(filterWorldEventsForPlayer(state, "player-3", events), [events[1], events[6], events[7]]);
+});
+
+test("filterWorldEventsForPlayer falls back to participant player ids when battle heroes are no longer present", () => {
+  const state = createWorldState({
+    heroes: [
+      createHero({
+        id: "hero-3",
+        playerId: "player-3",
+        name: "旁观者",
+        position: { x: 0, y: 0 }
+      })
+    ]
+  });
+  const events = [
+    {
+      type: "battle.started" as const,
+      heroId: "hero-1",
+      attackerPlayerId: "player-1",
+      defenderHeroId: "hero-2",
+      defenderPlayerId: "player-2",
+      encounterKind: "hero" as const,
+      battleId: "battle-hero-1-vs-hero-2",
+      path: [{ x: 1, y: 1 }, { x: 2, y: 1 }],
+      moveCost: 1
+    },
+    {
+      type: "battle.resolved" as const,
+      heroId: "hero-1",
+      attackerPlayerId: "player-1",
+      defenderHeroId: "hero-2",
+      defenderPlayerId: "player-2",
+      battleId: "battle-hero-1-vs-hero-2",
+      result: "defender_victory" as const
+    }
+  ];
+
+  assert.deepEqual(filterWorldEventsForPlayer(state, "player-1", events), events);
+  assert.deepEqual(filterWorldEventsForPlayer(state, "player-2", events), events);
+  assert.deepEqual(filterWorldEventsForPlayer(state, "player-3", events), []);
 });
 
 test("applyBattleAction uses deterministic damage and retaliation flow", () => {


### PR DESCRIPTION
Summary
- add attacker/defender player ids to shared battle start and resolution events so progression logic does not depend on mutable hero lookups
- persist the same participant metadata into server-side battle replay captures and use it when building player replay summaries
- cover the new metadata path in shared filtering tests, server achievement wiring tests, replay summary tests, and updated room expectations

Testing
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:client:h5
- npm run typecheck:cocos
- npm test

Refs #27