### PR TITLE
ops(release): fail candidate promotion when manual readiness checks stay pending (#282)

### DIFF
--- a/apps/cocos-client/test/cocos-release-candidate-snapshot.test.ts
+++ b/apps/cocos-client/test/cocos-release-candidate-snapshot.test.ts
@@ -10,6 +10,58 @@ function createSnapshotPath(): string {
   return path.join(tempDir, "cocos-rc-snapshot.json");
 }
 
+function writeLinkedReleaseReadinessSnapshot(status: "pending" | "passed"): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-release-readiness-"));
+  const outputPath = path.join(tempDir, "release-readiness.json");
+  fs.writeFileSync(
+    outputPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        generatedAt: "2026-03-29T08:00:00+08:00",
+        revision: {
+          commit: "abc1234567890",
+          shortCommit: "abc1234",
+          branch: "main",
+          dirty: false
+        },
+        runner: {
+          nodeVersion: process.version,
+          platform: process.platform,
+          hostname: "localhost",
+          cwd: path.resolve(__dirname, "../../..")
+        },
+        summary: {
+          total: 1,
+          passed: status === "passed" ? 1 : 0,
+          failed: 0,
+          pending: status === "pending" ? 1 : 0,
+          notApplicable: 0,
+          requiredFailed: 0,
+          requiredPending: status === "pending" ? 1 : 0,
+          status
+        },
+        checks: [
+          {
+            id: "runtime-health-review",
+            title: "Runtime health review",
+            kind: "manual",
+            required: true,
+            status,
+            notes: "",
+            evidence: [],
+            source: "file"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  return outputPath;
+}
+
 test("release:cocos-rc:snapshot writes a reusable template", () => {
   const outputPath = createSnapshotPath();
 
@@ -154,5 +206,66 @@ test("release:cocos-rc:snapshot rejects incomplete required evidence", () => {
         }
       ),
     /requiredEvidence\[roomId\]\.value must be a non-empty string/
+  );
+});
+
+test("release:cocos-rc:snapshot rejects pending required manual readiness checks during validation", () => {
+  const outputPath = createSnapshotPath();
+  const readinessSnapshotPath = writeLinkedReleaseReadinessSnapshot("pending");
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/cocos-release-candidate-snapshot.ts",
+      "--output",
+      outputPath,
+      "--candidate",
+      "issue-282-pending-manual",
+      "--release-readiness-snapshot",
+      readinessSnapshotPath
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      stdio: "pipe"
+    }
+  );
+
+  const snapshot = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    execution: { owner: string; executedAt: string; overallStatus: string; summary: string };
+    environment: { server: string };
+    requiredEvidence: Array<{ id: string; value: string; evidence: string[] }>;
+    journey: Array<{ id: string; status: string; evidence: string[]; sourceRefs: string[] }>;
+  };
+  snapshot.execution.owner = "codex";
+  snapshot.execution.executedAt = "2026-03-29T08:40:00+08:00";
+  snapshot.execution.overallStatus = "passed";
+  snapshot.execution.summary = "Candidate flow passed but manual readiness checks are still pending.";
+  snapshot.environment.server = "ws://127.0.0.1:2567";
+
+  for (const field of snapshot.requiredEvidence) {
+    field.value = `${field.id}-ok`;
+    field.evidence = ["manual"];
+  }
+  for (const step of snapshot.journey) {
+    step.status = "passed";
+    step.evidence = ["manual"];
+    step.sourceRefs = ["creator-preview"];
+  }
+  fs.writeFileSync(outputPath, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+
+  assert.throws(
+    () =>
+      execFileSync(
+        "node",
+        ["--import", "tsx", "./scripts/cocos-release-candidate-snapshot.ts", "--output", outputPath, "--check"],
+        {
+          cwd: path.resolve(__dirname, "../../.."),
+          encoding: "utf8",
+          stdio: "pipe"
+        }
+      ),
+    /Linked release readiness snapshot still has pending required manual checks: runtime-health-review/
   );
 });

--- a/scripts/cocos-release-candidate-snapshot.ts
+++ b/scripts/cocos-release-candidate-snapshot.ts
@@ -31,6 +31,17 @@ interface LinkedEvidenceRef {
   sourceRevision?: string;
 }
 
+interface ReleaseReadinessSnapshotCheck {
+  id: string;
+  kind?: "automated" | "manual";
+  required?: boolean;
+  status?: "passed" | "failed" | "pending" | "not_applicable";
+}
+
+interface ReleaseReadinessSnapshot {
+  checks?: ReleaseReadinessSnapshotCheck[];
+}
+
 interface CanonicalEvidenceField {
   id: CanonicalEvidenceId;
   label: string;
@@ -491,6 +502,22 @@ function assertSnapshotResult(value: unknown): SnapshotResult {
   fail(`execution.overallStatus has unsupported value: ${String(value)}`);
 }
 
+function validateLinkedReleaseReadinessSnapshot(snapshotRef: LinkedEvidenceRef | undefined): void {
+  if (!snapshotRef) {
+    return;
+  }
+
+  const readinessSnapshot = readJsonFile<ReleaseReadinessSnapshot>(snapshotRef.path);
+  const pendingRequiredManualChecks = (readinessSnapshot.checks ?? []).filter(
+    (check) => check.kind === "manual" && check.required === true && check.status === "pending"
+  );
+  if (pendingRequiredManualChecks.length > 0) {
+    fail(
+      `Linked release readiness snapshot still has pending required manual checks: ${pendingRequiredManualChecks.map((check) => check.id).join(", ")}.`
+    );
+  }
+}
+
 function validateSnapshot(snapshot: CocosReleaseCandidateSnapshot): void {
   if (snapshot.schemaVersion !== 1) {
     fail(`Snapshot schemaVersion must be 1, received ${JSON.stringify(snapshot.schemaVersion)}.`);
@@ -548,6 +575,8 @@ function validateSnapshot(snapshot: CocosReleaseCandidateSnapshot): void {
       fail(`Missing required evidence field: ${requiredId}`);
     }
   }
+
+  validateLinkedReleaseReadinessSnapshot(snapshot.linkedEvidence.releaseReadinessSnapshot);
 }
 
 function main(): void {


### PR DESCRIPTION
## Summary
- fail Cocos RC snapshot validation when the linked release-readiness snapshot still has required manual checks in pending
- keep the change scoped to candidate promotion validation instead of broadening release-readiness rules
- add a regression test covering pending required manual readiness checks

## Testing
- node --import tsx --test apps/cocos-client/test/cocos-release-candidate-snapshot.test.ts