### PR TITLE
release: standardize WeChat device runtime evidence in RC summaries

### DIFF
--- a/docs/release-evidence/wechat-release-manual-review.example.json
+++ b/docs/release-evidence/wechat-release-manual-review.example.json
@@ -27,7 +27,11 @@
     "artifactPath": "artifacts/wechat-release/device-runtime-review.json",
     "evidence": [
       "artifacts/wechat-release/codex.wechat.smoke-report.json",
-      "startup / reconnect / share recordings"
+      "login-lobby capture",
+      "room-entry capture",
+      "reconnect-recovery capture",
+      "share-roundtrip capture",
+      "key-assets capture"
     ]
   },
   {

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -132,8 +132,8 @@
 同时 `validate:wechat-rc` 现在会为 reviewer 生成一份 candidate summary：
 
 - `codex.wechat.release-candidate-summary.json`：candidate-level contract，固定引用同一 revision 的 package、validation、smoke、upload、manual review 状态
-- `codex.wechat.release-candidate-summary.md`：可直接贴进 PR、CI summary 或提审记录的精简摘要
-- `blockers`：显式列出缺失 smoke report、失败校验、待完成 manual review，以及对应 artifact / next command
+- `codex.wechat.release-candidate-summary.md`：可直接贴进 PR、CI summary 或提审记录的精简摘要；会额外展开 WeChat 设备/runtime 执行人、设备、执行时间、五个 smoke case 状态，以及 reconnect/share 的结构化字段
+- `blockers`：显式列出缺失 smoke report、失败校验、待完成 manual review，以及对应 artifact / next command；若 smoke report 的 `execution.executedAt` 缺失、非法或早于 summary 生成时间 24h，也会直接阻塞 candidate
 - `--manual-checks <json>`：读取显式 manual review 状态；推荐直接从 `docs/release-evidence/wechat-release-manual-review.example.json` 复制当次 candidate 文件
 - `--manual-check <id>:<title>`：临时追加一条 pending manual review
 - `npm run release:wechat:rehearsal` 的 `## Artifacts` 区块会自动列出 `codex.wechat.release-candidate-summary.json` / `.md`，方便 reviewer 或 PR 作者直接复制 `.md` 文件内容到评论区，并将 `.json` 作为结构化证据随 artifact 一起上传
@@ -150,7 +150,7 @@
 默认 required checks 分别对应三类 release evidence：
 
 - `wechat-devtools-export-review`：真实导出目录已在微信开发者工具中导入并成功启动
-- `wechat-device-runtime-review`：同一 revision 已完成真机或微信开发者工具真机调试 runtime smoke，并附上 `codex.wechat.smoke-report.json`
+- `wechat-device-runtime-review`：同一 revision 已完成真机或微信开发者工具真机调试 runtime smoke，并附上 `codex.wechat.smoke-report.json`、`login-lobby`、`room-entry`、`reconnect-recovery`、`share-roundtrip`、`key-assets` 对应 capture
 - `wechat-runtime-observability-signoff`：同一 candidate revision 的 release 环境已复核 `/api/runtime/health`、`/api/runtime/diagnostic-snapshot`、`/api/runtime/metrics`，并记录 reviewer、`recordedAt`、任何告警或接受风险
 - `wechat-release-checklist`：RC checklist / blocker register 已对齐同一 candidate
 

--- a/scripts/test/wechat-release-artifacts.test.ts
+++ b/scripts/test/wechat-release-artifacts.test.ts
@@ -109,7 +109,7 @@ function writePassingSmokeReport(metadataPath: string, reportPath: string): void
       tester: "codex",
       device: "iPhone 15 / WeChat 8.0.x",
       clientVersion: "1.0.155",
-      executedAt: "2026-03-30T09:00:00+08:00",
+      executedAt: "2026-04-02T09:00:00+08:00",
       result: "passed",
       summary: "All required smoke cases passed."
     },
@@ -532,6 +532,12 @@ test("validate:wechat-rc marks the candidate ready when smoke evidence and manua
       package: { status: string };
       validation: { status: string };
       smoke: { status: string };
+      deviceRuntime: {
+        status: string;
+        freshness: string;
+        execution: { tester: string; device: string };
+        cases: Array<{ id: string; status: string; requiredEvidence?: Record<string, string> }>;
+      } | null;
       manualReview: { status: string; requiredPendingChecks: number; requiredFailedChecks: number };
     };
     blockers: Array<{ id: string }>;
@@ -543,11 +549,119 @@ test("validate:wechat-rc marks the candidate ready when smoke evidence and manua
   assert.equal(summary.evidence.package.status, "passed");
   assert.equal(summary.evidence.validation.status, "passed");
   assert.equal(summary.evidence.smoke.status, "passed");
+  assert.equal(summary.evidence.deviceRuntime?.status, "ready");
+  assert.equal(summary.evidence.deviceRuntime?.freshness, "fresh");
+  assert.equal(summary.evidence.deviceRuntime?.execution.tester, "codex");
+  assert.match(summary.evidence.deviceRuntime?.execution.device ?? "", /iPhone 15/);
+  assert.equal(summary.evidence.deviceRuntime?.cases.find((entry) => entry.id === "share-roundtrip")?.requiredEvidence?.shareScene, "lobby");
   assert.equal(summary.evidence.manualReview.status, "ready");
   assert.equal(summary.evidence.manualReview.requiredPendingChecks, 0);
   assert.equal(summary.evidence.manualReview.requiredFailedChecks, 0);
   assert.equal(summary.blockers.length, 0);
   assert.match(fs.readFileSync(markdownPath, "utf8"), /Candidate status: `ready`/);
+  assert.match(fs.readFileSync(markdownPath, "utf8"), /## Device Runtime Evidence/);
+  assert.match(fs.readFileSync(markdownPath, "utf8"), /reconnect details: roomId=room-alpha/);
+  assert.match(fs.readFileSync(markdownPath, "utf8"), /share details: shareScene=lobby/);
+});
+
+test("validate:wechat-rc blocks stale device runtime evidence in the candidate summary", () => {
+  const artifact = packageFixtureArtifact();
+  const smokeReportPath = path.join(artifact.artifactsDir, "codex.wechat.smoke-report.json");
+  const manualChecksPath = path.join(artifact.artifactsDir, "wechat-manual-review.json");
+  const summaryPath = path.join(artifact.artifactsDir, "codex.wechat.release-candidate-summary.json");
+
+  writePassingSmokeReport(artifact.metadataPath, smokeReportPath);
+  const staleReport = JSON.parse(fs.readFileSync(smokeReportPath, "utf8")) as {
+    execution: { executedAt: string };
+  };
+  staleReport.execution.executedAt = "2026-03-30T09:00:00+08:00";
+  fs.writeFileSync(smokeReportPath, `${JSON.stringify(staleReport, null, 2)}\n`, "utf8");
+
+  writeManualChecks(manualChecksPath, [
+    {
+      id: "wechat-devtools-export-review",
+      title: "Real WeChat export imported and launched in Developer Tools",
+      status: "passed",
+      required: true,
+      notes: "ok",
+      evidence: ["devtools-startup.png"],
+      owner: "release-oncall",
+      recordedAt: "2026-04-02T08:10:00.000Z",
+      revision: sourceRevision
+    },
+    {
+      id: "wechat-device-runtime-review",
+      title: "Physical-device WeChat runtime validated for this candidate",
+      status: "passed",
+      required: true,
+      notes: "ok",
+      evidence: ["artifacts/wechat-release/codex.wechat.smoke-report.json", "device-runtime.mp4"],
+      owner: "release-oncall",
+      recordedAt: "2026-04-02T08:12:00.000Z",
+      revision: sourceRevision
+    },
+    {
+      id: "wechat-runtime-observability-signoff",
+      title: "WeChat runtime observability reviewed for this candidate",
+      status: "passed",
+      required: true,
+      notes: "ok",
+      evidence: ["/api/runtime/health payload"],
+      owner: "release-oncall",
+      recordedAt: "2026-04-02T08:14:00.000Z",
+      revision: sourceRevision
+    },
+    {
+      id: "wechat-release-checklist",
+      title: "WeChat RC checklist and blockers reviewed",
+      status: "passed",
+      required: true,
+      notes: "ok",
+      evidence: ["docs/release-evidence/cocos-wechat-rc-checklist.template.md"],
+      owner: "release-oncall",
+      recordedAt: "2026-04-02T08:15:00.000Z",
+      revision: sourceRevision
+    }
+  ]);
+
+  const output = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/validate-wechat-release-candidate.ts",
+      "--archive",
+      artifact.archivePath,
+      "--metadata",
+      artifact.metadataPath,
+      "--smoke-report",
+      smokeReportPath,
+      "--manual-checks",
+      manualChecksPath,
+      "--summary",
+      summaryPath,
+      "--expected-revision",
+      sourceRevision
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8")) as {
+    candidate: { status: string };
+    evidence: { deviceRuntime: { status: string; freshness: string } | null };
+    blockers: Array<{ id: string; summary: string }>;
+  };
+
+  assert.match(output, /Candidate status: blocked/);
+  assert.equal(summary.candidate.status, "blocked");
+  assert.equal(summary.evidence.deviceRuntime?.status, "blocked");
+  assert.equal(summary.evidence.deviceRuntime?.freshness, "stale");
+  assert.deepEqual(summary.blockers.map((entry) => entry.id), ["smoke-report-stale"]);
+  assert.match(summary.blockers[0]?.summary ?? "", /older than 24h/);
 });
 
 test("smoke:wechat-release ingests automated runtime evidence into the existing smoke schema", () => {

--- a/scripts/validate-wechat-release-candidate.ts
+++ b/scripts/validate-wechat-release-candidate.ts
@@ -7,6 +7,20 @@ type CheckStatus = "passed" | "failed" | "skipped";
 type GateStatus = "passed" | "failed";
 type CandidateStatus = "ready" | "blocked";
 type EvidenceFreshness = "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp";
+type SmokeExecutionResult = "pending" | "blocked" | "passed" | "failed";
+type SmokeStatus = "pending" | "blocked" | "passed" | "failed" | "not_applicable";
+
+interface ReconnectRecoveryEvidence {
+  roomId: string;
+  reconnectPrompt: string;
+  restoredState: string;
+}
+
+interface ShareRoundtripEvidence {
+  shareScene: string;
+  shareQuery: string;
+  roundtripState: string;
+}
 
 interface Args {
   artifactsDir?: string;
@@ -56,6 +70,42 @@ interface UploadReceipt {
   usedAppIdOverride: boolean;
   uploadRobot: number;
   uploadedAt: string;
+}
+
+interface WechatMinigameSmokeCase {
+  id: "login-lobby" | "room-entry" | "reconnect-recovery" | "share-roundtrip" | "key-assets";
+  title: string;
+  status: SmokeStatus;
+  required: boolean;
+  notes: string;
+  evidence: string[];
+  steps: string[];
+  requiredEvidence?: ReconnectRecoveryEvidence | ShareRoundtripEvidence;
+}
+
+interface WechatMinigameSmokeReport {
+  schemaVersion: 1;
+  buildTemplatePlatform: "wechatgame";
+  projectName: string;
+  appId: string;
+  artifact: {
+    archiveFileName: string;
+    archiveSha256: string;
+    artifactsDir?: string;
+    metadataPath: string;
+    sourceRevision?: string;
+    runtimeRemoteUrl?: string;
+    remoteAssetRoot?: string;
+  };
+  execution: {
+    tester: string;
+    device: string;
+    clientVersion: string;
+    executedAt: string;
+    result: SmokeExecutionResult;
+    summary: string;
+  };
+  cases: WechatMinigameSmokeCase[];
 }
 
 interface ValidationCheck {
@@ -149,6 +199,20 @@ interface CandidateSummary {
       summary: string;
       artifactPath: string;
     };
+    deviceRuntime: {
+      status: CandidateStatus;
+      freshness: EvidenceFreshness;
+      artifactPath: string;
+      execution: {
+        tester: string;
+        device: string;
+        clientVersion: string;
+        executedAt: string;
+        result: SmokeExecutionResult;
+        summary: string;
+      };
+      cases: WechatMinigameSmokeCase[];
+    } | null;
     upload: {
       status: CheckStatus;
       summary: string;
@@ -190,7 +254,14 @@ const DEFAULT_MANUAL_CHECKS: ManualReviewCheck[] = [
     required: true,
     status: "pending",
     notes: "Attach the smoke report and supporting captures from a physical-device or WeChat real-device-debugging runtime pass against the same candidate revision.",
-    evidence: ["artifacts/wechat-release/codex.wechat.smoke-report.json", "startup/reconnect/share capture"],
+    evidence: [
+      "artifacts/wechat-release/codex.wechat.smoke-report.json",
+      "login-lobby capture",
+      "room-entry capture",
+      "reconnect-recovery capture",
+      "share-roundtrip capture",
+      "key-assets capture"
+    ],
     source: "default"
   },
   {
@@ -562,6 +633,7 @@ function buildCandidateSummary(
   manualChecks: ManualReviewCheck[],
   metadata: WechatMinigameReleasePackageMetadata,
   artifacts: { artifactsDir?: string; archivePath: string; metadataPath: string },
+  smokeReport: WechatMinigameSmokeReport | null,
   reportPath: string,
   summaryPath: string,
   markdownPath: string,
@@ -576,6 +648,7 @@ function buildCandidateSummary(
   const generatedAt = new Date().toISOString();
   const generatedAtMs = Date.parse(generatedAt);
   const manualMetadataFailures = manualChecks.flatMap((check) => collectManualReviewMetadataFailures(check, commit, generatedAtMs));
+  const smokeFreshness = smokeReport ? evaluateManualReviewFreshness(smokeReport.execution.executedAt, generatedAtMs) : "missing_timestamp";
 
   for (const check of checks) {
     if (check.status === "failed") {
@@ -594,6 +667,27 @@ function buildCandidateSummary(
       artifactPath: smokeCheck.artifactPath,
       nextCommand: "npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]"
     });
+  } else if (smokeReport) {
+    if (smokeFreshness === "missing_timestamp") {
+      blockers.push({
+        id: "smoke-report-metadata",
+        summary: "Smoke report is missing execution.executedAt; WeChat device/runtime evidence must include a capture timestamp.",
+        artifactPath: smokeCheck.artifactPath
+      });
+    } else if (smokeFreshness === "invalid_timestamp") {
+      blockers.push({
+        id: "smoke-report-metadata",
+        summary: `Smoke report execution.executedAt is invalid: ${smokeReport.execution.executedAt}.`,
+        artifactPath: smokeCheck.artifactPath
+      });
+    } else if (smokeFreshness === "stale") {
+      blockers.push({
+        id: "smoke-report-stale",
+        summary: `Smoke report is stale: ${smokeReport.execution.executedAt} is older than 24h for this RC summary.`,
+        artifactPath: smokeCheck.artifactPath,
+        nextCommand: "npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]"
+      });
+    }
   }
 
   for (const check of manualChecks) {
@@ -666,6 +760,17 @@ function buildCandidateSummary(
           smokeCheck.artifactPath ??
           path.join(artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath), "codex.wechat.smoke-report.json")
       },
+      deviceRuntime: smokeReport
+        ? {
+            status: smokeCheck.status === "passed" && smokeFreshness === "fresh" ? "ready" : "blocked",
+            freshness: smokeFreshness,
+            artifactPath:
+              smokeCheck.artifactPath ??
+              path.join(artifacts.artifactsDir ?? path.dirname(artifacts.metadataPath), "codex.wechat.smoke-report.json"),
+            execution: smokeReport.execution,
+            cases: smokeReport.cases
+          }
+        : null,
       upload: {
         status: uploadCheck.status,
         summary: uploadCheck.summary,
@@ -708,10 +813,42 @@ function renderCandidateMarkdown(summary: CandidateSummary): string {
   lines.push(
     `- Smoke evidence: \`${summary.evidence.smoke.status}\` (${summary.evidence.smoke.summary}) -> \`${path.relative(process.cwd(), summary.evidence.smoke.artifactPath).replace(/\\\\/g, "/")}\``
   );
+  if (summary.evidence.deviceRuntime) {
+    lines.push(
+      `- Device runtime evidence: \`${summary.evidence.deviceRuntime.status}\` (freshness: \`${summary.evidence.deviceRuntime.freshness}\`) -> \`${path.relative(process.cwd(), summary.evidence.deviceRuntime.artifactPath).replace(/\\\\/g, "/")}\``
+    );
+  }
   lines.push(
     `- Upload receipt: \`${summary.evidence.upload.status}\` (${summary.evidence.upload.summary}) -> \`${path.relative(process.cwd(), summary.evidence.upload.artifactPath).replace(/\\\\/g, "/")}\``,
     ""
   );
+  if (summary.evidence.deviceRuntime) {
+    lines.push("## Device Runtime Evidence", "");
+    lines.push(`- Result: \`${summary.evidence.deviceRuntime.execution.result}\``);
+    lines.push(`- Executed at: \`${summary.evidence.deviceRuntime.execution.executedAt}\``);
+    lines.push(`- Tester: \`${summary.evidence.deviceRuntime.execution.tester}\``);
+    lines.push(`- Device: \`${summary.evidence.deviceRuntime.execution.device}\``);
+    lines.push(`- Client version: \`${summary.evidence.deviceRuntime.execution.clientVersion}\``);
+    lines.push(`- Summary: ${summary.evidence.deviceRuntime.execution.summary}`, "");
+    for (const entry of summary.evidence.deviceRuntime.cases) {
+      lines.push(
+        `- \`${entry.status}\` ${entry.id}: ${entry.title}${entry.notes ? ` - ${entry.notes}` : ""}${entry.evidence.length > 0 ? ` Evidence: ${entry.evidence.join(", ")}` : ""}`
+      );
+      if (entry.id === "reconnect-recovery" && entry.requiredEvidence) {
+        const requiredEvidence = entry.requiredEvidence as ReconnectRecoveryEvidence;
+        lines.push(
+          `  reconnect details: roomId=${requiredEvidence.roomId}; reconnectPrompt=${requiredEvidence.reconnectPrompt}; restoredState=${requiredEvidence.restoredState}`
+        );
+      }
+      if (entry.id === "share-roundtrip" && entry.requiredEvidence) {
+        const requiredEvidence = entry.requiredEvidence as ShareRoundtripEvidence;
+        lines.push(
+          `  share details: shareScene=${requiredEvidence.shareScene}; shareQuery=${requiredEvidence.shareQuery}; roundtripState=${requiredEvidence.roundtripState}`
+        );
+      }
+    }
+    lines.push("");
+  }
   lines.push("## Manual Review", "");
   for (const check of summary.evidence.manualReview.checks) {
     const evidence = check.evidence.length > 0 ? ` Evidence: ${check.evidence.join(", ")}` : "";
@@ -890,6 +1027,7 @@ function main(): void {
   const commit = metadata.sourceRevision ?? args.expectedRevision ?? null;
   let version = args.version ?? null;
   let exitCode = 0;
+  let smokeReport: WechatMinigameSmokeReport | null = null;
 
   try {
     validatePackageMetadataShape(metadata, artifacts.archivePath);
@@ -952,6 +1090,9 @@ function main(): void {
     smokeCheck.id = "smoke-report";
     smokeCheck.title = "Smoke report validation";
     smokeCheck.required = args.requireSmokeReport;
+    if (smokeCheck.status === "passed" && fs.existsSync(smokeReportPath)) {
+      smokeReport = readJsonFile<WechatMinigameSmokeReport>(smokeReportPath);
+    }
     if (smokeCheck.status === "failed" || args.requireSmokeReport) {
       checks.push(smokeCheck);
       if (smokeCheck.status === "failed") {
@@ -1060,6 +1201,7 @@ function main(): void {
     manualChecks,
     metadata,
     artifacts,
+    smokeReport,
     reportPath,
     summaryPath,
     markdownPath,


### PR DESCRIPTION
## Summary
- surface structured WeChat device runtime execution and case evidence directly in RC summaries
- block candidate summaries when the attached WeChat smoke report is stale for more than 24h
- standardize the documented/manual-review evidence list for login, room entry, reconnect, share roundtrip, and key assets

## Testing
- node --import tsx --test ./scripts/test/wechat-release-artifacts.test.ts
- npm run typecheck:ops

Closes #667