### PR TITLE
test(multiplayer): promote reconnect soak into release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,12 @@ jobs:
             --artifact "${RUNNER_TEMP}/release-readiness/stress-rooms-runtime-metrics-${GITHUB_SHA}.json" \
             --output "${RUNNER_TEMP}/release-readiness/runtime-regression-report-${GITHUB_SHA}.json"
 
+      - name: Capture reconnect soak release-gate artifact
+        if: always()
+        run: |
+          npm run stress:rooms:reconnect-soak -- \
+            --artifact-path "${RUNNER_TEMP}/release-readiness/colyseus-reconnect-soak-summary-${GITHUB_SHA}.json"
+
       - name: Publish coverage summary
         if: always()
         run: |
@@ -355,6 +361,9 @@ jobs:
           )
           if [[ -f "${RUNNER_TEMP}/release-readiness/client-release-candidate-smoke-${GITHUB_SHA}.json" ]]; then
             args+=(--h5-smoke "${RUNNER_TEMP}/release-readiness/client-release-candidate-smoke-${GITHUB_SHA}.json")
+          fi
+          if [[ -f "${RUNNER_TEMP}/runtime-regression/colyseus-reconnect-soak-summary-${GITHUB_SHA}.json" ]]; then
+            args+=(--reconnect-soak "${RUNNER_TEMP}/runtime-regression/colyseus-reconnect-soak-summary-${GITHUB_SHA}.json")
           fi
           if [[ -d "${RUNNER_TEMP}/wechat-release" ]]; then
             args+=(--wechat-artifacts-dir "${RUNNER_TEMP}/wechat-release")

--- a/docs/reconnect-soak-gate.md
+++ b/docs/reconnect-soak-gate.md
@@ -60,6 +60,12 @@ npm run stress:rooms:reconnect-soak -- --artifact-path=artifacts/release-readine
 
 建议 CI 至少把该 JSON artifact 保留到构建产物中，供 release-readiness 记录引用。
 
+`npm run release:gate:summary` 现在会把这份 artifact 作为正式 release gate 输入之一:
+
+- PR / 日常多人回归先看 `npm run test:e2e:multiplayer:smoke`
+- release candidate、shipping 候选包、或 reconnect / 房间恢复语义改动，再额外要求 reconnect soak gate 通过
+- gate 除了检查 reconnect invariant，还会检查 soak 清理后 `activeRoomCount / connectionCount / activeBattleCount / heroCount` 是否回到 `0`
+
 ## When This Must Pass
 
 出现下面任一条件，发版或扩大 playtest 范围前必须重新执行，并且结果必须为 `passed`：

--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -6,6 +6,7 @@ It intentionally reuses the current evidence instead of introducing a parallel g
 
 - `npm run release:readiness:snapshot` for the baseline regression/build gate state
 - `npm run smoke:client:release-candidate` for packaged H5 smoke evidence
+- `npm run stress:rooms:reconnect-soak` for bounded reconnect soak plus room cleanup evidence
 - `npm run validate:wechat-rc` or `npm run smoke:wechat-release -- --check` for WeChat release evidence
 - `configs/.config-center-library.json` for the latest applied config-center publish audit and config change risk summary
 
@@ -23,6 +24,7 @@ Point at explicit artifact paths when CI already produced stable filenames:
 npm run release:gate:summary -- \
   --snapshot artifacts/release-readiness/release-readiness-2026-03-29T08-12-04.512Z.json \
   --h5-smoke artifacts/release-readiness/client-release-candidate-smoke-abc1234-2026-03-29T08-15-10.000Z.json \
+  --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary.json \
   --config-center-library configs/.config-center-library.json \
   --wechat-artifacts-dir artifacts/wechat-release
 ```
@@ -44,12 +46,16 @@ If you do not pass output flags, the script writes:
 
 ## Gate Rules
 
-The summary contains four release dimensions:
+The summary contains five release dimensions:
 
 - `release-readiness`
   - Fails when the snapshot is missing, when the snapshot summary is not `passed`, or when any required snapshot check is `failed` or `pending`.
 - `h5-release-candidate-smoke`
   - Fails when the packaged H5 smoke report is missing, the smoke execution status is not `passed`, or any smoke case failed.
+- `multiplayer-reconnect-soak`
+  - Fails when the reconnect soak artifact is missing, when the soak run itself failed, or when it did not record reconnect attempts plus invariant checks.
+  - Fails closed when the post-soak cleanup counters show lingering active rooms, live connections, active battles, or hero snapshots.
+  - Use this gate for release candidates and reconnect / room-recovery changes; keep `test:e2e:multiplayer:smoke` as the faster PR-level signal for canonical multiplayer link health.
 - `wechat-release`
   - Prefers `codex.wechat.rc-validation-report.json` when present.
   - Falls back to `codex.wechat.smoke-report.json` when the RC validation report is absent.
@@ -65,7 +71,7 @@ Any failed dimension makes the script exit non-zero so the result can act as a C
 
 ## Config Change Risk Summary
 
-Besides the three hard release gates, the report now appends a structured `Config Change Risk Summary` section sourced from the latest `resultStatus=applied` config-center publish audit.
+Besides the four hard release gates, the report now appends a structured `Config Change Risk Summary` section sourced from the latest `resultStatus=applied` config-center publish audit.
 
 Current baseline coverage includes:
 

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -8,6 +8,7 @@ type GateStatus = "passed" | "failed";
 interface Args {
   snapshotPath?: string;
   h5SmokePath?: string;
+  reconnectSoakPath?: string;
   wechatRcValidationPath?: string;
   wechatSmokeReportPath?: string;
   wechatArtifactsDir?: string;
@@ -95,12 +96,12 @@ interface WechatSmokeReport {
 }
 
 interface GateSource {
-  kind: "release-readiness-snapshot" | "h5-release-candidate-smoke" | "wechat-rc-validation" | "wechat-smoke-report";
+  kind: "release-readiness-snapshot" | "h5-release-candidate-smoke" | "reconnect-soak" | "wechat-rc-validation" | "wechat-smoke-report";
   path: string;
 }
 
 interface GateResult {
-  id: "release-readiness" | "h5-release-candidate-smoke" | "wechat-release" | "phase1-evidence-consistency";
+  id: "release-readiness" | "h5-release-candidate-smoke" | "multiplayer-reconnect-soak" | "wechat-release" | "phase1-evidence-consistency";
   label: string;
   status: GateStatus;
   summary: string;
@@ -109,12 +110,39 @@ interface GateResult {
 }
 
 interface Phase1EvidenceReference {
-  gateId: "release-readiness" | "h5-release-candidate-smoke" | "wechat-release";
+  gateId: "release-readiness" | "h5-release-candidate-smoke" | "multiplayer-reconnect-soak" | "wechat-release";
   label: string;
   source: GateSource;
   commit?: string;
   generatedAt?: string;
   candidateHint?: string;
+}
+
+interface ReconnectSoakArtifact {
+  generatedAt?: string;
+  revision?: {
+    commit?: string;
+    shortCommit?: string;
+  };
+  status?: "passed" | "failed";
+  summary?: {
+    failedScenarios?: number;
+    scenarioNames?: string[];
+  };
+  soakSummary?: {
+    reconnectAttempts?: number;
+    invariantChecks?: number;
+  } | null;
+  results?: Array<{
+    scenario?: string;
+    failedRooms?: number;
+    runtimeHealthAfterCleanup?: {
+      activeRoomCount?: number;
+      connectionCount?: number;
+      activeBattleCount?: number;
+      heroCount?: number;
+    };
+  }>;
 }
 
 type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
@@ -193,6 +221,7 @@ interface ReleaseGateSummaryReport {
   inputs: {
     snapshotPath?: string;
     h5SmokePath?: string;
+    reconnectSoakPath?: string;
     wechatRcValidationPath?: string;
     wechatSmokeReportPath?: string;
     wechatArtifactsDir?: string;
@@ -299,6 +328,7 @@ function fail(message: string): never {
 function parseArgs(argv: string[]): Args {
   let snapshotPath: string | undefined;
   let h5SmokePath: string | undefined;
+  let reconnectSoakPath: string | undefined;
   let wechatRcValidationPath: string | undefined;
   let wechatSmokeReportPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
@@ -317,6 +347,11 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--h5-smoke" && next) {
       h5SmokePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--reconnect-soak" && next) {
+      reconnectSoakPath = next;
       index += 1;
       continue;
     }
@@ -357,6 +392,7 @@ function parseArgs(argv: string[]): Args {
   return {
     ...(snapshotPath ? { snapshotPath } : {}),
     ...(h5SmokePath ? { h5SmokePath } : {}),
+    ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
     ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
@@ -409,6 +445,19 @@ function resolveH5SmokePath(args: Args): string | undefined {
   }
   return resolveLatestFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
     entry.startsWith("client-release-candidate-smoke-") && entry.endsWith(".json")
+  );
+}
+
+function resolveReconnectSoakPath(args: Args): string | undefined {
+  if (args.reconnectSoakPath) {
+    return path.resolve(args.reconnectSoakPath);
+  }
+  const fixedCandidate = path.join(DEFAULT_RELEASE_READINESS_DIR, "colyseus-reconnect-soak-summary.json");
+  if (fs.existsSync(fixedCandidate)) {
+    return fixedCandidate;
+  }
+  return resolveLatestFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
+    entry.startsWith("colyseus-reconnect-soak-summary") && entry.endsWith(".json")
   );
 }
 
@@ -572,6 +621,79 @@ export function evaluateH5SmokeGate(h5SmokePath: string | undefined): GateResult
   };
 }
 
+export function evaluateReconnectSoakGate(reconnectSoakPath: string | undefined): GateResult {
+  if (!reconnectSoakPath || !fs.existsSync(reconnectSoakPath)) {
+    return missingGate(
+      "multiplayer-reconnect-soak",
+      "Multiplayer reconnect soak",
+      "Missing multiplayer reconnect soak artifact.",
+      ["Reconnect soak artifact was not found."]
+    );
+  }
+
+  const report = readJsonFile<ReconnectSoakArtifact>(reconnectSoakPath);
+  const failures: string[] = [];
+  const reconnectSoakResult = report.results?.find((entry) => entry.scenario === "reconnect_soak");
+  const cleanup = reconnectSoakResult?.runtimeHealthAfterCleanup;
+
+  if (report.status !== "passed") {
+    failures.push(`Reconnect soak artifact status is ${JSON.stringify(report.status ?? "missing")}.`);
+  }
+  if ((report.summary?.failedScenarios ?? 0) > 0) {
+    failures.push(`Reconnect soak artifact reports ${report.summary?.failedScenarios} failed scenario(s).`);
+  }
+  if (!report.summary?.scenarioNames?.includes("reconnect_soak")) {
+    failures.push("Reconnect soak artifact does not include the reconnect_soak scenario.");
+  }
+  if (!reconnectSoakResult) {
+    failures.push("Reconnect soak result is missing from the artifact.");
+  }
+  if ((reconnectSoakResult?.failedRooms ?? 0) > 0) {
+    failures.push(`Reconnect soak reports ${reconnectSoakResult?.failedRooms} failed room(s).`);
+  }
+  if ((report.soakSummary?.reconnectAttempts ?? 0) <= 0) {
+    failures.push("Reconnect soak artifact did not record any reconnect attempts.");
+  }
+  if ((report.soakSummary?.invariantChecks ?? 0) <= 0) {
+    failures.push("Reconnect soak artifact did not record any invariant checks.");
+  }
+  if (!cleanup) {
+    failures.push("Reconnect soak cleanup counters are missing.");
+  } else {
+    if (cleanup.activeRoomCount !== 0) {
+      failures.push(`Reconnect soak cleanup left ${cleanup.activeRoomCount} active room(s).`);
+    }
+    if (cleanup.connectionCount !== 0) {
+      failures.push(`Reconnect soak cleanup left ${cleanup.connectionCount} live connection(s).`);
+    }
+    if (cleanup.activeBattleCount !== 0) {
+      failures.push(`Reconnect soak cleanup left ${cleanup.activeBattleCount} active battle(s).`);
+    }
+    if (cleanup.heroCount !== 0) {
+      failures.push(`Reconnect soak cleanup left ${cleanup.heroCount} hero snapshot(s) in active rooms.`);
+    }
+  }
+
+  const cleanupSummary = cleanup
+    ? `cleanup rooms=${cleanup.activeRoomCount} connections=${cleanup.connectionCount} battles=${cleanup.activeBattleCount}`
+    : "cleanup counters missing";
+
+  return {
+    id: "multiplayer-reconnect-soak",
+    label: "Multiplayer reconnect soak",
+    status: failures.length === 0 ? "passed" : "failed",
+    summary:
+      failures.length === 0
+        ? `Reconnect soak passed ${report.soakSummary?.reconnectAttempts ?? 0} reconnects and ${report.soakSummary?.invariantChecks ?? 0} invariant checks; ${cleanupSummary}.`
+        : `Reconnect soak gate failed: ${failures[0]}`,
+    failures,
+    source: {
+      kind: "reconnect-soak",
+      path: reconnectSoakPath
+    }
+  };
+}
+
 export function evaluateWechatGate(
   wechatRcValidationPath: string | undefined,
   wechatSmokeReportPath: string | undefined
@@ -710,6 +832,7 @@ function formatEvidenceDescriptor(entry: Phase1EvidenceReference): string {
 function collectPhase1EvidenceReferences(
   snapshotPath: string | undefined,
   h5SmokePath: string | undefined,
+  reconnectSoakPath: string | undefined,
   wechatRcValidationPath: string | undefined,
   wechatSmokeReportPath: string | undefined
 ): Phase1EvidenceReference[] {
@@ -744,6 +867,22 @@ function collectPhase1EvidenceReferences(
       commit,
       generatedAt: report.execution?.finishedAt ?? report.generatedAt,
       candidateHint: deriveCandidateHint(h5SmokePath, commit)
+    });
+  }
+
+  if (reconnectSoakPath && fs.existsSync(reconnectSoakPath)) {
+    const report = readJsonFile<ReconnectSoakArtifact>(reconnectSoakPath);
+    const commit = report.revision?.commit ?? report.revision?.shortCommit;
+    evidence.push({
+      gateId: "multiplayer-reconnect-soak",
+      label: "Multiplayer reconnect soak",
+      source: {
+        kind: "reconnect-soak",
+        path: reconnectSoakPath
+      },
+      commit,
+      generatedAt: report.generatedAt,
+      candidateHint: deriveCandidateHint(reconnectSoakPath, commit)
     });
   }
 
@@ -784,6 +923,7 @@ export function evaluatePhase1EvidenceConsistencyGate(
   revision: GitRevision,
   snapshotPath: string | undefined,
   h5SmokePath: string | undefined,
+  reconnectSoakPath: string | undefined,
   wechatRcValidationPath: string | undefined,
   wechatSmokeReportPath: string | undefined
 ): GateResult {
@@ -791,9 +931,16 @@ export function evaluatePhase1EvidenceConsistencyGate(
   const expectedArtifacts: Array<Pick<Phase1EvidenceReference, "gateId" | "label">> = [
     { gateId: "release-readiness", label: "Release readiness snapshot" },
     { gateId: "h5-release-candidate-smoke", label: "H5 packaged RC smoke" },
+    { gateId: "multiplayer-reconnect-soak", label: "Multiplayer reconnect soak" },
     { gateId: "wechat-release", label: "WeChat release validation" }
   ];
-  const evidence = collectPhase1EvidenceReferences(snapshotPath, h5SmokePath, wechatRcValidationPath, wechatSmokeReportPath);
+  const evidence = collectPhase1EvidenceReferences(
+    snapshotPath,
+    h5SmokePath,
+    reconnectSoakPath,
+    wechatRcValidationPath,
+    wechatSmokeReportPath
+  );
   const expectedCommit = revision.commit;
   const expectedCandidateHint = normalizeCommit(revision.commit)?.slice(0, 12) ?? revision.shortCommit.toLowerCase();
 
@@ -1015,6 +1162,7 @@ export function buildConfigChangeRiskSummary(configCenterLibraryPath: string | u
 export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision): ReleaseGateSummaryReport {
   const snapshotPath = resolveSnapshotPath(args);
   const h5SmokePath = resolveH5SmokePath(args);
+  const reconnectSoakPath = resolveReconnectSoakPath(args);
   const wechatArtifactsDir = resolveWechatArtifactsDir(args);
   const wechatRcValidationPath = resolveWechatRcValidationPath(args, wechatArtifactsDir);
   const wechatSmokeReportPath = resolveWechatSmokeReportPath(args, wechatArtifactsDir);
@@ -1023,8 +1171,16 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
   const gates = [
     evaluateReleaseReadinessGate(snapshotPath),
     evaluateH5SmokeGate(h5SmokePath),
+    evaluateReconnectSoakGate(reconnectSoakPath),
     evaluateWechatGate(wechatRcValidationPath, wechatSmokeReportPath),
-    evaluatePhase1EvidenceConsistencyGate(revision, snapshotPath, h5SmokePath, wechatRcValidationPath, wechatSmokeReportPath)
+    evaluatePhase1EvidenceConsistencyGate(
+      revision,
+      snapshotPath,
+      h5SmokePath,
+      reconnectSoakPath,
+      wechatRcValidationPath,
+      wechatSmokeReportPath
+    )
   ];
   const failedGates = gates.filter((gate) => gate.status === "failed");
 
@@ -1042,6 +1198,7 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
     inputs: {
       ...(snapshotPath ? { snapshotPath } : {}),
       ...(h5SmokePath ? { h5SmokePath } : {}),
+      ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
       ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
       ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
       ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
@@ -1066,6 +1223,7 @@ export function renderMarkdown(report: ReleaseGateSummaryReport): string {
   lines.push("");
   lines.push(`- Snapshot: \`${report.inputs.snapshotPath ? relativeReportPath(report.inputs.snapshotPath) : "<missing>"}\``);
   lines.push(`- H5 smoke: \`${report.inputs.h5SmokePath ? relativeReportPath(report.inputs.h5SmokePath) : "<missing>"}\``);
+  lines.push(`- Reconnect soak: \`${report.inputs.reconnectSoakPath ? relativeReportPath(report.inputs.reconnectSoakPath) : "<missing>"}\``);
   lines.push(`- WeChat validation: \`${report.inputs.wechatRcValidationPath ? relativeReportPath(report.inputs.wechatRcValidationPath) : "<missing>"}\``);
   lines.push(`- WeChat smoke fallback: \`${report.inputs.wechatSmokeReportPath ? relativeReportPath(report.inputs.wechatSmokeReportPath) : "<missing>"}\``);
   lines.push(`- WeChat artifacts dir: \`${report.inputs.wechatArtifactsDir ? relativeReportPath(report.inputs.wechatArtifactsDir) : "<missing>"}\``);

--- a/scripts/stress-concurrent-rooms.ts
+++ b/scripts/stress-concurrent-rooms.ts
@@ -17,7 +17,12 @@ import {
   type SessionStatePayload,
   type Vec2
 } from "../packages/shared/src/index";
-import { configureRoomSnapshotStore, resetLobbyRoomRegistry, VeilColyseusRoom } from "../apps/server/src/colyseus-room";
+import {
+  configureRoomSnapshotStore,
+  getActiveRoomInstances,
+  resetLobbyRoomRegistry,
+  VeilColyseusRoom
+} from "../apps/server/src/colyseus-room";
 import { createMemoryRoomSnapshotStore } from "../apps/server/src/memory-room-snapshot-store";
 import { registerRuntimeObservabilityRoutes, resetRuntimeObservability } from "../apps/server/src/observability";
 import type { RoomSnapshotStore } from "../apps/server/src/persistence";
@@ -76,6 +81,7 @@ interface ScenarioResult {
   peakActiveHandles: number;
   runtimeHealthAfterConnect?: RuntimeHealthSummary;
   runtimeHealthAfterScenario?: RuntimeHealthSummary;
+  runtimeHealthAfterCleanup?: RuntimeHealthSummary;
   soakSummary?: ReconnectSoakSummary;
   errorMessage?: string;
 }
@@ -182,12 +188,16 @@ function toMegabytes(bytes: number): number {
 }
 
 function parseIntegerFlag(name: string, fallback: number): number {
-  const argument = process.argv.findLast((item) => item.startsWith(`--${name}=`));
-  if (!argument) {
+  const inlineArgument = process.argv.findLast((item) => item.startsWith(`--${name}=`));
+  const argumentIndex = process.argv.lastIndexOf(`--${name}`);
+  if (!inlineArgument && argumentIndex === -1) {
     return fallback;
   }
 
-  const value = Number(argument.slice(name.length + 3));
+  const rawValue = inlineArgument
+    ? inlineArgument.slice(name.length + 3)
+    : process.argv[argumentIndex + 1];
+  const value = Number(rawValue);
   if (!Number.isInteger(value) || value <= 0) {
     throw new Error(`--${name} must be a positive integer`);
   }
@@ -196,12 +206,15 @@ function parseIntegerFlag(name: string, fallback: number): number {
 }
 
 function parseStringFlag(name: string, fallback: string): string {
-  const argument = process.argv.findLast((item) => item.startsWith(`--${name}=`));
-  if (!argument) {
+  const inlineArgument = process.argv.findLast((item) => item.startsWith(`--${name}=`));
+  const argumentIndex = process.argv.lastIndexOf(`--${name}`);
+  if (!inlineArgument && argumentIndex === -1) {
     return fallback;
   }
 
-  const value = argument.slice(name.length + 3).trim();
+  const value = (inlineArgument
+    ? inlineArgument.slice(name.length + 3)
+    : process.argv[argumentIndex + 1] ?? "").trim();
   if (!value) {
     throw new Error(`--${name} must not be empty`);
   }
@@ -1072,6 +1085,32 @@ async function runReconnectSoakScenario(
 
 async function cleanupRooms(contexts: RoomContext[]): Promise<void> {
   await Promise.all(contexts.map((context) => closeRoom(context.room).catch(() => undefined)));
+  for (const context of contexts) {
+    const room = getActiveRoomInstances().get(context.roomId) as { disconnect?: () => Promise<unknown> | unknown } | undefined;
+    try {
+      await room?.disconnect?.();
+    } catch {
+      // Best-effort cleanup for soak artifact counters.
+    }
+  }
+}
+
+async function waitForCleanupHealth(host: string, port: number, timeoutMs = 5_000): Promise<RuntimeHealthSummary | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  let latest = await fetchRuntimeHealthSummary(host, port);
+  while (latest && Date.now() < deadline) {
+    if (
+      latest.activeRoomCount === 0 &&
+      latest.connectionCount === 0 &&
+      latest.activeBattleCount === 0 &&
+      latest.heroCount === 0
+    ) {
+      return latest;
+    }
+    await wait(50);
+    latest = await fetchRuntimeHealthSummary(host, port);
+  }
+  return latest;
 }
 
 async function runScenario(scenario: ScenarioName, options: StressOptions, store: RoomSnapshotStore | null): Promise<ScenarioResult> {
@@ -1079,6 +1118,7 @@ async function runScenario(scenario: ScenarioName, options: StressOptions, store
   let contexts: RoomContext[] = [];
   let runtimeHealthAfterConnect: RuntimeHealthSummary | undefined;
   let runtimeHealthAfterScenario: RuntimeHealthSummary | undefined;
+  let result: ScenarioResult | undefined;
 
   try {
     const connected = await connectRooms(options, scenario);
@@ -1097,7 +1137,7 @@ async function runScenario(scenario: ScenarioName, options: StressOptions, store
       completedActions += soak.completedActions;
       runtimeHealthAfterScenario = await fetchRuntimeHealthSummary(options.host, options.port);
       const resources = monitor.stop();
-      return {
+      result = {
         scenario,
         rooms: options.rooms,
         successfulRooms: options.rooms,
@@ -1121,11 +1161,12 @@ async function runScenario(scenario: ScenarioName, options: StressOptions, store
         ...(runtimeHealthAfterConnect ? { runtimeHealthAfterConnect } : {}),
         ...(runtimeHealthAfterScenario ? { runtimeHealthAfterScenario } : {})
       };
+      return result;
     }
     runtimeHealthAfterScenario = await fetchRuntimeHealthSummary(options.host, options.port);
 
     const resources = monitor.stop();
-    return {
+    result = {
       scenario,
       rooms: options.rooms,
       successfulRooms: options.rooms,
@@ -1148,10 +1189,11 @@ async function runScenario(scenario: ScenarioName, options: StressOptions, store
       ...(runtimeHealthAfterConnect ? { runtimeHealthAfterConnect } : {}),
       ...(runtimeHealthAfterScenario ? { runtimeHealthAfterScenario } : {})
     };
+    return result;
   } catch (error) {
     runtimeHealthAfterScenario = await fetchRuntimeHealthSummary(options.host, options.port);
     const resources = monitor.stop();
-    return {
+    result = {
       scenario,
       rooms: options.rooms,
       successfulRooms: 0,
@@ -1175,8 +1217,13 @@ async function runScenario(scenario: ScenarioName, options: StressOptions, store
       ...(runtimeHealthAfterScenario ? { runtimeHealthAfterScenario } : {}),
       errorMessage: error instanceof Error ? error.message : String(error)
     };
+    return result;
   } finally {
     await cleanupRooms(contexts);
+    const runtimeHealthAfterCleanup = await waitForCleanupHealth(options.host, options.port);
+    if (result && runtimeHealthAfterCleanup) {
+      result.runtimeHealthAfterCleanup = runtimeHealthAfterCleanup;
+    }
   }
 }
 
@@ -1193,6 +1240,8 @@ function printSummary(results: ScenarioResult[], options: StressOptions): void {
       failed: result.failedRooms,
       activeRooms: result.runtimeHealthAfterConnect?.activeRoomCount ?? "",
       connections: result.runtimeHealthAfterConnect?.connectionCount ?? "",
+      cleanupRooms: result.runtimeHealthAfterCleanup?.activeRoomCount ?? "",
+      cleanupConnections: result.runtimeHealthAfterCleanup?.connectionCount ?? "",
       actionMsgs: result.runtimeHealthAfterScenario?.actionMessagesTotal ?? "",
       durationMs: result.durationMs,
       roomsPerSec: result.roomsPerSecond,
@@ -1258,7 +1307,15 @@ function emitArtifact(results: ScenarioResult[], options: StressOptions): void {
           worldReconnectCycles: artifact.soakSummary.worldReconnectCycles,
           battleReconnectCycles: artifact.soakSummary.battleReconnectCycles,
           finalBattleRooms: artifact.soakSummary.finalBattleRooms,
-          finalDayRange: artifact.soakSummary.finalDayRange
+          finalDayRange: artifact.soakSummary.finalDayRange,
+          cleanup: soakResult?.runtimeHealthAfterCleanup
+            ? {
+                activeRoomCount: soakResult.runtimeHealthAfterCleanup.activeRoomCount,
+                connectionCount: soakResult.runtimeHealthAfterCleanup.connectionCount,
+                activeBattleCount: soakResult.runtimeHealthAfterCleanup.activeBattleCount,
+                heroCount: soakResult.runtimeHealthAfterCleanup.heroCount
+              }
+            : null
         },
         null,
         2

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   buildConfigChangeRiskSummary,
   buildReleaseGateSummaryReport,
+  evaluateReconnectSoakGate,
   evaluatePhase1EvidenceConsistencyGate,
   evaluateWechatGate,
   renderMarkdown
@@ -25,6 +26,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   const workspace = createTempWorkspace();
   const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
   const wechatArtifactsDir = path.join(workspace, "artifacts", "wechat-release");
   const wechatRcValidationPath = path.join(wechatArtifactsDir, "codex.wechat.rc-validation-report.json");
   const configCenterLibraryPath = path.join(workspace, "configs", ".config-center-library.json");
@@ -67,6 +69,34 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
       passed: 2,
       failed: 0
     }
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-03-29T08:33:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 384,
+      invariantChecks: 2304
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
   });
   writeJson(wechatRcValidationPath, {
     generatedAt: "2026-03-29T08:35:00.000Z",
@@ -121,6 +151,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
     {
       snapshotPath,
       h5SmokePath,
+      reconnectSoakPath,
       wechatArtifactsDir,
       configCenterLibraryPath
     },
@@ -134,9 +165,10 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
 
   assert.equal(report.summary.status, "passed");
   assert.deepEqual(report.summary.failedGateIds, []);
-  assert.equal(report.summary.totalGates, 4);
+  assert.equal(report.summary.totalGates, 5);
   assert.equal(report.gates.every((gate) => gate.status === "passed"), true);
-  assert.equal(report.gates[3]?.id, "phase1-evidence-consistency");
+  assert.equal(report.gates[2]?.id, "multiplayer-reconnect-soak");
+  assert.equal(report.gates[4]?.id, "phase1-evidence-consistency");
   assert.equal(report.configChangeRisk.status, "available");
   assert.equal(report.configChangeRisk.overallRisk, "high");
   assert.equal(report.configChangeRisk.recommendRehearsal, true);
@@ -144,6 +176,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /Overall status: \*\*PASSED\*\*/);
   assert.match(renderMarkdown(report), /## Selected Inputs/);
   assert.match(renderMarkdown(report), /release-readiness-pass\.json/);
+  assert.match(renderMarkdown(report), /colyseus-reconnect-soak-summary-pass\.json/);
   assert.match(renderMarkdown(report), /codex\.wechat\.rc-validation-report\.json/);
   assert.match(renderMarkdown(report), /Config Change Risk Summary/);
   assert.match(renderMarkdown(report), /Recommend rehearsal: yes/);
@@ -153,6 +186,7 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
   const workspace = createTempWorkspace();
   const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-fail.json");
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
   const wechatSmokeReportPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.smoke-report.json");
 
   writeJson(snapshotPath, {
@@ -194,6 +228,34 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
       failed: 0
     }
   });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-03-29T08:33:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 384,
+      invariantChecks: 2304
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
   writeJson(wechatSmokeReportPath, {
     artifact: {
       sourceRevision: "abc123"
@@ -220,6 +282,7 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
     {
       snapshotPath,
       h5SmokePath,
+      reconnectSoakPath,
       wechatSmokeReportPath
     },
     {
@@ -233,8 +296,8 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
   assert.equal(report.summary.status, "failed");
   assert.deepEqual(report.summary.failedGateIds, ["release-readiness", "wechat-release"]);
   assert.match(report.gates[0]?.summary ?? "", /not release-ready/);
-  assert.match(report.gates[2]?.summary ?? "", /blocked/i);
-  assert.match(report.gates[2]?.failures.join("\n") ?? "", /blocked pending device evidence|WeChat smoke case is blocked/);
+  assert.match(report.gates[3]?.summary ?? "", /blocked/i);
+  assert.match(report.gates[3]?.failures.join("\n") ?? "", /blocked pending device evidence|WeChat smoke case is blocked/);
 });
 
 test("evaluateWechatGate prefers RC validation and falls back to smoke report", () => {
@@ -259,10 +322,51 @@ test("evaluateWechatGate prefers RC validation and falls back to smoke report", 
   assert.equal(smokeGate.source?.kind, "wechat-smoke-report");
 });
 
+test("evaluateReconnectSoakGate fails when cleanup leaves active runtime state behind", () => {
+  const workspace = createTempWorkspace();
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-fail.json");
+
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-03-29T08:33:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 384,
+      invariantChecks: 2304
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 1,
+          connectionCount: 2,
+          activeBattleCount: 0,
+          heroCount: 1
+        }
+      }
+    ]
+  });
+
+  const gate = evaluateReconnectSoakGate(reconnectSoakPath);
+  assert.equal(gate.status, "failed");
+  assert.match(gate.summary, /Reconnect soak gate failed/);
+  assert.match(gate.failures.join("\n"), /left 1 active room/);
+  assert.match(gate.failures.join("\n"), /left 2 live connection/);
+});
+
 test("evaluatePhase1EvidenceConsistencyGate fails stale or mismatched candidate evidence", () => {
   const workspace = createTempWorkspace();
   const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
   const wechatRcValidationPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.rc-validation-report.json");
 
   writeJson(snapshotPath, {
@@ -298,6 +402,34 @@ test("evaluatePhase1EvidenceConsistencyGate fails stale or mismatched candidate 
       failed: 0
     }
   });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-03-29T08:33:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 384,
+      invariantChecks: 2304
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
   writeJson(wechatRcValidationPath, {
     generatedAt: "2026-03-29T08:35:00.000Z",
     commit: "abc123",
@@ -317,6 +449,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails stale or mismatched candidate 
     },
     snapshotPath,
     h5SmokePath,
+    reconnectSoakPath,
     wechatRcValidationPath,
     undefined
   );
@@ -331,6 +464,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails when Phase 1 evidence timestam
   const workspace = createTempWorkspace();
   const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
   const wechatRcValidationPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.rc-validation-report.json");
 
   writeJson(snapshotPath, {
@@ -366,6 +500,34 @@ test("evaluatePhase1EvidenceConsistencyGate fails when Phase 1 evidence timestam
       failed: 0
     }
   });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-03-24T08:31:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 384,
+      invariantChecks: 2304
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
   writeJson(wechatRcValidationPath, {
     generatedAt: "2026-03-24T09:00:00.000Z",
     commit: "abc123",
@@ -385,6 +547,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails when Phase 1 evidence timestam
     },
     snapshotPath,
     h5SmokePath,
+    reconnectSoakPath,
     wechatRcValidationPath,
     undefined
   );
@@ -399,6 +562,7 @@ test("buildReleaseGateSummaryReport fails when all artifacts are stale for the c
   const workspace = createTempWorkspace();
   const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
   const wechatRcValidationPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.rc-validation-report.json");
 
   writeJson(snapshotPath, {
@@ -434,6 +598,34 @@ test("buildReleaseGateSummaryReport fails when all artifacts are stale for the c
       failed: 0
     }
   });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-03-29T08:33:00.000Z",
+    revision: {
+      commit: "deadbeef",
+      shortCommit: "deadbee"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 384,
+      invariantChecks: 2304
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
   writeJson(wechatRcValidationPath, {
     generatedAt: "2026-03-29T08:35:00.000Z",
     commit: "deadbeef",
@@ -448,6 +640,7 @@ test("buildReleaseGateSummaryReport fails when all artifacts are stale for the c
     {
       snapshotPath,
       h5SmokePath,
+      reconnectSoakPath,
       wechatRcValidationPath
     },
     {
@@ -460,7 +653,7 @@ test("buildReleaseGateSummaryReport fails when all artifacts are stale for the c
 
   assert.equal(report.summary.status, "failed");
   assert.deepEqual(report.summary.failedGateIds, ["phase1-evidence-consistency"]);
-  assert.match(report.gates[3]?.summary ?? "", /artifact commit deadbeef.*does not match candidate abc123/);
+  assert.match(report.gates[4]?.summary ?? "", /artifact commit deadbeef.*does not match candidate abc123/);
   assert.match(renderMarkdown(report), /Phase 1 evidence consistency/);
 });
 


### PR DESCRIPTION
## Summary
- add reconnect soak as a required release-gate input with cleanup invariants and candidate evidence consistency checks
- record post-cleanup runtime counters in the reconnect soak artifact and make the stress CLI accept both `--flag=value` and `--flag value`
- wire CI to produce the soak artifact and document when to use this release gate versus the existing multiplayer smoke matrix

## Testing
- npm run test:release-gate-summary
- npm run stress:rooms:reconnect-soak -- --rooms=4 --connect-concurrency=2 --action-concurrency=2 --reconnect-cycles=2 --artifact-path=/tmp/projectveil-issue-518-reconnect-soak.json
- npm run typecheck:ci *(currently fails on pre-existing main issues in apps/server/src/admin-console.ts, apps/server/src/dev-server.ts, apps/server/src/observability.ts)*

Closes #518