### PR TITLE
test(cocos): add unit harness for prediction planning

### DIFF
--- a/apps/cocos-client/test/cocos-prediction.test.ts
+++ b/apps/cocos-client/test/cocos-prediction.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { predictPlayerWorldAction } from "../assets/scripts/cocos-prediction.ts";
+import {
+  createPredictionWorld,
+  placeOwnHero,
+  updateTile,
+  withOccupant
+} from "./helpers/cocos-prediction-harness.ts";
+
+test("predictPlayerWorldAction plans a reachable move and updates hero position, occupancy and remaining reachability", () => {
+  const world = createPredictionWorld();
+
+  const prediction = predictPlayerWorldAction(world, {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 }
+  });
+
+  assert.equal(prediction.reason, undefined);
+  assert.deepEqual(prediction.movementPlan, {
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 },
+    path: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 2, y: 0 }],
+    travelPath: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 2, y: 0 }],
+    moveCost: 2,
+    endsInEncounter: false,
+    encounterKind: "none"
+  });
+  assert.deepEqual(prediction.world.ownHeroes[0]?.position, { x: 2, y: 0 });
+  assert.equal(prediction.world.ownHeroes[0]?.move.remaining, 4);
+  assert.equal(prediction.world.map.tiles[0]?.occupant, undefined);
+  assert.deepEqual(prediction.world.map.tiles[2]?.occupant, {
+    kind: "hero",
+    refId: "hero-1"
+  });
+  assert.deepEqual(prediction.reachableTiles, [
+    { x: 0, y: 0 },
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+    { x: 3, y: 0 },
+    { x: 0, y: 1 },
+    { x: 1, y: 1 },
+    { x: 2, y: 1 },
+    { x: 3, y: 1 },
+    { x: 0, y: 2 },
+    { x: 1, y: 2 },
+    { x: 2, y: 2 },
+    { x: 3, y: 2 }
+  ]);
+});
+
+test("predictPlayerWorldAction stops short of neutral encounters and leaves no predicted occupant on the contested tile", () => {
+  const world = withOccupant(
+    createPredictionWorld(),
+    { x: 2, y: 0 },
+    { kind: "neutral", refId: "neutral-1" }
+  );
+
+  const prediction = predictPlayerWorldAction(world, {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 }
+  });
+
+  assert.equal(prediction.reason, undefined);
+  assert.deepEqual(prediction.movementPlan, {
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 },
+    path: [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 2, y: 0 }],
+    travelPath: [{ x: 0, y: 0 }, { x: 1, y: 0 }],
+    moveCost: 1,
+    endsInEncounter: true,
+    encounterKind: "neutral",
+    encounterRefId: "neutral-1"
+  });
+  assert.deepEqual(prediction.world.ownHeroes[0]?.position, { x: 1, y: 0 });
+  assert.equal(prediction.world.map.tiles[1]?.occupant, undefined);
+  assert.deepEqual(prediction.world.map.tiles[2]?.occupant, {
+    kind: "neutral",
+    refId: "neutral-1"
+  });
+  assert.deepEqual(prediction.reachableTiles, []);
+});
+
+test("predictPlayerWorldAction rejects destinations blocked by owned heroes or visible enemy heroes when no alternate path exists", () => {
+  let world = createPredictionWorld();
+  world = placeOwnHero(world, {
+    id: "hero-2",
+    playerId: world.playerId,
+    name: "Second",
+    position: { x: 1, y: 0 }
+  });
+  world = updateTile(world, { x: 0, y: 1 }, { walkable: false });
+  world = updateTile(world, { x: 1, y: 1 }, { walkable: false });
+
+  const ownHeroBlocked = predictPlayerWorldAction(world, {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 }
+  });
+
+  assert.equal(ownHeroBlocked.reason, "path_not_found");
+  assert.equal(ownHeroBlocked.movementPlan, null);
+  assert.deepEqual(ownHeroBlocked.reachableTiles, []);
+
+  const enemyBlockedWorld = updateTile(
+    createPredictionWorld({
+      visibleHeroes: [
+        {
+          id: "enemy-1",
+          playerId: "player-2",
+          name: "Invader",
+          position: { x: 1, y: 0 }
+        }
+      ]
+    }),
+    { x: 0, y: 1 },
+    { walkable: false }
+  );
+  const sealedEnemyBlockedWorld = updateTile(enemyBlockedWorld, { x: 1, y: 1 }, { walkable: false });
+
+  const enemyBlocked = predictPlayerWorldAction(sealedEnemyBlockedWorld, {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 }
+  });
+
+  assert.equal(enemyBlocked.reason, "path_not_found");
+  assert.equal(enemyBlocked.movementPlan, null);
+  assert.deepEqual(enemyBlocked.reachableTiles, []);
+});
+
+test("predictPlayerWorldAction reports move-point exhaustion after planning a valid route", () => {
+  const world = createPredictionWorld({ moveRemaining: 1 });
+
+  const prediction = predictPlayerWorldAction(world, {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 }
+  });
+
+  assert.equal(prediction.reason, "not_enough_move_points");
+  assert.equal(prediction.movementPlan, null);
+  assert.deepEqual(prediction.reachableTiles, []);
+  assert.deepEqual(prediction.world.ownHeroes[0]?.position, { x: 0, y: 0 });
+});

--- a/apps/cocos-client/test/helpers/cocos-prediction-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-prediction-harness.ts
@@ -1,0 +1,126 @@
+import type { HeroView, OccupantState, PlayerTileView, PlayerWorldView, Vec2 } from "../../assets/scripts/VeilCocosSession.ts";
+import { createSessionUpdate } from "./cocos-session-fixtures.ts";
+
+export function createPredictionWorld(options?: {
+  width?: number;
+  height?: number;
+  heroPosition?: Vec2;
+  moveRemaining?: number;
+  visibleHeroes?: PlayerWorldView["visibleHeroes"];
+}) : PlayerWorldView {
+  const baseWorld = createSessionUpdate().world;
+  const width = options?.width ?? 4;
+  const height = options?.height ?? 3;
+  const heroPosition = options?.heroPosition ?? { x: 0, y: 0 };
+  const moveRemaining = options?.moveRemaining ?? 6;
+
+  const tiles: PlayerTileView[] = [];
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      tiles.push({
+        position: { x, y },
+        fog: "visible",
+        terrain: "grass",
+        walkable: true,
+        resource: undefined,
+        occupant: undefined,
+        building: undefined
+      });
+    }
+  }
+
+  const hero: HeroView = {
+    ...baseWorld.ownHeroes[0]!,
+    position: { ...heroPosition },
+    move: {
+      ...baseWorld.ownHeroes[0]!.move,
+      remaining: moveRemaining
+    }
+  };
+
+  setTileOccupant(tiles, width, heroPosition, {
+    kind: "hero",
+    refId: hero.id
+  });
+
+  return {
+    ...baseWorld,
+    map: {
+      width,
+      height,
+      tiles
+    },
+    ownHeroes: [hero],
+    visibleHeroes: options?.visibleHeroes?.map((item) => ({
+      ...item,
+      position: { ...item.position }
+    })) ?? []
+  };
+}
+
+export function updateTile(
+  world: PlayerWorldView,
+  position: Vec2,
+  update: Partial<PlayerTileView>
+): PlayerWorldView {
+  return {
+    ...world,
+    map: {
+      ...world.map,
+      tiles: world.map.tiles.map((tile) =>
+        samePosition(tile.position, position)
+          ? {
+              ...tile,
+              ...update
+            }
+          : tile
+      )
+    }
+  };
+}
+
+export function placeOwnHero(world: PlayerWorldView, hero: Pick<HeroView, "id" | "playerId" | "name" | "position">): PlayerWorldView {
+  const template = world.ownHeroes[0]!;
+  return {
+    ...world,
+    ownHeroes: [
+      ...world.ownHeroes,
+      {
+        ...template,
+        id: hero.id,
+        playerId: hero.playerId,
+        name: hero.name,
+        position: { ...hero.position }
+      }
+    ],
+    map: {
+      ...world.map,
+      tiles: setTileOccupant(world.map.tiles, world.map.width, hero.position, {
+        kind: "hero",
+        refId: hero.id
+      })
+    }
+  };
+}
+
+export function withOccupant(world: PlayerWorldView, position: Vec2, occupant: OccupantState | undefined): PlayerWorldView {
+  return updateTile(world, position, { occupant });
+}
+
+function setTileOccupant(
+  tiles: PlayerTileView[],
+  width: number,
+  position: Vec2,
+  occupant: OccupantState
+): PlayerTileView[] {
+  const index = position.y * width + position.x;
+  tiles[index] = {
+    ...tiles[index]!,
+    occupant
+  };
+  return tiles;
+}
+
+function samePosition(a: Vec2, b: Vec2): boolean {
+  return a.x === b.x && a.y === b.y;
+}


### PR DESCRIPTION
## Summary
- add a reusable Cocos prediction-world test harness for focused client-side planning scenarios
- cover representative movement planning cases for normal travel, encounter stop-short behavior, blocking, and move-point exhaustion
- keep failures easy to diagnose with explicit path, occupancy, and reachability assertions

## Testing
- node --import tsx --test apps/cocos-client/test/cocos-prediction.test.ts
- npm run typecheck:cocos

Closes #384