### PR TITLE
ci(release): enforce release health gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,7 @@ jobs:
           retention-days: 14
 
   publish-release-signal-trend:
+    name: Release health gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
@@ -343,7 +344,6 @@ jobs:
           npm run ci:trend-summary -- "${args[@]}"
 
       - name: Build release health summary artifact
-        continue-on-error: true
         run: |
           args=(
             --release-readiness "${RUNNER_TEMP}/release-readiness/release-readiness-${GITHUB_SHA}.json"
@@ -355,7 +355,8 @@ jobs:
           if [[ -f ".coverage/summary.json" ]]; then
             args+=(--coverage-summary ".coverage/summary.json")
           fi
-          npm run release:health:summary -- "${args[@]}" || true
+          # release-health-summary exits non-zero only for blocking conditions; warnings still publish artifacts/comments.
+          npm run release:health:summary -- "${args[@]}"
 
       - name: Build PR release summary comment
         if: |

--- a/docs/release-health-summary.md
+++ b/docs/release-health-summary.md
@@ -27,6 +27,15 @@ The output normalizes findings into three severities:
 
 This makes the JSON easy for bots to consume while keeping the Markdown readable for daily release checks or PR comments.
 
+## PR Gate Rule
+
+In CI, the `Release health gate` check runs `npm run release:health:summary` after the release readiness, release gate, and trend artifacts are assembled.
+
+- `blocking` summary status fails the PR check.
+- `warning` and `healthy` summary statuses keep the check green, while still publishing the JSON/Markdown summary and the PR comment.
+
+That keeps the existing summary/comment flow usable without turning warning-only noise into a merge blocker.
+
 ## Usage
 
 Use the latest local artifacts discovered under `artifacts/release-readiness/` plus `.coverage/summary.json`:

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "test:runtime-regression": "node --import tsx --test ./scripts/test/compare-runtime-regression.test.ts",
     "test:multiplayer-protocol-compatibility": "node --import tsx ./scripts/multiplayer-protocol-compatibility.ts",
     "test:release-gate-summary": "node --import tsx --test ./scripts/test/release-gate-summary.test.ts",
-    "test:release-health-summary": "node --import tsx --test ./scripts/test/release-health-summary.test.ts",
+    "test:release-health-summary": "node --import tsx --test ./scripts/test/release-health-summary.test.ts ./scripts/test/release-health-summary-cli.test.ts",
     "test:sync-governance-matrix": "node --import tsx --test ./scripts/test/sync-governance-matrix.test.ts",
     "test:validate-assets": "node --import tsx --test ./scripts/test/validate-assets.test.ts",
     "test:ci-trend-summary": "node --import tsx --test ./scripts/test/publish-ci-trend-summary.test.ts",

--- a/scripts/test/release-health-summary-cli.test.ts
+++ b/scripts/test/release-health-summary-cli.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+function writeJson(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function createTempWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "veil-release-health-cli-"));
+}
+
+function runReleaseHealthSummary(args: string[]) {
+  return spawnSync("node", ["--import", "tsx", "./scripts/release-health-summary.ts", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+}
+
+test("release:health:summary exits 0 for a healthy report", () => {
+  const workspace = createTempWorkspace();
+  const releaseReadinessPath = path.join(workspace, "release-readiness-pass.json");
+  const releaseGateSummaryPath = path.join(workspace, "release-gate-summary-pass.json");
+  const ciTrendSummaryPath = path.join(workspace, "ci-trend-summary-pass.json");
+  const coverageSummaryPath = path.join(workspace, "summary.json");
+  const syncGovernancePath = path.join(workspace, "sync-governance-pass.json");
+  const outputPath = path.join(workspace, "release-health-summary.json");
+  const markdownOutputPath = path.join(workspace, "release-health-summary.md");
+
+  writeJson(releaseReadinessPath, {
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [{ id: "npm-test", required: true, status: "passed" }]
+  });
+  writeJson(releaseGateSummaryPath, {
+    summary: { status: "passed", failedGateIds: [] },
+    gates: [{ id: "release-readiness", status: "passed", summary: "ok" }]
+  });
+  writeJson(ciTrendSummaryPath, {
+    summary: { overallStatus: "passed", totalFindings: 0, newFindings: 0, ongoingFindings: 0, recoveredFindings: 0 },
+    runtime: { findings: [] },
+    releaseGate: { findings: [] }
+  });
+  writeJson(coverageSummaryPath, [
+    {
+      scope: "shared",
+      lineThreshold: 90,
+      branchThreshold: 70,
+      functionThreshold: 90,
+      metrics: { lines: 95, branches: 80, functions: 96 },
+      failures: []
+    }
+  ]);
+  writeJson(syncGovernancePath, {
+    execution: { status: "passed" },
+    summary: { passed: 2, failed: 0, skipped: 0 },
+    scenarios: [{ id: "room-push-redaction", status: "passed" }]
+  });
+
+  const result = runReleaseHealthSummary([
+    "--release-readiness",
+    releaseReadinessPath,
+    "--release-gate-summary",
+    releaseGateSummaryPath,
+    "--ci-trend-summary",
+    ciTrendSummaryPath,
+    "--coverage-summary",
+    coverageSummaryPath,
+    "--sync-governance",
+    syncGovernancePath,
+    "--output",
+    outputPath,
+    "--markdown-output",
+    markdownOutputPath
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Wrote release health JSON summary:/);
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(markdownOutputPath), true);
+});
+
+test("release:health:summary exits 1 when release readiness is blocking", () => {
+  const workspace = createTempWorkspace();
+  const releaseReadinessPath = path.join(workspace, "release-readiness-fail.json");
+  const releaseGateSummaryPath = path.join(workspace, "release-gate-summary-pass.json");
+  const outputPath = path.join(workspace, "release-health-summary.json");
+  const markdownOutputPath = path.join(workspace, "release-health-summary.md");
+
+  writeJson(releaseReadinessPath, {
+    summary: { status: "failed", requiredFailed: 1, requiredPending: 0 },
+    checks: [{ id: "npm-test", required: true, status: "failed" }]
+  });
+  writeJson(releaseGateSummaryPath, {
+    summary: { status: "passed", failedGateIds: [] },
+    gates: [{ id: "release-readiness", status: "passed", summary: "ok" }]
+  });
+
+  const result = runReleaseHealthSummary([
+    "--release-readiness",
+    releaseReadinessPath,
+    "--release-gate-summary",
+    releaseGateSummaryPath,
+    "--output",
+    outputPath,
+    "--markdown-output",
+    markdownOutputPath
+  ]);
+
+  assert.equal(result.status, 1, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+  assert.equal(fs.existsSync(outputPath), true);
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as { summary: { status: string; blockingSignalIds: string[] } };
+  assert.equal(report.summary.status, "blocking");
+  assert.deepEqual(report.summary.blockingSignalIds, ["release-readiness"]);
+});
+
+test("release:health:summary exits 1 when sync governance is blocking", () => {
+  const workspace = createTempWorkspace();
+  const releaseReadinessPath = path.join(workspace, "release-readiness-pass.json");
+  const releaseGateSummaryPath = path.join(workspace, "release-gate-summary-pass.json");
+  const syncGovernancePath = path.join(workspace, "sync-governance-fail.json");
+  const outputPath = path.join(workspace, "release-health-summary.json");
+  const markdownOutputPath = path.join(workspace, "release-health-summary.md");
+
+  writeJson(releaseReadinessPath, {
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [{ id: "npm-test", required: true, status: "passed" }]
+  });
+  writeJson(releaseGateSummaryPath, {
+    summary: { status: "passed", failedGateIds: [] },
+    gates: [{ id: "release-readiness", status: "passed", summary: "ok" }]
+  });
+  writeJson(syncGovernancePath, {
+    execution: { status: "failed" },
+    summary: { passed: 1, failed: 1, skipped: 0 },
+    scenarios: [{ id: "battle-reconnect-turn-resume", status: "failed" }]
+  });
+
+  const result = runReleaseHealthSummary([
+    "--release-readiness",
+    releaseReadinessPath,
+    "--release-gate-summary",
+    releaseGateSummaryPath,
+    "--sync-governance",
+    syncGovernancePath,
+    "--output",
+    outputPath,
+    "--markdown-output",
+    markdownOutputPath
+  ]);
+
+  assert.equal(result.status, 1, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as { summary: { status: string; blockingSignalIds: string[] } };
+  assert.equal(report.summary.status, "blocking");
+  assert.deepEqual(report.summary.blockingSignalIds, ["sync-governance"]);
+});


### PR DESCRIPTION
## Summary
- fail the existing release health summary step when it reports blocking conditions so PRs get a real failing check
- keep the existing release summary artifacts and PR comment flow intact for warning and healthy runs
- add CLI coverage for one healthy case and two blocking cases, and document the gate rule

## Testing
- npm run test:release-health-summary

Closes #430