### PR TITLE
Align release reporting reviewer markdown contract

### DIFF
--- a/scripts/release-health-summary.ts
+++ b/scripts/release-health-summary.ts
@@ -8,6 +8,7 @@ import {
   formatReadinessTrendNoBaselineSummary,
   formatReadinessTrendRegressionSummary,
   formatReadinessTrendUnchangedUnreadySummary,
+  renderReviewerFacingMarkdownEntry,
   type ReadinessDecision
 } from "./release-reporting-contract.ts";
 
@@ -1266,11 +1267,13 @@ export function renderMarkdown(report: ReleaseHealthSummaryReport): string {
     lines.push("- None.");
   } else {
     for (const entry of report.triage.blockers) {
-      lines.push(`- **${entry.title}**: ${entry.summary}`);
-      lines.push(`  Next step: ${entry.nextStep}`);
-      if (entry.artifacts.length > 0) {
-        lines.push(`  Artifacts: ${entry.artifacts.map((artifact) => `\`${toDisplayPath(artifact.path)}\``).join(", ")}`);
-      }
+      lines.push(
+        ...renderReviewerFacingMarkdownEntry(entry.title, entry.summary, {
+          nextStep: entry.nextStep,
+          artifacts: entry.artifacts,
+          toDisplayPath
+        })
+      );
     }
   }
   lines.push("");
@@ -1280,11 +1283,13 @@ export function renderMarkdown(report: ReleaseHealthSummaryReport): string {
     lines.push("- None.");
   } else {
     for (const entry of report.triage.warnings) {
-      lines.push(`- **${entry.title}**: ${entry.summary}`);
-      lines.push(`  Next step: ${entry.nextStep}`);
-      if (entry.artifacts.length > 0) {
-        lines.push(`  Artifacts: ${entry.artifacts.map((artifact) => `\`${toDisplayPath(artifact.path)}\``).join(", ")}`);
-      }
+      lines.push(
+        ...renderReviewerFacingMarkdownEntry(entry.title, entry.summary, {
+          nextStep: entry.nextStep,
+          artifacts: entry.artifacts,
+          toDisplayPath
+        })
+      );
     }
   }
   lines.push("");

--- a/scripts/release-reporting-contract.ts
+++ b/scripts/release-reporting-contract.ts
@@ -15,6 +15,10 @@ export interface ReviewerFacingTriageEntry {
   nextStep: string;
 }
 
+export interface ReviewerFacingArtifact {
+  path: string;
+}
+
 export function formatReadinessTrendNoBaselineSummary(currentCandidate: string, currentDecision: ReadinessDecision): string {
   return `No previous candidate dashboard was available; current candidate ${currentCandidate} is ${currentDecision}.`;
 }
@@ -52,13 +56,34 @@ export function renderPrCommentHealthSignal(
   signal: ReviewerFacingSignal,
   triageEntry?: ReviewerFacingTriageEntry
 ): string[] {
-  const statusLabel = signal.status.toUpperCase();
   const firstDetail = signal.details.find((detail) => detail.trim().length > 0);
   const summary = triageEntry?.summary ?? firstDetail ?? signal.summary;
-  const lines = [`- **${signal.label}**: \`${statusLabel}\` ${summary}`];
+  return renderReviewerFacingMarkdownEntry(signal.label, summary, {
+    status: signal.status,
+    nextStep: triageEntry?.nextStep
+  });
+}
 
-  if (triageEntry) {
-    lines.push(`  Next step: ${triageEntry.nextStep}`);
+export function renderReviewerFacingMarkdownEntry(
+  label: string,
+  summary: string,
+  options?: {
+    status?: ReviewerSignalStatus;
+    nextStep?: string;
+    artifacts?: ReviewerFacingArtifact[];
+    toDisplayPath?: (filePath: string) => string;
+  }
+): string[] {
+  const statusLabel = options?.status ? `\`${options.status.toUpperCase()}\` ` : "";
+  const lines = [`- **${label}**: ${statusLabel}${summary}`];
+
+  if (options?.nextStep) {
+    lines.push(`  Next step: ${options.nextStep}`);
+  }
+
+  if (options?.artifacts && options.artifacts.length > 0) {
+    const toDisplayPath = options.toDisplayPath ?? ((filePath: string) => filePath);
+    lines.push(`  Artifacts: ${options.artifacts.map((artifact) => `\`${toDisplayPath(artifact.path)}\``).join(", ")}`);
   }
 
   return lines;

--- a/scripts/test/release-health-summary.test.ts
+++ b/scripts/test/release-health-summary.test.ts
@@ -468,7 +468,10 @@ test("buildReleaseHealthSummaryReport reports candidate readiness trend regressi
     report.findings.filter((finding) => finding.signalId === "readiness-trend").map((finding) => finding.summary),
     ["Candidate readiness regressed from ready at prev9876 to blocked at cur1234."]
   );
-  assert.match(renderMarkdown(report), /Candidate readiness regressed from ready at prev9876 to blocked at cur1234\./);
+  assert.match(
+    renderMarkdown(report),
+    /- \*\*Candidate readiness trend\*\*: Candidate readiness regressed from ready at prev9876 to blocked at cur1234\.\n  Next step: Open `.*release-readiness-dashboard\.json` and `.*release-readiness-dashboard\.json` to compare the candidate blockers or pending checks before advancing the next revision\.\n  Artifacts: `.*release-readiness-dashboard\.json`, `.*release-readiness-dashboard\.json`/
+  );
 });
 
 test("resolveInputPaths discovers the latest local artifacts", () => {

--- a/scripts/test/release-pr-comment.test.ts
+++ b/scripts/test/release-pr-comment.test.ts
@@ -225,6 +225,12 @@ test("renderPrComment and release-health triage share the same readiness-trend r
   const readinessTriage = report.triage.warnings.find((entry) => entry.signalId === "readiness-trend");
 
   assert.ok(readinessTriage);
-  assert.match(markdown, new RegExp(escapeRegExp(readinessTriage.summary)));
-  assert.match(markdown, new RegExp(escapeRegExp(readinessTriage.nextStep)));
+  assert.match(
+    markdown,
+    new RegExp(
+      escapeRegExp(
+        `- **Candidate readiness trend**: \`WARN\` ${readinessTriage.summary}\n  Next step: ${readinessTriage.nextStep}`
+      )
+    )
+  );
 });

--- a/scripts/test/release-reporting-contract.test.ts
+++ b/scripts/test/release-reporting-contract.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderReviewerFacingMarkdownEntry } from "../release-reporting-contract.ts";
+
+test("renderReviewerFacingMarkdownEntry keeps reviewer-facing markdown lines stable", () => {
+  assert.deepEqual(
+    renderReviewerFacingMarkdownEntry(
+      "Candidate readiness trend",
+      "Candidate readiness regressed from ready at prev9876 to blocked at cur1234.",
+      {
+        status: "warn",
+        nextStep:
+          "Open `artifacts/release-readiness/release-readiness-dashboard.json` and `baseline/release-readiness-dashboard.json` to compare the candidate blockers or pending checks before advancing the next revision.",
+        artifacts: [
+          { path: "/tmp/current/release-readiness-dashboard.json" },
+          { path: "/tmp/baseline/release-readiness-dashboard.json" }
+        ],
+        toDisplayPath: (filePath) => filePath.replace(/^\/tmp\//, "")
+      }
+    ),
+    [
+      "- **Candidate readiness trend**: `WARN` Candidate readiness regressed from ready at prev9876 to blocked at cur1234.",
+      "  Next step: Open `artifacts/release-readiness/release-readiness-dashboard.json` and `baseline/release-readiness-dashboard.json` to compare the candidate blockers or pending checks before advancing the next revision.",
+      "  Artifacts: `current/release-readiness-dashboard.json`, `baseline/release-readiness-dashboard.json`"
+    ]
+  );
+});


### PR DESCRIPTION
## Summary
- centralize the reviewer-facing release-health markdown entry formatter used by release summary output and PR comments
- keep the change limited to the release reporting readiness/triage contract
- add targeted tests to lock the shared markdown semantics

## Testing
- node --import tsx --test ./scripts/test/release-reporting-contract.test.ts ./scripts/test/release-pr-comment.test.ts ./scripts/test/release-health-summary.test.ts ./scripts/test/release-health-summary-cli.test.ts

Closes #609