### PR TITLE
test(server): cover Colyseus room lifecycle and battle replay emission seams

### DIFF
--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -2,11 +2,28 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { ClientState, matchMaker } from "colyseus";
 import type { Client } from "colyseus";
-import type { ServerMessage } from "../../../packages/shared/src/index";
+import type { BattleState, ServerMessage } from "../../../packages/shared/src/index";
 import { VeilColyseusRoom, configureRoomSnapshotStore, listLobbyRooms, resetLobbyRoomRegistry } from "../src/colyseus-room";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import type { PlayerAccountProgressPatch, PlayerAccountSnapshot } from "../src/persistence";
 
 interface FakeClient extends Client {
   sent: ServerMessage[];
+}
+
+class InstrumentedRoomSnapshotStore extends MemoryRoomSnapshotStore {
+  readonly progressSaves: Array<{ playerId: string; patch: PlayerAccountProgressPatch }> = [];
+
+  override async savePlayerAccountProgress(
+    playerId: string,
+    patch: PlayerAccountProgressPatch
+  ): Promise<PlayerAccountSnapshot> {
+    this.progressSaves.push({
+      playerId,
+      patch: structuredClone(patch)
+    });
+    return super.savePlayerAccountProgress(playerId, patch);
+  }
 }
 
 function createFakeClient(sessionId: string): FakeClient {
@@ -97,6 +114,64 @@ async function emitRoomMessage(room: VeilColyseusRoom, type: string, client: Fak
   await flushAsyncWork();
 }
 
+async function connectPlayer(
+  room: VeilColyseusRoom,
+  client: FakeClient,
+  playerId: string,
+  requestId: string
+): Promise<void> {
+  room.clients.push(client);
+  room.onJoin(client, { playerId });
+  await emitRoomMessage(room, "connect", client, {
+    type: "connect",
+    requestId,
+    roomId: room.roomId,
+    playerId
+  });
+}
+
+function getBattleForPlayer(room: VeilColyseusRoom, playerId: string): BattleState | null {
+  const internalRoom = room as VeilColyseusRoom & {
+    worldRoom: {
+      getBattleForPlayer(playerId: string): BattleState | null;
+    };
+  };
+
+  return internalRoom.worldRoom.getBattleForPlayer(playerId);
+}
+
+async function resolveBattleThroughRoom(room: VeilColyseusRoom, client: FakeClient, playerId: string): Promise<number> {
+  let steps = 0;
+  while (steps < 20) {
+    const battle = getBattleForPlayer(room, playerId);
+    if (!battle) {
+      return steps;
+    }
+
+    const activeUnitId = battle.activeUnitId;
+    const activeUnit = activeUnitId ? battle.units[activeUnitId] : undefined;
+    const target = activeUnit
+      ? Object.values(battle.units).find((unit) => unit.camp !== activeUnit.camp && unit.count > 0)
+      : undefined;
+
+    assert.ok(activeUnitId, "expected an active unit while battle is in progress");
+    assert.ok(target, "expected a valid battle target while battle is in progress");
+
+    await emitRoomMessage(room, "battle.action", client, {
+      type: "battle.action",
+      requestId: `battle-step-${steps + 1}`,
+      action: {
+        type: "battle.attack",
+        attackerId: activeUnitId,
+        defenderId: target.id
+      }
+    });
+    steps += 1;
+  }
+
+  assert.fail(`expected battle for ${playerId} to resolve within 20 player actions`);
+}
+
 function lastSessionState(client: FakeClient, delivery?: "reply" | "push"): Extract<ServerMessage, { type: "session.state" }> {
   const states = client.sent.filter(
     (message): message is Extract<ServerMessage, { type: "session.state" }> =>
@@ -184,6 +259,33 @@ test("client reconnect within the window restores room state and records reconne
   const reconnectedAt = internalRoom.reconnectedAtByPlayerId.get("player-1");
   assert.ok(reconnectedAt);
   assert.equal(new Date(reconnectedAt).toISOString(), reconnectedAt);
+});
+
+test("stale leave after a successful reconnect does not clear the resumed player slot", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-reconnect-leave-${Date.now()}`);
+  const originalClient = createFakeClient("session-stale-original");
+  const reconnectedClient = createFakeClient("session-stale-reconnected");
+  const internalRoom = room as VeilColyseusRoom & {
+    playerIdBySessionId: Map<string, string>;
+    allowReconnection(client: Client, seconds: number): Promise<Client>;
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, originalClient, "player-1", "connect-stale-original");
+  internalRoom.allowReconnection = async () => reconnectedClient;
+
+  await room.onDrop(originalClient);
+  room.onLeave(originalClient);
+
+  assert.equal(internalRoom.playerIdBySessionId.get("session-stale-reconnected"), "player-1");
+  assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 1);
 });
 
 test("client that misses the reconnect window is cleaned up from the player slot map", async (t) => {
@@ -325,6 +427,94 @@ test("disposing one registered room preserves the other room summary", async (t)
     [roomB.roomId]
   );
   assert.equal(remainingRooms[0]?.seed, 2002);
+});
+
+test("battle replay persistence runs once at settlement and is drained from the room buffer", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new InstrumentedRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-replay-${Date.now()}`);
+  const client = createFakeClient("session-replay");
+  const internalRoom = room as VeilColyseusRoom & {
+    worldRoom: {
+      consumeCompletedBattleReplays(): unknown[];
+    };
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, client, "player-1", "connect-replay");
+  await emitRoomMessage(room, "world.action", client, {
+    type: "world.action",
+    requestId: "move-replay",
+    action: {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 5, y: 4 }
+    }
+  });
+
+  assert.equal((await store.loadPlayerAccount("player-1"))?.recentBattleReplays?.length ?? 0, 0);
+
+  const steps = await resolveBattleThroughRoom(room, client, "player-1");
+  const account = await store.loadPlayerAccount("player-1");
+  const replay = account?.recentBattleReplays?.[0];
+  const replaySaves = store.progressSaves.filter(
+    (entry) => entry.playerId === "player-1" && (entry.patch.recentBattleReplays?.length ?? 0) > 0
+  );
+
+  assert.ok(steps > 0);
+  assert.equal(account?.recentBattleReplays?.length, 1);
+  assert.equal(replay?.roomId, room.roomId);
+  assert.equal(replay?.steps.filter((step) => step.source === "player").length, steps);
+  assert.ok((replay?.steps.length ?? 0) > steps);
+  assert.ok(replay?.steps.some((step) => step.source === "automated"));
+  assert.equal(replaySaves.length, 1);
+  assert.equal(replaySaves[0]?.patch.recentBattleReplays?.[0]?.id, replay?.id);
+  assert.deepEqual(internalRoom.worldRoom.consumeCompletedBattleReplays(), []);
+});
+
+test("battle replay persistence stays isolated to the room that settled the battle", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new InstrumentedRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const roomA = await createTestRoom(`lifecycle-replay-room-a-${Date.now()}`, 1001);
+  const roomB = await createTestRoom(`lifecycle-replay-room-b-${Date.now()}`, 2002);
+  const clientA = createFakeClient("session-replay-a");
+  const clientB = createFakeClient("session-replay-b");
+
+  t.after(() => {
+    cleanupRoom(roomA);
+    cleanupRoom(roomB);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(roomA, clientA, "player-1", "connect-replay-a");
+  await connectPlayer(roomB, clientB, "player-2", "connect-replay-b");
+  await emitRoomMessage(roomA, "world.action", clientA, {
+    type: "world.action",
+    requestId: "move-room-a",
+    action: {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 5, y: 4 }
+    }
+  });
+  await resolveBattleThroughRoom(roomA, clientA, "player-1");
+
+  const roomAAccount = await store.loadPlayerAccount("player-1");
+  const roomBAccount = await store.loadPlayerAccount("player-2");
+
+  assert.equal(roomAAccount?.recentBattleReplays?.length, 1);
+  assert.equal(roomAAccount?.recentBattleReplays?.[0]?.roomId, roomA.roomId);
+  assert.equal(roomBAccount?.recentBattleReplays?.length ?? 0, 0);
+  assert.equal(listLobbyRooms().find((entry) => entry.roomId === roomA.roomId)?.activeBattles, 0);
+  assert.equal(listLobbyRooms().find((entry) => entry.roomId === roomB.roomId)?.activeBattles, 0);
 });
 
 test("room at maxClients capacity rejects a new join reservation", async (t) => {


### PR DESCRIPTION
closes #317

## Summary
- add integration-style Colyseus room lifecycle coverage for reconnect/resume, replay persistence, and room isolation boundaries
- verify completed battle replays persist once at settlement and do not leak across rooms
- keep the suite deterministic with an instrumented in-memory snapshot store instead of broader end-to-end setup

## Testing
- node --import tsx --test apps/server/test/colyseus-room-lifecycle.test.ts
- node --import tsx --test apps/server/test/battle-replays.test.ts apps/server/test/room-persistence.test.ts
- npm run typecheck:server