### PR TITLE
feat(cocos): add primary equipment inventory panel

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilEquipmentPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilEquipmentPanel.ts
@@ -1,0 +1,388 @@
+import { _decorator, Color, Component, Graphics, Label, Node, UITransform } from "cc";
+import type { EventLogEntry } from "./project-shared/index.ts";
+import type { HeroView } from "./VeilCocosSession.ts";
+import {
+  buildHeroEquipmentActionRows,
+  formatEquipmentOverviewLines,
+  formatEquipmentStatSummary,
+  formatInventorySummaryLines,
+  formatRecentLootLines,
+  type CocosEquipmentActionRow
+} from "./cocos-hero-equipment.ts";
+import { assignUiLayer } from "./cocos-ui-layer.ts";
+
+const { ccclass } = _decorator;
+const H_ALIGN_LEFT = 0;
+const H_ALIGN_CENTER = 1;
+const V_ALIGN_TOP = 0;
+const V_ALIGN_MIDDLE = 1;
+const OVERFLOW_RESIZE_HEIGHT = 3;
+const PANEL_BG = new Color(14, 20, 29, 238);
+const PANEL_BORDER = new Color(232, 224, 192, 120);
+const PANEL_INNER = new Color(255, 248, 214, 16);
+const CARD_FILL = new Color(34, 46, 64, 190);
+const CARD_HIGHLIGHT_FILL = new Color(52, 70, 98, 214);
+const BUTTON_FILL = new Color(70, 92, 120, 228);
+const EQUIP_FILL = new Color(84, 116, 86, 232);
+const UNEQUIP_FILL = new Color(122, 82, 72, 232);
+
+interface EquipmentPanelButtonTone {
+  fill: Color;
+  stroke: Color;
+}
+
+interface EquipmentPanelButtonState {
+  name: string;
+  label: string;
+  callback: (() => void) | null;
+  tone: "default" | "equip" | "unequip";
+}
+
+export interface VeilEquipmentPanelRenderState {
+  hero: HeroView | null;
+  recentEventLog: EventLogEntry[];
+  recentSessionEvents?: Array<{
+    type: "hero.equipmentFound";
+    heroId: string;
+    equipmentName: string;
+    rarity: "common" | "rare" | "epic";
+    overflowed?: boolean;
+  }>;
+}
+
+export interface VeilEquipmentPanelOptions {
+  onClose?: () => void;
+  onEquipItem?: (slot: "weapon" | "armor" | "accessory", equipmentId: string) => void;
+  onUnequipItem?: (slot: "weapon" | "armor" | "accessory") => void;
+}
+
+function buildActionButtons(
+  rows: CocosEquipmentActionRow[],
+  onEquipItem: VeilEquipmentPanelOptions["onEquipItem"],
+  onUnequipItem: VeilEquipmentPanelOptions["onUnequipItem"]
+): EquipmentPanelButtonState[] {
+  const buttons: EquipmentPanelButtonState[] = [];
+
+  for (const row of rows) {
+    for (const item of row.inventory) {
+      buttons.push({
+        name: `EquipmentPanelAction-${row.slot}-${item.itemId}`,
+        label: `${row.label} 装备 ${item.name}${item.count > 1 ? ` x${item.count}` : ""}`,
+        tone: "equip",
+        callback: onEquipItem ? () => onEquipItem(row.slot, item.itemId) : null
+      });
+    }
+
+    if (row.itemId) {
+      buttons.push({
+        name: `EquipmentPanelAction-${row.slot}-unequip`,
+        label: `${row.label} 卸下 ${row.itemName}`,
+        tone: "unequip",
+        callback: onUnequipItem ? () => onUnequipItem(row.slot) : null
+      });
+    }
+  }
+
+  return buttons;
+}
+
+@ccclass("ProjectVeilEquipmentPanel")
+export class VeilEquipmentPanel extends Component {
+  private onClose: (() => void) | undefined;
+  private onEquipItem: VeilEquipmentPanelOptions["onEquipItem"];
+  private onUnequipItem: VeilEquipmentPanelOptions["onUnequipItem"];
+
+  configure(options: VeilEquipmentPanelOptions): void {
+    this.onClose = options.onClose;
+    this.onEquipItem = options.onEquipItem;
+    this.onUnequipItem = options.onUnequipItem;
+  }
+
+  render(state: VeilEquipmentPanelRenderState): void {
+    const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const width = transform.width || 420;
+    const height = transform.height || 520;
+    const contentWidth = width - 30;
+    const hero = state.hero;
+    const rows = buildHeroEquipmentActionRows(hero);
+    const buttons = buildActionButtons(rows, this.onEquipItem, this.onUnequipItem);
+    const bonusSummary = formatEquipmentStatSummary(hero);
+    const loadoutLines = formatEquipmentOverviewLines(hero);
+    const inventoryLines = formatInventorySummaryLines(hero);
+    const lootLines = formatRecentLootLines(
+      state.recentEventLog,
+      hero?.id,
+      3,
+      state.recentSessionEvents ?? [],
+      hero?.name
+    );
+
+    let cursorY = height / 2 - 16;
+    this.syncChrome(width, height);
+
+    cursorY = this.renderCard(
+      "EquipmentPanelHeader",
+      0,
+      cursorY,
+      contentWidth,
+      78,
+      [
+        hero ? `${hero.name} 的装备背包` : "装备背包",
+        hero ? `可查看已穿戴装备、背包物品与最近战利品。` : "等待英雄快照同步。",
+        bonusSummary.length > 0
+          ? `总加成 ${bonusSummary.map((entry) => `${entry.label} +${entry.value}`).join(" / ")}`
+          : "总加成 当前无额外属性"
+      ],
+      {
+        fill: CARD_HIGHLIGHT_FILL,
+        stroke: new Color(244, 236, 208, 82)
+      },
+      null,
+      14,
+      18
+    );
+
+    this.renderButton(
+      "EquipmentPanelClose",
+      contentWidth / 2 - 42,
+      height / 2 - 18,
+      72,
+      24,
+      "关闭",
+      {
+        fill: new Color(112, 72, 64, 220),
+        stroke: new Color(244, 226, 214, 114)
+      },
+      this.onClose ?? null
+    );
+
+    cursorY = this.renderCard(
+      "EquipmentPanelLoadout",
+      0,
+      cursorY,
+      contentWidth,
+      Math.max(112, 34 + loadoutLines.length * 16),
+      ["穿戴配置", ...loadoutLines],
+      {
+        fill: CARD_FILL,
+        stroke: new Color(220, 230, 244, 56)
+      },
+      null,
+      13,
+      16
+    );
+
+    cursorY = this.renderCard(
+      "EquipmentPanelInventory",
+      0,
+      cursorY,
+      contentWidth,
+      Math.max(110, 34 + inventoryLines.length * 16),
+      ["背包清单", ...inventoryLines],
+      {
+        fill: CARD_FILL,
+        stroke: new Color(220, 230, 244, 56)
+      },
+      null,
+      13,
+      16
+    );
+
+    cursorY = this.renderCard(
+      "EquipmentPanelLoot",
+      0,
+      cursorY,
+      contentWidth,
+      Math.max(94, 34 + lootLines.length * 16),
+      ["最近战利品", ...lootLines],
+      {
+        fill: CARD_FILL,
+        stroke: new Color(220, 230, 244, 56)
+      },
+      null,
+      13,
+      16
+    );
+
+    this.renderActionButtons(contentWidth, cursorY, buttons);
+  }
+
+  private syncChrome(width: number, height: number): void {
+    const graphics = this.node.getComponent(Graphics) ?? this.node.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = PANEL_BG;
+    graphics.strokeColor = PANEL_BORDER;
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 18);
+    graphics.fill();
+    graphics.stroke();
+    graphics.fillColor = PANEL_INNER;
+    graphics.roundRect(-width / 2 + 14, height / 2 - 22, width - 28, 6, 3);
+    graphics.fill();
+  }
+
+  private renderCard(
+    name: string,
+    centerX: number,
+    topY: number,
+    width: number,
+    minHeight: number,
+    lines: string[],
+    tone: EquipmentPanelButtonTone,
+    onPress: (() => void) | null,
+    fontSize: number,
+    lineHeight: number
+  ): number {
+    const height = Math.max(minHeight, 20 + lines.length * lineHeight);
+    let cardNode = this.node.getChildByName(name);
+    if (!cardNode) {
+      cardNode = new Node(name);
+      cardNode.parent = this.node;
+    }
+    assignUiLayer(cardNode);
+    cardNode.active = true;
+
+    const transform = cardNode.getComponent(UITransform) ?? cardNode.addComponent(UITransform);
+    transform.setContentSize(width, height);
+    cardNode.setPosition(centerX, topY - height / 2, 0.5);
+    const graphics = cardNode.getComponent(Graphics) ?? cardNode.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = tone.fill;
+    graphics.strokeColor = tone.stroke;
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 14);
+    graphics.fill();
+    graphics.stroke();
+    graphics.fillColor = new Color(255, 255, 255, 16);
+    graphics.roundRect(-width / 2 + 12, height / 2 - 16, width - 24, 5, 3);
+    graphics.fill();
+
+    let labelNode = cardNode.getChildByName("Label");
+    if (!labelNode) {
+      labelNode = new Node("Label");
+      labelNode.parent = cardNode;
+    }
+    assignUiLayer(labelNode);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(width - 24, height - 14);
+    labelNode.setPosition(0, 0, 1);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = lines.join("\n");
+    label.fontSize = fontSize;
+    label.lineHeight = lineHeight;
+    label.horizontalAlign = H_ALIGN_LEFT;
+    label.verticalAlign = V_ALIGN_TOP;
+    label.overflow = OVERFLOW_RESIZE_HEIGHT;
+    label.enableWrapText = true;
+    label.color = new Color(244, 247, 252, 255);
+
+    cardNode.off(Node.EventType.TOUCH_END);
+    cardNode.off(Node.EventType.MOUSE_UP);
+    if (onPress) {
+      cardNode.on(Node.EventType.TOUCH_END, onPress);
+      cardNode.on(Node.EventType.MOUSE_UP, onPress);
+    }
+
+    return topY - height - 10;
+  }
+
+  private renderButton(
+    name: string,
+    centerX: number,
+    centerY: number,
+    width: number,
+    height: number,
+    labelText: string,
+    tone: EquipmentPanelButtonTone,
+    onPress: (() => void) | null
+  ): void {
+    let buttonNode = this.node.getChildByName(name);
+    if (!buttonNode) {
+      buttonNode = new Node(name);
+      buttonNode.parent = this.node;
+    }
+    assignUiLayer(buttonNode);
+    buttonNode.active = true;
+    const transform = buttonNode.getComponent(UITransform) ?? buttonNode.addComponent(UITransform);
+    transform.setContentSize(width, height);
+    buttonNode.setPosition(centerX, centerY, 1);
+    const graphics = buttonNode.getComponent(Graphics) ?? buttonNode.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = tone.fill;
+    graphics.strokeColor = tone.stroke;
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 10);
+    graphics.fill();
+    graphics.stroke();
+
+    let labelNode = buttonNode.getChildByName("Label");
+    if (!labelNode) {
+      labelNode = new Node("Label");
+      labelNode.parent = buttonNode;
+    }
+    assignUiLayer(labelNode);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(width - 12, height - 6);
+    labelNode.setPosition(0, 0, 1);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = labelText;
+    label.fontSize = 11;
+    label.lineHeight = 13;
+    label.horizontalAlign = H_ALIGN_CENTER;
+    label.verticalAlign = V_ALIGN_MIDDLE;
+    label.enableWrapText = false;
+    label.color = new Color(244, 247, 252, 255);
+
+    buttonNode.off(Node.EventType.TOUCH_END);
+    buttonNode.off(Node.EventType.MOUSE_UP);
+    if (onPress) {
+      buttonNode.on(Node.EventType.TOUCH_END, onPress);
+      buttonNode.on(Node.EventType.MOUSE_UP, onPress);
+    }
+  }
+
+  private renderActionButtons(contentWidth: number, topY: number, buttons: EquipmentPanelButtonState[]): void {
+    const actionButtons = buttons.length > 0
+      ? buttons
+      : [
+          {
+            name: "EquipmentPanelAction-empty",
+            label: "当前没有可执行的装备操作",
+            callback: null,
+            tone: "default" as const
+          }
+        ];
+
+    const buttonWidth = Math.floor((contentWidth - 6) / 2);
+    const buttonHeight = 24;
+    const gap = 6;
+    const startY = topY - 10 - buttonHeight / 2;
+    actionButtons.forEach((button, index) => {
+      const row = Math.floor(index / 2);
+      const column = index % 2;
+      const centerX = column === 0 ? -buttonWidth / 2 - gap / 2 : buttonWidth / 2 + gap / 2;
+      const centerY = startY - row * (buttonHeight + gap);
+      const fill =
+        button.tone === "equip" ? EQUIP_FILL : button.tone === "unequip" ? UNEQUIP_FILL : BUTTON_FILL;
+      this.renderButton(
+        button.name,
+        centerX,
+        centerY,
+        buttonWidth,
+        buttonHeight,
+        button.label,
+        {
+          fill,
+          stroke: new Color(230, 238, 246, 106)
+        },
+        button.callback
+      );
+    });
+
+    for (const child of this.node.children) {
+      if (child.name.startsWith("EquipmentPanelAction-") && !actionButtons.some((button) => button.name === child.name)) {
+        child.active = false;
+      }
+    }
+  }
+}

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -210,6 +210,7 @@ function getSessionIndicatorBadge(indicators: VeilHudSessionIndicator[]): string
 export interface VeilHudPanelOptions {
   onNewRun?: () => void;
   onRefresh?: () => void;
+  onToggleInventory?: () => void;
   onToggleAchievements?: () => void;
   onLearnSkill?: (skillId: string) => void;
   onEquipItem?: (slot: EquipmentType, equipmentId: string) => void;
@@ -311,6 +312,7 @@ export class VeilHudPanel extends Component {
   private requestedIcons = false;
   private onNewRun: (() => void) | undefined;
   private onRefresh: (() => void) | undefined;
+  private onToggleInventory: (() => void) | undefined;
   private onToggleAchievements: (() => void) | undefined;
   private onLearnSkill: ((skillId: string) => void) | undefined;
   private onEquipItem: ((slot: EquipmentType, equipmentId: string) => void) | undefined;
@@ -322,6 +324,7 @@ export class VeilHudPanel extends Component {
   configure(options: VeilHudPanelOptions): void {
     this.onNewRun = options.onNewRun;
     this.onRefresh = options.onRefresh;
+    this.onToggleInventory = options.onToggleInventory;
     this.onToggleAchievements = options.onToggleAchievements;
     this.onLearnSkill = options.onLearnSkill;
     this.onEquipItem = options.onEquipItem;
@@ -602,6 +605,7 @@ export class VeilHudPanel extends Component {
     const chromeActions: Array<{ nodeName: string; debugLabel: string; callback: (() => void) | null }> = [
       { nodeName: "HudNewRun", debugLabel: "new-run", callback: this.onNewRun ?? null },
       { nodeName: "HudRefresh", debugLabel: "refresh", callback: this.onRefresh ?? null },
+      { nodeName: "HudInventory", debugLabel: "inventory", callback: this.onToggleInventory ?? null },
       { nodeName: "HudAchievements", debugLabel: "achievements", callback: this.onToggleAchievements ?? null },
       { nodeName: "HudEndDay", debugLabel: "end-day", callback: this.onEndDay ?? null },
       { nodeName: "HudReturnLobby", debugLabel: "return-lobby", callback: this.onReturnLobby ?? null }
@@ -1460,6 +1464,7 @@ export class VeilHudPanel extends Component {
 
     this.ensureActionButton(actionsNode, "HudNewRun", "新开一局");
     this.ensureActionButton(actionsNode, "HudRefresh", "刷新状态");
+    this.ensureActionButton(actionsNode, "HudInventory", "装备背包");
     this.ensureActionButton(actionsNode, "HudAchievements", "战报中心");
     this.ensureActionButton(actionsNode, "HudEndDay", "推进一天");
     this.ensureActionButton(actionsNode, "HudReturnLobby", "返回大厅");
@@ -1474,12 +1479,13 @@ export class VeilHudPanel extends Component {
     }
 
     const actionsTransform = actionsNode.getComponent(UITransform) ?? actionsNode.addComponent(UITransform);
-    actionsTransform.setContentSize(Math.max(164, transform.width - 28), 176);
+    actionsTransform.setContentSize(Math.max(164, transform.width - 28), 206);
     actionsNode.setPosition(0, transform.height / 2 - 118, 1);
 
     const buttons: HudActionButtonState[] = [
       { name: "HudNewRun", label: "新开一局", callback: this.onNewRun ?? null },
       { name: "HudRefresh", label: "刷新状态", callback: this.onRefresh ?? null },
+      { name: "HudInventory", label: "装备背包", callback: this.onToggleInventory ?? null },
       { name: "HudAchievements", label: "战报中心", callback: this.onToggleAchievements ?? null },
       { name: "HudEndDay", label: "推进一天", callback: this.onEndDay ?? null },
       { name: "HudReturnLobby", label: "返回大厅", callback: this.onReturnLobby ?? null }
@@ -1506,8 +1512,10 @@ export class VeilHudPanel extends Component {
           : index === 1
             ? new Color(51, 70, 99, 228)
             : index === 2
-              ? new Color(73, 88, 62, 230)
+              ? new Color(76, 98, 72, 232)
               : index === 3
+              ? new Color(73, 88, 62, 230)
+              : index === 4
               ? new Color(92, 86, 54, 232)
               : new Color(121, 84, 70, 234);
       graphics.strokeColor =
@@ -1516,15 +1524,22 @@ export class VeilHudPanel extends Component {
           : index === 1
             ? new Color(218, 229, 242, 112)
             : index === 2
-              ? new Color(224, 240, 199, 108)
+              ? new Color(224, 240, 214, 108)
               : index === 3
+              ? new Color(224, 240, 199, 108)
+              : index === 4
               ? new Color(242, 224, 171, 120)
               : new Color(244, 225, 213, 116);
       graphics.lineWidth = 2;
       graphics.roundRect(-buttonWidth / 2, -buttonHeight / 2, buttonWidth, buttonHeight, 10);
       graphics.fill();
       graphics.stroke();
-      graphics.fillColor = new Color(255, 255, 255, index === 0 ? 22 : index === 1 ? 14 : index === 2 ? 16 : index === 3 ? 18 : 16);
+      graphics.fillColor = new Color(
+        255,
+        255,
+        255,
+        index === 0 ? 22 : index === 1 ? 14 : index === 2 ? 16 : index === 3 ? 16 : index === 4 ? 18 : 16
+      );
       graphics.roundRect(-buttonWidth / 2 + 12, buttonHeight / 2 - 9, buttonWidth - 24, 3, 2);
       graphics.fill();
 

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -102,6 +102,7 @@ import {
 } from "./cocos-session-launch.ts";
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
 import { VeilProgressionPanel } from "./VeilProgressionPanel.ts";
+import { VeilEquipmentPanel } from "./VeilEquipmentPanel.ts";
 import { formatEquipmentActionReason, formatEquipmentSlotLabel } from "./cocos-hero-equipment.ts";
 import { type CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
 import { createCocosBattlePresentationController } from "./cocos-battle-presentation-controller.ts";
@@ -133,6 +134,7 @@ const BATTLE_NODE_NAME = "ProjectVeilBattlePanel";
 const TIMELINE_NODE_NAME = "ProjectVeilTimelinePanel";
 const LOBBY_NODE_NAME = "ProjectVeilLobbyPanel";
 const ACCOUNT_REVIEW_PANEL_NODE_NAME = "ProjectVeilAccountReviewPanel";
+const EQUIPMENT_PANEL_NODE_NAME = "ProjectVeilEquipmentPanel";
 const DEFAULT_MAP_WIDTH_TILES = 8;
 const DEFAULT_MAP_HEIGHT_TILES = 8;
 const BATTLE_FEEDBACK_DURATION_MS = 2600;
@@ -255,6 +257,8 @@ export class VeilRoot extends Component {
   private gameplayAccountRefreshInFlight = false;
   private gameplayAccountReviewPanel: VeilProgressionPanel | null = null;
   private gameplayAccountReviewPanelOpen = false;
+  private gameplayEquipmentPanel: VeilEquipmentPanel | null = null;
+  private gameplayEquipmentPanelOpen = false;
   private activeAccountFlow: CocosAccountLifecycleKind | null = null;
   private registrationDisplayName = "";
   private registrationToken = "";
@@ -699,6 +703,9 @@ export class VeilRoot extends Component {
       onRefresh: () => {
         void this.refreshSnapshot();
       },
+      onToggleInventory: () => {
+        this.toggleGameplayEquipmentPanel();
+      },
       onToggleAchievements: () => {
         void this.openGameplayBattleReportCenter();
       },
@@ -899,6 +906,28 @@ export class VeilRoot extends Component {
       }
     });
 
+    let equipmentPanelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
+    if (!equipmentPanelNode) {
+      equipmentPanelNode = new Node(EQUIPMENT_PANEL_NODE_NAME);
+      equipmentPanelNode.parent = this.node;
+    }
+    assignUiLayer(equipmentPanelNode);
+    const equipmentPanelTransform = equipmentPanelNode.getComponent(UITransform) ?? equipmentPanelNode.addComponent(UITransform);
+    equipmentPanelTransform.setContentSize(Math.max(360, Math.min(460, visibleSize.width - 56)), Math.max(420, visibleSize.height - 96));
+    this.gameplayEquipmentPanel =
+      equipmentPanelNode.getComponent(VeilEquipmentPanel) ?? equipmentPanelNode.addComponent(VeilEquipmentPanel);
+    this.gameplayEquipmentPanel.configure({
+      onClose: () => {
+        this.toggleGameplayEquipmentPanel(false);
+      },
+      onEquipItem: (slot, equipmentId) => {
+        void this.equipHeroItem(slot, equipmentId);
+      },
+      onUnequipItem: (slot) => {
+        void this.unequipHeroItem(slot);
+      }
+    });
+
     this.battleTransition = this.node.getComponent(VeilBattleTransition) ?? this.node.addComponent(VeilBattleTransition);
     this.updateLayout();
   }
@@ -959,6 +988,7 @@ export class VeilRoot extends Component {
     const battleNode = this.node.getChildByName(BATTLE_NODE_NAME);
     const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
     const accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
+    const equipmentPanelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
     const showingGame = !this.showLobby;
 
     if (lobbyNode) {
@@ -978,6 +1008,9 @@ export class VeilRoot extends Component {
     }
     if (accountReviewPanelNode) {
       accountReviewPanelNode.active = showingGame && this.gameplayAccountReviewPanelOpen;
+    }
+    if (equipmentPanelNode) {
+      equipmentPanelNode.active = showingGame && this.gameplayEquipmentPanelOpen;
     }
 
     if (this.showLobby) {
@@ -1059,7 +1092,30 @@ export class VeilRoot extends Component {
     this.timelinePanel?.render({
       entries: this.timelineEntries
     });
+    this.renderGameplayEquipmentPanel();
     this.renderGameplayAccountReviewPanel();
+  }
+
+  private renderGameplayEquipmentPanel(): void {
+    const panelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
+    if (!panelNode) {
+      return;
+    }
+
+    if (!this.gameplayEquipmentPanelOpen) {
+      panelNode.active = false;
+      return;
+    }
+
+    panelNode.active = true;
+    this.gameplayEquipmentPanel?.render({
+      hero: this.activeHero(),
+      recentEventLog: this.lobbyAccountProfile.recentEventLog,
+      recentSessionEvents: (this.lastUpdate?.events ?? []).filter(
+        (event): event is Extract<NonNullable<SessionUpdate["events"]>[number], { type: "hero.equipmentFound" }> =>
+          event.type === "hero.equipmentFound"
+      )
+    });
   }
 
   private renderGameplayAccountReviewPanel(): void {
@@ -1276,6 +1332,11 @@ export class VeilRoot extends Component {
     await this.refreshActiveAccountReviewSection();
   }
 
+  private toggleGameplayEquipmentPanel(forceOpen?: boolean): void {
+    this.gameplayEquipmentPanelOpen = forceOpen ?? !this.gameplayEquipmentPanelOpen;
+    this.renderView();
+  }
+
   private async openGameplayBattleReportCenter(): Promise<void> {
     this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
       type: "section.selected",
@@ -1445,6 +1506,7 @@ export class VeilRoot extends Component {
     const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
     const lobbyNode = this.node.getChildByName(LOBBY_NODE_NAME);
     const accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
+    const equipmentPanelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
 
     this.mapBoard?.configure({
       tileSize: effectiveTileSize,
@@ -1467,6 +1529,9 @@ export class VeilRoot extends Component {
         },
         onRefresh: () => {
           void this.refreshSnapshot();
+        },
+        onToggleInventory: () => {
+          this.toggleGameplayEquipmentPanel();
         },
         onToggleAchievements: () => {
           void this.openGameplayBattleReportCenter();
@@ -1527,6 +1592,13 @@ export class VeilRoot extends Component {
         accountReviewPanelNode.getComponent(UITransform) ?? accountReviewPanelNode.addComponent(UITransform);
       accountReviewTransform.setContentSize(Math.max(320, Math.min(420, visibleSize.width - 56)), Math.max(360, visibleSize.height - 96));
       accountReviewPanelNode.setPosition(0, 0, 4);
+    }
+
+    if (equipmentPanelNode) {
+      const equipmentPanelTransform =
+        equipmentPanelNode.getComponent(UITransform) ?? equipmentPanelNode.addComponent(UITransform);
+      equipmentPanelTransform.setContentSize(Math.max(360, Math.min(460, visibleSize.width - 56)), Math.max(420, visibleSize.height - 96));
+      equipmentPanelNode.setPosition(0, 0, 4);
     }
   }
 
@@ -2289,6 +2361,7 @@ export class VeilRoot extends Component {
     await this.disposeCurrentSession();
     this.resetSessionViewport("已返回 Cocos Lobby。");
     this.gameplayAccountReviewPanelOpen = false;
+    this.gameplayEquipmentPanelOpen = false;
     this.showLobby = true;
     this.syncWechatShareBridge();
     this.lobbyStatus = "已返回大厅，可继续选房或创建新实例。";

--- a/apps/cocos-client/test/cocos-equipment-panel.test.ts
+++ b/apps/cocos-client/test/cocos-equipment-panel.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VeilEquipmentPanel } from "../assets/scripts/VeilEquipmentPanel.ts";
+import { createLobbyPanelTestAccount } from "../assets/scripts/cocos-lobby-panel-model.ts";
+import { createComponentHarness, findNode, pressNode, readCardLabel } from "./helpers/cocos-panel-harness.ts";
+import { createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
+
+test("VeilEquipmentPanel renders loadout, inventory, and recent loot in a dedicated panel", () => {
+  const { component, node } = createComponentHarness(VeilEquipmentPanel, {
+    name: "EquipmentPanelRoot",
+    width: 420,
+    height: 520
+  });
+  const update = createSessionUpdate();
+  const hero = update.world.ownHeroes[0]!;
+  hero.name = "凯琳";
+  hero.loadout.equipment.weaponId = "vanguard_blade";
+  hero.loadout.inventory = ["militia_pike", "scout_compass"];
+
+  component.render({
+    hero,
+    recentEventLog: [
+      {
+        ...createLobbyPanelTestAccount().recentEventLog[0]!,
+        id: "loot-1",
+        description: "凯琳 在战斗后获得了稀有装备 斥候罗盘。",
+        worldEventType: "hero.equipmentFound",
+        heroId: "hero-1"
+      }
+    ]
+  });
+
+  assert.match(readCardLabel(node, "EquipmentPanelHeader"), /凯琳 的装备背包/);
+  assert.match(readCardLabel(node, "EquipmentPanelLoadout"), /武器 先锋战刃/);
+  assert.match(readCardLabel(node, "EquipmentPanelInventory"), /背包 2\/6 件/);
+  assert.match(readCardLabel(node, "EquipmentPanelLoot"), /战利品 最近 1 条/);
+});
+
+test("VeilEquipmentPanel routes close and equip actions through rendered buttons", () => {
+  const { component, node } = createComponentHarness(VeilEquipmentPanel, {
+    name: "EquipmentPanelRoot",
+    width: 420,
+    height: 520
+  });
+  const update = createSessionUpdate();
+  update.world.ownHeroes[0]!.loadout.inventory = ["militia_pike"];
+  let closed = 0;
+  let equipped: { slot: string; equipmentId: string } | null = null;
+
+  component.configure({
+    onClose: () => {
+      closed += 1;
+    },
+    onEquipItem: (slot, equipmentId) => {
+      equipped = { slot, equipmentId };
+    }
+  });
+  component.render({
+    hero: update.world.ownHeroes[0]!,
+    recentEventLog: []
+  });
+
+  pressNode(findNode(node, "EquipmentPanelAction-weapon-militia_pike"));
+  pressNode(findNode(node, "EquipmentPanelClose"));
+
+  assert.deepEqual(equipped, {
+    slot: "weapon",
+    equipmentId: "militia_pike"
+  });
+  assert.equal(closed, 1);
+});

--- a/apps/cocos-client/test/cocos-hud-panel.test.ts
+++ b/apps/cocos-client/test/cocos-hud-panel.test.ts
@@ -118,6 +118,27 @@ test("VeilHudPanel dispatchPointerUp routes equipment button presses through the
   });
 });
 
+test("VeilHudPanel dispatchPointerUp routes the inventory chrome button", () => {
+  const { component, node } = createComponentHarness(VeilHudPanel, { name: "HudPanelRoot", width: 320, height: 720 });
+  const state = createHudState();
+  let opened = 0;
+
+  component.configure({
+    onToggleInventory: () => {
+      opened += 1;
+    }
+  });
+  component.render(state);
+
+  const button = findNode(node, "HudInventory");
+  assert.ok(button);
+  const buttonCenter = toHudLocalPosition(node, button);
+  const action = component.dispatchPointerUp(buttonCenter.x, buttonCenter.y);
+
+  assert.equal(action, "inventory");
+  assert.equal(opened, 1);
+});
+
 test("VeilHudPanel surfaces reconnect, replay, resync, and degraded session indicators in the status card", () => {
   const { component, node } = createComponentHarness(VeilHudPanel, { name: "HudPanelRoot", width: 320, height: 720 });
   const state = createHudState();

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -224,6 +224,16 @@ test("VeilRoot wires the equipment loot loop through equip and unequip session u
   ]);
 });
 
+test("VeilRoot toggles a dedicated gameplay equipment panel from the HUD flow", () => {
+  const root = createVeilRootHarness();
+
+  assert.equal(root.gameplayEquipmentPanelOpen, false);
+  root.toggleGameplayEquipmentPanel();
+  assert.equal(root.gameplayEquipmentPanelOpen, true);
+  root.toggleGameplayEquipmentPanel(false);
+  assert.equal(root.gameplayEquipmentPanelOpen, false);
+});
+
 test("VeilRoot emits primary-client telemetry for progression, inventory, and combat checkpoints", async () => {
   const root = createVeilRootHarness();
   root.roomId = "room-telemetry";

--- a/docs/cocos-equipment-loot-validation.md
+++ b/docs/cocos-equipment-loot-validation.md
@@ -8,7 +8,7 @@
 - Cocos session layer: `apps/cocos-client/assets/scripts/VeilCocosSession.ts` already sends `hero.equip` / `hero.unequip` requests and caches the returned `SessionUpdate`.
 - Cocos prediction/HUD layer: `apps/cocos-client/assets/scripts/cocos-prediction.ts`, `apps/cocos-client/assets/scripts/cocos-hero-equipment.ts`, and `apps/cocos-client/assets/scripts/VeilHudPanel.ts` present hero loadout state, grouped inventory choices, recent loot, and visible stat changes inside the primary runtime.
 
-## Implemented Slice For #503
+## Implemented Slice For #602
 
 - HUD `装备配置` card now shows:
   - current slot occupancy for weapon / armor / accessory
@@ -18,6 +18,10 @@
   - current backpack occupancy against the fixed 6-slot equipment inventory cap
   - a full-bag warning before the next equipment pickup would overflow
   - recent loot lines from the Cocos-visible account event log
+- Primary client `装备背包` panel now provides a dedicated runtime surface for the same loop:
+  - open it from the left HUD chrome without leaving the main scene
+  - inspect equipped slots, grouped backpack contents, and recent loot in one place
+  - execute equip / unequip actions from the panel and reuse the existing prediction plus authoritative reconciliation path
 - Existing equip/unequip buttons remain the interaction surface and continue to drive prediction plus server reconciliation.
 - The hero summary card now renders equipment-adjusted totals from shared progression math, so stat changes are visible during prediction and after reconciliation instead of only after a secondary refresh path.
 - Recent loot rows now merge the latest authoritative session loot events with the persisted account event log, so battle drops and overflowed pickups stay visible immediately after combat even before account-history refresh finishes.
@@ -34,14 +38,14 @@
 2. Open `apps/cocos-client` in Cocos Creator 3.8.x and preview a scene with `VeilRoot`.
 3. Enter a room and move until you trigger at least one neutral battle.
 4. Win a battle that grants equipment.
-5. Confirm the HUD `装备配置` card shows a `战利品` section with the new drop.
-6. Confirm the same card shows the item in the `背包` list with rarity and stat summary.
+5. Click `装备背包` in the left HUD chrome and confirm the dedicated panel opens.
+6. Confirm the panel `最近战利品` section shows the new drop and the `背包清单` section shows the item with rarity and stat summary.
 7. Fill the inventory to 6 items and trigger another equipment drop.
-8. Confirm the HUD and event log clearly state the backpack was full and the overflowed drop was not picked up.
+8. Confirm the panel, HUD, and event log clearly state the backpack was full and the overflowed drop was not picked up.
 9. While the backpack is full, try to unequip an item and confirm the action is rejected with a full-inventory message.
-10. Free one slot, then click an equipment action button in the same card.
+10. Free one slot, then click an equip action button inside the `装备背包` panel.
 11. Confirm the hero stat lines in the HUD update immediately after prediction/reconciliation.
-12. Click the matching unequip action and confirm the item returns to inventory and the stat gain line rolls back.
+12. Click the matching unequip action in the same panel and confirm the item returns to inventory and the stat gain line rolls back.
 
 ## Temporary Assumptions
 


### PR DESCRIPTION
## Summary
- add a dedicated equipment inventory panel to the Cocos primary client and expose it from the HUD chrome
- reuse the existing equip/unequip + loot formatting pipeline so immediate stat refresh and loot visibility stay in sync
- cover the panel and HUD/root toggle flow with deterministic Cocos tests and update local validation docs

## Testing
- node --import tsx --test ./apps/cocos-client/test/cocos-equipment-panel.test.ts ./apps/cocos-client/test/cocos-hud-panel.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts
- npm run typecheck:cocos

fixes #602