### PR TITLE
feat: surface player progression snapshots in H5 account card

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 - 装备系统的第一批基础能力现已落到 shared/core：共享层补上了 `weapon / armor / accessory` 三类装备目录、品质与特殊效果元数据，英雄长期档里的装备槽位 ID 会直接映射成可计算的属性加成，并且会在创建战斗栈时折算进攻击/防御，方便后续继续接掉落、锻造与 UI。
 - 当前玩家账号骨架也已接到 `player_accounts`：账号记录现已包含 `displayName / lastRoomId / lastSeenAt / globalResources`，并开放 `GET /api/player-accounts`、`GET /api/player-accounts/:playerId`、`PUT /api/player-accounts/:playerId` 供开发态查看与改名；房间 `connect` 时会自动建档或刷新最近活跃房间。
 - 玩家账号进度读模型现已补上共享世界事件日志与成就摘要接口：服务端会把移动、建筑、战斗、技能、成就解锁，以及玩家可见的 `neutral.moved` 追击/巡逻事件写入 `recentEventLog`，并开放 `GET /api/player-accounts/:playerId/event-log`、`/achievements`、`/progression` 供 H5 / Cocos 直接读取；多阶段成就还会追加“成就进度推进”日志，方便后续做提示或回顾面板。
+- H5 账号资料卡现在会额外拉取 `/api/player-accounts/:playerId/progression` 覆盖成就/事件摘要，因此即使基础账号接口只返回轻量档案，前端也能稳定展示最新的成就推进、最近解锁和世界事件日志，而不会继续依赖旧的内嵌快照。
 - H5 左侧面板现已补上账号资料卡：会优先显示服务端账号昵称，也会在浏览器本地记住上次使用的游客昵称；远端房间首次 `connect` 时会把这份 `displayName` 一并带给服务端，用于初始化游客账号资料。`/api/player-accounts/me` 返回的 `globalResources` 也会直接显示成“全局仓库”摘要，方便确认跨房间继承的金币/木材/矿石。
 - H5 现在也有真正的 Lobby / 登录入口：当页面没有携带 `roomId / playerId` 查询参数时，会先进入大厅页，显示游客 `playerId / 昵称 / roomId` 表单和 `/api/lobby/rooms` 活跃房间列表；选房或手动输入房间后即可进入实例，游戏内也能一键返回大厅。
 - Lobby 进入房间前现在会先请求 `POST /api/auth/guest-login`，服务端会签发一个游客登录 token；浏览器会缓存这份游客会话，因此后续页面只带 `?roomId=...` 也能直接进入房间，不再必须把 `playerId` 写进 URL。

--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -1,4 +1,4 @@
-import { getLatestUnlockedAchievement } from "../../../packages/shared/src/index";
+import { getLatestProgressedAchievement, getLatestUnlockedAchievement } from "../../../packages/shared/src/index";
 import type { PlayerAccountProfile } from "./player-account";
 
 function escapeHtml(value: string): string {
@@ -40,8 +40,15 @@ function formatRewardLabel(
 function formatAchievementSummary(account: PlayerAccountProfile): string {
   const unlocked = account.achievements.filter((achievement) => achievement.unlocked).length;
   const latestUnlocked = getLatestUnlockedAchievement(account.achievements);
+  const latestProgressed = getLatestProgressedAchievement(account.achievements);
+  if (latestUnlocked && latestProgressed && latestProgressed.id !== latestUnlocked.id) {
+    return `成就 ${unlocked}/${account.achievements.length} 已解锁 · 最新 ${latestUnlocked.title} · 最近推进 ${latestProgressed.title} ${latestProgressed.current}/${latestProgressed.target}`;
+  }
+
   return latestUnlocked
     ? `成就 ${unlocked}/${account.achievements.length} 已解锁 · 最新 ${latestUnlocked.title}`
+    : latestProgressed
+      ? `成就 ${unlocked}/${account.achievements.length} 已解锁 · 最近推进 ${latestProgressed.title} ${latestProgressed.current}/${latestProgressed.target}`
     : `成就 ${unlocked}/${account.achievements.length} 已解锁`;
 }
 
@@ -85,9 +92,10 @@ export function renderRecentAccountEvents(account: PlayerAccountProfile): string
     return '<div class="account-subsection"><strong>世界事件日志</strong><p class="account-meta">尚未记录关键事件。</p></div>';
   }
 
+  const latestEventLabel = account.recentEventLog[0]?.timestamp ? ` · 最新 ${formatTimestamp(account.recentEventLog[0].timestamp)}` : "";
   return `<div class="account-subsection">
     <strong>世界事件日志</strong>
-    <p class="account-meta">最近 ${account.recentEventLog.length} 条关键事件</p>
+    <p class="account-meta">最近 ${account.recentEventLog.length} 条关键事件${escapeHtml(latestEventLabel)}</p>
     <div class="account-event-list">
       ${account.recentEventLog
         .map((entry) => {

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -46,8 +46,8 @@ import {
 } from "./lobby-preferences";
 import {
   createFallbackPlayerAccountProfile as createLocalAccountProfile,
+  loadPlayerAccountProfileWithProgression as loadAccountProfileWithProgression,
   bindPlayerAccountCredentials as bindAccountCredentials,
-  loadPlayerAccountProfile as loadAccountProfile,
   rememberPreferredPlayerDisplayName,
   readPreferredPlayerDisplayName as readLocalPreferredDisplayName,
   savePlayerAccountDisplayName as saveAccountDisplayName,
@@ -1913,7 +1913,7 @@ async function refreshAccountProfileFromServer(): Promise<void> {
   }
 
   accountRefreshPromise = (async () => {
-    const account = await loadAccountProfile(playerId, roomId);
+    const account = await loadAccountProfileWithProgression(playerId, roomId);
     state.account = account;
     if (!state.accountSaving) {
       state.accountDraftName = account.displayName;
@@ -3512,7 +3512,7 @@ async function bootstrap(): Promise<void> {
 }
 
 async function syncPlayerAccountProfile(): Promise<void> {
-  const account = await loadAccountProfile(playerId, roomId);
+  const account = await loadAccountProfileWithProgression(playerId, roomId);
   state.account = account;
   state.accountDraftName = account.displayName;
   state.accountLoginId = account.loginId ?? state.accountLoginId;

--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -84,6 +84,19 @@ interface PlayerAchievementListApiPayload {
 
 interface PlayerProgressionApiPayload extends Partial<PlayerProgressionSnapshot> {}
 
+function hasMeaningfulProgressionSnapshot(snapshot: PlayerProgressionSnapshot): boolean {
+  return (
+    snapshot.summary.unlockedAchievements > 0 ||
+    snapshot.summary.inProgressAchievements > 0 ||
+    snapshot.summary.recentEventCount > 0 ||
+    snapshot.achievements.some(
+      (achievement) =>
+        achievement.current > 0 || achievement.unlocked || Boolean(achievement.progressUpdatedAt) || Boolean(achievement.unlockedAt)
+    ) ||
+    snapshot.recentEventLog.length > 0
+  );
+}
+
 function normalizePlayerDisplayName(playerId: string, displayName?: string | null): string {
   const normalizedPlayerId = playerId.trim() || "player";
   const normalizedDisplayName = displayName?.trim();
@@ -506,6 +519,31 @@ export async function loadPlayerProgressionSnapshot(playerId: string, eventLimit
     }
     return normalizePlayerProgressionSnapshot();
   }
+}
+
+export function applyPlayerProgressionSnapshot(
+  account: PlayerAccountProfile,
+  snapshot: PlayerProgressionSnapshot
+): PlayerAccountProfile {
+  if (!hasMeaningfulProgressionSnapshot(snapshot)) {
+    return account;
+  }
+
+  return {
+    ...account,
+    achievements: snapshot.achievements,
+    recentEventLog: snapshot.recentEventLog
+  };
+}
+
+export async function loadPlayerAccountProfileWithProgression(
+  playerId: string,
+  roomId: string,
+  eventLimit?: number
+): Promise<PlayerAccountProfile> {
+  const account = await loadPlayerAccountProfile(playerId, roomId);
+  const snapshot = await loadPlayerProgressionSnapshot(playerId, eventLimit);
+  return applyPlayerProgressionSnapshot(account, snapshot);
 }
 
 export async function savePlayerAccountDisplayName(

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -30,7 +30,8 @@ function createProfile(): PlayerAccountProfile {
         metric: "battles_won",
         current: 2,
         target: 3,
-        unlocked: false
+        unlocked: false,
+        progressUpdatedAt: "2026-03-27T12:02:00.000Z"
       }
     ],
     recentEventLog: [
@@ -65,6 +66,7 @@ test("account history renderer shows unlocked achievement state and footnotes", 
   const html = renderAchievementProgress(createProfile());
 
   assert.match(html, /成就 1\/2 已解锁/);
+  assert.match(html, /最近推进 猎敌者 2\/3/);
   assert.match(html, /已解锁/);
   assert.match(html, /解锁于/);
   assert.match(html, /还差 1 点进度/);
@@ -74,6 +76,7 @@ test("account history renderer shows full event history metadata and reward chip
   const html = renderRecentAccountEvents(createProfile());
 
   assert.match(html, /最近 2 条关键事件/);
+  assert.match(html, /最新/);
   assert.match(html, /英雄 hero-1/);
   assert.match(html, /事件 battle\.started/);
   assert.match(html, /成就 first_battle/);

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  applyPlayerProgressionSnapshot,
   createFallbackPlayerAccountProfile,
   getPlayerAccountStorageKey,
+  loadPlayerAccountProfileWithProgression,
   loadPlayerAchievementProgress,
   loadPlayerBattleReplayDetail,
   loadPlayerBattleReplayPlayback,
@@ -98,6 +100,141 @@ test("player account helpers can build a local fallback profile", () => {
     lastRoomId: "room-beta",
     source: "local"
   });
+});
+
+test("player account progression overlay keeps existing account data when snapshot is empty", () => {
+  const account = createFallbackPlayerAccountProfile("player-9", "room-beta", "本地访客");
+
+  const merged = applyPlayerProgressionSnapshot(account, {
+    summary: {
+      totalAchievements: 5,
+      unlockedAchievements: 0,
+      inProgressAchievements: 0,
+      recentEventCount: 0
+    },
+    achievements: account.achievements,
+    recentEventLog: []
+  });
+
+  assert.deepEqual(merged, account);
+});
+
+test("player account loader can overlay progression snapshot onto base account profile", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(): string | null {
+          return null;
+        },
+        setItem(): void {}
+      }
+    }
+  });
+
+  globalThis.fetch = (async (input) => {
+    const url = String(input);
+    requestedUrls.push(url);
+    if (url.endsWith("/progression?limit=2")) {
+      return new Response(
+        JSON.stringify({
+          summary: {
+            totalAchievements: 5,
+            unlockedAchievements: 1,
+            inProgressAchievements: 1,
+            latestUnlockedAchievementId: "first_battle",
+            latestUnlockedAt: "2026-03-27T12:00:00.000Z",
+            latestProgressAchievementId: "enemy_slayer",
+            latestProgressAt: "2026-03-27T12:02:00.000Z",
+            recentEventCount: 1,
+            latestEventAt: "2026-03-27T12:03:00.000Z"
+          },
+          achievements: [
+            {
+              id: "first_battle",
+              current: 1,
+              unlockedAt: "2026-03-27T12:00:00.000Z"
+            },
+            {
+              id: "enemy_slayer",
+              current: 2,
+              progressUpdatedAt: "2026-03-27T12:02:00.000Z"
+            }
+          ],
+          recentEventLog: [
+            {
+              id: "event-1",
+              timestamp: "2026-03-27T12:03:00.000Z",
+              roomId: "room-alpha",
+              playerId: "player-1",
+              category: "achievement",
+              description: "解锁成就：初次交锋",
+              achievementId: "first_battle",
+              rewards: [{ type: "badge", label: "初次交锋" }]
+            }
+          ]
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        account: {
+          playerId: "player-1",
+          displayName: "暮火侦骑",
+          globalResources: {
+            gold: 12,
+            wood: 4,
+            ore: 2
+          },
+          achievements: [],
+          recentEventLog: [],
+          lastRoomId: "room-alpha"
+        }
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+  }) as typeof fetch;
+
+  try {
+    const account = await loadPlayerAccountProfileWithProgression("player-1", "room-alpha", 2);
+
+    assert.deepEqual(requestedUrls, [
+      "http://127.0.0.1:2567/api/player-accounts/player-1",
+      "http://127.0.0.1:2567/api/player-accounts/player-1/progression?limit=2"
+    ]);
+    assert.equal(account.displayName, "暮火侦骑");
+    assert.equal(account.achievements[0]?.id, "first_battle");
+    assert.equal(account.achievements[1]?.current, 2);
+    assert.deepEqual(account.recentEventLog.map((entry) => entry.id), ["event-1"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("player replay loader sends shared filters and normalizes newest first", async () => {


### PR DESCRIPTION
## Summary
- overlay H5 account profile loads with `/api/player-accounts/:playerId/progression` so the account card uses the latest achievement and event-log snapshot
- refine the account history UI to surface recent achievement progression and latest event freshness without expanding server schema
- add client tests for progression overlay behavior and update README notes for the new H5 integration

## Testing
- `node --import tsx --test ./apps/client/test/player-account-storage.test.ts ./apps/client/test/account-history-render.test.ts`
- `npm test`

Refs #27

## Scope
This slice only makes the previously merged server tracking more usable from the H5 client. It does not attempt to finish the broader world event log and achievement system work.