### PR TITLE
Add Cocos runtime boot/reconnect coverage

### DIFF
--- a/apps/cocos-client/test/cocos-session-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-session-orchestration.test.ts
@@ -6,6 +6,7 @@ import {
   VeilCocosSession
 } from "../assets/scripts/VeilCocosSession.ts";
 import {
+  createReachableReply,
   createRawStateReply,
   createMemoryStorage,
   createSdkLoader,
@@ -49,6 +50,12 @@ function createEncodedStatePayload(options?: {
     movementPlan: null,
     reachableTiles: [{ x: 0, y: 0 }]
   };
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
 }
 
 test("VeilCocosSession reuses a stored reconnection token and announces recovery", async () => {
@@ -186,6 +193,53 @@ test("VeilCocosSession hands off to a fresh room after reconnect failure and rep
     { logicalRoomId: "room-alpha", playerId: "player-1", seed: 1001 }
   ]);
   assert.equal(storage.getItem("project-veil:cocos:reconnection:room-alpha:player-1"), "recovered-token");
+
+  await session.dispose();
+});
+
+test("VeilCocosSession retries a recoverable reachable query after reconnect handoff", async () => {
+  const storage = createMemoryStorage();
+  const initialRoom = new FakeColyseusRoom([createSessionUpdate(2)], "initial-token");
+  const recoveredRoom = new FakeColyseusRoom(
+    [createSessionUpdate(6)],
+    "recovered-token",
+    {
+      "world.reachable": [createReachableReply([{ x: 1, y: 0 }, { x: 1, y: 1 }])]
+    }
+  );
+  const events: string[] = [];
+  const pushedDays: number[] = [];
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    wait: async () => undefined,
+    loadSdk: createSdkLoader({
+      joinRooms: [initialRoom, recoveredRoom]
+    })
+  });
+
+  const session = await VeilCocosSession.create("room-alpha", "player-1", 1001, {
+    onConnectionEvent: (event) => {
+      events.push(event);
+    },
+    onPushUpdate: (update) => {
+      pushedDays.push(update.world.meta.day);
+    }
+  });
+
+  await session.snapshot();
+
+  const reachablePromise = session.listReachable("hero-1");
+  await flushMicrotasks();
+  initialRoom.emitLeave(4002);
+
+  const reachableTiles = await reachablePromise;
+
+  assert.deepEqual(reachableTiles, [{ x: 1, y: 0 }, { x: 1, y: 1 }]);
+  assert.deepEqual(events, ["reconnect_failed", "reconnected"]);
+  assert.deepEqual(pushedDays, [6]);
+  assert.equal(storage.getItem("project-veil:cocos:reconnection:room-alpha:player-1"), "recovered-token");
+  assert.deepEqual(recoveredRoom.sentMessages.map((entry) => entry.type), ["connect", "world.reachable"]);
 
   await session.dispose();
 });

--- a/apps/cocos-client/test/cocos-veil-root.test.ts
+++ b/apps/cocos-client/test/cocos-veil-root.test.ts
@@ -158,6 +158,37 @@ test("VeilRoot warm boot reuses the stored account session and cached replay dur
   assert.equal(root.lastUpdate?.world.meta.day, 3);
 });
 
+test("VeilRoot warm boot keeps direct room resume in auto-connect mode", () => {
+  const storage = createMemoryStorage();
+  storage.setItem(
+    "project-veil:auth-session",
+    JSON.stringify({
+      token: "resume.token",
+      playerId: "account-player",
+      displayName: "雾林司灯",
+      authMode: "account",
+      provider: "account-password",
+      loginId: "veil-ranger",
+      source: "remote"
+    })
+  );
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+
+  const root = createVeilRootHarness();
+  root.autoConnect = true;
+  root.readLaunchSearch = () => "?roomId=room-resume";
+
+  root.hydrateLaunchIdentity();
+
+  assert.equal(root.showLobby, false);
+  assert.equal(root.autoConnect, true);
+  assert.equal(root.roomId, "room-resume");
+  assert.equal(root.playerId, "account-player");
+  assert.equal(root.displayName, "雾林司灯");
+  assert.equal(root.authToken, "resume.token");
+  assert.equal(root.sessionSource, "remote");
+});
+
 test("VeilRoot memory warnings request GC and surface the warning in HUD state", () => {
   const root = createVeilRootHarness();
   let memoryWarningHandler: ((payload?: { level?: number } | null) => void) | null = null;

--- a/apps/cocos-client/test/helpers/cocos-session-fixtures.ts
+++ b/apps/cocos-client/test/helpers/cocos-session-fixtures.ts
@@ -8,6 +8,10 @@ type FakeRoomReply =
       delivery?: "reply" | "push";
     }
   | {
+      kind: "reachable";
+      reachableTiles: Array<{ x: number; y: number }>;
+    }
+  | {
       kind: "error";
       reason: string;
     };
@@ -173,21 +177,36 @@ export function createErrorReply(reason: string): FakeRoomReply {
   };
 }
 
+export function createReachableReply(reachableTiles: Array<{ x: number; y: number }>): FakeRoomReply {
+  return {
+    kind: "reachable",
+    reachableTiles
+  };
+}
+
 type MessageHandler = (type: string, payload: unknown) => void;
 
 export class FakeColyseusRoom {
   reconnectionToken?: string;
   readonly sentMessages: Array<{ type: string; payload: unknown }> = [];
   readonly connectReplies: FakeRoomReply[];
+  readonly requestReplies: Partial<Record<string, FakeRoomReply[]>>;
   leaveCalls = 0;
   private messageHandler: MessageHandler | null = null;
   private dropHandler: (() => void) | null = null;
   private reconnectHandler: (() => void) | null = null;
   private leaveHandler: ((code: number) => void) | null = null;
 
-  constructor(connectReplies: FakeRoomReply[], reconnectionToken?: string) {
+  constructor(
+    connectReplies: FakeRoomReply[],
+    reconnectionToken?: string,
+    requestReplies: Partial<Record<string, FakeRoomReply[]>> = {}
+  ) {
     this.connectReplies = [...connectReplies];
     this.reconnectionToken = reconnectionToken;
+    this.requestReplies = Object.fromEntries(
+      Object.entries(requestReplies).map(([type, replies]) => [type, [...replies]])
+    );
   }
 
   onMessage(_type: string, callback: MessageHandler): void {
@@ -213,24 +232,28 @@ export class FakeColyseusRoom {
 
   send(type: string, payload: { requestId: string }): void {
     this.sentMessages.push({ type, payload });
-    if (type === "connect") {
-      const reply = this.connectReplies.shift();
-      if (!reply) {
-        throw new Error("missing_connect_reply");
-      }
+    const replies = type === "connect" ? this.connectReplies : this.requestReplies[type];
+    const reply = replies?.shift();
+    if (!reply) {
+      return;
+    }
 
-      if ("kind" in reply) {
-        if (reply.kind === "error") {
-          this.emitError(payload.requestId, reply.reason);
-          return;
-        }
-
-        this.emitState(reply.payload, reply.delivery ?? "reply", payload.requestId);
+    if ("kind" in reply) {
+      if (reply.kind === "error") {
+        this.emitError(payload.requestId, reply.reason);
         return;
       }
 
-      this.emitState(toSessionStatePayload(reply), "reply", payload.requestId);
+      if (reply.kind === "reachable") {
+        this.emitReachable(payload.requestId, reply.reachableTiles);
+        return;
+      }
+
+      this.emitState(reply.payload, reply.delivery ?? "reply", payload.requestId);
+      return;
     }
+
+    this.emitState(toSessionStatePayload(reply), "reply", payload.requestId);
   }
 
   emitPush(update: SessionUpdate): void {
@@ -251,6 +274,14 @@ export class FakeColyseusRoom {
       type: "error",
       requestId,
       reason
+    });
+  }
+
+  emitReachable(requestId: string, reachableTiles: Array<{ x: number; y: number }>): void {
+    this.messageHandler?.("world.reachable", {
+      type: "world.reachable",
+      requestId,
+      reachableTiles
     });
   }
 


### PR DESCRIPTION
Closes #393

## Summary
- add a small fake Colyseus request-reply seam for deterministic non-connect runtime requests
- cover VeilCocosSession reconnect handoff while retrying an in-flight reachable query
- cover VeilRoot warm-boot identity hydration for direct room resume and keep the existing replay-based reconnect recovery path under test

## Testing
- node --import tsx --test apps/cocos-client/test/cocos-veil-root.test.ts apps/cocos-client/test/cocos-session-orchestration.test.ts
- npm run typecheck:cocos