### PR TITLE
release: formalize Cocos presentation fallback sign-off per candidate

### DIFF
--- a/docs/cocos-phase1-presentation-signoff.md
+++ b/docs/cocos-phase1-presentation-signoff.md
@@ -1,6 +1,6 @@
 # Cocos Phase 1 Presentation Placeholder Sign-Off
 
-This checklist is the canonical reviewer-facing record for the remaining Cocos presentation debt that is still allowed to exist during Phase 1 hardening. Use it to make placeholder and fallback behavior explicit before declaring a release candidate fit for Phase 1 exit.
+This checklist is the canonical reviewer-facing process for the remaining Cocos presentation debt that is still allowed to exist during Phase 1 hardening. Use it to make placeholder and fallback behavior explicit before declaring a release candidate fit for Phase 1 exit.
 
 It does not replace the broader RC snapshot, checklist, or blocker log. It narrows one specific question that already appears across the maturity scorecard and release-readiness docs:
 
@@ -23,17 +23,46 @@ For the same candidate revision, keep this checklist next to the existing RC evi
 - [`docs/release-evidence/cocos-wechat-rc-checklist.template.md`](./release-evidence/cocos-wechat-rc-checklist.template.md)
 - [`docs/release-evidence/cocos-wechat-rc-blockers.template.md`](./release-evidence/cocos-wechat-rc-blockers.template.md)
 
+Generate the candidate-scoped artifact with:
+
+```bash
+npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface <surface>
+```
+
+That command now emits:
+
+- `artifacts/release-readiness/cocos-presentation-signoff-<candidate>-<short-sha>.json`
+- `artifacts/release-readiness/cocos-presentation-signoff-<candidate>-<short-sha>.md`
+
+Those files are the attachable per-candidate sign-off record. This doc defines how to review and, if needed, edit the generated checklist before the candidate is widened beyond controlled internal testing.
+
 ## Sign-Off Rules
 
-- Every known placeholder, fallback, or substitution item must have one row in the checklist below.
-- `Status` must be one of `closed`, `accepted-non-blocking`, or `blocking`.
-- `accepted-non-blocking` requires an owner, explicit rationale, and a linked follow-up issue or blocker record.
+- Every known placeholder, fallback, or substitution item must have one row in the candidate artifact checklist below.
+- `Status` must be one of `pass`, `waived-controlled-test`, or `fail`.
+- `waived-controlled-test` means the candidate may be used only for controlled internal testing. It requires an owner, explicit rationale, and a linked follow-up issue or blocker record.
+- `fail` means the candidate is not presentation-ready for wider external evaluation.
 - Phase 1 exit is not signed off until no row remains ambiguous or undocumented.
-- If `cocos-presentation-readiness` or RC evidence reports a new substitution, add it here rather than burying it in free-form notes.
+- If `cocos-presentation-readiness` or RC evidence reports a new substitution, add it to the candidate artifact rather than burying it in free-form notes.
+
+## Blocking Vs Controlled-Test Gaps
+
+Treat a presentation item as `fail` when any of the following is true:
+
+- it makes the first-session journey look materially incomplete for wider external review
+- it is already reported as blocking by `cocos-presentation-readiness`
+- it hides release-required evidence such as room identity, reconnect state, or battle result
+
+Treat a presentation item as `waived-controlled-test` only when all of the following are true:
+
+- the candidate is still functionally passed by the RC snapshot / main journey evidence
+- the gap is acceptable for controlled internal testing only
+- the artifact names an owner, rationale, and follow-up slice
+- the same gap is not being silently widened to broader external review
 
 ## Candidate Header
 
-Copy this section into the active candidate record and fill it before review:
+The generated candidate artifact already fills this header. Review and correct it before sign-off:
 
 - Candidate: `rc-YYYY-MM-DD`
 - Commit: `<git-sha>`
@@ -47,24 +76,25 @@ Copy this section into the active candidate record and fill it before review:
 
 | Area | Example debt to review | Evidence source | Status | Owner | Resolution or acceptance rationale | Follow-up / blocker link |
 | --- | --- | --- | --- | --- | --- | --- |
-| Pixel art / scene visuals | Placeholder tiles, sprites, portraits, icons, temporary VFX, mismatched atlas content | `cocos-presentation-readiness`, RC screenshots/video, Creator preview, WeChat smoke | `closed | accepted-non-blocking | blocking` | `<name>` | What was fixed, or why Phase 1 can ship with this exact gap | Issue / blocker / artifact |
-| Audio | Mixed packs, missing cues, temporary BGM/SFX, abrupt silence or fallback clips | RC video, device smoke notes, audio audit notes | `closed | accepted-non-blocking | blocking` | `<name>` | What remains, player impact, and why it is or is not acceptable | Issue / blocker / artifact |
-| Animation / transitions | Fallback transition modes, missing hit reactions, temporary motion states, abrupt battle entry/exit | RC video, diagnostics markdown, reviewer notes | `closed | accepted-non-blocking | blocking` | `<name>` | What behavior is still fallback and whether it affects the production-intent journey | Issue / blocker / artifact |
-| HUD / copy / readability | Temporary labels, unclear badges, weak state messaging, unresolved placeholder strings, ambiguous battle win/loss settlement copy | RC screenshots, Cocos journey evidence, manual review notes | `closed | accepted-non-blocking | blocking` | `<name>` | Why the current wording is acceptable or what must change before sign-off | Issue / blocker / artifact |
-| Asset substitutions from automation | Any remaining substitution already reported by validation or presentation-readiness output | Validation artifact, release bundle summary, CI artifact | `closed | accepted-non-blocking | blocking` | `<name>` | Explicitly acknowledge each reported substitution instead of assuming it is understood | Issue / blocker / artifact |
+| Pixel art / scene visuals | Placeholder tiles, sprites, portraits, icons, temporary VFX, mismatched atlas content | `cocos-presentation-readiness`, RC screenshots/video, Creator preview, WeChat smoke | `pass | waived-controlled-test | fail` | `<name>` | What was fixed, or why only controlled internal testing is acceptable | Issue / blocker / artifact |
+| Audio | Mixed packs, missing cues, temporary BGM/SFX, abrupt silence or fallback clips | RC video, device smoke notes, audio audit notes | `pass | waived-controlled-test | fail` | `<name>` | What remains, player impact, and why it is or is not acceptable | Issue / blocker / artifact |
+| Animation / transitions | Fallback transition modes, missing hit reactions, temporary motion states, abrupt battle entry/exit | RC video, diagnostics markdown, reviewer notes | `pass | waived-controlled-test | fail` | `<name>` | What behavior is still fallback and whether it affects the production-intent journey | Issue / blocker / artifact |
+| HUD / copy / readability | Temporary labels, unclear badges, weak state messaging, unresolved placeholder strings, ambiguous battle win/loss settlement copy | RC screenshots, Cocos journey evidence, manual review notes | `pass | waived-controlled-test | fail` | `<name>` | Why the current wording is acceptable or what must change before sign-off | Issue / blocker / artifact |
+| Asset substitutions from automation | Any remaining substitution already reported by validation or presentation-readiness output | Validation artifact, release bundle summary, CI artifact | `pass | waived-controlled-test | fail` | `<name>` | Explicitly acknowledge each reported substitution instead of assuming it is understood | Issue / blocker / artifact |
 
 ## Reviewer Decision
 
-- Phase 1 presentation sign-off: `approved | hold`
+- Functional evidence status: `passed | partial | blocked | failed`
+- Phase 1 presentation sign-off: `approved | approved-for-controlled-test | hold`
 - Summary:
 - Blocking items, if any:
-- Accepted non-blocking items, if any:
+- Controlled-test gaps, if any:
 
 ## Exit Standard
 
 For Phase 1 exit, this checklist should end in one of two states:
 
-1. All rows are `closed`.
-2. Some rows are `accepted-non-blocking`, but each one has explicit owner, rationale, and linked follow-up, and none of them undermines the canonical journey `Lobby -> world -> battle -> settlement -> reconnect`.
+1. All rows are `pass`.
+2. Some rows are `waived-controlled-test`, but each one has explicit owner, rationale, and linked follow-up, and none of them undermines the canonical journey `Lobby -> world -> battle -> settlement -> reconnect`.
 
 If a reviewer cannot tell which remaining fallback items are intentional, Phase 1 exit is not yet signed off.

--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -83,10 +83,12 @@ Keep these manual items short and attach evidence through the existing release e
 
 1. Complete the current candidate snapshot with `npm run release:cocos-rc:snapshot`.
 2. Refresh the primary-client diagnostic artifact with `npm run release:cocos:primary-diagnostics`.
-3. Copy and fill the RC checklist/template files in [`docs/release-evidence`](./release-evidence/), and attach the current [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) review for any remaining placeholder/fallback presentation items.
+3. Run `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface <surface>` and keep the generated `cocos-presentation-signoff-<candidate>-<short-sha>.json/.md` with the rest of the candidate bundle.
+   Review that artifact using [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md), and classify each presentation row as `pass`, `waived-controlled-test`, or `fail` so reviewers can distinguish functional RC pass from presentation risk.
    The same candidate evidence should explicitly show one polished battle journey covering encounter entry, at least one command/impact beat, and a stable victory or defeat settlement state before reconnect review.
-4. Record any open risk in the blocker template before sign-off.
-5. Confirm the release candidate still matches the intended commit/revision.
+4. Copy and fill the RC checklist/template files in [`docs/release-evidence`](./release-evidence/), reusing the generated presentation sign-off artifact instead of free-form PR notes.
+5. Record any open risk in the blocker template before sign-off.
+6. Confirm the release candidate still matches the intended commit/revision.
 
 ## Related Commands
 

--- a/scripts/cocos-rc-evidence-bundle.ts
+++ b/scripts/cocos-rc-evidence-bundle.ts
@@ -10,7 +10,8 @@ import {
 type BuildSurface = "creator_preview" | "wechat_preview" | "wechat_upload_candidate" | "other";
 type EvidenceStatus = "pending" | "blocked" | "passed" | "failed" | "not_applicable";
 type SnapshotResult = "pending" | "blocked" | "passed" | "failed" | "partial";
-type PresentationSignoffStatus = "approved" | "hold";
+type PresentationChecklistStatus = "pass" | "waived-controlled-test" | "fail";
+type PresentationSignoffStatus = "approved" | "approved-for-controlled-test" | "hold";
 
 interface Args {
   candidate: string;
@@ -188,7 +189,8 @@ interface BundleManifest {
     mainJourneyManifestMarkdown: string;
     snapshot: string;
     summaryMarkdown: string;
-    presentationSignoffSummaryMarkdown: string;
+    presentationSignoff: string;
+    presentationSignoffMarkdown: string;
     checklistMarkdown: string;
     blockersMarkdown: string;
   };
@@ -220,12 +222,68 @@ interface BundleManifest {
   review: {
     phase1Gate: string;
     attachHint: string;
+    functionalEvidence: {
+      status: SnapshotResult;
+      summary: string;
+    };
     presentationSignoff: {
       status: PresentationSignoffStatus;
       summary: string;
     };
   };
   failureSummary: FailureSummary;
+}
+
+interface PresentationChecklistItem {
+  id: string;
+  area: string;
+  status: PresentationChecklistStatus;
+  blockingPolicy: "blocking" | "acceptable-controlled-test-gap";
+  detail: string;
+  evidence: string[];
+  owner: string;
+  followUp: string;
+}
+
+interface PresentationSignoffArtifact {
+  schemaVersion: 1;
+  candidate: {
+    name: string;
+    buildSurface: BuildSurface;
+    branch: string;
+    commit: string;
+    shortCommit: string;
+  };
+  generatedAt: string;
+  reviewer: {
+    owner: string;
+    reviewDate: string;
+  };
+  linkedEvidence: {
+    snapshot: string;
+    bundleSummary: string;
+    blockers: string;
+    canonicalDoc: string;
+  };
+  functionalEvidence: {
+    status: SnapshotResult;
+    summary: string;
+  };
+  controlledTestPolicy: {
+    blocking: string[];
+    acceptable: string[];
+  };
+  automatedReadiness: {
+    summary: string;
+    nextStep: string;
+  };
+  checklist: PresentationChecklistItem[];
+  signoff: {
+    status: PresentationSignoffStatus;
+    summary: string;
+    blockingItems: string[];
+    controlledTestGaps: string[];
+  };
 }
 
 const DEFAULT_OUTPUT_DIR = path.join("artifacts", "release-readiness");
@@ -576,7 +634,8 @@ function renderBundleMarkdown(snapshot: CocosReleaseCandidateSnapshot, artifacts
   lines.push(`- Main-journey manifest: \`${toRepoRelative(artifacts.mainJourneyManifest)}\``);
   lines.push(`- Main-journey manifest markdown: \`${toRepoRelative(artifacts.mainJourneyManifestMarkdown)}\``);
   lines.push(`- Snapshot: \`${toRepoRelative(artifacts.snapshot)}\``);
-  lines.push(`- Presentation sign-off summary: \`${toRepoRelative(artifacts.presentationSignoffSummaryMarkdown)}\``);
+  lines.push(`- Presentation sign-off JSON: \`${toRepoRelative(artifacts.presentationSignoff)}\``);
+  lines.push(`- Presentation sign-off markdown: \`${toRepoRelative(artifacts.presentationSignoffMarkdown)}\``);
   lines.push(`- Checklist: \`${toRepoRelative(artifacts.checklistMarkdown)}\``);
   lines.push(`- Blockers: \`${toRepoRelative(artifacts.blockersMarkdown)}\``);
   lines.push(`- Bundle manifest: \`${toRepoRelative(artifacts.summaryMarkdown.replace(/\.md$/, ".json"))}\``);
@@ -629,6 +688,7 @@ function renderBundleMarkdown(snapshot: CocosReleaseCandidateSnapshot, artifacts
   }
   lines.push("## Summary");
   lines.push("");
+  lines.push(`- Functional evidence status: \`${snapshot.execution.overallStatus}\``);
   lines.push(snapshot.execution.summary);
   if (
     snapshot.failureSummary.regressedJourneySegments.length > 0 ||
@@ -658,13 +718,159 @@ function renderBundleMarkdown(snapshot: CocosReleaseCandidateSnapshot, artifacts
   return `${lines.join("\n")}\n`;
 }
 
-function buildPresentationSignoffReview(snapshot: CocosReleaseCandidateSnapshot): BundleManifest["review"]["presentationSignoff"] {
-  const releaseGate = getCocosPresentationReleaseGate(cocosPresentationReadiness);
+function buildFunctionalEvidenceReview(snapshot: CocosReleaseCandidateSnapshot): BundleManifest["review"]["functionalEvidence"] {
   return {
-    status: releaseGate.ready ? "approved" : "hold",
-    summary: releaseGate.ready
-      ? `Automated presentation readiness reports production-intent pixel, audio, and animation coverage for candidate ${snapshot.candidate.name}.`
-      : `Automated presentation readiness for candidate ${snapshot.candidate.name} still reports blocking presentation debt: ${releaseGate.blockers.join(", ")}.`
+    status: snapshot.execution.overallStatus,
+    summary: snapshot.execution.summary
+  };
+}
+
+function buildPresentationChecklist(snapshot: CocosReleaseCandidateSnapshot): PresentationChecklistItem[] {
+  const releaseGate = getCocosPresentationReleaseGate(cocosPresentationReadiness);
+  const owner = snapshot.execution.owner || "<name>";
+  const checklist: PresentationChecklistItem[] = [
+    {
+      id: "pixel-art-scene-visuals",
+      area: "Pixel art / scene visuals",
+      status: cocosPresentationReadiness.pixel.stage === "production" ? "pass" : "fail",
+      blockingPolicy: cocosPresentationReadiness.pixel.stage === "production" ? "acceptable-controlled-test-gap" : "blocking",
+      detail: `${cocosPresentationReadiness.pixel.headline}; ${cocosPresentationReadiness.pixel.detail}`,
+      evidence: ["cocos-presentation-readiness", "release bundle summary", "Creator/WeChat captures"],
+      owner,
+      followUp: cocosPresentationReadiness.pixel.stage === "production" ? "none" : "Replace placeholder or mixed visual assets before widening external evaluation."
+    },
+    {
+      id: "audio-fallback-cues",
+      area: "Audio",
+      status: cocosPresentationReadiness.audio.stage === "production" ? "pass" : "waived-controlled-test",
+      blockingPolicy: cocosPresentationReadiness.audio.stage === "production" ? "acceptable-controlled-test-gap" : "acceptable-controlled-test-gap",
+      detail: `${cocosPresentationReadiness.audio.headline}; ${cocosPresentationReadiness.audio.detail}`,
+      evidence: ["cocos-presentation-readiness", "device smoke notes", "battle capture"],
+      owner,
+      followUp: cocosPresentationReadiness.audio.stage === "production" ? "none" : "Allowed only for controlled internal testing while reviewer records player-impact notes and owner follow-up."
+    },
+    {
+      id: "animation-transitions",
+      area: "Animation / transitions",
+      status: releaseGate.blockers.includes("正式动画资产") || releaseGate.blockers.includes("Spine Skeleton") ? "fail" : "pass",
+      blockingPolicy:
+        releaseGate.blockers.includes("正式动画资产") || releaseGate.blockers.includes("Spine Skeleton")
+          ? "blocking"
+          : "acceptable-controlled-test-gap",
+      detail: `${cocosPresentationReadiness.animation.headline}; ${cocosPresentationReadiness.animation.detail}`,
+      evidence: ["cocos-presentation-readiness", "primary journey evidence", "battle diagnostics markdown"],
+      owner,
+      followUp:
+        releaseGate.blockers.includes("正式动画资产") || releaseGate.blockers.includes("Spine Skeleton")
+          ? "Close fallback animation delivery before broader external review."
+          : "none"
+    },
+    {
+      id: "hud-copy-readability",
+      area: "HUD / copy / readability",
+      status: "waived-controlled-test",
+      blockingPolicy: "acceptable-controlled-test-gap",
+      detail:
+        "Manual reviewer must verify Lobby -> world -> battle -> settlement -> reconnect copy remains readable and does not hide required state, even when automation only proves the journey is functionally passed.",
+      evidence: ["primary journey evidence markdown", "manual Creator/WeChat screenshots", "RC checklist"],
+      owner,
+      followUp: "If any copy/state confusion affects first-session comprehension, upgrade this row to fail and link the blocker."
+    },
+    {
+      id: "automation-reported-substitutions",
+      area: "Asset substitutions from automation",
+      status: releaseGate.ready ? "pass" : "fail",
+      blockingPolicy: releaseGate.ready ? "acceptable-controlled-test-gap" : "blocking",
+      detail:
+        releaseGate.ready
+          ? "Automation reports production-intent presentation coverage for the tracked asset families."
+          : `Automation still reports unresolved presentation substitutions: ${releaseGate.blockers.join(", ")}.`,
+      evidence: ["cocos-presentation-readiness", "bundle manifest", "RC blocker log"],
+      owner,
+      followUp: releaseGate.ready ? "none" : "List each unresolved substitution in the candidate blocker log or a follow-up issue before sign-off."
+    }
+  ];
+
+  return checklist;
+}
+
+function summarizePresentationSignoff(
+  snapshot: CocosReleaseCandidateSnapshot,
+  checklist: PresentationChecklistItem[]
+): PresentationSignoffArtifact["signoff"] {
+  const blockingItems = checklist.filter((item) => item.status === "fail").map((item) => item.area);
+  const controlledTestGaps = checklist.filter((item) => item.status === "waived-controlled-test").map((item) => item.area);
+  const status: PresentationSignoffStatus =
+    blockingItems.length > 0 ? "hold" : controlledTestGaps.length > 0 ? "approved-for-controlled-test" : "approved";
+  const summary =
+    status === "hold"
+      ? `Candidate ${snapshot.candidate.name} is functionally ${snapshot.execution.overallStatus}, but presentation sign-off remains on hold: ${blockingItems.join(", ")}.`
+      : status === "approved-for-controlled-test"
+        ? `Candidate ${snapshot.candidate.name} functionally passes, but presentation still carries controlled-test-only gaps: ${controlledTestGaps.join(", ")}.`
+        : `Candidate ${snapshot.candidate.name} has both functional pass evidence and presentation sign-off coverage for the tracked fallback surfaces.`;
+
+  return {
+    status,
+    summary,
+    blockingItems,
+    controlledTestGaps
+  };
+}
+
+function buildPresentationSignoffArtifact(
+  snapshot: CocosReleaseCandidateSnapshot,
+  artifacts: BundleManifest["artifacts"]
+): PresentationSignoffArtifact {
+  const checklist = buildPresentationChecklist(snapshot);
+  const signoff = summarizePresentationSignoff(snapshot, checklist);
+
+  return {
+    schemaVersion: 1,
+    candidate: {
+      name: snapshot.candidate.name,
+      buildSurface: snapshot.candidate.buildSurface,
+      branch: snapshot.candidate.branch,
+      commit: snapshot.candidate.commit,
+      shortCommit: snapshot.candidate.shortCommit
+    },
+    generatedAt: new Date().toISOString(),
+    reviewer: {
+      owner: snapshot.execution.owner,
+      reviewDate: (snapshot.execution.executedAt || new Date().toISOString()).slice(0, 10)
+    },
+    linkedEvidence: {
+      snapshot: toRepoRelative(artifacts.snapshot),
+      bundleSummary: toRepoRelative(artifacts.summaryMarkdown),
+      blockers: toRepoRelative(artifacts.blockersMarkdown),
+      canonicalDoc: "docs/cocos-phase1-presentation-signoff.md"
+    },
+    functionalEvidence: buildFunctionalEvidenceReview(snapshot),
+    controlledTestPolicy: {
+      blocking: [
+        "Any placeholder or fallback issue that makes the first-session journey look materially incomplete for wider external evaluation.",
+        "Any missing or fallback animation/visual surface already reported as blocking by cocos-presentation-readiness.",
+        "Any presentation issue that hides room identity, reconnect state, battle result, or other release-required evidence."
+      ],
+      acceptable: [
+        "Audio polish gaps may be accepted only for controlled internal testing when the candidate remains functionally passed and the reviewer records owner plus follow-up.",
+        "HUD/copy/readability review may stay controlled-test-only when wording is understandable and no required state is obscured.",
+        "Controlled-test waivers must stay out of broad external review until the same candidate or a successor closes the gap."
+      ]
+    },
+    automatedReadiness: {
+      summary: cocosPresentationReadiness.summary,
+      nextStep: cocosPresentationReadiness.nextStep
+    },
+    checklist,
+    signoff
+  };
+}
+
+function buildPresentationSignoffReview(snapshot: CocosReleaseCandidateSnapshot): BundleManifest["review"]["presentationSignoff"] {
+  const artifact = summarizePresentationSignoff(snapshot, buildPresentationChecklist(snapshot));
+  return {
+    status: artifact.status,
+    summary: artifact.summary
   };
 }
 
@@ -672,54 +878,61 @@ function renderPresentationSignoffSummary(
   snapshot: CocosReleaseCandidateSnapshot,
   artifacts: BundleManifest["artifacts"]
 ): string {
-  const releaseGate = getCocosPresentationReleaseGate(cocosPresentationReadiness);
-  const review = buildPresentationSignoffReview(snapshot);
+  const signoff = buildPresentationSignoffArtifact(snapshot, artifacts);
   const lines: string[] = [];
 
-  lines.push("# Cocos Presentation Sign-Off Summary");
+  lines.push("# Cocos Presentation Sign-Off");
   lines.push("");
-  lines.push(
-    "This generated summary narrows the current candidate-level presentation review into one attachable artifact. It does not replace the canonical checklist in `docs/cocos-phase1-presentation-signoff.md`."
-  );
+  lines.push("This generated artifact is the candidate-scoped presentation fallback checklist and sign-off record that travels with the RC bundle.");
   lines.push("");
   lines.push("## Candidate Header");
   lines.push("");
-  lines.push(`- Candidate: \`${snapshot.candidate.name}\``);
-  lines.push(`- Commit: \`${snapshot.candidate.commit}\``);
-  lines.push(`- Surface: \`${snapshot.candidate.buildSurface}\``);
-  lines.push(`- Owner: ${snapshot.execution.owner || "_unassigned_"}`);
-  lines.push(`- Review date: \`${(snapshot.execution.executedAt || new Date().toISOString()).slice(0, 10)}\``);
-  lines.push(`- Linked RC snapshot: \`${toRepoRelative(artifacts.snapshot)}\``);
-  lines.push(`- Linked blocker log: \`${toRepoRelative(artifacts.blockersMarkdown)}\``);
-  lines.push(`- Canonical checklist: \`docs/cocos-phase1-presentation-signoff.md\``);
+  lines.push(`- Candidate: \`${signoff.candidate.name}\``);
+  lines.push(`- Commit: \`${signoff.candidate.commit}\``);
+  lines.push(`- Surface: \`${signoff.candidate.buildSurface}\``);
+  lines.push(`- Owner: ${signoff.reviewer.owner || "_unassigned_"}`);
+  lines.push(`- Review date: \`${signoff.reviewer.reviewDate}\``);
+  lines.push(`- Linked RC snapshot: \`${signoff.linkedEvidence.snapshot}\``);
+  lines.push(`- Linked blocker log: \`${signoff.linkedEvidence.blockers}\``);
+  lines.push(`- Canonical process doc: \`${signoff.linkedEvidence.canonicalDoc}\``);
   lines.push("");
-  lines.push("## Automated Readiness");
+  lines.push("## Evidence Split");
   lines.push("");
-  lines.push(`- Summary: ${cocosPresentationReadiness.summary}`);
-  lines.push(`- Next step: ${cocosPresentationReadiness.nextStep}`);
-  lines.push(`- Automated sign-off status: \`${review.status}\``);
-  lines.push(`- Automated sign-off summary: ${review.summary}`);
+  lines.push(`- Functional evidence status: \`${signoff.functionalEvidence.status}\``);
+  lines.push(`- Functional evidence summary: ${signoff.functionalEvidence.summary}`);
+  lines.push(`- Presentation sign-off status: \`${signoff.signoff.status}\``);
+  lines.push(`- Presentation sign-off summary: ${signoff.signoff.summary}`);
   lines.push("");
-  lines.push("| Area | Stage | Detail |");
-  lines.push("| --- | --- | --- |");
-  lines.push(`| Pixel art / scene visuals | \`${cocosPresentationReadiness.pixel.stage}\` | ${cocosPresentationReadiness.pixel.headline}; ${cocosPresentationReadiness.pixel.detail} |`);
-  lines.push(`| Audio | \`${cocosPresentationReadiness.audio.stage}\` | ${cocosPresentationReadiness.audio.headline}; ${cocosPresentationReadiness.audio.detail} |`);
-  lines.push(`| Animation / transitions | \`${cocosPresentationReadiness.animation.stage}\` | ${cocosPresentationReadiness.animation.headline}; ${cocosPresentationReadiness.animation.detail} |`);
+  lines.push("## Controlled-Test Policy");
+  lines.push("");
+  lines.push("- Blocking gaps:");
+  for (const rule of signoff.controlledTestPolicy.blocking) {
+    lines.push(`  - ${rule}`);
+  }
+  lines.push("- Acceptable only for controlled internal testing:");
+  for (const rule of signoff.controlledTestPolicy.acceptable) {
+    lines.push(`  - ${rule}`);
+  }
+  lines.push("");
+  lines.push("## Checklist");
+  lines.push("");
+  lines.push("| Area | Status | Policy | Detail | Evidence | Follow-up |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
+  for (const item of signoff.checklist) {
+    lines.push(
+      `| ${item.area} | \`${item.status}\` | \`${item.blockingPolicy}\` | ${item.detail} | ${item.evidence.map((entry) => `\`${entry}\``).join("<br>")} | ${item.followUp} |`
+    );
+  }
   lines.push("");
   lines.push("## Reviewer Decision");
   lines.push("");
-  lines.push(`- Phase 1 presentation sign-off: \`${review.status}\``);
-  lines.push(`- Summary: ${review.summary}`);
+  lines.push(`- Phase 1 presentation sign-off: \`${signoff.signoff.status}\``);
+  lines.push(`- Summary: ${signoff.signoff.summary}`);
+  lines.push(`- Blocking items, if any: ${signoff.signoff.blockingItems.length > 0 ? signoff.signoff.blockingItems.join(", ") : "_none_"}.`);
   lines.push(
-    `- Blocking items, if any: ${releaseGate.blockers.length > 0 ? releaseGate.blockers.join(", ") : "_none reported by automated readiness_"}.`
+    `- Controlled-test gaps, if any: ${signoff.signoff.controlledTestGaps.length > 0 ? signoff.signoff.controlledTestGaps.join(", ") : "_none_"}.`
   );
-  lines.push("- Accepted non-blocking items, if any: Record any manual acceptance in `docs/cocos-phase1-presentation-signoff.md` before Phase 1 exit.");
-  lines.push("");
-  lines.push("## Reviewer Follow-Through");
-  lines.push("");
-  lines.push("- Reconcile any remaining placeholder, fallback, or substituted items in the canonical checklist.");
-  lines.push(`- Attach this summary with \`${toRepoRelative(artifacts.summaryMarkdown)}\`, \`${toRepoRelative(artifacts.snapshot)}\`, and \`${toRepoRelative(artifacts.blockersMarkdown)}\` in the release review packet.`);
-  lines.push("- If a blocker is accepted as non-blocking, record owner, rationale, and follow-up issue explicitly.");
+  lines.push(`- Attach this markdown plus \`${toRepoRelative(artifacts.presentationSignoff)}\` with the RC snapshot and blocker log.`);
   lines.push("");
 
   return `${lines.join("\n")}\n`;
@@ -803,6 +1016,7 @@ function buildManifest(snapshot: CocosReleaseCandidateSnapshot, artifacts: Bundl
       phase1Gate: "Phase 1 exit criterion 4: candidate-specific Cocos primary-client evidence must be current.",
       attachHint:
         "Attach the markdown bundle summary and presentation sign-off summary to CI artifacts or PR comments, and keep the JSON manifest alongside the snapshot.",
+      functionalEvidence: buildFunctionalEvidenceReview(snapshot),
       presentationSignoff: buildPresentationSignoffReview(snapshot)
     },
     failureSummary: snapshot.failureSummary
@@ -823,7 +1037,8 @@ function main(): void {
   const manifestPath = path.join(outputDir, `cocos-rc-evidence-bundle-${baseName}.json`);
   const mainJourneyManifestPath = path.join(outputDir, `cocos-main-journey-manifest-${baseName}.json`);
   const mainJourneyManifestMarkdownPath = path.join(outputDir, `cocos-main-journey-manifest-${baseName}.md`);
-  const presentationSignoffSummaryPath = path.join(outputDir, `cocos-presentation-signoff-summary-${baseName}.md`);
+  const presentationSignoffPath = path.join(outputDir, `cocos-presentation-signoff-${baseName}.json`);
+  const presentationSignoffSummaryPath = path.join(outputDir, `cocos-presentation-signoff-${baseName}.md`);
   const checklistPath = path.join(outputDir, `cocos-rc-checklist-${baseName}.md`);
   const blockersPath = path.join(outputDir, `cocos-rc-blockers-${baseName}.md`);
 
@@ -842,15 +1057,18 @@ function main(): void {
     mainJourneyManifestMarkdown: path.resolve(mainJourneyManifestMarkdownPath),
     snapshot: path.resolve(snapshotPath),
     summaryMarkdown: path.resolve(summaryMarkdownPath),
-    presentationSignoffSummaryMarkdown: path.resolve(presentationSignoffSummaryPath),
+    presentationSignoff: path.resolve(presentationSignoffPath),
+    presentationSignoffMarkdown: path.resolve(presentationSignoffSummaryPath),
     checklistMarkdown: path.resolve(checklistPath),
     blockersMarkdown: path.resolve(blockersPath)
   };
   const mainJourneyManifest = buildMainJourneyManifest(snapshot, artifacts);
+  const presentationSignoff = buildPresentationSignoffArtifact(snapshot, artifacts);
 
   writeJsonFile(mainJourneyManifestPath, mainJourneyManifest, args.force);
   writeTextFile(mainJourneyManifestMarkdownPath, renderMainJourneyManifestMarkdown(mainJourneyManifest), args.force);
   writeTextFile(summaryMarkdownPath, renderBundleMarkdown(snapshot, artifacts), args.force);
+  writeJsonFile(presentationSignoffPath, presentationSignoff, args.force);
   writeTextFile(presentationSignoffSummaryPath, renderPresentationSignoffSummary(snapshot, artifacts), args.force);
   writeTextFile(checklistPath, renderChecklist(snapshot, artifacts), args.force);
   writeTextFile(blockersPath, renderBlockers(snapshot, artifacts), args.force);

--- a/scripts/test/cocos-rc-evidence-bundle.test.ts
+++ b/scripts/test/cocos-rc-evidence-bundle.test.ts
@@ -89,9 +89,8 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   const snapshotFile = files.find((entry) => entry.startsWith("cocos-rc-snapshot-") && entry.endsWith(".json"));
   const mainJourneyManifestFile = files.find((entry) => entry.startsWith("cocos-main-journey-manifest-") && entry.endsWith(".json"));
   const mainJourneyManifestMarkdownFile = files.find((entry) => entry.startsWith("cocos-main-journey-manifest-") && entry.endsWith(".md"));
-  const presentationSignoffSummaryFile = files.find(
-    (entry) => entry.startsWith("cocos-presentation-signoff-summary-") && entry.endsWith(".md")
-  );
+  const presentationSignoffFile = files.find((entry) => entry.startsWith("cocos-presentation-signoff-") && entry.endsWith(".json"));
+  const presentationSignoffMarkdownFile = files.find((entry) => entry.startsWith("cocos-presentation-signoff-") && entry.endsWith(".md"));
   const checklistFile = files.find((entry) => entry.startsWith("cocos-rc-checklist-") && entry.endsWith(".md"));
   const blockersFile = files.find((entry) => entry.startsWith("cocos-rc-blockers-") && entry.endsWith(".md"));
 
@@ -102,7 +101,8 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.ok(snapshotFile);
   assert.ok(mainJourneyManifestFile);
   assert.ok(mainJourneyManifestMarkdownFile);
-  assert.ok(presentationSignoffSummaryFile);
+  assert.ok(presentationSignoffFile);
+  assert.ok(presentationSignoffMarkdownFile);
   assert.ok(checklistFile);
   assert.ok(blockersFile);
   assert.match(manifestFile ?? "", /rc-issue-507-/);
@@ -123,9 +123,14 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
       mainJourneyManifestMarkdown: string;
       snapshot: string;
       summaryMarkdown: string;
-      presentationSignoffSummaryMarkdown: string;
+      presentationSignoff: string;
+      presentationSignoffMarkdown: string;
       checklistMarkdown: string;
       blockersMarkdown: string;
+    };
+    review: {
+      functionalEvidence: { status: string; summary: string };
+      presentationSignoff: { status: string; summary: string };
     };
     journey: Array<{ id: string; status: string }>;
     checkpointLedger?: {
@@ -148,9 +153,14 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.equal(manifest.requiredEvidence.find((entry) => entry.id === "roomId")?.filled, true);
   assert.equal(path.basename(manifest.artifacts.snapshot), snapshotFile);
   assert.equal(path.basename(manifest.artifacts.summaryMarkdown), summaryFile);
-  assert.equal(path.basename(manifest.artifacts.presentationSignoffSummaryMarkdown), presentationSignoffSummaryFile);
+  assert.equal(path.basename(manifest.artifacts.presentationSignoff), presentationSignoffFile);
+  assert.equal(path.basename(manifest.artifacts.presentationSignoffMarkdown), presentationSignoffMarkdownFile);
   assert.equal(path.basename(manifest.artifacts.checklistMarkdown), checklistFile);
   assert.equal(path.basename(manifest.artifacts.blockersMarkdown), blockersFile);
+  assert.equal(manifest.review.functionalEvidence.status, "passed");
+  assert.match(manifest.review.functionalEvidence.summary, /lobby, room, and reconnect/);
+  assert.equal(manifest.review.presentationSignoff.status, "hold");
+  assert.match(manifest.review.presentationSignoff.summary, /presentation sign-off remains on hold/);
   assert.equal(manifest.failureSummary.summary, "No regressions or evidence gaps recorded.");
   assert.equal(manifest.failureSummary.regressedJourneySegments.length, 0);
   assert.equal(manifest.failureSummary.blockedJourneySegments.length, 0);
@@ -162,7 +172,9 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.match(summaryMarkdown, /Overall status: `passed`/);
   assert.match(summaryMarkdown, /Primary journey evidence:/);
   assert.match(summaryMarkdown, /Main-journey manifest:/);
-  assert.match(summaryMarkdown, /Presentation sign-off summary:/);
+  assert.match(summaryMarkdown, /Presentation sign-off JSON:/);
+  assert.match(summaryMarkdown, /Presentation sign-off markdown:/);
+  assert.match(summaryMarkdown, /Functional evidence status: `passed`/);
   assert.match(summaryMarkdown, /Lobby entry \| `passed` \| 2 item\(s\)/);
   assert.match(summaryMarkdown, /## Checkpoint Ledger/);
   assert.match(summaryMarkdown, /Battle settlement/);
@@ -186,12 +198,25 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.match(mainJourneyManifestMarkdown, /placeholder=yes, manual-only=yes/);
   assert.match(mainJourneyManifestMarkdown, /Room join/);
 
-  const presentationSignoffSummaryMarkdown = fs.readFileSync(path.join(outputDir, presentationSignoffSummaryFile!), "utf8");
-  assert.match(presentationSignoffSummaryMarkdown, /# Cocos Presentation Sign-Off Summary/);
-  assert.match(presentationSignoffSummaryMarkdown, /Candidate: `rc-issue-507`/);
-  assert.match(presentationSignoffSummaryMarkdown, /Commit: `/);
-  assert.match(presentationSignoffSummaryMarkdown, /Automated sign-off status: `hold`/);
-  assert.match(presentationSignoffSummaryMarkdown, /Canonical checklist: `docs\/cocos-phase1-presentation-signoff\.md`/);
+  const presentationSignoff = JSON.parse(fs.readFileSync(path.join(outputDir, presentationSignoffFile!), "utf8")) as {
+    functionalEvidence: { status: string; summary: string };
+    checklist: Array<{ area: string; status: string; blockingPolicy: string }>;
+    signoff: { status: string; blockingItems: string[]; controlledTestGaps: string[]; summary: string };
+  };
+  assert.equal(presentationSignoff.functionalEvidence.status, "passed");
+  assert.equal(presentationSignoff.signoff.status, "hold");
+  assert.ok(presentationSignoff.checklist.some((entry) => entry.area === "Audio" && entry.status === "waived-controlled-test"));
+  assert.ok(presentationSignoff.checklist.some((entry) => entry.area === "Animation / transitions" && entry.blockingPolicy === "blocking"));
+  assert.ok(presentationSignoff.signoff.blockingItems.includes("Pixel art / scene visuals"));
+  assert.ok(presentationSignoff.signoff.controlledTestGaps.includes("Audio"));
+
+  const presentationSignoffMarkdown = fs.readFileSync(path.join(outputDir, presentationSignoffMarkdownFile!), "utf8");
+  assert.match(presentationSignoffMarkdown, /# Cocos Presentation Sign-Off/);
+  assert.match(presentationSignoffMarkdown, /Candidate: `rc-issue-507`/);
+  assert.match(presentationSignoffMarkdown, /Functional evidence status: `passed`/);
+  assert.match(presentationSignoffMarkdown, /Presentation sign-off status: `hold`/);
+  assert.match(presentationSignoffMarkdown, /waived-controlled-test/);
+  assert.match(presentationSignoffMarkdown, /acceptable-controlled-test-gap/);
 
   const checklistMarkdown = fs.readFileSync(path.join(outputDir, checklistFile!), "utf8");
   assert.match(checklistMarkdown, /Candidate: `rc-issue-507`/);


### PR DESCRIPTION
## Summary
- formalize a candidate-scoped Cocos presentation sign-off artifact in the RC bundle
- distinguish functional RC pass from presentation risk, including controlled-test-only gaps
- document the sign-off workflow and targeted status semantics for candidate review

## Testing
- node --import tsx --test scripts/test/cocos-rc-evidence-bundle.test.ts
- node --import tsx --test scripts/test/cocos-release-candidate-snapshot.test.ts
- npm run typecheck:ops

Closes #668