### PR TITLE
test(e2e): add deterministic golden-path regression gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:e2e": "npm run validate:e2e:fixtures && playwright test",
     "test:e2e:headed": "npm run validate:e2e:fixtures && playwright test --headed",
     "test:e2e:all": "npm run test:e2e && npm run test:e2e:multiplayer",
+    "test:e2e:golden-path": "npm run validate:e2e:fixtures && playwright test ./tests/e2e/golden-path-player-journey.spec.ts --config=playwright.smoke.config.ts",
     "test:e2e:smoke": "npm run validate:e2e:fixtures && playwright test --config=playwright.smoke.config.ts",
     "test:e2e:h5:connectivity": "npm run validate:e2e:fixtures && playwright test --config=playwright.h5-connectivity.config.ts",
     "test:e2e:multiplayer": "npm run validate:e2e:fixtures && playwright test --config=playwright.multiplayer.config.ts",

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  testMatch: /(lobby-smoke|reconnect-prediction-convergence)\.spec\.ts/,
+  testMatch: /(golden-path-player-journey|lobby-smoke|reconnect-prediction-convergence)\.spec\.ts/,
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
   fullyParallel: false,

--- a/tests/e2e/golden-path-player-journey.spec.ts
+++ b/tests/e2e/golden-path-player-journey.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+import {
+  getHeroMoveTotal,
+  getMineClaimLogText,
+  getMineIncome,
+  getNeutralBattleReward,
+  getNeutralBattleRewardText
+} from "./config-fixtures";
+import {
+  attackOnce,
+  buildRoomId,
+  dismissBattleModal,
+  expectHeroMove,
+  expectHeroMoveSpent,
+  pressTile,
+  waitForLobbyReady,
+  withSmokeDiagnostics
+} from "./smoke-helpers";
+
+test("golden path player journey stays stable from lobby entry through world progress and battle reward", async (
+  { page },
+  testInfo
+) => {
+  const roomId = buildRoomId("e2e-golden-path");
+
+  await withSmokeDiagnostics(testInfo, [page], async () => {
+    await test.step("lobby: enter a room as a guest", async () => {
+      await waitForLobbyReady(page);
+      await page.locator("[data-lobby-room-id]").fill(roomId);
+      await page.locator("[data-lobby-player-id]").fill("player-1");
+      await page.locator("[data-lobby-display-name]").fill("Golden Path Guest");
+      await page.locator("[data-enter-room]").click();
+
+      await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
+      await expect(page.getByTestId("account-card")).toContainText("Golden Path Guest");
+      await expect(page.getByTestId("stat-day")).toHaveText(/1/);
+      await expectHeroMove(page, getHeroMoveTotal());
+      await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*0/);
+      await expect(page.getByTestId("stat-gold")).toHaveText(/Gold\s*0/);
+    });
+
+    await test.step("world: collect wood and claim the mine", async () => {
+      await pressTile(page, 0, 1);
+      await expectHeroMoveSpent(page, 1);
+
+      await pressTile(page, 0, 0);
+      await expectHeroMoveSpent(page, 2);
+
+      await pressTile(page, 0, 0);
+      await expect(page.getByTestId("stat-wood")).toHaveText(/Wood\s*5/);
+
+      await pressTile(page, 3, 1);
+      await expectHeroMoveSpent(page, 6);
+
+      await pressTile(page, 3, 1);
+      await expect(page.getByTestId("stat-wood")).toHaveText(new RegExp(`Wood\\s*${5 + getMineIncome()}`));
+      await expect(page.getByTestId("event-log")).toContainText(getMineClaimLogText());
+    });
+
+    await test.step("world: end the day and reset movement", async () => {
+      await page.locator("[data-end-day]").click();
+      await expect(page.getByTestId("stat-day")).toHaveText(/2/);
+      await expectHeroMove(page, getHeroMoveTotal());
+      await expect(page.getByTestId("stat-wood")).toHaveText(new RegExp(`Wood\\s*${5 + getMineIncome()}`));
+    });
+
+    await test.step("battle: clear the neutral encounter and keep the reward", async () => {
+      await pressTile(page, 5, 4);
+      await expectHeroMoveSpent(page, 5);
+      await expect(page.getByTestId("battle-attack")).toBeVisible();
+
+      for (let index = 0; index < 6; index += 1) {
+        if (await page.getByTestId("battle-modal").isVisible().catch(() => false)) {
+          break;
+        }
+
+        await attackOnce(page);
+      }
+
+      await expect(page.getByTestId("battle-modal-title")).toHaveText("战斗胜利");
+      await expect(page.getByTestId("battle-modal-body")).toContainText(getNeutralBattleRewardText());
+      await dismissBattleModal(page);
+      await expect(page.getByTestId("stat-gold")).toHaveText(new RegExp(`Gold\\s*${getNeutralBattleReward().amount}`));
+      await expect(page.getByTestId("battle-empty")).toHaveText(/No active battle/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic Playwright golden-path player journey that reuses the existing smoke/runtime helpers
- include the journey in the existing smoke gate and expose a narrow `test:e2e:golden-path` script for CI/local use
- keep the change set dependency-light by staying on current Playwright and app runtime surfaces

## Verification
- `npm run validate:e2e:fixtures`
- `npm run typecheck:client:h5`
- `npm run test:e2e:golden-path` *(blocked in this host environment: Playwright Chromium cannot launch because `libatk-bridge-2.0.so.0` is missing)*

Closes #449