### PR TITLE
Add GitHub Actions CI pipeline for tests and typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck:ci
+
+      - name: Test
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:e2e:multiplayer": "playwright test --config=playwright.multiplayer.config.ts",
     "test:e2e:multiplayer:headed": "playwright test --config=playwright.multiplayer.config.ts --headed",
     "test:shared": "node --import tsx --test ./packages/shared/test/shared-core.test.ts ./packages/shared/test/event-log-labels.test.ts ./packages/shared/test/event-log-foundation.test.ts",
+    "typecheck:ci": "npm run typecheck:shared && npm run typecheck:server && npm run typecheck:client:h5 && npm run typecheck:cocos",
     "typecheck": "tsc -p tsconfig.base.json --noEmit",
     "typecheck:cocos": "tsc -p apps/cocos-client/tsconfig.json --noEmit",
     "typecheck:shared": "tsc -p packages/shared/tsconfig.json --noEmit",


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow for pushes and pull requests against `main`
- install dependencies with `npm ci`, run the full existing `npm test`, and run a new `typecheck:ci` aggregate script
- scope CI typechecking to the existing passing package/app targets instead of the current root `typecheck`, which fails on unrelated pre-existing test/script typing issues

Closes #114