### PR TITLE
release: add historical readiness trend reporting across candidate revisions

### DIFF
--- a/.github/workflows/release-readiness-history.yml
+++ b/.github/workflows/release-readiness-history.yml
@@ -346,10 +346,14 @@ jobs:
           args=(
             --release-readiness "${HISTORY_DIR}/release-readiness-snapshot.json"
             --release-gate-summary "${HISTORY_DIR}/release-gate-summary.json"
+            --release-readiness-dashboard "${HISTORY_DIR}/release-readiness-dashboard.json"
             --ci-trend-summary "${HISTORY_DIR}/ci-trend-summary.json"
             --output "${HISTORY_DIR}/release-health-summary.json"
             --markdown-output "${HISTORY_DIR}/release-health-summary.md"
           )
+          if [[ -f "${RUNNER_TEMP}/baseline/release-readiness-dashboard.json" ]]; then
+            args+=(--previous-release-readiness-dashboard "${RUNNER_TEMP}/baseline/release-readiness-dashboard.json")
+          fi
           if [[ -f "${HISTORY_DIR}/coverage/summary.json" ]]; then
             args+=(--coverage-summary "${HISTORY_DIR}/coverage/summary.json")
           fi
@@ -394,11 +398,18 @@ jobs:
           ];
 
           const blockers = health?.triage?.blockers ?? [];
+          const readinessTrend = health?.signals?.find((signal) => signal.id === "readiness-trend");
           if (blockers.length > 0) {
             lines.push("### Blocking Signals", "");
             for (const blocker of blockers.slice(0, 3)) {
               lines.push(`- ${blocker.title}: ${blocker.summary}`);
             }
+            lines.push("");
+          }
+
+          if (readinessTrend) {
+            lines.push("### Candidate Trend", "");
+            lines.push(`- ${readinessTrend.summary}`);
             lines.push("");
           }
 

--- a/docs/release-health-summary.md
+++ b/docs/release-health-summary.md
@@ -7,11 +7,13 @@ The summary now includes a unified `triage` section so maintainers can see, in o
 - which signals are blocking vs warning-only
 - which underlying artifact(s) to open next
 - the next debugging command or inspection step for each failing signal
+- how the latest candidate readiness call changed versus the previous candidate revision when dashboard history is available
 
 It reuses the current artifact producers instead of redefining them:
 
 - `npm run release:readiness:snapshot`
 - `npm run release:gate:summary`
+- `npm run release:readiness:dashboard`
 - `npm run ci:trend-summary`
 - `npm run test:coverage:ci`
 - `npm run test:sync-governance:matrix`
@@ -56,6 +58,8 @@ Point at explicit artifact paths when CI already produced stable filenames:
 npm run release:health:summary -- \
   --release-readiness artifacts/release-readiness/release-readiness-2026-03-30T08-00-00.000Z.json \
   --release-gate-summary artifacts/release-readiness/release-gate-summary.json \
+  --release-readiness-dashboard artifacts/release-readiness/release-readiness-dashboard.json \
+  --previous-release-readiness-dashboard artifacts/release-readiness/release-readiness-dashboard-prev.json \
   --ci-trend-summary artifacts/release-readiness/ci-trend-summary.json \
   --coverage-summary .coverage/summary.json \
   --sync-governance artifacts/release-readiness/sync-governance-matrix-abc1234.json
@@ -88,6 +92,7 @@ The JSON report contains:
   - resolved artifact paths used for this run
 - `signals`
   - per-artifact status, summary, detail lines, and source path
+  - when a current readiness dashboard is provided, includes `readiness-trend` for regression/improvement across candidate revisions
 - `findings`
   - flattened machine-readable findings with `severity`, `signalId`, and source path
 - `triage`
@@ -102,4 +107,5 @@ For branch-level readiness history in GitHub Actions, use the `Release Readiness
 
 - Open the latest successful workflow run for the branch.
 - Download the `release-readiness-history` artifact.
-- Start with `release-health-summary.md` for the top-level call, then inspect `ci-trend-summary.md` for deltas versus the previous successful history baseline and `release-readiness-dashboard.md` for the latest go/no-go view.
+- Start with `release-health-summary.md` for the top-level call. It now includes candidate readiness trend reporting when the workflow can compare the latest dashboard against the previous successful history baseline.
+- Then inspect `ci-trend-summary.md` for runtime/release-gate deltas and `release-readiness-dashboard.md` for the latest go/no-go view.

--- a/scripts/release-health-summary.ts
+++ b/scripts/release-health-summary.ts
@@ -9,6 +9,7 @@ type SignalStatus = "pass" | "warn" | "fail";
 type ReleaseHealthSignalId =
   | "release-readiness"
   | "release-gate"
+  | "readiness-trend"
   | "ci-trend"
   | "coverage"
   | "sync-governance";
@@ -16,6 +17,8 @@ type ReleaseHealthSignalId =
 interface Args {
   releaseReadinessPath?: string;
   releaseGateSummaryPath?: string;
+  releaseReadinessDashboardPath?: string;
+  previousReleaseReadinessDashboardPath?: string;
   ciTrendSummaryPath?: string;
   coverageSummaryPath?: string;
   syncGovernancePath?: string;
@@ -69,6 +72,19 @@ interface ReleaseGateSummaryReport {
       path?: string;
     };
   }>;
+}
+
+interface ReleaseReadinessDashboardReport {
+  generatedAt?: string;
+  goNoGo?: {
+    decision?: "ready" | "pending" | "blocked";
+    summary?: string;
+    candidateRevision?: string;
+    requiredFailed?: number;
+    requiredPending?: number;
+    blockers?: string[];
+    pending?: string[];
+  };
 }
 
 interface CiTrendSummaryReport {
@@ -183,6 +199,8 @@ export interface ReleaseHealthSummaryReport {
   inputs: {
     releaseReadinessPath?: string;
     releaseGateSummaryPath?: string;
+    releaseReadinessDashboardPath?: string;
+    previousReleaseReadinessDashboardPath?: string;
     ciTrendSummaryPath?: string;
     coverageSummaryPath?: string;
     syncGovernancePath?: string;
@@ -210,6 +228,8 @@ function fail(message: string): never {
 function parseArgs(argv: string[]): Args {
   let releaseReadinessPath: string | undefined;
   let releaseGateSummaryPath: string | undefined;
+  let releaseReadinessDashboardPath: string | undefined;
+  let previousReleaseReadinessDashboardPath: string | undefined;
   let ciTrendSummaryPath: string | undefined;
   let coverageSummaryPath: string | undefined;
   let syncGovernancePath: string | undefined;
@@ -227,6 +247,16 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--release-gate-summary" && next) {
       releaseGateSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--release-readiness-dashboard" && next) {
+      releaseReadinessDashboardPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--previous-release-readiness-dashboard" && next) {
+      previousReleaseReadinessDashboardPath = next;
       index += 1;
       continue;
     }
@@ -261,6 +291,8 @@ function parseArgs(argv: string[]): Args {
   return {
     ...(releaseReadinessPath ? { releaseReadinessPath } : {}),
     ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
+    ...(releaseReadinessDashboardPath ? { releaseReadinessDashboardPath } : {}),
+    ...(previousReleaseReadinessDashboardPath ? { previousReleaseReadinessDashboardPath } : {}),
     ...(ciTrendSummaryPath ? { ciTrendSummaryPath } : {}),
     ...(coverageSummaryPath ? { coverageSummaryPath } : {}),
     ...(syncGovernancePath ? { syncGovernancePath } : {}),
@@ -320,6 +352,12 @@ function getRevision(): GitRevision {
 export function resolveInputPaths(args: Args): ReleaseHealthSummaryReport["inputs"] {
   const explicitReleaseReadinessPath = args.releaseReadinessPath ? path.resolve(args.releaseReadinessPath) : undefined;
   const explicitReleaseGateSummaryPath = args.releaseGateSummaryPath ? path.resolve(args.releaseGateSummaryPath) : undefined;
+  const explicitReleaseReadinessDashboardPath = args.releaseReadinessDashboardPath
+    ? path.resolve(args.releaseReadinessDashboardPath)
+    : undefined;
+  const explicitPreviousReleaseReadinessDashboardPath = args.previousReleaseReadinessDashboardPath
+    ? path.resolve(args.previousReleaseReadinessDashboardPath)
+    : undefined;
   const explicitCiTrendSummaryPath = args.ciTrendSummaryPath ? path.resolve(args.ciTrendSummaryPath) : undefined;
   const explicitCoverageSummaryPath = args.coverageSummaryPath ? path.resolve(args.coverageSummaryPath) : undefined;
   const explicitSyncGovernancePath = args.syncGovernancePath ? path.resolve(args.syncGovernancePath) : undefined;
@@ -340,6 +378,12 @@ export function resolveInputPaths(args: Args): ReleaseHealthSummaryReport["input
       ? path.resolve(getDefaultReleaseReadinessDir(), "release-gate-summary.json")
       : resolveLatestFile(getDefaultReleaseReadinessDir(), (entry) => entry.startsWith("release-gate-summary-") && entry.endsWith(".json")));
 
+  const releaseReadinessDashboardPath =
+    explicitReleaseReadinessDashboardPath ??
+    (fs.existsSync(path.resolve(getDefaultReleaseReadinessDir(), "release-readiness-dashboard.json"))
+      ? path.resolve(getDefaultReleaseReadinessDir(), "release-readiness-dashboard.json")
+      : undefined);
+
   const ciTrendSummaryPath =
     explicitCiTrendSummaryPath ??
     (fs.existsSync(path.resolve(getDefaultReleaseReadinessDir(), "ci-trend-summary.json"))
@@ -356,6 +400,10 @@ export function resolveInputPaths(args: Args): ReleaseHealthSummaryReport["input
   return {
     ...(releaseReadinessPath ? { releaseReadinessPath } : {}),
     ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
+    ...(releaseReadinessDashboardPath ? { releaseReadinessDashboardPath } : {}),
+    ...(explicitPreviousReleaseReadinessDashboardPath
+      ? { previousReleaseReadinessDashboardPath: explicitPreviousReleaseReadinessDashboardPath }
+      : {}),
     ...(ciTrendSummaryPath ? { ciTrendSummaryPath } : {}),
     ...(coverageSummaryPath ? { coverageSummaryPath } : {}),
     ...(syncGovernancePath ? { syncGovernancePath } : {})
@@ -557,6 +605,110 @@ function evaluateReleaseGateSignal(filePath: string | undefined): { signal: Rele
   return {
     signal: buildSignal("release-gate", "Release gate summary", "pass", "All release gates are currently passing.", [], source),
     findings: [buildFinding("release-gate:passed", "release-gate", "info", "All release gates are currently passing.", source)]
+  };
+}
+
+function getReadinessDecisionRank(decision: ReleaseReadinessDashboardReport["goNoGo"] extends { decision?: infer T } ? T : never): number {
+  if (decision === "ready") {
+    return 2;
+  }
+  if (decision === "pending") {
+    return 1;
+  }
+  return 0;
+}
+
+function getDashboardCandidateRevision(report: ReleaseReadinessDashboardReport | undefined): string {
+  return report?.goNoGo?.candidateRevision ?? "<unverified>";
+}
+
+function evaluateReadinessTrendSignal(
+  currentPath: string | undefined,
+  previousPath: string | undefined
+): { signal?: ReleaseHealthSignal; findings: ReleaseHealthFinding[] } {
+  if (!currentPath) {
+    return { findings: [] };
+  }
+
+  if (!fs.existsSync(currentPath)) {
+    return {
+      signal: buildSignal(
+        "readiness-trend",
+        "Candidate readiness trend",
+        "warn",
+        "Current release readiness dashboard is missing, so candidate trend could not be computed.",
+        ["Generate the dashboard first so the candidate revision can be compared against prior history."]
+      ),
+      findings: [
+        buildFinding(
+          "readiness-trend:missing-current",
+          "readiness-trend",
+          "warning",
+          "Current release readiness dashboard is missing, so candidate trend could not be computed."
+        )
+      ]
+    };
+  }
+
+  const currentReport = readJsonFile<ReleaseReadinessDashboardReport>(currentPath);
+  const currentSource = createSource(currentPath, currentReport.generatedAt);
+  const currentDecision = currentReport.goNoGo?.decision ?? "blocked";
+  const currentCandidate = getDashboardCandidateRevision(currentReport);
+  const currentSummary = currentReport.goNoGo?.summary?.trim() || `Current candidate is ${currentDecision}.`;
+
+  if (!previousPath || !fs.existsSync(previousPath)) {
+    const status: SignalStatus = currentDecision === "ready" ? "pass" : "warn";
+    const summary = `No previous candidate dashboard was available; current candidate ${currentCandidate} is ${currentDecision}.`;
+    return {
+      signal: buildSignal("readiness-trend", "Candidate readiness trend", status, summary, [currentSummary], currentSource),
+      findings: [
+        buildFinding(
+          `readiness-trend:${status === "pass" ? "passed" : "warning"}-no-baseline`,
+          "readiness-trend",
+          status === "pass" ? "info" : "warning",
+          summary,
+          currentSource
+        )
+      ]
+    };
+  }
+
+  const previousReport = readJsonFile<ReleaseReadinessDashboardReport>(previousPath);
+  const previousDecision = previousReport.goNoGo?.decision ?? "blocked";
+  const previousCandidate = getDashboardCandidateRevision(previousReport);
+  const previousSummary = previousReport.goNoGo?.summary?.trim() || `Previous candidate was ${previousDecision}.`;
+  const currentRank = getReadinessDecisionRank(currentDecision);
+  const previousRank = getReadinessDecisionRank(previousDecision);
+  const details = [
+    `current=${currentCandidate}:${currentDecision}`,
+    `previous=${previousCandidate}:${previousDecision}`,
+    `current summary: ${currentSummary}`,
+    `previous summary: ${previousSummary}`
+  ];
+
+  if (currentRank < previousRank) {
+    const summary = `Candidate readiness regressed from ${previousDecision} at ${previousCandidate} to ${currentDecision} at ${currentCandidate}.`;
+    return {
+      signal: buildSignal("readiness-trend", "Candidate readiness trend", "warn", summary, details, currentSource),
+      findings: [buildFinding("readiness-trend:regressed", "readiness-trend", "warning", summary, currentSource)]
+    };
+  }
+
+  if (currentRank === previousRank && currentDecision !== "ready") {
+    const summary = `Candidate readiness remains ${currentDecision} across ${previousCandidate} and ${currentCandidate}.`;
+    return {
+      signal: buildSignal("readiness-trend", "Candidate readiness trend", "warn", summary, details, currentSource),
+      findings: [buildFinding("readiness-trend:unchanged-unready", "readiness-trend", "warning", summary, currentSource)]
+    };
+  }
+
+  const summary =
+    currentRank > previousRank
+      ? `Candidate readiness improved from ${previousDecision} at ${previousCandidate} to ${currentDecision} at ${currentCandidate}.`
+      : `Candidate readiness remains ready across ${previousCandidate} and ${currentCandidate}.`;
+  return {
+    signal: buildSignal("readiness-trend", "Candidate readiness trend", "pass", summary, details, currentSource),
+    findings: [buildFinding("readiness-trend:passed", "readiness-trend", "info", summary, currentSource)]
   };
 }
 
@@ -864,6 +1016,86 @@ function buildCiTrendTriage(filePath: string | undefined): ReleaseHealthTriageEn
   ];
 }
 
+function buildReadinessTrendTriage(
+  currentPath: string | undefined,
+  previousPath: string | undefined
+): ReleaseHealthTriageEntry[] {
+  if (!currentPath) {
+    return [];
+  }
+
+  if (!fs.existsSync(currentPath)) {
+    return [
+      buildTriageEntry(
+        "readiness-trend:missing-current",
+        "readiness-trend",
+        "warning",
+        "Candidate readiness trend",
+        "Current release readiness dashboard is missing, so candidate history cannot be compared.",
+        "Run `npm run release:readiness:dashboard` for the candidate revision before rebuilding the release health summary.",
+        [],
+        []
+      )
+    ];
+  }
+
+  const currentReport = readJsonFile<ReleaseReadinessDashboardReport>(currentPath);
+  const currentDecision = currentReport.goNoGo?.decision ?? "blocked";
+  const currentCandidate = getDashboardCandidateRevision(currentReport);
+
+  if (!previousPath || !fs.existsSync(previousPath)) {
+    if (currentDecision === "ready") {
+      return [];
+    }
+    return [
+      buildTriageEntry(
+        "readiness-trend:no-baseline",
+        "readiness-trend",
+        "warning",
+        "Candidate readiness trend",
+        `No previous candidate dashboard is available; current candidate ${currentCandidate} is ${currentDecision}.`,
+        "Keep publishing the history artifact for each candidate revision so future readiness deltas can be compared.",
+        [currentReport.goNoGo?.summary?.trim() || `Current candidate is ${currentDecision}.`],
+        createArtifactReference("Current release readiness dashboard", currentPath, currentReport.generatedAt)
+      )
+    ];
+  }
+
+  const previousReport = readJsonFile<ReleaseReadinessDashboardReport>(previousPath);
+  const previousDecision = previousReport.goNoGo?.decision ?? "blocked";
+  const previousCandidate = getDashboardCandidateRevision(previousReport);
+  const currentRank = getReadinessDecisionRank(currentDecision);
+  const previousRank = getReadinessDecisionRank(previousDecision);
+
+  if (currentRank > previousRank || (currentRank === previousRank && currentDecision === "ready")) {
+    return [];
+  }
+
+  const summary =
+    currentRank < previousRank
+      ? `Candidate readiness regressed from ${previousDecision} at ${previousCandidate} to ${currentDecision} at ${currentCandidate}.`
+      : `Candidate readiness remains ${currentDecision} across ${previousCandidate} and ${currentCandidate}.`;
+
+  return [
+    buildTriageEntry(
+      "readiness-trend:triage",
+      "readiness-trend",
+      "warning",
+      "Candidate readiness trend",
+      summary,
+      `Open \`${toDisplayPath(currentPath)}\` and \`${toDisplayPath(previousPath)}\` to compare the candidate blockers or pending checks before advancing the next revision.`,
+      [
+        `Current summary: ${currentReport.goNoGo?.summary?.trim() || `Current candidate is ${currentDecision}.`}`,
+        `Previous summary: ${previousReport.goNoGo?.summary?.trim() || `Previous candidate was ${previousDecision}.`}`
+      ],
+      [
+        ...createArtifactReference("Current release readiness dashboard", currentPath, currentReport.generatedAt),
+        ...createArtifactReference("Previous release readiness dashboard", previousPath, previousReport.generatedAt)
+      ]
+    )
+  ];
+}
+
 function buildCoverageTriage(filePath: string | undefined): ReleaseHealthTriageEntry[] {
   if (!filePath || !fs.existsSync(filePath)) {
     return [
@@ -951,6 +1183,7 @@ function buildTriageReport(inputs: ReleaseHealthSummaryReport["inputs"]): Releas
       ...syncGovernanceTriage.filter((entry) => entry.severity === "blocker")
     ],
     warnings: [
+      ...buildReadinessTrendTriage(inputs.releaseReadinessDashboardPath, inputs.previousReleaseReadinessDashboardPath),
       ...buildCiTrendTriage(inputs.ciTrendSummaryPath),
       ...buildCoverageTriage(inputs.coverageSummaryPath),
       ...syncGovernanceTriage.filter((entry) => entry.severity === "warning")
@@ -960,9 +1193,14 @@ function buildTriageReport(inputs: ReleaseHealthSummaryReport["inputs"]): Releas
 
 export function buildReleaseHealthSummaryReport(args: Args, revision: GitRevision): ReleaseHealthSummaryReport {
   const inputs = resolveInputPaths(args);
+  const readinessTrend = evaluateReadinessTrendSignal(
+    inputs.releaseReadinessDashboardPath,
+    inputs.previousReleaseReadinessDashboardPath
+  );
   const signalResults = [
     evaluateReleaseReadinessSignal(inputs.releaseReadinessPath),
     evaluateReleaseGateSignal(inputs.releaseGateSummaryPath),
+    ...(readinessTrend.signal ? [readinessTrend] : []),
     evaluateCiTrendSignal(inputs.ciTrendSummaryPath),
     evaluateCoverageSignal(inputs.coverageSummaryPath),
     evaluateSyncGovernanceSignal(inputs.syncGovernancePath)

--- a/scripts/test/release-health-summary-cli.test.ts
+++ b/scripts/test/release-health-summary-cli.test.ts
@@ -23,6 +23,25 @@ function runReleaseHealthSummary(args: string[]) {
   });
 }
 
+function createDashboard(overrides?: {
+  decision?: "ready" | "pending" | "blocked";
+  summary?: string;
+  candidateRevision?: string;
+}) {
+  return {
+    generatedAt: "2026-03-30T12:00:00.000Z",
+    goNoGo: {
+      decision: overrides?.decision ?? "ready",
+      summary: overrides?.summary ?? "Candidate is release-ready.",
+      candidateRevision: overrides?.candidateRevision ?? "abc1234",
+      requiredFailed: 0,
+      requiredPending: 0,
+      blockers: [],
+      pending: []
+    }
+  };
+}
+
 test("release:health:summary exits 0 for a healthy report", () => {
   const workspace = createTempWorkspace();
   const releaseReadinessPath = path.join(workspace, "release-readiness-pass.json");
@@ -158,4 +177,56 @@ test("release:health:summary exits 1 when sync governance is blocking", () => {
   const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as { summary: { status: string; blockingSignalIds: string[] } };
   assert.equal(report.summary.status, "blocking");
   assert.deepEqual(report.summary.blockingSignalIds, ["sync-governance"]);
+});
+
+test("release:health:summary accepts candidate readiness dashboard trend inputs", () => {
+  const workspace = createTempWorkspace();
+  const releaseReadinessPath = path.join(workspace, "release-readiness-pass.json");
+  const releaseGateSummaryPath = path.join(workspace, "release-gate-summary-pass.json");
+  const dashboardPath = path.join(workspace, "release-readiness-dashboard.json");
+  const previousDashboardPath = path.join(workspace, "release-readiness-dashboard-prev.json");
+  const outputPath = path.join(workspace, "release-health-summary.json");
+  const markdownOutputPath = path.join(workspace, "release-health-summary.md");
+
+  writeJson(releaseReadinessPath, {
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [{ id: "npm-test", required: true, status: "passed" }]
+  });
+  writeJson(releaseGateSummaryPath, {
+    summary: { status: "passed", failedGateIds: [] },
+    gates: [{ id: "release-readiness", status: "passed", summary: "ok" }]
+  });
+  writeJson(
+    dashboardPath,
+    createDashboard({
+      decision: "blocked",
+      summary: "Candidate is blocked by stale evidence.",
+      candidateRevision: "cur1234"
+    })
+  );
+  writeJson(previousDashboardPath, createDashboard({ decision: "ready", candidateRevision: "prev9876" }));
+
+  const result = runReleaseHealthSummary([
+    "--release-readiness",
+    releaseReadinessPath,
+    "--release-gate-summary",
+    releaseGateSummaryPath,
+    "--release-readiness-dashboard",
+    dashboardPath,
+    "--previous-release-readiness-dashboard",
+    previousDashboardPath,
+    "--output",
+    outputPath,
+    "--markdown-output",
+    markdownOutputPath
+  ]);
+
+  assert.equal(result.status, 0, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    summary: { status: string; warningSignalIds: string[] };
+    signals: Array<{ id: string; summary: string }>;
+  };
+  assert.equal(report.summary.status, "warning");
+  assert.equal(report.summary.warningSignalIds.includes("readiness-trend"), true);
+  assert.match(report.signals.find((signal) => signal.id === "readiness-trend")?.summary ?? "", /regressed from ready/);
 });

--- a/scripts/test/release-health-summary.test.ts
+++ b/scripts/test/release-health-summary.test.ts
@@ -15,6 +15,26 @@ function createTempWorkspace(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "veil-release-health-summary-"));
 }
 
+function createDashboard(overrides?: {
+  generatedAt?: string;
+  decision?: "ready" | "pending" | "blocked";
+  summary?: string;
+  candidateRevision?: string;
+}) {
+  return {
+    generatedAt: overrides?.generatedAt ?? "2026-03-30T12:00:00.000Z",
+    goNoGo: {
+      decision: overrides?.decision ?? "ready",
+      summary: overrides?.summary ?? "Candidate is release-ready.",
+      candidateRevision: overrides?.candidateRevision ?? "abc1234",
+      requiredFailed: 0,
+      requiredPending: 0,
+      blockers: [],
+      pending: []
+    }
+  };
+}
+
 const TEST_REVISION = {
   commit: "abc123",
   shortCommit: "abc123",
@@ -393,6 +413,64 @@ test("buildReleaseHealthSummaryReport aggregates degraded warning signals withou
   assert.match(renderMarkdown(report), /Coverage thresholds failed in 1 scope\(s\)\./);
 });
 
+test("buildReleaseHealthSummaryReport reports candidate readiness trend regressions across revisions", () => {
+  const workspace = createTempWorkspace();
+  const releaseReadinessPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
+  const releaseGateSummaryPath = path.join(workspace, "artifacts", "release-readiness", "release-gate-summary-pass.json");
+  const currentDashboardPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-dashboard.json");
+  const previousDashboardPath = path.join(workspace, "baseline", "release-readiness-dashboard.json");
+
+  writeJson(releaseReadinessPath, {
+    generatedAt: "2026-03-30T11:00:00.000Z",
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [{ id: "npm-test", required: true, status: "passed" }]
+  });
+  writeJson(releaseGateSummaryPath, {
+    generatedAt: "2026-03-30T11:05:00.000Z",
+    summary: { status: "passed", failedGateIds: [] },
+    gates: [{ id: "wechat-release", status: "passed", summary: "ok" }]
+  });
+  writeJson(
+    currentDashboardPath,
+    createDashboard({
+      generatedAt: "2026-03-30T12:00:00.000Z",
+      decision: "blocked",
+      summary: "Candidate is blocked by stale WeChat smoke evidence.",
+      candidateRevision: "cur1234"
+    })
+  );
+  writeJson(
+    previousDashboardPath,
+    createDashboard({
+      generatedAt: "2026-03-29T12:00:00.000Z",
+      decision: "ready",
+      summary: "Candidate is release-ready.",
+      candidateRevision: "prev9876"
+    })
+  );
+
+  const report = buildReleaseHealthSummaryReport(
+    {
+      releaseReadinessPath,
+      releaseGateSummaryPath,
+      releaseReadinessDashboardPath: currentDashboardPath,
+      previousReleaseReadinessDashboardPath: previousDashboardPath
+    },
+    TEST_REVISION
+  );
+
+  assert.equal(report.summary.status, "warning");
+  assert.deepEqual(report.summary.blockingSignalIds, []);
+  assert.equal(report.summary.warningSignalIds.includes("readiness-trend"), true);
+  assert.equal(report.signals.some((signal) => signal.id === "readiness-trend"), true);
+  assert.equal(report.triage.warnings.some((entry) => entry.signalId === "readiness-trend"), true);
+  assert.deepEqual(
+    report.findings.filter((finding) => finding.signalId === "readiness-trend").map((finding) => finding.summary),
+    ["Candidate readiness regressed from ready at prev9876 to blocked at cur1234."]
+  );
+  assert.match(renderMarkdown(report), /Candidate readiness regressed from ready at prev9876 to blocked at cur1234\./);
+});
+
 test("resolveInputPaths discovers the latest local artifacts", () => {
   const workspace = createTempWorkspace();
   const previousCwd = process.cwd();
@@ -405,6 +483,7 @@ test("resolveInputPaths discovers the latest local artifacts", () => {
     writeJson(path.join(workspace, "artifacts", "release-readiness", "release-gate-summary.json"), {
       summary: { status: "passed" }
     });
+    writeJson(path.join(workspace, "artifacts", "release-readiness", "release-readiness-dashboard.json"), createDashboard());
     writeJson(path.join(workspace, "artifacts", "release-readiness", "ci-trend-summary.json"), {
       summary: { overallStatus: "passed" }
     });
@@ -416,6 +495,7 @@ test("resolveInputPaths discovers the latest local artifacts", () => {
     const resolved = resolveInputPaths({});
     assert.equal(resolved.releaseReadinessPath?.endsWith("release-readiness-2026-03-29T00-00-00.000Z.json"), true);
     assert.equal(resolved.releaseGateSummaryPath?.endsWith("artifacts/release-readiness/release-gate-summary.json"), true);
+    assert.equal(resolved.releaseReadinessDashboardPath?.endsWith("artifacts/release-readiness/release-readiness-dashboard.json"), true);
     assert.equal(resolved.ciTrendSummaryPath?.endsWith("artifacts/release-readiness/ci-trend-summary.json"), true);
     assert.equal(resolved.syncGovernancePath?.endsWith("artifacts/release-readiness/sync-governance-matrix-abc123.json"), true);
     assert.equal(resolved.coverageSummaryPath?.endsWith(".coverage/summary.json"), true);


### PR DESCRIPTION
## Summary
- add optional release-readiness dashboard inputs to release health summary and report candidate readiness trend across revisions
- surface the readiness trend in release-readiness-history workflow summaries and docs
- cover the new comparison path with release health summary unit and CLI tests

Closes #575