### PR TITLE
feat(release): automate candidate-level Cocos RC evidence bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ npm run dev:client:h5
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - 微信小游戏 RC artifact 聚合验收：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>]`
 - 微信小游戏发布彩排：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir>`（顺序执行 prepare / package / verify / validate，并在 `artifacts/wechat-release/` 输出 JSON + Markdown 摘要）
+- Cocos RC candidate bundle：`npm run release:cocos-rc:bundle -- --candidate <candidate-name> [--build-surface creator_preview|wechat_preview|wechat_upload_candidate]`（在 `artifacts/release-readiness/` 输出 candidate+revision 命名的 snapshot / checklist / blockers / JSON+Markdown bundle）
 - Issue #33 开源素材 staging 校验：`npm run check:issue33-assets -- --require-pack`
 - GitHub Actions `wechat-build-validation` 会把发布归档与 sidecar 元数据作为 artifact `wechat-release-<sha>` 上传，便于提审前下载与回溯
 - 统一发布门禁汇总默认输出到 `artifacts/release-readiness/release-gate-summary-<short-sha>.json` 和 `.md`，用于 CI artifact、PR 评论或人工巡检；详情见 `docs/release-gate-summary.md`

--- a/docs/cocos-release-evidence-template.md
+++ b/docs/cocos-release-evidence-template.md
@@ -1,6 +1,6 @@
 # Cocos Release Evidence Template
 
-本模板现在以 `npm run release:cocos-rc:snapshot` 生成的 machine-readable JSON 为主，Markdown 只保留使用说明、字段规则和样例路径。目标是把 Cocos Creator 预览与微信小游戏 RC 的证据收口到同一份可归档、可校验、可对比的快照里，并配套一份可直接复制的检查清单与 blocker 记录。
+本模板现在以 `npm run release:cocos-rc:bundle` 生成的 candidate-level evidence bundle 为主，内部仍复用 `npm run release:cocos-rc:snapshot` 作为 machine-readable JSON。目标是把 Cocos Creator 预览与微信小游戏 RC 的证据收口到同一份可归档、可校验、可对比的快照里，并自动补齐可直接附到 CI artifact / PR 评论的 Markdown 摘要、检查清单与 blocker 记录。
 
 相关文档：
 
@@ -15,18 +15,20 @@
 
 ## RC Evidence Packet
 
-每个 Cocos / WeChat release candidate 都固定产出同一组证据：
+每个 Cocos / WeChat release candidate 都固定产出同一组证据，并统一落在 `artifacts/release-readiness/`：
 
-1. `artifacts/release-readiness/<candidate>.json`
-   - 自动化 + manual gate 的统一发布快照
-2. `artifacts/release-evidence/<candidate>.<surface>.json`
+1. `artifacts/release-readiness/cocos-rc-evidence-bundle-<candidate>-<short-sha>.json`
+   - candidate-scoped bundle manifest，适合挂 CI artifact 或 PR 机器人
+2. `artifacts/release-readiness/cocos-rc-evidence-bundle-<candidate>-<short-sha>.md`
+   - 同一 bundle 的人类可读摘要，直接列出主链路 pass/fail/pending 状态
+3. `artifacts/release-readiness/cocos-rc-snapshot-<candidate>-<short-sha>.json`
    - `npm run release:cocos-rc:snapshot` 生成并回填的结构化 RC 证据
-3. `docs/release-evidence/cocos-wechat-rc-checklist.template.md`
-   - 执行人复制后填写的人工检查清单，明确每一步是否已完成
-4. `docs/release-evidence/cocos-wechat-rc-blockers.template.md`
-   - 记录 `P0/P1/P2` blocker、owner、退出条件和放行决定
+4. `artifacts/release-readiness/cocos-rc-checklist-<candidate>-<short-sha>.md`
+   - 从模板复制并预填 candidate / revision 的人工检查清单
+5. `artifacts/release-readiness/cocos-rc-blockers-<candidate>-<short-sha>.md`
+   - 从模板复制并预填 candidate / revision 的 blocker 记录
 
-其中 2 是权威 machine-readable 记录，3 和 4 是 reviewer / release owner 快速扫读的补充视图。不要为同一个 RC 另外发明独立格式。
+其中 3 是权威 machine-readable 记录，1/2/4/5 是 reviewer / release owner 快速扫读和留档的补充视图。不要为同一个 RC 另外发明独立格式。
 
 ## 标准流程
 
@@ -37,42 +39,33 @@ npm run release:readiness:snapshot -- \
   --manual-checks docs/release-readiness-manual-checks.example.json
 ```
 
-2. 生成一份 Cocos RC 快照模板：
+2. 生成 candidate-level Cocos RC evidence bundle：
 
 ```bash
-npm run release:cocos-rc:snapshot -- \
+npm run release:cocos-rc:bundle -- \
   --candidate rc-2026-03-29 \
-  --build-surface creator_preview \
-  --output artifacts/release-evidence/rc-2026-03-29.creator.json
+  --build-surface creator_preview
 ```
 
-3. 若目标面是微信小游戏，先完成 `verify` 与 `smoke`，再把 smoke 报告挂到同一份 RC 快照：
+3. 若目标面是微信小游戏，先完成 `verify` 与 `smoke`，再把 smoke 报告挂到同一份 bundle：
 
 ```bash
-npm run release:cocos-rc:snapshot -- \
+npm run release:cocos-rc:bundle -- \
   --candidate rc-2026-03-29 \
   --build-surface wechat_preview \
   --wechat-smoke-report artifacts/wechat-rc/codex.wechat.smoke-report.json \
-  --release-readiness-snapshot artifacts/release-readiness/rc-2026-03-29.json \
-  --output artifacts/release-evidence/rc-2026-03-29.wechat.json
+  --release-readiness-snapshot artifacts/release-readiness/rc-2026-03-29.json
 ```
 
-4. 回填后执行校验：
+4. 回填 bundle 内的 snapshot 后执行校验：
 
 ```bash
 npm run release:cocos-rc:snapshot -- \
-  --output artifacts/release-evidence/rc-2026-03-29.creator.json \
+  --output artifacts/release-readiness/cocos-rc-snapshot-rc-2026-03-29-<short-sha>.json \
   --check
 ```
 
-5. 复制 RC 检查清单与 blocker 模板，作为 PR 或 release issue 的人类可读附件：
-
-```bash
-cp docs/release-evidence/cocos-wechat-rc-checklist.template.md \
-  artifacts/release-evidence/rc-2026-03-29.checklist.md
-cp docs/release-evidence/cocos-wechat-rc-blockers.template.md \
-  artifacts/release-evidence/rc-2026-03-29.blockers.md
-```
+5. 将 bundle 的 Markdown 摘要、checklist 与 blockers 文件附到 PR、release issue 或 CI artifact；它们已经由同一条命令生成，不需要额外复制模板。
 
 ## 快照结构
 

--- a/docs/phase1-maturity-scorecard.md
+++ b/docs/phase1-maturity-scorecard.md
@@ -62,8 +62,9 @@ The candidate passes:
 `npm run release:readiness:snapshot` for the candidate shows no `requiredFailed` checks and no `requiredPending` checks.
 
 4. `Cocos primary-client evidence is current.`
-A candidate-specific Cocos RC snapshot/checklist exists and demonstrates the complete main journey:
+A candidate-specific Cocos RC evidence bundle exists under `artifacts/release-readiness/` and demonstrates the complete main journey:
 `Lobby/login -> room join -> map exploration -> encounter battle -> settlement -> reconnect/session recovery`.
+The canonical generation path is `npm run release:cocos-rc:bundle -- --candidate <candidate-name> ...`, which must emit the candidate+revision bundle manifest, Markdown summary, RC snapshot, checklist, and blocker log for the same revision.
 
 5. `WeChat release evidence is current when WeChat is the target surface.`
 The candidate has current package/verify/smoke evidence, and the required report is attached rather than implied from a successful build alone.

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -33,7 +33,7 @@
 - 生成 / 校验真机冒烟报告：`npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> [--report <report-path>] [--runtime-evidence <runtime-evidence.json>] [--check --expected-revision <git-sha>]`
 - 导入自动化设备/runtime 证据：`npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
-- 统一 Cocos RC 证据快照：`npm run release:cocos-rc:snapshot`
+- 统一 Cocos RC candidate bundle：`npm run release:cocos-rc:bundle`
 - Primary client delivery checklist：`docs/cocos-primary-client-delivery.md`
 - Primary client delivery audit：`npm run audit:cocos-primary-delivery -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--expected-revision <git-sha>]`
 - RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
@@ -74,8 +74,8 @@
 9. 若本次 RC 没有自动化 runtime 证据，再运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板，并在真机或准真机上逐项补录结果。
 10. 完成自动导入或人工补录后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
    - `reconnect-recovery` 必须复用 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md) 的 canonical scenario、最小成功信号和失败诊断口径。
-11. 运行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，脚本会自动把微信 smoke 的 Lobby / 进房 / 重连证据映射到统一的 Cocos RC 快照；若仍缺 Creator 预览链路，会在快照里显式标成 `partial` 或 `blocked`，而不是默认为通过。
-12. 复制 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，仅补充自动化未覆盖的设备、结论和 blocker。
+11. 运行 `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json [--release-readiness-snapshot artifacts/release-readiness/<candidate>.json]`，脚本会在 `artifacts/release-readiness/` 一次性生成 candidate+revision 命名的 bundle manifest、Markdown 摘要、RC snapshot、checklist 与 blockers，并自动把微信 smoke 的 Lobby / 进房 / 重连证据映射到统一的 Cocos RC 快照；若仍缺 Creator 预览链路，会在快照和摘要里显式标成 `partial` 或 `blocked`，而不是默认为通过。
+12. 直接回填同一 bundle 里的 checklist / blockers 文件，仅补充自动化未覆盖的设备、结论和 blocker；不要再额外复制模板或在 PR 里发明另一套字段。
 13. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
 14. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
 
@@ -146,8 +146,8 @@
    - `reconnect-recovery.requiredEvidence` 下的 `roomId`、`reconnectPrompt`、`restoredState` 都必须填非空字符串；细则见 [`docs/reconnect-smoke-gate.md`](/home/gpt/project/ProjectVeil/.worktrees/issue-203/docs/reconnect-smoke-gate.md)
    - `share-roundtrip.requiredEvidence` 下的 `shareScene`、`shareQuery`、`roundtripState` 也都必须填非空字符串，用来说明分享入口、参数和回流结果
 5. 回填完成后执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`
-6. 再执行 `npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json --output artifacts/release-evidence/<candidate-name>.wechat.json`，把 `login-lobby`、`room-entry`、`reconnect-recovery` 自动映射到统一 RC 快照；若设备 evidence 缺失，快照会标成 `blocked`，避免在 RC 汇总里被误判为通过。
-7. 复制并回填 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 与 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，确保 reviewer 能直接看到当前 RC 的设备、结论与未关闭风险。
+6. 再执行 `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json`，把 `login-lobby`、`room-entry`、`reconnect-recovery` 自动映射到统一 RC 快照，并在 `artifacts/release-readiness/` 生成可直接附到 CI artifact / PR 评论的 bundle 摘要；若设备 evidence 缺失，快照会标成 `blocked`，避免在 RC 汇总里被误判为通过。
+7. 回填同一 bundle 里的 checklist / blockers 文件，确保 reviewer 能直接看到当前 RC 的设备、结论与未关闭风险。
 
 ### 自动化 Runtime Evidence Schema
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "release:wechat:rehearsal": "node --import tsx ./scripts/wechat-release-rehearsal.ts",
     "ci:trend-summary": "node --import tsx ./scripts/publish-ci-trend-summary.ts",
     "release:cocos-rc:snapshot": "node --import tsx ./scripts/cocos-release-candidate-snapshot.ts",
+    "release:cocos-rc:bundle": "node --import tsx ./scripts/cocos-rc-evidence-bundle.ts",
     "audit:cocos-primary-delivery": "node --import tsx ./scripts/audit-cocos-primary-delivery.ts",
     "check:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts --check && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/build-templates/wechatgame && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime && node --import tsx ./scripts/prepare-wechat-minigame-release.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime --check",
     "check:cocos-release-readiness": "node --import tsx ./scripts/validate-assets.ts --require-cocos-release-ready && npm run check:wechat-build",

--- a/scripts/cocos-rc-evidence-bundle.ts
+++ b/scripts/cocos-rc-evidence-bundle.ts
@@ -1,0 +1,481 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+type BuildSurface = "creator_preview" | "wechat_preview" | "wechat_upload_candidate" | "other";
+type EvidenceStatus = "pending" | "blocked" | "passed" | "failed" | "not_applicable";
+type SnapshotResult = "pending" | "blocked" | "passed" | "failed" | "partial";
+
+interface Args {
+  candidate: string;
+  outputDir: string;
+  owner?: string;
+  buildSurface: BuildSurface;
+  server?: string;
+  creatorVersion?: string;
+  wechatClient?: string;
+  device?: string;
+  notes?: string;
+  wechatSmokeReportPath?: string;
+  releaseReadinessSnapshotPath?: string;
+  force: boolean;
+}
+
+interface LinkedEvidenceRef {
+  path: string;
+  summary?: string;
+  result?: string;
+  sourceRevision?: string;
+}
+
+interface CanonicalEvidenceField {
+  id: string;
+  label: string;
+  required: boolean;
+  value: string;
+  notes: string;
+  evidence: string[];
+}
+
+interface JourneyStep {
+  id: string;
+  title: string;
+  required: boolean;
+  status: EvidenceStatus;
+  notes: string;
+  evidence: string[];
+  sourceRefs: string[];
+}
+
+interface CocosReleaseCandidateSnapshot {
+  schemaVersion: 1;
+  candidate: {
+    name: string;
+    scope: string;
+    branch: string;
+    commit: string;
+    shortCommit: string;
+    buildSurface: BuildSurface;
+  };
+  execution: {
+    owner: string;
+    executedAt: string;
+    overallStatus: SnapshotResult;
+    summary: string;
+    notes: string;
+  };
+  environment: {
+    server: string;
+    cocosCreatorVersion: string;
+    wechatClient: string;
+    device: string;
+  };
+  linkedEvidence: {
+    releaseReadinessSnapshot?: LinkedEvidenceRef;
+    wechatSmokeReport?: LinkedEvidenceRef;
+  };
+  requiredEvidence: CanonicalEvidenceField[];
+  journey: JourneyStep[];
+}
+
+interface BundleManifest {
+  schemaVersion: 1;
+  bundle: {
+    generatedAt: string;
+    outputDir: string;
+    candidate: string;
+    buildSurface: BuildSurface;
+    branch: string;
+    commit: string;
+    shortCommit: string;
+    overallStatus: SnapshotResult;
+    owner: string;
+    summary: string;
+  };
+  artifacts: {
+    snapshot: string;
+    summaryMarkdown: string;
+    checklistMarkdown: string;
+    blockersMarkdown: string;
+  };
+  linkedEvidence: CocosReleaseCandidateSnapshot["linkedEvidence"];
+  journey: Array<{
+    id: string;
+    title: string;
+    status: EvidenceStatus;
+    evidenceCount: number;
+  }>;
+  requiredEvidence: Array<{
+    id: string;
+    label: string;
+    filled: boolean;
+    evidenceCount: number;
+  }>;
+  review: {
+    phase1Gate: string;
+    attachHint: string;
+  };
+}
+
+const DEFAULT_OUTPUT_DIR = path.join("artifacts", "release-readiness");
+const CHECKLIST_TEMPLATE_PATH = path.resolve("docs", "release-evidence", "cocos-wechat-rc-checklist.template.md");
+const BLOCKERS_TEMPLATE_PATH = path.resolve("docs", "release-evidence", "cocos-wechat-rc-blockers.template.md");
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let candidate = "";
+  let outputDir = DEFAULT_OUTPUT_DIR;
+  let owner: string | undefined;
+  let buildSurface: BuildSurface = "creator_preview";
+  let server: string | undefined;
+  let creatorVersion: string | undefined;
+  let wechatClient: string | undefined;
+  let device: string | undefined;
+  let notes: string | undefined;
+  let wechatSmokeReportPath: string | undefined;
+  let releaseReadinessSnapshotPath: string | undefined;
+  let force = false;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--candidate" && next) {
+      candidate = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--output-dir" && next) {
+      outputDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--owner" && next) {
+      owner = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--build-surface" && next) {
+      buildSurface = parseBuildSurface(next);
+      index += 1;
+      continue;
+    }
+    if (arg === "--server" && next) {
+      server = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--creator-version" && next) {
+      creatorVersion = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--wechat-client" && next) {
+      wechatClient = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--device" && next) {
+      device = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--notes" && next) {
+      notes = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--wechat-smoke-report" && next) {
+      wechatSmokeReportPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--release-readiness-snapshot" && next) {
+      releaseReadinessSnapshotPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--force") {
+      force = true;
+      continue;
+    }
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  if (!candidate) {
+    fail("--candidate is required.");
+  }
+
+  return {
+    candidate,
+    outputDir,
+    ...(owner ? { owner } : {}),
+    buildSurface,
+    ...(server ? { server } : {}),
+    ...(creatorVersion ? { creatorVersion } : {}),
+    ...(wechatClient ? { wechatClient } : {}),
+    ...(device ? { device } : {}),
+    ...(notes ? { notes } : {}),
+    ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
+    ...(releaseReadinessSnapshotPath ? { releaseReadinessSnapshotPath } : {}),
+    force
+  };
+}
+
+function parseBuildSurface(value: string): BuildSurface {
+  if (
+    value === "creator_preview" ||
+    value === "wechat_preview" ||
+    value === "wechat_upload_candidate" ||
+    value === "other"
+  ) {
+    return value;
+  }
+  fail(`Unsupported build surface: ${value}`);
+}
+
+function getGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function slugifyCandidate(candidate: string): string {
+  const slug = candidate
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "cocos-rc";
+}
+
+function writeTextFile(filePath: string, content: string, force: boolean): void {
+  if (!force && fs.existsSync(filePath)) {
+    fail(`Output file already exists: ${filePath}. Pass --force to overwrite.`);
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function writeJsonFile(filePath: string, payload: unknown, force: boolean): void {
+  writeTextFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, force);
+}
+
+function runSnapshotCommand(args: Args, snapshotPath: string): void {
+  const commandArgs = [
+    "--import",
+    "tsx",
+    "./scripts/cocos-release-candidate-snapshot.ts",
+    "--candidate",
+    args.candidate,
+    "--build-surface",
+    args.buildSurface,
+    "--output",
+    snapshotPath
+  ];
+
+  if (args.owner) {
+    commandArgs.push("--owner", args.owner);
+  }
+  if (args.server) {
+    commandArgs.push("--server", args.server);
+  }
+  if (args.creatorVersion) {
+    commandArgs.push("--creator-version", args.creatorVersion);
+  }
+  if (args.wechatClient) {
+    commandArgs.push("--wechat-client", args.wechatClient);
+  }
+  if (args.device) {
+    commandArgs.push("--device", args.device);
+  }
+  if (args.notes) {
+    commandArgs.push("--notes", args.notes);
+  }
+  if (args.wechatSmokeReportPath) {
+    commandArgs.push("--wechat-smoke-report", args.wechatSmokeReportPath);
+  }
+  if (args.releaseReadinessSnapshotPath) {
+    commandArgs.push("--release-readiness-snapshot", args.releaseReadinessSnapshotPath);
+  }
+  if (args.force) {
+    commandArgs.push("--force");
+  }
+
+  const result = spawnSync(process.execPath, commandArgs, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(result.stderr.trim() || result.stdout.trim() || "Failed to generate Cocos RC snapshot.");
+  }
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function renderBundleMarkdown(snapshot: CocosReleaseCandidateSnapshot, artifacts: BundleManifest["artifacts"]): string {
+  const lines: string[] = [];
+  lines.push("# Cocos RC Evidence Bundle");
+  lines.push("");
+  lines.push(`- Candidate: \`${snapshot.candidate.name}\``);
+  lines.push(`- Surface: \`${snapshot.candidate.buildSurface}\``);
+  lines.push(`- Commit: \`${snapshot.candidate.shortCommit}\` (${snapshot.candidate.branch})`);
+  lines.push(`- Overall status: \`${snapshot.execution.overallStatus}\``);
+  lines.push(`- Owner: ${snapshot.execution.owner || "_unassigned_"}`);
+  lines.push(`- Generated evidence packet for Phase 1 exit criterion 4 in \`artifacts/release-readiness/\`.`);
+  lines.push("");
+  lines.push("## Artifacts");
+  lines.push("");
+  lines.push(`- Snapshot: \`${toRepoRelative(artifacts.snapshot)}\``);
+  lines.push(`- Checklist: \`${toRepoRelative(artifacts.checklistMarkdown)}\``);
+  lines.push(`- Blockers: \`${toRepoRelative(artifacts.blockersMarkdown)}\``);
+  lines.push(`- Bundle manifest: \`${toRepoRelative(artifacts.summaryMarkdown.replace(/\.md$/, ".json"))}\``);
+  lines.push("");
+  lines.push("## Canonical Journey");
+  lines.push("");
+  lines.push("| Step | Status | Evidence |");
+  lines.push("| --- | --- | --- |");
+  for (const step of snapshot.journey) {
+    lines.push(`| ${step.title} | \`${step.status}\` | ${step.evidence.length} item(s) |`);
+  }
+  lines.push("");
+  lines.push("## Required Evidence");
+  lines.push("");
+  lines.push("| Field | Value | Evidence |");
+  lines.push("| --- | --- | --- |");
+  for (const field of snapshot.requiredEvidence) {
+    lines.push(`| \`${field.id}\` | ${field.value ? `\`${field.value}\`` : "_missing_"} | ${field.evidence.length} item(s) |`);
+  }
+  lines.push("");
+  if (snapshot.linkedEvidence.releaseReadinessSnapshot || snapshot.linkedEvidence.wechatSmokeReport) {
+    lines.push("## Linked Evidence");
+    lines.push("");
+    if (snapshot.linkedEvidence.releaseReadinessSnapshot) {
+      lines.push(`- Release readiness snapshot: \`${toRepoRelative(snapshot.linkedEvidence.releaseReadinessSnapshot.path)}\``);
+    }
+    if (snapshot.linkedEvidence.wechatSmokeReport) {
+      lines.push(`- WeChat smoke report: \`${toRepoRelative(snapshot.linkedEvidence.wechatSmokeReport.path)}\``);
+    }
+    lines.push("");
+  }
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(snapshot.execution.summary);
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function renderChecklist(snapshot: CocosReleaseCandidateSnapshot, artifactPaths: BundleManifest["artifacts"]): string {
+  const template = fs.readFileSync(CHECKLIST_TEMPLATE_PATH, "utf8");
+  const date = (snapshot.execution.executedAt || new Date().toISOString()).slice(0, 10);
+  return template
+    .replace("rc-YYYY-MM-DD", snapshot.candidate.name)
+    .replace("creator_preview | wechat_preview | wechat_upload_candidate", snapshot.candidate.buildSurface)
+    .replace("<git-sha>", snapshot.candidate.commit)
+    .replace("<name>", snapshot.execution.owner || "<name>")
+    .replace("<YYYY-MM-DD>", date)
+    .replace("artifacts/release-readiness/<candidate>.json", toRepoRelative(artifactPaths.summaryMarkdown).replace(/\.md$/, ".json"))
+    .replace("artifacts/release-evidence/<candidate>.<surface>.json", toRepoRelative(artifactPaths.snapshot));
+}
+
+function renderBlockers(snapshot: CocosReleaseCandidateSnapshot, artifactPaths: BundleManifest["artifacts"]): string {
+  const template = fs.readFileSync(BLOCKERS_TEMPLATE_PATH, "utf8");
+  const lastUpdated = snapshot.execution.executedAt || new Date().toISOString();
+  return template
+    .replace("rc-YYYY-MM-DD", snapshot.candidate.name)
+    .replace("creator_preview | wechat_preview | wechat_upload_candidate", snapshot.candidate.buildSurface)
+    .replace("<git-sha>", snapshot.candidate.commit)
+    .replace("<name>", snapshot.execution.owner || "<name>")
+    .replace("<YYYY-MM-DD HH:mm TZ>", lastUpdated)
+    .replace("artifacts/release-evidence/<candidate>.<surface>.json", toRepoRelative(artifactPaths.snapshot));
+}
+
+function toRepoRelative(filePath: string): string {
+  return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+}
+
+function buildManifest(snapshot: CocosReleaseCandidateSnapshot, artifacts: BundleManifest["artifacts"], outputDir: string): BundleManifest {
+  return {
+    schemaVersion: 1,
+    bundle: {
+      generatedAt: new Date().toISOString(),
+      outputDir: toRepoRelative(outputDir),
+      candidate: snapshot.candidate.name,
+      buildSurface: snapshot.candidate.buildSurface,
+      branch: snapshot.candidate.branch,
+      commit: snapshot.candidate.commit,
+      shortCommit: snapshot.candidate.shortCommit,
+      overallStatus: snapshot.execution.overallStatus,
+      owner: snapshot.execution.owner,
+      summary: snapshot.execution.summary
+    },
+    artifacts,
+    linkedEvidence: snapshot.linkedEvidence,
+    journey: snapshot.journey.map((step) => ({
+      id: step.id,
+      title: step.title,
+      status: step.status,
+      evidenceCount: step.evidence.length
+    })),
+    requiredEvidence: snapshot.requiredEvidence.map((field) => ({
+      id: field.id,
+      label: field.label,
+      filled: field.value.trim().length > 0,
+      evidenceCount: field.evidence.length
+    })),
+    review: {
+      phase1Gate: "Phase 1 exit criterion 4: candidate-specific Cocos primary-client evidence must be current.",
+      attachHint: "Attach the markdown summary to CI artifacts or PR comments, and keep the JSON manifest alongside the snapshot."
+    }
+  };
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const commit = getGitValue(["rev-parse", "HEAD"]);
+  const shortCommit = getGitValue(["rev-parse", "--short", "HEAD"]);
+  const slug = slugifyCandidate(args.candidate);
+  const outputDir = path.resolve(args.outputDir);
+  const baseName = `${slug}-${shortCommit}`;
+  const snapshotPath = path.join(outputDir, `cocos-rc-snapshot-${baseName}.json`);
+  const summaryMarkdownPath = path.join(outputDir, `cocos-rc-evidence-bundle-${baseName}.md`);
+  const manifestPath = path.join(outputDir, `cocos-rc-evidence-bundle-${baseName}.json`);
+  const checklistPath = path.join(outputDir, `cocos-rc-checklist-${baseName}.md`);
+  const blockersPath = path.join(outputDir, `cocos-rc-blockers-${baseName}.md`);
+
+  runSnapshotCommand(args, snapshotPath);
+
+  const snapshot = readJsonFile<CocosReleaseCandidateSnapshot>(snapshotPath);
+  if (snapshot.candidate.commit !== commit || snapshot.candidate.shortCommit !== shortCommit) {
+    fail("Generated snapshot revision does not match the current git revision.");
+  }
+
+  const artifacts: BundleManifest["artifacts"] = {
+    snapshot: path.resolve(snapshotPath),
+    summaryMarkdown: path.resolve(summaryMarkdownPath),
+    checklistMarkdown: path.resolve(checklistPath),
+    blockersMarkdown: path.resolve(blockersPath)
+  };
+
+  writeTextFile(summaryMarkdownPath, renderBundleMarkdown(snapshot, artifacts), args.force);
+  writeTextFile(checklistPath, renderChecklist(snapshot, artifacts), args.force);
+  writeTextFile(blockersPath, renderBlockers(snapshot, artifacts), args.force);
+  writeJsonFile(manifestPath, buildManifest(snapshot, artifacts, outputDir), args.force);
+
+  console.log(`Wrote Cocos RC evidence bundle: ${toRepoRelative(manifestPath)}`);
+  console.log(`  Candidate: ${snapshot.candidate.name}`);
+  console.log(`  Surface: ${snapshot.candidate.buildSurface}`);
+  console.log(`  Result: ${snapshot.execution.overallStatus}`);
+}
+
+main();

--- a/scripts/test/cocos-rc-evidence-bundle.test.ts
+++ b/scripts/test/cocos-rc-evidence-bundle.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+function writeJson(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and markdown attachments", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-cocos-rc-bundle-"));
+  const outputDir = path.join(workspace, "artifacts", "release-readiness");
+  const smokeReportPath = path.join(workspace, "codex.wechat.smoke-report.json");
+
+  writeJson(smokeReportPath, {
+    execution: {
+      tester: "bundle-bot",
+      device: "iPad Mini",
+      clientVersion: "WeChat 8.0.52",
+      executedAt: "2026-04-01T20:40:00+08:00",
+      result: "passed",
+      summary: "Imported smoke evidence covered lobby, room, and reconnect."
+    },
+    artifact: {
+      sourceRevision: "abc1234"
+    },
+    cases: [
+      {
+        id: "login-lobby",
+        status: "passed",
+        notes: "Lobby entered.",
+        evidence: ["artifacts/wechat-release/lobby.png"]
+      },
+      {
+        id: "room-entry",
+        status: "passed",
+        notes: "Joined room-alpha.",
+        evidence: ["artifacts/wechat-release/room-entry.png"]
+      },
+      {
+        id: "reconnect-recovery",
+        status: "passed",
+        notes: "Recovered room-alpha after reconnect.",
+        evidence: ["artifacts/wechat-release/reconnect.mp4"],
+        requiredEvidence: {
+          roomId: "room-alpha",
+          reconnectPrompt: "连接已恢复",
+          restoredState: "Restored world HUD after reconnect."
+        }
+      }
+    ]
+  });
+
+  execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/cocos-rc-evidence-bundle.ts",
+      "--candidate",
+      "rc-issue-507",
+      "--build-surface",
+      "wechat_preview",
+      "--owner",
+      "release-bot",
+      "--server",
+      "wss://example.invalid",
+      "--wechat-smoke-report",
+      smokeReportPath,
+      "--output-dir",
+      outputDir
+    ],
+    {
+      cwd: repoRoot,
+      stdio: "pipe"
+    }
+  );
+
+  const files = fs.readdirSync(outputDir).sort();
+  const manifestFile = files.find((entry) => entry.startsWith("cocos-rc-evidence-bundle-") && entry.endsWith(".json"));
+  const summaryFile = files.find((entry) => entry.startsWith("cocos-rc-evidence-bundle-") && entry.endsWith(".md"));
+  const snapshotFile = files.find((entry) => entry.startsWith("cocos-rc-snapshot-") && entry.endsWith(".json"));
+  const checklistFile = files.find((entry) => entry.startsWith("cocos-rc-checklist-") && entry.endsWith(".md"));
+  const blockersFile = files.find((entry) => entry.startsWith("cocos-rc-blockers-") && entry.endsWith(".md"));
+
+  assert.ok(manifestFile);
+  assert.ok(summaryFile);
+  assert.ok(snapshotFile);
+  assert.ok(checklistFile);
+  assert.ok(blockersFile);
+  assert.match(manifestFile ?? "", /rc-issue-507-/);
+
+  const manifest = JSON.parse(fs.readFileSync(path.join(outputDir, manifestFile!), "utf8")) as {
+    bundle: { candidate: string; buildSurface: string; overallStatus: string };
+    artifacts: { snapshot: string; summaryMarkdown: string; checklistMarkdown: string; blockersMarkdown: string };
+    journey: Array<{ id: string; status: string }>;
+    requiredEvidence: Array<{ id: string; filled: boolean }>;
+  };
+  assert.equal(manifest.bundle.candidate, "rc-issue-507");
+  assert.equal(manifest.bundle.buildSurface, "wechat_preview");
+  assert.equal(manifest.bundle.overallStatus, "partial");
+  assert.equal(manifest.journey.find((entry) => entry.id === "lobby-entry")?.status, "passed");
+  assert.equal(manifest.requiredEvidence.find((entry) => entry.id === "roomId")?.filled, true);
+  assert.equal(path.basename(manifest.artifacts.snapshot), snapshotFile);
+  assert.equal(path.basename(manifest.artifacts.summaryMarkdown), summaryFile);
+  assert.equal(path.basename(manifest.artifacts.checklistMarkdown), checklistFile);
+  assert.equal(path.basename(manifest.artifacts.blockersMarkdown), blockersFile);
+
+  const summaryMarkdown = fs.readFileSync(path.join(outputDir, summaryFile!), "utf8");
+  assert.match(summaryMarkdown, /# Cocos RC Evidence Bundle/);
+  assert.match(summaryMarkdown, /Overall status: `partial`/);
+  assert.match(summaryMarkdown, /Lobby entry \| `passed` \| 1 item\(s\)/);
+
+  const checklistMarkdown = fs.readFileSync(path.join(outputDir, checklistFile!), "utf8");
+  assert.match(checklistMarkdown, /Candidate: `rc-issue-507`/);
+  assert.match(checklistMarkdown, /cocos-rc-snapshot-rc-issue-507-/);
+
+  const blockersMarkdown = fs.readFileSync(path.join(outputDir, blockersFile!), "utf8");
+  assert.match(blockersMarkdown, /Candidate: `rc-issue-507`/);
+  assert.match(blockersMarkdown, /cocos-rc-snapshot-rc-issue-507-/);
+});


### PR DESCRIPTION
## Summary
- add a single `release:cocos-rc:bundle` command that emits a candidate+revision evidence packet under `artifacts/release-readiness/`
- reuse the existing RC snapshot flow, but automatically generate the PR/CI-friendly markdown summary plus candidate-scoped checklist and blockers attachments
- document the bundle as the Phase 1 Cocos evidence handoff path and cover it with a focused script test

## Testing
- node --import tsx --test ./scripts/test/cocos-release-candidate-snapshot.test.ts ./scripts/test/cocos-rc-evidence-bundle.test.ts
- npm run typecheck:shared -- --pretty false

Closes #507