### PR TITLE
feat(cocos): close equipment, inventory, and loot loop in primary client

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -2949,9 +2949,13 @@ export class VeilRoot extends Component {
       return;
     }
 
+    if (this.sessionSource !== "remote") {
+      return;
+    }
+
     this.gameplayAccountRefreshInFlight = true;
     try {
-      const profile = await loadCocosPlayerAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
+      const profile = await resolveVeilRootRuntime().loadAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
         storage: this.readWebStorage(),
         authSession: this.authToken
           ? {

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -224,6 +224,99 @@ test("VeilRoot wires the equipment loot loop through equip and unequip session u
   ]);
 });
 
+test("VeilRoot gameplay account refresh uses the injected loader for remote equipment and loot updates", async () => {
+  const storage = createMemoryStorage();
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+
+  const root = createVeilRootHarness();
+  root.remoteUrl = "http://127.0.0.1:2567";
+  root.roomId = "room-equipment";
+  root.playerId = "player-1";
+  root.displayName = "暮潮守望";
+  root.authMode = "account";
+  root.authToken = "account.token";
+  root.loginId = "veil-ranger";
+  root.sessionSource = "remote";
+
+  const calls: Array<{
+    remoteUrl: string;
+    playerId: string;
+    roomId: string;
+    authSession: { token: string; playerId: string; displayName: string; authMode: string; loginId?: string; source: string } | null;
+  }> = [];
+  installVeilRootRuntime({
+    loadAccountProfile: async (remoteUrl, playerId, roomId, options) => {
+      calls.push({
+        remoteUrl,
+        playerId,
+        roomId,
+        authSession: options?.authSession ?? null
+      });
+      return {
+        ...root.lobbyAccountProfile,
+        playerId,
+        roomId,
+        displayName: "暮潮守望",
+        source: "remote",
+        authMode: "account",
+        loginId: "veil-ranger",
+        recentEventLog: [
+          {
+            id: "loot-1",
+            timestamp: "2026-04-01T12:00:00.000Z",
+            roomId,
+            playerId,
+            category: "combat",
+            description: "暮潮守望在战斗后获得了稀有装备 先锋战刃。",
+            heroId: "hero-1",
+            worldEventType: "hero.equipmentFound",
+            rewards: []
+          }
+        ]
+      };
+    }
+  });
+
+  await root.refreshGameplayAccountProfile();
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], {
+    remoteUrl: "http://127.0.0.1:2567",
+    playerId: "player-1",
+    roomId: "room-equipment",
+    authSession: {
+      token: "account.token",
+      playerId: "player-1",
+      displayName: "暮潮守望",
+      authMode: "account",
+      loginId: "veil-ranger",
+      source: "remote"
+    }
+  });
+  assert.equal(root.lobbyAccountProfile.recentEventLog[0]?.worldEventType, "hero.equipmentFound");
+  assert.match(String(root.lobbyAccountProfile.recentEventLog[0]?.description), /先锋战刃/);
+});
+
+test("VeilRoot gameplay account refresh skips remote profile loads for local sessions", async () => {
+  const root = createVeilRootHarness();
+  root.roomId = "room-local";
+  root.playerId = "player-local";
+  root.displayName = "本地旅人";
+  root.sessionSource = "local";
+
+  let calls = 0;
+  installVeilRootRuntime({
+    loadAccountProfile: async () => {
+      calls += 1;
+      return root.lobbyAccountProfile;
+    }
+  });
+
+  await root.refreshGameplayAccountProfile();
+
+  assert.equal(calls, 0);
+});
+
 test("VeilRoot account lifecycle flow switches panels and surfaces validation feedback", async () => {
   const root = createVeilRootHarness();
 

--- a/docs/cocos-equipment-loot-validation.md
+++ b/docs/cocos-equipment-loot-validation.md
@@ -8,7 +8,7 @@
 - Cocos session layer: `apps/cocos-client/assets/scripts/VeilCocosSession.ts` already sends `hero.equip` / `hero.unequip` requests and caches the returned `SessionUpdate`.
 - Cocos prediction/HUD layer: `apps/cocos-client/assets/scripts/cocos-prediction.ts`, `apps/cocos-client/assets/scripts/cocos-hero-equipment.ts`, and `apps/cocos-client/assets/scripts/VeilHudPanel.ts` present hero loadout state, grouped inventory choices, recent loot, and visible stat changes inside the primary runtime.
 
-## Implemented Slice For #206
+## Implemented Slice For #503
 
 - HUD `装备配置` card now shows:
   - current slot occupancy for weapon / armor / accessory
@@ -17,6 +17,7 @@
   - carried inventory grouped by item type with rarity and bonus metadata
   - recent loot lines from the Cocos-visible account event log
 - Existing equip/unequip buttons remain the interaction surface and continue to drive prediction plus server reconciliation.
+- Remote gameplay refresh now stays on the injectable/root runtime loader and is skipped for local/manual sessions, so recent loot/event HUD data follows authoritative account updates without forcing unintended remote fetches.
 - No unrelated gameplay systems were changed; this is a presentation-first slice on top of the existing authoritative flow.
 
 ## Local Verification


### PR DESCRIPTION
## Summary
- keep gameplay account refresh on the injected VeilRoot runtime loader so equipment/loot HUD data follows authoritative account updates
- skip gameplay account profile fetches for local/manual sessions to avoid unintended remote calls outside the primary remote client flow
- add root-level regression coverage for remote loot refresh and local-session no-fetch behavior

## Testing
- `node --import tsx --test apps/cocos-client/test/cocos-root-orchestration.test.ts --test-name-pattern "gameplay account refresh"`
- `node --import tsx --test apps/cocos-client/test/cocos-hero-equipment.test.ts apps/cocos-client/test/cocos-hud-panel.test.ts apps/cocos-client/test/cocos-primary-client-journey.test.ts`

closes #503