### PR TITLE
Add formal account registration auth slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
 - 账号体系现已从“纯游客模式”升级为“双模式骨架”：`player_accounts` 新增 `loginId / passwordHash / credentialBoundAt`，服务端开放 `POST /api/auth/account-bind` 与 `POST /api/auth/account-login`，可把当前游客档绑定成口令账号，并在之后直接用登录 ID + 口令进入房间。
 - 鉴权入口现已补上进程内安全闸门：`POST /api/auth/guest-login`、`/account-login`、`/account-bind` 都会按来源 IP 走滑动窗口限流，`account-login` 还会在连续失败达到阈值后临时锁定账号；默认值分别来自 `VEIL_RATE_LIMIT_AUTH_WINDOW_MS=60000`、`VEIL_RATE_LIMIT_AUTH_MAX=10`、`VEIL_AUTH_LOCKOUT_THRESHOLD=10`、`VEIL_AUTH_LOCKOUT_DURATION_MINUTES=15`，游客会话缓存还会受 `VEIL_MAX_GUEST_SESSIONS=10000` 的 LRU 上限约束。
 - 正式账号会话现在补上了过期与撤销链路：访问令牌默认 1 小时（`VEIL_AUTH_ACCESS_TTL_SECONDS`），刷新令牌默认 30 天（`VEIL_AUTH_REFRESH_TTL_SECONDS`），游客 token 默认 7 天（`VEIL_AUTH_GUEST_TTL_SECONDS`）；服务端新增 `POST /api/auth/refresh` 与 `POST /api/auth/logout`，并把当前刷新令牌族持久化到 `player_accounts` 上，账号口令修改也会同步撤销现有会话。
+- 服务端现已补上开发态正式注册后端闭环：`POST /api/auth/account-registration/request` 可为全新正式账号预留 `loginId` 并生成短时效注册令牌，`POST /api/auth/account-registration/confirm` 会创建新的 `player_accounts` 档案、绑定口令并立即签发首个账号会话；默认通过 `VEIL_ACCOUNT_REGISTRATION_DELIVERY_MODE=dev-token` 直接回传开发态令牌，TTL 由 `VEIL_ACCOUNT_REGISTRATION_TTL_MINUTES` 控制，确认成功后会向账号 `recentEventLog` 追加注册申请/完成两条 `account` 审计事件。
 - 服务端现已补上开发态密码找回闭环：`POST /api/auth/password-recovery/request` 会为已绑定口令账号生成短时效重置令牌，`POST /api/auth/password-recovery/confirm` 可用该令牌重置口令并撤销旧会话；默认通过 `VEIL_PASSWORD_RECOVERY_DELIVERY_MODE=dev-token` 直接回传开发态令牌，TTL 由 `VEIL_PASSWORD_RECOVERY_TTL_MINUTES` 控制，且找回申请/确认都会写入账号 `recentEventLog` 的 `account` 审计事件。详细说明见 `docs/account-auth-lifecycle.md`。
 - H5 Lobby 现已补上“账号口令登录”表单；游戏内账号资料卡也能直接绑定或更新口令账号，绑定成功后会立即把当前会话升级成账号模式，不需要重新手写 `playerId`，并会继续沿用同一份英雄长期档与全局资源仓库。
 - H5 Lobby 和游戏内都已补上“退出游客会话 / 切换游客账号”入口；当前 token 无效时会自动清掉本地会话并回到大厅。
@@ -166,7 +167,7 @@
 - Cocos Web 现在也有真正的 Lobby 面板：没有 `roomId` 查询参数时会先进入大厅，可刷新 `/api/lobby/rooms` 活跃实例、点击字段卡片修改 `playerId / 昵称 / roomId / 登录 ID`、直接游客进入，或走“账号登录并进入”直连正式账号；Lobby 还会通过 `/api/player-accounts/me` / `GET /api/player-accounts/:playerId` 同步当前账号资料与全局仓库摘要。
 - Cocos Lobby 现在也提供“打开配置台”入口，会按当前联机目标自动跳到共享的 `config-center.html`，把配置联调从 H5 侧迁成主客户端可达链路。
 - 服务端新增 `GET /api/lobby/rooms`，会实时返回当前进程内活跃房间的 `roomId / day / seed / connectedPlayers / heroCount / activeBattles / updatedAt` 摘要，便于大厅入口和后续房间浏览器直接复用。
-- 这套账号目前仍是“轻量正式化”阶段：虽然已经有口令绑定、刷新令牌轮换和单账号会话撤销，但还没有正式注册流程、真正的多端并行会话管理或更完整的第三方身份接入。
+- 这套账号目前仍是“轻量正式化”阶段：虽然已经有独立正式注册、口令绑定、刷新令牌轮换和单账号会话撤销，但还没有注册 / 找回前端入口、真正的多端并行会话管理或更完整的第三方身份接入。
 - H5 会优先连接 `ws://127.0.0.1:2567` 的本地会话服务；若服务未启动，则自动回退到浏览器内嵌房间模式。
 - 本地会话服务已支持房间内 `session.state` 推送同步，后续可在此基础上继续扩展多人联机。
 - 多人原型已支持双英雄同房间联调，以及踩到敌方英雄格时触发玩家对玩家遭遇战。

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -97,7 +97,16 @@ interface PasswordRecoveryState {
   expiresAt: string;
 }
 
+interface AccountRegistrationState {
+  loginId: string;
+  requestedDisplayName: string;
+  tokenHash: string;
+  issuedAt: string;
+  expiresAt: string;
+}
+
 type PasswordRecoveryDeliveryMode = "disabled" | "dev-token";
+type AccountRegistrationDeliveryMode = "disabled" | "dev-token";
 
 const AUTH_SECRET = process.env.VEIL_AUTH_SECRET?.trim() || "project-veil-dev-secret";
 const MIN_ACCOUNT_PASSWORD_LENGTH = 6;
@@ -109,12 +118,14 @@ const DEFAULT_MAX_GUEST_SESSIONS = 10_000;
 const DEFAULT_AUTH_ACCESS_TTL_SECONDS = 60 * 60;
 const DEFAULT_AUTH_REFRESH_TTL_SECONDS = 30 * 24 * 60 * 60;
 const DEFAULT_GUEST_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60;
+const DEFAULT_ACCOUNT_REGISTRATION_TTL_MINUTES = 15;
 const DEFAULT_PASSWORD_RECOVERY_TTL_MINUTES = 15;
 
 const authRateLimitCounters = new Map<string, number[]>();
 const accountLockoutStateByLoginId = new Map<string, AccountLockoutState>();
 const guestSessionsById = new Map<string, GuestAuthSession>();
 const accountAuthStateByPlayerId = new Map<string, AccountAuthSessionState>();
+const accountRegistrationStateByLoginId = new Map<string, AccountRegistrationState>();
 const passwordRecoveryStateByLoginId = new Map<string, PasswordRecoveryState>();
 
 function parseEnvNumber(
@@ -191,6 +202,10 @@ function hashRefreshToken(token: string): string {
 
 function hashPasswordRecoveryToken(token: string): string {
   return createHmac("sha256", AUTH_SECRET).update(`password-recovery:${token}`).digest("hex");
+}
+
+function hashAccountRegistrationToken(token: string): string {
+  return createHmac("sha256", AUTH_SECRET).update(`account-registration:${token}`).digest("hex");
 }
 
 function cacheAccountAuthState(input: {
@@ -341,6 +356,36 @@ function normalizePasswordRecoveryToken(token?: string | null): string {
   return normalized;
 }
 
+function normalizeAccountRegistrationToken(token?: string | null): string {
+  const normalized = token?.trim();
+  if (!normalized) {
+    throw new Error("registrationToken must not be empty");
+  }
+
+  return normalized;
+}
+
+function createFormalAccountPlayerId(): string {
+  return `account-${randomUUID().slice(0, 8)}`;
+}
+
+function normalizeRequestedRegistrationDisplayName(loginId: string, displayName?: string | null): string {
+  return normalizeDisplayName(loginId, displayName);
+}
+
+function readAccountRegistrationDeliveryMode(env: NodeJS.ProcessEnv = process.env): AccountRegistrationDeliveryMode {
+  const normalized = env.VEIL_ACCOUNT_REGISTRATION_DELIVERY_MODE?.trim().toLowerCase();
+  return normalized === "disabled" ? "disabled" : "dev-token";
+}
+
+function readAccountRegistrationTtlMs(env: NodeJS.ProcessEnv = process.env): number {
+  return (
+    parseEnvNumber(env.VEIL_ACCOUNT_REGISTRATION_TTL_MINUTES, DEFAULT_ACCOUNT_REGISTRATION_TTL_MINUTES, {
+      minimum: 1 / 60_000
+    }) * 60_000
+  );
+}
+
 function readPasswordRecoveryDeliveryMode(env: NodeJS.ProcessEnv = process.env): PasswordRecoveryDeliveryMode {
   const normalized = env.VEIL_PASSWORD_RECOVERY_DELIVERY_MODE?.trim().toLowerCase();
   return normalized === "disabled" ? "disabled" : "dev-token";
@@ -384,6 +429,52 @@ async function appendAccountAuditLog(
 
 function createPasswordRecoveryToken(): string {
   return randomBytes(24).toString("base64url");
+}
+
+function createAccountRegistrationToken(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+function getAccountRegistrationState(loginId: string): AccountRegistrationState | null {
+  const existing = accountRegistrationStateByLoginId.get(loginId);
+  if (!existing) {
+    return null;
+  }
+
+  if (isExpiredTimestamp(existing.expiresAt)) {
+    accountRegistrationStateByLoginId.delete(loginId);
+    return null;
+  }
+
+  return existing;
+}
+
+function storeAccountRegistrationState(loginId: string, requestedDisplayName: string, token: string): AccountRegistrationState {
+  const issuedAt = new Date().toISOString();
+  const expiresAt = new Date(nowMs() + readAccountRegistrationTtlMs()).toISOString();
+  const state: AccountRegistrationState = {
+    loginId,
+    requestedDisplayName,
+    tokenHash: hashAccountRegistrationToken(token),
+    issuedAt,
+    expiresAt
+  };
+  accountRegistrationStateByLoginId.set(loginId, state);
+  return state;
+}
+
+function consumeAccountRegistrationState(loginId: string, token: string): AccountRegistrationState | null {
+  const state = getAccountRegistrationState(loginId);
+  if (!state) {
+    return null;
+  }
+
+  if (state.tokenHash !== hashAccountRegistrationToken(token)) {
+    return null;
+  }
+
+  accountRegistrationStateByLoginId.delete(loginId);
+  return state;
 }
 
 function getPasswordRecoveryState(loginId: string): PasswordRecoveryState | null {
@@ -1165,6 +1256,7 @@ export function resetGuestAuthSessions(): void {
   accountLockoutStateByLoginId.clear();
   guestSessionsById.clear();
   accountAuthStateByPlayerId.clear();
+  accountRegistrationStateByLoginId.clear();
   passwordRecoveryStateByLoginId.clear();
 }
 
@@ -1571,6 +1663,177 @@ export function registerAuthRoutes(
       });
       sendJson(response, 200, {
         account,
+        session: await createAccountSessionBundle(store, {
+          playerId: account.playerId,
+          displayName: account.displayName,
+          loginId
+        })
+      });
+    } catch (error) {
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/auth/account-registration/request", async (request, response) => {
+    if (!store) {
+      sendStoreUnavailable(response);
+      return;
+    }
+
+    if (!enforceAuthRateLimit(request, response, "account-registration-request")) {
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        loginId?: string | null;
+        displayName?: string | null;
+      };
+
+      if (body.loginId !== undefined && body.loginId !== null && typeof body.loginId !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: loginId"
+          }
+        });
+        return;
+      }
+
+      if (body.displayName !== undefined && body.displayName !== null && typeof body.displayName !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected optional string field: displayName"
+          }
+        });
+        return;
+      }
+
+      const loginId = normalizeAccountLoginId(body.loginId);
+      const existingAuthAccount = await store.loadPlayerAccountAuthByLoginId(loginId);
+      if (existingAuthAccount) {
+        sendJson(response, 409, {
+          error: {
+            code: "login_id_taken",
+            message: "Login ID is already registered"
+          }
+        });
+        return;
+      }
+
+      const requestedDisplayName = normalizeRequestedRegistrationDisplayName(loginId, body.displayName);
+      const registrationToken = createAccountRegistrationToken();
+      const registrationState = storeAccountRegistrationState(loginId, requestedDisplayName, registrationToken);
+      const deliveryMode = readAccountRegistrationDeliveryMode();
+
+      sendJson(response, 202, {
+        status: "registration_requested",
+        expiresAt: registrationState.expiresAt,
+        ...(deliveryMode === "dev-token" ? { registrationToken } : {})
+      });
+    } catch (error) {
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/auth/account-registration/confirm", async (request, response) => {
+    if (!store) {
+      sendStoreUnavailable(response);
+      return;
+    }
+
+    if (!enforceAuthRateLimit(request, response, "account-registration-confirm")) {
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        loginId?: string | null;
+        registrationToken?: string | null;
+        password?: string | null;
+      };
+
+      if (body.loginId !== undefined && body.loginId !== null && typeof body.loginId !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: loginId"
+          }
+        });
+        return;
+      }
+
+      if (body.registrationToken !== undefined && body.registrationToken !== null && typeof body.registrationToken !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: registrationToken"
+          }
+        });
+        return;
+      }
+
+      if (body.password !== undefined && body.password !== null && typeof body.password !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: password"
+          }
+        });
+        return;
+      }
+
+      const loginId = normalizeAccountLoginId(body.loginId);
+      const registrationToken = normalizeAccountRegistrationToken(body.registrationToken);
+      const password = normalizeAccountPassword(body.password);
+      const pendingRegistrationState = getAccountRegistrationState(loginId);
+      if (!pendingRegistrationState) {
+        sendJson(response, 401, {
+          error: {
+            code: "invalid_registration_token",
+            message: "Registration token is invalid or expired"
+          }
+        });
+        return;
+      }
+
+      const registrationState = consumeAccountRegistrationState(loginId, registrationToken);
+      if (!registrationState) {
+        sendJson(response, 401, {
+          error: {
+            code: "invalid_registration_token",
+            message: "Registration token is invalid or expired"
+          }
+        });
+        return;
+      }
+
+      const existingAuthAccount = await store.loadPlayerAccountAuthByLoginId(loginId);
+      if (existingAuthAccount) {
+        sendJson(response, 409, {
+          error: {
+            code: "login_id_taken",
+            message: "Login ID is already registered"
+          }
+        });
+        return;
+      }
+
+      const playerId = createFormalAccountPlayerId();
+      const createdAccount = await store.ensurePlayerAccount({
+        playerId,
+        displayName: registrationState.requestedDisplayName
+      });
+      const account = await store.bindPlayerAccountCredentials(createdAccount.playerId, {
+        loginId,
+        passwordHash: hashAccountPassword(password)
+      });
+      await appendAccountAuditLog(store, account.playerId, `发起正式注册申请，预留登录 ID ${loginId}。`, registrationState.issuedAt);
+      await appendAccountAuditLog(store, account.playerId, "完成正式账号注册，并签发首个账号会话。");
+
+      sendJson(response, 200, {
+        account: (await store.loadPlayerAccount(account.playerId)) ?? account,
         session: await createAccountSessionBundle(store, {
           playerId: account.playerId,
           displayName: account.displayName,

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -973,6 +973,204 @@ test("guest auth session LRU eviction invalidates the oldest idle guest token", 
   assert.equal(activePayload.session.playerId, "guest-lru-3");
 });
 
+test("account registration request and confirm create a new formal account, session, and audit trail", {
+  concurrency: false
+}, async (t) => {
+  const port = 44710 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const requestResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "formal-ranger",
+      displayName: "晨星旅团"
+    })
+  });
+  const requestPayload = (await requestResponse.json()) as {
+    status: string;
+    expiresAt?: string;
+    registrationToken?: string;
+  };
+
+  assert.equal(requestResponse.status, 202);
+  assert.equal(requestPayload.status, "registration_requested");
+  assert.ok(requestPayload.expiresAt);
+  assert.equal(typeof requestPayload.registrationToken, "string");
+
+  const confirmResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "formal-ranger",
+      registrationToken: requestPayload.registrationToken,
+      password: "hunter2"
+    })
+  });
+  const confirmPayload = (await confirmResponse.json()) as {
+    account: PlayerAccountSnapshot;
+    session: GuestAuthSession;
+  };
+
+  assert.equal(confirmResponse.status, 200);
+  assert.match(confirmPayload.account.playerId, /^account-/);
+  assert.equal(confirmPayload.account.displayName, "晨星旅团");
+  assert.equal(confirmPayload.account.loginId, "formal-ranger");
+  assert.equal(confirmPayload.session.authMode, "account");
+  assert.equal(confirmPayload.session.loginId, "formal-ranger");
+  assert.equal(typeof confirmPayload.session.refreshToken, "string");
+
+  const storedAccount = await store.loadPlayerAccount(confirmPayload.account.playerId);
+  assert.equal(storedAccount?.recentEventLog[0]?.category, "account");
+  assert.match(storedAccount?.recentEventLog[0]?.description ?? "", /完成正式账号注册/);
+  assert.equal(storedAccount?.recentEventLog[1]?.category, "account");
+  assert.match(storedAccount?.recentEventLog[1]?.description ?? "", /发起正式注册申请/);
+
+  const loginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "formal-ranger",
+      password: "hunter2"
+    })
+  });
+  assert.equal(loginResponse.status, 200);
+});
+
+test("account registration request rejects already-bound login IDs", { concurrency: false }, async (t) => {
+  const port = 44715 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  await store.ensurePlayerAccount({
+    playerId: "registration-conflict-player",
+    displayName: "已占用旅人"
+  });
+  await store.bindPlayerAccountCredentials("registration-conflict-player", {
+    loginId: "taken-ranger",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "taken-ranger",
+      displayName: "新旅人"
+    })
+  });
+  const payload = (await response.json()) as { error: { code: string } };
+
+  assert.equal(response.status, 409);
+  assert.equal(payload.error.code, "login_id_taken");
+});
+
+test("account registration confirm rejects invalid tokens", { concurrency: false }, async (t) => {
+  const port = 44720 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const requestResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "invalid-registration-ranger"
+    })
+  });
+  assert.equal(requestResponse.status, 202);
+
+  const confirmResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "invalid-registration-ranger",
+      registrationToken: "wrong-token",
+      password: "hunter2"
+    })
+  });
+  const confirmPayload = (await confirmResponse.json()) as { error: { code: string } };
+
+  assert.equal(confirmResponse.status, 401);
+  assert.equal(confirmPayload.error.code, "invalid_registration_token");
+});
+
+test("account registration request returns 429 after the per-IP rate limit is exceeded", { concurrency: false }, async (t) => {
+  const cleanup: Array<() => void> = [];
+  withEnvOverrides(
+    {
+      VEIL_RATE_LIMIT_AUTH_WINDOW_MS: "60000",
+      VEIL_RATE_LIMIT_AUTH_MAX: "2"
+    },
+    cleanup
+  );
+
+  const port = 44722 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    cleanup.reverse().forEach((fn) => fn());
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  for (let index = 0; index < 2; index += 1) {
+    const response = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/request`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        loginId: `registration-limit-${index}`
+      })
+    });
+    assert.equal(response.status, 202);
+  }
+
+  const limitedResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "registration-limit-3"
+    })
+  });
+  const limitedPayload = (await limitedResponse.json()) as { error: { code: string } };
+
+  assert.equal(limitedResponse.status, 429);
+  assert.equal(limitedPayload.error.code, "rate_limited");
+  assert.equal(limitedResponse.headers.get("Retry-After"), "60");
+});
+
 test("password recovery request and confirm reset the password, revoke old sessions, and append account audit events", {
   concurrency: false
 }, async (t) => {

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -1,6 +1,6 @@
-# 账号鉴权与密码找回
+# 账号鉴权、正式注册与密码找回
 
-本文档描述当前仓库已经落地的正式账号能力，以及 `#124` 本轮新增的密码找回后端闭环。
+本文档描述当前仓库已经落地的正式账号能力，以及 `#124` 当前已接上的正式注册 / 密码找回后端闭环。
 
 ## 当前已落地能力
 
@@ -15,6 +15,60 @@
 1. 玩家可先以游客身份进入房间并形成 `player_accounts` 档案。
 2. 需要长期登录时，再把当前游客档绑定到 `loginId + password`。
 3. 后续账号登录会继续复用同一份英雄长期档、全局资源仓库和账号事件历史。
+
+## 正式注册闭环
+
+### 1. 发起注册
+
+接口：`POST /api/auth/account-registration/request`
+
+请求体：
+
+```json
+{
+  "loginId": "veil-ranger",
+  "displayName": "暮潮守望"
+}
+```
+
+行为：
+
+- 为“全新正式账号”预留 `loginId`，不依赖先创建游客档。
+- 校验 `loginId` 格式、口令账号占用情况，并按来源 IP 走现有滑动窗口限流。
+- 当前默认开发态投递模式为 `VEIL_ACCOUNT_REGISTRATION_DELIVERY_MODE=dev-token`，会直接在响应体里回传 `registrationToken` 供联调使用。
+- 若 `loginId` 已被绑定，接口返回 `409 login_id_taken`。
+- 注册申请事件会在确认成功后补写入新账号的 `recentEventLog`，便于后续统一审计。
+
+成功响应示例：
+
+```json
+{
+  "status": "registration_requested",
+  "expiresAt": "2026-03-28T12:34:56.000Z",
+  "registrationToken": "dev-token-example"
+}
+```
+
+### 2. 确认注册
+
+接口：`POST /api/auth/account-registration/confirm`
+
+请求体：
+
+```json
+{
+  "loginId": "veil-ranger",
+  "registrationToken": "dev-token-example",
+  "password": "hunter2"
+}
+```
+
+行为：
+
+- 校验 `loginId`、注册令牌和新口令长度。
+- 令牌错误或过期时返回 `401 invalid_registration_token`。
+- 成功后会创建新的 `player_accounts` 正式档案、绑定口令凭据并立即签发首个账号会话。
+- 服务端会向新账号 `recentEventLog` 追加两条 `category=account` 审计事件，分别记录“发起正式注册申请”和“完成正式账号注册”。
 
 ## 密码找回闭环
 
@@ -71,6 +125,11 @@
 
 ## 运行时参数
 
+- `VEIL_ACCOUNT_REGISTRATION_DELIVERY_MODE`
+  - `dev-token`：默认值，直接在响应里返回开发态注册令牌
+  - `disabled`：不向客户端直出令牌，保留接口占位
+- `VEIL_ACCOUNT_REGISTRATION_TTL_MINUTES`
+  - 默认 `15`
 - `VEIL_PASSWORD_RECOVERY_DELIVERY_MODE`
   - `dev-token`：默认值，直接在响应里返回开发态重置令牌
   - `disabled`：不向客户端直出令牌，保留接口占位
@@ -83,9 +142,8 @@
 
 ## 本轮未覆盖的 #124 范围
 
-本次只落了后端密码找回 vertical slice，仍未完成：
+本次只落了后端正式注册 + 密码找回 vertical slice，仍未完成：
 
-- 正式注册入口和独立注册接口
 - H5 Lobby / Cocos Lobby 的注册或找回 UI 入口
 - 游客绑定账号与“全新正式注册账号”之间的迁移规则文档
 - 真实邮件 / 短信 / 验证码通道


### PR DESCRIPTION
## Summary
- add backend-only formal account registration request/confirm endpoints with dev-token delivery, validation, rate limiting, and account audit events
- cover the new registration slice with focused auth tests and keep the existing password recovery coverage in the same narrow run
- document the new registration endpoints, runtime flags, and the remaining #124 scope in the auth lifecycle docs and README

## Testing
- node --import tsx --test --test-name-pattern='account registration|password recovery' apps/server/test/auth-guest-login.test.ts\n- npm run typecheck:server\n\nrefs #124\n\nRemaining scope:\n- H5 Lobby / Cocos Lobby registration and recovery UI entry points\n- guest-bind versus brand-new formal registration migration rules\n- real email / SMS / verification-code delivery channels