### PR TITLE
test(cocos): cover VeilRoot and session startup orchestration

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -1520,6 +1520,8 @@ export function setVeilCocosSessionRuntimeForTests(runtime: {
   loadSdk?: (() => Promise<ColyseusSdkRuntime>) | null;
   wait?: ((ms: number) => Promise<void>) | null;
 }): void {
+  // Keep the session state machine real in tests; only storage, SDK loading,
+  // and retry timing are swapped so reconnect orchestration stays exercised.
   if ("storage" in runtime) {
     testStorageOverride = runtime.storage;
   }

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -3082,6 +3082,8 @@ export class VeilRoot extends Component {
 }
 
 export function setVeilRootRuntimeForTests(runtime: Partial<VeilRootRuntime>): void {
+  // Tests only replace transport/persistence edges here so the VeilRoot boot,
+  // reconnect, and handoff orchestration still runs through the production code.
   testVeilRootRuntimeOverrides = {
     ...testVeilRootRuntimeOverrides,
     ...runtime

--- a/apps/cocos-client/test/cocos-runtime-harness.test.ts
+++ b/apps/cocos-client/test/cocos-runtime-harness.test.ts
@@ -236,15 +236,29 @@ test("Cocos lifecycle harness recovers VeilRoot through VeilCocosSession reconne
   };
 
   await harness.root.connect();
+  const connectedSession = harness.root.session;
   initialRoom.emitLeave(4002);
   await flushMicrotasks();
 
   assert.deepEqual(order, ["replay:2", "live:3", "live:5"]);
+  assert.equal(harness.root.session, connectedSession);
   assert.equal(harness.root.lastUpdate?.world.meta.day, 5);
   assert.equal(harness.root.diagnosticsConnectionStatus, "connected");
   assert.deepEqual(harness.joinedOptions, [
     { logicalRoomId: "room-recover", playerId: "player-349", seed: 1001 },
     { logicalRoomId: "room-recover", playerId: "player-349", seed: 1001 }
+  ]);
+  assert.deepEqual(recoveredRoom.sentMessages, [
+    {
+      type: "connect",
+      payload: {
+        type: "connect",
+        requestId: "cocos-req-1",
+        roomId: "room-recover",
+        playerId: "player-349",
+        displayName: "Player 349"
+      }
+    }
   ]);
   assert.equal(
     harness.storage.getItem("project-veil:cocos:reconnection:room-recover:player-349"),

--- a/apps/cocos-client/test/helpers/cocos-runtime-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-runtime-harness.ts
@@ -82,6 +82,8 @@ export function createVeilCocosSessionRuntimeHarness(options?: {
   reconnectRooms?: FakeColyseusRoom[];
   wait?: (() => Promise<void>) | null;
 }) {
+  // Uses the real VeilCocosSession runtime with fake storage/Colyseus rooms so
+  // lifecycle tests exercise snapshot persistence and reconnect handoff logic.
   const storage = options?.storage ?? createMemoryStorage();
   const reconnectTokens: string[] = [];
   const endpoints: string[] = [];
@@ -126,6 +128,9 @@ export function createVeilRootSessionLifecycleHarness(options?: {
     source: "remote" | "local";
   } | null;
 }) {
+  // This is the closest CI harness to a Cocos client launch: VeilRoot uses the
+  // real VeilCocosSession orchestration, while only storage/network boundaries
+  // are faked to avoid needing a live editor/runtime session.
   const storage = options?.storage ?? createMemoryStorage();
   const reconnectTokens: string[] = [];
   const endpoints: string[] = [];

--- a/apps/cocos-client/test/helpers/veil-root-harness.ts
+++ b/apps/cocos-client/test/helpers/veil-root-harness.ts
@@ -6,6 +6,8 @@ import {
 import type { SessionUpdate } from "../../assets/scripts/VeilCocosSession.ts";
 
 export function createVeilRootHarness(): VeilRoot & Record<string, unknown> {
+  // This harness keeps VeilRoot's startup/reconnect logic intact while stubbing
+  // only engine-facing rendering and platform adapters that are irrelevant to CI.
   const root = new VeilRoot() as VeilRoot & Record<string, unknown>;
   root.renderView = () => undefined;
   root.syncBrowserRoomQuery = () => undefined;


### PR DESCRIPTION
## Summary
- strengthen the Cocos lifecycle harness coverage around VeilRoot reconnect handoff through the real VeilCocosSession runtime
- document which VeilRoot and VeilCocosSession seams are stubbed in CI and which orchestration paths still run production code
- keep the runtime doubles limited to storage, SDK, timing, and engine-facing adapters

## Testing
- node --import tsx --test apps/cocos-client/test/cocos-runtime-harness.test.ts apps/cocos-client/test/cocos-session-orchestration.test.ts apps/cocos-client/test/cocos-veil-root.test.ts apps/cocos-client/test/cocos-root-orchestration.test.ts
- npm run typecheck:cocos

Closes #399