### PR TITLE
Polish multiplayer encounter UX and room-state feedback

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -127,6 +127,8 @@ interface BattleSettlementSummary {
   title: string;
   summary: string;
   aftermath: string;
+  roomState: string;
+  nextAction: string;
   tone: "victory" | "defeat" | "neutral";
 }
 
@@ -1867,6 +1869,10 @@ function formatVisibleHeroSummary(
   return `玩家 ${hero.playerId} · 英雄 ${hero.name || hero.id} · 坐标 (${hero.position.x},${hero.position.y})`;
 }
 
+function activeHeroSnapshot(world: PlayerWorldView = state.world): PlayerWorldView["ownHeroes"][number] | null {
+  return world.ownHeroes[0] ?? null;
+}
+
 function opposingHeroId(battle: BattleState, world: PlayerWorldView = state.world): string | null {
   const playerCamp = controlledBattleCamp(battle, world);
   if (!playerCamp) {
@@ -1916,6 +1922,91 @@ function renderEncounterHeadline(): { phase: string; detail: string } {
   };
 }
 
+function resolveEncounterOpponentContext(): {
+  label: string;
+  detail: string;
+} | null {
+  const playerCamp = state.battle ? controlledBattleCamp(state.battle, state.world) : null;
+
+  if (state.battle?.defenderHeroId) {
+    const opponentId = opposingHeroId(state.battle, state.world);
+    const opponent = findHeroSnapshot(opponentId, state.world);
+    return {
+      label: "对手信息",
+      detail: `${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：战斗中 · 我方席位：${
+        playerCamp === "attacker" ? "进攻方" : "防守方"
+      }`
+    };
+  }
+
+  if (state.battle?.neutralArmyId) {
+    return {
+      label: "遭遇目标",
+      detail: `${state.battle.neutralArmyId} · 房间态：战斗中`
+    };
+  }
+
+  if (state.previewPlan?.endsInEncounter && state.previewPlan.encounterKind === "hero") {
+    const opponent = findHeroSnapshot(state.previewPlan.encounterRefId, state.world);
+    return {
+      label: "对手信息",
+      detail: `${formatVisibleHeroSummary(opponent, state.previewPlan.encounterRefId)} · 房间态：待接敌`
+    };
+  }
+
+  if (state.previewPlan?.endsInEncounter && state.previewPlan.encounterKind === "neutral") {
+    return {
+      label: "遭遇目标",
+      detail: `${state.previewPlan.encounterRefId ?? "neutral"} · 房间态：待接敌`
+    };
+  }
+
+  if (state.lastBattleSettlement && state.lastEncounterStarted) {
+    if (state.lastEncounterStarted.encounterKind === "hero") {
+      const ownedIds = ownedHeroIds(state.world);
+      const opponentId = ownedIds.has(state.lastEncounterStarted.heroId)
+        ? state.lastEncounterStarted.defenderHeroId ?? null
+        : state.lastEncounterStarted.heroId;
+      const opponent = findHeroSnapshot(opponentId, state.world);
+      return {
+        label: "最近对手",
+        detail: `${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：已结算`
+      };
+    }
+
+    return {
+      label: "最近遭遇",
+      detail: `${state.lastEncounterStarted.neutralArmyId ?? "neutral"} · 房间态：已结算`
+    };
+  }
+
+  return null;
+}
+
+function renderRoomResultSummary(): string {
+  if (state.lastBattleSettlement) {
+    return `房间结果：${state.lastBattleSettlement.roomState}`;
+  }
+
+  if (state.battle) {
+    return "房间结果：多人遭遇战已接管地图行动，待战斗链路关闭后统一回写房间状态。";
+  }
+
+  if (state.diagnostics.connectionStatus === "reconnecting") {
+    return "恢复状态：正在恢复连接与房间主状态，期间可能短暂保留上一帧视图。";
+  }
+
+  if (state.diagnostics.connectionStatus === "reconnect_failed") {
+    return "恢复状态：正在通过最近快照回补房间，等待权威状态确认当前可行动信息。";
+  }
+
+  if (state.predictionStatus.includes("已回放本地缓存状态")) {
+    return `恢复状态：${state.predictionStatus}`;
+  }
+
+  return "房间结果：当前处于稳定探索态，等待新的移动、交互或多人遭遇。";
+}
+
 function buildBattleSettlementSummary(
   event: Extract<SessionUpdate["events"][number], { type: "battle.resolved" }>,
   world: PlayerWorldView,
@@ -1939,6 +2030,15 @@ function buildBattleSettlementSummary(
         : `${progressEvent.experienceGained} 经验`
       : null;
   const summaryParts = [rewardText, equipmentText ? `装备 ${equipmentText}` : null, progressText].filter(Boolean);
+  const hero = activeHeroSnapshot(world);
+  const winnerNextAction =
+    hero && hero.move.remaining > 0
+      ? "当前英雄仍可继续移动、交互，或直接推进到下一天。"
+      : "当前英雄本日行动已接近结束，可等待其他玩家或直接结束当天。";
+  const loserNextAction =
+    hero && hero.move.remaining > 0
+      ? "可先整理当前房间态，再决定是否继续行动。"
+      : "当前英雄已无法继续移动，建议等待其他玩家推进房间或直接结束当天。";
 
   if (didWin) {
     return {
@@ -1947,6 +2047,10 @@ function buildBattleSettlementSummary(
         ? `已击败 ${formatHeroIdentity(opponent, event.defenderHeroId)}。`
         : "已击败本次守军。",
       aftermath: summaryParts.length > 0 ? `结算收益：${summaryParts.join(" · ")}。` : "结算完成，可继续处理房间内后续操作。",
+      roomState: event.defenderHeroId
+        ? "英雄遭遇已关闭，房间已回到地图探索阶段，本次结果已对双方同步生效。"
+        : "守军已清除，房间已回到地图探索阶段，可继续接管地图交互。",
+      nextAction: winnerNextAction,
       tone: "victory"
     };
   }
@@ -1957,6 +2061,10 @@ function buildBattleSettlementSummary(
       ? `遭遇战失利，对手 ${formatHeroIdentity(opponent, event.defenderHeroId ?? event.heroId)} 仍留在房间内。`
       : "本次遭遇战失利。",
     aftermath: "英雄被击退，生命值下降且本日移动力清零。",
+    roomState: event.defenderHeroId
+      ? "英雄遭遇已关闭，对手仍保留在房间地图上，当前结算已同步回写。"
+      : "守军仍保留在房间地图上，当前结算已同步回写。",
+    nextAction: loserNextAction,
     tone: "defeat"
   };
 }
@@ -2033,6 +2141,10 @@ function rollbackPendingPrediction(reason?: string): void {
 
 function applyReplayedUpdate(update: SessionUpdate): void {
   clearPendingPrediction();
+  const replayResolved = update.events.find(isBattleEvent);
+  const replayStarted = update.events.find(
+    (event): event is Extract<SessionUpdate["events"][number], { type: "battle.started" }> => event.type === "battle.started"
+  );
   state.world = update.world;
   state.battle = update.battle;
   state.previewPlan = null;
@@ -2043,7 +2155,11 @@ function applyReplayedUpdate(update: SessionUpdate): void {
   state.selectedBattleTargetId = null;
   state.feedbackTone = update.battle ? "battle" : "idle";
   state.pendingBattleAction = null;
-  state.lastBattleSettlement = null;
+  state.lastBattleSettlement =
+    replayResolved?.type === "battle.resolved" ? buildBattleSettlementSummary(replayResolved, update.world, update.events) : null;
+  if (replayStarted) {
+    state.lastEncounterStarted = replayStarted;
+  }
   state.predictionStatus = "已回放本地缓存状态，正在等待房间同步...";
   state.log.unshift("已从本地缓存回放最近房间状态");
   state.log = state.log.slice(0, 12);
@@ -2464,6 +2580,8 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
       title: "战斗结束",
       summary: "本场遭遇已结束。",
       aftermath: "房间状态已回到地图探索，可继续验证后续流程。",
+      roomState: "本场遭遇链路已经关闭，房间已回到地图探索阶段。",
+      nextAction: "可继续地图移动、交互，或等待其他玩家完成后续操作。",
       tone: "neutral"
     };
     openBattleModal("战斗结束", "本场遭遇已结束。");
@@ -3389,14 +3507,10 @@ function renderBattleIntelPanel(): string {
 function renderRoomStatusPanel(): string {
   const encounter = renderEncounterHeadline();
   const hero = activeHero();
-  const opponentId = state.battle ? opposingHeroId(state.battle, state.world) : state.previewPlan?.encounterRefId ?? null;
-  const opponent = findHeroSnapshot(opponentId, state.world);
-  const opponentLine =
-    state.battle?.defenderHeroId || state.previewPlan?.encounterKind === "hero"
-      ? `对手信息：${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：${state.battle ? "战斗中" : "待接敌"}`
-      : state.battle?.neutralArmyId || state.previewPlan?.encounterKind === "neutral"
-        ? `遭遇目标：${state.battle?.neutralArmyId ?? state.previewPlan?.encounterRefId ?? "neutral"} · 房间态：${state.battle ? "战斗中" : "待接敌"}`
-        : "对手信息：当前没有遭遇目标";
+  const opponentContext = resolveEncounterOpponentContext();
+  const opponentLine = opponentContext
+    ? `${opponentContext.label}：${opponentContext.detail}`
+    : "对手信息：当前没有遭遇目标";
   const playerSummary = hero
     ? `我方状态：${hero.name} · HP ${hero.stats.hp}/${hero.stats.maxHp} · Move ${hero.move.remaining}/${hero.move.total}`
     : "我方状态：等待英雄数据同步";
@@ -3421,6 +3535,7 @@ function renderRoomStatusPanel(): string {
         diagnostics: state.diagnostics,
         predictionStatus: state.predictionStatus
       })}</p>
+      <p class="muted" data-testid="room-result-summary" data-tone="${roomFeedbackTone}">${renderRoomResultSummary()}</p>
       <p class="muted" data-testid="opponent-summary">${opponentLine}</p>
       <div class="room-status-chips">
         <span class="battle-intel-chip" data-testid="room-player-summary">${playerSummary}</span>
@@ -3429,7 +3544,9 @@ function renderRoomStatusPanel(): string {
       <p class="muted" data-testid="room-next-action" data-tone="${roomFeedbackTone}">${renderRoomActionHint({
         battle: state.battle,
         lastBattleSettlement: state.lastBattleSettlement,
-        activeHero: activeHero()
+        activeHero: activeHero(),
+        diagnostics: state.diagnostics,
+        predictionStatus: state.predictionStatus
       })}</p>
     </section>
   `;
@@ -3451,6 +3568,8 @@ function renderBattleSettlementPanel(): string {
       </div>
       <p data-testid="battle-settlement-summary">${state.lastBattleSettlement.summary}</p>
       <p class="muted" data-testid="battle-settlement-aftermath">${state.lastBattleSettlement.aftermath}</p>
+      <p class="muted" data-testid="battle-settlement-room-state">${state.lastBattleSettlement.roomState}</p>
+      <p class="muted" data-testid="battle-settlement-next-action">${state.lastBattleSettlement.nextAction}</p>
     </section>
   `;
 }

--- a/apps/client/src/room-feedback.ts
+++ b/apps/client/src/room-feedback.ts
@@ -2,6 +2,7 @@ import type { BattleState, CocosBattleFeedbackTone, MovementPlan, PlayerWorldVie
 import type { SessionUpdate } from "./local-session";
 
 interface BattleSettlementSummaryLike {
+  title?: string;
   aftermath: string;
 }
 
@@ -26,6 +27,8 @@ export interface RoomActionHintInput {
   battle: BattleState | null;
   lastBattleSettlement: BattleSettlementSummaryLike | null;
   activeHero: ActiveHeroLike | null;
+  diagnostics: DiagnosticStateLike;
+  predictionStatus: string;
 }
 
 export interface AppState {
@@ -65,41 +68,52 @@ export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): 
     const ownedIds = ownedHeroIds(input.world);
     if (event.encounterKind === "hero") {
       return ownedIds.has(event.heroId)
-        ? "遭遇来源：我方主动接触敌方英雄并进入房间内对抗。"
-        : "遭遇来源：敌方英雄先手接触我方并拉入对抗。";
+        ? "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到多人遭遇战结算。"
+        : "遭遇来源：敌方英雄先手接触我方，当前房间已切到多人遭遇战结算。";
     }
 
     return event.initiator === "neutral"
-      ? "遭遇来源：中立守军主动拦截，房间已切换到战斗结算链路。"
-      : "遭遇来源：我方接触了中立守军，房间已切换到战斗结算链路。";
+      ? "遭遇来源：中立守军主动拦截，当前房间已切到遭遇战结算链路。"
+      : "遭遇来源：我方接触了中立守军，当前房间已切到遭遇战结算链路。";
   }
 
   if (input.previewPlan?.endsInEncounter) {
     return input.previewPlan.encounterKind === "hero"
-      ? "遭遇提示：确认移动后会立即切入英雄对抗。"
-      : "遭遇提示：确认移动后会立即切入中立战斗。";
+      ? "遭遇提示：确认移动后会立刻接敌，并锁定到英雄遭遇战。"
+      : "遭遇提示：确认移动后会立刻接敌，并锁定到中立遭遇战。";
   }
 
   if (input.lastBattleSettlement) {
-    return "战后反馈：房间权威状态已回写到地图，可直接继续联调后续房间动作。";
+    return "战后反馈：本场结果已结算并回写到房间地图，可按当前结果继续移动、推进回合或等待对手。";
   }
 
   if (input.diagnostics.connectionStatus === "reconnecting") {
-    return "连接反馈：房间连接中断，正在尝试恢复当前多人状态。";
+    return "连接反馈：房间连接中断，正在恢复多人房间与战斗归属；恢复前请以权威状态为准。";
   }
 
   if (input.diagnostics.connectionStatus === "reconnect_failed") {
-    return "连接反馈：旧连接恢复失败，正在通过最近快照恢复房间。";
+    return "连接反馈：旧连接恢复失败，正在通过最近快照回补房间；短暂期间可能只显示缓存状态。";
   }
 
   if (input.predictionStatus.includes("已回放本地缓存状态")) {
     return `连接反馈：${input.predictionStatus}`;
   }
 
-  return "遭遇提示：当前房间处于稳定同步状态，可继续探索或等待新的多人交互。";
+  return "遭遇提示：当前房间同步稳定，可继续探索、观察对手位置或等待新的多人交互。";
 }
 
 export function renderRoomActionHint(input: RoomActionHintInput): string {
+  if (input.diagnostics.connectionStatus === "reconnecting") {
+    return "下一步：等待重连恢复完成；此时先不要依赖本地预览判断最终房间结果。";
+  }
+
+  if (
+    input.diagnostics.connectionStatus === "reconnect_failed" ||
+    input.predictionStatus.includes("已回放本地缓存状态")
+  ) {
+    return "下一步：等待权威房间状态回补；恢复完成后再继续地图移动或确认战后结果。";
+  }
+
   if (input.battle) {
     return "下一步：继续完成当前回合内操作，等待本场对抗结算。";
   }
@@ -111,7 +125,7 @@ export function renderRoomActionHint(input: RoomActionHintInput): string {
   if (input.lastBattleSettlement) {
     return input.activeHero.move.remaining > 0
       ? "下一步：当前英雄仍可继续移动、交互，或直接推进到下一天。"
-      : "下一步：当前英雄移动力已耗尽，可推进到下一天或等待其他玩家。";
+      : "下一步：当前英雄移动力已耗尽，可等待其他玩家推进房间或直接结束当天。";
   }
 
   return input.activeHero.move.remaining > 0

--- a/apps/client/test/room-feedback.test.ts
+++ b/apps/client/test/room-feedback.test.ts
@@ -106,7 +106,7 @@ function createEncounterStartedEvent(
     battleKind: "hero",
     encounterKind: "hero",
     heroId: "hero-1",
-    opponentHeroId: "hero-2",
+    defenderHeroId: "hero-2",
     initiator: "hero",
     ...overrides
   };
@@ -151,7 +151,7 @@ test("renderEncounterSourceDetail covers active hero encounter initiative branch
       battle: activeBattle,
       lastEncounterStarted: createEncounterStartedEvent()
     }),
-    "遭遇来源：我方主动接触敌方英雄并进入房间内对抗。"
+    "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到多人遭遇战结算。"
   );
 
   assert.equal(
@@ -160,10 +160,10 @@ test("renderEncounterSourceDetail covers active hero encounter initiative branch
       battle: activeBattle,
       lastEncounterStarted: createEncounterStartedEvent({
         heroId: "hero-2",
-        opponentHeroId: "hero-1"
+        defenderHeroId: "hero-1"
       })
     }),
-    "遭遇来源：敌方英雄先手接触我方并拉入对抗。"
+    "遭遇来源：敌方英雄先手接触我方，当前房间已切到多人遭遇战结算。"
   );
 });
 
@@ -181,7 +181,7 @@ test("renderEncounterSourceDetail covers active neutral encounter initiator bran
         initiator: "neutral"
       })
     }),
-    "遭遇来源：中立守军主动拦截，房间已切换到战斗结算链路。"
+    "遭遇来源：中立守军主动拦截，当前房间已切到遭遇战结算链路。"
   );
 
   assert.equal(
@@ -195,7 +195,7 @@ test("renderEncounterSourceDetail covers active neutral encounter initiator bran
         initiator: "hero"
       })
     }),
-    "遭遇来源：我方接触了中立守军，房间已切换到战斗结算链路。"
+    "遭遇来源：我方接触了中立守军，当前房间已切到遭遇战结算链路。"
   );
 });
 
@@ -209,7 +209,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
         encounterRefId: "hero-2"
       })
     }),
-    "遭遇提示：确认移动后会立即切入英雄对抗。"
+    "遭遇提示：确认移动后会立刻接敌，并锁定到英雄遭遇战。"
   );
 
   assert.equal(
@@ -221,7 +221,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
         encounterRefId: "neutral-1"
       })
     }),
-    "遭遇提示：确认移动后会立即切入中立战斗。"
+    "遭遇提示：确认移动后会立刻接敌，并锁定到中立遭遇战。"
   );
 
   assert.equal(
@@ -231,7 +231,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
         aftermath: "已结算"
       }
     }),
-    "战后反馈：房间权威状态已回写到地图，可直接继续联调后续房间动作。"
+    "战后反馈：本场结果已结算并回写到房间地图，可按当前结果继续移动、推进回合或等待对手。"
   );
 
   assert.equal(
@@ -241,7 +241,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
         connectionStatus: "reconnecting"
       }
     }),
-    "连接反馈：房间连接中断，正在尝试恢复当前多人状态。"
+    "连接反馈：房间连接中断，正在恢复多人房间与战斗归属；恢复前请以权威状态为准。"
   );
 
   assert.equal(
@@ -251,7 +251,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
         connectionStatus: "reconnect_failed"
       }
     }),
-    "连接反馈：旧连接恢复失败，正在通过最近快照恢复房间。"
+    "连接反馈：旧连接恢复失败，正在通过最近快照回补房间；短暂期间可能只显示缓存状态。"
   );
 
   assert.equal(
@@ -263,7 +263,43 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
   );
 });
 
-test("renderRoomActionHint covers battle active and missing hero states", () => {
+test("renderRoomActionHint covers recovery, battle active, and missing hero states", () => {
+  assert.equal(
+    renderRoomActionHint({
+      battle: null,
+      lastBattleSettlement: null,
+      activeHero: {
+        move: {
+          total: 6,
+          remaining: 4
+        }
+      },
+      diagnostics: {
+        connectionStatus: "reconnecting"
+      },
+      predictionStatus: ""
+    }),
+    "下一步：等待重连恢复完成；此时先不要依赖本地预览判断最终房间结果。"
+  );
+
+  assert.equal(
+    renderRoomActionHint({
+      battle: null,
+      lastBattleSettlement: null,
+      activeHero: {
+        move: {
+          total: 6,
+          remaining: 4
+        }
+      },
+      diagnostics: {
+        connectionStatus: "reconnect_failed"
+      },
+      predictionStatus: ""
+    }),
+    "下一步：等待权威房间状态回补；恢复完成后再继续地图移动或确认战后结果。"
+  );
+
   assert.equal(
     renderRoomActionHint({
       battle: createBattle(),
@@ -273,7 +309,11 @@ test("renderRoomActionHint covers battle active and missing hero states", () => 
           total: 6,
           remaining: 4
         }
-      }
+      },
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
     }),
     "下一步：继续完成当前回合内操作，等待本场对抗结算。"
   );
@@ -282,7 +322,11 @@ test("renderRoomActionHint covers battle active and missing hero states", () => 
     renderRoomActionHint({
       battle: null,
       lastBattleSettlement: null,
-      activeHero: null
+      activeHero: null,
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
     }),
     "下一步：等待房间首帧同步完成。"
   );
@@ -300,7 +344,11 @@ test("renderRoomActionHint covers settlement and exploration move branches", () 
           total: 6,
           remaining: 2
         }
-      }
+      },
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
     }),
     "下一步：当前英雄仍可继续移动、交互，或直接推进到下一天。"
   );
@@ -316,9 +364,13 @@ test("renderRoomActionHint covers settlement and exploration move branches", () 
           total: 6,
           remaining: 0
         }
-      }
+      },
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
     }),
-    "下一步：当前英雄移动力已耗尽，可推进到下一天或等待其他玩家。"
+    "下一步：当前英雄移动力已耗尽，可等待其他玩家推进房间或直接结束当天。"
   );
 
   assert.equal(
@@ -330,7 +382,11 @@ test("renderRoomActionHint covers settlement and exploration move branches", () 
           total: 6,
           remaining: 3
         }
-      }
+      },
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
     }),
     "下一步：选择地图格继续探索；若接敌，将自动切入对抗。"
   );
@@ -344,7 +400,11 @@ test("renderRoomActionHint covers settlement and exploration move branches", () 
           total: 6,
           remaining: 0
         }
-      }
+      },
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
     }),
     "下一步：当前英雄今日已无移动力，可推进到下一天。"
   );

--- a/tests/e2e/pvp-hero-encounter.spec.ts
+++ b/tests/e2e/pvp-hero-encounter.spec.ts
@@ -36,10 +36,11 @@ test("two players can enter a hero-vs-hero battle and resolve it with correct tu
   await expect(playerOnePage.getByTestId("room-phase")).toHaveText("战斗中");
   await expect(playerTwoPage.getByTestId("room-phase")).toHaveText("战斗中");
   await expect(playerOnePage.getByTestId("room-status-detail")).toContainText("英雄遭遇战");
-  await expect(playerOnePage.getByTestId("encounter-source")).toContainText("我方主动接触敌方英雄");
+  await expect(playerOnePage.getByTestId("encounter-source")).toContainText("我方英雄先手接触敌方英雄");
   await expect(playerOnePage.getByTestId("encounter-source")).toHaveAttribute("data-tone", "action");
   await expect(playerTwoPage.getByTestId("opponent-summary")).toContainText("player-1");
   await expect(playerTwoPage.getByTestId("opponent-summary")).toContainText("房间态：战斗中");
+  await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("多人遭遇战已接管地图行动");
   await expect(playerTwoPage.getByTestId("room-next-action")).toContainText("等待本场对抗结算");
   await expect(playerTwoPage.getByTestId("room-next-action")).toHaveAttribute("data-tone", "action");
   await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
@@ -65,13 +66,18 @@ test("two players can enter a hero-vs-hero battle and resolve it with correct tu
   await expect(playerTwoPage.getByTestId("battle-modal-title")).toHaveText("战斗失败");
   await expect(playerOnePage.getByTestId("battle-settlement")).toContainText("战斗胜利");
   await expect(playerOnePage.getByTestId("battle-settlement-summary")).toContainText("已击败");
+  await expect(playerOnePage.getByTestId("battle-settlement-room-state")).toContainText("房间已回到地图探索阶段");
+  await expect(playerOnePage.getByTestId("battle-settlement-next-action")).toContainText("仍可继续移动");
   await expect(playerOnePage.getByTestId("room-phase")).toHaveText("已结算");
-  await expect(playerOnePage.getByTestId("encounter-source")).toContainText("房间权威状态已回写到地图");
+  await expect(playerOnePage.getByTestId("encounter-source")).toContainText("本场结果已结算并回写到房间地图");
   await expect(playerOnePage.getByTestId("encounter-source")).toHaveAttribute("data-tone", "victory");
+  await expect(playerOnePage.getByTestId("room-result-summary")).toContainText("房间已回到地图探索阶段");
+  await expect(playerOnePage.getByTestId("opponent-summary")).toContainText("最近对手");
   await expect(playerOnePage.getByTestId("room-next-action")).toContainText("仍可继续移动");
   await expect(playerOnePage.getByTestId("room-next-action")).toHaveAttribute("data-tone", "victory");
   await expect(playerTwoPage.getByTestId("room-next-action")).toContainText("移动力已耗尽");
   await expect(playerTwoPage.getByTestId("battle-settlement-aftermath")).toContainText("移动力清零");
+  await expect(playerTwoPage.getByTestId("battle-settlement-room-state")).toContainText("对手仍保留在房间地图上");
   await expect(playerTwoPage.getByTestId("hero-hp")).toHaveText(/HP 15\/30/);
   await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
 

--- a/tests/e2e/pvp-postbattle-reconnect.spec.ts
+++ b/tests/e2e/pvp-postbattle-reconnect.spec.ts
@@ -47,6 +47,16 @@ test("players can reload after a PvP battle resolves and keep the settled world 
   await expect(playerTwoPage.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
   await expect(playerOnePage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
   await expect(playerTwoPage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
+  await expect(playerOnePage.getByTestId("room-phase")).toHaveText("已结算");
+  await expect(playerTwoPage.getByTestId("room-phase")).toHaveText("已结算");
+  await expect(playerOnePage.getByTestId("battle-settlement-summary")).toContainText("已击败");
+  await expect(playerOnePage.getByTestId("battle-settlement-room-state")).toContainText("房间已回到地图探索阶段");
+  await expect(playerOnePage.getByTestId("battle-settlement-next-action")).toContainText("仍可继续移动");
+  await expect(playerTwoPage.getByTestId("battle-settlement-summary")).toContainText("遭遇战失利");
+  await expect(playerTwoPage.getByTestId("battle-settlement-room-state")).toContainText("对手仍保留在房间地图上");
+  await expect(playerTwoPage.getByTestId("battle-settlement-next-action")).toContainText("已无法继续移动");
+  await expect(playerOnePage.getByTestId("opponent-summary")).toContainText("最近对手");
+  await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("当前结算已同步回写");
 
   await expect(playerOnePage.getByTestId("battle-empty")).toHaveText(/No active battle/);
   await expect(playerTwoPage.getByTestId("battle-empty")).toHaveText(/No active battle/);


### PR DESCRIPTION
## Summary
- polish the H5 multiplayer room panel with clearer encounter source, room-result, opponent, and next-step messaging
- preserve encounter/settlement context across reconnect replay so post-battle closure feedback survives reloads
- extend multiplayer coverage for hero encounter feedback and the post-battle reconnect closure path

## Testing
- npm run typecheck:client:h5
- node --import tsx --test ./apps/client/test/room-feedback.test.ts
- npx playwright test --config=playwright.multiplayer.config.ts tests/e2e/pvp-hero-encounter.spec.ts tests/e2e/pvp-postbattle-reconnect.spec.ts *(fails in this environment before test startup: Chromium is missing libatk-bridge-2.0.so.0)*

Closes #192