### PR TITLE
Implement room feedback tone data attributes

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -71,7 +71,7 @@ import {
   renderBattleReportReplayCenter,
   renderRecentAccountEvents
 } from "./account-history";
-import { renderEncounterSourceDetail, renderRoomActionHint } from "./room-feedback";
+import { renderEncounterSourceDetail, renderRoomActionHint, resolveRoomFeedbackTone } from "./room-feedback";
 
 const params = new URLSearchParams(window.location.search);
 const queryRoomId = params.get("roomId")?.trim() ?? "";
@@ -3374,6 +3374,7 @@ function renderRoomStatusPanel(): string {
   const playerSummary = hero
     ? `我方状态：${hero.name} · HP ${hero.stats.hp}/${hero.stats.maxHp} · Move ${hero.move.remaining}/${hero.move.total}`
     : "我方状态：等待英雄数据同步";
+  const roomFeedbackTone = resolveRoomFeedbackTone(state);
 
   return `
     <section class="room-status-panel info-card" data-testid="room-status-panel">
@@ -3385,7 +3386,7 @@ function renderRoomStatusPanel(): string {
         <span class="status-pill">${state.world.meta.roomId}</span>
       </div>
       <p data-testid="room-status-detail">${encounter.detail}</p>
-      <p class="muted" data-testid="encounter-source">${renderEncounterSourceDetail({
+      <p class="muted" data-testid="encounter-source" data-tone="${roomFeedbackTone}">${renderEncounterSourceDetail({
         battle: state.battle,
         lastEncounterStarted: state.lastEncounterStarted,
         world: state.world,
@@ -3399,7 +3400,7 @@ function renderRoomStatusPanel(): string {
         <span class="battle-intel-chip" data-testid="room-player-summary">${playerSummary}</span>
         <span class="battle-intel-chip" data-testid="room-connection-summary">连接状态：${diagnosticsConnectionStatusLabel(state.diagnostics.connectionStatus)}</span>
       </div>
-      <p class="muted" data-testid="room-next-action">${renderRoomActionHint({
+      <p class="muted" data-testid="room-next-action" data-tone="${roomFeedbackTone}">${renderRoomActionHint({
         battle: state.battle,
         lastBattleSettlement: state.lastBattleSettlement,
         activeHero: activeHero()

--- a/apps/client/src/room-feedback.ts
+++ b/apps/client/src/room-feedback.ts
@@ -1,4 +1,4 @@
-import type { BattleState, MovementPlan, PlayerWorldView } from "../../../packages/shared/src/index";
+import type { BattleState, CocosBattleFeedbackTone, MovementPlan, PlayerWorldView } from "../../../packages/shared/src/index";
 import type { SessionUpdate } from "./local-session";
 
 interface BattleSettlementSummaryLike {
@@ -28,8 +28,35 @@ export interface RoomActionHintInput {
   activeHero: ActiveHeroLike | null;
 }
 
+export interface AppState {
+  battle: BattleState | null;
+  previewPlan: MovementPlan | null;
+  lastBattleSettlement: (BattleSettlementSummaryLike & { tone?: CocosBattleFeedbackTone }) | null;
+  diagnostics: DiagnosticStateLike;
+}
+
 function ownedHeroIds(world: PlayerWorldView): Set<string> {
   return new Set(world.ownHeroes.map((hero) => hero.id));
+}
+
+export function resolveRoomFeedbackTone(state: AppState): CocosBattleFeedbackTone {
+  if (state.lastBattleSettlement?.tone === "victory" || state.lastBattleSettlement?.tone === "defeat") {
+    return state.lastBattleSettlement.tone;
+  }
+
+  if (state.battle) {
+    return "action";
+  }
+
+  if (state.previewPlan?.endsInEncounter) {
+    return "skill";
+  }
+
+  if (state.diagnostics.connectionStatus === "reconnect_failed") {
+    return "hit";
+  }
+
+  return "neutral";
 }
 
 export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): string {

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -66,6 +66,43 @@ button {
   color: var(--muted);
 }
 
+[data-tone] {
+  padding: 8px 10px;
+  border-left: 3px solid transparent;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.48);
+}
+
+[data-tone="neutral"] {
+  border-left-color: #8a6f55;
+  background: rgba(120, 104, 89, 0.08);
+}
+
+[data-tone="action"] {
+  border-left-color: #a44d2c;
+  background: rgba(164, 77, 44, 0.1);
+}
+
+[data-tone="skill"] {
+  border-left-color: #8c6a2d;
+  background: rgba(195, 152, 72, 0.14);
+}
+
+[data-tone="hit"] {
+  border-left-color: #8a3131;
+  background: rgba(138, 49, 49, 0.1);
+}
+
+[data-tone="victory"] {
+  border-left-color: #2f6e5b;
+  background: rgba(47, 110, 91, 0.1);
+}
+
+[data-tone="defeat"] {
+  border-left-color: #6b4152;
+  background: rgba(107, 65, 82, 0.1);
+}
+
 .eyebrow {
   font-size: 12px;
   letter-spacing: 0.18em;

--- a/apps/client/test/room-feedback.test.ts
+++ b/apps/client/test/room-feedback.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { BattleState, MovementPlan, PlayerWorldView } from "../../../packages/shared/src/index";
 import type { SessionUpdate } from "../src/local-session";
-import { renderEncounterSourceDetail, renderRoomActionHint } from "../src/room-feedback";
+import { renderEncounterSourceDetail, renderRoomActionHint, resolveRoomFeedbackTone } from "../src/room-feedback";
 
 type EncounterStartedEvent = Extract<SessionUpdate["events"][number], { type: "battle.started" }>;
 
@@ -347,5 +347,71 @@ test("renderRoomActionHint covers settlement and exploration move branches", () 
       }
     }),
     "下一步：当前英雄今日已无移动力，可推进到下一天。"
+  );
+});
+
+test("resolveRoomFeedbackTone covers settlement, battle, preview, reconnect failure, and stable states", () => {
+  assert.equal(
+    resolveRoomFeedbackTone({
+      battle: null,
+      previewPlan: null,
+      lastBattleSettlement: { aftermath: "已结算", tone: "victory" },
+      diagnostics: { connectionStatus: "connected" }
+    }),
+    "victory"
+  );
+
+  assert.equal(
+    resolveRoomFeedbackTone({
+      battle: null,
+      previewPlan: null,
+      lastBattleSettlement: { aftermath: "已结算", tone: "defeat" },
+      diagnostics: { connectionStatus: "connected" }
+    }),
+    "defeat"
+  );
+
+  assert.equal(
+    resolveRoomFeedbackTone({
+      battle: createBattle(),
+      previewPlan: null,
+      lastBattleSettlement: null,
+      diagnostics: { connectionStatus: "connected" }
+    }),
+    "action"
+  );
+
+  assert.equal(
+    resolveRoomFeedbackTone({
+      battle: null,
+      previewPlan: createPreviewPlan({
+        endsInEncounter: true,
+        encounterKind: "hero",
+        encounterRefId: "hero-2"
+      }),
+      lastBattleSettlement: null,
+      diagnostics: { connectionStatus: "connected" }
+    }),
+    "skill"
+  );
+
+  assert.equal(
+    resolveRoomFeedbackTone({
+      battle: null,
+      previewPlan: null,
+      lastBattleSettlement: null,
+      diagnostics: { connectionStatus: "reconnect_failed" }
+    }),
+    "hit"
+  );
+
+  assert.equal(
+    resolveRoomFeedbackTone({
+      battle: null,
+      previewPlan: null,
+      lastBattleSettlement: null,
+      diagnostics: { connectionStatus: "connected" }
+    }),
+    "neutral"
   );
 });

--- a/apps/cocos-client/assets/scripts/VeilBattlePanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilBattlePanel.ts
@@ -7,7 +7,7 @@ import {
   type BattleCamp,
   type BattlePanelStageView
 } from "./cocos-battle-panel-model.ts";
-import type { CocosBattleFeedbackTone } from "./cocos-battle-feedback.ts";
+import type { CocosBattleFeedbackTone } from "./project-shared/index.ts";
 import { assignUiLayer } from "./cocos-ui-layer.ts";
 import type { BattleAction } from "./VeilCocosSession.ts";
 import { getPixelSpriteAssets, loadPixelSpriteAssets } from "./cocos-pixel-sprites.ts";

--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -1,6 +1,5 @@
+import type { CocosBattleFeedbackTone } from "./project-shared/index.ts";
 import type { BattleAction, BattleState, SessionUpdate } from "./VeilCocosSession.ts";
-
-export type CocosBattleFeedbackTone = "neutral" | "action" | "skill" | "hit" | "victory" | "defeat";
 
 export interface CocosBattleFeedbackView {
   title: string;

--- a/apps/cocos-client/assets/scripts/project-shared/feedback.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/feedback.ts
@@ -1,0 +1,1 @@
+export type CocosBattleFeedbackTone = "neutral" | "action" | "skill" | "hit" | "victory" | "defeat";

--- a/apps/cocos-client/assets/scripts/project-shared/feedback.ts.meta
+++ b/apps/cocos-client/assets/scripts/project-shared/feedback.ts.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "4.0.24",
+  "importer": "typescript",
+  "imported": true,
+  "uuid": "5a91595e-8558-45fe-8b7b-83803c9df9ac",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/apps/cocos-client/assets/scripts/project-shared/index.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/index.ts
@@ -3,6 +3,7 @@ export * from "./battle.ts";
 export * from "./battle-replay.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";
+export * from "./feedback.ts";
 export * from "./hero-skills.ts";
 export * from "./hero-progression.ts";
 export * from "./map.ts";

--- a/packages/shared/src/feedback.ts
+++ b/packages/shared/src/feedback.ts
@@ -1,0 +1,1 @@
+export type CocosBattleFeedbackTone = "neutral" | "action" | "skill" | "hit" | "victory" | "defeat";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./battle.ts";
 export * from "./battle-replay.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";
+export * from "./feedback.ts";
 export * from "./hero-skills.ts";
 export * from "./hero-progression.ts";
 export * from "./map.ts";

--- a/tests/e2e/pvp-hero-encounter.spec.ts
+++ b/tests/e2e/pvp-hero-encounter.spec.ts
@@ -37,9 +37,11 @@ test("two players can enter a hero-vs-hero battle and resolve it with correct tu
   await expect(playerTwoPage.getByTestId("room-phase")).toHaveText("战斗中");
   await expect(playerOnePage.getByTestId("room-status-detail")).toContainText("英雄遭遇战");
   await expect(playerOnePage.getByTestId("encounter-source")).toContainText("我方主动接触敌方英雄");
+  await expect(playerOnePage.getByTestId("encounter-source")).toHaveAttribute("data-tone", "action");
   await expect(playerTwoPage.getByTestId("opponent-summary")).toContainText("player-1");
   await expect(playerTwoPage.getByTestId("opponent-summary")).toContainText("房间态：战斗中");
   await expect(playerTwoPage.getByTestId("room-next-action")).toContainText("等待本场对抗结算");
+  await expect(playerTwoPage.getByTestId("room-next-action")).toHaveAttribute("data-tone", "action");
   await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
   await expect(playerOnePage.getByTestId("battle-actions")).toContainText("等待对手操作");
 
@@ -65,7 +67,9 @@ test("two players can enter a hero-vs-hero battle and resolve it with correct tu
   await expect(playerOnePage.getByTestId("battle-settlement-summary")).toContainText("已击败");
   await expect(playerOnePage.getByTestId("room-phase")).toHaveText("已结算");
   await expect(playerOnePage.getByTestId("encounter-source")).toContainText("房间权威状态已回写到地图");
+  await expect(playerOnePage.getByTestId("encounter-source")).toHaveAttribute("data-tone", "victory");
   await expect(playerOnePage.getByTestId("room-next-action")).toContainText("仍可继续移动");
+  await expect(playerOnePage.getByTestId("room-next-action")).toHaveAttribute("data-tone", "victory");
   await expect(playerTwoPage.getByTestId("room-next-action")).toContainText("移动力已耗尽");
   await expect(playerTwoPage.getByTestId("battle-settlement-aftermath")).toContainText("移动力清零");
   await expect(playerTwoPage.getByTestId("hero-hp")).toHaveText(/HP 15\/30/);


### PR DESCRIPTION
Closes #168

## Summary
- move `CocosBattleFeedbackTone` into the shared layer and re-export it for both clients
- add `resolveRoomFeedbackTone(state)` for the H5 room feedback elements and surface `data-tone` attributes
- add minimal CSS tone treatments and update focused unit/e2e specs

## Checks
- `npm run typecheck:shared`
- `npm run typecheck:client:h5`
- `npm run typecheck:cocos`
- `node --import tsx --test ./apps/client/test/room-feedback.test.ts`
- `npx playwright test --config=playwright.multiplayer.config.ts tests/e2e/pvp-hero-encounter.spec.ts` *(blocked locally: missing `libatk-bridge-2.0.so.0` for Playwright Chromium launch)*