### PR TITLE
test(wechat): harden smoke-report validation for share/reconnect (#283)

### DIFF
--- a/apps/cocos-client/test/cocos-wechat-smoke-release.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-smoke-release.test.ts
@@ -123,7 +123,7 @@ test("smoke:wechat-release validates a completed acceptance report", () => {
 
   const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
     execution: { tester: string; device: string; clientVersion: string; executedAt: string; result: string; summary: string };
-    cases: Array<{ status: string; notes: string; evidence: string[] }>;
+    cases: Array<{ id: string; status: string; notes: string; evidence: string[]; requiredEvidence?: Record<string, string> }>;
   };
   report.execution.tester = "codex";
   report.execution.device = "iPhone 15 / WeChat 8.0.x";
@@ -135,6 +135,18 @@ test("smoke:wechat-release validates a completed acceptance report", () => {
     entry.status = "passed";
     entry.notes = "ok";
     entry.evidence = ["manual"];
+  }
+  const reconnectCase = report.cases.find((entry) => entry.id === "reconnect-recovery");
+  if (reconnectCase?.requiredEvidence) {
+    reconnectCase.requiredEvidence.roomId = "room-alpha";
+    reconnectCase.requiredEvidence.reconnectPrompt = "连接已恢复";
+    reconnectCase.requiredEvidence.restoredState = "Returned to room-alpha with Move 4/6 and Wood 5.";
+  }
+  const shareCase = report.cases.find((entry) => entry.id === "share-roundtrip");
+  if (shareCase?.requiredEvidence) {
+    shareCase.requiredEvidence.shareScene = "lobby";
+    shareCase.requiredEvidence.shareQuery = "roomId=room-alpha&inviterId=player-7&shareScene=lobby";
+    shareCase.requiredEvidence.roundtripState = "Roundtrip reopened room-alpha and restored inviterId player-7.";
   }
   fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
 
@@ -176,7 +188,7 @@ test("smoke:wechat-release rejects incomplete acceptance reports", () => {
 
   const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
     execution: { tester: string; device: string; executedAt: string; result: string };
-    cases: Array<{ id: string; status: string }>;
+    cases: Array<{ id: string; status: string; requiredEvidence?: Record<string, string> }>;
   };
   report.execution.tester = "codex";
   report.execution.device = "Android / WeChat";
@@ -185,9 +197,16 @@ test("smoke:wechat-release rejects incomplete acceptance reports", () => {
   for (const entry of report.cases) {
     entry.status = "passed";
   }
+  const reconnectCase = report.cases.find((entry) => entry.id === "reconnect-recovery");
+  if (reconnectCase?.requiredEvidence) {
+    reconnectCase.requiredEvidence.roomId = "room-alpha";
+    reconnectCase.requiredEvidence.reconnectPrompt = "连接已恢复";
+    reconnectCase.requiredEvidence.restoredState = "Recovered into the same room without rollback.";
+  }
   const shareCase = report.cases.find((entry) => entry.id === "share-roundtrip");
-  if (shareCase) {
-    shareCase.status = "pending";
+  if (shareCase?.requiredEvidence) {
+    shareCase.requiredEvidence.shareScene = "battle";
+    shareCase.requiredEvidence.roundtripState = "Returned to battle room room-alpha after share.";
   }
   fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
 
@@ -202,6 +221,62 @@ test("smoke:wechat-release rejects incomplete acceptance reports", () => {
           stdio: "pipe"
         }
       ),
-    /Smoke report case login-lobby is still pending.|Smoke report case share-roundtrip is still pending./
+    /"path":"cases\[\d+\]#share-roundtrip\.requiredEvidence\.shareQuery","message":"Share-roundtrip case must record the emitted share query or equivalent payload summary\."/
+  );
+});
+
+test("smoke:wechat-release rejects missing reconnect evidence fields", () => {
+  const { artifactsDir, reportPath } = createPackagedWechatReleaseArtifact();
+
+  execFileSync(
+    "node",
+    ["--import", "tsx", "./scripts/smoke-wechat-minigame-release.ts", "--artifacts-dir", artifactsDir],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      stdio: "pipe"
+    }
+  );
+
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
+    execution: { tester: string; device: string; clientVersion: string; executedAt: string; result: string; summary: string };
+    cases: Array<{ id: string; status: string; notes: string; evidence: string[]; requiredEvidence?: Record<string, string> }>;
+  };
+  report.execution.tester = "codex";
+  report.execution.device = "iPhone 15 / WeChat 8.0.x";
+  report.execution.clientVersion = "1.0.155";
+  report.execution.executedAt = "2026-03-28T23:50:00+08:00";
+  report.execution.result = "passed";
+  report.execution.summary = "Reconnect evidence should fail fast when a required field is missing.";
+
+  for (const entry of report.cases) {
+    entry.status = "passed";
+    entry.notes = "ok";
+    entry.evidence = ["manual"];
+  }
+  const reconnectCase = report.cases.find((entry) => entry.id === "reconnect-recovery");
+  if (reconnectCase?.requiredEvidence) {
+    reconnectCase.requiredEvidence.roomId = "room-alpha";
+    reconnectCase.requiredEvidence.restoredState = "Recovered into the same room without rollback.";
+  }
+  const shareCase = report.cases.find((entry) => entry.id === "share-roundtrip");
+  if (shareCase?.requiredEvidence) {
+    shareCase.requiredEvidence.shareScene = "lobby";
+    shareCase.requiredEvidence.shareQuery = "roomId=room-alpha&inviterId=player-7&shareScene=lobby";
+    shareCase.requiredEvidence.roundtripState = "Roundtrip reopened room-alpha and restored inviterId player-7.";
+  }
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+
+  assert.throws(
+    () =>
+      execFileSync(
+        "node",
+        ["--import", "tsx", "./scripts/smoke-wechat-minigame-release.ts", "--artifacts-dir", artifactsDir, "--check"],
+        {
+          cwd: path.resolve(__dirname, "../../.."),
+          encoding: "utf8",
+          stdio: "pipe"
+        }
+      ),
+    /"path":"cases\[\d+\]#reconnect-recovery\.requiredEvidence\.reconnectPrompt","message":"Reconnect case must record the reconnect prompt or equivalent recovery signal\."/
   );
 });

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -98,12 +98,22 @@
 - `share-roundtrip`：验证分享链路与回流后房间号 / 邀请参数恢复
 - `key-assets`：验证首屏、Lobby、房间或首场战斗关键资源加载无白名单 / 缺图 / 404
 
+其中两条 case 额外带有强制结构化证据字段，`--check` 时会直接校验：
+
+- `reconnect-recovery.requiredEvidence.roomId`：恢复后确认仍在原权威房间
+- `reconnect-recovery.requiredEvidence.reconnectPrompt`：记录“连接已恢复”或等效恢复提示
+- `reconnect-recovery.requiredEvidence.restoredState`：记录恢复后未回档的关键状态
+- `share-roundtrip.requiredEvidence.shareScene`：记录从 Lobby / 世界 / 战斗中的哪个入口触发分享
+- `share-roundtrip.requiredEvidence.shareQuery`：记录分享 query 或等效 payload 摘要，至少覆盖 `roomId` / `inviterId` 等关键参数
+- `share-roundtrip.requiredEvidence.roundtripState`：记录回流后识别到的房间号、邀请参数或恢复到的界面状态
+
 推荐执行方式：
 
 1. 先跑 `npm run verify:wechat-release -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>]`
 2. 再跑 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板
 3. 在真机或微信开发者工具真机调试模式中逐项填写 `tester`、`device`、`executedAt`、`summary` 以及每个 case 的 `status` / `notes` / `evidence`
-   - `reconnect-recovery` 至少要记录原 `roomId`、恢复提示、恢复后未回档状态三项证据；细则见 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md)
+   - `reconnect-recovery.requiredEvidence` 下的 `roomId`、`reconnectPrompt`、`restoredState` 都必须填非空字符串；细则见 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md)
+   - `share-roundtrip.requiredEvidence` 下的 `shareScene`、`shareQuery`、`roundtripState` 也都必须填非空字符串，用来说明分享入口、参数和回流结果
 4. 回填完成后执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`
 5. 再执行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把 `login-lobby`、`room-entry`、`reconnect-recovery` 映射到统一 RC 快照，并补齐 `firstBattleResult` 与 `return-to-world` 证据。
 6. 复制并回填 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，确保 reviewer 能直接看到当前 RC 的设备、结论与未关闭风险。

--- a/scripts/smoke-wechat-minigame-release.ts
+++ b/scripts/smoke-wechat-minigame-release.ts
@@ -29,6 +29,21 @@ interface WechatMinigameReleasePackageMetadata {
 
 type SmokeStatus = "pending" | "passed" | "failed" | "not_applicable";
 
+type ReconnectEvidenceFieldId = "roomId" | "reconnectPrompt" | "restoredState";
+type ShareRoundtripEvidenceFieldId = "shareScene" | "shareQuery" | "roundtripState";
+
+interface ReconnectRecoveryEvidence {
+  roomId: string;
+  reconnectPrompt: string;
+  restoredState: string;
+}
+
+interface ShareRoundtripEvidence {
+  shareScene: string;
+  shareQuery: string;
+  roundtripState: string;
+}
+
 interface WechatMinigameSmokeCase {
   id: "login-lobby" | "room-entry" | "reconnect-recovery" | "share-roundtrip" | "key-assets";
   title: string;
@@ -37,6 +52,7 @@ interface WechatMinigameSmokeCase {
   notes: string;
   evidence: string[];
   steps: string[];
+  requiredEvidence?: ReconnectRecoveryEvidence | ShareRoundtripEvidence;
 }
 
 interface WechatMinigameSmokeReport {
@@ -209,6 +225,11 @@ function buildSmokeCases(): WechatMinigameSmokeCase[] {
       required: true,
       notes: "",
       evidence: [],
+      requiredEvidence: {
+        roomId: "",
+        reconnectPrompt: "",
+        restoredState: ""
+      },
       steps: [
         "在房间内主动切到飞行模式、关闭 Wi-Fi 或切后台后恢复网络。",
         "确认客户端能自动重连、恢复到原房间，或给出可接受的恢复提示。",
@@ -222,6 +243,11 @@ function buildSmokeCases(): WechatMinigameSmokeCase[] {
       required: true,
       notes: "",
       evidence: [],
+      requiredEvidence: {
+        shareScene: "",
+        shareQuery: "",
+        roundtripState: ""
+      },
       steps: [
         "从 Lobby、世界或战斗入口触发分享。",
         "完成一次真实分享或准真机回流，确认小游戏回到前台后状态正常。",
@@ -286,6 +312,121 @@ function validateReportShape(report: WechatMinigameSmokeReport): void {
   }
 }
 
+interface ValidationErrorDetail {
+  code: "missing_required_field" | "invalid_case_shape";
+  path: string;
+  message: string;
+}
+
+function failStructured(error: ValidationErrorDetail): never {
+  fail(`Smoke report validation error: ${JSON.stringify(error)}`);
+}
+
+function findCase(report: WechatMinigameSmokeReport, caseId: WechatMinigameSmokeCase["id"]): { entry: WechatMinigameSmokeCase; index: number } {
+  const index = report.cases.findIndex((entry) => entry.id === caseId);
+  if (index < 0) {
+    fail(`Smoke report is missing required case ${caseId}.`);
+  }
+  const entry = report.cases[index];
+  if (!entry) {
+    fail(`Smoke report is missing required case ${caseId}.`);
+  }
+  return { entry, index };
+}
+
+function validateRequiredStringField(
+  caseId: WechatMinigameSmokeCase["id"],
+  caseIndex: number,
+  fieldGroup: string,
+  fieldName: string,
+  value: unknown,
+  message: string
+): void {
+  if (typeof value !== "string" || !value.trim()) {
+    failStructured({
+      code: "missing_required_field",
+      path: `cases[${caseIndex}]#${caseId}.${fieldGroup}.${fieldName}`,
+      message
+    });
+  }
+}
+
+function validateReconnectRecoveryEvidence(report: WechatMinigameSmokeReport): void {
+  const { entry, index } = findCase(report, "reconnect-recovery");
+  const requiredEvidence = entry.requiredEvidence;
+  if (!requiredEvidence || typeof requiredEvidence !== "object" || Array.isArray(requiredEvidence)) {
+    failStructured({
+      code: "invalid_case_shape",
+      path: `cases[${index}]#reconnect-recovery.requiredEvidence`,
+      message: "Reconnect case must include a requiredEvidence object."
+    });
+  }
+
+  const reconnectEvidence = requiredEvidence as Partial<Record<ReconnectEvidenceFieldId, unknown>>;
+  validateRequiredStringField(
+    "reconnect-recovery",
+    index,
+    "requiredEvidence",
+    "roomId",
+    reconnectEvidence.roomId,
+    "Reconnect case must record the restored roomId."
+  );
+  validateRequiredStringField(
+    "reconnect-recovery",
+    index,
+    "requiredEvidence",
+    "reconnectPrompt",
+    reconnectEvidence.reconnectPrompt,
+    "Reconnect case must record the reconnect prompt or equivalent recovery signal."
+  );
+  validateRequiredStringField(
+    "reconnect-recovery",
+    index,
+    "requiredEvidence",
+    "restoredState",
+    reconnectEvidence.restoredState,
+    "Reconnect case must record the post-recovery state that proves no rollback occurred."
+  );
+}
+
+function validateShareRoundtripEvidence(report: WechatMinigameSmokeReport): void {
+  const { entry, index } = findCase(report, "share-roundtrip");
+  const requiredEvidence = entry.requiredEvidence;
+  if (!requiredEvidence || typeof requiredEvidence !== "object" || Array.isArray(requiredEvidence)) {
+    failStructured({
+      code: "invalid_case_shape",
+      path: `cases[${index}]#share-roundtrip.requiredEvidence`,
+      message: "Share-roundtrip case must include a requiredEvidence object."
+    });
+  }
+
+  const shareEvidence = requiredEvidence as Partial<Record<ShareRoundtripEvidenceFieldId, unknown>>;
+  validateRequiredStringField(
+    "share-roundtrip",
+    index,
+    "requiredEvidence",
+    "shareScene",
+    shareEvidence.shareScene,
+    "Share-roundtrip case must record where the share was triggered."
+  );
+  validateRequiredStringField(
+    "share-roundtrip",
+    index,
+    "requiredEvidence",
+    "shareQuery",
+    shareEvidence.shareQuery,
+    "Share-roundtrip case must record the emitted share query or equivalent payload summary."
+  );
+  validateRequiredStringField(
+    "share-roundtrip",
+    index,
+    "requiredEvidence",
+    "roundtripState",
+    shareEvidence.roundtripState,
+    "Share-roundtrip case must record the state restored after returning to the mini game."
+  );
+}
+
 function validateReportAgainstMetadata(
   report: WechatMinigameSmokeReport,
   metadata: WechatMinigameReleasePackageMetadata,
@@ -343,6 +484,9 @@ function validateReportAgainstMetadata(
   if (report.execution.result === "pending") {
     fail("Smoke report execution.result must be passed or failed before validation.");
   }
+
+  validateReconnectRecoveryEvidence(report);
+  validateShareRoundtripEvidence(report);
 
   const hasFailedCase = report.cases.some((entry) => entry.status === "failed");
   if (report.execution.result === "passed" && hasFailedCase) {


### PR DESCRIPTION
## Summary
- require structured reconnect evidence fields in the WeChat smoke report template and validator
- require structured share-roundtrip evidence fields and fail fast with clear path/code/message errors
- extend smoke-release tests for the pass path and both reconnect/share failure paths, and document the required fields

## Testing
- `node --import tsx --test apps/cocos-client/test/cocos-wechat-smoke-release.test.ts`
- `npm run typecheck` *(blocked by unrelated pre-existing repo-wide TypeScript errors in this worktree; no new typecheck target was introduced by this change)*