### PR TITLE
feat(content-pipeline): add typed validation for hero progression and equipment config packs

### DIFF
--- a/docs/content-pack-validation.md
+++ b/docs/content-pack-validation.md
@@ -1,0 +1,117 @@
+# Content Pack Validation
+
+`npm run validate:content-pack` validates the shipped default content pack, and `npm run validate:content-pack:all` extends the same checks across the additional shipped map-pack presets.
+
+The validator is intended to fail before runtime when authored config would otherwise be silently normalized or only break after archive hydration, equipment reconciliation, or reward application.
+
+## Local Workflow
+
+Run the default shipped bundle:
+
+```bash
+npm run validate:content-pack
+```
+
+Run every shipped bundle:
+
+```bash
+npm run validate:content-pack:all
+```
+
+Write a machine-readable report artifact:
+
+```bash
+npm run validate:content-pack -- --report-path artifacts/release-readiness/content-pack-validation.json
+```
+
+Target an alternate preset while editing one pack:
+
+```bash
+npm run validate:content-pack -- --map-pack ridgeway-crossing
+```
+
+The CLI prints the document path, issue code, human-readable failure, and a suggested fix for each failing entry.
+
+## CI Workflow
+
+CI already runs the validator as a standalone step in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) with:
+
+```bash
+npm run validate:content-pack -- --report-path "${RUNNER_TEMP}/content-pack-validation-report.json"
+```
+
+That step uploads the generated report artifact so reviewers can inspect the exact diagnostics from the candidate revision.
+
+## Typed Checks Covered
+
+- Hero progression fields must stay compatible with runtime progression math.
+- Learned hero skills must match the shipped hero skill tree, including max rank, required level, and prerequisites.
+- Authored skill-point totals must fit the hero's current level.
+- Equipped and inventory items must resolve through the built-in equipment catalog, respect slot typing, and stay within the six-slot backpack limit.
+- Legacy `loadout.equipment.trinketIds` entries are rejected so authors migrate to `accessoryId` plus `inventory` before archive/persistence use.
+- Neutral-army rewards and guaranteed resource payloads must use positive integer amounts.
+
+## Common Invalid States
+
+Invalid progression level for authored XP:
+
+```json
+{
+  "progression": {
+    "level": 1,
+    "experience": 175
+  }
+}
+```
+
+Fix: raise `level` to the minimum produced by that XP total, or lower `experience`.
+
+Invalid equipment slot + overflowed inventory:
+
+```json
+{
+  "loadout": {
+    "equipment": {
+      "weaponId": "padded_gambeson"
+    },
+    "inventory": [
+      "militia_pike",
+      "vanguard_blade",
+      "padded_gambeson",
+      "scout_compass",
+      "oak_longbow",
+      "tower_shield_mail",
+      "scribe_charm"
+    ]
+  }
+}
+```
+
+Fix: move each item into a compatible slot and keep `inventory` at six items or fewer.
+
+Invalid legacy accessory migration:
+
+```json
+{
+  "loadout": {
+    "equipment": {
+      "trinketIds": ["scout_compass"]
+    }
+  }
+}
+```
+
+Fix: move one accessory into `loadout.equipment.accessoryId` and place any extras into `loadout.inventory`.
+
+Invalid reward payload:
+
+```json
+{
+  "reward": {
+    "kind": "gold",
+    "amount": 0
+  }
+}
+```
+
+Fix: use a positive integer reward amount so resource grants, event logs, and persisted account state stay aligned.

--- a/docs/operational-entry-point-repo-map.md
+++ b/docs/operational-entry-point-repo-map.md
@@ -59,7 +59,7 @@ For detailed release sequencing, keep [`docs/same-revision-release-evidence-runb
 
 | Need | Primary command or entry point | Canonical docs |
 | --- | --- | --- |
-| Validate shipped content packs | `npm run validate:content-pack`, `npm run validate:content-pack:all` | [`docs/core-gameplay-release-readiness.md`](./core-gameplay-release-readiness.md). Use this when config-pack or map-pack changes need release-facing validation before they are bundled into persistence or candidate evidence. |
+| Validate shipped content packs | `npm run validate:content-pack`, `npm run validate:content-pack:all` | [`docs/content-pack-validation.md`](./content-pack-validation.md), [`docs/core-gameplay-release-readiness.md`](./core-gameplay-release-readiness.md). Use this when config-pack or map-pack changes need release-facing validation before they are bundled into persistence or candidate evidence. |
 | Validate battle balance assumptions | `npm run validate:battle` | [`docs/core-gameplay-release-readiness.md`](./core-gameplay-release-readiness.md) |
 | Review shared client/server contract coverage | `npm run test:contracts`, `npm run test:shared` | [`docs/shared-contract-snapshots.md`](./shared-contract-snapshots.md), [`docs/test-coverage-audit-issue-199.md`](./test-coverage-audit-issue-199.md) |
 

--- a/packages/shared/src/content-pack-validation.ts
+++ b/packages/shared/src/content-pack-validation.ts
@@ -1,6 +1,14 @@
-import type {
+import { getEquipmentDefinition, HERO_EQUIPMENT_INVENTORY_CAPACITY } from "./equipment.ts";
+import {
+  getDefaultHeroSkillTreeConfig
+} from "./world-config.ts";
+import {
+  levelForExperience,
   BattleBalanceConfig,
   BattleSkillCatalogConfig,
+  EquipmentType,
+  HeroConfig,
+  HeroLearnedSkillState,
   MapObjectsConfig,
   UnitCatalogConfig,
   WorldGenerationConfig
@@ -97,6 +105,311 @@ function validateWorldReferences(
   });
 }
 
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && value > 0;
+}
+
+function heroPath(heroIndex: number, suffix: string): string {
+  return `heroes[${heroIndex}]${suffix}`;
+}
+
+function buildHeroSkillIndex(): Map<string, { requiredLevel: number; maxRank: number; prerequisites: string[] }> {
+  const config = getDefaultHeroSkillTreeConfig();
+  return new Map(
+    config.skills.map((skill) => [
+      skill.id,
+      {
+        requiredLevel: skill.requiredLevel,
+        maxRank: skill.maxRank,
+        prerequisites: [...(skill.prerequisites ?? [])]
+      }
+    ] as const)
+  );
+}
+
+function validateHeroProgression(
+  hero: HeroConfig,
+  heroIndex: number,
+  issues: ContentPackValidationIssue[],
+  heroSkillIndex: Map<string, { requiredLevel: number; maxRank: number; prerequisites: string[] }>
+): void {
+  const progression = hero.progression;
+  if (!progression) {
+    return;
+  }
+
+  const level = progression.level ?? 1;
+  const experience = progression.experience ?? 0;
+  const skillPoints = progression.skillPoints ?? 0;
+  const battlesWon = progression.battlesWon ?? 0;
+  const neutralBattlesWon = progression.neutralBattlesWon ?? 0;
+  const pvpBattlesWon = progression.pvpBattlesWon ?? 0;
+
+  const integerChecks = [
+    { key: "level", value: level },
+    { key: "experience", value: experience },
+    { key: "skillPoints", value: skillPoints },
+    { key: "battlesWon", value: battlesWon },
+    { key: "neutralBattlesWon", value: neutralBattlesWon },
+    { key: "pvpBattlesWon", value: pvpBattlesWon }
+  ];
+
+  for (const check of integerChecks) {
+    if (!isNonNegativeInteger(check.value)) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, `.progression.${check.key}`),
+        code: "invalid_hero_progression_value",
+        message: `Hero ${hero.id} progression.${check.key} must be a non-negative integer.`,
+        suggestion: "Use whole numbers for authored progression fields so archive hydration stays deterministic."
+      });
+    }
+  }
+
+  if (isNonNegativeInteger(level) && isNonNegativeInteger(experience)) {
+    const minimumLevel = levelForExperience(experience);
+    if (level < minimumLevel) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, ".progression.level"),
+        code: "hero_progression_level_experience_mismatch",
+        message: `Hero ${hero.id} level ${level} is below the minimum level ${minimumLevel} for ${experience} experience.`,
+        suggestion: `Increase the hero level to at least ${minimumLevel} or lower the authored experience total.`
+      });
+    }
+  }
+
+  if (
+    isNonNegativeInteger(battlesWon) &&
+    isNonNegativeInteger(neutralBattlesWon) &&
+    isNonNegativeInteger(pvpBattlesWon) &&
+    neutralBattlesWon + pvpBattlesWon > battlesWon
+  ) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath(heroIndex, ".progression"),
+      code: "hero_battle_counters_mismatch",
+      message: `Hero ${hero.id} has ${neutralBattlesWon} neutral wins and ${pvpBattlesWon} PvP wins but only ${battlesWon} total battles won.`,
+      suggestion: "Keep battlesWon greater than or equal to the sum of neutralBattlesWon and pvpBattlesWon."
+    });
+  }
+
+  const learnedSkills = hero.learnedSkills ?? [];
+  let spentSkillPoints = 0;
+  const learnedSkillRanks = new Map<string, number>();
+
+  for (const [skillIndex, learnedSkill] of learnedSkills.entries()) {
+    if (!validateLearnedHeroSkill(hero, heroIndex, skillIndex, learnedSkill, heroSkillIndex, issues)) {
+      continue;
+    }
+
+    spentSkillPoints += learnedSkill.rank;
+    learnedSkillRanks.set(learnedSkill.skillId, learnedSkill.rank);
+  }
+
+  if (isNonNegativeInteger(level) && isNonNegativeInteger(skillPoints)) {
+    const earnedSkillPoints = Math.max(0, level - 1);
+    if (spentSkillPoints + skillPoints > earnedSkillPoints) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, ".progression.skillPoints"),
+        code: "hero_skill_points_exceed_progression",
+        message: `Hero ${hero.id} spends ${spentSkillPoints} skill point(s) in learnedSkills and still has ${skillPoints} available, exceeding the ${earnedSkillPoints} point(s) granted by level ${level}.`,
+        suggestion: "Lower learned skill ranks, reduce remaining skillPoints, or raise the hero level so authored progression matches the archive state."
+      });
+    }
+  }
+
+  for (const [skillIndex, learnedSkill] of learnedSkills.entries()) {
+    const skill = heroSkillIndex.get(learnedSkill.skillId);
+    if (!skill) {
+      continue;
+    }
+
+    const missingPrerequisite = skill.prerequisites.find((prerequisite) => (learnedSkillRanks.get(prerequisite) ?? 0) <= 0);
+    if (missingPrerequisite) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].skillId`),
+        code: "hero_skill_prerequisite_missing",
+        message: `Hero ${hero.id} learns ${learnedSkill.skillId} without prerequisite ${missingPrerequisite}.`,
+        suggestion: "Add the prerequisite skill to learnedSkills or remove the dependent skill from the authored hero archive."
+      });
+    }
+  }
+}
+
+function validateLearnedHeroSkill(
+  hero: HeroConfig,
+  heroIndex: number,
+  skillIndex: number,
+  learnedSkill: HeroLearnedSkillState,
+  heroSkillIndex: Map<string, { requiredLevel: number; maxRank: number; prerequisites: string[] }>,
+  issues: ContentPackValidationIssue[]
+): learnedSkill is HeroLearnedSkillState & { skillId: string; rank: number } {
+  const skillId = learnedSkill?.skillId?.trim();
+  if (!skillId) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].skillId`),
+      code: "hero_skill_id_missing",
+      message: `Hero ${hero.id} learnedSkills[${skillIndex}] is missing a skill id.`,
+      suggestion: "Set the skillId to a valid hero skill or remove the empty entry."
+    });
+    return false;
+  }
+
+  if (!isPositiveInteger(learnedSkill.rank)) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].rank`),
+      code: "hero_skill_rank_invalid",
+      message: `Hero ${hero.id} learned skill ${skillId} rank must be a positive integer.`,
+      suggestion: "Use a whole-number rank between 1 and the skill's maxRank."
+    });
+    return false;
+  }
+
+  const skill = heroSkillIndex.get(skillId);
+  if (!skill) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].skillId`),
+      code: "hero_skill_missing",
+      message: `Hero ${hero.id} references unknown hero skill ${skillId}.`,
+      suggestion: "Use a skill from hero-skill-trees-full.json or remove the stale learnedSkills entry."
+    });
+    return false;
+  }
+
+  if (learnedSkill.rank > skill.maxRank) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].rank`),
+      code: "hero_skill_rank_exceeds_max",
+      message: `Hero ${hero.id} sets ${skillId} to rank ${learnedSkill.rank}, but the skill only supports rank ${skill.maxRank}.`,
+      suggestion: "Lower the authored rank so it stays within the skill tree definition."
+    });
+  }
+
+  if ((hero.progression?.level ?? 1) < skill.requiredLevel) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}]`),
+      code: "hero_skill_level_too_low",
+      message: `Hero ${hero.id} is level ${hero.progression?.level ?? 1} but ${skillId} requires level ${skill.requiredLevel}.`,
+      suggestion: "Raise the hero level or remove the learned skill until the prerequisite level is reached."
+    });
+  }
+
+  return true;
+}
+
+function validateHeroEquipmentLoadout(hero: HeroConfig, heroIndex: number, issues: ContentPackValidationIssue[]): void {
+  const loadout = hero.loadout;
+  if (!loadout) {
+    return;
+  }
+
+  const inventory = loadout.inventory ?? [];
+  if (inventory.length > HERO_EQUIPMENT_INVENTORY_CAPACITY) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath(heroIndex, ".loadout.inventory"),
+      code: "hero_inventory_capacity_exceeded",
+      message: `Hero ${hero.id} starts with ${inventory.length} equipment item(s), exceeding the ${HERO_EQUIPMENT_INVENTORY_CAPACITY}-slot backpack limit.`,
+      suggestion: "Trim the authored inventory or equip some items before exporting the content pack."
+    });
+  }
+
+  inventory.forEach((equipmentId, inventoryIndex) => {
+    const definition = typeof equipmentId === "string" ? getEquipmentDefinition(equipmentId) : undefined;
+    if (!definition) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, `.loadout.inventory[${inventoryIndex}]`),
+        code: "hero_inventory_equipment_missing",
+        message: `Hero ${hero.id} inventory references unknown equipment id ${String(equipmentId)}.`,
+        suggestion: "Use an item from the default equipment catalog or remove the stale inventory entry."
+      });
+    }
+  });
+
+  const slotEntries: Array<{ slot: EquipmentType; key: "weaponId" | "armorId" | "accessoryId" }> = [
+    { slot: "weapon", key: "weaponId" },
+    { slot: "armor", key: "armorId" },
+    { slot: "accessory", key: "accessoryId" }
+  ];
+
+  slotEntries.forEach(({ slot, key }) => {
+    const equipmentId = loadout.equipment?.[key];
+    if (!equipmentId) {
+      return;
+    }
+
+    const definition = getEquipmentDefinition(equipmentId);
+    if (!definition) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, `.loadout.equipment.${key}`),
+        code: "hero_equipment_missing",
+        message: `Hero ${hero.id} equips unknown equipment id ${equipmentId} in ${slot} slot.`,
+        suggestion: "Use an item from the default equipment catalog or clear the slot."
+      });
+      return;
+    }
+
+    if (definition.type !== slot) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, `.loadout.equipment.${key}`),
+        code: "hero_equipment_slot_mismatch",
+        message: `Hero ${hero.id} equips ${equipmentId} in the ${slot} slot, but that item is typed as ${definition.type}.`,
+        suggestion: `Move ${equipmentId} to the ${definition.type} slot or replace it with a ${slot} item.`
+      });
+    }
+  });
+
+  const trinketIds = loadout.equipment?.trinketIds ?? [];
+  if (trinketIds.length > 0) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath(heroIndex, ".loadout.equipment.trinketIds"),
+      code: "hero_equipment_legacy_trinket_ids",
+      message: `Hero ${hero.id} still uses legacy loadout.equipment.trinketIds, which no longer maps to active slots or archive inventory rules.`,
+      suggestion: "Move one accessory into loadout.equipment.accessoryId and place any extras into loadout.inventory."
+    });
+  }
+
+  trinketIds.forEach((equipmentId, trinketIndex) => {
+    const definition = typeof equipmentId === "string" ? getEquipmentDefinition(equipmentId) : undefined;
+    if (!definition) {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, `.loadout.equipment.trinketIds[${trinketIndex}]`),
+        code: "hero_legacy_trinket_missing",
+        message: `Hero ${hero.id} legacy trinket entry references unknown equipment id ${String(equipmentId)}.`,
+        suggestion: "Remove the stale trinket id or replace it with a valid accessory item."
+      });
+      return;
+    }
+
+    if (definition.type !== "accessory") {
+      pushIssue(issues, {
+        documentId: "world",
+        path: heroPath(heroIndex, `.loadout.equipment.trinketIds[${trinketIndex}]`),
+        code: "hero_legacy_trinket_slot_mismatch",
+        message: `Hero ${hero.id} legacy trinket entry ${equipmentId} is typed as ${definition.type}, not accessory.`,
+        suggestion: "Only accessory items belong in trinketIds during migration; move other item types into their matching slot or inventory."
+      });
+    }
+  });
+}
+
 function validateMapObjectReferences(
   world: WorldGenerationConfig,
   mapObjects: MapObjectsConfig,
@@ -147,6 +460,18 @@ function validateMapObjectReferences(
       }
     });
 
+    if (army.reward) {
+      if (!isPositiveInteger(army.reward.amount)) {
+        pushIssue(issues, {
+          documentId: "mapObjects",
+          path: `neutralArmies[${armyIndex}].reward.amount`,
+          code: "neutral_reward_amount_invalid",
+          message: `Neutral army ${army.id} reward amount must be a positive integer, received ${String(army.reward.amount)}.`,
+          suggestion: "Author reward.amount as a whole number greater than zero so persistence and event logs stay consistent."
+        });
+      }
+    }
+
     const terrain = blockedTerrain.get(positionKey(army.position));
     if (terrain) {
       pushIssue(issues, {
@@ -188,6 +513,16 @@ function validateMapObjectReferences(
   });
 
   mapObjects.guaranteedResources.forEach((resource, index) => {
+    if (!isPositiveInteger(resource.resource.amount)) {
+      pushIssue(issues, {
+        documentId: "mapObjects",
+        path: `guaranteedResources[${index}].resource.amount`,
+        code: "guaranteed_resource_amount_invalid",
+        message: `Guaranteed resource ${resource.resource.kind} amount must be a positive integer, received ${String(resource.resource.amount)}.`,
+        suggestion: "Author guaranteed resource amounts as whole numbers greater than zero."
+      });
+    }
+
     const terrain = blockedTerrain.get(positionKey(resource.position));
     if (terrain) {
       pushIssue(issues, {
@@ -305,8 +640,13 @@ function buildSummary(issueCount: number): string {
 
 export function validateContentPackConsistency(bundle: RuntimeConfigBundle): ContentPackValidationReport {
   const issues: ContentPackValidationIssue[] = [];
+  const heroSkillIndex = buildHeroSkillIndex();
 
   validateWorldReferences(bundle.world, bundle.units, issues);
+  bundle.world.heroes.forEach((hero, heroIndex) => {
+    validateHeroProgression(hero, heroIndex, issues, heroSkillIndex);
+    validateHeroEquipmentLoadout(hero, heroIndex, issues);
+  });
   validateMapObjectReferences(bundle.world, bundle.mapObjects, bundle.units, issues);
   validateUnitSkillReferences(bundle.units, bundle.battleSkills, issues);
   if (bundle.battleBalance) {

--- a/scripts/test/validate-content-pack.test.ts
+++ b/scripts/test/validate-content-pack.test.ts
@@ -123,3 +123,89 @@ test("validate-content-pack supports the stonewatch fork preset on its own", asy
   assert.match(stdout, /Bundle: stonewatch-fork/);
   assert.match(stdout, /Result: PASS/);
 });
+
+test("validate-content-pack fails on typed hero progression and equipment authoring mismatches", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "veil-content-pack-"));
+  await seedContentPackRoot(tempDir);
+
+  const worldPath = join(tempDir, "phase1-world.json");
+  const world = JSON.parse(await readFile(worldPath, "utf8")) as {
+    heroes: Array<{
+      progression: {
+        level: number;
+        experience: number;
+        skillPoints?: number;
+      };
+      loadout: {
+        equipment?: {
+          weaponId?: string;
+          accessoryId?: string;
+          trinketIds?: string[];
+        };
+        inventory: string[];
+      };
+      learnedSkills?: Array<{ skillId: string; rank: number }>;
+    }>;
+  };
+
+  world.heroes[0]!.progression.level = 1;
+  world.heroes[0]!.progression.experience = 175;
+  world.heroes[0]!.progression.skillPoints = 2;
+  world.heroes[0]!.learnedSkills = [{ skillId: "war_banner", rank: 1 }];
+  world.heroes[0]!.loadout.equipment = {
+    weaponId: "padded_gambeson",
+    accessoryId: "missing_accessory",
+    trinketIds: ["militia_pike"]
+  };
+  world.heroes[0]!.loadout.inventory = [
+    "militia_pike",
+    "vanguard_blade",
+    "padded_gambeson",
+    "scout_compass",
+    "oak_longbow",
+    "tower_shield_mail",
+    "scribe_charm"
+  ];
+  await writeFile(worldPath, `${JSON.stringify(world, null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    execFileAsync("node", ["--import", "tsx", scriptPath, "--root-dir", tempDir], { cwd: repoRoot }),
+    (error: NodeJS.ErrnoException & { stdout?: string }) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stdout ?? "", /hero_progression_level_experience_mismatch/);
+      assert.match(error.stdout ?? "", /hero_skill_points_exceed_progression/);
+      assert.match(error.stdout ?? "", /hero_equipment_slot_mismatch/);
+      assert.match(error.stdout ?? "", /hero_equipment_missing/);
+      assert.match(error.stdout ?? "", /hero_equipment_legacy_trinket_ids/);
+      assert.match(error.stdout ?? "", /hero_inventory_capacity_exceeded/);
+      assert.match(error.stdout ?? "", /Suggestion:/);
+      return true;
+    }
+  );
+});
+
+test("validate-content-pack fails on invalid reward payload amounts before runtime", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "veil-content-pack-"));
+  await seedContentPackRoot(tempDir);
+
+  const mapObjectsPath = join(tempDir, "phase1-map-objects.json");
+  const mapObjects = JSON.parse(await readFile(mapObjectsPath, "utf8")) as {
+    neutralArmies: Array<{ reward?: { kind: string; amount: number } }>;
+    guaranteedResources: Array<{ resource: { amount: number } }>;
+  };
+
+  mapObjects.neutralArmies[0]!.reward = { kind: "gold", amount: 0 };
+  mapObjects.guaranteedResources[0]!.resource.amount = -2;
+  await writeFile(mapObjectsPath, `${JSON.stringify(mapObjects, null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    execFileAsync("node", ["--import", "tsx", scriptPath, "--root-dir", tempDir], { cwd: repoRoot }),
+    (error: NodeJS.ErrnoException & { stdout?: string }) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stdout ?? "", /neutral_reward_amount_invalid/);
+      assert.match(error.stdout ?? "", /guaranteed_resource_amount_invalid/);
+      assert.match(error.stdout ?? "", /must be a positive integer/);
+      return true;
+    }
+  );
+});

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -139,7 +139,10 @@ function validateDocuments(bundleId: string, bundle: RuntimeConfigBundle): Docum
   return issues;
 }
 
-function printIssues(title: string, issues: Array<{ documentId: string; path: string; message: string }>): void {
+function printIssues(
+  title: string,
+  issues: Array<{ documentId: string; path: string; message: string; suggestion?: string; code?: string }>
+): void {
   if (issues.length === 0) {
     console.log(`${title}: 0 issues`);
     return;
@@ -147,7 +150,9 @@ function printIssues(title: string, issues: Array<{ documentId: string; path: st
 
   console.log(`${title}: ${issues.length} issue(s)`);
   for (const issue of issues) {
-    console.log(`- [${issue.documentId}] ${issue.path}: ${issue.message}`);
+    const code = issue.code ? ` (${issue.code})` : "";
+    const suggestion = issue.suggestion ? ` Suggestion: ${issue.suggestion}` : "";
+    console.log(`- [${issue.documentId}] ${issue.path}${code}: ${issue.message}${suggestion}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- extend content-pack validation with typed hero progression, learned-skill, equipment, and reward payload checks
- print validator issue codes plus author-facing fix suggestions in the CLI output
- document the local/CI content-pack validation workflow and common invalid states

## Validation
- node --import tsx --test ./scripts/test/validate-content-pack.test.ts
- npm run validate:content-pack

Closes #690