### PR TITLE
feat: add player event history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 - 装备系统的第一批基础能力现已落到 shared/core：共享层补上了 `weapon / armor / accessory` 三类装备目录、品质与特殊效果元数据，英雄长期档里的装备槽位 ID 会直接映射成可计算的属性加成，并且会在创建战斗栈时折算进攻击/防御，方便后续继续接掉落、锻造与 UI。
 - 当前玩家账号骨架也已接到 `player_accounts`：账号记录现已包含 `displayName / lastRoomId / lastSeenAt / globalResources`，并开放 `GET /api/player-accounts`、`GET /api/player-accounts/:playerId`、`PUT /api/player-accounts/:playerId` 供开发态查看与改名；房间 `connect` 时会自动建档或刷新最近活跃房间。
 - 玩家账号进度读模型现已补上共享世界事件日志与成就摘要接口：服务端会把移动、建筑、战斗、技能、成就解锁，以及玩家可见的 `neutral.moved` 追击/巡逻事件写入 `recentEventLog`，并开放 `GET /api/player-accounts/:playerId/event-log`、`/achievements`、`/progression` 供 H5 / Cocos 直接读取；多阶段成就还会追加“成就进度推进”日志，方便后续做提示或回顾面板。
+- 这轮又补了一层独立的玩家事件历史读模型：`savePlayerAccountProgress()` 会把账号 `recentEventLog` 里新增的结构化事件增量追加到 MySQL `player_event_history`，并开放 `GET /api/player-accounts/:playerId/event-history` / `/me/event-history`（支持 `limit`、`offset` 和现有事件筛选条件），让前端可以先做分页历史回顾而不用等完整战斗回放或完整成就 UI。
 - 事件日志的共享基础当前收敛在 `packages/shared/src/event-log.ts`：除了事件/成就 schema、归一化和查询助手外，这里也统一提供世界事件日志工厂与成就日志工厂，服务端只负责把共享 `WorldEvent[]` 喂给这些 helper；完整战斗回放、完整成就 UI 和更长历史存储仍留给后续 issue 继续扩展。
 - H5 账号资料卡现在会额外拉取 `/api/player-accounts/:playerId/progression` 覆盖成就/事件摘要，因此即使基础账号接口只返回轻量档案，前端也能稳定展示最新的成就推进、最近解锁和世界事件日志，而不会继续依赖旧的内嵌快照。
 - H5 账号资料卡的成就/事件展示本轮也补了一层可读性整理：成就卡会把“已解锁”和“最近推进”的项目排到前面，并显示最近推进时间；世界事件日志则会把 `battle.started`、`first_battle` 这类内部 ID 转成中文标签，同时在摘要里补充各事件类别计数，方便后续继续接提示面板或筛选器。

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -4,6 +4,7 @@ import {
   normalizeAchievementProgress,
   normalizeEventLogEntries,
   normalizePlayerAccountReadModel,
+  type EventLogQuery,
   normalizeHeroState,
   type EventLogEntry,
   type HeroState,
@@ -19,6 +20,7 @@ export interface RoomSnapshotStore {
   load(roomId: string): Promise<RoomPersistenceSnapshot | null>;
   loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null>;
   loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null>;
+  loadPlayerEventHistory(playerId: string, query?: PlayerEventHistoryQuery): Promise<PlayerEventHistorySnapshot>;
   loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]>;
   loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerHeroArchives(playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]>;
@@ -104,6 +106,23 @@ interface PlayerAccountAuthRow extends RowDataPacket {
   login_id: string | null;
   password_hash: string | null;
   credential_bound_at: Date | string | null;
+}
+
+interface PlayerEventHistoryRow extends RowDataPacket {
+  player_id: string;
+  event_id: string;
+  timestamp: Date | string;
+  room_id: string;
+  category: EventLogEntry["category"];
+  hero_id: string | null;
+  world_event_type: EventLogEntry["worldEventType"] | null;
+  achievement_id: EventLogEntry["achievementId"] | null;
+  entry_json: string | EventLogEntry;
+  created_at: Date | string;
+}
+
+interface PlayerEventHistoryCountRow extends RowDataPacket {
+  total: number;
 }
 
 interface PlayerHeroArchiveRow extends RowDataPacket {
@@ -194,6 +213,13 @@ export interface PlayerRoomProfileSummary {
   expired: boolean;
 }
 
+export interface PlayerEventHistoryQuery extends EventLogQuery {}
+
+export interface PlayerEventHistorySnapshot {
+  items: EventLogEntry[];
+  total: number;
+}
+
 export interface PlayerRoomProfileListOptions {
   limit?: number;
   roomId?: string;
@@ -208,6 +234,8 @@ export const MYSQL_PLAYER_ROOM_PROFILE_UPDATED_AT_INDEX = "idx_player_room_profi
 export const MYSQL_PLAYER_ACCOUNT_TABLE = "player_accounts";
 export const MYSQL_PLAYER_ACCOUNT_UPDATED_AT_INDEX = "idx_player_accounts_updated_at";
 export const MYSQL_PLAYER_ACCOUNT_LOGIN_ID_INDEX = "uidx_player_accounts_login_id";
+export const MYSQL_PLAYER_EVENT_HISTORY_TABLE = "player_event_history";
+export const MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX = "idx_player_event_history_player_time";
 export const MYSQL_PLAYER_HERO_ARCHIVE_TABLE = "player_hero_archives";
 export const MYSQL_PLAYER_HERO_ARCHIVE_UPDATED_AT_INDEX = "idx_player_hero_archives_updated_at";
 export const MYSQL_CONFIG_DOCUMENT_TABLE = "config_documents";
@@ -341,6 +369,30 @@ function normalizePlayerAccountSnapshot(account: {
     ...(account.createdAt ? { createdAt: account.createdAt } : {}),
     ...(account.updatedAt ? { updatedAt: account.updatedAt } : {})
   };
+}
+
+function normalizePlayerEventHistoryQuery(query: PlayerEventHistoryQuery = {}): Required<Pick<PlayerEventHistoryQuery, "offset">> &
+  Pick<PlayerEventHistoryQuery, "category" | "heroId" | "achievementId" | "worldEventType"> &
+  { limit?: number } {
+  return {
+    ...(query.limit == null ? {} : { limit: Math.max(1, Math.floor(query.limit)) }),
+    offset: Math.max(0, Math.floor(query.offset ?? 0)),
+    ...(query.category ? { category: query.category } : {}),
+    ...(query.heroId?.trim() ? { heroId: query.heroId.trim() } : {}),
+    ...(query.achievementId ? { achievementId: query.achievementId } : {}),
+    ...(query.worldEventType ? { worldEventType: query.worldEventType } : {})
+  };
+}
+
+function extractNewPlayerEventHistoryEntries(
+  existing: Partial<EventLogEntry>[] | null | undefined,
+  next: Partial<EventLogEntry>[] | null | undefined
+): EventLogEntry[] {
+  const existingIds = new Set(normalizeEventLogEntries(existing).map((entry) => entry.id));
+
+  return normalizeEventLogEntries(next)
+    .filter((entry) => !existingIds.has(entry.id))
+    .sort((left, right) => left.timestamp.localeCompare(right.timestamp) || left.id.localeCompare(right.id));
 }
 
 function collectPlayerIds(state: WorldState): string[] {
@@ -600,6 +652,20 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   PRIMARY KEY (player_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (
+  player_id VARCHAR(191) NOT NULL,
+  event_id VARCHAR(191) NOT NULL,
+  timestamp DATETIME NOT NULL,
+  room_id VARCHAR(191) NOT NULL,
+  category VARCHAR(32) NOT NULL,
+  hero_id VARCHAR(191) NULL,
+  world_event_type VARCHAR(64) NULL,
+  achievement_id VARCHAR(64) NULL,
+  entry_json LONGTEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (player_id, event_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 SET @veil_player_accounts_display_name_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.COLUMNS
@@ -617,6 +683,24 @@ SET @veil_player_accounts_display_name_sql := IF(
 PREPARE veil_player_accounts_display_name_stmt FROM @veil_player_accounts_display_name_sql;
 EXECUTE veil_player_accounts_display_name_stmt;
 DEALLOCATE PREPARE veil_player_accounts_display_name_stmt;
+
+SET @veil_player_event_history_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_EVENT_HISTORY_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX}'
+);
+
+SET @veil_player_event_history_idx_sql := IF(
+  @veil_player_event_history_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX}\` ON \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (player_id, timestamp)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_event_history_idx_stmt FROM @veil_player_event_history_idx_sql;
+EXECUTE veil_player_event_history_idx_stmt;
+DEALLOCATE PREPARE veil_player_event_history_idx_stmt;
 
 SET @veil_player_accounts_achievements_exists := (
   SELECT COUNT(*)
@@ -1033,6 +1117,60 @@ function toPlayerAccountAuthSnapshot(row: PlayerAccountAuthRow): PlayerAccountAu
   };
 }
 
+function toPlayerEventHistoryEntry(row: PlayerEventHistoryRow): EventLogEntry {
+  const entry = parseJsonColumn<EventLogEntry>(row.entry_json);
+
+  return normalizeEventLogEntries([
+    {
+      ...entry,
+      id: row.event_id,
+      playerId: row.player_id,
+      roomId: row.room_id,
+      timestamp: formatTimestamp(row.timestamp) ?? entry.timestamp,
+      category: row.category,
+      ...(row.hero_id ? { heroId: row.hero_id } : {}),
+      ...(row.world_event_type ? { worldEventType: row.world_event_type } : {}),
+      ...(row.achievement_id ? { achievementId: row.achievement_id } : {})
+    }
+  ])[0] as EventLogEntry;
+}
+
+async function appendPlayerEventHistoryEntries(
+  queryable: Pick<Pool, "query"> | Pick<PoolConnection, "query">,
+  playerId: string,
+  entries: EventLogEntry[]
+): Promise<void> {
+  for (const entry of entries) {
+    await queryable.query(
+      `INSERT INTO \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (
+         player_id,
+         event_id,
+         timestamp,
+         room_id,
+         category,
+         hero_id,
+         world_event_type,
+         achievement_id,
+         entry_json
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         entry_json = VALUES(entry_json)`,
+      [
+        playerId,
+        entry.id,
+        new Date(entry.timestamp),
+        entry.roomId,
+        entry.category,
+        entry.heroId ?? null,
+        entry.worldEventType ?? null,
+        entry.achievementId ?? null,
+        JSON.stringify(entry)
+      ]
+    );
+  }
+}
+
 async function deletePlayerProfilesForRoom(connection: PoolConnection, roomId: string): Promise<void> {
   await connection.query(`DELETE FROM \`${MYSQL_PLAYER_ROOM_PROFILE_TABLE}\` WHERE room_id = ?`, [roomId]);
 }
@@ -1101,6 +1239,7 @@ async function savePlayerAccounts(
         JSON.stringify(normalizedAccount.recentBattleReplays)
       ]
     );
+    await appendPlayerEventHistoryEntries(connection, normalizedAccount.playerId, normalizedAccount.recentEventLog);
   }
 }
 
@@ -1231,6 +1370,21 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
         PRIMARY KEY (player_id)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+    );
+    await pool.query(
+      `CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (
+        player_id VARCHAR(191) NOT NULL,
+        event_id VARCHAR(191) NOT NULL,
+        timestamp DATETIME NOT NULL,
+        room_id VARCHAR(191) NOT NULL,
+        category VARCHAR(32) NOT NULL,
+        hero_id VARCHAR(191) NULL,
+        world_event_type VARCHAR(64) NULL,
+        achievement_id VARCHAR(64) NULL,
+        entry_json LONGTEXT NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (player_id, event_id)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
     );
     await pool.query(
@@ -1427,6 +1581,23 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       );
     }
 
+    const [playerEventHistoryIndexRows] = await pool.query<RowDataPacket[]>(
+      `SELECT 1
+       FROM INFORMATION_SCHEMA.STATISTICS
+       WHERE TABLE_SCHEMA = ?
+         AND TABLE_NAME = ?
+         AND INDEX_NAME = ?
+       LIMIT 1`,
+      [config.database, MYSQL_PLAYER_EVENT_HISTORY_TABLE, MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX]
+    );
+
+    if (!playerEventHistoryIndexRows[0]) {
+      await pool.query(
+        `CREATE INDEX \`${MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX}\`
+         ON \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (player_id, timestamp)`
+      );
+    }
+
     const [playerHeroArchiveIndexRows] = await pool.query<RowDataPacket[]>(
       `SELECT 1
        FROM INFORMATION_SCHEMA.STATISTICS
@@ -1543,6 +1714,76 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const row = rows[0];
     return row ? toPlayerAccountSnapshot(row) : null;
+  }
+
+  async loadPlayerEventHistory(
+    playerId: string,
+    query: PlayerEventHistoryQuery = {}
+  ): Promise<PlayerEventHistorySnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const normalizedQuery = normalizePlayerEventHistoryQuery(query);
+    const clauses = ["player_id = ?"];
+    const params: Array<string | number> = [normalizedPlayerId];
+
+    if (normalizedQuery.category) {
+      clauses.push("category = ?");
+      params.push(normalizedQuery.category);
+    }
+    if (normalizedQuery.heroId) {
+      clauses.push("hero_id = ?");
+      params.push(normalizedQuery.heroId);
+    }
+    if (normalizedQuery.achievementId) {
+      clauses.push("achievement_id = ?");
+      params.push(normalizedQuery.achievementId);
+    }
+    if (normalizedQuery.worldEventType) {
+      clauses.push("world_event_type = ?");
+      params.push(normalizedQuery.worldEventType);
+    }
+
+    const whereClause = `WHERE ${clauses.join(" AND ")}`;
+    const [countRows] = await this.pool.query<PlayerEventHistoryCountRow[]>(
+      `SELECT COUNT(*) AS total
+       FROM \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\`
+       ${whereClause}`,
+      params
+    );
+
+    const queryParams = [...params];
+    let limitClause = "";
+    const safeOffset = normalizedQuery.offset ?? 0;
+    if (normalizedQuery.limit != null) {
+      limitClause = "LIMIT ? OFFSET ?";
+      queryParams.push(normalizedQuery.limit, safeOffset);
+    } else if (safeOffset > 0) {
+      limitClause = "LIMIT 18446744073709551615 OFFSET ?";
+      queryParams.push(safeOffset);
+    }
+
+    const [rows] = await this.pool.query<PlayerEventHistoryRow[]>(
+      `SELECT
+         player_id,
+         event_id,
+         timestamp,
+         room_id,
+         category,
+         hero_id,
+         world_event_type,
+         achievement_id,
+         entry_json,
+         created_at
+       FROM \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\`
+       ${whereClause}
+       ORDER BY timestamp DESC, event_id ASC
+       ${limitClause}`,
+      queryParams
+    );
+
+    return {
+      total: Math.max(0, Math.floor(countRows[0]?.total ?? 0)),
+      items: rows.map((row) => toPlayerEventHistoryEntry(row))
+    };
   }
 
   async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {
@@ -1780,8 +2021,9 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
           : {}
         : existing.lastRoomId
           ? { lastRoomId: existing.lastRoomId }
-          : {})
+        : {})
     });
+    const newHistoryEntries = extractNewPlayerEventHistoryEntries(existing.recentEventLog, nextAccount.recentEventLog);
 
     await this.pool.query(
       `INSERT INTO \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
@@ -1815,6 +2057,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         existing.lastSeenAt ? new Date(existing.lastSeenAt) : null
       ]
     );
+    await appendPlayerEventHistoryEntries(this.pool, normalizedPlayerId, newHistoryEntries);
 
     return (
       (await this.loadPlayerAccount(normalizedPlayerId)) ??

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -10,7 +10,12 @@ import {
   type PlayerBattleReplaySummary
 } from "../../../packages/shared/src/index";
 import { issueNextAuthSession, resolveAuthSessionFromRequest } from "./auth";
-import type { PlayerAccountProfilePatch, PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
+import type {
+  PlayerAccountProfilePatch,
+  PlayerAccountSnapshot,
+  PlayerEventHistoryQuery,
+  RoomSnapshotStore
+} from "./persistence";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -65,6 +70,17 @@ async function readJsonBody(request: IncomingMessage): Promise<unknown> {
 function parseLimit(request: IncomingMessage): number | undefined {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
   const value = url.searchParams.get("limit");
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseOffset(request: IncomingMessage): number | undefined {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const value = url.searchParams.get("offset");
   if (!value) {
     return undefined;
   }
@@ -198,6 +214,28 @@ function toEventLogResponse(
       ...(achievementId ? { achievementId } : {}),
       ...(worldEventType ? { worldEventType } : {})
     })
+  };
+}
+
+function toEventHistoryQuery(request: IncomingMessage): PlayerEventHistoryQuery {
+  const offset = parseOffset(request);
+  const limit = parseLimit(request);
+  const category = parseOptionalQueryParam(request, "category") as PlayerAccountSnapshot["recentEventLog"][number]["category"] | undefined;
+  const heroId = parseOptionalQueryParam(request, "heroId");
+  const achievementId = parseOptionalQueryParam(request, "achievementId") as
+    | PlayerAccountSnapshot["recentEventLog"][number]["achievementId"]
+    | undefined;
+  const worldEventType = parseOptionalQueryParam(request, "worldEventType") as
+    | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
+    | undefined;
+
+  return {
+    ...(limit != null ? { limit } : {}),
+    ...(offset != null ? { offset } : {}),
+    ...(category ? { category } : {}),
+    ...(heroId ? { heroId } : {}),
+    ...(achievementId ? { achievementId } : {}),
+    ...(worldEventType ? { worldEventType } : {})
   };
 }
 
@@ -539,6 +577,49 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.get("/api/player-accounts/me/event-history", async (request, response) => {
+    const authSession = resolveAuthSessionFromRequest(request);
+    if (!authSession) {
+      sendUnauthorized(response);
+      return;
+    }
+
+    const query = toEventHistoryQuery(request);
+    if (!store) {
+      const account = createLocalModeAccount({
+        playerId: authSession.playerId,
+        displayName: authSession.displayName,
+        loginId: authSession.loginId
+      });
+      const total = queryEventLogEntries(account.recentEventLog, {
+        ...query,
+        limit: undefined,
+        offset: undefined
+      }).length;
+      const items = queryEventLogEntries(account.recentEventLog, query);
+      sendJson(response, 200, {
+        items,
+        total,
+        offset: Math.max(0, Math.floor(query.offset ?? 0)),
+        limit: query.limit ?? items.length,
+        hasMore: (query.offset ?? 0) + items.length < total
+      });
+      return;
+    }
+
+    try {
+      const history = await store.loadPlayerEventHistory(authSession.playerId, query);
+      sendJson(response, 200, {
+        ...history,
+        offset: Math.max(0, Math.floor(query.offset ?? 0)),
+        limit: query.limit ?? history.items.length,
+        hasMore: (query.offset ?? 0) + history.items.length < history.total
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
   app.get("/api/player-accounts/me/achievements", async (request, response) => {
     const authSession = resolveAuthSessionFromRequest(request);
     if (!authSession) {
@@ -807,6 +888,39 @@ export function registerPlayerAccountRoutes(
       }
 
       sendJson(response, 200, toEventLogResponse(account, request));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/:playerId/event-history", async (request, response) => {
+    const playerId = request.params.playerId?.trim();
+    if (!playerId) {
+      sendNotFound(response);
+      return;
+    }
+
+    const query = toEventHistoryQuery(request);
+    if (!store) {
+      const items = queryEventLogEntries([], query);
+      sendJson(response, 200, {
+        items,
+        total: 0,
+        offset: Math.max(0, Math.floor(query.offset ?? 0)),
+        limit: query.limit ?? items.length,
+        hasMore: false
+      });
+      return;
+    }
+
+    try {
+      const history = await store.loadPlayerEventHistory(playerId, query);
+      sendJson(response, 200, {
+        ...history,
+        offset: Math.max(0, Math.floor(query.offset ?? 0)),
+        limit: query.limit ?? history.items.length,
+        hasMore: (query.offset ?? 0) + history.items.length < history.total
+      });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -10,6 +10,8 @@ import type {
   PlayerAccountAuthSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
+  PlayerEventHistoryQuery,
+  PlayerEventHistorySnapshot,
   PlayerAccountListOptions,
   PlayerAccountProfilePatch,
   PlayerAccountSnapshot,
@@ -17,6 +19,7 @@ import type {
   RoomSnapshotStore
 } from "../src/persistence";
 import type { RoomPersistenceSnapshot } from "../src/index";
+import { queryEventLogEntries } from "../../../packages/shared/src/index";
 
 class MemoryAuthStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
@@ -39,6 +42,22 @@ class MemoryAuthStore implements RoomSnapshotStore {
     return playerIds
       .map((playerId) => this.accounts.get(playerId))
       .filter((account): account is PlayerAccountSnapshot => Boolean(account));
+  }
+
+  async loadPlayerEventHistory(
+    playerId: string,
+    query: PlayerEventHistoryQuery = {}
+  ): Promise<PlayerEventHistorySnapshot> {
+    const account = this.accounts.get(playerId);
+    const total = queryEventLogEntries(account?.recentEventLog ?? [], {
+      ...query,
+      limit: undefined,
+      offset: undefined
+    }).length;
+    return {
+      items: queryEventLogEntries(account?.recentEventLog ?? [], query),
+      total
+    };
   }
 
   async loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null> {

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -7,6 +7,7 @@ import {
   decodePlayerWorldView,
   getDefaultMapObjectsConfig,
   getDefaultWorldConfig,
+  queryEventLogEntries,
   type ClientMessage,
   type ServerMessage
 } from "../../../packages/shared/src/index";
@@ -18,6 +19,8 @@ import {
   type PlayerAccountProgressPatch,
   type PlayerAccountAuthSnapshot,
   type PlayerAccountCredentialInput,
+  type PlayerEventHistoryQuery,
+  type PlayerEventHistorySnapshot,
   type PlayerAccountSnapshot,
   type PlayerHeroArchiveSnapshot,
   type RoomSnapshotStore
@@ -44,6 +47,22 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     const account = this.accounts.get(playerId);
     return account ? structuredClone(account) : null;
+  }
+
+  async loadPlayerEventHistory(
+    playerId: string,
+    query: PlayerEventHistoryQuery = {}
+  ): Promise<PlayerEventHistorySnapshot> {
+    const account = this.accounts.get(playerId);
+    const total = queryEventLogEntries(account?.recentEventLog ?? [], {
+      ...query,
+      limit: undefined,
+      offset: undefined
+    }).length;
+    return {
+      items: queryEventLogEntries(account?.recentEventLog ?? [], query).map((entry) => structuredClone(entry)),
+      total
+    };
   }
 
   async loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null> {

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { MySqlRoomSnapshotStore, type PlayerAccountSnapshot } from "../src/persistence";
+import {
+  MySqlRoomSnapshotStore,
+  type PlayerAccountSnapshot,
+  type PlayerEventHistorySnapshot
+} from "../src/persistence";
 
 function createExistingAccount(overrides: Partial<PlayerAccountSnapshot> = {}): PlayerAccountSnapshot {
   return {
@@ -94,4 +98,122 @@ test("bindPlayerAccountCredentials writes directly without a login-owner pre-che
   assert.match(queries[0].sql, /UPDATE `player_accounts`/);
   assert.deepEqual(queries[0].params.slice(0, 2), ["veil-ranger", "next-hash"]);
   assert.equal(queries[0].params[3], "player-1");
+});
+
+test("savePlayerAccountProgress appends only newly added entries into player event history", async () => {
+  const existingAccount = createExistingAccount({
+    recentEventLog: [
+      {
+        id: "event-older",
+        timestamp: "2026-03-20T00:00:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "combat",
+        description: "older",
+        rewards: []
+      }
+    ]
+  });
+  const persistedAccount = createExistingAccount({
+    recentEventLog: [
+      {
+        id: "event-new",
+        timestamp: "2026-03-20T00:05:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "achievement",
+        description: "new",
+        achievementId: "first_battle",
+        rewards: [{ type: "badge", label: "初次交锋" }]
+      },
+      existingAccount.recentEventLog[0]!
+    ]
+  });
+  const store = createStoreHarness();
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  let loadCount = 0;
+
+  store.loadPlayerAccount = async () => {
+    loadCount += 1;
+    return loadCount === 1 ? existingAccount : persistedAccount;
+  };
+  store.ensurePlayerAccount = async () => {
+    throw new Error("ensurePlayerAccount should not be called when the account already exists");
+  };
+  store.loadPlayerAccountByLoginId = async () => null;
+  store.pool = {
+    query: async (sql: string, params: unknown[]) => {
+      queries.push({ sql, params });
+      return [];
+    }
+  };
+
+  const account = await store.savePlayerAccountProgress("player-1", {
+    recentEventLog: persistedAccount.recentEventLog
+  });
+
+  assert.equal(account.recentEventLog[0]?.id, "event-new");
+  assert.equal(queries.length, 2);
+  assert.match(queries[0].sql, /INSERT INTO `player_accounts`/);
+  assert.match(queries[1].sql, /INSERT INTO `player_event_history`/);
+  assert.deepEqual(queries[1].params.slice(0, 4), [
+    "player-1",
+    "event-new",
+    new Date("2026-03-20T00:05:00.000Z"),
+    "room-1"
+  ]);
+});
+
+test("loadPlayerEventHistory returns paged rows and total count", async () => {
+  const store = createStoreHarness();
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+
+  store.pool = {
+    query: async (sql: string, params: unknown[]) => {
+      queries.push({ sql, params });
+      if (/COUNT\(\*\) AS total/.test(sql)) {
+        return [[{ total: 2 }]];
+      }
+
+      return [[
+        {
+          player_id: "player-1",
+          event_id: "event-2",
+          timestamp: "2026-03-20T00:05:00.000Z",
+          room_id: "room-1",
+          category: "achievement",
+          hero_id: "hero-1",
+          world_event_type: null,
+          achievement_id: "first_battle",
+          entry_json: JSON.stringify({
+            id: "event-2",
+            timestamp: "2026-03-20T00:05:00.000Z",
+            roomId: "room-1",
+            playerId: "player-1",
+            category: "achievement",
+            description: "new",
+            heroId: "hero-1",
+            achievementId: "first_battle",
+            rewards: [{ type: "badge", label: "初次交锋" }]
+          }),
+          created_at: "2026-03-20T00:05:00.000Z"
+        }
+      ]];
+    }
+  };
+
+  const history = (await store.loadPlayerEventHistory("player-1", {
+    heroId: "hero-1",
+    category: "achievement",
+    limit: 1,
+    offset: 1
+  })) as PlayerEventHistorySnapshot;
+
+  assert.equal(history.total, 2);
+  assert.deepEqual(history.items.map((entry) => entry.id), ["event-2"]);
+  assert.equal(queries.length, 2);
+  assert.match(queries[0].sql, /FROM `player_event_history`/);
+  assert.deepEqual(queries[0].params, ["player-1", "achievement", "hero-1"]);
+  assert.match(queries[1].sql, /ORDER BY timestamp DESC, event_id ASC/);
+  assert.deepEqual(queries[1].params, ["player-1", "achievement", "hero-1", 1, 1]);
 });

--- a/apps/server/test/player-account-battle-replay-detail-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-detail-routes.test.ts
@@ -7,6 +7,8 @@ import type {
   PlayerAccountAuthSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
+  PlayerEventHistoryQuery,
+  PlayerEventHistorySnapshot,
   PlayerAccountListOptions,
   PlayerAccountProfilePatch,
   PlayerAccountProgressPatch,
@@ -15,7 +17,7 @@ import type {
   RoomSnapshotStore
 } from "../src/persistence";
 import type { RoomPersistenceSnapshot } from "../src/index";
-import { createEmptyBattleState, type PlayerBattleReplaySummary } from "../../../packages/shared/src/index";
+import { createEmptyBattleState, queryEventLogEntries, type PlayerBattleReplaySummary } from "../../../packages/shared/src/index";
 
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
@@ -36,6 +38,22 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return playerIds
       .map((playerId) => this.accounts.get(playerId))
       .filter((account): account is PlayerAccountSnapshot => Boolean(account));
+  }
+
+  async loadPlayerEventHistory(
+    playerId: string,
+    query: PlayerEventHistoryQuery = {}
+  ): Promise<PlayerEventHistorySnapshot> {
+    const account = this.accounts.get(playerId);
+    const total = queryEventLogEntries(account?.recentEventLog ?? [], {
+      ...query,
+      limit: undefined,
+      offset: undefined
+    }).length;
+    return {
+      items: queryEventLogEntries(account?.recentEventLog ?? [], query),
+      total
+    };
   }
 
   async loadPlayerAccountAuthByLoginId(_loginId: string): Promise<PlayerAccountAuthSnapshot | null> {

--- a/apps/server/test/player-account-battle-replay-playback-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-playback-routes.test.ts
@@ -7,6 +7,8 @@ import type {
   PlayerAccountAuthSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
+  PlayerEventHistoryQuery,
+  PlayerEventHistorySnapshot,
   PlayerAccountListOptions,
   PlayerAccountProfilePatch,
   PlayerAccountProgressPatch,
@@ -17,6 +19,7 @@ import type {
 import type { RoomPersistenceSnapshot } from "../src/index";
 import {
   createEmptyBattleState,
+  queryEventLogEntries,
   type BattleReplayPlaybackState,
   type PlayerBattleReplaySummary
 } from "../../../packages/shared/src/index";
@@ -40,6 +43,22 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return playerIds
       .map((playerId) => this.accounts.get(playerId))
       .filter((account): account is PlayerAccountSnapshot => Boolean(account));
+  }
+
+  async loadPlayerEventHistory(
+    playerId: string,
+    query: PlayerEventHistoryQuery = {}
+  ): Promise<PlayerEventHistorySnapshot> {
+    const account = this.accounts.get(playerId);
+    const total = queryEventLogEntries(account?.recentEventLog ?? [], {
+      ...query,
+      limit: undefined,
+      offset: undefined
+    }).length;
+    return {
+      items: queryEventLogEntries(account?.recentEventLog ?? [], query),
+      total
+    };
   }
 
   async loadPlayerAccountAuthByLoginId(_loginId: string): Promise<PlayerAccountAuthSnapshot | null> {

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -9,6 +9,8 @@ import type {
   PlayerAccountAuthSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
+  PlayerEventHistoryQuery,
+  PlayerEventHistorySnapshot,
   PlayerAccountListOptions,
   PlayerAccountProfilePatch,
   PlayerAccountSnapshot,
@@ -19,6 +21,7 @@ import type { RoomPersistenceSnapshot } from "../src/index";
 import {
   createDefaultHeroLoadout,
   createDefaultHeroProgression,
+  queryEventLogEntries,
   type PlayerAchievementProgress,
   type PlayerProgressionSnapshot,
   type PlayerBattleReplaySummary,
@@ -28,6 +31,7 @@ import {
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
+  private readonly eventHistoryByPlayerId = new Map<string, PlayerAccountSnapshot["recentEventLog"]>();
 
   async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
     return null;
@@ -42,6 +46,23 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return (
       Array.from(this.accounts.values()).find((account) => account.loginId === normalizedLoginId) ?? null
     );
+  }
+
+  async loadPlayerEventHistory(
+    playerId: string,
+    query: PlayerEventHistoryQuery = {}
+  ): Promise<PlayerEventHistorySnapshot> {
+    const items = queryEventLogEntries(this.eventHistoryByPlayerId.get(playerId) ?? [], query);
+    const total = queryEventLogEntries(this.eventHistoryByPlayerId.get(playerId) ?? [], {
+      ...query,
+      limit: undefined,
+      offset: undefined
+    }).length;
+
+    return {
+      items,
+      total
+    };
   }
 
   async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {
@@ -175,6 +196,13 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   seedAccount(account: PlayerAccountSnapshot): void {
     this.accounts.set(account.playerId, account);
+    if (!this.eventHistoryByPlayerId.has(account.playerId)) {
+      this.eventHistoryByPlayerId.set(account.playerId, structuredClone(account.recentEventLog ?? []));
+    }
+  }
+
+  seedEventHistory(playerId: string, entries: PlayerAccountSnapshot["recentEventLog"]): void {
+    this.eventHistoryByPlayerId.set(playerId, structuredClone(entries));
   }
 }
 
@@ -691,6 +719,112 @@ test("player account event-log routes filter recent entries without loading prog
   const mePayload = (await meResponse.json()) as { items: PlayerAccountSnapshot["recentEventLog"] };
   assert.equal(meResponse.status, 200);
   assert.deepEqual(mePayload.items.map((entry) => entry.id), ["event-achievement"]);
+});
+
+test("player account event-history routes page dedicated history entries beyond the recent snapshot", async (t) => {
+  const port = 42069 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-history",
+    displayName: "霜灯抄录员",
+    globalResources: { gold: 22, wood: 7, ore: 1 },
+    achievements: [],
+    recentEventLog: [
+      {
+        id: "event-recent",
+        timestamp: "2026-03-27T12:05:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-history",
+        category: "achievement",
+        description: "recent snapshot entry",
+        heroId: "hero-1",
+        achievementId: "first_battle",
+        rewards: [{ type: "badge", label: "初次交锋" }]
+      }
+    ],
+    recentBattleReplays: [],
+    lastRoomId: "room-alpha",
+    lastSeenAt: new Date("2026-03-27T12:06:00.000Z").toISOString()
+  });
+  store.seedEventHistory("player-history", [
+    {
+      id: "event-history-3",
+      timestamp: "2026-03-27T12:05:00.000Z",
+      roomId: "room-alpha",
+      playerId: "player-history",
+      category: "achievement",
+      description: "history newest",
+      heroId: "hero-1",
+      achievementId: "first_battle",
+      rewards: [{ type: "badge", label: "初次交锋" }]
+    },
+    {
+      id: "event-history-2",
+      timestamp: "2026-03-27T12:03:00.000Z",
+      roomId: "room-alpha",
+      playerId: "player-history",
+      category: "combat",
+      description: "history middle",
+      heroId: "hero-1",
+      worldEventType: "battle.started",
+      rewards: []
+    },
+    {
+      id: "event-history-1",
+      timestamp: "2026-03-27T12:01:00.000Z",
+      roomId: "room-alpha",
+      playerId: "player-history",
+      category: "combat",
+      description: "history oldest",
+      heroId: "hero-1",
+      worldEventType: "battle.resolved",
+      rewards: []
+    }
+  ]);
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-history",
+    displayName: "霜灯抄录员"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const publicResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-history/event-history?heroId=hero-1&offset=1&limit=1`
+  );
+  const publicPayload = (await publicResponse.json()) as {
+    items: PlayerAccountSnapshot["recentEventLog"];
+    total: number;
+    offset: number;
+    limit: number;
+    hasMore: boolean;
+  };
+  assert.equal(publicResponse.status, 200);
+  assert.equal(publicPayload.total, 3);
+  assert.equal(publicPayload.offset, 1);
+  assert.equal(publicPayload.limit, 1);
+  assert.equal(publicPayload.hasMore, true);
+  assert.deepEqual(publicPayload.items.map((entry) => entry.id), ["event-history-2"]);
+
+  const meResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/event-history?category=combat`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const mePayload = (await meResponse.json()) as {
+    items: PlayerAccountSnapshot["recentEventLog"];
+    total: number;
+    hasMore: boolean;
+  };
+  assert.equal(meResponse.status, 200);
+  assert.equal(mePayload.total, 2);
+  assert.equal(mePayload.hasMore, false);
+  assert.deepEqual(mePayload.items.map((entry) => entry.id), ["event-history-2", "event-history-1"]);
 });
 
 test("player account achievement routes filter normalized progress without loading event history", async (t) => {

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -9,6 +9,8 @@ The current persistence scope is:
 - World state snapshot
 - All active battle snapshots in the room
 - Per-player room progress snapshot
+- Per-player account progression snapshot
+- Per-player append-only event history read model
 - Config center documents for `world`, `mapObjects`, and `units`
 
 Snapshots are stored as serialized JSON strings for compatibility with older MySQL versions.
@@ -68,6 +70,55 @@ Recommended index:
 
 When loading older snapshots that predate hero progression, the server will backfill default progression values before the room is restored.
 
+### Table: `player_accounts`
+
+| Column | Type | Nullable | Default | Description |
+| --- | --- | --- | --- | --- |
+| `player_id` | `VARCHAR(191)` | No | - | Player id, primary key |
+| `display_name` | `VARCHAR(80)` | Yes | `NULL` | Public display name |
+| `global_resources_json` | `LONGTEXT` | No | - | Serialized account-wide resource ledger |
+| `achievements_json` | `LONGTEXT` | Yes | `NULL` | Serialized achievement progress snapshot |
+| `recent_event_log_json` | `LONGTEXT` | Yes | `NULL` | Serialized compact recent event snapshot used by `/event-log` and `/progression` |
+| `recent_battle_replays_json` | `LONGTEXT` | Yes | `NULL` | Serialized recent battle replay summaries |
+| `last_room_id` | `VARCHAR(191)` | Yes | `NULL` | Last room seen for this account |
+| `last_seen_at` | `DATETIME` | Yes | `NULL` | Last known activity timestamp |
+| `login_id` | `VARCHAR(40)` | Yes | `NULL` | Bound login id for credential auth |
+| `password_hash` | `VARCHAR(255)` | Yes | `NULL` | Stored password hash |
+| `credential_bound_at` | `DATETIME` | Yes | `NULL` | First credential bind time |
+| `version` | `BIGINT UNSIGNED` | No | `1` | Incremented on every upsert |
+| `created_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | First persistence time |
+| `updated_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | Last persistence time |
+
+Recommended indexes:
+
+- `idx_player_accounts_updated_at` on `updated_at`
+- `uidx_player_accounts_login_id` unique on `login_id`
+
+### Table: `player_event_history`
+
+| Column | Type | Nullable | Default | Description |
+| --- | --- | --- | --- | --- |
+| `player_id` | `VARCHAR(191)` | No | - | Player id |
+| `event_id` | `VARCHAR(191)` | No | - | Stable event log id within the player timeline |
+| `timestamp` | `DATETIME` | No | - | Event time used for history ordering |
+| `room_id` | `VARCHAR(191)` | No | - | Source room id |
+| `category` | `VARCHAR(32)` | No | - | Event category for lightweight filtering |
+| `hero_id` | `VARCHAR(191)` | Yes | `NULL` | Optional hero id filter key |
+| `world_event_type` | `VARCHAR(64)` | Yes | `NULL` | Optional world event type filter key |
+| `achievement_id` | `VARCHAR(64)` | Yes | `NULL` | Optional achievement id filter key |
+| `entry_json` | `LONGTEXT` | No | - | Serialized `EventLogEntry` payload |
+| `created_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | First persistence time |
+
+Primary key:
+
+- `(player_id, event_id)`
+
+Recommended index:
+
+- `idx_player_event_history_player_time` on `(player_id, timestamp)`
+
+The server appends only newly seen `recentEventLog` entries into this table when player account progress is saved. This keeps the existing compact snapshot read model intact while exposing a paged `/api/player-accounts/:playerId/event-history` API for player-facing history views.
+
 ### Table: `config_documents`
 
 | Column | Type | Nullable | Default | Description |
@@ -107,7 +158,7 @@ The repository includes a SQL file and an init script:
 - SQL: `docs/mysql-persistence.sql`
 - Script: `npm run db:init:mysql`
 
-Running the init script creates the database, `room_snapshots`, `player_room_profiles`, and `config_documents` if they do not already exist.
+Running the init script creates the database, `room_snapshots`, `player_room_profiles`, `player_accounts`, `player_event_history`, and `config_documents` if they do not already exist.
 
 ## Manual Operations
 

--- a/docs/mysql-persistence.sql
+++ b/docs/mysql-persistence.sql
@@ -61,6 +61,92 @@ PREPARE veil_player_profiles_idx_stmt FROM @veil_player_profiles_idx_sql;
 EXECUTE veil_player_profiles_idx_stmt;
 DEALLOCATE PREPARE veil_player_profiles_idx_stmt;
 
+CREATE TABLE IF NOT EXISTS `player_accounts` (
+  player_id VARCHAR(191) NOT NULL,
+  display_name VARCHAR(80) NULL,
+  global_resources_json LONGTEXT NOT NULL,
+  achievements_json LONGTEXT NULL,
+  recent_event_log_json LONGTEXT NULL,
+  recent_battle_replays_json LONGTEXT NULL,
+  last_room_id VARCHAR(191) NULL,
+  last_seen_at DATETIME NULL DEFAULT NULL,
+  login_id VARCHAR(40) NULL,
+  password_hash VARCHAR(255) NULL,
+  credential_bound_at DATETIME NULL DEFAULT NULL,
+  version BIGINT UNSIGNED NOT NULL DEFAULT 1,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (player_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @veil_player_accounts_updated_at_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'player_accounts'
+    AND INDEX_NAME = 'idx_player_accounts_updated_at'
+);
+
+SET @veil_player_accounts_updated_at_idx_sql := IF(
+  @veil_player_accounts_updated_at_idx_exists = 0,
+  'CREATE INDEX `idx_player_accounts_updated_at` ON `player_accounts` (updated_at)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_updated_at_idx_stmt FROM @veil_player_accounts_updated_at_idx_sql;
+EXECUTE veil_player_accounts_updated_at_idx_stmt;
+DEALLOCATE PREPARE veil_player_accounts_updated_at_idx_stmt;
+
+SET @veil_player_accounts_login_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'player_accounts'
+    AND INDEX_NAME = 'uidx_player_accounts_login_id'
+);
+
+SET @veil_player_accounts_login_idx_sql := IF(
+  @veil_player_accounts_login_idx_exists = 0,
+  'CREATE UNIQUE INDEX `uidx_player_accounts_login_id` ON `player_accounts` (login_id)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_login_idx_stmt FROM @veil_player_accounts_login_idx_sql;
+EXECUTE veil_player_accounts_login_idx_stmt;
+DEALLOCATE PREPARE veil_player_accounts_login_idx_stmt;
+
+CREATE TABLE IF NOT EXISTS `player_event_history` (
+  player_id VARCHAR(191) NOT NULL,
+  event_id VARCHAR(191) NOT NULL,
+  timestamp DATETIME NOT NULL,
+  room_id VARCHAR(191) NOT NULL,
+  category VARCHAR(32) NOT NULL,
+  hero_id VARCHAR(191) NULL,
+  world_event_type VARCHAR(64) NULL,
+  achievement_id VARCHAR(64) NULL,
+  entry_json LONGTEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (player_id, event_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @veil_player_event_history_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'player_event_history'
+    AND INDEX_NAME = 'idx_player_event_history_player_time'
+);
+
+SET @veil_player_event_history_idx_sql := IF(
+  @veil_player_event_history_idx_exists = 0,
+  'CREATE INDEX `idx_player_event_history_player_time` ON `player_event_history` (player_id, timestamp)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_event_history_idx_stmt FROM @veil_player_event_history_idx_sql;
+EXECUTE veil_player_event_history_idx_stmt;
+DEALLOCATE PREPARE veil_player_event_history_idx_stmt;
+
 CREATE TABLE IF NOT EXISTS `config_documents` (
   document_id VARCHAR(64) NOT NULL,
   content_json LONGTEXT NOT NULL,

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -32,6 +32,7 @@ export interface EventLogEntry {
 
 export interface EventLogQuery {
   limit?: number | undefined;
+  offset?: number | undefined;
   category?: EventLogCategory | undefined;
   heroId?: string | undefined;
   achievementId?: AchievementId | undefined;
@@ -711,6 +712,7 @@ export function queryEventLogEntries(
   query: EventLogQuery = {}
 ): EventLogEntry[] {
   const safeLimit = query.limit == null ? undefined : Math.max(1, Math.floor(query.limit));
+  const safeOffset = Math.max(0, Math.floor(query.offset ?? 0));
   const heroId = query.heroId?.trim();
 
   return normalizeEventLogEntries(entries)
@@ -718,7 +720,7 @@ export function queryEventLogEntries(
     .filter((entry) => (heroId ? entry.heroId === heroId : true))
     .filter((entry) => (query.achievementId ? entry.achievementId === query.achievementId : true))
     .filter((entry) => (query.worldEventType ? entry.worldEventType === query.worldEventType : true))
-    .slice(0, safeLimit);
+    .slice(safeOffset, safeLimit == null ? undefined : safeOffset + safeLimit);
 }
 
 export function buildPlayerProgressionSnapshot(

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -435,7 +435,7 @@ test("event log helper keeps newest unique entries first", () => {
   );
 });
 
-test("event log query helper filters by category, hero, and achievement metadata", () => {
+test("event log query helper filters by category, hero, achievement metadata, and offset", () => {
   const queried = queryEventLogEntries(
     [
       {
@@ -481,6 +481,42 @@ test("event log query helper filters by category, hero, and achievement metadata
   );
 
   assert.deepEqual(queried.map((entry) => entry.id), ["achievement-entry"]);
+
+  const paged = queryEventLogEntries(
+    [
+      {
+        id: "newest-entry",
+        timestamp: "2026-03-27T10:07:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "achievement",
+        description: "newest",
+        heroId: "hero-1",
+        achievementId: "first_battle",
+        rewards: []
+      },
+      {
+        id: "older-entry",
+        timestamp: "2026-03-27T10:05:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "achievement",
+        description: "older",
+        heroId: "hero-1",
+        achievementId: "first_battle",
+        rewards: []
+      }
+    ],
+    {
+      category: "achievement",
+      heroId: "hero-1",
+      achievementId: "first_battle",
+      offset: 1,
+      limit: 1
+    }
+  );
+
+  assert.deepEqual(paged.map((entry) => entry.id), ["older-entry"]);
 });
 
 test("achievement progress query helper filters by id, metric, unlocked state, and limit", () => {


### PR DESCRIPTION
## Summary
- add a dedicated player event history read model and MySQL persistence table that appends only new event-log entries
- expose `/api/player-accounts/:playerId/event-history` and `/api/player-accounts/me/event-history` with paging and shared filters
- cover the new offset query helper, route behavior, and persistence writes/reads with focused tests

## Testing
- `node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/persistence-account-credentials.test.ts ./apps/server/test/player-account-routes.test.ts ./apps/server/test/player-account-battle-replay-detail-routes.test.ts ./apps/server/test/player-account-battle-replay-playback-routes.test.ts ./apps/server/test/auth-guest-login.test.ts ./apps/server/test/colyseus-persistence-recovery.test.ts`
- `npm run typecheck:server`

Refs #27