### PR TITLE
ops: add same-revision Phase 1 release evidence assembly runbook

### DIFF
--- a/docs/release-evidence/wechat-runtime-observability-signoff.template.md
+++ b/docs/release-evidence/wechat-runtime-observability-signoff.template.md
@@ -28,24 +28,30 @@
 - [ ] `GET /api/runtime/health`
   Artifact / link:
   Captured at:
-- [ ] `GET /api/runtime/diagnostic-snapshot`
+- [ ] `GET /api/runtime/auth-readiness`
   Artifact / link:
   Captured at:
 - [ ] `GET /api/runtime/metrics`
   Artifact / link:
   Captured at:
+- [ ] Optional: `GET /api/runtime/diagnostic-snapshot`
+  Artifact / link:
+  Captured at:
 
 ## Review Questions
 
-- [ ] 三个 endpoint 都对应同一 candidate revision 的目标环境，而不是本地 dev server 或旧 staging
+- [ ] `health`、`auth-readiness`、`metrics` 三个 required endpoint 都对应同一 candidate revision 的目标环境，而不是本地 dev server 或旧 staging
   Notes:
 - [ ] `/api/runtime/health` 已确认 `activeRoomCount`、`connectionCount`、`gameplayTraffic` 与 auth 摘要形状合理
   Evidence:
   Notes:
-- [ ] `/api/runtime/diagnostic-snapshot` 已确认 room summary、diagnostics 状态与 log tail 没有明显陈旧或缺口
+- [ ] `/api/runtime/auth-readiness` 已确认 auth 状态、阻塞项与目标环境一致，没有明显陈旧或缺口
   Evidence:
   Notes:
 - [ ] `/api/runtime/metrics` 已确认关键 runtime metrics 可抓取，且没有未知缺维、空白导出或权限失败
+  Evidence:
+  Notes:
+- [ ] 若附上 `/api/runtime/diagnostic-snapshot`，其内容只作为补充排障上下文，不替代 required endpoint review
   Evidence:
   Notes:
 - [ ] 若存在告警、缺口或接受风险，已同步写入 blocker register 或 owner ledger
@@ -57,8 +63,9 @@
 | Endpoint | Status | Reviewer summary | Evidence path / link |
 | --- | --- | --- | --- |
 | `/api/runtime/health` | `pass | hold | fail` |  |  |
-| `/api/runtime/diagnostic-snapshot` | `pass | hold | fail` |  |  |
+| `/api/runtime/auth-readiness` | `pass | hold | fail` |  |  |
 | `/api/runtime/metrics` | `pass | hold | fail` |  |  |
+| Optional `/api/runtime/diagnostic-snapshot` | `pass | hold | fail | not-recorded` |  |  |
 
 ## Release Decision
 

--- a/docs/same-revision-release-evidence-runbook.md
+++ b/docs/same-revision-release-evidence-runbook.md
@@ -14,6 +14,9 @@ Related references:
 - [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md)
 - [`docs/wechat-minigame-release.md`](./wechat-minigame-release.md)
 - [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md)
+- [`docs/reconnect-soak-gate.md`](./reconnect-soak-gate.md)
+- [`docs/release-gate-summary.md`](./release-gate-summary.md)
+- [`docs/phase1-maturity-scorecard.md`](./phase1-maturity-scorecard.md)
 
 ## Same-Revision Rule
 
@@ -30,14 +33,37 @@ These are the minimum artifacts for a same-revision release call:
 | Evidence area | Command or source | Expected output |
 | --- | --- | --- |
 | Automated release baseline | `npm run release:readiness:snapshot -- --manual-checks docs/release-readiness-manual-checks.example.json` | `artifacts/release-readiness/release-readiness-*.json` |
-| WeChat packaged RC smoke | `npm run smoke:wechat-release -- --artifacts-dir artifacts/wechat-release --check --expected-revision <git-sha>` | `artifacts/wechat-release/codex.wechat.smoke-report.json` |
+| Candidate reconnect soak | `npm run release:reconnect-soak -- --candidate <candidate-name> --candidate-revision <git-sha>` | `artifacts/release-readiness/colyseus-reconnect-soak-summary-<candidate>-<short-sha>.json` plus paired `.md` |
+| Release gate summary | `npm run release:gate:summary -- --target-surface <wechat|h5>` | `artifacts/release-readiness/release-gate-summary-<short-sha>.json` plus paired `.md` |
 | Cocos / WeChat RC bundle | `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report artifacts/wechat-release/codex.wechat.smoke-report.json --release-readiness-snapshot <snapshot-json>` | `artifacts/release-readiness/cocos-rc-evidence-bundle-<candidate>-<short-sha>.json` plus paired `.md`, snapshot, checklist, and blockers files |
+| WeChat validation or rehearsal when WeChat is the target surface | `npm run validate:wechat-rc -- --artifacts-dir artifacts/wechat-release --expected-revision <git-sha> --require-smoke-report --manual-checks docs/release-evidence/wechat-release-manual-review.example.json` or `npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir artifacts/wechat-release --source-revision <git-sha> --expected-revision <git-sha> --require-smoke-report` | `artifacts/wechat-release/codex.wechat.release-candidate-summary.json`, `artifacts/wechat-release/codex.wechat.rc-validation-report.json`, `artifacts/wechat-release/codex.wechat.smoke-report.json`, or `artifacts/wechat-release/wechat-release-rehearsal-<short-sha>.json` plus paired `.md` |
 | Runtime observability sign-off | Manual review using `docs/wechat-runtime-observability-signoff.md` plus `docs/release-evidence/wechat-runtime-observability-signoff.template.md` | `artifacts/wechat-release/runtime-observability-signoff-<candidate>-<short-sha>.md` or equivalent reviewer artifact |
 | Manual evidence owner ledger | Copy `docs/release-evidence/manual-release-evidence-owner-ledger.template.md` for the candidate and update it as manual evidence lands | `artifacts/release-readiness/manual-release-evidence-owner-ledger-<candidate>-<short-sha>.md` or release PR table |
 | Same-candidate evidence audit | `npm run release:same-candidate:evidence-audit -- --candidate <candidate-name> --candidate-revision <git-sha>` | `artifacts/release-readiness/same-candidate-evidence-audit-<candidate>-<short-sha>.json` plus paired `.md` |
 | Final same-revision assembly check | `npm run release:readiness:dashboard -- --server-url http://127.0.0.1:2567 --wechat-artifacts-dir artifacts/wechat-release --candidate-revision <git-sha>` | `artifacts/release-readiness/release-readiness-dashboard-*.json` plus `.md` |
 
 If the candidate is missing any item above, the release call is still incomplete even if individual scripts passed earlier.
+
+## Required Evidence Vs Optional Diagnostics
+
+Treat the following as `required evidence` for the candidate packet:
+
+- release readiness snapshot
+- reconnect soak artifact for the same `<candidate-name>` and `<git-sha>`
+- release gate summary for the target surface
+- Cocos RC bundle for the same `<candidate-name>` and `<git-sha>`
+- WeChat candidate summary or rehearsal summary when WeChat is the release surface
+- runtime observability sign-off covering `/api/runtime/health`, `/api/runtime/auth-readiness`, and `/api/runtime/metrics`
+- manual evidence owner ledger
+- same-candidate evidence audit
+- final release-readiness dashboard output
+
+Treat these as `optional diagnostics` unless another release doc explicitly upgrades them to required for your target surface:
+
+- rerunning `npm run release:wechat:rehearsal` when `validate:wechat-rc` already points at a fresh same-revision artifact set
+- keeping intermediate `verify:wechat-release`, `prepare:wechat-release`, or upload receipts in the packet when the release decision only needs candidate-readiness evidence
+- extra H5 packaged smoke details when the selected `--target-surface` is `wechat` and the gate summary already captures the current H5 signal
+- additional runtime diagnostic snapshot captures beyond the reviewer artifact and dashboard probe
 
 ## Ordered Assembly Flow
 
@@ -64,23 +90,54 @@ Freshness check:
 - confirm `summary.requiredFailed == 0`
 - confirm any remaining `requiredPending` items are the manual checks you still plan to finish in this same pass
 
-3. Refresh or verify the WeChat smoke evidence for the same packaged revision.
+3. Run the candidate-scoped reconnect soak for the pinned revision.
 
 ```bash
-npm run smoke:wechat-release -- \
-  --artifacts-dir artifacts/wechat-release \
-  --check \
-  --expected-revision <git-sha>
+npm run release:reconnect-soak -- \
+  --candidate <candidate-name> \
+  --candidate-revision <git-sha>
 ```
 
 Freshness check:
 
-- open `artifacts/wechat-release/codex.wechat.smoke-report.json`
-- confirm the report revision matches `<git-sha>`
-- confirm required cases are not `pending` or `blocked`
-- confirm `reconnect-recovery.requiredEvidence` is populated, not just free-form notes
+- open `artifacts/release-readiness/colyseus-reconnect-soak-summary-<candidate>-<short-sha>.json`
+- confirm `candidate` and `candidateRevision` match `<candidate-name>` and `<git-sha>`
+- confirm the verdict is `passed`
+- confirm the cleanup counters returned to zero and the artifact records reconnect attempts plus invariant checks
 
-4. Build the candidate-scoped Cocos RC bundle from the same snapshot and WeChat smoke report.
+4. Refresh the WeChat candidate evidence when WeChat is the target surface.
+
+If `artifacts/wechat-release/` already contains a same-revision package, smoke report, and manual-review metadata, run the validation path:
+
+```bash
+npm run validate:wechat-rc -- \
+  --artifacts-dir artifacts/wechat-release \
+  --expected-revision <git-sha> \
+  --require-smoke-report \
+  --manual-checks docs/release-evidence/wechat-release-manual-review.example.json
+```
+
+Freshness check:
+
+- open `artifacts/wechat-release/codex.wechat.release-candidate-summary.json`
+- confirm the summary revision matches `<git-sha>`
+- confirm required manual review rows have `owner`, `recordedAt`, `revision`, and artifact paths
+- confirm the linked `codex.wechat.smoke-report.json` has required cases completed and `reconnect-recovery.requiredEvidence` populated
+
+If you need to regenerate the WeChat artifact family from the same source revision instead of only checking it, run the rehearsal path:
+
+```bash
+npm run release:wechat:rehearsal -- \
+  --build-dir <wechatgame-build-dir> \
+  --artifacts-dir artifacts/wechat-release \
+  --source-revision <git-sha> \
+  --expected-revision <git-sha> \
+  --require-smoke-report
+```
+
+Use the rehearsal output when you need one report that proves prepare/package/verify/validate still run in sequence for this exact revision. Keep the resulting `wechat-release-rehearsal-<short-sha>.json` and `.md` next to the WeChat candidate summary instead of replacing it.
+
+5. Build the candidate-scoped Cocos RC bundle from the same snapshot and WeChat evidence.
 
 ```bash
 npm run release:cocos-rc:bundle -- \
@@ -97,12 +154,12 @@ Freshness check:
 - confirm the paired snapshot, checklist, and blockers files were regenerated for the same candidate
 - confirm the bundle did not inherit an older smoke report or snapshot path
 
-5. Complete the runtime observability sign-off for the same candidate revision.
+6. Complete the runtime observability sign-off for the same candidate revision.
 
 Use [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md) and [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md), and capture:
 
 - `/api/runtime/health`
-- `/api/runtime/diagnostic-snapshot`
+- `/api/runtime/auth-readiness`
 - `/api/runtime/metrics`
 - reviewer, timestamp, revision, conclusion, and any accepted follow-up
 
@@ -112,7 +169,7 @@ Freshness check:
 - confirm the captured environment is the release environment you are actually calling from
 - confirm any blockers or follow-ups are also reflected in the RC checklist or blocker register
 
-6. Update the manual evidence owner ledger for the same candidate revision.
+7. Update the manual evidence owner ledger for the same candidate revision.
 
 Copy [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md) into the candidate artifact set or PR body and keep one row for each required manual sign-off.
 
@@ -122,7 +179,25 @@ Freshness check:
 - confirm `owner`, `status`, `target revision`, `recorded at`, and `artifact path` agree with the underlying artifact
 - confirm any row still marked `pending` or `hold` explains the next follow-up clearly enough for handoff
 
-7. Run the artifact-family audit for the pinned candidate.
+8. Run the release gate summary for the same release surface and artifact packet.
+
+```bash
+npm run release:gate:summary -- \
+  --target-surface <wechat|h5> \
+  --snapshot <snapshot-json> \
+  --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary-<candidate>-<short-sha>.json \
+  --manual-evidence-ledger artifacts/release-readiness/manual-release-evidence-owner-ledger-<candidate>-<short-sha>.md \
+  --wechat-artifacts-dir artifacts/wechat-release
+```
+
+Freshness check:
+
+- open `artifacts/release-readiness/release-gate-summary-<short-sha>.json`
+- confirm the summary selected the same snapshot, reconnect soak artifact, ledger, and WeChat artifact directory you intended
+- confirm `targetSurface` matches the release decision you are making
+- confirm no required gate dimension is `failed`, `pending`, or stale for `<git-sha>`
+
+9. Run the artifact-family audit for the pinned candidate.
 
 Before the broad dashboard pass, run the artifact-family audit that explicitly compares the latest readiness snapshot, release-gate summary, Cocos RC bundle, and manual evidence ledger for the same candidate:
 
@@ -134,7 +209,7 @@ npm run release:same-candidate:evidence-audit -- \
 
 This audit emits one JSON + Markdown summary and exits non-zero when any required artifact family is missing, stale, points at a different revision, or still links to a different readiness snapshot.
 
-8. Run the final assembly check that enforces same-revision consistency.
+10. Run the final assembly check that enforces same-revision consistency.
 
 ```bash
 npm run release:readiness:dashboard -- \
@@ -154,8 +229,12 @@ Freshness check:
 Before making the release call, verify this exact packet exists:
 
 - one release readiness snapshot JSON for `<git-sha>`
-- one WeChat smoke report JSON for `<git-sha>`
+- one reconnect soak JSON for `<candidate-name>` and `<git-sha>`
+- one release gate summary JSON or Markdown for `<git-sha>`
 - one Cocos RC evidence bundle JSON for `<candidate-name>` and `<git-sha>`
+- one WeChat candidate summary JSON for `<git-sha>` when WeChat is the target surface
+- one WeChat smoke report JSON for `<git-sha>` when WeChat is the target surface
+- one WeChat rehearsal summary JSON or Markdown when you used rehearsal instead of a prebuilt same-revision artifact family
 - one RC checklist Markdown file for `<candidate-name>` and `<git-sha>`
 - one RC blocker Markdown file for `<candidate-name>` and `<git-sha>`
 - one runtime observability sign-off artifact for `<git-sha>`
@@ -164,6 +243,17 @@ Before making the release call, verify this exact packet exists:
 - one release readiness dashboard JSON or Markdown for `<git-sha>`
 
 If two files for the "same" evidence disagree on revision or timestamp window, treat the packet as invalid and refresh the stale file instead of choosing by hand.
+
+## Minimum Evidence To Call Phase 1 Ready
+
+This runbook does not redefine Phase 1 exit criteria. Use it to assemble the evidence packet that lets you answer the scorecard's existing question for one candidate revision.
+
+Before calling Phase 1 ready for `<candidate-name>` at `<git-sha>`, confirm the packet above is complete and then re-read:
+
+- [`docs/phase1-maturity-scorecard.md`](./phase1-maturity-scorecard.md#explicit-phase-1-exit-criteria)
+- [`docs/phase1-maturity-scorecard.md`](./phase1-maturity-scorecard.md#what-advancing-beyond-phase-1-means-here)
+
+If the packet cannot prove the scorecard's same-revision exit criteria without ad hoc explanation, the candidate is still in Phase 1 hardening.
 
 ## Go / No-Go Checklist
 

--- a/docs/wechat-runtime-observability-signoff.md
+++ b/docs/wechat-runtime-observability-signoff.md
@@ -26,11 +26,12 @@ For the same candidate revision, capture and attach:
 
 - `/api/runtime/health`
   - Confirm the payload is live for the release environment and note `activeRoomCount`, `connectionCount`, `gameplayTraffic`, and auth summary.
-- `/api/runtime/diagnostic-snapshot`
-  - Confirm the response renders the current room overview and diagnostics state.
-  - `?format=text` is acceptable when it is easier to attach to PR or artifact logs.
+- `/api/runtime/auth-readiness`
+  - Confirm the auth summary is reachable for the same release environment and records a coherent `status` for the candidate.
 - `/api/runtime/metrics`
   - Capture at least one scrape/export showing the runtime metrics endpoint is reachable for the same environment.
+- Optional supporting diagnostic: `/api/runtime/diagnostic-snapshot`
+  - Attach this when it helps explain a warning, blocker, or accepted follow-up, but do not use it as a substitute for `health`, `auth-readiness`, or `metrics`.
 - Reviewer decision
   - Record owner, `recordedAt`, revision, artifact path, and any follow-up or accepted risk.
   - Mirror the same owner, revision, artifact path, and follow-up status into the manual evidence owner ledger so the candidate handoff still has one pending-signoff view.
@@ -48,9 +49,9 @@ Store one small JSON or Markdown artifact under `artifacts/wechat-release/` or `
 Keep the artifact scoped to:
 
 - candidate revision and environment
-- endpoint captures or links
+- endpoint captures or links for `health`, `auth-readiness`, and `metrics`
 - reviewer / timestamp
 - conclusion: `passed | hold | ship-with-followups`
 - follow-ups or blocker IDs
 
-The preferred Markdown shape is the template at [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md). If you emit JSON instead, keep the same fields: candidate, target revision, environment, reviewer, recorded timestamp, per-endpoint status, conclusion, and follow-ups.
+The preferred Markdown shape is the template at [`docs/release-evidence/wechat-runtime-observability-signoff.template.md`](./release-evidence/wechat-runtime-observability-signoff.template.md). If you emit JSON instead, keep the same fields: candidate, target revision, environment, reviewer, recorded timestamp, per-endpoint status, conclusion, and follow-ups. Add `/api/runtime/diagnostic-snapshot` only as supporting context when needed.


### PR DESCRIPTION
## Summary
- tighten the same-revision release evidence runbook so it sequences the required Phase 1 candidate evidence for one candidate revision
- add explicit required-vs-optional evidence guidance, including reconnect soak, release gate summary, and WeChat validation/rehearsal routing
- align the WeChat runtime observability sign-off docs and template with the required runtime endpoints: health, auth-readiness, and metrics

## Validation
- `git diff --check`

Closes #673