### PR TITLE
Add asset manifest metadata validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@
 - 当前美术接入方式为 `configs/assets.json` + `apps/client/public/assets/` 占位素材，逻辑对象已通过稳定资源 key 映射到前端表现层。
 - `assets.json` 已支持多状态资源描述，当前单位和标记可按 `idle / selected / hit` 状态切换占位素材。
 - 地形资源已支持稳定多变体切换，单位资源也已拆成 `portrait + frame` 槽位，后续可直接替换成正式美术素材而不改逻辑层 key。
+- `assets.json` 现已强制声明 `metadata`：每个被引用的资源路径都要带 `slot / stage / source`，用于追踪“当前占位图对应哪个稳定槽位、是否已经转正、来源是什么”。
+- `npm run validate:assets` 现在除了校验 schema 和文件存在性，也会拦截缺失元数据、重复槽位和游离元数据；后续正式美术替换可直接沿用同一套 manifest 规则补齐审计信息。
 - `units.json` 现已补上 `faction / rarity` 元数据，前端会自动挂载阵营与品质 badge，占位资源层已经具备继续细化正式 UI 的结构。
 - `battle-skills.json` 现已承载战斗技能与持续状态目录，shared 战斗结算会在创建战斗和执行技能时直接读取运行时配置，不再依赖硬编码技能表。
 - `battle-balance.json` 现已补上第一批战斗平衡基础配置，当前 shared 战斗运行时已经会直接读取其中的伤害公式参数，以及遭遇战环境里路障/陷阱的生成阈值、耐久、伤害和次数；本批还未把它接进配置中心 UI，只先建立 shared 侧可验证的数据驱动链路。

--- a/apps/client/src/assets.ts
+++ b/apps/client/src/assets.ts
@@ -1,8 +1,8 @@
 import assetConfigJson from "../../../configs/assets.json";
 import unitCatalog from "../../../configs/units.json";
-import type { AssetConfig } from "../../../packages/shared/src/assets-config";
+import { parseAssetConfig, type AssetConfig, type AssetMetadataEntry } from "../../../packages/shared/src/assets-config";
 
-const assetConfig: AssetConfig = assetConfigJson;
+const assetConfig: AssetConfig = parseAssetConfig(assetConfigJson);
 
 type TerrainKey = keyof typeof assetConfig.terrain;
 type ResourceKey = keyof typeof assetConfig.resources;
@@ -48,6 +48,10 @@ export function unitAsset(key: string, state: AssetState = "idle"): string | nul
 
 export function unitFrameAsset(key: string): string | null {
   return assetConfig.units[key as UnitKey]?.frame ?? null;
+}
+
+export function assetManifestEntry(assetPath: string): AssetMetadataEntry | null {
+  return assetConfig.metadata[assetPath] ?? null;
 }
 
 export function unitBadgeAssets(key: string): { faction: string | null; rarity: string | null } {

--- a/configs/assets.json
+++ b/configs/assets.json
@@ -61,6 +61,189 @@
       "hit": "/assets/markers/neutral-marker-hit.svg"
     }
   },
+  "metadata": {
+    "/assets/terrain/grass-tile.svg": {
+      "slot": "terrain.grass.default",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/terrain/grass-tile-alt.svg": {
+      "slot": "terrain.grass.alt",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/terrain/dirt-tile.svg": {
+      "slot": "terrain.dirt.default",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/terrain/dirt-tile-alt.svg": {
+      "slot": "terrain.dirt.alt",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/terrain/sand-tile.svg": {
+      "slot": "terrain.sand.default",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/terrain/sand-tile-alt.svg": {
+      "slot": "terrain.sand.alt",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/terrain/water-tile.svg": {
+      "slot": "terrain.water.default",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/terrain/water-tile-alt.svg": {
+      "slot": "terrain.water.alt",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/terrain/fog-tile.svg": {
+      "slot": "terrain.unknown.default",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/resources/gold-pile.svg": {
+      "slot": "resource.gold",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/resources/wood-stack.svg": {
+      "slot": "resource.wood",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/resources/ore-crate.svg": {
+      "slot": "resource.ore",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/buildings/recruitment-post.svg": {
+      "slot": "building.recruitment_post",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/buildings/attribute-shrine.svg": {
+      "slot": "building.attribute_shrine",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/buildings/resource-mine.svg": {
+      "slot": "building.resource_mine",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/units/hero-guard-basic.svg": {
+      "slot": "unit.hero_guard_basic.idle",
+      "stage": "placeholder",
+      "source": "generated",
+      "notes": "Pixel Fantasy placeholder sprite pending production replacement."
+    },
+    "/assets/units/hero-guard-basic-selected.svg": {
+      "slot": "unit.hero_guard_basic.selected",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/units/hero-guard-basic-hit.svg": {
+      "slot": "unit.hero_guard_basic.hit",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/frames/unit-frame-ally.svg": {
+      "slot": "unit.hero_guard_basic.frame",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/units/wolf-pack.svg": {
+      "slot": "unit.wolf_pack.idle",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/units/wolf-pack-selected.svg": {
+      "slot": "unit.wolf_pack.selected",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/units/wolf-pack-hit.svg": {
+      "slot": "unit.wolf_pack.hit",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/frames/unit-frame-enemy.svg": {
+      "slot": "unit.wolf_pack.frame",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/markers/hero-marker.svg": {
+      "slot": "marker.hero.idle",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/markers/hero-marker-selected.svg": {
+      "slot": "marker.hero.selected",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/markers/hero-marker-hit.svg": {
+      "slot": "marker.hero.hit",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/markers/neutral-marker.svg": {
+      "slot": "marker.neutral.idle",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/markers/neutral-marker-selected.svg": {
+      "slot": "marker.neutral.selected",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/markers/neutral-marker-hit.svg": {
+      "slot": "marker.neutral.hit",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/badges/faction-crown.svg": {
+      "slot": "badge.factions.crown",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/badges/faction-wild.svg": {
+      "slot": "badge.factions.wild",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/badges/rarity-common.svg": {
+      "slot": "badge.rarities.common",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/badges/rarity-elite.svg": {
+      "slot": "badge.rarities.elite",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/badges/interaction-move.svg": {
+      "slot": "badge.interactions.move",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/badges/interaction-pickup.svg": {
+      "slot": "badge.interactions.pickup",
+      "stage": "placeholder",
+      "source": "generated"
+    },
+    "/assets/badges/interaction-battle.svg": {
+      "slot": "badge.interactions.battle",
+      "stage": "placeholder",
+      "source": "generated"
+    }
+  },
   "badges": {
     "factions": {
       "crown": "/assets/badges/faction-crown.svg",

--- a/packages/shared/src/assets-config.ts
+++ b/packages/shared/src/assets-config.ts
@@ -2,6 +2,8 @@ import type { BuildingKind, ResourceKind, TerrainType } from "./models";
 
 export type AssetState = "idle" | "selected" | "hit";
 export type MarkerKind = "hero" | "neutral";
+export type AssetStage = "placeholder" | "production";
+export type AssetSource = "generated" | "licensed" | "commissioned";
 
 export interface TerrainAssetEntry {
   default: string;
@@ -19,12 +21,20 @@ export interface MarkerAssetEntry {
   hit: string;
 }
 
+export interface AssetMetadataEntry {
+  slot: string;
+  stage: AssetStage;
+  source: AssetSource;
+  notes?: string;
+}
+
 export interface AssetConfig {
   terrain: Record<TerrainType | "unknown", TerrainAssetEntry>;
   resources: Record<ResourceKind, string>;
   buildings: Record<BuildingKind, string>;
   units: Record<string, UnitAssetEntry>;
   markers: Record<MarkerKind, MarkerAssetEntry>;
+  metadata: Record<string, AssetMetadataEntry>;
   badges: {
     factions: Record<string, string>;
     rarities: Record<string, string>;
@@ -50,7 +60,12 @@ export function getAssetConfigValidationErrors(config: unknown): string[] {
   validateStringMapSection(config.buildings, BUILDING_KEYS, "buildings", errors);
   validateUnitsSection(config.units, errors);
   validateMarkersSection(config.markers, errors);
+  validateMetadataSection(config.metadata, errors);
   validateBadgesSection(config.badges, errors);
+
+  if (errors.length === 0) {
+    validateMetadataCoverage(config as unknown as AssetConfig, errors);
+  }
 
   return errors;
 }
@@ -171,6 +186,63 @@ function validateBadgesSection(section: unknown, errors: string[]): void {
   }
 }
 
+function validateMetadataSection(section: unknown, errors: string[]): void {
+  if (!isRecord(section)) {
+    errors.push("metadata must be an object");
+    return;
+  }
+
+  const seenSlots = new Map<string, string>();
+
+  for (const [assetPath, entry] of Object.entries(section)) {
+    validateAssetPath(assetPath, `metadata.${assetPath}`, errors);
+
+    if (!isRecord(entry)) {
+      errors.push(`metadata[${assetPath}] must be an object`);
+      continue;
+    }
+
+    if (typeof entry.slot !== "string" || entry.slot.length === 0) {
+      errors.push(`metadata[${assetPath}].slot must be a non-empty string`);
+    } else {
+      if (!/^[a-z0-9_.-]+$/.test(entry.slot)) {
+        errors.push(`metadata[${assetPath}].slot must use lowercase letters, numbers, dots, dashes or underscores`);
+      }
+
+      const existingPath = seenSlots.get(entry.slot);
+      if (existingPath) {
+        errors.push(`metadata[${assetPath}].slot duplicates metadata[${existingPath}].slot (${entry.slot})`);
+      } else {
+        seenSlots.set(entry.slot, assetPath);
+      }
+    }
+
+    validateEnum(entry.stage, ["placeholder", "production"], `metadata[${assetPath}].stage`, errors);
+    validateEnum(entry.source, ["generated", "licensed", "commissioned"], `metadata[${assetPath}].source`, errors);
+
+    if (entry.notes !== undefined && typeof entry.notes !== "string") {
+      errors.push(`metadata[${assetPath}].notes must be a string when provided`);
+    }
+  }
+}
+
+function validateMetadataCoverage(config: AssetConfig, errors: string[]): void {
+  const referencedPaths = new Set(collectAssetPaths(config));
+  const metadataPaths = new Set(Object.keys(config.metadata));
+
+  for (const assetPath of referencedPaths) {
+    if (!metadataPaths.has(assetPath)) {
+      errors.push(`metadata[${assetPath}] is missing for referenced asset path`);
+    }
+  }
+
+  for (const assetPath of metadataPaths) {
+    if (!referencedPaths.has(assetPath)) {
+      errors.push(`metadata[${assetPath}] does not map to any referenced asset path`);
+    }
+  }
+}
+
 function validateAssetPathArray(value: unknown, path: string, errors: string[]): void {
   if (!Array.isArray(value) || value.length === 0) {
     errors.push(`${path} must be a non-empty array`);
@@ -191,6 +263,83 @@ function validateAssetPath(value: unknown, path: string, errors: string[]): void
   if (!value.startsWith("/assets/")) {
     errors.push(`${path} must start with /assets/`);
   }
+}
+
+function validateEnum(value: unknown, choices: readonly string[], path: string, errors: string[]): void {
+  if (typeof value !== "string" || !choices.includes(value)) {
+    errors.push(`${path} must be one of: ${choices.join(", ")}`);
+  }
+}
+
+export function collectAssetPaths(assetConfig: AssetConfig): string[] {
+  const paths = new Set<string>();
+
+  for (const terrain of Object.values(assetConfig.terrain)) {
+    paths.add(terrain.default);
+    for (const variant of terrain.variants) {
+      paths.add(variant);
+    }
+  }
+
+  for (const resource of Object.values(assetConfig.resources)) {
+    paths.add(resource);
+  }
+
+  for (const building of Object.values(assetConfig.buildings)) {
+    paths.add(building);
+  }
+
+  for (const unit of Object.values(assetConfig.units)) {
+    for (const portrait of Object.values(unit.portrait)) {
+      paths.add(portrait);
+    }
+    paths.add(unit.frame);
+  }
+
+  for (const marker of Object.values(assetConfig.markers)) {
+    for (const state of Object.values(marker)) {
+      paths.add(state);
+    }
+  }
+
+  for (const badgeGroup of Object.values(assetConfig.badges)) {
+    for (const badge of Object.values(badgeGroup)) {
+      paths.add(badge);
+    }
+  }
+
+  return [...paths];
+}
+
+export function getAssetMetadataEntry(assetConfig: AssetConfig, assetPath: string): AssetMetadataEntry | null {
+  return assetConfig.metadata[assetPath] ?? null;
+}
+
+export function summarizeAssetMetadata(assetConfig: AssetConfig): {
+  total: number;
+  byStage: Record<AssetStage, number>;
+  bySource: Record<AssetSource, number>;
+} {
+  const summary = {
+    total: 0,
+    byStage: {
+      placeholder: 0,
+      production: 0
+    },
+    bySource: {
+      generated: 0,
+      licensed: 0,
+      commissioned: 0
+    }
+  };
+
+  for (const entry of Object.values(assetConfig.metadata)) {
+    summary.total += 1;
+    summary.byStage[entry.stage] += 1;
+    summary.bySource[entry.source] += 1;
+  }
+
+  return summary;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -35,6 +35,7 @@ import {
   getBattleBalanceConfig,
   getAchievementDefinitions,
   getAssetConfigValidationErrors,
+  getAssetMetadataEntry,
   getDefaultMapObjectsConfig,
   getDefaultBattleSkillCatalog,
   getDefaultHeroSkillTreeConfig,
@@ -56,6 +57,7 @@ import {
   resetRuntimeConfigs,
   simulateAutomatedBattle,
   simulateAutomatedBattles,
+  summarizeAssetMetadata,
   stepBattleReplayPlayback,
   tickBattleReplayPlayback,
   resolveWorldAction,
@@ -228,6 +230,30 @@ test("asset config passes schema validation", () => {
   assert.deepEqual(getAssetConfigValidationErrors(assetConfig), []);
 });
 
+test("asset config exposes metadata for referenced asset paths", () => {
+  const assetPath = assetConfig.units.hero_guard_basic.portrait.idle;
+
+  assert.deepEqual(getAssetMetadataEntry(assetConfig, assetPath), {
+    slot: "unit.hero_guard_basic.idle",
+    stage: "placeholder",
+    source: "generated",
+    notes: "Pixel Fantasy placeholder sprite pending production replacement."
+  });
+
+  assert.deepEqual(summarizeAssetMetadata(assetConfig), {
+    total: 36,
+    byStage: {
+      placeholder: 36,
+      production: 0
+    },
+    bySource: {
+      generated: 36,
+      licensed: 0,
+      commissioned: 0
+    }
+  });
+});
+
 test("asset config validation reports missing terrain variants and bad asset roots", () => {
   const errors = getAssetConfigValidationErrors({
     terrain: {
@@ -284,6 +310,18 @@ test("asset config validation reports missing terrain variants and bad asset roo
         hit: "/assets/markers/neutral-marker-hit.svg"
       }
     },
+    metadata: {
+      "/assets/terrain/grass-tile.svg": {
+        slot: "terrain.grass.default",
+        stage: "placeholder",
+        source: "generated"
+      },
+      "/assets/resources/wood-stack.svg": {
+        slot: "resource.wood",
+        stage: "production",
+        source: "outsourced"
+      }
+    },
     badges: {
       factions: {
         crown: "/assets/badges/faction-crown.svg"
@@ -299,6 +337,172 @@ test("asset config validation reports missing terrain variants and bad asset roo
 
   assert.ok(errors.includes("terrain.unknown.variants must be a non-empty array"));
   assert.ok(errors.includes("resources.wood must start with /assets/"));
+  assert.ok(errors.includes("metadata[/assets/resources/wood-stack.svg].source must be one of: generated, licensed, commissioned"));
+});
+
+test("asset config validation reports missing metadata coverage and duplicate slots", () => {
+  const errors = getAssetConfigValidationErrors({
+    terrain: {
+      grass: {
+        default: "/assets/terrain/grass-tile.svg",
+        variants: ["/assets/terrain/grass-tile.svg"]
+      },
+      dirt: {
+        default: "/assets/terrain/dirt-tile.svg",
+        variants: ["/assets/terrain/dirt-tile.svg"]
+      },
+      sand: {
+        default: "/assets/terrain/sand-tile.svg",
+        variants: ["/assets/terrain/sand-tile.svg"]
+      },
+      water: {
+        default: "/assets/terrain/water-tile.svg",
+        variants: ["/assets/terrain/water-tile.svg"]
+      },
+      unknown: {
+        default: "/assets/terrain/fog-tile.svg",
+        variants: ["/assets/terrain/fog-tile.svg"]
+      }
+    },
+    resources: {
+      gold: "/assets/resources/gold-pile.svg",
+      wood: "/assets/resources/wood-stack.svg",
+      ore: "/assets/resources/ore-crate.svg"
+    },
+    buildings: {
+      recruitment_post: "/assets/buildings/recruitment-post.svg",
+      attribute_shrine: "/assets/buildings/attribute-shrine.svg",
+      resource_mine: "/assets/buildings/resource-mine.svg"
+    },
+    units: {
+      hero_guard_basic: {
+        portrait: {
+          idle: "/assets/units/hero-guard-basic.svg",
+          selected: "/assets/units/hero-guard-basic-selected.svg",
+          hit: "/assets/units/hero-guard-basic-hit.svg"
+        },
+        frame: "/assets/frames/unit-frame-ally.svg"
+      }
+    },
+    markers: {
+      hero: {
+        idle: "/assets/markers/hero-marker.svg",
+        selected: "/assets/markers/hero-marker-selected.svg",
+        hit: "/assets/markers/hero-marker-hit.svg"
+      },
+      neutral: {
+        idle: "/assets/markers/neutral-marker.svg",
+        selected: "/assets/markers/neutral-marker-selected.svg",
+        hit: "/assets/markers/neutral-marker-hit.svg"
+      }
+    },
+    metadata: {
+      "/assets/terrain/grass-tile.svg": {
+        slot: "terrain.base",
+        stage: "placeholder",
+        source: "generated"
+      },
+      "/assets/terrain/dirt-tile.svg": {
+        slot: "terrain.base",
+        stage: "placeholder",
+        source: "generated"
+      }
+    },
+    badges: {
+      factions: {
+        crown: "/assets/badges/faction-crown.svg"
+      },
+      rarities: {
+        common: "/assets/badges/rarity-common.svg"
+      },
+      interactions: {
+        move: "/assets/badges/interaction-move.svg"
+      }
+    }
+  });
+
+  assert.ok(
+    errors.includes("metadata[/assets/terrain/dirt-tile.svg].slot duplicates metadata[/assets/terrain/grass-tile.svg].slot (terrain.base)")
+  );
+});
+
+test("asset config validation reports missing metadata coverage", () => {
+  const errors = getAssetConfigValidationErrors({
+    terrain: {
+      grass: {
+        default: "/assets/terrain/grass-tile.svg",
+        variants: ["/assets/terrain/grass-tile.svg"]
+      },
+      dirt: {
+        default: "/assets/terrain/dirt-tile.svg",
+        variants: ["/assets/terrain/dirt-tile.svg"]
+      },
+      sand: {
+        default: "/assets/terrain/sand-tile.svg",
+        variants: ["/assets/terrain/sand-tile.svg"]
+      },
+      water: {
+        default: "/assets/terrain/water-tile.svg",
+        variants: ["/assets/terrain/water-tile.svg"]
+      },
+      unknown: {
+        default: "/assets/terrain/fog-tile.svg",
+        variants: ["/assets/terrain/fog-tile.svg"]
+      }
+    },
+    resources: {
+      gold: "/assets/resources/gold-pile.svg",
+      wood: "/assets/resources/wood-stack.svg",
+      ore: "/assets/resources/ore-crate.svg"
+    },
+    buildings: {
+      recruitment_post: "/assets/buildings/recruitment-post.svg",
+      attribute_shrine: "/assets/buildings/attribute-shrine.svg",
+      resource_mine: "/assets/buildings/resource-mine.svg"
+    },
+    units: {
+      hero_guard_basic: {
+        portrait: {
+          idle: "/assets/units/hero-guard-basic.svg",
+          selected: "/assets/units/hero-guard-basic-selected.svg",
+          hit: "/assets/units/hero-guard-basic-hit.svg"
+        },
+        frame: "/assets/frames/unit-frame-ally.svg"
+      }
+    },
+    markers: {
+      hero: {
+        idle: "/assets/markers/hero-marker.svg",
+        selected: "/assets/markers/hero-marker-selected.svg",
+        hit: "/assets/markers/hero-marker-hit.svg"
+      },
+      neutral: {
+        idle: "/assets/markers/neutral-marker.svg",
+        selected: "/assets/markers/neutral-marker-selected.svg",
+        hit: "/assets/markers/neutral-marker-hit.svg"
+      }
+    },
+    metadata: {
+      "/assets/terrain/grass-tile.svg": {
+        slot: "terrain.grass.default",
+        stage: "placeholder",
+        source: "generated"
+      }
+    },
+    badges: {
+      factions: {
+        crown: "/assets/badges/faction-crown.svg"
+      },
+      rarities: {
+        common: "/assets/badges/rarity-common.svg"
+      },
+      interactions: {
+        move: "/assets/badges/interaction-move.svg"
+      }
+    }
+  });
+
+  assert.ok(errors.includes("metadata[/assets/terrain/fog-tile.svg] is missing for referenced asset path"));
 });
 
 test("achievement helpers unlock milestones and preserve catalog order", () => {

--- a/scripts/validate-assets.ts
+++ b/scripts/validate-assets.ts
@@ -2,7 +2,12 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import assetConfigJson from "../configs/assets.json";
 import unitCatalog from "../configs/units.json";
-import { getAssetConfigValidationErrors, parseAssetConfig } from "../packages/shared/src/assets-config";
+import {
+  collectAssetPaths,
+  getAssetConfigValidationErrors,
+  parseAssetConfig,
+  summarizeAssetMetadata
+} from "../packages/shared/src/assets-config";
 
 const rootDir = process.cwd();
 const publicDir = path.join(rootDir, "apps/client/public");
@@ -22,8 +27,9 @@ if (errors.length > 0) {
   }
   process.exitCode = 1;
 } else {
+  const metadata = summarizeAssetMetadata(assetConfig);
   console.log(
-    `Asset validation passed: ${Object.keys(assetConfig.units).length} units, ${countAssetPaths(assetConfig)} registered files`
+    `Asset validation passed: ${Object.keys(assetConfig.units).length} units, ${collectAssetPaths(assetConfig).length} registered files, ${metadata.byStage.placeholder} placeholder / ${metadata.byStage.production} production`
   );
 }
 
@@ -75,48 +81,4 @@ function validateAssetFiles(assetConfig: ReturnType<typeof parseAssetConfig>, er
       errors.push(`${assetPath} does not exist at ${path.relative(rootDir, filepath)}`);
     }
   }
-}
-
-function collectAssetPaths(assetConfig: ReturnType<typeof parseAssetConfig>): string[] {
-  const paths = new Set<string>();
-
-  for (const terrain of Object.values(assetConfig.terrain)) {
-    paths.add(terrain.default);
-    for (const variant of terrain.variants) {
-      paths.add(variant);
-    }
-  }
-
-  for (const resource of Object.values(assetConfig.resources)) {
-    paths.add(resource);
-  }
-
-  for (const building of Object.values(assetConfig.buildings)) {
-    paths.add(building);
-  }
-
-  for (const unit of Object.values(assetConfig.units)) {
-    for (const portrait of Object.values(unit.portrait)) {
-      paths.add(portrait);
-    }
-    paths.add(unit.frame);
-  }
-
-  for (const marker of Object.values(assetConfig.markers)) {
-    for (const state of Object.values(marker)) {
-      paths.add(state);
-    }
-  }
-
-  for (const badgeGroup of Object.values(assetConfig.badges)) {
-    for (const badge of Object.values(badgeGroup)) {
-      paths.add(badge);
-    }
-  }
-
-  return [...paths];
-}
-
-function countAssetPaths(assetConfig: ReturnType<typeof parseAssetConfig>): number {
-  return collectAssetPaths(assetConfig).length;
 }


### PR DESCRIPTION
## Summary
- require asset manifest metadata for every referenced web asset path
- validate metadata coverage, slot uniqueness, and stage/source values in shared schema + asset validation script
- expose manifest lookup helpers and document the new contract

## Testing
- npm run test:shared
- npm run validate:assets
- npm run typecheck:shared
- npm run typecheck:client:h5

Refs #33