### PR TITLE
test(cocos): add VeilRoot and session lifecycle harness coverage

### DIFF
--- a/apps/cocos-client/test/cocos-runtime-harness.test.ts
+++ b/apps/cocos-client/test/cocos-runtime-harness.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 import { VeilCocosSession } from "../assets/scripts/VeilCocosSession.ts";
-import { createSessionUpdate, FakeColyseusRoom } from "./helpers/cocos-session-fixtures.ts";
+import { writeStoredCocosAuthSession } from "../assets/scripts/cocos-session-launch.ts";
+import { createMemoryStorage, createSessionUpdate, FakeColyseusRoom } from "./helpers/cocos-session-fixtures.ts";
 import {
   createVeilCocosSessionRuntimeHarness,
   createVeilRootRuntimeHarness,
+  createVeilRootSessionLifecycleHarness,
   resetCocosRuntimeHarnesses
 } from "./helpers/cocos-runtime-harness.ts";
 
@@ -16,6 +18,17 @@ function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => {
     setImmediate(resolve);
   });
+}
+
+function seedStoredReplay(storage: Storage, update: ReturnType<typeof createSessionUpdate>): void {
+  storage.setItem(
+    `project-veil:cocos:session-replay:${update.world.meta.roomId}:${update.world.playerId}`,
+    JSON.stringify({
+      version: 1,
+      storedAt: Date.now(),
+      update
+    })
+  );
 }
 
 test("Cocos runtime harness boots VeilRoot from lobby handoff into the first live snapshot", async () => {
@@ -131,4 +144,161 @@ test("Cocos runtime harness lets VeilCocosSession persist replay data across rec
   );
 
   await session.dispose();
+});
+
+test("Cocos lifecycle harness replays cached local boot state before VeilRoot opens the live session", async () => {
+  const storage = createMemoryStorage();
+  writeStoredCocosAuthSession(storage, {
+    token: "guest.local.token",
+    playerId: "local-player",
+    displayName: "本地旅人",
+    authMode: "guest",
+    provider: "guest",
+    source: "local"
+  });
+  const cachedUpdate = createSessionUpdate(2, "room-local", "local-player");
+  const liveUpdate = createSessionUpdate(3, "room-local", "local-player");
+  seedStoredReplay(storage, cachedUpdate);
+
+  const room = new FakeColyseusRoom([liveUpdate], "local-reconnect-token");
+  const harness = createVeilRootSessionLifecycleHarness({
+    storage,
+    joinRooms: [room]
+  });
+  const order: string[] = [];
+  const originalApplySessionUpdate = harness.root.applySessionUpdate.bind(harness.root);
+
+  harness.root.readLaunchSearch = () => "?roomId=room-local";
+  harness.root.applyReplayedSessionUpdate = (update) => {
+    order.push(`replay:${update.world.meta.day}`);
+    harness.root.lastUpdate = {
+      ...update,
+      events: [],
+      movementPlan: null
+    };
+  };
+  harness.root.applySessionUpdate = async (update) => {
+    order.push(`live:${update.world.meta.day}`);
+    await originalApplySessionUpdate(update);
+  };
+
+  harness.root.hydrateLaunchIdentity();
+  await harness.root.connect();
+
+  assert.equal(harness.root.showLobby, false);
+  assert.equal(harness.root.sessionSource, "local");
+  assert.equal(harness.root.authToken, "guest.local.token");
+  assert.deepEqual(order, ["replay:2", "live:3"]);
+  assert.equal(harness.root.lastUpdate?.world.meta.day, 3);
+  assert.deepEqual(room.sentMessages, [
+    {
+      type: "connect",
+      payload: {
+        type: "connect",
+        requestId: "cocos-req-1",
+        roomId: "room-local",
+        playerId: "local-player",
+        displayName: "本地旅人",
+        authToken: "guest.local.token"
+      }
+    }
+  ]);
+});
+
+test("Cocos lifecycle harness recovers VeilRoot through VeilCocosSession reconnect handoff", async () => {
+  const replayedUpdate = createSessionUpdate(2, "room-recover", "player-349");
+  const initialUpdate = createSessionUpdate(3, "room-recover", "player-349");
+  const recoveredUpdate = createSessionUpdate(5, "room-recover", "player-349");
+  const initialRoom = new FakeColyseusRoom([initialUpdate], "initial-token");
+  const recoveredRoom = new FakeColyseusRoom([recoveredUpdate, recoveredUpdate], "recovered-token");
+  const harness = createVeilRootSessionLifecycleHarness({
+    joinRooms: [initialRoom, recoveredRoom],
+    wait: async () => undefined
+  });
+  const order: string[] = [];
+  const originalApplySessionUpdate = harness.root.applySessionUpdate.bind(harness.root);
+
+  harness.root.roomId = "room-recover";
+  harness.root.playerId = "player-349";
+  harness.root.displayName = "Player 349";
+  seedStoredReplay(harness.storage, replayedUpdate);
+  harness.root.applyReplayedSessionUpdate = (update) => {
+    order.push(`replay:${update.world.meta.day}`);
+    harness.root.lastUpdate = {
+      ...update,
+      events: [],
+      movementPlan: null
+    };
+  };
+  harness.root.applySessionUpdate = async (update) => {
+    order.push(`live:${update.world.meta.day}`);
+    await originalApplySessionUpdate(update);
+  };
+
+  await harness.root.connect();
+  initialRoom.emitLeave(4002);
+  await flushMicrotasks();
+
+  assert.deepEqual(order, ["replay:2", "live:3", "live:5"]);
+  assert.equal(harness.root.lastUpdate?.world.meta.day, 5);
+  assert.equal(harness.root.diagnosticsConnectionStatus, "connected");
+  assert.deepEqual(harness.joinedOptions, [
+    { logicalRoomId: "room-recover", playerId: "player-349", seed: 1001 },
+    { logicalRoomId: "room-recover", playerId: "player-349", seed: 1001 }
+  ]);
+  assert.equal(
+    harness.storage.getItem("project-veil:cocos:reconnection:room-recover:player-349"),
+    "recovered-token"
+  );
+});
+
+test("Cocos lifecycle harness hands lobby auth off into a live VeilRoot session", async () => {
+  const storage = createMemoryStorage();
+  writeStoredCocosAuthSession(storage, {
+    token: "account.token",
+    playerId: "account-player",
+    displayName: "暮潮守望",
+    authMode: "account",
+    provider: "account-password",
+    loginId: "veil-ranger",
+    source: "remote"
+  });
+  const room = new FakeColyseusRoom([createSessionUpdate(6, "room-lobby", "account-player")], "account-reconnect-token");
+  const harness = createVeilRootSessionLifecycleHarness({
+    storage,
+    joinRooms: [room],
+    syncedAuthSession: {
+      token: "account.token",
+      playerId: "account-player",
+      displayName: "暮潮守望",
+      authMode: "account",
+      provider: "account-password",
+      loginId: "veil-ranger",
+      source: "remote"
+    }
+  });
+
+  harness.root.readLaunchSearch = () => "";
+  harness.root.syncBrowserRoomQuery = () => undefined;
+  harness.root.hydrateLaunchIdentity();
+  await harness.root.enterLobbyRoom("room-lobby");
+
+  assert.equal(harness.root.showLobby, false);
+  assert.equal(harness.root.authMode, "account");
+  assert.equal(harness.root.authToken, "account.token");
+  assert.equal(harness.root.sessionSource, "remote");
+  assert.equal(harness.root.lastUpdate?.world.meta.day, 6);
+  assert.deepEqual(room.sentMessages, [
+    {
+      type: "connect",
+      payload: {
+        type: "connect",
+        requestId: "cocos-req-1",
+        roomId: "room-lobby",
+        playerId: "account-player",
+        displayName: "暮潮守望",
+        authToken: "account.token"
+      }
+    }
+  ]);
 });

--- a/apps/cocos-client/test/helpers/cocos-runtime-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-runtime-harness.ts
@@ -109,3 +109,68 @@ export function createVeilCocosSessionRuntimeHarness(options?: {
     }
   };
 }
+
+export function createVeilRootSessionLifecycleHarness(options?: {
+  storage?: Storage;
+  joinRooms?: Array<FakeColyseusRoom | Error>;
+  reconnectRooms?: FakeColyseusRoom[];
+  wait?: (() => Promise<void>) | null;
+  guestAuthToken?: string;
+  syncedAuthSession?: {
+    token?: string;
+    playerId: string;
+    displayName: string;
+    authMode: "guest" | "account";
+    provider?: "guest" | "account-password" | "wechat-mini-game";
+    loginId?: string;
+    source: "remote" | "local";
+  } | null;
+}) {
+  const storage = options?.storage ?? createMemoryStorage();
+  const reconnectTokens: string[] = [];
+  const endpoints: string[] = [];
+  const joinedOptions: Array<{ logicalRoomId: string; playerId: string; seed: number }> = [];
+
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    ...(options?.wait ? { wait: options.wait } : {}),
+    loadSdk: createSdkLoader({
+      joinRooms: options?.joinRooms,
+      reconnectRooms: options?.reconnectRooms,
+      reconnectTokens,
+      joinedOptions,
+      endpoints
+    })
+  });
+
+  installVeilRootRuntime({
+    createSession: (...args) => VeilCocosSession.create(...args),
+    readStoredReplay: (...args) => VeilCocosSession.readStoredReplay(...args),
+    ...(options?.guestAuthToken
+      ? {
+          loginGuestAuthSession: async (_remoteUrl, playerId, displayName) => ({
+            token: options.guestAuthToken,
+            playerId,
+            displayName,
+            authMode: "guest" as const,
+            provider: "guest" as const,
+            source: "remote" as const
+          })
+        }
+      : {}),
+    ...(typeof options?.syncedAuthSession !== "undefined"
+      ? {
+          syncAuthSession: async () => options.syncedAuthSession ?? null
+        }
+      : {})
+  });
+
+  return {
+    root: createVeilRootHarness(),
+    storage,
+    reconnectTokens,
+    joinedOptions,
+    endpoints
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared lifecycle harness that wires VeilRoot to the real VeilCocosSession test runtime
- cover cached local boot, reconnect recovery, and lobby-to-session handoff through the harness
- keep the scope limited to Cocos runtime test coverage for root/session orchestration

Closes #349