### PR TITLE
feat(release): bundle Phase 1 candidate release dossiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ npm run dev:client:h5
 - 统一发布门禁汇总：`npm run release:gate:summary`
 - Candidate-level reconnect soak：`npm run release:reconnect-soak -- --candidate <candidate-name> --candidate-revision <git-sha>`（输出 candidate+revision 命名的 reconnect soak JSON / Markdown，并供 release gate / dossier 直接引用）
 - 发布健康度聚合摘要：`npm run release:health:summary`
-- Phase 1 candidate dossier + single exit evidence gate：`npm run release:phase1:candidate-dossier -- --candidate <candidate-name> --candidate-revision <git-sha> [--server-url http://127.0.0.1:2567]`
+- Phase 1 candidate dossier + single exit evidence gate：`npm run release:phase1:candidate-dossier -- --candidate <candidate-name> --candidate-revision <git-sha> [--server-url http://127.0.0.1:2567] [--output-dir artifacts/release-dossiers/<candidate>-<git-sha>]`
 - 打包 H5 客户端 RC 冒烟：`npm run smoke:client:release-candidate`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - 微信小游戏发布包产出：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`

--- a/docs/phase1-candidate-dossier.md
+++ b/docs/phase1-candidate-dossier.md
@@ -54,12 +54,27 @@ npm run release:phase1:candidate-dossier -- \
   --markdown-output artifacts/release-readiness/phase1-candidate-dossier.md
 ```
 
+Write the dossier bundle into one stable candidate directory:
+
+```bash
+npm run release:phase1:candidate-dossier -- \
+  --candidate phase1-wechat-rc \
+  --candidate-revision abc1234 \
+  --output-dir artifacts/release-dossiers/phase1-wechat-rc-abc1234
+```
+
 ## Default Outputs
 
-If you do not pass output flags, the script writes:
+If you do not pass output flags, the script writes one stable candidate bundle directory:
 
-- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>.json`
-- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>.md`
+- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/phase1-candidate-dossier.json`
+- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/phase1-candidate-dossier.md`
+- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/release-gate-summary.json`
+- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/release-gate-summary.md`
+- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/release-health-summary.json`
+- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/release-health-summary.md`
+
+If you pass `--output-dir`, the same file names are written into that directory instead.
 
 ## Output Contract
 
@@ -68,6 +83,7 @@ The dossier surfaces:
 - generated timestamp plus candidate branch/dirty metadata
 - one candidate revision and target surface
 - one `Selected Inputs` block so reviewers can see the exact artifact paths and runtime URL that were used
+- one `Generated Bundle` block so PR/release巡检 reviewers can stay inside the dossier directory
 - one `phase1ExitEvidenceGate` result with blocking/pending/accepted-risk section lists
 - `requiredFailed`
 - `requiredPending`

--- a/scripts/phase1-candidate-dossier.ts
+++ b/scripts/phase1-candidate-dossier.ts
@@ -4,8 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-import { buildReleaseGateSummaryReport } from "./release-gate-summary.ts";
-import { buildReleaseHealthSummaryReport } from "./release-health-summary.ts";
+import { buildReleaseGateSummaryReport, renderMarkdown as renderReleaseGateMarkdown } from "./release-gate-summary.ts";
+import { buildReleaseHealthSummaryReport, renderMarkdown as renderReleaseHealthMarkdown } from "./release-health-summary.ts";
 
 type TargetSurface = "h5" | "wechat";
 type EvidenceFreshness = "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp" | "unknown";
@@ -29,6 +29,7 @@ interface Args {
   coverageSummaryPath?: string;
   configCenterLibraryPath?: string;
   targetSurface: TargetSurface;
+  outputDir?: string;
   outputPath?: string;
   markdownOutputPath?: string;
   maxEvidenceAgeHours: number;
@@ -368,6 +369,15 @@ interface Phase1CandidateDossier {
     coverageSummaryPath?: string;
     configCenterLibraryPath?: string;
   };
+  artifacts?: {
+    outputDir: string;
+    dossierJsonPath: string;
+    dossierMarkdownPath: string;
+    releaseGateSummaryPath: string;
+    releaseGateMarkdownPath: string;
+    releaseHealthSummaryPath: string;
+    releaseHealthMarkdownPath: string;
+  };
   sections: DossierSection[];
   acceptedRisks: DossierAcceptedRisk[];
 }
@@ -406,6 +416,7 @@ function parseArgs(argv: string[]): Args {
   let coverageSummaryPath: string | undefined;
   let configCenterLibraryPath: string | undefined;
   let targetSurface: TargetSurface = "wechat";
+  let outputDir: string | undefined;
   let outputPath: string | undefined;
   let markdownOutputPath: string | undefined;
   let maxEvidenceAgeHours = 72;
@@ -502,6 +513,11 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--output-dir" && next) {
+      outputDir = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--output" && next) {
       outputPath = next;
       index += 1;
@@ -543,6 +559,7 @@ function parseArgs(argv: string[]): Args {
     ...(coverageSummaryPath ? { coverageSummaryPath } : {}),
     ...(configCenterLibraryPath ? { configCenterLibraryPath } : {}),
     targetSurface,
+    ...(outputDir ? { outputDir } : {}),
     ...(outputPath ? { outputPath } : {}),
     ...(markdownOutputPath ? { markdownOutputPath } : {}),
     maxEvidenceAgeHours
@@ -1572,6 +1589,82 @@ function buildOverallStatus(requiredFailed: string[], requiredPending: string[],
   return "passed";
 }
 
+function replaceSectionArtifactPath(sections: DossierSection[], id: DossierSection["id"], artifactPath: string): DossierSection[] {
+  return sections.map((section) => (section.id === id ? { ...section, artifactPath } : section));
+}
+
+function replaceSectionEvidence(
+  sections: DossierSection[],
+  id: DossierSection["id"],
+  evidence: DossierEvidenceRef[]
+): DossierSection[] {
+  return sections.map((section) => (section.id === id ? { ...section, evidence } : section));
+}
+
+function buildSupportingReports(
+  inputs: Phase1CandidateDossier["inputs"],
+  args: Args,
+  revision: GitRevision
+): {
+  gateReport: ReturnType<typeof buildReleaseGateSummaryReport>;
+  healthReport: ReturnType<typeof buildReleaseHealthSummaryReport>;
+} {
+  const gateReport = buildReleaseGateSummaryReport(
+    {
+      ...(inputs.snapshotPath ? { snapshotPath: inputs.snapshotPath } : {}),
+      ...(inputs.h5SmokePath ? { h5SmokePath: inputs.h5SmokePath } : {}),
+      ...(inputs.reconnectSoakPath ? { reconnectSoakPath: inputs.reconnectSoakPath } : {}),
+      ...(inputs.wechatArtifactsDir ? { wechatArtifactsDir: inputs.wechatArtifactsDir } : {}),
+      ...(inputs.wechatCandidateSummaryPath ? { wechatCandidateSummaryPath: inputs.wechatCandidateSummaryPath } : {}),
+      ...(inputs.wechatRcValidationPath ? { wechatRcValidationPath: inputs.wechatRcValidationPath } : {}),
+      ...(inputs.wechatSmokeReportPath ? { wechatSmokeReportPath: inputs.wechatSmokeReportPath } : {}),
+      ...(inputs.configCenterLibraryPath ? { configCenterLibraryPath: inputs.configCenterLibraryPath } : {}),
+      targetSurface: args.targetSurface
+    },
+    revision
+  );
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-phase1-dossier-"));
+  const tempGatePath = path.join(tempDir, "release-gate-summary.json");
+  writeJsonFile(tempGatePath, gateReport);
+
+  const healthReport = buildReleaseHealthSummaryReport(
+    {
+      ...(inputs.snapshotPath ? { releaseReadinessPath: inputs.snapshotPath } : {}),
+      releaseGateSummaryPath: tempGatePath,
+      ...(inputs.ciTrendSummaryPath ? { ciTrendSummaryPath: inputs.ciTrendSummaryPath } : {}),
+      ...(inputs.coverageSummaryPath ? { coverageSummaryPath: inputs.coverageSummaryPath } : {}),
+      ...(inputs.syncGovernancePath ? { syncGovernancePath: inputs.syncGovernancePath } : {})
+    },
+    revision
+  );
+
+  return {
+    gateReport,
+    healthReport
+  };
+}
+
+function resolveBundlePaths(args: Args, dossier: Phase1CandidateDossier): Phase1CandidateDossier["artifacts"] {
+  const defaultOutputDir = path.resolve(
+    DEFAULT_RELEASE_READINESS_DIR,
+    `phase1-candidate-dossier-${slugify(dossier.candidate.name)}-${dossier.candidate.shortRevision}`
+  );
+  const outputDir = path.resolve(args.outputDir ?? defaultOutputDir);
+  const dossierJsonPath = path.resolve(args.outputPath ?? path.join(outputDir, "phase1-candidate-dossier.json"));
+  const dossierMarkdownPath = path.resolve(args.markdownOutputPath ?? path.join(outputDir, "phase1-candidate-dossier.md"));
+  const bundleDir = path.dirname(dossierJsonPath);
+  return {
+    outputDir: bundleDir,
+    dossierJsonPath,
+    dossierMarkdownPath,
+    releaseGateSummaryPath: path.join(bundleDir, "release-gate-summary.json"),
+    releaseGateMarkdownPath: path.join(bundleDir, "release-gate-summary.md"),
+    releaseHealthSummaryPath: path.join(bundleDir, "release-health-summary.json"),
+    releaseHealthMarkdownPath: path.join(bundleDir, "release-health-summary.md")
+  };
+}
+
 function buildPhase1ExitEvidenceGateSection(sections: DossierSection[], generatedAt: string | undefined): {
   section: DossierSection;
   gate: Phase1ExitEvidenceGate;
@@ -1662,6 +1755,17 @@ export function renderMarkdown(dossier: Phase1CandidateDossier): string {
   lines.push(`- CI trend summary: \`${dossier.inputs.ciTrendSummaryPath ? relativeArtifactPath(dossier.inputs.ciTrendSummaryPath) : "<missing>"}\``);
   lines.push(`- Coverage summary: \`${dossier.inputs.coverageSummaryPath ? relativeArtifactPath(dossier.inputs.coverageSummaryPath) : "<missing>"}\``);
   lines.push(`- Config audit: \`${dossier.inputs.configCenterLibraryPath ? relativeArtifactPath(dossier.inputs.configCenterLibraryPath) : "<missing>"}\``, "");
+
+  if (dossier.artifacts) {
+    lines.push("## Generated Bundle", "");
+    lines.push(`- Output dir: \`${relativeArtifactPath(dossier.artifacts.outputDir)}\``);
+    lines.push(`- Dossier JSON: \`${relativeArtifactPath(dossier.artifacts.dossierJsonPath)}\``);
+    lines.push(`- Dossier Markdown: \`${relativeArtifactPath(dossier.artifacts.dossierMarkdownPath)}\``);
+    lines.push(`- Release gate summary JSON: \`${relativeArtifactPath(dossier.artifacts.releaseGateSummaryPath)}\``);
+    lines.push(`- Release gate summary Markdown: \`${relativeArtifactPath(dossier.artifacts.releaseGateMarkdownPath)}\``);
+    lines.push(`- Release health summary JSON: \`${relativeArtifactPath(dossier.artifacts.releaseHealthSummaryPath)}\``);
+    lines.push(`- Release health summary Markdown: \`${relativeArtifactPath(dossier.artifacts.releaseHealthMarkdownPath)}\``, "");
+  }
 
   lines.push("## Phase 1 Exit Evidence Gate", "");
   lines.push(`- Result: \`${dossier.phase1ExitEvidenceGate.result}\``);
@@ -1777,35 +1881,7 @@ export async function buildPhase1CandidateDossier(args: Args): Promise<Phase1Can
   const reconnectSoakSection = buildReconnectSoakSection(inputs.reconnectSoakPath, revision.commit, maxAgeMs);
   const persistenceSection = buildPersistenceSection(inputs.persistencePath, revision.commit, maxAgeMs);
 
-  const gateReport = buildReleaseGateSummaryReport(
-    {
-      ...(inputs.snapshotPath ? { snapshotPath: inputs.snapshotPath } : {}),
-      ...(inputs.h5SmokePath ? { h5SmokePath: inputs.h5SmokePath } : {}),
-      ...(inputs.reconnectSoakPath ? { reconnectSoakPath: inputs.reconnectSoakPath } : {}),
-      ...(inputs.wechatArtifactsDir ? { wechatArtifactsDir: inputs.wechatArtifactsDir } : {}),
-      ...(inputs.wechatCandidateSummaryPath ? { wechatCandidateSummaryPath: inputs.wechatCandidateSummaryPath } : {}),
-      ...(inputs.wechatRcValidationPath ? { wechatRcValidationPath: inputs.wechatRcValidationPath } : {}),
-      ...(inputs.wechatSmokeReportPath ? { wechatSmokeReportPath: inputs.wechatSmokeReportPath } : {}),
-      ...(inputs.configCenterLibraryPath ? { configCenterLibraryPath: inputs.configCenterLibraryPath } : {}),
-      targetSurface: args.targetSurface
-    },
-    revision
-  );
-
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-phase1-dossier-"));
-  const tempGatePath = path.join(tempDir, "release-gate-summary.json");
-  writeJsonFile(tempGatePath, gateReport);
-
-  const healthReport = buildReleaseHealthSummaryReport(
-    {
-      ...(inputs.snapshotPath ? { releaseReadinessPath: inputs.snapshotPath } : {}),
-      releaseGateSummaryPath: tempGatePath,
-      ...(inputs.ciTrendSummaryPath ? { ciTrendSummaryPath: inputs.ciTrendSummaryPath } : {}),
-      ...(inputs.coverageSummaryPath ? { coverageSummaryPath: inputs.coverageSummaryPath } : {}),
-      ...(inputs.syncGovernancePath ? { syncGovernancePath: inputs.syncGovernancePath } : {})
-    },
-    revision
-  );
+  const { gateReport, healthReport } = buildSupportingReports(inputs, args, revision);
 
   const releaseGateSection = buildDerivedSection(
     "release-gate",
@@ -1901,17 +1977,73 @@ export async function buildPhase1CandidateDossier(args: Args): Promise<Phase1Can
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
-  const dossier = await buildPhase1CandidateDossier(args);
+  const revision = getRevision(args.candidateRevision);
+  const inputs = resolveInputPaths(args);
+  const { gateReport, healthReport } = buildSupportingReports(inputs, args, revision);
+  let dossier = await buildPhase1CandidateDossier(args);
+  const artifacts = resolveBundlePaths(args, dossier);
 
-  const outputBaseName = `phase1-candidate-dossier-${slugify(dossier.candidate.name)}-${dossier.candidate.shortRevision}`;
-  const outputPath = path.resolve(args.outputPath ?? path.join(DEFAULT_RELEASE_READINESS_DIR, `${outputBaseName}.json`));
-  const markdownOutputPath = path.resolve(args.markdownOutputPath ?? path.join(DEFAULT_RELEASE_READINESS_DIR, `${outputBaseName}.md`));
+  writeJsonFile(artifacts.releaseGateSummaryPath, gateReport);
+  writeFile(artifacts.releaseGateMarkdownPath, renderReleaseGateMarkdown(gateReport));
+  writeJsonFile(artifacts.releaseHealthSummaryPath, healthReport);
+  writeFile(artifacts.releaseHealthMarkdownPath, renderReleaseHealthMarkdown(healthReport));
 
-  writeJsonFile(outputPath, dossier);
-  writeFile(markdownOutputPath, renderMarkdown(dossier));
+  dossier = {
+    ...dossier,
+    artifacts,
+    sections: replaceSectionEvidence(
+      replaceSectionEvidence(
+        replaceSectionArtifactPath(
+          replaceSectionArtifactPath(dossier.sections, "release-gate", artifacts.releaseGateSummaryPath),
+          "release-health",
+          artifacts.releaseHealthSummaryPath
+        ),
+        "release-gate",
+        [
+          {
+            label: "Release gate summary",
+            path: artifacts.releaseGateSummaryPath,
+            summary: `status=${gateReport.summary.status}`,
+            observedAt: gateReport.generatedAt,
+            freshness: evaluateFreshness(gateReport.generatedAt, 1000 * 60 * 60 * 72)
+          },
+          {
+            label: "Release gate summary markdown",
+            path: artifacts.releaseGateMarkdownPath,
+            summary: "Reviewer-facing release gate summary markdown.",
+            observedAt: gateReport.generatedAt,
+            freshness: evaluateFreshness(gateReport.generatedAt, 1000 * 60 * 60 * 72)
+          }
+        ]
+      ),
+      "release-health",
+      [
+        {
+          label: "Release health summary",
+          path: artifacts.releaseHealthSummaryPath,
+          summary: `status=${healthReport.summary.status}`,
+          observedAt: healthReport.generatedAt,
+          freshness: evaluateFreshness(healthReport.generatedAt, 1000 * 60 * 60 * 72)
+        },
+        {
+          label: "Release health summary markdown",
+          path: artifacts.releaseHealthMarkdownPath,
+          summary: "Reviewer-facing release health summary markdown.",
+          observedAt: healthReport.generatedAt,
+          freshness: evaluateFreshness(healthReport.generatedAt, 1000 * 60 * 60 * 72)
+        }
+      ]
+    )
+  };
 
-  console.log(`Wrote Phase 1 candidate dossier JSON: ${path.relative(process.cwd(), outputPath).replace(/\\/g, "/")}`);
-  console.log(`Wrote Phase 1 candidate dossier Markdown: ${path.relative(process.cwd(), markdownOutputPath).replace(/\\/g, "/")}`);
+  writeJsonFile(artifacts.dossierJsonPath, dossier);
+  writeFile(artifacts.dossierMarkdownPath, renderMarkdown(dossier));
+
+  console.log(`Wrote Phase 1 candidate dossier bundle: ${path.relative(process.cwd(), artifacts.outputDir).replace(/\\/g, "/")}`);
+  console.log(`Wrote Phase 1 candidate dossier JSON: ${path.relative(process.cwd(), artifacts.dossierJsonPath).replace(/\\/g, "/")}`);
+  console.log(`Wrote Phase 1 candidate dossier Markdown: ${path.relative(process.cwd(), artifacts.dossierMarkdownPath).replace(/\\/g, "/")}`);
+  console.log(`Wrote release gate summary JSON: ${path.relative(process.cwd(), artifacts.releaseGateSummaryPath).replace(/\\/g, "/")}`);
+  console.log(`Wrote release health summary JSON: ${path.relative(process.cwd(), artifacts.releaseHealthSummaryPath).replace(/\\/g, "/")}`);
   console.log(`Candidate: ${dossier.candidate.name}`);
   console.log(`Revision: ${dossier.candidate.revision}`);
   console.log(`Overall status: ${dossier.summary.status}`);

--- a/scripts/test/phase1-candidate-dossier.test.ts
+++ b/scripts/test/phase1-candidate-dossier.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
@@ -539,4 +540,188 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
       });
     });
   }
+});
+
+test("phase1 candidate dossier CLI writes a stable candidate bundle directory with supporting summaries", () => {
+  const workspace = createTempWorkspace();
+  const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
+  const revision = "abc1234";
+  const outputDir = path.join(workspace, "artifacts", "release-dossiers", "phase1-rc-abc1234");
+  const repoRoot = path.resolve(process.cwd());
+
+  const snapshotPath = path.join(artifactsDir, "release-readiness-pass.json");
+  const h5SmokePath = path.join(artifactsDir, "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(artifactsDir, "colyseus-reconnect-soak-summary-pass.json");
+  const cocosBundlePath = path.join(artifactsDir, "cocos-rc-evidence-bundle-pass.json");
+  const persistencePath = path.join(artifactsDir, `phase1-release-persistence-regression-${revision}.json`);
+  const syncGovernancePath = path.join(artifactsDir, "sync-governance-matrix-pass.json");
+  const ciTrendSummaryPath = path.join(artifactsDir, "ci-trend-summary.json");
+  const coverageSummaryPath = path.join(workspace, ".coverage", "summary.json");
+  const configCenterLibraryPath = path.join(workspace, "configs", ".config-center-library.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-04-02T08:30:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [{ id: "npm-test", required: true, status: "passed" }]
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: "2026-04-02T08:32:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    execution: { status: "passed", exitCode: 0 },
+    summary: { total: 2, passed: 2, failed: 0 }
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-04-02T08:33:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    status: "passed",
+    summary: { failedScenarios: 0, scenarioNames: ["reconnect_soak"] },
+    soakSummary: { reconnectAttempts: 64, invariantChecks: 256 },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
+  writeJson(cocosBundlePath, {
+    bundle: {
+      generatedAt: "2026-04-02T08:34:00.000Z",
+      candidate: "phase1-rc",
+      commit: revision,
+      shortCommit: revision,
+      overallStatus: "passed",
+      summary: "Cocos RC evidence is complete."
+    },
+    review: { phase1Gate: "passed" },
+    journey: [{ id: "lobby-entry", status: "passed" }],
+    requiredEvidence: [{ id: "roomId", label: "Room id recorded", filled: true }]
+  });
+  writeJson(persistencePath, {
+    generatedAt: "2026-04-02T08:41:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    summary: { status: "passed", assertionCount: 6 },
+    contentValidation: { valid: true, bundleCount: 5, summary: "All shipped content packs validated.", issueCount: 0 },
+    persistenceRegression: { mapPackId: "phase1", assertions: ["room hydration reapplied resources"] }
+  });
+  writeJson(syncGovernancePath, {
+    generatedAt: "2026-04-02T08:42:00.000Z",
+    execution: { status: "passed" },
+    summary: { passed: 2, failed: 0, skipped: 0 },
+    scenarios: [{ id: "room-push-redaction", status: "passed" }]
+  });
+  writeJson(ciTrendSummaryPath, {
+    generatedAt: "2026-04-02T08:43:00.000Z",
+    summary: {
+      overallStatus: "passed",
+      totalFindings: 0,
+      newFindings: 0,
+      ongoingFindings: 0,
+      recoveredFindings: 0
+    },
+    runtime: { findings: [] },
+    releaseGate: { findings: [] }
+  });
+  writeJson(coverageSummaryPath, [
+    {
+      scope: "shared",
+      lineThreshold: 90,
+      branchThreshold: 70,
+      functionThreshold: 90,
+      metrics: {
+        lines: 95,
+        branches: 80,
+        functions: 96
+      },
+      failures: []
+    }
+  ]);
+  writeJson(configCenterLibraryPath, {
+    publishAuditHistory: []
+  });
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      "./scripts/phase1-candidate-dossier.ts",
+      "--candidate",
+      "phase1-rc",
+      "--candidate-revision",
+      revision,
+      "--target-surface",
+      "h5",
+      "--snapshot",
+      snapshotPath,
+      "--h5-smoke",
+      h5SmokePath,
+      "--reconnect-soak",
+      reconnectSoakPath,
+      "--cocos-bundle",
+      cocosBundlePath,
+      "--phase1-persistence",
+      persistencePath,
+      "--sync-governance",
+      syncGovernancePath,
+      "--ci-trend-summary",
+      ciTrendSummaryPath,
+      "--coverage-summary",
+      coverageSummaryPath,
+      "--config-center-library",
+      configCenterLibraryPath,
+      "--output-dir",
+      outputDir
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Wrote Phase 1 candidate dossier bundle:/);
+
+  const dossierJsonPath = path.join(outputDir, "phase1-candidate-dossier.json");
+  const dossierMarkdownPath = path.join(outputDir, "phase1-candidate-dossier.md");
+  const releaseGateSummaryPath = path.join(outputDir, "release-gate-summary.json");
+  const releaseGateMarkdownPath = path.join(outputDir, "release-gate-summary.md");
+  const releaseHealthSummaryPath = path.join(outputDir, "release-health-summary.json");
+  const releaseHealthMarkdownPath = path.join(outputDir, "release-health-summary.md");
+
+  for (const filePath of [
+    dossierJsonPath,
+    dossierMarkdownPath,
+    releaseGateSummaryPath,
+    releaseGateMarkdownPath,
+    releaseHealthSummaryPath,
+    releaseHealthMarkdownPath
+  ]) {
+    assert.equal(fs.existsSync(filePath), true, `${filePath} should exist`);
+  }
+
+  const dossier = JSON.parse(fs.readFileSync(dossierJsonPath, "utf8")) as {
+    artifacts?: {
+      outputDir: string;
+      releaseGateSummaryPath: string;
+      releaseHealthSummaryPath: string;
+    };
+    sections: Array<{ id: string; artifactPath?: string }>;
+  };
+  assert.equal(dossier.artifacts?.outputDir, outputDir);
+  assert.equal(dossier.artifacts?.releaseGateSummaryPath, releaseGateSummaryPath);
+  assert.equal(dossier.artifacts?.releaseHealthSummaryPath, releaseHealthSummaryPath);
+  assert.equal(dossier.sections.find((section) => section.id === "release-gate")?.artifactPath, releaseGateSummaryPath);
+  assert.equal(dossier.sections.find((section) => section.id === "release-health")?.artifactPath, releaseHealthSummaryPath);
+
+  const markdown = fs.readFileSync(dossierMarkdownPath, "utf8");
+  assert.match(markdown, /## Generated Bundle/);
+  assert.match(markdown, /release-gate-summary\.json/);
+  assert.match(markdown, /release-health-summary\.json/);
 });


### PR DESCRIPTION
## Summary
- write Phase 1 candidate dossier outputs into a stable per-candidate bundle directory by default
- emit release-gate and release-health summary JSON/Markdown beside the dossier and link them from the dossier payload
- cover the new bundle contract with a focused CLI test and update the dossier docs

## Validation
- npm run test:phase1-candidate-dossier

Closes #695