### PR TITLE
test: add Cocos runtime harness for VeilRoot and VeilCocosSession

### DIFF
--- a/apps/cocos-client/test/cocos-runtime-harness.test.ts
+++ b/apps/cocos-client/test/cocos-runtime-harness.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { VeilCocosSession } from "../assets/scripts/VeilCocosSession.ts";
+import { createSessionUpdate, FakeColyseusRoom } from "./helpers/cocos-session-fixtures.ts";
+import {
+  createVeilCocosSessionRuntimeHarness,
+  createVeilRootRuntimeHarness,
+  resetCocosRuntimeHarnesses
+} from "./helpers/cocos-runtime-harness.ts";
+
+afterEach(() => {
+  resetCocosRuntimeHarnesses();
+});
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+test("Cocos runtime harness boots VeilRoot from lobby handoff into the first live snapshot", async () => {
+  const liveUpdate = createSessionUpdate(4, "room-issue-338", "guest-338");
+  const harness = createVeilRootRuntimeHarness({
+    liveUpdate,
+    guestAuthToken: "guest.issue-338.token"
+  });
+
+  harness.root.showLobby = true;
+  harness.root.roomId = "room-issue-338";
+  harness.root.playerId = "guest-338";
+  harness.root.displayName = "Guest 338";
+  harness.root.syncBrowserRoomQuery = () => undefined;
+
+  await harness.root.enterLobbyRoom();
+
+  assert.equal(harness.root.session, harness.session);
+  assert.equal(harness.root.lastUpdate?.world.meta.day, 4);
+  assert.equal(harness.root.showLobby, false);
+  assert.equal(harness.root.authToken, "guest.issue-338.token");
+  assert.equal(harness.root.sessionSource, "remote");
+});
+
+test("Cocos runtime harness replays cached VeilRoot state before reconnect recovery converges", async () => {
+  const replayedUpdate = createSessionUpdate(2, "room-issue-338", "player-338");
+  replayedUpdate.events = [
+    {
+      type: "battle.resolved",
+      battleId: "battle-338",
+      battleKind: "neutral",
+      heroId: "hero-1",
+      result: "attacker_victory",
+      resourcesGained: {
+        gold: 0,
+        wood: 0,
+        ore: 0
+      },
+      experienceGained: 10,
+      skillPointsAwarded: 0
+    }
+  ];
+  const liveUpdate = createSessionUpdate(3, "room-issue-338", "player-338");
+  const recoveredUpdate = createSessionUpdate(4, "room-issue-338", "player-338");
+  const order: string[] = [];
+  const harness = createVeilRootRuntimeHarness({
+    replayedUpdate,
+    liveUpdate
+  });
+
+  harness.root.roomId = "room-issue-338";
+  harness.root.playerId = "player-338";
+  harness.root.applyReplayedSessionUpdate = (update) => {
+    order.push(`replay:${update.world.meta.day}`);
+    harness.root.lastUpdate = {
+      ...update,
+      events: [],
+      movementPlan: null
+    };
+  };
+  harness.root.applySessionUpdate = async (update) => {
+    order.push(`live:${update.world.meta.day}`);
+    harness.root.lastUpdate = update;
+  };
+
+  await harness.root.connect();
+  harness.emitConnectionEvent("reconnect_failed");
+  harness.emitPushUpdate(recoveredUpdate);
+  harness.emitConnectionEvent("reconnected");
+  await flushMicrotasks();
+
+  assert.deepEqual(order, ["replay:2", "live:3", "live:4"]);
+  assert.equal(harness.root.lastUpdate?.world.meta.day, 4);
+  assert.equal(harness.root.diagnosticsConnectionStatus, "connected");
+});
+
+test("Cocos runtime harness lets VeilCocosSession persist replay data across reconnect recovery", async () => {
+  const initialRoom = new FakeColyseusRoom([createSessionUpdate(1)], "initial-token");
+  const recoveredRoom = new FakeColyseusRoom([createSessionUpdate(5), createSessionUpdate(5)], "recovered-token");
+  const events: string[] = [];
+  const pushedDays: number[] = [];
+  const harness = createVeilCocosSessionRuntimeHarness({
+    joinRooms: [initialRoom, recoveredRoom],
+    wait: async () => undefined
+  });
+
+  const session = await harness.create("room-issue-338", "player-338", 1001, {
+    onConnectionEvent: (event) => {
+      events.push(event);
+    },
+    onPushUpdate: (update) => {
+      pushedDays.push(update.world.meta.day);
+    }
+  });
+
+  const initialSnapshot = await session.snapshot();
+  initialRoom.emitLeave(4002);
+  await flushMicrotasks();
+  const recoveredSnapshot = await session.snapshot("after-reconnect");
+
+  assert.equal(initialSnapshot.world.meta.day, 1);
+  assert.equal(recoveredSnapshot.world.meta.day, 5);
+  assert.equal(recoveredSnapshot.reason, "after-reconnect");
+  assert.deepEqual(events, ["reconnect_failed", "reconnected"]);
+  assert.deepEqual(pushedDays, [5]);
+  assert.equal(
+    harness.storage.getItem("project-veil:cocos:reconnection:room-issue-338:player-338"),
+    "recovered-token"
+  );
+  assert.equal(
+    VeilCocosSession.readStoredReplay("room-issue-338", "player-338")?.world.meta.day,
+    5
+  );
+
+  await session.dispose();
+});

--- a/apps/cocos-client/test/helpers/cocos-runtime-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-runtime-harness.ts
@@ -1,0 +1,111 @@
+import { sys } from "cc";
+import type { ConnectionEvent, SessionUpdate, VeilCocosSessionOptions } from "../../assets/scripts/VeilCocosSession.ts";
+import {
+  resetVeilCocosSessionRuntimeForTests,
+  setVeilCocosSessionRuntimeForTests,
+  VeilCocosSession
+} from "../../assets/scripts/VeilCocosSession.ts";
+import { createMemoryStorage, createSdkLoader, FakeColyseusRoom } from "./cocos-session-fixtures.ts";
+import { createVeilRootHarness, installVeilRootRuntime, resetVeilRootRuntime } from "./veil-root-harness.ts";
+
+type RootSessionDouble = {
+  snapshot(): Promise<SessionUpdate>;
+  dispose(): Promise<void>;
+};
+
+export function resetCocosRuntimeHarnesses(): void {
+  resetVeilRootRuntime();
+  resetVeilCocosSessionRuntimeForTests();
+  (sys as unknown as { localStorage: Storage | null }).localStorage = null;
+}
+
+export function createVeilRootRuntimeHarness(options: {
+  replayedUpdate?: SessionUpdate | null;
+  liveUpdate: SessionUpdate;
+  storage?: Storage;
+  session?: RootSessionDouble;
+  guestAuthToken?: string;
+}) {
+  const storage = options.storage ?? createMemoryStorage();
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+
+  const root = createVeilRootHarness();
+  const session =
+    options.session ??
+    ({
+      async snapshot() {
+        return options.liveUpdate;
+      },
+      async dispose() {}
+    } satisfies RootSessionDouble);
+
+  let capturedOptions: VeilCocosSessionOptions | undefined;
+  installVeilRootRuntime({
+    readStoredReplay: () => options.replayedUpdate ?? null,
+    createSession: async (_roomId, _playerId, _seed, sessionOptions) => {
+      capturedOptions = sessionOptions;
+      return session as never;
+    },
+    ...(options.guestAuthToken
+      ? {
+          loginGuestAuthSession: async (_remoteUrl, playerId, displayName) => ({
+            token: options.guestAuthToken,
+            playerId,
+            displayName,
+            authMode: "guest" as const,
+            provider: "guest" as const,
+            source: "remote" as const
+          })
+        }
+      : {})
+  });
+
+  return {
+    root,
+    storage,
+    session,
+    getSessionOptions(): VeilCocosSessionOptions | undefined {
+      return capturedOptions;
+    },
+    emitConnectionEvent(event: ConnectionEvent): void {
+      capturedOptions?.onConnectionEvent?.(event);
+    },
+    emitPushUpdate(update: SessionUpdate): void {
+      capturedOptions?.onPushUpdate?.(update);
+    }
+  };
+}
+
+export function createVeilCocosSessionRuntimeHarness(options?: {
+  storage?: Storage;
+  joinRooms?: Array<FakeColyseusRoom | Error>;
+  reconnectRooms?: FakeColyseusRoom[];
+  wait?: (() => Promise<void>) | null;
+}) {
+  const storage = options?.storage ?? createMemoryStorage();
+  const reconnectTokens: string[] = [];
+  const endpoints: string[] = [];
+  const joinedOptions: Array<{ logicalRoomId: string; playerId: string; seed: number }> = [];
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    ...(options?.wait ? { wait: options.wait } : {}),
+    loadSdk: createSdkLoader({
+      joinRooms: options?.joinRooms,
+      reconnectRooms: options?.reconnectRooms,
+      reconnectTokens,
+      joinedOptions,
+      endpoints
+    })
+  });
+
+  return {
+    storage,
+    reconnectTokens,
+    joinedOptions,
+    endpoints,
+    create(roomId = "room-alpha", playerId = "player-1", seed = 1001, sessionOptions?: VeilCocosSessionOptions) {
+      return VeilCocosSession.create(roomId, playerId, seed, sessionOptions);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable Cocos runtime test harness for VeilRoot and VeilCocosSession
- cover lobby handoff into a live snapshot, cached replay before reconnect convergence, and session-side reconnect recovery
- keep the scope to Node-stable, high-signal runtime orchestration tests

## Testing
- node --import tsx --test apps/cocos-client/test/cocos-runtime-harness.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-root-orchestration.test.ts apps/cocos-client/test/cocos-session-orchestration.test.ts

Closes #338