### PR TITLE
ci(cocos): gate release packaging PRs with diagnostics evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -158,6 +160,30 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
+
+      - name: Detect PRs that touch Cocos release packaging surfaces
+        id: cocos-release-packaging
+        if: github.event_name == 'pull_request'
+        run: |
+          changed_paths="${RUNNER_TEMP}/release-readiness/cocos-release-packaging-changed-paths-${GITHUB_SHA}.txt"
+          mkdir -p "$(dirname "${changed_paths}")"
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" | tee "${changed_paths}"
+
+          touched=false
+          if rg -n \
+            '^(apps/cocos-client/|scripts/cocos-[^/]+|scripts/.*release.*|docs/cocos-[^/]+|apps/cocos-client/build-templates/wechatgame/|apps/cocos-client/test/fixtures/wechatgame-export/|apps/cocos-client/wechat-minigame\.build\.json$)' \
+            "${changed_paths}" >/dev/null; then
+            touched=true
+          fi
+
+          echo "touched=${touched}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "## Cocos Release Packaging PR Detection"
+            echo
+            echo "- Base ref: \`${{ github.base_ref }}\`"
+            echo "- Qualifying paths touched: \`${touched}\`"
+            echo "- Changed-path report: \`${changed_paths}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Check WeChat mini game templates and exported fixture
         run: npm run check:wechat-build
@@ -176,7 +202,19 @@ jobs:
             --markdown-output "${RUNNER_TEMP}/release-readiness/cocos-primary-delivery-audit-${GITHUB_SHA}.md" \
             --github-step-summary "${GITHUB_STEP_SUMMARY}"
 
+      - name: Run primary Cocos client journey regression gate
+        if: always() && github.event_name == 'pull_request' && steps.cocos-release-packaging.outputs.touched == 'true'
+        run: npm run test:cocos:primary-journey
+
+      - name: Capture primary Cocos diagnostics evidence
+        if: always() && github.event_name == 'pull_request' && steps.cocos-release-packaging.outputs.touched == 'true'
+        run: |
+          npm run release:cocos:primary-diagnostics -- \
+            --output "${RUNNER_TEMP}/release-readiness/cocos-primary-client-diagnostics-${GITHUB_SHA}.json" \
+            --markdown-output "${RUNNER_TEMP}/release-readiness/cocos-primary-client-diagnostics-${GITHUB_SHA}.md"
+
       - name: Upload WeChat release artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: wechat-release-${{ github.sha }}
@@ -184,10 +222,65 @@ jobs:
           if-no-files-found: error
 
       - name: Upload primary Cocos delivery audit
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cocos-primary-delivery-audit-${{ github.sha }}
           path: ${{ runner.temp }}/release-readiness/cocos-primary-delivery-audit-${{ github.sha }}.*
+          if-no-files-found: error
+
+      - name: Assemble PR Cocos diagnostics evidence bundle
+        if: always() && github.event_name == 'pull_request' && steps.cocos-release-packaging.outputs.touched == 'true'
+        env:
+          BUNDLE_DIR: ${{ runner.temp }}/release-readiness/cocos-release-packaging-evidence-${{ github.sha }}
+        run: |
+          mkdir -p "${BUNDLE_DIR}"
+
+          changed_paths="${RUNNER_TEMP}/release-readiness/cocos-release-packaging-changed-paths-${GITHUB_SHA}.txt"
+          audit_json="${RUNNER_TEMP}/release-readiness/cocos-primary-delivery-audit-${GITHUB_SHA}.json"
+          audit_md="${RUNNER_TEMP}/release-readiness/cocos-primary-delivery-audit-${GITHUB_SHA}.md"
+          diagnostics_json="${RUNNER_TEMP}/release-readiness/cocos-primary-client-diagnostics-${GITHUB_SHA}.json"
+          diagnostics_md="${RUNNER_TEMP}/release-readiness/cocos-primary-client-diagnostics-${GITHUB_SHA}.md"
+          summary_path="${BUNDLE_DIR}/SUMMARY.md"
+
+          cp "${changed_paths}" "${BUNDLE_DIR}/changed-paths.txt"
+          for candidate in "${audit_json}" "${audit_md}" "${diagnostics_json}" "${diagnostics_md}"; do
+            if [[ -f "${candidate}" ]]; then
+              cp "${candidate}" "${BUNDLE_DIR}/"
+            fi
+          done
+
+          {
+            echo "# Cocos Release Packaging Diagnostics Evidence"
+            echo
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- PR: #${{ github.event.pull_request.number }}"
+            echo "- Trigger: qualifying Cocos release packaging paths changed"
+            echo "- Changed paths: \`changed-paths.txt\`"
+            echo
+            echo "## Expected evidence"
+            if [[ -f "${audit_json}" && -f "${audit_md}" ]]; then
+              echo "- Delivery audit: present"
+            else
+              echo "- Delivery audit: missing. Regressed command: \`npm run audit:cocos-primary-delivery -- --output-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir \\\"\${WECHAT_RELEASE_ARTIFACTS_DIR}\\\" --expect-exported-runtime --expected-revision \\\"\${GITHUB_SHA}\\\"\`"
+            fi
+            if [[ -f "${diagnostics_json}" && -f "${diagnostics_md}" ]]; then
+              echo "- Primary-client diagnostics: present"
+            else
+              echo "- Primary-client diagnostics: missing. Regressed command: \`npm run release:cocos:primary-diagnostics -- --output <json> --markdown-output <md>\`"
+            fi
+            echo
+            echo "Review this bundle before merge when a PR changes release packaging surfaces."
+          } > "${summary_path}"
+
+          cat "${summary_path}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload PR Cocos diagnostics evidence bundle
+        if: always() && github.event_name == 'pull_request' && steps.cocos-release-packaging.outputs.touched == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cocos-release-packaging-evidence-${{ github.sha }}
+          path: ${{ runner.temp }}/release-readiness/cocos-release-packaging-evidence-${{ github.sha }}
           if-no-files-found: error
 
   wechat-release-artifact-smoke:

--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -39,6 +39,13 @@ The audit currently enforces two stable checks:
 
 The command emits a concise JSON plus Markdown summary under `artifacts/release-readiness/` by default, and CI appends the Markdown summary to the GitHub step summary.
 
+For PRs that touch Cocos release-packaging surfaces, GitHub Actions now treats this audit as part of the merge gate. The same run also executes:
+
+- `npm run test:cocos:primary-journey`
+- `npm run release:cocos:primary-diagnostics`
+
+CI then uploads a single reviewer-facing artifact named `cocos-release-packaging-evidence-<sha>`. Its `SUMMARY.md` calls out whether the delivery audit or primary-client diagnostics evidence was missing so regressions are actionable without digging through raw logs first.
+
 ## Primary-Client Diagnostic Snapshots
 
 Generate the structured diagnostic evidence packet before final release review:

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -13,6 +13,9 @@
 - 当前自动化可把已校验导出目录打成确定性的 `tar.gz` 发布包，并输出 sidecar 元数据 `codex.wechat.package.json`
   - sidecar 会记录归档文件名、SHA-256、字节数、导出目录来源，以及归档内文件清单摘要
 - 当前自动化还会运行 `npm run audit:cocos-primary-delivery`，把 primary client 的导出校验与 artifact 校验收口成一份简明 JSON / Markdown 摘要
+- 当 PR 改动 `apps/cocos-client/**`、`scripts/cocos-*`、`scripts/*release*`、`docs/cocos-*` 或微信小游戏打包路径时，CI 会额外运行 `npm run test:cocos:primary-journey` 与 `npm run release:cocos:primary-diagnostics`
+  - 结果会统一上传为 GitHub Actions artifact `cocos-release-packaging-evidence-<sha>`，其中固定包含 `SUMMARY.md`，并在成功时附带 primary delivery audit 与 primary-client diagnostics 的 JSON / Markdown 证据
+  - 若任一证据缺失，`SUMMARY.md` 会明确指出缺失的是 delivery audit 还是 diagnostics artifact，并给出对应回归命令
 - CI 会把上述归档与 sidecar 元数据作为 GitHub Actions artifact `wechat-release-<sha>` 上传，供提审前下载、留档与回滚追溯
 - CI 额外会把刚上传的 artifact 再下载一次，并运行 `npm run verify:wechat-release` 做 artifact 级 smoke 验收
 - GitHub Actions 现支持在 `workflow_dispatch` 时显式开启 `upload`，或推送 `wechat-release-<version>` tag 后自动执行 `miniprogram-ci` 上传
@@ -36,6 +39,7 @@
 - 统一 Cocos RC candidate bundle：`npm run release:cocos-rc:bundle`
 - Primary client delivery checklist：`docs/cocos-primary-client-delivery.md`
 - Primary client delivery audit：`npm run audit:cocos-primary-delivery -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--expected-revision <git-sha>]`
+- PR 包装改动门禁：匹配上述路径时，查看 CI artifact `cocos-release-packaging-evidence-<git-sha>`
 - RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
 - RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
 - WeChat 手工复核 contract 示例：`docs/release-evidence/wechat-release-manual-review.example.json`


### PR DESCRIPTION
## Summary
- detect pull requests that touch Cocos release packaging surfaces inside `wechat-build-validation`
- run the primary-client journey and diagnostics evidence export for qualifying PRs and upload a stable reviewer bundle artifact
- document the new CI gate and evidence artifact in the Cocos/WeChat release docs

## Validation
- python - <<'PY' ... yaml.safe_load(".github/workflows/ci.yml") ... PY
- node --import tsx --test ./apps/cocos-client/test/cocos-primary-delivery-audit.test.ts ./scripts/test/cocos-primary-client-diagnostic-snapshots.test.ts
- npm run test:cocos:primary-journey
- npm run check:wechat-build

Closes #524