### PR TITLE
Refs #27: unify event log query normalization contracts

### DIFF
--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -1,6 +1,7 @@
 import { createConnection, createPool, type Pool, type PoolConnection, type ResultSetHeader, type RowDataPacket } from "mysql2/promise";
 import {
   appendPlayerBattleReplaySummaries,
+  normalizeEventLogQuery,
   normalizeAchievementProgress,
   normalizeEventLogEntries,
   normalizePlayerAccountReadModel,
@@ -374,29 +375,7 @@ function normalizePlayerAccountSnapshot(account: {
 function normalizePlayerEventHistoryQuery(query: PlayerEventHistoryQuery = {}): Required<Pick<PlayerEventHistoryQuery, "offset">> &
   Pick<PlayerEventHistoryQuery, "category" | "heroId" | "achievementId" | "worldEventType" | "since" | "until"> &
   { limit?: number } {
-  const since = normalizeHistoryTimestampFilter(query.since);
-  const until = normalizeHistoryTimestampFilter(query.until);
-
-  return {
-    ...(query.limit == null ? {} : { limit: Math.max(1, Math.floor(query.limit)) }),
-    offset: Math.max(0, Math.floor(query.offset ?? 0)),
-    ...(query.category ? { category: query.category } : {}),
-    ...(query.heroId?.trim() ? { heroId: query.heroId.trim() } : {}),
-    ...(query.achievementId ? { achievementId: query.achievementId } : {}),
-    ...(query.worldEventType ? { worldEventType: query.worldEventType } : {}),
-    ...(since ? { since } : {}),
-    ...(until ? { until } : {})
-  };
-}
-
-function normalizeHistoryTimestampFilter(value?: string | null): string | undefined {
-  const normalized = value?.trim();
-  if (!normalized) {
-    return undefined;
-  }
-
-  const parsed = new Date(normalized);
-  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  return normalizeEventLogQuery(query);
 }
 
 function extractNewPlayerEventHistoryEntries(

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -4,6 +4,8 @@ import {
   buildPlayerProgressionSnapshot,
   findPlayerBattleReplaySummary,
   getAchievementDefinitions,
+  normalizeAchievementProgressQuery,
+  normalizeEventLogQuery,
   queryPlayerBattleReplaySummaries,
   queryAchievementProgress,
   queryEventLogEntries,
@@ -204,72 +206,56 @@ function toEventLogResponse(
   account: PlayerAccountSnapshot,
   request: IncomingMessage
 ): { items: PlayerAccountSnapshot["recentEventLog"] } {
-  const limit = parseLimit(request);
-  const category = parseOptionalQueryParam(request, "category") as
-    | PlayerAccountSnapshot["recentEventLog"][number]["category"]
-    | undefined;
-  const heroId = parseOptionalQueryParam(request, "heroId");
-  const achievementId = parseOptionalQueryParam(request, "achievementId") as
-    | PlayerAccountSnapshot["recentEventLog"][number]["achievementId"]
-    | undefined;
-  const worldEventType = parseOptionalQueryParam(request, "worldEventType") as
-    | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
-    | undefined;
+  const query = normalizeEventLogQuery({
+    limit: parseLimit(request) ?? undefined,
+    category: parseOptionalQueryParam(request, "category") as
+      | PlayerAccountSnapshot["recentEventLog"][number]["category"]
+      | undefined,
+    heroId: parseOptionalQueryParam(request, "heroId") ?? undefined,
+    achievementId: parseOptionalQueryParam(request, "achievementId") as
+      | PlayerAccountSnapshot["recentEventLog"][number]["achievementId"]
+      | undefined,
+    worldEventType: parseOptionalQueryParam(request, "worldEventType") as
+      | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
+      | undefined
+  });
 
   return {
-    items: queryEventLogEntries(account.recentEventLog, {
-      ...(limit != null ? { limit } : {}),
-      ...(category ? { category } : {}),
-      ...(heroId ? { heroId } : {}),
-      ...(achievementId ? { achievementId } : {}),
-      ...(worldEventType ? { worldEventType } : {})
-    })
+    items: queryEventLogEntries(account.recentEventLog, query)
   };
 }
 
 function toEventHistoryQuery(request: IncomingMessage): PlayerEventHistoryQuery {
-  const offset = parseOffset(request);
-  const limit = parseLimit(request);
-  const category = parseOptionalQueryParam(request, "category") as PlayerAccountSnapshot["recentEventLog"][number]["category"] | undefined;
-  const heroId = parseOptionalQueryParam(request, "heroId");
-  const achievementId = parseOptionalQueryParam(request, "achievementId") as
-    | PlayerAccountSnapshot["recentEventLog"][number]["achievementId"]
-    | undefined;
-  const worldEventType = parseOptionalQueryParam(request, "worldEventType") as
-    | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
-    | undefined;
-  const since = parseTimestampQueryParam(request, "since");
-  const until = parseTimestampQueryParam(request, "until");
-
-  return {
-    ...(limit != null ? { limit } : {}),
-    ...(offset != null ? { offset } : {}),
-    ...(category ? { category } : {}),
-    ...(heroId ? { heroId } : {}),
-    ...(achievementId ? { achievementId } : {}),
-    ...(worldEventType ? { worldEventType } : {}),
-    ...(since ? { since } : {}),
-    ...(until ? { until } : {})
-  };
+  return normalizeEventLogQuery({
+    limit: parseLimit(request) ?? undefined,
+    offset: parseOffset(request) ?? undefined,
+    category: parseOptionalQueryParam(request, "category") as PlayerAccountSnapshot["recentEventLog"][number]["category"] | undefined,
+    heroId: parseOptionalQueryParam(request, "heroId") ?? undefined,
+    achievementId: parseOptionalQueryParam(request, "achievementId") as
+      | PlayerAccountSnapshot["recentEventLog"][number]["achievementId"]
+      | undefined,
+    worldEventType: parseOptionalQueryParam(request, "worldEventType") as
+      | PlayerAccountSnapshot["recentEventLog"][number]["worldEventType"]
+      | undefined,
+    since: parseTimestampQueryParam(request, "since") ?? undefined,
+    until: parseTimestampQueryParam(request, "until") ?? undefined
+  });
 }
 
 function toAchievementResponse(account: PlayerAccountSnapshot, request: IncomingMessage): { items: PlayerAccountSnapshot["achievements"] } {
-  const limit = parseLimit(request);
-  const achievementId = parseOptionalQueryParam(request, "achievementId") as
-    | PlayerAccountSnapshot["achievements"][number]["id"]
-    | undefined;
-  const metric = parseOptionalQueryParam(request, "metric") as
-    | PlayerAccountSnapshot["achievements"][number]["metric"]
-    | undefined;
-  const unlocked = parseBooleanQueryParam(request, "unlocked");
+  const query = normalizeAchievementProgressQuery({
+    limit: parseLimit(request) ?? undefined,
+    achievementId: parseOptionalQueryParam(request, "achievementId") as
+      | PlayerAccountSnapshot["achievements"][number]["id"]
+      | undefined,
+    metric: parseOptionalQueryParam(request, "metric") as
+      | PlayerAccountSnapshot["achievements"][number]["metric"]
+      | undefined,
+    unlocked: parseBooleanQueryParam(request, "unlocked") ?? undefined
+  });
 
   return {
-    items: queryAchievementProgress(account.achievements, {
-      ...(limit != null ? { limit } : {}),
-      ...(achievementId ? { achievementId } : {}),
-      ...(metric ? { metric } : {}),
-      ...(unlocked != null ? { unlocked } : {})
-    })
+    items: queryAchievementProgress(account.achievements, query)
   };
 }
 

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -121,6 +121,8 @@ The server appends only newly seen `recentEventLog` entries into this table when
 
 The event history routes support the existing `category` / `heroId` / `achievementId` / `worldEventType` filters, plus optional inclusive `since` and `until` ISO-8601 timestamps. MySQL-backed queries push those time-range predicates down into SQL so player history views can page within a bounded time window without scanning unrelated rows.
 
+Issue #27 follow-up note: event-log and achievement history queries now share a single normalization contract in `packages/shared/src/event-log.ts`. Route handlers and MySQL persistence both reuse that helper so trimming, pagination clamping, and ISO timestamp coercion stay consistent before full event-log persistence and richer achievement views land.
+
 ### Table: `config_documents`
 
 | Column | Type | Nullable | Default | Description |

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -68,6 +68,24 @@ export interface AchievementProgressQuery {
   unlocked?: boolean | undefined;
 }
 
+export interface NormalizedEventLogQuery {
+  limit?: number;
+  offset: number;
+  category?: EventLogCategory;
+  heroId?: string;
+  achievementId?: AchievementId;
+  worldEventType?: WorldEvent["type"];
+  since?: string;
+  until?: string;
+}
+
+export interface NormalizedAchievementProgressQuery {
+  limit?: number;
+  achievementId?: AchievementId;
+  metric?: AchievementMetric;
+  unlocked?: boolean;
+}
+
 export interface PlayerProgressionSummary {
   totalAchievements: number;
   unlockedAchievements: number;
@@ -653,13 +671,22 @@ export function queryAchievementProgress(
   progress?: Partial<PlayerAchievementProgress>[] | null,
   query: AchievementProgressQuery = {}
 ): PlayerAchievementProgress[] {
-  const safeLimit = query.limit == null ? undefined : Math.max(1, Math.floor(query.limit));
+  const normalizedQuery = normalizeAchievementProgressQuery(query);
 
   return normalizeAchievementProgress(progress)
-    .filter((entry) => (query.achievementId ? entry.id === query.achievementId : true))
-    .filter((entry) => (query.metric ? entry.metric === query.metric : true))
-    .filter((entry) => (query.unlocked == null ? true : entry.unlocked === query.unlocked))
-    .slice(0, safeLimit);
+    .filter((entry) => (normalizedQuery.achievementId ? entry.id === normalizedQuery.achievementId : true))
+    .filter((entry) => (normalizedQuery.metric ? entry.metric === normalizedQuery.metric : true))
+    .filter((entry) => (normalizedQuery.unlocked == null ? true : entry.unlocked === normalizedQuery.unlocked))
+    .slice(0, normalizedQuery.limit);
+}
+
+export function normalizeAchievementProgressQuery(query: AchievementProgressQuery = {}): NormalizedAchievementProgressQuery {
+  return {
+    ...(query.limit == null ? {} : { limit: Math.max(1, Math.floor(query.limit)) }),
+    ...(query.achievementId ? { achievementId: query.achievementId } : {}),
+    ...(query.metric ? { metric: query.metric } : {}),
+    ...(query.unlocked == null ? {} : { unlocked: query.unlocked })
+  };
 }
 
 export function normalizeEventLogEntries(entries?: Partial<EventLogEntry>[] | null): EventLogEntry[] {
@@ -723,20 +750,35 @@ export function queryEventLogEntries(
   entries?: Partial<EventLogEntry>[] | null,
   query: EventLogQuery = {}
 ): EventLogEntry[] {
-  const safeLimit = query.limit == null ? undefined : Math.max(1, Math.floor(query.limit));
-  const safeOffset = Math.max(0, Math.floor(query.offset ?? 0));
-  const heroId = query.heroId?.trim();
+  const normalizedQuery = normalizeEventLogQuery(query);
+
+  return normalizeEventLogEntries(entries)
+    .filter((entry) => (normalizedQuery.category ? entry.category === normalizedQuery.category : true))
+    .filter((entry) => (normalizedQuery.heroId ? entry.heroId === normalizedQuery.heroId : true))
+    .filter((entry) => (normalizedQuery.achievementId ? entry.achievementId === normalizedQuery.achievementId : true))
+    .filter((entry) => (normalizedQuery.worldEventType ? entry.worldEventType === normalizedQuery.worldEventType : true))
+    .filter((entry) => (normalizedQuery.since ? entry.timestamp >= normalizedQuery.since : true))
+    .filter((entry) => (normalizedQuery.until ? entry.timestamp <= normalizedQuery.until : true))
+    .slice(
+      normalizedQuery.offset,
+      normalizedQuery.limit == null ? undefined : normalizedQuery.offset + normalizedQuery.limit
+    );
+}
+
+export function normalizeEventLogQuery(query: EventLogQuery = {}): NormalizedEventLogQuery {
   const since = normalizeTimestampFilter(query.since);
   const until = normalizeTimestampFilter(query.until);
 
-  return normalizeEventLogEntries(entries)
-    .filter((entry) => (query.category ? entry.category === query.category : true))
-    .filter((entry) => (heroId ? entry.heroId === heroId : true))
-    .filter((entry) => (query.achievementId ? entry.achievementId === query.achievementId : true))
-    .filter((entry) => (query.worldEventType ? entry.worldEventType === query.worldEventType : true))
-    .filter((entry) => (since ? entry.timestamp >= since : true))
-    .filter((entry) => (until ? entry.timestamp <= until : true))
-    .slice(safeOffset, safeLimit == null ? undefined : safeOffset + safeLimit);
+  return {
+    ...(query.limit == null ? {} : { limit: Math.max(1, Math.floor(query.limit)) }),
+    offset: Math.max(0, Math.floor(query.offset ?? 0)),
+    ...(query.category ? { category: query.category } : {}),
+    ...(query.heroId?.trim() ? { heroId: query.heroId.trim() } : {}),
+    ...(query.achievementId ? { achievementId: query.achievementId } : {}),
+    ...(query.worldEventType ? { worldEventType: query.worldEventType } : {}),
+    ...(since ? { since } : {}),
+    ...(until ? { until } : {})
+  };
 }
 
 export function buildPlayerProgressionSnapshot(

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -46,6 +46,8 @@ import {
   getLatestProgressedAchievement,
   getLatestUnlockedAchievement,
   hasFullyExploredMap,
+  normalizeAchievementProgressQuery,
+  normalizeEventLogQuery,
   normalizePlayerAccountReadModel,
   normalizePlayerBattleReplaySummaries,
   pauseBattleReplayPlayback,
@@ -769,6 +771,30 @@ test("event log query helper filters by inclusive time range when provided", () 
   assert.deepEqual(queried.map((entry) => entry.id), ["middle-entry"]);
 });
 
+test("event log query normalization trims filters and canonicalizes paging and timestamps", () => {
+  assert.deepEqual(
+    normalizeEventLogQuery({
+      limit: 2.9,
+      offset: -3,
+      heroId: " hero-1 ",
+      category: "combat",
+      achievementId: "first_battle",
+      worldEventType: "battle.started",
+      since: " 2026-03-27T10:04:00+08:00 ",
+      until: "invalid"
+    }),
+    {
+      limit: 2,
+      offset: 0,
+      heroId: "hero-1",
+      category: "combat",
+      achievementId: "first_battle",
+      worldEventType: "battle.started",
+      since: "2026-03-27T02:04:00.000Z"
+    }
+  );
+});
+
 test("achievement progress query helper filters by id, metric, unlocked state, and limit", () => {
   const queried = queryAchievementProgress(
     [
@@ -798,6 +824,23 @@ test("achievement progress query helper filters by id, metric, unlocked state, a
   assert.deepEqual(queried.map((entry) => entry.id), ["skill_scholar"]);
   assert.equal(queried[0]?.title, "求知者");
   assert.equal(queried[0]?.target, 5);
+});
+
+test("achievement progress query normalization keeps only supported filters", () => {
+  assert.deepEqual(
+    normalizeAchievementProgressQuery({
+      limit: 1.8,
+      achievementId: "skill_scholar",
+      metric: "skills_learned",
+      unlocked: false
+    }),
+    {
+      limit: 1,
+      achievementId: "skill_scholar",
+      metric: "skills_learned",
+      unlocked: false
+    }
+  );
 });
 
 test("player progression snapshot summarizes unlocked achievements and recent events", () => {


### PR DESCRIPTION
## Summary
- add shared normalization helpers for event-log and achievement-progress queries in the shared package
- reuse the shared query contract in player account routes and MySQL-backed event history persistence
- document the new contract and add focused shared tests for trimming, paging, and timestamp coercion

## Testing
- npm run test:shared
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts ./apps/server/test/player-achievements.test.ts ./apps/server/test/persistence-account-credentials.test.ts
- npm run typecheck:shared
- npm run typecheck:server

Refs #27