### PR TITLE
feat(multiplayer): tighten PvP encounter UX, settlement feedback, and evidence coverage

### DIFF
--- a/apps/client/src/main-session-runtime.ts
+++ b/apps/client/src/main-session-runtime.ts
@@ -4,6 +4,12 @@ import type { SessionUpdate } from "./local-session";
 
 interface MainSessionRuntimeState {
   accountDraftName: string;
+  battle?: {
+    defenderHeroId?: string | null;
+  } | null;
+  lastBattleSettlement?: {
+    kind?: "pvp" | "pve" | "generic";
+  } | null;
   lobby: {
     authSession: StoredAuthSession | null;
   };
@@ -20,31 +26,46 @@ interface CreateMainSessionRuntimeOptions {
   render: () => void;
 }
 
-function summarizeRecoveryEvent(event: "reconnecting" | "reconnected" | "reconnect_failed"): {
+function summarizeRecoveryEvent(
+  event: "reconnecting" | "reconnected" | "reconnect_failed",
+  state: MainSessionRuntimeState
+): {
   connectionStatus: RuntimeDiagnosticsConnectionStatus;
   recoverySummary: string;
   logLine: string;
 } {
+  const inPvpEncounter = Boolean(state.battle?.defenderHeroId);
+  const recoveringPvpSettlement = state.lastBattleSettlement?.kind === "pvp";
   if (event === "reconnecting") {
     return {
       connectionStatus: "reconnecting",
-      recoverySummary: "连接暂时中断，正在尝试重新加入房间。",
-      logLine: "连接中断，正在尝试重连..."
+      recoverySummary: inPvpEncounter
+        ? "PVP 遭遇连接暂时中断，正在尝试重新加入当前对抗房间。"
+        : "连接暂时中断，正在尝试重新加入房间。",
+      logLine: inPvpEncounter ? "PVP 遭遇连接中断，正在尝试重连..." : "连接中断，正在尝试重连..."
     };
   }
 
   if (event === "reconnected") {
     return {
       connectionStatus: "connected",
-      recoverySummary: "连接已恢复，正在用最新房间状态校正地图与战斗结果。",
-      logLine: "连接已恢复"
+      recoverySummary: inPvpEncounter
+        ? "PVP 遭遇连接已恢复，正在用最新房间状态校正当前回合与战斗结果。"
+        : "连接已恢复，正在用最新房间状态校正地图与战斗结果。",
+      logLine: inPvpEncounter ? "PVP 遭遇连接已恢复" : "连接已恢复"
     };
   }
 
   return {
     connectionStatus: "reconnect_failed",
-    recoverySummary: "旧连接未恢复，正在改用持久化快照补救当前房间状态。",
-    logLine: "旧连接恢复失败，正在尝试从持久化快照恢复房间..."
+    recoverySummary:
+      inPvpEncounter || recoveringPvpSettlement
+        ? "PVP 遭遇旧连接未恢复，正在改用持久化快照补救当前房间状态。"
+        : "旧连接未恢复，正在改用持久化快照补救当前房间状态。",
+    logLine:
+      inPvpEncounter || recoveringPvpSettlement
+        ? "PVP 遭遇旧连接恢复失败，正在尝试从持久化快照恢复房间..."
+        : "旧连接恢复失败，正在尝试从持久化快照恢复房间..."
   };
 }
 
@@ -58,7 +79,7 @@ export function createMainSessionRuntime({ state, applyUpdate, render }: CreateM
       applyUpdate(update, "push");
     },
     onConnectionEvent: (event: "reconnecting" | "reconnected" | "reconnect_failed") => {
-      const next = summarizeRecoveryEvent(event);
+      const next = summarizeRecoveryEvent(event, state);
       state.diagnostics.connectionStatus = next.connectionStatus;
       state.diagnostics.recoverySummary = next.recoverySummary;
       state.log.unshift(next.logLine);

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -157,6 +157,7 @@ interface BattleFxState {
 
 interface BattleSettlementSummary {
   title: string;
+  kind: "pvp" | "pve" | "generic";
   summary: string;
   aftermath: string;
   roomState: string;
@@ -2358,6 +2359,7 @@ function buildBattleSettlementSummary(
       : null;
   const summaryParts = [rewardText, equipmentText ? `装备 ${equipmentText}` : null, progressText].filter(Boolean);
   const hero = activeHeroSnapshot(world);
+  const battleKind = event.defenderHeroId ? "pvp" : "pve";
   const winnerNextAction =
     hero && hero.move.remaining > 0
       ? "当前英雄仍可继续移动、交互，或直接推进到下一天。"
@@ -2370,12 +2372,13 @@ function buildBattleSettlementSummary(
   if (didWin) {
     return {
       title: "战斗胜利",
+      kind: battleKind,
       summary: event.defenderHeroId
-        ? `已击败 ${formatHeroIdentity(opponent, event.defenderHeroId)}。`
+        ? `PVP 胜利：已击败 ${formatHeroIdentity(opponent, event.defenderHeroId)}。`
         : "已击败本次守军。",
       aftermath: summaryParts.length > 0 ? `结算收益：${summaryParts.join(" · ")}。` : "结算完成，可继续处理房间内后续操作。",
       roomState: event.defenderHeroId
-        ? "英雄遭遇已关闭，房间已回到地图探索阶段，本次结果已对双方同步生效。"
+        ? "PVP 结算已回写到房间地图，房间已回到地图探索阶段，本次结果已对双方同步生效。"
         : "守军已清除，房间已回到地图探索阶段，可继续接管地图交互。",
       nextAction: winnerNextAction,
       tone: "victory"
@@ -2384,12 +2387,13 @@ function buildBattleSettlementSummary(
 
   return {
     title: "战斗失败",
+    kind: battleKind,
     summary: event.defenderHeroId
-      ? `遭遇战失利，对手 ${formatHeroIdentity(opponent, event.defenderHeroId ?? event.heroId)} 仍留在房间内。`
+      ? `PVP 失利：对手 ${formatHeroIdentity(opponent, event.defenderHeroId ?? event.heroId)} 仍留在房间内。`
       : "本次遭遇战失利。",
     aftermath: "英雄被击退，生命值下降且本日移动力清零。",
     roomState: event.defenderHeroId
-      ? "英雄遭遇已关闭，对手仍保留在房间地图上，当前结算已同步回写。"
+      ? "PVP 结算已回写到房间地图，对手仍保留在房间地图上，当前结算已同步回写。"
       : "守军仍保留在房间地图上，当前结算已同步回写。",
     nextAction: loserNextAction,
     tone: "defeat"
@@ -2916,6 +2920,7 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
   } else if (hadBattle && !update.battle && update.events.length === 0) {
     state.lastBattleSettlement = {
       title: "战斗结束",
+      kind: "generic",
       summary: "本场遭遇已结束。",
       aftermath: "房间状态已回到地图探索，可继续验证后续流程。",
       roomState: "本场遭遇链路已经关闭，房间已回到地图探索阶段。",

--- a/apps/client/src/room-feedback.ts
+++ b/apps/client/src/room-feedback.ts
@@ -2,8 +2,10 @@ import type { BattleState, CocosBattleFeedbackTone, MovementPlan, PlayerWorldVie
 import type { SessionUpdate } from "./local-session";
 
 interface BattleSettlementSummaryLike {
+  kind?: "pvp" | "pve" | "generic";
   title?: string;
   aftermath: string;
+  roomState?: string;
 }
 
 interface DiagnosticStateLike {
@@ -92,13 +94,14 @@ export function resolveRoomFeedbackTone(state: AppState): CocosBattleFeedbackTon
 }
 
 export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): string {
+  const isPvpSettlement = input.lastBattleSettlement != null && input.lastBattleSettlement.kind === "pvp";
   if (input.battle && input.lastEncounterStarted) {
     const event = input.lastEncounterStarted;
     const ownedIds = ownedHeroIds(input.world);
     if (event.encounterKind === "hero") {
       return ownedIds.has(event.heroId)
-        ? `遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到多人遭遇战结算，战斗会话 ${event.battleId} 已建立。`
-        : `遭遇来源：敌方英雄先手接触我方，当前房间已切到多人遭遇战结算，战斗会话 ${event.battleId} 已建立。`;
+        ? `遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到 PVP 多人遭遇战结算；对手身份、当前回合与房间归属现在统一挂到战斗会话 ${event.battleId}。`
+        : `遭遇来源：敌方英雄先手接触我方，当前房间已切到 PVP 多人遭遇战结算；对手身份、当前回合与房间归属现在统一挂到战斗会话 ${event.battleId}。`;
     }
 
     return event.initiator === "neutral"
@@ -108,8 +111,8 @@ export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): 
 
   if (input.previewPlan?.endsInEncounter) {
     return input.previewPlan.encounterKind === "hero"
-      ? "遭遇提示：确认移动后会立刻接敌，并锁定到英雄遭遇战。"
-      : "遭遇提示：确认移动后会立刻接敌，并锁定到中立遭遇战。";
+      ? "遭遇提示：确认移动后会立刻接敌，并锁定到 PVP 英雄遭遇战；进入后会先展示对手摘要与战斗会话。"
+      : "遭遇提示：确认移动后会立刻接敌，并锁定到 PVE 中立遭遇战。";
   }
 
   if (input.lastBattleSettlement) {
@@ -117,10 +120,16 @@ export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): 
   }
 
   if (input.diagnostics.connectionStatus === "reconnecting") {
+    if (input.battle?.defenderHeroId) {
+      return `连接反馈：PVP 遭遇 ${input.world.meta.roomId}/${input.battle.id} 连接中断，正在恢复对手归属、当前回合与房间主状态；恢复前请以权威状态为准。`;
+    }
     return "连接反馈：房间连接中断，正在恢复多人房间与战斗归属；恢复前请以权威状态为准。";
   }
 
   if (input.diagnostics.connectionStatus === "reconnect_failed") {
+    if (input.battle?.defenderHeroId || isPvpSettlement) {
+      return "连接反馈：PVP 遭遇旧连接恢复失败，正在通过最近快照回补当前胜负、回合归属和房间状态；短暂期间可能只显示缓存状态。";
+    }
     return "连接反馈：旧连接恢复失败，正在通过最近快照回补房间；短暂期间可能只显示缓存状态。";
   }
 
@@ -132,7 +141,11 @@ export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): 
 }
 
 export function renderRoomActionHint(input: RoomActionHintInput): string {
+  const isPvpSettlement = input.lastBattleSettlement != null && input.lastBattleSettlement.kind === "pvp";
   if (input.diagnostics.connectionStatus === "reconnecting") {
+    if (input.battle?.defenderHeroId) {
+      return "下一步：等待 PVP 遭遇恢复完成；此时先不要依赖本地预览判断胜负或当前回合归属。";
+    }
     return "下一步：等待重连恢复完成；此时先不要依赖本地预览判断最终房间结果。";
   }
 
@@ -140,6 +153,9 @@ export function renderRoomActionHint(input: RoomActionHintInput): string {
     input.diagnostics.connectionStatus === "reconnect_failed" ||
     input.predictionStatus.includes("已回放本地缓存状态")
   ) {
+    if (input.battle?.defenderHeroId || isPvpSettlement) {
+      return "下一步：等待权威房间状态回补；恢复完成后再确认胜负、当前回合与是否还能继续移动。";
+    }
     return "下一步：等待权威房间状态回补；恢复完成后再继续地图移动或确认战后结果。";
   }
 
@@ -164,16 +180,25 @@ export function renderRoomActionHint(input: RoomActionHintInput): string {
 
 export function renderRoomResultSummary(input: {
   battle: BattleState | null;
-  lastBattleSettlement: { roomState: string } | null;
+  lastBattleSettlement: { kind?: "pvp" | "pve" | "generic"; roomState: string } | null;
   diagnostics: DiagnosticStateLike;
   predictionStatus: string;
   roomId: string;
 }): string {
+  const isPvpSettlement = input.lastBattleSettlement != null && input.lastBattleSettlement.kind === "pvp";
   if (input.diagnostics.connectionStatus === "reconnecting") {
+    if (input.battle?.defenderHeroId) {
+      return `房间结果：PVP 遭遇 ${input.roomId}/${input.battle.id} 正在恢复连接；期间请以恢复后的权威胜负、回合归属和房间阶段为准。`;
+    }
     return "房间结果：正在恢复连接与房间主状态，期间请以恢复后的权威结果为准。";
   }
 
   if (input.diagnostics.connectionStatus === "reconnect_failed") {
+    if (input.battle?.defenderHeroId || isPvpSettlement) {
+      return input.battle?.defenderHeroId
+        ? `房间结果：PVP 遭遇 ${input.roomId}/${input.battle.id} 的旧连接未恢复，正在通过最近快照回补当前胜负、回合归属和房间状态。`
+        : "房间结果：PVP 结算旧连接未恢复，正在通过最近快照回补当前胜负与房间状态。";
+    }
     return "房间结果：旧连接未恢复，正在通过最近快照回补房间，等待权威状态确认当前可行动信息。";
   }
 
@@ -182,7 +207,7 @@ export function renderRoomResultSummary(input: {
   }
 
   if (input.diagnostics.recoverySummary && input.lastBattleSettlement) {
-    return `房间结果：${trimTrailingPunctuation(input.diagnostics.recoverySummary)}；当前结算已同步回写。`;
+    return `房间结果：${trimTrailingPunctuation(input.diagnostics.recoverySummary)}；当前${isPvpSettlement ? " PVP" : ""}结算已同步回写。`;
   }
 
   if (input.diagnostics.recoverySummary && input.battle) {
@@ -198,7 +223,9 @@ export function renderRoomResultSummary(input: {
   }
 
   if (input.battle) {
-    return `房间结果：多人遭遇战已接管地图行动，当前由 遭遇会话：${input.roomId}/${input.battle.id} 驱动；待战斗链路关闭后统一回写房间状态。`;
+    return input.battle.defenderHeroId
+      ? `房间结果：PVP 遭遇战已接管地图行动，当前由 遭遇会话：${input.roomId}/${input.battle.id} 驱动；待战斗链路关闭后统一回写房间状态。`
+      : `房间结果：多人遭遇战已接管地图行动，当前由 遭遇会话：${input.roomId}/${input.battle.id} 驱动；待战斗链路关闭后统一回写房间状态。`;
   }
 
   return "房间结果：当前处于稳定探索态，等待新的移动、交互或多人遭遇。";
@@ -210,11 +237,18 @@ export function renderRecoverySummary(input: {
   diagnostics: DiagnosticStateLike;
   predictionStatus: string;
 }): string {
+  const isPvpSettlement = input.lastBattleSettlement != null && input.lastBattleSettlement.kind === "pvp";
   if (input.diagnostics.connectionStatus === "reconnecting") {
+    if (input.battle?.defenderHeroId) {
+      return "恢复状态：正在重新加入 PVP 遭遇并校正对手归属、当前回合与房间状态，结果请以恢复后的权威状态为准。";
+    }
     return "恢复状态：正在重新加入多人房间并校正战斗归属，结果请以恢复后的权威状态为准。";
   }
 
   if (input.diagnostics.connectionStatus === "reconnect_failed") {
+    if (input.battle?.defenderHeroId || isPvpSettlement) {
+      return "恢复状态：PVP 遭遇旧连接恢复失败，已切换到快照回补链路；当前先展示最近缓存与回补进度。";
+    }
     return "恢复状态：旧连接恢复失败，已切换到快照回补链路；当前先展示最近缓存与回补进度。";
   }
 
@@ -229,7 +263,9 @@ export function renderRecoverySummary(input: {
   if (input.lastBattleSettlement) {
     return input.battle
       ? "恢复状态：战后房间仍在切换阶段，等待当前战斗链路完全关闭。"
-      : "恢复状态：最近一场遭遇的结算与地图房间态已经重新对齐。";
+      : isPvpSettlement
+        ? "恢复状态：最近一场 PVP 遭遇的结算与地图房间态已经重新对齐。"
+        : "恢复状态：最近一场遭遇的结算与地图房间态已经重新对齐。";
   }
 
   return "恢复状态：当前未触发重连补救，房间同步保持稳定。";

--- a/apps/client/test/main-session-runtime.test.ts
+++ b/apps/client/test/main-session-runtime.test.ts
@@ -126,3 +126,41 @@ test("createMainSessionRuntime maps reconnect transitions to stable diagnostics 
   assert.deepEqual(renders, ["reconnecting", "connected", "reconnect_failed"]);
   assert.equal(runtime.getAuthToken(), null);
 });
+
+test("createMainSessionRuntime specializes reconnect copy for active pvp encounters", () => {
+  const state = {
+    accountDraftName: "访客骑士",
+    battle: {
+      defenderHeroId: "hero-2"
+    },
+    lastBattleSettlement: null,
+    lobby: {
+      authSession: null
+    },
+    diagnostics: {
+      connectionStatus: "connecting" as const,
+      recoverySummary: null as string | null
+    },
+    log: []
+  };
+
+  const runtime = createMainSessionRuntime({
+    state,
+    applyUpdate: () => {
+      throw new Error("push updates are not part of this assertion");
+    },
+    render: () => undefined
+  });
+
+  runtime.onConnectionEvent("reconnecting");
+  assert.equal(state.diagnostics.recoverySummary, "PVP 遭遇连接暂时中断，正在尝试重新加入当前对抗房间。");
+  assert.equal(state.log[0], "PVP 遭遇连接中断，正在尝试重连...");
+
+  runtime.onConnectionEvent("reconnected");
+  assert.equal(state.diagnostics.recoverySummary, "PVP 遭遇连接已恢复，正在用最新房间状态校正当前回合与战斗结果。");
+  assert.equal(state.log[0], "PVP 遭遇连接已恢复");
+
+  runtime.onConnectionEvent("reconnect_failed");
+  assert.equal(state.diagnostics.recoverySummary, "PVP 遭遇旧连接未恢复，正在改用持久化快照补救当前房间状态。");
+  assert.equal(state.log[0], "PVP 遭遇旧连接恢复失败，正在尝试从持久化快照恢复房间...");
+});

--- a/apps/client/test/room-feedback.test.ts
+++ b/apps/client/test/room-feedback.test.ts
@@ -100,7 +100,8 @@ function createBattle(): BattleState {
     rng: {
       seed: 1,
       cursor: 0
-    }
+    },
+    defenderHeroId: "hero-2"
   };
 }
 
@@ -158,7 +159,7 @@ test("renderEncounterSourceDetail covers active hero encounter initiative branch
       battle: activeBattle,
       lastEncounterStarted: createEncounterStartedEvent()
     }),
-    "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到多人遭遇战结算，战斗会话 battle-1 已建立。"
+    "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到 PVP 多人遭遇战结算；对手身份、当前回合与房间归属现在统一挂到战斗会话 battle-1。"
   );
 
   assert.equal(
@@ -170,7 +171,7 @@ test("renderEncounterSourceDetail covers active hero encounter initiative branch
         defenderHeroId: "hero-1"
       })
     }),
-    "遭遇来源：敌方英雄先手接触我方，当前房间已切到多人遭遇战结算，战斗会话 battle-1 已建立。"
+    "遭遇来源：敌方英雄先手接触我方，当前房间已切到 PVP 多人遭遇战结算；对手身份、当前回合与房间归属现在统一挂到战斗会话 battle-1。"
   );
 });
 
@@ -216,7 +217,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
         encounterRefId: "hero-2"
       })
     }),
-    "遭遇提示：确认移动后会立刻接敌，并锁定到英雄遭遇战。"
+    "遭遇提示：确认移动后会立刻接敌，并锁定到 PVP 英雄遭遇战；进入后会先展示对手摘要与战斗会话。"
   );
 
   assert.equal(
@@ -228,7 +229,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
         encounterRefId: "neutral-1"
       })
     }),
-    "遭遇提示：确认移动后会立刻接敌，并锁定到中立遭遇战。"
+    "遭遇提示：确认移动后会立刻接敌，并锁定到 PVE 中立遭遇战。"
   );
 
   assert.equal(
@@ -244,21 +245,23 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
   assert.equal(
     renderEncounterSourceDetail({
       ...createEncounterSourceInput(),
+      battle: createBattle(),
       diagnostics: {
         connectionStatus: "reconnecting"
       }
     }),
-    "连接反馈：房间连接中断，正在恢复多人房间与战斗归属；恢复前请以权威状态为准。"
+    "连接反馈：PVP 遭遇 room-alpha/battle-1 连接中断，正在恢复对手归属、当前回合与房间主状态；恢复前请以权威状态为准。"
   );
 
   assert.equal(
     renderEncounterSourceDetail({
       ...createEncounterSourceInput(),
+      battle: createBattle(),
       diagnostics: {
         connectionStatus: "reconnect_failed"
       }
     }),
-    "连接反馈：旧连接恢复失败，正在通过最近快照回补房间；短暂期间可能只显示缓存状态。"
+    "连接反馈：PVP 遭遇旧连接恢复失败，正在通过最近快照回补当前胜负、回合归属和房间状态；短暂期间可能只显示缓存状态。"
   );
 
   assert.equal(
@@ -273,7 +276,7 @@ test("renderEncounterSourceDetail covers preview, settlement, reconnect, and rep
 test("renderRoomActionHint covers recovery, battle active, and missing hero states", () => {
   assert.equal(
     renderRoomActionHint({
-      battle: null,
+      battle: createBattle(),
       lastBattleSettlement: null,
       activeHero: {
         move: {
@@ -286,12 +289,12 @@ test("renderRoomActionHint covers recovery, battle active, and missing hero stat
       },
       predictionStatus: ""
     }),
-    "下一步：等待重连恢复完成；此时先不要依赖本地预览判断最终房间结果。"
+    "下一步：等待 PVP 遭遇恢复完成；此时先不要依赖本地预览判断胜负或当前回合归属。"
   );
 
   assert.equal(
     renderRoomActionHint({
-      battle: null,
+      battle: createBattle(),
       lastBattleSettlement: null,
       activeHero: {
         move: {
@@ -304,7 +307,7 @@ test("renderRoomActionHint covers recovery, battle active, and missing hero stat
       },
       predictionStatus: ""
     }),
-    "下一步：等待权威房间状态回补；恢复完成后再继续地图移动或确认战后结果。"
+    "下一步：等待权威房间状态回补；恢复完成后再确认胜负、当前回合与是否还能继续移动。"
   );
 
   assert.equal(
@@ -420,26 +423,26 @@ test("renderRoomActionHint covers settlement and exploration move branches", () 
 test("renderRecoverySummary covers reconnect, replay fallback, explicit recovery, and steady state branches", () => {
   assert.equal(
     renderRecoverySummary({
-      battle: null,
+      battle: createBattle(),
       lastBattleSettlement: null,
       diagnostics: {
         connectionStatus: "reconnecting"
       },
       predictionStatus: ""
     }),
-    "恢复状态：正在重新加入多人房间并校正战斗归属，结果请以恢复后的权威状态为准。"
+    "恢复状态：正在重新加入 PVP 遭遇并校正对手归属、当前回合与房间状态，结果请以恢复后的权威状态为准。"
   );
 
   assert.equal(
     renderRecoverySummary({
-      battle: null,
-      lastBattleSettlement: null,
+      battle: createBattle(),
+      lastBattleSettlement: { kind: "pvp", aftermath: "已结算" },
       diagnostics: {
-        connectionStatus: "connected"
+        connectionStatus: "reconnect_failed"
       },
-      predictionStatus: "已回放本地缓存状态，正在等待房间同步..."
+      predictionStatus: ""
     }),
-    "恢复状态：已回放本地缓存状态，正在等待房间同步..."
+    "恢复状态：PVP 遭遇旧连接恢复失败，已切换到快照回补链路；当前先展示最近缓存与回补进度。"
   );
 
   assert.equal(
@@ -459,6 +462,7 @@ test("renderRecoverySummary covers reconnect, replay fallback, explicit recovery
     renderRecoverySummary({
       battle: null,
       lastBattleSettlement: {
+        kind: "pvp",
         aftermath: "已结算"
       },
       diagnostics: {
@@ -466,7 +470,7 @@ test("renderRecoverySummary covers reconnect, replay fallback, explicit recovery
       },
       predictionStatus: ""
     }),
-    "恢复状态：最近一场遭遇的结算与地图房间态已经重新对齐。"
+    "恢复状态：最近一场 PVP 遭遇的结算与地图房间态已经重新对齐。"
   );
 
   assert.equal(
@@ -538,8 +542,9 @@ test("resolveRecoveryRoomStateLabel distinguishes pending, fallback, and restore
 test("renderRoomResultSummary prioritizes reconnect guidance over stale settlement copy and surfaces restored state", () => {
   assert.equal(
     renderRoomResultSummary({
-      battle: null,
+      battle: createBattle(),
       lastBattleSettlement: {
+        kind: "pvp",
         roomState: "房间已回到地图探索阶段。"
       },
       diagnostics: {
@@ -548,7 +553,7 @@ test("renderRoomResultSummary prioritizes reconnect guidance over stale settleme
       predictionStatus: "",
       roomId: "room-alpha"
     }),
-    "房间结果：正在恢复连接与房间主状态，期间请以恢复后的权威结果为准。"
+    "房间结果：PVP 遭遇 room-alpha/battle-1 正在恢复连接；期间请以恢复后的权威胜负、回合归属和房间阶段为准。"
   );
 
   assert.equal(
@@ -569,6 +574,7 @@ test("renderRoomResultSummary prioritizes reconnect guidance over stale settleme
     renderRoomResultSummary({
       battle: null,
       lastBattleSettlement: {
+        kind: "pvp",
         roomState: "房间已回到地图探索阶段。"
       },
       diagnostics: {
@@ -578,7 +584,7 @@ test("renderRoomResultSummary prioritizes reconnect guidance over stale settleme
       predictionStatus: "",
       roomId: "room-alpha"
     }),
-    "房间结果：权威房间状态已恢复，战后结果与地图状态已经重新对齐；当前结算已同步回写。"
+    "房间结果：权威房间状态已恢复，战后结果与地图状态已经重新对齐；当前 PVP结算已同步回写。"
   );
 });
 

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -2961,12 +2961,19 @@ export class VeilRoot extends Component {
   private handleConnectionEvent(event: ConnectionEvent): void {
     this.diagnosticsConnectionStatus =
       event === "reconnecting" ? "reconnecting" : event === "reconnected" ? "connected" : "reconnect_failed";
+    const activePvpBattle = Boolean(this.lastUpdate?.battle?.defenderHeroId);
     const label =
       event === "reconnecting"
-        ? "连接已中断，正在尝试重连..."
+        ? activePvpBattle
+          ? "PVP 遭遇连接已中断，正在尝试重连..."
+          : "连接已中断，正在尝试重连..."
         : event === "reconnected"
-          ? "连接已恢复。"
-          : "重连失败，正在尝试恢复房间快照...";
+          ? activePvpBattle
+            ? "PVP 遭遇连接已恢复。"
+            : "连接已恢复。"
+          : activePvpBattle
+            ? "PVP 遭遇重连失败，正在尝试恢复房间快照..."
+            : "重连失败，正在尝试恢复房间快照...";
     if (this.showLobby) {
       this.lobbyStatus = label;
     }
@@ -3192,12 +3199,19 @@ export class VeilRoot extends Component {
     const indicators: VeilHudRenderState["sessionIndicators"] = [];
     const replayingCachedSnapshot =
       this.lastRoomUpdateSource === "replay" && this.lastRoomUpdateReason === "cached_snapshot";
+    const activePvpBattle = this.lastUpdate?.battle?.defenderHeroId
+      ? {
+          sessionId: `${this.lastUpdate.world.meta.roomId}/${this.lastUpdate.battle.id}`
+        }
+      : null;
 
     if (this.diagnosticsConnectionStatus === "reconnecting") {
       indicators.push({
         kind: "reconnecting",
-        label: "重连中",
-        detail: "正在尝试恢复与权威房间的连接。"
+        label: activePvpBattle ? "PVP 重连中" : "重连中",
+        detail: activePvpBattle
+          ? `正在恢复 ${activePvpBattle.sessionId} 的对手归属、当前回合与权威房间状态。`
+          : "正在尝试恢复与权威房间的连接。"
       });
     }
 
@@ -3217,8 +3231,10 @@ export class VeilRoot extends Component {
     if (this.diagnosticsConnectionStatus === "reconnect_failed") {
       indicators.push({
         kind: "degraded_offline_fallback",
-        label: "降级/离线回退",
-        detail: "最近一次重连失败，客户端正依赖回退路径维持会话。"
+        label: activePvpBattle ? "PVP 快照回补" : "降级/离线回退",
+        detail: activePvpBattle
+          ? `最近一次 ${activePvpBattle.sessionId} 重连失败，客户端正依赖回退路径恢复当前对抗结果。`
+          : "最近一次重连失败，客户端正依赖回退路径维持会话。"
       });
     }
 

--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -79,9 +79,12 @@ export function buildBattleTransitionFeedback(
   const battle = update.battle;
   const started = update.events.find((event) => event.type === "battle.started");
   if (battle && started) {
+    const isPvp = Boolean(battle.defenderHeroId);
     return {
-      title: battle.defenderHeroId ? "英雄遭遇已展开" : "中立遭遇已展开",
-      detail: battle.log[battle.log.length - 1] ?? "战斗开始",
+      title: isPvp ? "PVP 对抗已展开" : "PVE 遭遇已展开",
+      detail: isPvp
+        ? `对手 ${battle.defenderHeroId ?? "未知"} · 遭遇会话 ${update.world.meta.roomId}/${battle.id} 已建立`
+        : battle.log[battle.log.length - 1] ?? "战斗开始",
       badge: "ENGAGE",
       tone: "action"
     };
@@ -95,7 +98,7 @@ export function buildBattleTransitionFeedback(
 
     const settlement = buildBattleSettlementSummary(previousBattle, update, heroId);
     return {
-      title: "战斗收束",
+      title: previousBattle?.defenderHeroId ? "PVP 结算同步中" : "战斗收束",
       detail: settlement.detail,
       badge: "SETTLE",
       tone: "neutral"
@@ -111,7 +114,7 @@ export function buildBattleTransitionFeedback(
   const settlement = buildBattleSettlementSummary(previousBattle, update, heroId);
 
   return {
-    title: didWin ? "战斗胜利" : "战斗失利",
+    title: previousBattle?.defenderHeroId ? (didWin ? "PVP 胜利" : "PVP 失利") : didWin ? "战斗胜利" : "战斗失利",
     detail: settlement.detail,
     badge: didWin ? "WIN" : "LOSE",
     tone: didWin ? "victory" : "defeat"
@@ -247,17 +250,40 @@ function buildBattleSettlementSummary(
 ): BattleSettlementSummary {
   const rewards = collectSettlementRewardParts(update);
   const fieldStatus = describeSettlementFieldState(previousBattle, heroId);
+  const encounterStatus = describeSettlementEncounterState(previousBattle, heroId);
   const lines = [fieldStatus, ...rewards];
   const detailParts = [
+    encounterStatus,
     fieldStatus,
     rewards.length > 0 ? rewards.join(" / ") : null,
-    "准备返回世界地图"
+    previousBattle?.defenderHeroId ? "准备回写 PVP 世界态" : "准备返回世界地图"
   ].filter((part): part is string => Boolean(part));
 
   return {
     detail: detailParts.join(" · "),
     lines
   };
+}
+
+function describeSettlementEncounterState(previousBattle: BattleState | null, heroId: string | null): string {
+  if (!previousBattle) {
+    return "遭遇已关闭";
+  }
+
+  if (!previousBattle.defenderHeroId) {
+    return "PVE 遭遇已关闭";
+  }
+
+  const heroCamp = resolveHeroCamp(previousBattle, heroId);
+  const didHoldField =
+    heroCamp === "attacker"
+      ? countAliveUnits(previousBattle, "attacker") >= countAliveUnits(previousBattle, "defender")
+      : heroCamp === "defender"
+        ? countAliveUnits(previousBattle, "defender") >= countAliveUnits(previousBattle, "attacker")
+        : true;
+  return didHoldField
+    ? `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇`
+    : `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在房间地图上`;
 }
 
 function collectSettlementRewardParts(update: SessionUpdate): string[] {

--- a/apps/cocos-client/assets/scripts/cocos-battle-transition-copy.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-transition-copy.ts
@@ -38,15 +38,25 @@ export function buildBattleEnterCopy(update: SessionUpdate): BattleTransitionCop
   if (event.encounterKind === "hero") {
     return {
       badge: "PVP",
-      title: event.defenderHeroId ? `敌方英雄 ${event.defenderHeroId}` : "敌方英雄遭遇",
+      title: event.defenderHeroId ? `PVP 对手 ${event.defenderHeroId}` : "PVP 英雄遭遇",
       subtitle: joinParts([
         terrainLabel,
         encounterPosition ? formatEncounterPosition(encounterPosition) : null,
-        event.initiator === "neutral" ? "对手抢先切入，准备迎战" : "双方部队展开接战"
+        `${update.world.meta.roomId}/${event.battleId}`,
+        event.initiator === "neutral" ? "对手抢先切入，多人对抗即将展开" : "我方先手切入，多人对抗即将展开"
       ]),
       tone: "enter",
       terrain,
-      detailChips: []
+      detailChips: [
+        {
+          icon: "hero",
+          label: event.defenderHeroId ? `对手 ${event.defenderHeroId}` : "对手英雄"
+        },
+        {
+          icon: "battle",
+          label: `${update.world.meta.roomId}/${event.battleId}`
+        }
+      ]
     };
   }
 
@@ -69,12 +79,17 @@ export function buildBattleExitCopy(previousBattle: SessionUpdate["battle"], upd
   const encounterPosition = previousBattle?.encounterPosition ?? null;
   const terrainLabel = terrain ? formatBattleTerrainLabel(terrain) : null;
   const detailChips = buildBattleExitDetailChips(update.events);
+  const isPvp = Boolean(previousBattle?.defenderHeroId);
 
   if (!didWin) {
     return {
-      badge: "RETREAT",
-      title: "战斗失利",
-      subtitle: joinParts([terrainLabel, encounterPosition ? formatEncounterPosition(encounterPosition) : null, "部队需要整顿后再战"]),
+      badge: isPvp ? "PVP" : "RETREAT",
+      title: isPvp ? "英雄对决失利" : "战斗失利",
+      subtitle: joinParts([
+        terrainLabel,
+        encounterPosition ? formatEncounterPosition(encounterPosition) : null,
+        isPvp ? "对手仍保留在房间地图上，等待世界态回写" : "部队需要整顿后再战"
+      ]),
       tone: "defeat",
       terrain,
       detailChips: detailChips.slice(0, 3)
@@ -82,9 +97,13 @@ export function buildBattleExitCopy(previousBattle: SessionUpdate["battle"], upd
   }
 
   return {
-    badge: "VICTORY",
-    title: "战斗胜利",
-    subtitle: joinParts([terrainLabel, encounterPosition ? formatEncounterPosition(encounterPosition) : null, "返回世界地图，继续推进前线"]),
+    badge: isPvp ? "PVP" : "VICTORY",
+    title: isPvp ? "英雄对决胜利" : "战斗胜利",
+    subtitle: joinParts([
+      terrainLabel,
+      encounterPosition ? formatEncounterPosition(encounterPosition) : null,
+      isPvp ? "PVP 结算已回写，房间返回世界地图" : "返回世界地图，继续推进前线"
+    ]),
     tone: "victory",
     terrain,
     detailChips: detailChips.slice(0, 3)

--- a/apps/cocos-client/test/cocos-battle-feedback.test.ts
+++ b/apps/cocos-client/test/cocos-battle-feedback.test.ts
@@ -222,6 +222,49 @@ test("battle feedback summarizes action, progress, and outcome", () => {
   assert.match(unsettledFeedback?.detail ?? "", /准备返回世界地图/);
 });
 
+test("battle feedback calls out pvp encounter identity and settlement state", () => {
+  const pvpBattle: BattleState = {
+    ...createBattleState(),
+    id: "battle-pvp",
+    defenderHeroId: "hero-9",
+    neutralArmyId: undefined
+  };
+
+  const pvpEnter = buildBattleTransitionFeedback(
+    {
+      ...createResolvedUpdate("attacker_victory"),
+      battle: pvpBattle,
+      events: [
+        {
+          type: "battle.started",
+          heroId: "hero-1",
+          encounterKind: "hero",
+          defenderHeroId: "hero-9",
+          initiator: "hero",
+          battleId: "battle-pvp",
+          path: [{ x: 0, y: 0 }],
+          moveCost: 1
+        }
+      ]
+    },
+    "hero-1"
+  );
+  assert.equal(pvpEnter?.title, "PVP 对抗已展开");
+  assert.match(pvpEnter?.detail ?? "", /room-alpha\/battle-pvp/);
+
+  const pvpSettlement = buildBattleTransitionFeedback(
+    {
+      ...createResolvedUpdate("attacker_victory"),
+      events: []
+    },
+    "hero-1",
+    pvpBattle
+  );
+  assert.equal(pvpSettlement?.title, "PVP 结算同步中");
+  assert.match(pvpSettlement?.detail ?? "", /PVP 结算：对手 hero-9/);
+  assert.match(pvpSettlement?.detail ?? "", /准备回写 PVP 世界态/);
+});
+
 test("battle presentation plan formalizes enter, impact, and resolution phases", () => {
   const battle = createBattleState();
   const actionPlan = buildBattleActionPresentation(
@@ -294,7 +337,7 @@ test("battle presentation plan formalizes enter, impact, and resolution phases",
   assert.equal(resolutionPlan.transition?.copy.badge, "VICTORY");
   assert.deepEqual(resolutionPlan.state.summaryLines.slice(0, 2), [
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
-    "播报：战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
+    "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
   ]);
 
   const unsettledResolutionPlan = buildBattlePresentationPlan(

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -104,7 +104,7 @@ test("buildBattlePanelViewModel surfaces settlement and presentation layer summa
     actionPending: false,
     feedback: {
       title: "战斗胜利",
-      detail: "战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+      detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
       badge: "WIN",
       tone: "victory"
     },
@@ -113,13 +113,13 @@ test("buildBattlePanelViewModel surfaces settlement and presentation layer summa
       phase: "resolution",
       moment: "result_victory",
       label: "战斗胜利",
-      detail: "战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+      detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
       badge: "WIN",
       tone: "victory",
       result: "victory",
       summaryLines: [
         "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
-        "播报：战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+        "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
         "战利品：金币 +12"
       ],
       feedbackLayer: {
@@ -136,7 +136,7 @@ test("buildBattlePanelViewModel surfaces settlement and presentation layer summa
   assert.deepEqual(view.summaryLines, [
     "战斗胜利",
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
-    "播报：战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+    "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
     "战利品：金币 +12"
   ]);
 });
@@ -150,7 +150,7 @@ test("buildBattlePanelViewModel keeps neutral settlement in the battle result sh
     actionPending: false,
     feedback: {
       title: "战斗收束",
-      detail: "战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图",
+      detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图",
       badge: "SETTLE",
       tone: "neutral"
     },
@@ -159,13 +159,13 @@ test("buildBattlePanelViewModel keeps neutral settlement in the battle result sh
       phase: "resolution",
       moment: "result_settlement",
       label: "战斗收束",
-      detail: "战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图",
+      detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图",
       badge: "SETTLE",
       tone: "neutral",
       result: null,
       summaryLines: [
         "反馈层：动画 待机",
-        "播报：战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
+        "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
       ],
       feedbackLayer: {
         animation: "idle",

--- a/apps/cocos-client/test/cocos-battle-panel.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel.test.ts
@@ -98,7 +98,7 @@ test("VeilBattlePanel preserves settlement feedback after battle resolution", ()
       update: { ...createBattleUpdate(), battle: null },
       feedback: {
         title: "战斗胜利",
-        detail: "战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+        detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
         badge: "WIN",
         tone: "victory"
       },
@@ -107,13 +107,13 @@ test("VeilBattlePanel preserves settlement feedback after battle resolution", ()
         phase: "resolution",
         moment: "result_victory",
         label: "战斗胜利",
-        detail: "战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+        detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
         badge: "WIN",
         tone: "victory",
         result: "victory",
         summaryLines: [
           "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
-          "播报：战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
+          "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
           "战利品：金币 +12"
         ],
         feedbackLayer: {

--- a/apps/cocos-client/test/cocos-battle-transition-copy.test.ts
+++ b/apps/cocos-client/test/cocos-battle-transition-copy.test.ts
@@ -89,6 +89,12 @@ function createBattleEnterUpdate(event: WorldEvent, terrain: TerrainType, encoun
         cursor: 0
       },
       worldHeroId: "hero-1",
+      ...(event.type === "battle.started" && event.encounterKind === "hero" && event.defenderHeroId
+        ? { defenderHeroId: event.defenderHeroId }
+        : {}),
+      ...(event.type === "battle.started" && event.encounterKind === "neutral" && event.neutralArmyId
+        ? { neutralArmyId: event.neutralArmyId }
+        : {}),
       encounterPosition
     },
     events: [event],
@@ -137,9 +143,47 @@ test("buildBattleEnterCopy distinguishes pve and pvp encounters", () => {
   ));
   assert.deepEqual(heroEnter, {
     badge: "PVP",
-    title: "敌方英雄 hero-2",
-    subtitle: "草野战场 · 坐标 (3,5) · 双方部队展开接战",
+    title: "PVP 对手 hero-2",
+    subtitle: "草野战场 · 坐标 (3,5) · room-alpha/battle-2 · 我方先手切入，多人对抗即将展开",
     tone: "enter",
+    terrain: "grass",
+    detailChips: [
+      { icon: "hero", label: "对手 hero-2" },
+      { icon: "battle", label: "room-alpha/battle-2" }
+    ]
+  });
+});
+
+test("buildBattleExitCopy distinguishes pvp settlement from pve settlement", () => {
+  const update = createBattleEnterUpdate(
+    {
+      type: "battle.started",
+      heroId: "hero-1",
+      encounterKind: "hero",
+      defenderHeroId: "hero-2",
+      initiator: "hero",
+      battleId: "battle-pvp",
+      path: [{ x: 2, y: 2 }, { x: 3, y: 2 }],
+      moveCost: 1
+    },
+    "grass",
+    { x: 3, y: 2 }
+  );
+
+  assert.deepEqual(buildBattleExitCopy(update.battle, update, true), {
+    badge: "PVP",
+    title: "英雄对决胜利",
+    subtitle: "草野战场 · 坐标 (3,2) · PVP 结算已回写，房间返回世界地图",
+    tone: "victory",
+    terrain: "grass",
+    detailChips: []
+  });
+
+  assert.deepEqual(buildBattleExitCopy(update.battle, update, false), {
+    badge: "PVP",
+    title: "英雄对决失利",
+    subtitle: "草野战场 · 坐标 (3,2) · 对手仍保留在房间地图上，等待世界态回写",
+    tone: "defeat",
     terrain: "grass",
     detailChips: []
   });

--- a/apps/cocos-client/test/cocos-release-candidate-snapshot.test.ts
+++ b/apps/cocos-client/test/cocos-release-candidate-snapshot.test.ts
@@ -103,7 +103,7 @@ test("release:cocos-rc:snapshot writes a reusable template", () => {
   );
   assert.deepEqual(
     snapshot.journey.map((entry) => entry.id),
-    ["lobby-entry", "room-join", "map-explore", "first-battle", "reconnect-restore", "return-to-world"]
+    ["lobby-entry", "room-join", "map-explore", "first-battle", "pvp-encounter", "reconnect-restore", "return-to-world"]
   );
   assert.ok(snapshot.journey.every((entry) => entry.status === "pending"));
 });

--- a/docs/cocos-release-evidence-template.md
+++ b/docs/cocos-release-evidence-template.md
@@ -82,7 +82,7 @@ npm run release:cocos-rc:snapshot -- \
 - `requiredEvidence`
   - 四个强制证据字段：`roomId`、`reconnectPrompt`、`restoredState`、`firstBattleResult`
 - `journey`
-  - 六个固定主链路节点：`lobby-entry`、`room-join`、`map-explore`、`first-battle`、`reconnect-restore`、`return-to-world`
+  - 七个固定主链路节点：`lobby-entry`、`room-join`、`map-explore`、`first-battle`、`pvp-encounter`、`reconnect-restore`、`return-to-world`
 - `mappings`
   - Creator 预览观察项与 WeChat smoke 报告字段如何映射回同一份 RC 快照
 

--- a/docs/release-evidence/cocos-rc-snapshot.example.json
+++ b/docs/release-evidence/cocos-rc-snapshot.example.json
@@ -83,6 +83,12 @@
       "sourceField": "execution.summary",
       "target": "execution.summary",
       "notes": "WeChat RC 结果可以复用 smoke 总结，但仍需补齐首战与返回世界证据。"
+    },
+    {
+      "source": "creator-preview",
+      "sourceField": "PvP encounter HUD / settlement path",
+      "target": "journey[pvp-encounter]",
+      "notes": "同一 candidate revision 至少记录一条完整 PvP 遭遇证据，包含入场、结算与回到房间态。"
     }
   ],
   "requiredEvidence": [
@@ -175,6 +181,19 @@
       "notes": "Completed the first encounter and settlement flow.",
       "evidence": [
         "artifacts/cocos-rc/first-battle.png"
+      ],
+      "sourceRefs": [
+        "creator-preview"
+      ]
+    },
+    {
+      "id": "pvp-encounter",
+      "title": "PvP encounter",
+      "required": true,
+      "status": "passed",
+      "notes": "Recorded a hero-vs-hero encounter with opponent identity, settlement feedback, and return-to-world continuity on the same candidate revision.",
+      "evidence": [
+        "artifacts/cocos-rc/pvp-encounter.mp4"
       ],
       "sourceRefs": [
         "creator-preview"

--- a/scripts/cocos-release-candidate-snapshot.ts
+++ b/scripts/cocos-release-candidate-snapshot.ts
@@ -5,7 +5,14 @@ import path from "node:path";
 type EvidenceStatus = "pending" | "blocked" | "passed" | "failed" | "not_applicable";
 type SnapshotResult = "pending" | "blocked" | "passed" | "failed" | "partial";
 type BuildSurface = "creator_preview" | "wechat_preview" | "wechat_upload_candidate" | "other";
-type JourneyStepId = "lobby-entry" | "room-join" | "map-explore" | "first-battle" | "reconnect-restore" | "return-to-world";
+type JourneyStepId =
+  | "lobby-entry"
+  | "room-join"
+  | "map-explore"
+  | "first-battle"
+  | "pvp-encounter"
+  | "reconnect-restore"
+  | "return-to-world";
 type CanonicalEvidenceId = "roomId" | "reconnectPrompt" | "restoredState" | "firstBattleResult";
 
 interface Args {
@@ -129,6 +136,7 @@ const REQUIRED_JOURNEY_STEP_IDS: JourneyStepId[] = [
   "room-join",
   "map-explore",
   "first-battle",
+  "pvp-encounter",
   "reconnect-restore",
   "return-to-world"
 ];
@@ -329,6 +337,12 @@ function buildMappings(): EvidenceMapping[] {
       sourceField: "execution.summary",
       target: "execution.summary",
       notes: "WeChat RC 结果可以复用 smoke 总结，但仍需补齐首战与返回世界证据。"
+    },
+    {
+      source: "creator-preview",
+      sourceField: "PvP encounter HUD / settlement path",
+      target: "journey[pvp-encounter]",
+      notes: "同一 candidate revision 至少记录一条完整 PvP 遭遇证据，包含入场、结算与回到房间态。"
     }
   ];
 }
@@ -405,6 +419,15 @@ function buildJourney(): JourneyStep[] {
       required: true,
       status: "pending",
       notes: "进入首场遭遇战并完成一次完整结算。",
+      evidence: [],
+      sourceRefs: []
+    },
+    {
+      id: "pvp-encounter",
+      title: "PvP encounter",
+      required: true,
+      status: "pending",
+      notes: "记录同一 candidate revision 下的一条完整 PvP 遭遇链路，至少覆盖对手身份、结算反馈与返回房间态。",
       evidence: [],
       sourceRefs: []
     },
@@ -635,7 +658,7 @@ function applyWechatSmokeReport(snapshot: CocosReleaseCandidateSnapshot, report:
       "Imported WeChat smoke evidence is blocked; complete the missing device/runtime steps before treating this RC snapshot as passed.";
   } else if (hasPendingUnmappedStep) {
     snapshot.execution.summary =
-      "Imported WeChat smoke evidence populated lobby, room, and reconnect steps; creator-preview evidence is still required for explore, first battle, and return-to-world.";
+      "Imported WeChat smoke evidence populated lobby, room, and reconnect steps; creator-preview evidence is still required for explore, first battle, PvP encounter, and return-to-world.";
   }
 }
 


### PR DESCRIPTION
## Summary
- make PvP encounter entry and settlement copy explicitly distinguish PVP vs PVE across the H5 regression HUD and Cocos primary-client transition/feedback layers
- surface opponent/session context during PvP encounter entry and specialize degraded reconnect messaging so active PvP recovery no longer reads like a generic failure
- add PvP candidate evidence coverage to the Cocos RC snapshot template/example and extend unit coverage for the new states

## Testing
- node --import tsx --test ./apps/client/test/room-feedback.test.ts ./apps/client/test/main-session-runtime.test.ts
- node --import tsx --test ./apps/cocos-client/test/cocos-battle-transition-copy.test.ts ./apps/cocos-client/test/cocos-battle-feedback.test.ts ./apps/cocos-client/test/cocos-release-candidate-snapshot.test.ts ./apps/cocos-client/test/cocos-battle-panel-model.test.ts ./apps/cocos-client/test/cocos-battle-panel.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts
- npm run typecheck:client:h5
- npm run typecheck:cocos
- attempted: npx playwright test tests/e2e/pvp-hero-encounter.spec.ts tests/e2e/pvp-postbattle-reconnect.spec.ts tests/e2e/pvp-reconnect-recovery.spec.ts --config=playwright.multiplayer.config.ts
  - blocked in this environment because Chromium cannot start: missing shared library libatk-bridge-2.0.so.0

Closes #535.