### PR TITLE
fix(server): lock down replay and event-log reads

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -373,6 +373,31 @@ async function requireAuthSession(
   return result.session;
 }
 
+async function requireAuthorizedPlayerScope(
+  request: IncomingMessage,
+  response: ServerResponse,
+  store: RoomSnapshotStore | null,
+  playerId?: string | null
+) {
+  const normalizedPlayerId = playerId?.trim();
+  if (!normalizedPlayerId) {
+    sendNotFound(response);
+    return null;
+  }
+
+  const authSession = await requireAuthSession(request, response, store);
+  if (!authSession) {
+    return null;
+  }
+
+  if (authSession.playerId !== normalizedPlayerId) {
+    sendForbidden(response);
+    return null;
+  }
+
+  return authSession;
+}
+
 function toPublicPlayerAccount(
   account: PlayerAccountSnapshot
 ): Omit<
@@ -944,6 +969,11 @@ export function registerPlayerAccountRoutes(
       return;
     }
 
+    const authSession = await requireAuthorizedPlayerScope(request, response, store, playerId);
+    if (!authSession) {
+      return;
+    }
+
     if (!store) {
       sendJson(response, 404, {
         error: {
@@ -955,25 +985,17 @@ export function registerPlayerAccountRoutes(
     }
 
     try {
-      const account = await store.loadPlayerAccount(playerId);
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
       if (!account) {
-        if (isEphemeralGuestPlayerId(playerId)) {
-          sendJson(
-            response,
-            200,
-            toEventLogResponse(
-              createLocalModeAccount({
-                playerId
-              }),
-              request
-            )
-          );
-          return;
-        }
         sendJson(response, 404, {
           error: {
-            code: "player_account_not_found",
-            message: `Player account not found: ${playerId}`
+            code: "player_battle_replay_not_found",
+            message: `Player battle replay not found: ${replayId}`
           }
         });
         return;
@@ -1004,6 +1026,11 @@ export function registerPlayerAccountRoutes(
       return;
     }
 
+    const authSession = await requireAuthorizedPlayerScope(request, response, store, playerId);
+    if (!authSession) {
+      return;
+    }
+
     if (!store) {
       sendJson(response, 404, {
         error: {
@@ -1015,25 +1042,17 @@ export function registerPlayerAccountRoutes(
     }
 
     try {
-      const account = await store.loadPlayerAccount(playerId);
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
       if (!account) {
-        if (isEphemeralGuestPlayerId(playerId)) {
-          sendJson(
-            response,
-            200,
-            toAchievementResponse(
-              createLocalModeAccount({
-                playerId
-              }),
-              request
-            )
-          );
-          return;
-        }
         sendJson(response, 404, {
           error: {
-            code: "player_account_not_found",
-            message: `Player account not found: ${playerId}`
+            code: "player_battle_replay_not_found",
+            message: `Player battle replay not found: ${replayId}`
           }
         });
         return;
@@ -1058,6 +1077,11 @@ export function registerPlayerAccountRoutes(
 
   app.get("/api/player-accounts/:playerId/event-log", async (request, response) => {
     const playerId = request.params.playerId?.trim();
+    const authSession = await requireAuthorizedPlayerScope(request, response, store, playerId);
+    if (!authSession) {
+      return;
+    }
+
     if (!playerId) {
       sendNotFound(response);
       return;
@@ -1069,7 +1093,9 @@ export function registerPlayerAccountRoutes(
         200,
         toEventLogResponse(
           createLocalModeAccount({
-            playerId
+            playerId: authSession.playerId,
+            displayName: authSession.displayName,
+            ...(authSession.loginId ? { loginId: authSession.loginId } : {})
           }),
           request
         )
@@ -1078,29 +1104,12 @@ export function registerPlayerAccountRoutes(
     }
 
     try {
-      const account = await store.loadPlayerAccount(playerId);
-      if (!account) {
-        if (isEphemeralGuestPlayerId(playerId)) {
-          sendJson(
-            response,
-            200,
-            toEventLogResponse(
-              createLocalModeAccount({
-                playerId
-              }),
-              request
-            )
-          );
-          return;
-        }
-        sendJson(response, 404, {
-          error: {
-            code: "player_account_not_found",
-            message: `Player account not found: ${playerId}`
-          }
-        });
-        return;
-      }
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
 
       sendJson(response, 200, toEventLogResponse(account, request));
     } catch (error) {
@@ -1110,6 +1119,11 @@ export function registerPlayerAccountRoutes(
 
   app.get("/api/player-accounts/:playerId/event-history", async (request, response) => {
     const playerId = request.params.playerId?.trim();
+    const authSession = await requireAuthorizedPlayerScope(request, response, store, playerId);
+    if (!authSession) {
+      return;
+    }
+
     if (!playerId) {
       sendNotFound(response);
       return;
@@ -1129,7 +1143,7 @@ export function registerPlayerAccountRoutes(
     }
 
     try {
-      const history = await store.loadPlayerEventHistory(playerId, query);
+      const history = await store.loadPlayerEventHistory(authSession.playerId, query);
       sendJson(response, 200, {
         ...history,
         offset: Math.max(0, Math.floor(query.offset ?? 0)),

--- a/apps/server/test/player-account-battle-replay-detail-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-detail-routes.test.ts
@@ -365,16 +365,24 @@ test("player account battle replay detail routes return a normalized replay payl
     playerId: "player-1",
     displayName: "回声骑士"
   });
+  const otherSession = issueGuestAuthSession({
+    playerId: "player-2",
+    displayName: "异乡旅人"
+  });
 
   t.after(async () => {
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
-  const publicResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-detail`);
-  const publicPayload = (await publicResponse.json()) as { replay: PlayerBattleReplaySummary };
-  assert.equal(publicResponse.status, 200);
-  assert.equal(publicPayload.replay.id, "replay-detail");
-  assert.equal(publicPayload.replay.steps[0]?.index, 1);
+  const playerResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-detail`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const playerPayload = (await playerResponse.json()) as { replay: PlayerBattleReplaySummary };
+  assert.equal(playerResponse.status, 200);
+  assert.equal(playerPayload.replay.id, "replay-detail");
+  assert.equal(playerPayload.replay.steps[0]?.index, 1);
 
   const meResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/battle-replays/replay-detail`, {
     headers: {
@@ -384,9 +392,16 @@ test("player account battle replay detail routes return a normalized replay payl
   const mePayload = (await meResponse.json()) as { replay: PlayerBattleReplaySummary };
   assert.equal(meResponse.status, 200);
   assert.equal(mePayload.replay.id, "replay-detail");
+
+  const crossAccountResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-detail`, {
+    headers: {
+      Authorization: `Bearer ${otherSession.token}`
+    }
+  });
+  assert.equal(crossAccountResponse.status, 403);
 });
 
-test("player account battle replay detail routes return 404s for missing resources and 401 without auth", async (t) => {
+test("player account battle replay detail routes require auth before exposing account-scoped data", async (t) => {
   const port = 43020 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
   store.seedAccount({
@@ -405,14 +420,25 @@ test("player account battle replay detail routes return 404s for missing resourc
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
-  const missingReplayResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/missing-replay`);
-  assert.equal(missingReplayResponse.status, 404);
-
-  const missingPlayerResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/missing/battle-replays/replay-detail`);
-  assert.equal(missingPlayerResponse.status, 404);
-
   const unauthorizedResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/battle-replays/replay-detail`);
   assert.equal(unauthorizedResponse.status, 401);
+
+  const protectedUnauthorizedResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-detail`
+  );
+  assert.equal(protectedUnauthorizedResponse.status, 401);
+
+  const session = issueGuestAuthSession({
+    playerId: "player-1",
+    displayName: "回声骑士"
+  });
+
+  const missingReplayResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/missing-replay`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  assert.equal(missingReplayResponse.status, 404);
 });
 
 test("player account battle replay detail routes read a replay captured and persisted from a live room lifecycle", async (t) => {
@@ -449,7 +475,15 @@ test("player account battle replay detail routes read a replay captured and pers
   const replay = account?.recentBattleReplays?.[0];
   assert.ok(replay, "expected a persisted replay to be saved for player-1");
 
-  const response = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/${replay.id}`);
+  const session = issueGuestAuthSession({
+    playerId: "player-1",
+    displayName: "player-1"
+  });
+  const response = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/${replay.id}`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
   const payload = (await response.json()) as { replay: PlayerBattleReplaySummary };
 
   assert.equal(response.status, 200);

--- a/apps/server/test/player-account-battle-replay-playback-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-playback-routes.test.ts
@@ -218,20 +218,29 @@ test("player account battle replay playback routes derive stateless playback con
     playerId: "player-1",
     displayName: "回声骑士"
   });
+  const otherSession = issueGuestAuthSession({
+    playerId: "player-2",
+    displayName: "异乡旅人"
+  });
 
   t.after(async () => {
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
-  const publicResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-playback/playback?action=tick&repeat=2`
+  const playerResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-playback/playback?action=tick&repeat=2`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
   );
-  const publicPayload = (await publicResponse.json()) as { playback: BattleReplayPlaybackState };
-  assert.equal(publicResponse.status, 200);
-  assert.equal(publicPayload.playback.replay.id, "replay-playback");
-  assert.equal(publicPayload.playback.currentStepIndex, 2);
-  assert.equal(publicPayload.playback.status, "completed");
-  assert.equal(publicPayload.playback.currentStep?.index, 2);
+  const playerPayload = (await playerResponse.json()) as { playback: BattleReplayPlaybackState };
+  assert.equal(playerResponse.status, 200);
+  assert.equal(playerPayload.playback.replay.id, "replay-playback");
+  assert.equal(playerPayload.playback.currentStepIndex, 2);
+  assert.equal(playerPayload.playback.status, "completed");
+  assert.equal(playerPayload.playback.currentStep?.index, 2);
 
   const meResponse = await fetch(
     `http://127.0.0.1:${port}/api/player-accounts/me/battle-replays/replay-playback/playback?currentStepIndex=1&status=playing&action=pause`,
@@ -246,9 +255,19 @@ test("player account battle replay playback routes derive stateless playback con
   assert.equal(mePayload.playback.currentStepIndex, 1);
   assert.equal(mePayload.playback.status, "paused");
   assert.equal(mePayload.playback.nextStep?.index, 2);
+
+  const crossAccountResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-playback/playback`,
+    {
+      headers: {
+        Authorization: `Bearer ${otherSession.token}`
+      }
+    }
+  );
+  assert.equal(crossAccountResponse.status, 403);
 });
 
-test("player account battle replay playback routes return 404s for missing resources and 401 without auth", async (t) => {
+test("player account battle replay playback routes require auth before exposing account-scoped data", async (t) => {
   const port = 43040 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
   store.seedAccount({
@@ -267,12 +286,26 @@ test("player account battle replay playback routes return 404s for missing resou
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
-  const missingReplayResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/missing-replay/playback`);
-  assert.equal(missingReplayResponse.status, 404);
-
-  const missingPlayerResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/missing/battle-replays/replay-playback/playback`);
-  assert.equal(missingPlayerResponse.status, 404);
-
   const unauthorizedResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/battle-replays/replay-playback/playback`);
   assert.equal(unauthorizedResponse.status, 401);
+
+  const protectedUnauthorizedResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/replay-playback/playback`
+  );
+  assert.equal(protectedUnauthorizedResponse.status, 401);
+
+  const session = issueGuestAuthSession({
+    playerId: "player-1",
+    displayName: "回声骑士"
+  });
+
+  const missingReplayResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-1/battle-replays/missing-replay/playback`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  assert.equal(missingReplayResponse.status, 404);
 });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -729,7 +729,7 @@ test("player account routes degrade to local-mode responses when persistence is 
   assert.equal(meProgressPayload.summary.unlockedAchievements, 0);
 });
 
-test("public guest player routes return empty fallback payloads instead of 404 noise", async (t) => {
+test("public guest player routes keep only intended public payloads exposed", async (t) => {
   const port = 40045 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
   const server = await startAccountRouteServer(port, store);
@@ -751,9 +751,7 @@ test("public guest player routes return empty fallback payloads instead of 404 n
   assert.deepEqual(replayPayload.items, []);
 
   const eventLogResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/guest-preview/event-log?limit=2`);
-  const eventLogPayload = (await eventLogResponse.json()) as { items: PlayerAccountSnapshot["recentEventLog"] };
-  assert.equal(eventLogResponse.status, 200);
-  assert.deepEqual(eventLogPayload.items ?? [], []);
+  assert.equal(eventLogResponse.status, 401);
 
   const achievementResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/guest-preview/achievements?limit=2`);
   const achievementPayload = (await achievementResponse.json()) as { items: PlayerAchievementProgress[] };
@@ -958,17 +956,31 @@ test("player account event-log routes filter recent entries without loading prog
     playerId: "player-events",
     displayName: "星炬记录官"
   });
+  const otherSession = issueGuestAuthSession({
+    playerId: "player-other",
+    displayName: "旁观者"
+  });
 
   t.after(async () => {
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
-  const publicResponse = await fetch(
+  const unauthorizedResponse = await fetch(
     `http://127.0.0.1:${port}/api/player-accounts/player-events/event-log?category=achievement&achievementId=first_battle&heroId=hero-1`
   );
-  const publicPayload = (await publicResponse.json()) as { items: PlayerAccountSnapshot["recentEventLog"] };
-  assert.equal(publicResponse.status, 200);
-  assert.deepEqual(publicPayload.items.map((entry) => entry.id), ["event-achievement"]);
+  assert.equal(unauthorizedResponse.status, 401);
+
+  const playerResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-events/event-log?category=achievement&achievementId=first_battle&heroId=hero-1`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const playerPayload = (await playerResponse.json()) as { items: PlayerAccountSnapshot["recentEventLog"] };
+  assert.equal(playerResponse.status, 200);
+  assert.deepEqual(playerPayload.items.map((entry) => entry.id), ["event-achievement"]);
 
   const meResponse = await fetch(
     `http://127.0.0.1:${port}/api/player-accounts/me/event-log?heroId=hero-1&limit=1`,
@@ -981,6 +993,13 @@ test("player account event-log routes filter recent entries without loading prog
   const mePayload = (await meResponse.json()) as { items: PlayerAccountSnapshot["recentEventLog"] };
   assert.equal(meResponse.status, 200);
   assert.deepEqual(mePayload.items.map((entry) => entry.id), ["event-achievement"]);
+
+  const crossAccountResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-events/event-log`, {
+    headers: {
+      Authorization: `Bearer ${otherSession.token}`
+    }
+  });
+  assert.equal(crossAccountResponse.status, 403);
 });
 
 test("player account event-history routes page dedicated history entries beyond the recent snapshot", async (t) => {
@@ -1048,27 +1067,41 @@ test("player account event-history routes page dedicated history entries beyond 
     playerId: "player-history",
     displayName: "霜灯抄录员"
   });
+  const otherSession = issueGuestAuthSession({
+    playerId: "player-other",
+    displayName: "旁观者"
+  });
 
   t.after(async () => {
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
-  const publicResponse = await fetch(
+  const unauthorizedResponse = await fetch(
     `http://127.0.0.1:${port}/api/player-accounts/player-history/event-history?heroId=hero-1&offset=1&limit=1`
   );
-  const publicPayload = (await publicResponse.json()) as {
+  assert.equal(unauthorizedResponse.status, 401);
+
+  const playerResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-history/event-history?heroId=hero-1&offset=1&limit=1`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const playerPayload = (await playerResponse.json()) as {
     items: PlayerAccountSnapshot["recentEventLog"];
     total: number;
     offset: number;
     limit: number;
     hasMore: boolean;
   };
-  assert.equal(publicResponse.status, 200);
-  assert.equal(publicPayload.total, 3);
-  assert.equal(publicPayload.offset, 1);
-  assert.equal(publicPayload.limit, 1);
-  assert.equal(publicPayload.hasMore, true);
-  assert.deepEqual(publicPayload.items.map((entry) => entry.id), ["event-history-2"]);
+  assert.equal(playerResponse.status, 200);
+  assert.equal(playerPayload.total, 3);
+  assert.equal(playerPayload.offset, 1);
+  assert.equal(playerPayload.limit, 1);
+  assert.equal(playerPayload.hasMore, true);
+  assert.deepEqual(playerPayload.items.map((entry) => entry.id), ["event-history-2"]);
 
   const meResponse = await fetch(
     `http://127.0.0.1:${port}/api/player-accounts/me/event-history?category=combat`,
@@ -1088,8 +1121,20 @@ test("player account event-history routes page dedicated history entries beyond 
   assert.equal(mePayload.hasMore, false);
   assert.deepEqual(mePayload.items.map((entry) => entry.id), ["event-history-2", "event-history-1"]);
 
+  const crossAccountResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/player-history/event-history`, {
+    headers: {
+      Authorization: `Bearer ${otherSession.token}`
+    }
+  });
+  assert.equal(crossAccountResponse.status, 403);
+
   const rangedResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/player-history/event-history?since=2026-03-27T12:02:00.000Z&until=2026-03-27T12:04:00.000Z`
+    `http://127.0.0.1:${port}/api/player-accounts/player-history/event-history?since=2026-03-27T12:02:00.000Z&until=2026-03-27T12:04:00.000Z`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
   );
   const rangedPayload = (await rangedResponse.json()) as {
     items: PlayerAccountSnapshot["recentEventLog"];


### PR DESCRIPTION
## Summary
- require a matching authenticated session on `:playerId` replay detail, replay playback, event-log, and event-history reads
- keep intended public account surfaces unchanged, including account summaries, replay lists, achievements, and progression
- add focused route coverage for unauthenticated, same-account, and cross-account access paths

## Testing
- node --import tsx --test apps/server/test/player-account-battle-replay-detail-routes.test.ts apps/server/test/player-account-battle-replay-playback-routes.test.ts apps/server/test/player-account-routes.test.ts
- npm run typecheck:server

Closes #429