### PR TITLE
test(server): cover matchmaking queue TTL expiry and reconnect cleanup

### DIFF
--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -420,6 +420,39 @@ test("client that misses the reconnect window is cleaned up from the player slot
   assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 0);
 });
 
+test("failed reconnect cleanup removes only the expired session and preserves other connected players", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-reconnect-timeout-multi-${Date.now()}`);
+  const timeoutClient = createFakeClient("session-timeout-multi");
+  const steadyClient = createFakeClient("session-steady-multi");
+  const internalRoom = room as VeilColyseusRoom & {
+    playerIdBySessionId: Map<string, string>;
+    allowReconnection(client: Client, seconds: number): Promise<Client>;
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, timeoutClient, "player-timeout", "connect-timeout-multi");
+  await connectPlayer(room, steadyClient, "player-steady", "connect-steady-multi");
+
+  internalRoom.allowReconnection = async () => {
+    throw new Error("reconnect window expired");
+  };
+  await room.onDrop(timeoutClient);
+  room.onLeave(timeoutClient);
+
+  assert.equal(internalRoom.playerIdBySessionId.has("session-timeout-multi"), false);
+  assert.equal(internalRoom.playerIdBySessionId.get("session-steady-multi"), "player-steady");
+  assert.deepEqual(Array.from(internalRoom.playerIdBySessionId.values()), ["player-steady"]);
+  assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 1);
+  assert.equal(lastSessionState(steadyClient, "reply").payload.world.ownHeroes[0]?.playerId, "player-steady");
+});
+
 test("room disposal after the last client leaves removes it from the active room list", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);

--- a/apps/server/test/matchmaking-routes.test.ts
+++ b/apps/server/test/matchmaking-routes.test.ts
@@ -411,3 +411,16 @@ test("pruneStaleEntries reports number of expired entries and keeps fresh ones",
   assert.equal(service.getStatus("player-expired-2").status, "idle");
   assert.equal(service.getStatus("player-fresh").status, "queued");
 });
+
+test("pruneStaleEntries keeps entries at the TTL boundary and expires only older ones", () => {
+  const service = new MatchmakingService();
+  seedQueue(service, [
+    createQueueRequest("player-expired", "2026-03-28T08:02:59.999Z"),
+    createQueueRequest("player-boundary", "2026-03-28T08:03:00.000Z")
+  ]);
+
+  const removed = service.pruneStaleEntries(2 * 60 * 1000, new Date("2026-03-28T08:05:00.000Z"));
+  assert.equal(removed, 1);
+  assert.equal(service.getStatus("player-expired").status, "idle");
+  assert.equal(service.getStatus("player-boundary").status, "queued");
+});


### PR DESCRIPTION
## Summary
- add a direct matchmaking TTL boundary test so queue expiry behavior is covered at the exact cutoff
- add reconnect cleanup coverage that proves an expired session is removed without disturbing other connected players
- keep coverage transport-free and CI-stable by extending the existing server test suites

## Testing
- node --import tsx --test ./apps/server/test/matchmaking-routes.test.ts
- node --import tsx --test ./apps/server/test/colyseus-room-lifecycle.test.ts

Closes #469