### PR TITLE
Add baseline multiplayer/load-test gate

### DIFF
--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -15,6 +15,7 @@
 - H5 / Lobby 冒烟：`npm run test:e2e:smoke`
 - 多人同步冒烟：`npm run test:e2e:multiplayer:smoke`
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
+- 多人放量基线：`docs/multiplayer-loadtest-gate.md`
 - 微信小游戏构建校验：`npm run check:wechat-build`
 - 发布就绪快照：`npm run release:readiness:snapshot`
 - Cocos RC 证据快照：`npm run release:cocos-rc:snapshot`
@@ -54,7 +55,8 @@
 - [ ] 英雄移动、资源拾取、建筑访问、战斗结算都由 shared/server 权威结果驱动，而不是前端本地写死。
 - [ ] 至少覆盖一条“探索 -> 遭遇战 -> 战后回写世界状态”的完整回归链路。
 - [ ] 双客户端或多客户端进入同一房间后，同步不会出现长期分叉；断线重连后能收敛到权威状态。
-- [ ] reconnect 验收必须复用 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md) 的唯一场景和最小成功信号，而不是只写“重连成功”。
+- [ ] reconnect 验收必须复用 [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md) 的唯一场景和最小成功信号，而不是只写“重连成功”。
+- [ ] wider playtest 前必须复用 [`docs/multiplayer-loadtest-gate.md`](./multiplayer-loadtest-gate.md) 中固定的 smoke + `stress:rooms` 命令组合、阈值、回退动作和重跑触发条件。
 - [ ] 失败路径可读：非法 action、超时、会话失效时，客户端能收到明确错误而不是静默卡死。
 
 `P1 follow-up`
@@ -66,7 +68,7 @@
 
 - `npm test`
 - `npm run test:e2e:multiplayer:smoke`
-- 必要时补跑：`npm run stress:rooms -- --rooms=<n>`
+- wider playtest 前必跑：[`docs/multiplayer-loadtest-gate.md`](./multiplayer-loadtest-gate.md)
 
 ### 2. H5 调试壳与回归验证面
 
@@ -87,7 +89,7 @@
 建议证据：
 
 - `npm run test:e2e:smoke`
-- [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md) 中定义的 reconnect 证据
+- [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md) 中定义的 reconnect 证据
 - 必要时补跑：`npm run test:e2e`
 
 ### 3. Cocos 主客户端体验面
@@ -110,7 +112,7 @@
 - `npm test`
 - `npm run check:wechat-build`
 - `npm run release:cocos-rc:snapshot -- --output <snapshot-path>`
-- [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md) 中定义的 reconnect 证据
+- [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md) 中定义的 reconnect 证据
 - 按 [`docs/wechat-minigame-release.md`](/home/gpt/project/ProjectVeil/docs/wechat-minigame-release.md) 完成 `verify` 与 `smoke`
 
 ### 4. 观测、诊断与运维门禁
@@ -160,8 +162,8 @@ H5 冒烟和多人 Playwright 已经比较成熟，但真实发布面是 `apps/c
   - 固定一条 Lobby -> 进房 -> 战斗 -> 重连 -> 返回世界的验收脚本
   - 使用 `npm run release:cocos-rc:snapshot` 产出统一 evidence，并参考 `docs/release-evidence/cocos-rc-snapshot.example.json` 回填
 - `多人放量门禁`
-  - 固定压测参数
-  - 记录可接受阈值和回退条件
+  - 复用 `docs/multiplayer-loadtest-gate.md`
+  - 固定压测参数、阈值、回退条件与样例记录
 - `微信提审门禁`
   - 固定 smoke 设备矩阵
   - 固定分享回流、资源白名单和登录回归证据

--- a/docs/multiplayer-loadtest-gate.md
+++ b/docs/multiplayer-loadtest-gate.md
@@ -1,0 +1,157 @@
+# ProjectVeil Multiplayer / Load-Test Gate
+
+本说明把 wider playtest 前必须复用的多人同步 / 多房间基线固定下来，避免每次临时换参数、换阈值、换回退口径。
+
+它是 [`docs/core-gameplay-release-readiness.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-214/docs/core-gameplay-release-readiness.md) 中“权威玩法与多人同步”门禁的唯一放量基线。
+
+## Standard Command Set
+
+扩大测试范围前，至少按下面顺序执行一次：
+
+1. 多人同步冒烟
+
+```bash
+npm run test:e2e:multiplayer:smoke
+```
+
+2. 多房间基线压测
+
+```bash
+npm run stress:rooms -- \
+  --rooms=48 \
+  --connect-concurrency=12 \
+  --action-concurrency=12 \
+  --sample-interval-ms=100 \
+  --reconnect-pause-ms=150
+```
+
+说明：
+
+- `48 rooms` 是当前 wider playtest 前的固定基线，不在本门禁里临时上调。
+- 默认场景固定为 `world_progression,battle_settlement,reconnect`，不要删场景只跑其中一段。
+- `test:e2e:multiplayer:smoke` 负责回答“多人主链路还通不通”，`stress:rooms` 负责回答“同一套候选包在多房间下是否还在可接受性能区间内”。
+
+若环境无法跑 Playwright，但 `stress:rooms` 能跑，请把 Playwright 阻塞原因和缺失依赖写进本次记录，不能直接把 smoke 视为通过。
+
+## Required Thresholds
+
+`npm run stress:rooms` 的控制台摘要和 `STRESS_RESULT_JSON_*` 输出中，至少要满足下面阈值：
+
+| 指标 | 阈值 | 说明 |
+| --- | --- | --- |
+| `successfulRooms` | 每个场景都必须等于 `48` | 任何房间失败都算 gate fail |
+| `failedRooms` | 每个场景都必须等于 `0` | 不接受部分成功 |
+| `runtimeHealthAfterConnect.activeRoomCount` | `48` | 确认房间数确实拉满 |
+| `runtimeHealthAfterConnect.connectionCount` | `48` | 当前基线是每房 1 连接 |
+| `runtimeHealthAfterScenario.worldActionsTotal` | `world_progression >= 96` | 固定命令下应完成 48 次移动 + 48 次结束回合 |
+| `runtimeHealthAfterScenario.worldActionsTotal` | `battle_settlement >= 144` | battle 场景结束后累计 world action 总数下限 |
+| `runtimeHealthAfterScenario.battleActionsTotal` | `battle_settlement >= 144` | battle 结算必须实际消耗战斗动作 |
+| `runtimeHealthAfterScenario.connectMessagesTotal` | `reconnect >= 192` | reconnect 场景结束后累计连接消息下限 |
+| `runtimeHealthAfterScenario.actionMessagesTotal` | `reconnect >= 336` | 固定三场景顺序下的累计动作总数下限 |
+| `actionsPerSecond` | `world_progression >= 150` | 当前基线下的最低可接受吞吐 |
+| `actionsPerSecond` | `battle_settlement >= 250` | 战斗结算压测最低吞吐 |
+| `actionsPerSecond` | `reconnect >= 100` | reconnect 恢复场景最低吞吐 |
+| `durationMs` | `world_progression <= 1200` | 单场景耗时上限 |
+| `durationMs` | `battle_settlement <= 1200` | 单场景耗时上限 |
+| `durationMs` | `reconnect <= 1500` | reconnect 允许更高耗时 |
+| `cpuCoreUtilizationPct` | `world_progression <= 80` | 超过说明 CPU 已接近无缓冲区 |
+| `cpuCoreUtilizationPct` | `battle_settlement <= 75` | 战斗场景更容易暴露 CPU 压力 |
+| `cpuCoreUtilizationPct` | `reconnect <= 50` | reconnect 不应靠高 CPU 扛过去 |
+| `rssPeakMb` | 每个场景都必须 `<= 320` | 粗粒度内存上限 |
+| `heapPeakMb` | 每个场景都必须 `<= 110` | JS 堆上限 |
+| `peakActiveHandles` | 每个场景都必须 `<= 120` | 防止句柄泄漏式放量 |
+| reconnect 恢复成功率 | `100%` | 以 `reconnect` 场景 `successfulRooms / rooms` 计算 |
+
+判定规则：
+
+- 任一阈值失败，本次候选包不能进入 wider playtest。
+- 若 smoke 失败但压测通过，仍按 gate fail 处理，因为这通常说明主链路逻辑或测试环境有回归。
+- 若 smoke 因环境依赖缺失无法执行，允许把结果记为 `blocked`，但不能标记为 `passed`。
+
+## Rollback Guidance
+
+只要触发下列任一情况，优先回退到“上一次通过本基线的候选包 / 配置”，而不是带着异常继续放量：
+
+- `failedRooms > 0`
+- reconnect 恢复成功率不是 `100%`
+- `rssPeakMb`、`heapPeakMb` 或 `peakActiveHandles` 超阈值
+- `actionsPerSecond` 明显跌破阈值，且伴随 `durationMs` 上升
+- smoke 出现多人状态分叉、错误房间恢复、结算后回档
+
+建议回退动作：
+
+1. 停止扩大测试名单，维持当前已知稳定的 playtest 范围。
+2. 回退最近引入的多人协议、房间生命周期、持久化、reconnect、战斗结算相关变更。
+3. 在回退候选包上重新执行本门禁，确认指标恢复到阈值内。
+4. 仅在新的修复候选包再次通过 smoke + stress 后，才重新放量。
+
+## When To Rerun
+
+出现下面任一条件，必须重跑本门禁，不能复用旧记录：
+
+- `apps/server`、`packages/shared` 中任何影响房间状态、战斗、同步、reconnect、持久化的改动
+- `apps/client` 或 `apps/cocos-client` 中任何影响多人房间进入、状态恢复、事件驱动的改动
+- 调整 `stress:rooms` 参数、默认场景、阈值，或 observability 指标口径
+- 准备把 playtest 范围扩大到更多玩家、更多时段，或从 H5 过渡到 Cocos 主客户端验证
+- 距离上一次基线记录已超过 14 天
+- 上一次记录结果为 `partial`、`blocked` 或 `fail`
+
+## Result Record Template
+
+最小记录至少包含以下字段，建议直接保存一份 JSON 到 `docs/release-evidence/`：
+
+```json
+{
+  "schemaVersion": 1,
+  "gate": "multiplayer-loadtest-baseline",
+  "executedAt": "2026-03-29T08:12:22+08:00",
+  "revision": {
+    "branch": "<branch>",
+    "commit": "<commit>",
+    "shortCommit": "<short>"
+  },
+  "commands": [
+    "npm run test:e2e:multiplayer:smoke",
+    "npm run stress:rooms -- --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150"
+  ],
+  "status": "passed | blocked | failed",
+  "thresholds": {
+    "rooms": 48,
+    "reconnectSuccessRate": "100%",
+    "rssPeakMbMax": 320,
+    "heapPeakMbMax": 110,
+    "peakActiveHandlesMax": 120
+  },
+  "results": [],
+  "validation": {
+    "multiplayerSmoke": {
+      "status": "passed | blocked | failed",
+      "notes": ""
+    },
+    "stressRooms": {
+      "status": "passed | failed",
+      "notes": ""
+    }
+  },
+  "rollbackDecision": {
+    "required": false,
+    "notes": ""
+  }
+}
+```
+
+## Real Sample Record
+
+本仓库当前基线样例见：
+
+- [`docs/release-evidence/multiplayer-loadtest-baseline-2026-03-29.json`](/home/gpt/project/ProjectVeil/.worktrees/issue-214/docs/release-evidence/multiplayer-loadtest-baseline-2026-03-29.json)
+
+这份样例来自真实执行：
+
+- `npm run stress:rooms -- --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150`
+- `npm run test:e2e:multiplayer:smoke`
+
+其中：
+
+- `stress:rooms` 通过，3 个场景均达到 `48/48` 成功房间，reconnect 恢复成功率 `100%`。
+- `test:e2e:multiplayer:smoke` 在当前容器中被环境依赖阻塞，Chromium 启动失败并缺少 `libatk-bridge-2.0.so.0`，因此样例记录为 `blocked`，没有把 smoke 误记成 `passed`。

--- a/docs/release-evidence/multiplayer-loadtest-baseline-2026-03-29.json
+++ b/docs/release-evidence/multiplayer-loadtest-baseline-2026-03-29.json
@@ -1,0 +1,178 @@
+{
+  "schemaVersion": 1,
+  "gate": "multiplayer-loadtest-baseline",
+  "executedAt": "2026-03-29T08:12:22+08:00",
+  "revision": {
+    "branch": "codex/issue-214-loadtest-gate-0329-0811",
+    "commit": "034737d3c1724f7a069745c97077406b55d07719",
+    "shortCommit": "034737d"
+  },
+  "status": "blocked",
+  "summary": "The fixed 48-room stress baseline passed all thresholds. Multiplayer Playwright smoke was blocked in the container because Chromium could not load libatk-bridge-2.0.so.0, so the overall record is blocked rather than passed.",
+  "commands": [
+    "npm run test:e2e:multiplayer:smoke",
+    "npm run stress:rooms -- --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150"
+  ],
+  "thresholds": {
+    "rooms": 48,
+    "successfulRoomsPerScenario": 48,
+    "failedRoomsPerScenario": 0,
+    "activeRoomCountAfterConnect": 48,
+    "connectionCountAfterConnect": 48,
+    "worldProgression": {
+      "worldActionsTotalMin": 96,
+      "actionsPerSecondMin": 150,
+      "durationMsMax": 1200,
+      "cpuCoreUtilizationPctMax": 80
+    },
+    "battleSettlement": {
+      "worldActionsTotalMin": 144,
+      "battleActionsTotalMin": 144,
+      "actionsPerSecondMin": 250,
+      "durationMsMax": 1200,
+      "cpuCoreUtilizationPctMax": 75
+    },
+    "reconnect": {
+      "connectMessagesTotalMin": 192,
+      "actionMessagesTotalMin": 336,
+      "successRate": "100%",
+      "actionsPerSecondMin": 100,
+      "durationMsMax": 1500,
+      "cpuCoreUtilizationPctMax": 50
+    },
+    "rssPeakMbMax": 320,
+    "heapPeakMbMax": 110,
+    "peakActiveHandlesMax": 120
+  },
+  "validation": {
+    "multiplayerSmoke": {
+      "status": "blocked",
+      "command": "npm run test:e2e:multiplayer:smoke",
+      "notes": "Playwright Chromium failed to launch in the container because libatk-bridge-2.0.so.0 was missing.",
+      "error": "browserType.launch: chrome-headless-shell: error while loading shared libraries: libatk-bridge-2.0.so.0: cannot open shared object file: No such file or directory"
+    },
+    "stressRooms": {
+      "status": "passed",
+      "command": "npm run stress:rooms -- --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150",
+      "notes": "All three fixed scenarios passed on the local embedded Colyseus server."
+    }
+  },
+  "results": [
+    {
+      "scenario": "world_progression",
+      "status": "passed",
+      "rooms": 48,
+      "successfulRooms": 48,
+      "failedRooms": 0,
+      "completedActions": 144,
+      "durationMs": 821.43,
+      "roomsPerSecond": 58.43,
+      "actionsPerSecond": 175.3,
+      "cpuCoreUtilizationPct": 71.5,
+      "rssPeakMb": 213.95,
+      "heapPeakMb": 55.42,
+      "peakActiveHandles": 105,
+      "runtimeHealthAfterConnect": {
+        "checkedAt": "2026-03-29T00:13:59.240Z",
+        "activeRoomCount": 48,
+        "connectionCount": 48,
+        "activeBattleCount": 0,
+        "heroCount": 96,
+        "connectMessagesTotal": 48,
+        "worldActionsTotal": 0,
+        "battleActionsTotal": 0,
+        "actionMessagesTotal": 0
+      },
+      "runtimeHealthAfterScenario": {
+        "checkedAt": "2026-03-29T00:13:59.417Z",
+        "activeRoomCount": 48,
+        "connectionCount": 48,
+        "activeBattleCount": 48,
+        "heroCount": 96,
+        "connectMessagesTotal": 48,
+        "worldActionsTotal": 96,
+        "battleActionsTotal": 0,
+        "actionMessagesTotal": 96
+      }
+    },
+    {
+      "scenario": "battle_settlement",
+      "status": "passed",
+      "rooms": 48,
+      "successfulRooms": 48,
+      "failedRooms": 0,
+      "completedActions": 240,
+      "durationMs": 763.29,
+      "roomsPerSecond": 62.89,
+      "actionsPerSecond": 314.43,
+      "cpuCoreUtilizationPct": 62.36,
+      "rssPeakMb": 227.58,
+      "heapPeakMb": 68.78,
+      "peakActiveHandles": 105,
+      "runtimeHealthAfterConnect": {
+        "checkedAt": "2026-03-29T00:13:59.851Z",
+        "activeRoomCount": 48,
+        "connectionCount": 48,
+        "activeBattleCount": 0,
+        "heroCount": 96,
+        "connectMessagesTotal": 96,
+        "worldActionsTotal": 96,
+        "battleActionsTotal": 0,
+        "actionMessagesTotal": 96
+      },
+      "runtimeHealthAfterScenario": {
+        "checkedAt": "2026-03-29T00:14:00.203Z",
+        "activeRoomCount": 48,
+        "connectionCount": 48,
+        "activeBattleCount": 0,
+        "heroCount": 96,
+        "connectMessagesTotal": 96,
+        "worldActionsTotal": 144,
+        "battleActionsTotal": 144,
+        "actionMessagesTotal": 288
+      }
+    },
+    {
+      "scenario": "reconnect",
+      "status": "passed",
+      "rooms": 48,
+      "successfulRooms": 48,
+      "failedRooms": 0,
+      "completedActions": 144,
+      "durationMs": 1181.68,
+      "roomsPerSecond": 40.62,
+      "actionsPerSecond": 121.86,
+      "cpuCoreUtilizationPct": 37.81,
+      "rssPeakMb": 268.21,
+      "heapPeakMb": 91.6,
+      "peakActiveHandles": 106,
+      "reconnectSuccessRate": "100%",
+      "runtimeHealthAfterConnect": {
+        "checkedAt": "2026-03-29T00:14:00.660Z",
+        "activeRoomCount": 48,
+        "connectionCount": 48,
+        "activeBattleCount": 0,
+        "heroCount": 96,
+        "connectMessagesTotal": 144,
+        "worldActionsTotal": 144,
+        "battleActionsTotal": 144,
+        "actionMessagesTotal": 288
+      },
+      "runtimeHealthAfterScenario": {
+        "checkedAt": "2026-03-29T00:14:01.400Z",
+        "activeRoomCount": 48,
+        "connectionCount": 96,
+        "activeBattleCount": 48,
+        "heroCount": 96,
+        "connectMessagesTotal": 192,
+        "worldActionsTotal": 192,
+        "battleActionsTotal": 144,
+        "actionMessagesTotal": 336
+      }
+    }
+  ],
+  "rollbackDecision": {
+    "required": false,
+    "notes": "No rollback is needed for the stress baseline itself. Re-run the smoke gate in an environment with Playwright system dependencies before marking the overall wider-playtest gate as passed."
+  }
+}

--- a/scripts/stress-concurrent-rooms.ts
+++ b/scripts/stress-concurrent-rooms.ts
@@ -48,6 +48,8 @@ interface ScenarioResult {
   heapPeakMb: number;
   heapEndMb: number;
   peakActiveHandles: number;
+  runtimeHealthAfterConnect?: RuntimeHealthSummary;
+  runtimeHealthAfterScenario?: RuntimeHealthSummary;
   errorMessage?: string;
 }
 
@@ -70,6 +72,18 @@ interface ResourceReport extends ResourceSnapshot {
   heapPeakMb: number;
   heapEndMb: number;
   peakActiveHandles: number;
+}
+
+interface RuntimeHealthSummary {
+  checkedAt: string;
+  activeRoomCount: number;
+  connectionCount: number;
+  activeBattleCount: number;
+  heroCount: number;
+  connectMessagesTotal: number;
+  worldActionsTotal: number;
+  battleActionsTotal: number;
+  actionMessagesTotal: number;
 }
 
 const DEFAULT_BATTLE_DESTINATION: Vec2 = { x: 5, y: 4 };
@@ -146,6 +160,61 @@ function parseStressOptions(): StressOptions {
     maxBattleTurns: parseIntegerFlag("max-battle-turns", 24),
     scenarios: parseScenarioFlag()
   };
+}
+
+async function fetchRuntimeHealthSummary(host: string, port: number): Promise<RuntimeHealthSummary | undefined> {
+  try {
+    const response = await fetch(`http://${host}:${port}/api/runtime/health`);
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const payload = (await response.json()) as {
+      checkedAt?: string;
+      runtime?: {
+        activeRoomCount?: number;
+        connectionCount?: number;
+        activeBattleCount?: number;
+        heroCount?: number;
+        gameplayTraffic?: {
+          connectMessagesTotal?: number;
+          worldActionsTotal?: number;
+          battleActionsTotal?: number;
+          actionMessagesTotal?: number;
+        };
+      };
+    };
+
+    const runtime = payload.runtime;
+    const gameplayTraffic = runtime?.gameplayTraffic;
+    if (
+      !payload.checkedAt ||
+      typeof runtime?.activeRoomCount !== "number" ||
+      typeof runtime.connectionCount !== "number" ||
+      typeof runtime.activeBattleCount !== "number" ||
+      typeof runtime.heroCount !== "number" ||
+      typeof gameplayTraffic?.connectMessagesTotal !== "number" ||
+      typeof gameplayTraffic.worldActionsTotal !== "number" ||
+      typeof gameplayTraffic.battleActionsTotal !== "number" ||
+      typeof gameplayTraffic.actionMessagesTotal !== "number"
+    ) {
+      return undefined;
+    }
+
+    return {
+      checkedAt: payload.checkedAt,
+      activeRoomCount: runtime.activeRoomCount,
+      connectionCount: runtime.connectionCount,
+      activeBattleCount: runtime.activeBattleCount,
+      heroCount: runtime.heroCount,
+      connectMessagesTotal: gameplayTraffic.connectMessagesTotal,
+      worldActionsTotal: gameplayTraffic.worldActionsTotal,
+      battleActionsTotal: gameplayTraffic.battleActionsTotal,
+      actionMessagesTotal: gameplayTraffic.actionMessagesTotal
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function installLogFilter(): () => void {
@@ -587,10 +656,13 @@ async function cleanupRooms(contexts: RoomContext[]): Promise<void> {
 async function runScenario(scenario: ScenarioName, options: StressOptions): Promise<ScenarioResult> {
   const monitor = new ResourceMonitor(options.sampleIntervalMs);
   let contexts: RoomContext[] = [];
+  let runtimeHealthAfterConnect: RuntimeHealthSummary | undefined;
+  let runtimeHealthAfterScenario: RuntimeHealthSummary | undefined;
 
   try {
     const connected = await connectRooms(options, scenario);
     contexts = connected.contexts;
+    runtimeHealthAfterConnect = await fetchRuntimeHealthSummary(options.host, options.port);
     let completedActions = connected.completedActions;
 
     if (scenario === "world_progression") {
@@ -600,6 +672,7 @@ async function runScenario(scenario: ScenarioName, options: StressOptions): Prom
     } else {
       completedActions += await runReconnectScenario(contexts, options);
     }
+    runtimeHealthAfterScenario = await fetchRuntimeHealthSummary(options.host, options.port);
 
     const resources = monitor.stop();
     return {
@@ -621,9 +694,12 @@ async function runScenario(scenario: ScenarioName, options: StressOptions): Prom
       heapStartMb: resources.heapStartMb,
       heapPeakMb: resources.heapPeakMb,
       heapEndMb: resources.heapEndMb,
-      peakActiveHandles: resources.peakActiveHandles
+      peakActiveHandles: resources.peakActiveHandles,
+      ...(runtimeHealthAfterConnect ? { runtimeHealthAfterConnect } : {}),
+      ...(runtimeHealthAfterScenario ? { runtimeHealthAfterScenario } : {})
     };
   } catch (error) {
+    runtimeHealthAfterScenario = await fetchRuntimeHealthSummary(options.host, options.port);
     const resources = monitor.stop();
     return {
       scenario,
@@ -645,6 +721,8 @@ async function runScenario(scenario: ScenarioName, options: StressOptions): Prom
       heapPeakMb: resources.heapPeakMb,
       heapEndMb: resources.heapEndMb,
       peakActiveHandles: resources.peakActiveHandles,
+      ...(runtimeHealthAfterConnect ? { runtimeHealthAfterConnect } : {}),
+      ...(runtimeHealthAfterScenario ? { runtimeHealthAfterScenario } : {}),
       errorMessage: error instanceof Error ? error.message : String(error)
     };
   } finally {
@@ -663,6 +741,9 @@ function printSummary(results: ScenarioResult[], options: StressOptions): void {
       rooms: result.rooms,
       success: result.successfulRooms,
       failed: result.failedRooms,
+      activeRooms: result.runtimeHealthAfterConnect?.activeRoomCount ?? "",
+      connections: result.runtimeHealthAfterConnect?.connectionCount ?? "",
+      actionMsgs: result.runtimeHealthAfterScenario?.actionMessagesTotal ?? "",
       durationMs: result.durationMs,
       roomsPerSec: result.roomsPerSecond,
       actions: result.completedActions,


### PR DESCRIPTION
## Summary
- add a dedicated multiplayer/load-test gate doc with fixed commands, thresholds, rollback guidance, rerun triggers, and a result template
- extend the concurrent room stress script to capture runtime health snapshots so active rooms, connections, and action counters are preserved in the output
- add a real 2026-03-29 sample evidence record and link the new gate from core gameplay release readiness

## Validation
- `npm run stress:rooms -- --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150`
- `npm run test:e2e:multiplayer:smoke` (blocked: missing `libatk-bridge-2.0.so.0` in the container)
- `npm run typecheck` (pre-existing repo-wide failures; confirmed no remaining `scripts/stress-concurrent-rooms.ts` errors)

Closes #214
