### PR TITLE
fix: stabilize registration and recovery request tokens

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -93,6 +93,7 @@ interface PasswordRecoveryState {
   playerId: string;
   loginId: string;
   tokenHash: string;
+  deliveryToken?: string;
   issuedAt: string;
   expiresAt: string;
 }
@@ -101,6 +102,7 @@ interface AccountRegistrationState {
   loginId: string;
   requestedDisplayName: string;
   tokenHash: string;
+  deliveryToken?: string;
   issuedAt: string;
   expiresAt: string;
 }
@@ -452,10 +454,12 @@ function getAccountRegistrationState(loginId: string): AccountRegistrationState 
 function storeAccountRegistrationState(loginId: string, requestedDisplayName: string, token: string): AccountRegistrationState {
   const issuedAt = new Date().toISOString();
   const expiresAt = new Date(nowMs() + readAccountRegistrationTtlMs()).toISOString();
+  const deliveryMode = readAccountRegistrationDeliveryMode();
   const state: AccountRegistrationState = {
     loginId,
     requestedDisplayName,
     tokenHash: hashAccountRegistrationToken(token),
+    ...(deliveryMode === "dev-token" ? { deliveryToken: token } : {}),
     issuedAt,
     expiresAt
   };
@@ -494,10 +498,12 @@ function getPasswordRecoveryState(loginId: string): PasswordRecoveryState | null
 function storePasswordRecoveryState(playerId: string, loginId: string, token: string): PasswordRecoveryState {
   const issuedAt = new Date().toISOString();
   const expiresAt = new Date(nowMs() + readPasswordRecoveryTtlMs()).toISOString();
+  const deliveryMode = readPasswordRecoveryDeliveryMode();
   const state: PasswordRecoveryState = {
     playerId,
     loginId,
     tokenHash: hashPasswordRecoveryToken(token),
+    ...(deliveryMode === "dev-token" ? { deliveryToken: token } : {}),
     issuedAt,
     expiresAt
   };
@@ -1723,14 +1729,17 @@ export function registerAuthRoutes(
       }
 
       const requestedDisplayName = normalizeRequestedRegistrationDisplayName(loginId, body.displayName);
-      const registrationToken = createAccountRegistrationToken();
-      const registrationState = storeAccountRegistrationState(loginId, requestedDisplayName, registrationToken);
       const deliveryMode = readAccountRegistrationDeliveryMode();
+      const existingRegistrationState = getAccountRegistrationState(loginId);
+      const registrationState =
+        existingRegistrationState?.requestedDisplayName === requestedDisplayName
+          ? existingRegistrationState
+          : storeAccountRegistrationState(loginId, requestedDisplayName, createAccountRegistrationToken());
 
       sendJson(response, 202, {
         status: "registration_requested",
         expiresAt: registrationState.expiresAt,
-        ...(deliveryMode === "dev-token" ? { registrationToken } : {})
+        ...(deliveryMode === "dev-token" && registrationState.deliveryToken ? { registrationToken: registrationState.deliveryToken } : {})
       });
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
@@ -1880,18 +1889,20 @@ export function registerAuthRoutes(
         return;
       }
 
-      const recoveryToken = createPasswordRecoveryToken();
-      const recoveryState = storePasswordRecoveryState(authAccount.playerId, loginId, recoveryToken);
-      await appendAccountAuditLog(
-        store,
-        authAccount.playerId,
-        deliveryMode === "dev-token" ? "发起密码找回申请，已生成开发态重置令牌。" : "发起密码找回申请。"
-      );
+      let recoveryState = getPasswordRecoveryState(loginId);
+      if (!recoveryState || recoveryState.playerId !== authAccount.playerId) {
+        recoveryState = storePasswordRecoveryState(authAccount.playerId, loginId, createPasswordRecoveryToken());
+        await appendAccountAuditLog(
+          store,
+          authAccount.playerId,
+          deliveryMode === "dev-token" ? "发起密码找回申请，已生成开发态重置令牌。" : "发起密码找回申请。"
+        );
+      }
 
       sendJson(response, 202, {
         status: "recovery_requested",
         expiresAt: recoveryState.expiresAt,
-        ...(deliveryMode === "dev-token" ? { recoveryToken } : {})
+        ...(deliveryMode === "dev-token" && recoveryState.deliveryToken ? { recoveryToken: recoveryState.deliveryToken } : {})
       });
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -1122,6 +1122,70 @@ test("account registration confirm rejects invalid tokens", { concurrency: false
   assert.equal(confirmPayload.error.code, "invalid_registration_token");
 });
 
+test("account registration request reuses the active token for the same loginId until it is consumed", { concurrency: false }, async (t) => {
+  const port = 44721 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "stable-registration-ranger",
+      displayName: "雾海守望"
+    })
+  });
+  const firstPayload = (await firstResponse.json()) as {
+    status: string;
+    expiresAt?: string;
+    registrationToken?: string;
+  };
+
+  const secondResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "stable-registration-ranger",
+      displayName: "雾海守望"
+    })
+  });
+  const secondPayload = (await secondResponse.json()) as {
+    status: string;
+    expiresAt?: string;
+    registrationToken?: string;
+  };
+
+  assert.equal(firstResponse.status, 202);
+  assert.equal(secondResponse.status, 202);
+  assert.equal(firstPayload.status, "registration_requested");
+  assert.equal(secondPayload.status, "registration_requested");
+  assert.equal(secondPayload.registrationToken, firstPayload.registrationToken);
+  assert.equal(secondPayload.expiresAt, firstPayload.expiresAt);
+
+  const confirmResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "stable-registration-ranger",
+      registrationToken: firstPayload.registrationToken,
+      password: "hunter2"
+    })
+  });
+
+  assert.equal(confirmResponse.status, 200);
+});
+
 test("account registration request returns 429 after the per-IP rate limit is exceeded", { concurrency: false }, async (t) => {
   const cleanup: Array<() => void> = [];
   withEnvOverrides(
@@ -1326,6 +1390,80 @@ test("password recovery confirm rejects invalid tokens", { concurrency: false },
 
   assert.equal(confirmResponse.status, 401);
   assert.equal(confirmPayload.error.code, "invalid_recovery_token");
+});
+
+test("password recovery request reuses the active token and avoids duplicate audit entries", { concurrency: false }, async (t) => {
+  const port = 44740 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  await store.ensurePlayerAccount({
+    playerId: "recovery-stable-player",
+    displayName: "稳定旅人"
+  });
+  await store.bindPlayerAccountCredentials("recovery-stable-player", {
+    loginId: "stable-recovery-ranger",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstResponse = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "stable-recovery-ranger"
+    })
+  });
+  const firstPayload = (await firstResponse.json()) as {
+    status: string;
+    expiresAt?: string;
+    recoveryToken?: string;
+  };
+
+  const secondResponse = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "stable-recovery-ranger"
+    })
+  });
+  const secondPayload = (await secondResponse.json()) as {
+    status: string;
+    expiresAt?: string;
+    recoveryToken?: string;
+  };
+
+  assert.equal(firstResponse.status, 202);
+  assert.equal(secondResponse.status, 202);
+  assert.equal(firstPayload.status, "recovery_requested");
+  assert.equal(secondPayload.status, "recovery_requested");
+  assert.equal(secondPayload.recoveryToken, firstPayload.recoveryToken);
+  assert.equal(secondPayload.expiresAt, firstPayload.expiresAt);
+
+  const accountAfterRequests = await store.loadPlayerAccount("recovery-stable-player");
+  assert.equal(accountAfterRequests?.recentEventLog.filter((entry) => /发起密码找回申请/.test(entry.description)).length, 1);
+
+  const confirmResponse = await fetch(`http://127.0.0.1:${port}/api/auth/password-recovery/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "stable-recovery-ranger",
+      recoveryToken: firstPayload.recoveryToken,
+      newPassword: "hunter3"
+    })
+  });
+
+  assert.equal(confirmResponse.status, 200);
 });
 
 test("password recovery request returns 429 after the per-IP rate limit is exceeded", { concurrency: false }, async (t) => {

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -36,6 +36,7 @@
 - 为“全新正式账号”预留 `loginId`，不依赖先创建游客档。
 - 校验 `loginId` 格式、口令账号占用情况，并按来源 IP 走现有滑动窗口限流。
 - 当前默认开发态投递模式为 `VEIL_ACCOUNT_REGISTRATION_DELIVERY_MODE=dev-token`，会直接在响应体里回传 `registrationToken` 供联调使用。
+- 若同一个 `loginId` 仍有未过期的注册申请，服务端会复用现有令牌与到期时间，而不是生成新令牌，避免联调时旧令牌被静默顶掉。
 - 若 `loginId` 已被绑定，接口返回 `409 login_id_taken`。
 - 注册申请事件会在确认成功后补写入新账号的 `recentEventLog`，便于后续统一审计。
 
@@ -89,6 +90,7 @@
 - 仅对已绑定口令账号生效；不存在的 `loginId` 仍返回 `202`，避免泄漏账号存在性。
 - 服务端生成一次性短时效重置令牌，并按来源 IP 走现有滑动窗口限流。
 - 当前默认开发态投递模式为 `VEIL_PASSWORD_RECOVERY_DELIVERY_MODE=dev-token`，会直接在响应体里回传 `recoveryToken` 供联调使用。
+- 若同一账号已有未过期的找回申请，服务端会复用现有令牌与到期时间，避免重复请求导致先前令牌失效或连续追加重复审计事件。
 - 若后续切到 `disabled`，接口仍保留，但不会直接把令牌回传给客户端。
 - 成功发起时会向该账号的 `recentEventLog` 追加一条 `category=account` 的审计事件。
 


### PR DESCRIPTION
## Summary
- reuse active dev-mode registration tokens for repeated requests on the same loginId until the pending request expires or is consumed
- reuse active dev-mode password recovery tokens to avoid silently invalidating earlier tokens and duplicating recovery audit entries
- add focused auth tests and lifecycle docs for the repeated-request behavior

## Testing
- npm run typecheck:server
- node --import tsx --test ./apps/server/test/auth-guest-login.test.ts

refs #124