### PR TITLE
test(cocos): add primary client lobby journey coverage

### DIFF
--- a/apps/cocos-client/test/cocos-primary-client-journey.test.ts
+++ b/apps/cocos-client/test/cocos-primary-client-journey.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { Node, sys } from "cc";
+import { resetVeilCocosSessionRuntimeForTests, setVeilCocosSessionRuntimeForTests, VeilCocosSession } from "../assets/scripts/VeilCocosSession.ts";
+import { createFallbackCocosPlayerAccountProfile } from "../assets/scripts/cocos-lobby.ts";
+import { resetPixelSpriteRuntimeForTests } from "../assets/scripts/cocos-pixel-sprites.ts";
+import { buildCocosRuntimeDiagnosticsSnapshot } from "../assets/scripts/cocos-runtime-diagnostics.ts";
+import { writeStoredCocosAuthSession } from "../assets/scripts/cocos-session-launch.ts";
+import { resetVeilRootRuntimeForTests, setVeilRootRuntimeForTests, VeilRoot } from "../assets/scripts/VeilRoot.ts";
+import { createMemoryStorage, createSessionUpdate, createSdkLoader, FakeColyseusRoom } from "./helpers/cocos-session-fixtures.ts";
+
+type RootState = VeilRoot & Record<string, any>;
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+async function waitFor(assertion: () => boolean, onTimeout: () => unknown, attempts = 30): Promise<void> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (assertion()) {
+      return;
+    }
+    await flushMicrotasks();
+  }
+
+  assert.fail(JSON.stringify(onTimeout(), null, 2));
+}
+
+function createRootHarness() {
+  const sceneNode = new Node("PrimaryJourneyScene");
+  const rootNode = new Node("VeilRootJourney");
+  rootNode.parent = sceneNode;
+  const root = rootNode.addComponent(VeilRoot) as RootState;
+  root.renderView = () => undefined;
+  root.ensureViewNodes = () => undefined;
+  root.ensureUiCameraVisibility = () => undefined;
+  root.ensureHudActionBinding = () => undefined;
+  root.syncBrowserRoomQuery = () => undefined;
+  root.syncWechatShareBridge = () => ({
+    available: false,
+    menuEnabled: false,
+    handlerRegistered: false,
+    canShareDirectly: false,
+    immediateShared: false,
+    payload: null,
+    message: "disabled"
+  });
+  return { root, rootNode };
+}
+
+function captureJourneyArtifact(options: {
+  root: RootState;
+  phase: string;
+  joinedOptions?: Array<{ logicalRoomId: string; playerId: string; seed: number }>;
+  room?: FakeColyseusRoom;
+}) {
+  const { root } = options;
+  const update = root.lastUpdate ?? null;
+  return {
+    phase: options.phase,
+    identity: {
+      roomId: root.roomId,
+      playerId: root.playerId,
+      displayName: root.displayName,
+      authMode: root.authMode,
+      loginId: root.loginId,
+      sessionSource: root.sessionSource,
+      authTokenPresent: Boolean(root.authToken)
+    },
+    lobby: {
+      showLobby: root.showLobby,
+      status: root.lobbyStatus,
+      loading: root.lobbyLoading,
+      entering: root.lobbyEntering,
+      rooms: root.lobbyRooms?.map((room: Record<string, unknown>) => ({
+        roomId: room.roomId,
+        day: room.day,
+        connectedPlayers: room.connectedPlayers
+      })) ?? []
+    },
+    room: {
+      diagnosticsConnectionStatus: root.diagnosticsConnectionStatus,
+      lastUpdateDay: update?.world.meta.day ?? null,
+      lastUpdateReason: root.lastRoomUpdateReason,
+      lastUpdateSource: root.lastRoomUpdateSource,
+      logTail: root.logLines?.slice(0, 8) ?? [],
+      timelineTail: root.timelineEntries?.slice(0, 6) ?? [],
+      sentMessages: options.room?.sentMessages ?? [],
+      joinedOptions: options.joinedOptions ?? []
+    },
+    diagnostics: buildCocosRuntimeDiagnosticsSnapshot({
+      devOnly: true,
+      mode: update?.battle ? "battle" : "world",
+      roomId: root.roomId,
+      playerId: root.playerId,
+      connectionStatus: root.diagnosticsConnectionStatus,
+      lastUpdateSource: root.lastRoomUpdateSource,
+      lastUpdateReason: root.lastRoomUpdateReason,
+      lastUpdateAt: root.lastRoomUpdateAtMs,
+      update,
+      account: root.lobbyAccountProfile ?? createFallbackCocosPlayerAccountProfile(root.playerId, root.roomId, root.displayName),
+      timelineEntries: root.timelineEntries ?? [],
+      logLines: root.logLines ?? [],
+      predictionStatus: root.predictionStatus ?? "",
+      recoverySummary:
+        typeof root.predictionStatus === "string" && root.predictionStatus.includes("回放缓存状态")
+          ? root.predictionStatus
+          : null
+    })
+  };
+}
+
+afterEach(() => {
+  resetVeilRootRuntimeForTests();
+  resetVeilCocosSessionRuntimeForTests();
+  resetPixelSpriteRuntimeForTests();
+  (sys as unknown as { localStorage: Storage | null }).localStorage = null;
+  delete (globalThis as { history?: History }).history;
+  delete (globalThis as { location?: Location }).location;
+});
+
+test("primary cocos client journey reuses an account session from lobby bootstrap and joins the selected room", async () => {
+  const storage = createMemoryStorage();
+  const roomUpdate = createSessionUpdate(4, "room-journey", "player-account");
+  const room = new FakeColyseusRoom([roomUpdate], "journey-reconnect-token");
+  const joinedOptions: Array<{ logicalRoomId: string; playerId: string; seed: number }> = [];
+  const syncedAuthSession = {
+    token: "account.session.token",
+    playerId: "player-account",
+    displayName: "暮潮守望",
+    authMode: "account" as const,
+    provider: "account-password" as const,
+    loginId: "veil-ranger",
+    source: "remote" as const
+  };
+
+  writeStoredCocosAuthSession(storage, syncedAuthSession);
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+  (globalThis as { location?: Pick<Location, "search" | "href"> }).location = {
+    search: "",
+    href: "http://127.0.0.1:4173/"
+  };
+  (globalThis as { history?: Pick<History, "replaceState"> }).history = {
+    replaceState() {}
+  };
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    loadSdk: createSdkLoader({
+      joinRooms: [room],
+      joinedOptions
+    })
+  });
+  setVeilRootRuntimeForTests({
+    createSession: (...args) => VeilCocosSession.create(...args),
+    readStoredReplay: (...args) => VeilCocosSession.readStoredReplay(...args),
+    syncAuthSession: async () => syncedAuthSession,
+    loadLobbyRooms: async () => [
+      {
+        roomId: "room-journey",
+        seed: 1001,
+        day: 4,
+        connectedPlayers: 1,
+        heroCount: 1,
+        activeBattles: 0,
+        updatedAt: "2026-03-31T08:22:00.000Z"
+      }
+    ],
+    loadAccountProfile: async () =>
+      createFallbackCocosPlayerAccountProfile("player-account", "room-journey", "暮潮守望", {
+        source: "remote",
+        authMode: "account",
+        loginId: "veil-ranger"
+      })
+  });
+
+  const { root } = createRootHarness();
+  root.onLoad();
+  root.start();
+
+  await waitFor(
+    () => root.showLobby === true && root.lobbyRooms.length === 1 && root.sessionSource === "remote",
+    () => captureJourneyArtifact({ root, phase: "lobby-bootstrap", joinedOptions, room })
+  );
+
+  assert.equal(root.authMode, "account");
+  assert.equal(root.loginId, "veil-ranger");
+  assert.equal(root.lobbyRooms[0]?.roomId, "room-journey");
+  await root.enterLobbyRoom("room-journey");
+
+  await waitFor(
+    () => root.showLobby === false && root.lastUpdate?.world.meta.roomId === "room-journey",
+    () => captureJourneyArtifact({ root, phase: "room-join", joinedOptions, room })
+  );
+
+  assert.equal(root.authMode, "account");
+  assert.equal(root.loginId, "veil-ranger");
+  assert.equal(root.sessionSource, "remote");
+  assert.equal(root.lastUpdate?.world.meta.day, 4);
+  assert.deepEqual(joinedOptions, [
+    {
+      logicalRoomId: "room-journey",
+      playerId: "player-account",
+      seed: 1001
+    }
+  ]);
+  assert.deepEqual(room.sentMessages, [
+    {
+      type: "connect",
+      payload: {
+        type: "connect",
+        requestId: "cocos-req-1",
+        roomId: "room-journey",
+        playerId: "player-account",
+        displayName: "暮潮守望",
+        authToken: "account.session.token"
+      }
+    }
+  ]);
+
+  root.onDestroy();
+  await flushMicrotasks();
+});
+
+test("primary cocos client journey surfaces stale stored account sessions before room entry and clears auth state", async () => {
+  const storage = createMemoryStorage();
+
+  writeStoredCocosAuthSession(storage, {
+    token: "expired.account.token",
+    playerId: "player-expired",
+    displayName: "失效旅人",
+    authMode: "account",
+    provider: "account-password",
+    loginId: "expired-ranger",
+    source: "remote"
+  });
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+  (globalThis as { location?: Pick<Location, "search" | "href"> }).location = {
+    search: "",
+    href: "http://127.0.0.1:4173/"
+  };
+  (globalThis as { history?: Pick<History, "replaceState"> }).history = {
+    replaceState() {}
+  };
+
+  setVeilRootRuntimeForTests({
+    syncAuthSession: async () => null
+  });
+
+  const { root } = createRootHarness();
+  root.onLoad();
+
+  await root.enterLobbyRoom("room-expired");
+
+  const storedSession = storage.getItem("project-veil:auth-session");
+  assert.equal(root.showLobby, true, JSON.stringify(captureJourneyArtifact({ root, phase: "stale-session" }), null, 2));
+  assert.equal(root.authMode, "guest");
+  assert.equal(root.authToken, null);
+  assert.equal(root.sessionSource, "none");
+  assert.equal(root.loginId, "");
+  assert.equal(storedSession, null);
+  assert.equal(root.lobbyStatus, "账号会话已失效，请重新登录后再进入房间。");
+
+  root.onDestroy();
+  await flushMicrotasks();
+});

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -221,4 +221,4 @@
 当前仍未完成：
 
 - 真实邮件 / 短信 / 验证码通道
-- 更细的前端自动化回归，例如直接覆盖 Lobby DOM / Cocos 交互入口的端到端脚本
+- 更完整的前端自动化回归矩阵；当前已补上 `npm run test:cocos:primary-journey` 这条 primary Cocos client 的账号会话 -> Lobby -> 首次进房自动化切片，但更广的交互矩阵仍待继续扩充

--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -1,6 +1,20 @@
 # Primary Cocos Client Delivery Checklist
 
-This checklist is the maintained delivery baseline for the primary client at [`apps/cocos-client`](/home/gpt/project/ProjectVeil/apps/cocos-client). It keeps the release path small and stable by splitting release readiness into two automated artifact audits plus a short manual sign-off list.
+This checklist is the maintained delivery baseline for the primary client at [`apps/cocos-client`](/home/gpt/project/ProjectVeil/apps/cocos-client). It keeps the release path small and stable by splitting regression validation into one runtime-journey guard, two automated artifact audits, and a short manual sign-off list.
+
+## Primary Client Regression Gate
+
+Run the account -> lobby -> room-entry automation slice before packaging or signing off the primary client:
+
+```bash
+npm run test:cocos:primary-journey
+```
+
+The command exercises the Cocos `VeilRoot` launch path in CI-friendly node-based automation, reuses the existing runtime/session harness, and records artifact-rich assertion payloads when it fails so contributors can tell apart:
+
+- lobby/bootstrap environment issues
+- stale or unavailable auth session bootstrap
+- room join or gameplay-state regressions after lobby entry
 
 ## Automated Delivery Audit
 
@@ -37,6 +51,7 @@ Keep these manual items short and attach evidence through the existing release e
 ## Related Commands
 
 - Export template refresh: `npm run prepare:wechat-build`
+- Primary client journey regression: `npm run test:cocos:primary-journey`
 - Export validation: `npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - Package artifact: `npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime --source-revision <git-sha>`
 - RC artifact validation: `npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> --expected-revision <git-sha>`

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test": "node --import tsx --test \"packages/shared/test/**/*.test.ts\" \"apps/server/test/**/*.test.ts\" \"apps/client/test/**/*.test.ts\" \"apps/cocos-client/test/**/*.test.ts\"",
     "test:coverage:ci": "node --import tsx ./scripts/ci-v8-coverage.ts",
     "test:cocos:runtime-smoke": "node --import tsx --test ./apps/cocos-client/test/cocos-primary-runtime-smoke.test.ts",
+    "test:cocos:primary-journey": "node --import tsx --test ./apps/cocos-client/test/cocos-primary-client-journey.test.ts",
     "test:e2e": "npm run validate:e2e:fixtures && playwright test",
     "test:e2e:headed": "npm run validate:e2e:fixtures && playwright test --headed",
     "test:e2e:all": "npm run test:e2e && npm run test:e2e:multiplayer",


### PR DESCRIPTION
## Summary
- add a deterministic Cocos primary-client journey test for account-session bootstrap, lobby readiness, and first room join
- cover the stale stored-session negative path with artifact-rich assertion payloads built from runtime diagnostics
- document 
> project-veil@0.1.0 test:cocos:primary-journey
> node --import tsx --test ./apps/cocos-client/test/cocos-primary-client-journey.test.ts

✔ primary cocos client journey reuses an account session from lobby bootstrap and joins the selected room (21.655098ms)
✔ primary cocos client journey surfaces stale stored account sessions before room entry and clears auth state (2.73893ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 640.816079 as part of primary-client regression validation

Closes #482