### PR TITLE
release(cocos): add a primary-client RC checkpoint ledger

### DIFF
--- a/docs/release-evidence/cocos-rc-snapshot.example.json
+++ b/docs/release-evidence/cocos-rc-snapshot.example.json
@@ -226,5 +226,44 @@
         "creator-preview"
       ]
     }
+  ],
+  "checkpointLedger": {
+    "source": "primary-journey-evidence",
+    "milestoneDir": "artifacts/release-readiness/cocos-primary-journey-rc-2026-03-29-example-abc1234",
+    "entryCount": 2,
+    "entries": [
+      {
+        "id": "battle-settlement",
+        "title": "Battle settlement",
+        "status": "passed",
+        "summary": "Recorded the first battle settlement with rewards applied before returning to world continuity on the same candidate revision.",
+        "artifactPath": "artifacts/release-readiness/cocos-primary-journey-rc-2026-03-29-example-abc1234/05-battle-settlement.json",
+        "phase": "battle-settlement",
+        "roomId": "room-7d3f1",
+        "playerId": "player-account",
+        "connectionStatus": "connected",
+        "lastUpdateReason": "journey.battle.settlement",
+        "telemetryCheckpoints": [
+          "encounter.resolved",
+          "encounter.started"
+        ]
+      },
+      {
+        "id": "reconnect-restore",
+        "title": "Reconnect / restore",
+        "status": "passed",
+        "summary": "Reconnect canonical scenario preserved roomId and post-battle state.",
+        "artifactPath": "artifacts/release-readiness/cocos-primary-journey-rc-2026-03-29-example-abc1234/06-reconnect-restore.json",
+        "phase": "reconnect-restore",
+        "roomId": "room-7d3f1",
+        "playerId": "player-account",
+        "connectionStatus": "connected",
+        "lastUpdateReason": "journey.reconnect.restore",
+        "telemetryCheckpoints": [
+          "encounter.resolved",
+          "encounter.started"
+        ]
+      }
+    ]
   ]
 }

--- a/scripts/cocos-rc-evidence-bundle.ts
+++ b/scripts/cocos-rc-evidence-bundle.ts
@@ -47,6 +47,20 @@ interface JourneyStep {
   sourceRefs: string[];
 }
 
+interface CheckpointLedgerEntry {
+  id: string;
+  title: string;
+  status: EvidenceStatus;
+  summary: string;
+  artifactPath: string;
+  phase: string;
+  roomId: string;
+  playerId: string;
+  connectionStatus: string;
+  lastUpdateReason: string;
+  telemetryCheckpoints: string[];
+}
+
 interface CocosReleaseCandidateSnapshot {
   schemaVersion: 1;
   candidate: {
@@ -77,6 +91,12 @@ interface CocosReleaseCandidateSnapshot {
   };
   requiredEvidence: CanonicalEvidenceField[];
   journey: JourneyStep[];
+  checkpointLedger?: {
+    source: "primary-journey-evidence";
+    milestoneDir: string;
+    entryCount: number;
+    entries: CheckpointLedgerEntry[];
+  };
 }
 
 interface BundleManifest {
@@ -108,6 +128,18 @@ interface BundleManifest {
     status: EvidenceStatus;
     evidenceCount: number;
   }>;
+  checkpointLedger?: {
+    source: "primary-journey-evidence";
+    entryCount: number;
+    milestoneDir: string;
+    entries: Array<{
+      id: string;
+      title: string;
+      status: EvidenceStatus;
+      artifactPath: string;
+      telemetryCheckpointCount: number;
+    }>;
+  };
   requiredEvidence: Array<{
     id: string;
     label: string;
@@ -384,6 +416,18 @@ function renderBundleMarkdown(snapshot: CocosReleaseCandidateSnapshot, artifacts
     lines.push(`| ${step.title} | \`${step.status}\` | ${step.evidence.length} item(s) |`);
   }
   lines.push("");
+  if (snapshot.checkpointLedger?.entries.length) {
+    lines.push("## Checkpoint Ledger");
+    lines.push("");
+    lines.push("| Step | Phase | Telemetry checkpoints | Artifact |");
+    lines.push("| --- | --- | --- | --- |");
+    for (const entry of snapshot.checkpointLedger.entries) {
+      lines.push(
+        `| ${entry.title} | \`${entry.phase || "<none>"}\` | ${entry.telemetryCheckpoints.length > 0 ? `\`${entry.telemetryCheckpoints.join(", ")}\`` : "_none_"} | \`${entry.artifactPath}\` |`
+      );
+    }
+    lines.push("");
+  }
   lines.push("## Required Evidence");
   lines.push("");
   lines.push("| Field | Value | Evidence |");
@@ -469,6 +513,22 @@ function buildManifest(snapshot: CocosReleaseCandidateSnapshot, artifacts: Bundl
       status: step.status,
       evidenceCount: step.evidence.length
     })),
+    ...(snapshot.checkpointLedger
+      ? {
+          checkpointLedger: {
+            source: snapshot.checkpointLedger.source,
+            entryCount: snapshot.checkpointLedger.entryCount,
+            milestoneDir: snapshot.checkpointLedger.milestoneDir,
+            entries: snapshot.checkpointLedger.entries.map((entry) => ({
+              id: entry.id,
+              title: entry.title,
+              status: entry.status,
+              artifactPath: entry.artifactPath,
+              telemetryCheckpointCount: entry.telemetryCheckpoints.length
+            }))
+          }
+        }
+      : {}),
     requiredEvidence: snapshot.requiredEvidence.map((field) => ({
       id: field.id,
       label: field.label,

--- a/scripts/cocos-release-candidate-snapshot.ts
+++ b/scripts/cocos-release-candidate-snapshot.ts
@@ -49,6 +49,9 @@ interface PrimaryJourneyEvidenceArtifact {
   environment?: {
     server?: string;
   };
+  artifacts?: {
+    milestoneDir?: string;
+  };
   requiredEvidence?: Array<{
     id?: CanonicalEvidenceId;
     value?: string;
@@ -60,6 +63,23 @@ interface PrimaryJourneyEvidenceArtifact {
     summary?: string;
     evidence?: string[];
   }>;
+}
+
+interface PrimaryJourneyMilestoneArtifact {
+  phase?: string;
+  identity?: {
+    roomId?: string;
+    playerId?: string;
+  };
+  room?: {
+    diagnosticsConnectionStatus?: string;
+    lastUpdateReason?: string | null;
+  };
+  diagnostics?: {
+    primaryClientTelemetry?: Array<{
+      checkpoint?: string;
+    }>;
+  };
 }
 
 interface ReleaseReadinessSnapshotCheck {
@@ -122,6 +142,20 @@ interface EvidenceMapping {
   notes: string;
 }
 
+interface CheckpointLedgerEntry {
+  id: JourneyStepId;
+  title: string;
+  status: EvidenceStatus;
+  summary: string;
+  artifactPath: string;
+  phase: string;
+  roomId: string;
+  playerId: string;
+  connectionStatus: string;
+  lastUpdateReason: string;
+  telemetryCheckpoints: string[];
+}
+
 interface CocosReleaseCandidateSnapshot {
   schemaVersion: 1;
   candidate: {
@@ -153,6 +187,12 @@ interface CocosReleaseCandidateSnapshot {
   mappings: EvidenceMapping[];
   requiredEvidence: CanonicalEvidenceField[];
   journey: JourneyStep[];
+  checkpointLedger?: {
+    source: "primary-journey-evidence";
+    milestoneDir: string;
+    entryCount: number;
+    entries: CheckpointLedgerEntry[];
+  };
 }
 
 const DEFAULT_OUTPUT_DIR = path.join("artifacts", "release-evidence");
@@ -305,6 +345,17 @@ function getGitValue(args: string[]): string {
 
 function readJsonFile<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function resolveArtifactPath(baseDir: string, filePath: string): string {
+  if (path.isAbsolute(filePath)) {
+    return filePath;
+  }
+  const repoPath = path.resolve(process.cwd(), filePath);
+  if (fs.existsSync(repoPath)) {
+    return repoPath;
+  }
+  return path.resolve(baseDir, filePath);
 }
 
 function writeJsonFile(filePath: string, payload: unknown, force: boolean): void {
@@ -631,6 +682,64 @@ function appendUnique(target: string[], additions: string[]): string[] {
   return target;
 }
 
+function normalizeString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value.trim() : fallback;
+}
+
+function loadCheckpointLedgerEntry(
+  baseDir: string,
+  step: JourneyStep,
+  evidencePath: string
+): CheckpointLedgerEntry {
+  const resolvedPath = resolveArtifactPath(baseDir, evidencePath);
+  const artifact = readJsonFile<PrimaryJourneyMilestoneArtifact>(resolvedPath);
+  const telemetry = Array.isArray(artifact.diagnostics?.primaryClientTelemetry)
+    ? artifact.diagnostics.primaryClientTelemetry
+        .map((entry) => normalizeString(entry?.checkpoint))
+        .filter((entry) => entry.length > 0)
+    : [];
+
+  return {
+    id: step.id,
+    title: step.title,
+    status: step.status,
+    summary: step.notes,
+    artifactPath: evidencePath,
+    phase: normalizeString(artifact.phase, step.id),
+    roomId: normalizeString(artifact.identity?.roomId),
+    playerId: normalizeString(artifact.identity?.playerId),
+    connectionStatus: normalizeString(artifact.room?.diagnosticsConnectionStatus),
+    lastUpdateReason: normalizeString(artifact.room?.lastUpdateReason),
+    telemetryCheckpoints: [...new Set(telemetry)]
+  };
+}
+
+function buildCheckpointLedger(
+  baseDir: string,
+  milestoneDir: string | undefined,
+  journey: JourneyStep[]
+): CocosReleaseCandidateSnapshot["checkpointLedger"] {
+  const entries: CheckpointLedgerEntry[] = [];
+  for (const step of journey) {
+    const artifactPath = step.evidence.find((entry) => entry.endsWith(".json"));
+    if (!artifactPath) {
+      continue;
+    }
+    entries.push(loadCheckpointLedgerEntry(baseDir, step, artifactPath));
+  }
+
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return {
+    source: "primary-journey-evidence",
+    milestoneDir: milestoneDir ?? "",
+    entryCount: entries.length,
+    entries
+  };
+}
+
 function resolveMergedStatus(current: EvidenceStatus, incoming: EvidenceStatus): EvidenceStatus {
   const rank: Record<EvidenceStatus, number> = {
     failed: 5,
@@ -726,6 +835,12 @@ function applyPrimaryJourneyEvidence(snapshot: CocosReleaseCandidateSnapshot, ar
   if (artifact.execution?.summary?.trim()) {
     snapshot.execution.summary = artifact.execution.summary.trim();
   }
+
+  snapshot.checkpointLedger = buildCheckpointLedger(
+    path.dirname(snapshot.linkedEvidence.primaryJourneyEvidence?.path ?? process.cwd()),
+    artifact.artifacts?.milestoneDir,
+    snapshot.journey
+  );
 }
 
 function applyWechatSmokeReport(snapshot: CocosReleaseCandidateSnapshot, report: WechatSmokeReport): void {
@@ -877,6 +992,35 @@ function validateSnapshot(snapshot: CocosReleaseCandidateSnapshot): void {
   for (const requiredId of REQUIRED_EVIDENCE_IDS) {
     if (!evidenceById.has(requiredId)) {
       fail(`Missing required evidence field: ${requiredId}`);
+    }
+  }
+
+  if (snapshot.checkpointLedger) {
+    if (snapshot.checkpointLedger.source !== "primary-journey-evidence") {
+      fail(`checkpointLedger.source has unsupported value: ${snapshot.checkpointLedger.source}`);
+    }
+    if (snapshot.checkpointLedger.entryCount !== snapshot.checkpointLedger.entries.length) {
+      fail("checkpointLedger.entryCount must match checkpointLedger.entries.length.");
+    }
+
+    const ledgerById = new Map<JourneyStepId, CheckpointLedgerEntry>();
+    for (const entry of snapshot.checkpointLedger.entries) {
+      if (ledgerById.has(entry.id)) {
+        fail(`Duplicate checkpoint ledger entry: ${entry.id}`);
+      }
+      assertNonEmptyString(entry.title, `checkpointLedger.entries[${entry.id}].title`);
+      assertEvidenceStatus(entry.status, `checkpointLedger.entries[${entry.id}].status`);
+      assertNonEmptyString(entry.artifactPath, `checkpointLedger.entries[${entry.id}].artifactPath`);
+      assertStringArray(entry.telemetryCheckpoints, `checkpointLedger.entries[${entry.id}].telemetryCheckpoints`);
+      ledgerById.set(entry.id, entry);
+    }
+
+    if (snapshot.linkedEvidence.primaryJourneyEvidence) {
+      for (const requiredId of REQUIRED_JOURNEY_STEP_IDS) {
+        if (!ledgerById.has(requiredId)) {
+          fail(`Missing checkpoint ledger entry: ${requiredId}`);
+        }
+      }
     }
   }
 

--- a/scripts/test/cocos-rc-evidence-bundle.test.ts
+++ b/scripts/test/cocos-rc-evidence-bundle.test.ts
@@ -110,6 +110,10 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
       blockersMarkdown: string;
     };
     journey: Array<{ id: string; status: string }>;
+    checkpointLedger?: {
+      entryCount: number;
+      entries: Array<{ id: string; artifactPath: string; telemetryCheckpointCount: number }>;
+    };
     requiredEvidence: Array<{ id: string; filled: boolean }>;
   };
   assert.equal(manifest.bundle.candidate, "rc-issue-507");
@@ -118,6 +122,9 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.equal(path.basename(manifest.artifacts.primaryJourneyEvidence), primaryJourneyFile);
   assert.equal(path.basename(manifest.artifacts.primaryJourneyEvidenceMarkdown), primaryJourneyMarkdownFile);
   assert.equal(manifest.journey.find((entry) => entry.id === "lobby-entry")?.status, "passed");
+  assert.equal(manifest.checkpointLedger?.entryCount, 7);
+  assert.ok((manifest.checkpointLedger?.entries.find((entry) => entry.id === "battle-settlement")?.telemetryCheckpointCount ?? -1) >= 0);
+  assert.match(manifest.checkpointLedger?.entries.find((entry) => entry.id === "battle-settlement")?.artifactPath ?? "", /05-battle-settlement\.json$/);
   assert.equal(manifest.requiredEvidence.find((entry) => entry.id === "roomId")?.filled, true);
   assert.equal(path.basename(manifest.artifacts.snapshot), snapshotFile);
   assert.equal(path.basename(manifest.artifacts.summaryMarkdown), summaryFile);
@@ -129,6 +136,8 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.match(summaryMarkdown, /Overall status: `passed`/);
   assert.match(summaryMarkdown, /Primary journey evidence:/);
   assert.match(summaryMarkdown, /Lobby entry \| `passed` \| 2 item\(s\)/);
+  assert.match(summaryMarkdown, /## Checkpoint Ledger/);
+  assert.match(summaryMarkdown, /Battle settlement/);
 
   const checklistMarkdown = fs.readFileSync(path.join(outputDir, checklistFile!), "utf8");
   assert.match(checklistMarkdown, /Candidate: `rc-issue-507`/);

--- a/scripts/test/cocos-release-candidate-snapshot.test.ts
+++ b/scripts/test/cocos-release-candidate-snapshot.test.ts
@@ -12,6 +12,47 @@ function writeJson(filePath: string, payload: unknown): void {
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
+function writeJourneyMilestones(workspace: string): Record<string, string> {
+  const milestoneDir = path.join(workspace, "milestones");
+  const files: Record<string, string> = {
+    "lobby-entry": path.join(milestoneDir, "01-lobby-entry.json"),
+    "room-join": path.join(milestoneDir, "02-room-join.json"),
+    "map-explore": path.join(milestoneDir, "03-map-explore.json"),
+    "first-battle": path.join(milestoneDir, "04-first-battle.json"),
+    "battle-settlement": path.join(milestoneDir, "05-battle-settlement.json"),
+    "reconnect-restore": path.join(milestoneDir, "06-reconnect-restore.json"),
+    "return-to-world": path.join(milestoneDir, "07-return-to-world.json")
+  };
+
+  for (const [stepId, filePath] of Object.entries(files)) {
+    writeJson(filePath, {
+      phase: stepId,
+      identity: {
+        roomId: "room-primary-journey",
+        playerId: "player-account"
+      },
+      room: {
+        diagnosticsConnectionStatus: stepId === "reconnect-restore" ? "reconnecting" : "connected",
+        lastUpdateReason: `journey.${stepId}`
+      },
+      diagnostics: {
+        primaryClientTelemetry:
+          stepId === "battle-settlement"
+            ? [
+                { checkpoint: "encounter.started" },
+                { checkpoint: "hero.progressed" },
+                { checkpoint: "encounter.resolved" }
+              ]
+            : stepId === "first-battle"
+              ? [{ checkpoint: "encounter.started" }]
+              : []
+      }
+    });
+  }
+
+  return files;
+}
+
 test("release:cocos-rc:snapshot imports WeChat smoke evidence into linked journey fields", () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-cocos-rc-snapshot-"));
   const smokeReportPath = path.join(workspace, "codex.wechat.smoke-report.json");
@@ -102,6 +143,7 @@ test("release:cocos-rc:snapshot imports primary journey evidence into the canoni
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-cocos-primary-journey-snapshot-"));
   const primaryJourneyPath = path.join(workspace, "cocos-primary-journey.json");
   const outputPath = path.join(workspace, "rc.snapshot.json");
+  const milestoneFiles = writeJourneyMilestones(workspace);
 
   writeJson(primaryJourneyPath, {
     candidate: {
@@ -116,36 +158,39 @@ test("release:cocos-rc:snapshot imports primary journey evidence into the canoni
     environment: {
       server: "ws://127.0.0.1:2567"
     },
+    artifacts: {
+      milestoneDir: path.join(workspace, "milestones")
+    },
     requiredEvidence: [
       {
         id: "roomId",
         value: "room-primary-journey",
-        evidence: ["artifacts/release-readiness/02-room-join.json"]
+        evidence: [milestoneFiles["room-join"]]
       },
       {
         id: "reconnectPrompt",
         value: "连接已恢复",
-        evidence: ["artifacts/release-readiness/06-reconnect-restore.json"]
+        evidence: [milestoneFiles["reconnect-restore"]]
       },
       {
         id: "restoredState",
         value: "Restored room-primary-journey on day 5 with preserved world state.",
-        evidence: ["artifacts/release-readiness/06-reconnect-restore.json"]
+        evidence: [milestoneFiles["reconnect-restore"]]
       },
       {
         id: "firstBattleResult",
         value: "attacker_victory; gold +12; experience +25",
-        evidence: ["artifacts/release-readiness/05-battle-settlement.json"]
+        evidence: [milestoneFiles["battle-settlement"]]
       }
     ],
     journey: [
-      { id: "lobby-entry", status: "passed", summary: "Lobby ok", evidence: ["01-lobby-entry.json"] },
-      { id: "room-join", status: "passed", summary: "Room ok", evidence: ["02-room-join.json"] },
-      { id: "map-explore", status: "passed", summary: "Explore ok", evidence: ["03-map-explore.json"] },
-      { id: "first-battle", status: "passed", summary: "Battle ok", evidence: ["04-first-battle.json"] },
-      { id: "battle-settlement", status: "passed", summary: "Settlement ok", evidence: ["05-battle-settlement.json"] },
-      { id: "reconnect-restore", status: "passed", summary: "Reconnect ok", evidence: ["06-reconnect-restore.json"] },
-      { id: "return-to-world", status: "passed", summary: "Return ok", evidence: ["07-return-to-world.json"] }
+      { id: "lobby-entry", status: "passed", summary: "Lobby ok", evidence: [milestoneFiles["lobby-entry"]] },
+      { id: "room-join", status: "passed", summary: "Room ok", evidence: [milestoneFiles["room-join"]] },
+      { id: "map-explore", status: "passed", summary: "Explore ok", evidence: [milestoneFiles["map-explore"]] },
+      { id: "first-battle", status: "passed", summary: "Battle ok", evidence: [milestoneFiles["first-battle"]] },
+      { id: "battle-settlement", status: "passed", summary: "Settlement ok", evidence: [milestoneFiles["battle-settlement"]] },
+      { id: "reconnect-restore", status: "passed", summary: "Reconnect ok", evidence: [milestoneFiles["reconnect-restore"]] },
+      { id: "return-to-world", status: "passed", summary: "Return ok", evidence: [milestoneFiles["return-to-world"]] }
     ]
   });
 
@@ -172,6 +217,10 @@ test("release:cocos-rc:snapshot imports primary journey evidence into the canoni
     execution: { owner: string; executedAt: string; overallStatus: string; summary: string };
     environment: { server: string };
     linkedEvidence: { primaryJourneyEvidence?: { path: string } };
+    checkpointLedger?: {
+      entryCount: number;
+      entries: Array<{ id: string; artifactPath: string; telemetryCheckpoints: string[]; roomId: string }>;
+    };
     requiredEvidence: Array<{ id: string; value: string }>;
     journey: Array<{ id: string; status: string; notes: string }>;
   };
@@ -184,4 +233,12 @@ test("release:cocos-rc:snapshot imports primary journey evidence into the canoni
   assert.equal(snapshot.requiredEvidence.find((entry) => entry.id === "firstBattleResult")?.value, "attacker_victory; gold +12; experience +25");
   assert.equal(snapshot.journey.find((entry) => entry.id === "battle-settlement")?.status, "passed");
   assert.match(snapshot.journey.find((entry) => entry.id === "reconnect-restore")?.notes ?? "", /Reconnect ok/);
+  assert.equal(snapshot.checkpointLedger?.entryCount, 7);
+  assert.equal(snapshot.checkpointLedger?.entries.find((entry) => entry.id === "battle-settlement")?.artifactPath, milestoneFiles["battle-settlement"]);
+  assert.deepEqual(snapshot.checkpointLedger?.entries.find((entry) => entry.id === "battle-settlement")?.telemetryCheckpoints, [
+    "encounter.started",
+    "hero.progressed",
+    "encounter.resolved"
+  ]);
+  assert.equal(snapshot.checkpointLedger?.entries.find((entry) => entry.id === "room-join")?.roomId, "room-primary-journey");
 });


### PR DESCRIPTION
## Summary
- add a checkpoint ledger to the canonical Cocos RC snapshot derived from primary-journey milestone artifacts
- surface the ledger in the RC bundle manifest and markdown summary for reviewer-facing evidence
- extend the focused RC snapshot and bundle tests to cover milestone-backed ledger imports

Closes #569