### PR TITLE
feat(multiplayer): tighten the PvP encounter experience loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ npm run dev:client:h5
   当前覆盖 Lobby 入口与 reconnect predicted-state -> authoritative convergence canonical smoke
 - 打包 H5 客户端 RC 冒烟会把结构化结果写入 `artifacts/release-readiness/`
 - 多人联机 Playwright 冒烟：`npm run test:e2e:multiplayer:smoke`
+  默认覆盖多人同步基线与 PvP 遭遇反馈链路；若要复核 reconnect / 战后恢复分支，改跑 `npm run test:e2e:multiplayer -- pvp-reconnect-recovery` 或 `npm run test:e2e:multiplayer -- pvp-postbattle-reconnect`
 - 多人同步治理矩阵：`npm run test:sync-governance:matrix`（输出 `artifacts/release-readiness/sync-governance-matrix-<short-sha>.json`）
 - GitHub Actions `playwright-smoke` 会先等待 `health` / `auth-readiness` / `lobby rooms` readiness contract，再执行 H5 与多人冒烟；失败时会上传 Playwright trace / screenshot / video，以及 npm 调试日志，便于区分环境漂移和真实回归
 - PR 上的多人联机 smoke 现在保留为非阻塞诊断；若它失败，先看 artifact 里的 npm 日志与 Playwright trace，再本地复跑 `npm run test:e2e:multiplayer:smoke`

--- a/apps/client/src/room-feedback.ts
+++ b/apps/client/src/room-feedback.ts
@@ -105,13 +105,13 @@ export function renderEncounterSourceDetail(input: EncounterSourceDetailInput): 
     if (event.encounterKind === "hero") {
       const sessionId = formatBattleSession(input.world.meta.roomId, event.battleId);
       return ownedIds.has(event.heroId)
-        ? `遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到 PVP 多人遭遇战结算；对手身份、当前回合与房间归属现在统一挂到遭遇会话 ${sessionId}。`
-        : `遭遇来源：敌方英雄先手接触我方，当前房间已切到 PVP 多人遭遇战结算；对手身份、当前回合与房间归属现在统一挂到遭遇会话 ${sessionId}。`;
+        ? `遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到 PVP 多人遭遇链路；对手身份、当前回合与房间归属现在统一挂到遭遇会话 ${sessionId}。`
+        : `遭遇来源：敌方英雄先手接触我方，当前房间已切到 PVP 多人遭遇链路；对手身份、当前回合与房间归属现在统一挂到遭遇会话 ${sessionId}。`;
     }
 
     return event.initiator === "neutral"
-      ? `遭遇来源：中立守军主动拦截，当前房间已切到遭遇战结算链路，战斗会话 ${event.battleId} 已建立。`
-      : `遭遇来源：我方接触了中立守军，当前房间已切到遭遇战结算链路，战斗会话 ${event.battleId} 已建立。`;
+      ? `遭遇来源：中立守军主动拦截，当前房间已切到遭遇战链路，战斗会话 ${event.battleId} 已建立。`
+      : `遭遇来源：我方接触了中立守军，当前房间已切到遭遇战链路，战斗会话 ${event.battleId} 已建立。`;
   }
 
   if (input.previewPlan?.endsInEncounter) {

--- a/apps/client/test/room-feedback.test.ts
+++ b/apps/client/test/room-feedback.test.ts
@@ -159,7 +159,7 @@ test("renderEncounterSourceDetail covers active hero encounter initiative branch
       battle: activeBattle,
       lastEncounterStarted: createEncounterStartedEvent()
     }),
-    "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到 PVP 多人遭遇战结算；对手身份、当前回合与房间归属现在统一挂到遭遇会话 room-alpha/battle-1。"
+    "遭遇来源：我方英雄先手接触敌方英雄，当前房间已切到 PVP 多人遭遇链路；对手身份、当前回合与房间归属现在统一挂到遭遇会话 room-alpha/battle-1。"
   );
 
   assert.equal(
@@ -171,7 +171,7 @@ test("renderEncounterSourceDetail covers active hero encounter initiative branch
         defenderHeroId: "hero-1"
       })
     }),
-    "遭遇来源：敌方英雄先手接触我方，当前房间已切到 PVP 多人遭遇战结算；对手身份、当前回合与房间归属现在统一挂到遭遇会话 room-alpha/battle-1。"
+    "遭遇来源：敌方英雄先手接触我方，当前房间已切到 PVP 多人遭遇链路；对手身份、当前回合与房间归属现在统一挂到遭遇会话 room-alpha/battle-1。"
   );
 });
 
@@ -189,7 +189,7 @@ test("renderEncounterSourceDetail covers active neutral encounter initiator bran
         initiator: "neutral"
       })
     }),
-    "遭遇来源：中立守军主动拦截，当前房间已切到遭遇战结算链路，战斗会话 battle-1 已建立。"
+    "遭遇来源：中立守军主动拦截，当前房间已切到遭遇战链路，战斗会话 battle-1 已建立。"
   );
 
   assert.equal(
@@ -203,7 +203,7 @@ test("renderEncounterSourceDetail covers active neutral encounter initiator bran
         initiator: "hero"
       })
     }),
-    "遭遇来源：我方接触了中立守军，当前房间已切到遭遇战结算链路，战斗会话 battle-1 已建立。"
+    "遭遇来源：我方接触了中立守军，当前房间已切到遭遇战链路，战斗会话 battle-1 已建立。"
   );
 });
 

--- a/docs/cocos-pvp-encounter-lifecycle.md
+++ b/docs/cocos-pvp-encounter-lifecycle.md
@@ -25,15 +25,30 @@
 
 ## 自动化与人工验收
 
+- Canonical multiplayer smoke：
+  - `npm run test:e2e:multiplayer:smoke`
+  - 当前默认覆盖多人同步基线与 `tests/e2e/pvp-hero-encounter.spec.ts`，用于快速确认“能进遭遇、能看懂对手与房间态、能读出结算结果”。
 - Happy path：
   - `tests/e2e/pvp-hero-encounter.spec.ts`
   - 断言进入战斗时存在 `room-phase`、`encounter-source`、`opponent-summary`、`room-result-summary`
+  - 断言结算后仍保留 `battle-settlement-*`、`room-next-action` 与最近对手 / 遭遇会话
 - Lifecycle edge：
+  - `npm run test:e2e:multiplayer -- pvp-reconnect-recovery`
   - `tests/e2e/pvp-reconnect-recovery.spec.ts`
   - 断言遭遇中断后仍保留对手摘要、遭遇会话、恢复提示，并在恢复后回到可继续操作的权威战斗态
+- Post-settlement recovery：
+  - `npm run test:e2e:multiplayer -- pvp-postbattle-reconnect`
+  - `tests/e2e/pvp-postbattle-reconnect.spec.ts`
+  - 断言结算弹窗、战后房间态、最近对手与遭遇会话在恢复后仍保持一致
 - 文案 / 状态分支：
   - `apps/client/test/room-feedback.test.ts`
   - `apps/client/test/main-session-runtime.test.ts`
+
+## 已知边界
+
+- 本 slice 只收口已有双人遭遇 / 房间反馈链路，不扩展新的匹配系统、排位或复杂房间编排。
+- `npm run test:e2e:multiplayer:smoke` 仍是 PR 级快反馈，不覆盖 reconnect / 结算恢复的所有分支；这些分支继续用 `npm run test:e2e:multiplayer` 下的对应 PvP spec 复核。
+- H5 回归壳与 Cocos 主客户端应复用同一套“对手摘要 / 房间态 / 遭遇会话 / 结算结果”语义，但本地自动化当前仍以 H5 壳为最快反馈面。
 
 ## CI / 手工成功信号
 

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -203,8 +203,8 @@ H5 冒烟和多人 Playwright 已经比较成熟，但真实发布面是 `apps/c
 用于验证 issue #208 这类“多人遭遇进入 / 结算 / 回到地图”反馈是否仍然完整可读。
 
 1. 启动本地房间与 H5 调试壳：`npm run dev:server`、`npm run dev:client`
-2. 跑最小 PvP 反馈回归：`npx playwright test tests/e2e/pvp-hero-encounter.spec.ts --config=playwright.multiplayer.config.ts`
-3. 跑结算后重载回归：`npx playwright test tests/e2e/pvp-postbattle-reconnect.spec.ts --config=playwright.multiplayer.config.ts`
+2. 跑 PR 级 PvP 反馈回归：`npm run test:e2e:multiplayer:smoke`
+3. 若改动触及恢复 / 战后结算，再补跑：`npm run test:e2e:multiplayer -- pvp-postbattle-reconnect`
 4. 若只想快速校验文案分支，补跑单测：`node --import tsx --test ./apps/client/test/room-feedback.test.ts`
 
 成功信号：

--- a/docs/reconnect-smoke-gate.md
+++ b/docs/reconnect-smoke-gate.md
@@ -30,8 +30,8 @@
 - 单测例过滤：`npm run test:e2e:smoke -- reconnect-prediction-convergence`
 - 覆盖用例：`tests/e2e/reconnect-prediction-convergence.spec.ts`
 - 辅助多人 / 结算恢复参考：
-  - `npm run test:e2e:multiplayer:smoke -- pvp-reconnect-recovery`
-  - `npm run test:e2e:multiplayer:smoke -- pvp-postbattle-reconnect`
+  - `npm run test:e2e:multiplayer -- pvp-reconnect-recovery`
+  - `npm run test:e2e:multiplayer -- pvp-postbattle-reconnect`
 
 若当前命令包装不支持测试名过滤，直接运行完整命令：
 

--- a/playwright.multiplayer.smoke.config.ts
+++ b/playwright.multiplayer.smoke.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  testMatch: /multiplayer-sync\.spec\.ts/,
-  grep: /second player receives room push updates without leaking another player's move details/,
+  testMatch: /(multiplayer-sync|pvp-hero-encounter)\.spec\.ts/,
   timeout: 30_000,
   retries: process.env.CI ? 1 : 0,
   fullyParallel: false,


### PR DESCRIPTION
## Summary
- tighten PvP encounter entry copy so battle-start feedback no longer claims the room is already in settlement
- make `npm run test:e2e:multiplayer:smoke` cover the PvP encounter feedback path in addition to the existing multiplayer sync baseline
- update the PvP lifecycle and readiness docs with the canonical validation entry points and known scope boundaries

## Validation
- `node --import tsx --test ./apps/client/test/room-feedback.test.ts`
- `npm run test:e2e:multiplayer:smoke` *(blocked in this container: Chromium cannot launch because `libatk-bridge-2.0.so.0` is missing)*

Closes #685