### PR TITLE
Add password recovery backend slice for issue #124

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
 - 账号体系现已从“纯游客模式”升级为“双模式骨架”：`player_accounts` 新增 `loginId / passwordHash / credentialBoundAt`，服务端开放 `POST /api/auth/account-bind` 与 `POST /api/auth/account-login`，可把当前游客档绑定成口令账号，并在之后直接用登录 ID + 口令进入房间。
 - 鉴权入口现已补上进程内安全闸门：`POST /api/auth/guest-login`、`/account-login`、`/account-bind` 都会按来源 IP 走滑动窗口限流，`account-login` 还会在连续失败达到阈值后临时锁定账号；默认值分别来自 `VEIL_RATE_LIMIT_AUTH_WINDOW_MS=60000`、`VEIL_RATE_LIMIT_AUTH_MAX=10`、`VEIL_AUTH_LOCKOUT_THRESHOLD=10`、`VEIL_AUTH_LOCKOUT_DURATION_MINUTES=15`，游客会话缓存还会受 `VEIL_MAX_GUEST_SESSIONS=10000` 的 LRU 上限约束。
 - 正式账号会话现在补上了过期与撤销链路：访问令牌默认 1 小时（`VEIL_AUTH_ACCESS_TTL_SECONDS`），刷新令牌默认 30 天（`VEIL_AUTH_REFRESH_TTL_SECONDS`），游客 token 默认 7 天（`VEIL_AUTH_GUEST_TTL_SECONDS`）；服务端新增 `POST /api/auth/refresh` 与 `POST /api/auth/logout`，并把当前刷新令牌族持久化到 `player_accounts` 上，账号口令修改也会同步撤销现有会话。
+- 服务端现已补上开发态密码找回闭环：`POST /api/auth/password-recovery/request` 会为已绑定口令账号生成短时效重置令牌，`POST /api/auth/password-recovery/confirm` 可用该令牌重置口令并撤销旧会话；默认通过 `VEIL_PASSWORD_RECOVERY_DELIVERY_MODE=dev-token` 直接回传开发态令牌，TTL 由 `VEIL_PASSWORD_RECOVERY_TTL_MINUTES` 控制，且找回申请/确认都会写入账号 `recentEventLog` 的 `account` 审计事件。详细说明见 `docs/account-auth-lifecycle.md`。
 - H5 Lobby 现已补上“账号口令登录”表单；游戏内账号资料卡也能直接绑定或更新口令账号，绑定成功后会立即把当前会话升级成账号模式，不需要重新手写 `playerId`，并会继续沿用同一份英雄长期档与全局资源仓库。
 - H5 Lobby 和游戏内都已补上“退出游客会话 / 切换游客账号”入口；当前 token 无效时会自动清掉本地会话并回到大厅。
 - Cocos Web 启动入口现在会复用和 H5 共用的 `project-veil:auth-session`：如果浏览器里已有已签名会话，那么直接访问 `?roomId=...` 就能沿用当前游客或正式账号身份进房，HUD 会标出当前是云端游客、正式账号还是本地/手动参数启动。

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomBytes, randomUUID, scryptSync, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { appendEventLogEntries, type EventLogEntry } from "../../../packages/shared/src/index";
 import type { RoomSnapshotStore } from "./persistence";
 
 export type AuthMode = "guest" | "account";
@@ -88,6 +89,16 @@ interface AccountAuthSessionState {
   refreshTokenExpiresAt?: string;
 }
 
+interface PasswordRecoveryState {
+  playerId: string;
+  loginId: string;
+  tokenHash: string;
+  issuedAt: string;
+  expiresAt: string;
+}
+
+type PasswordRecoveryDeliveryMode = "disabled" | "dev-token";
+
 const AUTH_SECRET = process.env.VEIL_AUTH_SECRET?.trim() || "project-veil-dev-secret";
 const MIN_ACCOUNT_PASSWORD_LENGTH = 6;
 const DEFAULT_RATE_LIMIT_AUTH_WINDOW_MS = 60_000;
@@ -98,11 +109,13 @@ const DEFAULT_MAX_GUEST_SESSIONS = 10_000;
 const DEFAULT_AUTH_ACCESS_TTL_SECONDS = 60 * 60;
 const DEFAULT_AUTH_REFRESH_TTL_SECONDS = 30 * 24 * 60 * 60;
 const DEFAULT_GUEST_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
+const DEFAULT_PASSWORD_RECOVERY_TTL_MINUTES = 15;
 
 const authRateLimitCounters = new Map<string, number[]>();
 const accountLockoutStateByLoginId = new Map<string, AccountLockoutState>();
 const guestSessionsById = new Map<string, GuestAuthSession>();
 const accountAuthStateByPlayerId = new Map<string, AccountAuthSessionState>();
+const passwordRecoveryStateByLoginId = new Map<string, PasswordRecoveryState>();
 
 function parseEnvNumber(
   value: string | undefined,
@@ -174,6 +187,10 @@ function isExpiredTimestamp(value: string): boolean {
 
 function hashRefreshToken(token: string): string {
   return createHmac("sha256", AUTH_SECRET).update(`refresh:${token}`).digest("hex");
+}
+
+function hashPasswordRecoveryToken(token: string): string {
+  return createHmac("sha256", AUTH_SECRET).update(`password-recovery:${token}`).digest("hex");
 }
 
 function cacheAccountAuthState(input: {
@@ -313,6 +330,102 @@ function normalizeAccountPassword(password?: string | null): string {
   }
 
   return normalized;
+}
+
+function normalizePasswordRecoveryToken(token?: string | null): string {
+  const normalized = token?.trim();
+  if (!normalized) {
+    throw new Error("recoveryToken must not be empty");
+  }
+
+  return normalized;
+}
+
+function readPasswordRecoveryDeliveryMode(env: NodeJS.ProcessEnv = process.env): PasswordRecoveryDeliveryMode {
+  const normalized = env.VEIL_PASSWORD_RECOVERY_DELIVERY_MODE?.trim().toLowerCase();
+  return normalized === "disabled" ? "disabled" : "dev-token";
+}
+
+function readPasswordRecoveryTtlMs(env: NodeJS.ProcessEnv = process.env): number {
+  return (
+    parseEnvNumber(env.VEIL_PASSWORD_RECOVERY_TTL_MINUTES, DEFAULT_PASSWORD_RECOVERY_TTL_MINUTES, {
+      minimum: 1 / 60_000
+    }) * 60_000
+  );
+}
+
+function createAccountAuditLogEntry(
+  playerId: string,
+  description: string,
+  timestamp = new Date().toISOString()
+): EventLogEntry {
+  return {
+    id: `${playerId}:${timestamp}:account:${randomUUID().slice(0, 8)}`,
+    timestamp,
+    roomId: "auth",
+    playerId,
+    category: "account",
+    description,
+    rewards: []
+  };
+}
+
+async function appendAccountAuditLog(
+  store: RoomSnapshotStore,
+  playerId: string,
+  description: string,
+  timestamp = new Date().toISOString()
+): Promise<void> {
+  const account = await store.ensurePlayerAccount({ playerId });
+  await store.savePlayerAccountProgress(playerId, {
+    recentEventLog: appendEventLogEntries(account.recentEventLog, [createAccountAuditLogEntry(playerId, description, timestamp)])
+  });
+}
+
+function createPasswordRecoveryToken(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+function getPasswordRecoveryState(loginId: string): PasswordRecoveryState | null {
+  const existing = passwordRecoveryStateByLoginId.get(loginId);
+  if (!existing) {
+    return null;
+  }
+
+  if (isExpiredTimestamp(existing.expiresAt)) {
+    passwordRecoveryStateByLoginId.delete(loginId);
+    return null;
+  }
+
+  return existing;
+}
+
+function storePasswordRecoveryState(playerId: string, loginId: string, token: string): PasswordRecoveryState {
+  const issuedAt = new Date().toISOString();
+  const expiresAt = new Date(nowMs() + readPasswordRecoveryTtlMs()).toISOString();
+  const state: PasswordRecoveryState = {
+    playerId,
+    loginId,
+    tokenHash: hashPasswordRecoveryToken(token),
+    issuedAt,
+    expiresAt
+  };
+  passwordRecoveryStateByLoginId.set(loginId, state);
+  return state;
+}
+
+function consumePasswordRecoveryState(loginId: string, token: string): PasswordRecoveryState | null {
+  const state = getPasswordRecoveryState(loginId);
+  if (!state) {
+    return null;
+  }
+
+  if (state.tokenHash !== hashPasswordRecoveryToken(token)) {
+    return null;
+  }
+
+  passwordRecoveryStateByLoginId.delete(loginId);
+  return state;
 }
 
 function normalizeWechatMiniGameCode(code?: string | null): string {
@@ -534,8 +647,8 @@ export function issueWechatMiniGameAuthSession(input: {
       displayName: input.displayName,
       loginId,
       provider: "wechat-mini-game",
-      sessionId: input.sessionId,
-      sessionVersion: input.sessionVersion
+      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+      ...(input.sessionVersion !== undefined ? { sessionVersion: input.sessionVersion } : {})
     });
   }
 
@@ -561,21 +674,24 @@ export function issueNextAuthSession(
 ): GuestAuthSession {
   const loginId = normalizeLoginId(input.loginId);
   if (currentSession?.authMode === "account" && loginId) {
+    const nextSessionId = input.sessionId ?? currentSession.sessionId;
+    const nextSessionVersion = input.sessionVersion ?? currentSession.sessionVersion;
     return issueAccountAccessSession({
       playerId: input.playerId,
       displayName: input.displayName,
       loginId,
-      provider: currentSession.provider,
-      sessionId: input.sessionId ?? currentSession.sessionId,
-      sessionVersion: input.sessionVersion ?? currentSession.sessionVersion
+      ...(currentSession.provider ? { provider: currentSession.provider } : {}),
+      ...(nextSessionId !== undefined ? { sessionId: nextSessionId } : {}),
+      ...(nextSessionVersion !== undefined ? { sessionVersion: nextSessionVersion } : {})
     });
   }
 
+  const nextGuestSessionId = input.sessionId ?? currentSession?.sessionId;
   return issueGuestAccessSession({
     playerId: input.playerId,
     displayName: input.displayName,
     provider: currentSession?.provider ?? "guest",
-    sessionId: input.sessionId ?? currentSession?.sessionId
+    ...(nextGuestSessionId !== undefined ? { sessionId: nextGuestSessionId } : {})
   });
 }
 
@@ -784,7 +900,7 @@ async function validateAuthToken(
       return {
         session: {
           ...session,
-          refreshExpiresAt: authAccount.refreshTokenExpiresAt
+          ...(authAccount.refreshTokenExpiresAt ? { refreshExpiresAt: authAccount.refreshTokenExpiresAt } : {})
         }
       };
     }
@@ -829,7 +945,7 @@ async function createAccountSessionBundle(
     playerId: input.playerId,
     displayName: input.displayName,
     loginId: input.loginId,
-    provider: input.provider,
+    ...(input.provider ? { provider: input.provider } : {}),
     sessionId: refreshSessionId,
     sessionVersion: nextSessionVersion
   });
@@ -854,7 +970,7 @@ async function createAccountSessionBundle(
     playerId: input.playerId,
     displayName: input.displayName,
     loginId: input.loginId,
-    provider: input.provider,
+    ...(input.provider ? { provider: input.provider } : {}),
     sessionId: refreshSessionId,
     sessionVersion: finalizedAuth.accountSessionVersion
   });
@@ -1049,6 +1165,7 @@ export function resetGuestAuthSessions(): void {
   accountLockoutStateByLoginId.clear();
   guestSessionsById.clear();
   accountAuthStateByPlayerId.clear();
+  passwordRecoveryStateByLoginId.clear();
 }
 
 export function registerAuthRoutes(
@@ -1459,6 +1576,170 @@ export function registerAuthRoutes(
           displayName: account.displayName,
           loginId
         })
+      });
+    } catch (error) {
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/auth/password-recovery/request", async (request, response) => {
+    if (!store) {
+      sendStoreUnavailable(response);
+      return;
+    }
+
+    if (!enforceAuthRateLimit(request, response, "password-recovery-request")) {
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        loginId?: string | null;
+      };
+
+      if (body.loginId !== undefined && body.loginId !== null && typeof body.loginId !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: loginId"
+          }
+        });
+        return;
+      }
+
+      const loginId = normalizeAccountLoginId(body.loginId);
+      const deliveryMode = readPasswordRecoveryDeliveryMode();
+      const authAccount = await store.loadPlayerAccountAuthByLoginId(loginId);
+      if (!authAccount) {
+        sendJson(response, 202, {
+          status: "recovery_requested"
+        });
+        return;
+      }
+
+      const recoveryToken = createPasswordRecoveryToken();
+      const recoveryState = storePasswordRecoveryState(authAccount.playerId, loginId, recoveryToken);
+      await appendAccountAuditLog(
+        store,
+        authAccount.playerId,
+        deliveryMode === "dev-token" ? "发起密码找回申请，已生成开发态重置令牌。" : "发起密码找回申请。"
+      );
+
+      sendJson(response, 202, {
+        status: "recovery_requested",
+        expiresAt: recoveryState.expiresAt,
+        ...(deliveryMode === "dev-token" ? { recoveryToken } : {})
+      });
+    } catch (error) {
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/auth/password-recovery/confirm", async (request, response) => {
+    if (!store) {
+      sendStoreUnavailable(response);
+      return;
+    }
+
+    if (!enforceAuthRateLimit(request, response, "password-recovery-confirm")) {
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        loginId?: string | null;
+        recoveryToken?: string | null;
+        newPassword?: string | null;
+      };
+
+      if (body.loginId !== undefined && body.loginId !== null && typeof body.loginId !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: loginId"
+          }
+        });
+        return;
+      }
+
+      if (body.recoveryToken !== undefined && body.recoveryToken !== null && typeof body.recoveryToken !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: recoveryToken"
+          }
+        });
+        return;
+      }
+
+      if (body.newPassword !== undefined && body.newPassword !== null && typeof body.newPassword !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: newPassword"
+          }
+        });
+        return;
+      }
+
+      const loginId = normalizeAccountLoginId(body.loginId);
+      const recoveryToken = normalizePasswordRecoveryToken(body.recoveryToken);
+      const newPassword = normalizeAccountPassword(body.newPassword);
+      const pendingRecoveryState = getPasswordRecoveryState(loginId);
+      if (!pendingRecoveryState) {
+        sendJson(response, 401, {
+          error: {
+            code: "invalid_recovery_token",
+            message: "Password recovery token is invalid or expired"
+          }
+        });
+        return;
+      }
+
+      const recoveryState = consumePasswordRecoveryState(loginId, recoveryToken);
+      if (!recoveryState) {
+        sendJson(response, 401, {
+          error: {
+            code: "invalid_recovery_token",
+            message: "Password recovery token is invalid or expired"
+          }
+        });
+        return;
+      }
+
+      const authAccount = await store.loadPlayerAccountAuthByLoginId(loginId);
+      if (!authAccount || authAccount.playerId !== recoveryState.playerId) {
+        sendJson(response, 401, {
+          error: {
+            code: "invalid_recovery_token",
+            message: "Password recovery token is invalid or expired"
+          }
+        });
+        return;
+      }
+
+      const credentialBoundAt = new Date().toISOString();
+      const revokedAuth = await store.revokePlayerAccountAuthSessions(authAccount.playerId, {
+        passwordHash: hashAccountPassword(newPassword),
+        credentialBoundAt
+      });
+      if (revokedAuth) {
+        cacheAccountAuthState({
+          playerId: revokedAuth.playerId,
+          accountSessionVersion: revokedAuth.accountSessionVersion
+        });
+      }
+      clearAccountLoginFailures(loginId);
+      await appendAccountAuditLog(store, authAccount.playerId, "通过密码找回流程重置口令，并撤销旧会话。", credentialBoundAt);
+      const account =
+        (await store.loadPlayerAccount(authAccount.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authAccount.playerId,
+          displayName: authAccount.displayName
+        }));
+
+      sendJson(response, 200, {
+        account
       });
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -973,6 +973,221 @@ test("guest auth session LRU eviction invalidates the oldest idle guest token", 
   assert.equal(activePayload.session.playerId, "guest-lru-3");
 });
 
+test("password recovery request and confirm reset the password, revoke old sessions, and append account audit events", {
+  concurrency: false
+}, async (t) => {
+  const port = 44725 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  await store.ensurePlayerAccount({
+    playerId: "recovery-player",
+    displayName: "回响旅人"
+  });
+  await store.bindPlayerAccountCredentials("recovery-player", {
+    loginId: "recovery-ranger",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const loginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "recovery-ranger",
+      password: "hunter2"
+    })
+  });
+  const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
+  assert.equal(loginResponse.status, 200);
+
+  const requestResponse = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "recovery-ranger"
+    })
+  });
+  const requestPayload = (await requestResponse.json()) as {
+    status: string;
+    expiresAt?: string;
+    recoveryToken?: string;
+  };
+
+  assert.equal(requestResponse.status, 202);
+  assert.equal(requestPayload.status, "recovery_requested");
+  assert.equal(typeof requestPayload.recoveryToken, "string");
+  assert.ok(requestPayload.expiresAt);
+
+  const confirmResponse = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "recovery-ranger",
+      recoveryToken: requestPayload.recoveryToken,
+      newPassword: "hunter3"
+    })
+  });
+  const confirmPayload = (await confirmResponse.json()) as { account: PlayerAccountSnapshot };
+
+  assert.equal(confirmResponse.status, 200);
+  assert.equal(confirmPayload.account.playerId, "recovery-player");
+
+  const revokedResponse = await fetch(`http://127.0.0.1:${port}/api/auth/session`, {
+    headers: {
+      Authorization: `Bearer ${loginPayload.session.token}`
+    }
+  });
+  const revokedPayload = (await revokedResponse.json()) as { error: { code: string } };
+  assert.equal(revokedResponse.status, 401);
+  assert.equal(revokedPayload.error.code, "session_revoked");
+
+  const stalePasswordResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "recovery-ranger",
+      password: "hunter2"
+    })
+  });
+  assert.equal(stalePasswordResponse.status, 401);
+
+  const freshPasswordResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "recovery-ranger",
+      password: "hunter3"
+    })
+  });
+  assert.equal(freshPasswordResponse.status, 200);
+
+  const account = await store.loadPlayerAccount("recovery-player");
+  assert.equal(account?.recentEventLog[0]?.category, "account");
+  assert.match(account?.recentEventLog[0]?.description ?? "", /重置口令/);
+  assert.equal(account?.recentEventLog[1]?.category, "account");
+  assert.match(account?.recentEventLog[1]?.description ?? "", /发起密码找回申请/);
+});
+
+test("password recovery confirm rejects invalid tokens", { concurrency: false }, async (t) => {
+  const port = 44735 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  await store.ensurePlayerAccount({
+    playerId: "recovery-invalid-player",
+    displayName: "失效旅人"
+  });
+  await store.bindPlayerAccountCredentials("recovery-invalid-player", {
+    loginId: "invalid-ranger",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const requestResponse = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "invalid-ranger"
+    })
+  });
+  assert.equal(requestResponse.status, 202);
+
+  const confirmResponse = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "invalid-ranger",
+      recoveryToken: "wrong-token",
+      newPassword: "hunter3"
+    })
+  });
+  const confirmPayload = (await confirmResponse.json()) as { error: { code: string } };
+
+  assert.equal(confirmResponse.status, 401);
+  assert.equal(confirmPayload.error.code, "invalid_recovery_token");
+});
+
+test("password recovery request returns 429 after the per-IP rate limit is exceeded", { concurrency: false }, async (t) => {
+  const cleanup: Array<() => void> = [];
+  withEnvOverrides(
+    {
+      VEIL_RATE_LIMIT_AUTH_WINDOW_MS: "60000",
+      VEIL_RATE_LIMIT_AUTH_MAX: "2"
+    },
+    cleanup
+  );
+
+  const port = 44745 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  await store.ensurePlayerAccount({
+    playerId: "recovery-rate-limit-player",
+    displayName: "限流旅人"
+  });
+  await store.bindPlayerAccountCredentials("recovery-rate-limit-player", {
+    loginId: "limit-ranger",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+
+  t.after(async () => {
+    cleanup.reverse().forEach((fn) => fn());
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  for (let index = 0; index < 2; index += 1) {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/request`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        loginId: "limit-ranger"
+      })
+    });
+    assert.equal(response.status, 202);
+  }
+
+  const limitedResponse = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "limit-ranger"
+    })
+  });
+  const limitedPayload = (await limitedResponse.json()) as { error: { code: string } };
+
+  assert.equal(limitedResponse.status, 429);
+  assert.equal(limitedPayload.error.code, "rate_limited");
+  assert.equal(limitedResponse.headers.get("Retry-After"), "60");
+});
+
 test("wechat mini game scaffold route returns 501 until mock mode is enabled", { concurrency: false }, async (t) => {
   const port = 44750 + Math.floor(Math.random() * 1000);
   const server = await startAuthServer(port);

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -1,0 +1,91 @@
+# 账号鉴权与密码找回
+
+本文档描述当前仓库已经落地的正式账号能力，以及 `#124` 本轮新增的密码找回后端闭环。
+
+## 当前已落地能力
+
+- 游客登录：`POST /api/auth/guest-login`
+- 游客档升级成口令账号：`POST /api/auth/account-bind`
+- 口令账号登录：`POST /api/auth/account-login`
+- 会话校验 / 刷新 / 退出：`GET /api/auth/session`、`POST /api/auth/refresh`、`POST /api/auth/logout`
+- 已登录账号修改口令：`PUT /api/player-accounts/me`
+
+当前账号模式仍沿用“先游客、再绑定”的模型：
+
+1. 玩家可先以游客身份进入房间并形成 `player_accounts` 档案。
+2. 需要长期登录时，再把当前游客档绑定到 `loginId + password`。
+3. 后续账号登录会继续复用同一份英雄长期档、全局资源仓库和账号事件历史。
+
+## 密码找回闭环
+
+### 1. 发起找回
+
+接口：`POST /api/auth/password-recovery/request`
+
+请求体：
+
+```json
+{
+  "loginId": "veil-ranger"
+}
+```
+
+行为：
+
+- 仅对已绑定口令账号生效；不存在的 `loginId` 仍返回 `202`，避免泄漏账号存在性。
+- 服务端生成一次性短时效重置令牌，并按来源 IP 走现有滑动窗口限流。
+- 当前默认开发态投递模式为 `VEIL_PASSWORD_RECOVERY_DELIVERY_MODE=dev-token`，会直接在响应体里回传 `recoveryToken` 供联调使用。
+- 若后续切到 `disabled`，接口仍保留，但不会直接把令牌回传给客户端。
+- 成功发起时会向该账号的 `recentEventLog` 追加一条 `category=account` 的审计事件。
+
+成功响应示例：
+
+```json
+{
+  "status": "recovery_requested",
+  "expiresAt": "2026-03-28T12:34:56.000Z",
+  "recoveryToken": "dev-token-example"
+}
+```
+
+### 2. 确认重置
+
+接口：`POST /api/auth/password-recovery/confirm`
+
+请求体：
+
+```json
+{
+  "loginId": "veil-ranger",
+  "recoveryToken": "dev-token-example",
+  "newPassword": "hunter3"
+}
+```
+
+行为：
+
+- 校验 `loginId`、重置令牌和新口令长度。
+- 令牌错误或过期时返回 `401 invalid_recovery_token`。
+- 成功后会更新口令哈希、提升 `accountSessionVersion`、撤销旧刷新令牌族，并使旧访问令牌失效。
+- 完成后同样会追加一条 `category=account` 的审计事件，便于通过 `/api/player-accounts/:playerId/event-log` 或 `/me/event-log` 查询。
+
+## 运行时参数
+
+- `VEIL_PASSWORD_RECOVERY_DELIVERY_MODE`
+  - `dev-token`：默认值，直接在响应里返回开发态重置令牌
+  - `disabled`：不向客户端直出令牌，保留接口占位
+- `VEIL_PASSWORD_RECOVERY_TTL_MINUTES`
+  - 默认 `15`
+- `VEIL_RATE_LIMIT_AUTH_WINDOW_MS`
+  - 默认 `60000`
+- `VEIL_RATE_LIMIT_AUTH_MAX`
+  - 默认 `10`
+
+## 本轮未覆盖的 #124 范围
+
+本次只落了后端密码找回 vertical slice，仍未完成：
+
+- 正式注册入口和独立注册接口
+- H5 Lobby / Cocos Lobby 的注册或找回 UI 入口
+- 游客绑定账号与“全新正式注册账号”之间的迁移规则文档
+- 真实邮件 / 短信 / 验证码通道

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -1,7 +1,7 @@
 import { formatEquipmentRarityLabel } from "./equipment";
 import type { FogState, ResourceKind, WorldEvent, WorldState } from "./models";
 
-export type EventLogCategory = "movement" | "combat" | "building" | "skill" | "achievement";
+export type EventLogCategory = "movement" | "combat" | "building" | "skill" | "achievement" | "account";
 export type EventLogRewardType = "resource" | "experience" | "skill_point" | "badge";
 export type AchievementId = "first_battle" | "enemy_slayer" | "skill_scholar" | "world_explorer" | "epic_collector";
 export type AchievementMetric =


### PR DESCRIPTION
## Summary
- add backend password recovery request/confirm endpoints with short-lived dev-mode reset tokens
- revoke existing account sessions after recovery and append account audit events into recent event history
- add focused auth tests for recovery success, invalid token, and rate limiting, plus docs for the current account lifecycle

## Testing
- npm run typecheck:server
- npm run typecheck:shared
- node --import tsx --test ./apps/server/test/auth-guest-login.test.ts
- node --import tsx --test ./packages/shared/test/event-log-foundation.test.ts ./packages/shared/test/event-log-labels.test.ts

## Remaining scope
- formal registration endpoint and client entry are still outstanding
- guest-to-formal migration rules still need explicit product and API treatment
- real mail/code delivery is not implemented; this slice uses a dev-token placeholder flow

refs #124