### PR TITLE
feat(ops): add Phase 1 go/no-go dashboard report

### DIFF
--- a/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildBuildPackageGate,
   buildCriticalEvidenceGate,
+  buildGoNoGoReport,
   summarizeCocosRc,
   summarizeSnapshot,
   summarizeWechatPackage,
@@ -13,6 +14,9 @@ import {
 test("summarizeSnapshot fails when a required release-readiness check is missing from an otherwise passed snapshot", () => {
   const summary = summarizeSnapshot("/tmp/release-readiness.json", {
     generatedAt: "2026-03-30T00:00:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
     summary: {
       status: "passed"
     },
@@ -35,6 +39,9 @@ test("summarizeSnapshot fails when a required release-readiness check is missing
 test("buildBuildPackageGate aggregates snapshot, package, and smoke evidence into a failing gate", () => {
   const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
     generatedAt: "2026-03-30T00:00:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
     summary: {
       status: "partial"
     },
@@ -72,6 +79,9 @@ test("buildBuildPackageGate aggregates snapshot, package, and smoke evidence int
 test("buildCriticalEvidenceGate downgrades stale evidence to warn and preserves fresh failures", () => {
   const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
     generatedAt: "2026-03-01T00:00:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
     summary: {
       status: "passed"
     },
@@ -131,4 +141,53 @@ test("buildCriticalEvidenceGate fails when a critical artifact is missing and ex
   assert.deepEqual(gate.warnReasons, []);
   assert.equal(gate.evidence.every((entry) => entry.availability === "missing"), true);
   assert.equal(gate.details.every((detail) => detail.endsWith("missing artifact")), true);
+});
+
+test("buildGoNoGoReport marks a candidate blocked when linked evidence revisions disagree", () => {
+  const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
+    generatedAt: "2026-03-30T00:00:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
+    summary: {
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
+    },
+    checks: [
+      { id: "npm-test", status: "passed", required: true },
+      { id: "typecheck-ci", status: "passed", required: true },
+      { id: "e2e-smoke", status: "passed", required: true },
+      { id: "e2e-multiplayer-smoke", status: "passed", required: true },
+      { id: "cocos-primary-journey", status: "passed", required: true },
+      { id: "wechat-build-check", status: "passed", required: true }
+    ]
+  });
+  const smokeSummary = summarizeWechatSmoke("/tmp/codex.wechat.smoke-report.json", {
+    artifact: {
+      sourceRevision: "def5678"
+    },
+    execution: {
+      result: "passed",
+      executedAt: "2026-03-30T00:05:00.000Z"
+    },
+    cases: [{ id: "login-lobby", status: "passed" }]
+  });
+  const goNoGo = buildGoNoGoReport({
+    candidateRevision: "abc1234",
+    snapshot: {
+      summary: {
+        requiredFailed: 0,
+        requiredPending: 0
+      }
+    },
+    gates: [],
+    evidence: [snapshotSummary.evidence, smokeSummary.evidence]
+  });
+
+  assert.equal(goNoGo.decision, "blocked");
+  assert.equal(goNoGo.revisionStatus, "mismatch");
+  assert.deepEqual(goNoGo.blockers, ["candidate_revision_mismatch"]);
+  assert.equal(goNoGo.evidence[0]?.matchesCandidate, true);
+  assert.equal(goNoGo.evidence[1]?.matchesCandidate, false);
 });

--- a/apps/cocos-client/test/release-readiness-dashboard.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard.test.ts
@@ -40,8 +40,13 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
 
   writeJson(snapshotPath, {
     generatedAt: "2026-03-29T08:00:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
     summary: {
-      status: "passed"
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
     },
     checks: [
       { id: "npm-test", status: "passed", required: true },
@@ -53,6 +58,9 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     ]
   });
   writeJson(cocosRcPath, {
+    candidate: {
+      shortCommit: "abc1234"
+    },
     execution: {
       overallStatus: "passed",
       executedAt: "2026-03-29T08:20:00.000Z",
@@ -169,6 +177,8 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
         cocosRcPath,
         "--wechat-artifacts-dir",
         wechatArtifactsDir,
+        "--candidate-revision",
+        "abc1234",
         "--output",
         outputPath,
         "--markdown-output",
@@ -178,8 +188,16 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     );
 
     assert.match(output, /Overall status: pass/);
+    assert.match(output, /Go\/No-Go decision: ready/);
     const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
       overallStatus: string;
+      goNoGo: {
+        decision: string;
+        candidateRevision?: string;
+        requiredFailed: number;
+        requiredPending: number;
+        revisionStatus: string;
+      };
       gates: Array<{
         id: string;
         status: string;
@@ -189,6 +207,11 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
       }>;
     };
     assert.equal(report.overallStatus, "pass");
+    assert.equal(report.goNoGo.decision, "ready");
+    assert.equal(report.goNoGo.candidateRevision, "abc1234");
+    assert.equal(report.goNoGo.requiredFailed, 0);
+    assert.equal(report.goNoGo.requiredPending, 0);
+    assert.equal(report.goNoGo.revisionStatus, "aligned");
     assert.deepEqual(
       report.gates.map((gate) => [gate.id, gate.status]),
       [
@@ -200,7 +223,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     );
     assert.deepEqual(report.gates.every((gate) => gate.failReasons.length === 0), true);
     assert.equal(report.gates[3]?.evidence.every((entry) => entry.availability === "present"), true);
-    assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /Phase 1 Release Readiness Dashboard/);
+    assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /Phase 1 Go\/No-Go/);
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {
@@ -225,8 +248,13 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
 
   writeJson(snapshotPath, {
     generatedAt: "2026-03-29T08:00:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
     summary: {
-      status: "failed"
+      status: "failed",
+      requiredFailed: 1,
+      requiredPending: 0
     },
     checks: [
       { id: "npm-test", status: "failed", required: true },
@@ -244,6 +272,9 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
     archiveSha256: "abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abcd"
   });
   writeJson(smokeReportPath, {
+    artifact: {
+      sourceRevision: "abc1234"
+    },
     execution: {
       result: "pending",
       executedAt: "2026-03-29T08:15:00.000Z"
@@ -263,6 +294,8 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
       snapshotPath,
       "--wechat-artifacts-dir",
       wechatArtifactsDir,
+      "--candidate-revision",
+      "abc1234",
       "--output",
       outputPath,
       "--markdown-output",
@@ -276,8 +309,16 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
   );
 
   assert.match(output, /Overall status: fail/);
+  assert.match(output, /Go\/No-Go decision: blocked/);
   const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
     overallStatus: string;
+    goNoGo: {
+      decision: string;
+      requiredFailed: number;
+      requiredPending: number;
+      revisionStatus: string;
+      blockers: string[];
+    };
     gates: Array<{
       id: string;
       status: string;
@@ -287,6 +328,11 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
     }>;
   };
   assert.equal(report.overallStatus, "fail");
+  assert.equal(report.goNoGo.decision, "blocked");
+  assert.equal(report.goNoGo.requiredFailed, 1);
+  assert.equal(report.goNoGo.requiredPending, 0);
+  assert.equal(report.goNoGo.revisionStatus, "aligned");
+  assert.equal(report.goNoGo.blockers.includes("requiredFailed=1"), true);
   assert.deepEqual(
     report.gates.map((gate) => [gate.id, gate.status]),
     [

--- a/docs/release-readiness-dashboard.md
+++ b/docs/release-readiness-dashboard.md
@@ -1,6 +1,6 @@
 # Phase 1 Release Readiness Dashboard
 
-`npm run release:readiness:dashboard` generates a single local report for the current Phase 1 gameplay release gates. It reuses existing evidence instead of redefining the workflow:
+`npm run release:readiness:dashboard` generates a single local report for the current Phase 1 gameplay release gates. It now promotes one Phase 1 `go/no-go` decision for a candidate revision, including first-class `requiredFailed` / `requiredPending` counts plus linked artifact paths for quick audit. The report reuses existing evidence instead of redefining the workflow:
 
 - `npm run release:readiness:snapshot` for automated regression/build gates
 - `GET /api/runtime/health`, `GET /api/runtime/auth-readiness`, `GET /api/runtime/metrics` for live server/auth posture
@@ -25,7 +25,8 @@ npm run release:readiness:dashboard -- \
   --server-url http://127.0.0.1:2567 \
   --snapshot artifacts/release-readiness/rc-2026-03-29.json \
   --cocos-rc artifacts/release-evidence/phase1-wechat-rc.json \
-  --wechat-artifacts-dir artifacts/wechat-release
+  --wechat-artifacts-dir artifacts/wechat-release \
+  --candidate-revision abc1234
 ```
 
 Write to explicit output files:
@@ -42,9 +43,24 @@ If your evidence freshness window should be stricter or looser than the default 
 npm run release:readiness:dashboard -- --max-evidence-age-days 7
 ```
 
+If you want the report to pin all automated and manual evidence to one explicit candidate revision, pass:
+
+```bash
+npm run release:readiness:dashboard -- --candidate-revision <git-sha>
+```
+
 ## Gate Mapping
 
-The report summarizes four bounded gates:
+The report starts with one `go/no-go` section:
+
+- `ready`
+  - `requiredFailed=0`, `requiredPending=0`, no gate is failing or warning, and the linked evidence revisions align with the candidate revision when one can be verified.
+- `pending`
+  - no blocking failures exist, but required checks are still pending, some evidence is stale / missing a timestamp, live/manual checks were not run, or the candidate revision cannot yet be verified across the linked evidence.
+- `blocked`
+  - one or more required checks failed, a gate failed, or linked artifact revisions disagree on which candidate is under review.
+
+After that, the report summarizes the same four bounded gates:
 
 - `Server health`
   - `pass` when `/api/runtime/health` is reachable and `/api/runtime/metrics` exposes the expected gameplay/auth counters.
@@ -59,7 +75,7 @@ The report summarizes four bounded gates:
   - Confirms a `*.package.json` WeChat sidecar exists alongside its archive.
   - Reads `codex.wechat.smoke-report.json` and flags `pending` as `warn`, `failed` as `fail`.
 - `Critical readiness evidence`
-  - Lists the latest linked evidence with exact timestamps.
+  - Lists the latest linked evidence with exact timestamps, paths, and any revision identifiers discovered in the source artifacts.
   - Warns when evidence is missing or older than the configured freshness window.
 
 ## Recommended Local Flow
@@ -98,4 +114,4 @@ npm run release:readiness:dashboard -- \
   --wechat-artifacts-dir artifacts/wechat-release
 ```
 
-The Markdown output is intended to be attachable to issue/PR discussion, while the JSON output is intended for automation or later aggregation.
+The Markdown output is intended to be attachable to issue/PR discussion, while the JSON output is intended for automation or later aggregation. Both formats now expose the same candidate-level `goNoGo` block so reviewers do not need to stitch the final Phase 1 release call together by hand.

--- a/scripts/release-readiness-dashboard.ts
+++ b/scripts/release-readiness-dashboard.ts
@@ -13,6 +13,7 @@ interface Args {
   wechatArtifactsDir?: string;
   wechatSmokeReportPath?: string;
   wechatPackageMetadataPath?: string;
+  candidateRevision?: string;
   outputPath?: string;
   markdownOutputPath?: string;
   maxEvidenceAgeDays: number;
@@ -26,6 +27,11 @@ interface ReleaseReadinessSnapshotCheck {
 
 interface ReleaseReadinessSnapshot {
   generatedAt?: string;
+  revision?: {
+    commit?: string;
+    shortCommit?: string;
+    branch?: string;
+  };
   summary?: {
     status?: "passed" | "failed" | "pending" | "partial";
     requiredFailed?: number;
@@ -92,6 +98,10 @@ interface WechatSmokeReport {
 }
 
 interface CocosReleaseCandidateSnapshot {
+  candidate?: {
+    commit?: string;
+    shortCommit?: string;
+  };
   execution?: {
     overallStatus?: "pending" | "passed" | "failed" | "partial";
     executedAt?: string;
@@ -106,6 +116,7 @@ interface EvidenceItem {
   availability: EvidenceAvailability;
   freshness: EvidenceFreshness;
   observedAt?: string;
+  sourceRevision?: string;
   summary: string;
   reasonCodes: string[];
 }
@@ -126,6 +137,7 @@ interface DashboardReport {
   generatedAt: string;
   overallStatus: GateStatus;
   summary: string;
+  goNoGo: GoNoGoReport;
   inputs: {
     serverUrl?: string;
     snapshotPath?: string;
@@ -133,8 +145,35 @@ interface DashboardReport {
     wechatArtifactsDir?: string;
     wechatSmokeReportPath?: string;
     wechatPackageMetadataPath?: string;
+    candidateRevision?: string;
   };
   gates: GateReport[];
+}
+
+type GoNoGoDecision = "ready" | "pending" | "blocked";
+type RevisionStatus = "aligned" | "mismatch" | "unknown";
+
+interface GoNoGoEvidenceRef {
+  label: string;
+  path: string;
+  sourceRevision?: string;
+  observedAt?: string;
+  status: GateStatus;
+  availability: EvidenceAvailability;
+  freshness: EvidenceFreshness;
+  matchesCandidate?: boolean;
+}
+
+interface GoNoGoReport {
+  decision: GoNoGoDecision;
+  summary: string;
+  candidateRevision?: string;
+  revisionStatus: RevisionStatus;
+  requiredFailed: number;
+  requiredPending: number;
+  blockers: string[];
+  pending: string[];
+  evidence: GoNoGoEvidenceRef[];
 }
 
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
@@ -159,6 +198,7 @@ function parseArgs(argv: string[]): Args {
   let wechatArtifactsDir: string | undefined;
   let wechatSmokeReportPath: string | undefined;
   let wechatPackageMetadataPath: string | undefined;
+  let candidateRevision: string | undefined;
   let outputPath: string | undefined;
   let markdownOutputPath: string | undefined;
   let maxEvidenceAgeDays = 14;
@@ -197,6 +237,11 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--candidate-revision" && next) {
+      candidateRevision = next.trim();
+      index += 1;
+      continue;
+    }
     if (arg === "--output" && next) {
       outputPath = next;
       index += 1;
@@ -227,6 +272,7 @@ function parseArgs(argv: string[]): Args {
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
     ...(wechatPackageMetadataPath ? { wechatPackageMetadataPath } : {}),
+    ...(candidateRevision ? { candidateRevision } : {}),
     ...(outputPath ? { outputPath } : {}),
     ...(markdownOutputPath ? { markdownOutputPath } : {}),
     maxEvidenceAgeDays
@@ -325,6 +371,56 @@ function parseIsoDate(value: string | undefined): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function normalizeRevision(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized ? normalized : undefined;
+}
+
+function revisionsMatch(left: string | undefined, right: string | undefined): boolean {
+  const normalizedLeft = normalizeRevision(left);
+  const normalizedRight = normalizeRevision(right);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  return normalizedLeft === normalizedRight || normalizedLeft.startsWith(normalizedRight) || normalizedRight.startsWith(normalizedLeft);
+}
+
+function countSnapshotOutcomes(snapshot: ReleaseReadinessSnapshot | undefined): { requiredFailed: number; requiredPending: number } {
+  if (!snapshot) {
+    return { requiredFailed: 0, requiredPending: 0 };
+  }
+
+  if (
+    typeof snapshot.summary?.requiredFailed === "number" &&
+    Number.isFinite(snapshot.summary.requiredFailed) &&
+    typeof snapshot.summary?.requiredPending === "number" &&
+    Number.isFinite(snapshot.summary.requiredPending)
+  ) {
+    return {
+      requiredFailed: snapshot.summary.requiredFailed,
+      requiredPending: snapshot.summary.requiredPending
+    };
+  }
+
+  const requiredChecks = (snapshot.checks ?? []).filter((check) => check.required);
+  return {
+    requiredFailed: requiredChecks.filter((check) => check.status === "failed").length,
+    requiredPending: requiredChecks.filter((check) => check.status === "pending").length
+  };
+}
+
+function resolveCandidateRevision(inputRevision: string | undefined, revisions: string[]): string | undefined {
+  if (inputRevision?.trim()) {
+    return inputRevision.trim();
+  }
+
+  const [firstRevision] = revisions;
+  if (!firstRevision) {
+    return undefined;
+  }
+  return revisions.every((revision) => revisionsMatch(firstRevision, revision)) ? firstRevision : undefined;
+}
+
 function describeAge(observedAt: string | undefined, maxAgeDays: number): { status: GateStatus; detail: string } {
   if (!observedAt) {
     return {
@@ -361,6 +457,7 @@ function createEvidenceItem(input: {
   summary: string;
   availability?: EvidenceAvailability;
   freshness?: EvidenceFreshness;
+  sourceRevision?: string;
   reasonCodes?: string[];
 }): EvidenceItem {
   return {
@@ -370,6 +467,7 @@ function createEvidenceItem(input: {
     availability: input.availability ?? "present",
     freshness: input.freshness ?? "unknown",
     observedAt: input.observedAt,
+    sourceRevision: input.sourceRevision,
     summary: input.summary,
     reasonCodes: input.reasonCodes ?? []
   };
@@ -615,6 +713,7 @@ export function summarizeSnapshot(snapshotPath: string | undefined, snapshot: Re
       path: snapshotPath,
       status,
       observedAt: snapshot.generatedAt,
+      sourceRevision: snapshot.revision?.shortCommit ?? snapshot.revision?.commit,
       summary: parts.join(" | "),
       reasonCodes: status === "fail" ? failReasons : warnReasons
     }),
@@ -664,6 +763,7 @@ export function summarizeWechatPackage(metadataPath: string | undefined, metadat
       path: metadataPath,
       status,
       observedAt: new Date(fs.statSync(metadataPath).mtimeMs).toISOString(),
+      sourceRevision: metadata.sourceRevision,
       summary: valid
         ? `archive=${archiveFileName} sha=${archiveSha256?.slice(0, 12)}…`
         : "Package metadata is incomplete or the archive is missing.",
@@ -736,6 +836,7 @@ export function summarizeWechatSmoke(reportPath: string | undefined, report: Wec
       path: reportPath,
       status,
       observedAt: report.execution?.executedAt,
+      sourceRevision: report.artifact?.sourceRevision,
       summary: parts.join(" | "),
       reasonCodes: status === "fail" ? failReasons : warnReasons
     }),
@@ -782,6 +883,7 @@ export function summarizeCocosRc(snapshotPath: string | undefined, snapshot: Coc
       path: snapshotPath,
       status,
       observedAt: snapshot.execution?.executedAt,
+      sourceRevision: snapshot.candidate?.shortCommit ?? snapshot.candidate?.commit,
       summary: `overallStatus=${overallStatus ?? "<missing>"}`,
       reasonCodes: status === "fail" ? failReasons : warnReasons
     }),
@@ -910,6 +1012,70 @@ function buildOverallSummary(gates: GateReport[]): string {
   return "Pass: key Phase 1 release-readiness gates are green.";
 }
 
+export function buildGoNoGoReport(input: {
+  candidateRevision?: string;
+  snapshot: ReleaseReadinessSnapshot | undefined;
+  gates: GateReport[];
+  evidence: Array<EvidenceItem | undefined>;
+}): GoNoGoReport {
+  const snapshotCounts = countSnapshotOutcomes(input.snapshot);
+  const goNoGoEvidence = input.evidence
+    .filter((entry): entry is EvidenceItem => Boolean(entry))
+    .map((entry) => ({
+      label: entry.label,
+      path: entry.path,
+      sourceRevision: entry.sourceRevision,
+      observedAt: entry.observedAt,
+      status: entry.status,
+      availability: entry.availability,
+      freshness: entry.freshness
+    }));
+  const knownRevisions = goNoGoEvidence
+    .map((entry) => entry.sourceRevision?.trim())
+    .filter((entry): entry is string => Boolean(entry));
+  const candidateRevision = resolveCandidateRevision(input.candidateRevision, knownRevisions);
+  const mismatchedEvidence = candidateRevision
+    ? goNoGoEvidence.filter((entry) => entry.sourceRevision && !revisionsMatch(candidateRevision, entry.sourceRevision))
+    : [];
+  const revisionStatus: RevisionStatus =
+    mismatchedEvidence.length > 0 ? "mismatch" : candidateRevision ? "aligned" : "unknown";
+
+  const blockingGates = input.gates.filter((gate) => gate.status === "fail").map((gate) => gate.label);
+  const pendingGates = input.gates.filter((gate) => gate.status === "warn").map((gate) => gate.label);
+  const blockers = [
+    ...(snapshotCounts.requiredFailed > 0 ? [`requiredFailed=${snapshotCounts.requiredFailed}`] : []),
+    ...(revisionStatus === "mismatch" ? ["candidate_revision_mismatch"] : []),
+    ...blockingGates
+  ];
+  const pending = [
+    ...(snapshotCounts.requiredPending > 0 ? [`requiredPending=${snapshotCounts.requiredPending}`] : []),
+    ...(revisionStatus === "unknown" ? ["candidate_revision_unverified"] : []),
+    ...pendingGates
+  ];
+  const decision: GoNoGoDecision =
+    blockers.length > 0 ? "blocked" : pending.length > 0 ? "pending" : "ready";
+
+  return {
+    decision,
+    summary:
+      decision === "ready"
+        ? `Ready: requiredFailed=0, requiredPending=0, and the Phase 1 evidence set is current for ${candidateRevision ?? "the candidate revision"}.`
+        : decision === "blocked"
+          ? `Blocked: ${blockers.join(", ")}.`
+          : `Pending: ${pending.join(", ")}.`,
+    ...(candidateRevision ? { candidateRevision } : {}),
+    revisionStatus,
+    requiredFailed: snapshotCounts.requiredFailed,
+    requiredPending: snapshotCounts.requiredPending,
+    blockers,
+    pending,
+    evidence: goNoGoEvidence.map((entry) => ({
+      ...entry,
+      ...(candidateRevision && entry.sourceRevision ? { matchesCandidate: revisionsMatch(candidateRevision, entry.sourceRevision) } : {})
+    }))
+  };
+}
+
 function renderMarkdown(report: DashboardReport): string {
   const lines: string[] = [];
   lines.push("# Phase 1 Release Readiness Dashboard");
@@ -917,7 +1083,39 @@ function renderMarkdown(report: DashboardReport): string {
   lines.push(`- Generated at: ${report.generatedAt}`);
   lines.push(`- Overall status: ${report.overallStatus.toUpperCase()}`);
   lines.push(`- Summary: ${report.summary}`);
+  lines.push(`- Go/No-Go decision: ${report.goNoGo.decision.toUpperCase()}`);
+  lines.push(`- Go/No-Go summary: ${report.goNoGo.summary}`);
+  lines.push(`- Required failed: ${report.goNoGo.requiredFailed}`);
+  lines.push(`- Required pending: ${report.goNoGo.requiredPending}`);
+  lines.push(`- Candidate revision: ${report.goNoGo.candidateRevision ?? "<unverified>"}`);
+  lines.push(`- Revision status: ${report.goNoGo.revisionStatus.toUpperCase()}`);
   lines.push("");
+  lines.push("## Phase 1 Go/No-Go");
+  lines.push("");
+  lines.push(`- Decision: ${report.goNoGo.decision.toUpperCase()}`);
+  lines.push(`- Summary: ${report.goNoGo.summary}`);
+  lines.push(`- Required failed: ${report.goNoGo.requiredFailed}`);
+  lines.push(`- Required pending: ${report.goNoGo.requiredPending}`);
+  lines.push(`- Candidate revision: ${report.goNoGo.candidateRevision ?? "<unverified>"}`);
+  lines.push(`- Revision status: ${report.goNoGo.revisionStatus.toUpperCase()}`);
+  if (report.goNoGo.blockers.length > 0) {
+    lines.push(`- Blockers: ${report.goNoGo.blockers.join(", ")}`);
+  }
+  if (report.goNoGo.pending.length > 0) {
+    lines.push(`- Pending: ${report.goNoGo.pending.join(", ")}`);
+  }
+  if (report.goNoGo.evidence.length > 0) {
+    lines.push("- Evidence:");
+    for (const item of report.goNoGo.evidence) {
+      const observedAt = item.observedAt ? ` @ ${item.observedAt}` : "";
+      const revision = item.sourceRevision ? ` revision=${item.sourceRevision}` : "";
+      const candidateMatch = typeof item.matchesCandidate === "boolean" ? ` matchesCandidate=${item.matchesCandidate}` : "";
+      lines.push(
+        `  - ${item.label}: ${item.status.toUpperCase()}${observedAt} (${item.path}) [availability=${item.availability} freshness=${item.freshness}${revision}${candidateMatch}]`
+      );
+    }
+    lines.push("");
+  }
   lines.push("| Gate | Status | Summary |");
   lines.push("| --- | --- | --- |");
   for (const gate of report.gates) {
@@ -1029,13 +1227,20 @@ async function main(): Promise<void> {
     generatedAt: new Date().toISOString(),
     overallStatus: mergeStatuses(gates.map((gate) => gate.status)),
     summary: buildOverallSummary(gates),
+    goNoGo: buildGoNoGoReport({
+      candidateRevision: args.candidateRevision,
+      snapshot,
+      gates,
+      evidence: [snapshotSummary.evidence, packageSummary.evidence, smokeSummary.evidence, cocosRcSummary.evidence]
+    }),
     inputs: {
       ...(args.serverUrl ? { serverUrl: args.serverUrl } : {}),
       ...(resolvedSnapshotPath ? { snapshotPath: resolvedSnapshotPath } : {}),
       ...(resolvedCocosRcPath ? { cocosRcPath: resolvedCocosRcPath } : {}),
       ...(args.wechatArtifactsDir ? { wechatArtifactsDir: path.resolve(args.wechatArtifactsDir) } : {}),
       ...(wechatArtifacts.smokeReportPath ? { wechatSmokeReportPath: wechatArtifacts.smokeReportPath } : {}),
-      ...(wechatArtifacts.packageMetadataPath ? { wechatPackageMetadataPath: wechatArtifacts.packageMetadataPath } : {})
+      ...(wechatArtifacts.packageMetadataPath ? { wechatPackageMetadataPath: wechatArtifacts.packageMetadataPath } : {}),
+      ...(args.candidateRevision ? { candidateRevision: args.candidateRevision } : {})
     },
     gates
   };
@@ -1049,6 +1254,10 @@ async function main(): Promise<void> {
   console.log(`Wrote release-readiness dashboard JSON: ${toRelativePath(jsonOutputPath)}`);
   console.log(`Wrote release-readiness dashboard Markdown: ${toRelativePath(markdownOutputPath)}`);
   console.log(`Overall status: ${report.overallStatus}`);
+  console.log(`Go/No-Go decision: ${report.goNoGo.decision}`);
+  console.log(`Required failed: ${report.goNoGo.requiredFailed}`);
+  console.log(`Required pending: ${report.goNoGo.requiredPending}`);
+  console.log(`Candidate revision: ${report.goNoGo.candidateRevision ?? "<unverified>"}`);
   for (const gate of report.gates) {
     console.log(`- ${gate.label}: ${gate.status} (${gate.summary})`);
   }


### PR DESCRIPTION
## Summary
- add a first-class Phase 1 go/no-go decision to the release-readiness dashboard
- surface requiredFailed, requiredPending, candidate revision alignment, and linked evidence paths in JSON, Markdown, and CLI output
- document the candidate-revision flow and cover the new decision logic with focused dashboard tests

## Testing
- node --import tsx --test ./apps/cocos-client/test/release-readiness-dashboard.test.ts
- node --import tsx --test ./apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts