### PR TITLE
ci: retain WeChat release artifacts refs #126

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
   wechat-build-validation:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      WECHAT_RELEASE_ARTIFACTS_DIR: ${{ runner.temp }}/wechat-release
 
     steps:
       - name: Checkout
@@ -57,4 +59,11 @@ jobs:
         run: npm run check:wechat-build
 
       - name: Package WeChat exported fixture
-        run: npm run package:wechat-release -- --output-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir "${RUNNER_TEMP}/wechat-release" --expect-exported-runtime --source-revision "${GITHUB_SHA}"
+        run: npm run package:wechat-release -- --output-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir "${WECHAT_RELEASE_ARTIFACTS_DIR}" --expect-exported-runtime --source-revision "${GITHUB_SHA}"
+
+      - name: Upload WeChat release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wechat-release-${{ github.sha }}
+          path: ${{ env.WECHAT_RELEASE_ARTIFACTS_DIR }}
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 - 微信小游戏 CI 同款校验：`npm run check:wechat-build`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
+- GitHub Actions `wechat-build-validation` 会把发布归档与 sidecar 元数据作为 artifact `wechat-release-<sha>` 上传，便于提审前下载与回溯
 - H5 调试壳开发服务：`npm run dev:client:h5`
 - H5 调试壳构建验证：`npm run build:client:h5`
 - H5 调试壳类型检查：`npm run typecheck:client:h5`

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -12,6 +12,7 @@
   - 清单内包含导出目录文件列表、字节数、SHA-256、主包 / 分包体积汇总，以及可选的源码 revision 标识
 - 当前自动化可把已校验导出目录打成确定性的 `tar.gz` 发布包，并输出 sidecar 元数据 `codex.wechat.package.json`
   - sidecar 会记录归档文件名、SHA-256、字节数、导出目录来源，以及归档内文件清单摘要
+- CI 会把上述归档与 sidecar 元数据作为 GitHub Actions artifact `wechat-release-<sha>` 上传，供提审前下载、留档与回滚追溯
   - 当前仍不在 CI 中直连微信上传接口；提审上传继续人工执行
 
 ## 本地执行


### PR DESCRIPTION
## Summary
- upload the packaged WeChat mini game release bundle and sidecar metadata from CI as a named workflow artifact
- reuse a single artifact directory env var for packaging and upload steps
- document the retained CI artifact in the README and WeChat release guide

## Testing
- npm run check:wechat-build
- node --import tsx --test ./apps/cocos-client/test/cocos-wechat-build.test.ts

Closes #126