### PR TITLE
feat(auth-ui): validate registration and recovery flows

### DIFF
--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,6 +1,7 @@
 import "./styles.css";
 import {
   buildRuntimeDiagnosticsTriageView,
+  describeAccountAuthFailure,
   renderRuntimeDiagnosticsSnapshotText,
   createBattleReplayPlaybackState,
   createHeroSkillTreeView,
@@ -29,7 +30,10 @@ import {
   type PlayerTileView,
   type PlayerWorldView,
   type RuntimeDiagnosticsConnectionStatus,
-  type RuntimeDiagnosticsTriageSection
+  type RuntimeDiagnosticsTriageSection,
+  validateAccountLifecycleConfirm,
+  validateAccountLifecycleRequest,
+  validateAccountPassword
 } from "../../../packages/shared/src/index";
 import { createGameSession, readStoredSessionReplay, type SessionUpdate } from "./local-session";
 import { buildH5RuntimeDiagnosticsSnapshot } from "./runtime-diagnostics";
@@ -3270,20 +3274,9 @@ function describeAccountFlowError(
     return error instanceof Error ? error.message : fallback;
   }
 
-  if (failure.status === 409 && failure.code === "login_id_taken") {
-    return "登录 ID 已被占用，请更换后重试。";
-  }
-  if (failure.status === 401 && options.invalidTokenCode && failure.code === options.invalidTokenCode) {
-    return "令牌无效或已过期，请重新申请后再确认。";
-  }
-  if (failure.status === 401) {
-    return "登录 ID 或口令不正确，请检查后重试。";
-  }
-  if (failure.status === 400) {
-    return "输入格式不合法，请检查登录 ID、令牌和口令后重试。";
-  }
-  if (failure.status === 429) {
-    return "请求过于频繁，请稍后再试。";
+  const message = describeAccountAuthFailure(failure, options);
+  if (message) {
+    return message;
   }
 
   return error instanceof Error ? error.message : fallback;
@@ -3318,14 +3311,16 @@ async function enterLobbyRoom(roomIdOverride?: string): Promise<void> {
 async function loginLobbyAccount(roomIdOverride?: string): Promise<void> {
   const preferences = saveLobbyPreferences(state.lobby.playerId, roomIdOverride ?? state.lobby.roomId);
   const loginId = state.lobby.loginId.trim().toLowerCase();
-  if (!loginId) {
-    state.lobby.status = "请输入登录 ID 后再使用口令登录。";
+  const loginIdError = validateAccountLifecycleRequest("registration", loginId);
+  if (loginIdError) {
+    state.lobby.status = loginIdError.message;
     render();
     return;
   }
 
-  if (!state.lobby.password.trim()) {
-    state.lobby.status = "请输入账号口令后再登录。";
+  const passwordError = validateAccountPassword(state.lobby.password, "password", "账号口令");
+  if (passwordError) {
+    state.lobby.status = passwordError.message;
     render();
     return;
   }
@@ -3359,8 +3354,9 @@ async function loginLobbyAccount(roomIdOverride?: string): Promise<void> {
 
 async function requestLobbyAccountRegistration(): Promise<void> {
   const loginId = state.lobby.loginId.trim().toLowerCase();
-  if (!loginId) {
-    state.lobby.status = "请输入登录 ID 后再申请正式注册令牌。";
+  const validationError = validateAccountLifecycleRequest("registration", loginId);
+  if (validationError) {
+    state.lobby.status = validationError.message;
     render();
     return;
   }
@@ -3387,18 +3383,13 @@ async function requestLobbyAccountRegistration(): Promise<void> {
 async function confirmLobbyAccountRegistration(roomIdOverride?: string): Promise<void> {
   const preferences = saveLobbyPreferences(state.lobby.playerId, roomIdOverride ?? state.lobby.roomId);
   const loginId = state.lobby.loginId.trim().toLowerCase();
-  if (!loginId) {
-    state.lobby.status = "请输入登录 ID 后再确认正式注册。";
-    render();
-    return;
-  }
-  if (!state.lobby.registrationToken.trim()) {
-    state.lobby.status = "请先申请并填写注册令牌。";
-    render();
-    return;
-  }
-  if (!state.lobby.registrationPassword.trim()) {
-    state.lobby.status = "请输入注册口令后再确认。";
+  const validationError = validateAccountLifecycleConfirm("registration", {
+    loginId,
+    token: state.lobby.registrationToken,
+    password: state.lobby.registrationPassword
+  });
+  if (validationError) {
+    state.lobby.status = validationError.message;
     render();
     return;
   }
@@ -3436,8 +3427,9 @@ async function confirmLobbyAccountRegistration(roomIdOverride?: string): Promise
 
 async function requestLobbyPasswordRecovery(): Promise<void> {
   const loginId = state.lobby.loginId.trim().toLowerCase();
-  if (!loginId) {
-    state.lobby.status = "请输入登录 ID 后再申请密码找回令牌。";
+  const validationError = validateAccountLifecycleRequest("recovery", loginId);
+  if (validationError) {
+    state.lobby.status = validationError.message;
     render();
     return;
   }
@@ -3464,18 +3456,13 @@ async function requestLobbyPasswordRecovery(): Promise<void> {
 async function confirmLobbyPasswordRecovery(roomIdOverride?: string): Promise<void> {
   const preferences = saveLobbyPreferences(state.lobby.playerId, roomIdOverride ?? state.lobby.roomId);
   const loginId = state.lobby.loginId.trim().toLowerCase();
-  if (!loginId) {
-    state.lobby.status = "请输入登录 ID 后再确认密码重置。";
-    render();
-    return;
-  }
-  if (!state.lobby.recoveryToken.trim()) {
-    state.lobby.status = "请先申请并填写找回令牌。";
-    render();
-    return;
-  }
-  if (!state.lobby.recoveryPassword.trim()) {
-    state.lobby.status = "请输入新口令后再确认重置。";
+  const validationError = validateAccountLifecycleConfirm("recovery", {
+    loginId,
+    token: state.lobby.recoveryToken,
+    password: state.lobby.recoveryPassword
+  });
+  if (validationError) {
+    state.lobby.status = validationError.message;
     render();
     return;
   }

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -98,7 +98,13 @@ import { buildCocosRuntimeTriageSummaryLines } from "./cocos-runtime-diagnostics
 import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
 import { cocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
 import { getPixelSpriteLoadStatus, loadPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
-import type { RuntimeDiagnosticsConnectionStatus } from "../../../../packages/shared/src/index.ts";
+import {
+  describeAccountAuthFailure,
+  type RuntimeDiagnosticsConnectionStatus,
+  validateAccountLifecycleConfirm,
+  validateAccountLifecycleRequest,
+  validateAccountPassword
+} from "../../../../packages/shared/src/index.ts";
 
 const { ccclass, property } = _decorator;
 
@@ -1883,8 +1889,9 @@ export class VeilRoot extends Component {
     if (nextLoginId === undefined) {
       return;
     }
-    if (!nextLoginId) {
-      this.lobbyStatus = "请输入登录 ID 后再使用正式账号进入。";
+    const loginIdError = validateAccountLifecycleRequest("registration", nextLoginId);
+    if (loginIdError) {
+      this.lobbyStatus = loginIdError.message;
       this.renderView();
       return;
     }
@@ -1893,8 +1900,9 @@ export class VeilRoot extends Component {
     if (password == null) {
       return;
     }
-    if (!password.trim()) {
-      this.lobbyStatus = "请输入账号口令后再登录。";
+    const passwordError = validateAccountPassword(password, "password", "账号口令");
+    if (passwordError) {
+      this.lobbyStatus = passwordError.message;
       this.renderView();
       return;
     }
@@ -1963,20 +1971,9 @@ export class VeilRoot extends Component {
       return error instanceof Error ? error.message : fallback;
     }
 
-    if (failure.status === 409 && failure.code === "login_id_taken") {
-      return "登录 ID 已被占用，请更换后重试。";
-    }
-    if (failure.status === 401 && options.invalidTokenCode && failure.code === options.invalidTokenCode) {
-      return "令牌无效或已过期，请重新申请后再确认。";
-    }
-    if (failure.status === 401) {
-      return "登录 ID 或口令不正确，请检查后重试。";
-    }
-    if (failure.status === 400) {
-      return "输入格式不合法，请检查登录 ID、令牌和口令后重试。";
-    }
-    if (failure.status === 429) {
-      return "请求过于频繁，请稍后再试。";
+    const message = describeAccountAuthFailure(failure, options);
+    if (message) {
+      return message;
     }
 
     return error instanceof Error ? error.message : fallback;
@@ -2212,8 +2209,9 @@ export class VeilRoot extends Component {
       return;
     }
     const loginId = this.loginId.trim().toLowerCase();
-    if (!loginId) {
-      this.lobbyStatus = "请输入登录 ID 后再申请令牌。";
+    const validationError = validateAccountLifecycleRequest(this.activeAccountFlow, loginId);
+    if (validationError) {
+      this.lobbyStatus = validationError.message;
       this.renderView();
       return;
     }
@@ -2264,38 +2262,23 @@ export class VeilRoot extends Component {
       return;
     }
     const loginId = this.loginId.trim().toLowerCase();
-    if (!loginId) {
-      this.lobbyStatus = "请输入登录 ID 后再确认。";
+    this.loginId = loginId;
+    const validationError = validateAccountLifecycleConfirm(this.activeAccountFlow, {
+      loginId,
+      token: this.activeAccountFlow === "registration" ? this.registrationToken : this.recoveryToken,
+      password: this.activeAccountFlow === "registration" ? this.registrationPassword : this.recoveryPassword
+    });
+    if (validationError) {
+      this.lobbyStatus = validationError.message;
       this.renderView();
       return;
     }
-    this.loginId = loginId;
 
     if (this.activeAccountFlow === "registration") {
-      if (!this.registrationToken.trim()) {
-        this.lobbyStatus = "请先填写注册令牌。";
-        this.renderView();
-        return;
-      }
-      if (!this.registrationPassword.trim()) {
-        this.lobbyStatus = "请输入注册口令后再确认。";
-        this.renderView();
-        return;
-      }
       await this.confirmLobbyAccountRegistration(loginId);
       return;
     }
 
-    if (!this.recoveryToken.trim()) {
-      this.lobbyStatus = "请先填写找回令牌。";
-      this.renderView();
-      return;
-    }
-    if (!this.recoveryPassword.trim()) {
-      this.lobbyStatus = "请输入新口令后再确认重置。";
-      this.renderView();
-      return;
-    }
     await this.confirmLobbyAccountRecovery(loginId);
   }
 

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -158,6 +158,39 @@ test("VeilRoot boots into lobby mode and triggers lobby bootstrap when no roomId
   assert.equal(bootstrapCalls, 1);
 });
 
+test("VeilRoot account lifecycle flow switches panels and surfaces validation feedback", async () => {
+  const root = createVeilRootHarness();
+
+  await root.registerLobbyAccount();
+  assert.equal(root.activeAccountFlow, "registration");
+  assert.match(String(root.lobbyStatus), /已打开正式注册面板/);
+
+  root.loginId = "A";
+  await root.requestActiveAccountFlow();
+  assert.equal(root.lobbyEntering, false);
+  assert.equal(root.activeAccountFlow, "registration");
+  assert.equal(root.lobbyStatus, "登录 ID 需为 3-40 位小写字母、数字、下划线或连字符。");
+
+  root.loginId = "veil-ranger";
+  root.registrationToken = "dev-registration-token";
+  root.registrationPassword = "123";
+  await root.confirmActiveAccountFlow();
+  assert.equal(root.lobbyEntering, false);
+  assert.equal(root.lobbyStatus, "注册口令至少 6 位。");
+
+  root.closeLobbyAccountFlow();
+  assert.equal(root.activeAccountFlow, null);
+  assert.match(String(root.lobbyStatus), /已收起账号生命周期面板/);
+
+  await root.recoverLobbyAccountPassword();
+  assert.equal(root.activeAccountFlow, "recovery");
+  root.loginId = "veil-ranger";
+  root.recoveryToken = "";
+  root.recoveryPassword = "hunter3";
+  await root.confirmActiveAccountFlow();
+  assert.equal(root.lobbyStatus, "请先申请并填写找回令牌。");
+});
+
 test("VeilRoot connect replays cached session state before applying the live snapshot", async () => {
   const root = createVeilRootHarness();
   root.roomId = "room-alpha";

--- a/packages/shared/src/auth-ui.ts
+++ b/packages/shared/src/auth-ui.ts
@@ -1,0 +1,125 @@
+export interface AccountAuthRequestFailure {
+  status: number;
+  code: string;
+}
+
+export type AccountLifecycleKind = "registration" | "recovery";
+export type AccountLifecycleValidationField = "loginId" | "token" | "password";
+
+export interface AccountLifecycleDraft {
+  loginId: string;
+  token: string;
+  password: string;
+}
+
+export interface AccountLifecycleValidationError {
+  field: AccountLifecycleValidationField;
+  message: string;
+}
+
+const LOGIN_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{2,39}$/;
+const MIN_PASSWORD_LENGTH = 6;
+
+export function normalizeAccountLoginIdDraft(loginId: string): string {
+  return loginId.trim().toLowerCase();
+}
+
+export function validateAccountLoginId(loginId: string): AccountLifecycleValidationError | null {
+  const normalized = normalizeAccountLoginIdDraft(loginId);
+  if (!normalized) {
+    return {
+      field: "loginId",
+      message: "请输入登录 ID。"
+    };
+  }
+
+  if (!LOGIN_ID_PATTERN.test(normalized)) {
+    return {
+      field: "loginId",
+      message: "登录 ID 需为 3-40 位小写字母、数字、下划线或连字符。"
+    };
+  }
+
+  return null;
+}
+
+export function validateAccountPassword(
+  password: string,
+  field: Extract<AccountLifecycleValidationField, "password">,
+  label: string
+): AccountLifecycleValidationError | null {
+  const normalized = password.trim();
+  if (!normalized) {
+    return {
+      field,
+      message: `请输入${label}。`
+    };
+  }
+
+  if (normalized.length < MIN_PASSWORD_LENGTH) {
+    return {
+      field,
+      message: `${label}至少 ${MIN_PASSWORD_LENGTH} 位。`
+    };
+  }
+
+  return null;
+}
+
+export function validateAccountLifecycleRequest(
+  _kind: AccountLifecycleKind,
+  loginId: string
+): AccountLifecycleValidationError | null {
+  return validateAccountLoginId(loginId);
+}
+
+export function validateAccountLifecycleConfirm(
+  kind: AccountLifecycleKind,
+  draft: AccountLifecycleDraft
+): AccountLifecycleValidationError | null {
+  const loginIdError = validateAccountLoginId(draft.loginId);
+  if (loginIdError) {
+    return loginIdError;
+  }
+
+  if (!draft.token.trim()) {
+    return {
+      field: "token",
+      message: kind === "registration" ? "请先申请并填写注册令牌。" : "请先申请并填写找回令牌。"
+    };
+  }
+
+  return validateAccountPassword(
+    draft.password,
+    "password",
+    kind === "registration" ? "注册口令" : "新口令"
+  );
+}
+
+export function describeAccountAuthFailure(
+  failure: AccountAuthRequestFailure,
+  options: {
+    invalidTokenCode?: string;
+  } = {}
+): string {
+  if (failure.status === 409 && failure.code === "login_id_taken") {
+    return "登录 ID 已被占用，请更换后重试。";
+  }
+  if (failure.status === 403 && failure.code === "account_locked") {
+    return "该账号因连续失败已被临时锁定，请稍后再试。";
+  }
+  if (failure.status === 401 && options.invalidTokenCode && failure.code === options.invalidTokenCode) {
+    return "令牌无效或已过期，请重新申请后再确认。";
+  }
+  if (failure.status === 401) {
+    return "登录 ID 或口令不正确，请检查后重试。";
+  }
+  if (failure.status === 400) {
+    return "输入格式不合法，请检查登录 ID、令牌和口令后重试。";
+  }
+  if (failure.status === 429) {
+    return "请求过于频繁，请稍后再试。";
+  }
+
+  return "";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./auth-ui.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";
 export * from "./battle-replay.ts";

--- a/packages/shared/test/auth-ui.test.ts
+++ b/packages/shared/test/auth-ui.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  describeAccountAuthFailure,
+  normalizeAccountLoginIdDraft,
+  validateAccountLifecycleConfirm,
+  validateAccountLifecycleRequest,
+  validateAccountPassword
+} from "../src/auth-ui.ts";
+
+test("auth ui helper normalizes login IDs and rejects malformed drafts", () => {
+  assert.equal(normalizeAccountLoginIdDraft(" Veil-Ranger "), "veil-ranger");
+  assert.deepEqual(validateAccountLifecycleRequest("registration", " A "), {
+    field: "loginId",
+    message: "登录 ID 需为 3-40 位小写字母、数字、下划线或连字符。"
+  });
+  assert.equal(validateAccountLifecycleRequest("recovery", "veil_ranger-1"), null);
+});
+
+test("auth ui helper validates confirm drafts for registration and recovery", () => {
+  assert.deepEqual(
+    validateAccountLifecycleConfirm("registration", {
+      loginId: "veil-ranger",
+      token: "",
+      password: "hunter2"
+    }),
+    {
+      field: "token",
+      message: "请先申请并填写注册令牌。"
+    }
+  );
+
+  assert.deepEqual(
+    validateAccountLifecycleConfirm("recovery", {
+      loginId: "veil-ranger",
+      token: "dev-recovery-token",
+      password: "123"
+    }),
+    {
+      field: "password",
+      message: "新口令至少 6 位。"
+    }
+  );
+
+  assert.equal(
+    validateAccountLifecycleConfirm("registration", {
+      loginId: "veil-ranger",
+      token: "dev-registration-token",
+      password: "hunter2"
+    }),
+    null
+  );
+});
+
+test("auth ui helper validates password labels and maps server failures", () => {
+  assert.deepEqual(validateAccountPassword(" ", "password", "账号口令"), {
+    field: "password",
+    message: "请输入账号口令。"
+  });
+
+  assert.equal(
+    describeAccountAuthFailure({ status: 403, code: "account_locked" }),
+    "该账号因连续失败已被临时锁定，请稍后再试。"
+  );
+  assert.equal(
+    describeAccountAuthFailure({ status: 429, code: "too_many_requests" }),
+    "请求过于频繁，请稍后再试。"
+  );
+  assert.equal(
+    describeAccountAuthFailure(
+      { status: 401, code: "invalid_registration_token" },
+      { invalidTokenCode: "invalid_registration_token" }
+    ),
+    "令牌无效或已过期，请重新申请后再确认。"
+  );
+});


### PR DESCRIPTION
## Summary
- add a shared auth-ui helper for login-id/password validation and duplicate/rate-limit/lockout messaging
- reuse that helper in both H5 and Cocos auth registration/recovery/login flows
- add shared helper tests plus Cocos lifecycle state-transition coverage

## Validation
- `npm test -- --test "packages/shared/test/auth-ui.test.ts" "apps/cocos-client/test/cocos-root-orchestration.test.ts" "apps/cocos-client/test/cocos-account-lifecycle.test.ts" "apps/client/test/auth-session-storage.test.ts"` (repo script expands to the full test suite; passed)
- `npm run typecheck:shared`
- `npm run typecheck:client:h5`
- `npm run typecheck:cocos`
- `npx playwright test --config=playwright.smoke.config.ts --grep "formal registration"` (blocked in this environment: Chromium failed to launch because `libatk-bridge-2.0.so.0` is missing)

Closes #294