### PR TITLE
ci(release): fail when dashboard evidence drifts across candidate revisions

### DIFF
--- a/.github/workflows/release-readiness-history.yml
+++ b/.github/workflows/release-readiness-history.yml
@@ -278,7 +278,6 @@ jobs:
           npm run release:gate:summary -- "${args[@]}"
 
       - name: Build release readiness dashboard
-        continue-on-error: true
         env:
           SOURCE_SHA: ${{ steps.source.outputs.head-sha }}
         run: |

--- a/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
@@ -197,8 +197,10 @@ test("buildGoNoGoReport marks a candidate blocked when linked evidence revisions
     },
     cases: [{ id: "login-lobby", status: "passed" }]
   });
+  const criticalEvidenceGate = buildCriticalEvidenceGate(14, [snapshotSummary.evidence, smokeSummary.evidence]);
   const goNoGo = buildGoNoGoReport({
     candidateRevision: "abc1234",
+    maxEvidenceAgeDays: 14,
     snapshot: {
       summary: {
         requiredFailed: 0,
@@ -206,12 +208,69 @@ test("buildGoNoGoReport marks a candidate blocked when linked evidence revisions
       }
     },
     gates: [],
-    evidence: [snapshotSummary.evidence, smokeSummary.evidence]
+    evidence: criticalEvidenceGate.evidence
   });
 
   assert.equal(goNoGo.decision, "blocked");
   assert.equal(goNoGo.revisionStatus, "mismatch");
   assert.deepEqual(goNoGo.blockers, ["candidate_revision_mismatch"]);
+  assert.equal(goNoGo.candidateConsistencyFindings[0]?.path, "/tmp/codex.wechat.smoke-report.json");
+  assert.match(goNoGo.candidateConsistencyFindings[0]?.summary ?? "", /Expected candidate revision abc1234/);
   assert.equal(goNoGo.evidence[0]?.matchesCandidate, true);
   assert.equal(goNoGo.evidence[1]?.matchesCandidate, false);
+});
+
+test("buildGoNoGoReport blocks explicit candidate pinning when evidence metadata is missing or stale", () => {
+  const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
+    generatedAt: "2026-03-01T00:00:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
+    summary: {
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
+    },
+    checks: [
+      { id: "npm-test", status: "passed", required: true },
+      { id: "typecheck-ci", status: "passed", required: true },
+      { id: "e2e-smoke", status: "passed", required: true },
+      { id: "e2e-multiplayer-smoke", status: "passed", required: true },
+      { id: "cocos-primary-journey", status: "passed", required: true },
+      { id: "wechat-build-check", status: "passed", required: true }
+    ]
+  });
+  const smokeSummary = summarizeWechatSmoke("/tmp/codex.wechat.smoke-report.json", {
+    execution: {
+      result: "passed",
+      executedAt: "2026-03-30T00:05:00.000Z"
+    },
+    cases: [{ id: "login-lobby", status: "passed" }]
+  });
+  const criticalEvidenceGate = buildCriticalEvidenceGate(14, [snapshotSummary.evidence, smokeSummary.evidence]);
+
+  const goNoGo = buildGoNoGoReport({
+    candidateRevision: "abc1234",
+    maxEvidenceAgeDays: 14,
+    snapshot: {
+      summary: {
+        requiredFailed: 0,
+        requiredPending: 0
+      }
+    },
+    gates: [],
+    evidence: criticalEvidenceGate.evidence
+  });
+
+  assert.equal(goNoGo.decision, "blocked");
+  assert.deepEqual(goNoGo.blockers, [
+    "candidate_revision_metadata_missing",
+    "candidate_evidence_stale"
+  ]);
+  assert.deepEqual(
+    goNoGo.candidateConsistencyFindings.map((finding) => finding.code),
+    ["candidate_revision_metadata_missing", "candidate_evidence_stale"]
+  );
+  assert.match(goNoGo.candidateConsistencyFindings[0]?.summary ?? "", /missing revision metadata/);
+  assert.match(goNoGo.candidateConsistencyFindings[1]?.summary ?? "", /older than the 14-day freshness window/);
 });

--- a/apps/cocos-client/test/release-readiness-dashboard.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard.test.ts
@@ -307,32 +307,41 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
     ]
   });
 
-  const output = execFileSync(
-    "node",
-    [
-      "--import",
-      "tsx",
-      "./scripts/release-readiness-dashboard.ts",
-      "--snapshot",
-      snapshotPath,
-      "--wechat-artifacts-dir",
-      wechatArtifactsDir,
-      "--candidate-revision",
-      "abc1234",
-      "--output",
-      outputPath,
-      "--markdown-output",
-      markdownOutputPath
-    ],
-    {
-      cwd: path.resolve(__dirname, "../../.."),
-      encoding: "utf8",
-      stdio: "pipe"
-    }
-  );
+  let output = "";
+  try {
+    output = execFileSync(
+      "node",
+      [
+        "--import",
+        "tsx",
+        "./scripts/release-readiness-dashboard.ts",
+        "--snapshot",
+        snapshotPath,
+        "--wechat-artifacts-dir",
+        wechatArtifactsDir,
+        "--candidate-revision",
+        "abc1234",
+        "--output",
+        outputPath,
+        "--markdown-output",
+        markdownOutputPath
+      ],
+      {
+        cwd: path.resolve(__dirname, "../../.."),
+        encoding: "utf8",
+        stdio: "pipe"
+      }
+    );
+    assert.fail("expected the dashboard command to exit non-zero");
+  } catch (error) {
+    const execError = error as NodeJS.ErrnoException & { stdout?: string; status?: number };
+    assert.equal(execError.status, 1);
+    output = execError.stdout ?? "";
+  }
 
   assert.match(output, /Overall status: fail/);
   assert.match(output, /Go\/No-Go decision: blocked/);
+  assert.match(output, /Candidate consistency: Expected candidate revision abc1234, but WeChat package metadata is missing revision metadata/);
   const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
     overallStatus: string;
     goNoGo: {
@@ -341,6 +350,7 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
       requiredPending: number;
       revisionStatus: string;
       blockers: string[];
+      candidateConsistencyFindings: Array<{ code: string; path: string; summary: string }>;
     };
     gates: Array<{
       id: string;
@@ -356,6 +366,8 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
   assert.equal(report.goNoGo.requiredPending, 0);
   assert.equal(report.goNoGo.revisionStatus, "aligned");
   assert.equal(report.goNoGo.blockers.includes("requiredFailed=1"), true);
+  assert.equal(report.goNoGo.blockers.includes("candidate_revision_metadata_missing"), true);
+  assert.equal(report.goNoGo.candidateConsistencyFindings.some((finding) => finding.path === packageMetadataPath), true);
   assert.deepEqual(
     report.gates.map((gate) => [gate.id, gate.status]),
     [

--- a/docs/release-readiness-dashboard.md
+++ b/docs/release-readiness-dashboard.md
@@ -51,6 +51,12 @@ If you want the report to pin all automated and manual evidence to one explicit 
 npm run release:readiness:dashboard -- --candidate-revision <git-sha>
 ```
 
+When `--candidate-revision` is set, the command becomes an enforcing candidate-consistency check for the required local evidence set. It still writes the JSON + Markdown dashboard, but exits non-zero if any linked artifact:
+
+- reports a different revision than the pinned candidate
+- omits revision metadata, so the candidate cannot be verified end to end
+- is older than `--max-evidence-age-days`, missing a timestamp, or carries an invalid timestamp
+
 ## Gate Mapping
 
 The report starts with one `go/no-go` section:
@@ -61,6 +67,7 @@ The report starts with one `go/no-go` section:
   - no blocking failures exist, but required checks are still pending, some evidence is stale / missing a timestamp, live/manual checks were not run, or the candidate revision cannot yet be verified across the linked evidence.
 - `blocked`
   - one or more required checks failed, a gate failed, or linked artifact revisions disagree on which candidate is under review.
+  - when `--candidate-revision` is supplied, `blocked` also covers required evidence with missing revision metadata or freshness that cannot be verified inside the configured window.
 
 After that, the report summarizes the same four bounded gates:
 
@@ -120,7 +127,10 @@ npm run dev:server
 ```bash
 npm run release:readiness:dashboard -- \
   --server-url http://127.0.0.1:2567 \
-  --wechat-artifacts-dir artifacts/wechat-release
+  --wechat-artifacts-dir artifacts/wechat-release \
+  --candidate-revision <git-sha>
 ```
+
+Use the same `<git-sha>` across the snapshot, WeChat package/smoke artifacts, Cocos RC snapshot, and primary-client diagnostics generation flow. If one artifact drifts to another revision or goes stale, the dashboard now prints the exact artifact path plus the observed/expected revision mismatch before exiting non-zero.
 
 The Markdown output is intended to be attachable to issue/PR discussion, while the JSON output is intended for automation or later aggregation. Both formats now expose the same candidate-level `goNoGo` block so reviewers do not need to stitch the final Phase 1 release call together by hand.

--- a/scripts/release-readiness-dashboard.ts
+++ b/scripts/release-readiness-dashboard.ts
@@ -194,7 +194,24 @@ interface GoNoGoReport {
   requiredPending: number;
   blockers: string[];
   pending: string[];
+  candidateConsistencyFindings: CandidateConsistencyFinding[];
   evidence: GoNoGoEvidenceRef[];
+}
+
+type CandidateConsistencyFindingCode =
+  | "candidate_revision_mismatch"
+  | "candidate_revision_metadata_missing"
+  | "candidate_evidence_stale";
+
+interface CandidateConsistencyFinding {
+  code: CandidateConsistencyFindingCode;
+  label: string;
+  path: string;
+  summary: string;
+  expectedRevision?: string;
+  observedRevision?: string;
+  observedAt?: string;
+  freshness?: EvidenceFreshness;
 }
 
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
@@ -1112,6 +1129,7 @@ function buildOverallSummary(gates: GateReport[]): string {
 
 export function buildGoNoGoReport(input: {
   candidateRevision?: string;
+  maxEvidenceAgeDays: number;
   snapshot: ReleaseReadinessSnapshot | undefined;
   gates: GateReport[];
   evidence: Array<EvidenceItem | undefined>;
@@ -1131,10 +1149,58 @@ export function buildGoNoGoReport(input: {
   const knownRevisions = goNoGoEvidence
     .map((entry) => entry.sourceRevision?.trim())
     .filter((entry): entry is string => Boolean(entry));
-  const candidateRevision = resolveCandidateRevision(input.candidateRevision, knownRevisions);
+  const expectedCandidateRevision = input.candidateRevision?.trim();
+  const candidateRevision = resolveCandidateRevision(expectedCandidateRevision, knownRevisions);
   const mismatchedEvidence = candidateRevision
     ? goNoGoEvidence.filter((entry) => entry.sourceRevision && !revisionsMatch(candidateRevision, entry.sourceRevision))
     : [];
+  const candidateConsistencyFindings: CandidateConsistencyFinding[] = [
+    ...mismatchedEvidence.map((entry) => ({
+      code: "candidate_revision_mismatch" as const,
+      label: entry.label,
+      path: entry.path,
+      summary: `Expected candidate revision ${candidateRevision}, but ${entry.label} reports ${entry.sourceRevision ?? "<missing>"}.`,
+      expectedRevision: candidateRevision,
+      observedRevision: entry.sourceRevision,
+      observedAt: entry.observedAt,
+      freshness: entry.freshness
+    })),
+    ...(expectedCandidateRevision
+      ? goNoGoEvidence
+          .filter((entry) => entry.availability === "present" && !entry.sourceRevision?.trim())
+          .map((entry) => ({
+            code: "candidate_revision_metadata_missing" as const,
+            label: entry.label,
+            path: entry.path,
+            summary: `Expected candidate revision ${expectedCandidateRevision}, but ${entry.label} is missing revision metadata.`,
+            expectedRevision: expectedCandidateRevision,
+            observedAt: entry.observedAt,
+            freshness: entry.freshness
+          }))
+      : []),
+    ...(expectedCandidateRevision
+      ? goNoGoEvidence
+          .filter((entry) =>
+            entry.availability === "present" &&
+            (entry.freshness === "stale" || entry.freshness === "missing_timestamp" || entry.freshness === "invalid_timestamp")
+          )
+          .map((entry) => ({
+            code: "candidate_evidence_stale" as const,
+            label: entry.label,
+            path: entry.path,
+            summary:
+              entry.freshness === "stale"
+                ? `${entry.label} is older than the ${input.maxEvidenceAgeDays}-day freshness window for candidate ${expectedCandidateRevision}.`
+                : entry.freshness === "missing_timestamp"
+                  ? `${entry.label} is missing a timestamp, so candidate ${expectedCandidateRevision} freshness cannot be verified.`
+                  : `${entry.label} has an invalid timestamp (${entry.observedAt ?? "<missing>"}), so candidate ${expectedCandidateRevision} freshness cannot be verified.`,
+            expectedRevision: expectedCandidateRevision,
+            observedRevision: entry.sourceRevision,
+            observedAt: entry.observedAt,
+            freshness: entry.freshness
+          }))
+      : [])
+  ];
   const revisionStatus: RevisionStatus =
     mismatchedEvidence.length > 0 ? "mismatch" : candidateRevision ? "aligned" : "unknown";
 
@@ -1142,7 +1208,7 @@ export function buildGoNoGoReport(input: {
   const pendingGates = input.gates.filter((gate) => gate.status === "warn").map((gate) => gate.label);
   const blockers = [
     ...(snapshotCounts.requiredFailed > 0 ? [`requiredFailed=${snapshotCounts.requiredFailed}`] : []),
-    ...(revisionStatus === "mismatch" ? ["candidate_revision_mismatch"] : []),
+    ...[...new Set(candidateConsistencyFindings.map((finding) => finding.code))],
     ...blockingGates
   ];
   const pending = [
@@ -1167,6 +1233,7 @@ export function buildGoNoGoReport(input: {
     requiredPending: snapshotCounts.requiredPending,
     blockers,
     pending,
+    candidateConsistencyFindings,
     evidence: goNoGoEvidence.map((entry) => ({
       ...entry,
       ...(candidateRevision && entry.sourceRevision ? { matchesCandidate: revisionsMatch(candidateRevision, entry.sourceRevision) } : {})
@@ -1201,6 +1268,12 @@ function renderMarkdown(report: DashboardReport): string {
   }
   if (report.goNoGo.pending.length > 0) {
     lines.push(`- Pending: ${report.goNoGo.pending.join(", ")}`);
+  }
+  if (report.goNoGo.candidateConsistencyFindings.length > 0) {
+    lines.push("- Candidate consistency findings:");
+    for (const finding of report.goNoGo.candidateConsistencyFindings) {
+      lines.push(`  - ${finding.summary} (${finding.path})`);
+    }
   }
   if (report.goNoGo.evidence.length > 0) {
     lines.push("- Evidence:");
@@ -1320,17 +1393,19 @@ async function main(): Promise<void> {
     primaryClientDiagnostics
   );
 
+  const criticalEvidenceGate = buildCriticalEvidenceGate(args.maxEvidenceAgeDays, [
+    snapshotSummary.evidence,
+    packageSummary.evidence,
+    smokeSummary.evidence,
+    cocosRcSummary.evidence,
+    primaryClientDiagnosticsSummary.evidence
+  ]);
+
   const gates = [
     buildHealthGate(args.serverUrl, healthPayload, metricsText, healthError ?? metricsError),
     buildAuthGate(args.serverUrl, authPayload, authError),
     buildBuildPackageGate(snapshotSummary, packageSummary, smokeSummary),
-    buildCriticalEvidenceGate(args.maxEvidenceAgeDays, [
-      snapshotSummary.evidence,
-      packageSummary.evidence,
-      smokeSummary.evidence,
-      cocosRcSummary.evidence,
-      primaryClientDiagnosticsSummary.evidence
-    ])
+    criticalEvidenceGate
   ];
 
   const report: DashboardReport = {
@@ -1340,15 +1415,10 @@ async function main(): Promise<void> {
     summary: buildOverallSummary(gates),
     goNoGo: buildGoNoGoReport({
       candidateRevision: args.candidateRevision,
+      maxEvidenceAgeDays: args.maxEvidenceAgeDays,
       snapshot,
       gates,
-      evidence: [
-        snapshotSummary.evidence,
-        packageSummary.evidence,
-        smokeSummary.evidence,
-        cocosRcSummary.evidence,
-        primaryClientDiagnosticsSummary.evidence
-      ]
+      evidence: criticalEvidenceGate.evidence
     }),
     inputs: {
       ...(args.serverUrl ? { serverUrl: args.serverUrl } : {}),
@@ -1376,8 +1446,14 @@ async function main(): Promise<void> {
   console.log(`Required failed: ${report.goNoGo.requiredFailed}`);
   console.log(`Required pending: ${report.goNoGo.requiredPending}`);
   console.log(`Candidate revision: ${report.goNoGo.candidateRevision ?? "<unverified>"}`);
+  for (const finding of report.goNoGo.candidateConsistencyFindings) {
+    console.log(`! Candidate consistency: ${finding.summary} (${toRelativePath(path.resolve(finding.path))})`);
+  }
   for (const gate of report.gates) {
     console.log(`- ${gate.label}: ${gate.status} (${gate.summary})`);
+  }
+  if (report.goNoGo.candidateConsistencyFindings.length > 0) {
+    process.exitCode = 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- make the release-readiness dashboard enforce explicit candidate pinning by blocking on revision mismatches, missing revision metadata, and stale/unverifiable required evidence
- surface artifact-specific candidate consistency findings in the dashboard JSON, Markdown, and CLI output, and make the release-readiness-history workflow fail on those findings
- document the pinned-candidate flow and cover the new behavior with dashboard unit and CLI tests

## Testing
- node --import tsx --test ./apps/cocos-client/test/release-readiness-dashboard.test.ts ./apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts

Closes #527