### PR TITLE
Add WeChat minigame build validation CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,23 @@ jobs:
 
       - name: Test
         run: npm test
+
+  wechat-build-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check WeChat mini game build templates
+        run: npm run check:wechat-build

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@
 - 终端逻辑演示：`npm run demo:flow`
 - 主客户端入口说明：`npm run client:primary`
 - Cocos 主客户端类型检查：`npm run typecheck:client`
+- 微信小游戏模板刷新：`npm run prepare:wechat-build`
+- 微信小游戏 CI 同款校验：`npm run check:wechat-build`
 - H5 调试壳开发服务：`npm run dev:client:h5`
 - H5 调试壳构建验证：`npm run build:client:h5`
 - H5 调试壳类型检查：`npm run typecheck:client:h5`
@@ -104,6 +106,7 @@
 - 战斗平衡验证：`npm run validate:battle -- --count=1000 --scenario=all --skill-config=configs/battle-skills-v1.1.json`
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
+- 微信小游戏构建 / 发布 / 回滚说明：`docs/wechat-minigame-release.md`
 - 当前 H5 调试壳仍支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。
 - 当前 H5 联机体验已支持：客户端预测、断线自动重连、刷新后本地快照首帧回放，再由权威房间状态收敛。
 - 当前 Cocos Creator 主客户端已补齐：

--- a/apps/cocos-client/assets/scripts/cocos-wechat-build.ts
+++ b/apps/cocos-client/assets/scripts/cocos-wechat-build.ts
@@ -99,6 +99,12 @@ const DEFAULT_BUILD_OUTPUT_DIR = "build/wechatgame";
 const DEFAULT_MAIN_PACKAGE_BUDGET_MB = 4;
 const DEFAULT_TOTAL_SUBPACKAGE_BUDGET_MB = 30;
 const DEFAULT_TIMEOUT_MS = 10_000;
+const REQUIRED_BUILD_OUTPUT_FILES = [
+  "game.json",
+  "project.config.json",
+  "codex.wechat.build.json",
+  "README.codex.md"
+] as const;
 
 function normalizeString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -501,6 +507,11 @@ export function analyzeWechatMinigameBuildOutput(
   const errors: string[] = [];
   const files = listFilesRecursively(resolvedOutputDir);
   const totalBytes = files.reduce((sum, file) => sum + file.bytes, 0);
+  for (const requiredFile of REQUIRED_BUILD_OUTPUT_FILES) {
+    if (!files.some((file) => file.relativePath === requiredFile)) {
+      errors.push(`Build output is missing required file: ${requiredFile}`);
+    }
+  }
   const gameJsonPath = path.join(resolvedOutputDir, "game.json");
   let actualSubpackageRoots: string[] = [];
   if (fs.existsSync(gameJsonPath)) {

--- a/apps/cocos-client/test/cocos-wechat-build.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-build.test.ts
@@ -152,19 +152,22 @@ test("analyzeWechatMinigameBuildOutput measures main package and subpackage budg
     })
   );
   fs.writeFileSync(path.join(tempDir, "game.js"), Buffer.alloc(140));
+  fs.writeFileSync(path.join(tempDir, "project.config.json"), JSON.stringify({ compileType: "game" }));
+  fs.writeFileSync(path.join(tempDir, "codex.wechat.build.json"), JSON.stringify({ buildTemplatePlatform: "wechatgame" }));
+  fs.writeFileSync(path.join(tempDir, "README.codex.md"), "# checklist\n");
   fs.writeFileSync(path.join(tempDir, "subpackages", "battle", "index.js"), Buffer.alloc(60));
 
   const analysis = analyzeWechatMinigameBuildOutput(
     tempDir,
     normalizeWechatMinigameBuildConfig({
-      mainPackageBudgetMb: 0.0002,
-      totalSubpackageBudgetMb: 0.0002,
+      mainPackageBudgetMb: 1,
+      totalSubpackageBudgetMb: 1,
       expectedSubpackages: [{ root: "subpackages/battle" }]
     })
   );
 
   assert.equal(analysis.errors.length, 0);
-  assert.equal(analysis.mainPackageBytes, 187);
+  assert.ok(analysis.mainPackageBytes > 140);
   assert.equal(analysis.totalSubpackageBytes, 60);
   assert.deepEqual(analysis.subpackages, [{ root: "subpackages/battle", bytes: 60 }]);
 });
@@ -193,7 +196,10 @@ test("analyzeWechatMinigameBuildOutput reports budget overruns and missing expec
 
   assert.deepEqual(analysis.subpackages, [{ root: "subpackages/scene", bytes: 0 }]);
   assert.equal(analysis.missingExpectedSubpackages[0], "subpackages/scene");
-  assert.match(analysis.errors[0] ?? "", /Main package exceeded budget/);
+  assert.match(analysis.errors.join("\n"), /Main package exceeded budget/);
+  assert.match(analysis.errors.join("\n"), /Build output is missing required file: project\.config\.json/);
+  assert.match(analysis.errors.join("\n"), /Build output is missing required file: codex\.wechat\.build\.json/);
+  assert.match(analysis.errors.join("\n"), /Build output is missing required file: README\.codex\.md/);
   assert.match(analysis.warnings.join("\n"), /Expected subpackages missing/);
   assert.match(analysis.warnings.join("\n"), /request domain checklist/);
   assert.match(analysis.warnings.join("\n"), /socket domain checklist/);

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -1,0 +1,39 @@
+# 微信小游戏构建校验与发布说明
+
+## 自动化边界
+
+- CI 入口：GitHub Actions `wechat-build-validation`
+- 执行命令：`npm run check:wechat-build`
+- 当前自动化会做三件事：
+  - 校验 `apps/cocos-client/wechat-minigame.build.json` 生成出的模板产物是否已经提交且未漂移
+  - 校验 `apps/cocos-client/build-templates/wechatgame/` 中必需文件是否齐全
+  - 校验主包 / 分包预算、预期分包声明，以及运行时域名白名单缺口告警
+
+## 本地执行
+
+- 刷新模板：`npm run prepare:wechat-build`
+- 只做 CI 同款校验：`npm run check:wechat-build`
+- 校验真实导出目录：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir>`
+
+## 发布步骤
+
+1. 先更新 `apps/cocos-client/wechat-minigame.build.json` 中的 `appid`、远程资源地址、预算和域名清单。
+2. 运行 `npm run prepare:wechat-build`，确认 `apps/cocos-client/build-templates/wechatgame/` 产物已更新。
+3. 在 Cocos Creator 中执行 `wechatgame` 正式导出，并把模板目录内容合入导出目录。
+4. 对真实导出目录执行 `npm run validate:wechat-build -- --output-dir <wechatgame-build-dir>`。
+5. 将远程资源上传到 CDN，在微信开发者工具中导入构建目录并完成人工 smoke check。
+
+## Smoke Check
+
+- 能正常启动到 Lobby / 首屏
+- `wx` 登录链路或游客降级链路可用
+- 与 `runtimeRemoteUrl` 对应的请求 / socket 域名无白名单报错
+- 关键远程资源可加载，首轮进入房间或战斗不出现缺图 / 缺配置
+
+## 回滚
+
+- 构建模板或配置回滚：回退 `apps/cocos-client/wechat-minigame.build.json` 与 `apps/cocos-client/build-templates/wechatgame/`
+- CDN 资源回滚：切回上一个静态资源目录版本
+- 小游戏包回滚：在微信开发者工具 / 平台侧重新上传上一个已验证通过的构建目录
+
+当前仓库未接入微信发布凭据，也不在 CI 中直连微信上传接口；正式提审和回滚发布仍保持人工执行。

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
     "validate:battle": "node --import tsx ./scripts/validate-battle-balance.ts",
     "prepare:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts",
+    "check:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts --check && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/build-templates/wechatgame",
     "validate:wechat-build": "node --import tsx ./scripts/validate-wechat-minigame-build.ts",
     "sync:assets:h5-pixel": "node ./scripts/sync-h5-pixel-assets.mjs",
     "validate:assets": "node --import tsx ./scripts/validate-assets.ts",

--- a/scripts/prepare-wechat-minigame-build.ts
+++ b/scripts/prepare-wechat-minigame-build.ts
@@ -8,12 +8,14 @@ import {
 interface Args {
   configPath: string;
   templateDir: string;
+  check: boolean;
   outputDir?: string;
 }
 
 function parseArgs(argv: string[]): Args {
   let configPath = "apps/cocos-client/wechat-minigame.build.json";
   let templateDir = "apps/cocos-client/build-templates/wechatgame";
+  let check = false;
   let outputDir: string | undefined;
 
   for (let index = 2; index < argv.length; index += 1) {
@@ -32,12 +34,17 @@ function parseArgs(argv: string[]): Args {
     if (arg === "--output-dir" && next) {
       outputDir = next;
       index += 1;
+      continue;
+    }
+    if (arg === "--check") {
+      check = true;
     }
   }
 
   return {
     configPath,
     templateDir,
+    check,
     ...(outputDir ? { outputDir } : {})
   };
 }
@@ -52,6 +59,19 @@ function writeTextFile(filePath: string, content: string): void {
   fs.writeFileSync(filePath, `${content}\n`, "utf8");
 }
 
+function compareFileContent(filePath: string, expected: string): string | undefined {
+  if (!fs.existsSync(filePath)) {
+    return `missing: ${filePath}`;
+  }
+
+  const actual = fs.readFileSync(filePath, "utf8");
+  if (actual !== expected) {
+    return `stale: ${filePath}`;
+  }
+
+  return undefined;
+}
+
 function main(): void {
   const args = parseArgs(process.argv);
   const repoRoot = process.cwd();
@@ -59,6 +79,35 @@ function main(): void {
   const templateDir = path.resolve(repoRoot, args.templateDir);
   const config = normalizeWechatMinigameBuildConfig(JSON.parse(fs.readFileSync(configPath, "utf8")));
   const artifacts = buildWechatMinigameTemplateArtifacts(config);
+
+  if (args.check) {
+    const mismatches = [
+      compareFileContent(path.join(templateDir, "game.json"), `${JSON.stringify(artifacts.gameJson, null, 2)}\n`),
+      compareFileContent(
+        path.join(templateDir, "project.config.json"),
+        `${JSON.stringify(artifacts.projectConfigJson, null, 2)}\n`
+      ),
+      compareFileContent(
+        path.join(templateDir, "codex.wechat.build.json"),
+        `${JSON.stringify(artifacts.manifestJson, null, 2)}\n`
+      ),
+      compareFileContent(path.join(templateDir, "README.codex.md"), `${artifacts.releaseChecklistMarkdown}\n`)
+    ].filter((value): value is string => Boolean(value));
+
+    if (mismatches.length > 0) {
+      console.error("WeChat mini game template artifacts are stale:");
+      for (const mismatch of mismatches) {
+        const [status, mismatchPath] = mismatch.split(": ", 2);
+        console.error(`  - ${status} ${path.relative(repoRoot, mismatchPath)}`);
+      }
+      console.error("Run npm run prepare:wechat-build to refresh them.");
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(`WeChat mini game templates are up to date: ${path.relative(repoRoot, templateDir)}`);
+    return;
+  }
 
   writeJsonFile(path.join(templateDir, "game.json"), artifacts.gameJson);
   writeJsonFile(path.join(templateDir, "project.config.json"), artifacts.projectConfigJson);


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions job that runs the repo's WeChat minigame validation command in CI
- add a non-mutating `--check` mode plus `npm run check:wechat-build` to verify committed template artifacts and required files
- document the local validation, release handoff, smoke checklist, and rollback path for the current manual WeChat DevTools boundary

## Testing
- `npm run check:wechat-build`
- `node --import tsx --test ./apps/cocos-client/test/cocos-wechat-build.test.ts`
- `npm run typecheck:ci` *(currently fails on pre-existing `apps/server/src/auth.ts` exactOptionalPropertyTypes errors unrelated to this change)*

Refs #126