### PR TITLE
ops: surface manual evidence ownership in the readiness summary

### DIFF
--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -93,6 +93,8 @@ The report now includes a `Target Surface Contract` section with:
   - pass/fail call for the selected surface
 - `releaseSurface.evidence[*]`
   - exact evidence item, freshness, owner, revision, waiver, and artifact path
+- Markdown `Manual Evidence Ownership`
+  - a reviewer-facing rollup of each required manual evidence item with owner, freshness, recorded timestamp, revision, blocker ids, and artifact path so pending sign-offs are visible without expanding the full evidence list
 
 For `wechat`, the required surface evidence is:
 

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -1595,6 +1595,7 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
 }
 
 export function renderMarkdown(report: ReleaseGateSummaryReport): string {
+  const manualEvidence = report.releaseSurface.evidence.filter((entry) => entry.id.startsWith("manual:"));
   const lines = [
     "# Release Gate Summary",
     "",
@@ -1639,6 +1640,31 @@ export function renderMarkdown(report: ReleaseGateSummaryReport): string {
       .filter((value) => value.length > 0)
       .join(" ");
     lines.push(`  - ${entry.label}: ${entry.summary} [${details}]`);
+  }
+  lines.push("");
+
+  lines.push("### Manual Evidence Ownership");
+  lines.push("");
+  if (manualEvidence.length === 0) {
+    lines.push("- No required manual evidence items are attached to the target surface.");
+  } else {
+    for (const entry of manualEvidence) {
+      const details = [
+        `status=${entry.status}`,
+        `freshness=${entry.freshness}`,
+        `owner=${entry.owner ?? "<missing>"}`,
+        `revision=${entry.revision ?? "<missing>"}`,
+        `recordedAt=${entry.observedAt ?? "<missing>"}`,
+        `artifact=${entry.artifactPath ? relativeReportPath(entry.artifactPath) : "<missing>"}`
+      ];
+      if (entry.blockerIds.length > 0) {
+        details.push(`blockers=${entry.blockerIds.join(",")}`);
+      }
+      if (entry.waiverReason) {
+        details.push(`waiver=${entry.waiverReason}`);
+      }
+      lines.push(`- ${entry.label}: ${entry.summary} [${details.join(" ")}]`);
+    }
   }
   lines.push("");
 

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -232,6 +232,9 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /release-readiness-pass\.json/);
   assert.match(renderMarkdown(report), /colyseus-reconnect-soak-summary-pass\.json/);
   assert.match(renderMarkdown(report), /codex\.wechat\.release-candidate-summary\.json/);
+  assert.match(renderMarkdown(report), /### Manual Evidence Ownership/);
+  assert.match(renderMarkdown(report), /owner=release-oncall/);
+  assert.match(renderMarkdown(report), /artifact=artifacts\/wechat-release\/device-runtime-review\.json/);
   assert.match(renderMarkdown(report), /Config Change Risk Summary/);
   assert.match(renderMarkdown(report), /Recommend rehearsal: yes/);
 });
@@ -353,6 +356,8 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
   assert.match(report.gates[0]?.summary ?? "", /not release-ready/);
   assert.match(report.gates[3]?.summary ?? "", /blocked/i);
   assert.match(report.gates[3]?.failures.join("\n") ?? "", /blocked pending device evidence|WeChat smoke case is blocked/);
+  assert.match(renderMarkdown(report), /### Manual Evidence Ownership/);
+  assert.match(renderMarkdown(report), /No required manual evidence items are attached to the target surface/);
 });
 
 test("evaluateWechatGate prefers RC validation and falls back to smoke report", () => {


### PR DESCRIPTION
## Summary
- surface required manual evidence ownership in the release gate markdown summary
- keep the change docs/ops-focused by reusing existing release surface evidence data
- document the new reviewer-facing ownership rollup and cover it with summary tests

## Verification
- npm run test:release-gate-summary

Closes #629