### PR TITLE
feat(product): wire battle report center contract into Cocos lobby

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ npm run dev:client:h5
 
 运行后会生成 `.coverage/summary.md` 和 `.coverage/summary.json`。如果任一 scope 的任一 metric 低于 floor，摘要顶部会明确列出失败的 scope 和具体阈值差距，方便直接对照 CI 失败原因。
 - 战斗回放读模型当前已补上两块更适合前端直接消费的能力：`GET /api/player-accounts/:playerId/battle-replays` 现支持 `limit` + `offset` 分页，shared 侧也新增了可从 `initialState + steps` 推导每步回合与伤害/减员结算的 replay timeline helper，H5 战报面板会直接显示这些逐步结算摘要。
+- 战报中心现在也有独立读模型入口：`GET /api/player-accounts/:playerId/battle-reports` / `GET /api/player-accounts/me/battle-reports` 会按与 replay 相同的筛选条件返回 `latestReportId + items[]`，把结果、奖励摘要、关键参与者、时间与证据可用性收敛成前端可直接消费的 contract。
 - Cocos Lobby 现已复用这套 timeline helper：账号资料回顾的“战报”卡片可直接点击进入战报时间线面板，会按行动阵营/单位、动作类型和主要结算概览显示最近 6 条步骤，并在没有战斗或回放缺失时回退提示。
 - H5 账号资料卡现在会额外拉取 `/api/player-accounts/:playerId/progression` 覆盖成就/事件摘要，因此即使基础账号接口只返回轻量档案，前端也能稳定展示最新的成就推进、最近解锁和世界事件日志，而不会继续依赖旧的内嵌快照。
 - H5 账号资料卡的成就/事件展示本轮也补了一层可读性整理：成就卡会把“已解锁”和“最近推进”的项目排到前面，并显示最近推进时间；世界事件日志则会把 `battle.started`、`first_battle` 这类内部 ID 转成中文标签，同时在摘要里补充各事件类别计数，方便后续继续接提示面板或筛选器。

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -6,6 +6,7 @@ import {
   writeStoredCocosAuthSession
 } from "./cocos-session-launch.ts";
 import {
+  normalizePlayerBattleReportCenter,
   normalizePlayerBattleReplaySummaries,
   normalizePlayerAccountReadModel,
   normalizeEventLogEntries,
@@ -15,6 +16,8 @@ import {
   type EventLogEntry,
   type EventLogQuery,
   type PlayerAccountReadModel,
+  type PlayerBattleReportCenter,
+  type PlayerBattleReportSummary,
   type PlayerProgressionSnapshot,
   type PlayerBattleReplayQuery,
   type PlayerBattleReplaySummary,
@@ -100,6 +103,10 @@ interface LobbyRoomsApiPayload {
 
 interface PlayerBattleReplayListApiPayload {
   items?: Partial<PlayerBattleReplaySummary>[];
+}
+
+interface PlayerBattleReportCenterApiPayload extends Partial<PlayerBattleReportCenter> {
+  items?: Partial<PlayerBattleReportSummary>[];
 }
 
 interface PlayerBattleReplayHistoryApiPayload extends PlayerBattleReplayListApiPayload {
@@ -365,7 +372,8 @@ function asCocosPlayerAccountProfile(
   roomId: string,
   source: CocosPlayerAccountProfile["source"],
   account?: PlayerAccountApiPayload["account"],
-  fallbackDisplayName?: string | null
+  fallbackDisplayName?: string | null,
+  battleReportCenter?: PlayerBattleReportCenter
 ): CocosPlayerAccountProfile {
   const accountProfile = normalizePlayerAccountReadModel({
     playerId,
@@ -375,6 +383,7 @@ function asCocosPlayerAccountProfile(
     achievements: account?.achievements,
     recentEventLog: account?.recentEventLog,
     recentBattleReplays: account?.recentBattleReplays,
+    ...(battleReportCenter ? { battleReportCenter } : {}),
     loginId: normalizeLoginId(account?.loginId),
     credentialBoundAt: account?.credentialBoundAt,
     lastRoomId: account?.lastRoomId ?? roomId,
@@ -427,6 +436,48 @@ export async function loadCocosBattleReplaySummaries(
       throw error;
     }
     return normalizePlayerBattleReplaySummaries();
+  }
+}
+
+async function loadCocosBattleReportCenter(
+  remoteUrl: string,
+  playerId: string,
+  query?: PlayerBattleReplayQuery,
+  options?: {
+    fetchImpl?: FetchLike;
+    authSession?: CocosStoredAuthSession | null;
+    storage?: Pick<Storage, "removeItem"> | null;
+    throwOnError?: boolean;
+  }
+): Promise<PlayerBattleReportCenter> {
+  const authSession = options?.authSession ?? null;
+  const queryString = toBattleReplayQueryString(query);
+  const endpoint = authSession?.token
+    ? `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/battle-reports${queryString}`
+    : `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/${encodeURIComponent(playerId)}/battle-reports${queryString}`;
+
+  try {
+    const payload = (await fetchCocosAuthJson(
+      remoteUrl,
+      endpoint,
+      {
+        ...(authSession?.token ? { headers: buildCocosAuthHeaders(authSession.token) } : {})
+      },
+      authSession,
+      {
+        ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        ...(options ? { storage: options.storage ?? null } : {})
+      }
+    )) as PlayerBattleReportCenterApiPayload;
+    return normalizePlayerBattleReportCenter(payload, query ? { query } : undefined);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && options?.storage) {
+      clearStoredCocosAuthSession(options.storage);
+    }
+    if (options?.throwOnError) {
+      throw error;
+    }
+    return normalizePlayerBattleReportCenter(undefined, query ? { query } : undefined);
   }
 }
 
@@ -1219,18 +1270,26 @@ export async function loadCocosPlayerAccountProfile(
       }
     )) as PlayerAccountApiPayload;
     const resolvedPlayerId = payload.account?.playerId?.trim() || authSession?.playerId || playerId;
+    const [recentBattleReplays, battleReportCenter] = await Promise.all([
+      loadCocosBattleReplaySummaries(remoteUrl, resolvedPlayerId, undefined, {
+        ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        authSession: authSession ?? null,
+        storage
+      }),
+      loadCocosBattleReportCenter(remoteUrl, resolvedPlayerId, undefined, {
+        ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        authSession: authSession ?? null,
+        storage
+      })
+    ]);
     const profile = asCocosPlayerAccountProfile(
       resolvedPlayerId,
       roomId,
       "remote",
       payload.account,
-      storedDisplayName
+      storedDisplayName,
+      battleReportCenter
     );
-    const recentBattleReplays = await loadCocosBattleReplaySummaries(remoteUrl, resolvedPlayerId, undefined, {
-      ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
-      authSession: authSession ?? null,
-      storage
-    });
 
     if (storage?.setItem) {
       storage.setItem(getCocosPlayerAccountStorageKey(profile.playerId), profile.displayName);

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -619,6 +619,43 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         );
       }
 
+      if (url.endsWith("/api/player-accounts/me/battle-reports")) {
+        return new Response(
+          JSON.stringify({
+            latestReportId: "room-beta:battle-1:account-player",
+            items: [
+              {
+                id: "room-beta:battle-1:account-player",
+                replayId: "room-beta:battle-1:account-player",
+                roomId: "room-beta",
+                playerId: "account-player",
+                battleId: "battle-1",
+                battleKind: "neutral",
+                playerCamp: "attacker",
+                heroId: "hero-1",
+                neutralArmyId: "neutral-1",
+                startedAt: "2026-03-25T12:58:00.000Z",
+                completedAt: "2026-03-25T13:00:00.000Z",
+                result: "victory",
+                turnCount: 1,
+                actionCount: 0,
+                rewards: [],
+                evidence: {
+                  replay: "available",
+                  rewards: "missing"
+                }
+              }
+            ]
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json"
+            }
+          }
+        );
+      }
+
       return new Response(
         JSON.stringify({
           items: [
@@ -679,7 +716,8 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
 
   assert.deepEqual(requestedUrls, [
     "http://127.0.0.1:2567/api/player-accounts/me",
-    "http://127.0.0.1:2567/api/player-accounts/me/battle-replays"
+    "http://127.0.0.1:2567/api/player-accounts/me/battle-replays",
+    "http://127.0.0.1:2567/api/player-accounts/me/battle-reports"
   ]);
   assert.deepEqual(profile, {
     playerId: "account-player",
@@ -798,6 +836,32 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         result: "attacker_victory"
       }
     ],
+    battleReportCenter: {
+      latestReportId: "room-beta:battle-1:account-player",
+      items: [
+        {
+          id: "room-beta:battle-1:account-player",
+          replayId: "room-beta:battle-1:account-player",
+          roomId: "room-beta",
+          playerId: "account-player",
+          battleId: "battle-1",
+          battleKind: "neutral",
+          playerCamp: "attacker",
+          heroId: "hero-1",
+          neutralArmyId: "neutral-1",
+          startedAt: "2026-03-25T12:58:00.000Z",
+          completedAt: "2026-03-25T13:00:00.000Z",
+          result: "victory",
+          turnCount: 1,
+          actionCount: 0,
+          rewards: [],
+          evidence: {
+            replay: "available",
+            rewards: "missing"
+          }
+        }
+      ]
+    },
     source: "remote"
   });
   assert.ok(values.get("project-veil:auth-session")?.includes("\"loginId\":\"veil-ranger\""));

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -24,6 +24,7 @@ import {
   createDefaultHeroProgression,
   queryEventLogEntries,
   type PlayerAchievementProgress,
+  type PlayerBattleReportCenter,
   type PlayerProgressionSnapshot,
   type PlayerBattleReplaySummary,
   type WorldState
@@ -865,6 +866,87 @@ test("player account battle replay routes filter replay summaries by battle meta
   const mePayload = (await meResponse.json()) as { items: PlayerBattleReplaySummary[] };
   assert.equal(meResponse.status, 200);
   assert.deepEqual(mePayload.items.map((replay) => replay.id), ["replay-hero-loss"]);
+});
+
+test("player account battle report routes expose normalized report summaries with replay filters", async (t) => {
+  const port = 42045 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "player-report",
+    displayName: "回响书记",
+    globalResources: { gold: 75, wood: 4, ore: 2 },
+    achievements: [],
+    recentEventLog: [
+      {
+        id: "event-report-reward",
+        timestamp: "2026-03-27T12:06:30.000Z",
+        roomId: "room-neutral",
+        playerId: "player-report",
+        category: "combat",
+        description: "hero-1 击退中立守军。",
+        heroId: "hero-1",
+        worldEventType: "battle.resolved",
+        rewards: [{ type: "experience", label: "经验", amount: 40 }]
+      }
+    ],
+    recentBattleReplays: [
+      createReplaySummary("replay-hero-loss", "2026-03-27T12:05:00.000Z", {
+        playerId: "player-report",
+        roomId: "room-hero",
+        battleId: "battle-hero-loss",
+        battleKind: "hero",
+        playerCamp: "defender",
+        heroId: "hero-3",
+        opponentHeroId: "hero-9",
+        result: "defender_victory"
+      }),
+      createReplaySummary("replay-neutral-win", "2026-03-27T12:06:00.000Z", {
+        playerId: "player-report",
+        roomId: "room-neutral",
+        battleId: "battle-neutral-win",
+        battleKind: "neutral",
+        heroId: "hero-1",
+        neutralArmyId: "neutral-1",
+        opponentHeroId: undefined,
+        result: "attacker_victory"
+      })
+    ],
+    lastRoomId: "room-neutral",
+    lastSeenAt: new Date("2026-03-27T12:06:30.000Z").toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "player-report",
+    displayName: "回响书记"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const publicResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/player-report/battle-reports?battleKind=neutral&heroId=hero-1&neutralArmyId=neutral-1`
+  );
+  const publicPayload = (await publicResponse.json()) as PlayerBattleReportCenter;
+  assert.equal(publicResponse.status, 200);
+  assert.equal(publicPayload.latestReportId, "replay-neutral-win");
+  assert.equal(publicPayload.items[0]?.result, "victory");
+  assert.deepEqual(publicPayload.items[0]?.rewards, [{ type: "experience", label: "经验", amount: 40 }]);
+  assert.equal(publicPayload.items[0]?.evidence.replay, "available");
+  assert.equal(publicPayload.items[0]?.evidence.rewards, "available");
+
+  const meResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/battle-reports?roomId=room-hero&battleId=battle-hero-loss&playerCamp=defender&result=defender_victory&opponentHeroId=hero-9`,
+    {
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const mePayload = (await meResponse.json()) as PlayerBattleReportCenter;
+  assert.equal(meResponse.status, 200);
+  assert.deepEqual(mePayload.items.map((report) => report.id), ["replay-hero-loss"]);
+  assert.equal(mePayload.items[0]?.result, "victory");
 });
 
 test("player account me battle replay route resolves the current authenticated account", async (t) => {


### PR DESCRIPTION
## Summary
- load the dedicated `/battle-reports` contract when Cocos account profiles hydrate so the replay center uses the server-shaped battle report payload instead of only replay summaries
- add server coverage for `/api/player-accounts/:playerId/battle-reports` and `/api/player-accounts/me/battle-reports`, including filtering and reward evidence assertions
- document the battle report center read model in the README

## Validation
- `node --import tsx --test ./apps/server/test/player-account-routes.test.ts ./apps/cocos-client/test/cocos-lobby.test.ts`

Closes #684