### PR TITLE
release: make reconnect soak and persistence evidence first-class RC gates

### DIFF
--- a/apps/cocos-client/test/release-readiness-dashboard.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard.test.ts
@@ -34,6 +34,8 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
   const snapshotPath = path.join(workspaceDir, "release-readiness.json");
   const cocosRcPath = path.join(workspaceDir, "cocos-rc.json");
   const primaryClientDiagnosticsPath = path.join(workspaceDir, "cocos-primary-diagnostics.json");
+  const reconnectSoakPath = path.join(workspaceDir, "colyseus-reconnect-soak-summary.json");
+  const persistencePath = path.join(workspaceDir, "phase1-release-persistence-regression-abc1234.json");
   const wechatArtifactsDir = path.join(workspaceDir, "wechat-artifacts");
   const packageMetadataPath = path.join(wechatArtifactsDir, "project-veil.package.json");
   const archivePath = path.join(wechatArtifactsDir, "project-veil.tar.gz");
@@ -86,6 +88,54 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
       ]
     },
     checkpoints: []
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-03-29T08:22:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 192,
+      invariantChecks: 768
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
+  writeJson(persistencePath, {
+    generatedAt: "2026-03-29T08:24:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
+    effectiveStorageMode: "memory",
+    summary: {
+      status: "passed",
+      assertionCount: 6
+    },
+    contentValidation: {
+      valid: true,
+      bundleCount: 5,
+      summary: "All shipped content packs validated.",
+      issueCount: 0
+    },
+    persistenceRegression: {
+      mapPackId: "phase1",
+      assertions: ["room hydration reapplied resources"]
+    }
   });
   fs.mkdirSync(wechatArtifactsDir, { recursive: true });
   fs.writeFileSync(archivePath, "archive-binary", "utf8");
@@ -197,6 +247,10 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
         cocosRcPath,
         "--primary-client-diagnostics",
         primaryClientDiagnosticsPath,
+        "--reconnect-soak",
+        reconnectSoakPath,
+        "--phase1-persistence",
+        persistencePath,
         "--wechat-artifacts-dir",
         wechatArtifactsDir,
         "--candidate-revision",
@@ -240,12 +294,14 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
         ["server-health", "pass"],
         ["auth-readiness", "pass"],
         ["build-package-validation", "pass"],
+        ["reconnect-soak", "pass"],
+        ["phase1-persistence", "pass"],
         ["critical-evidence", "pass"]
       ]
     );
     assert.deepEqual(report.gates.every((gate) => gate.failReasons.length === 0), true);
-    assert.equal(report.gates[3]?.evidence.every((entry) => entry.availability === "present"), true);
-    assert.equal(report.gates[3]?.evidence.length, 5);
+    assert.equal(report.gates[5]?.evidence.every((entry) => entry.availability === "present"), true);
+    assert.equal(report.gates[5]?.evidence.length, 7);
     assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /Phase 1 Go\/No-Go/);
   } finally {
     await new Promise<void>((resolve, reject) => {
@@ -265,6 +321,8 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
   const outputPath = path.join(workspaceDir, "dashboard.json");
   const markdownOutputPath = path.join(workspaceDir, "dashboard.md");
   const snapshotPath = path.join(workspaceDir, "release-readiness.json");
+  const reconnectSoakPath = path.join(workspaceDir, "colyseus-reconnect-soak-summary.json");
+  const persistencePath = path.join(workspaceDir, "phase1-release-persistence-regression-abc1234.json");
   const wechatArtifactsDir = path.join(workspaceDir, "wechat-artifacts");
   const packageMetadataPath = path.join(wechatArtifactsDir, "project-veil.package.json");
   const smokeReportPath = path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json");
@@ -306,6 +364,54 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
       { id: "login-lobby", status: "pending" }
     ]
   });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-03-29T08:22:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
+    status: "failed",
+    summary: {
+      failedScenarios: 1,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 32,
+      invariantChecks: 128
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 1,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 2,
+          connectionCount: 1,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
+  writeJson(persistencePath, {
+    generatedAt: "2026-03-29T08:24:00.000Z",
+    revision: {
+      shortCommit: "abc1234"
+    },
+    effectiveStorageMode: "memory",
+    summary: {
+      status: "passed",
+      assertionCount: 0
+    },
+    contentValidation: {
+      valid: false,
+      bundleCount: 5,
+      summary: "Content validation failed.",
+      issueCount: 2
+    },
+    persistenceRegression: {
+      mapPackId: "phase1",
+      assertions: []
+    }
+  });
 
   let output = "";
   try {
@@ -317,6 +423,10 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
         "./scripts/release-readiness-dashboard.ts",
         "--snapshot",
         snapshotPath,
+        "--reconnect-soak",
+        reconnectSoakPath,
+        "--phase1-persistence",
+        persistencePath,
         "--wechat-artifacts-dir",
         wechatArtifactsDir,
         "--candidate-revision",
@@ -374,6 +484,8 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
       ["server-health", "warn"],
       ["auth-readiness", "warn"],
       ["build-package-validation", "fail"],
+      ["reconnect-soak", "fail"],
+      ["phase1-persistence", "fail"],
       ["critical-evidence", "fail"]
     ]
   );
@@ -383,6 +495,15 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
     "wechat_package_metadata_incomplete"
   ]);
   assert.deepEqual(report.gates[2]?.warnReasons, ["wechat_smoke_pending", "wechat_smoke_cases_pending"]);
-  assert.equal(report.gates[3]?.evidence.some((entry) => entry.freshness === "fresh"), true);
+  assert.deepEqual(report.gates[3]?.failReasons, [
+    "reconnect_soak_failed",
+    "reconnect_soak_rooms_failed",
+    "reconnect_soak_cleanup_incomplete"
+  ]);
+  assert.deepEqual(report.gates[4]?.failReasons, [
+    "phase1_content_validation_failed",
+    "phase1_persistence_assertions_missing"
+  ]);
+  assert.equal(report.gates[5]?.evidence.some((entry) => entry.freshness === "fresh"), true);
   assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /Release validation evidence is incomplete or still pending|One or more release validation surfaces failed/);
 });

--- a/docs/phase1-candidate-dossier.md
+++ b/docs/phase1-candidate-dossier.md
@@ -9,6 +9,7 @@ The command stays intentionally thin and reuses the existing evidence producers:
 - `npm run release:readiness:snapshot`
 - `npm run release:cocos-rc:bundle`
 - `npm run validate:wechat-rc` / `codex.wechat.release-candidate-summary.json`
+- `npm run stress:rooms:reconnect-soak`
 - `npm run test:phase1-release-persistence`
 - `npm run release:gate:summary`
 - `npm run release:health:summary`
@@ -35,6 +36,7 @@ npm run release:phase1:candidate-dossier -- \
   --candidate-revision abc1234 \
   --snapshot artifacts/release-readiness/release-readiness-abc1234.json \
   --cocos-bundle artifacts/release-readiness/cocos-rc-evidence-bundle-phase1-wechat-rc-abc1234.json \
+  --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary.json \
   --wechat-candidate-summary artifacts/wechat-release/codex.wechat.release-candidate-summary.json \
   --phase1-persistence artifacts/release-readiness/phase1-release-persistence-regression-abc1234.json \
   --server-url http://127.0.0.1:2567
@@ -60,6 +62,6 @@ The dossier surfaces:
 - `requiredPending`
 - `acceptedRisks`
 - per-section freshness and artifact paths
-- Phase 1 sections for readiness, Cocos RC, WeChat release, runtime sampling, persistence/content-pack validation, release gate summary, and release health summary
+- Phase 1 sections for readiness, Cocos RC, WeChat release, runtime sampling, reconnect soak, persistence/content-pack validation, release gate summary, and release health summary
 
 The JSON artifact is intended for CI/automation, and the Markdown artifact is intended for PR/release review so reviewers do not need to stitch Phase 1 exit evidence together by hand.

--- a/docs/release-readiness-dashboard.md
+++ b/docs/release-readiness-dashboard.md
@@ -8,6 +8,8 @@
 - `npm run smoke:wechat-release` for device/quasi-device smoke evidence
 - `npm run release:cocos-rc:snapshot` for recent Cocos RC journey evidence
 - `npm run release:cocos:primary-diagnostics` for checkpointed primary-client runtime diagnostics evidence
+- `npm run stress:rooms:reconnect-soak` for reconnect soak + teardown evidence
+- `npm run test:phase1-release-persistence` for persistence + shipped content evidence
 
 The dashboard writes both JSON and Markdown so it works as a quick terminal summary and as a review artifact.
 
@@ -27,6 +29,8 @@ npm run release:readiness:dashboard -- \
   --snapshot artifacts/release-readiness/rc-2026-03-29.json \
   --cocos-rc artifacts/release-evidence/phase1-wechat-rc.json \
   --primary-client-diagnostics artifacts/release-readiness/cocos-primary-client-diagnostic-snapshots-abc1234-2026-03-29T08-18-00.000Z.json \
+  --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary.json \
+  --phase1-persistence artifacts/release-readiness/phase1-release-persistence-regression-abc1234.json \
   --wechat-artifacts-dir artifacts/wechat-release \
   --candidate-revision abc1234
 ```
@@ -69,7 +73,7 @@ The report starts with one `go/no-go` section:
   - one or more required checks failed, a gate failed, or linked artifact revisions disagree on which candidate is under review.
   - when `--candidate-revision` is supplied, `blocked` also covers required evidence with missing revision metadata or freshness that cannot be verified inside the configured window.
 
-After that, the report summarizes the same four bounded gates:
+After that, the report summarizes the same six bounded gates:
 
 - `Server health`
   - `pass` when `/api/runtime/health` is reachable and `/api/runtime/metrics` exposes the expected gameplay/auth counters.
@@ -87,6 +91,12 @@ After that, the report summarizes the same four bounded gates:
   - Lists the latest linked evidence with exact timestamps, paths, and any revision identifiers discovered in the source artifacts.
   - Fails closed when primary-client diagnostic snapshots are missing or incomplete.
   - Warns when present evidence is older than the configured freshness window.
+- `Reconnect soak evidence`
+  - Fails when the reconnect soak artifact is missing, reports failed scenarios / rooms, omits reconnect or invariant counters, or leaves cleanup counters above zero.
+  - Warns when the artifact passes but is older than the configured freshness window.
+- `Phase 1 persistence evidence`
+  - Fails when the persistence regression artifact is missing, the regression did not pass, shipped content validation failed, or no persistence assertions were recorded.
+  - Warns when the artifact passes but is older than the configured freshness window.
 
 ## Recommended Local Flow
 
@@ -116,13 +126,20 @@ npm run release:cocos-rc:snapshot -- --candidate <candidate-name> --build-surfac
 npm run release:cocos:primary-diagnostics
 ```
 
-5. Start the local server if you want live runtime/auth evidence in the same report:
+5. Refresh reconnect soak and persistence evidence when the RC scope touches room recovery or shipped content/persistence paths:
+
+```bash
+npm run stress:rooms:reconnect-soak
+npm run test:phase1-release-persistence
+```
+
+6. Start the local server if you want live runtime/auth evidence in the same report:
 
 ```bash
 npm run dev:server
 ```
 
-6. Generate the dashboard:
+7. Generate the dashboard:
 
 ```bash
 npm run release:readiness:dashboard -- \

--- a/scripts/phase1-candidate-dossier.ts
+++ b/scripts/phase1-candidate-dossier.ts
@@ -216,6 +216,33 @@ interface Phase1PersistenceReleaseReport {
   };
 }
 
+interface ReconnectSoakArtifact {
+  generatedAt?: string;
+  revision?: {
+    commit?: string;
+    shortCommit?: string;
+  };
+  status?: "passed" | "failed";
+  summary?: {
+    failedScenarios?: number;
+    scenarioNames?: string[];
+  };
+  soakSummary?: {
+    reconnectAttempts?: number;
+    invariantChecks?: number;
+  } | null;
+  results?: Array<{
+    scenario?: string;
+    failedRooms?: number;
+    runtimeHealthAfterCleanup?: {
+      activeRoomCount?: number;
+      connectionCount?: number;
+      activeBattleCount?: number;
+      heroCount?: number;
+    };
+  }>;
+}
+
 interface RuntimeHealthPayload {
   status?: "ok";
   checkedAt?: string;
@@ -270,6 +297,7 @@ interface DossierSection {
     | "cocos-rc-bundle"
     | "wechat-release"
     | "runtime-health"
+    | "reconnect-soak"
     | "phase1-persistence"
     | "phase1-exit-evidence-gate"
     | "release-gate"
@@ -1383,6 +1411,96 @@ function buildPersistenceSection(persistencePath: string | undefined, candidateR
   };
 }
 
+function buildReconnectSoakSection(reconnectSoakPath: string | undefined, candidateRevision: string, maxAgeMs: number): DossierSection {
+  if (!reconnectSoakPath || !fs.existsSync(reconnectSoakPath)) {
+    return {
+      id: "reconnect-soak",
+      label: "Reconnect soak evidence",
+      required: true,
+      result: "pending",
+      summary: "Reconnect soak artifact is missing.",
+      artifactPath: reconnectSoakPath,
+      freshness: "unknown",
+      details: ["Run npm run stress:rooms:reconnect-soak for the candidate revision."],
+      evidence: [],
+      acceptedRisks: []
+    };
+  }
+
+  const report = readJsonFile<ReconnectSoakArtifact>(reconnectSoakPath);
+  const freshness = evaluateFreshness(report.generatedAt, maxAgeMs);
+  const revision = report.revision?.commit ?? report.revision?.shortCommit;
+  const reconnectResult = report.results?.find((entry) => entry.scenario === "reconnect_soak");
+  const cleanup = reconnectResult?.runtimeHealthAfterCleanup;
+  const lingeringCleanupMetrics = [
+    ["activeRoomCount", cleanup?.activeRoomCount ?? 0],
+    ["connectionCount", cleanup?.connectionCount ?? 0],
+    ["activeBattleCount", cleanup?.activeBattleCount ?? 0],
+    ["heroCount", cleanup?.heroCount ?? 0]
+  ].filter(([, value]) => value > 0);
+
+  const details: string[] = [
+    `reconnectAttempts=${report.soakSummary?.reconnectAttempts ?? 0}`,
+    `invariantChecks=${report.soakSummary?.invariantChecks ?? 0}`
+  ];
+  if (report.summary?.scenarioNames?.length) {
+    details.push(`scenarios=${report.summary.scenarioNames.join(",")}`);
+  }
+  if (lingeringCleanupMetrics.length > 0) {
+    details.push(`cleanup=${lingeringCleanupMetrics.map(([label, value]) => `${label}=${value}`).join(",")}`);
+  }
+  if (!commitsMatch(revision, candidateRevision)) {
+    details.push(`revision mismatch: expected ${candidateRevision}, observed ${revision ?? "missing"}`);
+  }
+  if (freshness !== "fresh") {
+    details.push(`reconnect soak freshness=${freshness}`);
+  }
+
+  let result: DossierResult = "passed";
+  if (
+    report.status !== "passed" ||
+    (report.summary?.failedScenarios ?? 0) > 0 ||
+    (reconnectResult?.failedRooms ?? 0) > 0 ||
+    (report.soakSummary?.reconnectAttempts ?? 0) <= 0 ||
+    (report.soakSummary?.invariantChecks ?? 0) <= 0 ||
+    lingeringCleanupMetrics.length > 0 ||
+    !commitsMatch(revision, candidateRevision)
+  ) {
+    result = "failed";
+  } else if (freshness !== "fresh") {
+    result = "pending";
+  }
+
+  return {
+    id: "reconnect-soak",
+    label: "Reconnect soak evidence",
+    required: true,
+    result,
+    summary:
+      result === "failed"
+        ? "Reconnect soak evidence is not aligned with this candidate."
+        : result === "pending"
+          ? "Reconnect soak evidence passed, but freshness still needs review."
+          : "Reconnect soak evidence passed with clean room teardown.",
+    artifactPath: reconnectSoakPath,
+    observedAt: report.generatedAt,
+    freshness,
+    revision,
+    details,
+    evidence: [
+      {
+        label: "Reconnect soak summary",
+        path: reconnectSoakPath,
+        summary: `reconnectAttempts=${report.soakSummary?.reconnectAttempts ?? 0} invariantChecks=${report.soakSummary?.invariantChecks ?? 0}`,
+        observedAt: report.generatedAt,
+        freshness,
+        revision
+      }
+    ],
+    acceptedRisks: []
+  };
+}
+
 function buildDerivedSection(
   id: DossierSection["id"],
   label: string,
@@ -1621,6 +1739,7 @@ export async function buildPhase1CandidateDossier(args: Args): Promise<Phase1Can
     maxAgeMs
   );
   const runtimeSection = await buildRuntimeSection(inputs.serverUrl, maxAgeMs);
+  const reconnectSoakSection = buildReconnectSoakSection(inputs.reconnectSoakPath, revision.commit, maxAgeMs);
   const persistenceSection = buildPersistenceSection(inputs.persistencePath, revision.commit, maxAgeMs);
 
   const gateReport = buildReleaseGateSummaryReport(
@@ -1683,7 +1802,7 @@ export async function buildPhase1CandidateDossier(args: Args): Promise<Phase1Can
     "Release health summary is blocking."
   );
   const { section: phase1ExitEvidenceGateSection, gate: phase1ExitEvidenceGate } = buildPhase1ExitEvidenceGateSection(
-    [snapshotSection, cocosSection, wechatSection, runtimeSection, persistenceSection, releaseGateSection],
+    [snapshotSection, cocosSection, wechatSection, runtimeSection, reconnectSoakSection, persistenceSection, releaseGateSection],
     gateReport.generatedAt
   );
 
@@ -1693,6 +1812,7 @@ export async function buildPhase1CandidateDossier(args: Args): Promise<Phase1Can
     cocosSection,
     wechatSection,
     runtimeSection,
+    reconnectSoakSection,
     persistenceSection,
     releaseGateSection,
     releaseHealthSection

--- a/scripts/release-readiness-dashboard.ts
+++ b/scripts/release-readiness-dashboard.ts
@@ -11,6 +11,8 @@ interface Args {
   snapshotPath?: string;
   cocosRcPath?: string;
   primaryClientDiagnosticsPath?: string;
+  reconnectSoakPath?: string;
+  persistencePath?: string;
   wechatArtifactsDir?: string;
   wechatSmokeReportPath?: string;
   wechatPackageMetadataPath?: string;
@@ -129,6 +131,59 @@ interface PrimaryClientDiagnosticSnapshotsArtifact {
   }>;
 }
 
+interface ReconnectSoakArtifact {
+  generatedAt?: string;
+  revision?: {
+    commit?: string;
+    shortCommit?: string;
+  };
+  status?: "passed" | "failed";
+  summary?: {
+    failedScenarios?: number;
+    scenarioNames?: string[];
+  };
+  soakSummary?: {
+    reconnectAttempts?: number;
+    invariantChecks?: number;
+    worldReconnectCycles?: number;
+    battleReconnectCycles?: number;
+  } | null;
+  results?: Array<{
+    scenario?: string;
+    failedRooms?: number;
+    runtimeHealthAfterCleanup?: {
+      activeRoomCount?: number;
+      connectionCount?: number;
+      activeBattleCount?: number;
+      heroCount?: number;
+    };
+  }>;
+}
+
+interface Phase1PersistenceReleaseReport {
+  generatedAt?: string;
+  revision?: {
+    commit?: string;
+    shortCommit?: string;
+  };
+  effectiveStorageMode?: string;
+  storageDescription?: string;
+  summary?: {
+    status?: "passed";
+    assertionCount?: number;
+  };
+  contentValidation?: {
+    valid?: boolean;
+    bundleCount?: number;
+    summary?: string;
+    issueCount?: number;
+  };
+  persistenceRegression?: {
+    mapPackId?: string;
+    assertions?: string[];
+  };
+}
+
 interface EvidenceItem {
   label: string;
   path: string;
@@ -163,6 +218,8 @@ interface DashboardReport {
     snapshotPath?: string;
     cocosRcPath?: string;
     primaryClientDiagnosticsPath?: string;
+    reconnectSoakPath?: string;
+    persistencePath?: string;
     wechatArtifactsDir?: string;
     wechatSmokeReportPath?: string;
     wechatPackageMetadataPath?: string;
@@ -242,6 +299,8 @@ function parseArgs(argv: string[]): Args {
   let snapshotPath: string | undefined;
   let cocosRcPath: string | undefined;
   let primaryClientDiagnosticsPath: string | undefined;
+  let reconnectSoakPath: string | undefined;
+  let persistencePath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let wechatSmokeReportPath: string | undefined;
   let wechatPackageMetadataPath: string | undefined;
@@ -271,6 +330,16 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--primary-client-diagnostics" && next) {
       primaryClientDiagnosticsPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--reconnect-soak" && next) {
+      reconnectSoakPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--phase1-persistence" && next) {
+      persistencePath = next;
       index += 1;
       continue;
     }
@@ -322,6 +391,8 @@ function parseArgs(argv: string[]): Args {
     ...(snapshotPath ? { snapshotPath } : {}),
     ...(cocosRcPath ? { cocosRcPath } : {}),
     ...(primaryClientDiagnosticsPath ? { primaryClientDiagnosticsPath } : {}),
+    ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
+    ...(persistencePath ? { persistencePath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
     ...(wechatPackageMetadataPath ? { wechatPackageMetadataPath } : {}),
@@ -1115,6 +1186,173 @@ export function buildCriticalEvidenceGate(
   };
 }
 
+export function summarizeReconnectSoak(
+  artifactPath: string | undefined,
+  artifact: ReconnectSoakArtifact | undefined,
+  maxEvidenceAgeDays: number
+): EvidenceSummary {
+  if (!artifactPath || !artifact) {
+    return {
+      status: "fail",
+      detail: "Reconnect soak artifact missing.",
+      evidence: createEvidenceItem({
+        label: "Reconnect soak summary",
+        path: artifactPath ?? "<missing-reconnect-soak-artifact>",
+        status: "fail",
+        availability: "missing",
+        summary: "Reconnect soak artifact missing.",
+        reasonCodes: ["reconnect_soak_artifact_missing"]
+      }),
+      failReasons: ["reconnect_soak_artifact_missing"],
+      warnReasons: []
+    };
+  }
+
+  const reconnectResult = artifact.results?.find((entry) => entry.scenario === "reconnect_soak");
+  const cleanup = reconnectResult?.runtimeHealthAfterCleanup;
+  const lingeringCleanupMetrics = [
+    ["activeRoomCount", cleanup?.activeRoomCount ?? 0],
+    ["connectionCount", cleanup?.connectionCount ?? 0],
+    ["activeBattleCount", cleanup?.activeBattleCount ?? 0],
+    ["heroCount", cleanup?.heroCount ?? 0]
+  ].filter(([, value]) => value > 0);
+
+  const failReasons: string[] = [];
+  if (artifact.status !== "passed") {
+    failReasons.push("reconnect_soak_failed");
+  }
+  if ((artifact.summary?.failedScenarios ?? 0) > 0 || (reconnectResult?.failedRooms ?? 0) > 0) {
+    failReasons.push("reconnect_soak_rooms_failed");
+  }
+  if ((artifact.soakSummary?.reconnectAttempts ?? 0) <= 0 || (artifact.soakSummary?.invariantChecks ?? 0) <= 0) {
+    failReasons.push("reconnect_soak_counters_missing");
+  }
+  if (lingeringCleanupMetrics.length > 0) {
+    failReasons.push("reconnect_soak_cleanup_incomplete");
+  }
+
+  const age = describeAge(artifact.generatedAt, maxEvidenceAgeDays);
+  const warnReasons = failReasons.length === 0 && age.status === "warn" ? ["reconnect_soak_stale"] : [];
+  const status: GateStatus = failReasons.length > 0 ? "fail" : age.status === "warn" ? "warn" : "pass";
+
+  const parts = [
+    `status=${artifact.status ?? "<missing>"}`,
+    `reconnectAttempts=${artifact.soakSummary?.reconnectAttempts ?? 0}`,
+    `invariantChecks=${artifact.soakSummary?.invariantChecks ?? 0}`,
+    `cleanup=${lingeringCleanupMetrics.length === 0 ? "clean" : lingeringCleanupMetrics.map(([label, value]) => `${label}=${value}`).join(",")}`
+  ];
+  if (artifact.summary?.scenarioNames?.length) {
+    parts.push(`scenarios=${artifact.summary.scenarioNames.join(",")}`);
+  }
+  if (warnReasons.length > 0) {
+    parts.push(age.detail);
+  }
+
+  return {
+    status,
+    detail: parts.join(" | "),
+    evidence: createEvidenceItem({
+      label: "Reconnect soak summary",
+      path: artifactPath,
+      status,
+      observedAt: artifact.generatedAt,
+      sourceRevision: artifact.revision?.shortCommit ?? artifact.revision?.commit,
+      summary: parts.join(" | "),
+      reasonCodes: status === "fail" ? failReasons : warnReasons
+    }),
+    failReasons,
+    warnReasons
+  };
+}
+
+export function summarizePhase1Persistence(
+  artifactPath: string | undefined,
+  artifact: Phase1PersistenceReleaseReport | undefined,
+  maxEvidenceAgeDays: number
+): EvidenceSummary {
+  if (!artifactPath || !artifact) {
+    return {
+      status: "fail",
+      detail: "Phase 1 persistence regression artifact missing.",
+      evidence: createEvidenceItem({
+        label: "Phase 1 persistence regression",
+        path: artifactPath ?? "<missing-phase1-persistence-artifact>",
+        status: "fail",
+        availability: "missing",
+        summary: "Phase 1 persistence regression artifact missing.",
+        reasonCodes: ["phase1_persistence_artifact_missing"]
+      }),
+      failReasons: ["phase1_persistence_artifact_missing"],
+      warnReasons: []
+    };
+  }
+
+  const failReasons: string[] = [];
+  if (artifact.summary?.status !== "passed") {
+    failReasons.push("phase1_persistence_failed");
+  }
+  if (artifact.contentValidation?.valid !== true) {
+    failReasons.push("phase1_content_validation_failed");
+  }
+  if ((artifact.summary?.assertionCount ?? 0) <= 0 || (artifact.persistenceRegression?.assertions?.length ?? 0) <= 0) {
+    failReasons.push("phase1_persistence_assertions_missing");
+  }
+
+  const age = describeAge(artifact.generatedAt, maxEvidenceAgeDays);
+  const warnReasons = failReasons.length === 0 && age.status === "warn" ? ["phase1_persistence_stale"] : [];
+  const status: GateStatus = failReasons.length > 0 ? "fail" : age.status === "warn" ? "warn" : "pass";
+
+  const parts = [
+    `status=${artifact.summary?.status ?? "<missing>"}`,
+    `contentValid=${artifact.contentValidation?.valid === true}`,
+    `assertions=${artifact.summary?.assertionCount ?? artifact.persistenceRegression?.assertions?.length ?? 0}`,
+    `storage=${artifact.effectiveStorageMode ?? "<missing>"}`,
+    `mapPack=${artifact.persistenceRegression?.mapPackId ?? "<missing>"}`
+  ];
+  if (artifact.contentValidation?.summary?.trim()) {
+    parts.push(artifact.contentValidation.summary.trim());
+  }
+  if (warnReasons.length > 0) {
+    parts.push(age.detail);
+  }
+
+  return {
+    status,
+    detail: parts.join(" | "),
+    evidence: createEvidenceItem({
+      label: "Phase 1 persistence regression",
+      path: artifactPath,
+      status,
+      observedAt: artifact.generatedAt,
+      sourceRevision: artifact.revision?.shortCommit ?? artifact.revision?.commit,
+      summary: parts.join(" | "),
+      reasonCodes: status === "fail" ? failReasons : warnReasons
+    }),
+    failReasons,
+    warnReasons
+  };
+}
+
+export function buildArtifactGate(
+  id: string,
+  label: string,
+  summary: EvidenceSummary,
+  passedSummary: string,
+  warnSummary: string,
+  failedSummary: string
+): GateReport {
+  return {
+    id,
+    label,
+    status: summary.status,
+    failReasons: summary.failReasons,
+    warnReasons: summary.warnReasons,
+    summary: summary.status === "pass" ? passedSummary : summary.status === "warn" ? warnSummary : failedSummary,
+    details: [summary.detail],
+    evidence: [summary.evidence]
+  };
+}
+
 function buildOverallSummary(gates: GateReport[]): string {
   const failed = gates.filter((gate) => gate.status === "fail").map((gate) => gate.label);
   const warned = gates.filter((gate) => gate.status === "warn").map((gate) => gate.label);
@@ -1350,11 +1588,19 @@ async function main(): Promise<void> {
     : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
         entry.startsWith("cocos-primary-client-diagnostic-snapshots-")
       );
+  const resolvedReconnectSoakPath = args.reconnectSoakPath
+    ? path.resolve(args.reconnectSoakPath)
+    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) => entry.startsWith("colyseus-reconnect-soak-summary"));
+  const resolvedPersistencePath = args.persistencePath
+    ? path.resolve(args.persistencePath)
+    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) => entry.startsWith("phase1-release-persistence-regression-"));
   const wechatArtifacts = resolveWechatArtifacts(args);
 
   const snapshot = readJsonFile<ReleaseReadinessSnapshot>(resolvedSnapshotPath);
   const cocosRcSnapshot = readJsonFile<CocosReleaseCandidateSnapshot>(resolvedCocosRcPath);
   const primaryClientDiagnostics = readJsonFile<PrimaryClientDiagnosticSnapshotsArtifact>(resolvedPrimaryClientDiagnosticsPath);
+  const reconnectSoakArtifact = readJsonFile<ReconnectSoakArtifact>(resolvedReconnectSoakPath);
+  const persistenceArtifact = readJsonFile<Phase1PersistenceReleaseReport>(resolvedPersistencePath);
   const wechatSmokeReport = readJsonFile<WechatSmokeReport>(wechatArtifacts.smokeReportPath);
   const wechatPackageMetadata = readJsonFile<WechatPackageMetadata>(wechatArtifacts.packageMetadataPath);
 
@@ -1392,19 +1638,39 @@ async function main(): Promise<void> {
     resolvedPrimaryClientDiagnosticsPath,
     primaryClientDiagnostics
   );
+  const reconnectSoakSummary = summarizeReconnectSoak(resolvedReconnectSoakPath, reconnectSoakArtifact, args.maxEvidenceAgeDays);
+  const persistenceSummary = summarizePhase1Persistence(resolvedPersistencePath, persistenceArtifact, args.maxEvidenceAgeDays);
 
   const criticalEvidenceGate = buildCriticalEvidenceGate(args.maxEvidenceAgeDays, [
     snapshotSummary.evidence,
     packageSummary.evidence,
     smokeSummary.evidence,
     cocosRcSummary.evidence,
-    primaryClientDiagnosticsSummary.evidence
+    primaryClientDiagnosticsSummary.evidence,
+    reconnectSoakSummary.evidence,
+    persistenceSummary.evidence
   ]);
 
   const gates = [
     buildHealthGate(args.serverUrl, healthPayload, metricsText, healthError ?? metricsError),
     buildAuthGate(args.serverUrl, authPayload, authError),
     buildBuildPackageGate(snapshotSummary, packageSummary, smokeSummary),
+    buildArtifactGate(
+      "reconnect-soak",
+      "Reconnect soak evidence",
+      reconnectSoakSummary,
+      "Reconnect soak evidence passed with clean room teardown.",
+      "Reconnect soak evidence exists, but freshness needs review.",
+      "Reconnect soak evidence is missing or failing."
+    ),
+    buildArtifactGate(
+      "phase1-persistence",
+      "Phase 1 persistence evidence",
+      persistenceSummary,
+      "Phase 1 persistence regression and shipped content validation passed.",
+      "Phase 1 persistence evidence exists, but freshness needs review.",
+      "Phase 1 persistence evidence is missing or failing."
+    ),
     criticalEvidenceGate
   ];
 
@@ -1425,6 +1691,8 @@ async function main(): Promise<void> {
       ...(resolvedSnapshotPath ? { snapshotPath: resolvedSnapshotPath } : {}),
       ...(resolvedCocosRcPath ? { cocosRcPath: resolvedCocosRcPath } : {}),
       ...(resolvedPrimaryClientDiagnosticsPath ? { primaryClientDiagnosticsPath: resolvedPrimaryClientDiagnosticsPath } : {}),
+      ...(resolvedReconnectSoakPath ? { reconnectSoakPath: resolvedReconnectSoakPath } : {}),
+      ...(resolvedPersistencePath ? { persistencePath: resolvedPersistencePath } : {}),
       ...(args.wechatArtifactsDir ? { wechatArtifactsDir: path.resolve(args.wechatArtifactsDir) } : {}),
       ...(wechatArtifacts.smokeReportPath ? { wechatSmokeReportPath: wechatArtifacts.smokeReportPath } : {}),
       ...(wechatArtifacts.packageMetadataPath ? { wechatPackageMetadataPath: wechatArtifacts.packageMetadataPath } : {}),

--- a/scripts/test/phase1-candidate-dossier.test.ts
+++ b/scripts/test/phase1-candidate-dossier.test.ts
@@ -360,6 +360,8 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     assert.equal(dossier.sections.find((section) => section.id === "release-gate")?.result, "passed");
     assert.equal(dossier.sections.find((section) => section.id === "phase1-exit-evidence-gate")?.result, "accepted_risk");
     assert.equal(dossier.sections.find((section) => section.id === "runtime-health")?.result, "passed");
+    assert.equal(dossier.sections.find((section) => section.id === "reconnect-soak")?.result, "passed");
+    assert.equal(dossier.sections.find((section) => section.id === "phase1-persistence")?.result, "passed");
     assert.equal(dossier.acceptedRisks[0]?.label, "Unit and integration regression");
     assert.match(dossier.acceptedRisks[0]?.reason ?? "", /accepted for this RC only/i);
 
@@ -370,6 +372,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     assert.match(markdown, /Phase 1 exit evidence gate: `accepted_risk`/);
     assert.match(markdown, /Release readiness snapshot/);
     assert.match(markdown, /Runtime health\/auth-readiness\/metrics/);
+    assert.match(markdown, /Reconnect soak evidence/);
     assert.match(markdown, /Accepted Risks/);
   } finally {
     await new Promise<void>((resolve, reject) => {
@@ -394,6 +397,7 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
   const snapshotPath = path.join(artifactsDir, "release-readiness-pass.json");
   const h5SmokePath = path.join(artifactsDir, "client-release-candidate-smoke-pass.json");
   const cocosBundlePath = path.join(artifactsDir, "cocos-rc-evidence-bundle-pass.json");
+  const reconnectSoakPath = path.join(artifactsDir, "colyseus-reconnect-soak-summary-pass.json");
   const persistencePath = path.join(artifactsDir, `phase1-release-persistence-regression-${revision}.json`);
   const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
 
@@ -421,6 +425,25 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
     review: { phase1Gate: "passed" },
     journey: [{ id: "lobby-entry", status: "passed" }],
     requiredEvidence: [{ id: "roomId", label: "Room id recorded", filled: true }]
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-04-02T08:33:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    status: "failed",
+    summary: { failedScenarios: 1, scenarioNames: ["reconnect_soak"] },
+    soakSummary: { reconnectAttempts: 12, invariantChecks: 48 },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 1,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 1,
+          connectionCount: 1,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
   });
   writeJson(wechatCandidateSummaryPath, {
     generatedAt: "2026-04-02T08:40:00.000Z",
@@ -463,6 +486,7 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
       serverUrl: runtime.url,
       snapshotPath,
       h5SmokePath,
+      reconnectSoakPath,
       cocosBundlePath,
       wechatCandidateSummaryPath,
       persistencePath,
@@ -471,6 +495,7 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
     });
 
     assert.equal(dossier.sections.find((section) => section.id === "release-gate")?.result, "failed");
+    assert.equal(dossier.sections.find((section) => section.id === "reconnect-soak")?.result, "failed");
     assert.equal(dossier.phase1ExitEvidenceGate.result, "failed");
     assert.equal(dossier.summary.status, "failed");
     assert.match(dossier.phase1ExitEvidenceGate.summary, /blocked/i);


### PR DESCRIPTION
## Summary
- promote reconnect soak and Phase 1 persistence evidence to explicit release-readiness dashboard gates
- add reconnect soak as a first-class Phase 1 candidate dossier section and exit-gate input
- update targeted tests and docs for the new RC gate inputs and outputs

## Testing
- node --import tsx --test apps/cocos-client/test/release-readiness-dashboard.test.ts
- node --import tsx --test scripts/test/phase1-candidate-dossier.test.ts
- node --import tsx --test scripts/test/release-gate-summary.test.ts
- npm run typecheck:ci *(currently fails in pre-existing unrelated files: apps/server/src/admin-console.ts, apps/server/src/dev-server.ts)*

Closes #554