### PR TITLE
Fix fog-of-war filtering in broadcast world sync

### DIFF
--- a/packages/shared/src/map-sync.ts
+++ b/packages/shared/src/map-sync.ts
@@ -145,8 +145,7 @@ export function encodePlayerWorldView(
     for (let x = bounds.x; x < bounds.x + bounds.width; x += 1) {
       const tile = view.map.tiles[tileIndex(view.map.width, x, y)]!;
       terrain[localIndex] = TERRAIN_CODES[tile.terrain];
-      // 临时开启上帝视角：强制设为 visible (2)
-      fog[localIndex] = 2; // FOG_CODES["visible"]
+      fog[localIndex] = FOG_CODES[tile.fog];
       walkable[localIndex] = tile.walkable ? 1 : 0;
 
       if (tile.resource || tile.occupant || tile.building) {


### PR DESCRIPTION
## Summary
- preserve per-tile fog state when encoding player world views for typed-array sync
- keep broadcast map chunks aligned with the player-filtered world snapshot instead of marking obscured tiles visible

## Verification
- node --import tsx --test ./packages/shared/test/shared-core.test.ts ./apps/server/test/colyseus-persistence-recovery.test.ts

Closes #626