### PR TITLE
release: publish PR-visible readiness trend deltas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: write
@@ -485,6 +486,39 @@ jobs:
           name: wechat-release-${{ github.sha }}
           path: ${{ runner.temp }}/wechat-release
 
+      - name: Resolve previous successful history baseline
+        if: |
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        id: history-baseline
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const response = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "release-readiness-history.yml",
+              branch,
+              status: "completed",
+              per_page: 20
+            });
+
+            const baseline = response.data.workflow_runs.find((run) => run.conclusion === "success");
+            core.setOutput("run-id", baseline ? String(baseline.id) : "");
+            core.setOutput("run-url", baseline?.html_url ?? "");
+
+      - name: Download previous release-readiness history artifact
+        if: steps.history-baseline.outputs.run-id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.history-baseline.outputs.run-id }}
+          name: release-readiness-history
+          path: ${{ runner.temp }}/baseline
+
       - name: Build release gate summary artifact
         continue-on-error: true
         run: |
@@ -529,6 +563,20 @@ jobs:
           fi
           npm run ci:trend-summary -- "${args[@]}"
 
+      - name: Build release readiness dashboard artifact
+        continue-on-error: true
+        run: |
+          args=(
+            --snapshot "${RUNNER_TEMP}/release-readiness/release-readiness-${GITHUB_SHA}.json"
+            --candidate-revision "${GITHUB_SHA}"
+            --output "${RUNNER_TEMP}/release-readiness/release-readiness-dashboard-${GITHUB_SHA}.json"
+            --markdown-output "${RUNNER_TEMP}/release-readiness/release-readiness-dashboard-${GITHUB_SHA}.md"
+          )
+          if [[ -d "${RUNNER_TEMP}/wechat-release" ]]; then
+            args+=(--wechat-artifacts-dir "${RUNNER_TEMP}/wechat-release")
+          fi
+          npm run release:readiness:dashboard -- "${args[@]}"
+
       - name: Build release health summary artifact
         run: |
           args=(
@@ -538,6 +586,12 @@ jobs:
             --output "${RUNNER_TEMP}/release-readiness/release-health-summary-${GITHUB_SHA}.json"
             --markdown-output "${RUNNER_TEMP}/release-readiness/release-health-summary-${GITHUB_SHA}.md"
           )
+          if [[ -f "${RUNNER_TEMP}/release-readiness/release-readiness-dashboard-${GITHUB_SHA}.json" ]]; then
+            args+=(--release-readiness-dashboard "${RUNNER_TEMP}/release-readiness/release-readiness-dashboard-${GITHUB_SHA}.json")
+          fi
+          if [[ -f "${RUNNER_TEMP}/baseline/release-readiness-dashboard.json" ]]; then
+            args+=(--previous-release-readiness-dashboard "${RUNNER_TEMP}/baseline/release-readiness-dashboard.json")
+          fi
           if [[ -f ".coverage/summary.json" ]]; then
             args+=(--coverage-summary ".coverage/summary.json")
           fi

--- a/scripts/release-pr-comment.ts
+++ b/scripts/release-pr-comment.ts
@@ -114,6 +114,9 @@ function summarizeGate(gate: ReleaseGateSummaryReport["gates"][number]): string 
 
 function summarizeHealthSignal(signal: ReleaseHealthSummaryReport["signals"][number]): string {
   const statusLabel = signal.status.toUpperCase();
+  if (signal.id === "readiness-trend") {
+    return `- **${signal.label}**: \`${statusLabel}\` ${signal.summary}`;
+  }
   const firstDetail = signal.details.find((detail) => detail.trim().length > 0);
   return `- **${signal.label}**: \`${statusLabel}\` ${firstDetail ?? signal.summary}`;
 }

--- a/scripts/test/release-pr-comment.test.ts
+++ b/scripts/test/release-pr-comment.test.ts
@@ -71,6 +71,16 @@ test("renderPrComment combines readiness and non-duplicative health sections", (
           details: ["release-gate:wechat-release remained failing"]
         },
         {
+          id: "readiness-trend",
+          label: "Candidate readiness trend",
+          status: "warn",
+          summary: "Candidate readiness regressed from ready at prev9876 to blocked at abc1234.",
+          details: [
+            "current=abc1234:blocked",
+            "previous=prev9876:ready"
+          ]
+        },
+        {
           id: "coverage",
           label: "Coverage summary",
           status: "pass",
@@ -88,6 +98,11 @@ test("renderPrComment combines readiness and non-duplicative health sections", (
   assert.match(markdown, /WeChat smoke case is still pending: login-flow\./);
   assert.match(markdown, /### Release Health/);
   assert.match(markdown, /\*\*CI trend summary\*\*: `WARN` release-gate:wechat-release remained failing/);
+  assert.match(
+    markdown,
+    /\*\*Candidate readiness trend\*\*: `WARN` Candidate readiness regressed from ready at prev9876 to blocked at abc1234\./
+  );
+  assert.doesNotMatch(markdown, /\*\*Candidate readiness trend\*\*: `WARN` current=abc1234:blocked/);
   assert.match(markdown, /\*\*Coverage summary\*\*: `PASS` thresholds passed/);
   assert.doesNotMatch(markdown, /\*\*Release gate summary\*\*: `FAIL`/);
 });


### PR DESCRIPTION
## Summary
- build a PR-path release readiness dashboard pinned to the candidate revision and feed it into the release health summary
- pull the previous successful release-readiness history artifact on same-repo PRs so readiness deltas can be compared in CI
- render `readiness-trend` in the PR comment using the human-readable delta summary

## Testing
- npm run test:release-health-summary
- node --import tsx --test ./scripts/test/release-pr-comment.test.ts
- npm run typecheck:ops

Closes #586