### PR TITLE
feat: add event history time-range filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@
 - 当前玩家账号骨架也已接到 `player_accounts`：账号记录现已包含 `displayName / lastRoomId / lastSeenAt / globalResources`，并开放 `GET /api/player-accounts`、`GET /api/player-accounts/:playerId`、`PUT /api/player-accounts/:playerId` 供开发态查看与改名；房间 `connect` 时会自动建档或刷新最近活跃房间。
 - 玩家账号进度读模型现已补上共享世界事件日志与成就摘要接口：服务端会把移动、建筑、战斗、技能、成就解锁，以及玩家可见的 `neutral.moved` 追击/巡逻事件写入 `recentEventLog`，并开放 `GET /api/player-accounts/:playerId/event-log`、`/achievements`、`/progression` 供 H5 / Cocos 直接读取；多阶段成就还会追加“成就进度推进”日志，方便后续做提示或回顾面板。
 - 这轮又补了一层独立的玩家事件历史读模型：`savePlayerAccountProgress()` 会把账号 `recentEventLog` 里新增的结构化事件增量追加到 MySQL `player_event_history`，并开放 `GET /api/player-accounts/:playerId/event-history` / `/me/event-history`（支持 `limit`、`offset` 和现有事件筛选条件），让前端可以先做分页历史回顾而不用等完整战斗回放或完整成就 UI。
+- 玩家事件历史接口现已支持可选 `since` / `until` 时间范围筛选，且本地模式与 MySQL 持久化模式保持一致，方便后续只拉取某个时间窗内的世界事件或成就回顾。
 - 事件日志的共享基础当前收敛在 `packages/shared/src/event-log.ts`：除了事件/成就 schema、归一化和查询助手外，这里也统一提供世界事件日志工厂与成就日志工厂，服务端只负责把共享 `WorldEvent[]` 喂给这些 helper；完整战斗回放、完整成就 UI 和更长历史存储仍留给后续 issue 继续扩展。
 - H5 账号资料卡现在会额外拉取 `/api/player-accounts/:playerId/progression` 覆盖成就/事件摘要，因此即使基础账号接口只返回轻量档案，前端也能稳定展示最新的成就推进、最近解锁和世界事件日志，而不会继续依赖旧的内嵌快照。
 - H5 账号资料卡的成就/事件展示本轮也补了一层可读性整理：成就卡会把“已解锁”和“最近推进”的项目排到前面，并显示最近推进时间；世界事件日志则会把 `battle.started`、`first_battle` 这类内部 ID 转成中文标签，同时在摘要里补充各事件类别计数，方便后续继续接提示面板或筛选器。

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -372,16 +372,31 @@ function normalizePlayerAccountSnapshot(account: {
 }
 
 function normalizePlayerEventHistoryQuery(query: PlayerEventHistoryQuery = {}): Required<Pick<PlayerEventHistoryQuery, "offset">> &
-  Pick<PlayerEventHistoryQuery, "category" | "heroId" | "achievementId" | "worldEventType"> &
+  Pick<PlayerEventHistoryQuery, "category" | "heroId" | "achievementId" | "worldEventType" | "since" | "until"> &
   { limit?: number } {
+  const since = normalizeHistoryTimestampFilter(query.since);
+  const until = normalizeHistoryTimestampFilter(query.until);
+
   return {
     ...(query.limit == null ? {} : { limit: Math.max(1, Math.floor(query.limit)) }),
     offset: Math.max(0, Math.floor(query.offset ?? 0)),
     ...(query.category ? { category: query.category } : {}),
     ...(query.heroId?.trim() ? { heroId: query.heroId.trim() } : {}),
     ...(query.achievementId ? { achievementId: query.achievementId } : {}),
-    ...(query.worldEventType ? { worldEventType: query.worldEventType } : {})
+    ...(query.worldEventType ? { worldEventType: query.worldEventType } : {}),
+    ...(since ? { since } : {}),
+    ...(until ? { until } : {})
   };
+}
+
+function normalizeHistoryTimestampFilter(value?: string | null): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
 }
 
 function extractNewPlayerEventHistoryEntries(
@@ -1740,6 +1755,14 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     if (normalizedQuery.worldEventType) {
       clauses.push("world_event_type = ?");
       params.push(normalizedQuery.worldEventType);
+    }
+    if (normalizedQuery.since) {
+      clauses.push("timestamp >= ?");
+      params.push(normalizedQuery.since);
+    }
+    if (normalizedQuery.until) {
+      clauses.push("timestamp <= ?");
+      params.push(normalizedQuery.until);
     }
 
     const whereClause = `WHERE ${clauses.join(" AND ")}`;

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -122,6 +122,16 @@ function parseNumberQueryParam(request: IncomingMessage, key: string): number | 
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function parseTimestampQueryParam(request: IncomingMessage, key: string): string | undefined {
+  const value = parseOptionalQueryParam(request, key);
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
 function toReplayResponseFromRequest(
   account: PlayerAccountSnapshot,
   request: IncomingMessage
@@ -228,6 +238,8 @@ function toEventHistoryQuery(request: IncomingMessage): PlayerEventHistoryQuery 
   const worldEventType = parseOptionalQueryParam(request, "worldEventType") as
     | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
     | undefined;
+  const since = parseTimestampQueryParam(request, "since");
+  const until = parseTimestampQueryParam(request, "until");
 
   return {
     ...(limit != null ? { limit } : {}),
@@ -235,7 +247,9 @@ function toEventHistoryQuery(request: IncomingMessage): PlayerEventHistoryQuery 
     ...(category ? { category } : {}),
     ...(heroId ? { heroId } : {}),
     ...(achievementId ? { achievementId } : {}),
-    ...(worldEventType ? { worldEventType } : {})
+    ...(worldEventType ? { worldEventType } : {}),
+    ...(since ? { since } : {}),
+    ...(until ? { until } : {})
   };
 }
 

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -217,3 +217,54 @@ test("loadPlayerEventHistory returns paged rows and total count", async () => {
   assert.match(queries[1].sql, /ORDER BY timestamp DESC, event_id ASC/);
   assert.deepEqual(queries[1].params, ["player-1", "achievement", "hero-1", 1, 1]);
 });
+
+test("mysql player event history query applies inclusive timestamp filters", async () => {
+  const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
+  const store = new MySqlRoomSnapshotStore({
+    query: async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      if (queries.length === 1) {
+        return [[{ total: 1 }]];
+      }
+
+      return [[
+        {
+          player_id: "player-1",
+          event_id: "event-2",
+          timestamp: "2026-03-20T00:05:00.000Z",
+          room_id: "room-1",
+          category: "achievement",
+          hero_id: "hero-1",
+          world_event_type: null,
+          achievement_id: "first_battle",
+          entry_json: JSON.stringify({
+            id: "event-2",
+            timestamp: "2026-03-20T00:05:00.000Z",
+            roomId: "room-1",
+            playerId: "player-1",
+            category: "achievement",
+            description: "new",
+            heroId: "hero-1",
+            achievementId: "first_battle",
+            rewards: [{ type: "badge", label: "初次交锋" }]
+          }),
+          created_at: "2026-03-20T00:05:00.000Z"
+        }
+      ]];
+    }
+  } as never);
+
+  const history = (await store.loadPlayerEventHistory("player-1", {
+    since: "2026-03-20T00:00:00.000Z",
+    until: "2026-03-20T00:06:00.000Z"
+  })) as PlayerEventHistorySnapshot;
+
+  assert.equal(history.total, 1);
+  assert.deepEqual(history.items.map((entry) => entry.id), ["event-2"]);
+  assert.equal(queries.length, 2);
+  assert.match(queries[0].sql, /timestamp >= \?/);
+  assert.match(queries[0].sql, /timestamp <= \?/);
+  assert.deepEqual(queries[0].params, ["player-1", "2026-03-20T00:00:00.000Z", "2026-03-20T00:06:00.000Z"]);
+  assert.match(queries[1].sql, /ORDER BY timestamp DESC, event_id ASC/);
+  assert.deepEqual(queries[1].params, ["player-1", "2026-03-20T00:00:00.000Z", "2026-03-20T00:06:00.000Z"]);
+});

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -825,6 +825,20 @@ test("player account event-history routes page dedicated history entries beyond 
   assert.equal(mePayload.total, 2);
   assert.equal(mePayload.hasMore, false);
   assert.deepEqual(mePayload.items.map((entry) => entry.id), ["event-history-2", "event-history-1"]);
+
+  const rangedResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-history/event-history?since=2026-03-27T12:02:00.000Z&until=2026-03-27T12:04:00.000Z`
+  );
+  const rangedPayload = (await rangedResponse.json()) as {
+    items: PlayerAccountSnapshot["recentEventLog"];
+    total: number;
+    offset: number;
+    limit: number;
+    hasMore: boolean;
+  };
+  assert.equal(rangedResponse.status, 200);
+  assert.equal(rangedPayload.total, 1);
+  assert.deepEqual(rangedPayload.items.map((entry) => entry.id), ["event-history-2"]);
 });
 
 test("player account achievement routes filter normalized progress without loading event history", async (t) => {

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -119,6 +119,8 @@ Recommended index:
 
 The server appends only newly seen `recentEventLog` entries into this table when player account progress is saved. This keeps the existing compact snapshot read model intact while exposing a paged `/api/player-accounts/:playerId/event-history` API for player-facing history views.
 
+The event history routes support the existing `category` / `heroId` / `achievementId` / `worldEventType` filters, plus optional inclusive `since` and `until` ISO-8601 timestamps. MySQL-backed queries push those time-range predicates down into SQL so player history views can page within a bounded time window without scanning unrelated rows.
+
 ### Table: `config_documents`
 
 | Column | Type | Nullable | Default | Description |

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -37,6 +37,8 @@ export interface EventLogQuery {
   heroId?: string | undefined;
   achievementId?: AchievementId | undefined;
   worldEventType?: WorldEvent["type"] | undefined;
+  since?: string | undefined;
+  until?: string | undefined;
 }
 
 export interface AchievementDefinition {
@@ -186,6 +188,16 @@ function normalizeTimestamp(value?: string | null): string | undefined {
 
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+function normalizeTimestampFilter(value?: string | null): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
 }
 
 function findHero(state: WorldState, heroId?: string): WorldState["heroes"][number] | undefined {
@@ -714,12 +726,16 @@ export function queryEventLogEntries(
   const safeLimit = query.limit == null ? undefined : Math.max(1, Math.floor(query.limit));
   const safeOffset = Math.max(0, Math.floor(query.offset ?? 0));
   const heroId = query.heroId?.trim();
+  const since = normalizeTimestampFilter(query.since);
+  const until = normalizeTimestampFilter(query.until);
 
   return normalizeEventLogEntries(entries)
     .filter((entry) => (query.category ? entry.category === query.category : true))
     .filter((entry) => (heroId ? entry.heroId === heroId : true))
     .filter((entry) => (query.achievementId ? entry.achievementId === query.achievementId : true))
     .filter((entry) => (query.worldEventType ? entry.worldEventType === query.worldEventType : true))
+    .filter((entry) => (since ? entry.timestamp >= since : true))
+    .filter((entry) => (until ? entry.timestamp <= until : true))
     .slice(safeOffset, safeLimit == null ? undefined : safeOffset + safeLimit);
 }
 

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -519,6 +519,52 @@ test("event log query helper filters by category, hero, achievement metadata, an
   assert.deepEqual(paged.map((entry) => entry.id), ["older-entry"]);
 });
 
+test("event log query helper filters by inclusive time range when provided", () => {
+  const queried = queryEventLogEntries(
+    [
+      {
+        id: "newest-entry",
+        timestamp: "2026-03-27T10:07:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "achievement",
+        description: "newest",
+        heroId: "hero-1",
+        achievementId: "first_battle",
+        rewards: []
+      },
+      {
+        id: "middle-entry",
+        timestamp: "2026-03-27T10:05:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "combat",
+        description: "middle",
+        heroId: "hero-1",
+        worldEventType: "battle.started",
+        rewards: []
+      },
+      {
+        id: "older-entry",
+        timestamp: "2026-03-27T10:03:00.000Z",
+        roomId: "room-1",
+        playerId: "player-1",
+        category: "combat",
+        description: "older",
+        heroId: "hero-1",
+        worldEventType: "battle.resolved",
+        rewards: []
+      }
+    ],
+    {
+      since: "2026-03-27T10:04:00.000Z",
+      until: "2026-03-27T10:06:00.000Z"
+    }
+  );
+
+  assert.deepEqual(queried.map((entry) => entry.id), ["middle-entry"]);
+});
+
 test("achievement progress query helper filters by id, metric, unlocked state, and limit", () => {
   const queried = queryAchievementProgress(
     [


### PR DESCRIPTION
## Summary
- add optional inclusive `since` / `until` filters to player event-history queries
- apply the same time-range behavior in shared local-mode filtering and MySQL-backed history lookups
- cover the new filters with shared, route, and persistence tests and document the API

## Testing
- node --import tsx --test packages/shared/test/shared-core.test.ts
- node --import tsx --test apps/server/test/player-account-routes.test.ts
- node --import tsx --test apps/server/test/persistence-account-credentials.test.ts

Refs #27