### PR TITLE
test(wechat): surface candidate summary artifact

### DIFF
--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -132,6 +132,7 @@
 - `blockers`：显式列出缺失 smoke report、失败校验、待完成 manual review，以及对应 artifact / next command
 - `--manual-checks <json>`：读取显式 manual review 状态；推荐直接从 `docs/release-evidence/wechat-release-manual-review.example.json` 复制当次 candidate 文件
 - `--manual-check <id>:<title>`：临时追加一条 pending manual review
+- `npm run release:wechat:rehearsal` 的 `## Artifacts` 区块会自动列出 `codex.wechat.release-candidate-summary.json` / `.md`，方便 reviewer 或 PR 作者直接复制 `.md` 文件内容到评论区，并将 `.json` 作为结构化证据随 artifact 一起上传
 
 ## 提审前 Smoke Check
 

--- a/scripts/test/wechat-release-rehearsal.test.ts
+++ b/scripts/test/wechat-release-rehearsal.test.ts
@@ -61,4 +61,10 @@ test("release:wechat:rehearsal produces structured + markdown summaries", () => 
   );
   assert.ok(report.summary.artifacts.archivePath?.includes(".tar.gz"));
   assert.ok(report.summary.artifacts.metadataPath?.endsWith(".package.json"));
+  assert.ok(
+    report.summary.artifacts.candidateSummaryJsonPath?.endsWith("codex.wechat.release-candidate-summary.json")
+  );
+  assert.ok(
+    report.summary.artifacts.candidateSummaryMarkdownPath?.endsWith("codex.wechat.release-candidate-summary.md")
+  );
 });

--- a/scripts/wechat-release-rehearsal.ts
+++ b/scripts/wechat-release-rehearsal.ts
@@ -68,6 +68,8 @@ interface DetectedArtifacts {
   validationReportPath?: string;
   smokeReportPath?: string;
   uploadReceiptPath?: string;
+  candidateSummaryJsonPath?: string;
+  candidateSummaryMarkdownPath?: string;
 }
 
 const OUTPUT_LIMIT = 4000;
@@ -283,12 +285,18 @@ function detectArtifacts(artifactsDir: string): DetectedArtifacts {
   const report = entries.find((entry) => entry === "codex.wechat.rc-validation-report.json");
   const smoke = entries.find((entry) => entry === "codex.wechat.smoke-report.json");
   const receipt = entries.find((entry) => entry.endsWith(".upload.json"));
+  const candidateSummaryJson = entries.find((entry) => entry === "codex.wechat.release-candidate-summary.json");
+  const candidateSummaryMarkdown = entries.find((entry) => entry === "codex.wechat.release-candidate-summary.md");
   return {
     ...(archive ? { archivePath: path.join(artifactsDir, archive) } : {}),
     ...(metadata ? { metadataPath: path.join(artifactsDir, metadata) } : {}),
     ...(report ? { validationReportPath: path.join(artifactsDir, report) } : {}),
     ...(smoke ? { smokeReportPath: path.join(artifactsDir, smoke) } : {}),
-    ...(receipt ? { uploadReceiptPath: path.join(artifactsDir, receipt) } : {})
+    ...(receipt ? { uploadReceiptPath: path.join(artifactsDir, receipt) } : {}),
+    ...(candidateSummaryJson ? { candidateSummaryJsonPath: path.join(artifactsDir, candidateSummaryJson) } : {}),
+    ...(candidateSummaryMarkdown
+      ? { candidateSummaryMarkdownPath: path.join(artifactsDir, candidateSummaryMarkdown) }
+      : {})
   };
 }
 
@@ -332,6 +340,12 @@ function renderMarkdown(summary: RehearsalSummary): string {
   }
   if (artifacts.uploadReceiptPath) {
     artifactLines.push(`- Upload Receipt: \`${artifacts.uploadReceiptPath}\``);
+  }
+  if (artifacts.candidateSummaryJsonPath) {
+    artifactLines.push(`- Candidate Summary (JSON): \`${artifacts.candidateSummaryJsonPath}\``);
+  }
+  if (artifacts.candidateSummaryMarkdownPath) {
+    artifactLines.push(`- Candidate Summary (Markdown): \`${artifacts.candidateSummaryMarkdownPath}\``);
   }
   if (artifactLines.length > 0) {
     lines.push("\n## Artifacts\n\n");


### PR DESCRIPTION
## Summary
- surface the release candidate summary JSON/Markdown paths in the release rehearsal artifact list so reviewers can grab them directly
- document that release rehearsal surfaces codex.wechat.release-candidate-summary files for PR reviews
- extend the release rehearsal test to guard the new artifact detection

## Testing
- node --import tsx --test scripts/test/wechat-release-rehearsal.test.ts
- node --import tsx --test scripts/test/wechat-release-artifacts.test.ts

Closes #528