### PR TITLE
release: add release gate triage summary

### DIFF
--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -57,6 +57,17 @@ If you do not pass output flags, the script writes:
 - `artifacts/release-readiness/release-gate-summary-<short-sha>.json`
 - `artifacts/release-readiness/release-gate-summary-<short-sha>.md`
 
+## Triage Summary
+
+The JSON and Markdown outputs now include a normalized `triage` section for operator handoff:
+
+- `triage.blockers`
+  - one entry per failing required release-gate dimension, with `impactedSurface`, `summary`, `nextStep`, and artifact paths
+- `triage.warnings`
+  - advisory items that should be reviewed before promotion, such as elevated config-change risk
+
+Use this first when CI is red or when a PR comment needs one concise release/ops answer.
+
 ## Gate Rules
 
 The summary contains five release dimensions:

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -198,6 +198,22 @@ interface ReleaseSurfaceContract {
   evidence: ReleaseSurfaceEvidenceItem[];
 }
 
+interface ReleaseGateArtifactReference {
+  label: string;
+  path: string;
+}
+
+interface ReleaseGateTriageEntry {
+  id: string;
+  severity: "blocker" | "warning";
+  gateId: GateResult["id"] | "config-change-risk";
+  title: string;
+  impactedSurface: TargetSurface;
+  summary: string;
+  nextStep: string;
+  artifacts: ReleaseGateArtifactReference[];
+}
+
 interface ReconnectSoakArtifact {
   generatedAt?: string;
   revision?: {
@@ -316,6 +332,10 @@ interface ReleaseGateSummaryReport {
     wechatArtifactsDir?: string;
     manualEvidenceLedgerPath?: string;
     configCenterLibraryPath?: string;
+  };
+  triage: {
+    blockers: ReleaseGateTriageEntry[];
+    warnings: ReleaseGateTriageEntry[];
   };
   gates: GateResult[];
   releaseSurface: ReleaseSurfaceContract;
@@ -671,6 +691,36 @@ function missingGate(
     summary,
     failures
   };
+}
+
+function createTriageArtifactReference(label: string, filePath: string | undefined): ReleaseGateArtifactReference[] {
+  if (!filePath) {
+    return [];
+  }
+  return [{ label, path: filePath }];
+}
+
+function buildGateTriageArtifacts(
+  gate: GateResult,
+  inputs: ReleaseGateSummaryReport["inputs"]
+): ReleaseGateArtifactReference[] {
+  const artifacts = [
+    ...createTriageArtifactReference(gate.label, gate.source?.path),
+    ...(gate.id === "phase1-evidence-consistency"
+      ? [
+          ...createTriageArtifactReference("Release readiness snapshot", inputs.snapshotPath),
+          ...createTriageArtifactReference("H5 packaged RC smoke", inputs.h5SmokePath),
+          ...createTriageArtifactReference("Multiplayer reconnect soak", inputs.reconnectSoakPath),
+          ...createTriageArtifactReference(
+            "WeChat release evidence",
+            inputs.wechatCandidateSummaryPath ?? inputs.wechatRcValidationPath ?? inputs.wechatSmokeReportPath
+          ),
+          ...createTriageArtifactReference("Manual evidence owner ledger", inputs.manualEvidenceLedgerPath)
+        ]
+      : [])
+  ];
+
+  return artifacts.filter((artifact, index, entries) => entries.findIndex((entry) => entry.path === artifact.path) === index);
 }
 
 export function evaluateReleaseReadinessGate(
@@ -1590,6 +1640,75 @@ export function buildConfigChangeRiskSummary(configCenterLibraryPath: string | u
   };
 }
 
+function buildReleaseGateNextStep(gate: GateResult, targetSurface: TargetSurface): string {
+  const sourceInstruction = gate.source?.path ? `Open \`${relativeReportPath(gate.source.path)}\`` : "Open the failing release evidence";
+
+  if (gate.id === "release-readiness") {
+    return `${sourceInstruction}, clear the failing or pending readiness checks, then rerun \`npm run release:gate:summary -- --target-surface ${targetSurface}\`.`;
+  }
+  if (gate.id === "h5-release-candidate-smoke") {
+    return `${sourceInstruction}, rerun \`npm run smoke:client:release-candidate\`, then rerun \`npm run release:gate:summary -- --target-surface ${targetSurface}\`.`;
+  }
+  if (gate.id === "multiplayer-reconnect-soak") {
+    return `${sourceInstruction}, rerun \`npm run stress:rooms:reconnect-soak\`, then rerun \`npm run release:gate:summary -- --target-surface ${targetSurface}\`.`;
+  }
+  if (gate.id === "wechat-release") {
+    const command =
+      gate.source?.kind === "wechat-smoke-report"
+        ? "npm run smoke:wechat-release -- --check"
+        : "npm run validate:wechat-rc";
+    return `${sourceInstruction}, rerun \`${command}\` to refresh the WeChat evidence, then rerun \`npm run release:gate:summary -- --target-surface ${targetSurface}\`.`;
+  }
+  return `${sourceInstruction}, refresh the release evidence for one candidate revision, then rerun \`npm run release:gate:summary -- --target-surface ${targetSurface}\`.`;
+}
+
+function buildReleaseGateTriage(
+  gates: GateResult[],
+  inputs: ReleaseGateSummaryReport["inputs"],
+  targetSurface: TargetSurface,
+  configChangeRisk: ConfigChangeRiskSummary
+): ReleaseGateSummaryReport["triage"] {
+  const blockers = gates
+    .filter((gate) => gate.required && gate.status === "failed")
+    .map((gate) => ({
+      id: `gate:${gate.id}`,
+      severity: "blocker" as const,
+      gateId: gate.id,
+      title: gate.label,
+      impactedSurface: targetSurface,
+      summary: `${gate.label} blocked ${targetSurface}: ${gate.failures[0] ?? gate.summary}`,
+      nextStep: buildReleaseGateNextStep(gate, targetSurface),
+      artifacts: buildGateTriageArtifacts(gate, inputs)
+    }));
+
+  const warnings: ReleaseGateTriageEntry[] =
+    configChangeRisk.status === "available" &&
+    (configChangeRisk.overallRisk === "medium" ||
+      configChangeRisk.overallRisk === "high" ||
+      configChangeRisk.recommendCanary === true ||
+      configChangeRisk.recommendRehearsal === true)
+      ? [
+          {
+            id: "config-change-risk:warning",
+            severity: "warning",
+            gateId: "config-change-risk",
+            title: "Config change risk summary",
+            impactedSurface: targetSurface,
+            summary: `Config changes are ${configChangeRisk.overallRisk?.toUpperCase() ?? "UNKNOWN"} risk for ${targetSurface} and stay advisory until the suggested validation is complete.`,
+            nextStep: `Open \`${relativeReportPath(configChangeRisk.source?.path ?? DEFAULT_CONFIG_CENTER_LIBRARY_PATH)}\` and run ${(
+              configChangeRisk.suggestedValidationActions ?? []
+            )
+              .slice(0, 3)
+              .map((command) => `\`${command}\``)
+              .join(", ")} before promotion.`,
+            artifacts: createTriageArtifactReference("Config publish audit", configChangeRisk.source?.path)
+          }
+        ]
+      : [];
+
+  return { blockers, warnings };
+}
+
 export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision): ReleaseGateSummaryReport {
   const snapshotPath = resolveSnapshotPath(args);
   const h5SmokePath = resolveH5SmokePath(args);
@@ -1626,6 +1745,18 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
     )
   ];
   const failedGates = gates.filter((gate) => gate.required && gate.status === "failed");
+  const inputs = {
+    ...(snapshotPath ? { snapshotPath } : {}),
+    ...(h5SmokePath ? { h5SmokePath } : {}),
+    ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
+    ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
+    ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
+    ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
+    ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
+    ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
+    ...(configCenterLibraryPath ? { configCenterLibraryPath } : {})
+  };
+  const configChangeRisk = buildConfigChangeRiskSummary(configCenterLibraryPath);
 
   return {
     schemaVersion: 1,
@@ -1639,20 +1770,11 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
       failedGates: failedGates.length,
       failedGateIds: failedGates.map((gate) => gate.id)
     },
-    inputs: {
-      ...(snapshotPath ? { snapshotPath } : {}),
-      ...(h5SmokePath ? { h5SmokePath } : {}),
-      ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
-      ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
-      ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
-      ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
-      ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
-      ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
-      ...(configCenterLibraryPath ? { configCenterLibraryPath } : {})
-    },
+    inputs,
+    triage: buildReleaseGateTriage(gates, inputs, args.targetSurface, configChangeRisk),
     gates,
     releaseSurface,
-    configChangeRisk: buildConfigChangeRiskSummary(configCenterLibraryPath)
+    configChangeRisk
   };
 }
 
@@ -1681,6 +1803,37 @@ export function renderMarkdown(report: ReleaseGateSummaryReport): string {
   lines.push(`- WeChat artifacts dir: \`${report.inputs.wechatArtifactsDir ? relativeReportPath(report.inputs.wechatArtifactsDir) : "<missing>"}\``);
   lines.push(`- Manual evidence ledger: \`${report.inputs.manualEvidenceLedgerPath ? relativeReportPath(report.inputs.manualEvidenceLedgerPath) : "<missing>"}\``);
   lines.push(`- Config audit: \`${report.inputs.configCenterLibraryPath ? relativeReportPath(report.inputs.configCenterLibraryPath) : "<missing>"}\``);
+  lines.push("");
+
+  lines.push("## Triage Summary");
+  lines.push("");
+  lines.push(`### Blockers (${report.triage.blockers.length})`);
+  lines.push("");
+  if (report.triage.blockers.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const entry of report.triage.blockers) {
+      lines.push(`- **${entry.title}** (${entry.impactedSurface}): ${entry.summary}`);
+      lines.push(`  Next step: ${entry.nextStep}`);
+      if (entry.artifacts.length > 0) {
+        lines.push(`  Artifacts: ${entry.artifacts.map((artifact) => `\`${relativeReportPath(artifact.path)}\``).join(", ")}`);
+      }
+    }
+  }
+  lines.push("");
+  lines.push(`### Warnings (${report.triage.warnings.length})`);
+  lines.push("");
+  if (report.triage.warnings.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const entry of report.triage.warnings) {
+      lines.push(`- **${entry.title}** (${entry.impactedSurface}): ${entry.summary}`);
+      lines.push(`  Next step: ${entry.nextStep}`);
+      if (entry.artifacts.length > 0) {
+        lines.push(`  Artifacts: ${entry.artifacts.map((artifact) => `\`${relativeReportPath(artifact.path)}\``).join(", ")}`);
+      }
+    }
+  }
   lines.push("");
 
   lines.push("## Target Surface Contract");

--- a/scripts/release-pr-comment.ts
+++ b/scripts/release-pr-comment.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 
 import {
   renderPrCommentHealthSignal,
+  renderReviewerFacingMarkdownEntry,
   type ReviewerFacingSignal,
   type ReviewerFacingTriageEntry
 } from "./release-reporting-contract.ts";
@@ -33,6 +34,22 @@ interface ReleaseGateSummaryReport {
     summary: string;
     failures?: string[];
   }>;
+  triage: {
+    blockers: Array<{
+      title: string;
+      impactedSurface: "h5" | "wechat";
+      summary: string;
+      nextStep: string;
+      artifacts: Array<{ path: string }>;
+    }>;
+    warnings: Array<{
+      title: string;
+      impactedSurface: "h5" | "wechat";
+      summary: string;
+      nextStep: string;
+      artifacts: Array<{ path: string }>;
+    }>;
+  };
 }
 
 interface ReleaseHealthSummaryReport {
@@ -147,6 +164,41 @@ export function renderPrComment(
     `- Release readiness: **${releaseGateReport.summary.status.toUpperCase()}** (${releaseGateReport.summary.passedGates}/${releaseGateReport.summary.totalGates} gates passing)`,
     `- Release health: **${releaseHealthReport.summary.status.toUpperCase()}** (${releaseHealthReport.summary.blockerCount} blocker, ${releaseHealthReport.summary.warningCount} warning, ${releaseHealthReport.summary.infoCount} info)`,
     ...(runUrl ? [`- CI run: ${runUrl}`] : []),
+    "",
+    "### Triage",
+    "",
+    ...renderReviewerFacingMarkdownEntry(
+      "Release blockers",
+      releaseGateReport.triage.blockers.length === 0
+        ? "No blocking release-gate triage items."
+        : `${releaseGateReport.triage.blockers.length} blocking release-gate item(s) need operator follow-up.`,
+      {
+        status: releaseGateReport.triage.blockers.length === 0 ? "pass" : "fail",
+        nextStep: releaseGateReport.triage.blockers[0]?.nextStep,
+        artifacts: releaseGateReport.triage.blockers[0]?.artifacts
+      }
+    ),
+    ...(releaseGateReport.triage.blockers.length === 0
+      ? []
+      : releaseGateReport.triage.blockers.map(
+          (entry) => `  - **${entry.title}** (${entry.impactedSurface}): ${entry.summary}`
+        )),
+    ...renderReviewerFacingMarkdownEntry(
+      "Release warnings",
+      releaseGateReport.triage.warnings.length === 0
+        ? "No advisory release-gate warnings."
+        : `${releaseGateReport.triage.warnings.length} advisory release-gate warning(s) are worth checking before promotion.`,
+      {
+        status: releaseGateReport.triage.warnings.length === 0 ? "pass" : "warn",
+        nextStep: releaseGateReport.triage.warnings[0]?.nextStep,
+        artifacts: releaseGateReport.triage.warnings[0]?.artifacts
+      }
+    ),
+    ...(releaseGateReport.triage.warnings.length === 0
+      ? []
+      : releaseGateReport.triage.warnings.map(
+          (entry) => `  - **${entry.title}** (${entry.impactedSurface}): ${entry.summary}`
+        )),
     "",
     "### Release Readiness",
     "",

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -241,6 +241,9 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
 
   assert.equal(report.summary.status, "passed");
   assert.deepEqual(report.summary.failedGateIds, []);
+  assert.equal(report.triage.blockers.length, 0);
+  assert.equal(report.triage.warnings.length, 1);
+  assert.match(report.triage.warnings[0]?.summary ?? "", /HIGH risk/);
   assert.equal(report.summary.totalGates, 5);
   assert.equal(report.gates.every((gate) => gate.status === "passed"), true);
   assert.equal(report.gates[2]?.id, "multiplayer-reconnect-soak");
@@ -251,6 +254,9 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(report.configChangeRisk.summary, /最高风险 HIGH/);
   assert.match(renderMarkdown(report), /Overall status: \*\*PASSED\*\*/);
   assert.match(renderMarkdown(report), /## Selected Inputs/);
+  assert.match(renderMarkdown(report), /## Triage Summary/);
+  assert.match(renderMarkdown(report), /### Warnings \(1\)/);
+  assert.match(renderMarkdown(report), /Config changes are HIGH risk for wechat/);
   assert.match(renderMarkdown(report), /release-readiness-pass\.json/);
   assert.match(renderMarkdown(report), /colyseus-reconnect-soak-summary-pass\.json/);
   assert.match(renderMarkdown(report), /codex\.wechat\.release-candidate-summary\.json/);
@@ -376,9 +382,17 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
 
   assert.equal(report.summary.status, "failed");
   assert.deepEqual(report.summary.failedGateIds, ["release-readiness", "wechat-release"]);
+  assert.deepEqual(
+    report.triage.blockers.map((entry) => entry.gateId),
+    ["release-readiness", "wechat-release"]
+  );
+  assert.match(report.triage.blockers[0]?.nextStep ?? "", /release:gate:summary -- --target-surface wechat/);
+  assert.match(report.triage.blockers[1]?.summary ?? "", /blocked wechat/i);
   assert.match(report.gates[0]?.summary ?? "", /not release-ready/);
   assert.match(report.gates[3]?.summary ?? "", /blocked/i);
   assert.match(report.gates[3]?.failures.join("\n") ?? "", /blocked pending device evidence|WeChat smoke case is blocked/);
+  assert.match(renderMarkdown(report), /### Blockers \(2\)/);
+  assert.match(renderMarkdown(report), /Release readiness snapshot blocked wechat/);
   assert.match(renderMarkdown(report), /### Manual Evidence Ownership/);
   assert.match(renderMarkdown(report), /No required manual evidence items are attached to the target surface/);
 });

--- a/scripts/test/release-pr-comment.test.ts
+++ b/scripts/test/release-pr-comment.test.ts
@@ -41,7 +41,30 @@ function createReleaseGateReport() {
         summary: "WeChat validation failed.",
         failures: ["WeChat smoke case is still pending: login-flow."]
       }
-    ]
+    ],
+    triage: {
+      blockers: [
+        {
+          title: "WeChat release validation",
+          impactedSurface: "wechat" as const,
+          summary: "WeChat release validation blocked wechat: WeChat smoke case is still pending: login-flow.",
+          nextStep:
+            "Open `artifacts/wechat-release/codex.wechat.smoke-report.json`, rerun `npm run smoke:wechat-release -- --check` to refresh the WeChat evidence, then rerun `npm run release:gate:summary -- --target-surface wechat`.",
+          artifacts: [{ path: "artifacts/wechat-release/codex.wechat.smoke-report.json" }]
+        }
+      ],
+      warnings: [
+        {
+          title: "Config change risk summary",
+          impactedSurface: "wechat" as const,
+          summary:
+            "Config changes are HIGH risk for wechat and stay advisory until the suggested validation is complete.",
+          nextStep:
+            "Open `configs/.config-center-library.json` and run `npm run release:readiness:snapshot`, `npm run smoke:client:release-candidate`, `npm run validate:battle` before promotion.",
+          artifacts: [{ path: "configs/.config-center-library.json" }]
+        }
+      ]
+    }
   };
 }
 
@@ -138,6 +161,15 @@ test("renderPrComment combines readiness and non-duplicative health sections", (
   );
 
   assert.match(markdown, /## Release Automation Summary/);
+  assert.match(markdown, /### Triage/);
+  assert.match(markdown, /\*\*Release blockers\*\*: `FAIL` 1 blocking release-gate item\(s\) need operator follow-up\./);
+  assert.match(
+    markdown,
+    /Next step: Open `artifacts\/wechat-release\/codex\.wechat\.smoke-report\.json`, rerun `npm run smoke:wechat-release -- --check` to refresh the WeChat evidence, then rerun `npm run release:gate:summary -- --target-surface wechat`\./
+  );
+  assert.match(markdown, /Artifacts: `artifacts\/wechat-release\/codex\.wechat\.smoke-report\.json`/);
+  assert.match(markdown, /\*\*WeChat release validation\*\* \(wechat\): WeChat release validation blocked wechat/);
+  assert.match(markdown, /\*\*Release warnings\*\*: `WARN` 1 advisory release-gate warning\(s\) are worth checking before promotion\./);
   assert.match(markdown, /Release readiness: \*\*FAILED\*\* \(2\/3 gates passing\)/);
   assert.match(markdown, /### Release Readiness/);
   assert.match(markdown, /WeChat smoke case is still pending: login-flow\./);


### PR DESCRIPTION
## Summary
- add a normalized triage block to release-gate summary JSON/Markdown for blockers, warnings, artifact paths, and next steps
- surface the release-gate triage rollup in the PR release summary comment
- document the new triage section and cover it with focused tests

## Verification
- npm run test:release-gate-summary
- node --import tsx --test ./scripts/test/release-pr-comment.test.ts

Closes #637