### PR TITLE
Harden Playwright smoke flows against reconnect and multiplayer flake

### DIFF
--- a/docs/reconnect-smoke-gate.md
+++ b/docs/reconnect-smoke-gate.md
@@ -36,6 +36,16 @@
 - `npm run test:e2e:smoke`
 - `npm run test:e2e:multiplayer:smoke`
 
+## Smoke Hardening Notes
+
+当前 Playwright 冒烟链路针对两类高频假失败做了固定收口：
+
+- reload / 刷新前必须先确认 reconnect token 已经写入存储，再触发页面恢复；不要用裸 `page.reload()` 直接赌时序。
+- 多人房间断言前必须先确认 `session-meta`、`diagnostic-connection-status`、`room-connection-summary` 都已经回到稳定的“已连接”态，再判断玩法同步或结算结果。
+- 若 spec 失败，优先查看 Playwright 附件里的 client automation state、diagnostic snapshot text/json，以及 server diagnostic snapshot text，先区分是房间未启动、客户端未完成握手，还是玩法状态真实回归。
+
+这三条的目标是把“基础设施 / 启动时序问题”和“玩法断言失败”拆开，减少 CI 因偶发 race condition 误报。
+
 ## Minimum Success Signals
 
 ### Local Run

--- a/tests/e2e/lobby-smoke.spec.ts
+++ b/tests/e2e/lobby-smoke.spec.ts
@@ -1,30 +1,47 @@
 import { expect, test, type Page } from "@playwright/test";
+import { buildRoomId, expectRoomReady, withSmokeDiagnostics } from "./smoke-helpers";
 
-async function expectEnteredRoom(page: Page, roomId: string): Promise<void> {
+async function expectEnteredRoom(page: Page, roomId: string, playerId?: string): Promise<void> {
   await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
+  if (playerId) {
+    await expectRoomReady(page, {
+      roomId,
+      playerId,
+      expectedMoveText: /Move 6\/6/
+    });
+    return;
+  }
+
   await expect(page.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
+  await expect(page.getByTestId("diagnostic-panel")).toBeVisible();
+  await expect(page.getByTestId("diagnostic-connection-status")).toHaveText("已连接");
+  await expect(page.getByTestId("room-connection-summary")).toContainText("已连接");
   await expect(page.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
 }
 
-test("lobby opens and a guest can enter a room", async ({ page }) => {
-  const roomId = `e2e-lobby-${Date.now()}`;
+test("lobby opens and a guest can enter a room", async ({ page }, testInfo) => {
+  const roomId = buildRoomId("e2e-lobby");
 
-  await page.goto("/");
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await test.step("setup: open lobby shell", async () => {
+      await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
-  await expect(page.getByText("活跃房间")).toBeVisible();
+      await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
+      await expect(page.getByText("活跃房间")).toBeVisible();
+    });
 
-  await page.locator("[data-lobby-room-id]").fill(roomId);
-  await page.locator("[data-lobby-player-id]").fill("player-1");
-  await page.locator("[data-lobby-display-name]").fill("Smoke Guest");
-  await page.locator("[data-enter-room]").click();
+    await page.locator("[data-lobby-room-id]").fill(roomId);
+    await page.locator("[data-lobby-player-id]").fill("player-1");
+    await page.locator("[data-lobby-display-name]").fill("Smoke Guest");
+    await page.locator("[data-enter-room]").click();
 
-  await expectEnteredRoom(page, roomId);
-  await expect(page.getByTestId("account-card")).toContainText("Smoke Guest");
+    await expectEnteredRoom(page, roomId, "player-1");
+    await expect(page.getByTestId("account-card")).toContainText("Smoke Guest");
+  });
 });
 
-test("lobby reuses a cached guest session when entering a room", async ({ page }) => {
-  const roomId = `e2e-lobby-cached-${Date.now()}`;
+test("lobby reuses a cached guest session when entering a room", async ({ page }, testInfo) => {
+  const roomId = buildRoomId("e2e-lobby-cached");
 
   await page.addInitScript(() => {
     window.localStorage.setItem(
@@ -38,59 +55,62 @@ test("lobby reuses a cached guest session when entering a room", async ({ page }
     );
   });
 
-  await page.goto("/");
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await page.goto("/");
 
-  await expect(page.getByText("已缓存本地会话：cached-guest-1")).toBeVisible();
-  await page.locator("[data-lobby-room-id]").fill(roomId);
-  await page.locator("[data-enter-room]").click();
+    await expect(page.getByText("已缓存本地会话：cached-guest-1")).toBeVisible();
+    await page.locator("[data-lobby-room-id]").fill(roomId);
+    await page.locator("[data-enter-room]").click();
 
-  await expectEnteredRoom(page, roomId);
-  await expect(page.getByTestId("session-meta")).toContainText("Player: cached-guest-1");
-  await expect(page.getByTestId("account-card")).toContainText("Cached Guest");
+    await expectEnteredRoom(page, roomId, "cached-guest-1");
+    await expect(page.getByTestId("account-card")).toContainText("Cached Guest");
+  });
 });
 
-test("lobby supports formal registration and enters the room with an account session", async ({ page }) => {
+test("lobby supports formal registration and enters the room with an account session", async ({ page }, testInfo) => {
   const stamp = Date.now();
   const roomId = `e2e-lobby-register-${stamp}`;
   const loginId = `formal-ranger-${stamp}`;
   const displayName = "Formal Ranger";
   const password = "formal-pass-1";
 
-  await page.goto("/");
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
-  await page.locator("[data-lobby-room-id]").fill(roomId);
-  await page.locator("[data-lobby-login-id]").fill(loginId);
-  await page.locator("[data-registration-display-name]").fill(displayName);
-  await page.locator("[data-registration-password]").fill(password);
-  await page.locator("[data-request-registration]").click();
+    await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
+    await page.locator("[data-lobby-room-id]").fill(roomId);
+    await page.locator("[data-lobby-login-id]").fill(loginId);
+    await page.locator("[data-registration-display-name]").fill(displayName);
+    await page.locator("[data-registration-password]").fill(password);
+    await page.locator("[data-request-registration]").click();
 
-  await expect(page.locator("[data-registration-token]")).toHaveValue(/\S+/, { timeout: 10_000 });
-  await expect(page.locator(".account-status")).toContainText("注册令牌已生成");
+    await expect(page.locator("[data-registration-token]")).toHaveValue(/\S+/, { timeout: 10_000 });
+    await expect(page.locator(".account-status")).toContainText("注册令牌已生成");
 
-  await page.locator("[data-confirm-registration]").click();
+    await page.locator("[data-confirm-registration]").click();
 
-  await expectEnteredRoom(page, roomId);
-  await expect(page.getByTestId("account-card")).toContainText(displayName);
-  await expect(page.getByTestId("account-card")).toContainText(`已绑定登录 ID：${loginId}`);
+    await expectEnteredRoom(page, roomId);
+    await expect(page.getByTestId("account-card")).toContainText(displayName);
+    await expect(page.getByTestId("account-card")).toContainText(`已绑定登录 ID：${loginId}`);
 
-  await expect
-    .poll(async () =>
-      page.evaluate(() => {
-        const raw = window.localStorage.getItem("project-veil:auth-session");
-        return raw ? (JSON.parse(raw) as { authMode?: string; loginId?: string; playerId?: string }) : null;
-      })
-    )
-    .toMatchObject({
-      authMode: "account",
-      loginId
-    });
+    await expect
+      .poll(async () =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("project-veil:auth-session");
+          return raw ? (JSON.parse(raw) as { authMode?: string; loginId?: string; playerId?: string }) : null;
+        })
+      )
+      .toMatchObject({
+        authMode: "account",
+        loginId
+      });
+  });
 });
 
 test("lobby supports password recovery and rotates the account password before entering the room", async ({
   page,
   request
-}) => {
+}, testInfo) => {
   const stamp = Date.now();
   const roomId = `e2e-lobby-recovery-${stamp}`;
   const loginId = `recovery-ranger-${stamp}`;
@@ -117,36 +137,38 @@ test("lobby supports password recovery and rotates the account password before e
   });
   expect(confirmRegistrationResponse.ok()).toBeTruthy();
 
-  await page.goto("/");
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
-  await page.locator("[data-lobby-room-id]").fill(roomId);
-  await page.locator("[data-lobby-login-id]").fill(loginId);
-  await page.locator("[data-request-recovery]").click();
+    await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
+    await page.locator("[data-lobby-room-id]").fill(roomId);
+    await page.locator("[data-lobby-login-id]").fill(loginId);
+    await page.locator("[data-request-recovery]").click();
 
-  await expect(page.locator("[data-recovery-token]")).toHaveValue(/\S+/, { timeout: 10_000 });
-  await expect(page.locator(".account-status")).toContainText("找回令牌已生成");
+    await expect(page.locator("[data-recovery-token]")).toHaveValue(/\S+/, { timeout: 10_000 });
+    await expect(page.locator(".account-status")).toContainText("找回令牌已生成");
 
-  await page.locator("[data-recovery-password]").fill(nextPassword);
-  await page.locator("[data-confirm-recovery]").click();
+    await page.locator("[data-recovery-password]").fill(nextPassword);
+    await page.locator("[data-confirm-recovery]").click();
 
-  await expectEnteredRoom(page, roomId);
-  await expect(page.getByTestId("account-card")).toContainText(displayName);
-  await expect(page.getByTestId("account-card")).toContainText(`已绑定登录 ID：${loginId}`);
+    await expectEnteredRoom(page, roomId);
+    await expect(page.getByTestId("account-card")).toContainText(displayName);
+    await expect(page.getByTestId("account-card")).toContainText(`已绑定登录 ID：${loginId}`);
 
-  const oldPasswordLoginResponse = await request.post("http://127.0.0.1:2567/api/auth/account-login", {
-    data: {
-      loginId,
-      password: originalPassword
-    }
+    const oldPasswordLoginResponse = await request.post("http://127.0.0.1:2567/api/auth/account-login", {
+      data: {
+        loginId,
+        password: originalPassword
+      }
+    });
+    expect(oldPasswordLoginResponse.status()).toBe(401);
+
+    const newPasswordLoginResponse = await request.post("http://127.0.0.1:2567/api/auth/account-login", {
+      data: {
+        loginId,
+        password: nextPassword
+      }
+    });
+    expect(newPasswordLoginResponse.ok()).toBeTruthy();
   });
-  expect(oldPasswordLoginResponse.status()).toBe(401);
-
-  const newPasswordLoginResponse = await request.post("http://127.0.0.1:2567/api/auth/account-login", {
-    data: {
-      loginId,
-      password: nextPassword
-    }
-  });
-  expect(newPasswordLoginResponse.ok()).toBeTruthy();
 });

--- a/tests/e2e/multiplayer-sync.spec.ts
+++ b/tests/e2e/multiplayer-sync.spec.ts
@@ -1,75 +1,92 @@
 import { expect, test, type Page } from "@playwright/test";
-
-async function pressTile(page: Page, x: number, y: number): Promise<void> {
-  await page.locator(`[data-x="${x}"][data-y="${y}"]`).dispatchEvent("pointerdown", {
-    button: 0
-  });
-}
+import { buildRoomId, openRoom, pressTile, withSmokeDiagnostics } from "./smoke-helpers";
 
 async function hoverTile(page: Page, x: number, y: number): Promise<void> {
   await page.locator(`[data-x="${x}"][data-y="${y}"]`).hover();
 }
 
-test("second player receives room push updates without leaking another player's move details", async ({ browser }) => {
-  const roomId = `e2e-multi-${Date.now()}`;
+test("second player receives room push updates without leaking another player's move details", async ({ browser }, testInfo) => {
+  const roomId = buildRoomId("e2e-multi");
   const playerOneContext = await browser.newContext();
   const playerTwoContext = await browser.newContext();
   const playerOnePage = await playerOneContext.newPage();
   const playerTwoPage = await playerTwoContext.newPage();
 
-  await Promise.all([
-    playerOnePage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-1`),
-    playerTwoPage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-2`)
-  ]);
+  try {
+    await withSmokeDiagnostics(testInfo, [playerOnePage, playerTwoPage], async () => {
+      await test.step("setup: both players join the sync room", async () => {
+        await Promise.all([
+          openRoom(playerOnePage, {
+            roomId,
+            playerId: "player-1",
+            expectedMoveText: /Move 6\/6/
+          }),
+          openRoom(playerTwoPage, {
+            roomId,
+            playerId: "player-2",
+            expectedMoveText: /Move 6\/6/
+          })
+        ]);
+      });
 
-  await expect(playerOnePage.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
-  await expect(playerTwoPage.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
+      await pressTile(playerOnePage, 0, 1);
 
-  await pressTile(playerOnePage, 0, 1);
-
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 5\/6/);
-  await expect(playerTwoPage.getByTestId("event-log")).toContainText("收到房间同步推送", { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("event-log")).not.toContainText("Moved 1 steps");
-  await expect(playerTwoPage.getByTestId("event-log")).not.toContainText("Path:");
-  await expect(playerTwoPage.getByTestId("timeline-panel")).not.toContainText("英雄完成移动");
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/);
-
-  await playerOneContext.close();
-  await playerTwoContext.close();
+      await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 5\/6/);
+      await expect(playerTwoPage.getByTestId("event-log")).toContainText("收到房间同步推送", { timeout: 10_000 });
+      await expect(playerTwoPage.getByTestId("room-connection-summary")).toContainText("已连接");
+      await expect(playerTwoPage.getByTestId("event-log")).not.toContainText("Moved 1 steps");
+      await expect(playerTwoPage.getByTestId("event-log")).not.toContainText("Path:");
+      await expect(playerTwoPage.getByTestId("timeline-panel")).not.toContainText("英雄完成移动");
+      await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/);
+    });
+  } finally {
+    await playerOneContext.close();
+    await playerTwoContext.close();
+  }
 });
 
-test("building ownership changes are pushed to other clients with the same visible state", async ({ browser }) => {
-  const roomId = `e2e-building-sync-${Date.now()}`;
+test("building ownership changes are pushed to other clients with the same visible state", async ({ browser }, testInfo) => {
+  const roomId = buildRoomId("e2e-building-sync");
   const playerOneContext = await browser.newContext();
   const playerTwoContext = await browser.newContext();
   const playerOnePage = await playerOneContext.newPage();
   const playerTwoPage = await playerTwoContext.newPage();
 
-  await Promise.all([
-    playerOnePage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-1`),
-    playerTwoPage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-2`)
-  ]);
+  try {
+    await withSmokeDiagnostics(testInfo, [playerOnePage, playerTwoPage], async () => {
+      await test.step("setup: both players join the ownership sync room", async () => {
+        await Promise.all([
+          openRoom(playerOnePage, {
+            roomId,
+            playerId: "player-1",
+            expectedMoveText: /Move 6\/6/
+          }),
+          openRoom(playerTwoPage, {
+            roomId,
+            playerId: "player-2",
+            expectedMoveText: /Move 6\/6/
+          })
+        ]);
+      });
 
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
+      await pressTile(playerTwoPage, 3, 3);
+      await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
 
-  await pressTile(playerTwoPage, 3, 3);
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
+      await hoverTile(playerTwoPage, 3, 1);
+      await expect(playerTwoPage.locator(".object-card-copy")).toContainText("当前无人占领");
 
-  await hoverTile(playerTwoPage, 3, 1);
-  await expect(playerTwoPage.locator(".object-card-copy")).toContainText("当前无人占领");
+      await pressTile(playerOnePage, 3, 1);
+      await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 4\/6/);
+      await pressTile(playerOnePage, 3, 1);
 
-  await pressTile(playerOnePage, 3, 1);
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 4\/6/);
-  await pressTile(playerOnePage, 3, 1);
+      await expect(playerTwoPage.getByTestId("event-log")).toContainText("收到房间同步推送", { timeout: 10_000 });
+      await expect(playerTwoPage.getByTestId("room-connection-summary")).toContainText("已连接");
 
-  await expect(playerTwoPage.getByTestId("event-log")).toContainText("收到房间同步推送", { timeout: 10_000 });
-
-  await hoverTile(playerTwoPage, 3, 1);
-  await expect(playerTwoPage.locator(".object-card-copy")).toContainText("当前归属 player-1");
-
-  await playerOneContext.close();
-  await playerTwoContext.close();
+      await hoverTile(playerTwoPage, 3, 1);
+      await expect(playerTwoPage.locator(".object-card-copy")).toContainText("当前归属 player-1");
+    });
+  } finally {
+    await playerOneContext.close();
+    await playerTwoContext.close();
+  }
 });

--- a/tests/e2e/pvp-postbattle-continue.spec.ts
+++ b/tests/e2e/pvp-postbattle-continue.spec.ts
@@ -1,60 +1,76 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import {
+  attackOnce,
+  buildRoomId,
+  openRoom,
+  pressTile,
+  reloadAndExpectRecoveredSession,
+  withSmokeDiagnostics
+} from "./smoke-helpers";
 
-async function pressTile(page: Page, x: number, y: number): Promise<void> {
-  await page.locator(`[data-x="${x}"][data-y="${y}"]`).dispatchEvent("pointerdown", {
-    button: 0
-  });
-}
-
-async function attackOnce(page: Page): Promise<void> {
-  await expect(page.getByTestId("battle-attack")).toBeVisible({ timeout: 10_000 });
-  await page.getByTestId("battle-attack").click();
-}
-
-test("winner can keep moving after a reloaded PvP settlement while loser stays locked by zero movement", async ({ browser }) => {
-  const roomId = `e2e-pvp-postbattle-continue-${Date.now()}`;
+test("winner can keep moving after a reloaded PvP settlement while loser stays locked by zero movement", async ({ browser }, testInfo) => {
+  const roomId = buildRoomId("e2e-pvp-postbattle-continue");
   const playerOneContext = await browser.newContext();
   const playerTwoContext = await browser.newContext();
   const playerOnePage = await playerOneContext.newPage();
   const playerTwoPage = await playerTwoContext.newPage();
 
-  await Promise.all([
-    playerOnePage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-1`),
-    playerTwoPage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-2`)
-  ]);
+  try {
+    await withSmokeDiagnostics(testInfo, [playerOnePage, playerTwoPage], async () => {
+      await test.step("setup: both players join the room", async () => {
+        await Promise.all([
+          openRoom(playerOnePage, {
+            roomId,
+            playerId: "player-1",
+            expectedMoveText: /Move 6\/6/
+          }),
+          openRoom(playerTwoPage, {
+            roomId,
+            playerId: "player-2",
+            expectedMoveText: /Move 6\/6/
+          })
+        ]);
+      });
 
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
+      await test.step("gameplay: resolve the battle before settlement reload", async () => {
+        await pressTile(playerOnePage, 3, 4);
+        await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
 
-  await pressTile(playerOnePage, 3, 4);
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
+        await pressTile(playerTwoPage, 3, 4);
 
-  await pressTile(playerTwoPage, 3, 4);
+        await attackOnce(playerTwoPage);
+        await attackOnce(playerOnePage);
+        await attackOnce(playerTwoPage);
+        await attackOnce(playerOnePage);
+        await attackOnce(playerTwoPage);
 
-  await attackOnce(playerTwoPage);
-  await attackOnce(playerOnePage);
-  await attackOnce(playerTwoPage);
-  await attackOnce(playerOnePage);
-  await attackOnce(playerTwoPage);
+        await expect(playerOnePage.getByTestId("battle-modal-title")).toHaveText("战斗胜利");
+        await expect(playerTwoPage.getByTestId("battle-modal-title")).toHaveText("战斗失败");
+      });
 
-  await expect(playerOnePage.getByTestId("battle-modal-title")).toHaveText("战斗胜利");
-  await expect(playerTwoPage.getByTestId("battle-modal-title")).toHaveText("战斗失败");
+      await Promise.all([
+        reloadAndExpectRecoveredSession(playerOnePage, {
+          roomId,
+          playerId: "player-1"
+        }),
+        reloadAndExpectRecoveredSession(playerTwoPage, {
+          roomId,
+          playerId: "player-2"
+        })
+      ]);
 
-  await playerOnePage.reload();
-  await playerTwoPage.reload();
+      await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
+      await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
 
-  await expect(playerOnePage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
+      await pressTile(playerOnePage, 2, 4);
+      await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
 
-  await pressTile(playerOnePage, 2, 4);
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
-
-  await pressTile(playerTwoPage, 2, 5);
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
-  await expect(playerTwoPage.getByTestId("event-log")).toContainText("Action rejected: not_enough_move_points");
-
-  await playerOneContext.close();
-  await playerTwoContext.close();
+      await pressTile(playerTwoPage, 2, 5);
+      await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
+      await expect(playerTwoPage.getByTestId("event-log")).toContainText("Action rejected: not_enough_move_points");
+    });
+  } finally {
+    await playerOneContext.close();
+    await playerTwoContext.close();
+  }
 });

--- a/tests/e2e/pvp-postbattle-reconnect.spec.ts
+++ b/tests/e2e/pvp-postbattle-reconnect.spec.ts
@@ -1,75 +1,89 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import {
+  attackOnce,
+  buildRoomId,
+  openRoom,
+  pressTile,
+  reloadAndExpectRecoveredSession,
+  withSmokeDiagnostics
+} from "./smoke-helpers";
 
-async function pressTile(page: Page, x: number, y: number): Promise<void> {
-  await page.locator(`[data-x="${x}"][data-y="${y}"]`).dispatchEvent("pointerdown", {
-    button: 0
-  });
-}
-
-async function attackOnce(page: Page): Promise<void> {
-  await expect(page.getByTestId("battle-attack")).toBeVisible({ timeout: 10_000 });
-  await page.getByTestId("battle-attack").click();
-}
-
-test("players can reload after a PvP battle resolves and keep the settled world state", async ({ browser }) => {
-  const roomId = `e2e-pvp-postbattle-${Date.now()}`;
+test("players can reload after a PvP battle resolves and keep the settled world state", async ({ browser }, testInfo) => {
+  const roomId = buildRoomId("e2e-pvp-postbattle");
   const playerOneContext = await browser.newContext();
   const playerTwoContext = await browser.newContext();
   const playerOnePage = await playerOneContext.newPage();
   const playerTwoPage = await playerTwoContext.newPage();
 
-  await Promise.all([
-    playerOnePage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-1`),
-    playerTwoPage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-2`)
-  ]);
+  try {
+    await withSmokeDiagnostics(testInfo, [playerOnePage, playerTwoPage], async () => {
+      await test.step("setup: both players join the room", async () => {
+        await Promise.all([
+          openRoom(playerOnePage, {
+            roomId,
+            playerId: "player-1",
+            expectedMoveText: /Move 6\/6/
+          }),
+          openRoom(playerTwoPage, {
+            roomId,
+            playerId: "player-2",
+            expectedMoveText: /Move 6\/6/
+          })
+        ]);
+      });
 
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
+      await test.step("gameplay: resolve the PvP battle to settlement", async () => {
+        await pressTile(playerOnePage, 3, 4);
+        await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
 
-  await pressTile(playerOnePage, 3, 4);
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
+        await pressTile(playerTwoPage, 3, 4);
 
-  await pressTile(playerTwoPage, 3, 4);
+        await attackOnce(playerTwoPage);
+        await attackOnce(playerOnePage);
+        await attackOnce(playerTwoPage);
+        await attackOnce(playerOnePage);
+        await attackOnce(playerTwoPage);
 
-  await attackOnce(playerTwoPage);
-  await attackOnce(playerOnePage);
-  await attackOnce(playerTwoPage);
-  await attackOnce(playerOnePage);
-  await attackOnce(playerTwoPage);
+        await expect(playerOnePage.getByTestId("battle-modal-title")).toHaveText("战斗胜利");
+        await expect(playerTwoPage.getByTestId("battle-modal-title")).toHaveText("战斗失败");
+      });
 
-  await expect(playerOnePage.getByTestId("battle-modal-title")).toHaveText("战斗胜利");
-  await expect(playerTwoPage.getByTestId("battle-modal-title")).toHaveText("战斗失败");
+      await Promise.all([
+        reloadAndExpectRecoveredSession(playerOnePage, {
+          roomId,
+          playerId: "player-1"
+        }),
+        reloadAndExpectRecoveredSession(playerTwoPage, {
+          roomId,
+          playerId: "player-2"
+        })
+      ]);
 
-  await playerOnePage.reload();
-  await playerTwoPage.reload();
+      await expect(playerOnePage.getByTestId("room-recovery-summary")).toContainText("权威房间状态已恢复");
+      await expect(playerOnePage.getByTestId("room-recovery-summary")).toContainText("战后结果与地图状态已经重新对齐");
+      await expect(playerTwoPage.getByTestId("room-recovery-summary")).toContainText("权威房间状态已恢复");
+      await expect(playerOnePage.getByTestId("room-phase")).toHaveText("已结算");
+      await expect(playerTwoPage.getByTestId("room-phase")).toHaveText("已结算");
+      await expect(playerOnePage.getByTestId("battle-settlement-summary")).toContainText("已击败");
+      await expect(playerOnePage.getByTestId("battle-settlement-room-state")).toContainText("房间已回到地图探索阶段");
+      await expect(playerOnePage.getByTestId("battle-settlement-next-action")).toContainText("仍可继续移动");
+      await expect(playerTwoPage.getByTestId("battle-settlement-summary")).toContainText("遭遇战失利");
+      await expect(playerTwoPage.getByTestId("battle-settlement-room-state")).toContainText("对手仍保留在房间地图上");
+      await expect(playerTwoPage.getByTestId("battle-settlement-next-action")).toContainText("已无法继续移动");
+      await expect(playerOnePage.getByTestId("opponent-summary")).toContainText("最近对手");
+      await expect(playerOnePage.getByTestId("opponent-summary")).toContainText(`遭遇会话：${roomId}/battle-`);
+      await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("权威房间状态已恢复");
+      await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("当前结算已同步回写");
 
-  await expect(playerOnePage.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
-  await expect(playerTwoPage.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
-  await expect(playerOnePage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
-  await expect(playerOnePage.getByTestId("room-recovery-summary")).toContainText("权威房间状态已恢复");
-  await expect(playerOnePage.getByTestId("room-recovery-summary")).toContainText("战后结果与地图状态已经重新对齐");
-  await expect(playerTwoPage.getByTestId("room-recovery-summary")).toContainText("权威房间状态已恢复");
-  await expect(playerOnePage.getByTestId("room-phase")).toHaveText("已结算");
-  await expect(playerTwoPage.getByTestId("room-phase")).toHaveText("已结算");
-  await expect(playerOnePage.getByTestId("battle-settlement-summary")).toContainText("已击败");
-  await expect(playerOnePage.getByTestId("battle-settlement-room-state")).toContainText("房间已回到地图探索阶段");
-  await expect(playerOnePage.getByTestId("battle-settlement-next-action")).toContainText("仍可继续移动");
-  await expect(playerTwoPage.getByTestId("battle-settlement-summary")).toContainText("遭遇战失利");
-  await expect(playerTwoPage.getByTestId("battle-settlement-room-state")).toContainText("对手仍保留在房间地图上");
-  await expect(playerTwoPage.getByTestId("battle-settlement-next-action")).toContainText("已无法继续移动");
-  await expect(playerOnePage.getByTestId("opponent-summary")).toContainText("最近对手");
-  await expect(playerOnePage.getByTestId("opponent-summary")).toContainText(`遭遇会话：${roomId}/battle-`);
-  await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("权威房间状态已恢复");
-  await expect(playerTwoPage.getByTestId("room-result-summary")).toContainText("当前结算已同步回写");
-
-  await expect(playerOnePage.getByTestId("battle-empty")).toHaveText(/No active battle/);
-  await expect(playerTwoPage.getByTestId("battle-empty")).toHaveText(/No active battle/);
-  await expect(playerOnePage.getByTestId("hero-hp")).toHaveText(/HP 30\/30/);
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
-  await expect(playerTwoPage.getByTestId("hero-hp")).toHaveText(/HP 15\/30/);
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
-
-  await playerOneContext.close();
-  await playerTwoContext.close();
+      await expect(playerOnePage.getByTestId("battle-empty")).toHaveText(/No active battle/);
+      await expect(playerTwoPage.getByTestId("battle-empty")).toHaveText(/No active battle/);
+      await expect(playerOnePage.getByTestId("hero-hp")).toHaveText(/HP 30\/30/);
+      await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
+      await expect(playerTwoPage.getByTestId("hero-hp")).toHaveText(/HP 15\/30/);
+      await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 0\/6/);
+    });
+  } finally {
+    await playerOneContext.close();
+    await playerTwoContext.close();
+  }
 });

--- a/tests/e2e/pvp-reconnect-recovery.spec.ts
+++ b/tests/e2e/pvp-reconnect-recovery.spec.ts
@@ -1,59 +1,69 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import {
+  attackOnce,
+  buildRoomId,
+  openRoom,
+  pressTile,
+  reloadAndExpectRecoveredSession,
+  withSmokeDiagnostics
+} from "./smoke-helpers";
 
-async function pressTile(page: Page, x: number, y: number): Promise<void> {
-  await page.locator(`[data-x="${x}"][data-y="${y}"]`).dispatchEvent("pointerdown", {
-    button: 0
-  });
-}
-
-async function attackOnce(page: Page): Promise<void> {
-  await expect(page.getByTestId("battle-attack")).toBeVisible({ timeout: 10_000 });
-  await page.getByTestId("battle-attack").click();
-}
-
-test("players can reload during a PvP battle and resume from the same turn state", async ({ browser }) => {
-  const roomId = `e2e-pvp-reconnect-${Date.now()}`;
+test("players can reload during a PvP battle and resume from the same turn state", async ({ browser }, testInfo) => {
+  const roomId = buildRoomId("e2e-pvp-reconnect");
   const playerOneContext = await browser.newContext();
   const playerTwoContext = await browser.newContext();
   const playerOnePage = await playerOneContext.newPage();
   const playerTwoPage = await playerTwoContext.newPage();
 
-  await Promise.all([
-    playerOnePage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-1`),
-    playerTwoPage.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=player-2`)
-  ]);
+  try {
+    await withSmokeDiagnostics(testInfo, [playerOnePage, playerTwoPage], async () => {
+      await test.step("setup: both players join the same PvP room", async () => {
+        await Promise.all([
+          openRoom(playerOnePage, {
+            roomId,
+            playerId: "player-1",
+            expectedMoveText: /Move 6\/6/
+          }),
+          openRoom(playerTwoPage, {
+            roomId,
+            playerId: "player-2",
+            expectedMoveText: /Move 6\/6/
+          })
+        ]);
+      });
 
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
+      await test.step("gameplay: collide heroes into the same battle", async () => {
+        await pressTile(playerOnePage, 3, 4);
+        await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
 
-  await pressTile(playerOnePage, 3, 4);
-  await expect(playerOnePage.getByTestId("hero-move")).toHaveText(/Move 1\/6/);
+        await pressTile(playerTwoPage, 3, 4);
 
-  await pressTile(playerTwoPage, 3, 4);
+        await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
+        await expect(playerOnePage.getByTestId("battle-actions")).toContainText("等待对手操作");
+      });
 
-  await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
-  await expect(playerOnePage.getByTestId("battle-actions")).toContainText("等待对手操作");
+      await reloadAndExpectRecoveredSession(playerTwoPage, {
+        roomId,
+        playerId: "player-2"
+      });
+      await expect(playerTwoPage.getByTestId("battle-panel")).not.toContainText("No active battle");
+      await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
 
-  await playerTwoPage.reload();
+      await attackOnce(playerTwoPage);
+      await expect(playerOnePage.getByTestId("battle-attack")).toBeVisible();
 
-  await expect(playerTwoPage.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
-  await expect(playerTwoPage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
-  await expect(playerTwoPage.getByTestId("battle-panel")).not.toContainText("No active battle");
-  await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
+      await reloadAndExpectRecoveredSession(playerOnePage, {
+        roomId,
+        playerId: "player-1"
+      });
+      await expect(playerOnePage.getByTestId("battle-panel")).not.toContainText("No active battle");
+      await expect(playerOnePage.getByTestId("battle-attack")).toBeVisible();
 
-  await attackOnce(playerTwoPage);
-  await expect(playerOnePage.getByTestId("battle-attack")).toBeVisible();
-
-  await playerOnePage.reload();
-
-  await expect(playerOnePage.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
-  await expect(playerOnePage.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
-  await expect(playerOnePage.getByTestId("battle-panel")).not.toContainText("No active battle");
-  await expect(playerOnePage.getByTestId("battle-attack")).toBeVisible();
-
-  await attackOnce(playerOnePage);
-  await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
-
-  await playerOneContext.close();
-  await playerTwoContext.close();
+      await attackOnce(playerOnePage);
+      await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
+    });
+  } finally {
+    await playerOneContext.close();
+    await playerTwoContext.close();
+  }
 });

--- a/tests/e2e/reconnect-recovery.spec.ts
+++ b/tests/e2e/reconnect-recovery.spec.ts
@@ -1,20 +1,18 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { buildRoomId, openRoom, pressTile, reloadAndExpectRecoveredSession, withSmokeDiagnostics } from "./smoke-helpers";
 
 const PLAYER_ID = "player-1";
 
-async function pressTile(page: Page, x: number, y: number): Promise<void> {
-  await page.locator(`[data-x="${x}"][data-y="${y}"]`).dispatchEvent("pointerdown", {
-    button: 0
-  });
-}
+test("page reload restores the remote room session and preserves world state", async ({ page }, testInfo) => {
+  const roomId = buildRoomId("e2e-reconnect");
 
-test("page reload restores the remote room session and preserves world state", async ({ page }) => {
-  const roomId = `e2e-reconnect-${Date.now()}`;
-  const storageKey = `project-veil:reconnection:${roomId}:${PLAYER_ID}`;
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await openRoom(page, {
+      roomId,
+      playerId: PLAYER_ID,
+      expectedMoveText: /Move 6\/6/
+    });
 
-  await page.goto(`http://127.0.0.1:4173/?roomId=${roomId}&playerId=${PLAYER_ID}`);
-
-  await expect(page.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
   await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*0/);
 
   await pressTile(page, 0, 1);
@@ -26,14 +24,12 @@ test("page reload restores the remote room session and preserves world state", a
   await pressTile(page, 0, 0);
   await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*5/);
 
-  await expect
-    .poll(async () => page.evaluate((key) => window.sessionStorage.getItem(key), storageKey))
-    .not.toBeNull();
+    await reloadAndExpectRecoveredSession(page, {
+      roomId,
+      playerId: PLAYER_ID
+    });
 
-  await page.reload();
-
-  await expect(page.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
-  await expect(page.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
-  await expect(page.getByTestId("hero-move")).toHaveText(/Move 4\/6/);
-  await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*5/);
+    await expect(page.getByTestId("hero-move")).toHaveText(/Move 4\/6/);
+    await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*5/);
+  });
 });

--- a/tests/e2e/smoke-helpers.ts
+++ b/tests/e2e/smoke-helpers.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+const CLIENT_BASE_URL = "http://127.0.0.1:4173";
+const SERVER_DIAGNOSTICS_URL = "http://127.0.0.1:2567/api/runtime/diagnostic-snapshot?format=text";
+
+interface RoomSessionOptions {
+  roomId: string;
+  playerId: string;
+  expectedMoveText?: RegExp | null;
+}
+
+interface ReconnectOptions extends RoomSessionOptions {
+  storage?: "sessionStorage" | "localStorage";
+}
+
+function encodeRoomQuery(roomId: string, playerId: string): string {
+  return `${CLIENT_BASE_URL}/?roomId=${encodeURIComponent(roomId)}&playerId=${encodeURIComponent(playerId)}`;
+}
+
+export function buildRoomId(prefix: string): string {
+  return `${prefix}-${Date.now()}`;
+}
+
+export async function pressTile(page: Page, x: number, y: number): Promise<void> {
+  await page.locator(`[data-x="${x}"][data-y="${y}"]`).dispatchEvent("pointerdown", {
+    button: 0
+  });
+}
+
+export async function attackOnce(page: Page): Promise<void> {
+  await expect(page.getByTestId("battle-attack")).toBeVisible({ timeout: 10_000 });
+  await page.getByTestId("battle-attack").click();
+}
+
+export async function openRoom(page: Page, options: RoomSessionOptions): Promise<void> {
+  await test.step(`setup: open ${options.playerId} in ${options.roomId}`, async () => {
+    await page.goto(encodeRoomQuery(options.roomId, options.playerId));
+    await expectRoomReady(page, options);
+  });
+}
+
+export async function expectRoomReady(page: Page, options: RoomSessionOptions): Promise<void> {
+  await expect(page.getByTestId("session-meta")).toContainText(`Room: ${options.roomId}`);
+  await expect(page.getByTestId("session-meta")).toContainText(`Player: ${options.playerId}`);
+  await expect(page.getByTestId("diagnostic-panel")).toBeVisible();
+  await expect(page.getByTestId("diagnostic-connection-status")).toHaveText("已连接");
+  await expect(page.getByTestId("room-connection-summary")).toContainText("已连接");
+  if (options.expectedMoveText) {
+    await expect(page.getByTestId("hero-move")).toHaveText(options.expectedMoveText, { timeout: 10_000 });
+  }
+}
+
+export async function waitForReconnectionToken(page: Page, options: ReconnectOptions): Promise<void> {
+  const storageKey = `project-veil:reconnection:${options.roomId}:${options.playerId}`;
+  const storageAccessor = options.storage ?? "sessionStorage";
+
+  await test.step(`setup: persist reconnect token for ${options.playerId}`, async () => {
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            ({ key, storageAccessor }) => window[storageAccessor].getItem(key),
+            { key: storageKey, storageAccessor }
+          ),
+        {
+          message: `waiting for reconnect token ${storageKey}`
+        }
+      )
+      .not.toBeNull();
+  });
+}
+
+export async function reloadAndExpectRecoveredSession(page: Page, options: ReconnectOptions): Promise<void> {
+  await test.step(`reconnect: reload ${options.playerId} in ${options.roomId}`, async () => {
+    await waitForReconnectionToken(page, options);
+    await page.reload();
+    await expectRoomReady(page, {
+      ...options,
+      expectedMoveText: options.expectedMoveText ?? null
+    });
+    await expect(page.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
+    await expect(page.getByTestId("room-recovery-summary")).toContainText("已恢复");
+  });
+}
+
+async function attachText(testInfo: TestInfo, name: string, body: string | null): Promise<void> {
+  if (!body) {
+    return;
+  }
+
+  await testInfo.attach(name, {
+    body: Buffer.from(body, "utf8"),
+    contentType: "text/plain"
+  });
+}
+
+async function attachJson(testInfo: TestInfo, name: string, body: string | null): Promise<void> {
+  if (!body) {
+    return;
+  }
+
+  await testInfo.attach(name, {
+    body: Buffer.from(body, "utf8"),
+    contentType: "application/json"
+  });
+}
+
+async function readPageText(page: Page, selector: string): Promise<string | null> {
+  try {
+    const locator = page.locator(selector);
+    if (!(await locator.count())) {
+      return null;
+    }
+    return await locator.innerText();
+  } catch {
+    return null;
+  }
+}
+
+async function attachPageDiagnostics(testInfo: TestInfo, page: Page, label: string): Promise<void> {
+  await attachText(testInfo, `${label}-url.txt`, page.url() || null);
+  await attachText(testInfo, `${label}-session-meta.txt`, await readPageText(page, '[data-testid="session-meta"]'));
+  await attachText(testInfo, `${label}-event-log.txt`, await readPageText(page, '[data-testid="event-log"]'));
+  await attachText(
+    testInfo,
+    `${label}-room-connection-summary.txt`,
+    await readPageText(page, '[data-testid="room-connection-summary"]')
+  );
+  await attachText(
+    testInfo,
+    `${label}-diagnostic-summary.txt`,
+    await page.evaluate(() => window.render_diagnostic_snapshot_to_text?.() ?? null).catch(() => null)
+  );
+  await attachJson(
+    testInfo,
+    `${label}-diagnostic-snapshot.json`,
+    await page.evaluate(() => window.export_diagnostic_snapshot?.() ?? null).catch(() => null)
+  );
+  await attachJson(
+    testInfo,
+    `${label}-automation-state.json`,
+    await page.evaluate(() => window.render_game_to_text?.() ?? null).catch(() => null)
+  );
+}
+
+async function attachServerDiagnostics(testInfo: TestInfo): Promise<void> {
+  try {
+    const response = await fetch(SERVER_DIAGNOSTICS_URL);
+    if (!response.ok) {
+      await attachText(testInfo, "server-diagnostics-error.txt", `HTTP ${response.status}`);
+      return;
+    }
+    await attachText(testInfo, "server-diagnostics.txt", await response.text());
+  } catch (error) {
+    await attachText(
+      testInfo,
+      "server-diagnostics-error.txt",
+      error instanceof Error ? error.stack ?? error.message : String(error)
+    );
+  }
+}
+
+export async function withSmokeDiagnostics<T>(
+  testInfo: TestInfo,
+  pages: Page[],
+  callback: () => Promise<T>
+): Promise<T> {
+  try {
+    return await callback();
+  } catch (error) {
+    await attachServerDiagnostics(testInfo);
+    for (const [index, page] of pages.entries()) {
+      await attachPageDiagnostics(testInfo, page, `page-${index + 1}`);
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared Playwright smoke helper for deterministic room boot, reconnect-token gating, and failure-time client/server diagnostics attachments
- harden lobby, multiplayer sync, and PvP reconnect/post-battle smoke specs to use explicit setup/reconnect steps and connected-state assertions instead of raw reload timing
- document the top reconnect smoke failure modes and the mitigation strategy in the reconnect smoke gate doc

## Test Plan
- `node --import tsx --test apps/client/test/runtime-diagnostics.test.ts apps/client/test/reconnection-storage.test.ts`
- `npm run typecheck:client:h5`
- attempted `npm run test:e2e:smoke -- --repeat-each=3` but Chromium could not launch in this environment because `libatk-bridge-2.0.so.0` is missing
- attempted `npm run test:e2e:multiplayer:smoke -- --repeat-each=3` but standalone webServer startup also surfaced a pre-existing `Config content is not valid JSON` failure while booting the dev server