### PR TITLE
Add WeChat release packaging automation refs #126

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,6 @@ jobs:
 
       - name: Check WeChat mini game templates and exported fixture
         run: npm run check:wechat-build
+
+      - name: Package WeChat exported fixture
+        run: npm run package:wechat-release -- --output-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir "${RUNNER_TEMP}/wechat-release" --expect-exported-runtime --source-revision "${GITHUB_SHA}"

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - 微信小游戏模板刷新：`npm run prepare:wechat-build`
 - 微信小游戏 CI 同款校验：`npm run check:wechat-build`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
+- 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - H5 调试壳开发服务：`npm run dev:client:h5`
 - H5 调试壳构建验证：`npm run build:client:h5`
 - H5 调试壳类型检查：`npm run typecheck:client:h5`

--- a/apps/cocos-client/test/cocos-wechat-build.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-build.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -303,6 +304,87 @@ test("buildWechatMinigameReleaseManifest emits deterministic file hashes for val
   assert.equal(manifest.files[0]?.sha256.length, 64);
   assert.match(manifest.files[0]?.sha256 ?? "", /^[a-f0-9]{64}$/);
   assert.deepEqual(manifest.warnings, ["No subpackages were detected or configured for this build."]);
+});
+
+test("package-wechat-release creates an archive and sidecar metadata from a validated exported build", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-"));
+  const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-artifacts-"));
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-config-"));
+  fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tempDir, "game.json"),
+    JSON.stringify({
+      deviceOrientation: "portrait",
+      networkTimeout: {
+        request: 10000,
+        connectSocket: 10000,
+        uploadFile: 10000,
+        downloadFile: 10000
+      },
+      subpackages: []
+    })
+  );
+  fs.writeFileSync(path.join(tempDir, "game.js"), "\"use strict\";\n");
+  fs.writeFileSync(path.join(tempDir, "application.js"), "\"use strict\";\n");
+  fs.writeFileSync(path.join(tempDir, "src", "settings.json"), JSON.stringify({ subpackages: [] }));
+  const config = normalizeWechatMinigameBuildConfig({
+    runtimeRemoteUrl: "https://veil.example.com/socket",
+    remoteAssetRoot: "https://cdn.example.com/assets",
+    domains: {
+      request: ["https://veil.example.com"],
+      socket: ["wss://veil.example.com"],
+      uploadFile: [],
+      downloadFile: ["https://cdn.example.com"]
+    }
+  });
+  const artifacts = buildWechatMinigameTemplateArtifacts(config);
+  const configPath = path.join(configDir, "wechat-minigame.build.json");
+  fs.writeFileSync(path.join(tempDir, "project.config.json"), JSON.stringify(artifacts.projectConfigJson));
+  fs.writeFileSync(path.join(tempDir, "codex.wechat.build.json"), JSON.stringify(artifacts.manifestJson));
+  fs.writeFileSync(path.join(tempDir, "README.codex.md"), `${artifacts.releaseChecklistMarkdown}\n`);
+  fs.writeFileSync(configPath, JSON.stringify(config));
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/package-wechat-minigame-release.ts",
+      "--config",
+      configPath,
+      "--output-dir",
+      tempDir,
+      "--artifacts-dir",
+      artifactsDir,
+      "--expect-exported-runtime",
+      "--source-revision",
+      "abc1234"
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      stdio: "pipe"
+    }
+  );
+
+  const archivePath = path.join(artifactsDir, "project-veil-wechatgame-release.tar.gz");
+  const metadataPath = path.join(artifactsDir, "project-veil-wechatgame-release.package.json");
+  assert.ok(fs.existsSync(archivePath));
+  assert.ok(fs.existsSync(metadataPath));
+
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as {
+    archiveFileName: string;
+    archiveSha256: string;
+    fileCount: number;
+    sourceRevision?: string;
+  };
+  assert.equal(metadata.archiveFileName, "project-veil-wechatgame-release.tar.gz");
+  assert.match(metadata.archiveSha256, /^[a-f0-9]{64}$/);
+  assert.equal(metadata.fileCount, 7);
+  assert.equal(metadata.sourceRevision, "abc1234");
+
+  const archiveListing = execFileSync("tar", ["-tzf", archivePath], { encoding: "utf8" });
+  assert.match(archiveListing, /project-veil-wechatgame-release\/wechatgame\/codex\.wechat\.release\.json/);
+  assert.match(archiveListing, /project-veil-wechatgame-release\/wechatgame\/game\.json/);
 });
 
 test("analyzeWechatMinigameBuildOutput reports injected config drift and missing exported bootstrap files", () => {

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -10,12 +10,15 @@
   - 通过仓库内导出夹具校验注入配置、运行时 bootstrap 文件、主包 / 分包预算，以及运行时域名白名单缺口告警
 - 当前自动化额外会校验一份确定性的发布元数据：`codex.wechat.release.json`
   - 清单内包含导出目录文件列表、字节数、SHA-256、主包 / 分包体积汇总，以及可选的源码 revision 标识
-  - 当前只生成和校验元数据，不在 CI 中打包 zip 或上传微信后台
+- 当前自动化可把已校验导出目录打成确定性的 `tar.gz` 发布包，并输出 sidecar 元数据 `codex.wechat.package.json`
+  - sidecar 会记录归档文件名、SHA-256、字节数、导出目录来源，以及归档内文件清单摘要
+  - 当前仍不在 CI 中直连微信上传接口；提审上传继续人工执行
 
 ## 本地执行
 
 - 刷新模板：`npm run prepare:wechat-build`
 - 生成发布元数据：`npm run prepare:wechat-release -- --output-dir <wechatgame-build-dir> --expect-exported-runtime [--source-revision <git-sha>]`
+- 产出发布归档：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - 只做 CI 同款校验：`npm run check:wechat-build`
 - 校验真实导出目录：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 
@@ -25,8 +28,8 @@
 2. 运行 `npm run prepare:wechat-build`，确认 `apps/cocos-client/build-templates/wechatgame/` 产物已更新。
 3. 在 Cocos Creator 中执行 `wechatgame` 正式导出，并把模板目录内容合入导出目录。
 4. 对真实导出目录执行 `npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`。
-5. 运行 `npm run prepare:wechat-release -- --output-dir <wechatgame-build-dir> --expect-exported-runtime [--source-revision <git-sha>]`，生成 `codex.wechat.release.json` 供提审留档与后续比对。
-6. 将远程资源上传到 CDN，在微信开发者工具中导入构建目录并完成人工 smoke check。
+5. 运行 `npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`，生成包含 `codex.wechat.release.json` 的归档包与 sidecar 元数据。
+6. 将远程资源上传到 CDN，在微信开发者工具中导入归档解压后的构建目录并完成人工 smoke check。
 
 ## Smoke Check
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "validate:battle": "node --import tsx ./scripts/validate-battle-balance.ts",
     "prepare:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts",
     "prepare:wechat-release": "node --import tsx ./scripts/prepare-wechat-minigame-release.ts",
+    "package:wechat-release": "node --import tsx ./scripts/package-wechat-minigame-release.ts",
     "check:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts --check && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/build-templates/wechatgame && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime && node --import tsx ./scripts/prepare-wechat-minigame-release.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime --check",
     "validate:wechat-build": "node --import tsx ./scripts/validate-wechat-minigame-build.ts",
     "sync:assets:h5-pixel": "node ./scripts/sync-h5-pixel-assets.mjs",

--- a/scripts/package-wechat-minigame-release.ts
+++ b/scripts/package-wechat-minigame-release.ts
@@ -1,0 +1,215 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  analyzeWechatMinigameBuildOutput,
+  buildWechatMinigameReleaseManifest,
+  normalizeWechatMinigameBuildConfig
+} from "../apps/cocos-client/assets/scripts/cocos-wechat-build.ts";
+
+interface Args {
+  artifactsDir: string;
+  configPath: string;
+  expectExportedRuntime: boolean;
+  outputDir?: string;
+  packageName?: string;
+  sourceRevision?: string;
+}
+
+interface WechatMinigameReleasePackageMetadata {
+  schemaVersion: 1;
+  buildTemplatePlatform: "wechatgame";
+  projectName: string;
+  appId: string;
+  archiveFileName: string;
+  archiveBytes: number;
+  archiveSha256: string;
+  releaseManifestFile: string;
+  exportedBuildDir: string;
+  packagedBuildDir: string;
+  fileCount: number;
+  sourceRevision?: string;
+  runtimeRemoteUrl?: string;
+  remoteAssetRoot?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  let artifactsDir = "artifacts/wechat-release";
+  let configPath = "apps/cocos-client/wechat-minigame.build.json";
+  let expectExportedRuntime = false;
+  let outputDir: string | undefined;
+  let packageName: string | undefined;
+  let sourceRevision: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--artifacts-dir" && next) {
+      artifactsDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--config" && next) {
+      configPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output-dir" && next) {
+      outputDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--package-name" && next) {
+      packageName = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--source-revision" && next) {
+      sourceRevision = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--expect-exported-runtime") {
+      expectExportedRuntime = true;
+    }
+  }
+
+  return {
+    artifactsDir,
+    configPath,
+    expectExportedRuntime,
+    ...(outputDir ? { outputDir } : {}),
+    ...(packageName ? { packageName } : {}),
+    ...(sourceRevision ? { sourceRevision } : {})
+  };
+}
+
+function sanitizePackageName(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "wechatgame-release";
+}
+
+function hashFileSha256(filePath: string): string {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function packageBuildDirectory(stagingRoot: string, packageRootName: string, archivePath: string): void {
+  const result = spawnSync(
+    "tar",
+    [
+      "--sort=name",
+      "--mtime=UTC 1970-01-01",
+      "--owner=0",
+      "--group=0",
+      "--numeric-owner",
+      "-czf",
+      archivePath,
+      "-C",
+      stagingRoot,
+      packageRootName
+    ],
+    {
+      encoding: "utf8"
+    }
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || "tar failed while packaging the WeChat mini game release.");
+  }
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const repoRoot = process.cwd();
+  const configPath = path.resolve(repoRoot, args.configPath);
+  const config = normalizeWechatMinigameBuildConfig(JSON.parse(fs.readFileSync(configPath, "utf8")));
+  const resolvedOutputDir = path.resolve(repoRoot, args.outputDir ?? config.buildOutputDir);
+  const resolvedArtifactsDir = path.resolve(repoRoot, args.artifactsDir);
+
+  const analysis = analyzeWechatMinigameBuildOutput(resolvedOutputDir, config, {
+    expectExportedRuntime: args.expectExportedRuntime
+  });
+  if (analysis.errors.length > 0) {
+    console.error(`WeChat mini game build is not ready for packaging: ${path.relative(repoRoot, resolvedOutputDir)}`);
+    for (const error of analysis.errors) {
+      console.error(`  - ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const manifest = buildWechatMinigameReleaseManifest(resolvedOutputDir, config, {
+    expectExportedRuntime: args.expectExportedRuntime,
+    ...(args.sourceRevision ? { sourceRevision: args.sourceRevision } : {})
+  });
+  const packageRootName = args.packageName
+    ? sanitizePackageName(args.packageName)
+    : `${sanitizePackageName(config.projectName)}-wechatgame-release`;
+  const archiveFileName = `${packageRootName}.tar.gz`;
+  const archivePath = path.join(resolvedArtifactsDir, archiveFileName);
+  const metadataPath = path.join(resolvedArtifactsDir, `${packageRootName}.package.json`);
+  const stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-package-"));
+
+  try {
+    const packageRoot = path.join(stagingRoot, packageRootName);
+    const stagedBuildDir = path.join(packageRoot, "wechatgame");
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.cpSync(resolvedOutputDir, stagedBuildDir, { recursive: true });
+    writeJsonFile(path.join(stagedBuildDir, "codex.wechat.release.json"), manifest);
+
+    fs.mkdirSync(resolvedArtifactsDir, { recursive: true });
+    if (fs.existsSync(archivePath)) {
+      fs.rmSync(archivePath);
+    }
+    if (fs.existsSync(metadataPath)) {
+      fs.rmSync(metadataPath);
+    }
+
+    packageBuildDirectory(stagingRoot, packageRootName, archivePath);
+    const archiveStats = fs.statSync(archivePath);
+    const metadata: WechatMinigameReleasePackageMetadata = {
+      schemaVersion: 1,
+      buildTemplatePlatform: "wechatgame",
+      projectName: config.projectName,
+      appId: config.appId,
+      archiveFileName,
+      archiveBytes: archiveStats.size,
+      archiveSha256: hashFileSha256(archivePath),
+      releaseManifestFile: "wechatgame/codex.wechat.release.json",
+      exportedBuildDir: path.relative(repoRoot, resolvedOutputDir).replace(/\\/g, "/"),
+      packagedBuildDir: "wechatgame",
+      fileCount: manifest.files.length,
+      ...(args.sourceRevision ? { sourceRevision: args.sourceRevision } : {}),
+      ...(config.runtimeRemoteUrl ? { runtimeRemoteUrl: config.runtimeRemoteUrl } : {}),
+      ...(config.remoteAssetRoot ? { remoteAssetRoot: config.remoteAssetRoot } : {})
+    };
+    writeJsonFile(metadataPath, metadata);
+
+    console.log(`Packaged WeChat mini game release: ${path.relative(repoRoot, archivePath)}`);
+    console.log(`Wrote package metadata: ${path.relative(repoRoot, metadataPath)}`);
+    if (analysis.warnings.length > 0) {
+      console.log("Warnings:");
+      for (const warning of analysis.warnings) {
+        console.log(`  - ${warning}`);
+      }
+    }
+  } finally {
+    fs.rmSync(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a deterministic WeChat release packaging script that validates exported builds, injects release metadata, and emits a tar.gz plus sidecar package metadata
- cover the package flow with focused WeChat build tests and wire the exported fixture packaging step into CI
- document the new release packaging command in the README and WeChat release runbook

## Testing
- node --import tsx --test ./apps/cocos-client/test/cocos-wechat-build.test.ts
- npm run check:wechat-build
- npm run package:wechat-release -- --output-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir /tmp/project-veil-wechat-release --expect-exported-runtime --source-revision HEAD

Refs #126