### PR TITLE
feat: add WeChat release candidate summary artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ npm run dev:client:h5
 - 打包 H5 客户端 RC 冒烟：`npm run smoke:client:release-candidate`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
-- 微信小游戏 RC artifact 聚合验收：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>]`
+- 微信小游戏 RC artifact 聚合验收：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--manual-checks docs/release-evidence/wechat-release-manual-review.example.json]`（输出 `codex.wechat.rc-validation-report.json`、`codex.wechat.release-candidate-summary.json` 和 `.md`）
 - 微信小游戏发布彩排：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir>`（顺序执行 prepare / package / verify / validate，并在 `artifacts/wechat-release/` 输出 JSON + Markdown 摘要）
 - Cocos RC candidate bundle：`npm run release:cocos-rc:bundle -- --candidate <candidate-name> [--build-surface creator_preview|wechat_preview|wechat_upload_candidate]`（在 `artifacts/release-readiness/` 输出 candidate+revision 命名的 snapshot / checklist / blockers / JSON+Markdown bundle）
 - Issue #33 开源素材 staging 校验：`npm run check:issue33-assets -- --require-pack`

--- a/docs/release-evidence/wechat-release-manual-review.example.json
+++ b/docs/release-evidence/wechat-release-manual-review.example.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "wechat-runtime-review",
+    "title": "Runtime health/auth-readiness/metrics reviewed for this candidate",
+    "status": "pending",
+    "required": true,
+    "notes": "Capture runtime evidence against the same candidate revision before marking the WeChat target release-ready.",
+    "evidence": [
+      "GET /api/runtime/health",
+      "GET /api/runtime/auth-readiness",
+      "GET /api/runtime/metrics"
+    ]
+  },
+  {
+    "id": "wechat-release-checklist",
+    "title": "WeChat RC checklist and blockers reviewed",
+    "status": "pending",
+    "required": true,
+    "notes": "Attach the completed RC checklist and blocker register for the same packaged candidate.",
+    "evidence": [
+      "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
+      "docs/release-evidence/cocos-wechat-rc-blockers.template.md"
+    ]
+  }
+]

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -25,7 +25,7 @@
 - 刷新模板：`npm run prepare:wechat-build`
 - 生成发布元数据：`npm run prepare:wechat-release -- --output-dir <wechatgame-build-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - 产出发布归档：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
-- 聚合校验 RC artifact：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report]`
+- 聚合校验 RC artifact：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report] [--manual-checks docs/release-evidence/wechat-release-manual-review.example.json]`
 - 发布彩排与汇总：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> [--summary <json>] [--markdown <md>]`（顺序执行 prepare / package / verify / validate，并输出结构化 + Markdown 摘要）
 - 上传已打包产物：`npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`
 - 按 SHA 下载 CI artifact：`npm run download:wechat-release -- --sha <git-sha> [--output-dir artifacts/downloaded/wechat-release-<git-sha>]`
@@ -38,6 +38,7 @@
 - Primary client delivery audit：`npm run audit:cocos-primary-delivery -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--expected-revision <git-sha>]`
 - RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
 - RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
+- WeChat 手工复核 contract 示例：`docs/release-evidence/wechat-release-manual-review.example.json`
 - 只做 CI 同款校验：`npm run check:cocos-release-readiness`
 - 校验真实导出目录：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 
@@ -66,10 +67,13 @@
 4. 对真实导出目录执行 `npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`。
 5. 运行 `npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`，生成包含 `codex.wechat.release.json` 的归档包与 sidecar 元数据。
 6. 运行 `npm run verify:wechat-release -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>]`，在上传前先做一次本地 artifact 级冒烟验收。
-7. 如需把 sidecar、归档、可选 smoke report / upload receipt 收口成单条门禁，运行 `npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report]`。
+7. 如需把 sidecar、归档、smoke、manual review 与可选 upload receipt 收口成同一条 candidate-level 证据，运行 `npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report] [--manual-checks docs/release-evidence/wechat-release-manual-review.example.json]`。
    - 该命令会稳定输出 `codex.wechat.rc-validation-report.json`
+   - 同目录还会输出 `codex.wechat.release-candidate-summary.json` 与 `.md`，把 package、validation、smoke、upload、manual review 汇总到同一个 revision
+   - summary 中缺失 smoke 证据或待完成 manual review 会直接列为 `blockers`，而不是分散在多个文件里
    - JSON 至少包含 `version`、`commit`、artifact 路径、逐项检查结果和 `failureSummary`
    - `--version` 会要求并校验 `*.upload.json`；`--require-smoke-report` 会把 `codex.wechat.smoke-report.json` 设为必需门禁
+   - 若未显式传 `--manual-checks`，脚本仍会内置两条必需 manual review：runtime endpoint review 与 RC checklist/blocker review
 8. 若已有设备农场、真机调试或准真机脚本产出的结构化 runtime 证据，执行 `npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`，把证据直接写入既有 `codex.wechat.smoke-report.json` schema。
 9. 若本次 RC 没有自动化 runtime 证据，再运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板，并在真机或准真机上逐项补录结果。
 10. 完成自动导入或人工补录后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
@@ -115,6 +119,14 @@
 - artifact 归档与 sidecar 是否仍能通过 `verify:wechat-release`
 - 若存在 `codex.wechat.smoke-report.json`，则复用 `smoke:wechat-release --check` 校验其结果；传 `--require-smoke-report` 时缺失也会直接失败
 - 若存在 `*.upload.json`，则校验其与 sidecar 的 archive / SHA / commit 一致；传 `--version <wechat-version>` 时会把 upload receipt 设为必需并校验版本号
+
+同时 `validate:wechat-rc` 现在会为 reviewer 生成一份 candidate summary：
+
+- `codex.wechat.release-candidate-summary.json`：candidate-level contract，固定引用同一 revision 的 package、validation、smoke、upload、manual review 状态
+- `codex.wechat.release-candidate-summary.md`：可直接贴进 PR、CI summary 或提审记录的精简摘要
+- `blockers`：显式列出缺失 smoke report、失败校验、待完成 manual review，以及对应 artifact / next command
+- `--manual-checks <json>`：读取显式 manual review 状态；推荐直接从 `docs/release-evidence/wechat-release-manual-review.example.json` 复制当次 candidate 文件
+- `--manual-check <id>:<title>`：临时追加一条 pending manual review
 
 ## 提审前 Smoke Check
 

--- a/scripts/test/wechat-release-artifacts.test.ts
+++ b/scripts/test/wechat-release-artifacts.test.ts
@@ -35,6 +35,15 @@ interface RuntimeEvidenceCasePayload {
   requiredEvidence?: Record<string, string>;
 }
 
+interface ManualReviewCheckPayload {
+  id: string;
+  title: string;
+  status?: "passed" | "failed" | "pending" | "not_applicable";
+  required?: boolean;
+  notes?: string;
+  evidence?: string[];
+}
+
 function hashFileSha256(filePath: string): string {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
@@ -193,6 +202,10 @@ function updateArchiveMetadata(metadataPath: string, archivePath: string): void 
   fs.writeFileSync(metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
 }
 
+function writeManualChecks(filePath: string, checks: ManualReviewCheckPayload[]): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(checks, null, 2)}\n`, "utf8");
+}
+
 test("verify:wechat-release supports explicit artifact paths and keep-extracted output", () => {
   const artifact = packageFixtureArtifact();
 
@@ -274,6 +287,8 @@ test("verify:wechat-release fails when a required smoke file is missing from the
 test("validate:wechat-rc marks smoke and upload receipt checks as skipped when optional artifacts are absent", () => {
   const artifact = packageFixtureArtifact();
   const reportPath = path.join(artifact.artifactsDir, "explicit-report.json");
+  const summaryPath = path.join(artifact.artifactsDir, "explicit-summary.json");
+  const markdownPath = path.join(artifact.artifactsDir, "explicit-summary.md");
 
   const output = execFileSync(
     "node",
@@ -287,6 +302,10 @@ test("validate:wechat-rc marks smoke and upload receipt checks as skipped when o
       artifact.metadataPath,
       "--report",
       reportPath,
+      "--summary",
+      summaryPath,
+      "--markdown",
+      markdownPath,
       "--expected-revision",
       sourceRevision
     ],
@@ -320,6 +339,32 @@ test("validate:wechat-rc marks smoke and upload receipt checks as skipped when o
       "upload-receipt:skipped:Upload receipt not present."
     ]
   );
+
+  const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8")) as {
+    candidate: { revision: string; status: string };
+    artifacts: { validationReportPath: string; smokeReportPath: string; markdownPath: string };
+    evidence: {
+      smoke: { status: string };
+      manualReview: { status: string; requiredPendingChecks: number; checks: Array<{ id: string; status: string }> };
+    };
+    blockers: Array<{ id: string; summary: string }>;
+  };
+
+  assert.match(output, /Candidate status: blocked/);
+  assert.equal(summary.candidate.revision, sourceRevision);
+  assert.equal(summary.candidate.status, "blocked");
+  assert.equal(summary.artifacts.validationReportPath, reportPath);
+  assert.equal(summary.artifacts.markdownPath, markdownPath);
+  assert.equal(summary.evidence.smoke.status, "skipped");
+  assert.equal(summary.evidence.manualReview.status, "blocked");
+  assert.equal(summary.evidence.manualReview.requiredPendingChecks, 2);
+  assert.deepEqual(
+    summary.evidence.manualReview.checks.map((check) => `${check.id}:${check.status}`),
+    ["wechat-runtime-review:pending", "wechat-release-checklist:pending"]
+  );
+  assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /smoke-report-missing/);
+  assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /manual:wechat-runtime-review/);
+  assert.match(fs.readFileSync(markdownPath, "utf8"), /WeChat Release Candidate Summary/);
 });
 
 test("validate:wechat-rc requires an upload receipt when version validation is requested", () => {
@@ -375,6 +420,87 @@ test("validate:wechat-rc requires an upload receipt when version validation is r
       "upload-receipt:failed"
     ]
   );
+});
+
+test("validate:wechat-rc marks the candidate ready when smoke evidence and manual review are complete", () => {
+  const artifact = packageFixtureArtifact();
+  const smokeReportPath = path.join(artifact.artifactsDir, "codex.wechat.smoke-report.json");
+  const manualChecksPath = path.join(artifact.artifactsDir, "wechat-manual-review.json");
+  const summaryPath = path.join(artifact.artifactsDir, "codex.wechat.release-candidate-summary.json");
+  const markdownPath = path.join(artifact.artifactsDir, "codex.wechat.release-candidate-summary.md");
+  writePassingSmokeReport(artifact.metadataPath, smokeReportPath);
+  writeManualChecks(manualChecksPath, [
+    {
+      id: "wechat-runtime-review",
+      title: "Runtime health/auth-readiness/metrics reviewed for this candidate",
+      status: "passed",
+      required: true,
+      notes: "Captured candidate runtime endpoints for the same revision.",
+      evidence: ["GET /api/runtime/health", "GET /api/runtime/auth-readiness", "GET /api/runtime/metrics"]
+    },
+    {
+      id: "wechat-release-checklist",
+      title: "WeChat RC checklist and blockers reviewed",
+      status: "passed",
+      required: true,
+      notes: "Checklist and blockers resolved for the packaged candidate.",
+      evidence: [
+        "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
+        "docs/release-evidence/cocos-wechat-rc-blockers.template.md"
+      ]
+    }
+  ]);
+
+  const output = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/validate-wechat-release-candidate.ts",
+      "--archive",
+      artifact.archivePath,
+      "--metadata",
+      artifact.metadataPath,
+      "--smoke-report",
+      smokeReportPath,
+      "--manual-checks",
+      manualChecksPath,
+      "--summary",
+      summaryPath,
+      "--markdown",
+      markdownPath,
+      "--expected-revision",
+      sourceRevision
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8")) as {
+    candidate: { status: string; revision: string };
+    evidence: {
+      package: { status: string };
+      validation: { status: string };
+      smoke: { status: string };
+      manualReview: { status: string; requiredPendingChecks: number; requiredFailedChecks: number };
+    };
+    blockers: Array<{ id: string }>;
+  };
+
+  assert.match(output, /Candidate status: ready/);
+  assert.equal(summary.candidate.status, "ready");
+  assert.equal(summary.candidate.revision, sourceRevision);
+  assert.equal(summary.evidence.package.status, "passed");
+  assert.equal(summary.evidence.validation.status, "passed");
+  assert.equal(summary.evidence.smoke.status, "passed");
+  assert.equal(summary.evidence.manualReview.status, "ready");
+  assert.equal(summary.evidence.manualReview.requiredPendingChecks, 0);
+  assert.equal(summary.evidence.manualReview.requiredFailedChecks, 0);
+  assert.equal(summary.blockers.length, 0);
+  assert.match(fs.readFileSync(markdownPath, "utf8"), /Candidate status: `ready`/);
 });
 
 test("smoke:wechat-release ingests automated runtime evidence into the existing smoke schema", () => {

--- a/scripts/validate-wechat-release-candidate.ts
+++ b/scripts/validate-wechat-release-candidate.ts
@@ -1,19 +1,25 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { parseManualCheckArg, parseManualChecksFile } from "./release-readiness-snapshot.ts";
 
 type CheckStatus = "passed" | "failed" | "skipped";
 type GateStatus = "passed" | "failed";
+type CandidateStatus = "ready" | "blocked";
 
 interface Args {
   artifactsDir?: string;
   archivePath?: string;
   metadataPath?: string;
   reportPath?: string;
+  summaryPath?: string;
+  markdownPath?: string;
   expectedRevision?: string;
   version?: string;
   smokeReportPath?: string;
   uploadReceiptPath?: string;
+  manualChecksPath?: string;
+  manualChecks: string[];
   requireSmokeReport: boolean;
 }
 
@@ -85,7 +91,98 @@ interface ValidationReport {
   checks: ValidationCheck[];
 }
 
+interface ManualReviewCheck {
+  id: string;
+  title: string;
+  required: boolean;
+  status: "passed" | "failed" | "pending" | "not_applicable";
+  notes: string;
+  evidence: string[];
+  source: "default" | "file" | "cli";
+}
+
+interface CandidateSummary {
+  schemaVersion: 1;
+  generatedAt: string;
+  candidate: {
+    revision: string | null;
+    version: string | null;
+    projectName: string;
+    appId: string;
+    status: CandidateStatus;
+  };
+  artifacts: {
+    artifactsDir?: string;
+    archivePath: string;
+    metadataPath: string;
+    validationReportPath: string;
+    summaryPath: string;
+    smokeReportPath: string;
+    uploadReceiptPath: string;
+    markdownPath: string;
+  };
+  evidence: {
+    package: {
+      status: CheckStatus;
+      summary: string;
+      artifactPath: string;
+    };
+    validation: {
+      status: CheckStatus;
+      summary: string;
+      artifactPath: string;
+    };
+    smoke: {
+      status: CheckStatus;
+      summary: string;
+      artifactPath: string;
+    };
+    upload: {
+      status: CheckStatus;
+      summary: string;
+      artifactPath: string;
+    };
+    manualReview: {
+      status: CandidateStatus;
+      totalChecks: number;
+      completedChecks: number;
+      requiredPendingChecks: number;
+      requiredFailedChecks: number;
+      checks: ManualReviewCheck[];
+    };
+  };
+  blockers: Array<{
+    id: string;
+    summary: string;
+    artifactPath?: string;
+    nextCommand?: string;
+  }>;
+}
+
 const OUTPUT_TAIL_BYTES = 4000;
+const DEFAULT_MANUAL_CHECKS: ManualReviewCheck[] = [
+  {
+    id: "wechat-runtime-review",
+    title: "Runtime health/auth-readiness/metrics reviewed for this candidate",
+    required: true,
+    status: "pending",
+    notes: "Capture runtime health evidence against the same candidate revision before marking the WeChat target release-ready.",
+    evidence: ["GET /api/runtime/health", "GET /api/runtime/auth-readiness", "GET /api/runtime/metrics"],
+    source: "default"
+  },
+  {
+    id: "wechat-release-checklist",
+    title: "WeChat RC checklist and blockers reviewed",
+    required: true,
+    status: "pending",
+    notes: "Attach the completed RC checklist and blocker register for the same packaged candidate.",
+    evidence: [
+      "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
+      "docs/release-evidence/cocos-wechat-rc-blockers.template.md"
+    ],
+    source: "default"
+  }
+];
 
 function fail(message: string): never {
   throw new Error(message);
@@ -96,10 +193,14 @@ function parseArgs(argv: string[]): Args {
   let archivePath: string | undefined;
   let metadataPath: string | undefined;
   let reportPath: string | undefined;
+  let summaryPath: string | undefined;
+  let markdownPath: string | undefined;
   let expectedRevision: string | undefined;
   let version: string | undefined;
   let smokeReportPath: string | undefined;
   let uploadReceiptPath: string | undefined;
+  let manualChecksPath: string | undefined;
+  const manualChecks: string[] = [];
   let requireSmokeReport = false;
 
   for (let index = 2; index < argv.length; index += 1) {
@@ -126,6 +227,16 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--summary" && next) {
+      summaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--markdown" && next) {
+      markdownPath = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--expected-revision" && next) {
       expectedRevision = next.trim() || undefined;
       index += 1;
@@ -146,6 +257,16 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--manual-checks" && next) {
+      manualChecksPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--manual-check" && next) {
+      manualChecks.push(next);
+      index += 1;
+      continue;
+    }
     if (arg === "--require-smoke-report") {
       requireSmokeReport = true;
       continue;
@@ -159,10 +280,14 @@ function parseArgs(argv: string[]): Args {
     ...(archivePath ? { archivePath } : {}),
     ...(metadataPath ? { metadataPath } : {}),
     ...(reportPath ? { reportPath } : {}),
+    ...(summaryPath ? { summaryPath } : {}),
+    ...(markdownPath ? { markdownPath } : {}),
     ...(expectedRevision ? { expectedRevision } : {}),
     ...(version ? { version } : {}),
     ...(smokeReportPath ? { smokeReportPath } : {}),
     ...(uploadReceiptPath ? { uploadReceiptPath } : {}),
+    ...(manualChecksPath ? { manualChecksPath } : {}),
+    manualChecks,
     requireSmokeReport
   };
 }
@@ -237,6 +362,16 @@ function defaultReportPath(artifactsDir: string | undefined, metadataPath: strin
   return path.join(path.dirname(metadataPath), "codex.wechat.rc-validation-report.json");
 }
 
+function defaultSummaryPath(artifactsDir: string | undefined, metadataPath: string): string {
+  const baseDir = artifactsDir ?? path.dirname(metadataPath);
+  return path.join(baseDir, "codex.wechat.release-candidate-summary.json");
+}
+
+function defaultMarkdownPath(artifactsDir: string | undefined, metadataPath: string): string {
+  const baseDir = artifactsDir ?? path.dirname(metadataPath);
+  return path.join(baseDir, "codex.wechat.release-candidate-summary.md");
+}
+
 function validatePackageMetadataShape(metadata: WechatMinigameReleasePackageMetadata, archivePath: string): void {
   if (metadata.schemaVersion !== 1) {
     fail(`Release sidecar schemaVersion must be 1, received ${JSON.stringify(metadata.schemaVersion)}.`);
@@ -280,6 +415,219 @@ function resolveOptionalArtifactPath(explicitPath: string | undefined, fallbackP
     return path.resolve(explicitPath);
   }
   return fs.existsSync(fallbackPath) ? fallbackPath : undefined;
+}
+
+function readManualChecks(args: Args): ManualReviewCheck[] {
+  if (!args.manualChecksPath && args.manualChecks.length === 0) {
+    return DEFAULT_MANUAL_CHECKS.map((check) => ({ ...check, evidence: [...check.evidence] }));
+  }
+
+  const fromFile = args.manualChecksPath
+    ? parseManualChecksFile(args.manualChecksPath).map((check) => ({
+        id: check.id,
+        title: check.title,
+        required: check.required,
+        status: check.status,
+        notes: check.notes,
+        evidence: [...check.evidence],
+        source: "file" as const
+      }))
+    : [];
+  const fromCli = args.manualChecks.map((value) => {
+    const check = parseManualCheckArg(value);
+    return {
+      id: check.id,
+      title: check.title,
+      required: check.required,
+      status: check.status,
+      notes: check.notes,
+      evidence: [...check.evidence],
+      source: "cli" as const
+    };
+  });
+
+  const checks = [...fromFile, ...fromCli];
+  const seen = new Set<string>();
+  for (const check of checks) {
+    if (seen.has(check.id)) {
+      fail(`Duplicate manual review check id detected: ${check.id}`);
+    }
+    seen.add(check.id);
+  }
+  return checks;
+}
+
+function requireCheck(checks: ValidationCheck[], id: string): ValidationCheck {
+  const match = checks.find((check) => check.id === id);
+  if (!match) {
+    fail(`Missing validation check: ${id}`);
+  }
+  return match;
+}
+
+function buildCandidateSummary(
+  checks: ValidationCheck[],
+  manualChecks: ManualReviewCheck[],
+  metadata: WechatMinigameReleasePackageMetadata,
+  artifacts: { artifactsDir?: string; archivePath: string; metadataPath: string },
+  reportPath: string,
+  summaryPath: string,
+  markdownPath: string,
+  commit: string | null,
+  version: string | null
+): CandidateSummary {
+  const packageCheck = requireCheck(checks, "package-sidecar");
+  const verifyCheck = requireCheck(checks, "artifact-verify");
+  const smokeCheck = requireCheck(checks, "smoke-report");
+  const uploadCheck = requireCheck(checks, "upload-receipt");
+  const blockers: CandidateSummary["blockers"] = [];
+
+  for (const check of checks) {
+    if (check.status === "failed") {
+      blockers.push({
+        id: check.id,
+        summary: check.summary,
+        ...(check.artifactPath ? { artifactPath: check.artifactPath } : {}),
+        ...(check.command ? { nextCommand: check.command } : {})
+      });
+    }
+  }
+  if (smokeCheck.status === "skipped") {
+    blockers.push({
+      id: "smoke-report-missing",
+      summary: "Candidate summary is blocked until codex.wechat.smoke-report.json is generated and validated for the same revision.",
+      artifactPath: smokeCheck.artifactPath,
+      nextCommand: "npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]"
+    });
+  }
+
+  for (const check of manualChecks) {
+    if (!check.required || check.status === "passed" || check.status === "not_applicable") {
+      continue;
+    }
+    blockers.push({
+      id: `manual:${check.id}`,
+      summary:
+        check.status === "failed"
+          ? `Manual review failed: ${check.title}. ${check.notes}`.trim()
+          : `Manual review pending: ${check.title}. ${check.notes}`.trim()
+    });
+  }
+
+  const requiredPendingChecks = manualChecks.filter((check) => check.required && check.status === "pending").length;
+  const requiredFailedChecks = manualChecks.filter((check) => check.required && check.status === "failed").length;
+  const completedChecks = manualChecks.filter((check) => check.status === "passed" || check.status === "not_applicable").length;
+  const status: CandidateStatus = blockers.length === 0 ? "ready" : "blocked";
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    candidate: {
+      revision: commit,
+      version,
+      projectName: metadata.projectName,
+      appId: metadata.appId,
+      status
+    },
+    artifacts: {
+      ...(artifacts.artifactsDir ? { artifactsDir: artifacts.artifactsDir } : {}),
+      archivePath: artifacts.archivePath,
+      metadataPath: artifacts.metadataPath,
+      validationReportPath: reportPath,
+      summaryPath,
+      smokeReportPath:
+        smokeCheck.artifactPath ??
+        path.join(artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath), "codex.wechat.smoke-report.json"),
+      uploadReceiptPath:
+        uploadCheck.artifactPath ??
+        path.join(
+          artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath),
+          `${path.basename(artifacts.metadataPath, ".package.json")}.upload.json`
+        ),
+      markdownPath
+    },
+    evidence: {
+      package: {
+        status: packageCheck.status,
+        summary: packageCheck.summary,
+        artifactPath: packageCheck.artifactPath ?? artifacts.metadataPath
+      },
+      validation: {
+        status: verifyCheck.status,
+        summary: verifyCheck.summary,
+        artifactPath: reportPath
+      },
+      smoke: {
+        status: smokeCheck.status,
+        summary: smokeCheck.summary,
+        artifactPath:
+          smokeCheck.artifactPath ??
+          path.join(artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath), "codex.wechat.smoke-report.json")
+      },
+      upload: {
+        status: uploadCheck.status,
+        summary: uploadCheck.summary,
+        artifactPath:
+          uploadCheck.artifactPath ??
+          path.join(
+            artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath),
+            `${path.basename(artifacts.metadataPath, ".package.json")}.upload.json`
+          )
+      },
+      manualReview: {
+        status: requiredPendingChecks === 0 && requiredFailedChecks === 0 ? "ready" : "blocked",
+        totalChecks: manualChecks.length,
+        completedChecks,
+        requiredPendingChecks,
+        requiredFailedChecks,
+        checks: manualChecks
+      }
+    },
+    blockers
+  };
+}
+
+function renderCandidateMarkdown(summary: CandidateSummary): string {
+  const lines: string[] = [];
+  lines.push("# WeChat Release Candidate Summary", "");
+  lines.push(`- Candidate status: \`${summary.candidate.status}\``);
+  lines.push(`- Revision: \`${summary.candidate.revision ?? "unknown"}\``);
+  lines.push(`- Version: \`${summary.candidate.version ?? "unknown"}\``);
+  lines.push(`- Project: \`${summary.candidate.projectName}\``);
+  lines.push(`- App ID: \`${summary.candidate.appId}\``, "");
+  lines.push("## Evidence", "");
+  lines.push(
+    `- Package metadata: \`${summary.evidence.package.status}\` (${summary.evidence.package.summary}) -> \`${path.relative(process.cwd(), summary.evidence.package.artifactPath).replace(/\\\\/g, "/")}\``
+  );
+  lines.push(
+    `- Artifact validation: \`${summary.evidence.validation.status}\` (${summary.evidence.validation.summary}) -> \`${path.relative(process.cwd(), summary.artifacts.validationReportPath).replace(/\\\\/g, "/")}\``
+  );
+  lines.push(
+    `- Smoke evidence: \`${summary.evidence.smoke.status}\` (${summary.evidence.smoke.summary}) -> \`${path.relative(process.cwd(), summary.evidence.smoke.artifactPath).replace(/\\\\/g, "/")}\``
+  );
+  lines.push(
+    `- Upload receipt: \`${summary.evidence.upload.status}\` (${summary.evidence.upload.summary}) -> \`${path.relative(process.cwd(), summary.evidence.upload.artifactPath).replace(/\\\\/g, "/")}\``,
+    ""
+  );
+  lines.push("## Manual Review", "");
+  for (const check of summary.evidence.manualReview.checks) {
+    const evidence = check.evidence.length > 0 ? ` Evidence: ${check.evidence.join(", ")}` : "";
+    lines.push(`- \`${check.status}\` ${check.title}${check.notes ? ` - ${check.notes}` : ""}${evidence}`);
+  }
+  lines.push("", "## Blockers", "");
+  if (summary.blockers.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const blocker of summary.blockers) {
+      lines.push(`- ${blocker.id}: ${blocker.summary}`);
+    }
+  }
+  lines.push(
+    "",
+    `Validation report: \`${path.relative(process.cwd(), summary.artifacts.validationReportPath).replace(/\\/g, "/")}\``,
+    `Summary JSON: \`${path.relative(process.cwd(), summary.artifacts.summaryPath).replace(/\\/g, "/")}\``
+  );
+  return `${lines.join("\n")}\n`;
 }
 
 function runCommandCheck(
@@ -423,6 +771,9 @@ function main(): void {
     )
   );
   const reportPath = path.resolve(args.reportPath ?? defaultReportPath(artifacts.artifactsDir, artifacts.metadataPath));
+  const summaryPath = path.resolve(args.summaryPath ?? defaultSummaryPath(artifacts.artifactsDir, artifacts.metadataPath));
+  const markdownPath = path.resolve(args.markdownPath ?? defaultMarkdownPath(artifacts.artifactsDir, artifacts.metadataPath));
+  const manualChecks = readManualChecks(args);
   const commit = metadata.sourceRevision ?? args.expectedRevision ?? null;
   let version = args.version ?? null;
   let exitCode = 0;
@@ -591,11 +942,27 @@ function main(): void {
   };
 
   writeJsonFile(reportPath, report);
+  const candidateSummary = buildCandidateSummary(
+    checks,
+    manualChecks,
+    metadata,
+    artifacts,
+    reportPath,
+    summaryPath,
+    markdownPath,
+    commit,
+    version
+  );
+  writeJsonFile(summaryPath, candidateSummary);
+  fs.writeFileSync(markdownPath, renderCandidateMarkdown(candidateSummary), "utf8");
   console.log(`Wrote release candidate validation report: ${path.relative(process.cwd(), reportPath).replace(/\\/g, "/")}`);
+  console.log(`Wrote release candidate summary: ${path.relative(process.cwd(), summaryPath).replace(/\\/g, "/")}`);
+  console.log(`Wrote release candidate markdown: ${path.relative(process.cwd(), markdownPath).replace(/\\/g, "/")}`);
   console.log(`Artifact: ${path.relative(process.cwd(), artifacts.archivePath).replace(/\\/g, "/")}`);
   console.log(`Commit: ${commit ?? "unknown"}`);
   console.log(`Version: ${version ?? "unknown"}`);
   console.log(`Result: ${report.summary.status}`);
+  console.log(`Candidate status: ${candidateSummary.candidate.status}`);
 
   if (failedChecks.length > 0) {
     console.error("Failures:");


### PR DESCRIPTION
closes #508

## Summary
- add a candidate-level WeChat release summary artifact and Markdown companion to `validate:wechat-rc`
- make missing smoke evidence and required manual review checks explicit blockers in one revision-scoped contract
- document the new review flow and add a dedicated manual-review example file

## Test
- node --import tsx --test ./scripts/test/wechat-release-artifacts.test.ts
- npm run check:wechat-build