### PR TITLE
test: add reconnect convergence smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ npm run dev:client:h5
 - H5 开发态诊断导出：
   `window.export_diagnostic_snapshot()` 返回稳定 JSON；
   `window.render_diagnostic_snapshot_to_text()` 返回与面板一致的紧凑文本摘要，便于自动化留档
-- H5 / Lobby Playwright 冒烟：`npm run test:e2e:smoke`
+- H5 Playwright 冒烟：`npm run test:e2e:smoke`
+  当前覆盖 Lobby 入口与 reconnect predicted-state -> authoritative convergence canonical smoke
 - 打包 H5 客户端 RC 冒烟会把结构化结果写入 `artifacts/release-readiness/`
 - 多人联机 Playwright 冒烟：`npm run test:e2e:multiplayer:smoke`
 - 多人同步治理矩阵：`npm run test:sync-governance:matrix`（输出 `artifacts/release-readiness/sync-governance-matrix-<short-sha>.json`）

--- a/docs/reconnect-smoke-gate.md
+++ b/docs/reconnect-smoke-gate.md
@@ -13,20 +13,22 @@
 
 1. 进入同一个候选包对应的房间，确认 `roomId` 与 `playerId` 已显示。
 2. 在世界态先做一个可见且可回读的状态变化：
-   - 默认基线使用 `tests/e2e/reconnect-recovery.spec.ts` 的路径
+   - 默认基线使用 `tests/e2e/reconnect-prediction-convergence.spec.ts` 的路径
    - 角色从初始位置移动两次
    - 领取一次木材资源
 3. 在状态变化已经落地后，主动触发一次恢复动作：
    - 本地：刷新页面
    - RC：切后台再回前台、断网再恢复、刷新或重进前台容器，三选一即可
-4. 等待恢复完成，确认客户端回到原房间，并继续显示断线前已经发生的状态变化。
+4. 等待恢复完成，确认客户端先回放最近缓存状态，再收敛回原权威房间，并继续显示断线前已经发生的状态变化。
+5. 在恢复完成后再执行一个后续操作，确认房间不是停留在“看起来活着”的假恢复状态。
 
 这条门禁的目标不是证明“重新连上了 socket”而已，而是证明“重新连上后仍回到同一权威房间，且权威世界状态未丢”。
 
 ## Automation Reference
 
-- 本地 canonical smoke：`npm run test:e2e:smoke -- reconnect-recovery`
-- 覆盖用例：`tests/e2e/reconnect-recovery.spec.ts`
+- 本地 canonical smoke：`npm run test:e2e:smoke`
+- 单测例过滤：`npm run test:e2e:smoke -- reconnect-prediction-convergence`
+- 覆盖用例：`tests/e2e/reconnect-prediction-convergence.spec.ts`
 - 辅助多人 / 结算恢复参考：
   - `npm run test:e2e:multiplayer:smoke -- pvp-reconnect-recovery`
   - `npm run test:e2e:multiplayer:smoke -- pvp-postbattle-reconnect`
@@ -54,10 +56,14 @@
 
 1. `session-meta` 仍显示原 `roomId`。
 2. `event-log` 出现“连接已恢复”。
-3. 角色移动力没有重置，仍保留断线前的消耗结果。
+3. 恢复过程中可确认客户端确实回放过本地缓存，再等待权威状态完成校正。
+   - 当前基线值：event log 含 `已从本地缓存回放最近房间状态`
+4. 角色移动力没有重置，仍保留断线前的消耗结果。
    - 当前基线值：`Move 4/6`
-4. 世界状态没有回档。
+5. 世界状态没有回档。
    - 当前基线值：`Wood 5`
+6. 恢复后仍能继续执行一个新动作并得到权威结果。
+   - 当前基线值：再移动 1 步后变成 `Move 3/6`
 
 ### Release-Candidate Run
 

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  testMatch: /lobby-smoke\.spec\.ts/,
+  testMatch: /(lobby-smoke|reconnect-prediction-convergence)\.spec\.ts/,
   timeout: 30_000,
   fullyParallel: false,
   workers: 1,

--- a/tests/e2e/reconnect-prediction-convergence.spec.ts
+++ b/tests/e2e/reconnect-prediction-convergence.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+import {
+  buildRoomId,
+  expectHeroMoveSpent,
+  fullMoveTextPattern,
+  openRoom,
+  pressTile,
+  reloadAndExpectAuthoritativeConvergence,
+  withSmokeDiagnostics
+} from "./smoke-helpers";
+
+const PLAYER_ID = "player-1";
+
+test("reload replays predicted room state and converges back to the authoritative room before further actions", async (
+  { page },
+  testInfo
+) => {
+  const roomId = buildRoomId("e2e-reconnect-convergence");
+
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await test.step("setup: open the room and establish a visible world-state delta", async () => {
+      await openRoom(page, {
+        roomId,
+        playerId: PLAYER_ID,
+        expectedMoveText: fullMoveTextPattern(PLAYER_ID)
+      });
+
+      await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*0/);
+
+      await pressTile(page, 0, 1);
+      await expectHeroMoveSpent(page, 1, PLAYER_ID);
+
+      await pressTile(page, 0, 0);
+      await expectHeroMoveSpent(page, 2, PLAYER_ID);
+
+      await pressTile(page, 0, 0);
+      await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*5/);
+    });
+
+    await test.step("disconnect and reconnect: reload into cached replay and wait for authoritative convergence", async () => {
+      await reloadAndExpectAuthoritativeConvergence(page, {
+        roomId,
+        playerId: PLAYER_ID
+      });
+      await expectHeroMoveSpent(page, 2, PLAYER_ID);
+      await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*5/);
+    });
+
+    await test.step("post-reconnect: perform one more authoritative action", async () => {
+      await pressTile(page, 1, 0);
+      await expectHeroMoveSpent(page, 3, PLAYER_ID);
+      await expect(page.getByTestId("event-log")).toContainText("Moved 1 steps", { timeout: 10_000 });
+      await expect(page.getByTestId("room-next-action")).not.toContainText("等待权威");
+    });
+  });
+});

--- a/tests/e2e/smoke-helpers.ts
+++ b/tests/e2e/smoke-helpers.ts
@@ -112,6 +112,21 @@ export async function reloadAndExpectRecoveredSession(page: Page, options: Recon
   });
 }
 
+export async function reloadAndExpectAuthoritativeConvergence(page: Page, options: ReconnectOptions): Promise<void> {
+  await test.step(`reconnect: converge ${options.playerId} in ${options.roomId}`, async () => {
+    await waitForReconnectionToken(page, options);
+    await page.reload();
+    await expectRoomReady(page, {
+      ...options,
+      expectedMoveText: options.expectedMoveText ?? null
+    });
+    await expect(page.getByTestId("event-log")).toContainText("已从本地缓存回放最近房间状态", { timeout: 10_000 });
+    await expect(page.getByTestId("event-log")).toContainText("连接已恢复", { timeout: 10_000 });
+    await expect(page.getByTestId("room-recovery-summary")).toContainText("权威房间状态已恢复");
+    await expect(page.getByTestId("prediction-status")).toHaveCount(0);
+  });
+}
+
 interface SettlementRecoveryExpectations {
   phase: string;
   recoverySummaryIncludes: string[];


### PR DESCRIPTION
## Summary
- add a focused e2e reconnect smoke that proves cached replay -> authoritative convergence before allowing post-reconnect actions
- wire the reconnect smoke into the existing `test:e2e:smoke` lane and refresh reconnect gate docs/README to match the actual command path
- keep failure diagnostics on Playwright traces plus page/server smoke attachments through the existing smoke helper path

## Validation
- `npm run validate:e2e:fixtures`
- `npx playwright test --config=playwright.smoke.config.ts --list`
- `node --import tsx --test apps/client/test/main-session-runtime.test.ts`
- `node --import tsx --test apps/client/test/room-feedback.test.ts`
- `npm run typecheck:client:h5`
- `npm run test:e2e:smoke -- reconnect-prediction-convergence` (blocked in this environment: Playwright Chromium failed to launch because `libatk-bridge-2.0.so.0` is missing)

Closes #379