### PR TITLE
Close multiplayer reconnect UX summary gaps

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -79,7 +79,14 @@ import {
   renderBattleReportReplayCenter,
   renderRecentAccountEvents
 } from "./account-history";
-import { renderEncounterSourceDetail, renderRecoverySummary, renderRoomActionHint, resolveRoomFeedbackTone } from "./room-feedback";
+import {
+  renderEncounterSourceDetail,
+  renderRecoverySummary,
+  renderRoomActionHint,
+  renderRoomResultSummary,
+  resolveRecoveryRoomStateLabel,
+  resolveRoomFeedbackTone
+} from "./room-feedback";
 
 const params = new URLSearchParams(window.location.search);
 const queryRoomId = params.get("roomId")?.trim() ?? "";
@@ -1967,26 +1974,33 @@ function resolveEncounterOpponentContext(): {
   detail: string;
 } | null {
   const playerCamp = state.battle ? controlledBattleCamp(state.battle, state.world) : null;
+  const recoveryRoomState = resolveRecoveryRoomStateLabel({
+    diagnostics: state.diagnostics,
+    predictionStatus: state.predictionStatus
+  });
+  const roomStateLabel = recoveryRoomState ? `房间态：${recoveryRoomState}` : null;
 
   if (state.battle?.defenderHeroId) {
     const opponentId = opposingHeroId(state.battle, state.world);
     const opponent = findHeroSnapshot(opponentId, state.world);
     return {
       label: "对手信息",
-      detail: `${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：战斗中 · ${battleSessionSummary(
+      detail: `${formatVisibleHeroSummary(opponent, opponentId)} · ${roomStateLabel ?? "房间态：战斗中"} · ${battleSessionSummary(
         state.battle.id,
         state.world.meta.roomId
-      )} · ${battleTurnContextLabel(state.battle, state.world)} · 我方席位：${playerCamp === "attacker" ? "进攻方" : "防守方"}`
+      )} · ${recoveryRoomState ? "当前回合：等待权威恢复" : battleTurnContextLabel(state.battle, state.world)} · 我方席位：${
+        playerCamp === "attacker" ? "进攻方" : "防守方"
+      }`
     };
   }
 
   if (state.battle?.neutralArmyId) {
     return {
       label: "遭遇目标",
-      detail: `${state.battle.neutralArmyId} · 房间态：战斗中 · ${battleSessionSummary(
+      detail: `${state.battle.neutralArmyId} · ${roomStateLabel ?? "房间态：战斗中"} · ${battleSessionSummary(
         state.battle.id,
         state.world.meta.roomId
-      )} · ${battleTurnContextLabel(state.battle, state.world)}`
+      )} · ${recoveryRoomState ? "当前回合：等待权威恢复" : battleTurnContextLabel(state.battle, state.world)}`
     };
   }
 
@@ -2014,7 +2028,7 @@ function resolveEncounterOpponentContext(): {
       const opponent = findHeroSnapshot(opponentId, state.world);
       return {
         label: "最近对手",
-        detail: `${formatVisibleHeroSummary(opponent, opponentId)} · 房间态：已结算 · ${battleSessionSummary(
+        detail: `${formatVisibleHeroSummary(opponent, opponentId)} · ${roomStateLabel ?? "房间态：已结算"} · ${battleSessionSummary(
           state.lastEncounterStarted.battleId,
           state.world.meta.roomId
         )}`
@@ -2023,7 +2037,7 @@ function resolveEncounterOpponentContext(): {
 
     return {
       label: "最近遭遇",
-      detail: `${state.lastEncounterStarted.neutralArmyId ?? "neutral"} · 房间态：已结算 · ${battleSessionSummary(
+      detail: `${state.lastEncounterStarted.neutralArmyId ?? "neutral"} · ${roomStateLabel ?? "房间态：已结算"} · ${battleSessionSummary(
         state.lastEncounterStarted.battleId,
         state.world.meta.roomId
       )}`
@@ -2031,33 +2045,6 @@ function resolveEncounterOpponentContext(): {
   }
 
   return null;
-}
-
-function renderRoomResultSummary(): string {
-  if (state.lastBattleSettlement) {
-    return `房间结果：${state.lastBattleSettlement.roomState}`;
-  }
-
-  if (state.battle) {
-    return `房间结果：多人遭遇战已接管地图行动，当前由 ${battleSessionSummary(
-      state.battle.id,
-      state.world.meta.roomId
-    )} 驱动；待战斗链路关闭后统一回写房间状态。`;
-  }
-
-  if (state.diagnostics.connectionStatus === "reconnecting") {
-    return "恢复状态：正在恢复连接与房间主状态，期间可能短暂保留上一帧视图。";
-  }
-
-  if (state.diagnostics.connectionStatus === "reconnect_failed") {
-    return "恢复状态：正在通过最近快照回补房间，等待权威状态确认当前可行动信息。";
-  }
-
-  if (state.predictionStatus.includes("已回放本地缓存状态")) {
-    return `恢复状态：${state.predictionStatus}`;
-  }
-
-  return "房间结果：当前处于稳定探索态，等待新的移动、交互或多人遭遇。";
 }
 
 function buildBattleSettlementSummary(
@@ -3612,7 +3599,13 @@ function renderRoomStatusPanel(): string {
         diagnostics: state.diagnostics,
         predictionStatus: state.predictionStatus
       })}</p>
-      <p class="muted" data-testid="room-result-summary" data-tone="${roomFeedbackTone}">${renderRoomResultSummary()}</p>
+      <p class="muted" data-testid="room-result-summary" data-tone="${roomFeedbackTone}">${renderRoomResultSummary({
+        battle: state.battle,
+        lastBattleSettlement: state.lastBattleSettlement,
+        diagnostics: state.diagnostics,
+        predictionStatus: state.predictionStatus,
+        roomId: state.world.meta.roomId
+      })}</p>
       <p class="muted" data-testid="opponent-summary">${opponentLine}</p>
       <div class="room-status-chips">
         <span class="battle-intel-chip" data-testid="room-player-summary">${playerSummary}</span>

--- a/apps/client/src/room-feedback.ts
+++ b/apps/client/src/room-feedback.ts
@@ -14,6 +14,10 @@ interface DiagnosticStateLike {
 type EncounterStartedEvent = Extract<SessionUpdate["events"][number], { type: "battle.started" }>;
 type ActiveHeroLike = Pick<PlayerWorldView["ownHeroes"][number], "move">;
 
+function trimTrailingPunctuation(text: string): string {
+  return text.trim().replace(/[。；，、.!?]+$/u, "");
+}
+
 export interface EncounterSourceDetailInput {
   battle: BattleState | null;
   lastEncounterStarted: EncounterStartedEvent | null;
@@ -38,6 +42,29 @@ export interface AppState {
   lastBattleSettlement: (BattleSettlementSummaryLike & { tone?: CocosBattleFeedbackTone }) | null;
   diagnostics: DiagnosticStateLike;
   predictionStatus?: string;
+}
+
+export function resolveRecoveryRoomStateLabel(input: {
+  diagnostics: DiagnosticStateLike;
+  predictionStatus: string;
+}): string | null {
+  if (input.diagnostics.connectionStatus === "reconnecting") {
+    return "恢复中（等待权威同步）";
+  }
+
+  if (input.diagnostics.connectionStatus === "reconnect_failed") {
+    return "快照回补中";
+  }
+
+  if (input.predictionStatus.includes("已回放本地缓存状态")) {
+    return "缓存已回放，等待校正";
+  }
+
+  if (input.diagnostics.recoverySummary) {
+    return "已恢复并完成校正";
+  }
+
+  return null;
 }
 
 function ownedHeroIds(world: PlayerWorldView): Set<string> {
@@ -133,6 +160,48 @@ export function renderRoomActionHint(input: RoomActionHintInput): string {
   return input.activeHero.move.remaining > 0
     ? "下一步：选择地图格继续探索；若接敌，将自动切入对抗。"
     : "下一步：当前英雄今日已无移动力，可推进到下一天。";
+}
+
+export function renderRoomResultSummary(input: {
+  battle: BattleState | null;
+  lastBattleSettlement: { roomState: string } | null;
+  diagnostics: DiagnosticStateLike;
+  predictionStatus: string;
+  roomId: string;
+}): string {
+  if (input.diagnostics.connectionStatus === "reconnecting") {
+    return "房间结果：正在恢复连接与房间主状态，期间请以恢复后的权威结果为准。";
+  }
+
+  if (input.diagnostics.connectionStatus === "reconnect_failed") {
+    return "房间结果：旧连接未恢复，正在通过最近快照回补房间，等待权威状态确认当前可行动信息。";
+  }
+
+  if (input.predictionStatus.includes("已回放本地缓存状态")) {
+    return `房间结果：${input.predictionStatus}`;
+  }
+
+  if (input.diagnostics.recoverySummary && input.lastBattleSettlement) {
+    return `房间结果：${trimTrailingPunctuation(input.diagnostics.recoverySummary)}；当前结算已同步回写。`;
+  }
+
+  if (input.diagnostics.recoverySummary && input.battle) {
+    return `房间结果：${trimTrailingPunctuation(input.diagnostics.recoverySummary)}；当前仍由 ${input.roomId}/${input.battle.id} 驱动本场对抗。`;
+  }
+
+  if (input.diagnostics.recoverySummary) {
+    return `房间结果：${input.diagnostics.recoverySummary}`;
+  }
+
+  if (input.lastBattleSettlement) {
+    return `房间结果：${input.lastBattleSettlement.roomState}`;
+  }
+
+  if (input.battle) {
+    return `房间结果：多人遭遇战已接管地图行动，当前由 遭遇会话：${input.roomId}/${input.battle.id} 驱动；待战斗链路关闭后统一回写房间状态。`;
+  }
+
+  return "房间结果：当前处于稳定探索态，等待新的移动、交互或多人遭遇。";
 }
 
 export function renderRecoverySummary(input: {

--- a/apps/client/test/room-feedback.test.ts
+++ b/apps/client/test/room-feedback.test.ts
@@ -2,7 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { BattleState, MovementPlan, PlayerWorldView } from "../../../packages/shared/src/index";
 import type { SessionUpdate } from "../src/local-session";
-import { renderEncounterSourceDetail, renderRecoverySummary, renderRoomActionHint, resolveRoomFeedbackTone } from "../src/room-feedback";
+import {
+  renderEncounterSourceDetail,
+  renderRecoverySummary,
+  renderRoomActionHint,
+  renderRoomResultSummary,
+  resolveRecoveryRoomStateLabel,
+  resolveRoomFeedbackTone
+} from "../src/room-feedback";
 
 type EncounterStartedEvent = Extract<SessionUpdate["events"][number], { type: "battle.started" }>;
 
@@ -472,6 +479,106 @@ test("renderRecoverySummary covers reconnect, replay fallback, explicit recovery
       predictionStatus: ""
     }),
     "恢复状态：当前未触发重连补救，房间同步保持稳定。"
+  );
+});
+
+test("resolveRecoveryRoomStateLabel distinguishes pending, fallback, and restored authority states", () => {
+  assert.equal(
+    resolveRecoveryRoomStateLabel({
+      diagnostics: {
+        connectionStatus: "reconnecting"
+      },
+      predictionStatus: ""
+    }),
+    "恢复中（等待权威同步）"
+  );
+
+  assert.equal(
+    resolveRecoveryRoomStateLabel({
+      diagnostics: {
+        connectionStatus: "reconnect_failed"
+      },
+      predictionStatus: ""
+    }),
+    "快照回补中"
+  );
+
+  assert.equal(
+    resolveRecoveryRoomStateLabel({
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: "已回放本地缓存状态，正在等待房间同步..."
+    }),
+    "缓存已回放，等待校正"
+  );
+
+  assert.equal(
+    resolveRecoveryRoomStateLabel({
+      diagnostics: {
+        connectionStatus: "connected",
+        recoverySummary: "权威房间状态已恢复，战后结果与地图状态已经重新对齐。"
+      },
+      predictionStatus: ""
+    }),
+    "已恢复并完成校正"
+  );
+
+  assert.equal(
+    resolveRecoveryRoomStateLabel({
+      diagnostics: {
+        connectionStatus: "connected"
+      },
+      predictionStatus: ""
+    }),
+    null
+  );
+});
+
+test("renderRoomResultSummary prioritizes reconnect guidance over stale settlement copy and surfaces restored state", () => {
+  assert.equal(
+    renderRoomResultSummary({
+      battle: null,
+      lastBattleSettlement: {
+        roomState: "房间已回到地图探索阶段。"
+      },
+      diagnostics: {
+        connectionStatus: "reconnecting"
+      },
+      predictionStatus: "",
+      roomId: "room-alpha"
+    }),
+    "房间结果：正在恢复连接与房间主状态，期间请以恢复后的权威结果为准。"
+  );
+
+  assert.equal(
+    renderRoomResultSummary({
+      battle: createBattle(),
+      lastBattleSettlement: null,
+      diagnostics: {
+        connectionStatus: "connected",
+        recoverySummary: "权威战斗状态已恢复，当前行动顺序与房间归属重新对齐。"
+      },
+      predictionStatus: "",
+      roomId: "room-alpha"
+    }),
+    "房间结果：权威战斗状态已恢复，当前行动顺序与房间归属重新对齐；当前仍由 room-alpha/battle-1 驱动本场对抗。"
+  );
+
+  assert.equal(
+    renderRoomResultSummary({
+      battle: null,
+      lastBattleSettlement: {
+        roomState: "房间已回到地图探索阶段。"
+      },
+      diagnostics: {
+        connectionStatus: "connected",
+        recoverySummary: "权威房间状态已恢复，战后结果与地图状态已经重新对齐。"
+      },
+      predictionStatus: "",
+      roomId: "room-alpha"
+    }),
+    "房间结果：权威房间状态已恢复，战后结果与地图状态已经重新对齐；当前结算已同步回写。"
   );
 });
 

--- a/tests/e2e/pvp-postbattle-reconnect.spec.ts
+++ b/tests/e2e/pvp-postbattle-reconnect.spec.ts
@@ -60,6 +60,7 @@ test("players can reload after a PvP battle resolves and keep the settled world 
   await expect(playerTwoPage.getByTestId("battle-settlement-next-action")).toContainText("已无法继续移动");
   await expect(playerOnePage.getByTestId("opponent-summary")).toContainText("最近对手");
   await expect(playerOnePage.getByTestId("opponent-summary")).toContainText(`遭遇会话：${roomId}/battle-`);
+  await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("权威房间状态已恢复");
   await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("当前结算已同步回写");
 
   await expect(playerOnePage.getByTestId("battle-empty")).toHaveText(/No active battle/);


### PR DESCRIPTION
## Summary
- make room result copy recovery-aware so reconnect, replay fallback, and restored authority states override stale battle/settlement text
- surface recovery-aware room-state labels in opponent summaries during active and recently settled encounters
- add focused room-feedback coverage and extend the post-battle reconnect e2e expectation

closes #259