### PR TITLE
docs: add RC runtime observability sign-off template

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ npm run dev:client:h5
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
 - 微信小游戏构建 / 发布 / 回滚说明：`docs/wechat-minigame-release.md`
 - 微信小游戏 runtime observability 签核：`docs/wechat-runtime-observability-signoff.md`
+- 微信小游戏 runtime observability 签核模板：`docs/release-evidence/wechat-runtime-observability-signoff.template.md`
 - Phase 1 成熟度记分卡与退出标准：`docs/phase1-maturity-scorecard.md`
 - 仓库成熟度基线与独立 follow-up slices：`docs/repo-maturity-baseline.md`
 - 核心玩法发布门禁清单：`docs/core-gameplay-release-readiness.md`

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -27,6 +27,7 @@
 - Cocos Phase 1 占位 / fallback 表现签核：`docs/cocos-phase1-presentation-signoff.md`
 - Cocos / WeChat RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
 - Cocos / WeChat RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
+- WeChat runtime observability 签核模板：`docs/release-evidence/wechat-runtime-observability-signoff.template.md`
 - 微信小游戏提审前冒烟：`docs/wechat-minigame-release.md`
 
 ## 发布判断规则
@@ -38,6 +39,8 @@
 建议在每次 release candidate 上记录状态：`pass / partial / fail / n/a`，并附上证据链接、执行人和日期。对于 Cocos / WeChat RC，再额外固定两份人类可读附件：一份 checklist，一份 blocker register。
 
 如果希望把自动化门禁和人工门禁统一收口成一个结构化记录，可执行 `npm run release:readiness:snapshot -- --manual-checks docs/release-readiness-manual-checks.example.json`，生成当前 revision 的快照并保留 pending manual check。Cocos 主链路证据则统一用 `npm run release:cocos-rc:snapshot` 生成单独的 RC 快照，并在同一份 JSON 中回填 Creator 预览或微信 RC 证据；人工 reviewer 则复用 `docs/release-evidence/cocos-wechat-rc-checklist.template.md` 和 `docs/release-evidence/cocos-wechat-rc-blockers.template.md`，不要在 issue 或 PR 中重新发明字段。
+
+对于 WeChat release candidate / shipping candidate，再额外固定一份 `docs/release-evidence/wechat-runtime-observability-signoff.template.md` 的回填结果，用来记录同一 candidate revision 的 runtime health / diagnostics / metrics 签核；不要只在 PR 评论里写“ops 已看过”。
 
 如果希望把这些已有证据再压成单份本地总览，可执行 `npm run release:readiness:dashboard`。它会复用最新的 release snapshot、WeChat package / smoke evidence、Cocos RC snapshot，并可选探测 `/api/runtime/health`、`/api/runtime/auth-readiness`、`/api/runtime/metrics`，输出一份 `pass / warn / fail` 的 Phase 1 看板。
 
@@ -139,6 +142,7 @@
 - [ ] `/api/runtime/health`、`/api/runtime/auth-readiness`、`/api/runtime/metrics` 在候选包对应环境可访问。
 - [ ] 至少能看到活跃房间数、连接数、世界 / 战斗 action 计数，以及鉴权会话摘要。
 - [ ] 日志或接口输出足以区分登录失败、进房失败、同步失败和资源 / 配置失败。
+- [ ] WeChat release candidate / shipping candidate 已回填 candidate-scoped runtime observability sign-off，并记录 reviewer、`recordedAt`、target revision 与结论。
 
 `P1 follow-up`
 
@@ -151,6 +155,7 @@
 - 手动抓取：`GET /api/runtime/health`
 - 手动抓取：`GET /api/runtime/auth-readiness`
 - 手动抓取：`GET /api/runtime/metrics`
+- `docs/release-evidence/wechat-runtime-observability-signoff.template.md`
 
 ## 当前顶级发布风险
 

--- a/docs/release-evidence/wechat-runtime-observability-signoff.template.md
+++ b/docs/release-evidence/wechat-runtime-observability-signoff.template.md
@@ -1,0 +1,80 @@
+# WeChat Runtime Observability Sign-Off Template
+
+将本模板复制到当前 candidate 的 `artifacts/wechat-release/` 或 `artifacts/release-readiness/` 中回填。它用于证明同一候选 revision 在目标 release 环境里不仅能启动，而且仍然可观测、可排障。
+
+建议文件名：`runtime-observability-signoff-<candidate>-<short-sha>.md`
+
+## When Required
+
+- WeChat `release candidate` / `shipping candidate` 必填。
+- 进入 same-revision release evidence packet 时必填，和 readiness snapshot、WeChat smoke、RC checklist / blockers、manual evidence owner ledger 一起组成同一 candidate 的最小证据包。
+- 若本次候选包涉及运行时观测口径、指标维度、告警阈值、诊断接口或 auth/runtime 健康路径，也应重新生成，而不要复用旧 candidate 的签核。
+
+## Candidate
+
+- Candidate: `rc-YYYY-MM-DD`
+- Surface: `wechat_preview | wechat_upload_candidate`
+- Target revision: `<git-sha>`
+- Environment: `staging | production-like | production`
+- Reviewer: `<name>`
+- Reviewer role: `ops | oncall | release-owner`
+- Recorded at: `<YYYY-MM-DDTHH:MM:SSZ>`
+- Related RC checklist:
+- Related blocker register:
+- Related owner ledger:
+
+## Linked Evidence
+
+- [ ] `GET /api/runtime/health`
+  Artifact / link:
+  Captured at:
+- [ ] `GET /api/runtime/diagnostic-snapshot`
+  Artifact / link:
+  Captured at:
+- [ ] `GET /api/runtime/metrics`
+  Artifact / link:
+  Captured at:
+
+## Review Questions
+
+- [ ] 三个 endpoint 都对应同一 candidate revision 的目标环境，而不是本地 dev server 或旧 staging
+  Notes:
+- [ ] `/api/runtime/health` 已确认 `activeRoomCount`、`connectionCount`、`gameplayTraffic` 与 auth 摘要形状合理
+  Evidence:
+  Notes:
+- [ ] `/api/runtime/diagnostic-snapshot` 已确认 room summary、diagnostics 状态与 log tail 没有明显陈旧或缺口
+  Evidence:
+  Notes:
+- [ ] `/api/runtime/metrics` 已确认关键 runtime metrics 可抓取，且没有未知缺维、空白导出或权限失败
+  Evidence:
+  Notes:
+- [ ] 若存在告警、缺口或接受风险，已同步写入 blocker register 或 owner ledger
+  Evidence:
+  Notes:
+
+## Endpoint Summary
+
+| Endpoint | Status | Reviewer summary | Evidence path / link |
+| --- | --- | --- | --- |
+| `/api/runtime/health` | `pass | hold | fail` |  |  |
+| `/api/runtime/diagnostic-snapshot` | `pass | hold | fail` |  |  |
+| `/api/runtime/metrics` | `pass | hold | fail` |  |  |
+
+## Release Decision
+
+- Conclusion: `passed | hold | ship-with-followups`
+- Summary:
+- Accepted risks:
+- Follow-ups / owners:
+- Blocker IDs:
+
+## Ledger Mirror
+
+将以下字段同步回填到 manual evidence owner ledger 对应行：
+
+- `Evidence item`: `runtime-observability-signoff`
+- `Owner`: `<reviewer>`
+- `Status`: `<conclusion>`
+- `Target revision`: `<git-sha>`
+- `Recorded at`: `<recorded-at>`
+- `Artifact path / link`: `<this-file>`

--- a/docs/same-revision-release-evidence-runbook.md
+++ b/docs/same-revision-release-evidence-runbook.md
@@ -11,6 +11,7 @@ Related references:
 - [`docs/release-readiness-dashboard.md`](./release-readiness-dashboard.md)
 - [`docs/cocos-release-evidence-template.md`](./cocos-release-evidence-template.md)
 - [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md)
+- [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md)
 - [`docs/wechat-minigame-release.md`](./wechat-minigame-release.md)
 - [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md)
 
@@ -31,7 +32,7 @@ These are the minimum artifacts for a same-revision release call:
 | Automated release baseline | `npm run release:readiness:snapshot -- --manual-checks docs/release-readiness-manual-checks.example.json` | `artifacts/release-readiness/release-readiness-*.json` |
 | WeChat packaged RC smoke | `npm run smoke:wechat-release -- --artifacts-dir artifacts/wechat-release --check --expected-revision <git-sha>` | `artifacts/wechat-release/codex.wechat.smoke-report.json` |
 | Cocos / WeChat RC bundle | `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report artifacts/wechat-release/codex.wechat.smoke-report.json --release-readiness-snapshot <snapshot-json>` | `artifacts/release-readiness/cocos-rc-evidence-bundle-<candidate>-<short-sha>.json` plus paired `.md`, snapshot, checklist, and blockers files |
-| Runtime observability sign-off | Manual review using `docs/wechat-runtime-observability-signoff.md` | `artifacts/wechat-release/runtime-observability-signoff.json` or equivalent reviewer artifact |
+| Runtime observability sign-off | Manual review using `docs/wechat-runtime-observability-signoff.md` plus `docs/release-evidence/wechat-runtime-observability-signoff.template.md` | `artifacts/wechat-release/runtime-observability-signoff-<candidate>-<short-sha>.md` or equivalent reviewer artifact |
 | Manual evidence owner ledger | Copy `docs/release-evidence/manual-release-evidence-owner-ledger.template.md` for the candidate and update it as manual evidence lands | `artifacts/release-readiness/manual-release-evidence-owner-ledger-<candidate>-<short-sha>.md` or release PR table |
 | Final same-revision assembly check | `npm run release:readiness:dashboard -- --server-url http://127.0.0.1:2567 --wechat-artifacts-dir artifacts/wechat-release --candidate-revision <git-sha>` | `artifacts/release-readiness/release-readiness-dashboard-*.json` plus `.md` |
 
@@ -97,7 +98,7 @@ Freshness check:
 
 5. Complete the runtime observability sign-off for the same candidate revision.
 
-Use [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md) and capture:
+Use [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md) and [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md), and capture:
 
 - `/api/runtime/health`
 - `/api/runtime/diagnostic-snapshot`

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -40,6 +40,7 @@
 - Primary client delivery checklist：`docs/cocos-primary-client-delivery.md`
 - Cocos Phase 1 占位 / fallback 表现签核：`docs/cocos-phase1-presentation-signoff.md`
 - WeChat runtime observability 签核：`docs/wechat-runtime-observability-signoff.md`
+- WeChat runtime observability 签核模板：`docs/release-evidence/wechat-runtime-observability-signoff.template.md`
 - Primary client delivery audit：`npm run audit:cocos-primary-delivery -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--expected-revision <git-sha>]`
 - PR 包装改动门禁：匹配上述路径时，查看 CI artifact `cocos-release-packaging-evidence-<git-sha>`
 - RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
@@ -85,7 +86,7 @@
 9. 若本次 RC 没有自动化 runtime 证据，再运行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir>` 生成模板，并在真机或准真机上逐项补录结果。
 10. 完成自动导入或人工补录后，执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`，确认登录、进房、重连、分享回流、关键资源加载都已有结果记录。
    - `reconnect-recovery` 必须复用 [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md) 的 canonical scenario、最小成功信号和失败诊断口径。
-11. 按 [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md) 为同一 revision 回填 `artifacts/wechat-release/runtime-observability-signoff.json`，确认 release 环境的 `/api/runtime/health`、`/api/runtime/diagnostic-snapshot`、`/api/runtime/metrics` 都已有可追溯证据。
+11. 按 [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md) 与 [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md) 为同一 candidate revision 回填 runtime observability sign-off，确认 release 环境的 `/api/runtime/health`、`/api/runtime/diagnostic-snapshot`、`/api/runtime/metrics` 都已有可追溯证据，并记录 reviewer 与 `recordedAt`。
 12. 运行 `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json [--release-readiness-snapshot artifacts/release-readiness/<candidate>.json]`，脚本会先自动生成 candidate+revision 命名的 `cocos-primary-journey-evidence` JSON / Markdown 与 milestone diagnostics，再一次性输出 bundle manifest、Markdown 摘要、RC snapshot、checklist 与 blockers，并把微信 smoke 的 Lobby / 进房 / 重连证据并入统一的 Cocos RC 快照；若设备 evidence 缺失，会在快照和摘要里显式标成 `partial` 或 `blocked`，而不是默认为通过。
 13. 直接回填同一 bundle 里的 checklist / blockers 文件，仅补充自动化未覆盖的设备、observability 结论和 blocker；不要再额外复制模板或在 PR 里发明另一套字段。
 14. 运行 `npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`，脚本会先复用 `verify:wechat-release` 验收，再调用 `miniprogram-ci` 上传，并在 artifact 目录旁写入 `*.upload.json` 回执。
@@ -150,7 +151,7 @@
 
 - `wechat-devtools-export-review`：真实导出目录已在微信开发者工具中导入并成功启动
 - `wechat-device-runtime-review`：同一 revision 已完成真机或微信开发者工具真机调试 runtime smoke，并附上 `codex.wechat.smoke-report.json`
-- `wechat-runtime-observability-signoff`：同一 revision 的 release 环境已复核 `/api/runtime/health`、`/api/runtime/diagnostic-snapshot`、`/api/runtime/metrics`，并记录任何告警或接受风险
+- `wechat-runtime-observability-signoff`：同一 candidate revision 的 release 环境已复核 `/api/runtime/health`、`/api/runtime/diagnostic-snapshot`、`/api/runtime/metrics`，并记录 reviewer、`recordedAt`、任何告警或接受风险
 - `wechat-release-checklist`：RC checklist / blocker register 已对齐同一 candidate
 
 ## 提审前 Smoke Check

--- a/docs/wechat-runtime-observability-signoff.md
+++ b/docs/wechat-runtime-observability-signoff.md
@@ -5,9 +5,20 @@ This sign-off is the manual release contract for proving that the WeChat candida
 Use it together with:
 
 - [`docs/wechat-minigame-release.md`](./wechat-minigame-release.md)
+- [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md)
 - [`docs/release-evidence/wechat-release-manual-review.example.json`](./release-evidence/wechat-release-manual-review.example.json)
 - [`docs/release-evidence/cocos-wechat-rc-checklist.template.md`](./release-evidence/cocos-wechat-rc-checklist.template.md)
 - [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md)
+
+## When This Artifact Is Required
+
+Treat this sign-off as candidate-scoped release evidence, not a reusable ops note.
+
+- Required for every WeChat `release candidate` or `shipping candidate`.
+- Required when assembling the same-revision release evidence packet described in [`docs/same-revision-release-evidence-runbook.md`](./same-revision-release-evidence-runbook.md).
+- Re-record it whenever the candidate revision changes, or when the candidate touches runtime observability surfaces such as runtime endpoints, metrics dimensions, diagnostic payloads, or alerting assumptions.
+
+Use the dedicated template at [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md) so the output stays aligned with the repo's other release evidence artifacts.
 
 ## Required Evidence
 
@@ -32,7 +43,7 @@ For the same candidate revision, capture and attach:
 
 ## Suggested Artifact Shape
 
-Store one small JSON or Markdown artifact at `artifacts/wechat-release/runtime-observability-signoff.json` and reference it from the WeChat manual-review file.
+Store one small JSON or Markdown artifact under `artifacts/wechat-release/` or `artifacts/release-readiness/` and reference it from the WeChat manual-review file.
 
 Keep the artifact scoped to:
 
@@ -41,3 +52,5 @@ Keep the artifact scoped to:
 - reviewer / timestamp
 - conclusion: `passed | hold | ship-with-followups`
 - follow-ups or blocker IDs
+
+The preferred Markdown shape is the template at [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md). If you emit JSON instead, keep the same fields: candidate, target revision, environment, reviewer, recorded timestamp, per-endpoint status, conclusion, and follow-ups.


### PR DESCRIPTION
## Summary
- add a candidate-scoped WeChat runtime observability sign-off template under `docs/release-evidence/`
- update release/readiness docs to explain when the artifact is required and point maintainers to the canonical template
- keep the artifact shape aligned with the existing release evidence family and same-revision packet flow

## Validation
- `git diff --check`

Closes #660