### PR TITLE
test(release): cover release-health-summary edge cases

### DIFF
--- a/scripts/test/release-health-summary.test.ts
+++ b/scripts/test/release-health-summary.test.ts
@@ -15,6 +15,13 @@ function createTempWorkspace(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "veil-release-health-summary-"));
 }
 
+const TEST_REVISION = {
+  commit: "abc123",
+  shortCommit: "abc123",
+  branch: "test-branch",
+  dirty: false
+} as const;
+
 test("buildReleaseHealthSummaryReport aggregates passing artifacts into a healthy summary", () => {
   const workspace = createTempWorkspace();
   const releaseReadinessPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
@@ -84,12 +91,7 @@ test("buildReleaseHealthSummaryReport aggregates passing artifacts into a health
       coverageSummaryPath,
       syncGovernancePath
     },
-    {
-      commit: "abc123",
-      shortCommit: "abc123",
-      branch: "test-branch",
-      dirty: false
-    }
+    TEST_REVISION
   );
 
   assert.equal(report.summary.status, "healthy");
@@ -160,12 +162,7 @@ test("buildReleaseHealthSummaryReport classifies blockers and warnings from mixe
       coverageSummaryPath,
       syncGovernancePath
     },
-    {
-      commit: "abc123",
-      shortCommit: "abc123",
-      branch: "test-branch",
-      dirty: false
-    }
+    TEST_REVISION
   );
 
   assert.equal(report.summary.status, "blocking");
@@ -176,6 +173,199 @@ test("buildReleaseHealthSummaryReport classifies blockers and warnings from mixe
   assert.match(renderMarkdown(report), /## Blocker Findings/);
   assert.match(renderMarkdown(report), /## Warning Findings/);
   assert.match(renderMarkdown(report), /Upload receipt mismatch\./);
+  assert.match(renderMarkdown(report), /Coverage thresholds failed in 1 scope\(s\)\./);
+});
+
+test("buildReleaseHealthSummaryReport uses fallback details for sparse degraded artifacts", () => {
+  const workspace = createTempWorkspace();
+  const releaseReadinessPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-sparse.json");
+  const releaseGateSummaryPath = path.join(workspace, "artifacts", "release-readiness", "release-gate-summary-sparse.json");
+  const ciTrendSummaryPath = path.join(workspace, "artifacts", "release-readiness", "ci-trend-summary-sparse.json");
+  const coverageSummaryPath = path.join(workspace, ".coverage", "summary.json");
+  const syncGovernancePath = path.join(workspace, "artifacts", "release-readiness", "sync-governance-matrix-sparse.json");
+
+  writeJson(releaseReadinessPath, {
+    generatedAt: "2026-03-30T10:00:00.000Z",
+    summary: {
+      status: "pending",
+      requiredFailed: 0,
+      requiredPending: 0
+    },
+    checks: []
+  });
+  writeJson(releaseGateSummaryPath, {
+    generatedAt: "2026-03-30T10:05:00.000Z",
+    summary: {
+      status: "failed",
+      failedGateIds: []
+    },
+    gates: []
+  });
+  writeJson(ciTrendSummaryPath, {
+    generatedAt: "2026-03-30T10:10:00.000Z",
+    summary: {
+      overallStatus: "failed",
+      totalFindings: 3,
+      newFindings: 0,
+      ongoingFindings: 0,
+      recoveredFindings: 3
+    },
+    runtime: { findings: [{ status: "recovered", summary: "Recovered runtime regression." }] },
+    releaseGate: { findings: [] }
+  });
+  writeJson(coverageSummaryPath, [
+    {
+      scope: "client",
+      lineThreshold: 85,
+      branchThreshold: 70,
+      functionThreshold: 85,
+      metrics: null,
+      failures: [{ metric: "functions", actual: null, threshold: 85 }]
+    }
+  ]);
+  writeJson(syncGovernancePath, {
+    generatedAt: "2026-03-30T10:15:00.000Z",
+    execution: { status: "failed" },
+    summary: { passed: 0, failed: 0, skipped: 2 },
+    scenarios: [{ id: "lobby-rejoin", status: "skipped" }]
+  });
+
+  const report = buildReleaseHealthSummaryReport(
+    {
+      releaseReadinessPath,
+      releaseGateSummaryPath,
+      ciTrendSummaryPath,
+      coverageSummaryPath,
+      syncGovernancePath
+    },
+    TEST_REVISION
+  );
+
+  assert.equal(report.summary.status, "blocking");
+  assert.deepEqual(report.summary.blockingSignalIds, ["release-readiness", "release-gate", "sync-governance"]);
+  assert.deepEqual(report.summary.warningSignalIds, ["ci-trend", "coverage"]);
+  assert.deepEqual(
+    report.findings.filter((finding) => finding.severity === "blocker").map((finding) => finding.summary),
+    [
+      'Snapshot summary status is "pending".',
+      'Release gate overall status is "failed".',
+      'Sync governance execution status is "failed".'
+    ]
+  );
+  assert.deepEqual(
+    report.findings.filter((finding) => finding.severity === "warning").map((finding) => finding.summary),
+    [
+      'CI trend overall status is "failed".',
+      "client functions coverage output is missing (floor 85%)."
+    ]
+  );
+  assert.match(renderMarkdown(report), /Snapshot summary status is "pending"\./);
+  assert.match(renderMarkdown(report), /Release gate overall status is "failed"\./);
+  assert.match(renderMarkdown(report), /Sync governance execution status is "failed"\./);
+  assert.match(renderMarkdown(report), /client functions coverage output is missing \(floor 85%\)\./);
+});
+
+test("buildReleaseHealthSummaryReport aggregates degraded warning signals without blockers", () => {
+  const workspace = createTempWorkspace();
+  const releaseReadinessPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
+  const releaseGateSummaryPath = path.join(workspace, "artifacts", "release-readiness", "release-gate-summary-pass.json");
+  const ciTrendSummaryPath = path.join(workspace, "artifacts", "release-readiness", "ci-trend-summary-degraded.json");
+  const coverageSummaryPath = path.join(workspace, ".coverage", "summary.json");
+  const syncGovernancePath = path.join(workspace, "artifacts", "release-readiness", "sync-governance-matrix-pass.json");
+
+  writeJson(releaseReadinessPath, {
+    generatedAt: "2026-03-30T11:00:00.000Z",
+    summary: {
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
+    },
+    checks: [{ id: "npm-test", required: true, status: "passed" }]
+  });
+  writeJson(releaseGateSummaryPath, {
+    generatedAt: "2026-03-30T11:05:00.000Z",
+    summary: {
+      status: "passed",
+      failedGateIds: []
+    },
+    gates: [{ id: "wechat-release", status: "passed", summary: "ok" }]
+  });
+  writeJson(ciTrendSummaryPath, {
+    generatedAt: "2026-03-30T11:10:00.000Z",
+    summary: {
+      overallStatus: "passed",
+      totalFindings: 3,
+      newFindings: 1,
+      ongoingFindings: 2,
+      recoveredFindings: 1
+    },
+    runtime: {
+      findings: [
+        { id: "runtime-latency", status: "new", summary: "Runtime latency regressed by 18%." },
+        { id: "runtime-flake", status: "recovered", summary: "Recovered runtime flake." }
+      ]
+    },
+    releaseGate: {
+      findings: [{ id: "wechat-gate-duration", status: "ongoing", summary: "WeChat gate duration remains elevated." }]
+    }
+  });
+  writeJson(coverageSummaryPath, [
+    {
+      scope: "shared",
+      lineThreshold: 90,
+      branchThreshold: 75,
+      functionThreshold: 90,
+      metrics: { lines: 88.5, branches: 72.1, functions: 93.4 },
+      failures: [
+        { metric: "lines", actual: 88.5, threshold: 90 },
+        { metric: "branches", actual: 72.1, threshold: 75 }
+      ]
+    },
+    {
+      scope: "server",
+      lineThreshold: 80,
+      branchThreshold: 70,
+      functionThreshold: 80,
+      metrics: { lines: 82.4, branches: 73.8, functions: 81.2 },
+      failures: []
+    }
+  ]);
+  writeJson(syncGovernancePath, {
+    generatedAt: "2026-03-30T11:15:00.000Z",
+    execution: { status: "passed" },
+    summary: { passed: 2, failed: 0, skipped: 0 },
+    scenarios: [{ id: "room-push-redaction", status: "passed" }]
+  });
+
+  const report = buildReleaseHealthSummaryReport(
+    {
+      releaseReadinessPath,
+      releaseGateSummaryPath,
+      ciTrendSummaryPath,
+      coverageSummaryPath,
+      syncGovernancePath
+    },
+    TEST_REVISION
+  );
+
+  assert.equal(report.summary.status, "warning");
+  assert.equal(report.summary.blockerCount, 0);
+  assert.equal(report.summary.warningCount, 4);
+  assert.deepEqual(report.summary.blockingSignalIds, []);
+  assert.deepEqual(report.summary.warningSignalIds, ["ci-trend", "coverage"]);
+  assert.deepEqual(
+    report.findings.filter((finding) => finding.signalId === "ci-trend").map((finding) => finding.summary),
+    ["Runtime latency regressed by 18%.", "WeChat gate duration remains elevated."]
+  );
+  assert.deepEqual(
+    report.findings.filter((finding) => finding.signalId === "coverage").map((finding) => finding.summary),
+    [
+      "shared lines coverage is 88.50%, below the 90% floor.",
+      "shared branches coverage is 72.10%, below the 75% floor."
+    ]
+  );
+  assert.match(renderMarkdown(report), /Overall status: \*\*WARNING\*\*/);
+  assert.match(renderMarkdown(report), /CI trend shows 2 active regression finding\(s\)\./);
   assert.match(renderMarkdown(report), /Coverage thresholds failed in 1 scope\(s\)\./);
 });
 


### PR DESCRIPTION
## Summary
- add focused release-health-summary coverage for sparse degraded artifacts and fallback detail generation
- assert degraded warning-signal aggregation across CI trend and coverage without blockers
- keep the change scoped to the existing release-health-summary test suite

## Testing
- npm run test:release-health-summary
- npm run test:release-gate-summary

Closes #420