### PR TITLE
test(cocos): add primary journey release gate

### DIFF
--- a/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
@@ -20,6 +20,7 @@ test("summarizeSnapshot fails when a required release-readiness check is missing
       { id: "npm-test", status: "passed", required: true },
       { id: "typecheck-ci", status: "passed", required: true },
       { id: "e2e-smoke", status: "passed", required: true },
+      { id: "cocos-primary-journey", status: "passed", required: true },
       { id: "wechat-build-check", status: "passed", required: true }
     ]
   });
@@ -42,6 +43,7 @@ test("buildBuildPackageGate aggregates snapshot, package, and smoke evidence int
       { id: "typecheck-ci", status: "passed", required: true },
       { id: "e2e-smoke", status: "passed", required: true },
       { id: "e2e-multiplayer-smoke", status: "pending", required: true },
+      { id: "cocos-primary-journey", status: "passed", required: true },
       { id: "wechat-build-check", status: "passed", required: true }
     ]
   });
@@ -78,6 +80,7 @@ test("buildCriticalEvidenceGate downgrades stale evidence to warn and preserves 
       { id: "typecheck-ci", status: "passed", required: true },
       { id: "e2e-smoke", status: "passed", required: true },
       { id: "e2e-multiplayer-smoke", status: "passed", required: true },
+      { id: "cocos-primary-journey", status: "passed", required: true },
       { id: "wechat-build-check", status: "passed", required: true }
     ]
   });

--- a/apps/cocos-client/test/release-readiness-dashboard.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard.test.ts
@@ -48,6 +48,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
       { id: "typecheck-ci", status: "passed", required: true },
       { id: "e2e-smoke", status: "passed", required: true },
       { id: "e2e-multiplayer-smoke", status: "passed", required: true },
+      { id: "cocos-primary-journey", status: "passed", required: true },
       { id: "wechat-build-check", status: "passed", required: true }
     ]
   });
@@ -232,6 +233,7 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
       { id: "typecheck-ci", status: "passed", required: true },
       { id: "e2e-smoke", status: "passed", required: true },
       { id: "e2e-multiplayer-smoke", status: "passed", required: true },
+      { id: "cocos-primary-journey", status: "passed", required: true },
       { id: "wechat-build-check", status: "passed", required: true }
     ]
   });

--- a/apps/cocos-client/test/release-readiness-snapshot.test.ts
+++ b/apps/cocos-client/test/release-readiness-snapshot.test.ts
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -98,4 +102,51 @@ test("buildReleaseReadinessSnapshot keeps optional failures partial when require
   assert.equal(snapshot.summary.failed, 1);
   assert.equal(snapshot.summary.requiredFailed, 0);
   assert.equal(snapshot.summary.passed, 1);
+});
+
+test("release-readiness snapshot CLI includes the Cocos primary journey as a required automated check", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-release-snapshot-"));
+  const outputPath = path.join(tempDir, "release-readiness.json");
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/release-readiness-snapshot.ts",
+      "--no-run",
+      "--output",
+      outputPath
+    ],
+    {
+      cwd: path.resolve(__dirname, "../../.."),
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  const snapshot = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    checks: Array<{
+      id: string;
+      title: string;
+      required: boolean;
+      kind: string;
+      status: string;
+      command?: string;
+      notes: string;
+      evidence: string[];
+      source: string;
+    }>;
+  };
+
+  const primaryJourneyCheck = snapshot.checks.find((check) => check.id === "cocos-primary-journey");
+  assert.ok(primaryJourneyCheck);
+  assert.equal(primaryJourneyCheck.title, "Cocos primary journey regression");
+  assert.equal(primaryJourneyCheck.required, true);
+  assert.equal(primaryJourneyCheck.kind, "automated");
+  assert.equal(primaryJourneyCheck.status, "pending");
+  assert.equal(primaryJourneyCheck.command, "npm run test:cocos:primary-journey");
+  assert.equal(primaryJourneyCheck.notes, "Skipped command execution via --no-run.");
+  assert.deepEqual(primaryJourneyCheck.evidence, []);
+  assert.equal(primaryJourneyCheck.source, "default");
 });

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -119,6 +119,7 @@
 建议证据：
 
 - `npm test`
+- `npm run test:cocos:primary-journey`
 - `npm run check:cocos-release-readiness`
 - `npm run release:cocos-rc:snapshot -- --output <snapshot-path>`
 - `docs/release-evidence/cocos-wechat-rc-checklist.template.md`

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -125,8 +125,8 @@ Sample output:
     "dirty": false
   },
   "summary": {
-    "total": 7,
-    "passed": 5,
+    "total": 8,
+    "passed": 6,
     "failed": 0,
     "pending": 2,
     "notApplicable": 0,
@@ -140,6 +140,12 @@ Sample output:
       "kind": "automated",
       "status": "passed",
       "command": "npm test"
+    },
+    {
+      "id": "cocos-primary-journey",
+      "kind": "automated",
+      "status": "passed",
+      "command": "npm run test:cocos:primary-journey"
     },
     {
       "id": "wechat-device-smoke",

--- a/scripts/release-readiness-dashboard.ts
+++ b/scripts/release-readiness-dashboard.ts
@@ -139,7 +139,7 @@ interface DashboardReport {
 
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
 const DEFAULT_RELEASE_EVIDENCE_DIR = path.resolve("artifacts", "release-evidence");
-const REQUIRED_SNAPSHOT_CHECK_IDS = ["npm-test", "typecheck-ci", "e2e-smoke", "e2e-multiplayer-smoke", "wechat-build-check"] as const;
+const REQUIRED_SNAPSHOT_CHECK_IDS = ["npm-test", "typecheck-ci", "e2e-smoke", "e2e-multiplayer-smoke", "cocos-primary-journey", "wechat-build-check"] as const;
 const REQUIRED_METRICS = [
   "veil_active_room_count",
   "veil_connection_count",

--- a/scripts/release-readiness-snapshot.ts
+++ b/scripts/release-readiness-snapshot.ts
@@ -99,6 +99,12 @@ const AUTOMATED_CHECKS: Array<Pick<ReleaseReadinessCheck, "id" | "title" | "comm
     required: true
   },
   {
+    id: "cocos-primary-journey",
+    title: "Cocos primary journey regression",
+    command: "npm run test:cocos:primary-journey",
+    required: true
+  },
+  {
     id: "sync-governance-matrix",
     title: "Deterministic sync-governance matrix",
     command: "npm run test:sync-governance:matrix -- --output artifacts/release-readiness/sync-governance-matrix.json",


### PR DESCRIPTION
## Summary
- add the deterministic Cocos primary journey test as an explicit required release-readiness check
- require the new check in the release-readiness dashboard and cover it with focused regression tests
- update release-readiness docs to reflect the candidate-grade Cocos gate

Closes #496