### PR TITLE
feat: polish multiplayer encounter recovery feedback

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -79,7 +79,7 @@ import {
   renderBattleReportReplayCenter,
   renderRecentAccountEvents
 } from "./account-history";
-import { renderEncounterSourceDetail, renderRoomActionHint, resolveRoomFeedbackTone } from "./room-feedback";
+import { renderEncounterSourceDetail, renderRecoverySummary, renderRoomActionHint, resolveRoomFeedbackTone } from "./room-feedback";
 
 const params = new URLSearchParams(window.location.search);
 const queryRoomId = params.get("roomId")?.trim() ?? "";
@@ -149,6 +149,7 @@ interface DiagnosticState {
   lastUpdateReason: string | null;
   lastEventTypes: string[];
   exportStatus: string;
+  recoverySummary: string | null;
 }
 
 interface LobbyViewState {
@@ -298,7 +299,8 @@ const state: AppState = {
     lastUpdateSource: null,
     lastUpdateReason: null,
     lastEventTypes: [],
-    exportStatus: "等待导出诊断快照"
+    exportStatus: "等待导出诊断快照",
+    recoverySummary: null
   }
 };
 
@@ -335,6 +337,12 @@ let sessionPromise: ReturnType<typeof createGameSession> | null = shouldBootGame
       onConnectionEvent: (event) => {
         state.diagnostics.connectionStatus =
           event === "reconnecting" ? "reconnecting" : event === "reconnect_failed" ? "reconnect_failed" : "connected";
+        state.diagnostics.recoverySummary =
+          event === "reconnecting"
+            ? "连接暂时中断，正在尝试重新加入房间。"
+            : event === "reconnected"
+              ? "连接已恢复，正在用最新房间状态校正地图与战斗结果。"
+              : "旧连接未恢复，正在改用持久化快照补救当前房间状态。";
         state.log.unshift(
           event === "reconnecting"
             ? "连接中断，正在尝试重连..."
@@ -405,6 +413,7 @@ function buildDiagnosticSnapshot() {
         text: entry.text
       })),
       logTail: state.log.slice(0, 8),
+      recoverySummary: state.diagnostics.recoverySummary,
       predictionStatus: state.predictionStatus,
       pendingUiTasks: scheduledUiTasks.filter((task) => !task.canceled).length,
       replay:
@@ -2205,6 +2214,7 @@ function applyReplayedUpdate(update: SessionUpdate): void {
     state.lastEncounterStarted = replayStarted;
   }
   state.predictionStatus = "已回放本地缓存状态，正在等待房间同步...";
+  state.diagnostics.recoverySummary = "已回放本地缓存状态，等待权威房间同步完成最终校正。";
   state.log.unshift("已从本地缓存回放最近房间状态");
   state.log = state.log.slice(0, 12);
   pushTimeline([
@@ -2542,6 +2552,9 @@ function extractDamageText(lines: string[]): string | null {
 }
 
 function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "local"): void {
+  const previousConnectionStatus = state.diagnostics.connectionStatus;
+  const previousRecoverySummary = state.diagnostics.recoverySummary;
+  const previousPredictionStatus = state.predictionStatus;
   clearPendingPrediction();
   const hadBattle = Boolean(state.battle);
   const previousBattle = state.battle;
@@ -2647,6 +2660,20 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
     )
   ) {
     void refreshAccountProfileFromServer();
+  }
+
+  const recoveredFromFallback =
+    previousConnectionStatus === "reconnecting" ||
+    previousConnectionStatus === "reconnect_failed" ||
+    previousPredictionStatus.includes("已回放本地缓存状态");
+  if (recoveredFromFallback) {
+    state.diagnostics.recoverySummary = update.battle
+      ? "权威战斗状态已恢复，当前行动顺序与房间归属重新对齐。"
+      : state.lastBattleSettlement
+        ? "权威房间状态已恢复，战后结果与地图状态已经重新对齐。"
+        : "权威房间状态已恢复，当前地图探索状态已经重新对齐。";
+  } else if (source === "local" && previousRecoverySummary && !update.reason) {
+    state.diagnostics.recoverySummary = null;
   }
 
   syncKeyboardCursor();
@@ -3575,6 +3602,12 @@ function renderRoomStatusPanel(): string {
         lastEncounterStarted: state.lastEncounterStarted,
         world: state.world,
         previewPlan: state.previewPlan,
+        lastBattleSettlement: state.lastBattleSettlement,
+        diagnostics: state.diagnostics,
+        predictionStatus: state.predictionStatus
+      })}</p>
+      <p class="muted" data-testid="room-recovery-summary" data-tone="${roomFeedbackTone}">${renderRecoverySummary({
+        battle: state.battle,
         lastBattleSettlement: state.lastBattleSettlement,
         diagnostics: state.diagnostics,
         predictionStatus: state.predictionStatus

--- a/apps/client/src/room-feedback.ts
+++ b/apps/client/src/room-feedback.ts
@@ -8,6 +8,7 @@ interface BattleSettlementSummaryLike {
 
 interface DiagnosticStateLike {
   connectionStatus: "connecting" | "connected" | "reconnecting" | "reconnect_failed";
+  recoverySummary?: string | null;
 }
 
 type EncounterStartedEvent = Extract<SessionUpdate["events"][number], { type: "battle.started" }>;
@@ -36,6 +37,7 @@ export interface AppState {
   previewPlan: MovementPlan | null;
   lastBattleSettlement: (BattleSettlementSummaryLike & { tone?: CocosBattleFeedbackTone }) | null;
   diagnostics: DiagnosticStateLike;
+  predictionStatus?: string;
 }
 
 function ownedHeroIds(world: PlayerWorldView): Set<string> {
@@ -131,4 +133,35 @@ export function renderRoomActionHint(input: RoomActionHintInput): string {
   return input.activeHero.move.remaining > 0
     ? "下一步：选择地图格继续探索；若接敌，将自动切入对抗。"
     : "下一步：当前英雄今日已无移动力，可推进到下一天。";
+}
+
+export function renderRecoverySummary(input: {
+  battle: BattleState | null;
+  lastBattleSettlement: BattleSettlementSummaryLike | null;
+  diagnostics: DiagnosticStateLike;
+  predictionStatus: string;
+}): string {
+  if (input.diagnostics.connectionStatus === "reconnecting") {
+    return "恢复状态：正在重新加入多人房间并校正战斗归属，结果请以恢复后的权威状态为准。";
+  }
+
+  if (input.diagnostics.connectionStatus === "reconnect_failed") {
+    return "恢复状态：旧连接恢复失败，已切换到快照回补链路；当前先展示最近缓存与回补进度。";
+  }
+
+  if (input.predictionStatus.includes("已回放本地缓存状态")) {
+    return `恢复状态：${input.predictionStatus}`;
+  }
+
+  if (input.diagnostics.recoverySummary) {
+    return `恢复状态：${input.diagnostics.recoverySummary}`;
+  }
+
+  if (input.lastBattleSettlement) {
+    return input.battle
+      ? "恢复状态：战后房间仍在切换阶段，等待当前战斗链路完全关闭。"
+      : "恢复状态：最近一场遭遇的结算与地图房间态已经重新对齐。";
+  }
+
+  return "恢复状态：当前未触发重连补救，房间同步保持稳定。";
 }

--- a/apps/client/src/runtime-diagnostics.ts
+++ b/apps/client/src/runtime-diagnostics.ts
@@ -54,6 +54,7 @@ export interface H5RuntimeDiagnosticsSnapshotInput {
     eventTypes: string[];
     timelineTail: TimelineEntrySnapshot[];
     logTail: string[];
+    recoverySummary: string | null;
     predictionStatus: string;
     pendingUiTasks: number;
     replay: ReplaySnapshotInput | null;
@@ -151,6 +152,7 @@ export function buildH5RuntimeDiagnosticsSnapshot(
         text: entry.text
       })),
       logTail: [...input.diagnostics.logTail],
+      recoverySummary: input.diagnostics.recoverySummary || null,
       predictionStatus: input.diagnostics.predictionStatus || null,
       pendingUiTasks: input.diagnostics.pendingUiTasks,
       replay: input.diagnostics.replay ? { ...input.diagnostics.replay } : null

--- a/apps/client/test/room-feedback.test.ts
+++ b/apps/client/test/room-feedback.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { BattleState, MovementPlan, PlayerWorldView } from "../../../packages/shared/src/index";
 import type { SessionUpdate } from "../src/local-session";
-import { renderEncounterSourceDetail, renderRoomActionHint, resolveRoomFeedbackTone } from "../src/room-feedback";
+import { renderEncounterSourceDetail, renderRecoverySummary, renderRoomActionHint, resolveRoomFeedbackTone } from "../src/room-feedback";
 
 type EncounterStartedEvent = Extract<SessionUpdate["events"][number], { type: "battle.started" }>;
 
@@ -407,6 +407,71 @@ test("renderRoomActionHint covers settlement and exploration move branches", () 
       predictionStatus: ""
     }),
     "下一步：当前英雄今日已无移动力，可推进到下一天。"
+  );
+});
+
+test("renderRecoverySummary covers reconnect, replay fallback, explicit recovery, and steady state branches", () => {
+  assert.equal(
+    renderRecoverySummary({
+      battle: null,
+      lastBattleSettlement: null,
+      diagnostics: {
+        connectionStatus: "reconnecting"
+      },
+      predictionStatus: ""
+    }),
+    "恢复状态：正在重新加入多人房间并校正战斗归属，结果请以恢复后的权威状态为准。"
+  );
+
+  assert.equal(
+    renderRecoverySummary({
+      battle: null,
+      lastBattleSettlement: null,
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: "已回放本地缓存状态，正在等待房间同步..."
+    }),
+    "恢复状态：已回放本地缓存状态，正在等待房间同步..."
+  );
+
+  assert.equal(
+    renderRecoverySummary({
+      battle: null,
+      lastBattleSettlement: null,
+      diagnostics: {
+        connectionStatus: "connected",
+        recoverySummary: "权威房间状态已恢复，战后结果与地图状态已经重新对齐。"
+      },
+      predictionStatus: ""
+    }),
+    "恢复状态：权威房间状态已恢复，战后结果与地图状态已经重新对齐。"
+  );
+
+  assert.equal(
+    renderRecoverySummary({
+      battle: null,
+      lastBattleSettlement: {
+        aftermath: "已结算"
+      },
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
+    }),
+    "恢复状态：最近一场遭遇的结算与地图房间态已经重新对齐。"
+  );
+
+  assert.equal(
+    renderRecoverySummary({
+      battle: null,
+      lastBattleSettlement: null,
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
+    }),
+    "恢复状态：当前未触发重连补救，房间同步保持稳定。"
   );
 });
 

--- a/apps/client/test/runtime-diagnostics.test.ts
+++ b/apps/client/test/runtime-diagnostics.test.ts
@@ -224,6 +224,7 @@ test("buildH5RuntimeDiagnosticsSnapshot creates a stable export payload for dev 
         }
       ],
       logTail: ["Room room-alpha connected", "Battle resolved"],
+      recoverySummary: "权威房间状态已恢复，战后结果与地图状态已经重新对齐。",
       predictionStatus: "",
       pendingUiTasks: 2,
       replay: {
@@ -246,6 +247,7 @@ test("buildH5RuntimeDiagnosticsSnapshot creates a stable export payload for dev 
   assert.equal(snapshot.world?.hero?.id, "hero-1");
   assert.deepEqual(snapshot.world?.resources, { gold: 150, wood: 10, ore: 4 });
   assert.equal(snapshot.account.recentReplayCount, 1);
+  assert.equal(snapshot.diagnostics.recoverySummary, "权威房间状态已恢复，战后结果与地图状态已经重新对齐。");
   assert.equal(snapshot.diagnostics.predictionStatus, null);
   assert.equal(snapshot.diagnostics.replay?.totalSteps, 3);
 
@@ -253,10 +255,12 @@ test("buildH5RuntimeDiagnosticsSnapshot creates a stable export payload for dev 
   assert.match(serialized, /"schemaVersion": 1/);
   assert.match(serialized, /"surface": "h5-debug-shell"/);
   assert.match(serialized, /"reachableTileCount": 2/);
+  assert.match(serialized, /"recoverySummary": "权威房间状态已恢复，战后结果与地图状态已经重新对齐。"/);
   assert.match(serialized, /"predictionStatus": null/);
 
   const summary = renderRuntimeDiagnosticsSnapshotText(snapshot);
   assert.match(summary, /Room room-alpha \/ Player player-1 \/ Sync connected/);
   assert.match(summary, /Resources gold=150 wood=10 ore=4/);
   assert.match(summary, /Events battle.started, battle.resolved/);
+  assert.match(summary, /Recovery 权威房间状态已恢复，战后结果与地图状态已经重新对齐。/);
 });

--- a/packages/shared/src/runtime-diagnostics.ts
+++ b/packages/shared/src/runtime-diagnostics.ts
@@ -110,6 +110,7 @@ export interface RuntimeDiagnosticsSnapshot {
       text: string;
     }>;
     logTail: string[];
+    recoverySummary: string | null;
     predictionStatus: string | null;
     pendingUiTasks: number;
     replay: RuntimeDiagnosticsReplaySnapshot | null;
@@ -167,6 +168,10 @@ export function buildRuntimeDiagnosticsSummaryLines(snapshot: RuntimeDiagnostics
 
   if (snapshot.diagnostics.predictionStatus) {
     lines.push(`Prediction ${snapshot.diagnostics.predictionStatus}`);
+  }
+
+  if (snapshot.diagnostics.recoverySummary) {
+    lines.push(`Recovery ${snapshot.diagnostics.recoverySummary}`);
   }
 
   lines.push(`Pending UI tasks ${snapshot.diagnostics.pendingUiTasks}`);

--- a/packages/shared/test/runtime-diagnostics.test.ts
+++ b/packages/shared/test/runtime-diagnostics.test.ts
@@ -85,6 +85,7 @@ function createRuntimeDiagnosticsSnapshot(): RuntimeDiagnosticsSnapshot {
         }
       ],
       logTail: ["Room room-alpha connected", "Battle resolved"],
+      recoverySummary: "连接已恢复，当前地图与战斗状态来自最新权威快照。",
       predictionStatus: "server-authoritative",
       pendingUiTasks: 2,
       replay: {
@@ -113,6 +114,7 @@ test("runtime diagnostics summary text stays stable for panel and automation con
   assert.match(rendered, /World 4x3 \/ visible 7 \/ reachable 4/);
   assert.match(rendered, /Hero 凯琳 @ 0,0 \/ MOV 4\/6 \/ HP 30\/30/);
   assert.match(rendered, /Account 暮火侦骑 \(remote\) \/ events 3 \/ replays 1/);
+  assert.match(rendered, /Recovery 连接已恢复，当前地图与战斗状态来自最新权威快照。/);
   assert.match(rendered, /Replay room-alpha:battle-1:player-1 \/ paused \/ step 1\/3/);
   assert.match(rendered, /Timeline \[push\/battle\] Room room-alpha finished battle battle-1/);
 });

--- a/tests/e2e/pvp-postbattle-reconnect.spec.ts
+++ b/tests/e2e/pvp-postbattle-reconnect.spec.ts
@@ -47,6 +47,9 @@ test("players can reload after a PvP battle resolves and keep the settled world 
   await expect(playerTwoPage.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
   await expect(playerOnePage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
   await expect(playerTwoPage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
+  await expect(playerOnePage.getByTestId("room-recovery-summary")).toContainText("权威房间状态已恢复");
+  await expect(playerOnePage.getByTestId("room-recovery-summary")).toContainText("战后结果与地图状态已经重新对齐");
+  await expect(playerTwoPage.getByTestId("room-recovery-summary")).toContainText("权威房间状态已恢复");
   await expect(playerOnePage.getByTestId("room-phase")).toHaveText("已结算");
   await expect(playerTwoPage.getByTestId("room-phase")).toHaveText("已结算");
   await expect(playerOnePage.getByTestId("battle-settlement-summary")).toContainText("已击败");


### PR DESCRIPTION
## Summary
- add a dedicated room recovery summary so reconnect, replay fallback, and restored authoritative state stay visible after PvP encounters settle
- persist recovery feedback through H5 diagnostics exports and summary text so reload/debug flows show the latest recovery posture
- extend room feedback and multiplayer reconnect coverage for the new post-battle recovery copy

Closes #253