### PR TITLE
test: lock Cocos runtime handoff paths (#278)

### DIFF
--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -222,3 +222,49 @@ test("VeilRoot keeps the lobby visible and explains when an account session has 
   assert.equal(root.sessionSource, "none");
   assert.equal(root.lobbyStatus, "账号会话已失效，请重新登录后再进入房间。");
 });
+
+test("VeilRoot forwards session connection events into runtime diagnostics and logs", async () => {
+  const root = createVeilRootHarness();
+  root.roomId = "room-alpha";
+  root.playerId = "player-1";
+  root.displayName = "暮潮守望";
+  root.authToken = "account.token";
+
+  const liveUpdate = createSessionUpdate(7);
+  let capturedOptions:
+    | {
+        onConnectionEvent?: ((event: "reconnecting" | "reconnected" | "reconnect_failed") => void) | undefined;
+        getDisplayName?: (() => string) | undefined;
+        getAuthToken?: (() => string | null) | undefined;
+      }
+    | undefined;
+
+  installVeilRootRuntime({
+    createSession: async (_roomId, _playerId, _seed, options) => {
+      capturedOptions = options;
+      return {
+        async snapshot() {
+          return liveUpdate;
+        },
+        async dispose() {}
+      } as never;
+    }
+  });
+
+  await root.connect();
+
+  assert.equal(capturedOptions?.getDisplayName?.(), "暮潮守望");
+  assert.equal(capturedOptions?.getAuthToken?.(), "account.token");
+
+  capturedOptions?.onConnectionEvent?.("reconnecting");
+  assert.equal(root.diagnosticsConnectionStatus, "reconnecting");
+  assert.equal(root.logLines[0], "连接已中断，正在尝试重连...");
+
+  capturedOptions?.onConnectionEvent?.("reconnected");
+  assert.equal(root.diagnosticsConnectionStatus, "connected");
+  assert.equal(root.logLines[0], "连接已恢复。");
+
+  capturedOptions?.onConnectionEvent?.("reconnect_failed");
+  assert.equal(root.diagnosticsConnectionStatus, "reconnect_failed");
+  assert.equal(root.logLines[0], "重连失败，正在尝试恢复房间快照...");
+});

--- a/apps/cocos-client/test/cocos-session-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-session-orchestration.test.ts
@@ -127,3 +127,38 @@ test("VeilCocosSession hands off to a fresh room after reconnect failure and rep
 
   await session.dispose();
 });
+
+test("VeilCocosSession includes display name and auth token in the authenticated connect payload", async () => {
+  const storage = createMemoryStorage();
+  const room = new FakeColyseusRoom([createSessionUpdate(8)], "reconnect-token");
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    loadSdk: createSdkLoader({
+      joinRooms: [room]
+    })
+  });
+
+  const session = await VeilCocosSession.create("room-alpha", "player-1", 1001, {
+    getDisplayName: () => "暮潮守望",
+    getAuthToken: () => "account.token"
+  });
+
+  await session.snapshot();
+
+  assert.deepEqual(room.sentMessages, [
+    {
+      type: "connect",
+      payload: {
+        type: "connect",
+        requestId: "cocos-req-1",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        displayName: "暮潮守望",
+        authToken: "account.token"
+      }
+    }
+  ]);
+
+  await session.dispose();
+});


### PR DESCRIPTION
## Summary
- add a VeilRoot harness test that captures session options and verifies runtime connection events update diagnostics/log state
- add a VeilCocosSession harness test that locks authenticated connect payload propagation for display name and auth token
- keep the slice focused on runtime handoff behavior already called out by #278

## Test Notes
- `node --import tsx --test apps/cocos-client/test/cocos-root-orchestration.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-session-orchestration.test.ts`