### PR TITLE
test(client): add H5 boot/session regression coverage for main.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ npm run dev:client:h5
 - `apps/client`
   - H5 调试 / 回归壳。
   - 当前保留给浏览器内快速验证、配置联调和回归测试使用，不再作为主客户端运行时。
+  - `apps/client/test/main-boot.test.ts` 额外承担一层轻量 boot/session 回归：固定 `main.ts` 启动阶段的缓存会话回放、远端会话不可用时的本地回退或失败信号、以及 automation/debug hooks 注册结果。
+  - 这层回归不覆盖真实浏览器导航、Colyseus 长链路重连、或 Cocos 主客户端集成；这些仍由 Playwright、`local-session.ts`/server 测试和 `apps/cocos-client` 自动化承担。
 - `apps/cocos-client`
   - Cocos Creator 3.x 主客户端运行时。
   - 当前已覆盖 Lobby、地图探索、战斗、账号会话恢复和配置中心跳转的主流程。

--- a/apps/client/src/main-boot.ts
+++ b/apps/client/src/main-boot.ts
@@ -82,6 +82,18 @@ interface RegisterAutomationHooksOptions {
   advanceUiTime: (ms: number) => Promise<void>;
 }
 
+function summarizeBootSessionFailure(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return "会话恢复失败，请刷新页面或稍后重试。";
+  }
+
+  if (error.message === "session_not_ready" || error.message === "session_unavailable") {
+    return "会话恢复失败，请返回大厅后重新进入房间。";
+  }
+
+  return `会话恢复失败：${error.message}`;
+}
+
 export async function bootstrapH5App({
   state,
   shouldBootGame,
@@ -127,17 +139,26 @@ export async function bootstrapH5App({
     applyReplayedUpdate(replayed);
   }
 
-  const session = await getSession();
-  const initial = await session.snapshot();
-  state.diagnostics.connectionStatus = "connected";
-  state.log = [
-    `会话已连接。Room ${roomId} / Player ${playerId}`,
-    ...state.log.filter(
-      (line) => line !== "正在连接本地会话服务..." && line !== `会话已连接。Room ${roomId} / Player ${playerId}`
-    )
-  ].slice(0, 12);
-  applyUpdate(initial, "system");
-  void syncPlayerAccountProfile();
+  try {
+    const session = await getSession();
+    const initial = await session.snapshot();
+    state.diagnostics.connectionStatus = "connected";
+    state.log = [
+      `会话已连接。Room ${roomId} / Player ${playerId}`,
+      ...state.log.filter(
+        (line) => line !== "正在连接本地会话服务..." && line !== `会话已连接。Room ${roomId} / Player ${playerId}`
+      )
+    ].slice(0, 12);
+    applyUpdate(initial, "system");
+    void syncPlayerAccountProfile();
+  } catch (error) {
+    state.diagnostics.connectionStatus = "reconnect_failed";
+    state.log = [
+      replayed ? "远端会话暂不可用，当前仅展示最近缓存状态。" : summarizeBootSessionFailure(error),
+      ...state.log.filter((line) => line !== "正在连接本地会话服务...")
+    ].slice(0, 12);
+    render();
+  }
 }
 
 export async function syncH5PlayerAccountProfile({

--- a/apps/client/test/main-boot.test.ts
+++ b/apps/client/test/main-boot.test.ts
@@ -132,6 +132,141 @@ test("bootstrapH5App replays cached session state before the fresh snapshot and 
   assert.deepEqual(state.log, ["会话已连接。Room room-alpha / Player player-auth", "old-line"]);
 });
 
+test("bootstrapH5App keeps the cached session visible and marks boot failure when the remote snapshot is unavailable", async () => {
+  const replayed = createSessionUpdate("cached");
+  const events: string[] = [];
+  const state = {
+    lobby: {
+      playerId: "player-auth",
+      displayName: "访客骑士",
+      loginId: "",
+      authSession: null
+    },
+    accountDraftName: "访客骑士",
+    accountLoginId: "",
+    diagnostics: {
+      connectionStatus: "connecting" as const
+    },
+    log: ["正在连接本地会话服务...", "old-line"]
+  };
+
+  await bootstrapH5App({
+    state,
+    shouldBootGame: true,
+    queryPlayerId: "player-auth",
+    roomId: "room-alpha",
+    playerId: "player-auth",
+    bindKeyboardShortcuts: () => {
+      events.push("bindKeyboardShortcuts");
+    },
+    render: () => {
+      events.push("render");
+    },
+    syncCurrentAuthSession: async () => {
+      events.push("syncCurrentAuthSession");
+      return createStoredSession({ source: "local" });
+    },
+    refreshLobbyRoomList: async () => {
+      events.push("refreshLobbyRoomList");
+    },
+    logoutGuestSession: () => {
+      events.push("logoutGuestSession");
+    },
+    readStoredSessionReplay: () => {
+      events.push("readStoredSessionReplay");
+      return replayed;
+    },
+    applyReplayedUpdate: (update) => {
+      events.push(`applyReplayedUpdate:${update.reason}`);
+    },
+    getSession: async () => {
+      events.push("getSession");
+      throw new Error("session_unavailable");
+    },
+    applyUpdate: () => {
+      events.push("applyUpdate");
+    },
+    syncPlayerAccountProfile: () => {
+      events.push("syncPlayerAccountProfile");
+    }
+  });
+
+  assert.deepEqual(events, [
+    "bindKeyboardShortcuts",
+    "render",
+    "syncCurrentAuthSession",
+    "readStoredSessionReplay",
+    "applyReplayedUpdate:cached",
+    "getSession",
+    "render"
+  ]);
+  assert.equal(state.diagnostics.connectionStatus, "reconnect_failed");
+  assert.deepEqual(state.log, ["远端会话暂不可用，当前仅展示最近缓存状态。", "old-line"]);
+});
+
+test("bootstrapH5App logs out when no query player or synced session can restore the boot identity", async () => {
+  const events: string[] = [];
+  const state = {
+    lobby: {
+      playerId: "guest-001",
+      displayName: "本地游客",
+      loginId: "",
+      authSession: createStoredSession({ authMode: "guest", source: "local", playerId: "guest-001", loginId: undefined })
+    },
+    accountDraftName: "本地游客",
+    accountLoginId: "",
+    diagnostics: {
+      connectionStatus: "connecting" as const
+    },
+    log: ["正在连接本地会话服务..."]
+  };
+
+  await bootstrapH5App({
+    state,
+    shouldBootGame: true,
+    queryPlayerId: "",
+    roomId: "room-alpha",
+    playerId: "guest-001",
+    bindKeyboardShortcuts: () => {
+      events.push("bindKeyboardShortcuts");
+    },
+    render: () => {
+      events.push("render");
+    },
+    syncCurrentAuthSession: async () => {
+      events.push("syncCurrentAuthSession");
+      return null;
+    },
+    refreshLobbyRoomList: async () => {
+      events.push("refreshLobbyRoomList");
+    },
+    logoutGuestSession: () => {
+      events.push("logoutGuestSession");
+    },
+    readStoredSessionReplay: () => {
+      events.push("readStoredSessionReplay");
+      return null;
+    },
+    applyReplayedUpdate: () => {
+      events.push("applyReplayedUpdate");
+    },
+    getSession: async () => {
+      events.push("getSession");
+      throw new Error("should_not_fetch_session");
+    },
+    applyUpdate: () => {
+      events.push("applyUpdate");
+    },
+    syncPlayerAccountProfile: () => {
+      events.push("syncPlayerAccountProfile");
+    }
+  });
+
+  assert.deepEqual(events, ["bindKeyboardShortcuts", "render", "syncCurrentAuthSession", "logoutGuestSession"]);
+  assert.equal(state.lobby.authSession, null);
+  assert.equal(state.diagnostics.connectionStatus, "connecting");
+});
+
 test("syncH5PlayerAccountProfile keeps boot usable when progression falls back to local storage", async () => {
   const events: string[] = [];
   const state = {


### PR DESCRIPTION
## Summary
- add focused H5 boot/session regression coverage around `apps/client/src/main.ts` via `main-boot.ts`
- cover cached session replay, remote session unavailable failure signaling, missing boot identity logout, and automation/debug hook registration
- document what this regression layer covers and does not cover in `README.md`

## Testing
- node --import tsx --test apps/client/test/main-boot.test.ts
- npm run typecheck --prefix apps/client

Closes #245
