### PR TITLE
ops(ci): add V8 coverage reporting and per-app thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,23 @@ jobs:
       - name: Typecheck
         run: npm run typecheck:ci
 
-      - name: Test
-        run: npm test
+      - name: Test With V8 Coverage
+        run: npm run test:coverage:ci
+
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          if [[ -f .coverage/summary.md ]]; then
+            cat .coverage/summary.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload V8 coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: v8-coverage-${{ github.sha }}
+          path: .coverage
+          if-no-files-found: error
 
   wechat-build-validation:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 dist
 .turbo
 coverage
+.coverage
 *.log
 .env
 .env.local

--- a/docs/test-coverage-audit-issue-199.md
+++ b/docs/test-coverage-audit-issue-199.md
@@ -99,7 +99,7 @@ The largest remaining gap is that most actual scene/controller entry points are 
 The current tooling makes coverage expansion slower than it needs to be:
 
 1. The root `npm test` script is a manually maintained file list instead of a discovery-based pattern. This already caused five checked-in suites to be skipped until this audit.
-2. The repo does not publish a line/branch coverage report in local scripts, so prioritization still depends on manual source-vs-test inventory instead of measured gaps.
+2. The repo now publishes scoped Node/V8 coverage through `npm run test:coverage:ci`, including `.coverage/summary.md`, raw V8 JSON artifacts, and minimum line thresholds for `shared`, `server`, `client`, and `cocos-client`. The remaining limitation is that thresholds currently gate line coverage only; branch/function gaps still rely on the report output rather than hard CI floors.
 3. H5 Playwright coverage is useful, but it only validates the DOM debug shell; it does not exercise the Cocos runtime that now serves as the primary client.
 4. Cocos scene components depend on `cc` runtime behavior, which makes them harder to test in plain `node:test` without maintaining more test doubles or extracting more pure logic seams.
 5. WeChat readiness still depends on artifact validation and manual smoke-report workflows rather than automated device/runtime execution.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "validate:assets": "node --import tsx ./scripts/validate-assets.ts",
     "check:issue33-assets": "node ./scripts/check-issue-33-art-staging.mjs",
     "test": "node --import tsx --test \"packages/shared/test/**/*.test.ts\" \"apps/server/test/**/*.test.ts\" \"apps/client/test/**/*.test.ts\" \"apps/cocos-client/test/**/*.test.ts\"",
+    "test:coverage:ci": "node --import tsx ./scripts/ci-v8-coverage.ts",
     "test:e2e": "npm run validate:e2e:fixtures && playwright test",
     "test:e2e:headed": "npm run validate:e2e:fixtures && playwright test --headed",
     "test:e2e:all": "npm run test:e2e && npm run test:e2e:multiplayer",

--- a/scripts/ci-v8-coverage.ts
+++ b/scripts/ci-v8-coverage.ts
@@ -1,0 +1,163 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+type CoverageSuite = {
+  name: string;
+  include: string;
+  lineThreshold: number;
+  tests: string[];
+};
+
+type CoverageMetrics = {
+  lines: number;
+  branches: number;
+  functions: number;
+};
+
+const coverageRoot = path.resolve(".coverage");
+
+const suites: CoverageSuite[] = [
+  {
+    name: "shared",
+    include: "packages/shared/src/**/*.ts",
+    lineThreshold: 90,
+    tests: ["packages/shared/test/**/*.test.ts"],
+  },
+  {
+    name: "server",
+    include: "apps/server/src/**/*.ts",
+    lineThreshold: 75,
+    tests: ["apps/server/test/**/*.test.ts"],
+  },
+  {
+    name: "client",
+    include: "apps/client/src/**/*.ts",
+    lineThreshold: 78,
+    tests: ["apps/client/test/**/*.test.ts"],
+  },
+  {
+    name: "cocos-client",
+    include: "apps/cocos-client/assets/scripts/**/*.ts",
+    lineThreshold: 55,
+    tests: ["apps/cocos-client/test/**/*.test.ts"],
+  },
+];
+
+async function main() {
+  await rm(coverageRoot, { force: true, recursive: true });
+  await mkdir(path.join(coverageRoot, "v8"), { recursive: true });
+
+  const summaries: Array<{ suite: CoverageSuite; metrics: CoverageMetrics | null }> = [];
+
+  for (const suite of suites) {
+    const suiteCoverageDir = path.join(coverageRoot, "v8", suite.name);
+    await mkdir(suiteCoverageDir, { recursive: true });
+
+    const args = [
+      "--import",
+      "tsx",
+      "--test",
+      "--experimental-test-coverage",
+      `--test-coverage-include=${suite.include}`,
+      `--test-coverage-lines=${suite.lineThreshold}`,
+      ...suite.tests,
+    ];
+
+    process.stdout.write(`\n=== ${suite.name} coverage ===\n`);
+    const { code, output } = await runNodeCommand(args, {
+      ...process.env,
+      NODE_V8_COVERAGE: suiteCoverageDir,
+    });
+
+    await writeFile(path.join(coverageRoot, `${suite.name}.log`), output);
+
+    const metrics = parseCoverageMetrics(output);
+    summaries.push({ suite, metrics });
+
+    if (code !== 0) {
+      await writeSummary(summaries);
+      process.exit(code ?? 1);
+    }
+  }
+
+  await writeSummary(summaries);
+}
+
+function runNodeCommand(args: string[], env: NodeJS.ProcessEnv) {
+  return new Promise<{ code: number | null; output: string }>((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: process.cwd(),
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let output = "";
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      const text = chunk.toString();
+      output += text;
+      process.stdout.write(text);
+    });
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      const text = chunk.toString();
+      output += text;
+      process.stderr.write(text);
+    });
+
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, output }));
+  });
+}
+
+function parseCoverageMetrics(output: string): CoverageMetrics | null {
+  const match = output.match(/all files\s+\|\s+([\d.]+)\s+\|\s+([\d.]+)\s+\|\s+([\d.]+)/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    lines: Number(match[1]),
+    branches: Number(match[2]),
+    functions: Number(match[3]),
+  };
+}
+
+async function writeSummary(
+  summaries: Array<{ suite: CoverageSuite; metrics: CoverageMetrics | null }>,
+) {
+  const lines = [
+    "# V8 Coverage Summary",
+    "",
+    "| Scope | Line Threshold | Line % | Branch % | Function % |",
+    "| --- | ---: | ---: | ---: | ---: |",
+    ...summaries.map(({ suite, metrics }) => {
+      if (!metrics) {
+        return `| ${suite.name} | ${suite.lineThreshold}% | n/a | n/a | n/a |`;
+      }
+      return `| ${suite.name} | ${suite.lineThreshold}% | ${metrics.lines.toFixed(2)}% | ${metrics.branches.toFixed(2)}% | ${metrics.functions.toFixed(2)}% |`;
+    }),
+    "",
+    `Raw V8 coverage artifacts: \`${path.relative(process.cwd(), path.join(coverageRoot, "v8"))}\``,
+  ];
+
+  await writeFile(path.join(coverageRoot, "summary.md"), `${lines.join("\n")}\n`);
+  await writeFile(
+    path.join(coverageRoot, "summary.json"),
+    `${JSON.stringify(
+      summaries.map(({ suite, metrics }) => ({
+        scope: suite.name,
+        lineThreshold: suite.lineThreshold,
+        metrics,
+      })),
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a dependency-free Node/V8 coverage runner that executes shared, server, client, and cocos-client suites with per-scope minimum line thresholds and raw artifact output
- switch CI validate to run the new coverage command, publish the markdown summary to the job summary, and upload `.coverage` as an artifact
- document the new coverage entrypoint in the existing coverage audit notes

## Validation
- npm run test:coverage:ci
- npm run typecheck:ci

Closes #300