### PR TITLE
test(cocos): add component coverage for map board, battle panel, and lobby panel

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -66,6 +66,15 @@ export interface BattlePanelViewModel {
   idle: boolean;
 }
 
+export interface BattlePanelSections {
+  stage: BattlePanelStageView | null;
+  orderItems: BattlePanelOrderItem[];
+  friendlyItems: BattlePanelFriendlyItem[];
+  enemyTargets: BattlePanelUnitView[];
+  actions: BattlePanelActionView[];
+  idle: boolean;
+}
+
 export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelViewModel {
   const battle = state.update?.battle;
   if (!battle) {
@@ -173,6 +182,18 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
     enemyTargets,
     actions,
     idle: false
+  };
+}
+
+export function buildBattlePanelSections(state: BattlePanelInput): BattlePanelSections {
+  const model = buildBattlePanelViewModel(state);
+  return {
+    stage: model.stage,
+    orderItems: model.orderItems,
+    friendlyItems: model.friendlyItems,
+    enemyTargets: model.enemyTargets,
+    actions: model.actions,
+    idle: model.idle
   };
 }
 

--- a/apps/cocos-client/assets/scripts/cocos-lobby-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby-panel-model.ts
@@ -1,0 +1,95 @@
+import type { CocosLobbyRoomSummary, CocosPlayerAccountProfile } from "./cocos-lobby.ts";
+import type { VeilLobbyRenderState } from "./VeilLobbyPanel.ts";
+import {
+  getLobbyShowcaseUnitPageCount,
+  lobbyBuildingShowcaseEntries,
+  lobbyHeroShowcaseEntries,
+  lobbyShowcaseUnitEntries,
+  lobbyTerrainShowcaseEntries
+} from "./cocos-showcase-gallery.ts";
+
+const DEFAULT_LOBBY_ROOM_ID = "room-alpha";
+
+export interface LobbyRoomCardView {
+  roomId: string;
+  title: string;
+  meta: string;
+}
+
+export interface LobbyGuestEntryView {
+  displayName: string;
+  roomId: string;
+}
+
+export interface LobbyAccountIdentityView {
+  showLoginId: boolean;
+  loginIdValue: string;
+  credentialBound: boolean;
+}
+
+export interface LobbyShowcaseInventorySummary {
+  heroes: number;
+  terrain: number;
+  buildings: number;
+  units: number;
+  rotatingUnitPages: number;
+}
+
+export function buildLobbyRoomCards(rooms: CocosLobbyRoomSummary[]): LobbyRoomCardView[] {
+  return rooms.slice(0, 4).map((room) => ({
+    roomId: room.roomId,
+    title: room.roomId,
+    meta: `Day ${room.day} · Seed ${room.seed} · 玩家 ${room.connectedPlayers} · 英雄 ${room.heroCount} · 战斗 ${room.activeBattles}`
+  }));
+}
+
+export function buildLobbyGuestEntryView(
+  state: Pick<VeilLobbyRenderState, "playerId" | "displayName" | "roomId" | "account">
+): LobbyGuestEntryView {
+  return {
+    displayName: state.displayName.trim() || state.account.displayName || state.playerId,
+    roomId: state.roomId.trim() || state.account.lastRoomId || DEFAULT_LOBBY_ROOM_ID
+  };
+}
+
+export function buildLobbyAccountIdentityView(
+  state: Pick<VeilLobbyRenderState, "authMode" | "loginId" | "account">
+): LobbyAccountIdentityView {
+  const loginIdValue = state.loginId.trim() || state.account.loginId || "";
+  const credentialBound = Boolean(state.account.credentialBoundAt);
+  return {
+    showLoginId: state.authMode === "account" && credentialBound,
+    loginIdValue,
+    credentialBound
+  };
+}
+
+export function summarizeLobbyShowcaseInventory(): LobbyShowcaseInventorySummary {
+  return {
+    heroes: lobbyHeroShowcaseEntries.length,
+    terrain: lobbyTerrainShowcaseEntries.length,
+    buildings: lobbyBuildingShowcaseEntries.length,
+    units: lobbyShowcaseUnitEntries.length,
+    rotatingUnitPages: getLobbyShowcaseUnitPageCount()
+  };
+}
+
+export function createLobbyPanelTestAccount(
+  overrides: Partial<CocosPlayerAccountProfile> = {}
+): CocosPlayerAccountProfile {
+  return {
+    playerId: overrides.playerId ?? "guest-1001",
+    displayName: overrides.displayName ?? "雾行者",
+    eloRating: overrides.eloRating ?? 1000,
+    globalResources: overrides.globalResources ?? { gold: 0, wood: 0, ore: 0 },
+    achievements: overrides.achievements ?? [],
+    recentEventLog: overrides.recentEventLog ?? [],
+    recentBattleReplays: overrides.recentBattleReplays ?? [],
+    source: overrides.source ?? "local",
+    ...(overrides.avatarUrl ? { avatarUrl: overrides.avatarUrl } : {}),
+    ...(overrides.loginId ? { loginId: overrides.loginId } : {}),
+    ...(overrides.credentialBoundAt ? { credentialBoundAt: overrides.credentialBoundAt } : {}),
+    ...(overrides.lastRoomId ? { lastRoomId: overrides.lastRoomId } : {}),
+    ...(overrides.lastSeenAt ? { lastSeenAt: overrides.lastSeenAt } : {})
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-map-board-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-map-board-model.ts
@@ -1,0 +1,138 @@
+import type { PlayerTileView, SessionUpdate, Vec2 } from "./VeilCocosSession.ts";
+import { resolveCocosTileMarkerVisual, type CocosTileMarkerVisual } from "./cocos-object-visuals.ts";
+
+export interface MapBoardTileViewModel {
+  key: string;
+  tile: PlayerTileView | null;
+  fog: PlayerTileView["fog"] | "hidden";
+  reachable: boolean;
+  heroTile: boolean;
+  interactable: boolean;
+  objectMarker: CocosTileMarkerVisual | null;
+}
+
+export interface MapBoardKeyboardCursorMove {
+  previous: Vec2 | null;
+  current: Vec2;
+  clearedKey: string | null;
+  highlightedKey: string;
+}
+
+export type MapBoardKeyboardDirection = "up" | "right" | "down" | "left";
+
+export function mapBoardTileKey(position: Vec2): string {
+  return `${position.x}-${position.y}`;
+}
+
+export function buildTileViewModel(
+  update: SessionUpdate,
+  position: Vec2,
+  heroId?: string
+): MapBoardTileViewModel {
+  const tile = update.world.map.tiles.find((entry) => entry.position.x === position.x && entry.position.y === position.y) ?? null;
+  const activeHero = update.world.ownHeroes.find((hero) => hero.id === heroId) ?? update.world.ownHeroes[0] ?? null;
+  const reachable = (update.reachableTiles ?? []).some((entry) => entry.x === position.x && entry.y === position.y);
+  const heroTile = Boolean(activeHero && activeHero.position.x === position.x && activeHero.position.y === position.y);
+
+  return {
+    key: mapBoardTileKey(position),
+    tile,
+    fog: tile?.fog ?? "hidden",
+    reachable,
+    heroTile,
+    interactable: tile !== null,
+    objectMarker: tile ? resolveMapBoardObjectMarker(tile) : null
+  };
+}
+
+export function resolveMapBoardObjectMarker(tile: PlayerTileView | null): CocosTileMarkerVisual | null {
+  return resolveCocosTileMarkerVisual(tile);
+}
+
+export function moveMapBoardKeyboardCursor(
+  previous: Vec2 | null,
+  direction: MapBoardKeyboardDirection,
+  bounds: { width: number; height: number }
+): MapBoardKeyboardCursorMove {
+  const current = previous ? { ...previous } : { x: 0, y: 0 };
+  if (direction === "up") {
+    current.y = Math.max(0, current.y - 1);
+  } else if (direction === "right") {
+    current.x = Math.min(bounds.width - 1, current.x + 1);
+  } else if (direction === "down") {
+    current.y = Math.min(bounds.height - 1, current.y + 1);
+  } else {
+    current.x = Math.max(0, current.x - 1);
+  }
+
+  return {
+    previous,
+    current,
+    clearedKey: previous ? mapBoardTileKey(previous) : null,
+    highlightedKey: mapBoardTileKey(current)
+  };
+}
+
+export function resolveMapBoardFeedbackLabel(
+  event: SessionUpdate["events"][number],
+  options: {
+    heroId?: string;
+  } = {}
+): string | null {
+  if (event.type === "hero.moved") {
+    return `MOVE ${event.moveCost}`;
+  }
+
+  if (event.type === "hero.collected") {
+    return `+${event.resource.kind.toUpperCase()}`;
+  }
+
+  if (event.type === "hero.recruited") {
+    return `+${event.count}`;
+  }
+
+  if (event.type === "hero.visited") {
+    return event.bonus.attack > 0
+      ? "+ATK"
+      : event.bonus.defense > 0
+        ? "+DEF"
+        : event.bonus.power > 0
+          ? "+POW"
+          : event.bonus.knowledge > 0
+            ? "+KNW"
+            : "+STAT";
+  }
+
+  if (event.type === "hero.claimedMine") {
+    return `+${event.resourceKind.toUpperCase()}`;
+  }
+
+  if (event.type === "resource.produced") {
+    return `+${event.resource.kind.toUpperCase()}`;
+  }
+
+  if (event.type === "neutral.moved") {
+    return event.reason === "chase" ? "CHASE" : event.reason === "return" ? "GUARD" : "PATROL";
+  }
+
+  if (event.type === "hero.progressed") {
+    return event.levelsGained > 0 ? `LV ${event.level}` : `XP +${event.experienceGained}`;
+  }
+
+  if (event.type === "battle.started") {
+    return event.encounterKind === "hero" ? "PVP" : "PVE";
+  }
+
+  if (event.type === "battle.resolved" && options.heroId) {
+    return didHeroWin(event, options.heroId) ? "VICTORY" : "DEFEAT";
+  }
+
+  return null;
+}
+
+function didHeroWin(event: Extract<SessionUpdate["events"][number], { type: "battle.resolved" }>, heroId: string): boolean {
+  if (event.result === "attacker_victory") {
+    return event.heroId === heroId;
+  }
+  return event.defenderHeroId === heroId;
+}

--- a/apps/cocos-client/assets/scripts/cocos-map-visuals.ts
+++ b/apps/cocos-client/assets/scripts/cocos-map-visuals.ts
@@ -1,4 +1,5 @@
 import type { PlayerTileView, SessionUpdate, Vec2 } from "./VeilCocosSession.ts";
+import { resolveMapBoardFeedbackLabel } from "./cocos-map-board-model.ts";
 
 const NORTH_BIT = 1;
 const EAST_BIT = 2;
@@ -152,7 +153,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
     if (event.type === "hero.moved" && event.path.length > 0) {
       entries.push({
         position: event.path[event.path.length - 1]!,
-        text: `MOVE ${event.moveCost}`,
+        text: resolveMapBoardFeedbackLabel(event) ?? `MOVE ${event.moveCost}`,
         durationSeconds: 0.7
       });
       continue;
@@ -161,7 +162,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
     if (event.type === "hero.collected" && heroPosition) {
       entries.push({
         position: heroPosition,
-        text: `+${event.resource.kind.toUpperCase()}`,
+        text: resolveMapBoardFeedbackLabel(event) ?? `+${event.resource.kind.toUpperCase()}`,
         durationSeconds: 0.85
       });
       continue;
@@ -170,7 +171,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
     if (event.type === "hero.recruited" && heroPosition) {
       entries.push({
         position: heroPosition,
-        text: `+${event.count}`,
+        text: resolveMapBoardFeedbackLabel(event) ?? `+${event.count}`,
         durationSeconds: 0.9
       });
       continue;
@@ -189,7 +190,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
                 : "STAT";
       entries.push({
         position: heroPosition,
-        text: `+${firstBonus}`,
+        text: resolveMapBoardFeedbackLabel(event) ?? `+${firstBonus}`,
         durationSeconds: 0.92
       });
       continue;
@@ -200,7 +201,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
       if (buildingPosition) {
         entries.push({
           position: buildingPosition,
-          text: `+${event.resourceKind.toUpperCase()}`,
+          text: resolveMapBoardFeedbackLabel(event) ?? `+${event.resourceKind.toUpperCase()}`,
           durationSeconds: 0.94
         });
       }
@@ -212,7 +213,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
       if (buildingPosition) {
         entries.push({
           position: buildingPosition,
-          text: `+${event.resource.kind.toUpperCase()}`,
+          text: resolveMapBoardFeedbackLabel(event) ?? `+${event.resource.kind.toUpperCase()}`,
           durationSeconds: 0.9
         });
       }
@@ -222,7 +223,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
     if (event.type === "neutral.moved") {
       entries.push({
         position: event.to,
-        text: event.reason === "chase" ? "CHASE" : event.reason === "return" ? "GUARD" : "PATROL",
+        text: resolveMapBoardFeedbackLabel(event) ?? (event.reason === "chase" ? "CHASE" : event.reason === "return" ? "GUARD" : "PATROL"),
         durationSeconds: 0.88
       });
       continue;
@@ -231,7 +232,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
     if (event.type === "hero.progressed" && heroPosition) {
       entries.push({
         position: heroPosition,
-        text: event.levelsGained > 0 ? `LV ${event.level}` : `XP +${event.experienceGained}`,
+        text: resolveMapBoardFeedbackLabel(event) ?? (event.levelsGained > 0 ? `LV ${event.level}` : `XP +${event.experienceGained}`),
         durationSeconds: 1
       });
       continue;
@@ -242,7 +243,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
       if (position) {
         entries.push({
           position,
-          text: event.encounterKind === "hero" ? "PVP" : "PVE",
+          text: resolveMapBoardFeedbackLabel(event) ?? (event.encounterKind === "hero" ? "PVP" : "PVE"),
           durationSeconds: 0.95
         });
       }
@@ -252,7 +253,7 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
     if (event.type === "battle.resolved" && heroPosition && heroId) {
       entries.push({
         position: heroPosition,
-        text: didHeroWin(event, heroId) ? "VICTORY" : "DEFEAT",
+        text: resolveMapBoardFeedbackLabel(event, { heroId }) ?? (didHeroWin(event, heroId) ? "VICTORY" : "DEFEAT"),
         durationSeconds: 1.1
       });
     }

--- a/apps/cocos-client/test/cocos-battle-panel.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildBattlePanelSections } from "../assets/scripts/cocos-battle-panel-model";
+import { resolveBattlePanelUnitVisual } from "../assets/scripts/cocos-battle-unit-visuals";
+import type { SessionUpdate, TerrainType } from "../assets/scripts/VeilCocosSession";
+
+function createTile(position: { x: number; y: number }, terrain: TerrainType = "grass") {
+  return {
+    position,
+    fog: "visible" as const,
+    terrain,
+    walkable: true,
+    resource: undefined,
+    occupant: undefined,
+    building: undefined
+  };
+}
+
+function createBattleUpdate(): SessionUpdate {
+  return {
+    world: {
+      meta: {
+        roomId: "room-alpha",
+        seed: 1001,
+        day: 1
+      },
+      map: {
+        width: 2,
+        height: 2,
+        tiles: [createTile({ x: 0, y: 0 }, "grass"), createTile({ x: 1, y: 1 }, "sand")]
+      },
+      ownHeroes: [
+        {
+          id: "hero-1",
+          playerId: "player-1",
+          name: "Katherine",
+          position: { x: 1, y: 1 },
+          vision: 4,
+          move: { total: 6, remaining: 6 },
+          stats: {
+            attack: 2,
+            defense: 2,
+            power: 1,
+            knowledge: 1,
+            hp: 30,
+            maxHp: 30
+          },
+          progression: {
+            level: 1,
+            experience: 0,
+            skillPoints: 0,
+            battlesWon: 0,
+            neutralBattlesWon: 0,
+            pvpBattlesWon: 0
+          },
+          armyCount: 12,
+          armyTemplateId: "hero_guard_basic",
+          learnedSkills: []
+        }
+      ],
+      visibleHeroes: [],
+      resources: {
+        gold: 0,
+        wood: 0,
+        ore: 0
+      },
+      playerId: "player-1"
+    },
+    battle: {
+      id: "battle-1",
+      round: 2,
+      lanes: 1,
+      activeUnitId: "hero-1-stack",
+      turnOrder: ["hero-1-stack", "neutral-1-stack"],
+      units: {
+        "hero-1-stack": {
+          id: "hero-1-stack",
+          templateId: "hero_guard_basic",
+          camp: "attacker",
+          lane: 0,
+          stackName: "Guard",
+          initiative: 7,
+          attack: 4,
+          defense: 4,
+          minDamage: 1,
+          maxDamage: 2,
+          count: 12,
+          currentHp: 10,
+          maxHp: 10,
+          hasRetaliated: false,
+          defending: false,
+          skills: [],
+          statusEffects: []
+        },
+        "neutral-1-stack": {
+          id: "neutral-1-stack",
+          templateId: "orc_warrior",
+          camp: "defender",
+          lane: 0,
+          stackName: "Orc",
+          initiative: 5,
+          attack: 3,
+          defense: 3,
+          minDamage: 1,
+          maxDamage: 3,
+          count: 8,
+          currentHp: 9,
+          maxHp: 9,
+          hasRetaliated: true,
+          defending: false,
+          skills: [],
+          statusEffects: []
+        }
+      },
+      environment: [],
+      log: [],
+      rng: { seed: 1, cursor: 0 },
+      worldHeroId: "hero-1",
+      neutralArmyId: "neutral-1"
+    },
+    events: [],
+    movementPlan: null,
+    reachableTiles: []
+  };
+}
+
+test("buildBattlePanelSections groups ally, enemy and queue rows from a battle state", () => {
+  const sections = buildBattlePanelSections({
+    update: createBattleUpdate(),
+    timelineEntries: [],
+    controlledCamp: "attacker",
+    selectedTargetId: "neutral-1-stack",
+    actionPending: false,
+    feedback: null
+  });
+
+  assert.equal(sections.idle, false);
+  assert.equal(sections.orderItems.length, 2);
+  assert.equal(sections.friendlyItems[0]?.title, "Guard x12");
+  assert.equal(sections.enemyTargets[0]?.title, "Orc x8");
+  assert.equal(sections.enemyTargets[0]?.selected, true);
+});
+
+test("battle panel stage banner derives the PVE terrain title from the encounter position", () => {
+  const sections = buildBattlePanelSections({
+    update: createBattleUpdate(),
+    timelineEntries: [],
+    controlledCamp: "attacker",
+    selectedTargetId: null,
+    actionPending: false,
+    feedback: null
+  });
+
+  assert.deepEqual(sections.stage, {
+    terrain: "sand",
+    title: "沙原战场 · 中立遭遇",
+    subtitle: "坐标 (1,1) · 无额外障碍",
+    badge: "PVE"
+  });
+});
+
+test("battle panel actions disable when it is not the controlled camp's turn", () => {
+  const update = createBattleUpdate();
+  if (update.battle) {
+    update.battle.activeUnitId = "neutral-1-stack";
+  }
+
+  const sections = buildBattlePanelSections({
+    update,
+    timelineEntries: [],
+    controlledCamp: "attacker",
+    selectedTargetId: "neutral-1-stack",
+    actionPending: false,
+    feedback: null
+  });
+
+  assert.equal(sections.actions.every((action) => action.enabled === false), true);
+});
+
+test("battle unit visuals switch to the selected portrait variant for the chosen target", () => {
+  assert.equal(resolveBattlePanelUnitVisual("orc_warrior", { selected: false }).portraitState, "idle");
+  assert.equal(resolveBattlePanelUnitVisual("orc_warrior", { selected: true }).portraitState, "selected");
+});

--- a/apps/cocos-client/test/cocos-lobby-panel.test.ts
+++ b/apps/cocos-client/test/cocos-lobby-panel.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildLobbyAccountIdentityView,
+  buildLobbyGuestEntryView,
+  buildLobbyRoomCards,
+  createLobbyPanelTestAccount,
+  summarizeLobbyShowcaseInventory
+} from "../assets/scripts/cocos-lobby-panel-model";
+import type { VeilLobbyRenderState } from "../assets/scripts/VeilLobbyPanel";
+
+function createLobbyState(overrides: Partial<VeilLobbyRenderState> = {}): VeilLobbyRenderState {
+  return {
+    playerId: "guest-1001",
+    displayName: "",
+    roomId: "",
+    authMode: "guest",
+    loginId: "",
+    loginHint: "游客模式",
+    loginActionLabel: "账号登录并进入",
+    shareHint: "共享存档未启用",
+    vaultSummary: "本地存档",
+    account: createLobbyPanelTestAccount(),
+    sessionSource: "none",
+    loading: false,
+    entering: false,
+    status: "等待操作...",
+    rooms: [],
+    accountFlow: null,
+    presentationReadiness: {
+      ready: false,
+      summary: "等待表现资源",
+      nextStep: "等待资源包"
+    },
+    ...overrides
+  };
+}
+
+test("lobby panel room cards render active room summaries from the server response", () => {
+  const cards = buildLobbyRoomCards([
+    {
+      roomId: "room-alpha",
+      seed: 1001,
+      day: 3,
+      connectedPlayers: 1,
+      heroCount: 2,
+      activeBattles: 1,
+      updatedAt: "2026-03-29T12:00:00.000Z"
+    }
+  ]);
+
+  assert.deepEqual(cards, [
+    {
+      roomId: "room-alpha",
+      title: "room-alpha",
+      meta: "Day 3 · Seed 1001 · 玩家 1 · 英雄 2 · 战斗 1"
+    }
+  ]);
+});
+
+test("guest login view resolves displayName and room ID from account and lobby state", () => {
+  const view = buildLobbyGuestEntryView(
+    createLobbyState({
+      playerId: "guest-202503",
+      account: createLobbyPanelTestAccount({
+        displayName: "晶塔旅人",
+        lastRoomId: "room-beta"
+      })
+    })
+  );
+
+  assert.deepEqual(view, {
+    displayName: "晶塔旅人",
+    roomId: "room-beta"
+  });
+});
+
+test("account identity view shows the loginId field only when credentials are bound", () => {
+  const bound = buildLobbyAccountIdentityView(
+    createLobbyState({
+      authMode: "account",
+      loginId: "veil-ranger",
+      account: createLobbyPanelTestAccount({
+        loginId: "veil-ranger",
+        credentialBoundAt: "2026-03-28T12:34:56.000Z"
+      })
+    })
+  );
+  assert.equal(bound.showLoginId, true);
+  assert.equal(bound.loginIdValue, "veil-ranger");
+
+  const guest = buildLobbyAccountIdentityView(createLobbyState());
+  assert.equal(guest.showLoginId, false);
+});
+
+test("showcase gallery inventory stays aligned with the configured hero, terrain, building and unit counts", () => {
+  assert.deepEqual(summarizeLobbyShowcaseInventory(), {
+    heroes: 4,
+    terrain: 5,
+    buildings: 4,
+    units: 6,
+    rotatingUnitPages: 2
+  });
+});

--- a/apps/cocos-client/test/cocos-map-board.test.ts
+++ b/apps/cocos-client/test/cocos-map-board.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildTileViewModel,
+  moveMapBoardKeyboardCursor,
+  resolveMapBoardFeedbackLabel
+} from "../assets/scripts/cocos-map-board-model";
+import type { PlayerTileView, SessionUpdate } from "../assets/scripts/VeilCocosSession";
+
+function createTile(
+  position: { x: number; y: number },
+  overrides: Partial<PlayerTileView> = {}
+): PlayerTileView {
+  return {
+    position,
+    fog: "visible",
+    terrain: "grass",
+    walkable: true,
+    resource: undefined,
+    occupant: undefined,
+    building: undefined,
+    ...overrides
+  };
+}
+
+function createBaseUpdate(): SessionUpdate {
+  return {
+    world: {
+      meta: {
+        roomId: "room-alpha",
+        seed: 1001,
+        day: 1
+      },
+      map: {
+        width: 3,
+        height: 3,
+        tiles: [
+          createTile({ x: 0, y: 0 }, { fog: "explored" }),
+          createTile({ x: 1, y: 1 }, { resource: { kind: "wood", amount: 5 } }),
+          createTile({ x: 2, y: 2 })
+        ]
+      },
+      ownHeroes: [
+        {
+          id: "hero-1",
+          playerId: "player-1",
+          name: "Katherine",
+          position: { x: 1, y: 1 },
+          vision: 4,
+          move: {
+            total: 6,
+            remaining: 4
+          },
+          stats: {
+            attack: 2,
+            defense: 2,
+            power: 1,
+            knowledge: 1,
+            hp: 30,
+            maxHp: 30
+          },
+          progression: {
+            level: 2,
+            experience: 40,
+            skillPoints: 1,
+            battlesWon: 1,
+            neutralBattlesWon: 1,
+            pvpBattlesWon: 0
+          },
+          armyCount: 11,
+          armyTemplateId: "hero_guard_basic",
+          learnedSkills: []
+        }
+      ],
+      visibleHeroes: [],
+      resources: {
+        gold: 0,
+        wood: 0,
+        ore: 0
+      },
+      playerId: "player-1"
+    },
+    battle: null,
+    events: [],
+    movementPlan: null,
+    reachableTiles: [{ x: 1, y: 1 }, { x: 2, y: 2 }]
+  };
+}
+
+test("buildTileViewModel exposes interactable, reachable and fog flags from the world snapshot", () => {
+  const update = createBaseUpdate();
+
+  assert.deepEqual(buildTileViewModel(update, { x: 0, y: 0 }), {
+    key: "0-0",
+    tile: update.world.map.tiles[0],
+    fog: "explored",
+    reachable: false,
+    heroTile: false,
+    interactable: true,
+    objectMarker: null
+  });
+
+  const heroTile = buildTileViewModel(update, { x: 1, y: 1 });
+  assert.equal(heroTile.fog, "visible");
+  assert.equal(heroTile.reachable, true);
+  assert.equal(heroTile.heroTile, true);
+  assert.equal(heroTile.objectMarker?.iconKey, "wood");
+  assert.equal(heroTile.objectMarker?.fallbackLabel, "木材");
+});
+
+test("map board marker resolution preserves resource icon keys and fallback labels", () => {
+  const update = createBaseUpdate();
+  const view = buildTileViewModel(update, { x: 1, y: 1 });
+
+  assert.equal(view.objectMarker?.descriptor.title, "木材堆");
+  assert.equal(view.objectMarker?.iconKey, "wood");
+  assert.equal(view.objectMarker?.fallbackLabel, "木材");
+  assert.equal(view.objectMarker?.interactionType, "pickup");
+});
+
+test("keyboard cursor movement advances the highlight and clears the previous tile key", () => {
+  const firstMove = moveMapBoardKeyboardCursor(null, "right", { width: 4, height: 3 });
+  assert.deepEqual(firstMove, {
+    previous: null,
+    current: { x: 1, y: 0 },
+    clearedKey: null,
+    highlightedKey: "1-0"
+  });
+
+  const secondMove = moveMapBoardKeyboardCursor(firstMove.current, "down", { width: 4, height: 3 });
+  assert.deepEqual(secondMove, {
+    previous: { x: 1, y: 0 },
+    current: { x: 1, y: 1 },
+    clearedKey: "1-0",
+    highlightedKey: "1-1"
+  });
+});
+
+test("resolveMapBoardFeedbackLabel maps move, resource, battle-start and battle-result events", () => {
+  assert.equal(
+    resolveMapBoardFeedbackLabel({
+      type: "hero.moved",
+      heroId: "hero-1",
+      path: [{ x: 1, y: 1 }],
+      moveCost: 2
+    }),
+    "MOVE 2"
+  );
+  assert.equal(
+    resolveMapBoardFeedbackLabel({
+      type: "hero.collected",
+      heroId: "hero-1",
+      resource: { kind: "wood", amount: 5 }
+    }),
+    "+WOOD"
+  );
+  assert.equal(
+    resolveMapBoardFeedbackLabel({
+      type: "battle.started",
+      heroId: "hero-1",
+      path: [{ x: 2, y: 2 }],
+      encounterKind: "neutral"
+    }),
+    "PVE"
+  );
+  assert.equal(
+    resolveMapBoardFeedbackLabel(
+      {
+        type: "battle.resolved",
+        heroId: "hero-1",
+        defenderHeroId: undefined,
+        battleId: "battle-1",
+        result: "attacker_victory"
+      },
+      { heroId: "hero-1" }
+    ),
+    "VICTORY"
+  );
+});


### PR DESCRIPTION
## Summary
- add pure model helpers for map-board tile/object/feedback/cursor state and lobby-panel room/account/showcase state
- add component-focused node:test coverage for VeilMapBoard, VeilBattlePanel, and VeilLobbyPanel
- expose battle-panel sections as a pure test seam and reuse the map feedback label helper in existing feedback generation

## Validation
- `node --import tsx --test apps/cocos-client/test/cocos-map-board.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-battle-panel.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-lobby-panel.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-map-visuals.test.ts`
- `npm run typecheck:cocos`

## Blocker
- A broader repo test sweep via `npm test -- --test "apps/cocos-client/test/**/*.test.ts"` still hits pre-existing unrelated failures in `apps/cocos-client/test/cocos-root-orchestration.test.ts` and `apps/cocos-client/test/cocos-session-orchestration.test.ts` because Node cannot resolve the `cc` module in those existing tests from this worktree. This change set does not modify those files.

Closes #238
