### PR TITLE
feat(release): add packaged client RC smoke validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,41 @@ jobs:
       - name: Verify downloaded WeChat release artifact
         run: npm run verify:wechat-release -- --artifacts-dir "${RUNNER_TEMP}/wechat-release-downloaded" --expected-revision "${GITHUB_SHA}"
 
+  client-release-candidate-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Run packaged client RC smoke
+        run: npm run smoke:client:release-candidate -- --output "${RUNNER_TEMP}/release-readiness/client-release-candidate-smoke-${GITHUB_SHA}.json"
+
+      - name: Upload packaged client RC smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: client-release-candidate-smoke-${{ github.sha }}
+          path: ${{ runner.temp }}/release-readiness
+          if-no-files-found: error
+
   wechat-release-upload:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs:
       - wechat-build-validation
       - wechat-release-artifact-smoke
+      - client-release-candidate-smoke
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.upload == 'true') ||
       startsWith(github.ref, 'refs/tags/wechat-release-')

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ npm run dev:client:h5
 - 微信小游戏模板刷新：`npm run prepare:wechat-build`
 - 微信小游戏 CI 同款校验：`npm run check:wechat-build`
 - 发布就绪快照：`npm run release:readiness:snapshot`
+- 打包 H5 客户端 RC 冒烟：`npm run smoke:client:release-candidate`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - Issue #33 开源素材 staging 校验：`npm run check:issue33-assets -- --require-pack`
@@ -155,6 +156,7 @@ npm run dev:client:h5
   `window.export_diagnostic_snapshot()` 返回稳定 JSON；
   `window.render_diagnostic_snapshot_to_text()` 返回与面板一致的紧凑文本摘要，便于自动化留档
 - H5 / Lobby Playwright 冒烟：`npm run test:e2e:smoke`
+- 打包 H5 客户端 RC 冒烟会把结构化结果写入 `artifacts/release-readiness/`
 - 多人联机 Playwright 冒烟：`npm run test:e2e:multiplayer:smoke`
 - GitHub Actions `playwright-smoke` 会执行上述两条冒烟回归，并在失败时上传 Playwright trace / screenshot / video 诊断材料
 - MySQL 首次初始化 / 升级：`npm run db:migrate`

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -3,6 +3,16 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   root: resolve(__dirname),
+  preview: {
+    host: "127.0.0.1",
+    port: 4173,
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:2567",
+        changeOrigin: true
+      }
+    }
+  },
   server: {
     host: "0.0.0.0",
     port: 4173,

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -12,6 +12,14 @@ The default automated checks are:
 - `npm run test:e2e:multiplayer:smoke`
 - `npm run check:wechat-build`
 
+For packaged H5 release-candidate validation, run:
+
+```bash
+npm run smoke:client:release-candidate
+```
+
+That flow rebuilds `apps/client/dist`, serves the packaged artifact instead of the dev shell, exercises guest login plus cached-session room boot, and writes machine-readable evidence under `artifacts/release-readiness/`. Pass `--output <path>` when CI or a reviewer needs a stable artifact filename.
+
 The snapshot also supports manual gates, so the same file can carry pending or completed human checks such as runtime endpoint review, reconnect evidence, device smoke acceptance, or RC blocker review.
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:e2e:multiplayer": "npm run validate:e2e:fixtures && playwright test --config=playwright.multiplayer.config.ts",
     "test:e2e:multiplayer:smoke": "npm run validate:e2e:fixtures && playwright test --config=playwright.multiplayer.smoke.config.ts",
     "test:e2e:multiplayer:headed": "npm run validate:e2e:fixtures && playwright test --config=playwright.multiplayer.config.ts --headed",
+    "smoke:client:release-candidate": "node --import tsx ./scripts/release-candidate-client-artifact-smoke.ts",
     "test:shared": "node --import tsx --test \"packages/shared/test/**/*.test.ts\"",
     "typecheck:ci": "npm run typecheck:shared && npm run typecheck:server && npm run typecheck:client:h5 && npm run typecheck:cocos",
     "typecheck": "tsc -p tsconfig.base.json --noEmit",

--- a/playwright.release-candidate-artifact-smoke.config.ts
+++ b/playwright.release-candidate-artifact-smoke.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: /release-candidate-artifact-smoke\.spec\.ts/,
+  timeout: 30_000,
+  fullyParallel: false,
+  workers: 1,
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    headless: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure"
+  },
+  webServer: [
+    {
+      command: "npm run dev:server",
+      port: 2567,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      gracefulShutdown: {
+        signal: "SIGTERM",
+        timeout: 5_000
+      }
+    },
+    {
+      command: "npx vite preview --config apps/client/vite.config.ts --host 127.0.0.1 --port 4173 --strictPort",
+      port: 4173,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      gracefulShutdown: {
+        signal: "SIGTERM",
+        timeout: 5_000
+      }
+    }
+  ]
+});

--- a/scripts/release-candidate-client-artifact-smoke.ts
+++ b/scripts/release-candidate-client-artifact-smoke.ts
@@ -1,0 +1,327 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+type CaseStatus = "passed" | "failed" | "skipped";
+type ExecutionStatus = "passed" | "failed";
+
+interface Args {
+  outputPath?: string;
+  clientArtifactDir?: string;
+}
+
+interface PlaywrightJsonReport {
+  stats?: {
+    expected?: number;
+    skipped?: number;
+    unexpected?: number;
+    flaky?: number;
+    duration?: number;
+  };
+  suites?: PlaywrightSuite[];
+}
+
+interface PlaywrightSuite {
+  title?: string;
+  suites?: PlaywrightSuite[];
+  specs?: PlaywrightSpec[];
+}
+
+interface PlaywrightSpec {
+  title?: string;
+  ok?: boolean;
+  tests?: PlaywrightTest[];
+}
+
+interface PlaywrightTest {
+  projectName?: string;
+  results?: Array<{
+    status?: string;
+    duration?: number;
+  }>;
+}
+
+interface CollectedTestCase {
+  id: string;
+  title: string;
+  projectName: string;
+  status: CaseStatus;
+  durationMs: number;
+}
+
+interface ReleaseCandidateClientArtifactSmokeReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  revision: {
+    commit: string;
+    shortCommit: string;
+    branch: string;
+    dirty: boolean;
+  };
+  artifact: {
+    kind: "apps/client/dist";
+    path: string;
+    buildCommand: string;
+    smokeCommand: string;
+  };
+  execution: {
+    status: ExecutionStatus;
+    exitCode: number;
+    startedAt: string;
+    finishedAt: string;
+    durationMs: number;
+    stdoutTail?: string;
+    stderrTail?: string;
+    rawPlaywrightReportPath: string;
+  };
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    skipped: number;
+    flaky: number;
+  };
+  cases: CollectedTestCase[];
+}
+
+const BUILD_COMMAND = "npm run build:client:h5";
+const FIXTURE_COMMAND = "npm run validate:e2e:fixtures";
+const PLAYWRIGHT_COMMAND = "npx playwright test --config=playwright.release-candidate-artifact-smoke.config.ts --reporter=json";
+const OUTPUT_TAIL_BYTES = 4000;
+const REQUIRED_CASE_TITLES = [
+  "rc-artifact: guest login reaches lobby and room boot",
+  "rc-artifact: cached session restore reaches room boot"
+] as const;
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let outputPath: string | undefined;
+  let clientArtifactDir: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--client-artifact-dir" && next) {
+      clientArtifactDir = next;
+      index += 1;
+      continue;
+    }
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    ...(outputPath ? { outputPath } : {}),
+    ...(clientArtifactDir ? { clientArtifactDir } : {})
+  };
+}
+
+function tailText(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.length > OUTPUT_TAIL_BYTES ? normalized.slice(-OUTPUT_TAIL_BYTES) : normalized;
+}
+
+function readGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function runCommand(command: string): void {
+  const result = spawnSync(command, {
+    cwd: process.cwd(),
+    shell: true,
+    stdio: "inherit",
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`${command} failed with exit code ${result.status ?? -1}.`);
+  }
+}
+
+function aggregateResultStatus(test: PlaywrightTest | undefined, specOk: boolean | undefined): CaseStatus {
+  const resultStatuses = test?.results?.map((entry) => entry.status).filter((entry): entry is string => Boolean(entry)) ?? [];
+  if (resultStatuses.some((status) => status === "failed" || status === "timedOut" || status === "interrupted")) {
+    return "failed";
+  }
+  if (resultStatuses.some((status) => status === "passed")) {
+    return "passed";
+  }
+  if (specOk === false) {
+    return "failed";
+  }
+  return "skipped";
+}
+
+function collectCasesFromSuite(suite: PlaywrightSuite | undefined, cases: CollectedTestCase[]): void {
+  if (!suite) {
+    return;
+  }
+
+  for (const spec of suite.specs ?? []) {
+    const test = spec.tests?.[0];
+    cases.push({
+      id: (spec.title ?? "unnamed-spec").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, ""),
+      title: spec.title ?? "Unnamed Playwright spec",
+      projectName: test?.projectName ?? "default",
+      status: aggregateResultStatus(test, spec.ok),
+      durationMs: test?.results?.reduce((sum, entry) => sum + (entry.duration ?? 0), 0) ?? 0
+    });
+  }
+
+  for (const child of suite.suites ?? []) {
+    collectCasesFromSuite(child, cases);
+  }
+}
+
+function collectCases(report: PlaywrightJsonReport): CollectedTestCase[] {
+  const cases: CollectedTestCase[] = [];
+  for (const suite of report.suites ?? []) {
+    collectCasesFromSuite(suite, cases);
+  }
+  return cases;
+}
+
+function ensureRequiredCases(cases: CollectedTestCase[]): void {
+  for (const title of REQUIRED_CASE_TITLES) {
+    if (!cases.some((entry) => entry.title === title)) {
+      fail(`Playwright report is missing required packaged RC smoke case: ${title}`);
+    }
+  }
+}
+
+function resolveOutputPath(requestedPath: string | undefined, shortCommit: string): string {
+  if (requestedPath) {
+    return path.resolve(requestedPath);
+  }
+  const timestamp = new Date().toISOString().replace(/:/g, "-");
+  return path.resolve("artifacts", "release-readiness", `client-release-candidate-smoke-${shortCommit}-${timestamp}.json`);
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const commit = readGitValue(["rev-parse", "HEAD"]);
+  const shortCommit = readGitValue(["rev-parse", "--short", "HEAD"]);
+  const branch = readGitValue(["rev-parse", "--abbrev-ref", "HEAD"]);
+  const dirty = readGitValue(["status", "--porcelain"]).length > 0;
+  const artifactDir = path.resolve(args.clientArtifactDir ?? "apps/client/dist");
+  const outputPath = resolveOutputPath(args.outputPath, shortCommit);
+  const rawPlaywrightReportPath = outputPath.replace(/\.json$/, ".playwright.json");
+  const startedAtValue = Date.now();
+  const startedAt = new Date(startedAtValue).toISOString();
+
+  runCommand(FIXTURE_COMMAND);
+  runCommand(BUILD_COMMAND);
+
+  if (!fs.existsSync(artifactDir)) {
+    fail(`Built client artifact directory does not exist: ${artifactDir}`);
+  }
+
+  const result = spawnSync(PLAYWRIGHT_COMMAND, {
+    cwd: process.cwd(),
+    shell: true,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 20
+  });
+  const finishedAtValue = Date.now();
+  const finishedAt = new Date(finishedAtValue).toISOString();
+
+  if (!result.stdout.trim()) {
+    fail("Packaged client RC smoke did not emit a Playwright JSON report.");
+  }
+
+  let playwrightReport: PlaywrightJsonReport;
+  try {
+    playwrightReport = JSON.parse(result.stdout) as PlaywrightJsonReport;
+  } catch (error) {
+    writeJsonFile(rawPlaywrightReportPath, {
+      parseError: error instanceof Error ? error.message : String(error),
+      stdout: result.stdout
+    });
+    throw error;
+  }
+
+  writeJsonFile(rawPlaywrightReportPath, playwrightReport);
+
+  const cases = collectCases(playwrightReport);
+  ensureRequiredCases(cases);
+
+  const failed = cases.filter((entry) => entry.status === "failed").length;
+  const skipped = cases.filter((entry) => entry.status === "skipped").length;
+  const passed = cases.filter((entry) => entry.status === "passed").length;
+  const summary = {
+    total: cases.length,
+    passed,
+    failed,
+    skipped,
+    flaky: playwrightReport.stats?.flaky ?? 0
+  };
+
+  const report: ReleaseCandidateClientArtifactSmokeReport = {
+    schemaVersion: 1,
+    generatedAt: finishedAt,
+    revision: {
+      commit,
+      shortCommit,
+      branch,
+      dirty
+    },
+    artifact: {
+      kind: "apps/client/dist",
+      path: path.relative(process.cwd(), artifactDir).replace(/\\/g, "/"),
+      buildCommand: BUILD_COMMAND,
+      smokeCommand: PLAYWRIGHT_COMMAND
+    },
+    execution: {
+      status: result.status === 0 ? "passed" : "failed",
+      exitCode: result.status ?? 1,
+      startedAt,
+      finishedAt,
+      durationMs: finishedAtValue - startedAtValue,
+      ...(tailText(result.stdout) !== undefined ? { stdoutTail: tailText(result.stdout) } : {}),
+      ...(tailText(result.stderr) !== undefined ? { stderrTail: tailText(result.stderr) } : {}),
+      rawPlaywrightReportPath: path.relative(process.cwd(), rawPlaywrightReportPath).replace(/\\/g, "/")
+    },
+    summary,
+    cases
+  };
+
+  writeJsonFile(outputPath, report);
+
+  console.log(`Wrote packaged client RC smoke report: ${path.relative(process.cwd(), outputPath).replace(/\\/g, "/")}`);
+  console.log(`Revision: ${shortCommit}`);
+  console.log(`Status: ${report.execution.status}`);
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    process.exitCode = result.status ?? 1;
+  }
+}
+
+main();

--- a/tests/e2e/release-candidate-artifact-smoke.spec.ts
+++ b/tests/e2e/release-candidate-artifact-smoke.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test, type Page } from "@playwright/test";
+import { buildRoomId, expectRoomReady, fullMoveTextPattern, withSmokeDiagnostics } from "./smoke-helpers";
+
+async function expectEnteredRoom(page: Page, roomId: string, playerId: string): Promise<void> {
+  await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
+  await expectRoomReady(page, {
+    roomId,
+    playerId,
+    expectedMoveText: fullMoveTextPattern(playerId)
+  });
+}
+
+test("rc-artifact: guest login reaches lobby and room boot", async ({ page }, testInfo) => {
+  const roomId = buildRoomId("rc-artifact-guest");
+  const playerId = "player-1";
+
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
+    await expect(page.getByText("活跃房间")).toBeVisible();
+
+    await page.locator("[data-lobby-room-id]").fill(roomId);
+    await page.locator("[data-lobby-player-id]").fill(playerId);
+    await page.locator("[data-lobby-display-name]").fill("RC Smoke Guest");
+    await page.locator("[data-enter-room]").click();
+
+    await expectEnteredRoom(page, roomId, playerId);
+    await expect(page.getByTestId("account-card")).toContainText("RC Smoke Guest");
+    await expect(page.getByTestId("event-log")).toContainText("已加入房间", { timeout: 10_000 });
+  });
+});
+
+test("rc-artifact: cached session restore reaches room boot", async ({ page }, testInfo) => {
+  const roomId = buildRoomId("rc-artifact-cached");
+  const playerId = "cached-guest-1";
+
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "project-veil:auth-session",
+      JSON.stringify({
+        playerId: "cached-guest-1",
+        displayName: "Cached RC Guest",
+        authMode: "guest",
+        source: "local"
+      })
+    );
+  });
+
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await page.goto("/");
+
+    await expect(page.getByText("已缓存本地会话：cached-guest-1")).toBeVisible();
+    await page.locator("[data-lobby-room-id]").fill(roomId);
+    await page.locator("[data-enter-room]").click();
+
+    await expectEnteredRoom(page, roomId, playerId);
+    await expect(page.getByTestId("account-card")).toContainText("Cached RC Guest");
+    await expect(page.getByTestId("event-log")).toContainText("已加入房间", { timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Summary
- add a packaged H5 release-candidate smoke flow that builds `apps/client/dist`, serves the packaged artifact, and runs a focused Playwright critical-path smoke
- emit machine-readable release-readiness JSON plus raw Playwright JSON for the tested revision and retain it in CI as an artifact
- document the maintainer command in the release-readiness docs and README

## Validation
- `npm run typecheck:client:h5`
- `node --import tsx --test "apps/cocos-client/test/cocos-wechat-smoke-release.test.ts"`
- `npx tsc --noEmit --target es2022 --module nodenext --moduleResolution nodenext --types node ./scripts/release-candidate-client-artifact-smoke.ts`
- `npm run smoke:client:release-candidate -- --output artifacts/release-readiness/client-release-candidate-smoke-local.json` (fails on this host before browser launch because Playwright Chromium is missing `libatk-bridge-2.0.so.0`)

Closes #307