### PR TITLE
feat: add H5 battle replay detail controls

### DIFF
--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -1,8 +1,11 @@
 import {
+  createBattleReplayPlaybackState,
   formatAchievementLabel,
   formatWorldEventTypeLabel,
   getLatestProgressedAchievement,
-  getLatestUnlockedAchievement
+  getLatestUnlockedAchievement,
+  type BattleReplayPlaybackState,
+  type BattleReplayStep
 } from "../../../packages/shared/src/index";
 import type { PlayerAccountProfile } from "./player-account";
 
@@ -103,6 +106,49 @@ function summarizeBattleReplaySteps(
     attack,
     skill
   };
+}
+
+function formatBattleReplayAction(step: BattleReplayStep | null): string {
+  if (!step) {
+    return "暂无动作";
+  }
+
+  if (step.action.type === "battle.attack") {
+    return `${step.action.attackerId} 攻击 ${step.action.defenderId}`;
+  }
+
+  if (step.action.type === "battle.skill") {
+    return `${step.action.unitId} 施放 ${step.action.skillId}${step.action.targetId ? ` -> ${step.action.targetId}` : ""}`;
+  }
+
+  if (step.action.type === "battle.defend") {
+    return `${step.action.unitId} 防御`;
+  }
+
+  return `${step.action.unitId} 等待`;
+}
+
+function formatBattleReplayPlaybackStatus(status: BattleReplayPlaybackState["status"]): string {
+  if (status === "playing") {
+    return "播放中";
+  }
+
+  if (status === "completed") {
+    return "已播完";
+  }
+
+  return "已暂停";
+}
+
+function formatBattleReplaySourceLabel(source: BattleReplayStep["source"]): string {
+  return source === "automated" ? "自动" : "玩家";
+}
+
+function formatBattleReplayUnitSummary(playback: BattleReplayPlaybackState): string {
+  const aliveUnits = Object.values(playback.currentState.units).filter((unit) => unit.count > 0);
+  const attackerAlive = aliveUnits.filter((unit) => unit.camp === "attacker").length;
+  const defenderAlive = aliveUnits.filter((unit) => unit.camp === "defender").length;
+  return `攻方 ${attackerAlive} 队 · 守方 ${defenderAlive} 队`;
 }
 
 function compareAchievementDisplayOrder(
@@ -242,7 +288,12 @@ export function renderRecentAccountEvents(account: PlayerAccountProfile): string
   </div>`;
 }
 
-export function renderRecentBattleReplays(account: PlayerAccountProfile): string {
+export function renderRecentBattleReplays(
+  account: PlayerAccountProfile,
+  options: {
+    selectedReplayId?: string | null;
+  } = {}
+): string {
   if (account.recentBattleReplays.length === 0) {
     return '<div class="account-subsection"><strong>最近战报</strong><p class="account-meta">尚未记录可回看的战斗摘要。</p></div>';
   }
@@ -255,6 +306,7 @@ export function renderRecentBattleReplays(account: PlayerAccountProfile): string
       ${visibleReplays
         .map((replay) => {
           const stepSummary = summarizeBattleReplaySteps(replay);
+          const isSelected = options.selectedReplayId === replay.id;
           const summaryChips = [
             `回放 ${replay.steps.length} 步`,
             `玩家 ${stepSummary.player}`,
@@ -262,7 +314,7 @@ export function renderRecentBattleReplays(account: PlayerAccountProfile): string
             stepSummary.attack > 0 ? `攻击 ${stepSummary.attack}` : "",
             stepSummary.skill > 0 ? `技能 ${stepSummary.skill}` : ""
           ].filter(Boolean);
-          return `<div class="account-replay-entry ${replay.result === "attacker_victory" ? "is-victory" : "is-defeat"}">
+          return `<button type="button" class="account-replay-entry ${replay.result === "attacker_victory" ? "is-victory" : "is-defeat"} ${isSelected ? "is-selected" : ""}" data-select-replay="${escapeHtml(replay.id)}">
             <div class="account-replay-head">
               <span class="account-badge tone-${replay.result === "attacker_victory" ? "victory" : "defeat"}">${escapeHtml(formatBattleReplayResultLabel(replay))}</span>
               <span>${escapeHtml(formatTimestamp(replay.completedAt))}</span>
@@ -276,6 +328,102 @@ export function renderRecentBattleReplays(account: PlayerAccountProfile): string
             <div class="account-event-rewards">${summaryChips
               .map((chip) => `<span class="account-reward-chip">${escapeHtml(chip)}</span>`)
               .join("")}</div>
+          </button>`;
+        })
+        .join("")}
+    </div>
+  </div>`;
+}
+
+export function renderBattleReplayInspector(input: {
+  replay: PlayerAccountProfile["recentBattleReplays"][number] | null;
+  playback: BattleReplayPlaybackState | null;
+  loading?: boolean;
+  status?: string;
+}): string {
+  if (!input.replay) {
+    return `<div class="account-subsection">
+      <strong>回放详情</strong>
+      <p class="account-meta">${escapeHtml(input.status?.trim() || "选择一场最近战斗，即可查看逐步回放。")}</p>
+    </div>`;
+  }
+
+  const playback = input.playback ?? createBattleReplayPlaybackState(input.replay);
+  const activeUnits = Object.values(playback.currentState.units)
+    .filter((unit) => unit.count > 0)
+    .sort((left, right) => {
+      if (left.camp !== right.camp) {
+        return left.camp.localeCompare(right.camp);
+      }
+      if (left.lane !== right.lane) {
+        return left.lane - right.lane;
+      }
+      return left.id.localeCompare(right.id);
+    });
+
+  return `<div class="account-subsection replay-inspector" data-testid="battle-replay-inspector">
+    <div class="account-replay-inspector-head">
+      <div>
+        <strong>回放详情</strong>
+        <p class="account-meta">${escapeHtml(
+          `${formatBattleReplayResultLabel(input.replay)} · ${formatBattleReplayKind(input.replay)} · ${formatBattleReplayEncounter(input.replay)}`
+        )}</p>
+      </div>
+      <button type="button" class="account-replay-dismiss" data-clear-replay="true">收起</button>
+    </div>
+    <div class="account-replay-meta">
+      <span>状态 ${escapeHtml(formatBattleReplayPlaybackStatus(playback.status))}</span>
+      <span>进度 ${playback.currentStepIndex}/${playback.totalSteps}</span>
+      <span>${escapeHtml(formatBattleReplayUnitSummary(playback))}</span>
+    </div>
+    <div class="account-replay-controls">
+      <button type="button" class="modal-button" data-replay-control="play" ${playback.status === "playing" || playback.status === "completed" ? "disabled" : ""}>播放</button>
+      <button type="button" class="modal-button" data-replay-control="pause" ${playback.status !== "playing" ? "disabled" : ""}>暂停</button>
+      <button type="button" class="modal-button" data-replay-control="step" ${playback.currentStepIndex >= playback.totalSteps ? "disabled" : ""}>步进</button>
+      <button type="button" class="modal-button" data-replay-control="reset" ${playback.currentStepIndex === 0 && playback.status !== "completed" ? "disabled" : ""}>重置</button>
+    </div>
+    <p class="account-meta">${escapeHtml(input.loading ? "正在刷新回放详情..." : input.status?.trim() || "按步骤回放本场战斗。")}</p>
+    <div class="account-replay-progress">
+      <div><strong>当前动作</strong><span>${escapeHtml(formatBattleReplayAction(playback.currentStep))}</span></div>
+      <div><strong>下一动作</strong><span>${escapeHtml(formatBattleReplayAction(playback.nextStep))}</span></div>
+    </div>
+    <div class="account-replay-state">
+      ${
+        activeUnits.length > 0
+          ? activeUnits
+              .map((unit) => {
+                const effects = (unit.statusEffects ?? []).map((effect) => effect.name).filter(Boolean);
+                return `<div class="account-replay-unit ${unit.camp === "attacker" ? "is-attacker" : "is-defender"}">
+                  <div class="account-replay-unit-head">
+                    <strong>${escapeHtml(unit.stackName)}</strong>
+                    <span>${escapeHtml(`${unit.camp === "attacker" ? "攻方" : "守方"} · ${unit.id}`)}</span>
+                  </div>
+                  <div class="account-replay-unit-meta">
+                    <span>数量 ${unit.count}</span>
+                    <span>HP ${unit.currentHp}/${unit.maxHp}</span>
+                    <span>格位 ${unit.lane}</span>
+                    ${unit.defending ? "<span>防御中</span>" : ""}
+                    ${effects.map((effect) => `<span>${escapeHtml(effect)}</span>`).join("")}
+                  </div>
+                </div>`;
+              })
+              .join("")
+          : '<div class="account-replay-unit"><span class="account-meta">当前战场没有可展示的存活单位。</span></div>'
+      }
+    </div>
+    <div class="account-replay-step-list">
+      ${input.replay.steps
+        .map((step) => {
+          const tone =
+            step.index === playback.currentStepIndex
+              ? "is-current"
+              : step.index < playback.currentStepIndex
+                ? "is-complete"
+                : "is-upcoming";
+          return `<div class="account-replay-step ${tone}">
+            <span class="account-badge">${step.index}</span>
+            <strong>${escapeHtml(formatBattleReplayAction(step))}</strong>
+            <span>${escapeHtml(formatBattleReplaySourceLabel(step.source))}</span>
           </div>`;
         })
         .join("")}

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,5 +1,6 @@
 import "./styles.css";
 import {
+  createBattleReplayPlaybackState,
   createHeroSkillTreeView,
   createHeroAttributeBreakdown,
   createHeroEquipmentLoadoutView,
@@ -9,8 +10,15 @@ import {
   formatEquipmentRarityLabel,
   getDefaultBattleSkillCatalog,
   getEquipmentDefinition,
+  pauseBattleReplayPlayback,
   predictPlayerWorldAction,
+  playBattleReplayPlayback,
+  resetBattleReplayPlayback,
+  stepBattleReplayPlayback,
+  tickBattleReplayPlayback,
   totalExperienceRequiredForLevel,
+  type BattleReplayPlaybackState,
+  type PlayerBattleReplaySummary,
   type BattleAction,
   type BattleState,
   type EquipmentType,
@@ -48,12 +56,18 @@ import {
   createFallbackPlayerAccountProfile as createLocalAccountProfile,
   loadPlayerAccountProfileWithProgression as loadAccountProfileWithProgression,
   bindPlayerAccountCredentials as bindAccountCredentials,
+  loadPlayerBattleReplayDetail,
   rememberPreferredPlayerDisplayName,
   readPreferredPlayerDisplayName as readLocalPreferredDisplayName,
   savePlayerAccountDisplayName as saveAccountDisplayName,
   type PlayerAccountProfile as ClientPlayerAccountProfile
 } from "./player-account";
-import { renderAchievementProgress, renderRecentAccountEvents, renderRecentBattleReplays } from "./account-history";
+import {
+  renderAchievementProgress,
+  renderBattleReplayInspector,
+  renderRecentAccountEvents,
+  renderRecentBattleReplays
+} from "./account-history";
 
 const params = new URLSearchParams(window.location.search);
 const queryRoomId = params.get("roomId")?.trim() ?? "";
@@ -127,6 +141,13 @@ interface AppState {
   accountSaving: boolean;
   accountBinding: boolean;
   accountStatus: string;
+  replayDetail: {
+    selectedReplayId: string | null;
+    replay: PlayerBattleReplaySummary | null;
+    playback: BattleReplayPlaybackState | null;
+    loading: boolean;
+    status: string;
+  };
   selectedHeroId: string | null;
   selectedTile: { x: number; y: number } | null;
   hoveredTile: { x: number; y: number } | null;
@@ -186,6 +207,13 @@ const state: AppState = {
   accountSaving: false,
   accountBinding: false,
   accountStatus: "游客账号资料将在连接后自动同步。",
+  replayDetail: {
+    selectedReplayId: null,
+    replay: null,
+    playback: null,
+    loading: false,
+    status: "选择一场最近战斗，即可查看逐步回放。"
+  },
   selectedHeroId: null,
   selectedTile: null,
   hoveredTile: null,
@@ -217,7 +245,9 @@ let nextUiTaskId = 1;
 let scheduledUiTasks: ScheduledUiTask[] = [];
 let pathAnimationTaskIds: number[] = [];
 let battleFxTaskId: number | null = null;
+let replayPlaybackTaskId: number | null = null;
 let keyboardShortcutsBound = false;
+let replayLoadToken = 0;
 
 interface PendingPrediction {
   world: PlayerWorldView;
@@ -369,6 +399,140 @@ function formatAccountLastSeen(account: ClientPlayerAccountProfile): string {
 
 function formatGlobalVault(account: ClientPlayerAccountProfile): string {
   return `全局仓库 金币 ${account.globalResources.gold} / 木材 ${account.globalResources.wood} / 矿石 ${account.globalResources.ore}`;
+}
+
+function findReplaySummary(replayId: string | null | undefined): PlayerBattleReplaySummary | null {
+  const normalizedReplayId = replayId?.trim();
+  if (!normalizedReplayId) {
+    return null;
+  }
+
+  return state.account.recentBattleReplays.find((replay) => replay.id === normalizedReplayId) ?? null;
+}
+
+function clearReplayPlaybackLoop(): void {
+  if (replayPlaybackTaskId != null) {
+    window.clearTimeout(replayPlaybackTaskId);
+  }
+  replayPlaybackTaskId = null;
+}
+
+function syncReplayPlaybackLoop(): void {
+  clearReplayPlaybackLoop();
+  if (state.replayDetail.playback?.status !== "playing") {
+    return;
+  }
+
+  replayPlaybackTaskId = window.setTimeout(() => {
+    replayPlaybackTaskId = null;
+    if (!state.replayDetail.playback) {
+      return;
+    }
+
+    state.replayDetail.playback = tickBattleReplayPlayback(state.replayDetail.playback);
+    state.replayDetail.status =
+      state.replayDetail.playback.status === "completed" ? "本场回放已播放完成。" : "正在自动推进回放。";
+    syncReplayPlaybackLoop();
+    render();
+  }, 420);
+}
+
+function clearReplayDetail(status = "选择一场最近战斗，即可查看逐步回放。"): void {
+  replayLoadToken += 1;
+  clearReplayPlaybackLoop();
+  state.replayDetail = {
+    selectedReplayId: null,
+    replay: null,
+    playback: null,
+    loading: false,
+    status
+  };
+}
+
+async function selectReplayDetail(replayId: string): Promise<void> {
+  const summary = findReplaySummary(replayId);
+  if (!summary) {
+    clearReplayDetail("该回放已不在最近战报列表中。");
+    render();
+    return;
+  }
+
+  const requestToken = ++replayLoadToken;
+  clearReplayPlaybackLoop();
+  state.replayDetail = {
+    selectedReplayId: replayId,
+    replay: summary,
+    playback: createBattleReplayPlaybackState(summary),
+    loading: true,
+    status: "正在加载回放详情..."
+  };
+  render();
+
+  let replay = summary;
+  try {
+    const detail = await loadPlayerBattleReplayDetail(state.account.playerId, replayId);
+    if (requestToken !== replayLoadToken) {
+      return;
+    }
+
+    replay = detail ?? summary;
+    state.replayDetail = {
+      selectedReplayId: replayId,
+      replay,
+      playback: createBattleReplayPlaybackState(replay),
+      loading: false,
+      status: detail ? "已加载完整回放，可逐步回看。" : "已从最近战报缓存恢复回放。"
+    };
+    render();
+  } catch {
+    if (requestToken !== replayLoadToken) {
+      return;
+    }
+
+    state.replayDetail = {
+      selectedReplayId: replayId,
+      replay,
+      playback: createBattleReplayPlaybackState(replay),
+      loading: false,
+      status: "回放详情加载失败，已回退到最近战报缓存。"
+    };
+    render();
+  }
+}
+
+function applyReplayPlaybackControl(action: "play" | "pause" | "step" | "reset"): void {
+  const currentPlayback = state.replayDetail.playback;
+  if (!currentPlayback) {
+    return;
+  }
+
+  clearReplayPlaybackLoop();
+  if (action === "play") {
+    state.replayDetail.playback = playBattleReplayPlayback(currentPlayback);
+    state.replayDetail.status = "正在自动推进回放。";
+    syncReplayPlaybackLoop();
+    render();
+    return;
+  }
+
+  if (action === "pause") {
+    state.replayDetail.playback = pauseBattleReplayPlayback(currentPlayback);
+    state.replayDetail.status = "回放已暂停。";
+    render();
+    return;
+  }
+
+  if (action === "step") {
+    state.replayDetail.playback = stepBattleReplayPlayback(currentPlayback);
+    state.replayDetail.status =
+      state.replayDetail.playback.status === "completed" ? "已步进到最后一步。" : "已前进一步。";
+    render();
+    return;
+  }
+
+  state.replayDetail.playback = resetBattleReplayPlayback(currentPlayback);
+  state.replayDetail.status = "回放已重置到初始状态。";
+  render();
 }
 
 function formatLobbyRoomUpdatedAt(updatedAt: string): string {
@@ -1180,6 +1344,17 @@ function renderGameToText(): string {
     feedbackTone: state.feedbackTone,
     predictionStatus: state.predictionStatus,
     modal: state.modal.visible ? { ...state.modal } : null,
+    replayDetail: state.replayDetail.replay
+      ? {
+          replayId: state.replayDetail.replay.id,
+          loading: state.replayDetail.loading,
+          status: state.replayDetail.playback?.status ?? "paused",
+          currentStepIndex: state.replayDetail.playback?.currentStepIndex ?? 0,
+          totalSteps: state.replayDetail.playback?.totalSteps ?? state.replayDetail.replay.steps.length,
+          currentAction: state.replayDetail.playback?.currentStep?.action.type ?? null,
+          nextAction: state.replayDetail.playback?.nextStep?.action.type ?? null
+        }
+      : null,
     animation: {
       animatedPath: state.animatedPath.map((node) => ({ x: node.x, y: node.y })),
       animatedPathIndex: state.animatedPathIndex,
@@ -3127,7 +3302,15 @@ function render(): void {
           <p class="account-meta">${escapeHtml(formatAccountLastSeen(state.account))}</p>
           <p class="account-meta">${escapeHtml(formatGlobalVault(state.account))}</p>
           ${renderAchievementProgress(state.account)}
-          ${renderRecentBattleReplays(state.account)}
+          ${renderRecentBattleReplays(state.account, {
+            selectedReplayId: state.replayDetail.selectedReplayId
+          })}
+          ${renderBattleReplayInspector({
+            replay: state.replayDetail.replay,
+            playback: state.replayDetail.playback,
+            loading: state.replayDetail.loading,
+            status: state.replayDetail.status
+          })}
           ${renderRecentAccountEvents(state.account)}
           <div class="account-editor">
             <input
@@ -3406,6 +3589,35 @@ function render(): void {
     });
   }
 
+  for (const replayButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-select-replay]"))) {
+    replayButton.addEventListener("click", () => {
+      const replayId = replayButton.dataset.selectReplay;
+      if (!replayId) {
+        return;
+      }
+
+      void selectReplayDetail(replayId);
+    });
+  }
+
+  for (const replayControlButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-replay-control]"))) {
+    replayControlButton.addEventListener("click", () => {
+      const action = replayControlButton.dataset.replayControl;
+      if (action !== "play" && action !== "pause" && action !== "step" && action !== "reset") {
+        return;
+      }
+
+      applyReplayPlaybackControl(action);
+    });
+  }
+
+  for (const clearReplayButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-clear-replay]"))) {
+    clearReplayButton.addEventListener("click", () => {
+      clearReplayDetail();
+      render();
+    });
+  }
+
   for (const accountInput of Array.from(root.querySelectorAll<HTMLInputElement>("[data-account-name]"))) {
     accountInput.addEventListener("input", () => {
       state.accountDraftName = accountInput.value;
@@ -3523,6 +3735,9 @@ async function syncPlayerAccountProfile(): Promise<void> {
         ? `账号资料与全局仓库已同步，当前已绑定登录 ID ${account.loginId}。`
         : "账号资料与全局仓库已同步，可继续把当前游客档升级成口令账号。"
       : "当前运行在本地游客档，昵称仅保存在浏览器。";
+  if (state.replayDetail.selectedReplayId && !account.recentBattleReplays.some((replay) => replay.id === state.replayDetail.selectedReplayId)) {
+    clearReplayDetail("最近战报已刷新，当前选中的回放已不可用。");
+  }
   render();
 }
 

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -391,12 +391,27 @@ h1 {
 }
 
 .account-replay-entry {
+  width: 100%;
   padding: 10px 12px;
   border-radius: 12px;
   border: 1px solid rgba(78, 58, 42, 0.08);
   background: rgba(78, 58, 42, 0.04);
   display: grid;
   gap: 6px;
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.account-replay-entry:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(84, 57, 35, 0.08);
+}
+
+.account-replay-entry.is-selected {
+  border-color: rgba(74, 120, 178, 0.28);
+  box-shadow: 0 0 0 2px rgba(74, 120, 178, 0.12);
 }
 
 .account-replay-entry.is-victory {
@@ -434,6 +449,103 @@ h1 {
   gap: 6px 10px;
   color: var(--muted);
   font-size: 12px;
+}
+
+.replay-inspector {
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(78, 58, 42, 0.08);
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.account-replay-inspector-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.account-replay-dismiss {
+  border: 0;
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: rgba(78, 58, 42, 0.08);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.account-replay-controls,
+.account-replay-progress,
+.account-replay-state,
+.account-replay-step-list {
+  display: grid;
+  gap: 8px;
+}
+
+.account-replay-controls {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.account-replay-progress {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.account-replay-progress div,
+.account-replay-unit,
+.account-replay-step {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(78, 58, 42, 0.05);
+}
+
+.account-replay-progress div {
+  display: grid;
+  gap: 4px;
+}
+
+.account-replay-unit {
+  display: grid;
+  gap: 6px;
+}
+
+.account-replay-unit.is-attacker {
+  border-left: 3px solid rgba(47, 110, 91, 0.38);
+}
+
+.account-replay-unit.is-defender {
+  border-left: 3px solid rgba(164, 77, 44, 0.38);
+}
+
+.account-replay-unit-head,
+.account-replay-unit-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: center;
+}
+
+.account-replay-unit-meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.account-replay-step {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.account-replay-step.is-current {
+  background: rgba(74, 120, 178, 0.1);
+}
+
+.account-replay-step.is-complete {
+  opacity: 0.8;
+}
+
+.account-replay-step.is-upcoming {
+  opacity: 0.64;
 }
 
 .account-reward-chip {
@@ -1466,6 +1578,11 @@ h1 {
 
   .lobby-auth-grid,
   .account-binding-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .account-replay-controls,
+  .account-replay-progress {
     grid-template-columns: 1fr;
   }
 

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderAchievementProgress, renderRecentAccountEvents, renderRecentBattleReplays } from "../src/account-history";
+import {
+  renderAchievementProgress,
+  renderBattleReplayInspector,
+  renderRecentAccountEvents,
+  renderRecentBattleReplays
+} from "../src/account-history";
+import { createBattleReplayPlaybackState, stepBattleReplayPlayback } from "../../../packages/shared/src/index";
 import type { PlayerAccountProfile } from "../src/player-account";
 
 function createProfile(): PlayerAccountProfile {
@@ -163,7 +169,9 @@ test("account history renderer shows readable event metadata, category summary, 
 });
 
 test("account history renderer shows recent battle replay summaries with step chips", () => {
-  const html = renderRecentBattleReplays(createProfile());
+  const html = renderRecentBattleReplays(createProfile(), {
+    selectedReplayId: "room-alpha:battle-1:player-1"
+  });
 
   assert.match(html, /最近 2 场战斗的回放摘要/);
   assert.match(html, /PVE · 中立守军 neutral-1/);
@@ -172,4 +180,38 @@ test("account history renderer shows recent battle replay summaries with step ch
   assert.match(html, /玩家 1/);
   assert.match(html, /自动 1/);
   assert.match(html, /技能 1/);
+  assert.match(html, /data-select-replay="room-alpha:battle-1:player-1"/);
+  assert.match(html, /account-replay-entry is-victory is-selected/);
+});
+
+test("account history renderer shows replay inspector controls and current playback snapshot", () => {
+  const replay = createProfile().recentBattleReplays[0]!;
+  const playback = stepBattleReplayPlayback(createBattleReplayPlaybackState(replay));
+  const html = renderBattleReplayInspector({
+    replay,
+    playback,
+    status: "已前进一步。"
+  });
+
+  assert.match(html, /回放详情/);
+  assert.match(html, /状态 已暂停/);
+  assert.match(html, /进度 1\/2/);
+  assert.match(html, /当前动作/);
+  assert.match(html, /hero-1-stack 攻击 neutral-1-stack/);
+  assert.match(html, /下一动作/);
+  assert.match(html, /neutral-1-stack 防御/);
+  assert.match(html, /data-replay-control="play"/);
+  assert.match(html, /data-replay-control="step"/);
+  assert.match(html, /data-clear-replay="true"/);
+});
+
+test("account history renderer shows replay inspector placeholder before a replay is selected", () => {
+  const html = renderBattleReplayInspector({
+    replay: null,
+    playback: null,
+    status: "选择一场最近战斗，即可查看逐步回放。"
+  });
+
+  assert.match(html, /回放详情/);
+  assert.match(html, /选择一场最近战斗/);
 });

--- a/progress.md
+++ b/progress.md
@@ -353,3 +353,41 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 当前结论：
   - 现在这条本地预览链路已经从“只能看到 empty state”变成“打一场后即可看到真实最近战报”
   - 下一步再做回放中心详情页时，可以直接复用这条本地数据链路继续迭代，不需要先补环境依赖。
+
+## H5 replay detail controls - 2026-03-28
+
+- 已在 `#27 世界事件日志与成就系统` 下继续推进“战斗回放控制”这一段，当前先把 H5 调试壳补成可用的最近战报详情区：
+  - `apps/client/src/account-history.ts`
+    - 最近战报条目改为可点击入口，支持高亮当前选中的 replay
+    - 新增 `renderBattleReplayInspector`，可渲染回放状态、当前动作、下一动作、存活单位列表与步骤轨迹
+  - `apps/client/src/main.ts`
+    - 新增 H5 侧 replay 详情状态
+    - 点击战报会请求 `/battle-replays/:replayId` 详情，并在本地用 shared playback helper 执行 `play / pause / step / reset`
+    - `render_game_to_text` 现已输出当前 replay 的选中状态与步骤进度，方便自动化回归
+  - `apps/client/src/styles.css`
+    - 补齐 replay 详情区、控制按钮、步骤列表和单位状态卡的样式
+- 新增 / 更新测试：
+  - `apps/client/test/account-history-render.test.ts`
+    - 覆盖回放条目选中态
+    - 覆盖 replay inspector 的控制按钮与步骤文案
+- 当前验证结果：
+  - `npm run typecheck:client:h5` 通过
+  - `node --import tsx --test ./apps/client/test/account-history-render.test.ts ./apps/client/test/player-account-storage.test.ts` 通过（20/20）
+  - `npm test` 通过（269/269）
+  - 本地 H5 联调已验证：
+    - 先用 `develop-web-game` 脚本跑 `tests/automation/keyboard-battle.actions.json` 生成真实 replay
+    - 再次用 `develop-web-game` 打开同一房间并点击最近战报，`state-0.json` 已出现：
+      - `replayDetail.replayId = replay-detail-20260328:battle-neutral-1:player-1`
+      - `currentStepIndex = 0`
+      - `totalSteps = 4`
+      - `nextAction = battle.skill`
+    - 额外用 Playwright 实点 `step -> play -> pause -> reset`，状态流转为：
+      - 初始 `0/4`
+      - `step` 后 `1/4`
+      - `play` 后推进到 `2/4`
+      - `pause` 停在 `2/4`
+      - `reset` 回到 `0/4`
+    - 已实际检查账号卡截图，最近战报详情区和控制按钮在页面中可见
+- 当前下一步：
+  - 可以继续把当前 H5 回放详情区往“独立回放中心页面”推进
+  - 或者把同一套 replay detail / playback 交互补到 Cocos 端入口上。


### PR DESCRIPTION
## Summary
- add a selectable H5 battle replay inspector below the recent battle report list
- support local replay playback controls for play, pause, step, and reset using the shared replay helpers
- cover the new inspector rendering states with focused account history tests and update progress notes

## Testing
- npm run typecheck:client:h5
- node --import tsx --test ./apps/client/test/account-history-render.test.ts ./apps/client/test/player-account-storage.test.ts
- npm test
- local H5 replay regression: generate a real replay, open the inspector, verify `step -> play -> pause -> reset`

Closes #27