### PR TITLE
test(cocos): add primary runtime smoke harness

### DIFF
--- a/apps/cocos-client/test/cocos-primary-runtime-smoke.test.ts
+++ b/apps/cocos-client/test/cocos-primary-runtime-smoke.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { Node, sys } from "cc";
+import { resetVeilCocosSessionRuntimeForTests, setVeilCocosSessionRuntimeForTests, VeilCocosSession } from "../assets/scripts/VeilCocosSession.ts";
+import { resetPixelSpriteRuntimeForTests } from "../assets/scripts/cocos-pixel-sprites.ts";
+import { writeStoredCocosAuthSession } from "../assets/scripts/cocos-session-launch.ts";
+import { resetVeilRootRuntimeForTests, setVeilRootRuntimeForTests, VeilRoot } from "../assets/scripts/VeilRoot.ts";
+import { createMemoryStorage, createSdkLoader, createSessionUpdate, FakeColyseusRoom } from "./helpers/cocos-session-fixtures.ts";
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+async function waitFor(assertion: () => boolean, onTimeout: () => string, attempts = 20): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (assertion()) {
+      return;
+    }
+    await flushMicrotasks();
+  }
+
+  assert.fail(onTimeout());
+}
+
+function seedStoredReplay(storage: Storage, update: ReturnType<typeof createSessionUpdate>): void {
+  storage.setItem(
+    `project-veil:cocos:session-replay:${update.world.meta.roomId}:${update.world.playerId}`,
+    JSON.stringify({
+      version: 1,
+      storedAt: Date.now(),
+      update
+    })
+  );
+}
+
+afterEach(() => {
+  resetVeilRootRuntimeForTests();
+  resetVeilCocosSessionRuntimeForTests();
+  resetPixelSpriteRuntimeForTests();
+  (sys as unknown as { localStorage: Storage | null }).localStorage = null;
+  delete (globalThis as { history?: History }).history;
+  delete (globalThis as { location?: Location }).location;
+});
+
+test("primary cocos runtime smoke boots VeilRoot from cached replay into the first live snapshot", async () => {
+  const storage = createMemoryStorage();
+  const replayedUpdate = createSessionUpdate(2, "room-smoke", "player-smoke");
+  const liveUpdate = createSessionUpdate(3, "room-smoke", "player-smoke");
+  const room = new FakeColyseusRoom([liveUpdate], "smoke-reconnect-token");
+  const joinedOptions: Array<{ logicalRoomId: string; playerId: string; seed: number }> = [];
+
+  writeStoredCocosAuthSession(storage, {
+    token: "smoke.auth.token",
+    playerId: "player-smoke",
+    displayName: "Smoke Player",
+    authMode: "account",
+    provider: "account-password",
+    loginId: "smoke-player",
+    source: "remote"
+  });
+  seedStoredReplay(storage, replayedUpdate);
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    loadSdk: createSdkLoader({
+      joinRooms: [room],
+      joinedOptions
+    })
+  });
+  setVeilRootRuntimeForTests({
+    createSession: (...args) => VeilCocosSession.create(...args),
+    readStoredReplay: (...args) => VeilCocosSession.readStoredReplay(...args)
+  });
+
+  (globalThis as { location?: Pick<Location, "search" | "href"> }).location = {
+    search: "?roomId=room-smoke",
+    href: "http://127.0.0.1:4173/?roomId=room-smoke"
+  };
+  (globalThis as { history?: Pick<History, "replaceState"> }).history = {
+    replaceState() {}
+  };
+
+  const sceneNode = new Node("RuntimeSmokeScene");
+  const rootNode = new Node("VeilRootSmoke");
+  rootNode.parent = sceneNode;
+  const root = rootNode.addComponent(VeilRoot) as VeilRoot & Record<string, unknown>;
+  const applyReplayedSessionUpdate = root.applyReplayedSessionUpdate.bind(root);
+  const applySessionUpdate = root.applySessionUpdate.bind(root);
+  const order: string[] = [];
+
+  root.applyReplayedSessionUpdate = (update) => {
+    order.push(`replay:${update.world.meta.day}`);
+    applyReplayedSessionUpdate(update);
+  };
+  root.applySessionUpdate = async (update) => {
+    order.push(`live:${update.world.meta.day}`);
+    await applySessionUpdate(update);
+  };
+
+  root.onLoad();
+  root.autoConnect = true;
+  root.start();
+  await waitFor(
+    () => root.lastUpdate?.world.meta.day === 3,
+    () =>
+      JSON.stringify({
+        showLobby: root.showLobby,
+        autoConnect: root.autoConnect,
+        sessionSource: root.sessionSource,
+        lastUpdateDay: root.lastUpdate?.world.meta.day ?? null,
+        logLines: root.logLines,
+        sentMessages: room.sentMessages
+      })
+  );
+
+  assert.equal(root.showLobby, false);
+  assert.equal(root.sessionSource, "remote");
+  assert.equal(root.authToken, "smoke.auth.token");
+  assert.equal(root.lastUpdate?.world.meta.day, 3);
+  assert.deepEqual(order, ["replay:2", "live:3"]);
+  assert.deepEqual(joinedOptions, [
+    {
+      logicalRoomId: "room-smoke",
+      playerId: "player-smoke",
+      seed: 1001
+    }
+  ]);
+  assert.deepEqual(room.sentMessages, [
+    {
+      type: "connect",
+      payload: {
+        type: "connect",
+        requestId: "cocos-req-1",
+        roomId: "room-smoke",
+        playerId: "player-smoke",
+        displayName: "Smoke Player",
+        authToken: "smoke.auth.token"
+      }
+    }
+  ]);
+  assert.deepEqual(
+    rootNode.children.map((child) => child.name),
+    [
+      "ProjectVeilMusicAudio",
+      "ProjectVeilCueAudio",
+      "ProjectVeilHud",
+      "ProjectVeilLobbyPanel",
+      "ProjectVeilMap",
+      "ProjectVeilBattlePanel",
+      "ProjectVeilTimelinePanel",
+      "ProjectVeilAccountReviewPanel"
+    ]
+  );
+
+  root.onDestroy();
+  await flushMicrotasks();
+});

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "check:issue33-assets": "node ./scripts/check-issue-33-art-staging.mjs",
     "test": "node --import tsx --test \"packages/shared/test/**/*.test.ts\" \"apps/server/test/**/*.test.ts\" \"apps/client/test/**/*.test.ts\" \"apps/cocos-client/test/**/*.test.ts\"",
     "test:coverage:ci": "node --import tsx ./scripts/ci-v8-coverage.ts",
+    "test:cocos:runtime-smoke": "node --import tsx --test ./apps/cocos-client/test/cocos-primary-runtime-smoke.test.ts",
     "test:e2e": "npm run validate:e2e:fixtures && playwright test",
     "test:e2e:headed": "npm run validate:e2e:fixtures && playwright test --headed",
     "test:e2e:all": "npm run test:e2e && npm run test:e2e:multiplayer",


### PR DESCRIPTION
## Summary
- add a direct Cocos primary runtime smoke test that mounts `VeilRoot` on the repo-native `cc` stub scene graph
- drive `onLoad`/`start` through a real `VeilCocosSession` backed by fake Colyseus rooms so cached replay plus first live snapshot boot stays covered
- expose the harness with `npm run test:cocos:runtime-smoke` for CI and local verification

## Testing
- npm run test:cocos:runtime-smoke
- node --import tsx --test apps/cocos-client/test/cocos-runtime-harness.test.ts

Closes #448