### PR TITLE
test: add shared contract snapshots for client-facing payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,13 @@ npm run dev:client:h5
 - 并发房间压测启动后，也可直接查看同进程观测面：`/api/runtime/health`、`/api/runtime/auth-readiness` 与 `/api/runtime/metrics`
 - 战斗平衡验证：`npm run validate:battle -- --count=1000 --scenario=all --skill-config=configs/battle-skills-v1.1.json`
 - 内容包一致性验证：`npm run validate:content-pack -- --report-path artifacts/content-pack-validation-report.json`
+- 共享客户端载荷 contract 快照：`npm run test:contracts`
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
 - 微信小游戏构建 / 发布 / 回滚说明：`docs/wechat-minigame-release.md`
 - 核心玩法发布门禁清单：`docs/core-gameplay-release-readiness.md`
 - 发布就绪快照说明：`docs/release-readiness-snapshot.md`
+- 共享 contract 快照说明：`docs/shared-contract-snapshots.md`
 - 当前 H5 调试壳仍支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。
 - 当前 H5 联机体验已支持：客户端预测、断线自动重连、刷新后本地快照首帧回放，再由权威房间状态收敛。
 - 当前 Cocos Creator 主客户端已补齐：

--- a/docs/shared-contract-snapshots.md
+++ b/docs/shared-contract-snapshots.md
@@ -1,0 +1,37 @@
+# Shared Contract Snapshots
+
+Issue `#328` adds file-backed shared contract snapshots for high-value client-facing payloads under `packages/shared/test/fixtures/contract-snapshots/`.
+
+## Covered Payloads
+
+- `SessionStatePayload`
+- `PlayerProgressionSnapshot`
+- `RuntimeDiagnosticsSnapshot`
+
+The contract test lives in `packages/shared/test/client-payload-contracts.test.ts` and runs through both:
+
+- `npm run test:contracts`
+- `npm run test:shared`
+
+## Failure Mode
+
+The suite fails when:
+
+- a checked-in snapshot file is missing or renamed
+- a payload shape changes in a way that modifies the serialized JSON contract
+
+Failures print the snapshot path, the first differing line, and the exact refresh command.
+
+## Safe Update Workflow
+
+Only refresh snapshots when the contract change is intentional and reviewed.
+
+```bash
+UPDATE_CONTRACT_SNAPSHOTS=1 npm run test:contracts
+```
+
+Before committing:
+
+- review the JSON diff in `packages/shared/test/fixtures/contract-snapshots/`
+- confirm downstream H5 / Cocos / server consumers still agree on the changed structure
+- include the snapshot update in the same PR as the contract change

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "smoke:client:release-candidate": "node --import tsx ./scripts/release-candidate-client-artifact-smoke.ts",
     "test:release-gate-summary": "node --import tsx --test ./scripts/test/release-gate-summary.test.ts",
     "test:shared": "node --import tsx --test \"packages/shared/test/**/*.test.ts\"",
+    "test:contracts": "node --import tsx --test ./packages/shared/test/client-payload-contracts.test.ts",
     "typecheck:ci": "npm run typecheck:shared && npm run typecheck:server && npm run typecheck:client:h5 && npm run typecheck:cocos",
     "typecheck": "tsc -p tsconfig.base.json --noEmit",
     "typecheck:cocos": "tsc -p apps/cocos-client/tsconfig.json --noEmit",

--- a/packages/shared/test/client-payload-contracts.test.ts
+++ b/packages/shared/test/client-payload-contracts.test.ts
@@ -1,0 +1,386 @@
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  buildPlayerProgressionSnapshot,
+  createDefaultHeroLoadout,
+  createDefaultHeroProgression,
+  createDemoBattleState,
+  createPlayerWorldView,
+  encodePlayerWorldView,
+  type PlayerAchievementProgress,
+  type PlayerProgressionSnapshot,
+  type RuntimeDiagnosticsSnapshot,
+  type SessionStatePayload,
+  type WorldState
+} from "../src/index.ts";
+import { assertContractSnapshot } from "./support/contract-snapshot.ts";
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const CONTRACT_SNAPSHOT_DIR = path.join(THIS_DIR, "fixtures", "contract-snapshots");
+
+function createContractWorldState(): WorldState {
+  return {
+    meta: {
+      roomId: "room-contract",
+      seed: 328,
+      day: 7,
+      mapVariantId: "frontier-basin"
+    },
+    map: {
+      width: 3,
+      height: 2,
+      tiles: [
+        {
+          position: { x: 0, y: 0 },
+          terrain: "grass",
+          walkable: true,
+          resource: undefined,
+          occupant: { kind: "hero", refId: "hero-1" },
+          building: undefined
+        },
+        {
+          position: { x: 1, y: 0 },
+          terrain: "sand",
+          walkable: true,
+          resource: { kind: "wood", amount: 4 },
+          occupant: undefined,
+          building: undefined
+        },
+        {
+          position: { x: 2, y: 0 },
+          terrain: "water",
+          walkable: false,
+          resource: undefined,
+          occupant: undefined,
+          building: undefined
+        },
+        {
+          position: { x: 0, y: 1 },
+          terrain: "dirt",
+          walkable: true,
+          resource: undefined,
+          occupant: undefined,
+          building: undefined
+        },
+        {
+          position: { x: 1, y: 1 },
+          terrain: "grass",
+          walkable: true,
+          resource: undefined,
+          occupant: { kind: "neutral", refId: "neutral-1" },
+          building: undefined
+        },
+        {
+          position: { x: 2, y: 1 },
+          terrain: "grass",
+          walkable: true,
+          resource: undefined,
+          occupant: { kind: "hero", refId: "hero-2" },
+          building: undefined
+        }
+      ]
+    },
+    heroes: [
+      {
+        id: "hero-1",
+        playerId: "player-1",
+        name: "暮火侦骑",
+        position: { x: 0, y: 0 },
+        vision: 3,
+        move: { total: 6, remaining: 4 },
+        stats: { attack: 3, defense: 2, power: 1, knowledge: 1, hp: 26, maxHp: 30 },
+        progression: {
+          ...createDefaultHeroProgression(),
+          level: 2,
+          experience: 120,
+          skillPoints: 1,
+          battlesWon: 2,
+          neutralBattlesWon: 2
+        },
+        loadout: createDefaultHeroLoadout(),
+        armyTemplateId: "hero_guard_basic",
+        armyCount: 14,
+        learnedSkills: []
+      },
+      {
+        id: "hero-2",
+        playerId: "player-2",
+        name: "霜牙掠影",
+        position: { x: 2, y: 1 },
+        vision: 2,
+        move: { total: 6, remaining: 6 },
+        stats: { attack: 2, defense: 3, power: 1, knowledge: 1, hp: 30, maxHp: 30 },
+        progression: createDefaultHeroProgression(),
+        loadout: createDefaultHeroLoadout(),
+        armyTemplateId: "hero_guard_basic",
+        armyCount: 12,
+        learnedSkills: []
+      }
+    ],
+    neutralArmies: {
+      "neutral-1": {
+        id: "neutral-1",
+        position: { x: 1, y: 1 },
+        reward: { kind: "gold", amount: 100 },
+        stacks: [{ templateId: "wolf_pack", count: 8 }]
+      }
+    },
+    buildings: {},
+    resources: {
+      "player-1": { gold: 180, wood: 12, ore: 5 },
+      "player-2": { gold: 90, wood: 4, ore: 3 }
+    },
+    visibilityByPlayer: {
+      "player-1": ["visible", "visible", "explored", "visible", "visible", "visible"]
+    }
+  };
+}
+
+function createSessionStatePayloadFixture(): SessionStatePayload {
+  const worldView = createPlayerWorldView(createContractWorldState(), "player-1");
+
+  return {
+    world: encodePlayerWorldView(worldView),
+    battle: createDemoBattleState(),
+    events: [
+      {
+        type: "hero.moved",
+        heroId: "hero-1",
+        path: [
+          { x: 0, y: 0 },
+          { x: 0, y: 1 }
+        ],
+        moveCost: 1
+      },
+      {
+        type: "battle.started",
+        heroId: "hero-1",
+        attackerPlayerId: "player-1",
+        encounterKind: "neutral",
+        neutralArmyId: "neutral-1",
+        battleId: "battle-demo",
+        path: [
+          { x: 0, y: 1 },
+          { x: 1, y: 1 }
+        ],
+        moveCost: 1
+      }
+    ],
+    movementPlan: {
+      heroId: "hero-1",
+      destination: { x: 1, y: 1 },
+      path: [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 },
+        { x: 1, y: 1 }
+      ],
+      travelPath: [
+        { x: 0, y: 0 },
+        { x: 0, y: 1 }
+      ],
+      moveCost: 1,
+      endsInEncounter: true,
+      encounterKind: "neutral",
+      encounterRefId: "neutral-1"
+    },
+    reachableTiles: [
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 }
+    ],
+    reason: "battle.started"
+  };
+}
+
+function createPlayerProgressionSnapshotFixture(): PlayerProgressionSnapshot {
+  const achievements: Partial<PlayerAchievementProgress>[] = [
+    {
+      id: "first_battle",
+      current: 1,
+      unlocked: true,
+      progressUpdatedAt: "2026-03-29T06:00:00.000Z",
+      unlockedAt: "2026-03-29T06:00:00.000Z"
+    },
+    {
+      id: "enemy_slayer",
+      current: 2,
+      progressUpdatedAt: "2026-03-29T06:30:00.000Z"
+    },
+    {
+      id: "skill_scholar",
+      current: 1,
+      progressUpdatedAt: "2026-03-29T07:00:00.000Z"
+    }
+  ];
+
+  return buildPlayerProgressionSnapshot(
+    achievements,
+    [
+      {
+        id: "player-1:2026-03-29T07:00:00.000Z:achievement:3:skill_scholar",
+        timestamp: "2026-03-29T07:00:00.000Z",
+        roomId: "room-contract",
+        playerId: "player-1",
+        category: "achievement",
+        description: "求知者 进度推进至 1/5。",
+        achievementId: "skill_scholar",
+        rewards: []
+      },
+      {
+        id: "player-1:2026-03-29T06:30:00.000Z:battle.resolved:2",
+        timestamp: "2026-03-29T06:30:00.000Z",
+        roomId: "room-contract",
+        playerId: "player-1",
+        category: "combat",
+        description: "暮火侦骑 击退了中立守军。",
+        heroId: "hero-1",
+        worldEventType: "battle.resolved",
+        rewards: [{ type: "experience", label: "hero_xp", amount: 120 }]
+      },
+      {
+        id: "player-1:2026-03-29T06:00:00.000Z:achievement:1:first_battle",
+        timestamp: "2026-03-29T06:00:00.000Z",
+        roomId: "room-contract",
+        playerId: "player-1",
+        category: "achievement",
+        description: "初次交锋 已解锁。",
+        achievementId: "first_battle",
+        rewards: [{ type: "badge", label: "初次交锋" }]
+      }
+    ],
+    3
+  );
+}
+
+function createRuntimeDiagnosticsSnapshotFixture(): RuntimeDiagnosticsSnapshot {
+  return {
+    schemaVersion: 1,
+    exportedAt: "2026-03-29T07:10:00.000Z",
+    source: {
+      surface: "cocos-runtime-overlay",
+      devOnly: true,
+      mode: "battle"
+    },
+    room: {
+      roomId: "room-contract",
+      playerId: "player-1",
+      day: 7,
+      connectionStatus: "connected",
+      lastUpdateSource: "push",
+      lastUpdateReason: "battle.started",
+      lastUpdateAt: "2026-03-29T07:09:30.000Z"
+    },
+    world: {
+      map: {
+        width: 3,
+        height: 2,
+        visibleTileCount: 5,
+        reachableTileCount: 4
+      },
+      resources: {
+        gold: 180,
+        wood: 12,
+        ore: 5
+      },
+      selectedTile: { x: 1, y: 1 },
+      hoveredTile: { x: 1, y: 1 },
+      keyboardCursor: { x: 0, y: 1 },
+      hero: {
+        id: "hero-1",
+        name: "暮火侦骑",
+        position: { x: 0, y: 0 },
+        move: { total: 6, remaining: 4 },
+        stats: {
+          attack: 3,
+          defense: 2,
+          power: 1,
+          knowledge: 1,
+          hp: 26,
+          maxHp: 30
+        },
+        armyTemplateId: "hero_guard_basic",
+        armyCount: 14,
+        progression: {
+          level: 2,
+          experience: 120,
+          skillPoints: 1,
+          battlesWon: 2,
+          neutralBattlesWon: 2,
+          pvpBattlesWon: 0
+        }
+      },
+      visibleHeroes: [{ id: "hero-2", playerId: "player-2", position: { x: 2, y: 1 } }]
+    },
+    battle: {
+      id: "battle-demo",
+      round: 1,
+      activeUnitId: "wolf-d",
+      selectedTargetId: "pikeman-a",
+      unitCount: 2,
+      environmentCount: 0,
+      logTail: ["战斗开始", "恶狼率先行动"]
+    },
+    account: {
+      playerId: "player-1",
+      displayName: "暮火侦骑",
+      source: "remote",
+      loginId: "veil-ranger",
+      recentEventCount: 3,
+      recentReplayCount: 1
+    },
+    overview: null,
+    diagnostics: {
+      eventTypes: ["hero.moved", "battle.started"],
+      timelineTail: [
+        {
+          id: "timeline-1",
+          tone: "neutral",
+          source: "push",
+          text: "Room room-contract entered battle battle-demo"
+        },
+        {
+          id: "timeline-2",
+          tone: "warning",
+          source: "prediction",
+          text: "Predicted path resolved into neutral encounter"
+        }
+      ],
+      logTail: ["Connected to room-contract", "Pushed authoritative battle snapshot"],
+      recoverySummary: "权威房间已接管预测结果，战斗态一致。",
+      predictionStatus: "server-authoritative",
+      pendingUiTasks: 1,
+      replay: {
+        replayId: "room-contract:battle-demo:player-1",
+        loading: false,
+        status: "paused",
+        currentStepIndex: 0,
+        totalSteps: 2
+      }
+    }
+  };
+}
+
+test("shared contract snapshots stay stable for high-value client-facing payloads", async (t) => {
+  const fixtures = [
+    {
+      name: "session-state-payload",
+      value: createSessionStatePayloadFixture()
+    },
+    {
+      name: "player-progression-snapshot",
+      value: createPlayerProgressionSnapshotFixture()
+    },
+    {
+      name: "runtime-diagnostics-snapshot",
+      value: createRuntimeDiagnosticsSnapshotFixture()
+    }
+  ];
+
+  for (const fixture of fixtures) {
+    await t.test(fixture.name, () => {
+      assertContractSnapshot(path.join(CONTRACT_SNAPSHOT_DIR, `${fixture.name}.json`), fixture.value);
+    });
+  }
+});

--- a/packages/shared/test/fixtures/contract-snapshots/player-progression-snapshot.json
+++ b/packages/shared/test/fixtures/contract-snapshots/player-progression-snapshot.json
@@ -1,0 +1,110 @@
+{
+  "summary": {
+    "totalAchievements": 5,
+    "unlockedAchievements": 1,
+    "inProgressAchievements": 2,
+    "latestProgressAchievementId": "skill_scholar",
+    "latestProgressAchievementTitle": "求知者",
+    "latestProgressAt": "2026-03-29T07:00:00.000Z",
+    "latestUnlockedAchievementId": "first_battle",
+    "latestUnlockedAchievementTitle": "初次交锋",
+    "latestUnlockedAt": "2026-03-29T06:00:00.000Z",
+    "recentEventCount": 3,
+    "latestEventAt": "2026-03-29T07:00:00.000Z"
+  },
+  "achievements": [
+    {
+      "id": "first_battle",
+      "title": "初次交锋",
+      "description": "首次进入战斗。",
+      "metric": "battles_started",
+      "current": 1,
+      "target": 1,
+      "unlocked": true,
+      "progressUpdatedAt": "2026-03-29T06:00:00.000Z",
+      "unlockedAt": "2026-03-29T06:00:00.000Z"
+    },
+    {
+      "id": "enemy_slayer",
+      "title": "猎敌者",
+      "description": "击败 3 名敌人或中立守军。",
+      "metric": "battles_won",
+      "current": 2,
+      "target": 3,
+      "unlocked": false,
+      "progressUpdatedAt": "2026-03-29T06:30:00.000Z"
+    },
+    {
+      "id": "skill_scholar",
+      "title": "求知者",
+      "description": "学习 5 个长期技能。",
+      "metric": "skills_learned",
+      "current": 1,
+      "target": 5,
+      "unlocked": false,
+      "progressUpdatedAt": "2026-03-29T07:00:00.000Z"
+    },
+    {
+      "id": "world_explorer",
+      "title": "踏勘全境",
+      "description": "揭开整张地图的迷雾。",
+      "metric": "maps_fully_explored",
+      "current": 0,
+      "target": 1,
+      "unlocked": false
+    },
+    {
+      "id": "epic_collector",
+      "title": "史诗武装",
+      "description": "为同一名英雄装备全套史诗装备。",
+      "metric": "epic_equipment_slots",
+      "current": 0,
+      "target": 3,
+      "unlocked": false
+    }
+  ],
+  "recentEventLog": [
+    {
+      "id": "player-1:2026-03-29T07:00:00.000Z:achievement:3:skill_scholar",
+      "timestamp": "2026-03-29T07:00:00.000Z",
+      "roomId": "room-contract",
+      "playerId": "player-1",
+      "category": "achievement",
+      "description": "求知者 进度推进至 1/5。",
+      "achievementId": "skill_scholar",
+      "rewards": []
+    },
+    {
+      "id": "player-1:2026-03-29T06:30:00.000Z:battle.resolved:2",
+      "timestamp": "2026-03-29T06:30:00.000Z",
+      "roomId": "room-contract",
+      "playerId": "player-1",
+      "category": "combat",
+      "description": "暮火侦骑 击退了中立守军。",
+      "heroId": "hero-1",
+      "worldEventType": "battle.resolved",
+      "rewards": [
+        {
+          "type": "experience",
+          "label": "hero_xp",
+          "amount": 120
+        }
+      ]
+    },
+    {
+      "id": "player-1:2026-03-29T06:00:00.000Z:achievement:1:first_battle",
+      "timestamp": "2026-03-29T06:00:00.000Z",
+      "roomId": "room-contract",
+      "playerId": "player-1",
+      "category": "achievement",
+      "description": "初次交锋 已解锁。",
+      "achievementId": "first_battle",
+      "rewards": [
+        {
+          "type": "badge",
+          "label": "初次交锋"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/shared/test/fixtures/contract-snapshots/runtime-diagnostics-snapshot.json
+++ b/packages/shared/test/fixtures/contract-snapshots/runtime-diagnostics-snapshot.json
@@ -1,0 +1,138 @@
+{
+  "schemaVersion": 1,
+  "exportedAt": "2026-03-29T07:10:00.000Z",
+  "source": {
+    "surface": "cocos-runtime-overlay",
+    "devOnly": true,
+    "mode": "battle"
+  },
+  "room": {
+    "roomId": "room-contract",
+    "playerId": "player-1",
+    "day": 7,
+    "connectionStatus": "connected",
+    "lastUpdateSource": "push",
+    "lastUpdateReason": "battle.started",
+    "lastUpdateAt": "2026-03-29T07:09:30.000Z"
+  },
+  "world": {
+    "map": {
+      "width": 3,
+      "height": 2,
+      "visibleTileCount": 5,
+      "reachableTileCount": 4
+    },
+    "resources": {
+      "gold": 180,
+      "wood": 12,
+      "ore": 5
+    },
+    "selectedTile": {
+      "x": 1,
+      "y": 1
+    },
+    "hoveredTile": {
+      "x": 1,
+      "y": 1
+    },
+    "keyboardCursor": {
+      "x": 0,
+      "y": 1
+    },
+    "hero": {
+      "id": "hero-1",
+      "name": "暮火侦骑",
+      "position": {
+        "x": 0,
+        "y": 0
+      },
+      "move": {
+        "total": 6,
+        "remaining": 4
+      },
+      "stats": {
+        "attack": 3,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 26,
+        "maxHp": 30
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 14,
+      "progression": {
+        "level": 2,
+        "experience": 120,
+        "skillPoints": 1,
+        "battlesWon": 2,
+        "neutralBattlesWon": 2,
+        "pvpBattlesWon": 0
+      }
+    },
+    "visibleHeroes": [
+      {
+        "id": "hero-2",
+        "playerId": "player-2",
+        "position": {
+          "x": 2,
+          "y": 1
+        }
+      }
+    ]
+  },
+  "battle": {
+    "id": "battle-demo",
+    "round": 1,
+    "activeUnitId": "wolf-d",
+    "selectedTargetId": "pikeman-a",
+    "unitCount": 2,
+    "environmentCount": 0,
+    "logTail": [
+      "战斗开始",
+      "恶狼率先行动"
+    ]
+  },
+  "account": {
+    "playerId": "player-1",
+    "displayName": "暮火侦骑",
+    "source": "remote",
+    "loginId": "veil-ranger",
+    "recentEventCount": 3,
+    "recentReplayCount": 1
+  },
+  "overview": null,
+  "diagnostics": {
+    "eventTypes": [
+      "hero.moved",
+      "battle.started"
+    ],
+    "timelineTail": [
+      {
+        "id": "timeline-1",
+        "tone": "neutral",
+        "source": "push",
+        "text": "Room room-contract entered battle battle-demo"
+      },
+      {
+        "id": "timeline-2",
+        "tone": "warning",
+        "source": "prediction",
+        "text": "Predicted path resolved into neutral encounter"
+      }
+    ],
+    "logTail": [
+      "Connected to room-contract",
+      "Pushed authoritative battle snapshot"
+    ],
+    "recoverySummary": "权威房间已接管预测结果，战斗态一致。",
+    "predictionStatus": "server-authoritative",
+    "pendingUiTasks": 1,
+    "replay": {
+      "replayId": "room-contract:battle-demo:player-1",
+      "loading": false,
+      "status": "paused",
+      "currentStepIndex": 0,
+      "totalSteps": 2
+    }
+  }
+}

--- a/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
+++ b/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
@@ -1,0 +1,322 @@
+{
+  "world": {
+    "meta": {
+      "roomId": "room-contract",
+      "seed": 328,
+      "day": 7,
+      "mapVariantId": "frontier-basin"
+    },
+    "map": {
+      "width": 3,
+      "height": 2,
+      "encodedTiles": {
+        "format": "typed-array-v1",
+        "bounds": {
+          "x": 0,
+          "y": 0,
+          "width": 3,
+          "height": 2
+        },
+        "terrain": "AAIDAQAA",
+        "fog": "AgIBAgIC",
+        "walkable": "AQEAAQEB",
+        "overlays": [
+          {
+            "index": 0,
+            "occupant": {
+              "kind": "hero",
+              "refId": "hero-1"
+            }
+          },
+          {
+            "index": 1,
+            "resource": {
+              "kind": "wood",
+              "amount": 4
+            }
+          },
+          {
+            "index": 4,
+            "occupant": {
+              "kind": "neutral",
+              "refId": "neutral-1"
+            }
+          },
+          {
+            "index": 5,
+            "occupant": {
+              "kind": "hero",
+              "refId": "hero-2"
+            }
+          }
+        ]
+      }
+    },
+    "ownHeroes": [
+      {
+        "id": "hero-1",
+        "playerId": "player-1",
+        "name": "暮火侦骑",
+        "position": {
+          "x": 0,
+          "y": 0
+        },
+        "vision": 3,
+        "move": {
+          "total": 6,
+          "remaining": 4
+        },
+        "stats": {
+          "attack": 3,
+          "defense": 2,
+          "power": 1,
+          "knowledge": 1,
+          "hp": 26,
+          "maxHp": 30
+        },
+        "progression": {
+          "level": 2,
+          "experience": 120,
+          "skillPoints": 1,
+          "battlesWon": 2,
+          "neutralBattlesWon": 2,
+          "pvpBattlesWon": 0
+        },
+        "loadout": {
+          "learnedSkills": [],
+          "equipment": {
+            "trinketIds": []
+          },
+          "inventory": []
+        },
+        "armyTemplateId": "hero_guard_basic",
+        "armyCount": 14,
+        "learnedSkills": []
+      }
+    ],
+    "visibleHeroes": [
+      {
+        "id": "hero-2",
+        "playerId": "player-2",
+        "name": "霜牙掠影",
+        "position": {
+          "x": 2,
+          "y": 1
+        }
+      }
+    ],
+    "resources": {
+      "gold": 180,
+      "wood": 12,
+      "ore": 5
+    },
+    "playerId": "player-1"
+  },
+  "battle": {
+    "id": "battle-demo",
+    "round": 1,
+    "lanes": 1,
+    "activeUnitId": "wolf-d",
+    "turnOrder": [
+      "wolf-d",
+      "pikeman-a"
+    ],
+    "units": {
+      "pikeman-a": {
+        "id": "pikeman-a",
+        "templateId": "hero_guard_basic",
+        "camp": "attacker",
+        "lane": 0,
+        "stackName": "枪兵",
+        "initiative": 8,
+        "attack": 4,
+        "defense": 5,
+        "minDamage": 1,
+        "maxDamage": 3,
+        "count": 12,
+        "currentHp": 10,
+        "maxHp": 10,
+        "hasRetaliated": false,
+        "defending": false,
+        "skills": [
+          {
+            "id": "power_shot",
+            "name": "投矛射击",
+            "description": "远程压制目标，伤害略低，但不会触发反击。",
+            "kind": "active",
+            "target": "enemy",
+            "delivery": "ranged",
+            "cooldown": 2,
+            "remainingCooldown": 0
+          },
+          {
+            "id": "armor_spell",
+            "name": "护甲术",
+            "description": "为自己附加护甲术，在后续回合提升防御。",
+            "kind": "active",
+            "target": "self",
+            "cooldown": 3,
+            "remainingCooldown": 0
+          },
+          {
+            "id": "battle_focus",
+            "name": "战意激发",
+            "description": "短暂提升自身攻击，适合在贴身缠斗前蓄势。",
+            "kind": "active",
+            "target": "self",
+            "cooldown": 3,
+            "remainingCooldown": 0
+          },
+          {
+            "id": "sundering_spear",
+            "name": "破甲投枪",
+            "description": "投出破甲短枪，伤害略低，但能在数回合内撕开目标防线。",
+            "kind": "active",
+            "target": "enemy",
+            "delivery": "ranged",
+            "cooldown": 2,
+            "remainingCooldown": 0
+          }
+        ],
+        "statusEffects": []
+      },
+      "wolf-d": {
+        "id": "wolf-d",
+        "templateId": "wolf_pack",
+        "camp": "defender",
+        "lane": 0,
+        "stackName": "恶狼",
+        "initiative": 10,
+        "attack": 6,
+        "defense": 4,
+        "minDamage": 2,
+        "maxDamage": 4,
+        "count": 8,
+        "currentHp": 8,
+        "maxHp": 8,
+        "hasRetaliated": false,
+        "defending": false,
+        "skills": [
+          {
+            "id": "venomous_fangs",
+            "name": "毒牙",
+            "description": "命中后让目标陷入中毒，回合开始时持续掉血。",
+            "kind": "passive",
+            "target": "enemy",
+            "cooldown": 0,
+            "remainingCooldown": 0
+          },
+          {
+            "id": "crippling_howl",
+            "name": "裂伤嚎叫",
+            "description": "发出撕裂嚎叫，压低伤害换取削弱效果，且不触发反击。",
+            "kind": "active",
+            "target": "enemy",
+            "delivery": "ranged",
+            "cooldown": 3,
+            "remainingCooldown": 0
+          }
+        ],
+        "statusEffects": []
+      }
+    },
+    "environment": [],
+    "log": [
+      "战斗开始"
+    ],
+    "rng": {
+      "seed": 4242,
+      "cursor": 0
+    }
+  },
+  "events": [
+    {
+      "type": "hero.moved",
+      "heroId": "hero-1",
+      "path": [
+        {
+          "x": 0,
+          "y": 0
+        },
+        {
+          "x": 0,
+          "y": 1
+        }
+      ],
+      "moveCost": 1
+    },
+    {
+      "type": "battle.started",
+      "heroId": "hero-1",
+      "attackerPlayerId": "player-1",
+      "encounterKind": "neutral",
+      "neutralArmyId": "neutral-1",
+      "battleId": "battle-demo",
+      "path": [
+        {
+          "x": 0,
+          "y": 1
+        },
+        {
+          "x": 1,
+          "y": 1
+        }
+      ],
+      "moveCost": 1
+    }
+  ],
+  "movementPlan": {
+    "heroId": "hero-1",
+    "destination": {
+      "x": 1,
+      "y": 1
+    },
+    "path": [
+      {
+        "x": 0,
+        "y": 0
+      },
+      {
+        "x": 0,
+        "y": 1
+      },
+      {
+        "x": 1,
+        "y": 1
+      }
+    ],
+    "travelPath": [
+      {
+        "x": 0,
+        "y": 0
+      },
+      {
+        "x": 0,
+        "y": 1
+      }
+    ],
+    "moveCost": 1,
+    "endsInEncounter": true,
+    "encounterKind": "neutral",
+    "encounterRefId": "neutral-1"
+  },
+  "reachableTiles": [
+    {
+      "x": 0,
+      "y": 0
+    },
+    {
+      "x": 1,
+      "y": 0
+    },
+    {
+      "x": 0,
+      "y": 1
+    },
+    {
+      "x": 1,
+      "y": 1
+    }
+  ],
+  "reason": "battle.started"
+}

--- a/packages/shared/test/support/contract-snapshot.ts
+++ b/packages/shared/test/support/contract-snapshot.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export const CONTRACT_SNAPSHOT_UPDATE_COMMAND = "UPDATE_CONTRACT_SNAPSHOTS=1 npm run test:contracts";
+
+function shouldUpdateContractSnapshots(): boolean {
+  const value = process.env.UPDATE_CONTRACT_SNAPSHOTS?.trim().toLowerCase();
+  return value === "1" || value === "true";
+}
+
+function formatSnapshot(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function describeFirstDifference(expected: string, actual: string): string {
+  const expectedLines = expected.split("\n");
+  const actualLines = actual.split("\n");
+  const maxLineCount = Math.max(expectedLines.length, actualLines.length);
+
+  for (let index = 0; index < maxLineCount; index += 1) {
+    if (expectedLines[index] !== actualLines[index]) {
+      return `line ${index + 1}\nexpected: ${JSON.stringify(expectedLines[index] ?? "")}\nactual:   ${JSON.stringify(actualLines[index] ?? "")}`;
+    }
+  }
+
+  return "contents differ";
+}
+
+export function assertContractSnapshot(snapshotFilePath: string, value: unknown): void {
+  const actual = formatSnapshot(value);
+  const relativeSnapshotPath = path.relative(process.cwd(), snapshotFilePath);
+
+  if (shouldUpdateContractSnapshots()) {
+    mkdirSync(path.dirname(snapshotFilePath), { recursive: true });
+    writeFileSync(snapshotFilePath, actual, "utf8");
+    return;
+  }
+
+  if (!existsSync(snapshotFilePath)) {
+    assert.fail(
+      [
+        `Missing contract snapshot: ${relativeSnapshotPath}`,
+        `Create or refresh it with: ${CONTRACT_SNAPSHOT_UPDATE_COMMAND}`
+      ].join("\n")
+    );
+  }
+
+  const expected = readFileSync(snapshotFilePath, "utf8");
+  if (expected !== actual) {
+    assert.fail(
+      [
+        `Contract snapshot mismatch: ${relativeSnapshotPath}`,
+        describeFirstDifference(expected, actual),
+        `If this structural change is intentional, review the diff and rerun: ${CONTRACT_SNAPSHOT_UPDATE_COMMAND}`
+      ].join("\n")
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared file-backed contract snapshot harness for high-value client-facing payloads
- lock SessionStatePayload, PlayerProgressionSnapshot, and RuntimeDiagnosticsSnapshot to checked-in JSON snapshots
- document the safe snapshot refresh workflow and expose a lightweight npm test command

Closes #328