### PR TITLE
test(cocos): add VeilRoot/VeilCocosSession handoff harness coverage

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -2626,6 +2626,14 @@ export class VeilRoot extends Component {
       return "房间会话已失效，请点击刷新状态恢复。";
     }
 
+    if (
+      error.message === "unsupported_player_world_view_encoding" ||
+      error.message === "invalid_player_world_view_encoding_length" ||
+      error.message === "missing_player_world_view_base"
+    ) {
+      return "房间状态损坏，请重建房间或检查服务端同步。";
+    }
+
     return error.message || fallback;
   }
 

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -231,6 +231,29 @@ test("VeilRoot connect replays cached session state before applying the live sna
   assert.equal(root.lastUpdate?.world.meta.day, 3);
 });
 
+test("VeilRoot surfaces broken room snapshots with a stable runtime error message", async () => {
+  const root = createVeilRootHarness();
+  root.roomId = "room-alpha";
+  root.playerId = "player-1";
+  root.remoteUrl = "http://127.0.0.1:2567";
+
+  installVeilRootRuntime({
+    createSession: async () =>
+      ({
+        async snapshot() {
+          throw new Error("missing_player_world_view_base");
+        },
+        async dispose() {}
+      }) as never
+  });
+
+  await root.connect();
+
+  assert.equal(root.session, null);
+  assert.equal(root.predictionStatus, "房间状态损坏，请重建房间或检查服务端同步。");
+  assert.equal(root.logLines[0], "房间状态损坏，请重建房间或检查服务端同步。");
+});
+
 test("VeilRoot gameplay achievement panel loads achievement progress from the account endpoint", async () => {
   const root = createVeilRootHarness();
   root.playerId = "player-1";

--- a/apps/cocos-client/test/cocos-session-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-session-orchestration.test.ts
@@ -6,6 +6,7 @@ import {
   VeilCocosSession
 } from "../assets/scripts/VeilCocosSession.ts";
 import {
+  createRawStateReply,
   createMemoryStorage,
   createSdkLoader,
   createSessionUpdate,
@@ -15,6 +16,40 @@ import {
 afterEach(() => {
   resetVeilCocosSessionRuntimeForTests();
 });
+
+function encodeBytes(values: number[]): string {
+  return Buffer.from(Uint8Array.from(values)).toString("base64");
+}
+
+function createEncodedStatePayload(options?: {
+  bounds?: { x: number; y: number; width: number; height: number };
+  terrain?: number[];
+  fog?: number[];
+  walkable?: number[];
+}) {
+  const update = createSessionUpdate(1);
+  return {
+    world: {
+      ...update.world,
+      map: {
+        width: update.world.map.width,
+        height: update.world.map.height,
+        encodedTiles: {
+          format: "typed-array-v1",
+          terrain: encodeBytes(options?.terrain ?? [0, 1, 2, 0]),
+          fog: encodeBytes(options?.fog ?? [2, 1, 0, 2]),
+          walkable: encodeBytes(options?.walkable ?? [1, 1, 1, 1]),
+          overlays: [],
+          ...(options?.bounds ? { bounds: options.bounds } : {})
+        }
+      }
+    },
+    battle: null,
+    events: [],
+    movementPlan: null,
+    reachableTiles: [{ x: 0, y: 0 }]
+  };
+}
 
 test("VeilCocosSession reuses a stored reconnection token and announces recovery", async () => {
   const storage = createMemoryStorage();
@@ -83,6 +118,33 @@ test("VeilCocosSession persists local snapshot replay data from live snapshots a
   await session.dispose();
 });
 
+test("VeilCocosSession reports reconnect lifecycle transitions from the active room", async () => {
+  const storage = createMemoryStorage();
+  const room = new FakeColyseusRoom([createSessionUpdate(3)], "reconnect-token");
+  const events: string[] = [];
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    loadSdk: createSdkLoader({
+      joinRooms: [room]
+    })
+  });
+
+  const session = await VeilCocosSession.create("room-alpha", "player-1", 1001, {
+    onConnectionEvent: (event) => {
+      events.push(event);
+    }
+  });
+
+  await session.snapshot();
+  room.emitDrop();
+  room.emitReconnect();
+
+  assert.deepEqual(events, ["reconnecting", "reconnected"]);
+
+  await session.dispose();
+});
+
 test("VeilCocosSession hands off to a fresh room after reconnect failure and replays a recovery snapshot", async () => {
   const storage = createMemoryStorage();
   const initialRoom = new FakeColyseusRoom([createSessionUpdate(1)], "initial-token");
@@ -124,6 +186,64 @@ test("VeilCocosSession hands off to a fresh room after reconnect failure and rep
     { logicalRoomId: "room-alpha", playerId: "player-1", seed: 1001 }
   ]);
   assert.equal(storage.getItem("project-veil:cocos:reconnection:room-alpha:player-1"), "recovered-token");
+
+  await session.dispose();
+});
+
+test("VeilCocosSession rejects malformed encoded room snapshots", async () => {
+  const storage = createMemoryStorage();
+  const room = new FakeColyseusRoom(
+    [
+      createRawStateReply(
+        createEncodedStatePayload({
+          terrain: [0, 1, 2]
+        })
+      )
+    ],
+    "reconnect-token"
+  );
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    loadSdk: createSdkLoader({
+      joinRooms: [room]
+    })
+  });
+
+  const session = await VeilCocosSession.create("room-alpha", "player-1", 1001);
+
+  await assert.rejects(() => session.snapshot(), /invalid_player_world_view_encoding_length/);
+  assert.equal(VeilCocosSession.readStoredReplay("room-alpha", "player-1"), null);
+
+  await session.dispose();
+});
+
+test("VeilCocosSession rejects delta room snapshots before it has an authoritative base", async () => {
+  const storage = createMemoryStorage();
+  const room = new FakeColyseusRoom(
+    [
+      createRawStateReply(
+        createEncodedStatePayload({
+          bounds: { x: 0, y: 0, width: 1, height: 1 },
+          terrain: [0],
+          fog: [2],
+          walkable: [1]
+        })
+      )
+    ],
+    "reconnect-token"
+  );
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    loadSdk: createSdkLoader({
+      joinRooms: [room]
+    })
+  });
+
+  const session = await VeilCocosSession.create("room-alpha", "player-1", 1001);
+
+  await assert.rejects(() => session.snapshot(), /missing_player_world_view_base/);
 
   await session.dispose();
 });

--- a/apps/cocos-client/test/helpers/cocos-session-fixtures.ts
+++ b/apps/cocos-client/test/helpers/cocos-session-fixtures.ts
@@ -1,5 +1,17 @@
 import type { SessionUpdate } from "../../assets/scripts/VeilCocosSession.ts";
 
+type FakeRoomReply =
+  | SessionUpdate
+  | {
+      kind: "state";
+      payload: unknown;
+      delivery?: "reply" | "push";
+    }
+  | {
+      kind: "error";
+      reason: string;
+    };
+
 export function createMemoryStorage(): Storage {
   const values = new Map<string, string>();
   return {
@@ -146,18 +158,33 @@ export function toSessionStatePayload(update: SessionUpdate) {
   };
 }
 
+export function createRawStateReply(payload: unknown, delivery: "reply" | "push" = "reply"): FakeRoomReply {
+  return {
+    kind: "state",
+    payload,
+    delivery
+  };
+}
+
+export function createErrorReply(reason: string): FakeRoomReply {
+  return {
+    kind: "error",
+    reason
+  };
+}
+
 type MessageHandler = (type: string, payload: unknown) => void;
 
 export class FakeColyseusRoom {
   reconnectionToken?: string;
   readonly sentMessages: Array<{ type: string; payload: unknown }> = [];
-  readonly connectReplies: SessionUpdate[];
+  readonly connectReplies: FakeRoomReply[];
   private messageHandler: MessageHandler | null = null;
   private dropHandler: (() => void) | null = null;
   private reconnectHandler: (() => void) | null = null;
   private leaveHandler: ((code: number) => void) | null = null;
 
-  constructor(connectReplies: SessionUpdate[], reconnectionToken?: string) {
+  constructor(connectReplies: FakeRoomReply[], reconnectionToken?: string) {
     this.connectReplies = [...connectReplies];
     this.reconnectionToken = reconnectionToken;
   }
@@ -190,21 +217,38 @@ export class FakeColyseusRoom {
         throw new Error("missing_connect_reply");
       }
 
-      this.messageHandler?.("session.state", {
-        type: "session.state",
-        requestId: payload.requestId,
-        delivery: "reply",
-        payload: toSessionStatePayload(reply)
-      });
+      if ("kind" in reply) {
+        if (reply.kind === "error") {
+          this.emitError(payload.requestId, reply.reason);
+          return;
+        }
+
+        this.emitState(reply.payload, reply.delivery ?? "reply", payload.requestId);
+        return;
+      }
+
+      this.emitState(toSessionStatePayload(reply), "reply", payload.requestId);
     }
   }
 
   emitPush(update: SessionUpdate): void {
+    this.emitState(toSessionStatePayload(update), "push", "push-1");
+  }
+
+  emitState(payload: unknown, delivery: "reply" | "push" = "push", requestId = "push-1"): void {
     this.messageHandler?.("session.state", {
       type: "session.state",
-      requestId: "push-1",
-      delivery: "push",
-      payload: toSessionStatePayload(update)
+      requestId,
+      delivery,
+      payload
+    });
+  }
+
+  emitError(requestId: string, reason: string): void {
+    this.messageHandler?.("error", {
+      type: "error",
+      requestId,
+      reason
     });
   }
 


### PR DESCRIPTION
## Summary
- extend the Cocos Node test doubles so VeilCocosSession tests can drive raw room state, reconnect lifecycle, and malformed session payloads
- add runtime orchestration coverage for reconnect lifecycle transitions, reconnect handoff, replay-before-live convergence, and malformed authoritative snapshot failures
- surface broken room snapshot decode errors in VeilRoot with a stable user-facing message

## Test Plan
- node --import tsx --test ./apps/cocos-client/test/cocos-session-launch.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts ./apps/cocos-client/test/cocos-session-orchestration.test.ts
- npm run typecheck:cocos

Closes #316