### PR TITLE
Add replay timeline panel slice for #125

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 - 这轮又补了一层独立的玩家事件历史读模型：`savePlayerAccountProgress()` 会把账号 `recentEventLog` 里新增的结构化事件增量追加到 MySQL `player_event_history`，并开放 `GET /api/player-accounts/:playerId/event-history` / `/me/event-history`（支持 `limit`、`offset` 和现有事件筛选条件），让前端可以先做分页历史回顾而不用等完整战斗回放或完整成就 UI。
 - 玩家事件历史接口现已支持可选 `since` / `until` 时间范围筛选，且本地模式与 MySQL 持久化模式保持一致，方便后续只拉取某个时间窗内的世界事件或成就回顾。
 - 事件日志的共享基础当前收敛在 `packages/shared/src/event-log.ts`：除了事件/成就 schema、归一化和查询助手外，这里也统一提供世界事件日志工厂与成就日志工厂，服务端只负责把共享 `WorldEvent[]` 喂给这些 helper；完整战斗回放、完整成就 UI 和更长历史存储仍留给后续 issue 继续扩展。
+- 战斗回放读模型当前已补上两块更适合前端直接消费的能力：`GET /api/player-accounts/:playerId/battle-replays` 现支持 `limit` + `offset` 分页，shared 侧也新增了可从 `initialState + steps` 推导每步回合与伤害/减员结算的 replay timeline helper，H5 战报面板会直接显示这些逐步结算摘要。
 - H5 账号资料卡现在会额外拉取 `/api/player-accounts/:playerId/progression` 覆盖成就/事件摘要，因此即使基础账号接口只返回轻量档案，前端也能稳定展示最新的成就推进、最近解锁和世界事件日志，而不会继续依赖旧的内嵌快照。
 - H5 账号资料卡的成就/事件展示本轮也补了一层可读性整理：成就卡会把“已解锁”和“最近推进”的项目排到前面，并显示最近推进时间；世界事件日志则会把 `battle.started`、`first_battle` 这类内部 ID 转成中文标签，同时在摘要里补充各事件类别计数，方便后续继续接提示面板或筛选器。
 - H5 左侧面板现已补上账号资料卡：会优先显示服务端账号昵称，也会在浏览器本地记住上次使用的游客昵称；远端房间首次 `connect` 时会把这份 `displayName` 一并带给服务端，用于初始化游客账号资料。`/api/player-accounts/me` 返回的 `globalResources` 也会直接显示成“全局仓库”摘要，方便确认跨房间继承的金币/木材/矿石。

--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -1,11 +1,14 @@
 import {
+  buildBattleReplayTimeline,
   createBattleReplayPlaybackState,
   formatAchievementLabel,
   formatWorldEventTypeLabel,
   getLatestProgressedAchievement,
   getLatestUnlockedAchievement,
   type BattleReplayPlaybackState,
-  type BattleReplayStep
+  type BattleReplayStep,
+  type BattleReplayTimelineEntry,
+  type BattleReplayTimelineUnitChange
 } from "../../../packages/shared/src/index";
 import type { PlayerAccountProfile } from "./player-account";
 
@@ -142,6 +145,25 @@ function formatBattleReplayPlaybackStatus(status: BattleReplayPlaybackState["sta
 
 function formatBattleReplaySourceLabel(source: BattleReplayStep["source"]): string {
   return source === "automated" ? "自动" : "玩家";
+}
+
+function formatBattleReplayRound(entry: BattleReplayTimelineEntry): string {
+  return entry.resultingRound !== entry.round ? `第 ${entry.round} 回合 -> ${entry.resultingRound}` : `第 ${entry.round} 回合`;
+}
+
+function formatBattleReplayChange(change: BattleReplayTimelineUnitChange): string {
+  const parts = [
+    change.hpChange < 0 ? `伤害 ${Math.abs(change.hpChange)}` : "",
+    change.hpChange > 0 ? `恢复 ${change.hpChange}` : "",
+    change.countChange < 0 ? `减员 ${Math.abs(change.countChange)}` : "",
+    change.countChange > 0 ? `增员 ${change.countChange}` : "",
+    change.defeated ? "击倒" : "",
+    change.defendingChanged ? "防御切换" : "",
+    ...change.statusAdded.map((status) => `获得 ${status}`),
+    ...change.statusRemoved.map((status) => `失去 ${status}`)
+  ].filter(Boolean);
+
+  return `${change.stackName}${parts.length > 0 ? ` · ${parts.join(" · ")}` : ""}`;
 }
 
 function formatBattleReplayUnitSummary(playback: BattleReplayPlaybackState): string {
@@ -383,6 +405,9 @@ export function renderBattleReplayInspector(input: {
   }
 
   const playback = input.playback ?? createBattleReplayPlaybackState(input.replay);
+  const timeline = buildBattleReplayTimeline(input.replay);
+  const currentTimelineEntry = timeline[playback.currentStepIndex - 1] ?? null;
+  const nextTimelineEntry = timeline[playback.currentStepIndex] ?? null;
   const activeUnits = Object.values(playback.currentState.units)
     .filter((unit) => unit.count > 0)
     .sort((left, right) => {
@@ -418,9 +443,23 @@ export function renderBattleReplayInspector(input: {
     </div>
     <p class="account-meta">${escapeHtml(input.loading ? "正在刷新回放详情..." : input.status?.trim() || "按步骤回放本场战斗。")}</p>
     <div class="account-replay-progress">
-      <div><strong>当前动作</strong><span>${escapeHtml(formatBattleReplayAction(playback.currentStep))}</span></div>
-      <div><strong>下一动作</strong><span>${escapeHtml(formatBattleReplayAction(playback.nextStep))}</span></div>
+      <div><strong>当前动作</strong><span>${escapeHtml(formatBattleReplayAction(playback.currentStep))}</span><span class="account-meta">${escapeHtml(currentTimelineEntry ? formatBattleReplayRound(currentTimelineEntry) : "等待开始")}</span></div>
+      <div><strong>下一动作</strong><span>${escapeHtml(formatBattleReplayAction(playback.nextStep))}</span><span class="account-meta">${escapeHtml(nextTimelineEntry ? formatBattleReplayRound(nextTimelineEntry) : playback.status === "completed" ? "胜负已结算" : "无下一步")}</span></div>
     </div>
+    ${
+      currentTimelineEntry
+        ? `<div class="account-replay-impact">
+            <strong>本步结算</strong>
+            ${
+              currentTimelineEntry.changes.length > 0
+                ? currentTimelineEntry.changes
+                    .map((change) => `<span class="account-reward-chip">${escapeHtml(formatBattleReplayChange(change))}</span>`)
+                    .join("")
+                : `<span class="account-meta">本步未产生可见结算。</span>`
+            }
+          </div>`
+        : ""
+    }
     <div class="account-replay-state">
       ${
         activeUnits.length > 0
@@ -446,8 +485,9 @@ export function renderBattleReplayInspector(input: {
       }
     </div>
     <div class="account-replay-step-list">
-      ${input.replay.steps
-        .map((step) => {
+      ${timeline
+        .map((entry) => {
+          const step = entry.step;
           const tone =
             step.index === playback.currentStepIndex
               ? "is-current"
@@ -456,7 +496,15 @@ export function renderBattleReplayInspector(input: {
                 : "is-upcoming";
           return `<div class="account-replay-step ${tone}">
             <span class="account-badge">${step.index}</span>
-            <strong>${escapeHtml(formatBattleReplayAction(step))}</strong>
+            <div class="account-replay-step-copy">
+              <strong>${escapeHtml(formatBattleReplayAction(step))}</strong>
+              <span class="account-meta">${escapeHtml(formatBattleReplayRound(entry))}</span>
+              ${
+                entry.changes.length > 0
+                  ? `<span class="account-meta">${escapeHtml(entry.changes.map((change) => formatBattleReplayChange(change)).join(" / "))}</span>`
+                  : ""
+              }
+            </div>
             <span>${escapeHtml(formatBattleReplaySourceLabel(step.source))}</span>
           </div>`;
         })

--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -161,6 +161,9 @@ function toBattleReplayQueryString(query?: PlayerBattleReplayQuery): string {
   if (query.limit != null) {
     searchParams.set("limit", String(query.limit));
   }
+  if (query.offset != null) {
+    searchParams.set("offset", String(query.offset));
+  }
   if (query.roomId) {
     searchParams.set("roomId", query.roomId);
   }

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -490,6 +490,7 @@ h1 {
 
 .account-replay-controls,
 .account-replay-progress,
+.account-replay-impact,
 .account-replay-state,
 .account-replay-step-list {
   display: grid;
@@ -515,6 +516,12 @@ h1 {
 .account-replay-progress div {
   display: grid;
   gap: 4px;
+}
+
+.account-replay-impact {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(74, 120, 178, 0.06);
 }
 
 .account-replay-unit {
@@ -548,6 +555,11 @@ h1 {
   grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: 10px;
+}
+
+.account-replay-step-copy {
+  display: grid;
+  gap: 4px;
 }
 
 .account-replay-step.is-current {

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -219,6 +219,7 @@ test("account history renderer shows replay inspector controls and current playb
   assert.match(html, /hero-1-stack 攻击 neutral-1-stack/);
   assert.match(html, /下一动作/);
   assert.match(html, /neutral-1-stack 防御/);
+  assert.match(html, /第 1 回合/);
   assert.match(html, /data-replay-control="play"/);
   assert.match(html, /data-replay-control="step"/);
   assert.match(html, /data-clear-replay="true"/);

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -44,6 +44,7 @@ test("player account helpers can build a local fallback profile", () => {
   assert.deepEqual(createFallbackPlayerAccountProfile("player-9", "room-beta", "本地访客"), {
     playerId: "player-9",
     displayName: "本地访客",
+    eloRating: 1000,
     globalResources: {
       gold: 0,
       wood: 0,
@@ -351,6 +352,49 @@ test("player replay loader sends shared filters and normalizes newest first", as
             },
             steps: [],
             result: "defender_victory"
+          },
+          {
+            id: "replay-older",
+            roomId: "room-alpha",
+            playerId: "player-1",
+            battleId: "battle-3",
+            battleKind: "hero",
+            playerCamp: "defender",
+            heroId: "hero-1",
+            opponentHeroId: "hero-9",
+            startedAt: "2026-03-27T11:59:00.000Z",
+            completedAt: "2026-03-27T12:00:00.000Z",
+            initialState: {
+              id: "battle-3",
+              round: 1,
+              lanes: 1,
+              activeUnitId: "unit-1",
+              turnOrder: ["unit-1"],
+              units: {
+                "unit-1": {
+                  id: "unit-1",
+                  camp: "attacker",
+                  templateId: "hero_guard_basic",
+                  lane: 0,
+                  stackName: "暮火侦骑",
+                  initiative: 4,
+                  attack: 2,
+                  defense: 2,
+                  minDamage: 1,
+                  maxDamage: 2,
+                  count: 10,
+                  currentHp: 10,
+                  maxHp: 10,
+                  hasRetaliated: false,
+                  defending: false
+                }
+              },
+              environment: [],
+              log: [],
+              rng: { seed: 9, cursor: 0 }
+            },
+            steps: [],
+            result: "defender_victory"
           }
         ]
       }),
@@ -366,6 +410,7 @@ test("player replay loader sends shared filters and normalizes newest first", as
   try {
     const replays = await loadPlayerBattleReplaySummaries("player-1", {
       limit: 1,
+      offset: 0,
       roomId: "room-alpha",
       battleKind: "hero",
       playerCamp: "defender",
@@ -375,7 +420,7 @@ test("player replay loader sends shared filters and normalizes newest first", as
     });
     assert.equal(
       requestedUrl,
-      "http://127.0.0.1:2567/api/player-accounts/player-1/battle-replays?limit=1&roomId=room-alpha&battleKind=hero&playerCamp=defender&heroId=hero-1&opponentHeroId=hero-9&result=defender_victory"
+      "http://127.0.0.1:2567/api/player-accounts/player-1/battle-replays?limit=1&offset=0&roomId=room-alpha&battleKind=hero&playerCamp=defender&heroId=hero-1&opponentHeroId=hero-9&result=defender_victory"
     );
     assert.deepEqual(replays.map((replay) => replay.id), ["replay-newer"]);
   } finally {

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -146,6 +146,7 @@ function toReplayResponseFromRequest(
   request: IncomingMessage
 ): { items: PlayerAccountSnapshot["recentBattleReplays"] } {
   const limit = parseLimit(request);
+  const offset = parseOffset(request);
   const roomId = parseOptionalQueryParam(request, "roomId");
   const battleId = parseOptionalQueryParam(request, "battleId");
   const battleKind = parseOptionalQueryParam(request, "battleKind") as
@@ -164,6 +165,7 @@ function toReplayResponseFromRequest(
   return {
     items: queryPlayerBattleReplaySummaries(account.recentBattleReplays, {
       ...(limit != null ? { limit } : {}),
+      ...(offset != null ? { offset } : {}),
       ...(roomId ? { roomId } : {}),
       ...(battleId ? { battleId } : {}),
       ...(battleKind ? { battleKind } : {}),

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -608,7 +608,7 @@ test("player account routes degrade to local-mode responses when persistence is 
   assert.equal(meProgressPayload.summary.unlockedAchievements, 0);
 });
 
-test("player account battle replay routes return normalized replay summaries with optional limit", async (t) => {
+test("player account battle replay routes return normalized replay summaries with optional limit and offset", async (t) => {
   const port = 40050 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
   store.seedAccount({
@@ -636,6 +636,13 @@ test("player account battle replay routes return normalized replay summaries wit
   const detailPayload = (await detailResponse.json()) as { items: PlayerBattleReplaySummary[] };
   assert.equal(detailResponse.status, 200);
   assert.deepEqual(detailPayload.items.map((replay) => replay.id), ["replay-newer"]);
+
+  const pagedResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays?limit=1&offset=1`
+  );
+  const pagedPayload = (await pagedResponse.json()) as { items: PlayerBattleReplaySummary[] };
+  assert.equal(pagedResponse.status, 200);
+  assert.deepEqual(pagedPayload.items.map((replay) => replay.id), ["replay-older"]);
 
   const missingResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/missing/battle-replays`);
   assert.equal(missingResponse.status, 404);

--- a/packages/shared/src/battle-replay.ts
+++ b/packages/shared/src/battle-replay.ts
@@ -1,5 +1,5 @@
-import { applyBattleAction } from "./battle";
-import type { BattleAction, BattleState } from "./models";
+import { applyBattleAction, getBattleOutcome } from "./battle";
+import type { BattleAction, BattleOutcome, BattleState, UnitStack } from "./models";
 
 export type BattleReplayResult = "attacker_victory" | "defender_victory";
 export type BattleReplaySource = "player" | "automated";
@@ -30,6 +30,7 @@ export interface PlayerBattleReplaySummary {
 
 export interface PlayerBattleReplayQuery {
   limit?: number | undefined;
+  offset?: number | undefined;
   roomId?: string | undefined;
   battleId?: string | undefined;
   battleKind?: PlayerBattleReplaySummary["battleKind"] | undefined;
@@ -60,6 +61,28 @@ export interface BattleReplayPlaybackCommand {
   repeat?: number | undefined;
 }
 
+export interface BattleReplayTimelineUnitChange {
+  unitId: string;
+  stackName: string;
+  camp: UnitStack["camp"];
+  lane: number;
+  hpChange: number;
+  countChange: number;
+  defeated: boolean;
+  defendingChanged: boolean;
+  statusAdded: string[];
+  statusRemoved: string[];
+}
+
+export interface BattleReplayTimelineEntry {
+  step: BattleReplayStep;
+  round: number;
+  resultingRound: number;
+  state: BattleState;
+  outcome: BattleOutcome["status"];
+  changes: BattleReplayTimelineUnitChange[];
+}
+
 function normalizeTimestamp(value?: string | null): string | undefined {
   if (!value) {
     return undefined;
@@ -71,6 +94,62 @@ function normalizeTimestamp(value?: string | null): string | undefined {
 
 function cloneBattleState(state: BattleState): BattleState {
   return structuredClone(state);
+}
+
+function unitHpPool(unit?: UnitStack | null): number {
+  if (!unit || unit.count <= 0 || unit.currentHp <= 0) {
+    return 0;
+  }
+
+  return (unit.count - 1) * unit.maxHp + unit.currentHp;
+}
+
+function compareTimelineUnitChanges(beforeState: BattleState, afterState: BattleState): BattleReplayTimelineUnitChange[] {
+  const unitIds = Array.from(new Set([...Object.keys(beforeState.units), ...Object.keys(afterState.units)]));
+
+  return unitIds
+    .map((unitId) => {
+      const beforeUnit = beforeState.units[unitId];
+      const afterUnit = afterState.units[unitId];
+      const reference = afterUnit ?? beforeUnit;
+      if (!reference) {
+        return null;
+      }
+
+      const hpChange = unitHpPool(afterUnit) - unitHpPool(beforeUnit);
+      const countChange = (afterUnit?.count ?? 0) - (beforeUnit?.count ?? 0);
+      const beforeStatuses = new Set((beforeUnit?.statusEffects ?? []).map((status) => status.name));
+      const afterStatuses = new Set((afterUnit?.statusEffects ?? []).map((status) => status.name));
+      const statusAdded = Array.from(afterStatuses).filter((status) => !beforeStatuses.has(status));
+      const statusRemoved = Array.from(beforeStatuses).filter((status) => !afterStatuses.has(status));
+      const defendingChanged = (beforeUnit?.defending ?? false) !== (afterUnit?.defending ?? false);
+
+      if (hpChange === 0 && countChange === 0 && statusAdded.length === 0 && statusRemoved.length === 0 && !defendingChanged) {
+        return null;
+      }
+
+      return {
+        unitId,
+        stackName: reference.stackName,
+        camp: reference.camp,
+        lane: reference.lane,
+        hpChange,
+        countChange,
+        defeated: (beforeUnit?.count ?? 0) > 0 && (afterUnit?.count ?? 0) <= 0,
+        defendingChanged,
+        statusAdded,
+        statusRemoved
+      };
+    })
+    .filter((entry): entry is BattleReplayTimelineUnitChange => Boolean(entry))
+    .sort(
+      (left, right) =>
+        Math.abs(right.hpChange) - Math.abs(left.hpChange) ||
+        Math.abs(right.countChange) - Math.abs(left.countChange) ||
+        left.camp.localeCompare(right.camp) ||
+        left.lane - right.lane ||
+        left.unitId.localeCompare(right.unitId)
+    );
 }
 
 function resolvePlaybackStatus(
@@ -206,6 +285,26 @@ export function applyBattleReplayPlaybackCommand(
   }
 }
 
+export function buildBattleReplayTimeline(replay: PlayerBattleReplaySummary): BattleReplayTimelineEntry[] {
+  const timeline: BattleReplayTimelineEntry[] = [];
+  let currentState = cloneBattleState(replay.initialState);
+
+  for (const step of replay.steps) {
+    const nextState = applyBattleAction(currentState, step.action);
+    timeline.push({
+      step,
+      round: currentState.round,
+      resultingRound: nextState.round,
+      state: cloneBattleState(nextState),
+      outcome: getBattleOutcome(nextState).status,
+      changes: compareTimelineUnitChanges(currentState, nextState)
+    });
+    currentState = nextState;
+  }
+
+  return timeline;
+}
+
 function normalizeBattleReplayStep(step: Partial<BattleReplayStep> | null | undefined, fallbackIndex: number): BattleReplayStep | null {
   const action = step?.action;
   const type = action?.type;
@@ -303,6 +402,7 @@ export function queryPlayerBattleReplaySummaries(
   query: PlayerBattleReplayQuery = {}
 ): PlayerBattleReplaySummary[] {
   const safeLimit = query.limit == null ? undefined : Math.max(1, Math.floor(query.limit));
+  const safeOffset = Math.max(0, Math.floor(query.offset ?? 0));
   const roomId = query.roomId?.trim();
   const battleId = query.battleId?.trim();
   const heroId = query.heroId?.trim();
@@ -318,6 +418,7 @@ export function queryPlayerBattleReplaySummaries(
     .filter((replay) => (opponentHeroId ? replay.opponentHeroId === opponentHeroId : true))
     .filter((replay) => (neutralArmyId ? replay.neutralArmyId === neutralArmyId : true))
     .filter((replay) => (query.result ? replay.result === query.result : true))
+    .slice(safeOffset)
     .slice(0, safeLimit);
 }
 

--- a/packages/shared/test/battle-replay-playback-command.test.ts
+++ b/packages/shared/test/battle-replay-playback-command.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   applyBattleReplayPlaybackCommand,
+  buildBattleReplayTimeline,
   createEmptyBattleState,
+  queryPlayerBattleReplaySummaries,
   restoreBattleReplayPlaybackState,
   type PlayerBattleReplaySummary
 } from "../src/index";
@@ -105,4 +107,81 @@ test("applyBattleReplayPlaybackCommand supports play, pause, and reset from a re
   assert.equal(reset.currentStepIndex, 0);
   assert.equal(reset.currentStep, null);
   assert.equal(reset.nextStep?.index, 1);
+});
+
+test("battle replay timeline derives round-aware state deltas", () => {
+  const replay = createReplay();
+  replay.initialState.units = {
+    "stack-1": {
+      id: "stack-1",
+      templateId: "hero-guard-basic",
+      camp: "attacker",
+      lane: 0,
+      stackName: "前锋卫队",
+      initiative: 12,
+      attack: 5,
+      defense: 4,
+      minDamage: 1,
+      maxDamage: 2,
+      count: 3,
+      currentHp: 10,
+      maxHp: 10,
+      hasRetaliated: false,
+      defending: false
+    },
+    "stack-2": {
+      id: "stack-2",
+      templateId: "wolf-pack",
+      camp: "defender",
+      lane: 1,
+      stackName: "狼群",
+      initiative: 8,
+      attack: 4,
+      defense: 4,
+      minDamage: 1,
+      maxDamage: 2,
+      count: 2,
+      currentHp: 10,
+      maxHp: 10,
+      hasRetaliated: false,
+      defending: false
+    }
+  };
+  replay.initialState.round = 1;
+  replay.initialState.turnOrder = ["stack-1", "stack-2"];
+  replay.initialState.activeUnitId = "stack-1";
+  replay.steps = [
+    {
+      index: 1,
+      source: "player",
+      action: {
+        type: "battle.defend",
+        unitId: "stack-1"
+      }
+    }
+  ];
+
+  const timeline = buildBattleReplayTimeline(replay);
+
+  assert.equal(timeline.length, 1);
+  assert.equal(timeline[0]?.round, 1);
+  assert.match(timeline[0]?.state.log.join(" ") ?? "", /stack-1/);
+  assert.equal(timeline[0]?.outcome, "in_progress");
+});
+
+test("queryPlayerBattleReplaySummaries supports offset pagination", () => {
+  const older = createReplay();
+  older.id = "replay-older";
+  older.completedAt = "2026-03-27T10:00:00.000Z";
+
+  const newer = createReplay();
+  newer.id = "replay-newer";
+  newer.completedAt = "2026-03-27T10:05:00.000Z";
+
+  const paged = queryPlayerBattleReplaySummaries([older, newer], {
+    limit: 1,
+    offset: 1
+  });
+
+  assert.deepEqual(paged.map((replay) => replay.id), ["replay-older"]);
 });


### PR DESCRIPTION
## Summary
- add replay list offset pagination to the shared helper, H5 loader, and player-account routes
- derive a shared battle replay timeline read model from `initialState + steps` so clients can inspect round-by-round settlement data
- upgrade the H5 battle replay inspector to show round labels and per-step settlement chips, with focused tests and README notes

## Testing
- `node --import tsx --test ./packages/shared/test/battle-replay-playback-command.test.ts`
- `node --import tsx --test ./apps/server/test/player-account-routes.test.ts ./apps/client/test/player-account-storage.test.ts ./apps/client/test/account-history-render.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:client:h5`

## Remaining Scope
- room-level/public battle-instance replay APIs and spectate entrypoints are still out of scope for this slice
- Cocos-side replay detail UI is still not implemented here

refs #125