### PR TITLE
release: validate real WeChat export/runtime on developer tools and device

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ npm run dev:client:h5
 - 打包 H5 客户端 RC 冒烟：`npm run smoke:client:release-candidate`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
-- 微信小游戏 RC artifact 聚合验收：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--manual-checks docs/release-evidence/wechat-release-manual-review.example.json]`（输出 `codex.wechat.rc-validation-report.json`、`codex.wechat.release-candidate-summary.json` 和 `.md`）
+- 微信小游戏 RC artifact 聚合验收：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--manual-checks docs/release-evidence/wechat-release-manual-review.example.json]`（输出 `codex.wechat.rc-validation-report.json`、`codex.wechat.release-candidate-summary.json` 和 `.md`，并默认要求开发者工具真实导出复核、真机 runtime 复核、RC checklist）
 - 微信小游戏发布彩排：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir>`（顺序执行 prepare / package / verify / validate，并在 `artifacts/wechat-release/` 输出 JSON + Markdown 摘要）
 - Cocos RC candidate bundle：`npm run release:cocos-rc:bundle -- --candidate <candidate-name> [--build-surface creator_preview|wechat_preview|wechat_upload_candidate]`（在 `artifacts/release-readiness/` 输出 candidate+revision 命名的 snapshot / checklist / blockers / JSON+Markdown bundle）
 - Issue #33 开源素材 staging 校验：`npm run check:issue33-assets -- --require-pack`

--- a/docs/release-evidence/cocos-wechat-rc-checklist.template.md
+++ b/docs/release-evidence/cocos-wechat-rc-checklist.template.md
@@ -59,12 +59,15 @@
 
 ## WeChat-Specific Checks
 
+- [ ] 已用真实导出目录在微信开发者工具中完成导入与启动验证
+  Evidence:
+  Notes:
 - [ ] 登录进入 Lobby 或游客降级结果已记录
 - [ ] 进房成功并记录 `roomId`
 - [ ] `reconnect-recovery` 已复用 `docs/reconnect-smoke-gate.md` 的 canonical scenario
 - [ ] 分享回流已验证，或明确标记 `not_applicable`
 - [ ] 关键资源加载无 404 / 白名单 / 缺图阻断
-- [ ] 真机或准真机设备、客户端版本、执行时间已记录
+- [ ] 真机或微信开发者工具真机调试的 runtime smoke 已记录设备、客户端版本、执行时间
 
 ## Release Decision
 
@@ -72,4 +75,3 @@
 - Summary:
 - Remaining blockers doc:
 - Follow-ups / owners:
-

--- a/docs/release-evidence/wechat-release-manual-review.example.json
+++ b/docs/release-evidence/wechat-release-manual-review.example.json
@@ -1,18 +1,33 @@
 [
   {
-    "id": "wechat-runtime-review",
-    "title": "Runtime health/auth-readiness/metrics reviewed for this candidate",
+    "id": "wechat-devtools-export-review",
+    "title": "Real WeChat export imported and launched in Developer Tools",
     "status": "pending",
     "required": true,
-    "notes": "Capture runtime evidence against the same candidate revision before marking the WeChat target release-ready.",
+    "notes": "Import the packaged candidate's real wechatgame export into WeChat Developer Tools and capture startup/runtime evidence for the same revision.",
     "owner": "<release-owner>",
     "recordedAt": "<2026-04-02T08:10:00.000Z>",
     "revision": "<git-sha>",
-    "artifactPath": "artifacts/wechat-release/runtime-review.json",
+    "artifactPath": "artifacts/wechat-release/devtools-export-review.json",
     "evidence": [
-      "GET /api/runtime/health",
-      "GET /api/runtime/auth-readiness",
-      "GET /api/runtime/metrics"
+      "WeChat Developer Tools startup screenshot",
+      "WeChat Developer Tools console log",
+      "Imported wechatgame project path or package manifest reference"
+    ]
+  },
+  {
+    "id": "wechat-device-runtime-review",
+    "title": "Physical-device WeChat runtime validated for this candidate",
+    "status": "pending",
+    "required": true,
+    "notes": "Attach the smoke report and supporting captures from a physical-device or WeChat real-device-debugging runtime pass against the same candidate revision.",
+    "owner": "<release-owner>",
+    "recordedAt": "<2026-04-02T08:12:00.000Z>",
+    "revision": "<git-sha>",
+    "artifactPath": "artifacts/wechat-release/device-runtime-review.json",
+    "evidence": [
+      "artifacts/wechat-release/codex.wechat.smoke-report.json",
+      "startup / reconnect / share recordings"
     ]
   },
   {

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -44,7 +44,7 @@ npm run smoke:client:release-candidate
 
 That flow rebuilds `apps/client/dist`, serves the packaged artifact instead of the dev shell, exercises guest login plus cached-session room boot, and writes machine-readable evidence under `artifacts/release-readiness/`. Pass `--output <path>` when CI or a reviewer needs a stable artifact filename.
 
-The snapshot also supports manual gates, so the same file can carry pending or completed human checks such as runtime endpoint review, reconnect evidence, device smoke acceptance, or RC blocker review.
+The snapshot also supports manual gates, so the same file can carry pending or completed human checks such as WeChat Developer Tools export review, reconnect evidence, device smoke acceptance, or RC blocker review.
 
 ## Usage
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -78,7 +78,7 @@
    - summary 中缺失 smoke 证据或待完成 manual review 会直接列为 `blockers`，而不是分散在多个文件里
    - JSON 至少包含 `version`、`commit`、artifact 路径、逐项检查结果和 `failureSummary`
    - `--version` 会要求并校验 `*.upload.json`；`--require-smoke-report` 会把 `codex.wechat.smoke-report.json` 设为必需门禁
-   - 若未显式传 `--manual-checks`，脚本仍会内置两条必需 manual review：runtime endpoint review 与 RC checklist/blocker review
+  - 若未显式传 `--manual-checks`，脚本仍会内置三条必需 manual review：微信开发者工具真实导出复核、真机 runtime 复核，以及 RC checklist/blocker review
    - required manual review 现在必须带 `owner`、`recordedAt`、`revision`；当 review 时间超过 24h、revision 不匹配或元数据缺失时，candidate summary 会继续保持 `blocked`
 8. 若已有设备农场、真机调试或准真机脚本产出的结构化 runtime 证据，执行 `npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`，把证据直接写入既有 `codex.wechat.smoke-report.json` schema。
 9. 若本次 RC 没有自动化 runtime 证据，再运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板，并在真机或准真机上逐项补录结果。
@@ -144,6 +144,12 @@
 - 对 checklist/blocker review 可额外补 `blockerIds`
 - 若为带条件放行，可补 `waiver.approvedBy` / `waiver.approvedAt` / `waiver.reason`
 
+默认 required checks 分别对应三类 release evidence：
+
+- `wechat-devtools-export-review`：真实导出目录已在微信开发者工具中导入并成功启动
+- `wechat-device-runtime-review`：同一 revision 已完成真机或微信开发者工具真机调试 runtime smoke，并附上 `codex.wechat.smoke-report.json`
+- `wechat-release-checklist`：RC checklist / blocker register 已对齐同一 candidate
+
 ## 提审前 Smoke Check
 
 `npm run smoke:wechat-release` 会生成 `codex.wechat.smoke-report.json`，也可以通过 `--runtime-evidence <runtime-evidence.json>` 直接把自动化设备/runtime 结果导入同一 schema。该文件是提审前必须保留的最小验收记录，建议直接随 artifact 归档保存。
@@ -170,7 +176,7 @@
 1. 先跑 `npm run verify:wechat-release -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>]`
 2. 若已有自动化设备/runtime 证据，执行 `npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`
 3. 若没有自动化证据，再跑 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板
-4. 在真机或微信开发者工具真机调试模式中逐项填写 `tester`、`device`、`executedAt`、`summary` 以及每个 case 的 `status` / `notes` / `evidence`
+4. 先在微信开发者工具中导入同一 revision 的真实 `wechatgame` 导出目录并记录启动结果，再在真机或微信开发者工具真机调试模式中逐项填写 `tester`、`device`、`executedAt`、`summary` 以及每个 case 的 `status` / `notes` / `evidence`
    - `reconnect-recovery.requiredEvidence` 下的 `roomId`、`reconnectPrompt`、`restoredState` 都必须填非空字符串；细则见 [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md)
    - `share-roundtrip.requiredEvidence` 下的 `shareScene`、`shareQuery`、`roundtripState` 也都必须填非空字符串，用来说明分享入口、参数和回流结果
 5. 回填完成后执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`

--- a/scripts/smoke-wechat-minigame-release.ts
+++ b/scripts/smoke-wechat-minigame-release.ts
@@ -517,7 +517,7 @@ function buildReportTemplate(metadata: WechatMinigameReleasePackageMetadata, met
       clientVersion: "",
       executedAt: "",
       result: "pending",
-      summary: `Fill this report after running the real-device or quasi-device smoke pass for ${path.basename(reportPath)}.`
+      summary: `Fill this report after running the physical-device or WeChat real-device-debugging smoke pass for ${path.basename(reportPath)}.`
     },
     cases: buildSmokeCases()
   };

--- a/scripts/test/phase1-candidate-dossier.test.ts
+++ b/scripts/test/phase1-candidate-dossier.test.ts
@@ -246,14 +246,24 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
         requiredMetadataFailures: 0,
         checks: [
           {
-            id: "wechat-runtime-review",
-            title: "Runtime health/auth-readiness/metrics reviewed for this candidate",
+            id: "wechat-devtools-export-review",
+            title: "Real WeChat export imported and launched in Developer Tools",
             required: true,
             status: "passed",
             owner: "release-oncall",
             recordedAt: "2026-04-02T08:39:00.000Z",
             revision,
-            artifactPath: path.join(wechatDir, "runtime-review.json")
+            artifactPath: path.join(wechatDir, "devtools-export-review.json")
+          },
+          {
+            id: "wechat-device-runtime-review",
+            title: "Physical-device WeChat runtime validated for this candidate",
+            required: true,
+            status: "passed",
+            owner: "release-oncall",
+            recordedAt: "2026-04-02T08:40:00.000Z",
+            revision,
+            artifactPath: path.join(wechatDir, "device-runtime-review.json")
           }
         ]
       }
@@ -457,13 +467,22 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
         requiredMetadataFailures: 0,
         checks: [
           {
-            id: "wechat-runtime-review",
+            id: "wechat-devtools-export-review",
             required: true,
             status: "passed",
             owner: "release-oncall",
             recordedAt: "2026-04-02T08:39:00.000Z",
             revision,
-            artifactPath: path.join(wechatDir, "runtime-review.json")
+            artifactPath: path.join(wechatDir, "devtools-export-review.json")
+          },
+          {
+            id: "wechat-device-runtime-review",
+            required: true,
+            status: "passed",
+            owner: "release-oncall",
+            recordedAt: "2026-04-02T08:40:00.000Z",
+            revision,
+            artifactPath: path.join(wechatDir, "device-runtime-review.json")
           }
         ]
       }

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -126,14 +126,24 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
         requiredMetadataFailures: 0,
         checks: [
           {
-            id: "wechat-runtime-review",
-            title: "Runtime health/auth-readiness/metrics reviewed for this candidate",
+            id: "wechat-devtools-export-review",
+            title: "Real WeChat export imported and launched in Developer Tools",
             required: true,
             status: "passed",
             owner: "release-oncall",
             recordedAt: "2026-04-02T08:10:00.000Z",
             revision: "abc123",
-            artifactPath: "artifacts/wechat-release/runtime-review.json"
+            artifactPath: "artifacts/wechat-release/devtools-export-review.json"
+          },
+          {
+            id: "wechat-device-runtime-review",
+            title: "Physical-device WeChat runtime validated for this candidate",
+            required: true,
+            status: "passed",
+            owner: "release-oncall",
+            recordedAt: "2026-04-02T08:12:00.000Z",
+            revision: "abc123",
+            artifactPath: "artifacts/wechat-release/device-runtime-review.json"
           },
           {
             id: "wechat-release-checklist",

--- a/scripts/test/wechat-release-artifacts.test.ts
+++ b/scripts/test/wechat-release-artifacts.test.ts
@@ -361,13 +361,18 @@ test("validate:wechat-rc marks smoke and upload receipt checks as skipped when o
   assert.equal(summary.artifacts.markdownPath, markdownPath);
   assert.equal(summary.evidence.smoke.status, "skipped");
   assert.equal(summary.evidence.manualReview.status, "blocked");
-  assert.equal(summary.evidence.manualReview.requiredPendingChecks, 2);
+  assert.equal(summary.evidence.manualReview.requiredPendingChecks, 3);
   assert.deepEqual(
     summary.evidence.manualReview.checks.map((check) => `${check.id}:${check.status}`),
-    ["wechat-runtime-review:pending", "wechat-release-checklist:pending"]
+    [
+      "wechat-devtools-export-review:pending",
+      "wechat-device-runtime-review:pending",
+      "wechat-release-checklist:pending"
+    ]
   );
   assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /smoke-report-missing/);
-  assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /manual:wechat-runtime-review/);
+  assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /manual:wechat-devtools-export-review/);
+  assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /manual:wechat-device-runtime-review/);
   assert.match(fs.readFileSync(markdownPath, "utf8"), /WeChat Release Candidate Summary/);
 });
 
@@ -435,16 +440,28 @@ test("validate:wechat-rc marks the candidate ready when smoke evidence and manua
   writePassingSmokeReport(artifact.metadataPath, smokeReportPath);
   writeManualChecks(manualChecksPath, [
     {
-      id: "wechat-runtime-review",
-      title: "Runtime health/auth-readiness/metrics reviewed for this candidate",
+      id: "wechat-devtools-export-review",
+      title: "Real WeChat export imported and launched in Developer Tools",
       status: "passed",
       required: true,
-      notes: "Captured candidate runtime endpoints for the same revision.",
-      evidence: ["GET /api/runtime/health", "GET /api/runtime/auth-readiness", "GET /api/runtime/metrics"],
+      notes: "Imported the packaged export into WeChat Developer Tools and captured startup evidence for the same revision.",
+      evidence: ["devtools-startup.png", "devtools-console.log"],
       owner: "release-oncall",
       recordedAt: "2026-04-02T08:10:00.000Z",
       revision: sourceRevision,
-      artifactPath: "artifacts/wechat-release/runtime-review.json"
+      artifactPath: "artifacts/wechat-release/devtools-export-review.json"
+    },
+    {
+      id: "wechat-device-runtime-review",
+      title: "Physical-device WeChat runtime validated for this candidate",
+      status: "passed",
+      required: true,
+      notes: "Attached the smoke report and capture set from the device validation pass for the same revision.",
+      evidence: ["artifacts/wechat-release/codex.wechat.smoke-report.json", "device-runtime.mp4"],
+      owner: "release-oncall",
+      recordedAt: "2026-04-02T08:12:00.000Z",
+      revision: sourceRevision,
+      artifactPath: "artifacts/wechat-release/device-runtime-review.json"
     },
     {
       id: "wechat-release-checklist",

--- a/scripts/validate-wechat-release-candidate.ts
+++ b/scripts/validate-wechat-release-candidate.ts
@@ -176,12 +176,21 @@ const OUTPUT_TAIL_BYTES = 4000;
 const MANUAL_REVIEW_MAX_AGE_MS = 1000 * 60 * 60 * 24;
 const DEFAULT_MANUAL_CHECKS: ManualReviewCheck[] = [
   {
-    id: "wechat-runtime-review",
-    title: "Runtime health/auth-readiness/metrics reviewed for this candidate",
+    id: "wechat-devtools-export-review",
+    title: "Real WeChat export imported and launched in Developer Tools",
     required: true,
     status: "pending",
-    notes: "Capture runtime health evidence against the same candidate revision before marking the WeChat target release-ready.",
-    evidence: ["GET /api/runtime/health", "GET /api/runtime/auth-readiness", "GET /api/runtime/metrics"],
+    notes: "Import the packaged candidate's real wechatgame export into WeChat Developer Tools and capture startup/runtime evidence for the same revision.",
+    evidence: ["artifacts/wechat-release/devtools-export-review.json", "WeChat Developer Tools startup screenshot or console log"],
+    source: "default"
+  },
+  {
+    id: "wechat-device-runtime-review",
+    title: "Physical-device WeChat runtime validated for this candidate",
+    required: true,
+    status: "pending",
+    notes: "Attach the smoke report and supporting captures from a physical-device or WeChat real-device-debugging runtime pass against the same candidate revision.",
+    evidence: ["artifacts/wechat-release/codex.wechat.smoke-report.json", "startup/reconnect/share capture"],
     source: "default"
   },
   {


### PR DESCRIPTION
## Summary
- require explicit WeChat Developer Tools export-review evidence before RC readiness
- require explicit physical-device runtime-review evidence alongside the smoke report
- update release docs, example evidence, and consumer tests to the new RC contract

Closes #557