### PR TITLE
test(server): lock room lifecycle and battle replay orchestration

### DIFF
--- a/apps/server/test/battle-replays.test.ts
+++ b/apps/server/test/battle-replays.test.ts
@@ -211,3 +211,103 @@ test("battle replay capture skips unresolved outcomes and empty replay appends",
   const account = createAccount();
   assert.equal(appendCompletedBattleReplaysToAccount(account, []), account);
 });
+
+test("battle replay capture records sequential immutable steps for each action appended", () => {
+  const capture = createBattleReplayCapture(
+    "room-steps-272",
+    createBattleState({
+      id: "battle-steps-272",
+      worldHeroId: "hero-replay"
+    }),
+    { attackerPlayerId: "player-step" },
+    "2026-03-29T15:00:00.000Z"
+  );
+
+  const firstAction: BattleAction = {
+    type: "battle.attack",
+    attackerId: "hero-stack",
+    defenderId: "wolf-stack"
+  };
+  const withFirstStep = appendBattleReplayStep(capture, firstAction, "player");
+  firstAction.attackerId = "mutated-after-append";
+
+  const secondAction: BattleAction = {
+    type: "battle.wait",
+    unitId: "hero-stack"
+  };
+  const withSecondStep = appendBattleReplayStep(withFirstStep, secondAction, "automated");
+  secondAction.unitId = "mutated-after-append";
+
+  assert.equal(withSecondStep.steps.length, 2);
+  assert.deepEqual(withSecondStep.steps[0], {
+    index: 1,
+    source: "player",
+    action: {
+      type: "battle.attack",
+      attackerId: "hero-stack",
+      defenderId: "wolf-stack"
+    }
+  });
+  assert.deepEqual(withSecondStep.steps[1], {
+    index: 2,
+    source: "automated",
+    action: {
+      type: "battle.wait",
+      unitId: "hero-stack"
+    }
+  });
+});
+
+test("battle replay emission requires hero identifiers before generating summaries", () => {
+  const attackerCapture = finalizeBattleReplayCapture(
+    createBattleReplayCapture(
+      "room-prereq-272",
+      createBattleState({
+        id: "battle-prereq-272"
+      }),
+      { attackerPlayerId: "player-hero-prereq" },
+      "2026-03-29T15:10:00.000Z"
+    ),
+    createBattleState({
+      id: "battle-prereq-272"
+    }),
+    {
+      status: "attacker_victory",
+      survivingAttackers: [],
+      survivingDefenders: []
+    },
+    "2026-03-29T15:11:00.000Z"
+  );
+
+  assert.ok(attackerCapture);
+  assert.deepEqual(buildPlayerBattleReplaySummariesForPlayer(attackerCapture, "player-hero-prereq"), []);
+
+  const defenderBattle = createBattleState({
+    id: "battle-prereq-defender-272",
+    worldHeroId: "hero-attacker-prereq"
+  });
+  const defenderCapture = finalizeBattleReplayCapture(
+    createBattleReplayCapture(
+      "room-prereq-272",
+      defenderBattle,
+      {
+        attackerPlayerId: "player-hero-prereq",
+        defenderPlayerId: "player-hero-prereq-defender"
+      },
+      "2026-03-29T15:12:00.000Z"
+    ),
+    defenderBattle,
+    {
+      status: "defender_victory",
+      survivingAttackers: [],
+      survivingDefenders: []
+    },
+    "2026-03-29T15:13:00.000Z"
+  );
+
+  assert.ok(defenderCapture);
+  assert.deepEqual(
+    buildPlayerBattleReplaySummariesForPlayer(defenderCapture, "player-hero-prereq-defender"),
+    []
+  );
+});

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -261,6 +261,44 @@ test("client reconnect within the window restores room state and records reconne
   assert.equal(new Date(reconnectedAt).toISOString(), reconnectedAt);
 });
 
+test("reconnect preserves lobby registration counts while other players stay connected", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-reconnect-multi-${Date.now()}`);
+  const reconnectingClient = createFakeClient("session-reconnect-multi");
+  const reconnectedClient = createFakeClient("session-reconnect-multi-resumed");
+  const otherClient = createFakeClient("session-reconnect-multi-other");
+  const internalRoom = room as VeilColyseusRoom & {
+    playerIdBySessionId: Map<string, string>;
+    allowReconnection(client: Client, seconds: number): Promise<Client>;
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, reconnectingClient, "player-reconnect-multi", "connect-reconnect-multi");
+  await connectPlayer(room, otherClient, "player-other-multi", "connect-other-multi");
+
+  assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 2);
+
+  internalRoom.allowReconnection = async () => {
+    room.clients.push(reconnectedClient);
+    return reconnectedClient;
+  };
+  await room.onDrop(reconnectingClient);
+
+  assert.equal(internalRoom.playerIdBySessionId.get(reconnectedClient.sessionId), "player-reconnect-multi");
+  assert.equal(internalRoom.playerIdBySessionId.get(otherClient.sessionId), "player-other-multi");
+  assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 2);
+
+  const resumedState = lastSessionState(reconnectedClient, "push");
+  assert.equal(resumedState.requestId, "push");
+  assert.equal(resumedState.delivery, "push");
+});
+
 test("stale leave after a successful reconnect does not clear the resumed player slot", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
@@ -341,6 +379,33 @@ test("room disposal after the last client leaves removes it from the active room
   room.onDispose();
 
   assert.equal(listLobbyRooms().some((entry) => entry.roomId === room.roomId), false);
+});
+
+test("stale room disposal cannot unregister a replacement room with the same logical id", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const logicalRoomId = `lifecycle-multi-room-${Date.now()}`;
+  const firstRoom = await createTestRoom(logicalRoomId, 3101);
+  const secondRoom = await createTestRoom(logicalRoomId, 4202);
+
+  t.after(() => {
+    cleanupRoom(firstRoom);
+    cleanupRoom(secondRoom);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  const summaryAfterReplacement = listLobbyRooms().find((entry) => entry.roomId === logicalRoomId);
+  assert.ok(summaryAfterReplacement);
+  assert.equal(summaryAfterReplacement.seed, 4202);
+
+  firstRoom.onDispose();
+  const summaryAfterStaleDispose = listLobbyRooms().find((entry) => entry.roomId === logicalRoomId);
+  assert.ok(summaryAfterStaleDispose);
+  assert.equal(summaryAfterStaleDispose.seed, 4202);
+
+  secondRoom.onDispose();
+  assert.equal(listLobbyRooms().some((entry) => entry.roomId === logicalRoomId), false);
 });
 
 test("simultaneous rooms keep seeded world state isolated", async (t) => {


### PR DESCRIPTION
## Summary
- add reconnection + multi-room disposal regression coverage for VeilColyseusRoom
- add replay capture sequencing and emission prerequisite tests

Closes #374.

## Testing
- node --import tsx --test apps/server/test/colyseus-room-lifecycle.test.ts apps/server/test/battle-replays.test.ts
- npm test
- npm run test:coverage:ci