### PR TITLE
Polish Cocos battle presentation and settlement feedback

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -15,6 +15,11 @@ export interface BattleProgressAnalysis {
   skillTriggered: boolean;
 }
 
+interface BattleSettlementSummary {
+  detail: string;
+  lines: string[];
+}
+
 export function buildBattleActionFeedback(
   action: BattleAction,
   battle: BattleState | null
@@ -65,7 +70,11 @@ export function buildBattleActionFeedback(
   };
 }
 
-export function buildBattleTransitionFeedback(update: SessionUpdate, heroId: string | null): CocosBattleFeedbackView | null {
+export function buildBattleTransitionFeedback(
+  update: SessionUpdate,
+  heroId: string | null,
+  previousBattle: BattleState | null = null
+): CocosBattleFeedbackView | null {
   const battle = update.battle;
   const started = update.events.find((event) => event.type === "battle.started");
   if (battle && started) {
@@ -88,10 +97,11 @@ export function buildBattleTransitionFeedback(update: SessionUpdate, heroId: str
         ? resolved.heroId === heroId
         : resolved.defenderHeroId === heroId
       : resolved.result === "attacker_victory";
+  const settlement = buildBattleSettlementSummary(previousBattle, update, heroId);
 
   return {
     title: didWin ? "战斗胜利" : "战斗失利",
-    detail: didWin ? "部队完成收口，准备返回世界地图" : "部队撤离战场，准备返回世界地图",
+    detail: settlement.detail,
     badge: didWin ? "WIN" : "LOSE",
     tone: didWin ? "victory" : "defeat"
   };
@@ -179,4 +189,141 @@ export function analyzeBattleProgress(
     damagedUnits,
     skillTriggered: latestLog.includes("施放")
   };
+}
+
+export function buildBattleSettlementLines(
+  previousBattle: BattleState | null,
+  update: SessionUpdate,
+  heroId: string | null
+): string[] {
+  return buildBattleSettlementSummary(previousBattle, update, heroId).lines;
+}
+
+function buildBattleSettlementSummary(
+  previousBattle: BattleState | null,
+  update: SessionUpdate,
+  heroId: string | null
+): BattleSettlementSummary {
+  const rewards = collectSettlementRewardParts(update);
+  const fieldStatus = describeSettlementFieldState(previousBattle, heroId);
+  const lines = [fieldStatus, ...rewards];
+  const detailParts = [
+    fieldStatus,
+    rewards.length > 0 ? rewards.join(" / ") : null,
+    "准备返回世界地图"
+  ].filter((part): part is string => Boolean(part));
+
+  return {
+    detail: detailParts.join(" · "),
+    lines
+  };
+}
+
+function collectSettlementRewardParts(update: SessionUpdate): string[] {
+  const parts: string[] = [];
+  const resources = {
+    gold: 0,
+    wood: 0,
+    ore: 0
+  };
+  let experienceGained = 0;
+  let skillPointsAwarded = 0;
+  let featuredEquipmentName = "";
+
+  for (const event of update.events) {
+    if (event.type === "hero.collected") {
+      resources[event.resource.kind] += Math.max(0, event.resource.amount);
+      continue;
+    }
+
+    if (event.type === "hero.progressed") {
+      experienceGained += Math.max(0, event.experienceGained);
+      skillPointsAwarded += Math.max(0, event.skillPointsAwarded);
+      continue;
+    }
+
+    if (event.type === "hero.equipmentFound") {
+      featuredEquipmentName = event.equipmentName;
+      continue;
+    }
+  }
+
+  const resolved = update.events.find((event) => event.type === "battle.resolved");
+  const resolvedRecord = isRecord(resolved) ? (resolved as unknown as Record<string, unknown>) : null;
+  const resolvedResources = resolvedRecord?.["resourcesGained"];
+  if (isRecord(resolvedResources)) {
+    resources.gold += readPositiveNumber(resolvedResources["gold"]);
+    resources.wood += readPositiveNumber(resolvedResources["wood"]);
+    resources.ore += readPositiveNumber(resolvedResources["ore"]);
+  }
+  experienceGained += readPositiveNumber(resolvedRecord?.["experienceGained"]);
+  skillPointsAwarded += readPositiveNumber(resolvedRecord?.["skillPointsAwarded"]);
+
+  if (resources.gold > 0 || resources.wood > 0 || resources.ore > 0) {
+    const resourceParts = (["gold", "wood", "ore"] as const)
+      .filter((kind) => resources[kind] > 0)
+      .map((kind) => `${formatResourceLabel(kind)} +${resources[kind]}`);
+    parts.push(`战利品：${resourceParts.join(" / ")}`);
+  }
+
+  if (experienceGained > 0 || skillPointsAwarded > 0) {
+    const progressionParts = [];
+    if (experienceGained > 0) {
+      progressionParts.push(`XP +${experienceGained}`);
+    }
+    if (skillPointsAwarded > 0) {
+      progressionParts.push(`技能点 +${skillPointsAwarded}`);
+    }
+    parts.push(`成长：${progressionParts.join(" / ")}`);
+  }
+
+  if (featuredEquipmentName) {
+    parts.push(`掉落：${featuredEquipmentName}`);
+  }
+
+  return parts;
+}
+
+function describeSettlementFieldState(previousBattle: BattleState | null, heroId: string | null): string {
+  if (!previousBattle) {
+    return "战线已完成收口";
+  }
+
+  const heroCamp = resolveHeroCamp(previousBattle, heroId);
+  if (!heroCamp) {
+    return "战线已完成收口";
+  }
+
+  const friendlyAlive = countAliveUnits(previousBattle, heroCamp);
+  const enemyAlive = countAliveUnits(previousBattle, heroCamp === "attacker" ? "defender" : "attacker");
+  return `战线：我方剩余 ${friendlyAlive} 队 / 对方剩余 ${enemyAlive} 队`;
+}
+
+function resolveHeroCamp(previousBattle: BattleState, heroId: string | null): "attacker" | "defender" | null {
+  if (!heroId) {
+    return "attacker";
+  }
+  if (previousBattle.worldHeroId === heroId) {
+    return "attacker";
+  }
+  if (previousBattle.defenderHeroId === heroId) {
+    return "defender";
+  }
+  return null;
+}
+
+function countAliveUnits(previousBattle: BattleState, camp: "attacker" | "defender"): number {
+  return Object.values(previousBattle.units).filter((unit) => unit.camp === camp && unit.count > 0).length;
+}
+
+function formatResourceLabel(kind: "gold" | "wood" | "ore"): string {
+  return kind === "gold" ? "金币" : kind === "wood" ? "木材" : "矿石";
+}
+
+function readPositiveNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -81,7 +81,7 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
   const battle = state.update?.battle;
   if (!battle) {
     const presentationSummary = state.presentationState
-      ? [state.presentationState.label, state.presentationState.detail]
+      ? [state.presentationState.label, ...state.presentationState.summaryLines]
       : ["当前没有战斗。"];
     return {
       title: state.presentationState?.result ? "战斗结算" : "战斗面板",
@@ -168,12 +168,13 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
   const statusSummary = activeUnit ? buildStatusSummary(activeUnit) : "无异常";
 
   return {
-    title: "战斗面板",
+    title: state.presentationState?.phase === "enter" ? "战斗展开" : "战斗面板",
     stage: buildBattleStageView(state.update, battle),
     feedback: state.feedback,
     summaryLines: [
       `${battle.id} · 第 ${battle.round} 回合`,
       `流程：${state.presentationState?.label ?? "战斗进行中"}`,
+      ...(state.presentationState?.summaryLines ?? []),
       `阵营：${controlLabel}`,
       `阶段：${turnLabel}`,
       `行动单位：${activeUnit ? formatActiveUnitLine(activeUnit) : "等待中"}`,

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation-controller.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation-controller.ts
@@ -16,6 +16,17 @@ export interface CocosBattlePresentationState {
   badge: string;
   tone: CocosBattleFeedbackTone;
   result: "victory" | "defeat" | null;
+  summaryLines: string[];
+  feedbackLayer: {
+    animation: CocosBattlePresentationPlan["animation"];
+    cue: CocosBattlePresentationPlan["cue"];
+    transition: CocosBattlePresentationPlan["transition"] extends infer Transition
+      ? Transition extends { kind: infer Kind }
+        ? Kind | null
+        : null
+      : null;
+    durationMs: number | null;
+  };
 }
 
 export interface CocosBattlePresentationController {
@@ -33,7 +44,14 @@ const IDLE_STATE: CocosBattlePresentationState = {
   detail: "当前没有战斗。",
   badge: "IDLE",
   tone: "neutral",
-  result: null
+  result: null,
+  summaryLines: [],
+  feedbackLayer: {
+    animation: "idle",
+    cue: null,
+    transition: null,
+    durationMs: null
+  }
 };
 
 export function createCocosBattlePresentationController(): CocosBattlePresentationController {

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
@@ -4,6 +4,7 @@ import { buildBattleEnterCopy, buildBattleExitCopy, type BattleTransitionCopy } 
 import {
   analyzeBattleProgress,
   buildBattleActionFeedback,
+  buildBattleSettlementLines,
   buildBattleProgressFeedback,
   buildBattleTransitionFeedback,
   type CocosBattleFeedbackView
@@ -68,7 +69,16 @@ export function buildBattleActionPresentation(
         : "idle",
     transition: null,
     moment,
-    state: buildPresentationState("command", moment, battle?.id ?? null, feedback, null)
+    state: buildPresentationState("command", moment, battle?.id ?? null, feedback, null, {
+      cue: action.type === "battle.attack" ? "attack" : action.type === "battle.skill" ? "skill" : null,
+      animation:
+        action.type === "battle.attack" || (action.type === "battle.skill" && action.targetId && action.targetId !== action.unitId)
+          ? "attack"
+          : "idle",
+      transition: null,
+      durationMs: null,
+      summaryLines: []
+    })
   };
 }
 
@@ -92,27 +102,41 @@ export function buildBattlePresentationPlan(
         copy: buildBattleEnterCopy(update)
       },
       moment: "battle_enter",
-      state: buildPresentationState("enter", "battle_enter", nextBattle.id, feedback, null)
+      state: buildPresentationState("enter", "battle_enter", nextBattle.id, feedback, null, {
+        cue: null,
+        animation: "attack",
+        transition: "enter",
+        durationMs: null,
+        summaryLines: []
+      })
     };
   }
 
   if (previousBattle && !nextBattle) {
     const didWin = resolveBattleResolution(update, heroId);
-    const feedback = buildBattleTransitionFeedback(update, heroId);
+    const feedback = buildBattleTransitionFeedback(update, heroId, previousBattle);
     const result = didWin === null ? null : didWin ? "victory" : "defeat";
     const moment = didWin ? "result_victory" : "result_defeat";
+    const cue = didWin === null ? null : didWin ? "victory" : "defeat";
+    const animation = didWin === null ? "idle" : didWin ? "victory" : "defeat";
     return {
       phase: "resolution",
       feedback,
       feedbackDurationMs: RESOLUTION_FEEDBACK_DURATION_MS,
-      cue: didWin === null ? null : didWin ? "victory" : "defeat",
-      animation: didWin === null ? "idle" : didWin ? "victory" : "defeat",
+      cue,
+      animation,
       transition: {
         kind: "exit",
         copy: buildBattleExitCopy(previousBattle, update, didWin ?? false)
       },
       moment,
-      state: buildPresentationState("resolution", moment, previousBattle.id, feedback, result)
+      state: buildPresentationState("resolution", moment, previousBattle.id, feedback, result, {
+        cue,
+        animation,
+        transition: "exit",
+        durationMs: RESOLUTION_FEEDBACK_DURATION_MS,
+        summaryLines: buildBattleSettlementLines(previousBattle, update, heroId)
+      })
     };
   }
 
@@ -134,7 +158,13 @@ export function buildBattlePresentationPlan(
       animation,
       transition: null,
       moment,
-      state: buildPresentationState(phase, moment, nextBattle.id, feedback, null)
+      state: buildPresentationState(phase, moment, nextBattle.id, feedback, null, {
+        cue,
+        animation,
+        transition: null,
+        durationMs: null,
+        summaryLines: []
+      })
     };
   }
 
@@ -146,7 +176,13 @@ export function buildBattlePresentationPlan(
     animation: "idle",
     transition: null,
     moment: "idle",
-    state: buildPresentationState("idle", "idle", null, null, null)
+    state: buildPresentationState("idle", "idle", null, null, null, {
+      cue: null,
+      animation: "idle",
+      transition: null,
+      durationMs: null,
+      summaryLines: []
+    })
   };
 }
 
@@ -187,7 +223,8 @@ function buildPresentationState(
   moment: CocosBattlePresentationMoment,
   battleId: string | null,
   feedback: CocosBattleFeedbackView | null,
-  result: CocosBattlePresentationState["result"]
+  result: CocosBattlePresentationState["result"],
+  feedbackLayer: CocosBattlePresentationState["feedbackLayer"] & { summaryLines: string[] }
 ): CocosBattlePresentationState {
   if (!feedback) {
     return {
@@ -198,7 +235,9 @@ function buildPresentationState(
       detail: phase === "idle" ? "当前没有战斗。" : "等待新的战斗反馈。",
       badge: phase === "idle" ? "IDLE" : "LIVE",
       tone: phase === "idle" ? "neutral" : "action",
-      result
+      result,
+      summaryLines: buildPresentationSummaryLines(null, feedbackLayer),
+      feedbackLayer
     };
   }
 
@@ -210,8 +249,61 @@ function buildPresentationState(
     detail: feedback.detail,
     badge: feedback.badge,
     tone: feedback.tone,
-    result
+    result,
+    summaryLines: buildPresentationSummaryLines(feedback, feedbackLayer),
+    feedbackLayer
   };
+}
+
+function buildPresentationSummaryLines(
+  feedback: CocosBattleFeedbackView | null,
+  feedbackLayer: CocosBattlePresentationState["feedbackLayer"] & { summaryLines: string[] }
+): string[] {
+  const lines: string[] = [];
+  const layerParts = [`动画 ${formatAnimationLabel(feedbackLayer.animation)}`];
+  if (feedbackLayer.cue) {
+    layerParts.push(`音效 ${formatCueLabel(feedbackLayer.cue)}`);
+  }
+  if (feedbackLayer.transition) {
+    layerParts.push(`转场 ${feedbackLayer.transition === "enter" ? "开战" : "结算"}`);
+  }
+  lines.push(`反馈层：${layerParts.join(" / ")}`);
+  if (feedback?.detail) {
+    lines.push(`播报：${feedback.detail}`);
+  }
+  return lines.concat(feedbackLayer.summaryLines);
+}
+
+function formatAnimationLabel(animation: CocosBattlePresentationAnimation): string {
+  switch (animation) {
+    case "attack":
+      return "攻击";
+    case "hit":
+      return "受击";
+    case "victory":
+      return "胜利";
+    case "defeat":
+      return "失败";
+    default:
+      return "待机";
+  }
+}
+
+function formatCueLabel(cue: CocosAudioCue): string {
+  switch (cue) {
+    case "attack":
+      return "攻击";
+    case "skill":
+      return "技能";
+    case "hit":
+      return "受击";
+    case "victory":
+      return "胜利";
+    case "defeat":
+      return "失败";
+    default:
+      return cue;
+  }
 }
 
 function resolvePresentationLabel(moment: CocosBattlePresentationMoment, fallback: string): string {

--- a/apps/cocos-client/test/cocos-battle-feedback.test.ts
+++ b/apps/cocos-client/test/cocos-battle-feedback.test.ts
@@ -186,6 +186,7 @@ test("battle feedback summarizes action, progress, and outcome", () => {
   const victoryFeedback = buildBattleTransitionFeedback(createResolvedUpdate("attacker_victory"), "hero-1");
   assert.equal(victoryFeedback?.tone, "victory");
   assert.equal(victoryFeedback?.badge, "WIN");
+  assert.match(victoryFeedback?.detail ?? "", /准备返回世界地图/);
 
   const defeatFeedback = buildBattleTransitionFeedback(createResolvedUpdate("defender_victory"), "hero-1");
   assert.equal(defeatFeedback?.tone, "defeat");
@@ -262,4 +263,47 @@ test("battle presentation plan formalizes enter, impact, and resolution phases",
   assert.equal(resolutionPlan.feedbackDurationMs, 4200);
   assert.equal(resolutionPlan.transition?.kind, "exit");
   assert.equal(resolutionPlan.transition?.copy.badge, "VICTORY");
+  assert.deepEqual(resolutionPlan.state.summaryLines.slice(0, 2), [
+    "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
+    "播报：战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
+  ]);
+});
+
+test("battle transition feedback summarizes settlement rewards and field state", () => {
+  const battle = createBattleState();
+  const update: SessionUpdate = {
+    ...createResolvedUpdate("attacker_victory"),
+    events: [
+      {
+        type: "battle.resolved",
+        battleId: "battle-1",
+        battleKind: "neutral",
+        heroId: "hero-1",
+        result: "attacker_victory",
+        resourcesGained: {
+          gold: 12,
+          wood: 0,
+          ore: 3
+        },
+        experienceGained: 25,
+        skillPointsAwarded: 1
+      },
+      {
+        type: "hero.equipmentFound",
+        heroId: "hero-1",
+        battleId: "battle-1",
+        battleKind: "neutral",
+        equipmentId: "iron_spear",
+        equipmentName: "铁枪",
+        rarity: "common"
+      }
+    ]
+  };
+
+  const feedback = buildBattleTransitionFeedback(update, "hero-1", battle);
+  assert.equal(feedback?.badge, "WIN");
+  assert.match(feedback?.detail ?? "", /战线：我方剩余 1 队 \/ 对方剩余 1 队/);
+  assert.match(feedback?.detail ?? "", /战利品：金币 \+12 \/ 矿石 \+3/);
+  assert.match(feedback?.detail ?? "", /成长：XP \+25 \/ 技能点 \+1/);
+  assert.match(feedback?.detail ?? "", /掉落：铁枪/);
 });

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -95,6 +95,52 @@ test("buildBattlePanelViewModel keeps idle summary focused on battle state", () 
   assert.equal(view.actions.length, 0);
 });
 
+test("buildBattlePanelViewModel surfaces settlement and presentation layer summaries after battle exit", () => {
+  const view = buildBattlePanelViewModel({
+    update: createBaseUpdate(),
+    timelineEntries: [],
+    controlledCamp: null,
+    selectedTargetId: null,
+    actionPending: false,
+    feedback: {
+      title: "战斗胜利",
+      detail: "战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+      badge: "WIN",
+      tone: "victory"
+    },
+    presentationState: {
+      battleId: "battle-1",
+      phase: "resolution",
+      moment: "result_victory",
+      label: "战斗胜利",
+      detail: "战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+      badge: "WIN",
+      tone: "victory",
+      result: "victory",
+      summaryLines: [
+        "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
+        "播报：战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+        "战利品：金币 +12"
+      ],
+      feedbackLayer: {
+        animation: "victory",
+        cue: "victory",
+        transition: "exit",
+        durationMs: 4200
+      }
+    }
+  });
+
+  assert.equal(view.idle, true);
+  assert.equal(view.title, "战斗结算");
+  assert.deepEqual(view.summaryLines, [
+    "战斗胜利",
+    "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
+    "播报：战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+    "战利品：金币 +12"
+  ]);
+});
+
 test("buildBattlePanelViewModel enables attack actions on the player's turn", () => {
   const update = createBaseUpdate();
   update.battle = {

--- a/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
+++ b/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
@@ -179,6 +179,7 @@ test("battle presentation controller formalizes command, casualty, and result fl
     label: "战斗展开",
     badge: "ENGAGE"
   });
+  assert.equal(controller.getState().summaryLines[0], "反馈层：动画 攻击 / 转场 开战");
 
   controller.previewAction(
     {
@@ -195,6 +196,7 @@ test("battle presentation controller formalizes command, casualty, and result fl
     tone: "skill",
     badge: "SKILL"
   });
+  assert.equal(controller.getState().feedbackLayer.cue, "skill");
 
   controller.applyUpdate(
     battle,
@@ -247,4 +249,6 @@ test("battle presentation controller formalizes command, casualty, and result fl
     tone: "victory",
     result: "victory"
   });
+  assert.equal(controller.getState().feedbackLayer.transition, "exit");
+  assert.match(controller.getState().summaryLines[1] ?? "", /战线：我方剩余 1 队 \/ 对方剩余 1 队/);
 });


### PR DESCRIPTION
## Summary
- formalize the Cocos battle presentation state into an explicit feedback layer with animation, cue, and transition summaries
- enrich battle settlement feedback with battlefield state, rewards, progression, and loot fallback details for the battle panel resolution flow
- add focused Cocos tests covering enter-to-resolution presentation state and settlement panel summaries

## Validation
- `node --import tsx --test apps/cocos-client/test/cocos-battle-feedback.test.ts apps/cocos-client/test/cocos-battle-presentation-controller.test.ts apps/cocos-client/test/cocos-battle-panel-model.test.ts`
- `npm run typecheck:cocos`

closes #258