### PR TITLE
feat(release): add candidate-level release dashboard and blocker drill-down

### DIFF
--- a/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
@@ -5,6 +5,7 @@ import {
   buildBuildPackageGate,
   buildCriticalEvidenceGate,
   buildGoNoGoReport,
+  summarizeSameCandidateAudit,
   summarizeCocosRc,
   summarizePrimaryClientDiagnostics,
   summarizeSnapshot,
@@ -71,7 +72,7 @@ test("buildBuildPackageGate aggregates snapshot, package, and smoke evidence int
   assert.deepEqual(gate.failReasons, ["wechat_package_metadata_missing", "wechat_smoke_failed"]);
   assert.deepEqual(gate.warnReasons, ["release_readiness_snapshot_pending", "release_readiness_required_checks_pending"]);
   assert.deepEqual(gate.details, [
-    "snapshot=partial | pending=e2e-multiplayer-smoke",
+    "snapshot=partial | multiplayerSmoke=pending | cocosPrimaryJourney=passed | wechatBuild=passed | pending=e2e-multiplayer-smoke",
     "WeChat package metadata missing.",
     "result=failed | failed=login-lobby"
   ]);
@@ -165,6 +166,17 @@ test("summarizePrimaryClientDiagnostics fails incomplete checkpoint coverage", (
   assert.match(summary.detail, /missingCheckpointIds=inventory-overflow,reconnect-cached-replay,reconnect-recovery/);
   assert.match(summary.detail, /missingCategoryIds=inventory,reconnect/);
   assert.deepEqual(summary.failReasons, ["primary_client_diagnostic_snapshots_incomplete"]);
+});
+
+test("summarizeSameCandidateAudit warns when the dashboard was not run as a candidate pair", () => {
+  const summary = summarizeSameCandidateAudit(undefined, undefined, {
+    candidateRevision: "abc1234",
+    maxEvidenceAgeDays: 14
+  });
+
+  assert.equal(summary.status, "warn");
+  assert.deepEqual(summary.warnReasons, ["same_candidate_evidence_audit_not_checked"]);
+  assert.equal(summary.evidence.availability, "missing");
 });
 
 test("buildGoNoGoReport marks a candidate blocked when linked evidence revisions disagree", () => {

--- a/apps/cocos-client/test/release-readiness-dashboard.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard.test.ts
@@ -36,6 +36,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
   const primaryClientDiagnosticsPath = path.join(workspaceDir, "cocos-primary-diagnostics.json");
   const reconnectSoakPath = path.join(workspaceDir, "colyseus-reconnect-soak-summary.json");
   const persistencePath = path.join(workspaceDir, "phase1-release-persistence-regression-abc1234.json");
+  const sameCandidateAuditPath = path.join(workspaceDir, "same-candidate-evidence-audit-phase1-rc-abc1234.json");
   const wechatArtifactsDir = path.join(workspaceDir, "wechat-artifacts");
   const packageMetadataPath = path.join(wechatArtifactsDir, "project-veil.package.json");
   const archivePath = path.join(wechatArtifactsDir, "project-veil.tar.gz");
@@ -135,6 +136,17 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     persistenceRegression: {
       mapPackId: "phase1",
       assertions: ["room hydration reapplied resources"]
+    }
+  });
+  writeJson(sameCandidateAuditPath, {
+    candidate: {
+      name: "phase1-rc",
+      revision: "abc1234"
+    },
+    summary: {
+      status: "passed",
+      findingCount: 0,
+      summary: "Same-candidate evidence is current for phase1-rc at abc1234."
     }
   });
   fs.mkdirSync(wechatArtifactsDir, { recursive: true });
@@ -251,6 +263,10 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
         reconnectSoakPath,
         "--phase1-persistence",
         persistencePath,
+        "--candidate",
+        "phase1-rc",
+        "--same-candidate-audit",
+        sameCandidateAuditPath,
         "--wechat-artifacts-dir",
         wechatArtifactsDir,
         "--candidate-revision",
@@ -281,6 +297,10 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
         warnReasons: string[];
         evidence: Array<{ availability: string; freshness: string }>;
       }>;
+      triage: {
+        blockers: Array<{ title: string }>;
+        warnings: Array<{ title: string }>;
+      };
     };
     assert.equal(report.overallStatus, "pass");
     assert.equal(report.goNoGo.decision, "ready");
@@ -296,13 +316,17 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
         ["build-package-validation", "pass"],
         ["reconnect-soak", "pass"],
         ["phase1-persistence", "pass"],
+        ["same-candidate-evidence", "pass"],
         ["critical-evidence", "pass"]
       ]
     );
     assert.deepEqual(report.gates.every((gate) => gate.failReasons.length === 0), true);
-    assert.equal(report.gates[5]?.evidence.every((entry) => entry.availability === "present"), true);
-    assert.equal(report.gates[5]?.evidence.length, 7);
+    assert.equal(report.gates[6]?.evidence.every((entry) => entry.availability === "present"), true);
+    assert.equal(report.gates[6]?.evidence.length, 8);
+    assert.deepEqual(report.triage.blockers, []);
+    assert.deepEqual(report.triage.warnings, []);
     assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /Phase 1 Go\/No-Go/);
+    assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /## Blocker Drill-Down/);
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => {
@@ -486,6 +510,7 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
       ["build-package-validation", "fail"],
       ["reconnect-soak", "fail"],
       ["phase1-persistence", "fail"],
+      ["same-candidate-evidence", "warn"],
       ["critical-evidence", "fail"]
     ]
   );
@@ -504,6 +529,7 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
     "phase1_content_validation_failed",
     "phase1_persistence_assertions_missing"
   ]);
-  assert.equal(report.gates[5]?.evidence.some((entry) => entry.freshness === "fresh"), true);
+  assert.deepEqual(report.gates[5]?.warnReasons, ["same_candidate_evidence_audit_not_checked"]);
+  assert.equal(report.gates[6]?.evidence.some((entry) => entry.freshness === "fresh"), true);
   assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /Release validation evidence is incomplete or still pending|One or more release validation surfaces failed/);
 });

--- a/docs/release-readiness-dashboard.md
+++ b/docs/release-readiness-dashboard.md
@@ -1,6 +1,6 @@
 # Phase 1 Release Readiness Dashboard
 
-`npm run release:readiness:dashboard` generates a single local report for the current Phase 1 gameplay release gates. It now promotes one Phase 1 `go/no-go` decision for a candidate revision, including first-class `requiredFailed` / `requiredPending` counts plus linked artifact paths for quick audit. The report reuses existing evidence instead of redefining the workflow:
+`npm run release:readiness:dashboard` generates a single local report for the current Phase 1 gameplay release gates. It now promotes one Phase 1 `go/no-go` decision for a candidate/revision pair, including first-class `requiredFailed` / `requiredPending` counts, normalized blocker/warning drill-down, and linked artifact paths for quick audit. The report reuses existing evidence instead of redefining the workflow:
 
 - `npm run release:readiness:snapshot` for automated regression/build gates
 - `GET /api/runtime/health`, `GET /api/runtime/auth-readiness`, `GET /api/runtime/metrics` for live server/auth posture
@@ -10,6 +10,7 @@
 - `npm run release:cocos:primary-diagnostics` for checkpointed primary-client runtime diagnostics evidence
 - `npm run stress:rooms:reconnect-soak` for reconnect soak + teardown evidence
 - `npm run test:phase1-release-persistence` for persistence + shipped content evidence
+- `npm run release:same-candidate:evidence-audit` for the candidate-scoped artifact-family consistency check under `artifacts/release-readiness/`
 
 If you need the faster maintainer-facing index of which command or doc owns each operational task, open [`docs/operational-entry-point-repo-map.md`](./operational-entry-point-repo-map.md).
 
@@ -23,18 +24,20 @@ Generate a report from the latest local evidence already under `artifacts/`:
 npm run release:readiness:dashboard
 ```
 
-Probe a live local server and point the report at a specific WeChat artifact directory:
+Generate a candidate-scoped dashboard for one candidate/revision pair:
 
 ```bash
 npm run release:readiness:dashboard -- \
+  --candidate phase1-rc \
+  --candidate-revision abc1234 \
   --server-url http://127.0.0.1:2567 \
   --snapshot artifacts/release-readiness/rc-2026-03-29.json \
   --cocos-rc artifacts/release-evidence/phase1-wechat-rc.json \
   --primary-client-diagnostics artifacts/release-readiness/cocos-primary-client-diagnostic-snapshots-abc1234-2026-03-29T08-18-00.000Z.json \
-  --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary.json \
+  --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary-phase1-rc-abc1234.json \
   --phase1-persistence artifacts/release-readiness/phase1-release-persistence-regression-abc1234.json \
+  --same-candidate-audit artifacts/release-readiness/same-candidate-evidence-audit-phase1-rc-abc1234.json \
   --wechat-artifacts-dir artifacts/wechat-release \
-  --candidate-revision abc1234
 ```
 
 Write to explicit output files:
@@ -54,10 +57,10 @@ npm run release:readiness:dashboard -- --max-evidence-age-days 7
 If you want the report to pin all automated and manual evidence to one explicit candidate revision, pass:
 
 ```bash
-npm run release:readiness:dashboard -- --candidate-revision <git-sha>
+npm run release:readiness:dashboard -- --candidate <candidate-name> --candidate-revision <git-sha>
 ```
 
-When `--candidate-revision` is set, the command becomes an enforcing candidate-consistency check for the required local evidence set. It still writes the JSON + Markdown dashboard, but exits non-zero if any linked artifact:
+When both `--candidate` and `--candidate-revision` are set, the command becomes the enforcing candidate-consistency check for the required local evidence set. It still writes the JSON + Markdown dashboard, but the dashboard now explicitly calls out when the same-candidate audit is missing or failing, and exits non-zero if any linked artifact:
 
 - reports a different revision than the pinned candidate
 - omits revision metadata, so the candidate cannot be verified end to end
@@ -75,7 +78,7 @@ The report starts with one `go/no-go` section:
   - one or more required checks failed, a gate failed, or linked artifact revisions disagree on which candidate is under review.
   - when `--candidate-revision` is supplied, `blocked` also covers required evidence with missing revision metadata or freshness that cannot be verified inside the configured window.
 
-After that, the report summarizes the same six bounded gates:
+After that, the report summarizes seven bounded gates:
 
 - `Server health`
   - `pass` when `/api/runtime/health` is reachable and `/api/runtime/metrics` exposes the expected gameplay/auth counters.
@@ -93,6 +96,10 @@ After that, the report summarizes the same six bounded gates:
   - Lists the latest linked evidence with exact timestamps, paths, and any revision identifiers discovered in the source artifacts.
   - Fails closed when primary-client diagnostic snapshots are missing or incomplete.
   - Warns when present evidence is older than the configured freshness window.
+- `Same-candidate evidence`
+  - Reuses `same-candidate-evidence-audit-<candidate>-<short-sha>.json` when you run the dashboard as a candidate/revision pair.
+  - Fails when the audit is missing or failed for the selected candidate.
+  - Warns instead of failing when the dashboard is run without a pinned candidate pair and no audit was selected.
 - `Reconnect soak evidence`
   - Fails when the reconnect soak artifact is missing, reports failed scenarios / rooms, omits reconnect or invariant counters, or leaves cleanup counters above zero.
   - Warns when the artifact passes but is older than the configured freshness window.
@@ -141,17 +148,32 @@ npm run test:phase1-release-persistence
 npm run dev:server
 ```
 
-7. Generate the dashboard:
+7. Run the same-candidate audit for the pinned candidate pair:
+
+```bash
+npm run release:same-candidate:evidence-audit -- \
+  --candidate <candidate-name> \
+  --candidate-revision <git-sha>
+```
+
+8. Generate the dashboard:
 
 ```bash
 npm run release:readiness:dashboard -- \
+  --candidate <candidate-name> \
   --server-url http://127.0.0.1:2567 \
   --wechat-artifacts-dir artifacts/wechat-release \
   --candidate-revision <git-sha>
 ```
 
-Use the same `<git-sha>` across the snapshot, WeChat package/smoke artifacts, Cocos RC snapshot, and primary-client diagnostics generation flow. If one artifact drifts to another revision or goes stale, the dashboard now prints the exact artifact path plus the observed/expected revision mismatch before exiting non-zero.
+Use the same `<candidate-name>` and `<git-sha>` across the snapshot, reconnect soak artifact, same-candidate audit, WeChat package/smoke artifacts, Cocos RC snapshot, and primary-client diagnostics generation flow. If one artifact drifts to another revision or goes stale, the dashboard now prints the exact artifact path plus the observed/expected revision mismatch before exiting non-zero.
 
-The Markdown output is intended to be attachable to issue/PR discussion, while the JSON output is intended for automation or later aggregation. Both formats now expose the same candidate-level `goNoGo` block so reviewers do not need to stitch the final Phase 1 release call together by hand.
+The Markdown output is intended to be attachable to issue/PR discussion, while the JSON output is intended for automation or later aggregation. Both formats now expose the same candidate-level `goNoGo` block plus a `Blocker Drill-Down` section so reviewers do not need to stitch the final Phase 1 release call together by hand.
+
+## CI And Manual Review
+
+- CI should treat the JSON dashboard as the machine-readable contract and key off `overallStatus`, `goNoGo.decision`, `goNoGo.blockers`, and `triage.blockers`.
+- Manual release review should start with the Markdown `Blocker Drill-Down`, then open the listed evidence paths for the specific failing or warning gate instead of re-reading the entire artifact packet.
+- The dashboard replaces manual evidence stitching when the selected candidate pair already has fresh snapshot, reconnect soak, same-candidate audit, WeChat, and Cocos evidence. It does not replace manual runtime observability sign-off, RC checklist review, or any target-surface-specific human approvals that are still recorded outside the dashboard.
 
 If `release:health:summary` later flags a `readiness-trend` warning for this dashboard, use [`docs/release-readiness-trend-troubleshooting.md`](./release-readiness-trend-troubleshooting.md) to compare this candidate call against the previous successful branch baseline.

--- a/scripts/release-readiness-dashboard.ts
+++ b/scripts/release-readiness-dashboard.ts
@@ -7,12 +7,14 @@ type EvidenceAvailability = "present" | "missing";
 type EvidenceFreshness = "unknown" | "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp";
 
 interface Args {
+  candidate?: string;
   serverUrl?: string;
   snapshotPath?: string;
   cocosRcPath?: string;
   primaryClientDiagnosticsPath?: string;
   reconnectSoakPath?: string;
   persistencePath?: string;
+  sameCandidateAuditPath?: string;
   wechatArtifactsDir?: string;
   wechatSmokeReportPath?: string;
   wechatPackageMetadataPath?: string;
@@ -213,13 +215,16 @@ interface DashboardReport {
   overallStatus: GateStatus;
   summary: string;
   goNoGo: GoNoGoReport;
+  triage: DashboardTriageReport;
   inputs: {
+    candidate?: string;
     serverUrl?: string;
     snapshotPath?: string;
     cocosRcPath?: string;
     primaryClientDiagnosticsPath?: string;
     reconnectSoakPath?: string;
     persistencePath?: string;
+    sameCandidateAuditPath?: string;
     wechatArtifactsDir?: string;
     wechatSmokeReportPath?: string;
     wechatPackageMetadataPath?: string;
@@ -271,6 +276,32 @@ interface CandidateConsistencyFinding {
   freshness?: EvidenceFreshness;
 }
 
+interface SameCandidateEvidenceAuditReport {
+  candidate?: {
+    name?: string;
+    revision?: string;
+  };
+  summary?: {
+    status?: "passed" | "failed";
+    findingCount?: number;
+    summary?: string;
+  };
+}
+
+interface DashboardTriageEntry {
+  id: string;
+  severity: "blocker" | "warning";
+  title: string;
+  summary: string;
+  gateId?: string;
+  evidencePaths: string[];
+}
+
+interface DashboardTriageReport {
+  blockers: DashboardTriageEntry[];
+  warnings: DashboardTriageEntry[];
+}
+
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
 const DEFAULT_RELEASE_EVIDENCE_DIR = path.resolve("artifacts", "release-evidence");
 const REQUIRED_SNAPSHOT_CHECK_IDS = ["npm-test", "typecheck-ci", "e2e-smoke", "e2e-multiplayer-smoke", "cocos-primary-journey", "wechat-build-check"] as const;
@@ -295,12 +326,14 @@ function fail(message: string): never {
 }
 
 function parseArgs(argv: string[]): Args {
+  let candidate: string | undefined;
   let serverUrl: string | undefined;
   let snapshotPath: string | undefined;
   let cocosRcPath: string | undefined;
   let primaryClientDiagnosticsPath: string | undefined;
   let reconnectSoakPath: string | undefined;
   let persistencePath: string | undefined;
+  let sameCandidateAuditPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let wechatSmokeReportPath: string | undefined;
   let wechatPackageMetadataPath: string | undefined;
@@ -313,6 +346,11 @@ function parseArgs(argv: string[]): Args {
     const arg = argv[index];
     const next = argv[index + 1];
 
+    if (arg === "--candidate" && next) {
+      candidate = next.trim();
+      index += 1;
+      continue;
+    }
     if (arg === "--server-url" && next) {
       serverUrl = next.trim();
       index += 1;
@@ -340,6 +378,11 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--phase1-persistence" && next) {
       persistencePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--same-candidate-audit" && next) {
+      sameCandidateAuditPath = next;
       index += 1;
       continue;
     }
@@ -387,12 +430,14 @@ function parseArgs(argv: string[]): Args {
   }
 
   return {
+    ...(candidate ? { candidate } : {}),
     ...(serverUrl ? { serverUrl } : {}),
     ...(snapshotPath ? { snapshotPath } : {}),
     ...(cocosRcPath ? { cocosRcPath } : {}),
     ...(primaryClientDiagnosticsPath ? { primaryClientDiagnosticsPath } : {}),
     ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
     ...(persistencePath ? { persistencePath } : {}),
+    ...(sameCandidateAuditPath ? { sameCandidateAuditPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
     ...(wechatPackageMetadataPath ? { wechatPackageMetadataPath } : {}),
@@ -403,7 +448,11 @@ function parseArgs(argv: string[]): Args {
   };
 }
 
-function resolveLatestMatchingJsonFile(dirPath: string, matcher: (entry: string) => boolean): string | undefined {
+function resolveLatestMatchingJsonFile(
+  dirPath: string,
+  matcher: (entry: string) => boolean,
+  preferredMatcher?: (entry: string) => boolean
+): string | undefined {
   if (!fs.existsSync(dirPath)) {
     return undefined;
   }
@@ -413,6 +462,12 @@ function resolveLatestMatchingJsonFile(dirPath: string, matcher: (entry: string)
     .map((entry) => path.join(dirPath, entry))
     .filter((entry) => fs.statSync(entry).isFile())
     .sort((left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs);
+  if (preferredMatcher) {
+    const preferredCandidate = candidates.find((entry) => preferredMatcher(path.basename(entry)));
+    if (preferredCandidate) {
+      return preferredCandidate;
+    }
+  }
   return candidates[0];
 }
 
@@ -465,6 +520,15 @@ function writeTextFile(filePath: string, content: string): void {
 
 function toRelativePath(filePath: string): string {
   return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+}
+
+function slugify(value: string | undefined): string | undefined {
+  const normalized = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || undefined;
 }
 
 function statusRank(status: GateStatus): number {
@@ -788,6 +852,9 @@ export function summarizeSnapshot(snapshotPath: string | undefined, snapshot: Re
   const missingRequiredChecks = REQUIRED_SNAPSHOT_CHECK_IDS.filter((id) => !checksById.has(id));
   const failedRequiredChecks = REQUIRED_SNAPSHOT_CHECK_IDS.filter((id) => checksById.get(id)?.status === "failed");
   const pendingRequiredChecks = REQUIRED_SNAPSHOT_CHECK_IDS.filter((id) => checksById.get(id)?.status === "pending");
+  const multiplayerSmokeStatus = checksById.get("e2e-multiplayer-smoke")?.status ?? "missing";
+  const cocosPrimaryJourneyStatus = checksById.get("cocos-primary-journey")?.status ?? "missing";
+  const wechatBuildStatus = checksById.get("wechat-build-check")?.status ?? "missing";
 
   let status: GateStatus = "pass";
   if (snapshot.summary?.status === "failed" || failedRequiredChecks.length > 0 || missingRequiredChecks.length > 0) {
@@ -818,7 +885,12 @@ export function summarizeSnapshot(snapshotPath: string | undefined, snapshot: Re
     warnReasons.push("release_readiness_required_checks_pending");
   }
 
-  const parts = [`snapshot=${snapshot.summary?.status ?? "<missing>"}`];
+  const parts = [
+    `snapshot=${snapshot.summary?.status ?? "<missing>"}`,
+    `multiplayerSmoke=${multiplayerSmokeStatus}`,
+    `cocosPrimaryJourney=${cocosPrimaryJourneyStatus}`,
+    `wechatBuild=${wechatBuildStatus}`
+  ];
   if (failedRequiredChecks.length > 0) {
     parts.push(`failed=${failedRequiredChecks.join(", ")}`);
   }
@@ -838,6 +910,74 @@ export function summarizeSnapshot(snapshotPath: string | undefined, snapshot: Re
       status,
       observedAt: snapshot.generatedAt,
       sourceRevision: snapshot.revision?.shortCommit ?? snapshot.revision?.commit,
+      summary: parts.join(" | "),
+      reasonCodes: status === "fail" ? failReasons : warnReasons
+    }),
+    failReasons,
+    warnReasons
+  };
+}
+
+export function summarizeSameCandidateAudit(
+  auditPath: string | undefined,
+  audit: SameCandidateEvidenceAuditReport | undefined,
+  input: { candidate?: string; candidateRevision?: string; maxEvidenceAgeDays: number }
+): EvidenceSummary {
+  const candidatePinned = Boolean(input.candidate?.trim() && input.candidateRevision?.trim());
+
+  if (!auditPath || !audit) {
+    const status: GateStatus = candidatePinned ? "fail" : "warn";
+    const reasonCode = candidatePinned ? "same_candidate_evidence_audit_missing" : "same_candidate_evidence_audit_not_checked";
+    return {
+      status,
+      detail: candidatePinned
+        ? "Same-candidate evidence audit missing."
+        : "Same-candidate evidence audit not selected; pass --candidate plus --candidate-revision to enforce candidate-level evidence stitching.",
+      evidence: createEvidenceItem({
+        label: "Same-candidate evidence audit",
+        path: auditPath ?? "<missing-same-candidate-evidence-audit>",
+        status,
+        availability: "missing",
+        summary: candidatePinned
+          ? "Same-candidate evidence audit missing."
+          : "Same-candidate evidence audit not selected.",
+        reasonCodes: [reasonCode]
+      }),
+      failReasons: candidatePinned ? [reasonCode] : [],
+      warnReasons: candidatePinned ? [] : [reasonCode]
+    };
+  }
+
+  const failReasons: string[] = [];
+  if (audit.summary?.status !== "passed") {
+    failReasons.push("same_candidate_evidence_audit_failed");
+  }
+
+  const age = describeAge(auditPath ? new Date(fs.statSync(auditPath).mtimeMs).toISOString() : undefined, input.maxEvidenceAgeDays);
+  const warnReasons = failReasons.length === 0 && age.status === "warn" ? ["same_candidate_evidence_audit_stale"] : [];
+  const status: GateStatus = failReasons.length > 0 ? "fail" : age.status === "warn" ? "warn" : "pass";
+  const parts = [
+    `status=${audit.summary?.status ?? "<missing>"}`,
+    `candidate=${audit.candidate?.name ?? "<missing>"}`,
+    `revision=${audit.candidate?.revision ?? "<missing>"}`,
+    `findings=${audit.summary?.findingCount ?? 0}`
+  ];
+  if (audit.summary?.summary?.trim()) {
+    parts.push(audit.summary.summary.trim());
+  }
+  if (warnReasons.length > 0) {
+    parts.push(age.detail);
+  }
+
+  return {
+    status,
+    detail: parts.join(" | "),
+    evidence: createEvidenceItem({
+      label: "Same-candidate evidence audit",
+      path: auditPath,
+      status,
+      observedAt: new Date(fs.statSync(auditPath).mtimeMs).toISOString(),
+      sourceRevision: audit.candidate?.revision,
       summary: parts.join(" | "),
       reasonCodes: status === "fail" ? failReasons : warnReasons
     }),
@@ -1479,6 +1619,41 @@ export function buildGoNoGoReport(input: {
   };
 }
 
+function buildDashboardTriage(report: Pick<DashboardReport, "gates" | "goNoGo">): DashboardTriageReport {
+  const blockers: DashboardTriageEntry[] = [
+    ...report.gates
+      .filter((gate) => gate.status === "fail")
+      .map((gate) => ({
+        id: `gate:${gate.id}`,
+        severity: "blocker" as const,
+        title: gate.label,
+        summary: gate.failReasons[0] ?? gate.summary,
+        gateId: gate.id,
+        evidencePaths: gate.evidence.map((entry) => entry.path)
+      })),
+    ...report.goNoGo.candidateConsistencyFindings.map((finding) => ({
+      id: `candidate-consistency:${finding.code}:${finding.label}`,
+      severity: "blocker" as const,
+      title: "Candidate consistency",
+      summary: finding.summary,
+      evidencePaths: [finding.path]
+    }))
+  ];
+
+  const warnings: DashboardTriageEntry[] = report.gates
+    .filter((gate) => gate.status === "warn")
+    .map((gate) => ({
+      id: `gate:${gate.id}`,
+      severity: "warning" as const,
+      title: gate.label,
+      summary: gate.warnReasons[0] ?? gate.summary,
+      gateId: gate.id,
+      evidencePaths: gate.evidence.map((entry) => entry.path)
+    }));
+
+  return { blockers, warnings };
+}
+
 function renderMarkdown(report: DashboardReport): string {
   const lines: string[] = [];
   lines.push("# Phase 1 Release Readiness Dashboard");
@@ -1492,6 +1667,19 @@ function renderMarkdown(report: DashboardReport): string {
   lines.push(`- Required pending: ${report.goNoGo.requiredPending}`);
   lines.push(`- Candidate revision: ${report.goNoGo.candidateRevision ?? "<unverified>"}`);
   lines.push(`- Revision status: ${report.goNoGo.revisionStatus.toUpperCase()}`);
+  lines.push("");
+  lines.push("## Selected Inputs");
+  lines.push("");
+  lines.push(`- Candidate: ${report.inputs.candidate ?? "<unverified>"}`);
+  lines.push(`- Snapshot: ${report.inputs.snapshotPath ?? "<missing>"}`);
+  lines.push(`- Cocos RC: ${report.inputs.cocosRcPath ?? "<missing>"}`);
+  lines.push(`- Primary-client diagnostics: ${report.inputs.primaryClientDiagnosticsPath ?? "<missing>"}`);
+  lines.push(`- Reconnect soak: ${report.inputs.reconnectSoakPath ?? "<missing>"}`);
+  lines.push(`- Phase 1 persistence: ${report.inputs.persistencePath ?? "<missing>"}`);
+  lines.push(`- Same-candidate audit: ${report.inputs.sameCandidateAuditPath ?? "<missing>"}`);
+  lines.push(`- WeChat artifacts dir: ${report.inputs.wechatArtifactsDir ?? "<missing>"}`);
+  lines.push(`- WeChat smoke report: ${report.inputs.wechatSmokeReportPath ?? "<missing>"}`);
+  lines.push(`- WeChat package metadata: ${report.inputs.wechatPackageMetadataPath ?? "<missing>"}`);
   lines.push("");
   lines.push("## Phase 1 Go/No-Go");
   lines.push("");
@@ -1525,6 +1713,34 @@ function renderMarkdown(report: DashboardReport): string {
     }
     lines.push("");
   }
+  lines.push("## Blocker Drill-Down");
+  lines.push("");
+  lines.push(`### Blockers (${report.triage.blockers.length})`);
+  lines.push("");
+  if (report.triage.blockers.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const entry of report.triage.blockers) {
+      lines.push(`- **${entry.title}**: ${entry.summary}`);
+      if (entry.evidencePaths.length > 0) {
+        lines.push(`  Evidence: ${entry.evidencePaths.join(", ")}`);
+      }
+    }
+  }
+  lines.push("");
+  lines.push(`### Warnings (${report.triage.warnings.length})`);
+  lines.push("");
+  if (report.triage.warnings.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const entry of report.triage.warnings) {
+      lines.push(`- **${entry.title}**: ${entry.summary}`);
+      if (entry.evidencePaths.length > 0) {
+        lines.push(`  Evidence: ${entry.evidencePaths.join(", ")}`);
+      }
+    }
+  }
+  lines.push("");
   lines.push("| Gate | Status | Summary |");
   lines.push("| --- | --- | --- |");
   for (const gate of report.gates) {
@@ -1567,9 +1783,15 @@ function renderMarkdown(report: DashboardReport): string {
   return `${lines.join("\n").trim()}\n`;
 }
 
-function defaultOutputPaths(): { jsonPath: string; markdownPath: string } {
+function defaultOutputPaths(args: Args): { jsonPath: string; markdownPath: string } {
+  const candidateSlug = slugify(args.candidate);
+  const revisionSuffix = args.candidateRevision?.slice(0, 12);
   const timestamp = new Date().toISOString().replace(/:/g, "-");
-  const baseName = `phase1-release-dashboard-${timestamp}`;
+  const baseName = candidateSlug && revisionSuffix
+    ? `release-readiness-dashboard-${candidateSlug}-${revisionSuffix}`
+    : revisionSuffix
+      ? `release-readiness-dashboard-${revisionSuffix}`
+      : `release-readiness-dashboard-${timestamp}`;
   return {
     jsonPath: path.resolve(DEFAULT_RELEASE_READINESS_DIR, `${baseName}.json`),
     markdownPath: path.resolve(DEFAULT_RELEASE_READINESS_DIR, `${baseName}.md`)
@@ -1578,24 +1800,55 @@ function defaultOutputPaths(): { jsonPath: string; markdownPath: string } {
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
-  const outputDefaults = defaultOutputPaths();
+  const outputDefaults = defaultOutputPaths(args);
+  const candidateSlug = slugify(args.candidate);
+  const revisionSuffix = args.candidateRevision?.slice(0, 12);
   const resolvedSnapshotPath = args.snapshotPath
     ? path.resolve(args.snapshotPath)
-    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) => entry.startsWith("release-readiness-"));
+    : resolveLatestMatchingJsonFile(
+        DEFAULT_RELEASE_READINESS_DIR,
+        (entry) => entry.startsWith("release-readiness-"),
+        (entry) => Boolean(revisionSuffix && entry.includes(revisionSuffix))
+      );
   const resolvedCocosRcPath = args.cocosRcPath
     ? path.resolve(args.cocosRcPath)
-    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_EVIDENCE_DIR, (entry) => entry.endsWith(".json"));
+    : resolveLatestMatchingJsonFile(
+        DEFAULT_RELEASE_EVIDENCE_DIR,
+        (entry) => entry.endsWith(".json"),
+        (entry) => Boolean(candidateSlug && revisionSuffix && entry.includes(candidateSlug) && entry.includes(revisionSuffix))
+      );
   const resolvedPrimaryClientDiagnosticsPath = args.primaryClientDiagnosticsPath
     ? path.resolve(args.primaryClientDiagnosticsPath)
-    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
-        entry.startsWith("cocos-primary-client-diagnostic-snapshots-")
+    : resolveLatestMatchingJsonFile(
+        DEFAULT_RELEASE_READINESS_DIR,
+        (entry) => entry.startsWith("cocos-primary-client-diagnostic-snapshots-"),
+        (entry) => Boolean(revisionSuffix && entry.includes(revisionSuffix))
       );
   const resolvedReconnectSoakPath = args.reconnectSoakPath
     ? path.resolve(args.reconnectSoakPath)
-    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) => entry.startsWith("colyseus-reconnect-soak-summary"));
+    : resolveLatestMatchingJsonFile(
+        DEFAULT_RELEASE_READINESS_DIR,
+        (entry) => entry.startsWith("colyseus-reconnect-soak-summary"),
+        (entry) => Boolean(
+          revisionSuffix &&
+            entry.includes(revisionSuffix) &&
+            (!candidateSlug || entry.includes(candidateSlug))
+        )
+      );
   const resolvedPersistencePath = args.persistencePath
     ? path.resolve(args.persistencePath)
-    : resolveLatestMatchingJsonFile(DEFAULT_RELEASE_READINESS_DIR, (entry) => entry.startsWith("phase1-release-persistence-regression-"));
+    : resolveLatestMatchingJsonFile(
+        DEFAULT_RELEASE_READINESS_DIR,
+        (entry) => entry.startsWith("phase1-release-persistence-regression-"),
+        (entry) => Boolean(revisionSuffix && entry.includes(revisionSuffix) && (!candidateSlug || entry.includes(candidateSlug)))
+      );
+  const resolvedSameCandidateAuditPath = args.sameCandidateAuditPath
+    ? path.resolve(args.sameCandidateAuditPath)
+    : resolveLatestMatchingJsonFile(
+        DEFAULT_RELEASE_READINESS_DIR,
+        (entry) => entry.startsWith("same-candidate-evidence-audit-") && entry.endsWith(".json"),
+        (entry) => Boolean(candidateSlug && revisionSuffix && entry.includes(candidateSlug) && entry.includes(revisionSuffix))
+      );
   const wechatArtifacts = resolveWechatArtifacts(args);
 
   const snapshot = readJsonFile<ReleaseReadinessSnapshot>(resolvedSnapshotPath);
@@ -1603,6 +1856,7 @@ async function main(): Promise<void> {
   const primaryClientDiagnostics = readJsonFile<PrimaryClientDiagnosticSnapshotsArtifact>(resolvedPrimaryClientDiagnosticsPath);
   const reconnectSoakArtifact = readJsonFile<ReconnectSoakArtifact>(resolvedReconnectSoakPath);
   const persistenceArtifact = readJsonFile<Phase1PersistenceReleaseReport>(resolvedPersistencePath);
+  const sameCandidateAudit = readJsonFile<SameCandidateEvidenceAuditReport>(resolvedSameCandidateAuditPath);
   const wechatSmokeReport = readJsonFile<WechatSmokeReport>(wechatArtifacts.smokeReportPath);
   const wechatPackageMetadata = readJsonFile<WechatPackageMetadata>(wechatArtifacts.packageMetadataPath);
 
@@ -1642,6 +1896,11 @@ async function main(): Promise<void> {
   );
   const reconnectSoakSummary = summarizeReconnectSoak(resolvedReconnectSoakPath, reconnectSoakArtifact, args.maxEvidenceAgeDays);
   const persistenceSummary = summarizePhase1Persistence(resolvedPersistencePath, persistenceArtifact, args.maxEvidenceAgeDays);
+  const sameCandidateAuditSummary = summarizeSameCandidateAudit(resolvedSameCandidateAuditPath, sameCandidateAudit, {
+    candidate: args.candidate,
+    candidateRevision: args.candidateRevision,
+    maxEvidenceAgeDays: args.maxEvidenceAgeDays
+  });
 
   const criticalEvidenceGate = buildCriticalEvidenceGate(args.maxEvidenceAgeDays, [
     snapshotSummary.evidence,
@@ -1650,7 +1909,8 @@ async function main(): Promise<void> {
     cocosRcSummary.evidence,
     primaryClientDiagnosticsSummary.evidence,
     reconnectSoakSummary.evidence,
-    persistenceSummary.evidence
+    persistenceSummary.evidence,
+    sameCandidateAuditSummary.evidence
   ]);
 
   const gates = [
@@ -1673,28 +1933,40 @@ async function main(): Promise<void> {
       "Phase 1 persistence evidence exists, but freshness needs review.",
       "Phase 1 persistence evidence is missing or failing."
     ),
+    buildArtifactGate(
+      "same-candidate-evidence",
+      "Same-candidate evidence",
+      sameCandidateAuditSummary,
+      "Same-candidate evidence audit is present and passing for this candidate.",
+      "Same-candidate evidence was not pinned or needs freshness review.",
+      "Same-candidate evidence is missing or failing."
+    ),
     criticalEvidenceGate
   ];
 
+  const goNoGo = buildGoNoGoReport({
+    candidateRevision: args.candidateRevision,
+    maxEvidenceAgeDays: args.maxEvidenceAgeDays,
+    snapshot,
+    gates,
+    evidence: criticalEvidenceGate.evidence
+  });
   const report: DashboardReport = {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
     overallStatus: mergeStatuses(gates.map((gate) => gate.status)),
     summary: buildOverallSummary(gates),
-    goNoGo: buildGoNoGoReport({
-      candidateRevision: args.candidateRevision,
-      maxEvidenceAgeDays: args.maxEvidenceAgeDays,
-      snapshot,
-      gates,
-      evidence: criticalEvidenceGate.evidence
-    }),
+    goNoGo,
+    triage: buildDashboardTriage({ gates, goNoGo }),
     inputs: {
+      ...(args.candidate ? { candidate: args.candidate } : {}),
       ...(args.serverUrl ? { serverUrl: args.serverUrl } : {}),
       ...(resolvedSnapshotPath ? { snapshotPath: resolvedSnapshotPath } : {}),
       ...(resolvedCocosRcPath ? { cocosRcPath: resolvedCocosRcPath } : {}),
       ...(resolvedPrimaryClientDiagnosticsPath ? { primaryClientDiagnosticsPath: resolvedPrimaryClientDiagnosticsPath } : {}),
       ...(resolvedReconnectSoakPath ? { reconnectSoakPath: resolvedReconnectSoakPath } : {}),
       ...(resolvedPersistencePath ? { persistencePath: resolvedPersistencePath } : {}),
+      ...(resolvedSameCandidateAuditPath ? { sameCandidateAuditPath: resolvedSameCandidateAuditPath } : {}),
       ...(args.wechatArtifactsDir ? { wechatArtifactsDir: path.resolve(args.wechatArtifactsDir) } : {}),
       ...(wechatArtifacts.smokeReportPath ? { wechatSmokeReportPath: wechatArtifacts.smokeReportPath } : {}),
       ...(wechatArtifacts.packageMetadataPath ? { wechatPackageMetadataPath: wechatArtifacts.packageMetadataPath } : {}),
@@ -1722,7 +1994,7 @@ async function main(): Promise<void> {
   for (const gate of report.gates) {
     console.log(`- ${gate.label}: ${gate.status} (${gate.summary})`);
   }
-  if (report.goNoGo.candidateConsistencyFindings.length > 0) {
+  if (report.goNoGo.decision === "blocked") {
     process.exitCode = 1;
   }
 }

--- a/scripts/test/release-readiness-dashboard.test.ts
+++ b/scripts/test/release-readiness-dashboard.test.ts
@@ -153,7 +153,7 @@ test("release-readiness dashboard keeps stale and partial mixed-surface evidence
     path.resolve(__dirname, "../..")
   );
 
-  assert.equal(result.status, 0);
+  assert.equal(result.status, 1);
   assert.match(result.stdout, /Overall status: fail/);
   assert.match(result.stdout, /Go\/No-Go decision: blocked/);
 
@@ -187,6 +187,7 @@ test("release-readiness dashboard keeps stale and partial mixed-surface evidence
       ["build-package-validation", "fail"],
       ["reconnect-soak", "warn"],
       ["phase1-persistence", "pass"],
+      ["same-candidate-evidence", "warn"],
       ["critical-evidence", "fail"]
     ]
   );
@@ -194,12 +195,17 @@ test("release-readiness dashboard keeps stale and partial mixed-surface evidence
     "wechat_package_metadata_missing"
   ]);
   assert.deepEqual(report.gates.find((gate) => gate.id === "reconnect-soak")?.warnReasons, ["reconnect_soak_stale"]);
+  assert.deepEqual(report.gates.find((gate) => gate.id === "same-candidate-evidence")?.warnReasons, [
+    "same_candidate_evidence_audit_not_checked"
+  ]);
   assert.match(report.gates.find((gate) => gate.id === "critical-evidence")?.details.join("\n") ?? "", /older than 14 day\(s\)/);
   assert.match(report.gates.find((gate) => gate.id === "critical-evidence")?.details.join("\n") ?? "", /Primary-client diagnostic snapshots: missing artifact/);
 
   const markdown = fs.readFileSync(markdownOutputPath, "utf8");
+  assert.match(markdown, /## Blocker Drill-Down/);
   assert.match(markdown, /## Server health[\s\S]*- Evidence: unavailable\./);
   assert.match(markdown, /## Auth readiness[\s\S]*- Evidence: unavailable\./);
+  assert.match(markdown, /## Same-candidate evidence[\s\S]*Same-candidate evidence audit not selected/);
   assert.match(markdown, /WeChat package metadata missing\./);
   assert.match(markdown, /Primary-client diagnostic snapshots: FAIL \(/);
   assert.match(markdown, /Cocos RC snapshot: FAIL @ 2026-03-30T00:10:00.000Z/);


### PR DESCRIPTION
## Summary
- make `release:readiness:dashboard` candidate-aware so it can resolve candidate-scoped evidence under `artifacts/release-readiness/`
- add same-candidate evidence handling plus normalized blocker/warning drill-down in the JSON and Markdown outputs
- document the candidate-pair flow for CI and manual release review and extend the dashboard test coverage

## Validation
- npm run test:release-readiness-dashboard

Closes #688