### PR TITLE
feat: add per-IP rate limiting to matchmaking queue endpoints

### DIFF
--- a/apps/server/src/matchmaking.ts
+++ b/apps/server/src/matchmaking.ts
@@ -10,9 +10,24 @@ import {
   type MatchmakingRequest
 } from "../../../packages/shared/src/index";
 import { validateAuthSessionFromRequest } from "./auth";
+import { recordMatchmakingRateLimited } from "./observability";
 import type { RoomSnapshotStore } from "./persistence";
 
 export const DEFAULT_MATCHMAKING_QUEUE_TTL_SECONDS = 5 * 60;
+const DEFAULT_RATE_LIMIT_MATCHMAKING_WINDOW_MS = 60_000;
+const DEFAULT_RATE_LIMIT_MATCHMAKING_MAX = 30;
+
+interface MatchmakingRuntimeConfig {
+  rateLimitWindowMs: number;
+  rateLimitMax: number;
+}
+
+interface RateLimitResult {
+  allowed: boolean;
+  retryAfterSeconds?: number;
+}
+
+const matchmakingRateLimitCounters = new Map<string, number[]>();
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -25,6 +40,99 @@ function toErrorPayload(error: unknown): { code: string; message: string } {
     code: error instanceof Error ? error.name || "error" : "error",
     message: error instanceof Error ? error.message : String(error)
   };
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function parseEnvNumber(
+  value: string | undefined,
+  fallback: number,
+  options: { minimum?: number; integer?: boolean } = {}
+): number {
+  const parsed = Number(value?.trim());
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  const normalized = options.integer ? Math.floor(parsed) : parsed;
+  if (options.minimum != null && normalized < options.minimum) {
+    return fallback;
+  }
+
+  return normalized;
+}
+
+function readMatchmakingRuntimeConfig(env: NodeJS.ProcessEnv = process.env): MatchmakingRuntimeConfig {
+  return {
+    rateLimitWindowMs: parseEnvNumber(
+      env.VEIL_RATE_LIMIT_MATCHMAKING_WINDOW_MS,
+      DEFAULT_RATE_LIMIT_MATCHMAKING_WINDOW_MS,
+      {
+        minimum: 1,
+        integer: true
+      }
+    ),
+    rateLimitMax: parseEnvNumber(env.VEIL_RATE_LIMIT_MATCHMAKING_MAX, DEFAULT_RATE_LIMIT_MATCHMAKING_MAX, {
+      minimum: 1,
+      integer: true
+    })
+  };
+}
+
+function readHeaderValue(value: string | string[] | undefined): string | null {
+  return Array.isArray(value) ? value[0]?.trim() || null : value?.trim() || null;
+}
+
+function readHeaderCsvValue(value: string | string[] | undefined): string | null {
+  const headerValue = readHeaderValue(value);
+  return headerValue?.split(",")[0]?.trim() || null;
+}
+
+function resolveRequestIp(request: Pick<IncomingMessage, "headers" | "socket">): string {
+  const forwardedFor = readHeaderCsvValue(request.headers["x-forwarded-for"]);
+  const rawIp = forwardedFor || request.socket.remoteAddress?.trim() || "unknown";
+  return rawIp.startsWith("::ffff:") ? rawIp.slice("::ffff:".length) : rawIp;
+}
+
+function consumeSlidingWindowRateLimit(key: string, config = readMatchmakingRuntimeConfig()): RateLimitResult {
+  const currentTime = nowMs();
+  const windowStart = currentTime - config.rateLimitWindowMs;
+  const timestamps = (matchmakingRateLimitCounters.get(key) ?? []).filter((timestamp) => timestamp > windowStart);
+  if (timestamps.length >= config.rateLimitMax) {
+    matchmakingRateLimitCounters.set(key, timestamps);
+    const oldestTimestamp = timestamps[0] ?? currentTime;
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((oldestTimestamp + config.rateLimitWindowMs - currentTime) / 1000))
+    };
+  }
+
+  timestamps.push(currentTime);
+  matchmakingRateLimitCounters.set(key, timestamps);
+  return { allowed: true };
+}
+
+function enforceMatchmakingRateLimit(
+  request: Pick<IncomingMessage, "headers" | "socket">,
+  response: ServerResponse,
+  endpointKey: string
+): boolean {
+  const rateLimitResult = consumeSlidingWindowRateLimit(`${endpointKey}:${resolveRequestIp(request)}`);
+  if (rateLimitResult.allowed) {
+    return true;
+  }
+
+  recordMatchmakingRateLimited();
+  response.setHeader("Retry-After", String(rateLimitResult.retryAfterSeconds ?? 1));
+  sendJson(response, 429, {
+    error: {
+      code: "rate_limited",
+      message: "Too many matchmaking requests, please retry later"
+    }
+  });
+  return false;
 }
 
 async function requireAuthSession(
@@ -201,6 +309,7 @@ let configuredMatchmakingService = new MatchmakingService();
 
 export function resetMatchmakingService(): void {
   configuredMatchmakingService = new MatchmakingService();
+  matchmakingRateLimitCounters.clear();
 }
 
 export function registerMatchmakingRoutes(
@@ -234,6 +343,10 @@ export function registerMatchmakingRoutes(
   });
 
   app.post("/api/matchmaking/enqueue", async (request, response) => {
+    if (!enforceMatchmakingRateLimit(request, response, "enqueue")) {
+      return;
+    }
+
     if (queueTtlMs > 0) {
       service.pruneStaleEntries(queueTtlMs);
     }
@@ -283,7 +396,11 @@ export function registerMatchmakingRoutes(
     }
   });
 
-  app.delete("/api/matchmaking/dequeue", async (request, response) => {
+  const cancelHandler = async (request: IncomingMessage, response: ServerResponse) => {
+    if (!enforceMatchmakingRateLimit(request, response, "cancel")) {
+      return;
+    }
+
     const authSession = await requireAuthSession(request, response, options.store);
     if (!authSession) {
       return;
@@ -296,9 +413,16 @@ export function registerMatchmakingRoutes(
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
-  });
+  };
+
+  app.delete("/api/matchmaking/cancel", cancelHandler);
+  app.delete("/api/matchmaking/dequeue", cancelHandler);
 
   app.get("/api/matchmaking/status", async (request, response) => {
+    if (!enforceMatchmakingRateLimit(request, response, "status")) {
+      return;
+    }
+
     const authSession = await requireAuthSession(request, response, options.store);
     if (!authSession) {
       return;

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -37,6 +37,10 @@ interface AuthObservabilityCounters {
   tokenDeliveryDeadLettersTotal: number;
 }
 
+interface MatchmakingObservabilityCounters {
+  rateLimitedTotal: number;
+}
+
 type AuthSessionFailureReason = "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked";
 type AuthTokenDeliveryFailureReason = "misconfigured" | "timeout" | "network" | "webhook_4xx" | "webhook_429" | "webhook_5xx";
 type AuthTokenDeliveryAttemptStatus = "disabled" | "dev-token" | "delivered" | "retry_scheduled" | "dead-lettered";
@@ -75,6 +79,9 @@ interface RuntimeObservabilityState {
   rooms: Map<string, RuntimeRoomSnapshot>;
   counters: RuntimeObservabilityCounters;
   auth: AuthObservabilityState;
+  matchmaking: {
+    counters: MatchmakingObservabilityCounters;
+  };
 }
 
 interface RuntimeHealthPayload {
@@ -116,6 +123,9 @@ interface RuntimeHealthPayload {
         >;
         failureReasons: Record<AuthTokenDeliveryFailureReason, number>;
       };
+    };
+    matchmaking: {
+      counters: MatchmakingObservabilityCounters;
     };
   };
 }
@@ -195,6 +205,11 @@ const runtimeObservability: RuntimeObservabilityState = {
       webhook_5xx: 0
     },
     tokenDeliveryRecentAttempts: []
+  },
+  matchmaking: {
+    counters: {
+      rateLimitedTotal: 0
+    }
   }
 };
 
@@ -265,6 +280,9 @@ function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPaylo
           },
           failureReasons: { ...runtimeObservability.auth.tokenDeliveryFailureReasons }
         }
+      },
+      matchmaking: {
+        counters: { ...runtimeObservability.matchmaking.counters }
       }
     }
   };
@@ -406,7 +424,8 @@ function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): Runtim
       logTail: [
         `service ${service} rooms=${health.runtime.activeRoomCount} connections=${health.runtime.connectionCount}`,
         `traffic connect=${health.runtime.gameplayTraffic.connectMessagesTotal} world=${health.runtime.gameplayTraffic.worldActionsTotal} battle=${health.runtime.gameplayTraffic.battleActionsTotal}`,
-        `auth guest=${health.runtime.auth.activeGuestSessionCount} account=${health.runtime.auth.activeAccountSessionCount} queue=${health.runtime.auth.tokenDelivery.queueCount}`
+        `auth guest=${health.runtime.auth.activeGuestSessionCount} account=${health.runtime.auth.activeAccountSessionCount} queue=${health.runtime.auth.tokenDelivery.queueCount} rateLimited=${health.runtime.auth.counters.rateLimitedTotal}`,
+        `matchmaking rateLimited=${health.runtime.matchmaking.counters.rateLimitedTotal}`
       ],
       recoverySummary: null,
       predictionStatus: "server-observability",
@@ -489,6 +508,9 @@ function buildMetricsDocument(): string {
     "# HELP veil_auth_rate_limited_total Total auth requests rejected by rate limiting.",
     "# TYPE veil_auth_rate_limited_total counter",
     `veil_auth_rate_limited_total ${health.runtime.auth.counters.rateLimitedTotal}`,
+    "# HELP veil_matchmaking_rate_limited_total Total matchmaking requests rejected by rate limiting.",
+    "# TYPE veil_matchmaking_rate_limited_total counter",
+    `veil_matchmaking_rate_limited_total ${health.runtime.matchmaking.counters.rateLimitedTotal}`,
     "# HELP veil_auth_invalid_credentials_total Total auth requests rejected for invalid credentials.",
     "# TYPE veil_auth_invalid_credentials_total counter",
     `veil_auth_invalid_credentials_total ${health.runtime.auth.counters.invalidCredentialsTotal}`,
@@ -651,6 +673,10 @@ export function recordAuthRateLimited(): void {
   runtimeObservability.auth.counters.rateLimitedTotal += 1;
 }
 
+export function recordMatchmakingRateLimited(): void {
+  runtimeObservability.matchmaking.counters.rateLimitedTotal += 1;
+}
+
 export function recordAuthInvalidCredentials(): void {
   runtimeObservability.auth.counters.invalidCredentialsTotal += 1;
 }
@@ -745,6 +771,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.auth.tokenDeliveryFailureReasons.webhook_429 = 0;
   runtimeObservability.auth.tokenDeliveryFailureReasons.webhook_5xx = 0;
   runtimeObservability.auth.tokenDeliveryRecentAttempts.length = 0;
+  runtimeObservability.matchmaking.counters.rateLimitedTotal = 0;
 }
 
 export function registerRuntimeObservabilityRoutes(

--- a/apps/server/test/matchmaking-routes.test.ts
+++ b/apps/server/test/matchmaking-routes.test.ts
@@ -12,7 +12,26 @@ import {
 import { issueGuestAuthSession, resetGuestAuthSessions } from "../src/auth";
 import { MatchmakingService, registerMatchmakingRoutes, resetMatchmakingService } from "../src/matchmaking";
 import { createMemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import { resetRuntimeObservability } from "../src/observability";
 import type { RoomSnapshotStore } from "../src/persistence";
+
+function withEnvOverrides(overrides: Record<string, string | undefined>, cleanup: Array<() => void>): void {
+  for (const [key, value] of Object.entries(overrides)) {
+    const previousValue = process.env[key];
+    if (value == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+    cleanup.push(() => {
+      if (previousValue == null) {
+        delete process.env[key];
+        return;
+      }
+      process.env[key] = previousValue;
+    });
+  }
+}
 
 function createHero(playerId: string, heroId: string): HeroState {
   return {
@@ -74,6 +93,7 @@ async function startMatchmakingServer(
 ): Promise<Server> {
   resetGuestAuthSessions();
   resetMatchmakingService();
+  resetRuntimeObservability();
   const transport = new WebSocketTransport();
   registerMatchmakingRoutes(transport.getExpressApp() as never, {
     store,
@@ -182,7 +202,7 @@ test("matchmaking routes enqueue, match, report status, and dequeue cleanly", as
   assert.equal(statusTwoPayload.status, "matched");
   assert.equal(statusTwoPayload.roomId, statusOnePayload.roomId);
 
-  const dequeueTwo = await fetch(`http://127.0.0.1:${port}/api/matchmaking/dequeue`, {
+  const dequeueTwo = await fetch(`http://127.0.0.1:${port}/api/matchmaking/cancel`, {
     method: "DELETE",
     headers: {
       Authorization: `Bearer ${sessionTwo.token}`
@@ -191,7 +211,7 @@ test("matchmaking routes enqueue, match, report status, and dequeue cleanly", as
   const dequeueTwoPayload = (await dequeueTwo.json()) as { status: string };
   assert.equal(dequeueTwoPayload.status, "idle");
 
-  const dequeueOne = await fetch(`http://127.0.0.1:${port}/api/matchmaking/dequeue`, {
+  const dequeueOne = await fetch(`http://127.0.0.1:${port}/api/matchmaking/cancel`, {
     method: "DELETE",
     headers: {
       Authorization: `Bearer ${sessionOne.token}`
@@ -237,6 +257,131 @@ test("matchmaking enqueue prunes stale queue entries before adding new players",
   });
   assert.equal(enqueueResponse.status, 200);
   assert.equal(service.getStatus("player-stale").status, "idle");
+});
+
+test("matchmaking routes return 429 with Retry-After after the per-IP rate limit is exceeded", { concurrency: false }, async (t) => {
+  const cleanup: Array<() => void> = [];
+  withEnvOverrides(
+    {
+      VEIL_RATE_LIMIT_MATCHMAKING_WINDOW_MS: "60000",
+      VEIL_RATE_LIMIT_MATCHMAKING_MAX: "2"
+    },
+    cleanup
+  );
+
+  const store = createMemoryRoomSnapshotStore();
+  await store.save(
+    "room-rate-limit",
+    createSnapshot("room-rate-limit", [createHero("player-1", "hero-1"), createHero("player-2", "hero-2")])
+  );
+  await store.ensurePlayerAccount({ playerId: "player-1", displayName: "One", lastRoomId: "room-rate-limit" });
+  await store.ensurePlayerAccount({ playerId: "player-2", displayName: "Two", lastRoomId: "room-rate-limit" });
+
+  const port = 43000 + Math.floor(Math.random() * 1000);
+  const server = await startMatchmakingServer(store, port);
+  const sessionOne = issueGuestAuthSession({ playerId: "player-1", displayName: "One" });
+  const sessionTwo = issueGuestAuthSession({ playerId: "player-2", displayName: "Two" });
+
+  t.after(async () => {
+    cleanup.reverse().forEach((fn) => fn());
+    resetGuestAuthSessions();
+    resetMatchmakingService();
+    resetRuntimeObservability();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  for (const session of [sessionOne, sessionTwo]) {
+    const response = await fetch(`http://127.0.0.1:${port}/api/matchmaking/status`, {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    });
+    assert.equal(response.status, 200);
+  }
+
+  const limitedStatusResponse = await fetch(`http://127.0.0.1:${port}/api/matchmaking/status`, {
+    headers: {
+      Authorization: `Bearer ${sessionOne.token}`
+    }
+  });
+  const limitedStatusPayload = (await limitedStatusResponse.json()) as { error: { code: string } };
+
+  assert.equal(limitedStatusResponse.status, 429);
+  assert.equal(limitedStatusPayload.error.code, "rate_limited");
+  assert.equal(limitedStatusResponse.headers.get("Retry-After"), "60");
+
+  for (const session of [sessionOne, sessionTwo]) {
+    const response = await fetch(`http://127.0.0.1:${port}/api/matchmaking/cancel`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    });
+    assert.equal(response.status, 200);
+  }
+
+  const limitedCancelResponse = await fetch(`http://127.0.0.1:${port}/api/matchmaking/cancel`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${sessionOne.token}`
+    }
+  });
+  const limitedCancelPayload = (await limitedCancelResponse.json()) as { error: { code: string } };
+
+  assert.equal(limitedCancelResponse.status, 429);
+  assert.equal(limitedCancelPayload.error.code, "rate_limited");
+  assert.equal(limitedCancelResponse.headers.get("Retry-After"), "60");
+});
+
+test("matchmaking enqueue returns 429 with Retry-After after the per-IP rate limit is exceeded", { concurrency: false }, async (t) => {
+  const cleanup: Array<() => void> = [];
+  withEnvOverrides(
+    {
+      VEIL_RATE_LIMIT_MATCHMAKING_WINDOW_MS: "60000",
+      VEIL_RATE_LIMIT_MATCHMAKING_MAX: "2"
+    },
+    cleanup
+  );
+
+  const store = createMemoryRoomSnapshotStore();
+  await store.save("room-enqueue-limit", createSnapshot("room-enqueue-limit", [createHero("player-1", "hero-1")]));
+  await store.ensurePlayerAccount({ playerId: "player-1", displayName: "One", lastRoomId: "room-enqueue-limit" });
+
+  const port = 43000 + Math.floor(Math.random() * 1000);
+  const server = await startMatchmakingServer(store, port);
+  const session = issueGuestAuthSession({ playerId: "player-1", displayName: "One" });
+
+  t.after(async () => {
+    cleanup.reverse().forEach((fn) => fn());
+    resetGuestAuthSessions();
+    resetMatchmakingService();
+    resetRuntimeObservability();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const response = await fetch(`http://127.0.0.1:${port}/api/matchmaking/enqueue`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    });
+    assert.equal(response.status, 200);
+  }
+
+  const limitedResponse = await fetch(`http://127.0.0.1:${port}/api/matchmaking/enqueue`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const limitedPayload = (await limitedResponse.json()) as { error: { code: string } };
+
+  assert.equal(limitedResponse.status, 429);
+  assert.equal(limitedPayload.error.code, "rate_limited");
+  assert.equal(limitedResponse.headers.get("Retry-After"), "60");
 });
 
 test("pruneStaleEntries retains entries newer than TTL", () => {

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -5,7 +5,11 @@ import { Server, WebSocketTransport } from "colyseus";
 import type { ClientMessage, ServerMessage } from "../../../packages/shared/src/index";
 import { resetAccountTokenDeliveryState } from "../src/account-token-delivery";
 import { configureRoomSnapshotStore, resetLobbyRoomRegistry, VeilColyseusRoom } from "../src/colyseus-room";
-import { registerRuntimeObservabilityRoutes, resetRuntimeObservability } from "../src/observability";
+import {
+  recordMatchmakingRateLimited,
+  registerRuntimeObservabilityRoutes,
+  resetRuntimeObservability
+} from "../src/observability";
 
 async function wait(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -112,6 +116,8 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   );
 
   await wait(100);
+  recordMatchmakingRateLimited();
+  recordMatchmakingRateLimited();
 
   const healthResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/health`);
   const healthPayload = (await healthResponse.json()) as {
@@ -133,6 +139,11 @@ test("runtime observability routes expose live room counts and gameplay traffic"
           sessionChecksTotal: number;
         };
       };
+      matchmaking: {
+        counters: {
+          rateLimitedTotal: number;
+        };
+      };
     };
   };
 
@@ -148,6 +159,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(healthPayload.runtime.auth.activeGuestSessionCount, 0);
   assert.equal(healthPayload.runtime.auth.activeAccountSessionCount, 0);
   assert.equal(healthPayload.runtime.auth.counters.sessionChecksTotal, 0);
+  assert.equal(healthPayload.runtime.matchmaking.counters.rateLimitedTotal, 2);
 
   const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
   const readinessPayload = (await readinessResponse.json()) as {
@@ -216,4 +228,5 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(metricsText, /^veil_auth_guest_sessions 0$/m);
   assert.match(metricsText, /^veil_auth_account_sessions 0$/m);
   assert.match(metricsText, /^veil_auth_session_checks_total 0$/m);
+  assert.match(metricsText, /^veil_matchmaking_rate_limited_total 2$/m);
 });


### PR DESCRIPTION
## Summary
- add per-IP sliding-window rate limiting to `POST /api/matchmaking/enqueue`, `GET /api/matchmaking/status`, and `DELETE /api/matchmaking/cancel`
- make matchmaking limiter thresholds configurable with `VEIL_RATE_LIMIT_MATCHMAKING_WINDOW_MS` and `VEIL_RATE_LIMIT_MATCHMAKING_MAX`, while keeping `/api/matchmaking/dequeue` as a compatibility alias
- expose `matchmakingRateLimitedTotal` in runtime health/metrics observability and add targeted tests for `429` and `Retry-After`

## Validation
- `npm run typecheck:server`
- `node --import tsx --test apps/server/test/matchmaking-routes.test.ts apps/server/test/runtime-observability-routes.test.ts`

Closes #331.
