### PR TITLE
test: add H5 boot and local-session regression coverage (#277)

### DIFF
--- a/apps/client/test/local-session.test.ts
+++ b/apps/client/test/local-session.test.ts
@@ -206,6 +206,19 @@ test("createGameSession falls back to a local session when remote bootstrap is u
   assert.equal(update.world.playerId, "player-1");
 });
 
+test("createGameSession falls back to a local session when remote bootstrap times out", async () => {
+  const session = await localSessionTestHooks.createGameSessionWithRuntime("room-alpha", "player-1", 1001, undefined, {
+    async connectRemoteGameSession() {
+      throw new Error("connect_timeout");
+    }
+  });
+
+  const update = await session.snapshot("timeout-fallback");
+  assert.equal(update.reason, "timeout-fallback");
+  assert.equal(update.world.meta.roomId, "room-alpha");
+  assert.equal(update.world.playerId, "player-1");
+});
+
 test("createGameSession surfaces stored-token recovery as a successful remote resume", async () => {
   const events: ConnectionEvent[] = [];
   const session = await localSessionTestHooks.createGameSessionWithRuntime(

--- a/apps/client/test/main-boot.test.ts
+++ b/apps/client/test/main-boot.test.ts
@@ -201,6 +201,9 @@ test("bootstrapH5App keeps the cached session visible and marks boot failure whe
     "render"
   ]);
   assert.equal(state.diagnostics.connectionStatus, "reconnect_failed");
+  assert.equal(state.lobby.displayName, "访客骑士");
+  assert.equal(state.accountDraftName, "访客骑士");
+  assert.equal(state.accountLoginId, "veil-ranger");
   assert.deepEqual(state.log, ["远端会话暂不可用，当前仅展示最近缓存状态。", "old-line"]);
 });
 
@@ -374,4 +377,37 @@ test("registerAutomationHooks wires CI-facing automation helpers and only expose
   assert.equal(devWindow.render_game_to_text?.(), "rendered-dev");
   assert.equal(devWindow.export_diagnostic_snapshot?.(), "diagnostic-dev");
   assert.equal(devWindow.render_diagnostic_snapshot_to_text?.(), "diagnostic-text-dev");
+});
+
+test("registerAutomationHooks removes dev-only debug exports when the same window is re-registered for non-dev boot", async () => {
+  const sharedWindow: {
+    render_game_to_text?: () => string;
+    export_diagnostic_snapshot?: () => string;
+    render_diagnostic_snapshot_to_text?: () => string;
+    advanceTime?: (ms: number) => Promise<void>;
+  } = {};
+
+  registerAutomationHooks({
+    window: sharedWindow,
+    devDiagnosticsEnabled: true,
+    renderGameToText: () => "rendered-dev",
+    exportDiagnosticSnapshot: () => "diagnostic-dev",
+    renderDiagnosticSnapshotToText: () => "diagnostic-text-dev",
+    advanceUiTime: async () => {}
+  });
+  registerAutomationHooks({
+    window: sharedWindow,
+    devDiagnosticsEnabled: false,
+    renderGameToText: () => "rendered-prod",
+    exportDiagnosticSnapshot: () => "diagnostic-prod",
+    renderDiagnosticSnapshotToText: () => "diagnostic-text-prod",
+    advanceUiTime: async (ms) => {
+      assert.equal(ms, 32);
+    }
+  });
+
+  assert.equal(sharedWindow.render_game_to_text?.(), "rendered-prod");
+  assert.equal(sharedWindow.export_diagnostic_snapshot, undefined);
+  assert.equal(sharedWindow.render_diagnostic_snapshot_to_text, undefined);
+  await assert.doesNotReject(async () => sharedWindow.advanceTime?.(32));
 });


### PR DESCRIPTION
## Summary
- add a local-session regression covering remote bootstrap timeout fallback to the local session
- tighten H5 boot failure assertions so cached-session fallback keeps synced account boot state visible
- add a hook-registration regression proving dev-only debug exports are removed when the same window is later booted in non-dev mode

## Testing
- node --import tsx --test apps/client/test/main-boot.test.ts apps/client/test/local-session.test.ts