### PR TITLE
feat(cocos): formalize battle presentation for the primary client release path

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -21,6 +21,12 @@ interface BattleSettlementSummary {
   lines: string[];
 }
 
+interface BattleResolvedView {
+  result: "attacker_victory" | "defender_victory";
+  heroId: string;
+  defenderHeroId: string | null;
+}
+
 export function buildBattleActionFeedback(
   action: BattleAction,
   battle: BattleState | null
@@ -248,9 +254,10 @@ function buildBattleSettlementSummary(
   update: SessionUpdate,
   heroId: string | null
 ): BattleSettlementSummary {
+  const resolved = readBattleResolvedView(update);
   const rewards = collectSettlementRewardParts(update);
-  const fieldStatus = describeSettlementFieldState(previousBattle, heroId);
-  const encounterStatus = describeSettlementEncounterState(previousBattle, heroId);
+  const fieldStatus = describeSettlementFieldState(previousBattle, heroId, resolved);
+  const encounterStatus = describeSettlementEncounterState(previousBattle, heroId, resolved);
   const lines = [fieldStatus, ...rewards];
   const detailParts = [
     encounterStatus,
@@ -263,27 +270,6 @@ function buildBattleSettlementSummary(
     detail: detailParts.join(" · "),
     lines
   };
-}
-
-function describeSettlementEncounterState(previousBattle: BattleState | null, heroId: string | null): string {
-  if (!previousBattle) {
-    return "遭遇已关闭";
-  }
-
-  if (!previousBattle.defenderHeroId) {
-    return "PVE 遭遇已关闭";
-  }
-
-  const heroCamp = resolveHeroCamp(previousBattle, heroId);
-  const didHoldField =
-    heroCamp === "attacker"
-      ? countAliveUnits(previousBattle, "attacker") >= countAliveUnits(previousBattle, "defender")
-      : heroCamp === "defender"
-        ? countAliveUnits(previousBattle, "defender") >= countAliveUnits(previousBattle, "attacker")
-        : true;
-  return didHoldField
-    ? `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇`
-    : `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在房间地图上`;
 }
 
 function collectSettlementRewardParts(update: SessionUpdate): string[] {
@@ -351,7 +337,11 @@ function collectSettlementRewardParts(update: SessionUpdate): string[] {
   return parts;
 }
 
-function describeSettlementFieldState(previousBattle: BattleState | null, heroId: string | null): string {
+function describeSettlementFieldState(
+  previousBattle: BattleState | null,
+  heroId: string | null,
+  resolved: BattleResolvedView | null
+): string {
   if (!previousBattle) {
     return "战线已完成收口";
   }
@@ -361,8 +351,17 @@ function describeSettlementFieldState(previousBattle: BattleState | null, heroId
     return "战线已完成收口";
   }
 
-  const friendlyAlive = countAliveUnits(previousBattle, heroCamp);
-  const enemyAlive = countAliveUnits(previousBattle, heroCamp === "attacker" ? "defender" : "attacker");
+  const opposing = heroCamp === "attacker" ? "defender" : "attacker";
+  let friendlyAlive = countAliveUnits(previousBattle, heroCamp);
+  let enemyAlive = countAliveUnits(previousBattle, opposing);
+  const didWin = didHeroWinResolution(resolved, heroId);
+  if (didWin === true) {
+    friendlyAlive = Math.max(1, friendlyAlive);
+    enemyAlive = 0;
+  } else if (didWin === false) {
+    friendlyAlive = 0;
+    enemyAlive = Math.max(1, enemyAlive);
+  }
   return `战线：我方剩余 ${friendlyAlive} 队 / 对方剩余 ${enemyAlive} 队`;
 }
 
@@ -377,6 +376,68 @@ function resolveHeroCamp(previousBattle: BattleState, heroId: string | null): "a
     return "defender";
   }
   return null;
+}
+
+function describeSettlementEncounterState(
+  previousBattle: BattleState | null,
+  heroId: string | null,
+  resolved: BattleResolvedView | null
+): string {
+  if (!previousBattle) {
+    return "遭遇已关闭";
+  }
+
+  if (!previousBattle.defenderHeroId) {
+    return "PVE 遭遇已关闭";
+  }
+
+  const didWin = didHeroWinResolution(resolved, heroId);
+  if (didWin === true) {
+    return `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇`;
+  }
+  if (didWin === false) {
+    return `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在房间地图上`;
+  }
+
+  const heroCamp = resolveHeroCamp(previousBattle, heroId);
+  const didHoldField =
+    heroCamp === "attacker"
+      ? countAliveUnits(previousBattle, "attacker") >= countAliveUnits(previousBattle, "defender")
+      : heroCamp === "defender"
+        ? countAliveUnits(previousBattle, "defender") >= countAliveUnits(previousBattle, "attacker")
+        : true;
+  return didHoldField
+    ? `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇`
+    : `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在房间地图上`;
+}
+
+function didHeroWinResolution(resolved: BattleResolvedView | null, heroId: string | null): boolean | null {
+  if (!resolved) {
+    return null;
+  }
+
+  if (!heroId) {
+    return resolved.result === "attacker_victory";
+  }
+
+  if (resolved.result === "attacker_victory") {
+    return resolved.heroId === heroId;
+  }
+
+  return resolved.defenderHeroId === heroId;
+}
+
+function readBattleResolvedView(update: SessionUpdate): BattleResolvedView | null {
+  const resolved = update.events.find((event) => event.type === "battle.resolved");
+  if (!resolved) {
+    return null;
+  }
+
+  return {
+    result: resolved.result,
+    heroId: resolved.heroId,
+    defenderHeroId: resolved.defenderHeroId ?? null
+  };
 }
 
 function countAliveUnits(previousBattle: BattleState, camp: "attacker" | "defender"): number {

--- a/apps/cocos-client/test/cocos-battle-feedback.test.ts
+++ b/apps/cocos-client/test/cocos-battle-feedback.test.ts
@@ -200,14 +200,16 @@ test("battle feedback summarizes action, progress, and outcome", () => {
   assert.equal(skillImpactFeedback?.badge, "SKILL");
   assert.match(skillImpactFeedback?.title ?? "", /投矛射击 命中，Orc 受到打击/);
 
-  const victoryFeedback = buildBattleTransitionFeedback(createResolvedUpdate("attacker_victory"), "hero-1");
+  const victoryFeedback = buildBattleTransitionFeedback(createResolvedUpdate("attacker_victory"), "hero-1", battle);
   assert.equal(victoryFeedback?.tone, "victory");
   assert.equal(victoryFeedback?.badge, "WIN");
+  assert.match(victoryFeedback?.detail ?? "", /战线：我方剩余 1 队 \/ 对方剩余 0 队/);
   assert.match(victoryFeedback?.detail ?? "", /准备返回世界地图/);
 
-  const defeatFeedback = buildBattleTransitionFeedback(createResolvedUpdate("defender_victory"), "hero-1");
+  const defeatFeedback = buildBattleTransitionFeedback(createResolvedUpdate("defender_victory"), "hero-1", battle);
   assert.equal(defeatFeedback?.tone, "defeat");
   assert.equal(defeatFeedback?.badge, "LOSE");
+  assert.match(defeatFeedback?.detail ?? "", /战线：我方剩余 0 队 \/ 对方剩余 1 队/);
 
   const unsettledFeedback = buildBattleTransitionFeedback(
     {
@@ -337,7 +339,7 @@ test("battle presentation plan formalizes enter, impact, and resolution phases",
   assert.equal(resolutionPlan.transition?.copy.badge, "VICTORY");
   assert.deepEqual(resolutionPlan.state.summaryLines.slice(0, 2), [
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
-    "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
+    "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 准备返回世界地图"
   ]);
 
   const unsettledResolutionPlan = buildBattlePresentationPlan(
@@ -389,7 +391,7 @@ test("battle transition feedback summarizes settlement rewards and field state",
 
   const feedback = buildBattleTransitionFeedback(update, "hero-1", battle);
   assert.equal(feedback?.badge, "WIN");
-  assert.match(feedback?.detail ?? "", /战线：我方剩余 1 队 \/ 对方剩余 1 队/);
+  assert.match(feedback?.detail ?? "", /战线：我方剩余 1 队 \/ 对方剩余 0 队/);
   assert.match(feedback?.detail ?? "", /战利品：金币 \+12 \/ 矿石 \+3/);
   assert.match(feedback?.detail ?? "", /成长：XP \+25 \/ 技能点 \+1/);
   assert.match(feedback?.detail ?? "", /掉落：铁枪/);

--- a/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
+++ b/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
@@ -250,7 +250,7 @@ test("battle presentation controller formalizes command, casualty, and result fl
     result: "victory"
   });
   assert.equal(controller.getState().feedbackLayer.transition, "exit");
-  assert.match(controller.getState().summaryLines[1] ?? "", /战线：我方剩余 1 队 \/ 对方剩余 1 队/);
+  assert.match(controller.getState().summaryLines[1] ?? "", /战线：我方剩余 1 队 \/ 对方剩余 0 队/);
 
   controller.applyUpdate(battle, createUpdate(null, []), "hero-1");
   assertState(controller.getState(), {

--- a/docs/cocos-phase1-presentation-signoff.md
+++ b/docs/cocos-phase1-presentation-signoff.md
@@ -6,6 +6,8 @@ It does not replace the broader RC snapshot, checklist, or blocker log. It narro
 
 `Which placeholder, fallback, or substituted presentation items still exist, and has each one been explicitly closed or accepted before Phase 1 exit?`
 
+For the primary-client battle path, reviewers should treat `encounter entry -> command/impact feedback -> result settlement` as one continuous presentation surface. Evidence is incomplete if it only shows the map shell or only the final settlement shell.
+
 ## When To Use This
 
 Use this checklist whenever a candidate is being reviewed for:
@@ -48,7 +50,7 @@ Copy this section into the active candidate record and fill it before review:
 | Pixel art / scene visuals | Placeholder tiles, sprites, portraits, icons, temporary VFX, mismatched atlas content | `cocos-presentation-readiness`, RC screenshots/video, Creator preview, WeChat smoke | `closed | accepted-non-blocking | blocking` | `<name>` | What was fixed, or why Phase 1 can ship with this exact gap | Issue / blocker / artifact |
 | Audio | Mixed packs, missing cues, temporary BGM/SFX, abrupt silence or fallback clips | RC video, device smoke notes, audio audit notes | `closed | accepted-non-blocking | blocking` | `<name>` | What remains, player impact, and why it is or is not acceptable | Issue / blocker / artifact |
 | Animation / transitions | Fallback transition modes, missing hit reactions, temporary motion states, abrupt battle entry/exit | RC video, diagnostics markdown, reviewer notes | `closed | accepted-non-blocking | blocking` | `<name>` | What behavior is still fallback and whether it affects the production-intent journey | Issue / blocker / artifact |
-| HUD / copy / readability | Temporary labels, unclear badges, weak state messaging, unresolved placeholder strings | RC screenshots, Cocos journey evidence, manual review notes | `closed | accepted-non-blocking | blocking` | `<name>` | Why the current wording is acceptable or what must change before sign-off | Issue / blocker / artifact |
+| HUD / copy / readability | Temporary labels, unclear badges, weak state messaging, unresolved placeholder strings, ambiguous battle win/loss settlement copy | RC screenshots, Cocos journey evidence, manual review notes | `closed | accepted-non-blocking | blocking` | `<name>` | Why the current wording is acceptable or what must change before sign-off | Issue / blocker / artifact |
 | Asset substitutions from automation | Any remaining substitution already reported by validation or presentation-readiness output | Validation artifact, release bundle summary, CI artifact | `closed | accepted-non-blocking | blocking` | `<name>` | Explicitly acknowledge each reported substitution instead of assuming it is understood | Issue / blocker / artifact |
 
 ## Reviewer Decision

--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -63,7 +63,7 @@ The exporter reuses the existing Cocos `VeilRoot` harness and records checkpoint
 
 - progression review loading
 - inventory overflow / blocked equipment evidence
-- combat-loop resolution
+- battle entry -> command/impact feedback -> resolution/settlement handoff
 - reconnect cached-replay fallback
 - reconnect recovery back to authoritative state
 
@@ -82,6 +82,7 @@ Keep these manual items short and attach evidence through the existing release e
 1. Complete the current candidate snapshot with `npm run release:cocos-rc:snapshot`.
 2. Refresh the primary-client diagnostic artifact with `npm run release:cocos:primary-diagnostics`.
 3. Copy and fill the RC checklist/template files in [`docs/release-evidence`](./release-evidence/), and attach the current [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) review for any remaining placeholder/fallback presentation items.
+   The same candidate evidence should explicitly show one polished battle journey covering encounter entry, at least one command/impact beat, and a stable victory or defeat settlement state before reconnect review.
 4. Record any open risk in the blocker template before sign-off.
 5. Confirm the release candidate still matches the intended commit/revision.
 


### PR DESCRIPTION
## Summary
- anchor battle settlement presentation to authoritative resolution events so win/loss state stays explicit after immediate battle teardown
- lock the corrected Cocos battle presentation flow with regression coverage for resolution summaries
- update primary-client delivery and presentation sign-off docs to require battle-flow evidence in the release path

## Testing
- node --import tsx --test ./apps/cocos-client/test/cocos-battle-feedback.test.ts ./apps/cocos-client/test/cocos-battle-presentation-controller.test.ts ./apps/cocos-client/test/cocos-battle-panel-model.test.ts ./apps/cocos-client/test/cocos-battle-transition-copy.test.ts
- npm run typecheck:cocos

Closes #540