### PR TITLE
Tighten multiplayer encounter room feedback (#208)

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1869,6 +1869,28 @@ function formatVisibleHeroSummary(
   return `玩家 ${hero.playerId} · 英雄 ${hero.name || hero.id} · 坐标 (${hero.position.x},${hero.position.y})`;
 }
 
+function battleTurnContextLabel(battle: BattleState, world: PlayerWorldView = state.world): string {
+  if (!battle.activeUnitId) {
+    return "当前回合：等待下一行动单位";
+  }
+
+  const activeUnit = battle.units[battle.activeUnitId];
+  if (!activeUnit) {
+    return "当前回合：等待权威同步";
+  }
+
+  const playerCamp = controlledBattleCamp(battle, world);
+  if (!playerCamp) {
+    return "当前回合：等待权威同步";
+  }
+
+  return activeUnit.camp === playerCamp ? "当前回合：我方操作" : "当前回合：对手操作";
+}
+
+function battleSessionSummary(battleId: string, roomId: string): string {
+  return `遭遇会话：${roomId}/${battleId}`;
+}
+
 function activeHeroSnapshot(world: PlayerWorldView = state.world): PlayerWorldView["ownHeroes"][number] | null {
   return world.ownHeroes[0] ?? null;
 }
@@ -1889,8 +1911,8 @@ function renderEncounterHeadline(): { phase: string; detail: string } {
     return {
       phase: "战斗中",
       detail: state.battle.defenderHeroId
-        ? `已进入英雄遭遇战，对手 ${formatHeroIdentity(opponent, opponentId)}。`
-        : `已进入中立遭遇战，目标 ${state.battle.neutralArmyId ?? "neutral"}。`
+        ? `已进入英雄遭遇战，对手 ${formatHeroIdentity(opponent, opponentId)}。${battleSessionSummary(state.battle.id, state.world.meta.roomId)}。`
+        : `已进入中立遭遇战，目标 ${state.battle.neutralArmyId ?? "neutral"}。${battleSessionSummary(state.battle.id, state.world.meta.roomId)}。`
     };
   }
 
@@ -1933,16 +1955,20 @@ function resolveEncounterOpponentContext(): {
     const opponent = findHeroSnapshot(opponentId, state.world);
     return {
       label: "对手信息",
-      detail: `${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：战斗中 · 我方席位：${
-        playerCamp === "attacker" ? "进攻方" : "防守方"
-      }`
+      detail: `${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：战斗中 · ${battleSessionSummary(
+        state.battle.id,
+        state.world.meta.roomId
+      )} · ${battleTurnContextLabel(state.battle, state.world)} · 我方席位：${playerCamp === "attacker" ? "进攻方" : "防守方"}`
     };
   }
 
   if (state.battle?.neutralArmyId) {
     return {
       label: "遭遇目标",
-      detail: `${state.battle.neutralArmyId} · 房间态：战斗中`
+      detail: `${state.battle.neutralArmyId} · 房间态：战斗中 · ${battleSessionSummary(
+        state.battle.id,
+        state.world.meta.roomId
+      )} · ${battleTurnContextLabel(state.battle, state.world)}`
     };
   }
 
@@ -1970,13 +1996,19 @@ function resolveEncounterOpponentContext(): {
       const opponent = findHeroSnapshot(opponentId, state.world);
       return {
         label: "最近对手",
-        detail: `${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：已结算`
+        detail: `${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：已结算 · ${battleSessionSummary(
+          state.lastEncounterStarted.battleId,
+          state.world.meta.roomId
+        )}`
       };
     }
 
     return {
       label: "最近遭遇",
-      detail: `${state.lastEncounterStarted.neutralArmyId ?? "neutral"} · 房间态：已结算`
+      detail: `${state.lastEncounterStarted.neutralArmyId ?? "neutral"} · 房间态：已结算 · ${battleSessionSummary(
+        state.lastEncounterStarted.battleId,
+        state.world.meta.roomId
+      )}`
     };
   }
 
@@ -1989,7 +2021,10 @@ function renderRoomResultSummary(): string {
   }
 
   if (state.battle) {
-    return "房间结果：多人遭遇战已接管地图行动，待战斗链路关闭后统一回写房间状态。";
+    return `房间结果：多人遭遇战已接管地图行动，当前由 ${battleSessionSummary(
+      state.battle.id,
+      state.world.meta.roomId
+    )} 驱动；待战斗链路关闭后统一回写房间状态。`;
   }
 
   if (state.diagnostics.connectionStatus === "reconnecting") {

--- a/apps/client/src/room-feedback.ts
+++ b/apps/client/src/room-feedback.ts
@@ -68,13 +68,13 @@ export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): 
     const ownedIds = ownedHeroIds(input.world);
     if (event.encounterKind === "hero") {
       return ownedIds.has(event.heroId)
-        ? "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到多人遭遇战结算。"
-        : "遭遇来源：敌方英雄先手接触我方，当前房间已切到多人遭遇战结算。";
+        ? `遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到多人遭遇战结算，战斗会话 ${event.battleId} 已建立。`
+        : `遭遇来源：敌方英雄先手接触我方，当前房间已切到多人遭遇战结算，战斗会话 ${event.battleId} 已建立。`;
     }
 
     return event.initiator === "neutral"
-      ? "遭遇来源：中立守军主动拦截，当前房间已切到遭遇战结算链路。"
-      : "遭遇来源：我方接触了中立守军，当前房间已切到遭遇战结算链路。";
+      ? `遭遇来源：中立守军主动拦截，当前房间已切到遭遇战结算链路，战斗会话 ${event.battleId} 已建立。`
+      : `遭遇来源：我方接触了中立守军，当前房间已切到遭遇战结算链路，战斗会话 ${event.battleId} 已建立。`;
   }
 
   if (input.previewPlan?.endsInEncounter) {
@@ -84,7 +84,7 @@ export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): 
   }
 
   if (input.lastBattleSettlement) {
-    return "战后反馈：本场结果已结算并回写到房间地图，可按当前结果继续移动、推进回合或等待对手。";
+    return "战后反馈：本场结果已结算并回写到房间地图；可结合最近战斗会话、房间态和对手摘要继续移动、推进回合或等待对手。";
   }
 
   if (input.diagnostics.connectionStatus === "reconnecting") {

--- a/apps/client/test/room-feedback.test.ts
+++ b/apps/client/test/room-feedback.test.ts
@@ -151,7 +151,7 @@ test("renderEncounterSourceDetail covers active hero encounter initiative branch
       battle: activeBattle,
       lastEncounterStarted: createEncounterStartedEvent()
     }),
-    "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到多人遭遇战结算。"
+    "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到多人遭遇战结算，战斗会话 battle-1 已建立。"
   );
 
   assert.equal(
@@ -163,7 +163,7 @@ test("renderEncounterSourceDetail covers active hero encounter initiative branch
         defenderHeroId: "hero-1"
       })
     }),
-    "遭遇来源：敌方英雄先手接触我方，当前房间已切到多人遭遇战结算。"
+    "遭遇来源：敌方英雄先手接触我方，当前房间已切到多人遭遇战结算，战斗会话 battle-1 已建立。"
   );
 });
 
@@ -181,7 +181,7 @@ test("renderEncounterSourceDetail covers active neutral encounter initiator bran
         initiator: "neutral"
       })
     }),
-    "遭遇来源：中立守军主动拦截，当前房间已切到遭遇战结算链路。"
+    "遭遇来源：中立守军主动拦截，当前房间已切到遭遇战结算链路，战斗会话 battle-1 已建立。"
   );
 
   assert.equal(
@@ -195,7 +195,7 @@ test("renderEncounterSourceDetail covers active neutral encounter initiator bran
         initiator: "hero"
       })
     }),
-    "遭遇来源：我方接触了中立守军，当前房间已切到遭遇战结算链路。"
+    "遭遇来源：我方接触了中立守军，当前房间已切到遭遇战结算链路，战斗会话 battle-1 已建立。"
   );
 });
 
@@ -231,7 +231,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
         aftermath: "已结算"
       }
     }),
-    "战后反馈：本场结果已结算并回写到房间地图，可按当前结果继续移动、推进回合或等待对手。"
+    "战后反馈：本场结果已结算并回写到房间地图；可结合最近战斗会话、房间态和对手摘要继续移动、推进回合或等待对手。"
   );
 
   assert.equal(

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -70,6 +70,7 @@
 
 - [ ] H5 Lobby 能游客进入房间，且缓存会话 / 账号登录 / 找回链路至少各通过一次。
 - [ ] H5 壳可稳定复现大地图、资源点、建筑、战斗和结果弹窗，作为快速回归基线。
+- [ ] 多人遭遇战反馈链路可读：进入战斗时至少能看到 `room-phase`、`encounter-source`、`opponent-summary` 中的房间态 / 对手摘要 / 遭遇会话；结算回到地图后仍能看到 `battle-settlement-*` 与最近遭遇摘要。
 - [ ] H5 reconnect 冒烟至少保留一次 canonical gate 记录，证据中必须同时能看见原 `roomId`、恢复提示和未回档状态。
 - [ ] 关键 E2E 用例与当前配置一致，没有依赖过期坐标、旧数值或旧文案。
 - [ ] H5 回归壳在失败时能提供足够诊断信息，例如 trace、screenshot、事件文案或运行时摘要。
@@ -166,3 +167,18 @@ H5 冒烟和多人 Playwright 已经比较成熟，但真实发布面是 `apps/c
 2. 再跑 `npm run test:e2e:smoke` 与 `npm run test:e2e:multiplayer:smoke`，确认 H5 回归面和多人主链路。
 3. 若候选包涉及微信小游戏，再跑 `npm run check:wechat-build`，并按微信发布文档回填真实 smoke 报告。
 4. 用本清单逐项标记 `pass / partial / fail`，只要存在 `P0 blocker = fail`，该候选版本就不应进入更广范围测试。
+
+## 多人遭遇反馈本地验收流
+
+用于验证 issue #208 这类“多人遭遇进入 / 结算 / 回到地图”反馈是否仍然完整可读。
+
+1. 启动本地房间与 H5 调试壳：`npm run dev:server`、`npm run dev:client`
+2. 跑最小 PvP 反馈回归：`npx playwright test tests/e2e/pvp-hero-encounter.spec.ts --config=playwright.multiplayer.config.ts`
+3. 跑结算后重载回归：`npx playwright test tests/e2e/pvp-postbattle-reconnect.spec.ts --config=playwright.multiplayer.config.ts`
+4. 若只想快速校验文案分支，补跑单测：`node --import tsx --test ./apps/client/test/room-feedback.test.ts`
+
+成功信号：
+
+- 战斗进入后，`room-phase` 显示 `战斗中`，并且 `encounter-source` / `opponent-summary` 能看到遭遇会话与当前房间态。
+- PvP 轮转期间，`opponent-summary` 能看出当前回合归属和我方席位，避免靠日志猜是谁在操作。
+- 战斗结算后，`battle-settlement-summary`、`battle-settlement-room-state`、`battle-settlement-next-action` 与 `最近对手/最近遭遇` 同时保留，能够说明“这场遭遇是谁、结果是什么、房间现在回到了哪里”。

--- a/tests/e2e/pvp-hero-encounter.spec.ts
+++ b/tests/e2e/pvp-hero-encounter.spec.ts
@@ -36,11 +36,16 @@ test("two players can enter a hero-vs-hero battle and resolve it with correct tu
   await expect(playerOnePage.getByTestId("room-phase")).toHaveText("战斗中");
   await expect(playerTwoPage.getByTestId("room-phase")).toHaveText("战斗中");
   await expect(playerOnePage.getByTestId("room-status-detail")).toContainText("英雄遭遇战");
+  await expect(playerOnePage.getByTestId("room-status-detail")).toContainText(`遭遇会话：${roomId}/battle-`);
   await expect(playerOnePage.getByTestId("encounter-source")).toContainText("我方英雄先手接触敌方英雄");
+  await expect(playerOnePage.getByTestId("encounter-source")).toContainText("战斗会话 battle-");
   await expect(playerOnePage.getByTestId("encounter-source")).toHaveAttribute("data-tone", "action");
   await expect(playerTwoPage.getByTestId("opponent-summary")).toContainText("player-1");
   await expect(playerTwoPage.getByTestId("opponent-summary")).toContainText("房间态：战斗中");
+  await expect(playerTwoPage.getByTestId("opponent-summary")).toContainText(`遭遇会话：${roomId}/battle-`);
+  await expect(playerTwoPage.getByTestId("opponent-summary")).toContainText("当前回合：我方操作");
   await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("多人遭遇战已接管地图行动");
+  await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText(`遭遇会话：${roomId}/battle-`);
   await expect(playerTwoPage.getByTestId("room-next-action")).toContainText("等待本场对抗结算");
   await expect(playerTwoPage.getByTestId("room-next-action")).toHaveAttribute("data-tone", "action");
   await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
@@ -73,6 +78,7 @@ test("two players can enter a hero-vs-hero battle and resolve it with correct tu
   await expect(playerOnePage.getByTestId("encounter-source")).toHaveAttribute("data-tone", "victory");
   await expect(playerOnePage.getByTestId("room-result-summary")).toContainText("房间已回到地图探索阶段");
   await expect(playerOnePage.getByTestId("opponent-summary")).toContainText("最近对手");
+  await expect(playerOnePage.getByTestId("opponent-summary")).toContainText(`遭遇会话：${roomId}/battle-`);
   await expect(playerOnePage.getByTestId("room-next-action")).toContainText("仍可继续移动");
   await expect(playerOnePage.getByTestId("room-next-action")).toHaveAttribute("data-tone", "victory");
   await expect(playerTwoPage.getByTestId("room-next-action")).toContainText("移动力已耗尽");

--- a/tests/e2e/pvp-postbattle-reconnect.spec.ts
+++ b/tests/e2e/pvp-postbattle-reconnect.spec.ts
@@ -56,6 +56,7 @@ test("players can reload after a PvP battle resolves and keep the settled world 
   await expect(playerTwoPage.getByTestId("battle-settlement-room-state")).toContainText("对手仍保留在房间地图上");
   await expect(playerTwoPage.getByTestId("battle-settlement-next-action")).toContainText("已无法继续移动");
   await expect(playerOnePage.getByTestId("opponent-summary")).toContainText("最近对手");
+  await expect(playerOnePage.getByTestId("opponent-summary")).toContainText(`遭遇会话：${roomId}/battle-`);
   await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("当前结算已同步回写");
 
   await expect(playerOnePage.getByTestId("battle-empty")).toHaveText(/No active battle/);


### PR DESCRIPTION
## Summary
- surface multiplayer encounter session IDs in the H5 room-status panel during entry, battle, and post-settlement states
- add explicit turn-ownership context to opponent/encounter summaries so PvP smoke runs show who should act now
- document a repeatable local validation flow for the multiplayer feedback path in release-readiness notes

## Validation
- `node --import tsx --test ./apps/client/test/room-feedback.test.ts`
- `npm run typecheck:client:h5`
- `npx playwright test tests/e2e/pvp-hero-encounter.spec.ts --config=playwright.multiplayer.config.ts` *(blocked in this environment: Playwright Chromium could not launch because `libatk-bridge-2.0.so.0` is missing)*
- `npx playwright test tests/e2e/pvp-postbattle-reconnect.spec.ts --config=playwright.multiplayer.config.ts` *(blocked in this environment for the same missing library)*

Closes #208