### PR TITLE
Implement issue #146 frontier basin content pack

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/map.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map.ts
@@ -34,7 +34,7 @@ import {
   normalizeHeroState,
   totalExperienceRequiredForLevel
 } from "./models.ts";
-import { getDefaultMapObjectsConfig, getDefaultWorldConfig } from "./world-config.ts";
+import { getRuntimeConfigBundleForRoom } from "./world-config.ts";
 import {
   validateMapObjectsConfig,
   validateWorldConfig
@@ -112,8 +112,8 @@ function maybeAwardBattleEquipmentDrop(
   };
 }
 
-function createTerrainTile(position: Vec2, roll: number): TileState {
-  const terrain = roll < 0.55 ? "grass" : roll < 0.75 ? "dirt" : roll < 0.92 ? "sand" : "water";
+function createTerrainTile(position: Vec2, roll: number, forcedTerrain?: TileState["terrain"]): TileState {
+  const terrain = forcedTerrain ?? (roll < 0.55 ? "grass" : roll < 0.75 ? "dirt" : roll < 0.92 ? "sand" : "water");
   return {
     position,
     terrain,
@@ -1293,15 +1293,19 @@ export function createWorldStateFromConfigs(
     ...patrolWaypointKeys,
     ...mapObjects.buildings.map((building) => tileKey(building.position))
   ]);
+  const terrainOverrides = new Map(
+    (config.terrainOverrides ?? []).map((override) => [tileKey(override.position), override.terrain] as const)
+  );
 
   const tiles: TileState[] = [];
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
       const position = { x, y };
       const key = tileKey(position);
+      const terrain = terrainOverrides.get(key);
       const tile = forcedWalkableKeys.has(key)
-        ? ensureTileIsWalkable(createTerrainTile(position, rng()))
-        : createTerrainTile(position, rng());
+        ? ensureTileIsWalkable(createTerrainTile(position, rng(), terrain))
+        : createTerrainTile(position, rng(), terrain);
       const guaranteedResource = mapObjects.guaranteedResources.find((item) => samePosition(item.position, { x, y }));
       if (guaranteedResource) {
         tile.resource = guaranteedResource.resource;
@@ -1345,7 +1349,15 @@ export function createWorldStateFromConfigs(
 }
 
 export function createInitialWorldState(seed = 1001, roomId = "room-alpha"): WorldState {
-  return createWorldStateFromConfigs(getDefaultWorldConfig(), getDefaultMapObjectsConfig(), seed, roomId);
+  const bundle = getRuntimeConfigBundleForRoom(roomId, seed);
+  const state = createWorldStateFromConfigs(bundle.world, bundle.mapObjects, seed, roomId);
+  return {
+    ...state,
+    meta: {
+      ...state.meta,
+      mapVariantId: bundle.mapVariantId
+    }
+  };
 }
 
 export function listReachableTiles(state: WorldState, heroId: string): Vec2[] {

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -295,6 +295,7 @@ export interface WorldMetaState {
   roomId: string;
   seed: number;
   day: number;
+  mapVariantId?: string;
 }
 
 export interface WorldState {
@@ -913,11 +914,17 @@ export interface ResourceSpawnConfig {
   oreChance: number;
 }
 
+export interface TerrainOverrideConfig {
+  position: Vec2;
+  terrain: TerrainType;
+}
+
 export interface WorldGenerationConfig {
   width: number;
   height: number;
   heroes: HeroConfig[];
   resourceSpawn: ResourceSpawnConfig;
+  terrainOverrides?: TerrainOverrideConfig[];
 }
 
 export interface MapObjectsConfig {

--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -1,8 +1,10 @@
 import defaultBattleSkillsConfig from "../../../../../configs/battle-skills.json";
 import defaultBattleBalanceConfig from "../../../../../configs/battle-balance.json";
 import defaultHeroSkillTreesConfig from "../../../../../configs/hero-skill-trees-full.json";
+import frontierBasinMapObjectsConfig from "../../../../../configs/phase1-map-objects-frontier-basin.json";
 import defaultMapObjectsConfig from "../../../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../../../configs/units.json";
+import frontierBasinWorldConfig from "../../../../../configs/phase1-world-frontier-basin.json";
 import defaultWorldConfig from "../../../../../configs/phase1-world.json";
 import type {
   BattleSkillCatalogConfig,
@@ -14,6 +16,7 @@ import type {
   NeutralBehaviorMode,
   ResourceLedger,
   ResourceNode,
+  TerrainType,
   UnitCatalogConfig,
   WorldGenerationConfig
 } from "./models.ts";
@@ -25,12 +28,19 @@ let runtimeBattleSkillCatalog: BattleSkillCatalogConfig = structuredClone(defaul
 let runtimeBattleBalanceConfig: BattleBalanceConfig = structuredClone(defaultBattleBalanceConfig as BattleBalanceConfig);
 let runtimeHeroSkillTree: HeroSkillTreeConfig = structuredClone(defaultHeroSkillTreesConfig as HeroSkillTreeConfig);
 
+export const DEFAULT_MAP_VARIANT_ID = "phase1";
+export const FRONTIER_BASIN_MAP_VARIANT_ID = "frontier_basin";
+
 export interface RuntimeConfigBundle {
   world: WorldGenerationConfig;
   mapObjects: MapObjectsConfig;
   units: UnitCatalogConfig;
   battleSkills: BattleSkillCatalogConfig;
   battleBalance?: BattleBalanceConfig;
+}
+
+export interface RoomRuntimeConfigBundle extends RuntimeConfigBundle {
+  mapVariantId: string;
 }
 
 function cloneWorldConfig(config: WorldGenerationConfig): WorldGenerationConfig {
@@ -118,6 +128,10 @@ function isNonEmptyString(value: unknown): value is string {
 
 function isResourceKind(value: unknown): value is "gold" | "wood" | "ore" {
   return value === "gold" || value === "wood" || value === "ore";
+}
+
+function isTerrainType(value: unknown): value is TerrainType {
+  return value === "grass" || value === "dirt" || value === "sand" || value === "water";
 }
 
 function isNeutralBehaviorMode(value: unknown): value is NeutralBehaviorMode {
@@ -404,6 +418,27 @@ export function validateWorldConfig(config: WorldGenerationConfig): void {
       }
     }
   }
+
+  const occupiedTerrainOverrides = new Set<string>();
+  for (const override of config.terrainOverrides ?? []) {
+    if (!isTerrainType(override.terrain)) {
+      throw new Error(`World config terrain override has invalid terrain: ${String(override.terrain)}`);
+    }
+    if (
+      override.position.x < 0 ||
+      override.position.y < 0 ||
+      override.position.x >= config.width ||
+      override.position.y >= config.height
+    ) {
+      throw new Error("World config terrain override exceeds map bounds");
+    }
+
+    const key = `${override.position.x},${override.position.y}`;
+    if (occupiedTerrainOverrides.has(key)) {
+      throw new Error(`Duplicate terrain override at ${key}`);
+    }
+    occupiedTerrainOverrides.add(key);
+  }
 }
 
 export function validateMapObjectsConfig(
@@ -658,6 +693,66 @@ export function getDefaultHeroSkillTreeConfig(): HeroSkillTreeConfig {
   const config = cloneHeroSkillTreeConfig(runtimeHeroSkillTree);
   validateHeroSkillTreeConfig(config);
   return config;
+}
+
+function hashVariantSeed(value: string, seed: number): number {
+  let hash = seed >>> 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = Math.imul(hash ^ value.charCodeAt(index), 16777619) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+function parseRequestedMapVariantId(roomId: string): string | undefined {
+  const match = roomId.match(/\[map:([a-z0-9_-]+)\]/i);
+  return match?.[1]?.toLowerCase();
+}
+
+function getAvailableMapVariantIds(): string[] {
+  return [DEFAULT_MAP_VARIANT_ID, FRONTIER_BASIN_MAP_VARIANT_ID];
+}
+
+export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string {
+  const requested = parseRequestedMapVariantId(roomId);
+  if (!requested) {
+    return DEFAULT_MAP_VARIANT_ID;
+  }
+  if (requested === "random") {
+    const variants = getAvailableMapVariantIds();
+    return variants[hashVariantSeed(roomId, seed) % variants.length] ?? DEFAULT_MAP_VARIANT_ID;
+  }
+  if (requested === DEFAULT_MAP_VARIANT_ID || requested === FRONTIER_BASIN_MAP_VARIANT_ID) {
+    return requested;
+  }
+  return DEFAULT_MAP_VARIANT_ID;
+}
+
+export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): RoomRuntimeConfigBundle {
+  const mapVariantId = resolveMapVariantIdForRoom(roomId, seed);
+  const units = getDefaultUnitCatalog();
+  const battleSkills = getDefaultBattleSkillCatalog();
+  const battleBalance = getBattleBalanceConfig();
+
+  const world =
+    mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
+      ? cloneWorldConfig(frontierBasinWorldConfig as WorldGenerationConfig)
+      : getDefaultWorldConfig();
+  const mapObjects =
+    mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
+      ? cloneMapObjectsConfig(frontierBasinMapObjectsConfig as MapObjectsConfig)
+      : getDefaultMapObjectsConfig();
+
+  validateWorldConfig(world);
+  validateMapObjectsConfig(mapObjects, world, units);
+
+  return {
+    mapVariantId,
+    world,
+    mapObjects,
+    units,
+    battleSkills,
+    battleBalance
+  };
 }
 
 export function setWorldConfig(config: WorldGenerationConfig): void {

--- a/configs/phase1-map-objects-frontier-basin.json
+++ b/configs/phase1-map-objects-frontier-basin.json
@@ -1,0 +1,210 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": {
+        "x": 5,
+        "y": 4
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 300
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 8
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolRadius": 4,
+        "detectionRadius": 5,
+        "chaseDistance": 10,
+        "speed": 2
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": {
+        "x": 4,
+        "y": 5
+      },
+      "reward": {
+        "kind": "ore",
+        "amount": 4
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 5
+        },
+        {
+          "templateId": "wolf_pack",
+          "count": 3
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": {
+        "x": 6,
+        "y": 3
+      },
+      "reward": {
+        "kind": "wood",
+        "amount": 6
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 6
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolRadius": 1,
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": {
+        "x": 1,
+        "y": 6
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 220
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 7
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    {
+      "position": {
+        "x": 2,
+        "y": 1
+      },
+      "resource": {
+        "kind": "wood",
+        "amount": 5
+      }
+    },
+    {
+      "position": {
+        "x": 6,
+        "y": 5
+      },
+      "resource": {
+        "kind": "ore",
+        "amount": 4
+      }
+    }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 1,
+        "y": 3
+      },
+      "label": "前线招募所",
+      "unitTemplateId": "hero_guard_basic",
+      "recruitCount": 4,
+      "cost": {
+        "gold": 240,
+        "wood": 0,
+        "ore": 0
+      }
+    },
+    {
+      "id": "shrine-attack-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 3,
+        "y": 2
+      },
+      "label": "战旗圣坛",
+      "bonus": {
+        "attack": 2,
+        "defense": 0,
+        "power": 0,
+        "knowledge": 0
+      }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 3,
+        "y": 1
+      },
+      "label": "前线伐木场",
+      "resourceKind": "wood",
+      "income": 5
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 6,
+        "y": 1
+      },
+      "label": "峡口哨募站",
+      "unitTemplateId": "hero_guard_basic",
+      "recruitCount": 3,
+      "cost": {
+        "gold": 180,
+        "wood": 1,
+        "ore": 0
+      }
+    },
+    {
+      "id": "shrine-knowledge-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 4,
+        "y": 2
+      },
+      "label": "星纹观测坛",
+      "bonus": {
+        "attack": 0,
+        "defense": 0,
+        "power": 1,
+        "knowledge": 1
+      }
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 1,
+        "y": 5
+      },
+      "label": "裂谷矿井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-world-frontier-basin.json
+++ b/configs/phase1-world-frontier-basin.json
@@ -1,0 +1,171 @@
+{
+  "width": 8,
+  "height": 8,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": {
+        "x": 1,
+        "y": 1
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "militia_pike",
+          "vanguard_blade",
+          "padded_gambeson",
+          "scout_compass"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": {
+        "x": 6,
+        "y": 6
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "oak_longbow",
+          "tower_shield_mail",
+          "scribe_charm",
+          "captains_insignia"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.06,
+    "woodChance": 0.06,
+    "oreChance": 0.06
+  },
+  "terrainOverrides": [
+    {
+      "position": { "x": 2, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 2, "y": 3 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 3 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 3 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 5, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 5, "y": 3 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 1, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 2, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 3, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 4, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 5, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 6, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 4, "y": 1 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 1 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 6, "y": 1 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 6, "y": 2 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 6, "y": 3 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 1, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 2, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 3, "y": 5 },
+      "terrain": "dirt"
+    }
+  ]
+}

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -34,7 +34,7 @@ import {
   normalizeHeroState,
   totalExperienceRequiredForLevel
 } from "./models.ts";
-import { getDefaultMapObjectsConfig, getDefaultWorldConfig } from "./world-config.ts";
+import { getRuntimeConfigBundleForRoom } from "./world-config.ts";
 import {
   validateMapObjectsConfig,
   validateWorldConfig
@@ -112,8 +112,8 @@ function maybeAwardBattleEquipmentDrop(
   };
 }
 
-function createTerrainTile(position: Vec2, roll: number): TileState {
-  const terrain = roll < 0.55 ? "grass" : roll < 0.75 ? "dirt" : roll < 0.92 ? "sand" : "water";
+function createTerrainTile(position: Vec2, roll: number, forcedTerrain?: TileState["terrain"]): TileState {
+  const terrain = forcedTerrain ?? (roll < 0.55 ? "grass" : roll < 0.75 ? "dirt" : roll < 0.92 ? "sand" : "water");
   return {
     position,
     terrain,
@@ -1293,15 +1293,19 @@ export function createWorldStateFromConfigs(
     ...patrolWaypointKeys,
     ...mapObjects.buildings.map((building) => tileKey(building.position))
   ]);
+  const terrainOverrides = new Map(
+    (config.terrainOverrides ?? []).map((override) => [tileKey(override.position), override.terrain] as const)
+  );
 
   const tiles: TileState[] = [];
   for (let y = 0; y < height; y += 1) {
     for (let x = 0; x < width; x += 1) {
       const position = { x, y };
       const key = tileKey(position);
+      const terrain = terrainOverrides.get(key);
       const tile = forcedWalkableKeys.has(key)
-        ? ensureTileIsWalkable(createTerrainTile(position, rng()))
-        : createTerrainTile(position, rng());
+        ? ensureTileIsWalkable(createTerrainTile(position, rng(), terrain))
+        : createTerrainTile(position, rng(), terrain);
       const guaranteedResource = mapObjects.guaranteedResources.find((item) => samePosition(item.position, { x, y }));
       if (guaranteedResource) {
         tile.resource = guaranteedResource.resource;
@@ -1345,7 +1349,15 @@ export function createWorldStateFromConfigs(
 }
 
 export function createInitialWorldState(seed = 1001, roomId = "room-alpha"): WorldState {
-  return createWorldStateFromConfigs(getDefaultWorldConfig(), getDefaultMapObjectsConfig(), seed, roomId);
+  const bundle = getRuntimeConfigBundleForRoom(roomId, seed);
+  const state = createWorldStateFromConfigs(bundle.world, bundle.mapObjects, seed, roomId);
+  return {
+    ...state,
+    meta: {
+      ...state.meta,
+      mapVariantId: bundle.mapVariantId
+    }
+  };
 }
 
 export function listReachableTiles(state: WorldState, heroId: string): Vec2[] {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -298,6 +298,7 @@ export interface WorldMetaState {
   roomId: string;
   seed: number;
   day: number;
+  mapVariantId?: string;
 }
 
 export interface WorldState {
@@ -916,11 +917,17 @@ export interface ResourceSpawnConfig {
   oreChance: number;
 }
 
+export interface TerrainOverrideConfig {
+  position: Vec2;
+  terrain: TerrainType;
+}
+
 export interface WorldGenerationConfig {
   width: number;
   height: number;
   heroes: HeroConfig[];
   resourceSpawn: ResourceSpawnConfig;
+  terrainOverrides?: TerrainOverrideConfig[];
 }
 
 export interface MapObjectsConfig {

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -1,8 +1,10 @@
 import defaultBattleSkillsConfig from "../../../configs/battle-skills.json";
 import defaultBattleBalanceConfig from "../../../configs/battle-balance.json";
 import defaultHeroSkillTreesConfig from "../../../configs/hero-skill-trees-full.json";
+import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
 import defaultMapObjectsConfig from "../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../configs/units.json";
+import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
 import defaultWorldConfig from "../../../configs/phase1-world.json";
 import type {
   BattleSkillCatalogConfig,
@@ -14,6 +16,7 @@ import type {
   NeutralBehaviorMode,
   ResourceLedger,
   ResourceNode,
+  TerrainType,
   UnitCatalogConfig,
   WorldGenerationConfig
 } from "./models.ts";
@@ -25,12 +28,19 @@ let runtimeBattleSkillCatalog: BattleSkillCatalogConfig = structuredClone(defaul
 let runtimeBattleBalanceConfig: BattleBalanceConfig = structuredClone(defaultBattleBalanceConfig as BattleBalanceConfig);
 let runtimeHeroSkillTree: HeroSkillTreeConfig = structuredClone(defaultHeroSkillTreesConfig as HeroSkillTreeConfig);
 
+export const DEFAULT_MAP_VARIANT_ID = "phase1";
+export const FRONTIER_BASIN_MAP_VARIANT_ID = "frontier_basin";
+
 export interface RuntimeConfigBundle {
   world: WorldGenerationConfig;
   mapObjects: MapObjectsConfig;
   units: UnitCatalogConfig;
   battleSkills: BattleSkillCatalogConfig;
   battleBalance?: BattleBalanceConfig;
+}
+
+export interface RoomRuntimeConfigBundle extends RuntimeConfigBundle {
+  mapVariantId: string;
 }
 
 function cloneWorldConfig(config: WorldGenerationConfig): WorldGenerationConfig {
@@ -118,6 +128,10 @@ function isNonEmptyString(value: unknown): value is string {
 
 function isResourceKind(value: unknown): value is "gold" | "wood" | "ore" {
   return value === "gold" || value === "wood" || value === "ore";
+}
+
+function isTerrainType(value: unknown): value is TerrainType {
+  return value === "grass" || value === "dirt" || value === "sand" || value === "water";
 }
 
 function isNeutralBehaviorMode(value: unknown): value is NeutralBehaviorMode {
@@ -410,6 +424,27 @@ export function validateWorldConfig(config: WorldGenerationConfig): void {
       }
     }
   }
+
+  const occupiedTerrainOverrides = new Set<string>();
+  for (const override of config.terrainOverrides ?? []) {
+    if (!isTerrainType(override.terrain)) {
+      throw new Error(`World config terrain override has invalid terrain: ${String(override.terrain)}`);
+    }
+    if (
+      override.position.x < 0 ||
+      override.position.y < 0 ||
+      override.position.x >= config.width ||
+      override.position.y >= config.height
+    ) {
+      throw new Error("World config terrain override exceeds map bounds");
+    }
+
+    const key = `${override.position.x},${override.position.y}`;
+    if (occupiedTerrainOverrides.has(key)) {
+      throw new Error(`Duplicate terrain override at ${key}`);
+    }
+    occupiedTerrainOverrides.add(key);
+  }
 }
 
 export function validateMapObjectsConfig(
@@ -668,6 +703,66 @@ export function getDefaultHeroSkillTreeConfig(): HeroSkillTreeConfig {
   const config = cloneHeroSkillTreeConfig(runtimeHeroSkillTree);
   validateHeroSkillTreeConfig(config);
   return config;
+}
+
+function hashVariantSeed(value: string, seed: number): number {
+  let hash = seed >>> 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = Math.imul(hash ^ value.charCodeAt(index), 16777619) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+function parseRequestedMapVariantId(roomId: string): string | undefined {
+  const match = roomId.match(/\[map:([a-z0-9_-]+)\]/i);
+  return match?.[1]?.toLowerCase();
+}
+
+function getAvailableMapVariantIds(): string[] {
+  return [DEFAULT_MAP_VARIANT_ID, FRONTIER_BASIN_MAP_VARIANT_ID];
+}
+
+export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string {
+  const requested = parseRequestedMapVariantId(roomId);
+  if (!requested) {
+    return DEFAULT_MAP_VARIANT_ID;
+  }
+  if (requested === "random") {
+    const variants = getAvailableMapVariantIds();
+    return variants[hashVariantSeed(roomId, seed) % variants.length] ?? DEFAULT_MAP_VARIANT_ID;
+  }
+  if (requested === DEFAULT_MAP_VARIANT_ID || requested === FRONTIER_BASIN_MAP_VARIANT_ID) {
+    return requested;
+  }
+  return DEFAULT_MAP_VARIANT_ID;
+}
+
+export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): RoomRuntimeConfigBundle {
+  const mapVariantId = resolveMapVariantIdForRoom(roomId, seed);
+  const units = getDefaultUnitCatalog();
+  const battleSkills = getDefaultBattleSkillCatalog();
+  const battleBalance = getBattleBalanceConfig();
+
+  const world =
+    mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
+      ? cloneWorldConfig(frontierBasinWorldConfig as WorldGenerationConfig)
+      : getDefaultWorldConfig();
+  const mapObjects =
+    mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
+      ? cloneMapObjectsConfig(frontierBasinMapObjectsConfig as MapObjectsConfig)
+      : getDefaultMapObjectsConfig();
+
+  validateWorldConfig(world);
+  validateMapObjectsConfig(mapObjects, world, units);
+
+  return {
+    mapVariantId,
+    world,
+    mapObjects,
+    units,
+    battleSkills,
+    battleBalance
+  };
 }
 
 export function setWorldConfig(config: WorldGenerationConfig): void {

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -27,6 +27,7 @@ import {
   createDefaultHeroLoadout,
   createNeutralBattleState,
   createDefaultHeroProgression,
+  createInitialWorldState,
   createPlayerWorldView,
   createWorldStateFromConfigs,
   decodePlayerWorldView,
@@ -2131,6 +2132,46 @@ test("createWorldStateFromConfigs reuses deterministic generation for preview an
   assert.equal(shrineTile?.building?.kind, "attribute_shrine");
   assert.equal(mineTile?.building?.kind, "resource_mine");
   assert.deepEqual(previewState.map.tiles[0]?.occupant, { kind: "hero", refId: "hero-1" });
+});
+
+test("createInitialWorldState selects the frontier basin variant and supports the new ore mine interaction", () => {
+  const state = createInitialWorldState(1001, "preview-frontier[map:frontier_basin]");
+
+  assert.equal(state.meta.mapVariantId, "frontier_basin");
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 2 && tile.position.y === 2)?.terrain, "water");
+  assert.equal(state.buildings["mine-ore-1"]?.kind, "resource_mine");
+  assert.equal(state.buildings["mine-ore-1"]?.resourceKind, "ore");
+  assert.equal(state.buildings["mine-ore-1"]?.income, 4);
+  assert.equal(state.neutralArmies["neutral-2"]?.reward?.kind, "ore");
+  assert.equal(state.neutralArmies["neutral-3"]?.reward?.kind, "wood");
+  assert.equal(state.neutralArmies["neutral-4"]?.reward?.amount, 220);
+
+  const moved = resolveWorldAction(state, {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 1, y: 5 }
+  });
+
+  assert.deepEqual(moved.state.heroes.find((hero) => hero.id === "hero-1")?.position, { x: 1, y: 5 });
+
+  const claimed = resolveWorldAction(moved.state, {
+    type: "hero.claimMine",
+    heroId: "hero-1",
+    buildingId: "mine-ore-1"
+  });
+
+  assert.deepEqual(claimed.events, [
+    {
+      type: "hero.claimedMine",
+      heroId: "hero-1",
+      buildingId: "mine-ore-1",
+      buildingKind: "resource_mine",
+      resourceKind: "ore",
+      income: 4,
+      ownerPlayerId: "player-1"
+    }
+  ]);
+  assert.equal(claimed.state.resources["player-1"]?.ore, 4);
 });
 
 test("applyBattleOutcomeToWorld grants neutral rewards and moves the hero onto the defeated army tile", () => {


### PR DESCRIPTION
## Summary
- add a new `frontier_basin` map variant with terrain overrides and deterministic room-side selection via `[map:<id>]` / `[map:random]` room tags
- add three new map objects/buildings and three new neutral groups with distinct reward drops in the new content pack
- add focused automated coverage for variant selection and ore mine interaction

## Testing
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:cocos
- node --import tsx --test ./packages/shared/test/shared-core.test.ts
- node --import tsx --test ./apps/server/test/authoritative-room.test.ts

Closes #146