### PR TITLE
ops(release): formalize target-surface evidence freshness

### DIFF
--- a/docs/release-evidence/wechat-release-manual-review.example.json
+++ b/docs/release-evidence/wechat-release-manual-review.example.json
@@ -5,6 +5,10 @@
     "status": "pending",
     "required": true,
     "notes": "Capture runtime evidence against the same candidate revision before marking the WeChat target release-ready.",
+    "owner": "<release-owner>",
+    "recordedAt": "<2026-04-02T08:10:00.000Z>",
+    "revision": "<git-sha>",
+    "artifactPath": "artifacts/wechat-release/runtime-review.json",
     "evidence": [
       "GET /api/runtime/health",
       "GET /api/runtime/auth-readiness",
@@ -17,6 +21,13 @@
     "status": "pending",
     "required": true,
     "notes": "Attach the completed RC checklist and blocker register for the same packaged candidate.",
+    "owner": "<release-owner>",
+    "recordedAt": "<2026-04-02T08:15:00.000Z>",
+    "revision": "<git-sha>",
+    "artifactPath": "artifacts/wechat-release/checklist-review.json",
+    "blockerIds": [
+      "none"
+    ],
     "evidence": [
       "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
       "docs/release-evidence/cocos-wechat-rc-blockers.template.md"

--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -10,12 +10,24 @@ It intentionally reuses the current evidence instead of introducing a parallel g
 - `npm run validate:wechat-rc` or `npm run smoke:wechat-release -- --check` for WeChat release evidence
 - `configs/.config-center-library.json` for the latest applied config-center publish audit and config change risk summary
 
+The summary now also records one explicit `targetSurface` contract. That contract is what makes `H5 passed` different from `WeChat passed`: WeChat release decisions now require a current `codex.wechat.release-candidate-summary.json` plus fresh manual/runtime review metadata, while H5-only release decisions can mark the WeChat gate as advisory.
+
 ## Usage
 
 Use the latest local artifacts under `artifacts/release-readiness/` and `artifacts/wechat-release/`:
 
 ```bash
 npm run release:gate:summary
+```
+
+Pick the release target surface explicitly when needed:
+
+```bash
+npm run release:gate:summary -- --target-surface wechat
+```
+
+```bash
+npm run release:gate:summary -- --target-surface h5
 ```
 
 Point at explicit artifact paths when CI already produced stable filenames:
@@ -57,9 +69,11 @@ The summary contains five release dimensions:
   - Fails closed when the post-soak cleanup counters show lingering active rooms, live connections, active battles, or hero snapshots.
   - Use this gate for release candidates and reconnect / room-recovery changes; keep `test:e2e:multiplayer:smoke` as the faster PR-level signal for canonical multiplayer link health.
 - `wechat-release`
-  - Prefers `codex.wechat.rc-validation-report.json` when present.
+  - Prefers `codex.wechat.release-candidate-summary.json` when present.
+  - Falls back to `codex.wechat.rc-validation-report.json` when the candidate summary is absent.
   - Falls back to `codex.wechat.smoke-report.json` when the RC validation report is absent.
   - Fails closed when required WeChat evidence is missing, failed, blocked, or still pending.
+  - When the candidate summary is available, also fails on required manual-review metadata drift: missing `owner`, missing `recordedAt`, missing `revision`, revision mismatch, or review evidence older than 24h.
   - Markdown/JSON summary text distinguishes `blocked` device/runtime evidence from true execution failures so CI reviewers can see whether a gate is red because proof is absent or because the runtime actually regressed.
 - `phase1-evidence-consistency`
   - Cross-checks the release-readiness snapshot, packaged H5 smoke report, and selected WeChat evidence as one Phase 1 candidate set.
@@ -68,6 +82,25 @@ The summary contains five release dimensions:
   - The Markdown output now includes a `Selected Inputs` section so reviewers can see the exact artifact paths that were compared instead of inferring them from the default directory scan.
 
 Any failed dimension makes the script exit non-zero so the result can act as a CI release gate.
+
+## Target Surface Contract
+
+The report now includes a `Target Surface Contract` section with:
+
+- `targetSurface`
+  - `wechat` or `h5`
+- `releaseSurface.status`
+  - pass/fail call for the selected surface
+- `releaseSurface.evidence[*]`
+  - exact evidence item, freshness, owner, revision, waiver, and artifact path
+
+For `wechat`, the required surface evidence is:
+
+- release readiness snapshot
+- H5 packaged RC smoke
+- reconnect soak
+- WeChat candidate summary
+- required WeChat manual-review checks with current owner/timestamp/revision metadata
 
 ## Config Change Risk Summary
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -79,6 +79,7 @@
    - JSON 至少包含 `version`、`commit`、artifact 路径、逐项检查结果和 `failureSummary`
    - `--version` 会要求并校验 `*.upload.json`；`--require-smoke-report` 会把 `codex.wechat.smoke-report.json` 设为必需门禁
    - 若未显式传 `--manual-checks`，脚本仍会内置两条必需 manual review：runtime endpoint review 与 RC checklist/blocker review
+   - required manual review 现在必须带 `owner`、`recordedAt`、`revision`；当 review 时间超过 24h、revision 不匹配或元数据缺失时，candidate summary 会继续保持 `blocked`
 8. 若已有设备农场、真机调试或准真机脚本产出的结构化 runtime 证据，执行 `npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`，把证据直接写入既有 `codex.wechat.smoke-report.json` schema。
 9. 若本次 RC 没有自动化 runtime 证据，再运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板，并在真机或准真机上逐项补录结果。
 10. 完成自动导入或人工补录后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
@@ -133,6 +134,15 @@
 - `--manual-checks <json>`：读取显式 manual review 状态；推荐直接从 `docs/release-evidence/wechat-release-manual-review.example.json` 复制当次 candidate 文件
 - `--manual-check <id>:<title>`：临时追加一条 pending manual review
 - `npm run release:wechat:rehearsal` 的 `## Artifacts` 区块会自动列出 `codex.wechat.release-candidate-summary.json` / `.md`，方便 reviewer 或 PR 作者直接复制 `.md` 文件内容到评论区，并将 `.json` 作为结构化证据随 artifact 一起上传
+
+推荐的 manual review JSON 现在至少包含：
+
+- `owner`
+- `recordedAt`
+- `revision`
+- `artifactPath`
+- 对 checklist/blocker review 可额外补 `blockerIds`
+- 若为带条件放行，可补 `waiver.approvedBy` / `waiver.approvedAt` / `waiver.reason`
 
 ## 提审前 Smoke Check
 

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -4,15 +4,19 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 type GateStatus = "passed" | "failed";
+type TargetSurface = "h5" | "wechat";
+type EvidenceFreshness = "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp" | "unknown";
 
 interface Args {
   snapshotPath?: string;
   h5SmokePath?: string;
   reconnectSoakPath?: string;
   wechatRcValidationPath?: string;
+  wechatCandidateSummaryPath?: string;
   wechatSmokeReportPath?: string;
   wechatArtifactsDir?: string;
   configCenterLibraryPath?: string;
+  targetSurface: TargetSurface;
   outputPath?: string;
   markdownOutputPath?: string;
 }
@@ -79,6 +83,51 @@ interface WechatRcValidationReport {
   }>;
 }
 
+interface WechatReleaseCandidateSummary {
+  generatedAt?: string;
+  candidate?: {
+    revision?: string | null;
+    status?: "ready" | "blocked";
+  };
+  evidence?: {
+    smoke?: {
+      status?: "passed" | "failed" | "skipped";
+      artifactPath?: string;
+    };
+    manualReview?: {
+      status?: "ready" | "blocked";
+      requiredPendingChecks?: number;
+      requiredFailedChecks?: number;
+      requiredMetadataFailures?: number;
+      checks?: Array<{
+        id?: string;
+        title?: string;
+        required?: boolean;
+        status?: "passed" | "failed" | "pending" | "not_applicable";
+        notes?: string;
+        evidence?: string[];
+        owner?: string;
+        recordedAt?: string;
+        revision?: string;
+        artifactPath?: string;
+        blockerIds?: string[];
+        waiver?: {
+          approvedBy?: string;
+          approvedAt?: string;
+          reason?: string;
+          expiresAt?: string;
+        };
+      }>;
+    };
+  };
+  blockers?: Array<{
+    id?: string;
+    summary?: string;
+    artifactPath?: string;
+    nextCommand?: string;
+  }>;
+}
+
 interface WechatSmokeReport {
   artifact?: {
     sourceRevision?: string;
@@ -96,7 +145,13 @@ interface WechatSmokeReport {
 }
 
 interface GateSource {
-  kind: "release-readiness-snapshot" | "h5-release-candidate-smoke" | "reconnect-soak" | "wechat-rc-validation" | "wechat-smoke-report";
+  kind:
+    | "release-readiness-snapshot"
+    | "h5-release-candidate-smoke"
+    | "reconnect-soak"
+    | "wechat-rc-validation"
+    | "wechat-release-candidate-summary"
+    | "wechat-smoke-report";
   path: string;
 }
 
@@ -104,6 +159,7 @@ interface GateResult {
   id: "release-readiness" | "h5-release-candidate-smoke" | "multiplayer-reconnect-soak" | "wechat-release" | "phase1-evidence-consistency";
   label: string;
   status: GateStatus;
+  required: boolean;
   summary: string;
   failures: string[];
   source?: GateSource;
@@ -116,6 +172,28 @@ interface Phase1EvidenceReference {
   commit?: string;
   generatedAt?: string;
   candidateHint?: string;
+}
+
+interface ReleaseSurfaceEvidenceItem {
+  id: string;
+  label: string;
+  required: boolean;
+  status: GateStatus;
+  summary: string;
+  freshness: EvidenceFreshness;
+  observedAt?: string;
+  owner?: string;
+  revision?: string;
+  artifactPath?: string;
+  blockerIds: string[];
+  waiverReason?: string;
+}
+
+interface ReleaseSurfaceContract {
+  targetSurface: TargetSurface;
+  status: GateStatus;
+  summary: string;
+  evidence: ReleaseSurfaceEvidenceItem[];
 }
 
 interface ReconnectSoakArtifact {
@@ -211,6 +289,7 @@ interface ReleaseGateSummaryReport {
   schemaVersion: 1;
   generatedAt: string;
   revision: GitRevision;
+  targetSurface: TargetSurface;
   summary: {
     status: GateStatus;
     totalGates: number;
@@ -223,11 +302,13 @@ interface ReleaseGateSummaryReport {
     h5SmokePath?: string;
     reconnectSoakPath?: string;
     wechatRcValidationPath?: string;
+    wechatCandidateSummaryPath?: string;
     wechatSmokeReportPath?: string;
     wechatArtifactsDir?: string;
     configCenterLibraryPath?: string;
   };
   gates: GateResult[];
+  releaseSurface: ReleaseSurfaceContract;
   configChangeRisk: ConfigChangeRiskSummary;
 }
 
@@ -236,6 +317,7 @@ const DEFAULT_WECHAT_ARTIFACTS_DIR = path.resolve("artifacts", "wechat-release")
 const DEFAULT_CONFIG_CENTER_LIBRARY_PATH = path.resolve("configs", ".config-center-library.json");
 const HEX_REVISION_PATTERN = /^[a-f0-9]+$/i;
 const MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS = 1000 * 60 * 60 * 72;
+const MAX_TARGET_SURFACE_REVIEW_AGE_MS = 1000 * 60 * 60 * 24;
 const RISK_PRIORITY: Record<ConfigRiskLevel, number> = {
   low: 1,
   medium: 2,
@@ -330,9 +412,11 @@ function parseArgs(argv: string[]): Args {
   let h5SmokePath: string | undefined;
   let reconnectSoakPath: string | undefined;
   let wechatRcValidationPath: string | undefined;
+  let wechatCandidateSummaryPath: string | undefined;
   let wechatSmokeReportPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let configCenterLibraryPath: string | undefined;
+  let targetSurface: TargetSurface = "wechat";
   let outputPath: string | undefined;
   let markdownOutputPath: string | undefined;
 
@@ -360,6 +444,11 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--wechat-candidate-summary" && next) {
+      wechatCandidateSummaryPath = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--wechat-smoke-report" && next) {
       wechatSmokeReportPath = next;
       index += 1;
@@ -372,6 +461,14 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--config-center-library" && next) {
       configCenterLibraryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--target-surface" && next) {
+      if (next !== "h5" && next !== "wechat") {
+        fail(`Unsupported --target-surface value: ${next}`);
+      }
+      targetSurface = next;
       index += 1;
       continue;
     }
@@ -394,9 +491,11 @@ function parseArgs(argv: string[]): Args {
     ...(h5SmokePath ? { h5SmokePath } : {}),
     ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
     ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
+    ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(configCenterLibraryPath ? { configCenterLibraryPath } : {}),
+    targetSurface,
     ...(outputPath ? { outputPath } : {}),
     ...(markdownOutputPath ? { markdownOutputPath } : {})
   };
@@ -482,6 +581,17 @@ function resolveWechatRcValidationPath(args: Args, wechatArtifactsDir?: string):
   return fs.existsSync(candidate) ? candidate : undefined;
 }
 
+function resolveWechatCandidateSummaryPath(args: Args, wechatArtifactsDir?: string): string | undefined {
+  if (args.wechatCandidateSummaryPath) {
+    return path.resolve(args.wechatCandidateSummaryPath);
+  }
+  if (!wechatArtifactsDir) {
+    return undefined;
+  }
+  const candidate = path.join(wechatArtifactsDir, "codex.wechat.release-candidate-summary.json");
+  return fs.existsSync(candidate) ? candidate : undefined;
+}
+
 function resolveWechatSmokeReportPath(args: Args, wechatArtifactsDir?: string): string | undefined {
   if (args.wechatSmokeReportPath) {
     return path.resolve(args.wechatSmokeReportPath);
@@ -524,11 +634,13 @@ function missingGate(
   id: GateResult["id"],
   label: string,
   summary: string,
-  failures: string[]
+  failures: string[],
+  required = true
 ): GateResult {
   return {
     id,
     label,
+    required,
     status: "failed",
     summary,
     failures
@@ -572,6 +684,7 @@ export function evaluateReleaseReadinessGate(
   return {
     id: "release-readiness",
     label: "Release readiness snapshot",
+    required: true,
     status: failures.length === 0 ? "passed" : "failed",
     summary:
       failures.length === 0
@@ -608,6 +721,7 @@ export function evaluateH5SmokeGate(h5SmokePath: string | undefined): GateResult
   return {
     id: "h5-release-candidate-smoke",
     label: "H5 packaged RC smoke",
+    required: true,
     status: failures.length === 0 ? "passed" : "failed",
     summary:
       failures.length === 0
@@ -681,6 +795,7 @@ export function evaluateReconnectSoakGate(reconnectSoakPath: string | undefined)
   return {
     id: "multiplayer-reconnect-soak",
     label: "Multiplayer reconnect soak",
+    required: true,
     status: failures.length === 0 ? "passed" : "failed",
     summary:
       failures.length === 0
@@ -695,9 +810,59 @@ export function evaluateReconnectSoakGate(reconnectSoakPath: string | undefined)
 }
 
 export function evaluateWechatGate(
+  targetSurface: TargetSurface,
   wechatRcValidationPath: string | undefined,
+  wechatCandidateSummaryPath: string | undefined,
   wechatSmokeReportPath: string | undefined
 ): GateResult {
+  const required = targetSurface === "wechat";
+  if (wechatCandidateSummaryPath && fs.existsSync(wechatCandidateSummaryPath)) {
+    const summary = readJsonFile<WechatReleaseCandidateSummary>(wechatCandidateSummaryPath);
+    const failures: string[] = [];
+
+    if (summary.candidate?.status !== "ready") {
+      failures.push(`WeChat candidate summary status is ${JSON.stringify(summary.candidate?.status ?? "missing")}.`);
+    }
+    if (summary.evidence?.smoke?.status !== "passed") {
+      failures.push(`WeChat candidate smoke evidence is ${JSON.stringify(summary.evidence?.smoke?.status ?? "missing")}.`);
+    }
+    if (summary.evidence?.manualReview?.status !== "ready") {
+      failures.push(`WeChat manual review status is ${JSON.stringify(summary.evidence?.manualReview?.status ?? "missing")}.`);
+    }
+    if ((summary.evidence?.manualReview?.requiredPendingChecks ?? 0) > 0) {
+      failures.push(`WeChat manual review reports ${summary.evidence?.manualReview?.requiredPendingChecks} required pending check(s).`);
+    }
+    if ((summary.evidence?.manualReview?.requiredFailedChecks ?? 0) > 0) {
+      failures.push(`WeChat manual review reports ${summary.evidence?.manualReview?.requiredFailedChecks} required failed check(s).`);
+    }
+    if ((summary.evidence?.manualReview?.requiredMetadataFailures ?? 0) > 0) {
+      failures.push(
+        `WeChat manual review reports ${summary.evidence?.manualReview?.requiredMetadataFailures} metadata freshness or ownership failure(s).`
+      );
+    }
+    for (const blocker of summary.blockers ?? []) {
+      if (blocker.summary?.trim()) {
+        failures.push(blocker.summary.trim());
+      }
+    }
+
+    return {
+      id: "wechat-release",
+      label: "WeChat release validation",
+      required,
+      status: failures.length === 0 ? "passed" : "failed",
+      summary:
+        failures.length === 0
+          ? "WeChat candidate summary passed."
+          : `WeChat candidate summary failed: ${failures[0]}`,
+      failures,
+      source: {
+        kind: "wechat-release-candidate-summary",
+        path: wechatCandidateSummaryPath
+      }
+    };
+  }
+
   if (wechatRcValidationPath && fs.existsSync(wechatRcValidationPath)) {
     const report = readJsonFile<WechatRcValidationReport>(wechatRcValidationPath);
     const failures: string[] = [];
@@ -715,6 +880,7 @@ export function evaluateWechatGate(
     return {
       id: "wechat-release",
       label: "WeChat release validation",
+      required,
       status: failures.length === 0 ? "passed" : "failed",
       summary:
         failures.length === 0
@@ -733,7 +899,8 @@ export function evaluateWechatGate(
       "wechat-release",
       "WeChat release validation",
       "Missing WeChat RC validation or smoke evidence.",
-      ["Neither codex.wechat.rc-validation-report.json nor codex.wechat.smoke-report.json was found."]
+      ["Neither codex.wechat.release-candidate-summary.json, codex.wechat.rc-validation-report.json, nor codex.wechat.smoke-report.json was found."],
+      required
     );
   }
 
@@ -765,6 +932,7 @@ export function evaluateWechatGate(
   return {
     id: "wechat-release",
     label: "WeChat release validation",
+    required,
     status: failures.length === 0 ? "passed" : "failed",
     summary:
       failures.length === 0
@@ -801,6 +969,189 @@ function relativeReportPath(filePath: string): string {
   return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
 }
 
+function evaluateFreshness(timestamp: string | undefined, maxAgeMs: number): EvidenceFreshness {
+  if (!timestamp?.trim()) {
+    return "missing_timestamp";
+  }
+  const timestampMs = Date.parse(timestamp);
+  if (Number.isNaN(timestampMs)) {
+    return "invalid_timestamp";
+  }
+  return Date.now() - timestampMs > maxAgeMs ? "stale" : "fresh";
+}
+
+function createSurfaceEvidenceItem(input: {
+  id: string;
+  label: string;
+  required: boolean;
+  status: GateStatus;
+  summary: string;
+  freshness?: EvidenceFreshness;
+  observedAt?: string;
+  owner?: string;
+  revision?: string;
+  artifactPath?: string;
+  blockerIds?: string[];
+  waiverReason?: string;
+}): ReleaseSurfaceEvidenceItem {
+  return {
+    id: input.id,
+    label: input.label,
+    required: input.required,
+    status: input.status,
+    summary: input.summary,
+    freshness: input.freshness ?? "unknown",
+    ...(input.observedAt ? { observedAt: input.observedAt } : {}),
+    ...(input.owner ? { owner: input.owner } : {}),
+    ...(input.revision ? { revision: input.revision } : {}),
+    ...(input.artifactPath ? { artifactPath: input.artifactPath } : {}),
+    blockerIds: input.blockerIds ?? [],
+    ...(input.waiverReason ? { waiverReason: input.waiverReason } : {})
+  };
+}
+
+function buildReleaseSurfaceContract(
+  targetSurface: TargetSurface,
+  snapshotPath: string | undefined,
+  h5SmokePath: string | undefined,
+  reconnectSoakPath: string | undefined,
+  wechatCandidateSummaryPath: string | undefined
+): ReleaseSurfaceContract {
+  const evidence: ReleaseSurfaceEvidenceItem[] = [];
+
+  evidence.push(
+    createSurfaceEvidenceItem({
+      id: "release-readiness",
+      label: "Release readiness snapshot",
+      required: true,
+      status: snapshotPath && fs.existsSync(snapshotPath) ? "passed" : "failed",
+      summary: snapshotPath && fs.existsSync(snapshotPath) ? "Found release readiness snapshot." : "Release readiness snapshot is missing.",
+      freshness: snapshotPath && fs.existsSync(snapshotPath)
+        ? evaluateFreshness(readJsonFile<ReleaseReadinessSnapshot>(snapshotPath).generatedAt, MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS)
+        : "unknown",
+      observedAt: snapshotPath && fs.existsSync(snapshotPath) ? readJsonFile<ReleaseReadinessSnapshot>(snapshotPath).generatedAt : undefined,
+      artifactPath: snapshotPath
+    })
+  );
+
+  evidence.push(
+    createSurfaceEvidenceItem({
+      id: "h5-release-candidate-smoke",
+      label: "H5 packaged RC smoke",
+      required: true,
+      status: h5SmokePath && fs.existsSync(h5SmokePath) ? "passed" : "failed",
+      summary: h5SmokePath && fs.existsSync(h5SmokePath) ? "Found H5 packaged RC smoke evidence." : "H5 packaged RC smoke evidence is missing.",
+      freshness: h5SmokePath && fs.existsSync(h5SmokePath)
+        ? evaluateFreshness(
+            readJsonFile<ReleaseCandidateClientArtifactSmokeReport>(h5SmokePath).execution?.finishedAt ??
+              readJsonFile<ReleaseCandidateClientArtifactSmokeReport>(h5SmokePath).generatedAt,
+            MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS
+          )
+        : "unknown",
+      observedAt: h5SmokePath && fs.existsSync(h5SmokePath)
+        ? readJsonFile<ReleaseCandidateClientArtifactSmokeReport>(h5SmokePath).execution?.finishedAt ??
+          readJsonFile<ReleaseCandidateClientArtifactSmokeReport>(h5SmokePath).generatedAt
+        : undefined,
+      artifactPath: h5SmokePath
+    })
+  );
+
+  evidence.push(
+    createSurfaceEvidenceItem({
+      id: "multiplayer-reconnect-soak",
+      label: "Multiplayer reconnect soak",
+      required: true,
+      status: reconnectSoakPath && fs.existsSync(reconnectSoakPath) ? "passed" : "failed",
+      summary: reconnectSoakPath && fs.existsSync(reconnectSoakPath) ? "Found reconnect soak evidence." : "Reconnect soak evidence is missing.",
+      freshness: reconnectSoakPath && fs.existsSync(reconnectSoakPath)
+        ? evaluateFreshness(readJsonFile<ReconnectSoakArtifact>(reconnectSoakPath).generatedAt, MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS)
+        : "unknown",
+      observedAt: reconnectSoakPath && fs.existsSync(reconnectSoakPath)
+        ? readJsonFile<ReconnectSoakArtifact>(reconnectSoakPath).generatedAt
+        : undefined,
+      artifactPath: reconnectSoakPath
+    })
+  );
+
+  if (targetSurface === "wechat") {
+    if (!wechatCandidateSummaryPath || !fs.existsSync(wechatCandidateSummaryPath)) {
+      evidence.push(
+        createSurfaceEvidenceItem({
+          id: "wechat-candidate-summary",
+          label: "WeChat candidate summary",
+          required: true,
+          status: "failed",
+          summary: "WeChat candidate summary is missing.",
+          artifactPath: wechatCandidateSummaryPath
+        })
+      );
+    } else {
+      const summary = readJsonFile<WechatReleaseCandidateSummary>(wechatCandidateSummaryPath);
+      evidence.push(
+        createSurfaceEvidenceItem({
+          id: "wechat-candidate-summary",
+          label: "WeChat candidate summary",
+          required: true,
+          status: summary.candidate?.status === "ready" ? "passed" : "failed",
+          summary:
+            summary.candidate?.status === "ready"
+              ? "WeChat candidate summary is ready for release review."
+              : `WeChat candidate summary is ${JSON.stringify(summary.candidate?.status ?? "missing")}.`,
+          freshness: evaluateFreshness(summary.generatedAt, MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS),
+          observedAt: summary.generatedAt,
+          revision: summary.candidate?.revision ?? undefined,
+          artifactPath: wechatCandidateSummaryPath
+        })
+      );
+
+      for (const check of summary.evidence?.manualReview?.checks ?? []) {
+        if (check.required === false) {
+          continue;
+        }
+        const freshness = evaluateFreshness(check.recordedAt, MAX_TARGET_SURFACE_REVIEW_AGE_MS);
+        const metadataFailures = [
+          !check.owner?.trim() ? "owner missing" : "",
+          !check.revision?.trim() ? "revision missing" : "",
+          freshness !== "fresh" ? `freshness=${freshness}` : ""
+        ].filter((value) => value.length > 0);
+        evidence.push(
+          createSurfaceEvidenceItem({
+            id: `manual:${check.id ?? "unknown"}`,
+            label: check.title ?? check.id ?? "WeChat manual review",
+            required: true,
+            status: check.status === "passed" && metadataFailures.length === 0 ? "passed" : "failed",
+            summary:
+              check.status === "passed" && metadataFailures.length === 0
+                ? "Manual review is complete and current."
+                : `${JSON.stringify(check.status ?? "missing")} (${metadataFailures.join(", ") || "review unresolved"})`,
+            freshness,
+            observedAt: check.recordedAt,
+            owner: check.owner,
+            revision: check.revision,
+            artifactPath: check.artifactPath,
+            blockerIds: check.blockerIds ?? [],
+            waiverReason: check.waiver?.reason
+          })
+        );
+      }
+    }
+  }
+
+  const failures = evidence.filter(
+    (entry) => entry.required && (entry.status === "failed" || entry.freshness === "stale" || entry.freshness === "missing_timestamp" || entry.freshness === "invalid_timestamp")
+  );
+
+  return {
+    targetSurface,
+    status: failures.length === 0 ? "passed" : "failed",
+    summary:
+      failures.length === 0
+        ? `Target surface ${targetSurface} has current required evidence.`
+        : `Target surface ${targetSurface} is blocked: ${failures[0]?.label} -> ${failures[0]?.summary}`,
+    evidence
+  };
+}
+
 function deriveCandidateHint(filePath: string, commit: string | undefined): string | undefined {
   const normalizedCommit = normalizeCommit(commit);
   if (normalizedCommit) {
@@ -830,10 +1181,12 @@ function formatEvidenceDescriptor(entry: Phase1EvidenceReference): string {
 }
 
 function collectPhase1EvidenceReferences(
+  targetSurface: TargetSurface,
   snapshotPath: string | undefined,
   h5SmokePath: string | undefined,
   reconnectSoakPath: string | undefined,
   wechatRcValidationPath: string | undefined,
+  wechatCandidateSummaryPath: string | undefined,
   wechatSmokeReportPath: string | undefined
 ): Phase1EvidenceReference[] {
   const evidence: Phase1EvidenceReference[] = [];
@@ -886,7 +1239,21 @@ function collectPhase1EvidenceReferences(
     });
   }
 
-  if (wechatRcValidationPath && fs.existsSync(wechatRcValidationPath)) {
+  if (wechatCandidateSummaryPath && fs.existsSync(wechatCandidateSummaryPath)) {
+    const report = readJsonFile<WechatReleaseCandidateSummary>(wechatCandidateSummaryPath);
+    const commit = report.candidate?.revision ?? undefined;
+    evidence.push({
+      gateId: "wechat-release",
+      label: "WeChat release validation",
+      source: {
+        kind: "wechat-release-candidate-summary",
+        path: wechatCandidateSummaryPath
+      },
+      commit,
+      generatedAt: report.generatedAt,
+      candidateHint: deriveCandidateHint(wechatCandidateSummaryPath, commit)
+    });
+  } else if (wechatRcValidationPath && fs.existsSync(wechatRcValidationPath)) {
     const report = readJsonFile<WechatRcValidationReport>(wechatRcValidationPath);
     const commit = report.commit ?? undefined;
     evidence.push({
@@ -900,7 +1267,7 @@ function collectPhase1EvidenceReferences(
       generatedAt: report.generatedAt,
       candidateHint: deriveCandidateHint(wechatRcValidationPath, commit)
     });
-  } else if (wechatSmokeReportPath && fs.existsSync(wechatSmokeReportPath)) {
+  } else if (targetSurface === "wechat" && wechatSmokeReportPath && fs.existsSync(wechatSmokeReportPath)) {
     const report = readJsonFile<WechatSmokeReport>(wechatSmokeReportPath);
     const commit = report.artifact?.sourceRevision;
     evidence.push({
@@ -920,11 +1287,13 @@ function collectPhase1EvidenceReferences(
 }
 
 export function evaluatePhase1EvidenceConsistencyGate(
+  targetSurface: TargetSurface,
   revision: GitRevision,
   snapshotPath: string | undefined,
   h5SmokePath: string | undefined,
   reconnectSoakPath: string | undefined,
   wechatRcValidationPath: string | undefined,
+  wechatCandidateSummaryPath: string | undefined,
   wechatSmokeReportPath: string | undefined
 ): GateResult {
   const failures: string[] = [];
@@ -932,13 +1301,15 @@ export function evaluatePhase1EvidenceConsistencyGate(
     { gateId: "release-readiness", label: "Release readiness snapshot" },
     { gateId: "h5-release-candidate-smoke", label: "H5 packaged RC smoke" },
     { gateId: "multiplayer-reconnect-soak", label: "Multiplayer reconnect soak" },
-    { gateId: "wechat-release", label: "WeChat release validation" }
+    ...(targetSurface === "wechat" ? [{ gateId: "wechat-release" as const, label: "WeChat release validation" }] : [])
   ];
   const evidence = collectPhase1EvidenceReferences(
+    targetSurface,
     snapshotPath,
     h5SmokePath,
     reconnectSoakPath,
     wechatRcValidationPath,
+    wechatCandidateSummaryPath,
     wechatSmokeReportPath
   );
   const expectedCommit = revision.commit;
@@ -1025,6 +1396,7 @@ export function evaluatePhase1EvidenceConsistencyGate(
   return {
     id: "phase1-evidence-consistency",
     label: "Phase 1 evidence consistency",
+    required: true,
     status: failures.length === 0 ? "passed" : "failed",
     summary,
     failures: failures.length === 0 && uniqueCommitCount === 1 ? [] : failures,
@@ -1165,33 +1537,44 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
   const reconnectSoakPath = resolveReconnectSoakPath(args);
   const wechatArtifactsDir = resolveWechatArtifactsDir(args);
   const wechatRcValidationPath = resolveWechatRcValidationPath(args, wechatArtifactsDir);
+  const wechatCandidateSummaryPath = resolveWechatCandidateSummaryPath(args, wechatArtifactsDir);
   const wechatSmokeReportPath = resolveWechatSmokeReportPath(args, wechatArtifactsDir);
   const configCenterLibraryPath = resolveConfigCenterLibraryPath(args);
+  const releaseSurface = buildReleaseSurfaceContract(
+    args.targetSurface,
+    snapshotPath,
+    h5SmokePath,
+    reconnectSoakPath,
+    wechatCandidateSummaryPath
+  );
 
   const gates = [
     evaluateReleaseReadinessGate(snapshotPath),
     evaluateH5SmokeGate(h5SmokePath),
     evaluateReconnectSoakGate(reconnectSoakPath),
-    evaluateWechatGate(wechatRcValidationPath, wechatSmokeReportPath),
+    evaluateWechatGate(args.targetSurface, wechatRcValidationPath, wechatCandidateSummaryPath, wechatSmokeReportPath),
     evaluatePhase1EvidenceConsistencyGate(
+      args.targetSurface,
       revision,
       snapshotPath,
       h5SmokePath,
       reconnectSoakPath,
       wechatRcValidationPath,
+      wechatCandidateSummaryPath,
       wechatSmokeReportPath
     )
   ];
-  const failedGates = gates.filter((gate) => gate.status === "failed");
+  const failedGates = gates.filter((gate) => gate.required && gate.status === "failed");
 
   return {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
     revision,
+    targetSurface: args.targetSurface,
     summary: {
-      status: failedGates.length === 0 ? "passed" : "failed",
+      status: failedGates.length === 0 && releaseSurface.status === "passed" ? "passed" : "failed",
       totalGates: gates.length,
-      passedGates: gates.length - failedGates.length,
+      passedGates: gates.filter((gate) => !gate.required || gate.status === "passed").length,
       failedGates: failedGates.length,
       failedGateIds: failedGates.map((gate) => gate.id)
     },
@@ -1200,11 +1583,13 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
       ...(h5SmokePath ? { h5SmokePath } : {}),
       ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
       ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
+      ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
       ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
       ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
       ...(configCenterLibraryPath ? { configCenterLibraryPath } : {})
     },
     gates,
+    releaseSurface,
     configChangeRisk: buildConfigChangeRiskSummary(configCenterLibraryPath)
   };
 }
@@ -1215,6 +1600,7 @@ export function renderMarkdown(report: ReleaseGateSummaryReport): string {
     "",
     `- Generated at: \`${report.generatedAt}\``,
     `- Revision: \`${report.revision.shortCommit}\` on \`${report.revision.branch}\``,
+    `- Target surface: \`${report.targetSurface}\``,
     `- Overall status: **${report.summary.status.toUpperCase()}**`,
     ""
   ];
@@ -1225,15 +1611,42 @@ export function renderMarkdown(report: ReleaseGateSummaryReport): string {
   lines.push(`- H5 smoke: \`${report.inputs.h5SmokePath ? relativeReportPath(report.inputs.h5SmokePath) : "<missing>"}\``);
   lines.push(`- Reconnect soak: \`${report.inputs.reconnectSoakPath ? relativeReportPath(report.inputs.reconnectSoakPath) : "<missing>"}\``);
   lines.push(`- WeChat validation: \`${report.inputs.wechatRcValidationPath ? relativeReportPath(report.inputs.wechatRcValidationPath) : "<missing>"}\``);
+  lines.push(
+    `- WeChat candidate summary: \`${report.inputs.wechatCandidateSummaryPath ? relativeReportPath(report.inputs.wechatCandidateSummaryPath) : "<missing>"}\``
+  );
   lines.push(`- WeChat smoke fallback: \`${report.inputs.wechatSmokeReportPath ? relativeReportPath(report.inputs.wechatSmokeReportPath) : "<missing>"}\``);
   lines.push(`- WeChat artifacts dir: \`${report.inputs.wechatArtifactsDir ? relativeReportPath(report.inputs.wechatArtifactsDir) : "<missing>"}\``);
   lines.push(`- Config audit: \`${report.inputs.configCenterLibraryPath ? relativeReportPath(report.inputs.configCenterLibraryPath) : "<missing>"}\``);
+  lines.push("");
+
+  lines.push("## Target Surface Contract");
+  lines.push("");
+  lines.push(`- Surface: \`${report.releaseSurface.targetSurface}\``);
+  lines.push(`- Status: **${report.releaseSurface.status.toUpperCase()}**`);
+  lines.push(`- Summary: ${report.releaseSurface.summary}`);
+  lines.push("- Evidence:");
+  for (const entry of report.releaseSurface.evidence) {
+    const details = [
+      `required=${entry.required ? "yes" : "no"}`,
+      `status=${entry.status}`,
+      `freshness=${entry.freshness}`,
+      entry.observedAt ? `observedAt=${entry.observedAt}` : "",
+      entry.owner ? `owner=${entry.owner}` : "",
+      entry.revision ? `revision=${entry.revision}` : "",
+      entry.waiverReason ? `waiver=${entry.waiverReason}` : "",
+      entry.artifactPath ? `path=${relativeReportPath(entry.artifactPath)}` : ""
+    ]
+      .filter((value) => value.length > 0)
+      .join(" ");
+    lines.push(`  - ${entry.label}: ${entry.summary} [${details}]`);
+  }
   lines.push("");
 
   for (const gate of report.gates) {
     lines.push(`## ${gate.label}`);
     lines.push("");
     lines.push(`- Status: **${gate.status.toUpperCase()}**`);
+    lines.push(`- Required for target surface: ${gate.required ? "yes" : "no"}`);
     lines.push(`- Summary: ${gate.summary}`);
     if (gate.source) {
       lines.push(`- Source: \`${relativeReportPath(gate.source.path)}\``);

--- a/scripts/release-health-summary.ts
+++ b/scripts/release-health-summary.ts
@@ -56,10 +56,16 @@ interface ReleaseGateSummaryReport {
     id?: string;
     label?: string;
     status?: "passed" | "failed";
+    required?: boolean;
     summary?: string;
     failures?: string[];
     source?: {
-      kind?: "release-readiness-snapshot" | "h5-release-candidate-smoke" | "wechat-rc-validation" | "wechat-smoke-report";
+      kind?:
+        | "release-readiness-snapshot"
+        | "h5-release-candidate-smoke"
+        | "wechat-rc-validation"
+        | "wechat-release-candidate-summary"
+        | "wechat-smoke-report";
       path?: string;
     };
   }>;
@@ -529,7 +535,7 @@ function evaluateReleaseGateSignal(filePath: string | undefined): { signal: Rele
 
   const report = readJsonFile<ReleaseGateSummaryReport>(filePath);
   const source = createSource(filePath, report.generatedAt);
-  const failingGates = (report.gates ?? []).filter((gate) => gate.status === "failed");
+  const failingGates = (report.gates ?? []).filter((gate) => gate.required !== false && gate.status === "failed");
 
   if (report.summary?.status !== "passed" || failingGates.length > 0) {
     const details = failingGates.flatMap((gate) => {
@@ -789,7 +795,7 @@ function buildReleaseGateTriage(filePath: string | undefined): ReleaseHealthTria
   }
 
   const report = readJsonFile<ReleaseGateSummaryReport>(filePath);
-  const failingGates = (report.gates ?? []).filter((gate) => gate.status === "failed");
+  const failingGates = (report.gates ?? []).filter((gate) => gate.required !== false && gate.status === "failed");
   if (failingGates.length === 0 && report.summary?.status === "passed") {
     return [];
   }

--- a/scripts/release-readiness-snapshot.ts
+++ b/scripts/release-readiness-snapshot.ts
@@ -27,6 +27,17 @@ interface ReleaseReadinessCheck {
   notes: string;
   evidence: string[];
   source: "default" | "file" | "cli";
+  owner?: string;
+  recordedAt?: string;
+  revision?: string;
+  artifactPath?: string;
+  blockerIds?: string[];
+  waiver?: {
+    approvedBy?: string;
+    approvedAt?: string;
+    reason?: string;
+    expiresAt?: string;
+  };
   startedAt?: string;
   finishedAt?: string;
   stdoutTail?: string;
@@ -40,6 +51,17 @@ interface ManualCheckInput {
   required?: boolean;
   notes?: string;
   evidence?: string[];
+  owner?: string;
+  recordedAt?: string;
+  revision?: string;
+  artifactPath?: string;
+  blockerIds?: string[];
+  waiver?: {
+    approvedBy?: string;
+    approvedAt?: string;
+    reason?: string;
+    expiresAt?: string;
+  };
 }
 
 interface ReleaseReadinessSnapshot {
@@ -205,7 +227,30 @@ export function normalizeManualCheck(entry: ManualCheckInput, source: "file" | "
     evidence: Array.isArray(entry.evidence)
       ? entry.evidence.map((value) => String(value).trim()).filter((value) => value.length > 0)
       : [],
-    source
+    source,
+    ...(entry.owner?.trim() ? { owner: entry.owner.trim() } : {}),
+    ...(entry.recordedAt?.trim() ? { recordedAt: entry.recordedAt.trim() } : {}),
+    ...(entry.revision?.trim() ? { revision: entry.revision.trim() } : {}),
+    ...(entry.artifactPath?.trim() ? { artifactPath: entry.artifactPath.trim() } : {}),
+    ...(Array.isArray(entry.blockerIds)
+      ? {
+          blockerIds: entry.blockerIds.map((value) => String(value).trim()).filter((value) => value.length > 0)
+        }
+      : {}),
+    ...(entry.waiver &&
+    (entry.waiver.approvedBy?.trim() ||
+      entry.waiver.approvedAt?.trim() ||
+      entry.waiver.reason?.trim() ||
+      entry.waiver.expiresAt?.trim())
+      ? {
+          waiver: {
+            ...(entry.waiver.approvedBy?.trim() ? { approvedBy: entry.waiver.approvedBy.trim() } : {}),
+            ...(entry.waiver.approvedAt?.trim() ? { approvedAt: entry.waiver.approvedAt.trim() } : {}),
+            ...(entry.waiver.reason?.trim() ? { reason: entry.waiver.reason.trim() } : {}),
+            ...(entry.waiver.expiresAt?.trim() ? { expiresAt: entry.waiver.expiresAt.trim() } : {})
+          }
+        }
+      : {})
   };
 }
 

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -29,10 +29,11 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
   const wechatArtifactsDir = path.join(workspace, "artifacts", "wechat-release");
   const wechatRcValidationPath = path.join(wechatArtifactsDir, "codex.wechat.rc-validation-report.json");
+  const wechatCandidateSummaryPath = path.join(wechatArtifactsDir, "codex.wechat.release-candidate-summary.json");
   const configCenterLibraryPath = path.join(workspace, "configs", ".config-center-library.json");
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-03-29T08:30:00.000Z",
+    generatedAt: "2026-04-02T08:30:00.000Z",
     revision: {
       commit: "abc123",
       shortCommit: "abc123",
@@ -53,7 +54,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
     ]
   });
   writeJson(h5SmokePath, {
-    generatedAt: "2026-03-29T08:32:00.000Z",
+    generatedAt: "2026-04-02T08:32:00.000Z",
     revision: {
       commit: "abc123",
       shortCommit: "abc123",
@@ -71,7 +72,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
     }
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-03-29T08:33:00.000Z",
+    generatedAt: "2026-04-02T08:33:00.000Z",
     revision: {
       commit: "abc123",
       shortCommit: "abc123"
@@ -99,13 +100,55 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
     ]
   });
   writeJson(wechatRcValidationPath, {
-    generatedAt: "2026-03-29T08:35:00.000Z",
+    generatedAt: "2026-04-02T08:35:00.000Z",
     commit: "abc123",
     summary: {
       status: "passed",
       failedChecks: 0,
       failureSummary: []
     }
+  });
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: "2026-04-02T08:40:00.000Z",
+    candidate: {
+      revision: "abc123",
+      status: "ready"
+    },
+    evidence: {
+      smoke: {
+        status: "passed",
+        artifactPath: path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json")
+      },
+      manualReview: {
+        status: "ready",
+        requiredPendingChecks: 0,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: [
+          {
+            id: "wechat-runtime-review",
+            title: "Runtime health/auth-readiness/metrics reviewed for this candidate",
+            required: true,
+            status: "passed",
+            owner: "release-oncall",
+            recordedAt: "2026-04-02T08:10:00.000Z",
+            revision: "abc123",
+            artifactPath: "artifacts/wechat-release/runtime-review.json"
+          },
+          {
+            id: "wechat-release-checklist",
+            title: "WeChat RC checklist and blockers reviewed",
+            required: true,
+            status: "passed",
+            owner: "release-oncall",
+            recordedAt: "2026-04-02T08:15:00.000Z",
+            revision: "abc123",
+            artifactPath: "artifacts/wechat-release/checklist-review.json"
+          }
+        ]
+      }
+    },
+    blockers: []
   });
   writeJson(configCenterLibraryPath, {
     publishAuditHistory: [
@@ -153,6 +196,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
       h5SmokePath,
       reconnectSoakPath,
       wechatArtifactsDir,
+      targetSurface: "wechat",
       configCenterLibraryPath
     },
     {
@@ -177,7 +221,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /## Selected Inputs/);
   assert.match(renderMarkdown(report), /release-readiness-pass\.json/);
   assert.match(renderMarkdown(report), /colyseus-reconnect-soak-summary-pass\.json/);
-  assert.match(renderMarkdown(report), /codex\.wechat\.rc-validation-report\.json/);
+  assert.match(renderMarkdown(report), /codex\.wechat\.release-candidate-summary\.json/);
   assert.match(renderMarkdown(report), /Config Change Risk Summary/);
   assert.match(renderMarkdown(report), /Recommend rehearsal: yes/);
 });
@@ -283,7 +327,8 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
       snapshotPath,
       h5SmokePath,
       reconnectSoakPath,
-      wechatSmokeReportPath
+      wechatSmokeReportPath,
+      targetSurface: "wechat"
     },
     {
       commit: "abc123",
@@ -317,7 +362,7 @@ test("evaluateWechatGate prefers RC validation and falls back to smoke report", 
     ]
   });
 
-  const smokeGate = evaluateWechatGate(undefined, wechatSmokeReportPath);
+  const smokeGate = evaluateWechatGate("wechat", undefined, undefined, wechatSmokeReportPath);
   assert.equal(smokeGate.status, "passed");
   assert.equal(smokeGate.source?.kind, "wechat-smoke-report");
 });
@@ -441,6 +486,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails stale or mismatched candidate 
   });
 
   const gate = evaluatePhase1EvidenceConsistencyGate(
+    "wechat",
     {
       commit: "abc123",
       shortCommit: "abc123",
@@ -451,6 +497,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails stale or mismatched candidate 
     h5SmokePath,
     reconnectSoakPath,
     wechatRcValidationPath,
+    undefined,
     undefined
   );
 
@@ -539,6 +586,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails when Phase 1 evidence timestam
   });
 
   const gate = evaluatePhase1EvidenceConsistencyGate(
+    "wechat",
     {
       commit: "abc123",
       shortCommit: "abc123",
@@ -549,6 +597,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails when Phase 1 evidence timestam
     h5SmokePath,
     reconnectSoakPath,
     wechatRcValidationPath,
+    undefined,
     undefined
   );
 
@@ -641,7 +690,8 @@ test("buildReleaseGateSummaryReport fails when all artifacts are stale for the c
       snapshotPath,
       h5SmokePath,
       reconnectSoakPath,
-      wechatRcValidationPath
+      wechatRcValidationPath,
+      targetSurface: "wechat"
     },
     {
       commit: "abc123",

--- a/scripts/test/wechat-release-artifacts.test.ts
+++ b/scripts/test/wechat-release-artifacts.test.ts
@@ -42,6 +42,10 @@ interface ManualReviewCheckPayload {
   required?: boolean;
   notes?: string;
   evidence?: string[];
+  owner?: string;
+  recordedAt?: string;
+  revision?: string;
+  artifactPath?: string;
 }
 
 function hashFileSha256(filePath: string): string {
@@ -436,7 +440,11 @@ test("validate:wechat-rc marks the candidate ready when smoke evidence and manua
       status: "passed",
       required: true,
       notes: "Captured candidate runtime endpoints for the same revision.",
-      evidence: ["GET /api/runtime/health", "GET /api/runtime/auth-readiness", "GET /api/runtime/metrics"]
+      evidence: ["GET /api/runtime/health", "GET /api/runtime/auth-readiness", "GET /api/runtime/metrics"],
+      owner: "release-oncall",
+      recordedAt: "2026-04-02T08:10:00.000Z",
+      revision: sourceRevision,
+      artifactPath: "artifacts/wechat-release/runtime-review.json"
     },
     {
       id: "wechat-release-checklist",
@@ -447,7 +455,11 @@ test("validate:wechat-rc marks the candidate ready when smoke evidence and manua
       evidence: [
         "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
         "docs/release-evidence/cocos-wechat-rc-blockers.template.md"
-      ]
+      ],
+      owner: "release-oncall",
+      recordedAt: "2026-04-02T08:15:00.000Z",
+      revision: sourceRevision,
+      artifactPath: "artifacts/wechat-release/checklist-review.json"
     }
   ]);
 

--- a/scripts/validate-wechat-release-candidate.ts
+++ b/scripts/validate-wechat-release-candidate.ts
@@ -6,6 +6,7 @@ import { parseManualCheckArg, parseManualChecksFile } from "./release-readiness-
 type CheckStatus = "passed" | "failed" | "skipped";
 type GateStatus = "passed" | "failed";
 type CandidateStatus = "ready" | "blocked";
+type EvidenceFreshness = "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp";
 
 interface Args {
   artifactsDir?: string;
@@ -99,6 +100,17 @@ interface ManualReviewCheck {
   notes: string;
   evidence: string[];
   source: "default" | "file" | "cli";
+  owner?: string;
+  recordedAt?: string;
+  revision?: string;
+  artifactPath?: string;
+  blockerIds?: string[];
+  waiver?: {
+    approvedBy?: string;
+    approvedAt?: string;
+    reason?: string;
+    expiresAt?: string;
+  };
 }
 
 interface CandidateSummary {
@@ -148,6 +160,7 @@ interface CandidateSummary {
       completedChecks: number;
       requiredPendingChecks: number;
       requiredFailedChecks: number;
+      requiredMetadataFailures: number;
       checks: ManualReviewCheck[];
     };
   };
@@ -160,6 +173,7 @@ interface CandidateSummary {
 }
 
 const OUTPUT_TAIL_BYTES = 4000;
+const MANUAL_REVIEW_MAX_AGE_MS = 1000 * 60 * 60 * 24;
 const DEFAULT_MANUAL_CHECKS: ManualReviewCheck[] = [
   {
     id: "wechat-runtime-review",
@@ -430,7 +444,13 @@ function readManualChecks(args: Args): ManualReviewCheck[] {
         status: check.status,
         notes: check.notes,
         evidence: [...check.evidence],
-        source: "file" as const
+        source: "file" as const,
+        ...(check.owner ? { owner: check.owner } : {}),
+        ...(check.recordedAt ? { recordedAt: check.recordedAt } : {}),
+        ...(check.revision ? { revision: check.revision } : {}),
+        ...(check.artifactPath ? { artifactPath: check.artifactPath } : {}),
+        ...(check.blockerIds ? { blockerIds: [...check.blockerIds] } : {}),
+        ...(check.waiver ? { waiver: { ...check.waiver } } : {})
       }))
     : [];
   const fromCli = args.manualChecks.map((value) => {
@@ -442,7 +462,13 @@ function readManualChecks(args: Args): ManualReviewCheck[] {
       status: check.status,
       notes: check.notes,
       evidence: [...check.evidence],
-      source: "cli" as const
+      source: "cli" as const,
+      ...(check.owner ? { owner: check.owner } : {}),
+      ...(check.recordedAt ? { recordedAt: check.recordedAt } : {}),
+      ...(check.revision ? { revision: check.revision } : {}),
+      ...(check.artifactPath ? { artifactPath: check.artifactPath } : {}),
+      ...(check.blockerIds ? { blockerIds: [...check.blockerIds] } : {}),
+      ...(check.waiver ? { waiver: { ...check.waiver } } : {})
     };
   });
 
@@ -455,6 +481,48 @@ function readManualChecks(args: Args): ManualReviewCheck[] {
     seen.add(check.id);
   }
   return checks;
+}
+
+function evaluateManualReviewFreshness(recordedAt: string | undefined, generatedAtMs: number): EvidenceFreshness {
+  if (!recordedAt?.trim()) {
+    return "missing_timestamp";
+  }
+  const recordedAtMs = Date.parse(recordedAt);
+  if (Number.isNaN(recordedAtMs)) {
+    return "invalid_timestamp";
+  }
+  return generatedAtMs - recordedAtMs > MANUAL_REVIEW_MAX_AGE_MS ? "stale" : "fresh";
+}
+
+function collectManualReviewMetadataFailures(
+  check: ManualReviewCheck,
+  commit: string | null,
+  generatedAtMs: number
+): string[] {
+  if (!check.required || check.status !== "passed") {
+    return [];
+  }
+
+  const failures: string[] = [];
+  if (!check.owner?.trim()) {
+    failures.push(`Manual review is missing owner: ${check.title}.`);
+  }
+  if (!check.revision?.trim()) {
+    failures.push(`Manual review is missing revision binding: ${check.title}.`);
+  } else if (commit && check.revision !== commit) {
+    failures.push(`Manual review revision mismatch for ${check.title}: expected ${commit}, got ${check.revision}.`);
+  }
+
+  const freshness = evaluateManualReviewFreshness(check.recordedAt, generatedAtMs);
+  if (freshness === "missing_timestamp") {
+    failures.push(`Manual review is missing recordedAt timestamp: ${check.title}.`);
+  } else if (freshness === "invalid_timestamp") {
+    failures.push(`Manual review has invalid recordedAt timestamp for ${check.title}: ${check.recordedAt}.`);
+  } else if (freshness === "stale") {
+    failures.push(`Manual review is stale for ${check.title}: ${check.recordedAt} is older than 24h.`);
+  }
+
+  return failures;
 }
 
 function requireCheck(checks: ValidationCheck[], id: string): ValidationCheck {
@@ -481,6 +549,9 @@ function buildCandidateSummary(
   const smokeCheck = requireCheck(checks, "smoke-report");
   const uploadCheck = requireCheck(checks, "upload-receipt");
   const blockers: CandidateSummary["blockers"] = [];
+  const generatedAt = new Date().toISOString();
+  const generatedAtMs = Date.parse(generatedAt);
+  const manualMetadataFailures = manualChecks.flatMap((check) => collectManualReviewMetadataFailures(check, commit, generatedAtMs));
 
   for (const check of checks) {
     if (check.status === "failed") {
@@ -513,15 +584,22 @@ function buildCandidateSummary(
           : `Manual review pending: ${check.title}. ${check.notes}`.trim()
     });
   }
+  for (const failure of manualMetadataFailures) {
+    blockers.push({
+      id: "manual-review-metadata",
+      summary: failure
+    });
+  }
 
   const requiredPendingChecks = manualChecks.filter((check) => check.required && check.status === "pending").length;
   const requiredFailedChecks = manualChecks.filter((check) => check.required && check.status === "failed").length;
   const completedChecks = manualChecks.filter((check) => check.status === "passed" || check.status === "not_applicable").length;
+  const requiredMetadataFailures = manualMetadataFailures.length;
   const status: CandidateStatus = blockers.length === 0 ? "ready" : "blocked";
 
   return {
     schemaVersion: 1,
-    generatedAt: new Date().toISOString(),
+    generatedAt,
     candidate: {
       revision: commit,
       version,
@@ -575,11 +653,12 @@ function buildCandidateSummary(
           )
       },
       manualReview: {
-        status: requiredPendingChecks === 0 && requiredFailedChecks === 0 ? "ready" : "blocked",
+        status: requiredPendingChecks === 0 && requiredFailedChecks === 0 && requiredMetadataFailures === 0 ? "ready" : "blocked",
         totalChecks: manualChecks.length,
         completedChecks,
         requiredPendingChecks,
         requiredFailedChecks,
+        requiredMetadataFailures,
         checks: manualChecks
       }
     },
@@ -612,7 +691,17 @@ function renderCandidateMarkdown(summary: CandidateSummary): string {
   lines.push("## Manual Review", "");
   for (const check of summary.evidence.manualReview.checks) {
     const evidence = check.evidence.length > 0 ? ` Evidence: ${check.evidence.join(", ")}` : "";
-    lines.push(`- \`${check.status}\` ${check.title}${check.notes ? ` - ${check.notes}` : ""}${evidence}`);
+    const metadata = [
+      check.owner ? `owner=${check.owner}` : "",
+      check.recordedAt ? `recordedAt=${check.recordedAt}` : "",
+      check.revision ? `revision=${check.revision}` : "",
+      check.waiver?.reason ? `waiver=${check.waiver.reason}` : ""
+    ]
+      .filter((value) => value.length > 0)
+      .join(" ");
+    lines.push(
+      `- \`${check.status}\` ${check.title}${check.notes ? ` - ${check.notes}` : ""}${evidence}${metadata ? ` Metadata: ${metadata}` : ""}`
+    );
   }
   lines.push("", "## Blockers", "");
   if (summary.blockers.length === 0) {


### PR DESCRIPTION
## Summary
- formalize a target-surface release contract in `release:gate:summary`, including explicit `--target-surface` handling and WeChat candidate-summary preference
- require current owner/timestamp/revision metadata on WeChat manual review evidence and carry it through the candidate summary
- document the new contract and cover it with release-gate, release-health, and WeChat artifact tests

## Testing
- npm run test:release-gate-summary
- node --import tsx --test ./scripts/test/wechat-release-artifacts.test.ts
- npm run test:release-health-summary
- npm run typecheck:ci *(currently fails in pre-existing server files outside this change: `apps/server/src/admin-console.ts` and `apps/server/src/dev-server.ts`)*

Closes #548