### PR TITLE
feat(cocos): close the primary-client equipment, inventory, and loot loop

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -79,6 +79,14 @@ interface HudEquipmentButtonState {
   callback: (() => void) | null;
 }
 
+interface HudRecentLootEvent {
+  type: "hero.equipmentFound";
+  heroId: string;
+  equipmentName: string;
+  rarity: "common" | "rare" | "epic";
+  overflowed?: boolean;
+}
+
 export type VeilHudSessionIndicatorKind =
   | "reconnecting"
   | "replaying_cached_snapshot"
@@ -109,7 +117,8 @@ function formatHeroLearnedSkills(hero: NonNullable<VeilHudRenderState["update"]>
 
 function formatHeroEquipmentLines(
   hero: NonNullable<VeilHudRenderState["update"]>["world"]["ownHeroes"][number] | null,
-  recentEventLog: VeilHudRenderState["account"]["recentEventLog"]
+  recentEventLog: VeilHudRenderState["account"]["recentEventLog"],
+  recentSessionEvents: HudRecentLootEvent[] = []
 ): string[] {
   if (!hero) {
     return ["装备 等待房间状态...", ""];
@@ -117,13 +126,34 @@ function formatHeroEquipmentLines(
 
   const equipmentLines = formatEquipmentOverviewLines(hero);
   const inventoryLines = formatInventorySummaryLines(hero);
-  const lootLines = formatRecentLootLines(recentEventLog, hero.id);
+  const lootLines = formatRecentLootLines(recentEventLog, hero.id, 2, recentSessionEvents, hero.name);
 
   return [
     ...equipmentLines,
     ...inventoryLines,
     ...lootLines
   ];
+}
+
+function toHudRecentLootEvents(
+  events: NonNullable<VeilHudRenderState["update"]>["events"]
+): HudRecentLootEvent[] {
+  const recentLoot: HudRecentLootEvent[] = [];
+  for (const event of events) {
+    if (event.type !== "hero.equipmentFound") {
+      continue;
+    }
+
+    recentLoot.push({
+      type: event.type,
+      heroId: event.heroId,
+      equipmentName: event.equipmentName,
+      rarity: event.rarity,
+      ...(event.overflowed ? { overflowed: true } : {})
+    });
+  }
+
+  return recentLoot;
 }
 
 export interface VeilHudRenderState {
@@ -324,7 +354,12 @@ export class VeilHudPanel extends Component {
     const skillPanelView = buildCocosHudSkillPanelView(state.update, this.onLearnSkill);
     const progressMeter = hero ? createHeroProgressMeterView({ progression: { ...hero.progression } }) : null;
     const attributeRows = hero ? createHeroAttributeBreakdown(toHudHeroSkillState(hero), world ?? undefined) : [];
-    const equipmentLines = formatHeroEquipmentLines(hero, state.account.recentEventLog);
+    const attackTotal = attributeRows.find((row) => row.key === "attack")?.total ?? hero?.stats.attack ?? 0;
+    const defenseTotal = attributeRows.find((row) => row.key === "defense")?.total ?? hero?.stats.defense ?? 0;
+    const powerTotal = attributeRows.find((row) => row.key === "power")?.total ?? hero?.stats.power ?? 0;
+    const knowledgeTotal = attributeRows.find((row) => row.key === "knowledge")?.total ?? hero?.stats.knowledge ?? 0;
+    const maxHpTotal = attributeRows.find((row) => row.key === "maxHp")?.total ?? hero?.stats.maxHp ?? 0;
+    const equipmentLines = formatHeroEquipmentLines(hero, state.account.recentEventLog, toHudRecentLootEvents(state.update?.events ?? []));
     const equipmentRows = buildHeroEquipmentActionRows(hero);
     const equipmentButtons = this.buildEquipmentButtonStates(equipmentRows);
     const equipmentLineCount = (hero ? 1 + equipmentLines.length : 3);
@@ -414,7 +449,7 @@ export class VeilHudPanel extends Component {
             `英雄  ${hero.name}`,
             `坐标 (${hero.position.x},${hero.position.y})`,
             `等级 ${hero.progression.level}  经验 ${progressMeter?.currentLevelExperience ?? 0}/${progressMeter?.nextLevelExperience ?? 100}  技能点 ${hero.progression.skillPoints ?? 0}`,
-            `攻 ${hero.stats.attack}  防 ${hero.stats.defense}  力 ${hero.stats.power}  知 ${hero.stats.knowledge}`,
+            `攻 ${attackTotal}  防 ${defenseTotal}  力 ${powerTotal}  知 ${knowledgeTotal}`,
             attributeRows[0] ? `攻防公式 ${attributeRows[0].formula} / ${attributeRows[1]?.formula ?? ""}` : "",
             attributeRows[2] ? `法术公式 ${attributeRows[2].formula} / ${attributeRows[3]?.formula ?? ""}` : "",
             attributeRows[4] ? attributeRows[4].formula : "",
@@ -488,7 +523,7 @@ export class VeilHudPanel extends Component {
           Boolean(state.levelUpNotice)
         );
       }
-      this.renderHeroMeters(`${CARD_PREFIX}-hero`, hero.move.remaining, hero.move.total, hero.stats.hp, hero.stats.maxHp, hero.armyCount);
+      this.renderHeroMeters(`${CARD_PREFIX}-hero`, hero.move.remaining, hero.move.total, hero.stats.hp, maxHpTotal, hero.armyCount);
       this.tightenHeroLabelLayout(leftX, cardWidth);
       this.renderEquipmentActionButtons(`${CARD_PREFIX}-equipment`, equipmentButtons);
       this.renderLearnableSkillButtons(`${CARD_PREFIX}-skills`, skillPanelView.actions);

--- a/apps/cocos-client/assets/scripts/cocos-hero-equipment.ts
+++ b/apps/cocos-client/assets/scripts/cocos-hero-equipment.ts
@@ -1,10 +1,11 @@
 import {
   createHeroEquipmentBonusSummary,
   createHeroEquipmentLoadoutView,
-  formatEquipmentBonusSummary,
   formatEquipmentRarityLabel,
+  formatEquipmentBonusSummary,
   HERO_EQUIPMENT_INVENTORY_CAPACITY,
   type EventLogEntry,
+  type EquipmentRarity,
   getEquipmentDefinition,
   type EquipmentType,
   type HeroState
@@ -34,6 +35,14 @@ export interface CocosEquipmentActionRow {
 export interface CocosEquipmentStatSummaryLine {
   label: string;
   value: number;
+}
+
+interface CocosRecentLootEvent {
+  type: "hero.equipmentFound";
+  heroId: string;
+  equipmentName: string;
+  rarity: EquipmentRarity;
+  overflowed?: boolean;
 }
 
 function toHeroState(hero: HeroView): HeroState {
@@ -213,25 +222,51 @@ export function formatEquipmentOverviewLines(hero: HeroView | null): string[] {
   return [`装备 ${equipped.join("  ·  ")}`, ...detail, summaryLine, ...effects, ...descriptions];
 }
 
+function formatSessionLootDescription(
+  event: CocosRecentLootEvent,
+  heroName?: string
+): string {
+  const actorName = heroName?.trim() || event.heroId;
+  return event.overflowed
+    ? `${actorName} 在战斗后发现了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}，但背包已满，未能拾取。`
+    : `${actorName} 在战斗后获得了${formatEquipmentRarityLabel(event.rarity)}装备 ${event.equipmentName}。`;
+}
+
 export function formatRecentLootLines(
   recentEventLog: EventLogEntry[],
   heroId?: string | null,
-  limit = 2
+  limit = 2,
+  recentSessionEvents: CocosRecentLootEvent[] = [],
+  heroName?: string
 ): string[] {
   const normalizedHeroId = heroId?.trim();
+  const recentSessionLoot = recentSessionEvents
+    .filter(
+      (event): event is CocosRecentLootEvent =>
+        event.type === "hero.equipmentFound" && (!normalizedHeroId || event.heroId === normalizedHeroId)
+    )
+    .map((event) => formatSessionLootDescription(event, heroName));
   const heroLoot = recentEventLog.filter(
     (entry) => entry.worldEventType === "hero.equipmentFound" && (!normalizedHeroId || entry.heroId === normalizedHeroId)
   );
-  const source = heroLoot.length > 0
-    ? heroLoot
-    : recentEventLog.filter((entry) => entry.worldEventType === "hero.equipmentFound");
-  const visibleEntries = source.slice(0, Math.max(1, Math.floor(limit)));
+  const fallbackLoot = recentEventLog.filter((entry) => entry.worldEventType === "hero.equipmentFound");
+  const persistedDescriptions = (heroLoot.length > 0 ? heroLoot : fallbackLoot).map((entry) => entry.description);
+  const seenDescriptions = new Set<string>();
+  const mergedDescriptions = [...recentSessionLoot, ...persistedDescriptions].filter((description) => {
+    if (seenDescriptions.has(description)) {
+      return false;
+    }
+
+    seenDescriptions.add(description);
+    return true;
+  });
+  const visibleEntries = mergedDescriptions.slice(0, Math.max(1, Math.floor(limit)));
 
   if (visibleEntries.length === 0) {
     return ["战利品 最近暂无装备掉落"];
   }
 
-  return [`战利品 最近 ${source.length} 条`, ...visibleEntries.map((entry) => entry.description)];
+  return [`战利品 最近 ${mergedDescriptions.length} 条`, ...visibleEntries];
 }
 
 export function buildHeroEquipmentActionRows(hero: HeroView | null): CocosEquipmentActionRow[] {

--- a/apps/cocos-client/test/cocos-hero-equipment.test.ts
+++ b/apps/cocos-client/test/cocos-hero-equipment.test.ts
@@ -272,3 +272,45 @@ test("formatRecentLootLines keeps the latest hero loot entries visible in Cocos 
   ]);
   assert.deepEqual(formatRecentLootLines([], "hero-1"), ["战利品 最近暂无装备掉落"]);
 });
+
+test("formatRecentLootLines prioritizes authoritative session loot before account refresh catches up", () => {
+  const entries: EventLogEntry[] = [
+    {
+      id: "loot-1",
+      timestamp: "2026-03-28T10:00:00.000Z",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      category: "combat",
+      description: "凯琳在战斗后获得了普通装备 塔盾链甲。",
+      heroId: "hero-1",
+      worldEventType: "hero.equipmentFound",
+      rewards: []
+    }
+  ];
+
+  assert.deepEqual(
+    formatRecentLootLines(
+      entries,
+      "hero-1",
+      2,
+      [
+        {
+          type: "hero.equipmentFound",
+          heroId: "hero-1",
+          battleId: "battle-1",
+          battleKind: "neutral",
+          equipmentId: "warden_aegis",
+          equipmentName: "守誓圣铠",
+          rarity: "epic",
+          overflowed: true
+        }
+      ],
+      "凯琳"
+    ),
+    [
+      "战利品 最近 2 条",
+      "凯琳 在战斗后发现了史诗装备 守誓圣铠，但背包已满，未能拾取。",
+      "凯琳在战斗后获得了普通装备 塔盾链甲。"
+    ]
+  );
+});

--- a/apps/cocos-client/test/cocos-hud-panel.test.ts
+++ b/apps/cocos-client/test/cocos-hud-panel.test.ts
@@ -155,3 +155,34 @@ test("VeilHudPanel surfaces reconnect, replay, resync, and degraded session indi
   assert.match(statusText, /会话 降级\/离线回退 · 最近一次重连失败，客户端正依赖回退路径维持会话。/);
   assert.equal(badgeText, "重连中");
 });
+
+test("VeilHudPanel renders equipment-adjusted hero totals and immediate session loot", () => {
+  const { component, node } = createComponentHarness(VeilHudPanel, { name: "HudPanelRoot", width: 320, height: 720 });
+  const state = createHudState();
+  state.account.recentEventLog = [];
+  state.update!.world.ownHeroes[0]!.name = "凯琳";
+  state.update!.world.ownHeroes[0]!.loadout.equipment.armorId = "padded_gambeson";
+  state.update!.world.ownHeroes[0]!.loadout.equipment.accessoryId = "scout_compass";
+  state.update!.events = [
+    {
+      type: "hero.equipmentFound",
+      heroId: "hero-1",
+      battleId: "battle-1",
+      battleKind: "neutral",
+      equipmentId: "warden_aegis",
+      equipmentName: "守誓圣铠",
+      rarity: "epic",
+      overflowed: true
+    }
+  ];
+
+  component.render(state);
+
+  const heroText = readLabelString(findNode(node, "HudHero"));
+  const equipmentText = readLabelString(findNode(node, "HudEquipment"));
+
+  assert.match(heroText, /攻 2  防 2  力 1  知 2/);
+  assert.match(heroText, /生命上限 14 = 基础 12 装备 \+2/);
+  assert.match(equipmentText, /战利品 最近 1 条/);
+  assert.match(equipmentText, /凯琳 在战斗后发现了史诗装备 守誓圣铠，但背包已满，未能拾取。/);
+});

--- a/docs/cocos-equipment-loot-validation.md
+++ b/docs/cocos-equipment-loot-validation.md
@@ -19,6 +19,8 @@
   - a full-bag warning before the next equipment pickup would overflow
   - recent loot lines from the Cocos-visible account event log
 - Existing equip/unequip buttons remain the interaction surface and continue to drive prediction plus server reconciliation.
+- The hero summary card now renders equipment-adjusted totals from shared progression math, so stat changes are visible during prediction and after reconciliation instead of only after a secondary refresh path.
+- Recent loot rows now merge the latest authoritative session loot events with the persisted account event log, so battle drops and overflowed pickups stay visible immediately after combat even before account-history refresh finishes.
 - Equipment loot now respects a fixed 6-slot backpack cap:
   - battle drops are only added when space remains
   - when full, the drop is surfaced as overflowed/not picked up instead of being silently appended


### PR DESCRIPTION
## Summary
- render equipment-adjusted hero totals directly in the primary Cocos HUD so equip and unequip changes are visible immediately
- merge authoritative session loot events with persisted account history so battle drops and overflowed pickups stay visible before async profile refresh completes
- cover the tightened HUD and loot behavior with focused Cocos tests and document the validation flow

Closes #539