### PR TITLE
docs: publish codex automation branch maintenance runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ npm run dev:client:h5
 - 仓库变更风险分级验证矩阵：`docs/verification-matrix.md`
 - 多人同步治理矩阵说明：`docs/sync-governance-matrix.md`
 - 共享 contract 快照说明：`docs/shared-contract-snapshots.md`
+- Codex automation 分支审计与清理 runbook：`docs/codex-automation-branch-maintenance.md`
 - 当前 H5 调试壳仍支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。
 - 当前 H5 联机体验已支持：客户端预测、断线自动重连、刷新后本地快照首帧回放，再由权威房间状态收敛。
 - 当前 Cocos Creator 主客户端已补齐：

--- a/docs/codex-automation-branch-maintenance.md
+++ b/docs/codex-automation-branch-maintenance.md
@@ -1,43 +1,106 @@
-# Codex Automation Branch Maintenance
+# Codex Automation Branch Maintenance Runbook
 
-`npm run ops:codex-branches` audits stale `codex/issue-*` automation branches in this repo without touching unrelated worktrees or files. The command inspects both local refs and `origin/codex/issue-*` refs, then combines Git state with current open-PR state from `gh` for the same repository.
+This runbook is for operators auditing and pruning stale `codex/issue-*` automation branches in `dannagrace/ProjectVeil`.
 
-## Audit Usage
+`npm run ops:codex-branches` inspects local refs and `origin/codex/issue-*` refs in the current repository, then combines Git state with current open-PR data from `gh`. It does not touch unrelated files or worktrees, and `prune` is dry-run by default.
+
+## When To Run It
+
+Run this workflow when codex automation branches have accumulated and you need to confirm which ones are still active, which need manual follow-up, and which merged branches are old enough to prune.
+
+Use it before doing any manual branch cleanup in GitHub or locally. The script is the source of truth for the audit classification.
+
+## Safety Checks Before Any Cleanup
+
+Confirm all of the following before acting on a prune result:
+
+- You are in the `ProjectVeil` repo and have fetched the latest remote refs.
+- Your local `main` is current with `origin/main`.
+- `gh auth status` succeeds for the GitHub account that can read PR state for this repo.
+- You are not currently checked out on a branch you expect to prune.
+- You have reviewed the dry-run output from `prune` in the same repo state you plan to act on.
+
+Recommended prep:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git fetch --prune origin
+gh auth status
+```
+
+## Audit Workflow
+
+Start with a read-only audit:
 
 ```bash
 npm run ops:codex-branches -- list
+```
+
+Use JSON output if you want to save or diff the report:
+
+```bash
 npm run ops:codex-branches -- list --format json
 ```
 
-Each branch row includes:
+Each row reports:
 
 - age in days since the latest commit
 - upstream tracking status for local branches
 - whether the branch tip is already merged into `main`
 - whether an open PR still exists for that branch name
 - a classification of `active`, `safe-to-delete`, or `manual-review`
+- the suggested next action for that branch
 
-## Retention Policy
+## Classification And Explicit Exclusions
+
+The audit intentionally excludes the following branches from automatic pruning:
+
+- Open PR branches: any branch with an open pull request stays `active`, even if already merged.
+- Active branches: the currently checked-out branch and recent unmerged work stay out of automatic deletion.
+- Manual-review branches: stale unmerged branches and branches whose tracked upstream is already gone require human review and are never auto-pruned.
+
+Retention policy:
 
 - Active branches: keep any branch with an open PR, the currently checked-out branch, or unmerged work updated within the last 30 days.
-- Merged branches: keep merged branches for 7 days after their latest commit so recent automation work remains visible while PR review and post-merge checks settle.
-- Abandoned branches: treat unmerged branches older than 30 days and branches whose tracked upstream is already gone as manual-review candidates. They are stale enough to investigate, but not safe for automatic deletion.
+- Merged branches: keep merged branches for 7 days after their latest commit so recent automation work remains visible while review and post-merge checks settle.
+- Abandoned branches: treat unmerged branches older than 30 days and branches whose tracked upstream is already gone as `manual-review`.
 
-Only one class is auto-prunable:
+Only one class is eligible for automatic pruning:
 
 - Safe-to-delete: merged into `main`, no open PR, older than the 7-day merged retention window, and not the currently checked-out branch.
 
-## Guarded Cleanup
+## Dry-Run-First Prune Workflow
 
-`prune` is dry-run by default and only targets `safe-to-delete` rows.
+Always preview prune candidates before deletion:
 
 ```bash
 npm run ops:codex-branches -- prune
+```
+
+That command only prints `safe-to-delete` rows. It does not delete anything until `--apply` is present.
+
+If the dry run looks correct, delete eligible local branches:
+
+```bash
 npm run ops:codex-branches -- prune --apply
+```
+
+Delete remote branches only after confirming the dry-run set still looks correct and you explicitly want to remove `origin/*` refs too:
+
+```bash
 npm run ops:codex-branches -- prune --apply --delete-remote
 ```
 
-Cleanup safeguards:
+## Post-Run Verification
+
+After any applied prune:
+
+- Re-run `npm run ops:codex-branches -- list` to confirm the remaining branch set.
+- Check that any expected open PR branches still appear as `active`.
+- If you deleted remote refs, verify GitHub no longer shows those fully merged, no-PR branches as active heads.
+
+## Guardrails Enforced By The Script
 
 - No deletion happens unless `--apply` is present.
 - Remote branch deletion is disabled unless `--delete-remote` is present.


### PR DESCRIPTION
## Summary
- expand the codex automation branch maintenance doc into an operator-facing runbook
- document dry-run-first audit and prune workflows, safety checks, and explicit exclusions
- link the runbook from the contributor guidance in README

Closes #579