### PR TITLE
Add CI workflow for full multiplayer Playwright suite

### DIFF
--- a/.github/workflows/playwright-multiplayer.yml
+++ b/.github/workflows/playwright-multiplayer.yml
@@ -1,0 +1,50 @@
+name: Playwright Multiplayer
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: playwright-multiplayer-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  multiplayer:
+    name: Multiplayer Full Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run multiplayer Playwright suite
+        run: npm run test:e2e:multiplayer
+
+      - name: Upload multiplayer Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-multiplayer-${{ github.sha }}
+          path: |
+            playwright-report
+            test-results
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for the full multiplayer Playwright suite
- keep the existing smoke workflow unchanged
- upload `playwright-report` and `test-results/` with 14-day retention to match smoke

## Validation
- `npx playwright test --config=playwright.multiplayer.config.ts --list`
- `npm run test:e2e:multiplayer` *(blocked locally: Chromium could not launch because `libatk-bridge-2.0.so.0` is missing in this host environment)*

Closes #332