### PR TITLE
chore(config): wire frontier-basin and phase2 map configs into content-pack validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "validate:quickstart": "node ./scripts/validate-local-dev-quickstart.mjs",
     "validate:e2e:fixtures": "node --import tsx ./scripts/validate-e2e-config-fixtures.ts",
     "validate:content-pack": "node --import tsx ./scripts/validate-content-pack.ts",
+    "validate:content-pack:all": "node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack phase2",
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
     "stress:rooms:baseline": "node --import tsx ./scripts/stress-concurrent-rooms.ts --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --artifact-path=artifacts/release-readiness/stress-rooms-runtime-metrics.json",
     "stress:rooms:reconnect-soak": "node --import tsx ./scripts/stress-concurrent-rooms.ts --scenarios=reconnect_soak --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --reconnect-cycles=8",

--- a/scripts/content-pack-map-packs.ts
+++ b/scripts/content-pack-map-packs.ts
@@ -1,0 +1,36 @@
+export interface ContentPackMapPackDefinition {
+  id: string;
+  worldFileName: string;
+  mapObjectsFileName: string;
+  aliases?: string[];
+}
+
+export const DEFAULT_CONTENT_PACK_MAP_PACK: ContentPackMapPackDefinition = {
+  id: "default",
+  worldFileName: "phase1-world.json",
+  mapObjectsFileName: "phase1-map-objects.json"
+};
+
+export const EXTRA_CONTENT_PACK_MAP_PACKS: ContentPackMapPackDefinition[] = [
+  {
+    id: "frontier-basin",
+    worldFileName: "phase1-world-frontier-basin.json",
+    mapObjectsFileName: "phase1-map-objects-frontier-basin.json",
+    aliases: ["frontier_basin"]
+  },
+  {
+    id: "phase2",
+    worldFileName: "phase2-contested-basin.json",
+    mapObjectsFileName: "phase2-map-objects-contested-basin.json",
+    aliases: ["contested-basin", "contested_basin", "phase2-contested-basin"]
+  }
+];
+
+export function resolveExtraContentPackMapPack(id: string): ContentPackMapPackDefinition | undefined {
+  const normalized = id.trim().toLowerCase();
+  return EXTRA_CONTENT_PACK_MAP_PACKS.find(
+    (definition) =>
+      definition.id === normalized ||
+      definition.aliases?.some((alias) => alias === normalized)
+  );
+}

--- a/scripts/test/validate-content-pack.test.ts
+++ b/scripts/test/validate-content-pack.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const configsDir = join(repoRoot, "configs");
+const scriptPath = join(repoRoot, "scripts", "validate-content-pack.ts");
+
+async function copyConfigFixture(tempDir: string, fileName: string): Promise<void> {
+  const content = await readFile(join(configsDir, fileName), "utf8");
+  await writeFile(join(tempDir, fileName), content, "utf8");
+}
+
+async function seedContentPackRoot(tempDir: string): Promise<void> {
+  await Promise.all(
+    [
+      "phase1-world.json",
+      "phase1-map-objects.json",
+      "phase1-world-frontier-basin.json",
+      "phase1-map-objects-frontier-basin.json",
+      "phase2-contested-basin.json",
+      "phase2-map-objects-contested-basin.json",
+      "units.json",
+      "battle-skills.json",
+      "battle-balance.json"
+    ].map((fileName) => copyConfigFixture(tempDir, fileName))
+  );
+}
+
+test("validate-content-pack validates all shipped map packs with CLI presets", async () => {
+  const { stdout } = await execFileAsync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      scriptPath,
+      "--root-dir",
+      configsDir,
+      "--map-pack",
+      "frontier-basin",
+      "--map-pack",
+      "phase2"
+    ],
+    { cwd: repoRoot }
+  );
+
+  assert.match(stdout, /Bundles: 3/);
+  assert.match(stdout, /Bundle: frontier-basin/);
+  assert.match(stdout, /Bundle: phase2/);
+  assert.match(stdout, /Result: PASS/);
+});
+
+test("validate-content-pack fails when an extra map pack has cross-file consistency errors", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "veil-content-pack-"));
+  await seedContentPackRoot(tempDir);
+
+  const frontierWorldPath = join(tempDir, "phase1-world-frontier-basin.json");
+  const frontierWorld = JSON.parse(await readFile(frontierWorldPath, "utf8")) as {
+    heroes: Array<{ armyTemplateId: string }>;
+  };
+  frontierWorld.heroes[0] = {
+    ...frontierWorld.heroes[0],
+    armyTemplateId: "missing_template"
+  };
+  await writeFile(frontierWorldPath, `${JSON.stringify(frontierWorld, null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    execFileAsync(
+      "node",
+      [
+        "--import",
+        "tsx",
+        scriptPath,
+        "--root-dir",
+        tempDir,
+        "--map-pack",
+        "frontier-basin"
+      ],
+      { cwd: repoRoot }
+    ),
+    (error: NodeJS.ErrnoException & { stdout?: string }) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stdout ?? "", /Bundle: frontier-basin/);
+      assert.match(error.stdout ?? "", /\[world\] heroes\[0\]\.armyTemplateId/);
+      return true;
+    }
+  );
+});

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -17,22 +17,27 @@ import {
   type UnitCatalogConfig,
   type WorldGenerationConfig
 } from "../packages/shared/src/index.ts";
-
-interface DocumentDefinition {
-  id: ContentPackDocumentId;
-  fileName: string;
-}
+import {
+  DEFAULT_CONTENT_PACK_MAP_PACK,
+  resolveExtraContentPackMapPack,
+  type ContentPackMapPackDefinition
+} from "./content-pack-map-packs.ts";
 
 interface DocumentValidationIssue {
+  bundleId: string;
   documentId: ContentPackDocumentId;
   path: string;
   message: string;
 }
 
-interface ContentPackCliReport {
-  schemaVersion: 1;
-  generatedAt: string;
-  rootDir: string;
+interface BundleContentPackValidationIssue extends ContentPackValidationIssue {
+  bundleId: string;
+}
+
+interface BundleValidationReport {
+  id: string;
+  worldFileName: string;
+  mapObjectsFileName: string;
   valid: boolean;
   documentValidation: {
     valid: boolean;
@@ -43,21 +48,38 @@ interface ContentPackCliReport {
     valid: boolean;
     issueCount: number;
     summary: string;
-    issues: ContentPackValidationIssue[];
+    issues: BundleContentPackValidationIssue[];
   };
 }
 
-const DOCUMENTS: DocumentDefinition[] = [
-  { id: "world", fileName: "phase1-world.json" },
-  { id: "mapObjects", fileName: "phase1-map-objects.json" },
-  { id: "units", fileName: "units.json" },
-  { id: "battleSkills", fileName: "battle-skills.json" },
-  { id: "battleBalance", fileName: "battle-balance.json" }
-];
+interface ContentPackCliReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  rootDir: string;
+  valid: boolean;
+  bundleCount: number;
+  documentValidation: {
+    valid: boolean;
+    issueCount: number;
+    issues: DocumentValidationIssue[];
+  };
+  contentPack: {
+    valid: boolean;
+    issueCount: number;
+    summary: string;
+    issues: BundleContentPackValidationIssue[];
+  };
+  bundles: BundleValidationReport[];
+}
 
-function parseArgs(argv: string[]): { rootDir: string; reportPath: string | null } {
+function parseArgs(argv: string[]): {
+  rootDir: string;
+  reportPath: string | null;
+  extraMapPacks: ContentPackMapPackDefinition[];
+} {
   let rootDir = resolve(process.cwd(), "configs");
   let reportPath: string | null = null;
+  const extraMapPacks: ContentPackMapPackDefinition[] = [];
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -67,17 +89,25 @@ function parseArgs(argv: string[]): { rootDir: string; reportPath: string | null
     } else if (arg === "--report-path") {
       reportPath = resolve(argv[index + 1] ?? "");
       index += 1;
+    } else if (arg === "--map-pack") {
+      const presetId = argv[index + 1] ?? "";
+      const definition = resolveExtraContentPackMapPack(presetId);
+      if (!definition) {
+        throw new Error(`Unknown map pack "${presetId}". Supported values: frontier-basin, phase2.`);
+      }
+      extraMapPacks.push(definition);
+      index += 1;
     }
   }
 
-  return { rootDir, reportPath };
+  return { rootDir, reportPath, extraMapPacks };
 }
 
 async function readJsonConfig<T>(rootDir: string, fileName: string): Promise<T> {
   return JSON.parse(await readFile(resolve(rootDir, fileName), "utf8")) as T;
 }
 
-function validateDocuments(bundle: RuntimeConfigBundle): DocumentValidationIssue[] {
+function validateDocuments(bundleId: string, bundle: RuntimeConfigBundle): DocumentValidationIssue[] {
   const issues: DocumentValidationIssue[] = [];
 
   const capture = (documentId: ContentPackDocumentId, path: string, callback: () => void) => {
@@ -85,6 +115,7 @@ function validateDocuments(bundle: RuntimeConfigBundle): DocumentValidationIssue
       callback();
     } catch (error) {
       issues.push({
+        bundleId,
         documentId,
         path,
         message: error instanceof Error ? error.message : "Unknown validation error"
@@ -115,49 +146,92 @@ function printIssues(title: string, issues: Array<{ documentId: string; path: st
   }
 }
 
-async function main(): Promise<void> {
-  const { rootDir, reportPath } = parseArgs(process.argv.slice(2));
+async function loadBundle(rootDir: string, definition: ContentPackMapPackDefinition): Promise<RuntimeConfigBundle> {
   const [world, mapObjects, units, battleSkills, battleBalance] = await Promise.all([
-    readJsonConfig<WorldGenerationConfig>(rootDir, "phase1-world.json"),
-    readJsonConfig<MapObjectsConfig>(rootDir, "phase1-map-objects.json"),
+    readJsonConfig<WorldGenerationConfig>(rootDir, definition.worldFileName),
+    readJsonConfig<MapObjectsConfig>(rootDir, definition.mapObjectsFileName),
     readJsonConfig<UnitCatalogConfig>(rootDir, "units.json"),
     readJsonConfig<BattleSkillCatalogConfig>(rootDir, "battle-skills.json"),
     readJsonConfig<BattleBalanceConfig>(rootDir, "battle-balance.json")
   ]);
 
-  const bundle: RuntimeConfigBundle = {
+  return {
     world,
     mapObjects,
     units,
     battleSkills,
     battleBalance
   };
+}
 
-  const documentIssues = validateDocuments(bundle);
-  const contentPack = validateContentPackConsistency(bundle);
+async function main(): Promise<void> {
+  const { rootDir, reportPath, extraMapPacks } = parseArgs(process.argv.slice(2));
+  const bundleDefinitions = [DEFAULT_CONTENT_PACK_MAP_PACK, ...extraMapPacks];
+  const bundles = await Promise.all(
+    bundleDefinitions.map(async (definition): Promise<BundleValidationReport> => {
+      const bundle = await loadBundle(rootDir, definition);
+      const documentIssues = validateDocuments(definition.id, bundle);
+      const contentPack = validateContentPackConsistency(bundle);
+
+      return {
+        id: definition.id,
+        worldFileName: definition.worldFileName,
+        mapObjectsFileName: definition.mapObjectsFileName,
+        valid: documentIssues.length === 0 && contentPack.valid,
+        documentValidation: {
+          valid: documentIssues.length === 0,
+          issueCount: documentIssues.length,
+          issues: documentIssues
+        },
+        contentPack: {
+          valid: contentPack.valid,
+          issueCount: contentPack.issueCount,
+          summary: contentPack.summary,
+          issues: contentPack.issues.map((issue) => ({
+            ...issue,
+            bundleId: definition.id
+          }))
+        }
+      };
+    })
+  );
+
+  const documentIssues = bundles.flatMap((bundle) => bundle.documentValidation.issues);
+  const contentPackIssues = bundles.flatMap((bundle) => bundle.contentPack.issues);
   const report: ContentPackCliReport = {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
     rootDir,
-    valid: documentIssues.length === 0 && contentPack.valid,
+    valid: bundles.every((bundle) => bundle.valid),
+    bundleCount: bundles.length,
     documentValidation: {
       valid: documentIssues.length === 0,
       issueCount: documentIssues.length,
       issues: documentIssues
     },
     contentPack: {
-      valid: contentPack.valid,
-      issueCount: contentPack.issueCount,
-      summary: contentPack.summary,
-      issues: contentPack.issues
-    }
+      valid: contentPackIssues.length === 0,
+      issueCount: contentPackIssues.length,
+      summary:
+        contentPackIssues.length === 0
+          ? `Content-pack consistency passed across ${bundles.length} validated bundle(s).`
+          : `Found ${contentPackIssues.length} content-pack consistency issue(s) across ${bundles.length} validated bundle(s).`,
+      issues: contentPackIssues
+    },
+    bundles
   };
 
   console.log("Project Veil content-pack validation");
   console.log(`Root: ${rootDir}`);
+  console.log(`Bundles: ${report.bundleCount}`);
   console.log(`Result: ${report.valid ? "PASS" : "FAIL"}`);
-  printIssues("Per-document validation", report.documentValidation.issues);
-  printIssues("Content-pack consistency", report.contentPack.issues);
+  for (const bundle of report.bundles) {
+    console.log(
+      `Bundle: ${bundle.id} (${bundle.worldFileName} + ${bundle.mapObjectsFileName})`
+    );
+    printIssues("Per-document validation", bundle.documentValidation.issues);
+    printIssues("Content-pack consistency", bundle.contentPack.issues);
+  }
 
   if (reportPath) {
     await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");

--- a/scripts/validate-e2e-config-fixtures.ts
+++ b/scripts/validate-e2e-config-fixtures.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   e2eConfigFixtures,
   getHeroMoveTotal,
@@ -8,15 +10,28 @@ import {
   getShrineVisitLogText,
   validateE2EConfigFixtures
 } from "../tests/e2e/config-fixtures.ts";
+import { EXTRA_CONTENT_PACK_MAP_PACKS } from "./content-pack-map-packs.ts";
+
+function validateAdditionalMapPackFixtures(): void {
+  for (const definition of EXTRA_CONTENT_PACK_MAP_PACKS) {
+    for (const fileName of [definition.worldFileName, definition.mapObjectsFileName]) {
+      JSON.parse(readFileSync(resolve(process.cwd(), "configs", fileName), "utf8")) as unknown;
+    }
+  }
+}
 
 function main(): void {
   validateE2EConfigFixtures();
+  validateAdditionalMapPackFixtures();
 
   const reward = getNeutralBattleReward();
   const recruitmentCost = getRecruitmentCost();
 
   console.log(
     `[validate:e2e-config-fixtures] loaded heroes=${e2eConfigFixtures.world.heroes.length} buildings=${e2eConfigFixtures.mapObjects.buildings.length} neutralArmies=${e2eConfigFixtures.mapObjects.neutralArmies.length}`
+  );
+  console.log(
+    `[validate:e2e-config-fixtures] additional map packs=${EXTRA_CONTENT_PACK_MAP_PACKS.map((definition) => definition.id).join(", ")}`
   );
   console.log(
     `[validate:e2e-config-fixtures] player-1 move=${getHeroMoveTotal()} recruitCount=${getRecruitmentCount()} recruitGold=${recruitmentCost.gold} mineIncome=${getMineIncome()} shrine="${getShrineVisitLogText()}" battleReward=${reward.kind}+${reward.amount}`


### PR DESCRIPTION
## Summary
- add shared extra map-pack definitions for the shipped frontier-basin and phase2 bundles
- extend the content-pack validator CLI with --map-pack presets and add npm run validate:content-pack:all
- keep e2e fixture validation aware of the extra map config files and add a focused CLI test

Closes #387
