### PR TITLE
test(cocos): add VeilProgressionPanel harness coverage

### DIFF
--- a/apps/cocos-client/test/cocos-progression-panel.test.ts
+++ b/apps/cocos-client/test/cocos-progression-panel.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VeilProgressionPanel } from "../assets/scripts/VeilProgressionPanel.ts";
+import {
+  createBattleReplaySummary,
+  createComponentHarness,
+  createProgressionPanelPage,
+  findNode,
+  pressNode,
+  readCardLabel,
+  readLabelString
+} from "./helpers/cocos-panel-harness.ts";
+
+test("VeilProgressionPanel switches sections through rendered tab buttons", () => {
+  const selectedSections: string[] = [];
+  const { component, node } = createComponentHarness(VeilProgressionPanel, {
+    name: "ProgressionPanelRoot",
+    width: 380,
+    height: 440
+  });
+
+  component.configure({
+    onSelectSection: (section) => {
+      selectedSections.push(section);
+    }
+  });
+  component.render({ page: createProgressionPanelPage() });
+
+  assert.match(readCardLabel(node, "ProgressionHeader"), /账号成长/);
+  assert.equal(readLabelString(findNode(node, "ProgressionTab-progression")), "成长 3");
+
+  pressNode(findNode(node, "ProgressionTab-battle-replays"));
+  pressNode(findNode(node, "ProgressionTab-achievements"));
+
+  assert.deepEqual(selectedSections, ["battle-replays", "achievements"]);
+});
+
+test("VeilProgressionPanel emits paged navigation callbacks for event history", () => {
+  const pageSelections: Array<[string, number]> = [];
+  const { component, node } = createComponentHarness(VeilProgressionPanel, {
+    name: "ProgressionPanelRoot",
+    width: 380,
+    height: 440
+  });
+
+  component.configure({
+    onSelectPage: (section, page) => {
+      pageSelections.push([section, page]);
+    }
+  });
+  component.render({
+    page: createProgressionPanelPage([
+      { type: "section.selected", section: "event-history" },
+      {
+        type: "event-history.loaded",
+        items: [
+          {
+            id: "event-page-4",
+            timestamp: "2026-03-28T12:08:00.000Z",
+            roomId: "room-alpha",
+            playerId: "guest-1001",
+            category: "combat",
+            description: "完成了第四条事件",
+            worldEventType: "battle.resolved",
+            rewards: []
+          },
+          {
+            id: "event-page-5",
+            timestamp: "2026-03-28T12:09:00.000Z",
+            roomId: "room-alpha",
+            playerId: "guest-1001",
+            category: "movement",
+            description: "完成了第五条事件",
+            worldEventType: "hero.moved",
+            rewards: []
+          },
+          {
+            id: "event-page-6",
+            timestamp: "2026-03-28T12:10:00.000Z",
+            roomId: "room-alpha",
+            playerId: "guest-1001",
+            category: "achievement",
+            description: "完成了第六条事件",
+            achievementId: "first_battle",
+            rewards: []
+          }
+        ],
+        page: 1,
+        pageSize: 3,
+        total: 7,
+        hasMore: true
+      }
+    ])
+  });
+
+  assert.match(readCardLabel(node, "ProgressionHeader"), /当前页 2\/3/);
+  pressNode(findNode(node, "ProgressionPrev"));
+  pressNode(findNode(node, "ProgressionNext"));
+
+  assert.deepEqual(pageSelections, [
+    ["event-history", 0],
+    ["event-history", 2]
+  ]);
+});
+
+test("VeilProgressionPanel refreshes render callbacks across rerenders", () => {
+  const pageSelections: Array<[string, number]> = [];
+  const retriedSections: string[] = [];
+  let closeCount = 0;
+  const { component, node } = createComponentHarness(VeilProgressionPanel, {
+    name: "ProgressionPanelRoot",
+    width: 380,
+    height: 440
+  });
+
+  component.configure({
+    onClose: () => {
+      closeCount += 1;
+    },
+    onRetrySection: (section) => {
+      retriedSections.push(section);
+    },
+    onSelectPage: (section, page) => {
+      pageSelections.push([section, page]);
+    }
+  });
+
+  component.render({
+    page: createProgressionPanelPage([
+      { type: "section.selected", section: "battle-replays" },
+      {
+        type: "battle-replays.loaded",
+        items: [
+          {
+            ...createBattleReplaySummary(),
+            id: "replay-page-2",
+            battleId: "battle-page-2",
+            neutralArmyId: "neutral-2",
+            startedAt: "2026-03-28T12:10:00.000Z",
+            completedAt: "2026-03-28T12:11:00.000Z",
+            steps: [],
+            result: "attacker_victory"
+          }
+        ],
+        page: 1,
+        pageSize: 1,
+        hasMore: false
+      }
+    ])
+  });
+
+  pressNode(findNode(node, "ProgressionPrev"));
+  pressNode(findNode(node, "ProgressionClose"));
+
+  component.render({
+    page: createProgressionPanelPage([
+      { type: "section.selected", section: "event-history" },
+      {
+        type: "section.failed",
+        section: "event-history",
+        message: "history_fetch_failed"
+      }
+    ])
+  });
+
+  assert.equal(findNode(node, "ProgressionBanner")?.active, true);
+  pressNode(findNode(node, "ProgressionRetry"));
+  pressNode(findNode(node, "ProgressionNext"));
+  pressNode(findNode(node, "ProgressionClose"));
+
+  component.render({ page: createProgressionPanelPage() });
+  pressNode(findNode(node, "ProgressionRetry"));
+  pressNode(findNode(node, "ProgressionNext"));
+
+  assert.deepEqual(pageSelections, [["battle-replays", 0]]);
+  assert.deepEqual(retriedSections, ["event-history"]);
+  assert.equal(closeCount, 2);
+});

--- a/apps/cocos-client/test/helpers/cocos-panel-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-panel-harness.ts
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { Label, Node, UITransform } from "cc";
-import { buildCocosAccountReviewPage, createCocosAccountReviewState, transitionCocosAccountReviewState } from "../../assets/scripts/cocos-account-review.ts";
+import {
+  buildCocosAccountReviewPage,
+  createCocosAccountReviewState,
+  transitionCocosAccountReviewState,
+  type CocosAccountReviewAction,
+  type CocosAccountReviewPage
+} from "../../assets/scripts/cocos-account-review.ts";
 import { buildCocosBattleReplayCenterView } from "../../assets/scripts/cocos-battle-replay-center.ts";
 import { createLobbyPanelTestAccount } from "../../assets/scripts/cocos-lobby-panel-model.ts";
 import { createBattleReplayPlaybackState, type PlayerBattleReplaySummary } from "../../assets/scripts/project-shared/battle-replay.ts";
@@ -409,6 +415,98 @@ export function createReplayReadyLobbyState(): VeilLobbyRenderState {
     battleReplaySectionStatus: "ready",
     selectedBattleReplayId: replay.id
   });
+}
+
+export function createProgressionPanelPage(
+  actions: CocosAccountReviewAction[] = []
+): CocosAccountReviewPage {
+  const account = createLobbyPanelTestAccount({
+    achievements: [
+      {
+        id: "first_battle",
+        title: "初次交锋",
+        description: "首次进入战斗。",
+        metric: "battles_started",
+        current: 1,
+        target: 1,
+        unlocked: true,
+        unlockedAt: "2026-03-28T12:05:00.000Z"
+      },
+      {
+        id: "enemy_slayer",
+        title: "猎敌者",
+        description: "击败 3 名敌人或中立守军。",
+        metric: "battles_won",
+        current: 2,
+        target: 3,
+        unlocked: false,
+        progressUpdatedAt: "2026-03-28T12:03:00.000Z"
+      },
+      {
+        id: "skill_scholar",
+        title: "秘法学徒",
+        description: "学习 3 个长期技能。",
+        metric: "skills_learned",
+        current: 0,
+        target: 3,
+        unlocked: false
+      }
+    ],
+    recentEventLog: [
+      {
+        id: "event-new",
+        timestamp: "2026-03-28T12:06:00.000Z",
+        roomId: "room-alpha",
+        playerId: "guest-1001",
+        category: "achievement",
+        description: "解锁成就：初次交锋",
+        achievementId: "first_battle",
+        rewards: [{ type: "badge", label: "初次交锋" }]
+      },
+      {
+        id: "event-mid",
+        timestamp: "2026-03-28T12:04:00.000Z",
+        roomId: "room-alpha",
+        playerId: "guest-1001",
+        category: "combat",
+        description: "击退了北侧守军",
+        worldEventType: "battle.resolved",
+        rewards: []
+      },
+      {
+        id: "event-old",
+        timestamp: "2026-03-28T12:02:00.000Z",
+        roomId: "room-alpha",
+        playerId: "guest-1001",
+        category: "movement",
+        description: "向东移动 1 格",
+        worldEventType: "hero.moved",
+        rewards: []
+      }
+    ],
+    recentBattleReplays: [
+      createBattleReplaySummary(),
+      {
+        ...createBattleReplaySummary(),
+        id: "replay-2",
+        roomId: "room-beta",
+        battleId: "battle-2",
+        battleKind: "hero",
+        playerCamp: "defender",
+        opponentHeroId: "hero-9",
+        neutralArmyId: undefined,
+        completedAt: "2026-03-28T11:52:00.000Z",
+        result: "defender_victory",
+        steps: []
+      }
+    ]
+  });
+  const state = actions.reduce(
+    (currentState, action) => transitionCocosAccountReviewState(currentState, action),
+    createCocosAccountReviewState(account)
+  );
+
+  return buildCocosAccountReviewPage(state);
 }
 
 export function assertLobbyFixture(state: VeilLobbyRenderState): void {


### PR DESCRIPTION
## Summary
- add a compact account-review fixture builder for progression panel harness tests
- cover tab switching and paged prev/next callbacks through rendered VeilProgressionPanel nodes
- verify rerendered callback wiring clears stale actions and keeps close/retry interactions stable

## Verification
- node --import tsx --test apps/cocos-client/test/cocos-progression-panel.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-account-review.test.ts
- npm run typecheck:cocos

Closes #405