### PR TITLE
test: cover H5 boot fallback wiring

### DIFF
--- a/apps/client/src/main-launch.ts
+++ b/apps/client/src/main-launch.ts
@@ -1,0 +1,114 @@
+import type { StoredAuthSession } from "./auth-session";
+import { startH5ClientApp } from "./main-entry";
+import { bootstrapH5App, registerAutomationHooks } from "./main-boot";
+import type { SessionUpdate } from "./local-session";
+
+interface LobbyBootState {
+  playerId: string;
+  displayName: string;
+  loginId: string;
+  authSession: StoredAuthSession | null;
+}
+
+interface MainLaunchState {
+  lobby: LobbyBootState;
+  accountDraftName: string;
+  accountLoginId: string;
+  diagnostics: {
+    connectionStatus: "connecting" | "connected" | "reconnecting" | "reconnect_failed";
+  };
+  log: string[];
+}
+
+interface MainLaunchSession {
+  snapshot(): Promise<SessionUpdate>;
+}
+
+interface LaunchH5ClientAppOptions {
+  state: MainLaunchState;
+  shouldBootGame: boolean;
+  queryPlayerId: string;
+  roomId: string;
+  playerId: string;
+  bindKeyboardShortcuts: () => void;
+  render: () => void;
+  syncCurrentAuthSession: () => Promise<StoredAuthSession | null>;
+  refreshLobbyRoomList: () => Promise<void>;
+  logoutGuestSession: () => void;
+  readStoredSessionReplay: (roomId: string, playerId: string) => SessionUpdate | null;
+  applyReplayedUpdate: (update: SessionUpdate) => void;
+  getSession: () => Promise<MainLaunchSession>;
+  applyUpdate: (update: SessionUpdate, source: "system") => void;
+  syncPlayerAccountProfile: () => Promise<void> | void;
+  window: {
+    render_game_to_text?: () => string;
+    export_diagnostic_snapshot?: () => string;
+    render_diagnostic_snapshot_to_text?: () => string;
+    advanceTime?: (ms: number) => Promise<void>;
+  };
+  devDiagnosticsEnabled: boolean;
+  renderGameToText: () => string;
+  exportDiagnosticSnapshot: () => string;
+  renderDiagnosticSnapshotToText: () => string;
+  advanceUiTime: (ms: number) => Promise<void>;
+  startApp?: typeof startH5ClientApp;
+  bootstrapH5AppImpl?: typeof bootstrapH5App;
+  registerAutomationHooksImpl?: typeof registerAutomationHooks;
+}
+
+export function launchH5ClientApp({
+  state,
+  shouldBootGame,
+  queryPlayerId,
+  roomId,
+  playerId,
+  bindKeyboardShortcuts,
+  render,
+  syncCurrentAuthSession,
+  refreshLobbyRoomList,
+  logoutGuestSession,
+  readStoredSessionReplay,
+  applyReplayedUpdate,
+  getSession,
+  applyUpdate,
+  syncPlayerAccountProfile,
+  window,
+  devDiagnosticsEnabled,
+  renderGameToText,
+  exportDiagnosticSnapshot,
+  renderDiagnosticSnapshotToText,
+  advanceUiTime,
+  startApp = startH5ClientApp,
+  bootstrapH5AppImpl = bootstrapH5App,
+  registerAutomationHooksImpl = registerAutomationHooks
+}: LaunchH5ClientAppOptions): void {
+  startApp({
+    bootstrapApp: () =>
+      bootstrapH5AppImpl({
+        state,
+        shouldBootGame,
+        queryPlayerId,
+        roomId,
+        playerId,
+        bindKeyboardShortcuts,
+        render,
+        syncCurrentAuthSession,
+        refreshLobbyRoomList,
+        logoutGuestSession,
+        readStoredSessionReplay,
+        applyReplayedUpdate,
+        getSession,
+        applyUpdate,
+        syncPlayerAccountProfile
+      }),
+    registerAutomationHooks: () =>
+      registerAutomationHooksImpl({
+        window,
+        devDiagnosticsEnabled,
+        renderGameToText,
+        exportDiagnosticSnapshot,
+        renderDiagnosticSnapshotToText,
+        advanceUiTime
+      })
+  });
+}

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -50,8 +50,8 @@ import {
   unitFrameAsset
 } from "./assets";
 import { describeTileObject } from "./object-visuals";
-import { startH5ClientApp } from "./main-entry";
-import { bootstrapH5App, registerAutomationHooks, syncH5PlayerAccountProfile } from "./main-boot";
+import { launchH5ClientApp } from "./main-launch";
+import { bootstrapH5App, syncH5PlayerAccountProfile } from "./main-boot";
 import {
   confirmAccountRegistration,
   confirmPasswordRecovery,
@@ -5121,15 +5121,26 @@ async function onBindAccountProfile(): Promise<void> {
   }
 }
 
-startH5ClientApp({
-  bootstrapApp: bootstrap,
-  registerAutomationHooks: () =>
-    registerAutomationHooks({
-    window,
-    devDiagnosticsEnabled: DEV_DIAGNOSTICS_ENABLED,
-    renderGameToText,
-    exportDiagnosticSnapshot,
-    renderDiagnosticSnapshotToText,
-    advanceUiTime
-    })
+launchH5ClientApp({
+  state,
+  shouldBootGame,
+  queryPlayerId,
+  roomId,
+  playerId,
+  bindKeyboardShortcuts,
+  render,
+  syncCurrentAuthSession,
+  refreshLobbyRoomList,
+  logoutGuestSession,
+  readStoredSessionReplay,
+  applyReplayedUpdate,
+  getSession,
+  applyUpdate,
+  syncPlayerAccountProfile,
+  window,
+  devDiagnosticsEnabled: DEV_DIAGNOSTICS_ENABLED,
+  renderGameToText,
+  exportDiagnosticSnapshot,
+  renderDiagnosticSnapshotToText,
+  advanceUiTime
 });

--- a/apps/client/test/main-launch.test.ts
+++ b/apps/client/test/main-launch.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { StoredAuthSession } from "../src/auth-session";
+import { launchH5ClientApp } from "../src/main-launch";
+
+function createStoredSession(overrides: Partial<StoredAuthSession> = {}): StoredAuthSession {
+  return {
+    token: "signed.token",
+    playerId: "player-auth",
+    displayName: "访客骑士",
+    authMode: "account",
+    loginId: "veil-ranger",
+    source: "remote",
+    ...overrides
+  };
+}
+
+test("launchH5ClientApp boots the cached H5 session fallback flow and registers automation hooks", async () => {
+  const events: string[] = [];
+  const hookedWindow: {
+    render_game_to_text?: () => string;
+    export_diagnostic_snapshot?: () => string;
+    render_diagnostic_snapshot_to_text?: () => string;
+    advanceTime?: (ms: number) => Promise<void>;
+  } = {};
+  const state = {
+    lobby: {
+      playerId: "player-auth",
+      displayName: "访客骑士",
+      loginId: "",
+      authSession: null
+    },
+    accountDraftName: "访客骑士",
+    accountLoginId: "",
+    diagnostics: {
+      connectionStatus: "connecting" as const
+    },
+    log: ["正在连接本地会话服务...", "old-line"]
+  };
+  const replayed = {
+    world: {
+      meta: {
+        roomId: "room-alpha",
+        seed: 1001,
+        day: 2
+      },
+      map: {
+        width: 1,
+        height: 1,
+        tiles: []
+      },
+      ownHeroes: [],
+      visibleHeroes: [],
+      resources: {
+        gold: 50,
+        wood: 3,
+        ore: 1
+      },
+      playerId: "player-auth"
+    },
+    battle: null,
+    events: [],
+    movementPlan: null,
+    reachableTiles: [{ x: 0, y: 0 }],
+    reason: "cached"
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    launchH5ClientApp({
+      state,
+      shouldBootGame: true,
+      queryPlayerId: "player-auth",
+      roomId: "room-alpha",
+      playerId: "player-auth",
+      bindKeyboardShortcuts: () => {
+        events.push("bindKeyboardShortcuts");
+      },
+      render: () => {
+        events.push("render");
+      },
+      syncCurrentAuthSession: async () => {
+        events.push("syncCurrentAuthSession");
+        return createStoredSession({ source: "local" });
+      },
+      refreshLobbyRoomList: async () => {
+        events.push("refreshLobbyRoomList");
+      },
+      logoutGuestSession: () => {
+        events.push("logoutGuestSession");
+      },
+      readStoredSessionReplay: () => {
+        events.push("readStoredSessionReplay");
+        return replayed;
+      },
+      applyReplayedUpdate: (update) => {
+        events.push(`applyReplayedUpdate:${update.reason}`);
+      },
+      getSession: async () => {
+        events.push("getSession");
+        throw new Error("session_unavailable");
+      },
+      applyUpdate: () => {
+        events.push("applyUpdate");
+      },
+      syncPlayerAccountProfile: () => {
+        events.push("syncPlayerAccountProfile");
+      },
+      window: hookedWindow,
+      devDiagnosticsEnabled: false,
+      renderGameToText: () => "rendered",
+      exportDiagnosticSnapshot: () => "diagnostic",
+      renderDiagnosticSnapshotToText: () => "diagnostic-text",
+      advanceUiTime: async (ms) => {
+        events.push(`advanceUiTime:${ms}`);
+      },
+      startApp: ({ bootstrapApp, registerAutomationHooks }) => {
+        void bootstrapApp().then(resolve, reject);
+        registerAutomationHooks();
+      }
+    });
+  });
+
+  assert.deepEqual(events, [
+    "bindKeyboardShortcuts",
+    "render",
+    "syncCurrentAuthSession",
+    "readStoredSessionReplay",
+    "applyReplayedUpdate:cached",
+    "getSession",
+    "render"
+  ]);
+  assert.equal(state.diagnostics.connectionStatus, "reconnect_failed");
+  assert.deepEqual(state.log, ["远端会话暂不可用，当前仅展示最近缓存状态。", "old-line"]);
+  assert.equal(hookedWindow.render_game_to_text?.(), "rendered");
+  assert.equal(hookedWindow.export_diagnostic_snapshot, undefined);
+  assert.equal(hookedWindow.render_diagnostic_snapshot_to_text, undefined);
+  await assert.doesNotReject(async () => hookedWindow.advanceTime?.(16));
+  assert.deepEqual(events, [
+    "bindKeyboardShortcuts",
+    "render",
+    "syncCurrentAuthSession",
+    "readStoredSessionReplay",
+    "applyReplayedUpdate:cached",
+    "getSession",
+    "render",
+    "advanceUiTime:16"
+  ]);
+});


### PR DESCRIPTION
## Summary
- extract the thin H5 entry wiring from `apps/client/src/main.ts` into a testable launch helper
- add CI-covered regression coverage for cached-session replay fallback and automation hook registration through the entry boundary
- keep runtime behavior unchanged while avoiding a full browser-shell import in Node tests

## Testing
- `node --import tsx --test apps/client/test/main-entry.test.ts apps/client/test/main-boot.test.ts apps/client/test/main-launch.test.ts apps/client/test/local-session.test.ts`
- `npm run typecheck:client:h5`

Closes #337