### PR TITLE
test(client): add H5 config center coverage

### DIFF
--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -1,0 +1,949 @@
+type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
+
+interface ConfigDocumentSummary {
+  id: ConfigDocumentId;
+  title: string;
+  description: string;
+  fileName: string;
+  updatedAt: string;
+  summary: string;
+  storage?: "filesystem" | "mysql";
+  version?: number;
+  exportedAt?: string | null;
+}
+
+interface ConfigDocument extends ConfigDocumentSummary {
+  content: string;
+}
+
+interface ValidationIssue {
+  path: string;
+  severity: "error" | "warning";
+  message: string;
+  suggestion: string;
+  line?: number;
+}
+
+interface ConfigSchemaSummary {
+  id: string;
+  title: string;
+  version: string;
+  description: string;
+  required: string[];
+}
+
+interface ValidationReport {
+  valid: boolean;
+  summary: string;
+  issues: ValidationIssue[];
+  schema: ConfigSchemaSummary;
+}
+
+interface ConfigSnapshotSummary {
+  id: string;
+  label: string;
+  createdAt: string;
+  version: number;
+}
+
+interface ConfigDiffEntry {
+  path: string;
+  change: "added" | "removed" | "updated";
+  previousValue: string;
+  nextValue: string;
+}
+
+interface ConfigDiff {
+  entries: ConfigDiffEntry[];
+}
+
+interface ConfigPresetSummary {
+  id: string;
+  name: string;
+  kind: "builtin" | "custom";
+  updatedAt: string;
+  description: string;
+}
+
+type TerrainType = "grass" | "dirt" | "sand" | "water";
+type ResourceKind = "gold" | "wood" | "ore";
+
+interface WorldConfigPreviewTile {
+  position: {
+    x: number;
+    y: number;
+  };
+  terrain: TerrainType;
+  walkable: boolean;
+  resource?:
+    | {
+        kind: ResourceKind;
+        amount: number;
+        source: "random" | "guaranteed";
+      }
+    | undefined;
+  occupant?:
+    | {
+        kind: "hero" | "neutral";
+        refId: string;
+        label: string;
+        playerId?: string;
+      }
+    | undefined;
+  building?:
+    | {
+        kind: "recruitment_post";
+        refId: string;
+        label: string;
+        unitTemplateId: string;
+        availableCount: number;
+      }
+    | {
+        kind: "attribute_shrine";
+        refId: string;
+        label: string;
+        bonus: {
+          attack: number;
+          defense: number;
+          power: number;
+          knowledge: number;
+        };
+        visitedCount: number;
+      }
+    | {
+        kind: "resource_mine";
+        refId: string;
+        label: string;
+        resourceKind: ResourceKind;
+        income: number;
+        ownerPlayerId?: string;
+      }
+    | undefined;
+}
+
+interface WorldConfigPreview {
+  seed: number;
+  roomId: string;
+  width: number;
+  height: number;
+  counts: {
+    walkable: number;
+    blocked: number;
+    terrain: Record<TerrainType, number>;
+    resourceTiles: Record<ResourceKind, number>;
+    resourceAmounts: Record<ResourceKind, number>;
+    guaranteedResources: number;
+    randomResources: number;
+    heroes: number;
+    neutralArmies: number;
+    buildings: number;
+  };
+  tiles: WorldConfigPreviewTile[];
+}
+
+interface ApiErrorPayload {
+  error?: {
+    message?: string;
+  };
+}
+
+interface DownloadPayload {
+  blob: Blob;
+  fileName: string | null;
+  exportedAt: string | null;
+}
+
+interface AppState {
+  items: ConfigDocumentSummary[];
+  current: ConfigDocument | null;
+  selectedId: ConfigDocumentId | null;
+  storageMode: "filesystem" | "mysql" | null;
+  loading: boolean;
+  saving: boolean;
+  statusTone: "neutral" | "success" | "error";
+  statusMessage: string;
+  draft: string;
+  previewSeed: number;
+  worldPreview: WorldConfigPreview | null;
+  previewLoading: boolean;
+  previewError: string;
+  validation: ValidationReport | null;
+  validationLoading: boolean;
+  snapshots: ConfigSnapshotSummary[];
+  selectedSnapshotId: string | null;
+  snapshotDiff: ConfigDiff | null;
+  historyLoading: boolean;
+  presets: ConfigPresetSummary[];
+  presetsLoading: boolean;
+}
+
+interface ConfigCenterControllerOptions {
+  fetch?: typeof fetch;
+  onStateChange?: () => void;
+  prompt?: (message?: string, defaultValue?: string) => string | null;
+  download?: (payload: DownloadPayload & { fallbackFileName: string }) => void;
+  setTimeout?: typeof globalThis.setTimeout;
+  clearTimeout?: typeof globalThis.clearTimeout;
+  now?: () => string;
+}
+
+export interface DraftParseState {
+  valid: boolean;
+  detail: string;
+  rootKeys: number;
+}
+
+const WORLD_PREVIEW_DEBOUNCE_MS = 260;
+
+const EMPTY_SCHEMA_SUMMARY: ConfigSchemaSummary = {
+  id: "project-veil.config-center.unknown",
+  title: "Unknown Schema",
+  version: "0",
+  description: "Schema 信息暂不可用。",
+  required: []
+};
+
+function encodeBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export function createConfigCenterController(options: ConfigCenterControllerOptions = {}) {
+  const fetchImpl = options.fetch ?? fetch;
+  const notify = options.onStateChange ?? (() => {});
+  const promptImpl = options.prompt ?? (() => null);
+  const downloadImpl = options.download ?? (() => {});
+  const setTimer = options.setTimeout ?? globalThis.setTimeout.bind(globalThis);
+  const clearTimer = options.clearTimeout ?? globalThis.clearTimeout.bind(globalThis);
+  const now = options.now ?? (() => new Date().toISOString());
+
+  const state: AppState = {
+    items: [],
+    current: null,
+    selectedId: null,
+    storageMode: null,
+    loading: true,
+    saving: false,
+    statusTone: "neutral",
+    statusMessage: "正在加载配置中心...",
+    draft: "",
+    previewSeed: 1001,
+    worldPreview: null,
+    previewLoading: false,
+    previewError: "",
+    validation: null,
+    validationLoading: false,
+    snapshots: [],
+    selectedSnapshotId: null,
+    snapshotDiff: null,
+    historyLoading: false,
+    presets: [],
+    presetsLoading: false
+  };
+
+  let previewRequestVersion = 0;
+  let previewDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let validationRequestVersion = 0;
+  let validationDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function isWorldDocumentSelected(): boolean {
+    return state.current?.id === "world";
+  }
+
+  function getDraftParseState(): DraftParseState {
+    try {
+      const parsed = JSON.parse(state.draft || "{}") as Record<string, unknown>;
+      return {
+        valid: true,
+        detail: "JSON 语法有效",
+        rootKeys: Object.keys(parsed).length
+      };
+    } catch (error) {
+      return {
+        valid: false,
+        detail: error instanceof Error ? error.message : "JSON 语法无效",
+        rootKeys: 0
+      };
+    }
+  }
+
+  function normalizePreviewSeed(value: number, fallback = state.previewSeed): number {
+    if (!Number.isFinite(value)) {
+      return fallback;
+    }
+
+    return Math.max(0, Math.floor(value));
+  }
+
+  async function requestJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+    const response = await fetchImpl(input, init);
+    const data = (await response.json()) as T & ApiErrorPayload;
+
+    if (!response.ok) {
+      throw new Error(data.error?.message ?? `Request failed: ${response.status}`);
+    }
+
+    return data;
+  }
+
+  function parseDownloadFileName(headerValue: string | null): string | null {
+    if (!headerValue) {
+      return null;
+    }
+
+    const utf8Match = headerValue.match(/filename\*=UTF-8''([^;]+)/i);
+    if (utf8Match?.[1]) {
+      try {
+        return decodeURIComponent(utf8Match[1]);
+      } catch {
+        return utf8Match[1];
+      }
+    }
+
+    const quotedMatch = headerValue.match(/filename=\"([^\"]+)\"/i);
+    if (quotedMatch?.[1]) {
+      return quotedMatch[1];
+    }
+
+    const plainMatch = headerValue.match(/filename=([^;]+)/i);
+    return plainMatch?.[1]?.trim() ?? null;
+  }
+
+  async function requestDownload(input: RequestInfo, init?: RequestInit): Promise<DownloadPayload> {
+    const response = await fetchImpl(input, init);
+    if (!response.ok) {
+      let errorMessage = `Request failed: ${response.status}`;
+      try {
+        const data = (await response.json()) as ApiErrorPayload;
+        errorMessage = data.error?.message ?? errorMessage;
+      } catch {
+        // ignore
+      }
+      throw new Error(errorMessage);
+    }
+
+    return {
+      blob: await response.blob(),
+      fileName: parseDownloadFileName(response.headers.get("Content-Disposition")),
+      exportedAt: response.headers.get("X-Config-Exported-At")
+    };
+  }
+
+  function clearWorldPreview(cancelPending = true): void {
+    if (cancelPending && previewDebounceTimer != null) {
+      clearTimer(previewDebounceTimer);
+      previewDebounceTimer = null;
+    }
+
+    previewRequestVersion += 1;
+    state.worldPreview = null;
+    state.previewLoading = false;
+    state.previewError = "";
+  }
+
+  function setDraft(nextDraft: string): void {
+    state.draft = nextDraft;
+  }
+
+  async function loadList(): Promise<void> {
+    const response = await requestJson<{
+      storage: "filesystem" | "mysql";
+      items: ConfigDocumentSummary[];
+    }>("/api/config-center/configs");
+    state.storageMode = response.storage;
+    state.items = response.items;
+    notify();
+  }
+
+  async function loadSnapshots(id: ConfigDocumentId): Promise<void> {
+    state.historyLoading = true;
+    notify();
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        snapshots: ConfigSnapshotSummary[];
+      }>(`/api/config-center/configs/${id}/snapshots`);
+      state.storageMode = response.storage;
+      state.snapshots = response.snapshots;
+      if (!state.snapshots.some((item) => item.id === state.selectedSnapshotId)) {
+        state.selectedSnapshotId = state.snapshots[0]?.id ?? null;
+        state.snapshotDiff = null;
+      }
+    } finally {
+      state.historyLoading = false;
+      notify();
+    }
+
+    if (state.selectedSnapshotId) {
+      await loadSnapshotDiff();
+    }
+  }
+
+  async function loadPresets(id: ConfigDocumentId): Promise<void> {
+    state.presetsLoading = true;
+    notify();
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        presets: ConfigPresetSummary[];
+      }>(`/api/config-center/configs/${id}/presets`);
+      state.storageMode = response.storage;
+      state.presets = response.presets;
+    } finally {
+      state.presetsLoading = false;
+      notify();
+    }
+  }
+
+  async function loadSnapshotDiff(): Promise<void> {
+    if (!state.current || !state.selectedSnapshotId) {
+      state.snapshotDiff = null;
+      notify();
+      return;
+    }
+
+    const response = await requestJson<{
+      storage: "filesystem" | "mysql";
+      diff: ConfigDiff;
+    }>(`/api/config-center/configs/${state.current.id}/diff`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        snapshotId: state.selectedSnapshotId
+      })
+    });
+    state.storageMode = response.storage;
+    state.snapshotDiff = response.diff;
+    notify();
+  }
+
+  async function loadWorldPreview(): Promise<void> {
+    if (!isWorldDocumentSelected()) {
+      clearWorldPreview();
+      notify();
+      return;
+    }
+
+    const parseState = getDraftParseState();
+    if (!parseState.valid) {
+      state.previewLoading = false;
+      state.worldPreview = null;
+      state.previewError = `JSON 语法无效：${parseState.detail}`;
+      notify();
+      return;
+    }
+
+    const requestVersion = ++previewRequestVersion;
+
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        preview: WorldConfigPreview;
+      }>("/api/config-center/configs/world/preview", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          content: state.draft,
+          seed: state.previewSeed
+        })
+      });
+
+      if (requestVersion !== previewRequestVersion || !isWorldDocumentSelected()) {
+        return;
+      }
+
+      state.storageMode = response.storage;
+      state.worldPreview = response.preview;
+      state.previewError = "";
+    } catch (error) {
+      if (requestVersion !== previewRequestVersion) {
+        return;
+      }
+
+      state.worldPreview = null;
+      state.previewError = error instanceof Error ? error.message : "地图预览生成失败";
+    } finally {
+      if (requestVersion === previewRequestVersion) {
+        state.previewLoading = false;
+        notify();
+      }
+    }
+  }
+
+  async function loadValidation(delayMs = 0): Promise<void> {
+    if (!state.current) {
+      state.validation = null;
+      notify();
+      return;
+    }
+
+    if (validationDebounceTimer != null) {
+      clearTimer(validationDebounceTimer);
+      validationDebounceTimer = null;
+    }
+
+    const run = async () => {
+      const requestVersion = ++validationRequestVersion;
+      state.validationLoading = true;
+      notify();
+
+      try {
+        const response = await requestJson<{
+          storage: "filesystem" | "mysql";
+          validation: ValidationReport;
+        }>(`/api/config-center/configs/${state.current?.id}/validate`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            content: state.draft
+          })
+        });
+
+        if (requestVersion !== validationRequestVersion) {
+          return;
+        }
+
+        state.storageMode = response.storage;
+        state.validation = response.validation;
+      } catch (error) {
+        if (requestVersion !== validationRequestVersion) {
+          return;
+        }
+
+        state.validation = {
+          valid: false,
+          summary: error instanceof Error ? error.message : "校验失败",
+          issues: [
+            {
+              path: "$",
+              severity: "error",
+              message: error instanceof Error ? error.message : "校验失败",
+              suggestion: "检查 JSON 语法和字段格式后重试。"
+            }
+          ],
+          schema: state.validation?.schema ?? EMPTY_SCHEMA_SUMMARY
+        };
+      } finally {
+        if (requestVersion === validationRequestVersion) {
+          state.validationLoading = false;
+          notify();
+        }
+      }
+    };
+
+    if (delayMs <= 0) {
+      await run();
+      return;
+    }
+
+    validationDebounceTimer = setTimer(() => {
+      validationDebounceTimer = null;
+      void run();
+    }, delayMs);
+  }
+
+  function scheduleWorldPreview(delayMs = WORLD_PREVIEW_DEBOUNCE_MS): void {
+    if (!isWorldDocumentSelected()) {
+      clearWorldPreview();
+      notify();
+      return;
+    }
+
+    if (previewDebounceTimer != null) {
+      clearTimer(previewDebounceTimer);
+      previewDebounceTimer = null;
+    }
+
+    const parseState = getDraftParseState();
+    if (!parseState.valid) {
+      state.previewLoading = false;
+      state.worldPreview = null;
+      state.previewError = `JSON 语法无效：${parseState.detail}`;
+      notify();
+      return;
+    }
+
+    state.previewLoading = true;
+    state.previewError = "";
+    notify();
+
+    previewDebounceTimer = setTimer(() => {
+      previewDebounceTimer = null;
+      void loadWorldPreview();
+    }, delayMs);
+  }
+
+  async function loadDocument(id: ConfigDocumentId): Promise<void> {
+    state.loading = true;
+    state.statusTone = "neutral";
+    state.statusMessage = `正在加载 ${id} 配置...`;
+    notify();
+
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        document: ConfigDocument;
+      }>(`/api/config-center/configs/${id}`);
+      state.storageMode = response.storage;
+      state.current = response.document;
+      state.selectedId = response.document.id;
+      state.draft = response.document.content;
+      state.validation = null;
+      state.snapshots = [];
+      state.presets = [];
+      state.snapshotDiff = null;
+      state.selectedSnapshotId = null;
+      state.statusMessage = `${response.document.title} 已加载`;
+
+      if (response.document.id === "world") {
+        state.worldPreview = null;
+        state.previewLoading = true;
+        state.previewError = "";
+      } else {
+        clearWorldPreview();
+      }
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "加载配置失败";
+    } finally {
+      state.loading = false;
+      notify();
+
+      if (isWorldDocumentSelected()) {
+        void loadWorldPreview();
+      }
+      void loadValidation();
+      void loadSnapshots(id);
+      void loadPresets(id);
+    }
+  }
+
+  async function saveCurrentDocument(): Promise<void> {
+    if (!state.current || state.saving) {
+      return;
+    }
+
+    if (state.validation && !state.validation.valid) {
+      state.statusTone = "error";
+      state.statusMessage = "当前配置存在校验问题，已阻止保存";
+      notify();
+      return;
+    }
+
+    state.saving = true;
+    state.statusTone = "neutral";
+    state.statusMessage = `正在保存 ${state.current.title}...`;
+    notify();
+
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        document: ConfigDocument;
+      }>(`/api/config-center/configs/${state.current.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          content: state.draft
+        })
+      });
+
+      state.storageMode = response.storage;
+      state.current = response.document;
+      state.draft = response.document.content;
+      state.statusTone = "success";
+      state.statusMessage = `${response.document.title} 已保存，并同步刷新服务端运行时配置`;
+      await loadList();
+      await Promise.all([loadSnapshots(response.document.id), loadPresets(response.document.id)]);
+
+      if (response.document.id === "world") {
+        state.previewLoading = true;
+        state.previewError = "";
+      }
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "保存配置失败";
+    } finally {
+      state.saving = false;
+      notify();
+
+      if (isWorldDocumentSelected()) {
+        void loadWorldPreview();
+      }
+    }
+  }
+
+  function restoreCurrentDocument(): void {
+    if (!state.current) {
+      return;
+    }
+
+    state.draft = state.current.content;
+    state.statusTone = "neutral";
+    state.statusMessage = `${state.current.title} 已恢复到上次加载内容`;
+
+    if (isWorldDocumentSelected()) {
+      state.previewLoading = true;
+      state.previewError = "";
+    }
+
+    notify();
+
+    if (isWorldDocumentSelected()) {
+      void loadWorldPreview();
+    }
+    void loadValidation();
+  }
+
+  async function createSnapshot(): Promise<void> {
+    if (!state.current) {
+      return;
+    }
+
+    const label = promptImpl("快照名称（可选）", `${state.current.title} v${state.current.version ?? 1}`) ?? "";
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        snapshot: ConfigSnapshotSummary;
+      }>(`/api/config-center/configs/${state.current.id}/snapshots`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          content: state.draft,
+          label
+        })
+      });
+      state.storageMode = response.storage;
+      state.statusTone = "success";
+      state.statusMessage = `已保存快照 ${response.snapshot.label}`;
+      await loadSnapshots(state.current.id);
+      notify();
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "保存快照失败";
+      notify();
+    }
+  }
+
+  async function rollbackSnapshot(snapshotId: string): Promise<void> {
+    if (!state.current) {
+      return;
+    }
+
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        document: ConfigDocument;
+      }>(`/api/config-center/configs/${state.current.id}/rollback`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ snapshotId })
+      });
+      state.storageMode = response.storage;
+      state.current = response.document;
+      state.draft = response.document.content;
+      state.statusTone = "success";
+      state.statusMessage = `已回滚到快照 ${snapshotId}`;
+      await loadList();
+      await Promise.all([loadSnapshots(response.document.id), loadPresets(response.document.id)]);
+      notify();
+      if (isWorldDocumentSelected()) {
+        void loadWorldPreview();
+      }
+      void loadValidation();
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "回滚快照失败";
+      notify();
+    }
+  }
+
+  async function applyPreset(presetId: string): Promise<void> {
+    if (!state.current) {
+      return;
+    }
+
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        document: ConfigDocument;
+      }>(`/api/config-center/configs/${state.current.id}/presets/${presetId}/apply`, {
+        method: "POST"
+      });
+      state.storageMode = response.storage;
+      state.current = response.document;
+      state.draft = response.document.content;
+      state.statusTone = "success";
+      state.statusMessage = `已应用预设 ${presetId}，运行时配置已刷新`;
+      await loadList();
+      await Promise.all([loadSnapshots(response.document.id), loadPresets(response.document.id)]);
+      notify();
+      if (isWorldDocumentSelected()) {
+        void loadWorldPreview();
+      }
+      void loadValidation();
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "应用预设失败";
+      notify();
+    }
+  }
+
+  async function saveCurrentAsPreset(): Promise<void> {
+    if (!state.current) {
+      return;
+    }
+
+    const name = promptImpl("自定义预设名称", `${state.current.title} 自定义预设`);
+    if (!name) {
+      return;
+    }
+
+    try {
+      await requestJson<{
+        storage: "filesystem" | "mysql";
+        preset: ConfigPresetSummary;
+      }>(`/api/config-center/configs/${state.current.id}/presets`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          name,
+          content: state.draft
+        })
+      });
+      state.statusTone = "success";
+      state.statusMessage = `已保存自定义预设 ${name}`;
+      await loadPresets(state.current.id);
+      notify();
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "保存预设失败";
+      notify();
+    }
+  }
+
+  async function exportCurrentDocument(format: "xlsx" | "jsonc" | "csv"): Promise<void> {
+    if (!state.current) {
+      return;
+    }
+
+    try {
+      const download = await requestDownload(`/api/config-center/configs/${state.current.id}/export?format=${format}`);
+      downloadImpl({
+        ...download,
+        fallbackFileName: `${state.current.id}.${format}`
+      });
+      if (state.current) {
+        state.current.exportedAt = download.exportedAt ?? now();
+        const item = state.items.find((entry) => entry.id === state.current?.id);
+        if (item) {
+          item.exportedAt = state.current.exportedAt;
+        }
+      }
+      state.statusTone = "success";
+      state.statusMessage =
+        format === "xlsx" ? "已导出 Excel 工作簿" : format === "csv" ? "已导出字段清单 CSV" : "已导出 JSON 注释版";
+      notify();
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "导出失败";
+      notify();
+    }
+  }
+
+  async function importWorkbook(file: File): Promise<void> {
+    if (!state.current) {
+      return;
+    }
+
+    try {
+      const buffer = await file.arrayBuffer();
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        document: ConfigDocument;
+      }>(`/api/config-center/configs/${state.current.id}/import`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          workbookBase64: encodeBase64(buffer)
+        })
+      });
+      state.storageMode = response.storage;
+      state.current = response.document;
+      state.draft = response.document.content;
+      state.statusTone = "success";
+      state.statusMessage = `已从 ${file.name} 导入并覆盖当前配置`;
+      await loadList();
+      await Promise.all([loadSnapshots(response.document.id), loadPresets(response.document.id)]);
+      notify();
+      if (isWorldDocumentSelected()) {
+        void loadWorldPreview();
+      }
+      void loadValidation();
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "Excel 导入失败";
+      notify();
+    }
+  }
+
+  return {
+    state,
+    getDraftParseState,
+    normalizePreviewSeed,
+    setDraft,
+    clearWorldPreview,
+    loadList,
+    loadSnapshots,
+    loadPresets,
+    loadSnapshotDiff,
+    loadWorldPreview,
+    loadValidation,
+    scheduleWorldPreview,
+    loadDocument,
+    saveCurrentDocument,
+    restoreCurrentDocument,
+    createSnapshot,
+    rollbackSnapshot,
+    applyPreset,
+    saveCurrentAsPreset,
+    exportCurrentDocument,
+    importWorkbook,
+    parseDownloadFileName
+  };
+}
+
+export type {
+  AppState,
+  ConfigDiff,
+  ConfigDocument,
+  ConfigDocumentId,
+  ConfigDocumentSummary,
+  ConfigPresetSummary,
+  ConfigSchemaSummary,
+  ConfigSnapshotSummary,
+  DownloadPayload,
+  ValidationIssue,
+  ValidationReport,
+  WorldConfigPreview,
+  WorldConfigPreviewTile
+};

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -1,4 +1,5 @@
 import "./config-center.css";
+import { createConfigCenterController } from "./config-center-controller";
 
 type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
 type TerrainType = "grass" | "dirt" | "sand" | "water";
@@ -249,42 +250,42 @@ if (!appRoot) {
 
 const root = appRoot;
 
-const state: AppState = {
-  items: [],
-  current: null,
-  selectedId: null,
-  storageMode: null,
-  loading: true,
-  saving: false,
-  statusTone: "neutral",
-  statusMessage: "正在加载配置中心...",
-  draft: "",
-  previewSeed: 1001,
-  worldPreview: null,
-  previewLoading: false,
-  previewError: "",
-  validation: null,
-  validationLoading: false,
-  snapshots: [],
-  selectedSnapshotId: null,
-  snapshotDiff: null,
-  historyLoading: false,
-  presets: [],
-  presetsLoading: false
-};
+const controller = createConfigCenterController({
+  onStateChange: () => {
+    render();
+  },
+  prompt: (message, defaultValue) => window.prompt(message, defaultValue),
+  download: ({ blob, fileName, fallbackFileName }) => {
+    const href = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.download = fileName ?? fallbackFileName;
+    anchor.click();
+    URL.revokeObjectURL(href);
+  }
+});
 
-const EMPTY_SCHEMA_SUMMARY: ConfigSchemaSummary = {
-  id: "project-veil.config-center.unknown",
-  title: "Unknown Schema",
-  version: "0",
-  description: "Schema 信息暂不可用。",
-  required: []
-};
-
-let previewRequestVersion = 0;
-let previewDebounceTimer: number | null = null;
-let validationRequestVersion = 0;
-let validationDebounceTimer: number | null = null;
+const {
+  state,
+  getDraftParseState,
+  normalizePreviewSeed,
+  loadList,
+  loadSnapshots,
+  loadPresets,
+  loadSnapshotDiff,
+  loadWorldPreview,
+  loadValidation,
+  scheduleWorldPreview,
+  loadDocument,
+  saveCurrentDocument,
+  restoreCurrentDocument,
+  createSnapshot,
+  rollbackSnapshot,
+  applyPreset,
+  saveCurrentAsPreset,
+  exportCurrentDocument,
+  importWorkbook
+} = controller;
 
 function formatTime(value: string): string {
   const date = new Date(value);
@@ -301,20 +302,7 @@ function escapeHtml(value: string): string {
 }
 
 function currentParseState(): { valid: boolean; detail: string; rootKeys: number } {
-  try {
-    const parsed = JSON.parse(state.draft || "{}") as Record<string, unknown>;
-    return {
-      valid: true,
-      detail: "JSON 语法有效",
-      rootKeys: Object.keys(parsed).length
-    };
-  } catch (error) {
-    return {
-      valid: false,
-      detail: error instanceof Error ? error.message : "JSON 语法无效",
-      rootKeys: 0
-    };
-  }
+  return getDraftParseState();
 }
 
 function currentBattleSkillCatalogState(): {
@@ -370,16 +358,8 @@ function isBattleBalanceDocumentSelected(): boolean {
   return state.current?.id === "battleBalance";
 }
 
-function normalizePreviewSeed(value: number, fallback = state.previewSeed): number {
-  if (!Number.isFinite(value)) {
-    return fallback;
-  }
-
-  return Math.max(0, Math.floor(value));
-}
-
 function setDraftContent(nextDraft: string): void {
-  state.draft = nextDraft;
+  controller.setDraft(nextDraft);
   const textarea = document.querySelector<HTMLTextAreaElement>("[data-role='editor']");
   if (textarea && textarea.value !== nextDraft) {
     textarea.value = nextDraft;
@@ -530,577 +510,6 @@ async function requestDownload(input: RequestInfo, init?: RequestInit): Promise<
 
 function serializeDisplayValue(value: string): string {
   return value.length > 48 ? `${value.slice(0, 48)}...` : value || "空";
-}
-
-function clearWorldPreview(cancelPending = true): void {
-  if (cancelPending && previewDebounceTimer != null) {
-    window.clearTimeout(previewDebounceTimer);
-    previewDebounceTimer = null;
-  }
-
-  previewRequestVersion += 1;
-  state.worldPreview = null;
-  state.previewLoading = false;
-  state.previewError = "";
-}
-
-async function loadList(): Promise<void> {
-  const response = await requestJson<{
-    storage: "filesystem" | "mysql";
-    items: ConfigDocumentSummary[];
-  }>("/api/config-center/configs");
-  state.storageMode = response.storage;
-  state.items = response.items;
-}
-
-async function loadSnapshots(id: ConfigDocumentId): Promise<void> {
-  state.historyLoading = true;
-  refreshPreviewPane();
-  try {
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      snapshots: ConfigSnapshotSummary[];
-    }>(`/api/config-center/configs/${id}/snapshots`);
-    state.storageMode = response.storage;
-    state.snapshots = response.snapshots;
-    if (!state.snapshots.some((item) => item.id === state.selectedSnapshotId)) {
-      state.selectedSnapshotId = state.snapshots[0]?.id ?? null;
-      state.snapshotDiff = null;
-    }
-  } finally {
-    state.historyLoading = false;
-    refreshPreviewPane();
-  }
-
-  if (state.selectedSnapshotId) {
-    await loadSnapshotDiff();
-  }
-}
-
-async function loadPresets(id: ConfigDocumentId): Promise<void> {
-  state.presetsLoading = true;
-  refreshPreviewPane();
-  try {
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      presets: ConfigPresetSummary[];
-    }>(`/api/config-center/configs/${id}/presets`);
-    state.storageMode = response.storage;
-    state.presets = response.presets;
-  } finally {
-    state.presetsLoading = false;
-    refreshPreviewPane();
-  }
-}
-
-async function loadSnapshotDiff(): Promise<void> {
-  if (!state.current || !state.selectedSnapshotId) {
-    state.snapshotDiff = null;
-    refreshPreviewPane();
-    return;
-  }
-
-  const response = await requestJson<{
-    storage: "filesystem" | "mysql";
-    diff: ConfigDiff;
-  }>(`/api/config-center/configs/${state.current.id}/diff`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json"
-    },
-    body: JSON.stringify({
-      snapshotId: state.selectedSnapshotId
-    })
-  });
-  state.storageMode = response.storage;
-  state.snapshotDiff = response.diff;
-  refreshPreviewPane();
-}
-
-async function loadWorldPreview(): Promise<void> {
-  if (!isWorldDocumentSelected()) {
-    clearWorldPreview();
-    refreshPreviewPane();
-    return;
-  }
-
-  const parseState = currentParseState();
-  if (!parseState.valid) {
-    state.previewLoading = false;
-    state.worldPreview = null;
-    state.previewError = `JSON 语法无效：${parseState.detail}`;
-    refreshPreviewPane();
-    return;
-  }
-
-  const requestVersion = ++previewRequestVersion;
-
-  try {
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      preview: WorldConfigPreview;
-    }>("/api/config-center/configs/world/preview", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        content: state.draft,
-        seed: state.previewSeed
-      })
-    });
-
-    if (requestVersion !== previewRequestVersion || !isWorldDocumentSelected()) {
-      return;
-    }
-
-    state.storageMode = response.storage;
-    state.worldPreview = response.preview;
-    state.previewError = "";
-  } catch (error) {
-    if (requestVersion !== previewRequestVersion) {
-      return;
-    }
-
-    state.worldPreview = null;
-    state.previewError = error instanceof Error ? error.message : "地图预览生成失败";
-  } finally {
-    if (requestVersion === previewRequestVersion) {
-      state.previewLoading = false;
-      refreshPreviewPane();
-    }
-  }
-}
-
-async function loadValidation(delayMs = 0): Promise<void> {
-  if (!state.current) {
-    state.validation = null;
-    refreshPreviewPane();
-    return;
-  }
-
-  if (validationDebounceTimer != null) {
-    window.clearTimeout(validationDebounceTimer);
-    validationDebounceTimer = null;
-  }
-
-  const run = async () => {
-    const requestVersion = ++validationRequestVersion;
-    state.validationLoading = true;
-    refreshPreviewPane();
-
-    try {
-      const response = await requestJson<{
-        storage: "filesystem" | "mysql";
-        validation: ValidationReport;
-      }>(`/api/config-center/configs/${state.current?.id}/validate`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-          content: state.draft
-        })
-      });
-
-      if (requestVersion !== validationRequestVersion) {
-        return;
-      }
-
-      state.storageMode = response.storage;
-      state.validation = response.validation;
-    } catch (error) {
-      if (requestVersion !== validationRequestVersion) {
-        return;
-      }
-
-      state.validation = {
-        valid: false,
-        summary: error instanceof Error ? error.message : "校验失败",
-        issues: [
-          {
-            path: "$",
-            severity: "error",
-            message: error instanceof Error ? error.message : "校验失败",
-            suggestion: "检查 JSON 语法和字段格式后重试。"
-          }
-        ],
-        schema: state.validation?.schema ?? EMPTY_SCHEMA_SUMMARY
-      };
-    } finally {
-      if (requestVersion === validationRequestVersion) {
-        state.validationLoading = false;
-        refreshPreviewPane();
-      }
-    }
-  };
-
-  if (delayMs <= 0) {
-    await run();
-    return;
-  }
-
-  validationDebounceTimer = window.setTimeout(() => {
-    validationDebounceTimer = null;
-    void run();
-  }, delayMs);
-}
-
-function scheduleWorldPreview(delayMs = WORLD_PREVIEW_DEBOUNCE_MS): void {
-  if (!isWorldDocumentSelected()) {
-    clearWorldPreview();
-    refreshPreviewPane();
-    return;
-  }
-
-  if (previewDebounceTimer != null) {
-    window.clearTimeout(previewDebounceTimer);
-    previewDebounceTimer = null;
-  }
-
-  const parseState = currentParseState();
-  if (!parseState.valid) {
-    state.previewLoading = false;
-    state.worldPreview = null;
-    state.previewError = `JSON 语法无效：${parseState.detail}`;
-    refreshPreviewPane();
-    return;
-  }
-
-  state.previewLoading = true;
-  state.previewError = "";
-  refreshPreviewPane();
-
-  previewDebounceTimer = window.setTimeout(() => {
-    previewDebounceTimer = null;
-    void loadWorldPreview();
-  }, delayMs);
-}
-
-async function loadDocument(id: ConfigDocumentId): Promise<void> {
-  state.loading = true;
-  state.statusTone = "neutral";
-  state.statusMessage = `正在加载 ${id} 配置...`;
-  render();
-
-  try {
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      document: ConfigDocument;
-    }>(`/api/config-center/configs/${id}`);
-    state.storageMode = response.storage;
-    state.current = response.document;
-    state.selectedId = response.document.id;
-    state.draft = response.document.content;
-    state.validation = null;
-    state.snapshots = [];
-    state.presets = [];
-    state.snapshotDiff = null;
-    state.selectedSnapshotId = null;
-    state.statusMessage = `${response.document.title} 已加载`;
-
-    if (response.document.id === "world") {
-      state.worldPreview = null;
-      state.previewLoading = true;
-      state.previewError = "";
-    } else {
-      clearWorldPreview();
-    }
-  } catch (error) {
-    state.statusTone = "error";
-    state.statusMessage = error instanceof Error ? error.message : "加载配置失败";
-  } finally {
-    state.loading = false;
-    render();
-
-    if (isWorldDocumentSelected()) {
-      void loadWorldPreview();
-    }
-    void loadValidation();
-    void loadSnapshots(id);
-    void loadPresets(id);
-  }
-}
-
-async function saveCurrentDocument(): Promise<void> {
-  if (!state.current || state.saving) {
-    return;
-  }
-
-  if (state.validation && !state.validation.valid) {
-    state.statusTone = "error";
-    state.statusMessage = "当前配置存在校验问题，已阻止保存";
-    render();
-    return;
-  }
-
-  state.saving = true;
-  state.statusTone = "neutral";
-  state.statusMessage = `正在保存 ${state.current.title}...`;
-  render();
-
-  try {
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      document: ConfigDocument;
-    }>(`/api/config-center/configs/${state.current.id}`, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        content: state.draft
-      })
-    });
-
-    state.storageMode = response.storage;
-    state.current = response.document;
-    state.draft = response.document.content;
-    state.statusTone = "success";
-    state.statusMessage = `${response.document.title} 已保存，并同步刷新服务端运行时配置`;
-    await loadList();
-    await Promise.all([loadSnapshots(response.document.id), loadPresets(response.document.id)]);
-
-    if (response.document.id === "world") {
-      state.previewLoading = true;
-      state.previewError = "";
-    }
-  } catch (error) {
-    state.statusTone = "error";
-    state.statusMessage = error instanceof Error ? error.message : "保存配置失败";
-  } finally {
-    state.saving = false;
-    render();
-
-    if (isWorldDocumentSelected()) {
-      void loadWorldPreview();
-    }
-  }
-}
-
-function restoreCurrentDocument(): void {
-  if (!state.current) {
-    return;
-  }
-
-  state.draft = state.current.content;
-  state.statusTone = "neutral";
-  state.statusMessage = `${state.current.title} 已恢复到上次加载内容`;
-
-  if (isWorldDocumentSelected()) {
-    state.previewLoading = true;
-    state.previewError = "";
-  }
-
-  render();
-
-  if (isWorldDocumentSelected()) {
-    void loadWorldPreview();
-  }
-  void loadValidation();
-}
-
-async function createSnapshot(): Promise<void> {
-  if (!state.current) {
-    return;
-  }
-
-  const label = window.prompt("快照名称（可选）", `${state.current.title} v${state.current.version ?? 1}`) ?? "";
-  try {
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      snapshot: ConfigSnapshotSummary;
-    }>(`/api/config-center/configs/${state.current.id}/snapshots`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        content: state.draft,
-        label
-      })
-    });
-    state.storageMode = response.storage;
-    state.statusTone = "success";
-    state.statusMessage = `已保存快照 ${response.snapshot.label}`;
-    await loadSnapshots(state.current.id);
-    render();
-  } catch (error) {
-    state.statusTone = "error";
-    state.statusMessage = error instanceof Error ? error.message : "保存快照失败";
-    render();
-  }
-}
-
-async function rollbackSnapshot(snapshotId: string): Promise<void> {
-  if (!state.current) {
-    return;
-  }
-
-  try {
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      document: ConfigDocument;
-    }>(`/api/config-center/configs/${state.current.id}/rollback`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({ snapshotId })
-    });
-    state.storageMode = response.storage;
-    state.current = response.document;
-    state.draft = response.document.content;
-    state.statusTone = "success";
-    state.statusMessage = `已回滚到快照 ${snapshotId}`;
-    await loadList();
-    await Promise.all([loadSnapshots(response.document.id), loadPresets(response.document.id)]);
-    render();
-    if (isWorldDocumentSelected()) {
-      void loadWorldPreview();
-    }
-    void loadValidation();
-  } catch (error) {
-    state.statusTone = "error";
-    state.statusMessage = error instanceof Error ? error.message : "回滚快照失败";
-    render();
-  }
-}
-
-async function applyPreset(presetId: string): Promise<void> {
-  if (!state.current) {
-    return;
-  }
-
-  try {
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      document: ConfigDocument;
-    }>(`/api/config-center/configs/${state.current.id}/presets/${presetId}/apply`, {
-      method: "POST"
-    });
-    state.storageMode = response.storage;
-    state.current = response.document;
-    state.draft = response.document.content;
-    state.statusTone = "success";
-    state.statusMessage = `已应用预设 ${presetId}，运行时配置已刷新`;
-    await loadList();
-    await Promise.all([loadSnapshots(response.document.id), loadPresets(response.document.id)]);
-    render();
-    if (isWorldDocumentSelected()) {
-      void loadWorldPreview();
-    }
-    void loadValidation();
-  } catch (error) {
-    state.statusTone = "error";
-    state.statusMessage = error instanceof Error ? error.message : "应用预设失败";
-    render();
-  }
-}
-
-async function saveCurrentAsPreset(): Promise<void> {
-  if (!state.current) {
-    return;
-  }
-
-  const name = window.prompt("自定义预设名称", `${state.current.title} 自定义预设`);
-  if (!name) {
-    return;
-  }
-
-  try {
-    await requestJson<{
-      storage: "filesystem" | "mysql";
-      preset: ConfigPresetSummary;
-    }>(`/api/config-center/configs/${state.current.id}/presets`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        name,
-        content: state.draft
-      })
-    });
-    state.statusTone = "success";
-    state.statusMessage = `已保存自定义预设 ${name}`;
-    await loadPresets(state.current.id);
-    render();
-  } catch (error) {
-    state.statusTone = "error";
-    state.statusMessage = error instanceof Error ? error.message : "保存预设失败";
-    render();
-  }
-}
-
-async function exportCurrentDocument(format: "xlsx" | "jsonc" | "csv"): Promise<void> {
-  if (!state.current) {
-    return;
-  }
-
-  try {
-    const download = await requestDownload(`/api/config-center/configs/${state.current.id}/export?format=${format}`);
-    const href = URL.createObjectURL(download.blob);
-    const anchor = document.createElement("a");
-    anchor.href = href;
-    anchor.download = download.fileName ?? `${state.current.id}.${format}`;
-    anchor.click();
-    URL.revokeObjectURL(href);
-    if (state.current) {
-      state.current.exportedAt = download.exportedAt ?? new Date().toISOString();
-      const item = state.items.find((entry) => entry.id === state.current?.id);
-      if (item) {
-        item.exportedAt = state.current.exportedAt;
-      }
-    }
-    state.statusTone = "success";
-    state.statusMessage =
-      format === "xlsx" ? "已导出 Excel 工作簿" : format === "csv" ? "已导出字段清单 CSV" : "已导出 JSON 注释版";
-    render();
-  } catch (error) {
-    state.statusTone = "error";
-    state.statusMessage = error instanceof Error ? error.message : "导出失败";
-    render();
-  }
-}
-
-async function importWorkbook(file: File): Promise<void> {
-  if (!state.current) {
-    return;
-  }
-
-  try {
-    const buffer = await file.arrayBuffer();
-    const base64 = btoa(String.fromCharCode(...new Uint8Array(buffer)));
-    const response = await requestJson<{
-      storage: "filesystem" | "mysql";
-      document: ConfigDocument;
-    }>(`/api/config-center/configs/${state.current.id}/import`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify({
-        workbookBase64: base64
-      })
-    });
-    state.storageMode = response.storage;
-    state.current = response.document;
-    state.draft = response.document.content;
-    state.statusTone = "success";
-    state.statusMessage = `已从 ${file.name} 导入并覆盖当前配置`;
-    await loadList();
-    await Promise.all([loadSnapshots(response.document.id), loadPresets(response.document.id)]);
-    render();
-    if (isWorldDocumentSelected()) {
-      void loadWorldPreview();
-    }
-    void loadValidation();
-  } catch (error) {
-    state.statusTone = "error";
-    state.statusMessage = error instanceof Error ? error.message : "Excel 导入失败";
-    render();
-  }
 }
 
 function jumpToValidationIssue(line?: number): void {

--- a/apps/client/test/config-center.test.ts
+++ b/apps/client/test/config-center.test.ts
@@ -1,0 +1,634 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createConfigCenterController } from "../src/config-center-controller";
+
+type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
+
+interface RequestRecord {
+  url: string;
+  method: string;
+  body: string | null;
+}
+
+function createDocument(id: ConfigDocumentId, content: string, overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id,
+    title: overrides.title ?? `${id} title`,
+    description: overrides.description ?? `${id} description`,
+    fileName: overrides.fileName ?? `${id}.json`,
+    updatedAt: overrides.updatedAt ?? "2026-03-29T06:00:00.000Z",
+    summary: overrides.summary ?? `${id} summary`,
+    content,
+    ...(overrides.version != null ? { version: overrides.version } : {})
+  };
+}
+
+function createValidationReport(valid = true) {
+  return {
+    valid,
+    summary: valid ? "Schema 校验通过" : "发现字段错误",
+    issues: valid
+      ? []
+      : [
+          {
+            path: "$.width",
+            severity: "error" as const,
+            message: "width must be >= 1",
+            suggestion: "修正地图宽度后重试。",
+            line: 2
+          }
+        ],
+    schema: {
+      id: "project-veil.config-center.world",
+      title: "World Schema",
+      version: "1",
+      description: "World config schema",
+      required: ["width", "height"]
+    }
+  };
+}
+
+function createWorldPreview() {
+  return {
+    seed: 1001,
+    roomId: "preview-room",
+    width: 8,
+    height: 8,
+    counts: {
+      walkable: 50,
+      blocked: 14,
+      terrain: {
+        grass: 30,
+        dirt: 12,
+        sand: 10,
+        water: 12
+      },
+      resourceTiles: {
+        gold: 3,
+        wood: 2,
+        ore: 1
+      },
+      resourceAmounts: {
+        gold: 600,
+        wood: 10,
+        ore: 5
+      },
+      guaranteedResources: 3,
+      randomResources: 3,
+      heroes: 2,
+      neutralArmies: 4,
+      buildings: 3
+    },
+    tiles: [
+      {
+        position: { x: 0, y: 0 },
+        terrain: "grass" as const,
+        walkable: true
+      }
+    ]
+  };
+}
+
+function createFetchStub(
+  handler: (request: RequestRecord) => Response | Promise<Response>
+): { fetch: typeof fetch; requests: RequestRecord[] } {
+  const requests: RequestRecord[] = [];
+
+  const fetch = (async (input, init) => {
+    const request = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: typeof init?.body === "string" ? init.body : init?.body ? String(init.body) : null
+    };
+    requests.push(request);
+    return handler(request);
+  }) as typeof globalThis.fetch;
+
+  return {
+    fetch,
+    requests
+  };
+}
+
+test("config center validation surfaces legal JSON success and blocks invalid JSON with a repair hint", async () => {
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url.endsWith("/validate")) {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          validation: createValidationReport(true)
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n");
+  controller.setDraft("{\n  \"width\": 8\n}\n");
+
+  assert.deepEqual(controller.getDraftParseState(), {
+    valid: true,
+    detail: "JSON 语法有效",
+    rootKeys: 1
+  });
+
+  await controller.loadValidation();
+
+  assert.equal(controller.state.validation?.valid, true);
+  assert.equal(requests[0]?.url, "/api/config-center/configs/world/validate");
+  assert.deepEqual(JSON.parse(requests[0]?.body ?? "{}"), {
+    content: "{\n  \"width\": 8\n}\n"
+  });
+
+  controller.setDraft("{\n  \"width\": \n}\n");
+  assert.equal(controller.getDraftParseState().valid, false);
+  assert.match(controller.getDraftParseState().detail, /JSON|Unexpected/);
+
+  const failingFetch = createFetchStub(() =>
+    new Response(JSON.stringify({ error: { message: "invalid json payload" } }), {
+      status: 400,
+      headers: {
+        "Content-Type": "application/json"
+      }
+    })
+  );
+  const failingController = createConfigCenterController({ fetch: failingFetch.fetch });
+  failingController.state.current = createDocument("world", "{\n  \"width\": \n}\n");
+  failingController.setDraft("{\n  \"width\": \n}\n");
+
+  await failingController.loadValidation();
+
+  assert.equal(failingController.state.validation?.valid, false);
+  assert.equal(failingController.state.validation?.issues[0]?.suggestion, "检查 JSON 语法和字段格式后重试。");
+  assert.equal(failingController.state.validation?.summary, "invalid json payload");
+});
+
+test("config center save flow calls the config API with the edited draft body", async () => {
+  const savedDocument = createDocument("mapObjects", "{\n  \"neutralArmies\": []\n}\n", { version: 3 });
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/mapObjects" && request.method === "PUT") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          document: savedDocument
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs") {
+      return new Response(JSON.stringify({ storage: "filesystem", items: [savedDocument] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/mapObjects/snapshots") {
+      return new Response(JSON.stringify({ storage: "filesystem", snapshots: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/mapObjects/presets") {
+      return new Response(JSON.stringify({ storage: "filesystem", presets: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("mapObjects", "{\n  \"neutralArmies\": [1]\n}\n", { version: 2 });
+  controller.state.validation = createValidationReport(true);
+  controller.setDraft("{\n  \"neutralArmies\": []\n}\n");
+
+  await controller.saveCurrentDocument();
+
+  const saveRequest = requests.find((request) => request.url === "/api/config-center/configs/mapObjects" && request.method === "PUT");
+  assert.ok(saveRequest);
+  assert.deepEqual(JSON.parse(saveRequest.body ?? "{}"), {
+    content: "{\n  \"neutralArmies\": []\n}\n"
+  });
+  assert.equal(controller.state.current?.content, "{\n  \"neutralArmies\": []\n}\n");
+  assert.equal(controller.state.statusTone, "success");
+});
+
+test("config center snapshot diff exposes non-empty changes for an edited field", async () => {
+  const { fetch } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/diff" && request.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          diff: {
+            entries: [
+              {
+                path: "$.width",
+                change: "updated",
+                previousValue: "8",
+                nextValue: "10"
+              }
+            ]
+          }
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 10\n}\n");
+  controller.state.selectedSnapshotId = "snapshot-1";
+
+  await controller.loadSnapshotDiff();
+
+  assert.equal(controller.state.snapshotDiff?.entries.length, 1);
+  assert.deepEqual(controller.state.snapshotDiff?.entries[0], {
+    path: "$.width",
+    change: "updated",
+    previousValue: "8",
+    nextValue: "10"
+  });
+});
+
+test("config center rollback restores the previous snapshot content", async () => {
+  const rolledBackDocument = createDocument("world", "{\n  \"width\": 8,\n  \"height\": 8\n}\n", { version: 2 });
+  const { fetch } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/rollback" && request.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          document: rolledBackDocument
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs") {
+      return new Response(JSON.stringify({ storage: "filesystem", items: [rolledBackDocument] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots") {
+      return new Response(JSON.stringify({ storage: "filesystem", snapshots: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/presets") {
+      return new Response(JSON.stringify({ storage: "filesystem", presets: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/validate") {
+      return new Response(JSON.stringify({ storage: "filesystem", validation: createValidationReport(true) }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/preview" && request.method === "POST") {
+      return new Response(JSON.stringify({ storage: "filesystem", preview: createWorldPreview() }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 10,\n  \"height\": 8\n}\n", { version: 3 });
+  controller.setDraft("{\n  \"width\": 10,\n  \"height\": 8\n}\n");
+
+  await controller.rollbackSnapshot("snapshot-1");
+
+  assert.equal(controller.state.current?.content, "{\n  \"width\": 8,\n  \"height\": 8\n}\n");
+  assert.equal(controller.state.draft, "{\n  \"width\": 8,\n  \"height\": 8\n}\n");
+  assert.equal(controller.state.statusTone, "success");
+});
+
+test("config center builtin presets apply the expected field changes", async () => {
+  const baseDocument = createDocument(
+    "battleBalance",
+    JSON.stringify(
+      {
+        damage: {
+          defendingDefenseBonus: 5,
+          offenseAdvantageStep: 0.05,
+          minimumOffenseMultiplier: 0.3,
+          varianceBase: 0.9,
+          varianceRange: 0.2
+        },
+        environment: {
+          blockerSpawnThreshold: 0.62,
+          blockerDurability: 1,
+          trapSpawnThreshold: 0.58,
+          trapDamage: 1,
+          trapCharges: 1
+        },
+        pvp: {
+          eloK: 32
+        }
+      },
+      null,
+      2
+    ) + "\n"
+  );
+
+  const presets = new Map([
+    [
+      "easy",
+      createDocument(
+        "battleBalance",
+        JSON.stringify(
+          {
+            damage: {
+              defendingDefenseBonus: 4,
+              offenseAdvantageStep: 0.05,
+              minimumOffenseMultiplier: 0.3,
+              varianceBase: 0.9,
+              varianceRange: 0.2
+            },
+            environment: {
+              blockerSpawnThreshold: 0.7,
+              blockerDurability: 1,
+              trapSpawnThreshold: 0.65,
+              trapDamage: 1,
+              trapCharges: 1
+            },
+            pvp: {
+              eloK: 24
+            }
+          },
+          null,
+          2
+        ) + "\n"
+      )
+    ],
+    [
+      "normal",
+      createDocument(
+        "battleBalance",
+        JSON.stringify(
+          {
+            damage: {
+              defendingDefenseBonus: 5,
+              offenseAdvantageStep: 0.05,
+              minimumOffenseMultiplier: 0.3,
+              varianceBase: 0.9,
+              varianceRange: 0.2
+            },
+            environment: {
+              blockerSpawnThreshold: 0.62,
+              blockerDurability: 1,
+              trapSpawnThreshold: 0.58,
+              trapDamage: 1,
+              trapCharges: 1
+            },
+            pvp: {
+              eloK: 32
+            }
+          },
+          null,
+          2
+        ) + "\n"
+      )
+    ],
+    [
+      "hard",
+      createDocument(
+        "battleBalance",
+        JSON.stringify(
+          {
+            damage: {
+              defendingDefenseBonus: 6,
+              offenseAdvantageStep: 0.05,
+              minimumOffenseMultiplier: 0.3,
+              varianceBase: 0.9,
+              varianceRange: 0.2
+            },
+            environment: {
+              blockerSpawnThreshold: 0.55,
+              blockerDurability: 1,
+              trapSpawnThreshold: 0.5,
+              trapDamage: 2,
+              trapCharges: 2
+            },
+            pvp: {
+              eloK: 40
+            }
+          },
+          null,
+          2
+        ) + "\n"
+      )
+    ]
+  ]);
+
+  const { fetch } = createFetchStub((request) => {
+    const presetId = request.url.match(/\/presets\/([^/]+)\/apply$/)?.[1];
+    if (presetId && request.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          document: presets.get(presetId)
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs") {
+      return new Response(JSON.stringify({ storage: "filesystem", items: [baseDocument] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/battleBalance/snapshots") {
+      return new Response(JSON.stringify({ storage: "filesystem", snapshots: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/battleBalance/presets") {
+      return new Response(JSON.stringify({ storage: "filesystem", presets: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/battleBalance/validate") {
+      return new Response(JSON.stringify({ storage: "filesystem", validation: createValidationReport(true) }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = baseDocument;
+
+  await controller.applyPreset("easy");
+  assert.equal(JSON.parse(controller.state.current?.content ?? "{}").pvp.eloK, 24);
+
+  await controller.applyPreset("normal");
+  assert.equal(JSON.parse(controller.state.current?.content ?? "{}").pvp.eloK, 32);
+
+  await controller.applyPreset("hard");
+  const hardConfig = JSON.parse(controller.state.current?.content ?? "{}");
+  assert.equal(hardConfig.pvp.eloK, 40);
+  assert.equal(hardConfig.environment.trapDamage, 2);
+});
+
+test("config center world preview posts the current phase1-world draft and stores the generated sample", async () => {
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/preview" && request.method === "POST") {
+      return new Response(JSON.stringify({ storage: "filesystem", preview: createWorldPreview() }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const draft = "{\n  \"width\": 8,\n  \"height\": 8,\n  \"heroes\": []\n}\n";
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", draft, { fileName: "phase1-world.json" });
+  controller.setDraft(draft);
+
+  await controller.loadWorldPreview();
+
+  const previewRequest = requests[0];
+  assert.equal(previewRequest?.url, "/api/config-center/configs/world/preview");
+  assert.deepEqual(JSON.parse(previewRequest?.body ?? "{}"), {
+    content: draft,
+    seed: 1001
+  });
+  assert.equal(controller.state.worldPreview?.width, 8);
+  assert.equal(controller.state.worldPreview?.counts.heroes, 2);
+});
+
+test("config center export flow preserves the server MIME type for Excel and CSV downloads", async () => {
+  const downloads: Array<{ fileName: string | null; fallbackFileName: string; type: string }> = [];
+  const { fetch } = createFetchStub((request) => {
+    if (request.url.endsWith("format=xlsx")) {
+      return new Response(new Blob(["xlsx"], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), {
+        status: 200,
+        headers: {
+          "Content-Disposition": "attachment; filename*=UTF-8''phase1-world.xlsx",
+          "X-Config-Exported-At": "2026-03-29T06:30:00.000Z"
+        }
+      });
+    }
+
+    if (request.url.endsWith("format=csv")) {
+      return new Response(new Blob(["csv"], { type: "text/csv" }), {
+        status: 200,
+        headers: {
+          "Content-Disposition": "attachment; filename=\"phase1-world-fields.csv\"",
+          "X-Config-Exported-At": "2026-03-29T06:31:00.000Z"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({
+    fetch,
+    download: ({ blob, fileName, fallbackFileName }) => {
+      downloads.push({
+        fileName,
+        fallbackFileName,
+        type: blob.type
+      });
+    }
+  });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n", { exportedAt: null });
+  controller.state.items = [createDocument("world", "{\n  \"width\": 8\n}\n", { exportedAt: null })];
+
+  await controller.exportCurrentDocument("xlsx");
+  await controller.exportCurrentDocument("csv");
+
+  assert.deepEqual(downloads, [
+    {
+      fileName: "phase1-world.xlsx",
+      fallbackFileName: "world.xlsx",
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    },
+    {
+      fileName: "phase1-world-fields.csv",
+      fallbackFileName: "world.csv",
+      type: "text/csv"
+    }
+  ]);
+  assert.equal(controller.state.current?.exportedAt, "2026-03-29T06:31:00.000Z");
+});


### PR DESCRIPTION
## Summary
- extract the H5 config-center state machine into a testable controller module
- add node:test coverage for validation, save, diff, rollback, preset, preview, and export flows
- keep the browser entrypoint focused on rendering/binding while reusing the tested controller

## Validation
- `node --import tsx --test apps/client/test/config-center.test.ts`
- `node --import tsx --test "apps/client/test/**/*.test.ts"`
- `npm run typecheck:client:h5`
- `npm test` *(currently fails in unrelated Cocos tests with `Cannot find module "cc"` in `apps/cocos-client/test/cocos-root-orchestration.test.ts` and `apps/cocos-client/test/cocos-session-orchestration.test.ts`)*

Closes #235