### PR TITLE
Issue #186: add auth/session metrics readiness summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 - 安装依赖：`npm install`
 - 本地 WebSocket 服务：`npm run dev:server`
 - 运行时健康检查：`GET http://127.0.0.1:2567/api/runtime/health`
+- 鉴权就绪摘要：`GET http://127.0.0.1:2567/api/runtime/auth-readiness`
 - 运行时指标抓取：`GET http://127.0.0.1:2567/api/runtime/metrics`
 - 终端逻辑演示：`npm run demo:flow`
 - 主客户端入口说明：`npm run client:primary`
@@ -112,7 +113,7 @@
 - MySQL 回滚上一版 schema：`npm run db:migrate:rollback`
 - `npm run db:init:mysql` 现已委托给同一条迁移链路，不再走独立一次性建表逻辑
 - 并发房间压测：`npm run stress:rooms -- --rooms=120 --connect-concurrency=24 --action-concurrency=24`
-- 并发房间压测启动后，也可直接查看同进程观测面：`/api/runtime/health` 与 `/api/runtime/metrics`
+- 并发房间压测启动后，也可直接查看同进程观测面：`/api/runtime/health`、`/api/runtime/auth-readiness` 与 `/api/runtime/metrics`
 - 战斗平衡验证：`npm run validate:battle -- --count=1000 --scenario=all --skill-config=configs/battle-skills-v1.1.json`
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -8,6 +8,24 @@ import {
   readAccountRegistrationDeliveryMode,
   readPasswordRecoveryDeliveryMode
 } from "./account-token-delivery";
+import {
+  recordAuthAccountBinding,
+  recordAuthAccountLogin,
+  recordAuthAccountRegistration,
+  recordAuthGuestLogin,
+  recordAuthInvalidCredentials,
+  recordAuthLogout,
+  recordAuthRateLimited,
+  recordAuthRefresh,
+  recordAuthSessionCheck,
+  recordAuthSessionFailure,
+  removeAuthAccountSessionsForPlayer,
+  setAuthAccountLockCount,
+  setAuthGuestSessionCount,
+  setPendingAuthRecoveryCount,
+  setPendingAuthRegistrationCount,
+  upsertAuthAccountSession
+} from "./observability";
 import type { RoomSnapshotStore } from "./persistence";
 
 export type AuthMode = "guest" | "account";
@@ -133,6 +151,31 @@ const guestSessionsById = new Map<string, GuestAuthSession>();
 const accountAuthStateByPlayerId = new Map<string, AccountAuthSessionState>();
 const accountRegistrationStateByLoginId = new Map<string, AccountRegistrationState>();
 const passwordRecoveryStateByLoginId = new Map<string, PasswordRecoveryState>();
+
+function countActiveAccountLockouts(): number {
+  const currentTime = nowMs();
+  let count = 0;
+
+  for (const [loginId, state] of accountLockoutStateByLoginId.entries()) {
+    if (state.lockedUntil && state.lockedUntil > currentTime) {
+      count += 1;
+      continue;
+    }
+
+    if (state.failedAttempts.length === 0) {
+      accountLockoutStateByLoginId.delete(loginId);
+    }
+  }
+
+  return count;
+}
+
+function syncAuthStateTelemetry(): void {
+  setAuthGuestSessionCount(guestSessionsById.size);
+  setAuthAccountLockCount(countActiveAccountLockouts());
+  setPendingAuthRegistrationCount(accountRegistrationStateByLoginId.size);
+  setPendingAuthRecoveryCount(passwordRecoveryStateByLoginId.size);
+}
 
 function parseEnvNumber(
   value: string | undefined,
@@ -446,6 +489,7 @@ function getAccountRegistrationState(loginId: string): AccountRegistrationState 
 
   if (isExpiredTimestamp(existing.expiresAt)) {
     accountRegistrationStateByLoginId.delete(loginId);
+    syncAuthStateTelemetry();
     return null;
   }
 
@@ -464,6 +508,7 @@ function storeAccountRegistrationState(loginId: string, requestedDisplayName: st
     expiresAt
   };
   accountRegistrationStateByLoginId.set(loginId, state);
+  syncAuthStateTelemetry();
   return state;
 }
 
@@ -478,6 +523,7 @@ function consumeAccountRegistrationState(loginId: string, token: string): Accoun
   }
 
   accountRegistrationStateByLoginId.delete(loginId);
+  syncAuthStateTelemetry();
   return state;
 }
 
@@ -489,6 +535,7 @@ function getPasswordRecoveryState(loginId: string): PasswordRecoveryState | null
 
   if (isExpiredTimestamp(existing.expiresAt)) {
     passwordRecoveryStateByLoginId.delete(loginId);
+    syncAuthStateTelemetry();
     return null;
   }
 
@@ -507,6 +554,7 @@ function storePasswordRecoveryState(playerId: string, loginId: string, token: st
     expiresAt
   };
   passwordRecoveryStateByLoginId.set(loginId, state);
+  syncAuthStateTelemetry();
   return state;
 }
 
@@ -521,6 +569,7 @@ function consumePasswordRecoveryState(loginId: string, token: string): PasswordR
   }
 
   passwordRecoveryStateByLoginId.delete(loginId);
+  syncAuthStateTelemetry();
   return state;
 }
 
@@ -887,18 +936,22 @@ async function validateAuthToken(
   store: RoomSnapshotStore | null,
   expectedKind: "access" | "refresh" = "access"
 ): Promise<ValidateAuthSessionResult> {
+  recordAuthSessionCheck();
   const normalizedToken = token.trim();
   if (!normalizedToken) {
+    recordAuthSessionFailure("unauthorized");
     return { session: null, errorCode: "unauthorized" };
   }
 
   const [encodedPayload, signature] = normalizedToken.split(".");
   if (!encodedPayload || !signature) {
+    recordAuthSessionFailure("unauthorized");
     return { session: null, errorCode: "unauthorized" };
   }
 
   const expectedSignature = createHmac("sha256", AUTH_SECRET).update(encodedPayload).digest("base64url");
   if (signature !== expectedSignature) {
+    recordAuthSessionFailure("unauthorized");
     return { session: null, errorCode: "unauthorized" };
   }
 
@@ -910,11 +963,13 @@ async function validateAuthToken(
       typeof payload.issuedAt !== "string" ||
       typeof payload.expiresAt !== "string"
     ) {
+      recordAuthSessionFailure("unauthorized");
       return { session: null, errorCode: "unauthorized" };
     }
 
     const tokenKind = payload.tokenKind ?? "access";
     if (tokenKind !== expectedKind) {
+      recordAuthSessionFailure("token_kind_invalid");
       return { session: null, errorCode: "token_kind_invalid" };
     }
 
@@ -936,6 +991,7 @@ async function validateAuthToken(
     };
 
     if (isExpiredTimestamp(session.expiresAt)) {
+      recordAuthSessionFailure("token_expired");
       return { session: null, errorCode: "token_expired" };
     }
 
@@ -943,6 +999,7 @@ async function validateAuthToken(
       if (session.sessionId) {
         const touchedSession = touchGuestSession(session.sessionId, normalizedToken);
         if (!touchedSession) {
+          recordAuthSessionFailure("session_revoked");
           return { session: null, errorCode: "session_revoked" };
         }
         return { session: touchedSession };
@@ -956,6 +1013,9 @@ async function validateAuthToken(
 
     const authAccount = await store.loadPlayerAccountAuthByPlayerId(session.playerId);
     if (!authAccount) {
+      if (session.sessionVersion != null) {
+        recordAuthSessionFailure("session_revoked");
+      }
       return session.sessionVersion == null ? { session } : { session: null, errorCode: "session_revoked" };
     }
 
@@ -963,23 +1023,28 @@ async function validateAuthToken(
       session.sessionVersion != null &&
       session.sessionVersion !== authAccount.accountSessionVersion
     ) {
+      recordAuthSessionFailure("session_revoked");
       return { session: null, errorCode: "session_revoked" };
     }
 
     if (expectedKind === "refresh") {
       if (!session.sessionId) {
+        recordAuthSessionFailure("session_revoked");
         return { session: null, errorCode: "session_revoked" };
       }
       const authDeviceSession = await store.loadPlayerAccountAuthSession(session.playerId, session.sessionId);
       if (!authDeviceSession) {
+        recordAuthSessionFailure("session_revoked");
         return { session: null, errorCode: "session_revoked" };
       }
       if (isExpiredTimestamp(authDeviceSession.refreshTokenExpiresAt)) {
+        recordAuthSessionFailure("token_expired");
         return { session: null, errorCode: "token_expired" };
       }
       if (
         authDeviceSession.refreshTokenHash !== hashRefreshToken(normalizedToken)
       ) {
+        recordAuthSessionFailure("session_revoked");
         return { session: null, errorCode: "session_revoked" };
       }
       await store.touchPlayerAccountAuthSession(session.playerId, session.sessionId, session.lastUsedAt);
@@ -994,6 +1059,7 @@ async function validateAuthToken(
     if (session.sessionId) {
       const authDeviceSession = await store.loadPlayerAccountAuthSession(session.playerId, session.sessionId);
       if (!authDeviceSession) {
+        recordAuthSessionFailure("session_revoked");
         return { session: null, errorCode: "session_revoked" };
       }
       await store.touchPlayerAccountAuthSession(session.playerId, session.sessionId, session.lastUsedAt);
@@ -1006,6 +1072,7 @@ async function validateAuthToken(
       }
     };
   } catch {
+    recordAuthSessionFailure("unauthorized");
     return { session: null, errorCode: "unauthorized" };
   }
 }
@@ -1016,7 +1083,13 @@ export async function validateAuthSessionFromRequest(
   expectedKind: "access" | "refresh" = "access"
 ): Promise<ValidateAuthSessionResult> {
   const token = readGuestAuthTokenFromRequest(request);
-  return token ? validateAuthToken(token, store, expectedKind) : { session: null, errorCode: "unauthorized" };
+  if (!token) {
+    recordAuthSessionCheck();
+    recordAuthSessionFailure("unauthorized");
+    return { session: null, errorCode: "unauthorized" };
+  }
+
+  return validateAuthToken(token, store, expectedKind);
 }
 
 async function createAccountSessionBundle(
@@ -1051,6 +1124,7 @@ async function createAccountSessionBundle(
     ...(input.deviceLabel ? { deviceLabel: input.deviceLabel } : {}),
     lastUsedAt: refreshSession.issuedAt
   });
+  upsertAuthAccountSession(input.playerId, refreshSessionId, input.provider ?? "account-password");
   const finalizedAuth = await store.loadPlayerAccountAuthByPlayerId(input.playerId);
   if (!finalizedAuth) {
     throw new Error("account_auth_not_found");
@@ -1195,6 +1269,7 @@ function enforceAuthRateLimit(
     return true;
   }
 
+  recordAuthRateLimited();
   response.setHeader("Retry-After", String(rateLimitResult.retryAfterSeconds ?? 1));
   sendJson(response, 429, {
     error: {
@@ -1216,10 +1291,12 @@ function pruneAccountLockoutState(loginId: string, config = readAuthRuntimeConfi
 
   if (nextState.failedAttempts.length === 0 && !nextState.lockedUntil) {
     accountLockoutStateByLoginId.delete(loginId);
+    syncAuthStateTelemetry();
     return nextState;
   }
 
   accountLockoutStateByLoginId.set(loginId, nextState);
+  syncAuthStateTelemetry();
   return nextState;
 }
 
@@ -1235,11 +1312,13 @@ function recordAccountLoginFailure(loginId: string, config = readAuthRuntimeConf
     nextState.lockedUntil = currentTime + config.lockoutDurationMs;
   }
   accountLockoutStateByLoginId.set(loginId, nextState);
+  syncAuthStateTelemetry();
   return nextState.lockedUntil ?? null;
 }
 
 function clearAccountLoginFailures(loginId: string): void {
   accountLockoutStateByLoginId.delete(loginId);
+  syncAuthStateTelemetry();
 }
 
 function sendAccountLocked(response: ServerResponse, lockedUntilMs: number): void {
@@ -1268,6 +1347,7 @@ function registerGuestSession(session: GuestAuthSession, config = readAuthRuntim
   }
 
   guestSessionsById.set(session.sessionId, session);
+  syncAuthStateTelemetry();
 }
 
 function touchGuestSession(sessionId: string, token: string): GuestAuthSession | null {
@@ -1292,6 +1372,7 @@ export function resetGuestAuthSessions(): void {
   accountAuthStateByPlayerId.clear();
   accountRegistrationStateByLoginId.clear();
   passwordRecoveryStateByLoginId.clear();
+  syncAuthStateTelemetry();
 }
 
 export function registerAuthRoutes(
@@ -1375,6 +1456,7 @@ export function registerAuthRoutes(
         ...(refreshSession.sessionId ? { refreshSessionId: refreshSession.sessionId } : {}),
         deviceLabel: resolveDeviceLabel(request)
       });
+      recordAuthRefresh();
       sendJson(response, 200, { session });
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
@@ -1397,10 +1479,13 @@ export function registerAuthRoutes(
             accountSessionVersion: revokedAuth.accountSessionVersion
           });
         }
+        removeAuthAccountSessionsForPlayer(authSession.playerId);
       } else if (authSession.authMode === "guest" && authSession.sessionId) {
         guestSessionsById.delete(authSession.sessionId);
+        syncAuthStateTelemetry();
       }
 
+      recordAuthLogout();
       sendJson(response, 200, { ok: true });
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
@@ -1456,6 +1541,7 @@ export function registerAuthRoutes(
           displayName
         })
       });
+      recordAuthGuestLogin();
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
@@ -1628,6 +1714,11 @@ export function registerAuthRoutes(
                 ...(loginId ? { loginId } : {})
               })
       });
+      if (store && loginId) {
+        recordAuthAccountLogin();
+      } else {
+        recordAuthGuestLogin();
+      }
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
@@ -1679,6 +1770,7 @@ export function registerAuthRoutes(
 
       const authAccount = await store.loadPlayerAccountAuthByLoginId(loginId);
       if (!authAccount || !verifyAccountPassword(password, authAccount.passwordHash)) {
+        recordAuthInvalidCredentials();
         const nextLockedUntil = recordAccountLoginFailure(loginId);
         if (nextLockedUntil) {
           sendAccountLocked(response, nextLockedUntil);
@@ -1707,6 +1799,7 @@ export function registerAuthRoutes(
           deviceLabel: resolveDeviceLabel(request)
         })
       });
+      recordAuthAccountLogin();
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
@@ -1894,6 +1987,7 @@ export function registerAuthRoutes(
           deviceLabel: resolveDeviceLabel(request)
         })
       });
+      recordAuthAccountRegistration();
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }
@@ -2060,6 +2154,7 @@ export function registerAuthRoutes(
           accountSessionVersion: revokedAuth.accountSessionVersion
         });
       }
+      removeAuthAccountSessionsForPlayer(authAccount.playerId);
       clearAccountLoginFailures(loginId);
       await appendAccountAuditLog(store, authAccount.playerId, "通过密码找回流程重置口令，并撤销旧会话。", credentialBoundAt);
       const account =
@@ -2135,6 +2230,7 @@ export function registerAuthRoutes(
           deviceLabel: resolveDeviceLabel(request)
         })
       });
+      recordAuthAccountBinding();
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
     }

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -66,6 +66,8 @@ async function startDevServer(
   // eslint-disable-next-line no-console
   console.log(`Runtime health available at http://${host}:${port}/api/runtime/health`);
   // eslint-disable-next-line no-console
+  console.log(`Auth readiness available at http://${host}:${port}/api/runtime/auth-readiness`);
+  // eslint-disable-next-line no-console
   console.log(`Runtime metrics available at http://${host}:${port}/api/runtime/metrics`);
   // eslint-disable-next-line no-console
   console.log(`Config center storage: ${configCenterStore.mode}`);

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -13,10 +13,36 @@ interface RuntimeObservabilityCounters {
   battleActionsTotal: number;
 }
 
+interface AuthObservabilityCounters {
+  sessionChecksTotal: number;
+  sessionFailuresTotal: number;
+  guestLoginsTotal: number;
+  accountLoginsTotal: number;
+  accountBindingsTotal: number;
+  accountRegistrationsTotal: number;
+  refreshesTotal: number;
+  logoutsTotal: number;
+  rateLimitedTotal: number;
+  invalidCredentialsTotal: number;
+}
+
+type AuthSessionFailureReason = "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked";
+
+interface AuthObservabilityState {
+  counters: AuthObservabilityCounters;
+  activeGuestSessionCount: number;
+  activeAccountSessions: Map<string, { playerId: string; provider: string }>;
+  activeAccountLockCount: number;
+  pendingRegistrationCount: number;
+  pendingRecoveryCount: number;
+  sessionFailureReasons: Record<AuthSessionFailureReason, number>;
+}
+
 interface RuntimeObservabilityState {
   startedAt: number;
   rooms: Map<string, RuntimeRoomSnapshot>;
   counters: RuntimeObservabilityCounters;
+  auth: AuthObservabilityState;
 }
 
 interface RuntimeHealthPayload {
@@ -36,7 +62,26 @@ interface RuntimeHealthPayload {
       battleActionsTotal: number;
       actionMessagesTotal: number;
     };
+    auth: {
+      activeGuestSessionCount: number;
+      activeAccountSessionCount: number;
+      activeAccountSessionByProvider: Record<string, number>;
+      activeAccountLockCount: number;
+      pendingRegistrationCount: number;
+      pendingRecoveryCount: number;
+      counters: AuthObservabilityCounters;
+      sessionFailureReasons: Record<AuthSessionFailureReason, number>;
+    };
   };
+}
+
+interface AuthReadinessPayload {
+  status: "ok" | "warn";
+  service: string;
+  checkedAt: string;
+  headline: string;
+  alerts: string[];
+  auth: RuntimeHealthPayload["runtime"]["auth"];
 }
 
 const runtimeObservability: RuntimeObservabilityState = {
@@ -46,6 +91,31 @@ const runtimeObservability: RuntimeObservabilityState = {
     connectMessagesTotal: 0,
     worldActionsTotal: 0,
     battleActionsTotal: 0
+  },
+  auth: {
+    counters: {
+      sessionChecksTotal: 0,
+      sessionFailuresTotal: 0,
+      guestLoginsTotal: 0,
+      accountLoginsTotal: 0,
+      accountBindingsTotal: 0,
+      accountRegistrationsTotal: 0,
+      refreshesTotal: 0,
+      logoutsTotal: 0,
+      rateLimitedTotal: 0,
+      invalidCredentialsTotal: 0
+    },
+    activeGuestSessionCount: 0,
+    activeAccountSessions: new Map<string, { playerId: string; provider: string }>(),
+    activeAccountLockCount: 0,
+    pendingRegistrationCount: 0,
+    pendingRecoveryCount: 0,
+    sessionFailureReasons: {
+      unauthorized: 0,
+      token_expired: 0,
+      token_kind_invalid: 0,
+      session_revoked: 0
+    }
   }
 };
 
@@ -70,6 +140,13 @@ function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPaylo
   const heroCount = roomSnapshots.reduce((total, room) => total + room.heroCount, 0);
   const actionMessagesTotal =
     runtimeObservability.counters.worldActionsTotal + runtimeObservability.counters.battleActionsTotal;
+  const activeAccountSessionByProvider = Array.from(runtimeObservability.auth.activeAccountSessions.values()).reduce<Record<string, number>>(
+    (summary, session) => {
+      summary[session.provider] = (summary[session.provider] ?? 0) + 1;
+      return summary;
+    },
+    {}
+  );
 
   return {
     status: "ok",
@@ -87,8 +164,44 @@ function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPaylo
         worldActionsTotal: runtimeObservability.counters.worldActionsTotal,
         battleActionsTotal: runtimeObservability.counters.battleActionsTotal,
         actionMessagesTotal
+      },
+      auth: {
+        activeGuestSessionCount: runtimeObservability.auth.activeGuestSessionCount,
+        activeAccountSessionCount: runtimeObservability.auth.activeAccountSessions.size,
+        activeAccountSessionByProvider,
+        activeAccountLockCount: runtimeObservability.auth.activeAccountLockCount,
+        pendingRegistrationCount: runtimeObservability.auth.pendingRegistrationCount,
+        pendingRecoveryCount: runtimeObservability.auth.pendingRecoveryCount,
+        counters: { ...runtimeObservability.auth.counters },
+        sessionFailureReasons: { ...runtimeObservability.auth.sessionFailureReasons }
       }
     }
+  };
+}
+
+function buildAuthReadinessPayload(service = "project-veil-server"): AuthReadinessPayload {
+  const health = buildHealthPayload(service);
+  const alerts: string[] = [];
+
+  if (health.runtime.auth.activeAccountLockCount > 0) {
+    alerts.push(`${health.runtime.auth.activeAccountLockCount} account lockout(s) active`);
+  }
+
+  if (health.runtime.auth.pendingRecoveryCount > 10) {
+    alerts.push(`${health.runtime.auth.pendingRecoveryCount} password recovery tokens pending`);
+  }
+
+  if (health.runtime.auth.pendingRegistrationCount > 10) {
+    alerts.push(`${health.runtime.auth.pendingRegistrationCount} account registration tokens pending`);
+  }
+
+  return {
+    status: alerts.length > 0 ? "warn" : "ok",
+    service,
+    checkedAt: health.checkedAt,
+    headline: `auth ready; guest=${health.runtime.auth.activeGuestSessionCount} account=${health.runtime.auth.activeAccountSessionCount} lockouts=${health.runtime.auth.activeAccountLockCount}`,
+    alerts,
+    auth: health.runtime.auth
   };
 }
 
@@ -122,7 +235,64 @@ function buildMetricsDocument(): string {
     `veil_battle_actions_total ${health.runtime.gameplayTraffic.battleActionsTotal}`,
     "# HELP veil_gameplay_action_messages_total Total processed gameplay action messages.",
     "# TYPE veil_gameplay_action_messages_total counter",
-    `veil_gameplay_action_messages_total ${health.runtime.gameplayTraffic.actionMessagesTotal}`
+    `veil_gameplay_action_messages_total ${health.runtime.gameplayTraffic.actionMessagesTotal}`,
+    "# HELP veil_auth_guest_sessions Active guest auth sessions tracked by this process.",
+    "# TYPE veil_auth_guest_sessions gauge",
+    `veil_auth_guest_sessions ${health.runtime.auth.activeGuestSessionCount}`,
+    "# HELP veil_auth_account_sessions Active account device sessions tracked by this process.",
+    "# TYPE veil_auth_account_sessions gauge",
+    `veil_auth_account_sessions ${health.runtime.auth.activeAccountSessionCount}`,
+    "# HELP veil_auth_account_locks Active account login lockouts.",
+    "# TYPE veil_auth_account_locks gauge",
+    `veil_auth_account_locks ${health.runtime.auth.activeAccountLockCount}`,
+    "# HELP veil_auth_pending_registrations Pending account registration tokens.",
+    "# TYPE veil_auth_pending_registrations gauge",
+    `veil_auth_pending_registrations ${health.runtime.auth.pendingRegistrationCount}`,
+    "# HELP veil_auth_pending_recoveries Pending password recovery tokens.",
+    "# TYPE veil_auth_pending_recoveries gauge",
+    `veil_auth_pending_recoveries ${health.runtime.auth.pendingRecoveryCount}`,
+    "# HELP veil_auth_session_checks_total Total auth session validations.",
+    "# TYPE veil_auth_session_checks_total counter",
+    `veil_auth_session_checks_total ${health.runtime.auth.counters.sessionChecksTotal}`,
+    "# HELP veil_auth_session_failures_total Total failed auth session validations.",
+    "# TYPE veil_auth_session_failures_total counter",
+    `veil_auth_session_failures_total ${health.runtime.auth.counters.sessionFailuresTotal}`,
+    "# HELP veil_auth_guest_logins_total Total guest login issuances.",
+    "# TYPE veil_auth_guest_logins_total counter",
+    `veil_auth_guest_logins_total ${health.runtime.auth.counters.guestLoginsTotal}`,
+    "# HELP veil_auth_account_logins_total Total account login issuances.",
+    "# TYPE veil_auth_account_logins_total counter",
+    `veil_auth_account_logins_total ${health.runtime.auth.counters.accountLoginsTotal}`,
+    "# HELP veil_auth_account_bindings_total Total guest-to-account binding issuances.",
+    "# TYPE veil_auth_account_bindings_total counter",
+    `veil_auth_account_bindings_total ${health.runtime.auth.counters.accountBindingsTotal}`,
+    "# HELP veil_auth_account_registrations_total Total account registration confirmations.",
+    "# TYPE veil_auth_account_registrations_total counter",
+    `veil_auth_account_registrations_total ${health.runtime.auth.counters.accountRegistrationsTotal}`,
+    "# HELP veil_auth_refreshes_total Total account refresh rotations.",
+    "# TYPE veil_auth_refreshes_total counter",
+    `veil_auth_refreshes_total ${health.runtime.auth.counters.refreshesTotal}`,
+    "# HELP veil_auth_logouts_total Total successful auth logouts.",
+    "# TYPE veil_auth_logouts_total counter",
+    `veil_auth_logouts_total ${health.runtime.auth.counters.logoutsTotal}`,
+    "# HELP veil_auth_rate_limited_total Total auth requests rejected by rate limiting.",
+    "# TYPE veil_auth_rate_limited_total counter",
+    `veil_auth_rate_limited_total ${health.runtime.auth.counters.rateLimitedTotal}`,
+    "# HELP veil_auth_invalid_credentials_total Total auth requests rejected for invalid credentials.",
+    "# TYPE veil_auth_invalid_credentials_total counter",
+    `veil_auth_invalid_credentials_total ${health.runtime.auth.counters.invalidCredentialsTotal}`,
+    "# HELP veil_auth_session_failures_unauthorized_total Total auth session failures caused by missing or invalid credentials.",
+    "# TYPE veil_auth_session_failures_unauthorized_total counter",
+    `veil_auth_session_failures_unauthorized_total ${health.runtime.auth.sessionFailureReasons.unauthorized}`,
+    "# HELP veil_auth_session_failures_token_expired_total Total auth session failures caused by expired tokens.",
+    "# TYPE veil_auth_session_failures_token_expired_total counter",
+    `veil_auth_session_failures_token_expired_total ${health.runtime.auth.sessionFailureReasons.token_expired}`,
+    "# HELP veil_auth_session_failures_token_kind_invalid_total Total auth session failures caused by wrong token kind.",
+    "# TYPE veil_auth_session_failures_token_kind_invalid_total counter",
+    `veil_auth_session_failures_token_kind_invalid_total ${health.runtime.auth.sessionFailureReasons.token_kind_invalid}`,
+    "# HELP veil_auth_session_failures_session_revoked_total Total auth session failures caused by revoked sessions.",
+    "# TYPE veil_auth_session_failures_session_revoked_total counter",
+    `veil_auth_session_failures_session_revoked_total ${health.runtime.auth.sessionFailureReasons.session_revoked}`
   ].join("\n");
 }
 
@@ -146,12 +316,123 @@ export function recordBattleActionMessage(): void {
   runtimeObservability.counters.battleActionsTotal += 1;
 }
 
+export function setAuthGuestSessionCount(count: number): void {
+  runtimeObservability.auth.activeGuestSessionCount = Math.max(0, Math.floor(count));
+}
+
+export function upsertAuthAccountSession(playerId: string, sessionId: string, provider: string): void {
+  const normalizedPlayerId = playerId.trim();
+  const normalizedSessionId = sessionId.trim();
+  if (!normalizedPlayerId || !normalizedSessionId) {
+    return;
+  }
+
+  runtimeObservability.auth.activeAccountSessions.set(normalizedSessionId, {
+    playerId: normalizedPlayerId,
+    provider: provider.trim() || "account-password"
+  });
+}
+
+export function removeAuthAccountSession(sessionId: string): void {
+  const normalizedSessionId = sessionId.trim();
+  if (!normalizedSessionId) {
+    return;
+  }
+
+  runtimeObservability.auth.activeAccountSessions.delete(normalizedSessionId);
+}
+
+export function removeAuthAccountSessionsForPlayer(playerId: string): void {
+  const normalizedPlayerId = playerId.trim();
+  if (!normalizedPlayerId) {
+    return;
+  }
+
+  for (const [sessionId, session] of runtimeObservability.auth.activeAccountSessions.entries()) {
+    if (session.playerId === normalizedPlayerId) {
+      runtimeObservability.auth.activeAccountSessions.delete(sessionId);
+    }
+  }
+}
+
+export function setAuthAccountLockCount(count: number): void {
+  runtimeObservability.auth.activeAccountLockCount = Math.max(0, Math.floor(count));
+}
+
+export function setPendingAuthRegistrationCount(count: number): void {
+  runtimeObservability.auth.pendingRegistrationCount = Math.max(0, Math.floor(count));
+}
+
+export function setPendingAuthRecoveryCount(count: number): void {
+  runtimeObservability.auth.pendingRecoveryCount = Math.max(0, Math.floor(count));
+}
+
+export function recordAuthSessionCheck(): void {
+  runtimeObservability.auth.counters.sessionChecksTotal += 1;
+}
+
+export function recordAuthSessionFailure(reason: AuthSessionFailureReason): void {
+  runtimeObservability.auth.counters.sessionFailuresTotal += 1;
+  runtimeObservability.auth.sessionFailureReasons[reason] += 1;
+}
+
+export function recordAuthGuestLogin(): void {
+  runtimeObservability.auth.counters.guestLoginsTotal += 1;
+}
+
+export function recordAuthAccountLogin(): void {
+  runtimeObservability.auth.counters.accountLoginsTotal += 1;
+}
+
+export function recordAuthAccountBinding(): void {
+  runtimeObservability.auth.counters.accountBindingsTotal += 1;
+}
+
+export function recordAuthAccountRegistration(): void {
+  runtimeObservability.auth.counters.accountRegistrationsTotal += 1;
+}
+
+export function recordAuthRefresh(): void {
+  runtimeObservability.auth.counters.refreshesTotal += 1;
+}
+
+export function recordAuthLogout(): void {
+  runtimeObservability.auth.counters.logoutsTotal += 1;
+}
+
+export function recordAuthRateLimited(): void {
+  runtimeObservability.auth.counters.rateLimitedTotal += 1;
+}
+
+export function recordAuthInvalidCredentials(): void {
+  runtimeObservability.auth.counters.invalidCredentialsTotal += 1;
+}
+
 export function resetRuntimeObservability(): void {
   runtimeObservability.startedAt = Date.now();
   runtimeObservability.rooms.clear();
   runtimeObservability.counters.connectMessagesTotal = 0;
   runtimeObservability.counters.worldActionsTotal = 0;
   runtimeObservability.counters.battleActionsTotal = 0;
+  runtimeObservability.auth.counters.sessionChecksTotal = 0;
+  runtimeObservability.auth.counters.sessionFailuresTotal = 0;
+  runtimeObservability.auth.counters.guestLoginsTotal = 0;
+  runtimeObservability.auth.counters.accountLoginsTotal = 0;
+  runtimeObservability.auth.counters.accountBindingsTotal = 0;
+  runtimeObservability.auth.counters.accountRegistrationsTotal = 0;
+  runtimeObservability.auth.counters.refreshesTotal = 0;
+  runtimeObservability.auth.counters.logoutsTotal = 0;
+  runtimeObservability.auth.counters.rateLimitedTotal = 0;
+  runtimeObservability.auth.counters.invalidCredentialsTotal = 0;
+  runtimeObservability.auth.activeGuestSessionCount = 0;
+  runtimeObservability.auth.activeAccountSessions.clear();
+  runtimeObservability.auth.activeAccountLockCount = 0;
+  runtimeObservability.auth.pendingRegistrationCount = 0;
+  runtimeObservability.auth.pendingRecoveryCount = 0;
+  runtimeObservability.auth.sessionFailureReasons.unauthorized = 0;
+  runtimeObservability.auth.sessionFailureReasons.token_expired = 0;
+  runtimeObservability.auth.sessionFailureReasons.token_kind_invalid = 0;
+  runtimeObservability.auth.sessionFailureReasons.session_revoked = 0;
 }
 
 export function registerRuntimeObservabilityRoutes(
@@ -192,6 +473,14 @@ export function registerRuntimeObservabilityRoutes(
       response.statusCode = 200;
       response.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
       response.end(`${buildMetricsDocument()}\n`);
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/runtime/auth-readiness", async (_request, response) => {
+    try {
+      sendJson(response, 200, buildAuthReadinessPayload(serviceName));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -19,6 +19,7 @@ import {
   validateAuthSessionFromRequest,
   verifyAccountPassword
 } from "./auth";
+import { recordAuthInvalidCredentials, removeAuthAccountSession, removeAuthAccountSessionsForPlayer } from "./observability";
 import type {
   PlayerAccountProfilePatch,
   PlayerAccountSnapshot,
@@ -561,6 +562,7 @@ export function registerPlayerAccountRoutes(
         return;
       }
 
+      removeAuthAccountSession(sessionId);
       const items = await store.listPlayerAccountAuthSessions(authSession.playerId);
       sendJson(response, 200, {
         ok: true,
@@ -1366,6 +1368,7 @@ export function registerPlayerAccountRoutes(
 
         const authAccount = await store.loadPlayerAccountAuthByPlayerId(authSession.playerId);
         if (!authAccount || !verifyAccountPassword(currentPassword, authAccount.passwordHash)) {
+          recordAuthInvalidCredentials();
           sendJson(response, 401, {
             error: {
               code: "invalid_credentials",
@@ -1386,6 +1389,7 @@ export function registerPlayerAccountRoutes(
             accountSessionVersion: revokedAuth.accountSessionVersion
           });
         }
+        removeAuthAccountSessionsForPlayer(authSession.playerId);
         account =
           (await store.loadPlayerAccount(authSession.playerId)) ??
           ({

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -12,6 +12,7 @@ import {
   type GuestAuthSession
 } from "../src/auth";
 import { configureRoomSnapshotStore, VeilColyseusRoom } from "../src/colyseus-room";
+import { registerRuntimeObservabilityRoutes, resetRuntimeObservability } from "../src/observability";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import type {
   PlayerAccountProgressPatch,
@@ -327,9 +328,11 @@ class MemoryAuthStore implements RoomSnapshotStore {
 async function startAuthServer(port: number, store: RoomSnapshotStore | null = null): Promise<Server> {
   configureRoomSnapshotStore(store);
   resetGuestAuthSessions();
+  resetRuntimeObservability();
   const transport = new WebSocketTransport();
   registerAuthRoutes(transport.getExpressApp() as never, store);
   registerPlayerAccountRoutes(transport.getExpressApp() as never, store);
+  registerRuntimeObservabilityRoutes(transport.getExpressApp() as never);
   const server = new Server({ transport });
   server.define("veil", VeilColyseusRoom).filterBy(["logicalRoomId"]);
   await server.listen(port, "127.0.0.1");
@@ -778,6 +781,147 @@ test("refresh rotation invalidates the previous refresh token and logout revokes
 
   assert.equal(revokedRefreshResponse.status, 401);
   assert.equal(revokedRefreshPayload.error.code, "session_revoked");
+});
+
+test("auth readiness and metrics summarize auth posture for dashboards", async (t) => {
+  const port = 44590 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  await store.bindPlayerAccountCredentials("metrics-player", {
+    loginId: "metrics-ranger",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    resetRuntimeObservability();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const guestLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: "metrics-guest",
+      displayName: "指标访客"
+    })
+  });
+  const guestLoginPayload = (await guestLoginResponse.json()) as { session: GuestAuthSession };
+  assert.equal(guestLoginResponse.status, 200);
+
+  const accountLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "Metrics Browser"
+    },
+    body: JSON.stringify({
+      loginId: "metrics-ranger",
+      password: "hunter2"
+    })
+  });
+  const accountLoginPayload = (await accountLoginResponse.json()) as { session: GuestAuthSession };
+  assert.equal(accountLoginResponse.status, 200);
+
+  const revokedRefreshResponse = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accountLoginPayload.session.refreshToken}`
+    }
+  });
+  const rotatedPayload = (await revokedRefreshResponse.json()) as { session: GuestAuthSession };
+  assert.equal(revokedRefreshResponse.status, 200);
+
+  const staleRefreshResponse = await fetch(`http://127.0.0.1:${port}/api/auth/refresh`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accountLoginPayload.session.refreshToken}`
+    }
+  });
+  assert.equal(staleRefreshResponse.status, 401);
+
+  const invalidLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "metrics-ranger",
+      password: "wrong-password"
+    })
+  });
+  assert.equal(invalidLoginResponse.status, 401);
+
+  const healthResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/health`);
+  const healthPayload = (await healthResponse.json()) as {
+    runtime: {
+      auth: {
+        activeGuestSessionCount: number;
+        activeAccountSessionCount: number;
+        counters: {
+          guestLoginsTotal: number;
+          accountLoginsTotal: number;
+          refreshesTotal: number;
+          invalidCredentialsTotal: number;
+          sessionFailuresTotal: number;
+        };
+        sessionFailureReasons: {
+          session_revoked: number;
+        };
+      };
+    };
+  };
+
+  assert.equal(healthResponse.status, 200);
+  assert.equal(healthPayload.runtime.auth.activeGuestSessionCount, 1);
+  assert.equal(healthPayload.runtime.auth.activeAccountSessionCount, 1);
+  assert.equal(healthPayload.runtime.auth.counters.guestLoginsTotal, 1);
+  assert.equal(healthPayload.runtime.auth.counters.accountLoginsTotal, 1);
+  assert.equal(healthPayload.runtime.auth.counters.refreshesTotal, 1);
+  assert.equal(healthPayload.runtime.auth.counters.invalidCredentialsTotal, 1);
+  assert.equal(healthPayload.runtime.auth.counters.sessionFailuresTotal, 1);
+  assert.equal(healthPayload.runtime.auth.sessionFailureReasons.session_revoked, 1);
+
+  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
+  const readinessPayload = (await readinessResponse.json()) as {
+    status: string;
+    headline: string;
+    alerts: string[];
+    auth: {
+      activeGuestSessionCount: number;
+      activeAccountSessionCount: number;
+    };
+  };
+
+  assert.equal(readinessResponse.status, 200);
+  assert.equal(readinessPayload.status, "ok");
+  assert.match(readinessPayload.headline, /guest=1 account=1 lockouts=0/);
+  assert.deepEqual(readinessPayload.alerts, []);
+  assert.equal(readinessPayload.auth.activeGuestSessionCount, 1);
+  assert.equal(readinessPayload.auth.activeAccountSessionCount, 1);
+
+  const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);
+  const metricsText = await metricsResponse.text();
+
+  assert.equal(metricsResponse.status, 200);
+  assert.match(metricsText, /^veil_auth_guest_sessions 1$/m);
+  assert.match(metricsText, /^veil_auth_account_sessions 1$/m);
+  assert.match(metricsText, /^veil_auth_guest_logins_total 1$/m);
+  assert.match(metricsText, /^veil_auth_account_logins_total 1$/m);
+  assert.match(metricsText, /^veil_auth_refreshes_total 1$/m);
+  assert.match(metricsText, /^veil_auth_invalid_credentials_total 1$/m);
+  assert.match(metricsText, /^veil_auth_session_failures_total 1$/m);
+  assert.match(metricsText, /^veil_auth_session_failures_session_revoked_total 1$/m);
+
+  const logoutResponse = await fetch(`http://127.0.0.1:${port}/api/auth/logout`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${rotatedPayload.session.token}`
+    }
+  });
+  assert.equal(logoutResponse.status, 200);
 });
 
 test("revoking one device session leaves other account sessions active and blocks further refreshes for the revoked device", async (t) => {

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -124,6 +124,13 @@ test("runtime observability routes expose live room counts and gameplay traffic"
         battleActionsTotal: number;
         actionMessagesTotal: number;
       };
+      auth: {
+        activeGuestSessionCount: number;
+        activeAccountSessionCount: number;
+        counters: {
+          sessionChecksTotal: number;
+        };
+      };
     };
   };
 
@@ -136,6 +143,19 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(healthPayload.runtime.gameplayTraffic.worldActionsTotal, 1);
   assert.equal(healthPayload.runtime.gameplayTraffic.battleActionsTotal, 0);
   assert.equal(healthPayload.runtime.gameplayTraffic.actionMessagesTotal, 1);
+  assert.equal(healthPayload.runtime.auth.activeGuestSessionCount, 0);
+  assert.equal(healthPayload.runtime.auth.activeAccountSessionCount, 0);
+  assert.equal(healthPayload.runtime.auth.counters.sessionChecksTotal, 0);
+
+  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
+  const readinessPayload = (await readinessResponse.json()) as {
+    status: string;
+    headline: string;
+  };
+
+  assert.equal(readinessResponse.status, 200);
+  assert.equal(readinessPayload.status, "ok");
+  assert.match(readinessPayload.headline, /guest=0 account=0 lockouts=0/);
 
   const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);
   const metricsText = await metricsResponse.text();
@@ -148,4 +168,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(metricsText, /^veil_connect_messages_total 1$/m);
   assert.match(metricsText, /^veil_world_actions_total 1$/m);
   assert.match(metricsText, /^veil_gameplay_action_messages_total 1$/m);
+  assert.match(metricsText, /^veil_auth_guest_sessions 0$/m);
+  assert.match(metricsText, /^veil_auth_account_sessions 0$/m);
+  assert.match(metricsText, /^veil_auth_session_checks_total 0$/m);
 });

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -25,6 +25,18 @@
 - `DELETE /api/player-accounts/me/sessions/:sessionId` 仅允许撤销“非当前设备”的会话；被撤销的设备会话会立刻从列表消失，且旧刷新令牌随后会返回 `401 session_revoked`。
 - `POST /api/auth/logout` 与口令修改仍然属于“全量撤销”：会清空当前账号全部设备会话，并通过提升 `accountSessionVersion` 让旧访问令牌也一起失效。
 
+## 鉴权观测面
+
+- `GET /api/runtime/health` 现已附带 `runtime.auth`，用于和现有运行时健康面一起查看鉴权态势。
+- `GET /api/runtime/auth-readiness` 提供更紧凑的鉴权摘要，适合直接接现有 dashboard / alerting tooling。
+- `GET /api/runtime/metrics` 现已补充以下 Prometheus 指标：
+  - 当前进程内活跃游客会话：`veil_auth_guest_sessions`
+  - 当前进程内活跃正式账号设备会话：`veil_auth_account_sessions`
+  - 当前登录锁定数：`veil_auth_account_locks`
+  - 待确认注册 / 找回令牌：`veil_auth_pending_registrations`、`veil_auth_pending_recoveries`
+  - 会话校验、游客登录、账号登录、绑定、注册确认、刷新、退出、限流、口令错误等累计计数：`veil_auth_*_total`
+- 以上“活跃会话”指标是当前服务进程内的运行时视角，适合做本机 readiness / traffic 观测；若部署多实例，应按实例维度抓取再在监控端汇总。
+
 ## 正式注册闭环
 
 ### 1. 发起注册


### PR DESCRIPTION
## Summary
- extend runtime observability with auth/session counters, active session gauges, and Prometheus metrics
- add a compact `/api/runtime/auth-readiness` summary for dashboard and alert consumption
- cover the new auth observability surface with server tests and document the new endpoints

## Testing
- node --import tsx --test ./apps/server/test/runtime-observability-routes.test.ts ./apps/server/test/auth-guest-login.test.ts
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
