### PR TITLE
ops: serialize codex automation runs per worktree

### DIFF
--- a/docs/codex-automation-branch-maintenance.md
+++ b/docs/codex-automation-branch-maintenance.md
@@ -2,7 +2,7 @@
 
 This runbook is for operators auditing and pruning stale `codex/issue-*` automation branches in `dannagrace/ProjectVeil`.
 
-`npm run ops:codex-branches` inspects local refs and `origin/codex/issue-*` refs in the current repository, then combines Git state with current open-PR data from `gh`. It does not touch unrelated files or worktrees, and `prune` is dry-run by default.
+`npm run ops:codex-branches` inspects local refs and `origin/codex/issue-*` refs in the current repository, then combines Git state with current open-PR data from `gh`. It does not touch unrelated files or worktrees, `prune` is dry-run by default, and runs are serialized per repository worktree so two Codex automation invocations cannot mutate the same worktree concurrently.
 
 ## When To Run It
 
@@ -28,6 +28,8 @@ git pull --ff-only origin main
 git fetch --prune origin
 gh auth status
 ```
+
+If another Codex automation run is already using the same worktree, the command waits for that worktree-local lock to clear before continuing. Independent Git worktrees keep separate locks and do not block each other.
 
 ## Audit Workflow
 
@@ -104,6 +106,7 @@ After any applied prune:
 
 - No deletion happens unless `--apply` is present.
 - Remote branch deletion is disabled unless `--delete-remote` is present.
+- Only one `ops:codex-branches` run can execute at a time per repository worktree.
 - Branches with open PRs are never pruned.
 - Unmerged stale branches stay in `manual-review`; the tool does not auto-delete them.
 - The currently checked-out branch is never pruned, even if it would otherwise qualify.

--- a/scripts/audit-codex-automation-branches.ts
+++ b/scripts/audit-codex-automation-branches.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 
@@ -64,6 +66,10 @@ const BRANCH_PREFIX = "codex/issue-";
 const DEFAULT_BASE_BRANCH = "main";
 const DEFAULT_MERGED_RETENTION_DAYS = 7;
 const DEFAULT_ABANDONED_REVIEW_DAYS = 30;
+const WORKTREE_LOCK_DIRNAME = "codex-automation-run.lock";
+const WORKTREE_LOCK_METADATA_FILE = "owner.json";
+const DEFAULT_LOCK_TIMEOUT_MS = 300_000;
+const DEFAULT_LOCK_POLL_INTERVAL_MS = 100;
 
 function fail(message: string): never {
   throw new Error(message);
@@ -175,8 +181,18 @@ function runCommand(command: string, args: string[], allowFailure = false): stri
   return result.stdout.trim();
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 function readCurrentBranch(): string {
   return runCommand("git", ["branch", "--show-current"]);
+}
+
+function readCurrentWorktreeGitDir(): string {
+  return runCommand("git", ["rev-parse", "--absolute-git-dir"]);
 }
 
 function ensureBaseBranchExists(base: string): void {
@@ -402,54 +418,133 @@ function deleteBranch(entry: BranchAuditEntry): void {
   console.log(`Deleted remote branch origin/${entry.branch}`);
 }
 
+function buildLockMetadata(lockPath: string): Record<string, unknown> {
+  return {
+    pid: process.pid,
+    cwd: process.cwd(),
+    acquiredAt: new Date().toISOString(),
+    lockPath,
+    argv: process.argv.slice(2)
+  };
+}
+
+function readLockOwner(lockPath: string): string | null {
+  try {
+    const raw = fs.readFileSync(path.join(lockPath, WORKTREE_LOCK_METADATA_FILE), "utf8");
+    const parsed = JSON.parse(raw) as {
+      pid?: number;
+      acquiredAt?: string;
+      cwd?: string;
+      argv?: string[];
+    };
+    const details = [
+      typeof parsed.pid === "number" ? `pid ${parsed.pid}` : null,
+      parsed.acquiredAt ? `acquired ${parsed.acquiredAt}` : null,
+      parsed.cwd ? `cwd ${parsed.cwd}` : null,
+      Array.isArray(parsed.argv) && parsed.argv.length > 0 ? `args ${parsed.argv.join(" ")}` : null
+    ].filter(Boolean);
+    return details.length > 0 ? details.join(", ") : "metadata unavailable";
+  } catch {
+    return null;
+  }
+}
+
+export async function withSerializedWorktreeExecution<T>(
+  gitDir: string,
+  action: () => Promise<T> | T,
+  options: {
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+  } = {}
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_LOCK_POLL_INTERVAL_MS;
+  const lockPath = path.join(gitDir, WORKTREE_LOCK_DIRNAME);
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    try {
+      fs.mkdirSync(lockPath);
+      fs.writeFileSync(
+        path.join(lockPath, WORKTREE_LOCK_METADATA_FILE),
+        `${JSON.stringify(buildLockMetadata(lockPath), null, 2)}\n`,
+        "utf8"
+      );
+      break;
+    } catch (error) {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") {
+        throw error;
+      }
+
+      if (Date.now() >= deadline) {
+        const owner = readLockOwner(lockPath);
+        fail(
+          owner
+            ? `Another codex automation run is still active for this repository worktree (${owner}).`
+            : "Another codex automation run is still active for this repository worktree."
+        );
+      }
+
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  try {
+    return await action();
+  } finally {
+    fs.rmSync(lockPath, { recursive: true, force: true });
+  }
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
   ensureBaseBranchExists(args.base);
-
-  const entries = buildBranchAuditReport({
-    branches: readBranchSnapshots(),
-    mergedRefs: readMergedRefs(args.base),
-    openPrsByBranch: readOpenPullRequests(),
-    base: args.base,
-    currentBranch: readCurrentBranch(),
-    nowMs: Date.now(),
-    mergedRetentionDays: args.mergedRetentionDays,
-    abandonedReviewDays: args.abandonedReviewDays
-  });
-  const pruneCandidates = selectPruneCandidates(entries, args.deleteRemote);
-
-  if (args.format === "json") {
-    renderJson({
-      entries: args.command === "prune" ? pruneCandidates : entries,
-      summary: buildSummary(entries, pruneCandidates)
+  await withSerializedWorktreeExecution(readCurrentWorktreeGitDir(), async () => {
+    const entries = buildBranchAuditReport({
+      branches: readBranchSnapshots(),
+      mergedRefs: readMergedRefs(args.base),
+      openPrsByBranch: readOpenPullRequests(),
+      base: args.base,
+      currentBranch: readCurrentBranch(),
+      nowMs: Date.now(),
+      mergedRetentionDays: args.mergedRetentionDays,
+      abandonedReviewDays: args.abandonedReviewDays
     });
-  } else if (args.command === "prune") {
-    renderTable(pruneCandidates);
-  } else {
-    renderTable(entries);
-  }
+    const pruneCandidates = selectPruneCandidates(entries, args.deleteRemote);
 
-  if (args.format !== "json") {
-    printSummary(entries, pruneCandidates);
-  }
-
-  if (args.command !== "prune") {
-    return;
-  }
-
-  if (!args.apply) {
-    console.log("Dry run only. Re-run with --apply to delete the listed safe candidates.");
-    if (!args.deleteRemote) {
-      console.log("Remote branches are audit-only unless --delete-remote is also set.");
+    if (args.format === "json") {
+      renderJson({
+        entries: args.command === "prune" ? pruneCandidates : entries,
+        summary: buildSummary(entries, pruneCandidates)
+      });
+    } else if (args.command === "prune") {
+      renderTable(pruneCandidates);
+    } else {
+      renderTable(entries);
     }
-    return;
-  }
 
-  for (const entry of pruneCandidates) {
-    deleteBranch(entry);
-  }
+    if (args.format !== "json") {
+      printSummary(entries, pruneCandidates);
+    }
 
-  console.log(`Pruned ${pruneCandidates.length} branch ref(s).`);
+    if (args.command !== "prune") {
+      return;
+    }
+
+    if (!args.apply) {
+      console.log("Dry run only. Re-run with --apply to delete the listed safe candidates.");
+      if (!args.deleteRemote) {
+        console.log("Remote branches are audit-only unless --delete-remote is also set.");
+      }
+      return;
+    }
+
+    for (const entry of pruneCandidates) {
+      deleteBranch(entry);
+    }
+
+    console.log(`Pruned ${pruneCandidates.length} branch ref(s).`);
+  });
 }
 
 const isDirectExecution =

--- a/scripts/test/codex-automation-branches.test.ts
+++ b/scripts/test/codex-automation-branches.test.ts
@@ -4,10 +4,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 
 import {
   buildBranchAuditReport,
   selectPruneCandidates,
+  withSerializedWorktreeExecution,
   type BranchAuditEntry
 } from "../audit-codex-automation-branches.ts";
 
@@ -296,6 +298,70 @@ test("selectPruneCandidates leaves remote refs alone unless remote deletion is e
   assert.deepEqual(
     selectPruneCandidates(entries, true).map((entry) => `${entry.scope}:${entry.branch}`),
     ["local:codex/issue-103-local", "remote:codex/issue-103-remote"]
+  );
+});
+
+test("withSerializedWorktreeExecution serializes concurrent runs within the same worktree git dir", async () => {
+  const gitDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-codex-lock-"));
+  const events: string[] = [];
+
+  const firstRun = withSerializedWorktreeExecution(gitDir, async () => {
+    events.push("first:start");
+    await delay(150);
+    events.push("first:end");
+  });
+
+  await delay(25);
+
+  const secondRun = withSerializedWorktreeExecution(
+    gitDir,
+    async () => {
+      events.push("second:start");
+      events.push("second:end");
+    },
+    {
+      pollIntervalMs: 10,
+      timeoutMs: 1_000
+    }
+  );
+
+  await Promise.all([firstRun, secondRun]);
+
+  assert.deepEqual(events, ["first:start", "first:end", "second:start", "second:end"]);
+});
+
+test("withSerializedWorktreeExecution times out with owner details when the worktree lock stays held", async () => {
+  const gitDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-codex-lock-timeout-"));
+  const lockDir = path.join(gitDir, "codex-automation-run.lock");
+  fs.mkdirSync(lockDir);
+  fs.writeFileSync(
+    path.join(lockDir, "owner.json"),
+    `${JSON.stringify(
+      {
+        pid: 4321,
+        acquiredAt: "2026-04-02T00:00:00.000Z",
+        cwd: "/tmp/example-worktree",
+        argv: ["prune", "--apply"]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  await assert.rejects(
+    () =>
+      withSerializedWorktreeExecution(
+        gitDir,
+        async () => {
+          throw new Error("unreachable");
+        },
+        {
+          pollIntervalMs: 10,
+          timeoutMs: 40
+        }
+      ),
+    /Another codex automation run is still active for this repository worktree \(pid 4321, acquired 2026-04-02T00:00:00.000Z, cwd \/tmp\/example-worktree, args prune --apply\)\./
   );
 });
 


### PR DESCRIPTION
## Summary
- serialize ops:codex-branches runs within the current repository worktree by taking a worktree-local Git-dir lock
- keep the lock scoped per worktree so independent Git worktrees can run without blocking each other
- cover the new locking behavior with targeted tests and document the operator-facing behavior

## Testing
- npm run test:codex-branches
- npm run typecheck:ops

Closes #585