### PR TITLE
feat(shared): replace battle variance Math.random path with seeded PRNG

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/battle.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle.ts
@@ -15,15 +15,11 @@ import type {
   UnitStack,
   ValidationResult
 } from "./models.ts";
+import { nextDeterministicRandom } from "./deterministic-rng.ts";
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
 import { grantedHeroBattleSkillIds } from "./hero-skills.ts";
 import { requireValue, withOptionalProperty } from "./invariant.ts";
 import { getBattleBalanceConfig, getDefaultBattleSkillCatalog, getDefaultUnitCatalog } from "./world-config.ts";
-
-interface RngStep {
-  nextSeed: number;
-  value: number;
-}
 
 interface ContactResolutionResult {
   state: BattleState;
@@ -33,14 +29,6 @@ interface ContactResolutionResult {
 interface BattleCatalogIndex {
   skillById: Map<BattleSkillId, BattleSkillConfig>;
   statusById: Map<BattleStatusEffectId, BattleStatusEffectConfig>;
-}
-
-function nextRng(seed: number): RngStep {
-  const nextSeed = (seed * 1664525 + 1013904223) >>> 0;
-  return {
-    nextSeed,
-    value: nextSeed / 0x100000000
-  };
 }
 
 function cloneSkillState(skill: BattleSkillState): BattleSkillState {
@@ -193,9 +181,9 @@ export function createBattleEnvironmentState(lanes: number, seed: number): Battl
   let environmentSeed = (seed ^ 0x9e3779b9) >>> 0;
   const hazards: BattleHazardState[] = [];
 
-  const blockerRoll = nextRng(environmentSeed);
+  const blockerRoll = nextDeterministicRandom(environmentSeed);
   environmentSeed = blockerRoll.nextSeed;
-  const blockerLaneRoll = nextRng(environmentSeed);
+  const blockerLaneRoll = nextDeterministicRandom(environmentSeed);
   environmentSeed = blockerLaneRoll.nextSeed;
   if (blockerRoll.value >= balance.blockerSpawnThreshold) {
     hazards.push({
@@ -209,13 +197,13 @@ export function createBattleEnvironmentState(lanes: number, seed: number): Battl
     });
   }
 
-  const trapRoll = nextRng(environmentSeed);
+  const trapRoll = nextDeterministicRandom(environmentSeed);
   environmentSeed = trapRoll.nextSeed;
-  const trapLaneRoll = nextRng(environmentSeed);
+  const trapLaneRoll = nextDeterministicRandom(environmentSeed);
   environmentSeed = trapLaneRoll.nextSeed;
   if (trapRoll.value >= balance.trapSpawnThreshold) {
     const lane = Math.min(resolvedLanes - 1, Math.floor(trapLaneRoll.value * resolvedLanes));
-    const trapTypeRoll = nextRng(environmentSeed);
+    const trapTypeRoll = nextDeterministicRandom(environmentSeed);
     const trapType = trapTypeRoll.value < 1 / 3 ? "damage" : trapTypeRoll.value < 2 / 3 ? "slow" : "silence";
     const trapBase =
       trapType === "damage"
@@ -904,7 +892,7 @@ function applyAttackSequence(
 
   const attacker = preparedState.state.units[attackerId]!;
   const defender = preparedState.state.units[defenderId]!;
-  const attackRoll = nextRng(preparedState.state.rng.seed);
+  const attackRoll = nextDeterministicRandom(preparedState.state.rng.seed);
   const attackDamage = estimateDamage(attacker, defender, attackRoll.value, options?.damageMultiplier ?? 1);
   const nextUnits: Record<string, UnitStack> = {
     ...preparedState.state.units,
@@ -929,7 +917,7 @@ function applyAttackSequence(
   nextUnits[defender.id] = damagedDefender;
 
   if ((options?.allowRetaliation ?? true) && damagedDefender.count > 0 && !damagedDefender.hasRetaliated) {
-    const retaliationRoll = nextRng(nextRngState.seed);
+    const retaliationRoll = nextDeterministicRandom(nextRngState.seed);
     const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value);
     let damagedAttacker = applyDamage(attacker, retaliationDamage);
     damagedAttacker = applyOnHitStatuses(damagedDefender, damagedAttacker, log, catalogIndex);

--- a/apps/cocos-client/assets/scripts/project-shared/deterministic-rng.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/deterministic-rng.ts
@@ -1,0 +1,12 @@
+export interface DeterministicRandomStep {
+  nextSeed: number;
+  value: number;
+}
+
+export function nextDeterministicRandom(seed: number): DeterministicRandomStep {
+  const nextSeed = (seed * 1664525 + 1013904223) >>> 0;
+  return {
+    nextSeed,
+    value: nextSeed / 0x100000000
+  };
+}

--- a/apps/cocos-client/assets/scripts/project-shared/index.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/index.ts
@@ -2,6 +2,7 @@ export * from "./achievement-ui.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";
 export * from "./battle-replay.ts";
+export * from "./deterministic-rng.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";
 export * from "./feedback.ts";

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -15,15 +15,11 @@ import type {
   UnitStack,
   ValidationResult
 } from "./models.ts";
+import { nextDeterministicRandom } from "./deterministic-rng.ts";
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
 import { grantedHeroBattleSkillIds } from "./hero-skills.ts";
 import { requireValue, withOptionalProperty } from "./invariant.ts";
 import { getBattleBalanceConfig, getDefaultBattleSkillCatalog, getDefaultUnitCatalog } from "./world-config.ts";
-
-interface RngStep {
-  nextSeed: number;
-  value: number;
-}
 
 interface ContactResolutionResult {
   state: BattleState;
@@ -33,14 +29,6 @@ interface ContactResolutionResult {
 interface BattleCatalogIndex {
   skillById: Map<BattleSkillId, BattleSkillConfig>;
   statusById: Map<BattleStatusEffectId, BattleStatusEffectConfig>;
-}
-
-function nextRng(seed: number): RngStep {
-  const nextSeed = (seed * 1664525 + 1013904223) >>> 0;
-  return {
-    nextSeed,
-    value: nextSeed / 0x100000000
-  };
 }
 
 function cloneSkillState(skill: BattleSkillState): BattleSkillState {
@@ -193,9 +181,9 @@ export function createBattleEnvironmentState(lanes: number, seed: number): Battl
   let environmentSeed = (seed ^ 0x9e3779b9) >>> 0;
   const hazards: BattleHazardState[] = [];
 
-  const blockerRoll = nextRng(environmentSeed);
+  const blockerRoll = nextDeterministicRandom(environmentSeed);
   environmentSeed = blockerRoll.nextSeed;
-  const blockerLaneRoll = nextRng(environmentSeed);
+  const blockerLaneRoll = nextDeterministicRandom(environmentSeed);
   environmentSeed = blockerLaneRoll.nextSeed;
   if (blockerRoll.value >= balance.blockerSpawnThreshold) {
     hazards.push({
@@ -209,13 +197,13 @@ export function createBattleEnvironmentState(lanes: number, seed: number): Battl
     });
   }
 
-  const trapRoll = nextRng(environmentSeed);
+  const trapRoll = nextDeterministicRandom(environmentSeed);
   environmentSeed = trapRoll.nextSeed;
-  const trapLaneRoll = nextRng(environmentSeed);
+  const trapLaneRoll = nextDeterministicRandom(environmentSeed);
   environmentSeed = trapLaneRoll.nextSeed;
   if (trapRoll.value >= balance.trapSpawnThreshold) {
     const lane = Math.min(resolvedLanes - 1, Math.floor(trapLaneRoll.value * resolvedLanes));
-    const trapTypeRoll = nextRng(environmentSeed);
+    const trapTypeRoll = nextDeterministicRandom(environmentSeed);
     const trapType = trapTypeRoll.value < 1 / 3 ? "damage" : trapTypeRoll.value < 2 / 3 ? "slow" : "silence";
     const trapBase =
       trapType === "damage"
@@ -904,7 +892,7 @@ function applyAttackSequence(
 
   const attacker = preparedState.state.units[attackerId]!;
   const defender = preparedState.state.units[defenderId]!;
-  const attackRoll = nextRng(preparedState.state.rng.seed);
+  const attackRoll = nextDeterministicRandom(preparedState.state.rng.seed);
   const attackDamage = estimateDamage(attacker, defender, attackRoll.value, options?.damageMultiplier ?? 1);
   const nextUnits: Record<string, UnitStack> = {
     ...preparedState.state.units,
@@ -929,7 +917,7 @@ function applyAttackSequence(
   nextUnits[defender.id] = damagedDefender;
 
   if ((options?.allowRetaliation ?? true) && damagedDefender.count > 0 && !damagedDefender.hasRetaliated) {
-    const retaliationRoll = nextRng(nextRngState.seed);
+    const retaliationRoll = nextDeterministicRandom(nextRngState.seed);
     const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value);
     let damagedAttacker = applyDamage(attacker, retaliationDamage);
     damagedAttacker = applyOnHitStatuses(damagedDefender, damagedAttacker, log, catalogIndex);

--- a/packages/shared/src/deterministic-rng.ts
+++ b/packages/shared/src/deterministic-rng.ts
@@ -1,0 +1,12 @@
+export interface DeterministicRandomStep {
+  nextSeed: number;
+  value: number;
+}
+
+export function nextDeterministicRandom(seed: number): DeterministicRandomStep {
+  const nextSeed = (seed * 1664525 + 1013904223) >>> 0;
+  return {
+    nextSeed,
+    value: nextSeed / 0x100000000
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from "./assets-config.ts";
 export * from "./battle.ts";
 export * from "./battle-replay.ts";
 export * from "./content-pack-validation.ts";
+export * from "./deterministic-rng.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";
 export * from "./feedback.ts";

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -25,6 +25,7 @@ import {
   createBattleEnvironmentState,
   createBattleReplayPlaybackState,
   createDemoBattleState,
+  nextDeterministicRandom,
   createEmptyBattleState,
   executeBattleSkill,
   createHeroBattleState,
@@ -4250,6 +4251,45 @@ test("applyBattleAction uses deterministic damage and retaliation flow", () => {
     "枪兵 反击 恶狼，造成 18 伤害",
     "枪兵 受到中毒影响，损失 2 生命"
   ]);
+});
+
+test("nextDeterministicRandom is repeatable for the same seed", () => {
+  const firstRun = [
+    nextDeterministicRandom(4242),
+    nextDeterministicRandom(3779851977),
+    nextDeterministicRandom(188715412)
+  ];
+  const secondStep = nextDeterministicRandom(4242);
+  const thirdStep = nextDeterministicRandom(secondStep.nextSeed);
+  const fourthStep = nextDeterministicRandom(thirdStep.nextSeed);
+  const secondRun = [secondStep, thirdStep, fourthStep];
+
+  assert.deepEqual(secondRun, firstRun);
+  assert.deepEqual(
+    firstRun.map((step) => step.value),
+    [0.8800653687212616, 0.04393873084336519, 0.35202502529136837]
+  );
+});
+
+test("applyBattleAction repeats battle damage variance for the same seed", () => {
+  const firstState = createDemoBattleState();
+  const secondState = createDemoBattleState();
+
+  const firstResult = applyBattleAction(firstState, {
+    type: "battle.attack",
+    attackerId: "wolf-d",
+    defenderId: "pikeman-a"
+  });
+  const secondResult = applyBattleAction(secondState, {
+    type: "battle.attack",
+    attackerId: "wolf-d",
+    defenderId: "pikeman-a"
+  });
+
+  assert.equal(firstResult.log.at(-4), "恶狼 对 枪兵 造成 27 伤害");
+  assert.deepEqual(secondResult.log, firstResult.log);
+  assert.deepEqual(secondResult.units, firstResult.units);
+  assert.deepEqual(secondResult.rng, firstResult.rng);
 });
 
 test("applyBattleAction supports active ranged skills without retaliation", () => {


### PR DESCRIPTION
## Summary
- extract the shared deterministic PRNG step into runtime-safe code and use it for battle damage/environment rolls
- keep the cocos shared mirror aligned with the shared package implementation
- add focused tests for seeded PRNG repeatability and repeatable battle damage variance

## Testing
- node --import tsx --test packages/shared/test/shared-core.test.ts
- npm run typecheck:shared
- npm run typecheck:cocos

Closes #424