### PR TITLE
ci: add targeted typecheck lane for ops tooling changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,53 @@ jobs:
       - name: Validate contributor quickstart
         run: npm run validate:quickstart
 
+  ops-tooling-typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Detect PRs that touch ops tooling typecheck surfaces
+        id: ops-tooling
+        run: |
+          changed_paths="${RUNNER_TEMP}/ops-tooling/changed-paths-${GITHUB_SHA}.txt"
+          mkdir -p "$(dirname "${changed_paths}")"
+          git diff --name-only "origin/${{ github.base_ref }}...HEAD" | tee "${changed_paths}"
+
+          touched=false
+          if rg -n \
+            '^(scripts/audit-codex-automation-branches\.ts|scripts/test/codex-automation-branches\.test\.ts|tsconfig\.ops-tooling\.json|package(-lock)?\.json|\.github/workflows/ci\.yml)$' \
+            "${changed_paths}" >/dev/null; then
+            touched=true
+          fi
+
+          echo "touched=${touched}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "## Ops Tooling Typecheck Detection"
+            echo
+            echo "- Base ref: \`${{ github.base_ref }}\`"
+            echo "- Qualifying paths touched: \`${touched}\`"
+            echo "- Changed-path report: \`${changed_paths}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Typecheck ops tooling surface
+        if: steps.ops-tooling.outputs.touched == 'true'
+        run: npm run typecheck:ops
+
   validate:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "test:shared": "node --import tsx --test \"packages/shared/test/**/*.test.ts\"",
     "test:contracts": "node --import tsx --test ./packages/shared/test/client-payload-contracts.test.ts",
     "typecheck:ci": "npm run typecheck:shared && npm run typecheck:server && npm run typecheck:client:h5 && npm run typecheck:cocos",
+    "typecheck:ops": "tsc -p tsconfig.ops-tooling.json --noEmit",
     "typecheck": "tsc -p tsconfig.base.json --noEmit",
     "typecheck:cocos": "tsc -p apps/cocos-client/tsconfig.json --noEmit",
     "typecheck:shared": "tsc -p packages/shared/tsconfig.json --noEmit",

--- a/scripts/audit-codex-automation-branches.ts
+++ b/scripts/audit-codex-automation-branches.ts
@@ -208,6 +208,9 @@ function readBranchSnapshots(): BranchSnapshot[] {
     .filter(Boolean)
     .map((line) => {
       const [refName, shortName, sha, updatedAt, upstreamRaw, upstreamTrackRaw] = line.split("\t");
+      if (!refName || !shortName || !sha || !updatedAt) {
+        fail(`Unexpected git for-each-ref output row: ${line}`);
+      }
       const scope: Scope = refName.startsWith("refs/heads/") ? "local" : "remote";
       const branch = scope === "remote" ? shortName.replace(/^origin\//, "") : shortName;
       return {

--- a/tsconfig.ops-tooling.json
+++ b/tsconfig.ops-tooling.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["scripts/audit-codex-automation-branches.ts", "scripts/test/codex-automation-branches.test.ts"]
+}


### PR DESCRIPTION
## Summary
- add a narrow `typecheck:ops` TypeScript project for the codex branch audit tooling surface
- add a PR-only CI job that detects ops tooling path changes and runs the scoped typecheck lane
- harden the branch snapshot parser so the newly checked script satisfies strict typing

## Validation
- npm run typecheck:ops
- npm run test:codex-branches
- npm run typecheck:ci *(currently fails on existing unrelated server baseline issues in `apps/server/src/admin-console.ts` and `apps/server/src/dev-server.ts` on `main`)*

Closes #581