### PR TITLE
ops: add manual release-evidence owner ledger

### DIFF
--- a/.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md
+++ b/.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md
@@ -13,6 +13,7 @@ assignees: ""
 - Evidence reviewed:
 - Revision or artifact date:
 - Links:
+- Manual evidence owner ledger:
 
 ## Observed gap
 <!-- What operational, release, or readiness gap remains open after reviewing the current evidence? -->

--- a/docs/release-evidence/manual-release-evidence-owner-ledger.template.md
+++ b/docs/release-evidence/manual-release-evidence-owner-ledger.template.md
@@ -1,0 +1,38 @@
+# Manual Release Evidence Owner Ledger
+
+Use this ledger when one candidate still depends on manual release evidence that lives across multiple JSON artifacts, checklist files, or sign-off notes.
+
+Create one copy per candidate under `artifacts/release-readiness/` or attach the same table to the release PR. Keep it lightweight: the goal is to show, in one place, which manual sign-offs are still missing, who owns them, and which artifact proves completion.
+
+## Candidate
+
+- Candidate: `rc-YYYY-MM-DD`
+- Target revision: `<git-sha>`
+- Release owner: `<name>`
+- Last updated: `<YYYY-MM-DDTHH:MM:SSZ>`
+- Linked readiness snapshot: `artifacts/release-readiness/<snapshot>.json`
+
+## Ledger
+
+| Evidence item | Area | Owner | Status | Target revision | Recorded at | Artifact path / link | Follow-up status | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `runtime-observability-signoff` | Runtime health | `oncall-ops` | `pending` | `abc123def456` | `pending` | `artifacts/wechat-release/runtime-observability-signoff.json` | Capture `/api/runtime/*` evidence before release call. | Same environment as the packaged candidate. |
+| `wechat-device-runtime-review` | WeChat validation | `qa-release` | `pending` | `abc123def456` | `pending` | `artifacts/wechat-release/device-runtime-review.json` | `Waiting on device smoke slot for this candidate.` | Attach smoke report plus supporting screenshots or recordings. |
+| `cocos-rc-checklist-review` | RC checklist / blockers | `release-owner` | `passed` | `abc123def456` | `2026-04-02T09:40:00Z` | `artifacts/release-readiness/cocos-rc-checklist-rc-2026-04-02-abc123d.md` | `No follow-up.` | Blocker register reviewed with `none` open. |
+| `presentation-signoff` | Presentation review | `client-lead` | `hold` | `abc123def456` | `2026-04-02T09:55:00Z` | `docs/cocos-phase1-presentation-signoff.md` | `Refresh world-map capture after fallback UI fix.` | Keep this row only when presentation review applies to the candidate. |
+
+## Rules
+
+- Keep one row per required manual evidence item for the candidate.
+- `Status` should stay within `pending | passed | hold | ship-with-followups | not_applicable`.
+- `Target revision` must match the candidate revision recorded in the readiness snapshot, WeChat manual-review JSON, and any RC checklist or sign-off artifact.
+- `Recorded at` stays `pending` until the linked artifact exists; once complete, replace it with the artifact timestamp.
+- `Artifact path / link` should point at the exact JSON, Markdown, PR comment, or checklist file used during the release call.
+- `Follow-up status` should answer the operational question directly: what is waiting, who is blocked, or why the item is allowed to ship with follow-ups.
+
+## Minimal Operating Flow
+
+1. Copy this template for the current candidate.
+2. Pre-fill one row for each manual check that is still required.
+3. Update the row as soon as the sign-off artifact lands.
+4. Treat the candidate as incomplete while any required row remains `pending` or `hold`.

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -49,6 +49,8 @@ That flow rebuilds `apps/client/dist`, serves the packaged artifact instead of t
 
 The snapshot also supports manual gates, so the same file can carry pending or completed human checks such as WeChat Developer Tools export review, reconnect evidence, device smoke acceptance, or RC blocker review.
 
+When a candidate has more than one manual sign-off in flight, track ownership in [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md) so reviewers can see pending items without opening each artifact separately.
+
 ## Usage
 
 Run the full automated snapshot and write the result under `artifacts/release-readiness/`:
@@ -132,6 +134,8 @@ Example:
   }
 ]
 ```
+
+If you are carrying several manual checks for one candidate, keep the JSON file as the machine-readable source of truth for status and mirror the owner, revision, artifact path, and next follow-up in the manual evidence owner ledger. The snapshot answers "which manual checks exist"; the ledger answers "who still owes which sign-off."
 
 ## Snapshot Shape
 

--- a/docs/same-revision-release-evidence-runbook.md
+++ b/docs/same-revision-release-evidence-runbook.md
@@ -10,6 +10,7 @@ Related references:
 - [`docs/release-readiness-snapshot.md`](./release-readiness-snapshot.md)
 - [`docs/release-readiness-dashboard.md`](./release-readiness-dashboard.md)
 - [`docs/cocos-release-evidence-template.md`](./cocos-release-evidence-template.md)
+- [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md)
 - [`docs/wechat-minigame-release.md`](./wechat-minigame-release.md)
 - [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md)
 
@@ -31,6 +32,7 @@ These are the minimum artifacts for a same-revision release call:
 | WeChat packaged RC smoke | `npm run smoke:wechat-release -- --artifacts-dir artifacts/wechat-release --check --expected-revision <git-sha>` | `artifacts/wechat-release/codex.wechat.smoke-report.json` |
 | Cocos / WeChat RC bundle | `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report artifacts/wechat-release/codex.wechat.smoke-report.json --release-readiness-snapshot <snapshot-json>` | `artifacts/release-readiness/cocos-rc-evidence-bundle-<candidate>-<short-sha>.json` plus paired `.md`, snapshot, checklist, and blockers files |
 | Runtime observability sign-off | Manual review using `docs/wechat-runtime-observability-signoff.md` | `artifacts/wechat-release/runtime-observability-signoff.json` or equivalent reviewer artifact |
+| Manual evidence owner ledger | Copy `docs/release-evidence/manual-release-evidence-owner-ledger.template.md` for the candidate and update it as manual evidence lands | `artifacts/release-readiness/manual-release-evidence-owner-ledger-<candidate>-<short-sha>.md` or release PR table |
 | Final same-revision assembly check | `npm run release:readiness:dashboard -- --server-url http://127.0.0.1:2567 --wechat-artifacts-dir artifacts/wechat-release --candidate-revision <git-sha>` | `artifacts/release-readiness/release-readiness-dashboard-*.json` plus `.md` |
 
 If the candidate is missing any item above, the release call is still incomplete even if individual scripts passed earlier.
@@ -108,7 +110,17 @@ Freshness check:
 - confirm the captured environment is the release environment you are actually calling from
 - confirm any blockers or follow-ups are also reflected in the RC checklist or blocker register
 
-6. Run the final assembly check that enforces same-revision consistency.
+6. Update the manual evidence owner ledger for the same candidate revision.
+
+Copy [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md) into the candidate artifact set or PR body and keep one row for each required manual sign-off.
+
+Freshness check:
+
+- confirm every required manual evidence item has one row
+- confirm `owner`, `status`, `target revision`, `recorded at`, and `artifact path` agree with the underlying artifact
+- confirm any row still marked `pending` or `hold` explains the next follow-up clearly enough for handoff
+
+7. Run the final assembly check that enforces same-revision consistency.
 
 ```bash
 npm run release:readiness:dashboard -- \
@@ -133,6 +145,7 @@ Before making the release call, verify this exact packet exists:
 - one RC checklist Markdown file for `<candidate-name>` and `<git-sha>`
 - one RC blocker Markdown file for `<candidate-name>` and `<git-sha>`
 - one runtime observability sign-off artifact for `<git-sha>`
+- one manual evidence owner ledger Markdown file or PR table for `<candidate-name>` and `<git-sha>`
 - one release readiness dashboard JSON or Markdown for `<git-sha>`
 
 If two files for the "same" evidence disagree on revision or timestamp window, treat the packet as invalid and refresh the stale file instead of choosing by hand.
@@ -146,6 +159,7 @@ Release is `go` only when all of the following are true:
 - the WeChat smoke report has no required case in `failed`, `blocked`, or `pending`
 - the Cocos RC bundle is generated for the same candidate and revision and includes the latest checklist/blocker files
 - the runtime observability sign-off is recorded for the same revision and environment
+- the manual evidence owner ledger shows no required row still in `pending` or `hold` without an accepted release decision
 - the final readiness dashboard does not report revision mismatch, missing revision metadata, or stale evidence
 
 Release is `no-go` when any of the following happens:

--- a/docs/wechat-runtime-observability-signoff.md
+++ b/docs/wechat-runtime-observability-signoff.md
@@ -7,6 +7,7 @@ Use it together with:
 - [`docs/wechat-minigame-release.md`](./wechat-minigame-release.md)
 - [`docs/release-evidence/wechat-release-manual-review.example.json`](./release-evidence/wechat-release-manual-review.example.json)
 - [`docs/release-evidence/cocos-wechat-rc-checklist.template.md`](./release-evidence/cocos-wechat-rc-checklist.template.md)
+- [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md)
 
 ## Required Evidence
 
@@ -21,6 +22,7 @@ For the same candidate revision, capture and attach:
   - Capture at least one scrape/export showing the runtime metrics endpoint is reachable for the same environment.
 - Reviewer decision
   - Record owner, `recordedAt`, revision, artifact path, and any follow-up or accepted risk.
+  - Mirror the same owner, revision, artifact path, and follow-up status into the manual evidence owner ledger so the candidate handoff still has one pending-signoff view.
 
 ## Minimum Review Questions
 


### PR DESCRIPTION
## Summary
- add one canonical manual release-evidence owner ledger template with example entries for runtime, WeChat, RC checklist, and presentation sign-off
- link the ledger from the same-revision runbook, release-readiness snapshot docs, and runtime observability sign-off guidance so pending manual evidence is visible in one place
- add a readiness issue-template field for the ledger link during follow-up intake

Closes #617