### PR TITLE
test(cocos): make WeChat release validation suites work from git worktrees

### DIFF
--- a/apps/cocos-client/test/cocos-primary-delivery-audit.test.ts
+++ b/apps/cocos-client/test/cocos-primary-delivery-audit.test.ts
@@ -7,7 +7,8 @@ import test from "node:test";
 import {
   buildWechatMinigameTemplateArtifacts,
   normalizeWechatMinigameBuildConfig
-} from "../assets/scripts/cocos-wechat-build.ts";
+  // Keep release-validation helpers sourced from tooling/ so root test discovery works in git worktrees.
+} from "../tooling/cocos-wechat-build.ts";
 
 function createPackagedWechatReleaseArtifact(): {
   tempDir: string;

--- a/apps/cocos-client/test/cocos-wechat-rc-validation.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-rc-validation.test.ts
@@ -7,7 +7,9 @@ import test from "node:test";
 import {
   buildWechatMinigameTemplateArtifacts,
   normalizeWechatMinigameBuildConfig
-} from "../assets/scripts/cocos-wechat-build.ts";
+  // Release validation tests run under the repo root runner from both the main checkout and git worktrees.
+  // Import the shared Node-only helper from tooling/, not the Cocos asset tree.
+} from "../tooling/cocos-wechat-build.ts";
 
 interface PackagedArtifact {
   artifactsDir: string;

--- a/apps/cocos-client/test/cocos-wechat-tooling-imports.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-tooling-imports.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const COCOS_TEST_DIR = path.resolve(__dirname);
+const REMOVED_BUILD_HELPER_IMPORT = "../assets/scripts/cocos-wechat-build.ts";
+const CANONICAL_BUILD_HELPER_IMPORT = "../tooling/cocos-wechat-build.ts";
+
+test("Cocos WeChat validation suites import build helpers from tooling", () => {
+  const testFiles = fs
+    .readdirSync(COCOS_TEST_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".test.ts"))
+    .map((entry) => path.join(COCOS_TEST_DIR, entry.name));
+
+  const filesReferencingBuildHelper = testFiles.filter((filePath) =>
+    fs.readFileSync(filePath, "utf8").match(/from\s+["']\.\.\/(?:assets\/scripts|tooling)\/cocos-wechat-build\.ts["']/)
+  );
+
+  assert.ok(filesReferencingBuildHelper.length > 0, "Expected at least one Cocos test to cover the WeChat build helper.");
+
+  for (const filePath of filesReferencingBuildHelper) {
+    const source = fs.readFileSync(filePath, "utf8");
+    assert.doesNotMatch(
+      source,
+      new RegExp(REMOVED_BUILD_HELPER_IMPORT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+      `${path.basename(filePath)} still imports the removed asset-tree WeChat build helper path.`
+    );
+    assert.match(
+      source,
+      new RegExp(CANONICAL_BUILD_HELPER_IMPORT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+      `${path.basename(filePath)} should import the WeChat build helper from tooling/.`
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- switch the two Cocos WeChat release-validation suites to import the shared build helper from `apps/cocos-client/tooling`
- document why the tests must use the tooling path when root test discovery runs from git worktrees
- add a regression test that fails if any Cocos test drifts back to the removed asset-tree helper path

## Verification
- node --import tsx --test ./apps/cocos-client/test/cocos-primary-delivery-audit.test.ts ./apps/cocos-client/test/cocos-wechat-rc-validation.test.ts ./apps/cocos-client/test/cocos-wechat-tooling-imports.test.ts
- npm test

Closes #491