### PR TITLE
Add formal account session management UI and device list

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@
 - 服务端还新增了 `GET /api/auth/session` 与 `GET /api/player-accounts/me`、`PUT /api/player-accounts/me`：前者用于校验和刷新当前游客会话，后者用于按当前登录态读取/修改自己的账号资料，不需要前端再手拼 `playerId`。
 - 账号体系现已从“纯游客模式”升级为“双模式骨架”：`player_accounts` 新增 `loginId / passwordHash / credentialBoundAt`，服务端开放 `POST /api/auth/account-bind` 与 `POST /api/auth/account-login`，可把当前游客档绑定成口令账号，并在之后直接用登录 ID + 口令进入房间。
 - 鉴权入口现已补上进程内安全闸门：`POST /api/auth/guest-login`、`/account-login`、`/account-bind` 都会按来源 IP 走滑动窗口限流，`account-login` 还会在连续失败达到阈值后临时锁定账号；默认值分别来自 `VEIL_RATE_LIMIT_AUTH_WINDOW_MS=60000`、`VEIL_RATE_LIMIT_AUTH_MAX=10`、`VEIL_AUTH_LOCKOUT_THRESHOLD=10`、`VEIL_AUTH_LOCKOUT_DURATION_MINUTES=15`，游客会话缓存还会受 `VEIL_MAX_GUEST_SESSIONS=10000` 的 LRU 上限约束。
-- 正式账号会话现在补上了过期与撤销链路：访问令牌默认 1 小时（`VEIL_AUTH_ACCESS_TTL_SECONDS`），刷新令牌默认 30 天（`VEIL_AUTH_REFRESH_TTL_SECONDS`），游客 token 默认 7 天（`VEIL_AUTH_GUEST_TTL_SECONDS`）；服务端新增 `POST /api/auth/refresh` 与 `POST /api/auth/logout`，并把当前刷新令牌族持久化到 `player_accounts` 上，账号口令修改也会同步撤销现有会话。
+- 正式账号会话现在补上了过期、设备列表与撤销链路：访问令牌默认 1 小时（`VEIL_AUTH_ACCESS_TTL_SECONDS`），刷新令牌默认 30 天（`VEIL_AUTH_REFRESH_TTL_SECONDS`），游客 token 默认 7 天（`VEIL_AUTH_GUEST_TTL_SECONDS`）；服务端新增 `POST /api/auth/refresh`、`POST /api/auth/logout`、`GET /api/player-accounts/me/sessions` 与 `DELETE /api/player-accounts/me/sessions/:sessionId`，正式账号可在 H5 资料卡查看当前设备列表、标记当前设备并撤销其他设备会话，账号口令修改仍会同步撤销现有会话。
 - 服务端现已补上开发态正式注册后端闭环：`POST /api/auth/account-registration/request` 可为全新正式账号预留 `loginId` 并生成短时效注册令牌，`POST /api/auth/account-registration/confirm` 会创建新的 `player_accounts` 档案、绑定口令并立即签发首个账号会话；默认通过 `VEIL_ACCOUNT_REGISTRATION_DELIVERY_MODE=dev-token` 直接回传开发态令牌，TTL 由 `VEIL_ACCOUNT_REGISTRATION_TTL_MINUTES` 控制，确认成功后会向账号 `recentEventLog` 追加注册申请/完成两条 `account` 审计事件。
 - 服务端现已补上开发态密码找回闭环：`POST /api/auth/password-recovery/request` 会为已绑定口令账号生成短时效重置令牌，`POST /api/auth/password-recovery/confirm` 可用该令牌重置口令并撤销旧会话；默认通过 `VEIL_PASSWORD_RECOVERY_DELIVERY_MODE=dev-token` 直接回传开发态令牌，TTL 由 `VEIL_PASSWORD_RECOVERY_TTL_MINUTES` 控制，且找回申请/确认都会写入账号 `recentEventLog` 的 `account` 审计事件。详细说明见 `docs/account-auth-lifecycle.md`。
 - H5 Lobby 现已补上“账号口令登录”表单；游戏内账号资料卡也能直接绑定或更新口令账号，绑定成功后会立即把当前会话升级成账号模式，不需要重新手写 `playerId`，并会继续沿用同一份英雄长期档与全局资源仓库。
@@ -180,7 +180,7 @@
 - Cocos Lobby 现已追加“正式注册 / 密码找回”按钮：沿用当前 prompt 式输入链路完成 request / confirm 联调，开发态可直接复用响应里的 token 完成新账号注册或重置后登录，不再需要手拼 API 请求。
 - Cocos Lobby 现在也提供“打开配置台”入口，会按当前联机目标自动跳到共享的 `config-center.html`，把配置联调从 H5 侧迁成主客户端可达链路。
 - 服务端新增 `GET /api/lobby/rooms`，会实时返回当前进程内活跃房间的 `roomId / day / seed / connectedPlayers / heroCount / activeBattles / updatedAt` 摘要，便于大厅入口和后续房间浏览器直接复用。
-- 这套账号目前仍是“轻量正式化”阶段：虽然已经有独立正式注册、口令绑定、前端注册 / 找回入口、刷新令牌轮换和单账号会话撤销，但仍没有真正的多端并行会话管理或更完整的第三方身份接入。
+- 这套账号目前仍是“轻量正式化”阶段：虽然已经有独立正式注册、口令绑定、前端注册 / 找回入口、设备会话列表 / 定向撤销和刷新令牌轮换，但更完整的第三方身份接入与更细的账号安全策略仍留给后续 issue 继续扩展。
 - H5 会优先连接 `ws://127.0.0.1:2567` 的本地会话服务；若服务未启动，则自动回退到浏览器内嵌房间模式。
 - 本地会话服务已支持房间内 `session.state` 推送同步，后续可在此基础上继续扩展多人联机。
 - 多人原型已支持双英雄同房间联调，以及踩到敌方英雄格时触发玩家对玩家遭遇战。

--- a/apps/client/src/auth-session.ts
+++ b/apps/client/src/auth-session.ts
@@ -6,6 +6,7 @@ export interface StoredAuthSession {
   displayName: string;
   authMode: "guest" | "account";
   loginId?: string;
+  sessionId?: string;
   token?: string;
   refreshToken?: string;
   expiresAt?: string;
@@ -21,6 +22,7 @@ interface AuthSessionApiPayload {
     displayName?: string;
     authMode?: "guest" | "account";
     loginId?: string;
+    sessionId?: string;
     expiresAt?: string;
     refreshExpiresAt?: string;
   };
@@ -87,7 +89,7 @@ function asStoredAuthSession(
   payload: AuthSessionApiPayload["session"],
   source: StoredAuthSession["source"],
   fallback: Pick<StoredAuthSession, "playerId" | "displayName" | "authMode"> &
-    Partial<Pick<StoredAuthSession, "loginId" | "token" | "refreshToken" | "expiresAt" | "refreshExpiresAt">>
+    Partial<Pick<StoredAuthSession, "loginId" | "sessionId" | "token" | "refreshToken" | "expiresAt" | "refreshExpiresAt">>
 ): StoredAuthSession {
   const playerId = normalizePlayerId(payload?.playerId ?? fallback.playerId);
   const loginId = normalizeLoginId(payload?.loginId ?? fallback.loginId);
@@ -98,6 +100,7 @@ function asStoredAuthSession(
     displayName: normalizeDisplayName(playerId, payload?.displayName ?? fallback.displayName),
     authMode,
     ...(loginId ? { loginId } : {}),
+    ...(payload?.sessionId ? { sessionId: payload.sessionId } : fallback.sessionId ? { sessionId: fallback.sessionId } : {}),
     ...(payload?.token ? { token: payload.token } : fallback.token ? { token: fallback.token } : {}),
     ...(payload?.refreshToken ? { refreshToken: payload.refreshToken } : fallback.refreshToken ? { refreshToken: fallback.refreshToken } : {}),
     ...(payload?.expiresAt ? { expiresAt: payload.expiresAt } : fallback.expiresAt ? { expiresAt: fallback.expiresAt } : {}),
@@ -159,6 +162,7 @@ export function readStoredAuthSession(
       displayName?: unknown;
       authMode?: unknown;
       loginId?: unknown;
+      sessionId?: unknown;
       token?: unknown;
       refreshToken?: unknown;
       expiresAt?: unknown;
@@ -175,6 +179,7 @@ export function readStoredAuthSession(
       displayName: parsed.displayName,
       authMode: parsed.authMode === "account" || loginId ? "account" : "guest",
       ...(loginId ? { loginId } : {}),
+      ...(typeof parsed.sessionId === "string" ? { sessionId: parsed.sessionId } : {}),
       ...(typeof parsed.token === "string" ? { token: parsed.token } : {}),
       ...(typeof parsed.refreshToken === "string" ? { refreshToken: parsed.refreshToken } : {}),
       ...(typeof parsed.expiresAt === "string" ? { expiresAt: parsed.expiresAt } : {}),

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -60,11 +60,14 @@ import {
   createFallbackPlayerAccountProfile as createLocalAccountProfile,
   loadPlayerAccountProfileWithProgression as loadAccountProfileWithProgression,
   bindPlayerAccountCredentials as bindAccountCredentials,
+  loadPlayerAccountSessions,
   loadPlayerBattleReplayDetail,
   rememberPreferredPlayerDisplayName,
   readPreferredPlayerDisplayName as readLocalPreferredDisplayName,
+  revokePlayerAccountSession,
   savePlayerAccountDisplayName as saveAccountDisplayName,
-  type PlayerAccountProfile as ClientPlayerAccountProfile
+  type PlayerAccountProfile as ClientPlayerAccountProfile,
+  type PlayerAccountSessionDevice
 } from "./player-account";
 import {
   renderAchievementProgress,
@@ -171,6 +174,9 @@ interface AppState {
   accountSaving: boolean;
   accountBinding: boolean;
   accountStatus: string;
+  accountSessions: PlayerAccountSessionDevice[];
+  accountSessionsLoading: boolean;
+  accountSessionRevokingId: string | null;
   replayDetail: {
     selectedReplayId: string | null;
     replay: PlayerBattleReplaySummary | null;
@@ -245,6 +251,9 @@ const state: AppState = {
   accountSaving: false,
   accountBinding: false,
   accountStatus: "游客账号资料将在连接后自动同步。",
+  accountSessions: [],
+  accountSessionsLoading: false,
+  accountSessionRevokingId: null,
   replayDetail: {
     selectedReplayId: null,
     replay: null,
@@ -642,6 +651,70 @@ function formatAccountLastSeen(account: ClientPlayerAccountProfile): string {
 
 function formatGlobalVault(account: ClientPlayerAccountProfile): string {
   return `全局仓库 金币 ${account.globalResources.gold} / 木材 ${account.globalResources.wood} / 矿石 ${account.globalResources.ore}`;
+}
+
+function formatRelativeSessionTimestamp(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function formatSessionProviderLabel(provider: string): string {
+  if (provider === "wechat-mini-game") {
+    return "微信小游戏";
+  }
+  if (provider === "account-password") {
+    return "口令登录";
+  }
+  return provider;
+}
+
+function renderAccountSessionPanel(): string {
+  if (state.lobby.authSession?.authMode !== "account") {
+    return "";
+  }
+
+  const items = state.accountSessions.length
+    ? state.accountSessions
+        .map((session) => {
+          const revokeDisabled = session.current || state.accountSessionRevokingId !== null;
+          const revokeLabel =
+            state.accountSessionRevokingId === session.sessionId ? "撤销中..." : session.current ? "当前设备" : "撤销";
+          return `
+            <div class="account-session-item">
+              <div class="account-session-copy">
+                <div class="account-session-head">
+                  <strong>${escapeHtml(session.deviceLabel)}</strong>
+                  <span class="account-session-badge">${escapeHtml(
+                    session.current ? "当前设备" : formatSessionProviderLabel(session.provider)
+                  )}</span>
+                </div>
+                <p class="account-meta">最近活跃 ${escapeHtml(formatRelativeSessionTimestamp(session.lastUsedAt))}</p>
+                <p class="account-meta">刷新令牌到期 ${escapeHtml(formatRelativeSessionTimestamp(session.refreshExpiresAt))}</p>
+              </div>
+              <button
+                class="account-save account-session-action"
+                data-revoke-account-session="${escapeHtml(session.sessionId)}"
+                ${revokeDisabled ? "disabled" : ""}
+              >${escapeHtml(revokeLabel)}</button>
+            </div>
+          `;
+        })
+        .join("")
+    : `<p class="muted account-status">${escapeHtml(
+        state.accountSessionsLoading ? "正在同步设备会话..." : "当前没有可撤销的其他设备会话。"
+      )}</p>`;
+
+  return `
+    <div class="account-binding-card">
+      <div class="account-binding-head">
+        <strong>设备会话</strong>
+        <span>查看当前正式账号在哪些设备保持登录，并撤销其他设备。</span>
+      </div>
+      <div class="account-session-list">
+        ${items}
+      </div>
+    </div>
+  `;
 }
 
 function findReplaySummary(replayId: string | null | undefined): PlayerBattleReplaySummary | null {
@@ -4135,6 +4208,7 @@ function render(): void {
               ${state.accountSaving || state.accountBinding || state.account.source !== "remote" ? "disabled" : ""}
             >${state.accountBinding ? "提交中..." : state.account.loginId ? "更新口令" : "绑定账号"}</button>
           </div>
+          ${renderAccountSessionPanel()}
           <p class="muted account-status">${escapeHtml(state.accountStatus)}</p>
         </div>
         ${state.predictionStatus ? `<p class="muted" data-testid="prediction-status">${state.predictionStatus}</p>` : ""}
@@ -4453,6 +4527,15 @@ function render(): void {
     });
   }
 
+  for (const revokeSessionButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-revoke-account-session]"))) {
+    revokeSessionButton.addEventListener("click", () => {
+      const sessionId = revokeSessionButton.dataset.revokeAccountSession?.trim();
+      if (sessionId) {
+        void onRevokeAccountSession(sessionId);
+      }
+    });
+  }
+
   for (const returnLobbyButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-return-lobby]"))) {
     returnLobbyButton.addEventListener("click", () => {
       returnToLobby();
@@ -4511,8 +4594,14 @@ async function bootstrap(): Promise<void> {
 }
 
 async function syncPlayerAccountProfile(): Promise<void> {
+  state.accountSessionsLoading = true;
   const account = await loadAccountProfileWithProgression(playerId, roomId);
+  const accountSessions =
+    state.lobby.authSession?.authMode === "account" || readStoredAuthSession()?.authMode === "account"
+      ? await loadPlayerAccountSessions()
+      : [];
   state.account = account;
+  state.accountSessions = accountSessions;
   state.accountDraftName = account.displayName;
   state.accountLoginId = account.loginId ?? state.accountLoginId;
   state.accountStatus =
@@ -4524,7 +4613,25 @@ async function syncPlayerAccountProfile(): Promise<void> {
   if (state.replayDetail.selectedReplayId && !account.recentBattleReplays.some((replay) => replay.id === state.replayDetail.selectedReplayId)) {
     clearReplayDetail("最近战报已刷新，当前选中的回放已不可用。");
   }
+  state.accountSessionsLoading = false;
   render();
+}
+
+async function onRevokeAccountSession(sessionId: string): Promise<void> {
+  state.accountSessionRevokingId = sessionId;
+  state.accountStatus = "正在撤销所选设备会话...";
+  render();
+
+  try {
+    state.accountSessions = await revokePlayerAccountSession(sessionId);
+    state.accountSessionRevokingId = null;
+    state.accountStatus = "已撤销所选设备会话，旧刷新令牌现已失效。";
+    render();
+  } catch (error) {
+    state.accountSessionRevokingId = null;
+    state.accountStatus = error instanceof Error ? error.message : "account_session_revoke_failed";
+    render();
+  }
 }
 
 async function onSaveAccountProfile(): Promise<void> {
@@ -4569,6 +4676,7 @@ async function onBindAccountProfile(): Promise<void> {
   try {
     const account = await bindAccountCredentials(loginId, state.accountPassword, roomId);
     state.account = account;
+    state.accountSessions = await loadPlayerAccountSessions();
     state.accountLoginId = account.loginId ?? loginId;
     state.accountPassword = "";
     state.accountBinding = false;

--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -34,6 +34,16 @@ export interface PlayerAccountProfile extends PlayerAccountReadModel {
   source: "remote" | "local";
 }
 
+export interface PlayerAccountSessionDevice {
+  sessionId: string;
+  provider: string;
+  deviceLabel: string;
+  lastUsedAt: string;
+  createdAt: string;
+  refreshExpiresAt: string;
+  current: boolean;
+}
+
 interface PlayerAccountApiPayload {
   account?: {
     playerId?: string;
@@ -58,6 +68,7 @@ interface PlayerAccountApiPayload {
     displayName?: string;
     authMode?: "guest" | "account";
     loginId?: string;
+    sessionId?: string;
     expiresAt?: string;
     refreshExpiresAt?: string;
   };
@@ -88,6 +99,10 @@ interface PlayerAchievementListApiPayload {
 }
 
 interface PlayerProgressionApiPayload extends Partial<PlayerProgressionSnapshot> {}
+
+interface PlayerAccountSessionListApiPayload {
+  items?: Array<Partial<PlayerAccountSessionDevice>>;
+}
 
 function hasMeaningfulProgressionSnapshot(snapshot: PlayerProgressionSnapshot): boolean {
   return (
@@ -288,6 +303,7 @@ function asStoredAuthSession(
     displayName: payload?.displayName?.trim() || previousSession.displayName,
     authMode: payload?.authMode === "account" || loginId ? "account" : previousSession.authMode,
     ...(loginId ? { loginId } : {}),
+    ...(payload?.sessionId ? { sessionId: payload.sessionId } : previousSession.sessionId ? { sessionId: previousSession.sessionId } : {}),
     ...(payload?.token ? { token: payload.token } : previousSession.token ? { token: previousSession.token } : {}),
     ...(payload?.refreshToken
       ? { refreshToken: payload.refreshToken }
@@ -675,4 +691,68 @@ export async function bindPlayerAccountCredentials(
   );
   rememberPreferredPlayerDisplayName(profile.playerId, profile.displayName);
   return profile;
+}
+
+function normalizePlayerAccountSessionDevices(
+  items?: Array<Partial<PlayerAccountSessionDevice>>
+): PlayerAccountSessionDevice[] {
+  return (items ?? [])
+    .map((item) => {
+      const sessionId = item.sessionId?.trim();
+      const lastUsedAt = item.lastUsedAt?.trim();
+      const createdAt = item.createdAt?.trim();
+      const refreshExpiresAt = item.refreshExpiresAt?.trim();
+      if (!sessionId || !lastUsedAt || !createdAt || !refreshExpiresAt) {
+        return null;
+      }
+
+      return {
+        sessionId,
+        provider: item.provider?.trim() || "account-password",
+        deviceLabel: item.deviceLabel?.trim() || "Unknown device",
+        lastUsedAt,
+        createdAt,
+        refreshExpiresAt,
+        current: item.current === true
+      };
+    })
+    .filter((item): item is PlayerAccountSessionDevice => Boolean(item))
+    .sort((left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt) || right.createdAt.localeCompare(left.createdAt));
+}
+
+export async function loadPlayerAccountSessions(): Promise<PlayerAccountSessionDevice[]> {
+  const authSession = readStoredAuthSession();
+  if (!authSession?.token || authSession.authMode !== "account") {
+    return [];
+  }
+
+  try {
+    const payload = (await fetchPlayerAccountJson(`${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/sessions`, {
+      headers: buildAuthHeaders(authSession.token)
+    }, authSession)) as PlayerAccountSessionListApiPayload;
+    return normalizePlayerAccountSessionDevices(payload.items);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("player_account_request_failed:401:")) {
+      clearCurrentAuthSession();
+    }
+    return [];
+  }
+}
+
+export async function revokePlayerAccountSession(sessionId: string): Promise<PlayerAccountSessionDevice[]> {
+  const authSession = readStoredAuthSession();
+  if (!authSession?.token || authSession.authMode !== "account") {
+    throw new Error("auth_session_required");
+  }
+
+  const payload = (await fetchPlayerAccountJson(
+    `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/sessions/${encodeURIComponent(sessionId)}`,
+    {
+      method: "DELETE",
+      headers: buildAuthHeaders(authSession.token)
+    },
+    authSession
+  )) as PlayerAccountSessionListApiPayload;
+
+  return normalizePlayerAccountSessionDevices(payload.items);
 }

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -703,6 +703,47 @@ h1 {
   cursor: not-allowed;
 }
 
+.account-session-list {
+  display: grid;
+  gap: 10px;
+}
+
+.account-session-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(78, 58, 42, 0.05);
+}
+
+.account-session-copy {
+  display: grid;
+  gap: 6px;
+}
+
+.account-session-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.account-session-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  color: var(--muted);
+  background: rgba(78, 58, 42, 0.08);
+}
+
+.account-session-action {
+  min-width: 88px;
+}
+
 .timeline-panel {
   display: grid;
   gap: 8px;

--- a/apps/client/test/auth-session-storage.test.ts
+++ b/apps/client/test/auth-session-storage.test.ts
@@ -38,6 +38,7 @@ test("auth session helpers can persist and clear stored guest sessions", () => {
     displayName: "访客骑士",
     authMode: "account",
     loginId: "veil-ranger",
+    sessionId: "session-current",
     source: "remote"
   });
   assert.deepEqual(readStoredAuthSession(storage), {
@@ -46,6 +47,7 @@ test("auth session helpers can persist and clear stored guest sessions", () => {
     displayName: "访客骑士",
     authMode: "account",
     loginId: "veil-ranger",
+    sessionId: "session-current",
     source: "remote"
   });
 

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -11,8 +11,10 @@ import {
   loadPlayerBattleReplayPlayback,
   loadPlayerBattleReplaySummaries,
   loadPlayerEventLog,
+  loadPlayerAccountSessions,
   loadPlayerProgressionSnapshot,
   readStoredPlayerDisplayName,
+  revokePlayerAccountSession,
   writeStoredPlayerDisplayName
 } from "../src/player-account";
 
@@ -231,6 +233,123 @@ test("player account loader can overlay progression snapshot onto base account p
     assert.equal(account.achievements[0]?.id, "first_battle");
     assert.equal(account.achievements[1]?.current, 2);
     assert.deepEqual(account.recentEventLog.map((entry) => entry.id), ["event-1"]);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("player account session helpers list and revoke formal-account device sessions", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  const values = new Map<string, string>([
+    [
+      "project-veil:auth-session",
+      JSON.stringify({
+        playerId: "player-1",
+        displayName: "暮火侦骑",
+        authMode: "account",
+        loginId: "veil-ranger",
+        sessionId: "session-current",
+        token: "access-token",
+        refreshToken: "refresh-token",
+        source: "remote"
+      })
+    ]
+  ]);
+  const requests: Array<{ url: string; method: string; authorization?: string }> = [];
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(key: string): string | null {
+          return values.get(key) ?? null;
+        },
+        setItem(key: string, value: string): void {
+          values.set(key, value);
+        },
+        removeItem(key: string): void {
+          values.delete(key);
+        }
+      }
+    }
+  });
+
+  globalThis.fetch = (async (input, init) => {
+    requests.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      authorization: (init?.headers as Record<string, string> | undefined)?.Authorization
+    });
+
+    return new Response(
+      JSON.stringify({
+        items:
+          init?.method === "DELETE"
+            ? [
+                {
+                  sessionId: "session-current",
+                  provider: "account-password",
+                  deviceLabel: "Current Browser",
+                  lastUsedAt: "2026-03-29T08:00:00.000Z",
+                  createdAt: "2026-03-28T08:00:00.000Z",
+                  refreshExpiresAt: "2026-04-28T08:00:00.000Z",
+                  current: true
+                }
+              ]
+            : [
+                {
+                  sessionId: "session-current",
+                  provider: "account-password",
+                  deviceLabel: "Current Browser",
+                  lastUsedAt: "2026-03-29T08:00:00.000Z",
+                  createdAt: "2026-03-28T08:00:00.000Z",
+                  refreshExpiresAt: "2026-04-28T08:00:00.000Z",
+                  current: true
+                },
+                {
+                  sessionId: "session-other",
+                  provider: "wechat-mini-game",
+                  deviceLabel: "WeChat DevTools",
+                  lastUsedAt: "2026-03-29T07:00:00.000Z",
+                  createdAt: "2026-03-27T07:00:00.000Z",
+                  refreshExpiresAt: "2026-04-27T07:00:00.000Z",
+                  current: false
+                }
+              ]
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+  }) as typeof fetch;
+
+  try {
+    const sessions = await loadPlayerAccountSessions();
+    assert.deepEqual(sessions.map((session) => session.sessionId), ["session-current", "session-other"]);
+
+    const remainingSessions = await revokePlayerAccountSession("session-other");
+    assert.deepEqual(remainingSessions.map((session) => session.sessionId), ["session-current"]);
+    assert.deepEqual(
+      requests.map((request) => [request.method, request.url, request.authorization]),
+      [
+        ["GET", "http://127.0.0.1:2567/api/player-accounts/me/sessions", "Bearer access-token"],
+        ["DELETE", "http://127.0.0.1:2567/api/player-accounts/me/sessions/session-other", "Bearer access-token"]
+      ]
+    );
   } finally {
     Object.defineProperty(globalThis, "window", {
       configurable: true,

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -304,6 +304,13 @@ function normalizeSessionVersion(sessionVersion?: number | null): number | undef
   return Math.max(0, Math.floor(sessionVersion));
 }
 
+function resolveDeviceLabel(request: Pick<IncomingMessage, "headers">): string {
+  const userAgent = request.headers["user-agent"];
+  const raw = Array.isArray(userAgent) ? userAgent[0] : userAgent;
+  const normalized = raw?.trim();
+  return normalized ? normalized.slice(0, 191) : "Unknown device";
+}
+
 function normalizeAuthMode(authMode?: string | null, loginId?: string | null): AuthMode {
   return authMode === "account" || Boolean(normalizeLoginId(loginId)) ? "account" : "guest";
 }
@@ -847,16 +854,6 @@ function resolveAuthSession(token: string): GuestAuthSession | null {
         if (session.sessionVersion != null && session.sessionVersion !== cachedState.sessionVersion) {
           return null;
         }
-        if (session.sessionId && cachedState.refreshSessionId && session.sessionId !== cachedState.refreshSessionId) {
-          return null;
-        }
-        if (
-          payload.tokenKind === "refresh" &&
-          cachedState.refreshTokenHash &&
-          cachedState.refreshTokenHash !== hashRefreshToken(normalizedToken)
-        ) {
-          return null;
-        }
       }
     }
 
@@ -977,35 +974,42 @@ async function validateAuthToken(
       return { session: null, errorCode: "session_revoked" };
     }
 
-    if (session.sessionId && authAccount.refreshSessionId && session.sessionId !== authAccount.refreshSessionId) {
-      return { session: null, errorCode: "session_revoked" };
-    }
-
     if (expectedKind === "refresh") {
-      if (!session.sessionId || !authAccount.refreshSessionId || !authAccount.refreshTokenHash) {
+      if (!session.sessionId) {
         return { session: null, errorCode: "session_revoked" };
       }
-      if (authAccount.refreshTokenExpiresAt && isExpiredTimestamp(authAccount.refreshTokenExpiresAt)) {
+      const authDeviceSession = await store.loadPlayerAccountAuthSession(session.playerId, session.sessionId);
+      if (!authDeviceSession) {
+        return { session: null, errorCode: "session_revoked" };
+      }
+      if (isExpiredTimestamp(authDeviceSession.refreshTokenExpiresAt)) {
         return { session: null, errorCode: "token_expired" };
       }
       if (
-        authAccount.refreshSessionId !== session.sessionId ||
-        authAccount.refreshTokenHash !== hashRefreshToken(normalizedToken)
+        authDeviceSession.refreshTokenHash !== hashRefreshToken(normalizedToken)
       ) {
         return { session: null, errorCode: "session_revoked" };
       }
+      await store.touchPlayerAccountAuthSession(session.playerId, session.sessionId, session.lastUsedAt);
       return {
         session: {
           ...session,
-          ...(authAccount.refreshTokenExpiresAt ? { refreshExpiresAt: authAccount.refreshTokenExpiresAt } : {})
+          refreshExpiresAt: authDeviceSession.refreshTokenExpiresAt
         }
       };
+    }
+
+    if (session.sessionId) {
+      const authDeviceSession = await store.loadPlayerAccountAuthSession(session.playerId, session.sessionId);
+      if (!authDeviceSession) {
+        return { session: null, errorCode: "session_revoked" };
+      }
+      await store.touchPlayerAccountAuthSession(session.playerId, session.sessionId, session.lastUsedAt);
     }
 
     return {
       session: {
         ...session,
-        ...(authAccount.refreshSessionId ? { sessionId: authAccount.refreshSessionId } : {}),
         sessionVersion: authAccount.accountSessionVersion
       }
     };
@@ -1030,26 +1034,30 @@ async function createAccountSessionBundle(
     displayName: string;
     loginId: string;
     provider?: AuthProvider;
+    refreshSessionId?: string;
+    deviceLabel?: string;
   }
 ): Promise<GuestAuthSession> {
-  const refreshSessionId = randomUUID();
+  const refreshSessionId = input.refreshSessionId ?? randomUUID();
   const existingAuth = await store.loadPlayerAccountAuthByPlayerId(input.playerId);
   if (!existingAuth) {
     throw new Error("account_auth_not_found");
   }
-  const nextSessionVersion = existingAuth.accountSessionVersion + 1;
   const refreshSession = issueAccountRefreshSession({
     playerId: input.playerId,
     displayName: input.displayName,
     loginId: input.loginId,
     ...(input.provider ? { provider: input.provider } : {}),
     sessionId: refreshSessionId,
-    sessionVersion: nextSessionVersion
+    sessionVersion: existingAuth.accountSessionVersion
   });
   await store.savePlayerAccountAuthSession(input.playerId, {
     refreshSessionId,
     refreshTokenHash: hashRefreshToken(refreshSession.token),
-    refreshTokenExpiresAt: refreshSession.expiresAt
+    refreshTokenExpiresAt: refreshSession.expiresAt,
+    ...(input.provider ? { provider: input.provider } : {}),
+    ...(input.deviceLabel ? { deviceLabel: input.deviceLabel } : {}),
+    lastUsedAt: refreshSession.issuedAt
   });
   const finalizedAuth = await store.loadPlayerAccountAuthByPlayerId(input.playerId);
   if (!finalizedAuth) {
@@ -1343,7 +1351,9 @@ export function registerAuthRoutes(
         playerId: account.playerId,
         displayName: account.displayName,
         loginId: refreshSession.loginId,
-        provider: refreshSession.provider
+        provider: refreshSession.provider,
+        ...(refreshSession.sessionId ? { refreshSessionId: refreshSession.sessionId } : {}),
+        deviceLabel: resolveDeviceLabel(request)
       });
       sendJson(response, 200, { session });
     } catch (error) {
@@ -1589,7 +1599,8 @@ export function registerAuthRoutes(
                 playerId,
                 displayName,
                 loginId,
-                provider: "wechat-mini-game"
+                provider: "wechat-mini-game",
+                deviceLabel: resolveDeviceLabel(request)
               })
             : issueWechatMiniGameAuthSession({
                 playerId,
@@ -1672,7 +1683,8 @@ export function registerAuthRoutes(
         session: await createAccountSessionBundle(store, {
           playerId: account.playerId,
           displayName: account.displayName,
-          loginId
+          loginId,
+          deviceLabel: resolveDeviceLabel(request)
         })
       });
     } catch (error) {
@@ -1846,7 +1858,8 @@ export function registerAuthRoutes(
         session: await createAccountSessionBundle(store, {
           playerId: account.playerId,
           displayName: account.displayName,
-          loginId
+          loginId,
+          deviceLabel: resolveDeviceLabel(request)
         })
       });
     } catch (error) {
@@ -2074,7 +2087,8 @@ export function registerAuthRoutes(
         session: await createAccountSessionBundle(store, {
           playerId: account.playerId,
           displayName: account.displayName,
-          loginId
+          loginId,
+          deviceLabel: resolveDeviceLabel(request)
         })
       });
     } catch (error) {

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -12,6 +12,7 @@ import {
   type PlayerAccountAuthSnapshot,
   type PlayerAccountAuthRevokeInput,
   type PlayerAccountAuthSessionInput,
+  type PlayerAccountDeviceSessionSnapshot,
   type PlayerAccountCredentialInput,
   type PlayerAccountEnsureInput,
   type PlayerAccountListOptions,
@@ -61,10 +62,20 @@ function normalizeLoginId(loginId: string): string {
   return normalized;
 }
 
+function normalizeSessionId(sessionId: string): string {
+  const normalized = sessionId.trim();
+  if (!normalized) {
+    throw new Error("sessionId must not be empty");
+  }
+
+  return normalized;
+}
+
 export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly snapshots = new Map<string, RoomPersistenceSnapshot>();
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
+  private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
   private readonly heroArchives = new Map<string, PlayerHeroArchiveSnapshot>();
 
@@ -228,12 +239,24 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
 
     const nextAuth: PlayerAccountAuthSnapshot = {
       ...existing,
-      accountSessionVersion: existing.accountSessionVersion + 1,
-      refreshSessionId: input.refreshSessionId.trim(),
+      refreshSessionId: normalizeSessionId(input.refreshSessionId),
       refreshTokenHash: input.refreshTokenHash.trim(),
       refreshTokenExpiresAt: new Date(input.refreshTokenExpiresAt).toISOString()
     };
     this.authByLoginId.set(existing.loginId, structuredClone(nextAuth));
+
+    const existingSessions = this.authSessionsByPlayerId.get(normalizedPlayerId) ?? new Map<string, PlayerAccountDeviceSessionSnapshot>();
+    existingSessions.set(nextAuth.refreshSessionId!, {
+      playerId: normalizedPlayerId,
+      sessionId: nextAuth.refreshSessionId!,
+      provider: input.provider?.trim() || "account-password",
+      deviceLabel: input.deviceLabel?.trim() || "Unknown device",
+      refreshTokenHash: nextAuth.refreshTokenHash!,
+      refreshTokenExpiresAt: nextAuth.refreshTokenExpiresAt!,
+      createdAt: existingSessions.get(nextAuth.refreshSessionId!)?.createdAt ?? new Date().toISOString(),
+      lastUsedAt: input.lastUsedAt ? new Date(input.lastUsedAt).toISOString() : new Date().toISOString()
+    });
+    this.authSessionsByPlayerId.set(normalizedPlayerId, existingSessions);
 
     const account = this.accounts.get(normalizedPlayerId);
     if (account) {
@@ -247,6 +270,44 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     }
 
     return structuredClone(nextAuth);
+  }
+
+  async loadPlayerAccountAuthSession(
+    playerId: string,
+    sessionId: string
+  ): Promise<PlayerAccountDeviceSessionSnapshot | null> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const normalizedSessionId = normalizeSessionId(sessionId);
+    const session = this.authSessionsByPlayerId.get(normalizedPlayerId)?.get(normalizedSessionId) ?? null;
+    return session ? structuredClone(session) : null;
+  }
+
+  async listPlayerAccountAuthSessions(playerId: string): Promise<PlayerAccountDeviceSessionSnapshot[]> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    return Array.from(this.authSessionsByPlayerId.get(normalizedPlayerId)?.values() ?? [])
+      .sort((left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt) || right.createdAt.localeCompare(left.createdAt))
+      .map((session) => structuredClone(session));
+  }
+
+  async touchPlayerAccountAuthSession(playerId: string, sessionId: string, lastUsedAt?: string): Promise<void> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const normalizedSessionId = normalizeSessionId(sessionId);
+    const sessions = this.authSessionsByPlayerId.get(normalizedPlayerId);
+    const existing = sessions?.get(normalizedSessionId);
+    if (!existing || !sessions) {
+      return;
+    }
+
+    sessions.set(normalizedSessionId, {
+      ...structuredClone(existing),
+      lastUsedAt: lastUsedAt ? new Date(lastUsedAt).toISOString() : new Date().toISOString()
+    });
+  }
+
+  async revokePlayerAccountAuthSession(playerId: string, sessionId: string): Promise<boolean> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const normalizedSessionId = normalizeSessionId(sessionId);
+    return this.authSessionsByPlayerId.get(normalizedPlayerId)?.delete(normalizedSessionId) ?? false;
   }
 
   async revokePlayerAccountAuthSessions(
@@ -271,6 +332,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     delete nextAuth.refreshTokenHash;
     delete nextAuth.refreshTokenExpiresAt;
     this.authByLoginId.set(existing.loginId, structuredClone(nextAuth));
+    this.authSessionsByPlayerId.delete(normalizedPlayerId);
 
     const account = this.accounts.get(normalizedPlayerId);
     if (account) {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -37,6 +37,13 @@ export interface RoomSnapshotStore {
     playerId: string,
     input: PlayerAccountAuthSessionInput
   ): Promise<PlayerAccountAuthSnapshot | null>;
+  loadPlayerAccountAuthSession(
+    playerId: string,
+    sessionId: string
+  ): Promise<PlayerAccountDeviceSessionSnapshot | null>;
+  listPlayerAccountAuthSessions(playerId: string): Promise<PlayerAccountDeviceSessionSnapshot[]>;
+  touchPlayerAccountAuthSession(playerId: string, sessionId: string, lastUsedAt?: string): Promise<void>;
+  revokePlayerAccountAuthSession(playerId: string, sessionId: string): Promise<boolean>;
   revokePlayerAccountAuthSessions(
     playerId: string,
     input?: PlayerAccountAuthRevokeInput
@@ -154,6 +161,17 @@ interface PlayerEventHistoryCountRow extends RowDataPacket {
   total: number;
 }
 
+interface PlayerAccountDeviceSessionRow extends RowDataPacket {
+  player_id: string;
+  session_id: string;
+  provider: string | null;
+  device_label: string | null;
+  refresh_token_hash: string;
+  refresh_token_expires_at: Date | string;
+  created_at: Date | string;
+  last_used_at: Date | string;
+}
+
 interface PlayerHeroArchiveRow extends RowDataPacket {
   player_id: string;
   hero_id: string;
@@ -206,6 +224,17 @@ export interface PlayerAccountAuthSnapshot {
   credentialBoundAt?: string;
 }
 
+export interface PlayerAccountDeviceSessionSnapshot {
+  playerId: string;
+  sessionId: string;
+  provider: string;
+  deviceLabel: string;
+  refreshTokenHash: string;
+  refreshTokenExpiresAt: string;
+  createdAt: string;
+  lastUsedAt: string;
+}
+
 export interface PlayerHeroArchiveSnapshot {
   playerId: string;
   heroId: string;
@@ -240,6 +269,9 @@ export interface PlayerAccountAuthSessionInput {
   refreshSessionId: string;
   refreshTokenHash: string;
   refreshTokenExpiresAt: string;
+  provider?: string;
+  deviceLabel?: string;
+  lastUsedAt?: string;
 }
 
 export interface PlayerAccountAuthRevokeInput {
@@ -293,6 +325,8 @@ export const MYSQL_PLAYER_ACCOUNT_TABLE = "player_accounts";
 export const MYSQL_PLAYER_ACCOUNT_UPDATED_AT_INDEX = "idx_player_accounts_updated_at";
 export const MYSQL_PLAYER_ACCOUNT_LOGIN_ID_INDEX = "uidx_player_accounts_login_id";
 export const MYSQL_PLAYER_ACCOUNT_WECHAT_OPEN_ID_INDEX = "uidx_player_accounts_wechat_open_id";
+export const MYSQL_PLAYER_ACCOUNT_SESSION_TABLE = "player_account_sessions";
+export const MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX = "idx_player_account_sessions_player_last_used";
 export const MYSQL_PLAYER_EVENT_HISTORY_TABLE = "player_event_history";
 export const MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX = "idx_player_event_history_player_time";
 export const MYSQL_PLAYER_HERO_ARCHIVE_TABLE = "player_hero_archives";
@@ -388,6 +422,20 @@ function normalizeWechatMiniGameOpenId(openId: string): string {
 function normalizeWechatMiniGameUnionId(unionId?: string | null): string | undefined {
   const normalized = unionId?.trim();
   return normalized ? normalized : undefined;
+}
+
+function normalizeAuthSessionId(sessionId: string): string {
+  const normalized = sessionId.trim();
+  if (!normalized) {
+    throw new Error("sessionId must not be empty");
+  }
+
+  return normalized;
+}
+
+function normalizeAuthSessionDeviceLabel(deviceLabel?: string | null): string {
+  const normalized = deviceLabel?.trim();
+  return normalized ? normalized.slice(0, 191) : "Unknown device";
 }
 
 function formatTimestamp(value: Date | string | null | undefined): string | undefined {
@@ -743,6 +791,19 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (player_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\` (
+  player_id VARCHAR(191) NOT NULL,
+  session_id VARCHAR(64) NOT NULL,
+  provider VARCHAR(64) NULL,
+  device_label VARCHAR(191) NULL,
+  refresh_token_hash VARCHAR(255) NOT NULL,
+  refresh_token_expires_at DATETIME NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_used_at DATETIME NOT NULL,
+  PRIMARY KEY (session_id),
+  KEY \`${MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX}\` (player_id, last_used_at DESC)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (
@@ -1351,6 +1412,28 @@ function toPlayerEventHistoryEntry(row: PlayerEventHistoryRow): EventLogEntry {
   ])[0] as EventLogEntry;
 }
 
+function toPlayerAccountDeviceSessionSnapshot(
+  row: PlayerAccountDeviceSessionRow
+): PlayerAccountDeviceSessionSnapshot {
+  const refreshTokenExpiresAt = formatTimestamp(row.refresh_token_expires_at);
+  const createdAt = formatTimestamp(row.created_at);
+  const lastUsedAt = formatTimestamp(row.last_used_at);
+  if (!refreshTokenExpiresAt || !createdAt || !lastUsedAt) {
+    throw new Error("player account device session timestamps must be present");
+  }
+
+  return {
+    playerId: normalizePlayerId(row.player_id),
+    sessionId: normalizeAuthSessionId(row.session_id),
+    provider: row.provider?.trim() || "account-password",
+    deviceLabel: normalizeAuthSessionDeviceLabel(row.device_label),
+    refreshTokenHash: row.refresh_token_hash,
+    refreshTokenExpiresAt,
+    createdAt,
+    lastUsedAt
+  };
+}
+
 async function appendPlayerEventHistoryEntries(
   queryable: Pick<Pool, "query"> | Pick<PoolConnection, "query">,
   playerId: string,
@@ -1862,6 +1945,84 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     return row ? toPlayerAccountAuthSnapshot(row) : null;
   }
 
+  async loadPlayerAccountAuthSession(
+    playerId: string,
+    sessionId: string
+  ): Promise<PlayerAccountDeviceSessionSnapshot | null> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const normalizedSessionId = normalizeAuthSessionId(sessionId);
+    const [rows] = await this.pool.query<PlayerAccountDeviceSessionRow[]>(
+      `SELECT
+         player_id,
+         session_id,
+         provider,
+         device_label,
+         refresh_token_hash,
+         refresh_token_expires_at,
+         created_at,
+         last_used_at
+       FROM \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\`
+       WHERE player_id = ?
+         AND session_id = ?
+       LIMIT 1`,
+      [normalizedPlayerId, normalizedSessionId]
+    );
+
+    const row = rows[0];
+    return row ? toPlayerAccountDeviceSessionSnapshot(row) : null;
+  }
+
+  async listPlayerAccountAuthSessions(playerId: string): Promise<PlayerAccountDeviceSessionSnapshot[]> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const [rows] = await this.pool.query<PlayerAccountDeviceSessionRow[]>(
+      `SELECT
+         player_id,
+         session_id,
+         provider,
+         device_label,
+         refresh_token_hash,
+         refresh_token_expires_at,
+         created_at,
+         last_used_at
+       FROM \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\`
+       WHERE player_id = ?
+       ORDER BY last_used_at DESC, created_at DESC, session_id ASC`,
+      [normalizedPlayerId]
+    );
+
+    return rows.map((row) => toPlayerAccountDeviceSessionSnapshot(row));
+  }
+
+  async touchPlayerAccountAuthSession(playerId: string, sessionId: string, lastUsedAt?: string): Promise<void> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const normalizedSessionId = normalizeAuthSessionId(sessionId);
+    const normalizedLastUsedAt = lastUsedAt ? new Date(lastUsedAt) : new Date();
+    if (Number.isNaN(normalizedLastUsedAt.getTime())) {
+      throw new Error("lastUsedAt must be a valid ISO timestamp");
+    }
+
+    await this.pool.query(
+      `UPDATE \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\`
+       SET last_used_at = ?
+       WHERE player_id = ?
+         AND session_id = ?`,
+      [normalizedLastUsedAt, normalizedPlayerId, normalizedSessionId]
+    );
+  }
+
+  async revokePlayerAccountAuthSession(playerId: string, sessionId: string): Promise<boolean> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const normalizedSessionId = normalizeAuthSessionId(sessionId);
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `DELETE FROM \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\`
+       WHERE player_id = ?
+         AND session_id = ?`,
+      [normalizedPlayerId, normalizedSessionId]
+    );
+
+    return result.affectedRows > 0;
+  }
+
   async bindPlayerAccountCredentials(
     playerId: string,
     input: PlayerAccountCredentialInput
@@ -1912,9 +2073,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     input: PlayerAccountAuthSessionInput
   ): Promise<PlayerAccountAuthSnapshot | null> {
     const normalizedPlayerId = normalizePlayerId(playerId);
-    const refreshSessionId = input.refreshSessionId.trim();
+    const refreshSessionId = normalizeAuthSessionId(input.refreshSessionId);
     const refreshTokenHash = input.refreshTokenHash.trim();
     const refreshTokenExpiresAt = new Date(input.refreshTokenExpiresAt);
+    const lastUsedAt = input.lastUsedAt ? new Date(input.lastUsedAt) : new Date();
+    const provider = input.provider?.trim() || "account-password";
+    const deviceLabel = normalizeAuthSessionDeviceLabel(input.deviceLabel);
     if (!refreshSessionId) {
       throw new Error("refreshSessionId must not be empty");
     }
@@ -1924,11 +2088,33 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     if (Number.isNaN(refreshTokenExpiresAt.getTime())) {
       throw new Error("refreshTokenExpiresAt must be a valid ISO timestamp");
     }
+    if (Number.isNaN(lastUsedAt.getTime())) {
+      throw new Error("lastUsedAt must be a valid ISO timestamp");
+    }
+
+    await this.pool.query(
+      `INSERT INTO \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\` (
+         player_id,
+         session_id,
+         provider,
+         device_label,
+         refresh_token_hash,
+         refresh_token_expires_at,
+         last_used_at
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         provider = VALUES(provider),
+         device_label = VALUES(device_label),
+         refresh_token_hash = VALUES(refresh_token_hash),
+         refresh_token_expires_at = VALUES(refresh_token_expires_at),
+         last_used_at = VALUES(last_used_at)`,
+      [normalizedPlayerId, refreshSessionId, provider, deviceLabel, refreshTokenHash, refreshTokenExpiresAt, lastUsedAt]
+    );
 
     await this.pool.query(
       `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
-       SET account_session_version = account_session_version + 1,
-           refresh_session_id = ?,
+       SET refresh_session_id = ?,
            refresh_token_hash = ?,
            refresh_token_expires_at = ?,
            version = version + 1
@@ -1952,6 +2138,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     if (input.credentialBoundAt !== undefined && (!credentialBoundAt || Number.isNaN(credentialBoundAt.getTime()))) {
       throw new Error("credentialBoundAt must be a valid ISO timestamp");
     }
+
+    await this.pool.query(
+      `DELETE FROM \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\`
+       WHERE player_id = ?`,
+      [normalizedPlayerId]
+    );
 
     await this.pool.query(
       `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -386,13 +386,14 @@ export function registerPlayerAccountRoutes(
   app: {
     use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
     get: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
+    delete: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
     put: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
   },
   store: RoomSnapshotStore | null
 ): void {
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
-    response.setHeader("Access-Control-Allow-Methods", "GET,PUT,OPTIONS");
+    response.setHeader("Access-Control-Allow-Methods", "GET,PUT,DELETE,OPTIONS");
     response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
 
     if (request.method === "OPTIONS") {
@@ -461,6 +462,117 @@ export function registerPlayerAccountRoutes(
       sendJson(response, 200, {
         account,
         session: issueNextAuthSession(account, authSession)
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/me/sessions", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (authSession.authMode !== "account" || !authSession.loginId) {
+      sendJson(response, 403, {
+        error: {
+          code: "account_auth_required",
+          message: "Device sessions are only available for formal account logins"
+        }
+      });
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 200, { items: [] });
+      return;
+    }
+
+    try {
+      const items = await store.listPlayerAccountAuthSessions(authSession.playerId);
+      sendJson(response, 200, {
+        items: items.map((session) => ({
+          sessionId: session.sessionId,
+          provider: session.provider,
+          deviceLabel: session.deviceLabel,
+          lastUsedAt: session.lastUsedAt,
+          createdAt: session.createdAt,
+          refreshExpiresAt: session.refreshTokenExpiresAt,
+          current: authSession.sessionId === session.sessionId
+        }))
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.delete("/api/player-accounts/me/sessions/:sessionId", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    const sessionId = request.params.sessionId?.trim();
+    if (!sessionId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (authSession.authMode !== "account" || !authSession.loginId) {
+      sendJson(response, 403, {
+        error: {
+          code: "account_auth_required",
+          message: "Device sessions are only available for formal account logins"
+        }
+      });
+      return;
+    }
+
+    if (authSession.sessionId === sessionId) {
+      sendJson(response, 400, {
+        error: {
+          code: "current_session_revoke_forbidden",
+          message: "Use logout to revoke the current device session"
+        }
+      });
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 404, {
+        error: {
+          code: "session_not_found",
+          message: `Auth session not found: ${sessionId}`
+        }
+      });
+      return;
+    }
+
+    try {
+      const revoked = await store.revokePlayerAccountAuthSession(authSession.playerId, sessionId);
+      if (!revoked) {
+        sendJson(response, 404, {
+          error: {
+            code: "session_not_found",
+            message: `Auth session not found: ${sessionId}`
+          }
+        });
+        return;
+      }
+
+      const items = await store.listPlayerAccountAuthSessions(authSession.playerId);
+      sendJson(response, 200, {
+        ok: true,
+        items: items.map((session) => ({
+          sessionId: session.sessionId,
+          provider: session.provider,
+          deviceLabel: session.deviceLabel,
+          lastUsedAt: session.lastUsedAt,
+          createdAt: session.createdAt,
+          refreshExpiresAt: session.refreshTokenExpiresAt,
+          current: authSession.sessionId === session.sessionId
+        }))
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -15,6 +15,7 @@ import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import type {
   PlayerAccountProgressPatch,
   PlayerAccountAuthSnapshot,
+  PlayerAccountDeviceSessionSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
   PlayerEventHistoryQuery,
@@ -31,6 +32,7 @@ import { queryEventLogEntries } from "../../../packages/shared/src/index";
 class MemoryAuthStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
+  private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
 
   async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
@@ -79,6 +81,32 @@ class MemoryAuthStore implements RoomSnapshotStore {
 
   async loadPlayerAccountAuthByPlayerId(playerId: string): Promise<PlayerAccountAuthSnapshot | null> {
     return Array.from(this.authByLoginId.values()).find((auth) => auth.playerId === playerId.trim()) ?? null;
+  }
+
+  async loadPlayerAccountAuthSession(playerId: string, sessionId: string): Promise<PlayerAccountDeviceSessionSnapshot | null> {
+    return this.authSessionsByPlayerId.get(playerId.trim())?.get(sessionId.trim()) ?? null;
+  }
+
+  async listPlayerAccountAuthSessions(playerId: string): Promise<PlayerAccountDeviceSessionSnapshot[]> {
+    return Array.from(this.authSessionsByPlayerId.get(playerId.trim())?.values() ?? []).sort(
+      (left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt) || right.createdAt.localeCompare(left.createdAt)
+    );
+  }
+
+  async touchPlayerAccountAuthSession(playerId: string, sessionId: string, lastUsedAt?: string): Promise<void> {
+    const sessions = this.authSessionsByPlayerId.get(playerId.trim());
+    const existing = sessions?.get(sessionId.trim());
+    if (!sessions || !existing) {
+      return;
+    }
+    sessions.set(sessionId.trim(), {
+      ...existing,
+      lastUsedAt: lastUsedAt ? new Date(lastUsedAt).toISOString() : new Date().toISOString()
+    });
+  }
+
+  async revokePlayerAccountAuthSession(playerId: string, sessionId: string): Promise<boolean> {
+    return this.authSessionsByPlayerId.get(playerId.trim())?.delete(sessionId.trim()) ?? false;
   }
 
   async loadPlayerHeroArchives(_playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
@@ -140,7 +168,14 @@ class MemoryAuthStore implements RoomSnapshotStore {
 
   async savePlayerAccountAuthSession(
     playerId: string,
-    input: { refreshSessionId: string; refreshTokenHash: string; refreshTokenExpiresAt: string }
+    input: {
+      refreshSessionId: string;
+      refreshTokenHash: string;
+      refreshTokenExpiresAt: string;
+      provider?: string;
+      deviceLabel?: string;
+      lastUsedAt?: string;
+    }
   ): Promise<PlayerAccountAuthSnapshot | null> {
     const auth = await this.loadPlayerAccountAuthByPlayerId(playerId);
     if (!auth) {
@@ -149,12 +184,23 @@ class MemoryAuthStore implements RoomSnapshotStore {
 
     const nextAuth: PlayerAccountAuthSnapshot = {
       ...auth,
-      accountSessionVersion: auth.accountSessionVersion + 1,
       refreshSessionId: input.refreshSessionId,
       refreshTokenHash: input.refreshTokenHash,
       refreshTokenExpiresAt: input.refreshTokenExpiresAt
     };
     this.authByLoginId.set(auth.loginId, nextAuth);
+    const sessions = this.authSessionsByPlayerId.get(playerId) ?? new Map<string, PlayerAccountDeviceSessionSnapshot>();
+    sessions.set(input.refreshSessionId, {
+      playerId,
+      sessionId: input.refreshSessionId,
+      provider: input.provider ?? "account-password",
+      deviceLabel: input.deviceLabel ?? "Unknown device",
+      refreshTokenHash: input.refreshTokenHash,
+      refreshTokenExpiresAt: input.refreshTokenExpiresAt,
+      createdAt: sessions.get(input.refreshSessionId)?.createdAt ?? new Date().toISOString(),
+      lastUsedAt: input.lastUsedAt ?? new Date().toISOString()
+    });
+    this.authSessionsByPlayerId.set(playerId, sessions);
     return nextAuth;
   }
 
@@ -177,6 +223,7 @@ class MemoryAuthStore implements RoomSnapshotStore {
     delete nextAuth.refreshTokenHash;
     delete nextAuth.refreshTokenExpiresAt;
     this.authByLoginId.set(auth.loginId, nextAuth);
+    this.authSessionsByPlayerId.delete(playerId);
     return nextAuth;
   }
 
@@ -677,6 +724,82 @@ test("refresh rotation invalidates the previous refresh token and logout revokes
 
   assert.equal(revokedRefreshResponse.status, 401);
   assert.equal(revokedRefreshPayload.error.code, "session_revoked");
+});
+
+test("revoking one device session leaves other account sessions active and blocks further refreshes for the revoked device", async (t) => {
+  const port = 44600 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  await store.bindPlayerAccountCredentials("device-player", {
+    loginId: "device-ranger",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "Current Browser"
+    },
+    body: JSON.stringify({
+      loginId: "device-ranger",
+      password: "hunter2"
+    })
+  });
+  const firstLoginPayload = (await firstLoginResponse.json()) as { session: GuestAuthSession };
+
+  const secondLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "WeChat DevTools"
+    },
+    body: JSON.stringify({
+      loginId: "device-ranger",
+      password: "hunter2"
+    })
+  });
+  const secondLoginPayload = (await secondLoginResponse.json()) as { session: GuestAuthSession };
+
+  assert.equal(firstLoginResponse.status, 200);
+  assert.equal(secondLoginResponse.status, 200);
+  assert.notEqual(firstLoginPayload.session.sessionId, secondLoginPayload.session.sessionId);
+
+  const revokeResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/sessions/${encodeURIComponent(secondLoginPayload.session.sessionId ?? "")}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${firstLoginPayload.session.token}`
+      }
+    }
+  );
+  assert.equal(revokeResponse.status, 200);
+
+  const revokedRefreshResponse = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${secondLoginPayload.session.refreshToken}`
+    }
+  });
+  const revokedRefreshPayload = (await revokedRefreshResponse.json()) as { error: { code: string } };
+
+  assert.equal(revokedRefreshResponse.status, 401);
+  assert.equal(revokedRefreshPayload.error.code, "session_revoked");
+
+  const survivingRefreshResponse = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${firstLoginPayload.session.refreshToken}`
+    }
+  });
+
+  assert.equal(survivingRefreshResponse.status, 200);
 });
 
 test("password changes revoke the current account session family", async (t) => {

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -76,6 +76,20 @@ class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     return auth ? structuredClone(auth) : null;
   }
 
+  async loadPlayerAccountAuthSession(): Promise<null> {
+    return null;
+  }
+
+  async listPlayerAccountAuthSessions(): Promise<[]> {
+    return [];
+  }
+
+  async touchPlayerAccountAuthSession(): Promise<void> {}
+
+  async revokePlayerAccountAuthSession(): Promise<boolean> {
+    return false;
+  }
+
   async loadPlayerHeroArchives(playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
     const playerIdSet = new Set(playerIds);
     return Array.from(this.heroArchives.values())

--- a/apps/server/test/player-account-battle-replay-detail-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-detail-routes.test.ts
@@ -60,6 +60,20 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return null;
   }
 
+  async loadPlayerAccountAuthSession(): Promise<null> {
+    return null;
+  }
+
+  async listPlayerAccountAuthSessions(): Promise<[]> {
+    return [];
+  }
+
+  async touchPlayerAccountAuthSession(): Promise<void> {}
+
+  async revokePlayerAccountAuthSession(): Promise<boolean> {
+    return false;
+  }
+
   async loadPlayerHeroArchives(_playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
     return [];
   }

--- a/apps/server/test/player-account-battle-replay-playback-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-playback-routes.test.ts
@@ -65,6 +65,20 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return null;
   }
 
+  async loadPlayerAccountAuthSession(): Promise<null> {
+    return null;
+  }
+
+  async listPlayerAccountAuthSessions(): Promise<[]> {
+    return [];
+  }
+
+  async touchPlayerAccountAuthSession(): Promise<void> {}
+
+  async revokePlayerAccountAuthSession(): Promise<boolean> {
+    return false;
+  }
+
   async loadPlayerHeroArchives(_playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
     return [];
   }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -7,6 +7,7 @@ import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import type {
   PlayerAccountProgressPatch,
   PlayerAccountAuthSnapshot,
+  PlayerAccountDeviceSessionSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
   PlayerEventHistoryQuery,
@@ -31,6 +32,7 @@ import {
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
+  private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
   private readonly eventHistoryByPlayerId = new Map<string, PlayerAccountSnapshot["recentEventLog"]>();
 
@@ -83,6 +85,32 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async loadPlayerAccountAuthByPlayerId(playerId: string): Promise<PlayerAccountAuthSnapshot | null> {
     return Array.from(this.authByLoginId.values()).find((auth) => auth.playerId === playerId.trim()) ?? null;
+  }
+
+  async loadPlayerAccountAuthSession(playerId: string, sessionId: string): Promise<PlayerAccountDeviceSessionSnapshot | null> {
+    return this.authSessionsByPlayerId.get(playerId.trim())?.get(sessionId.trim()) ?? null;
+  }
+
+  async listPlayerAccountAuthSessions(playerId: string): Promise<PlayerAccountDeviceSessionSnapshot[]> {
+    return Array.from(this.authSessionsByPlayerId.get(playerId.trim())?.values() ?? []).sort(
+      (left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt) || right.createdAt.localeCompare(left.createdAt)
+    );
+  }
+
+  async touchPlayerAccountAuthSession(playerId: string, sessionId: string, lastUsedAt?: string): Promise<void> {
+    const sessions = this.authSessionsByPlayerId.get(playerId.trim());
+    const existing = sessions?.get(sessionId.trim());
+    if (!sessions || !existing) {
+      return;
+    }
+    sessions.set(sessionId.trim(), {
+      ...existing,
+      lastUsedAt: lastUsedAt ? new Date(lastUsedAt).toISOString() : new Date().toISOString()
+    });
+  }
+
+  async revokePlayerAccountAuthSession(playerId: string, sessionId: string): Promise<boolean> {
+    return this.authSessionsByPlayerId.get(playerId.trim())?.delete(sessionId.trim()) ?? false;
   }
 
   async loadPlayerHeroArchives(_playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
@@ -145,7 +173,14 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async savePlayerAccountAuthSession(
     playerId: string,
-    input: { refreshSessionId: string; refreshTokenHash: string; refreshTokenExpiresAt: string }
+    input: {
+      refreshSessionId: string;
+      refreshTokenHash: string;
+      refreshTokenExpiresAt: string;
+      provider?: string;
+      deviceLabel?: string;
+      lastUsedAt?: string;
+    }
   ): Promise<PlayerAccountAuthSnapshot | null> {
     const auth = await this.loadPlayerAccountAuthByPlayerId(playerId);
     if (!auth) {
@@ -153,12 +188,23 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     }
     const nextAuth: PlayerAccountAuthSnapshot = {
       ...auth,
-      accountSessionVersion: auth.accountSessionVersion + 1,
       refreshSessionId: input.refreshSessionId,
       refreshTokenHash: input.refreshTokenHash,
       refreshTokenExpiresAt: input.refreshTokenExpiresAt
     };
     this.authByLoginId.set(auth.loginId, nextAuth);
+    const sessions = this.authSessionsByPlayerId.get(playerId) ?? new Map<string, PlayerAccountDeviceSessionSnapshot>();
+    sessions.set(input.refreshSessionId, {
+      playerId,
+      sessionId: input.refreshSessionId,
+      provider: input.provider ?? "account-password",
+      deviceLabel: input.deviceLabel ?? "Unknown device",
+      refreshTokenHash: input.refreshTokenHash,
+      refreshTokenExpiresAt: input.refreshTokenExpiresAt,
+      createdAt: sessions.get(input.refreshSessionId)?.createdAt ?? new Date().toISOString(),
+      lastUsedAt: input.lastUsedAt ?? new Date().toISOString()
+    });
+    this.authSessionsByPlayerId.set(playerId, sessions);
     return nextAuth;
   }
 
@@ -180,6 +226,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     delete nextAuth.refreshTokenHash;
     delete nextAuth.refreshTokenExpiresAt;
     this.authByLoginId.set(auth.loginId, nextAuth);
+    this.authSessionsByPlayerId.delete(playerId);
     return nextAuth;
   }
 
@@ -1596,6 +1643,91 @@ test("player account me route preserves account-mode sessions and returns the gl
   });
   assert.equal(mePayload.session.authMode, "account");
   assert.equal(mePayload.session.loginId, "veil-ranger");
+});
+
+test("player account session routes list active devices and revoke a selected non-current session", async (t) => {
+  const port = 42125 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  await store.ensurePlayerAccount({
+    playerId: "account-player",
+    displayName: "暮潮守望"
+  });
+  await store.bindPlayerAccountCredentials("account-player", {
+    loginId: "veil-ranger",
+    passwordHash: "hashed-password"
+  });
+  await store.savePlayerAccountAuthSession("account-player", {
+    refreshSessionId: "session-current",
+    refreshTokenHash: "hash-current",
+    refreshTokenExpiresAt: "2026-04-29T08:00:00.000Z",
+    deviceLabel: "Current Browser",
+    lastUsedAt: "2025-03-29T08:00:00.000Z"
+  });
+  await store.savePlayerAccountAuthSession("account-player", {
+    refreshSessionId: "session-other",
+    refreshTokenHash: "hash-other",
+    refreshTokenExpiresAt: "2026-04-28T08:00:00.000Z",
+    provider: "wechat-mini-game",
+    deviceLabel: "WeChat DevTools",
+    lastUsedAt: "2025-03-29T07:00:00.000Z"
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueAccountAuthSession({
+    playerId: "account-player",
+    displayName: "暮潮守望",
+    loginId: "veil-ranger",
+    sessionId: "session-current",
+    sessionVersion: 0
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const listResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/sessions`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const listPayload = (await listResponse.json()) as {
+    items: Array<{ sessionId: string; deviceLabel: string; current: boolean }>;
+  };
+
+  assert.equal(listResponse.status, 200);
+  assert.deepEqual(
+    listPayload.items.map((item) => [item.sessionId, item.current, item.deviceLabel]),
+    [
+      ["session-current", true, "Current Browser"],
+      ["session-other", false, "WeChat DevTools"]
+    ]
+  );
+
+  const revokeResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/sessions/session-other`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const revokePayload = (await revokeResponse.json()) as {
+    items: Array<{ sessionId: string }>;
+  };
+
+  assert.equal(revokeResponse.status, 200);
+  assert.deepEqual(revokePayload.items.map((item) => item.sessionId), ["session-current"]);
+  assert.equal(await store.loadPlayerAccountAuthSession("account-player", "session-other"), null);
+
+  const revokeCurrentResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/sessions/session-current`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const revokeCurrentPayload = (await revokeCurrentResponse.json()) as {
+    error: { code: string };
+  };
+
+  assert.equal(revokeCurrentResponse.status, 400);
+  assert.equal(revokeCurrentPayload.error.code, "current_session_revoke_forbidden");
 });
 
 test("player account update routes reject oversized JSON bodies with 413", async (t) => {

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -8,6 +8,7 @@
 - 游客档升级成口令账号：`POST /api/auth/account-bind`
 - 口令账号登录：`POST /api/auth/account-login`
 - 会话校验 / 刷新 / 退出：`GET /api/auth/session`、`POST /api/auth/refresh`、`POST /api/auth/logout`
+- 正式账号设备会话列表 / 撤销：`GET /api/player-accounts/me/sessions`、`DELETE /api/player-accounts/me/sessions/:sessionId`
 - 已登录账号修改口令：`PUT /api/player-accounts/me`
 
 当前账号模式仍沿用“先游客、再绑定”的模型：
@@ -15,6 +16,13 @@
 1. 玩家可先以游客身份进入房间并形成 `player_accounts` 档案。
 2. 需要长期登录时，再把当前游客档绑定到 `loginId + password`。
 3. 后续账号登录会继续复用同一份英雄长期档、全局资源仓库和账号事件历史。
+
+## 设备会话管理
+
+- 正式账号登录后，服务端会为每个刷新令牌族持久化一条设备会话记录，包含 `sessionId`、最近活跃时间、刷新令牌到期时间以及一个最小设备标签（当前取自请求 `User-Agent`）。
+- `GET /api/player-accounts/me/sessions` 只返回当前账号仍然活跃的设备会话，并额外标记 `current=true` 的当前设备。
+- `DELETE /api/player-accounts/me/sessions/:sessionId` 仅允许撤销“非当前设备”的会话；被撤销的设备会话会立刻从列表消失，且旧刷新令牌随后会返回 `401 session_revoked`。
+- `POST /api/auth/logout` 与口令修改仍然属于“全量撤销”：会清空当前账号全部设备会话，并通过提升 `accountSessionVersion` 让旧访问令牌也一起失效。
 
 ## 正式注册闭环
 

--- a/scripts/migrations/0008_add_player_account_device_sessions.ts
+++ b/scripts/migrations/0008_add_player_account_device_sessions.ts
@@ -1,0 +1,42 @@
+import {
+  dropTableIfExists,
+  ensureIndexExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX,
+  MYSQL_PLAYER_ACCOUNT_SESSION_TABLE
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  await ensureTableExists(
+    connection,
+    MYSQL_PLAYER_ACCOUNT_SESSION_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\` (
+      player_id VARCHAR(191) NOT NULL,
+      session_id VARCHAR(64) NOT NULL,
+      provider VARCHAR(64) NULL,
+      device_label VARCHAR(191) NULL,
+      refresh_token_hash VARCHAR(255) NOT NULL,
+      refresh_token_expires_at DATETIME NOT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      last_used_at DATETIME NOT NULL,
+      PRIMARY KEY (session_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+
+  const database = connection.config.database;
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_SESSION_TABLE,
+    MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX,
+    `CREATE INDEX \`${MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX}\`
+     ON \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\` (player_id, last_used_at DESC)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  await dropTableIfExists(connection, MYSQL_PLAYER_ACCOUNT_SESSION_TABLE);
+}


### PR DESCRIPTION
## Summary
- add per-device formal account session persistence and authenticated list/revoke routes
- update account auth validation/refresh to use persisted device sessions without breaking account-wide revocation
- add the H5 account-card session panel, client wiring, tests, and doc updates

## Testing
- `npm run typecheck:server`
- `npm run typecheck:client:h5`
- `node --import tsx --test ./apps/server/test/auth-guest-login.test.ts`
- `node --import tsx --test ./apps/server/test/player-account-routes.test.ts ./apps/server/test/memory-room-snapshot-store.test.ts`
- `node --import tsx --test ./apps/client/test/player-account-storage.test.ts ./apps/client/test/auth-session-storage.test.ts`

Resolves #171