### PR TITLE
feat(release): publish go/no-go packet into PR summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,16 +598,67 @@ jobs:
           # release-health-summary exits non-zero only for blocking conditions; warnings still publish artifacts/comments.
           npm run release:health:summary -- "${args[@]}"
 
+      - name: Build go/no-go decision packet artifact
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        run: |
+          candidate="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          candidate_slug="$(printf '%s' "${candidate}" | tr -cs '[:alnum:]._-' '-' | sed 's/^-*//; s/-*$//')"
+          short_sha="${GITHUB_SHA::7}"
+          dossier_dir="${RUNNER_TEMP}/release-readiness/phase1-candidate-dossier-${candidate_slug}-${short_sha}"
+
+          args=(
+            --candidate "${candidate}"
+            --candidate-revision "${GITHUB_SHA}"
+            --snapshot "${RUNNER_TEMP}/release-readiness/release-readiness-${GITHUB_SHA}.json"
+            --target-surface wechat
+            --output-dir "${dossier_dir}"
+          )
+          if [[ -f "${RUNNER_TEMP}/release-readiness/client-release-candidate-smoke-${GITHUB_SHA}.json" ]]; then
+            args+=(--h5-smoke "${RUNNER_TEMP}/release-readiness/client-release-candidate-smoke-${GITHUB_SHA}.json")
+          fi
+          if [[ -f "${RUNNER_TEMP}/runtime-regression/colyseus-reconnect-soak-summary-${GITHUB_SHA}.json" ]]; then
+            args+=(--reconnect-soak "${RUNNER_TEMP}/runtime-regression/colyseus-reconnect-soak-summary-${GITHUB_SHA}.json")
+          fi
+          if [[ -d "${RUNNER_TEMP}/wechat-release" ]]; then
+            args+=(--wechat-artifacts-dir "${RUNNER_TEMP}/wechat-release")
+          fi
+          if [[ -f "${RUNNER_TEMP}/release-readiness/ci-trend-summary-${GITHUB_SHA}.json" ]]; then
+            args+=(--ci-trend-summary "${RUNNER_TEMP}/release-readiness/ci-trend-summary-${GITHUB_SHA}.json")
+          fi
+          if [[ -f ".coverage/summary.json" ]]; then
+            args+=(--coverage-summary ".coverage/summary.json")
+          fi
+
+          npm run release:phase1:candidate-dossier -- "${args[@]}"
+          npm run release:go-no-go-packet -- \
+            --dossier "${dossier_dir}/phase1-candidate-dossier.json" \
+            --release-gate-summary "${RUNNER_TEMP}/release-readiness/release-gate-summary-${GITHUB_SHA}.json" \
+            --output "${RUNNER_TEMP}/release-readiness/go-no-go-decision-packet-${candidate_slug}-${short_sha}.json" \
+            --markdown-output "${RUNNER_TEMP}/release-readiness/go-no-go-decision-packet-${candidate_slug}-${short_sha}.md"
+
       - name: Build PR release summary comment
         if: |
           always() &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         run: |
+          candidate="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          candidate_slug="$(printf '%s' "${candidate}" | tr -cs '[:alnum:]._-' '-' | sed 's/^-*//; s/-*$//')"
+          short_sha="${GITHUB_SHA::7}"
+          packet_args=()
+          if [[ -f "${RUNNER_TEMP}/release-readiness/go-no-go-decision-packet-${candidate_slug}-${short_sha}.json" ]]; then
+            packet_args+=(--go-no-go-packet "${RUNNER_TEMP}/release-readiness/go-no-go-decision-packet-${candidate_slug}-${short_sha}.json")
+          fi
+
           node --import tsx ./scripts/release-pr-comment.ts \
             --release-gate-summary "${RUNNER_TEMP}/release-readiness/release-gate-summary-${GITHUB_SHA}.json" \
             --release-health-summary "${RUNNER_TEMP}/release-readiness/release-health-summary-${GITHUB_SHA}.json" \
             --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            "${packet_args[@]}" \
             --output "${RUNNER_TEMP}/release-readiness/release-pr-comment-${GITHUB_SHA}.md"
 
       - name: Comment PR with release summary

--- a/docs/release-go-no-go-decision-packet.md
+++ b/docs/release-go-no-go-decision-packet.md
@@ -13,6 +13,8 @@ Use it after the lower-level evidence has already been generated. This command d
 
 Use the packet when the release owner, QA owner, or operator needs one final decision attachment instead of reading those artifacts separately.
 
+Use the PR-visible summary when reviewers only need the verdict, counts, and artifact pointers in the pull request itself. Use the full packet artifact when release operators need the complete blocker, warning, and manual-review drill-down.
+
 ## What It Emits
 
 The command writes both of these under `artifacts/release-readiness/`:
@@ -75,6 +77,8 @@ Those errors are intentional. The packet is the last-mile reviewer artifact, so 
 2. Build the candidate dossier and release gate summary for that same revision.
 3. Refresh the WeChat candidate summary and manual-review metadata when the target surface is `wechat`.
 4. Run `npm run release:go-no-go-packet`.
-5. Attach the Markdown packet to the release PR, handoff note, or operator checklist.
+5. Run `npm run release:pr-summary -- --release-gate-summary <path> --release-health-summary <path> --go-no-go-packet <path>` to render the concise PR-visible summary markdown when you need to preview the exact reviewer digest locally.
+6. In CI pull-request runs, the `Build go/no-go decision packet artifact` plus `Comment PR with release summary` steps publish or update the single bot comment in place, so reruns refresh the same PR-visible summary instead of creating duplicates.
+7. Attach or inspect the Markdown packet itself when the release owner needs the full operator record.
 
 If the packet still shows blocker items, clear those upstream artifacts first and regenerate the packet instead of editing the packet by hand.

--- a/docs/release-health-summary.md
+++ b/docs/release-health-summary.md
@@ -41,6 +41,7 @@ In CI, the `Release health gate` check runs `npm run release:health:summary` aft
 
 - `blocking` summary status fails the PR check.
 - `warning` and `healthy` summary statuses keep the check green, while still publishing the JSON/Markdown summary and the PR comment.
+- When the go/no-go packet is available for the same revision, the PR comment also includes a concise verdict section with blocker/warning counts plus links or paths back to the full packet and its key evidence inputs.
 
 That keeps the existing summary/comment flow usable without turning warning-only noise into a merge blocker.
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "release:readiness:dashboard": "node --import tsx ./scripts/release-readiness-dashboard.ts",
     "release:gate:summary": "node --import tsx ./scripts/release-gate-summary.ts",
     "release:go-no-go-packet": "node --import tsx ./scripts/release-go-no-go-decision-packet.ts",
+    "release:pr-summary": "node --import tsx ./scripts/release-pr-comment.ts",
     "release:reconnect-soak": "node --import tsx ./scripts/release-candidate-reconnect-soak.ts",
     "release:same-candidate:evidence-audit": "node --import tsx ./scripts/same-candidate-evidence-audit.ts",
     "release:health:summary": "node --import tsx ./scripts/release-health-summary.ts",

--- a/scripts/release-pr-comment.ts
+++ b/scripts/release-pr-comment.ts
@@ -12,6 +12,7 @@ import {
 interface Args {
   releaseGateSummaryPath?: string;
   releaseHealthSummaryPath?: string;
+  goNoGoPacketPath?: string;
   outputPath?: string;
   runUrl?: string;
 }
@@ -81,6 +82,46 @@ interface ReleaseHealthSummaryReport {
   };
 }
 
+interface GoNoGoDecisionPacket {
+  generatedAt: string;
+  decision: {
+    status: "go" | "no_go";
+    summary: string;
+  };
+  candidate: {
+    name: string;
+    revision: string;
+    shortRevision: string;
+    branch: string;
+    targetSurface: "h5" | "wechat";
+  };
+  inputs: {
+    dossierPath: string;
+    releaseGateSummaryPath: string;
+    wechatCandidateSummaryPath?: string;
+  };
+  sections: {
+    blockerSummary: {
+      blockers: Array<{
+        title: string;
+        summary: string;
+        artifactPath?: string;
+        nextStep?: string;
+      }>;
+      warnings: Array<{
+        title: string;
+        summary: string;
+        artifactPath?: string;
+      }>;
+    };
+    unresolvedManualChecks: Array<{
+      title: string;
+      status: "passed" | "failed" | "pending" | "not_applicable";
+      artifactPath?: string;
+    }>;
+  };
+}
+
 const COMMENT_MARKER = "<!-- project-veil-release-summary -->";
 
 function fail(message: string): never {
@@ -90,6 +131,7 @@ function fail(message: string): never {
 function parseArgs(argv: string[]): Args {
   let releaseGateSummaryPath: string | undefined;
   let releaseHealthSummaryPath: string | undefined;
+  let goNoGoPacketPath: string | undefined;
   let outputPath: string | undefined;
   let runUrl: string | undefined;
 
@@ -104,6 +146,11 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--release-health-summary" && next) {
       releaseHealthSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--go-no-go-packet" && next) {
+      goNoGoPacketPath = next;
       index += 1;
       continue;
     }
@@ -124,6 +171,7 @@ function parseArgs(argv: string[]): Args {
   return {
     ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
     ...(releaseHealthSummaryPath ? { releaseHealthSummaryPath } : {}),
+    ...(goNoGoPacketPath ? { goNoGoPacketPath } : {}),
     ...(outputPath ? { outputPath } : {}),
     ...(runUrl ? { runUrl } : {})
   };
@@ -141,16 +189,81 @@ function writeFile(filePath: string, content: string): void {
   fs.writeFileSync(filePath, content, "utf8");
 }
 
+function toDisplayPath(filePath: string): string {
+  const absolutePath = path.resolve(filePath);
+  const relativePath = path.relative(process.cwd(), absolutePath).replace(/\\/g, "/");
+  if (relativePath.length > 0 && !relativePath.startsWith("../")) {
+    return relativePath;
+  }
+
+  const normalizedAbsolutePath = absolutePath.replace(/\\/g, "/");
+  for (const marker of ["/release-readiness/", "/wechat-release/", "/runtime-regression/", "/baseline/", "/configs/"]) {
+    const markerIndex = normalizedAbsolutePath.lastIndexOf(marker);
+    if (markerIndex >= 0) {
+      return normalizedAbsolutePath.slice(markerIndex + 1);
+    }
+  }
+
+  return normalizedAbsolutePath;
+}
+
 function summarizeGate(gate: ReleaseGateSummaryReport["gates"][number]): string {
   const statusLabel = gate.status === "passed" ? "PASS" : "FAIL";
   const firstFailure = gate.failures?.find((failure) => failure.trim().length > 0);
   return `- **${gate.label}**: \`${statusLabel}\` ${firstFailure ?? gate.summary}`;
 }
 
+function renderGoNoGoPacketSection(packet: GoNoGoDecisionPacket, packetPath: string): string[] {
+  const packetMarkdownPath = packetPath.endsWith(".json") ? packetPath.replace(/\.json$/u, ".md") : undefined;
+  const keyArtifacts = [
+    packetPath,
+    ...(packetMarkdownPath ? [packetMarkdownPath] : []),
+    packet.inputs.dossierPath,
+    packet.inputs.releaseGateSummaryPath,
+    ...(packet.inputs.wechatCandidateSummaryPath ? [packet.inputs.wechatCandidateSummaryPath] : []),
+    ...packet.sections.blockerSummary.blockers.flatMap((item) => (item.artifactPath ? [item.artifactPath] : [])),
+    ...packet.sections.blockerSummary.warnings.flatMap((item) => (item.artifactPath ? [item.artifactPath] : [])),
+    ...packet.sections.unresolvedManualChecks.flatMap((item) => (item.artifactPath ? [item.artifactPath] : []))
+  ].filter((item, index, values) => values.indexOf(item) === index);
+
+  return [
+    "### Go/No-Go Packet",
+    "",
+    ...renderReviewerFacingMarkdownEntry(
+      "Go/No-Go verdict",
+      `${packet.candidate.name} @ ${packet.candidate.shortRevision}: \`${packet.decision.status.toUpperCase()}\` with ${packet.sections.blockerSummary.blockers.length} blocker(s) and ${packet.sections.blockerSummary.warnings.length} warning(s).`,
+      {
+        status: packet.decision.status === "go" ? "pass" : "fail",
+        nextStep: packet.sections.blockerSummary.blockers[0]?.nextStep,
+        artifacts: keyArtifacts.map((artifactPath) => ({ path: artifactPath })),
+        toDisplayPath
+      }
+    ),
+    `- Packet summary: ${packet.decision.summary}`,
+    `- Target surface: \`${packet.candidate.targetSurface}\` on branch \`${packet.candidate.branch}\``,
+    `- Unresolved manual checks: ${packet.sections.unresolvedManualChecks.length}`,
+    ...(packet.sections.blockerSummary.blockers.length === 0
+      ? []
+      : packet.sections.blockerSummary.blockers
+          .slice(0, 2)
+          .map((item) => `- Blocking signal: **${item.title}** ${item.summary}`)),
+    ...(packet.sections.blockerSummary.warnings.length === 0
+      ? []
+      : packet.sections.blockerSummary.warnings
+          .slice(0, 2)
+          .map((item) => `- Advisory signal: **${item.title}** ${item.summary}`)),
+    ""
+  ];
+}
+
 export function renderPrComment(
   releaseGateReport: ReleaseGateSummaryReport,
   releaseHealthReport: ReleaseHealthSummaryReport,
-  runUrl?: string
+  options?: {
+    runUrl?: string;
+    goNoGoPacket?: GoNoGoDecisionPacket;
+    goNoGoPacketPath?: string;
+  }
 ): string {
   const healthSignals = releaseHealthReport.signals.filter(
     (signal) => signal.id !== "release-readiness" && signal.id !== "release-gate"
@@ -163,8 +276,16 @@ export function renderPrComment(
     `- Revision: \`${releaseGateReport.revision.shortCommit}\` on \`${releaseGateReport.revision.branch}\``,
     `- Release readiness: **${releaseGateReport.summary.status.toUpperCase()}** (${releaseGateReport.summary.passedGates}/${releaseGateReport.summary.totalGates} gates passing)`,
     `- Release health: **${releaseHealthReport.summary.status.toUpperCase()}** (${releaseHealthReport.summary.blockerCount} blocker, ${releaseHealthReport.summary.warningCount} warning, ${releaseHealthReport.summary.infoCount} info)`,
-    ...(runUrl ? [`- CI run: ${runUrl}`] : []),
+    ...(options?.goNoGoPacket
+      ? [
+          `- Go/no-go packet: **${options.goNoGoPacket.decision.status.toUpperCase()}** (${options.goNoGoPacket.sections.blockerSummary.blockers.length} blocker, ${options.goNoGoPacket.sections.blockerSummary.warnings.length} warning)`
+        ]
+      : []),
+    ...(options?.runUrl ? [`- CI run: ${options.runUrl}`] : []),
     "",
+    ...(options?.goNoGoPacket && options.goNoGoPacketPath
+      ? renderGoNoGoPacketSection(options.goNoGoPacket, options.goNoGoPacketPath)
+      : []),
     "### Triage",
     "",
     ...renderReviewerFacingMarkdownEntry(
@@ -234,7 +355,15 @@ function main(): void {
   const args = parseArgs(process.argv);
   const releaseGateReport = readJsonFile<ReleaseGateSummaryReport>(args.releaseGateSummaryPath);
   const releaseHealthReport = readJsonFile<ReleaseHealthSummaryReport>(args.releaseHealthSummaryPath);
-  const content = renderPrComment(releaseGateReport, releaseHealthReport, args.runUrl);
+  const content = renderPrComment(releaseGateReport, releaseHealthReport, {
+    runUrl: args.runUrl,
+    ...(args.goNoGoPacketPath
+      ? {
+          goNoGoPacket: readJsonFile<GoNoGoDecisionPacket>(args.goNoGoPacketPath),
+          goNoGoPacketPath: args.goNoGoPacketPath
+        }
+      : {})
+  });
   const outputPath = path.resolve(args.outputPath ?? path.join("artifacts", "release-readiness", "release-pr-comment.md"));
   writeFile(outputPath, content);
   console.log(`Wrote release PR comment markdown: ${path.relative(process.cwd(), outputPath).replace(/\\/g, "/")}`);

--- a/scripts/test/release-pr-comment.test.ts
+++ b/scripts/test/release-pr-comment.test.ts
@@ -146,6 +146,58 @@ function createReleaseHealthReport(
   };
 }
 
+function createGoNoGoPacket() {
+  return {
+    generatedAt: "2026-03-30T00:03:00.000Z",
+    decision: {
+      status: "no_go" as const,
+      summary: "Blocking release evidence remains for wechat: 2 blocker item(s) must be cleared before promotion."
+    },
+    candidate: {
+      name: "phase1-wechat-rc",
+      revision: "abc1234def5678",
+      shortRevision: "abc1234",
+      branch: "issue-419",
+      targetSurface: "wechat" as const
+    },
+    inputs: {
+      dossierPath: "/tmp/runner/release-readiness/phase1-candidate-dossier-phase1-wechat-rc-abc1234/phase1-candidate-dossier.json",
+      releaseGateSummaryPath: "/tmp/runner/release-readiness/release-gate-summary-abc1234.json",
+      wechatCandidateSummaryPath: "/tmp/runner/wechat-release/codex.wechat.release-candidate-summary.json"
+    },
+    sections: {
+      blockerSummary: {
+        blockers: [
+          {
+            title: "WeChat runtime observability reviewed for this candidate",
+            summary: "Need release-environment health/auth-readiness/metrics captures.",
+            artifactPath: "/tmp/runner/wechat-release/runtime-observability-signoff-phase1-wechat-rc-abc1234.md",
+            nextStep: "Complete the runtime observability sign-off and rerun validate:wechat-rc."
+          },
+          {
+            title: "Release gate summary",
+            summary: "Release surface evidence is still blocked for the selected wechat target."
+          }
+        ],
+        warnings: [
+          {
+            title: "Config change risk",
+            summary: "Config changes are HIGH risk for wechat and still need release-owner review.",
+            artifactPath: "/tmp/runner/configs/.config-center-library.json"
+          }
+        ]
+      },
+      unresolvedManualChecks: [
+        {
+          title: "WeChat runtime observability reviewed for this candidate",
+          status: "pending" as const,
+          artifactPath: "/tmp/runner/wechat-release/runtime-observability-signoff-phase1-wechat-rc-abc1234.md"
+        }
+      ]
+    }
+  };
+}
+
 test("renderPrComment combines readiness and non-duplicative health sections", () => {
   const markdown = renderPrComment(
     createReleaseGateReport(),
@@ -157,10 +209,26 @@ test("renderPrComment combines readiness and non-duplicative health sections", (
         "previous=prev9876:ready"
       ]
     }),
-    "https://github.com/example/repo/actions/runs/123"
+    {
+      runUrl: "https://github.com/example/repo/actions/runs/123",
+      goNoGoPacket: createGoNoGoPacket(),
+      goNoGoPacketPath: "/tmp/runner/release-readiness/go-no-go-decision-packet-phase1-wechat-rc-abc1234.json"
+    }
   );
 
   assert.match(markdown, /## Release Automation Summary/);
+  assert.match(markdown, /Go\/no-go packet: \*\*NO_GO\*\* \(2 blocker, 1 warning\)/);
+  assert.match(markdown, /### Go\/No-Go Packet/);
+  assert.match(
+    markdown,
+    /\*\*Go\/No-Go verdict\*\*: `FAIL` phase1-wechat-rc @ abc1234: `NO_GO` with 2 blocker\(s\) and 1 warning\(s\)\./
+  );
+  assert.match(markdown, /Packet summary: Blocking release evidence remains for wechat: 2 blocker item\(s\) must be cleared before promotion\./);
+  assert.match(markdown, /`release-readiness\/go-no-go-decision-packet-phase1-wechat-rc-abc1234\.md`/);
+  assert.match(markdown, /Artifacts: `release-readiness\/go-no-go-decision-packet-phase1-wechat-rc-abc1234\.json`/);
+  assert.match(markdown, /`release-readiness\/phase1-candidate-dossier-phase1-wechat-rc-abc1234\/phase1-candidate-dossier\.json`/);
+  assert.match(markdown, /`wechat-release\/codex\.wechat\.release-candidate-summary\.json`/);
+  assert.match(markdown, /Blocking signal: \*\*WeChat runtime observability reviewed for this candidate\*\* Need release-environment health\/auth-readiness\/metrics captures\./);
   assert.match(markdown, /### Triage/);
   assert.match(markdown, /\*\*Release blockers\*\*: `FAIL` 1 blocking release-gate item\(s\) need operator follow-up\./);
   assert.match(


### PR DESCRIPTION
## Summary
- publish the go/no-go decision packet into the existing PR-visible release summary comment
- build the candidate dossier and decision packet during PR CI so the comment can include packet verdict, counts, and artifact paths
- document when to use the PR-visible summary versus the full packet artifact

## Validation
- node --import tsx --test ./scripts/test/release-pr-comment.test.ts

Closes #706