### PR TITLE
ci(release): comment PR release summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 on:
   push:
     branches:
@@ -234,6 +239,13 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
+      - name: Download V8 coverage artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: v8-coverage-${{ github.sha }}
+          path: .coverage
+
       - name: Download runtime regression artifacts
         continue-on-error: true
         uses: actions/download-artifact@v4
@@ -258,7 +270,14 @@ jobs:
       - name: Build release gate summary artifact
         continue-on-error: true
         run: |
+          node --import tsx ./scripts/ci-release-readiness-snapshot.ts \
+            --validate-status "${{ needs.validate.result }}" \
+            --wechat-build-status "${{ needs.wechat-build-validation.result }}" \
+            --client-rc-smoke-status "${{ needs.client-release-candidate-smoke.result }}" \
+            --output "${RUNNER_TEMP}/release-readiness/release-readiness-${GITHUB_SHA}.json"
+
           args=(
+            --snapshot "${RUNNER_TEMP}/release-readiness/release-readiness-${GITHUB_SHA}.json"
             --output "${RUNNER_TEMP}/release-readiness/release-gate-summary-${GITHUB_SHA}.json"
             --markdown-output "${RUNNER_TEMP}/release-readiness/release-gate-summary-${GITHUB_SHA}.md"
           )
@@ -288,6 +307,70 @@ jobs:
             exit 0
           fi
           npm run ci:trend-summary -- "${args[@]}"
+
+      - name: Build release health summary artifact
+        continue-on-error: true
+        run: |
+          args=(
+            --release-readiness "${RUNNER_TEMP}/release-readiness/release-readiness-${GITHUB_SHA}.json"
+            --release-gate-summary "${RUNNER_TEMP}/release-readiness/release-gate-summary-${GITHUB_SHA}.json"
+            --ci-trend-summary "${RUNNER_TEMP}/release-readiness/ci-trend-summary-${GITHUB_SHA}.json"
+            --output "${RUNNER_TEMP}/release-readiness/release-health-summary-${GITHUB_SHA}.json"
+            --markdown-output "${RUNNER_TEMP}/release-readiness/release-health-summary-${GITHUB_SHA}.md"
+          )
+          if [[ -f ".coverage/summary.json" ]]; then
+            args+=(--coverage-summary ".coverage/summary.json")
+          fi
+          npm run release:health:summary -- "${args[@]}" || true
+
+      - name: Build PR release summary comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          node --import tsx ./scripts/release-pr-comment.ts \
+            --release-gate-summary "${RUNNER_TEMP}/release-readiness/release-gate-summary-${GITHUB_SHA}.json" \
+            --release-health-summary "${RUNNER_TEMP}/release-readiness/release-health-summary-${GITHUB_SHA}.json" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --output "${RUNNER_TEMP}/release-readiness/release-pr-comment-${GITHUB_SHA}.md"
+
+      - name: Comment PR with release summary
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        env:
+          COMMENT_PATH: ${{ runner.temp }}/release-readiness/release-pr-comment-${{ github.sha }}.md
+        with:
+          script: |
+            const fs = require("node:fs");
+            const marker = "<!-- project-veil-release-summary -->";
+            const body = fs.readFileSync(process.env.COMMENT_PATH, "utf8");
+            const issue_number = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100
+            });
+            const existing = comments.find((comment) => comment.user?.type === "Bot" && comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });
 
       - name: Upload release signal trend artifacts
         if: always()

--- a/scripts/ci-release-readiness-snapshot.ts
+++ b/scripts/ci-release-readiness-snapshot.ts
@@ -1,0 +1,239 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type CheckStatus = "passed" | "failed" | "pending" | "not_applicable";
+type SnapshotStatus = "passed" | "failed" | "pending" | "partial";
+
+interface Args {
+  outputPath?: string;
+  validateStatus?: string;
+  wechatBuildStatus?: string;
+  clientRcSmokeStatus?: string;
+}
+
+interface GitRevision {
+  commit: string;
+  shortCommit: string;
+  branch: string;
+  dirty: boolean;
+}
+
+export interface ReleaseReadinessCheck {
+  id: string;
+  title: string;
+  kind: "automated";
+  required: boolean;
+  status: CheckStatus;
+  notes: string;
+  evidence: string[];
+  source: "ci";
+}
+
+export interface CiReleaseReadinessSnapshot {
+  schemaVersion: 1;
+  generatedAt: string;
+  revision: GitRevision;
+  runner: {
+    nodeVersion: string;
+    platform: string;
+    cwd: string;
+  };
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+    pending: number;
+    notApplicable: number;
+    requiredFailed: number;
+    requiredPending: number;
+    status: SnapshotStatus;
+  };
+  checks: ReleaseReadinessCheck[];
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let outputPath: string | undefined;
+  let validateStatus: string | undefined;
+  let wechatBuildStatus: string | undefined;
+  let clientRcSmokeStatus: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--validate-status" && next) {
+      validateStatus = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--wechat-build-status" && next) {
+      wechatBuildStatus = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--client-rc-smoke-status" && next) {
+      clientRcSmokeStatus = next;
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    ...(outputPath ? { outputPath } : {}),
+    ...(validateStatus ? { validateStatus } : {}),
+    ...(wechatBuildStatus ? { wechatBuildStatus } : {}),
+    ...(clientRcSmokeStatus ? { clientRcSmokeStatus } : {})
+  };
+}
+
+function readGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function getRevision(): GitRevision {
+  return {
+    commit: readGitValue(["rev-parse", "HEAD"]),
+    shortCommit: readGitValue(["rev-parse", "--short", "HEAD"]),
+    branch: readGitValue(["rev-parse", "--abbrev-ref", "HEAD"]),
+    dirty: readGitValue(["status", "--porcelain"]).length > 0
+  };
+}
+
+export function mapWorkflowResultToCheckStatus(result: string | undefined): CheckStatus {
+  switch ((result ?? "").trim()) {
+    case "success":
+      return "passed";
+    case "failure":
+    case "cancelled":
+    case "timed_out":
+    case "action_required":
+      return "failed";
+    case "skipped":
+    case "neutral":
+      return "not_applicable";
+    case "":
+      return "pending";
+    default:
+      return "pending";
+  }
+}
+
+function buildCheck(id: string, title: string, result: string | undefined, notes: string, evidence: string[]): ReleaseReadinessCheck {
+  return {
+    id,
+    title,
+    kind: "automated",
+    required: true,
+    status: mapWorkflowResultToCheckStatus(result),
+    notes,
+    evidence,
+    source: "ci"
+  };
+}
+
+export function buildCiReleaseReadinessSnapshot(args: Args, revision: GitRevision): CiReleaseReadinessSnapshot {
+  const checks: ReleaseReadinessCheck[] = [
+    buildCheck(
+      "validate",
+      "Validate job",
+      args.validateStatus,
+      "Derived from the CI validate job conclusion. This covers the repo typecheck, regression suites, and runtime regression artifact publication bundled in that job.",
+      [".github/workflows/ci.yml"]
+    ),
+    buildCheck(
+      "wechat-build-validation",
+      "WeChat build validation job",
+      args.wechatBuildStatus,
+      "Derived from the CI WeChat build validation job conclusion.",
+      [".github/workflows/ci.yml"]
+    ),
+    buildCheck(
+      "client-release-candidate-smoke",
+      "H5 packaged RC smoke job",
+      args.clientRcSmokeStatus,
+      "Derived from the CI packaged client release-candidate smoke job conclusion.",
+      [".github/workflows/ci.yml"]
+    )
+  ];
+
+  const passed = checks.filter((check) => check.status === "passed").length;
+  const failed = checks.filter((check) => check.status === "failed").length;
+  const pending = checks.filter((check) => check.status === "pending").length;
+  const notApplicable = checks.filter((check) => check.status === "not_applicable").length;
+  const requiredFailed = checks.filter((check) => check.required && check.status === "failed").length;
+  const requiredPending = checks.filter((check) => check.required && check.status === "pending").length;
+
+  let status: SnapshotStatus = "passed";
+  if (requiredFailed > 0) {
+    status = "failed";
+  } else if (requiredPending > 0) {
+    status = passed > 0 ? "partial" : "pending";
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    revision,
+    runner: {
+      nodeVersion: process.version,
+      platform: process.platform,
+      cwd: process.cwd()
+    },
+    summary: {
+      total: checks.length,
+      passed,
+      failed,
+      pending,
+      notApplicable,
+      requiredFailed,
+      requiredPending,
+      status
+    },
+    checks
+  };
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function defaultOutputPath(outputPath: string | undefined, shortCommit: string): string {
+  if (outputPath) {
+    return path.resolve(outputPath);
+  }
+  return path.resolve("artifacts", "release-readiness", `ci-release-readiness-snapshot-${shortCommit}.json`);
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const revision = getRevision();
+  const snapshot = buildCiReleaseReadinessSnapshot(args, revision);
+  const outputPath = defaultOutputPath(args.outputPath, revision.shortCommit);
+  writeJsonFile(outputPath, snapshot);
+  console.log(`Wrote CI release readiness snapshot: ${path.relative(process.cwd(), outputPath).replace(/\\/g, "/")}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/release-pr-comment.ts
+++ b/scripts/release-pr-comment.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+interface Args {
+  releaseGateSummaryPath?: string;
+  releaseHealthSummaryPath?: string;
+  outputPath?: string;
+  runUrl?: string;
+}
+
+interface ReleaseGateSummaryReport {
+  generatedAt: string;
+  revision: {
+    shortCommit: string;
+    branch: string;
+  };
+  summary: {
+    status: "passed" | "failed";
+    passedGates: number;
+    totalGates: number;
+  };
+  gates: Array<{
+    id: string;
+    label: string;
+    status: "passed" | "failed";
+    summary: string;
+    failures?: string[];
+  }>;
+}
+
+interface ReleaseHealthSummaryReport {
+  generatedAt: string;
+  summary: {
+    status: "healthy" | "warning" | "blocking";
+    blockerCount: number;
+    warningCount: number;
+    infoCount: number;
+  };
+  signals: Array<{
+    id: string;
+    label: string;
+    status: "pass" | "warn" | "fail";
+    summary: string;
+    details: string[];
+  }>;
+}
+
+const COMMENT_MARKER = "<!-- project-veil-release-summary -->";
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let releaseGateSummaryPath: string | undefined;
+  let releaseHealthSummaryPath: string | undefined;
+  let outputPath: string | undefined;
+  let runUrl: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--release-gate-summary" && next) {
+      releaseGateSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--release-health-summary" && next) {
+      releaseHealthSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--run-url" && next) {
+      runUrl = next;
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
+    ...(releaseHealthSummaryPath ? { releaseHealthSummaryPath } : {}),
+    ...(outputPath ? { outputPath } : {}),
+    ...(runUrl ? { runUrl } : {})
+  };
+}
+
+function readJsonFile<T>(filePath: string | undefined): T {
+  if (!filePath) {
+    fail("Missing required file path.");
+  }
+  return JSON.parse(fs.readFileSync(path.resolve(filePath), "utf8")) as T;
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function summarizeGate(gate: ReleaseGateSummaryReport["gates"][number]): string {
+  const statusLabel = gate.status === "passed" ? "PASS" : "FAIL";
+  const firstFailure = gate.failures?.find((failure) => failure.trim().length > 0);
+  return `- **${gate.label}**: \`${statusLabel}\` ${firstFailure ?? gate.summary}`;
+}
+
+function summarizeHealthSignal(signal: ReleaseHealthSummaryReport["signals"][number]): string {
+  const statusLabel = signal.status.toUpperCase();
+  const firstDetail = signal.details.find((detail) => detail.trim().length > 0);
+  return `- **${signal.label}**: \`${statusLabel}\` ${firstDetail ?? signal.summary}`;
+}
+
+export function renderPrComment(
+  releaseGateReport: ReleaseGateSummaryReport,
+  releaseHealthReport: ReleaseHealthSummaryReport,
+  runUrl?: string
+): string {
+  const healthSignals = releaseHealthReport.signals.filter(
+    (signal) => signal.id !== "release-readiness" && signal.id !== "release-gate"
+  );
+
+  const lines = [
+    COMMENT_MARKER,
+    "## Release Automation Summary",
+    "",
+    `- Revision: \`${releaseGateReport.revision.shortCommit}\` on \`${releaseGateReport.revision.branch}\``,
+    `- Release readiness: **${releaseGateReport.summary.status.toUpperCase()}** (${releaseGateReport.summary.passedGates}/${releaseGateReport.summary.totalGates} gates passing)`,
+    `- Release health: **${releaseHealthReport.summary.status.toUpperCase()}** (${releaseHealthReport.summary.blockerCount} blocker, ${releaseHealthReport.summary.warningCount} warning, ${releaseHealthReport.summary.infoCount} info)`,
+    ...(runUrl ? [`- CI run: ${runUrl}`] : []),
+    "",
+    "### Release Readiness",
+    "",
+    ...releaseGateReport.gates.map((gate) => summarizeGate(gate)),
+    "",
+    "### Release Health",
+    ""
+  ];
+
+  if (healthSignals.length === 0) {
+    lines.push("- No additional release-health signals were available beyond release readiness.");
+  } else {
+    lines.push(...healthSignals.map((signal) => summarizeHealthSignal(signal)));
+  }
+
+  lines.push("");
+  lines.push(`<sub>Updated from CI artifacts at \`${releaseHealthReport.generatedAt}\`.</sub>`);
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const releaseGateReport = readJsonFile<ReleaseGateSummaryReport>(args.releaseGateSummaryPath);
+  const releaseHealthReport = readJsonFile<ReleaseHealthSummaryReport>(args.releaseHealthSummaryPath);
+  const content = renderPrComment(releaseGateReport, releaseHealthReport, args.runUrl);
+  const outputPath = path.resolve(args.outputPath ?? path.join("artifacts", "release-readiness", "release-pr-comment.md"));
+  writeFile(outputPath, content);
+  console.log(`Wrote release PR comment markdown: ${path.relative(process.cwd(), outputPath).replace(/\\/g, "/")}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/test/ci-release-readiness-snapshot.test.ts
+++ b/scripts/test/ci-release-readiness-snapshot.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildCiReleaseReadinessSnapshot, mapWorkflowResultToCheckStatus } from "../ci-release-readiness-snapshot.ts";
+
+const revision = {
+  commit: "abc1234567890",
+  shortCommit: "abc1234",
+  branch: "test/branch",
+  dirty: false
+};
+
+test("mapWorkflowResultToCheckStatus normalizes GitHub job conclusions", () => {
+  assert.equal(mapWorkflowResultToCheckStatus("success"), "passed");
+  assert.equal(mapWorkflowResultToCheckStatus("failure"), "failed");
+  assert.equal(mapWorkflowResultToCheckStatus("cancelled"), "failed");
+  assert.equal(mapWorkflowResultToCheckStatus("skipped"), "not_applicable");
+  assert.equal(mapWorkflowResultToCheckStatus(undefined), "pending");
+});
+
+test("buildCiReleaseReadinessSnapshot marks passing CI jobs as release-ready", () => {
+  const snapshot = buildCiReleaseReadinessSnapshot(
+    {
+      validateStatus: "success",
+      wechatBuildStatus: "success",
+      clientRcSmokeStatus: "success"
+    },
+    revision
+  );
+
+  assert.equal(snapshot.summary.status, "passed");
+  assert.equal(snapshot.summary.passed, 3);
+  assert.equal(snapshot.summary.failed, 0);
+  assert.equal(snapshot.summary.requiredFailed, 0);
+  assert.equal(snapshot.checks.map((check) => check.id).join(","), "validate,wechat-build-validation,client-release-candidate-smoke");
+});
+
+test("buildCiReleaseReadinessSnapshot fails when any required CI job fails", () => {
+  const snapshot = buildCiReleaseReadinessSnapshot(
+    {
+      validateStatus: "failure",
+      wechatBuildStatus: "success",
+      clientRcSmokeStatus: "success"
+    },
+    revision
+  );
+
+  assert.equal(snapshot.summary.status, "failed");
+  assert.equal(snapshot.summary.failed, 1);
+  assert.equal(snapshot.summary.requiredFailed, 1);
+  assert.deepEqual(
+    snapshot.checks.map((check) => [check.id, check.status]),
+    [
+      ["validate", "failed"],
+      ["wechat-build-validation", "passed"],
+      ["client-release-candidate-smoke", "passed"]
+    ]
+  );
+});

--- a/scripts/test/release-pr-comment.test.ts
+++ b/scripts/test/release-pr-comment.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { renderPrComment } from "../release-pr-comment.ts";
+
+test("renderPrComment combines readiness and non-duplicative health sections", () => {
+  const markdown = renderPrComment(
+    {
+      generatedAt: "2026-03-30T00:00:00.000Z",
+      revision: {
+        shortCommit: "abc1234",
+        branch: "issue-419"
+      },
+      summary: {
+        status: "failed",
+        passedGates: 2,
+        totalGates: 3
+      },
+      gates: [
+        {
+          id: "release-readiness",
+          label: "Release readiness snapshot",
+          status: "passed",
+          summary: "Snapshot passed.",
+          failures: []
+        },
+        {
+          id: "h5-release-candidate-smoke",
+          label: "H5 packaged RC smoke",
+          status: "passed",
+          summary: "H5 smoke passed.",
+          failures: []
+        },
+        {
+          id: "wechat-release",
+          label: "WeChat release validation",
+          status: "failed",
+          summary: "WeChat validation failed.",
+          failures: ["WeChat smoke case is still pending: login-flow."]
+        }
+      ]
+    },
+    {
+      generatedAt: "2026-03-30T00:02:00.000Z",
+      summary: {
+        status: "warning",
+        blockerCount: 0,
+        warningCount: 2,
+        infoCount: 3
+      },
+      signals: [
+        {
+          id: "release-readiness",
+          label: "Release readiness snapshot",
+          status: "pass",
+          summary: "ready",
+          details: []
+        },
+        {
+          id: "release-gate",
+          label: "Release gate summary",
+          status: "fail",
+          summary: "gates failed",
+          details: ["wechat pending"]
+        },
+        {
+          id: "ci-trend",
+          label: "CI trend summary",
+          status: "warn",
+          summary: "1 active regression",
+          details: ["release-gate:wechat-release remained failing"]
+        },
+        {
+          id: "coverage",
+          label: "Coverage summary",
+          status: "pass",
+          summary: "thresholds passed",
+          details: []
+        }
+      ]
+    },
+    "https://github.com/example/repo/actions/runs/123"
+  );
+
+  assert.match(markdown, /## Release Automation Summary/);
+  assert.match(markdown, /Release readiness: \*\*FAILED\*\* \(2\/3 gates passing\)/);
+  assert.match(markdown, /### Release Readiness/);
+  assert.match(markdown, /WeChat smoke case is still pending: login-flow\./);
+  assert.match(markdown, /### Release Health/);
+  assert.match(markdown, /\*\*CI trend summary\*\*: `WARN` release-gate:wechat-release remained failing/);
+  assert.match(markdown, /\*\*Coverage summary\*\*: `PASS` thresholds passed/);
+  assert.doesNotMatch(markdown, /\*\*Release gate summary\*\*: `FAIL`/);
+});


### PR DESCRIPTION
## Summary
- derive a CI release-readiness snapshot from existing job conclusions so PR automation can reuse the existing release gate and health summary scripts
- render a single sticky PR comment with a focused release-readiness section and a non-duplicative release-health section
- extend the CI aggregation job to build the summaries and post or update the PR comment on same-repo pull requests

## Testing
- node --import tsx --test ./scripts/test/ci-release-readiness-snapshot.test.ts ./scripts/test/release-pr-comment.test.ts ./scripts/test/release-health-summary.test.ts
- npm run test:release-gate-summary
- npm run typecheck:ci

Closes #419