### PR TITLE
test(config-center): add editor workflow regression coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ npm run dev:client:h5
 - 快速校验首条贡献路径：`npm run validate:quickstart`
 - 本地 WebSocket 服务：`npm run dev:server`
 - 仓库级 Node 单测入口：`npm test`
+- 配置中心编辑器回归：`npm run test:client:config-center`
 - 运行时健康检查：`GET http://127.0.0.1:2567/api/runtime/health`
 - 鉴权就绪摘要：`GET http://127.0.0.1:2567/api/runtime/auth-readiness`
 - 运行时指标抓取：`GET http://127.0.0.1:2567/api/runtime/metrics`
@@ -219,6 +220,7 @@ npm run dev:client:h5
   - 保存 `world / mapObjects / units / battle-skills / battle-balance` 后，右侧会同步展示一份 impact summary，带出变更字段、影响模块、潜在风险提示和建议验证动作；发布审计历史也会保留同样的摘要，便于做配置变更评审
   - 导出除 JSON 注释版外，还支持带 `Meta / Schema / Fields` 工作表的 Excel，以及更轻量的字段清单 CSV
   - 当前编辑 `phase1-world.json` 时，右侧会即时生成一份地图样本预览；可切换预览 seed，对照查看地形、随机资源、保底资源、英雄与中立怪分布
+  - 配置中心编辑器回归入口见 `npm run test:client:config-center`，覆盖保存、校验、快照/差异与地图预览等高风险工作流
   - 当前编辑 `battle-skills.json` 时，右侧会显示技能编辑器，可直接调整冷却、伤害倍率、目标类型、附加状态和状态持续参数，并同步回写 JSON 草稿
   - 当前编辑 `battle-balance.json` 时，右侧会显示战斗平衡编辑器，可直接调整伤害公式、路障/陷阱阈值、附加状态和 ELO K；非法值会在 Schema/语义校验里给出修复建议并阻止保存
 - H5 战斗面板现已补上“战术情报”区，会并排展示当前行动单位和已锁定目标的技能、状态、冷却与效果说明，便于直接核对配置是否符合预期。

--- a/apps/client/test/config-center.test.ts
+++ b/apps/client/test/config-center.test.ts
@@ -331,6 +331,101 @@ test("config center save surfaces API rejection without overwriting the edited d
   assert.equal(controller.state.statusMessage, "保存失败：battleBalance 配置版本已过期，请先重新加载。");
 });
 
+test("config center snapshot flow saves the current draft and refreshes the snapshot list", async () => {
+  const snapshot = {
+    id: "snapshot-world-4",
+    label: "世界配置 v4",
+    createdAt: "2026-03-31T02:00:00.000Z",
+    version: 4
+  };
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/snapshots" && request.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          snapshot
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots" && request.method === "GET") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          snapshots: [snapshot],
+          publishHistory: []
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs/world/diff" && request.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          diff: {
+            entries: [
+              {
+                path: "width",
+                change: "updated",
+                previousValue: "8",
+                nextValue: "10",
+                kind: "value",
+                required: true,
+                fieldType: "integer",
+                description: "地图宽度",
+                blastRadius: ["配置台编辑器", "世界预览"]
+              }
+            ]
+          }
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({
+    fetch,
+    prompt: () => "世界配置 v4"
+  });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8,\n  \"height\": 8\n}\n", { version: 4 });
+  controller.setDraft("{\n  \"width\": 10,\n  \"height\": 8\n}\n");
+
+  await controller.createSnapshot();
+
+  const snapshotRequest = requests.find(
+    (request) => request.url === "/api/config-center/configs/world/snapshots" && request.method === "POST"
+  );
+  assert.ok(snapshotRequest);
+  assert.deepEqual(JSON.parse(snapshotRequest.body ?? "{}"), {
+    content: "{\n  \"width\": 10,\n  \"height\": 8\n}\n",
+    label: "世界配置 v4"
+  });
+  assert.equal(controller.state.statusTone, "success");
+  assert.equal(controller.state.statusMessage, "已保存快照 世界配置 v4");
+  assert.deepEqual(controller.state.snapshots, [snapshot]);
+  assert.equal(controller.state.selectedSnapshotId, "snapshot-world-4");
+  assert.equal(controller.state.snapshotDiff?.entries[0]?.path, "width");
+});
+
 test("config center snapshot diff exposes non-empty changes for an edited field", async () => {
   const { fetch } = createFetchStub((request) => {
   if (request.url === "/api/config-center/configs/world/diff" && request.method === "POST") {
@@ -882,6 +977,23 @@ test("config center builtin presets apply the expected field changes", async () 
   const hardConfig = JSON.parse(controller.state.current?.content ?? "{}");
   assert.equal(hardConfig.pvp.eloK, 40);
   assert.equal(hardConfig.environment.trapDamage, 2);
+});
+
+test("config center world preview blocks invalid draft JSON before making a request", async () => {
+  const { fetch, requests } = createFetchStub((request) => {
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8,\n  \"height\": 8\n}\n");
+  controller.setDraft("{\n  \"width\": 8,\n");
+
+  await controller.loadWorldPreview();
+
+  assert.equal(requests.length, 0);
+  assert.equal(controller.state.worldPreview, null);
+  assert.match(controller.state.previewError, /^JSON 语法无效：/);
+  assert.equal(controller.state.previewLoading, false);
 });
 
 test("config center world preview posts the current phase1-world draft and stores the generated sample", async () => {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "test:validate-assets": "node --import tsx --test ./scripts/test/validate-assets.test.ts",
     "test:ci-trend-summary": "node --import tsx --test ./scripts/test/publish-ci-trend-summary.test.ts",
     "test:multiplayer-protocol-compatibility:unit": "node --import tsx --test ./scripts/test/multiplayer-protocol-compatibility.test.ts",
+    "test:client:config-center": "node --import tsx --test ./apps/client/test/config-center.test.ts ./apps/client/test/config-center-render.test.ts",
     "test:shared": "node --import tsx --test \"packages/shared/test/**/*.test.ts\"",
     "test:contracts": "node --import tsx --test ./packages/shared/test/client-payload-contracts.test.ts",
     "typecheck:ci": "npm run typecheck:shared && npm run typecheck:server && npm run typecheck:client:h5 && npm run typecheck:cocos",


### PR DESCRIPTION
## Summary
- add focused controller regression coverage for config-center snapshot save and invalid world preview flows
- expose a dedicated `npm run test:client:config-center` command for the editor save/diff/validation/preview regression slice
- document the new regression command in the README

## Testing
- npm run test:client:config-center
- npm run typecheck:client:h5

Closes #485