### PR TITLE
Add Cocos progression/history runtime panel

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -1291,7 +1291,7 @@ export class VeilHudPanel extends Component {
 
     this.ensureActionButton(actionsNode, "HudNewRun", "新开一局");
     this.ensureActionButton(actionsNode, "HudRefresh", "刷新状态");
-    this.ensureActionButton(actionsNode, "HudAchievements", "成就总览");
+    this.ensureActionButton(actionsNode, "HudAchievements", "成长回顾");
     this.ensureActionButton(actionsNode, "HudEndDay", "推进一天");
     this.ensureActionButton(actionsNode, "HudReturnLobby", "返回大厅");
   }
@@ -1311,7 +1311,7 @@ export class VeilHudPanel extends Component {
     const buttons: HudActionButtonState[] = [
       { name: "HudNewRun", label: "新开一局", callback: this.onNewRun ?? null },
       { name: "HudRefresh", label: "刷新状态", callback: this.onRefresh ?? null },
-      { name: "HudAchievements", label: "成就总览", callback: this.onToggleAchievements ?? null },
+      { name: "HudAchievements", label: "成长回顾", callback: this.onToggleAchievements ?? null },
       { name: "HudEndDay", label: "推进一天", callback: this.onEndDay ?? null },
       { name: "HudReturnLobby", label: "返回大厅", callback: this.onReturnLobby ?? null }
     ];

--- a/apps/cocos-client/assets/scripts/VeilProgressionPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilProgressionPanel.ts
@@ -1,0 +1,381 @@
+import { _decorator, Color, Component, Graphics, Label, Node, UITransform } from "cc";
+import { type CocosAccountReviewPage, type CocosAccountReviewSection } from "./cocos-account-review.ts";
+import { assignUiLayer } from "./cocos-ui-layer.ts";
+
+const { ccclass } = _decorator;
+const H_ALIGN_LEFT = 0;
+const H_ALIGN_CENTER = 1;
+const V_ALIGN_TOP = 0;
+const V_ALIGN_MIDDLE = 1;
+const OVERFLOW_RESIZE_HEIGHT = 3;
+const PANEL_BG = new Color(16, 22, 31, 238);
+const PANEL_BORDER = new Color(238, 230, 198, 118);
+const PANEL_INNER = new Color(255, 248, 214, 18);
+const TAB_IDLE_FILL = new Color(88, 104, 72, 220);
+const TAB_ACTIVE_FILL = new Color(106, 136, 88, 230);
+const ACTION_FILL = new Color(62, 84, 116, 224);
+const NEGATIVE_FILL = new Color(112, 72, 64, 220);
+const CARD_FILL = new Color(34, 46, 64, 186);
+const CARD_HIGHLIGHT_FILL = new Color(56, 74, 102, 208);
+const MUTED_FILL = new Color(28, 38, 52, 168);
+
+export interface VeilProgressionPanelRenderState {
+  page: CocosAccountReviewPage;
+}
+
+export interface VeilProgressionPanelOptions {
+  onClose?: () => void;
+  onSelectSection?: (section: CocosAccountReviewSection) => void;
+  onSelectPage?: (section: "battle-replays" | "event-history", page: number) => void;
+  onRetrySection?: (section: CocosAccountReviewSection) => void;
+}
+
+interface PanelButtonTone {
+  fill: Color;
+  stroke: Color;
+}
+
+function isPagedSection(section: CocosAccountReviewSection): section is "battle-replays" | "event-history" {
+  return section === "battle-replays" || section === "event-history";
+}
+
+@ccclass("ProjectVeilProgressionPanel")
+export class VeilProgressionPanel extends Component {
+  private currentState: VeilProgressionPanelRenderState | null = null;
+  private onClose: (() => void) | undefined;
+  private onSelectSection: ((section: CocosAccountReviewSection) => void) | undefined;
+  private onSelectPage: ((section: "battle-replays" | "event-history", page: number) => void) | undefined;
+  private onRetrySection: ((section: CocosAccountReviewSection) => void) | undefined;
+
+  configure(options: VeilProgressionPanelOptions): void {
+    this.onClose = options.onClose;
+    this.onSelectSection = options.onSelectSection;
+    this.onSelectPage = options.onSelectPage;
+    this.onRetrySection = options.onRetrySection;
+  }
+
+  render(state: VeilProgressionPanelRenderState): void {
+    this.currentState = state;
+    const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const width = transform.width || 380;
+    const height = transform.height || 440;
+    const contentWidth = width - 30;
+    const centerX = 0;
+    const pagedSection = isPagedSection(state.page.section) ? state.page.section : null;
+    let cursorY = height / 2 - 16;
+
+    this.syncChrome(width, height);
+
+    cursorY = this.renderCard(
+      "ProgressionHeader",
+      centerX,
+      cursorY,
+      contentWidth,
+      80,
+      [
+        state.page.title,
+        state.page.subtitle,
+        `当前页 ${state.page.pageLabel}`
+      ],
+      {
+        fill: CARD_HIGHLIGHT_FILL,
+        stroke: new Color(244, 236, 208, 82)
+      },
+      null,
+      15,
+      18
+    );
+
+    const tabWidth = Math.floor((contentWidth - 18) / Math.max(1, state.page.tabs.length));
+    const tabStartX = centerX - contentWidth / 2 + tabWidth / 2;
+    state.page.tabs.forEach((tab, index) => {
+      this.renderButton(
+        `ProgressionTab-${tab.section}`,
+        tabStartX + index * (tabWidth + 6),
+        cursorY - 14,
+        tabWidth,
+        26,
+        `${tab.label} ${tab.count}`,
+        tab.section === state.page.section
+          ? {
+              fill: TAB_ACTIVE_FILL,
+              stroke: new Color(230, 244, 222, 116)
+            }
+          : {
+              fill: TAB_IDLE_FILL,
+              stroke: new Color(232, 238, 220, 88)
+            },
+        () => this.onSelectSection?.(tab.section)
+      );
+    });
+
+    this.renderButton(
+      "ProgressionClose",
+      centerX + contentWidth / 2 - 42,
+      height / 2 - 18,
+      72,
+      24,
+      "关闭",
+      {
+        fill: NEGATIVE_FILL,
+        stroke: new Color(244, 226, 214, 114)
+      },
+      this.onClose ?? null
+    );
+
+    this.renderButton(
+      "ProgressionPrev",
+      centerX - contentWidth / 4 - 4,
+      cursorY - 48,
+      Math.floor((contentWidth - 8) / 2),
+      24,
+      "上一页",
+      {
+        fill: ACTION_FILL,
+        stroke: new Color(224, 236, 248, 108)
+      },
+      state.page.hasPreviousPage && pagedSection
+        ? () => this.onSelectPage?.(pagedSection, state.page.page - 1)
+        : null
+    );
+
+    this.renderButton(
+      "ProgressionNext",
+      centerX + contentWidth / 4 + 4,
+      cursorY - 48,
+      Math.floor((contentWidth - 8) / 2),
+      24,
+      "下一页",
+      {
+        fill: ACTION_FILL,
+        stroke: new Color(224, 236, 248, 108)
+      },
+      state.page.hasNextPage && pagedSection
+        ? () => this.onSelectPage?.(pagedSection, state.page.page + 1)
+        : null
+    );
+
+    this.renderButton(
+      "ProgressionRetry",
+      centerX,
+      cursorY - 78,
+      contentWidth,
+      22,
+      "重新同步当前面板",
+      {
+        fill: ACTION_FILL,
+        stroke: new Color(224, 236, 248, 108)
+      },
+      state.page.showRetry ? () => this.onRetrySection?.(state.page.section) : null
+    );
+
+    let cardsTop = cursorY - 100;
+    if (state.page.banner) {
+      cardsTop = this.renderCard(
+        "ProgressionBanner",
+        centerX,
+        cardsTop,
+        contentWidth,
+        62,
+        [state.page.banner.title, state.page.banner.detail],
+        state.page.banner.tone === "negative"
+          ? {
+              fill: NEGATIVE_FILL,
+              stroke: new Color(248, 228, 220, 112)
+            }
+          : {
+              fill: CARD_HIGHLIGHT_FILL,
+              stroke: new Color(236, 242, 250, 86)
+            },
+        null,
+        13,
+        16
+      );
+    } else {
+      const bannerNode = this.node.getChildByName("ProgressionBanner");
+      if (bannerNode) {
+        bannerNode.active = false;
+      }
+    }
+
+    const items = state.page.items.length > 0
+      ? state.page.items
+      : [
+          {
+            title: "当前暂无内容",
+            detail: state.page.subtitle,
+            footnote: "渲染面板已就绪，等待数据同步。",
+            emphasis: "neutral" as const
+          }
+        ];
+
+    items.forEach((item, index) => {
+      cardsTop = this.renderCard(
+        `ProgressionItem-${index}`,
+        centerX,
+        cardsTop,
+        contentWidth,
+        72,
+        [item.title, item.detail, item.footnote],
+        item.emphasis === "positive"
+          ? {
+              fill: CARD_HIGHLIGHT_FILL,
+              stroke: new Color(224, 240, 220, 78)
+            }
+          : {
+              fill: state.page.items.length > 0 ? CARD_FILL : MUTED_FILL,
+              stroke: new Color(220, 230, 244, 56)
+            },
+        null,
+        13,
+        16
+      );
+    });
+    this.hideExtraItems(items.length);
+  }
+
+  private syncChrome(width: number, height: number): void {
+    const graphics = this.node.getComponent(Graphics) ?? this.node.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = PANEL_BG;
+    graphics.strokeColor = PANEL_BORDER;
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 18);
+    graphics.fill();
+    graphics.stroke();
+    graphics.fillColor = PANEL_INNER;
+    graphics.roundRect(-width / 2 + 14, height / 2 - 22, width - 28, 6, 3);
+    graphics.fill();
+  }
+
+  private renderCard(
+    name: string,
+    centerX: number,
+    topY: number,
+    width: number,
+    minHeight: number,
+    lines: string[],
+    tone: PanelButtonTone,
+    onPress: (() => void) | null,
+    fontSize: number,
+    lineHeight: number
+  ): number {
+    let node = this.node.getChildByName(name);
+    if (!node) {
+      node = new Node(name);
+      node.parent = this.node;
+    }
+    assignUiLayer(node);
+    node.active = true;
+
+    const height = Math.max(minHeight, 24 + lines.length * lineHeight);
+    const centerY = topY - height / 2;
+    const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+    transform.setContentSize(width, height);
+    node.setPosition(centerX, centerY, 0.2);
+
+    const graphics = node.getComponent(Graphics) ?? node.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = tone.fill;
+    graphics.strokeColor = tone.stroke;
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 14);
+    graphics.fill();
+    graphics.stroke();
+    graphics.fillColor = new Color(255, 255, 255, 14);
+    graphics.roundRect(-width / 2 + 12, height / 2 - 14, width - 24, 4, 2);
+    graphics.fill();
+
+    let labelNode = node.getChildByName("Label");
+    if (!labelNode) {
+      labelNode = new Node("Label");
+      labelNode.parent = node;
+    }
+    assignUiLayer(labelNode);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(width - 22, height - 14);
+    labelNode.setPosition(0, 0, 0.1);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = lines.join("\n");
+    label.fontSize = fontSize;
+    label.lineHeight = lineHeight;
+    label.horizontalAlign = H_ALIGN_LEFT;
+    label.verticalAlign = V_ALIGN_TOP;
+    label.overflow = OVERFLOW_RESIZE_HEIGHT;
+    label.enableWrapText = true;
+    label.color = new Color(244, 240, 230, 255);
+
+    node.off(Node.EventType.TOUCH_END);
+    node.off(Node.EventType.MOUSE_UP);
+    if (onPress) {
+      node.on(Node.EventType.TOUCH_END, () => onPress());
+      node.on(Node.EventType.MOUSE_UP, () => onPress());
+    }
+    return topY - height - 8;
+  }
+
+  private renderButton(
+    name: string,
+    centerX: number,
+    centerY: number,
+    width: number,
+    height: number,
+    labelText: string,
+    tone: PanelButtonTone,
+    onPress: (() => void) | null
+  ): void {
+    let node = this.node.getChildByName(name);
+    if (!node) {
+      node = new Node(name);
+      node.parent = this.node;
+    }
+    assignUiLayer(node);
+    node.active = true;
+    const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+    transform.setContentSize(width, height);
+    node.setPosition(centerX, centerY, 0.4);
+
+    const graphics = node.getComponent(Graphics) ?? node.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = onPress ? tone.fill : new Color(tone.fill.r, tone.fill.g, tone.fill.b, 108);
+    graphics.strokeColor = tone.stroke;
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 10);
+    graphics.fill();
+    graphics.stroke();
+
+    let labelNode = node.getChildByName("Label");
+    if (!labelNode) {
+      labelNode = new Node("Label");
+      labelNode.parent = node;
+    }
+    assignUiLayer(labelNode);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(width - 12, height - 6);
+    labelNode.setPosition(0, 0, 0.1);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = labelText;
+    label.fontSize = 12;
+    label.lineHeight = 14;
+    label.horizontalAlign = H_ALIGN_CENTER;
+    label.verticalAlign = V_ALIGN_MIDDLE;
+    label.enableWrapText = false;
+    label.color = new Color(244, 247, 252, onPress ? 255 : 132);
+
+    node.off(Node.EventType.TOUCH_END);
+    node.off(Node.EventType.MOUSE_UP);
+    if (onPress) {
+      node.on(Node.EventType.TOUCH_END, () => onPress());
+      node.on(Node.EventType.MOUSE_UP, () => onPress());
+    }
+  }
+
+  private hideExtraItems(visibleCount: number): void {
+    for (let index = visibleCount; index < 8; index += 1) {
+      const node = this.node.getChildByName(`ProgressionItem-${index}`);
+      if (node) {
+        node.active = false;
+      }
+    }
+  }
+}

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -89,6 +89,7 @@ import {
 } from "./cocos-wechat-share.ts";
 import { readStoredCocosAuthSession, resolveCocosLaunchIdentity, type CocosAuthProvider } from "./cocos-session-launch.ts";
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
+import { VeilProgressionPanel } from "./VeilProgressionPanel.ts";
 import { formatEquipmentActionReason, formatEquipmentSlotLabel } from "./cocos-hero-equipment.ts";
 import { type CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
 import { createCocosBattlePresentationController } from "./cocos-battle-presentation-controller.ts";
@@ -99,8 +100,6 @@ import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
 import { cocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
 import { getPixelSpriteLoadStatus, loadPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
 import {
-  buildAchievementUiItems,
-  groupAchievementUiItems,
   describeAccountAuthFailure,
   type RuntimeDiagnosticsConnectionStatus,
   validateAccountLifecycleConfirm,
@@ -115,7 +114,7 @@ const MAP_NODE_NAME = "ProjectVeilMap";
 const BATTLE_NODE_NAME = "ProjectVeilBattlePanel";
 const TIMELINE_NODE_NAME = "ProjectVeilTimelinePanel";
 const LOBBY_NODE_NAME = "ProjectVeilLobbyPanel";
-const ACHIEVEMENT_PANEL_NODE_NAME = "ProjectVeilAchievementPanel";
+const ACCOUNT_REVIEW_PANEL_NODE_NAME = "ProjectVeilAccountReviewPanel";
 const DEFAULT_MAP_WIDTH_TILES = 8;
 const DEFAULT_MAP_HEIGHT_TILES = 8;
 const BATTLE_FEEDBACK_DURATION_MS = 2600;
@@ -236,10 +235,8 @@ export class VeilRoot extends Component {
   private lobbyAccountReviewState: CocosAccountReviewState = createCocosAccountReviewState(this.lobbyAccountProfile);
   private lobbyAccountEpoch = 0;
   private gameplayAccountRefreshInFlight = false;
-  private gameplayAchievementPanelOpen = false;
-  private gameplayAchievementPanelLoading = false;
-  private gameplayAchievementPanelStatus = "打开后将从成就接口同步最新进度。";
-  private gameplayAchievementItems: CocosPlayerAccountProfile["achievements"] = [];
+  private gameplayAccountReviewPanel: VeilProgressionPanel | null = null;
+  private gameplayAccountReviewPanelOpen = false;
   private activeAccountFlow: CocosAccountLifecycleKind | null = null;
   private registrationDisplayName = "";
   private registrationToken = "";
@@ -610,7 +607,7 @@ export class VeilRoot extends Component {
         void this.refreshSnapshot();
       },
       onToggleAchievements: () => {
-        void this.toggleGameplayAchievementPanel();
+        void this.toggleGameplayAccountReviewPanel();
       },
       onLearnSkill: (skillId) => {
         void this.learnHeroSkill(skillId);
@@ -774,14 +771,40 @@ export class VeilRoot extends Component {
     timelineTransform.setContentSize(rightWidth, timelineHeight);
     this.timelinePanel = timelineNode.getComponent(VeilTimelinePanel) ?? timelineNode.addComponent(VeilTimelinePanel);
 
-    let achievementPanelNode = this.node.getChildByName(ACHIEVEMENT_PANEL_NODE_NAME);
-    if (!achievementPanelNode) {
-      achievementPanelNode = new Node(ACHIEVEMENT_PANEL_NODE_NAME);
-      achievementPanelNode.parent = this.node;
+    let accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
+    if (!accountReviewPanelNode) {
+      accountReviewPanelNode = new Node(ACCOUNT_REVIEW_PANEL_NODE_NAME);
+      accountReviewPanelNode.parent = this.node;
     }
-    assignUiLayer(achievementPanelNode);
-    const achievementTransform = achievementPanelNode.getComponent(UITransform) ?? achievementPanelNode.addComponent(UITransform);
-    achievementTransform.setContentSize(Math.max(320, Math.min(420, visibleSize.width - 56)), Math.max(360, visibleSize.height - 96));
+    assignUiLayer(accountReviewPanelNode);
+    const accountReviewTransform = accountReviewPanelNode.getComponent(UITransform) ?? accountReviewPanelNode.addComponent(UITransform);
+    accountReviewTransform.setContentSize(Math.max(320, Math.min(420, visibleSize.width - 56)), Math.max(360, visibleSize.height - 96));
+    this.gameplayAccountReviewPanel =
+      accountReviewPanelNode.getComponent(VeilProgressionPanel) ?? accountReviewPanelNode.addComponent(VeilProgressionPanel);
+    this.gameplayAccountReviewPanel.configure({
+      onClose: () => {
+        void this.toggleGameplayAccountReviewPanel(false);
+      },
+      onSelectSection: (section) => {
+        this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+          type: "section.selected",
+          section
+        });
+        this.renderView();
+        void this.refreshActiveAccountReviewSection();
+      },
+      onSelectPage: (section, page) => {
+        this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+          type: "section.selected",
+          section
+        });
+        this.renderView();
+        void this.refreshAccountReviewPage(section, page);
+      },
+      onRetrySection: (section) => {
+        void this.refreshActiveAccountReviewSection(section);
+      }
+    });
 
     this.battleTransition = this.node.getComponent(VeilBattleTransition) ?? this.node.addComponent(VeilBattleTransition);
     this.updateLayout();
@@ -842,7 +865,7 @@ export class VeilRoot extends Component {
     const mapNode = this.node.getChildByName(MAP_NODE_NAME);
     const battleNode = this.node.getChildByName(BATTLE_NODE_NAME);
     const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
-    const achievementPanelNode = this.node.getChildByName(ACHIEVEMENT_PANEL_NODE_NAME);
+    const accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
     const showingGame = !this.showLobby;
 
     if (lobbyNode) {
@@ -860,8 +883,8 @@ export class VeilRoot extends Component {
     if (timelineNode) {
       timelineNode.active = showingGame;
     }
-    if (achievementPanelNode) {
-      achievementPanelNode.active = showingGame && this.gameplayAchievementPanelOpen;
+    if (accountReviewPanelNode) {
+      accountReviewPanelNode.active = showingGame && this.gameplayAccountReviewPanelOpen;
     }
 
     if (this.showLobby) {
@@ -941,69 +964,24 @@ export class VeilRoot extends Component {
     this.timelinePanel?.render({
       entries: this.timelineEntries
     });
-    this.renderGameplayAchievementPanel();
+    this.renderGameplayAccountReviewPanel();
   }
 
-  private renderGameplayAchievementPanel(): void {
-    const panelNode = this.node.getChildByName(ACHIEVEMENT_PANEL_NODE_NAME);
+  private renderGameplayAccountReviewPanel(): void {
+    const panelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
     if (!panelNode) {
       return;
     }
 
-    if (!this.gameplayAchievementPanelOpen) {
+    if (!this.gameplayAccountReviewPanelOpen) {
       panelNode.active = false;
       return;
     }
 
     panelNode.active = true;
-    assignUiLayer(panelNode);
-    const transform = panelNode.getComponent(UITransform) ?? panelNode.addComponent(UITransform);
-    const width = transform.width || 360;
-    const height = transform.height || 420;
-
-    const graphics = panelNode.getComponent(Graphics) ?? panelNode.addComponent(Graphics);
-    graphics.clear();
-    graphics.fillColor = new Color(21, 28, 38, 236);
-    graphics.strokeColor = new Color(242, 230, 188, 122);
-    graphics.lineWidth = 2;
-    graphics.roundRect(-width / 2, -height / 2, width, height, 18);
-    graphics.fill();
-    graphics.stroke();
-    graphics.fillColor = new Color(255, 248, 214, 20);
-    graphics.roundRect(-width / 2 + 16, height / 2 - 20, width - 32, 6, 3);
-    graphics.fill();
-
-    const groups = groupAchievementUiItems(buildAchievementUiItems(this.gameplayAchievementItems));
-    const panelText = groups.length > 0
-      ? groups
-          .map((group) =>
-            [
-              `${group.category.label} ${group.items.filter((item) => item.isUnlocked).length}/${group.items.length}`,
-              ...group.items.flatMap((item) => [
-                `${item.title} · ${item.statusLabel} · ${item.progressLabel} (${item.progressPercent}%)`,
-                item.description,
-                item.footnote
-              ])
-            ].join("\n")
-          )
-          .join("\n\n")
-      : "当前没有可展示的成就数据。";
-
-    let labelNode = panelNode.getChildByName("Label");
-    if (!labelNode) {
-      labelNode = new Node("Label");
-      labelNode.parent = panelNode;
-    }
-    assignUiLayer(labelNode);
-    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
-    labelTransform.setContentSize(width - 34, height - 62);
-    labelNode.setPosition(0, -12, 1);
-    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
-    label.string = `成就总览\n${this.gameplayAchievementPanelLoading ? "同步中...\n" : ""}${this.gameplayAchievementPanelStatus}\n\n${panelText}`;
-    label.fontSize = 14;
-    label.lineHeight = 19;
-    label.enableWrapText = true;
-    label.color = new Color(245, 239, 226, 255);
+    this.gameplayAccountReviewPanel?.render({
+      page: buildCocosAccountReviewPage(this.lobbyAccountReviewState)
+    });
   }
 
   private formatLobbyVaultSummary(): string {
@@ -1126,7 +1104,8 @@ export class VeilRoot extends Component {
     try {
       const snapshot = await resolveVeilRootRuntime().loadProgressionSnapshot(this.remoteUrl, this.playerId, 6, {
         storage: this.readWebStorage(),
-        authSession: this.currentLobbyAuthSession()
+        authSession: this.currentLobbyAuthSession(),
+        throwOnError: true
       });
       this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
         type: "progression.loaded",
@@ -1153,7 +1132,8 @@ export class VeilRoot extends Component {
     try {
       const items = await resolveVeilRootRuntime().loadAchievementProgress(this.remoteUrl, this.playerId, undefined, {
         storage: this.readWebStorage(),
-        authSession: this.currentLobbyAuthSession()
+        authSession: this.currentLobbyAuthSession(),
+        throwOnError: true
       });
       this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
         type: "achievements.loaded",
@@ -1170,37 +1150,16 @@ export class VeilRoot extends Component {
     this.renderView();
   }
 
-  private async toggleGameplayAchievementPanel(forceOpen?: boolean): Promise<void> {
-    const nextOpen = forceOpen ?? !this.gameplayAchievementPanelOpen;
-    this.gameplayAchievementPanelOpen = nextOpen;
+  private async toggleGameplayAccountReviewPanel(forceOpen?: boolean): Promise<void> {
+    const nextOpen = forceOpen ?? !this.gameplayAccountReviewPanelOpen;
+    this.gameplayAccountReviewPanelOpen = nextOpen;
     if (!nextOpen) {
       this.renderView();
       return;
     }
 
-    this.gameplayAchievementItems = this.lobbyAccountProfile.achievements;
-    this.gameplayAchievementPanelStatus = "正在同步成就目录...";
     this.renderView();
-    await this.refreshGameplayAchievementPanel();
-  }
-
-  private async refreshGameplayAchievementPanel(): Promise<void> {
-    this.gameplayAchievementPanelLoading = true;
-    this.renderView();
-
-    try {
-      const items = await resolveVeilRootRuntime().loadAchievementProgress(this.remoteUrl, this.playerId, undefined, {
-        storage: this.readWebStorage(),
-        authSession: this.currentLobbyAuthSession()
-      });
-      this.gameplayAchievementItems = items;
-      this.gameplayAchievementPanelStatus = items.length > 0 ? `已同步 ${items.length} 条成就进度。` : "当前没有可展示的成就数据。";
-    } catch (error) {
-      this.gameplayAchievementPanelStatus = this.describeAccountReviewLoadError(error);
-    } finally {
-      this.gameplayAchievementPanelLoading = false;
-      this.renderView();
-    }
+    await this.refreshActiveAccountReviewSection();
   }
 
   private async refreshAccountReviewPage(
@@ -1225,7 +1184,8 @@ export class VeilRoot extends Component {
           },
           {
             storage: this.readWebStorage(),
-            authSession: this.currentLobbyAuthSession()
+            authSession: this.currentLobbyAuthSession(),
+            throwOnError: true
           }
         );
         this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
@@ -1246,7 +1206,8 @@ export class VeilRoot extends Component {
           },
           {
             storage: this.readWebStorage(),
-            authSession: this.currentLobbyAuthSession()
+            authSession: this.currentLobbyAuthSession(),
+            throwOnError: true
           }
         );
         this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
@@ -1357,7 +1318,7 @@ export class VeilRoot extends Component {
     const battleNode = this.node.getChildByName(BATTLE_NODE_NAME);
     const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
     const lobbyNode = this.node.getChildByName(LOBBY_NODE_NAME);
-    const achievementPanelNode = this.node.getChildByName(ACHIEVEMENT_PANEL_NODE_NAME);
+    const accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
 
     this.mapBoard?.configure({
       tileSize: effectiveTileSize,
@@ -1382,7 +1343,7 @@ export class VeilRoot extends Component {
           void this.refreshSnapshot();
         },
         onToggleAchievements: () => {
-          void this.toggleGameplayAchievementPanel();
+          void this.toggleGameplayAccountReviewPanel();
         },
         onLearnSkill: (skillId) => {
           void this.learnHeroSkill(skillId);
@@ -1435,10 +1396,11 @@ export class VeilRoot extends Component {
       lobbyNode.setPosition(0, 0, 0);
     }
 
-    if (achievementPanelNode) {
-      const achievementTransform = achievementPanelNode.getComponent(UITransform) ?? achievementPanelNode.addComponent(UITransform);
-      achievementTransform.setContentSize(Math.max(320, Math.min(420, visibleSize.width - 56)), Math.max(360, visibleSize.height - 96));
-      achievementPanelNode.setPosition(0, 0, 4);
+    if (accountReviewPanelNode) {
+      const accountReviewTransform =
+        accountReviewPanelNode.getComponent(UITransform) ?? accountReviewPanelNode.addComponent(UITransform);
+      accountReviewTransform.setContentSize(Math.max(320, Math.min(420, visibleSize.width - 56)), Math.max(360, visibleSize.height - 96));
+      accountReviewPanelNode.setPosition(0, 0, 4);
     }
   }
 
@@ -1472,7 +1434,7 @@ export class VeilRoot extends Component {
 
     if (action === "achievements") {
       this.inputDebug = "button achievements";
-      void this.toggleGameplayAchievementPanel();
+      void this.toggleGameplayAccountReviewPanel();
       return;
     }
 
@@ -2212,7 +2174,7 @@ export class VeilRoot extends Component {
     this.displayName = rememberPreferredCocosDisplayName(this.playerId, this.displayName || this.playerId, storage);
     await this.disposeCurrentSession();
     this.resetSessionViewport("已返回 Cocos Lobby。");
-    this.gameplayAchievementPanelOpen = false;
+    this.gameplayAccountReviewPanelOpen = false;
     this.showLobby = true;
     this.syncWechatShareBridge();
     this.lobbyStatus = "已返回大厅，可继续选房或创建新实例。";
@@ -3021,9 +2983,6 @@ export class VeilRoot extends Component {
     }
 
     this.lobbyAccountProfile = profile;
-    if (this.gameplayAchievementPanelOpen) {
-      this.gameplayAchievementItems = profile.achievements;
-    }
     this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
       type: "account.synced",
       account: profile

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -396,6 +396,7 @@ export async function loadCocosBattleReplaySummaries(
     fetchImpl?: FetchLike;
     authSession?: CocosStoredAuthSession | null;
     storage?: Pick<Storage, "removeItem"> | null;
+    throwOnError?: boolean;
   }
 ): Promise<PlayerBattleReplaySummary[]> {
   const authSession = options?.authSession ?? null;
@@ -422,6 +423,9 @@ export async function loadCocosBattleReplaySummaries(
     if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && options?.storage) {
       clearStoredCocosAuthSession(options.storage);
     }
+    if (options?.throwOnError) {
+      throw error;
+    }
     return normalizePlayerBattleReplaySummaries();
   }
 }
@@ -434,6 +438,7 @@ export async function loadCocosBattleReplayHistoryPage(
     fetchImpl?: FetchLike;
     authSession?: CocosStoredAuthSession | null;
     storage?: Pick<Storage, "removeItem"> | null;
+    throwOnError?: boolean;
   }
 ): Promise<CocosBattleReplayHistoryPage> {
   const safeLimit = Math.max(1, Math.floor(query.limit ?? DEFAULT_HISTORY_PAGE_SIZE));
@@ -1295,6 +1300,7 @@ export async function loadCocosPlayerEventHistory(
     fetchImpl?: FetchLike;
     storage?: Pick<Storage, "getItem" | "removeItem"> | null;
     authSession?: CocosStoredAuthSession | null;
+    throwOnError?: boolean;
   }
 ): Promise<CocosEventHistoryPage> {
   const storage = options?.storage ?? getCocosStorage();
@@ -1332,6 +1338,9 @@ export async function loadCocosPlayerEventHistory(
     if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && storage) {
       clearStoredCocosAuthSession(storage);
     }
+    if (options?.throwOnError) {
+      throw error;
+    }
     const safeLimit = Math.max(1, Math.floor(query?.limit ?? DEFAULT_HISTORY_PAGE_SIZE));
     const safeOffset = Math.max(0, Math.floor(query?.offset ?? 0));
     return {
@@ -1352,6 +1361,7 @@ export async function loadCocosPlayerAchievementProgress(
     fetchImpl?: FetchLike;
     storage?: Pick<Storage, "getItem" | "removeItem"> | null;
     authSession?: CocosStoredAuthSession | null;
+    throwOnError?: boolean;
   }
 ): Promise<PlayerAchievementProgress[]> {
   const storage = options?.storage ?? getCocosStorage();
@@ -1380,6 +1390,9 @@ export async function loadCocosPlayerAchievementProgress(
     if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && storage) {
       clearStoredCocosAuthSession(storage);
     }
+    if (options?.throwOnError) {
+      throw error;
+    }
     return queryAchievementProgress(undefined, query);
   }
 }
@@ -1392,6 +1405,7 @@ export async function loadCocosPlayerProgressionSnapshot(
     fetchImpl?: FetchLike;
     storage?: Pick<Storage, "getItem" | "removeItem"> | null;
     authSession?: CocosStoredAuthSession | null;
+    throwOnError?: boolean;
   }
 ): Promise<PlayerProgressionSnapshot> {
   const storage = options?.storage ?? getCocosStorage();
@@ -1419,6 +1433,9 @@ export async function loadCocosPlayerProgressionSnapshot(
   } catch (error) {
     if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && storage) {
       clearStoredCocosAuthSession(storage);
+    }
+    if (options?.throwOnError) {
+      throw error;
     }
     return normalizePlayerProgressionSnapshot();
   }

--- a/apps/cocos-client/test/cocos-account-review.test.ts
+++ b/apps/cocos-client/test/cocos-account-review.test.ts
@@ -205,6 +205,24 @@ test("transitionCocosAccountReviewState exposes loading and error banners for pa
   assert.equal(review.showRetry, true);
 });
 
+test("buildCocosAccountReviewPage returns an empty-state subtitle for empty event history", () => {
+  let state = createCocosAccountReviewState(createProfile());
+  state = transitionCocosAccountReviewState(state, { type: "section.selected", section: "event-history" });
+  state = transitionCocosAccountReviewState(state, {
+    type: "event-history.loaded",
+    items: [],
+    page: 0,
+    pageSize: 3,
+    total: 0,
+    hasMore: false
+  });
+
+  const review = buildCocosAccountReviewPage(state);
+  assert.equal(review.section, "event-history");
+  assert.equal(review.subtitle, "最近还没有事件历史。");
+  assert.deepEqual(review.items, []);
+});
+
 test("transitionCocosAccountReviewState keeps replay selection aligned with the currently loaded page", () => {
   let state = createCocosAccountReviewState(createProfile());
   assert.equal(state.selectedBattleReplayId, "replay-1");

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 import { sys } from "cc";
-import { createCocosAccountReviewState, transitionCocosAccountReviewState } from "../assets/scripts/cocos-account-review.ts";
+import {
+  buildCocosAccountReviewPage,
+  createCocosAccountReviewState,
+  transitionCocosAccountReviewState
+} from "../assets/scripts/cocos-account-review.ts";
 import { createMemoryStorage, createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
 import { createVeilRootHarness, installVeilRootRuntime, resetVeilRootRuntime } from "./helpers/veil-root-harness.ts";
 import type { BattleAction, BattleState, SessionUpdate, VeilCocosSessionOptions } from "../assets/scripts/VeilCocosSession.ts";
@@ -347,7 +351,7 @@ test("VeilRoot surfaces broken room snapshots with a stable runtime error messag
   assert.equal(root.logLines[0], "房间状态损坏，请重建房间或检查服务端同步。");
 });
 
-test("VeilRoot gameplay achievement panel loads achievement progress from the account endpoint", async () => {
+test("VeilRoot gameplay account review panel loads progression snapshot from the account endpoint", async () => {
   const root = createVeilRootHarness();
   root.playerId = "player-1";
   root.roomId = "room-alpha";
@@ -355,29 +359,51 @@ test("VeilRoot gameplay achievement panel loads achievement progress from the ac
 
   let loadCalls = 0;
   installVeilRootRuntime({
-    loadAchievementProgress: async () => {
+    loadProgressionSnapshot: async () => {
       loadCalls += 1;
-      return [
-        {
-          id: "first_battle",
-          title: "初次交锋",
-          description: "首次进入战斗。",
-          metric: "battles_started",
-          current: 1,
-          target: 1,
-          unlocked: true,
-          unlockedAt: "2026-03-29T01:00:00.000Z"
-        }
-      ];
+      return {
+        summary: {
+          totalAchievements: 5,
+          unlockedAchievements: 1,
+          inProgressAchievements: 1,
+          recentEventCount: 2,
+          latestEventAt: "2026-03-29T01:03:00.000Z"
+        },
+        achievements: [
+          {
+            id: "first_battle",
+            title: "初次交锋",
+            description: "首次进入战斗。",
+            metric: "battles_started",
+            current: 1,
+            target: 1,
+            unlocked: true,
+            unlockedAt: "2026-03-29T01:00:00.000Z"
+          }
+        ],
+        recentEventLog: [
+          {
+            id: "event-1",
+            timestamp: "2026-03-29T01:03:00.000Z",
+            roomId: "room-alpha",
+            playerId: "player-1",
+            category: "achievement",
+            description: "解锁成就：初次交锋",
+            achievementId: "first_battle",
+            rewards: []
+          }
+        ]
+      };
     }
   });
 
-  await (root as VeilRoot & Record<string, unknown>).toggleGameplayAchievementPanel(true);
+  await (root as VeilRoot & Record<string, unknown>).toggleGameplayAccountReviewPanel(true);
 
   assert.equal(loadCalls, 1);
-  assert.equal(root.gameplayAchievementPanelOpen, true);
-  assert.equal((root.gameplayAchievementItems as Array<{ id: string }>)[0]?.id, "first_battle");
-  assert.match(String(root.gameplayAchievementPanelStatus), /已同步 1 条成就进度/);
+  assert.equal(root.gameplayAccountReviewPanelOpen, true);
+  assert.equal(root.lobbyAccountReviewState.progression.status, "ready");
+  assert.equal(root.lobbyAccountReviewState.progression.snapshot.summary.unlockedAchievements, 1);
+  assert.equal(root.lobbyAccountReviewState.progression.snapshot.recentEventLog[0]?.id, "event-1");
 });
 
 test("VeilRoot hands control to a fresh session when starting a new run", async () => {
@@ -683,4 +709,58 @@ test("VeilRoot refreshAccountReviewPage loads paged event history into the lobby
   assert.equal(root.lobbyAccountReviewState.eventHistory.page, 1);
   assert.equal(root.lobbyAccountReviewState.eventHistory.total, 4);
   assert.equal(root.lobbyAccountReviewState.eventHistory.items[0]?.id, "event-page-2");
+});
+
+test("VeilRoot review refresh keeps empty event history as a ready empty state", async () => {
+  const root = createVeilRootHarness();
+  root.playerId = "player-1";
+  root.lobbyAccountReviewState = transitionCocosAccountReviewState(
+    createCocosAccountReviewState(root.lobbyAccountProfile),
+    {
+      type: "section.selected",
+      section: "event-history"
+    }
+  );
+
+  installVeilRootRuntime({
+    loadEventHistory: async () => ({
+      items: [],
+      total: 0,
+      offset: 0,
+      limit: 3,
+      hasMore: false
+    })
+  });
+
+  await root.refreshActiveAccountReviewSection();
+
+  assert.equal(root.lobbyAccountReviewState.eventHistory.status, "ready");
+  assert.deepEqual(root.lobbyAccountReviewState.eventHistory.items, []);
+  assert.equal(root.lobbyAccountReviewState.eventHistory.total, 0);
+  assert.equal(buildCocosAccountReviewPage(root.lobbyAccountReviewState).subtitle, "最近还没有事件历史。");
+});
+
+test("VeilRoot review refresh exposes transport failures as an error state", async () => {
+  const root = createVeilRootHarness();
+  root.playerId = "player-1";
+  root.lobbyAccountReviewState = transitionCocosAccountReviewState(
+    createCocosAccountReviewState(root.lobbyAccountProfile),
+    {
+      type: "section.selected",
+      section: "achievements"
+    }
+  );
+
+  installVeilRootRuntime({
+    loadAchievementProgress: async () => {
+      throw new Error("cocos_request_failed:503:history_unavailable");
+    }
+  });
+
+  await root.refreshActiveAccountReviewSection();
+
+  assert.equal(root.lobbyAccountReviewState.achievements.status, "error");
+  const review = buildCocosAccountReviewPage(root.lobbyAccountReviewState);
+  assert.equal(review.banner?.title, "成就目录同步失败");
+  assert.equal(review.showRetry, true);
 });


### PR DESCRIPTION
## Summary
- add a runtime Cocos progression/history overlay reachable from the HUD action surface
- reuse the account review state machine for progression, achievements, event history, and paging/error states
- let review refreshes surface transport failures while keeping fallback behavior elsewhere intact
- add focused Cocos coverage for success, empty, and error review states

Closes #343