### PR TITLE
feat: add battle replay detail api for #27

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   buildPlayerProgressionSnapshot,
+  findPlayerBattleReplaySummary,
   getAchievementDefinitions,
   queryPlayerBattleReplaySummaries,
   queryAchievementProgress,
@@ -127,6 +128,14 @@ function toReplayResponseFromRequest(
       ...(result ? { result } : {})
     })
   };
+}
+
+function toReplayDetailResponse(
+  account: PlayerAccountSnapshot,
+  replayId?: string | null
+): { replay: NonNullable<PlayerAccountSnapshot["recentBattleReplays"]>[number] } | null {
+  const replay = findPlayerBattleReplaySummary(account.recentBattleReplays, replayId);
+  return replay ? { replay } : null;
 }
 
 function toEventLogResponse(
@@ -364,6 +373,53 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.get("/api/player-accounts/me/battle-replays/:replayId", async (request, response) => {
+    const authSession = resolveAuthSessionFromRequest(request);
+    if (!authSession) {
+      sendUnauthorized(response);
+      return;
+    }
+
+    const replayId = request.params.replayId?.trim();
+    if (!replayId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 404, {
+        error: {
+          code: "player_battle_replay_not_found",
+          message: `Player battle replay not found: ${replayId}`
+        }
+      });
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      const detail = toReplayDetailResponse(account, replayId);
+      if (!detail) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_battle_replay_not_found",
+            message: `Player battle replay not found: ${replayId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, detail);
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
   app.get("/api/player-accounts/me/event-log", async (request, response) => {
     const authSession = resolveAuthSessionFromRequest(request);
     if (!authSession) {
@@ -535,6 +591,53 @@ export function registerPlayerAccountRoutes(
       }
 
       sendJson(response, 200, toReplayResponseFromRequest(account, request));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/:playerId/battle-replays/:replayId", async (request, response) => {
+    const playerId = request.params.playerId?.trim();
+    const replayId = request.params.replayId?.trim();
+    if (!playerId || !replayId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 404, {
+        error: {
+          code: "player_battle_replay_not_found",
+          message: `Player battle replay not found: ${replayId}`
+        }
+      });
+      return;
+    }
+
+    try {
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_account_not_found",
+            message: `Player account not found: ${playerId}`
+          }
+        });
+        return;
+      }
+
+      const detail = toReplayDetailResponse(account, replayId);
+      if (!detail) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_battle_replay_not_found",
+            message: `Player battle replay not found: ${replayId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, detail);
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-battle-replay-detail-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-detail-routes.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Server, WebSocketTransport } from "colyseus";
+import { issueGuestAuthSession } from "../src/auth";
+import { registerPlayerAccountRoutes } from "../src/player-accounts";
+import type {
+  PlayerAccountAuthSnapshot,
+  PlayerAccountCredentialInput,
+  PlayerAccountEnsureInput,
+  PlayerAccountListOptions,
+  PlayerAccountProfilePatch,
+  PlayerAccountProgressPatch,
+  PlayerAccountSnapshot,
+  PlayerHeroArchiveSnapshot,
+  RoomSnapshotStore
+} from "../src/persistence";
+import type { RoomPersistenceSnapshot } from "../src/index";
+import { createEmptyBattleState, type PlayerBattleReplaySummary } from "../../../packages/shared/src/index";
+
+class MemoryPlayerAccountStore implements RoomSnapshotStore {
+  private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+
+  async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
+    return null;
+  }
+
+  async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
+    return this.accounts.get(playerId) ?? null;
+  }
+
+  async loadPlayerAccountByLoginId(_loginId: string): Promise<PlayerAccountSnapshot | null> {
+    return null;
+  }
+
+  async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {
+    return playerIds
+      .map((playerId) => this.accounts.get(playerId))
+      .filter((account): account is PlayerAccountSnapshot => Boolean(account));
+  }
+
+  async loadPlayerAccountAuthByLoginId(_loginId: string): Promise<PlayerAccountAuthSnapshot | null> {
+    return null;
+  }
+
+  async loadPlayerHeroArchives(_playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
+    return [];
+  }
+
+  async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
+    const existing = this.accounts.get(input.playerId);
+    const account: PlayerAccountSnapshot = {
+      playerId: input.playerId,
+      displayName: input.displayName?.trim() || existing?.displayName || input.playerId,
+      globalResources: existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 },
+      achievements: structuredClone(existing?.achievements ?? []),
+      recentEventLog: structuredClone(existing?.recentEventLog ?? []),
+      recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
+      createdAt: existing?.createdAt ?? new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(account.playerId, account);
+    return account;
+  }
+
+  async bindPlayerAccountCredentials(_playerId: string, _input: PlayerAccountCredentialInput): Promise<PlayerAccountSnapshot> {
+    throw new Error("not implemented");
+  }
+
+  async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      displayName: patch.displayName?.trim() || existing.displayName,
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(playerId, account);
+    return account;
+  }
+
+  async savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
+      recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      recentBattleReplays: structuredClone(
+        (patch.recentBattleReplays as PlayerAccountSnapshot["recentBattleReplays"] | undefined) ?? existing.recentBattleReplays
+      ),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(playerId, account);
+    return account;
+  }
+
+  async listPlayerAccounts(options: PlayerAccountListOptions = {}): Promise<PlayerAccountSnapshot[]> {
+    const accounts = Array.from(this.accounts.values()).filter((account) =>
+      options.playerId ? account.playerId === options.playerId : true
+    );
+    return accounts.slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
+  }
+
+  async save(_roomId: string, _snapshot: RoomPersistenceSnapshot): Promise<void> {}
+
+  async delete(_roomId: string): Promise<void> {}
+
+  async pruneExpired(): Promise<number> {
+    return 0;
+  }
+
+  async close(): Promise<void> {}
+
+  seedAccount(account: PlayerAccountSnapshot): void {
+    this.accounts.set(account.playerId, account);
+  }
+}
+
+async function startAccountRouteServer(port: number, store: RoomSnapshotStore | null): Promise<Server> {
+  const transport = new WebSocketTransport();
+  registerPlayerAccountRoutes(transport.getExpressApp() as never, store);
+  const server = new Server({ transport });
+  await server.listen(port, "127.0.0.1");
+  return server;
+}
+
+function createReplaySummary(id: string): PlayerBattleReplaySummary {
+  const initialState = createEmptyBattleState();
+  initialState.id = "battle-1";
+
+  return {
+    id,
+    roomId: "room-replay",
+    playerId: "player-1",
+    battleId: "battle-1",
+    battleKind: "neutral",
+    playerCamp: "attacker",
+    heroId: "hero-1",
+    neutralArmyId: "neutral-1",
+    startedAt: "2026-03-27T10:00:00.000Z",
+    completedAt: "2026-03-27T10:01:00.000Z",
+    initialState,
+    steps: [
+      {
+        index: 1,
+        source: "player",
+        action: {
+          type: "battle.wait",
+          unitId: "hero-1-stack"
+        }
+      }
+    ],
+    result: "attacker_victory"
+  };
+}
+
+test("player account battle replay detail routes return a normalized replay payload", async (t) => {
+  const port = 43010 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-1",
+    displayName: "回声骑士",
+    globalResources: { gold: 10, wood: 1, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [createReplaySummary(" replay-detail ")],
+    createdAt: "2026-03-27T10:00:00.000Z",
+    updatedAt: "2026-03-27T10:05:00.000Z"
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-1",
+    displayName: "回声骑士"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const publicResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-detail`);
+  const publicPayload = (await publicResponse.json()) as { replay: PlayerBattleReplaySummary };
+  assert.equal(publicResponse.status, 200);
+  assert.equal(publicPayload.replay.id, "replay-detail");
+  assert.equal(publicPayload.replay.steps[0]?.index, 1);
+
+  const meResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/battle-replays/replay-detail`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const mePayload = (await meResponse.json()) as { replay: PlayerBattleReplaySummary };
+  assert.equal(meResponse.status, 200);
+  assert.equal(mePayload.replay.id, "replay-detail");
+});
+
+test("player account battle replay detail routes return 404s for missing resources and 401 without auth", async (t) => {
+  const port = 43020 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-1",
+    displayName: "回声骑士",
+    globalResources: { gold: 10, wood: 1, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [createReplaySummary("replay-detail")],
+    createdAt: "2026-03-27T10:00:00.000Z",
+    updatedAt: "2026-03-27T10:05:00.000Z"
+  });
+  const server = await startAccountRouteServer(port, store);
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const missingReplayResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/missing-replay`);
+  assert.equal(missingReplayResponse.status, 404);
+
+  const missingPlayerResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/missing/battle-replays/replay-detail`);
+  assert.equal(missingPlayerResponse.status, 404);
+
+  const unauthorizedResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/battle-replays/replay-detail`);
+  assert.equal(unauthorizedResponse.status, 401);
+});

--- a/packages/shared/src/battle-replay.ts
+++ b/packages/shared/src/battle-replay.ts
@@ -262,3 +262,15 @@ export function queryPlayerBattleReplaySummaries(
     .filter((replay) => (query.result ? replay.result === query.result : true))
     .slice(0, safeLimit);
 }
+
+export function findPlayerBattleReplaySummary(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null,
+  replayId?: string | null
+): PlayerBattleReplaySummary | null {
+  const normalizedReplayId = replayId?.trim();
+  if (!normalizedReplayId) {
+    return null;
+  }
+
+  return normalizePlayerBattleReplaySummaries(replays).find((replay) => replay.id === normalizedReplayId) ?? null;
+}

--- a/packages/shared/test/battle-replay-detail.test.ts
+++ b/packages/shared/test/battle-replay-detail.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createEmptyBattleState, findPlayerBattleReplaySummary } from "../src/index";
+
+test("battle replay detail helper returns a normalized replay by id", () => {
+  const battle = createEmptyBattleState();
+  const replay = findPlayerBattleReplaySummary(
+    [
+      {
+        id: " replay-neutral ",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        battleId: "battle-neutral-1",
+        battleKind: "neutral",
+        playerCamp: "attacker",
+        heroId: "hero-1",
+        neutralArmyId: "neutral-1",
+        startedAt: "2026-03-27T10:00:00.000Z",
+        completedAt: "2026-03-27T10:01:00.000Z",
+        initialState: battle,
+        steps: [
+          {
+            index: 3,
+            source: "player",
+            action: {
+              type: "battle.wait",
+              unitId: "hero-1-stack"
+            }
+          }
+        ],
+        result: "attacker_victory"
+      }
+    ],
+    "replay-neutral"
+  );
+
+  assert.ok(replay);
+  assert.equal(replay.id, "replay-neutral");
+  assert.equal(replay.steps[0]?.index, 3);
+  assert.equal(findPlayerBattleReplaySummary([replay], "missing-replay"), null);
+  assert.equal(findPlayerBattleReplaySummary([replay], "   "), null);
+});


### PR DESCRIPTION
## Summary
- add a shared replay detail lookup helper so persisted battle replays can be fetched by replay id
- expose public and authenticated player-account replay detail endpoints that return the full stored replay payload
- cover the new replay detail route behavior with focused shared and server tests

## Testing
- node --import tsx --test ./packages/shared/test/battle-replay-detail.test.ts
- node --import tsx --test ./apps/server/test/player-account-battle-replay-detail-routes.test.ts
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- npm run typecheck:server

Refs #27