### PR TITLE
Formalize Cocos battle presentation feedback

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -79,13 +79,8 @@ import {
 import { readStoredCocosAuthSession, resolveCocosLaunchIdentity, type CocosAuthProvider } from "./cocos-session-launch.ts";
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
 import { formatEquipmentActionReason, formatEquipmentSlotLabel } from "./cocos-hero-equipment.ts";
-import { buildBattleEnterCopy, buildBattleExitCopy } from "./cocos-battle-transition-copy.ts";
-import {
-  buildBattleActionFeedback,
-  buildBattleProgressFeedback,
-  buildBattleTransitionFeedback,
-  type CocosBattleFeedbackView
-} from "./cocos-battle-feedback.ts";
+import { type CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
+import { buildBattleActionPresentation, buildBattlePresentationPlan } from "./cocos-battle-presentation.ts";
 import { createCocosAudioRuntime } from "./cocos-audio-runtime.ts";
 import { createCocosAudioAssetBridge } from "./cocos-audio-resources.ts";
 import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
@@ -102,15 +97,6 @@ const LOBBY_NODE_NAME = "ProjectVeilLobbyPanel";
 const DEFAULT_MAP_WIDTH_TILES = 8;
 const DEFAULT_MAP_HEIGHT_TILES = 8;
 const BATTLE_FEEDBACK_DURATION_MS = 2600;
-
-interface BattleResolvedEventLike {
-  type: "battle.resolved";
-  result: "attacker_victory" | "defender_victory";
-  heroId: string;
-  battleId: string;
-  defenderHeroId?: string;
-  [key: string]: unknown;
-}
 
 function formatHeroStatBonus(bonus: { attack: number; defense: number; power: number; knowledge: number }): string {
   return [
@@ -2453,28 +2439,6 @@ export class VeilRoot extends Component {
     historyRef.replaceState(null, "", nextUrl.toString());
   }
 
-  private isBattleResolvedEvent(event: SessionUpdate["events"][number]): event is BattleResolvedEventLike {
-    return (
-      event.type === "battle.resolved" &&
-      typeof event.heroId === "string" &&
-      (event.result === "attacker_victory" || event.result === "defender_victory") &&
-      (event.defenderHeroId === undefined || typeof event.defenderHeroId === "string")
-    );
-  }
-
-  private didCurrentPlayerWinBattle(event: BattleResolvedEventLike): boolean {
-    const heroId = this.activeHero()?.id;
-    if (!heroId) {
-      return false;
-    }
-
-    if (event.result === "attacker_victory") {
-      return event.heroId === heroId;
-    }
-
-    return event.defenderHeroId === heroId;
-  }
-
   private handleConnectionEvent(event: ConnectionEvent): void {
     const label =
       event === "reconnecting"
@@ -2492,6 +2456,7 @@ export class VeilRoot extends Component {
     }
 
     this.battleActionInFlight = true;
+    const actionPresentation = buildBattleActionPresentation(action, this.lastUpdate?.battle ?? null);
     const skillName =
       action.type === "battle.skill"
         ? this.lastUpdate?.battle?.units[action.unitId]?.skills?.find((skill) => skill.id === action.skillId)?.name ?? action.skillId
@@ -2505,17 +2470,15 @@ export class VeilRoot extends Component {
             ? "防御"
             : skillName ?? "技能";
     this.pushLog(`战斗指令：${actionLabel}`);
-    this.setBattleFeedback(buildBattleActionFeedback(action, this.lastUpdate?.battle ?? null));
-    if (action.type === "battle.attack") {
-      this.audioRuntime.playCue("attack");
-    } else if (action.type === "battle.skill") {
-      this.audioRuntime.playCue("skill");
+    this.setBattleFeedback(actionPresentation.feedback);
+    if (actionPresentation.cue) {
+      this.audioRuntime.playCue(actionPresentation.cue);
     }
     this.renderView();
 
     try {
-      if (action.type === "battle.attack" || (action.type === "battle.skill" && action.targetId && action.targetId !== action.unitId)) {
-        this.mapBoard?.playHeroAnimation("attack");
+      if (actionPresentation.animation !== "idle") {
+        this.mapBoard?.playHeroAnimation(actionPresentation.animation);
       }
 
       await this.applySessionUpdate(await this.session.actInBattle(action));
@@ -2530,9 +2493,8 @@ export class VeilRoot extends Component {
 
   private async applySessionUpdate(update: SessionUpdate): Promise<void> {
     const previousBattle = this.lastUpdate?.battle ?? null;
-    const previousBattleId = previousBattle?.id ?? null;
-    const nextBattleId = update.battle?.id ?? null;
     const heroId = this.activeHero()?.id ?? null;
+    const presentation = buildBattlePresentationPlan(previousBattle, update, heroId);
 
     this.pendingPrediction = null;
     this.predictionStatus = "";
@@ -2546,25 +2508,17 @@ export class VeilRoot extends Component {
     }
     this.syncSelectedBattleTarget();
     this.playMapFeedbackForUpdate(update);
-    this.maybePlayBattleHitCue(previousBattle, update.battle ?? null);
     this.maybeShowHeroProgressNotice(update);
+    this.setBattleFeedback(presentation.feedback, presentation.feedbackDurationMs ?? BATTLE_FEEDBACK_DURATION_MS);
+    if (presentation.cue) {
+      this.audioRuntime.playCue(presentation.cue);
+    }
+    this.mapBoard?.playHeroAnimation(presentation.animation);
 
-    if (!previousBattleId && nextBattleId) {
-      this.setBattleFeedback(buildBattleTransitionFeedback(update, heroId));
-      this.mapBoard?.playHeroAnimation("attack");
-      await this.battleTransition?.playEnter(buildBattleEnterCopy(update));
-    } else if (previousBattleId && !nextBattleId) {
-      const resolvedEvent = update.events.find((event) => this.isBattleResolvedEvent(event));
-      const didWin = resolvedEvent ? this.didCurrentPlayerWinBattle(resolvedEvent) : false;
-      this.setBattleFeedback(buildBattleTransitionFeedback(update, heroId), 4200);
-      this.audioRuntime.playCue(didWin ? "victory" : "defeat");
-      this.mapBoard?.playHeroAnimation(
-        resolvedEvent ? (didWin ? "victory" : "defeat") : "idle"
-      );
-      await this.battleTransition?.playExit(buildBattleExitCopy(previousBattle, update, didWin));
-    } else {
-      this.setBattleFeedback(buildBattleProgressFeedback(previousBattle, update.battle ?? null));
-      this.mapBoard?.playHeroAnimation("idle");
+    if (presentation.transition?.kind === "enter") {
+      await this.battleTransition?.playEnter(presentation.transition.copy);
+    } else if (presentation.transition?.kind === "exit") {
+      await this.battleTransition?.playExit(presentation.transition.copy);
     }
 
     this.syncWechatShareBridge();
@@ -2723,23 +2677,6 @@ export class VeilRoot extends Component {
     };
   }
 
-  private maybePlayBattleHitCue(previousBattle: SessionUpdate["battle"] | null, nextBattle: SessionUpdate["battle"] | null): void {
-    if (!previousBattle || !nextBattle) {
-      return;
-    }
-
-    for (const [unitId, unit] of Object.entries(nextBattle.units)) {
-      const previousUnit = previousBattle.units[unitId];
-      if (!previousUnit) {
-        continue;
-      }
-
-      if (unit.currentHp < previousUnit.currentHp || unit.count < previousUnit.count) {
-        this.audioRuntime.playCue("hit");
-        return;
-      }
-    }
-  }
 }
 
 function cloneSessionUpdate(update: SessionUpdate): SessionUpdate {

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
@@ -1,0 +1,135 @@
+import type { CocosAudioCue } from "./cocos-presentation-config.ts";
+import type { BattleAction, BattleState, SessionUpdate } from "./VeilCocosSession.ts";
+import { buildBattleEnterCopy, buildBattleExitCopy, type BattleTransitionCopy } from "./cocos-battle-transition-copy.ts";
+import {
+  buildBattleActionFeedback,
+  buildBattleProgressFeedback,
+  buildBattleTransitionFeedback,
+  type CocosBattleFeedbackView
+} from "./cocos-battle-feedback.ts";
+
+export type CocosBattlePresentationPhase = "idle" | "command" | "enter" | "impact" | "active" | "resolution";
+export type CocosBattlePresentationAnimation = "idle" | "attack" | "hit" | "victory" | "defeat";
+
+export interface CocosBattlePresentationTransition {
+  kind: "enter" | "exit";
+  copy: BattleTransitionCopy;
+}
+
+export interface CocosBattlePresentationPlan {
+  phase: CocosBattlePresentationPhase;
+  feedback: CocosBattleFeedbackView | null;
+  feedbackDurationMs: number | null;
+  cue: CocosAudioCue | null;
+  animation: CocosBattlePresentationAnimation;
+  transition: CocosBattlePresentationTransition | null;
+}
+
+const RESOLUTION_FEEDBACK_DURATION_MS = 4200;
+
+export function buildBattleActionPresentation(
+  action: BattleAction,
+  battle: BattleState | null
+): CocosBattlePresentationPlan {
+  return {
+    phase: "command",
+    feedback: buildBattleActionFeedback(action, battle),
+    feedbackDurationMs: null,
+    cue: action.type === "battle.attack" ? "attack" : action.type === "battle.skill" ? "skill" : null,
+    animation:
+      action.type === "battle.attack" || (action.type === "battle.skill" && action.targetId && action.targetId !== action.unitId)
+        ? "attack"
+        : "idle",
+    transition: null
+  };
+}
+
+export function buildBattlePresentationPlan(
+  previousBattle: BattleState | null,
+  update: SessionUpdate,
+  heroId: string | null
+): CocosBattlePresentationPlan {
+  const nextBattle = update.battle ?? null;
+
+  if (!previousBattle && nextBattle) {
+    return {
+      phase: "enter",
+      feedback: buildBattleTransitionFeedback(update, heroId),
+      feedbackDurationMs: null,
+      cue: null,
+      animation: "attack",
+      transition: {
+        kind: "enter",
+        copy: buildBattleEnterCopy(update)
+      }
+    };
+  }
+
+  if (previousBattle && !nextBattle) {
+    const didWin = resolveBattleResolution(update, heroId);
+    return {
+      phase: "resolution",
+      feedback: buildBattleTransitionFeedback(update, heroId),
+      feedbackDurationMs: RESOLUTION_FEEDBACK_DURATION_MS,
+      cue: didWin === null ? null : didWin ? "victory" : "defeat",
+      animation: didWin === null ? "idle" : didWin ? "victory" : "defeat",
+      transition: {
+        kind: "exit",
+        copy: buildBattleExitCopy(previousBattle, update, didWin ?? false)
+      }
+    };
+  }
+
+  if (previousBattle && nextBattle) {
+    const impactDetected = detectBattleImpact(previousBattle, nextBattle);
+    return {
+      phase: impactDetected ? "impact" : "active",
+      feedback: buildBattleProgressFeedback(previousBattle, nextBattle),
+      feedbackDurationMs: null,
+      cue: impactDetected ? "hit" : null,
+      animation: impactDetected ? "hit" : "idle",
+      transition: null
+    };
+  }
+
+  return {
+    phase: "idle",
+    feedback: null,
+    feedbackDurationMs: null,
+    cue: null,
+    animation: "idle",
+    transition: null
+  };
+}
+
+function resolveBattleResolution(update: SessionUpdate, heroId: string | null): boolean | null {
+  const resolved = update.events.find((event) => event.type === "battle.resolved");
+  if (!resolved) {
+    return null;
+  }
+
+  if (!heroId) {
+    return resolved.result === "attacker_victory";
+  }
+
+  if (resolved.result === "attacker_victory") {
+    return resolved.heroId === heroId;
+  }
+
+  return resolved.defenderHeroId === heroId;
+}
+
+function detectBattleImpact(previousBattle: BattleState, nextBattle: BattleState): boolean {
+  for (const [unitId, nextUnit] of Object.entries(nextBattle.units)) {
+    const previousUnit = previousBattle.units[unitId];
+    if (!previousUnit) {
+      continue;
+    }
+
+    if (nextUnit.currentHp < previousUnit.currentHp || nextUnit.count < previousUnit.count) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/apps/cocos-client/test/cocos-battle-feedback.test.ts
+++ b/apps/cocos-client/test/cocos-battle-feedback.test.ts
@@ -5,6 +5,7 @@ import {
   buildBattleProgressFeedback,
   buildBattleTransitionFeedback
 } from "../assets/scripts/cocos-battle-feedback";
+import { buildBattleActionPresentation, buildBattlePresentationPlan } from "../assets/scripts/cocos-battle-presentation";
 import type { BattleState, SessionUpdate } from "../assets/scripts/VeilCocosSession";
 
 function createBattleState(): BattleState {
@@ -189,4 +190,76 @@ test("battle feedback summarizes action, progress, and outcome", () => {
   const defeatFeedback = buildBattleTransitionFeedback(createResolvedUpdate("defender_victory"), "hero-1");
   assert.equal(defeatFeedback?.tone, "defeat");
   assert.equal(defeatFeedback?.badge, "LOSE");
+});
+
+test("battle presentation plan formalizes enter, impact, and resolution phases", () => {
+  const battle = createBattleState();
+  const actionPlan = buildBattleActionPresentation(
+    {
+      type: "battle.attack",
+      attackerId: "hero-1-stack",
+      defenderId: "neutral-1-stack"
+    },
+    battle
+  );
+  assert.equal(actionPlan.phase, "command");
+  assert.equal(actionPlan.cue, "attack");
+  assert.equal(actionPlan.animation, "attack");
+  assert.equal(actionPlan.feedback?.badge, "ATTACK");
+
+  const enterUpdate: SessionUpdate = {
+    ...createResolvedUpdate("attacker_victory"),
+    battle,
+    events: [
+      {
+        type: "battle.started",
+        heroId: "hero-1",
+        encounterKind: "neutral",
+        neutralArmyId: "neutral-1",
+        initiator: "hero",
+        battleId: "battle-1",
+        path: [{ x: 0, y: 0 }],
+        moveCost: 1
+      }
+    ]
+  };
+  const enterPlan = buildBattlePresentationPlan(null, enterUpdate, "hero-1");
+  assert.equal(enterPlan.phase, "enter");
+  assert.equal(enterPlan.animation, "attack");
+  assert.equal(enterPlan.transition?.kind, "enter");
+  assert.equal(enterPlan.feedback?.badge, "ENGAGE");
+
+  const nextBattle: BattleState = {
+    ...battle,
+    units: {
+      ...battle.units,
+      "neutral-1-stack": {
+        ...battle.units["neutral-1-stack"]!,
+        count: 5,
+        currentHp: 4
+      }
+    },
+    log: battle.log.concat("Guard 对 Orc 造成 7 伤害")
+  };
+  const impactPlan = buildBattlePresentationPlan(
+    battle,
+    {
+      ...enterUpdate,
+      battle: nextBattle,
+      events: []
+    },
+    "hero-1"
+  );
+  assert.equal(impactPlan.phase, "impact");
+  assert.equal(impactPlan.cue, "hit");
+  assert.equal(impactPlan.animation, "hit");
+  assert.equal(impactPlan.feedback?.badge, "HIT");
+
+  const resolutionPlan = buildBattlePresentationPlan(battle, createResolvedUpdate("attacker_victory"), "hero-1");
+  assert.equal(resolutionPlan.phase, "resolution");
+  assert.equal(resolutionPlan.cue, "victory");
+  assert.equal(resolutionPlan.animation, "victory");
+  assert.equal(resolutionPlan.feedbackDurationMs, 4200);
+  assert.equal(resolutionPlan.transition?.kind, "exit");
+  assert.equal(resolutionPlan.transition?.copy.badge, "VICTORY");
 });


### PR DESCRIPTION
## Summary
- add a focused Cocos battle presentation planner that formalizes command, enter, impact, and resolution states
- route VeilRoot battle feedback, audio cues, hero animation, and transition playback through the shared planner
- extend Cocos battle feedback coverage to verify enter, hit, and battle closeout presentation paths

## Verification
- node --import tsx --test ./apps/cocos-client/test/cocos-battle-feedback.test.ts ./apps/cocos-client/test/cocos-battle-transition-copy.test.ts ./apps/cocos-client/test/cocos-battle-panel-model.test.ts
- npm run typecheck:cocos

Closes #191