### PR TITLE
Add aggregated WeChat RC artifact validation gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ npm run dev:client:h5
 - 打包 H5 客户端 RC 冒烟：`npm run smoke:client:release-candidate`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
+- 微信小游戏 RC artifact 聚合验收：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>]`
 - Issue #33 开源素材 staging 校验：`npm run check:issue33-assets -- --require-pack`
 - GitHub Actions `wechat-build-validation` 会把发布归档与 sidecar 元数据作为 artifact `wechat-release-<sha>` 上传，便于提审前下载与回溯
 - H5 调试壳开发服务：`npm run dev:client:h5`

--- a/apps/cocos-client/test/cocos-wechat-rc-validation.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-rc-validation.test.ts
@@ -1,0 +1,281 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  buildWechatMinigameTemplateArtifacts,
+  normalizeWechatMinigameBuildConfig
+} from "../assets/scripts/cocos-wechat-build.ts";
+
+interface PackagedArtifact {
+  artifactsDir: string;
+  metadataPath: string;
+  reportPath: string;
+  uploadReceiptPath: string;
+}
+
+function createPackagedWechatReleaseArtifact(): PackagedArtifact {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-rc-build-"));
+  const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-rc-artifacts-"));
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-rc-config-"));
+  fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tempDir, "game.json"),
+    JSON.stringify({
+      deviceOrientation: "portrait",
+      networkTimeout: {
+        request: 10000,
+        connectSocket: 10000,
+        uploadFile: 10000,
+        downloadFile: 10000
+      },
+      subpackages: []
+    })
+  );
+  fs.writeFileSync(path.join(tempDir, "game.js"), "\"use strict\";\n");
+  fs.writeFileSync(path.join(tempDir, "application.js"), "\"use strict\";\n");
+  fs.writeFileSync(path.join(tempDir, "src", "settings.json"), JSON.stringify({ subpackages: [] }));
+
+  const configPath = path.join(configDir, "wechat-minigame.build.json");
+  const config = normalizeWechatMinigameBuildConfig({
+    projectName: "Project Veil",
+    appId: "wxrcartifactappid",
+    runtimeRemoteUrl: "wss://veil.example.com/socket",
+    remoteAssetRoot: "https://cdn.example.com/assets",
+    domains: {
+      request: ["https://veil.example.com"],
+      socket: ["wss://veil.example.com"],
+      uploadFile: [],
+      downloadFile: ["https://cdn.example.com"]
+    }
+  });
+  const artifacts = buildWechatMinigameTemplateArtifacts(config);
+  fs.writeFileSync(path.join(tempDir, "project.config.json"), JSON.stringify(artifacts.projectConfigJson));
+  fs.writeFileSync(path.join(tempDir, "codex.wechat.build.json"), JSON.stringify(artifacts.manifestJson));
+  fs.writeFileSync(path.join(tempDir, "README.codex.md"), `${artifacts.releaseChecklistMarkdown}\n`);
+  fs.writeFileSync(configPath, JSON.stringify(config));
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/package-wechat-minigame-release.ts",
+      "--config",
+      configPath,
+      "--output-dir",
+      tempDir,
+      "--artifacts-dir",
+      artifactsDir,
+      "--expect-exported-runtime",
+      "--source-revision",
+      "abc1234"
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      stdio: "pipe"
+    }
+  );
+
+  execFileSync(
+    "node",
+    ["--import", "tsx", "./scripts/smoke-wechat-minigame-release.ts", "--artifacts-dir", artifactsDir],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      stdio: "pipe"
+    }
+  );
+
+  const smokeReportPath = path.join(artifactsDir, "codex.wechat.smoke-report.json");
+  const smokeReport = JSON.parse(fs.readFileSync(smokeReportPath, "utf8")) as {
+    execution: { tester: string; device: string; clientVersion: string; executedAt: string; result: string; summary: string };
+    cases: Array<{ id: string; status: string; notes: string; evidence: string[]; requiredEvidence?: Record<string, string> }>;
+  };
+  smokeReport.execution.tester = "codex";
+  smokeReport.execution.device = "iPhone 15 / WeChat 8.0.x";
+  smokeReport.execution.clientVersion = "1.0.155";
+  smokeReport.execution.executedAt = "2026-03-29T21:20:00+08:00";
+  smokeReport.execution.result = "passed";
+  smokeReport.execution.summary = "All required smoke cases passed.";
+  for (const entry of smokeReport.cases) {
+    entry.status = "passed";
+    entry.notes = "ok";
+    entry.evidence = ["manual"];
+  }
+  const reconnectCase = smokeReport.cases.find((entry) => entry.id === "reconnect-recovery");
+  if (reconnectCase?.requiredEvidence) {
+    reconnectCase.requiredEvidence.roomId = "room-alpha";
+    reconnectCase.requiredEvidence.reconnectPrompt = "连接已恢复";
+    reconnectCase.requiredEvidence.restoredState = "Returned to room-alpha without rollback.";
+  }
+  const shareCase = smokeReport.cases.find((entry) => entry.id === "share-roundtrip");
+  if (shareCase?.requiredEvidence) {
+    shareCase.requiredEvidence.shareScene = "lobby";
+    shareCase.requiredEvidence.shareQuery = "roomId=room-alpha&inviterId=player-7&shareScene=lobby";
+    shareCase.requiredEvidence.roundtripState = "Roundtrip reopened room-alpha and restored inviterId player-7.";
+  }
+  fs.writeFileSync(smokeReportPath, `${JSON.stringify(smokeReport, null, 2)}\n`, "utf8");
+
+  const metadataPath = path.join(artifactsDir, "project-veil-wechatgame-release.package.json");
+  const uploadReceiptPath = path.join(artifactsDir, "project-veil-wechatgame-release.upload.json");
+  fs.writeFileSync(
+    uploadReceiptPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        buildTemplatePlatform: "wechatgame",
+        projectName: "Project Veil",
+        artifactArchiveFileName: "project-veil-wechatgame-release.tar.gz",
+        artifactArchiveSha256: JSON.parse(fs.readFileSync(metadataPath, "utf8")).archiveSha256 as string,
+        artifactMetadataPath: path.relative(path.resolve(__dirname, "../../.."), metadataPath).replace(/\\/g, "/"),
+        sourceRevision: "abc1234",
+        uploadVersion: "1.0.155",
+        uploadDescription: "robot 1 upload Project Veil 1.0.155 commit abc1234",
+        uploadAppId: "wxrcartifactappid",
+        artifactAppId: "wxrcartifactappid",
+        usedAppIdOverride: false,
+        uploadRobot: 1,
+        uploadedAt: "2026-03-29T13:20:00.000Z"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  return {
+    artifactsDir,
+    metadataPath,
+    reportPath: path.join(artifactsDir, "codex.wechat.rc-validation-report.json"),
+    uploadReceiptPath
+  };
+}
+
+test("validate:wechat-rc writes a stable aggregate report for a valid RC artifact bundle", () => {
+  const { artifactsDir, reportPath } = createPackagedWechatReleaseArtifact();
+
+  const output = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/validate-wechat-release-candidate.ts",
+      "--artifacts-dir",
+      artifactsDir,
+      "--expected-revision",
+      "abc1234",
+      "--version",
+      "1.0.155",
+      "--require-smoke-report"
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  assert.match(output, /Wrote release candidate validation report/);
+  assert.match(output, /Commit: abc1234/);
+  assert.match(output, /Version: 1.0.155/);
+  assert.match(output, /Result: passed/);
+
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
+    version: string | null;
+    commit: string | null;
+    artifact: { archivePath: string; metadataPath: string; smokeReportPath?: string; uploadReceiptPath?: string };
+    summary: { status: string; failureSummary: string[] };
+    checks: Array<{ id: string; status: string }>;
+  };
+  assert.equal(report.version, "1.0.155");
+  assert.equal(report.commit, "abc1234");
+  assert.equal(report.summary.status, "passed");
+  assert.deepEqual(report.summary.failureSummary, []);
+  assert.ok(report.artifact.archivePath.endsWith(".tar.gz"));
+  assert.ok(report.artifact.metadataPath.endsWith(".package.json"));
+  assert.ok(report.artifact.smokeReportPath?.endsWith("codex.wechat.smoke-report.json"));
+  assert.ok(report.artifact.uploadReceiptPath?.endsWith(".upload.json"));
+  assert.deepEqual(
+    report.checks.map((check) => `${check.id}:${check.status}`),
+    [
+      "package-sidecar:passed",
+      "artifact-verify:passed",
+      "smoke-report:passed",
+      "upload-receipt:passed"
+    ]
+  );
+});
+
+test("validate:wechat-rc fails clearly on release version mismatch", () => {
+  const { artifactsDir, reportPath } = createPackagedWechatReleaseArtifact();
+
+  assert.throws(
+    () =>
+      execFileSync(
+        "node",
+        [
+          "--import",
+          "tsx",
+          "./scripts/validate-wechat-release-candidate.ts",
+          "--artifacts-dir",
+          artifactsDir,
+          "--expected-revision",
+          "abc1234",
+          "--version",
+          "9.9.9",
+          "--require-smoke-report"
+        ],
+        {
+          cwd: path.resolve(__dirname, "../../.."),
+          encoding: "utf8",
+          stdio: "pipe"
+        }
+      ),
+    /Release candidate version mismatch: expected 9\.9\.9, receipt=1\.0\.155/
+  );
+
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
+    version: string | null;
+    summary: { status: string; failureSummary: string[] };
+  };
+  assert.equal(report.version, "9.9.9");
+  assert.equal(report.summary.status, "failed");
+  assert.match(report.summary.failureSummary.join("\n"), /upload-receipt: Release candidate version mismatch/);
+});
+
+test("validate:wechat-rc fails clearly on invalid package sidecar metadata", () => {
+  const { artifactsDir, metadataPath, reportPath } = createPackagedWechatReleaseArtifact();
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as { archiveSha256: string };
+  metadata.archiveSha256 = "bad-sha";
+  fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+
+  assert.throws(
+    () =>
+      execFileSync(
+        "node",
+        [
+          "--import",
+          "tsx",
+          "./scripts/validate-wechat-release-candidate.ts",
+          "--artifacts-dir",
+          artifactsDir,
+          "--expected-revision",
+          "abc1234"
+        ],
+        {
+          cwd: path.resolve(__dirname, "../../.."),
+          encoding: "utf8",
+          stdio: "pipe"
+        }
+      ),
+    /Release sidecar archiveSha256 must be a 64-character lowercase hex string/
+  );
+
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
+    summary: { status: string; failureSummary: string[] };
+  };
+  assert.equal(report.summary.status, "failed");
+  assert.match(report.summary.failureSummary.join("\n"), /package-sidecar: Release sidecar archiveSha256 must be a 64-character lowercase hex string/);
+});

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -24,6 +24,7 @@
 - 刷新模板：`npm run prepare:wechat-build`
 - 生成发布元数据：`npm run prepare:wechat-release -- --output-dir <wechatgame-build-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - 产出发布归档：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
+- 聚合校验 RC artifact：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report]`
 - 上传已打包产物：`npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`
 - 按 SHA 下载 CI artifact：`npm run download:wechat-release -- --sha <git-sha> [--output-dir artifacts/downloaded/wechat-release-<git-sha>]`
 - 验收已下载 artifact：`npm run verify:wechat-release -- --artifacts-dir <downloaded-artifact-dir> [--expected-revision <git-sha>]`
@@ -60,13 +61,17 @@
 4. 对真实导出目录执行 `npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`。
 5. 运行 `npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`，生成包含 `codex.wechat.release.json` 的归档包与 sidecar 元数据。
 6. 运行 `npm run verify:wechat-release -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>]`，在上传前先做一次本地 artifact 级冒烟验收。
-7. 运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成 `codex.wechat.smoke-report.json` 模板，并在真机或准真机上逐项填写结果。
-8. 完成真机 / 准真机冒烟后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
+7. 如需把 sidecar、归档、可选 smoke report / upload receipt 收口成单条门禁，运行 `npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report]`。
+   - 该命令会稳定输出 `codex.wechat.rc-validation-report.json`
+   - JSON 至少包含 `version`、`commit`、artifact 路径、逐项检查结果和 `failureSummary`
+   - `--version` 会要求并校验 `*.upload.json`；`--require-smoke-report` 会把 `codex.wechat.smoke-report.json` 设为必需门禁
+8. 运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成 `codex.wechat.smoke-report.json` 模板，并在真机或准真机上逐项填写结果。
+9. 完成真机 / 准真机冒烟后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
    - `reconnect-recovery` 必须复用 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md) 的 canonical scenario、最小成功信号和失败诊断口径。
-9. 运行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把微信 smoke 结果映射回统一的 Cocos RC 快照，并补齐首战 / 返回世界证据。
-10. 复制 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，为当前 candidate 回填设备、结论和 blocker。
-11. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
-12. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
+10. 运行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把微信 smoke 结果映射回统一的 Cocos RC 快照，并补齐首战 / 返回世界证据。
+11. 复制 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，为当前 candidate 回填设备、结论和 blocker。
+12. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
+13. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
 
 ## 下载与验收
 
@@ -85,6 +90,13 @@
 - `game.json`、`project.config.json`、`codex.wechat.build.json`、`README.codex.md`、`game.js`、`application.js`、`src/settings.json` 是否齐全
 - release manifest 中记录的文件列表、字节数、SHA-256 是否与归档内真实内容一致
 - `project.config.json` / `codex.wechat.build.json` 是否仍指向微信小游戏构建
+
+`validate:wechat-rc` 会在 `verify:wechat-release` 之上额外统一输出一份稳定 JSON 报告，并收口以下门禁：
+
+- release sidecar 基本字段是否完整，SHA / 字节数 / fileCount 是否具备有效形状
+- artifact 归档与 sidecar 是否仍能通过 `verify:wechat-release`
+- 若存在 `codex.wechat.smoke-report.json`，则复用 `smoke:wechat-release --check` 校验其结果；传 `--require-smoke-report` 时缺失也会直接失败
+- 若存在 `*.upload.json`，则校验其与 sidecar 的 archive / SHA / commit 一致；传 `--version <wechat-version>` 时会把 upload receipt 设为必需并校验版本号
 
 ## 提审前 Smoke Check
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "upload:wechat-release": "node --import tsx ./scripts/upload-wechat-minigame-release.ts",
     "download:wechat-release": "node --import tsx ./scripts/download-wechat-minigame-artifact.ts",
     "verify:wechat-release": "node --import tsx ./scripts/verify-wechat-minigame-artifact.ts",
+    "validate:wechat-rc": "node --import tsx ./scripts/validate-wechat-release-candidate.ts",
     "smoke:wechat-release": "node --import tsx ./scripts/smoke-wechat-minigame-release.ts",
     "release:readiness:snapshot": "node --import tsx ./scripts/release-readiness-snapshot.ts",
     "release:readiness:dashboard": "node --import tsx ./scripts/release-readiness-dashboard.ts",

--- a/scripts/validate-wechat-release-candidate.ts
+++ b/scripts/validate-wechat-release-candidate.ts
@@ -1,0 +1,610 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+type CheckStatus = "passed" | "failed" | "skipped";
+type GateStatus = "passed" | "failed";
+
+interface Args {
+  artifactsDir?: string;
+  archivePath?: string;
+  metadataPath?: string;
+  reportPath?: string;
+  expectedRevision?: string;
+  version?: string;
+  smokeReportPath?: string;
+  uploadReceiptPath?: string;
+  requireSmokeReport: boolean;
+}
+
+interface WechatMinigameReleasePackageMetadata {
+  schemaVersion: 1;
+  buildTemplatePlatform: "wechatgame";
+  projectName: string;
+  appId: string;
+  archiveFileName: string;
+  archiveBytes: number;
+  archiveSha256: string;
+  releaseManifestFile: string;
+  exportedBuildDir: string;
+  packagedBuildDir: string;
+  fileCount: number;
+  sourceRevision?: string;
+  runtimeRemoteUrl?: string;
+  remoteAssetRoot?: string;
+}
+
+interface UploadReceipt {
+  schemaVersion: 1;
+  buildTemplatePlatform: "wechatgame";
+  projectName: string;
+  artifactArchiveFileName: string;
+  artifactArchiveSha256: string;
+  artifactMetadataPath: string;
+  sourceRevision?: string;
+  uploadVersion: string;
+  uploadDescription: string;
+  uploadAppId: string;
+  artifactAppId: string;
+  usedAppIdOverride: boolean;
+  uploadRobot: number;
+  uploadedAt: string;
+}
+
+interface ValidationCheck {
+  id: string;
+  title: string;
+  status: CheckStatus;
+  required: boolean;
+  summary: string;
+  artifactPath?: string;
+  command?: string;
+  exitCode?: number | null;
+  stdoutTail?: string;
+  stderrTail?: string;
+}
+
+interface ValidationReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  version: string | null;
+  commit: string | null;
+  artifact: {
+    artifactsDir?: string;
+    archivePath: string;
+    metadataPath: string;
+    smokeReportPath?: string;
+    uploadReceiptPath?: string;
+  };
+  summary: {
+    status: GateStatus;
+    totalChecks: number;
+    failedChecks: number;
+    failureSummary: string[];
+  };
+  checks: ValidationCheck[];
+}
+
+const OUTPUT_TAIL_BYTES = 4000;
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let artifactsDir: string | undefined;
+  let archivePath: string | undefined;
+  let metadataPath: string | undefined;
+  let reportPath: string | undefined;
+  let expectedRevision: string | undefined;
+  let version: string | undefined;
+  let smokeReportPath: string | undefined;
+  let uploadReceiptPath: string | undefined;
+  let requireSmokeReport = false;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--artifacts-dir" && next) {
+      artifactsDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--archive" && next) {
+      archivePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--metadata" && next) {
+      metadataPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--report" && next) {
+      reportPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--expected-revision" && next) {
+      expectedRevision = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--version" && next) {
+      version = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--smoke-report" && next) {
+      smokeReportPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--upload-receipt" && next) {
+      uploadReceiptPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--require-smoke-report") {
+      requireSmokeReport = true;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    ...(artifactsDir ? { artifactsDir } : {}),
+    ...(archivePath ? { archivePath } : {}),
+    ...(metadataPath ? { metadataPath } : {}),
+    ...(reportPath ? { reportPath } : {}),
+    ...(expectedRevision ? { expectedRevision } : {}),
+    ...(version ? { version } : {}),
+    ...(smokeReportPath ? { smokeReportPath } : {}),
+    ...(uploadReceiptPath ? { uploadReceiptPath } : {}),
+    requireSmokeReport
+  };
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function tailText(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.length > OUTPUT_TAIL_BYTES ? normalized.slice(-OUTPUT_TAIL_BYTES) : normalized;
+}
+
+function resolveArtifactsFromDirectory(artifactsDir: string): { artifactsDir: string; archivePath: string; metadataPath: string } {
+  const resolvedArtifactsDir = path.resolve(artifactsDir);
+  if (!fs.existsSync(resolvedArtifactsDir)) {
+    fail(`Artifacts directory does not exist: ${resolvedArtifactsDir}`);
+  }
+
+  const entries = fs.readdirSync(resolvedArtifactsDir);
+  const archives = entries.filter((entry) => entry.endsWith(".tar.gz")).sort();
+  const sidecars = entries.filter((entry) => entry.endsWith(".package.json")).sort();
+  if (archives.length !== 1) {
+    fail(`Expected exactly one release archive in ${resolvedArtifactsDir}, found ${archives.length}.`);
+  }
+  if (sidecars.length !== 1) {
+    fail(`Expected exactly one release sidecar in ${resolvedArtifactsDir}, found ${sidecars.length}.`);
+  }
+
+  const archiveFileName = archives[0];
+  const sidecarFileName = sidecars[0];
+  if (!archiveFileName || !sidecarFileName) {
+    fail(`Unable to resolve release archive and sidecar in ${resolvedArtifactsDir}.`);
+  }
+
+  return {
+    artifactsDir: resolvedArtifactsDir,
+    archivePath: path.join(resolvedArtifactsDir, archiveFileName),
+    metadataPath: path.join(resolvedArtifactsDir, sidecarFileName)
+  };
+}
+
+function resolveArtifacts(args: Args): { artifactsDir?: string; archivePath: string; metadataPath: string } {
+  if (args.artifactsDir) {
+    return resolveArtifactsFromDirectory(args.artifactsDir);
+  }
+  if (!args.archivePath || !args.metadataPath) {
+    fail("Pass either --artifacts-dir <dir> or both --archive <tar.gz> and --metadata <package.json>.");
+  }
+
+  return {
+    archivePath: path.resolve(args.archivePath),
+    metadataPath: path.resolve(args.metadataPath)
+  };
+}
+
+function defaultReportPath(artifactsDir: string | undefined, metadataPath: string): string {
+  if (artifactsDir) {
+    return path.join(artifactsDir, "codex.wechat.rc-validation-report.json");
+  }
+  return path.join(path.dirname(metadataPath), "codex.wechat.rc-validation-report.json");
+}
+
+function validatePackageMetadataShape(metadata: WechatMinigameReleasePackageMetadata, archivePath: string): void {
+  if (metadata.schemaVersion !== 1) {
+    fail(`Release sidecar schemaVersion must be 1, received ${JSON.stringify(metadata.schemaVersion)}.`);
+  }
+  if (metadata.buildTemplatePlatform !== "wechatgame") {
+    fail(
+      `Release sidecar buildTemplatePlatform must be "wechatgame", received ${JSON.stringify(metadata.buildTemplatePlatform)}.`
+    );
+  }
+  if (!metadata.projectName?.trim()) {
+    fail("Release sidecar is missing projectName.");
+  }
+  if (!metadata.appId?.trim()) {
+    fail("Release sidecar is missing appId.");
+  }
+  if (!metadata.archiveFileName?.trim()) {
+    fail("Release sidecar is missing archiveFileName.");
+  }
+  if (!metadata.archiveSha256 || !/^[a-f0-9]{64}$/.test(metadata.archiveSha256)) {
+    fail("Release sidecar archiveSha256 must be a 64-character lowercase hex string.");
+  }
+  if (!Number.isFinite(metadata.archiveBytes) || metadata.archiveBytes <= 0) {
+    fail(`Release sidecar archiveBytes must be a positive number, received ${JSON.stringify(metadata.archiveBytes)}.`);
+  }
+  if (!metadata.releaseManifestFile?.trim()) {
+    fail("Release sidecar is missing releaseManifestFile.");
+  }
+  if (!metadata.packagedBuildDir?.trim()) {
+    fail("Release sidecar is missing packagedBuildDir.");
+  }
+  if (!Number.isInteger(metadata.fileCount) || metadata.fileCount <= 0) {
+    fail(`Release sidecar fileCount must be a positive integer, received ${JSON.stringify(metadata.fileCount)}.`);
+  }
+  if (path.basename(archivePath) !== metadata.archiveFileName) {
+    fail(`Release sidecar archiveFileName mismatch: ${metadata.archiveFileName} !== ${path.basename(archivePath)}`);
+  }
+}
+
+function resolveOptionalArtifactPath(explicitPath: string | undefined, fallbackPath: string): string | undefined {
+  if (explicitPath) {
+    return path.resolve(explicitPath);
+  }
+  return fs.existsSync(fallbackPath) ? fallbackPath : undefined;
+}
+
+function runCommandCheck(
+  title: string,
+  artifactPath: string | undefined,
+  args: string[]
+): ValidationCheck {
+  const result = spawnSync(process.execPath, args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 20
+  });
+
+  const stderrTail = tailText(result.stderr);
+  const stdoutTail = tailText(result.stdout);
+  if (result.error) {
+    return {
+      id: title,
+      title,
+      status: "failed",
+      required: true,
+      summary: result.error.message,
+      ...(artifactPath ? { artifactPath } : {}),
+      command: [process.execPath, ...args].join(" "),
+      exitCode: result.status,
+      ...(stdoutTail ? { stdoutTail } : {}),
+      ...(stderrTail ? { stderrTail } : {})
+    };
+  }
+
+  if (result.status !== 0) {
+    return {
+      id: title,
+      title,
+      status: "failed",
+      required: true,
+      summary: stderrTail ?? stdoutTail ?? `Command exited with code ${result.status}.`,
+      ...(artifactPath ? { artifactPath } : {}),
+      command: [process.execPath, ...args].join(" "),
+      exitCode: result.status,
+      ...(stdoutTail ? { stdoutTail } : {}),
+      ...(stderrTail ? { stderrTail } : {})
+    };
+  }
+
+  return {
+    id: title,
+    title,
+    status: "passed",
+    required: true,
+    summary: "ok",
+    ...(artifactPath ? { artifactPath } : {}),
+    command: [process.execPath, ...args].join(" "),
+    exitCode: result.status,
+    ...(stdoutTail ? { stdoutTail } : {}),
+    ...(stderrTail ? { stderrTail } : {})
+  };
+}
+
+function validateUploadReceipt(
+  uploadReceiptPath: string,
+  metadata: WechatMinigameReleasePackageMetadata,
+  metadataPath: string,
+  expectedVersion?: string,
+  expectedRevision?: string
+): ValidationCheck {
+  const receipt = readJsonFile<UploadReceipt>(uploadReceiptPath);
+  if (receipt.schemaVersion !== 1) {
+    fail(`Upload receipt schemaVersion must be 1, received ${JSON.stringify(receipt.schemaVersion)}.`);
+  }
+  if (receipt.buildTemplatePlatform !== "wechatgame") {
+    fail(
+      `Upload receipt buildTemplatePlatform must be "wechatgame", received ${JSON.stringify(receipt.buildTemplatePlatform)}.`
+    );
+  }
+  if (!receipt.uploadVersion?.trim()) {
+    fail("Upload receipt is missing uploadVersion.");
+  }
+  if (!receipt.uploadedAt?.trim()) {
+    fail("Upload receipt is missing uploadedAt.");
+  }
+  if (receipt.projectName !== metadata.projectName) {
+    fail(`Upload receipt projectName mismatch: ${receipt.projectName} !== ${metadata.projectName}`);
+  }
+  if (receipt.artifactArchiveFileName !== metadata.archiveFileName) {
+    fail(
+      `Upload receipt artifactArchiveFileName mismatch: ${receipt.artifactArchiveFileName} !== ${metadata.archiveFileName}`
+    );
+  }
+  if (receipt.artifactArchiveSha256 !== metadata.archiveSha256) {
+    fail("Upload receipt artifactArchiveSha256 does not match release sidecar.");
+  }
+
+  const expectedMetadataRelativePath = path.relative(process.cwd(), metadataPath).replace(/\\/g, "/");
+  if (receipt.artifactMetadataPath !== expectedMetadataRelativePath) {
+    fail(
+      `Upload receipt artifactMetadataPath mismatch: ${receipt.artifactMetadataPath} !== ${expectedMetadataRelativePath}`
+    );
+  }
+  if (expectedVersion && receipt.uploadVersion !== expectedVersion) {
+    fail(`Release candidate version mismatch: expected ${expectedVersion}, receipt=${receipt.uploadVersion}`);
+  }
+  if (metadata.sourceRevision && receipt.sourceRevision && metadata.sourceRevision !== receipt.sourceRevision) {
+    fail(
+      `Revision mismatch between release sidecar and upload receipt: ${metadata.sourceRevision} !== ${receipt.sourceRevision}`
+    );
+  }
+  if (expectedRevision) {
+    if (!receipt.sourceRevision) {
+      fail(`Upload receipt is missing sourceRevision; expected ${expectedRevision}.`);
+    }
+    if (receipt.sourceRevision !== expectedRevision) {
+      fail(`Release candidate commit mismatch: expected ${expectedRevision}, receipt=${receipt.sourceRevision}`);
+    }
+  }
+
+  return {
+    id: "upload-receipt",
+    title: "Upload receipt validation",
+    status: "passed",
+    required: Boolean(expectedVersion),
+    summary: "ok",
+    artifactPath: uploadReceiptPath
+  };
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const checks: ValidationCheck[] = [];
+  const artifacts = resolveArtifacts(args);
+  const metadata = readJsonFile<WechatMinigameReleasePackageMetadata>(artifacts.metadataPath);
+  const smokeReportPath = resolveOptionalArtifactPath(
+    args.smokeReportPath,
+    path.join(artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath), "codex.wechat.smoke-report.json")
+  );
+  const uploadReceiptPath = resolveOptionalArtifactPath(
+    args.uploadReceiptPath,
+    path.join(
+      artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath),
+      `${path.basename(artifacts.metadataPath, ".package.json")}.upload.json`
+    )
+  );
+  const reportPath = path.resolve(args.reportPath ?? defaultReportPath(artifacts.artifactsDir, artifacts.metadataPath));
+  const commit = metadata.sourceRevision ?? args.expectedRevision ?? null;
+  let version = args.version ?? null;
+  let exitCode = 0;
+
+  try {
+    validatePackageMetadataShape(metadata, artifacts.archivePath);
+    checks.push({
+      id: "package-sidecar",
+      title: "Release sidecar metadata",
+      status: "passed",
+      required: true,
+      summary: "ok",
+      artifactPath: artifacts.metadataPath
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    checks.push({
+      id: "package-sidecar",
+      title: "Release sidecar metadata",
+      status: "failed",
+      required: true,
+      summary: message,
+      artifactPath: artifacts.metadataPath
+    });
+    exitCode = 1;
+  }
+
+  const verifyArgs = [
+    "--import",
+    "tsx",
+    "./scripts/verify-wechat-minigame-artifact.ts",
+    "--archive",
+    artifacts.archivePath,
+    "--metadata",
+    artifacts.metadataPath
+  ];
+  if (args.expectedRevision) {
+    verifyArgs.push("--expected-revision", args.expectedRevision);
+  }
+  const verifyCheck = runCommandCheck("artifact-verify", artifacts.archivePath, verifyArgs);
+  verifyCheck.id = "artifact-verify";
+  verifyCheck.title = "Release archive verification";
+  checks.push(verifyCheck);
+  if (verifyCheck.status === "failed") {
+    exitCode = 1;
+  }
+
+  if (smokeReportPath) {
+    const smokeArgs = [
+      "--import",
+      "tsx",
+      "./scripts/smoke-wechat-minigame-release.ts",
+      "--metadata",
+      artifacts.metadataPath,
+      "--report",
+      smokeReportPath,
+      "--check"
+    ];
+    if (args.expectedRevision) {
+      smokeArgs.push("--expected-revision", args.expectedRevision);
+    }
+    const smokeCheck = runCommandCheck("smoke-report", smokeReportPath, smokeArgs);
+    smokeCheck.id = "smoke-report";
+    smokeCheck.title = "Smoke report validation";
+    smokeCheck.required = args.requireSmokeReport;
+    if (smokeCheck.status === "failed" || args.requireSmokeReport) {
+      checks.push(smokeCheck);
+      if (smokeCheck.status === "failed") {
+        exitCode = 1;
+      }
+    } else {
+      checks.push(smokeCheck);
+    }
+  } else if (args.requireSmokeReport) {
+    checks.push({
+      id: "smoke-report",
+      title: "Smoke report validation",
+      status: "failed",
+      required: true,
+      summary: "Required smoke report is missing.",
+      artifactPath: path.join(artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath), "codex.wechat.smoke-report.json")
+    });
+    exitCode = 1;
+  } else {
+    checks.push({
+      id: "smoke-report",
+      title: "Smoke report validation",
+      status: "skipped",
+      required: false,
+      summary: "Smoke report not present.",
+      artifactPath: path.join(artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath), "codex.wechat.smoke-report.json")
+    });
+  }
+
+  if (uploadReceiptPath) {
+    try {
+      const uploadCheck = validateUploadReceipt(
+        uploadReceiptPath,
+        metadata,
+        artifacts.metadataPath,
+        args.version,
+        args.expectedRevision
+      );
+      const receipt = readJsonFile<UploadReceipt>(uploadReceiptPath);
+      version = receipt.uploadVersion;
+      checks.push(uploadCheck);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      checks.push({
+        id: "upload-receipt",
+        title: "Upload receipt validation",
+        status: "failed",
+        required: Boolean(args.version),
+        summary: message,
+        artifactPath: uploadReceiptPath
+      });
+      exitCode = 1;
+    }
+  } else if (args.version) {
+    checks.push({
+      id: "upload-receipt",
+      title: "Upload receipt validation",
+      status: "failed",
+      required: true,
+      summary: `Upload receipt is required to validate release candidate version ${args.version}.`,
+      artifactPath: path.join(
+        artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath),
+        `${path.basename(artifacts.metadataPath, ".package.json")}.upload.json`
+      )
+    });
+    exitCode = 1;
+  } else {
+    checks.push({
+      id: "upload-receipt",
+      title: "Upload receipt validation",
+      status: "skipped",
+      required: false,
+      summary: "Upload receipt not present.",
+      artifactPath: path.join(
+        artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath),
+        `${path.basename(artifacts.metadataPath, ".package.json")}.upload.json`
+      )
+    });
+  }
+
+  const failedChecks = checks.filter((check) => check.status === "failed");
+  const report: ValidationReport = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    version,
+    commit,
+    artifact: {
+      ...(artifacts.artifactsDir ? { artifactsDir: artifacts.artifactsDir } : {}),
+      archivePath: artifacts.archivePath,
+      metadataPath: artifacts.metadataPath,
+      ...(smokeReportPath ? { smokeReportPath } : {}),
+      ...(uploadReceiptPath ? { uploadReceiptPath } : {})
+    },
+    summary: {
+      status: failedChecks.length > 0 ? "failed" : "passed",
+      totalChecks: checks.length,
+      failedChecks: failedChecks.length,
+      failureSummary: failedChecks.map((check) => `${check.id}: ${check.summary}`)
+    },
+    checks
+  };
+
+  writeJsonFile(reportPath, report);
+  console.log(`Wrote release candidate validation report: ${path.relative(process.cwd(), reportPath).replace(/\\/g, "/")}`);
+  console.log(`Artifact: ${path.relative(process.cwd(), artifacts.archivePath).replace(/\\/g, "/")}`);
+  console.log(`Commit: ${commit ?? "unknown"}`);
+  console.log(`Version: ${version ?? "unknown"}`);
+  console.log(`Result: ${report.summary.status}`);
+
+  if (failedChecks.length > 0) {
+    console.error("Failures:");
+    for (const failure of report.summary.failureSummary) {
+      console.error(`  - ${failure}`);
+    }
+    process.exitCode = exitCode || 1;
+    return;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a single `npm run validate:wechat-rc` command that aggregates WeChat RC artifact validation into one stable JSON report
- reuse the existing artifact verify and smoke validators, while adding upload receipt / version checks and clearer sidecar validation failures
- document the new RC gate and cover it with focused packaged-artifact tests

## Testing
- node --import tsx --test apps/cocos-client/test/cocos-wechat-build.test.ts apps/cocos-client/test/cocos-wechat-smoke-release.test.ts apps/cocos-client/test/cocos-wechat-rc-validation.test.ts
- npm run typecheck:cocos

Closes #312