### PR TITLE
test(wechat): automate device smoke evidence for RC gates

### DIFF
--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -53,7 +53,8 @@ The summary contains exactly three release dimensions:
 - `wechat-release`
   - Prefers `codex.wechat.rc-validation-report.json` when present.
   - Falls back to `codex.wechat.smoke-report.json` when the RC validation report is absent.
-  - Fails when required WeChat evidence is missing, failed, or still pending.
+  - Fails closed when required WeChat evidence is missing, failed, blocked, or still pending.
+  - Markdown/JSON summary text distinguishes `blocked` device/runtime evidence from true execution failures so CI reviewers can see whether a gate is red because proof is absent or because the runtime actually regressed.
 
 Any failed dimension makes the script exit non-zero so the result can act as a CI release gate.
 

--- a/docs/test-coverage-audit-issue-199.md
+++ b/docs/test-coverage-audit-issue-199.md
@@ -102,7 +102,7 @@ The current tooling makes coverage expansion slower than it needs to be:
 2. The repo now publishes scoped Node/V8 coverage through `npm run test:coverage:ci`, including `.coverage/summary.md`, raw V8 JSON artifacts, and minimum line/branch/function floors for `shared`, `server`, `client`, and `cocos-client`. The summary now calls out threshold failures explicitly so CI logs and `GITHUB_STEP_SUMMARY` show which scope and metric fell below its floor.
 3. H5 Playwright coverage is useful, but it only validates the DOM debug shell; it does not exercise the Cocos runtime that now serves as the primary client.
 4. Cocos scene components depend on `cc` runtime behavior, which makes them harder to test in plain `node:test` without maintaining more test doubles or extracting more pure logic seams.
-5. WeChat readiness still depends on artifact validation and manual smoke-report workflows rather than automated device/runtime execution.
+5. WeChat readiness now has a structured device/runtime evidence ingest path, but its confidence still depends on maintaining those automated evidence producers and expanding scene-level Cocos runtime coverage.
 
 ## Suggested Next Slice
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -30,7 +30,8 @@
 - 上传已打包产物：`npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`
 - 按 SHA 下载 CI artifact：`npm run download:wechat-release -- --sha <git-sha> [--output-dir artifacts/downloaded/wechat-release-<git-sha>]`
 - 验收已下载 artifact：`npm run verify:wechat-release -- --artifacts-dir <downloaded-artifact-dir> [--expected-revision <git-sha>]`
-- 生成 / 校验真机冒烟报告：`npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> [--report <report-path>] [--check --expected-revision <git-sha>]`
+- 生成 / 校验真机冒烟报告：`npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> [--report <report-path>] [--runtime-evidence <runtime-evidence.json>] [--check --expected-revision <git-sha>]`
+- 导入自动化设备/runtime 证据：`npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
 - 统一 Cocos RC 证据快照：`npm run release:cocos-rc:snapshot`
 - Primary client delivery checklist：`docs/cocos-primary-client-delivery.md`
@@ -69,13 +70,14 @@
    - 该命令会稳定输出 `codex.wechat.rc-validation-report.json`
    - JSON 至少包含 `version`、`commit`、artifact 路径、逐项检查结果和 `failureSummary`
    - `--version` 会要求并校验 `*.upload.json`；`--require-smoke-report` 会把 `codex.wechat.smoke-report.json` 设为必需门禁
-8. 运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成 `codex.wechat.smoke-report.json` 模板，并在真机或准真机上逐项填写结果。
-9. 完成真机 / 准真机冒烟后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
+8. 若已有设备农场、真机调试或准真机脚本产出的结构化 runtime 证据，执行 `npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`，把证据直接写入既有 `codex.wechat.smoke-report.json` schema。
+9. 若本次 RC 没有自动化 runtime 证据，再运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板，并在真机或准真机上逐项补录结果。
+10. 完成自动导入或人工补录后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
    - `reconnect-recovery` 必须复用 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md) 的 canonical scenario、最小成功信号和失败诊断口径。
-10. 运行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把微信 smoke 结果映射回统一的 Cocos RC 快照，并补齐首战 / 返回世界证据。
-11. 复制 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，为当前 candidate 回填设备、结论和 blocker。
-12. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
-13. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
+11. 运行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，脚本会自动把微信 smoke 的 Lobby / 进房 / 重连证据映射到统一的 Cocos RC 快照；若仍缺 Creator 预览链路，会在快照里显式标成 `partial` 或 `blocked`，而不是默认为通过。
+12. 复制 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，仅补充自动化未覆盖的设备、结论和 blocker。
+13. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
+14. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
 
 ## 发布彩排摘要
 
@@ -116,7 +118,7 @@
 
 ## 提审前 Smoke Check
 
-`npm run smoke:wechat-release` 会生成 `codex.wechat.smoke-report.json`，默认与 release artifact 放在同一目录。该文件是提审前必须保留的最小验收记录，建议直接随 artifact 归档保存。
+`npm run smoke:wechat-release` 会生成 `codex.wechat.smoke-report.json`，也可以通过 `--runtime-evidence <runtime-evidence.json>` 直接把自动化设备/runtime 结果导入同一 schema。该文件是提审前必须保留的最小验收记录，建议直接随 artifact 归档保存。
 
 最小必填项如下：
 
@@ -138,13 +140,58 @@
 推荐执行方式：
 
 1. 先跑 `npm run verify:wechat-release -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>]`
-2. 再跑 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板
-3. 在真机或微信开发者工具真机调试模式中逐项填写 `tester`、`device`、`executedAt`、`summary` 以及每个 case 的 `status` / `notes` / `evidence`
+2. 若已有自动化设备/runtime 证据，执行 `npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`
+3. 若没有自动化证据，再跑 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板
+4. 在真机或微信开发者工具真机调试模式中逐项填写 `tester`、`device`、`executedAt`、`summary` 以及每个 case 的 `status` / `notes` / `evidence`
    - `reconnect-recovery.requiredEvidence` 下的 `roomId`、`reconnectPrompt`、`restoredState` 都必须填非空字符串；细则见 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md)
    - `share-roundtrip.requiredEvidence` 下的 `shareScene`、`shareQuery`、`roundtripState` 也都必须填非空字符串，用来说明分享入口、参数和回流结果
-4. 回填完成后执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`
-5. 再执行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把 `login-lobby`、`room-entry`、`reconnect-recovery` 映射到统一 RC 快照，并补齐 `firstBattleResult` 与 `return-to-world` 证据。
-6. 复制并回填 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，确保 reviewer 能直接看到当前 RC 的设备、结论与未关闭风险。
+5. 回填完成后执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`
+6. 再执行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把 `login-lobby`、`room-entry`、`reconnect-recovery` 自动映射到统一 RC 快照；若设备 evidence 缺失，快照会标成 `blocked`，避免在 RC 汇总里被误判为通过。
+7. 复制并回填 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，确保 reviewer 能直接看到当前 RC 的设备、结论与未关闭风险。
+
+### 自动化 Runtime Evidence Schema
+
+`--runtime-evidence` 读取的是一个轻量 JSON，目标不是定义新 gate，而是把现有设备/runtime 观测写回 `codex.wechat.smoke-report.json`：
+
+```json
+{
+  "schemaVersion": 1,
+  "buildTemplatePlatform": "wechatgame",
+  "artifact": {
+    "archiveFileName": "veil-wechat-rc.tar.gz",
+    "archiveSha256": "<sha256>",
+    "sourceRevision": "<git-sha>"
+  },
+  "execution": {
+    "tester": "device-farm",
+    "device": "iPhone 15 Pro / WeChat 8.0.50",
+    "clientVersion": "8.0.50",
+    "executedAt": "2026-03-31T10:00:00+08:00",
+    "result": "passed",
+    "summary": "Automated device smoke evidence imported."
+  },
+  "cases": [
+    { "id": "startup", "status": "passed", "notes": "cold start ok", "evidence": ["startup.mp4"] },
+    { "id": "lobby-entry", "status": "passed", "notes": "lobby ok", "evidence": ["lobby.png"] },
+    { "id": "room-entry", "status": "passed", "notes": "room ok", "evidence": ["room.png"] },
+    {
+      "id": "reconnect-recovery",
+      "status": "passed",
+      "requiredEvidence": {
+        "roomId": "room-alpha",
+        "reconnectPrompt": "连接已恢复",
+        "restoredState": "Returned to the same room and HUD state."
+      }
+    },
+    { "id": "share-roundtrip", "status": "not_applicable" },
+    { "id": "key-assets", "status": "passed", "notes": "no 404 or whitelist error" }
+  ]
+}
+```
+
+- `startup` 与 `lobby-entry` 会合并写回现有 `login-lobby` case。
+- `blocked` 明确表示“设备/runtime 证据未完成”，RC summary 会把它和真正的 `failed` 区分开。
+- `reconnect-recovery.requiredEvidence` 仍是必填结构化字段，用来保证恢复路径不再只存在于人工备注中。
 
 若某项因当前包能力受限无法完整验证，可把 case 标记为 `not_applicable`，并在 `notes` 中写明原因与替代观察证据；其余必填项不得保留 `pending`。若因此形成风险，必须同步写入 blocker 模板，而不是只留在 smoke report 备注里。
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "verify:wechat-release": "node --import tsx ./scripts/verify-wechat-minigame-artifact.ts",
     "validate:wechat-rc": "node --import tsx ./scripts/validate-wechat-release-candidate.ts",
     "smoke:wechat-release": "node --import tsx ./scripts/smoke-wechat-minigame-release.ts",
+    "ingest:wechat-smoke-evidence": "node --import tsx ./scripts/smoke-wechat-minigame-release.ts",
     "release:readiness:snapshot": "node --import tsx ./scripts/release-readiness-snapshot.ts",
     "release:readiness:dashboard": "node --import tsx ./scripts/release-readiness-dashboard.ts",
     "release:gate:summary": "node --import tsx ./scripts/release-gate-summary.ts",

--- a/scripts/cocos-release-candidate-snapshot.ts
+++ b/scripts/cocos-release-candidate-snapshot.ts
@@ -2,8 +2,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-type EvidenceStatus = "pending" | "passed" | "failed" | "not_applicable";
-type SnapshotResult = "pending" | "passed" | "failed" | "partial";
+type EvidenceStatus = "pending" | "blocked" | "passed" | "failed" | "not_applicable";
+type SnapshotResult = "pending" | "blocked" | "passed" | "failed" | "partial";
 type BuildSurface = "creator_preview" | "wechat_preview" | "wechat_upload_candidate" | "other";
 type JourneyStepId = "lobby-entry" | "room-join" | "map-explore" | "first-battle" | "reconnect-restore" | "return-to-world";
 type CanonicalEvidenceId = "roomId" | "reconnectPrompt" | "restoredState" | "firstBattleResult";
@@ -40,6 +40,29 @@ interface ReleaseReadinessSnapshotCheck {
 
 interface ReleaseReadinessSnapshot {
   checks?: ReleaseReadinessSnapshotCheck[];
+}
+
+interface WechatSmokeReportCase {
+  id?: string;
+  status?: "pending" | "blocked" | "passed" | "failed" | "not_applicable";
+  notes?: string;
+  evidence?: string[];
+  requiredEvidence?: Partial<Record<CanonicalEvidenceId | "shareScene" | "shareQuery" | "roundtripState", string>>;
+}
+
+interface WechatSmokeReport {
+  execution?: {
+    tester?: string;
+    device?: string;
+    clientVersion?: string;
+    executedAt?: string;
+    result?: "pending" | "blocked" | "passed" | "failed";
+    summary?: string;
+  };
+  artifact?: {
+    sourceRevision?: string;
+  };
+  cases?: WechatSmokeReportCase[];
 }
 
 interface CanonicalEvidenceField {
@@ -439,7 +462,7 @@ function buildTemplate(args: Args): CocosReleaseCandidateSnapshot {
   const shortCommit = getGitValue(["rev-parse", "--short", "HEAD"]);
   const branch = getGitValue(["rev-parse", "--abbrev-ref", "HEAD"]);
 
-  return {
+  const snapshot: CocosReleaseCandidateSnapshot = {
     schemaVersion: 1,
     candidate: {
       name: args.candidate || `cocos-rc-${shortCommit}`,
@@ -472,6 +495,12 @@ function buildTemplate(args: Args): CocosReleaseCandidateSnapshot {
     requiredEvidence: buildRequiredEvidence(),
     journey: buildJourney()
   };
+
+  if (args.wechatSmokeReportPath) {
+    applyWechatSmokeReport(snapshot, readJsonFile<WechatSmokeReport>(path.resolve(args.wechatSmokeReportPath)));
+  }
+
+  return snapshot;
 }
 
 function assertNonEmptyString(value: unknown, label: string): string {
@@ -489,17 +518,125 @@ function assertStringArray(value: unknown, label: string): string[] {
 }
 
 function assertEvidenceStatus(value: unknown, label: string): EvidenceStatus {
-  if (value === "pending" || value === "passed" || value === "failed" || value === "not_applicable") {
+  if (value === "pending" || value === "blocked" || value === "passed" || value === "failed" || value === "not_applicable") {
     return value;
   }
   fail(`${label} has unsupported status: ${String(value)}`);
 }
 
 function assertSnapshotResult(value: unknown): SnapshotResult {
-  if (value === "pending" || value === "passed" || value === "failed" || value === "partial") {
+  if (value === "pending" || value === "blocked" || value === "passed" || value === "failed" || value === "partial") {
     return value;
   }
   fail(`execution.overallStatus has unsupported value: ${String(value)}`);
+}
+
+function mapSmokeStatusToJourneyStatus(value: WechatSmokeReportCase["status"]): EvidenceStatus {
+  if (value === "failed") {
+    return "failed";
+  }
+  if (value === "blocked") {
+    return "blocked";
+  }
+  if (value === "passed") {
+    return "passed";
+  }
+  if (value === "not_applicable") {
+    return "not_applicable";
+  }
+  return "pending";
+}
+
+function applyCaseToJourneyStep(
+  snapshot: CocosReleaseCandidateSnapshot,
+  stepId: JourneyStepId,
+  entry: WechatSmokeReportCase | undefined
+): void {
+  if (!entry) {
+    return;
+  }
+  const step = snapshot.journey.find((candidate) => candidate.id === stepId);
+  if (!step) {
+    return;
+  }
+  step.status = mapSmokeStatusToJourneyStatus(entry.status);
+  step.notes = entry.notes?.trim() || step.notes;
+  step.evidence = Array.isArray(entry.evidence) ? entry.evidence.filter((item): item is string => typeof item === "string") : [];
+  step.sourceRefs = ["wechat-smoke-report"];
+}
+
+function applyRequiredEvidenceValue(
+  snapshot: CocosReleaseCandidateSnapshot,
+  fieldId: CanonicalEvidenceId,
+  value: string | undefined,
+  evidence: string[]
+): void {
+  if (!value?.trim()) {
+    return;
+  }
+  const field = snapshot.requiredEvidence.find((entry) => entry.id === fieldId);
+  if (!field) {
+    return;
+  }
+  field.value = value.trim();
+  field.evidence = evidence;
+}
+
+function applyWechatSmokeReport(snapshot: CocosReleaseCandidateSnapshot, report: WechatSmokeReport): void {
+  const caseById = new Map((report.cases ?? []).map((entry) => [entry.id, entry]));
+  const loginLobby = caseById.get("login-lobby");
+  const roomEntry = caseById.get("room-entry");
+  const reconnect = caseById.get("reconnect-recovery");
+
+  applyCaseToJourneyStep(snapshot, "lobby-entry", loginLobby);
+  applyCaseToJourneyStep(snapshot, "room-join", roomEntry);
+  applyCaseToJourneyStep(snapshot, "reconnect-restore", reconnect);
+
+  const reconnectEvidence = reconnect?.requiredEvidence;
+  const reconnectArtifacts = Array.isArray(reconnect?.evidence)
+    ? reconnect.evidence.filter((item): item is string => typeof item === "string")
+    : [];
+  applyRequiredEvidenceValue(snapshot, "roomId", reconnectEvidence?.roomId, reconnectArtifacts);
+  applyRequiredEvidenceValue(snapshot, "reconnectPrompt", reconnectEvidence?.reconnectPrompt, reconnectArtifacts);
+  applyRequiredEvidenceValue(snapshot, "restoredState", reconnectEvidence?.restoredState, reconnectArtifacts);
+
+  if (!snapshot.execution.owner && report.execution?.tester?.trim()) {
+    snapshot.execution.owner = report.execution.tester.trim();
+  }
+  if (!snapshot.execution.executedAt && report.execution?.executedAt?.trim()) {
+    snapshot.execution.executedAt = report.execution.executedAt.trim();
+  }
+  if (!snapshot.environment.device && report.execution?.device?.trim()) {
+    snapshot.environment.device = report.execution.device.trim();
+  }
+  if (!snapshot.environment.wechatClient && report.execution?.clientVersion?.trim()) {
+    snapshot.environment.wechatClient = report.execution.clientVersion.trim();
+  }
+
+  const mappedSteps = snapshot.journey.filter((step) => ["lobby-entry", "room-join", "reconnect-restore"].includes(step.id));
+  const hasFailedMappedStep = mappedSteps.some((step) => step.status === "failed");
+  const hasBlockedMappedStep = mappedSteps.some((step) => step.status === "blocked");
+  const hasPendingUnmappedStep = snapshot.journey.some((step) => step.required && step.status === "pending");
+  if (hasFailedMappedStep) {
+    snapshot.execution.overallStatus = "failed";
+  } else if (hasBlockedMappedStep) {
+    snapshot.execution.overallStatus = "blocked";
+  } else if (hasPendingUnmappedStep) {
+    snapshot.execution.overallStatus = "partial";
+  } else {
+    snapshot.execution.overallStatus = report.execution?.result === "passed" ? "passed" : "partial";
+  }
+
+  const importedSummary = report.execution?.summary?.trim();
+  if (importedSummary) {
+    snapshot.execution.summary = importedSummary;
+  } else if (report.execution?.result === "blocked") {
+    snapshot.execution.summary =
+      "Imported WeChat smoke evidence is blocked; complete the missing device/runtime steps before treating this RC snapshot as passed.";
+  } else if (hasPendingUnmappedStep) {
+    snapshot.execution.summary =
+      "Imported WeChat smoke evidence populated lobby, room, and reconnect steps; creator-preview evidence is still required for explore, first battle, and return-to-world.";
+  }
 }
 
 function validateLinkedReleaseReadinessSnapshot(snapshotRef: LinkedEvidenceRef | undefined): void {
@@ -535,6 +672,9 @@ function validateSnapshot(snapshot: CocosReleaseCandidateSnapshot): void {
   if (snapshot.execution.overallStatus === "pending") {
     fail("execution.overallStatus must not be pending when using --check.");
   }
+  if (snapshot.execution.overallStatus === "blocked") {
+    fail("execution.overallStatus is blocked; required device/runtime evidence is still missing.");
+  }
   assertNonEmptyString(snapshot.execution.summary, "execution.summary");
   assertNonEmptyString(snapshot.environment.server, "environment.server");
 
@@ -547,6 +687,9 @@ function validateSnapshot(snapshot: CocosReleaseCandidateSnapshot): void {
     assertNonEmptyString(step.title, `journey[${step.id}].title`);
     assertStringArray(step.evidence, `journey[${step.id}].evidence`);
     assertStringArray(step.sourceRefs, `journey[${step.id}].sourceRefs`);
+    if (step.required && step.status === "blocked") {
+      fail(`Required journey step ${step.id} is blocked.`);
+    }
     if (step.required && step.status === "pending") {
       fail(`Required journey step ${step.id} is still pending.`);
     }

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -67,12 +67,12 @@ interface WechatRcValidationReport {
 
 interface WechatSmokeReport {
   execution?: {
-    result?: "pending" | "passed" | "failed";
+    result?: "pending" | "blocked" | "passed" | "failed";
     summary?: string;
   };
   cases?: Array<{
     id?: string;
-    status?: "pending" | "passed" | "failed" | "not_applicable";
+    status?: "pending" | "blocked" | "passed" | "failed" | "not_applicable";
     required?: boolean;
   }>;
 }
@@ -591,18 +591,27 @@ export function evaluateWechatGate(
   const failures: string[] = [];
   const requiredCases = (report.cases ?? []).filter((entry) => entry.required !== false);
   const failedCases = requiredCases.filter((entry) => entry.status === "failed");
+  const blockedCases = requiredCases.filter((entry) => entry.status === "blocked");
   const pendingCases = requiredCases.filter((entry) => entry.status === "pending");
 
   if (report.execution?.result !== "passed") {
-    failures.push(`WeChat smoke execution result is ${JSON.stringify(report.execution?.result ?? "missing")}.`);
+    if (report.execution?.result === "blocked" || report.execution?.result === "pending" || report.execution?.result === undefined) {
+      failures.push(`WeChat smoke evidence is blocked: execution result is ${JSON.stringify(report.execution?.result ?? "missing")}.`);
+    } else {
+      failures.push(`WeChat smoke execution result is ${JSON.stringify(report.execution?.result)}.`);
+    }
   }
   for (const entry of failedCases) {
     failures.push(`WeChat smoke case failed: ${entry.id ?? "unknown-case"}.`);
   }
+  for (const entry of blockedCases) {
+    failures.push(`WeChat smoke case is blocked: ${entry.id ?? "unknown-case"}.`);
+  }
   for (const entry of pendingCases) {
-    failures.push(`WeChat smoke case is still pending: ${entry.id ?? "unknown-case"}.`);
+    failures.push(`WeChat smoke case is blocked pending device evidence: ${entry.id ?? "unknown-case"}.`);
   }
 
+  const blocked = failures.some((entry) => entry.includes("blocked"));
   return {
     id: "wechat-release",
     label: "WeChat release validation",
@@ -610,7 +619,9 @@ export function evaluateWechatGate(
     summary:
       failures.length === 0
         ? `WeChat smoke report passed ${requiredCases.length} required cases.`
-        : `WeChat smoke report failed: ${failures[0]}`,
+        : blocked
+          ? `WeChat smoke report blocked: ${failures[0]}`
+          : `WeChat smoke report failed: ${failures[0]}`,
     failures,
     source: {
       kind: "wechat-smoke-report",

--- a/scripts/smoke-wechat-minigame-release.ts
+++ b/scripts/smoke-wechat-minigame-release.ts
@@ -5,6 +5,7 @@ interface Args {
   artifactsDir?: string;
   metadataPath?: string;
   reportPath?: string;
+  runtimeEvidencePath?: string;
   expectedRevision?: string;
   check: boolean;
   force: boolean;
@@ -27,7 +28,8 @@ interface WechatMinigameReleasePackageMetadata {
   remoteAssetRoot?: string;
 }
 
-type SmokeStatus = "pending" | "passed" | "failed" | "not_applicable";
+type SmokeStatus = "pending" | "blocked" | "passed" | "failed" | "not_applicable";
+type SmokeExecutionResult = "pending" | "blocked" | "passed" | "failed";
 
 type ReconnectEvidenceFieldId = "roomId" | "reconnectPrompt" | "restoredState";
 type ShareRoundtripEvidenceFieldId = "shareScene" | "shareQuery" | "roundtripState";
@@ -74,10 +76,47 @@ interface WechatMinigameSmokeReport {
     device: string;
     clientVersion: string;
     executedAt: string;
-    result: "pending" | "passed" | "failed";
+    result: SmokeExecutionResult;
     summary: string;
   };
   cases: WechatMinigameSmokeCase[];
+}
+
+type RuntimeEvidenceCaseId =
+  | "startup"
+  | "lobby-entry"
+  | "room-entry"
+  | "reconnect-recovery"
+  | "share-roundtrip"
+  | "key-assets";
+
+type RuntimeEvidenceStatus = "blocked" | "passed" | "failed" | "not_applicable";
+
+interface RuntimeEvidenceCase {
+  id: RuntimeEvidenceCaseId;
+  status: RuntimeEvidenceStatus;
+  notes?: string;
+  evidence?: string[];
+  requiredEvidence?: Partial<Record<ReconnectEvidenceFieldId | ShareRoundtripEvidenceFieldId, string>>;
+}
+
+interface RuntimeSmokeEvidenceReport {
+  schemaVersion: 1;
+  buildTemplatePlatform: "wechatgame";
+  artifact?: {
+    archiveFileName?: string;
+    archiveSha256?: string;
+    sourceRevision?: string;
+  };
+  execution: {
+    tester: string;
+    device: string;
+    clientVersion: string;
+    executedAt: string;
+    result?: Exclude<RuntimeEvidenceStatus, "not_applicable">;
+    summary?: string;
+  };
+  cases: RuntimeEvidenceCase[];
 }
 
 const REQUIRED_CASE_IDS: WechatMinigameSmokeCase["id"][] = [
@@ -96,6 +135,7 @@ function parseArgs(argv: string[]): Args {
   let artifactsDir: string | undefined;
   let metadataPath: string | undefined;
   let reportPath: string | undefined;
+  let runtimeEvidencePath: string | undefined;
   let expectedRevision: string | undefined;
   let check = false;
   let force = false;
@@ -118,6 +158,11 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--runtime-evidence" && next) {
+      runtimeEvidencePath = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--expected-revision" && next) {
       expectedRevision = next.trim() || undefined;
       index += 1;
@@ -136,6 +181,7 @@ function parseArgs(argv: string[]): Args {
     ...(artifactsDir ? { artifactsDir } : {}),
     ...(metadataPath ? { metadataPath } : {}),
     ...(reportPath ? { reportPath } : {}),
+    ...(runtimeEvidencePath ? { runtimeEvidencePath } : {}),
     ...(expectedRevision ? { expectedRevision } : {}),
     check,
     force
@@ -268,6 +314,185 @@ function buildSmokeCases(): WechatMinigameSmokeCase[] {
       ]
     }
   ];
+}
+
+function findRuntimeCase(
+  report: RuntimeSmokeEvidenceReport,
+  caseId: RuntimeEvidenceCaseId
+): RuntimeEvidenceCase | undefined {
+  return report.cases.find((entry) => entry.id === caseId);
+}
+
+function assertStringArray(value: unknown, label: string): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    fail(`${label} must be a string array.`);
+  }
+  return value.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+}
+
+function combineRuntimeStatuses(statuses: RuntimeEvidenceStatus[]): SmokeStatus {
+  if (statuses.some((status) => status === "failed")) {
+    return "failed";
+  }
+  if (statuses.some((status) => status === "blocked")) {
+    return "blocked";
+  }
+  if (statuses.every((status) => status === "not_applicable")) {
+    return "not_applicable";
+  }
+  if (statuses.every((status) => status === "passed")) {
+    return "passed";
+  }
+  return "pending";
+}
+
+function mergeText(parts: Array<string | undefined>): string {
+  return parts.map((part) => part?.trim() ?? "").filter((part) => part.length > 0).join("\n");
+}
+
+function requireRuntimeString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`Runtime evidence ${label} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function applyRuntimeEvidence(
+  template: WechatMinigameSmokeReport,
+  runtimeEvidence: RuntimeSmokeEvidenceReport,
+  metadata: WechatMinigameReleasePackageMetadata
+): WechatMinigameSmokeReport {
+  if (runtimeEvidence.schemaVersion !== 1) {
+    fail(`Runtime evidence schemaVersion must be 1, received ${JSON.stringify(runtimeEvidence.schemaVersion)}.`);
+  }
+  if (runtimeEvidence.buildTemplatePlatform !== "wechatgame") {
+    fail(
+      `Runtime evidence buildTemplatePlatform must be "wechatgame", received ${JSON.stringify(runtimeEvidence.buildTemplatePlatform)}.`
+    );
+  }
+  if (!Array.isArray(runtimeEvidence.cases)) {
+    fail("Runtime evidence cases must be an array.");
+  }
+  if (runtimeEvidence.artifact?.archiveFileName && runtimeEvidence.artifact.archiveFileName !== metadata.archiveFileName) {
+    fail(
+      `Runtime evidence archiveFileName mismatch: expected ${metadata.archiveFileName}, received ${runtimeEvidence.artifact.archiveFileName}.`
+    );
+  }
+  if (runtimeEvidence.artifact?.archiveSha256 && runtimeEvidence.artifact.archiveSha256 !== metadata.archiveSha256) {
+    fail("Runtime evidence archiveSha256 does not match the release sidecar.");
+  }
+  if (runtimeEvidence.artifact?.sourceRevision && runtimeEvidence.artifact.sourceRevision !== metadata.sourceRevision) {
+    fail(
+      `Runtime evidence sourceRevision mismatch: expected ${metadata.sourceRevision ?? "<empty>"}, received ${runtimeEvidence.artifact.sourceRevision}.`
+    );
+  }
+
+  const startup = findRuntimeCase(runtimeEvidence, "startup");
+  const lobbyEntry = findRuntimeCase(runtimeEvidence, "lobby-entry");
+  const roomEntry = findRuntimeCase(runtimeEvidence, "room-entry");
+  const reconnect = findRuntimeCase(runtimeEvidence, "reconnect-recovery");
+  const shareRoundtrip = findRuntimeCase(runtimeEvidence, "share-roundtrip");
+  const keyAssets = findRuntimeCase(runtimeEvidence, "key-assets");
+
+  const caseUpdates: Record<WechatMinigameSmokeCase["id"], Partial<WechatMinigameSmokeCase>> = {
+    "login-lobby": startup && lobbyEntry
+      ? {
+          status: combineRuntimeStatuses([startup.status, lobbyEntry.status]),
+          notes: mergeText([
+            "Automated runtime evidence imported for startup + lobby entry.",
+            startup.notes ? `startup: ${startup.notes}` : undefined,
+            lobbyEntry.notes ? `lobby-entry: ${lobbyEntry.notes}` : undefined
+          ]),
+          evidence: [...assertStringArray(startup.evidence, "runtimeEvidence.startup.evidence"), ...assertStringArray(lobbyEntry.evidence, "runtimeEvidence.lobby-entry.evidence")]
+        }
+      : startup
+        ? {
+            status: startup.status,
+            notes: mergeText(["Automated runtime evidence imported for startup.", startup.notes]),
+            evidence: assertStringArray(startup.evidence, "runtimeEvidence.startup.evidence")
+          }
+        : lobbyEntry
+          ? {
+              status: lobbyEntry.status,
+              notes: mergeText(["Automated runtime evidence imported for lobby entry.", lobbyEntry.notes]),
+              evidence: assertStringArray(lobbyEntry.evidence, "runtimeEvidence.lobby-entry.evidence")
+            }
+          : {},
+    "room-entry": roomEntry
+      ? {
+          status: roomEntry.status,
+          notes: mergeText(["Automated runtime evidence imported.", roomEntry.notes]),
+          evidence: assertStringArray(roomEntry.evidence, "runtimeEvidence.room-entry.evidence")
+        }
+      : {},
+    "reconnect-recovery": reconnect
+      ? {
+          status: reconnect.status,
+          notes: mergeText(["Automated runtime evidence imported.", reconnect.notes]),
+          evidence: assertStringArray(reconnect.evidence, "runtimeEvidence.reconnect-recovery.evidence"),
+          requiredEvidence: {
+            roomId: reconnect.requiredEvidence?.roomId ?? "",
+            reconnectPrompt: reconnect.requiredEvidence?.reconnectPrompt ?? "",
+            restoredState: reconnect.requiredEvidence?.restoredState ?? ""
+          }
+        }
+      : {},
+    "share-roundtrip": shareRoundtrip
+      ? {
+          status: shareRoundtrip.status,
+          notes: mergeText(["Automated runtime evidence imported.", shareRoundtrip.notes]),
+          evidence: assertStringArray(shareRoundtrip.evidence, "runtimeEvidence.share-roundtrip.evidence"),
+          requiredEvidence: {
+            shareScene: shareRoundtrip.requiredEvidence?.shareScene ?? "",
+            shareQuery: shareRoundtrip.requiredEvidence?.shareQuery ?? "",
+            roundtripState: shareRoundtrip.requiredEvidence?.roundtripState ?? ""
+          }
+        }
+      : {},
+    "key-assets": keyAssets
+      ? {
+          status: keyAssets.status,
+          notes: mergeText(["Automated runtime evidence imported.", keyAssets.notes]),
+          evidence: assertStringArray(keyAssets.evidence, "runtimeEvidence.key-assets.evidence")
+        }
+      : {}
+  };
+
+  const cases = template.cases.map((entry) => ({
+    ...entry,
+    ...caseUpdates[entry.id]
+  }));
+
+  const requiredStatuses = cases.filter((entry) => entry.required !== false).map((entry) => entry.status);
+  const executionResult = runtimeEvidence.execution.result
+    ? runtimeEvidence.execution.result
+    : requiredStatuses.some((status) => status === "failed")
+      ? "failed"
+      : requiredStatuses.some((status) => status === "blocked")
+        ? "blocked"
+        : requiredStatuses.every((status) => status === "not_applicable")
+          ? "blocked"
+          : requiredStatuses.every((status) => status === "passed" || status === "not_applicable")
+            ? "passed"
+            : "blocked";
+
+  return {
+    ...template,
+    execution: {
+      tester: requireRuntimeString(runtimeEvidence.execution.tester, "execution.tester"),
+      device: requireRuntimeString(runtimeEvidence.execution.device, "execution.device"),
+      clientVersion: requireRuntimeString(runtimeEvidence.execution.clientVersion, "execution.clientVersion"),
+      executedAt: requireRuntimeString(runtimeEvidence.execution.executedAt, "execution.executedAt"),
+      result: executionResult,
+      summary:
+        runtimeEvidence.execution.summary?.trim() ||
+        "Smoke report populated from automated runtime/device evidence."
+    },
+    cases
+  };
 }
 
 function buildReportTemplate(metadata: WechatMinigameReleasePackageMetadata, metadataPath: string, reportPath: string): WechatMinigameSmokeReport {
@@ -467,6 +692,9 @@ function validateReportAgainstMetadata(
     if (!entry.required) {
       fail(`Smoke report case ${caseId} must remain required.`);
     }
+    if (entry.status === "blocked") {
+      fail(`Smoke report case ${caseId} is blocked pending device/runtime evidence.`);
+    }
     if (entry.status === "pending") {
       fail(`Smoke report case ${caseId} is still pending.`);
     }
@@ -480,6 +708,9 @@ function validateReportAgainstMetadata(
   }
   if (!report.execution.executedAt.trim()) {
     fail("Smoke report executedAt must be filled before validation.");
+  }
+  if (report.execution.result === "blocked") {
+    fail("Smoke report execution.result is blocked pending device/runtime evidence.");
   }
   if (report.execution.result === "pending") {
     fail("Smoke report execution.result must be passed or failed before validation.");
@@ -517,7 +748,11 @@ function main(): void {
     fail(`Smoke report already exists: ${reportPath}. Pass --force to overwrite it.`);
   }
 
-  const report = buildReportTemplate(metadata, metadataPath, reportPath);
+  let report = buildReportTemplate(metadata, metadataPath, reportPath);
+  if (args.runtimeEvidencePath) {
+    const runtimeEvidence = readJsonFile<RuntimeSmokeEvidenceReport>(path.resolve(args.runtimeEvidencePath));
+    report = applyRuntimeEvidence(report, runtimeEvidence, metadata);
+  }
   writeJsonFile(reportPath, report);
   console.log(`Wrote WeChat smoke report template: ${reportPath}`);
   console.log(`Artifact: ${metadata.archiveFileName}`);

--- a/scripts/test/cocos-release-candidate-snapshot.test.ts
+++ b/scripts/test/cocos-release-candidate-snapshot.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+function writeJson(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+test("release:cocos-rc:snapshot imports WeChat smoke evidence into linked journey fields", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-cocos-rc-snapshot-"));
+  const smokeReportPath = path.join(workspace, "codex.wechat.smoke-report.json");
+  const outputPath = path.join(workspace, "rc.snapshot.json");
+
+  writeJson(smokeReportPath, {
+    execution: {
+      tester: "codex-bot",
+      device: "iPhone 15 Pro",
+      clientVersion: "WeChat 8.0.50",
+      executedAt: "2026-03-31T10:30:00+08:00",
+      result: "passed",
+      summary: "Automated WeChat smoke evidence passed for startup, room, and reconnect."
+    },
+    artifact: {
+      sourceRevision: "abc1234"
+    },
+    cases: [
+      {
+        id: "login-lobby",
+        status: "passed",
+        notes: "Cold start reached the lobby.",
+        evidence: ["artifacts/wechat-release/lobby.png"]
+      },
+      {
+        id: "room-entry",
+        status: "passed",
+        notes: "Joined room-alpha.",
+        evidence: ["artifacts/wechat-release/room-entry.png"]
+      },
+      {
+        id: "reconnect-recovery",
+        status: "passed",
+        notes: "Recovered room-alpha after network resume.",
+        evidence: ["artifacts/wechat-release/reconnect.mp4"],
+        requiredEvidence: {
+          roomId: "room-alpha",
+          reconnectPrompt: "连接已恢复",
+          restoredState: "Restored the same room and HUD state."
+        }
+      }
+    ]
+  });
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/cocos-release-candidate-snapshot.ts",
+      "--candidate",
+      "rc-issue-480",
+      "--owner",
+      "release-bot",
+      "--server",
+      "wss://example.invalid",
+      "--build-surface",
+      "wechat_preview",
+      "--wechat-smoke-report",
+      smokeReportPath,
+      "--output",
+      outputPath
+    ],
+    {
+      cwd: repoRoot,
+      stdio: "pipe"
+    }
+  );
+
+  const snapshot = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    execution: { overallStatus: string; summary: string; executedAt: string };
+    environment: { device: string; wechatClient: string };
+    requiredEvidence: Array<{ id: string; value: string }>;
+    journey: Array<{ id: string; status: string; notes: string }>;
+  };
+
+  assert.equal(snapshot.execution.overallStatus, "partial");
+  assert.equal(snapshot.execution.executedAt, "2026-03-31T10:30:00+08:00");
+  assert.equal(snapshot.environment.device, "iPhone 15 Pro");
+  assert.equal(snapshot.environment.wechatClient, "WeChat 8.0.50");
+  assert.equal(snapshot.requiredEvidence.find((entry) => entry.id === "roomId")?.value, "room-alpha");
+  assert.equal(snapshot.journey.find((entry) => entry.id === "lobby-entry")?.status, "passed");
+  assert.match(snapshot.journey.find((entry) => entry.id === "reconnect-restore")?.notes ?? "", /Recovered room-alpha/);
+  assert.match(snapshot.execution.summary, /Automated WeChat smoke evidence passed/);
+});

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -127,7 +127,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /Recommend rehearsal: yes/);
 });
 
-test("buildReleaseGateSummaryReport fails when required evidence is pending or missing", () => {
+test("buildReleaseGateSummaryReport reports blocked WeChat device evidence distinctly from failures", () => {
   const workspace = createTempWorkspace();
   const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-fail.json");
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
@@ -160,7 +160,7 @@ test("buildReleaseGateSummaryReport fails when required evidence is pending or m
   });
   writeJson(wechatSmokeReportPath, {
     execution: {
-      result: "passed"
+      result: "blocked"
     },
     cases: [
       {
@@ -171,7 +171,7 @@ test("buildReleaseGateSummaryReport fails when required evidence is pending or m
       {
         id: "reconnect-recovery",
         required: true,
-        status: "pending"
+        status: "blocked"
       }
     ]
   });
@@ -193,7 +193,8 @@ test("buildReleaseGateSummaryReport fails when required evidence is pending or m
   assert.equal(report.summary.status, "failed");
   assert.deepEqual(report.summary.failedGateIds, ["release-readiness", "wechat-release"]);
   assert.match(report.gates[0]?.summary ?? "", /not release-ready/);
-  assert.match(report.gates[2]?.summary ?? "", /failed/i);
+  assert.match(report.gates[2]?.summary ?? "", /blocked/i);
+  assert.match(report.gates[2]?.failures.join("\n") ?? "", /blocked pending device evidence|WeChat smoke case is blocked/);
 });
 
 test("evaluateWechatGate prefers RC validation and falls back to smoke report", () => {

--- a/scripts/test/wechat-release-artifacts.test.ts
+++ b/scripts/test/wechat-release-artifacts.test.ts
@@ -27,6 +27,14 @@ interface ReleasePackageMetadata {
   sourceRevision?: string;
 }
 
+interface RuntimeEvidenceCasePayload {
+  id: string;
+  status: "blocked" | "passed" | "failed" | "not_applicable";
+  notes?: string;
+  evidence?: string[];
+  requiredEvidence?: Record<string, string>;
+}
+
 function hashFileSha256(filePath: string): string {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
@@ -152,6 +160,30 @@ function writePassingSmokeReport(metadataPath: string, reportPath: string): void
   };
 
   fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+}
+
+function writeRuntimeEvidence(metadataPath: string, runtimeEvidencePath: string, cases: RuntimeEvidenceCasePayload[], result?: "blocked" | "passed" | "failed"): void {
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8")) as ReleasePackageMetadata;
+  const payload = {
+    schemaVersion: 1,
+    buildTemplatePlatform: "wechatgame",
+    artifact: {
+      archiveFileName: metadata.archiveFileName,
+      archiveSha256: metadata.archiveSha256,
+      sourceRevision: metadata.sourceRevision
+    },
+    execution: {
+      tester: "codex-bot",
+      device: "iPhone 15 Pro / WeChat 8.0.50",
+      clientVersion: "8.0.50",
+      executedAt: "2026-03-31T10:00:00+08:00",
+      ...(result ? { result } : {}),
+      summary: "Automated device evidence imported from CI runtime adapter."
+    },
+    cases
+  };
+
+  fs.writeFileSync(runtimeEvidencePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
 function updateArchiveMetadata(metadataPath: string, archivePath: string): void {
@@ -342,5 +374,190 @@ test("validate:wechat-rc requires an upload receipt when version validation is r
       "smoke-report:passed",
       "upload-receipt:failed"
     ]
+  );
+});
+
+test("smoke:wechat-release ingests automated runtime evidence into the existing smoke schema", () => {
+  const artifact = packageFixtureArtifact();
+  const runtimeEvidencePath = path.join(artifact.artifactsDir, "codex.wechat.runtime-evidence.json");
+  const smokeReportPath = path.join(artifact.artifactsDir, "codex.wechat.smoke-report.json");
+
+  writeRuntimeEvidence(artifact.metadataPath, runtimeEvidencePath, [
+    {
+      id: "startup",
+      status: "passed",
+      notes: "Cold start reached the login bridge in 2.1s.",
+      evidence: ["artifacts/wechat-release/startup.mp4"]
+    },
+    {
+      id: "lobby-entry",
+      status: "passed",
+      notes: "Lobby rendered with guest identity and no fatal modal.",
+      evidence: ["artifacts/wechat-release/lobby.png"]
+    },
+    {
+      id: "room-entry",
+      status: "passed",
+      notes: "Joined room-alpha from the lobby.",
+      evidence: ["artifacts/wechat-release/room-entry.png"]
+    },
+    {
+      id: "reconnect-recovery",
+      status: "passed",
+      notes: "Recovered the same authority room after a network toggle.",
+      evidence: ["artifacts/wechat-release/reconnect.mp4"],
+      requiredEvidence: {
+        roomId: "room-alpha",
+        reconnectPrompt: "连接已恢复",
+        restoredState: "Restored room-alpha with the same hero state and lobby context."
+      }
+    },
+    {
+      id: "share-roundtrip",
+      status: "not_applicable",
+      notes: "Share roundtrip automation is excluded from this RC lane; artifact still records the intended payload.",
+      evidence: ["artifacts/wechat-release/share-not-applicable.txt"],
+      requiredEvidence: {
+        shareScene: "lobby",
+        shareQuery: "roomId=room-alpha&inviterId=player-7",
+        roundtripState: "Not executed in this automated lane."
+      }
+    },
+    {
+      id: "key-assets",
+      status: "passed",
+      notes: "Startup, lobby, and room critical assets loaded without 404s.",
+      evidence: ["artifacts/wechat-release/assets.log"]
+    }
+  ]);
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/smoke-wechat-minigame-release.ts",
+      "--metadata",
+      artifact.metadataPath,
+      "--report",
+      smokeReportPath,
+      "--runtime-evidence",
+      runtimeEvidencePath
+    ],
+    {
+      cwd: repoRoot,
+      stdio: "pipe"
+    }
+  );
+
+  const report = JSON.parse(fs.readFileSync(smokeReportPath, "utf8")) as {
+    execution: { tester: string; result: string };
+    cases: Array<{ id: string; status: string; notes: string; requiredEvidence?: Record<string, string> }>;
+  };
+
+  assert.equal(report.execution.tester, "codex-bot");
+  assert.equal(report.execution.result, "passed");
+  assert.equal(report.cases.find((entry) => entry.id === "login-lobby")?.status, "passed");
+  assert.match(report.cases.find((entry) => entry.id === "login-lobby")?.notes ?? "", /startup \+ lobby entry/i);
+  assert.equal(report.cases.find((entry) => entry.id === "reconnect-recovery")?.requiredEvidence?.roomId, "room-alpha");
+  assert.equal(report.cases.find((entry) => entry.id === "share-roundtrip")?.status, "not_applicable");
+
+  const validationOutput = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/smoke-wechat-minigame-release.ts",
+      "--metadata",
+      artifact.metadataPath,
+      "--report",
+      smokeReportPath,
+      "--check",
+      "--expected-revision",
+      sourceRevision
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  assert.match(validationOutput, /Validated WeChat smoke report:/);
+});
+
+test("smoke:wechat-release reports blocked automated evidence distinctly from failed evidence", () => {
+  const artifact = packageFixtureArtifact();
+  const runtimeEvidencePath = path.join(artifact.artifactsDir, "codex.wechat.runtime-evidence.blocked.json");
+  const smokeReportPath = path.join(artifact.artifactsDir, "codex.wechat.smoke-report.blocked.json");
+
+  writeRuntimeEvidence(
+    artifact.metadataPath,
+    runtimeEvidencePath,
+    [
+      {
+        id: "startup",
+        status: "passed",
+        evidence: ["startup.log"]
+      },
+      {
+        id: "lobby-entry",
+        status: "blocked",
+        notes: "Device farm did not attach to the lobby interaction phase.",
+        evidence: ["device-farm-summary.txt"]
+      },
+      {
+        id: "share-roundtrip",
+        status: "not_applicable",
+        requiredEvidence: {
+          shareScene: "lobby",
+          shareQuery: "roomId=room-alpha",
+          roundtripState: "Not executed in this automated lane."
+        }
+      }
+    ],
+    "blocked"
+  );
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/smoke-wechat-minigame-release.ts",
+      "--metadata",
+      artifact.metadataPath,
+      "--report",
+      smokeReportPath,
+      "--runtime-evidence",
+      runtimeEvidencePath
+    ],
+    {
+      cwd: repoRoot,
+      stdio: "pipe"
+    }
+  );
+
+  assert.throws(
+    () =>
+      execFileSync(
+        "node",
+        [
+          "--import",
+          "tsx",
+          "./scripts/smoke-wechat-minigame-release.ts",
+          "--metadata",
+          artifact.metadataPath,
+          "--report",
+          smokeReportPath,
+          "--check"
+        ],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+          stdio: "pipe"
+        }
+      ),
+    /blocked pending device\/runtime evidence/
   );
 });


### PR DESCRIPTION
## Summary
- add automated runtime/device evidence ingest for WeChat smoke reports
- map imported WeChat smoke evidence into the Cocos RC snapshot and distinguish blocked vs failed device evidence in release summaries
- update docs and focused tests for the new RC evidence flow

Closes #480