### PR TITLE
test(h5): cover main boot and local-session fallback flows

### DIFF
--- a/apps/client/src/main-session-runtime.ts
+++ b/apps/client/src/main-session-runtime.ts
@@ -1,0 +1,69 @@
+import type { RuntimeDiagnosticsConnectionStatus } from "../../../packages/shared/src/index";
+import type { StoredAuthSession } from "./auth-session";
+import type { SessionUpdate } from "./local-session";
+
+interface MainSessionRuntimeState {
+  accountDraftName: string;
+  lobby: {
+    authSession: StoredAuthSession | null;
+  };
+  diagnostics: {
+    connectionStatus: RuntimeDiagnosticsConnectionStatus;
+    recoverySummary: string | null;
+  };
+  log: string[];
+}
+
+interface CreateMainSessionRuntimeOptions {
+  state: MainSessionRuntimeState;
+  applyUpdate: (update: SessionUpdate, source: "push") => void;
+  render: () => void;
+}
+
+function summarizeRecoveryEvent(event: "reconnecting" | "reconnected" | "reconnect_failed"): {
+  connectionStatus: RuntimeDiagnosticsConnectionStatus;
+  recoverySummary: string;
+  logLine: string;
+} {
+  if (event === "reconnecting") {
+    return {
+      connectionStatus: "reconnecting",
+      recoverySummary: "连接暂时中断，正在尝试重新加入房间。",
+      logLine: "连接中断，正在尝试重连..."
+    };
+  }
+
+  if (event === "reconnected") {
+    return {
+      connectionStatus: "connected",
+      recoverySummary: "连接已恢复，正在用最新房间状态校正地图与战斗结果。",
+      logLine: "连接已恢复"
+    };
+  }
+
+  return {
+    connectionStatus: "reconnect_failed",
+    recoverySummary: "旧连接未恢复，正在改用持久化快照补救当前房间状态。",
+    logLine: "旧连接恢复失败，正在尝试从持久化快照恢复房间..."
+  };
+}
+
+export function createMainSessionRuntime({ state, applyUpdate, render }: CreateMainSessionRuntimeOptions) {
+  return {
+    getDisplayName: () => state.accountDraftName,
+    getAuthToken: () => state.lobby.authSession?.token ?? null,
+    onPushUpdate: (update: SessionUpdate) => {
+      state.log.unshift("收到房间同步推送");
+      state.log = state.log.slice(0, 12);
+      applyUpdate(update, "push");
+    },
+    onConnectionEvent: (event: "reconnecting" | "reconnected" | "reconnect_failed") => {
+      const next = summarizeRecoveryEvent(event);
+      state.diagnostics.connectionStatus = next.connectionStatus;
+      state.diagnostics.recoverySummary = next.recoverySummary;
+      state.log.unshift(next.logLine);
+      state.log = state.log.slice(0, 12);
+      render();
+    }
+  };
+}

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -97,6 +97,7 @@ import {
   resolveRecoveryRoomStateLabel,
   resolveRoomFeedbackTone
 } from "./room-feedback";
+import { createMainSessionRuntime } from "./main-session-runtime";
 
 const params = new URLSearchParams(window.location.search);
 const queryRoomId = params.get("roomId")?.trim() ?? "";
@@ -365,34 +366,18 @@ interface PendingPrediction {
 
 let pendingPrediction: PendingPrediction | null = null;
 
+const mainSessionRuntime = createMainSessionRuntime({
+  state,
+  applyUpdate,
+  render
+});
+
 let sessionPromise: ReturnType<typeof createGameSession> | null = shouldBootGame
   ? createGameSession(roomId, playerId, 1001, {
-      getDisplayName: () => state.accountDraftName,
-      getAuthToken: () => state.lobby.authSession?.token ?? null,
-      onPushUpdate: (update) => {
-        state.log.unshift("收到房间同步推送");
-        state.log = state.log.slice(0, 12);
-        applyUpdate(update, "push");
-      },
-      onConnectionEvent: (event) => {
-        state.diagnostics.connectionStatus =
-          event === "reconnecting" ? "reconnecting" : event === "reconnect_failed" ? "reconnect_failed" : "connected";
-        state.diagnostics.recoverySummary =
-          event === "reconnecting"
-            ? "连接暂时中断，正在尝试重新加入房间。"
-            : event === "reconnected"
-              ? "连接已恢复，正在用最新房间状态校正地图与战斗结果。"
-              : "旧连接未恢复，正在改用持久化快照补救当前房间状态。";
-        state.log.unshift(
-          event === "reconnecting"
-            ? "连接中断，正在尝试重连..."
-            : event === "reconnected"
-              ? "连接已恢复"
-              : "旧连接恢复失败，正在尝试从持久化快照恢复房间..."
-        );
-        state.log = state.log.slice(0, 12);
-        render();
-      }
+      getDisplayName: mainSessionRuntime.getDisplayName,
+      getAuthToken: mainSessionRuntime.getAuthToken,
+      onPushUpdate: mainSessionRuntime.onPushUpdate,
+      onConnectionEvent: mainSessionRuntime.onConnectionEvent
     })
   : null;
 

--- a/apps/client/test/local-session.test.ts
+++ b/apps/client/test/local-session.test.ts
@@ -172,7 +172,7 @@ class FakeRoom {
   }
 }
 
-test("readStoredSessionReplay loads the cached browser session replay for H5 boot", () => {
+test("readStoredSessionReplay loads the cached browser session replay for H5 boot", { concurrency: false }, () => {
   const update = createSessionUpdate("cached", 4);
   const storage = createMemoryStorage([
     [
@@ -193,20 +193,37 @@ test("readStoredSessionReplay loads the cached browser session replay for H5 boo
   }
 });
 
-test("createGameSession falls back to a local session when remote bootstrap is unavailable", async () => {
-  const session = await localSessionTestHooks.createGameSessionWithRuntime("room-alpha", "player-1", 1001, undefined, {
-    async connectRemoteGameSession() {
-      throw new Error("connect_failed");
+test("createGameSession falls back to a local session when remote bootstrap is unavailable", { concurrency: false }, async () => {
+  const events: ConnectionEvent[] = [];
+  const pushed: SessionUpdate[] = [];
+  const session = await localSessionTestHooks.createGameSessionWithRuntime(
+    "room-alpha",
+    "player-1",
+    1001,
+    {
+      onConnectionEvent: (event) => {
+        events.push(event);
+      },
+      onPushUpdate: (update) => {
+        pushed.push(update);
+      }
+    },
+    {
+      async connectRemoteGameSession() {
+        throw new Error("connect_failed");
+      }
     }
-  });
+  );
 
   const update = await session.snapshot("local-fallback");
   assert.equal(update.reason, "local-fallback");
   assert.equal(update.world.meta.roomId, "room-alpha");
   assert.equal(update.world.playerId, "player-1");
+  assert.deepEqual(events, []);
+  assert.deepEqual(pushed, []);
 });
 
-test("createGameSession keeps the remote bootstrap session when the initial connection succeeds", async () => {
+test("createGameSession keeps the remote bootstrap session when the initial connection succeeds", { concurrency: false }, async () => {
   const expected = createSessionUpdate("remote-live", 9);
   const remoteSession = {
     async snapshot(reason?: string) {
@@ -265,7 +282,7 @@ test("createGameSession keeps the remote bootstrap session when the initial conn
   assert.deepEqual(await session.snapshot("boot"), { ...expected, reason: "boot" });
 });
 
-test("createGameSession falls back to a local session when remote bootstrap times out", async () => {
+test("createGameSession falls back to a local session when remote bootstrap times out", { concurrency: false }, async () => {
   const session = await localSessionTestHooks.createGameSessionWithRuntime("room-alpha", "player-1", 1001, undefined, {
     async connectRemoteGameSession() {
       throw new Error("connect_timeout");
@@ -278,7 +295,80 @@ test("createGameSession falls back to a local session when remote bootstrap time
   assert.equal(update.world.playerId, "player-1");
 });
 
-test("createGameSession surfaces stored-token recovery as a successful remote resume", async () => {
+test(
+  "recoverable remote sessions surface the recovered snapshot as a push update before a retried request resolves",
+  { concurrency: false },
+  async () => {
+    const storage = createMemoryStorage([
+      [getReconnectionStorageKey("room-alpha", "player-1"), "stale-token"] as const
+    ]);
+    const restoreWindow = installWindow(storage);
+    const firstRoom = new FakeRoom("token-first");
+    const secondRoom = new FakeRoom("token-second");
+    const pushed: SessionUpdate[] = [];
+    const events: ConnectionEvent[] = [];
+    let connectAttempts = 0;
+
+    try {
+      const session = await localSessionTestHooks.createGameSessionWithRuntime(
+        "room-alpha",
+        "player-1",
+        1001,
+        {
+          onPushUpdate: (update) => {
+            pushed.push(update);
+          },
+          onConnectionEvent: (event) => {
+            events.push(event);
+          }
+        },
+        {
+          async connectRemoteGameSession(roomId, playerId, seed, options) {
+            connectAttempts += 1;
+            const room = connectAttempts === 1 ? firstRoom : secondRoom;
+            return {
+              session: localSessionTestHooks.createRemoteGameSession(
+                room as unknown as ColyseusRoom,
+                roomId,
+                playerId,
+                options
+              ) as never,
+              recoveredFromStoredToken: false
+            };
+          },
+          async wait() {}
+        }
+      );
+
+      const snapshotPromise = session.snapshot("boot");
+      await waitFor(() => firstRoom.sent.length === 1, "initial remote snapshot was not requested");
+      firstRoom.emitLeave(CloseCode.FAILED_TO_RECONNECT);
+
+      await waitFor(() => secondRoom.sent.length >= 1, "recovery snapshot was not requested");
+      const recoveredUpdate = createSessionUpdate("recovered", 7);
+      const recoveryRequestId = (secondRoom.sent[0]?.payload as { requestId: string }).requestId;
+      secondRoom.emitMessage(toServerMessage(recoveryRequestId, recoveredUpdate));
+
+      await waitFor(() => events.length === 2, "recovery reconnect event was not emitted");
+      await waitFor(() => pushed.length === 1, "recovered snapshot push update was not emitted");
+      assert.deepEqual(events, ["reconnect_failed", "reconnected"]);
+      assert.deepEqual(pushed, [recoveredUpdate]);
+
+      await waitFor(() => secondRoom.sent.length >= 2, "retry snapshot was not requested");
+      const liveUpdate = createSessionUpdate("live", 8);
+      const retryRequestId = (secondRoom.sent[1]?.payload as { requestId: string }).requestId;
+      secondRoom.emitMessage(toServerMessage(retryRequestId, liveUpdate));
+
+      const update = await snapshotPromise;
+      assert.equal(update.reason, "boot");
+      assert.equal(update.world.meta.day, 8);
+    } finally {
+      restoreWindow();
+    }
+  }
+);
+
+test("createGameSession surfaces stored-token recovery as a successful remote resume", { concurrency: false }, async () => {
   const events: ConnectionEvent[] = [];
   const session = await localSessionTestHooks.createGameSessionWithRuntime(
     "room-alpha",
@@ -309,7 +399,10 @@ test("createGameSession surfaces stored-token recovery as a successful remote re
   assert.equal(update.world.meta.day, 5);
 });
 
-test("createGameSession falls back to a local session when remote bootstrap throws a non-recoverable error", async () => {
+test(
+  "createGameSession falls back to a local session when remote bootstrap throws a non-recoverable error",
+  { concurrency: false },
+  async () => {
   const session = await localSessionTestHooks.createGameSessionWithRuntime("room-alpha", "player-1", 1001, undefined, {
     async connectRemoteGameSession() {
       throw new Error("unexpected_bootstrap_failure");
@@ -320,9 +413,10 @@ test("createGameSession falls back to a local session when remote bootstrap thro
   assert.equal(update.reason, "local-after-unexpected-failure");
   assert.equal(update.world.meta.roomId, "room-alpha");
   assert.equal(update.world.playerId, "player-1");
-});
+  }
+);
 
-test("remote game sessions persist push updates and reconnection tokens", () => {
+test("remote game sessions persist push updates and reconnection tokens", { concurrency: false }, () => {
   const storage = createMemoryStorage();
   const restoreWindow = installWindow(storage);
   const room = new FakeRoom("token-initial");
@@ -362,7 +456,7 @@ test("remote game sessions persist push updates and reconnection tokens", () => 
   }
 });
 
-test("recoverable remote sessions retry after room loss and replay the recovered snapshot", async () => {
+test("recoverable remote sessions retry after room loss and replay the recovered snapshot", { concurrency: false }, async () => {
   const storage = createMemoryStorage([
     [getReconnectionStorageKey("room-alpha", "player-1"), "stale-token"] as const
   ]);

--- a/apps/client/test/main-entry.test.ts
+++ b/apps/client/test/main-entry.test.ts
@@ -46,3 +46,27 @@ test("startH5ClientApp reports boot failures while still wiring automation hooks
   await Promise.resolve();
   assert.deepEqual(events, ["bootstrap:start", "registerAutomationHooks", "reportBootstrapError:true"]);
 });
+
+test("startH5ClientApp keeps automation hook registration stable across repeated boots", async () => {
+  const events: string[] = [];
+
+  startH5ClientApp({
+    bootstrapApp: async () => {
+      events.push("bootstrap:first");
+    },
+    registerAutomationHooks: () => {
+      events.push("register:first");
+    }
+  });
+  startH5ClientApp({
+    bootstrapApp: async () => {
+      events.push("bootstrap:second");
+    },
+    registerAutomationHooks: () => {
+      events.push("register:second");
+    }
+  });
+
+  await Promise.resolve();
+  assert.deepEqual(events, ["bootstrap:first", "register:first", "bootstrap:second", "register:second"]);
+});

--- a/apps/client/test/main-session-runtime.test.ts
+++ b/apps/client/test/main-session-runtime.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { SessionUpdate } from "../src/local-session";
+import { createMainSessionRuntime } from "../src/main-session-runtime";
+
+function createSessionUpdate(reason = "push-sync", day = 2): SessionUpdate {
+  return {
+    world: {
+      meta: {
+        roomId: "room-alpha",
+        seed: 1001,
+        day
+      },
+      map: {
+        width: 1,
+        height: 1,
+        tiles: []
+      },
+      ownHeroes: [],
+      visibleHeroes: [],
+      resources: {
+        gold: 50,
+        wood: 3,
+        ore: 1
+      },
+      playerId: "player-auth"
+    },
+    battle: null,
+    events: [],
+    movementPlan: null,
+    reachableTiles: [{ x: 0, y: 0 }],
+    reason
+  };
+}
+
+test("createMainSessionRuntime forwards push updates and keeps the newest sync log entries bounded", () => {
+  const events: string[] = [];
+  const state = {
+    accountDraftName: "访客骑士",
+    lobby: {
+      authSession: {
+        token: "signed.token",
+        playerId: "player-auth",
+        displayName: "访客骑士",
+        authMode: "account" as const,
+        loginId: "veil-ranger",
+        source: "remote" as const
+      }
+    },
+    diagnostics: {
+      connectionStatus: "connected" as const,
+      recoverySummary: null
+    },
+    log: Array.from({ length: 12 }, (_, index) => `old-${index + 1}`)
+  };
+
+  const runtime = createMainSessionRuntime({
+    state,
+    applyUpdate: (update, source) => {
+      events.push(`applyUpdate:${source}:${update.reason}`);
+    },
+    render: () => {
+      events.push("render");
+    }
+  });
+
+  assert.equal(runtime.getDisplayName(), "访客骑士");
+  assert.equal(runtime.getAuthToken(), "signed.token");
+  runtime.onPushUpdate(createSessionUpdate());
+
+  assert.deepEqual(events, ["applyUpdate:push:push-sync"]);
+  assert.deepEqual(state.log, [
+    "收到房间同步推送",
+    "old-1",
+    "old-2",
+    "old-3",
+    "old-4",
+    "old-5",
+    "old-6",
+    "old-7",
+    "old-8",
+    "old-9",
+    "old-10",
+    "old-11"
+  ]);
+});
+
+test("createMainSessionRuntime maps reconnect transitions to stable diagnostics and fallback logs", () => {
+  const renders: string[] = [];
+  const state = {
+    accountDraftName: "访客骑士",
+    lobby: {
+      authSession: null
+    },
+    diagnostics: {
+      connectionStatus: "connecting" as const,
+      recoverySummary: null as string | null
+    },
+    log: ["old-line"]
+  };
+
+  const runtime = createMainSessionRuntime({
+    state,
+    applyUpdate: () => {
+      throw new Error("push updates are not part of this assertion");
+    },
+    render: () => {
+      renders.push(state.diagnostics.connectionStatus);
+    }
+  });
+
+  runtime.onConnectionEvent("reconnecting");
+  assert.equal(state.diagnostics.connectionStatus, "reconnecting");
+  assert.equal(state.diagnostics.recoverySummary, "连接暂时中断，正在尝试重新加入房间。");
+  assert.deepEqual(state.log.slice(0, 2), ["连接中断，正在尝试重连...", "old-line"]);
+
+  runtime.onConnectionEvent("reconnected");
+  assert.equal(state.diagnostics.connectionStatus, "connected");
+  assert.equal(state.diagnostics.recoverySummary, "连接已恢复，正在用最新房间状态校正地图与战斗结果。");
+  assert.deepEqual(state.log.slice(0, 2), ["连接已恢复", "连接中断，正在尝试重连..."]);
+
+  runtime.onConnectionEvent("reconnect_failed");
+  assert.equal(state.diagnostics.connectionStatus, "reconnect_failed");
+  assert.equal(state.diagnostics.recoverySummary, "旧连接未恢复，正在改用持久化快照补救当前房间状态。");
+  assert.deepEqual(state.log.slice(0, 2), ["旧连接恢复失败，正在尝试从持久化快照恢复房间...", "连接已恢复"]);
+  assert.deepEqual(renders, ["reconnecting", "connected", "reconnect_failed"]);
+  assert.equal(runtime.getAuthToken(), null);
+});


### PR DESCRIPTION
## Summary
- extract the main H5 session runtime wiring from `apps/client/src/main.ts` into a focused helper so push-update and reconnect fallback behavior can be tested directly
- add focused H5 boot/session regression tests covering cached-session boot wiring, remote-session unavailable fallback, local-session recovery push updates, and repeated automation hook registration stability
- serialize the browser-storage local-session tests to remove the global `window` race that showed up once the direct main-runtime coverage was added

## Testing
- `node --import tsx --test apps/client/test/main-session-runtime.test.ts apps/client/test/main-entry.test.ts apps/client/test/main-boot.test.ts apps/client/test/main-launch.test.ts apps/client/test/local-session.test.ts`
- `npm run typecheck:client:h5`
- `npm test`
- `npm run test:coverage:ci` *(fails outside this issue scope in `apps/server/test/colyseus-persistence-recovery.test.ts` with `Timed out waiting for push session.state` while running `colyseus room broadcasts bounded typed-array map chunks to non-source clients`)*

Closes #372