### PR TITLE
Add battle report summary center

### DIFF
--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -173,6 +173,161 @@ function formatBattleReplayUnitSummary(playback: BattleReplayPlaybackState): str
   return `攻方 ${attackerAlive} 队 · 守方 ${defenderAlive} 队`;
 }
 
+function toTimestampMs(value?: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function formatBattleRewardChip(
+  reward: PlayerAccountProfile["recentEventLog"][number]["rewards"][number]
+): string {
+  if (reward.type === "experience") {
+    return reward.amount != null ? `经验 +${reward.amount}` : "经验";
+  }
+
+  if (reward.type === "skill_point") {
+    return reward.amount != null ? `技能点 +${reward.amount}` : "技能点";
+  }
+
+  if (reward.type === "resource") {
+    return reward.amount != null ? `${reward.label} +${reward.amount}` : reward.label;
+  }
+
+  return reward.amount != null ? `${reward.label} +${reward.amount}` : reward.label;
+}
+
+function collectBattleReportEventLogEntries(
+  account: PlayerAccountProfile,
+  replay: PlayerAccountProfile["recentBattleReplays"][number]
+): PlayerAccountProfile["recentEventLog"] {
+  const startedAtMs = toTimestampMs(replay.startedAt);
+  const completedAtMs = toTimestampMs(replay.completedAt);
+  const fallbackEntries = account.recentEventLog.filter(
+    (entry) => entry.category === "combat" && entry.roomId === replay.roomId && (!entry.heroId || entry.heroId === replay.heroId)
+  );
+  const boundedEntries = fallbackEntries.filter((entry) => {
+    const timestamp = toTimestampMs(entry.timestamp);
+    if (timestamp == null || startedAtMs == null || completedAtMs == null) {
+      return true;
+    }
+
+    return timestamp >= startedAtMs && timestamp <= completedAtMs + 2 * 60 * 1000;
+  });
+
+  const candidates = boundedEntries.length > 0 ? boundedEntries : fallbackEntries;
+  return candidates.sort((left, right) => String(right.timestamp).localeCompare(String(left.timestamp)));
+}
+
+function summarizeBattleReplayCasualties(
+  replay: PlayerAccountProfile["recentBattleReplays"][number]
+): {
+  attackerLosses: number;
+  defenderLosses: number;
+  attackerDefeatedStacks: number;
+  defenderDefeatedStacks: number;
+} {
+  const timeline = buildBattleReplayTimeline(replay);
+  const finalState = timeline.at(-1)?.state ?? replay.initialState;
+  let attackerLosses = 0;
+  let defenderLosses = 0;
+  let attackerDefeatedStacks = 0;
+  let defenderDefeatedStacks = 0;
+
+  for (const initialUnit of Object.values(replay.initialState.units)) {
+    const finalUnit = finalState.units[initialUnit.id];
+    const finalCount = Math.max(0, finalUnit?.count ?? 0);
+    const losses = Math.max(0, initialUnit.count - finalCount);
+    if (initialUnit.camp === "attacker") {
+      attackerLosses += losses;
+      if (initialUnit.count > 0 && finalCount <= 0) {
+        attackerDefeatedStacks += 1;
+      }
+    } else {
+      defenderLosses += losses;
+      if (initialUnit.count > 0 && finalCount <= 0) {
+        defenderDefeatedStacks += 1;
+      }
+    }
+  }
+
+  return {
+    attackerLosses,
+    defenderLosses,
+    attackerDefeatedStacks,
+    defenderDefeatedStacks
+  };
+}
+
+function renderBattleReplayReportSummary(
+  account: PlayerAccountProfile,
+  replay: PlayerAccountProfile["recentBattleReplays"][number]
+): string {
+  const eventEntries = collectBattleReportEventLogEntries(account, replay);
+  const rewards = eventEntries.flatMap((entry) => entry.rewards);
+  const uniqueRewards = rewards.filter(
+    (reward, index, list) =>
+      index ===
+      list.findIndex(
+        (candidate) =>
+          candidate.type === reward.type && candidate.label === reward.label && (candidate.amount ?? null) === (reward.amount ?? null)
+      )
+  );
+  const rewardNotes = eventEntries
+    .filter((entry) => entry.worldEventType === "hero.progressed" || entry.worldEventType === "hero.equipmentFound")
+    .map((entry) => entry.description);
+  const casualties = summarizeBattleReplayCasualties(replay);
+  const didPlayerWin =
+    (replay.playerCamp === "attacker" && replay.result === "attacker_victory") ||
+    (replay.playerCamp === "defender" && replay.result === "defender_victory");
+  const playerLosses = replay.playerCamp === "attacker" ? casualties.attackerLosses : casualties.defenderLosses;
+  const enemyLosses = replay.playerCamp === "attacker" ? casualties.defenderLosses : casualties.attackerLosses;
+  const playerDefeatedStacks =
+    replay.playerCamp === "attacker" ? casualties.attackerDefeatedStacks : casualties.defenderDefeatedStacks;
+  const enemyDefeatedStacks =
+    replay.playerCamp === "attacker" ? casualties.defenderDefeatedStacks : casualties.attackerDefeatedStacks;
+
+  return `<div class="account-replay-report-summary">
+    <div class="account-replay-summary-card">
+      <strong>结果概览</strong>
+      <p>${escapeHtml(`${didPlayerWin ? "本场获胜" : "本场失利"} · ${formatBattleReplayCamp(replay)} · ${formatBattleReplayKind(replay)}`)}</p>
+      <div class="account-replay-meta">
+        <span>对阵 ${escapeHtml(formatBattleReplayEncounter(replay))}</span>
+        <span>步数 ${replay.steps.length}</span>
+      </div>
+    </div>
+    <div class="account-replay-summary-card">
+      <strong>伤亡摘要</strong>
+      <p>${escapeHtml(`我方减员 ${playerLosses} · 敌方减员 ${enemyLosses}`)}</p>
+      <div class="account-replay-meta">
+        <span>我方全灭编队 ${playerDefeatedStacks}</span>
+        <span>敌方全灭编队 ${enemyDefeatedStacks}</span>
+      </div>
+    </div>
+    <div class="account-replay-summary-card">
+      <strong>战后收益</strong>
+      ${
+        uniqueRewards.length > 0
+          ? `<div class="account-event-rewards">${uniqueRewards
+              .map((reward) => `<span class="account-reward-chip">${escapeHtml(formatBattleRewardChip(reward))}</span>`)
+              .join("")}</div>`
+          : '<p class="account-meta">近期事件日志里未记录额外奖励。</p>'
+      }
+      ${
+        rewardNotes.length > 0
+          ? `<div class="account-replay-summary-notes">${rewardNotes
+              .slice(0, 2)
+              .map((note) => `<span class="account-meta">${escapeHtml(note)}</span>`)
+              .join("")}</div>`
+          : ""
+      }
+    </div>
+  </div>`;
+}
+
 function compareAchievementDisplayOrder(
   left: PlayerAccountProfile["achievements"][number],
   right: PlayerAccountProfile["achievements"][number]
@@ -383,6 +538,7 @@ export function renderBattleReportReplayCenter(input: {
       ...(input.selectedReplayId !== undefined ? { selectedReplayId: input.selectedReplayId } : {})
     })}
     ${renderBattleReplayInspector({
+      account: input.account,
       replay: input.replay,
       playback: input.playback,
       ...(input.loading !== undefined ? { loading: input.loading } : {}),
@@ -392,6 +548,7 @@ export function renderBattleReportReplayCenter(input: {
 }
 
 export function renderBattleReplayInspector(input: {
+  account: PlayerAccountProfile;
   replay: PlayerAccountProfile["recentBattleReplays"][number] | null;
   playback: BattleReplayPlaybackState | null;
   loading?: boolean;
@@ -442,6 +599,7 @@ export function renderBattleReplayInspector(input: {
       <button type="button" class="modal-button" data-replay-control="reset" ${playback.currentStepIndex === 0 && playback.status !== "completed" ? "disabled" : ""}>重置</button>
     </div>
     <p class="account-meta">${escapeHtml(input.loading ? "正在刷新回放详情..." : input.status?.trim() || "按步骤回放本场战斗。")}</p>
+    ${renderBattleReplayReportSummary(input.account, input.replay)}
     <div class="account-replay-progress">
       <div><strong>当前动作</strong><span>${escapeHtml(formatBattleReplayAction(playback.currentStep))}</span><span class="account-meta">${escapeHtml(currentTimelineEntry ? formatBattleReplayRound(currentTimelineEntry) : "等待开始")}</span></div>
       <div><strong>下一动作</strong><span>${escapeHtml(formatBattleReplayAction(playback.nextStep))}</span><span class="account-meta">${escapeHtml(nextTimelineEntry ? formatBattleReplayRound(nextTimelineEntry) : playback.status === "completed" ? "胜负已结算" : "无下一步")}</span></div>

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -568,6 +568,7 @@ h1 {
 }
 
 .account-replay-controls,
+.account-replay-report-summary,
 .account-replay-progress,
 .account-replay-impact,
 .account-replay-state,
@@ -580,16 +581,37 @@ h1 {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
+.account-replay-report-summary {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 .account-replay-progress {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .account-replay-progress div,
+.account-replay-summary-card,
 .account-replay-unit,
 .account-replay-step {
   padding: 10px 12px;
   border-radius: 12px;
   background: rgba(78, 58, 42, 0.05);
+}
+
+.account-replay-summary-card {
+  display: grid;
+  gap: 6px;
+}
+
+.account-replay-summary-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.account-replay-summary-notes {
+  display: grid;
+  gap: 4px;
 }
 
 .account-replay-progress div {
@@ -1778,6 +1800,7 @@ h1 {
   }
 
   .account-replay-controls,
+  .account-replay-report-summary,
   .account-replay-progress,
   .diagnostics-grid {
     grid-template-columns: 1fr;

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -186,9 +186,10 @@ test("account history renderer shows recent battle replay summaries with step ch
 });
 
 test("account history renderer groups battle list and replay detail into a replay center", () => {
-  const replay = createProfile().recentBattleReplays[0]!;
+  const profile = createProfile();
+  const replay = profile.recentBattleReplays[0]!;
   const html = renderBattleReportReplayCenter({
-    account: createProfile(),
+    account: profile,
     selectedReplayId: replay.id,
     replay,
     playback: createBattleReplayPlaybackState(replay),
@@ -204,9 +205,11 @@ test("account history renderer groups battle list and replay detail into a repla
 });
 
 test("account history renderer shows replay inspector controls and current playback snapshot", () => {
-  const replay = createProfile().recentBattleReplays[0]!;
+  const profile = createProfile();
+  const replay = profile.recentBattleReplays[0]!;
   const playback = stepBattleReplayPlayback(createBattleReplayPlaybackState(replay));
   const html = renderBattleReplayInspector({
+    account: profile,
     replay,
     playback,
     status: "已前进一步。"
@@ -215,6 +218,10 @@ test("account history renderer shows replay inspector controls and current playb
   assert.match(html, /回放详情/);
   assert.match(html, /状态 已暂停/);
   assert.match(html, /进度 1\/2/);
+  assert.match(html, /结果概览/);
+  assert.match(html, /伤亡摘要/);
+  assert.match(html, /战后收益/);
+  assert.match(html, /经验 \+40/);
   assert.match(html, /当前动作/);
   assert.match(html, /hero-1-stack 攻击 neutral-1-stack/);
   assert.match(html, /下一动作/);
@@ -226,7 +233,9 @@ test("account history renderer shows replay inspector controls and current playb
 });
 
 test("account history renderer shows replay inspector placeholder before a replay is selected", () => {
+  const profile = createProfile();
   const html = renderBattleReplayInspector({
+    account: profile,
     replay: null,
     playback: null,
     status: "选择一场最近战斗，即可查看逐步回放。"

--- a/docs/battle-report-center-validation.md
+++ b/docs/battle-report-center-validation.md
@@ -1,0 +1,37 @@
+# Battle Report Center Validation
+
+## Scope
+
+- Supported client slice: `apps/client` H5 account card replay/report center
+- Data sources exercised:
+  - `/api/player-accounts/:playerId/battle-replays`
+  - `/api/player-accounts/:playerId`
+  - shared replay timeline helpers used by the H5 renderer
+
+## Repeatable Local Validation
+
+1. Start the local server and H5 client:
+   - `npm run dev:server`
+   - `npm run dev:client`
+2. Open the H5 shell with a clean room and player, for example:
+   - `http://127.0.0.1:4173/?roomId=replay-center-validate-20260329&playerId=player-1`
+3. Complete at least one battle in that room. The quickest repeatable path is to run the existing automation flow against the same room:
+   - `tests/automation/keyboard-battle.actions.json`
+4. Refresh or reopen the same room URL after the battle resolves.
+5. In the account card, verify the replay/report center shows:
+   - a recent battle report entry
+   - a selectable replay detail panel with step timeline rows
+   - explicit outcome text
+   - casualty summary
+   - reward chips or a clear "no extra rewards recorded" message sourced from recent combat events
+
+## Targeted Checks
+
+- Renderer regression:
+  - `node --import tsx --test ./apps/client/test/account-history-render.test.ts`
+- Client data loading regression:
+  - `node --import tsx --test ./apps/client/test/player-account-storage.test.ts`
+
+## Notes
+
+- The replay read model does not currently store rewards directly. The H5 report summary combines replay timeline data with recent combat event log entries to expose reward outcomes without requiring raw API inspection.


### PR DESCRIPTION
Closes #207

## Summary
- audited the existing replay/combat-summary path across shared replay helpers, server player-account replay routes, and current H5/Cocos client surfaces
- extended the H5 battle replay center so selecting a report now shows explicit outcome, casualty, and post-battle reward summary alongside the existing step timeline and playback controls
- added a repo validation note documenting a repeatable local workflow for generating and verifying replay/report data in the H5 client

## Validation
- `node --import tsx --test ./apps/client/test/account-history-render.test.ts ./apps/client/test/player-account-storage.test.ts`
- `npm run typecheck:client:h5`
