### PR TITLE
test(release): add Phase 1 persistence regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ npm run dev:client:h5
 - 并发房间压测启动后，也可直接查看同进程观测面：`/api/runtime/health`、`/api/runtime/auth-readiness` 与 `/api/runtime/metrics`
 - 战斗平衡验证：`npm run validate:battle -- --count=1000 --scenario=all --skill-config=configs/battle-skills-v1.1.json`
 - 内容包一致性验证：`npm run validate:content-pack -- --report-path artifacts/content-pack-validation-report.json`
+- Phase 1 持久化 + shipped content 回归：`npm run test:phase1-release-persistence`
 - 覆盖率 CI 同款校验：`npm run test:coverage:ci`
 - 覆盖率摘要：`.coverage/summary.md`
 - `npm test` 会通过 `git ls-files` 自动发现所有已检入仓库的 `*.test.ts` Node 测试文件并统一执行；新增此类测试时不需要手动维护根脚本列表。

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -65,6 +65,7 @@
 - [ ] reconnect 验收必须复用 [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md) 的唯一场景和最小成功信号，而不是只写“重连成功”。
 - [ ] wider playtest 前必须复用 [`docs/multiplayer-loadtest-gate.md`](./multiplayer-loadtest-gate.md) 中固定的 smoke + `stress:rooms` 命令组合、阈值、回退动作和重跑触发条件。
 - [ ] shipping / release candidate 前，任何涉及房间状态、reconnect、战斗或快照恢复的改动都必须额外通过 [`docs/reconnect-soak-gate.md`](./reconnect-soak-gate.md) 中的长时 reconnect soak。
+- [ ] shipping / release candidate 前，至少要有一条当前 `npm run test:phase1-release-persistence` 记录，同时证明目标持久化路径与 shipped config/content 校验一起通过。
 - [ ] 失败路径可读：非法 action、超时、会话失效时，客户端能收到明确错误而不是静默卡死。
 
 `P1 follow-up`
@@ -76,6 +77,7 @@
 
 - `npm test`
 - `npm run test:e2e:multiplayer:smoke`
+- `npm run test:phase1-release-persistence`
 - wider playtest 前必跑：[`docs/multiplayer-loadtest-gate.md`](./multiplayer-loadtest-gate.md)
 - shipping / RC 前必跑：[`docs/reconnect-soak-gate.md`](./reconnect-soak-gate.md)
 

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -190,3 +190,12 @@ The repository also includes manual player profile management commands:
 - `npm run db:profiles:prune`
 
 These commands are useful when you want to inspect retained per-player room progress, delete a specific player profile row, or force profile cleanup immediately.
+
+## Release Regression
+
+Use the Phase 1 release regression when you need one bounded proof that MySQL persistence and shipped config/content data are healthy together:
+
+- Local/default mode: `npm run test:phase1-release-persistence`
+- Release-target MySQL mode: `npm run test:phase1-release-persistence -- --storage mysql`
+
+The command writes a JSON artifact under `artifacts/release-readiness/`, validates the shipped Phase 1 content packs, saves representative player/account/world progression through the persistence store, and verifies fresh-room hydration still restores long-term account + hero data while resetting room-local position/readiness.

--- a/docs/phase1-maturity-scorecard.md
+++ b/docs/phase1-maturity-scorecard.md
@@ -72,7 +72,7 @@ The candidate has current package/verify/smoke evidence, and the required report
 `/api/runtime/health`, `/api/runtime/auth-readiness`, and `/api/runtime/metrics` are reachable for the candidate environment and reviewed as part of release evidence.
 
 7. `Phase 1 data and persistence are verified on the intended storage path.`
-The shipped config/content pack validates cleanly, and the intended persistence mode has completed at least one current regression proving player/account/world data flows still hold.
+The shipped config/content pack validates cleanly, and `npm run test:phase1-release-persistence` has completed at least one current regression on the intended storage mode. For release candidates with `VEIL_MYSQL_*` enabled, that means the generated report should show `Storage: mysql` while still proving player/account/world data flows hold.
 
 8. `Known Phase 1 blockers are closed or explicitly accepted.`
 Any remaining Cocos presentation fallback, reconnect risk, multiplayer divergence risk, or release-process blocker is either fixed or recorded as a conscious non-blocking acceptance with owner and rationale.

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -12,9 +12,17 @@ The default automated checks are:
 - `npm run typecheck:ci`
 - `npm run test:e2e:smoke`
 - `npm run test:e2e:multiplayer:smoke`
+- `npm run test:phase1-release-persistence -- --output artifacts/release-readiness/phase1-release-persistence-regression.json`
 - `npm run test:sync-governance:matrix -- --output artifacts/release-readiness/sync-governance-matrix.json`
 - `npm run test:multiplayer-protocol-compatibility -- --output artifacts/release-readiness/multiplayer-protocol-compatibility.json`
 - `npm run check:cocos-release-readiness`
+
+The Phase 1 persistence regression intentionally keeps config/content validation tied to the same release-hardening story:
+
+- it validates the shipped `phase1`, `frontier-basin`, and `phase2` content packs
+- it exercises persistence-backed player/account/world carryover with representative resources, hero growth, replay history, and event history
+
+When `VEIL_MYSQL_*` is configured, the regression automatically targets MySQL. Without MySQL env it falls back to the in-memory store so contributors can still run the same flow locally, but release verification should expect the generated report to show `Storage: mysql`.
 
 For packaged H5 release-candidate validation, run:
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "smoke:client:release-candidate": "node --import tsx ./scripts/release-candidate-client-artifact-smoke.ts",
     "test:runtime-regression": "node --import tsx --test ./scripts/test/compare-runtime-regression.test.ts",
     "test:multiplayer-protocol-compatibility": "node --import tsx ./scripts/multiplayer-protocol-compatibility.ts",
+    "test:phase1-release-persistence": "node --import tsx ./scripts/phase1-release-persistence-regression.ts",
     "test:release-gate-summary": "node --import tsx --test ./scripts/test/release-gate-summary.test.ts",
     "test:release-health-summary": "node --import tsx --test ./scripts/test/release-health-summary.test.ts ./scripts/test/release-health-summary-cli.test.ts",
     "test:sync-governance-matrix": "node --import tsx --test ./scripts/test/sync-governance-matrix.test.ts",

--- a/scripts/phase1-release-persistence-regression.ts
+++ b/scripts/phase1-release-persistence-regression.ts
@@ -1,0 +1,435 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import {
+  createWorldStateFromConfigs,
+  type EventLogEntry,
+  type MapObjectsConfig,
+  type PlayerBattleReplaySummary,
+  type WorldGenerationConfig
+} from "../packages/shared/src/index.ts";
+import { createMemoryRoomSnapshotStore } from "../apps/server/src/memory-room-snapshot-store.ts";
+import {
+  applyPlayerAccountsToWorldState,
+  applyPlayerHeroArchivesToWorldState,
+  MySqlRoomSnapshotStore,
+  readMySqlPersistenceConfig,
+  type RoomSnapshotStore
+} from "../apps/server/src/persistence.ts";
+import { buildContentPackCliReport } from "./validate-content-pack.ts";
+import { resolveExtraContentPackMapPack } from "./content-pack-map-packs.ts";
+
+type RequestedStorageMode = "auto" | "memory" | "mysql";
+type EffectiveStorageMode = "memory" | "mysql";
+
+interface Args {
+  outputPath?: string;
+  storageMode: RequestedStorageMode;
+  configsRoot: string;
+}
+
+interface GitRevision {
+  commit: string;
+  shortCommit: string;
+  branch: string;
+  dirty: boolean;
+}
+
+interface Phase1PersistenceReleaseReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  revision: GitRevision;
+  requestedStorageMode: RequestedStorageMode;
+  effectiveStorageMode: EffectiveStorageMode;
+  storageDescription: string;
+  configsRoot: string;
+  summary: {
+    status: "passed";
+    assertionCount: number;
+  };
+  contentValidation: {
+    valid: boolean;
+    bundleCount: number;
+    summary: string;
+    issueCount: number;
+  };
+  persistenceRegression: {
+    sourceRoomId: string;
+    targetRoomId: string;
+    playerId: string;
+    heroId: string;
+    assertions: string[];
+  };
+}
+
+const DEFAULT_OUTPUT_DIR = path.resolve("artifacts", "release-readiness");
+const SOURCE_ROOM_ID = "phase1-release-gate-source";
+const TARGET_ROOM_ID = "phase1-release-gate-target";
+const PLAYER_ONE_ID = "release-gate-player-1";
+const PLAYER_TWO_ID = "release-gate-player-2";
+const HERO_ONE_ID = "release-gate-hero-1";
+const HERO_TWO_ID = "release-gate-hero-2";
+const EVENT_ID = "release-gate-event-1";
+const REPLAY_ID = "release-gate-replay-1";
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let outputPath: string | undefined;
+  let storageMode: RequestedStorageMode = "auto";
+  let configsRoot = path.resolve("configs");
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--output" && next) {
+      outputPath = path.resolve(next);
+      index += 1;
+      continue;
+    }
+    if (arg === "--storage" && next) {
+      if (next !== "auto" && next !== "memory" && next !== "mysql") {
+        fail(`Unsupported storage mode: ${next}`);
+      }
+      storageMode = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--configs-root" && next) {
+      configsRoot = path.resolve(next);
+      index += 1;
+      continue;
+    }
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    ...(outputPath ? { outputPath } : {}),
+    storageMode,
+    configsRoot
+  };
+}
+
+function getGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function getRevision(): GitRevision {
+  return {
+    commit: getGitValue(["rev-parse", "HEAD"]),
+    shortCommit: getGitValue(["rev-parse", "--short", "HEAD"]),
+    branch: getGitValue(["rev-parse", "--abbrev-ref", "HEAD"]),
+    dirty: getGitValue(["status", "--porcelain"]).length > 0
+  };
+}
+
+function resolveOutputPath(outputPath: string | undefined, shortCommit: string): string {
+  if (outputPath) {
+    return outputPath;
+  }
+  return path.resolve(DEFAULT_OUTPUT_DIR, `phase1-release-persistence-regression-${shortCommit}.json`);
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function buildWorldConfigForRegression(config: WorldGenerationConfig): WorldGenerationConfig {
+  return {
+    ...structuredClone(config),
+    heroes: config.heroes.map((hero, index) => ({
+      ...structuredClone(hero),
+      id: index === 0 ? HERO_ONE_ID : HERO_TWO_ID,
+      playerId: index === 0 ? PLAYER_ONE_ID : PLAYER_TWO_ID
+    }))
+  };
+}
+
+function createReplaySummary(playerId: string, heroId: string): PlayerBattleReplaySummary {
+  return {
+    id: REPLAY_ID,
+    roomId: SOURCE_ROOM_ID,
+    playerId,
+    battleId: "release-gate-battle-1",
+    battleKind: "neutral",
+    playerCamp: "attacker",
+    heroId,
+    neutralArmyId: "neutral-1",
+    startedAt: "2026-03-31T00:00:00.000Z",
+    completedAt: "2026-03-31T00:03:00.000Z",
+    initialState: {
+      id: "release-gate-battle-1",
+      round: 1,
+      lanes: 1,
+      activeUnitId: "unit-1",
+      turnOrder: ["unit-1"],
+      units: {
+        "unit-1": {
+          id: "unit-1",
+          camp: "attacker",
+          templateId: "hero_guard_basic",
+          lane: 0,
+          stackName: "暮火侦骑",
+          initiative: 5,
+          attack: 3,
+          defense: 2,
+          minDamage: 1,
+          maxDamage: 3,
+          count: 16,
+          currentHp: 10,
+          maxHp: 10,
+          hasRetaliated: false,
+          defending: false
+        }
+      },
+      environment: [],
+      log: [],
+      rng: { seed: 11, cursor: 0 }
+    },
+    steps: [],
+    result: "attacker_victory"
+  };
+}
+
+function createEventLogEntry(playerId: string, heroId: string): EventLogEntry {
+  return {
+    id: EVENT_ID,
+    timestamp: "2026-03-31T00:02:00.000Z",
+    roomId: SOURCE_ROOM_ID,
+    playerId,
+    category: "achievement",
+    description: "Release gate progression event",
+    heroId,
+    achievementId: "first_battle",
+    rewards: [{ type: "resource", label: "Gold", amount: 180 }]
+  };
+}
+
+async function createSnapshotStore(storageMode: RequestedStorageMode): Promise<{
+  store: RoomSnapshotStore;
+  mode: EffectiveStorageMode;
+  description: string;
+}> {
+  if (storageMode === "memory") {
+    return {
+      store: createMemoryRoomSnapshotStore(),
+      mode: "memory",
+      description: "memory://room_snapshots"
+    };
+  }
+
+  const mysqlConfig = readMySqlPersistenceConfig();
+  if (storageMode === "mysql") {
+    if (!mysqlConfig) {
+      fail("MySQL storage was requested but VEIL_MYSQL_* is not configured.");
+    }
+    const store = await MySqlRoomSnapshotStore.create(mysqlConfig);
+    return {
+      store,
+      mode: "mysql",
+      description: `mysql://${mysqlConfig.database}/room_snapshots`
+    };
+  }
+
+  if (mysqlConfig) {
+    const store = await MySqlRoomSnapshotStore.create(mysqlConfig);
+    return {
+      store,
+      mode: "mysql",
+      description: `mysql://${mysqlConfig.database}/room_snapshots`
+    };
+  }
+
+  return {
+    store: createMemoryRoomSnapshotStore(),
+    mode: "memory",
+    description: "memory://room_snapshots"
+  };
+}
+
+export async function runPhase1ReleasePersistenceRegression(args: Args): Promise<Phase1PersistenceReleaseReport> {
+  const revision = getRevision();
+  const worldConfig = buildWorldConfigForRegression(readJsonFile<WorldGenerationConfig>(path.join(args.configsRoot, "phase1-world.json")));
+  const mapObjectsConfig = readJsonFile<MapObjectsConfig>(path.join(args.configsRoot, "phase1-map-objects.json"));
+  const frontierBasin = resolveExtraContentPackMapPack("frontier-basin");
+  const phase2 = resolveExtraContentPackMapPack("phase2");
+  if (!frontierBasin || !phase2) {
+    fail("Expected shipped extra content-pack definitions for frontier-basin and phase2.");
+  }
+
+  const contentReport = await buildContentPackCliReport({
+    rootDir: args.configsRoot,
+    extraMapPacks: [frontierBasin, phase2]
+  });
+  if (!contentReport.valid) {
+    fail(contentReport.contentPack.summary);
+  }
+
+  const { store, mode, description } = await createSnapshotStore(args.storageMode);
+  const assertions: string[] = [];
+
+  try {
+    const sourceState = createWorldStateFromConfigs(worldConfig, mapObjectsConfig, 1001, SOURCE_ROOM_ID);
+    const sourceHero = sourceState.heroes.find((hero) => hero.playerId === PLAYER_ONE_ID);
+    if (!sourceHero) {
+      fail(`Expected hero for ${PLAYER_ONE_ID}.`);
+    }
+    const originalTargetPosition = structuredClone(sourceHero.position);
+
+    sourceState.resources[PLAYER_ONE_ID] = { gold: 640, wood: 9, ore: 4 };
+    sourceHero.position = {
+      x: Math.min(sourceState.map.width - 1, sourceHero.position.x + 1),
+      y: Math.min(sourceState.map.height - 1, sourceHero.position.y + 1)
+    };
+    sourceHero.move = { total: 8, remaining: 2 };
+    sourceHero.stats = {
+      ...sourceHero.stats,
+      attack: sourceHero.stats.attack + 3,
+      defense: sourceHero.stats.defense + 2,
+      hp: 34,
+      maxHp: 34
+    };
+    sourceHero.progression = {
+      ...sourceHero.progression,
+      level: 4,
+      experience: 420,
+      skillPoints: 3,
+      battlesWon: 5,
+      neutralBattlesWon: 5,
+      pvpBattlesWon: 0
+    };
+    sourceHero.loadout = {
+      ...sourceHero.loadout,
+      learnedSkills: [{ skillId: "armor_spell", rank: 1 }],
+      equipment: {
+        weaponId: "bronze_halberd",
+        armorId: "march_guard",
+        accessoryId: "trail_compass",
+        trinketIds: ["wind_charm"]
+      },
+      inventory: ["sunforged_spear", "ranger_scale", "ember_talisman"]
+    };
+    sourceHero.learnedSkills = [{ skillId: "war_banner", rank: 2 }];
+    sourceHero.armyCount = 18;
+
+    await store.save(SOURCE_ROOM_ID, {
+      state: sourceState,
+      battles: []
+    });
+    await store.savePlayerAccountProgress(PLAYER_ONE_ID, {
+      recentEventLog: [createEventLogEntry(PLAYER_ONE_ID, HERO_ONE_ID)],
+      recentBattleReplays: [createReplaySummary(PLAYER_ONE_ID, HERO_ONE_ID)],
+      lastRoomId: SOURCE_ROOM_ID
+    });
+
+    const persistedSnapshot = await store.load(SOURCE_ROOM_ID);
+    const persistedAccount = await store.loadPlayerAccount(PLAYER_ONE_ID);
+    const persistedArchives = await store.loadPlayerHeroArchives([PLAYER_ONE_ID]);
+    const persistedHistory = await store.loadPlayerEventHistory(PLAYER_ONE_ID, {
+      category: "achievement",
+      heroId: HERO_ONE_ID
+    });
+
+    assert.equal(persistedSnapshot?.state.resources[PLAYER_ONE_ID]?.gold, 640);
+    assertions.push("source-room snapshot keeps upgraded world resources");
+
+    assert.equal(persistedSnapshot?.state.heroes.find((hero) => hero.id === HERO_ONE_ID)?.progression.level, 4);
+    assertions.push("source-room snapshot keeps upgraded hero progression");
+
+    assert.equal(persistedAccount?.globalResources.gold, 640);
+    assert.equal(persistedAccount?.recentBattleReplays?.[0]?.id, REPLAY_ID);
+    assert.equal(persistedAccount?.lastRoomId, SOURCE_ROOM_ID);
+    assertions.push("player-account persistence keeps resources, replay summary, and last room");
+
+    assert.equal(persistedHistory.total >= 1, true);
+    assert.equal(persistedHistory.items[0]?.id, EVENT_ID);
+    assertions.push("player event history remains queryable through the persistence store");
+
+    const archiveHero = persistedArchives.find((archive) => archive.heroId === HERO_ONE_ID)?.hero;
+    assert.equal(archiveHero?.stats.attack, sourceHero.stats.attack);
+    assert.equal(archiveHero?.progression.level, 4);
+    assertions.push("hero archive captures long-term hero growth");
+
+    const targetState = createWorldStateFromConfigs(worldConfig, mapObjectsConfig, 1002, TARGET_ROOM_ID);
+    const hydratedTargetState = applyPlayerHeroArchivesToWorldState(
+      applyPlayerAccountsToWorldState(targetState, persistedAccount ? [persistedAccount] : []),
+      persistedArchives
+    );
+    const hydratedHero = hydratedTargetState.heroes.find((hero) => hero.id === HERO_ONE_ID);
+
+    assert.equal(hydratedTargetState.resources[PLAYER_ONE_ID]?.gold, 640);
+    assert.equal(hydratedHero?.progression.level, 4);
+    assert.equal(hydratedHero?.stats.attack, sourceHero.stats.attack);
+    assert.deepEqual(hydratedHero?.position, originalTargetPosition);
+    assert.deepEqual(hydratedHero?.move, { total: 8, remaining: 8 });
+    assert.deepEqual(hydratedHero?.loadout.equipment, sourceHero.loadout.equipment);
+    assertions.push("fresh-room hydration reapplies account resources and hero growth while resetting room-local position/readiness");
+
+    return {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      revision,
+      requestedStorageMode: args.storageMode,
+      effectiveStorageMode: mode,
+      storageDescription: description,
+      configsRoot: args.configsRoot,
+      summary: {
+        status: "passed",
+        assertionCount: assertions.length
+      },
+      contentValidation: {
+        valid: true,
+        bundleCount: contentReport.bundleCount,
+        summary: contentReport.contentPack.summary,
+        issueCount: contentReport.documentValidation.issueCount + contentReport.contentPack.issueCount
+      },
+      persistenceRegression: {
+        sourceRoomId: SOURCE_ROOM_ID,
+        targetRoomId: TARGET_ROOM_ID,
+        playerId: PLAYER_ONE_ID,
+        heroId: HERO_ONE_ID,
+        assertions
+      }
+    };
+  } finally {
+    await Promise.resolve(store.delete?.(SOURCE_ROOM_ID)).catch(() => undefined);
+    await store.close();
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const report = await runPhase1ReleasePersistenceRegression(args);
+  const outputPath = resolveOutputPath(args.outputPath, report.revision.shortCommit);
+  writeJsonFile(outputPath, report);
+
+  console.log("Phase 1 release persistence regression");
+  console.log(`Storage: ${report.effectiveStorageMode}`);
+  console.log(`Content validation: PASS (${report.contentValidation.bundleCount} bundles)`);
+  console.log(`Assertions: ${report.summary.assertionCount}`);
+  console.log(`Report written to ${path.relative(process.cwd(), outputPath).replace(/\\/g, "/")}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch((error) => {
+    console.error(`Phase 1 release persistence regression failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-readiness-snapshot.ts
+++ b/scripts/release-readiness-snapshot.ts
@@ -105,6 +105,13 @@ const AUTOMATED_CHECKS: Array<Pick<ReleaseReadinessCheck, "id" | "title" | "comm
     required: true
   },
   {
+    id: "phase1-release-persistence",
+    title: "Phase 1 persistence and shipped content regression",
+    command:
+      "npm run test:phase1-release-persistence -- --output artifacts/release-readiness/phase1-release-persistence-regression.json",
+    required: true
+  },
+  {
     id: "sync-governance-matrix",
     title: "Deterministic sync-governance matrix",
     command: "npm run test:sync-governance:matrix -- --output artifacts/release-readiness/sync-governance-matrix.json",

--- a/scripts/test/phase1-release-persistence-regression.test.ts
+++ b/scripts/test/phase1-release-persistence-regression.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { runPhase1ReleasePersistenceRegression } from "../phase1-release-persistence-regression.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+test("phase1 release persistence regression validates shipped content and persistence carryover in memory mode", async () => {
+  const report = await runPhase1ReleasePersistenceRegression({
+    storageMode: "memory",
+    configsRoot: path.join(repoRoot, "configs")
+  });
+
+  assert.equal(report.summary.status, "passed");
+  assert.equal(report.effectiveStorageMode, "memory");
+  assert.equal(report.contentValidation.valid, true);
+  assert.equal(report.contentValidation.bundleCount, 3);
+  assert.equal(report.persistenceRegression.playerId, "release-gate-player-1");
+  assert.equal(report.persistenceRegression.heroId, "release-gate-hero-1");
+  assert.equal(report.persistenceRegression.assertions.length >= 6, true);
+  assert.match(
+    report.persistenceRegression.assertions.join("\n"),
+    /fresh-room hydration reapplies account resources and hero growth while resetting room-local position\/readiness/
+  );
+});

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   getDefaultBattleBalanceConfig,
   validateBattleBalanceConfig,
@@ -34,7 +35,7 @@ interface BundleContentPackValidationIssue extends ContentPackValidationIssue {
   bundleId: string;
 }
 
-interface BundleValidationReport {
+export interface BundleValidationReport {
   id: string;
   worldFileName: string;
   mapObjectsFileName: string;
@@ -52,7 +53,7 @@ interface BundleValidationReport {
   };
 }
 
-interface ContentPackCliReport {
+export interface ContentPackCliReport {
   schemaVersion: 1;
   generatedAt: string;
   rootDir: string;
@@ -164,9 +165,12 @@ async function loadBundle(rootDir: string, definition: ContentPackMapPackDefinit
   };
 }
 
-async function main(): Promise<void> {
-  const { rootDir, reportPath, extraMapPacks } = parseArgs(process.argv.slice(2));
-  const bundleDefinitions = [DEFAULT_CONTENT_PACK_MAP_PACK, ...extraMapPacks];
+export async function buildContentPackCliReport(options: {
+  rootDir?: string;
+  extraMapPacks?: ContentPackMapPackDefinition[];
+} = {}): Promise<ContentPackCliReport> {
+  const rootDir = options.rootDir ?? resolve(process.cwd(), "configs");
+  const bundleDefinitions = [DEFAULT_CONTENT_PACK_MAP_PACK, ...(options.extraMapPacks ?? [])];
   const bundles = await Promise.all(
     bundleDefinitions.map(async (definition): Promise<BundleValidationReport> => {
       const bundle = await loadBundle(rootDir, definition);
@@ -198,7 +202,7 @@ async function main(): Promise<void> {
 
   const documentIssues = bundles.flatMap((bundle) => bundle.documentValidation.issues);
   const contentPackIssues = bundles.flatMap((bundle) => bundle.contentPack.issues);
-  const report: ContentPackCliReport = {
+  return {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
     rootDir,
@@ -220,6 +224,14 @@ async function main(): Promise<void> {
     },
     bundles
   };
+}
+
+async function main(): Promise<void> {
+  const { rootDir, reportPath, extraMapPacks } = parseArgs(process.argv.slice(2));
+  const report = await buildContentPackCliReport({
+    rootDir,
+    extraMapPacks
+  });
 
   console.log("Project Veil content-pack validation");
   console.log(`Root: ${rootDir}`);
@@ -243,7 +255,9 @@ async function main(): Promise<void> {
   }
 }
 
-void main().catch((error) => {
-  console.error(`Content-pack validation failed: ${error instanceof Error ? error.message : String(error)}`);
-  process.exitCode = 1;
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch((error) => {
+    console.error(`Content-pack validation failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated Phase 1 release persistence regression that validates shipped content packs and exercises persistence-backed account/world carryover
- wire the regression into `release:readiness:snapshot` as a required automated check
- document how maintainers run and interpret the regression for release verification

## Verification
- npm run test:phase1-release-persistence -- --storage memory --output artifacts/release-readiness/phase1-release-persistence-regression.local.json
- node --import tsx --test ./scripts/test/phase1-release-persistence-regression.test.ts ./scripts/test/validate-content-pack.test.ts ./apps/cocos-client/test/release-readiness-snapshot.test.ts

## Notes
- `npm run typecheck` remains red in this worktree because of pre-existing unrelated type errors across client/cocos/scripts tests; the new regression command and focused node:test coverage passed.

Closes #497