### PR TITLE
feat: automate Cocos primary client candidate journey evidence

### DIFF
--- a/scripts/cocos-rc-evidence-bundle.ts
+++ b/scripts/cocos-rc-evidence-bundle.ts
@@ -67,6 +67,33 @@ interface CheckpointLedgerEntry {
   telemetryCheckpoints: string[];
 }
 
+interface FailureSummary {
+  summary: string;
+  regressedJourneySegments: Array<{
+    id: string;
+    title: string;
+    status: EvidenceStatus;
+    reason: string;
+  }>;
+  blockedJourneySegments: Array<{
+    id: string;
+    title: string;
+    status: EvidenceStatus;
+    reason: string;
+  }>;
+  lackingJourneyEvidence: Array<{
+    id: string;
+    title: string;
+    status: EvidenceStatus;
+    reason: string;
+  }>;
+  lackingRequiredEvidence: Array<{
+    id: string;
+    label: string;
+    reason: string;
+  }>;
+}
+
 interface CocosReleaseCandidateSnapshot {
   schemaVersion: 1;
   candidate: {
@@ -97,6 +124,7 @@ interface CocosReleaseCandidateSnapshot {
   };
   requiredEvidence: CanonicalEvidenceField[];
   journey: JourneyStep[];
+  failureSummary: FailureSummary;
   checkpointLedger?: {
     source: "primary-journey-evidence";
     milestoneDir: string;
@@ -197,6 +225,7 @@ interface BundleManifest {
       summary: string;
     };
   };
+  failureSummary: FailureSummary;
 }
 
 const DEFAULT_OUTPUT_DIR = path.join("artifacts", "release-readiness");
@@ -601,6 +630,30 @@ function renderBundleMarkdown(snapshot: CocosReleaseCandidateSnapshot, artifacts
   lines.push("## Summary");
   lines.push("");
   lines.push(snapshot.execution.summary);
+  if (
+    snapshot.failureSummary.regressedJourneySegments.length > 0 ||
+    snapshot.failureSummary.blockedJourneySegments.length > 0 ||
+    snapshot.failureSummary.lackingJourneyEvidence.length > 0 ||
+    snapshot.failureSummary.lackingRequiredEvidence.length > 0
+  ) {
+    lines.push("");
+    lines.push("## Failure Summary");
+    lines.push("");
+    lines.push(snapshot.failureSummary.summary);
+    lines.push("");
+    for (const step of snapshot.failureSummary.regressedJourneySegments) {
+      lines.push(`- Regressed: \`${step.id}\` (${step.title}) - ${step.reason}`);
+    }
+    for (const step of snapshot.failureSummary.blockedJourneySegments) {
+      lines.push(`- Blocked: \`${step.id}\` (${step.title}) - ${step.reason}`);
+    }
+    for (const step of snapshot.failureSummary.lackingJourneyEvidence) {
+      lines.push(`- Missing segment evidence: \`${step.id}\` (${step.title}) - ${step.reason}`);
+    }
+    for (const field of snapshot.failureSummary.lackingRequiredEvidence) {
+      lines.push(`- Missing required evidence: \`${field.id}\` (${field.label}) - ${field.reason}`);
+    }
+  }
   lines.push("");
   return `${lines.join("\n")}\n`;
 }
@@ -751,7 +804,8 @@ function buildManifest(snapshot: CocosReleaseCandidateSnapshot, artifacts: Bundl
       attachHint:
         "Attach the markdown bundle summary and presentation sign-off summary to CI artifacts or PR comments, and keep the JSON manifest alongside the snapshot.",
       presentationSignoff: buildPresentationSignoffReview(snapshot)
-    }
+    },
+    failureSummary: snapshot.failureSummary
   };
 }
 

--- a/scripts/cocos-release-candidate-snapshot.ts
+++ b/scripts/cocos-release-candidate-snapshot.ts
@@ -156,6 +156,27 @@ interface CheckpointLedgerEntry {
   telemetryCheckpoints: string[];
 }
 
+interface JourneySegmentFinding {
+  id: JourneyStepId;
+  title: string;
+  status: EvidenceStatus;
+  reason: string;
+}
+
+interface RequiredEvidenceGap {
+  id: CanonicalEvidenceId;
+  label: string;
+  reason: string;
+}
+
+interface FailureSummary {
+  summary: string;
+  regressedJourneySegments: JourneySegmentFinding[];
+  blockedJourneySegments: JourneySegmentFinding[];
+  lackingJourneyEvidence: JourneySegmentFinding[];
+  lackingRequiredEvidence: RequiredEvidenceGap[];
+}
+
 interface CocosReleaseCandidateSnapshot {
   schemaVersion: 1;
   candidate: {
@@ -187,6 +208,7 @@ interface CocosReleaseCandidateSnapshot {
   mappings: EvidenceMapping[];
   requiredEvidence: CanonicalEvidenceField[];
   journey: JourneyStep[];
+  failureSummary: FailureSummary;
   checkpointLedger?: {
     source: "primary-journey-evidence";
     milestoneDir: string;
@@ -612,7 +634,14 @@ function buildTemplate(args: Args): CocosReleaseCandidateSnapshot {
     },
     mappings: buildMappings(),
     requiredEvidence: buildRequiredEvidence(),
-    journey: buildJourney()
+    journey: buildJourney(),
+    failureSummary: {
+      summary: "No regressions or evidence gaps recorded.",
+      regressedJourneySegments: [],
+      blockedJourneySegments: [],
+      lackingJourneyEvidence: [],
+      lackingRequiredEvidence: []
+    }
   };
 
   if (args.primaryJourneyEvidencePath) {
@@ -623,6 +652,7 @@ function buildTemplate(args: Args): CocosReleaseCandidateSnapshot {
   }
 
   recomputeSnapshotExecution(snapshot);
+  snapshot.failureSummary = buildFailureSummary(snapshot);
 
   return snapshot;
 }
@@ -915,6 +945,62 @@ function recomputeSnapshotExecution(snapshot: CocosReleaseCandidateSnapshot): vo
   snapshot.execution.overallStatus = "passed";
 }
 
+function buildFailureSummary(snapshot: CocosReleaseCandidateSnapshot): FailureSummary {
+  const regressedJourneySegments = snapshot.journey
+    .filter((step) => step.required && step.status === "failed")
+    .map((step) => ({
+      id: step.id,
+      title: step.title,
+      status: step.status,
+      reason: step.notes || "Required journey segment regressed."
+    }));
+  const blockedJourneySegments = snapshot.journey
+    .filter((step) => step.required && step.status === "blocked")
+    .map((step) => ({
+      id: step.id,
+      title: step.title,
+      status: step.status,
+      reason: step.notes || "Required journey segment is blocked."
+    }));
+  const lackingJourneyEvidence = snapshot.journey
+    .filter((step) => step.required && step.status === "pending")
+    .map((step) => ({
+      id: step.id,
+      title: step.title,
+      status: step.status,
+      reason: step.notes || "Required journey segment lacks evidence."
+    }));
+  const lackingRequiredEvidence = snapshot.requiredEvidence
+    .filter((field) => field.required && field.value.trim().length === 0)
+    .map((field) => ({
+      id: field.id,
+      label: field.label,
+      reason: field.notes || "Required evidence field is still empty."
+    }));
+
+  const parts: string[] = [];
+  if (regressedJourneySegments.length > 0) {
+    parts.push(`Regressed journey segments: ${regressedJourneySegments.map((step) => step.id).join(", ")}`);
+  }
+  if (blockedJourneySegments.length > 0) {
+    parts.push(`Blocked journey segments: ${blockedJourneySegments.map((step) => step.id).join(", ")}`);
+  }
+  if (lackingJourneyEvidence.length > 0) {
+    parts.push(`Journey segments lacking evidence: ${lackingJourneyEvidence.map((step) => step.id).join(", ")}`);
+  }
+  if (lackingRequiredEvidence.length > 0) {
+    parts.push(`Required evidence still empty: ${lackingRequiredEvidence.map((field) => field.id).join(", ")}`);
+  }
+
+  return {
+    summary: parts.length > 0 ? parts.join(". ") : "No regressions or evidence gaps recorded.",
+    regressedJourneySegments,
+    blockedJourneySegments,
+    lackingJourneyEvidence,
+    lackingRequiredEvidence
+  };
+}
+
 function validateLinkedReleaseReadinessSnapshot(snapshotRef: LinkedEvidenceRef | undefined): void {
   if (!snapshotRef) {
     return;
@@ -953,6 +1039,30 @@ function validateSnapshot(snapshot: CocosReleaseCandidateSnapshot): void {
   }
   assertNonEmptyString(snapshot.execution.summary, "execution.summary");
   assertNonEmptyString(snapshot.environment.server, "environment.server");
+  assertNonEmptyString(snapshot.failureSummary.summary, "failureSummary.summary");
+  for (const entry of snapshot.failureSummary.regressedJourneySegments) {
+    assertNonEmptyString(entry.id, `failureSummary.regressedJourneySegments[${entry.id}].id`);
+    assertNonEmptyString(entry.title, `failureSummary.regressedJourneySegments[${entry.id}].title`);
+    assertEvidenceStatus(entry.status, `failureSummary.regressedJourneySegments[${entry.id}].status`);
+    assertNonEmptyString(entry.reason, `failureSummary.regressedJourneySegments[${entry.id}].reason`);
+  }
+  for (const entry of snapshot.failureSummary.blockedJourneySegments) {
+    assertNonEmptyString(entry.id, `failureSummary.blockedJourneySegments[${entry.id}].id`);
+    assertNonEmptyString(entry.title, `failureSummary.blockedJourneySegments[${entry.id}].title`);
+    assertEvidenceStatus(entry.status, `failureSummary.blockedJourneySegments[${entry.id}].status`);
+    assertNonEmptyString(entry.reason, `failureSummary.blockedJourneySegments[${entry.id}].reason`);
+  }
+  for (const entry of snapshot.failureSummary.lackingJourneyEvidence) {
+    assertNonEmptyString(entry.id, `failureSummary.lackingJourneyEvidence[${entry.id}].id`);
+    assertNonEmptyString(entry.title, `failureSummary.lackingJourneyEvidence[${entry.id}].title`);
+    assertEvidenceStatus(entry.status, `failureSummary.lackingJourneyEvidence[${entry.id}].status`);
+    assertNonEmptyString(entry.reason, `failureSummary.lackingJourneyEvidence[${entry.id}].reason`);
+  }
+  for (const field of snapshot.failureSummary.lackingRequiredEvidence) {
+    assertNonEmptyString(field.id, `failureSummary.lackingRequiredEvidence[${field.id}].id`);
+    assertNonEmptyString(field.label, `failureSummary.lackingRequiredEvidence[${field.id}].label`);
+    assertNonEmptyString(field.reason, `failureSummary.lackingRequiredEvidence[${field.id}].reason`);
+  }
 
   const journeyById = new Map<JourneyStepId, JourneyStep>();
   for (const step of snapshot.journey) {

--- a/scripts/test/cocos-rc-evidence-bundle.test.ts
+++ b/scripts/test/cocos-rc-evidence-bundle.test.ts
@@ -109,6 +109,13 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
 
   const manifest = JSON.parse(fs.readFileSync(path.join(outputDir, manifestFile!), "utf8")) as {
     bundle: { candidate: string; buildSurface: string; overallStatus: string };
+    failureSummary: {
+      summary: string;
+      regressedJourneySegments: Array<{ id: string }>;
+      blockedJourneySegments: Array<{ id: string }>;
+      lackingJourneyEvidence: Array<{ id: string }>;
+      lackingRequiredEvidence: Array<{ id: string }>;
+    };
     artifacts: {
       primaryJourneyEvidence: string;
       primaryJourneyEvidenceMarkdown: string;
@@ -144,6 +151,11 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.equal(path.basename(manifest.artifacts.presentationSignoffSummaryMarkdown), presentationSignoffSummaryFile);
   assert.equal(path.basename(manifest.artifacts.checklistMarkdown), checklistFile);
   assert.equal(path.basename(manifest.artifacts.blockersMarkdown), blockersFile);
+  assert.equal(manifest.failureSummary.summary, "No regressions or evidence gaps recorded.");
+  assert.equal(manifest.failureSummary.regressedJourneySegments.length, 0);
+  assert.equal(manifest.failureSummary.blockedJourneySegments.length, 0);
+  assert.equal(manifest.failureSummary.lackingJourneyEvidence.length, 0);
+  assert.equal(manifest.failureSummary.lackingRequiredEvidence.length, 0);
 
   const summaryMarkdown = fs.readFileSync(path.join(outputDir, summaryFile!), "utf8");
   assert.match(summaryMarkdown, /# Cocos RC Evidence Bundle/);

--- a/scripts/test/cocos-release-candidate-snapshot.test.ts
+++ b/scripts/test/cocos-release-candidate-snapshot.test.ts
@@ -125,6 +125,13 @@ test("release:cocos-rc:snapshot imports WeChat smoke evidence into linked journe
   const snapshot = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
     execution: { overallStatus: string; summary: string; executedAt: string };
     environment: { device: string; wechatClient: string };
+    failureSummary: {
+      summary: string;
+      regressedJourneySegments: Array<{ id: string }>;
+      blockedJourneySegments: Array<{ id: string }>;
+      lackingJourneyEvidence: Array<{ id: string }>;
+      lackingRequiredEvidence: Array<{ id: string }>;
+    };
     requiredEvidence: Array<{ id: string; value: string }>;
     journey: Array<{ id: string; status: string; notes: string }>;
   };
@@ -137,6 +144,14 @@ test("release:cocos-rc:snapshot imports WeChat smoke evidence into linked journe
   assert.equal(snapshot.journey.find((entry) => entry.id === "lobby-entry")?.status, "passed");
   assert.match(snapshot.journey.find((entry) => entry.id === "reconnect-restore")?.notes ?? "", /Recovered room-alpha/);
   assert.match(snapshot.execution.summary, /Automated WeChat smoke evidence passed/);
+  assert.equal(snapshot.failureSummary.regressedJourneySegments.length, 0);
+  assert.equal(snapshot.failureSummary.blockedJourneySegments.length, 0);
+  assert.deepEqual(
+    snapshot.failureSummary.lackingJourneyEvidence.map((entry) => entry.id),
+    ["map-explore", "first-battle", "battle-settlement", "return-to-world"]
+  );
+  assert.deepEqual(snapshot.failureSummary.lackingRequiredEvidence.map((entry) => entry.id), ["firstBattleResult"]);
+  assert.match(snapshot.failureSummary.summary, /Journey segments lacking evidence: map-explore, first-battle, battle-settlement, return-to-world/);
 });
 
 test("release:cocos-rc:snapshot imports primary journey evidence into the canonical RC path", () => {
@@ -217,6 +232,13 @@ test("release:cocos-rc:snapshot imports primary journey evidence into the canoni
     execution: { owner: string; executedAt: string; overallStatus: string; summary: string };
     environment: { server: string };
     linkedEvidence: { primaryJourneyEvidence?: { path: string } };
+    failureSummary: {
+      summary: string;
+      regressedJourneySegments: Array<{ id: string }>;
+      blockedJourneySegments: Array<{ id: string }>;
+      lackingJourneyEvidence: Array<{ id: string }>;
+      lackingRequiredEvidence: Array<{ id: string }>;
+    };
     checkpointLedger?: {
       entryCount: number;
       entries: Array<{ id: string; artifactPath: string; telemetryCheckpoints: string[]; roomId: string }>;
@@ -241,4 +263,9 @@ test("release:cocos-rc:snapshot imports primary journey evidence into the canoni
     "encounter.resolved"
   ]);
   assert.equal(snapshot.checkpointLedger?.entries.find((entry) => entry.id === "room-join")?.roomId, "room-primary-journey");
+  assert.equal(snapshot.failureSummary.summary, "No regressions or evidence gaps recorded.");
+  assert.equal(snapshot.failureSummary.regressedJourneySegments.length, 0);
+  assert.equal(snapshot.failureSummary.blockedJourneySegments.length, 0);
+  assert.equal(snapshot.failureSummary.lackingJourneyEvidence.length, 0);
+  assert.equal(snapshot.failureSummary.lackingRequiredEvidence.length, 0);
 });


### PR DESCRIPTION
## Summary
- add failure summaries to the Cocos release candidate snapshot for regressed, blocked, and missing journey evidence
- surface the failure summary in the RC evidence bundle manifest and markdown output
- cover the new snapshot and bundle fields with targeted script tests

## Testing
- node --import tsx --test ./scripts/test/cocos-release-candidate-snapshot.test.ts ./scripts/test/cocos-rc-evidence-bundle.test.ts
- npm run typecheck:ops

Closes #664