### PR TITLE
feat(config-center): surface config publish audit history

### DIFF
--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -93,6 +93,32 @@ interface ConfigPublishHistoryEntry {
   structuralChangeCount: number;
 }
 
+type ConfigPublishResultStatus = "applied" | "failed";
+type ConfigPublishChangeRuntimeStatus = "applied" | "failed" | "pending";
+
+interface ConfigPublishAuditChange {
+  documentId: ConfigDocumentId;
+  title: string;
+  fromVersion: number;
+  toVersion: number;
+  changeCount: number;
+  structuralChangeCount: number;
+  snapshotId: string | null;
+  runtimeStatus: ConfigPublishChangeRuntimeStatus;
+  runtimeMessage: string;
+  diffSummary: ConfigDiffEntry[];
+}
+
+interface ConfigPublishAuditEvent {
+  id: string;
+  author: string;
+  summary: string;
+  publishedAt: string;
+  resultStatus: ConfigPublishResultStatus;
+  resultMessage: string;
+  changes: ConfigPublishAuditChange[];
+}
+
 interface ConfigStageDocumentSummary {
   id: ConfigDocumentId;
   title: string;
@@ -228,6 +254,9 @@ interface AppState {
   presets: ConfigPresetSummary[];
   presetsLoading: boolean;
   publishHistory: ConfigPublishHistoryEntry[];
+  publishAuditHistory: ConfigPublishAuditEvent[];
+  publishAuditFilterId: ConfigDocumentId | "all";
+  publishAuditFilterStatus: ConfigPublishResultStatus | "all";
   publishStage: ConfigStageState | null;
   publishStageLoading: boolean;
 }
@@ -352,6 +381,9 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     presets: [],
     presetsLoading: false,
     publishHistory: [],
+    publishAuditHistory: [],
+    publishAuditFilterId: "all",
+    publishAuditFilterStatus: "all",
     publishStage: null,
     publishStageLoading: false
   };
@@ -571,6 +603,66 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     }
   }
 
+  async function loadPublishAuditHistory(): Promise<void> {
+    state.historyLoading = true;
+    notify();
+    try {
+      const response = await requestJson<{
+        storage: "filesystem" | "mysql";
+        history: ConfigPublishAuditEvent[];
+      }>("/api/config-center/publish-history");
+      state.storageMode = response.storage;
+      state.publishAuditHistory = response.history ?? [];
+    } catch (error) {
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "加载发布审计记录失败";
+    } finally {
+      state.historyLoading = false;
+      notify();
+    }
+  }
+
+  function setPublishAuditFilters(filters: {
+    documentId?: ConfigDocumentId | "all";
+    resultStatus?: ConfigPublishResultStatus | "all";
+  }): void {
+    if (filters.documentId) {
+      state.publishAuditFilterId = filters.documentId;
+    }
+    if (filters.resultStatus) {
+      state.publishAuditFilterStatus = filters.resultStatus;
+    }
+    notify();
+  }
+
+  async function inspectPublishedSnapshot(documentId: ConfigDocumentId, snapshotId: string): Promise<void> {
+    if (!snapshotId) {
+      return;
+    }
+
+    if (state.current?.id !== documentId) {
+      await loadDocument(documentId);
+    } else if (state.snapshots.length === 0) {
+      await loadSnapshots(documentId);
+    }
+
+    state.selectedSnapshotId = snapshotId;
+    notify();
+    await loadSnapshotDiff(snapshotId);
+  }
+
+  async function rollbackPublishedSnapshot(documentId: ConfigDocumentId, snapshotId: string): Promise<void> {
+    if (!snapshotId) {
+      return;
+    }
+
+    if (state.current?.id !== documentId) {
+      await loadDocument(documentId);
+    }
+
+    await rollbackSnapshot(snapshotId);
+  }
+
   async function persistStageDocuments(
     documents: Array<{ id: ConfigDocumentId; content: string }>,
     successMessage: string
@@ -717,6 +809,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       state.publishStage = response.stage ?? null;
       state.statusTone = "success";
       state.statusMessage = `已发布 ${response.publish.changes.length} 个草稿，并刷新运行时配置。`;
+      await loadPublishAuditHistory();
       const activeDocumentId = state.current?.id ?? null;
       await loadList();
       if (activeDocumentId && publishedDocumentIds.includes(activeDocumentId)) {
@@ -1247,6 +1340,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     loadPresets,
     loadSnapshotDiff,
     loadPublishStage,
+    loadPublishAuditHistory,
     loadWorldPreview,
     loadValidation,
     scheduleWorldPreview,
@@ -1263,6 +1357,9 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     removeDocumentFromStage,
     clearPublishStage,
     publishStageDrafts,
+    setPublishAuditFilters,
+    inspectPublishedSnapshot,
+    rollbackPublishedSnapshot,
     parseDownloadFileName
   };
 }
@@ -1274,6 +1371,8 @@ export type {
   ConfigDocumentId,
   ConfigDocumentSummary,
   ConfigPresetSummary,
+  ConfigPublishAuditEvent,
+  ConfigPublishAuditChange,
   ConfigPublishHistoryEntry,
   ConfigSchemaSummary,
   ConfigSnapshotSummary,

--- a/apps/client/src/config-center.css
+++ b/apps/client/src/config-center.css
@@ -589,6 +589,14 @@ body {
   background: rgba(255, 255, 255, 0.8);
 }
 
+.publish-history-head,
+.publish-change-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
 .publish-history-card strong {
   display: block;
   margin-bottom: 4px;
@@ -599,6 +607,80 @@ body {
   display: block;
   color: var(--text-muted);
   font-size: 13px;
+}
+
+.history-filters {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.history-filters label {
+  display: grid;
+  gap: 6px;
+  min-width: 160px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.history-filters select {
+  border: 1px solid rgba(138, 90, 43, 0.14);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #fffdf9;
+  color: var(--text-main);
+  font: inherit;
+}
+
+.publish-result-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: rgba(138, 90, 43, 0.12);
+  color: var(--text-main);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.publish-result-pill.is-applied {
+  background: rgba(45, 122, 74, 0.14);
+  color: var(--success);
+}
+
+.publish-result-pill.is-failed {
+  background: rgba(178, 69, 47, 0.14);
+  color: var(--danger);
+}
+
+.publish-change-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.publish-change-card {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(244, 239, 228, 0.7);
+  border: 1px solid rgba(138, 90, 43, 0.12);
+}
+
+.publish-diff-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.publish-diff-chip {
+  display: inline-flex;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(138, 90, 43, 0.12);
+  color: var(--text-main);
+  font-size: 12px;
 }
 
 .validation-item,

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -153,6 +153,32 @@ interface ConfigPublishHistoryEntry {
   structuralChangeCount: number;
 }
 
+type ConfigPublishResultStatus = "applied" | "failed";
+type ConfigPublishChangeRuntimeStatus = "applied" | "failed" | "pending";
+
+interface ConfigPublishAuditChange {
+  documentId: ConfigDocumentId;
+  title: string;
+  fromVersion: number;
+  toVersion: number;
+  changeCount: number;
+  structuralChangeCount: number;
+  snapshotId: string | null;
+  runtimeStatus: ConfigPublishChangeRuntimeStatus;
+  runtimeMessage: string;
+  diffSummary: ConfigDiffEntry[];
+}
+
+interface ConfigPublishAuditEvent {
+  id: string;
+  author: string;
+  summary: string;
+  publishedAt: string;
+  resultStatus: ConfigPublishResultStatus;
+  resultMessage: string;
+  changes: ConfigPublishAuditChange[];
+}
+
 interface ConfigStageDocumentSummary {
   id: ConfigDocumentId;
   title: string;
@@ -285,6 +311,9 @@ interface AppState {
   presets: ConfigPresetSummary[];
   presetsLoading: boolean;
   publishHistory: ConfigPublishHistoryEntry[];
+  publishAuditHistory: ConfigPublishAuditEvent[];
+  publishAuditFilterId: ConfigDocumentId | "all";
+  publishAuditFilterStatus: ConfigPublishResultStatus | "all";
   publishStage: ConfigStageState | null;
   publishStageLoading: boolean;
 }
@@ -360,6 +389,7 @@ const {
   loadPresets,
   loadSnapshotDiff,
   loadPublishStage,
+  loadPublishAuditHistory,
   loadWorldPreview,
   loadValidation,
   scheduleWorldPreview,
@@ -375,7 +405,10 @@ const {
   stageCurrentDraft,
   removeDocumentFromStage,
   clearPublishStage,
-  publishStageDrafts
+  publishStageDrafts,
+  setPublishAuditFilters,
+  inspectPublishedSnapshot,
+  rollbackPublishedSnapshot
 } = controller;
 
 function formatTime(value: string): string {
@@ -1331,38 +1364,135 @@ function renderSnapshotDiffPanel(): string {
 }
 
 function renderPublishHistoryList(): string {
-  const entries = state.publishHistory;
-  if (state.historyLoading && entries.length === 0) {
+  const entries = state.publishAuditHistory.filter((entry) => {
+    const matchesDocument =
+      state.publishAuditFilterId === "all" ||
+      entry.changes.some((change) => change.documentId === state.publishAuditFilterId);
+    const matchesResult =
+      state.publishAuditFilterStatus === "all" || entry.resultStatus === state.publishAuditFilterStatus;
+    return matchesDocument && matchesResult;
+  });
+  if (state.historyLoading && entries.length === 0 && state.publishAuditHistory.length === 0) {
     return `<div class="world-preview-empty">正在加载发布记录...</div>`;
   }
 
   if (entries.length === 0) {
-    return `<div class="world-preview-empty">暂无发布记录，先使用“发布草稿”功能再回来查看。</div>`;
+    return `
+      <section class="history-section">
+        <div class="config-preview-subhead">
+          <h4>发布审计历史</h4>
+          <span class="config-meta">0 条匹配记录</span>
+        </div>
+        <div class="history-filters">
+          <label>
+            <span>配置类型</span>
+            <select data-role="publish-filter-doc">
+              <option value="all">全部</option>
+              <option value="world" ${state.publishAuditFilterId === "world" ? "selected" : ""}>世界配置</option>
+              <option value="mapObjects" ${state.publishAuditFilterId === "mapObjects" ? "selected" : ""}>地图物件</option>
+              <option value="units" ${state.publishAuditFilterId === "units" ? "selected" : ""}>兵种配置</option>
+              <option value="battleSkills" ${state.publishAuditFilterId === "battleSkills" ? "selected" : ""}>技能配置</option>
+              <option value="battleBalance" ${state.publishAuditFilterId === "battleBalance" ? "selected" : ""}>战斗平衡</option>
+            </select>
+          </label>
+          <label>
+            <span>结果状态</span>
+            <select data-role="publish-filter-status">
+              <option value="all">全部</option>
+              <option value="applied" ${state.publishAuditFilterStatus === "applied" ? "selected" : ""}>已应用</option>
+              <option value="failed" ${state.publishAuditFilterStatus === "failed" ? "selected" : ""}>失败</option>
+            </select>
+          </label>
+        </div>
+        <div class="world-preview-empty">暂无匹配的发布记录，先使用“发布草稿”功能再回来查看。</div>
+      </section>
+    `;
   }
 
   return `
-    <div class="publish-history">
+    <section class="history-section publish-history">
       <div class="config-preview-subhead">
-        <h4>发布记录</h4>
-        <span class="config-meta">${entries.length} 次发布</span>
+        <h4>发布审计历史</h4>
+        <span class="config-meta">${entries.length} 条记录</span>
+      </div>
+      <div class="history-filters">
+        <label>
+          <span>配置类型</span>
+          <select data-role="publish-filter-doc">
+            <option value="all">全部</option>
+            <option value="world" ${state.publishAuditFilterId === "world" ? "selected" : ""}>世界配置</option>
+            <option value="mapObjects" ${state.publishAuditFilterId === "mapObjects" ? "selected" : ""}>地图物件</option>
+            <option value="units" ${state.publishAuditFilterId === "units" ? "selected" : ""}>兵种配置</option>
+            <option value="battleSkills" ${state.publishAuditFilterId === "battleSkills" ? "selected" : ""}>技能配置</option>
+            <option value="battleBalance" ${state.publishAuditFilterId === "battleBalance" ? "selected" : ""}>战斗平衡</option>
+          </select>
+        </label>
+        <label>
+          <span>结果状态</span>
+          <select data-role="publish-filter-status">
+            <option value="all">全部</option>
+            <option value="applied" ${state.publishAuditFilterStatus === "applied" ? "selected" : ""}>已应用</option>
+            <option value="failed" ${state.publishAuditFilterStatus === "failed" ? "selected" : ""}>失败</option>
+          </select>
+        </label>
       </div>
       <div class="publish-history-list">
         ${entries
-          .slice(0, 6)
+          .slice(0, 10)
           .map(
             (entry) => `
               <article class="publish-history-card">
-                <div>
-                  <strong>${escapeHtml(entry.summary)}</strong>
-                  <span>${escapeHtml(entry.author)} · ${formatTime(entry.publishedAt)}</span>
-                  <small>v${entry.fromVersion} → v${entry.toVersion} · ${entry.changeCount} 项变更${entry.structuralChangeCount ? `，其中 ${entry.structuralChangeCount} 项结构风险` : ""}</small>
+                <div class="publish-history-head">
+                  <div>
+                    <strong>${escapeHtml(entry.summary)}</strong>
+                    <span>${escapeHtml(entry.author)} · ${formatTime(entry.publishedAt)}</span>
+                  </div>
+                  <span class="publish-result-pill is-${entry.resultStatus}">${entry.resultStatus === "applied" ? "已应用" : "失败"}</span>
+                </div>
+                <small>${escapeHtml(entry.resultMessage)}</small>
+                <div class="config-badge-row">
+                  ${entry.changes.map((change) => `<span class="config-badge">${escapeHtml(change.title)} · v${change.fromVersion}→v${change.toVersion}</span>`).join("")}
+                </div>
+                <div class="publish-change-list">
+                  ${entry.changes
+                    .map(
+                      (change) => `
+                        <section class="publish-change-card">
+                          <div class="publish-change-head">
+                            <strong>${escapeHtml(change.title)}</strong>
+                            <span>${change.changeCount} 项变更${change.structuralChangeCount ? ` · ${change.structuralChangeCount} 项结构风险` : ""}</span>
+                          </div>
+                          <small>${escapeHtml(change.runtimeMessage)}</small>
+                          <div class="publish-diff-summary">
+                            ${
+                              change.diffSummary.length > 0
+                                ? change.diffSummary
+                                    .map(
+                                      (diff) => `
+                                        <span class="publish-diff-chip">
+                                          ${escapeHtml(diff.path)} · ${escapeHtml(diffKindLabel(diff.kind))}
+                                        </span>
+                                      `
+                                    )
+                                    .join("")
+                                : `<span class="publish-diff-chip">无字段差异</span>`
+                            }
+                          </div>
+                          <div class="history-actions">
+                            <button class="config-button is-secondary config-button-compact" data-action="inspect-publish-change" data-doc-id="${change.documentId}" data-snapshot-id="${change.snapshotId ?? ""}" ${change.snapshotId ? "" : "disabled"}>查看快照</button>
+                            <button class="config-button is-secondary config-button-compact" data-action="rollback-publish-change" data-doc-id="${change.documentId}" data-snapshot-id="${change.snapshotId ?? ""}" ${change.snapshotId ? "" : "disabled"}>快速回滚</button>
+                          </div>
+                        </section>
+                      `
+                    )
+                    .join("")}
                 </div>
               </article>
             `
           )
           .join("")}
       </div>
-    </div>
+    </section>
   `;
 }
 
@@ -1731,6 +1861,40 @@ function bindPublishStageControls(): void {
       }
     });
   });
+
+  const documentFilter = document.querySelector<HTMLSelectElement>("[data-role='publish-filter-doc']");
+  documentFilter?.addEventListener("change", () => {
+    setPublishAuditFilters({
+      documentId: (documentFilter.value || "all") as ConfigDocumentId | "all"
+    });
+  });
+
+  const statusFilter = document.querySelector<HTMLSelectElement>("[data-role='publish-filter-status']");
+  statusFilter?.addEventListener("change", () => {
+    setPublishAuditFilters({
+      resultStatus: (statusFilter.value || "all") as ConfigPublishResultStatus | "all"
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>("[data-action='inspect-publish-change']").forEach((button) => {
+    button.addEventListener("click", () => {
+      const docId = button.dataset.docId as ConfigDocumentId | undefined;
+      const snapshotId = button.dataset.snapshotId;
+      if (docId && snapshotId) {
+        void inspectPublishedSnapshot(docId, snapshotId);
+      }
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>("[data-action='rollback-publish-change']").forEach((button) => {
+    button.addEventListener("click", () => {
+      const docId = button.dataset.docId as ConfigDocumentId | undefined;
+      const snapshotId = button.dataset.snapshotId;
+      if (docId && snapshotId) {
+        void rollbackPublishedSnapshot(docId, snapshotId);
+      }
+    });
+  });
 }
 
 function refreshPreviewPane(): void {
@@ -1932,6 +2096,7 @@ async function bootstrap(): Promise<void> {
   try {
     await loadList();
     await loadPublishStage();
+    await loadPublishAuditHistory();
     const requestedId = new URLSearchParams(window.location.search).get("config") as ConfigDocumentId | null;
     const initialId = requestedId && state.items.some((item) => item.id === requestedId) ? requestedId : state.items[0]?.id ?? null;
 

--- a/apps/client/test/config-center.test.ts
+++ b/apps/client/test/config-center.test.ts
@@ -459,6 +459,164 @@ test("config center rollback requires confirmation before applying structural di
   assert.match(controller.state.statusMessage, /取消/);
 });
 
+test("config center publish audit history supports filters and snapshot inspection links", async () => {
+  const worldDocument = createDocument("world", "{\n  \"width\": 10,\n  \"height\": 8\n}\n", { version: 3 });
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/publish-history") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          history: [
+            {
+              id: "publish-1",
+              author: "ConfigOps",
+              summary: "扩图并补资源",
+              publishedAt: "2026-03-30T05:00:00.000Z",
+              resultStatus: "applied",
+              resultMessage: "运行时配置已刷新",
+              changes: [
+                {
+                  documentId: "world",
+                  title: "世界配置",
+                  fromVersion: 2,
+                  toVersion: 3,
+                  changeCount: 2,
+                  structuralChangeCount: 0,
+                  snapshotId: "snapshot-world-3",
+                  runtimeStatus: "applied",
+                  runtimeMessage: "运行时已刷新",
+                  diffSummary: [
+                    {
+                      path: "width",
+                      change: "updated",
+                      previousValue: "8",
+                      nextValue: "10",
+                      kind: "value",
+                      required: true,
+                      fieldType: "integer",
+                      description: "地图宽度",
+                      blastRadius: ["配置台编辑器"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs/world") {
+      return new Response(JSON.stringify({ storage: "filesystem", document: worldDocument }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/validate") {
+      return new Response(JSON.stringify({ storage: "filesystem", validation: createValidationReport(true) }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          snapshots: [{ id: "snapshot-world-3", label: "世界配置 v3", createdAt: "2026-03-30T05:00:00.000Z", version: 3 }],
+          publishHistory: []
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs/world/presets") {
+      return new Response(JSON.stringify({ storage: "filesystem", presets: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/diff" && request.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          diff: {
+            entries: [
+              {
+                path: "width",
+                change: "updated",
+                previousValue: "10",
+                nextValue: "8",
+                kind: "value",
+                required: true,
+                fieldType: "integer",
+                description: "地图宽度",
+                blastRadius: ["配置台编辑器"]
+              }
+            ]
+          }
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs/world/preview") {
+      return new Response(JSON.stringify({ storage: "filesystem", preview: createWorldPreview() }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+
+  await controller.loadPublishAuditHistory();
+  assert.equal(controller.state.publishAuditHistory.length, 1);
+
+  controller.setPublishAuditFilters({ documentId: "world", resultStatus: "applied" });
+  assert.equal(controller.state.publishAuditFilterId, "world");
+  assert.equal(controller.state.publishAuditFilterStatus, "applied");
+
+  await controller.inspectPublishedSnapshot("world", "snapshot-world-3");
+
+  assert.equal(controller.state.current?.id, "world");
+  assert.equal(controller.state.selectedSnapshotId, "snapshot-world-3");
+  assert.equal(controller.state.snapshotDiff?.entries[0]?.path, "width");
+  assert.equal(requests.some((request) => request.url === "/api/config-center/publish-history"), true);
+  assert.equal(
+    requests.some((request) => request.url === "/api/config-center/configs/world/diff" && request.method === "POST"),
+    true
+  );
+});
+
 test("config center builtin presets apply the expected field changes", async () => {
   const baseDocument = createDocument(
     "battleBalance",

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -155,6 +155,32 @@ export interface ConfigPublishHistoryEntry {
   structuralChangeCount: number;
 }
 
+export type ConfigPublishResultStatus = "applied" | "failed";
+export type ConfigPublishChangeRuntimeStatus = "applied" | "failed" | "pending";
+
+export interface ConfigPublishAuditChange {
+  documentId: ConfigDocumentId;
+  title: string;
+  fromVersion: number;
+  toVersion: number;
+  changeCount: number;
+  structuralChangeCount: number;
+  snapshotId: string | null;
+  runtimeStatus: ConfigPublishChangeRuntimeStatus;
+  runtimeMessage: string;
+  diffSummary: ConfigDiffEntry[];
+}
+
+export interface ConfigPublishAuditEvent {
+  id: string;
+  author: string;
+  summary: string;
+  publishedAt: string;
+  resultStatus: ConfigPublishResultStatus;
+  resultMessage: string;
+  changes: ConfigPublishAuditChange[];
+}
+
 export interface ConfigPublishChangeSummary {
   documentId: ConfigDocumentId;
   title: string;
@@ -285,6 +311,7 @@ export interface ConfigCenterStore {
   rollbackToSnapshot(id: ConfigDocumentId, snapshotId: string): Promise<ConfigDocument>;
   diffWithSnapshot(id: ConfigDocumentId, snapshotId: string): Promise<ConfigDiff>;
   listPublishHistory(id: ConfigDocumentId): Promise<ConfigPublishHistoryEntry[]>;
+  listPublishAuditHistory(): Promise<ConfigPublishAuditEvent[]>;
   listPresets(id: ConfigDocumentId): Promise<ConfigPresetSummary[]>;
   savePreset(id: ConfigDocumentId, name: string, content: string): Promise<ConfigPresetSummary>;
   applyPreset(id: ConfigDocumentId, presetId: string): Promise<ConfigDocument>;
@@ -375,6 +402,7 @@ interface ConfigCenterLibraryState {
   presets: Partial<Record<ConfigDocumentId, ConfigPresetRecord[]>>;
   stagedDraft: ConfigStageRecord | null;
   publishHistory: Partial<Record<ConfigDocumentId, ConfigPublishHistoryEntry[]>>;
+  publishAuditHistory: ConfigPublishAuditEvent[];
 }
 
 interface FlattenedConfigEntry {
@@ -732,7 +760,8 @@ function createEmptyLibraryState(): ConfigCenterLibraryState {
     snapshots: {},
     presets: {},
     stagedDraft: null,
-    publishHistory: {}
+    publishHistory: {},
+    publishAuditHistory: []
   };
 }
 
@@ -2514,7 +2543,8 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         snapshots: parsed.snapshots ?? {},
         presets: parsed.presets ?? {},
         stagedDraft: parsed.stagedDraft ?? null,
-        publishHistory: parsed.publishHistory ?? {}
+        publishHistory: parsed.publishHistory ?? {},
+        publishAuditHistory: parsed.publishAuditHistory ?? []
       };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -2670,6 +2700,11 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     return [...(state.publishHistory[id] ?? [])];
   }
 
+  async listPublishAuditHistory(): Promise<ConfigPublishAuditEvent[]> {
+    const state = await this.readLibraryState();
+    return [...(state.publishAuditHistory ?? [])].sort((left, right) => right.publishedAt.localeCompare(left.publishedAt));
+  }
+
   async getStagedDraft(): Promise<ConfigStageState | null> {
     const state = await this.readLibraryState();
     return this.mapStageRecordToState(state.stagedDraft);
@@ -2707,55 +2742,128 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     const publishedAt = new Date().toISOString();
     const publishChanges: ConfigPublishChangeSummary[] = [];
     const historyEntries: ConfigPublishHistoryEntry[] = [];
+    const auditChanges: ConfigPublishAuditChange[] = [];
+    const stagedContent = new Map(staged.documents.map((document) => [document.id, document.content] as const));
 
     for (const stagedDocument of staged.documents) {
       const current = await this.loadDocument(stagedDocument.id);
       const diffEntries = buildConfigDiffEntries(stagedDocument.id, current.content, stagedDocument.content);
       const structuralCount = diffEntries.filter((entry) => entry.kind !== "value").length;
-      const saved = await this.saveDocument(stagedDocument.id, stagedDocument.content);
       const definition = configDefinitionFor(stagedDocument.id);
       const fromVersion = current.version ?? 1;
-      const toVersion = saved.version ?? fromVersion;
-
-      publishChanges.push({
+      auditChanges.push({
         documentId: stagedDocument.id,
         title: definition?.title ?? stagedDocument.id,
         fromVersion,
-        toVersion,
+        toVersion: fromVersion,
         changeCount: diffEntries.length,
-        structuralChangeCount: structuralCount
-      });
-      historyEntries.push({
-        id: publishId,
-        documentId: stagedDocument.id,
-        author: metadata.author,
-        summary: metadata.summary,
-        publishedAt,
-        fromVersion,
-        toVersion,
-        changeCount: diffEntries.length,
-        structuralChangeCount: structuralCount
+        structuralChangeCount: structuralCount,
+        snapshotId: null,
+        runtimeStatus: "pending",
+        runtimeMessage: "等待运行时应用",
+        diffSummary: diffEntries.slice(0, 4)
       });
     }
 
-    state.stagedDraft = null;
-    state.publishHistory = state.publishHistory ?? {};
-    for (const entry of historyEntries) {
-      const existing = state.publishHistory[entry.documentId] ?? [];
-      state.publishHistory[entry.documentId] = [entry, ...existing].slice(0, MAX_PUBLISH_HISTORY_ENTRIES);
-    }
-    await this.writeLibraryState(state);
+    try {
+      for (const auditChange of auditChanges) {
+        const nextContent = stagedContent.get(auditChange.documentId);
+        if (typeof nextContent !== "string") {
+          throw new Error(`Missing staged document content: ${auditChange.documentId}`);
+        }
 
-    return {
-      stage: null,
-      publish: {
-        id: publishId,
-        author: metadata.author,
-        summary: metadata.summary,
-        publishedAt,
-        changes: publishChanges
+        const saved = await this.saveDocument(auditChange.documentId, nextContent);
+        const toVersion = saved.version ?? auditChange.fromVersion;
+        const snapshot = await this.findSnapshotByVersion(auditChange.documentId, toVersion);
+
+        auditChange.toVersion = toVersion;
+        auditChange.snapshotId = snapshot?.id ?? null;
+        auditChange.runtimeStatus = "applied";
+        auditChange.runtimeMessage = "运行时已刷新";
+        publishChanges.push({
+          documentId: auditChange.documentId,
+          title: auditChange.title,
+          fromVersion: auditChange.fromVersion,
+          toVersion,
+          changeCount: auditChange.changeCount,
+          structuralChangeCount: auditChange.structuralChangeCount
+        });
+        historyEntries.push({
+          id: publishId,
+          documentId: auditChange.documentId,
+          author: metadata.author,
+          summary: metadata.summary,
+          publishedAt,
+          fromVersion: auditChange.fromVersion,
+          toVersion,
+          changeCount: auditChange.changeCount,
+          structuralChangeCount: auditChange.structuralChangeCount
+        });
       }
-    };
+
+      state.stagedDraft = null;
+      state.publishHistory = state.publishHistory ?? {};
+      for (const entry of historyEntries) {
+        const existing = state.publishHistory[entry.documentId] ?? [];
+        state.publishHistory[entry.documentId] = [entry, ...existing].slice(0, MAX_PUBLISH_HISTORY_ENTRIES);
+      }
+      const appliedAuditEvent: ConfigPublishAuditEvent = {
+        id: publishId,
+        author: metadata.author,
+        summary: metadata.summary,
+        publishedAt,
+        resultStatus: "applied",
+        resultMessage: "运行时配置已刷新",
+        changes: auditChanges
+      };
+      state.publishAuditHistory = [appliedAuditEvent, ...(state.publishAuditHistory ?? [])].slice(
+        0,
+        MAX_PUBLISH_HISTORY_ENTRIES
+      );
+      await this.writeLibraryState(state);
+
+      return {
+        stage: null,
+        publish: {
+          id: publishId,
+          author: metadata.author,
+          summary: metadata.summary,
+          publishedAt,
+          changes: publishChanges
+        }
+      };
+    } catch (error) {
+      const failedMessage = error instanceof Error ? error.message : "发布配置失败";
+      const failedChange = auditChanges.find((entry) => entry.runtimeStatus === "pending");
+      if (failedChange) {
+        failedChange.runtimeStatus = "failed";
+        failedChange.runtimeMessage = failedMessage;
+      }
+
+      const failedAuditEvent: ConfigPublishAuditEvent = {
+        id: publishId,
+        author: metadata.author,
+        summary: metadata.summary,
+        publishedAt,
+        resultStatus: "failed",
+        resultMessage: failedMessage,
+        changes: auditChanges
+      };
+      state.publishAuditHistory = [failedAuditEvent, ...(state.publishAuditHistory ?? [])].slice(
+        0,
+        MAX_PUBLISH_HISTORY_ENTRIES
+      );
+      await this.writeLibraryState(state);
+      throw error;
+    }
+  }
+
+  protected async findSnapshotByVersion(
+    id: ConfigDocumentId,
+    version: number
+  ): Promise<ConfigSnapshotSummary | null> {
+    const snapshots = await this.listSnapshots(id);
+    return snapshots.find((snapshot) => snapshot.version === version) ?? null;
   }
 
   protected mapStageRecordToState(stage: ConfigStageRecord | null): ConfigStageState | null {
@@ -2801,13 +2909,10 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
       seen.add(document.id);
     }
 
-    const normalizedDocuments = documents.map((document) => {
-      const parsed = parseConfigDocument(document.id, document.content);
-      return {
-        id: document.id,
-        content: normalizeJsonContent(parsed)
-      };
-    });
+    const normalizedDocuments = documents.map((document) => ({
+      id: document.id,
+      content: normalizeJsonContent(JSON.parse(document.content) as ParsedConfigDocument)
+    }));
     const overrides: Partial<Record<ConfigDocumentId, string>> = {};
     for (const normalized of normalizedDocuments) {
       overrides[normalized.id] = normalized.content;
@@ -3272,6 +3377,17 @@ export function registerConfigCenterRoutes(
       sendJson(response, 200, {
         storage: store.mode,
         stage: await store.getStagedDraft()
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/config-center/publish-history", async (_request, response) => {
+    try {
+      sendJson(response, 200, {
+        storage: store.mode,
+        history: await store.listPublishAuditHistory()
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -662,7 +662,7 @@ test("config center staged publish applies bundled drafts and records publish hi
         guaranteedResources: [
           ...MAP_OBJECTS_CONFIG.guaranteedResources,
           {
-            position: { x: 1, y: 1 },
+            position: { x: 0, y: 0 },
             resource: { kind: "ore", amount: 20 }
           }
         ]
@@ -688,6 +688,14 @@ test("config center staged publish applies bundled drafts and records publish hi
   const mapHistory = await store.listPublishHistory("mapObjects");
   assert.equal(mapHistory[0]?.documentId, "mapObjects");
   assert.equal((mapHistory[0]?.structuralChangeCount ?? 0) >= 0, true);
+
+  const auditHistory = await store.listPublishAuditHistory();
+  assert.equal(auditHistory[0]?.author, "ConfigOps");
+  assert.equal(auditHistory[0]?.resultStatus, "applied");
+  assert.equal(auditHistory[0]?.changes.length, 2);
+  assert.equal(auditHistory[0]?.changes[0]?.runtimeStatus, "applied");
+  assert.equal(typeof auditHistory[0]?.changes[0]?.snapshotId, "string");
+  assert.equal((auditHistory[0]?.changes[0]?.diffSummary.length ?? 0) > 0, true);
 
   const stageAfter = await store.getStagedDraft();
   assert.equal(stageAfter, null);


### PR DESCRIPTION
## Summary
- add event-level publish audit history to config-center with runtime result, touched domains, diff summary, and snapshot links
- expose global publish history in the web console with config-type/result filters plus inspect and quick rollback actions
- cover the new server/client behavior with focused config-center tests

Fixes #358