### PR TITLE
test(cocos): cover timeline and renderer entry points

### DIFF
--- a/apps/cocos-client/test/cocos-fog-overlay.test.ts
+++ b/apps/cocos-client/test/cocos-fog-overlay.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Label, UIOpacity, UITransform } from "cc";
+import { VeilFogOverlay } from "../assets/scripts/VeilFogOverlay.ts";
+import type { FogOverlayStyle } from "../assets/scripts/cocos-map-visuals.ts";
+import { createComponentHarness, findNode, readLabelString } from "./helpers/cocos-panel-harness.ts";
+
+function createStyle(overrides: Partial<FogOverlayStyle> = {}): FogOverlayStyle {
+  return {
+    text: "FOG",
+    opacity: 112,
+    edgeOpacity: 54,
+    labelOpacity: 210,
+    tone: "hidden",
+    featherMask: 3,
+    ...overrides
+  };
+}
+
+test("VeilFogOverlay configures tile bounds and renders fog copy with opacity controls", () => {
+  const { component, node } = createComponentHarness(VeilFogOverlay, { name: "FogOverlayRoot", width: 0, height: 0 });
+
+  component.configure(72);
+  component.render(createStyle(), true);
+
+  const transform = node.getComponent(UITransform);
+  assert.equal(transform?.width, 60);
+  assert.equal(transform?.height, 60);
+
+  const labelNode = findNode(node, "Label");
+  const label = labelNode?.getComponent(Label) ?? null;
+  assert.equal(readLabelString(labelNode), "FOG");
+  assert.equal(label?.color?.a, 210);
+
+  const opacity = node.getComponent(UIOpacity);
+  assert.equal(opacity?.opacity, 255);
+  assert.equal(node.active, true);
+});
+
+test("VeilFogOverlay hides the overlay when disabled or no style is provided", () => {
+  const { component, node } = createComponentHarness(VeilFogOverlay, { name: "FogOverlayRoot", width: 0, height: 0 });
+
+  component.render(null, true);
+  assert.equal(node.active, false);
+
+  component.render(createStyle({ text: "VISIBLE", tone: "explored" }), false);
+  assert.equal(node.active, false);
+
+  component.render(createStyle({ text: "EDGE" }), true);
+  assert.equal(node.active, true);
+
+  component.render(null, true);
+  assert.equal(node.active, false);
+});

--- a/apps/cocos-client/test/cocos-tilemap-renderer.test.ts
+++ b/apps/cocos-client/test/cocos-tilemap-renderer.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TiledLayer, TiledMap } from "cc";
+import { VeilTilemapRenderer } from "../assets/scripts/VeilTilemapRenderer.ts";
+import type { PlayerTileView } from "../assets/scripts/VeilCocosSession.ts";
+import { createComponentHarness, createTile } from "./helpers/cocos-panel-harness.ts";
+
+class FakeLayer {
+  public readonly values = new Map<string, number>();
+  public writes = 0;
+
+  constructor(private readonly width: number, private readonly height: number) {}
+
+  getLayerSize(): { width: number; height: number } {
+    return { width: this.width, height: this.height };
+  }
+
+  setTileGIDAt(gid: number, x: number, y: number): void {
+    this.writes += 1;
+    this.values.set(`${x}:${y}`, gid);
+  }
+}
+
+function attachTestableLayers(
+  component: VeilTilemapRenderer,
+  names: string[]
+): { map: Map<string, FakeLayer>; testable: VeilTilemapRenderer & { resolveTiledMap(): TiledMap | null } } {
+  const layers = new Map<string, FakeLayer>();
+  names.forEach((name) => {
+    layers.set(name, new FakeLayer(4, 4));
+  });
+
+  const testable = component as VeilTilemapRenderer & { resolveTiledMap(): TiledMap | null };
+  const fakeMap = {
+    getLayer(name: string) {
+      const layer = layers.get(name);
+      return (layer as unknown as TiledLayer) ?? null;
+    }
+  } as TiledMap;
+
+  testable.resolveTiledMap = () => fakeMap;
+
+  return { map: layers, testable };
+}
+
+function toTiles(): PlayerTileView[] {
+  return [
+    createTile({ x: 0, y: 0 }, { terrain: "grass", fog: "visible" }),
+    createTile({ x: 1, y: 0 }, { terrain: "sand", fog: "hidden", resource: { kind: "wood", amount: 5 } }),
+    createTile({ x: 2, y: 0 }, { terrain: "dirt", fog: "visible", occupant: { kind: "neutral", refId: "neutral-1" } })
+  ];
+}
+
+function configureLayerNames(component: VeilTilemapRenderer): void {
+  component.terrainLayerName = "terrain";
+  component.fogLayerName = "fog";
+  component.fogEdgeLayerName = "fogEdge";
+  component.objectLayerName = "objects";
+  component.overlayLayerName = "overlay";
+}
+
+test("VeilTilemapRenderer syncs tile layers and caches repeated writes", () => {
+  const { component } = createComponentHarness(VeilTilemapRenderer, { name: "TilemapRoot", width: 0, height: 0 });
+  const { map } = attachTestableLayers(component, ["terrain", "fog", "fogEdge", "objects", "overlay"]);
+  configureLayerNames(component);
+
+  component.alphaFogOverlayEnabled = false;
+  component.grassTerrainGid = 11;
+  component.sandTerrainGid = 23;
+  component.dirtTerrainGid = 31;
+  component.hiddenFogGid = 5;
+  component.exploredFogGid = 3;
+  component.visibleFogGid = 1;
+  component.hiddenFogPulseGid = 7;
+  component.hiddenFogEdgeBaseGid = 90;
+  component.hiddenFogEdgePulseOffset = 4;
+  component.exploredFogEdgeBaseGid = 130;
+  component.exploredFogEdgePulseOffset = 6;
+  component.woodResourceGid = 44;
+  component.neutralOccupantGid = 55;
+  component.reachableOverlayGid = 99;
+  component.activeHeroOverlayGid = 120;
+
+  const tiles = toTiles();
+  const reachable = new Set<string>(["0:0", "1:0"]);
+
+  const rendered = component.syncTiles(tiles, {
+    activeHeroPosition: { x: 0, y: 0 },
+    fogPulsePhase: 1,
+    reachableKeys: reachable
+  });
+
+  assert.equal(rendered, true);
+
+  assert.equal(map.get("terrain")?.values.get("0:0"), 11);
+  assert.equal(map.get("terrain")?.values.get("1:0"), 23);
+  assert.equal(map.get("terrain")?.values.get("2:0"), 31);
+
+  const fogEntries = [...(map.get("fog")?.values.entries() ?? [])].sort(([a], [b]) => (a > b ? 1 : a < b ? -1 : 0));
+  assert.deepEqual(fogEntries, [
+    ["0:0", 1],
+    ["1:0", 7],
+    ["2:0", 1]
+  ]);
+
+  assert.ok((map.get("fogEdge")?.values.get("1:0") ?? 0) >= 90);
+
+  assert.equal(map.get("objects")?.values.get("2:0"), 55);
+
+  assert.equal(map.get("overlay")?.values.get("0:0"), 120);
+  assert.equal(map.get("overlay")?.values.get("1:0"), 99);
+
+  const overlayWrites = map.get("overlay")?.writes ?? 0;
+  component.syncTiles(tiles, {
+    activeHeroPosition: { x: 0, y: 0 },
+    fogPulsePhase: 1,
+    reachableKeys: reachable
+  });
+  assert.equal(map.get("overlay")?.writes, overlayWrites);
+});
+
+test("VeilTilemapRenderer clears cached tiles and reports missing layers", () => {
+  const { component } = createComponentHarness(VeilTilemapRenderer, { name: "TilemapRoot", width: 0, height: 0 });
+  const { map, testable } = attachTestableLayers(component, ["terrain"]);
+  configureLayerNames(component);
+
+  component.grassTerrainGid = 10;
+  const tiles = [createTile({ x: 0, y: 0 }, { terrain: "grass", fog: "visible" })];
+  const options = { activeHeroPosition: { x: 0, y: 0 }, fogPulsePhase: 0, reachableKeys: new Set<string>(["0:0"]) };
+
+  component.syncTiles(tiles, options);
+  component.clear();
+  assert.equal(map.get("terrain")?.values.get("0:0"), 0);
+
+  testable.resolveTiledMap = () => null;
+  const rendered = component.syncTiles(tiles, options);
+  assert.equal(rendered, false);
+});

--- a/apps/cocos-client/test/cocos-timeline-panel.test.ts
+++ b/apps/cocos-client/test/cocos-timeline-panel.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VeilTimelinePanel } from "../assets/scripts/VeilTimelinePanel.ts";
+import { loadPixelSpriteAssets } from "../assets/scripts/cocos-pixel-sprites.ts";
+import { getPlaceholderSpriteAssetUsageSummary } from "../assets/scripts/cocos-placeholder-sprites.ts";
+import { createComponentHarness, findNode, readLabelString } from "./helpers/cocos-panel-harness.ts";
+import { useCcSpriteResourceDoubles } from "./helpers/cc-sprite-resources.ts";
+
+test("VeilTimelinePanel retains placeholder sprites while entries exist and releases them when cleared", async (t) => {
+  useCcSpriteResourceDoubles(t);
+  await loadPixelSpriteAssets("boot");
+
+  const { component } = createComponentHarness(VeilTimelinePanel, { name: "TimelinePanel", width: 280, height: 320 });
+
+  component.render({
+    entries: ["系统： 自动重连成功"]
+  });
+
+  let usage = getPlaceholderSpriteAssetUsageSummary();
+  assert.equal(usage.referenceCounts.timeline, 1);
+
+  component.render({
+    entries: []
+  });
+
+  usage = getPlaceholderSpriteAssetUsageSummary();
+  assert.equal(usage.referenceCounts.timeline, 0);
+
+  component.onDestroy();
+  usage = getPlaceholderSpriteAssetUsageSummary();
+  assert.equal(usage.referenceCounts.timeline, 0);
+});
+
+test("VeilTimelinePanel renders timeline entries with icon and watermark transitions", async (t) => {
+  useCcSpriteResourceDoubles(t);
+  await loadPixelSpriteAssets("boot");
+
+  const { component, node } = createComponentHarness(VeilTimelinePanel, { name: "TimelinePanel", width: 320, height: 360 });
+
+  component.render({
+    entries: [
+      "系统： 房间权威状态恢复 · 推送缓存快照",
+      "事件： 英雄凯琳获得木材 +5",
+      "事件： 中立遭遇战胜利"
+    ]
+  });
+
+  const headerIcon = findNode(node, "TimelineHeaderIcon");
+  assert.ok(headerIcon, "expected header icon node");
+  assert.equal(headerIcon.active, true);
+
+  const watermark = findNode(node, "TimelineWatermark");
+  assert.ok(watermark, "expected watermark node");
+  assert.equal(watermark.active, false);
+
+  const firstEntryLabel = findNode(node, "TimelineEntry-0-Label");
+  assert.equal(readLabelString(firstEntryLabel), "房间权威状态恢复 · 推送缓存快照");
+  const secondEntryBadge = findNode(node, "TimelineEntry-1")?.getChildByName("Badge");
+  assert.match(readLabelString(secondEntryBadge), /事件/);
+  assert.equal(readLabelString(findNode(node, "TimelineContent")), "时间线");
+
+  component.render({
+    entries: ["系统： 等待房间动态"]
+  });
+  assert.equal(watermark.active, false);
+
+  component.render({ entries: [] });
+  assert.equal(watermark.active, true);
+  const summaryLabel = findNode(node, "TimelineContent");
+  assert.match(readLabelString(summaryLabel), /等待房间动态/);
+});

--- a/apps/cocos-client/test/cocos-unit-animator.test.ts
+++ b/apps/cocos-client/test/cocos-unit-animator.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Label, Node, Sprite, UIOpacity } from "cc";
+import { VeilUnitAnimator } from "../assets/scripts/VeilUnitAnimator.ts";
+import type { CocosAnimationProfile } from "../assets/scripts/cocos-presentation-config.ts";
+import { loadPixelSpriteAssets } from "../assets/scripts/cocos-pixel-sprites.ts";
+import { createComponentHarness } from "./helpers/cocos-panel-harness.ts";
+import { useCcSpriteResourceDoubles } from "./helpers/cc-sprite-resources.ts";
+
+function createAnimatorProfile(): CocosAnimationProfile {
+  return {
+    fallbackPrefix: "Hero",
+    spinePrefix: "Hero",
+    clipPrefix: "Hero",
+    spineNames: {
+      idle: "HeroIdle",
+      move: "HeroMove",
+      attack: "HeroAttack",
+      hit: "HeroHit",
+      victory: "HeroVictory",
+      defeat: "HeroDefeat"
+    },
+    clipNames: {
+      idle: "HeroClipIdle",
+      move: "HeroClipMove",
+      attack: "HeroClipAttack",
+      hit: "HeroClipHit",
+      victory: "HeroClipVictory",
+      defeat: "HeroClipDefeat"
+    },
+    returnTimings: {
+      attack: 0.4,
+      hit: 0.25,
+      victory: 0.8,
+      defeat: 0.8
+    },
+    returnToIdleAfterOneShot: true
+  };
+}
+
+test("VeilUnitAnimator plays pixel sequences and returns to idle after one-shot actions", async (t) => {
+  useCcSpriteResourceDoubles(t);
+  await loadPixelSpriteAssets("boot");
+
+  const { node, component } = createComponentHarness(VeilUnitAnimator, { name: "UnitAnimatorRoot", width: 0, height: 0 });
+  const heroIcon = new Node("HeroIcon");
+  heroIcon.parent = node;
+  heroIcon.addComponent(Sprite);
+  heroIcon.addComponent(UIOpacity);
+  node.addComponent(Label);
+
+  const profile = createAnimatorProfile();
+  let scheduledDelay = 0;
+  let scheduledCallback: (() => void) | null = null;
+  component.scheduleOnce = ((callback: () => void, delay?: number) => {
+    scheduledDelay = delay ?? 0;
+    scheduledCallback = callback;
+    return undefined;
+  }) as typeof component.scheduleOnce;
+
+  component.applyProfile(profile, "hero_guard_basic");
+  assert.equal(component.hasPixelFallback("hero_guard_basic"), true);
+
+  component.play("victory");
+
+  const heroSprite = heroIcon.getComponent(Sprite);
+  const opacity = heroIcon.getComponent(UIOpacity);
+  assert.ok(heroSprite?.spriteFrame, "expected hero sprite frame to be assigned");
+  assert.equal(heroSprite?.color?.r, 252);
+  assert.equal(opacity?.opacity, 255);
+  assert.equal(heroIcon.scale.x > 1, true);
+  assert.equal(scheduledDelay, profile.returnTimings.victory);
+
+  const stateful = component as VeilUnitAnimator & { currentState: string };
+  assert.equal(stateful.currentState, "victory");
+
+  scheduledCallback?.();
+  assert.equal(stateful.currentState, "idle");
+  assert.equal(heroIcon.scale.x, 1);
+});
+
+test("VeilUnitAnimator falls back to idle copy when sprite assets are unavailable", async (t) => {
+  useCcSpriteResourceDoubles(t);
+
+  const { node, component } = createComponentHarness(VeilUnitAnimator, { name: "UnitAnimatorRoot", width: 0, height: 0 });
+  node.addComponent(Label);
+
+  const profile = createAnimatorProfile();
+  profile.returnToIdleAfterOneShot = false;
+
+  component.applyProfile(profile, "unknown_template");
+  assert.equal(component.hasPixelFallback("unknown_template"), false);
+
+  component.play("attack");
+
+  const label = node.getComponent(Label);
+  assert.match(label?.string ?? "", /\[ATTACK]/);
+  assert.equal(component.hasPixelFallback(), false);
+});

--- a/apps/cocos-client/test/helpers/cc-sprite-resources.ts
+++ b/apps/cocos-client/test/helpers/cc-sprite-resources.ts
@@ -1,0 +1,52 @@
+import type { TestContext } from "node:test";
+import { ImageAsset, SpriteFrame, resources } from "cc";
+import { resetPixelSpriteRuntimeForTests } from "../../assets/scripts/cocos-pixel-sprites.ts";
+import {
+  resetPlaceholderSpriteAssetsForTests,
+  setPlaceholderSpriteRuntimeForTests
+} from "../../assets/scripts/cocos-placeholder-sprites.ts";
+
+const originalResourcesLoad = resources.load;
+const originalSpriteFrameCreateWithImage = SpriteFrame.createWithImage;
+
+function createSpriteFrame(imageAsset: ImageAsset): SpriteFrame {
+  const frame = new SpriteFrame();
+  frame.name = imageAsset.name;
+  frame.texture = imageAsset;
+  return frame;
+}
+
+export function useCcSpriteResourceDoubles(t: TestContext): void {
+  resetPixelSpriteRuntimeForTests();
+  resetPlaceholderSpriteAssetsForTests();
+
+  const loader = ((path: string, _type: typeof ImageAsset, callback: (err: Error | null, asset: ImageAsset) => void) => {
+    const asset = new ImageAsset();
+    asset.name = path;
+    callback(null, asset);
+  }) as typeof resources.load;
+
+  resources.load = loader;
+  SpriteFrame.createWithImage = ((imageAsset: ImageAsset) => createSpriteFrame(imageAsset)) as typeof SpriteFrame.createWithImage;
+
+  setPlaceholderSpriteRuntimeForTests({
+    loader: {
+      load: (path, _type, callback) => {
+        const asset = new ImageAsset();
+        asset.name = path;
+        callback(null, asset as never);
+      },
+      release() {}
+    },
+    spriteFrameFactory: {
+      createWithImage: (imageAsset: ImageAsset) => createSpriteFrame(imageAsset)
+    }
+  });
+
+  t.after(() => {
+    resources.load = originalResourcesLoad;
+    SpriteFrame.createWithImage = originalSpriteFrameCreateWithImage;
+    resetPixelSpriteRuntimeForTests();
+    resetPlaceholderSpriteAssetsForTests();
+  });
+}


### PR DESCRIPTION
## Summary
- add focused node:test suites for VeilTimelinePanel, VeilFogOverlay, VeilTilemapRenderer, and VeilUnitAnimator
- add a reusable cc resource double harness so timeline/unit tests can stub sprite loads without touching Creator assets
- exercise touchpoints that were still uncovered behind the primary journey, including placeholder retention, fog overlay chrome, tilemap gid wiring, and pixel animation fallbacks

Closes #553.

## Testing
- node --import tsx --test apps/cocos-client/test/cocos-timeline-panel.test.ts apps/cocos-client/test/cocos-fog-overlay.test.ts apps/cocos-client/test/cocos-tilemap-renderer.test.ts apps/cocos-client/test/cocos-unit-animator.test.ts