### PR TITLE
Implement WeChat identity provider integration for mini-game deployment

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -1105,7 +1105,7 @@ export async function loginCocosWechatAuthSession(
     ...(options?.timeoutMs != null ? { timeoutMs: options.timeoutMs } : {}),
     ...(options?.mockCode ? { mockCode: options.mockCode } : {})
   });
-  const exchangePath = options?.exchangePath?.trim() || "/api/auth/wechat-mini-game-login";
+  const exchangePath = options?.exchangePath?.trim() || "/api/auth/wechat-login";
 
   const payload = (await fetchJson(
     `${resolveCocosApiBaseUrl(remoteUrl)}${exchangePath.startsWith("/") ? exchangePath : `/${exchangePath}`}`,

--- a/apps/cocos-client/assets/scripts/cocos-login-provider.ts
+++ b/apps/cocos-client/assets/scripts/cocos-login-provider.ts
@@ -120,7 +120,7 @@ export function resolveCocosLoginRuntimeConfig(
       exchangePath:
         normalizeString(runtimeWechat?.exchangePath) ??
         normalizeString(env.VEIL_WECHAT_MINIGAME_LOGIN_EXCHANGE_PATH) ??
-        "/api/auth/wechat-mini-game-login",
+        "/api/auth/wechat-login",
       ...(normalizeString(runtimeWechat?.mockCode) ?? normalizeString(env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE)
         ? {
             mockCode:
@@ -160,8 +160,8 @@ export function resolveCocosLoginProviders(input: {
   const canUseMockCode = Boolean(input.config.wechatMiniGame.mockCode);
   providers.push({
     id: "wechat-mini-game",
-    label: "微信登录并进入",
-    available: hasWechatRuntime && input.config.wechatMiniGame.enabled && (hasWechatLoginApi || canUseMockCode),
+    label: "微信登录",
+    available: hasWechatRuntime && input.config.wechatMiniGame.enabled && hasWechatLoginApi,
     message: !hasWechatRuntime
       ? "仅在微信小游戏运行时暴露。"
       : !input.config.wechatMiniGame.enabled
@@ -169,8 +169,8 @@ export function resolveCocosLoginProviders(input: {
         : hasWechatLoginApi
           ? "将尝试调用 wx.login()，再把 code 交给服务端交换会话。"
           : canUseMockCode
-            ? "当前没有原生 wx.login()，将退化成配置中的 mock code 交换。"
-            : "当前小游戏壳没有暴露 wx.login()，且也未配置 mock code。"
+            ? "当前小游戏壳没有暴露 wx.login()，因此入口保持隐藏；开发联调可继续用 mock code 直调接口。"
+            : "当前小游戏壳没有暴露 wx.login()。"
   });
 
   return providers;

--- a/apps/cocos-client/test/cocos-login-provider.test.ts
+++ b/apps/cocos-client/test/cocos-login-provider.test.ts
@@ -22,7 +22,7 @@ test("resolveCocosLoginRuntimeConfig reads runtime overrides and keeps the defau
       wechatMiniGame: {
         enabled: true,
         appId: "wx123",
-        exchangePath: "/api/auth/wechat-mini-game-login",
+        exchangePath: "/api/auth/wechat-login",
         mockCode: "wx-dev-code"
       }
     }
@@ -36,7 +36,7 @@ test("resolveCocosLoginProviders promotes wechat login in mini game runtime when
     config: {
       wechatMiniGame: {
         enabled: true,
-        exchangePath: "/api/auth/wechat-mini-game-login"
+        exchangePath: "/api/auth/wechat-login"
       }
     },
     wx: {
@@ -67,7 +67,7 @@ test("loginWithCocosProvider sends wx.login code to the scaffold exchange endpoi
       config: {
         wechatMiniGame: {
           enabled: true,
-          exchangePath: "/api/auth/wechat-mini-game-login"
+          exchangePath: "/api/auth/wechat-login"
         }
       },
       fetchImpl: async (input, init) => {
@@ -94,7 +94,7 @@ test("loginWithCocosProvider sends wx.login code to the scaffold exchange endpoi
     }
   );
 
-  assert.equal(requestedUrl, "http://127.0.0.1:2567/api/auth/wechat-mini-game-login");
+  assert.equal(requestedUrl, "http://127.0.0.1:2567/api/auth/wechat-login");
   assert.match(requestedBody, /"code":"wx-code-123"/);
   assert.deepEqual(session, {
     token: "wechat.token",
@@ -106,40 +106,20 @@ test("loginWithCocosProvider sends wx.login code to the scaffold exchange endpoi
   });
 });
 
-test("loginWithCocosProvider falls back to configured mock code when wx.login is unavailable", async () => {
-  let requestedBody = "";
-  await loginWithCocosProvider(
-    "http://127.0.0.1:2567",
-    {
-      provider: "wechat-mini-game",
-      playerId: "guest-mini",
-      displayName: "雾海旅人"
-    },
-    {
-      config: {
-        wechatMiniGame: {
-          enabled: true,
-          exchangePath: "/api/auth/wechat-mini-game-login",
-          mockCode: "wx-dev-code"
-        }
-      },
-      fetchImpl: async (_input, init) => {
-        requestedBody = String(init?.body ?? "");
-        return new Response(
-          JSON.stringify({
-            session: {
-              token: "wechat.token",
-              playerId: "guest-mini",
-              displayName: "雾海旅人",
-              authMode: "guest",
-              provider: "wechat-mini-game"
-            }
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } }
-        );
+test("resolveCocosLoginProviders hides wechat login when wx.login is unavailable", () => {
+  const providers = resolveCocosLoginProviders({
+    platform: "wechat-game",
+    capabilities: resolveCocosRuntimeCapabilities("wechat-game"),
+    config: {
+      wechatMiniGame: {
+        enabled: true,
+        exchangePath: "/api/auth/wechat-login",
+        mockCode: "wx-dev-code"
       }
-    }
-  );
+    },
+    wx: {}
+  });
 
-  assert.match(requestedBody, /"code":"wx-dev-code"/);
+  assert.equal(providers.find((provider) => provider.id === "wechat-mini-game")?.available, false);
+  assert.equal(providers.find((provider) => provider.id === "wechat-mini-game")?.label, "微信登录");
 });

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -286,8 +286,15 @@ export function cachePlayerAccountAuthState(input: {
 
 function readWechatMiniGameLoginConfig(env: NodeJS.ProcessEnv = process.env): WechatMiniGameLoginConfig {
   const normalizedMode = env.VEIL_WECHAT_MINIGAME_LOGIN_MODE?.trim().toLowerCase();
+  const defaultMode = env.NODE_ENV?.trim().toLowerCase() === "production" ? "disabled" : "mock";
   const mode =
-    normalizedMode === "mock" ? "mock" : normalizedMode === "production" || normalizedMode === "code2session" ? "production" : "disabled";
+    normalizedMode === "mock"
+      ? "mock"
+      : normalizedMode === "production" || normalizedMode === "code2session"
+        ? "production"
+        : normalizedMode === "disabled"
+          ? "disabled"
+          : defaultMode;
   return {
     mode,
     mockCode: env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE?.trim() || "wechat-dev-code",
@@ -813,6 +820,181 @@ export function issueWechatMiniGameAuthSession(input: {
   });
   registerGuestSession(session);
   return session;
+}
+
+async function handleWechatLogin(
+  request: IncomingMessage,
+  response: ServerResponse,
+  store: RoomSnapshotStore | null
+): Promise<void> {
+  let authSession: GuestAuthSession | null = null;
+  const authToken = readGuestAuthTokenFromRequest(request);
+  if (authToken) {
+    const validation = await validateAuthToken(authToken, store);
+    if (!validation.session) {
+      sendAuthFailure(response, validation.errorCode);
+      return;
+    }
+    authSession = validation.session;
+  }
+  const body = (await readJsonBody(request)) as {
+    code?: string | null;
+    playerId?: string | null;
+    displayName?: string | null;
+    avatarUrl?: string | null;
+  };
+
+  if (body.code !== undefined && body.code !== null && typeof body.code !== "string") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected string field: code"
+      }
+    });
+    return;
+  }
+
+  if (body.playerId !== undefined && body.playerId !== null && typeof body.playerId !== "string") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional string field: playerId"
+      }
+    });
+    return;
+  }
+
+  if (body.displayName !== undefined && body.displayName !== null && typeof body.displayName !== "string") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional string field: displayName"
+      }
+    });
+    return;
+  }
+
+  if (body.avatarUrl !== undefined && body.avatarUrl !== null && typeof body.avatarUrl !== "string") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional string field: avatarUrl"
+      }
+    });
+    return;
+  }
+
+  const code = normalizeWechatMiniGameCode(body.code);
+  const avatarUrl = normalizeAvatarUrl(body.avatarUrl);
+  const wechatConfig = readWechatMiniGameLoginConfig();
+
+  let identity: WechatMiniGameIdentity;
+  try {
+    identity = await exchangeWechatMiniGameCode(code, wechatConfig);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "wechat_login_not_enabled";
+    if (message === "wechat_login_not_enabled") {
+      sendJson(response, 501, {
+        error: {
+          code: "wechat_login_not_enabled",
+          message: "WeChat login exchange exists, but code2Session is not configured"
+        }
+      });
+      return;
+    }
+
+    if (message === "invalid_wechat_code") {
+      sendJson(response, 401, {
+        error: {
+          code: "invalid_wechat_code",
+          message:
+            wechatConfig.mode === "mock" ? "WeChat mock code is incorrect" : "WeChat code is invalid or expired"
+        }
+      });
+      return;
+    }
+
+    sendJson(response, 502, {
+      error: {
+        code: "wechat_code2session_failed",
+        message
+      }
+    });
+    return;
+  }
+
+  let playerId = authSession?.playerId ?? normalizePlayerId(body.playerId || createWechatMiniGamePlayerId(identity.openId));
+  let displayName = normalizeDisplayName(playerId, body.displayName ?? authSession?.displayName);
+  let loginId = authSession?.loginId;
+
+  if (store) {
+    const boundAccount = await store.loadPlayerAccountByWechatMiniGameOpenId(identity.openId);
+    if (boundAccount && authSession && boundAccount.playerId !== authSession.playerId) {
+      sendJson(response, 409, {
+        error: {
+          code: "wechat_identity_already_bound",
+          message: "This WeChat identity is already bound to another account"
+        }
+      });
+      return;
+    }
+
+    const requestedPlayerId = body.playerId?.trim();
+    if (!authSession && requestedPlayerId) {
+      const existingRequestedAccount = await store.loadPlayerAccount(requestedPlayerId);
+      if (!existingRequestedAccount) {
+        playerId = normalizePlayerId(requestedPlayerId);
+      }
+    }
+
+    if (boundAccount) {
+      const syncedAccount = await store.bindPlayerAccountWechatMiniGameIdentity(boundAccount.playerId, {
+        openId: identity.openId,
+        ...(identity.unionId ? { unionId: identity.unionId } : {}),
+        ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
+        ...(avatarUrl ? { avatarUrl } : {})
+      });
+      playerId = syncedAccount.playerId;
+      displayName = syncedAccount.displayName;
+      loginId = syncedAccount.loginId;
+    } else {
+      const targetPlayerId = authSession?.playerId ?? playerId;
+      const boundAccountResult = await store.bindPlayerAccountWechatMiniGameIdentity(targetPlayerId, {
+        openId: identity.openId,
+        ...(identity.unionId ? { unionId: identity.unionId } : {}),
+        ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
+        ...(avatarUrl ? { avatarUrl } : {})
+      });
+      playerId = boundAccountResult.playerId;
+      displayName = boundAccountResult.displayName;
+      loginId = boundAccountResult.loginId;
+    }
+  } else if (!authSession && body.playerId?.trim()) {
+    playerId = normalizePlayerId(body.playerId);
+    displayName = normalizeDisplayName(playerId, body.displayName);
+  }
+
+  sendJson(response, 200, {
+    session:
+      store && loginId
+        ? await createAccountSessionBundle(store, {
+            playerId,
+            displayName,
+            loginId,
+            provider: "wechat-mini-game",
+            deviceLabel: resolveDeviceLabel(request)
+          })
+        : issueWechatMiniGameAuthSession({
+            playerId,
+            displayName,
+            ...(loginId ? { loginId } : {})
+          })
+  });
+  if (store && loginId) {
+    recordAuthAccountLogin();
+  } else {
+    recordAuthGuestLogin();
+  }
 }
 
 export function issueNextAuthSession(
@@ -1556,182 +1738,15 @@ export function registerAuthRoutes(
     }
   });
 
-  app.post("/api/auth/wechat-mini-game-login", async (request, response) => {
-    try {
-      let authSession: GuestAuthSession | null = null;
-      const authToken = readGuestAuthTokenFromRequest(request);
-      if (authToken) {
-        const validation = await validateAuthToken(authToken, store);
-        if (!validation.session) {
-          sendAuthFailure(response, validation.errorCode);
-          return;
-        }
-        authSession = validation.session;
-      }
-      const body = (await readJsonBody(request)) as {
-        code?: string | null;
-        playerId?: string | null;
-        displayName?: string | null;
-        avatarUrl?: string | null;
-      };
-
-      if (body.code !== undefined && body.code !== null && typeof body.code !== "string") {
-        sendJson(response, 400, {
-          error: {
-            code: "invalid_payload",
-            message: "Expected string field: code"
-          }
-        });
-        return;
-      }
-
-      if (body.playerId !== undefined && body.playerId !== null && typeof body.playerId !== "string") {
-        sendJson(response, 400, {
-          error: {
-            code: "invalid_payload",
-            message: "Expected optional string field: playerId"
-          }
-        });
-        return;
-      }
-
-      if (body.displayName !== undefined && body.displayName !== null && typeof body.displayName !== "string") {
-        sendJson(response, 400, {
-          error: {
-            code: "invalid_payload",
-            message: "Expected optional string field: displayName"
-          }
-        });
-        return;
-      }
-
-      if (body.avatarUrl !== undefined && body.avatarUrl !== null && typeof body.avatarUrl !== "string") {
-        sendJson(response, 400, {
-          error: {
-            code: "invalid_payload",
-            message: "Expected optional string field: avatarUrl"
-          }
-        });
-        return;
-      }
-
-      const code = normalizeWechatMiniGameCode(body.code);
-      const avatarUrl = normalizeAvatarUrl(body.avatarUrl);
-      const wechatConfig = readWechatMiniGameLoginConfig();
-
-      let identity: WechatMiniGameIdentity;
+  for (const routePath of ["/api/auth/wechat-login", "/api/auth/wechat-mini-game-login"]) {
+    app.post(routePath, async (request, response) => {
       try {
-        identity = await exchangeWechatMiniGameCode(code, wechatConfig);
+        await handleWechatLogin(request, response, store);
       } catch (error) {
-        const message = error instanceof Error ? error.message : "wechat_login_not_enabled";
-        if (message === "wechat_login_not_enabled") {
-          sendJson(response, 501, {
-            error: {
-              code: "wechat_login_not_enabled",
-              message: "WeChat mini game login exchange exists, but code2Session is not configured"
-            }
-          });
-          return;
-        }
-
-        if (message === "invalid_wechat_code") {
-          sendJson(response, 401, {
-            error: {
-              code: "invalid_wechat_code",
-              message:
-                wechatConfig.mode === "mock"
-                  ? "WeChat mini game mock code is incorrect"
-                  : "WeChat mini game code is invalid or expired"
-            }
-          });
-          return;
-        }
-
-        sendJson(response, 502, {
-          error: {
-            code: "wechat_code2session_failed",
-            message
-          }
-        });
-        return;
+        sendJson(response, 400, { error: toErrorPayload(error) });
       }
-
-      let playerId = authSession?.playerId ?? normalizePlayerId(body.playerId || createWechatMiniGamePlayerId(identity.openId));
-      let displayName = normalizeDisplayName(playerId, body.displayName ?? authSession?.displayName);
-      let loginId = authSession?.loginId;
-
-      if (store) {
-        const boundAccount = await store.loadPlayerAccountByWechatMiniGameOpenId(identity.openId);
-        if (boundAccount && authSession && boundAccount.playerId !== authSession.playerId) {
-          sendJson(response, 409, {
-            error: {
-              code: "wechat_identity_already_bound",
-              message: "This WeChat mini game identity is already bound to another account"
-            }
-          });
-          return;
-        }
-
-        const requestedPlayerId = body.playerId?.trim();
-        if (!authSession && requestedPlayerId) {
-          const existingRequestedAccount = await store.loadPlayerAccount(requestedPlayerId);
-          if (!existingRequestedAccount) {
-            playerId = normalizePlayerId(requestedPlayerId);
-          }
-        }
-
-        if (boundAccount) {
-          const syncedAccount = await store.bindPlayerAccountWechatMiniGameIdentity(boundAccount.playerId, {
-            openId: identity.openId,
-            ...(identity.unionId ? { unionId: identity.unionId } : {}),
-            ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
-            ...(avatarUrl ? { avatarUrl } : {})
-          });
-          playerId = syncedAccount.playerId;
-          displayName = syncedAccount.displayName;
-          loginId = syncedAccount.loginId;
-        } else {
-          const targetPlayerId = authSession?.playerId ?? playerId;
-          const boundAccountResult = await store.bindPlayerAccountWechatMiniGameIdentity(targetPlayerId, {
-            openId: identity.openId,
-            ...(identity.unionId ? { unionId: identity.unionId } : {}),
-            ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
-            ...(avatarUrl ? { avatarUrl } : {})
-          });
-          playerId = boundAccountResult.playerId;
-          displayName = boundAccountResult.displayName;
-          loginId = boundAccountResult.loginId;
-        }
-      } else if (!authSession && body.playerId?.trim()) {
-        playerId = normalizePlayerId(body.playerId);
-        displayName = normalizeDisplayName(playerId, body.displayName);
-      }
-
-      sendJson(response, 200, {
-        session:
-          store && loginId
-            ? await createAccountSessionBundle(store, {
-                playerId,
-                displayName,
-                loginId,
-                provider: "wechat-mini-game",
-                deviceLabel: resolveDeviceLabel(request)
-              })
-            : issueWechatMiniGameAuthSession({
-                playerId,
-                displayName,
-                ...(loginId ? { loginId } : {})
-              })
-      });
-      if (store && loginId) {
-        recordAuthAccountLogin();
-      } else {
-        recordAuthGuestLogin();
-      }
-    } catch (error) {
-      sendJson(response, 400, { error: toErrorPayload(error) });
-    }
-  });
+    });
+  }
 
   app.post("/api/auth/account-login", async (request, response) => {
     if (!store) {

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -175,7 +175,7 @@ export async function startDevServer(
   deps.logger.log(`Config viewer available at http://${host}:${port}/config-viewer`);
   deps.logger.log(`Player account API available at http://${host}:${port}/api/player-accounts`);
   deps.logger.log(`Guest auth API available at http://${host}:${port}/api/auth/guest-login`);
-  deps.logger.log(`WeChat mini game auth scaffold available at http://${host}:${port}/api/auth/wechat-mini-game-login`);
+  deps.logger.log(`WeChat auth API available at http://${host}:${port}/api/auth/wechat-login`);
   deps.logger.log(`Lobby API available at http://${host}:${port}/api/lobby/rooms`);
   deps.logger.log(`Matchmaking API available at http://${host}:${port}/api/matchmaking/status`);
   deps.logger.log(`Runtime health available at http://${host}:${port}/api/runtime/health`);

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -126,7 +126,13 @@ interface AuthReadinessPayload {
   checkedAt: string;
   headline: string;
   alerts: string[];
-  auth: RuntimeHealthPayload["runtime"]["auth"];
+  auth: RuntimeHealthPayload["runtime"]["auth"] & {
+    wechatLogin: {
+      mode: "disabled" | "mock" | "production";
+      credentialsStatus: "not_required" | "missing" | "configured";
+      route: string;
+    };
+  };
 }
 
 interface AuthTokenDeliveryPayload {
@@ -267,6 +273,23 @@ function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPaylo
 function buildAuthReadinessPayload(service = "project-veil-server"): AuthReadinessPayload {
   const health = buildHealthPayload(service);
   const alerts: string[] = [];
+  const normalizedWechatMode = process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE?.trim().toLowerCase();
+  const wechatMode =
+    normalizedWechatMode === "mock"
+      ? "mock"
+      : normalizedWechatMode === "production" || normalizedWechatMode === "code2session"
+        ? "production"
+        : normalizedWechatMode === "disabled"
+          ? "disabled"
+          : process.env.NODE_ENV?.trim().toLowerCase() === "production"
+            ? "disabled"
+            : "mock";
+  const wechatCredentialsStatus =
+    wechatMode === "production"
+      ? process.env.VEIL_WECHAT_MINIGAME_APP_ID?.trim() && process.env.VEIL_WECHAT_MINIGAME_APP_SECRET?.trim()
+        ? "configured"
+        : "missing"
+      : "not_required";
 
   if (health.runtime.auth.activeAccountLockCount > 0) {
     alerts.push(`${health.runtime.auth.activeAccountLockCount} account lockout(s) active`);
@@ -288,13 +311,28 @@ function buildAuthReadinessPayload(service = "project-veil-server"): AuthReadine
     alerts.push(`${health.runtime.auth.tokenDelivery.queueCount} token deliveries waiting for retry`);
   }
 
+  if (wechatCredentialsStatus === "missing") {
+    alerts.push("WeChat login production credentials are missing");
+  }
+
   return {
     status: alerts.length > 0 ? "warn" : "ok",
     service,
     checkedAt: health.checkedAt,
-    headline: `auth ready; guest=${health.runtime.auth.activeGuestSessionCount} account=${health.runtime.auth.activeAccountSessionCount} lockouts=${health.runtime.auth.activeAccountLockCount}`,
+    headline:
+      `auth ready; guest=${health.runtime.auth.activeGuestSessionCount} ` +
+      `account=${health.runtime.auth.activeAccountSessionCount} ` +
+      `lockouts=${health.runtime.auth.activeAccountLockCount} ` +
+      `wechat=${wechatMode}/${wechatCredentialsStatus}`,
     alerts,
-    auth: health.runtime.auth
+    auth: {
+      ...health.runtime.auth,
+      wechatLogin: {
+        mode: wechatMode,
+        credentialsStatus: wechatCredentialsStatus,
+        route: "/api/auth/wechat-login"
+      }
+    }
   };
 }
 

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -124,6 +124,8 @@ interface PlayerAccountRow extends RowDataPacket {
   refresh_session_id: string | null;
   refresh_token_hash: string | null;
   refresh_token_expires_at: Date | string | null;
+  wechat_open_id: string | null;
+  wechat_union_id: string | null;
   wechat_mini_game_open_id: string | null;
   wechat_mini_game_union_id: string | null;
   wechat_mini_game_bound_at: Date | string | null;
@@ -325,6 +327,7 @@ export const MYSQL_PLAYER_ACCOUNT_TABLE = "player_accounts";
 export const MYSQL_PLAYER_ACCOUNT_UPDATED_AT_INDEX = "idx_player_accounts_updated_at";
 export const MYSQL_PLAYER_ACCOUNT_LOGIN_ID_INDEX = "uidx_player_accounts_login_id";
 export const MYSQL_PLAYER_ACCOUNT_WECHAT_OPEN_ID_INDEX = "uidx_player_accounts_wechat_open_id";
+export const MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX = "uidx_player_accounts_wechat_idp_open_id";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_TABLE = "player_account_sessions";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX = "idx_player_account_sessions_player_last_used";
 export const MYSQL_PLAYER_EVENT_HISTORY_TABLE = "player_event_history";
@@ -782,6 +785,8 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   last_room_id VARCHAR(191) NULL,
   last_seen_at DATETIME NULL DEFAULT NULL,
   login_id VARCHAR(40) NULL,
+  wechat_open_id VARCHAR(191) NULL,
+  wechat_union_id VARCHAR(191) NULL,
   wechat_mini_game_open_id VARCHAR(191) NULL,
   wechat_mini_game_union_id VARCHAR(191) NULL,
   wechat_mini_game_bound_at DATETIME NULL DEFAULT NULL,
@@ -1018,6 +1023,42 @@ PREPARE veil_player_accounts_password_hash_stmt FROM @veil_player_accounts_passw
 EXECUTE veil_player_accounts_password_hash_stmt;
 DEALLOCATE PREPARE veil_player_accounts_password_hash_stmt;
 
+SET @veil_player_accounts_wechat_idp_open_id_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'wechat_open_id'
+);
+
+SET @veil_player_accounts_wechat_idp_open_id_sql := IF(
+  @veil_player_accounts_wechat_idp_open_id_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`wechat_open_id\` VARCHAR(191) NULL AFTER \`password_hash\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_wechat_idp_open_id_stmt FROM @veil_player_accounts_wechat_idp_open_id_sql;
+EXECUTE veil_player_accounts_wechat_idp_open_id_stmt;
+DEALLOCATE PREPARE veil_player_accounts_wechat_idp_open_id_stmt;
+
+SET @veil_player_accounts_wechat_idp_union_id_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'wechat_union_id'
+);
+
+SET @veil_player_accounts_wechat_idp_union_id_sql := IF(
+  @veil_player_accounts_wechat_idp_union_id_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`wechat_union_id\` VARCHAR(191) NULL AFTER \`wechat_open_id\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_wechat_idp_union_id_stmt FROM @veil_player_accounts_wechat_idp_union_id_sql;
+EXECUTE veil_player_accounts_wechat_idp_union_id_stmt;
+DEALLOCATE PREPARE veil_player_accounts_wechat_idp_union_id_stmt;
+
 SET @veil_player_accounts_wechat_open_id_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.COLUMNS
@@ -1143,6 +1184,24 @@ SET @veil_player_accounts_wechat_open_id_idx_sql := IF(
 PREPARE veil_player_accounts_wechat_open_id_idx_stmt FROM @veil_player_accounts_wechat_open_id_idx_sql;
 EXECUTE veil_player_accounts_wechat_open_id_idx_stmt;
 DEALLOCATE PREPARE veil_player_accounts_wechat_open_id_idx_stmt;
+
+SET @veil_player_accounts_wechat_idp_open_id_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX}'
+);
+
+SET @veil_player_accounts_wechat_idp_open_id_idx_sql := IF(
+  @veil_player_accounts_wechat_idp_open_id_idx_exists = 0,
+  'CREATE UNIQUE INDEX \`${MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX}\` ON \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (wechat_open_id)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_wechat_idp_open_id_idx_stmt FROM @veil_player_accounts_wechat_idp_open_id_idx_sql;
+EXECUTE veil_player_accounts_wechat_idp_open_id_idx_stmt;
+DEALLOCATE PREPARE veil_player_accounts_wechat_idp_open_id_idx_stmt;
 
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
@@ -1340,6 +1399,8 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
   const credentialBoundAt = formatTimestamp(row.credential_bound_at);
   const createdAt = formatTimestamp(row.created_at);
   const updatedAt = formatTimestamp(row.updated_at);
+  const wechatOpenId = row.wechat_open_id ?? row.wechat_mini_game_open_id;
+  const wechatUnionId = row.wechat_union_id ?? row.wechat_mini_game_union_id;
 
   return normalizePlayerAccountSnapshot({
     playerId: row.player_id,
@@ -1364,8 +1425,8 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(row.account_session_version > 0 ? { accountSessionVersion: row.account_session_version } : {}),
     ...(row.refresh_session_id ? { refreshSessionId: row.refresh_session_id } : {}),
     ...(refreshTokenExpiresAt ? { refreshTokenExpiresAt } : {}),
-    ...(row.wechat_mini_game_open_id ? { wechatMiniGameOpenId: row.wechat_mini_game_open_id } : {}),
-    ...(row.wechat_mini_game_union_id ? { wechatMiniGameUnionId: row.wechat_mini_game_union_id } : {}),
+    ...(wechatOpenId ? { wechatMiniGameOpenId: wechatOpenId } : {}),
+    ...(wechatUnionId ? { wechatMiniGameUnionId: wechatUnionId } : {}),
     ...(lastSeenAt ? { lastSeenAt } : {}),
     ...(wechatMiniGameBoundAt ? { wechatMiniGameBoundAt } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
@@ -1676,6 +1737,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          refresh_session_id,
          refresh_token_hash,
          refresh_token_expires_at,
+         wechat_open_id,
+         wechat_union_id,
          wechat_mini_game_open_id,
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
@@ -1711,6 +1774,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          refresh_session_id,
          refresh_token_hash,
          refresh_token_expires_at,
+         wechat_open_id,
+         wechat_union_id,
          wechat_mini_game_open_id,
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
@@ -1718,9 +1783,10 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
-       WHERE wechat_mini_game_open_id = ?
+       WHERE wechat_open_id = ?
+          OR wechat_mini_game_open_id = ?
        LIMIT 1`,
-      [normalizedOpenId]
+      [normalizedOpenId, normalizedOpenId]
     );
 
     const row = rows[0];
@@ -1829,6 +1895,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          refresh_session_id,
          refresh_token_hash,
          refresh_token_expires_at,
+         wechat_open_id,
+         wechat_union_id,
          wechat_mini_game_open_id,
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
@@ -2192,6 +2260,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
          SET display_name = COALESCE(?, display_name),
              avatar_url = COALESCE(?, avatar_url),
+             wechat_open_id = ?,
+             wechat_union_id = COALESCE(?, wechat_union_id),
              wechat_mini_game_open_id = ?,
              wechat_mini_game_union_id = COALESCE(?, wechat_mini_game_union_id),
              wechat_mini_game_bound_at = COALESCE(wechat_mini_game_bound_at, ?),
@@ -2200,6 +2270,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         [
           displayName,
           normalizedAvatarUrl ?? null,
+          normalizedOpenId,
+          normalizedUnionId ?? null,
           normalizedOpenId,
           normalizedUnionId ?? null,
           new Date(boundAt),
@@ -2406,6 +2478,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         wechat_open_id,
+         wechat_union_id,
          wechat_mini_game_open_id,
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -2268,7 +2268,7 @@ test("password recovery request returns 502 and dead-letters non-retryable webho
   assert.equal(deliveryPayload.delivery.recentAttempts[0]?.failureReason, "webhook_4xx");
 });
 
-test("wechat mini game scaffold route returns 501 until mock mode is enabled", { concurrency: false }, async (t) => {
+test("wechat login defaults to mock mode outside production", { concurrency: false }, async (t) => {
   const port = 44750 + Math.floor(Math.random() * 1000);
   const server = await startAuthServer(port);
 
@@ -2280,7 +2280,37 @@ test("wechat mini game scaffold route returns 501 until mock mode is enabled", {
   });
 
   delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
-  const response = await fetch(`http://127.0.0.1:${port}/api/auth/wechat-mini-game-login`, {
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      code: "wechat-dev-code",
+      playerId: "wechat-player",
+      displayName: "云桥旅人"
+    })
+  });
+  const payload = (await response.json()) as { session: GuestAuthSession };
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.session.playerId, "wechat-player");
+  assert.equal(payload.session.provider, "wechat-mini-game");
+});
+
+test("wechat login route can be explicitly disabled", { concurrency: false }, async (t) => {
+  const port = 44850 + Math.floor(Math.random() * 1000);
+  const server = await startAuthServer(port, new MemoryAuthStore());
+
+  t.after(async () => {
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE;
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "disabled";
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json"
@@ -2297,8 +2327,8 @@ test("wechat mini game scaffold route returns 501 until mock mode is enabled", {
   assert.equal(payload.error.code, "wechat_login_not_enabled");
 });
 
-test("wechat mini game scaffold route issues a provider-tagged session in mock mode", { concurrency: false }, async (t) => {
-  const port = 44850 + Math.floor(Math.random() * 1000);
+test("legacy wechat mini game route remains available as an alias", { concurrency: false }, async (t) => {
+  const port = 44855 + Math.floor(Math.random() * 1000);
   const server = await startAuthServer(port, new MemoryAuthStore());
 
   t.after(async () => {
@@ -2384,7 +2414,7 @@ test("wechat mini game production exchange binds code2Session identity onto an a
     );
   };
 
-  const response = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-mini-game-login`, {
+  const response = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -2455,7 +2485,7 @@ test("wechat mini game login reuses the bound player even when later requests sp
       }
     );
 
-  const firstResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-mini-game-login`, {
+  const firstResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json"
@@ -2468,7 +2498,7 @@ test("wechat mini game login reuses the bound player even when later requests sp
   });
   const firstPayload = (await firstResponse.json()) as { session: GuestAuthSession };
 
-  const secondResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-mini-game-login`, {
+  const secondResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json"

--- a/scripts/migrations/0009_add_wechat_idp_columns.ts
+++ b/scripts/migrations/0009_add_wechat_idp_columns.ts
@@ -1,0 +1,60 @@
+import {
+  ensureColumnExists,
+  ensureIndexExists,
+  dropColumnIfExists,
+  dropIndexIfExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_PLAYER_ACCOUNT_TABLE,
+  MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureColumnExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_TABLE,
+    "wechat_open_id",
+    "`wechat_open_id` VARCHAR(191) NULL AFTER `password_hash`"
+  );
+  await ensureColumnExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_TABLE,
+    "wechat_union_id",
+    "`wechat_union_id` VARCHAR(191) NULL AFTER `wechat_open_id`"
+  );
+
+  await connection.query(
+    `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+     SET wechat_open_id = COALESCE(wechat_open_id, wechat_mini_game_open_id),
+         wechat_union_id = COALESCE(wechat_union_id, wechat_mini_game_union_id)
+     WHERE wechat_mini_game_open_id IS NOT NULL
+        OR wechat_mini_game_union_id IS NOT NULL`
+  );
+
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_TABLE,
+    MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX,
+    `CREATE UNIQUE INDEX \`${MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX}\`
+     ON \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (wechat_open_id)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await dropIndexIfExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_TABLE,
+    MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX
+  );
+  await dropColumnIfExists(connection, database, MYSQL_PLAYER_ACCOUNT_TABLE, "wechat_union_id");
+  await dropColumnIfExists(connection, database, MYSQL_PLAYER_ACCOUNT_TABLE, "wechat_open_id");
+}


### PR DESCRIPTION
## Summary
- add the WeChat auth endpoint and keep the legacy mini-game login route as a compatibility alias
- add WeChat identity provider columns/migration and extend auth readiness with WeChat credential status
- update the Cocos mini-game login provider to show 微信登录 only when wx.login is available

## Testing
- npm run typecheck:server && npm run typecheck:cocos
- node --import tsx --test apps/server/test/auth-guest-login.test.ts --test-name-pattern "wechat login defaults to mock mode outside production|wechat login route can be explicitly disabled|legacy wechat mini game route remains available as an alias|wechat mini game production exchange binds code2Session identity onto an authenticated account|wechat mini game login reuses the bound player even when later requests spoof another playerId"
- node --import tsx --test apps/server/test/runtime-observability-routes.test.ts apps/server/test/schema-migrations.test.ts apps/cocos-client/test/cocos-login-provider.test.ts apps/cocos-client/test/cocos-lobby.test.ts

Closes #299