### PR TITLE
test(cocos): add primary client auth-expiry regression coverage

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -93,7 +93,12 @@ import {
   syncCocosWechatShareBridge,
   type CocosWechatShareRuntimeLike
 } from "./cocos-wechat-share.ts";
-import { readStoredCocosAuthSession, resolveCocosLaunchIdentity, type CocosAuthProvider } from "./cocos-session-launch.ts";
+import {
+  clearStoredCocosAuthSession,
+  readStoredCocosAuthSession,
+  resolveCocosLaunchIdentity,
+  type CocosAuthProvider
+} from "./cocos-session-launch.ts";
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
 import { VeilProgressionPanel } from "./VeilProgressionPanel.ts";
 import { formatEquipmentActionReason, formatEquipmentSlotLabel } from "./cocos-hero-equipment.ts";
@@ -1995,9 +2000,14 @@ export class VeilRoot extends Component {
     } catch (error) {
       this.showLobby = true;
       if (error instanceof Error && error.message === "cocos_request_failed:401") {
+        const storage = this.readWebStorage();
+        if (storage) {
+          clearStoredCocosAuthSession(storage);
+        }
         this.authToken = null;
         this.authMode = "guest";
         this.authProvider = "guest";
+        this.loginId = "";
         this.sessionSource = "none";
       }
       this.lobbyStatus =

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -542,8 +542,10 @@ test("VeilRoot keeps the lobby visible and explains when an account session has 
   assert.equal(root.authToken, null);
   assert.equal(root.authMode, "guest");
   assert.equal(root.authProvider, "guest");
+  assert.equal(root.loginId, "");
   assert.equal(root.sessionSource, "none");
   assert.equal(root.lobbyStatus, "账号会话已失效，请重新登录后再进入房间。");
+  assert.equal(storage.getItem("project-veil:auth-session"), null);
 });
 
 test("VeilRoot forwards session connection events into runtime diagnostics and logs", async () => {


### PR DESCRIPTION
## Summary
- add direct Cocos primary-client regression coverage for the expired account-session lobby handoff path
- clear the cached auth session and login draft when the primary client gets a 401 during room entry
- keep verification limited to lightweight node:test Cocos suites

## Testing
- node --import tsx --test apps/cocos-client/test/cocos-root-orchestration.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-runtime-harness.test.ts

Closes #436