### PR TITLE
feat(accounts): add paged Cocos account progression/history surfaces

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -1,7 +1,7 @@
 import { _decorator, Color, Component, Graphics, Label, Node, Sprite, SpriteFrame, UITransform } from "cc";
 import {
-  buildCocosAccountReviewPage,
   type CocosAccountReviewItem,
+  type CocosAccountReviewPage,
   type CocosAccountReviewSection
 } from "./cocos-account-review.ts";
 import type { CocosLobbyRoomSummary, CocosPlayerAccountProfile } from "./cocos-lobby.ts";
@@ -68,6 +68,8 @@ export interface VeilLobbyRenderState {
   shareHint: string;
   vaultSummary: string;
   account: CocosPlayerAccountProfile;
+  accountReview: CocosAccountReviewPage;
+  selectedBattleReplayId: string | null;
   sessionSource: "remote" | "local" | "manual" | "none";
   loading: boolean;
   entering: boolean;
@@ -94,6 +96,11 @@ export interface VeilLobbyPanelOptions {
   onOpenConfigCenter?: () => void;
   onLogout?: () => void;
   onJoinRoom?: (roomId: string) => void;
+  onToggleAccountReview?: (open: boolean) => void;
+  onSelectAccountReviewSection?: (section: CocosAccountReviewSection) => void;
+  onSelectAccountReviewPage?: (section: "battle-replays" | "event-history", page: number) => void;
+  onRetryAccountReviewSection?: (section: CocosAccountReviewSection) => void;
+  onSelectBattleReplayReview?: (replayId: string) => void;
 }
 
 interface PanelCardTone {
@@ -106,13 +113,6 @@ interface PanelCardTone {
 export class VeilLobbyPanel extends Component {
   private currentState: VeilLobbyRenderState | null = null;
   private showAccountReview = false;
-  private activeAccountReviewSection: CocosAccountReviewSection = "battle-replays";
-  private reviewPages: Record<CocosAccountReviewSection, number> = {
-    "battle-replays": 0,
-    "event-history": 0,
-    achievements: 0
-  };
-  private selectedBattleReplayId: string | null = null;
   private showcasePhase: LobbyShowcasePhase = "idle";
   private showcaseUnitPage = 0;
   private showcaseTickerStarted = false;
@@ -132,6 +132,11 @@ export class VeilLobbyPanel extends Component {
   private onOpenConfigCenter: (() => void) | undefined;
   private onLogout: (() => void) | undefined;
   private onJoinRoom: ((roomId: string) => void) | undefined;
+  private onToggleAccountReview: ((open: boolean) => void) | undefined;
+  private onSelectAccountReviewSection: ((section: CocosAccountReviewSection) => void) | undefined;
+  private onSelectAccountReviewPage: ((section: "battle-replays" | "event-history", page: number) => void) | undefined;
+  private onRetryAccountReviewSection: ((section: CocosAccountReviewSection) => void) | undefined;
+  private onSelectBattleReplayReview: ((replayId: string) => void) | undefined;
 
   onDestroy(): void {
     this.unscheduleAllCallbacks();
@@ -154,6 +159,11 @@ export class VeilLobbyPanel extends Component {
     this.onOpenConfigCenter = options.onOpenConfigCenter;
     this.onLogout = options.onLogout;
     this.onJoinRoom = options.onJoinRoom;
+    this.onToggleAccountReview = options.onToggleAccountReview;
+    this.onSelectAccountReviewSection = options.onSelectAccountReviewSection;
+    this.onSelectAccountReviewPage = options.onSelectAccountReviewPage;
+    this.onRetryAccountReviewSection = options.onRetryAccountReviewSection;
+    this.onSelectBattleReplayReview = options.onSelectBattleReplayReview;
   }
 
   render(state: VeilLobbyRenderState): void {
@@ -403,6 +413,7 @@ export class VeilLobbyPanel extends Component {
       },
       () => {
         this.showAccountReview = !this.showAccountReview;
+        this.onToggleAccountReview?.(this.showAccountReview);
         if (this.currentState) {
           this.render(this.currentState);
         }
@@ -411,22 +422,8 @@ export class VeilLobbyPanel extends Component {
 
     if (this.showAccountReview) {
       this.hideAccountFlowPanel();
-      const review = buildCocosAccountReviewPage(
-        state.account,
-        this.activeAccountReviewSection,
-        this.reviewPages[this.activeAccountReviewSection] ?? 0,
-        3
-      );
+      const review = state.accountReview;
       const hasBattleReplays = state.account.recentBattleReplays.length > 0;
-      if (!hasBattleReplays) {
-        this.selectedBattleReplayId = null;
-      } else if (
-        (!this.selectedBattleReplayId ||
-          !state.account.recentBattleReplays.some((replay) => replay.id === this.selectedBattleReplayId)) &&
-        review.section === "battle-replays"
-      ) {
-        this.selectedBattleReplayId = state.account.recentBattleReplays[0]?.id ?? null;
-      }
       const unlockedCount = state.account.achievements.filter((achievement) => achievement.unlocked).length;
       rightCursorY = this.renderCard(
         "LobbyAccountReviewHeader",
@@ -438,7 +435,7 @@ export class VeilLobbyPanel extends Component {
           "账号资料回顾",
           `战报 ${state.account.recentBattleReplays.length} · 事件 ${state.account.recentEventLog.length} · 成就 ${unlockedCount}/${state.account.achievements.length}`,
           review.subtitle,
-          `当前页 ${review.page + 1}/${review.totalPages}`
+          `当前页 ${review.pageLabel}`
         ],
         {
           fill: TITLE_FILL,
@@ -450,7 +447,7 @@ export class VeilLobbyPanel extends Component {
         18
       );
 
-      const tabWidth = Math.floor((rightWidth - 12) / 3);
+      const tabWidth = Math.floor((rightWidth - 18) / 4);
       const tabStartX = rightX - rightWidth / 2 + tabWidth / 2;
       review.tabs.forEach((tab, index) => {
         const isActive = tab.section === review.section;
@@ -473,7 +470,7 @@ export class VeilLobbyPanel extends Component {
                 accent: new Color(252, 232, 194, 110)
               },
           () => {
-            this.activeAccountReviewSection = tab.section;
+            this.onSelectAccountReviewSection?.(tab.section);
             if (this.currentState) {
               this.render(this.currentState);
             }
@@ -494,9 +491,8 @@ export class VeilLobbyPanel extends Component {
         },
         review.hasPreviousPage
           ? () => {
-              this.reviewPages[review.section] = review.page - 1;
-              if (this.currentState) {
-                this.render(this.currentState);
+              if (review.section === "battle-replays" || review.section === "event-history") {
+                this.onSelectAccountReviewPage?.(review.section, review.page - 1);
               }
             }
           : null
@@ -515,26 +511,43 @@ export class VeilLobbyPanel extends Component {
         },
         review.hasNextPage
           ? () => {
-              this.reviewPages[review.section] = review.page + 1;
-              if (this.currentState) {
-                this.render(this.currentState);
+              if (review.section === "battle-replays" || review.section === "event-history") {
+                this.onSelectAccountReviewPage?.(review.section, review.page + 1);
               }
-              }
+            }
           : null
       );
 
-      let reviewCardsTop = rightCursorY - 74;
-      if (review.section === "battle-replays" && hasBattleReplays && this.selectedBattleReplayId) {
+      this.renderActionButton(
+        "LobbyAccountReviewRetry",
+        rightX,
+        rightCursorY - 84,
+        rightWidth,
+        24,
+        "重新同步当前面板",
+        {
+          fill: ACTION_REFRESH,
+          stroke: new Color(233, 242, 250, 130),
+          accent: new Color(218, 230, 242, 120)
+        },
+        review.showRetry ? () => this.onRetryAccountReviewSection?.(review.section) : null
+      );
+
+      let reviewCardsTop = rightCursorY - 108;
+      if (review.section === "battle-replays" && hasBattleReplays && state.selectedBattleReplayId) {
         reviewCardsTop = this.renderBattleReplayTimelineDetail(rightX, reviewCardsTop, rightWidth, state.account);
         this.renderAccountReviewCards(rightX, reviewCardsTop, rightWidth, review.items, {
-          highlightReplayId: this.selectedBattleReplayId,
+          highlightReplayId: state.selectedBattleReplayId,
+          banner: review.banner,
           onSelectReplay: (replayId) => {
             this.selectBattleReplay(replayId);
           }
         });
       } else {
         this.hideBattleReplayTimelineCard();
-        this.renderAccountReviewCards(rightX, reviewCardsTop, rightWidth, review.items);
+        this.renderAccountReviewCards(rightX, reviewCardsTop, rightWidth, review.items, {
+          banner: review.banner
+        });
       }
       this.hideLobbyRooms();
     } else if (state.accountFlow) {
@@ -832,14 +845,11 @@ export class VeilLobbyPanel extends Component {
   }
 
   private selectBattleReplay(replayId: string): void {
-    if (this.selectedBattleReplayId === replayId) {
+    if (this.currentState?.selectedBattleReplayId === replayId) {
       return;
     }
 
-    this.selectedBattleReplayId = replayId;
-    if (this.currentState) {
-      this.render(this.currentState);
-    }
+    this.onSelectBattleReplayReview?.(replayId);
   }
 
   private renderBattleReplayTimelineDetail(
@@ -848,7 +858,7 @@ export class VeilLobbyPanel extends Component {
     width: number,
     account: CocosPlayerAccountProfile
   ): number {
-    const replay = findPlayerBattleReplaySummary(account.recentBattleReplays, this.selectedBattleReplayId);
+    const replay = findPlayerBattleReplaySummary(account.recentBattleReplays, this.currentState?.selectedBattleReplayId);
     const view = buildCocosBattleReplayTimelineView(replay);
     const timelineLines =
       view.entries.length > 0
@@ -890,14 +900,50 @@ export class VeilLobbyPanel extends Component {
     topY: number,
     width: number,
     items: CocosAccountReviewItem[],
-    options: { highlightReplayId?: string | null; onSelectReplay?: (replayId: string) => void } = {}
+    options: {
+      highlightReplayId?: string | null;
+      onSelectReplay?: (replayId: string) => void;
+      banner?: CocosAccountReviewPage["banner"];
+    } = {}
   ): void {
-    const { highlightReplayId = null, onSelectReplay } = options;
+    const { highlightReplayId = null, onSelectReplay, banner = null } = options;
+    let currentTopY = topY;
+
+    if (banner) {
+      currentTopY = this.renderCard(
+        "LobbyAccountReviewBanner",
+        centerX,
+        currentTopY,
+        width,
+        72,
+        [banner.title, banner.detail],
+        banner.tone === "negative"
+          ? {
+              fill: new Color(96, 62, 62, 190),
+              stroke: new Color(246, 214, 214, 84),
+              accent: new Color(236, 176, 176, 188)
+            }
+          : {
+              fill: MUTED_FILL,
+              stroke: new Color(214, 224, 238, 42),
+              accent: new Color(128, 146, 170, 156)
+            },
+        null,
+        13,
+        17
+      );
+    } else {
+      const bannerNode = this.node.getChildByName("LobbyAccountReviewBanner");
+      if (bannerNode) {
+        bannerNode.active = false;
+      }
+    }
+
     if (items.length === 0) {
       this.renderCard(
         "LobbyAccountReviewEmpty",
         centerX,
-        topY,
+        currentTopY,
         width,
         84,
         ["暂无回顾数据", "当前账号快照还没有战报、事件或成就进度。", "刷新 Lobby 或完成一局流程后会再次同步。"],
@@ -938,7 +984,7 @@ export class VeilLobbyPanel extends Component {
       this.renderCard(
         `LobbyAccountReview-${index}`,
         centerX,
-        topY - index * (cardHeight + 10),
+        currentTopY - index * (cardHeight + 10),
         width,
         cardHeight,
         [item.title, item.detail, item.footnote],
@@ -970,7 +1016,7 @@ export class VeilLobbyPanel extends Component {
     if (header) {
       header.active = false;
     }
-    (["battle-replays", "event-history", "achievements"] as CocosAccountReviewSection[]).forEach((section) => {
+    (["progression", "battle-replays", "event-history", "achievements"] as CocosAccountReviewSection[]).forEach((section) => {
       const tab = this.node.getChildByName(`LobbyAccountReviewTab-${section}`);
       if (tab) {
         tab.active = false;
@@ -987,6 +1033,14 @@ export class VeilLobbyPanel extends Component {
     const emptyNode = this.node.getChildByName("LobbyAccountReviewEmpty");
     if (emptyNode) {
       emptyNode.active = false;
+    }
+    const bannerNode = this.node.getChildByName("LobbyAccountReviewBanner");
+    if (bannerNode) {
+      bannerNode.active = false;
+    }
+    const retryButton = this.node.getChildByName("LobbyAccountReviewRetry");
+    if (retryButton) {
+      retryButton.active = false;
     }
     this.hideExtraAccountReviewCards(0);
   }

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -11,13 +11,24 @@ import {
   type Vec2
 } from "./VeilCocosSession.ts";
 import {
+  buildCocosAccountReviewPage,
+  createCocosAccountReviewState,
+  transitionCocosAccountReviewState,
+  type CocosAccountReviewSection,
+  type CocosAccountReviewState
+} from "./cocos-account-review.ts";
+import {
   confirmCocosAccountRegistration,
   confirmCocosPasswordRecovery,
   createFallbackCocosPlayerAccountProfile,
   createCocosGuestPlayerId,
+  loadCocosBattleReplayHistoryPage,
   createCocosLobbyPreferences,
   loadCocosLobbyRooms,
   loadCocosPlayerAccountProfile,
+  loadCocosPlayerAchievementProgress,
+  loadCocosPlayerEventHistory,
+  loadCocosPlayerProgressionSnapshot,
   loginCocosGuestAuthSession,
   logoutCurrentCocosAuthSession,
   readPreferredCocosDisplayName,
@@ -99,6 +110,7 @@ const LOBBY_NODE_NAME = "ProjectVeilLobbyPanel";
 const DEFAULT_MAP_WIDTH_TILES = 8;
 const DEFAULT_MAP_HEIGHT_TILES = 8;
 const BATTLE_FEEDBACK_DURATION_MS = 2600;
+const ACCOUNT_REVIEW_PAGE_SIZE = 3;
 
 interface VeilRootRuntime {
   createSession: typeof VeilCocosSession.create;
@@ -106,6 +118,10 @@ interface VeilRootRuntime {
   loadLobbyRooms: typeof loadCocosLobbyRooms;
   syncAuthSession: typeof syncCurrentCocosAuthSession;
   loadAccountProfile: typeof loadCocosPlayerAccountProfile;
+  loadProgressionSnapshot: typeof loadCocosPlayerProgressionSnapshot;
+  loadAchievementProgress: typeof loadCocosPlayerAchievementProgress;
+  loadEventHistory: typeof loadCocosPlayerEventHistory;
+  loadBattleReplayHistoryPage: typeof loadCocosBattleReplayHistoryPage;
   loginGuestAuthSession: typeof loginCocosGuestAuthSession;
 }
 
@@ -115,6 +131,10 @@ const defaultVeilRootRuntime: VeilRootRuntime = {
   loadLobbyRooms: (...args) => loadCocosLobbyRooms(...args),
   syncAuthSession: (...args) => syncCurrentCocosAuthSession(...args),
   loadAccountProfile: (...args) => loadCocosPlayerAccountProfile(...args),
+  loadProgressionSnapshot: (...args) => loadCocosPlayerProgressionSnapshot(...args),
+  loadAchievementProgress: (...args) => loadCocosPlayerAchievementProgress(...args),
+  loadEventHistory: (...args) => loadCocosPlayerEventHistory(...args),
+  loadBattleReplayHistoryPage: (...args) => loadCocosBattleReplayHistoryPage(...args),
   loginGuestAuthSession: (...args) => loginCocosGuestAuthSession(...args)
 };
 
@@ -204,6 +224,7 @@ export class VeilRoot extends Component {
   private lobbyLoading = false;
   private lobbyEntering = false;
   private lobbyAccountProfile: CocosPlayerAccountProfile = createFallbackCocosPlayerAccountProfile("player-1", "test-room");
+  private lobbyAccountReviewState: CocosAccountReviewState = createCocosAccountReviewState(this.lobbyAccountProfile);
   private lobbyAccountEpoch = 0;
   private gameplayAccountRefreshInFlight = false;
   private activeAccountFlow: CocosAccountLifecycleKind | null = null;
@@ -649,6 +670,37 @@ export class VeilRoot extends Component {
       },
       onJoinRoom: (roomId) => {
         void this.enterLobbyRoom(roomId);
+      },
+      onToggleAccountReview: (open) => {
+        if (open) {
+          void this.refreshActiveAccountReviewSection();
+        }
+      },
+      onSelectAccountReviewSection: (section) => {
+        this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+          type: "section.selected",
+          section
+        });
+        this.renderView();
+        void this.refreshActiveAccountReviewSection();
+      },
+      onSelectAccountReviewPage: (section, page) => {
+        this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+          type: "section.selected",
+          section
+        });
+        this.renderView();
+        void this.refreshAccountReviewPage(section, page);
+      },
+      onRetryAccountReviewSection: (section) => {
+        void this.refreshActiveAccountReviewSection(section);
+      },
+      onSelectBattleReplayReview: (replayId) => {
+        this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+          type: "battle-replay.selected",
+          replayId
+        });
+        this.renderView();
       }
     });
 
@@ -795,6 +847,8 @@ export class VeilRoot extends Component {
         shareHint: this.describeLobbyShareHint(),
         vaultSummary: this.formatLobbyVaultSummary(),
         account: this.lobbyAccountProfile,
+        accountReview: buildCocosAccountReviewPage(this.lobbyAccountReviewState),
+        selectedBattleReplayId: this.lobbyAccountReviewState.selectedBattleReplayId,
         sessionSource: this.sessionSource,
         loading: this.lobbyLoading,
         entering: this.lobbyEntering,
@@ -946,6 +1000,170 @@ export class VeilRoot extends Component {
     }
     this.syncWechatShareBridge();
     this.renderView();
+  }
+
+  private async refreshActiveAccountReviewSection(section = this.lobbyAccountReviewState.activeSection): Promise<void> {
+    if (section === "progression") {
+      await this.refreshProgressionReview();
+      return;
+    }
+
+    if (section === "achievements") {
+      await this.refreshAchievementReview();
+      return;
+    }
+
+    if (section === "event-history") {
+      await this.refreshAccountReviewPage("event-history", this.lobbyAccountReviewState.eventHistory.page);
+      return;
+    }
+
+    await this.refreshAccountReviewPage("battle-replays", this.lobbyAccountReviewState.battleReplays.page);
+  }
+
+  private async refreshProgressionReview(): Promise<void> {
+    this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+      type: "section.loading",
+      section: "progression"
+    });
+    this.renderView();
+
+    try {
+      const snapshot = await resolveVeilRootRuntime().loadProgressionSnapshot(this.remoteUrl, this.playerId, 6, {
+        storage: this.readWebStorage(),
+        authSession: this.currentLobbyAuthSession()
+      });
+      this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+        type: "progression.loaded",
+        snapshot
+      });
+    } catch (error) {
+      this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+        type: "section.failed",
+        section: "progression",
+        message: this.describeAccountReviewLoadError(error)
+      });
+    }
+
+    this.renderView();
+  }
+
+  private async refreshAchievementReview(): Promise<void> {
+    this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+      type: "section.loading",
+      section: "achievements"
+    });
+    this.renderView();
+
+    try {
+      const items = await resolveVeilRootRuntime().loadAchievementProgress(this.remoteUrl, this.playerId, undefined, {
+        storage: this.readWebStorage(),
+        authSession: this.currentLobbyAuthSession()
+      });
+      this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+        type: "achievements.loaded",
+        items
+      });
+    } catch (error) {
+      this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+        type: "section.failed",
+        section: "achievements",
+        message: this.describeAccountReviewLoadError(error)
+      });
+    }
+
+    this.renderView();
+  }
+
+  private async refreshAccountReviewPage(
+    section: "battle-replays" | "event-history",
+    page: number
+  ): Promise<void> {
+    const safePage = Math.max(0, Math.floor(page));
+    this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+      type: "section.loading",
+      section
+    });
+    this.renderView();
+
+    try {
+      if (section === "event-history") {
+        const history = await resolveVeilRootRuntime().loadEventHistory(
+          this.remoteUrl,
+          this.playerId,
+          {
+            limit: ACCOUNT_REVIEW_PAGE_SIZE,
+            offset: safePage * ACCOUNT_REVIEW_PAGE_SIZE
+          },
+          {
+            storage: this.readWebStorage(),
+            authSession: this.currentLobbyAuthSession()
+          }
+        );
+        this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+          type: "event-history.loaded",
+          items: history.items,
+          page: Math.floor(history.offset / Math.max(1, history.limit)),
+          pageSize: history.limit,
+          total: history.total,
+          hasMore: history.hasMore
+        });
+      } else {
+        const history = await resolveVeilRootRuntime().loadBattleReplayHistoryPage(
+          this.remoteUrl,
+          this.playerId,
+          {
+            limit: ACCOUNT_REVIEW_PAGE_SIZE,
+            offset: safePage * ACCOUNT_REVIEW_PAGE_SIZE
+          },
+          {
+            storage: this.readWebStorage(),
+            authSession: this.currentLobbyAuthSession()
+          }
+        );
+        this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+          type: "battle-replays.loaded",
+          items: history.items,
+          page: Math.floor(history.offset / Math.max(1, history.limit)),
+          pageSize: history.limit,
+          hasMore: history.hasMore
+        });
+      }
+    } catch (error) {
+      this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+        type: "section.failed",
+        section,
+        message: this.describeAccountReviewLoadError(error)
+      });
+    }
+
+    this.renderView();
+  }
+
+  private currentLobbyAuthSession(): {
+    token: string;
+    playerId: string;
+    displayName: string;
+    authMode: "guest" | "account";
+    loginId?: string;
+    source: "remote";
+  } | null {
+    if (!this.authToken) {
+      return null;
+    }
+
+    return {
+      token: this.authToken,
+      playerId: this.playerId,
+      displayName: this.displayName || this.playerId,
+      authMode: this.authMode,
+      ...(this.loginId ? { loginId: this.loginId } : {}),
+      source: "remote"
+    };
+  }
+
+  private describeAccountReviewLoadError(error: unknown): string {
+    return error instanceof Error && error.message.trim() ? error.message : "网络暂不可用，请稍后重试。";
   }
 
   private computeLayoutMetrics(): {
@@ -1609,7 +1827,10 @@ export class VeilRoot extends Component {
         return;
       }
 
-      this.lobbyAccountProfile = createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName);
+      this.commitAccountProfile(
+        createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName),
+        false
+      );
       this.renderView();
     } catch (error) {
       this.showLobby = true;
@@ -1866,7 +2087,7 @@ export class VeilRoot extends Component {
     this.loginId = "";
     this.sessionSource = "none";
     this.displayName = readPreferredCocosDisplayName(this.playerId, this.readWebStorage());
-    this.lobbyAccountProfile = createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName);
+    this.commitAccountProfile(createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName), false);
     this.syncWechatShareBridge();
     this.lobbyStatus = "已退出当前会话，请重新选择游客身份或使用正式账号进入。";
     this.renderView();
@@ -2396,7 +2617,7 @@ export class VeilRoot extends Component {
       this.authProvider = storedSession?.playerId === this.playerId ? storedSession.provider ?? "guest" : "guest";
       this.loginId = storedSession?.playerId === this.playerId ? storedSession.loginId ?? "" : "";
       this.sessionSource = storedSession?.playerId === this.playerId ? storedSession.source : "none";
-      this.lobbyAccountProfile = createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName);
+      this.commitAccountProfile(createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName), false);
       this.showLobby = true;
       this.autoConnect = false;
       this.lobbyStatus = storedSession
@@ -2416,7 +2637,7 @@ export class VeilRoot extends Component {
     this.loginId = launchIdentity.loginId ?? "";
     this.authToken = launchIdentity.authToken;
     this.sessionSource = launchIdentity.sessionSource;
-    this.lobbyAccountProfile = createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName);
+    this.commitAccountProfile(createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName), false);
 
     if (launchIdentity.usedStoredSession) {
       this.pushLog(
@@ -2659,6 +2880,10 @@ export class VeilRoot extends Component {
     }
 
     this.lobbyAccountProfile = profile;
+    this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+      type: "account.synced",
+      account: profile
+    });
   }
 
   private playMapFeedbackForUpdate(update: SessionUpdate): void {

--- a/apps/cocos-client/assets/scripts/cocos-account-review.ts
+++ b/apps/cocos-client/assets/scripts/cocos-account-review.ts
@@ -1,7 +1,19 @@
-import type { CocosPlayerAccountProfile } from "./cocos-lobby.ts";
+import {
+  buildPlayerProgressionSnapshot,
+  formatAchievementLabel,
+  formatWorldEventTypeLabel,
+  getLatestProgressedAchievement,
+  getLatestUnlockedAchievement,
+  type EventLogEntry,
+  type PlayerAchievementProgress,
+  type PlayerBattleReplaySummary,
+  type PlayerProgressionSnapshot
+} from "./project-shared/index.ts";
 import { buildCocosAchievementPanelItems } from "./cocos-achievements.ts";
+import type { CocosPlayerAccountProfile } from "./cocos-lobby.ts";
 
-export type CocosAccountReviewSection = "battle-replays" | "event-history" | "achievements";
+export type CocosAccountReviewSection = "progression" | "battle-replays" | "event-history" | "achievements";
+export type CocosAccountReviewSectionStatus = "idle" | "loading" | "ready" | "error";
 
 export interface CocosAccountReviewTab {
   section: CocosAccountReviewSection;
@@ -17,19 +29,281 @@ export interface CocosAccountReviewItem {
   replayId?: string;
 }
 
+export interface CocosAccountReviewStateBanner {
+  title: string;
+  detail: string;
+  tone: "neutral" | "negative";
+}
+
 export interface CocosAccountReviewPage {
   section: CocosAccountReviewSection;
   title: string;
   subtitle: string;
   items: CocosAccountReviewItem[];
   page: number;
-  totalPages: number;
+  pageLabel: string;
   hasPreviousPage: boolean;
   hasNextPage: boolean;
   tabs: CocosAccountReviewTab[];
+  banner: CocosAccountReviewStateBanner | null;
+  showRetry: boolean;
 }
 
-const SECTION_ORDER: CocosAccountReviewSection[] = ["battle-replays", "event-history", "achievements"];
+interface CocosAccountReviewCollectionState<T> {
+  status: CocosAccountReviewSectionStatus;
+  items: T[];
+  page: number;
+  pageSize: number;
+  total: number | null;
+  hasMore: boolean;
+  errorMessage: string | null;
+}
+
+interface CocosAccountProgressionReviewState {
+  status: CocosAccountReviewSectionStatus;
+  snapshot: PlayerProgressionSnapshot;
+  errorMessage: string | null;
+}
+
+export interface CocosAccountReviewState {
+  activeSection: CocosAccountReviewSection;
+  selectedBattleReplayId: string | null;
+  progression: CocosAccountProgressionReviewState;
+  achievements: CocosAccountReviewCollectionState<PlayerAchievementProgress>;
+  eventHistory: CocosAccountReviewCollectionState<EventLogEntry>;
+  battleReplays: CocosAccountReviewCollectionState<PlayerBattleReplaySummary>;
+}
+
+export type CocosAccountReviewAction =
+  | { type: "account.synced"; account: CocosPlayerAccountProfile }
+  | { type: "section.selected"; section: CocosAccountReviewSection }
+  | { type: "battle-replay.selected"; replayId: string | null }
+  | { type: "section.loading"; section: CocosAccountReviewSection }
+  | { type: "progression.loaded"; snapshot: PlayerProgressionSnapshot }
+  | { type: "achievements.loaded"; items: PlayerAchievementProgress[] }
+  | { type: "event-history.loaded"; items: EventLogEntry[]; page: number; pageSize: number; total: number; hasMore: boolean }
+  | {
+      type: "battle-replays.loaded";
+      items: PlayerBattleReplaySummary[];
+      page: number;
+      pageSize: number;
+      hasMore: boolean;
+    }
+  | { type: "section.failed"; section: CocosAccountReviewSection; message: string };
+
+const SECTION_ORDER: CocosAccountReviewSection[] = ["progression", "battle-replays", "event-history", "achievements"];
+const DEFAULT_PAGE_SIZE = 3;
+
+function createEmptyCollectionState<T>(pageSize = DEFAULT_PAGE_SIZE): CocosAccountReviewCollectionState<T> {
+  return {
+    status: "idle",
+    items: [],
+    page: 0,
+    pageSize,
+    total: 0,
+    hasMore: false,
+    errorMessage: null
+  };
+}
+
+function deriveProgressionSnapshot(account: Pick<CocosPlayerAccountProfile, "achievements" | "recentEventLog">): PlayerProgressionSnapshot {
+  return buildPlayerProgressionSnapshot(account.achievements, account.recentEventLog, account.recentEventLog.length || 12);
+}
+
+function seedCollectionState<T>(items: T[], pageSize = DEFAULT_PAGE_SIZE): CocosAccountReviewCollectionState<T> {
+  return {
+    status: "ready",
+    items: items.slice(0, pageSize),
+    page: 0,
+    pageSize,
+    total: items.length,
+    hasMore: items.length > pageSize,
+    errorMessage: null
+  };
+}
+
+function seedBattleReplaySelection(
+  previousReplayId: string | null,
+  items: readonly PlayerBattleReplaySummary[]
+): string | null {
+  if (previousReplayId && items.some((replay) => replay.id === previousReplayId)) {
+    return previousReplayId;
+  }
+
+  return items[0]?.id ?? null;
+}
+
+export function createCocosAccountReviewState(account: CocosPlayerAccountProfile): CocosAccountReviewState {
+  return {
+    activeSection: "progression",
+    selectedBattleReplayId: account.recentBattleReplays[0]?.id ?? null,
+    progression: {
+      status: "ready",
+      snapshot: deriveProgressionSnapshot(account),
+      errorMessage: null
+    },
+    achievements: seedCollectionState(account.achievements),
+    eventHistory: seedCollectionState(account.recentEventLog),
+    battleReplays: seedCollectionState(account.recentBattleReplays)
+  };
+}
+
+export function transitionCocosAccountReviewState(
+  state: CocosAccountReviewState,
+  action: CocosAccountReviewAction
+): CocosAccountReviewState {
+  switch (action.type) {
+    case "account.synced":
+      return {
+        ...createCocosAccountReviewState(action.account),
+        activeSection: state.activeSection,
+        selectedBattleReplayId: seedBattleReplaySelection(state.selectedBattleReplayId, action.account.recentBattleReplays)
+      };
+    case "section.selected":
+      return {
+        ...state,
+        activeSection: action.section
+      };
+    case "battle-replay.selected":
+      return {
+        ...state,
+        selectedBattleReplayId: action.replayId
+      };
+    case "section.loading":
+      if (action.section === "progression") {
+        return {
+          ...state,
+          progression: {
+            ...state.progression,
+            status: "loading",
+            errorMessage: null
+          }
+        };
+      }
+
+      if (action.section === "achievements") {
+        return {
+          ...state,
+          achievements: {
+            ...state.achievements,
+            status: "loading",
+            errorMessage: null
+          }
+        };
+      }
+
+      if (action.section === "event-history") {
+        return {
+          ...state,
+          eventHistory: {
+            ...state.eventHistory,
+            status: "loading",
+            errorMessage: null
+          }
+        };
+      }
+
+      return {
+        ...state,
+        battleReplays: {
+          ...state.battleReplays,
+          status: "loading",
+          errorMessage: null
+        }
+      };
+    case "progression.loaded":
+      return {
+        ...state,
+        progression: {
+          status: "ready",
+          snapshot: action.snapshot,
+          errorMessage: null
+        }
+      };
+    case "achievements.loaded":
+      return {
+        ...state,
+        achievements: {
+          status: "ready",
+          items: action.items,
+          page: 0,
+          pageSize: state.achievements.pageSize,
+          total: action.items.length,
+          hasMore: false,
+          errorMessage: null
+        }
+      };
+    case "event-history.loaded":
+      return {
+        ...state,
+        eventHistory: {
+          status: "ready",
+          items: action.items,
+          page: action.page,
+          pageSize: action.pageSize,
+          total: action.total,
+          hasMore: action.hasMore,
+          errorMessage: null
+        }
+      };
+    case "battle-replays.loaded":
+      return {
+        ...state,
+        selectedBattleReplayId: seedBattleReplaySelection(state.selectedBattleReplayId, action.items),
+        battleReplays: {
+          status: "ready",
+          items: action.items,
+          page: action.page,
+          pageSize: action.pageSize,
+          total: action.hasMore ? null : action.page * action.pageSize + action.items.length,
+          hasMore: action.hasMore,
+          errorMessage: null
+        }
+      };
+    case "section.failed":
+      if (action.section === "progression") {
+        return {
+          ...state,
+          progression: {
+            ...state.progression,
+            status: "error",
+            errorMessage: action.message
+          }
+        };
+      }
+
+      if (action.section === "achievements") {
+        return {
+          ...state,
+          achievements: {
+            ...state.achievements,
+            status: "error",
+            errorMessage: action.message
+          }
+        };
+      }
+
+      if (action.section === "event-history") {
+        return {
+          ...state,
+          eventHistory: {
+            ...state.eventHistory,
+            status: "error",
+            errorMessage: action.message
+          }
+        };
+      }
+
+      return {
+        ...state,
+        battleReplays: {
+          ...state.battleReplays,
+          status: "error",
+          errorMessage: action.message
+        }
+      };
+  }
+}
 
 function formatReviewTimestamp(value?: string): string {
   if (!value) {
@@ -44,7 +318,74 @@ function formatReviewTimestamp(value?: string): string {
   return parsed.toISOString().slice(0, 16).replace("T", " ");
 }
 
-function formatBattleReplayTitle(replay: CocosPlayerAccountProfile["recentBattleReplays"][number]): string {
+function formatProgressionHeadline(snapshot: PlayerProgressionSnapshot): string {
+  const summary = snapshot.summary;
+  const latestUnlocked = getLatestUnlockedAchievement(snapshot.achievements);
+  const latestProgressed = getLatestProgressedAchievement(snapshot.achievements);
+  if (latestUnlocked && latestProgressed && latestUnlocked.id !== latestProgressed.id) {
+    return `成就 ${summary.unlockedAchievements}/${summary.totalAchievements} 已解锁 · 最新 ${latestUnlocked.title} · 最近推进 ${latestProgressed.title} ${latestProgressed.current}/${latestProgressed.target}`;
+  }
+
+  if (latestUnlocked) {
+    return `成就 ${summary.unlockedAchievements}/${summary.totalAchievements} 已解锁 · 最新 ${latestUnlocked.title}`;
+  }
+
+  if (latestProgressed) {
+    return `成就 ${summary.unlockedAchievements}/${summary.totalAchievements} 已解锁 · 最近推进 ${latestProgressed.title} ${latestProgressed.current}/${latestProgressed.target}`;
+  }
+
+  return `成就 ${summary.unlockedAchievements}/${summary.totalAchievements} 已解锁`;
+}
+
+function buildProgressionItems(snapshot: PlayerProgressionSnapshot): CocosAccountReviewItem[] {
+  const summary = snapshot.summary;
+  const latestUnlocked = getLatestUnlockedAchievement(snapshot.achievements);
+  const latestProgressed = getLatestProgressedAchievement(snapshot.achievements);
+
+  const items: CocosAccountReviewItem[] = [
+    {
+      title: "成长概览",
+      detail: formatProgressionHeadline(snapshot),
+      footnote: summary.latestEventAt
+        ? `最近事件 ${formatReviewTimestamp(summary.latestEventAt)} · 共 ${summary.recentEventCount} 条`
+        : `最近事件 ${summary.recentEventCount} 条`,
+      emphasis: summary.unlockedAchievements > 0 || summary.inProgressAchievements > 0 ? "positive" : "neutral"
+    }
+  ];
+
+  if (latestUnlocked) {
+    items.push({
+      title: `最新解锁 · ${latestUnlocked.title}`,
+      detail: latestUnlocked.description,
+      footnote: `解锁于 ${formatReviewTimestamp(latestUnlocked.unlockedAt ?? latestUnlocked.progressUpdatedAt)}`,
+      emphasis: "positive"
+    });
+  }
+
+  if (latestProgressed && (!latestUnlocked || latestProgressed.id !== latestUnlocked.id)) {
+    items.push({
+      title: `最近推进 · ${latestProgressed.title}`,
+      detail: `${latestProgressed.current}/${latestProgressed.target} · ${latestProgressed.description}`,
+      footnote: latestProgressed.progressUpdatedAt
+        ? `更新于 ${formatReviewTimestamp(latestProgressed.progressUpdatedAt)}`
+        : "进度待同步",
+      emphasis: "neutral"
+    });
+  }
+
+  if (snapshot.recentEventLog[0]) {
+    items.push({
+      title: "最近事件",
+      detail: snapshot.recentEventLog[0].description,
+      footnote: formatReviewTimestamp(snapshot.recentEventLog[0].timestamp),
+      emphasis: snapshot.recentEventLog[0].category === "achievement" ? "positive" : "neutral"
+    });
+  }
+
+  return items;
+}
+
+function formatBattleReplayTitle(replay: PlayerBattleReplaySummary): string {
   const resultLabel = replay.result === "attacker_victory" ? "胜利" : "失利";
   const battleKindLabel = replay.battleKind === "hero" ? "PVP" : "PVE";
   const encounterLabel = replay.battleKind === "hero"
@@ -57,13 +398,13 @@ function formatBattleReplayTitle(replay: CocosPlayerAccountProfile["recentBattle
   return `${resultLabel} · ${battleKindLabel} · ${encounterLabel}`;
 }
 
-function formatBattleReplayFootnote(replay: CocosPlayerAccountProfile["recentBattleReplays"][number]): string {
+function formatBattleReplayFootnote(replay: PlayerBattleReplaySummary): string {
   const campLabel = replay.playerCamp === "attacker" ? "攻方" : "守方";
   return `${formatReviewTimestamp(replay.completedAt)} · ${campLabel} · 房间 ${replay.roomId}`;
 }
 
-function buildBattleReplayItems(account: CocosPlayerAccountProfile): CocosAccountReviewItem[] {
-  return account.recentBattleReplays.map((replay) => ({
+function buildBattleReplayItems(items: readonly PlayerBattleReplaySummary[]): CocosAccountReviewItem[] {
+  return items.map((replay) => ({
     title: formatBattleReplayTitle(replay),
     detail: `英雄 ${replay.heroId} · ${replay.steps.length} 步文本回顾`,
     footnote: formatBattleReplayFootnote(replay),
@@ -72,22 +413,28 @@ function buildBattleReplayItems(account: CocosPlayerAccountProfile): CocosAccoun
   }));
 }
 
-function buildEventHistoryItems(account: CocosPlayerAccountProfile): CocosAccountReviewItem[] {
-  return account.recentEventLog.map((entry) => ({
+function buildEventHistoryItems(items: readonly EventLogEntry[]): CocosAccountReviewItem[] {
+  return items.map((entry) => ({
     title: entry.description,
-    detail: `分类 ${entry.category}${entry.worldEventType ? ` · ${entry.worldEventType}` : ""}`,
+    detail: [
+      `分类 ${entry.category}`,
+      entry.worldEventType ? `事件 ${formatWorldEventTypeLabel(entry.worldEventType)}` : "",
+      entry.achievementId ? `成就 ${formatAchievementLabel(entry.achievementId)}` : ""
+    ]
+      .filter(Boolean)
+      .join(" · "),
     footnote: formatReviewTimestamp(entry.timestamp),
     emphasis: entry.category === "achievement" ? "positive" : "neutral"
   }));
 }
 
-function buildAchievementItems(account: CocosPlayerAccountProfile): CocosAccountReviewItem[] {
-  const featuredAchievements = account.achievements.filter(
+function buildAchievementItems(items: readonly PlayerAchievementProgress[]): CocosAccountReviewItem[] {
+  const featuredAchievements = items.filter(
     (achievement) => achievement.unlocked || achievement.current > 0 || Boolean(achievement.progressUpdatedAt)
   );
-  const source = featuredAchievements.length > 0 ? featuredAchievements : account.achievements;
+  const source = featuredAchievements.length > 0 ? featuredAchievements : items;
 
-  return buildCocosAchievementPanelItems(source).map((item) => ({
+  return buildCocosAchievementPanelItems([...source]).map((item) => ({
     title: `${item.title} · ${item.statusLabel}`,
     detail: `${item.progressLabel} · ${item.description}`,
     footnote: item.footnote,
@@ -95,82 +442,153 @@ function buildAchievementItems(account: CocosPlayerAccountProfile): CocosAccount
   }));
 }
 
-function buildItems(account: CocosPlayerAccountProfile, section: CocosAccountReviewSection): CocosAccountReviewItem[] {
-  switch (section) {
-    case "battle-replays":
-      return buildBattleReplayItems(account);
-    case "event-history":
-      return buildEventHistoryItems(account);
-    case "achievements":
-      return buildAchievementItems(account);
-  }
-}
-
-function buildSubtitle(section: CocosAccountReviewSection, count: number): string {
-  switch (section) {
-    case "battle-replays":
-      return count > 0
-        ? `最近 ${count} 条战报摘要，当前先提供文本化复盘入口。`
-        : "最近还没有战报；完成战斗后会同步摘要。";
-    case "event-history":
-      return count > 0
-        ? `最近 ${count} 条事件历史，按时间倒序分页查看。`
-        : "最近还没有事件历史；进入房间后触发探索或战斗即可积累。";
-    case "achievements":
-      return count > 0
-        ? "优先展示已解锁与最近推进的成就，没有进度时回退全量目录。"
-        : "成就目录暂未同步。";
-  }
-}
-
-function buildTabs(account: CocosPlayerAccountProfile): CocosAccountReviewTab[] {
+function buildTabs(state: CocosAccountReviewState): CocosAccountReviewTab[] {
   return [
+    {
+      section: "progression",
+      label: "成长",
+      count: Math.max(1, buildProgressionItems(state.progression.snapshot).length)
+    },
     {
       section: "battle-replays",
       label: "战报",
-      count: account.recentBattleReplays.length
+      count: state.battleReplays.total ?? state.battleReplays.items.length
     },
     {
       section: "event-history",
       label: "事件",
-      count: account.recentEventLog.length
+      count: state.eventHistory.total ?? state.eventHistory.items.length
     },
     {
       section: "achievements",
       label: "成就",
-      count: buildAchievementItems(account).length
+      count: state.achievements.total ?? state.achievements.items.length
     }
   ];
 }
 
-export function buildCocosAccountReviewPage(
-  account: CocosPlayerAccountProfile,
-  section: CocosAccountReviewSection,
-  page: number,
-  pageSize = 3
-): CocosAccountReviewPage {
-  const safePageSize = Math.max(1, Math.floor(pageSize));
-  const items = buildItems(account, section);
-  const totalPages = Math.max(1, Math.ceil(items.length / safePageSize));
-  const safePage = Math.max(0, Math.min(totalPages - 1, Math.floor(page)));
-  const start = safePage * safePageSize;
+function buildPageLabel(page: number, total: number | null, pageSize: number, hasMore: boolean): string {
+  if (total != null) {
+    return `${page + 1}/${Math.max(1, Math.ceil(total / Math.max(1, pageSize)))}`;
+  }
 
+  return hasMore ? `${page + 1}/更多` : `${page + 1}/${page + 1}`;
+}
+
+function buildSectionSubtitle(section: CocosAccountReviewSection, itemCount: number): string {
+  switch (section) {
+    case "progression":
+      return itemCount > 0 ? "成长摘要会优先显示最新解锁、最近推进和最新事件。" : "成长摘要暂未同步。";
+    case "battle-replays":
+      return itemCount > 0 ? "按页查看最近战报，并可在上方切换文本时间线。" : "最近还没有战报。";
+    case "event-history":
+      return itemCount > 0 ? "按页查看最近事件历史，适配移动端的短卡片阅读。" : "最近还没有事件历史。";
+    case "achievements":
+      return itemCount > 0 ? "优先展示已解锁与最近推进的成就。" : "成就目录暂未同步。";
+  }
+}
+
+function buildBanner(
+  status: CocosAccountReviewSectionStatus,
+  errorMessage: string | null,
+  hasItems: boolean,
+  sectionTitle: string
+): CocosAccountReviewStateBanner | null {
+  if (status === "loading") {
+    return {
+      title: `正在同步${sectionTitle}`,
+      detail: hasItems ? "已先展示本地缓存摘要，稍后会自动更新。" : "请稍候，移动端会在当前面板内完成刷新。",
+      tone: "neutral"
+    };
+  }
+
+  if (status === "error") {
+    return {
+      title: `${sectionTitle}同步失败`,
+      detail: errorMessage ?? "网络暂不可用，请稍后重试。",
+      tone: "negative"
+    };
+  }
+
+  return null;
+}
+
+export function buildCocosAccountReviewPage(state: CocosAccountReviewState): CocosAccountReviewPage {
+  const tabs = buildTabs(state).sort((left, right) => SECTION_ORDER.indexOf(left.section) - SECTION_ORDER.indexOf(right.section));
+
+  if (state.activeSection === "progression") {
+    const items = buildProgressionItems(state.progression.snapshot);
+    return {
+      section: "progression",
+      title: "账号成长",
+      subtitle: buildSectionSubtitle("progression", items.length),
+      items,
+      page: 0,
+      pageLabel: "1/1",
+      hasPreviousPage: false,
+      hasNextPage: false,
+      tabs,
+      banner: buildBanner(state.progression.status, state.progression.errorMessage, items.length > 0, "成长摘要"),
+      showRetry: state.progression.status === "error"
+    };
+  }
+
+  if (state.activeSection === "battle-replays") {
+    const items = buildBattleReplayItems(state.battleReplays.items);
+    return {
+      section: "battle-replays",
+      title: "账号战报",
+      subtitle: buildSectionSubtitle("battle-replays", items.length),
+      items,
+      page: state.battleReplays.page,
+      pageLabel: buildPageLabel(
+        state.battleReplays.page,
+        state.battleReplays.total,
+        state.battleReplays.pageSize,
+        state.battleReplays.hasMore
+      ),
+      hasPreviousPage: state.battleReplays.page > 0,
+      hasNextPage: state.battleReplays.hasMore,
+      tabs,
+      banner: buildBanner(state.battleReplays.status, state.battleReplays.errorMessage, items.length > 0, "战报列表"),
+      showRetry: state.battleReplays.status === "error"
+    };
+  }
+
+  if (state.activeSection === "event-history") {
+    const items = buildEventHistoryItems(state.eventHistory.items);
+    return {
+      section: "event-history",
+      title: "事件历史",
+      subtitle: buildSectionSubtitle("event-history", items.length),
+      items,
+      page: state.eventHistory.page,
+      pageLabel: buildPageLabel(
+        state.eventHistory.page,
+        state.eventHistory.total,
+        state.eventHistory.pageSize,
+        state.eventHistory.hasMore
+      ),
+      hasPreviousPage: state.eventHistory.page > 0,
+      hasNextPage: state.eventHistory.hasMore,
+      tabs,
+      banner: buildBanner(state.eventHistory.status, state.eventHistory.errorMessage, items.length > 0, "事件历史"),
+      showRetry: state.eventHistory.status === "error"
+    };
+  }
+
+  const items = buildAchievementItems(state.achievements.items);
   return {
-    section,
-    title:
-      section === "battle-replays"
-        ? "账号战报"
-        : section === "event-history"
-          ? "事件历史"
-          : "成就回顾",
-    subtitle: buildSubtitle(section, items.length),
-    items: items.slice(start, start + safePageSize),
-    page: safePage,
-    totalPages,
-    hasPreviousPage: safePage > 0,
-    hasNextPage: safePage < totalPages - 1,
-    tabs: buildTabs(account).sort(
-      (left, right) => SECTION_ORDER.indexOf(left.section) - SECTION_ORDER.indexOf(right.section)
-    )
+    section: "achievements",
+    title: "成就回顾",
+    subtitle: buildSectionSubtitle("achievements", items.length),
+    items,
+    page: 0,
+    pageLabel: "1/1",
+    hasPreviousPage: false,
+    hasNextPage: false,
+    tabs,
+    banner: buildBanner(state.achievements.status, state.achievements.errorMessage, items.length > 0, "成就目录"),
+    showRetry: state.achievements.status === "error"
   };
 }

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -16,6 +16,7 @@ import {
   type EventLogQuery,
   type PlayerAccountReadModel,
   type PlayerProgressionSnapshot,
+  type PlayerBattleReplayQuery,
   type PlayerBattleReplaySummary,
   type PlayerAchievementProgress
 } from "./project-shared/index.ts";
@@ -24,6 +25,7 @@ const LOBBY_PREFERENCES_STORAGE_KEY = "project-veil:lobby-preferences";
 const PLAYER_ACCOUNT_PREFIX = "project-veil:player-account";
 const DEFAULT_LOBBY_ROOM_ID = "room-alpha";
 const COCOS_REQUEST_TIMEOUT_MS = 1200;
+const DEFAULT_HISTORY_PAGE_SIZE = 3;
 
 export interface CocosLobbyPreferences {
   playerId: string;
@@ -100,8 +102,21 @@ interface PlayerBattleReplayListApiPayload {
   items?: Partial<PlayerBattleReplaySummary>[];
 }
 
+interface PlayerBattleReplayHistoryApiPayload extends PlayerBattleReplayListApiPayload {
+  offset?: number;
+  limit?: number;
+  hasMore?: boolean;
+}
+
 interface PlayerEventLogListApiPayload {
   items?: Partial<EventLogEntry>[];
+}
+
+interface PlayerEventHistoryApiPayload extends PlayerEventLogListApiPayload {
+  total?: number;
+  offset?: number;
+  limit?: number;
+  hasMore?: boolean;
 }
 
 interface PlayerAchievementListApiPayload {
@@ -118,6 +133,21 @@ export interface CocosPasswordRecoveryRequestResult {
   status: string;
   expiresAt?: string;
   recoveryToken?: string;
+}
+
+export interface CocosBattleReplayHistoryPage {
+  items: PlayerBattleReplaySummary[];
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+export interface CocosEventHistoryPage {
+  items: EventLogEntry[];
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
 }
 
 type PlayerProgressionApiPayload = Partial<PlayerProgressionSnapshot>;
@@ -201,6 +231,9 @@ function toEventLogQueryString(query?: EventLogQuery): string {
   if (query.limit != null) {
     searchParams.set("limit", String(query.limit));
   }
+  if (query.offset != null) {
+    searchParams.set("offset", String(query.offset));
+  }
   if (query.category) {
     searchParams.set("category", query.category);
   }
@@ -212,6 +245,47 @@ function toEventLogQueryString(query?: EventLogQuery): string {
   }
   if (query.worldEventType) {
     searchParams.set("worldEventType", query.worldEventType);
+  }
+
+  const serialized = searchParams.toString();
+  return serialized ? `?${serialized}` : "";
+}
+
+function toBattleReplayQueryString(query?: PlayerBattleReplayQuery): string {
+  if (!query) {
+    return "";
+  }
+
+  const searchParams = new URLSearchParams();
+  if (query.limit != null) {
+    searchParams.set("limit", String(query.limit));
+  }
+  if (query.offset != null) {
+    searchParams.set("offset", String(query.offset));
+  }
+  if (query.roomId) {
+    searchParams.set("roomId", query.roomId);
+  }
+  if (query.battleId) {
+    searchParams.set("battleId", query.battleId);
+  }
+  if (query.battleKind) {
+    searchParams.set("battleKind", query.battleKind);
+  }
+  if (query.playerCamp) {
+    searchParams.set("playerCamp", query.playerCamp);
+  }
+  if (query.heroId) {
+    searchParams.set("heroId", query.heroId);
+  }
+  if (query.opponentHeroId) {
+    searchParams.set("opponentHeroId", query.opponentHeroId);
+  }
+  if (query.neutralArmyId) {
+    searchParams.set("neutralArmyId", query.neutralArmyId);
+  }
+  if (query.result) {
+    searchParams.set("result", query.result);
   }
 
   const serialized = searchParams.toString();
@@ -314,9 +388,10 @@ function asCocosPlayerAccountProfile(
   };
 }
 
-async function loadCocosBattleReplaySummaries(
+export async function loadCocosBattleReplaySummaries(
   remoteUrl: string,
   playerId: string,
+  query?: PlayerBattleReplayQuery,
   options?: {
     fetchImpl?: FetchLike;
     authSession?: CocosStoredAuthSession | null;
@@ -324,9 +399,10 @@ async function loadCocosBattleReplaySummaries(
   }
 ): Promise<PlayerBattleReplaySummary[]> {
   const authSession = options?.authSession ?? null;
+  const queryString = toBattleReplayQueryString(query);
   const endpoint = authSession?.token
-    ? `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/battle-replays`
-    : `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/${encodeURIComponent(playerId)}/battle-replays`;
+    ? `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/battle-replays${queryString}`
+    : `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/${encodeURIComponent(playerId)}/battle-replays${queryString}`;
 
   try {
     const payload = (await fetchCocosAuthJson(
@@ -348,6 +424,37 @@ async function loadCocosBattleReplaySummaries(
     }
     return normalizePlayerBattleReplaySummaries();
   }
+}
+
+export async function loadCocosBattleReplayHistoryPage(
+  remoteUrl: string,
+  playerId: string,
+  query: PlayerBattleReplayQuery,
+  options?: {
+    fetchImpl?: FetchLike;
+    authSession?: CocosStoredAuthSession | null;
+    storage?: Pick<Storage, "removeItem"> | null;
+  }
+): Promise<CocosBattleReplayHistoryPage> {
+  const safeLimit = Math.max(1, Math.floor(query.limit ?? DEFAULT_HISTORY_PAGE_SIZE));
+  const safeOffset = Math.max(0, Math.floor(query.offset ?? 0));
+  const items = await loadCocosBattleReplaySummaries(
+    remoteUrl,
+    playerId,
+    {
+      ...query,
+      limit: safeLimit + 1,
+      offset: safeOffset
+    },
+    options
+  );
+
+  return {
+    items: items.slice(0, safeLimit),
+    offset: safeOffset,
+    limit: safeLimit,
+    hasMore: items.length > safeLimit
+  };
 }
 
 async function fetchJson(
@@ -1114,7 +1221,7 @@ export async function loadCocosPlayerAccountProfile(
       payload.account,
       storedDisplayName
     );
-    const recentBattleReplays = await loadCocosBattleReplaySummaries(remoteUrl, resolvedPlayerId, {
+    const recentBattleReplays = await loadCocosBattleReplaySummaries(remoteUrl, resolvedPlayerId, undefined, {
       ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
       authSession: authSession ?? null,
       storage
@@ -1177,6 +1284,63 @@ export async function loadCocosPlayerEventLog(
       clearStoredCocosAuthSession(storage);
     }
     return normalizeEventLogEntries();
+  }
+}
+
+export async function loadCocosPlayerEventHistory(
+  remoteUrl: string,
+  playerId: string,
+  query?: EventLogQuery,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "removeItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<CocosEventHistoryPage> {
+  const storage = options?.storage ?? getCocosStorage();
+  const authSession =
+    options && "authSession" in options ? options.authSession ?? null : readStoredCocosAuthSession(storage);
+  const queryString = toEventLogQueryString(query);
+  const endpoint = authSession?.token
+    ? `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/event-history${queryString}`
+    : `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/${encodeURIComponent(playerId)}/event-history${queryString}`;
+
+  try {
+    const payload = (await fetchCocosAuthJson(
+      remoteUrl,
+      endpoint,
+      {
+        ...(authSession?.token ? { headers: buildCocosAuthHeaders(authSession.token) } : {})
+      },
+      authSession,
+      {
+        ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        ...(storage !== undefined ? { storage } : {})
+      }
+    )) as PlayerEventHistoryApiPayload;
+    const safeLimit = Math.max(1, Math.floor(payload.limit ?? query?.limit ?? DEFAULT_HISTORY_PAGE_SIZE));
+    const safeOffset = Math.max(0, Math.floor(payload.offset ?? query?.offset ?? 0));
+    const items = normalizeEventLogEntries(payload.items);
+    return {
+      items,
+      total: Math.max(items.length, Math.floor(payload.total ?? items.length)),
+      offset: safeOffset,
+      limit: safeLimit,
+      hasMore: Boolean(payload.hasMore)
+    };
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && storage) {
+      clearStoredCocosAuthSession(storage);
+    }
+    const safeLimit = Math.max(1, Math.floor(query?.limit ?? DEFAULT_HISTORY_PAGE_SIZE));
+    const safeOffset = Math.max(0, Math.floor(query?.offset ?? 0));
+    return {
+      items: normalizeEventLogEntries(),
+      total: 0,
+      offset: safeOffset,
+      limit: safeLimit,
+      hasMore: false
+    };
   }
 }
 

--- a/apps/cocos-client/assets/scripts/project-shared/battle-replay.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle-replay.ts
@@ -30,6 +30,7 @@ export interface PlayerBattleReplaySummary {
 
 export interface PlayerBattleReplayQuery {
   limit?: number | undefined;
+  offset?: number | undefined;
   roomId?: string | undefined;
   battleId?: string | undefined;
   battleKind?: PlayerBattleReplaySummary["battleKind"] | undefined;

--- a/apps/cocos-client/test/cocos-account-review.test.ts
+++ b/apps/cocos-client/test/cocos-account-review.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildCocosAccountReviewPage } from "../assets/scripts/cocos-account-review.ts";
+import {
+  buildCocosAccountReviewPage,
+  createCocosAccountReviewState,
+  transitionCocosAccountReviewState
+} from "../assets/scripts/cocos-account-review.ts";
 import type { CocosPlayerAccountProfile } from "../assets/scripts/cocos-lobby.ts";
 
 function createProfile(): CocosPlayerAccountProfile {
@@ -167,37 +171,55 @@ function createProfile(): CocosPlayerAccountProfile {
   };
 }
 
-test("buildCocosAccountReviewPage paginates event history and exposes tab counts", () => {
-  const review = buildCocosAccountReviewPage(createProfile(), "event-history", 1, 2);
+test("buildCocosAccountReviewPage formats the progression surface from the latest unlock and activity", () => {
+  const state = createCocosAccountReviewState(createProfile());
+  const review = buildCocosAccountReviewPage(state);
 
-  assert.equal(review.title, "事件历史");
-  assert.equal(review.page, 1);
-  assert.equal(review.totalPages, 2);
-  assert.equal(review.hasPreviousPage, true);
-  assert.equal(review.hasNextPage, false);
-  assert.deepEqual(review.items.map((item) => item.title), ["向东移动 1 格"]);
-  assert.deepEqual(
-    review.tabs.map((tab) => `${tab.label}:${tab.count}`),
-    ["战报:2", "事件:3", "成就:2"]
-  );
+  assert.equal(review.section, "progression");
+  assert.equal(review.title, "账号成长");
+  assert.equal(review.pageLabel, "1/1");
+  assert.match(review.items[0]?.detail ?? "", /^成就 1\/5 已解锁 · 最新 初次交锋$/);
+  assert.equal(review.items[1]?.title, "最新解锁 · 初次交锋");
+  assert.equal(review.items.at(-1)?.title, "最近事件");
+  assert.equal(review.tabs.map((tab) => `${tab.label}:${tab.count}`).join(" | "), "成长:3 | 战报:2 | 事件:3 | 成就:3");
 });
 
-test("buildCocosAccountReviewPage prefers unlocked and recently progressed achievements", () => {
-  const review = buildCocosAccountReviewPage(createProfile(), "achievements", 0, 5);
+test("transitionCocosAccountReviewState exposes loading and error banners for paged history sections", () => {
+  let state = createCocosAccountReviewState(createProfile());
+  state = transitionCocosAccountReviewState(state, { type: "section.selected", section: "event-history" });
+  state = transitionCocosAccountReviewState(state, { type: "section.loading", section: "event-history" });
 
-  assert.equal(review.totalPages, 1);
-  assert.deepEqual(
-    review.items.map((item) => item.title),
-    ["初次交锋 · 已解锁", "猎敌者 · 未解锁"]
-  );
-  assert.match(review.items[1]?.detail ?? "", /^2\/3 · 击败 3 名敌人或中立守军。$/);
+  let review = buildCocosAccountReviewPage(state);
+  assert.equal(review.section, "event-history");
+  assert.equal(review.banner?.title, "正在同步事件历史");
+  assert.equal(review.showRetry, false);
+
+  state = transitionCocosAccountReviewState(state, {
+    type: "section.failed",
+    section: "event-history",
+    message: "history_fetch_failed"
+  });
+  review = buildCocosAccountReviewPage(state);
+  assert.equal(review.banner?.title, "事件历史同步失败");
+  assert.equal(review.banner?.detail, "history_fetch_failed");
+  assert.equal(review.showRetry, true);
 });
 
-test("buildCocosAccountReviewPage clamps invalid pages for battle replays", () => {
-  const review = buildCocosAccountReviewPage(createProfile(), "battle-replays", 99, 1);
+test("transitionCocosAccountReviewState keeps replay selection aligned with the currently loaded page", () => {
+  let state = createCocosAccountReviewState(createProfile());
+  assert.equal(state.selectedBattleReplayId, "replay-1");
 
-  assert.equal(review.page, 1);
-  assert.equal(review.totalPages, 2);
+  state = transitionCocosAccountReviewState(state, { type: "section.selected", section: "battle-replays" });
+  state = transitionCocosAccountReviewState(state, {
+    type: "battle-replays.loaded",
+    items: [createProfile().recentBattleReplays[1]!],
+    page: 1,
+    pageSize: 1,
+    hasMore: false
+  });
+
+  const review = buildCocosAccountReviewPage(state);
+  assert.equal(state.selectedBattleReplayId, "replay-2");
+  assert.equal(review.pageLabel, "2/2");
   assert.equal(review.items[0]?.title, "失利 · PVP · 对手 hero-9");
-  assert.equal(review.items[0]?.footnote, "2026-03-28 11:52 · 守方 · 房间 room-beta");
 });

--- a/apps/cocos-client/test/cocos-lobby-panel.test.ts
+++ b/apps/cocos-client/test/cocos-lobby-panel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { buildCocosAccountReviewPage, createCocosAccountReviewState } from "../assets/scripts/cocos-account-review.ts";
 import {
   buildLobbyAccountIdentityView,
   buildLobbyGuestEntryView,
@@ -10,6 +11,7 @@ import {
 import type { VeilLobbyRenderState } from "../assets/scripts/VeilLobbyPanel";
 
 function createLobbyState(overrides: Partial<VeilLobbyRenderState> = {}): VeilLobbyRenderState {
+  const account = createLobbyPanelTestAccount();
   return {
     playerId: "guest-1001",
     displayName: "",
@@ -20,7 +22,9 @@ function createLobbyState(overrides: Partial<VeilLobbyRenderState> = {}): VeilLo
     loginActionLabel: "账号登录并进入",
     shareHint: "共享存档未启用",
     vaultSummary: "本地存档",
-    account: createLobbyPanelTestAccount(),
+    account,
+    accountReview: buildCocosAccountReviewPage(createCocosAccountReviewState(account)),
+    selectedBattleReplayId: null,
     sessionSource: "none",
     loading: false,
     entering: false,

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -7,9 +7,11 @@ import {
   createCocosLobbyPreferences,
   getCocosLobbyPreferencesStorageKey,
   getCocosPlayerAccountStorageKey,
+  loadCocosBattleReplayHistoryPage,
   loadCocosPlayerAchievementProgress,
   loadCocosLobbyRooms,
   loadCocosPlayerAccountProfile,
+  loadCocosPlayerEventHistory,
   loadCocosPlayerEventLog,
   loadCocosPlayerProgressionSnapshot,
   loginCocosPasswordAuthSession,
@@ -120,6 +122,131 @@ test("loadCocosLobbyRooms queries the lobby api from the resolved remote host", 
 
   assert.equal(requestedUrls[0], "http://127.0.0.1:2567/api/lobby/rooms?limit=3");
   assert.equal(rooms[0]?.roomId, "room-alpha");
+});
+
+test("loadCocosPlayerEventHistory returns normalized paging metadata from the event-history route", async () => {
+  const requestedUrls: string[] = [];
+  const history = await loadCocosPlayerEventHistory("http://127.0.0.1:2567", "player-1", {
+    limit: 2,
+    offset: 2
+  }, {
+    fetchImpl: async (input) => {
+      requestedUrls.push(String(input));
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "event-3",
+              timestamp: "2026-03-29T12:04:00.000Z",
+              roomId: "room-alpha",
+              playerId: "player-1",
+              category: "combat",
+              description: "击退守军",
+              worldEventType: "battle.resolved",
+              rewards: []
+            }
+          ],
+          total: 5,
+          offset: 2,
+          limit: 2,
+          hasMore: true
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+  });
+
+  assert.equal(requestedUrls[0], "http://127.0.0.1:2567/api/player-accounts/player-1/event-history?limit=2&offset=2");
+  assert.equal(history.total, 5);
+  assert.equal(history.offset, 2);
+  assert.equal(history.limit, 2);
+  assert.equal(history.hasMore, true);
+  assert.equal(history.items[0]?.id, "event-3");
+});
+
+test("loadCocosBattleReplayHistoryPage overfetches one replay to expose hasMore", async () => {
+  const requestedUrls: string[] = [];
+  const page = await loadCocosBattleReplayHistoryPage("http://127.0.0.1:2567", "player-1", {
+    limit: 1,
+    offset: 1
+  }, {
+    fetchImpl: async (input) => {
+      requestedUrls.push(String(input));
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: "replay-2",
+              roomId: "room-alpha",
+              playerId: "player-1",
+              battleId: "battle-2",
+              battleKind: "hero",
+              playerCamp: "defender",
+              heroId: "hero-1",
+              opponentHeroId: "hero-2",
+              startedAt: "2026-03-29T12:03:00.000Z",
+              completedAt: "2026-03-29T12:04:00.000Z",
+              initialState: {
+                id: "battle-2",
+                round: 1,
+                lanes: 1,
+                activeUnitId: "stack-1",
+                turnOrder: ["stack-1"],
+                units: {},
+                environment: [],
+                log: [],
+                rng: { seed: 4, cursor: 0 }
+              },
+              steps: [],
+              result: "defender_victory"
+            },
+            {
+              id: "replay-3",
+              roomId: "room-alpha",
+              playerId: "player-1",
+              battleId: "battle-3",
+              battleKind: "neutral",
+              playerCamp: "attacker",
+              heroId: "hero-1",
+              neutralArmyId: "neutral-2",
+              startedAt: "2026-03-29T12:05:00.000Z",
+              completedAt: "2026-03-29T12:06:00.000Z",
+              initialState: {
+                id: "battle-3",
+                round: 1,
+                lanes: 1,
+                activeUnitId: "stack-1",
+                turnOrder: ["stack-1"],
+                units: {},
+                environment: [],
+                log: [],
+                rng: { seed: 5, cursor: 0 }
+              },
+              steps: [],
+              result: "attacker_victory"
+            }
+          ]
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+  });
+
+  assert.equal(requestedUrls[0], "http://127.0.0.1:2567/api/player-accounts/player-1/battle-replays?limit=2&offset=1");
+  assert.equal(page.limit, 1);
+  assert.equal(page.offset, 1);
+  assert.equal(page.hasMore, true);
+  assert.deepEqual(page.items.map((item) => item.id), ["replay-3"]);
 });
 
 test("loginCocosGuestAuthSession stores remote sessions and clearCurrentCocosAuthSession removes them", async () => {

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 import { sys } from "cc";
+import { createCocosAccountReviewState, transitionCocosAccountReviewState } from "../assets/scripts/cocos-account-review.ts";
 import { createMemoryStorage, createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
 import { createVeilRootHarness, installVeilRootRuntime, resetVeilRootRuntime } from "./helpers/veil-root-harness.ts";
 import type { BattleAction, BattleState, SessionUpdate, VeilCocosSessionOptions } from "../assets/scripts/VeilCocosSession.ts";
@@ -453,4 +454,51 @@ test("VeilRoot runtime harness carries the first battle back to world state", as
   assert.deepEqual(transitionCalls, ["enter:遭遇中立守军", "exit:战斗胜利"]);
   assert.equal(root.battlePresentation.getState().phase, "resolution");
   assert.equal(root.battlePresentation.getState().result, "victory");
+});
+
+test("VeilRoot refreshAccountReviewPage loads paged event history into the lobby review state", async () => {
+  const root = createVeilRootHarness();
+  root.playerId = "player-1";
+  root.displayName = "雾林司灯";
+  root.lobbyAccountProfile = {
+    playerId: "player-1",
+    displayName: "雾林司灯",
+    globalResources: { gold: 0, wood: 0, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [],
+    source: "remote"
+  };
+  root.lobbyAccountReviewState = createCocosAccountReviewState(root.lobbyAccountProfile);
+  root.lobbyAccountReviewState = transitionCocosAccountReviewState(root.lobbyAccountReviewState, {
+    type: "section.selected",
+    section: "event-history"
+  });
+
+  installVeilRootRuntime({
+    loadEventHistory: async () => ({
+      items: [
+        {
+          id: "event-page-2",
+          timestamp: "2026-03-29T12:08:00.000Z",
+          roomId: "room-alpha",
+          playerId: "player-1",
+          category: "combat",
+          description: "翻到第二页",
+          rewards: []
+        }
+      ],
+      total: 4,
+      offset: 3,
+      limit: 3,
+      hasMore: false
+    })
+  });
+
+  await root.refreshAccountReviewPage("event-history", 1);
+
+  assert.equal(root.lobbyAccountReviewState.eventHistory.status, "ready");
+  assert.equal(root.lobbyAccountReviewState.eventHistory.page, 1);
+  assert.equal(root.lobbyAccountReviewState.eventHistory.total, 4);
+  assert.equal(root.lobbyAccountReviewState.eventHistory.items[0]?.id, "event-page-2");
 });


### PR DESCRIPTION
## Summary
- add a stateful Cocos account review model with progression, achievements, event history, and battle replay surfaces
- wire VeilRoot and the lobby panel to load paged event/replay history with mobile-friendly loading, empty, and error banners
- add focused regressions for review formatting, loader pagination, and lobby review state transitions

Closes #290