### PR TITLE
feat(config): add cross-file content-pack consistency validation and config-center surfacing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck:ci
 
+      - name: Validate content-pack consistency
+        run: npm run validate:content-pack -- --report-path "${RUNNER_TEMP}/content-pack-validation-report.json"
+
       - name: Test With V8 Coverage
         run: npm run test:coverage:ci
 
@@ -66,6 +69,14 @@ jobs:
         with:
           name: v8-coverage-${{ github.sha }}
           path: .coverage
+          if-no-files-found: error
+
+      - name: Upload content-pack validation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: content-pack-validation-${{ github.sha }}
+          path: ${{ runner.temp }}/content-pack-validation-report.json
           if-no-files-found: error
 
   wechat-build-validation:

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ npm run dev:client:h5
 - 并发房间压测：`npm run stress:rooms -- --rooms=120 --connect-concurrency=24 --action-concurrency=24`
 - 并发房间压测启动后，也可直接查看同进程观测面：`/api/runtime/health`、`/api/runtime/auth-readiness` 与 `/api/runtime/metrics`
 - 战斗平衡验证：`npm run validate:battle -- --count=1000 --scenario=all --skill-config=configs/battle-skills-v1.1.json`
+- 内容包一致性验证：`npm run validate:content-pack -- --report-path artifacts/content-pack-validation-report.json`
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
 - 微信小游戏构建 / 发布 / 回滚说明：`docs/wechat-minigame-release.md`
@@ -192,7 +193,7 @@ npm run dev:client:h5
   - 未配置 MySQL 时走文件系统存储；配置 `VEIL_MYSQL_*` 后切换到 MySQL 主存储
   - 保存后会同时导出到 `configs/*.json`，并同步刷新服务端运行时配置，新建房间和战斗逻辑会直接读取新值
   - 当前已补上版本快照、快照差异对比、历史回滚，以及 Easy / Normal / Hard 三档内置预设和自定义预设保存
-  - 实时校验现已带出对应配置 schema 摘要、必填根字段和逐项修复建议；非法值会阻止保存
+  - 实时校验现已带出对应配置 schema 摘要、必填根字段、逐项修复建议，以及跨 `world / mapObjects / units / battleSkills / battleBalance` 的 content-pack 一致性结果；非法值会阻止保存
   - 导出除 JSON 注释版外，还支持带 `Meta / Schema / Fields` 工作表的 Excel，以及更轻量的字段清单 CSV
   - 当前编辑 `phase1-world.json` 时，右侧会即时生成一份地图样本预览；可切换预览 seed，对照查看地形、随机资源、保底资源、英雄与中立怪分布
   - 当前编辑 `battle-skills.json` 时，右侧会显示技能编辑器，可直接调整冷却、伤害倍率、目标类型、附加状态和状态持续参数，并同步回写 JSON 草稿
@@ -245,6 +246,7 @@ npm run dev:client:h5
 - `units.json` 现已补上 `faction / rarity` 元数据，前端会自动挂载阵营与品质 badge，占位资源层已经具备继续细化正式 UI 的结构。
 - `battle-skills.json` 现已承载战斗技能与持续状态目录，shared 战斗结算会在创建战斗和执行技能时直接读取运行时配置，不再依赖硬编码技能表。
 - `battle-balance.json` 现已接入配置中心：支持可视化编辑伤害公式、遭遇战环境和 PVP ELO 参数，保存后会联动导出 JSON 并直接刷新 shared/runtime 读取链路；实时校验还会检查阈值范围以及陷阱状态是否与 `battle-skills.json` 对齐。
+- `docs/release-evidence/content-pack-validation-report.example.json` 提供了一份 bundle-level 内容包校验样例，可直接对照 CI 产出的同结构 report 做 release review。
 - 当前示例技能已包含 `投矛射击 / 护甲术 / 战意激发 / 破甲投枪 / 毒牙 / 裂伤嚎叫`，并补充了 `守誓姿态` 模板；守军自动回合也会根据技能目标和效果优先选择施法，而不是固定平砍。
 - 英雄长期成长现已补上技能树：`hero.progressed` 在升级时会发放技能点，H5 英雄卡会直接显示分支、当前阶数和“学习 / 强化”按钮；已学技能会写入英雄长期档，并在下一场战斗里额外挂到英雄部队技能栏。
 - 地图对象也已拆出独立视觉元数据配置，悬停地图时会通过统一对象卡片展示 `interactionType / faction / rarity` 等信息。

--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -17,6 +17,7 @@ interface ConfigDocument extends ConfigDocumentSummary {
 }
 
 interface ValidationIssue {
+  documentId?: ConfigDocumentId;
   path: string;
   severity: "error" | "warning";
   message: string;
@@ -37,6 +38,14 @@ interface ValidationReport {
   summary: string;
   issues: ValidationIssue[];
   schema: ConfigSchemaSummary;
+  contentPack: {
+    schemaVersion: 1;
+    valid: boolean;
+    summary: string;
+    issueCount: number;
+    checkedDocuments: ConfigDocumentId[];
+    issues: ValidationIssue[];
+  };
 }
 
 interface ConfigSnapshotSummary {
@@ -255,6 +264,15 @@ const EMPTY_SCHEMA_SUMMARY: ConfigSchemaSummary = {
   version: "0",
   description: "Schema 信息暂不可用。",
   required: []
+};
+
+const EMPTY_CONTENT_PACK_REPORT: ValidationReport["contentPack"] = {
+  schemaVersion: 1,
+  valid: true,
+  summary: "Content-pack consistency information is not available yet.",
+  issueCount: 0,
+  checkedDocuments: ["world", "mapObjects", "units", "battleSkills", "battleBalance"],
+  issues: []
 };
 
 function encodeBase64(buffer: ArrayBuffer): string {
@@ -604,7 +622,8 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
               suggestion: "检查 JSON 语法和字段格式后重试。"
             }
           ],
-          schema: state.validation?.schema ?? EMPTY_SCHEMA_SUMMARY
+          schema: state.validation?.schema ?? EMPTY_SCHEMA_SUMMARY,
+          contentPack: state.validation?.contentPack ?? EMPTY_CONTENT_PACK_REPORT
         };
       } finally {
         if (requestVersion === validationRequestVersion) {

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -77,6 +77,7 @@ interface ConfigDocument extends ConfigDocumentSummary {
 }
 
 interface ValidationIssue {
+  documentId?: ConfigDocumentId;
   path: string;
   severity: "error" | "warning";
   message: string;
@@ -89,6 +90,14 @@ interface ValidationReport {
   summary: string;
   issues: ValidationIssue[];
   schema: ConfigSchemaSummary;
+  contentPack: {
+    schemaVersion: 1;
+    valid: boolean;
+    summary: string;
+    issueCount: number;
+    checkedDocuments: ConfigDocumentId[];
+    issues: ValidationIssue[];
+  };
 }
 
 interface ConfigSchemaSummary {
@@ -1028,6 +1037,42 @@ function renderValidationSection(): string {
   }
 
   const validation = state.validation;
+  const renderSchemaIssues = (issues: ValidationIssue[]) =>
+    issues.length > 0
+      ? `
+        <div class="validation-list">
+          ${issues
+            .map(
+              (issue, index) => `
+                <button class="validation-item" data-action="validation-jump" data-index="${index}">
+                  <strong>${escapeHtml(issue.path)}</strong>
+                  <span>${escapeHtml(issue.message)}</span>
+                  <small>${escapeHtml(issue.suggestion)}${issue.line ? ` · 第 ${issue.line} 行` : ""}</small>
+                </button>
+              `
+            )
+            .join("")}
+        </div>
+      `
+      : `<p class="config-hint">当前草稿满足 Schema / 运行时校验。</p>`;
+  const renderContentPackIssues = (issues: ValidationIssue[]) =>
+    issues.length > 0
+      ? `
+        <div class="validation-list">
+          ${issues
+            .map(
+              (issue) => `
+                <div class="validation-item">
+                  <strong>${escapeHtml(`${issue.documentId ?? state.current?.id ?? "config"}:${issue.path}`)}</strong>
+                  <span>${escapeHtml(issue.message)}</span>
+                  <small>${escapeHtml(issue.suggestion)}</small>
+                </div>
+              `
+            )
+            .join("")}
+        </div>
+      `
+      : `<p class="config-hint">当前草稿对应的内容包引用关系保持一致。</p>`;
   const content =
     state.validationLoading && !validation
       ? `<div class="world-preview-empty">正在进行 Schema 校验...</div>`
@@ -1044,31 +1089,20 @@ function renderValidationSection(): string {
             <small>${escapeHtml(validation.schema.id)} · v${escapeHtml(validation.schema.version)}</small>
             <small>必填根字段: ${escapeHtml(validation.schema.required.join(", ") || "无")}</small>
           </div>
-          ${
-            validation.issues.length > 0
-              ? `
-                <div class="validation-list">
-                  ${validation.issues
-                    .map(
-                      (issue, index) => `
-                        <button class="validation-item" data-action="validation-jump" data-index="${index}">
-                          <strong>${escapeHtml(issue.path)}</strong>
-                          <span>${escapeHtml(issue.message)}</span>
-                          <small>${escapeHtml(issue.suggestion)}${issue.line ? ` · 第 ${issue.line} 行` : ""}</small>
-                        </button>
-                      `
-                    )
-                    .join("")}
-                </div>
-              `
-              : `<p class="config-hint">当前草稿满足实时校验，保存时会继续经过服务端运行时校验。</p>`
-          }
+          <div class="schema-card">
+            <strong>内容包一致性</strong>
+            <span>${escapeHtml(validation.contentPack.summary)}</span>
+            <small>schema v${validation.contentPack.schemaVersion} · ${validation.contentPack.checkedDocuments.length} 个配置面</small>
+            <small>${escapeHtml(validation.contentPack.checkedDocuments.join(" / "))}</small>
+          </div>
+          ${renderSchemaIssues(validation.issues)}
+          ${renderContentPackIssues(validation.contentPack.issues)}
         `;
 
   return `
     <section class="validation-section">
       <div class="config-preview-subhead">
-        <h4>Schema 校验</h4>
+        <h4>配置校验</h4>
         <span class="config-meta">${validation?.valid ? "可提交" : "保存前需修复"}</span>
       </div>
       ${content}

--- a/apps/client/test/config-center.test.ts
+++ b/apps/client/test/config-center.test.ts
@@ -44,6 +44,24 @@ function createValidationReport(valid = true) {
       version: "1",
       description: "World config schema",
       required: ["width", "height"]
+    },
+    contentPack: {
+      schemaVersion: 1 as const,
+      valid,
+      summary: valid ? "Content-pack consistency passed" : "Found content-pack issues",
+      issueCount: valid ? 0 : 1,
+      checkedDocuments: ["world", "mapObjects", "units", "battleSkills", "battleBalance"] as const,
+      issues: valid
+        ? []
+        : [
+            {
+              documentId: "world" as const,
+              path: "heroes[0].armyTemplateId",
+              severity: "error" as const,
+              message: "missing unit template",
+              suggestion: "修正跨文件引用后重试。"
+            }
+          ]
     }
   };
 }

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -10,6 +10,7 @@ import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.j
 import {
   getBattleBalanceConfig,
   createWorldStateFromConfigs,
+  validateContentPackConsistency,
   getDefaultBattleBalanceConfig,
   getDefaultBattleSkillCatalog,
   getDefaultMapObjectsConfig,
@@ -21,6 +22,7 @@ import {
   validateMapObjectsConfig,
   validateUnitCatalog,
   validateWorldConfig,
+  type ContentPackValidationReport,
   type BattleBalanceConfig,
   type BattleSkillCatalogConfig,
   type MapObjectsConfig,
@@ -84,6 +86,7 @@ export interface ConfigDocument extends ConfigDocumentSummary {
 }
 
 export interface ValidationIssue {
+  documentId?: ConfigDocumentId;
   path: string;
   severity: "error" | "warning";
   message: string;
@@ -96,6 +99,7 @@ export interface ValidationReport {
   summary: string;
   issues: ValidationIssue[];
   schema: ConfigSchemaSummary;
+  contentPack: ContentPackValidationReport;
 }
 
 export interface ConfigSchemaSummary {
@@ -1959,16 +1963,31 @@ function buildValidationReportFromError(id: ConfigDocumentId, error: Error, cont
         ...(line != null ? { line } : {})
       }
     ],
-    schema
+    schema,
+    contentPack: {
+      schemaVersion: 1,
+      valid: false,
+      summary: "Content-pack consistency was not evaluated because the current document could not be parsed.",
+      issueCount: 0,
+      checkedDocuments: ["world", "mapObjects", "units", "battleSkills", "battleBalance"],
+      issues: []
+    }
   };
 }
 
-function summarizeIssues(issues: ValidationIssue[]): string {
-  if (issues.length === 0) {
-    return "Schema 校验通过，可以保存并立即生效。";
+function summarizeIssues(issues: ValidationIssue[], contentPack: ContentPackValidationReport): string {
+  if (issues.length === 0 && contentPack.issueCount === 0) {
+    return "Schema 与内容包一致性校验通过，可以保存并立即生效。";
   }
 
-  return `发现 ${issues.length} 个配置问题，需要先修复再保存。`;
+  const parts: string[] = [];
+  if (issues.length > 0) {
+    parts.push(`${issues.length} 个当前文档问题`);
+  }
+  if (contentPack.issueCount > 0) {
+    parts.push(`${contentPack.issueCount} 个内容包一致性问题`);
+  }
+  return `发现 ${parts.join("，")}，需要先修复再保存。`;
 }
 
 function validateWorldConfigDetailed(config: WorldGenerationConfig): ValidationIssue[] {
@@ -2261,6 +2280,36 @@ function validateBattleBalanceDetailed(
   return issues;
 }
 
+function buildCandidateRuntimeBundle(
+  id: ConfigDocumentId,
+  parsed: ParsedConfigDocument,
+  dependencies: {
+    world: WorldGenerationConfig;
+    mapObjects: MapObjectsConfig;
+    units: UnitCatalogConfig;
+    battleSkills: BattleSkillCatalogConfig;
+    battleBalance: BattleBalanceConfig;
+  }
+): RuntimeConfigBundle {
+  return {
+    world: id === "world" ? (parsed as WorldGenerationConfig) : dependencies.world,
+    mapObjects: id === "mapObjects" ? (parsed as MapObjectsConfig) : dependencies.mapObjects,
+    units: id === "units" ? (parsed as UnitCatalogConfig) : dependencies.units,
+    battleSkills: id === "battleSkills" ? (parsed as BattleSkillCatalogConfig) : dependencies.battleSkills,
+    battleBalance: id === "battleBalance" ? (parsed as BattleBalanceConfig) : dependencies.battleBalance
+  };
+}
+
+function mapContentPackIssuesToValidationIssues(report: ContentPackValidationReport): ValidationIssue[] {
+  return report.issues.map((issue) => ({
+    documentId: issue.documentId,
+    path: issue.path,
+    severity: issue.severity,
+    message: issue.message,
+    suggestion: issue.suggestion
+  }));
+}
+
 async function validateDocumentDetailed(
   store: Pick<ConfigCenterStore, "loadDocument">,
   id: ConfigDocumentId,
@@ -2269,6 +2318,14 @@ async function validateDocumentDetailed(
   try {
     const parsed = JSON.parse(content) as ParsedConfigDocument;
     const issues: ValidationIssue[] = [];
+    let contentPack: ContentPackValidationReport = {
+      schemaVersion: 1,
+      valid: true,
+      summary: "Content-pack consistency checks are pending.",
+      issueCount: 0,
+      checkedDocuments: ["world", "mapObjects", "units", "battleSkills", "battleBalance"],
+      issues: []
+    };
     validateSchemaNode(parsed, CONFIG_DOCUMENT_SCHEMAS[id], "", issues);
     try {
       const dependencies = await loadValidationDependencies(store, id);
@@ -2288,11 +2345,12 @@ async function validateDocumentDetailed(
                 )
               : id === "battleSkills"
                 ? validateBattleSkillsDetailed(parsed as BattleSkillCatalogConfig)
-                : validateBattleBalanceDetailed(
-                    parsed as BattleBalanceConfig,
-                    dependencies.battleSkills
-                  );
+              : validateBattleBalanceDetailed(
+                  parsed as BattleBalanceConfig,
+                  dependencies.battleSkills
+                );
       issues.push(...semanticIssues);
+      contentPack = validateContentPackConsistency(buildCandidateRuntimeBundle(id, parsed, dependencies));
     } catch {
       // Schema issues above already explain malformed structures; skip dependent semantic checks.
     }
@@ -2310,10 +2368,11 @@ async function validateDocumentDetailed(
     }
 
     return {
-      valid: issues.length === 0,
-      summary: summarizeIssues(issues),
+      valid: issues.length === 0 && contentPack.valid,
+      summary: summarizeIssues(issues, contentPack),
       issues,
-      schema: buildSchemaSummary(id)
+      schema: buildSchemaSummary(id),
+      contentPack
     };
   } catch (error) {
     return buildValidationReportFromError(id, error as Error, content);

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -393,6 +393,7 @@ test("config center can validate invalid world config with structured issues", a
   assert.match(report.issues.map((issue) => issue.path).join(","), /width|heroes\[0\]\.position\.x/);
   assert.equal(report.schema.id, "project-veil.config-center.world");
   assert.match(report.schema.version, /\d{4}-\d{2}-\d{2}/);
+  assert.equal(report.contentPack.valid, true);
 });
 
 test("config center schema validation reports missing and mistyped fields", async () => {
@@ -444,6 +445,38 @@ test("config center validates battle balance against thresholds and status refer
     /environment\.trapSpawnThreshold|environment\.trapGrantedStatusId/
   );
   assert.equal(report.schema.id, "project-veil.config-center.battleBalance");
+  assert.equal(report.contentPack.valid, false);
+  assert.match(
+    report.contentPack.issues.map((issue) => `${issue.documentId}:${issue.path}`).join(","),
+    /battleBalance:environment\.trapGrantedStatusId/
+  );
+});
+
+test("config center validation exposes content-pack issues from other config files", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  const report = await store.validateDocument(
+    "world",
+    JSON.stringify({
+      ...WORLD_CONFIG,
+      heroes: [
+        {
+          ...WORLD_CONFIG.heroes[0],
+          armyTemplateId: "missing_template"
+        }
+      ]
+    })
+  );
+
+  assert.equal(report.valid, false);
+  assert.equal(report.issues.length, 0);
+  assert.equal(report.contentPack.valid, false);
+  assert.match(
+    report.contentPack.issues.map((issue) => `${issue.documentId}:${issue.path}`).join(","),
+    /world:heroes\[0\]\.armyTemplateId/
+  );
 });
 
 test("config center snapshots support diff and rollback", async () => {

--- a/docs/release-evidence/content-pack-validation-report.example.json
+++ b/docs/release-evidence/content-pack-validation-report.example.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-03-29T12:48:16.045Z",
+  "rootDir": "configs",
+  "valid": true,
+  "documentValidation": {
+    "valid": true,
+    "issueCount": 0,
+    "issues": []
+  },
+  "contentPack": {
+    "valid": true,
+    "issueCount": 0,
+    "summary": "Content-pack consistency passed across world, map objects, units, battle skills, and battle balance.",
+    "issues": []
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "demo:flow": "node --import tsx ./scripts/demo.ts",
     "validate:quickstart": "node ./scripts/validate-local-dev-quickstart.mjs",
     "validate:e2e:fixtures": "node --import tsx ./scripts/validate-e2e-config-fixtures.ts",
+    "validate:content-pack": "node --import tsx ./scripts/validate-content-pack.ts",
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
     "stress:rooms:reconnect-soak": "node --import tsx ./scripts/stress-concurrent-rooms.ts --scenarios=reconnect_soak --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --reconnect-cycles=8",
     "validate:battle": "node --import tsx ./scripts/validate-battle-balance.ts",

--- a/packages/shared/src/content-pack-validation.ts
+++ b/packages/shared/src/content-pack-validation.ts
@@ -1,0 +1,243 @@
+import type {
+  BattleBalanceConfig,
+  BattleSkillCatalogConfig,
+  MapObjectsConfig,
+  UnitCatalogConfig,
+  WorldGenerationConfig
+} from "./models.ts";
+import type { RuntimeConfigBundle } from "./world-config.ts";
+
+export type ContentPackDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
+
+export interface ContentPackValidationIssue {
+  documentId: ContentPackDocumentId;
+  path: string;
+  severity: "error" | "warning";
+  code: string;
+  message: string;
+  suggestion: string;
+}
+
+export interface ContentPackValidationReport {
+  schemaVersion: 1;
+  valid: boolean;
+  summary: string;
+  issueCount: number;
+  checkedDocuments: ContentPackDocumentId[];
+  issues: ContentPackValidationIssue[];
+}
+
+function pushIssue(
+  issues: ContentPackValidationIssue[],
+  issue: Omit<ContentPackValidationIssue, "severity"> & { severity?: "error" | "warning" }
+): void {
+  issues.push({
+    severity: issue.severity ?? "error",
+    ...issue
+  });
+}
+
+function positionKey(position: { x: number; y: number }): string {
+  return `${position.x},${position.y}`;
+}
+
+function validateWorldReferences(
+  world: WorldGenerationConfig,
+  units: UnitCatalogConfig,
+  issues: ContentPackValidationIssue[]
+): void {
+  const unitIds = new Set(units.templates.map((template) => template.id));
+  const heroIds = new Set<string>();
+  const occupiedPositions = new Map<string, string>();
+
+  world.heroes.forEach((hero, index) => {
+    if (heroIds.has(hero.id)) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: `heroes[${index}].id`,
+        code: "duplicate_hero_id",
+        message: `Hero id ${hero.id} is duplicated inside the content pack.`,
+        suggestion: "Assign a unique hero id before exporting the pack."
+      });
+    }
+    heroIds.add(hero.id);
+
+    if (!unitIds.has(hero.armyTemplateId)) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: `heroes[${index}].armyTemplateId`,
+        code: "unknown_hero_army_template",
+        message: `Hero ${hero.id} references missing unit template ${hero.armyTemplateId}.`,
+        suggestion: "Point the hero at a template from units.json or add the missing template."
+      });
+    }
+
+    const key = positionKey(hero.position);
+    const existing = occupiedPositions.get(key);
+    if (existing) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: `heroes[${index}].position`,
+        code: "overlapping_hero_position",
+        message: `Hero ${hero.id} overlaps ${existing} at ${key}.`,
+        suggestion: "Move the hero to a unique map position."
+      });
+      return;
+    }
+
+    occupiedPositions.set(key, `hero ${hero.id}`);
+  });
+}
+
+function validateMapObjectReferences(
+  world: WorldGenerationConfig,
+  mapObjects: MapObjectsConfig,
+  units: UnitCatalogConfig,
+  issues: ContentPackValidationIssue[]
+): void {
+  const unitIds = new Set(units.templates.map((template) => template.id));
+  const occupiedPositions = new Map<string, string>(
+    world.heroes.map((hero) => [positionKey(hero.position), `hero ${hero.id}`] as const)
+  );
+
+  mapObjects.neutralArmies.forEach((army, armyIndex) => {
+    army.stacks.forEach((stack, stackIndex) => {
+      if (!unitIds.has(stack.templateId)) {
+        pushIssue(issues, {
+          documentId: "mapObjects",
+          path: `neutralArmies[${armyIndex}].stacks[${stackIndex}].templateId`,
+          code: "unknown_neutral_unit_template",
+          message: `Neutral army ${army.id} references missing unit template ${stack.templateId}.`,
+          suggestion: "Use a template from units.json or add the missing template."
+        });
+      }
+    });
+
+    const key = positionKey(army.position);
+    const existing = occupiedPositions.get(key);
+    if (existing) {
+      pushIssue(issues, {
+        documentId: "mapObjects",
+        path: `neutralArmies[${armyIndex}].position`,
+        code: "overlapping_map_object_position",
+        message: `Neutral army ${army.id} overlaps ${existing} at ${key}.`,
+        suggestion: "Move the neutral army to an unused tile."
+      });
+    } else {
+      occupiedPositions.set(key, `neutral army ${army.id}`);
+    }
+  });
+
+  mapObjects.guaranteedResources.forEach((resource, index) => {
+    const key = positionKey(resource.position);
+    const existing = occupiedPositions.get(key);
+    if (existing) {
+      pushIssue(issues, {
+        documentId: "mapObjects",
+        path: `guaranteedResources[${index}].position`,
+        code: "overlapping_map_object_position",
+        message: `Guaranteed resource overlaps ${existing} at ${key}.`,
+        suggestion: "Move the resource node to an unused tile."
+      });
+    } else {
+      occupiedPositions.set(key, `guaranteed resource ${resource.resource.kind}`);
+    }
+  });
+
+  mapObjects.buildings.forEach((building, index) => {
+    if (building.kind === "recruitment_post" && !unitIds.has(building.unitTemplateId)) {
+      pushIssue(issues, {
+        documentId: "mapObjects",
+        path: `buildings[${index}].unitTemplateId`,
+        code: "unknown_recruitment_unit_template",
+        message: `Building ${building.id} references missing unit template ${building.unitTemplateId}.`,
+        suggestion: "Use a template from units.json or add the missing template."
+      });
+    }
+
+    const key = positionKey(building.position);
+    const existing = occupiedPositions.get(key);
+    if (existing) {
+      pushIssue(issues, {
+        documentId: "mapObjects",
+        path: `buildings[${index}].position`,
+        code: "overlapping_map_object_position",
+        message: `Building ${building.id} overlaps ${existing} at ${key}.`,
+        suggestion: "Move the building to an unused tile."
+      });
+    } else {
+      occupiedPositions.set(key, `building ${building.id}`);
+    }
+  });
+}
+
+function validateUnitSkillReferences(
+  units: UnitCatalogConfig,
+  battleSkills: BattleSkillCatalogConfig,
+  issues: ContentPackValidationIssue[]
+): void {
+  const skillIds = new Set(battleSkills.skills.map((skill) => skill.id));
+
+  units.templates.forEach((template, templateIndex) => {
+    for (const [skillIndex, skillId] of (template.battleSkills ?? []).entries()) {
+      if (!skillIds.has(skillId)) {
+        pushIssue(issues, {
+          documentId: "units",
+          path: `templates[${templateIndex}].battleSkills[${skillIndex}]`,
+          code: "unknown_unit_battle_skill",
+          message: `Unit template ${template.id} references missing battle skill ${skillId}.`,
+          suggestion: "Use a skill from battle-skills.json or add the missing skill."
+        });
+      }
+    }
+  });
+}
+
+function validateBattleBalanceReferences(
+  battleBalance: BattleBalanceConfig,
+  battleSkills: BattleSkillCatalogConfig,
+  issues: ContentPackValidationIssue[]
+): void {
+  if (!battleBalance.environment.trapGrantedStatusId) {
+    return;
+  }
+
+  const statusIds = new Set(battleSkills.statuses.map((status) => status.id));
+  if (!statusIds.has(battleBalance.environment.trapGrantedStatusId)) {
+    pushIssue(issues, {
+      documentId: "battleBalance",
+      path: "environment.trapGrantedStatusId",
+      code: "unknown_trap_status",
+      message: `Battle balance references missing status ${battleBalance.environment.trapGrantedStatusId}.`,
+      suggestion: "Use a status from battle-skills.json or add the missing status."
+    });
+  }
+}
+
+function buildSummary(issueCount: number): string {
+  if (issueCount === 0) {
+    return "Content-pack consistency passed across world, map objects, units, battle skills, and battle balance.";
+  }
+
+  return `Found ${issueCount} content-pack consistency issue(s) across the active config bundle.`;
+}
+
+export function validateContentPackConsistency(bundle: RuntimeConfigBundle): ContentPackValidationReport {
+  const issues: ContentPackValidationIssue[] = [];
+
+  validateWorldReferences(bundle.world, bundle.units, issues);
+  validateMapObjectReferences(bundle.world, bundle.mapObjects, bundle.units, issues);
+  validateUnitSkillReferences(bundle.units, bundle.battleSkills, issues);
+  if (bundle.battleBalance) {
+    validateBattleBalanceReferences(bundle.battleBalance, bundle.battleSkills, issues);
+  }
+
+  return {
+    schemaVersion: 1,
+    valid: issues.length === 0,
+    summary: buildSummary(issues.length),
+    issueCount: issues.length,
+    checkedDocuments: ["world", "mapObjects", "units", "battleSkills", "battleBalance"],
+    issues
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./auth-ui.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";
 export * from "./battle-replay.ts";
+export * from "./content-pack-validation.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";
 export * from "./feedback.ts";

--- a/packages/shared/test/content-pack-validation.test.ts
+++ b/packages/shared/test/content-pack-validation.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getBattleBalanceConfig,
+  getDefaultBattleSkillCatalog,
+  getDefaultMapObjectsConfig,
+  getDefaultUnitCatalog,
+  getDefaultWorldConfig,
+  validateContentPackConsistency
+} from "../src/index.ts";
+
+test("content-pack validation passes for the default runtime bundle", () => {
+  const report = validateContentPackConsistency({
+    world: getDefaultWorldConfig(),
+    mapObjects: getDefaultMapObjectsConfig(),
+    units: getDefaultUnitCatalog(),
+    battleSkills: getDefaultBattleSkillCatalog(),
+    battleBalance: getBattleBalanceConfig()
+  });
+
+  assert.equal(report.valid, true);
+  assert.equal(report.issueCount, 0);
+});
+
+test("content-pack validation reports broken cross-file references clearly", () => {
+  const world = getDefaultWorldConfig();
+  world.heroes[0] = {
+    ...world.heroes[0],
+    armyTemplateId: "missing_hero_template"
+  };
+
+  const mapObjects = getDefaultMapObjectsConfig();
+  mapObjects.neutralArmies[0] = {
+    ...mapObjects.neutralArmies[0],
+    stacks: [{ templateId: "missing_neutral_template", count: 4 }]
+  };
+
+  const units = getDefaultUnitCatalog();
+  units.templates[0] = {
+    ...units.templates[0],
+    battleSkills: ["missing_skill"]
+  };
+
+  const battleBalance = {
+    ...getBattleBalanceConfig(),
+    environment: {
+      ...getBattleBalanceConfig().environment,
+      trapGrantedStatusId: "missing_status"
+    }
+  };
+
+  const report = validateContentPackConsistency({
+    world,
+    mapObjects,
+    units,
+    battleSkills: getDefaultBattleSkillCatalog(),
+    battleBalance
+  });
+
+  assert.equal(report.valid, false);
+  assert.deepEqual(
+    report.issues.map((issue) => `${issue.documentId}:${issue.path}`),
+    [
+      "world:heroes[0].armyTemplateId",
+      "mapObjects:neutralArmies[0].stacks[0].templateId",
+      "units:templates[0].battleSkills[0]",
+      "battleBalance:environment.trapGrantedStatusId"
+    ]
+  );
+});

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -1,0 +1,175 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  getDefaultBattleBalanceConfig,
+  validateBattleBalanceConfig,
+  validateBattleSkillCatalog,
+  validateContentPackConsistency,
+  validateMapObjectsConfig,
+  validateUnitCatalog,
+  validateWorldConfig,
+  type BattleBalanceConfig,
+  type BattleSkillCatalogConfig,
+  type ContentPackDocumentId,
+  type ContentPackValidationIssue,
+  type MapObjectsConfig,
+  type RuntimeConfigBundle,
+  type UnitCatalogConfig,
+  type WorldGenerationConfig
+} from "../packages/shared/src/index.ts";
+
+interface DocumentDefinition {
+  id: ContentPackDocumentId;
+  fileName: string;
+}
+
+interface DocumentValidationIssue {
+  documentId: ContentPackDocumentId;
+  path: string;
+  message: string;
+}
+
+interface ContentPackCliReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  rootDir: string;
+  valid: boolean;
+  documentValidation: {
+    valid: boolean;
+    issueCount: number;
+    issues: DocumentValidationIssue[];
+  };
+  contentPack: {
+    valid: boolean;
+    issueCount: number;
+    summary: string;
+    issues: ContentPackValidationIssue[];
+  };
+}
+
+const DOCUMENTS: DocumentDefinition[] = [
+  { id: "world", fileName: "phase1-world.json" },
+  { id: "mapObjects", fileName: "phase1-map-objects.json" },
+  { id: "units", fileName: "units.json" },
+  { id: "battleSkills", fileName: "battle-skills.json" },
+  { id: "battleBalance", fileName: "battle-balance.json" }
+];
+
+function parseArgs(argv: string[]): { rootDir: string; reportPath: string | null } {
+  let rootDir = resolve(process.cwd(), "configs");
+  let reportPath: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--root-dir") {
+      rootDir = resolve(argv[index + 1] ?? rootDir);
+      index += 1;
+    } else if (arg === "--report-path") {
+      reportPath = resolve(argv[index + 1] ?? "");
+      index += 1;
+    }
+  }
+
+  return { rootDir, reportPath };
+}
+
+async function readJsonConfig<T>(rootDir: string, fileName: string): Promise<T> {
+  return JSON.parse(await readFile(resolve(rootDir, fileName), "utf8")) as T;
+}
+
+function validateDocuments(bundle: RuntimeConfigBundle): DocumentValidationIssue[] {
+  const issues: DocumentValidationIssue[] = [];
+
+  const capture = (documentId: ContentPackDocumentId, path: string, callback: () => void) => {
+    try {
+      callback();
+    } catch (error) {
+      issues.push({
+        documentId,
+        path,
+        message: error instanceof Error ? error.message : "Unknown validation error"
+      });
+    }
+  };
+
+  capture("world", "$", () => validateWorldConfig(bundle.world));
+  capture("units", "$", () => validateUnitCatalog(bundle.units, bundle.battleSkills));
+  capture("battleSkills", "$", () => validateBattleSkillCatalog(bundle.battleSkills));
+  capture("mapObjects", "$", () => validateMapObjectsConfig(bundle.mapObjects, bundle.world, bundle.units));
+  capture("battleBalance", "$", () =>
+    validateBattleBalanceConfig(bundle.battleBalance ?? getDefaultBattleBalanceConfig(), bundle.battleSkills)
+  );
+
+  return issues;
+}
+
+function printIssues(title: string, issues: Array<{ documentId: string; path: string; message: string }>): void {
+  if (issues.length === 0) {
+    console.log(`${title}: 0 issues`);
+    return;
+  }
+
+  console.log(`${title}: ${issues.length} issue(s)`);
+  for (const issue of issues) {
+    console.log(`- [${issue.documentId}] ${issue.path}: ${issue.message}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const { rootDir, reportPath } = parseArgs(process.argv.slice(2));
+  const [world, mapObjects, units, battleSkills, battleBalance] = await Promise.all([
+    readJsonConfig<WorldGenerationConfig>(rootDir, "phase1-world.json"),
+    readJsonConfig<MapObjectsConfig>(rootDir, "phase1-map-objects.json"),
+    readJsonConfig<UnitCatalogConfig>(rootDir, "units.json"),
+    readJsonConfig<BattleSkillCatalogConfig>(rootDir, "battle-skills.json"),
+    readJsonConfig<BattleBalanceConfig>(rootDir, "battle-balance.json")
+  ]);
+
+  const bundle: RuntimeConfigBundle = {
+    world,
+    mapObjects,
+    units,
+    battleSkills,
+    battleBalance
+  };
+
+  const documentIssues = validateDocuments(bundle);
+  const contentPack = validateContentPackConsistency(bundle);
+  const report: ContentPackCliReport = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    rootDir,
+    valid: documentIssues.length === 0 && contentPack.valid,
+    documentValidation: {
+      valid: documentIssues.length === 0,
+      issueCount: documentIssues.length,
+      issues: documentIssues
+    },
+    contentPack: {
+      valid: contentPack.valid,
+      issueCount: contentPack.issueCount,
+      summary: contentPack.summary,
+      issues: contentPack.issues
+    }
+  };
+
+  console.log("Project Veil content-pack validation");
+  console.log(`Root: ${rootDir}`);
+  console.log(`Result: ${report.valid ? "PASS" : "FAIL"}`);
+  printIssues("Per-document validation", report.documentValidation.issues);
+  printIssues("Content-pack consistency", report.contentPack.issues);
+
+  if (reportPath) {
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    console.log(`Report written to ${reportPath}`);
+  }
+
+  if (!report.valid) {
+    process.exitCode = 1;
+  }
+}
+
+void main().catch((error) => {
+  console.error(`Content-pack validation failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Closes #308

## Summary
- add a shared content-pack consistency validator and CLI/report generator for the active config bundle
- surface content-pack validation results in the config center alongside document-level schema/runtime validation
- fail CI on content-pack regressions and include a sample report under docs/release-evidence

## Test
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:client:h5
- node --import tsx --test packages/shared/test/content-pack-validation.test.ts
- node --import tsx --test apps/server/test/config-center.test.ts
- node --import tsx --test apps/client/test/config-center.test.ts
- npm run validate:content-pack -- --report-path /tmp/project-veil-content-pack-report.json