### PR TITLE
ops: add fallback issue-intake smoke checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ npm run dev:client:h5
 - 共享 contract 快照说明：`docs/shared-contract-snapshots.md`
 - Codex automation 分支审计与清理 runbook：`docs/codex-automation-branch-maintenance.md`
 - GitHub issue intake fallback runbook：`docs/github-issue-intake-fallback.md`
+- GitHub issue intake fallback smoke checklist：`docs/github-issue-intake-fallback-smoke-checklist.md`
 - 当前 H5 调试壳仍支持：地图点击移动、可达格高亮、悬停路径预览、资源/明雷信息提示、轻量路径播放反馈、可视化战斗单位面板、目标选中、伤害飘字与战后结果弹窗。
 - 当前 H5 联机体验已支持：客户端预测、断线自动重连、刷新后本地快照首帧回放，再由权威房间状态收敛。
 - 当前 Cocos Creator 主客户端已补齐：

--- a/docs/github-issue-intake-fallback-smoke-checklist.md
+++ b/docs/github-issue-intake-fallback-smoke-checklist.md
@@ -1,0 +1,43 @@
+# GitHub Issue Intake Fallback Smoke Checklist
+
+Use this checklist during a model outage or a scheduled drill to prove GitHub issue intake still works when the primary Claude-led path is unavailable.
+
+Run the checklist against `dannagrace/ProjectVeil` and record the resulting issue URL in the incident log, drill notes, or handoff thread.
+
+## Preconditions
+
+- `gh auth status` succeeds for the operator who will create the issue
+- the operator can reach `dannagrace/ProjectVeil`
+- the repo's `ProjectVeil Ops Intake` template is still available in GitHub
+- the operator has a short outage or drill note to link from the test issue body, or can record `unknown`
+
+## Smoke Steps
+
+- [ ] Confirm the fallback trigger is explicit: Claude is `unavailable`, `degraded`, or the drill is intentionally simulating that condition.
+- [ ] Create a test issue with `gh issue create` using the `ProjectVeil Ops Intake` template or an equivalent non-interactive body with the same headings.
+- [ ] Use a title that clearly marks the issue as fallback verification, for example `ops: fallback intake smoke check <YYYY-MM-DD>`.
+- [ ] Verify the posted issue contains all required sections: `Summary`, `Problem`, `Proposed change`, `Acceptance criteria`, `Context`, and `Fallback / operator notes`.
+- [ ] Verify the body records fallback provenance: Claude availability state and that GPT or the operator created the issue directly through the fallback path.
+- [ ] Verify the issue includes enough metadata to triage without reopening the source chat:
+  - summary describes the outage or drill purpose
+  - problem states why the primary intake path was bypassed
+  - proposed change states the fallback verification action that was taken
+  - acceptance criteria describe what a successful fallback issue proves
+  - context includes the trigger source, affected area, environment or branch, and an evidence link or `unknown`
+- [ ] Verify the issue lands in the correct repository with the expected title prefix and no missing required headings.
+- [ ] Add or confirm the follow-up routing note in the issue body or first comment:
+  - whether the issue should remain open for tracking
+  - whether it should be closed after the drill
+  - who owns follow-up once the primary path recovers
+- [ ] If the smoke issue is only a drill artifact, close it with a short comment linking back to the outage or drill record.
+
+## Expected Outcome
+
+The smoke check passes when all of the following are true:
+
+- a fallback issue can be created without Claude
+- the issue preserves the minimum intake metadata quality bar
+- the fallback reason is auditable later
+- follow-up ownership or closure routing is explicit
+
+If any item fails, treat the fallback path as degraded and update the runbook before the next drill or outage.

--- a/docs/github-issue-intake-fallback.md
+++ b/docs/github-issue-intake-fallback.md
@@ -2,6 +2,8 @@
 
 Use this runbook when the normal Claude-led issue creation or routing flow is unavailable or degraded, but issue intake still needs to continue in `dannagrace/ProjectVeil`.
 
+For outage drills or live verification, use the companion checklist in [GitHub Issue Intake Fallback Smoke Checklist](./github-issue-intake-fallback-smoke-checklist.md).
+
 The fallback path is intentionally simple:
 
 - GPT creates the GitHub issue directly with `gh issue create`
@@ -78,6 +80,14 @@ EOF
 ```
 
 4. Verify the posted issue still contains all required headings before treating intake as complete.
+
+## Smoke Verification Checklist
+
+When the team needs to prove the fallback path still works end to end, run [GitHub Issue Intake Fallback Smoke Checklist](./github-issue-intake-fallback-smoke-checklist.md). The checklist is intentionally small and focuses on three things:
+
+- issue creation succeeds without Claude
+- the resulting issue preserves the required metadata quality bar
+- follow-up routing is explicit for drills and real outages
 
 ## Quality Bar
 


### PR DESCRIPTION
## Summary
- add a dedicated smoke checklist for GitHub issue-intake fallback drills and outages
- link the checklist from the existing fallback runbook and README docs index
- keep the change docs-only and scoped to fallback verification expectations

## Testing
- verified the new and updated Markdown paths and references locally with  and 

Closes #610