### PR TITLE
feat(dx): make minimal-validation-plan PR-aware and reviewer-friendly

### DIFF
--- a/docs/operational-entry-point-repo-map.md
+++ b/docs/operational-entry-point-repo-map.md
@@ -10,7 +10,7 @@ For detailed release sequencing, keep [`docs/same-revision-release-evidence-runb
 | --- | --- | --- |
 | Local contributor sanity check | `npm run validate:quickstart` | [`README.md`](../README.md), [`docs/verification-matrix.md`](./verification-matrix.md) |
 | Pick the smallest sufficient PR verification | [`docs/verification-matrix.md`](./verification-matrix.md) | [`docs/verification-matrix.md`](./verification-matrix.md) |
-| Turn changed paths into a minimal validation plan | `npm run plan:validation:minimal -- --base origin/main --head HEAD` | [`docs/verification-matrix.md`](./verification-matrix.md) |
+| Turn changed paths into a minimal validation plan | `npm run plan:validation:minimal -- --branch origin/main` | [`docs/verification-matrix.md`](./verification-matrix.md) |
 | Confirm the current primary client surface | `npm run client:primary` | [`README.md`](../README.md), [`docs/cocos-primary-client-delivery.md`](./cocos-primary-client-delivery.md) |
 | Audit Codex automation branches | `npm run ops:codex-branches` | [`docs/codex-automation-branch-maintenance.md`](./codex-automation-branch-maintenance.md) |
 

--- a/docs/verification-matrix.md
+++ b/docs/verification-matrix.md
@@ -2,7 +2,7 @@
 
 Use this matrix before opening a PR to pick the smallest verification set that still matches the risk of your change. It is intentionally scoped to the repo's current scripts, workflows, and release-readiness surfaces instead of generic "run everything" advice.
 
-For deterministic path-to-plan routing, use `npm run plan:validation:minimal -- --base origin/main --head HEAD` or pass explicit changed paths. The helper mirrors this matrix for major surfaces such as Cocos client, H5 shell, server runtime, release packaging, observability, and content/config. Treat its output as the fast routing layer, then fall back to the matrix when behavior or risk is broader than the touched paths suggest.
+For deterministic path-to-plan routing, use `npm run plan:validation:minimal -- --branch origin/main`, `npm run plan:validation:minimal -- --pr <number>`, or pass explicit changed paths. The helper mirrors this matrix for major surfaces such as Cocos client, H5 shell, server runtime, release packaging, observability, and content/config. Treat its output as the fast routing layer, then fall back to the matrix when behavior or risk is broader than the touched paths suggest.
 
 ## Contributor Quick Reference
 
@@ -27,7 +27,11 @@ If a change fits more than one row, combine the minimum required commands from e
 Use the helper when you want the repo to translate touched paths into a concise required-versus-optional validation plan:
 
 ```bash
-npm run plan:validation:minimal -- --base origin/main --head HEAD
+npm run plan:validation:minimal -- --branch origin/main
+```
+
+```bash
+npm run plan:validation:minimal -- --pr 708
 ```
 
 ```bash
@@ -36,10 +40,18 @@ npm run plan:validation:minimal -- \
   --path scripts/package-wechat-minigame-release.ts
 ```
 
+Maintainer and contributor flow:
+
+1. Before opening a PR, run `npm run plan:validation:minimal -- --branch origin/main` from your topic branch. The helper uses the same three-dot diff GitHub review uses, so the path set comes from the merge-base against `origin/main`.
+2. Paste the Markdown output into your PR description or working notes, then run the `Required checks` list.
+3. If you are reviewing an open PR, run `npm run plan:validation:minimal -- --pr <number>` to regenerate the same style of plan directly from the PR diff.
+4. Use `Optional diagnostics` only when the changed surface rationale matches the broader risk, a required check fails, or reviewers need extra release evidence.
+
 What it does:
 
 - maps changed paths to the maintained repo surfaces in this matrix
-- emits deduped `Required` steps plus `Optional diagnostics`
+- emits deduped Markdown `Required checks` plus `Optional diagnostics`
+- includes short rationale per changed surface so reviewers can see why each command is in the plan
 - points only at existing `npm run ...` commands or existing manual checks already described here
 
 What it does not do:
@@ -53,6 +65,7 @@ Override the helper and use the higher-risk matrix row when:
 - one change affects more than one runtime surface
 - a documented command or CI entry point changed
 - reviewers depend on a stable artifact or same-revision release evidence set
+- the PR comes from a fork and `gh pr diff <number> --name-only` is unavailable in your environment
 
 ## Verification Tiers
 

--- a/scripts/minimal-validation-plan.ts
+++ b/scripts/minimal-validation-plan.ts
@@ -52,9 +52,17 @@ export interface ValidationPlan {
 interface CliArgs {
   base?: string;
   head?: string;
+  branch?: string;
+  pr?: string;
   paths: string[];
   json: boolean;
+  markdown: boolean;
+  text: boolean;
   help: boolean;
+}
+
+interface RenderOptions {
+  comparisonLabel?: string;
 }
 
 const STEP_DEFINITIONS: StepDefinition[] = [
@@ -331,7 +339,13 @@ const SURFACE_RULES: SurfaceRule[] = [
     optionalStepIds: ["test-coverage-ci"],
     humanOverride: "If the tooling change only affects one surface, prefer that surface's targeted checks over broad coverage runs.",
     prefixes: ["scripts/test/"],
-    exact: ["package.json", "package-lock.json", "tsconfig.base.json", "tsconfig.ops-tooling.json"],
+    exact: [
+      "package.json",
+      "package-lock.json",
+      "scripts/minimal-validation-plan.ts",
+      "tsconfig.base.json",
+      "tsconfig.ops-tooling.json"
+    ],
     suffixes: [".config.ts"]
   }
 ];
@@ -490,14 +504,16 @@ function readGitPathList(args: string[]): string[] {
 }
 
 function detectPathsFromGit(base?: string, head = "HEAD"): string[] {
+  const includeHeadWorkspace = head === "HEAD";
+  const workspacePaths = includeHeadWorkspace
+    ? readGitPathList(["diff", "--name-only", "--diff-filter=ACMR"]).concat(
+        readGitPathList(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+      )
+    : [];
   const diffPaths =
     typeof base === "string"
-      ? readGitPathList(["diff", "--name-only", "--diff-filter=ACMR", `${base}...${head}`])
-      : uniqueSorted(
-          readGitPathList(["diff", "--name-only", "--diff-filter=ACMR"])
-            .concat(readGitPathList(["diff", "--cached", "--name-only", "--diff-filter=ACMR"]))
-            .concat(readGitPathList(["diff", "--name-only", "--diff-filter=ACMR", "origin/main...HEAD"]))
-        );
+      ? workspacePaths.concat(readGitPathList(["diff", "--name-only", "--diff-filter=ACMR", `${base}...${head}`]))
+      : workspacePaths.concat(readGitPathList(["diff", "--name-only", "--diff-filter=ACMR", "origin/main...HEAD"]));
 
   return uniqueSorted(diffPaths);
 }
@@ -506,6 +522,8 @@ function parseArgs(argv: string[]): CliArgs {
   const parsed: CliArgs = {
     paths: [],
     json: false,
+    markdown: false,
+    text: false,
     help: false
   };
 
@@ -540,8 +558,36 @@ function parseArgs(argv: string[]): CliArgs {
       continue;
     }
 
+    if (arg === "--branch") {
+      if (!next) {
+        throw new Error("Missing value for --branch.");
+      }
+      parsed.branch = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--pr") {
+      if (!next) {
+        throw new Error("Missing value for --pr.");
+      }
+      parsed.pr = next;
+      index += 1;
+      continue;
+    }
+
     if (arg === "--json") {
       parsed.json = true;
+      continue;
+    }
+
+    if (arg === "--markdown") {
+      parsed.markdown = true;
+      continue;
+    }
+
+    if (arg === "--text") {
+      parsed.text = true;
       continue;
     }
 
@@ -557,11 +603,15 @@ function parseArgs(argv: string[]): CliArgs {
 }
 
 function printHelp(): void {
-  console.log("Usage: npm run plan:validation:minimal -- [--base <ref> --head <ref>] [--path <file> ...] [--json]");
+  console.log(
+    "Usage: npm run plan:validation:minimal -- [--base <ref> --head <ref> | --branch <ref> | --pr <number>] [--path <file> ...] [--markdown|--text|--json]"
+  );
   console.log("");
   console.log("Examples:");
   console.log("  npm run plan:validation:minimal -- apps/cocos-client/assets/scripts/VeilRoot.ts");
   console.log("  npm run plan:validation:minimal -- --base origin/main --head HEAD");
+  console.log("  npm run plan:validation:minimal -- --branch origin/main --markdown");
+  console.log("  npm run plan:validation:minimal -- --pr 708");
   console.log("  npm run plan:validation:minimal -- --path apps/server/src/observability.ts --path docs/wechat-runtime-observability-signoff.md");
 }
 
@@ -574,11 +624,92 @@ function formatStep(step: ValidationPlanStep): string {
   return `- ${step.summary}${sourceText}`;
 }
 
-export function renderValidationPlan(plan: ValidationPlan): string {
+function formatMarkdownList(values: string[]): string {
+  return values.map((value) => `\`${value}\``).join(", ");
+}
+
+function renderMarkdownValidationPlan(plan: ValidationPlan, options?: RenderOptions): string {
+  const lines: string[] = [];
+
+  lines.push("## Recommended Minimal Validation Plan");
+  lines.push("");
+  if (options?.comparisonLabel) {
+    lines.push(`Comparison: \`${options.comparisonLabel}\``);
+  }
+  lines.push(`Detected paths: ${plan.detectedPaths.length}`);
+
+  if (plan.matchedSurfaces.length > 0) {
+    lines.push("");
+    lines.push("### Changed surfaces");
+    for (const surface of plan.matchedSurfaces) {
+      lines.push(`- **${surface.label}**: ${surface.rationale}`);
+      lines.push(`  Paths: ${formatMarkdownList(surface.matchedPaths)}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("### Required checks");
+  if (plan.requiredSteps.length === 0) {
+    lines.push("- [ ] No required steps inferred from the matched paths.");
+  } else {
+    for (const step of plan.requiredSteps) {
+      lines.push(
+        `- [ ] ${step.kind === "command" && step.command ? `\`${step.command}\`` : step.summary}`
+      );
+      if (step.kind !== "command" || !step.command) {
+        lines.push(`  Reason: ${step.summary}`);
+      } else {
+        lines.push(`  Reason: ${step.summary}`);
+      }
+      if (step.sources.length > 0) {
+        lines.push(`  Required because: ${step.sources.join(", ")}`);
+      }
+    }
+  }
+
+  lines.push("");
+  lines.push("### Optional diagnostics");
+  if (plan.optionalSteps.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const step of plan.optionalSteps) {
+      lines.push(
+        `- [ ] ${step.kind === "command" && step.command ? `\`${step.command}\`` : step.summary}`
+      );
+      lines.push(`  Reason: ${step.summary}`);
+      if (step.sources.length > 0) {
+        lines.push(`  Consider because: ${step.sources.join(", ")}`);
+      }
+    }
+  }
+
+  if (plan.unmatchedPaths.length > 0) {
+    lines.push("");
+    lines.push("### Unmatched paths");
+    for (const filePath of plan.unmatchedPaths) {
+      lines.push(`- \`${filePath}\``);
+    }
+  }
+
+  if (plan.humanOverrides.length > 0) {
+    lines.push("");
+    lines.push("### Reviewer notes");
+    for (const override of plan.humanOverrides) {
+      lines.push(`- ${override}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function renderPlainTextValidationPlan(plan: ValidationPlan, options?: RenderOptions): string {
   const lines: string[] = [];
 
   lines.push("Recommended minimal validation plan");
   lines.push("");
+  if (options?.comparisonLabel) {
+    lines.push(`Comparison: ${options.comparisonLabel}`);
+  }
   lines.push(`Detected paths: ${plan.detectedPaths.length}`);
 
   if (plan.matchedSurfaces.length > 0) {
@@ -628,6 +759,23 @@ export function renderValidationPlan(plan: ValidationPlan): string {
   return `${lines.join("\n")}\n`;
 }
 
+export function renderValidationPlan(plan: ValidationPlan, options?: RenderOptions): string {
+  return renderMarkdownValidationPlan(plan, options);
+}
+
+function readPullRequestPathList(pr: string): string[] {
+  const output = execFileSync("gh", ["pr", "diff", pr, "--name-only"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"]
+  });
+
+  return output
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
 function main(): void {
   const args = parseArgs(process.argv);
   if (args.help) {
@@ -635,12 +783,34 @@ function main(): void {
     return;
   }
 
-  const detectedPaths =
-    args.paths.length > 0 ? args.paths : detectPathsFromGit(args.base, args.head ?? "HEAD");
+  if (args.json && (args.markdown || args.text)) {
+    throw new Error("Choose only one output format: --json, --markdown, or --text.");
+  }
+
+  if (args.pr && (args.base || args.head || args.branch || args.paths.length > 0)) {
+    throw new Error("--pr cannot be combined with --base, --head, --branch, or explicit paths.");
+  }
+
+  const head = args.head ?? "HEAD";
+  const comparisonLabel = args.pr
+    ? `PR #${args.pr}`
+    : args.branch
+      ? `${args.branch}...${head}`
+      : args.base
+        ? `${args.base}...${head}`
+        : args.paths.length > 0
+          ? "explicit paths"
+          : "working tree + index + origin/main...HEAD";
+
+  const detectedPaths = args.paths.length > 0
+    ? args.paths
+    : args.pr
+      ? uniqueSorted(readPullRequestPathList(args.pr))
+      : detectPathsFromGit(args.branch ?? args.base, head);
   const plan = inferValidationPlan(detectedPaths);
 
   if (plan.detectedPaths.length === 0) {
-    throw new Error("No changed paths detected. Pass explicit paths or use --base/--head.");
+    throw new Error("No changed paths detected. Pass explicit paths or use --branch, --base/--head, or --pr.");
   }
 
   if (args.json) {
@@ -648,7 +818,11 @@ function main(): void {
     return;
   }
 
-  process.stdout.write(renderValidationPlan(plan));
+  process.stdout.write(
+    args.text
+      ? renderPlainTextValidationPlan(plan, { comparisonLabel })
+      : renderValidationPlan(plan, { comparisonLabel })
+  );
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/test/minimal-validation-plan.test.ts
+++ b/scripts/test/minimal-validation-plan.test.ts
@@ -61,10 +61,28 @@ test("flags release packaging and observability diagnostics without inventing ne
 });
 
 test("keeps unmatched paths visible so humans can widen the plan", () => {
-  const plan = inferValidationPlan(["unknown/path.txt", "scripts/minimal-validation-plan.ts"]);
+  const plan = inferValidationPlan(["unknown/path.txt"]);
 
   assert.deepEqual(plan.matchedSurfaces.map((surface) => surface.id), []);
-  assert.deepEqual(plan.unmatchedPaths, ["scripts/minimal-validation-plan.ts", "unknown/path.txt"]);
+  assert.deepEqual(plan.unmatchedPaths, ["unknown/path.txt"]);
   assert.ok(plan.humanOverrides.some((entry) => entry.includes("did not match a maintained surface")));
-  assert.match(renderValidationPlan(plan), /Unmatched paths:/);
+  assert.match(renderValidationPlan(plan), /### Unmatched paths/);
+});
+
+test("renders markdown output that is ready for PR comments", () => {
+  const plan = inferValidationPlan([
+    "apps/server/src/index.ts",
+    "docs/verification-matrix.md"
+  ]);
+
+  const rendered = renderValidationPlan(plan, { comparisonLabel: "origin/main...HEAD" });
+
+  assert.match(rendered, /^## Recommended Minimal Validation Plan/m);
+  assert.match(rendered, /Comparison: `origin\/main\.\.\.HEAD`/);
+  assert.match(rendered, /### Changed surfaces/);
+  assert.match(rendered, /- \*\*Docs or process guidance\*\*:/);
+  assert.match(rendered, /### Required checks/);
+  assert.match(rendered, /- \[ \] `npm run typecheck:server`/);
+  assert.match(rendered, /Required because: Server runtime/);
+  assert.match(rendered, /### Reviewer notes/);
 });


### PR DESCRIPTION
## Summary
- add branch and PR-aware input modes to `minimal-validation-plan`
- render reviewer-friendly Markdown with changed-surface rationale and required vs optional checks
- document the maintainer/contributor flow for branch and PR usage

## Validation
- `npm run test:minimal-validation-plan`
- `npm run plan:validation:minimal -- --branch origin/main`
- `npm run plan:validation:minimal -- --pr 709`

Closes #708