### PR TITLE
配置中心接入 battle-balance.json 可视化编辑与校验

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@
 - 当前已补上配置中心 MVP：
   - 前端入口：`http://127.0.0.1:4173/config-center.html`
   - 后端 API：`/api/config-center/configs`
-  - 当前支持编辑 `phase1-world.json / phase1-map-objects.json / units.json / battle-skills.json`
+  - 当前支持编辑 `phase1-world.json / phase1-map-objects.json / units.json / battle-skills.json / battle-balance.json`
   - 未配置 MySQL 时走文件系统存储；配置 `VEIL_MYSQL_*` 后切换到 MySQL 主存储
   - 保存后会同时导出到 `configs/*.json`，并同步刷新服务端运行时配置，新建房间和战斗逻辑会直接读取新值
   - 当前已补上版本快照、快照差异对比、历史回滚，以及 Easy / Normal / Hard 三档内置预设和自定义预设保存
@@ -139,6 +139,7 @@
   - 导出除 JSON 注释版外，还支持带 `Meta / Schema / Fields` 工作表的 Excel，以及更轻量的字段清单 CSV
   - 当前编辑 `phase1-world.json` 时，右侧会即时生成一份地图样本预览；可切换预览 seed，对照查看地形、随机资源、保底资源、英雄与中立怪分布
   - 当前编辑 `battle-skills.json` 时，右侧会显示技能编辑器，可直接调整冷却、伤害倍率、目标类型、附加状态和状态持续参数，并同步回写 JSON 草稿
+  - 当前编辑 `battle-balance.json` 时，右侧会显示战斗平衡编辑器，可直接调整伤害公式、路障/陷阱阈值、附加状态和 ELO K；非法值会在 Schema/语义校验里给出修复建议并阻止保存
 - H5 战斗面板现已补上“战术情报”区，会并排展示当前行动单位和已锁定目标的技能、状态、冷却与效果说明，便于直接核对配置是否符合预期。
 - Cocos 战斗面板现已补上技能摘要和目标状态提示，概要区、目标卡与动作按钮都会带出当前技能/状态信息，而不再只有基础攻击指令。
 - `phase1-map-objects.json` 现已支持配置 `buildings`，当前已接入 `recruitment_post` 招募所、`attribute_shrine` 属性神殿和 `resource_mine` 资源矿场；英雄停在建筑格上再次点击当前格即可访问或占领建筑。
@@ -183,7 +184,7 @@
 - `npm run validate:assets` 现在除了校验 schema 和文件存在性，也会拦截缺失元数据、重复槽位和游离元数据；后续正式美术替换可直接沿用同一套 manifest 规则补齐审计信息。
 - `units.json` 现已补上 `faction / rarity` 元数据，前端会自动挂载阵营与品质 badge，占位资源层已经具备继续细化正式 UI 的结构。
 - `battle-skills.json` 现已承载战斗技能与持续状态目录，shared 战斗结算会在创建战斗和执行技能时直接读取运行时配置，不再依赖硬编码技能表。
-- `battle-balance.json` 现已补上第一批战斗平衡基础配置，当前 shared 战斗运行时已经会直接读取其中的伤害公式参数，以及遭遇战环境里路障/陷阱的生成阈值、耐久、伤害和次数；本批还未把它接进配置中心 UI，只先建立 shared 侧可验证的数据驱动链路。
+- `battle-balance.json` 现已接入配置中心：支持可视化编辑伤害公式、遭遇战环境和 PVP ELO 参数，保存后会联动导出 JSON 并直接刷新 shared/runtime 读取链路；实时校验还会检查阈值范围以及陷阱状态是否与 `battle-skills.json` 对齐。
 - 当前示例技能已包含 `投矛射击 / 护甲术 / 战意激发 / 破甲投枪 / 毒牙 / 裂伤嚎叫`，并补充了 `守誓姿态` 模板；守军自动回合也会根据技能目标和效果优先选择施法，而不是固定平砍。
 - 英雄长期成长现已补上技能树：`hero.progressed` 在升级时会发放技能点，H5 英雄卡会直接显示分支、当前阶数和“学习 / 强化”按钮；已学技能会写入英雄长期档，并在下一场战斗里额外挂到英雄部队技能栏。
 - 地图对象也已拆出独立视觉元数据配置，悬停地图时会通过统一对象卡片展示 `interactionType / faction / rarity` 等信息。

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -1,6 +1,6 @@
 import "./config-center.css";
 
-type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills";
+type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
 type TerrainType = "grass" | "dirt" | "sand" | "water";
 type ResourceKind = "gold" | "wood" | "ore";
 type BattleSkillKind = "active" | "passive";
@@ -36,6 +36,27 @@ interface BattleStatusEffectConfig {
 interface BattleSkillCatalogConfig {
   skills: BattleSkillConfig[];
   statuses: BattleStatusEffectConfig[];
+}
+
+interface BattleBalanceConfig {
+  damage: {
+    defendingDefenseBonus: number;
+    offenseAdvantageStep: number;
+    minimumOffenseMultiplier: number;
+    varianceBase: number;
+    varianceRange: number;
+  };
+  environment: {
+    blockerSpawnThreshold: number;
+    blockerDurability: number;
+    trapSpawnThreshold: number;
+    trapDamage: number;
+    trapCharges: number;
+    trapGrantedStatusId?: string;
+  };
+  pvp: {
+    eloK: number;
+  };
 }
 
 interface ConfigDocumentSummary {
@@ -345,6 +366,10 @@ function isBattleSkillsDocumentSelected(): boolean {
   return state.current?.id === "battleSkills";
 }
 
+function isBattleBalanceDocumentSelected(): boolean {
+  return state.current?.id === "battleBalance";
+}
+
 function normalizePreviewSeed(value: number, fallback = state.previewSeed): number {
   if (!Number.isFinite(value)) {
     return fallback;
@@ -376,6 +401,59 @@ function updateBattleSkillCatalogDraft(
 
   const nextCatalog = updater(structuredClone(current.catalog));
   setDraftContent(`${JSON.stringify(nextCatalog, null, 2)}\n`);
+}
+
+function currentBattleBalanceState(): {
+  valid: boolean;
+  detail: string;
+  config: BattleBalanceConfig | null;
+} {
+  if (!isBattleBalanceDocumentSelected()) {
+    return {
+      valid: false,
+      detail: "当前未选择战斗平衡文档",
+      config: null
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(state.draft || "{}") as Partial<BattleBalanceConfig>;
+    if (
+      !parsed.damage ||
+      !parsed.environment ||
+      !parsed.pvp
+    ) {
+      return {
+        valid: false,
+        detail: "战斗平衡配置需要同时包含 damage、environment 和 pvp",
+        config: null
+      };
+    }
+
+    return {
+      valid: true,
+      detail: "战斗平衡结构有效",
+      config: parsed as BattleBalanceConfig
+    };
+  } catch (error) {
+    return {
+      valid: false,
+      detail: error instanceof Error ? error.message : "战斗平衡 JSON 无效",
+      config: null
+    };
+  }
+}
+
+function updateBattleBalanceDraft(
+  updater: (config: BattleBalanceConfig) => BattleBalanceConfig
+): void {
+  const current = currentBattleBalanceState();
+  if (!current.valid || !current.config) {
+    return;
+  }
+
+  const nextConfig = updater(structuredClone(current.config));
+  setDraftContent(`${JSON.stringify(nextConfig, null, 2)}\n`);
 }
 
 function cleanupSkillEffects(effects: BattleSkillEffectConfig): BattleSkillEffectConfig | undefined {
@@ -1366,6 +1444,128 @@ function renderBattleSkillEditorSection(): string {
   `;
 }
 
+function renderBattleBalanceEditorSection(): string {
+  if (!isBattleBalanceDocumentSelected()) {
+    return "";
+  }
+
+  const parseState = currentBattleBalanceState();
+  if (!parseState.valid || !parseState.config) {
+    return `
+      <section class="skill-editor-section">
+        <div class="config-preview-subhead">
+          <h4>战斗平衡编辑器</h4>
+          <span class="config-meta">等待合法 JSON</span>
+        </div>
+        <div class="world-preview-empty is-error">${escapeHtml(parseState.detail)}</div>
+      </section>
+    `;
+  }
+
+  const config = parseState.config;
+  const summaryBadges = [
+    `<span class="config-badge">防守加成 ${config.damage.defendingDefenseBonus}</span>`,
+    `<span class="config-badge">攻防步进 ${config.damage.offenseAdvantageStep}</span>`,
+    `<span class="config-badge">路障阈值 ${config.environment.blockerSpawnThreshold}</span>`,
+    `<span class="config-badge">陷阱阈值 ${config.environment.trapSpawnThreshold}</span>`,
+    `<span class="config-badge">ELO K=${config.pvp.eloK}</span>`
+  ].join("");
+
+  return `
+    <section class="skill-editor-section">
+      <div class="config-preview-subhead">
+        <h4>战斗平衡编辑器</h4>
+        <span class="config-meta">公式 / 环境 / PVP</span>
+      </div>
+      <p class="config-hint">右侧表单会直接改写当前 JSON 草稿，适合快速调伤害公式、路障/陷阱生成参数和 ELO K；底部原始 JSON 仍可手改。</p>
+      <div class="config-badge-row">${summaryBadges}</div>
+      <div class="skill-editor-group">
+        <article class="skill-editor-card">
+          <div class="skill-editor-card-head">
+            <div>
+              <strong>伤害公式</strong>
+              <span>damage</span>
+            </div>
+            <span class="config-badge">实时生效</span>
+          </div>
+          <div class="skill-editor-fields">
+            <label>
+              <span>防守防御加成</span>
+              <input type="number" step="1" value="${config.damage.defendingDefenseBonus}" data-role="battle-balance-field" data-section="damage" data-field="defendingDefenseBonus" />
+            </label>
+            <label>
+              <span>攻防差步进</span>
+              <input type="number" step="0.01" value="${config.damage.offenseAdvantageStep}" data-role="battle-balance-field" data-section="damage" data-field="offenseAdvantageStep" />
+            </label>
+            <label>
+              <span>最低伤害倍率</span>
+              <input type="number" step="0.01" value="${config.damage.minimumOffenseMultiplier}" data-role="battle-balance-field" data-section="damage" data-field="minimumOffenseMultiplier" />
+            </label>
+            <label>
+              <span>伤害波动基线</span>
+              <input type="number" step="0.01" value="${config.damage.varianceBase}" data-role="battle-balance-field" data-section="damage" data-field="varianceBase" />
+            </label>
+            <label>
+              <span>伤害波动范围</span>
+              <input type="number" step="0.01" value="${config.damage.varianceRange}" data-role="battle-balance-field" data-section="damage" data-field="varianceRange" />
+            </label>
+          </div>
+        </article>
+        <article class="skill-editor-card">
+          <div class="skill-editor-card-head">
+            <div>
+              <strong>遭遇战环境</strong>
+              <span>environment</span>
+            </div>
+            <span class="config-badge">路障 / 陷阱</span>
+          </div>
+          <div class="skill-editor-fields">
+            <label>
+              <span>路障生成阈值</span>
+              <input type="number" min="0" max="1" step="0.01" value="${config.environment.blockerSpawnThreshold}" data-role="battle-balance-field" data-section="environment" data-field="blockerSpawnThreshold" />
+            </label>
+            <label>
+              <span>路障耐久</span>
+              <input type="number" min="1" step="1" value="${config.environment.blockerDurability}" data-role="battle-balance-field" data-section="environment" data-field="blockerDurability" />
+            </label>
+            <label>
+              <span>陷阱生成阈值</span>
+              <input type="number" min="0" max="1" step="0.01" value="${config.environment.trapSpawnThreshold}" data-role="battle-balance-field" data-section="environment" data-field="trapSpawnThreshold" />
+            </label>
+            <label>
+              <span>陷阱伤害</span>
+              <input type="number" min="0" step="1" value="${config.environment.trapDamage}" data-role="battle-balance-field" data-section="environment" data-field="trapDamage" />
+            </label>
+            <label>
+              <span>陷阱次数</span>
+              <input type="number" min="1" step="1" value="${config.environment.trapCharges}" data-role="battle-balance-field" data-section="environment" data-field="trapCharges" />
+            </label>
+            <label class="is-wide">
+              <span>伤害型陷阱附加状态</span>
+              <input type="text" value="${escapeHtml(config.environment.trapGrantedStatusId ?? "")}" data-role="battle-balance-status" data-field="trapGrantedStatusId" placeholder="例如 weakened；留空则不附带状态" />
+            </label>
+          </div>
+        </article>
+        <article class="skill-editor-card">
+          <div class="skill-editor-card-head">
+            <div>
+              <strong>PVP 参数</strong>
+              <span>pvp</span>
+            </div>
+            <span class="config-badge">匹配结算</span>
+          </div>
+          <div class="skill-editor-fields">
+            <label>
+              <span>ELO K 因子</span>
+              <input type="number" min="1" step="1" value="${config.pvp.eloK}" data-role="battle-balance-field" data-section="pvp" data-field="eloK" />
+            </label>
+          </div>
+        </article>
+      </div>
+    </section>
+  `;
+}
+
 function renderValidationSection(): string {
   if (!state.current) {
     return "";
@@ -1622,6 +1822,7 @@ function renderPreviewContent(): string {
     ${renderExportSection()}
     ${renderWorldPreviewSection()}
     ${renderBattleSkillEditorSection()}
+    ${renderBattleBalanceEditorSection()}
   `;
 }
 
@@ -1814,6 +2015,52 @@ function bindSkillEditorControls(): void {
   });
 }
 
+function bindBattleBalanceEditorControls(): void {
+  document.querySelectorAll<HTMLInputElement>("[data-role='battle-balance-field']").forEach((field) => {
+    field.onchange = () => {
+      const section = field.dataset.section as "damage" | "environment" | "pvp" | undefined;
+      const key = field.dataset.field;
+      if (!section || !key) {
+        return;
+      }
+
+      updateBattleBalanceDraft((config) => {
+        const numericValue = Number(field.value);
+        const nextValue =
+          key === "blockerDurability" || key === "trapDamage" || key === "trapCharges" || key === "eloK"
+            ? Math.floor(Number.isFinite(numericValue) ? numericValue : 0)
+            : Number.isFinite(numericValue)
+              ? numericValue
+              : 0;
+
+        if (section === "damage") {
+          config.damage[key as keyof BattleBalanceConfig["damage"]] = nextValue;
+        } else if (section === "environment") {
+          config.environment[key as Exclude<keyof BattleBalanceConfig["environment"], "trapGrantedStatusId">] = nextValue;
+        } else {
+          config.pvp[key as keyof BattleBalanceConfig["pvp"]] = nextValue;
+        }
+
+        return config;
+      });
+    };
+  });
+
+  document.querySelectorAll<HTMLInputElement>("[data-role='battle-balance-status']").forEach((field) => {
+    field.onchange = () => {
+      updateBattleBalanceDraft((config) => {
+        const nextValue = field.value.trim();
+        if (nextValue) {
+          config.environment.trapGrantedStatusId = nextValue;
+        } else {
+          delete config.environment.trapGrantedStatusId;
+        }
+        return config;
+      });
+    };
+  });
+}
+
 function refreshPreviewPane(): void {
   const preview = document.querySelector<HTMLDivElement>("[data-role='preview-content']");
   if (!preview) {
@@ -1823,6 +2070,7 @@ function refreshPreviewPane(): void {
   preview.innerHTML = renderPreviewContent();
   bindPreviewControls();
   bindSkillEditorControls();
+  bindBattleBalanceEditorControls();
 }
 
 function refreshLivePanels(): void {

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -4,16 +4,20 @@ import { resolve } from "node:path";
 import { createPool, type Pool, type RowDataPacket } from "mysql2/promise";
 import * as XLSX from "xlsx";
 import {
+  getBattleBalanceConfig,
   createWorldStateFromConfigs,
+  getDefaultBattleBalanceConfig,
   getDefaultBattleSkillCatalog,
   getDefaultMapObjectsConfig,
   getDefaultUnitCatalog,
   getDefaultWorldConfig,
   replaceRuntimeConfigs,
+  validateBattleBalanceConfig,
   validateBattleSkillCatalog,
   validateMapObjectsConfig,
   validateUnitCatalog,
   validateWorldConfig,
+  type BattleBalanceConfig,
   type BattleSkillCatalogConfig,
   type MapObjectsConfig,
   type ResourceKind,
@@ -29,7 +33,7 @@ import {
   readMySqlPersistenceConfig
 } from "./persistence";
 
-export type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills";
+export type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
 
 interface ConfigDefinition {
   id: ConfigDocumentId;
@@ -38,7 +42,12 @@ interface ConfigDefinition {
   description: string;
 }
 
-type ParsedConfigDocument = WorldGenerationConfig | MapObjectsConfig | UnitCatalogConfig | BattleSkillCatalogConfig;
+type ParsedConfigDocument =
+  | WorldGenerationConfig
+  | MapObjectsConfig
+  | UnitCatalogConfig
+  | BattleSkillCatalogConfig
+  | BattleBalanceConfig;
 
 interface ErrorPayload {
   code: string;
@@ -240,6 +249,12 @@ const CONFIG_DEFINITIONS: ConfigDefinition[] = [
     fileName: "battle-skills.json",
     title: "技能配置",
     description: "战斗技能、持续状态与效果公式。"
+  },
+  {
+    id: "battleBalance",
+    fileName: "battle-balance.json",
+    title: "战斗平衡",
+    description: "伤害公式、战场环境和 PVP ELO 参数。"
   }
 ];
 
@@ -535,6 +550,59 @@ const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
             defenseModifier: { type: "integer", description: "防御修正。" },
             damagePerTurn: { type: "integer", minimum: 0, description: "每回合伤害。" }
           }
+        }
+      }
+    }
+  },
+  battleBalance: {
+    type: "object",
+    title: "Battle Balance Config",
+    description: "战斗公式、环境生成阈值和 PVP 参数。",
+    required: ["damage", "environment", "pvp"],
+    properties: {
+      damage: {
+        type: "object",
+        description: "伤害公式参数。",
+        required: [
+          "defendingDefenseBonus",
+          "offenseAdvantageStep",
+          "minimumOffenseMultiplier",
+          "varianceBase",
+          "varianceRange"
+        ],
+        properties: {
+          defendingDefenseBonus: { type: "number", description: "防守指令提供的额外防御值。" },
+          offenseAdvantageStep: { type: "number", description: "攻防差每点带来的伤害修正步进。" },
+          minimumOffenseMultiplier: { type: "number", minimum: 0.01, description: "伤害倍率下限。" },
+          varianceBase: { type: "number", minimum: 0.01, description: "伤害波动基础值。" },
+          varianceRange: { type: "number", minimum: 0, description: "伤害波动区间。" }
+        }
+      },
+      environment: {
+        type: "object",
+        description: "遭遇战环境生成参数。",
+        required: [
+          "blockerSpawnThreshold",
+          "blockerDurability",
+          "trapSpawnThreshold",
+          "trapDamage",
+          "trapCharges"
+        ],
+        properties: {
+          blockerSpawnThreshold: { type: "number", minimum: 0, description: "路障生成阈值，范围 0-1。" },
+          blockerDurability: { type: "integer", minimum: 1, description: "路障耐久。" },
+          trapSpawnThreshold: { type: "number", minimum: 0, description: "陷阱生成阈值，范围 0-1。" },
+          trapDamage: { type: "integer", minimum: 0, description: "伤害型陷阱的基础伤害。" },
+          trapCharges: { type: "integer", minimum: 1, description: "陷阱可触发次数。" },
+          trapGrantedStatusId: { type: "string", description: "伤害型陷阱附加的状态 id，可选。" }
+        }
+      },
+      pvp: {
+        type: "object",
+        description: "PVP 匹配与结算参数。",
+        required: ["eloK"],
+        properties: {
+          eloK: { type: "integer", minimum: 1, description: "ELO K 因子。" }
         }
       }
     }
@@ -1121,12 +1189,17 @@ function buildSummary(id: ConfigDocumentId, parsed: unknown): string {
     return `${config.templates.length} unit template(s)`;
   }
 
-  const config = parsed as BattleSkillCatalogConfig;
-  return `${config.skills.length} skill(s) · ${config.statuses.length} status(es)`;
+  if (id === "battleSkills") {
+    const config = parsed as BattleSkillCatalogConfig;
+    return `${config.skills.length} skill(s) · ${config.statuses.length} status(es)`;
+  }
+
+  const config = parsed as BattleBalanceConfig;
+  return `damage/env/pvp · K=${config.pvp.eloK} · trap=${config.environment.trapDamage}`;
 }
 
 function normalizeJsonContent(
-  parsed: WorldGenerationConfig | MapObjectsConfig | UnitCatalogConfig | BattleSkillCatalogConfig
+  parsed: ParsedConfigDocument
 ): string {
   return `${JSON.stringify(parsed, null, 2)}\n`;
 }
@@ -1281,6 +1354,50 @@ function applyBattleSkillPreset(
   };
 }
 
+function clampThreshold(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+function applyBattleBalancePreset(
+  config: BattleBalanceConfig,
+  presetId: typeof BUILTIN_PRESET_IDS[number]
+): BattleBalanceConfig {
+  if (presetId === "normal") {
+    return structuredClone(config);
+  }
+
+  const easier = presetId === "easy";
+
+  return {
+    damage: {
+      defendingDefenseBonus: config.damage.defendingDefenseBonus + (easier ? -1 : 1),
+      offenseAdvantageStep: Number((config.damage.offenseAdvantageStep * (easier ? 0.92 : 1.08)).toFixed(3)),
+      minimumOffenseMultiplier: Number(
+        Math.max(0.1, config.damage.minimumOffenseMultiplier * (easier ? 1.05 : 0.9)).toFixed(2)
+      ),
+      varianceBase: Number(config.damage.varianceBase.toFixed(2)),
+      varianceRange: Number(Math.max(0, config.damage.varianceRange * (easier ? 0.9 : 1.1)).toFixed(2))
+    },
+    environment: {
+      blockerSpawnThreshold: clampThreshold(
+        Math.min(1, Math.max(0, config.environment.blockerSpawnThreshold + (easier ? 0.08 : -0.08)))
+      ),
+      blockerDurability: Math.max(1, config.environment.blockerDurability + (easier ? -1 : 1)),
+      trapSpawnThreshold: clampThreshold(
+        Math.min(1, Math.max(0, config.environment.trapSpawnThreshold + (easier ? 0.08 : -0.08)))
+      ),
+      trapDamage: Math.max(0, config.environment.trapDamage + (easier ? -1 : 1)),
+      trapCharges: Math.max(1, config.environment.trapCharges + (easier ? -1 : 1)),
+      ...(config.environment.trapGrantedStatusId
+        ? { trapGrantedStatusId: config.environment.trapGrantedStatusId }
+        : {})
+    },
+    pvp: {
+      eloK: Math.max(1, config.pvp.eloK + (easier ? -4 : 4))
+    }
+  };
+}
+
 function applyBuiltinPresetToContent(
   id: ConfigDocumentId,
   content: string,
@@ -1294,7 +1411,9 @@ function applyBuiltinPresetToContent(
         ? applyMapObjectsPreset(parsed as MapObjectsConfig, presetId)
         : id === "units"
           ? applyUnitPreset(parsed as UnitCatalogConfig, presetId)
-          : applyBattleSkillPreset(parsed as BattleSkillCatalogConfig, presetId);
+          : id === "battleSkills"
+            ? applyBattleSkillPreset(parsed as BattleSkillCatalogConfig, presetId)
+            : applyBattleBalancePreset(parsed as BattleBalanceConfig, presetId);
 
   return normalizeJsonContent(next);
 }
@@ -1355,9 +1474,15 @@ function parseConfigDocument(
     return nextCatalog;
   }
 
-  const nextSkillCatalog = parsed as BattleSkillCatalogConfig;
-  validateBattleSkillCatalog(nextSkillCatalog);
-  return nextSkillCatalog;
+  if (id === "battleSkills") {
+    const nextSkillCatalog = parsed as BattleSkillCatalogConfig;
+    validateBattleSkillCatalog(nextSkillCatalog);
+    return nextSkillCatalog;
+  }
+
+  const nextBattleBalance = parsed as BattleBalanceConfig;
+  validateBattleBalanceConfig(nextBattleBalance);
+  return nextBattleBalance;
 }
 
 function buildRuntimeBundleWithParsedDocument(id: ConfigDocumentId, parsed: ParsedConfigDocument): RuntimeConfigBundle {
@@ -1370,6 +1495,23 @@ function buildRuntimeBundleWithParsedDocument(id: ConfigDocumentId, parsed: Pars
       return buildRuntimeConfigBundle({ units: parsed as UnitCatalogConfig });
     case "battleSkills":
       return buildRuntimeConfigBundle({ battleSkills: parsed as BattleSkillCatalogConfig });
+    case "battleBalance":
+      return buildRuntimeConfigBundle({ battleBalance: parsed as BattleBalanceConfig });
+  }
+}
+
+function contentForDocumentId(bundle: RuntimeConfigBundle, id: ConfigDocumentId): ParsedConfigDocument {
+  switch (id) {
+    case "world":
+      return bundle.world;
+    case "mapObjects":
+      return bundle.mapObjects;
+    case "units":
+      return bundle.units;
+    case "battleSkills":
+      return bundle.battleSkills;
+    case "battleBalance":
+      return bundle.battleBalance ?? getBattleBalanceConfig();
   }
 }
 
@@ -1511,17 +1653,20 @@ function buildRuntimeConfigBundle(
   const mapObjects = documents.mapObjects ?? getDefaultMapObjectsConfig();
   const units = documents.units ?? getDefaultUnitCatalog();
   const battleSkills = documents.battleSkills ?? getDefaultBattleSkillCatalog();
+  const battleBalance = documents.battleBalance ?? getBattleBalanceConfig();
 
   validateWorldConfig(world);
   validateMapObjectsConfig(mapObjects, world, units);
   validateBattleSkillCatalog(battleSkills);
   validateUnitCatalog(units, battleSkills);
+  validateBattleBalanceConfig(battleBalance, battleSkills);
 
   return {
     world,
     mapObjects,
     units,
-    battleSkills
+    battleSkills,
+    battleBalance
   };
 }
 
@@ -1559,12 +1704,14 @@ async function loadValidationDependencies(
   mapObjects: MapObjectsConfig;
   units: UnitCatalogConfig;
   battleSkills: BattleSkillCatalogConfig;
+  battleBalance: BattleBalanceConfig;
 }> {
-  const [worldDocument, mapObjectsDocument, unitsDocument, battleSkillsDocument] = await Promise.all([
+  const [worldDocument, mapObjectsDocument, unitsDocument, battleSkillsDocument, battleBalanceDocument] = await Promise.all([
     id === "world" ? Promise.resolve(null) : store.loadDocument("world"),
     id === "mapObjects" ? Promise.resolve(null) : store.loadDocument("mapObjects"),
     id === "units" ? Promise.resolve(null) : store.loadDocument("units"),
-    id === "battleSkills" ? Promise.resolve(null) : store.loadDocument("battleSkills")
+    id === "battleSkills" ? Promise.resolve(null) : store.loadDocument("battleSkills"),
+    id === "battleBalance" ? Promise.resolve(null) : store.loadDocument("battleBalance")
   ]);
 
   return {
@@ -1589,7 +1736,14 @@ async function loadValidationDependencies(
         : (parseConfigDocument(
             "battleSkills",
             battleSkillsDocument?.content ?? normalizeJsonContent(getDefaultBattleSkillCatalog())
-          ) as BattleSkillCatalogConfig)
+          ) as BattleSkillCatalogConfig),
+    battleBalance:
+      id === "battleBalance"
+        ? getDefaultBattleBalanceConfig()
+        : (parseConfigDocument(
+            "battleBalance",
+            battleBalanceDocument?.content ?? normalizeJsonContent(getDefaultBattleBalanceConfig())
+          ) as BattleBalanceConfig)
   };
 }
 
@@ -1857,6 +2011,59 @@ function validateBattleSkillsDetailed(config: BattleSkillCatalogConfig): Validat
   return issues;
 }
 
+function validateBattleBalanceDetailed(
+  config: BattleBalanceConfig,
+  battleSkills: BattleSkillCatalogConfig
+): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const statusIds = new Set(battleSkills.statuses.map((status) => status.id));
+
+  if (config.damage.minimumOffenseMultiplier > 1) {
+    pushIssue(issues, {
+      path: "damage.minimumOffenseMultiplier",
+      message: "最低伤害倍率通常不应高于 1。",
+      suggestion: "将 minimumOffenseMultiplier 调整到 0-1 区间内。"
+    });
+  }
+
+  if (config.damage.varianceBase + config.damage.varianceRange <= 0) {
+    pushIssue(issues, {
+      path: "damage.varianceRange",
+      message: "伤害波动上界必须大于 0。",
+      suggestion: "提高 varianceBase 或 varianceRange，避免最终伤害倍率恒为非正数。"
+    });
+  }
+
+  if (config.environment.blockerSpawnThreshold > 1) {
+    pushIssue(issues, {
+      path: "environment.blockerSpawnThreshold",
+      message: "路障生成阈值必须在 0-1 之间。",
+      suggestion: "将 blockerSpawnThreshold 调整到 0-1。"
+    });
+  }
+
+  if (config.environment.trapSpawnThreshold > 1) {
+    pushIssue(issues, {
+      path: "environment.trapSpawnThreshold",
+      message: "陷阱生成阈值必须在 0-1 之间。",
+      suggestion: "将 trapSpawnThreshold 调整到 0-1。"
+    });
+  }
+
+  if (
+    config.environment.trapGrantedStatusId &&
+    !statusIds.has(config.environment.trapGrantedStatusId)
+  ) {
+    pushIssue(issues, {
+      path: "environment.trapGrantedStatusId",
+      message: `陷阱附加状态 ${config.environment.trapGrantedStatusId} 不存在于 battle-skills.json。`,
+      suggestion: "改为 statuses 中已有的状态 id，或先在技能配置里创建该状态。"
+    });
+  }
+
+  return issues;
+}
+
 async function validateDocumentDetailed(
   store: Pick<ConfigCenterStore, "loadDocument">,
   id: ConfigDocumentId,
@@ -1882,7 +2089,12 @@ async function validateDocumentDetailed(
                   parsed as UnitCatalogConfig,
                   dependencies.battleSkills
                 )
-              : validateBattleSkillsDetailed(parsed as BattleSkillCatalogConfig);
+              : id === "battleSkills"
+                ? validateBattleSkillsDetailed(parsed as BattleSkillCatalogConfig)
+                : validateBattleBalanceDetailed(
+                    parsed as BattleBalanceConfig,
+                    dependencies.battleSkills
+                  );
       issues.push(...semanticIssues);
     } catch {
       // Schema issues above already explain malformed structures; skip dependent semantic checks.
@@ -2023,7 +2235,8 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
       this.exportDocumentToFile("world", normalizeJsonContent(bundle.world)),
       this.exportDocumentToFile("mapObjects", normalizeJsonContent(bundle.mapObjects)),
       this.exportDocumentToFile("units", normalizeJsonContent(bundle.units)),
-      this.exportDocumentToFile("battleSkills", normalizeJsonContent(bundle.battleSkills))
+      this.exportDocumentToFile("battleSkills", normalizeJsonContent(bundle.battleSkills)),
+      this.exportDocumentToFile("battleBalance", normalizeJsonContent(contentForDocumentId(bundle, "battleBalance")))
     ]);
   }
 
@@ -2217,7 +2430,7 @@ export class FileSystemConfigCenterStore extends BaseConfigCenterStore {
   async saveDocument(id: ConfigDocumentId, content: string): Promise<ConfigDocument> {
     const parsed = parseConfigDocument(id, content);
     const bundle = buildRuntimeBundleWithParsedDocument(id, parsed);
-    const serialized = normalizeJsonContent(bundle[id]);
+    const serialized = normalizeJsonContent(contentForDocumentId(bundle, id));
     const current = await this.loadDocument(id);
 
     if (current.content === serialized) {
@@ -2299,7 +2512,7 @@ export class MySqlConfigCenterStore extends BaseConfigCenterStore {
   async saveDocument(id: ConfigDocumentId, content: string): Promise<ConfigDocument> {
     const parsed = parseConfigDocument(id, content);
     const bundle = buildRuntimeBundleWithParsedDocument(id, parsed);
-    const serialized = normalizeJsonContent(bundle[id]);
+    const serialized = normalizeJsonContent(contentForDocumentId(bundle, id));
     const current = await this.loadDocument(id);
 
     if (current.content === serialized) {

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 import * as XLSX from "xlsx";
 import {
+  getBattleBalanceConfig,
   getDefaultBattleSkillCatalog,
   getDefaultWorldConfig,
   resetRuntimeConfigs
@@ -192,11 +193,33 @@ const BATTLE_SKILL_CONFIG = {
   ]
 };
 
+const BATTLE_BALANCE_CONFIG = {
+  damage: {
+    defendingDefenseBonus: 5,
+    offenseAdvantageStep: 0.05,
+    minimumOffenseMultiplier: 0.3,
+    varianceBase: 0.9,
+    varianceRange: 0.2
+  },
+  environment: {
+    blockerSpawnThreshold: 0.62,
+    blockerDurability: 1,
+    trapSpawnThreshold: 0.58,
+    trapDamage: 1,
+    trapCharges: 1,
+    trapGrantedStatusId: "poisoned"
+  },
+  pvp: {
+    eloK: 32
+  }
+};
+
 async function seedConfigRoot(rootDir: string): Promise<void> {
   await writeFile(join(rootDir, "phase1-world.json"), `${JSON.stringify(WORLD_CONFIG, null, 2)}\n`, "utf8");
   await writeFile(join(rootDir, "phase1-map-objects.json"), `${JSON.stringify(MAP_OBJECTS_CONFIG, null, 2)}\n`, "utf8");
   await writeFile(join(rootDir, "units.json"), `${JSON.stringify(UNIT_CONFIG, null, 2)}\n`, "utf8");
   await writeFile(join(rootDir, "battle-skills.json"), `${JSON.stringify(BATTLE_SKILL_CONFIG, null, 2)}\n`, "utf8");
+  await writeFile(join(rootDir, "battle-balance.json"), `${JSON.stringify(BATTLE_BALANCE_CONFIG, null, 2)}\n`, "utf8");
 }
 
 test.afterEach(() => {
@@ -212,7 +235,7 @@ test("config center lists seeded config documents", async () => {
 
   assert.deepEqual(
     items.map((item) => item.id),
-    ["world", "mapObjects", "units", "battleSkills"]
+    ["world", "mapObjects", "units", "battleSkills", "battleBalance"]
   );
   assert.match(items[0]?.summary ?? "", /8x8/);
 });
@@ -264,6 +287,35 @@ test("config center save writes battle skills file and refreshes runtime skill c
   assert.match(fileContent, /"重弩射击"/);
   assert.equal(powerShot?.name, "重弩射击");
   assert.equal(powerShot?.cooldown, 1);
+});
+
+test("config center save writes battle balance file and refreshes runtime battle balance", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+  await store.initializeRuntimeConfigs();
+
+  const nextBalance = {
+    ...BATTLE_BALANCE_CONFIG,
+    environment: {
+      ...BATTLE_BALANCE_CONFIG.environment,
+      trapDamage: 3,
+      trapCharges: 2
+    },
+    pvp: {
+      eloK: 28
+    }
+  };
+
+  const document = await store.saveDocument("battleBalance", JSON.stringify(nextBalance));
+  const fileContent = await readFile(join(rootDir, "battle-balance.json"), "utf8");
+  const runtimeBalance = getBattleBalanceConfig();
+
+  assert.equal(document.id, "battleBalance");
+  assert.match(fileContent, /"trapDamage": 3/);
+  assert.equal(runtimeBalance.environment.trapDamage, 3);
+  assert.equal(runtimeBalance.environment.trapCharges, 2);
+  assert.equal(runtimeBalance.pvp.eloK, 28);
 });
 
 test("config center rejects map objects that exceed current world bounds", async () => {
@@ -367,6 +419,31 @@ test("config center schema validation reports missing and mistyped fields", asyn
   assert.equal(report.valid, false);
   assert.match(report.issues.map((issue) => issue.path).join(","), /statuses|skills\[0\]\.kind|skills\[0\]\.cooldown/);
   assert.equal(report.schema.id, "project-veil.config-center.battleSkills");
+});
+
+test("config center validates battle balance against thresholds and status references", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  const report = await store.validateDocument(
+    "battleBalance",
+    JSON.stringify({
+      ...BATTLE_BALANCE_CONFIG,
+      environment: {
+        ...BATTLE_BALANCE_CONFIG.environment,
+        trapSpawnThreshold: 1.2,
+        trapGrantedStatusId: "missing_status"
+      }
+    })
+  );
+
+  assert.equal(report.valid, false);
+  assert.match(
+    report.issues.map((issue) => issue.path).join(","),
+    /environment\.trapSpawnThreshold|environment\.trapGrantedStatusId/
+  );
+  assert.equal(report.schema.id, "project-veil.config-center.battleBalance");
 });
 
 test("config center snapshots support diff and rollback", async () => {

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -660,6 +660,10 @@ export function getBattleBalanceConfig(): BattleBalanceConfig {
   return config;
 }
 
+export function getDefaultBattleBalanceConfig(): BattleBalanceConfig {
+  return getBattleBalanceConfig();
+}
+
 export function getDefaultHeroSkillTreeConfig(): HeroSkillTreeConfig {
   const config = cloneHeroSkillTreeConfig(runtimeHeroSkillTree);
   validateHeroSkillTreeConfig(config);


### PR DESCRIPTION
## Summary
- 将 battle-balance.json 接入配置中心 document registry、schema、导入导出、预设、快照与运行时刷新链路
- 在配置中心右侧新增 battle balance 结构化编辑器，覆盖伤害公式、遭遇战环境和 PVP ELO 参数
- 补充 battle balance 相关验证、运行时回归测试与 README 使用说明

## Testing
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:client:h5
- node --import tsx --test ./apps/server/test/config-center.test.ts ./packages/shared/test/shared-core.test.ts
- npm run validate:battle

Closes #142