### PR TITLE
ci(playwright): stabilize H5 and multiplayer smoke gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,8 @@ jobs:
   h5-connectivity-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      NPM_CONFIG_LOGS_DIR: ${{ runner.temp }}/npm-logs
 
     steps:
       - name: Checkout
@@ -230,6 +232,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+
+      - name: Pin npm runtime
+        run: npm install --global npm@10.9.3
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
@@ -248,6 +253,15 @@ jobs:
           path: |
             playwright-report
             test-results
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload H5 connectivity npm logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: h5-connectivity-npm-logs-${{ github.sha }}
+          path: ${{ runner.temp }}/npm-logs
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/playwright-multiplayer.yml
+++ b/.github/workflows/playwright-multiplayer.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 concurrency:
@@ -18,6 +15,8 @@ jobs:
     name: Multiplayer Full Suite
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      NPM_CONFIG_LOGS_DIR: ${{ runner.temp }}/npm-logs
 
     steps:
       - name: Checkout
@@ -28,6 +27,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+
+      - name: Pin npm runtime
+        run: npm install --global npm@10.9.3
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
@@ -46,5 +48,14 @@ jobs:
           path: |
             playwright-report
             test-results
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload multiplayer npm logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-multiplayer-npm-logs-${{ github.sha }}
+          path: ${{ runner.temp }}/npm-logs
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/playwright-smoke.yml
+++ b/.github/workflows/playwright-smoke.yml
@@ -18,6 +18,8 @@ jobs:
     name: H5 / Lobby Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      NPM_CONFIG_LOGS_DIR: ${{ runner.temp }}/npm-logs
 
     steps:
       - name: Checkout
@@ -28,6 +30,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+
+      - name: Pin npm runtime
+        run: npm install --global npm@10.9.3
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
@@ -49,10 +54,22 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      - name: Upload H5 npm logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-h5-npm-logs-${{ github.sha }}
+          path: ${{ runner.temp }}/npm-logs
+          if-no-files-found: ignore
+          retention-days: 14
+
   multiplayer-smoke:
     name: Multiplayer Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    env:
+      NPM_CONFIG_LOGS_DIR: ${{ runner.temp }}/npm-logs
 
     steps:
       - name: Checkout
@@ -63,6 +80,9 @@ jobs:
         with:
           node-version: 22
           cache: npm
+
+      - name: Pin npm runtime
+        run: npm install --global npm@10.9.3
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
@@ -81,5 +101,14 @@ jobs:
           path: |
             playwright-report
             test-results
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload multiplayer npm logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-multiplayer-npm-logs-${{ github.sha }}
+          path: ${{ runner.temp }}/npm-logs
           if-no-files-found: ignore
           retention-days: 14

--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ npm run dev:client:h5
 - 打包 H5 客户端 RC 冒烟会把结构化结果写入 `artifacts/release-readiness/`
 - 多人联机 Playwright 冒烟：`npm run test:e2e:multiplayer:smoke`
 - 多人同步治理矩阵：`npm run test:sync-governance:matrix`（输出 `artifacts/release-readiness/sync-governance-matrix-<short-sha>.json`）
-- GitHub Actions `playwright-smoke` 会执行上述两条冒烟回归，并在失败时上传 Playwright trace / screenshot / video 诊断材料
+- GitHub Actions `playwright-smoke` 会先等待 `health` / `auth-readiness` / `lobby rooms` readiness contract，再执行 H5 与多人冒烟；失败时会上传 Playwright trace / screenshot / video，以及 npm 调试日志，便于区分环境漂移和真实回归
+- PR 上的多人联机 smoke 现在保留为非阻塞诊断；若它失败，先看 artifact 里的 npm 日志与 Playwright trace，再本地复跑 `npm run test:e2e:multiplayer:smoke`
+- `playwright-multiplayer` 全量多人回归改为 `main` 分支和手动触发运行，避免把长链路浏览器噪音直接混进 PR 合并信号
 - MySQL 首次初始化 / 升级：`npm run db:migrate`
 - MySQL 回滚上一版 schema：`npm run db:migrate:rollback`
 - `npm run db:init:mysql` 现已委托给同一条迁移链路，不再走独立一次性建表逻辑

--- a/playwright.h5-connectivity.config.ts
+++ b/playwright.h5-connectivity.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: "./tests/e2e",
   testMatch: /h5-connectivity-smoke\.spec\.ts/,
   timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
   fullyParallel: false,
   workers: 1,
   reporter: [

--- a/playwright.multiplayer.smoke.config.ts
+++ b/playwright.multiplayer.smoke.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   testMatch: /multiplayer-sync\.spec\.ts/,
   grep: /second player receives room push updates without leaking another player's move details/,
   timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
   fullyParallel: false,
   workers: 1,
   reporter: [

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: "./tests/e2e",
   testMatch: /(lobby-smoke|reconnect-prediction-convergence)\.spec\.ts/,
   timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
   fullyParallel: false,
   workers: 1,
   reporter: [

--- a/tests/e2e/h5-connectivity-smoke.spec.ts
+++ b/tests/e2e/h5-connectivity-smoke.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { buildRoomId, fullMoveTextPattern, withSmokeDiagnostics } from "./smoke-helpers";
+import { buildRoomId, fullMoveTextPattern, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
 
 interface RuntimeDiagnosticSnapshot {
   room?: {
@@ -40,14 +40,12 @@ test("h5 smoke reaches lobby http path and room websocket path", async ({ page }
       return response.url().includes("/api/lobby/rooms") && response.request().method() === "GET";
     });
 
-    await page.goto("/");
-
+    await waitForLobbyReady(page);
     const lobbyRoomsResponse = await lobbyRoomsResponsePromise;
     expect(lobbyRoomsResponse.ok()).toBeTruthy();
-    await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
 
-    const runtimeHealth = await fetchJsonFromBrowser<{ ok?: boolean }>(page, "/api/runtime/health");
-    expect(runtimeHealth.ok).toBe(true);
+    const runtimeHealth = await fetchJsonFromBrowser<{ status?: string }>(page, "/api/runtime/health");
+    expect(runtimeHealth.status).toBe("ok");
 
     const lobbyRooms = await fetchJsonFromBrowser<{ rooms?: unknown[] }>(page, "/api/lobby/rooms");
     expect(Array.isArray(lobbyRooms.rooms)).toBe(true);

--- a/tests/e2e/lobby-smoke.spec.ts
+++ b/tests/e2e/lobby-smoke.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { buildRoomId, expectRoomReady, fullMoveTextPattern, withSmokeDiagnostics } from "./smoke-helpers";
+import { buildRoomId, expectRoomReady, fullMoveTextPattern, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
 
 async function expectEnteredRoom(page: Page, roomId: string, playerId?: string): Promise<void> {
   await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
@@ -24,10 +24,7 @@ test("lobby opens and a guest can enter a room", async ({ page }, testInfo) => {
 
   await withSmokeDiagnostics(testInfo, [page], async () => {
     await test.step("setup: open lobby shell", async () => {
-      await page.goto("/");
-
-      await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
-      await expect(page.getByText("活跃房间")).toBeVisible();
+      await waitForLobbyReady(page);
     });
 
     await page.locator("[data-lobby-room-id]").fill(roomId);
@@ -56,8 +53,7 @@ test("lobby reuses a cached guest session when entering a room", async ({ page }
   });
 
   await withSmokeDiagnostics(testInfo, [page], async () => {
-    await page.goto("/");
-
+    await waitForLobbyReady(page);
     await expect(page.getByText("已缓存本地会话：cached-guest-1")).toBeVisible();
     await page.locator("[data-lobby-room-id]").fill(roomId);
     await page.locator("[data-enter-room]").click();
@@ -75,9 +71,7 @@ test("lobby supports formal registration and enters the room with an account ses
   const password = "formal-pass-1";
 
   await withSmokeDiagnostics(testInfo, [page], async () => {
-    await page.goto("/");
-
-    await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
+    await waitForLobbyReady(page);
     await page.locator("[data-lobby-room-id]").fill(roomId);
     await page.locator("[data-lobby-login-id]").fill(loginId);
     await page.locator("[data-registration-display-name]").fill(displayName);
@@ -138,9 +132,7 @@ test("lobby supports password recovery and rotates the account password before e
   expect(confirmRegistrationResponse.ok()).toBeTruthy();
 
   await withSmokeDiagnostics(testInfo, [page], async () => {
-    await page.goto("/");
-
-    await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
+    await waitForLobbyReady(page);
     await page.locator("[data-lobby-room-id]").fill(roomId);
     await page.locator("[data-lobby-login-id]").fill(loginId);
     await page.locator("[data-request-recovery]").click();

--- a/tests/e2e/smoke-helpers.ts
+++ b/tests/e2e/smoke-helpers.ts
@@ -14,6 +14,18 @@ interface ReconnectOptions extends RoomSessionOptions {
   storage?: "sessionStorage" | "localStorage";
 }
 
+interface RuntimeHealthPayload {
+  status?: string;
+}
+
+interface AuthReadinessPayload {
+  status?: string;
+}
+
+interface LobbyRoomsPayload {
+  rooms?: unknown[];
+}
+
 function encodeRoomQuery(roomId: string, playerId: string): string {
   return `${CLIENT_BASE_URL}/?roomId=${encodeURIComponent(roomId)}&playerId=${encodeURIComponent(playerId)}`;
 }
@@ -32,6 +44,51 @@ export function fullMoveTextPattern(playerId = "player-1"): RegExp {
 
 export function moveRemainingAfterSpend(spent: number, playerId = "player-1"): number {
   return getHeroMoveTotal(playerId) - spent;
+}
+
+async function fetchJsonFromBrowser<T>(page: Page, path: string): Promise<T> {
+  return await page.evaluate(async (requestPath) => {
+    const response = await fetch(requestPath);
+    if (!response.ok) {
+      throw new Error(`browser_fetch_failed:${requestPath}:${response.status}`);
+    }
+    return (await response.json()) as T;
+  }, path);
+}
+
+export async function waitForLobbyReady(page: Page): Promise<void> {
+  await test.step("setup: wait for lobby smoke readiness", async () => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { name: "大厅 / 登录入口" })).toBeVisible();
+    await expect(page.getByText("活跃房间")).toBeVisible();
+    await expect
+      .poll(
+        async () => (await fetchJsonFromBrowser<RuntimeHealthPayload>(page, "/api/runtime/health")).status ?? null,
+        {
+          message: "waiting for runtime health endpoint",
+          timeout: 15_000
+        }
+      )
+      .toBe("ok");
+    await expect
+      .poll(
+        async () => (await fetchJsonFromBrowser<AuthReadinessPayload>(page, "/api/runtime/auth-readiness")).status ?? null,
+        {
+          message: "waiting for auth readiness endpoint",
+          timeout: 15_000
+        }
+      )
+      .toBe("ok");
+    await expect
+      .poll(
+        async () => Array.isArray((await fetchJsonFromBrowser<LobbyRoomsPayload>(page, "/api/lobby/rooms")).rooms),
+        {
+          message: "waiting for lobby room listing",
+          timeout: 15_000
+        }
+      )
+      .toBe(true);
+  });
 }
 
 export async function expectHeroMove(page: Page, remaining: number, playerId = "player-1"): Promise<void> {


### PR DESCRIPTION
## Summary
- add an explicit lobby readiness contract for the H5 smoke entrypoints and enable CI-only retries on the H5 smoke configs
- pin the smoke workflows to npm 10.9.3, upload npm logs on every run, and keep multiplayer smoke non-blocking on pull requests
- limit the full multiplayer Playwright workflow to main/manual runs and document first-step smoke triage in the repo

## Verification
- npm run validate:e2e:fixtures
- npm run test:e2e:smoke -- --list
- npm run test:e2e:h5:connectivity -- --list
- npm run test:e2e:multiplayer:smoke -- --list
- python3 - <<'PY' ... YAML parse for updated workflows
- git diff --check

## Notes
- `npx tsc -p tsconfig.base.json --noEmit` is already failing on unrelated pre-existing type errors across the repo, so it was not used as a gate for this CI-only change.

Closes #435