### PR TITLE
chore(ci): enforce clear branch/function coverage floor failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ npm run dev:client:h5
 - 并发房间压测启动后，也可直接查看同进程观测面：`/api/runtime/health`、`/api/runtime/auth-readiness` 与 `/api/runtime/metrics`
 - 战斗平衡验证：`npm run validate:battle -- --count=1000 --scenario=all --skill-config=configs/battle-skills-v1.1.json`
 - 内容包一致性验证：`npm run validate:content-pack -- --report-path artifacts/content-pack-validation-report.json`
+- 覆盖率 CI 同款校验：`npm run test:coverage:ci`
+- 覆盖率摘要：`.coverage/summary.md`
 - 共享客户端载荷 contract 快照：`npm run test:contracts`
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
@@ -218,6 +220,19 @@ npm run dev:client:h5
 - 这轮又补了一层独立的玩家事件历史读模型：`savePlayerAccountProgress()` 会把账号 `recentEventLog` 里新增的结构化事件增量追加到 MySQL `player_event_history`，并开放 `GET /api/player-accounts/:playerId/event-history` / `/me/event-history`（支持 `limit`、`offset` 和现有事件筛选条件），让前端可以先做分页历史回顾而不用等完整战斗回放或完整成就 UI。
 - 玩家事件历史接口现已支持可选 `since` / `until` 时间范围筛选，且本地模式与 MySQL 持久化模式保持一致，方便后续只拉取某个时间窗内的世界事件或成就回顾。
 - 事件日志的共享基础当前收敛在 `packages/shared/src/event-log.ts`：除了事件/成就 schema、归一化和查询助手外，这里也统一提供世界事件日志工厂与成就日志工厂，服务端只负责把共享 `WorldEvent[]` 喂给这些 helper；完整战斗回放、完整成就 UI 和更长历史存储仍留给后续 issue 继续扩展。
+
+## Coverage Policy
+
+`npm run test:coverage:ci` 是 coverage CI 的本地复现命令。它会按 `shared`、`server`、`client`、`cocos-client` 四个 scope 分开运行 `node:test`，并同时执行 line、branch、function 三类 floor 校验。
+
+当前 policy 是：
+
+- `shared`: lines `90%`, branches `70%`, functions `90%`
+- `server`: lines `75%`, branches `65%`, functions `75%`
+- `client`: lines `78%`, branches `65%`, functions `70%`
+- `cocos-client`: lines `55%`, branches `70%`, functions `60%`
+
+运行后会生成 `.coverage/summary.md` 和 `.coverage/summary.json`。如果任一 scope 的任一 metric 低于 floor，摘要顶部会明确列出失败的 scope 和具体阈值差距，方便直接对照 CI 失败原因。
 - 战斗回放读模型当前已补上两块更适合前端直接消费的能力：`GET /api/player-accounts/:playerId/battle-replays` 现支持 `limit` + `offset` 分页，shared 侧也新增了可从 `initialState + steps` 推导每步回合与伤害/减员结算的 replay timeline helper，H5 战报面板会直接显示这些逐步结算摘要。
 - Cocos Lobby 现已复用这套 timeline helper：账号资料回顾的“战报”卡片可直接点击进入战报时间线面板，会按行动阵营/单位、动作类型和主要结算概览显示最近 6 条步骤，并在没有战斗或回放缺失时回退提示。
 - H5 账号资料卡现在会额外拉取 `/api/player-accounts/:playerId/progression` 覆盖成就/事件摘要，因此即使基础账号接口只返回轻量档案，前端也能稳定展示最新的成就推进、最近解锁和世界事件日志，而不会继续依赖旧的内嵌快照。

--- a/docs/test-coverage-audit-issue-199.md
+++ b/docs/test-coverage-audit-issue-199.md
@@ -99,7 +99,7 @@ The largest remaining gap is that most actual scene/controller entry points are 
 The current tooling makes coverage expansion slower than it needs to be:
 
 1. The root `npm test` script is a manually maintained file list instead of a discovery-based pattern. This already caused five checked-in suites to be skipped until this audit.
-2. The repo now publishes scoped Node/V8 coverage through `npm run test:coverage:ci`, including `.coverage/summary.md`, raw V8 JSON artifacts, and minimum line thresholds for `shared`, `server`, `client`, and `cocos-client`. The remaining limitation is that thresholds currently gate line coverage only; branch/function gaps still rely on the report output rather than hard CI floors.
+2. The repo now publishes scoped Node/V8 coverage through `npm run test:coverage:ci`, including `.coverage/summary.md`, raw V8 JSON artifacts, and minimum line/branch/function floors for `shared`, `server`, `client`, and `cocos-client`. The summary now calls out threshold failures explicitly so CI logs and `GITHUB_STEP_SUMMARY` show which scope and metric fell below its floor.
 3. H5 Playwright coverage is useful, but it only validates the DOM debug shell; it does not exercise the Cocos runtime that now serves as the primary client.
 4. Cocos scene components depend on `cc` runtime behavior, which makes them harder to test in plain `node:test` without maintaining more test doubles or extracting more pure logic seams.
 5. WeChat readiness still depends on artifact validation and manual smoke-report workflows rather than automated device/runtime execution.

--- a/scripts/ci-v8-coverage.ts
+++ b/scripts/ci-v8-coverage.ts
@@ -1,6 +1,7 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 type CoverageSuite = {
   name: string;
@@ -17,9 +18,21 @@ type CoverageMetrics = {
   functions: number;
 };
 
-const coverageRoot = path.resolve(".coverage");
+type CoverageFailure = {
+  metric: keyof CoverageMetrics;
+  actual: number | null;
+  threshold: number;
+};
 
-const suites: CoverageSuite[] = [
+type CoverageSummary = {
+  suite: CoverageSuite;
+  metrics: CoverageMetrics | null;
+  failures: CoverageFailure[];
+};
+
+export const coverageRoot = path.resolve(".coverage");
+
+export const suites: CoverageSuite[] = [
   {
     name: "shared",
     include: "packages/shared/src/**/*.ts",
@@ -58,7 +71,7 @@ async function main() {
   await rm(coverageRoot, { force: true, recursive: true });
   await mkdir(path.join(coverageRoot, "v8"), { recursive: true });
 
-  const summaries: Array<{ suite: CoverageSuite; metrics: CoverageMetrics | null }> = [];
+  const summaries: CoverageSummary[] = [];
 
   for (const suite of suites) {
     const suiteCoverageDir = path.join(coverageRoot, "v8", suite.name);
@@ -85,10 +98,12 @@ async function main() {
     await writeFile(path.join(coverageRoot, `${suite.name}.log`), output);
 
     const metrics = parseCoverageMetrics(output);
-    summaries.push({ suite, metrics });
+    const summary = buildCoverageSummary(suite, metrics);
+    summaries.push(summary);
 
     if (code !== 0) {
       await writeSummary(summaries);
+      printFailureReport(summaries);
       process.exit(code ?? 1);
     }
   }
@@ -123,7 +138,7 @@ function runNodeCommand(args: string[], env: NodeJS.ProcessEnv) {
   });
 }
 
-function parseCoverageMetrics(output: string): CoverageMetrics | null {
+export function parseCoverageMetrics(output: string): CoverageMetrics | null {
   const match = output.match(/all files\s+\|\s+([\d.]+)\s+\|\s+([\d.]+)\s+\|\s+([\d.]+)/);
   if (!match) {
     return null;
@@ -136,11 +151,45 @@ function parseCoverageMetrics(output: string): CoverageMetrics | null {
   };
 }
 
-async function writeSummary(
-  summaries: Array<{ suite: CoverageSuite; metrics: CoverageMetrics | null }>,
-) {
+export function buildCoverageSummary(
+  suite: CoverageSuite,
+  metrics: CoverageMetrics | null,
+): CoverageSummary {
+  const failures: CoverageFailure[] = [];
+
+  if (!metrics) {
+    failures.push(
+      { metric: "lines", actual: null, threshold: suite.lineThreshold },
+      { metric: "branches", actual: null, threshold: suite.branchThreshold },
+      { metric: "functions", actual: null, threshold: suite.functionThreshold },
+    );
+  } else {
+    if (metrics.lines < suite.lineThreshold) {
+      failures.push({ metric: "lines", actual: metrics.lines, threshold: suite.lineThreshold });
+    }
+    if (metrics.branches < suite.branchThreshold) {
+      failures.push({ metric: "branches", actual: metrics.branches, threshold: suite.branchThreshold });
+    }
+    if (metrics.functions < suite.functionThreshold) {
+      failures.push({ metric: "functions", actual: metrics.functions, threshold: suite.functionThreshold });
+    }
+  }
+
+  return {
+    suite,
+    metrics,
+    failures,
+  };
+}
+
+export async function writeSummary(summaries: CoverageSummary[]) {
+  const failedSummaries = summaries.filter((summary) => summary.failures.length > 0);
   const lines = [
     "# V8 Coverage Summary",
+    "",
+    `Overall status: **${failedSummaries.length > 0 ? "FAILED" : "PASSED"}**`,
+    "",
+    ...renderFailureSection(failedSummaries),
     "",
     "| Scope | Lines | Branches | Functions |",
     "| --- | --- | --- | --- |",
@@ -158,12 +207,13 @@ async function writeSummary(
   await writeFile(
     path.join(coverageRoot, "summary.json"),
     `${JSON.stringify(
-      summaries.map(({ suite, metrics }) => ({
+      summaries.map(({ suite, metrics, failures }) => ({
         scope: suite.name,
         lineThreshold: suite.lineThreshold,
         branchThreshold: suite.branchThreshold,
         functionThreshold: suite.functionThreshold,
         metrics,
+        failures,
       })),
       null,
       2,
@@ -171,12 +221,49 @@ async function writeSummary(
   );
 }
 
+export function renderFailureSection(failedSummaries: CoverageSummary[]): string[] {
+  if (failedSummaries.length === 0) {
+    return ["## Threshold Failures", "", "None. All configured line, branch, and function coverage floors passed."];
+  }
+
+  return [
+    "## Threshold Failures",
+    "",
+    ...failedSummaries.map(({ suite, failures }) => {
+      const details = failures.map((failure) => formatFailure(failure)).join("; ");
+      return `- ${suite.name}: ${details}`;
+    }),
+  ];
+}
+
+export function printFailureReport(summaries: CoverageSummary[]): void {
+  const failedSummaries = summaries.filter((summary) => summary.failures.length > 0);
+  if (failedSummaries.length === 0) {
+    return;
+  }
+
+  process.stderr.write("\nCoverage threshold failures:\n");
+  for (const line of renderFailureSection(failedSummaries).slice(2)) {
+    process.stderr.write(`${line}\n`);
+  }
+}
+
+function formatFailure(failure: CoverageFailure): string {
+  if (failure.actual === null) {
+    return `${failure.metric} missing coverage output vs ${failure.threshold}% floor`;
+  }
+
+  return `${failure.metric} ${failure.actual.toFixed(2)}% below ${failure.threshold}% floor`;
+}
+
 function formatMetric(actual: number, threshold: number): string {
   const passed = actual >= threshold;
   return `${passed ? "PASS" : "FAIL"} ${actual.toFixed(2)}% vs ${threshold}%`;
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/test/ci-v8-coverage.test.ts
+++ b/scripts/test/ci-v8-coverage.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildCoverageSummary,
+  coverageRoot,
+  parseCoverageMetrics,
+  renderFailureSection,
+  writeSummary,
+} from "../ci-v8-coverage.ts";
+
+test("buildCoverageSummary flags branch and function floor misses alongside lines", () => {
+  const summary = buildCoverageSummary(
+    {
+      name: "client",
+      include: "apps/client/src/**/*.ts",
+      lineThreshold: 80,
+      branchThreshold: 70,
+      functionThreshold: 75,
+      tests: ["apps/client/test/**/*.test.ts"],
+    },
+    {
+      lines: 79.25,
+      branches: 69.5,
+      functions: 74.99,
+    },
+  );
+
+  assert.deepEqual(summary.failures, [
+    { metric: "lines", actual: 79.25, threshold: 80 },
+    { metric: "branches", actual: 69.5, threshold: 70 },
+    { metric: "functions", actual: 74.99, threshold: 75 },
+  ]);
+});
+
+test("renderFailureSection produces a clear failure list", () => {
+  const lines = renderFailureSection([
+    buildCoverageSummary(
+      {
+        name: "server",
+        include: "apps/server/src/**/*.ts",
+        lineThreshold: 75,
+        branchThreshold: 65,
+        functionThreshold: 75,
+        tests: ["apps/server/test/**/*.test.ts"],
+      },
+      {
+        lines: 77.25,
+        branches: 64.99,
+        functions: 74.5,
+      },
+    ),
+  ]);
+
+  assert.deepEqual(lines, [
+    "## Threshold Failures",
+    "",
+    "- server: branches 64.99% below 65% floor; functions 74.50% below 75% floor",
+  ]);
+});
+
+test("parseCoverageMetrics reads the all files summary row", () => {
+  const metrics = parseCoverageMetrics(`
+ℹ file | line % | branch % | funcs % | uncovered lines
+ℹ all files                     |  77.25 |    70.92 |   80.69 |
+`);
+
+  assert.deepEqual(metrics, {
+    lines: 77.25,
+    branches: 70.92,
+    functions: 80.69,
+  });
+});
+
+test("writeSummary includes overall status and explicit threshold failures", async () => {
+  fs.mkdirSync(coverageRoot, { recursive: true });
+
+  await writeSummary([
+    buildCoverageSummary(
+      {
+        name: "shared",
+        include: "packages/shared/src/**/*.ts",
+        lineThreshold: 90,
+        branchThreshold: 70,
+        functionThreshold: 90,
+        tests: ["packages/shared/test/**/*.test.ts"],
+      },
+      {
+        lines: 92.11,
+        branches: 74.54,
+        functions: 94.23,
+      },
+    ),
+    buildCoverageSummary(
+      {
+        name: "server",
+        include: "apps/server/src/**/*.ts",
+        lineThreshold: 78,
+        branchThreshold: 72,
+        functionThreshold: 82,
+        tests: ["apps/server/test/**/*.test.ts"],
+      },
+      {
+        lines: 77.25,
+        branches: 70.92,
+        functions: 80.69,
+      },
+    ),
+  ]);
+
+  const markdown = fs.readFileSync(path.join(coverageRoot, "summary.md"), "utf8");
+  const json = JSON.parse(fs.readFileSync(path.join(coverageRoot, "summary.json"), "utf8")) as Array<{
+    branchThreshold: number;
+    scope: string;
+    functionThreshold: number;
+    failures: Array<{ metric: string; actual: number; threshold: number }>;
+    lineThreshold: number;
+    metrics: { lines: number; branches: number; functions: number };
+  }>;
+
+  assert.match(markdown, /Overall status: \*\*FAILED\*\*/);
+  assert.match(markdown, /## Threshold Failures/);
+  assert.match(markdown, /- server: lines 77\.25% below 78% floor; branches 70\.92% below 72% floor; functions 80\.69% below 82% floor/);
+  assert.match(markdown, /\| shared \| PASS 92\.11% vs 90% \| PASS 74\.54% vs 70% \| PASS 94\.23% vs 90% \|/);
+  assert.deepEqual(json[1], {
+    branchThreshold: 72,
+    scope: "server",
+    functionThreshold: 82,
+    failures: [
+      { metric: "lines", actual: 77.25, threshold: 78 },
+      { metric: "branches", actual: 70.92, threshold: 72 },
+      { metric: "functions", actual: 80.69, threshold: 82 },
+    ],
+    lineThreshold: 78,
+    metrics: {
+      lines: 77.25,
+      branches: 70.92,
+      functions: 80.69,
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- make coverage floor evaluation explicit for lines, branches, and functions and surface failures clearly in the generated summary and CI logs
- add focused tests for the coverage summary helpers so threshold failures stay readable and stable
- document the stricter coverage policy and the local reproduction command

## Testing
- node --import tsx --test ./scripts/test/ci-v8-coverage.test.ts
- node --import tsx --test ./scripts/test/publish-ci-trend-summary.test.ts
- npm run test:coverage:ci *(currently blocked by two pre-existing failures in apps/server/test/config-center.test.ts: `config center staged publish applies bundled drafts and records publish history` and `config center staged publish blocks invalid drafts`)*

Closes #351