### PR TITLE
Persist primary-client diagnostic snapshots as release evidence artifacts

### DIFF
--- a/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
@@ -6,6 +6,7 @@ import {
   buildCriticalEvidenceGate,
   buildGoNoGoReport,
   summarizeCocosRc,
+  summarizePrimaryClientDiagnostics,
   summarizeSnapshot,
   summarizeWechatPackage,
   summarizeWechatSmoke
@@ -129,18 +130,41 @@ test("buildCriticalEvidenceGate fails when a critical artifact is missing and ex
   const gate = buildCriticalEvidenceGate(14, [
     summarizeSnapshot(undefined, undefined).evidence,
     summarizeWechatPackage(undefined, undefined).evidence,
-    summarizeWechatSmoke(undefined, undefined).evidence
+    summarizeWechatSmoke(undefined, undefined).evidence,
+    summarizePrimaryClientDiagnostics(undefined, undefined).evidence
   ]);
 
   assert.equal(gate.status, "fail");
   assert.deepEqual(gate.failReasons, [
     "release_readiness_snapshot_missing",
     "wechat_package_metadata_missing",
-    "wechat_smoke_report_missing"
+    "wechat_smoke_report_missing",
+    "primary_client_diagnostic_snapshots_missing"
   ]);
   assert.deepEqual(gate.warnReasons, []);
   assert.equal(gate.evidence.every((entry) => entry.availability === "missing"), true);
   assert.equal(gate.details.every((detail) => detail.endsWith("missing artifact")), true);
+});
+
+test("summarizePrimaryClientDiagnostics fails incomplete checkpoint coverage", () => {
+  const summary = summarizePrimaryClientDiagnostics("/tmp/cocos-primary-diagnostics.json", {
+    generatedAt: "2026-03-30T00:00:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
+    summary: {
+      status: "passed",
+      checkpointCount: 2,
+      categoryIds: ["progression", "combat"],
+      checkpointIds: ["progression-review", "combat-loop"]
+    },
+    checkpoints: []
+  });
+
+  assert.equal(summary.status, "fail");
+  assert.match(summary.detail, /missingCheckpointIds=inventory-overflow,reconnect-cached-replay,reconnect-recovery/);
+  assert.match(summary.detail, /missingCategoryIds=inventory,reconnect/);
+  assert.deepEqual(summary.failReasons, ["primary_client_diagnostic_snapshots_incomplete"]);
 });
 
 test("buildGoNoGoReport marks a candidate blocked when linked evidence revisions disagree", () => {

--- a/apps/cocos-client/test/release-readiness-dashboard.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard.test.ts
@@ -33,6 +33,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
   const markdownOutputPath = path.join(workspaceDir, "dashboard.md");
   const snapshotPath = path.join(workspaceDir, "release-readiness.json");
   const cocosRcPath = path.join(workspaceDir, "cocos-rc.json");
+  const primaryClientDiagnosticsPath = path.join(workspaceDir, "cocos-primary-diagnostics.json");
   const wechatArtifactsDir = path.join(workspaceDir, "wechat-artifacts");
   const packageMetadataPath = path.join(wechatArtifactsDir, "project-veil.package.json");
   const archivePath = path.join(wechatArtifactsDir, "project-veil.tar.gz");
@@ -66,6 +67,25 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
       executedAt: "2026-03-29T08:20:00.000Z",
       summary: "Canonical gameplay journey passed."
     }
+  });
+  writeJson(primaryClientDiagnosticsPath, {
+    generatedAt: "2026-03-29T08:18:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
+    summary: {
+      status: "passed",
+      checkpointCount: 5,
+      categoryIds: ["progression", "inventory", "combat", "reconnect"],
+      checkpointIds: [
+        "progression-review",
+        "inventory-overflow",
+        "combat-loop",
+        "reconnect-cached-replay",
+        "reconnect-recovery"
+      ]
+    },
+    checkpoints: []
   });
   fs.mkdirSync(wechatArtifactsDir, { recursive: true });
   fs.writeFileSync(archivePath, "archive-binary", "utf8");
@@ -175,6 +195,8 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
         snapshotPath,
         "--cocos-rc",
         cocosRcPath,
+        "--primary-client-diagnostics",
+        primaryClientDiagnosticsPath,
         "--wechat-artifacts-dir",
         wechatArtifactsDir,
         "--candidate-revision",
@@ -223,6 +245,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     );
     assert.deepEqual(report.gates.every((gate) => gate.failReasons.length === 0), true);
     assert.equal(report.gates[3]?.evidence.every((entry) => entry.availability === "present"), true);
+    assert.equal(report.gates[3]?.evidence.length, 5);
     assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /Phase 1 Go\/No-Go/);
   } finally {
     await new Promise<void>((resolve, reject) => {

--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -39,14 +39,44 @@ The audit currently enforces two stable checks:
 
 The command emits a concise JSON plus Markdown summary under `artifacts/release-readiness/` by default, and CI appends the Markdown summary to the GitHub step summary.
 
+## Primary-Client Diagnostic Snapshots
+
+Generate the structured diagnostic evidence packet before final release review:
+
+```bash
+npm run release:cocos:primary-diagnostics
+```
+
+By default this writes versioned JSON + Markdown artifacts under `artifacts/release-readiness/`:
+
+- `artifacts/release-readiness/cocos-primary-client-diagnostic-snapshots-<short-sha>-<timestamp>.json`
+- `artifacts/release-readiness/cocos-primary-client-diagnostic-snapshots-<short-sha>-<timestamp>.md`
+
+The exporter reuses the existing Cocos `VeilRoot` harness and records checkpointed runtime-diagnostics evidence for:
+
+- progression review loading
+- inventory overflow / blocked equipment evidence
+- combat-loop resolution
+- reconnect cached-replay fallback
+- reconnect recovery back to authoritative state
+
+Inspect the Markdown file for a reviewer-friendly summary and open the JSON file when you need the raw runtime snapshot payloads, telemetry checkpoints, and connection-state details. If you want explicit output paths:
+
+```bash
+npm run release:cocos:primary-diagnostics -- \
+  --output artifacts/release-readiness/cocos-primary-client-diagnostics.json \
+  --markdown-output artifacts/release-readiness/cocos-primary-client-diagnostics.md
+```
+
 ## Manual Release Sign-Off
 
 Keep these manual items short and attach evidence through the existing release evidence flow instead of inventing a new format:
 
 1. Complete the current candidate snapshot with `npm run release:cocos-rc:snapshot`.
-2. Copy and fill the RC checklist/template files in [`docs/release-evidence`](/home/gpt/project/ProjectVeil/docs/release-evidence).
-3. Record any open risk in the blocker template before sign-off.
-4. Confirm the release candidate still matches the intended commit/revision.
+2. Refresh the primary-client diagnostic artifact with `npm run release:cocos:primary-diagnostics`.
+3. Copy and fill the RC checklist/template files in [`docs/release-evidence`](/home/gpt/project/ProjectVeil/docs/release-evidence).
+4. Record any open risk in the blocker template before sign-off.
+5. Confirm the release candidate still matches the intended commit/revision.
 
 ## Related Commands
 
@@ -56,3 +86,4 @@ Keep these manual items short and attach evidence through the existing release e
 - Package artifact: `npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime --source-revision <git-sha>`
 - RC artifact validation: `npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> --expected-revision <git-sha>`
 - Unified Cocos evidence snapshot: `npm run release:cocos-rc:snapshot`
+- Primary-client diagnostic evidence: `npm run release:cocos:primary-diagnostics`

--- a/docs/release-readiness-dashboard.md
+++ b/docs/release-readiness-dashboard.md
@@ -7,6 +7,7 @@
 - `npm run package:wechat-release` sidecar metadata for package validation
 - `npm run smoke:wechat-release` for device/quasi-device smoke evidence
 - `npm run release:cocos-rc:snapshot` for recent Cocos RC journey evidence
+- `npm run release:cocos:primary-diagnostics` for checkpointed primary-client runtime diagnostics evidence
 
 The dashboard writes both JSON and Markdown so it works as a quick terminal summary and as a review artifact.
 
@@ -25,6 +26,7 @@ npm run release:readiness:dashboard -- \
   --server-url http://127.0.0.1:2567 \
   --snapshot artifacts/release-readiness/rc-2026-03-29.json \
   --cocos-rc artifacts/release-evidence/phase1-wechat-rc.json \
+  --primary-client-diagnostics artifacts/release-readiness/cocos-primary-client-diagnostic-snapshots-abc1234-2026-03-29T08-18-00.000Z.json \
   --wechat-artifacts-dir artifacts/wechat-release \
   --candidate-revision abc1234
 ```
@@ -76,7 +78,8 @@ After that, the report summarizes the same four bounded gates:
   - Reads `codex.wechat.smoke-report.json` and flags `pending` as `warn`, `failed` as `fail`.
 - `Critical readiness evidence`
   - Lists the latest linked evidence with exact timestamps, paths, and any revision identifiers discovered in the source artifacts.
-  - Warns when evidence is missing or older than the configured freshness window.
+  - Fails closed when primary-client diagnostic snapshots are missing or incomplete.
+  - Warns when present evidence is older than the configured freshness window.
 
 ## Recommended Local Flow
 
@@ -100,13 +103,19 @@ npm run smoke:wechat-release -- --artifacts-dir artifacts/wechat-release
 npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surface wechat_preview --output artifacts/release-evidence/<candidate-name>.json
 ```
 
-4. Start the local server if you want live runtime/auth evidence in the same report:
+4. Refresh the primary-client diagnostic evidence artifact:
+
+```bash
+npm run release:cocos:primary-diagnostics
+```
+
+5. Start the local server if you want live runtime/auth evidence in the same report:
 
 ```bash
 npm run dev:server
 ```
 
-5. Generate the dashboard:
+6. Generate the dashboard:
 
 ```bash
 npm run release:readiness:dashboard -- \

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ci:trend-summary": "node --import tsx ./scripts/publish-ci-trend-summary.ts",
     "release:cocos-rc:snapshot": "node --import tsx ./scripts/cocos-release-candidate-snapshot.ts",
     "release:cocos-rc:bundle": "node --import tsx ./scripts/cocos-rc-evidence-bundle.ts",
+    "release:cocos:primary-diagnostics": "node --import tsx ./scripts/cocos-primary-client-diagnostic-snapshots.ts",
     "audit:cocos-primary-delivery": "node --import tsx ./scripts/audit-cocos-primary-delivery.ts",
     "check:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts --check && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/build-templates/wechatgame && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime && node --import tsx ./scripts/prepare-wechat-minigame-release.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime --check",
     "check:cocos-release-readiness": "node --import tsx ./scripts/validate-assets.ts --require-cocos-release-ready && npm run check:wechat-build",

--- a/scripts/cocos-primary-client-diagnostic-snapshots.ts
+++ b/scripts/cocos-primary-client-diagnostic-snapshots.ts
@@ -1,0 +1,553 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { buildCocosRuntimeDiagnosticsSnapshot } from "../apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts";
+import { createFallbackCocosPlayerAccountProfile } from "../apps/cocos-client/assets/scripts/cocos-lobby.ts";
+import { createSessionUpdate } from "../apps/cocos-client/test/helpers/cocos-session-fixtures.ts";
+import {
+  createVeilRootHarness,
+  installVeilRootRuntime,
+  resetVeilRootRuntime
+} from "../apps/cocos-client/test/helpers/veil-root-harness.ts";
+import type {
+  RuntimeDiagnosticsConnectionStatus,
+  RuntimeDiagnosticsSnapshot
+} from "../packages/shared/src/runtime-diagnostics.ts";
+
+type ArtifactStatus = "passed";
+type CheckpointCategory = "progression" | "inventory" | "combat" | "reconnect";
+
+interface Args {
+  outputPath?: string;
+  markdownOutputPath?: string;
+}
+
+interface GitRevision {
+  commit: string;
+  shortCommit: string;
+  branch: string;
+  dirty: boolean;
+}
+
+interface ArtifactCheckpoint {
+  id: string;
+  title: string;
+  category: CheckpointCategory;
+  capturedAt: string;
+  summary: string;
+  connectionStatus: RuntimeDiagnosticsConnectionStatus;
+  telemetryCheckpoints: string[];
+  highlights: string[];
+  diagnostics: RuntimeDiagnosticsSnapshot;
+}
+
+export interface PrimaryClientDiagnosticSnapshotsArtifact {
+  schemaVersion: 1;
+  generatedAt: string;
+  revision: GitRevision;
+  summary: {
+    status: ArtifactStatus;
+    checkpointCount: number;
+    categoryIds: CheckpointCategory[];
+    checkpointIds: string[];
+  };
+  checkpoints: ArtifactCheckpoint[];
+}
+
+type RootState = ReturnType<typeof createVeilRootHarness> & Record<string, any>;
+
+const DEFAULT_OUTPUT_DIR = path.resolve("artifacts", "release-readiness");
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let outputPath: string | undefined;
+  let markdownOutputPath: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--markdown-output" && next) {
+      markdownOutputPath = next;
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    ...(outputPath ? { outputPath } : {}),
+    ...(markdownOutputPath ? { markdownOutputPath } : {})
+  };
+}
+
+function readGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function getRevision(): GitRevision {
+  return {
+    commit: readGitValue(["rev-parse", "HEAD"]),
+    shortCommit: readGitValue(["rev-parse", "--short", "HEAD"]),
+    branch: readGitValue(["rev-parse", "--abbrev-ref", "HEAD"]),
+    dirty: readGitValue(["status", "--porcelain"]).length > 0
+  };
+}
+
+function ensureParentDir(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function writeTextFile(filePath: string, content: string): void {
+  ensureParentDir(filePath);
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function toRepoRelative(filePath: string): string {
+  return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+}
+
+function buildBattleState() {
+  return {
+    id: "battle-primary-diagnostic",
+    round: 2,
+    lanes: 1,
+    activeUnitId: "hero-1-stack",
+    turnOrder: ["hero-1-stack", "neutral-1-stack"],
+    units: {
+      "hero-1-stack": {
+        id: "hero-1-stack",
+        templateId: "hero_guard_basic",
+        camp: "attacker",
+        lane: 0,
+        stackName: "Guard",
+        initiative: 7,
+        attack: 4,
+        defense: 4,
+        minDamage: 1,
+        maxDamage: 2,
+        count: 12,
+        currentHp: 9,
+        maxHp: 10,
+        hasRetaliated: false,
+        defending: false,
+        skills: [],
+        statusEffects: []
+      },
+      "neutral-1-stack": {
+        id: "neutral-1-stack",
+        templateId: "orc_warrior",
+        camp: "defender",
+        lane: 0,
+        stackName: "Orc",
+        initiative: 5,
+        attack: 3,
+        defense: 3,
+        minDamage: 1,
+        maxDamage: 3,
+        count: 4,
+        currentHp: 7,
+        maxHp: 9,
+        hasRetaliated: false,
+        defending: false,
+        skills: [],
+        statusEffects: []
+      }
+    },
+    environment: [],
+    log: ["战斗开始", "守军发动攻击", "暮潮守望完成反击"],
+    rng: {
+      seed: 1001,
+      cursor: 4
+    },
+    worldHeroId: "hero-1",
+    neutralArmyId: "neutral-1",
+    encounterPosition: { x: 1, y: 0 }
+  };
+}
+
+function buildDiagnosticsSnapshot(root: RootState, exportedAt: string): RuntimeDiagnosticsSnapshot {
+  const update = root.lastUpdate ?? null;
+  return buildCocosRuntimeDiagnosticsSnapshot({
+    exportedAt,
+    devOnly: true,
+    mode: root.showLobby ? "lobby" : update?.battle ? "battle" : "world",
+    roomId: root.roomId,
+    playerId: root.playerId,
+    connectionStatus: root.diagnosticsConnectionStatus,
+    lastUpdateSource: root.lastRoomUpdateSource ?? null,
+    lastUpdateReason: root.lastRoomUpdateReason ?? null,
+    lastUpdateAt: root.lastRoomUpdateAtMs ?? null,
+    update,
+    account:
+      root.lobbyAccountProfile ??
+      createFallbackCocosPlayerAccountProfile(root.playerId, root.roomId, root.displayName, {
+        source: "remote",
+        authMode: root.authMode,
+        loginId: root.loginId
+      }),
+    timelineEntries: root.timelineEntries ?? [],
+    logLines: root.logLines ?? [],
+    predictionStatus: root.predictionStatus ?? "",
+    recoverySummary:
+      typeof root.predictionStatus === "string" && root.predictionStatus.includes("回放缓存状态")
+        ? root.predictionStatus
+        : null,
+    primaryClientTelemetry: root.primaryClientTelemetry ?? []
+  });
+}
+
+function captureCheckpoint(input: {
+  root: RootState;
+  id: string;
+  title: string;
+  category: CheckpointCategory;
+  capturedAt: string;
+  summary: string;
+  telemetryCheckpoints: string[];
+  highlights: string[];
+}): ArtifactCheckpoint {
+  return {
+    id: input.id,
+    title: input.title,
+    category: input.category,
+    capturedAt: input.capturedAt,
+    summary: input.summary,
+    connectionStatus: input.root.diagnosticsConnectionStatus,
+    telemetryCheckpoints: input.telemetryCheckpoints,
+    highlights: input.highlights,
+    diagnostics: buildDiagnosticsSnapshot(input.root, input.capturedAt)
+  };
+}
+
+export async function buildPrimaryClientDiagnosticSnapshotsArtifact(
+  revision = getRevision(),
+  generatedAt = new Date().toISOString()
+): Promise<PrimaryClientDiagnosticSnapshotsArtifact> {
+  const root = createVeilRootHarness() as RootState;
+  delete root.applySessionUpdate;
+  delete root.applyReplayedSessionUpdate;
+
+  const baseMs = Date.parse(generatedAt);
+  const at = (offsetMinutes: number) => new Date(baseMs + offsetMinutes * 60_000).toISOString();
+
+  root.roomId = "room-primary-diagnostics";
+  root.playerId = "player-account";
+  root.displayName = "暮潮守望";
+  root.authMode = "account";
+  root.loginId = "veil-ranger";
+  root.authToken = "account.session.token";
+  root.sessionSource = "remote";
+  root.showLobby = false;
+  root.diagnosticsConnectionStatus = "connected";
+  root.logLines = [];
+  root.timelineEntries = [];
+  root.primaryClientTelemetry = [];
+  root.predictionStatus = "";
+
+  installVeilRootRuntime({
+    loadProgressionSnapshot: async () => ({
+      summary: {
+        totalAchievements: 3,
+        unlockedAchievements: 1,
+        inProgressAchievements: 2,
+        recentEventCount: 1,
+        latestEventAt: at(2)
+      },
+      achievements: [],
+      recentEventLog: [
+        {
+          id: "event-1",
+          timestamp: at(2),
+          roomId: root.roomId,
+          playerId: root.playerId,
+          category: "combat",
+          description: "战斗开始。",
+          rewards: []
+        }
+      ]
+    }),
+    loadAccountProfile: async () =>
+      createFallbackCocosPlayerAccountProfile(root.playerId, root.roomId, root.displayName, {
+        source: "remote",
+        authMode: root.authMode,
+        loginId: root.loginId
+      })
+  });
+
+  try {
+    const combatUpdate = createSessionUpdate(4, root.roomId, root.playerId);
+    combatUpdate.battle = buildBattleState();
+    combatUpdate.world.ownHeroes[0]!.position = { x: 1, y: 0 };
+    root.lastUpdate = combatUpdate;
+    root.session = {} as never;
+    root.lastRoomUpdateSource = "connect";
+    root.lastRoomUpdateReason = "initial_snapshot";
+    root.lastRoomUpdateAtMs = Date.parse(at(0));
+
+    await root.equipHeroItem("weapon", "militia_pike");
+    await (root as any).refreshProgressionReview();
+
+    const progressionCheckpoint = captureCheckpoint({
+      root,
+      id: "progression-review",
+      title: "Progression review loaded",
+      category: "progression",
+      capturedAt: at(2),
+      summary: "Primary-client progression review loaded with the latest achievement and event context after room entry.",
+      telemetryCheckpoints: ["review.loaded"],
+      highlights: [
+        "Review loader returned recent event log context for the active account.",
+        "Diagnostic snapshot stayed in connected mode while review data hydrated."
+      ]
+    });
+
+    const gameplayUpdate = createSessionUpdate(5, root.roomId, root.playerId);
+    gameplayUpdate.battle = buildBattleState();
+    gameplayUpdate.events = [
+      {
+        type: "battle.started",
+        heroId: "hero-1",
+        attackerPlayerId: root.playerId,
+        encounterKind: "neutral",
+        neutralArmyId: "neutral-1",
+        battleId: "battle-primary-diagnostic",
+        path: [{ x: 0, y: 0 }, { x: 1, y: 0 }],
+        moveCost: 1
+      },
+      {
+        type: "hero.progressed",
+        heroId: "hero-1",
+        battleId: "battle-primary-diagnostic",
+        battleKind: "neutral",
+        experienceGained: 25,
+        totalExperience: 125,
+        level: 2,
+        levelsGained: 1,
+        skillPointsAwarded: 1,
+        availableSkillPoints: 1
+      },
+      {
+        type: "hero.equipmentFound",
+        heroId: "hero-1",
+        battleId: "battle-primary-diagnostic",
+        battleKind: "neutral",
+        equipmentId: "militia_pike",
+        equipmentName: "Militia Pike",
+        rarity: "common",
+        overflowed: true
+      },
+      {
+        type: "battle.resolved",
+        heroId: "hero-1",
+        attackerPlayerId: root.playerId,
+        battleId: "battle-primary-diagnostic",
+        result: "attacker_victory"
+      }
+    ];
+    gameplayUpdate.world.ownHeroes[0]!.position = { x: 1, y: 0 };
+    gameplayUpdate.world.ownHeroes[0]!.progression.level = 2;
+    gameplayUpdate.world.ownHeroes[0]!.progression.experience = 125;
+    gameplayUpdate.world.ownHeroes[0]!.progression.battlesWon = 1;
+    gameplayUpdate.world.ownHeroes[0]!.progression.neutralBattlesWon = 1;
+    gameplayUpdate.world.ownHeroes[0]!.loadout.inventory = ["travel_boots", "militia_pike"];
+    gameplayUpdate.battle!.round = 3;
+    gameplayUpdate.battle!.log = ["战斗开始", "守军发动攻击", "暮潮守望完成反击", "战斗结束，获得长枪"];
+
+    await root.applySessionUpdate(gameplayUpdate);
+    root.lastRoomUpdateSource = "push";
+    root.lastRoomUpdateReason = "battle_resolution";
+    root.lastRoomUpdateAtMs = Date.parse(at(4));
+
+    const inventoryCheckpoint = captureCheckpoint({
+      root,
+      id: "inventory-overflow",
+      title: "Inventory overflow surfaced in diagnostics",
+      category: "inventory",
+      capturedAt: at(4),
+      summary: "Diagnostic snapshot captured blocked inventory loot handling and preserved the relevant telemetry trail.",
+      telemetryCheckpoints: ["equipment.equip.rejected", "loot.overflowed"],
+      highlights: [
+        "Blocked inventory telemetry remains attached to the active runtime diagnostics snapshot.",
+        "Inventory count stayed visible after the overflowed battle reward."
+      ]
+    });
+
+    const combatCheckpoint = captureCheckpoint({
+      root,
+      id: "combat-loop",
+      title: "Combat loop resolved",
+      category: "combat",
+      capturedAt: at(4),
+      summary: "Primary-client diagnostics recorded encounter start, progression gain, and combat resolution in one battle-loop checkpoint.",
+      telemetryCheckpoints: ["encounter.started", "hero.progressed", "encounter.resolved"],
+      highlights: [
+        "Battle diagnostics include round, active unit, and log tail.",
+        "Telemetry shows a complete neutral encounter loop ending in attacker victory."
+      ]
+    });
+
+    root.lastRoomUpdateSource = "replay";
+    root.lastRoomUpdateReason = "cached_snapshot";
+    root.lastRoomUpdateAtMs = Date.parse(at(6));
+    root.predictionStatus = "回放缓存状态：展示上一份本地快照，等待权威重同步恢复。";
+    (root as any).handleConnectionEvent("reconnecting");
+
+    const reconnectReplayCheckpoint = captureCheckpoint({
+      root,
+      id: "reconnect-cached-replay",
+      title: "Reconnect replay fallback",
+      category: "reconnect",
+      capturedAt: at(6),
+      summary: "Diagnostic snapshot preserved the cached replay fallback while the client was reconnecting.",
+      telemetryCheckpoints: [],
+      highlights: [
+        "Connection status downgraded to reconnecting while replaying cached state.",
+        "Recovery summary stayed attached for reviewer inspection."
+      ]
+    });
+
+    const recoveredUpdate = createSessionUpdate(6, root.roomId, root.playerId);
+    recoveredUpdate.world.ownHeroes[0]!.position = { x: 1, y: 1 };
+    recoveredUpdate.world.ownHeroes[0]!.progression.level = 2;
+    recoveredUpdate.world.ownHeroes[0]!.progression.experience = 125;
+    recoveredUpdate.world.ownHeroes[0]!.progression.battlesWon = 1;
+    recoveredUpdate.world.ownHeroes[0]!.progression.neutralBattlesWon = 1;
+    recoveredUpdate.world.resources.wood = 12;
+    recoveredUpdate.reason = "after-reconnect";
+    root.lastUpdate = recoveredUpdate;
+    root.lastRoomUpdateSource = "push";
+    root.lastRoomUpdateReason = "after-reconnect";
+    root.lastRoomUpdateAtMs = Date.parse(at(8));
+    root.predictionStatus = "";
+    (root as any).handleConnectionEvent("reconnected");
+
+    const reconnectRecoveryCheckpoint = captureCheckpoint({
+      root,
+      id: "reconnect-recovery",
+      title: "Reconnect recovered to authoritative world state",
+      category: "reconnect",
+      capturedAt: at(8),
+      summary: "Diagnostic snapshot confirmed reconnect recovery restored authoritative world state after cached replay fallback.",
+      telemetryCheckpoints: [],
+      highlights: [
+        "Connection returned to connected with a fresh authoritative push update.",
+        "World state advanced to the post-recovery day and resource snapshot."
+      ]
+    });
+
+    const checkpoints = [
+      progressionCheckpoint,
+      inventoryCheckpoint,
+      combatCheckpoint,
+      reconnectReplayCheckpoint,
+      reconnectRecoveryCheckpoint
+    ];
+
+    return {
+      schemaVersion: 1,
+      generatedAt,
+      revision,
+      summary: {
+        status: "passed",
+        checkpointCount: checkpoints.length,
+        categoryIds: ["progression", "inventory", "combat", "reconnect"],
+        checkpointIds: checkpoints.map((checkpoint) => checkpoint.id)
+      },
+      checkpoints
+    };
+  } finally {
+    resetVeilRootRuntime();
+  }
+}
+
+export function renderPrimaryClientDiagnosticSnapshotsMarkdown(
+  artifact: PrimaryClientDiagnosticSnapshotsArtifact,
+  jsonArtifactPath: string
+): string {
+  const lines: string[] = [];
+  lines.push("# Primary-Client Diagnostic Snapshots");
+  lines.push("");
+  lines.push(`- Generated at: ${artifact.generatedAt}`);
+  lines.push(`- Revision: ${artifact.revision.shortCommit} (${artifact.revision.branch}${artifact.revision.dirty ? ", dirty" : ""})`);
+  lines.push(`- JSON artifact: ${toRepoRelative(jsonArtifactPath)}`);
+  lines.push(`- Checkpoints: ${artifact.summary.checkpointCount}`);
+  lines.push(`- Categories: ${artifact.summary.categoryIds.join(", ")}`);
+  lines.push("");
+  lines.push("| Checkpoint | Category | Connection | Captured At |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const checkpoint of artifact.checkpoints) {
+    lines.push(`| ${checkpoint.id} | ${checkpoint.category} | ${checkpoint.connectionStatus} | ${checkpoint.capturedAt} |`);
+  }
+  lines.push("");
+
+  for (const checkpoint of artifact.checkpoints) {
+    lines.push(`## ${checkpoint.title}`);
+    lines.push("");
+    lines.push(`- Checkpoint ID: ${checkpoint.id}`);
+    lines.push(`- Category: ${checkpoint.category}`);
+    lines.push(`- Summary: ${checkpoint.summary}`);
+    lines.push(`- Connection status: ${checkpoint.connectionStatus}`);
+    lines.push(`- Captured at: ${checkpoint.capturedAt}`);
+    lines.push(`- Telemetry checkpoints: ${checkpoint.telemetryCheckpoints.length > 0 ? checkpoint.telemetryCheckpoints.join(", ") : "<none>"}`);
+    for (const highlight of checkpoint.highlights) {
+      lines.push(`- ${highlight}`);
+    }
+    lines.push(`- Snapshot mode: ${checkpoint.diagnostics.source.mode}`);
+    lines.push(
+      `- Room summary: room=${checkpoint.diagnostics.room?.roomId ?? "<none>"} day=${checkpoint.diagnostics.room?.day ?? "<none>"} source=${checkpoint.diagnostics.room?.lastUpdateSource ?? "<none>"}`
+    );
+    lines.push("");
+  }
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+function defaultOutputPaths(revision: GitRevision, generatedAt: string): { jsonPath: string; markdownPath: string } {
+  const timestamp = generatedAt.replace(/:/g, "-");
+  const baseName = `cocos-primary-client-diagnostic-snapshots-${revision.shortCommit}-${timestamp}`;
+  return {
+    jsonPath: path.resolve(DEFAULT_OUTPUT_DIR, `${baseName}.json`),
+    markdownPath: path.resolve(DEFAULT_OUTPUT_DIR, `${baseName}.md`)
+  };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const revision = getRevision();
+  const generatedAt = new Date().toISOString();
+  const outputDefaults = defaultOutputPaths(revision, generatedAt);
+  const artifact = await buildPrimaryClientDiagnosticSnapshotsArtifact(revision, generatedAt);
+  const jsonOutputPath = path.resolve(args.outputPath ?? outputDefaults.jsonPath);
+  const markdownOutputPath = path.resolve(args.markdownOutputPath ?? outputDefaults.markdownPath);
+
+  writeTextFile(jsonOutputPath, `${JSON.stringify(artifact, null, 2)}\n`);
+  writeTextFile(markdownOutputPath, renderPrimaryClientDiagnosticSnapshotsMarkdown(artifact, jsonOutputPath));
+
+  console.log(`Wrote primary-client diagnostic JSON: ${toRepoRelative(jsonOutputPath)}`);
+  console.log(`Wrote primary-client diagnostic Markdown: ${toRepoRelative(markdownOutputPath)}`);
+  console.log(`Checkpoint count: ${artifact.summary.checkpointCount}`);
+  console.log(`Categories: ${artifact.summary.categoryIds.join(", ")}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main();
+}

--- a/scripts/release-readiness-dashboard.ts
+++ b/scripts/release-readiness-dashboard.ts
@@ -10,6 +10,7 @@ interface Args {
   serverUrl?: string;
   snapshotPath?: string;
   cocosRcPath?: string;
+  primaryClientDiagnosticsPath?: string;
   wechatArtifactsDir?: string;
   wechatSmokeReportPath?: string;
   wechatPackageMetadataPath?: string;
@@ -109,6 +110,25 @@ interface CocosReleaseCandidateSnapshot {
   };
 }
 
+interface PrimaryClientDiagnosticSnapshotsArtifact {
+  generatedAt?: string;
+  revision?: {
+    commit?: string;
+    shortCommit?: string;
+  };
+  summary?: {
+    status?: "passed";
+    checkpointCount?: number;
+    categoryIds?: string[];
+    checkpointIds?: string[];
+  };
+  checkpoints?: Array<{
+    id?: string;
+    category?: "progression" | "inventory" | "combat" | "reconnect";
+    capturedAt?: string;
+  }>;
+}
+
 interface EvidenceItem {
   label: string;
   path: string;
@@ -142,6 +162,7 @@ interface DashboardReport {
     serverUrl?: string;
     snapshotPath?: string;
     cocosRcPath?: string;
+    primaryClientDiagnosticsPath?: string;
     wechatArtifactsDir?: string;
     wechatSmokeReportPath?: string;
     wechatPackageMetadataPath?: string;
@@ -179,6 +200,14 @@ interface GoNoGoReport {
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
 const DEFAULT_RELEASE_EVIDENCE_DIR = path.resolve("artifacts", "release-evidence");
 const REQUIRED_SNAPSHOT_CHECK_IDS = ["npm-test", "typecheck-ci", "e2e-smoke", "e2e-multiplayer-smoke", "cocos-primary-journey", "wechat-build-check"] as const;
+const REQUIRED_PRIMARY_DIAGNOSTIC_CATEGORY_IDS = ["progression", "inventory", "combat", "reconnect"] as const;
+const REQUIRED_PRIMARY_DIAGNOSTIC_CHECKPOINT_IDS = [
+  "progression-review",
+  "inventory-overflow",
+  "combat-loop",
+  "reconnect-cached-replay",
+  "reconnect-recovery"
+] as const;
 const REQUIRED_METRICS = [
   "veil_active_room_count",
   "veil_connection_count",
@@ -195,6 +224,7 @@ function parseArgs(argv: string[]): Args {
   let serverUrl: string | undefined;
   let snapshotPath: string | undefined;
   let cocosRcPath: string | undefined;
+  let primaryClientDiagnosticsPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let wechatSmokeReportPath: string | undefined;
   let wechatPackageMetadataPath: string | undefined;
@@ -219,6 +249,11 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--cocos-rc" && next) {
       cocosRcPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--primary-client-diagnostics" && next) {
+      primaryClientDiagnosticsPath = next;
       index += 1;
       continue;
     }
@@ -269,6 +304,7 @@ function parseArgs(argv: string[]): Args {
     ...(serverUrl ? { serverUrl } : {}),
     ...(snapshotPath ? { snapshotPath } : {}),
     ...(cocosRcPath ? { cocosRcPath } : {}),
+    ...(primaryClientDiagnosticsPath ? { primaryClientDiagnosticsPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
     ...(wechatPackageMetadataPath ? { wechatPackageMetadataPath } : {}),
@@ -279,13 +315,13 @@ function parseArgs(argv: string[]): Args {
   };
 }
 
-function resolveLatestJsonFile(dirPath: string): string | undefined {
+function resolveLatestMatchingJsonFile(dirPath: string, matcher: (entry: string) => boolean): string | undefined {
   if (!fs.existsSync(dirPath)) {
     return undefined;
   }
   const candidates = fs
     .readdirSync(dirPath)
-    .filter((entry) => entry.endsWith(".json"))
+    .filter((entry) => entry.endsWith(".json") && matcher(entry))
     .map((entry) => path.join(dirPath, entry))
     .filter((entry) => fs.statSync(entry).isFile())
     .sort((left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs);
@@ -892,6 +928,68 @@ export function summarizeCocosRc(snapshotPath: string | undefined, snapshot: Coc
   };
 }
 
+export function summarizePrimaryClientDiagnostics(
+  artifactPath: string | undefined,
+  artifact: PrimaryClientDiagnosticSnapshotsArtifact | undefined
+): {
+  status: GateStatus;
+  detail: string;
+  evidence: EvidenceItem;
+  failReasons: string[];
+  warnReasons: string[];
+} {
+  if (!artifactPath || !artifact) {
+    return {
+      status: "fail",
+      detail: "Primary-client diagnostic snapshots missing.",
+      evidence: createEvidenceItem({
+        label: "Primary-client diagnostic snapshots",
+        path: artifactPath ?? "<missing-primary-client-diagnostic-snapshots>",
+        status: "fail",
+        availability: "missing",
+        summary: "Primary-client diagnostic snapshots missing.",
+        reasonCodes: ["primary_client_diagnostic_snapshots_missing"]
+      }),
+      failReasons: ["primary_client_diagnostic_snapshots_missing"],
+      warnReasons: []
+    };
+  }
+
+  const checkpointIds = new Set(
+    (artifact.summary?.checkpointIds ?? artifact.checkpoints?.map((checkpoint) => checkpoint.id).filter(Boolean) ?? []) as string[]
+  );
+  const categoryIds = new Set(
+    (artifact.summary?.categoryIds ?? artifact.checkpoints?.map((checkpoint) => checkpoint.category).filter(Boolean) ?? []) as string[]
+  );
+  const missingCheckpointIds = REQUIRED_PRIMARY_DIAGNOSTIC_CHECKPOINT_IDS.filter((id) => !checkpointIds.has(id));
+  const missingCategoryIds = REQUIRED_PRIMARY_DIAGNOSTIC_CATEGORY_IDS.filter((id) => !categoryIds.has(id));
+  const status: GateStatus = missingCheckpointIds.length === 0 && missingCategoryIds.length === 0 ? "pass" : "fail";
+  const failReasons = status === "fail" ? ["primary_client_diagnostic_snapshots_incomplete"] : [];
+  const details = [`checkpoints=${artifact.summary?.checkpointCount ?? artifact.checkpoints?.length ?? 0}`];
+  if (missingCheckpointIds.length > 0) {
+    details.push(`missingCheckpointIds=${missingCheckpointIds.join(",")}`);
+  }
+  if (missingCategoryIds.length > 0) {
+    details.push(`missingCategoryIds=${missingCategoryIds.join(",")}`);
+  }
+
+  return {
+    status,
+    detail: details.join(" | "),
+    evidence: createEvidenceItem({
+      label: "Primary-client diagnostic snapshots",
+      path: artifactPath,
+      status,
+      observedAt: artifact.generatedAt,
+      sourceRevision: artifact.revision?.shortCommit ?? artifact.revision?.commit,
+      summary: details.join(" | "),
+      reasonCodes: failReasons
+    }),
+    failReasons,
+    warnReasons: []
+  };
+}
+
 export function buildBuildPackageGate(
   snapshotSummary: ReturnType<typeof summarizeSnapshot>,
   packageSummary: ReturnType<typeof summarizeWechatPackage>,
@@ -1170,12 +1268,20 @@ async function main(): Promise<void> {
   const outputDefaults = defaultOutputPaths();
   const resolvedSnapshotPath = args.snapshotPath
     ? path.resolve(args.snapshotPath)
-    : resolveLatestJsonFile(DEFAULT_RELEASE_READINESS_DIR);
-  const resolvedCocosRcPath = args.cocosRcPath ? path.resolve(args.cocosRcPath) : resolveLatestJsonFile(DEFAULT_RELEASE_EVIDENCE_DIR);
+    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) => entry.startsWith("release-readiness-"));
+  const resolvedCocosRcPath = args.cocosRcPath
+    ? path.resolve(args.cocosRcPath)
+    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_EVIDENCE_DIR, (entry) => entry.endsWith(".json"));
+  const resolvedPrimaryClientDiagnosticsPath = args.primaryClientDiagnosticsPath
+    ? path.resolve(args.primaryClientDiagnosticsPath)
+    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
+        entry.startsWith("cocos-primary-client-diagnostic-snapshots-")
+      );
   const wechatArtifacts = resolveWechatArtifacts(args);
 
   const snapshot = readJsonFile<ReleaseReadinessSnapshot>(resolvedSnapshotPath);
   const cocosRcSnapshot = readJsonFile<CocosReleaseCandidateSnapshot>(resolvedCocosRcPath);
+  const primaryClientDiagnostics = readJsonFile<PrimaryClientDiagnosticSnapshotsArtifact>(resolvedPrimaryClientDiagnosticsPath);
   const wechatSmokeReport = readJsonFile<WechatSmokeReport>(wechatArtifacts.smokeReportPath);
   const wechatPackageMetadata = readJsonFile<WechatPackageMetadata>(wechatArtifacts.packageMetadataPath);
 
@@ -1209,6 +1315,10 @@ async function main(): Promise<void> {
   const packageSummary = summarizeWechatPackage(wechatArtifacts.packageMetadataPath, wechatPackageMetadata);
   const smokeSummary = summarizeWechatSmoke(wechatArtifacts.smokeReportPath, wechatSmokeReport);
   const cocosRcSummary = summarizeCocosRc(resolvedCocosRcPath, cocosRcSnapshot);
+  const primaryClientDiagnosticsSummary = summarizePrimaryClientDiagnostics(
+    resolvedPrimaryClientDiagnosticsPath,
+    primaryClientDiagnostics
+  );
 
   const gates = [
     buildHealthGate(args.serverUrl, healthPayload, metricsText, healthError ?? metricsError),
@@ -1218,7 +1328,8 @@ async function main(): Promise<void> {
       snapshotSummary.evidence,
       packageSummary.evidence,
       smokeSummary.evidence,
-      cocosRcSummary.evidence
+      cocosRcSummary.evidence,
+      primaryClientDiagnosticsSummary.evidence
     ])
   ];
 
@@ -1231,12 +1342,19 @@ async function main(): Promise<void> {
       candidateRevision: args.candidateRevision,
       snapshot,
       gates,
-      evidence: [snapshotSummary.evidence, packageSummary.evidence, smokeSummary.evidence, cocosRcSummary.evidence]
+      evidence: [
+        snapshotSummary.evidence,
+        packageSummary.evidence,
+        smokeSummary.evidence,
+        cocosRcSummary.evidence,
+        primaryClientDiagnosticsSummary.evidence
+      ]
     }),
     inputs: {
       ...(args.serverUrl ? { serverUrl: args.serverUrl } : {}),
       ...(resolvedSnapshotPath ? { snapshotPath: resolvedSnapshotPath } : {}),
       ...(resolvedCocosRcPath ? { cocosRcPath: resolvedCocosRcPath } : {}),
+      ...(resolvedPrimaryClientDiagnosticsPath ? { primaryClientDiagnosticsPath: resolvedPrimaryClientDiagnosticsPath } : {}),
       ...(args.wechatArtifactsDir ? { wechatArtifactsDir: path.resolve(args.wechatArtifactsDir) } : {}),
       ...(wechatArtifacts.smokeReportPath ? { wechatSmokeReportPath: wechatArtifacts.smokeReportPath } : {}),
       ...(wechatArtifacts.packageMetadataPath ? { wechatPackageMetadataPath: wechatArtifacts.packageMetadataPath } : {}),

--- a/scripts/test/cocos-primary-client-diagnostic-snapshots.test.ts
+++ b/scripts/test/cocos-primary-client-diagnostic-snapshots.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+function createTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test("release:cocos:primary-diagnostics exports versioned JSON and Markdown artifacts with required checkpoints", () => {
+  const workspace = createTempDir("veil-primary-diagnostics-");
+  const outputPath = path.join(workspace, "primary-diagnostics.json");
+  const markdownOutputPath = path.join(workspace, "primary-diagnostics.md");
+
+  const stdout = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/cocos-primary-client-diagnostic-snapshots.ts",
+      "--output",
+      outputPath,
+      "--markdown-output",
+      markdownOutputPath
+    ],
+    {
+      cwd: path.resolve(__dirname, "../.."),
+      encoding: "utf8"
+    }
+  );
+
+  assert.match(stdout, /Wrote primary-client diagnostic JSON:/);
+  assert.match(stdout, /Checkpoint count: 5/);
+
+  const artifact = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    schemaVersion: number;
+    summary: {
+      status: string;
+      checkpointCount: number;
+      categoryIds: string[];
+      checkpointIds: string[];
+    };
+    checkpoints: Array<{
+      id: string;
+      category: string;
+      telemetryCheckpoints: string[];
+      diagnostics: {
+        source: {
+          mode: string;
+        };
+      };
+    }>;
+  };
+
+  assert.equal(artifact.schemaVersion, 1);
+  assert.equal(artifact.summary.status, "passed");
+  assert.equal(artifact.summary.checkpointCount, 5);
+  assert.deepEqual(artifact.summary.categoryIds, ["progression", "inventory", "combat", "reconnect"]);
+  assert.deepEqual(artifact.summary.checkpointIds, [
+    "progression-review",
+    "inventory-overflow",
+    "combat-loop",
+    "reconnect-cached-replay",
+    "reconnect-recovery"
+  ]);
+  assert.deepEqual(
+    artifact.checkpoints.map((checkpoint) => checkpoint.id),
+    artifact.summary.checkpointIds
+  );
+  assert.equal(artifact.checkpoints.find((checkpoint) => checkpoint.id === "combat-loop")?.diagnostics.source.mode, "battle");
+  assert.deepEqual(
+    artifact.checkpoints.find((checkpoint) => checkpoint.id === "inventory-overflow")?.telemetryCheckpoints,
+    ["equipment.equip.rejected", "loot.overflowed"]
+  );
+  assert.equal(fs.existsSync(markdownOutputPath), true);
+  const markdown = fs.readFileSync(markdownOutputPath, "utf8");
+  assert.match(markdown, /# Primary-Client Diagnostic Snapshots/);
+  assert.match(markdown, /reconnect-cached-replay/);
+});


### PR DESCRIPTION
## Summary
- add a versioned primary-client diagnostic snapshot exporter that emits JSON and Markdown release evidence artifacts for progression, inventory, combat-loop, and reconnect checkpoints
- wire the new artifact into the release-readiness dashboard so missing or incomplete evidence fails closed and stale evidence is visible
- document how to generate and inspect the artifact locally and cover the new flow with focused tests

Closes #517