### PR TITLE
feat(shared): add validateAction pre-check layer

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/action-precheck.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/action-precheck.ts
@@ -1,0 +1,19 @@
+import type { ValidationResult } from "./models.ts";
+
+export interface ActionPrecheckResult<TState> {
+  state: TState;
+  validation: ValidationResult;
+}
+
+export function validateAction<TState, TAction>(
+  state: TState,
+  action: TAction,
+  validate: (state: TState, action: TAction) => ValidationResult,
+  normalizeState?: (state: TState) => TState
+): ActionPrecheckResult<TState> {
+  const nextState = normalizeState ? normalizeState(state) : state;
+  return {
+    state: nextState,
+    validation: validate(nextState, action)
+  };
+}

--- a/apps/cocos-client/assets/scripts/project-shared/battle.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle.ts
@@ -15,6 +15,7 @@ import type {
   UnitStack,
   ValidationResult
 } from "./models.ts";
+import { validateAction } from "./action-precheck.ts";
 import { nextDeterministicRandom } from "./deterministic-rng.ts";
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
 import { grantedHeroBattleSkillIds } from "./hero-skills.ts";
@@ -61,6 +62,16 @@ function withNormalizedCollections(unit: UnitStack): UnitStack {
 
 function hazardsOf(state: BattleState): BattleHazardState[] {
   return state.environment ?? [];
+}
+
+function normalizeBattleState(state: BattleState): BattleState {
+  return {
+    ...state,
+    units: Object.fromEntries(
+      Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
+    ),
+    environment: hazardsOf(state).map(cloneHazardState)
+  };
 }
 
 function battleCatalogIndexFor(catalog: BattleSkillCatalogConfig): BattleCatalogIndex {
@@ -1407,14 +1418,12 @@ export function getBattleOutcome(state: BattleState): BattleOutcome {
 }
 
 export function applyBattleAction(state: BattleState, action: BattleAction): BattleState {
-  const normalizedState: BattleState = {
-    ...state,
-    units: Object.fromEntries(
-      Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
-    ),
-    environment: hazardsOf(state).map(cloneHazardState)
-  };
-  const validation = validateBattleAction(normalizedState, action);
+  const { state: normalizedState, validation } = validateAction(
+    state,
+    action,
+    validateBattleAction,
+    normalizeBattleState
+  );
   if (!validation.valid) {
     return {
       ...normalizedState,

--- a/apps/cocos-client/assets/scripts/project-shared/index.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/index.ts
@@ -1,4 +1,5 @@
 export * from "./achievement-ui.ts";
+export * from "./action-precheck.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";
 export * from "./battle-replay.ts";

--- a/apps/cocos-client/assets/scripts/project-shared/map.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map.ts
@@ -28,6 +28,7 @@ import type {
   WorldResourceLedger,
   WorldState
 } from "./models.ts";
+import { validateAction } from "./action-precheck.ts";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills.ts";
 import { applyHeroEquipmentChange, rollEquipmentDrop, validateHeroEquipmentChange } from "./equipment.ts";
 import {
@@ -2487,6 +2488,11 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
 }
 
 export function applyWorldAction(state: WorldState, action: WorldAction): WorldState {
+  const { validation } = validateAction(state, action, validateWorldAction);
+  if (!validation.valid) {
+    return state;
+  }
+
   return resolveWorldAction(state, action).state;
 }
 

--- a/packages/shared/src/action-precheck.ts
+++ b/packages/shared/src/action-precheck.ts
@@ -1,0 +1,19 @@
+import type { ValidationResult } from "./models.ts";
+
+export interface ActionPrecheckResult<TState> {
+  state: TState;
+  validation: ValidationResult;
+}
+
+export function validateAction<TState, TAction>(
+  state: TState,
+  action: TAction,
+  validate: (state: TState, action: TAction) => ValidationResult,
+  normalizeState?: (state: TState) => TState
+): ActionPrecheckResult<TState> {
+  const nextState = normalizeState ? normalizeState(state) : state;
+  return {
+    state: nextState,
+    validation: validate(nextState, action)
+  };
+}

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -15,6 +15,7 @@ import type {
   UnitStack,
   ValidationResult
 } from "./models.ts";
+import { validateAction } from "./action-precheck.ts";
 import { nextDeterministicRandom } from "./deterministic-rng.ts";
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
 import { grantedHeroBattleSkillIds } from "./hero-skills.ts";
@@ -61,6 +62,16 @@ function withNormalizedCollections(unit: UnitStack): UnitStack {
 
 function hazardsOf(state: BattleState): BattleHazardState[] {
   return state.environment ?? [];
+}
+
+function normalizeBattleState(state: BattleState): BattleState {
+  return {
+    ...state,
+    units: Object.fromEntries(
+      Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
+    ),
+    environment: hazardsOf(state).map(cloneHazardState)
+  };
 }
 
 function battleCatalogIndexFor(catalog: BattleSkillCatalogConfig): BattleCatalogIndex {
@@ -1407,14 +1418,12 @@ export function getBattleOutcome(state: BattleState): BattleOutcome {
 }
 
 export function applyBattleAction(state: BattleState, action: BattleAction): BattleState {
-  const normalizedState: BattleState = {
-    ...state,
-    units: Object.fromEntries(
-      Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
-    ),
-    environment: hazardsOf(state).map(cloneHazardState)
-  };
-  const validation = validateBattleAction(normalizedState, action);
+  const { state: normalizedState, validation } = validateAction(
+    state,
+    action,
+    validateBattleAction,
+    normalizeBattleState
+  );
   if (!validation.valid) {
     return {
       ...normalizedState,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./achievement-ui.ts";
+export * from "./action-precheck.ts";
 export * from "./auth-ui.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -28,6 +28,7 @@ import type {
   WorldResourceLedger,
   WorldState
 } from "./models.ts";
+import { validateAction } from "./action-precheck.ts";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills.ts";
 import { applyHeroEquipmentChange, rollEquipmentDrop, validateHeroEquipmentChange } from "./equipment.ts";
 import {
@@ -2487,6 +2488,11 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
 }
 
 export function applyWorldAction(state: WorldState, action: WorldAction): WorldState {
+  const { validation } = validateAction(state, action, validateWorldAction);
+  if (!validation.valid) {
+    return state;
+  }
+
   return resolveWorldAction(state, action).state;
 }
 

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -8,6 +8,7 @@ import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-
 import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
 import {
   applyBattleAction,
+  applyWorldAction,
   appendEventLogEntries,
   appendPlayerBattleReplaySummaries,
   applyBattleOutcomeToWorld,
@@ -4691,6 +4692,32 @@ test("applyBattleAction logs rejected actions without mutating battle flow", () 
   assert.equal(next.activeUnitId, initial.activeUnitId);
   assert.deepEqual(next.turnOrder, initial.turnOrder);
   assert.equal(next.log.at(-1), "Action rejected: attacker_not_active");
+});
+
+test("applyWorldAction rejects invalid movement before mutating world state", () => {
+  const hero = createHero({
+    id: "hero-blocked",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 0 },
+    move: { total: 6, remaining: 1 }
+  });
+  const initial = createWorldState({
+    width: 3,
+    height: 1,
+    heroes: [hero],
+    tiles: [createTile(0, 0), createTile(1, 0), createTile(2, 0)]
+  });
+
+  const next = applyWorldAction(initial, {
+    type: "hero.move",
+    heroId: "hero-blocked",
+    destination: { x: 2, y: 0 }
+  });
+
+  assert.equal(next, initial);
+  assert.deepEqual(next.heroes[0]?.position, { x: 0, y: 0 });
+  assert.equal(next.heroes[0]?.move.remaining, 1);
 });
 
 test("applyBattleAction resolves wait plus turn-start poison death and cooldown ticking", () => {


### PR DESCRIPTION
## Summary
- add a shared `validateAction` pre-check helper and route `applyBattleAction` through it after deterministic state normalization
- add the same dedicated pre-check before `applyWorldAction` so invalid world actions are rejected before resolver mutation logic runs
- cover the pre-check behavior with focused shared tests for battle and world action rejection paths

## Testing
- node --import tsx --test packages/shared/test/shared-core.test.ts
- npm run typecheck:shared
- npm run typecheck:cocos

Closes #423
