### PR TITLE
docs: document ops readiness follow-up template

### DIFF
--- a/.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md
+++ b/.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md
@@ -11,7 +11,8 @@ assignees: ""
 
 ## Current evidence
 - Evidence reviewed:
-- Revision or artifact date:
+- Candidate or release train:
+- Revision, artifact date, or report timestamp:
 - Links:
 - Manual evidence owner ledger:
 
@@ -24,6 +25,7 @@ assignees: ""
 ## Owner
 - Team or directly responsible person:
 - Supporting reviewers or operators:
+- Expected review surface:
 
 ## Smallest next slice
 - 
@@ -35,4 +37,4 @@ assignees: ""
 - Affected area:
 - Environment or branch:
 - Related issues or docs:
-- Dependencies or sequencing notes:
+- Blockers, dependencies, or sequencing notes:

--- a/docs/operational-entry-point-repo-map.md
+++ b/docs/operational-entry-point-repo-map.md
@@ -55,6 +55,7 @@ Use this as the maintainer-facing map for the repository's existing operational 
 | Need | Primary command or entry point | Canonical docs |
 | --- | --- | --- |
 | Check current repository maturity and next ops slices | [`docs/repo-maturity-baseline.md`](./repo-maturity-baseline.md) | [`docs/repo-maturity-baseline.md`](./repo-maturity-baseline.md) |
+| Open an ops/readiness follow-up issue with the expected evidence fields | [`.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md`](../.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md) | [`.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md`](../.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md), [`docs/repo-maturity-baseline.md`](./repo-maturity-baseline.md) |
 | Check Phase 1 exit posture and remaining release gaps | [`docs/phase1-maturity-scorecard.md`](./phase1-maturity-scorecard.md) | [`docs/phase1-maturity-scorecard.md`](./phase1-maturity-scorecard.md) |
 | Fall back when GitHub issue intake automation is unavailable | [`docs/github-issue-intake-fallback.md`](./github-issue-intake-fallback.md) | [`docs/github-issue-intake-fallback.md`](./github-issue-intake-fallback.md), [`docs/github-issue-intake-fallback-smoke-checklist.md`](./github-issue-intake-fallback-smoke-checklist.md) |
 

--- a/docs/repo-maturity-baseline.md
+++ b/docs/repo-maturity-baseline.md
@@ -48,7 +48,7 @@ These slices are intentionally small and low-dependency so they can become follo
 | Add a single backlog ledger for manual-release evidence owners | Makes pending manual checks visible without opening several templates or JSON examples. | Markdown tracker or JSON schema that records owner, revision, timestamp, and follow-up for runtime, WeChat, and presentation sign-off evidence. |
 | Document the minimum verification sets for common issue types | Helps contributors choose the smallest sufficient validation path before opening PRs. | Expand `docs/verification-matrix.md` or add a companion quick-reference for docs-only, runtime, release-tooling, and Cocos delivery changes. |
 | Add a repo map for operational entry points | Makes it faster to discover which scripts/docs correspond to release, readiness, persistence, and client delivery concerns. | Lightweight doc that groups the existing `package.json` commands and key docs by operational function. |
-| Add one issue template or checklist for ops/readiness follow-ups | Keeps future maturity-gap issues consistent and immediately actionable. | `.github/ISSUE_TEMPLATE` entry or Markdown template that requires current evidence, observed gap, owner, and smallest next slice. |
+| Add one issue template or checklist for ops/readiness follow-ups | Keeps future maturity-gap issues consistent and immediately actionable. | Use [`.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md`](../.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md) so issues always capture current evidence, candidate or revision context, owner, and the smallest next slice. |
 
 ## Recommended Backlog Order
 
@@ -56,7 +56,7 @@ These slices are intentionally small and low-dependency so they can become follo
 2. Manual evidence owner ledger
 3. Verification quick-reference for common issue types
 4. Operational entry-point repo map
-5. Ops/readiness issue template
+5. Ops/readiness issue template: [`.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md`](../.github/ISSUE_TEMPLATE/projectveil-ops-readiness.md)
 
 This order keeps the first slices focused on reducing release ambiguity, then improves discoverability and issue quality once the operational path is clearer.
 


### PR DESCRIPTION
## Summary
- make the ops/readiness issue template explicitly ask for candidate or revision context, expected review surface, and blocker notes
- link the template from the maturity baseline and operational entry-point repo map so it is easy to discover

## Validation
- `git diff --check`

Closes #679