### PR TITLE
Add contested basin map and expanded neutral content pack

### DIFF
--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -115,7 +115,7 @@ interface WorldConfigPreviewTile {
           power: number;
           knowledge: number;
         };
-        visitedCount: number;
+        lastUsedDay?: number;
       }
     | {
         kind: "resource_mine";
@@ -123,7 +123,14 @@ interface WorldConfigPreviewTile {
         label: string;
         resourceKind: ResourceKind;
         income: number;
-        ownerPlayerId?: string;
+        lastHarvestDay?: number;
+      }
+    | {
+        kind: "watchtower";
+        refId: string;
+        label: string;
+        visionBonus: number;
+        lastUsedDay?: number;
       }
     | undefined;
 }

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -172,7 +172,7 @@ interface WorldConfigPreviewTile {
           power: number;
           knowledge: number;
         };
-        visitedCount: number;
+        lastUsedDay?: number;
       }
     | {
         kind: "resource_mine";
@@ -180,7 +180,14 @@ interface WorldConfigPreviewTile {
         label: string;
         resourceKind: ResourceKind;
         income: number;
-        ownerPlayerId?: string;
+        lastHarvestDay?: number;
+      }
+    | {
+        kind: "watchtower";
+        refId: string;
+        label: string;
+        visionBonus: number;
+        lastUsedDay?: number;
       }
     | undefined;
 }
@@ -594,9 +601,11 @@ function buildWorldPreviewTileTitle(tile: WorldConfigPreviewTile): string {
         tile.building.bonus.power > 0 ? `力量 +${tile.building.bonus.power}` : "",
         tile.building.bonus.knowledge > 0 ? `知识 +${tile.building.bonus.knowledge}` : ""
       ].filter(Boolean);
-      parts.push(`建筑: ${tile.building.label} / ${bonus.join("、") || "属性加成"} / 访问 ${tile.building.visitedCount}`);
+      parts.push(`建筑: ${tile.building.label} / ${bonus.join("、") || "属性加成"}${typeof tile.building.lastUsedDay === "number" ? ` / 第 ${tile.building.lastUsedDay} 天已访问` : ""}`);
+    } else if (tile.building.kind === "resource_mine") {
+      parts.push(`建筑: ${tile.building.label} / ${tile.building.resourceKind} +${tile.building.income}/day${typeof tile.building.lastHarvestDay === "number" ? ` / 第 ${tile.building.lastHarvestDay} 天已采集` : ""}`);
     } else {
-      parts.push(`建筑: ${tile.building.label} / ${tile.building.resourceKind} +${tile.building.income}/day${tile.building.ownerPlayerId ? ` / ${tile.building.ownerPlayerId}` : ""}`);
+      parts.push(`建筑: ${tile.building.label} / 视野 +${tile.building.visionBonus}${typeof tile.building.lastUsedDay === "number" ? ` / 第 ${tile.building.lastUsedDay} 天已登塔` : ""}`);
     }
   }
 

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1733,7 +1733,15 @@ function buildAutomationTilePayload(tile: PlayerTileView) {
                     bonus: { ...tile.building.bonus },
                     ...(typeof tile.building.lastUsedDay === "number" ? { lastUsedDay: tile.building.lastUsedDay } : {})
                   }
-                : {
+                : tile.building.kind === "watchtower"
+                  ? {
+                      id: tile.building.id,
+                      kind: tile.building.kind,
+                      label: tile.building.label,
+                      visionBonus: tile.building.visionBonus,
+                      ...(typeof tile.building.lastUsedDay === "number" ? { lastUsedDay: tile.building.lastUsedDay } : {})
+                    }
+                  : {
                     id: tile.building.id,
                     kind: tile.building.kind,
                     label: tile.building.label,
@@ -2520,7 +2528,11 @@ function appendLog(update: SessionUpdate): void {
     } else if (event.type === "hero.recruited") {
       state.log.unshift(`Recruited ${event.unitTemplateId} x${event.count}`);
     } else if (event.type === "hero.visited") {
-      state.log.unshift(`Visited ${event.buildingId}: ${formatHeroStatBonus(event.bonus)}`);
+      state.log.unshift(
+        event.buildingKind === "watchtower"
+          ? `Visited ${event.buildingId}: vision +${event.visionBonus}`
+          : `Visited ${event.buildingId}: ${formatHeroStatBonus(event.bonus)}`
+      );
     } else if (event.type === "hero.claimedMine") {
       state.log.unshift(`Claimed mine: ${formatDailyIncome(event.resourceKind, event.income)}`);
     } else if (event.type === "resource.produced") {
@@ -2632,7 +2644,10 @@ function buildTimelineEntries(update: SessionUpdate, source: TimelineEntry["sour
         id: `${stamp}-visit-${index}`,
         tone: "loot",
         source,
-        text: `访问属性建筑，获得 ${formatHeroStatBonus(event.bonus)}`
+        text:
+          event.buildingKind === "watchtower"
+            ? `登上瞭望塔，视野提高 ${event.visionBonus}`
+            : `访问属性建筑，获得 ${formatHeroStatBonus(event.bonus)}`
       });
       return;
     }
@@ -3010,6 +3025,7 @@ async function onTileClick(x: number, y: number): Promise<void> {
               buildingId: targetTile.building.id
             } as const)
           : targetTile.building.kind === "attribute_shrine"
+            || targetTile.building.kind === "watchtower"
             ? ({
                 type: "hero.visit",
                 heroId: hero.id,
@@ -3032,6 +3048,8 @@ async function onTileClick(x: number, y: number): Promise<void> {
               ? `预演中：在 ${targetTile.building.label} 招募 ${targetTile.building.availableCount} 单位`
               : targetTile.building.kind === "attribute_shrine"
                 ? `预演中：访问 ${targetTile.building.label}，获得 ${formatHeroStatBonus(targetTile.building.bonus)}`
+                : targetTile.building.kind === "watchtower"
+                  ? `预演中：登上 ${targetTile.building.label}，视野提高 ${targetTile.building.visionBonus}`
                 : `预演中：占领 ${targetTile.building.label}，改为每日产出 ${formatDailyIncome(targetTile.building.resourceKind, targetTile.building.income)}`,
           tone: "loot"
         });
@@ -3042,7 +3060,7 @@ async function onTileClick(x: number, y: number): Promise<void> {
         applyUpdate(
           targetTile.building.kind === "recruitment_post"
             ? await session.recruit(hero.id, targetTile.building.id)
-            : targetTile.building.kind === "attribute_shrine"
+            : targetTile.building.kind === "attribute_shrine" || targetTile.building.kind === "watchtower"
               ? await session.visitBuilding(hero.id, targetTile.building.id)
               : await session.claimMine(hero.id, targetTile.building.id)
         );
@@ -3052,7 +3070,7 @@ async function onTileClick(x: number, y: number): Promise<void> {
             ? error.message
             : targetTile.building.kind === "recruitment_post"
               ? "recruit_failed"
-              : targetTile.building.kind === "attribute_shrine"
+              : targetTile.building.kind === "attribute_shrine" || targetTile.building.kind === "watchtower"
                 ? "visit_failed"
                 : "claim_failed"
         );

--- a/apps/client/src/object-visuals.ts
+++ b/apps/client/src/object-visuals.ts
@@ -101,6 +101,20 @@ export function describeTileObject(tile: PlayerTileView | null): TileCardDescrip
     };
   }
 
+  if (tile.building?.kind === "watchtower") {
+    const config = objectVisuals.buildings.watchtower;
+    const visited = typeof tile.building.lastUsedDay === "number";
+    return {
+      title: tile.building.label || config.title,
+      subtitle: `${config.subtitle}${visited ? " 本局已完成勘察。" : " 当前仍可登塔。"}`,
+      value: `视野 +${tile.building.visionBonus}${visited ? " · 已记录塔顶视域" : ""}`.trim(),
+      icon: buildingAsset(tile.building.kind),
+      faction: toFactionKey(config.faction),
+      rarity: toRarityKey(config.rarity),
+      interactionType: toInteractionKey(config.interactionType)
+    };
+  }
+
   if (tile.occupant?.kind === "hero") {
     return {
       title: objectVisuals.hero.title,

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -15,7 +15,7 @@ export interface ResourceLedger {
 export type FogState = "hidden" | "explored" | "visible";
 export type TerrainType = "grass" | "dirt" | "sand" | "water" | "unknown";
 export type OccupantKind = "hero" | "neutral" | "building";
-export type BuildingKind = "recruitment_post" | "attribute_shrine" | "resource_mine";
+export type BuildingKind = "recruitment_post" | "attribute_shrine" | "resource_mine" | "watchtower";
 
 export interface HeroProgression {
   level: number;
@@ -164,10 +164,19 @@ export interface ResourceMineBuildingView {
   lastHarvestDay?: number;
 }
 
+export interface WatchtowerBuildingView {
+  id: string;
+  kind: "watchtower";
+  label: string;
+  visionBonus: number;
+  lastUsedDay?: number;
+}
+
 export type PlayerBuildingView =
   | RecruitmentBuildingView
   | AttributeShrineBuildingView
-  | ResourceMineBuildingView;
+  | ResourceMineBuildingView
+  | WatchtowerBuildingView;
 
 export interface UnitStack {
   id: string;
@@ -318,6 +327,13 @@ export type WorldEvent =
       buildingId: string;
       buildingKind: "attribute_shrine";
       bonus: HeroStatBonus;
+    }
+  | {
+      type: "hero.visited";
+      heroId: string;
+      buildingId: string;
+      buildingKind: "watchtower";
+      visionBonus: number;
     }
   | {
       type: "hero.claimedMine";

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -1665,7 +1665,7 @@ export class VeilRoot extends Component {
                 heroId: hero.id,
                 buildingId: tile.building.id
               }
-            : tile.building.kind === "attribute_shrine"
+            : tile.building.kind === "attribute_shrine" || tile.building.kind === "watchtower"
               ? {
                   type: "hero.visit",
                   heroId: hero.id,
@@ -1680,6 +1680,8 @@ export class VeilRoot extends Component {
             ? `预演招募 ${tile.building.availableCount} 单位`
             : tile.building.kind === "attribute_shrine"
               ? `预演获得 ${formatHeroStatBonus(tile.building.bonus)}`
+              : tile.building.kind === "watchtower"
+                ? `预演提高视野 ${tile.building.visionBonus}`
               : `预演占领矿场，改为每日产出 ${tile.building.income} ${formatResourceKindLabel(tile.building.resourceKind)}`
         );
         this.renderView();
@@ -1689,7 +1691,7 @@ export class VeilRoot extends Component {
           await this.applySessionUpdate(
             tile.building.kind === "recruitment_post"
               ? await this.session.recruit(hero.id, tile.building.id)
-              : tile.building.kind === "attribute_shrine"
+              : tile.building.kind === "attribute_shrine" || tile.building.kind === "watchtower"
                 ? await this.session.visitBuilding(hero.id, tile.building.id)
                 : await this.session.claimMine(hero.id, tile.building.id)
           );
@@ -1698,6 +1700,8 @@ export class VeilRoot extends Component {
               ? "招募已结算。"
               : tile.building.kind === "attribute_shrine"
                 ? "神殿访问已结算。"
+                : tile.building.kind === "watchtower"
+                  ? "瞭望塔访问已结算。"
                 : "矿场占领已结算。"
           );
         } catch (error) {
@@ -1706,7 +1710,7 @@ export class VeilRoot extends Component {
               ? error.message
               : tile.building.kind === "recruitment_post"
                 ? "招募失败。"
-                : tile.building.kind === "attribute_shrine"
+                : tile.building.kind === "attribute_shrine" || tile.building.kind === "watchtower"
                   ? "访问失败。"
                   : "占领失败。"
           );

--- a/apps/cocos-client/assets/scripts/cocos-map-board-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-map-board-model.ts
@@ -92,6 +92,10 @@ export function resolveMapBoardFeedbackLabel(
   }
 
   if (event.type === "hero.visited") {
+    if (event.buildingKind === "watchtower") {
+      return `+VIS ${event.visionBonus}`;
+    }
+
     return event.bonus.attack > 0
       ? "+ATK"
       : event.bonus.defense > 0

--- a/apps/cocos-client/assets/scripts/cocos-map-visuals.ts
+++ b/apps/cocos-client/assets/scripts/cocos-map-visuals.ts
@@ -179,15 +179,17 @@ export function buildMapFeedbackEntriesFromUpdate(update: SessionUpdate, heroId?
 
     if (event.type === "hero.visited" && heroPosition) {
       const firstBonus =
-        event.bonus.attack > 0
-          ? "ATK"
-          : event.bonus.defense > 0
-            ? "DEF"
-            : event.bonus.power > 0
-              ? "POW"
-              : event.bonus.knowledge > 0
-                ? "KNW"
-                : "STAT";
+        event.buildingKind === "watchtower"
+          ? "VIS"
+          : event.bonus.attack > 0
+            ? "ATK"
+            : event.bonus.defense > 0
+              ? "DEF"
+              : event.bonus.power > 0
+                ? "POW"
+                : event.bonus.knowledge > 0
+                  ? "KNW"
+                  : "STAT";
       entries.push({
         position: heroPosition,
         text: resolveMapBoardFeedbackLabel(event) ?? `+${firstBonus}`,

--- a/apps/cocos-client/assets/scripts/cocos-object-visuals.ts
+++ b/apps/cocos-client/assets/scripts/cocos-object-visuals.ts
@@ -4,7 +4,7 @@ import type { PlayerTileView } from "./VeilCocosSession.ts";
 type FactionKey = "crown" | "wild";
 type RarityKey = "common" | "elite";
 type InteractionKey = "move" | "pickup" | "battle";
-export type CocosTileMarkerIconKey = "wood" | "gold" | "ore" | "neutral" | "hero" | "recruitment" | "shrine" | "mine";
+export type CocosTileMarkerIconKey = "wood" | "gold" | "ore" | "neutral" | "hero" | "recruitment" | "shrine" | "mine" | "tower";
 
 export interface CocosTileVisualDescriptor {
   title: string;
@@ -78,6 +78,19 @@ export function describeCocosTileObject(tile: PlayerTileView | null): CocosTileV
       subtitle: `${formatResourceKindLabel(tile.building.resourceKind)} +${tile.building.income}${typeof tile.building.lastHarvestDay === "number" ? " · 今日已采集" : " · 可立即采集"}`,
       shortLabel: "矿场",
       tag: "采集",
+      faction: toFactionKey(config.faction),
+      rarity: toRarityKey(config.rarity),
+      interactionType: toInteractionKey(config.interactionType)
+    };
+  }
+
+  if (tile.building?.kind === "watchtower") {
+    const config = objectVisuals.buildings.watchtower;
+    return {
+      title: tile.building.label || config.title,
+      subtitle: `视野 +${tile.building.visionBonus}${typeof tile.building.lastUsedDay === "number" ? " · 今日已观测" : " · 可立即登塔"}`,
+      shortLabel: "塔楼",
+      tag: "访问",
       faction: toFactionKey(config.faction),
       rarity: toRarityKey(config.rarity),
       interactionType: toInteractionKey(config.interactionType)
@@ -184,6 +197,9 @@ export function buildCocosTileMarkerText(tile: PlayerTileView | null): string {
     if (tile.building.kind === "resource_mine") {
       return ">M";
     }
+    if (tile.building.kind === "watchtower") {
+      return ">T";
+    }
     return ">B";
   }
 
@@ -246,6 +262,10 @@ function resolveMarkerIconKey(tile: PlayerTileView | null): CocosTileMarkerIconK
 
   if (tile?.building?.kind === "resource_mine") {
     return "mine";
+  }
+
+  if (tile?.building?.kind === "watchtower") {
+    return "tower";
   }
 
   return null;

--- a/apps/cocos-client/assets/scripts/cocos-pixel-sprite-manifest.ts
+++ b/apps/cocos-client/assets/scripts/cocos-pixel-sprite-manifest.ts
@@ -24,6 +24,7 @@ export interface PixelIconSpriteManifest {
   recruitment: string;
   shrine: string;
   mine: string;
+  tower: string;
   hud: string;
   battle: string;
   timeline: string;
@@ -85,6 +86,7 @@ export const pixelSpriteManifest: PixelSpriteManifest = {
     recruitment: requireResourcePath(assetConfig.buildings.recruitment_post, "buildings.recruitment_post"),
     shrine: requireResourcePath(assetConfig.buildings.attribute_shrine, "buildings.attribute_shrine"),
     mine: requireResourcePath(assetConfig.buildings.resource_mine, "buildings.resource_mine"),
+    tower: requireResourcePath(assetConfig.buildings.watchtower, "buildings.watchtower"),
     hud: "pixel/ui/hud-icon",
     battle: "pixel/ui/battle-icon",
     timeline: "pixel/ui/timeline-icon"

--- a/apps/cocos-client/assets/scripts/cocos-prediction.ts
+++ b/apps/cocos-client/assets/scripts/cocos-prediction.ts
@@ -7,6 +7,7 @@ import type {
   PlayerWorldView,
   RecruitmentBuildingView,
   ResourceMineBuildingView,
+  WatchtowerBuildingView,
   Vec2
 } from "./VeilCocosSession.ts";
 
@@ -334,7 +335,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: CocosWor
       };
     }
 
-    if (!isAttributeShrineBuilding(building)) {
+    if (!isAttributeShrineBuilding(building) && !isWatchtowerBuilding(building)) {
       return {
         world: view,
         movementPlan: null,
@@ -354,25 +355,37 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: CocosWor
 
     const predictedWorld: PlayerWorldView = {
       ...view,
-      ownHeroes: view.ownHeroes.map((item) =>
-        item.id === hero.id
-          ? {
-              ...item,
-              stats: {
-                ...item.stats,
-                attack: item.stats.attack + building.bonus.attack,
-                defense: item.stats.defense + building.bonus.defense,
-                power: item.stats.power + building.bonus.power,
-                knowledge: item.stats.knowledge + building.bonus.knowledge
-              }
+      ownHeroes: view.ownHeroes.map((item) => {
+        if (item.id !== hero.id) {
+          return item;
+        }
+
+        if (isAttributeShrineBuilding(building)) {
+          return {
+            ...item,
+            stats: {
+              ...item.stats,
+              attack: item.stats.attack + building.bonus.attack,
+              defense: item.stats.defense + building.bonus.defense,
+              power: item.stats.power + building.bonus.power,
+              knowledge: item.stats.knowledge + building.bonus.knowledge
             }
-          : item
-      ),
+          };
+        }
+
+        return {
+          ...item,
+          vision: item.vision + building.visionBonus
+        };
+      }),
       map: {
         ...view.map,
         tiles: view.map.tiles.map((item) => {
           const currentBuilding = item.building;
-          if (!samePosition(item.position, hero.position) || !isAttributeShrineBuilding(currentBuilding)) {
+          if (
+            !samePosition(item.position, hero.position) ||
+            (!isAttributeShrineBuilding(currentBuilding) && !isWatchtowerBuilding(currentBuilding))
+          ) {
             return item;
           }
 
@@ -380,7 +393,6 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: CocosWor
             ...item,
             building: {
               ...currentBuilding,
-              bonus: { ...currentBuilding.bonus },
               lastUsedDay: view.meta.day
             }
           };
@@ -711,6 +723,10 @@ function isRecruitmentBuilding(building: PlayerTileView["building"]): building i
 
 function isAttributeShrineBuilding(building: PlayerTileView["building"]): building is AttributeShrineBuildingView {
   return building?.kind === "attribute_shrine";
+}
+
+function isWatchtowerBuilding(building: PlayerTileView["building"]): building is WatchtowerBuildingView {
+  return building?.kind === "watchtower";
 }
 
 function isResourceMineBuilding(building: PlayerTileView["building"]): building is ResourceMineBuildingView {

--- a/apps/cocos-client/assets/scripts/cocos-showcase-gallery.ts
+++ b/apps/cocos-client/assets/scripts/cocos-showcase-gallery.ts
@@ -15,7 +15,7 @@ export interface LobbyTerrainShowcaseEntry {
 export interface LobbyBuildingShowcaseEntry {
   id: string;
   label: string;
-  iconKey: "recruitment" | "shrine" | "mine" | "battle";
+  iconKey: "recruitment" | "shrine" | "mine" | "tower";
 }
 
 export interface LobbyShowcaseAssets<Frame = unknown> {
@@ -58,7 +58,7 @@ export const lobbyBuildingShowcaseEntries: LobbyBuildingShowcaseEntry[] = [
   { id: "recruitment_post", label: "招募", iconKey: "recruitment" },
   { id: "attribute_shrine", label: "神社", iconKey: "shrine" },
   { id: "resource_mine", label: "矿场", iconKey: "mine" },
-  { id: "forge_hall", label: "锻炉", iconKey: "battle" }
+  { id: "watchtower", label: "塔楼", iconKey: "tower" }
 ];
 
 export function getLobbyShowcaseUnitPageCount(): number {

--- a/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
+++ b/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
@@ -56,7 +56,9 @@ function formatWorldEvent(event: WorldEvent): string | null {
   }
 
   if (event.type === "hero.visited") {
-    return `访问属性建筑，获得 ${formatHeroStatBonus(event.bonus)}。`;
+    return event.buildingKind === "watchtower"
+      ? `登上瞭望塔，视野提高 ${event.visionBonus}。`
+      : `访问属性建筑，获得 ${formatHeroStatBonus(event.bonus)}。`;
   }
 
   if (event.type === "hero.claimedMine") {

--- a/apps/cocos-client/assets/scripts/project-shared/assets-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/assets-config.ts
@@ -52,7 +52,7 @@ export interface AssetConfig {
 
 const TERRAIN_KEYS = ["grass", "dirt", "sand", "water", "unknown"] as const;
 const RESOURCE_KEYS = ["gold", "wood", "ore"] as const;
-const BUILDING_KEYS = ["recruitment_post", "attribute_shrine", "resource_mine"] as const;
+const BUILDING_KEYS = ["recruitment_post", "attribute_shrine", "resource_mine", "watchtower"] as const;
 const MARKER_KEYS = ["hero", "neutral"] as const;
 const ASSET_STATE_KEYS = ["idle", "selected", "hit"] as const;
 const BADGE_GROUP_KEYS = ["factions", "rarities", "interactions"] as const;

--- a/apps/cocos-client/assets/scripts/project-shared/map.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map.ts
@@ -373,6 +373,13 @@ function createBuildingState(config: MapObjectsConfig["buildings"][number]): Map
     };
   }
 
+  if (config.kind === "watchtower") {
+    return {
+      ...config,
+      position: { ...config.position }
+    };
+  }
+
   return {
     ...config,
     position: { ...config.position }
@@ -506,6 +513,16 @@ function clonePlayerBuildingView(building: MapBuildingState): PlayerBuildingView
     };
   }
 
+  if (building.kind === "watchtower") {
+    return {
+      id: building.id,
+      kind: building.kind,
+      label: building.label,
+      visionBonus: building.visionBonus,
+      ...(typeof building.lastUsedDay === "number" ? { lastUsedDay: building.lastUsedDay } : {})
+    };
+  }
+
   return {
     id: building.id,
     kind: building.kind,
@@ -530,6 +547,13 @@ function cloneBuildingState(building: MapBuildingState): MapBuildingState {
       ...building,
       position: { ...building.position },
       bonus: cloneHeroStatBonus(building.bonus)
+    };
+  }
+
+  if (building.kind === "watchtower") {
+    return {
+      ...building,
+      position: { ...building.position }
     };
   }
 
@@ -566,6 +590,13 @@ function applyHeroStatBonus(hero: HeroState, bonus: HeroStatBonus): HeroState {
       power: hero.stats.power + bonus.power,
       knowledge: hero.stats.knowledge + bonus.knowledge
     }
+  };
+}
+
+function applyHeroVisionBonus(hero: HeroState, visionBonus: number): HeroState {
+  return {
+    ...hero,
+    vision: hero.vision + visionBonus
   };
 }
 
@@ -1678,7 +1709,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
       };
     }
 
-    if (tile.building.kind !== "attribute_shrine") {
+    if (tile.building.kind !== "attribute_shrine" && tile.building.kind !== "watchtower") {
       return {
         world: view,
         movementPlan: null,
@@ -1699,18 +1730,24 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
 
     const predictedWorld: PlayerWorldView = {
       ...view,
-      ownHeroes: view.ownHeroes.map((item) =>
-        item.id === hero.id ? applyHeroStatBonus(item, building.bonus) : item
-      ),
+      ownHeroes: view.ownHeroes.map((item) => {
+        if (item.id !== hero.id) {
+          return item;
+        }
+
+        return building.kind === "attribute_shrine"
+          ? applyHeroStatBonus(item, building.bonus)
+          : applyHeroVisionBonus(item, building.visionBonus);
+      }),
       map: {
         ...view.map,
         tiles: view.map.tiles.map((item) =>
-          samePosition(item.position, hero.position) && item.building?.kind === "attribute_shrine"
+          samePosition(item.position, hero.position) &&
+          (item.building?.kind === "attribute_shrine" || item.building?.kind === "watchtower")
             ? {
                 ...item,
                 building: {
                   ...item.building,
-                  bonus: cloneHeroStatBonus(item.building.bonus),
                   lastUsedDay: view.meta.day
                 }
               }
@@ -1937,7 +1974,7 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
       return { valid: false, reason: "hero_not_on_building" };
     }
 
-    if (building.kind !== "attribute_shrine") {
+    if (building.kind !== "attribute_shrine" && building.kind !== "watchtower") {
       return { valid: false, reason: "building_not_visitable" };
     }
 
@@ -2325,19 +2362,23 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
   if (action.type === "hero.visit") {
     const hero = state.heroes.find((item) => item.id === action.heroId);
     const building = state.buildings[action.buildingId];
-    if (!hero || !building || building.kind !== "attribute_shrine") {
+    if (!hero || !building || (building.kind !== "attribute_shrine" && building.kind !== "watchtower")) {
       return { state, events: [] };
     }
 
     const heroes = state.heroes.map((item) =>
-      item.id === hero.id ? applyHeroStatBonus(item, building.bonus) : item
+      item.id === hero.id
+        ? building.kind === "attribute_shrine"
+          ? applyHeroStatBonus(item, building.bonus)
+          : applyHeroVisionBonus(item, building.visionBonus)
+        : item
     );
     const buildings = {
       ...state.buildings,
       [building.id]: {
         ...building,
         position: { ...building.position },
-        bonus: cloneHeroStatBonus(building.bonus),
+        ...(building.kind === "attribute_shrine" ? { bonus: cloneHeroStatBonus(building.bonus) } : {}),
         lastUsedDay: state.meta.day
       }
     };
@@ -2346,13 +2387,21 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
     return {
       state: nextState,
       events: [
-        {
-          type: "hero.visited",
-          heroId: hero.id,
-          buildingId: building.id,
-          buildingKind: building.kind,
-          bonus: cloneHeroStatBonus(building.bonus)
-        }
+        building.kind === "attribute_shrine"
+          ? {
+              type: "hero.visited",
+              heroId: hero.id,
+              buildingId: building.id,
+              buildingKind: building.kind,
+              bonus: cloneHeroStatBonus(building.bonus)
+            }
+          : {
+              type: "hero.visited",
+              heroId: hero.id,
+              buildingId: building.id,
+              buildingKind: building.kind,
+              visionBonus: building.visionBonus
+            }
       ]
     };
   }

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -2,7 +2,7 @@ export type TerrainType = "grass" | "dirt" | "sand" | "water";
 export type FogState = "hidden" | "explored" | "visible";
 export type ResourceKind = "gold" | "wood" | "ore";
 export type OccupantKind = "hero" | "neutral" | "building";
-export type BuildingKind = "recruitment_post" | "attribute_shrine" | "resource_mine";
+export type BuildingKind = "recruitment_post" | "attribute_shrine" | "resource_mine" | "watchtower";
 export type ResourceLedger = Record<ResourceKind, number>;
 export type WorldResourceLedger = Record<string, ResourceLedger>;
 
@@ -220,10 +220,19 @@ export interface ResourceMineBuildingConfig {
   income: number;
 }
 
+export interface WatchtowerBuildingConfig {
+  id: string;
+  kind: "watchtower";
+  position: Vec2;
+  label: string;
+  visionBonus: number;
+}
+
 export type MapBuildingConfig =
   | RecruitmentBuildingConfig
   | AttributeShrineBuildingConfig
-  | ResourceMineBuildingConfig;
+  | ResourceMineBuildingConfig
+  | WatchtowerBuildingConfig;
 
 export interface RecruitmentBuildingState extends RecruitmentBuildingConfig {
   availableCount: number;
@@ -238,10 +247,15 @@ export interface ResourceMineBuildingState extends ResourceMineBuildingConfig {
   lastHarvestDay?: number;
 }
 
+export interface WatchtowerBuildingState extends WatchtowerBuildingConfig {
+  lastUsedDay?: number;
+}
+
 export type MapBuildingState =
   | RecruitmentBuildingState
   | AttributeShrineBuildingState
-  | ResourceMineBuildingState;
+  | ResourceMineBuildingState
+  | WatchtowerBuildingState;
 
 export interface RecruitmentBuildingView {
   id: string;
@@ -271,10 +285,19 @@ export interface ResourceMineBuildingView {
   lastHarvestDay?: number;
 }
 
+export interface WatchtowerBuildingView {
+  id: string;
+  kind: "watchtower";
+  label: string;
+  visionBonus: number;
+  lastUsedDay?: number;
+}
+
 export type PlayerBuildingView =
   | RecruitmentBuildingView
   | AttributeShrineBuildingView
-  | ResourceMineBuildingView;
+  | ResourceMineBuildingView
+  | WatchtowerBuildingView;
 
 export interface TileState {
   position: Vec2;
@@ -591,6 +614,13 @@ export type WorldEvent =
       buildingId: string;
       buildingKind: "attribute_shrine";
       bonus: HeroStatBonus;
+    }
+  | {
+      type: "hero.visited";
+      heroId: string;
+      buildingId: string;
+      buildingKind: "watchtower";
+      visionBonus: number;
     }
   | {
       type: "hero.claimedMine";

--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -1,9 +1,11 @@
 import defaultBattleSkillsConfig from "../../../../../configs/battle-skills.json";
 import defaultBattleBalanceConfig from "../../../../../configs/battle-balance.json";
 import defaultHeroSkillTreesConfig from "../../../../../configs/hero-skill-trees-full.json";
+import contestedBasinMapObjectsConfig from "../../../../../configs/phase2-map-objects-contested-basin.json";
 import frontierBasinMapObjectsConfig from "../../../../../configs/phase1-map-objects-frontier-basin.json";
 import defaultMapObjectsConfig from "../../../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../../../configs/units.json";
+import contestedBasinWorldConfig from "../../../../../configs/phase2-contested-basin.json";
 import frontierBasinWorldConfig from "../../../../../configs/phase1-world-frontier-basin.json";
 import defaultWorldConfig from "../../../../../configs/phase1-world.json";
 import type {
@@ -30,6 +32,7 @@ let runtimeHeroSkillTree: HeroSkillTreeConfig = structuredClone(defaultHeroSkill
 
 export const DEFAULT_MAP_VARIANT_ID = "phase1";
 export const FRONTIER_BASIN_MAP_VARIANT_ID = "frontier_basin";
+export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
 
 export interface RuntimeConfigBundle {
   world: WorldGenerationConfig;
@@ -617,6 +620,10 @@ export function validateMapObjectsConfig(
       if (!Number.isInteger(building.income) || building.income <= 0) {
         throw new Error(`Map building ${building.id} income must be a positive integer`);
       }
+    } else if (building.kind === "watchtower") {
+      if (!Number.isInteger(building.visionBonus) || building.visionBonus <= 0) {
+        throw new Error(`Map building ${building.id} visionBonus must be a positive integer`);
+      }
     } else {
       throw new Error(`Map building has invalid kind: ${String((building as { kind?: unknown }).kind)}`);
     }
@@ -709,7 +716,7 @@ function parseRequestedMapVariantId(roomId: string): string | undefined {
 }
 
 function getAvailableMapVariantIds(): string[] {
-  return [DEFAULT_MAP_VARIANT_ID, FRONTIER_BASIN_MAP_VARIANT_ID];
+  return [DEFAULT_MAP_VARIANT_ID, FRONTIER_BASIN_MAP_VARIANT_ID, CONTESTED_BASIN_MAP_VARIANT_ID];
 }
 
 export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string {
@@ -721,7 +728,11 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     const variants = getAvailableMapVariantIds();
     return variants[hashVariantSeed(roomId, seed) % variants.length] ?? DEFAULT_MAP_VARIANT_ID;
   }
-  if (requested === DEFAULT_MAP_VARIANT_ID || requested === FRONTIER_BASIN_MAP_VARIANT_ID) {
+  if (
+    requested === DEFAULT_MAP_VARIANT_ID ||
+    requested === FRONTIER_BASIN_MAP_VARIANT_ID ||
+    requested === CONTESTED_BASIN_MAP_VARIANT_ID
+  ) {
     return requested;
   }
   return DEFAULT_MAP_VARIANT_ID;
@@ -736,11 +747,15 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
   const world =
     mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
       ? cloneWorldConfig(frontierBasinWorldConfig as WorldGenerationConfig)
-      : getDefaultWorldConfig();
+      : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
+        ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
+        : getDefaultWorldConfig();
   const mapObjects =
     mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
       ? cloneMapObjectsConfig(frontierBasinMapObjectsConfig as MapObjectsConfig)
-      : getDefaultMapObjectsConfig();
+      : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
+        : getDefaultMapObjectsConfig();
 
   validateWorldConfig(world);
   validateMapObjectsConfig(mapObjects, world, units);

--- a/apps/cocos-client/test/cocos-presentation-readiness.test.ts
+++ b/apps/cocos-client/test/cocos-presentation-readiness.test.ts
@@ -9,7 +9,7 @@ import {
 test("presentation readiness summarizes placeholder pixel, audio and fallback animation coverage", () => {
   const readiness = buildCocosPresentationReadiness();
   assert.equal(readiness.pixel.stage, "placeholder");
-  assert.match(readiness.pixel.headline, /5 地形 \/ 4 英雄 \/ 8 单位 \/ 4 建筑/);
+  assert.match(readiness.pixel.headline, /5 地形 \/ 4 英雄 \/ 10 单位 \/ 5 建筑/);
   assert.equal(readiness.audio.stage, "mixed");
   assert.match(readiness.audio.headline, /2 首 BGM \/ 6 组 SFX/);
   assert.match(readiness.audio.detail, /2 正式 \/ 6 占位/);

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -3,6 +3,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolve } from "node:path";
 import { createPool, type Pool, type RowDataPacket } from "mysql2/promise";
 import * as XLSX from "xlsx";
+import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
+import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
+import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
+import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
 import {
   getBattleBalanceConfig,
   createWorldStateFromConfigs,
@@ -185,6 +189,13 @@ export interface WorldConfigPreviewTile {
         income: number;
         lastHarvestDay?: number;
       }
+    | {
+        kind: "watchtower";
+        refId: string;
+        label: string;
+        visionBonus: number;
+        lastUsedDay?: number;
+      }
     | undefined;
 }
 
@@ -309,7 +320,9 @@ interface JsonSchemaNode {
 }
 
 const CONFIG_CENTER_LIBRARY_FILE = ".config-center-library.json";
-const BUILTIN_PRESET_IDS = ["easy", "normal", "hard"] as const;
+const BUILTIN_DIFFICULTY_PRESET_IDS = ["easy", "normal", "hard"] as const;
+const BUILTIN_WORLD_LAYOUT_PRESETS = ["layout_phase1", "layout_frontier_basin", "layout_contested_basin"] as const;
+const BUILTIN_MAP_OBJECT_LAYOUT_PRESETS = ["layout_phase1", "layout_frontier_basin", "layout_contested_basin"] as const;
 const CONFIG_SCHEMA_VERSION = "2026-03-26";
 const BASE_VALUE_IMPACT = ["配置台编辑器"];
 const BASE_SCHEMA_IMPACT = ["配置台编辑器", "Schema 校验器"];
@@ -470,7 +483,7 @@ const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
           required: ["id", "kind", "position", "label"],
           properties: {
             id: { type: "string", description: "建筑 id。" },
-            kind: { type: "string", description: "建筑种类。" },
+            kind: { type: "string", enum: ["recruitment_post", "attribute_shrine", "resource_mine", "watchtower"], description: "建筑种类。" },
             label: { type: "string", description: "建筑显示名。" },
             position: {
               type: "object",
@@ -479,7 +492,14 @@ const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
                 x: { type: "integer", minimum: 0, description: "X 坐标。" },
                 y: { type: "integer", minimum: 0, description: "Y 坐标。" }
               }
-            }
+            },
+            unitTemplateId: { type: "string", description: "招募建筑使用的兵种模板 id。" },
+            recruitCount: { type: "integer", minimum: 1, description: "招募建筑每次提供的兵力数量。" },
+            cost: { type: "object", description: "招募建筑的资源消耗。" },
+            bonus: { type: "object", description: "属性神殿提供的永久属性加成。" },
+            resourceKind: { type: "string", enum: ["gold", "wood", "ore"], description: "资源矿场的产出类型。" },
+            income: { type: "integer", minimum: 1, description: "资源矿场的每日产出。" },
+            visionBonus: { type: "integer", minimum: 1, description: "瞭望塔提供的永久视野加成。" }
           }
         }
       }
@@ -1214,7 +1234,7 @@ function parseWorkbookToContent(workbookBuffer: Buffer): string {
   return `${JSON.stringify(root, null, 2)}\n`;
 }
 
-function buildBuiltinPresetSummary(id: typeof BUILTIN_PRESET_IDS[number]): ConfigPresetSummary {
+function buildBuiltinPresetSummary(id: typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]): ConfigPresetSummary {
   const title = id === "easy" ? "Easy" : id === "normal" ? "Normal" : "Hard";
   const description =
     id === "easy"
@@ -1296,7 +1316,7 @@ function normalizeJsonContent(
   return `${JSON.stringify(parsed, null, 2)}\n`;
 }
 
-function applyWorldPreset(config: WorldGenerationConfig, presetId: typeof BUILTIN_PRESET_IDS[number]): WorldGenerationConfig {
+function applyWorldPreset(config: WorldGenerationConfig, presetId: typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]): WorldGenerationConfig {
   if (presetId === "normal") {
     return structuredClone(config);
   }
@@ -1333,7 +1353,7 @@ function applyWorldPreset(config: WorldGenerationConfig, presetId: typeof BUILTI
   };
 }
 
-function applyMapObjectsPreset(config: MapObjectsConfig, presetId: typeof BUILTIN_PRESET_IDS[number]): MapObjectsConfig {
+function applyMapObjectsPreset(config: MapObjectsConfig, presetId: typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]): MapObjectsConfig {
   if (presetId === "normal") {
     return structuredClone(config);
   }
@@ -1378,6 +1398,13 @@ function applyMapObjectsPreset(config: MapObjectsConfig, presetId: typeof BUILTI
         };
       }
 
+      if (building.kind === "watchtower") {
+        return {
+          ...building,
+          visionBonus: Math.max(1, Math.round(building.visionBonus * rewardScale))
+        };
+      }
+
       return {
         ...building,
         income: Math.max(1, Math.round(building.income * rewardScale))
@@ -1386,7 +1413,7 @@ function applyMapObjectsPreset(config: MapObjectsConfig, presetId: typeof BUILTI
   };
 }
 
-function applyUnitPreset(config: UnitCatalogConfig, presetId: typeof BUILTIN_PRESET_IDS[number]): UnitCatalogConfig {
+function applyUnitPreset(config: UnitCatalogConfig, presetId: typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]): UnitCatalogConfig {
   if (presetId === "normal") {
     return structuredClone(config);
   }
@@ -1409,7 +1436,7 @@ function applyUnitPreset(config: UnitCatalogConfig, presetId: typeof BUILTIN_PRE
 
 function applyBattleSkillPreset(
   config: BattleSkillCatalogConfig,
-  presetId: typeof BUILTIN_PRESET_IDS[number]
+  presetId: typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]
 ): BattleSkillCatalogConfig {
   if (presetId === "normal") {
     return structuredClone(config);
@@ -1452,7 +1479,7 @@ function clampThreshold(value: number): number {
 
 function applyBattleBalancePreset(
   config: BattleBalanceConfig,
-  presetId: typeof BUILTIN_PRESET_IDS[number]
+  presetId: typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]
 ): BattleBalanceConfig {
   if (presetId === "normal") {
     return structuredClone(config);
@@ -1493,7 +1520,7 @@ function applyBattleBalancePreset(
 function applyBuiltinPresetToContent(
   id: ConfigDocumentId,
   content: string,
-  presetId: typeof BUILTIN_PRESET_IDS[number]
+  presetId: typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]
 ): string {
   const parsed = parseConfigDocument(id, content);
   const next =
@@ -1508,6 +1535,76 @@ function applyBuiltinPresetToContent(
             : applyBattleBalancePreset(parsed as BattleBalanceConfig, presetId);
 
   return normalizeJsonContent(next);
+}
+
+function buildLayoutPresetSummary(id: typeof BUILTIN_WORLD_LAYOUT_PRESETS[number]): ConfigPresetSummary {
+  const name =
+    id === "layout_frontier_basin"
+      ? "Frontier Basin"
+      : id === "layout_contested_basin"
+        ? "Contested Basin"
+        : "Phase 1";
+  const description =
+    id === "layout_frontier_basin"
+      ? "切换为首个峡谷盆地布局，适合验证水域与矿点分布。"
+      : id === "layout_contested_basin"
+        ? "切换为争夺盆地布局，包含新巡逻守军与瞭望塔。"
+        : "恢复默认 Phase 1 地图布局。";
+
+  return {
+    id,
+    name,
+    kind: "builtin",
+    updatedAt: new Date(0).toISOString(),
+    description
+  };
+}
+
+function getBuiltinPresetSummaries(id: ConfigDocumentId): ConfigPresetSummary[] {
+  const summaries = BUILTIN_DIFFICULTY_PRESET_IDS.map((presetId) => buildBuiltinPresetSummary(presetId));
+  if (id === "world") {
+    summaries.push(...BUILTIN_WORLD_LAYOUT_PRESETS.map((presetId) => buildLayoutPresetSummary(presetId)));
+  }
+  if (id === "mapObjects") {
+    summaries.push(...BUILTIN_MAP_OBJECT_LAYOUT_PRESETS.map((presetId) => buildLayoutPresetSummary(presetId)));
+  }
+  return summaries;
+}
+
+function resolveBuiltinPresetContent(id: ConfigDocumentId, currentContent: string, presetId: string): string | null {
+  if (BUILTIN_DIFFICULTY_PRESET_IDS.includes(presetId as typeof BUILTIN_DIFFICULTY_PRESET_IDS[number])) {
+    return applyBuiltinPresetToContent(
+      id,
+      currentContent,
+      presetId as typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]
+    );
+  }
+
+  if (id === "world") {
+    if (presetId === "layout_phase1") {
+      return normalizeJsonContent(getDefaultWorldConfig());
+    }
+    if (presetId === "layout_frontier_basin") {
+      return normalizeJsonContent(frontierBasinWorldConfig as WorldGenerationConfig);
+    }
+    if (presetId === "layout_contested_basin") {
+      return normalizeJsonContent(contestedBasinWorldConfig as WorldGenerationConfig);
+    }
+  }
+
+  if (id === "mapObjects") {
+    if (presetId === "layout_phase1") {
+      return normalizeJsonContent(getDefaultMapObjectsConfig());
+    }
+    if (presetId === "layout_frontier_basin") {
+      return normalizeJsonContent(frontierBasinMapObjectsConfig as MapObjectsConfig);
+    }
+    if (presetId === "layout_contested_basin") {
+      return normalizeJsonContent(contestedBasinMapObjectsConfig as MapObjectsConfig);
+    }
+  }
+
+  return null;
 }
 
 function positionKey(position: { x: number; y: number }): string {
@@ -1689,7 +1786,8 @@ export function createWorldConfigPreview(
               },
               ...(typeof tile.building.lastUsedDay === "number" ? { lastUsedDay: tile.building.lastUsedDay } : {})
             }
-          : {
+          : tile.building.kind === "resource_mine"
+            ? {
               kind: tile.building.kind,
               refId: tile.building.id,
               label: tile.building.label,
@@ -1698,6 +1796,13 @@ export function createWorldConfigPreview(
               ...(typeof tile.building.lastHarvestDay === "number"
                 ? { lastHarvestDay: tile.building.lastHarvestDay }
                 : {})
+            }
+            : {
+              kind: tile.building.kind,
+              refId: tile.building.id,
+              label: tile.building.label,
+              visionBonus: tile.building.visionBonus,
+              ...(typeof tile.building.lastUsedDay === "number" ? { lastUsedDay: tile.building.lastUsedDay } : {})
             };
 
     return {
@@ -2410,7 +2515,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
       kind: "custom" as const
     }));
 
-    return [...BUILTIN_PRESET_IDS.map((presetId) => buildBuiltinPresetSummary(presetId)), ...customPresets].sort((left, right) =>
+    return [...getBuiltinPresetSummaries(id), ...customPresets].sort((left, right) =>
       left.kind === right.kind ? right.updatedAt.localeCompare(left.updatedAt) : left.kind === "builtin" ? -1 : 1
     );
   }
@@ -2447,9 +2552,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     const customPreset = (state.presets[id] ?? []).find((item) => item.id === presetId);
     const presetContent = customPreset
       ? customPreset.content
-      : BUILTIN_PRESET_IDS.includes(presetId as typeof BUILTIN_PRESET_IDS[number])
-        ? applyBuiltinPresetToContent(id, current.content, presetId as typeof BUILTIN_PRESET_IDS[number])
-        : null;
+      : resolveBuiltinPresetContent(id, current.content, presetId);
 
     if (!presetContent) {
       throw new Error(`Preset not found: ${presetId}`);

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -623,6 +623,7 @@ function mergeHeroArchiveIntoFreshHero(baseHero: HeroState, archive: PlayerHeroA
 
   return normalizeHeroState({
     ...baseHero,
+    vision: archivedHero.vision,
     stats: {
       ...archivedHero.stats,
       hp: archivedHero.stats.maxHp

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -320,6 +320,61 @@ test("room allows visiting an attribute shrine once and persists the stat bonus"
   assert.equal(revisitResult.reason, "building_on_cooldown");
 });
 
+test("room allows visiting the contested basin watchtower and persists the vision bonus", () => {
+  const room = createRoom("room-watchtower[map:contested_basin]", 1001);
+
+  const moveResult = room.dispatch("player-1", {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 4, y: 5 }
+  });
+
+  assert.equal(moveResult.ok, true);
+  assert.deepEqual(moveResult.snapshot.state.ownHeroes[0]?.position, { x: 4, y: 5 });
+
+  const nextDayResult = room.dispatch("player-1", {
+    type: "turn.endDay"
+  });
+
+  assert.equal(nextDayResult.ok, true);
+
+  const finalMoveResult = room.dispatch("player-1", {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 5, y: 4 }
+  });
+
+  assert.equal(finalMoveResult.ok, true);
+  assert.deepEqual(finalMoveResult.snapshot.state.ownHeroes[0]?.position, { x: 5, y: 4 });
+
+  const visitResult = room.dispatch("player-1", {
+    type: "hero.visit",
+    heroId: "hero-1",
+    buildingId: "watchtower-basin-1"
+  });
+
+  assert.equal(visitResult.ok, true);
+  assert.deepEqual(visitResult.events, [
+    {
+      type: "hero.visited",
+      heroId: "hero-1",
+      buildingId: "watchtower-basin-1",
+      buildingKind: "watchtower",
+      visionBonus: 2
+    }
+  ]);
+  assert.equal(visitResult.snapshot.state.ownHeroes[0]?.vision, 4);
+
+  const revisitResult = room.dispatch("player-1", {
+    type: "hero.visit",
+    heroId: "hero-1",
+    buildingId: "watchtower-basin-1"
+  });
+
+  assert.equal(revisitResult.ok, false);
+  assert.equal(revisitResult.reason, "building_on_cooldown");
+});
+
 test("room allows harvesting a resource mine and restores it on the next day", () => {
   const room = createRoom("room-mine", 1001);
 

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -474,6 +474,24 @@ test("config center snapshots support diff and rollback", async () => {
   assert.equal(JSON.parse(rolledBack.content).width, WORLD_CONFIG.width);
 });
 
+test("config center exposes built-in layout presets for the additional map variants", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  const worldPresets = await store.listPresets("world");
+  const mapObjectPresets = await store.listPresets("mapObjects");
+
+  assert.ok(worldPresets.some((preset) => preset.id === "layout_contested_basin"));
+  assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_contested_basin"));
+
+  const worldDocument = await store.applyPreset("world", "layout_contested_basin");
+  const mapObjectsDocument = await store.applyPreset("mapObjects", "layout_contested_basin");
+
+  assert.match(worldDocument.content, /"width": 10/);
+  assert.match(mapObjectsDocument.content, /"kind": "watchtower"/);
+});
+
 test("config center diff classifies added, removed, and type changes", async () => {
   const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
   await seedConfigRoot(rootDir);

--- a/configs/assets.json
+++ b/configs/assets.json
@@ -43,7 +43,8 @@
   "buildings": {
     "recruitment_post": "/assets/pixel/buildings/recruitment-post.png",
     "attribute_shrine": "/assets/pixel/buildings/attribute-shrine.png",
-    "resource_mine": "/assets/pixel/buildings/resource-mine.png"
+    "resource_mine": "/assets/pixel/buildings/resource-mine.png",
+    "watchtower": "/assets/pixel/buildings/forge-hall.png"
   },
   "units": {
     "hero_guard_basic": {
@@ -59,6 +60,22 @@
         "idle": "/assets/pixel/units/wolf-pack.png",
         "selected": "/assets/pixel/units/wolf-pack-selected.png",
         "hit": "/assets/pixel/units/wolf-pack-hit.png"
+      },
+      "frame": "/assets/pixel/frames/unit-frame-enemy.png"
+    },
+    "moss_stalker": {
+      "portrait": {
+        "idle": "/assets/pixel/showcase-units/moss-stalker.png",
+        "selected": "/assets/pixel/showcase-units/moss-stalker-selected.png",
+        "hit": "/assets/pixel/showcase-units/moss-stalker-hit.png"
+      },
+      "frame": "/assets/pixel/frames/unit-frame-enemy.png"
+    },
+    "iron_walker": {
+      "portrait": {
+        "idle": "/assets/pixel/showcase-units/iron-walker.png",
+        "selected": "/assets/pixel/showcase-units/iron-walker-selected.png",
+        "hit": "/assets/pixel/showcase-units/iron-walker-hit.png"
       },
       "frame": "/assets/pixel/frames/unit-frame-enemy.png"
     }
@@ -487,6 +504,7 @@
     "snow": "/assets/pixel/showcase-terrain/snow-tile.png"
   },
   "showcaseBuildings": {
-    "forge_hall": "/assets/pixel/buildings/forge-hall.png"
+    "forge_hall": "/assets/pixel/buildings/forge-hall.png",
+    "watchtower": "/assets/pixel/buildings/forge-hall.png"
   }
 }

--- a/configs/battle-skills-v1.1.json
+++ b/configs/battle-skills-v1.1.json
@@ -129,6 +129,52 @@
         "allowRetaliation": false,
         "onHitStatusId": "weakened"
       }
+    },
+    {
+      "id": "ambush_pounce",
+      "name": "伏击扑杀",
+      "description": "借助地形突然扑击，压低单次伤害但留下破甲创口。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 2,
+      "effects": {
+        "damageMultiplier": 0.95,
+        "onHitStatusId": "armor_break"
+      }
+    },
+    {
+      "id": "bog_veil",
+      "name": "沼雾潜行",
+      "description": "借雾气隐蔽身形，短时间内提高先手并削弱敌方反击节奏。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 3,
+      "effects": {
+        "grantedStatusId": "mist_shroud"
+      }
+    },
+    {
+      "id": "shield_bash",
+      "name": "塔盾猛击",
+      "description": "以厚盾撞击敌军，伤害稳定并附带短暂压制。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 1.05,
+        "onHitStatusId": "weakened"
+      }
+    },
+    {
+      "id": "watcher_stance",
+      "name": "瞭望戒备",
+      "description": "驻守时主动收紧阵线，提高防御并延后敌方节奏。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 4,
+      "effects": {
+        "grantedStatusId": "watchful_guard"
+      }
     }
   ],
   "statuses": [
@@ -219,6 +265,28 @@
       "damagePerTurn": 0,
       "initiativeModifier": 0,
       "blocksActiveSkills": true
+    },
+    {
+      "id": "mist_shroud",
+      "name": "沼雾隐迹",
+      "description": "在迷雾掩护下行动，先手提升且更难被压制。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 1,
+      "damagePerTurn": 0,
+      "initiativeModifier": 3,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "watchful_guard",
+      "name": "瞭望戒备",
+      "description": "重整盾阵，提升防御并稳住站位。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 3,
+      "damagePerTurn": 0,
+      "initiativeModifier": -1,
+      "blocksActiveSkills": false
     }
   ]
 }

--- a/configs/battle-skills.json
+++ b/configs/battle-skills.json
@@ -129,6 +129,52 @@
         "allowRetaliation": false,
         "onHitStatusId": "weakened"
       }
+    },
+    {
+      "id": "ambush_pounce",
+      "name": "伏击扑杀",
+      "description": "借助地形突然扑击，压低单次伤害但留下破甲创口。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 2,
+      "effects": {
+        "damageMultiplier": 0.95,
+        "onHitStatusId": "armor_break"
+      }
+    },
+    {
+      "id": "bog_veil",
+      "name": "沼雾潜行",
+      "description": "借雾气隐蔽身形，短时间内提高先手并削弱敌方反击节奏。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 3,
+      "effects": {
+        "grantedStatusId": "mist_shroud"
+      }
+    },
+    {
+      "id": "shield_bash",
+      "name": "塔盾猛击",
+      "description": "以厚盾撞击敌军，伤害稳定并附带短暂压制。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 1.05,
+        "onHitStatusId": "weakened"
+      }
+    },
+    {
+      "id": "watcher_stance",
+      "name": "瞭望戒备",
+      "description": "驻守时主动收紧阵线，提高防御并延后敌方节奏。",
+      "kind": "active",
+      "target": "self",
+      "cooldown": 4,
+      "effects": {
+        "grantedStatusId": "watchful_guard"
+      }
     }
   ],
   "statuses": [
@@ -219,6 +265,28 @@
       "damagePerTurn": 0,
       "initiativeModifier": 0,
       "blocksActiveSkills": true
+    },
+    {
+      "id": "mist_shroud",
+      "name": "沼雾隐迹",
+      "description": "在迷雾掩护下行动，先手提升且更难被压制。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 1,
+      "damagePerTurn": 0,
+      "initiativeModifier": 3,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "watchful_guard",
+      "name": "瞭望戒备",
+      "description": "重整盾阵，提升防御并稳住站位。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 3,
+      "damagePerTurn": 0,
+      "initiativeModifier": -1,
+      "blocksActiveSkills": false
     }
   ]
 }

--- a/configs/object-visuals.json
+++ b/configs/object-visuals.json
@@ -40,6 +40,13 @@
       "interactionType": "move",
       "faction": "crown",
       "rarity": "elite"
+    },
+    "watchtower": {
+      "title": "前线瞭望塔",
+      "subtitle": "访问后可永久扩大英雄的视野范围。",
+      "interactionType": "move",
+      "faction": "crown",
+      "rarity": "elite"
     }
   },
   "resources": {

--- a/configs/phase2-contested-basin.json
+++ b/configs/phase2-contested-basin.json
@@ -1,0 +1,136 @@
+{
+  "width": 10,
+  "height": 8,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": {
+        "x": 1,
+        "y": 2
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "militia_pike",
+          "vanguard_blade",
+          "padded_gambeson",
+          "scout_compass"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": {
+        "x": 8,
+        "y": 5
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "oak_longbow",
+          "tower_shield_mail",
+          "scribe_charm",
+          "captains_insignia"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.06,
+    "woodChance": 0.07,
+    "oreChance": 0.07
+  },
+  "terrainOverrides": [
+    { "position": { "x": 3, "y": 0 }, "terrain": "water" },
+    { "position": { "x": 4, "y": 0 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 0 }, "terrain": "sand" },
+    { "position": { "x": 7, "y": 0 }, "terrain": "sand" },
+    { "position": { "x": 2, "y": 1 }, "terrain": "dirt" },
+    { "position": { "x": 3, "y": 1 }, "terrain": "water" },
+    { "position": { "x": 4, "y": 1 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 1 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 1 }, "terrain": "sand" },
+    { "position": { "x": 1, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 2, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 4, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 2 }, "terrain": "sand" },
+    { "position": { "x": 2, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 3, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 4, "y": 3 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 3 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 1, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 2, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 3, "y": 4 }, "terrain": "water" },
+    { "position": { "x": 4, "y": 4 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 1, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 2, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 3, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 4, "y": 5 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 5 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 2, "y": 6 }, "terrain": "sand" },
+    { "position": { "x": 3, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 5, "y": 6 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 3, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 4, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 6, "y": 7 }, "terrain": "water" }
+  ]
+}

--- a/configs/phase2-map-objects-contested-basin.json
+++ b/configs/phase2-map-objects-contested-basin.json
@@ -1,0 +1,174 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-reed-patrol",
+      "position": {
+        "x": 3,
+        "y": 3
+      },
+      "reward": {
+        "kind": "wood",
+        "amount": 8
+      },
+      "stacks": [
+        {
+          "templateId": "moss_stalker",
+          "count": 5
+        },
+        {
+          "templateId": "wolf_pack",
+          "count": 4
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [
+          { "x": 3, "y": 3 },
+          { "x": 2, "y": 3 },
+          { "x": 2, "y": 2 },
+          { "x": 3, "y": 2 }
+        ],
+        "detectionRadius": 4,
+        "chaseDistance": 7,
+        "speed": 2
+      }
+    },
+    {
+      "id": "neutral-watch-guard",
+      "position": {
+        "x": 7,
+        "y": 4
+      },
+      "reward": {
+        "kind": "ore",
+        "amount": 5
+      },
+      "stacks": [
+        {
+          "templateId": "iron_walker",
+          "count": 4
+        },
+        {
+          "templateId": "hero_guard_basic",
+          "count": 5
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-ford-scouts",
+      "position": {
+        "x": 5,
+        "y": 6
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 260
+      },
+      "stacks": [
+        {
+          "templateId": "moss_stalker",
+          "count": 3
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolRadius": 1,
+        "detectionRadius": 3,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    {
+      "position": {
+        "x": 2,
+        "y": 1
+      },
+      "resource": {
+        "kind": "wood",
+        "amount": 6
+      }
+    },
+    {
+      "position": {
+        "x": 7,
+        "y": 6
+      },
+      "resource": {
+        "kind": "ore",
+        "amount": 4
+      }
+    },
+    {
+      "position": {
+        "x": 4,
+        "y": 6
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 220
+      }
+    }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-basin-1",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 1,
+        "y": 3
+      },
+      "label": "峡湾征募站",
+      "unitTemplateId": "hero_guard_basic",
+      "recruitCount": 4,
+      "cost": {
+        "gold": 220,
+        "wood": 1,
+        "ore": 0
+      }
+    },
+    {
+      "id": "shrine-knowledge-basin-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 5,
+        "y": 1
+      },
+      "label": "雾潮圣龛",
+      "bonus": {
+        "attack": 0,
+        "defense": 1,
+        "power": 1,
+        "knowledge": 1
+      }
+    },
+    {
+      "id": "mine-ore-basin-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 6,
+        "y": 5
+      },
+      "label": "裂隙矿脉",
+      "resourceKind": "ore",
+      "income": 4
+    },
+    {
+      "id": "watchtower-basin-1",
+      "kind": "watchtower",
+      "position": {
+        "x": 5,
+        "y": 4
+      },
+      "label": "回声瞭望塔",
+      "visionBonus": 2
+    }
+  ]
+}

--- a/configs/units.json
+++ b/configs/units.json
@@ -25,6 +25,32 @@
       "maxDamage": 4,
       "maxHp": 8,
       "battleSkills": ["venomous_fangs", "crippling_howl"]
+    },
+    {
+      "id": "moss_stalker",
+      "stackName": "苔痕潜猎者",
+      "faction": "wild",
+      "rarity": "elite",
+      "initiative": 11,
+      "attack": 5,
+      "defense": 3,
+      "minDamage": 2,
+      "maxDamage": 5,
+      "maxHp": 7,
+      "battleSkills": ["ambush_pounce", "bog_veil"]
+    },
+    {
+      "id": "iron_walker",
+      "stackName": "铁卫行者",
+      "faction": "wild",
+      "rarity": "elite",
+      "initiative": 7,
+      "attack": 6,
+      "defense": 7,
+      "minDamage": 3,
+      "maxDamage": 5,
+      "maxHp": 14,
+      "battleSkills": ["shield_bash", "watcher_stance"]
     }
   ]
 }

--- a/packages/shared/src/assets-config.ts
+++ b/packages/shared/src/assets-config.ts
@@ -52,7 +52,7 @@ export interface AssetConfig {
 
 const TERRAIN_KEYS = ["grass", "dirt", "sand", "water", "unknown"] as const;
 const RESOURCE_KEYS = ["gold", "wood", "ore"] as const;
-const BUILDING_KEYS = ["recruitment_post", "attribute_shrine", "resource_mine"] as const;
+const BUILDING_KEYS = ["recruitment_post", "attribute_shrine", "resource_mine", "watchtower"] as const;
 const MARKER_KEYS = ["hero", "neutral"] as const;
 const ASSET_STATE_KEYS = ["idle", "selected", "hit"] as const;
 const BADGE_GROUP_KEYS = ["factions", "rarities", "interactions"] as const;

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -373,6 +373,13 @@ function createBuildingState(config: MapObjectsConfig["buildings"][number]): Map
     };
   }
 
+  if (config.kind === "watchtower") {
+    return {
+      ...config,
+      position: { ...config.position }
+    };
+  }
+
   return {
     ...config,
     position: { ...config.position }
@@ -506,6 +513,16 @@ function clonePlayerBuildingView(building: MapBuildingState): PlayerBuildingView
     };
   }
 
+  if (building.kind === "watchtower") {
+    return {
+      id: building.id,
+      kind: building.kind,
+      label: building.label,
+      visionBonus: building.visionBonus,
+      ...(typeof building.lastUsedDay === "number" ? { lastUsedDay: building.lastUsedDay } : {})
+    };
+  }
+
   return {
     id: building.id,
     kind: building.kind,
@@ -530,6 +547,13 @@ function cloneBuildingState(building: MapBuildingState): MapBuildingState {
       ...building,
       position: { ...building.position },
       bonus: cloneHeroStatBonus(building.bonus)
+    };
+  }
+
+  if (building.kind === "watchtower") {
+    return {
+      ...building,
+      position: { ...building.position }
     };
   }
 
@@ -566,6 +590,13 @@ function applyHeroStatBonus(hero: HeroState, bonus: HeroStatBonus): HeroState {
       power: hero.stats.power + bonus.power,
       knowledge: hero.stats.knowledge + bonus.knowledge
     }
+  };
+}
+
+function applyHeroVisionBonus(hero: HeroState, visionBonus: number): HeroState {
+  return {
+    ...hero,
+    vision: hero.vision + visionBonus
   };
 }
 
@@ -1678,7 +1709,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
       };
     }
 
-    if (tile.building.kind !== "attribute_shrine") {
+    if (tile.building.kind !== "attribute_shrine" && tile.building.kind !== "watchtower") {
       return {
         world: view,
         movementPlan: null,
@@ -1699,18 +1730,24 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
 
     const predictedWorld: PlayerWorldView = {
       ...view,
-      ownHeroes: view.ownHeroes.map((item) =>
-        item.id === hero.id ? applyHeroStatBonus(item, building.bonus) : item
-      ),
+      ownHeroes: view.ownHeroes.map((item) => {
+        if (item.id !== hero.id) {
+          return item;
+        }
+
+        return building.kind === "attribute_shrine"
+          ? applyHeroStatBonus(item, building.bonus)
+          : applyHeroVisionBonus(item, building.visionBonus);
+      }),
       map: {
         ...view.map,
         tiles: view.map.tiles.map((item) =>
-          samePosition(item.position, hero.position) && item.building?.kind === "attribute_shrine"
+          samePosition(item.position, hero.position) &&
+          (item.building?.kind === "attribute_shrine" || item.building?.kind === "watchtower")
             ? {
                 ...item,
                 building: {
                   ...item.building,
-                  bonus: cloneHeroStatBonus(item.building.bonus),
                   lastUsedDay: view.meta.day
                 }
               }
@@ -1937,7 +1974,7 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
       return { valid: false, reason: "hero_not_on_building" };
     }
 
-    if (building.kind !== "attribute_shrine") {
+    if (building.kind !== "attribute_shrine" && building.kind !== "watchtower") {
       return { valid: false, reason: "building_not_visitable" };
     }
 
@@ -2325,19 +2362,23 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
   if (action.type === "hero.visit") {
     const hero = state.heroes.find((item) => item.id === action.heroId);
     const building = state.buildings[action.buildingId];
-    if (!hero || !building || building.kind !== "attribute_shrine") {
+    if (!hero || !building || (building.kind !== "attribute_shrine" && building.kind !== "watchtower")) {
       return { state, events: [] };
     }
 
     const heroes = state.heroes.map((item) =>
-      item.id === hero.id ? applyHeroStatBonus(item, building.bonus) : item
+      item.id === hero.id
+        ? building.kind === "attribute_shrine"
+          ? applyHeroStatBonus(item, building.bonus)
+          : applyHeroVisionBonus(item, building.visionBonus)
+        : item
     );
     const buildings = {
       ...state.buildings,
       [building.id]: {
         ...building,
         position: { ...building.position },
-        bonus: cloneHeroStatBonus(building.bonus),
+        ...(building.kind === "attribute_shrine" ? { bonus: cloneHeroStatBonus(building.bonus) } : {}),
         lastUsedDay: state.meta.day
       }
     };
@@ -2346,13 +2387,21 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
     return {
       state: nextState,
       events: [
-        {
-          type: "hero.visited",
-          heroId: hero.id,
-          buildingId: building.id,
-          buildingKind: building.kind,
-          bonus: cloneHeroStatBonus(building.bonus)
-        }
+        building.kind === "attribute_shrine"
+          ? {
+              type: "hero.visited",
+              heroId: hero.id,
+              buildingId: building.id,
+              buildingKind: building.kind,
+              bonus: cloneHeroStatBonus(building.bonus)
+            }
+          : {
+              type: "hero.visited",
+              heroId: hero.id,
+              buildingId: building.id,
+              buildingKind: building.kind,
+              visionBonus: building.visionBonus
+            }
       ]
     };
   }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -2,7 +2,7 @@ export type TerrainType = "grass" | "dirt" | "sand" | "water";
 export type FogState = "hidden" | "explored" | "visible";
 export type ResourceKind = "gold" | "wood" | "ore";
 export type OccupantKind = "hero" | "neutral" | "building";
-export type BuildingKind = "recruitment_post" | "attribute_shrine" | "resource_mine";
+export type BuildingKind = "recruitment_post" | "attribute_shrine" | "resource_mine" | "watchtower";
 export type ResourceLedger = Record<ResourceKind, number>;
 export type WorldResourceLedger = Record<string, ResourceLedger>;
 
@@ -223,10 +223,19 @@ export interface ResourceMineBuildingConfig {
   income: number;
 }
 
+export interface WatchtowerBuildingConfig {
+  id: string;
+  kind: "watchtower";
+  position: Vec2;
+  label: string;
+  visionBonus: number;
+}
+
 export type MapBuildingConfig =
   | RecruitmentBuildingConfig
   | AttributeShrineBuildingConfig
-  | ResourceMineBuildingConfig;
+  | ResourceMineBuildingConfig
+  | WatchtowerBuildingConfig;
 
 export interface RecruitmentBuildingState extends RecruitmentBuildingConfig {
   availableCount: number;
@@ -241,10 +250,15 @@ export interface ResourceMineBuildingState extends ResourceMineBuildingConfig {
   lastHarvestDay?: number;
 }
 
+export interface WatchtowerBuildingState extends WatchtowerBuildingConfig {
+  lastUsedDay?: number;
+}
+
 export type MapBuildingState =
   | RecruitmentBuildingState
   | AttributeShrineBuildingState
-  | ResourceMineBuildingState;
+  | ResourceMineBuildingState
+  | WatchtowerBuildingState;
 
 export interface RecruitmentBuildingView {
   id: string;
@@ -274,10 +288,19 @@ export interface ResourceMineBuildingView {
   lastHarvestDay?: number;
 }
 
+export interface WatchtowerBuildingView {
+  id: string;
+  kind: "watchtower";
+  label: string;
+  visionBonus: number;
+  lastUsedDay?: number;
+}
+
 export type PlayerBuildingView =
   | RecruitmentBuildingView
   | AttributeShrineBuildingView
-  | ResourceMineBuildingView;
+  | ResourceMineBuildingView
+  | WatchtowerBuildingView;
 
 export interface TileState {
   position: Vec2;
@@ -594,6 +617,13 @@ export type WorldEvent =
       buildingId: string;
       buildingKind: "attribute_shrine";
       bonus: HeroStatBonus;
+    }
+  | {
+      type: "hero.visited";
+      heroId: string;
+      buildingId: string;
+      buildingKind: "watchtower";
+      visionBonus: number;
     }
   | {
       type: "hero.claimedMine";

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -1,9 +1,11 @@
 import defaultBattleSkillsConfig from "../../../configs/battle-skills.json";
 import defaultBattleBalanceConfig from "../../../configs/battle-balance.json";
 import defaultHeroSkillTreesConfig from "../../../configs/hero-skill-trees-full.json";
+import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
 import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
 import defaultMapObjectsConfig from "../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../configs/units.json";
+import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
 import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
 import defaultWorldConfig from "../../../configs/phase1-world.json";
 import type {
@@ -30,6 +32,7 @@ let runtimeHeroSkillTree: HeroSkillTreeConfig = structuredClone(defaultHeroSkill
 
 export const DEFAULT_MAP_VARIANT_ID = "phase1";
 export const FRONTIER_BASIN_MAP_VARIANT_ID = "frontier_basin";
+export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
 
 export interface RuntimeConfigBundle {
   world: WorldGenerationConfig;
@@ -623,6 +626,10 @@ export function validateMapObjectsConfig(
       if (!Number.isInteger(building.income) || building.income <= 0) {
         throw new Error(`Map building ${building.id} income must be a positive integer`);
       }
+    } else if (building.kind === "watchtower") {
+      if (!Number.isInteger(building.visionBonus) || building.visionBonus <= 0) {
+        throw new Error(`Map building ${building.id} visionBonus must be a positive integer`);
+      }
     } else {
       throw new Error(`Map building has invalid kind: ${String((building as { kind?: unknown }).kind)}`);
     }
@@ -719,7 +726,7 @@ function parseRequestedMapVariantId(roomId: string): string | undefined {
 }
 
 function getAvailableMapVariantIds(): string[] {
-  return [DEFAULT_MAP_VARIANT_ID, FRONTIER_BASIN_MAP_VARIANT_ID];
+  return [DEFAULT_MAP_VARIANT_ID, FRONTIER_BASIN_MAP_VARIANT_ID, CONTESTED_BASIN_MAP_VARIANT_ID];
 }
 
 export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string {
@@ -731,7 +738,11 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     const variants = getAvailableMapVariantIds();
     return variants[hashVariantSeed(roomId, seed) % variants.length] ?? DEFAULT_MAP_VARIANT_ID;
   }
-  if (requested === DEFAULT_MAP_VARIANT_ID || requested === FRONTIER_BASIN_MAP_VARIANT_ID) {
+  if (
+    requested === DEFAULT_MAP_VARIANT_ID ||
+    requested === FRONTIER_BASIN_MAP_VARIANT_ID ||
+    requested === CONTESTED_BASIN_MAP_VARIANT_ID
+  ) {
     return requested;
   }
   return DEFAULT_MAP_VARIANT_ID;
@@ -746,11 +757,15 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
   const world =
     mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
       ? cloneWorldConfig(frontierBasinWorldConfig as WorldGenerationConfig)
-      : getDefaultWorldConfig();
+      : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
+        ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
+        : getDefaultWorldConfig();
   const mapObjects =
     mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
       ? cloneMapObjectsConfig(frontierBasinMapObjectsConfig as MapObjectsConfig)
-      : getDefaultMapObjectsConfig();
+      : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
+        : getDefaultMapObjectsConfig();
 
   validateWorldConfig(world);
   validateMapObjectsConfig(mapObjects, world, units);

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -4,6 +4,8 @@ import test from "node:test";
 import assetConfig from "../../../configs/assets.json";
 import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
 import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
+import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
+import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
 import {
   applyBattleAction,
   appendEventLogEntries,
@@ -32,6 +34,7 @@ import {
   createInitialWorldState,
   createPlayerWorldView,
   createWorldStateFromConfigs,
+  CONTESTED_BASIN_MAP_VARIANT_ID,
   decodePlayerWorldView,
   encodePlayerWorldView,
   filterWorldEventsForPlayer,
@@ -311,7 +314,8 @@ test("asset config validation reports missing terrain variants and bad asset roo
     buildings: {
       recruitment_post: "/assets/buildings/recruitment-post.svg",
       attribute_shrine: "/assets/buildings/attribute-shrine.svg",
-      resource_mine: "/assets/buildings/resource-mine.svg"
+      resource_mine: "/assets/buildings/resource-mine.svg",
+      watchtower: "/assets/buildings/watchtower.svg"
     },
     units: {
       hero_guard_basic: {
@@ -401,7 +405,8 @@ test("asset config validation accepts prototype stage and open-source provenance
     buildings: {
       recruitment_post: "/assets/buildings/recruitment-post.png",
       attribute_shrine: "/assets/buildings/attribute-shrine.png",
-      resource_mine: "/assets/buildings/resource-mine.png"
+      resource_mine: "/assets/buildings/resource-mine.png",
+      watchtower: "/assets/buildings/watchtower.png"
     },
     heroes: {
       hero_knight: {
@@ -498,6 +503,11 @@ test("asset config validation accepts prototype stage and open-source provenance
       },
       "/assets/buildings/resource-mine.png": {
         slot: "building.resource_mine",
+        stage: "prototype",
+        source: "open-source"
+      },
+      "/assets/buildings/watchtower.png": {
+        slot: "building.watchtower",
         stage: "prototype",
         source: "open-source"
       },
@@ -760,7 +770,8 @@ test("asset config validation reports missing metadata coverage", () => {
     buildings: {
       recruitment_post: "/assets/pixel/buildings/recruitment-post.png",
       attribute_shrine: "/assets/pixel/buildings/attribute-shrine.png",
-      resource_mine: "/assets/pixel/buildings/resource-mine.png"
+      resource_mine: "/assets/pixel/buildings/resource-mine.png",
+      watchtower: "/assets/pixel/buildings/watchtower.png"
     },
     heroes: {
       hero_guard_basic: {
@@ -826,6 +837,7 @@ test("asset config validation reports missing metadata coverage", () => {
   });
 
   assert.ok(errors.includes("metadata[/assets/pixel/terrain/fog-tile.png] is missing for referenced asset path"));
+  assert.ok(errors.includes("metadata[/assets/pixel/buildings/watchtower.png] is missing for referenced asset path"));
 });
 
 test("achievement helpers unlock milestones and preserve catalog order", () => {
@@ -2207,6 +2219,20 @@ test("createWorldStateFromConfigs produces a valid frontier basin world", () => 
   }
 });
 
+test("createInitialWorldState selects the contested basin variant with the new content pack", () => {
+  const state = createInitialWorldState(1001, "preview-contested[map:contested_basin]");
+
+  assert.equal(state.meta.mapVariantId, "contested_basin");
+  assert.equal(state.heroes[0]?.position.x, 1);
+  assert.equal(state.heroes[0]?.position.y, 2);
+  assert.equal(state.buildings["watchtower-basin-1"]?.kind, "watchtower");
+  assert.equal(state.buildings["watchtower-basin-1"]?.visionBonus, 2);
+  assert.equal(state.neutralArmies["neutral-reed-patrol"]?.behavior?.mode, "patrol");
+  assert.equal(state.neutralArmies["neutral-watch-guard"]?.behavior?.mode, "guard");
+  assert.equal(state.neutralArmies["neutral-watch-guard"]?.stacks[0]?.templateId, "iron_walker");
+  assert.equal(state.neutralArmies["neutral-reed-patrol"]?.stacks[0]?.templateId, "moss_stalker");
+});
+
 test("frontier basin generates a distinct layout from the default phase1 variant", () => {
   const seed = 5124;
   const defaultRoomId = "preview-default";
@@ -2251,6 +2277,20 @@ test("frontier basin configs validate alongside the default configs", () => {
   assert.doesNotThrow(() => {
     validateMapObjectsConfig(defaultMapObjects, defaultWorld, units);
     validateMapObjectsConfig(frontierMapObjects, frontierWorld, units);
+  });
+});
+
+test("contested basin configs validate alongside the existing variants", () => {
+  const units = getDefaultUnitCatalog();
+  const contestedWorld = contestedBasinWorldConfig as WorldGenerationConfig;
+  const contestedMapObjects = contestedBasinMapObjectsConfig as MapObjectsConfig;
+  const bundle = getRuntimeConfigBundleForRoom("preview-contested[map:contested_basin]", 5124);
+
+  assert.equal(bundle.mapVariantId, CONTESTED_BASIN_MAP_VARIANT_ID);
+
+  assert.doesNotThrow(() => {
+    validateWorldConfig(contestedWorld);
+    validateMapObjectsConfig(contestedMapObjects, contestedWorld, units);
   });
 });
 
@@ -3204,6 +3244,82 @@ test("resolveWorldAction visits an attribute shrine once, grants permanent stats
   assert.equal(nextDayOutcome.state.buildings["shrine-1"]?.lastUsedDay, 1);
   assert.equal(nextDayOutcome.state.heroes[0]?.stats.attack, 3);
   assert.equal(nextDayOutcome.state.heroes[0]?.stats.power, 2);
+});
+
+test("resolveWorldAction visits a watchtower once, grants permanent vision, and keeps it after day advance", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 1, y: 1 }
+  });
+  const state = createWorldState({
+    width: 2,
+    height: 2,
+    heroes: [hero],
+    buildings: {
+      "tower-1": {
+        id: "tower-1",
+        kind: "watchtower",
+        position: { x: 1, y: 1 },
+        label: "回声瞭望塔",
+        visionBonus: 2,
+        lastUsedDay: undefined
+      }
+    },
+    tiles: [
+      createTile(0, 0),
+      createTile(1, 0),
+      createTile(0, 1),
+      createTile(1, 1, {
+        occupant: { kind: "hero", refId: "hero-1" },
+        building: {
+          id: "tower-1",
+          kind: "watchtower",
+          position: { x: 1, y: 1 },
+          label: "回声瞭望塔",
+          visionBonus: 2,
+          lastUsedDay: undefined
+        }
+      })
+    ],
+    visibilityByPlayer: {
+      "player-1": ["visible", "visible", "visible", "visible"]
+    }
+  });
+
+  const visitOutcome = resolveWorldAction(state, {
+    type: "hero.visit",
+    heroId: "hero-1",
+    buildingId: "tower-1"
+  });
+
+  assert.equal(visitOutcome.state.heroes[0]?.vision, 4);
+  assert.equal(visitOutcome.state.buildings["tower-1"]?.lastUsedDay, 1);
+  assert.deepEqual(visitOutcome.events, [
+    {
+      type: "hero.visited",
+      heroId: "hero-1",
+      buildingId: "tower-1",
+      buildingKind: "watchtower",
+      visionBonus: 2
+    }
+  ]);
+
+  assert.equal(
+    predictPlayerWorldAction(createPlayerWorldView(state, "player-1"), {
+      type: "hero.visit",
+      heroId: "hero-1",
+      buildingId: "tower-1"
+    }).world.ownHeroes[0]?.vision,
+    4
+  );
+
+  const nextDayOutcome = resolveWorldAction(visitOutcome.state, {
+    type: "turn.endDay"
+  });
+
+  assert.equal(nextDayOutcome.state.heroes[0]?.vision, 4);
 });
 
 test("resolveWorldAction harvests a resource mine immediately and unlocks it again on the next day", () => {

--- a/scripts/stress-concurrent-rooms.ts
+++ b/scripts/stress-concurrent-rooms.ts
@@ -129,6 +129,7 @@ interface RuntimeHealthSummary {
 const DEFAULT_BATTLE_DESTINATION: Vec2 = { x: 5, y: 4 };
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_ROOM_PLAYER_ID = "player-1";
+const STRESS_ROOM_VARIANTS = ["phase1", "frontier_basin", "contested_basin"] as const;
 const COLYSEUS_RECONNECT_MIN_UPTIME_LOG = "[Colyseus reconnection]: ❌ Room has not been up for long enough for automatic reconnection.";
 const DEFAULT_RECONNECT_SOAK_ARTIFACT_PATH = path.resolve("artifacts", "release-readiness", "colyseus-reconnect-soak-summary.json");
 
@@ -497,7 +498,8 @@ async function connectRooms(
 ): Promise<{ contexts: RoomContext[]; completedActions: number }> {
   const indexes = Array.from({ length: options.rooms }, (_, index) => index);
   const contexts = await mapConcurrent(indexes, options.connectConcurrency, async (index) => {
-    const roomId = `stress-${scenario}-${index}`;
+    const variant = STRESS_ROOM_VARIANTS[index % STRESS_ROOM_VARIANTS.length] ?? "phase1";
+    const roomId = `stress-${scenario}-${index}[map:${variant}]`;
     const room = await joinRoomWithRetry(options.host, options.port, roomId, DEFAULT_ROOM_PLAYER_ID);
     const response = await sendRequest(
       room,


### PR DESCRIPTION
Closes #297

## Summary
- add the contested basin layout and map-object config as a second playable map variant
- expand the neutral/content pack with new patrol and guard archetypes, new units, and supporting battle skills
- add watchtower building support across shared/server/H5/Cocos flows, including config-center preview/presets and hero vision persistence

## Testing
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `npm run typecheck:client:h5`
- `npm run typecheck:cocos`
- `npm run validate:assets`
- `npm run validate:battle -- --count=500 --scenario=all`
- `npm run build:client:h5`
- `npm test`