### PR TITLE
test(e2e): add lightweight H5 connectivity smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,40 @@ jobs:
           path: ${{ runner.temp }}/release-readiness
           if-no-files-found: error
 
+  h5-connectivity-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run H5 connectivity smoke
+        run: npm run test:e2e:h5:connectivity
+
+      - name: Upload H5 connectivity smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: h5-connectivity-smoke-${{ github.sha }}
+          path: |
+            playwright-report
+            test-results
+          if-no-files-found: ignore
+          retention-days: 14
+
   publish-release-signal-trend:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ npm run dev:client:h5
 - H5 开发态诊断导出：
   `window.export_diagnostic_snapshot()` 返回稳定 JSON；
   `window.render_diagnostic_snapshot_to_text()` 返回与面板一致的紧凑文本摘要，便于自动化留档
+- H5 连接性 CI 冒烟：`npm run test:e2e:h5:connectivity`
 - H5 Playwright 冒烟：`npm run test:e2e:smoke`
   当前覆盖 Lobby 入口与 reconnect predicted-state -> authoritative convergence canonical smoke
 - 打包 H5 客户端 RC 冒烟会把结构化结果写入 `artifacts/release-readiness/`

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:e2e:headed": "npm run validate:e2e:fixtures && playwright test --headed",
     "test:e2e:all": "npm run test:e2e && npm run test:e2e:multiplayer",
     "test:e2e:smoke": "npm run validate:e2e:fixtures && playwright test --config=playwright.smoke.config.ts",
+    "test:e2e:h5:connectivity": "npm run validate:e2e:fixtures && playwright test --config=playwright.h5-connectivity.config.ts",
     "test:e2e:multiplayer": "npm run validate:e2e:fixtures && playwright test --config=playwright.multiplayer.config.ts",
     "test:e2e:multiplayer:smoke": "npm run validate:e2e:fixtures && playwright test --config=playwright.multiplayer.smoke.config.ts",
     "test:e2e:multiplayer:headed": "npm run validate:e2e:fixtures && playwright test --config=playwright.multiplayer.config.ts --headed",

--- a/playwright.h5-connectivity.config.ts
+++ b/playwright.h5-connectivity.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: /h5-connectivity-smoke\.spec\.ts/,
+  timeout: 30_000,
+  fullyParallel: false,
+  workers: 1,
+  reporter: [
+    ["list"],
+    ["html", { open: "never" }]
+  ],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    headless: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure"
+  },
+  webServer: [
+    {
+      command: "npm run dev:server",
+      port: 2567,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      gracefulShutdown: {
+        signal: "SIGTERM",
+        timeout: 5_000
+      }
+    },
+    {
+      command: "npm run dev:client",
+      port: 4173,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      gracefulShutdown: {
+        signal: "SIGTERM",
+        timeout: 5_000
+      }
+    }
+  ]
+});

--- a/tests/e2e/h5-connectivity-smoke.spec.ts
+++ b/tests/e2e/h5-connectivity-smoke.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test, type Page } from "@playwright/test";
+import { buildRoomId, fullMoveTextPattern, withSmokeDiagnostics } from "./smoke-helpers";
+
+interface RuntimeDiagnosticSnapshot {
+  room?: {
+    roomId?: string | null;
+    playerId?: string | null;
+    connectionStatus?: string | null;
+    lastUpdateSource?: string | null;
+  } | null;
+}
+
+async function fetchJsonFromBrowser<T>(page: Page, path: string): Promise<T> {
+  return await page.evaluate(async (requestPath) => {
+    const response = await fetch(requestPath);
+    if (!response.ok) {
+      throw new Error(`browser_fetch_failed:${requestPath}:${response.status}`);
+    }
+    return (await response.json()) as T;
+  }, path);
+}
+
+async function readRuntimeDiagnosticSnapshot(page: Page): Promise<RuntimeDiagnosticSnapshot> {
+  return await page.evaluate(() => {
+    const exported = window.export_diagnostic_snapshot?.();
+    if (!exported) {
+      throw new Error("missing_runtime_diagnostic_snapshot");
+    }
+
+    return JSON.parse(exported) as RuntimeDiagnosticSnapshot;
+  });
+}
+
+test("h5 smoke reaches lobby http path and room websocket path", async ({ page }, testInfo) => {
+  const roomId = buildRoomId("e2e-h5-connectivity");
+  const playerId = "player-1";
+
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    const lobbyRoomsResponsePromise = page.waitForResponse((response) => {
+      return response.url().includes("/api/lobby/rooms") && response.request().method() === "GET";
+    });
+
+    await page.goto("/");
+
+    const lobbyRoomsResponse = await lobbyRoomsResponsePromise;
+    expect(lobbyRoomsResponse.ok()).toBeTruthy();
+    await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
+
+    const runtimeHealth = await fetchJsonFromBrowser<{ ok?: boolean }>(page, "/api/runtime/health");
+    expect(runtimeHealth.ok).toBe(true);
+
+    const lobbyRooms = await fetchJsonFromBrowser<{ rooms?: unknown[] }>(page, "/api/lobby/rooms");
+    expect(Array.isArray(lobbyRooms.rooms)).toBe(true);
+
+    await page.locator("[data-lobby-room-id]").fill(roomId);
+    await page.locator("[data-lobby-player-id]").fill(playerId);
+    await page.locator("[data-lobby-display-name]").fill("Connectivity Smoke");
+    await page.locator("[data-enter-room]").click();
+
+    await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
+    await expect(page.getByTestId("session-meta")).toContainText(`Room: ${roomId}`);
+    await expect(page.getByTestId("session-meta")).toContainText(`Player: ${playerId}`);
+    await expect(page.getByTestId("diagnostic-connection-status")).toHaveText("已连接");
+    await expect(page.getByTestId("room-connection-summary")).toContainText("已连接");
+    await expect(page.getByTestId("hero-move")).toHaveText(fullMoveTextPattern(playerId), { timeout: 10_000 });
+
+    const diagnostics = await readRuntimeDiagnosticSnapshot(page);
+    expect(diagnostics.room).toMatchObject({
+      roomId,
+      playerId,
+      connectionStatus: "connected",
+      lastUpdateSource: "system"
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a single-purpose Playwright H5 connectivity smoke that proves the lobby HTTP path and room websocket path are reachable
- add a dedicated Playwright config and npm script so the gate stays fast and deterministic
- wire the smoke into the main CI workflow with artifact upload on failure

## Verification
- npm run typecheck:client:h5
- npx playwright test --config=playwright.h5-connectivity.config.ts --list
- npm run test:e2e:h5:connectivity *(blocked locally: host is missing Playwright Chromium runtime libs such as libatk-bridge-2.0.so.0; CI installs Chromium with deps via the workflow)*

Closes #431