### PR TITLE
fix(server): cull broadcast WorldState per player

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -5,6 +5,7 @@ import {
   filterWorldEventsForPlayer,
   listReachableTiles,
   planHeroMovement,
+  type PlayerWorldView,
   type PlayerBattleReplaySummary,
   type ClientMessage,
   type MovementPlan,
@@ -454,9 +455,10 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         width: number;
         height: number;
       } | null;
+      snapshot?: PlayerWorldView;
     }
   ): SessionStatePayload {
-    const snapshot = this.worldRoom.getSnapshot(playerId).state;
+    const snapshot = options?.snapshot ?? this.worldRoom.getSnapshot(playerId).state;
     const world = encodePlayerWorldView(snapshot, options?.mapBounds ? { bounds: options.mapBounds } : undefined);
     const battle = this.worldRoom.getBattleForPlayer(playerId);
     const heroId = world.ownHeroes[0]?.id;
@@ -490,8 +492,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         continue;
       }
 
-      const fullState = this.worldRoom.getSnapshot(playerId).state;
-      const mapBounds = resolveFocusedMapBounds(fullState);
+      const snapshot = this.worldRoom.getSnapshot(playerId).state;
+      const mapBounds = resolveFocusedMapBounds(snapshot);
       sendMessage(client, "session.state", {
         requestId: "push",
         delivery: "push",
@@ -503,7 +505,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
             ...(extras?.reason ? { reason: extras.reason } : {})
           },
           {
-            mapBounds
+            mapBounds,
+            snapshot
           }
         )
       });

--- a/apps/server/test/colyseus-persistence-recovery.test.ts
+++ b/apps/server/test/colyseus-persistence-recovery.test.ts
@@ -656,6 +656,14 @@ test("colyseus room broadcasts bounded typed-array map chunks to non-source clie
   const decoded = decodePlayerWorldView(pushed.payload.world, decodePlayerWorldView(observerInitial.payload.world));
   assert.equal(decoded.ownHeroes[0]?.id, "hero-2");
   assert.equal(decoded.map.tiles.length, 24 * 24);
+  assert.deepEqual(
+    decoded.visibleHeroes.map((hero) => hero.id),
+    []
+  );
+  const hiddenSourceTile = decoded.map.tiles.find((tile) => tile.position.x === 2 && tile.position.y === 1);
+  assert.equal(hiddenSourceTile?.fog, "hidden");
+  assert.equal(hiddenSourceTile?.terrain, "unknown");
+  assert.equal(hiddenSourceTile?.occupant, undefined);
 });
 
 test("colyseus room hydrates long-term hero archives into fresh rooms", async (t) => {


### PR DESCRIPTION
## Summary
- harden the Colyseus push path so each recipient payload is built from that recipient's visibility-limited snapshot
- keep bounded map chunk pushes using the same per-player snapshot used for encoding
- extend the server transport test to assert hidden enemy tiles and heroes stay hidden for observers

## Testing
- node --import tsx --test apps/server/test/colyseus-persistence-recovery.test.ts
- node --import tsx --test apps/server/test/colyseus-room-lifecycle.test.ts

Closes #425