### PR TITLE
feat(telemetry): instrument primary-client progression, inventory, and combat checkpoints

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -111,7 +111,13 @@ import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
 import { cocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
 import { getPixelSpriteLoadStatus, loadPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
 import {
+  appendPrimaryClientTelemetry,
+  buildPrimaryClientTelemetryFromUpdate,
+  createPrimaryClientTelemetryEvent
+} from "./cocos-primary-client-telemetry.ts";
+import {
   describeAccountAuthFailure,
+  type PrimaryClientTelemetryEvent,
   type RuntimeDiagnosticsConnectionStatus,
   validateAccountLifecycleConfirm,
   validateAccountLifecycleRequest,
@@ -272,6 +278,7 @@ export class VeilRoot extends Component {
   private lastRoomUpdateSource: string | null = null;
   private lastRoomUpdateReason: string | null = null;
   private lastRoomUpdateAtMs: number | null = null;
+  private primaryClientTelemetry: PrimaryClientTelemetryEvent[] = [];
   private stopRuntimeMemoryWarnings: (() => void) | null = null;
   private battlePresentation = createCocosBattlePresentationController();
 
@@ -497,6 +504,15 @@ export class VeilRoot extends Component {
     const hero = this.activeHero();
     if (!hero) {
       this.pushLog("当前快照里没有可控制的英雄。");
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(), {
+          category: "inventory",
+          checkpoint: "equipment.equip.rejected",
+          status: "blocked",
+          detail: "Equip request ignored because no controlled hero is present.",
+          reason: "no_controlled_hero"
+        })
+      );
       this.renderView();
       return;
     }
@@ -504,6 +520,15 @@ export class VeilRoot extends Component {
     if (this.lastUpdate?.battle) {
       this.pushLog("战斗中无法调整装备。");
       this.predictionStatus = "战斗中无法调整装备。";
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(hero.id), {
+          category: "inventory",
+          checkpoint: "equipment.equip.rejected",
+          status: "blocked",
+          detail: "Equip request rejected because the client is currently in battle.",
+          reason: "in_battle"
+        })
+      );
       this.renderView();
       return;
     }
@@ -531,6 +556,19 @@ export class VeilRoot extends Component {
         rejectedLabel: "装备调整"
       });
     } catch (error) {
+      const reason = error instanceof Error ? error.message : "equip_failed";
+      const detail = error instanceof Error ? formatEquipmentActionReason(error.message) : "装备失败。";
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(hero.id), {
+          category: "inventory",
+          checkpoint: "equipment.equip.rejected",
+          status: "failure",
+          detail,
+          reason,
+          slot,
+          ...(equipmentId ? { equipmentId } : {})
+        })
+      );
       this.rollbackPrediction(error instanceof Error ? formatEquipmentActionReason(error.message) : "装备失败。");
     } finally {
       this.moveInFlight = false;
@@ -552,6 +590,15 @@ export class VeilRoot extends Component {
     const hero = this.activeHero();
     if (!hero) {
       this.pushLog("当前快照里没有可控制的英雄。");
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(), {
+          category: "inventory",
+          checkpoint: "equipment.unequip.rejected",
+          status: "blocked",
+          detail: "Unequip request ignored because no controlled hero is present.",
+          reason: "no_controlled_hero"
+        })
+      );
       this.renderView();
       return;
     }
@@ -559,6 +606,15 @@ export class VeilRoot extends Component {
     if (this.lastUpdate?.battle) {
       this.pushLog("战斗中无法调整装备。");
       this.predictionStatus = "战斗中无法调整装备。";
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(hero.id), {
+          category: "inventory",
+          checkpoint: "equipment.unequip.rejected",
+          status: "blocked",
+          detail: "Unequip request rejected because the client is currently in battle.",
+          reason: "in_battle"
+        })
+      );
       this.renderView();
       return;
     }
@@ -591,6 +647,19 @@ export class VeilRoot extends Component {
         rejectedLabel: "卸装"
       });
     } catch (error) {
+      const reason = error instanceof Error ? error.message : "unequip_failed";
+      const detail = error instanceof Error ? formatEquipmentActionReason(error.message) : "卸装失败。";
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(hero.id), {
+          category: "inventory",
+          checkpoint: "equipment.unequip.rejected",
+          status: "failure",
+          detail,
+          reason,
+          slot,
+          ...(currentItemId ? { equipmentId: currentItemId } : {})
+        })
+      );
       this.rollbackPrediction(error instanceof Error ? formatEquipmentActionReason(error.message) : "卸装失败。");
     } finally {
       this.moveInFlight = false;
@@ -966,7 +1035,8 @@ export class VeilRoot extends Component {
         timelineEntries: this.timelineEntries,
         logLines: this.logLines,
         predictionStatus: this.predictionStatus,
-        recoverySummary: this.predictionStatus.includes("回放缓存状态") ? this.predictionStatus : null
+        recoverySummary: this.predictionStatus.includes("回放缓存状态") ? this.predictionStatus : null,
+        primaryClientTelemetry: this.primaryClientTelemetry
       }),
       levelUpNotice: this.levelUpNotice ? { title: this.levelUpNotice.title, detail: this.levelUpNotice.detail } : null,
       achievementNotice: this.achievementNotice
@@ -1134,12 +1204,31 @@ export class VeilRoot extends Component {
         type: "progression.loaded",
         snapshot
       });
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(), {
+          category: "progression",
+          checkpoint: "review.loaded",
+          status: "success",
+          detail: `Progression review loaded with ${snapshot.recentEventLog.length} recent events.`,
+          itemCount: snapshot.recentEventLog.length
+        })
+      );
     } catch (error) {
+      const message = this.describeAccountReviewLoadError(error);
       this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
         type: "section.failed",
         section: "progression",
-        message: this.describeAccountReviewLoadError(error)
+        message
       });
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(), {
+          category: "progression",
+          checkpoint: "review.failed",
+          status: "failure",
+          detail: message,
+          reason: message
+        })
+      );
     }
 
     this.renderView();
@@ -1486,6 +1575,18 @@ export class VeilRoot extends Component {
     this.logLines = this.logLines.slice(0, 8);
   }
 
+  private emitPrimaryClientTelemetry(event: PrimaryClientTelemetryEvent | PrimaryClientTelemetryEvent[] | null): void {
+    this.primaryClientTelemetry = appendPrimaryClientTelemetry(this.primaryClientTelemetry, event);
+  }
+
+  private createTelemetryContext(heroId?: string | null): { roomId: string; playerId: string; heroId?: string } {
+    return {
+      roomId: this.roomId,
+      playerId: this.playerId,
+      ...(heroId ? { heroId } : {})
+    };
+  }
+
   private setBattleFeedback(feedback: CocosBattleFeedbackView | null, durationMs = BATTLE_FEEDBACK_DURATION_MS): void {
     if (!feedback) {
       return;
@@ -1800,6 +1901,7 @@ export class VeilRoot extends Component {
     this.predictionStatus = "正在开启新一局...";
     this.inputDebug = "input waiting";
     this.timelineEntries = [];
+    this.primaryClientTelemetry = [];
     this.logLines = [`正在创建新房间 ${nextRoomId} ...`];
     this.renderView();
 
@@ -2566,6 +2668,7 @@ export class VeilRoot extends Component {
     this.predictionStatus = "";
     this.inputDebug = "input waiting";
     this.timelineEntries = [];
+    this.primaryClientTelemetry = [];
     this.logLines = [logLine];
   }
 
@@ -2878,6 +2981,15 @@ export class VeilRoot extends Component {
             ? "防御"
             : skillName ?? "技能";
     this.pushLog(`战斗指令：${actionLabel}`);
+    this.emitPrimaryClientTelemetry(
+      createPrimaryClientTelemetryEvent(this.createTelemetryContext(this.activeHero()?.id ?? null), {
+        category: "combat",
+        checkpoint: "command.submitted",
+        status: "info",
+        detail: `Battle command submitted: ${actionLabel}.`,
+        ...(this.lastUpdate?.battle?.id ? { battleId: this.lastUpdate.battle.id } : {})
+      })
+    );
     this.setBattleFeedback(actionPresentation.feedback);
     if (actionPresentation.cue) {
       this.audioRuntime.playCue(actionPresentation.cue);
@@ -2898,7 +3010,19 @@ export class VeilRoot extends Component {
         });
       }
     } catch (error) {
-      this.pushLog(error instanceof Error ? error.message : "战斗操作失败。");
+      const reason = error instanceof Error ? error.message : "battle_action_failed";
+      const detail = error instanceof Error ? error.message : "战斗操作失败。";
+      this.pushLog(detail);
+      this.emitPrimaryClientTelemetry(
+        createPrimaryClientTelemetryEvent(this.createTelemetryContext(this.activeHero()?.id ?? null), {
+          category: "combat",
+          checkpoint: "command.rejected",
+          status: "failure",
+          detail,
+          reason,
+          ...(this.lastUpdate?.battle?.id ? { battleId: this.lastUpdate.battle.id } : {})
+        })
+      );
       this.mapBoard?.playHeroAnimation("hit");
     } finally {
       this.battleActionInFlight = false;
@@ -2922,6 +3046,9 @@ export class VeilRoot extends Component {
     if (eventEntries.length > 0) {
       this.timelineEntries = collapseAdjacentEntries([...eventEntries, ...this.timelineEntries]).slice(0, 12);
     }
+    this.emitPrimaryClientTelemetry(
+      buildPrimaryClientTelemetryFromUpdate(update, this.createTelemetryContext(heroId))
+    );
     if (shouldRefreshGameplayAccountProfileForEvents(update.events.map((event) => event.type))) {
       void this.refreshGameplayAccountProfile();
     }

--- a/apps/cocos-client/assets/scripts/cocos-primary-client-telemetry.ts
+++ b/apps/cocos-client/assets/scripts/cocos-primary-client-telemetry.ts
@@ -1,0 +1,171 @@
+import type { PrimaryClientTelemetryEvent, PrimaryClientTelemetryStatus } from "../../../../packages/shared/src/index.ts";
+import type { SessionUpdate, WorldEvent } from "./VeilCocosSession.ts";
+import type { EquipmentType } from "./project-shared/index.ts";
+
+const PRIMARY_CLIENT_TELEMETRY_LIMIT = 12;
+
+interface PrimaryClientTelemetryContext {
+  roomId: string;
+  playerId: string;
+  heroId?: string | null;
+  at?: string;
+}
+
+interface PrimaryClientTelemetryDraft {
+  category: PrimaryClientTelemetryEvent["category"];
+  checkpoint: string;
+  status: PrimaryClientTelemetryStatus;
+  detail: string;
+  battleId?: string;
+  battleKind?: "neutral" | "hero";
+  result?: "attacker_victory" | "defender_victory";
+  reason?: string;
+  slot?: EquipmentType;
+  equipmentId?: string;
+  equipmentName?: string;
+  itemCount?: number;
+  level?: number;
+  experienceGained?: number;
+  levelsGained?: number;
+  skillPointsAwarded?: number;
+}
+
+export function appendPrimaryClientTelemetry(
+  entries: PrimaryClientTelemetryEvent[],
+  next: PrimaryClientTelemetryEvent | PrimaryClientTelemetryEvent[] | null | undefined
+): PrimaryClientTelemetryEvent[] {
+  const incoming = Array.isArray(next) ? next : next ? [next] : [];
+  if (incoming.length === 0) {
+    return entries;
+  }
+
+  return [...incoming.reverse(), ...entries].slice(0, PRIMARY_CLIENT_TELEMETRY_LIMIT);
+}
+
+export function createPrimaryClientTelemetryEvent(
+  context: PrimaryClientTelemetryContext,
+  draft: PrimaryClientTelemetryDraft
+): PrimaryClientTelemetryEvent {
+  return {
+    at: context.at ?? new Date().toISOString(),
+    category: draft.category,
+    checkpoint: draft.checkpoint,
+    status: draft.status,
+    detail: draft.detail,
+    roomId: context.roomId,
+    playerId: context.playerId,
+    ...(context.heroId ? { heroId: context.heroId } : {}),
+    ...(draft.battleId ? { battleId: draft.battleId } : {}),
+    ...(draft.battleKind ? { battleKind: draft.battleKind } : {}),
+    ...(draft.result ? { result: draft.result } : {}),
+    ...(draft.reason ? { reason: draft.reason } : {}),
+    ...(draft.slot ? { slot: draft.slot } : {}),
+    ...(draft.equipmentId ? { equipmentId: draft.equipmentId } : {}),
+    ...(draft.equipmentName ? { equipmentName: draft.equipmentName } : {}),
+    ...(draft.itemCount != null ? { itemCount: draft.itemCount } : {}),
+    ...(draft.level != null ? { level: draft.level } : {}),
+    ...(draft.experienceGained != null ? { experienceGained: draft.experienceGained } : {}),
+    ...(draft.levelsGained != null ? { levelsGained: draft.levelsGained } : {}),
+    ...(draft.skillPointsAwarded != null ? { skillPointsAwarded: draft.skillPointsAwarded } : {})
+  };
+}
+
+export function buildPrimaryClientTelemetryFromUpdate(
+  update: SessionUpdate,
+  context: PrimaryClientTelemetryContext
+): PrimaryClientTelemetryEvent[] {
+  const hero = update.world.ownHeroes[0] ?? null;
+  const nextHeroId = hero?.id ?? context.heroId ?? null;
+  const nextContext: PrimaryClientTelemetryContext = nextHeroId
+    ? {
+        ...context,
+        heroId: nextHeroId
+      }
+    : context;
+  const entries: PrimaryClientTelemetryEvent[] = [];
+
+  for (const event of update.events) {
+    const entry = mapWorldEventToTelemetry(event, nextContext, hero?.loadout.inventory.length ?? undefined);
+    if (entry) {
+      entries.push(entry);
+    }
+  }
+
+  return entries;
+}
+
+function mapWorldEventToTelemetry(
+  event: WorldEvent,
+  context: PrimaryClientTelemetryContext,
+  itemCount?: number
+): PrimaryClientTelemetryEvent | null {
+  switch (event.type) {
+    case "hero.progressed":
+      return createPrimaryClientTelemetryEvent({ ...context, heroId: event.heroId }, {
+        category: "progression",
+        checkpoint: "hero.progressed",
+        status: "success",
+        detail:
+          event.levelsGained > 0
+            ? `Hero reached level ${event.level} with XP +${event.experienceGained}.`
+            : `Hero gained XP +${event.experienceGained}.`,
+        battleId: event.battleId,
+        battleKind: event.battleKind,
+        level: event.level,
+        experienceGained: event.experienceGained,
+        levelsGained: event.levelsGained,
+        skillPointsAwarded: event.skillPointsAwarded
+      });
+    case "hero.equipmentChanged":
+      return createPrimaryClientTelemetryEvent({ ...context, heroId: event.heroId }, {
+        category: "inventory",
+        checkpoint: event.equippedItemId ? "equipment.equipped" : "equipment.unequipped",
+        status: "success",
+        detail: event.equippedItemId
+          ? `Equipment committed on ${event.slot} slot.`
+          : `Equipment removed from ${event.slot} slot.`,
+        slot: event.slot,
+        ...(event.equippedItemId || event.unequippedItemId
+          ? { equipmentId: event.equippedItemId ?? event.unequippedItemId }
+          : {}),
+        ...(itemCount != null ? { itemCount } : {})
+      });
+    case "hero.equipmentFound":
+      return createPrimaryClientTelemetryEvent({ ...context, heroId: event.heroId }, {
+        category: "inventory",
+        checkpoint: event.overflowed ? "loot.overflowed" : "loot.collected",
+        status: event.overflowed ? "blocked" : "success",
+        detail: event.overflowed
+          ? `Loot ${event.equipmentName} could not be stored because inventory is full.`
+          : `Loot ${event.equipmentName} added to inventory.`,
+        battleId: event.battleId,
+        battleKind: event.battleKind,
+        equipmentId: event.equipmentId,
+        equipmentName: event.equipmentName,
+        ...(itemCount != null ? { itemCount } : {})
+      });
+    case "battle.started":
+      return createPrimaryClientTelemetryEvent({ ...context, heroId: event.heroId }, {
+        category: "combat",
+        checkpoint: "encounter.started",
+        status: "info",
+        detail: `Battle ${event.battleId} started against ${event.encounterKind}.`,
+        battleId: event.battleId,
+        battleKind: event.encounterKind
+      });
+    case "battle.resolved":
+      return createPrimaryClientTelemetryEvent({ ...context, heroId: event.heroId }, {
+        category: "combat",
+        checkpoint: "encounter.resolved",
+        status: "success",
+        detail: `Battle ${event.battleId} resolved as ${event.result}.`,
+        battleId: event.battleId,
+        ...("battleKind" in event && (event.battleKind === "neutral" || event.battleKind === "hero")
+          ? { battleKind: event.battleKind }
+          : {}),
+        result: event.result
+      });
+    default:
+      return null;
+  }
+}

--- a/apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts
+++ b/apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts
@@ -1,4 +1,5 @@
 import {
+  type PrimaryClientTelemetryEvent,
   buildRuntimeDiagnosticsTriageView,
   type RuntimeDiagnosticsConnectionStatus,
   type RuntimeDiagnosticsMode,
@@ -30,6 +31,7 @@ export interface CocosRuntimeDiagnosticsSnapshotInput {
   logLines: string[];
   predictionStatus: string;
   recoverySummary: string | null;
+  primaryClientTelemetry: PrimaryClientTelemetryEvent[];
 }
 
 function buildTimelineTail(entries: string[]): CocosTimelineEntrySnapshot[] {
@@ -122,7 +124,8 @@ export function buildCocosRuntimeDiagnosticsSnapshot(
       recoverySummary: input.recoverySummary,
       predictionStatus: input.predictionStatus || null,
       pendingUiTasks: 0,
-      replay: null
+      replay: null,
+      primaryClientTelemetry: input.primaryClientTelemetry.slice(0, 8)
     }
   };
 }

--- a/apps/cocos-client/test/cocos-primary-client-journey.test.ts
+++ b/apps/cocos-client/test/cocos-primary-client-journey.test.ts
@@ -107,7 +107,8 @@ function captureJourneyArtifact(options: {
       recoverySummary:
         typeof root.predictionStatus === "string" && root.predictionStatus.includes("回放缓存状态")
           ? root.predictionStatus
-          : null
+          : null,
+      primaryClientTelemetry: root.primaryClientTelemetry ?? []
     })
   };
 }

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -224,6 +224,113 @@ test("VeilRoot wires the equipment loot loop through equip and unequip session u
   ]);
 });
 
+test("VeilRoot emits primary-client telemetry for progression, inventory, and combat checkpoints", async () => {
+  const root = createVeilRootHarness();
+  root.roomId = "room-telemetry";
+  root.playerId = "player-1";
+  root.displayName = "暮潮守望";
+  delete root.applySessionUpdate;
+
+  const baseUpdate = createSessionUpdate(2, "room-telemetry", "player-1");
+  root.lastUpdate = {
+    ...baseUpdate,
+    battle: createFirstBattleState()
+  };
+  root.session = {} as never;
+
+  await root.equipHeroItem("weapon", "militia_pike");
+
+  installVeilRootRuntime({
+    loadProgressionSnapshot: async () => ({
+      summary: {
+        totalAchievements: 3,
+        unlockedAchievements: 1,
+        inProgressAchievements: 2,
+        recentEventCount: 1,
+        latestEventAt: "2026-04-01T08:00:00.000Z"
+      },
+      achievements: [],
+      recentEventLog: [
+        {
+          id: "event-1",
+          timestamp: "2026-04-01T08:00:00.000Z",
+          roomId: "room-telemetry",
+          playerId: "player-1",
+          category: "combat",
+          description: "战斗开始。",
+          rewards: []
+        }
+      ]
+    })
+  });
+
+  await root.refreshProgressionReview();
+
+  const update = createSessionUpdate(2, "room-telemetry", "player-1");
+  update.events = [
+    {
+      type: "battle.started",
+      heroId: "hero-1",
+      attackerPlayerId: "player-1",
+      encounterKind: "neutral",
+      neutralArmyId: "neutral-1",
+      battleId: "battle-telemetry",
+      path: [{ x: 0, y: 0 }, { x: 1, y: 0 }],
+      moveCost: 1
+    },
+    {
+      type: "hero.progressed",
+      heroId: "hero-1",
+      battleId: "battle-telemetry",
+      battleKind: "neutral",
+      experienceGained: 25,
+      totalExperience: 125,
+      level: 2,
+      levelsGained: 1,
+      skillPointsAwarded: 1,
+      availableSkillPoints: 1
+    },
+    {
+      type: "hero.equipmentFound",
+      heroId: "hero-1",
+      battleId: "battle-telemetry",
+      battleKind: "neutral",
+      equipmentId: "militia_pike",
+      equipmentName: "Militia Pike",
+      rarity: "common",
+      overflowed: true
+    },
+    {
+      type: "battle.resolved",
+      heroId: "hero-1",
+      attackerPlayerId: "player-1",
+      battleId: "battle-telemetry",
+      result: "attacker_victory"
+    }
+  ];
+  update.world.ownHeroes[0]!.loadout.inventory = ["travel_boots", "militia_pike"];
+
+  await root.applySessionUpdate(update);
+
+  assert.deepEqual(
+    root.primaryClientTelemetry.map((entry: Record<string, unknown>) => entry.checkpoint).slice(0, 6),
+    [
+      "encounter.resolved",
+      "loot.overflowed",
+      "hero.progressed",
+      "encounter.started",
+      "review.loaded",
+      "equipment.equip.rejected"
+    ]
+  );
+  assert.equal(root.primaryClientTelemetry[0]?.result, "attacker_victory");
+  assert.equal(root.primaryClientTelemetry[1]?.reason, undefined);
+  assert.equal(root.primaryClientTelemetry[1]?.status, "blocked");
+  assert.equal(root.primaryClientTelemetry[1]?.itemCount, 2);
+  assert.equal(root.primaryClientTelemetry[4]?.status, "success");
+  assert.equal(root.primaryClientTelemetry[5]?.reason, "in_battle");
+});
+
 test("VeilRoot gameplay account refresh uses the injected loader for remote equipment and loot updates", async () => {
   const storage = createMemoryStorage();
   (sys as unknown as { localStorage: Storage }).localStorage = storage;

--- a/apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
+++ b/apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
@@ -31,7 +31,21 @@ test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage",
     timelineEntries: ["房间 room-alpha 已恢复同步。"],
     logLines: ["连接已中断，正在尝试重连...", "已回放缓存状态，等待房间同步..."],
     predictionStatus: "已回放缓存状态，等待房间同步...",
-    recoverySummary: "已回放缓存状态，等待房间同步..."
+    recoverySummary: "已回放缓存状态，等待房间同步...",
+    primaryClientTelemetry: [
+      {
+        at: "2026-03-29T08:59:42.000Z",
+        category: "combat",
+        checkpoint: "encounter.started",
+        status: "info",
+        detail: "Battle battle-1 started against neutral.",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        heroId: "hero-1",
+        battleId: "battle-1",
+        battleKind: "neutral"
+      }
+    ]
   });
 
   assert.equal(snapshot.source.surface, "cocos-runtime-overlay");
@@ -55,7 +69,8 @@ test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage",
       timelineEntries: ["房间 room-alpha 已恢复同步。"],
       logLines: ["连接已中断，正在尝试重连...", "已回放缓存状态，等待房间同步..."],
       predictionStatus: "已回放缓存状态，等待房间同步...",
-      recoverySummary: "已回放缓存状态，等待房间同步..."
+      recoverySummary: "已回放缓存状态，等待房间同步...",
+      primaryClientTelemetry: []
     },
     "2026-03-29T09:00:20.000Z"
   );

--- a/docs/cocos-primary-client-telemetry.md
+++ b/docs/cocos-primary-client-telemetry.md
@@ -1,0 +1,33 @@
+# Cocos Primary-Client Telemetry
+
+Issue #514 adds a bounded primary-client telemetry stream to the existing runtime diagnostics snapshot. The goal is not backend analytics yet; it is a stable, inspectable contract for verifying the core client loop in tests and release evidence.
+
+## Schema
+
+Runtime diagnostics now expose `diagnostics.primaryClientTelemetry`, a short rolling array of structured checkpoints:
+
+- `at`: ISO timestamp captured on the client
+- `category`: `progression`, `inventory`, or `combat`
+- `checkpoint`: stable checkpoint id such as `review.loaded`, `hero.progressed`, `loot.overflowed`, `encounter.started`
+- `status`: `info`, `success`, `failure`, or `blocked`
+- `detail`: human-readable summary for logs and evidence bundles
+- Context fields when available: `roomId`, `playerId`, `heroId`, `battleId`, `battleKind`, `result`, `reason`, `slot`, `equipmentId`, `equipmentName`, `itemCount`, `level`, `experienceGained`, `levelsGained`, `skillPointsAwarded`
+
+## Current coverage
+
+- Progression checkpoints
+  - progression review load success/failure
+  - hero progression events emitted from authoritative session updates
+- Inventory checkpoints
+  - equip/unequip rejection reasons from client-side guardrails and failed requests
+  - loot pickup vs. inventory overflow after combat
+  - committed equipment changes from authoritative session updates
+- Combat checkpoints
+  - encounter start and resolution
+  - battle command submission and command failure
+
+## Validation
+
+- `packages/shared/test/runtime-diagnostics.test.ts` keeps the shared text rendering stable.
+- `packages/shared/test/client-payload-contracts.test.ts` snapshots the diagnostics payload contract.
+- `apps/cocos-client/test/cocos-root-orchestration.test.ts` verifies `VeilRoot` emits progression, inventory, and combat checkpoints from real client orchestration paths.

--- a/packages/shared/src/runtime-diagnostics.ts
+++ b/packages/shared/src/runtime-diagnostics.ts
@@ -125,6 +125,33 @@ export interface RuntimeDiagnosticsReplaySnapshot {
   totalSteps: number;
 }
 
+export type PrimaryClientTelemetryCategory = "progression" | "inventory" | "combat";
+
+export type PrimaryClientTelemetryStatus = "info" | "success" | "failure" | "blocked";
+
+export interface PrimaryClientTelemetryEvent {
+  at: string;
+  category: PrimaryClientTelemetryCategory;
+  checkpoint: string;
+  status: PrimaryClientTelemetryStatus;
+  detail: string;
+  roomId: string;
+  playerId: string;
+  heroId?: string;
+  battleId?: string;
+  battleKind?: "neutral" | "hero";
+  result?: "attacker_victory" | "defender_victory";
+  reason?: string;
+  slot?: string;
+  equipmentId?: string;
+  equipmentName?: string;
+  itemCount?: number;
+  level?: number;
+  experienceGained?: number;
+  levelsGained?: number;
+  skillPointsAwarded?: number;
+}
+
 export interface RuntimeDiagnosticsSnapshot {
   schemaVersion: number;
   exportedAt: string;
@@ -147,6 +174,7 @@ export interface RuntimeDiagnosticsSnapshot {
     predictionStatus: string | null;
     pendingUiTasks: number;
     replay: RuntimeDiagnosticsReplaySnapshot | null;
+    primaryClientTelemetry: PrimaryClientTelemetryEvent[];
   };
 }
 
@@ -511,6 +539,10 @@ export function buildRuntimeDiagnosticsSummaryLines(snapshot: RuntimeDiagnostics
 
   if (snapshot.diagnostics.recoverySummary) {
     lines.push(`Recovery ${snapshot.diagnostics.recoverySummary}`);
+  }
+
+  for (const entry of snapshot.diagnostics.primaryClientTelemetry.slice(0, 2)) {
+    lines.push(`Telemetry ${entry.category}/${entry.checkpoint} (${entry.status}) ${entry.detail}`);
   }
 
   lines.push(`Pending UI tasks ${snapshot.diagnostics.pendingUiTasks}`);

--- a/packages/shared/test/fixtures/contract-snapshots/runtime-diagnostics-snapshot.json
+++ b/packages/shared/test/fixtures/contract-snapshots/runtime-diagnostics-snapshot.json
@@ -126,6 +126,35 @@
     ],
     "recoverySummary": "权威房间已接管预测结果，战斗态一致。",
     "predictionStatus": "server-authoritative",
+    "primaryClientTelemetry": [
+      {
+        "at": "2026-03-29T07:09:31.000Z",
+        "category": "combat",
+        "checkpoint": "encounter.started",
+        "status": "info",
+        "detail": "Battle battle-demo started against neutral.",
+        "roomId": "room-contract",
+        "playerId": "player-1",
+        "heroId": "hero-1",
+        "battleId": "battle-demo",
+        "battleKind": "neutral"
+      },
+      {
+        "at": "2026-03-29T07:09:50.000Z",
+        "category": "inventory",
+        "checkpoint": "loot.collected",
+        "status": "success",
+        "detail": "Loot Scout Pike added to inventory.",
+        "roomId": "room-contract",
+        "playerId": "player-1",
+        "heroId": "hero-1",
+        "battleId": "battle-demo",
+        "battleKind": "neutral",
+        "equipmentId": "scout_pike",
+        "equipmentName": "Scout Pike",
+        "itemCount": 2
+      }
+    ],
     "pendingUiTasks": 1,
     "replay": {
       "replayId": "room-contract:battle-demo:player-1",

--- a/packages/shared/test/runtime-diagnostics.test.ts
+++ b/packages/shared/test/runtime-diagnostics.test.ts
@@ -90,6 +90,20 @@ function createRuntimeDiagnosticsSnapshot(): RuntimeDiagnosticsSnapshot {
       logTail: ["Room room-alpha connected", "Battle resolved"],
       recoverySummary: "连接已恢复，当前地图与战斗状态来自最新权威快照。",
       predictionStatus: "server-authoritative",
+      primaryClientTelemetry: [
+        {
+          at: "2026-03-29T07:09:05.000Z",
+          category: "combat",
+          checkpoint: "encounter.resolved",
+          status: "success",
+          detail: "Battle battle-1 resolved as attacker_victory.",
+          roomId: "room-alpha",
+          playerId: "player-1",
+          heroId: "hero-1",
+          battleId: "battle-1",
+          result: "attacker_victory"
+        }
+      ],
       pendingUiTasks: 2,
       replay: {
         replayId: "room-alpha:battle-1:player-1",
@@ -118,6 +132,7 @@ test("runtime diagnostics summary text stays stable for panel and automation con
   assert.match(rendered, /Hero 凯琳 @ 0,0 \/ MOV 4\/6 \/ HP 30\/30/);
   assert.match(rendered, /Account 暮火侦骑 \(remote\) \/ events 3 \/ replays 1/);
   assert.match(rendered, /Recovery 连接已恢复，当前地图与战斗状态来自最新权威快照。/);
+  assert.match(rendered, /Telemetry combat\/encounter\.resolved \(success\) Battle battle-1 resolved as attacker_victory\./);
   assert.match(rendered, /Replay room-alpha:battle-1:player-1 \/ paused \/ step 1\/3/);
   assert.match(rendered, /Timeline \[push\/battle\] Room room-alpha finished battle battle-1/);
 });
@@ -172,6 +187,7 @@ test("runtime diagnostics summary text supports aggregate server snapshots", () 
       logTail: ["project-veil-server rooms=2 connections=3"],
       recoverySummary: null,
       predictionStatus: "server-observability",
+      primaryClientTelemetry: [],
       pendingUiTasks: 0,
       replay: null
     }

--- a/packages/shared/test/support/multiplayer-protocol-fixtures.ts
+++ b/packages/shared/test/support/multiplayer-protocol-fixtures.ts
@@ -345,6 +345,35 @@ export function createRuntimeDiagnosticsSnapshotFixture(): RuntimeDiagnosticsSna
       logTail: ["Connected to room-contract", "Pushed authoritative battle snapshot"],
       recoverySummary: "权威房间已接管预测结果，战斗态一致。",
       predictionStatus: "server-authoritative",
+      primaryClientTelemetry: [
+        {
+          at: "2026-03-29T07:09:31.000Z",
+          category: "combat",
+          checkpoint: "encounter.started",
+          status: "info",
+          detail: "Battle battle-demo started against neutral.",
+          roomId: "room-contract",
+          playerId: "player-1",
+          heroId: "hero-1",
+          battleId: "battle-demo",
+          battleKind: "neutral"
+        },
+        {
+          at: "2026-03-29T07:09:50.000Z",
+          category: "inventory",
+          checkpoint: "loot.collected",
+          status: "success",
+          detail: "Loot Scout Pike added to inventory.",
+          roomId: "room-contract",
+          playerId: "player-1",
+          heroId: "hero-1",
+          battleId: "battle-demo",
+          battleKind: "neutral",
+          equipmentId: "scout_pike",
+          equipmentName: "Scout Pike",
+          itemCount: 2
+        }
+      ],
       pendingUiTasks: 1,
       replay: {
         replayId: "room-contract:battle-demo:player-1",


### PR DESCRIPTION
## Summary
- add a bounded primary-client telemetry stream to the shared runtime diagnostics snapshot
- emit progression, inventory/loot, and combat-loop checkpoints from VeilRoot orchestration paths
- document the event schema and lock the contract with focused diagnostics/orchestration tests

## Testing
- npm run typecheck:cocos
- node --import tsx --test ./packages/shared/test/runtime-diagnostics.test.ts
- node --import tsx --test ./apps/cocos-client/test/cocos-runtime-diagnostics.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts

closes #514