### PR TITLE
ci(playwright): stabilize H5 smoke PR gate coverage

### DIFF
--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  testMatch: /(golden-path-player-journey|lobby-smoke|reconnect-prediction-convergence)\.spec\.ts/,
+  testMatch: /(lobby-smoke|reconnect-prediction-convergence)\.spec\.ts/,
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
   fullyParallel: false,


### PR DESCRIPTION
## Summary
- narrow the PR H5 Playwright smoke config to the documented lobby + reconnect coverage
- keep the broader golden-path journey out of the smoke gate so PR signal stays focused and less noisy

## Verification
- `npm run test:e2e:smoke -- --list`
- `npm run test:e2e:multiplayer:smoke -- --list`
- `npm run test:e2e:smoke` *(blocked locally: Playwright Chromium launch fails because `libatk-bridge-2.0.so.0` is missing in this environment)*

Closes #635