### PR TITLE
build(cocos-client): add delivery readiness audit for primary client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,11 +131,29 @@ jobs:
       - name: Package WeChat exported fixture
         run: npm run package:wechat-release -- --output-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir "${WECHAT_RELEASE_ARTIFACTS_DIR}" --expect-exported-runtime --source-revision "${GITHUB_SHA}"
 
+      - name: Audit primary Cocos client delivery readiness
+        run: |
+          npm run audit:cocos-primary-delivery -- \
+            --output-dir apps/cocos-client/test/fixtures/wechatgame-export \
+            --artifacts-dir "${WECHAT_RELEASE_ARTIFACTS_DIR}" \
+            --expect-exported-runtime \
+            --expected-revision "${GITHUB_SHA}" \
+            --output "${RUNNER_TEMP}/release-readiness/cocos-primary-delivery-audit-${GITHUB_SHA}.json" \
+            --markdown-output "${RUNNER_TEMP}/release-readiness/cocos-primary-delivery-audit-${GITHUB_SHA}.md" \
+            --github-step-summary "${GITHUB_STEP_SUMMARY}"
+
       - name: Upload WeChat release artifacts
         uses: actions/upload-artifact@v4
         with:
           name: wechat-release-${{ github.sha }}
           path: ${{ env.WECHAT_RELEASE_ARTIFACTS_DIR }}
+          if-no-files-found: error
+
+      - name: Upload primary Cocos delivery audit
+        uses: actions/upload-artifact@v4
+        with:
+          name: cocos-primary-delivery-audit-${{ github.sha }}
+          path: ${{ runner.temp }}/release-readiness/cocos-primary-delivery-audit-${{ github.sha }}.*
           if-no-files-found: error
 
   wechat-release-artifact-smoke:

--- a/apps/cocos-client/test/cocos-primary-delivery-audit.test.ts
+++ b/apps/cocos-client/test/cocos-primary-delivery-audit.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  buildWechatMinigameTemplateArtifacts,
+  normalizeWechatMinigameBuildConfig
+} from "../assets/scripts/cocos-wechat-build.ts";
+
+function createPackagedWechatReleaseArtifact(): {
+  tempDir: string;
+  artifactsDir: string;
+  configPath: string;
+} {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-primary-delivery-build-"));
+  const artifactsDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-primary-delivery-artifacts-"));
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-primary-delivery-config-"));
+  fs.mkdirSync(path.join(tempDir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(tempDir, "game.json"),
+    JSON.stringify({
+      deviceOrientation: "portrait",
+      networkTimeout: {
+        request: 10000,
+        connectSocket: 10000,
+        uploadFile: 10000,
+        downloadFile: 10000
+      },
+      subpackages: []
+    })
+  );
+  fs.writeFileSync(path.join(tempDir, "game.js"), "\"use strict\";\n");
+  fs.writeFileSync(path.join(tempDir, "application.js"), "\"use strict\";\n");
+  fs.writeFileSync(path.join(tempDir, "src", "settings.json"), JSON.stringify({ subpackages: [] }));
+  const config = normalizeWechatMinigameBuildConfig({
+    projectName: "Project Veil",
+    appId: "touristappid",
+    runtimeRemoteUrl: "https://veil.example.com/socket",
+    remoteAssetRoot: "https://cdn.example.com/assets",
+    domains: {
+      request: ["https://veil.example.com"],
+      socket: ["wss://veil.example.com"],
+      uploadFile: [],
+      downloadFile: ["https://cdn.example.com"]
+    }
+  });
+  const artifacts = buildWechatMinigameTemplateArtifacts(config);
+  const configPath = path.join(configDir, "wechat-minigame.build.json");
+  fs.writeFileSync(path.join(tempDir, "project.config.json"), JSON.stringify(artifacts.projectConfigJson));
+  fs.writeFileSync(path.join(tempDir, "codex.wechat.build.json"), JSON.stringify(artifacts.manifestJson));
+  fs.writeFileSync(path.join(tempDir, "README.codex.md"), `${artifacts.releaseChecklistMarkdown}\n`);
+  fs.writeFileSync(configPath, JSON.stringify(config));
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/package-wechat-minigame-release.ts",
+      "--config",
+      configPath,
+      "--output-dir",
+      tempDir,
+      "--artifacts-dir",
+      artifactsDir,
+      "--expect-exported-runtime",
+      "--source-revision",
+      "abc1234"
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      stdio: "pipe"
+    }
+  );
+
+  return {
+    tempDir,
+    artifactsDir,
+    configPath
+  };
+}
+
+test("audit:cocos-primary-delivery writes passing JSON and markdown summaries", () => {
+  const { tempDir, artifactsDir, configPath } = createPackagedWechatReleaseArtifact();
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-primary-delivery-report-"));
+  const outputPath = path.join(reportDir, "primary-delivery-audit.json");
+  const markdownOutputPath = path.join(reportDir, "primary-delivery-audit.md");
+
+  const output = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/audit-cocos-primary-delivery.ts",
+      "--config",
+      configPath,
+      "--output-dir",
+      tempDir,
+      "--artifacts-dir",
+      artifactsDir,
+      "--expect-exported-runtime",
+      "--expected-revision",
+      "abc1234",
+      "--output",
+      outputPath,
+      "--markdown-output",
+      markdownOutputPath
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  assert.match(output, /Overall status: passed/);
+
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    summary: { status: string; passedChecks: number; failedChecks: number };
+    checks: Array<{ id: string; status: string }>;
+  };
+  assert.equal(report.summary.status, "passed");
+  assert.equal(report.summary.passedChecks, 2);
+  assert.equal(report.summary.failedChecks, 0);
+  assert.deepEqual(
+    report.checks.map((check) => [check.id, check.status]),
+    [
+      ["exported-build-validation", "passed"],
+      ["packaged-artifact-audit", "passed"]
+    ]
+  );
+
+  const markdown = fs.readFileSync(markdownOutputPath, "utf8");
+  assert.match(markdown, /Primary Cocos Client Delivery Audit/);
+  assert.match(markdown, /Overall status: \*\*PASSED\*\*/);
+  assert.match(markdown, /docs\/cocos-primary-client-delivery\.md/);
+});

--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -1,0 +1,43 @@
+# Primary Cocos Client Delivery Checklist
+
+This checklist is the maintained delivery baseline for the primary client at [`apps/cocos-client`](/home/gpt/project/ProjectVeil/apps/cocos-client). It keeps the release path small and stable by splitting release readiness into two automated artifact audits plus a short manual sign-off list.
+
+## Automated Delivery Audit
+
+Run the audit after exporting and packaging the WeChat build:
+
+```bash
+npm run audit:cocos-primary-delivery -- \
+  --output-dir <wechatgame-build-dir> \
+  --artifacts-dir <release-artifacts-dir> \
+  --expect-exported-runtime \
+  --expected-revision <git-sha>
+```
+
+The audit currently enforces two stable checks:
+
+1. `exported-build-validation`
+   - Re-runs `validate:wechat-build` against the exported primary-client build.
+   - Confirms required files, injected templates/runtime bootstrap, and package budget constraints still match the checked-in config.
+2. `packaged-artifact-audit`
+   - Re-runs `validate:wechat-rc` against the packaged release artifact directory.
+   - Confirms the archive, sidecar, release manifest, and revision metadata still form a valid release candidate.
+
+The command emits a concise JSON plus Markdown summary under `artifacts/release-readiness/` by default, and CI appends the Markdown summary to the GitHub step summary.
+
+## Manual Release Sign-Off
+
+Keep these manual items short and attach evidence through the existing release evidence flow instead of inventing a new format:
+
+1. Complete the current candidate snapshot with `npm run release:cocos-rc:snapshot`.
+2. Copy and fill the RC checklist/template files in [`docs/release-evidence`](/home/gpt/project/ProjectVeil/docs/release-evidence).
+3. Record any open risk in the blocker template before sign-off.
+4. Confirm the release candidate still matches the intended commit/revision.
+
+## Related Commands
+
+- Export template refresh: `npm run prepare:wechat-build`
+- Export validation: `npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
+- Package artifact: `npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime --source-revision <git-sha>`
+- RC artifact validation: `npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> --expected-revision <git-sha>`
+- Unified Cocos evidence snapshot: `npm run release:cocos-rc:snapshot`

--- a/docs/cocos-release-evidence-template.md
+++ b/docs/cocos-release-evidence-template.md
@@ -5,6 +5,7 @@
 相关文档：
 
 - 核心玩法发布就绪总清单：`docs/core-gameplay-release-readiness.md`
+- Primary client delivery checklist：`docs/cocos-primary-client-delivery.md`
 - 发布就绪自动化快照：`docs/release-readiness-snapshot.md`
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
 - 微信小游戏构建 / 打包 / 验收：`docs/wechat-minigame-release.md`

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -12,6 +12,7 @@
   - 清单内包含导出目录文件列表、字节数、SHA-256、主包 / 分包体积汇总，以及可选的源码 revision 标识
 - 当前自动化可把已校验导出目录打成确定性的 `tar.gz` 发布包，并输出 sidecar 元数据 `codex.wechat.package.json`
   - sidecar 会记录归档文件名、SHA-256、字节数、导出目录来源，以及归档内文件清单摘要
+- 当前自动化还会运行 `npm run audit:cocos-primary-delivery`，把 primary client 的导出校验与 artifact 校验收口成一份简明 JSON / Markdown 摘要
 - CI 会把上述归档与 sidecar 元数据作为 GitHub Actions artifact `wechat-release-<sha>` 上传，供提审前下载、留档与回滚追溯
 - CI 额外会把刚上传的 artifact 再下载一次，并运行 `npm run verify:wechat-release` 做 artifact 级 smoke 验收
 - GitHub Actions 现支持在 `workflow_dispatch` 时显式开启 `upload`，或推送 `wechat-release-<version>` tag 后自动执行 `miniprogram-ci` 上传
@@ -32,6 +33,8 @@
 - 生成 / 校验真机冒烟报告：`npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> [--report <report-path>] [--check --expected-revision <git-sha>]`
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
 - 统一 Cocos RC 证据快照：`npm run release:cocos-rc:snapshot`
+- Primary client delivery checklist：`docs/cocos-primary-client-delivery.md`
+- Primary client delivery audit：`npm run audit:cocos-primary-delivery -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--expected-revision <git-sha>]`
 - RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
 - RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
 - 只做 CI 同款校验：`npm run check:cocos-release-readiness`

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "release:wechat:rehearsal": "node --import tsx ./scripts/wechat-release-rehearsal.ts",
     "ci:trend-summary": "node --import tsx ./scripts/publish-ci-trend-summary.ts",
     "release:cocos-rc:snapshot": "node --import tsx ./scripts/cocos-release-candidate-snapshot.ts",
+    "audit:cocos-primary-delivery": "node --import tsx ./scripts/audit-cocos-primary-delivery.ts",
     "check:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts --check && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/build-templates/wechatgame && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime && node --import tsx ./scripts/prepare-wechat-minigame-release.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime --check",
     "check:cocos-release-readiness": "node --import tsx ./scripts/validate-assets.ts --require-cocos-release-ready && npm run check:wechat-build",
     "validate:wechat-build": "node --import tsx ./scripts/validate-wechat-minigame-build.ts",

--- a/scripts/audit-cocos-primary-delivery.ts
+++ b/scripts/audit-cocos-primary-delivery.ts
@@ -1,0 +1,363 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+type CheckStatus = "passed" | "failed";
+type AuditStatus = "passed" | "failed";
+
+interface Args {
+  configPath: string;
+  artifactsDir: string;
+  expectExportedRuntime: boolean;
+  outputDir?: string;
+  expectedRevision?: string;
+  outputPath?: string;
+  markdownOutputPath?: string;
+  githubStepSummaryPath?: string;
+}
+
+interface GitRevision {
+  commit: string;
+  shortCommit: string;
+  branch: string;
+  dirty: boolean;
+}
+
+interface AuditCheck {
+  id: string;
+  title: string;
+  status: CheckStatus;
+  summary: string;
+  artifactPath?: string;
+  command: string;
+  exitCode: number | null;
+  stdoutTail?: string;
+  stderrTail?: string;
+}
+
+interface DeliveryAuditReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  revision: GitRevision;
+  target: {
+    client: "apps/cocos-client";
+    deliveryTarget: "wechatgame";
+    checklistPath: string;
+    outputDir: string;
+    artifactsDir: string;
+  };
+  summary: {
+    status: AuditStatus;
+    totalChecks: number;
+    passedChecks: number;
+    failedChecks: number;
+    headline: string;
+  };
+  checks: AuditCheck[];
+}
+
+const OUTPUT_TAIL_BYTES = 4000;
+const DEFAULT_CONFIG_PATH = "apps/cocos-client/wechat-minigame.build.json";
+const DEFAULT_ARTIFACTS_DIR = "artifacts/wechat-release";
+const CHECKLIST_PATH = "docs/cocos-primary-client-delivery.md";
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let configPath = DEFAULT_CONFIG_PATH;
+  let artifactsDir = DEFAULT_ARTIFACTS_DIR;
+  let expectExportedRuntime = false;
+  let outputDir: string | undefined;
+  let expectedRevision: string | undefined;
+  let outputPath: string | undefined;
+  let markdownOutputPath: string | undefined;
+  let githubStepSummaryPath: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--config" && next) {
+      configPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--artifacts-dir" && next) {
+      artifactsDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output-dir" && next) {
+      outputDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--expected-revision" && next) {
+      expectedRevision = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--markdown-output" && next) {
+      markdownOutputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--github-step-summary" && next) {
+      githubStepSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--expect-exported-runtime") {
+      expectExportedRuntime = true;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    configPath,
+    artifactsDir,
+    expectExportedRuntime,
+    ...(outputDir ? { outputDir } : {}),
+    ...(expectedRevision ? { expectedRevision } : {}),
+    ...(outputPath ? { outputPath } : {}),
+    ...(markdownOutputPath ? { markdownOutputPath } : {}),
+    ...(githubStepSummaryPath ? { githubStepSummaryPath } : {})
+  };
+}
+
+function readGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function getRevision(): GitRevision {
+  return {
+    commit: readGitValue(["rev-parse", "HEAD"]),
+    shortCommit: readGitValue(["rev-parse", "--short", "HEAD"]),
+    branch: readGitValue(["rev-parse", "--abbrev-ref", "HEAD"]),
+    dirty: readGitValue(["status", "--porcelain"]).length > 0
+  };
+}
+
+function defaultOutputPath(shortCommit: string): string {
+  return path.resolve("artifacts", "release-readiness", `cocos-primary-delivery-audit-${shortCommit}.json`);
+}
+
+function defaultMarkdownOutputPath(outputPath: string): string {
+  return outputPath.replace(/\.json$/i, ".md");
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function tailText(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length > OUTPUT_TAIL_BYTES ? trimmed.slice(-OUTPUT_TAIL_BYTES) : trimmed;
+}
+
+function runAuditCheck(id: string, title: string, artifactPath: string | undefined, args: string[]): AuditCheck {
+  const result = spawnSync(process.execPath, args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 20
+  });
+
+  const stdoutTail = tailText(result.stdout);
+  const stderrTail = tailText(result.stderr);
+  const command = [process.execPath, ...args].join(" ");
+
+  if (result.error) {
+    return {
+      id,
+      title,
+      status: "failed",
+      summary: result.error.message,
+      ...(artifactPath ? { artifactPath } : {}),
+      command,
+      exitCode: result.status,
+      ...(stdoutTail ? { stdoutTail } : {}),
+      ...(stderrTail ? { stderrTail } : {})
+    };
+  }
+
+  if (result.status !== 0) {
+    return {
+      id,
+      title,
+      status: "failed",
+      summary: stderrTail ?? stdoutTail ?? `${title} failed.`,
+      ...(artifactPath ? { artifactPath } : {}),
+      command,
+      exitCode: result.status,
+      ...(stdoutTail ? { stdoutTail } : {}),
+      ...(stderrTail ? { stderrTail } : {})
+    };
+  }
+
+  return {
+    id,
+    title,
+    status: "passed",
+    summary: stdoutTail ?? `${title} passed.`,
+    ...(artifactPath ? { artifactPath } : {}),
+    command,
+    exitCode: result.status,
+    ...(stdoutTail ? { stdoutTail } : {})
+  };
+}
+
+function buildReport(args: Args, revision: GitRevision): DeliveryAuditReport {
+  const resolvedConfigPath = path.resolve(args.configPath);
+  const resolvedArtifactsDir = path.resolve(args.artifactsDir);
+  const resolvedOutputDir = path.resolve(args.outputDir ?? "apps/cocos-client/build/wechatgame");
+
+  const validateBuildArgs = [
+    "--import",
+    "tsx",
+    "./scripts/validate-wechat-minigame-build.ts",
+    "--config",
+    resolvedConfigPath,
+    "--output-dir",
+    resolvedOutputDir
+  ];
+  if (args.expectExportedRuntime) {
+    validateBuildArgs.push("--expect-exported-runtime");
+  }
+
+  const validateArtifactArgs = [
+    "--import",
+    "tsx",
+    "./scripts/validate-wechat-release-candidate.ts",
+    "--artifacts-dir",
+    resolvedArtifactsDir
+  ];
+  if (args.expectedRevision) {
+    validateArtifactArgs.push("--expected-revision", args.expectedRevision);
+  }
+
+  const checks: AuditCheck[] = [
+    runAuditCheck(
+      "exported-build-validation",
+      "Exported WeChat build validation",
+      resolvedOutputDir,
+      validateBuildArgs
+    ),
+    runAuditCheck(
+      "packaged-artifact-audit",
+      "Packaged WeChat release artifact audit",
+      resolvedArtifactsDir,
+      validateArtifactArgs
+    )
+  ];
+
+  const failedChecks = checks.filter((check) => check.status === "failed");
+  const passedChecks = checks.length - failedChecks.length;
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    revision,
+    target: {
+      client: "apps/cocos-client",
+      deliveryTarget: "wechatgame",
+      checklistPath: CHECKLIST_PATH,
+      outputDir: resolvedOutputDir,
+      artifactsDir: resolvedArtifactsDir
+    },
+    summary: {
+      status: failedChecks.length === 0 ? "passed" : "failed",
+      totalChecks: checks.length,
+      passedChecks,
+      failedChecks: failedChecks.length,
+      headline:
+        failedChecks.length === 0
+          ? `Primary Cocos client delivery audits passed (${passedChecks}/${checks.length}).`
+          : `Primary Cocos client delivery audit failed: ${failedChecks[0]?.title}.`
+    },
+    checks
+  };
+}
+
+function renderMarkdown(report: DeliveryAuditReport): string {
+  const lines = [
+    "# Primary Cocos Client Delivery Audit",
+    "",
+    `- Generated at: \`${report.generatedAt}\``,
+    `- Revision: \`${report.revision.shortCommit}\` on \`${report.revision.branch}\`${report.revision.dirty ? " (dirty)" : ""}`,
+    `- Overall status: **${report.summary.status.toUpperCase()}**`,
+    `- Target: \`${report.target.client}\` -> \`${report.target.deliveryTarget}\``,
+    `- Checklist: \`${report.target.checklistPath}\``,
+    "",
+    "## Automated Audits",
+    ""
+  ];
+
+  for (const check of report.checks) {
+    lines.push(`- ${check.status === "passed" ? "PASSED" : "FAILED"} ${check.title}: ${check.summary}`);
+  }
+
+  lines.push("", "## Manual Checklist", "", `- Follow \`${report.target.checklistPath}\` before release sign-off.`, "");
+  return lines.join("\n");
+}
+
+function appendFile(targetPath: string, content: string): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.appendFileSync(targetPath, `${content.endsWith("\n") ? content : `${content}\n`}`, "utf8");
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const revision = getRevision();
+  const report = buildReport(args, revision);
+  const outputPath = path.resolve(args.outputPath ?? defaultOutputPath(revision.shortCommit));
+  const markdownOutputPath = path.resolve(args.markdownOutputPath ?? defaultMarkdownOutputPath(outputPath));
+  const markdown = renderMarkdown(report);
+
+  writeJsonFile(outputPath, report);
+  writeFile(markdownOutputPath, `${markdown}\n`);
+
+  if (args.githubStepSummaryPath) {
+    appendFile(args.githubStepSummaryPath, markdown);
+  }
+
+  console.log(`Primary Cocos delivery audit: ${report.summary.headline}`);
+  for (const check of report.checks) {
+    console.log(`- ${check.status}: ${check.title}`);
+  }
+  console.log(`Overall status: ${report.summary.status}`);
+  console.log(`JSON: ${path.relative(process.cwd(), outputPath)}`);
+  console.log(`Markdown: ${path.relative(process.cwd(), markdownOutputPath)}`);
+
+  if (report.summary.status === "failed") {
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a maintained primary Cocos client delivery checklist and audit command
- run two stable post-build audits over the exported WeChat build and packaged release artifact
- publish concise delivery audit JSON/Markdown in CI and append the summary to the GitHub step summary

## Testing
- node --import tsx --test ./apps/cocos-client/test/cocos-primary-delivery-audit.test.ts ./apps/cocos-client/test/cocos-wechat-build.test.ts
- npm run typecheck:cocos

Closes #368