### PR TITLE
Add WeChat release artifact smoke verification and rollback rehearsal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,31 @@ jobs:
           name: wechat-release-${{ github.sha }}
           path: ${{ env.WECHAT_RELEASE_ARTIFACTS_DIR }}
           if-no-files-found: error
+
+  wechat-release-artifact-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - wechat-build-validation
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Download packaged WeChat release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wechat-release-${{ github.sha }}
+          path: ${{ runner.temp }}/wechat-release-downloaded
+
+      - name: Verify downloaded WeChat release artifact
+        run: npm run verify:wechat-release -- --artifacts-dir "${RUNNER_TEMP}/wechat-release-downloaded" --expected-revision "${GITHUB_SHA}"

--- a/apps/cocos-client/test/cocos-wechat-build.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-build.test.ts
@@ -12,6 +12,77 @@ import {
   normalizeWechatMinigameBuildConfig
 } from "../assets/scripts/cocos-wechat-build.ts";
 
+function createPackagedWechatReleaseArtifact(): {
+  tempDir: string;
+  artifactsDir: string;
+  configPath: string;
+} {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-"));
+  const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-artifacts-"));
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-config-"));
+  fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tempDir, "game.json"),
+    JSON.stringify({
+      deviceOrientation: "portrait",
+      networkTimeout: {
+        request: 10000,
+        connectSocket: 10000,
+        uploadFile: 10000,
+        downloadFile: 10000
+      },
+      subpackages: []
+    })
+  );
+  fs.writeFileSync(path.join(tempDir, "game.js"), "\"use strict\";\n");
+  fs.writeFileSync(path.join(tempDir, "application.js"), "\"use strict\";\n");
+  fs.writeFileSync(path.join(tempDir, "src", "settings.json"), JSON.stringify({ subpackages: [] }));
+  const config = normalizeWechatMinigameBuildConfig({
+    runtimeRemoteUrl: "https://veil.example.com/socket",
+    remoteAssetRoot: "https://cdn.example.com/assets",
+    domains: {
+      request: ["https://veil.example.com"],
+      socket: ["wss://veil.example.com"],
+      uploadFile: [],
+      downloadFile: ["https://cdn.example.com"]
+    }
+  });
+  const artifacts = buildWechatMinigameTemplateArtifacts(config);
+  const configPath = path.join(configDir, "wechat-minigame.build.json");
+  fs.writeFileSync(path.join(tempDir, "project.config.json"), JSON.stringify(artifacts.projectConfigJson));
+  fs.writeFileSync(path.join(tempDir, "codex.wechat.build.json"), JSON.stringify(artifacts.manifestJson));
+  fs.writeFileSync(path.join(tempDir, "README.codex.md"), `${artifacts.releaseChecklistMarkdown}\n`);
+  fs.writeFileSync(configPath, JSON.stringify(config));
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/package-wechat-minigame-release.ts",
+      "--config",
+      configPath,
+      "--output-dir",
+      tempDir,
+      "--artifacts-dir",
+      artifactsDir,
+      "--expect-exported-runtime",
+      "--source-revision",
+      "abc1234"
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      stdio: "pipe"
+    }
+  );
+
+  return {
+    tempDir,
+    artifactsDir,
+    configPath
+  };
+}
+
 test("normalizeWechatMinigameBuildConfig trims inputs and deduplicates valid domain lists", () => {
   const config = normalizeWechatMinigameBuildConfig({
     projectName: "  Project Veil Mini  ",
@@ -307,64 +378,7 @@ test("buildWechatMinigameReleaseManifest emits deterministic file hashes for val
 });
 
 test("package-wechat-release creates an archive and sidecar metadata from a validated exported build", () => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-"));
-  const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-artifacts-"));
-  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-build-package-config-"));
-  fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
-  fs.writeFileSync(
-    path.join(tempDir, "game.json"),
-    JSON.stringify({
-      deviceOrientation: "portrait",
-      networkTimeout: {
-        request: 10000,
-        connectSocket: 10000,
-        uploadFile: 10000,
-        downloadFile: 10000
-      },
-      subpackages: []
-    })
-  );
-  fs.writeFileSync(path.join(tempDir, "game.js"), "\"use strict\";\n");
-  fs.writeFileSync(path.join(tempDir, "application.js"), "\"use strict\";\n");
-  fs.writeFileSync(path.join(tempDir, "src", "settings.json"), JSON.stringify({ subpackages: [] }));
-  const config = normalizeWechatMinigameBuildConfig({
-    runtimeRemoteUrl: "https://veil.example.com/socket",
-    remoteAssetRoot: "https://cdn.example.com/assets",
-    domains: {
-      request: ["https://veil.example.com"],
-      socket: ["wss://veil.example.com"],
-      uploadFile: [],
-      downloadFile: ["https://cdn.example.com"]
-    }
-  });
-  const artifacts = buildWechatMinigameTemplateArtifacts(config);
-  const configPath = path.join(configDir, "wechat-minigame.build.json");
-  fs.writeFileSync(path.join(tempDir, "project.config.json"), JSON.stringify(artifacts.projectConfigJson));
-  fs.writeFileSync(path.join(tempDir, "codex.wechat.build.json"), JSON.stringify(artifacts.manifestJson));
-  fs.writeFileSync(path.join(tempDir, "README.codex.md"), `${artifacts.releaseChecklistMarkdown}\n`);
-  fs.writeFileSync(configPath, JSON.stringify(config));
-
-  execFileSync(
-    "node",
-    [
-      "--import",
-      "tsx",
-      "./scripts/package-wechat-minigame-release.ts",
-      "--config",
-      configPath,
-      "--output-dir",
-      tempDir,
-      "--artifacts-dir",
-      artifactsDir,
-      "--expect-exported-runtime",
-      "--source-revision",
-      "abc1234"
-    ],
-    {
-      cwd: path.resolve(__dirname, "../../.."),
-      stdio: "pipe"
-    }
-  );
+  const { artifactsDir } = createPackagedWechatReleaseArtifact();
 
   const archivePath = path.join(artifactsDir, "project-veil-wechatgame-release.tar.gz");
   const metadataPath = path.join(artifactsDir, "project-veil-wechatgame-release.package.json");
@@ -385,6 +399,58 @@ test("package-wechat-release creates an archive and sidecar metadata from a vali
   const archiveListing = execFileSync("tar", ["-tzf", archivePath], { encoding: "utf8" });
   assert.match(archiveListing, /project-veil-wechatgame-release\/wechatgame\/codex\.wechat\.release\.json/);
   assert.match(archiveListing, /project-veil-wechatgame-release\/wechatgame\/game\.json/);
+});
+
+test("verify-wechat-release validates a downloaded artifact bundle", () => {
+  const { artifactsDir } = createPackagedWechatReleaseArtifact();
+
+  const output = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/verify-wechat-minigame-artifact.ts",
+      "--artifacts-dir",
+      artifactsDir,
+      "--expected-revision",
+      "abc1234"
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  assert.match(output, /Verified WeChat release archive/);
+  assert.match(output, /Smoke checklist passed/);
+  assert.match(output, /Revision: abc1234/);
+});
+
+test("verify-wechat-release fails when the requested rollback revision does not match the artifact", () => {
+  const { artifactsDir } = createPackagedWechatReleaseArtifact();
+
+  assert.throws(
+    () =>
+      execFileSync(
+        "node",
+        [
+          "--import",
+          "tsx",
+          "./scripts/verify-wechat-minigame-artifact.ts",
+          "--artifacts-dir",
+          artifactsDir,
+          "--expected-revision",
+          "deadbeef"
+        ],
+        {
+          cwd: path.resolve(__dirname, "../../.."),
+          encoding: "utf8",
+          stdio: "pipe"
+        }
+      ),
+    /Release revision mismatch: expected deadbeef, sidecar=abc1234, manifest=abc1234/
+  );
 });
 
 test("analyzeWechatMinigameBuildOutput reports injected config drift and missing exported bootstrap files", () => {

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -13,6 +13,7 @@
 - 当前自动化可把已校验导出目录打成确定性的 `tar.gz` 发布包，并输出 sidecar 元数据 `codex.wechat.package.json`
   - sidecar 会记录归档文件名、SHA-256、字节数、导出目录来源，以及归档内文件清单摘要
 - CI 会把上述归档与 sidecar 元数据作为 GitHub Actions artifact `wechat-release-<sha>` 上传，供提审前下载、留档与回滚追溯
+- CI 额外会把刚上传的 artifact 再下载一次，并运行 `npm run verify:wechat-release` 做 artifact 级 smoke 验收
   - 当前仍不在 CI 中直连微信上传接口；提审上传继续人工执行
 
 ## 本地执行
@@ -20,6 +21,8 @@
 - 刷新模板：`npm run prepare:wechat-build`
 - 生成发布元数据：`npm run prepare:wechat-release -- --output-dir <wechatgame-build-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - 产出发布归档：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
+- 按 SHA 下载 CI artifact：`npm run download:wechat-release -- --sha <git-sha> [--output-dir artifacts/downloaded/wechat-release-<git-sha>]`
+- 验收已下载 artifact：`npm run verify:wechat-release -- --artifacts-dir <downloaded-artifact-dir> [--expected-revision <git-sha>]`
 - 只做 CI 同款校验：`npm run check:wechat-build`
 - 校验真实导出目录：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 
@@ -30,16 +33,44 @@
 3. 在 Cocos Creator 中执行 `wechatgame` 正式导出，并把模板目录内容合入导出目录。
 4. 对真实导出目录执行 `npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`。
 5. 运行 `npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`，生成包含 `codex.wechat.release.json` 的归档包与 sidecar 元数据。
-6. 将远程资源上传到 CDN，在微信开发者工具中导入归档解压后的构建目录并完成人工 smoke check。
+6. 运行 `npm run verify:wechat-release -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>]`，在上传前先做一次本地 artifact 级冒烟验收。
+7. 将远程资源上传到 CDN，在微信开发者工具中导入归档解压后的构建目录并完成人工 smoke check。
 
-## Smoke Check
+## 下载与验收
 
+给定某次构建 SHA，可用以下方式标准化下载并验收对应发布包：
+
+1. 下载 artifact：`npm run download:wechat-release -- --sha <git-sha>`
+2. 复核 sidecar、release manifest 与 smoke 清单：`npm run verify:wechat-release -- --artifacts-dir artifacts/downloaded/wechat-release-<git-sha> --expected-revision <git-sha>`
+3. 通过后再解压归档并导入微信开发者工具，执行人工提审前检查
+
+`verify:wechat-release` 默认会完成以下检查：
+
+- sidecar 中记录的归档文件名、字节数、SHA-256 是否与下载产物一致
+- `codex.wechat.release.json` 是否存在，且 `sourceRevision` 与 sidecar / 目标 revision 一致
+- `game.json`、`project.config.json`、`codex.wechat.build.json`、`README.codex.md`、`game.js`、`application.js`、`src/settings.json` 是否齐全
+- release manifest 中记录的文件列表、字节数、SHA-256 是否与归档内真实内容一致
+- `project.config.json` / `codex.wechat.build.json` 是否仍指向微信小游戏构建
+
+## 提审前 Smoke Check
+
+- artifact 验收脚本通过，无 sidecar / manifest / revision 漂移
 - 能正常启动到 Lobby / 首屏
 - `wx` 登录链路或游客降级链路可用
 - 与 `runtimeRemoteUrl` 对应的请求 / socket 域名无白名单报错
 - 关键远程资源可加载，首轮进入房间或战斗不出现缺图 / 缺配置
 
-## 回滚
+## 回滚演练
+
+以下步骤用于演练如何恢复到某个历史 revision，对应 issue #141 的“可下载、可回退、可追溯”目标：
+
+1. 选择目标 revision：确认要恢复的 Git SHA，例如 `<rollback-sha>`。
+2. 下载历史包：`npm run download:wechat-release -- --sha <rollback-sha> --output-dir artifacts/rollback/<rollback-sha>`
+3. 验证历史包：`npm run verify:wechat-release -- --artifacts-dir artifacts/rollback/<rollback-sha> --expected-revision <rollback-sha>`
+4. 解压并恢复构建目录：`tar -xzf artifacts/rollback/<rollback-sha>/*.tar.gz -C artifacts/rollback/<rollback-sha>/extracted`
+5. 切换远程资源：把 CDN 指向该历史包对应的资源版本，或同步恢复其资源目录快照。
+6. 在微信开发者工具中导入 `artifacts/rollback/<rollback-sha>/extracted/<package-name>/wechatgame`，确认能启动并完成最小 smoke check。
+7. 记录演练结果：保存使用的 SHA、artifact 名称、验收结果和恢复时间，确保后续回滚步骤不依赖人工记忆。
 
 - 构建模板或配置回滚：回退 `apps/cocos-client/wechat-minigame.build.json` 与 `apps/cocos-client/build-templates/wechatgame/`
 - CI 导出夹具回滚：若只是校验夹具与脚本演进不一致，可同步回退 `apps/cocos-client/test/fixtures/wechatgame-export/`

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "prepare:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts",
     "prepare:wechat-release": "node --import tsx ./scripts/prepare-wechat-minigame-release.ts",
     "package:wechat-release": "node --import tsx ./scripts/package-wechat-minigame-release.ts",
+    "download:wechat-release": "node --import tsx ./scripts/download-wechat-minigame-artifact.ts",
+    "verify:wechat-release": "node --import tsx ./scripts/verify-wechat-minigame-artifact.ts",
     "check:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts --check && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/build-templates/wechatgame && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime && node --import tsx ./scripts/prepare-wechat-minigame-release.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime --check",
     "validate:wechat-build": "node --import tsx ./scripts/validate-wechat-minigame-build.ts",
     "sync:assets:h5-pixel": "node ./scripts/sync-h5-pixel-assets.mjs",

--- a/scripts/download-wechat-minigame-artifact.ts
+++ b/scripts/download-wechat-minigame-artifact.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+interface Args {
+  repo: string;
+  sha: string;
+  outputDir: string;
+  runId?: string;
+}
+
+interface GithubRunSummary {
+  databaseId: number;
+  workflowName?: string;
+  status?: string;
+  conclusion?: string;
+  headSha?: string;
+  createdAt?: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  let repo = "dannagrace/ProjectVeil";
+  let sha = "";
+  let outputDir = "";
+  let runId: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--repo" && next) {
+      repo = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--sha" && next) {
+      sha = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--output-dir" && next) {
+      outputDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--run-id" && next) {
+      runId = next.trim() || undefined;
+      index += 1;
+    }
+  }
+
+  if (!sha) {
+    throw new Error("Missing required argument: --sha <git-sha>");
+  }
+
+  return {
+    repo,
+    sha,
+    outputDir: outputDir || `artifacts/downloaded/wechat-release-${sha}`,
+    ...(runId ? { runId } : {})
+  };
+}
+
+function runCommand(command: string, args: string[]): string {
+  const result = spawnSync(command, args, {
+    encoding: "utf8"
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || `${command} ${args.join(" ")} failed.`);
+  }
+  return result.stdout;
+}
+
+function resolveRunId(repo: string, sha: string): string {
+  const runsJson = runCommand("gh", [
+    "run",
+    "list",
+    "--repo",
+    repo,
+    "--commit",
+    sha,
+    "--json",
+    "databaseId,workflowName,status,conclusion,headSha,createdAt",
+    "--limit",
+    "20"
+  ]);
+  const runs = JSON.parse(runsJson) as GithubRunSummary[];
+  const matchedRun = runs.find((run) => run.workflowName === "CI" && run.status === "completed");
+  if (!matchedRun) {
+    throw new Error(`No completed CI run found for ${repo}@${sha}.`);
+  }
+  return String(matchedRun.databaseId);
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const artifactName = `wechat-release-${args.sha}`;
+  const outputDir = path.resolve(args.outputDir);
+  const runId = args.runId ?? resolveRunId(args.repo, args.sha);
+
+  fs.rmSync(outputDir, { recursive: true, force: true });
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  runCommand("gh", ["run", "download", runId, "--repo", args.repo, "--name", artifactName, "--dir", outputDir]);
+
+  console.log(`Downloaded ${artifactName} from run ${runId}`);
+  console.log(`Artifacts directory: ${outputDir}`);
+}
+
+main();

--- a/scripts/verify-wechat-minigame-artifact.ts
+++ b/scripts/verify-wechat-minigame-artifact.ts
@@ -1,0 +1,371 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+interface Args {
+  artifactsDir?: string;
+  archivePath?: string;
+  metadataPath?: string;
+  expectedRevision?: string;
+  keepExtracted: boolean;
+}
+
+interface WechatMinigameReleasePackageMetadata {
+  schemaVersion: 1;
+  buildTemplatePlatform: "wechatgame";
+  projectName: string;
+  appId: string;
+  archiveFileName: string;
+  archiveBytes: number;
+  archiveSha256: string;
+  releaseManifestFile: string;
+  exportedBuildDir: string;
+  packagedBuildDir: string;
+  fileCount: number;
+  sourceRevision?: string;
+  runtimeRemoteUrl?: string;
+  remoteAssetRoot?: string;
+}
+
+interface WechatMinigameReleaseManifestFile {
+  relativePath: string;
+  bytes: number;
+  sha256: string;
+}
+
+interface WechatMinigameReleaseManifest {
+  schemaVersion: 1;
+  buildTemplatePlatform: "wechatgame";
+  projectName: string;
+  appId: string;
+  buildOutputDir: string;
+  sourceRevision?: string;
+  runtimeRemoteUrl?: string;
+  remoteAssetRoot?: string;
+  packageSizes: {
+    totalBytes: number;
+    mainPackageBytes: number;
+    totalSubpackageBytes: number;
+  };
+  warnings: string[];
+  files: WechatMinigameReleaseManifestFile[];
+}
+
+const REQUIRED_SMOKE_FILES = [
+  "game.json",
+  "project.config.json",
+  "codex.wechat.build.json",
+  "README.codex.md",
+  "codex.wechat.release.json",
+  "game.js",
+  "application.js",
+  "src/settings.json"
+] as const;
+
+function parseArgs(argv: string[]): Args {
+  let artifactsDir: string | undefined;
+  let archivePath: string | undefined;
+  let metadataPath: string | undefined;
+  let expectedRevision: string | undefined;
+  let keepExtracted = false;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--artifacts-dir" && next) {
+      artifactsDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--archive" && next) {
+      archivePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--metadata" && next) {
+      metadataPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--expected-revision" && next) {
+      expectedRevision = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--keep-extracted") {
+      keepExtracted = true;
+    }
+  }
+
+  return {
+    ...(artifactsDir ? { artifactsDir } : {}),
+    ...(archivePath ? { archivePath } : {}),
+    ...(metadataPath ? { metadataPath } : {}),
+    ...(expectedRevision ? { expectedRevision } : {}),
+    keepExtracted
+  };
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function hashFileSha256(filePath: string): string {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function listFilesRecursively(rootDir: string, currentDir = rootDir): Array<{ relativePath: string; bytes: number }> {
+  const entries = fs
+    .readdirSync(currentDir, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const files: Array<{ relativePath: string; bytes: number }> = [];
+  for (const entry of entries) {
+    const fullPath = path.join(currentDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursively(rootDir, fullPath));
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const stats = fs.statSync(fullPath);
+    files.push({
+      relativePath: path.relative(rootDir, fullPath).replace(/\\/g, "/"),
+      bytes: stats.size
+    });
+  }
+  return files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+function resolveArtifactsFromDirectory(artifactsDir: string): { archivePath: string; metadataPath: string } {
+  const resolvedArtifactsDir = path.resolve(artifactsDir);
+  if (!fs.existsSync(resolvedArtifactsDir)) {
+    fail(`Artifacts directory does not exist: ${resolvedArtifactsDir}`);
+  }
+
+  const entries = fs.readdirSync(resolvedArtifactsDir);
+  const archives = entries.filter((entry) => entry.endsWith(".tar.gz")).sort();
+  const sidecars = entries.filter((entry) => entry.endsWith(".package.json")).sort();
+  if (archives.length !== 1) {
+    fail(`Expected exactly one release archive in ${resolvedArtifactsDir}, found ${archives.length}.`);
+  }
+  if (sidecars.length !== 1) {
+    fail(`Expected exactly one release sidecar in ${resolvedArtifactsDir}, found ${sidecars.length}.`);
+  }
+
+  const [archiveFileName] = archives;
+  const [sidecarFileName] = sidecars;
+
+  return {
+    archivePath: path.join(resolvedArtifactsDir, archiveFileName),
+    metadataPath: path.join(resolvedArtifactsDir, sidecarFileName)
+  };
+}
+
+function resolveInputArtifacts(args: Args): { archivePath: string; metadataPath: string } {
+  if (args.artifactsDir) {
+    return resolveArtifactsFromDirectory(args.artifactsDir);
+  }
+
+  if (!args.archivePath || !args.metadataPath) {
+    fail("Pass either --artifacts-dir <dir> or both --archive <tar.gz> and --metadata <package.json>.");
+  }
+
+  return {
+    archivePath: path.resolve(args.archivePath),
+    metadataPath: path.resolve(args.metadataPath)
+  };
+}
+
+function extractArchive(archivePath: string, targetDir: string): void {
+  const result = spawnSync("tar", ["-xzf", archivePath, "-C", targetDir], {
+    encoding: "utf8"
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    fail(result.stderr.trim() || `tar failed while extracting ${archivePath}`);
+  }
+}
+
+function verifyRevision(
+  expectedRevision: string | undefined,
+  metadataRevision: string | undefined,
+  manifestRevision: string | undefined
+): void {
+  if (metadataRevision && manifestRevision && metadataRevision !== manifestRevision) {
+    fail(`Revision mismatch between sidecar and release manifest: ${metadataRevision} !== ${manifestRevision}`);
+  }
+
+  if (expectedRevision) {
+    if (!metadataRevision) {
+      fail(`Release sidecar is missing sourceRevision; expected ${expectedRevision}.`);
+    }
+    if (!manifestRevision) {
+      fail(`Release manifest is missing sourceRevision; expected ${expectedRevision}.`);
+    }
+    if (metadataRevision !== expectedRevision || manifestRevision !== expectedRevision) {
+      fail(
+        `Release revision mismatch: expected ${expectedRevision}, sidecar=${metadataRevision}, manifest=${manifestRevision}`
+      );
+    }
+  }
+}
+
+function verifySmokeFiles(buildDir: string): void {
+  for (const relativePath of REQUIRED_SMOKE_FILES) {
+    const filePath = path.join(buildDir, relativePath);
+    if (!fs.existsSync(filePath)) {
+      fail(`Smoke validation failed: required file is missing from release payload: ${relativePath}`);
+    }
+  }
+}
+
+function verifyBuildMetadataConsistency(
+  buildDir: string,
+  metadata: WechatMinigameReleasePackageMetadata,
+  manifest: WechatMinigameReleaseManifest
+): void {
+  const projectConfig = readJsonFile<{ projectname?: string; appid?: string; compileType?: string }>(
+    path.join(buildDir, "project.config.json")
+  );
+  const buildManifest = readJsonFile<{ buildTemplatePlatform?: string; projectName?: string; buildOutputDir?: string }>(
+    path.join(buildDir, "codex.wechat.build.json")
+  );
+
+  if (projectConfig.projectname !== manifest.projectName || projectConfig.projectname !== metadata.projectName) {
+    fail("project.config.json projectname does not match release sidecar/manifest.");
+  }
+  if (projectConfig.appid !== manifest.appId || projectConfig.appid !== metadata.appId) {
+    fail("project.config.json appid does not match release sidecar/manifest.");
+  }
+  if (projectConfig.compileType !== "game") {
+    fail(`project.config.json compileType must be "game", received ${JSON.stringify(projectConfig.compileType)}.`);
+  }
+  if (buildManifest.buildTemplatePlatform !== "wechatgame") {
+    fail(
+      `codex.wechat.build.json buildTemplatePlatform must be "wechatgame", received ${JSON.stringify(buildManifest.buildTemplatePlatform)}.`
+    );
+  }
+  if (buildManifest.projectName !== manifest.projectName) {
+    fail("codex.wechat.build.json projectName does not match release manifest.");
+  }
+}
+
+function verifyManifestFiles(
+  buildDir: string,
+  metadata: WechatMinigameReleasePackageMetadata,
+  manifest: WechatMinigameReleaseManifest
+): void {
+  if (metadata.fileCount !== manifest.files.length) {
+    fail(`Sidecar fileCount mismatch: expected ${metadata.fileCount}, manifest listed ${manifest.files.length}.`);
+  }
+
+  const actualFiles = listFilesRecursively(buildDir);
+  const actualFilesWithoutManifest = actualFiles.filter((file) => file.relativePath !== "codex.wechat.release.json");
+  const actualTotalBytes = actualFilesWithoutManifest.reduce((sum, file) => sum + file.bytes, 0);
+  if (actualTotalBytes !== manifest.packageSizes.totalBytes) {
+    fail(
+      `Manifest packageSizes.totalBytes mismatch: expected ${manifest.packageSizes.totalBytes}, actual ${actualTotalBytes}.`
+    );
+  }
+
+  const manifestEntries = new Map(manifest.files.map((file) => [file.relativePath, file]));
+  for (const file of actualFilesWithoutManifest) {
+    const manifestEntry = manifestEntries.get(file.relativePath);
+    if (!manifestEntry) {
+      fail(`Release manifest is missing file entry: ${file.relativePath}`);
+    }
+    if (manifestEntry.bytes !== file.bytes) {
+      fail(`Release manifest byte count mismatch for ${file.relativePath}: ${manifestEntry.bytes} !== ${file.bytes}`);
+    }
+    const actualSha = hashFileSha256(path.join(buildDir, file.relativePath));
+    if (manifestEntry.sha256 !== actualSha) {
+      fail(`Release manifest SHA-256 mismatch for ${file.relativePath}.`);
+    }
+  }
+
+  for (const relativePath of manifestEntries.keys()) {
+    if (!actualFilesWithoutManifest.some((file) => file.relativePath === relativePath)) {
+      fail(`Release payload is missing manifest-listed file: ${relativePath}`);
+    }
+  }
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const { archivePath, metadataPath } = resolveInputArtifacts(args);
+
+  const metadata = readJsonFile<WechatMinigameReleasePackageMetadata>(metadataPath);
+  if (metadata.schemaVersion !== 1 || metadata.buildTemplatePlatform !== "wechatgame") {
+    fail(`Unsupported WeChat release sidecar: ${metadataPath}`);
+  }
+
+  if (path.basename(archivePath) !== metadata.archiveFileName) {
+    fail(`Sidecar archiveFileName mismatch: ${metadata.archiveFileName} !== ${path.basename(archivePath)}`);
+  }
+
+  const archiveStats = fs.statSync(archivePath);
+  if (archiveStats.size !== metadata.archiveBytes) {
+    fail(`Sidecar archiveBytes mismatch: ${metadata.archiveBytes} !== ${archiveStats.size}`);
+  }
+
+  const archiveSha = hashFileSha256(archivePath);
+  if (archiveSha !== metadata.archiveSha256) {
+    fail(`Sidecar archiveSha256 mismatch for ${path.basename(archivePath)}.`);
+  }
+
+  const extractedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-release-verify-"));
+  try {
+    extractArchive(archivePath, extractedRoot);
+
+    const packageRootName = metadata.archiveFileName.replace(/\.tar\.gz$/, "");
+    const packageRoot = path.join(extractedRoot, packageRootName);
+    if (!fs.existsSync(packageRoot)) {
+      fail(`Extracted archive root is missing: ${packageRootName}`);
+    }
+
+    const buildDir = path.join(packageRoot, metadata.packagedBuildDir);
+    if (!fs.existsSync(buildDir)) {
+      fail(`Packaged build directory is missing from archive: ${metadata.packagedBuildDir}`);
+    }
+
+    const releaseManifestPath = path.join(packageRoot, metadata.releaseManifestFile);
+    if (!fs.existsSync(releaseManifestPath)) {
+      fail(`Release manifest is missing from archive: ${metadata.releaseManifestFile}`);
+    }
+
+    const manifest = readJsonFile<WechatMinigameReleaseManifest>(releaseManifestPath);
+    if (manifest.schemaVersion !== 1 || manifest.buildTemplatePlatform !== "wechatgame") {
+      fail(`Unsupported WeChat release manifest: ${metadata.releaseManifestFile}`);
+    }
+
+    verifyRevision(args.expectedRevision, metadata.sourceRevision, manifest.sourceRevision);
+    verifySmokeFiles(buildDir);
+    verifyBuildMetadataConsistency(buildDir, metadata, manifest);
+    verifyManifestFiles(buildDir, metadata, manifest);
+
+    console.log(`Verified WeChat release archive: ${archivePath}`);
+    console.log(`Smoke checklist passed for ${metadata.packagedBuildDir}`);
+    console.log(`Release manifest entries: ${manifest.files.length}`);
+    if (metadata.sourceRevision) {
+      console.log(`Revision: ${metadata.sourceRevision}`);
+    }
+  } finally {
+    if (args.keepExtracted) {
+      console.log(`Kept extracted files at ${extractedRoot}`);
+    } else {
+      fs.rmSync(extractedRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add standard scripts to download `wechat-release-<sha>` artifacts and verify downloaded release bundles
- add artifact smoke verification coverage in tests and GitHub Actions after artifact upload
- document download, acceptance, and rollback rehearsal flow for WeChat mini game release artifacts

Closes #141