### PR TITLE
release: validate owner ledger freshness against candidate revision

### DIFF
--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -37,6 +37,7 @@ npm run release:gate:summary -- \
   --snapshot artifacts/release-readiness/release-readiness-2026-03-29T08-12-04.512Z.json \
   --h5-smoke artifacts/release-readiness/client-release-candidate-smoke-abc1234-2026-03-29T08-15-10.000Z.json \
   --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary.json \
+  --manual-evidence-ledger artifacts/release-readiness/manual-release-evidence-owner-ledger-abc1234.md \
   --config-center-library configs/.config-center-library.json \
   --wechat-artifacts-dir artifacts/wechat-release
 ```
@@ -77,7 +78,9 @@ The summary contains five release dimensions:
   - Markdown/JSON summary text distinguishes `blocked` device/runtime evidence from true execution failures so CI reviewers can see whether a gate is red because proof is absent or because the runtime actually regressed.
 - `phase1-evidence-consistency`
   - Cross-checks the release-readiness snapshot, packaged H5 smoke report, and selected WeChat evidence as one Phase 1 candidate set.
+  - When a manual evidence owner ledger is provided, or when one exists under `artifacts/release-readiness/`, it also validates the ledger header against the current candidate revision.
   - Fails when any artifact is missing revision metadata, missing/invalid generated timestamps, points at a different commit than the current release candidate, carries a conflicting candidate hint from its artifact path, or disagrees with another artifact’s commit/candidate hint.
+  - For the ledger, the checked fields are `Target revision` and `Last updated`.
   - Fails when the selected evidence timestamps drift by more than 72 hours, which is the cutoff for “same candidate evidence set” in this report.
   - The Markdown output now includes a `Selected Inputs` section so reviewers can see the exact artifact paths that were compared instead of inferring them from the default directory scan.
 

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -15,6 +15,7 @@ interface Args {
   wechatCandidateSummaryPath?: string;
   wechatSmokeReportPath?: string;
   wechatArtifactsDir?: string;
+  manualEvidenceLedgerPath?: string;
   configCenterLibraryPath?: string;
   targetSurface: TargetSurface;
   outputPath?: string;
@@ -151,7 +152,8 @@ interface GateSource {
     | "reconnect-soak"
     | "wechat-rc-validation"
     | "wechat-release-candidate-summary"
-    | "wechat-smoke-report";
+    | "wechat-smoke-report"
+    | "manual-evidence-owner-ledger";
   path: string;
 }
 
@@ -253,6 +255,13 @@ interface ConfigCenterLibraryState {
   publishAuditHistory?: ConfigPublishAuditEvent[];
 }
 
+interface ManualEvidenceOwnerLedgerMetadata {
+  candidate?: string;
+  targetRevision?: string;
+  lastUpdated?: string;
+  linkedReadinessSnapshot?: string;
+}
+
 interface ConfigRiskChangeSummary {
   documentId: ConfigDocumentId;
   title: string;
@@ -305,6 +314,7 @@ interface ReleaseGateSummaryReport {
     wechatCandidateSummaryPath?: string;
     wechatSmokeReportPath?: string;
     wechatArtifactsDir?: string;
+    manualEvidenceLedgerPath?: string;
     configCenterLibraryPath?: string;
   };
   gates: GateResult[];
@@ -415,6 +425,7 @@ function parseArgs(argv: string[]): Args {
   let wechatCandidateSummaryPath: string | undefined;
   let wechatSmokeReportPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
+  let manualEvidenceLedgerPath: string | undefined;
   let configCenterLibraryPath: string | undefined;
   let targetSurface: TargetSurface = "wechat";
   let outputPath: string | undefined;
@@ -459,6 +470,11 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--manual-evidence-ledger" && next) {
+      manualEvidenceLedgerPath = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--config-center-library" && next) {
       configCenterLibraryPath = next;
       index += 1;
@@ -494,6 +510,7 @@ function parseArgs(argv: string[]): Args {
     ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
+    ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
     ...(configCenterLibraryPath ? { configCenterLibraryPath } : {}),
     targetSurface,
     ...(outputPath ? { outputPath } : {}),
@@ -608,6 +625,15 @@ function resolveConfigCenterLibraryPath(args: Args): string | undefined {
     ? path.resolve(args.configCenterLibraryPath)
     : DEFAULT_CONFIG_CENTER_LIBRARY_PATH;
   return fs.existsSync(candidate) ? candidate : undefined;
+}
+
+function resolveManualEvidenceLedgerPath(args: Args): string | undefined {
+  if (args.manualEvidenceLedgerPath) {
+    return path.resolve(args.manualEvidenceLedgerPath);
+  }
+  return resolveLatestFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
+    entry.includes("manual-release-evidence-owner-ledger") && entry.endsWith(".md")
+  );
 }
 
 function readGitValue(args: string[]): string {
@@ -980,6 +1006,21 @@ function evaluateFreshness(timestamp: string | undefined, maxAgeMs: number): Evi
   return Date.now() - timestampMs > maxAgeMs ? "stale" : "fresh";
 }
 
+function parseManualEvidenceOwnerLedger(filePath: string): ManualEvidenceOwnerLedgerMetadata {
+  const content = fs.readFileSync(filePath, "utf8");
+  const capture = (label: string): string | undefined => {
+    const match = content.match(new RegExp(`^- ${label}:\\s+\`([^\\n\`]+)\``, "m"));
+    return match?.[1]?.trim();
+  };
+
+  return {
+    candidate: capture("Candidate"),
+    targetRevision: capture("Target revision"),
+    lastUpdated: capture("Last updated"),
+    linkedReadinessSnapshot: capture("Linked readiness snapshot")
+  };
+}
+
 function createSurfaceEvidenceItem(input: {
   id: string;
   label: string;
@@ -1187,7 +1228,8 @@ function collectPhase1EvidenceReferences(
   reconnectSoakPath: string | undefined,
   wechatRcValidationPath: string | undefined,
   wechatCandidateSummaryPath: string | undefined,
-  wechatSmokeReportPath: string | undefined
+  wechatSmokeReportPath: string | undefined,
+  manualEvidenceLedgerPath: string | undefined
 ): Phase1EvidenceReference[] {
   const evidence: Phase1EvidenceReference[] = [];
 
@@ -1283,6 +1325,21 @@ function collectPhase1EvidenceReferences(
     });
   }
 
+  if (manualEvidenceLedgerPath && fs.existsSync(manualEvidenceLedgerPath)) {
+    const ledger = parseManualEvidenceOwnerLedger(manualEvidenceLedgerPath);
+    evidence.push({
+      gateId: "wechat-release",
+      label: "Manual evidence owner ledger",
+      source: {
+        kind: "manual-evidence-owner-ledger",
+        path: manualEvidenceLedgerPath
+      },
+      commit: ledger.targetRevision,
+      generatedAt: ledger.lastUpdated,
+      candidateHint: deriveCandidateHint(manualEvidenceLedgerPath, ledger.targetRevision)
+    });
+  }
+
   return evidence;
 }
 
@@ -1294,7 +1351,8 @@ export function evaluatePhase1EvidenceConsistencyGate(
   reconnectSoakPath: string | undefined,
   wechatRcValidationPath: string | undefined,
   wechatCandidateSummaryPath: string | undefined,
-  wechatSmokeReportPath: string | undefined
+  wechatSmokeReportPath: string | undefined,
+  manualEvidenceLedgerPath: string | undefined
 ): GateResult {
   const failures: string[] = [];
   const expectedArtifacts: Array<Pick<Phase1EvidenceReference, "gateId" | "label">> = [
@@ -1310,7 +1368,8 @@ export function evaluatePhase1EvidenceConsistencyGate(
     reconnectSoakPath,
     wechatRcValidationPath,
     wechatCandidateSummaryPath,
-    wechatSmokeReportPath
+    wechatSmokeReportPath,
+    manualEvidenceLedgerPath
   );
   const expectedCommit = revision.commit;
   const expectedCandidateHint = normalizeCommit(revision.commit)?.slice(0, 12) ?? revision.shortCommit.toLowerCase();
@@ -1539,6 +1598,7 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
   const wechatRcValidationPath = resolveWechatRcValidationPath(args, wechatArtifactsDir);
   const wechatCandidateSummaryPath = resolveWechatCandidateSummaryPath(args, wechatArtifactsDir);
   const wechatSmokeReportPath = resolveWechatSmokeReportPath(args, wechatArtifactsDir);
+  const manualEvidenceLedgerPath = resolveManualEvidenceLedgerPath(args);
   const configCenterLibraryPath = resolveConfigCenterLibraryPath(args);
   const releaseSurface = buildReleaseSurfaceContract(
     args.targetSurface,
@@ -1561,7 +1621,8 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
       reconnectSoakPath,
       wechatRcValidationPath,
       wechatCandidateSummaryPath,
-      wechatSmokeReportPath
+      wechatSmokeReportPath,
+      manualEvidenceLedgerPath
     )
   ];
   const failedGates = gates.filter((gate) => gate.required && gate.status === "failed");
@@ -1586,6 +1647,7 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
       ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
       ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
       ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
+      ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
       ...(configCenterLibraryPath ? { configCenterLibraryPath } : {})
     },
     gates,
@@ -1617,6 +1679,7 @@ export function renderMarkdown(report: ReleaseGateSummaryReport): string {
   );
   lines.push(`- WeChat smoke fallback: \`${report.inputs.wechatSmokeReportPath ? relativeReportPath(report.inputs.wechatSmokeReportPath) : "<missing>"}\``);
   lines.push(`- WeChat artifacts dir: \`${report.inputs.wechatArtifactsDir ? relativeReportPath(report.inputs.wechatArtifactsDir) : "<missing>"}\``);
+  lines.push(`- Manual evidence ledger: \`${report.inputs.manualEvidenceLedgerPath ? relativeReportPath(report.inputs.manualEvidenceLedgerPath) : "<missing>"}\``);
   lines.push(`- Config audit: \`${report.inputs.configCenterLibraryPath ? relativeReportPath(report.inputs.configCenterLibraryPath) : "<missing>"}\``);
   lines.push("");
 

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -27,6 +27,12 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
   const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
+  const manualEvidenceLedgerPath = path.join(
+    workspace,
+    "artifacts",
+    "release-readiness",
+    "manual-release-evidence-owner-ledger-abc123.md"
+  );
   const wechatArtifactsDir = path.join(workspace, "artifacts", "wechat-release");
   const wechatRcValidationPath = path.join(wechatArtifactsDir, "codex.wechat.rc-validation-report.json");
   const wechatCandidateSummaryPath = path.join(wechatArtifactsDir, "codex.wechat.release-candidate-summary.json");
@@ -199,6 +205,21 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
       }
     ]
   });
+  fs.mkdirSync(path.dirname(manualEvidenceLedgerPath), { recursive: true });
+  fs.writeFileSync(
+    manualEvidenceLedgerPath,
+    `# Manual Release Evidence Owner Ledger
+
+## Candidate
+
+- Candidate: \`rc-2026-04-02\`
+- Target revision: \`abc123\`
+- Release owner: \`release-oncall\`
+- Last updated: \`2026-04-02T08:16:00.000Z\`
+- Linked readiness snapshot: \`artifacts/release-readiness/release-readiness-pass.json\`
+`,
+    "utf8"
+  );
 
   const report = buildReleaseGateSummaryReport(
     {
@@ -206,6 +227,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
       h5SmokePath,
       reconnectSoakPath,
       wechatArtifactsDir,
+      manualEvidenceLedgerPath,
       targetSurface: "wechat",
       configCenterLibraryPath
     },
@@ -232,6 +254,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /release-readiness-pass\.json/);
   assert.match(renderMarkdown(report), /colyseus-reconnect-soak-summary-pass\.json/);
   assert.match(renderMarkdown(report), /codex\.wechat\.release-candidate-summary\.json/);
+  assert.match(renderMarkdown(report), /manual-release-evidence-owner-ledger-abc123\.md/);
   assert.match(renderMarkdown(report), /### Manual Evidence Ownership/);
   assert.match(renderMarkdown(report), /owner=release-oncall/);
   assert.match(renderMarkdown(report), /artifact=artifacts\/wechat-release\/device-runtime-review\.json/);
@@ -513,6 +536,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails stale or mismatched candidate 
     reconnectSoakPath,
     wechatRcValidationPath,
     undefined,
+    undefined,
     undefined
   );
 
@@ -613,6 +637,7 @@ test("evaluatePhase1EvidenceConsistencyGate fails when Phase 1 evidence timestam
     reconnectSoakPath,
     wechatRcValidationPath,
     undefined,
+    undefined,
     undefined
   );
 
@@ -620,6 +645,138 @@ test("evaluatePhase1EvidenceConsistencyGate fails when Phase 1 evidence timestam
   assert.match(gate.failures.join("\n"), /timestamps drift by 9[67]h/);
   assert.match(gate.failures.join("\n"), /release-readiness-pass\.json/);
   assert.match(gate.failures.join("\n"), /codex\.wechat\.rc-validation-report\.json/);
+});
+
+test("evaluatePhase1EvidenceConsistencyGate fails when manual evidence owner ledger drifts from the candidate revision", () => {
+  const workspace = createTempWorkspace();
+  const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
+  const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
+  const wechatCandidateSummaryPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.release-candidate-summary.json");
+  const manualEvidenceLedgerPath = path.join(
+    workspace,
+    "artifacts",
+    "release-readiness",
+    "manual-release-evidence-owner-ledger-deadbee.md"
+  );
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-04-02T08:30:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
+    summary: {
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
+    }
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: "2026-04-02T08:32:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
+    execution: {
+      status: "passed",
+      finishedAt: "2026-04-02T08:32:00.000Z",
+      exitCode: 0
+    },
+    summary: {
+      total: 2,
+      passed: 2,
+      failed: 0
+    }
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-04-02T08:33:00.000Z",
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 384,
+      invariantChecks: 2304
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: "2026-04-02T08:35:00.000Z",
+    candidate: {
+      revision: "abc123",
+      status: "ready"
+    },
+    evidence: {
+      smoke: {
+        status: "passed"
+      },
+      manualReview: {
+        status: "ready",
+        requiredPendingChecks: 0,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: []
+      }
+    },
+    blockers: []
+  });
+  fs.mkdirSync(path.dirname(manualEvidenceLedgerPath), { recursive: true });
+  fs.writeFileSync(
+    manualEvidenceLedgerPath,
+    `# Manual Release Evidence Owner Ledger
+
+## Candidate
+
+- Candidate: \`rc-2026-04-02\`
+- Target revision: \`deadbeef\`
+- Release owner: \`release-oncall\`
+- Last updated: \`2026-04-02T08:40:00.000Z\`
+- Linked readiness snapshot: \`artifacts/release-readiness/release-readiness-pass.json\`
+`,
+    "utf8"
+  );
+
+  const gate = evaluatePhase1EvidenceConsistencyGate(
+    "wechat",
+    {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
+    snapshotPath,
+    h5SmokePath,
+    reconnectSoakPath,
+    undefined,
+    wechatCandidateSummaryPath,
+    undefined,
+    manualEvidenceLedgerPath
+  );
+
+  assert.equal(gate.status, "failed");
+  assert.match(gate.failures.join("\n"), /Manual evidence owner ledger/);
+  assert.match(gate.failures.join("\n"), /does not match candidate abc123/);
 });
 
 test("buildReleaseGateSummaryReport fails when all artifacts are stale for the current candidate", () => {


### PR DESCRIPTION
## Summary
- validate optional manual evidence owner ledger headers in release gate summary
- compare ledger target revision and last updated timestamp against the candidate evidence set
- cover the ledger path with focused release-gate tests and docs

Closes #628