### PR TITLE
H5: add battle report and replay center

### DIFF
--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -298,7 +298,7 @@ export function renderRecentBattleReplays(
     return '<div class="account-subsection"><strong>最近战报</strong><p class="account-meta">尚未记录可回看的战斗摘要。</p></div>';
   }
 
-  const visibleReplays = account.recentBattleReplays.slice(0, 3);
+  const visibleReplays = account.recentBattleReplays.slice(0, 6);
   return `<div class="account-subsection">
     <strong>最近战报</strong>
     <p class="account-meta">最近 ${visibleReplays.length} 场战斗的回放摘要</p>
@@ -333,6 +333,40 @@ export function renderRecentBattleReplays(
         .join("")}
     </div>
   </div>`;
+}
+
+export function renderBattleReportReplayCenter(input: {
+  account: PlayerAccountProfile;
+  selectedReplayId?: string | null;
+  replay: PlayerAccountProfile["recentBattleReplays"][number] | null;
+  playback: BattleReplayPlaybackState | null;
+  loading?: boolean;
+  status?: string;
+}): string {
+  const replayCount = input.account.recentBattleReplays.length;
+  const headline =
+    replayCount > 0
+      ? `最近累计 ${replayCount} 场战斗，支持从列表进入详情或基础回放。`
+      : "暂无可回看的战斗记录，完成一场战斗后这里会自动出现首批战报。";
+
+  return `<section class="account-subsection account-replay-center" data-testid="battle-report-center">
+    <div class="account-replay-center-head">
+      <div>
+        <strong>战报与回放中心</strong>
+        <p class="account-meta">${escapeHtml(headline)}</p>
+      </div>
+      <span class="account-badge">${replayCount > 0 ? `战报 ${replayCount}` : "暂无战报"}</span>
+    </div>
+    ${renderRecentBattleReplays(input.account, {
+      ...(input.selectedReplayId !== undefined ? { selectedReplayId: input.selectedReplayId } : {})
+    })}
+    ${renderBattleReplayInspector({
+      replay: input.replay,
+      playback: input.playback,
+      ...(input.loading !== undefined ? { loading: input.loading } : {}),
+      ...(input.status !== undefined ? { status: input.status } : {})
+    })}
+  </section>`;
 }
 
 export function renderBattleReplayInspector(input: {

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -64,9 +64,8 @@ import {
 } from "./player-account";
 import {
   renderAchievementProgress,
-  renderBattleReplayInspector,
-  renderRecentAccountEvents,
-  renderRecentBattleReplays
+  renderBattleReportReplayCenter,
+  renderRecentAccountEvents
 } from "./account-history";
 
 const params = new URLSearchParams(window.location.search);
@@ -3474,10 +3473,9 @@ function render(): void {
           <p class="account-meta">${escapeHtml(formatAccountLastSeen(state.account))}</p>
           <p class="account-meta">${escapeHtml(formatGlobalVault(state.account))}</p>
           ${renderAchievementProgress(state.account)}
-          ${renderRecentBattleReplays(state.account, {
-            selectedReplayId: state.replayDetail.selectedReplayId
-          })}
-          ${renderBattleReplayInspector({
+          ${renderBattleReportReplayCenter({
+            account: state.account,
+            selectedReplayId: state.replayDetail.selectedReplayId,
             replay: state.replayDetail.replay,
             playback: state.replayDetail.playback,
             loading: state.replayDetail.loading,

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -320,6 +320,20 @@ h1 {
   gap: 8px;
 }
 
+.account-replay-center {
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(78, 58, 42, 0.08);
+  background: rgba(255, 248, 240, 0.72);
+}
+
+.account-replay-center-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
 .account-achievement-list,
 .account-event-list,
 .account-replay-list {

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   renderAchievementProgress,
+  renderBattleReportReplayCenter,
   renderBattleReplayInspector,
   renderRecentAccountEvents,
   renderRecentBattleReplays
@@ -184,6 +185,24 @@ test("account history renderer shows recent battle replay summaries with step ch
   assert.match(html, /account-replay-entry is-victory is-selected/);
 });
 
+test("account history renderer groups battle list and replay detail into a replay center", () => {
+  const replay = createProfile().recentBattleReplays[0]!;
+  const html = renderBattleReportReplayCenter({
+    account: createProfile(),
+    selectedReplayId: replay.id,
+    replay,
+    playback: createBattleReplayPlaybackState(replay),
+    status: "已加载完整回放，可逐步回看。"
+  });
+
+  assert.match(html, /data-testid="battle-report-center"/);
+  assert.match(html, /战报与回放中心/);
+  assert.match(html, /最近累计 2 场战斗/);
+  assert.match(html, /支持从列表进入详情或基础回放/);
+  assert.match(html, /战报 2/);
+  assert.match(html, /回放详情/);
+});
+
 test("account history renderer shows replay inspector controls and current playback snapshot", () => {
   const replay = createProfile().recentBattleReplays[0]!;
   const playback = stepBattleReplayPlayback(createBattleReplayPlaybackState(replay));
@@ -213,5 +232,24 @@ test("account history renderer shows replay inspector placeholder before a repla
   });
 
   assert.match(html, /回放详情/);
+  assert.match(html, /选择一场最近战斗/);
+});
+
+test("account history renderer shows replay center empty state without blank content", () => {
+  const profile = createProfile();
+  profile.recentBattleReplays = [];
+
+  const html = renderBattleReportReplayCenter({
+    account: profile,
+    selectedReplayId: null,
+    replay: null,
+    playback: null,
+    status: "选择一场最近战斗，即可查看逐步回放。"
+  });
+
+  assert.match(html, /战报与回放中心/);
+  assert.match(html, /暂无可回看的战斗记录/);
+  assert.match(html, /暂无战报/);
+  assert.match(html, /尚未记录可回看的战斗摘要/);
   assert.match(html, /选择一场最近战斗/);
 });


### PR DESCRIPTION
## Summary
- group the H5 account replay list and replay inspector into a single 战报与回放中心 section
- expand the visible recent battle list and keep the existing low-risk playback flow unchanged
- add H5 renderer coverage for the replay center wrapper and empty state

## Checks
- node --import tsx --test ./apps/client/test/account-history-render.test.ts
- npm run typecheck:client:h5
- npm run build:client:h5

closes #109