### PR TITLE
feat: formalize cocos battle presentation

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilBattleTransition.ts
+++ b/apps/cocos-client/assets/scripts/VeilBattleTransition.ts
@@ -2,6 +2,11 @@ import { _decorator, Color, Component, Graphics, Label, Node, Sprite, Tween, UIO
 import { assignUiLayer } from "./cocos-ui-layer.ts";
 import type { BattleTransitionCopy } from "./cocos-battle-transition-copy.ts";
 import { getPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
+import {
+  getPlaceholderSpriteAssets,
+  releasePlaceholderSpriteAssets,
+  retainPlaceholderSpriteAssets
+} from "./cocos-placeholder-sprites.ts";
 
 const { ccclass, property } = _decorator;
 
@@ -37,11 +42,20 @@ export class VeilBattleTransition extends Component {
   private titleLabel: Label | null = null;
   private subtitleLabel: Label | null = null;
   private sequenceToken = 0;
+  private placeholderAssetsRetained = false;
 
   onLoad(): void {
     this.ensureOverlay();
+    void this.retainPlaceholderAssets();
     if (this.overlayNode) {
       this.overlayNode.active = false;
+    }
+  }
+
+  onDestroy(): void {
+    if (this.placeholderAssetsRetained) {
+      releasePlaceholderSpriteAssets("battle");
+      this.placeholderAssetsRetained = false;
     }
   }
 
@@ -256,7 +270,9 @@ export class VeilBattleTransition extends Component {
     const terrainFrame =
       copy.terrain === null
         ? null
-        : (getPixelSpriteAssets()?.tiles[copy.terrain].find((frame) => Boolean(frame)) ?? null);
+        : (getPixelSpriteAssets()?.tiles[copy.terrain].find((frame) => Boolean(frame))
+          ?? getPlaceholderSpriteAssets()?.tiles[copy.terrain][0]
+          ?? null);
     if (terrainNode) {
       terrainNode.active = Boolean(terrainFrame);
     }
@@ -273,6 +289,16 @@ export class VeilBattleTransition extends Component {
     subtitleTransform.setContentSize(hasTerrain ? panelTransform.width - 192 : panelTransform.width - 52, hasChips ? 40 : 48);
     this.titleLabel.node.setPosition(hasTerrain ? 38 : 0, 8, 1);
     this.subtitleLabel.node.setPosition(hasTerrain ? 42 : 0, hasChips ? -28 : -46, 1);
+  }
+
+  private async retainPlaceholderAssets(): Promise<void> {
+    if (this.placeholderAssetsRetained) {
+      return;
+    }
+    this.placeholderAssetsRetained = true;
+    await retainPlaceholderSpriteAssets("battle").catch(() => {
+      this.placeholderAssetsRetained = false;
+    });
   }
 
   private syncDetailChips(copy: BattleTransitionCopy): void {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -80,7 +80,7 @@ import { readStoredCocosAuthSession, resolveCocosLaunchIdentity, type CocosAuthP
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
 import { formatEquipmentActionReason, formatEquipmentSlotLabel } from "./cocos-hero-equipment.ts";
 import { type CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
-import { buildBattleActionPresentation, buildBattlePresentationPlan } from "./cocos-battle-presentation.ts";
+import { createCocosBattlePresentationController } from "./cocos-battle-presentation-controller.ts";
 import { createCocosAudioRuntime } from "./cocos-audio-runtime.ts";
 import { createCocosAudioAssetBridge } from "./cocos-audio-resources.ts";
 import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
@@ -225,6 +225,7 @@ export class VeilRoot extends Component {
   private wechatShareAvailable = false;
   private runtimeMemoryNotice = "";
   private stopRuntimeMemoryWarnings: (() => void) | null = null;
+  private battlePresentation = createCocosBattlePresentationController();
 
   onLoad(): void {
     this.audioRuntime.dispose();
@@ -825,7 +826,8 @@ export class VeilRoot extends Component {
       controlledCamp: this.controlledBattleCamp(),
       selectedTargetId: this.selectedBattleTargetId,
       actionPending: this.battleActionInFlight,
-      feedback: this.battleFeedback
+      feedback: this.battleFeedback,
+      presentationState: this.battlePresentation.getState()
     });
     this.timelinePanel?.render({
       entries: this.timelineEntries
@@ -2225,6 +2227,8 @@ export class VeilRoot extends Component {
     this.selectedBattleTargetId = null;
     this.moveInFlight = false;
     this.battleActionInFlight = false;
+    this.battleFeedback = null;
+    this.battlePresentation.reset();
     this.predictionStatus = "";
     this.inputDebug = "input waiting";
     this.timelineEntries = [];
@@ -2493,7 +2497,7 @@ export class VeilRoot extends Component {
     }
 
     this.battleActionInFlight = true;
-    const actionPresentation = buildBattleActionPresentation(action, this.lastUpdate?.battle ?? null);
+    const actionPresentation = this.battlePresentation.previewAction(action, this.lastUpdate?.battle ?? null);
     const skillName =
       action.type === "battle.skill"
         ? this.lastUpdate?.battle?.units[action.unitId]?.skills?.find((skill) => skill.id === action.skillId)?.name ?? action.skillId
@@ -2531,7 +2535,7 @@ export class VeilRoot extends Component {
   private async applySessionUpdate(update: SessionUpdate): Promise<void> {
     const previousBattle = this.lastUpdate?.battle ?? null;
     const heroId = this.activeHero()?.id ?? null;
-    const presentation = buildBattlePresentationPlan(previousBattle, update, heroId);
+    const presentation = this.battlePresentation.applyUpdate(previousBattle, update, heroId);
 
     this.pendingPrediction = null;
     this.predictionStatus = "";
@@ -2651,6 +2655,7 @@ export class VeilRoot extends Component {
       events: [],
       movementPlan: null
     };
+    this.battlePresentation.reset();
     this.renderView();
   }
 

--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -8,6 +8,13 @@ export interface CocosBattleFeedbackView {
   tone: CocosBattleFeedbackTone;
 }
 
+export interface BattleProgressAnalysis {
+  latestLog: string;
+  defeatedUnits: string[];
+  damagedUnits: string[];
+  skillTriggered: boolean;
+}
+
 export function buildBattleActionFeedback(
   action: BattleAction,
   battle: BattleState | null
@@ -94,6 +101,53 @@ export function buildBattleProgressFeedback(
   previousBattle: BattleState | null,
   nextBattle: BattleState | null
 ): CocosBattleFeedbackView | null {
+  const analysis = analyzeBattleProgress(previousBattle, nextBattle);
+  if (!analysis) {
+    return null;
+  }
+
+  if (analysis.defeatedUnits.length > 0) {
+    const primaryTarget = analysis.defeatedUnits[0];
+    return {
+      title: `${primaryTarget} 已被击倒`,
+      detail: analysis.latestLog || "单位已离场，战线出现缺口",
+      badge: "K.O.",
+      tone: "hit"
+    };
+  }
+
+  if (analysis.skillTriggered) {
+    return {
+      title: "主动技能已触发",
+      detail: analysis.latestLog || "技能进入结算阶段",
+      badge: "SKILL",
+      tone: "skill"
+    };
+  }
+
+  if (analysis.damagedUnits.length > 0) {
+    return {
+      title: `${analysis.damagedUnits[0]} 受到打击`,
+      detail: analysis.latestLog || "伤害已结算",
+      badge: "HIT",
+      tone: "hit"
+    };
+  }
+
+  return analysis.latestLog
+    ? {
+        title: "战斗状态更新",
+        detail: analysis.latestLog,
+        badge: "LOG",
+        tone: "neutral"
+      }
+    : null;
+}
+
+export function analyzeBattleProgress(
+  previousBattle: BattleState | null,
+  nextBattle: BattleState | null
+): BattleProgressAnalysis | null {
   if (!previousBattle || !nextBattle) {
     return null;
   }
@@ -119,41 +173,10 @@ export function buildBattleProgressFeedback(
     }
   }
 
-  if (defeatedUnits.length > 0) {
-    return {
-      title: `${defeatedUnits.join(" / ")} 溃散`,
-      detail: latestLog || "单位已被击倒",
-      badge: "K.O.",
-      tone: "hit"
-    };
-  }
-
-  if (latestLog.includes("施放")) {
-    return {
-      title: "技能已触发",
-      detail: latestLog,
-      badge: "SKILL",
-      tone: "skill"
-    };
-  }
-
-  if (damagedUnits.length > 0) {
-    return {
-      title: `${damagedUnits[0]} 受到打击`,
-      detail: latestLog || "伤害已结算",
-      badge: "HIT",
-      tone: "hit"
-    };
-  }
-
-  if (!latestLog) {
-    return null;
-  }
-
   return {
-    title: "战斗状态更新",
-    detail: latestLog,
-    badge: "LOG",
-    tone: "neutral"
+    latestLog,
+    defeatedUnits,
+    damagedUnits,
+    skillTriggered: latestLog.includes("施放")
   };
 }

--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -1,5 +1,6 @@
 import type { BattleAction, BattleState, SessionUpdate, TerrainType, Vec2 } from "./VeilCocosSession.ts";
 import type { CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
+import type { CocosBattlePresentationState } from "./cocos-battle-presentation-controller.ts";
 
 export type BattleCamp = "attacker" | "defender";
 
@@ -10,6 +11,7 @@ export interface BattlePanelInput {
   selectedTargetId: string | null;
   actionPending: boolean;
   feedback: CocosBattleFeedbackView | null;
+  presentationState: CocosBattlePresentationState | null;
 }
 
 export interface BattlePanelUnitView {
@@ -78,11 +80,14 @@ export interface BattlePanelSections {
 export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelViewModel {
   const battle = state.update?.battle;
   if (!battle) {
+    const presentationSummary = state.presentationState
+      ? [state.presentationState.label, state.presentationState.detail]
+      : ["当前没有战斗。"];
     return {
-      title: "战斗面板",
+      title: state.presentationState?.result ? "战斗结算" : "战斗面板",
       stage: null,
       feedback: state.feedback,
-      summaryLines: ["当前没有战斗。"],
+      summaryLines: presentationSummary,
       orderLines: [],
       friendlyLines: [],
       orderItems: [],
@@ -168,6 +173,7 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
     feedback: state.feedback,
     summaryLines: [
       `${battle.id} · 第 ${battle.round} 回合`,
+      `流程：${state.presentationState?.label ?? "战斗进行中"}`,
       `阵营：${controlLabel}`,
       `阶段：${turnLabel}`,
       `行动单位：${activeUnit ? formatActiveUnitLine(activeUnit) : "等待中"}`,

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation-controller.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation-controller.ts
@@ -1,0 +1,60 @@
+import type { CocosBattleFeedbackTone } from "./project-shared/index.ts";
+import type { BattleAction, BattleState, SessionUpdate } from "./VeilCocosSession.ts";
+import {
+  buildBattleActionPresentation,
+  buildBattlePresentationPlan,
+  type CocosBattlePresentationMoment,
+  type CocosBattlePresentationPlan
+} from "./cocos-battle-presentation.ts";
+
+export interface CocosBattlePresentationState {
+  battleId: string | null;
+  phase: CocosBattlePresentationPlan["phase"];
+  moment: CocosBattlePresentationMoment;
+  label: string;
+  detail: string;
+  badge: string;
+  tone: CocosBattleFeedbackTone;
+  result: "victory" | "defeat" | null;
+}
+
+export interface CocosBattlePresentationController {
+  previewAction(action: BattleAction, battle: BattleState | null): CocosBattlePresentationPlan;
+  applyUpdate(previousBattle: BattleState | null, update: SessionUpdate, heroId: string | null): CocosBattlePresentationPlan;
+  getState(): CocosBattlePresentationState;
+  reset(): void;
+}
+
+const IDLE_STATE: CocosBattlePresentationState = {
+  battleId: null,
+  phase: "idle",
+  moment: "idle",
+  label: "等待战斗",
+  detail: "当前没有战斗。",
+  badge: "IDLE",
+  tone: "neutral",
+  result: null
+};
+
+export function createCocosBattlePresentationController(): CocosBattlePresentationController {
+  let state = IDLE_STATE;
+
+  return {
+    previewAction(action, battle) {
+      const plan = buildBattleActionPresentation(action, battle);
+      state = plan.state;
+      return plan;
+    },
+    applyUpdate(previousBattle, update, heroId) {
+      const plan = buildBattlePresentationPlan(previousBattle, update, heroId);
+      state = plan.state;
+      return plan;
+    },
+    getState() {
+      return state;
+    },
+    reset() {
+      state = IDLE_STATE;
+    }
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
@@ -2,14 +2,29 @@ import type { CocosAudioCue } from "./cocos-presentation-config.ts";
 import type { BattleAction, BattleState, SessionUpdate } from "./VeilCocosSession.ts";
 import { buildBattleEnterCopy, buildBattleExitCopy, type BattleTransitionCopy } from "./cocos-battle-transition-copy.ts";
 import {
+  analyzeBattleProgress,
   buildBattleActionFeedback,
   buildBattleProgressFeedback,
   buildBattleTransitionFeedback,
   type CocosBattleFeedbackView
 } from "./cocos-battle-feedback.ts";
+import type { CocosBattlePresentationState } from "./cocos-battle-presentation-controller.ts";
 
 export type CocosBattlePresentationPhase = "idle" | "command" | "enter" | "impact" | "active" | "resolution";
 export type CocosBattlePresentationAnimation = "idle" | "attack" | "hit" | "victory" | "defeat";
+export type CocosBattlePresentationMoment =
+  | "idle"
+  | "battle_enter"
+  | "command_attack"
+  | "command_skill"
+  | "command_guard"
+  | "command_wait"
+  | "impact_hit"
+  | "impact_death"
+  | "active_skill"
+  | "active"
+  | "result_victory"
+  | "result_defeat";
 
 export interface CocosBattlePresentationTransition {
   kind: "enter" | "exit";
@@ -23,6 +38,8 @@ export interface CocosBattlePresentationPlan {
   cue: CocosAudioCue | null;
   animation: CocosBattlePresentationAnimation;
   transition: CocosBattlePresentationTransition | null;
+  moment: CocosBattlePresentationMoment;
+  state: CocosBattlePresentationState;
 }
 
 const RESOLUTION_FEEDBACK_DURATION_MS = 4200;
@@ -31,16 +48,27 @@ export function buildBattleActionPresentation(
   action: BattleAction,
   battle: BattleState | null
 ): CocosBattlePresentationPlan {
+  const feedback = buildBattleActionFeedback(action, battle);
+  const moment =
+    action.type === "battle.attack"
+      ? "command_attack"
+      : action.type === "battle.skill"
+        ? "command_skill"
+        : action.type === "battle.defend"
+          ? "command_guard"
+          : "command_wait";
   return {
     phase: "command",
-    feedback: buildBattleActionFeedback(action, battle),
+    feedback,
     feedbackDurationMs: null,
     cue: action.type === "battle.attack" ? "attack" : action.type === "battle.skill" ? "skill" : null,
     animation:
       action.type === "battle.attack" || (action.type === "battle.skill" && action.targetId && action.targetId !== action.unitId)
         ? "attack"
         : "idle",
-    transition: null
+    transition: null,
+    moment,
+    state: buildPresentationState("command", moment, battle?.id ?? null, feedback, null)
   };
 }
 
@@ -52,43 +80,61 @@ export function buildBattlePresentationPlan(
   const nextBattle = update.battle ?? null;
 
   if (!previousBattle && nextBattle) {
+    const feedback = buildBattleTransitionFeedback(update, heroId);
     return {
       phase: "enter",
-      feedback: buildBattleTransitionFeedback(update, heroId),
+      feedback,
       feedbackDurationMs: null,
       cue: null,
       animation: "attack",
       transition: {
         kind: "enter",
         copy: buildBattleEnterCopy(update)
-      }
+      },
+      moment: "battle_enter",
+      state: buildPresentationState("enter", "battle_enter", nextBattle.id, feedback, null)
     };
   }
 
   if (previousBattle && !nextBattle) {
     const didWin = resolveBattleResolution(update, heroId);
+    const feedback = buildBattleTransitionFeedback(update, heroId);
+    const result = didWin === null ? null : didWin ? "victory" : "defeat";
+    const moment = didWin ? "result_victory" : "result_defeat";
     return {
       phase: "resolution",
-      feedback: buildBattleTransitionFeedback(update, heroId),
+      feedback,
       feedbackDurationMs: RESOLUTION_FEEDBACK_DURATION_MS,
       cue: didWin === null ? null : didWin ? "victory" : "defeat",
       animation: didWin === null ? "idle" : didWin ? "victory" : "defeat",
       transition: {
         kind: "exit",
         copy: buildBattleExitCopy(previousBattle, update, didWin ?? false)
-      }
+      },
+      moment,
+      state: buildPresentationState("resolution", moment, previousBattle.id, feedback, result)
     };
   }
 
   if (previousBattle && nextBattle) {
+    const analysis = analyzeBattleProgress(previousBattle, nextBattle);
     const impactDetected = detectBattleImpact(previousBattle, nextBattle);
+    const defeatedUnitDetected = Boolean(analysis && analysis.defeatedUnits.length > 0);
+    const skillDetected = Boolean(analysis?.skillTriggered);
+    const moment = defeatedUnitDetected ? "impact_death" : impactDetected ? "impact_hit" : skillDetected ? "active_skill" : "active";
+    const phase = defeatedUnitDetected || impactDetected ? "impact" : "active";
+    const cue = defeatedUnitDetected || impactDetected ? "hit" : skillDetected ? "skill" : null;
+    const animation = defeatedUnitDetected || impactDetected ? "hit" : "idle";
+    const feedback = buildBattleProgressFeedback(previousBattle, nextBattle);
     return {
-      phase: impactDetected ? "impact" : "active",
-      feedback: buildBattleProgressFeedback(previousBattle, nextBattle),
+      phase,
+      feedback,
       feedbackDurationMs: null,
-      cue: impactDetected ? "hit" : null,
-      animation: impactDetected ? "hit" : "idle",
-      transition: null
+      cue,
+      animation,
+      transition: null,
+      moment,
+      state: buildPresentationState(phase, moment, nextBattle.id, feedback, null)
     };
   }
 
@@ -98,7 +144,9 @@ export function buildBattlePresentationPlan(
     feedbackDurationMs: null,
     cue: null,
     animation: "idle",
-    transition: null
+    transition: null,
+    moment: "idle",
+    state: buildPresentationState("idle", "idle", null, null, null)
   };
 }
 
@@ -132,4 +180,63 @@ function detectBattleImpact(previousBattle: BattleState, nextBattle: BattleState
   }
 
   return false;
+}
+
+function buildPresentationState(
+  phase: CocosBattlePresentationPhase,
+  moment: CocosBattlePresentationMoment,
+  battleId: string | null,
+  feedback: CocosBattleFeedbackView | null,
+  result: CocosBattlePresentationState["result"]
+): CocosBattlePresentationState {
+  if (!feedback) {
+    return {
+      battleId,
+      phase,
+      moment,
+      label: phase === "idle" ? "等待战斗" : "战斗进行中",
+      detail: phase === "idle" ? "当前没有战斗。" : "等待新的战斗反馈。",
+      badge: phase === "idle" ? "IDLE" : "LIVE",
+      tone: phase === "idle" ? "neutral" : "action",
+      result
+    };
+  }
+
+  return {
+    battleId,
+    phase,
+    moment,
+    label: resolvePresentationLabel(moment, feedback.title),
+    detail: feedback.detail,
+    badge: feedback.badge,
+    tone: feedback.tone,
+    result
+  };
+}
+
+function resolvePresentationLabel(moment: CocosBattlePresentationMoment, fallback: string): string {
+  switch (moment) {
+    case "battle_enter":
+      return "战斗展开";
+    case "command_attack":
+      return "普通攻击";
+    case "command_skill":
+      return "主动技能";
+    case "command_guard":
+      return "防御指令";
+    case "command_wait":
+      return "等待指令";
+    case "impact_hit":
+      return "命中反馈";
+    case "impact_death":
+      return "单位击倒";
+    case "active_skill":
+      return "技能结算";
+    case "result_victory":
+      return "战斗胜利";
+    case "result_defeat":
+      return "战斗失利";
+    default:
+      return fallback;
+  }
 }

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -82,7 +82,8 @@ test("buildBattlePanelViewModel keeps idle summary focused on battle state", () 
     controlledCamp: null,
     selectedTargetId: null,
     actionPending: false,
-    feedback: null
+    feedback: null,
+    presentationState: null
   });
 
   assert.equal(view.idle, true);
@@ -193,7 +194,8 @@ test("buildBattlePanelViewModel enables attack actions on the player's turn", ()
     controlledCamp: "attacker",
     selectedTargetId: "neutral-1-stack",
     actionPending: false,
-    feedback: null
+    feedback: null,
+    presentationState: null
   });
 
   assert.equal(view.idle, false);
@@ -203,10 +205,11 @@ test("buildBattlePanelViewModel enables attack actions on the player's turn", ()
     subtitle: "坐标 (0,0) · 1 陷阱",
     badge: "PVE"
   });
-  assert.equal(view.summaryLines[2], "阶段：轮到我方");
-  assert.equal(view.summaryLines[4], "技能1：投矛射击[敌/就绪] / 护甲术[自/就绪]");
-  assert.equal(view.summaryLines[5], "状态：无异常");
-  assert.equal(view.summaryLines[6], "环境1：1线 捕兽夹陷阱 · 2伤 · 1次");
+  assert.equal(view.summaryLines[2], "阵营：我方先攻");
+  assert.equal(view.summaryLines[3], "阶段：轮到我方");
+  assert.equal(view.summaryLines[5], "技能1：投矛射击[敌/就绪] / 护甲术[自/就绪]");
+  assert.equal(view.summaryLines[6], "状态：无异常");
+  assert.equal(view.summaryLines[7], "环境1：1线 捕兽夹陷阱 · 2伤 · 1次");
   assert.equal(view.orderLines[0], "行动顺序");
   assert.equal(view.orderLines[1], "> Guard x12");
   assert.equal(view.orderLines[2], "2. Orc x8 (DEF/RET)");
@@ -319,7 +322,8 @@ test("buildBattlePanelViewModel disables commands during enemy turns", () => {
     controlledCamp: "attacker",
     selectedTargetId: "hero-2-stack",
     actionPending: false,
-    feedback: null
+    feedback: null,
+    presentationState: null
   });
 
   assert.deepEqual(view.stage, {
@@ -328,9 +332,10 @@ test("buildBattlePanelViewModel disables commands during enemy turns", () => {
     subtitle: "坐标 (0,0) · 无额外障碍",
     badge: "PVP"
   });
-  assert.equal(view.summaryLines[2], "阶段：轮到对方");
-  assert.equal(view.summaryLines[4], "技能：普通攻击");
-  assert.equal(view.summaryLines[5], "状态：无异常");
+  assert.equal(view.summaryLines[2], "阵营：我方先攻");
+  assert.equal(view.summaryLines[3], "阶段：轮到对方");
+  assert.equal(view.summaryLines[5], "技能：普通攻击");
+  assert.equal(view.summaryLines[6], "状态：无异常");
   assert.equal(view.orderLines[1], "> Raider x11");
   assert.equal(view.orderItems[0]!.badge, "行动中");
   assert.equal(view.orderItems[1]!.badge, "2");
@@ -453,7 +458,8 @@ test("buildBattlePanelViewModel hides unrevealed traps and disables skills while
     controlledCamp: "attacker",
     selectedTargetId: "neutral-1-stack",
     actionPending: false,
-    feedback: null
+    feedback: null,
+    presentationState: null
   });
 
   assert.equal(view.summaryLines.includes("环境：当前战场没有额外障碍或陷阱"), false);
@@ -569,7 +575,8 @@ test("buildBattlePanelViewModel derives stage terrain from encounter position an
     controlledCamp: "attacker",
     selectedTargetId: "neutral-2-stack",
     actionPending: false,
-    feedback: null
+    feedback: null,
+    presentationState: null
   });
 
   assert.deepEqual(view.stage, {

--- a/apps/cocos-client/test/cocos-battle-panel.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel.test.ts
@@ -131,7 +131,8 @@ test("buildBattlePanelSections groups ally, enemy and queue rows from a battle s
     controlledCamp: "attacker",
     selectedTargetId: "neutral-1-stack",
     actionPending: false,
-    feedback: null
+    feedback: null,
+    presentationState: null
   });
 
   assert.equal(sections.idle, false);
@@ -148,7 +149,8 @@ test("battle panel stage banner derives the PVE terrain title from the encounter
     controlledCamp: "attacker",
     selectedTargetId: null,
     actionPending: false,
-    feedback: null
+    feedback: null,
+    presentationState: null
   });
 
   assert.deepEqual(sections.stage, {
@@ -171,7 +173,8 @@ test("battle panel actions disable when it is not the controlled camp's turn", (
     controlledCamp: "attacker",
     selectedTargetId: "neutral-1-stack",
     actionPending: false,
-    feedback: null
+    feedback: null,
+    presentationState: null
   });
 
   assert.equal(sections.actions.every((action) => action.enabled === false), true);

--- a/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
+++ b/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createCocosBattlePresentationController,
+  type CocosBattlePresentationState
+} from "../assets/scripts/cocos-battle-presentation-controller.ts";
+import type { BattleState, SessionUpdate } from "../assets/scripts/VeilCocosSession.ts";
+
+function createBattleState(): BattleState {
+  return {
+    id: "battle-1",
+    round: 1,
+    lanes: 1,
+    activeUnitId: "hero-1-stack",
+    turnOrder: ["hero-1-stack", "neutral-1-stack"],
+    units: {
+      "hero-1-stack": {
+        id: "hero-1-stack",
+        templateId: "hero_guard_basic",
+        camp: "attacker",
+        lane: 0,
+        stackName: "Guard",
+        initiative: 7,
+        attack: 4,
+        defense: 4,
+        minDamage: 1,
+        maxDamage: 2,
+        count: 12,
+        currentHp: 10,
+        maxHp: 10,
+        hasRetaliated: false,
+        defending: false,
+        skills: [
+          {
+            id: "power_shot",
+            name: "投矛射击",
+            description: "远程压制",
+            kind: "active",
+            target: "enemy",
+            delivery: "ranged",
+            cooldown: 2,
+            remainingCooldown: 0
+          }
+        ],
+        statusEffects: []
+      },
+      "neutral-1-stack": {
+        id: "neutral-1-stack",
+        templateId: "orc_warrior",
+        camp: "defender",
+        lane: 0,
+        stackName: "Orc",
+        initiative: 5,
+        attack: 3,
+        defense: 3,
+        minDamage: 1,
+        maxDamage: 3,
+        count: 8,
+        currentHp: 9,
+        maxHp: 9,
+        hasRetaliated: false,
+        defending: false,
+        skills: [],
+        statusEffects: []
+      }
+    },
+    environment: [],
+    log: ["战斗开始"],
+    rng: { seed: 1, cursor: 0 },
+    worldHeroId: "hero-1",
+    neutralArmyId: "neutral-1",
+    encounterPosition: { x: 1, y: 1 }
+  };
+}
+
+function createUpdate(battle: BattleState | null, events: SessionUpdate["events"] = []): SessionUpdate {
+  return {
+    world: {
+      meta: {
+        roomId: "room-alpha",
+        seed: 1001,
+        day: 1
+      },
+      map: {
+        width: 1,
+        height: 1,
+        tiles: [
+          {
+            position: { x: 1, y: 1 },
+            fog: "visible",
+            terrain: "grass",
+            walkable: true,
+            resource: undefined,
+            occupant: undefined,
+            building: undefined
+          }
+        ]
+      },
+      ownHeroes: [
+        {
+          id: "hero-1",
+          playerId: "player-1",
+          name: "Katherine",
+          position: { x: 1, y: 1 },
+          vision: 4,
+          move: { total: 6, remaining: 6 },
+          stats: {
+            attack: 2,
+            defense: 2,
+            power: 1,
+            knowledge: 1,
+            hp: 30,
+            maxHp: 30
+          },
+          progression: {
+            level: 1,
+            experience: 0,
+            skillPoints: 0,
+            battlesWon: 0,
+            neutralBattlesWon: 0,
+            pvpBattlesWon: 0
+          },
+          loadout: {
+            learnedSkills: [],
+            equipment: {
+              trinketIds: []
+            },
+            inventory: []
+          },
+          armyCount: 12,
+          armyTemplateId: "hero_guard_basic",
+          learnedSkills: []
+        }
+      ],
+      visibleHeroes: [],
+      resources: {
+        gold: 0,
+        wood: 0,
+        ore: 0
+      },
+      playerId: "player-1"
+    },
+    battle,
+    events,
+    movementPlan: null,
+    reachableTiles: []
+  };
+}
+
+function assertState(state: CocosBattlePresentationState, expected: Partial<CocosBattlePresentationState>): void {
+  for (const [key, value] of Object.entries(expected)) {
+    assert.deepEqual(state[key as keyof CocosBattlePresentationState], value);
+  }
+}
+
+test("battle presentation controller formalizes command, casualty, and result flow", () => {
+  const controller = createCocosBattlePresentationController();
+  const battle = createBattleState();
+
+  controller.applyUpdate(
+    null,
+    createUpdate(battle, [
+      {
+        type: "battle.started",
+        heroId: "hero-1",
+        encounterKind: "neutral",
+        neutralArmyId: "neutral-1",
+        initiator: "hero",
+        battleId: "battle-1",
+        path: [{ x: 1, y: 1 }],
+        moveCost: 1
+      }
+    ]),
+    "hero-1"
+  );
+  assertState(controller.getState(), {
+    phase: "enter",
+    moment: "battle_enter",
+    label: "战斗展开",
+    badge: "ENGAGE"
+  });
+
+  controller.previewAction(
+    {
+      type: "battle.skill",
+      unitId: "hero-1-stack",
+      skillId: "power_shot",
+      targetId: "neutral-1-stack"
+    },
+    battle
+  );
+  assertState(controller.getState(), {
+    phase: "command",
+    moment: "command_skill",
+    tone: "skill",
+    badge: "SKILL"
+  });
+
+  controller.applyUpdate(
+    battle,
+    createUpdate({
+      ...battle,
+      units: {
+        ...battle.units,
+        "neutral-1-stack": {
+          ...battle.units["neutral-1-stack"]!,
+          count: 0,
+          currentHp: 0
+        }
+      },
+      log: battle.log.concat("Guard 施放 投矛射击，Orc 被击倒")
+    }),
+    "hero-1"
+  );
+  assertState(controller.getState(), {
+    phase: "impact",
+    moment: "impact_death",
+    label: "单位击倒",
+    tone: "hit"
+  });
+  assert.match(controller.getState().detail, /Orc/);
+
+  controller.applyUpdate(
+    battle,
+    createUpdate(null, [
+      {
+        type: "battle.resolved",
+        battleId: "battle-1",
+        battleKind: "neutral",
+        heroId: "hero-1",
+        result: "attacker_victory",
+        resourcesGained: {
+          gold: 0,
+          wood: 0,
+          ore: 0
+        },
+        experienceGained: 10,
+        skillPointsAwarded: 0
+      }
+    ]),
+    "hero-1"
+  );
+  assertState(controller.getState(), {
+    phase: "resolution",
+    moment: "result_victory",
+    label: "战斗胜利",
+    tone: "victory",
+    result: "victory"
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable Cocos battle presentation/result-flow controller and wire it through VeilRoot
- formalize command, hit, death, and victory/defeat feedback in the battle panel and transition flow
- keep battle transitions usable with placeholder terrain fallbacks and cover the flow with focused battle presentation tests

## Verification
- node --import tsx --test apps/cocos-client/test/cocos-battle-feedback.test.ts apps/cocos-client/test/cocos-battle-panel.test.ts apps/cocos-client/test/cocos-battle-panel-model.test.ts apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
- npm run typecheck:cocos

Closes #252