### PR TITLE
feat(config-center): staged draft publish flow

### DIFF
--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -81,6 +81,35 @@ interface ConfigPresetSummary {
   description: string;
 }
 
+interface ConfigPublishHistoryEntry {
+  id: string;
+  documentId: ConfigDocumentId;
+  author: string;
+  summary: string;
+  publishedAt: string;
+  fromVersion: number;
+  toVersion: number;
+  changeCount: number;
+  structuralChangeCount: number;
+}
+
+interface ConfigStageDocumentSummary {
+  id: ConfigDocumentId;
+  title: string;
+  fileName: string;
+  content: string;
+  updatedAt: string;
+  validation: ValidationReport;
+}
+
+interface ConfigStageState {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  documents: ConfigStageDocumentSummary[];
+  valid: boolean;
+}
+
 type TerrainType = "grass" | "dirt" | "sand" | "water";
 type ResourceKind = "gold" | "wood" | "ore";
 
@@ -198,6 +227,9 @@ interface AppState {
   historyLoading: boolean;
   presets: ConfigPresetSummary[];
   presetsLoading: boolean;
+  publishHistory: ConfigPublishHistoryEntry[];
+  publishStage: ConfigStageState | null;
+  publishStageLoading: boolean;
 }
 
 interface ConfigCenterControllerOptions {
@@ -218,6 +250,7 @@ export interface DraftParseState {
 }
 
 const WORLD_PREVIEW_DEBOUNCE_MS = 260;
+export const MAX_STAGE_DOCUMENTS = 5;
 const DIFF_KIND_LABELS: Record<ConfigDiffChangeKind, string> = {
   value: "字段值变更",
   field_added: "新增字段",
@@ -317,7 +350,10 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     snapshotDiff: null,
     historyLoading: false,
     presets: [],
-    presetsLoading: false
+    presetsLoading: false,
+    publishHistory: [],
+    publishStage: null,
+    publishStageLoading: false
   };
 
   let previewRequestVersion = 0;
@@ -441,9 +477,11 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       const response = await requestJson<{
         storage: "filesystem" | "mysql";
         snapshots: ConfigSnapshotSummary[];
+        publishHistory?: ConfigPublishHistoryEntry[];
       }>(`/api/config-center/configs/${id}/snapshots`);
       state.storageMode = response.storage;
       state.snapshots = response.snapshots;
+      state.publishHistory = response.publishHistory ?? [];
       if (!state.snapshots.some((item) => item.id === state.selectedSnapshotId)) {
         state.selectedSnapshotId = state.snapshots[0]?.id ?? null;
         state.snapshotDiff = null;
@@ -512,6 +550,187 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     }
 
     return loadSnapshotDiff(snapshotId);
+  }
+
+  async function loadPublishStage(): Promise<void> {
+    state.publishStageLoading = true;
+    notify();
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        stage: ConfigStageState | null;
+      }>("/api/config-center/publish-stage");
+      state.storageMode = response.storage;
+      state.publishStage = response.stage ?? null;
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "加载发布草稿失败";
+    } finally {
+      state.publishStageLoading = false;
+      notify();
+    }
+  }
+
+  async function persistStageDocuments(
+    documents: Array<{ id: ConfigDocumentId; content: string }>,
+    successMessage: string
+  ): Promise<void> {
+    state.publishStageLoading = true;
+    state.statusTone = "neutral";
+    state.statusMessage = "正在同步发布草稿...";
+    notify();
+
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        stage: ConfigStageState | null;
+      }>("/api/config-center/publish-stage", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ documents })
+      });
+      state.storageMode = response.storage;
+      state.publishStage = response.stage ?? null;
+      state.statusTone = "success";
+      state.statusMessage = successMessage;
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "更新发布草稿失败";
+    } finally {
+      state.publishStageLoading = false;
+      notify();
+    }
+  }
+
+  async function stageCurrentDraft(): Promise<void> {
+    if (!state.current) {
+      return;
+    }
+
+    const stagedDocuments = state.publishStage?.documents ?? [];
+    const alreadyIncluded = stagedDocuments.some((document) => document.id === state.current?.id);
+    if (!alreadyIncluded && stagedDocuments.length >= MAX_STAGE_DOCUMENTS) {
+      state.statusTone = "error";
+      state.statusMessage = `最多只能准备 ${MAX_STAGE_DOCUMENTS} 个草稿，请先清理后再添加。`;
+      notify();
+      return;
+    }
+
+    const documents = stagedDocuments
+      .filter((document) => document.id !== state.current?.id)
+      .map((document) => ({
+        id: document.id,
+        content: document.content
+      }));
+    documents.push({
+      id: state.current.id,
+      content: state.draft
+    });
+
+    await persistStageDocuments(documents, `${state.current.title} 已加入发布草稿`);
+  }
+
+  async function removeDocumentFromStage(documentId: ConfigDocumentId): Promise<void> {
+    if (!state.publishStage) {
+      return;
+    }
+
+    const documents = state.publishStage.documents
+      .filter((document) => document.id !== documentId)
+      .map((document) => ({
+        id: document.id,
+        content: document.content
+      }));
+
+    await persistStageDocuments(documents, "已移除发布草稿");
+  }
+
+  async function clearPublishStage(): Promise<void> {
+    if (!state.publishStage || state.publishStage.documents.length === 0) {
+      return;
+    }
+    await persistStageDocuments([], "发布草稿已清空");
+  }
+
+  async function publishStageDrafts(): Promise<void> {
+    const stage = state.publishStage;
+    if (!stage || stage.documents.length === 0) {
+      state.statusTone = "error";
+      state.statusMessage = "当前没有待发布的草稿。";
+      notify();
+      return;
+    }
+
+    if (!stage.valid) {
+      state.statusTone = "error";
+      state.statusMessage = "草稿存在校验问题，发布前需要先修复。";
+      notify();
+      return;
+    }
+
+    const author = promptImpl("发布人（用于记录到历史）", "ConfigOps")?.trim();
+    if (!author) {
+      state.statusTone = "neutral";
+      state.statusMessage = "已取消发布（未填写发布人）。";
+      notify();
+      return;
+    }
+
+    const summary = promptImpl("发布说明（记录变更摘要）", "描述本次调参目的")?.trim();
+    if (!summary) {
+      state.statusTone = "neutral";
+      state.statusMessage = "已取消发布（未填写发布说明）。";
+      notify();
+      return;
+    }
+
+    const publishedDocumentIds = stage.documents.map((document) => document.id);
+    state.publishStageLoading = true;
+    state.statusTone = "neutral";
+    state.statusMessage = "正在发布配置...";
+    notify();
+
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        stage: ConfigStageState | null;
+        publish: {
+          id: string;
+          author: string;
+          summary: string;
+          publishedAt: string;
+          changes: Array<{ documentId: ConfigDocumentId }>;
+        };
+      }>("/api/config-center/publish-stage/publish", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          author,
+          summary
+        })
+      });
+      state.storageMode = response.storage;
+      state.publishStage = response.stage ?? null;
+      state.statusTone = "success";
+      state.statusMessage = `已发布 ${response.publish.changes.length} 个草稿，并刷新运行时配置。`;
+      const activeDocumentId = state.current?.id ?? null;
+      await loadList();
+      if (activeDocumentId && publishedDocumentIds.includes(activeDocumentId)) {
+        await loadDocument(activeDocumentId);
+      } else if (activeDocumentId) {
+        await loadSnapshots(activeDocumentId);
+      }
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "发布草稿失败";
+    } finally {
+      state.publishStageLoading = false;
+      notify();
+    }
   }
 
   async function loadWorldPreview(): Promise<void> {
@@ -692,6 +911,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       state.draft = response.document.content;
       state.validation = null;
       state.snapshots = [];
+      state.publishHistory = [];
       state.presets = [];
       state.snapshotDiff = null;
       state.selectedSnapshotId = null;
@@ -1026,6 +1246,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     loadSnapshots,
     loadPresets,
     loadSnapshotDiff,
+    loadPublishStage,
     loadWorldPreview,
     loadValidation,
     scheduleWorldPreview,
@@ -1038,6 +1259,10 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     saveCurrentAsPreset,
     exportCurrentDocument,
     importWorkbook,
+    stageCurrentDraft,
+    removeDocumentFromStage,
+    clearPublishStage,
+    publishStageDrafts,
     parseDownloadFileName
   };
 }
@@ -1049,8 +1274,10 @@ export type {
   ConfigDocumentId,
   ConfigDocumentSummary,
   ConfigPresetSummary,
+  ConfigPublishHistoryEntry,
   ConfigSchemaSummary,
   ConfigSnapshotSummary,
+  ConfigStageState,
   DownloadPayload,
   ValidationIssue,
   ValidationReport,

--- a/apps/client/src/config-center.css
+++ b/apps/client/src/config-center.css
@@ -538,6 +538,69 @@ body {
   margin-top: 12px;
 }
 
+.stage-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.stage-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 14px;
+  border: 1px solid rgba(138, 90, 43, 0.2);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.stage-card.is-invalid {
+  border-color: rgba(178, 69, 47, 0.35);
+  background: rgba(178, 69, 47, 0.08);
+}
+
+.stage-card strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.stage-card span,
+.stage-card small {
+  display: block;
+  color: var(--text-muted);
+}
+
+.publish-history {
+  margin-top: 18px;
+}
+
+.publish-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.publish-history-card {
+  border: 1px solid rgba(138, 90, 43, 0.18);
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.publish-history-card strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.publish-history-card span,
+.publish-history-card small {
+  display: block;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
 .validation-item,
 .snapshot-main {
   width: 100%;

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -1,5 +1,5 @@
 import "./config-center.css";
-import { createConfigCenterController } from "./config-center-controller";
+import { createConfigCenterController, MAX_STAGE_DOCUMENTS } from "./config-center-controller";
 
 type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
 type TerrainType = "grass" | "dirt" | "sand" | "water";
@@ -141,6 +141,35 @@ interface ConfigPresetSummary {
   description: string;
 }
 
+interface ConfigPublishHistoryEntry {
+  id: string;
+  documentId: ConfigDocumentId;
+  author: string;
+  summary: string;
+  publishedAt: string;
+  fromVersion: number;
+  toVersion: number;
+  changeCount: number;
+  structuralChangeCount: number;
+}
+
+interface ConfigStageDocumentSummary {
+  id: ConfigDocumentId;
+  title: string;
+  fileName: string;
+  content: string;
+  updatedAt: string;
+  validation: ValidationReport;
+}
+
+interface ConfigStageState {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  documents: ConfigStageDocumentSummary[];
+  valid: boolean;
+}
+
 interface WorldConfigPreviewTile {
   position: {
     x: number;
@@ -255,6 +284,9 @@ interface AppState {
   historyLoading: boolean;
   presets: ConfigPresetSummary[];
   presetsLoading: boolean;
+  publishHistory: ConfigPublishHistoryEntry[];
+  publishStage: ConfigStageState | null;
+  publishStageLoading: boolean;
 }
 
 const WORLD_PREVIEW_DEBOUNCE_MS = 260;
@@ -327,6 +359,7 @@ const {
   loadSnapshots,
   loadPresets,
   loadSnapshotDiff,
+  loadPublishStage,
   loadWorldPreview,
   loadValidation,
   scheduleWorldPreview,
@@ -338,7 +371,11 @@ const {
   applyPreset,
   saveCurrentAsPreset,
   exportCurrentDocument,
-  importWorkbook
+  importWorkbook,
+  stageCurrentDraft,
+  removeDocumentFromStage,
+  clearPublishStage,
+  publishStageDrafts
 } = controller;
 
 function formatTime(value: string): string {
@@ -1110,6 +1147,60 @@ function renderValidationSection(): string {
   `;
 }
 
+function renderPublishStageSection(): string {
+  if (!state.current) {
+    return "";
+  }
+
+  const stage = state.publishStage;
+  const documents = stage?.documents ?? [];
+  const stagedCount = documents.length;
+  const activeDocumentId = state.current?.id ?? null;
+  const isCurrentInStage = documents.some((document) => document.id === activeDocumentId);
+  const limitReached = !isCurrentInStage && stagedCount >= MAX_STAGE_DOCUMENTS;
+  const stageMeta = stage
+    ? `${stagedCount}/${MAX_STAGE_DOCUMENTS} 个草稿 · ${stage.valid ? "全部通过校验" : "存在阻塞"}`
+    : `0/${MAX_STAGE_DOCUMENTS} 个草稿`;
+
+  return `
+    <section class="history-section">
+      <div class="config-preview-subhead">
+        <h4>发布草稿队列</h4>
+        <span class="config-meta">${stageMeta}</span>
+      </div>
+      <p class="config-hint">可将多个配置草稿绑定在同一次发布中并统一校验，全部通过后再一键发布。发布记录会同步到版本历史，便于代码审计和追溯。</p>
+      <div class="history-actions">
+        <button class="config-button is-secondary config-button-compact" data-action="stage-current" ${state.current && !limitReached && !state.publishStageLoading ? "" : "disabled"}>${state.publishStageLoading ? "同步中..." : "将当前草稿加入队列"}</button>
+        <button class="config-button is-secondary config-button-compact" data-action="clear-stage" ${stage && stagedCount > 0 && !state.publishStageLoading ? "" : "disabled"}>清空草稿</button>
+        <button class="config-button config-button-compact" data-action="publish-stage" ${stage && stage.valid && stagedCount > 0 && !state.publishStageLoading ? "" : "disabled"}>${state.publishStageLoading ? "处理中..." : "发布草稿"}</button>
+      </div>
+      ${
+        state.publishStageLoading && stagedCount === 0
+          ? `<div class="world-preview-empty">正在加载发布草稿...</div>`
+          : stagedCount === 0
+            ? `<div class="world-preview-empty">暂无待发布草稿，可在左侧编辑器完成修改后加入队列。</div>`
+            : `
+        <div class="stage-list">
+          ${documents
+            .map(
+              (document) => `
+                <article class="stage-card ${document.validation.valid ? "" : "is-invalid"}">
+                  <div>
+                    <strong>${escapeHtml(document.title)}</strong>
+                    <span>${document.validation.valid ? "校验通过" : document.validation.summary}</span>
+                    <small>最近同步：${formatTime(document.updatedAt)}</small>
+                  </div>
+                  <button class="config-button is-secondary config-button-compact" data-action="remove-stage-doc" data-doc-id="${document.id}">移除</button>
+                </article>
+              `
+            )
+            .join("")}
+        </div>`
+      }
+    </section>
+  `;
+}
+
 function renderPresetSection(): string {
   if (!state.current) {
     return "";
@@ -1182,6 +1273,7 @@ function renderSnapshotSection(): string {
                 .join("")}
       </div>
       ${renderSnapshotDiffPanel()}
+      ${renderPublishHistoryList()}
     </section>
   `;
 }
@@ -1234,6 +1326,42 @@ function renderSnapshotDiffPanel(): string {
           `
         )
         .join("")}
+    </div>
+  `;
+}
+
+function renderPublishHistoryList(): string {
+  const entries = state.publishHistory;
+  if (state.historyLoading && entries.length === 0) {
+    return `<div class="world-preview-empty">正在加载发布记录...</div>`;
+  }
+
+  if (entries.length === 0) {
+    return `<div class="world-preview-empty">暂无发布记录，先使用“发布草稿”功能再回来查看。</div>`;
+  }
+
+  return `
+    <div class="publish-history">
+      <div class="config-preview-subhead">
+        <h4>发布记录</h4>
+        <span class="config-meta">${entries.length} 次发布</span>
+      </div>
+      <div class="publish-history-list">
+        ${entries
+          .slice(0, 6)
+          .map(
+            (entry) => `
+              <article class="publish-history-card">
+                <div>
+                  <strong>${escapeHtml(entry.summary)}</strong>
+                  <span>${escapeHtml(entry.author)} · ${formatTime(entry.publishedAt)}</span>
+                  <small>v${entry.fromVersion} → v${entry.toVersion} · ${entry.changeCount} 项变更${entry.structuralChangeCount ? `，其中 ${entry.structuralChangeCount} 项结构风险` : ""}</small>
+                </div>
+              </article>
+            `
+          )
+          .join("")}
+      </div>
     </div>
   `;
 }
@@ -1335,6 +1463,7 @@ function renderPreviewContent(): string {
     <div class="config-badge-row">${badges}</div>
     <p class="config-hint">保存后会先写主存储，再导出到 <code>configs/*.json</code>，并同步刷新服务端运行时配置。新建房间、战斗公式和世界生成会直接读取最新版本。</p>
     ${renderValidationSection()}
+    ${renderPublishStageSection()}
     ${renderPresetSection()}
     ${renderSnapshotSection()}
     ${renderExportSection()}
@@ -1402,6 +1531,8 @@ function bindPreviewControls(): void {
       scheduleWorldPreview(0);
     };
   }
+
+  bindPublishStageControls();
 }
 
 function bindSkillEditorControls(): void {
@@ -1576,6 +1707,29 @@ function bindBattleBalanceEditorControls(): void {
         return config;
       });
     };
+  });
+}
+
+function bindPublishStageControls(): void {
+  document.querySelector<HTMLButtonElement>("[data-action='stage-current']")?.addEventListener("click", () => {
+    void stageCurrentDraft();
+  });
+
+  document.querySelector<HTMLButtonElement>("[data-action='clear-stage']")?.addEventListener("click", () => {
+    void clearPublishStage();
+  });
+
+  document.querySelector<HTMLButtonElement>("[data-action='publish-stage']")?.addEventListener("click", () => {
+    void publishStageDrafts();
+  });
+
+  document.querySelectorAll<HTMLButtonElement>("[data-action='remove-stage-doc']").forEach((button) => {
+    button.addEventListener("click", () => {
+      const docId = button.dataset.docId as ConfigDocumentId | undefined;
+      if (docId) {
+        void removeDocumentFromStage(docId);
+      }
+    });
   });
 }
 
@@ -1777,6 +1931,7 @@ async function bootstrap(): Promise<void> {
   render();
   try {
     await loadList();
+    await loadPublishStage();
     const requestedId = new URLSearchParams(window.location.search).get("config") as ConfigDocumentId | null;
     const initialId = requestedId && state.items.some((item) => item.id === requestedId) ? requestedId : state.items[0]?.id ?? null;
 

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -143,6 +143,57 @@ export interface ConfigPresetSummary {
   description: string;
 }
 
+export interface ConfigPublishHistoryEntry {
+  id: string;
+  documentId: ConfigDocumentId;
+  author: string;
+  summary: string;
+  publishedAt: string;
+  fromVersion: number;
+  toVersion: number;
+  changeCount: number;
+  structuralChangeCount: number;
+}
+
+export interface ConfigPublishChangeSummary {
+  documentId: ConfigDocumentId;
+  title: string;
+  fromVersion: number;
+  toVersion: number;
+  changeCount: number;
+  structuralChangeCount: number;
+}
+
+export interface ConfigPublishEventSummary {
+  id: string;
+  author: string;
+  summary: string;
+  publishedAt: string;
+  changes: ConfigPublishChangeSummary[];
+}
+
+export interface ConfigStageDocumentInput {
+  id: ConfigDocumentId;
+  content: string;
+}
+
+export interface ConfigStageDocumentSummary {
+  id: ConfigDocumentId;
+  title: string;
+  fileName: string;
+  content: string;
+  updatedAt: string;
+  validation: ValidationReport;
+}
+
+export interface ConfigStageState {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  documents: ConfigStageDocumentSummary[];
+  valid: boolean;
+}
+
 export interface WorldConfigPreviewTile {
   position: {
     x: number;
@@ -233,6 +284,7 @@ export interface ConfigCenterStore {
   createSnapshot(id: ConfigDocumentId, content: string, label?: string): Promise<ConfigSnapshotSummary>;
   rollbackToSnapshot(id: ConfigDocumentId, snapshotId: string): Promise<ConfigDocument>;
   diffWithSnapshot(id: ConfigDocumentId, snapshotId: string): Promise<ConfigDiff>;
+  listPublishHistory(id: ConfigDocumentId): Promise<ConfigPublishHistoryEntry[]>;
   listPresets(id: ConfigDocumentId): Promise<ConfigPresetSummary[]>;
   savePreset(id: ConfigDocumentId, name: string, content: string): Promise<ConfigPresetSummary>;
   applyPreset(id: ConfigDocumentId, presetId: string): Promise<ConfigDocument>;
@@ -243,6 +295,12 @@ export interface ConfigCenterStore {
     exportedAt: string;
   }>;
   importDocumentFromWorkbook(id: ConfigDocumentId, workbook: Buffer): Promise<ConfigDocument>;
+  getStagedDraft(): Promise<ConfigStageState | null>;
+  saveStagedDraft(documents: ConfigStageDocumentInput[]): Promise<ConfigStageState | null>;
+  publishStagedDraft(metadata: { author: string; summary: string }): Promise<{
+    stage: ConfigStageState | null;
+    publish: ConfigPublishEventSummary;
+  }>;
   close(): Promise<void>;
   readonly mode: "filesystem" | "mysql";
 }
@@ -296,11 +354,27 @@ interface ConfigPresetRecord {
   content: string;
 }
 
+interface ConfigStageDocumentRecord {
+  id: ConfigDocumentId;
+  content: string;
+  validation: ValidationReport;
+  updatedAt: string;
+}
+
+interface ConfigStageRecord {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  documents: ConfigStageDocumentRecord[];
+}
+
 interface ConfigCenterLibraryState {
   filesystemVersions: Partial<Record<ConfigDocumentId, number>>;
   filesystemExports: Partial<Record<ConfigDocumentId, string>>;
   snapshots: Partial<Record<ConfigDocumentId, ConfigSnapshotRecord[]>>;
   presets: Partial<Record<ConfigDocumentId, ConfigPresetRecord[]>>;
+  stagedDraft: ConfigStageRecord | null;
+  publishHistory: Partial<Record<ConfigDocumentId, ConfigPublishHistoryEntry[]>>;
 }
 
 interface FlattenedConfigEntry {
@@ -324,6 +398,8 @@ interface JsonSchemaNode {
 }
 
 const CONFIG_CENTER_LIBRARY_FILE = ".config-center-library.json";
+const MAX_STAGE_DOCUMENTS = 5;
+const MAX_PUBLISH_HISTORY_ENTRIES = 20;
 const BUILTIN_DIFFICULTY_PRESET_IDS = ["easy", "normal", "hard"] as const;
 const BUILTIN_WORLD_LAYOUT_PRESETS = ["layout_phase1", "layout_frontier_basin", "layout_contested_basin"] as const;
 const BUILTIN_MAP_OBJECT_LAYOUT_PRESETS = ["layout_phase1", "layout_frontier_basin", "layout_contested_basin"] as const;
@@ -654,7 +730,9 @@ function createEmptyLibraryState(): ConfigCenterLibraryState {
     filesystemVersions: {},
     filesystemExports: {},
     snapshots: {},
-    presets: {}
+    presets: {},
+    stagedDraft: null,
+    publishHistory: {}
   };
 }
 
@@ -1899,7 +1977,8 @@ function formatTimestamp(value: Date | string | null | undefined): string | null
 
 async function loadValidationDependencies(
   store: Pick<ConfigCenterStore, "loadDocument">,
-  id: ConfigDocumentId
+  id: ConfigDocumentId,
+  overrides: Partial<Record<ConfigDocumentId, string>> = {}
 ): Promise<{
   world: WorldGenerationConfig;
   mapObjects: MapObjectsConfig;
@@ -1907,43 +1986,59 @@ async function loadValidationDependencies(
   battleSkills: BattleSkillCatalogConfig;
   battleBalance: BattleBalanceConfig;
 }> {
-  const [worldDocument, mapObjectsDocument, unitsDocument, battleSkillsDocument, battleBalanceDocument] = await Promise.all([
-    id === "world" ? Promise.resolve(null) : store.loadDocument("world"),
-    id === "mapObjects" ? Promise.resolve(null) : store.loadDocument("mapObjects"),
-    id === "units" ? Promise.resolve(null) : store.loadDocument("units"),
-    id === "battleSkills" ? Promise.resolve(null) : store.loadDocument("battleSkills"),
-    id === "battleBalance" ? Promise.resolve(null) : store.loadDocument("battleBalance")
+  const loadContent = async (docId: ConfigDocumentId): Promise<string | null> => {
+    if (docId === id) {
+      return null;
+    }
+
+    if (overrides[docId]) {
+      return overrides[docId] ?? null;
+    }
+
+    const document = await store.loadDocument(docId);
+    return document.content;
+  };
+
+  const [worldContent, mapObjectsContent, unitsContent, battleSkillsContent, battleBalanceContent] = await Promise.all([
+    id === "world" ? Promise.resolve(null) : loadContent("world"),
+    id === "mapObjects" ? Promise.resolve(null) : loadContent("mapObjects"),
+    id === "units" ? Promise.resolve(null) : loadContent("units"),
+    id === "battleSkills" ? Promise.resolve(null) : loadContent("battleSkills"),
+    id === "battleBalance" ? Promise.resolve(null) : loadContent("battleBalance")
   ]);
 
   return {
     world:
       id === "world"
         ? getDefaultWorldConfig()
-        : (parseConfigDocument("world", worldDocument?.content ?? normalizeJsonContent(getDefaultWorldConfig())) as WorldGenerationConfig),
+        : (parseConfigDocument(
+            "world",
+            worldContent ?? overrides.world ?? normalizeJsonContent(getDefaultWorldConfig())
+          ) as WorldGenerationConfig),
     mapObjects:
       id === "mapObjects"
         ? getDefaultMapObjectsConfig()
         : (parseConfigDocument(
             "mapObjects",
-            mapObjectsDocument?.content ?? normalizeJsonContent(getDefaultMapObjectsConfig())
+            mapObjectsContent ?? overrides.mapObjects ?? normalizeJsonContent(getDefaultMapObjectsConfig())
           ) as MapObjectsConfig),
     units:
       id === "units"
         ? getDefaultUnitCatalog()
-        : (parseConfigDocument("units", unitsDocument?.content ?? normalizeJsonContent(getDefaultUnitCatalog())) as UnitCatalogConfig),
+        : (parseConfigDocument("units", unitsContent ?? overrides.units ?? normalizeJsonContent(getDefaultUnitCatalog())) as UnitCatalogConfig),
     battleSkills:
       id === "battleSkills"
         ? getDefaultBattleSkillCatalog()
         : (parseConfigDocument(
             "battleSkills",
-            battleSkillsDocument?.content ?? normalizeJsonContent(getDefaultBattleSkillCatalog())
+            battleSkillsContent ?? overrides.battleSkills ?? normalizeJsonContent(getDefaultBattleSkillCatalog())
           ) as BattleSkillCatalogConfig),
     battleBalance:
       id === "battleBalance"
         ? getDefaultBattleBalanceConfig()
         : (parseConfigDocument(
             "battleBalance",
-            battleBalanceDocument?.content ?? normalizeJsonContent(getDefaultBattleBalanceConfig())
+            battleBalanceContent ?? overrides.battleBalance ?? normalizeJsonContent(getDefaultBattleBalanceConfig())
           ) as BattleBalanceConfig)
   };
 }
@@ -2313,7 +2408,8 @@ function mapContentPackIssuesToValidationIssues(report: ContentPackValidationRep
 async function validateDocumentDetailed(
   store: Pick<ConfigCenterStore, "loadDocument">,
   id: ConfigDocumentId,
-  content: string
+  content: string,
+  options: { overrides?: Partial<Record<ConfigDocumentId, string>> } = {}
 ): Promise<ValidationReport> {
   try {
     const parsed = JSON.parse(content) as ParsedConfigDocument;
@@ -2328,7 +2424,7 @@ async function validateDocumentDetailed(
     };
     validateSchemaNode(parsed, CONFIG_DOCUMENT_SCHEMAS[id], "", issues);
     try {
-      const dependencies = await loadValidationDependencies(store, id);
+      const dependencies = await loadValidationDependencies(store, id, options.overrides);
       const semanticIssues =
         id === "world"
           ? validateWorldConfigDetailed(parsed as WorldGenerationConfig)
@@ -2416,7 +2512,9 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         filesystemVersions: parsed.filesystemVersions ?? {},
         filesystemExports: parsed.filesystemExports ?? {},
         snapshots: parsed.snapshots ?? {},
-        presets: parsed.presets ?? {}
+        presets: parsed.presets ?? {},
+        stagedDraft: parsed.stagedDraft ?? null,
+        publishHistory: parsed.publishHistory ?? {}
       };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -2565,6 +2663,174 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     return {
       entries: buildConfigDiffEntries(id, snapshot.content, current.content)
     };
+  }
+
+  async listPublishHistory(id: ConfigDocumentId): Promise<ConfigPublishHistoryEntry[]> {
+    const state = await this.readLibraryState();
+    return [...(state.publishHistory[id] ?? [])];
+  }
+
+  async getStagedDraft(): Promise<ConfigStageState | null> {
+    const state = await this.readLibraryState();
+    return this.mapStageRecordToState(state.stagedDraft);
+  }
+
+  async saveStagedDraft(documents: ConfigStageDocumentInput[]): Promise<ConfigStageState | null> {
+    const state = await this.readLibraryState();
+    if (documents.length === 0) {
+      state.stagedDraft = null;
+      await this.writeLibraryState(state);
+      return null;
+    }
+
+    const stageRecord = await this.buildStageRecord(documents, state.stagedDraft);
+    state.stagedDraft = stageRecord;
+    await this.writeLibraryState(state);
+    return this.mapStageRecordToState(stageRecord);
+  }
+
+  async publishStagedDraft(metadata: { author: string; summary: string }): Promise<{
+    stage: ConfigStageState | null;
+    publish: ConfigPublishEventSummary;
+  }> {
+    const state = await this.readLibraryState();
+    const staged = state.stagedDraft;
+    if (!staged || staged.documents.length === 0) {
+      throw new Error("当前没有待发布的草稿。");
+    }
+
+    if (staged.documents.some((entry) => !entry.validation.valid)) {
+      throw new Error("存在未通过校验的草稿，发布前请先修复。");
+    }
+
+    const publishId = createId("publish");
+    const publishedAt = new Date().toISOString();
+    const publishChanges: ConfigPublishChangeSummary[] = [];
+    const historyEntries: ConfigPublishHistoryEntry[] = [];
+
+    for (const stagedDocument of staged.documents) {
+      const current = await this.loadDocument(stagedDocument.id);
+      const diffEntries = buildConfigDiffEntries(stagedDocument.id, current.content, stagedDocument.content);
+      const structuralCount = diffEntries.filter((entry) => entry.kind !== "value").length;
+      const saved = await this.saveDocument(stagedDocument.id, stagedDocument.content);
+      const definition = configDefinitionFor(stagedDocument.id);
+      const fromVersion = current.version ?? 1;
+      const toVersion = saved.version ?? fromVersion;
+
+      publishChanges.push({
+        documentId: stagedDocument.id,
+        title: definition?.title ?? stagedDocument.id,
+        fromVersion,
+        toVersion,
+        changeCount: diffEntries.length,
+        structuralChangeCount: structuralCount
+      });
+      historyEntries.push({
+        id: publishId,
+        documentId: stagedDocument.id,
+        author: metadata.author,
+        summary: metadata.summary,
+        publishedAt,
+        fromVersion,
+        toVersion,
+        changeCount: diffEntries.length,
+        structuralChangeCount: structuralCount
+      });
+    }
+
+    state.stagedDraft = null;
+    state.publishHistory = state.publishHistory ?? {};
+    for (const entry of historyEntries) {
+      const existing = state.publishHistory[entry.documentId] ?? [];
+      state.publishHistory[entry.documentId] = [entry, ...existing].slice(0, MAX_PUBLISH_HISTORY_ENTRIES);
+    }
+    await this.writeLibraryState(state);
+
+    return {
+      stage: null,
+      publish: {
+        id: publishId,
+        author: metadata.author,
+        summary: metadata.summary,
+        publishedAt,
+        changes: publishChanges
+      }
+    };
+  }
+
+  protected mapStageRecordToState(stage: ConfigStageRecord | null): ConfigStageState | null {
+    if (!stage) {
+      return null;
+    }
+
+    return {
+      id: stage.id,
+      createdAt: stage.createdAt,
+      updatedAt: stage.updatedAt,
+      documents: stage.documents.map((document) => {
+        const definition = configDefinitionFor(document.id);
+        return {
+          id: document.id,
+          title: definition?.title ?? document.id,
+          fileName: definition?.fileName ?? document.id,
+          content: document.content,
+          updatedAt: document.updatedAt,
+          validation: document.validation
+        };
+      }),
+      valid: stage.documents.every((document) => document.validation.valid)
+    };
+  }
+
+  private async buildStageRecord(
+    documents: ConfigStageDocumentInput[],
+    existing: ConfigStageRecord | null
+  ): Promise<ConfigStageRecord> {
+    if (documents.length > MAX_STAGE_DOCUMENTS) {
+      throw new Error(`一次最多只能准备 ${MAX_STAGE_DOCUMENTS} 个草稿。`);
+    }
+
+    const seen = new Set<ConfigDocumentId>();
+    for (const document of documents) {
+      if (!configDefinitionFor(document.id)) {
+        throw new Error(`Unsupported config id: ${document.id}`);
+      }
+      if (seen.has(document.id)) {
+        throw new Error("同一配置文档只能加入一次草稿捆绑。");
+      }
+      seen.add(document.id);
+    }
+
+    const normalizedDocuments = documents.map((document) => {
+      const parsed = parseConfigDocument(document.id, document.content);
+      return {
+        id: document.id,
+        content: normalizeJsonContent(parsed)
+      };
+    });
+    const overrides: Partial<Record<ConfigDocumentId, string>> = {};
+    for (const normalized of normalizedDocuments) {
+      overrides[normalized.id] = normalized.content;
+    }
+
+    const timestamp = new Date().toISOString();
+    const stageRecord: ConfigStageRecord = {
+      id: existing?.id ?? createId("stage"),
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+      documents: []
+    };
+
+    for (const normalized of normalizedDocuments) {
+      stageRecord.documents.push({
+        id: normalized.id,
+        content: normalized.content,
+        validation: await validateDocumentDetailed(this, normalized.id, normalized.content, { overrides }),
+        updatedAt: timestamp
+      });
+    }
+
+    return stageRecord;
   }
 
   async listPresets(id: ConfigDocumentId): Promise<ConfigPresetSummary[]> {
@@ -2987,12 +3253,93 @@ export function registerConfigCenterRoutes(
     }
 
     try {
+      const [snapshots, publishHistory] = await Promise.all([
+        store.listSnapshots(definition.id),
+        store.listPublishHistory(definition.id)
+      ]);
       sendJson(response, 200, {
         storage: store.mode,
-        snapshots: await store.listSnapshots(definition.id)
+        snapshots,
+        publishHistory
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/config-center/publish-stage", async (_request, response) => {
+    try {
+      sendJson(response, 200, {
+        storage: store.mode,
+        stage: await store.getStagedDraft()
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.put("/api/config-center/publish-stage", async (request, response) => {
+    try {
+      const body = (await readJsonBody(request)) as {
+        documents?: Array<{ id?: string; content?: string }>;
+      };
+      if (!Array.isArray(body.documents)) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected array field: documents"
+          }
+        });
+        return;
+      }
+
+      const documents: ConfigStageDocumentInput[] = body.documents.map((entry) => {
+        if (typeof entry.id !== "string" || typeof entry.content !== "string") {
+          throw new Error("Expected staged draft entries with string id and content");
+        }
+        const definition = configDefinitionFor(entry.id);
+        if (!definition) {
+          throw new Error(`Unsupported config id: ${entry.id}`);
+        }
+        return {
+          id: definition.id,
+          content: entry.content
+        };
+      });
+
+      sendJson(response, 200, {
+        storage: store.mode,
+        stage: await store.saveStagedDraft(documents)
+      });
+    } catch (error) {
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/config-center/publish-stage/publish", async (request, response) => {
+    try {
+      const body = (await readJsonBody(request)) as { author?: string; summary?: string };
+      if (typeof body.author !== "string" || !body.author.trim() || typeof body.summary !== "string" || !body.summary.trim()) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected non-empty strings: author, summary"
+          }
+        });
+        return;
+      }
+
+      const result = await store.publishStagedDraft({
+        author: body.author.trim(),
+        summary: body.summary.trim()
+      });
+      sendJson(response, 200, {
+        storage: store.mode,
+        stage: result.stage,
+        publish: result.publish
+      });
+    } catch (error) {
+      sendJson(response, 400, { error: toErrorPayload(error) });
     }
   });
 

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -643,3 +643,74 @@ test("config center presets and workbook import/export roundtrip", async () => {
   const restored = await store.applyPreset("battleSkills", preset.id);
   assert.equal(restored.content, original.content);
 });
+
+test("config center staged publish applies bundled drafts and records publish history", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+  await store.initializeRuntimeConfigs();
+
+  const staged = await store.saveStagedDraft([
+    {
+      id: "world",
+      content: JSON.stringify({ ...WORLD_CONFIG, width: WORLD_CONFIG.width + 2 })
+    },
+    {
+      id: "mapObjects",
+      content: JSON.stringify({
+        ...MAP_OBJECTS_CONFIG,
+        guaranteedResources: [
+          ...MAP_OBJECTS_CONFIG.guaranteedResources,
+          {
+            position: { x: 1, y: 1 },
+            resource: { kind: "ore", amount: 20 }
+          }
+        ]
+      })
+    }
+  ]);
+  assert.equal(staged?.documents.length, 2);
+  assert.equal(staged?.valid, true);
+
+  const published = await store.publishStagedDraft({ author: "ConfigOps", summary: "调大地图并补齐资源" });
+  assert.equal(published.stage, null);
+  assert.equal(published.publish.changes.length, 2);
+  assert.equal(published.publish.author, "ConfigOps");
+
+  const worldDocument = await store.loadDocument("world");
+  assert.match(worldDocument.content, new RegExp(`\"width\": ${WORLD_CONFIG.width + 2}`));
+
+  const worldHistory = await store.listPublishHistory("world");
+  assert.equal(worldHistory[0]?.author, "ConfigOps");
+  assert.equal(worldHistory[0]?.summary, "调大地图并补齐资源");
+  assert.equal((worldHistory[0]?.changeCount ?? 0) > 0, true);
+
+  const mapHistory = await store.listPublishHistory("mapObjects");
+  assert.equal(mapHistory[0]?.documentId, "mapObjects");
+  assert.equal((mapHistory[0]?.structuralChangeCount ?? 0) >= 0, true);
+
+  const stageAfter = await store.getStagedDraft();
+  assert.equal(stageAfter, null);
+});
+
+test("config center staged publish blocks invalid drafts", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  const staged = await store.saveStagedDraft([
+    {
+      id: "world",
+      content: JSON.stringify({
+        ...WORLD_CONFIG,
+        width: 0
+      })
+    }
+  ]);
+  assert.equal(staged?.valid, false);
+
+  await assert.rejects(
+    () => store.publishStagedDraft({ author: "Ops", summary: "bad publish" }),
+    /未通过校验|修复/
+  );
+});


### PR DESCRIPTION
## Summary
- add staged config publish queue with validation + metadata
- record publish history next to snapshots and surface new UI controls
- cover valid publish plus invalid draft cases with server tests

## Testing
- node --import tsx --test apps/server/test/config-center.test.ts apps/client/test/config-center.test.ts

Closes #345.