### PR TITLE
feat(ui): add in-game achievement panel and unlock toasts

### DIFF
--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -1,4 +1,6 @@
 import {
+  buildAchievementUiItems,
+  groupAchievementUiItems,
   buildBattleReplayTimeline,
   createBattleReplayPlaybackState,
   formatAchievementLabel,
@@ -328,41 +330,6 @@ function renderBattleReplayReportSummary(
   </div>`;
 }
 
-function compareAchievementDisplayOrder(
-  left: PlayerAccountProfile["achievements"][number],
-  right: PlayerAccountProfile["achievements"][number]
-): number {
-  if (left.unlocked !== right.unlocked) {
-    return left.unlocked ? -1 : 1;
-  }
-
-  const leftStarted = left.current > 0 || Boolean(left.progressUpdatedAt);
-  const rightStarted = right.current > 0 || Boolean(right.progressUpdatedAt);
-  if (leftStarted !== rightStarted) {
-    return leftStarted ? -1 : 1;
-  }
-
-  const leftTimestamp = left.unlocked ? left.unlockedAt ?? left.progressUpdatedAt ?? "" : left.progressUpdatedAt ?? "";
-  const rightTimestamp = right.unlocked ? right.unlockedAt ?? right.progressUpdatedAt ?? "" : right.progressUpdatedAt ?? "";
-  const timestampOrder = rightTimestamp.localeCompare(leftTimestamp);
-  if (timestampOrder !== 0) {
-    return timestampOrder;
-  }
-
-  const progressOrder = right.current - left.current;
-  return progressOrder || left.title.localeCompare(right.title, "zh-Hans-CN");
-}
-
-function formatAchievementFootnote(achievement: PlayerAccountProfile["achievements"][number]): string {
-  if (achievement.unlocked) {
-    return `解锁于 ${formatTimestamp(achievement.unlockedAt ?? achievement.progressUpdatedAt ?? "")}`;
-  }
-
-  const remaining = Math.max(0, achievement.target - achievement.current);
-  const progressLabel = achievement.progressUpdatedAt ? `最近推进 ${formatTimestamp(achievement.progressUpdatedAt)} · ` : "";
-  return `${progressLabel}还差 ${remaining} 点进度`;
-}
-
 function summarizeEventCategories(account: PlayerAccountProfile): string {
   const counts = new Map<PlayerAccountProfile["recentEventLog"][number]["category"], number>();
   for (const entry of account.recentEventLog) {
@@ -394,31 +361,41 @@ export function renderAchievementProgress(account: PlayerAccountProfile): string
     return '<p class="account-meta">暂无成就数据</p>';
   }
 
-  const sortedAchievements = [...account.achievements].sort(compareAchievementDisplayOrder);
+  const groups = groupAchievementUiItems(buildAchievementUiItems(account.achievements));
   return `<div class="account-subsection">
     <strong>成就进度</strong>
     <p class="account-meta">${escapeHtml(formatAchievementSummary(account))}</p>
-    <div class="account-achievement-list">
-      ${sortedAchievements
-        .map((achievement) => {
-          const ratio =
-            achievement.target > 0 ? Math.min(100, Math.round((achievement.current / achievement.target) * 100)) : 0;
-          return `<div class="account-achievement ${achievement.unlocked ? "is-unlocked" : ""}">
-            <div class="account-achievement-head">
-              <span>${escapeHtml(achievement.title)}</span>
-              <span class="account-achievement-status">${achievement.unlocked ? "已解锁" : "进行中"}</span>
+    ${groups
+      .map(
+        (group) => `
+          <div class="account-achievement-group">
+            <div class="account-achievement-group-head">
+              <strong>${escapeHtml(group.category.label)}</strong>
+              <span class="account-meta">${group.items.filter((item) => item.isUnlocked).length}/${group.items.length} 已解锁</span>
             </div>
-            <div class="account-achievement-meta">
-              <span>${achievement.current}/${achievement.target}</span>
-              <span>${ratio}%</span>
+            <div class="account-achievement-list">
+              ${group.items
+                .map(
+                  (achievement) => `<div class="account-achievement ${achievement.isUnlocked ? "is-unlocked" : ""}">
+                    <div class="account-achievement-head">
+                      <span>${escapeHtml(achievement.title)}</span>
+                      <span class="account-achievement-status">${escapeHtml(achievement.statusLabel)}</span>
+                    </div>
+                    <div class="account-achievement-meta">
+                      <span>${achievement.progressLabel}</span>
+                      <span>${achievement.progressPercent}%</span>
+                    </div>
+                    <div class="account-achievement-bar"><span style="width:${achievement.progressPercent}%"></span></div>
+                    <p>${escapeHtml(achievement.description)}</p>
+                    <div class="account-achievement-foot">${escapeHtml(achievement.footnote)}</div>
+                  </div>`
+                )
+                .join("")}
             </div>
-            <div class="account-achievement-bar"><span style="width:${ratio}%"></span></div>
-            <p>${escapeHtml(achievement.description)}</p>
-            <div class="account-achievement-foot">${escapeHtml(formatAchievementFootnote(achievement))}</div>
-          </div>`;
-        })
-        .join("")}
-    </div>
+          </div>
+        `
+      )
+      .join("")}
   </div>`;
 }
 

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,5 +1,7 @@
 import "./styles.css";
 import {
+  buildAchievementUiItems,
+  groupAchievementUiItems,
   buildRuntimeDiagnosticsTriageView,
   describeAccountAuthFailure,
   renderRuntimeDiagnosticsSnapshotText,
@@ -70,6 +72,7 @@ import {
 import {
   createFallbackPlayerAccountProfile as createLocalAccountProfile,
   loadPlayerAccountProfileWithProgression as loadAccountProfileWithProgression,
+  loadPlayerAchievementProgress,
   bindPlayerAccountCredentials as bindAccountCredentials,
   loadPlayerAccountSessions,
   loadPlayerBattleReplayDetail,
@@ -223,6 +226,17 @@ interface AppState {
   lastEncounterStarted: Extract<SessionUpdate["events"][number], { type: "battle.started" }> | null;
   predictionStatus: string;
   diagnostics: DiagnosticState;
+  achievementPanel: {
+    open: boolean;
+    loading: boolean;
+    status: string;
+    items: ClientPlayerAccountProfile["achievements"];
+  };
+  achievementToast: {
+    eventId: string;
+    title: string;
+    detail: string;
+  } | null;
 }
 
 type BattleUnitView = BattleState["units"][string];
@@ -314,10 +328,18 @@ const state: AppState = {
     lastEventTypes: [],
     exportStatus: "等待导出诊断快照",
     recoverySummary: null
-  }
+  },
+  achievementPanel: {
+    open: false,
+    loading: false,
+    status: "打开后将从成就接口同步最新进度。",
+    items: []
+  },
+  achievementToast: null
 };
 
 let accountRefreshPromise: Promise<void> | null = null;
+let achievementPanelRefreshPromise: Promise<void> | null = null;
 let uiClockMs = 0;
 let nextUiTaskId = 1;
 let scheduledUiTasks: ScheduledUiTask[] = [];
@@ -326,6 +348,10 @@ let battleFxTaskId: number | null = null;
 let replayPlaybackTaskId: number | null = null;
 let keyboardShortcutsBound = false;
 let replayLoadToken = 0;
+let achievementToastTaskId: number | null = null;
+const seenAchievementToastEventIds = new Set<string>();
+const pendingAchievementToasts: Array<{ eventId: string; title: string; detail: string }> = [];
+let hasHydratedAchievementFeed = false;
 
 interface PendingPrediction {
   world: PlayerWorldView;
@@ -593,6 +619,84 @@ function renderDiagnosticPanel(): string {
   `;
 }
 
+function renderAchievementToast(): string {
+  if (!state.achievementToast) {
+    return "";
+  }
+
+  return `
+    <div class="achievement-toast" data-testid="achievement-toast">
+      <span class="achievement-toast-kicker">成就解锁</span>
+      <strong>${escapeHtml(state.achievementToast.title)}</strong>
+      <p>${escapeHtml(state.achievementToast.detail)}</p>
+    </div>
+  `;
+}
+
+function renderGameplayAchievementPanel(): string {
+  if (!state.achievementPanel.open) {
+    return "";
+  }
+
+  const groups = groupAchievementUiItems(buildAchievementUiItems(state.achievementPanel.items));
+  return `
+    <aside class="achievement-panel-shell" data-testid="achievement-panel">
+      <div class="achievement-panel">
+        <div class="achievement-panel-head">
+          <div>
+            <span class="account-eyebrow">Gameplay</span>
+            <h3>成就总览</h3>
+          </div>
+          <div class="achievement-panel-actions">
+            <button class="session-link" data-refresh-achievements="true" ${state.achievementPanel.loading ? "disabled" : ""}>${state.achievementPanel.loading ? "同步中..." : "刷新"}</button>
+            <button class="session-link" data-close-achievements="true">关闭</button>
+          </div>
+        </div>
+        <p class="achievement-panel-status muted">${escapeHtml(state.achievementPanel.status)}</p>
+        <div class="achievement-panel-groups">
+          ${
+            groups.length > 0
+              ? groups
+                  .map(
+                    (group) => `
+                      <section class="achievement-panel-group">
+                        <div class="achievement-panel-group-head">
+                          <strong>${escapeHtml(group.category.label)}</strong>
+                          <span>${group.items.filter((item) => item.isUnlocked).length}/${group.items.length}</span>
+                        </div>
+                        <div class="achievement-panel-list">
+                          ${group.items
+                            .map(
+                              (item) => `
+                                <article class="achievement-panel-item ${item.isUnlocked ? "is-unlocked" : ""}">
+                                  <div class="achievement-panel-item-head">
+                                    <strong>${escapeHtml(item.title)}</strong>
+                                    <span>${escapeHtml(item.statusLabel)}</span>
+                                  </div>
+                                  <p>${escapeHtml(item.description)}</p>
+                                  <div class="achievement-panel-item-meta">
+                                    <span>${item.progressLabel}</span>
+                                    <span>${item.progressPercent}%</span>
+                                  </div>
+                                  <div class="achievement-panel-bar"><span style="width:${item.progressPercent}%"></span></div>
+                                  <div class="achievement-panel-foot">${escapeHtml(item.footnote)}</div>
+                                </article>
+                              `
+                            )
+                            .join("")}
+                        </div>
+                      </section>
+                    `
+                  )
+                  .join("")
+              : `<div class="achievement-panel-empty muted">当前没有可展示的成就数据。</div>`
+          }
+        </div>
+      </div>
+    </aside>
+  `;
+}
+
 async function getSession() {
   if (!sessionPromise) {
     throw new Error("session_not_ready");
@@ -773,6 +877,96 @@ function renderAccountSessionPanel(): string {
       </div>
     </div>
   `;
+}
+
+function isAchievementUnlockEntry(entry: ClientPlayerAccountProfile["recentEventLog"][number]): boolean {
+  return entry.category === "achievement" && (entry.description.startsWith("解锁成就：") || entry.rewards.some((reward) => reward.type === "badge"));
+}
+
+function buildAchievementToastNotice(
+  entry: ClientPlayerAccountProfile["recentEventLog"][number]
+): { eventId: string; title: string; detail: string } {
+  const achievementTitle =
+    entry.rewards.find((reward) => reward.type === "badge")?.label
+    ?? (entry.description.replace(/^解锁成就：/, "").trim() || "未知成就");
+  return {
+    eventId: entry.id,
+    title: achievementTitle,
+    detail: entry.description
+  };
+}
+
+function flushNextAchievementToast(): void {
+  if (state.achievementToast || pendingAchievementToasts.length === 0) {
+    return;
+  }
+
+  const nextToast = pendingAchievementToasts.shift() ?? null;
+  if (!nextToast) {
+    return;
+  }
+
+  cancelUiTask(achievementToastTaskId);
+  state.achievementToast = nextToast;
+  achievementToastTaskId = scheduleUiTask(3200, () => {
+    state.achievementToast = null;
+    achievementToastTaskId = null;
+    flushNextAchievementToast();
+    render();
+  });
+}
+
+function syncAchievementToastFeed(account: ClientPlayerAccountProfile, allowToast: boolean): void {
+  const unseenUnlocks = [...account.recentEventLog]
+    .reverse()
+    .filter((entry) => isAchievementUnlockEntry(entry) && !seenAchievementToastEventIds.has(entry.id));
+
+  unseenUnlocks.forEach((entry) => {
+    seenAchievementToastEventIds.add(entry.id);
+    if (allowToast) {
+      pendingAchievementToasts.push(buildAchievementToastNotice(entry));
+    }
+  });
+
+  if (allowToast) {
+    flushNextAchievementToast();
+  }
+}
+
+async function refreshAchievementPanelData(renderAfter = true): Promise<void> {
+  if (achievementPanelRefreshPromise) {
+    return achievementPanelRefreshPromise;
+  }
+
+  state.achievementPanel.loading = true;
+  state.achievementPanel.status = "正在同步成就目录...";
+  if (renderAfter) {
+    render();
+  }
+
+  achievementPanelRefreshPromise = (async () => {
+    const items = await loadPlayerAchievementProgress(state.account.playerId);
+    state.achievementPanel.items = items;
+    state.account = {
+      ...state.account,
+      achievements: items
+    };
+    state.achievementPanel.loading = false;
+    state.achievementPanel.status = items.length > 0 ? `已同步 ${items.length} 条成就进度。` : "当前没有可展示的成就进度。";
+    render();
+  })().finally(() => {
+    achievementPanelRefreshPromise = null;
+  });
+
+  return achievementPanelRefreshPromise;
+}
+
+function setAchievementPanelOpen(open: boolean): void {
+  state.achievementPanel.open = open;
+  if (open) {
+    void refreshAchievementPanelData(false);
+  }
+  render();
 }
 
 function findReplaySummary(replayId: string | null | undefined): PlayerBattleReplaySummary | null {
@@ -2753,6 +2947,12 @@ async function refreshAccountProfileFromServer(): Promise<void> {
   accountRefreshPromise = (async () => {
     const account = await loadAccountProfileWithProgression(playerId, roomId);
     state.account = account;
+    syncAchievementToastFeed(account, hasHydratedAchievementFeed);
+    hasHydratedAchievementFeed = true;
+    if (state.achievementPanel.open) {
+      state.achievementPanel.items = account.achievements;
+      void refreshAchievementPanelData(false);
+    }
     if (!state.accountSaving) {
       state.accountDraftName = account.displayName;
     }
@@ -4334,13 +4534,15 @@ function render(): void {
     .join("");
 
   root.innerHTML = `
-    <main class="shell">
+    ${renderAchievementToast()}
+    <main class="shell ${state.achievementPanel.open ? "has-achievement-panel" : ""}">
       <section class="hero-panel">
         <div class="eyebrow">Project Veil</div>
         <h1>H5 调试壳</h1>
         <p class="lead">这里保留给浏览器调试、配置联调和回归验证使用；主客户端运行时已切到 Cocos Creator。</p>
         <div class="session-meta-row">
           <p class="muted" data-testid="session-meta">Room: ${roomId} · Player: ${playerId}</p>
+          <button class="session-link" data-toggle-achievements="true">${state.achievementPanel.open ? "收起成就" : "成就面板"}</button>
           <button class="session-link" data-return-lobby="true">返回大厅</button>
           <button class="session-link" data-logout-guest="true">切换游客账号</button>
         </div>
@@ -4521,6 +4723,7 @@ function render(): void {
         ${renderBattleLog()}
       </section>
     </main>
+    ${renderGameplayAchievementPanel()}
     ${renderModal()}
   `;
 
@@ -4739,6 +4942,24 @@ function render(): void {
     });
   }
 
+  for (const toggleAchievementsButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-toggle-achievements]"))) {
+    toggleAchievementsButton.addEventListener("click", () => {
+      setAchievementPanelOpen(!state.achievementPanel.open);
+    });
+  }
+
+  for (const closeAchievementsButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-close-achievements]"))) {
+    closeAchievementsButton.addEventListener("click", () => {
+      setAchievementPanelOpen(false);
+    });
+  }
+
+  for (const refreshAchievementsButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-refresh-achievements]"))) {
+    refreshAchievementsButton.addEventListener("click", () => {
+      void refreshAchievementPanelData();
+    });
+  }
+
   for (const returnLobbyButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-return-lobby]"))) {
     returnLobbyButton.addEventListener("click", () => {
       returnToLobby();
@@ -4793,6 +5014,9 @@ async function syncPlayerAccountProfile(): Promise<void> {
     clearReplayDetail,
     render
   });
+  syncAchievementToastFeed(state.account, false);
+  hasHydratedAchievementFeed = true;
+  state.achievementPanel.items = state.account.achievements;
 }
 
 async function onRevokeAccountSession(sessionId: string): Promise<void> {

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -1874,6 +1874,126 @@ h1 {
   }
 }
 
+.achievement-toast {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 20;
+  display: grid;
+  gap: 4px;
+  min-width: 240px;
+  max-width: min(360px, calc(100vw - 36px));
+  padding: 14px 16px;
+  border: 1px solid rgba(173, 125, 51, 0.28);
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(92, 68, 35, 0.96), rgba(58, 44, 24, 0.94));
+  color: #fff4df;
+  box-shadow: 0 18px 32px rgba(41, 28, 14, 0.26);
+  animation: fadeSlideIn 180ms ease;
+}
+
+.achievement-toast-kicker {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 232, 187, 0.82);
+}
+
+.achievement-panel-shell {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  bottom: 18px;
+  z-index: 16;
+  width: min(380px, calc(100vw - 36px));
+  pointer-events: none;
+}
+
+.achievement-panel {
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid rgba(78, 58, 42, 0.14);
+  border-radius: 24px;
+  background: rgba(255, 248, 238, 0.96);
+  box-shadow: 0 24px 46px rgba(84, 57, 35, 0.16);
+  backdrop-filter: blur(8px);
+  pointer-events: auto;
+}
+
+.achievement-panel-head,
+.achievement-panel-actions,
+.achievement-panel-group-head,
+.achievement-panel-item-head,
+.achievement-panel-item-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.achievement-panel-groups {
+  display: grid;
+  gap: 16px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.achievement-panel-group,
+.account-achievement-group {
+  display: grid;
+  gap: 10px;
+}
+
+.achievement-panel-list {
+  display: grid;
+  gap: 10px;
+}
+
+.achievement-panel-item {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid rgba(78, 58, 42, 0.12);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(247, 239, 228, 0.84));
+}
+
+.achievement-panel-item.is-unlocked {
+  border-color: rgba(164, 122, 54, 0.28);
+  background: linear-gradient(180deg, rgba(255, 248, 228, 0.98), rgba(247, 235, 205, 0.9));
+}
+
+.achievement-panel-bar,
+.account-achievement-bar {
+  width: 100%;
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(78, 58, 42, 0.08);
+}
+
+.achievement-panel-bar span,
+.account-achievement-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #b46d3b, #d7b46e);
+}
+
+.achievement-panel-foot {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.achievement-panel-empty,
+.achievement-panel-status,
+.account-achievement-group-head {
+  color: var(--muted);
+}
+
 @media (max-width: 1100px) {
   .shell {
     grid-template-columns: 1fr;
@@ -1911,5 +2031,11 @@ h1 {
 
   .hero-attribute-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .achievement-panel-shell {
+    position: static;
+    width: 100%;
+    padding: 0 20px 20px;
   }
 }

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -140,6 +140,7 @@ export interface VeilHudRenderState {
 export interface VeilHudPanelOptions {
   onNewRun?: () => void;
   onRefresh?: () => void;
+  onToggleAchievements?: () => void;
   onLearnSkill?: (skillId: string) => void;
   onEquipItem?: (slot: EquipmentType, equipmentId: string) => void;
   onUnequipItem?: (slot: EquipmentType) => void;
@@ -240,6 +241,7 @@ export class VeilHudPanel extends Component {
   private requestedIcons = false;
   private onNewRun: (() => void) | undefined;
   private onRefresh: (() => void) | undefined;
+  private onToggleAchievements: (() => void) | undefined;
   private onLearnSkill: ((skillId: string) => void) | undefined;
   private onEquipItem: ((slot: EquipmentType, equipmentId: string) => void) | undefined;
   private onUnequipItem: ((slot: EquipmentType) => void) | undefined;
@@ -250,6 +252,7 @@ export class VeilHudPanel extends Component {
   configure(options: VeilHudPanelOptions): void {
     this.onNewRun = options.onNewRun;
     this.onRefresh = options.onRefresh;
+    this.onToggleAchievements = options.onToggleAchievements;
     this.onLearnSkill = options.onLearnSkill;
     this.onEquipItem = options.onEquipItem;
     this.onUnequipItem = options.onUnequipItem;
@@ -1288,6 +1291,7 @@ export class VeilHudPanel extends Component {
 
     this.ensureActionButton(actionsNode, "HudNewRun", "新开一局");
     this.ensureActionButton(actionsNode, "HudRefresh", "刷新状态");
+    this.ensureActionButton(actionsNode, "HudAchievements", "成就总览");
     this.ensureActionButton(actionsNode, "HudEndDay", "推进一天");
     this.ensureActionButton(actionsNode, "HudReturnLobby", "返回大厅");
   }
@@ -1301,12 +1305,13 @@ export class VeilHudPanel extends Component {
     }
 
     const actionsTransform = actionsNode.getComponent(UITransform) ?? actionsNode.addComponent(UITransform);
-    actionsTransform.setContentSize(Math.max(164, transform.width - 28), 146);
+    actionsTransform.setContentSize(Math.max(164, transform.width - 28), 176);
     actionsNode.setPosition(0, transform.height / 2 - 118, 1);
 
     const buttons: HudActionButtonState[] = [
       { name: "HudNewRun", label: "新开一局", callback: this.onNewRun ?? null },
       { name: "HudRefresh", label: "刷新状态", callback: this.onRefresh ?? null },
+      { name: "HudAchievements", label: "成就总览", callback: this.onToggleAchievements ?? null },
       { name: "HudEndDay", label: "推进一天", callback: this.onEndDay ?? null },
       { name: "HudReturnLobby", label: "返回大厅", callback: this.onReturnLobby ?? null }
     ];
@@ -1321,7 +1326,7 @@ export class VeilHudPanel extends Component {
       const buttonWidth = Math.floor(actionsTransform.width - 8);
       const buttonHeight = 28;
       buttonTransform.setContentSize(buttonWidth, buttonHeight);
-      const buttonY = index === 0 ? 45 : index === 1 ? 15 : index === 2 ? -15 : -45;
+      const buttonY = 60 - index * 30;
       node.setPosition(0, buttonY, 0);
 
       const graphics = node.getComponent(Graphics) ?? node.addComponent(Graphics);
@@ -1332,6 +1337,8 @@ export class VeilHudPanel extends Component {
           : index === 1
             ? new Color(51, 70, 99, 228)
             : index === 2
+              ? new Color(73, 88, 62, 230)
+              : index === 3
               ? new Color(92, 86, 54, 232)
               : new Color(121, 84, 70, 234);
       graphics.strokeColor =
@@ -1340,13 +1347,15 @@ export class VeilHudPanel extends Component {
           : index === 1
             ? new Color(218, 229, 242, 112)
             : index === 2
+              ? new Color(224, 240, 199, 108)
+              : index === 3
               ? new Color(242, 224, 171, 120)
               : new Color(244, 225, 213, 116);
       graphics.lineWidth = 2;
       graphics.roundRect(-buttonWidth / 2, -buttonHeight / 2, buttonWidth, buttonHeight, 10);
       graphics.fill();
       graphics.stroke();
-      graphics.fillColor = new Color(255, 255, 255, index === 0 ? 22 : index === 1 ? 14 : index === 2 ? 18 : 16);
+      graphics.fillColor = new Color(255, 255, 255, index === 0 ? 22 : index === 1 ? 14 : index === 2 ? 16 : index === 3 ? 18 : 16);
       graphics.roundRect(-buttonWidth / 2 + 12, buttonHeight / 2 - 9, buttonWidth - 24, 3, 2);
       graphics.fill();
 

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -1,4 +1,4 @@
-import { _decorator, Camera, Canvas, Component, EventMouse, EventTouch, input, Input, Layers, Node, sys, UITransform, view } from "cc";
+import { _decorator, Camera, Canvas, Color, Component, EventMouse, EventTouch, Graphics, input, Input, Label, Layers, Node, sys, UITransform, view } from "cc";
 import { getEquipmentDefinition, type EquipmentType } from "./project-shared/index.ts";
 import {
   type BattleAction,
@@ -99,6 +99,8 @@ import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
 import { cocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
 import { getPixelSpriteLoadStatus, loadPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
 import {
+  buildAchievementUiItems,
+  groupAchievementUiItems,
   describeAccountAuthFailure,
   type RuntimeDiagnosticsConnectionStatus,
   validateAccountLifecycleConfirm,
@@ -113,6 +115,7 @@ const MAP_NODE_NAME = "ProjectVeilMap";
 const BATTLE_NODE_NAME = "ProjectVeilBattlePanel";
 const TIMELINE_NODE_NAME = "ProjectVeilTimelinePanel";
 const LOBBY_NODE_NAME = "ProjectVeilLobbyPanel";
+const ACHIEVEMENT_PANEL_NODE_NAME = "ProjectVeilAchievementPanel";
 const DEFAULT_MAP_WIDTH_TILES = 8;
 const DEFAULT_MAP_HEIGHT_TILES = 8;
 const BATTLE_FEEDBACK_DURATION_MS = 2600;
@@ -233,6 +236,10 @@ export class VeilRoot extends Component {
   private lobbyAccountReviewState: CocosAccountReviewState = createCocosAccountReviewState(this.lobbyAccountProfile);
   private lobbyAccountEpoch = 0;
   private gameplayAccountRefreshInFlight = false;
+  private gameplayAchievementPanelOpen = false;
+  private gameplayAchievementPanelLoading = false;
+  private gameplayAchievementPanelStatus = "打开后将从成就接口同步最新进度。";
+  private gameplayAchievementItems: CocosPlayerAccountProfile["achievements"] = [];
   private activeAccountFlow: CocosAccountLifecycleKind | null = null;
   private registrationDisplayName = "";
   private registrationToken = "";
@@ -602,6 +609,9 @@ export class VeilRoot extends Component {
       onRefresh: () => {
         void this.refreshSnapshot();
       },
+      onToggleAchievements: () => {
+        void this.toggleGameplayAchievementPanel();
+      },
       onLearnSkill: (skillId) => {
         void this.learnHeroSkill(skillId);
       },
@@ -764,6 +774,15 @@ export class VeilRoot extends Component {
     timelineTransform.setContentSize(rightWidth, timelineHeight);
     this.timelinePanel = timelineNode.getComponent(VeilTimelinePanel) ?? timelineNode.addComponent(VeilTimelinePanel);
 
+    let achievementPanelNode = this.node.getChildByName(ACHIEVEMENT_PANEL_NODE_NAME);
+    if (!achievementPanelNode) {
+      achievementPanelNode = new Node(ACHIEVEMENT_PANEL_NODE_NAME);
+      achievementPanelNode.parent = this.node;
+    }
+    assignUiLayer(achievementPanelNode);
+    const achievementTransform = achievementPanelNode.getComponent(UITransform) ?? achievementPanelNode.addComponent(UITransform);
+    achievementTransform.setContentSize(Math.max(320, Math.min(420, visibleSize.width - 56)), Math.max(360, visibleSize.height - 96));
+
     this.battleTransition = this.node.getComponent(VeilBattleTransition) ?? this.node.addComponent(VeilBattleTransition);
     this.updateLayout();
   }
@@ -823,6 +842,7 @@ export class VeilRoot extends Component {
     const mapNode = this.node.getChildByName(MAP_NODE_NAME);
     const battleNode = this.node.getChildByName(BATTLE_NODE_NAME);
     const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
+    const achievementPanelNode = this.node.getChildByName(ACHIEVEMENT_PANEL_NODE_NAME);
     const showingGame = !this.showLobby;
 
     if (lobbyNode) {
@@ -839,6 +859,9 @@ export class VeilRoot extends Component {
     }
     if (timelineNode) {
       timelineNode.active = showingGame;
+    }
+    if (achievementPanelNode) {
+      achievementPanelNode.active = showingGame && this.gameplayAchievementPanelOpen;
     }
 
     if (this.showLobby) {
@@ -918,6 +941,69 @@ export class VeilRoot extends Component {
     this.timelinePanel?.render({
       entries: this.timelineEntries
     });
+    this.renderGameplayAchievementPanel();
+  }
+
+  private renderGameplayAchievementPanel(): void {
+    const panelNode = this.node.getChildByName(ACHIEVEMENT_PANEL_NODE_NAME);
+    if (!panelNode) {
+      return;
+    }
+
+    if (!this.gameplayAchievementPanelOpen) {
+      panelNode.active = false;
+      return;
+    }
+
+    panelNode.active = true;
+    assignUiLayer(panelNode);
+    const transform = panelNode.getComponent(UITransform) ?? panelNode.addComponent(UITransform);
+    const width = transform.width || 360;
+    const height = transform.height || 420;
+
+    const graphics = panelNode.getComponent(Graphics) ?? panelNode.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = new Color(21, 28, 38, 236);
+    graphics.strokeColor = new Color(242, 230, 188, 122);
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 18);
+    graphics.fill();
+    graphics.stroke();
+    graphics.fillColor = new Color(255, 248, 214, 20);
+    graphics.roundRect(-width / 2 + 16, height / 2 - 20, width - 32, 6, 3);
+    graphics.fill();
+
+    const groups = groupAchievementUiItems(buildAchievementUiItems(this.gameplayAchievementItems));
+    const panelText = groups.length > 0
+      ? groups
+          .map((group) =>
+            [
+              `${group.category.label} ${group.items.filter((item) => item.isUnlocked).length}/${group.items.length}`,
+              ...group.items.flatMap((item) => [
+                `${item.title} · ${item.statusLabel} · ${item.progressLabel} (${item.progressPercent}%)`,
+                item.description,
+                item.footnote
+              ])
+            ].join("\n")
+          )
+          .join("\n\n")
+      : "当前没有可展示的成就数据。";
+
+    let labelNode = panelNode.getChildByName("Label");
+    if (!labelNode) {
+      labelNode = new Node("Label");
+      labelNode.parent = panelNode;
+    }
+    assignUiLayer(labelNode);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(width - 34, height - 62);
+    labelNode.setPosition(0, -12, 1);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = `成就总览\n${this.gameplayAchievementPanelLoading ? "同步中...\n" : ""}${this.gameplayAchievementPanelStatus}\n\n${panelText}`;
+    label.fontSize = 14;
+    label.lineHeight = 19;
+    label.enableWrapText = true;
+    label.color = new Color(245, 239, 226, 255);
   }
 
   private formatLobbyVaultSummary(): string {
@@ -1084,6 +1170,39 @@ export class VeilRoot extends Component {
     this.renderView();
   }
 
+  private async toggleGameplayAchievementPanel(forceOpen?: boolean): Promise<void> {
+    const nextOpen = forceOpen ?? !this.gameplayAchievementPanelOpen;
+    this.gameplayAchievementPanelOpen = nextOpen;
+    if (!nextOpen) {
+      this.renderView();
+      return;
+    }
+
+    this.gameplayAchievementItems = this.lobbyAccountProfile.achievements;
+    this.gameplayAchievementPanelStatus = "正在同步成就目录...";
+    this.renderView();
+    await this.refreshGameplayAchievementPanel();
+  }
+
+  private async refreshGameplayAchievementPanel(): Promise<void> {
+    this.gameplayAchievementPanelLoading = true;
+    this.renderView();
+
+    try {
+      const items = await resolveVeilRootRuntime().loadAchievementProgress(this.remoteUrl, this.playerId, undefined, {
+        storage: this.readWebStorage(),
+        authSession: this.currentLobbyAuthSession()
+      });
+      this.gameplayAchievementItems = items;
+      this.gameplayAchievementPanelStatus = items.length > 0 ? `已同步 ${items.length} 条成就进度。` : "当前没有可展示的成就数据。";
+    } catch (error) {
+      this.gameplayAchievementPanelStatus = this.describeAccountReviewLoadError(error);
+    } finally {
+      this.gameplayAchievementPanelLoading = false;
+      this.renderView();
+    }
+  }
+
   private async refreshAccountReviewPage(
     section: "battle-replays" | "event-history",
     page: number
@@ -1238,6 +1357,7 @@ export class VeilRoot extends Component {
     const battleNode = this.node.getChildByName(BATTLE_NODE_NAME);
     const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
     const lobbyNode = this.node.getChildByName(LOBBY_NODE_NAME);
+    const achievementPanelNode = this.node.getChildByName(ACHIEVEMENT_PANEL_NODE_NAME);
 
     this.mapBoard?.configure({
       tileSize: effectiveTileSize,
@@ -1260,6 +1380,9 @@ export class VeilRoot extends Component {
         },
         onRefresh: () => {
           void this.refreshSnapshot();
+        },
+        onToggleAchievements: () => {
+          void this.toggleGameplayAchievementPanel();
         },
         onLearnSkill: (skillId) => {
           void this.learnHeroSkill(skillId);
@@ -1311,6 +1434,12 @@ export class VeilRoot extends Component {
       lobbyTransform.setContentSize(Math.max(360, Math.min(860, visibleSize.width - 40)), Math.max(520, visibleSize.height - 48));
       lobbyNode.setPosition(0, 0, 0);
     }
+
+    if (achievementPanelNode) {
+      const achievementTransform = achievementPanelNode.getComponent(UITransform) ?? achievementPanelNode.addComponent(UITransform);
+      achievementTransform.setContentSize(Math.max(320, Math.min(420, visibleSize.width - 56)), Math.max(360, visibleSize.height - 96));
+      achievementPanelNode.setPosition(0, 0, 4);
+    }
   }
 
   private handleHudActionInput(...args: unknown[]): void {
@@ -1341,6 +1470,12 @@ export class VeilRoot extends Component {
       return;
     }
 
+    if (action === "achievements") {
+      this.inputDebug = "button achievements";
+      void this.toggleGameplayAchievementPanel();
+      return;
+    }
+
     if (action === "return-lobby") {
       this.inputDebug = "button return-lobby";
       void this.returnToLobby();
@@ -1351,7 +1486,7 @@ export class VeilRoot extends Component {
     void this.advanceDay();
   }
 
-  private resolveHudActionAt(uiX: number, uiY: number): "new-run" | "refresh" | "end-day" | "return-lobby" | null {
+  private resolveHudActionAt(uiX: number, uiY: number): "new-run" | "refresh" | "achievements" | "end-day" | "return-lobby" | null {
     const visibleSize = view.getVisibleSize();
     const centeredX = uiX - visibleSize.width / 2;
     const centeredY = uiY - visibleSize.height / 2;
@@ -1377,19 +1512,23 @@ export class VeilRoot extends Component {
     const buttonWidth = Math.max(156, hudTransform.width - 36);
     const buttonHeight = 28;
 
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY + 45, buttonWidth, buttonHeight)) {
+    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY + 60, buttonWidth, buttonHeight)) {
       return "new-run";
     }
 
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY + 15, buttonWidth, buttonHeight)) {
+    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY + 30, buttonWidth, buttonHeight)) {
       return "refresh";
     }
 
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY - 15, buttonWidth, buttonHeight)) {
+    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY, buttonWidth, buttonHeight)) {
+      return "achievements";
+    }
+
+    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY - 30, buttonWidth, buttonHeight)) {
       return "end-day";
     }
 
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY - 45, buttonWidth, buttonHeight)) {
+    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY - 60, buttonWidth, buttonHeight)) {
       return "return-lobby";
     }
 
@@ -2069,6 +2208,7 @@ export class VeilRoot extends Component {
     this.displayName = rememberPreferredCocosDisplayName(this.playerId, this.displayName || this.playerId, storage);
     await this.disposeCurrentSession();
     this.resetSessionViewport("已返回 Cocos Lobby。");
+    this.gameplayAchievementPanelOpen = false;
     this.showLobby = true;
     this.syncWechatShareBridge();
     this.lobbyStatus = "已返回大厅，可继续选房或创建新实例。";
@@ -2866,6 +3006,9 @@ export class VeilRoot extends Component {
     }
 
     this.lobbyAccountProfile = profile;
+    if (this.gameplayAchievementPanelOpen) {
+      this.gameplayAchievementItems = profile.achievements;
+    }
     this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
       type: "account.synced",
       account: profile

--- a/apps/cocos-client/assets/scripts/cocos-achievements.ts
+++ b/apps/cocos-client/assets/scripts/cocos-achievements.ts
@@ -1,4 +1,5 @@
 import {
+  buildAchievementUiItems,
   formatAchievementLabel,
   type AchievementId,
   type EventLogEntry,
@@ -31,68 +32,15 @@ const GAMEPLAY_ACCOUNT_REFRESH_EVENT_TYPES = new Set([
   "hero.moved"
 ]);
 
-function formatAchievementTimestamp(value?: string): string {
-  if (!value) {
-    return "时间待同步";
-  }
-
-  const normalized = value.trim();
-  if (!normalized) {
-    return "时间待同步";
-  }
-
-  const parsed = new Date(normalized);
-  if (Number.isNaN(parsed.getTime())) {
-    return normalized;
-  }
-
-  return parsed.toISOString().slice(0, 16).replace("T", " ");
-}
-
-function compareAchievementDisplayOrder(left: PlayerAchievementProgress, right: PlayerAchievementProgress): number {
-  if (left.unlocked !== right.unlocked) {
-    return left.unlocked ? -1 : 1;
-  }
-
-  const leftStarted = left.current > 0 || Boolean(left.progressUpdatedAt);
-  const rightStarted = right.current > 0 || Boolean(right.progressUpdatedAt);
-  if (leftStarted !== rightStarted) {
-    return leftStarted ? -1 : 1;
-  }
-
-  const leftTimestamp = left.unlocked ? left.unlockedAt ?? left.progressUpdatedAt ?? "" : left.progressUpdatedAt ?? "";
-  const rightTimestamp = right.unlocked ? right.unlockedAt ?? right.progressUpdatedAt ?? "" : right.progressUpdatedAt ?? "";
-  const timestampOrder = rightTimestamp.localeCompare(leftTimestamp);
-  if (timestampOrder !== 0) {
-    return timestampOrder;
-  }
-
-  const progressOrder = right.current - left.current;
-  return progressOrder || left.title.localeCompare(right.title, "zh-Hans-CN");
-}
-
-function formatAchievementFootnote(achievement: PlayerAchievementProgress): string {
-  if (achievement.unlocked) {
-    return `解锁于 ${formatAchievementTimestamp(achievement.unlockedAt ?? achievement.progressUpdatedAt)}`;
-  }
-
-  const remaining = Math.max(0, achievement.target - achievement.current);
-  if (achievement.progressUpdatedAt) {
-    return `最近推进 ${formatAchievementTimestamp(achievement.progressUpdatedAt)} · 还差 ${remaining} 点进度`;
-  }
-
-  return `还差 ${remaining} 点进度`;
-}
-
 export function buildCocosAchievementPanelItems(progress: PlayerAchievementProgress[]): CocosAchievementPanelItem[] {
-  return [...progress].sort(compareAchievementDisplayOrder).map((achievement) => ({
+  return buildAchievementUiItems(progress).map((achievement) => ({
     id: achievement.id,
     title: achievement.title,
     description: achievement.description,
-    progressLabel: `${achievement.current}/${achievement.target}`,
-    footnote: formatAchievementFootnote(achievement),
-    statusLabel: achievement.unlocked ? "已解锁" : "未解锁",
-    isUnlocked: achievement.unlocked
+    progressLabel: achievement.progressLabel,
+    footnote: achievement.footnote,
+    statusLabel: achievement.statusLabel,
+    isUnlocked: achievement.isUnlocked
   }));
 }
 

--- a/apps/cocos-client/assets/scripts/project-shared/achievement-ui.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/achievement-ui.ts
@@ -1,0 +1,153 @@
+import {
+  normalizeAchievementProgress,
+  type AchievementId,
+  type PlayerAchievementProgress
+} from "./event-log.ts";
+
+export type AchievementUiCategoryId = "combat" | "exploration" | "progression" | "equipment";
+
+export interface AchievementUiCategory {
+  id: AchievementUiCategoryId;
+  label: string;
+}
+
+export interface AchievementUiItem {
+  id: AchievementId;
+  title: string;
+  description: string;
+  category: AchievementUiCategory;
+  current: number;
+  target: number;
+  progressFraction: number;
+  progressPercent: number;
+  progressLabel: string;
+  statusLabel: string;
+  footnote: string;
+  isUnlocked: boolean;
+  unlockedAt?: string;
+  progressUpdatedAt?: string;
+}
+
+export interface AchievementUiGroup {
+  category: AchievementUiCategory;
+  items: AchievementUiItem[];
+}
+
+const ACHIEVEMENT_UI_CATEGORIES: Record<AchievementUiCategoryId, AchievementUiCategory> = {
+  combat: { id: "combat", label: "战斗" },
+  exploration: { id: "exploration", label: "探索" },
+  progression: { id: "progression", label: "养成" },
+  equipment: { id: "equipment", label: "装备" }
+};
+
+const ACHIEVEMENT_CATEGORY_BY_ID: Record<AchievementId, AchievementUiCategoryId> = {
+  first_battle: "combat",
+  enemy_slayer: "combat",
+  skill_scholar: "progression",
+  world_explorer: "exploration",
+  epic_collector: "equipment"
+};
+
+const ACHIEVEMENT_CATEGORY_ORDER: AchievementUiCategoryId[] = ["combat", "exploration", "progression", "equipment"];
+
+function formatAchievementTimestamp(value?: string): string {
+  if (!value) {
+    return "时间待同步";
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    return "时间待同步";
+  }
+
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) {
+    return normalized;
+  }
+
+  return parsed.toISOString().slice(0, 16).replace("T", " ");
+}
+
+function compareAchievementDisplayOrder(left: PlayerAchievementProgress, right: PlayerAchievementProgress): number {
+  if (left.unlocked !== right.unlocked) {
+    return left.unlocked ? -1 : 1;
+  }
+
+  const leftStarted = left.current > 0 || Boolean(left.progressUpdatedAt);
+  const rightStarted = right.current > 0 || Boolean(right.progressUpdatedAt);
+  if (leftStarted !== rightStarted) {
+    return leftStarted ? -1 : 1;
+  }
+
+  const leftTimestamp = left.unlocked ? left.unlockedAt ?? left.progressUpdatedAt ?? "" : left.progressUpdatedAt ?? "";
+  const rightTimestamp = right.unlocked ? right.unlockedAt ?? right.progressUpdatedAt ?? "" : right.progressUpdatedAt ?? "";
+  const timestampOrder = rightTimestamp.localeCompare(leftTimestamp);
+  if (timestampOrder !== 0) {
+    return timestampOrder;
+  }
+
+  const progressOrder = right.current - left.current;
+  return progressOrder || left.title.localeCompare(right.title, "zh-Hans-CN");
+}
+
+export function resolveAchievementUiCategory(achievementId: AchievementId): AchievementUiCategory {
+  return ACHIEVEMENT_UI_CATEGORIES[ACHIEVEMENT_CATEGORY_BY_ID[achievementId]];
+}
+
+export function calculateAchievementProgressFraction(achievement: Pick<PlayerAchievementProgress, "current" | "target">): number {
+  if (!Number.isFinite(achievement.target) || achievement.target <= 0) {
+    return 0;
+  }
+
+  const fraction = achievement.current / achievement.target;
+  if (!Number.isFinite(fraction)) {
+    return 0;
+  }
+
+  return Math.min(1, Math.max(0, fraction));
+}
+
+export function formatAchievementUiFootnote(achievement: Pick<PlayerAchievementProgress, "unlocked" | "unlockedAt" | "progressUpdatedAt" | "target" | "current">): string {
+  if (achievement.unlocked) {
+    return `解锁于 ${formatAchievementTimestamp(achievement.unlockedAt ?? achievement.progressUpdatedAt)}`;
+  }
+
+  const remaining = Math.max(0, achievement.target - achievement.current);
+  if (achievement.progressUpdatedAt) {
+    return `最近推进 ${formatAchievementTimestamp(achievement.progressUpdatedAt)} · 还差 ${remaining} 点进度`;
+  }
+
+  return `还差 ${remaining} 点进度`;
+}
+
+export function buildAchievementUiItems(progress?: Partial<PlayerAchievementProgress>[] | null): AchievementUiItem[] {
+  return normalizeAchievementProgress(progress)
+    .sort(compareAchievementDisplayOrder)
+    .map((achievement) => {
+      const progressFraction = calculateAchievementProgressFraction(achievement);
+      return {
+        id: achievement.id,
+        title: achievement.title,
+        description: achievement.description,
+        category: resolveAchievementUiCategory(achievement.id),
+        current: achievement.current,
+        target: achievement.target,
+        progressFraction,
+        progressPercent: Math.round(progressFraction * 100),
+        progressLabel: `${achievement.current}/${achievement.target}`,
+        statusLabel: achievement.unlocked ? "已解锁" : achievement.current > 0 ? "进行中" : "未开始",
+        footnote: formatAchievementUiFootnote(achievement),
+        isUnlocked: achievement.unlocked,
+        ...(achievement.unlockedAt ? { unlockedAt: achievement.unlockedAt } : {}),
+        ...(achievement.progressUpdatedAt ? { progressUpdatedAt: achievement.progressUpdatedAt } : {})
+      };
+    });
+}
+
+export function groupAchievementUiItems(items: AchievementUiItem[]): AchievementUiGroup[] {
+  return ACHIEVEMENT_CATEGORY_ORDER.map((categoryId) => ({
+    category: ACHIEVEMENT_UI_CATEGORIES[categoryId],
+    items: items.filter((item) => item.category.id === categoryId)
+  })).filter((group) => group.items.length > 0);
+}
+

--- a/apps/cocos-client/assets/scripts/project-shared/index.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/index.ts
@@ -1,3 +1,4 @@
+export * from "./achievement-ui.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";
 export * from "./battle-replay.ts";

--- a/apps/cocos-client/test/cocos-achievements.test.ts
+++ b/apps/cocos-client/test/cocos-achievements.test.ts
@@ -31,11 +31,11 @@ test("buildCocosAchievementPanelItems sorts unlocked entries first and formats p
     }
   ]);
 
-  assert.deepEqual(items.map((item) => item.id), ["first_battle", "enemy_slayer"]);
+  assert.deepEqual(items.slice(0, 2).map((item) => item.id), ["first_battle", "enemy_slayer"]);
   assert.equal(items[0]?.statusLabel, "已解锁");
   assert.equal(items[0]?.progressLabel, "1/1");
   assert.equal(items[0]?.footnote, "解锁于 2026-03-28 12:05");
-  assert.equal(items[1]?.statusLabel, "未解锁");
+  assert.equal(items[1]?.statusLabel, "进行中");
   assert.equal(items[1]?.footnote, "最近推进 2026-03-28 12:03 · 还差 1 点进度");
 });
 

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -231,6 +231,39 @@ test("VeilRoot connect replays cached session state before applying the live sna
   assert.equal(root.lastUpdate?.world.meta.day, 3);
 });
 
+test("VeilRoot gameplay achievement panel loads achievement progress from the account endpoint", async () => {
+  const root = createVeilRootHarness();
+  root.playerId = "player-1";
+  root.roomId = "room-alpha";
+  root.remoteUrl = "http://127.0.0.1:2567";
+
+  let loadCalls = 0;
+  installVeilRootRuntime({
+    loadAchievementProgress: async () => {
+      loadCalls += 1;
+      return [
+        {
+          id: "first_battle",
+          title: "初次交锋",
+          description: "首次进入战斗。",
+          metric: "battles_started",
+          current: 1,
+          target: 1,
+          unlocked: true,
+          unlockedAt: "2026-03-29T01:00:00.000Z"
+        }
+      ];
+    }
+  });
+
+  await (root as VeilRoot & Record<string, unknown>).toggleGameplayAchievementPanel(true);
+
+  assert.equal(loadCalls, 1);
+  assert.equal(root.gameplayAchievementPanelOpen, true);
+  assert.equal((root.gameplayAchievementItems as Array<{ id: string }>)[0]?.id, "first_battle");
+  assert.match(String(root.gameplayAchievementPanelStatus), /已同步 1 条成就进度/);
+});
+
 test("VeilRoot hands control to a fresh session when starting a new run", async () => {
   const root = createVeilRootHarness();
   root.roomId = "room-alpha";

--- a/packages/shared/src/achievement-ui.ts
+++ b/packages/shared/src/achievement-ui.ts
@@ -1,0 +1,153 @@
+import {
+  normalizeAchievementProgress,
+  type AchievementId,
+  type PlayerAchievementProgress
+} from "./event-log.ts";
+
+export type AchievementUiCategoryId = "combat" | "exploration" | "progression" | "equipment";
+
+export interface AchievementUiCategory {
+  id: AchievementUiCategoryId;
+  label: string;
+}
+
+export interface AchievementUiItem {
+  id: AchievementId;
+  title: string;
+  description: string;
+  category: AchievementUiCategory;
+  current: number;
+  target: number;
+  progressFraction: number;
+  progressPercent: number;
+  progressLabel: string;
+  statusLabel: string;
+  footnote: string;
+  isUnlocked: boolean;
+  unlockedAt?: string;
+  progressUpdatedAt?: string;
+}
+
+export interface AchievementUiGroup {
+  category: AchievementUiCategory;
+  items: AchievementUiItem[];
+}
+
+const ACHIEVEMENT_UI_CATEGORIES: Record<AchievementUiCategoryId, AchievementUiCategory> = {
+  combat: { id: "combat", label: "战斗" },
+  exploration: { id: "exploration", label: "探索" },
+  progression: { id: "progression", label: "养成" },
+  equipment: { id: "equipment", label: "装备" }
+};
+
+const ACHIEVEMENT_CATEGORY_BY_ID: Record<AchievementId, AchievementUiCategoryId> = {
+  first_battle: "combat",
+  enemy_slayer: "combat",
+  skill_scholar: "progression",
+  world_explorer: "exploration",
+  epic_collector: "equipment"
+};
+
+const ACHIEVEMENT_CATEGORY_ORDER: AchievementUiCategoryId[] = ["combat", "exploration", "progression", "equipment"];
+
+function formatAchievementTimestamp(value?: string): string {
+  if (!value) {
+    return "时间待同步";
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    return "时间待同步";
+  }
+
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) {
+    return normalized;
+  }
+
+  return parsed.toISOString().slice(0, 16).replace("T", " ");
+}
+
+function compareAchievementDisplayOrder(left: PlayerAchievementProgress, right: PlayerAchievementProgress): number {
+  if (left.unlocked !== right.unlocked) {
+    return left.unlocked ? -1 : 1;
+  }
+
+  const leftStarted = left.current > 0 || Boolean(left.progressUpdatedAt);
+  const rightStarted = right.current > 0 || Boolean(right.progressUpdatedAt);
+  if (leftStarted !== rightStarted) {
+    return leftStarted ? -1 : 1;
+  }
+
+  const leftTimestamp = left.unlocked ? left.unlockedAt ?? left.progressUpdatedAt ?? "" : left.progressUpdatedAt ?? "";
+  const rightTimestamp = right.unlocked ? right.unlockedAt ?? right.progressUpdatedAt ?? "" : right.progressUpdatedAt ?? "";
+  const timestampOrder = rightTimestamp.localeCompare(leftTimestamp);
+  if (timestampOrder !== 0) {
+    return timestampOrder;
+  }
+
+  const progressOrder = right.current - left.current;
+  return progressOrder || left.title.localeCompare(right.title, "zh-Hans-CN");
+}
+
+export function resolveAchievementUiCategory(achievementId: AchievementId): AchievementUiCategory {
+  return ACHIEVEMENT_UI_CATEGORIES[ACHIEVEMENT_CATEGORY_BY_ID[achievementId]];
+}
+
+export function calculateAchievementProgressFraction(achievement: Pick<PlayerAchievementProgress, "current" | "target">): number {
+  if (!Number.isFinite(achievement.target) || achievement.target <= 0) {
+    return 0;
+  }
+
+  const fraction = achievement.current / achievement.target;
+  if (!Number.isFinite(fraction)) {
+    return 0;
+  }
+
+  return Math.min(1, Math.max(0, fraction));
+}
+
+export function formatAchievementUiFootnote(achievement: Pick<PlayerAchievementProgress, "unlocked" | "unlockedAt" | "progressUpdatedAt" | "target" | "current">): string {
+  if (achievement.unlocked) {
+    return `解锁于 ${formatAchievementTimestamp(achievement.unlockedAt ?? achievement.progressUpdatedAt)}`;
+  }
+
+  const remaining = Math.max(0, achievement.target - achievement.current);
+  if (achievement.progressUpdatedAt) {
+    return `最近推进 ${formatAchievementTimestamp(achievement.progressUpdatedAt)} · 还差 ${remaining} 点进度`;
+  }
+
+  return `还差 ${remaining} 点进度`;
+}
+
+export function buildAchievementUiItems(progress?: Partial<PlayerAchievementProgress>[] | null): AchievementUiItem[] {
+  return normalizeAchievementProgress(progress)
+    .sort(compareAchievementDisplayOrder)
+    .map((achievement) => {
+      const progressFraction = calculateAchievementProgressFraction(achievement);
+      return {
+        id: achievement.id,
+        title: achievement.title,
+        description: achievement.description,
+        category: resolveAchievementUiCategory(achievement.id),
+        current: achievement.current,
+        target: achievement.target,
+        progressFraction,
+        progressPercent: Math.round(progressFraction * 100),
+        progressLabel: `${achievement.current}/${achievement.target}`,
+        statusLabel: achievement.unlocked ? "已解锁" : achievement.current > 0 ? "进行中" : "未开始",
+        footnote: formatAchievementUiFootnote(achievement),
+        isUnlocked: achievement.unlocked,
+        ...(achievement.unlockedAt ? { unlockedAt: achievement.unlockedAt } : {}),
+        ...(achievement.progressUpdatedAt ? { progressUpdatedAt: achievement.progressUpdatedAt } : {})
+      };
+    });
+}
+
+export function groupAchievementUiItems(items: AchievementUiItem[]): AchievementUiGroup[] {
+  return ACHIEVEMENT_CATEGORY_ORDER.map((categoryId) => ({
+    category: ACHIEVEMENT_UI_CATEGORIES[categoryId],
+    items: items.filter((item) => item.category.id === categoryId)
+  })).filter((group) => group.items.length > 0);
+}
+

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./achievement-ui.ts";
 export * from "./auth-ui.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";

--- a/packages/shared/test/achievement-ui.test.ts
+++ b/packages/shared/test/achievement-ui.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildAchievementUiItems,
+  calculateAchievementProgressFraction,
+  groupAchievementUiItems,
+  resolveAchievementUiCategory
+} from "../src/achievement-ui.ts";
+
+test("achievement ui helpers map achievements into stable categories", () => {
+  assert.deepEqual(resolveAchievementUiCategory("first_battle"), { id: "combat", label: "战斗" });
+  assert.deepEqual(resolveAchievementUiCategory("world_explorer"), { id: "exploration", label: "探索" });
+  assert.deepEqual(resolveAchievementUiCategory("skill_scholar"), { id: "progression", label: "养成" });
+});
+
+test("achievement ui helpers clamp progress fractions and expose display labels", () => {
+  assert.equal(calculateAchievementProgressFraction({ current: 2, target: 4 }), 0.5);
+  assert.equal(calculateAchievementProgressFraction({ current: 9, target: 3 }), 1);
+  assert.equal(calculateAchievementProgressFraction({ current: 1, target: 0 }), 0);
+
+  const items = buildAchievementUiItems([
+    {
+      id: "enemy_slayer",
+      title: "猎敌者",
+      description: "击败 3 名敌人或中立守军。",
+      metric: "battles_won",
+      current: 2,
+      target: 3,
+      unlocked: false,
+      progressUpdatedAt: "2026-03-28T12:03:00.000Z"
+    },
+    {
+      id: "first_battle",
+      title: "初次交锋",
+      description: "首次进入战斗。",
+      metric: "battles_started",
+      current: 1,
+      target: 1,
+      unlocked: true,
+      unlockedAt: "2026-03-28T12:05:00.000Z"
+    }
+  ]);
+
+  assert.equal(items[0]?.id, "first_battle");
+  assert.equal(items[0]?.statusLabel, "已解锁");
+  assert.equal(items[0]?.progressPercent, 100);
+  assert.equal(items[1]?.statusLabel, "进行中");
+  assert.equal(items[1]?.progressPercent, 67);
+  assert.equal(items[1]?.footnote, "最近推进 2026-03-28 12:03 · 还差 1 点进度");
+
+  const groups = groupAchievementUiItems(items);
+  assert.deepEqual(groups.map((group) => group.category.id), ["combat", "exploration", "progression", "equipment"]);
+  assert.deepEqual(groups[0]?.items.map((item) => item.id), ["first_battle", "enemy_slayer"]);
+});


### PR DESCRIPTION
## Summary
- add a shared achievement UI helper with grouped categories, progress fractions, and stable display copy for H5 and Cocos
- add H5 unlock toast notifications plus a HUD-triggered achievement side panel backed by the achievements endpoint
- add a Cocos HUD achievement entry point, gameplay achievement panel overlay, and reuse the existing unlock notice flow

## Testing
- npm test
- npm run typecheck:shared
- npm run typecheck:client:h5
- npm run typecheck:cocos
- npm run test:e2e:smoke *(fails in this environment: Playwright Chromium is missing libatk-bridge-2.0.so.0)*

Closes #301