### PR TITLE
release: add a single candidate-level Phase 1 exit evidence gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ npm run dev:client:h5
 - 发布就绪快照：`npm run release:readiness:snapshot`
 - 统一发布门禁汇总：`npm run release:gate:summary`
 - 发布健康度聚合摘要：`npm run release:health:summary`
-- Phase 1 candidate dossier：`npm run release:phase1:candidate-dossier -- --candidate <candidate-name> --candidate-revision <git-sha> [--server-url http://127.0.0.1:2567]`
+- Phase 1 candidate dossier + single exit evidence gate：`npm run release:phase1:candidate-dossier -- --candidate <candidate-name> --candidate-revision <git-sha> [--server-url http://127.0.0.1:2567]`
 - 打包 H5 客户端 RC 冒烟：`npm run smoke:client:release-candidate`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`

--- a/docs/phase1-candidate-dossier.md
+++ b/docs/phase1-candidate-dossier.md
@@ -2,6 +2,8 @@
 
 `npm run release:phase1:candidate-dossier` folds the current Phase 1 exit evidence for one candidate revision into a single JSON dossier plus a Markdown attachment.
 
+It now also emits one explicit candidate-level `Phase 1 exit evidence gate` so reviewers can make the final pass/pending/fail call from one object instead of re-interpreting each evidence section by hand.
+
 The command stays intentionally thin and reuses the existing evidence producers:
 
 - `npm run release:readiness:snapshot`
@@ -53,6 +55,7 @@ npm run release:phase1:candidate-dossier -- \
 The dossier surfaces:
 
 - one candidate revision and target surface
+- one `phase1ExitEvidenceGate` result with blocking/pending/accepted-risk section lists
 - `requiredFailed`
 - `requiredPending`
 - `acceptedRisks`

--- a/scripts/phase1-candidate-dossier.ts
+++ b/scripts/phase1-candidate-dossier.ts
@@ -271,6 +271,7 @@ interface DossierSection {
     | "wechat-release"
     | "runtime-health"
     | "phase1-persistence"
+    | "phase1-exit-evidence-gate"
     | "release-gate"
     | "release-health";
   label: string;
@@ -284,6 +285,14 @@ interface DossierSection {
   details: string[];
   evidence: DossierEvidenceRef[];
   acceptedRisks: DossierAcceptedRisk[];
+}
+
+interface Phase1ExitEvidenceGate {
+  result: DossierResult;
+  summary: string;
+  blockingSections: string[];
+  pendingSections: string[];
+  acceptedRiskSections: string[];
 }
 
 interface Phase1CandidateDossier {
@@ -305,6 +314,7 @@ interface Phase1CandidateDossier {
     acceptedRiskCount: number;
     freshness: Record<EvidenceFreshness, number>;
   };
+  phase1ExitEvidenceGate: Phase1ExitEvidenceGate;
   inputs: {
     serverUrl?: string;
     snapshotPath?: string;
@@ -1417,17 +1427,74 @@ function buildDerivedSection(
   };
 }
 
-function buildOverallStatus(requiredFailed: string[], requiredPending: string[], acceptedRiskCount: number, releaseGate: DossierSection): DossierResult {
-  if (requiredFailed.length > 0 || releaseGate.result === "failed") {
+function buildOverallStatus(requiredFailed: string[], requiredPending: string[], acceptedRiskCount: number, exitGate: Phase1ExitEvidenceGate): DossierResult {
+  if (requiredFailed.length > 0 || exitGate.result === "failed") {
     return "failed";
   }
-  if (requiredPending.length > 0 || releaseGate.result === "pending") {
+  if (requiredPending.length > 0 || exitGate.result === "pending") {
     return "pending";
   }
   if (acceptedRiskCount > 0) {
     return "accepted_risk";
   }
   return "passed";
+}
+
+function buildPhase1ExitEvidenceGateSection(sections: DossierSection[], generatedAt: string | undefined): {
+  section: DossierSection;
+  gate: Phase1ExitEvidenceGate;
+} {
+  const scopedSections = sections.filter((section) => section.id !== "release-health");
+  const blockingSections = scopedSections.filter((section) => section.result === "failed").map((section) => section.label);
+  const pendingSections = scopedSections.filter((section) => section.result === "pending").map((section) => section.label);
+  const acceptedRiskSections = scopedSections.filter((section) => section.result === "accepted_risk").map((section) => section.label);
+  const details = [
+    ...blockingSections.map((label) => `blocking: ${label}`),
+    ...pendingSections.map((label) => `pending: ${label}`),
+    ...acceptedRiskSections.map((label) => `accepted risk: ${label}`)
+  ];
+  const freshness = evaluateFreshness(generatedAt, 1000 * 60 * 60 * 72);
+  let result: DossierResult = "passed";
+  if (blockingSections.length > 0) {
+    result = "failed";
+  } else if (pendingSections.length > 0 || freshness !== "fresh") {
+    result = "pending";
+  } else if (acceptedRiskSections.length > 0) {
+    result = "accepted_risk";
+  }
+
+  const summary =
+    result === "failed"
+      ? `Candidate-level Phase 1 exit evidence is blocked by ${blockingSections.join(", ")}.`
+      : result === "pending"
+        ? pendingSections.length > 0
+          ? `Candidate-level Phase 1 exit evidence is still pending for ${pendingSections.join(", ")}.`
+          : "Candidate-level Phase 1 exit evidence needs a fresh gate sample."
+        : result === "accepted_risk"
+          ? `Candidate-level Phase 1 exit evidence passed with accepted risks in ${acceptedRiskSections.join(", ")}.`
+          : "Candidate-level Phase 1 exit evidence is current for this revision.";
+
+  return {
+    section: {
+      id: "phase1-exit-evidence-gate",
+      label: "Phase 1 exit evidence gate",
+      required: true,
+      result,
+      summary,
+      observedAt: generatedAt,
+      freshness,
+      details,
+      evidence: [],
+      acceptedRisks: []
+    },
+    gate: {
+      result,
+      summary,
+      blockingSections,
+      pendingSections,
+      acceptedRiskSections
+    }
+  };
 }
 
 export function renderMarkdown(dossier: Phase1CandidateDossier): string {
@@ -1439,7 +1506,23 @@ export function renderMarkdown(dossier: Phase1CandidateDossier): string {
   lines.push(`- Overall status: **${dossier.summary.status.toUpperCase()}**`);
   lines.push(`- Required failed: ${dossier.summary.requiredFailed.length}`);
   lines.push(`- Required pending: ${dossier.summary.requiredPending.length}`);
+  lines.push(`- Phase 1 exit evidence gate: \`${dossier.phase1ExitEvidenceGate.result}\``);
+  lines.push(`- Phase 1 exit summary: ${dossier.phase1ExitEvidenceGate.summary}`);
   lines.push(`- Accepted risks: ${dossier.summary.acceptedRiskCount}`, "");
+
+  lines.push("## Phase 1 Exit Evidence Gate", "");
+  lines.push(`- Result: \`${dossier.phase1ExitEvidenceGate.result}\``);
+  lines.push(`- Summary: ${dossier.phase1ExitEvidenceGate.summary}`);
+  if (dossier.phase1ExitEvidenceGate.blockingSections.length > 0) {
+    lines.push(`- Blocking sections: ${dossier.phase1ExitEvidenceGate.blockingSections.join(", ")}`);
+  }
+  if (dossier.phase1ExitEvidenceGate.pendingSections.length > 0) {
+    lines.push(`- Pending sections: ${dossier.phase1ExitEvidenceGate.pendingSections.join(", ")}`);
+  }
+  if (dossier.phase1ExitEvidenceGate.acceptedRiskSections.length > 0) {
+    lines.push(`- Accepted-risk sections: ${dossier.phase1ExitEvidenceGate.acceptedRiskSections.join(", ")}`);
+  }
+  lines.push("");
 
   lines.push("## Section Summary", "");
   for (const section of dossier.sections) {
@@ -1599,8 +1682,13 @@ export async function buildPhase1CandidateDossier(args: Args): Promise<Phase1Can
     "Release health summary raised warnings.",
     "Release health summary is blocking."
   );
+  const { section: phase1ExitEvidenceGateSection, gate: phase1ExitEvidenceGate } = buildPhase1ExitEvidenceGateSection(
+    [snapshotSection, cocosSection, wechatSection, runtimeSection, persistenceSection, releaseGateSection],
+    gateReport.generatedAt
+  );
 
   const sections: DossierSection[] = [
+    phase1ExitEvidenceGateSection,
     snapshotSection,
     cocosSection,
     wechatSection,
@@ -1642,13 +1730,14 @@ export async function buildPhase1CandidateDossier(args: Args): Promise<Phase1Can
       targetSurface: args.targetSurface
     },
     summary: {
-      status: buildOverallStatus(requiredFailed, requiredPending, acceptedRisks.length, releaseGateSection),
+      status: buildOverallStatus(requiredFailed, requiredPending, acceptedRisks.length, phase1ExitEvidenceGate),
       totalSections: sections.length,
       requiredFailed,
       requiredPending,
       acceptedRiskCount: acceptedRisks.length,
       freshness: freshnessSummary
     },
+    phase1ExitEvidenceGate,
     inputs,
     sections,
     acceptedRisks

--- a/scripts/test/phase1-candidate-dossier.test.ts
+++ b/scripts/test/phase1-candidate-dossier.test.ts
@@ -355,7 +355,10 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     assert.deepEqual(dossier.summary.requiredFailed, []);
     assert.deepEqual(dossier.summary.requiredPending, []);
     assert.equal(dossier.summary.acceptedRiskCount, 1);
+    assert.equal(dossier.phase1ExitEvidenceGate.result, "accepted_risk");
+    assert.equal(dossier.phase1ExitEvidenceGate.acceptedRiskSections[0], "Release readiness snapshot");
     assert.equal(dossier.sections.find((section) => section.id === "release-gate")?.result, "passed");
+    assert.equal(dossier.sections.find((section) => section.id === "phase1-exit-evidence-gate")?.result, "accepted_risk");
     assert.equal(dossier.sections.find((section) => section.id === "runtime-health")?.result, "passed");
     assert.equal(dossier.acceptedRisks[0]?.label, "Unit and integration regression");
     assert.match(dossier.acceptedRisks[0]?.reason ?? "", /accepted for this RC only/i);
@@ -363,9 +366,115 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     const markdown = renderMarkdown(dossier);
     assert.match(markdown, /# Phase 1 Candidate Dossier/);
     assert.match(markdown, /Overall status: \*\*ACCEPTED_RISK\*\*/);
+    assert.match(markdown, /## Phase 1 Exit Evidence Gate/);
+    assert.match(markdown, /Phase 1 exit evidence gate: `accepted_risk`/);
     assert.match(markdown, /Release readiness snapshot/);
     assert.match(markdown, /Runtime health\/auth-readiness\/metrics/);
     assert.match(markdown, /Accepted Risks/);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      runtime.server.closeAllConnections?.();
+      runtime.server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+});
+
+test("phase1 candidate dossier fails the single exit evidence gate when the release gate summary is blocking", async () => {
+  const workspace = createTempWorkspace();
+  const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
+  const wechatDir = path.join(workspace, "artifacts", "wechat-release");
+  const revision = "abc1234";
+
+  const snapshotPath = path.join(artifactsDir, "release-readiness-pass.json");
+  const h5SmokePath = path.join(artifactsDir, "client-release-candidate-smoke-pass.json");
+  const cocosBundlePath = path.join(artifactsDir, "cocos-rc-evidence-bundle-pass.json");
+  const persistencePath = path.join(artifactsDir, `phase1-release-persistence-regression-${revision}.json`);
+  const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-04-02T08:30:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [{ id: "npm-test", required: true, status: "passed" }]
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: "2026-04-02T08:32:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    execution: { status: "passed", exitCode: 0 },
+    summary: { total: 2, passed: 2, failed: 0 }
+  });
+  writeJson(cocosBundlePath, {
+    bundle: {
+      generatedAt: "2026-04-02T08:34:00.000Z",
+      candidate: "phase1-rc",
+      commit: revision,
+      shortCommit: revision,
+      overallStatus: "passed",
+      summary: "Cocos RC evidence is complete."
+    },
+    review: { phase1Gate: "passed" },
+    journey: [{ id: "lobby-entry", status: "passed" }],
+    requiredEvidence: [{ id: "roomId", label: "Room id recorded", filled: true }]
+  });
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: "2026-04-02T08:40:00.000Z",
+    candidate: { revision, status: "ready" },
+    evidence: {
+      smoke: { status: "passed", artifactPath: path.join(wechatDir, "codex.wechat.smoke-report.json") },
+      manualReview: {
+        status: "ready",
+        requiredPendingChecks: 0,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: [
+          {
+            id: "wechat-runtime-review",
+            required: true,
+            status: "passed",
+            owner: "release-oncall",
+            recordedAt: "2026-04-02T08:39:00.000Z",
+            revision,
+            artifactPath: path.join(wechatDir, "runtime-review.json")
+          }
+        ]
+      }
+    },
+    blockers: []
+  });
+  writeJson(persistencePath, {
+    generatedAt: "2026-04-02T08:41:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    summary: { status: "passed", assertionCount: 6 },
+    contentValidation: { valid: true, bundleCount: 5, summary: "All shipped content packs validated.", issueCount: 0 },
+    persistenceRegression: { mapPackId: "phase1", assertions: ["room hydration reapplied resources"] }
+  });
+
+  const runtime = await startRuntimeServer();
+  try {
+    const dossier = await buildPhase1CandidateDossier({
+      candidate: "phase1-rc",
+      candidateRevision: revision,
+      serverUrl: runtime.url,
+      snapshotPath,
+      h5SmokePath,
+      cocosBundlePath,
+      wechatCandidateSummaryPath,
+      persistencePath,
+      targetSurface: "wechat",
+      maxEvidenceAgeHours: 72
+    });
+
+    assert.equal(dossier.sections.find((section) => section.id === "release-gate")?.result, "failed");
+    assert.equal(dossier.phase1ExitEvidenceGate.result, "failed");
+    assert.equal(dossier.summary.status, "failed");
+    assert.match(dossier.phase1ExitEvidenceGate.summary, /blocked/i);
+    assert.equal(dossier.phase1ExitEvidenceGate.blockingSections.includes("Release gate summary"), true);
   } finally {
     await new Promise<void>((resolve, reject) => {
       runtime.server.closeAllConnections?.();


### PR DESCRIPTION
## Summary
- add one explicit candidate-level Phase 1 exit evidence gate to the Phase 1 candidate dossier output
- surface the new gate in the dossier markdown and overall status calculation
- add coverage for accepted-risk and blocking release-gate scenarios, and document the new contract

## Testing
- npm run test:phase1-candidate-dossier
- npm run test:release-gate-summary
- npm run typecheck:ci (currently fails on pre-existing server type errors in apps/server/src/admin-console.ts and apps/server/src/dev-server.ts)

Closes #552