### PR TITLE
feat(cocos): formalize combat presentation feedback

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilBattlePanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilBattlePanel.ts
@@ -153,18 +153,19 @@ export class VeilBattlePanel extends Component {
 
     if (model.idle) {
       this.hideStageBanner();
-      this.syncIdleBadge(false, 0, "");
-      this.hideSection(this.feedbackLabel);
+      cursorY = this.renderBattleFeedback(model.feedback, cursorY - 4);
       cursorY = this.renderCardTextBlock(
         this.summaryLabel,
         "IdleSummary",
-        ["当前没有战斗。", "继续探索即可触发遭遇。"],
+        model.summaryLines.length > 0 ? model.summaryLines : ["当前没有战斗。", "继续探索即可触发遭遇。"],
         cursorY - 4,
         12,
         16,
         0,
         IDLE_SUMMARY_FILL
       );
+      const idleBadge = model.feedback?.badge ?? (model.summaryLines[0] === "当前没有战斗。" ? "" : "IDLE");
+      this.syncIdleBadge(!model.feedback && Boolean(idleBadge), this.summaryLabel?.node.position.y ?? 0, idleBadge);
       this.hideSection(this.idleHintLabel);
       this.hideSection(this.orderLabel);
       this.hideSection(this.friendlyLabel);

--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -13,6 +13,7 @@ export interface BattleProgressAnalysis {
   defeatedUnits: string[];
   damagedUnits: string[];
   skillTriggered: boolean;
+  skillName: string | null;
 }
 
 interface BattleSettlementSummary {
@@ -118,11 +119,22 @@ export function buildBattleProgressFeedback(
 
   if (analysis.defeatedUnits.length > 0) {
     const primaryTarget = analysis.defeatedUnits[0];
+    const skillPrefix = analysis.skillName ? `${analysis.skillName} 命中，` : "";
     return {
-      title: `${primaryTarget} 已被击倒`,
+      title: `${skillPrefix}${primaryTarget} 已被击倒`,
       detail: analysis.latestLog || "单位已离场，战线出现缺口",
       badge: "K.O.",
       tone: "hit"
+    };
+  }
+
+  if (analysis.skillTriggered && analysis.damagedUnits.length > 0) {
+    const primaryTarget = analysis.damagedUnits[0];
+    return {
+      title: `${analysis.skillName ?? "主动技能"} 命中，${primaryTarget} 受到打击`,
+      detail: analysis.latestLog || "技能伤害已结算",
+      badge: "SKILL",
+      tone: "skill"
     };
   }
 
@@ -136,8 +148,9 @@ export function buildBattleProgressFeedback(
   }
 
   if (analysis.damagedUnits.length > 0) {
+    const skillPrefix = analysis.skillName ? `${analysis.skillName} 命中，` : "";
     return {
-      title: `${analysis.damagedUnits[0]} 受到打击`,
+      title: `${skillPrefix}${analysis.damagedUnits[0]} 受到打击`,
       detail: analysis.latestLog || "伤害已结算",
       badge: "HIT",
       tone: "hit"
@@ -187,8 +200,26 @@ export function analyzeBattleProgress(
     latestLog,
     defeatedUnits,
     damagedUnits,
-    skillTriggered: latestLog.includes("施放")
+    skillTriggered: latestLog.includes("施放"),
+    skillName: inferTriggeredSkillName(nextBattle, latestLog)
   };
+}
+
+function inferTriggeredSkillName(nextBattle: BattleState, latestLog: string): string | null {
+  if (!latestLog.includes("施放")) {
+    return null;
+  }
+
+  for (const unit of Object.values(nextBattle.units)) {
+    for (const skill of unit.skills ?? []) {
+      if (skill.name && latestLog.includes(skill.name)) {
+        return skill.name;
+      }
+    }
+  }
+
+  const matched = latestLog.match(/施放\s+(.+?)(?:，|。|,|$)/);
+  return matched?.[1]?.trim() || null;
 }
 
 export function buildBattleSettlementLines(

--- a/apps/cocos-client/test/cocos-battle-feedback.test.ts
+++ b/apps/cocos-client/test/cocos-battle-feedback.test.ts
@@ -182,6 +182,23 @@ test("battle feedback summarizes action, progress, and outcome", () => {
   const progressFeedback = buildBattleProgressFeedback(battle, nextBattle);
   assert.equal(progressFeedback?.badge, "K.O.");
   assert.equal(progressFeedback?.tone, "hit");
+  assert.match(progressFeedback?.title ?? "", /Orc 已被击倒/);
+
+  const skillImpactBattle: BattleState = {
+    ...battle,
+    units: {
+      ...battle.units,
+      "neutral-1-stack": {
+        ...battle.units["neutral-1-stack"]!,
+        count: 6,
+        currentHp: 4
+      }
+    },
+    log: battle.log.concat("Guard 施放 投矛射击，Orc 受到 5 点伤害")
+  };
+  const skillImpactFeedback = buildBattleProgressFeedback(battle, skillImpactBattle);
+  assert.equal(skillImpactFeedback?.badge, "SKILL");
+  assert.match(skillImpactFeedback?.title ?? "", /投矛射击 命中，Orc 受到打击/);
 
   const victoryFeedback = buildBattleTransitionFeedback(createResolvedUpdate("attacker_victory"), "hero-1");
   assert.equal(victoryFeedback?.tone, "victory");

--- a/apps/cocos-client/test/cocos-battle-panel.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel.test.ts
@@ -89,6 +89,52 @@ test("VeilBattlePanel renders an idle placeholder when no battle payload is pres
   component.onDestroy();
 });
 
+test("VeilBattlePanel preserves settlement feedback after battle resolution", () => {
+  const { component, node } = createComponentHarness(VeilBattlePanel, { name: "BattlePanelRoot", width: 272, height: 420 });
+
+  component.configure({});
+  component.render(
+    createBattlePanelState({
+      update: { ...createBattleUpdate(), battle: null },
+      feedback: {
+        title: "战斗胜利",
+        detail: "战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+        badge: "WIN",
+        tone: "victory"
+      },
+      presentationState: {
+        battleId: "battle-1",
+        phase: "resolution",
+        moment: "result_victory",
+        label: "战斗胜利",
+        detail: "战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+        badge: "WIN",
+        tone: "victory",
+        result: "victory",
+        summaryLines: [
+          "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
+          "播报：战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+          "战利品：金币 +12"
+        ],
+        feedbackLayer: {
+          animation: "victory",
+          cue: "victory",
+          transition: "exit",
+          durationMs: 4200
+        }
+      }
+    })
+  );
+
+  const statefulComponent = component as VeilBattlePanel & Record<string, unknown>;
+
+  assert.equal((statefulComponent.titleLabel as { string: string } | null)?.string, "战斗结算");
+  assert.match(String((statefulComponent.feedbackLabel as { string: string } | null)?.string ?? ""), /战斗胜利/);
+  assert.match(String((statefulComponent.summaryLabel as { string: string } | null)?.string ?? ""), /反馈层：动画 胜利/);
+  assert.match(String((statefulComponent.summaryLabel as { string: string } | null)?.string ?? ""), /战利品：金币 \+12/);
+  component.onDestroy();
+});
+
 test("VeilBattlePanel rerenders from an active turn into a pending-resolution state", () => {
   const { component } = createComponentHarness(VeilBattlePanel, { name: "BattlePanelRoot", width: 272, height: 520 });
 


### PR DESCRIPTION
## Summary
- preserve battle settlement feedback in the primary Cocos battle panel after battle exit
- make skill-driven combat impacts surface explicit hit copy without changing command flow semantics
- add targeted Cocos tests covering the combined skill/hit feedback and post-battle result rendering

## Verification
- node --import tsx --test apps/cocos-client/test/cocos-battle-feedback.test.ts apps/cocos-client/test/cocos-battle-panel.test.ts apps/cocos-client/test/cocos-battle-presentation-controller.test.ts apps/cocos-client/test/cocos-battle-panel-model.test.ts
- npm run typecheck:cocos

Closes #443