### PR TITLE
feat: add unified H5 diagnostics summary slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ npm run dev:client:h5
 - H5 调试壳开发服务：`npm run dev:client:h5`
 - H5 调试壳构建验证：`npm run build:client:h5`
 - H5 调试壳类型检查：`npm run typecheck:client:h5`
+- H5 开发态诊断导出：
+  `window.export_diagnostic_snapshot()` 返回稳定 JSON；
+  `window.render_diagnostic_snapshot_to_text()` 返回与面板一致的紧凑文本摘要，便于自动化留档
 - H5 / Lobby Playwright 冒烟：`npm run test:e2e:smoke`
 - 多人联机 Playwright 冒烟：`npm run test:e2e:multiplayer:smoke`
 - GitHub Actions `playwright-smoke` 会执行上述两条冒烟回归，并在失败时上传 Playwright trace / screenshot / video 诊断材料

--- a/apps/client/src/main-boot.ts
+++ b/apps/client/src/main-boot.ts
@@ -74,11 +74,13 @@ interface RegisterAutomationHooksOptions {
   window: {
     render_game_to_text?: () => string;
     export_diagnostic_snapshot?: () => string;
+    render_diagnostic_snapshot_to_text?: () => string;
     advanceTime?: (ms: number) => Promise<void>;
   };
   devDiagnosticsEnabled: boolean;
   renderGameToText: () => string;
   exportDiagnosticSnapshot: () => string;
+  renderDiagnosticSnapshotToText: () => string;
   advanceUiTime: (ms: number) => Promise<void>;
 }
 
@@ -202,13 +204,16 @@ export function registerAutomationHooks({
   devDiagnosticsEnabled,
   renderGameToText,
   exportDiagnosticSnapshot,
+  renderDiagnosticSnapshotToText,
   advanceUiTime
 }: RegisterAutomationHooksOptions): void {
   window.render_game_to_text = renderGameToText;
   if (devDiagnosticsEnabled) {
     window.export_diagnostic_snapshot = exportDiagnosticSnapshot;
+    window.render_diagnostic_snapshot_to_text = renderDiagnosticSnapshotToText;
   } else {
     delete window.export_diagnostic_snapshot;
+    delete window.render_diagnostic_snapshot_to_text;
   }
   window.advanceTime = advanceUiTime;
 }

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,5 +1,6 @@
 import "./styles.css";
 import {
+  renderRuntimeDiagnosticsSnapshotText,
   createBattleReplayPlaybackState,
   createHeroSkillTreeView,
   createHeroAttributeBreakdown,
@@ -107,6 +108,7 @@ declare global {
   interface Window {
     render_game_to_text?: () => string;
     export_diagnostic_snapshot?: () => string;
+    render_diagnostic_snapshot_to_text?: () => string;
     advanceTime?: (ms: number) => Promise<void>;
   }
 }
@@ -423,6 +425,10 @@ function exportDiagnosticSnapshot(): string {
   return serializeRuntimeDiagnosticsSnapshot(buildDiagnosticSnapshot());
 }
 
+function renderDiagnosticSnapshotToText(): string {
+  return renderRuntimeDiagnosticsSnapshotText(buildDiagnosticSnapshot());
+}
+
 function sanitizeSnapshotFileSegment(value: string): string {
   const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
   return normalized || "unknown";
@@ -454,6 +460,7 @@ function renderDiagnosticPanel(): string {
   }
 
   const hero = activeHero();
+  const snapshotSummary = escapeHtml(renderDiagnosticSnapshotToText());
 
   return `
     <div class="log-panel diagnostics-panel" data-testid="diagnostic-panel">
@@ -486,6 +493,7 @@ function renderDiagnosticPanel(): string {
           <p class="muted">${escapeHtml(`${state.account.source} · replays ${state.account.recentBattleReplays.length} · events ${state.account.recentEventLog.length}`)}</p>
         </div>
       </div>
+      <pre class="diagnostics-summary" data-testid="diagnostic-summary">${snapshotSummary}</pre>
       <p class="muted diagnostics-export-status" data-testid="diagnostic-export-status">${escapeHtml(state.diagnostics.exportStatus)}</p>
     </div>
   `;
@@ -4778,10 +4786,11 @@ async function onBindAccountProfile(): Promise<void> {
 }
 
 void bootstrap();
-registerAutomationHooks({
-  window,
-  devDiagnosticsEnabled: DEV_DIAGNOSTICS_ENABLED,
-  renderGameToText,
-  exportDiagnosticSnapshot,
-  advanceUiTime
-});
+  registerAutomationHooks({
+    window,
+    devDiagnosticsEnabled: DEV_DIAGNOSTICS_ENABLED,
+    renderGameToText,
+    exportDiagnosticSnapshot,
+    renderDiagnosticSnapshotToText,
+    advanceUiTime
+  });

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -329,6 +329,18 @@ h1 {
   margin-top: 8px;
 }
 
+.diagnostics-summary {
+  margin: 0;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(78, 58, 42, 0.08);
+  background: rgba(255, 248, 239, 0.88);
+  color: #4f3f2f;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
 .account-card {
   margin-top: 14px;
   padding: 14px;

--- a/apps/client/test/main-boot.test.ts
+++ b/apps/client/test/main-boot.test.ts
@@ -340,9 +340,11 @@ test("registerAutomationHooks wires CI-facing automation helpers and only expose
   const prodWindow: {
     render_game_to_text?: () => string;
     export_diagnostic_snapshot?: () => string;
+    render_diagnostic_snapshot_to_text?: () => string;
     advanceTime?: (ms: number) => Promise<void>;
   } = {
-    export_diagnostic_snapshot: () => "stale"
+    export_diagnostic_snapshot: () => "stale",
+    render_diagnostic_snapshot_to_text: () => "stale-text"
   };
   const devWindow: typeof prodWindow = {};
 
@@ -351,6 +353,7 @@ test("registerAutomationHooks wires CI-facing automation helpers and only expose
     devDiagnosticsEnabled: false,
     renderGameToText: () => "rendered",
     exportDiagnosticSnapshot: () => "diagnostic",
+    renderDiagnosticSnapshotToText: () => "diagnostic-text",
     advanceUiTime: async (ms) => {
       assert.equal(ms, 16);
     }
@@ -360,12 +363,15 @@ test("registerAutomationHooks wires CI-facing automation helpers and only expose
     devDiagnosticsEnabled: true,
     renderGameToText: () => "rendered-dev",
     exportDiagnosticSnapshot: () => "diagnostic-dev",
+    renderDiagnosticSnapshotToText: () => "diagnostic-text-dev",
     advanceUiTime: async () => {}
   });
 
   assert.equal(prodWindow.render_game_to_text?.(), "rendered");
   assert.equal(prodWindow.export_diagnostic_snapshot, undefined);
+  assert.equal(prodWindow.render_diagnostic_snapshot_to_text, undefined);
   await assert.doesNotReject(async () => prodWindow.advanceTime?.(16));
   assert.equal(devWindow.render_game_to_text?.(), "rendered-dev");
   assert.equal(devWindow.export_diagnostic_snapshot?.(), "diagnostic-dev");
+  assert.equal(devWindow.render_diagnostic_snapshot_to_text?.(), "diagnostic-text-dev");
 });

--- a/apps/client/test/runtime-diagnostics.test.ts
+++ b/apps/client/test/runtime-diagnostics.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { serializeRuntimeDiagnosticsSnapshot, type PlayerBattleReplaySummary } from "../../../packages/shared/src/index";
+import {
+  renderRuntimeDiagnosticsSnapshotText,
+  serializeRuntimeDiagnosticsSnapshot,
+  type PlayerBattleReplaySummary
+} from "../../../packages/shared/src/index";
 import { buildH5RuntimeDiagnosticsSnapshot } from "../src/runtime-diagnostics";
 import type { PlayerAccountProfile } from "../src/player-account";
 
@@ -250,4 +254,9 @@ test("buildH5RuntimeDiagnosticsSnapshot creates a stable export payload for dev 
   assert.match(serialized, /"surface": "h5-debug-shell"/);
   assert.match(serialized, /"reachableTileCount": 2/);
   assert.match(serialized, /"predictionStatus": null/);
+
+  const summary = renderRuntimeDiagnosticsSnapshotText(snapshot);
+  assert.match(summary, /Room room-alpha \/ Player player-1 \/ Sync connected/);
+  assert.match(summary, /Resources gold=150 wood=10 ore=4/);
+  assert.match(summary, /Events battle.started, battle.resolved/);
 });

--- a/packages/shared/src/runtime-diagnostics.ts
+++ b/packages/shared/src/runtime-diagnostics.ts
@@ -116,6 +116,82 @@ export interface RuntimeDiagnosticsSnapshot {
   };
 }
 
+export function buildRuntimeDiagnosticsSummaryLines(snapshot: RuntimeDiagnosticsSnapshot): string[] {
+  const lines = [
+    `Mode ${snapshot.source.mode} (${snapshot.source.surface})`,
+    `Room ${snapshot.room.roomId} / Player ${snapshot.room.playerId} / Sync ${snapshot.room.connectionStatus}`
+  ];
+
+  if (snapshot.room.day != null) {
+    lines.push(`Day ${snapshot.room.day}`);
+  }
+
+  if (snapshot.room.lastUpdateSource || snapshot.room.lastUpdateReason || snapshot.room.lastUpdateAt) {
+    const updateParts = [
+      snapshot.room.lastUpdateSource ? `source=${snapshot.room.lastUpdateSource}` : null,
+      snapshot.room.lastUpdateReason ? `reason=${snapshot.room.lastUpdateReason}` : null,
+      snapshot.room.lastUpdateAt ? `at=${snapshot.room.lastUpdateAt}` : null
+    ].filter((value): value is string => value != null);
+
+    lines.push(`Last update ${updateParts.join(" / ")}`);
+  }
+
+  if (snapshot.world) {
+    lines.push(
+      `World ${snapshot.world.map.width}x${snapshot.world.map.height} / visible ${snapshot.world.map.visibleTileCount} / reachable ${snapshot.world.map.reachableTileCount}`
+    );
+    lines.push(
+      `Resources gold=${snapshot.world.resources.gold} wood=${snapshot.world.resources.wood} ore=${snapshot.world.resources.ore}`
+    );
+
+    if (snapshot.world.hero) {
+      lines.push(
+        `Hero ${snapshot.world.hero.name} @ ${snapshot.world.hero.position.x},${snapshot.world.hero.position.y} / MOV ${snapshot.world.hero.move.remaining}/${snapshot.world.hero.move.total} / HP ${snapshot.world.hero.stats.hp}/${snapshot.world.hero.stats.maxHp}`
+      );
+    }
+  }
+
+  if (snapshot.battle) {
+    lines.push(
+      `Battle ${snapshot.battle.id} / round ${snapshot.battle.round} / units ${snapshot.battle.unitCount} / environment ${snapshot.battle.environmentCount}`
+    );
+  }
+
+  lines.push(
+    `Account ${snapshot.account.displayName} (${snapshot.account.source}) / events ${snapshot.account.recentEventCount} / replays ${snapshot.account.recentReplayCount}`
+  );
+
+  if (snapshot.diagnostics.eventTypes.length > 0) {
+    lines.push(`Events ${snapshot.diagnostics.eventTypes.join(", ")}`);
+  }
+
+  if (snapshot.diagnostics.predictionStatus) {
+    lines.push(`Prediction ${snapshot.diagnostics.predictionStatus}`);
+  }
+
+  lines.push(`Pending UI tasks ${snapshot.diagnostics.pendingUiTasks}`);
+
+  if (snapshot.diagnostics.replay) {
+    lines.push(
+      `Replay ${snapshot.diagnostics.replay.replayId} / ${snapshot.diagnostics.replay.status} / step ${snapshot.diagnostics.replay.currentStepIndex}/${snapshot.diagnostics.replay.totalSteps}`
+    );
+  }
+
+  for (const entry of snapshot.diagnostics.timelineTail.slice(0, 3)) {
+    lines.push(`Timeline [${entry.source}/${entry.tone}] ${entry.text}`);
+  }
+
+  for (const line of snapshot.diagnostics.logTail.slice(0, 3)) {
+    lines.push(`Log ${line}`);
+  }
+
+  return lines;
+}
+
+export function renderRuntimeDiagnosticsSnapshotText(snapshot: RuntimeDiagnosticsSnapshot): string {
+  return buildRuntimeDiagnosticsSummaryLines(snapshot).join("\n");
+}
+
 export function serializeRuntimeDiagnosticsSnapshot(snapshot: RuntimeDiagnosticsSnapshot): string {
   return JSON.stringify(snapshot, null, 2);
 }

--- a/packages/shared/test/runtime-diagnostics.test.ts
+++ b/packages/shared/test/runtime-diagnostics.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildRuntimeDiagnosticsSummaryLines,
+  renderRuntimeDiagnosticsSnapshotText,
+  type RuntimeDiagnosticsSnapshot
+} from "../src/index";
+
+function createRuntimeDiagnosticsSnapshot(): RuntimeDiagnosticsSnapshot {
+  return {
+    schemaVersion: 1,
+    exportedAt: "2026-03-29T07:10:00.000Z",
+    source: {
+      surface: "h5-debug-shell",
+      devOnly: true,
+      mode: "world"
+    },
+    room: {
+      roomId: "room-alpha",
+      playerId: "player-1",
+      day: 3,
+      connectionStatus: "connected",
+      lastUpdateSource: "push",
+      lastUpdateReason: "battle.resolved",
+      lastUpdateAt: "2026-03-29T07:09:00.000Z"
+    },
+    world: {
+      map: {
+        width: 4,
+        height: 3,
+        visibleTileCount: 7,
+        reachableTileCount: 4
+      },
+      resources: {
+        gold: 150,
+        wood: 10,
+        ore: 4
+      },
+      selectedTile: { x: 0, y: 0 },
+      hoveredTile: { x: 1, y: 0 },
+      keyboardCursor: { x: 1, y: 0 },
+      hero: {
+        id: "hero-1",
+        name: "凯琳",
+        position: { x: 0, y: 0 },
+        move: { total: 6, remaining: 4 },
+        stats: {
+          attack: 2,
+          defense: 1,
+          power: 1,
+          knowledge: 0,
+          hp: 30,
+          maxHp: 30
+        },
+        armyTemplateId: "hero_guard_basic",
+        armyCount: 14,
+        progression: {
+          level: 2,
+          experience: 120,
+          skillPoints: 1,
+          battlesWon: 2,
+          neutralBattlesWon: 2,
+          pvpBattlesWon: 0
+        }
+      },
+      visibleHeroes: [{ id: "hero-2", playerId: "player-2", position: { x: 1, y: 0 } }]
+    },
+    battle: null,
+    account: {
+      playerId: "player-1",
+      displayName: "暮火侦骑",
+      source: "remote",
+      loginId: "player-1@example.com",
+      recentEventCount: 3,
+      recentReplayCount: 1
+    },
+    diagnostics: {
+      eventTypes: ["battle.started", "battle.resolved"],
+      timelineTail: [
+        {
+          id: "timeline-1",
+          tone: "battle",
+          source: "push",
+          text: "Room room-alpha finished battle battle-1"
+        }
+      ],
+      logTail: ["Room room-alpha connected", "Battle resolved"],
+      predictionStatus: "server-authoritative",
+      pendingUiTasks: 2,
+      replay: {
+        replayId: "room-alpha:battle-1:player-1",
+        loading: false,
+        status: "paused",
+        currentStepIndex: 1,
+        totalSteps: 3
+      }
+    }
+  };
+}
+
+test("runtime diagnostics summary text stays stable for panel and automation consumers", () => {
+  const snapshot = createRuntimeDiagnosticsSnapshot();
+
+  const lines = buildRuntimeDiagnosticsSummaryLines(snapshot);
+  assert.deepEqual(lines.slice(0, 4), [
+    "Mode world (h5-debug-shell)",
+    "Room room-alpha / Player player-1 / Sync connected",
+    "Day 3",
+    "Last update source=push / reason=battle.resolved / at=2026-03-29T07:09:00.000Z"
+  ]);
+
+  const rendered = renderRuntimeDiagnosticsSnapshotText(snapshot);
+  assert.match(rendered, /World 4x3 \/ visible 7 \/ reachable 4/);
+  assert.match(rendered, /Hero 凯琳 @ 0,0 \/ MOV 4\/6 \/ HP 30\/30/);
+  assert.match(rendered, /Account 暮火侦骑 \(remote\) \/ events 3 \/ replays 1/);
+  assert.match(rendered, /Replay room-alpha:battle-1:player-1 \/ paused \/ step 1\/3/);
+  assert.match(rendered, /Timeline \[push\/battle\] Room room-alpha finished battle battle-1/);
+});

--- a/tests/e2e/diagnostic-panel.spec.ts
+++ b/tests/e2e/diagnostic-panel.spec.ts
@@ -30,9 +30,12 @@ test("developer diagnostics panel exports a compact gameplay snapshot", async ({
   await expect(page.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
   await expect(page.getByTestId("diagnostic-panel")).toBeVisible();
   await expect(page.getByTestId("diagnostic-connection-status")).toHaveText("已连接");
+  await expect(page.getByTestId("diagnostic-summary")).toContainText(`Room ${roomId} / Player player-1 / Sync connected`);
 
   const exported = await page.evaluate(() => window.export_diagnostic_snapshot?.() ?? null);
   expect(exported).not.toBeNull();
+  const exportedText = await page.evaluate(() => window.render_diagnostic_snapshot_to_text?.() ?? null);
+  expect(exportedText).toContain(`Room ${roomId} / Player player-1 / Sync connected`);
 
   const snapshot = JSON.parse(exported!) as DiagnosticSnapshot;
   expect(snapshot.schemaVersion).toBe(1);


### PR DESCRIPTION
## Summary
- add a shared runtime diagnostics text formatter so the H5 panel, JSON export, and automation hooks use the same compact summary
- expose a dev-only `window.render_diagnostic_snapshot_to_text()` hook and render the shared summary inside the H5 diagnostics panel
- add shared/client coverage for the summary path and document the H5 diagnostics export hooks

## Validation
- `node --import tsx --test packages/shared/test/runtime-diagnostics.test.ts apps/client/test/runtime-diagnostics.test.ts apps/client/test/main-boot.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:client:h5`
- `npm run build:client:h5`
- `npx playwright test tests/e2e/diagnostic-panel.spec.ts` *(fails in this container because Chromium is missing `libatk-bridge-2.0.so.0`)*

Closes #254