### PR TITLE
refactor: align release health summary and PR comment reporting contracts

### DIFF
--- a/scripts/release-health-summary.ts
+++ b/scripts/release-health-summary.ts
@@ -3,6 +3,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import {
+  formatReadinessTrendHealthySummary,
+  formatReadinessTrendNoBaselineSummary,
+  formatReadinessTrendRegressionSummary,
+  formatReadinessTrendUnchangedUnreadySummary,
+  type ReadinessDecision
+} from "./release-reporting-contract.ts";
+
 type HealthStatus = "healthy" | "warning" | "blocking";
 type FindingSeverity = "blocker" | "warning" | "info";
 type SignalStatus = "pass" | "warn" | "fail";
@@ -618,6 +626,12 @@ function getReadinessDecisionRank(decision: ReleaseReadinessDashboardReport["goN
   return 0;
 }
 
+function normalizeReadinessDecision(
+  decision: ReleaseReadinessDashboardReport["goNoGo"] extends { decision?: infer T } ? T : never
+): ReadinessDecision {
+  return decision === "ready" || decision === "pending" ? decision : "blocked";
+}
+
 function getDashboardCandidateRevision(report: ReleaseReadinessDashboardReport | undefined): string {
   return report?.goNoGo?.candidateRevision ?? "<unverified>";
 }
@@ -652,13 +666,13 @@ function evaluateReadinessTrendSignal(
 
   const currentReport = readJsonFile<ReleaseReadinessDashboardReport>(currentPath);
   const currentSource = createSource(currentPath, currentReport.generatedAt);
-  const currentDecision = currentReport.goNoGo?.decision ?? "blocked";
+  const currentDecision = normalizeReadinessDecision(currentReport.goNoGo?.decision);
   const currentCandidate = getDashboardCandidateRevision(currentReport);
   const currentSummary = currentReport.goNoGo?.summary?.trim() || `Current candidate is ${currentDecision}.`;
 
   if (!previousPath || !fs.existsSync(previousPath)) {
     const status: SignalStatus = currentDecision === "ready" ? "pass" : "warn";
-    const summary = `No previous candidate dashboard was available; current candidate ${currentCandidate} is ${currentDecision}.`;
+    const summary = formatReadinessTrendNoBaselineSummary(currentCandidate, currentDecision);
     return {
       signal: buildSignal("readiness-trend", "Candidate readiness trend", status, summary, [currentSummary], currentSource),
       findings: [
@@ -674,7 +688,7 @@ function evaluateReadinessTrendSignal(
   }
 
   const previousReport = readJsonFile<ReleaseReadinessDashboardReport>(previousPath);
-  const previousDecision = previousReport.goNoGo?.decision ?? "blocked";
+  const previousDecision = normalizeReadinessDecision(previousReport.goNoGo?.decision);
   const previousCandidate = getDashboardCandidateRevision(previousReport);
   const previousSummary = previousReport.goNoGo?.summary?.trim() || `Previous candidate was ${previousDecision}.`;
   const currentRank = getReadinessDecisionRank(currentDecision);
@@ -687,7 +701,7 @@ function evaluateReadinessTrendSignal(
   ];
 
   if (currentRank < previousRank) {
-    const summary = `Candidate readiness regressed from ${previousDecision} at ${previousCandidate} to ${currentDecision} at ${currentCandidate}.`;
+    const summary = formatReadinessTrendRegressionSummary(previousDecision, previousCandidate, currentDecision, currentCandidate);
     return {
       signal: buildSignal("readiness-trend", "Candidate readiness trend", "warn", summary, details, currentSource),
       findings: [buildFinding("readiness-trend:regressed", "readiness-trend", "warning", summary, currentSource)]
@@ -695,17 +709,14 @@ function evaluateReadinessTrendSignal(
   }
 
   if (currentRank === previousRank && currentDecision !== "ready") {
-    const summary = `Candidate readiness remains ${currentDecision} across ${previousCandidate} and ${currentCandidate}.`;
+    const summary = formatReadinessTrendUnchangedUnreadySummary(currentDecision, previousCandidate, currentCandidate);
     return {
       signal: buildSignal("readiness-trend", "Candidate readiness trend", "warn", summary, details, currentSource),
       findings: [buildFinding("readiness-trend:unchanged-unready", "readiness-trend", "warning", summary, currentSource)]
     };
   }
 
-  const summary =
-    currentRank > previousRank
-      ? `Candidate readiness improved from ${previousDecision} at ${previousCandidate} to ${currentDecision} at ${currentCandidate}.`
-      : `Candidate readiness remains ready across ${previousCandidate} and ${currentCandidate}.`;
+  const summary = formatReadinessTrendHealthySummary(previousDecision, previousCandidate, currentDecision, currentCandidate);
   return {
     signal: buildSignal("readiness-trend", "Candidate readiness trend", "pass", summary, details, currentSource),
     findings: [buildFinding("readiness-trend:passed", "readiness-trend", "info", summary, currentSource)]
@@ -1040,7 +1051,7 @@ function buildReadinessTrendTriage(
   }
 
   const currentReport = readJsonFile<ReleaseReadinessDashboardReport>(currentPath);
-  const currentDecision = currentReport.goNoGo?.decision ?? "blocked";
+  const currentDecision = normalizeReadinessDecision(currentReport.goNoGo?.decision);
   const currentCandidate = getDashboardCandidateRevision(currentReport);
 
   if (!previousPath || !fs.existsSync(previousPath)) {
@@ -1053,7 +1064,7 @@ function buildReadinessTrendTriage(
         "readiness-trend",
         "warning",
         "Candidate readiness trend",
-        `No previous candidate dashboard is available; current candidate ${currentCandidate} is ${currentDecision}.`,
+        formatReadinessTrendNoBaselineSummary(currentCandidate, currentDecision),
         "Keep publishing the history artifact for each candidate revision so future readiness deltas can be compared.",
         [currentReport.goNoGo?.summary?.trim() || `Current candidate is ${currentDecision}.`],
         createArtifactReference("Current release readiness dashboard", currentPath, currentReport.generatedAt)
@@ -1062,7 +1073,7 @@ function buildReadinessTrendTriage(
   }
 
   const previousReport = readJsonFile<ReleaseReadinessDashboardReport>(previousPath);
-  const previousDecision = previousReport.goNoGo?.decision ?? "blocked";
+  const previousDecision = normalizeReadinessDecision(previousReport.goNoGo?.decision);
   const previousCandidate = getDashboardCandidateRevision(previousReport);
   const currentRank = getReadinessDecisionRank(currentDecision);
   const previousRank = getReadinessDecisionRank(previousDecision);
@@ -1073,8 +1084,8 @@ function buildReadinessTrendTriage(
 
   const summary =
     currentRank < previousRank
-      ? `Candidate readiness regressed from ${previousDecision} at ${previousCandidate} to ${currentDecision} at ${currentCandidate}.`
-      : `Candidate readiness remains ${currentDecision} across ${previousCandidate} and ${currentCandidate}.`;
+      ? formatReadinessTrendRegressionSummary(previousDecision, previousCandidate, currentDecision, currentCandidate)
+      : formatReadinessTrendUnchangedUnreadySummary(currentDecision, previousCandidate, currentCandidate);
 
   return [
     buildTriageEntry(

--- a/scripts/release-pr-comment.ts
+++ b/scripts/release-pr-comment.ts
@@ -2,6 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+import {
+  renderPrCommentHealthSignal,
+  type ReviewerFacingSignal,
+  type ReviewerFacingTriageEntry
+} from "./release-reporting-contract.ts";
+
 interface Args {
   releaseGateSummaryPath?: string;
   releaseHealthSummaryPath?: string;
@@ -44,6 +50,18 @@ interface ReleaseHealthSummaryReport {
     summary: string;
     details: string[];
   }>;
+  triage: {
+    blockers: Array<{
+      signalId: string;
+      summary: string;
+      nextStep: string;
+    }>;
+    warnings: Array<{
+      signalId: string;
+      summary: string;
+      nextStep: string;
+    }>;
+  };
 }
 
 const COMMENT_MARKER = "<!-- project-veil-release-summary -->";
@@ -112,15 +130,6 @@ function summarizeGate(gate: ReleaseGateSummaryReport["gates"][number]): string 
   return `- **${gate.label}**: \`${statusLabel}\` ${firstFailure ?? gate.summary}`;
 }
 
-function summarizeHealthSignal(signal: ReleaseHealthSummaryReport["signals"][number]): string {
-  const statusLabel = signal.status.toUpperCase();
-  if (signal.id === "readiness-trend") {
-    return `- **${signal.label}**: \`${statusLabel}\` ${signal.summary}`;
-  }
-  const firstDetail = signal.details.find((detail) => detail.trim().length > 0);
-  return `- **${signal.label}**: \`${statusLabel}\` ${firstDetail ?? signal.summary}`;
-}
-
 export function renderPrComment(
   releaseGateReport: ReleaseGateSummaryReport,
   releaseHealthReport: ReleaseHealthSummaryReport,
@@ -146,11 +155,21 @@ export function renderPrComment(
     "### Release Health",
     ""
   ];
+  const healthTriageBySignalId = new Map<string, ReviewerFacingTriageEntry>(
+    [...releaseHealthReport.triage.blockers, ...releaseHealthReport.triage.warnings].map((entry) => [entry.signalId, entry])
+  );
 
   if (healthSignals.length === 0) {
     lines.push("- No additional release-health signals were available beyond release readiness.");
   } else {
-    lines.push(...healthSignals.map((signal) => summarizeHealthSignal(signal)));
+    for (const signal of healthSignals) {
+      lines.push(
+        ...renderPrCommentHealthSignal(
+          signal as ReviewerFacingSignal,
+          healthTriageBySignalId.get(signal.id)
+        )
+      );
+    }
   }
 
   lines.push("");

--- a/scripts/release-reporting-contract.ts
+++ b/scripts/release-reporting-contract.ts
@@ -1,0 +1,65 @@
+export type ReviewerSignalStatus = "pass" | "warn" | "fail";
+export type ReadinessDecision = "ready" | "pending" | "blocked";
+
+export interface ReviewerFacingSignal {
+  id: string;
+  label: string;
+  status: ReviewerSignalStatus;
+  summary: string;
+  details: string[];
+}
+
+export interface ReviewerFacingTriageEntry {
+  signalId: string;
+  summary: string;
+  nextStep: string;
+}
+
+export function formatReadinessTrendNoBaselineSummary(currentCandidate: string, currentDecision: ReadinessDecision): string {
+  return `No previous candidate dashboard was available; current candidate ${currentCandidate} is ${currentDecision}.`;
+}
+
+export function formatReadinessTrendRegressionSummary(
+  previousDecision: ReadinessDecision,
+  previousCandidate: string,
+  currentDecision: ReadinessDecision,
+  currentCandidate: string
+): string {
+  return `Candidate readiness regressed from ${previousDecision} at ${previousCandidate} to ${currentDecision} at ${currentCandidate}.`;
+}
+
+export function formatReadinessTrendUnchangedUnreadySummary(
+  currentDecision: ReadinessDecision,
+  previousCandidate: string,
+  currentCandidate: string
+): string {
+  return `Candidate readiness remains ${currentDecision} across ${previousCandidate} and ${currentCandidate}.`;
+}
+
+export function formatReadinessTrendHealthySummary(
+  previousDecision: ReadinessDecision,
+  previousCandidate: string,
+  currentDecision: ReadinessDecision,
+  currentCandidate: string
+): string {
+  if (previousDecision === currentDecision) {
+    return `Candidate readiness remains ready across ${previousCandidate} and ${currentCandidate}.`;
+  }
+  return `Candidate readiness improved from ${previousDecision} at ${previousCandidate} to ${currentDecision} at ${currentCandidate}.`;
+}
+
+export function renderPrCommentHealthSignal(
+  signal: ReviewerFacingSignal,
+  triageEntry?: ReviewerFacingTriageEntry
+): string[] {
+  const statusLabel = signal.status.toUpperCase();
+  const firstDetail = signal.details.find((detail) => detail.trim().length > 0);
+  const summary = triageEntry?.summary ?? firstDetail ?? signal.summary;
+  const lines = [`- **${signal.label}**: \`${statusLabel}\` ${summary}`];
+
+  if (triageEntry) {
+    lines.push(`  Next step: ${triageEntry.nextStep}`);
+  }
+
+  return lines;
+}

--- a/scripts/test/release-pr-comment.test.ts
+++ b/scripts/test/release-pr-comment.test.ts
@@ -3,6 +3,10 @@ import assert from "node:assert/strict";
 
 import { renderPrComment } from "../release-pr-comment.ts";
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function createReleaseGateReport() {
   return {
     generatedAt: "2026-03-30T00:00:00.000Z",
@@ -94,7 +98,28 @@ function createReleaseHealthReport(
         summary: "thresholds passed",
         details: []
       }
-    ]
+    ],
+    triage: {
+      blockers: [],
+      warnings: [
+        {
+          signalId: "ci-trend",
+          summary: "release-gate:wechat-release remained failing",
+          nextStep:
+            "Open `artifacts/release-readiness/ci-trend-summary.json` and compare the new or ongoing regressions against the current runtime and release-gate artifacts before retrying the affected job."
+        },
+        ...(readinessTrendSignal
+          ? [
+              {
+                signalId: "readiness-trend",
+                summary: readinessTrendSignal.summary,
+                nextStep:
+                  "Open `artifacts/release-readiness/release-readiness-dashboard.json` and `artifacts/release-readiness/release-readiness-dashboard-prev.json` to compare the candidate blockers or pending checks before advancing the next revision."
+              }
+            ]
+          : [])
+      ]
+    }
   };
 }
 
@@ -120,9 +145,16 @@ test("renderPrComment combines readiness and non-duplicative health sections", (
   assert.match(markdown, /\*\*CI trend summary\*\*: `WARN` release-gate:wechat-release remained failing/);
   assert.match(
     markdown,
+    /Next step: Open `artifacts\/release-readiness\/ci-trend-summary\.json` and compare the new or ongoing regressions against the current runtime and release-gate artifacts before retrying the affected job\./
+  );
+  assert.match(
+    markdown,
     /\*\*Candidate readiness trend\*\*: `WARN` Candidate readiness regressed from ready at prev9876 to blocked at abc1234\./
   );
-  assert.doesNotMatch(markdown, /\*\*Candidate readiness trend\*\*: `WARN` current=abc1234:blocked/);
+  assert.match(
+    markdown,
+    /Next step: Open `artifacts\/release-readiness\/release-readiness-dashboard\.json` and `artifacts\/release-readiness\/release-readiness-dashboard-prev\.json` to compare the candidate blockers or pending checks before advancing the next revision\./
+  );
   assert.match(markdown, /\*\*Coverage summary\*\*: `PASS` thresholds passed/);
   assert.doesNotMatch(markdown, /\*\*Release gate summary\*\*: `FAIL`/);
 });
@@ -180,4 +212,19 @@ test("renderPrComment keeps readiness-trend markdown stable for edge-case summar
       assert.doesNotMatch(markdown, omittedLine, scenario.name);
     }
   }
+});
+
+test("renderPrComment and release-health triage share the same readiness-trend reviewer contract", () => {
+  const report = createReleaseHealthReport({
+    status: "warn",
+    summary: "Candidate readiness regressed from ready at prev9876 to blocked at abc1234.",
+    details: ["current=abc1234:blocked", "previous=prev9876:ready"]
+  });
+
+  const markdown = renderPrComment(createReleaseGateReport(), report);
+  const readinessTriage = report.triage.warnings.find((entry) => entry.signalId === "readiness-trend");
+
+  assert.ok(readinessTriage);
+  assert.match(markdown, new RegExp(escapeRegExp(readinessTriage.summary)));
+  assert.match(markdown, new RegExp(escapeRegExp(readinessTriage.nextStep)));
 });


### PR DESCRIPTION
## Summary
- add a shared release-reporting contract helper for readiness-trend wording and PR-comment health-line rendering
- drive PR comment release-health entries from release-health triage so reviewer-facing summaries and next steps stay aligned
- extend release reporting tests to lock the shared readiness-trend contract

Closes #598
