### PR TITLE
release: formalize WeChat runtime review and observability sign-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ npm run dev:client:h5
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
 - 微信小游戏构建 / 发布 / 回滚说明：`docs/wechat-minigame-release.md`
+- 微信小游戏 runtime observability 签核：`docs/wechat-runtime-observability-signoff.md`
 - Phase 1 成熟度记分卡与退出标准：`docs/phase1-maturity-scorecard.md`
 - 核心玩法发布门禁清单：`docs/core-gameplay-release-readiness.md`
 - 发布就绪快照说明：`docs/release-readiness-snapshot.md`

--- a/docs/release-evidence/cocos-wechat-rc-checklist.template.md
+++ b/docs/release-evidence/cocos-wechat-rc-checklist.template.md
@@ -19,6 +19,8 @@
 - [ ] Cocos RC snapshot 已生成并通过 `--check`：
   `artifacts/release-evidence/<candidate>.<surface>.json`
 - [ ] 若为 WeChat RC，已附上 `codex.wechat.smoke-report.json`
+- [ ] 若为 WeChat RC，已附上 runtime observability sign-off：
+  `artifacts/wechat-release/runtime-observability-signoff.json`
 - [ ] 若为上传候选包，已附上 `*.package.json` / `*.upload.json`
 
 ## Canonical Journey
@@ -68,6 +70,22 @@
 - [ ] 分享回流已验证，或明确标记 `not_applicable`
 - [ ] 关键资源加载无 404 / 白名单 / 缺图阻断
 - [ ] 真机或微信开发者工具真机调试的 runtime smoke 已记录设备、客户端版本、执行时间
+- [ ] Runtime observability sign-off 已附上同一 revision 的 `/api/runtime/health`、`/api/runtime/diagnostic-snapshot`、`/api/runtime/metrics` 证据
+
+## Runtime Observability Sign-Off
+
+- [ ] `/api/runtime/health` 已复核 activeRoomCount / connectionCount / gameplayTraffic / auth 摘要
+  Evidence:
+  Notes:
+- [ ] `/api/runtime/diagnostic-snapshot` 已复核 room summary、predictionStatus、log tail
+  Evidence:
+  Notes:
+- [ ] `/api/runtime/metrics` 已抓取关键指标样本并确认无未知缺口
+  Evidence:
+  Notes:
+- [ ] 任何告警、缺口或接受风险都已写入 blocker register 或 sign-off artifact
+  Evidence:
+  Notes:
 
 ## Release Decision
 

--- a/docs/release-evidence/wechat-release-manual-review.example.json
+++ b/docs/release-evidence/wechat-release-manual-review.example.json
@@ -31,13 +31,30 @@
     ]
   },
   {
+    "id": "wechat-runtime-observability-signoff",
+    "title": "WeChat runtime observability reviewed for this candidate",
+    "status": "pending",
+    "required": true,
+    "notes": "Review the same-revision runtime observability evidence for the release environment and record any accepted follow-ups before sign-off.",
+    "owner": "<release-owner>",
+    "recordedAt": "<2026-04-02T08:14:00.000Z>",
+    "revision": "<git-sha>",
+    "artifactPath": "artifacts/wechat-release/runtime-observability-signoff.json",
+    "evidence": [
+      "/api/runtime/health payload",
+      "/api/runtime/diagnostic-snapshot capture",
+      "/api/runtime/metrics scrape or export",
+      "summary of any non-blocking alerts or follow-ups"
+    ]
+  },
+  {
     "id": "wechat-release-checklist",
     "title": "WeChat RC checklist and blockers reviewed",
     "status": "pending",
     "required": true,
     "notes": "Attach the completed RC checklist and blocker register for the same packaged candidate.",
     "owner": "<release-owner>",
-    "recordedAt": "<2026-04-02T08:15:00.000Z>",
+    "recordedAt": "<2026-04-02T08:16:00.000Z>",
     "revision": "<git-sha>",
     "artifactPath": "artifacts/wechat-release/checklist-review.json",
     "blockerIds": [

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -39,6 +39,7 @@
 - 统一 Cocos RC candidate bundle：`npm run release:cocos-rc:bundle`
 - Primary client delivery checklist：`docs/cocos-primary-client-delivery.md`
 - Cocos Phase 1 占位 / fallback 表现签核：`docs/cocos-phase1-presentation-signoff.md`
+- WeChat runtime observability 签核：`docs/wechat-runtime-observability-signoff.md`
 - Primary client delivery audit：`npm run audit:cocos-primary-delivery -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--expected-revision <git-sha>]`
 - PR 包装改动门禁：匹配上述路径时，查看 CI artifact `cocos-release-packaging-evidence-<git-sha>`
 - RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
@@ -78,16 +79,17 @@
    - summary 中缺失 smoke 证据或待完成 manual review 会直接列为 `blockers`，而不是分散在多个文件里
    - JSON 至少包含 `version`、`commit`、artifact 路径、逐项检查结果和 `failureSummary`
    - `--version` 会要求并校验 `*.upload.json`；`--require-smoke-report` 会把 `codex.wechat.smoke-report.json` 设为必需门禁
-  - 若未显式传 `--manual-checks`，脚本仍会内置三条必需 manual review：微信开发者工具真实导出复核、真机 runtime 复核，以及 RC checklist/blocker review
+  - 若未显式传 `--manual-checks`，脚本仍会内置四条必需 manual review：微信开发者工具真实导出复核、真机 runtime 复核、runtime observability sign-off，以及 RC checklist/blocker review
    - required manual review 现在必须带 `owner`、`recordedAt`、`revision`；当 review 时间超过 24h、revision 不匹配或元数据缺失时，candidate summary 会继续保持 `blocked`
 8. 若已有设备农场、真机调试或准真机脚本产出的结构化 runtime 证据，执行 `npm run ingest:wechat-smoke-evidence -- --metadata <release-sidecar.package.json> --report <release-artifacts-dir>/codex.wechat.smoke-report.json --runtime-evidence <runtime-evidence.json>`，把证据直接写入既有 `codex.wechat.smoke-report.json` schema。
 9. 若本次 RC 没有自动化 runtime 证据，再运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板，并在真机或准真机上逐项补录结果。
 10. 完成自动导入或人工补录后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
    - `reconnect-recovery` 必须复用 [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md) 的 canonical scenario、最小成功信号和失败诊断口径。
-11. 运行 `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json [--release-readiness-snapshot artifacts/release-readiness/<candidate>.json]`，脚本会在 `artifacts/release-readiness/` 一次性生成 candidate+revision 命名的 bundle manifest、Markdown 摘要、RC snapshot、checklist 与 blockers，并自动把微信 smoke 的 Lobby / 进房 / 重连证据映射到统一的 Cocos RC 快照；若仍缺 Creator 预览链路，会在快照和摘要里显式标成 `partial` 或 `blocked`，而不是默认为通过。
-12. 直接回填同一 bundle 里的 checklist / blockers 文件，仅补充自动化未覆盖的设备、结论和 blocker；不要再额外复制模板或在 PR 里发明另一套字段。
-13. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
-14. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
+11. 按 [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md) 为同一 revision 回填 `artifacts/wechat-release/runtime-observability-signoff.json`，确认 release 环境的 `/api/runtime/health`、`/api/runtime/diagnostic-snapshot`、`/api/runtime/metrics` 都已有可追溯证据。
+12. 运行 `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json [--release-readiness-snapshot artifacts/release-readiness/<candidate>.json]`，脚本会在 `artifacts/release-readiness/` 一次性生成 candidate+revision 命名的 bundle manifest、Markdown 摘要、RC snapshot、checklist 与 blockers，并自动把微信 smoke 的 Lobby / 进房 / 重连证据映射到统一的 Cocos RC 快照；若仍缺 Creator 预览链路，会在快照和摘要里显式标成 `partial` 或 `blocked`，而不是默认为通过。
+13. 直接回填同一 bundle 里的 checklist / blockers 文件，仅补充自动化未覆盖的设备、observability 结论和 blocker；不要再额外复制模板或在 PR 里发明另一套字段。
+14. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
+15. 将远程资源上传到 CDN，并在微信后台 / 开发者工具中完成提审。
 
 ## 发布彩排摘要
 
@@ -148,6 +150,7 @@
 
 - `wechat-devtools-export-review`：真实导出目录已在微信开发者工具中导入并成功启动
 - `wechat-device-runtime-review`：同一 revision 已完成真机或微信开发者工具真机调试 runtime smoke，并附上 `codex.wechat.smoke-report.json`
+- `wechat-runtime-observability-signoff`：同一 revision 的 release 环境已复核 `/api/runtime/health`、`/api/runtime/diagnostic-snapshot`、`/api/runtime/metrics`，并记录任何告警或接受风险
 - `wechat-release-checklist`：RC checklist / blocker register 已对齐同一 candidate
 
 ## 提审前 Smoke Check
@@ -181,7 +184,7 @@
    - `share-roundtrip.requiredEvidence` 下的 `shareScene`、`shareQuery`、`roundtripState` 也都必须填非空字符串，用来说明分享入口、参数和回流结果
 5. 回填完成后执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`
 6. 再执行 `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json`，把 `login-lobby`、`room-entry`、`reconnect-recovery` 自动映射到统一 RC 快照，并在 `artifacts/release-readiness/` 生成可直接附到 CI artifact / PR 评论的 bundle 摘要；若设备 evidence 缺失，快照会标成 `blocked`，避免在 RC 汇总里被误判为通过。
-7. 回填同一 bundle 里的 checklist / blockers 文件，并同步附上 [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) 的当前结论，确保 reviewer 能直接看到当前 RC 的设备、结论与未关闭风险。
+7. 回填同一 bundle 里的 checklist / blockers 文件，并同步附上 [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) 与 [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md) 的当前结论，确保 reviewer 能直接看到当前 RC 的设备、observability 结论与未关闭风险。
 
 ### 自动化 Runtime Evidence Schema
 

--- a/docs/wechat-runtime-observability-signoff.md
+++ b/docs/wechat-runtime-observability-signoff.md
@@ -1,0 +1,41 @@
+# WeChat Runtime Observability Sign-Off
+
+This sign-off is the manual release contract for proving that the WeChat candidate can still be observed in the target runtime, not just launched.
+
+Use it together with:
+
+- [`docs/wechat-minigame-release.md`](./wechat-minigame-release.md)
+- [`docs/release-evidence/wechat-release-manual-review.example.json`](./release-evidence/wechat-release-manual-review.example.json)
+- [`docs/release-evidence/cocos-wechat-rc-checklist.template.md`](./release-evidence/cocos-wechat-rc-checklist.template.md)
+
+## Required Evidence
+
+For the same candidate revision, capture and attach:
+
+- `/api/runtime/health`
+  - Confirm the payload is live for the release environment and note `activeRoomCount`, `connectionCount`, `gameplayTraffic`, and auth summary.
+- `/api/runtime/diagnostic-snapshot`
+  - Confirm the response renders the current room overview and diagnostics state.
+  - `?format=text` is acceptable when it is easier to attach to PR or artifact logs.
+- `/api/runtime/metrics`
+  - Capture at least one scrape/export showing the runtime metrics endpoint is reachable for the same environment.
+- Reviewer decision
+  - Record owner, `recordedAt`, revision, artifact path, and any follow-up or accepted risk.
+
+## Minimum Review Questions
+
+- Does the target environment expose the runtime health, diagnostic, and metrics endpoints for this candidate revision?
+- Do the responses show coherent room, connection, and gameplay counters instead of empty or obviously stale data?
+- Are any alerts, missing dimensions, or environment-specific caveats documented in the sign-off artifact or blocker register?
+
+## Suggested Artifact Shape
+
+Store one small JSON or Markdown artifact at `artifacts/wechat-release/runtime-observability-signoff.json` and reference it from the WeChat manual-review file.
+
+Keep the artifact scoped to:
+
+- candidate revision and environment
+- endpoint captures or links
+- reviewer / timestamp
+- conclusion: `passed | hold | ship-with-followups`
+- follow-ups or blocker IDs

--- a/scripts/test/wechat-release-artifacts.test.ts
+++ b/scripts/test/wechat-release-artifacts.test.ts
@@ -361,18 +361,20 @@ test("validate:wechat-rc marks smoke and upload receipt checks as skipped when o
   assert.equal(summary.artifacts.markdownPath, markdownPath);
   assert.equal(summary.evidence.smoke.status, "skipped");
   assert.equal(summary.evidence.manualReview.status, "blocked");
-  assert.equal(summary.evidence.manualReview.requiredPendingChecks, 3);
+  assert.equal(summary.evidence.manualReview.requiredPendingChecks, 4);
   assert.deepEqual(
     summary.evidence.manualReview.checks.map((check) => `${check.id}:${check.status}`),
     [
       "wechat-devtools-export-review:pending",
       "wechat-device-runtime-review:pending",
+      "wechat-runtime-observability-signoff:pending",
       "wechat-release-checklist:pending"
     ]
   );
   assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /smoke-report-missing/);
   assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /manual:wechat-devtools-export-review/);
   assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /manual:wechat-device-runtime-review/);
+  assert.match(summary.blockers.map((blocker) => `${blocker.id}:${blocker.summary}`).join("\n"), /manual:wechat-runtime-observability-signoff/);
   assert.match(fs.readFileSync(markdownPath, "utf8"), /WeChat Release Candidate Summary/);
 });
 
@@ -462,6 +464,22 @@ test("validate:wechat-rc marks the candidate ready when smoke evidence and manua
       recordedAt: "2026-04-02T08:12:00.000Z",
       revision: sourceRevision,
       artifactPath: "artifacts/wechat-release/device-runtime-review.json"
+    },
+    {
+      id: "wechat-runtime-observability-signoff",
+      title: "WeChat runtime observability reviewed for this candidate",
+      status: "passed",
+      required: true,
+      notes: "Captured health, diagnostic snapshot, and metrics evidence for the release environment.",
+      evidence: [
+        "/api/runtime/health payload",
+        "/api/runtime/diagnostic-snapshot?format=text",
+        "/api/runtime/metrics scrape"
+      ],
+      owner: "release-oncall",
+      recordedAt: "2026-04-02T08:14:00.000Z",
+      revision: sourceRevision,
+      artifactPath: "artifacts/wechat-release/runtime-observability-signoff.json"
     },
     {
       id: "wechat-release-checklist",

--- a/scripts/validate-wechat-release-candidate.ts
+++ b/scripts/validate-wechat-release-candidate.ts
@@ -194,6 +194,21 @@ const DEFAULT_MANUAL_CHECKS: ManualReviewCheck[] = [
     source: "default"
   },
   {
+    id: "wechat-runtime-observability-signoff",
+    title: "WeChat runtime observability reviewed for this candidate",
+    required: true,
+    status: "pending",
+    notes:
+      "Attach the same-revision runtime observability review for the release environment, including /api/runtime/health, /api/runtime/diagnostic-snapshot, and /api/runtime/metrics evidence plus any approved follow-ups.",
+    evidence: [
+      "artifacts/wechat-release/runtime-observability-signoff.json",
+      "/api/runtime/health payload",
+      "/api/runtime/diagnostic-snapshot capture",
+      "/api/runtime/metrics scrape or export"
+    ],
+    source: "default"
+  },
+  {
     id: "wechat-release-checklist",
     title: "WeChat RC checklist and blockers reviewed",
     required: true,


### PR DESCRIPTION
## Summary
- add a required WeChat manual review gate for runtime observability sign-off in the RC validator
- document the required observability evidence and wire it into the WeChat release checklist/examples
- update validator tests to require the new sign-off before a candidate is ready

## Testing
- node --import tsx --test ./scripts/test/wechat-release-artifacts.test.ts
- npm run test:release-gate-summary
- node --import tsx --test ./apps/server/test/runtime-observability-routes.test.ts

Closes #564