### PR TITLE
test(cocos): add runtime harness for VeilRoot orchestration

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -98,6 +98,33 @@ const DEFAULT_MAP_WIDTH_TILES = 8;
 const DEFAULT_MAP_HEIGHT_TILES = 8;
 const BATTLE_FEEDBACK_DURATION_MS = 2600;
 
+interface VeilRootRuntime {
+  createSession: typeof VeilCocosSession.create;
+  readStoredReplay: typeof VeilCocosSession.readStoredReplay;
+  loadLobbyRooms: typeof loadCocosLobbyRooms;
+  syncAuthSession: typeof syncCurrentCocosAuthSession;
+  loadAccountProfile: typeof loadCocosPlayerAccountProfile;
+  loginGuestAuthSession: typeof loginCocosGuestAuthSession;
+}
+
+const defaultVeilRootRuntime: VeilRootRuntime = {
+  createSession: (...args) => VeilCocosSession.create(...args),
+  readStoredReplay: (...args) => VeilCocosSession.readStoredReplay(...args),
+  loadLobbyRooms: (...args) => loadCocosLobbyRooms(...args),
+  syncAuthSession: (...args) => syncCurrentCocosAuthSession(...args),
+  loadAccountProfile: (...args) => loadCocosPlayerAccountProfile(...args),
+  loginGuestAuthSession: (...args) => loginCocosGuestAuthSession(...args)
+};
+
+let testVeilRootRuntimeOverrides: Partial<VeilRootRuntime> | null = null;
+
+function resolveVeilRootRuntime(): VeilRootRuntime {
+  return {
+    ...defaultVeilRootRuntime,
+    ...testVeilRootRuntimeOverrides
+  };
+}
+
 function formatHeroStatBonus(bonus: { attack: number; defense: number; power: number; knowledge: number }): string {
   return [
     bonus.attack > 0 ? `攻击 +${bonus.attack}` : "",
@@ -258,7 +285,7 @@ export class VeilRoot extends Component {
     }
 
     this.pushLog(`正在连接 ${this.remoteUrl} ...`);
-    const replayed = VeilCocosSession.readStoredReplay(this.roomId, this.playerId);
+    const replayed = resolveVeilRootRuntime().readStoredReplay(this.roomId, this.playerId);
     if (replayed) {
       this.applyReplayedSessionUpdate(replayed);
       this.pushLog("已回放本地缓存，等待房间实时同步。");
@@ -268,7 +295,12 @@ export class VeilRoot extends Component {
     const sessionEpoch = this.bumpSessionEpoch();
     let nextSession: VeilCocosSession | null = null;
     try {
-      nextSession = await VeilCocosSession.create(this.roomId, this.playerId, this.seed, this.createSessionOptions(sessionEpoch));
+      nextSession = await resolveVeilRootRuntime().createSession(
+        this.roomId,
+        this.playerId,
+        this.seed,
+        this.createSessionOptions(sessionEpoch)
+      );
       if (!this.isActiveSessionEpoch(sessionEpoch)) {
         await nextSession.dispose().catch(() => undefined);
         return;
@@ -850,7 +882,7 @@ export class VeilRoot extends Component {
     const requestEpoch = this.bumpLobbyAccountEpoch();
     const storedSession = readStoredCocosAuthSession(storage);
     const activeSession = storedSession?.playerId === this.playerId ? storedSession : null;
-    const syncedSession = await syncCurrentCocosAuthSession(this.remoteUrl, {
+    const syncedSession = await resolveVeilRootRuntime().syncAuthSession(this.remoteUrl, {
       storage,
       session: activeSession
     });
@@ -874,7 +906,7 @@ export class VeilRoot extends Component {
       this.sessionSource = "none";
     }
 
-    const profile = await loadCocosPlayerAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
+    const profile = await resolveVeilRootRuntime().loadAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
       storage,
       authSession: syncedSession
     });
@@ -1422,7 +1454,12 @@ export class VeilRoot extends Component {
     this.renderView();
 
     try {
-      freshSession = await VeilCocosSession.create(nextRoomId, this.playerId, nextSeed, this.createSessionOptions(nextSessionEpoch));
+      freshSession = await resolveVeilRootRuntime().createSession(
+        nextRoomId,
+        this.playerId,
+        nextSeed,
+        this.createSessionOptions(nextSessionEpoch)
+      );
       if (!this.isActiveSessionEpoch(nextSessionEpoch)) {
         await freshSession.dispose().catch(() => undefined);
         return;
@@ -1470,7 +1507,7 @@ export class VeilRoot extends Component {
     this.renderView();
 
     try {
-      const rooms = await loadCocosLobbyRooms(this.remoteUrl);
+      const rooms = await resolveVeilRootRuntime().loadLobbyRooms(this.remoteUrl);
       this.lobbyRooms = rooms;
       this.lobbyStatus =
         rooms.length > 0
@@ -1506,7 +1543,7 @@ export class VeilRoot extends Component {
     try {
       let authSession: Awaited<ReturnType<typeof loginCocosGuestAuthSession>>;
       if (this.authMode === "account" && this.authToken) {
-        const syncedSession = await syncCurrentCocosAuthSession(this.remoteUrl, {
+        const syncedSession = await resolveVeilRootRuntime().syncAuthSession(this.remoteUrl, {
           storage,
           session: readStoredCocosAuthSession(storage)
         });
@@ -1515,7 +1552,7 @@ export class VeilRoot extends Component {
         }
         authSession = syncedSession;
       } else {
-        authSession = await loginCocosGuestAuthSession(this.remoteUrl, preferences.playerId, displayName, {
+        authSession = await resolveVeilRootRuntime().loginGuestAuthSession(this.remoteUrl, preferences.playerId, displayName, {
           storage
         });
       }
@@ -2677,6 +2714,17 @@ export class VeilRoot extends Component {
     };
   }
 
+}
+
+export function setVeilRootRuntimeForTests(runtime: Partial<VeilRootRuntime>): void {
+  testVeilRootRuntimeOverrides = {
+    ...testVeilRootRuntimeOverrides,
+    ...runtime
+  };
+}
+
+export function resetVeilRootRuntimeForTests(): void {
+  testVeilRootRuntimeOverrides = null;
 }
 
 function cloneSessionUpdate(update: SessionUpdate): SessionUpdate {

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { afterEach, test } from "node:test";
 import { sys } from "cc";
-import { VeilCocosSession } from "../assets/scripts/VeilCocosSession.ts";
 import { createMemoryStorage, createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
-import { createVeilRootHarness } from "./helpers/veil-root-harness.ts";
+import { createVeilRootHarness, installVeilRootRuntime, resetVeilRootRuntime } from "./helpers/veil-root-harness.ts";
+
+afterEach(() => {
+  resetVeilRootRuntime();
+  (sys as unknown as { localStorage: Storage | null }).localStorage = null;
+});
 
 test("VeilRoot boots into lobby mode and triggers lobby bootstrap when no roomId is provided", async () => {
   const storage = createMemoryStorage();
@@ -53,12 +57,6 @@ test("VeilRoot connect replays cached session state before applying the live sna
     },
     async dispose() {}
   };
-  const sessionClass = VeilCocosSession as unknown as {
-    readStoredReplay: (roomId: string, playerId: string) => unknown;
-    create: (...args: unknown[]) => Promise<unknown>;
-  };
-  const originalReadStoredReplay = sessionClass.readStoredReplay;
-  const originalCreate = sessionClass.create;
 
   root.applyReplayedSessionUpdate = (update) => {
     order.push(`replay:${update.world.meta.day}`);
@@ -73,15 +71,12 @@ test("VeilRoot connect replays cached session state before applying the live sna
     root.lastUpdate = update;
   };
 
-  sessionClass.readStoredReplay = () => replayedUpdate;
-  sessionClass.create = async () => fakeSession;
+  installVeilRootRuntime({
+    readStoredReplay: () => replayedUpdate,
+    createSession: async () => fakeSession as never
+  });
 
-  try {
-    await root.connect();
-  } finally {
-    sessionClass.readStoredReplay = originalReadStoredReplay;
-    sessionClass.create = originalCreate;
-  }
+  await root.connect();
 
   assert.deepEqual(order, ["replay:2", "live:3"]);
   assert.equal(root.session, fakeSession);
@@ -118,18 +113,15 @@ test("VeilRoot hands control to a fresh session when starting a new run", async 
     handoffOrder.push(`query:${roomId}`);
   };
 
-  const sessionClass = VeilCocosSession as unknown as {
-    create: (...args: unknown[]) => Promise<unknown>;
-  };
-  const originalCreate = sessionClass.create;
   const originalDateNow = Date.now;
-  sessionClass.create = async () => freshSession;
+  installVeilRootRuntime({
+    createSession: async () => freshSession as never
+  });
   Date.now = () => 1234567890123;
 
   try {
     await root.startNewRun();
   } finally {
-    sessionClass.create = originalCreate;
     Date.now = originalDateNow;
   }
 
@@ -142,4 +134,91 @@ test("VeilRoot hands control to a fresh session when starting a new run", async 
     "apply:run-fr4nch",
     "dispose:previous"
   ]);
+});
+
+test("VeilRoot lobby handoff enters a room with the authenticated session and live snapshot", async () => {
+  const storage = createMemoryStorage();
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+
+  const root = createVeilRootHarness();
+  root.showLobby = true;
+  root.roomId = "room-bravo";
+  root.playerId = "guest-7";
+  root.displayName = "Guest 7";
+
+  const liveUpdate = createSessionUpdate(4, "room-bravo", "guest-7");
+  const fakeSession = {
+    async snapshot() {
+      return liveUpdate;
+    },
+    async dispose() {}
+  };
+  const queryUpdates: Array<string | null> = [];
+  root.syncBrowserRoomQuery = (roomId: string | null) => {
+    queryUpdates.push(roomId);
+  };
+
+  installVeilRootRuntime({
+    loginGuestAuthSession: async () => ({
+      token: "guest.token",
+      playerId: "guest-7",
+      displayName: "Guest 7",
+      authMode: "guest",
+      provider: "guest",
+      source: "remote"
+    }),
+    createSession: async () => fakeSession as never
+  });
+
+  await root.enterLobbyRoom();
+
+  assert.equal(root.showLobby, false);
+  assert.equal(root.session, fakeSession);
+  assert.equal(root.playerId, "guest-7");
+  assert.equal(root.authToken, "guest.token");
+  assert.equal(root.sessionSource, "remote");
+  assert.equal(root.lastUpdate?.world.meta.day, 4);
+  assert.deepEqual(queryUpdates, ["room-bravo"]);
+});
+
+test("VeilRoot keeps the lobby visible and explains when an account session has expired", async () => {
+  const storage = createMemoryStorage();
+  storage.setItem(
+    "project-veil:auth-session",
+    JSON.stringify({
+      token: "expired.token",
+      playerId: "account-player",
+      displayName: "暮潮守望",
+      authMode: "account",
+      provider: "account-password",
+      loginId: "veil-ranger",
+      source: "remote"
+    })
+  );
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+
+  const root = createVeilRootHarness();
+  root.showLobby = true;
+  root.roomId = "room-charlie";
+  root.playerId = "account-player";
+  root.displayName = "暮潮守望";
+  root.authMode = "account";
+  root.authToken = "expired.token";
+  root.authProvider = "account-password";
+  root.loginId = "veil-ranger";
+  root.sessionSource = "remote";
+
+  installVeilRootRuntime({
+    syncAuthSession: async () => null
+  });
+
+  await root.enterLobbyRoom();
+
+  assert.equal(root.showLobby, true);
+  assert.equal(root.session, null);
+  assert.equal(root.authToken, null);
+  assert.equal(root.authMode, "guest");
+  assert.equal(root.authProvider, "guest");
+  assert.equal(root.sessionSource, "none");
+  assert.equal(root.lobbyStatus, "账号会话已失效，请重新登录后再进入房间。");
 });

--- a/apps/cocos-client/test/helpers/veil-root-harness.ts
+++ b/apps/cocos-client/test/helpers/veil-root-harness.ts
@@ -1,4 +1,8 @@
-import { VeilRoot } from "../../assets/scripts/VeilRoot.ts";
+import {
+  resetVeilRootRuntimeForTests,
+  setVeilRootRuntimeForTests,
+  VeilRoot
+} from "../../assets/scripts/VeilRoot.ts";
 import type { SessionUpdate } from "../../assets/scripts/VeilCocosSession.ts";
 
 export function createVeilRootHarness(): VeilRoot & Record<string, unknown> {
@@ -27,4 +31,12 @@ export function createVeilRootHarness(): VeilRoot & Record<string, unknown> {
   root.refreshLobbyRoomList = async () => undefined;
   root.refreshLobbyAccountProfile = async () => undefined;
   return root;
+}
+
+export function installVeilRootRuntime(overrides: Parameters<typeof setVeilRootRuntimeForTests>[0]): void {
+  setVeilRootRuntimeForTests(overrides);
+}
+
+export function resetVeilRootRuntime(): void {
+  resetVeilRootRuntimeForTests();
 }


### PR DESCRIPTION
## Summary
- add a small VeilRoot test-runtime override layer so orchestration tests can inject session and lobby dependencies without real Cocos editor runtime
- switch the existing VeilRoot orchestration coverage to the new harness and keep the cached replay / new-run handoff coverage
- add lobby handoff and expired account-session failure coverage alongside the existing VeilCocosSession reconnect tests

## Verification
- node --import tsx --test ./apps/cocos-client/test/cocos-root-orchestration.test.ts ./apps/cocos-client/test/cocos-session-orchestration.test.ts
- npm run typecheck:cocos

Closes #246