### PR TITLE
feat(cocos): wire equipment inventory and loot loop into primary client

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -79,6 +79,13 @@ interface HudEquipmentButtonState {
   callback: (() => void) | null;
 }
 
+type HudResolvedAction =
+  | {
+      debugLabel: string;
+      callback: (() => void) | null;
+    }
+  | null;
+
 function formatHeroLearnedSkills(hero: NonNullable<VeilHudRenderState["update"]>["world"]["ownHeroes"][number] | null): string {
   const learnedSkills = hero?.learnedSkills ?? [];
   if (!hero || learnedSkills.length === 0) {
@@ -484,6 +491,16 @@ export class VeilHudPanel extends Component {
     }
   }
 
+  dispatchPointerUp(localX: number, localY: number): string | null {
+    const action = this.resolvePointerAction(localX, localY);
+    if (!action) {
+      return null;
+    }
+
+    action.callback?.();
+    return action.debugLabel;
+  }
+
   private syncChrome(): void {
     const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
     const graphics = this.node.getComponent(Graphics) ?? this.node.addComponent(Graphics);
@@ -505,6 +522,84 @@ export class VeilHudPanel extends Component {
     graphics.fillColor = HUD_ACCENT_SOFT;
     graphics.roundRect(-width / 2 + 18, height / 2 - 46, Math.min(72, width * 0.22), 6, 4);
     graphics.fill();
+  }
+
+  private resolvePointerAction(localX: number, localY: number): HudResolvedAction {
+    const chromeActions: Array<{ nodeName: string; debugLabel: string; callback: (() => void) | null }> = [
+      { nodeName: "HudNewRun", debugLabel: "new-run", callback: this.onNewRun ?? null },
+      { nodeName: "HudRefresh", debugLabel: "refresh", callback: this.onRefresh ?? null },
+      { nodeName: "HudAchievements", debugLabel: "achievements", callback: this.onToggleAchievements ?? null },
+      { nodeName: "HudEndDay", debugLabel: "end-day", callback: this.onEndDay ?? null },
+      { nodeName: "HudReturnLobby", debugLabel: "return-lobby", callback: this.onReturnLobby ?? null }
+    ];
+
+    const actionsNode = this.node.getChildByName(ACTIONS_NODE_NAME);
+    for (const action of chromeActions) {
+      const node = actionsNode?.getChildByName(action.nodeName) ?? null;
+      if (this.pointInNode(localX, localY, node)) {
+        return {
+          debugLabel: action.debugLabel,
+          callback: action.callback
+        };
+      }
+    }
+
+    const skillCard = this.node.getChildByName(`${CARD_PREFIX}-skills`);
+    const skillActions = buildCocosHudSkillPanelView(this.currentState?.update ?? null, this.onLearnSkill).actions;
+    for (const skill of skillActions) {
+      const node = skillCard?.getChildByName(`${SKILL_BUTTON_PREFIX}-${skill.skillId}`) ?? null;
+      if (this.pointInNode(localX, localY, node)) {
+        return {
+          debugLabel: `learn-skill:${skill.skillId}`,
+          callback: skill.onSelect ?? null
+        };
+      }
+    }
+
+    const hero = this.currentState?.update?.world.ownHeroes[0] ?? null;
+    const equipmentCard = this.node.getChildByName(`${CARD_PREFIX}-equipment`);
+    const equipmentButtons = this.buildEquipmentButtonStates(buildHeroEquipmentActionRows(hero));
+    for (const button of equipmentButtons) {
+      const node = equipmentCard?.getChildByName(button.name) ?? null;
+      if (this.pointInNode(localX, localY, node)) {
+        return {
+          debugLabel: button.name,
+          callback: button.callback
+        };
+      }
+    }
+
+    return null;
+  }
+
+  private pointInNode(localX: number, localY: number, node: Node | null): boolean {
+    if (!node || !node.active) {
+      return false;
+    }
+
+    const transform = node.getComponent(UITransform) ?? null;
+    if (!transform) {
+      return false;
+    }
+
+    let centerX = 0;
+    let centerY = 0;
+    let current: Node | null = node;
+    while (current && current !== this.node) {
+      centerX += current.position.x;
+      centerY += current.position.y;
+      current = current.parent;
+    }
+
+    if (current !== this.node) {
+      return false;
+    }
+
+    return this.pointInRect(localX, localY, centerX, centerY, transform.width, transform.height);
+  }
+
+  private pointInRect(x: number, y: number, centerX: number, centerY: number, width: number, height: number): boolean {
+    return x >= centerX - width / 2 && x <= centerX + width / 2 && y >= centerY - height / 2 && y <= centerY + height / 2;
   }
 
   private ensureSectionLabels(): void {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -1438,90 +1438,32 @@ export class VeilRoot extends Component {
       return;
     }
 
-    const action = this.resolveHudActionAt(event.getUILocation().x, event.getUILocation().y);
-    if (!action) {
-      return;
-    }
-
-    if (action === "new-run") {
-      this.inputDebug = "button new-run";
-      void this.startNewRun();
-      return;
-    }
-
-    if (action === "refresh") {
-      this.inputDebug = "button refresh";
-      void this.refreshSnapshot();
-      return;
-    }
-
-    if (action === "achievements") {
-      this.inputDebug = "button achievements";
-      void this.toggleGameplayAccountReviewPanel();
-      return;
-    }
-
-    if (action === "return-lobby") {
-      this.inputDebug = "button return-lobby";
-      void this.returnToLobby();
-      return;
-    }
-
-    this.inputDebug = "button end-day";
-    void this.advanceDay();
-  }
-
-  private resolveHudActionAt(uiX: number, uiY: number): "new-run" | "refresh" | "achievements" | "end-day" | "return-lobby" | null {
     const visibleSize = view.getVisibleSize();
-    const centeredX = uiX - visibleSize.width / 2;
-    const centeredY = uiY - visibleSize.height / 2;
+    const centeredX = event.getUILocation().x - visibleSize.width / 2;
+    const centeredY = event.getUILocation().y - visibleSize.height / 2;
     const hudNode = this.node.getChildByName(HUD_NODE_NAME);
     const hudTransform = hudNode?.getComponent(UITransform) ?? null;
     if (!hudNode || !hudTransform) {
-      return null;
+      return;
     }
 
     const hudLocalX = centeredX - hudNode.position.x;
     const hudLocalY = centeredY - hudNode.position.y;
-
     if (
       hudLocalX < -hudTransform.width / 2 ||
       hudLocalX > hudTransform.width / 2 ||
       hudLocalY < -hudTransform.height / 2 ||
       hudLocalY > hudTransform.height / 2
     ) {
-      return null;
+      return;
     }
 
-    const actionsCenterY = hudTransform.height / 2 - 118;
-    const buttonWidth = Math.max(156, hudTransform.width - 36);
-    const buttonHeight = 28;
-
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY + 60, buttonWidth, buttonHeight)) {
-      return "new-run";
+    const action = this.hudPanel?.dispatchPointerUp(hudLocalX, hudLocalY) ?? null;
+    if (!action) {
+      return;
     }
 
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY + 30, buttonWidth, buttonHeight)) {
-      return "refresh";
-    }
-
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY, buttonWidth, buttonHeight)) {
-      return "achievements";
-    }
-
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY - 30, buttonWidth, buttonHeight)) {
-      return "end-day";
-    }
-
-    if (this.pointInRect(hudLocalX, hudLocalY, 0, actionsCenterY - 60, buttonWidth, buttonHeight)) {
-      return "return-lobby";
-    }
-
-    return null;
-  }
-
-  private pointInRect(x: number, y: number, centerX: number, centerY: number, width: number, height: number): boolean {
-    return x >= centerX - width / 2 && x <= centerX + width / 2 && y >= centerY - height / 2 && y <= centerY + height / 2;
+    this.inputDebug = `button ${action}`;
   }
 
   private scheduleFogPulseTick(): void {

--- a/apps/cocos-client/test/cocos-hud-panel.test.ts
+++ b/apps/cocos-client/test/cocos-hud-panel.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VeilHudPanel, type VeilHudRenderState } from "../assets/scripts/VeilHudPanel.ts";
+import { createLobbyPanelTestAccount } from "../assets/scripts/cocos-lobby-panel-model.ts";
+import { createComponentHarness, findNode } from "./helpers/cocos-panel-harness.ts";
+import { createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
+
+function toHudLocalPosition(root: { name: string }, node: { position: { x: number; y: number }; parent: unknown | null }): { x: number; y: number } {
+  let x = 0;
+  let y = 0;
+  let current: { position: { x: number; y: number }; parent: unknown | null } | null = node;
+  while (current && current !== root) {
+    x += current.position.x;
+    y += current.position.y;
+    current = current.parent as typeof current;
+  }
+  return { x, y };
+}
+
+function createHudState(): VeilHudRenderState {
+  return {
+    roomId: "room-alpha",
+    playerId: "player-1",
+    displayName: "暮潮守望",
+    account: createLobbyPanelTestAccount(),
+    authMode: "guest",
+    loginId: "",
+    sessionSource: "local",
+    remoteUrl: "http://127.0.0.1:2567",
+    update: createSessionUpdate(),
+    moveInFlight: false,
+    predictionStatus: "",
+    inputDebug: "",
+    runtimeHealth: "运行稳定",
+    triageSummaryLines: [],
+    levelUpNotice: null,
+    achievementNotice: null,
+    presentation: {
+      audio: {
+        supported: false,
+        assetBacked: false,
+        unlocked: false,
+        currentScene: null,
+        lastCue: null,
+        cueCount: 0,
+        musicMode: "idle",
+        cueMode: "idle"
+      },
+      pixelAssets: {
+        phase: "idle",
+        pendingGroups: [],
+        loadedGroups: [],
+        loadedResourceCount: 0,
+        totalResourceCount: 0,
+        loadDurationMs: null,
+        targetMs: 400,
+        hardLimitMs: 900,
+        exceededTarget: false,
+        exceededHardLimit: false
+      },
+      readiness: {
+        summary: "等待表现资源",
+        nextStep: "等待资源包",
+        pixel: {
+          label: "像素",
+          stage: "placeholder",
+          headline: "像素占位资源",
+          detail: "待补全",
+          shortLabel: "像素 占位"
+        },
+        audio: {
+          label: "音频",
+          stage: "placeholder",
+          headline: "音频占位资源",
+          detail: "待补全",
+          shortLabel: "音频 占位"
+        },
+        animation: {
+          label: "动画",
+          stage: "placeholder",
+          headline: "动画占位资源",
+          detail: "待补全",
+          shortLabel: "动画 占位",
+          deliveryModes: {
+            fallback: 1,
+            clip: 0,
+            spine: 0
+          }
+        }
+      }
+    }
+  };
+}
+
+test("VeilHudPanel dispatchPointerUp routes equipment button presses through the rendered inventory controls", () => {
+  const { component, node } = createComponentHarness(VeilHudPanel, { name: "HudPanelRoot", width: 320, height: 720 });
+  const state = createHudState();
+  state.update!.world.ownHeroes[0]!.loadout.inventory = ["militia_pike"];
+
+  let equipped: { slot: string; equipmentId: string } | null = null;
+  component.configure({
+    onEquipItem: (slot, equipmentId) => {
+      equipped = { slot, equipmentId };
+    }
+  });
+  component.render(state);
+
+  const button = findNode(node, "HudEquipButton-weapon-militia_pike");
+  assert.ok(button);
+  const buttonCenter = toHudLocalPosition(node, button);
+  const action = component.dispatchPointerUp(buttonCenter.x, buttonCenter.y);
+
+  assert.equal(action, "HudEquipButton-weapon-militia_pike");
+  assert.deepEqual(equipped, {
+    slot: "weapon",
+    equipmentId: "militia_pike"
+  });
+});

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -162,6 +162,51 @@ test("VeilRoot boots into lobby mode and triggers lobby bootstrap when no roomId
   assert.equal(bootstrapCalls, 1);
 });
 
+test("VeilRoot wires the equipment loot loop through equip and unequip session updates", async () => {
+  const root = createVeilRootHarness();
+  const baseUpdate = createSessionUpdate(1, "room-equipment", "player-1");
+  baseUpdate.world.ownHeroes[0]!.loadout.inventory = ["militia_pike"];
+  const equippedUpdate = createSessionUpdate(1, "room-equipment", "player-1");
+  equippedUpdate.world.ownHeroes[0]!.loadout.equipment.weaponId = "militia_pike";
+  equippedUpdate.world.ownHeroes[0]!.loadout.inventory = [];
+  const unequippedUpdate = createSessionUpdate(1, "room-equipment", "player-1");
+  unequippedUpdate.world.ownHeroes[0]!.loadout.inventory = ["militia_pike"];
+
+  const calls: Array<{ kind: "equip" | "unequip"; slot: string; equipmentId?: string }> = [];
+  root.lastUpdate = baseUpdate;
+  root.session = {
+    async equipHeroItem(heroId, slot, equipmentId) {
+      calls.push({ kind: "equip", slot, equipmentId });
+      assert.equal(heroId, "hero-1");
+      return equippedUpdate;
+    },
+    async unequipHeroItem(heroId, slot) {
+      calls.push({ kind: "unequip", slot });
+      assert.equal(heroId, "hero-1");
+      return unequippedUpdate;
+    }
+  } as never;
+
+  await root.equipHeroItem("weapon", "militia_pike");
+  assert.equal(root.lastUpdate?.world.ownHeroes[0]?.loadout.equipment.weaponId, "militia_pike");
+  assert.deepEqual(root.lastUpdate?.world.ownHeroes[0]?.loadout.inventory, []);
+
+  await root.unequipHeroItem("weapon");
+  assert.equal(root.lastUpdate?.world.ownHeroes[0]?.loadout.equipment.weaponId, undefined);
+  assert.deepEqual(root.lastUpdate?.world.ownHeroes[0]?.loadout.inventory, ["militia_pike"]);
+  assert.deepEqual(calls, [
+    {
+      kind: "equip",
+      slot: "weapon",
+      equipmentId: "militia_pike"
+    },
+    {
+      kind: "unequip",
+      slot: "weapon"
+    }
+  ]);
+});
+
 test("VeilRoot account lifecycle flow switches panels and surfaces validation feedback", async () => {
   const root = createVeilRootHarness();
 


### PR DESCRIPTION
## Summary
- route primary HUD pointer input through rendered action, skill, and equipment controls
- keep equip and unequip interactions wired to the existing session-authoritative flow
- add focused Cocos tests for HUD equipment dispatch and the equip/unequip loop

## Verification
- node --import tsx --test ./apps/cocos-client/test/cocos-hud-panel.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts ./apps/cocos-client/test/cocos-hero-equipment.test.ts
- npm run typecheck:cocos

Closes #441