### PR TITLE
Add release-readiness snapshot generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ npm run dev:client:h5
 - Cocos 主客户端类型检查：`npm run typecheck:client`
 - 微信小游戏模板刷新：`npm run prepare:wechat-build`
 - 微信小游戏 CI 同款校验：`npm run check:wechat-build`
+- 发布就绪快照：`npm run release:readiness:snapshot`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - Issue #33 开源素材 staging 校验：`npm run check:issue33-assets -- --require-pack`
@@ -160,6 +161,7 @@ npm run dev:client:h5
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
 - 微信小游戏构建 / 发布 / 回滚说明：`docs/wechat-minigame-release.md`
 - 核心玩法发布门禁清单：`docs/core-gameplay-release-readiness.md`
+- 发布就绪快照说明：`docs/release-readiness-snapshot.md`
 - 当前 H5 调试壳仍支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。
 - 当前 H5 联机体验已支持：客户端预测、断线自动重连、刷新后本地快照首帧回放，再由权威房间状态收敛。
 - 当前 Cocos Creator 主客户端已补齐：

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -16,6 +16,7 @@
 - 多人同步冒烟：`npm run test:e2e:multiplayer:smoke`
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
 - 微信小游戏构建校验：`npm run check:wechat-build`
+- 发布就绪快照：`npm run release:readiness:snapshot`
 - Cocos 发布证据模板：`docs/cocos-release-evidence-template.md`
 - 微信小游戏提审前冒烟：`docs/wechat-minigame-release.md`
 
@@ -26,6 +27,8 @@
 - `P2 polish`：不阻断测试扩大，但需要继续收口体验。
 
 建议在每次 release candidate 上记录状态：`pass / partial / fail / n/a`，并附上证据链接、执行人和日期。
+
+如果希望把自动化门禁和人工门禁统一收口成一个结构化记录，可执行 `npm run release:readiness:snapshot -- --manual-checks docs/release-readiness-manual-checks.example.json`，生成当前 revision 的快照并保留 pending manual check。
 
 ## 必过用户旅程
 

--- a/docs/release-readiness-manual-checks.example.json
+++ b/docs/release-readiness-manual-checks.example.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "runtime-health-review",
+    "title": "Runtime health/auth-readiness/metrics review",
+    "status": "pending",
+    "required": true,
+    "notes": "Capture candidate-environment runtime endpoints before widening playtest.",
+    "evidence": [
+      "GET /api/runtime/health",
+      "GET /api/runtime/auth-readiness",
+      "GET /api/runtime/metrics"
+    ]
+  },
+  {
+    "id": "wechat-device-smoke",
+    "title": "WeChat device smoke report",
+    "status": "pending",
+    "required": true,
+    "notes": "Run npm run smoke:wechat-release against the packaged RC artifact and attach the completed report.",
+    "evidence": [
+      "docs/wechat-minigame-release.md"
+    ]
+  }
+]

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -1,0 +1,128 @@
+# Release Readiness Snapshot
+
+`npm run release:readiness:snapshot` generates a machine-readable snapshot for the current revision and records the release gate results in one place.
+
+The default automated checks are:
+
+- `npm test`
+- `npm run typecheck:ci`
+- `npm run test:e2e:smoke`
+- `npm run test:e2e:multiplayer:smoke`
+- `npm run check:wechat-build`
+
+The snapshot also supports manual gates, so the same file can carry pending or completed human checks such as runtime endpoint review, reconnect evidence, or device smoke acceptance.
+
+## Usage
+
+Run the full automated snapshot and write the result under `artifacts/release-readiness/`:
+
+```bash
+npm run release:readiness:snapshot
+```
+
+Generate a pending template without executing the automated commands:
+
+```bash
+npm run release:readiness:snapshot -- --no-run
+```
+
+Merge in manual checks from a JSON file:
+
+```bash
+npm run release:readiness:snapshot -- \
+  --manual-checks docs/release-readiness-manual-checks.example.json
+```
+
+Add a one-off pending manual check from the CLI:
+
+```bash
+npm run release:readiness:snapshot -- \
+  --manual-check "wechat-device-smoke:WeChat device smoke report"
+```
+
+Write to a specific file:
+
+```bash
+npm run release:readiness:snapshot -- \
+  --output artifacts/release-readiness/rc-2026-03-29.json
+```
+
+## Manual Check File
+
+The manual check file can be either an array or an object with a `checks` array. Each entry supports:
+
+- `id`
+- `title`
+- `status`: `pending`, `passed`, `failed`, or `not_applicable`
+- `required`: defaults to `true`
+- `notes`
+- `evidence`: string array
+
+Example:
+
+```json
+[
+  {
+    "id": "runtime-health-review",
+    "title": "Runtime health/auth-readiness/metrics review",
+    "status": "pending",
+    "required": true,
+    "notes": "Capture candidate-environment endpoints before widening playtest.",
+    "evidence": [
+      "docs/core-gameplay-release-readiness.md"
+    ]
+  },
+  {
+    "id": "wechat-device-smoke",
+    "title": "WeChat device smoke report",
+    "status": "pending",
+    "required": true,
+    "notes": "Complete npm run smoke:wechat-release against the packaged RC build.",
+    "evidence": [
+      "docs/wechat-minigame-release.md"
+    ]
+  }
+]
+```
+
+## Snapshot Shape
+
+Sample output:
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-03-29T08:12:04.512Z",
+  "revision": {
+    "commit": "abc1234567890",
+    "shortCommit": "abc1234",
+    "branch": "codex/issue-213-release-readiness-snapshot-0329-0752",
+    "dirty": false
+  },
+  "summary": {
+    "total": 7,
+    "passed": 5,
+    "failed": 0,
+    "pending": 2,
+    "notApplicable": 0,
+    "requiredFailed": 0,
+    "requiredPending": 2,
+    "status": "pending"
+  },
+  "checks": [
+    {
+      "id": "npm-test",
+      "kind": "automated",
+      "status": "passed",
+      "command": "npm test"
+    },
+    {
+      "id": "wechat-device-smoke",
+      "kind": "manual",
+      "status": "pending"
+    }
+  ]
+}
+```
+
+Each automated check records the command, timestamps, duration, exit code, and stdout/stderr tail. That keeps the snapshot lightweight while still preserving enough evidence to debug failures.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "download:wechat-release": "node --import tsx ./scripts/download-wechat-minigame-artifact.ts",
     "verify:wechat-release": "node --import tsx ./scripts/verify-wechat-minigame-artifact.ts",
     "smoke:wechat-release": "node --import tsx ./scripts/smoke-wechat-minigame-release.ts",
+    "release:readiness:snapshot": "node --import tsx ./scripts/release-readiness-snapshot.ts",
     "check:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts --check && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/build-templates/wechatgame && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime && node --import tsx ./scripts/prepare-wechat-minigame-release.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime --check",
     "validate:wechat-build": "node --import tsx ./scripts/validate-wechat-minigame-build.ts",
     "sync:assets:h5-pixel": "npm run sync:assets:pixel",

--- a/scripts/release-readiness-snapshot.ts
+++ b/scripts/release-readiness-snapshot.ts
@@ -1,0 +1,408 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+type CheckStatus = "passed" | "failed" | "pending" | "not_applicable";
+type SnapshotStatus = "passed" | "failed" | "pending" | "partial";
+type CheckKind = "automated" | "manual";
+
+interface Args {
+  outputPath?: string;
+  manualChecksPath?: string;
+  manualChecks: string[];
+  noRun: boolean;
+}
+
+interface ReleaseReadinessCheck {
+  id: string;
+  title: string;
+  kind: CheckKind;
+  required: boolean;
+  status: CheckStatus;
+  command?: string;
+  exitCode?: number | null;
+  durationMs?: number;
+  notes: string;
+  evidence: string[];
+  source: "default" | "file" | "cli";
+  startedAt?: string;
+  finishedAt?: string;
+  stdoutTail?: string;
+  stderrTail?: string;
+}
+
+interface ManualCheckInput {
+  id: string;
+  title: string;
+  status?: CheckStatus;
+  required?: boolean;
+  notes?: string;
+  evidence?: string[];
+}
+
+interface ReleaseReadinessSnapshot {
+  schemaVersion: 1;
+  generatedAt: string;
+  revision: {
+    commit: string;
+    shortCommit: string;
+    branch: string;
+    dirty: boolean;
+  };
+  runner: {
+    nodeVersion: string;
+    platform: string;
+    hostname: string;
+    cwd: string;
+  };
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    pending: number;
+    notApplicable: number;
+    requiredFailed: number;
+    requiredPending: number;
+    status: SnapshotStatus;
+  };
+  checks: ReleaseReadinessCheck[];
+}
+
+const DEFAULT_OUTPUT_DIR = path.join("artifacts", "release-readiness");
+const OUTPUT_TAIL_BYTES = 4000;
+
+const AUTOMATED_CHECKS: Array<Pick<ReleaseReadinessCheck, "id" | "title" | "command" | "required">> = [
+  {
+    id: "npm-test",
+    title: "Unit and integration regression",
+    command: "npm test",
+    required: true
+  },
+  {
+    id: "typecheck-ci",
+    title: "TypeScript CI typecheck",
+    command: "npm run typecheck:ci",
+    required: true
+  },
+  {
+    id: "e2e-smoke",
+    title: "H5 smoke suite",
+    command: "npm run test:e2e:smoke",
+    required: true
+  },
+  {
+    id: "e2e-multiplayer-smoke",
+    title: "Multiplayer smoke suite",
+    command: "npm run test:e2e:multiplayer:smoke",
+    required: true
+  },
+  {
+    id: "wechat-build-check",
+    title: "WeChat build readiness",
+    command: "npm run check:wechat-build",
+    required: true
+  }
+];
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let outputPath: string | undefined;
+  let manualChecksPath: string | undefined;
+  const manualChecks: string[] = [];
+  let noRun = false;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--manual-checks" && next) {
+      manualChecksPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--manual-check" && next) {
+      manualChecks.push(next);
+      index += 1;
+      continue;
+    }
+    if (arg === "--no-run") {
+      noRun = true;
+      continue;
+    }
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    ...(outputPath ? { outputPath } : {}),
+    ...(manualChecksPath ? { manualChecksPath } : {}),
+    manualChecks,
+    noRun
+  };
+}
+
+function sanitizeStatus(value: unknown, context: string): CheckStatus {
+  if (value === undefined) {
+    return "pending";
+  }
+  if (value === "passed" || value === "failed" || value === "pending" || value === "not_applicable") {
+    return value;
+  }
+  fail(`Unsupported check status for ${context}: ${String(value)}`);
+}
+
+function normalizeManualCheck(entry: ManualCheckInput, source: "file" | "cli"): ReleaseReadinessCheck {
+  const id = entry.id?.trim();
+  const title = entry.title?.trim();
+  if (!id) {
+    fail(`Manual check from ${source} is missing id.`);
+  }
+  if (!title) {
+    fail(`Manual check ${id} from ${source} is missing title.`);
+  }
+
+  return {
+    id,
+    title,
+    kind: "manual",
+    required: entry.required ?? true,
+    status: sanitizeStatus(entry.status, id),
+    notes: entry.notes?.trim() ?? "",
+    evidence: Array.isArray(entry.evidence)
+      ? entry.evidence.map((value) => String(value).trim()).filter((value) => value.length > 0)
+      : [],
+    source
+  };
+}
+
+function parseManualCheckArg(value: string): ReleaseReadinessCheck {
+  const separatorIndex = value.indexOf(":");
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    fail(`Manual check must use "<id>:<title>" format, received: ${value}`);
+  }
+
+  return normalizeManualCheck(
+    {
+      id: value.slice(0, separatorIndex),
+      title: value.slice(separatorIndex + 1)
+    },
+    "cli"
+  );
+}
+
+function parseManualChecksFile(filePath: string): ReleaseReadinessCheck[] {
+  const resolvedPath = path.resolve(filePath);
+  const raw = JSON.parse(fs.readFileSync(resolvedPath, "utf8")) as ManualCheckInput[] | { checks?: ManualCheckInput[] };
+  const entries = Array.isArray(raw) ? raw : raw.checks;
+  if (!Array.isArray(entries)) {
+    fail(`Manual check file must be an array or an object with a "checks" array: ${resolvedPath}`);
+  }
+  return entries.map((entry) => normalizeManualCheck(entry, "file"));
+}
+
+function ensureUniqueIds(checks: ReleaseReadinessCheck[]): void {
+  const seen = new Set<string>();
+  for (const check of checks) {
+    if (seen.has(check.id)) {
+      fail(`Duplicate check id detected: ${check.id}`);
+    }
+    seen.add(check.id);
+  }
+}
+
+function getOutputPath(outputPath?: string): string {
+  if (outputPath) {
+    return path.resolve(outputPath);
+  }
+  const timestamp = new Date().toISOString().replace(/:/g, "-");
+  return path.resolve(DEFAULT_OUTPUT_DIR, `release-readiness-${timestamp}.json`);
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function runCommand(command: string): SpawnSyncReturns<string> {
+  return spawnSync(command, {
+    shell: true,
+    cwd: process.cwd(),
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 20
+  });
+}
+
+function tailText(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.length > OUTPUT_TAIL_BYTES ? normalized.slice(-OUTPUT_TAIL_BYTES) : normalized;
+}
+
+function buildAutomatedCheckStatus(definition: Pick<ReleaseReadinessCheck, "id" | "title" | "command" | "required">, noRun: boolean): ReleaseReadinessCheck {
+  if (noRun) {
+    return {
+      id: definition.id,
+      title: definition.title,
+      kind: "automated",
+      required: definition.required,
+      status: "pending",
+      command: definition.command,
+      notes: "Skipped command execution via --no-run.",
+      evidence: [],
+      source: "default"
+    };
+  }
+
+  const startedAt = new Date();
+  const startedAtIso = startedAt.toISOString();
+  const startedMs = Date.now();
+  const result = runCommand(definition.command ?? "");
+  const finishedAtIso = new Date().toISOString();
+  const durationMs = Date.now() - startedMs;
+
+  if (result.error) {
+    return {
+      id: definition.id,
+      title: definition.title,
+      kind: "automated",
+      required: definition.required,
+      status: "failed",
+      command: definition.command,
+      exitCode: result.status,
+      durationMs,
+      notes: result.error.message,
+      evidence: [],
+      source: "default",
+      startedAt: startedAtIso,
+      finishedAt: finishedAtIso,
+      ...(tailText(result.stdout) ? { stdoutTail: tailText(result.stdout) } : {}),
+      ...(tailText(result.stderr) ? { stderrTail: tailText(result.stderr) } : {})
+    };
+  }
+
+  return {
+    id: definition.id,
+    title: definition.title,
+    kind: "automated",
+    required: definition.required,
+    status: result.status === 0 ? "passed" : "failed",
+    command: definition.command,
+    exitCode: result.status,
+    durationMs,
+    notes: result.status === 0 ? "" : `Command exited with code ${result.status}.`,
+    evidence: [],
+    source: "default",
+    startedAt: startedAtIso,
+    finishedAt: finishedAtIso,
+    ...(tailText(result.stdout) ? { stdoutTail: tailText(result.stdout) } : {}),
+    ...(tailText(result.stderr) ? { stderrTail: tailText(result.stderr) } : {})
+  };
+}
+
+function getGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function isGitDirty(): boolean {
+  const result = spawnSync("git", ["status", "--porcelain"], {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git status --porcelain failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim().length > 0;
+}
+
+function computeSnapshotStatus(checks: ReleaseReadinessCheck[]): SnapshotStatus {
+  const requiredFailed = checks.some((check) => check.required && check.status === "failed");
+  if (requiredFailed) {
+    return "failed";
+  }
+
+  const requiredPending = checks.some((check) => check.required && check.status === "pending");
+  if (requiredPending) {
+    return "pending";
+  }
+
+  const hasAnyFailed = checks.some((check) => check.status === "failed");
+  const hasAnyPending = checks.some((check) => check.status === "pending");
+  if (hasAnyFailed || hasAnyPending) {
+    return "partial";
+  }
+
+  return "passed";
+}
+
+function buildSummary(checks: ReleaseReadinessCheck[]): ReleaseReadinessSnapshot["summary"] {
+  return {
+    total: checks.length,
+    passed: checks.filter((check) => check.status === "passed").length,
+    failed: checks.filter((check) => check.status === "failed").length,
+    pending: checks.filter((check) => check.status === "pending").length,
+    notApplicable: checks.filter((check) => check.status === "not_applicable").length,
+    requiredFailed: checks.filter((check) => check.required && check.status === "failed").length,
+    requiredPending: checks.filter((check) => check.required && check.status === "pending").length,
+    status: computeSnapshotStatus(checks)
+  };
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const outputPath = getOutputPath(args.outputPath);
+  const manualChecksFromFile = args.manualChecksPath ? parseManualChecksFile(args.manualChecksPath) : [];
+  const manualChecksFromCli = args.manualChecks.map((value) => parseManualCheckArg(value));
+  const automatedChecks = AUTOMATED_CHECKS.map((definition) => buildAutomatedCheckStatus(definition, args.noRun));
+  const checks = [...automatedChecks, ...manualChecksFromFile, ...manualChecksFromCli];
+  ensureUniqueIds(checks);
+
+  const snapshot: ReleaseReadinessSnapshot = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    revision: {
+      commit: getGitValue(["rev-parse", "HEAD"]),
+      shortCommit: getGitValue(["rev-parse", "--short", "HEAD"]),
+      branch: getGitValue(["rev-parse", "--abbrev-ref", "HEAD"]),
+      dirty: isGitDirty()
+    },
+    runner: {
+      nodeVersion: process.version,
+      platform: `${os.platform()} ${os.release()} (${os.arch()})`,
+      hostname: os.hostname(),
+      cwd: process.cwd()
+    },
+    summary: buildSummary(checks),
+    checks
+  };
+
+  writeJsonFile(outputPath, snapshot);
+
+  console.log(`Wrote release-readiness snapshot: ${path.relative(process.cwd(), outputPath).replace(/\\/g, "/")}`);
+  console.log(`  Commit: ${snapshot.revision.shortCommit} (${snapshot.revision.branch})`);
+  console.log(`  Overall status: ${snapshot.summary.status}`);
+  console.log(
+    `  Checks: ${snapshot.summary.passed} passed / ${snapshot.summary.failed} failed / ${snapshot.summary.pending} pending / ${snapshot.summary.notApplicable} n/a`
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a release-readiness snapshot command that records git revision metadata plus the required automated gates
- support pending/manual checks through inline flags or a JSON file so release evidence can live in one artifact
- document the command, workflow, and example manual checks in the README and release-readiness docs

## Validation
- npm run typecheck:ci
- npm run release:readiness:snapshot -- --no-run --manual-checks docs/release-readiness-manual-checks.example.json --output artifacts/release-readiness/issue-213-dry-run.json
- npm run release:readiness:snapshot -- --manual-checks docs/release-readiness-manual-checks.example.json --output artifacts/release-readiness/issue-213-full.json

## Notes
- The full snapshot recorded `npm test`, `npm run typecheck:ci`, and `npm run check:wechat-build` as passing.
- Playwright smoke commands failed in this environment because Chromium could not load `libatk-bridge-2.0.so.0`.

Closes #213
