### PR TITLE
fix: normalize deterministic battle rng state for replays

### DIFF
--- a/packages/shared/src/battle-replay.ts
+++ b/packages/shared/src/battle-replay.ts
@@ -1,4 +1,4 @@
-import { applyBattleAction } from "./battle.ts";
+import { applyBattleAction, normalizeBattleState } from "./battle.ts";
 import type { BattleAction, BattleState } from "./models.ts";
 import { getBattleOutcome } from "./battle.ts";
 import type { BattleOutcome, UnitStack } from "./models.ts";
@@ -95,7 +95,7 @@ function normalizeTimestamp(value?: string | null): string | undefined {
 }
 
 function cloneBattleState(state: BattleState): BattleState {
-  return structuredClone(state);
+  return normalizeBattleState(structuredClone(state));
 }
 
 function unitHpPool(unit?: UnitStack | null): number {

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -64,13 +64,22 @@ function hazardsOf(state: BattleState): BattleHazardState[] {
   return state.environment ?? [];
 }
 
-function normalizeBattleState(state: BattleState): BattleState {
+function normalizeBattleRngState(state: BattleState): BattleState["rng"] {
+  const rng = state.rng;
+  return {
+    seed: Number.isFinite(rng?.seed) ? Math.floor(rng.seed) >>> 0 : 1,
+    cursor: Number.isFinite(rng?.cursor) ? Math.max(0, Math.floor(rng.cursor)) : 0
+  };
+}
+
+export function normalizeBattleState(state: BattleState): BattleState {
   return {
     ...state,
     units: Object.fromEntries(
       Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
     ),
-    environment: hazardsOf(state).map(cloneHazardState)
+    environment: hazardsOf(state).map(cloneHazardState),
+    rng: normalizeBattleRngState(state)
   };
 }
 

--- a/packages/shared/test/battle-replay-playback-command.test.ts
+++ b/packages/shared/test/battle-replay-playback-command.test.ts
@@ -58,6 +58,18 @@ test("restoreBattleReplayPlaybackState rebuilds the replay cursor from a step in
   assert.equal(playback.nextStep?.index, 2);
 });
 
+test("restoreBattleReplayPlaybackState normalizes legacy replay states without rng metadata", () => {
+  const replay = createReplay();
+  delete (replay.initialState as { rng?: unknown }).rng;
+
+  const playback = restoreBattleReplayPlaybackState(replay, 0, "paused");
+
+  assert.deepEqual(playback.currentState.rng, {
+    seed: 1,
+    cursor: 0
+  });
+});
+
 test("applyBattleReplayPlaybackCommand advances stateless step and tick controls", () => {
   const replay = createReplay();
 

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -4556,6 +4556,25 @@ test("applyBattleAction repeats battle damage variance for the same seed", () =>
   assert.deepEqual(secondResult.rng, firstResult.rng);
 });
 
+test("applyBattleAction normalizes missing rng state before resolving deterministic damage", () => {
+  const state = createDemoBattleState();
+  delete (state as Partial<typeof state>).rng;
+
+  const next = applyBattleAction(state, {
+    type: "battle.attack",
+    attackerId: "wolf-d",
+    defenderId: "pikeman-a"
+  });
+
+  assert.equal(next.rng.cursor, 2);
+  assert.deepEqual(next.rng, {
+    seed: 1586005467,
+    cursor: 2
+  });
+  assert.equal(next.units["pikeman-a"]?.count, 10);
+  assert.equal(next.units["wolf-d"]?.count, 6);
+});
+
 test("applyBattleAction supports active ranged skills without retaliation", () => {
   const initial = createDemoBattleState();
   initial.activeUnitId = "pikeman-a";


### PR DESCRIPTION
## Summary
- normalize shared battle states so missing or malformed RNG metadata always falls back to the seeded deterministic PRNG state
- normalize replay playback state cloning through the shared battle normalizer so legacy captures replay deterministically from step 0
- add focused shared tests for battle action execution and replay restoration without RNG metadata

Closes #625