### PR TITLE
docs: add GPT GitHub issue fallback for issue 608

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ProjectVeil issue intake fallback runbook
+    url: https://github.com/dannagrace/ProjectVeil/blob/main/docs/github-issue-intake-fallback.md
+    about: Use this runbook when Claude is unavailable and GPT needs to create the issue directly with gh.

--- a/.github/ISSUE_TEMPLATE/projectveil-ops-intake.md
+++ b/.github/ISSUE_TEMPLATE/projectveil-ops-intake.md
@@ -1,0 +1,30 @@
+---
+name: ProjectVeil Ops Intake
+about: Create a ProjectVeil issue with the minimum required operational context.
+title: "ops: "
+labels: ""
+assignees: ""
+---
+
+## Summary
+<!-- One or two sentences describing the problem or requested work. -->
+
+## Problem
+<!-- What is blocked, broken, or missing right now? -->
+
+## Proposed change
+- 
+
+## Acceptance criteria
+- 
+
+## Context
+- Trigger or request source:
+- Affected area:
+- Environment or branch:
+- Evidence or links:
+
+## Fallback / operator notes
+<!-- Note whether Claude was unavailable and whether GPT created this issue directly. -->
+- Claude availability:
+- Created by:

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ npm run dev:client:h5
 - 多人同步治理矩阵说明：`docs/sync-governance-matrix.md`
 - 共享 contract 快照说明：`docs/shared-contract-snapshots.md`
 - Codex automation 分支审计与清理 runbook：`docs/codex-automation-branch-maintenance.md`
+- GitHub issue intake fallback runbook：`docs/github-issue-intake-fallback.md`
 - 当前 H5 调试壳仍支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。
 - 当前 H5 联机体验已支持：客户端预测、断线自动重连、刷新后本地快照首帧回放，再由权威房间状态收敛。
 - 当前 Cocos Creator 主客户端已补齐：

--- a/docs/github-issue-intake-fallback.md
+++ b/docs/github-issue-intake-fallback.md
@@ -1,0 +1,93 @@
+# GitHub Issue Intake Fallback Runbook
+
+Use this runbook when the normal Claude-led issue creation or routing flow is unavailable or degraded, but issue intake still needs to continue in `dannagrace/ProjectVeil`.
+
+The fallback path is intentionally simple:
+
+- GPT creates the GitHub issue directly with `gh issue create`
+- the issue body follows the repo's `ProjectVeil Ops Intake` template
+- the issue explicitly records that Claude was unavailable so the fallback is auditable later
+
+## When To Use It
+
+Use this runbook when any of the following is true:
+
+- Claude cannot create or route the issue
+- Claude is degraded enough that issue intake is blocked
+- the team needs to continue issue intake immediately and GPT is available
+
+Do not wait for Claude recovery if the work is otherwise ready to be captured as a GitHub issue.
+
+## Required Intake Fields
+
+Every fallback-created issue must preserve the same minimum metadata:
+
+- `Summary`: one or two sentences stating the request or defect
+- `Problem`: the current blocker, gap, or failure mode
+- `Proposed change`: the smallest credible change set to resolve the problem
+- `Acceptance criteria`: concrete checks that define done
+- `Context`: trigger source, affected area, environment or branch, and links/evidence when available
+- `Fallback / operator notes`: whether Claude was unavailable and whether GPT created the issue directly
+
+If any field is unknown, write `unknown` rather than omitting it.
+
+## GPT Fallback Workflow
+
+1. Confirm the repository and auth context:
+
+```bash
+git remote get-url origin
+gh auth status
+```
+
+2. Start from the repo template so the body structure stays consistent:
+
+```bash
+gh issue create --template "ProjectVeil Ops Intake"
+```
+
+3. If GPT is creating the issue non-interactively, provide the title and body directly with the same headings as the template:
+
+```bash
+gh issue create \
+  --title "ops: <short issue title>" \
+  --body "$(cat <<'EOF'
+## Summary
+<one or two sentence summary>
+
+## Problem
+<what is blocked, broken, or missing>
+
+## Proposed change
+- <smallest credible change>
+
+## Acceptance criteria
+- <observable done condition>
+
+## Context
+- Trigger or request source: <source>
+- Affected area: <area>
+- Environment or branch: <branch or environment>
+- Evidence or links: <links or unknown>
+
+## Fallback / operator notes
+- Claude availability: unavailable | degraded | unknown
+- Created by: GPT direct fallback via gh
+EOF
+)"
+```
+
+4. Verify the posted issue still contains all required headings before treating intake as complete.
+
+## Quality Bar
+
+The fallback issue should be as actionable as the primary Claude path:
+
+- title is specific enough to triage without opening the full thread
+- acceptance criteria are testable
+- evidence links are attached when they exist
+- the fallback note makes it clear why GPT created the issue directly
+
+## Recovery Back To The Primary Path
+
+When Claude is healthy again, no issue rewrite is required. Continue using the primary flow for new intake, and only edit a fallback-created issue if important context was missing at creation time.


### PR DESCRIPTION
## Summary
- add a repo-native `ProjectVeil Ops Intake` issue template for structured issue creation
- add a fallback runbook that documents how GPT should create issues directly with `gh issue create` when Claude is unavailable
- add a README pointer so operators can find the fallback path quickly

## Validation
- `git diff --check`
- `gh auth status`
- `git remote get-url origin`
- `test -f docs/github-issue-intake-fallback.md && test -f .github/ISSUE_TEMPLATE/projectveil-ops-intake.md && test -f .github/ISSUE_TEMPLATE/config.yml && rg -n "github-issue-intake-fallback.md|ProjectVeil Ops Intake|GPT direct fallback via gh" README.md docs/github-issue-intake-fallback.md .github/ISSUE_TEMPLATE/projectveil-ops-intake.md .github/ISSUE_TEMPLATE/config.yml`

Closes #608.
