### PR TITLE
test(cocos): cover battle transition fallback flow

### DIFF
--- a/apps/cocos-client/test/cocos-battle-transition.test.ts
+++ b/apps/cocos-client/test/cocos-battle-transition.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ImageAsset, Sprite, SpriteFrame, UIOpacity } from "cc";
+import { VeilBattleTransition } from "../assets/scripts/VeilBattleTransition.ts";
+import {
+  loadPlaceholderSpriteAssets,
+  resetPlaceholderSpriteAssetsForTests,
+  setPlaceholderSpriteRuntimeForTests
+} from "../assets/scripts/cocos-placeholder-sprites.ts";
+import { createComponentHarness, findNode, readLabelString } from "./helpers/cocos-panel-harness.ts";
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+test("VeilBattleTransition uses placeholder terrain frames when pixel battle art is unavailable", async (t) => {
+  setPlaceholderSpriteRuntimeForTests({
+    loader: {
+      load(path, _type, callback) {
+        const asset = new ImageAsset();
+        asset.name = path;
+        callback(null, asset);
+      },
+      release() {}
+    },
+    spriteFrameFactory: {
+      createWithImage(imageAsset: ImageAsset) {
+        const frame = new SpriteFrame();
+        frame.name = imageAsset.name;
+        frame.texture = imageAsset;
+        return frame;
+      }
+    }
+  });
+  t.after(() => {
+    resetPlaceholderSpriteAssetsForTests();
+  });
+
+  await loadPlaceholderSpriteAssets("map");
+
+  const { component, node } = createComponentHarness(VeilBattleTransition, {
+    name: "BattleTransitionRoot",
+    width: 960,
+    height: 640
+  });
+  const statefulComponent = component as VeilBattleTransition & Record<string, unknown>;
+  statefulComponent.scheduleOnce = ((callback: () => void) => {
+    callback();
+    return undefined;
+  }) as typeof component.scheduleOnce;
+
+  component.onLoad();
+  await flushMicrotasks();
+
+  await component.playEnter({
+    badge: "ENGAGE",
+    title: "遭遇中立守军",
+    subtitle: "切入战斗场景",
+    tone: "enter",
+    terrain: "sand",
+    detailChips: [
+      { icon: "battle", label: "中立遭遇" },
+      { icon: "hero", label: "Guard x12" }
+    ]
+  });
+
+  const overlayNode = findNode(node, "ProjectVeilBattleOverlay");
+  const terrainNode = findNode(node, "ProjectVeilBattleOverlayTerrain");
+  const terrainSprite = terrainNode?.getComponent(Sprite) ?? null;
+  const terrainOpacity = terrainNode?.getComponent(UIOpacity) ?? null;
+
+  assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlayBadge")), "ENGAGE");
+  assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlayTitle")), "遭遇中立守军");
+  assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlaySubtitle")), "切入战斗场景");
+  assert.equal(terrainNode?.active, true);
+  assert.equal(terrainSprite?.spriteFrame?.name, "placeholder/tiles/sand-1");
+  assert.equal(terrainOpacity?.opacity, 246);
+  assert.equal(findNode(node, "ProjectVeilBattleOverlayChips")?.active, true);
+  assert.equal(overlayNode?.active, false);
+
+  await component.playExit({
+    badge: "VICTORY",
+    title: "战斗胜利",
+    subtitle: "返回世界地图",
+    tone: "victory",
+    terrain: null,
+    detailChips: []
+  });
+
+  assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlayBadge")), "VICTORY");
+  assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlayTitle")), "战斗胜利");
+  assert.equal(terrainNode?.active, false);
+  assert.equal(terrainSprite?.spriteFrame, null);
+  assert.equal(terrainOpacity?.opacity, 0);
+  assert.equal(findNode(node, "ProjectVeilBattleOverlayChips")?.active, false);
+
+  component.onDestroy();
+});

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -6,6 +6,9 @@ import {
   createCocosAccountReviewState,
   transitionCocosAccountReviewState
 } from "../assets/scripts/cocos-account-review.ts";
+import { createCocosAudioRuntime } from "../assets/scripts/cocos-audio-runtime.ts";
+import { cocosPresentationConfig } from "../assets/scripts/cocos-presentation-config.ts";
+import { VeilRoot } from "../assets/scripts/VeilRoot.ts";
 import { createMemoryStorage, createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
 import { createVeilRootHarness, installVeilRootRuntime, resetVeilRootRuntime } from "./helpers/veil-root-harness.ts";
 import type { BattleAction, BattleState, SessionUpdate, VeilCocosSessionOptions } from "../assets/scripts/VeilCocosSession.ts";
@@ -709,6 +712,74 @@ test("VeilRoot runtime harness carries the first battle back to world state", as
   assert.deepEqual(transitionCalls, ["enter:遭遇中立守军", "exit:战斗胜利"]);
   assert.equal(root.battlePresentation.getState().phase, "resolution");
   assert.equal(root.battlePresentation.getState().result, "victory");
+});
+
+test("VeilRoot battle flow switches transition state and fallback audio scenes through enter and resolution", async () => {
+  const root = createVeilRootHarness();
+  const transitionCalls: string[] = [];
+  const animationCalls: string[] = [];
+
+  root.showLobby = false;
+  root.playerId = "player-1";
+  root.lastUpdate = createSessionUpdate(1);
+  root.mapBoard = {
+    playHeroAnimation(animation: string) {
+      animationCalls.push(animation);
+    },
+    showTileFeedback() {},
+    pulseObject() {}
+  } as never;
+  root.battleTransition = {
+    async playEnter(copy: { title: string }) {
+      transitionCalls.push(`enter:${copy.title}`);
+    },
+    async playExit(copy: { title: string }) {
+      transitionCalls.push(`exit:${copy.title}`);
+    }
+  } as never;
+  root.audioRuntime = createCocosAudioRuntime(cocosPresentationConfig.audio, {
+    setTimeout: (() => ({ id: 1 } as ReturnType<typeof setTimeout>)) as typeof setTimeout,
+    clearTimeout: (() => undefined) as typeof clearTimeout
+  }) as never;
+  root.renderView = (() => {
+    (VeilRoot.prototype as VeilRoot & Record<string, unknown>).syncMusicScene.call(root);
+  }) as typeof root.renderView;
+  root.syncWechatShareBridge = () => undefined;
+  root.refreshGameplayAccountProfile = async () => undefined;
+  delete root.applySessionUpdate;
+
+  await root.applySessionUpdate(createFirstBattleUpdate());
+
+  assert.deepEqual(transitionCalls, ["enter:遭遇中立守军"]);
+  assert.deepEqual(animationCalls, ["attack"]);
+  assert.deepEqual(root.audioRuntime.getState(), {
+    supported: false,
+    assetBacked: false,
+    unlocked: false,
+    currentScene: "battle",
+    lastCue: null,
+    cueCount: 0,
+    musicMode: "synth",
+    cueMode: "idle"
+  });
+  assert.equal(root.battlePresentation.getState().phase, "enter");
+
+  await root.applySessionUpdate(createReturnToWorldUpdate());
+
+  assert.deepEqual(transitionCalls, ["enter:遭遇中立守军", "exit:战斗胜利"]);
+  assert.deepEqual(animationCalls, ["attack", "victory"]);
+  assert.deepEqual(root.audioRuntime.getState(), {
+    supported: false,
+    assetBacked: false,
+    unlocked: false,
+    currentScene: "explore",
+    lastCue: "victory",
+    cueCount: 1,
+    musicMode: "synth",
+    cueMode: "idle"
+  });
+  assert.equal(root.battlePresentation.getState().phase, "resolution");
+  root.audioRuntime.dispose();
 });
 
 test("VeilRoot refreshAccountReviewPage loads paged event history into the lobby review state", async () => {


### PR DESCRIPTION
## Summary
- add direct component coverage for VeilBattleTransition enter/exit rendering with placeholder terrain fallback
- cover VeilRoot battle enter/resolution flow to verify transition calls and fallback audio scene changes
- keep validation scoped to focused cocos battle/audio fallback tests

Closes #457