### PR TITLE
test(release): add snapshot and dashboard aggregation coverage

### DIFF
--- a/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildBuildPackageGate,
+  buildCriticalEvidenceGate,
+  summarizeCocosRc,
+  summarizeSnapshot,
+  summarizeWechatPackage,
+  summarizeWechatSmoke
+} from "../../../scripts/release-readiness-dashboard.ts";
+
+test("summarizeSnapshot fails when a required release-readiness check is missing from an otherwise passed snapshot", () => {
+  const summary = summarizeSnapshot("/tmp/release-readiness.json", {
+    generatedAt: "2026-03-30T00:00:00.000Z",
+    summary: {
+      status: "passed"
+    },
+    checks: [
+      { id: "npm-test", status: "passed", required: true },
+      { id: "typecheck-ci", status: "passed", required: true },
+      { id: "e2e-smoke", status: "passed", required: true },
+      { id: "wechat-build-check", status: "passed", required: true }
+    ]
+  });
+
+  assert.equal(summary.status, "fail");
+  assert.match(summary.detail, /missing=e2e-multiplayer-smoke/);
+  assert.equal(summary.evidence?.status, "fail");
+});
+
+test("buildBuildPackageGate aggregates snapshot, package, and smoke evidence into a failing gate", () => {
+  const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
+    generatedAt: "2026-03-30T00:00:00.000Z",
+    summary: {
+      status: "partial"
+    },
+    checks: [
+      { id: "npm-test", status: "passed", required: true },
+      { id: "typecheck-ci", status: "passed", required: true },
+      { id: "e2e-smoke", status: "passed", required: true },
+      { id: "e2e-multiplayer-smoke", status: "pending", required: true },
+      { id: "wechat-build-check", status: "passed", required: true }
+    ]
+  });
+  const packageSummary = summarizeWechatPackage(undefined, undefined);
+  const smokeSummary = summarizeWechatSmoke("/tmp/codex.wechat.smoke-report.json", {
+    execution: {
+      result: "failed",
+      executedAt: "2026-03-30T00:05:00.000Z"
+    },
+    cases: [{ id: "login-lobby", status: "failed" }]
+  });
+
+  const gate = buildBuildPackageGate(snapshotSummary, packageSummary, smokeSummary);
+
+  assert.equal(gate.status, "fail");
+  assert.match(gate.summary, /failed/i);
+  assert.deepEqual(gate.details, [
+    "snapshot=partial | pending=e2e-multiplayer-smoke",
+    "WeChat package metadata missing.",
+    "result=failed | failed=login-lobby"
+  ]);
+});
+
+test("buildCriticalEvidenceGate downgrades stale evidence to warn and preserves fresh failures", () => {
+  const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
+    generatedAt: "2026-03-01T00:00:00.000Z",
+    summary: {
+      status: "passed"
+    },
+    checks: [
+      { id: "npm-test", status: "passed", required: true },
+      { id: "typecheck-ci", status: "passed", required: true },
+      { id: "e2e-smoke", status: "passed", required: true },
+      { id: "e2e-multiplayer-smoke", status: "passed", required: true },
+      { id: "wechat-build-check", status: "passed", required: true }
+    ]
+  });
+  const smokeSummary = summarizeWechatSmoke("/tmp/codex.wechat.smoke-report.json", {
+    execution: {
+      result: "failed",
+      executedAt: "2026-03-30T00:05:00.000Z"
+    },
+    cases: [{ id: "login-lobby", status: "failed" }]
+  });
+  const cocosSummary = summarizeCocosRc("/tmp/cocos-rc.json", {
+    execution: {
+      overallStatus: "passed",
+      executedAt: "2026-03-30T00:10:00.000Z",
+      summary: "RC journey passed."
+    }
+  });
+
+  const gate = buildCriticalEvidenceGate(14, [
+    snapshotSummary.evidence,
+    smokeSummary.evidence,
+    cocosSummary.evidence
+  ]);
+
+  assert.equal(gate.status, "fail");
+  assert.match(gate.summary, /failing readiness signals/i);
+  assert.match(gate.details[0] ?? "", /older than 14 day\(s\)/);
+  assert.match(gate.details[1] ?? "", /2026-03-30T00:05:00.000Z/);
+});

--- a/apps/cocos-client/test/release-readiness-snapshot.test.ts
+++ b/apps/cocos-client/test/release-readiness-snapshot.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildAutomatedCheckStatus,
+  buildReleaseReadinessSnapshot,
+  parseManualCheckArg
+} from "../../../scripts/release-readiness-snapshot.ts";
+
+function createRevision() {
+  return {
+    commit: "abcdef1234567890",
+    shortCommit: "abcdef1",
+    branch: "test-branch",
+    dirty: false
+  };
+}
+
+function createRunner() {
+  return {
+    nodeVersion: "v22.0.0",
+    platform: "linux 6.0.0 (x64)",
+    hostname: "test-host",
+    cwd: "/tmp/project-veil"
+  };
+}
+
+test("buildReleaseReadinessSnapshot reports pending when required automated checks are skipped", () => {
+  const checks = [
+    buildAutomatedCheckStatus(
+      {
+        id: "npm-test",
+        title: "Unit and integration regression",
+        command: "npm test",
+        required: true
+      },
+      true
+    ),
+    buildAutomatedCheckStatus(
+      {
+        id: "typecheck-ci",
+        title: "TypeScript CI typecheck",
+        command: "npm run typecheck:ci",
+        required: true
+      },
+      true
+    ),
+    parseManualCheckArg("release-notes:Release notes prepared")
+  ];
+
+  const snapshot = buildReleaseReadinessSnapshot({
+    generatedAt: "2026-03-30T00:00:00.000Z",
+    revision: createRevision(),
+    runner: createRunner(),
+    checks
+  });
+
+  assert.equal(snapshot.summary.status, "pending");
+  assert.equal(snapshot.summary.pending, 3);
+  assert.equal(snapshot.summary.requiredPending, 3);
+  assert.equal(snapshot.checks[0]?.notes, "Skipped command execution via --no-run.");
+  assert.equal(snapshot.checks[0]?.startedAt, undefined);
+  assert.equal(snapshot.checks[0]?.finishedAt, undefined);
+});
+
+test("buildReleaseReadinessSnapshot keeps optional failures partial when required checks passed", () => {
+  const checks = [
+    {
+      id: "npm-test",
+      title: "Unit and integration regression",
+      kind: "automated" as const,
+      required: true,
+      status: "passed" as const,
+      notes: "",
+      evidence: [],
+      source: "default" as const
+    },
+    {
+      id: "release-notes",
+      title: "Release notes prepared",
+      kind: "manual" as const,
+      required: false,
+      status: "failed" as const,
+      notes: "Draft still blocked on product copy.",
+      evidence: [],
+      source: "file" as const
+    }
+  ];
+
+  const snapshot = buildReleaseReadinessSnapshot({
+    generatedAt: "2026-03-30T00:00:00.000Z",
+    revision: createRevision(),
+    runner: createRunner(),
+    checks
+  });
+
+  assert.equal(snapshot.summary.status, "partial");
+  assert.equal(snapshot.summary.failed, 1);
+  assert.equal(snapshot.summary.requiredFailed, 0);
+  assert.equal(snapshot.summary.passed, 1);
+});

--- a/scripts/release-readiness-dashboard.ts
+++ b/scripts/release-readiness-dashboard.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 type GateStatus = "pass" | "warn" | "fail";
 
@@ -479,7 +480,7 @@ function buildAuthGate(serverUrl: string | undefined, authPayload: AuthReadiness
   };
 }
 
-function summarizeSnapshot(snapshotPath: string | undefined, snapshot: ReleaseReadinessSnapshot | undefined): {
+export function summarizeSnapshot(snapshotPath: string | undefined, snapshot: ReleaseReadinessSnapshot | undefined): {
   status: GateStatus;
   detail: string;
   evidence?: EvidenceItem;
@@ -531,7 +532,7 @@ function summarizeSnapshot(snapshotPath: string | undefined, snapshot: ReleaseRe
   };
 }
 
-function summarizeWechatPackage(metadataPath: string | undefined, metadata: WechatPackageMetadata | undefined): {
+export function summarizeWechatPackage(metadataPath: string | undefined, metadata: WechatPackageMetadata | undefined): {
   status: GateStatus;
   detail: string;
   evidence?: EvidenceItem;
@@ -566,7 +567,7 @@ function summarizeWechatPackage(metadataPath: string | undefined, metadata: Wech
   };
 }
 
-function summarizeWechatSmoke(reportPath: string | undefined, report: WechatSmokeReport | undefined): {
+export function summarizeWechatSmoke(reportPath: string | undefined, report: WechatSmokeReport | undefined): {
   status: GateStatus;
   detail: string;
   evidence?: EvidenceItem;
@@ -610,7 +611,7 @@ function summarizeWechatSmoke(reportPath: string | undefined, report: WechatSmok
   };
 }
 
-function summarizeCocosRc(snapshotPath: string | undefined, snapshot: CocosReleaseCandidateSnapshot | undefined): {
+export function summarizeCocosRc(snapshotPath: string | undefined, snapshot: CocosReleaseCandidateSnapshot | undefined): {
   status: GateStatus;
   detail: string;
   evidence?: EvidenceItem;
@@ -639,7 +640,7 @@ function summarizeCocosRc(snapshotPath: string | undefined, snapshot: CocosRelea
   };
 }
 
-function buildBuildPackageGate(
+export function buildBuildPackageGate(
   snapshotSummary: ReturnType<typeof summarizeSnapshot>,
   packageSummary: ReturnType<typeof summarizeWechatPackage>,
   smokeSummary: ReturnType<typeof summarizeWechatSmoke>
@@ -662,7 +663,7 @@ function buildBuildPackageGate(
   };
 }
 
-function buildCriticalEvidenceGate(
+export function buildCriticalEvidenceGate(
   maxEvidenceAgeDays: number,
   evidenceItems: Array<EvidenceItem | undefined>
 ): GateReport {
@@ -847,4 +848,6 @@ async function main(): Promise<void> {
   }
 }
 
-void main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main();
+}

--- a/scripts/release-readiness-snapshot.ts
+++ b/scripts/release-readiness-snapshot.ts
@@ -2,6 +2,7 @@ import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 type CheckStatus = "passed" | "failed" | "pending" | "not_applicable";
 type SnapshotStatus = "passed" | "failed" | "pending" | "partial";
@@ -161,7 +162,7 @@ function parseArgs(argv: string[]): Args {
   };
 }
 
-function sanitizeStatus(value: unknown, context: string): CheckStatus {
+export function sanitizeStatus(value: unknown, context: string): CheckStatus {
   if (value === undefined) {
     return "pending";
   }
@@ -171,7 +172,7 @@ function sanitizeStatus(value: unknown, context: string): CheckStatus {
   fail(`Unsupported check status for ${context}: ${String(value)}`);
 }
 
-function normalizeManualCheck(entry: ManualCheckInput, source: "file" | "cli"): ReleaseReadinessCheck {
+export function normalizeManualCheck(entry: ManualCheckInput, source: "file" | "cli"): ReleaseReadinessCheck {
   const id = entry.id?.trim();
   const title = entry.title?.trim();
   if (!id) {
@@ -195,7 +196,7 @@ function normalizeManualCheck(entry: ManualCheckInput, source: "file" | "cli"): 
   };
 }
 
-function parseManualCheckArg(value: string): ReleaseReadinessCheck {
+export function parseManualCheckArg(value: string): ReleaseReadinessCheck {
   const separatorIndex = value.indexOf(":");
   if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
     fail(`Manual check must use "<id>:<title>" format, received: ${value}`);
@@ -210,7 +211,7 @@ function parseManualCheckArg(value: string): ReleaseReadinessCheck {
   );
 }
 
-function parseManualChecksFile(filePath: string): ReleaseReadinessCheck[] {
+export function parseManualChecksFile(filePath: string): ReleaseReadinessCheck[] {
   const resolvedPath = path.resolve(filePath);
   const raw = JSON.parse(fs.readFileSync(resolvedPath, "utf8")) as ManualCheckInput[] | { checks?: ManualCheckInput[] };
   const entries = Array.isArray(raw) ? raw : raw.checks;
@@ -220,7 +221,7 @@ function parseManualChecksFile(filePath: string): ReleaseReadinessCheck[] {
   return entries.map((entry) => normalizeManualCheck(entry, "file"));
 }
 
-function ensureUniqueIds(checks: ReleaseReadinessCheck[]): void {
+export function ensureUniqueIds(checks: ReleaseReadinessCheck[]): void {
   const seen = new Set<string>();
   for (const check of checks) {
     if (seen.has(check.id)) {
@@ -263,7 +264,10 @@ function tailText(value: string | undefined): string | undefined {
   return normalized.length > OUTPUT_TAIL_BYTES ? normalized.slice(-OUTPUT_TAIL_BYTES) : normalized;
 }
 
-function buildAutomatedCheckStatus(definition: Pick<ReleaseReadinessCheck, "id" | "title" | "command" | "required">, noRun: boolean): ReleaseReadinessCheck {
+export function buildAutomatedCheckStatus(
+  definition: Pick<ReleaseReadinessCheck, "id" | "title" | "command" | "required">,
+  noRun: boolean
+): ReleaseReadinessCheck {
   if (noRun) {
     return {
       id: definition.id,
@@ -346,7 +350,7 @@ function isGitDirty(): boolean {
   return result.stdout.trim().length > 0;
 }
 
-function computeSnapshotStatus(checks: ReleaseReadinessCheck[]): SnapshotStatus {
+export function computeSnapshotStatus(checks: ReleaseReadinessCheck[]): SnapshotStatus {
   const requiredFailed = checks.some((check) => check.required && check.status === "failed");
   if (requiredFailed) {
     return "failed";
@@ -366,7 +370,7 @@ function computeSnapshotStatus(checks: ReleaseReadinessCheck[]): SnapshotStatus 
   return "passed";
 }
 
-function buildSummary(checks: ReleaseReadinessCheck[]): ReleaseReadinessSnapshot["summary"] {
+export function buildSummary(checks: ReleaseReadinessCheck[]): ReleaseReadinessSnapshot["summary"] {
   return {
     total: checks.length,
     passed: checks.filter((check) => check.status === "passed").length,
@@ -379,6 +383,22 @@ function buildSummary(checks: ReleaseReadinessCheck[]): ReleaseReadinessSnapshot
   };
 }
 
+export function buildReleaseReadinessSnapshot(input: {
+  generatedAt: string;
+  revision: ReleaseReadinessSnapshot["revision"];
+  runner: ReleaseReadinessSnapshot["runner"];
+  checks: ReleaseReadinessCheck[];
+}): ReleaseReadinessSnapshot {
+  return {
+    schemaVersion: 1,
+    generatedAt: input.generatedAt,
+    revision: input.revision,
+    runner: input.runner,
+    summary: buildSummary(input.checks),
+    checks: input.checks
+  };
+}
+
 function main(): void {
   const args = parseArgs(process.argv);
   const outputPath = getOutputPath(args.outputPath);
@@ -388,8 +408,7 @@ function main(): void {
   const checks = [...automatedChecks, ...manualChecksFromFile, ...manualChecksFromCli];
   ensureUniqueIds(checks);
 
-  const snapshot: ReleaseReadinessSnapshot = {
-    schemaVersion: 1,
+  const snapshot = buildReleaseReadinessSnapshot({
     generatedAt: new Date().toISOString(),
     revision: {
       commit: getGitValue(["rev-parse", "HEAD"]),
@@ -403,9 +422,8 @@ function main(): void {
       hostname: os.hostname(),
       cwd: process.cwd()
     },
-    summary: buildSummary(checks),
     checks
-  };
+  });
 
   writeJsonFile(outputPath, snapshot);
 
@@ -417,4 +435,6 @@ function main(): void {
   );
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add direct unit coverage for release-readiness snapshot generation status/count behavior
- add focused dashboard aggregation tests for missing required checks, package/smoke aggregation, and critical evidence freshness
- export narrow helper functions from the release scripts and guard CLI entrypoints for import-safe tests

Closes #415