### PR TITLE
feat(cocos): add inventory capacity safeguards

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -398,6 +398,7 @@ export type WorldEvent =
       equipmentId: string;
       equipmentName: string;
       rarity: EquipmentRarity;
+      overflowed?: boolean;
     }
   | {
       type: "battle.started";

--- a/apps/cocos-client/assets/scripts/cocos-battle-transition-copy.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-transition-copy.ts
@@ -155,7 +155,9 @@ function buildBattleExitDetailChips(events: WorldEvent[]): BattleTransitionChip[
   const equipmentChip = featuredEquipment
     ? {
         icon: "battle" as const,
-        label: `${formatEquipmentRarityLabel(featuredEquipment.rarity)} ${trimChipLabel(featuredEquipment.equipmentName, 10)}`
+        label: featuredEquipment.overflowed
+          ? `未拾取 ${trimChipLabel(featuredEquipment.equipmentName, 8)}`
+          : `${formatEquipmentRarityLabel(featuredEquipment.rarity)} ${trimChipLabel(featuredEquipment.equipmentName, 10)}`
       }
     : null;
   const progressionChip = progressionSummary

--- a/apps/cocos-client/assets/scripts/cocos-hero-equipment.ts
+++ b/apps/cocos-client/assets/scripts/cocos-hero-equipment.ts
@@ -3,6 +3,7 @@ import {
   createHeroEquipmentLoadoutView,
   formatEquipmentBonusSummary,
   formatEquipmentRarityLabel,
+  HERO_EQUIPMENT_INVENTORY_CAPACITY,
   type EventLogEntry,
   getEquipmentDefinition,
   type EquipmentType,
@@ -60,6 +61,10 @@ function toHeroState(hero: HeroView): HeroState {
 }
 
 export function formatEquipmentActionReason(reason: string): string {
+  if (reason === "equipment_inventory_full") {
+    return "背包已满，请先腾出空位";
+  }
+
   if (reason === "equipment_not_in_inventory") {
     return "背包里没有这件装备";
   }
@@ -145,17 +150,27 @@ export function formatInventorySummaryLines(hero: HeroView | null): string[] {
   }
 
   const items = inventoryItemsForHero(hero);
+  const totalCount = hero.loadout.inventory.length;
   if (items.length === 0) {
-    return ["背包 暂无可装备物品"];
+    return totalCount >= HERO_EQUIPMENT_INVENTORY_CAPACITY
+      ? [
+          `背包 ${totalCount}/${HERO_EQUIPMENT_INVENTORY_CAPACITY} 件`,
+          "背包已满，新的战利品会溢出",
+          "暂无可装备物品"
+        ]
+      : ["背包 暂无可装备物品"];
   }
 
-  const totalCount = items.reduce((sum, item) => sum + item.count, 0);
   const detailLines = items.map((item) => {
     const countLabel = item.count > 1 ? ` x${item.count}` : "";
     return `${formatEquipmentSlotLabel(item.slot)} ${item.rarityLabel} ${item.name}${countLabel} · ${item.bonusSummary}`;
   });
 
-  return [`背包 ${totalCount} 件（${items.length} 类）`, ...detailLines];
+  return [
+    `背包 ${totalCount}/${HERO_EQUIPMENT_INVENTORY_CAPACITY} 件（${items.length} 类）`,
+    ...(totalCount >= HERO_EQUIPMENT_INVENTORY_CAPACITY ? ["背包已满，新的战利品会溢出"] : []),
+    ...detailLines
+  ];
 }
 
 export function formatEquipmentStatSummary(hero: HeroView | null): CocosEquipmentStatSummaryLine[] {

--- a/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
+++ b/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
@@ -215,7 +215,9 @@ function formatWorldEvent(event: WorldEvent): string | null {
   }
 
   if (event.type === "hero.equipmentFound") {
-    return `战斗缴获 ${event.equipmentName}。`;
+    return event.overflowed
+      ? `战斗发现 ${event.equipmentName}，但背包已满，未能拾取。`
+      : `战斗缴获 ${event.equipmentName}。`;
   }
 
   if (event.type === "resource.produced" && isObjectRecord(event.resource)) {

--- a/apps/cocos-client/assets/scripts/project-shared/equipment.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/equipment.ts
@@ -1,6 +1,7 @@
 import {
   createDefaultEquipmentStatBonuses,
   type EquipmentCatalogConfig,
+  type EquipmentId,
   type EquipmentDefinition,
   type EquipmentRarity,
   type EquipmentStatBonuses,
@@ -8,6 +9,8 @@ import {
   type HeroState,
   type ValidationResult
 } from "./models.ts";
+
+export const HERO_EQUIPMENT_INVENTORY_CAPACITY = 6;
 
 const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
   entries: [
@@ -383,6 +386,27 @@ export function rollEquipmentDrop(
   };
 }
 
+export function isHeroEquipmentInventoryFull(inventory: EquipmentId[]): boolean {
+  return inventory.length >= HERO_EQUIPMENT_INVENTORY_CAPACITY;
+}
+
+export function tryAddEquipmentToInventory(
+  inventory: EquipmentId[],
+  equipmentId: EquipmentId
+): { inventory: EquipmentId[]; stored: boolean } {
+  if (isHeroEquipmentInventoryFull(inventory)) {
+    return {
+      inventory: [...inventory],
+      stored: false
+    };
+  }
+
+  return {
+    inventory: [...inventory, equipmentId],
+    stored: true
+  };
+}
+
 export function validateHeroEquipmentChange(
   hero: Pick<HeroState, "loadout">,
   slot: EquipmentType,
@@ -393,7 +417,15 @@ export function validateHeroEquipmentChange(
   const normalizedEquipmentId = equipmentId?.trim();
 
   if (!normalizedEquipmentId) {
-    return currentItemId ? { valid: true } : { valid: false, reason: "equipment_slot_empty" };
+    if (!currentItemId) {
+      return { valid: false, reason: "equipment_slot_empty" };
+    }
+
+    if (isHeroEquipmentInventoryFull(hero.loadout.inventory)) {
+      return { valid: false, reason: "equipment_inventory_full" };
+    }
+
+    return { valid: true };
   }
 
   const definition = resolveEquipmentDefinition(normalizedEquipmentId);

--- a/apps/cocos-client/assets/scripts/project-shared/event-log.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/event-log.ts
@@ -392,7 +392,9 @@ export function createWorldEventLogEntry(
         roomId: state.meta.roomId,
         playerId,
         category: "combat",
-        description: `${hero?.name ?? event.heroId} 在战斗后获得了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}。`,
+        description: event.overflowed
+          ? `${hero?.name ?? event.heroId} 在战斗后发现了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}，但背包已满，未能拾取。`
+          : `${hero?.name ?? event.heroId} 在战斗后获得了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}。`,
         heroId: event.heroId,
         worldEventType: event.type,
         rewards: []

--- a/apps/cocos-client/assets/scripts/project-shared/map.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map.ts
@@ -30,7 +30,12 @@ import type {
 } from "./models.ts";
 import { validateAction } from "./action-precheck.ts";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills.ts";
-import { applyHeroEquipmentChange, rollEquipmentDrop, validateHeroEquipmentChange } from "./equipment.ts";
+import {
+  applyHeroEquipmentChange,
+  rollEquipmentDrop,
+  tryAddEquipmentToInventory,
+  validateHeroEquipmentChange
+} from "./equipment.ts";
 import {
   normalizeHeroState,
   totalExperienceRequiredForLevel
@@ -93,12 +98,14 @@ function maybeAwardBattleEquipmentDrop(
     return null;
   }
 
+  const inventoryUpdate = tryAddEquipmentToInventory(hero.loadout.inventory, drop.itemId);
+
   return {
     hero: {
       ...hero,
       loadout: {
         ...hero.loadout,
-        inventory: [...hero.loadout.inventory, drop.itemId]
+        inventory: inventoryUpdate.inventory
       }
     },
     event: {
@@ -108,7 +115,8 @@ function maybeAwardBattleEquipmentDrop(
       battleKind,
       equipmentId: drop.itemId,
       equipmentName: drop.item.name,
-      rarity: drop.item.rarity
+      rarity: drop.item.rarity,
+      ...(inventoryUpdate.stored ? {} : { overflowed: true })
     }
   };
 }

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -685,6 +685,7 @@ export type WorldEvent =
       equipmentId: EquipmentId;
       equipmentName: string;
       rarity: EquipmentRarity;
+      overflowed?: boolean;
     }
   | {
       type: "battle.started";

--- a/apps/cocos-client/test/cocos-battle-transition-copy.test.ts
+++ b/apps/cocos-client/test/cocos-battle-transition-copy.test.ts
@@ -286,3 +286,43 @@ test("buildBattleExitCopy prioritizes level and equipment chips when rewards ove
     ]
   });
 });
+
+test("buildBattleExitCopy marks overflowed equipment so failed pickups stay visible", () => {
+  const update = createBattleEnterUpdate(
+    {
+      type: "battle.started",
+      heroId: "hero-1",
+      encounterKind: "neutral",
+      neutralArmyId: "neutral-9",
+      initiator: "hero",
+      battleId: "battle-3",
+      path: [{ x: 4, y: 3 }, { x: 5, y: 3 }],
+      moveCost: 1
+    },
+    "sand",
+    { x: 5, y: 3 }
+  );
+  update.events = [
+    {
+      type: "hero.equipmentFound",
+      heroId: "hero-1",
+      battleId: "battle-3",
+      battleKind: "neutral",
+      equipmentId: "ember-crown",
+      equipmentName: "余烬王冠",
+      rarity: "epic",
+      overflowed: true
+    }
+  ];
+
+  assert.deepEqual(buildBattleExitCopy(update.battle, update, true), {
+    badge: "VICTORY",
+    title: "战斗胜利",
+    subtitle: "沙原战场 · 坐标 (5,3) · 返回世界地图，继续推进前线",
+    tone: "victory",
+    terrain: "sand",
+    detailChips: [
+      { icon: "battle", label: "未拾取 余烬王冠" }
+    ]
+  });
+});

--- a/apps/cocos-client/test/cocos-hero-equipment.test.ts
+++ b/apps/cocos-client/test/cocos-hero-equipment.test.ts
@@ -120,6 +120,7 @@ test("buildHeroEquipmentActionRows exposes equipped items and remaining inventor
 });
 
 test("formatEquipmentActionReason keeps user-facing copy stable", () => {
+  assert.equal(formatEquipmentActionReason("equipment_inventory_full"), "背包已满，请先腾出空位");
   assert.equal(formatEquipmentActionReason("equipment_slot_empty"), "当前槽位没有可卸下的装备");
   assert.equal(formatEquipmentActionReason("equipment_not_in_inventory"), "背包里没有这件装备");
   assert.equal(formatEquipmentActionReason("unknown_reason"), "unknown_reason");
@@ -139,10 +140,43 @@ test("formatInventorySummaryLines exposes the current backpack as grouped readab
       })
     ),
     [
-      "背包 4 件（3 类）",
+      "背包 4/6 件（3 类）",
       "武器 普通 民兵长枪 x2 · 攻击 +6%",
       "护甲 普通 厚绗布甲 · 防御 +6% / 生命上限 +2",
       "饰品 普通 斥候罗盘 · 攻击 +3% / 知识 +1"
+    ]
+  );
+});
+
+test("formatInventorySummaryLines warns when the backpack has reached capacity", () => {
+  assert.deepEqual(
+    formatInventorySummaryLines(
+      createHero({
+        loadout: {
+          learnedSkills: [],
+          equipment: {
+            trinketIds: []
+          },
+          inventory: [
+            "militia_pike",
+            "oak_longbow",
+            "padded_gambeson",
+            "tower_shield_mail",
+            "scout_compass",
+            "sun_medallion"
+          ]
+        }
+      })
+    ),
+    [
+      "背包 6/6 件（6 类）",
+      "背包已满，新的战利品会溢出",
+      "武器 普通 民兵长枪 · 攻击 +6%",
+      "武器 普通 橡木长弓 · 攻击 +4% / 知识 +1",
+      "护甲 普通 厚绗布甲 · 防御 +6% / 生命上限 +2",
+      "护甲 普通 塔盾链甲 · 防御 +8%",
+      "饰品 普通 斥候罗盘 · 攻击 +3% / 知识 +1",
+      "饰品 史诗 曜日勋章 · 攻击 +8% / 防御 +8% / 力量 +1"
     ]
   );
 });
@@ -208,6 +242,17 @@ test("formatRecentLootLines keeps the latest hero loot entries visible in Cocos 
       rewards: []
     },
     {
+      id: "loot-3",
+      timestamp: "2026-03-28T08:30:00.000Z",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      category: "combat",
+      description: "凯琳在战斗后发现了史诗装备 守誓圣铠，但背包已满，未能拾取。",
+      heroId: "hero-1",
+      worldEventType: "hero.equipmentFound",
+      rewards: []
+    },
+    {
       id: "other-1",
       timestamp: "2026-03-28T08:00:00.000Z",
       roomId: "room-alpha",
@@ -221,7 +266,7 @@ test("formatRecentLootLines keeps the latest hero loot entries visible in Cocos 
   ];
 
   assert.deepEqual(formatRecentLootLines(entries, "hero-1"), [
-    "战利品 最近 2 条",
+    "战利品 最近 3 条",
     "凯琳在战斗后获得了普通装备 塔盾链甲。",
     "凯琳在战斗后获得了稀有装备 斥候罗盘。"
   ]);

--- a/apps/cocos-client/test/cocos-ui-formatters.test.ts
+++ b/apps/cocos-client/test/cocos-ui-formatters.test.ts
@@ -117,7 +117,8 @@ test("buildTimelineEntriesFromUpdate formats world events and system rejection",
         battleKind: "neutral",
         equipmentId: "tower_shield_mail",
         equipmentName: "塔盾链甲",
-        rarity: "common"
+        rarity: "common",
+        overflowed: true
       }
     ],
     movementPlan: {
@@ -144,7 +145,7 @@ test("buildTimelineEntriesFromUpdate formats world events and system rejection",
     "事件：中立守军 neutral-1 主动追击，移动到 (2,2)。",
     "事件：中立守军 neutral-1 主动发起战斗。",
     "事件：武器槽位已装备 先锋战刃，卸下 民兵长枪。",
-    "事件：战斗缴获 塔盾链甲。"
+    "事件：战斗发现 塔盾链甲，但背包已满，未能拾取。"
   ]);
 });
 
@@ -248,6 +249,7 @@ test("formatSystemTimelineEntry and pickRecentBattleTimeline keep timeline prese
 test("formatSessionActionReason translates shared rejection reasons into player-facing copy", () => {
   assert.equal(formatSessionActionReason("building_on_cooldown"), "这个建筑今天已经结算过了");
   assert.equal(formatSessionActionReason("not_enough_skill_points"), "技能点不足");
+  assert.equal(formatSessionActionReason("equipment_inventory_full"), "背包已满，请先腾出空位");
   assert.equal(formatSessionActionReason("equipment_not_in_inventory"), "背包里没有这件装备");
   assert.equal(formatSessionActionReason("friendly_fire_blocked"), "不能攻击友军");
   assert.equal(formatSessionActionReason("skill_on_cooldown"), "这个技能还在冷却中");

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -227,6 +227,36 @@ test("room equips hero items from carried inventory and emits the equipment chan
   ]);
 });
 
+test("room rejects unequip when the backpack is already full", () => {
+  const room = createRoom("room-unequip-full", 1001);
+  const state = room.getInternalState();
+  const hero = state.heroes.find((entry) => entry.id === "hero-1");
+
+  if (!hero) {
+    throw new Error("Expected hero-1 to exist");
+  }
+
+  hero.loadout.equipment.weaponId = "vanguard_blade";
+  hero.loadout.inventory = [
+    "militia_pike",
+    "oak_longbow",
+    "padded_gambeson",
+    "tower_shield_mail",
+    "scout_compass",
+    "sun_medallion"
+  ];
+
+  const result = room.dispatch("player-1", {
+    type: "hero.unequip",
+    heroId: "hero-1",
+    slot: "weapon"
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "equipment_inventory_full");
+  assert.equal(result.snapshot.state.ownHeroes[0]?.loadout.equipment.weaponId, "vanguard_blade");
+});
+
 test("room allows recruiting from a recruitment post when the hero stands on it", () => {
   const room = createRoom("room-recruit", 1001);
   const state = room.getInternalState();

--- a/docs/cocos-equipment-loot-validation.md
+++ b/docs/cocos-equipment-loot-validation.md
@@ -15,8 +15,14 @@
   - per-slot rarity and bonus summary
   - equipment-derived stat gains aggregated from shared logic
   - carried inventory grouped by item type with rarity and bonus metadata
+  - current backpack occupancy against the fixed 6-slot equipment inventory cap
+  - a full-bag warning before the next equipment pickup would overflow
   - recent loot lines from the Cocos-visible account event log
 - Existing equip/unequip buttons remain the interaction surface and continue to drive prediction plus server reconciliation.
+- Equipment loot now respects a fixed 6-slot backpack cap:
+  - battle drops are only added when space remains
+  - when full, the drop is surfaced as overflowed/not picked up instead of being silently appended
+  - unequip is rejected while the backpack is full so equipped items are not pushed past capacity
 - Remote gameplay refresh now stays on the injectable/root runtime loader and is skipped for local/manual sessions, so recent loot/event HUD data follows authoritative account updates without forcing unintended remote fetches.
 - No unrelated gameplay systems were changed; this is a presentation-first slice on top of the existing authoritative flow.
 
@@ -28,9 +34,12 @@
 4. Win a battle that grants equipment.
 5. Confirm the HUD `装备配置` card shows a `战利品` section with the new drop.
 6. Confirm the same card shows the item in the `背包` list with rarity and stat summary.
-7. Click an equipment action button in the same card.
-8. Confirm the hero stat lines in the HUD update immediately after prediction/reconciliation.
-9. Click the matching unequip action and confirm the item returns to inventory and the stat gain line rolls back.
+7. Fill the inventory to 6 items and trigger another equipment drop.
+8. Confirm the HUD and event log clearly state the backpack was full and the overflowed drop was not picked up.
+9. While the backpack is full, try to unequip an item and confirm the action is rejected with a full-inventory message.
+10. Free one slot, then click an equipment action button in the same card.
+11. Confirm the hero stat lines in the HUD update immediately after prediction/reconciliation.
+12. Click the matching unequip action and confirm the item returns to inventory and the stat gain line rolls back.
 
 ## Temporary Assumptions
 

--- a/packages/shared/src/equipment.ts
+++ b/packages/shared/src/equipment.ts
@@ -1,6 +1,7 @@
 import {
   createDefaultEquipmentStatBonuses,
   type EquipmentCatalogConfig,
+  type EquipmentId,
   type EquipmentDefinition,
   type EquipmentRarity,
   type EquipmentStatBonuses,
@@ -8,6 +9,8 @@ import {
   type HeroState,
   type ValidationResult
 } from "./models.ts";
+
+export const HERO_EQUIPMENT_INVENTORY_CAPACITY = 6;
 
 const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
   entries: [
@@ -383,6 +386,27 @@ export function rollEquipmentDrop(
   };
 }
 
+export function isHeroEquipmentInventoryFull(inventory: EquipmentId[]): boolean {
+  return inventory.length >= HERO_EQUIPMENT_INVENTORY_CAPACITY;
+}
+
+export function tryAddEquipmentToInventory(
+  inventory: EquipmentId[],
+  equipmentId: EquipmentId
+): { inventory: EquipmentId[]; stored: boolean } {
+  if (isHeroEquipmentInventoryFull(inventory)) {
+    return {
+      inventory: [...inventory],
+      stored: false
+    };
+  }
+
+  return {
+    inventory: [...inventory, equipmentId],
+    stored: true
+  };
+}
+
 export function validateHeroEquipmentChange(
   hero: Pick<HeroState, "loadout">,
   slot: EquipmentType,
@@ -393,7 +417,15 @@ export function validateHeroEquipmentChange(
   const normalizedEquipmentId = equipmentId?.trim();
 
   if (!normalizedEquipmentId) {
-    return currentItemId ? { valid: true } : { valid: false, reason: "equipment_slot_empty" };
+    if (!currentItemId) {
+      return { valid: false, reason: "equipment_slot_empty" };
+    }
+
+    if (isHeroEquipmentInventoryFull(hero.loadout.inventory)) {
+      return { valid: false, reason: "equipment_inventory_full" };
+    }
+
+    return { valid: true };
   }
 
   const definition = resolveEquipmentDefinition(normalizedEquipmentId);

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -392,7 +392,9 @@ export function createWorldEventLogEntry(
         roomId: state.meta.roomId,
         playerId,
         category: "combat",
-        description: `${hero?.name ?? event.heroId} 在战斗后获得了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}。`,
+        description: event.overflowed
+          ? `${hero?.name ?? event.heroId} 在战斗后发现了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}，但背包已满，未能拾取。`
+          : `${hero?.name ?? event.heroId} 在战斗后获得了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}。`,
         heroId: event.heroId,
         worldEventType: event.type,
         rewards: []

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -30,7 +30,12 @@ import type {
 } from "./models.ts";
 import { validateAction } from "./action-precheck.ts";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills.ts";
-import { applyHeroEquipmentChange, rollEquipmentDrop, validateHeroEquipmentChange } from "./equipment.ts";
+import {
+  applyHeroEquipmentChange,
+  rollEquipmentDrop,
+  tryAddEquipmentToInventory,
+  validateHeroEquipmentChange
+} from "./equipment.ts";
 import {
   normalizeHeroState,
   totalExperienceRequiredForLevel
@@ -93,12 +98,14 @@ function maybeAwardBattleEquipmentDrop(
     return null;
   }
 
+  const inventoryUpdate = tryAddEquipmentToInventory(hero.loadout.inventory, drop.itemId);
+
   return {
     hero: {
       ...hero,
       loadout: {
         ...hero.loadout,
-        inventory: [...hero.loadout.inventory, drop.itemId]
+        inventory: inventoryUpdate.inventory
       }
     },
     event: {
@@ -108,7 +115,8 @@ function maybeAwardBattleEquipmentDrop(
       battleKind,
       equipmentId: drop.itemId,
       equipmentName: drop.item.name,
-      rarity: drop.item.rarity
+      rarity: drop.item.rarity,
+      ...(inventoryUpdate.stored ? {} : { overflowed: true })
     }
   };
 }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -688,6 +688,7 @@ export type WorldEvent =
       equipmentId: EquipmentId;
       equipmentName: string;
       rarity: EquipmentRarity;
+      overflowed?: boolean;
     }
   | {
       type: "battle.started";

--- a/packages/shared/test/event-log-foundation.test.ts
+++ b/packages/shared/test/event-log-foundation.test.ts
@@ -128,6 +128,29 @@ test("shared event log factory builds world event entries with shared descriptio
   assert.match(loot?.description ?? "", /史诗装备 守誓圣铠/);
 });
 
+test("shared event log factory keeps overflowed equipment pickups explicit", () => {
+  const state = createEventTrackingWorldState();
+  const overflowedLoot = createWorldEventLogEntry(
+    state,
+    "player-1",
+    {
+      type: "hero.equipmentFound",
+      heroId: "hero-1",
+      battleId: "battle-1",
+      battleKind: "neutral",
+      equipmentId: "warden_aegis",
+      equipmentName: "守誓圣铠",
+      rarity: "epic",
+      overflowed: true
+    },
+    "2026-03-27T10:01:00.000Z",
+    3
+  );
+
+  assert.match(overflowedLoot?.description ?? "", /背包已满/);
+  assert.match(overflowedLoot?.description ?? "", /未能拾取/);
+});
+
 test("shared event log factory builds achievement progress and unlock entries", () => {
   const achievement: PlayerAchievementProgress = {
     id: "skill_scholar",

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -54,6 +54,7 @@ import {
   getDefaultEquipmentCatalog,
   getLatestProgressedAchievement,
   getLatestUnlockedAchievement,
+  HERO_EQUIPMENT_INVENTORY_CAPACITY,
   hasFullyExploredMap,
   normalizeAchievementProgressQuery,
   normalizeEventLogQuery,
@@ -1988,6 +1989,98 @@ test("equipment drops respect rarity pools and battle victories add loot to hero
       rarity: "common"
     }
   ]);
+});
+
+test("equipment drops overflow cleanly when the backpack is already full", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳"
+  });
+  hero.loadout.inventory = [
+    "militia_pike",
+    "oak_longbow",
+    "padded_gambeson",
+    "tower_shield_mail",
+    "scout_compass",
+    "sun_medallion"
+  ];
+  assert.equal(hero.loadout.inventory.length, HERO_EQUIPMENT_INVENTORY_CAPACITY);
+
+  const neutralArmy: NeutralArmyState = {
+    id: "neutral-1",
+    position: { x: 1, y: 0 },
+    reward: { kind: "gold", amount: 100 },
+    stacks: [{ templateId: "wolf_pack", count: 4 }]
+  };
+  const state = createWorldState({
+    heroes: [hero],
+    neutralArmies: { "neutral-1": neutralArmy },
+    resources: {
+      "player-1": {
+        gold: 0,
+        wood: 0,
+        ore: 0
+      }
+    }
+  });
+  state.meta.seed = 3;
+
+  const outcome = applyBattleOutcomeToWorld(state, "battle-neutral-1", "hero-1", {
+    status: "attacker_victory",
+    survivingAttackers: ["hero-1-stack"],
+    survivingDefenders: []
+  });
+
+  assert.deepEqual(outcome.state.heroes[0]?.loadout.inventory, hero.loadout.inventory);
+  assert.deepEqual(outcome.events.slice(-1), [
+    {
+      type: "hero.equipmentFound",
+      heroId: "hero-1",
+      battleId: "battle-neutral-1",
+      battleKind: "neutral",
+      equipmentId: "tower_shield_mail",
+      equipmentName: "塔盾链甲",
+      rarity: "common",
+      overflowed: true
+    }
+  ]);
+});
+
+test("validateWorldAction rejects unequip when the backpack is already full", () => {
+  const hero = createHero({
+    id: "hero-equip-action",
+    playerId: "player-1",
+    name: "凯琳",
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "vanguard_blade",
+        trinketIds: []
+      },
+      inventory: [
+        "militia_pike",
+        "oak_longbow",
+        "padded_gambeson",
+        "tower_shield_mail",
+        "scout_compass",
+        "sun_medallion"
+      ]
+    }
+  });
+  const state = createWorldState({ heroes: [hero] });
+
+  assert.deepEqual(
+    validateWorldAction(state, {
+      type: "hero.unequip",
+      heroId: "hero-equip-action",
+      slot: "weapon"
+    }),
+    {
+      valid: false,
+      reason: "equipment_inventory_full"
+    }
+  );
 });
 
 test("resolveWorldAction starts a battle when a hero reaches a neutral army tile", () => {


### PR DESCRIPTION
closes #513

## Summary
- add a fixed 6-slot equipment inventory capacity for the primary client shared flow
- prevent unequip overflow and mark battle loot as overflowed instead of silently appending when the bag is full
- surface full-inventory pickup feedback in Cocos HUD, timeline, battle transition copy, and docs

## Verification
- node --import tsx --test --test-name-pattern "equipment drops|validateWorldAction rejects unequip|shared event log factory keeps overflowed" ./packages/shared/test/shared-core.test.ts ./packages/shared/test/event-log-foundation.test.ts
- node --import tsx --test ./apps/cocos-client/test/cocos-hero-equipment.test.ts ./apps/cocos-client/test/cocos-ui-formatters.test.ts ./apps/cocos-client/test/cocos-battle-transition-copy.test.ts ./apps/server/test/authoritative-room.test.ts
- npm run typecheck:shared
- npm run typecheck:cocos

## Notes
- `npm run typecheck:server` still reports pre-existing unrelated errors in `apps/server/src/admin-console.ts` and `apps/server/src/dev-server.ts`.