### PR TITLE
feat(cocos): formalize account-readiness state for primary client release path

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -29,7 +29,11 @@ import {
   type LobbyShowcasePhase
 } from "./cocos-showcase-gallery.ts";
 import type { CocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
-import type { CocosAccountLifecycleFieldView, CocosAccountLifecyclePanelView } from "./cocos-account-lifecycle.ts";
+import type {
+  CocosAccountLifecycleFieldView,
+  CocosAccountLifecyclePanelView,
+  CocosAccountReadinessStatus
+} from "./cocos-account-lifecycle.ts";
 import {
   createBattleReplayPlaybackState,
   findPlayerBattleReplaySummary,
@@ -74,6 +78,16 @@ const REVIEW_HIGHLIGHT_STROKE = new Color(234, 246, 255, 120);
 const REVIEW_HIGHLIGHT_ACCENT = new Color(146, 198, 246, 214);
 const REPLAY_CONTROL_FILL = new Color(64, 92, 128, 220);
 const REPLAY_CONTROL_ACTIVE_FILL = new Color(84, 122, 94, 220);
+
+function formatAccountReadinessStatus(status: CocosAccountReadinessStatus): string {
+  if (status === "ready") {
+    return "READY";
+  }
+  if (status === "blocked") {
+    return "BLOCKED";
+  }
+  return "MISSING";
+}
 
 export interface VeilLobbyRenderState {
   playerId: string;
@@ -1264,8 +1278,13 @@ export class VeilLobbyPanel extends Component {
       centerX,
       topY,
       width,
-      96,
-      [flow.title, flow.intro, flow.deliveryHint],
+      118,
+      [
+        flow.title,
+        flow.intro,
+        `就绪状态 ${formatAccountReadinessStatus(flow.readiness.status)} · ${flow.readiness.summary}`,
+        `${flow.readiness.detail} ${flow.deliveryHint}`.trim()
+      ],
       {
         fill: TITLE_FILL,
         stroke: new Color(236, 228, 198, 62),
@@ -1282,8 +1301,12 @@ export class VeilLobbyPanel extends Component {
         centerX,
         cursorY,
         width,
-        62,
-        [field.label, field.value || field.placeholder, field.hint],
+        70,
+        [
+          field.label,
+          `${field.value || field.placeholder} · ${formatAccountReadinessStatus(field.readiness.status)}`,
+          `${field.readiness.summary}；${field.hint}`
+        ],
         {
           fill: FIELD_FILL,
           stroke: new Color(224, 235, 246, 52),

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -65,6 +65,7 @@ import { VeilLobbyPanel } from "./VeilLobbyPanel.ts";
 import {
   buildCocosAccountLifecyclePanelView,
   type CocosAccountLifecycleDeliveryMode,
+  type CocosAccountLifecycleDraft,
   type CocosAccountLifecycleKind
 } from "./cocos-account-lifecycle.ts";
 import { VeilMapBoard } from "./VeilMapBoard.ts";
@@ -2313,31 +2314,38 @@ export class VeilRoot extends Component {
   }
 
   private buildActiveAccountFlowPanelView() {
+    const draft = this.buildActiveAccountLifecycleDraft();
+    if (!draft) {
+      return null;
+    }
+
+    return buildCocosAccountLifecyclePanelView(draft);
+  }
+
+  private buildActiveAccountLifecycleDraft(): CocosAccountLifecycleDraft | null {
     if (!this.activeAccountFlow) {
       return null;
     }
 
-    return buildCocosAccountLifecyclePanelView(
-      this.activeAccountFlow === "registration"
-        ? {
-            kind: "registration",
-            loginId: this.loginId,
-            displayName: this.registrationDisplayName || this.displayName || this.loginId,
-            token: this.registrationToken,
-            password: this.registrationPassword,
-            deliveryMode: this.registrationDeliveryMode,
-            ...(this.registrationExpiresAt ? { expiresAt: this.registrationExpiresAt } : {})
-          }
-        : {
-            kind: "recovery",
-            loginId: this.loginId,
-            displayName: "",
-            token: this.recoveryToken,
-            password: this.recoveryPassword,
-            deliveryMode: this.recoveryDeliveryMode,
-            ...(this.recoveryExpiresAt ? { expiresAt: this.recoveryExpiresAt } : {})
-          }
-    );
+    return this.activeAccountFlow === "registration"
+      ? {
+          kind: "registration",
+          loginId: this.loginId,
+          displayName: this.registrationDisplayName || this.displayName || this.loginId,
+          token: this.registrationToken,
+          password: this.registrationPassword,
+          deliveryMode: this.registrationDeliveryMode,
+          ...(this.registrationExpiresAt ? { expiresAt: this.registrationExpiresAt } : {})
+        }
+      : {
+          kind: "recovery",
+          loginId: this.loginId,
+          displayName: "",
+          token: this.recoveryToken,
+          password: this.recoveryPassword,
+          deliveryMode: this.recoveryDeliveryMode,
+          ...(this.recoveryExpiresAt ? { expiresAt: this.recoveryExpiresAt } : {})
+        };
   }
 
   private openLobbyAccountFlow(kind: CocosAccountLifecycleKind): void {

--- a/apps/cocos-client/assets/scripts/cocos-account-lifecycle.ts
+++ b/apps/cocos-client/assets/scripts/cocos-account-lifecycle.ts
@@ -1,5 +1,6 @@
 export type CocosAccountLifecycleKind = "registration" | "recovery";
 export type CocosAccountLifecycleDeliveryMode = "idle" | "dev-token" | "external";
+export type CocosAccountReadinessStatus = "ready" | "missing" | "blocked";
 
 export interface CocosAccountLifecycleDraft {
   kind: CocosAccountLifecycleKind;
@@ -11,64 +12,215 @@ export interface CocosAccountLifecycleDraft {
   expiresAt?: string;
 }
 
+export interface CocosAccountLifecycleFieldReadiness {
+  status: CocosAccountReadinessStatus;
+  summary: string;
+}
+
 export interface CocosAccountLifecycleFieldView {
   key: "loginId" | "displayName" | "token" | "password";
   label: string;
   value: string;
   placeholder: string;
   hint: string;
+  readiness: CocosAccountLifecycleFieldReadiness;
+}
+
+export interface CocosAccountLifecycleReadinessView {
+  status: CocosAccountReadinessStatus;
+  summary: string;
+  detail: string;
 }
 
 export interface CocosAccountLifecyclePanelView {
   title: string;
   intro: string;
+  readiness: CocosAccountLifecycleReadinessView;
   fields: CocosAccountLifecycleFieldView[];
   deliveryHint: string;
   requestLabel: string;
   confirmLabel: string;
 }
 
+function normalizeValue(value: string): string {
+  return value.trim();
+}
+
 function formatExpiry(expiresAt?: string): string {
   return expiresAt ? `，过期时间：${expiresAt}` : "";
+}
+
+function resolvePasswordReadiness(password: string): CocosAccountLifecycleFieldReadiness {
+  const normalizedPassword = normalizeValue(password);
+  if (!normalizedPassword) {
+    return {
+      status: "missing",
+      summary: "缺少口令"
+    };
+  }
+
+  if (normalizedPassword.length < 6) {
+    return {
+      status: "missing",
+      summary: "口令至少 6 位"
+    };
+  }
+
+  return {
+    status: "ready",
+    summary: "口令已填写"
+  };
+}
+
+function resolveTokenReadiness(
+  draft: CocosAccountLifecycleDraft
+): CocosAccountLifecycleFieldReadiness {
+  if (normalizeValue(draft.token)) {
+    return {
+      status: "ready",
+      summary: "令牌已填写"
+    };
+  }
+
+  if (draft.deliveryMode === "external") {
+    return {
+      status: "blocked",
+      summary: "等待外部投递令牌"
+    };
+  }
+
+  return {
+    status: "missing",
+    summary: draft.kind === "registration" ? "尚未申请注册令牌" : "尚未申请找回令牌"
+  };
+}
+
+function buildLifecycleFieldViews(
+  draft: CocosAccountLifecycleDraft
+): CocosAccountLifecycleFieldView[] {
+  const loginIdReady = normalizeValue(draft.loginId).length > 0;
+
+  if (draft.kind === "registration") {
+    return [
+      {
+        key: "loginId",
+        label: "登录 ID",
+        value: draft.loginId,
+        placeholder: "点击填写",
+        hint: "会自动转成小写，用于后续正式账号登录。",
+        readiness: loginIdReady
+          ? { status: "ready", summary: "登录 ID 已填写" }
+          : { status: "missing", summary: "缺少登录 ID" }
+      },
+      {
+        key: "displayName",
+        label: "注册昵称",
+        value: draft.displayName,
+        placeholder: "点击填写",
+        hint: "留空时服务端会回退到登录 ID。",
+        readiness: normalizeValue(draft.displayName)
+          ? { status: "ready", summary: "注册昵称已填写" }
+          : { status: "ready", summary: "留空时回退到登录 ID" }
+      },
+      {
+        key: "token",
+        label: "注册令牌",
+        value: draft.token,
+        placeholder: "申请后填写",
+        hint: "开发环境会直返令牌；正式投递模式需从外部渠道填写。",
+        readiness: resolveTokenReadiness(draft)
+      },
+      {
+        key: "password",
+        label: "注册口令",
+        value: draft.password ? "********" : "",
+        placeholder: "点击填写",
+        hint: "至少 6 位，确认后会直接进入当前房间。",
+        readiness: resolvePasswordReadiness(draft.password)
+      }
+    ];
+  }
+
+  return [
+    {
+      key: "loginId",
+      label: "登录 ID",
+      value: draft.loginId,
+      placeholder: "点击填写",
+      hint: "填写要找回的正式账号登录 ID。",
+      readiness: loginIdReady
+        ? { status: "ready", summary: "登录 ID 已填写" }
+        : { status: "missing", summary: "缺少登录 ID" }
+    },
+    {
+      key: "token",
+      label: "找回令牌",
+      value: draft.token,
+      placeholder: "申请后填写",
+      hint: "开发环境会直返令牌；正式投递模式需从外部渠道填写。",
+      readiness: resolveTokenReadiness(draft)
+    },
+    {
+      key: "password",
+      label: "新口令",
+      value: draft.password ? "********" : "",
+      placeholder: "点击填写",
+      hint: "确认后会立即用新口令重新登录。",
+      readiness: resolvePasswordReadiness(draft.password)
+    }
+  ];
+}
+
+export function buildCocosAccountLifecycleReadinessView(
+  draft: CocosAccountLifecycleDraft
+): CocosAccountLifecycleReadinessView {
+  const fields = buildLifecycleFieldViews(draft);
+  const missingFields = fields.filter((field) => field.readiness.status === "missing");
+  const blockedFields = fields.filter((field) => field.readiness.status === "blocked");
+  const status: CocosAccountReadinessStatus =
+    missingFields.length > 0 ? "missing" : blockedFields.length > 0 ? "blocked" : "ready";
+
+  if (status === "ready") {
+    return {
+      status,
+      summary: "账号链路已就绪",
+      detail:
+        draft.kind === "registration"
+          ? "注册确认所需字段已齐备，可直接确认注册并进入房间。"
+          : "口令重置所需字段已齐备，可直接确认重置并重新登录。"
+    };
+  }
+
+  if (status === "blocked") {
+    return {
+      status,
+      summary: "账号链路被外部令牌阻塞",
+      detail:
+        draft.kind === "registration"
+          ? "注册草稿已齐备，但仍需等待外部渠道投递注册令牌。"
+          : "找回草稿已齐备，但仍需等待外部渠道投递找回令牌。"
+    };
+  }
+
+  return {
+    status,
+    summary: "账号链路仍缺少关键字段",
+    detail: `待补字段：${missingFields.map((field) => field.label).join("、")}。`
+  };
 }
 
 export function buildCocosAccountLifecyclePanelView(
   draft: CocosAccountLifecycleDraft
 ): CocosAccountLifecyclePanelView {
+  const fields = buildLifecycleFieldViews(draft);
+  const readiness = buildCocosAccountLifecycleReadinessView(draft);
+
   if (draft.kind === "registration") {
     return {
       title: "正式注册流程",
       intro: "先申请注册令牌，再确认口令并升级为正式账号会话。",
-      fields: [
-        {
-          key: "loginId",
-          label: "登录 ID",
-          value: draft.loginId,
-          placeholder: "点击填写",
-          hint: "会自动转成小写，用于后续正式账号登录。"
-        },
-        {
-          key: "displayName",
-          label: "注册昵称",
-          value: draft.displayName,
-          placeholder: "点击填写",
-          hint: "留空时服务端会回退到登录 ID。"
-        },
-        {
-          key: "token",
-          label: "注册令牌",
-          value: draft.token,
-          placeholder: "申请后填写",
-          hint: "开发环境会直返令牌；正式投递模式需从外部渠道填写。"
-        },
-        {
-          key: "password",
-          label: "注册口令",
-          value: draft.password ? "********" : "",
-          placeholder: "点击填写",
-          hint: "至少 6 位，确认后会直接进入当前房间。"
-        }
-      ],
+      readiness,
+      fields,
       deliveryHint:
         draft.deliveryMode === "dev-token"
           ? `当前为开发直返令牌模式，可直接确认注册${formatExpiry(draft.expiresAt)}。`
@@ -83,29 +235,8 @@ export function buildCocosAccountLifecyclePanelView(
   return {
     title: "密码找回流程",
     intro: "先申请找回令牌，再确认新口令并重新登录当前房间。",
-    fields: [
-      {
-        key: "loginId",
-        label: "登录 ID",
-        value: draft.loginId,
-        placeholder: "点击填写",
-        hint: "填写要找回的正式账号登录 ID。"
-      },
-      {
-        key: "token",
-        label: "找回令牌",
-        value: draft.token,
-        placeholder: "申请后填写",
-        hint: "开发环境会直返令牌；正式投递模式需从外部渠道填写。"
-      },
-      {
-        key: "password",
-        label: "新口令",
-        value: draft.password ? "********" : "",
-        placeholder: "点击填写",
-        hint: "确认后会立即用新口令重新登录。"
-      }
-    ],
+    readiness,
+    fields,
     deliveryHint:
       draft.deliveryMode === "dev-token"
         ? `当前为开发直返令牌模式，可直接确认重置${formatExpiry(draft.expiresAt)}。`

--- a/apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts
+++ b/apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts
@@ -1,4 +1,8 @@
 import {
+  buildCocosAccountLifecycleReadinessView,
+  type CocosAccountLifecycleDraft
+} from "./cocos-account-lifecycle.ts";
+import {
   type PrimaryClientTelemetryEvent,
   buildRuntimeDiagnosticsTriageView,
   type RuntimeDiagnosticsConnectionStatus,
@@ -21,6 +25,8 @@ export interface CocosRuntimeDiagnosticsSnapshotInput {
   mode: RuntimeDiagnosticsMode;
   roomId: string;
   playerId: string;
+  authMode?: "guest" | "account";
+  loginId?: string | null;
   connectionStatus: RuntimeDiagnosticsConnectionStatus;
   lastUpdateSource: string | null;
   lastUpdateReason: string | null;
@@ -32,6 +38,36 @@ export interface CocosRuntimeDiagnosticsSnapshotInput {
   predictionStatus: string;
   recoverySummary: string | null;
   primaryClientTelemetry: PrimaryClientTelemetryEvent[];
+  accountLifecycleDraft?: CocosAccountLifecycleDraft | null;
+}
+
+function buildAccountReadinessSnapshot(input: CocosRuntimeDiagnosticsSnapshotInput) {
+  if (input.accountLifecycleDraft) {
+    const readiness = buildCocosAccountLifecycleReadinessView(input.accountLifecycleDraft);
+    return {
+      status: readiness.status,
+      summary: readiness.summary,
+      detail: readiness.detail,
+      source: input.accountLifecycleDraft.kind
+    } as const;
+  }
+
+  const loginId = input.loginId?.trim() || input.account.loginId?.trim() || "";
+  if ((input.authMode === "account" || input.account.source === "remote") && loginId) {
+    return {
+      status: "ready" as const,
+      summary: "正式账号会话已绑定",
+      detail: "当前主客户端已具备正式账号登录态，可用于 RC 登录链路验收。",
+      source: "session" as const
+    };
+  }
+
+  return {
+    status: "missing" as const,
+    summary: "仍在游客或本地账号态",
+    detail: "当前快照缺少正式账号登录态，无法证明主客户端正式账号链路已就绪。",
+    source: "session" as const
+  };
 }
 
 function buildTimelineTail(entries: string[]): CocosTimelineEntrySnapshot[] {
@@ -114,7 +150,8 @@ export function buildCocosRuntimeDiagnosticsSnapshot(
       source: input.account.source,
       loginId: input.account.loginId ?? null,
       recentEventCount: input.account.recentEventLog.length,
-      recentReplayCount: input.account.recentBattleReplays.length
+      recentReplayCount: input.account.recentBattleReplays.length,
+      accountReadiness: buildAccountReadinessSnapshot(input)
     },
     overview: null,
     diagnostics: {

--- a/apps/cocos-client/test/cocos-account-lifecycle.test.ts
+++ b/apps/cocos-client/test/cocos-account-lifecycle.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildCocosAccountLifecyclePanelView } from "../assets/scripts/cocos-account-lifecycle.ts";
+import {
+  buildCocosAccountLifecyclePanelView,
+  buildCocosAccountLifecycleReadinessView
+} from "../assets/scripts/cocos-account-lifecycle.ts";
 
 test("buildCocosAccountLifecyclePanelView exposes registration dev-token guidance", () => {
   const view = buildCocosAccountLifecyclePanelView({
@@ -18,6 +21,8 @@ test("buildCocosAccountLifecyclePanelView exposes registration dev-token guidanc
   assert.match(view.deliveryHint, /开发直返令牌模式/);
   assert.match(view.deliveryHint, /2026-03-29T05:51:00.000Z/);
   assert.equal(view.confirmLabel, "确认注册并进房");
+  assert.equal(view.readiness.status, "ready");
+  assert.equal(view.fields[2]?.readiness.status, "ready");
 });
 
 test("buildCocosAccountLifecyclePanelView exposes recovery external-delivery guidance", () => {
@@ -39,4 +44,36 @@ test("buildCocosAccountLifecyclePanelView exposes recovery external-delivery gui
   assert.match(view.deliveryHint, /外部投递模式/);
   assert.match(view.deliveryHint, /2026-03-29T06:00:00.000Z/);
   assert.equal(view.requestLabel, "申请找回令牌");
+  assert.equal(view.readiness.status, "missing");
+  assert.equal(view.fields[1]?.readiness.status, "blocked");
+});
+
+test("buildCocosAccountLifecycleReadinessView reports missing critical registration fields", () => {
+  const readiness = buildCocosAccountLifecycleReadinessView({
+    kind: "registration",
+    loginId: "",
+    displayName: "",
+    token: "",
+    password: "",
+    deliveryMode: "idle"
+  });
+
+  assert.equal(readiness.status, "missing");
+  assert.match(readiness.detail, /登录 ID/);
+  assert.match(readiness.detail, /注册口令/);
+});
+
+test("buildCocosAccountLifecycleReadinessView reports blocked external token delivery once local fields are complete", () => {
+  const readiness = buildCocosAccountLifecycleReadinessView({
+    kind: "recovery",
+    loginId: "veil-ranger",
+    displayName: "",
+    token: "",
+    password: "hunter2",
+    deliveryMode: "external",
+    expiresAt: "2026-03-29T06:00:00.000Z"
+  });
+
+  assert.equal(readiness.status, "blocked");
+  assert.match(readiness.detail, /等待外部渠道投递找回令牌/);
 });

--- a/apps/cocos-client/test/cocos-primary-client-journey.test.ts
+++ b/apps/cocos-client/test/cocos-primary-client-journey.test.ts
@@ -282,6 +282,8 @@ function captureJourneyArtifact(options: {
       mode: update?.battle ? "battle" : "world",
       roomId: root.roomId,
       playerId: root.playerId,
+      authMode: root.authMode,
+      loginId: root.loginId,
       connectionStatus: root.diagnosticsConnectionStatus,
       lastUpdateSource: root.lastRoomUpdateSource,
       lastUpdateReason: root.lastRoomUpdateReason,

--- a/apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
+++ b/apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
@@ -22,6 +22,8 @@ test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage",
     mode: "world",
     roomId: "room-alpha",
     playerId: "player-1",
+    authMode: "guest",
+    loginId: null,
     connectionStatus: "reconnecting",
     lastUpdateSource: "replay",
     lastUpdateReason: "cached_snapshot",
@@ -53,6 +55,8 @@ test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage",
   assert.equal(snapshot.world?.hero?.id, "hero-1");
   assert.equal(snapshot.world?.visibleHeroes[0]?.playerId, "player-2");
   assert.equal(snapshot.diagnostics.recoverySummary, "已回放缓存状态，等待房间同步...");
+  assert.equal(snapshot.account?.accountReadiness?.status, "missing");
+  assert.match(snapshot.account?.accountReadiness?.detail ?? "", /缺少正式账号登录态/);
 
   const lines = buildCocosRuntimeTriageSummaryLines(
     {
@@ -60,6 +64,8 @@ test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage",
       mode: "world",
       roomId: "room-alpha",
       playerId: "player-1",
+      authMode: "guest",
+      loginId: null,
       connectionStatus: "reconnecting",
       lastUpdateSource: "replay",
       lastUpdateReason: "cached_snapshot",

--- a/packages/shared/src/runtime-diagnostics.ts
+++ b/packages/shared/src/runtime-diagnostics.ts
@@ -83,6 +83,12 @@ export interface RuntimeDiagnosticsAccountSnapshot {
   loginId: string | null;
   recentEventCount: number;
   recentReplayCount: number;
+  accountReadiness?: {
+    status: "ready" | "missing" | "blocked";
+    summary: string;
+    detail: string | null;
+    source: "session" | "registration" | "recovery";
+  };
 }
 
 export interface RuntimeDiagnosticsOverviewRoomSnapshot {
@@ -358,6 +364,12 @@ export function buildRuntimeDiagnosticsTriageView(
         {
           label: "最近回放数",
           value: snapshot.account ? `${snapshot.account.recentReplayCount}` : "0"
+        },
+        {
+          label: "账号就绪",
+          value: snapshot.account?.accountReadiness
+            ? `${snapshot.account.accountReadiness.status} · ${snapshot.account.accountReadiness.summary}`
+            : "未建模"
         }
       ]
     },
@@ -509,6 +521,13 @@ export function buildRuntimeDiagnosticsSummaryLines(snapshot: RuntimeDiagnostics
     lines.push(
       `Account ${snapshot.account.displayName} (${snapshot.account.source}) / events ${snapshot.account.recentEventCount} / replays ${snapshot.account.recentReplayCount}`
     );
+    if (snapshot.account.accountReadiness) {
+      lines.push(
+        `Account readiness ${snapshot.account.accountReadiness.status} / ${snapshot.account.accountReadiness.summary}${
+          snapshot.account.accountReadiness.detail ? ` / ${snapshot.account.accountReadiness.detail}` : ""
+        }`
+      );
+    }
   }
 
   if (snapshot.overview?.gameplayTraffic) {

--- a/packages/shared/test/runtime-diagnostics.test.ts
+++ b/packages/shared/test/runtime-diagnostics.test.ts
@@ -74,7 +74,13 @@ function createRuntimeDiagnosticsSnapshot(): RuntimeDiagnosticsSnapshot {
       source: "remote",
       loginId: "player-1@example.com",
       recentEventCount: 3,
-      recentReplayCount: 1
+      recentReplayCount: 1,
+      accountReadiness: {
+        status: "ready",
+        summary: "正式账号会话已绑定",
+        detail: "当前主客户端已具备正式账号登录态，可用于 RC 登录链路验收。",
+        source: "session"
+      }
     },
     overview: null,
     diagnostics: {
@@ -131,6 +137,7 @@ test("runtime diagnostics summary text stays stable for panel and automation con
   assert.match(rendered, /World 4x3 \/ visible 7 \/ reachable 4/);
   assert.match(rendered, /Hero 凯琳 @ 0,0 \/ MOV 4\/6 \/ HP 30\/30/);
   assert.match(rendered, /Account 暮火侦骑 \(remote\) \/ events 3 \/ replays 1/);
+  assert.match(rendered, /Account readiness ready \/ 正式账号会话已绑定/);
   assert.match(rendered, /Recovery 连接已恢复，当前地图与战斗状态来自最新权威快照。/);
   assert.match(rendered, /Telemetry combat\/encounter\.resolved \(success\) Battle battle-1 resolved as attacker_victory\./);
   assert.match(rendered, /Replay room-alpha:battle-1:player-1 \/ paused \/ step 1\/3/);

--- a/scripts/cocos-primary-client-diagnostic-snapshots.ts
+++ b/scripts/cocos-primary-client-diagnostic-snapshots.ts
@@ -192,6 +192,8 @@ function buildDiagnosticsSnapshot(root: RootState, exportedAt: string): RuntimeD
     mode: root.showLobby ? "lobby" : update?.battle ? "battle" : "world",
     roomId: root.roomId,
     playerId: root.playerId,
+    authMode: root.authMode,
+    loginId: root.loginId,
     connectionStatus: root.diagnosticsConnectionStatus,
     lastUpdateSource: root.lastRoomUpdateSource ?? null,
     lastUpdateReason: root.lastRoomUpdateReason ?? null,
@@ -507,6 +509,9 @@ export function renderPrimaryClientDiagnosticSnapshotsMarkdown(
     lines.push(`- Summary: ${checkpoint.summary}`);
     lines.push(`- Connection status: ${checkpoint.connectionStatus}`);
     lines.push(`- Captured at: ${checkpoint.capturedAt}`);
+    lines.push(
+      `- Account readiness: ${checkpoint.diagnostics.account?.accountReadiness ? `${checkpoint.diagnostics.account.accountReadiness.status} · ${checkpoint.diagnostics.account.accountReadiness.summary}` : "<not-modeled>"}`
+    );
     lines.push(`- Telemetry checkpoints: ${checkpoint.telemetryCheckpoints.length > 0 ? checkpoint.telemetryCheckpoints.join(", ") : "<none>"}`);
     for (const highlight of checkpoint.highlights) {
       lines.push(`- ${highlight}`);

--- a/scripts/cocos-primary-client-journey-evidence.ts
+++ b/scripts/cocos-primary-client-journey-evidence.ts
@@ -486,6 +486,8 @@ function captureJourneyArtifact(options: {
       mode: update?.battle ? "battle" : "world",
       roomId: root.roomId,
       playerId: root.playerId,
+      authMode: root.authMode,
+      loginId: root.loginId,
       connectionStatus: root.diagnosticsConnectionStatus,
       lastUpdateSource: root.lastRoomUpdateSource,
       lastUpdateReason: root.lastRoomUpdateReason,

--- a/scripts/test/cocos-primary-client-diagnostic-snapshots.test.ts
+++ b/scripts/test/cocos-primary-client-diagnostic-snapshots.test.ts
@@ -50,6 +50,12 @@ test("release:cocos:primary-diagnostics exports versioned JSON and Markdown arti
         source: {
           mode: string;
         };
+        account?: {
+          accountReadiness?: {
+            status: string;
+            summary: string;
+          };
+        };
       };
     }>;
   };
@@ -70,6 +76,7 @@ test("release:cocos:primary-diagnostics exports versioned JSON and Markdown arti
     artifact.summary.checkpointIds
   );
   assert.equal(artifact.checkpoints.find((checkpoint) => checkpoint.id === "combat-loop")?.diagnostics.source.mode, "battle");
+  assert.equal(artifact.checkpoints[0]?.diagnostics.account?.accountReadiness?.status, "ready");
   assert.deepEqual(
     artifact.checkpoints.find((checkpoint) => checkpoint.id === "inventory-overflow")?.telemetryCheckpoints,
     ["equipment.equip.rejected", "loot.overflowed"]
@@ -77,5 +84,6 @@ test("release:cocos:primary-diagnostics exports versioned JSON and Markdown arti
   assert.equal(fs.existsSync(markdownOutputPath), true);
   const markdown = fs.readFileSync(markdownOutputPath, "utf8");
   assert.match(markdown, /# Primary-Client Diagnostic Snapshots/);
+  assert.match(markdown, /Account readiness: ready · 正式账号会话已绑定/);
   assert.match(markdown, /reconnect-cached-replay/);
 });


### PR DESCRIPTION
## Summary
- formalize Cocos account lifecycle drafts into explicit ready/missing/blocked readiness states
- surface readiness in the lobby account flow and primary-client runtime diagnostics/export output
- cover ready, missing, and blocked lifecycle scenarios plus diagnostic artifact wiring

## Testing
- node --import tsx --test ./apps/cocos-client/test/cocos-account-lifecycle.test.ts ./apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
- node --import tsx --test ./apps/cocos-client/test/cocos-runtime-diagnostics.test.ts ./apps/cocos-client/test/cocos-primary-client-journey.test.ts
- node --import tsx --test ./packages/shared/test/runtime-diagnostics.test.ts ./scripts/test/cocos-primary-client-diagnostic-snapshots.test.ts
- npm run typecheck:cocos && npm run typecheck:shared

Closes #568