### PR TITLE
Turn diagnostic snapshots into an in-client triage panel

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,5 +1,6 @@
 import "./styles.css";
 import {
+  buildRuntimeDiagnosticsTriageView,
   renderRuntimeDiagnosticsSnapshotText,
   createBattleReplayPlaybackState,
   createHeroSkillTreeView,
@@ -27,7 +28,8 @@ import {
   type MovementPlan,
   type PlayerTileView,
   type PlayerWorldView,
-  type RuntimeDiagnosticsConnectionStatus
+  type RuntimeDiagnosticsConnectionStatus,
+  type RuntimeDiagnosticsTriageSection
 } from "../../../packages/shared/src/index";
 import { createGameSession, readStoredSessionReplay, type SessionUpdate } from "./local-session";
 import { buildH5RuntimeDiagnosticsSnapshot } from "./runtime-diagnostics";
@@ -470,22 +472,89 @@ function triggerDiagnosticSnapshotExport(): void {
   render();
 }
 
+async function copyDiagnosticSnapshotText(): Promise<void> {
+  if (!DEV_DIAGNOSTICS_ENABLED) {
+    return;
+  }
+
+  const snapshotText = renderDiagnosticSnapshotToText();
+  try {
+    if (!navigator.clipboard?.writeText) {
+      throw new Error("clipboard_unavailable");
+    }
+
+    await navigator.clipboard.writeText(snapshotText);
+    state.diagnostics.exportStatus = "已复制紧凑摘要";
+  } catch {
+    state.diagnostics.exportStatus = "复制失败：当前运行时不支持剪贴板写入";
+  }
+  render();
+}
+
+function renderDiagnosticsTriageSection(section: RuntimeDiagnosticsTriageSection): string {
+  const rows = section.items
+    .map(
+      (item) => `
+        <div class="diagnostics-triage-row"${item.tone ? ` data-tone="${item.tone}"` : ""}>
+          <span>${escapeHtml(item.label)}</span>
+          <strong>${escapeHtml(item.value)}</strong>
+        </div>
+      `
+    )
+    .join("");
+
+  return `
+    <section class="diagnostics-triage-section" data-testid="diagnostic-section-${section.id}">
+      <div class="diagnostics-triage-head">
+        <h4>${escapeHtml(section.title)}</h4>
+      </div>
+      <div class="diagnostics-triage-list">
+        ${rows}
+      </div>
+    </section>
+  `;
+}
+
 function renderDiagnosticPanel(): string {
   if (!DEV_DIAGNOSTICS_ENABLED || !shouldBootGame) {
     return "";
   }
 
   const hero = activeHero();
-  const snapshotSummary = escapeHtml(renderDiagnosticSnapshotToText());
+  const snapshot = buildDiagnosticSnapshot();
+  const triage = buildRuntimeDiagnosticsTriageView(snapshot);
+  const snapshotSummary = escapeHtml(renderRuntimeDiagnosticsSnapshotText(snapshot));
+  const alertMarkup =
+    triage.alerts.length > 0
+      ? triage.alerts
+          .map(
+            (alert, index) => `
+              <div class="diagnostics-alert" data-tone="${alert.tone}" data-testid="diagnostic-alert-${index}">
+                <strong>${escapeHtml(alert.label)}</strong>
+                <p>${escapeHtml(alert.detail)}</p>
+              </div>
+            `
+          )
+          .join("")
+      : `
+          <div class="diagnostics-alert" data-tone="neutral" data-testid="diagnostic-alert-0">
+            <strong>链路稳定</strong>
+            <p>当前没有发现明显的同步滞后或缺失快照。</p>
+          </div>
+        `;
+  const triageSections = triage.sections.map((section) => renderDiagnosticsTriageSection(section)).join("");
 
   return `
     <div class="log-panel diagnostics-panel" data-testid="diagnostic-panel">
       <div class="diagnostics-head">
         <div>
           <h3>开发态诊断</h3>
-          <p class="muted">统一查看房间、英雄、同步与最近链路状态。</p>
+          <p class="muted">统一查看房间、玩家、英雄、战斗与同步链路，直接定位问题更像是共享层、房间状态还是客户端渲染。</p>
         </div>
-        <button class="session-link" data-export-diagnostic="true" data-testid="diagnostic-export">导出快照</button>
+        <div class="diagnostics-actions">
+          <button class="session-link" data-copy-diagnostic-text="true" data-testid="diagnostic-copy-text">复制摘要</button>
+          <button class="session-link" data-export-diagnostic="true" data-testid="diagnostic-export">导出快照</button>
+        </div>
       </div>
       <div class="diagnostics-grid">
         <div class="diagnostics-card">
@@ -509,7 +578,12 @@ function renderDiagnosticPanel(): string {
           <p class="muted">${escapeHtml(`${state.account.source} · replays ${state.account.recentBattleReplays.length} · events ${state.account.recentEventLog.length}`)}</p>
         </div>
       </div>
-      <pre class="diagnostics-summary" data-testid="diagnostic-summary">${snapshotSummary}</pre>
+      <div class="diagnostics-alert-list" data-testid="diagnostic-alert-list">${alertMarkup}</div>
+      <div class="diagnostics-triage-grid">${triageSections}</div>
+      <details class="diagnostics-summary-shell">
+        <summary>紧凑摘要</summary>
+        <pre class="diagnostics-summary" data-testid="diagnostic-summary">${snapshotSummary}</pre>
+      </details>
       <p class="muted diagnostics-export-status" data-testid="diagnostic-export-status">${escapeHtml(state.diagnostics.exportStatus)}</p>
     </div>
   `;
@@ -4692,6 +4766,12 @@ function render(): void {
 
   for (const exportButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-export-diagnostic]"))) {
     exportButton.addEventListener("click", triggerDiagnosticSnapshotExport);
+  }
+
+  for (const copyButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-copy-diagnostic-text]"))) {
+    copyButton.addEventListener("click", () => {
+      void copyDiagnosticSnapshotText();
+    });
   }
 }
 

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -98,6 +98,16 @@ button {
   background: rgba(47, 110, 91, 0.1);
 }
 
+[data-tone="warning"] {
+  border-left-color: #b07a20;
+  background: rgba(176, 122, 32, 0.12);
+}
+
+[data-tone="danger"] {
+  border-left-color: #8a3131;
+  background: rgba(138, 49, 49, 0.12);
+}
+
 [data-tone="defeat"] {
   border-left-color: #6b4152;
   background: rgba(107, 65, 82, 0.1);
@@ -299,6 +309,13 @@ h1 {
   gap: 12px;
 }
 
+.diagnostics-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
 .diagnostics-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -329,11 +346,75 @@ h1 {
   margin-top: 8px;
 }
 
-.diagnostics-summary {
-  margin: 0;
+.diagnostics-alert-list,
+.diagnostics-triage-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.diagnostics-alert-list {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.diagnostics-alert {
+  padding: 12px;
+  border-radius: 14px;
+}
+
+.diagnostics-alert strong,
+.diagnostics-alert p {
+  display: block;
+}
+
+.diagnostics-alert p {
+  margin-top: 6px;
+}
+
+.diagnostics-triage-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.diagnostics-triage-section,
+.diagnostics-summary-shell {
   padding: 12px;
   border-radius: 14px;
   border: 1px solid rgba(78, 58, 42, 0.08);
+  background: rgba(255, 255, 255, 0.66);
+}
+
+.diagnostics-triage-head h4 {
+  font-size: 14px;
+}
+
+.diagnostics-triage-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.diagnostics-triage-row {
+  display: grid;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(247, 239, 228, 0.68);
+}
+
+.diagnostics-triage-row span {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.diagnostics-summary-shell summary {
+  cursor: pointer;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.diagnostics-summary {
+  margin: 10px 0 0;
+  padding: 12px;
+  border-radius: 14px;
   background: rgba(255, 248, 239, 0.88);
   color: #4f3f2f;
   font-size: 12px;
@@ -1814,11 +1895,14 @@ h1 {
   .account-replay-controls,
   .account-replay-report-summary,
   .account-replay-progress,
-  .diagnostics-grid {
+  .diagnostics-grid,
+  .diagnostics-triage-grid,
+  .diagnostics-alert-list {
     grid-template-columns: 1fr;
   }
 
   .account-editor,
+  .diagnostics-actions,
   .lobby-actions,
   .session-meta-row,
   .lobby-room-card-head {

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -121,6 +121,7 @@ export interface VeilHudRenderState {
   predictionStatus: string;
   inputDebug: string;
   runtimeHealth: string;
+  triageSummaryLines: string[];
   levelUpNotice: {
     title: string;
     detail: string;
@@ -306,6 +307,19 @@ export class VeilHudPanel extends Component {
         : hero && hero.move.remaining <= 0
           ? "今天已经没有移动点了。"
           : "点击地块移动，点击脚下资源即可采集。");
+    const statusLines = [
+      statusTitle,
+      statusDetail,
+      state.runtimeHealth,
+      ...state.triageSummaryLines,
+      formatAchievementSummary(state.account),
+      formatRecentEventLog(state.account),
+      latestBattleReport.title,
+      latestBattleReport.detail,
+      formatPresentationAudioSummary(state.presentation.audio),
+      formatPresentationLoadSummary(state.presentation.pixelAssets),
+      `表现 ${formatPresentationReadinessSummary(state.presentation.readiness)}`
+    ];
     const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
     const cardWidth = Math.max(168, transform.width - 28);
     const leftX = -transform.width / 2 + 14 + cardWidth / 2;
@@ -399,25 +413,14 @@ export class VeilHudPanel extends Component {
     cursorY = this.renderCardBlock(
       this.statusLabel,
       `${CARD_PREFIX}-status`,
-      [
-        statusTitle,
-        statusDetail,
-        state.runtimeHealth,
-        formatAchievementSummary(state.account),
-        formatRecentEventLog(state.account),
-        latestBattleReport.title,
-        latestBattleReport.detail,
-        formatPresentationAudioSummary(state.presentation.audio),
-        formatPresentationLoadSummary(state.presentation.pixelAssets),
-        `表现 ${formatPresentationReadinessSummary(state.presentation.readiness)}`
-      ],
+      statusLines,
       cursorY,
       12,
       16,
       cardWidth,
       leftX,
       4,
-      174
+      Math.max(174, 52 + statusLines.length * 16)
     );
 
     if (resources) {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -83,9 +83,11 @@ import { type CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
 import { createCocosBattlePresentationController } from "./cocos-battle-presentation-controller.ts";
 import { createCocosAudioRuntime } from "./cocos-audio-runtime.ts";
 import { createCocosAudioAssetBridge } from "./cocos-audio-resources.ts";
+import { buildCocosRuntimeTriageSummaryLines } from "./cocos-runtime-diagnostics.ts";
 import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
 import { cocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
 import { getPixelSpriteLoadStatus, loadPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
+import type { RuntimeDiagnosticsConnectionStatus } from "../../../../packages/shared/src/index.ts";
 
 const { ccclass, property } = _decorator;
 
@@ -224,6 +226,10 @@ export class VeilRoot extends Component {
   private wechatShareStatus = "分享功能仅在微信小游戏可用。";
   private wechatShareAvailable = false;
   private runtimeMemoryNotice = "";
+  private diagnosticsConnectionStatus: RuntimeDiagnosticsConnectionStatus = "connecting";
+  private lastRoomUpdateSource: string | null = null;
+  private lastRoomUpdateReason: string | null = null;
+  private lastRoomUpdateAtMs: number | null = null;
   private stopRuntimeMemoryWarnings: (() => void) | null = null;
   private battlePresentation = createCocosBattlePresentationController();
 
@@ -285,6 +291,7 @@ export class VeilRoot extends Component {
       return;
     }
 
+    this.diagnosticsConnectionStatus = "connecting";
     this.pushLog(`正在连接 ${this.remoteUrl} ...`);
     const replayed = resolveVeilRootRuntime().readStoredReplay(this.roomId, this.playerId);
     if (replayed) {
@@ -813,6 +820,22 @@ export class VeilRoot extends Component {
       predictionStatus: this.predictionStatus,
       inputDebug: this.inputDebug,
       runtimeHealth: this.describeRuntimeMemoryHealth(),
+      triageSummaryLines: buildCocosRuntimeTriageSummaryLines({
+        devOnly: true,
+        mode: this.lastUpdate?.battle ? "battle" : "world",
+        roomId: this.roomId,
+        playerId: this.playerId,
+        connectionStatus: this.diagnosticsConnectionStatus,
+        lastUpdateSource: this.lastRoomUpdateSource,
+        lastUpdateReason: this.lastRoomUpdateReason,
+        lastUpdateAt: this.lastRoomUpdateAtMs,
+        update: this.lastUpdate,
+        account: this.lobbyAccountProfile,
+        timelineEntries: this.timelineEntries,
+        logLines: this.logLines,
+        predictionStatus: this.predictionStatus,
+        recoverySummary: this.predictionStatus.includes("回放缓存状态") ? this.predictionStatus : null
+      }),
       levelUpNotice: this.levelUpNotice ? { title: this.levelUpNotice.title, detail: this.levelUpNotice.detail } : null,
       achievementNotice: this.achievementNotice
         ? { title: this.achievementNotice.title, detail: this.achievementNotice.detail }
@@ -2481,6 +2504,8 @@ export class VeilRoot extends Component {
   }
 
   private handleConnectionEvent(event: ConnectionEvent): void {
+    this.diagnosticsConnectionStatus =
+      event === "reconnecting" ? "reconnecting" : event === "reconnected" ? "connected" : "reconnect_failed";
     const label =
       event === "reconnecting"
         ? "连接已中断，正在尝试重连..."
@@ -2539,6 +2564,10 @@ export class VeilRoot extends Component {
 
     this.pendingPrediction = null;
     this.predictionStatus = "";
+    this.diagnosticsConnectionStatus = "connected";
+    this.lastRoomUpdateSource = "session";
+    this.lastRoomUpdateReason = update.reason ?? "snapshot";
+    this.lastRoomUpdateAtMs = Date.now();
     this.lastUpdate = update;
     const eventEntries = buildTimelineEntriesFromUpdate(update);
     if (eventEntries.length > 0) {
@@ -2650,6 +2679,9 @@ export class VeilRoot extends Component {
   private applyReplayedSessionUpdate(update: SessionUpdate): void {
     this.pendingPrediction = null;
     this.predictionStatus = "已回放缓存状态，等待房间同步...";
+    this.lastRoomUpdateSource = "replay";
+    this.lastRoomUpdateReason = "cached_snapshot";
+    this.lastRoomUpdateAtMs = Date.now();
     this.lastUpdate = {
       ...update,
       events: [],

--- a/apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts
+++ b/apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts
@@ -1,0 +1,149 @@
+import {
+  buildRuntimeDiagnosticsTriageView,
+  type RuntimeDiagnosticsConnectionStatus,
+  type RuntimeDiagnosticsMode,
+  type RuntimeDiagnosticsSnapshot
+} from "../../../../packages/shared/src/index.ts";
+import type { CocosPlayerAccountProfile } from "./cocos-lobby.ts";
+import type { SessionUpdate } from "./VeilCocosSession.ts";
+
+interface CocosTimelineEntrySnapshot {
+  id: string;
+  tone: string;
+  source: string;
+  text: string;
+}
+
+export interface CocosRuntimeDiagnosticsSnapshotInput {
+  exportedAt?: string;
+  devOnly: boolean;
+  mode: RuntimeDiagnosticsMode;
+  roomId: string;
+  playerId: string;
+  connectionStatus: RuntimeDiagnosticsConnectionStatus;
+  lastUpdateSource: string | null;
+  lastUpdateReason: string | null;
+  lastUpdateAt: number | null;
+  update: SessionUpdate | null;
+  account: CocosPlayerAccountProfile;
+  timelineEntries: string[];
+  logLines: string[];
+  predictionStatus: string;
+  recoverySummary: string | null;
+}
+
+function buildTimelineTail(entries: string[]): CocosTimelineEntrySnapshot[] {
+  return entries.slice(0, 4).map((entry, index) => ({
+    id: `cocos-timeline-${index + 1}`,
+    tone: "neutral",
+    source: "timeline",
+    text: entry
+  }));
+}
+
+export function buildCocosRuntimeDiagnosticsSnapshot(
+  input: CocosRuntimeDiagnosticsSnapshotInput
+): RuntimeDiagnosticsSnapshot {
+  const update = input.update;
+  const hero = update?.world.ownHeroes[0] ?? null;
+
+  return {
+    schemaVersion: 1,
+    exportedAt: input.exportedAt ?? new Date().toISOString(),
+    source: {
+      surface: "cocos-runtime-overlay",
+      devOnly: input.devOnly,
+      mode: input.mode
+    },
+    room: {
+      roomId: input.roomId,
+      playerId: input.playerId,
+      day: update?.world.meta.day ?? null,
+      connectionStatus: input.connectionStatus,
+      lastUpdateSource: input.lastUpdateSource,
+      lastUpdateReason: input.lastUpdateReason,
+      lastUpdateAt: input.lastUpdateAt ? new Date(input.lastUpdateAt).toISOString() : null
+    },
+    world: update
+      ? {
+          map: {
+            width: update.world.map.width,
+            height: update.world.map.height,
+            visibleTileCount: update.world.map.tiles.filter((tile) => tile.fog !== "hidden").length,
+            reachableTileCount: update.reachableTiles.length
+          },
+          resources: { ...update.world.resources },
+          selectedTile: null,
+          hoveredTile: null,
+          keyboardCursor: null,
+          hero: hero
+            ? {
+                id: hero.id,
+                name: hero.name,
+                position: { ...hero.position },
+                move: { ...hero.move },
+                stats: { ...hero.stats },
+                armyTemplateId: hero.armyTemplateId,
+                armyCount: hero.armyCount,
+                progression: { ...hero.progression }
+              }
+            : null,
+          visibleHeroes: update.world.visibleHeroes.map((visibleHero) => ({
+            id: visibleHero.id,
+            playerId: visibleHero.playerId,
+            position: { ...visibleHero.position }
+          }))
+        }
+      : null,
+    battle: update?.battle
+      ? {
+          id: update.battle.id,
+          round: update.battle.round,
+          activeUnitId: update.battle.activeUnitId,
+          selectedTargetId: null,
+          unitCount: Object.keys(update.battle.units).length,
+          environmentCount: update.battle.environment.length,
+          logTail: update.battle.log.slice(-6)
+        }
+      : null,
+    account: {
+      playerId: input.account.playerId,
+      displayName: input.account.displayName,
+      source: input.account.source,
+      loginId: input.account.loginId ?? null,
+      recentEventCount: input.account.recentEventLog.length,
+      recentReplayCount: input.account.recentBattleReplays.length
+    },
+    overview: null,
+    diagnostics: {
+      eventTypes: [],
+      timelineTail: buildTimelineTail(input.timelineEntries),
+      logTail: input.logLines.slice(0, 6),
+      recoverySummary: input.recoverySummary,
+      predictionStatus: input.predictionStatus || null,
+      pendingUiTasks: 0,
+      replay: null
+    }
+  };
+}
+
+export function buildCocosRuntimeTriageSummaryLines(
+  input: CocosRuntimeDiagnosticsSnapshotInput,
+  now: number | string | Date = Date.now()
+): string[] {
+  const snapshot = buildCocosRuntimeDiagnosticsSnapshot(input);
+  const triage = buildRuntimeDiagnosticsTriageView(snapshot, now);
+  const lines = triage.alerts.slice(0, 2).map((alert) => `${alert.label} · ${alert.detail}`);
+  const syncSection = triage.sections.find((section) => section.id === "sync");
+  const heroSection = triage.sections.find((section) => section.id === "heroes");
+
+  if (syncSection?.items[0]) {
+    lines.push(`${syncSection.items[0].label} ${syncSection.items[0].value}`);
+  }
+
+  if (heroSection?.items[0]) {
+    lines.push(`${heroSection.items[0].label} ${heroSection.items[0].value}`);
+  }
+
+  return lines.slice(0, 4);
+}

--- a/apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
+++ b/apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCocosRuntimeDiagnosticsSnapshot, buildCocosRuntimeTriageSummaryLines } from "../assets/scripts/cocos-runtime-diagnostics.ts";
+import { createFallbackCocosPlayerAccountProfile } from "../assets/scripts/cocos-lobby.ts";
+import { createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
+
+test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage", () => {
+  const account = createFallbackCocosPlayerAccountProfile("player-1", "room-alpha", "暮潮守望");
+  const update = createSessionUpdate(5, "room-alpha", "player-1");
+  update.world.visibleHeroes = [
+    {
+      id: "hero-2",
+      playerId: "player-2",
+      name: "敌方先锋",
+      position: { x: 1, y: 0 }
+    }
+  ];
+
+  const snapshot = buildCocosRuntimeDiagnosticsSnapshot({
+    exportedAt: "2026-03-29T09:00:00.000Z",
+    devOnly: true,
+    mode: "world",
+    roomId: "room-alpha",
+    playerId: "player-1",
+    connectionStatus: "reconnecting",
+    lastUpdateSource: "replay",
+    lastUpdateReason: "cached_snapshot",
+    lastUpdateAt: Date.parse("2026-03-29T08:59:40.000Z"),
+    update,
+    account,
+    timelineEntries: ["房间 room-alpha 已恢复同步。"],
+    logLines: ["连接已中断，正在尝试重连...", "已回放缓存状态，等待房间同步..."],
+    predictionStatus: "已回放缓存状态，等待房间同步...",
+    recoverySummary: "已回放缓存状态，等待房间同步..."
+  });
+
+  assert.equal(snapshot.source.surface, "cocos-runtime-overlay");
+  assert.equal(snapshot.room?.connectionStatus, "reconnecting");
+  assert.equal(snapshot.world?.hero?.id, "hero-1");
+  assert.equal(snapshot.world?.visibleHeroes[0]?.playerId, "player-2");
+  assert.equal(snapshot.diagnostics.recoverySummary, "已回放缓存状态，等待房间同步...");
+
+  const lines = buildCocosRuntimeTriageSummaryLines(
+    {
+      devOnly: true,
+      mode: "world",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      connectionStatus: "reconnecting",
+      lastUpdateSource: "replay",
+      lastUpdateReason: "cached_snapshot",
+      lastUpdateAt: Date.parse("2026-03-29T08:59:40.000Z"),
+      update,
+      account,
+      timelineEntries: ["房间 room-alpha 已恢复同步。"],
+      logLines: ["连接已中断，正在尝试重连...", "已回放缓存状态，等待房间同步..."],
+      predictionStatus: "已回放缓存状态，等待房间同步...",
+      recoverySummary: "已回放缓存状态，等待房间同步..."
+    },
+    "2026-03-29T09:00:20.000Z"
+  );
+
+  assert.deepEqual(lines, [
+    "同步中断 · 客户端正在尝试重连房间。",
+    "同步滞后 · 最后权威更新距今 40s。",
+    "最后同步年龄 40s",
+    "主控英雄 暮潮守望 @ 0,0"
+  ]);
+});

--- a/packages/shared/src/runtime-diagnostics.ts
+++ b/packages/shared/src/runtime-diagnostics.ts
@@ -150,6 +150,285 @@ export interface RuntimeDiagnosticsSnapshot {
   };
 }
 
+export type RuntimeDiagnosticsTriageTone = "neutral" | "warning" | "danger";
+
+export interface RuntimeDiagnosticsTriageAlert {
+  tone: RuntimeDiagnosticsTriageTone;
+  label: string;
+  detail: string;
+}
+
+export interface RuntimeDiagnosticsTriageItem {
+  label: string;
+  value: string;
+  tone?: RuntimeDiagnosticsTriageTone;
+}
+
+export interface RuntimeDiagnosticsTriageSection {
+  id: "room" | "players" | "heroes" | "battle" | "sync" | "recent-events";
+  title: string;
+  items: RuntimeDiagnosticsTriageItem[];
+}
+
+export interface RuntimeDiagnosticsTriageView {
+  alerts: RuntimeDiagnosticsTriageAlert[];
+  sections: RuntimeDiagnosticsTriageSection[];
+}
+
+function formatSyncAge(ms: number): string {
+  if (ms < 1_000) {
+    return `${ms}ms`;
+  }
+
+  if (ms < 60_000) {
+    return `${(ms / 1_000).toFixed(ms >= 10_000 ? 0 : 1)}s`;
+  }
+
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+export function getRuntimeDiagnosticsLastSyncAgeMs(
+  snapshot: RuntimeDiagnosticsSnapshot,
+  now: number | string | Date = Date.now()
+): number | null {
+  if (!snapshot.room?.lastUpdateAt) {
+    return null;
+  }
+
+  const nowMs = typeof now === "number" ? now : new Date(now).getTime();
+  const lastUpdateMs = Date.parse(snapshot.room.lastUpdateAt);
+  if (!Number.isFinite(nowMs) || !Number.isFinite(lastUpdateMs)) {
+    return null;
+  }
+
+  return Math.max(0, nowMs - lastUpdateMs);
+}
+
+export function buildRuntimeDiagnosticsTriageView(
+  snapshot: RuntimeDiagnosticsSnapshot,
+  now: number | string | Date = Date.now()
+): RuntimeDiagnosticsTriageView {
+  const alerts: RuntimeDiagnosticsTriageAlert[] = [];
+  const lastSyncAgeMs = getRuntimeDiagnosticsLastSyncAgeMs(snapshot, now);
+  const visiblePlayerIds = Array.from(
+    new Set([
+      ...(snapshot.world?.hero ? [snapshot.room?.playerId ?? snapshot.account?.playerId ?? ""] : []),
+      ...(snapshot.world?.visibleHeroes.map((hero) => hero.playerId) ?? [])
+    ].filter((value) => value.length > 0))
+  );
+
+  if (snapshot.room?.connectionStatus === "reconnecting") {
+    alerts.push({
+      tone: "warning",
+      label: "同步中断",
+      detail: "客户端正在尝试重连房间。"
+    });
+  } else if (snapshot.room?.connectionStatus === "reconnect_failed") {
+    alerts.push({
+      tone: "danger",
+      label: "重连失败",
+      detail: "需要依赖本地缓存或重新进入房间。"
+    });
+  }
+
+  if (lastSyncAgeMs != null && lastSyncAgeMs >= 15_000) {
+    alerts.push({
+      tone: lastSyncAgeMs >= 30_000 ? "danger" : "warning",
+      label: "同步滞后",
+      detail: `最后权威更新距今 ${formatSyncAge(lastSyncAgeMs)}。`
+    });
+  }
+
+  if (snapshot.source.mode !== "server" && snapshot.source.mode !== "lobby" && snapshot.world == null) {
+    alerts.push({
+      tone: "danger",
+      label: "世界快照缺失",
+      detail: "当前客户端没有可用于排障的世界状态。"
+    });
+  }
+
+  if (snapshot.source.mode === "world" && snapshot.world && snapshot.world.hero == null) {
+    alerts.push({
+      tone: "warning",
+      label: "可控英雄缺失",
+      detail: "世界状态已存在，但当前玩家没有可控英雄。"
+    });
+  }
+
+  if (snapshot.source.mode === "battle" && snapshot.battle == null) {
+    alerts.push({
+      tone: "warning",
+      label: "战斗快照缺失",
+      detail: "客户端处于战斗模式，但当前没有活动战斗状态。"
+    });
+  }
+
+  if (snapshot.diagnostics.pendingUiTasks > 0) {
+    alerts.push({
+      tone: snapshot.diagnostics.pendingUiTasks >= 5 ? "warning" : "neutral",
+      label: "待处理 UI 任务",
+      detail: `前端仍有 ${snapshot.diagnostics.pendingUiTasks} 个排队任务。`
+    });
+  }
+
+  if (snapshot.diagnostics.recoverySummary) {
+    alerts.push({
+      tone: "neutral",
+      label: "恢复链路",
+      detail: snapshot.diagnostics.recoverySummary
+    });
+  }
+
+  const sections: RuntimeDiagnosticsTriageSection[] = [
+    {
+      id: "room",
+      title: "房间",
+      items: snapshot.room
+        ? [
+            { label: "房间", value: snapshot.room.roomId },
+            { label: "玩家", value: snapshot.room.playerId },
+            ...(() => {
+              const tone: RuntimeDiagnosticsTriageTone | null =
+                snapshot.room.connectionStatus === "reconnect_failed"
+                  ? "danger"
+                  : snapshot.room.connectionStatus === "reconnecting"
+                    ? "warning"
+                    : null;
+              return [
+                tone
+                  ? { label: "连接", value: snapshot.room.connectionStatus, tone }
+                  : { label: "连接", value: snapshot.room.connectionStatus }
+              ];
+            })(),
+            { label: "天数", value: snapshot.room.day == null ? "未知" : `Day ${snapshot.room.day}` },
+            {
+              label: "最后更新",
+              value:
+                snapshot.room.lastUpdateSource || snapshot.room.lastUpdateReason
+                  ? `${snapshot.room.lastUpdateSource ?? "unknown"} / ${snapshot.room.lastUpdateReason ?? "snapshot"}`
+                  : "未记录"
+            }
+          ]
+        : [{ label: "状态", value: "当前快照没有房间上下文", tone: "warning" }]
+    },
+    {
+      id: "players",
+      title: "玩家",
+      items: [
+        {
+          label: "账号",
+          value: snapshot.account ? `${snapshot.account.displayName} (${snapshot.account.source})` : "未加载"
+        },
+        {
+          label: "可见玩家",
+          value: visiblePlayerIds.length > 0 ? visiblePlayerIds.join(", ") : "仅本地玩家"
+        },
+        {
+          label: "最近事件数",
+          value: snapshot.account ? `${snapshot.account.recentEventCount}` : "0"
+        },
+        {
+          label: "最近回放数",
+          value: snapshot.account ? `${snapshot.account.recentReplayCount}` : "0"
+        }
+      ]
+    },
+    {
+      id: "heroes",
+      title: "英雄",
+      items: snapshot.world
+        ? [
+            {
+              label: "主控英雄",
+              value: snapshot.world.hero ? `${snapshot.world.hero.name} @ ${snapshot.world.hero.position.x},${snapshot.world.hero.position.y}` : "缺失",
+              tone: snapshot.world.hero ? "neutral" : "warning"
+            },
+            {
+              label: "移动力",
+              value: snapshot.world.hero
+                ? `${snapshot.world.hero.move.remaining}/${snapshot.world.hero.move.total}`
+                : "未知"
+            },
+            {
+              label: "生命",
+              value: snapshot.world.hero
+                ? `${snapshot.world.hero.stats.hp}/${snapshot.world.hero.stats.maxHp}`
+                : "未知"
+            },
+            {
+              label: "可见英雄",
+              value:
+                snapshot.world.visibleHeroes.length > 0
+                  ? snapshot.world.visibleHeroes
+                      .map((hero) => `${hero.playerId}:${hero.id}@${hero.position.x},${hero.position.y}`)
+                      .join(" | ")
+                  : "无"
+            }
+          ]
+        : [{ label: "状态", value: "当前没有世界快照", tone: "warning" }]
+    },
+    {
+      id: "battle",
+      title: "战斗",
+      items: snapshot.battle
+        ? [
+            { label: "战斗", value: snapshot.battle.id },
+            { label: "回合", value: `${snapshot.battle.round}` },
+            { label: "行动单位", value: snapshot.battle.activeUnitId ?? "无" },
+            { label: "锁定目标", value: snapshot.battle.selectedTargetId ?? "无" }
+          ]
+        : [{ label: "状态", value: "当前不在战斗中" }]
+    },
+    {
+      id: "sync",
+      title: "同步",
+      items: [
+        {
+          label: "最后同步年龄",
+          value: lastSyncAgeMs == null ? "未记录" : formatSyncAge(lastSyncAgeMs),
+          ...(lastSyncAgeMs != null && lastSyncAgeMs >= 15_000
+            ? { tone: lastSyncAgeMs >= 30_000 ? ("danger" as const) : ("warning" as const) }
+            : {})
+        },
+        {
+          label: "预测状态",
+          value: snapshot.diagnostics.predictionStatus ?? "空闲"
+        },
+        {
+          label: "恢复状态",
+          value: snapshot.diagnostics.recoverySummary ?? "无"
+        },
+        {
+          label: "事件类型",
+          value: snapshot.diagnostics.eventTypes.length > 0 ? snapshot.diagnostics.eventTypes.join(", ") : "无"
+        }
+      ]
+    },
+    {
+      id: "recent-events",
+      title: "最近事件",
+      items: [
+        {
+          label: "时间线",
+          value:
+            snapshot.diagnostics.timelineTail.length > 0
+              ? snapshot.diagnostics.timelineTail
+                  .slice(0, 2)
+                  .map((entry) => `[${entry.source}/${entry.tone}] ${entry.text}`)
+                  .join(" | ")
+              : "无"
+        },
+        {
+          label: "日志",
+          value: snapshot.diagnostics.logTail.length > 0 ? snapshot.diagnostics.logTail.slice(0, 2).join(" | ") : "无"
+        }
+      ]
+    }
+  ];
+
+  return { alerts, sections };
+}
+
 export function buildRuntimeDiagnosticsSummaryLines(snapshot: RuntimeDiagnosticsSnapshot): string[] {
   const lines = [`Mode ${snapshot.source.mode} (${snapshot.source.surface})`];
 

--- a/packages/shared/test/runtime-diagnostics.test.ts
+++ b/packages/shared/test/runtime-diagnostics.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildRuntimeDiagnosticsTriageView,
   buildRuntimeDiagnosticsSummaryLines,
+  getRuntimeDiagnosticsLastSyncAgeMs,
   renderRuntimeDiagnosticsSnapshotText,
   type RuntimeDiagnosticsSnapshot
 } from "../src/index";
@@ -182,4 +184,31 @@ test("runtime diagnostics summary text supports aggregate server snapshots", () 
     "Auth guest=1 / account=2 / queue=1 / deadLetters=0",
     "Room summary room-alpha / day 3 / players 2 / heroes 2 / battles 1"
   ]);
+});
+
+test("runtime diagnostics triage view highlights stale sync and missing hero state", () => {
+  const snapshot = createRuntimeDiagnosticsSnapshot();
+  snapshot.world!.hero = null;
+  snapshot.room!.lastUpdateAt = "2026-03-29T07:08:30.000Z";
+
+  const ageMs = getRuntimeDiagnosticsLastSyncAgeMs(snapshot, "2026-03-29T07:09:10.000Z");
+  assert.equal(ageMs, 40_000);
+
+  const triage = buildRuntimeDiagnosticsTriageView(snapshot, "2026-03-29T07:09:10.000Z");
+  assert.deepEqual(
+    triage.alerts.map((alert) => alert.label),
+    ["同步滞后", "可控英雄缺失", "待处理 UI 任务", "恢复链路"]
+  );
+  assert.equal(triage.sections[0]?.id, "room");
+  assert.equal(triage.sections[4]?.id, "sync");
+  assert.deepEqual(triage.sections[4]?.items[0], {
+    label: "最后同步年龄",
+    value: "40s",
+    tone: "danger"
+  });
+  assert.deepEqual(triage.sections[2]?.items[0], {
+    label: "主控英雄",
+    value: "缺失",
+    tone: "warning"
+  });
 });

--- a/tests/e2e/diagnostic-panel.spec.ts
+++ b/tests/e2e/diagnostic-panel.spec.ts
@@ -30,6 +30,9 @@ test("developer diagnostics panel exports a compact gameplay snapshot", async ({
   await expect(page.getByTestId("hero-move")).toHaveText(/Move 6\/6/, { timeout: 10_000 });
   await expect(page.getByTestId("diagnostic-panel")).toBeVisible();
   await expect(page.getByTestId("diagnostic-connection-status")).toHaveText("已连接");
+  await expect(page.getByTestId("diagnostic-alert-list")).toContainText("链路稳定");
+  await expect(page.getByTestId("diagnostic-section-room")).toContainText(roomId);
+  await expect(page.getByTestId("diagnostic-section-sync")).toContainText("connected");
   await expect(page.getByTestId("diagnostic-summary")).toContainText(`Room ${roomId} / Player player-1 / Sync connected`);
 
   const exported = await page.evaluate(() => window.export_diagnostic_snapshot?.() ?? null);
@@ -45,6 +48,9 @@ test("developer diagnostics panel exports a compact gameplay snapshot", async ({
   expect(snapshot.world?.hero?.id).toBe("hero-1");
   expect(snapshot.world?.resources).toEqual({ gold: 0, wood: 0, ore: 0 });
   expect(snapshot.diagnostics.logTail[0]).toContain(`Room ${roomId}`);
+
+  await page.getByTestId("diagnostic-copy-text").click();
+  await expect(page.getByTestId("diagnostic-export-status")).toHaveText("已复制紧凑摘要");
 
   const downloadPromise = page.waitForEvent("download");
   await page.getByTestId("diagnostic-export").click();


### PR DESCRIPTION
## Summary
- add a shared runtime diagnostics triage model that converts snapshots into alert chips and structured room/player/hero/battle/sync/event sections
- replace the H5 dev diagnostics dump with a structured triage panel plus one-click compact-text copy and JSON export
- add a minimal Cocos HUD triage summary that reuses the same shared snapshot shape and cover the new paths with shared/Cocos regression tests

## Test Plan
- `node --import tsx --test packages/shared/test/runtime-diagnostics.test.ts apps/client/test/runtime-diagnostics.test.ts apps/cocos-client/test/cocos-runtime-diagnostics.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:client:h5`
- `npm run typecheck:cocos`
- `npx playwright test tests/e2e/diagnostic-panel.spec.ts` *(fails locally in this container: missing `libatk-bridge-2.0.so.0` for Chromium headless)*