### PR TITLE
docs(release): formalize Cocos/WeChat RC evidence and blocker templates

### DIFF
--- a/docs/cocos-release-evidence-template.md
+++ b/docs/cocos-release-evidence-template.md
@@ -1,6 +1,6 @@
 # Cocos Release Evidence Template
 
-本模板现在以 `npm run release:cocos-rc:snapshot` 生成的 machine-readable JSON 为主，Markdown 只保留使用说明、字段规则和样例路径。目标是把 Cocos Creator 预览与微信小游戏 RC 的证据收口到同一份可归档、可校验、可对比的快照里。
+本模板现在以 `npm run release:cocos-rc:snapshot` 生成的 machine-readable JSON 为主，Markdown 只保留使用说明、字段规则和样例路径。目标是把 Cocos Creator 预览与微信小游戏 RC 的证据收口到同一份可归档、可校验、可对比的快照里，并配套一份可直接复制的检查清单与 blocker 记录。
 
 相关文档：
 
@@ -9,6 +9,23 @@
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
 - 微信小游戏构建 / 打包 / 验收：`docs/wechat-minigame-release.md`
 - 样例快照：`docs/release-evidence/cocos-rc-snapshot.example.json`
+- RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
+- RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
+
+## RC Evidence Packet
+
+每个 Cocos / WeChat release candidate 都固定产出同一组证据：
+
+1. `artifacts/release-readiness/<candidate>.json`
+   - 自动化 + manual gate 的统一发布快照
+2. `artifacts/release-evidence/<candidate>.<surface>.json`
+   - `npm run release:cocos-rc:snapshot` 生成并回填的结构化 RC 证据
+3. `docs/release-evidence/cocos-wechat-rc-checklist.template.md`
+   - 执行人复制后填写的人工检查清单，明确每一步是否已完成
+4. `docs/release-evidence/cocos-wechat-rc-blockers.template.md`
+   - 记录 `P0/P1/P2` blocker、owner、退出条件和放行决定
+
+其中 2 是权威 machine-readable 记录，3 和 4 是 reviewer / release owner 快速扫读的补充视图。不要为同一个 RC 另外发明独立格式。
 
 ## 标准流程
 
@@ -47,6 +64,15 @@ npm run release:cocos-rc:snapshot -- \
   --check
 ```
 
+5. 复制 RC 检查清单与 blocker 模板，作为 PR 或 release issue 的人类可读附件：
+
+```bash
+cp docs/release-evidence/cocos-wechat-rc-checklist.template.md \
+  artifacts/release-evidence/rc-2026-03-29.checklist.md
+cp docs/release-evidence/cocos-wechat-rc-blockers.template.md \
+  artifacts/release-evidence/rc-2026-03-29.blockers.md
+```
+
 ## 快照结构
 
 快照固定包含以下区块：
@@ -80,6 +106,7 @@ npm run release:cocos-rc:snapshot -- \
 - `requiredEvidence.restoredState`
 - `requiredEvidence.firstBattleResult`
 - 所有 `journey[*].status`
+- 如存在 blocker，必须在配套 blocker 模板中写明 `severity`、`owner`、`next update`、`exit criteria`
 
 可选补充：
 
@@ -119,12 +146,16 @@ Creator 预览至少补：
 - `codex.wechat.smoke-report.json`
 - 真机或准真机截图 / 录屏
 - 若有发布包，则附 artifact 目录或 `*.upload.json`
+- 对应 RC checklist 中的设备、客户端版本、执行人和放行结论
+- 对应 blocker 模板中的未关闭风险与是否允许带风险推进
 
 ## 样例
 
 可直接复制并回填：
 
 - JSON 样例：`docs/release-evidence/cocos-rc-snapshot.example.json`
+- Markdown 检查清单：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
+- Markdown blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
 - 生成命令：
 
 ```bash

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -20,6 +20,8 @@
 - 发布就绪快照：`npm run release:readiness:snapshot`
 - Cocos RC 证据快照：`npm run release:cocos-rc:snapshot`
 - Cocos 发布证据模板：`docs/cocos-release-evidence-template.md`
+- Cocos / WeChat RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
+- Cocos / WeChat RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
 - 微信小游戏提审前冒烟：`docs/wechat-minigame-release.md`
 
 ## 发布判断规则
@@ -28,9 +30,9 @@
 - `P1 follow-up`：可以进入受控范围测试，但必须有明确 owner 和修复窗口。
 - `P2 polish`：不阻断测试扩大，但需要继续收口体验。
 
-建议在每次 release candidate 上记录状态：`pass / partial / fail / n/a`，并附上证据链接、执行人和日期。
+建议在每次 release candidate 上记录状态：`pass / partial / fail / n/a`，并附上证据链接、执行人和日期。对于 Cocos / WeChat RC，再额外固定两份人类可读附件：一份 checklist，一份 blocker register。
 
-如果希望把自动化门禁和人工门禁统一收口成一个结构化记录，可执行 `npm run release:readiness:snapshot -- --manual-checks docs/release-readiness-manual-checks.example.json`，生成当前 revision 的快照并保留 pending manual check。Cocos 主链路证据则统一用 `npm run release:cocos-rc:snapshot` 生成单独的 RC 快照，并在同一份 JSON 中回填 Creator 预览或微信 RC 证据。
+如果希望把自动化门禁和人工门禁统一收口成一个结构化记录，可执行 `npm run release:readiness:snapshot -- --manual-checks docs/release-readiness-manual-checks.example.json`，生成当前 revision 的快照并保留 pending manual check。Cocos 主链路证据则统一用 `npm run release:cocos-rc:snapshot` 生成单独的 RC 快照，并在同一份 JSON 中回填 Creator 预览或微信 RC 证据；人工 reviewer 则复用 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 和 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，不要在 issue 或 PR 中重新发明字段。
 
 ## 必过用户旅程
 
@@ -112,6 +114,8 @@
 - `npm test`
 - `npm run check:wechat-build`
 - `npm run release:cocos-rc:snapshot -- --output <snapshot-path>`
+- `docs/release-evidence/cocos-wechat-rc-checklist.template.md`
+- `docs/release-evidence/cocos-wechat-rc-blockers.template.md`
 - [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md) 中定义的 reconnect 证据
 - 按 [`docs/wechat-minigame-release.md`](/home/gpt/project/ProjectVeil/docs/wechat-minigame-release.md) 完成 `verify` 与 `smoke`
 
@@ -161,6 +165,7 @@ H5 冒烟和多人 Playwright 已经比较成熟，但真实发布面是 `apps/c
 - `Cocos 主链路发布证据`
   - 固定一条 Lobby -> 进房 -> 战斗 -> 重连 -> 返回世界的验收脚本
   - 使用 `npm run release:cocos-rc:snapshot` 产出统一 evidence，并参考 `docs/release-evidence/cocos-rc-snapshot.example.json` 回填
+  - 同步复制 RC checklist 与 blocker 模板，避免 PR 中只看到截图没有结论
 - `多人放量门禁`
   - 复用 `docs/multiplayer-loadtest-gate.md`
   - 固定压测参数、阈值、回退条件与样例记录

--- a/docs/release-evidence/cocos-rc-snapshot.example.json
+++ b/docs/release-evidence/cocos-rc-snapshot.example.json
@@ -27,6 +27,12 @@
       "summary": "Release readiness snapshot reference",
       "result": "passed",
       "sourceRevision": "abc1234"
+    },
+    "wechatSmokeReport": {
+      "path": "artifacts/wechat-rc/codex.wechat.smoke-report.json",
+      "summary": "WeChat RC smoke report reference",
+      "result": "passed",
+      "sourceRevision": "abc1234"
     }
   },
   "mappings": [

--- a/docs/release-evidence/cocos-wechat-rc-blockers.template.md
+++ b/docs/release-evidence/cocos-wechat-rc-blockers.template.md
@@ -1,0 +1,38 @@
+# Cocos / WeChat RC Blocker Template
+
+用于记录 release candidate 的未决风险。没有 blocker 也要保留一份，明确写 `none`，避免 reviewer 误以为记录缺失。
+
+## Candidate
+
+- Candidate: `rc-YYYY-MM-DD`
+- Surface: `creator_preview | wechat_preview | wechat_upload_candidate`
+- Commit: `<git-sha>`
+- Owner: `<name>`
+- Last updated: `<YYYY-MM-DD HH:mm TZ>`
+- Release decision: `ship | hold | ship-with-followups`
+
+## Blocker Rules
+
+- `P0`: 不允许放行；必须修复或显式降级范围后重验
+- `P1`: 可在受控范围内放行，但必须有 owner、时间窗口和回退方案
+- `P2`: 不阻断 RC，但要保留后续收口动作
+
+## Current Blockers
+
+| ID | Severity | Area | Summary | Evidence | Owner | Exit Criteria | Next Update | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| none | n/a | n/a | No open blockers at handoff time. | `artifacts/release-evidence/<candidate>.<surface>.json` | `<name>` | n/a | n/a | closed |
+
+若存在实际 blocker，把 `none` 行替换成真实记录，并保持每项都包含：
+
+- `Evidence`: 直接指向 RC snapshot、smoke report、截图、日志或 artifact
+- `Exit Criteria`: 明确到“什么条件满足后才能关闭”
+- `Next Update`: 下次同步时间，避免 blocker 变成无人维护的注释
+- `Status`: `open | mitigated | closed`
+
+## Release Owner Notes
+
+- 放行理由：
+- 若带风险放行，限制范围：
+- 回退动作：
+

--- a/docs/release-evidence/cocos-wechat-rc-checklist.template.md
+++ b/docs/release-evidence/cocos-wechat-rc-checklist.template.md
@@ -1,0 +1,75 @@
+# Cocos / WeChat RC Checklist Template
+
+将本模板复制到当前 RC 的 `artifacts/release-evidence/` 或 PR 描述中回填。它不是 JSON 快照的替代品，而是帮助 reviewer 快速确认“这次 RC 是否已经把该补的证据补齐”。
+
+## Candidate
+
+- Candidate: `rc-YYYY-MM-DD`
+- Surface: `creator_preview | wechat_preview | wechat_upload_candidate`
+- Commit: `<git-sha>`
+- Owner: `<name>`
+- Date: `<YYYY-MM-DD>`
+- Device / Client:
+- Server / Environment:
+
+## Linked Evidence
+
+- [ ] Release readiness snapshot 已生成：
+  `artifacts/release-readiness/<candidate>.json`
+- [ ] Cocos RC snapshot 已生成并通过 `--check`：
+  `artifacts/release-evidence/<candidate>.<surface>.json`
+- [ ] 若为 WeChat RC，已附上 `codex.wechat.smoke-report.json`
+- [ ] 若为上传候选包，已附上 `*.package.json` / `*.upload.json`
+
+## Canonical Journey
+
+- [ ] Lobby entry
+  Evidence:
+  Notes:
+- [ ] Room join
+  Evidence:
+  Notes:
+- [ ] Map explore
+  Evidence:
+  Notes:
+- [ ] First battle
+  Evidence:
+  Notes:
+- [ ] Reconnect / restore
+  Evidence:
+  Notes:
+- [ ] Return to world
+  Evidence:
+  Notes:
+
+## Required Evidence
+
+- [ ] `roomId` 已记录，且截图/录屏中可见
+  Value:
+  Evidence:
+- [ ] `reconnectPrompt` 已记录，且与 reconnect gate 口径一致
+  Value:
+  Evidence:
+- [ ] `restoredState` 已记录，能证明恢复后未回档
+  Value:
+  Evidence:
+- [ ] `firstBattleResult` 已记录，包含胜负与关键结算结果
+  Value:
+  Evidence:
+
+## WeChat-Specific Checks
+
+- [ ] 登录进入 Lobby 或游客降级结果已记录
+- [ ] 进房成功并记录 `roomId`
+- [ ] `reconnect-recovery` 已复用 `docs/reconnect-smoke-gate.md` 的 canonical scenario
+- [ ] 分享回流已验证，或明确标记 `not_applicable`
+- [ ] 关键资源加载无 404 / 白名单 / 缺图阻断
+- [ ] 真机或准真机设备、客户端版本、执行时间已记录
+
+## Release Decision
+
+- Decision: `ship | hold | ship-with-followups`
+- Summary:
+- Remaining blockers doc:
+- Follow-ups / owners:
+

--- a/docs/release-readiness-manual-checks.example.json
+++ b/docs/release-readiness-manual-checks.example.json
@@ -20,5 +20,16 @@
     "evidence": [
       "docs/wechat-minigame-release.md"
     ]
+  },
+  {
+    "id": "cocos-rc-blocker-review",
+    "title": "Cocos/WeChat RC blocker register reviewed",
+    "status": "pending",
+    "required": true,
+    "notes": "Attach the completed RC checklist and blocker template before marking the candidate release-ready.",
+    "evidence": [
+      "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
+      "docs/release-evidence/cocos-wechat-rc-blockers.template.md"
+    ]
   }
 ]

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -10,7 +10,7 @@ The default automated checks are:
 - `npm run test:e2e:multiplayer:smoke`
 - `npm run check:wechat-build`
 
-The snapshot also supports manual gates, so the same file can carry pending or completed human checks such as runtime endpoint review, reconnect evidence, or device smoke acceptance.
+The snapshot also supports manual gates, so the same file can carry pending or completed human checks such as runtime endpoint review, reconnect evidence, device smoke acceptance, or RC blocker review.
 
 ## Usage
 
@@ -80,6 +80,17 @@ Example:
     "notes": "Complete npm run smoke:wechat-release against the packaged RC build.",
     "evidence": [
       "docs/wechat-minigame-release.md"
+    ]
+  },
+  {
+    "id": "cocos-rc-blocker-review",
+    "title": "Cocos/WeChat RC blocker register reviewed",
+    "status": "pending",
+    "required": true,
+    "notes": "Attach the completed RC checklist and blocker template for the candidate before marking release-ready.",
+    "evidence": [
+      "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
+      "docs/release-evidence/cocos-wechat-rc-blockers.template.md"
     ]
   }
 ]

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -30,6 +30,8 @@
 - 生成 / 校验真机冒烟报告：`npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> [--report <report-path>] [--check --expected-revision <git-sha>]`
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
 - 统一 Cocos RC 证据快照：`npm run release:cocos-rc:snapshot`
+- RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
+- RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
 - 只做 CI 同款校验：`npm run check:wechat-build`
 - 校验真实导出目录：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 
@@ -62,8 +64,9 @@
 8. 完成真机 / 准真机冒烟后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
    - `reconnect-recovery` 必须复用 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md) 的 canonical scenario、最小成功信号和失败诊断口径。
 9. 运行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把微信 smoke 结果映射回统一的 Cocos RC 快照，并补齐首战 / 返回世界证据。
-10. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
-11. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
+10. 复制 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，为当前 candidate 回填设备、结论和 blocker。
+11. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
+12. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
 
 ## 下载与验收
 
@@ -103,8 +106,9 @@
    - `reconnect-recovery` 至少要记录原 `roomId`、恢复提示、恢复后未回档状态三项证据；细则见 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md)
 4. 回填完成后执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`
 5. 再执行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把 `login-lobby`、`room-entry`、`reconnect-recovery` 映射到统一 RC 快照，并补齐 `firstBattleResult` 与 `return-to-world` 证据。
+6. 复制并回填 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，确保 reviewer 能直接看到当前 RC 的设备、结论与未关闭风险。
 
-若某项因当前包能力受限无法完整验证，可把 case 标记为 `not_applicable`，并在 `notes` 中写明原因与替代观察证据；其余必填项不得保留 `pending`。
+若某项因当前包能力受限无法完整验证，可把 case 标记为 `not_applicable`，并在 `notes` 中写明原因与替代观察证据；其余必填项不得保留 `pending`。若因此形成风险，必须同步写入 blocker 模板，而不是只留在 smoke report 备注里。
 
 ## 回滚演练
 


### PR DESCRIPTION
## Summary
- formalize the Cocos/WeChat RC evidence packet around one snapshot, one checklist, and one blocker register
- add copyable RC checklist and blocker templates under docs/release-evidence
- wire the new templates into release-readiness, Cocos RC, and WeChat release docs

## Validation
- npm run release:cocos-rc:snapshot -- --output docs/release-evidence/cocos-rc-snapshot.example.json --check
- node -e "JSON.parse(require('node:fs').readFileSync('docs/release-readiness-manual-checks.example.json','utf8')); JSON.parse(require('node:fs').readFileSync('docs/release-evidence/cocos-rc-snapshot.example.json','utf8')); console.log('json ok')"

Closes #247