### PR TITLE
ops: track manual release evidence ownership in one ledger

### DIFF
--- a/docs/operational-entry-point-repo-map.md
+++ b/docs/operational-entry-point-repo-map.md
@@ -20,6 +20,7 @@ Use this as the maintainer-facing map for the repository's existing operational 
 | Aggregate release gates for one candidate | `npm run release:gate:summary` | [`docs/release-gate-summary.md`](./release-gate-summary.md) |
 | Aggregate top-level release health and triage | `npm run release:health:summary` | [`docs/release-health-summary.md`](./release-health-summary.md), [`docs/release-readiness-trend-troubleshooting.md`](./release-readiness-trend-troubleshooting.md) |
 | Assemble same-revision release evidence | [`docs/same-revision-release-evidence-runbook.md`](./same-revision-release-evidence-runbook.md) | [`docs/same-revision-release-evidence-runbook.md`](./same-revision-release-evidence-runbook.md) |
+| Track manual release evidence ownership for one candidate | Copy [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md) into `artifacts/release-readiness/` or the release PR | [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md), [`docs/same-revision-release-evidence-runbook.md`](./same-revision-release-evidence-runbook.md) |
 | Review the Phase 1 candidate dossier or rehearsal flow | `npm run release:phase1:candidate-dossier` / `npm run release:phase1:candidate-rehearsal` | [`docs/phase1-candidate-dossier.md`](./phase1-candidate-dossier.md), [`docs/phase1-candidate-rehearsal.md`](./phase1-candidate-rehearsal.md) |
 
 ## Cocos And WeChat Delivery

--- a/docs/release-evidence/manual-release-evidence-owner-ledger.template.md
+++ b/docs/release-evidence/manual-release-evidence-owner-ledger.template.md
@@ -14,25 +14,32 @@ Create one copy per candidate under `artifacts/release-readiness/` or attach the
 
 ## Ledger
 
-| Evidence item | Area | Owner | Status | Target revision | Recorded at | Artifact path / link | Follow-up status | Notes |
+| Evidence type | Candidate | Revision | Owner | Status | Last updated | Artifact path / link | Notes / blocker context |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `runtime-observability-signoff` | Runtime health | `oncall-ops` | `pending` | `abc123def456` | `pending` | `artifacts/wechat-release/runtime-observability-signoff.json` | Capture `/api/runtime/*` evidence before release call. | Same environment as the packaged candidate. |
-| `wechat-device-runtime-review` | WeChat validation | `qa-release` | `pending` | `abc123def456` | `pending` | `artifacts/wechat-release/device-runtime-review.json` | `Waiting on device smoke slot for this candidate.` | Attach smoke report plus supporting screenshots or recordings. |
-| `cocos-rc-checklist-review` | RC checklist / blockers | `release-owner` | `passed` | `abc123def456` | `2026-04-02T09:40:00Z` | `artifacts/release-readiness/cocos-rc-checklist-rc-2026-04-02-abc123d.md` | `No follow-up.` | Blocker register reviewed with `none` open. |
-| `presentation-signoff` | Presentation review | `client-lead` | `hold` | `abc123def456` | `2026-04-02T09:55:00Z` | `docs/cocos-phase1-presentation-signoff.md` | `Refresh world-map capture after fallback UI fix.` | Keep this row only when presentation review applies to the candidate. |
+| `cocos-rc-checklist-review` | `rc-YYYY-MM-DD` | `abc123def456` | `release-owner` | `in-review` | `2026-04-02T09:40:00Z` | `artifacts/release-readiness/cocos-rc-checklist-rc-YYYY-MM-DD-abc123d.md` | Reviewing RC checklist and blocker register for this candidate. |
+| `cocos-presentation-signoff` | `rc-YYYY-MM-DD` | `abc123def456` | `client-lead` | `pending` | `2026-04-02T09:42:00Z` | `artifacts/release-readiness/cocos-presentation-signoff-rc-YYYY-MM-DD-abc123d.md` | Refresh world-map capture after the latest fallback UI fix. |
+| `runtime-observability-review` | `rc-YYYY-MM-DD` | `abc123def456` | `oncall-ops` | `pending` | `2026-04-02T09:45:00Z` | `artifacts/wechat-release/runtime-observability-signoff-rc-YYYY-MM-DD-abc123d.md` | Capture `/api/runtime/health`, `/api/runtime/auth-readiness`, and `/api/runtime/metrics` in the release environment. |
+| `wechat-validation-review` | `rc-YYYY-MM-DD` | `abc123def456` | `qa-release` | `done` | `2026-04-02T09:55:00Z` | `artifacts/wechat-release/codex.wechat.release-candidate-summary.json` | Device runtime smoke and release rehearsal evidence are attached for the same revision. Use `waived` only when WeChat is not the target surface. |
+| `reconnect-release-followup` | `rc-YYYY-MM-DD` | `abc123def456` | `server-oncall` | `pending` | `2026-04-02T09:58:00Z` | `artifacts/release-readiness/colyseus-reconnect-soak-summary-rc-YYYY-MM-DD-abc123d.md` | Human review still needed on the reconnect warning before release call. |
 
 ## Rules
 
-- Keep one row per required manual evidence item for the candidate.
-- `Status` should stay within `pending | passed | hold | ship-with-followups | not_applicable`.
-- `Target revision` must match the candidate revision recorded in the readiness snapshot, WeChat manual-review JSON, and any RC checklist or sign-off artifact.
-- `Recorded at` stays `pending` until the linked artifact exists; once complete, replace it with the artifact timestamp.
+- Keep one row per required manual evidence item for the candidate revision. Do not split ownership for one sign-off across multiple rows unless the evidence artifacts are genuinely separate.
+- `Status` must stay within `pending | in-review | done | waived`.
+- The ledger should cover at least the current manual Phase 1 release checks:
+  - `cocos-rc-checklist-review`
+  - `cocos-presentation-signoff` when presentation review applies to the candidate
+  - `runtime-observability-review`
+  - `wechat-validation-review` or release rehearsal review when WeChat is the target surface
+  - `reconnect-release-followup` for reconnect or manual release-gate follow-ups that still require a human call
+- `Candidate` and `Revision` in each row must match the header and the linked readiness snapshot, WeChat summary, RC checklist, or sign-off artifact.
+- `Last updated` should be the latest timestamp at which the row status, owner, or linked artifact was confirmed.
 - `Artifact path / link` should point at the exact JSON, Markdown, PR comment, or checklist file used during the release call.
-- `Follow-up status` should answer the operational question directly: what is waiting, who is blocked, or why the item is allowed to ship with follow-ups.
+- `Notes / blocker context` should answer the handoff question directly: what is waiting, who is blocked, or why the item is `waived`.
 
 ## Minimal Operating Flow
 
 1. Copy this template for the current candidate.
-2. Pre-fill one row for each manual check that is still required.
-3. Update the row as soon as the sign-off artifact lands.
-4. Treat the candidate as incomplete while any required row remains `pending` or `hold`.
+2. Pre-fill one row for each required manual check before the release review starts, even if the artifact is not ready yet.
+3. Update the owner, status, timestamp, artifact path, and notes as soon as each sign-off changes state.
+4. Treat the candidate as incomplete while any required row remains `pending` or `in-review`.

--- a/docs/same-revision-release-evidence-runbook.md
+++ b/docs/same-revision-release-evidence-runbook.md
@@ -176,8 +176,8 @@ Copy [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](
 Freshness check:
 
 - confirm every required manual evidence item has one row
-- confirm `owner`, `status`, `target revision`, `recorded at`, and `artifact path` agree with the underlying artifact
-- confirm any row still marked `pending` or `hold` explains the next follow-up clearly enough for handoff
+- confirm `candidate`, `revision`, `owner`, `status`, `last updated`, and `artifact path` agree with the underlying artifact
+- confirm any row still marked `pending` or `in-review` explains the next follow-up clearly enough for handoff
 
 8. Run the release gate summary for the same release surface and artifact packet.
 
@@ -264,7 +264,7 @@ Release is `go` only when all of the following are true:
 - the WeChat smoke report has no required case in `failed`, `blocked`, or `pending`
 - the Cocos RC bundle is generated for the same candidate and revision and includes the latest checklist/blocker files
 - the runtime observability sign-off is recorded for the same revision and environment
-- the manual evidence owner ledger shows no required row still in `pending` or `hold` without an accepted release decision
+- the manual evidence owner ledger shows no required row still in `pending` or `in-review` without an accepted release decision
 - the final readiness dashboard does not report revision mismatch, missing revision metadata, or stale evidence
 
 Release is `no-go` when any of the following happens:


### PR DESCRIPTION
## Summary
- update the manual release evidence owner ledger template to use a single candidate-scoped ownership table for the required Phase 1 manual checks
- align the same-revision evidence runbook with the new ledger columns and statuses
- add the ledger template to the operational release-readiness repo map so maintainers can discover it from one index

## Validation
- `git diff --check -- docs/operational-entry-point-repo-map.md docs/release-evidence/manual-release-evidence-owner-ledger.template.md docs/same-revision-release-evidence-runbook.md`
- `rg -n "manual-release-evidence-owner-ledger\.template\.md" docs/release-readiness-snapshot.md docs/same-revision-release-evidence-runbook.md docs/operational-entry-point-repo-map.md`

Closes #674