### PR TITLE
feat(client): add battle report entry points to account surfaces

### DIFF
--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -498,6 +498,8 @@ export function renderBattleReportReplayCenter(input: {
   status?: string;
 }): string {
   const replayCount = input.account.recentBattleReplays.length;
+  const latestReplay = input.account.recentBattleReplays[0] ?? null;
+  const focusReplayId = input.selectedReplayId?.trim() || latestReplay?.id || null;
   const headline =
     replayCount > 0
       ? `最近累计 ${replayCount} 场战斗，支持从列表进入详情或基础回放。`
@@ -511,6 +513,19 @@ export function renderBattleReportReplayCenter(input: {
       </div>
       <span class="account-badge">${replayCount > 0 ? `战报 ${replayCount}` : "暂无战报"}</span>
     </div>
+    <div class="account-replay-entry-points">
+      <button
+        type="button"
+        class="account-replay-entry-point is-primary"
+        ${latestReplay ? `data-select-replay="${escapeHtml(latestReplay.id)}"` : "disabled"}
+      >${latestReplay ? "查看最新战报" : "等待首场战报"}</button>
+      <button
+        type="button"
+        class="account-replay-entry-point"
+        ${focusReplayId ? `data-select-replay="${escapeHtml(focusReplayId)}"` : "disabled"}
+      >${focusReplayId ? "进入回放中心" : "回放中心待解锁"}</button>
+    </div>
+    <p class="account-meta">可直接打开最新结算，或进入逐步回放。</p>
     ${renderRecentBattleReplays(input.account, {
       ...(input.selectedReplayId !== undefined ? { selectedReplayId: input.selectedReplayId } : {})
     })}

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -506,6 +506,37 @@ h1 {
   gap: 10px;
 }
 
+.account-replay-entry-points {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.account-replay-entry-point {
+  border: 1px solid rgba(78, 58, 42, 0.12);
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+}
+
+.account-replay-entry-point:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(84, 57, 35, 0.08);
+}
+
+.account-replay-entry-point.is-primary {
+  border-color: rgba(74, 120, 178, 0.22);
+  background: rgba(74, 120, 178, 0.1);
+}
+
+.account-replay-entry-point:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .account-achievement-list,
 .account-event-list,
 .account-replay-list {

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -201,6 +201,11 @@ test("account history renderer groups battle list and replay detail into a repla
   assert.match(html, /最近累计 2 场战斗/);
   assert.match(html, /支持从列表进入详情或基础回放/);
   assert.match(html, /战报 2/);
+  assert.match(html, /查看最新战报/);
+  assert.match(html, /进入回放中心/);
+  assert.match(html, /可直接打开最新结算，或进入逐步回放/);
+  assert.match(html, /class="account-replay-entry-point is-primary"/);
+  assert.match(html, /data-select-replay="room-alpha:battle-1:player-1"/);
   assert.match(html, /回放详情/);
 });
 
@@ -260,6 +265,8 @@ test("account history renderer shows replay center empty state without blank con
   assert.match(html, /战报与回放中心/);
   assert.match(html, /暂无可回看的战斗记录/);
   assert.match(html, /暂无战报/);
+  assert.match(html, /等待首场战报/);
+  assert.match(html, /回放中心待解锁/);
   assert.match(html, /尚未记录可回看的战斗摘要/);
   assert.match(html, /选择一场最近战斗/);
 });


### PR DESCRIPTION
## Summary
- add explicit account-card entry buttons for the latest battle report and replay center
- reuse the existing replay selection flow so the change stays deterministic and bounded
- extend the H5 account history renderer coverage for the new entry points and empty state

## Testing
- node --import tsx --test ./apps/client/test/account-history-render.test.ts
- node --import tsx --test ./apps/client/test/player-account-storage.test.ts

Closes #442