### PR TITLE
tooling: surface config impact summaries for world and battle data changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ npm run dev:client:h5
   - 保存后会同时导出到 `configs/*.json`，并同步刷新服务端运行时配置，新建房间和战斗逻辑会直接读取新值
   - 当前已补上版本快照、快照差异对比、历史回滚，以及 Easy / Normal / Hard 三档内置预设和自定义预设保存
   - 实时校验现已带出对应配置 schema 摘要、必填根字段、逐项修复建议，以及跨 `world / mapObjects / units / battleSkills / battleBalance` 的 content-pack 一致性结果；非法值会阻止保存
+  - 保存 `world / mapObjects / units / battle-skills / battle-balance` 后，右侧会同步展示一份 impact summary，带出变更字段、影响模块、潜在风险提示和建议验证动作；发布审计历史也会保留同样的摘要，便于做配置变更评审
   - 导出除 JSON 注释版外，还支持带 `Meta / Schema / Fields` 工作表的 Excel，以及更轻量的字段清单 CSV
   - 当前编辑 `phase1-world.json` 时，右侧会即时生成一份地图样本预览；可切换预览 seed，对照查看地形、随机资源、保底资源、英雄与中立怪分布
   - 当前编辑 `battle-skills.json` 时，右侧会显示技能编辑器，可直接调整冷却、伤害倍率、目标类型、附加状态和状态持续参数，并同步回写 JSON 草稿

--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -73,6 +73,19 @@ interface ConfigDiff {
   entries: ConfigDiffEntry[];
 }
 
+type ConfigImpactRiskLevel = "low" | "medium" | "high";
+
+interface ConfigImpactSummary {
+  documentId: ConfigDocumentId;
+  title: string;
+  summary: string;
+  riskLevel: ConfigImpactRiskLevel;
+  changedFields: string[];
+  impactedModules: string[];
+  riskHints: string[];
+  suggestedValidationActions: string[];
+}
+
 interface ConfigPresetSummary {
   id: string;
   name: string;
@@ -107,6 +120,7 @@ interface ConfigPublishAuditChange {
   runtimeStatus: ConfigPublishChangeRuntimeStatus;
   runtimeMessage: string;
   diffSummary: ConfigDiffEntry[];
+  impactSummary: ConfigImpactSummary | null;
 }
 
 interface ConfigPublishAuditEvent {
@@ -240,6 +254,7 @@ interface AppState {
   saving: boolean;
   statusTone: "neutral" | "success" | "error";
   statusMessage: string;
+  lastSavedImpactSummary: ConfigImpactSummary | null;
   draft: string;
   previewSeed: number;
   worldPreview: WorldConfigPreview | null;
@@ -367,6 +382,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     saving: false,
     statusTone: "neutral",
     statusMessage: "正在加载配置中心...",
+    lastSavedImpactSummary: null,
     draft: "",
     previewSeed: 1001,
     worldPreview: null,
@@ -1003,6 +1019,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       state.selectedId = response.document.id;
       state.draft = response.document.content;
       state.validation = null;
+      state.lastSavedImpactSummary = null;
       state.snapshots = [];
       state.publishHistory = [];
       state.presets = [];
@@ -1054,6 +1071,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       const response = await requestJson<{
         storage: "filesystem" | "mysql";
         document: ConfigDocument;
+        impactSummary?: ConfigImpactSummary | null;
       }>(`/api/config-center/configs/${state.current.id}`, {
         method: "PUT",
         headers: {
@@ -1066,6 +1084,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
 
       state.storageMode = response.storage;
       state.current = response.document;
+      state.lastSavedImpactSummary = response.impactSummary ?? null;
       state.draft = response.document.content;
       state.statusTone = "success";
       state.statusMessage = `${response.document.title} 已保存，并同步刷新服务端运行时配置`;

--- a/apps/client/src/config-center.css
+++ b/apps/client/src/config-center.css
@@ -674,6 +674,34 @@ body {
   margin-top: 10px;
 }
 
+.impact-summary-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.impact-summary-grid.is-compact {
+  margin-top: 10px;
+}
+
+.impact-summary-card {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 249, 241, 0.92);
+  border: 1px solid rgba(138, 90, 43, 0.12);
+}
+
+.impact-summary-card strong,
+.impact-summary-card span {
+  display: block;
+}
+
+.impact-summary-card span {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
 .publish-diff-chip {
   display: inline-flex;
   padding: 6px 10px;

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -133,6 +133,19 @@ interface ConfigDiff {
   entries: ConfigDiffEntry[];
 }
 
+type ConfigImpactRiskLevel = "low" | "medium" | "high";
+
+interface ConfigImpactSummary {
+  documentId: ConfigDocumentId;
+  title: string;
+  summary: string;
+  riskLevel: ConfigImpactRiskLevel;
+  changedFields: string[];
+  impactedModules: string[];
+  riskHints: string[];
+  suggestedValidationActions: string[];
+}
+
 interface ConfigPresetSummary {
   id: string;
   name: string;
@@ -167,6 +180,7 @@ interface ConfigPublishAuditChange {
   runtimeStatus: ConfigPublishChangeRuntimeStatus;
   runtimeMessage: string;
   diffSummary: ConfigDiffEntry[];
+  impactSummary: ConfigImpactSummary | null;
 }
 
 interface ConfigPublishAuditEvent {
@@ -297,6 +311,7 @@ interface AppState {
   saving: boolean;
   statusTone: "neutral" | "success" | "error";
   statusMessage: string;
+  lastSavedImpactSummary: ConfigImpactSummary | null;
   draft: string;
   previewSeed: number;
   worldPreview: WorldConfigPreview | null;
@@ -354,6 +369,16 @@ function sortDiffEntries(entries: ConfigDiffEntry[]): ConfigDiffEntry[] {
 
 function countStructuralEntries(diff: ConfigDiff): number {
   return diff.entries.filter(isStructuralDiff).length;
+}
+
+function impactRiskLabel(riskLevel: ConfigImpactRiskLevel): string {
+  if (riskLevel === "high") {
+    return "高风险";
+  }
+  if (riskLevel === "medium") {
+    return "中风险";
+  }
+  return "低风险";
 }
 
 const appRoot = document.querySelector<HTMLDivElement>("#app");
@@ -1180,6 +1205,40 @@ function renderValidationSection(): string {
   `;
 }
 
+function renderImpactSummarySection(): string {
+  if (!state.current || !state.lastSavedImpactSummary) {
+    return "";
+  }
+
+  const summary = state.lastSavedImpactSummary;
+  return `
+    <section class="history-section">
+      <div class="config-preview-subhead">
+        <h4>变更影响摘要</h4>
+        <span class="config-meta">${impactRiskLabel(summary.riskLevel)}</span>
+      </div>
+      <p class="config-hint">${escapeHtml(summary.summary)}</p>
+      <div class="config-badge-row">
+        ${summary.impactedModules.map((label) => `<span class="config-badge">${escapeHtml(label)}</span>`).join("")}
+      </div>
+      <div class="impact-summary-grid">
+        <article class="impact-summary-card">
+          <strong>变更字段</strong>
+          <span>${escapeHtml(summary.changedFields.join(" / ") || "无")}</span>
+        </article>
+        <article class="impact-summary-card">
+          <strong>潜在风险</strong>
+          <span>${escapeHtml(summary.riskHints.join(" / ") || "未检测到额外风险提示")}</span>
+        </article>
+        <article class="impact-summary-card">
+          <strong>建议验证</strong>
+          <span>${escapeHtml(summary.suggestedValidationActions.join(" / ") || "无")}</span>
+        </article>
+      </div>
+    </section>
+  `;
+}
+
 function renderPublishStageSection(): string {
   if (!state.current) {
     return "";
@@ -1463,6 +1522,26 @@ function renderPublishHistoryList(): string {
                             <span>${change.changeCount} 项变更${change.structuralChangeCount ? ` · ${change.structuralChangeCount} 项结构风险` : ""}</span>
                           </div>
                           <small>${escapeHtml(change.runtimeMessage)}</small>
+                          ${
+                            change.impactSummary
+                              ? `
+                                <div class="impact-summary-grid is-compact">
+                                  <article class="impact-summary-card">
+                                    <strong>${impactRiskLabel(change.impactSummary.riskLevel)}</strong>
+                                    <span>${escapeHtml(change.impactSummary.summary)}</span>
+                                  </article>
+                                  <article class="impact-summary-card">
+                                    <strong>影响模块</strong>
+                                    <span>${escapeHtml(change.impactSummary.impactedModules.join(" / "))}</span>
+                                  </article>
+                                  <article class="impact-summary-card">
+                                    <strong>风险提示</strong>
+                                    <span>${escapeHtml(change.impactSummary.riskHints.join(" / ") || "无")}</span>
+                                  </article>
+                                </div>
+                              `
+                              : ""
+                          }
                           <div class="publish-diff-summary">
                             ${
                               change.diffSummary.length > 0
@@ -1593,6 +1672,7 @@ function renderPreviewContent(): string {
     <div class="config-badge-row">${badges}</div>
     <p class="config-hint">保存后会先写主存储，再导出到 <code>configs/*.json</code>，并同步刷新服务端运行时配置。新建房间、战斗公式和世界生成会直接读取最新版本。</p>
     ${renderValidationSection()}
+    ${renderImpactSummarySection()}
     ${renderPublishStageSection()}
     ${renderPresetSection()}
     ${renderSnapshotSection()}

--- a/apps/client/test/config-center.test.ts
+++ b/apps/client/test/config-center.test.ts
@@ -196,7 +196,17 @@ test("config center save flow calls the config API with the edited draft body", 
       return new Response(
         JSON.stringify({
           storage: "filesystem",
-          document: savedDocument
+          document: savedDocument,
+          impactSummary: {
+            documentId: "mapObjects",
+            title: "地图物件",
+            summary: "1 项字段变更，主要关注 neutralArmies。",
+            riskLevel: "medium",
+            changedFields: ["neutralArmies"],
+            impactedModules: ["地图 POI", "招募库存"],
+            riskHints: ["地图对象已调整，守军、建筑或资源点分布可能改变探索与招募节奏。"],
+            suggestedValidationActions: ["config-center 地图预览"]
+          }
         }),
         {
           status: 200,
@@ -251,6 +261,8 @@ test("config center save flow calls the config API with the edited draft body", 
   });
   assert.equal(controller.state.current?.content, "{\n  \"neutralArmies\": []\n}\n");
   assert.equal(controller.state.statusTone, "success");
+  assert.equal(controller.state.lastSavedImpactSummary?.documentId, "mapObjects");
+  assert.equal(controller.state.lastSavedImpactSummary?.impactedModules.includes("招募库存"), true);
 });
 
 test("config center snapshot diff exposes non-empty changes for an edited field", async () => {

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -135,6 +135,19 @@ export interface ConfigDiff {
   entries: ConfigDiffEntry[];
 }
 
+export type ConfigImpactRiskLevel = "low" | "medium" | "high";
+
+export interface ConfigImpactSummary {
+  documentId: ConfigDocumentId;
+  title: string;
+  summary: string;
+  riskLevel: ConfigImpactRiskLevel;
+  changedFields: string[];
+  impactedModules: string[];
+  riskHints: string[];
+  suggestedValidationActions: string[];
+}
+
 export interface ConfigPresetSummary {
   id: string;
   name: string;
@@ -169,6 +182,7 @@ export interface ConfigPublishAuditChange {
   runtimeStatus: ConfigPublishChangeRuntimeStatus;
   runtimeMessage: string;
   diffSummary: ConfigDiffEntry[];
+  impactSummary: ConfigImpactSummary | null;
 }
 
 export interface ConfigPublishAuditEvent {
@@ -440,6 +454,40 @@ const CONFIG_RUNTIME_IMPACT: Record<ConfigDocumentId, string[]> = {
   units: ["战斗模拟器", "招募面板"],
   battleSkills: ["技能编辑器", "战斗模拟器"],
   battleBalance: ["战斗平衡计算", "PVP 匹配"]
+};
+const CONFIG_IMPACT_RULES: Record<
+  ConfigDocumentId,
+  {
+    defaultRisk: ConfigImpactRiskLevel;
+    impactedModules: string[];
+    suggestedValidationActions: string[];
+  }
+> = {
+  world: {
+    defaultRisk: "high",
+    impactedModules: ["地图生成", "英雄出生点", "资源分布"],
+    suggestedValidationActions: ["config-center 地图预览", "房间建图 smoke"]
+  },
+  mapObjects: {
+    defaultRisk: "medium",
+    impactedModules: ["地图 POI", "招募库存", "资源矿收益"],
+    suggestedValidationActions: ["config-center 地图预览", "建筑/守军布局检查"]
+  },
+  units: {
+    defaultRisk: "medium",
+    impactedModules: ["单位数值", "招募库存", "战斗节奏"],
+    suggestedValidationActions: ["content-pack 一致性校验", "战斗公式回归"]
+  },
+  battleSkills: {
+    defaultRisk: "high",
+    impactedModules: ["战斗技能", "状态效果", "伤害结算"],
+    suggestedValidationActions: ["content-pack 一致性校验", "技能链路回归"]
+  },
+  battleBalance: {
+    defaultRisk: "high",
+    impactedModules: ["战斗公式", "环境机关", "PVP ELO"],
+    suggestedValidationActions: ["战斗公式回归", "PVP 结算检查"]
+  }
 };
 
 const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
@@ -958,6 +1006,86 @@ function buildBlastRadius(id: ConfigDocumentId, kind: ConfigDiffChangeKind): str
   const base = kind === "value" ? BASE_VALUE_IMPACT : BASE_SCHEMA_IMPACT;
   const scoped = kind === "value" ? [] : CONFIG_RUNTIME_IMPACT[id] ?? [];
   return Array.from(new Set([...base, ...scoped]));
+}
+
+function uniqueStrings(items: Iterable<string>): string[] {
+  return Array.from(
+    new Set(
+      [...items]
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+    )
+  );
+}
+
+function buildConfigImpactSummary(
+  id: ConfigDocumentId,
+  title: string,
+  diffEntries: ConfigDiffEntry[]
+): ConfigImpactSummary | null {
+  if (diffEntries.length === 0) {
+    return null;
+  }
+
+  const rule = CONFIG_IMPACT_RULES[id];
+  const changedFields = uniqueStrings(diffEntries.map((entry) => entry.path)).slice(0, 4);
+  const impactedModules = uniqueStrings([
+    ...rule.impactedModules,
+    ...diffEntries.flatMap((entry) => entry.blastRadius),
+    ...(CONFIG_RUNTIME_IMPACT[id] ?? [])
+  ]);
+  const structuralCount = diffEntries.filter((entry) => entry.kind !== "value").length;
+  let riskLevel = rule.defaultRisk;
+
+  if (id === "mapObjects") {
+    const highSignal = changedFields.some((entry) =>
+      /(buildings|neutralArmies|guaranteedResources|reward|recruitCount|income|unitTemplateId)/.test(entry)
+    );
+    if (highSignal || structuralCount > 0 || diffEntries.length >= 8) {
+      riskLevel = "high";
+    }
+  } else if (id === "units") {
+    const highSignal = changedFields.some((entry) =>
+      /(attack|defense|minDamage|maxDamage|maxHp|initiative|skills|templateId)/.test(entry)
+    );
+    if (highSignal || structuralCount > 0 || diffEntries.length >= 10) {
+      riskLevel = "high";
+    }
+  }
+
+  const riskHints = uniqueStrings([
+    structuralCount > 0 ? `包含 ${structuralCount} 项结构变更，需留意 Schema/运行时兼容性。` : "",
+    riskLevel === "high" ? "命中高敏感配置域，建议在发布前补一次联动回归。" : "",
+    changedFields.some((entry) => /(width|height|heroes|resourceSpawn)/.test(entry))
+      ? "世界生成参数已变更，地图尺寸、出生点或资源刷率可能一起波动。"
+      : "",
+    changedFields.some((entry) => /(neutralArmies|buildings|guaranteedResources)/.test(entry))
+      ? "地图对象已调整，守军、建筑或资源点分布可能改变探索与招募节奏。"
+      : "",
+    changedFields.some((entry) => /(attack|defense|minDamage|maxDamage|maxHp|initiative)/.test(entry))
+      ? "单位面板已调整，战斗节奏和招募价值可能出现连锁变化。"
+      : "",
+    changedFields.some((entry) => /(cooldown|damageMultiplier|grantedStatusId|onHitStatusId|statuses)/.test(entry))
+      ? "技能或状态参数已调整，技能链和状态覆盖率需要重点复核。"
+      : "",
+    changedFields.some((entry) => /(damage|environment|eloK|trap|blocker)/.test(entry))
+      ? "战斗公式或环境机关已调整，伤害结算与 PVP 评分可能漂移。"
+      : ""
+  ]);
+
+  return {
+    documentId: id,
+    title,
+    summary:
+      structuralCount > 0
+        ? `${diffEntries.length} 项字段变更，其中 ${structuralCount} 项为结构风险。`
+        : `${diffEntries.length} 项字段变更，主要关注 ${changedFields.join(", ")}。`,
+    riskLevel,
+    changedFields,
+    impactedModules,
+    riskHints,
+    suggestedValidationActions: [...rule.suggestedValidationActions]
+  };
 }
 
 function buildConfigDiffEntries(
@@ -2761,7 +2889,12 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         snapshotId: null,
         runtimeStatus: "pending",
         runtimeMessage: "等待运行时应用",
-        diffSummary: diffEntries.slice(0, 4)
+        diffSummary: diffEntries.slice(0, 4),
+        impactSummary: buildConfigImpactSummary(
+          stagedDocument.id,
+          definition?.title ?? stagedDocument.id,
+          diffEntries
+        )
       });
     }
 
@@ -3689,9 +3822,13 @@ export function registerConfigCenterRoutes(
         return;
       }
 
+      const current = await store.loadDocument(definition.id);
+      const diffEntries = buildConfigDiffEntries(definition.id, current.content, body.content);
+
       sendJson(response, 200, {
         storage: store.mode,
-        document: await store.saveDocument(definition.id, body.content)
+        document: await store.saveDocument(definition.id, body.content),
+        impactSummary: buildConfigImpactSummary(definition.id, definition.title, diffEntries)
       });
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -696,6 +696,10 @@ test("config center staged publish applies bundled drafts and records publish hi
   assert.equal(auditHistory[0]?.changes[0]?.runtimeStatus, "applied");
   assert.equal(typeof auditHistory[0]?.changes[0]?.snapshotId, "string");
   assert.equal((auditHistory[0]?.changes[0]?.diffSummary.length ?? 0) > 0, true);
+  assert.equal(auditHistory[0]?.changes[0]?.impactSummary?.documentId, auditHistory[0]?.changes[0]?.documentId);
+  assert.equal((auditHistory[0]?.changes[0]?.impactSummary?.changedFields.length ?? 0) > 0, true);
+  assert.equal((auditHistory[0]?.changes[0]?.impactSummary?.impactedModules.length ?? 0) > 0, true);
+  assert.equal((auditHistory[0]?.changes[0]?.impactSummary?.riskHints.length ?? 0) > 0, true);
 
   const stageAfter = await store.getStagedDraft();
   assert.equal(stageAfter, null);


### PR DESCRIPTION
## Summary
- add server-side config impact summary generation for tracked world and battle documents
- surface the summary after save in config-center and retain it in publish audit history
- cover the new summary payload with focused config-center tests and README usage notes

Closes #380