### PR TITLE
Add server diagnostic snapshot export

### DIFF
--- a/apps/client/src/runtime-diagnostics.ts
+++ b/apps/client/src/runtime-diagnostics.ts
@@ -143,6 +143,7 @@ export function buildH5RuntimeDiagnosticsSnapshot(
       recentEventCount: input.account.recentEventLog.length,
       recentReplayCount: input.account.recentBattleReplays.length
     },
+    overview: null,
     diagnostics: {
       eventTypes: [...input.diagnostics.eventTypes],
       timelineTail: input.diagnostics.timelineTail.map((entry) => ({

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -180,6 +180,7 @@ export async function startDevServer(
   deps.logger.log(`Matchmaking API available at http://${host}:${port}/api/matchmaking/status`);
   deps.logger.log(`Runtime health available at http://${host}:${port}/api/runtime/health`);
   deps.logger.log(`Auth readiness available at http://${host}:${port}/api/runtime/auth-readiness`);
+  deps.logger.log(`Runtime diagnostic snapshot available at http://${host}:${port}/api/runtime/diagnostic-snapshot`);
   deps.logger.log(`Runtime metrics available at http://${host}:${port}/api/runtime/metrics`);
   deps.logger.log(`Config center storage: ${configCenterStore.mode}`);
   if (snapshotStore) {

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -1,10 +1,16 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  renderRuntimeDiagnosticsSnapshotText,
+  type RuntimeDiagnosticsSnapshot
+} from "../../../packages/shared/src/index";
 
 export interface RuntimeRoomSnapshot {
   roomId: string;
+  day: number | null;
   connectedPlayers: number;
   heroCount: number;
   activeBattles: number;
+  updatedAt: string;
 }
 
 interface RuntimeObservabilityCounters {
@@ -304,6 +310,70 @@ function buildAuthTokenDeliveryPayload(service = "project-veil-server"): AuthTok
     delivery: {
       ...health.runtime.auth.tokenDelivery,
       recentAttempts
+    }
+  };
+}
+
+function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): RuntimeDiagnosticsSnapshot {
+  const health = buildHealthPayload(service);
+  const roomSummaries = Array.from(runtimeObservability.rooms.values()).sort(
+    (left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.roomId.localeCompare(right.roomId)
+  );
+  const checkedAt = new Date().toISOString();
+
+  return {
+    schemaVersion: 1,
+    exportedAt: checkedAt,
+    source: {
+      surface: "server-observability",
+      devOnly: false,
+      mode: "server"
+    },
+    room: null,
+    world: null,
+    battle: null,
+    account: null,
+    overview: {
+      service,
+      activeRoomCount: health.runtime.activeRoomCount,
+      connectionCount: health.runtime.connectionCount,
+      activeBattleCount: health.runtime.activeBattleCount,
+      heroCount: health.runtime.heroCount,
+      gameplayTraffic: { ...health.runtime.gameplayTraffic },
+      auth: {
+        activeGuestSessionCount: health.runtime.auth.activeGuestSessionCount,
+        activeAccountSessionCount: health.runtime.auth.activeAccountSessionCount,
+        pendingRegistrationCount: health.runtime.auth.pendingRegistrationCount,
+        pendingRecoveryCount: health.runtime.auth.pendingRecoveryCount,
+        tokenDeliveryQueueCount: health.runtime.auth.tokenDelivery.queueCount,
+        tokenDeliveryDeadLetterCount: health.runtime.auth.tokenDelivery.deadLetterCount
+      },
+      roomSummaries: roomSummaries.map((room) => ({
+        roomId: room.roomId,
+        day: room.day,
+        connectedPlayers: room.connectedPlayers,
+        heroCount: room.heroCount,
+        activeBattles: room.activeBattles,
+        updatedAt: room.updatedAt
+      }))
+    },
+    diagnostics: {
+      eventTypes: [],
+      timelineTail: roomSummaries.slice(0, 5).map((room) => ({
+        id: `room:${room.roomId}:${room.updatedAt}`,
+        tone: room.activeBattles > 0 ? "battle" : "system",
+        source: "runtime-observability",
+        text: `Room ${room.roomId} day=${room.day ?? "?"} players=${room.connectedPlayers} heroes=${room.heroCount} battles=${room.activeBattles}`
+      })),
+      logTail: [
+        `service ${service} rooms=${health.runtime.activeRoomCount} connections=${health.runtime.connectionCount}`,
+        `traffic connect=${health.runtime.gameplayTraffic.connectMessagesTotal} world=${health.runtime.gameplayTraffic.worldActionsTotal} battle=${health.runtime.gameplayTraffic.battleActionsTotal}`,
+        `auth guest=${health.runtime.auth.activeGuestSessionCount} account=${health.runtime.auth.activeAccountSessionCount} queue=${health.runtime.auth.tokenDelivery.queueCount}`
+      ],
+      recoverySummary: null,
+      predictionStatus: "server-observability",
+      pendingUiTasks: 0,
+      replay: null
     }
   };
 }
@@ -685,6 +755,24 @@ export function registerRuntimeObservabilityRoutes(
   app.get("/api/runtime/auth-readiness", async (_request, response) => {
     try {
       sendJson(response, 200, buildAuthReadinessPayload(serviceName));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/runtime/diagnostic-snapshot", async (request, response) => {
+    try {
+      const snapshot = buildRuntimeDiagnosticSnapshot(serviceName);
+      const url = new URL(request.url ?? "/api/runtime/diagnostic-snapshot", "http://runtime.local");
+
+      if (url.searchParams.get("format") === "text") {
+        response.statusCode = 200;
+        response.setHeader("Content-Type", "text/plain; charset=utf-8");
+        response.end(`${renderRuntimeDiagnosticsSnapshotText(snapshot)}\n`);
+        return;
+      }
+
+      sendJson(response, 200, snapshot);
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -237,6 +237,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
     /Project Veil Colyseus dev server listening on ws:\/\/0\.0\.0\.0:3101/,
     /Runtime health available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/auth-readiness/,
+    /Runtime diagnostic snapshot available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/diagnostic-snapshot/,
     /Runtime metrics available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/metrics/,
     /Config center storage: filesystem/,
     /Local in-memory room persistence enabled/
@@ -311,6 +312,7 @@ test("dev server falls back to in-memory persistence and warns when schema migra
   assertStartupLogIncludes(base.logger, [
     /Runtime health available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/auth-readiness/,
+    /Runtime diagnostic snapshot available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/diagnostic-snapshot/,
     /Runtime metrics available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/metrics/,
     /Config center storage: filesystem/,
     /Local in-memory room persistence enabled/
@@ -395,6 +397,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
   assertStartupLogIncludes(base.logger, [
     /Runtime health available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/auth-readiness/,
+    /Runtime diagnostic snapshot available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/diagnostic-snapshot/,
     /Runtime metrics available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/metrics/,
     /Config center storage: mysql/,
     /MySQL room persistence enabled/,

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -159,6 +159,49 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(readinessPayload.status, "ok");
   assert.match(readinessPayload.headline, /guest=0 account=0 lockouts=0/);
 
+  const diagnosticResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot`);
+  const diagnosticPayload = (await diagnosticResponse.json()) as {
+    source: {
+      surface: string;
+      mode: string;
+    };
+    room: null;
+    overview: {
+      activeRoomCount: number;
+      connectionCount: number;
+      roomSummaries: Array<{
+        roomId: string;
+        day: number | null;
+        connectedPlayers: number;
+      }>;
+    };
+    diagnostics: {
+      predictionStatus: string | null;
+      logTail: string[];
+    };
+  };
+
+  assert.equal(diagnosticResponse.status, 200);
+  assert.equal(diagnosticPayload.source.surface, "server-observability");
+  assert.equal(diagnosticPayload.source.mode, "server");
+  assert.equal(diagnosticPayload.room, null);
+  assert.equal(diagnosticPayload.overview.activeRoomCount, 1);
+  assert.equal(diagnosticPayload.overview.connectionCount, 1);
+  assert.equal(diagnosticPayload.overview.roomSummaries[0]?.roomId, "room-observability-alpha");
+  assert.equal(diagnosticPayload.overview.roomSummaries[0]?.day, 1);
+  assert.equal(diagnosticPayload.overview.roomSummaries[0]?.connectedPlayers, 1);
+  assert.equal(diagnosticPayload.diagnostics.predictionStatus, "server-observability");
+  assert.match(diagnosticPayload.diagnostics.logTail[0] ?? "", /rooms=1 connections=1/);
+
+  const diagnosticTextResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot?format=text`);
+  const diagnosticText = await diagnosticTextResponse.text();
+
+  assert.equal(diagnosticTextResponse.status, 200);
+  assert.match(diagnosticTextResponse.headers.get("content-type") ?? "", /^text\/plain/);
+  assert.match(diagnosticText, /Mode server \(server-observability\)/);
+  assert.match(diagnosticText, /Runtime rooms 1 \/ connections 1 \/ battles 0/);
+  assert.match(diagnosticText, /Room summary room-observability-alpha \/ day 1 \/ players 1/);
+
   const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);
   const metricsText = await metricsResponse.text();
 

--- a/packages/shared/src/runtime-diagnostics.ts
+++ b/packages/shared/src/runtime-diagnostics.ts
@@ -1,4 +1,4 @@
-export type RuntimeDiagnosticsMode = "lobby" | "world" | "battle";
+export type RuntimeDiagnosticsMode = "lobby" | "world" | "battle" | "server";
 
 export type RuntimeDiagnosticsConnectionStatus = "connecting" | "connected" | "reconnecting" | "reconnect_failed";
 
@@ -85,6 +85,38 @@ export interface RuntimeDiagnosticsAccountSnapshot {
   recentReplayCount: number;
 }
 
+export interface RuntimeDiagnosticsOverviewRoomSnapshot {
+  roomId: string;
+  day: number | null;
+  connectedPlayers: number;
+  heroCount: number;
+  activeBattles: number;
+  updatedAt: string | null;
+}
+
+export interface RuntimeDiagnosticsOverviewSnapshot {
+  service: string;
+  activeRoomCount: number;
+  connectionCount: number;
+  activeBattleCount: number;
+  heroCount: number;
+  gameplayTraffic: {
+    connectMessagesTotal: number;
+    worldActionsTotal: number;
+    battleActionsTotal: number;
+    actionMessagesTotal: number;
+  } | null;
+  auth: {
+    activeGuestSessionCount: number;
+    activeAccountSessionCount: number;
+    pendingRegistrationCount: number;
+    pendingRecoveryCount: number;
+    tokenDeliveryQueueCount: number;
+    tokenDeliveryDeadLetterCount: number;
+  } | null;
+  roomSummaries: RuntimeDiagnosticsOverviewRoomSnapshot[];
+}
+
 export interface RuntimeDiagnosticsReplaySnapshot {
   replayId: string;
   loading: boolean;
@@ -97,10 +129,11 @@ export interface RuntimeDiagnosticsSnapshot {
   schemaVersion: number;
   exportedAt: string;
   source: RuntimeDiagnosticsSnapshotSource;
-  room: RuntimeDiagnosticsRoomSnapshot;
+  room: RuntimeDiagnosticsRoomSnapshot | null;
   world: RuntimeDiagnosticsWorldSnapshot | null;
   battle: RuntimeDiagnosticsBattleSnapshot | null;
-  account: RuntimeDiagnosticsAccountSnapshot;
+  account: RuntimeDiagnosticsAccountSnapshot | null;
+  overview: RuntimeDiagnosticsOverviewSnapshot | null;
   diagnostics: {
     eventTypes: string[];
     timelineTail: Array<{
@@ -118,16 +151,23 @@ export interface RuntimeDiagnosticsSnapshot {
 }
 
 export function buildRuntimeDiagnosticsSummaryLines(snapshot: RuntimeDiagnosticsSnapshot): string[] {
-  const lines = [
-    `Mode ${snapshot.source.mode} (${snapshot.source.surface})`,
-    `Room ${snapshot.room.roomId} / Player ${snapshot.room.playerId} / Sync ${snapshot.room.connectionStatus}`
-  ];
+  const lines = [`Mode ${snapshot.source.mode} (${snapshot.source.surface})`];
 
-  if (snapshot.room.day != null) {
+  if (snapshot.room) {
+    lines.push(`Room ${snapshot.room.roomId} / Player ${snapshot.room.playerId} / Sync ${snapshot.room.connectionStatus}`);
+  }
+
+  if (snapshot.overview) {
+    lines.push(
+      `Runtime rooms ${snapshot.overview.activeRoomCount} / connections ${snapshot.overview.connectionCount} / battles ${snapshot.overview.activeBattleCount} / heroes ${snapshot.overview.heroCount}`
+    );
+  }
+
+  if (snapshot.room?.day != null) {
     lines.push(`Day ${snapshot.room.day}`);
   }
 
-  if (snapshot.room.lastUpdateSource || snapshot.room.lastUpdateReason || snapshot.room.lastUpdateAt) {
+  if (snapshot.room && (snapshot.room.lastUpdateSource || snapshot.room.lastUpdateReason || snapshot.room.lastUpdateAt)) {
     const updateParts = [
       snapshot.room.lastUpdateSource ? `source=${snapshot.room.lastUpdateSource}` : null,
       snapshot.room.lastUpdateReason ? `reason=${snapshot.room.lastUpdateReason}` : null,
@@ -158,9 +198,29 @@ export function buildRuntimeDiagnosticsSummaryLines(snapshot: RuntimeDiagnostics
     );
   }
 
-  lines.push(
-    `Account ${snapshot.account.displayName} (${snapshot.account.source}) / events ${snapshot.account.recentEventCount} / replays ${snapshot.account.recentReplayCount}`
-  );
+  if (snapshot.account) {
+    lines.push(
+      `Account ${snapshot.account.displayName} (${snapshot.account.source}) / events ${snapshot.account.recentEventCount} / replays ${snapshot.account.recentReplayCount}`
+    );
+  }
+
+  if (snapshot.overview?.gameplayTraffic) {
+    lines.push(
+      `Traffic connect=${snapshot.overview.gameplayTraffic.connectMessagesTotal} / world=${snapshot.overview.gameplayTraffic.worldActionsTotal} / battle=${snapshot.overview.gameplayTraffic.battleActionsTotal}`
+    );
+  }
+
+  if (snapshot.overview?.auth) {
+    lines.push(
+      `Auth guest=${snapshot.overview.auth.activeGuestSessionCount} / account=${snapshot.overview.auth.activeAccountSessionCount} / queue=${snapshot.overview.auth.tokenDeliveryQueueCount} / deadLetters=${snapshot.overview.auth.tokenDeliveryDeadLetterCount}`
+    );
+  }
+
+  for (const roomSummary of snapshot.overview?.roomSummaries.slice(0, 3) ?? []) {
+    lines.push(
+      `Room summary ${roomSummary.roomId} / day ${roomSummary.day ?? "?"} / players ${roomSummary.connectedPlayers} / heroes ${roomSummary.heroCount} / battles ${roomSummary.activeBattles}`
+    );
+  }
 
   if (snapshot.diagnostics.eventTypes.length > 0) {
     lines.push(`Events ${snapshot.diagnostics.eventTypes.join(", ")}`);

--- a/packages/shared/test/runtime-diagnostics.test.ts
+++ b/packages/shared/test/runtime-diagnostics.test.ts
@@ -74,6 +74,7 @@ function createRuntimeDiagnosticsSnapshot(): RuntimeDiagnosticsSnapshot {
       recentEventCount: 3,
       recentReplayCount: 1
     },
+    overview: null,
     diagnostics: {
       eventTypes: ["battle.started", "battle.resolved"],
       timelineTail: [
@@ -117,4 +118,68 @@ test("runtime diagnostics summary text stays stable for panel and automation con
   assert.match(rendered, /Recovery 连接已恢复，当前地图与战斗状态来自最新权威快照。/);
   assert.match(rendered, /Replay room-alpha:battle-1:player-1 \/ paused \/ step 1\/3/);
   assert.match(rendered, /Timeline \[push\/battle\] Room room-alpha finished battle battle-1/);
+});
+
+test("runtime diagnostics summary text supports aggregate server snapshots", () => {
+  const lines = buildRuntimeDiagnosticsSummaryLines({
+    schemaVersion: 1,
+    exportedAt: "2026-03-29T07:15:00.000Z",
+    source: {
+      surface: "server-observability",
+      devOnly: false,
+      mode: "server"
+    },
+    room: null,
+    world: null,
+    battle: null,
+    account: null,
+    overview: {
+      service: "project-veil-server",
+      activeRoomCount: 2,
+      connectionCount: 3,
+      activeBattleCount: 1,
+      heroCount: 4,
+      gameplayTraffic: {
+        connectMessagesTotal: 5,
+        worldActionsTotal: 8,
+        battleActionsTotal: 2,
+        actionMessagesTotal: 10
+      },
+      auth: {
+        activeGuestSessionCount: 1,
+        activeAccountSessionCount: 2,
+        pendingRegistrationCount: 0,
+        pendingRecoveryCount: 0,
+        tokenDeliveryQueueCount: 1,
+        tokenDeliveryDeadLetterCount: 0
+      },
+      roomSummaries: [
+        {
+          roomId: "room-alpha",
+          day: 3,
+          connectedPlayers: 2,
+          heroCount: 2,
+          activeBattles: 1,
+          updatedAt: "2026-03-29T07:14:00.000Z"
+        }
+      ]
+    },
+    diagnostics: {
+      eventTypes: [],
+      timelineTail: [],
+      logTail: ["project-veil-server rooms=2 connections=3"],
+      recoverySummary: null,
+      predictionStatus: "server-observability",
+      pendingUiTasks: 0,
+      replay: null
+    }
+  });
+
+  assert.deepEqual(lines.slice(0, 5), [
+    "Mode server (server-observability)",
+    "Runtime rooms 2 / connections 3 / battles 1 / heroes 4",
+    "Traffic connect=5 / world=8 / battle=2",
+    "Auth guest=1 / account=2 / queue=1 / deadLetters=0",
+    "Room summary room-alpha / day 3 / players 2 / heroes 2 / battles 1"
+  ]);
 });


### PR DESCRIPTION
## Summary
- extend the shared runtime diagnostics snapshot schema to support aggregate runtime surfaces
- add a server observability snapshot export route with JSON and plain-text output at /api/runtime/diagnostic-snapshot
- cover the new shared summary output and server route in focused tests

## Testing
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:client:h5
- node --import tsx --test packages/shared/test/runtime-diagnostics.test.ts apps/client/test/runtime-diagnostics.test.ts apps/server/test/runtime-observability-routes.test.ts apps/server/test/dev-server.test.ts

refs #260