### PR TITLE
feat: add battle replay playback api for #27

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  applyBattleReplayPlaybackCommand,
   buildPlayerProgressionSnapshot,
   findPlayerBattleReplaySummary,
   getAchievementDefinitions,
@@ -95,6 +96,16 @@ function parseBooleanQueryParam(request: IncomingMessage, key: string): boolean 
   return undefined;
 }
 
+function parseNumberQueryParam(request: IncomingMessage, key: string): number | undefined {
+  const value = parseOptionalQueryParam(request, key);
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 function toReplayResponseFromRequest(
   account: PlayerAccountSnapshot,
   request: IncomingMessage
@@ -136,6 +147,31 @@ function toReplayDetailResponse(
 ): { replay: NonNullable<PlayerAccountSnapshot["recentBattleReplays"]>[number] } | null {
   const replay = findPlayerBattleReplaySummary(account.recentBattleReplays, replayId);
   return replay ? { replay } : null;
+}
+
+function toReplayPlaybackResponse(
+  account: PlayerAccountSnapshot,
+  request: IncomingMessage,
+  replayId?: string | null
+) {
+  const replay = findPlayerBattleReplaySummary(account.recentBattleReplays, replayId);
+  if (!replay) {
+    return null;
+  }
+
+  const currentStepIndex = parseNumberQueryParam(request, "currentStepIndex");
+  const status = parseOptionalQueryParam(request, "status") as "paused" | "playing" | undefined;
+  const action = parseOptionalQueryParam(request, "action") as "play" | "pause" | "step" | "tick" | "reset" | undefined;
+  const repeat = parseNumberQueryParam(request, "repeat");
+
+  return {
+    playback: applyBattleReplayPlaybackCommand(replay, {
+      ...(currentStepIndex != null ? { currentStepIndex } : {}),
+      ...(status ? { status } : {}),
+      ...(action ? { action } : {}),
+      ...(repeat != null ? { repeat } : {})
+    })
+  };
 }
 
 function toEventLogResponse(
@@ -420,6 +456,53 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.get("/api/player-accounts/me/battle-replays/:replayId/playback", async (request, response) => {
+    const authSession = resolveAuthSessionFromRequest(request);
+    if (!authSession) {
+      sendUnauthorized(response);
+      return;
+    }
+
+    const replayId = request.params.replayId?.trim();
+    if (!replayId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 404, {
+        error: {
+          code: "player_battle_replay_not_found",
+          message: `Player battle replay not found: ${replayId}`
+        }
+      });
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      const playback = toReplayPlaybackResponse(account, request, replayId);
+      if (!playback) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_battle_replay_not_found",
+            message: `Player battle replay not found: ${replayId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, playback);
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
   app.get("/api/player-accounts/me/event-log", async (request, response) => {
     const authSession = resolveAuthSessionFromRequest(request);
     if (!authSession) {
@@ -638,6 +721,53 @@ export function registerPlayerAccountRoutes(
       }
 
       sendJson(response, 200, detail);
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/:playerId/battle-replays/:replayId/playback", async (request, response) => {
+    const playerId = request.params.playerId?.trim();
+    const replayId = request.params.replayId?.trim();
+    if (!playerId || !replayId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 404, {
+        error: {
+          code: "player_battle_replay_not_found",
+          message: `Player battle replay not found: ${replayId}`
+        }
+      });
+      return;
+    }
+
+    try {
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_account_not_found",
+            message: `Player account not found: ${playerId}`
+          }
+        });
+        return;
+      }
+
+      const playback = toReplayPlaybackResponse(account, request, replayId);
+      if (!playback) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_battle_replay_not_found",
+            message: `Player battle replay not found: ${replayId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, playback);
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-battle-replay-playback-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-playback-routes.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Server, WebSocketTransport } from "colyseus";
+import { issueGuestAuthSession } from "../src/auth";
+import { registerPlayerAccountRoutes } from "../src/player-accounts";
+import type {
+  PlayerAccountAuthSnapshot,
+  PlayerAccountCredentialInput,
+  PlayerAccountEnsureInput,
+  PlayerAccountListOptions,
+  PlayerAccountProfilePatch,
+  PlayerAccountProgressPatch,
+  PlayerAccountSnapshot,
+  PlayerHeroArchiveSnapshot,
+  RoomSnapshotStore
+} from "../src/persistence";
+import type { RoomPersistenceSnapshot } from "../src/index";
+import {
+  createEmptyBattleState,
+  type BattleReplayPlaybackState,
+  type PlayerBattleReplaySummary
+} from "../../../packages/shared/src/index";
+
+class MemoryPlayerAccountStore implements RoomSnapshotStore {
+  private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+
+  async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
+    return null;
+  }
+
+  async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
+    return this.accounts.get(playerId) ?? null;
+  }
+
+  async loadPlayerAccountByLoginId(_loginId: string): Promise<PlayerAccountSnapshot | null> {
+    return null;
+  }
+
+  async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {
+    return playerIds
+      .map((playerId) => this.accounts.get(playerId))
+      .filter((account): account is PlayerAccountSnapshot => Boolean(account));
+  }
+
+  async loadPlayerAccountAuthByLoginId(_loginId: string): Promise<PlayerAccountAuthSnapshot | null> {
+    return null;
+  }
+
+  async loadPlayerHeroArchives(_playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
+    return [];
+  }
+
+  async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
+    const existing = this.accounts.get(input.playerId);
+    const account: PlayerAccountSnapshot = {
+      playerId: input.playerId,
+      displayName: input.displayName?.trim() || existing?.displayName || input.playerId,
+      globalResources: existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 },
+      achievements: structuredClone(existing?.achievements ?? []),
+      recentEventLog: structuredClone(existing?.recentEventLog ?? []),
+      recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
+      createdAt: existing?.createdAt ?? new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(account.playerId, account);
+    return account;
+  }
+
+  async bindPlayerAccountCredentials(_playerId: string, _input: PlayerAccountCredentialInput): Promise<PlayerAccountSnapshot> {
+    throw new Error("not implemented");
+  }
+
+  async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      displayName: patch.displayName?.trim() || existing.displayName,
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(playerId, account);
+    return account;
+  }
+
+  async savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
+      recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      recentBattleReplays: structuredClone(
+        (patch.recentBattleReplays as PlayerAccountSnapshot["recentBattleReplays"] | undefined) ?? existing.recentBattleReplays
+      ),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(playerId, account);
+    return account;
+  }
+
+  async listPlayerAccounts(options: PlayerAccountListOptions = {}): Promise<PlayerAccountSnapshot[]> {
+    const accounts = Array.from(this.accounts.values()).filter((account) =>
+      options.playerId ? account.playerId === options.playerId : true
+    );
+    return accounts.slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
+  }
+
+  async save(_roomId: string, _snapshot: RoomPersistenceSnapshot): Promise<void> {}
+
+  async delete(_roomId: string): Promise<void> {}
+
+  async pruneExpired(): Promise<number> {
+    return 0;
+  }
+
+  async close(): Promise<void> {}
+
+  seedAccount(account: PlayerAccountSnapshot): void {
+    this.accounts.set(account.playerId, account);
+  }
+}
+
+async function startAccountRouteServer(port: number, store: RoomSnapshotStore | null): Promise<Server> {
+  const transport = new WebSocketTransport();
+  registerPlayerAccountRoutes(transport.getExpressApp() as never, store);
+  const server = new Server({ transport });
+  await server.listen(port, "127.0.0.1");
+  return server;
+}
+
+function createReplaySummary(id: string): PlayerBattleReplaySummary {
+  const initialState = createEmptyBattleState();
+  initialState.id = "battle-playback";
+
+  return {
+    id,
+    roomId: "room-replay",
+    playerId: "player-1",
+    battleId: "battle-1",
+    battleKind: "neutral",
+    playerCamp: "attacker",
+    heroId: "hero-1",
+    neutralArmyId: "neutral-1",
+    startedAt: "2026-03-27T10:00:00.000Z",
+    completedAt: "2026-03-27T10:01:00.000Z",
+    initialState,
+    steps: [
+      {
+        index: 1,
+        source: "player",
+        action: {
+          type: "battle.wait",
+          unitId: "hero-1-stack"
+        }
+      },
+      {
+        index: 2,
+        source: "automated",
+        action: {
+          type: "battle.defend",
+          unitId: "neutral-1-stack"
+        }
+      }
+    ],
+    result: "attacker_victory"
+  };
+}
+
+test("player account battle replay playback routes derive stateless playback controls", async (t) => {
+  const port = 43030 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-1",
+    displayName: "回声骑士",
+    globalResources: { gold: 10, wood: 1, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [createReplaySummary(" replay-playback ")],
+    createdAt: "2026-03-27T10:00:00.000Z",
+    updatedAt: "2026-03-27T10:05:00.000Z"
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-1",
+    displayName: "回声骑士"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const publicResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-playback/playback?action=tick&repeat=2`
+  );
+  const publicPayload = (await publicResponse.json()) as { playback: BattleReplayPlaybackState };
+  assert.equal(publicResponse.status, 200);
+  assert.equal(publicPayload.playback.replay.id, "replay-playback");
+  assert.equal(publicPayload.playback.currentStepIndex, 2);
+  assert.equal(publicPayload.playback.status, "completed");
+  assert.equal(publicPayload.playback.currentStep?.index, 2);
+
+  const meResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/battle-replays/replay-playback/playback?currentStepIndex=1&status=playing&action=pause`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const mePayload = (await meResponse.json()) as { playback: BattleReplayPlaybackState };
+  assert.equal(meResponse.status, 200);
+  assert.equal(mePayload.playback.currentStepIndex, 1);
+  assert.equal(mePayload.playback.status, "paused");
+  assert.equal(mePayload.playback.nextStep?.index, 2);
+});
+
+test("player account battle replay playback routes return 404s for missing resources and 401 without auth", async (t) => {
+  const port = 43040 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-1",
+    displayName: "回声骑士",
+    globalResources: { gold: 10, wood: 1, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [createReplaySummary("replay-playback")],
+    createdAt: "2026-03-27T10:00:00.000Z",
+    updatedAt: "2026-03-27T10:05:00.000Z"
+  });
+  const server = await startAccountRouteServer(port, store);
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const missingReplayResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/missing-replay/playback`);
+  assert.equal(missingReplayResponse.status, 404);
+
+  const missingPlayerResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/missing/battle-replays/replay-playback/playback`);
+  assert.equal(missingPlayerResponse.status, 404);
+
+  const unauthorizedResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/battle-replays/replay-playback/playback`);
+  assert.equal(unauthorizedResponse.status, 401);
+});

--- a/packages/shared/src/battle-replay.ts
+++ b/packages/shared/src/battle-replay.ts
@@ -41,6 +41,7 @@ export interface PlayerBattleReplayQuery {
 }
 
 export type BattleReplayPlaybackStatus = "paused" | "playing" | "completed";
+export type BattleReplayPlaybackAction = "play" | "pause" | "step" | "tick" | "reset";
 
 export interface BattleReplayPlaybackState {
   replay: PlayerBattleReplaySummary;
@@ -50,6 +51,13 @@ export interface BattleReplayPlaybackState {
   currentState: BattleState;
   currentStep: BattleReplayStep | null;
   nextStep: BattleReplayStep | null;
+}
+
+export interface BattleReplayPlaybackCommand {
+  currentStepIndex?: number | undefined;
+  status?: Exclude<BattleReplayPlaybackStatus, "completed"> | undefined;
+  action?: BattleReplayPlaybackAction | undefined;
+  repeat?: number | undefined;
 }
 
 function normalizeTimestamp(value?: string | null): string | undefined {
@@ -94,6 +102,26 @@ function buildPlaybackState(
 
 export function createBattleReplayPlaybackState(replay: PlayerBattleReplaySummary): BattleReplayPlaybackState {
   return buildPlaybackState(replay, replay.initialState, 0, "paused");
+}
+
+export function restoreBattleReplayPlaybackState(
+  replay: PlayerBattleReplaySummary,
+  currentStepIndex = 0,
+  status: Exclude<BattleReplayPlaybackStatus, "completed"> = "paused"
+): BattleReplayPlaybackState {
+  const safeStepIndex = Math.max(0, Math.min(replay.steps.length, Math.floor(currentStepIndex)));
+  let currentState = cloneBattleState(replay.initialState);
+
+  for (let index = 0; index < safeStepIndex; index += 1) {
+    const step = replay.steps[index];
+    if (!step) {
+      break;
+    }
+
+    currentState = applyBattleAction(currentState, step.action);
+  }
+
+  return buildPlaybackState(replay, currentState, safeStepIndex, status);
 }
 
 export function playBattleReplayPlayback(playback: BattleReplayPlaybackState): BattleReplayPlaybackState {
@@ -146,6 +174,36 @@ export function tickBattleReplayPlayback(playback: BattleReplayPlaybackState): B
   }
 
   return stepBattleReplayPlayback(playback);
+}
+
+export function applyBattleReplayPlaybackCommand(
+  replay: PlayerBattleReplaySummary,
+  command: BattleReplayPlaybackCommand = {}
+): BattleReplayPlaybackState {
+  const repeat = Math.max(1, Math.floor(command.repeat ?? 1));
+  let playback = restoreBattleReplayPlaybackState(replay, command.currentStepIndex, command.status ?? "paused");
+
+  switch (command.action) {
+    case "play":
+      return playBattleReplayPlayback(playback);
+    case "pause":
+      return pauseBattleReplayPlayback(playback);
+    case "reset":
+      return resetBattleReplayPlayback(playback);
+    case "step":
+      for (let iteration = 0; iteration < repeat; iteration += 1) {
+        playback = stepBattleReplayPlayback(playback);
+      }
+      return playback;
+    case "tick":
+      playback = playBattleReplayPlayback(playback);
+      for (let iteration = 0; iteration < repeat; iteration += 1) {
+        playback = tickBattleReplayPlayback(playback);
+      }
+      return playback;
+    default:
+      return playback;
+  }
 }
 
 function normalizeBattleReplayStep(step: Partial<BattleReplayStep> | null | undefined, fallbackIndex: number): BattleReplayStep | null {

--- a/packages/shared/test/battle-replay-playback-command.test.ts
+++ b/packages/shared/test/battle-replay-playback-command.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyBattleReplayPlaybackCommand,
+  createEmptyBattleState,
+  restoreBattleReplayPlaybackState,
+  type PlayerBattleReplaySummary
+} from "../src/index";
+
+function createReplay(): PlayerBattleReplaySummary {
+  const initialState = createEmptyBattleState();
+  initialState.id = "battle-playback-command";
+
+  return {
+    id: "replay-playback-command",
+    roomId: "room-1",
+    playerId: "player-1",
+    battleId: "battle-1",
+    battleKind: "neutral",
+    playerCamp: "attacker",
+    heroId: "hero-1",
+    neutralArmyId: "neutral-1",
+    startedAt: "2026-03-27T10:00:00.000Z",
+    completedAt: "2026-03-27T10:01:00.000Z",
+    initialState,
+    steps: [
+      {
+        index: 1,
+        source: "player",
+        action: {
+          type: "battle.wait",
+          unitId: "stack-1"
+        }
+      },
+      {
+        index: 2,
+        source: "automated",
+        action: {
+          type: "battle.defend",
+          unitId: "stack-2"
+        }
+      }
+    ],
+    result: "attacker_victory"
+  };
+}
+
+test("restoreBattleReplayPlaybackState rebuilds the replay cursor from a step index", () => {
+  const playback = restoreBattleReplayPlaybackState(createReplay(), 1, "paused");
+
+  assert.equal(playback.currentStepIndex, 1);
+  assert.equal(playback.status, "paused");
+  assert.equal(playback.currentStep?.index, 1);
+  assert.equal(playback.nextStep?.index, 2);
+});
+
+test("applyBattleReplayPlaybackCommand advances stateless step and tick controls", () => {
+  const replay = createReplay();
+
+  const stepped = applyBattleReplayPlaybackCommand(replay, {
+    currentStepIndex: 0,
+    status: "paused",
+    action: "step",
+    repeat: 2
+  });
+  assert.equal(stepped.currentStepIndex, 2);
+  assert.equal(stepped.status, "completed");
+  assert.equal(stepped.currentStep?.index, 2);
+
+  const ticked = applyBattleReplayPlaybackCommand(replay, {
+    currentStepIndex: 0,
+    status: "paused",
+    action: "tick",
+    repeat: 1
+  });
+  assert.equal(ticked.currentStepIndex, 1);
+  assert.equal(ticked.status, "playing");
+});
+
+test("applyBattleReplayPlaybackCommand supports play, pause, and reset from a restored cursor", () => {
+  const replay = createReplay();
+
+  const playing = applyBattleReplayPlaybackCommand(replay, {
+    currentStepIndex: 1,
+    status: "paused",
+    action: "play"
+  });
+  assert.equal(playing.status, "playing");
+  assert.equal(playing.currentStepIndex, 1);
+
+  const paused = applyBattleReplayPlaybackCommand(replay, {
+    currentStepIndex: 1,
+    status: "playing",
+    action: "pause"
+  });
+  assert.equal(paused.status, "paused");
+  assert.equal(paused.currentStepIndex, 1);
+
+  const reset = applyBattleReplayPlaybackCommand(replay, {
+    currentStepIndex: 1,
+    status: "playing",
+    action: "reset"
+  });
+  assert.equal(reset.status, "paused");
+  assert.equal(reset.currentStepIndex, 0);
+  assert.equal(reset.currentStep, null);
+  assert.equal(reset.nextStep?.index, 1);
+});


### PR DESCRIPTION
## Summary
- add shared stateless replay playback command helpers so a stored replay can be restored at any cursor and advanced with play, pause, step, tick, and reset actions
- expose public and authenticated player-account battle replay playback endpoints that derive playback state from persisted replay detail without introducing server-side session state
- cover the new shared helper and server route behavior with focused playback tests while leaving the existing replay detail slice untouched

## Testing
- node --import tsx --test ./packages/shared/test/battle-replay-playback-command.test.ts
- node --import tsx --test ./apps/server/test/player-account-battle-replay-playback-routes.test.ts
- node --import tsx --test ./apps/server/test/player-account-battle-replay-detail-routes.test.ts
- npm run typecheck:shared
- npm run typecheck:server

Refs #27