### PR TITLE
ci(release): detect stale phase 1 evidence drift

### DIFF
--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -44,7 +44,7 @@ If you do not pass output flags, the script writes:
 
 ## Gate Rules
 
-The summary contains exactly three release dimensions:
+The summary contains four release dimensions:
 
 - `release-readiness`
   - Fails when the snapshot is missing, when the snapshot summary is not `passed`, or when any required snapshot check is `failed` or `pending`.
@@ -55,6 +55,10 @@ The summary contains exactly three release dimensions:
   - Falls back to `codex.wechat.smoke-report.json` when the RC validation report is absent.
   - Fails closed when required WeChat evidence is missing, failed, blocked, or still pending.
   - Markdown/JSON summary text distinguishes `blocked` device/runtime evidence from true execution failures so CI reviewers can see whether a gate is red because proof is absent or because the runtime actually regressed.
+- `phase1-evidence-consistency`
+  - Cross-checks the release-readiness snapshot, packaged H5 smoke report, and selected WeChat evidence as one Phase 1 candidate set.
+  - Fails when any artifact is missing revision metadata, missing/invalid generated timestamps, points at a different commit than the current release candidate, or disagrees with another artifact’s commit.
+  - This catches stale local artifacts and mismatched CI evidence before release signals drift silently.
 
 Any failed dimension makes the script exit non-zero so the result can act as a CI release gate.
 

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -52,6 +52,8 @@ interface ReleaseCandidateClientArtifactSmokeReport {
 }
 
 interface WechatRcValidationReport {
+  generatedAt?: string;
+  commit?: string | null;
   summary?: {
     status?: "passed" | "failed";
     failedChecks?: number;
@@ -66,7 +68,11 @@ interface WechatRcValidationReport {
 }
 
 interface WechatSmokeReport {
+  artifact?: {
+    sourceRevision?: string;
+  };
   execution?: {
+    executedAt?: string;
     result?: "pending" | "blocked" | "passed" | "failed";
     summary?: string;
   };
@@ -83,12 +89,20 @@ interface GateSource {
 }
 
 interface GateResult {
-  id: "release-readiness" | "h5-release-candidate-smoke" | "wechat-release";
+  id: "release-readiness" | "h5-release-candidate-smoke" | "wechat-release" | "phase1-evidence-consistency";
   label: string;
   status: GateStatus;
   summary: string;
   failures: string[];
   source?: GateSource;
+}
+
+interface Phase1EvidenceReference {
+  gateId: "release-readiness" | "h5-release-candidate-smoke" | "wechat-release";
+  label: string;
+  source: GateSource;
+  commit?: string;
+  generatedAt?: string;
 }
 
 type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
@@ -179,6 +193,7 @@ interface ReleaseGateSummaryReport {
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
 const DEFAULT_WECHAT_ARTIFACTS_DIR = path.resolve("artifacts", "wechat-release");
 const DEFAULT_CONFIG_CENTER_LIBRARY_PATH = path.resolve("configs", ".config-center-library.json");
+const HEX_REVISION_PATTERN = /^[a-f0-9]+$/i;
 const RISK_PRIORITY: Record<ConfigRiskLevel, number> = {
   low: 1,
   medium: 2,
@@ -630,6 +645,165 @@ export function evaluateWechatGate(
   };
 }
 
+function normalizeCommit(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized || !HEX_REVISION_PATTERN.test(normalized)) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function commitsMatch(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = normalizeCommit(left);
+  const normalizedRight = normalizeCommit(right);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  return normalizedLeft === normalizedRight || normalizedLeft.startsWith(normalizedRight) || normalizedRight.startsWith(normalizedLeft);
+}
+
+function collectPhase1EvidenceReferences(
+  snapshotPath: string | undefined,
+  h5SmokePath: string | undefined,
+  wechatRcValidationPath: string | undefined,
+  wechatSmokeReportPath: string | undefined
+): Phase1EvidenceReference[] {
+  const evidence: Phase1EvidenceReference[] = [];
+
+  if (snapshotPath && fs.existsSync(snapshotPath)) {
+    const snapshot = readJsonFile<ReleaseReadinessSnapshot & { generatedAt?: string; revision?: { commit?: string; shortCommit?: string } }>(
+      snapshotPath
+    );
+    evidence.push({
+      gateId: "release-readiness",
+      label: "Release readiness snapshot",
+      source: {
+        kind: "release-readiness-snapshot",
+        path: snapshotPath
+      },
+      commit: snapshot.revision?.commit ?? snapshot.revision?.shortCommit,
+      generatedAt: snapshot.generatedAt
+    });
+  }
+
+  if (h5SmokePath && fs.existsSync(h5SmokePath)) {
+    const report = readJsonFile<ReleaseCandidateClientArtifactSmokeReport>(h5SmokePath);
+    evidence.push({
+      gateId: "h5-release-candidate-smoke",
+      label: "H5 packaged RC smoke",
+      source: {
+        kind: "h5-release-candidate-smoke",
+        path: h5SmokePath
+      },
+      commit: report.revision?.commit ?? report.revision?.shortCommit,
+      generatedAt: report.execution?.finishedAt ?? report.generatedAt
+    });
+  }
+
+  if (wechatRcValidationPath && fs.existsSync(wechatRcValidationPath)) {
+    const report = readJsonFile<WechatRcValidationReport & { generatedAt?: string; commit?: string | null }>(wechatRcValidationPath);
+    evidence.push({
+      gateId: "wechat-release",
+      label: "WeChat release validation",
+      source: {
+        kind: "wechat-rc-validation",
+        path: wechatRcValidationPath
+      },
+      commit: report.commit ?? undefined,
+      generatedAt: report.generatedAt
+    });
+  } else if (wechatSmokeReportPath && fs.existsSync(wechatSmokeReportPath)) {
+    const report = readJsonFile<WechatSmokeReport & { artifact?: { sourceRevision?: string } }>(wechatSmokeReportPath);
+    evidence.push({
+      gateId: "wechat-release",
+      label: "WeChat release validation",
+      source: {
+        kind: "wechat-smoke-report",
+        path: wechatSmokeReportPath
+      },
+      commit: report.artifact?.sourceRevision,
+      generatedAt: report.execution?.executedAt
+    });
+  }
+
+  return evidence;
+}
+
+export function evaluatePhase1EvidenceConsistencyGate(
+  revision: GitRevision,
+  snapshotPath: string | undefined,
+  h5SmokePath: string | undefined,
+  wechatRcValidationPath: string | undefined,
+  wechatSmokeReportPath: string | undefined
+): GateResult {
+  const failures: string[] = [];
+  const expectedArtifacts: Array<Pick<Phase1EvidenceReference, "gateId" | "label">> = [
+    { gateId: "release-readiness", label: "Release readiness snapshot" },
+    { gateId: "h5-release-candidate-smoke", label: "H5 packaged RC smoke" },
+    { gateId: "wechat-release", label: "WeChat release validation" }
+  ];
+  const evidence = collectPhase1EvidenceReferences(snapshotPath, h5SmokePath, wechatRcValidationPath, wechatSmokeReportPath);
+  const expectedCommit = revision.commit;
+
+  for (const expected of expectedArtifacts) {
+    if (!evidence.some((entry) => entry.gateId === expected.gateId)) {
+      failures.push(`Phase 1 evidence is missing for ${expected.label}.`);
+    }
+  }
+
+  for (const entry of evidence) {
+    if (!normalizeCommit(entry.commit)) {
+      failures.push(`Phase 1 evidence is missing revision metadata for ${entry.label}.`);
+      continue;
+    }
+    if (!commitsMatch(entry.commit, expectedCommit)) {
+      failures.push(
+        `Phase 1 evidence is stale for ${entry.label}: artifact commit ${entry.commit} does not match candidate ${revision.shortCommit}.`
+      );
+    }
+    if (!entry.generatedAt?.trim()) {
+      failures.push(`Phase 1 evidence is missing a generated timestamp for ${entry.label}.`);
+      continue;
+    }
+    if (Number.isNaN(Date.parse(entry.generatedAt))) {
+      failures.push(`Phase 1 evidence has an invalid generated timestamp for ${entry.label}: ${entry.generatedAt}.`);
+    }
+  }
+
+  for (let index = 0; index < evidence.length; index += 1) {
+    const left = evidence[index];
+    if (!left) {
+      continue;
+    }
+    for (let innerIndex = index + 1; innerIndex < evidence.length; innerIndex += 1) {
+      const right = evidence[innerIndex];
+      if (!right) {
+        continue;
+      }
+      if (!commitsMatch(left.commit, right.commit)) {
+        failures.push(
+          `Phase 1 evidence commit mismatch: ${left.label}=${left.commit ?? "<missing>"} vs ${right.label}=${right.commit ?? "<missing>"}.`
+        );
+      }
+    }
+  }
+
+  const uniqueCommitCount = new Set(evidence.map((entry) => normalizeCommit(entry.commit)).filter((entry): entry is string => Boolean(entry))).size;
+  const summary =
+    failures.length === 0
+      ? `Phase 1 evidence matches candidate ${revision.shortCommit} across ${evidence.length} artifacts.`
+      : `Phase 1 evidence drift detected: ${failures[0]}`;
+
+  return {
+    id: "phase1-evidence-consistency",
+    label: "Phase 1 evidence consistency",
+    status: failures.length === 0 ? "passed" : "failed",
+    summary,
+    failures: failures.length === 0 && uniqueCommitCount === 1 ? [] : failures,
+    source: evidence[0]?.source
+  };
+}
+
 function uniqueStrings(items: Iterable<string>): string[] {
   return Array.from(new Set([...items].filter((value) => value.length > 0)));
 }
@@ -768,7 +942,8 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
   const gates = [
     evaluateReleaseReadinessGate(snapshotPath),
     evaluateH5SmokeGate(h5SmokePath),
-    evaluateWechatGate(wechatRcValidationPath, wechatSmokeReportPath)
+    evaluateWechatGate(wechatRcValidationPath, wechatSmokeReportPath),
+    evaluatePhase1EvidenceConsistencyGate(revision, snapshotPath, h5SmokePath, wechatRcValidationPath, wechatSmokeReportPath)
   ];
   const failedGates = gates.filter((gate) => gate.status === "failed");
 

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   buildConfigChangeRiskSummary,
   buildReleaseGateSummaryReport,
+  evaluatePhase1EvidenceConsistencyGate,
   evaluateWechatGate,
   renderMarkdown
 } from "../release-gate-summary.ts";
@@ -29,6 +30,13 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   const configCenterLibraryPath = path.join(workspace, "configs", ".config-center-library.json");
 
   writeJson(snapshotPath, {
+    generatedAt: "2026-03-29T08:30:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
     summary: {
       status: "passed",
       requiredFailed: 0,
@@ -43,6 +51,13 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
     ]
   });
   writeJson(h5SmokePath, {
+    generatedAt: "2026-03-29T08:32:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
     execution: {
       status: "passed",
       exitCode: 0
@@ -54,6 +69,8 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
     }
   });
   writeJson(wechatRcValidationPath, {
+    generatedAt: "2026-03-29T08:35:00.000Z",
+    commit: "abc123",
     summary: {
       status: "passed",
       failedChecks: 0,
@@ -117,7 +134,9 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
 
   assert.equal(report.summary.status, "passed");
   assert.deepEqual(report.summary.failedGateIds, []);
+  assert.equal(report.summary.totalGates, 4);
   assert.equal(report.gates.every((gate) => gate.status === "passed"), true);
+  assert.equal(report.gates[3]?.id, "phase1-evidence-consistency");
   assert.equal(report.configChangeRisk.status, "available");
   assert.equal(report.configChangeRisk.overallRisk, "high");
   assert.equal(report.configChangeRisk.recommendRehearsal, true);
@@ -134,6 +153,13 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
   const wechatSmokeReportPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.smoke-report.json");
 
   writeJson(snapshotPath, {
+    generatedAt: "2026-03-29T08:30:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
     summary: {
       status: "pending",
       requiredFailed: 0,
@@ -148,6 +174,13 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
     ]
   });
   writeJson(h5SmokePath, {
+    generatedAt: "2026-03-29T08:32:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
     execution: {
       status: "passed",
       exitCode: 0
@@ -159,7 +192,11 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
     }
   });
   writeJson(wechatSmokeReportPath, {
+    artifact: {
+      sourceRevision: "abc123"
+    },
     execution: {
+      executedAt: "2026-03-29T08:40:00.000Z",
       result: "blocked"
     },
     cases: [
@@ -217,6 +254,143 @@ test("evaluateWechatGate prefers RC validation and falls back to smoke report", 
   const smokeGate = evaluateWechatGate(undefined, wechatSmokeReportPath);
   assert.equal(smokeGate.status, "passed");
   assert.equal(smokeGate.source?.kind, "wechat-smoke-report");
+});
+
+test("evaluatePhase1EvidenceConsistencyGate fails stale or mismatched candidate evidence", () => {
+  const workspace = createTempWorkspace();
+  const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
+  const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const wechatRcValidationPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.rc-validation-report.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-03-29T08:30:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
+    summary: {
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
+    }
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: "2026-03-29T08:32:00.000Z",
+    revision: {
+      commit: "deadbeef",
+      shortCommit: "deadbee",
+      branch: "test-branch",
+      dirty: false
+    },
+    execution: {
+      status: "passed",
+      finishedAt: "2026-03-29T08:32:00.000Z",
+      exitCode: 0
+    },
+    summary: {
+      total: 2,
+      passed: 2,
+      failed: 0
+    }
+  });
+  writeJson(wechatRcValidationPath, {
+    generatedAt: "2026-03-29T08:35:00.000Z",
+    commit: "abc123",
+    summary: {
+      status: "passed",
+      failedChecks: 0,
+      failureSummary: []
+    }
+  });
+
+  const gate = evaluatePhase1EvidenceConsistencyGate(
+    {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
+    snapshotPath,
+    h5SmokePath,
+    wechatRcValidationPath,
+    undefined
+  );
+
+  assert.equal(gate.status, "failed");
+  assert.match(gate.summary, /Phase 1 evidence drift detected/);
+  assert.match(gate.failures.join("\n"), /stale for H5 packaged RC smoke/);
+  assert.match(gate.failures.join("\n"), /commit mismatch/);
+});
+
+test("buildReleaseGateSummaryReport fails when all artifacts are stale for the current candidate", () => {
+  const workspace = createTempWorkspace();
+  const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
+  const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const wechatRcValidationPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.rc-validation-report.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-03-29T08:30:00.000Z",
+    revision: {
+      commit: "deadbeef",
+      shortCommit: "deadbee",
+      branch: "test-branch",
+      dirty: false
+    },
+    summary: {
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
+    }
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: "2026-03-29T08:32:00.000Z",
+    revision: {
+      commit: "deadbeef",
+      shortCommit: "deadbee",
+      branch: "test-branch",
+      dirty: false
+    },
+    execution: {
+      status: "passed",
+      finishedAt: "2026-03-29T08:32:00.000Z",
+      exitCode: 0
+    },
+    summary: {
+      total: 2,
+      passed: 2,
+      failed: 0
+    }
+  });
+  writeJson(wechatRcValidationPath, {
+    generatedAt: "2026-03-29T08:35:00.000Z",
+    commit: "deadbeef",
+    summary: {
+      status: "passed",
+      failedChecks: 0,
+      failureSummary: []
+    }
+  });
+
+  const report = buildReleaseGateSummaryReport(
+    {
+      snapshotPath,
+      h5SmokePath,
+      wechatRcValidationPath
+    },
+    {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    }
+  );
+
+  assert.equal(report.summary.status, "failed");
+  assert.deepEqual(report.summary.failedGateIds, ["phase1-evidence-consistency"]);
+  assert.match(report.gates[3]?.summary ?? "", /artifact commit deadbeef does not match candidate abc123/);
+  assert.match(renderMarkdown(report), /Phase 1 evidence consistency/);
 });
 
 test("buildConfigChangeRiskSummary uses the latest applied publish audit and maps validation actions", () => {


### PR DESCRIPTION
## Summary
- add a Phase 1 evidence consistency gate to release gate summary
- fail when snapshot, H5 smoke, or WeChat evidence is stale for the current candidate or disagrees with peer artifacts
- cover stale/mismatched evidence paths with focused tests and document the new gate

## Testing
- npm run test:release-gate-summary

Closes #495