### PR TITLE
test(h5): add boot/session handoff regressions

### DIFF
--- a/apps/client/src/main-entry.ts
+++ b/apps/client/src/main-entry.ts
@@ -1,0 +1,16 @@
+interface StartH5ClientAppOptions {
+  bootstrapApp: () => Promise<void>;
+  registerAutomationHooks: () => void;
+  reportBootstrapError?: (error: unknown) => void;
+}
+
+export function startH5ClientApp({
+  bootstrapApp,
+  registerAutomationHooks,
+  reportBootstrapError
+}: StartH5ClientAppOptions): void {
+  void bootstrapApp().catch((error) => {
+    reportBootstrapError?.(error);
+  });
+  registerAutomationHooks();
+}

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -50,6 +50,7 @@ import {
   unitFrameAsset
 } from "./assets";
 import { describeTileObject } from "./object-visuals";
+import { startH5ClientApp } from "./main-entry";
 import { bootstrapH5App, registerAutomationHooks, syncH5PlayerAccountProfile } from "./main-boot";
 import {
   confirmAccountRegistration,
@@ -5120,12 +5121,15 @@ async function onBindAccountProfile(): Promise<void> {
   }
 }
 
-void bootstrap();
-  registerAutomationHooks({
+startH5ClientApp({
+  bootstrapApp: bootstrap,
+  registerAutomationHooks: () =>
+    registerAutomationHooks({
     window,
     devDiagnosticsEnabled: DEV_DIAGNOSTICS_ENABLED,
     renderGameToText,
     exportDiagnosticSnapshot,
     renderDiagnosticSnapshotToText,
     advanceUiTime
-  });
+    })
+});

--- a/apps/client/test/local-session.test.ts
+++ b/apps/client/test/local-session.test.ts
@@ -206,6 +206,65 @@ test("createGameSession falls back to a local session when remote bootstrap is u
   assert.equal(update.world.playerId, "player-1");
 });
 
+test("createGameSession keeps the remote bootstrap session when the initial connection succeeds", async () => {
+  const expected = createSessionUpdate("remote-live", 9);
+  const remoteSession = {
+    async snapshot(reason?: string) {
+      return reason ? { ...expected, reason } : expected;
+    },
+    async moveHero() {
+      throw new Error("not_implemented");
+    },
+    async collect() {
+      throw new Error("not_implemented");
+    },
+    async learnSkill() {
+      throw new Error("not_implemented");
+    },
+    async equipHeroItem() {
+      throw new Error("not_implemented");
+    },
+    async unequipHeroItem() {
+      throw new Error("not_implemented");
+    },
+    async recruit() {
+      throw new Error("not_implemented");
+    },
+    async visitBuilding() {
+      throw new Error("not_implemented");
+    },
+    async claimMine() {
+      throw new Error("not_implemented");
+    },
+    async endDay() {
+      throw new Error("not_implemented");
+    },
+    async actInBattle() {
+      throw new Error("not_implemented");
+    },
+    async previewMovement() {
+      throw new Error("not_implemented");
+    },
+    async listReachable() {
+      throw new Error("not_implemented");
+    }
+  };
+
+  const session = await localSessionTestHooks.createGameSessionWithRuntime("room-alpha", "player-1", 1001, undefined, {
+    async connectRemoteGameSession() {
+      return {
+        session: remoteSession as never,
+        recoveredFromStoredToken: false
+      };
+    },
+    createLocalSession() {
+      throw new Error("local_session_should_not_be_used");
+    }
+  });
+
+  assert.deepEqual(await session.snapshot("boot"), { ...expected, reason: "boot" });
+});
+
 test("createGameSession falls back to a local session when remote bootstrap times out", async () => {
   const session = await localSessionTestHooks.createGameSessionWithRuntime("room-alpha", "player-1", 1001, undefined, {
     async connectRemoteGameSession() {
@@ -248,6 +307,19 @@ test("createGameSession surfaces stored-token recovery as a successful remote re
   assert.deepEqual(events, ["reconnected"]);
   assert.equal(update.reason, "boot");
   assert.equal(update.world.meta.day, 5);
+});
+
+test("createGameSession falls back to a local session when remote bootstrap throws a non-recoverable error", async () => {
+  const session = await localSessionTestHooks.createGameSessionWithRuntime("room-alpha", "player-1", 1001, undefined, {
+    async connectRemoteGameSession() {
+      throw new Error("unexpected_bootstrap_failure");
+    }
+  });
+
+  const update = await session.snapshot("local-after-unexpected-failure");
+  assert.equal(update.reason, "local-after-unexpected-failure");
+  assert.equal(update.world.meta.roomId, "room-alpha");
+  assert.equal(update.world.playerId, "player-1");
 });
 
 test("remote game sessions persist push updates and reconnection tokens", () => {

--- a/apps/client/test/main-entry.test.ts
+++ b/apps/client/test/main-entry.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { startH5ClientApp } from "../src/main-entry";
+
+test("startH5ClientApp kicks off H5 boot and registers automation hooks without waiting for boot completion", async () => {
+  const events: string[] = [];
+  let resolveBootstrap!: () => void;
+
+  startH5ClientApp({
+    bootstrapApp: () =>
+      new Promise<void>((resolve) => {
+        events.push("bootstrap:start");
+        resolveBootstrap = () => {
+          events.push("bootstrap:resolved");
+          resolve();
+        };
+      }),
+    registerAutomationHooks: () => {
+      events.push("registerAutomationHooks");
+    }
+  });
+
+  assert.deepEqual(events, ["bootstrap:start", "registerAutomationHooks"]);
+  resolveBootstrap();
+  await Promise.resolve();
+  assert.deepEqual(events, ["bootstrap:start", "registerAutomationHooks", "bootstrap:resolved"]);
+});
+
+test("startH5ClientApp reports boot failures while still wiring automation hooks", async () => {
+  const events: string[] = [];
+  const boom = new Error("boot_failed");
+
+  startH5ClientApp({
+    bootstrapApp: async () => {
+      events.push("bootstrap:start");
+      throw boom;
+    },
+    registerAutomationHooks: () => {
+      events.push("registerAutomationHooks");
+    },
+    reportBootstrapError: (error) => {
+      events.push(`reportBootstrapError:${error === boom}`);
+    }
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(events, ["bootstrap:start", "registerAutomationHooks", "reportBootstrapError:true"]);
+});


### PR DESCRIPTION
## Summary
- extract the final H5 app boot handoff from `apps/client/src/main.ts` into a tiny testable seam
- add deterministic regression coverage for main boot kickoff and automation hook registration
- extend `local-session` tests to lock remote-success and local-fallback bootstrap boundaries

## Test Plan
- `node --import tsx --test "apps/client/test/main-entry.test.ts" "apps/client/test/main-boot.test.ts" "apps/client/test/local-session.test.ts"`
- `npm run typecheck:client:h5`
- `npm test`

Closes #315