### PR TITLE
build(test): prevent root test drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ npm run dev:client:h5
 - 安装依赖：`npm ci --no-audit --no-fund`
 - 快速校验首条贡献路径：`npm run validate:quickstart`
 - 本地 WebSocket 服务：`npm run dev:server`
+- 仓库级 Node 单测入口：`npm test`
 - 运行时健康检查：`GET http://127.0.0.1:2567/api/runtime/health`
 - 鉴权就绪摘要：`GET http://127.0.0.1:2567/api/runtime/auth-readiness`
 - 运行时指标抓取：`GET http://127.0.0.1:2567/api/runtime/metrics`
@@ -178,6 +179,8 @@ npm run dev:client:h5
 - 内容包一致性验证：`npm run validate:content-pack -- --report-path artifacts/content-pack-validation-report.json`
 - 覆盖率 CI 同款校验：`npm run test:coverage:ci`
 - 覆盖率摘要：`.coverage/summary.md`
+- `npm test` 会通过 `git ls-files` 自动发现所有已检入仓库的 `*.test.ts` Node 测试文件并统一执行；新增此类测试时不需要手动维护根脚本列表。
+- 若测试没有被 `npm test` 自动拾取，先检查文件名是否为 `*.test.ts` 且已经 `git add`；`tests/e2e/**/*.spec.ts` 仍由 Playwright 入口负责，不属于根 `node:test` 流程。
 - 共享客户端载荷 contract 快照：`npm run test:contracts`
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sync:assets:h5-pixel": "npm run sync:assets:pixel",
     "validate:assets": "node --import tsx ./scripts/validate-assets.ts",
     "check:issue33-assets": "node ./scripts/check-issue-33-art-staging.mjs",
-    "test": "node --import tsx --test \"packages/shared/test/**/*.test.ts\" \"apps/server/test/**/*.test.ts\" \"apps/client/test/**/*.test.ts\" \"apps/cocos-client/test/**/*.test.ts\"",
+    "test": "node --import tsx ./scripts/run-root-tests.ts",
     "test:coverage:ci": "node --import tsx ./scripts/ci-v8-coverage.ts",
     "test:cocos:runtime-smoke": "node --import tsx --test ./apps/cocos-client/test/cocos-primary-runtime-smoke.test.ts",
     "test:cocos:primary-journey": "node --import tsx --test ./apps/cocos-client/test/cocos-primary-client-journey.test.ts",

--- a/scripts/ci-v8-coverage.ts
+++ b/scripts/ci-v8-coverage.ts
@@ -36,11 +36,12 @@ export const suites: CoverageSuite[] = [
   {
     name: "release-scripts",
     include:
-      "{scripts/validate-wechat-release-candidate.ts,scripts/verify-wechat-minigame-artifact.ts}",
+      "{scripts/root-test-discovery.ts,scripts/validate-wechat-release-candidate.ts,scripts/verify-wechat-minigame-artifact.ts}",
     lineThreshold: 80,
     branchThreshold: 55,
     functionThreshold: 85,
     tests: [
+      "scripts/test/root-test-discovery.test.ts",
       "scripts/test/wechat-release-artifacts.test.ts",
       "apps/cocos-client/test/cocos-wechat-build.test.ts",
       "apps/cocos-client/test/cocos-wechat-rc-validation.test.ts",

--- a/scripts/root-test-discovery.ts
+++ b/scripts/root-test-discovery.ts
@@ -1,0 +1,17 @@
+import { execFileSync } from "node:child_process";
+
+const TEST_FILE_PATTERN = /\.test\.ts$/;
+
+export function listTrackedRootTestFiles(cwd = process.cwd()): string[] {
+  const output = execFileSync("git", ["ls-files", "-z", "--", "*.test.ts"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+
+  return output
+    .split("\0")
+    .filter((filePath) => filePath.length > 0)
+    .filter((filePath) => TEST_FILE_PATTERN.test(filePath))
+    .sort((left, right) => left.localeCompare(right));
+}

--- a/scripts/run-root-tests.ts
+++ b/scripts/run-root-tests.ts
@@ -1,0 +1,34 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+import { listTrackedRootTestFiles } from "./root-test-discovery.ts";
+
+const ROOT_TEST_COMMAND = [process.execPath, "--import", "tsx", "--test"] as const;
+
+function main(): never {
+  const trackedTestFiles = listTrackedRootTestFiles();
+
+  if (trackedTestFiles.length === 0) {
+    throw new Error("Root test runner found no tracked *.test.ts files.");
+  }
+
+  const result = spawnSync(
+    ROOT_TEST_COMMAND[0],
+    [...ROOT_TEST_COMMAND.slice(1), ...trackedTestFiles],
+    {
+      cwd: process.cwd(),
+      stdio: "inherit",
+    },
+  );
+
+  if (typeof result.status === "number") {
+    process.exit(result.status);
+  }
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(1);
+}
+
+main();

--- a/scripts/test/root-test-discovery.test.ts
+++ b/scripts/test/root-test-discovery.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import { listTrackedRootTestFiles } from "../root-test-discovery.ts";
+
+test("root test discovery includes every tracked .test.ts file", () => {
+  const expected = execFileSync("git", ["ls-files", "-z", "--", "*.test.ts"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  })
+    .split("\0")
+    .filter((filePath) => filePath.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+
+  assert.deepEqual(listTrackedRootTestFiles(), expected);
+});
+
+test("root test discovery stays focused on node:test suites", () => {
+  const discoveredFiles = listTrackedRootTestFiles();
+
+  assert.ok(discoveredFiles.length > 0);
+  assert.ok(discoveredFiles.every((filePath) => filePath.endsWith(".test.ts")));
+  assert.ok(discoveredFiles.some((filePath) => filePath.startsWith("scripts/test/")));
+  assert.ok(discoveredFiles.some((filePath) => filePath.startsWith("packages/shared/test/")));
+  assert.ok(discoveredFiles.some((filePath) => filePath.startsWith("apps/server/test/")));
+  assert.ok(discoveredFiles.some((filePath) => filePath.startsWith("apps/client/test/")));
+  assert.ok(discoveredFiles.some((filePath) => filePath.startsWith("apps/cocos-client/test/")));
+});


### PR DESCRIPTION
## Summary
- replace the root `npm test` hand-maintained suite list with tracked `*.test.ts` discovery
- add a CI-covered discovery guardrail test so checked-in Node suites cannot be silently omitted
- document how contributors get new `*.test.ts` files picked up automatically

Closes #487