### PR TITLE
feat(ux): add player battle report center and replay summary flow

### DIFF
--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -1,5 +1,6 @@
 import {
   buildAchievementUiItems,
+  buildPlayerBattleReportCenter,
   groupAchievementUiItems,
   buildBattleReplayTimeline,
   createBattleReplayPlaybackState,
@@ -202,26 +203,29 @@ function formatBattleRewardChip(
   return reward.amount != null ? `${reward.label} +${reward.amount}` : reward.label;
 }
 
-function collectBattleReportEventLogEntries(
+function resolveBattleReportCenter(account: PlayerAccountProfile) {
+  return account.battleReportCenter && account.battleReportCenter.items.length > 0
+    ? account.battleReportCenter
+    : buildPlayerBattleReportCenter(account.recentBattleReplays, account.recentEventLog);
+}
+
+function resolveBattleReportSummary(
   account: PlayerAccountProfile,
   replay: PlayerAccountProfile["recentBattleReplays"][number]
-): PlayerAccountProfile["recentEventLog"] {
-  const startedAtMs = toTimestampMs(replay.startedAt);
-  const completedAtMs = toTimestampMs(replay.completedAt);
-  const fallbackEntries = account.recentEventLog.filter(
-    (entry) => entry.category === "combat" && entry.roomId === replay.roomId && (!entry.heroId || entry.heroId === replay.heroId)
-  );
-  const boundedEntries = fallbackEntries.filter((entry) => {
-    const timestamp = toTimestampMs(entry.timestamp);
-    if (timestamp == null || startedAtMs == null || completedAtMs == null) {
-      return true;
-    }
+) {
+  return resolveBattleReportCenter(account).items.find((report) => report.id === replay.id) ?? null;
+}
 
-    return timestamp >= startedAtMs && timestamp <= completedAtMs + 2 * 60 * 1000;
-  });
+function formatBattleReportEncounter(input: {
+  battleKind: PlayerAccountProfile["recentBattleReplays"][number]["battleKind"];
+  opponentHeroId?: string;
+  neutralArmyId?: string;
+}): string {
+  if (input.battleKind === "hero") {
+    return input.opponentHeroId ? `敌方英雄 ${input.opponentHeroId}` : "敌方英雄";
+  }
 
-  const candidates = boundedEntries.length > 0 ? boundedEntries : fallbackEntries;
-  return candidates.sort((left, right) => String(right.timestamp).localeCompare(String(left.timestamp)));
+  return input.neutralArmyId ? `中立守军 ${input.neutralArmyId}` : "中立守军";
 }
 
 function summarizeBattleReplayCasualties(
@@ -268,23 +272,9 @@ function renderBattleReplayReportSummary(
   account: PlayerAccountProfile,
   replay: PlayerAccountProfile["recentBattleReplays"][number]
 ): string {
-  const eventEntries = collectBattleReportEventLogEntries(account, replay);
-  const rewards = eventEntries.flatMap((entry) => entry.rewards);
-  const uniqueRewards = rewards.filter(
-    (reward, index, list) =>
-      index ===
-      list.findIndex(
-        (candidate) =>
-          candidate.type === reward.type && candidate.label === reward.label && (candidate.amount ?? null) === (reward.amount ?? null)
-      )
-  );
-  const rewardNotes = eventEntries
-    .filter((entry) => entry.worldEventType === "hero.progressed" || entry.worldEventType === "hero.equipmentFound")
-    .map((entry) => entry.description);
+  const report = resolveBattleReportSummary(account, replay);
   const casualties = summarizeBattleReplayCasualties(replay);
-  const didPlayerWin =
-    (replay.playerCamp === "attacker" && replay.result === "attacker_victory") ||
-    (replay.playerCamp === "defender" && replay.result === "defender_victory");
+  const didPlayerWin = report ? report.result === "victory" : false;
   const playerLosses = replay.playerCamp === "attacker" ? casualties.attackerLosses : casualties.defenderLosses;
   const enemyLosses = replay.playerCamp === "attacker" ? casualties.defenderLosses : casualties.attackerLosses;
   const playerDefeatedStacks =
@@ -297,8 +287,9 @@ function renderBattleReplayReportSummary(
       <strong>结果概览</strong>
       <p>${escapeHtml(`${didPlayerWin ? "本场获胜" : "本场失利"} · ${formatBattleReplayCamp(replay)} · ${formatBattleReplayKind(replay)}`)}</p>
       <div class="account-replay-meta">
-        <span>对阵 ${escapeHtml(formatBattleReplayEncounter(replay))}</span>
-        <span>步数 ${replay.steps.length}</span>
+        <span>对阵 ${escapeHtml(report ? formatBattleReportEncounter(report) : formatBattleReplayEncounter(replay))}</span>
+        <span>${escapeHtml(`回合 ${report?.turnCount ?? Math.max(1, replay.initialState.round)}`)}</span>
+        <span>${escapeHtml(`步数 ${report?.actionCount ?? replay.steps.length}`)}</span>
       </div>
     </div>
     <div class="account-replay-summary-card">
@@ -312,20 +303,18 @@ function renderBattleReplayReportSummary(
     <div class="account-replay-summary-card">
       <strong>战后收益</strong>
       ${
-        uniqueRewards.length > 0
-          ? `<div class="account-event-rewards">${uniqueRewards
+        (report?.rewards.length ?? 0) > 0
+          ? `<div class="account-event-rewards">${(report?.rewards ?? [])
               .map((reward) => `<span class="account-reward-chip">${escapeHtml(formatBattleRewardChip(reward))}</span>`)
               .join("")}</div>`
-          : '<p class="account-meta">近期事件日志里未记录额外奖励。</p>'
+          : `<p class="account-meta">${
+              report?.evidence.rewards === "available" ? "收益证据同步中。" : "近期事件日志里未记录额外奖励。"
+            }</p>`
       }
-      ${
-        rewardNotes.length > 0
-          ? `<div class="account-replay-summary-notes">${rewardNotes
-              .slice(0, 2)
-              .map((note) => `<span class="account-meta">${escapeHtml(note)}</span>`)
-              .join("")}</div>`
-          : ""
-      }
+      <div class="account-replay-summary-notes">
+        <span class="account-meta">${escapeHtml(`回放证据 ${report?.evidence.replay === "available" ? "可用" : "缺失"}`)}</span>
+        <span class="account-meta">${escapeHtml(`收益证据 ${report?.evidence.rewards === "available" ? "可用" : "缺失"}`)}</span>
+      </div>
     </div>
   </div>`;
 }
@@ -448,36 +437,38 @@ export function renderRecentBattleReplays(
     selectedReplayId?: string | null;
   } = {}
 ): string {
-  if (account.recentBattleReplays.length === 0) {
+  const reportCenter = resolveBattleReportCenter(account);
+  if (reportCenter.items.length === 0) {
     return '<div class="account-subsection"><strong>最近战报</strong><p class="account-meta">尚未记录可回看的战斗摘要。</p></div>';
   }
 
-  const visibleReplays = account.recentBattleReplays.slice(0, 6);
+  const visibleReports = reportCenter.items.slice(0, 6);
   return `<div class="account-subsection">
     <strong>最近战报</strong>
-    <p class="account-meta">最近 ${visibleReplays.length} 场战斗的回放摘要</p>
+    <p class="account-meta">最近 ${visibleReports.length} 场战斗的结算摘要</p>
     <div class="account-replay-list">
-      ${visibleReplays
-        .map((replay) => {
-          const stepSummary = summarizeBattleReplaySteps(replay);
-          const isSelected = options.selectedReplayId === replay.id;
+      ${visibleReports
+        .map((report) => {
+          const isSelected = options.selectedReplayId === report.id;
           const summaryChips = [
-            `回放 ${replay.steps.length} 步`,
-            `玩家 ${stepSummary.player}`,
-            `自动 ${stepSummary.automated}`,
-            stepSummary.attack > 0 ? `攻击 ${stepSummary.attack}` : "",
-            stepSummary.skill > 0 ? `技能 ${stepSummary.skill}` : ""
+            `${report.turnCount} 回合`,
+            `${report.actionCount} 步`,
+            report.evidence.replay === "available" ? "可回放" : "无回放",
+            ...(report.rewards.slice(0, 2).map((reward) => formatBattleRewardChip(reward)) || []),
+            report.rewards.length === 0 ? "暂无额外奖励" : ""
           ].filter(Boolean);
-          return `<button type="button" class="account-replay-entry ${replay.result === "attacker_victory" ? "is-victory" : "is-defeat"} ${isSelected ? "is-selected" : ""}" data-select-replay="${escapeHtml(replay.id)}">
+          return `<button type="button" class="account-replay-entry ${report.result === "victory" ? "is-victory" : "is-defeat"} ${isSelected ? "is-selected" : ""}" data-select-replay="${escapeHtml(report.id)}">
             <div class="account-replay-head">
-              <span class="account-badge tone-${replay.result === "attacker_victory" ? "victory" : "defeat"}">${escapeHtml(formatBattleReplayResultLabel(replay))}</span>
-              <span>${escapeHtml(formatTimestamp(replay.completedAt))}</span>
+              <span class="account-badge tone-${report.result === "victory" ? "victory" : "defeat"}">${escapeHtml(
+                report.result === "victory" ? "胜利" : "失利"
+              )}</span>
+              <span>${escapeHtml(formatTimestamp(report.completedAt))}</span>
             </div>
-            <p>${escapeHtml(`${formatBattleReplayKind(replay)} · ${formatBattleReplayEncounter(replay)}`)}</p>
+            <p>${escapeHtml(`${report.battleKind === "hero" ? "PVP" : "PVE"} · ${formatBattleReportEncounter(report)}`)}</p>
             <div class="account-replay-meta">
-              <span>房间 ${escapeHtml(replay.roomId)}</span>
-              <span>阵营 ${escapeHtml(formatBattleReplayCamp(replay))}</span>
-              <span>英雄 ${escapeHtml(replay.heroId)}</span>
+              <span>房间 ${escapeHtml(report.roomId)}</span>
+              <span>阵营 ${escapeHtml(report.playerCamp === "attacker" ? "攻方" : "守方")}</span>
+              <span>英雄 ${escapeHtml(report.heroId)}</span>
             </div>
             <div class="account-event-rewards">${summaryChips
               .map((chip) => `<span class="account-reward-chip">${escapeHtml(chip)}</span>`)
@@ -497,12 +488,13 @@ export function renderBattleReportReplayCenter(input: {
   loading?: boolean;
   status?: string;
 }): string {
-  const replayCount = input.account.recentBattleReplays.length;
-  const latestReplay = input.account.recentBattleReplays[0] ?? null;
-  const focusReplayId = input.selectedReplayId?.trim() || latestReplay?.id || null;
+  const reportCenter = resolveBattleReportCenter(input.account);
+  const replayCount = reportCenter.items.length;
+  const latestReport = reportCenter.items[0] ?? null;
+  const focusReplayId = input.selectedReplayId?.trim() || latestReport?.id || null;
   const headline =
     replayCount > 0
-      ? `最近累计 ${replayCount} 场战斗，支持从列表进入详情或基础回放。`
+      ? `最近累计 ${replayCount} 份战报，支持从列表进入详情或基础回放。`
       : "暂无可回看的战斗记录，完成一场战斗后这里会自动出现首批战报。";
 
   return `<section class="account-subsection account-replay-center" data-testid="battle-report-center">
@@ -517,15 +509,15 @@ export function renderBattleReportReplayCenter(input: {
       <button
         type="button"
         class="account-replay-entry-point is-primary"
-        ${latestReplay ? `data-select-replay="${escapeHtml(latestReplay.id)}"` : "disabled"}
-      >${latestReplay ? "查看最新战报" : "等待首场战报"}</button>
+        ${latestReport ? `data-select-replay="${escapeHtml(latestReport.id)}"` : "disabled"}
+      >${latestReport ? "查看最新战报" : "等待首场战报"}</button>
       <button
         type="button"
         class="account-replay-entry-point"
         ${focusReplayId ? `data-select-replay="${escapeHtml(focusReplayId)}"` : "disabled"}
       >${focusReplayId ? "进入回放中心" : "回放中心待解锁"}</button>
     </div>
-    <p class="account-meta">可直接打开最新结算，或进入逐步回放。</p>
+    <p class="account-meta">可直接打开最新结算，查看收益证据，并进入逐步回放。</p>
     ${renderRecentBattleReplays(input.account, {
       ...(input.selectedReplayId !== undefined ? { selectedReplayId: input.selectedReplayId } : {})
     })}

--- a/apps/client/src/runtime-diagnostics.ts
+++ b/apps/client/src/runtime-diagnostics.ts
@@ -156,7 +156,8 @@ export function buildH5RuntimeDiagnosticsSnapshot(
       recoverySummary: input.diagnostics.recoverySummary || null,
       predictionStatus: input.diagnostics.predictionStatus || null,
       pendingUiTasks: input.diagnostics.pendingUiTasks,
-      replay: input.diagnostics.replay ? { ...input.diagnostics.replay } : null
+      replay: input.diagnostics.replay ? { ...input.diagnostics.replay } : null,
+      primaryClientTelemetry: []
     }
   };
 }

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -174,13 +174,12 @@ test("account history renderer shows recent battle replay summaries with step ch
     selectedReplayId: "room-alpha:battle-1:player-1"
   });
 
-  assert.match(html, /最近 2 场战斗的回放摘要/);
+  assert.match(html, /最近 2 场战斗的结算摘要/);
   assert.match(html, /PVE · 中立守军 neutral-1/);
   assert.match(html, /房间 room-alpha/);
-  assert.match(html, /回放 2 步/);
-  assert.match(html, /玩家 1/);
-  assert.match(html, /自动 1/);
-  assert.match(html, /技能 1/);
+  assert.match(html, /1 回合/);
+  assert.match(html, /2 步/);
+  assert.match(html, /经验 \+40/);
   assert.match(html, /data-select-replay="room-alpha:battle-1:player-1"/);
   assert.match(html, /account-replay-entry is-victory is-selected/);
 });
@@ -198,12 +197,12 @@ test("account history renderer groups battle list and replay detail into a repla
 
   assert.match(html, /data-testid="battle-report-center"/);
   assert.match(html, /战报与回放中心/);
-  assert.match(html, /最近累计 2 场战斗/);
+  assert.match(html, /最近累计 2 份战报/);
   assert.match(html, /支持从列表进入详情或基础回放/);
   assert.match(html, /战报 2/);
   assert.match(html, /查看最新战报/);
   assert.match(html, /进入回放中心/);
-  assert.match(html, /可直接打开最新结算，或进入逐步回放/);
+  assert.match(html, /可直接打开最新结算，查看收益证据，并进入逐步回放/);
   assert.match(html, /class="account-replay-entry-point is-primary"/);
   assert.match(html, /data-select-replay="room-alpha:battle-1:player-1"/);
   assert.match(html, /回放详情/);

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -332,7 +332,7 @@ export class VeilHudPanel extends Component {
       156,
       50 + equipmentLineCount * 16 + (equipmentButtons.length > 0 ? Math.ceil(equipmentButtons.length / 2) * 24 : 0)
     );
-    const latestBattleReport = summarizeLatestBattleReplay(state.account.recentBattleReplays);
+    const latestBattleReport = summarizeLatestBattleReplay(state.account.recentBattleReplays, state.account.recentEventLog);
     const reachableAhead =
       state.update?.reachableTiles.filter((tile) => !hero || tile.x !== hero.position.x || tile.y !== hero.position.y).length ?? 0;
     const sessionStatusBadge = getSessionIndicatorBadge(state.sessionIndicators);
@@ -1425,7 +1425,7 @@ export class VeilHudPanel extends Component {
 
     this.ensureActionButton(actionsNode, "HudNewRun", "新开一局");
     this.ensureActionButton(actionsNode, "HudRefresh", "刷新状态");
-    this.ensureActionButton(actionsNode, "HudAchievements", "成长回顾");
+    this.ensureActionButton(actionsNode, "HudAchievements", "战报中心");
     this.ensureActionButton(actionsNode, "HudEndDay", "推进一天");
     this.ensureActionButton(actionsNode, "HudReturnLobby", "返回大厅");
   }
@@ -1445,7 +1445,7 @@ export class VeilHudPanel extends Component {
     const buttons: HudActionButtonState[] = [
       { name: "HudNewRun", label: "新开一局", callback: this.onNewRun ?? null },
       { name: "HudRefresh", label: "刷新状态", callback: this.onRefresh ?? null },
-      { name: "HudAchievements", label: "成长回顾", callback: this.onToggleAchievements ?? null },
+      { name: "HudAchievements", label: "战报中心", callback: this.onToggleAchievements ?? null },
       { name: "HudEndDay", label: "推进一天", callback: this.onEndDay ?? null },
       { name: "HudReturnLobby", label: "返回大厅", callback: this.onReturnLobby ?? null }
     ];

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -699,7 +699,7 @@ export class VeilRoot extends Component {
         void this.refreshSnapshot();
       },
       onToggleAchievements: () => {
-        void this.toggleGameplayAccountReviewPanel();
+        void this.openGameplayBattleReportCenter();
       },
       onLearnSkill: (skillId) => {
         void this.learnHeroSkill(skillId);
@@ -1275,6 +1275,18 @@ export class VeilRoot extends Component {
     await this.refreshActiveAccountReviewSection();
   }
 
+  private async openGameplayBattleReportCenter(): Promise<void> {
+    this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+      type: "section.selected",
+      section: "battle-replays"
+    });
+    this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
+      type: "battle-replay.selected",
+      replayId: this.lobbyAccountProfile.battleReportCenter?.latestReportId ?? this.lobbyAccountReviewState.selectedBattleReplayId
+    });
+    await this.toggleGameplayAccountReviewPanel(true);
+  }
+
   private async refreshAccountReviewPage(
     section: "battle-replays" | "event-history",
     page: number
@@ -1456,7 +1468,7 @@ export class VeilRoot extends Component {
           void this.refreshSnapshot();
         },
         onToggleAchievements: () => {
-          void this.toggleGameplayAccountReviewPanel();
+          void this.openGameplayBattleReportCenter();
         },
         onLearnSkill: (skillId) => {
           void this.learnHeroSkill(skillId);

--- a/apps/cocos-client/assets/scripts/cocos-battle-report.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-report.ts
@@ -1,4 +1,4 @@
-import type { PlayerBattleReplaySummary } from "./project-shared/index.ts";
+import { buildPlayerBattleReportCenter, type EventLogEntry, type PlayerBattleReplaySummary } from "./project-shared/index.ts";
 
 export interface CocosBattleReportSummary {
   title: string;
@@ -52,22 +52,39 @@ function summarizeReplaySteps(replay: PlayerBattleReplaySummary): {
 }
 
 export function summarizeLatestBattleReplay(
-  replays: PlayerBattleReplaySummary[]
+  replays: PlayerBattleReplaySummary[],
+  recentEventLog: Partial<EventLogEntry>[] = []
 ): CocosBattleReportSummary {
-  const latest = replays[0];
-  if (!latest) {
+  const latestReport = buildPlayerBattleReportCenter(replays, recentEventLog).items[0];
+  if (!latestReport) {
     return {
       title: "战报 暂无记录",
-      detail: "完成一次战斗后，这里会同步最近回放摘要"
+      detail: "完成一次战斗后，这里会同步最近战报摘要"
     };
   }
 
-  const resultLabel = latest.result === "attacker_victory" ? "最近胜利" : "最近失利";
-  const campLabel = latest.playerCamp === "attacker" ? "攻方" : "守方";
+  const latest = replays.find((replay) => replay.id === latestReport.replayId) ?? replays[0] ?? null;
+  if (!latest) {
+    return {
+      title: "战报 暂无记录",
+      detail: "完成一次战斗后，这里会同步最近战报摘要"
+    };
+  }
+
+  const resultLabel = latestReport.result === "victory" ? "最近胜利" : "最近失利";
+  const campLabel = latestReport.playerCamp === "attacker" ? "攻方" : "守方";
+  const rewardSummary = latestReport.rewards[0]
+    ? latestReport.rewards
+        .slice(0, 2)
+        .map((reward) => (reward.amount != null ? `${reward.label}+${reward.amount}` : reward.label))
+        .join(" / ")
+    : latestReport.evidence.rewards === "available"
+      ? "收益同步中"
+      : "无额外奖励";
   const stepSummary = summarizeReplaySteps(latest);
 
   return {
     title: `战报 ${resultLabel} · ${formatBattleKindLabel(latest)} ${formatEncounterLabel(latest)}`,
-    detail: `${formatShortTimestamp(latest.completedAt)} · ${campLabel} · ${latest.steps.length} 步 · 玩${stepSummary.playerSteps}/自${stepSummary.automatedSteps}`
+    detail: `${formatShortTimestamp(latestReport.completedAt)} · ${campLabel} · ${latestReport.turnCount} 回合/${latestReport.actionCount} 步 · ${rewardSummary} · 玩${stepSummary.playerSteps}/自${stepSummary.automatedSteps}`
   };
 }

--- a/apps/cocos-client/assets/scripts/project-shared/battle-report.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle-report.ts
@@ -1,0 +1,266 @@
+import {
+  buildBattleReplayTimeline,
+  normalizePlayerBattleReplaySummaries,
+  type PlayerBattleReplayQuery,
+  type PlayerBattleReplaySummary
+} from "./battle-replay.ts";
+import { normalizeEventLogEntries, type EventLogEntry, type EventLogReward } from "./event-log.ts";
+
+export type PlayerBattleReportResult = "victory" | "defeat";
+export type PlayerBattleReportEvidenceAvailability = "available" | "missing";
+
+export interface PlayerBattleReportEvidence {
+  replay: PlayerBattleReportEvidenceAvailability;
+  rewards: PlayerBattleReportEvidenceAvailability;
+}
+
+export interface PlayerBattleReportSummary {
+  id: string;
+  replayId: string;
+  roomId: string;
+  playerId: string;
+  battleId: string;
+  battleKind: PlayerBattleReplaySummary["battleKind"];
+  playerCamp: PlayerBattleReplaySummary["playerCamp"];
+  heroId: string;
+  opponentHeroId?: string;
+  neutralArmyId?: string;
+  startedAt: string;
+  completedAt: string;
+  result: PlayerBattleReportResult;
+  turnCount: number;
+  actionCount: number;
+  rewards: EventLogReward[];
+  evidence: PlayerBattleReportEvidence;
+}
+
+export interface PlayerBattleReportCenter {
+  latestReportId: string | null;
+  items: PlayerBattleReportSummary[];
+}
+
+function normalizeTimestamp(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+function normalizeReward(reward?: Partial<EventLogReward> | null): EventLogReward | null {
+  const label = reward?.label?.trim();
+  if (!label) {
+    return null;
+  }
+
+  const type = reward?.type;
+  if (type !== "resource" && type !== "experience" && type !== "skill_point" && type !== "badge") {
+    return null;
+  }
+
+  const amount = reward?.amount == null ? undefined : Math.max(0, Math.floor(reward.amount));
+  return {
+    type,
+    label,
+    ...(amount != null ? { amount } : {})
+  };
+}
+
+function normalizeRewards(rewards?: Partial<EventLogReward>[] | null): EventLogReward[] {
+  return (rewards ?? [])
+    .map((reward) => normalizeReward(reward))
+    .filter((reward): reward is EventLogReward => Boolean(reward));
+}
+
+function didPlayerWin(replay: PlayerBattleReplaySummary): boolean {
+  return (
+    (replay.playerCamp === "attacker" && replay.result === "attacker_victory") ||
+    (replay.playerCamp === "defender" && replay.result === "defender_victory")
+  );
+}
+
+function toTimestampMs(value?: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function collectBattleReportEventLogEntries(
+  replay: PlayerBattleReplaySummary,
+  eventLog?: Partial<EventLogEntry>[] | null
+): EventLogEntry[] {
+  const entries = normalizeEventLogEntries(eventLog);
+  const startedAtMs = toTimestampMs(replay.startedAt);
+  const completedAtMs = toTimestampMs(replay.completedAt);
+  const fallbackEntries = entries.filter(
+    (entry) =>
+      entry.category === "combat" &&
+      entry.roomId === replay.roomId &&
+      entry.playerId === replay.playerId &&
+      (!entry.heroId || entry.heroId === replay.heroId)
+  );
+  const boundedEntries = fallbackEntries.filter((entry) => {
+    const timestamp = toTimestampMs(entry.timestamp);
+    if (timestamp == null || startedAtMs == null || completedAtMs == null) {
+      return true;
+    }
+
+    return timestamp >= startedAtMs && timestamp <= completedAtMs + 2 * 60 * 1000;
+  });
+  const candidates = boundedEntries.length > 0 ? boundedEntries : fallbackEntries;
+  return candidates.sort((left, right) => String(right.timestamp).localeCompare(String(left.timestamp)) || left.id.localeCompare(right.id));
+}
+
+function deriveTurnCount(replay: PlayerBattleReplaySummary): number {
+  if (replay.steps.length === 0) {
+    return Math.max(1, Math.floor(replay.initialState.round || 1));
+  }
+
+  const timeline = buildBattleReplayTimeline(replay);
+  return Math.max(1, timeline.at(-1)?.resultingRound ?? Math.floor(replay.initialState.round || 1));
+}
+
+export function buildPlayerBattleReportSummary(
+  replay: PlayerBattleReplaySummary,
+  eventLog?: Partial<EventLogEntry>[] | null
+): PlayerBattleReportSummary {
+  const evidenceEntries = collectBattleReportEventLogEntries(replay, eventLog);
+  const rewards = normalizeRewards(evidenceEntries.flatMap((entry) => entry.rewards));
+
+  return {
+    id: replay.id,
+    replayId: replay.id,
+    roomId: replay.roomId,
+    playerId: replay.playerId,
+    battleId: replay.battleId,
+    battleKind: replay.battleKind,
+    playerCamp: replay.playerCamp,
+    heroId: replay.heroId,
+    ...(replay.opponentHeroId ? { opponentHeroId: replay.opponentHeroId } : {}),
+    ...(replay.neutralArmyId ? { neutralArmyId: replay.neutralArmyId } : {}),
+    startedAt: replay.startedAt,
+    completedAt: replay.completedAt,
+    result: didPlayerWin(replay) ? "victory" : "defeat",
+    turnCount: deriveTurnCount(replay),
+    actionCount: replay.steps.length,
+    rewards,
+    evidence: {
+      replay: "available",
+      rewards: rewards.length > 0 ? "available" : "missing"
+    }
+  };
+}
+
+export function normalizePlayerBattleReportSummaries(
+  reports?: Partial<PlayerBattleReportSummary>[] | null
+): PlayerBattleReportSummary[] {
+  return (reports ?? [])
+    .map((report) => {
+      const id = report?.id?.trim();
+      const replayId = report?.replayId?.trim() ?? id;
+      const roomId = report?.roomId?.trim();
+      const playerId = report?.playerId?.trim();
+      const battleId = report?.battleId?.trim();
+      const heroId = report?.heroId?.trim();
+      const startedAt = normalizeTimestamp(report?.startedAt);
+      const completedAt = normalizeTimestamp(report?.completedAt);
+      const result = report?.result;
+      if (
+        !id ||
+        !replayId ||
+        !roomId ||
+        !playerId ||
+        !battleId ||
+        !heroId ||
+        !startedAt ||
+        !completedAt ||
+        (report?.battleKind !== "neutral" && report?.battleKind !== "hero") ||
+        (report?.playerCamp !== "attacker" && report?.playerCamp !== "defender") ||
+        (result !== "victory" && result !== "defeat")
+      ) {
+        return null;
+      }
+
+      const replayAvailability = report?.evidence?.replay === "missing" ? "missing" : "available";
+      const rewardAvailability = report?.evidence?.rewards === "available" ? "available" : "missing";
+
+      return {
+        id,
+        replayId,
+        roomId,
+        playerId,
+        battleId,
+        battleKind: report.battleKind,
+        playerCamp: report.playerCamp,
+        heroId,
+        ...(report.opponentHeroId?.trim() ? { opponentHeroId: report.opponentHeroId.trim() } : {}),
+        ...(report.neutralArmyId?.trim() ? { neutralArmyId: report.neutralArmyId.trim() } : {}),
+        startedAt,
+        completedAt,
+        result,
+        turnCount: Math.max(1, Math.floor(report.turnCount ?? 1)),
+        actionCount: Math.max(0, Math.floor(report.actionCount ?? 0)),
+        rewards: normalizeRewards(report.rewards),
+        evidence: {
+          replay: replayAvailability,
+          rewards: rewardAvailability
+        }
+      };
+    })
+    .filter((report): report is PlayerBattleReportSummary => Boolean(report))
+    .sort((left, right) => right.completedAt.localeCompare(left.completedAt) || left.id.localeCompare(right.id))
+    .filter((report, index, list) => index === list.findIndex((candidate) => candidate.id === report.id));
+}
+
+export function buildPlayerBattleReportCenter(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null,
+  eventLog?: Partial<EventLogEntry>[] | null,
+  limit?: number
+): PlayerBattleReportCenter {
+  const normalizedReplays = normalizePlayerBattleReplaySummaries(replays);
+  const safeLimit = limit == null ? normalizedReplays.length : Math.max(1, Math.floor(limit));
+  const items = normalizedReplays.slice(0, safeLimit).map((replay) => buildPlayerBattleReportSummary(replay, eventLog));
+
+  return {
+    latestReportId: items[0]?.id ?? null,
+    items
+  };
+}
+
+export function normalizePlayerBattleReportCenter(
+  center?: Partial<PlayerBattleReportCenter> | null,
+  fallback?: {
+    replays?: Partial<PlayerBattleReplaySummary>[] | null;
+    eventLog?: Partial<EventLogEntry>[] | null;
+    query?: PlayerBattleReplayQuery;
+  }
+): PlayerBattleReportCenter {
+  const fallbackCenter = buildPlayerBattleReportCenter(
+    fallback?.replays,
+    fallback?.eventLog,
+    fallback?.query?.limit
+  );
+  const items = normalizePlayerBattleReportSummaries(center?.items ?? fallbackCenter.items);
+  const latestReportId = center?.latestReportId?.trim() ?? items[0]?.id ?? fallbackCenter.latestReportId ?? null;
+
+  return {
+    latestReportId: latestReportId && items.some((item) => item.id === latestReportId) ? latestReportId : items[0]?.id ?? null,
+    items
+  };
+}
+
+export function findPlayerBattleReportSummary(
+  reports?: Partial<PlayerBattleReportSummary>[] | null,
+  reportId?: string | null
+): PlayerBattleReportSummary | null {
+  const normalizedReportId = reportId?.trim();
+  if (!normalizedReportId) {
+    return null;
+  }
+
+  return normalizePlayerBattleReportSummaries(reports).find((report) => report.id === normalizedReportId) ?? null;
+}

--- a/apps/cocos-client/assets/scripts/project-shared/index.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/index.ts
@@ -2,6 +2,7 @@ export * from "./achievement-ui.ts";
 export * from "./action-precheck.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";
+export * from "./battle-report.ts";
 export * from "./battle-replay.ts";
 export * from "./deterministic-rng.ts";
 export * from "./equipment.ts";

--- a/apps/cocos-client/assets/scripts/project-shared/player-account.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/player-account.ts
@@ -1,4 +1,8 @@
 import {
+  normalizePlayerBattleReportCenter,
+  type PlayerBattleReportCenter
+} from "./battle-report.ts";
+import {
   normalizeEventLogEntries,
   normalizeAchievementProgress,
   type EventLogEntry,
@@ -22,6 +26,7 @@ export interface PlayerAccountReadModel {
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
   recentBattleReplays?: PlayerBattleReplaySummary[];
+  battleReportCenter?: PlayerBattleReportCenter;
   loginId?: string;
   credentialBoundAt?: string;
   lastRoomId?: string;
@@ -37,6 +42,7 @@ export interface PlayerAccountReadModelInput {
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
+  battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
   lastRoomId?: string | undefined;
@@ -53,6 +59,8 @@ export function normalizePlayerAccountReadModel(
   const credentialBoundAt = account?.credentialBoundAt?.trim();
   const lastRoomId = account?.lastRoomId?.trim();
   const lastSeenAt = account?.lastSeenAt?.trim();
+  const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
+  const recentBattleReplays = normalizePlayerBattleReplaySummaries(account?.recentBattleReplays);
 
   return {
     playerId,
@@ -65,8 +73,12 @@ export function normalizePlayerAccountReadModel(
       ore: Math.max(0, Math.floor(account?.globalResources?.ore ?? 0))
     },
     achievements: normalizeAchievementProgress(account?.achievements),
-    recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
-    recentBattleReplays: normalizePlayerBattleReplaySummaries(account?.recentBattleReplays),
+    recentEventLog,
+    recentBattleReplays,
+    battleReportCenter: normalizePlayerBattleReportCenter(account?.battleReportCenter, {
+      replays: recentBattleReplays,
+      eventLog: recentEventLog
+    }),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(lastRoomId ? { lastRoomId } : {}),

--- a/apps/cocos-client/test/cocos-battle-report.test.ts
+++ b/apps/cocos-client/test/cocos-battle-report.test.ts
@@ -23,7 +23,7 @@ function createBattleState() {
 test("summarizeLatestBattleReplay falls back when no replays exist", () => {
   assert.deepEqual(summarizeLatestBattleReplay([]), {
     title: "战报 暂无记录",
-    detail: "完成一次战斗后，这里会同步最近回放摘要"
+    detail: "完成一次战斗后，这里会同步最近战报摘要"
   });
 });
 
@@ -65,7 +65,7 @@ test("summarizeLatestBattleReplay builds a concise latest replay summary", () =>
   ];
 
   assert.deepEqual(summarizeLatestBattleReplay(replays), {
-    title: "战报 最近失利 · PVP 英雄 hero-1",
-    detail: "03-27 12:03 · 守方 · 2 步 · 玩1/自1"
+    title: "战报 最近胜利 · PVP 英雄 hero-1",
+    detail: "03-27 12:03 · 守方 · 1 回合/2 步 · 无额外奖励 · 玩1/自1"
   });
 });

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -443,7 +443,8 @@ function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): Runtim
       recoverySummary: null,
       predictionStatus: "server-observability",
       pendingUiTasks: 0,
-      replay: null
+      replay: null,
+      primaryClientTelemetry: []
     }
   };
 }

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   applyBattleReplayPlaybackCommand,
+  buildPlayerBattleReportCenter,
   buildPlayerProgressionSnapshot,
   findPlayerBattleReplaySummary,
   getAchievementDefinitions,
@@ -182,6 +183,48 @@ function toReplayResponseFromRequest(
       ...(neutralArmyId ? { neutralArmyId } : {}),
       ...(result ? { result } : {})
     })
+  };
+}
+
+function toBattleReportResponseFromRequest(account: PlayerAccountSnapshot, request: IncomingMessage) {
+  const limit = parseLimit(request);
+  const offset = parseOffset(request);
+  const roomId = parseOptionalQueryParam(request, "roomId");
+  const battleId = parseOptionalQueryParam(request, "battleId");
+  const battleKind = parseOptionalQueryParam(request, "battleKind") as
+    | PlayerBattleReplaySummary["battleKind"]
+    | undefined;
+  const playerCamp = parseOptionalQueryParam(request, "playerCamp") as
+    | PlayerBattleReplaySummary["playerCamp"]
+    | undefined;
+  const heroId = parseOptionalQueryParam(request, "heroId");
+  const opponentHeroId = parseOptionalQueryParam(request, "opponentHeroId");
+  const neutralArmyId = parseOptionalQueryParam(request, "neutralArmyId");
+  const result = parseOptionalQueryParam(request, "result") as
+    | PlayerBattleReplaySummary["result"]
+    | undefined;
+
+  return buildPlayerBattleReportCenter(
+    queryPlayerBattleReplaySummaries(account.recentBattleReplays, {
+      ...(limit != null ? { limit } : {}),
+      ...(offset != null ? { offset } : {}),
+      ...(roomId ? { roomId } : {}),
+      ...(battleId ? { battleId } : {}),
+      ...(battleKind ? { battleKind } : {}),
+      ...(playerCamp ? { playerCamp } : {}),
+      ...(heroId ? { heroId } : {}),
+      ...(opponentHeroId ? { opponentHeroId } : {}),
+      ...(neutralArmyId ? { neutralArmyId } : {}),
+      ...(result ? { result } : {})
+    }),
+    account.recentEventLog
+  );
+}
+
+function withBattleReportCenter(account: PlayerAccountSnapshot): PlayerAccountSnapshot {
+  return {
+    ...account,
+    battleReportCenter: buildPlayerBattleReportCenter(account.recentBattleReplays, account.recentEventLog)
   };
 }
 
@@ -478,7 +521,7 @@ export function registerPlayerAccountRoutes(
         ...(authSession.loginId ? { loginId: authSession.loginId } : {})
       });
       sendJson(response, 200, {
-        account,
+        account: withBattleReportCenter(account),
         session: issueNextAuthSession(account, authSession)
       });
       return;
@@ -492,7 +535,7 @@ export function registerPlayerAccountRoutes(
           displayName: authSession.displayName
         }));
       sendJson(response, 200, {
-        account,
+        account: withBattleReportCenter(account),
         session: issueNextAuthSession(account, authSession)
       });
     } catch (error) {
@@ -633,6 +676,33 @@ export function registerPlayerAccountRoutes(
           displayName: authSession.displayName
         }));
       sendJson(response, 200, toReplayResponseFromRequest(account, request));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/me/battle-reports", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 200, {
+        latestReportId: null,
+        items: []
+      });
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      sendJson(response, 200, toBattleReportResponseFromRequest(account, request));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
@@ -887,9 +957,11 @@ export function registerPlayerAccountRoutes(
     if (!store) {
       sendJson(response, 200, {
         account: toPublicPlayerAccount(
-          createLocalModeAccount({
-            playerId
-          })
+          withBattleReportCenter(
+            createLocalModeAccount({
+              playerId
+            })
+          )
         )
       });
       return;
@@ -901,9 +973,11 @@ export function registerPlayerAccountRoutes(
         if (isEphemeralGuestPlayerId(playerId)) {
           sendJson(response, 200, {
             account: toPublicPlayerAccount(
-              createLocalModeAccount({
-                playerId
-              })
+              withBattleReportCenter(
+                createLocalModeAccount({
+                  playerId
+                })
+              )
             )
           });
           return;
@@ -917,7 +991,7 @@ export function registerPlayerAccountRoutes(
         return;
       }
 
-      sendJson(response, 200, { account: toPublicPlayerAccount(account) });
+      sendJson(response, 200, { account: toPublicPlayerAccount(withBattleReportCenter(account)) });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
@@ -956,6 +1030,46 @@ export function registerPlayerAccountRoutes(
       }
 
       sendJson(response, 200, toReplayResponseFromRequest(account, request));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/:playerId/battle-reports", async (request, response) => {
+    const playerId = request.params.playerId?.trim();
+    if (!playerId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 200, {
+        latestReportId: null,
+        items: []
+      });
+      return;
+    }
+
+    try {
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        if (isEphemeralGuestPlayerId(playerId)) {
+          sendJson(response, 200, {
+            latestReportId: null,
+            items: []
+          });
+          return;
+        }
+        sendJson(response, 404, {
+          error: {
+            code: "player_account_not_found",
+            message: `Player account not found: ${playerId}`
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, toBattleReportResponseFromRequest(account, request));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
@@ -1349,7 +1463,7 @@ export function registerPlayerAccountRoutes(
           ...(authSession.loginId ? { loginId: authSession.loginId } : {})
         });
         sendJson(response, 200, {
-          account,
+          account: withBattleReportCenter(account),
           session: issueNextAuthSession(account, authSession)
         });
         return;
@@ -1418,13 +1532,13 @@ export function registerPlayerAccountRoutes(
           } as typeof account);
 
         sendJson(response, 200, {
-          account
+          account: withBattleReportCenter(account)
         });
         return;
       }
 
       sendJson(response, 200, {
-        account,
+        account: withBattleReportCenter(account),
         session: issueNextAuthSession(account, authSession)
       });
     } catch (error) {
@@ -1506,7 +1620,7 @@ export function registerPlayerAccountRoutes(
           ...(authSession?.playerId === playerId && authSession.loginId ? { loginId: authSession.loginId } : {})
         });
         sendJson(response, 200, {
-          account,
+          account: withBattleReportCenter(account),
           ...(authSession?.playerId === playerId ? { session: issueNextAuthSession(account, authSession) } : {})
         });
         return;
@@ -1526,7 +1640,7 @@ export function registerPlayerAccountRoutes(
           : await store.savePlayerAccountProfile(playerId, patch);
 
       sendJson(response, 200, {
-        account,
+        account: withBattleReportCenter(account),
         session: issueNextAuthSession(account, authSession)
       });
     } catch (error) {

--- a/docs/battle-report-center-validation.md
+++ b/docs/battle-report-center-validation.md
@@ -3,35 +3,66 @@
 ## Scope
 
 - Supported client slice: `apps/client` H5 account card replay/report center
+- Primary client slice: `apps/cocos-client` gameplay HUD entry opens the account-level battle report center
 - Data sources exercised:
+  - `/api/player-accounts/:playerId/battle-reports`
   - `/api/player-accounts/:playerId/battle-replays`
   - `/api/player-accounts/:playerId`
-  - shared replay timeline helpers used by the H5 renderer
+  - shared `PlayerBattleReportCenter` contract derived from replay + combat event evidence
+  - shared replay timeline helpers used by the H5 renderer and Cocos replay center
+
+## Contract Summary
+
+- `PlayerBattleReportCenter.latestReportId`
+  - stable entry point for "open latest report" flows
+- `PlayerBattleReportCenter.items[]`
+  - `id` / `replayId`
+  - `result`
+  - `battleKind`
+  - `playerCamp`
+  - `heroId`
+  - `opponentHeroId` or `neutralArmyId`
+  - `turnCount`
+  - `actionCount`
+  - `completedAt`
+  - `rewards[]`
+  - `evidence.replay`
+  - `evidence.rewards`
 
 ## Repeatable Local Validation
 
 1. Start the local server and H5 client:
    - `npm run dev:server`
    - `npm run dev:client`
-2. Open the H5 shell with a clean room and player, for example:
+2. Optional Cocos parity check:
+   - open `apps/cocos-client` in Cocos Creator 3.8.x
+   - preview the `VeilRoot` scene
+   - in gameplay HUD, use `战报中心` to jump directly into the latest account-level battle report section
+3. Open the H5 shell with a clean room and player, for example:
    - `http://127.0.0.1:4173/?roomId=replay-center-validate-20260329&playerId=player-1`
-3. Complete at least one battle in that room. The quickest repeatable path is to run the existing automation flow against the same room:
+4. Complete at least one battle in that room. The quickest repeatable path is to run the existing automation flow against the same room:
    - `tests/automation/keyboard-battle.actions.json`
-4. Refresh or reopen the same room URL after the battle resolves.
-5. In the account card, verify the replay/report center shows:
+5. Refresh or reopen the same room URL after the battle resolves.
+6. In H5 and Cocos, verify the battle report center shows:
    - a recent battle report entry
+   - result, encounter, turn count, and timestamp
+   - reward chips or an explicit missing-evidence state
+   - replay availability and rewards evidence availability
    - a selectable replay detail panel with step timeline rows
-   - explicit outcome text
-   - casualty summary
-   - reward chips or a clear "no extra rewards recorded" message sourced from recent combat events
+   - explicit outcome text and casualty summary after opening a report
 
 ## Targeted Checks
 
+- Shared contract and report derivation:
+  - `node --import tsx --test ./packages/shared/test/shared-core.test.ts`
 - Renderer regression:
   - `node --import tsx --test ./apps/client/test/account-history-render.test.ts`
-- Client data loading regression:
-  - `node --import tsx --test ./apps/client/test/player-account-storage.test.ts`
+- Cocos report summary / replay-center regression:
+  - `node --import tsx --test ./apps/cocos-client/test/cocos-battle-report.test.ts ./apps/cocos-client/test/cocos-battle-replay-center.test.ts`
+- Cocos gameplay entry regression:
+  - `node --import tsx --test ./apps/cocos-client/test/cocos-root-orchestration.test.ts`
 
 ## Notes
 
-- The replay read model does not currently store rewards directly. The H5 report summary combines replay timeline data with recent combat event log entries to expose reward outcomes without requiring raw API inspection.
+- Rewards are still sourced from combat/account evidence rather than replay steps alone, but the summary/evidence contract is now normalized in shared code instead of being reconstructed independently per client.
+- `GET /api/player-accounts/:playerId/battle-reports` and `GET /api/player-accounts/me/battle-reports` mirror the replay query parameters and return the shared center payload.

--- a/packages/shared/src/battle-report.ts
+++ b/packages/shared/src/battle-report.ts
@@ -1,0 +1,266 @@
+import {
+  buildBattleReplayTimeline,
+  normalizePlayerBattleReplaySummaries,
+  type PlayerBattleReplayQuery,
+  type PlayerBattleReplaySummary
+} from "./battle-replay.ts";
+import { normalizeEventLogEntries, type EventLogEntry, type EventLogReward } from "./event-log.ts";
+
+export type PlayerBattleReportResult = "victory" | "defeat";
+export type PlayerBattleReportEvidenceAvailability = "available" | "missing";
+
+export interface PlayerBattleReportEvidence {
+  replay: PlayerBattleReportEvidenceAvailability;
+  rewards: PlayerBattleReportEvidenceAvailability;
+}
+
+export interface PlayerBattleReportSummary {
+  id: string;
+  replayId: string;
+  roomId: string;
+  playerId: string;
+  battleId: string;
+  battleKind: PlayerBattleReplaySummary["battleKind"];
+  playerCamp: PlayerBattleReplaySummary["playerCamp"];
+  heroId: string;
+  opponentHeroId?: string;
+  neutralArmyId?: string;
+  startedAt: string;
+  completedAt: string;
+  result: PlayerBattleReportResult;
+  turnCount: number;
+  actionCount: number;
+  rewards: EventLogReward[];
+  evidence: PlayerBattleReportEvidence;
+}
+
+export interface PlayerBattleReportCenter {
+  latestReportId: string | null;
+  items: PlayerBattleReportSummary[];
+}
+
+function normalizeTimestamp(value?: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+function normalizeReward(reward?: Partial<EventLogReward> | null): EventLogReward | null {
+  const label = reward?.label?.trim();
+  if (!label) {
+    return null;
+  }
+
+  const type = reward?.type;
+  if (type !== "resource" && type !== "experience" && type !== "skill_point" && type !== "badge") {
+    return null;
+  }
+
+  const amount = reward?.amount == null ? undefined : Math.max(0, Math.floor(reward.amount));
+  return {
+    type,
+    label,
+    ...(amount != null ? { amount } : {})
+  };
+}
+
+function normalizeRewards(rewards?: Partial<EventLogReward>[] | null): EventLogReward[] {
+  return (rewards ?? [])
+    .map((reward) => normalizeReward(reward))
+    .filter((reward): reward is EventLogReward => Boolean(reward));
+}
+
+function didPlayerWin(replay: PlayerBattleReplaySummary): boolean {
+  return (
+    (replay.playerCamp === "attacker" && replay.result === "attacker_victory") ||
+    (replay.playerCamp === "defender" && replay.result === "defender_victory")
+  );
+}
+
+function toTimestampMs(value?: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function collectBattleReportEventLogEntries(
+  replay: PlayerBattleReplaySummary,
+  eventLog?: Partial<EventLogEntry>[] | null
+): EventLogEntry[] {
+  const entries = normalizeEventLogEntries(eventLog);
+  const startedAtMs = toTimestampMs(replay.startedAt);
+  const completedAtMs = toTimestampMs(replay.completedAt);
+  const fallbackEntries = entries.filter(
+    (entry) =>
+      entry.category === "combat" &&
+      entry.roomId === replay.roomId &&
+      entry.playerId === replay.playerId &&
+      (!entry.heroId || entry.heroId === replay.heroId)
+  );
+  const boundedEntries = fallbackEntries.filter((entry) => {
+    const timestamp = toTimestampMs(entry.timestamp);
+    if (timestamp == null || startedAtMs == null || completedAtMs == null) {
+      return true;
+    }
+
+    return timestamp >= startedAtMs && timestamp <= completedAtMs + 2 * 60 * 1000;
+  });
+  const candidates = boundedEntries.length > 0 ? boundedEntries : fallbackEntries;
+  return candidates.sort((left, right) => String(right.timestamp).localeCompare(String(left.timestamp)) || left.id.localeCompare(right.id));
+}
+
+function deriveTurnCount(replay: PlayerBattleReplaySummary): number {
+  if (replay.steps.length === 0) {
+    return Math.max(1, Math.floor(replay.initialState.round || 1));
+  }
+
+  const timeline = buildBattleReplayTimeline(replay);
+  return Math.max(1, timeline.at(-1)?.resultingRound ?? Math.floor(replay.initialState.round || 1));
+}
+
+export function buildPlayerBattleReportSummary(
+  replay: PlayerBattleReplaySummary,
+  eventLog?: Partial<EventLogEntry>[] | null
+): PlayerBattleReportSummary {
+  const evidenceEntries = collectBattleReportEventLogEntries(replay, eventLog);
+  const rewards = normalizeRewards(evidenceEntries.flatMap((entry) => entry.rewards));
+
+  return {
+    id: replay.id,
+    replayId: replay.id,
+    roomId: replay.roomId,
+    playerId: replay.playerId,
+    battleId: replay.battleId,
+    battleKind: replay.battleKind,
+    playerCamp: replay.playerCamp,
+    heroId: replay.heroId,
+    ...(replay.opponentHeroId ? { opponentHeroId: replay.opponentHeroId } : {}),
+    ...(replay.neutralArmyId ? { neutralArmyId: replay.neutralArmyId } : {}),
+    startedAt: replay.startedAt,
+    completedAt: replay.completedAt,
+    result: didPlayerWin(replay) ? "victory" : "defeat",
+    turnCount: deriveTurnCount(replay),
+    actionCount: replay.steps.length,
+    rewards,
+    evidence: {
+      replay: "available",
+      rewards: rewards.length > 0 ? "available" : "missing"
+    }
+  };
+}
+
+export function normalizePlayerBattleReportSummaries(
+  reports?: Partial<PlayerBattleReportSummary>[] | null
+): PlayerBattleReportSummary[] {
+  return (reports ?? [])
+    .map((report) => {
+      const id = report?.id?.trim();
+      const replayId = report?.replayId?.trim() ?? id;
+      const roomId = report?.roomId?.trim();
+      const playerId = report?.playerId?.trim();
+      const battleId = report?.battleId?.trim();
+      const heroId = report?.heroId?.trim();
+      const startedAt = normalizeTimestamp(report?.startedAt);
+      const completedAt = normalizeTimestamp(report?.completedAt);
+      const result = report?.result;
+      if (
+        !id ||
+        !replayId ||
+        !roomId ||
+        !playerId ||
+        !battleId ||
+        !heroId ||
+        !startedAt ||
+        !completedAt ||
+        (report?.battleKind !== "neutral" && report?.battleKind !== "hero") ||
+        (report?.playerCamp !== "attacker" && report?.playerCamp !== "defender") ||
+        (result !== "victory" && result !== "defeat")
+      ) {
+        return null;
+      }
+
+      const replayAvailability = report?.evidence?.replay === "missing" ? "missing" : "available";
+      const rewardAvailability = report?.evidence?.rewards === "available" ? "available" : "missing";
+
+      return {
+        id,
+        replayId,
+        roomId,
+        playerId,
+        battleId,
+        battleKind: report.battleKind,
+        playerCamp: report.playerCamp,
+        heroId,
+        ...(report.opponentHeroId?.trim() ? { opponentHeroId: report.opponentHeroId.trim() } : {}),
+        ...(report.neutralArmyId?.trim() ? { neutralArmyId: report.neutralArmyId.trim() } : {}),
+        startedAt,
+        completedAt,
+        result,
+        turnCount: Math.max(1, Math.floor(report.turnCount ?? 1)),
+        actionCount: Math.max(0, Math.floor(report.actionCount ?? 0)),
+        rewards: normalizeRewards(report.rewards),
+        evidence: {
+          replay: replayAvailability,
+          rewards: rewardAvailability
+        }
+      };
+    })
+    .filter((report): report is PlayerBattleReportSummary => Boolean(report))
+    .sort((left, right) => right.completedAt.localeCompare(left.completedAt) || left.id.localeCompare(right.id))
+    .filter((report, index, list) => index === list.findIndex((candidate) => candidate.id === report.id));
+}
+
+export function buildPlayerBattleReportCenter(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null,
+  eventLog?: Partial<EventLogEntry>[] | null,
+  limit?: number
+): PlayerBattleReportCenter {
+  const normalizedReplays = normalizePlayerBattleReplaySummaries(replays);
+  const safeLimit = limit == null ? normalizedReplays.length : Math.max(1, Math.floor(limit));
+  const items = normalizedReplays.slice(0, safeLimit).map((replay) => buildPlayerBattleReportSummary(replay, eventLog));
+
+  return {
+    latestReportId: items[0]?.id ?? null,
+    items
+  };
+}
+
+export function normalizePlayerBattleReportCenter(
+  center?: Partial<PlayerBattleReportCenter> | null,
+  fallback?: {
+    replays?: Partial<PlayerBattleReplaySummary>[] | null;
+    eventLog?: Partial<EventLogEntry>[] | null;
+    query?: PlayerBattleReplayQuery;
+  }
+): PlayerBattleReportCenter {
+  const fallbackCenter = buildPlayerBattleReportCenter(
+    fallback?.replays,
+    fallback?.eventLog,
+    fallback?.query?.limit
+  );
+  const items = normalizePlayerBattleReportSummaries(center?.items ?? fallbackCenter.items);
+  const latestReportId = center?.latestReportId?.trim() ?? items[0]?.id ?? fallbackCenter.latestReportId ?? null;
+
+  return {
+    latestReportId: latestReportId && items.some((item) => item.id === latestReportId) ? latestReportId : items[0]?.id ?? null,
+    items
+  };
+}
+
+export function findPlayerBattleReportSummary(
+  reports?: Partial<PlayerBattleReportSummary>[] | null,
+  reportId?: string | null
+): PlayerBattleReportSummary | null {
+  const normalizedReportId = reportId?.trim();
+  if (!normalizedReportId) {
+    return null;
+  }
+
+  return normalizePlayerBattleReportSummaries(reports).find((report) => report.id === normalizedReportId) ?? null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./action-precheck.ts";
 export * from "./auth-ui.ts";
 export * from "./assets-config.ts";
 export * from "./battle.ts";
+export * from "./battle-report.ts";
 export * from "./battle-replay.ts";
 export * from "./content-pack-validation.ts";
 export * from "./deterministic-rng.ts";

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -1,4 +1,9 @@
 import {
+  buildPlayerBattleReportCenter,
+  normalizePlayerBattleReportCenter,
+  type PlayerBattleReportCenter
+} from "./battle-report.ts";
+import {
   normalizeEventLogEntries,
   normalizeAchievementProgress,
   type EventLogEntry,
@@ -17,6 +22,7 @@ export interface PlayerAccountReadModel {
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
   recentBattleReplays?: PlayerBattleReplaySummary[];
+  battleReportCenter?: PlayerBattleReportCenter;
   loginId?: string;
   credentialBoundAt?: string;
   lastRoomId?: string;
@@ -32,6 +38,7 @@ export interface PlayerAccountReadModelInput {
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
+  battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
   lastRoomId?: string | undefined;
@@ -48,6 +55,8 @@ export function normalizePlayerAccountReadModel(
   const credentialBoundAt = account?.credentialBoundAt?.trim();
   const lastRoomId = account?.lastRoomId?.trim();
   const lastSeenAt = account?.lastSeenAt?.trim();
+  const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
+  const recentBattleReplays = normalizePlayerBattleReplaySummaries(account?.recentBattleReplays);
 
   return {
     playerId,
@@ -60,8 +69,12 @@ export function normalizePlayerAccountReadModel(
       ore: Math.max(0, Math.floor(account?.globalResources?.ore ?? 0))
     },
     achievements: normalizeAchievementProgress(account?.achievements),
-    recentEventLog: normalizeEventLogEntries(account?.recentEventLog),
-    recentBattleReplays: normalizePlayerBattleReplaySummaries(account?.recentBattleReplays),
+    recentEventLog,
+    recentBattleReplays,
+    battleReportCenter: normalizePlayerBattleReportCenter(account?.battleReportCenter, {
+      replays: recentBattleReplays,
+      eventLog: recentEventLog
+    }),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(lastRoomId ? { lastRoomId } : {}),

--- a/packages/shared/test/battle-report-center-contract.test.ts
+++ b/packages/shared/test/battle-report-center-contract.test.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createBattleReportCenterFixture } from "./support/multiplayer-protocol-fixtures.ts";
+import { assertContractSnapshot } from "./support/contract-snapshot.ts";
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+test("battle report center contract snapshot stays stable", () => {
+  assertContractSnapshot(
+    path.join(THIS_DIR, "fixtures", "contract-snapshots", "battle-report-center.json"),
+    createBattleReportCenterFixture()
+  );
+});

--- a/packages/shared/test/battle-report.test.ts
+++ b/packages/shared/test/battle-report.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildPlayerBattleReportCenter, normalizePlayerAccountReadModel, createEmptyBattleState } from "../src/index.ts";
+
+test("battle report helpers derive rewards, turn count, and evidence availability from replay plus event log", () => {
+  const battle = createEmptyBattleState({
+    id: "battle-1",
+    round: 1,
+    attackerHeroId: "hero-1",
+    defenderHeroId: "neutral-1"
+  });
+
+  const center = buildPlayerBattleReportCenter(
+    [
+      {
+        id: "replay-1",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        battleId: "battle-1",
+        battleKind: "neutral",
+        playerCamp: "attacker",
+        heroId: "hero-1",
+        neutralArmyId: "neutral-1",
+        startedAt: "2026-03-27T10:00:00.000Z",
+        completedAt: "2026-03-27T10:01:00.000Z",
+        initialState: battle,
+        steps: [{ index: 1, source: "player", action: { type: "battle.wait", unitId: "hero-1-stack" } }],
+        result: "attacker_victory"
+      }
+    ],
+    [
+      {
+        id: "event-1",
+        timestamp: "2026-03-27T10:01:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        category: "combat",
+        description: "resolved",
+        heroId: "hero-1",
+        worldEventType: "battle.resolved",
+        rewards: [{ type: "experience", label: "经验", amount: 40 }]
+      }
+    ]
+  );
+
+  assert.equal(center.latestReportId, "replay-1");
+  assert.deepEqual(center.items[0]?.rewards, [{ type: "experience", label: "经验", amount: 40 }]);
+  assert.equal(center.items[0]?.turnCount, 1);
+  assert.equal(center.items[0]?.actionCount, 1);
+  assert.deepEqual(center.items[0]?.evidence, {
+    replay: "available",
+    rewards: "available"
+  });
+});
+
+test("player account read model derives a battle report center from replay and event inputs", () => {
+  const account = normalizePlayerAccountReadModel({
+    playerId: "player-1",
+    recentEventLog: [
+      {
+        id: "event-1",
+        timestamp: "2026-03-27T10:01:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        category: "combat",
+        description: "resolved",
+        heroId: "hero-1",
+        worldEventType: "battle.resolved",
+        rewards: [{ type: "experience", label: "经验", amount: 40 }]
+      }
+    ],
+    recentBattleReplays: [
+      {
+        id: "replay-1",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        battleId: "battle-1",
+        battleKind: "neutral",
+        playerCamp: "attacker",
+        heroId: "hero-1",
+        neutralArmyId: "neutral-1",
+        startedAt: "2026-03-27T10:00:00.000Z",
+        completedAt: "2026-03-27T10:01:00.000Z",
+        initialState: createEmptyBattleState({
+          id: "battle-1",
+          attackerHeroId: "hero-1",
+          defenderHeroId: "neutral-1"
+        }),
+        steps: [],
+        result: "attacker_victory"
+      }
+    ]
+  });
+
+  assert.equal(account.battleReportCenter?.latestReportId, "replay-1");
+  assert.equal(account.battleReportCenter?.items[0]?.result, "victory");
+  assert.deepEqual(account.battleReportCenter?.items[0]?.rewards, [{ type: "experience", label: "经验", amount: 40 }]);
+});

--- a/packages/shared/test/client-payload-contracts.test.ts
+++ b/packages/shared/test/client-payload-contracts.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  createBattleReportCenterFixture,
   createClientMessageFixtures,
   createPlayerProgressionSnapshotFixture,
   createRuntimeDiagnosticsSnapshotFixture,
@@ -19,6 +20,10 @@ test("shared contract snapshots stay stable for high-value client-facing payload
     {
       name: "session-state-payload",
       value: createSessionStatePayloadFixture()
+    },
+    {
+      name: "battle-report-center",
+      value: createBattleReportCenterFixture()
     },
     {
       name: "player-progression-snapshot",

--- a/packages/shared/test/fixtures/contract-snapshots/battle-report-center.json
+++ b/packages/shared/test/fixtures/contract-snapshots/battle-report-center.json
@@ -1,0 +1,32 @@
+{
+  "latestReportId": "room-contract:battle-demo:player-1",
+  "items": [
+    {
+      "id": "room-contract:battle-demo:player-1",
+      "replayId": "room-contract:battle-demo:player-1",
+      "roomId": "room-contract",
+      "playerId": "player-1",
+      "battleId": "battle-demo",
+      "battleKind": "neutral",
+      "playerCamp": "attacker",
+      "heroId": "hero-1",
+      "neutralArmyId": "neutral-1",
+      "startedAt": "2026-03-29T06:26:00.000Z",
+      "completedAt": "2026-03-29T06:30:00.000Z",
+      "result": "victory",
+      "turnCount": 1,
+      "actionCount": 2,
+      "rewards": [
+        {
+          "type": "experience",
+          "label": "hero_xp",
+          "amount": 120
+        }
+      ],
+      "evidence": {
+        "replay": "available",
+        "rewards": "available"
+      }
+    }
+  ]
+}

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -14,6 +14,7 @@ import {
   applyBattleOutcomeToWorld,
   applyAchievementMetricDelta,
   applyAchievementProgressValue,
+  buildPlayerBattleReportCenter,
   buildPlayerProgressionSnapshot,
   queryAchievementProgress,
   queryEventLogEntries,
@@ -1308,6 +1309,8 @@ test("player account read model helper normalizes progression, replays, and reso
   assert.deepEqual(account.recentBattleReplays.map((replay) => replay.id), ["replay-1"]);
   assert.equal(account.loginId, "captain");
   assert.equal(account.lastRoomId, "room-alpha");
+  assert.equal(account.battleReportCenter.latestReportId, "replay-1");
+  assert.equal(account.battleReportCenter.items[0]?.result, "victory");
 });
 
 test("player account read model helper falls back to empty progression collections", () => {
@@ -1317,6 +1320,10 @@ test("player account read model helper falls back to empty progression collectio
   assert.equal(account.achievements.length, getAchievementDefinitions().length);
   assert.deepEqual(account.recentEventLog, []);
   assert.deepEqual(account.recentBattleReplays, []);
+  assert.deepEqual(account.battleReportCenter, {
+    latestReportId: null,
+    items: []
+  });
   assert.deepEqual(account.globalResources, {
     gold: 0,
     wood: 0,
@@ -1382,6 +1389,57 @@ test("battle replay helpers normalize steps and keep newest unique replays first
   assert.deepEqual(merged.map((replay) => replay.id), ["replay-newer", "replay-older"]);
   assert.equal(merged[0]?.steps[0]?.index, 5);
   assert.equal(merged[1]?.steps[0]?.index, 9);
+});
+
+test("battle report helpers derive rewards, turn count, and evidence availability from replay plus event log", () => {
+  const battle = createEmptyBattleState({
+    id: "battle-1",
+    round: 1,
+    attackerHeroId: "hero-1",
+    defenderHeroId: "neutral-1"
+  });
+
+  const center = buildPlayerBattleReportCenter(
+    [
+      {
+        id: "replay-1",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        battleId: "battle-1",
+        battleKind: "neutral",
+        playerCamp: "attacker",
+        heroId: "hero-1",
+        neutralArmyId: "neutral-1",
+        startedAt: "2026-03-27T10:00:00.000Z",
+        completedAt: "2026-03-27T10:01:00.000Z",
+        initialState: battle,
+        steps: [{ index: 1, source: "player", action: { type: "battle.wait", unitId: "hero-1-stack" } }],
+        result: "attacker_victory"
+      }
+    ],
+    [
+      {
+        id: "event-1",
+        timestamp: "2026-03-27T10:01:00.000Z",
+        roomId: "room-alpha",
+        playerId: "player-1",
+        category: "combat",
+        description: "resolved",
+        heroId: "hero-1",
+        worldEventType: "battle.resolved",
+        rewards: [{ type: "experience", label: "经验", amount: 40 }]
+      }
+    ]
+  );
+
+  assert.equal(center.latestReportId, "replay-1");
+  assert.deepEqual(center.items[0]?.rewards, [{ type: "experience", label: "经验", amount: 40 }]);
+  assert.equal(center.items[0]?.turnCount, 1);
+  assert.equal(center.items[0]?.actionCount, 1);
+  assert.deepEqual(center.items[0]?.evidence, {
+    replay: "available",
+    rewards: "available"
+  });
 });
 
 test("battle replay query helper filters normalized summaries by replay metadata", () => {

--- a/packages/shared/test/support/multiplayer-protocol-fixtures.ts
+++ b/packages/shared/test/support/multiplayer-protocol-fixtures.ts
@@ -1,4 +1,5 @@
 import {
+  buildPlayerBattleReportCenter,
   buildPlayerProgressionSnapshot,
   createDefaultHeroLoadout,
   createDefaultHeroProgression,
@@ -246,6 +247,59 @@ export function createPlayerProgressionSnapshotFixture(): PlayerProgressionSnaps
       }
     ],
     3
+  );
+}
+
+export function createBattleReportCenterFixture() {
+  return buildPlayerBattleReportCenter(
+    [
+      {
+        id: "room-contract:battle-demo:player-1",
+        roomId: "room-contract",
+        playerId: "player-1",
+        battleId: "battle-demo",
+        battleKind: "neutral",
+        playerCamp: "attacker",
+        heroId: "hero-1",
+        neutralArmyId: "neutral-1",
+        startedAt: "2026-03-29T06:26:00.000Z",
+        completedAt: "2026-03-29T06:30:00.000Z",
+        initialState: createDemoBattleState(),
+        steps: [
+          {
+            index: 1,
+            source: "player",
+            action: {
+              type: "battle.attack",
+              attackerId: "hero-1-stack",
+              defenderId: "neutral-1-stack"
+            }
+          },
+          {
+            index: 2,
+            source: "automated",
+            action: {
+              type: "battle.defend",
+              unitId: "neutral-1-stack"
+            }
+          }
+        ],
+        result: "attacker_victory"
+      }
+    ],
+    [
+      {
+        id: "player-1:2026-03-29T06:30:00.000Z:battle.resolved:2",
+        timestamp: "2026-03-29T06:30:00.000Z",
+        roomId: "room-contract",
+        playerId: "player-1",
+        category: "combat",
+        description: "暮火侦骑 击退了中立守军。",
+        heroId: "hero-1",
+        worldEventType: "battle.resolved",
+        rewards: [{ type: "experience", label: "hero_xp", amount: 120 }]
+      }
+    ]
   );
 }
 


### PR DESCRIPTION
## Summary
- add a shared player battle report center contract with replay and reward evidence availability
- expose battle report summaries from player account routes and wire the H5/Cocos report center entry points to the new summary flow
- document the contract and add focused regressions for shared derivation, H5 report rendering, and Cocos latest-report/replay-center behavior

## Validation
- npm run typecheck:shared
- npm run typecheck:client:h5
- npm run typecheck:cocos
- node --import tsx --test ./packages/shared/test/battle-report.test.ts ./packages/shared/test/battle-report-center-contract.test.ts
- node --import tsx --test ./apps/client/test/account-history-render.test.ts
- node --import tsx --test ./apps/cocos-client/test/cocos-battle-report.test.ts ./apps/cocos-client/test/cocos-battle-replay-center.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts

## Notes
- Full `npm run typecheck:server` still reports unrelated pre-existing failures in `apps/server/src/admin-console.ts` and `apps/server/src/dev-server.ts`; the touched server files for this issue were syntax-validated via `node --import tsx`.

closes #534