### PR TITLE
github: add ops readiness issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md
+++ b/.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md
@@ -1,0 +1,34 @@
+---
+name: ProjectVeil Ops Readiness
+about: Create an ops/readiness follow-up issue with current evidence, the observed gap, and the smallest next slice.
+title: "readiness: "
+labels: ""
+assignees: ""
+---
+
+## Summary
+<!-- One or two sentences describing the readiness follow-up. -->
+
+## Current evidence
+- Evidence reviewed:
+- Revision or artifact date:
+- Links:
+
+## Observed gap
+<!-- What operational, release, or readiness gap remains open after reviewing the current evidence? -->
+
+## Owner
+- Team or directly responsible person:
+- Supporting reviewers or operators:
+
+## Smallest next slice
+- 
+
+## Acceptance criteria
+- 
+
+## Context
+- Affected area:
+- Environment or branch:
+- Related issues or docs:
+- Constraints or dependencies:


### PR DESCRIPTION
## Summary
- add a dedicated GitHub issue template for ops/readiness follow-up work
- require current evidence, observed gap, owner, and the smallest next slice

## Verification
- git diff --check

Closes #620