### PR TITLE
feat(cocos): formalize battle presentation

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -89,7 +89,17 @@ export function buildBattleTransitionFeedback(
 
   const resolved = update.events.find((event) => event.type === "battle.resolved");
   if (!resolved) {
-    return null;
+    if (!previousBattle) {
+      return null;
+    }
+
+    const settlement = buildBattleSettlementSummary(previousBattle, update, heroId);
+    return {
+      title: "战斗收束",
+      detail: settlement.detail,
+      badge: "SETTLE",
+      tone: "neutral"
+    };
   }
 
   const didWin =

--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -84,7 +84,7 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
       ? [state.presentationState.label, ...state.presentationState.summaryLines]
       : ["当前没有战斗。"];
     return {
-      title: state.presentationState?.result ? "战斗结算" : "战斗面板",
+      title: state.presentationState?.phase === "resolution" ? "战斗结算" : "战斗面板",
       stage: null,
       feedback: state.feedback,
       summaryLines: presentationSummary,

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
@@ -24,6 +24,7 @@ export type CocosBattlePresentationMoment =
   | "impact_death"
   | "active_skill"
   | "active"
+  | "result_settlement"
   | "result_victory"
   | "result_defeat";
 
@@ -113,27 +114,28 @@ export function buildBattlePresentationPlan(
   }
 
   if (previousBattle && !nextBattle) {
-    const didWin = resolveBattleResolution(update, heroId);
+    const resolution = resolveBattleResolution(update, heroId);
     const feedback = buildBattleTransitionFeedback(update, heroId, previousBattle);
-    const result = didWin === null ? null : didWin ? "victory" : "defeat";
-    const moment = didWin ? "result_victory" : "result_defeat";
-    const cue = didWin === null ? null : didWin ? "victory" : "defeat";
-    const animation = didWin === null ? "idle" : didWin ? "victory" : "defeat";
+    const result = resolution;
+    const moment =
+      resolution === "victory" ? "result_victory" : resolution === "defeat" ? "result_defeat" : "result_settlement";
+    const cue = resolution === null ? null : resolution;
+    const animation = resolution === null ? "idle" : resolution === "victory" ? "victory" : "defeat";
     return {
       phase: "resolution",
       feedback,
       feedbackDurationMs: RESOLUTION_FEEDBACK_DURATION_MS,
       cue,
       animation,
-      transition: {
+      transition: resolution === null ? null : {
         kind: "exit",
-        copy: buildBattleExitCopy(previousBattle, update, didWin ?? false)
+        copy: buildBattleExitCopy(previousBattle, update, resolution === "victory")
       },
       moment,
       state: buildPresentationState("resolution", moment, previousBattle.id, feedback, result, {
         cue,
         animation,
-        transition: "exit",
+        transition: resolution === null ? null : "exit",
         durationMs: RESOLUTION_FEEDBACK_DURATION_MS,
         summaryLines: buildBattleSettlementLines(previousBattle, update, heroId)
       })
@@ -186,21 +188,21 @@ export function buildBattlePresentationPlan(
   };
 }
 
-function resolveBattleResolution(update: SessionUpdate, heroId: string | null): boolean | null {
+function resolveBattleResolution(update: SessionUpdate, heroId: string | null): "victory" | "defeat" | null {
   const resolved = update.events.find((event) => event.type === "battle.resolved");
   if (!resolved) {
     return null;
   }
 
   if (!heroId) {
-    return resolved.result === "attacker_victory";
+    return resolved.result === "attacker_victory" ? "victory" : "defeat";
   }
 
   if (resolved.result === "attacker_victory") {
-    return resolved.heroId === heroId;
+    return resolved.heroId === heroId ? "victory" : "defeat";
   }
 
-  return resolved.defenderHeroId === heroId;
+  return resolved.defenderHeroId === heroId ? "victory" : "defeat";
 }
 
 function detectBattleImpact(previousBattle: BattleState, nextBattle: BattleState): boolean {
@@ -324,6 +326,8 @@ function resolvePresentationLabel(moment: CocosBattlePresentationMoment, fallbac
       return "单位击倒";
     case "active_skill":
       return "技能结算";
+    case "result_settlement":
+      return "战斗收束";
     case "result_victory":
       return "战斗胜利";
     case "result_defeat":

--- a/apps/cocos-client/test/cocos-battle-feedback.test.ts
+++ b/apps/cocos-client/test/cocos-battle-feedback.test.ts
@@ -208,6 +208,18 @@ test("battle feedback summarizes action, progress, and outcome", () => {
   const defeatFeedback = buildBattleTransitionFeedback(createResolvedUpdate("defender_victory"), "hero-1");
   assert.equal(defeatFeedback?.tone, "defeat");
   assert.equal(defeatFeedback?.badge, "LOSE");
+
+  const unsettledFeedback = buildBattleTransitionFeedback(
+    {
+      ...createResolvedUpdate("attacker_victory"),
+      events: []
+    },
+    "hero-1",
+    battle
+  );
+  assert.equal(unsettledFeedback?.tone, "neutral");
+  assert.equal(unsettledFeedback?.badge, "SETTLE");
+  assert.match(unsettledFeedback?.detail ?? "", /准备返回世界地图/);
 });
 
 test("battle presentation plan formalizes enter, impact, and resolution phases", () => {
@@ -284,6 +296,21 @@ test("battle presentation plan formalizes enter, impact, and resolution phases",
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
     "播报：战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
   ]);
+
+  const unsettledResolutionPlan = buildBattlePresentationPlan(
+    battle,
+    {
+      ...createResolvedUpdate("attacker_victory"),
+      events: []
+    },
+    "hero-1"
+  );
+  assert.equal(unsettledResolutionPlan.phase, "resolution");
+  assert.equal(unsettledResolutionPlan.moment, "result_settlement");
+  assert.equal(unsettledResolutionPlan.cue, null);
+  assert.equal(unsettledResolutionPlan.animation, "idle");
+  assert.equal(unsettledResolutionPlan.transition, null);
+  assert.equal(unsettledResolutionPlan.feedback?.badge, "SETTLE");
 });
 
 test("battle transition feedback summarizes settlement rewards and field state", () => {

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -141,6 +141,46 @@ test("buildBattlePanelViewModel surfaces settlement and presentation layer summa
   ]);
 });
 
+test("buildBattlePanelViewModel keeps neutral settlement in the battle result shell", () => {
+  const view = buildBattlePanelViewModel({
+    update: createBaseUpdate(),
+    timelineEntries: [],
+    controlledCamp: null,
+    selectedTargetId: null,
+    actionPending: false,
+    feedback: {
+      title: "战斗收束",
+      detail: "战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图",
+      badge: "SETTLE",
+      tone: "neutral"
+    },
+    presentationState: {
+      battleId: "battle-1",
+      phase: "resolution",
+      moment: "result_settlement",
+      label: "战斗收束",
+      detail: "战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图",
+      badge: "SETTLE",
+      tone: "neutral",
+      result: null,
+      summaryLines: [
+        "反馈层：动画 待机",
+        "播报：战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
+      ],
+      feedbackLayer: {
+        animation: "idle",
+        cue: null,
+        transition: null,
+        durationMs: 4200
+      }
+    }
+  });
+
+  assert.equal(view.idle, true);
+  assert.equal(view.title, "战斗结算");
+  assert.equal(view.summaryLines[0], "战斗收束");
+});
+
 test("buildBattlePanelViewModel enables attack actions on the player's turn", () => {
   const update = createBaseUpdate();
   update.battle = {

--- a/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
+++ b/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
@@ -251,4 +251,15 @@ test("battle presentation controller formalizes command, casualty, and result fl
   });
   assert.equal(controller.getState().feedbackLayer.transition, "exit");
   assert.match(controller.getState().summaryLines[1] ?? "", /战线：我方剩余 1 队 \/ 对方剩余 1 队/);
+
+  controller.applyUpdate(battle, createUpdate(null, []), "hero-1");
+  assertState(controller.getState(), {
+    phase: "resolution",
+    moment: "result_settlement",
+    label: "战斗收束",
+    tone: "neutral",
+    result: null
+  });
+  assert.equal(controller.getState().badge, "SETTLE");
+  assert.equal(controller.getState().feedbackLayer.transition, null);
 });

--- a/docs/phase1-maturity-scorecard.md
+++ b/docs/phase1-maturity-scorecard.md
@@ -24,7 +24,7 @@ The repository already contains the core gameplay loop, shared rules, authoritat
 | --- | --- | --- | --- | --- |
 | Phase 1 scope delivery | `Mostly complete` | [`README.md`](../README.md), [`docs/phase1-design.md`](./phase1-design.md) | Scope exists across multiple docs, but there was no single scorecard mapping shipped work to advancement criteria. | This scorecard stays current with repo reality, and scope drift remains bounded to the documented Phase 1 loop rather than Phase 2 expansion. |
 | Shared gameplay rules and authoritative server | `Established` | `packages/shared`, `apps/server`, [`docs/core-gameplay-release-readiness.md`](./core-gameplay-release-readiness.md) | Need continued proof that exploration, encounter, settlement, reconnect, and multiplayer sync stay authoritative under release-candidate pressure. | Latest candidate passes `npm test`, `npm run typecheck:ci`, `npm run test:e2e:smoke`, `npm run test:e2e:multiplayer:smoke`, and the release snapshot still records no required automated failures. |
-| Primary client runtime | `Mostly complete` | `apps/cocos-client`, [`docs/cocos-primary-client-delivery.md`](./cocos-primary-client-delivery.md), [`docs/wechat-minigame-release.md`](./wechat-minigame-release.md) | Cocos is the primary client, but the repo still calls out placeholder/fallback presentation risk and relies on structured RC evidence to prove the main journey. | A current Cocos RC snapshot exists for the same candidate, the main journey `Lobby -> world -> battle -> settlement -> reconnect` is recorded, and any remaining placeholder/fallback presentation items are either closed or explicitly accepted as non-blocking. |
+| Primary client runtime | `Mostly complete` | `apps/cocos-client`, [`docs/cocos-primary-client-delivery.md`](./cocos-primary-client-delivery.md), [`docs/wechat-minigame-release.md`](./wechat-minigame-release.md) | Cocos is the primary client, and the battle loop presentation is now formalized at the copy/state layer, but the repo still carries asset-level placeholder/fallback risk and relies on structured RC evidence to prove the main journey. | A current Cocos RC snapshot exists for the same candidate, the main journey `Lobby -> world -> battle -> settlement -> reconnect` is recorded, and any remaining placeholder/fallback presentation items are either closed or explicitly accepted as non-blocking. |
 | H5 debug and regression surface | `Established` | `apps/client`, Playwright smoke coverage, [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md) | H5 is intentionally no longer the shipping client, so the risk is regression drift between the debug shell and the Cocos runtime. | H5 remains green as a regression surface, and no Phase 1 gate depends on an H5-only behavior that the Cocos runtime cannot reproduce. |
 | Persistence and config pipeline | `Mostly complete` | MySQL migrations, config-center flows, [`docs/mysql-persistence.md`](./mysql-persistence.md), content-pack/balance validators | Persistence/config foundations exist, but they still need disciplined release-time verification instead of assuming parity from implementation alone. | The latest candidate includes one successful persistence regression on the intended storage mode plus passing config/content validation for shipped Phase 1 data. |
 | Release and operational readiness | `Partial` | [`docs/release-readiness-snapshot.md`](./release-readiness-snapshot.md), [`docs/release-readiness-dashboard.md`](./release-readiness-dashboard.md), [`docs/release-gate-summary.md`](./release-gate-summary.md) | The repo has strong gate machinery, but Phase 1 exit still depends on keeping human evidence fresh: runtime review, Cocos RC checklist/blockers, and WeChat smoke/reporting. | For a single candidate revision, automated gates pass, required manual checks are no longer pending, evidence is fresh, and the candidate can be rebuilt/reviewed without ad hoc interpretation. |
@@ -76,6 +76,20 @@ The shipped config/content pack validates cleanly, and `npm run test:phase1-rele
 
 8. `Known Phase 1 blockers are closed or explicitly accepted.`
 Any remaining Cocos presentation fallback, reconnect risk, multiplayer divergence risk, or release-process blocker is either fixed or recorded as a conscious non-blocking acceptance with owner and rationale.
+
+## Battle Presentation Baseline
+
+For the primary Cocos client battle path, the following now count as `production-intent` presentation behavior rather than fallback:
+
+- battle entry uses encounter-specific transition copy with terrain/context
+- battle command, impact, and resolution phases expose explicit labels, badges, and summary lines in the battle panel
+- battle settlement no longer falls back to an accidental defeat state when the client is only waiting for world-state sync
+- victory / defeat settlement remains the only path that drives the dedicated exit transition overlay
+
+The following are still considered `non-blocking fallback` for Phase 1 hardening and should stay tracked through presentation-readiness / RC evidence rather than battle-loop copy logic:
+
+- placeholder pixel art, mixed audio packs, and animation fallback delivery modes
+- any remaining asset substitutions already reported by `cocos-presentation-readiness`
 
 ## What Advancing Beyond Phase 1 Means Here
 


### PR DESCRIPTION
## Summary
- formalize Cocos battle resolution presentation so unresolved exits render as neutral settlement instead of accidental defeat
- keep the battle result shell active for neutral settlement states while preserving victory/defeat transition overlays
- document the battle presentation baseline and extend focused Cocos tests

closes #502