### PR TITLE
feat(ops): compare candidate against release-health trend baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ npm run dev:client:h5
 - Candidate-level reconnect soak：`npm run release:reconnect-soak -- --candidate <candidate-name> --candidate-revision <git-sha>`（输出 candidate+revision 命名的 reconnect soak JSON / Markdown，并供 release gate / dossier 直接引用）
 - 发布健康度聚合摘要：`npm run release:health:summary`
 - 最近候选包发布健康趋势基线：`npm run release:health:trend-baseline`
+- 当前候选包对比最近发布健康基线：`npm run release:health:trend-compare`
 - Phase 1 candidate dossier + single exit evidence gate：`npm run release:phase1:candidate-dossier -- --candidate <candidate-name> --candidate-revision <git-sha> [--server-url http://127.0.0.1:2567] [--output-dir artifacts/release-dossiers/<candidate>-<git-sha>]`
 - 打包 H5 客户端 RC 冒烟：`npm run smoke:client:release-candidate`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`

--- a/docs/release-health-trend-baseline.md
+++ b/docs/release-health-trend-baseline.md
@@ -2,6 +2,8 @@
 
 `npm run release:health:trend-baseline` summarizes the latest N `release-readiness-history` artifact directories into one concise baseline for maintainers.
 
+`npm run release:health:trend-compare` reuses the same history window, but turns that baseline into one explicit candidate-vs-baseline delta report for CI, PR review, or release triage.
+
 It is intended to answer three questions quickly:
 
 - Is the current candidate healthier or worse than the last few candidates?
@@ -41,12 +43,25 @@ npm run release:health:trend-baseline -- \
   --limit 5
 ```
 
+Generate the focused compare artifact instead of the broader trend baseline:
+
+```bash
+npm run release:health:trend-compare -- \
+  --cache-dir ./tmp/release-readiness-history-cache \
+  --limit 5
+```
+
 ## Default Outputs
 
 If you do not pass output flags, the script writes:
 
 - `artifacts/release-readiness/release-health-trend-baseline.json`
 - `artifacts/release-readiness/release-health-trend-baseline.md`
+
+Compare mode writes:
+
+- `artifacts/release-readiness/release-health-trend-compare.json`
+- `artifacts/release-readiness/release-health-trend-compare.md`
 
 ## Output Shape
 
@@ -72,6 +87,37 @@ The Markdown output is stable enough for PR comments or release notes because it
 - `Signal Trends`
 - `Recent Candidates`
 
+The compare JSON output contains:
+
+- `summary`
+  - compare status: `pass`, `warn`, or `fail`
+  - current candidate plus the explicit baseline candidate revisions
+  - which baseline-selection rule was used
+  - total blocking and warning findings
+- `baseline`
+  - baseline candidates, median blocker count, median warning count
+  - per-signal expected status and presence history across the baseline pool
+- `findings`
+  - structured `blocker-count`, `warning-count`, `missing-evidence`, and `signal-regression` findings
+
+The compare Markdown output keeps the reviewer-facing sections fixed:
+
+- `Findings`
+- `Baseline Heuristics`
+- `Baseline Signals`
+
+## Compare Heuristics
+
+The compare report intentionally keeps the regression rules small and reviewable:
+
+- Baseline pool: earlier candidates inside the selected history window, preferring non-blocking candidates. If no earlier non-blocking candidate exists, the tool falls back to all earlier candidates.
+- Blocker count regression: the current candidate exceeds the baseline median blocker count.
+- Warning count regression: the current candidate exceeds the baseline median warning count.
+- Missing evidence: a tracked signal is absent for the current candidate after appearing in at least half of baseline candidates.
+- Signal regression: the current signal falls below the highest status reached by at least half of baseline candidates.
+
+This keeps the compare artifact opinionated enough to be actionable without hiding the raw candidate history.
+
 ## Local Regeneration
 
 Populate the default cache path with recent workflow artifacts. One straightforward pattern is to download the `release-readiness-history` artifact from several workflow runs into separate directories:
@@ -96,6 +142,7 @@ In GitHub Actions, reuse the existing `release-readiness-history` artifact inste
 
 1. Download recent `release-readiness-history` artifacts into sibling directories under a workspace cache path.
 2. Run `npm run release:health:trend-baseline -- --cache-dir <that-path> --limit <n>`.
-3. Attach the generated JSON / Markdown to the workflow summary, PR comment, or release notes bundle.
+3. Run `npm run release:health:trend-compare -- --cache-dir <that-path> --limit <n>` when CI or a PR comment needs the explicit current-candidate delta.
+4. Attach the generated JSON / Markdown to the workflow summary, PR comment, or release notes bundle.
 
 This keeps the trend baseline aligned with the same normalized artifacts already used by `release:health:summary`, `release:gate:summary`, and `release:readiness:dashboard`.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "release:same-candidate:evidence-audit": "node --import tsx ./scripts/same-candidate-evidence-audit.ts",
     "release:health:summary": "node --import tsx ./scripts/release-health-summary.ts",
     "release:health:trend-baseline": "node --import tsx ./scripts/release-health-trend-baseline.ts",
+    "release:health:trend-compare": "node --import tsx ./scripts/release-health-trend-baseline.ts --compare-current",
     "release:phase1:candidate-dossier": "node --import tsx ./scripts/phase1-candidate-dossier.ts",
     "release:phase1:candidate-rehearsal": "node --import tsx ./scripts/phase1-candidate-rehearsal.ts",
     "release:wechat:rehearsal": "node --import tsx ./scripts/wechat-release-rehearsal.ts",

--- a/scripts/release-health-trend-baseline.ts
+++ b/scripts/release-health-trend-baseline.ts
@@ -14,6 +14,7 @@ interface Args {
   limit: number;
   outputPath?: string;
   markdownOutputPath?: string;
+  compareCurrent?: boolean;
 }
 
 interface SourceRunMetadata {
@@ -84,6 +85,7 @@ interface CandidateSignalSnapshot {
   label: string;
   status: ReviewerSignalStatus;
   summary: string;
+  present: boolean;
 }
 
 interface CandidateTrendEntry {
@@ -117,6 +119,63 @@ interface SignalTrendReport {
   direction: TrendDirection;
   summary: string;
   history: string[];
+}
+
+interface BaselineSignalExpectation {
+  id: string;
+  label: string;
+  expectedStatus: ReviewerSignalStatus;
+  presentCount: number;
+  candidateCount: number;
+  candidateRevisions: string[];
+  statuses: Array<{
+    candidateRevision: string;
+    status: ReviewerSignalStatus;
+    present: boolean;
+  }>;
+}
+
+type ComparisonFindingCategory = "blocker-count" | "warning-count" | "missing-evidence" | "signal-regression";
+type ComparisonFindingSeverity = "warning" | "blocking";
+
+interface ReleaseHealthTrendComparisonFinding {
+  id: string;
+  category: ComparisonFindingCategory;
+  severity: ComparisonFindingSeverity;
+  signalId?: string;
+  summary: string;
+  currentCandidate: string;
+  baselineCandidates: string[];
+  currentValue?: number | string;
+  baselineValue?: number | string;
+}
+
+export interface ReleaseHealthTrendBaselineComparisonReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  summary: {
+    status: "pass" | "warn" | "fail";
+    currentCandidate: string;
+    baselineCandidateCount: number;
+    baselineCandidates: string[];
+    baselineSelection: "non-blocking-history" | "all-history-fallback";
+    totalFindings: number;
+    blockingFindings: number;
+    warningFindings: number;
+  };
+  inputs: {
+    artifactDirs: string[];
+    cacheDir?: string;
+    limit: number;
+  };
+  current: CandidateTrendEntry;
+  baseline: {
+    candidates: CandidateTrendEntry[];
+    blockerCountMedian: number;
+    warningCountMedian: number;
+    signalExpectations: BaselineSignalExpectation[];
+  };
+  findings: ReleaseHealthTrendComparisonFinding[];
 }
 
 export interface ReleaseHealthTrendBaselineReport {
@@ -160,6 +219,8 @@ const RELEASE_HEALTH_FILENAME = "release-health-summary.json";
 const RELEASE_GATE_FILENAME = "release-gate-summary.json";
 const DASHBOARD_FILENAME = "release-readiness-dashboard.json";
 const SOURCE_RUN_FILENAME = "source-run.json";
+const COMPARE_OUTPUT_FILENAME = "release-health-trend-compare.json";
+const COMPARE_MARKDOWN_OUTPUT_FILENAME = "release-health-trend-compare.md";
 
 const SIGNAL_SPECS = [
   {
@@ -170,7 +231,8 @@ const SIGNAL_SPECS = [
         id: "release-health",
         label: "Release health",
         status: candidate.releaseHealth.status === "healthy" ? "pass" : candidate.releaseHealth.status === "warning" ? "warn" : "fail",
-        summary: `Release health is ${candidate.releaseHealth.status}.`
+        summary: `Release health is ${candidate.releaseHealth.status}.`,
+        present: true
       };
     }
   },
@@ -183,7 +245,8 @@ const SIGNAL_SPECS = [
         label: "Candidate readiness",
         status:
           candidate.dashboard.decision === "ready" ? "pass" : candidate.dashboard.decision === "pending" ? "warn" : "fail",
-        summary: candidate.dashboard.summary
+        summary: candidate.dashboard.summary,
+        present: true
       };
     }
   },
@@ -234,6 +297,7 @@ function parseArgs(argv: string[]): Args {
   let limit = 5;
   let outputPath: string | undefined;
   let markdownOutputPath: string | undefined;
+  let compareCurrent = false;
 
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -268,6 +332,10 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--compare-current") {
+      compareCurrent = true;
+      continue;
+    }
 
     fail(`Unknown argument: ${arg}`);
   }
@@ -277,7 +345,8 @@ function parseArgs(argv: string[]): Args {
     ...(cacheDir ? { cacheDir } : {}),
     limit,
     ...(outputPath ? { outputPath } : {}),
-    ...(markdownOutputPath ? { markdownOutputPath } : {})
+    ...(markdownOutputPath ? { markdownOutputPath } : {}),
+    compareCurrent
   };
 }
 
@@ -311,7 +380,8 @@ function findSignal(
       id,
       label,
       status: fallbackStatus,
-      summary: fallbackSummary
+      summary: fallbackSummary,
+      present: false
     }
   );
 }
@@ -397,7 +467,8 @@ function collectSignals(
       id: gate.id,
       label: gate.label,
       status: normalizeGateStatus(gate.status),
-      summary: gate.summary?.trim() || `${gate.label} is ${gate.status ?? "unknown"}.`
+      summary: gate.summary?.trim() || `${gate.label} is ${gate.status ?? "unknown"}.`,
+      present: true
     });
   }
 
@@ -409,7 +480,8 @@ function collectSignals(
       id: gate.id,
       label: gate.label,
       status: gate.status === "pass" || gate.status === "warn" ? gate.status : "fail",
-      summary: gate.summary?.trim() || `${gate.label} is ${gate.status ?? "unknown"}.`
+      summary: gate.summary?.trim() || `${gate.label} is ${gate.status ?? "unknown"}.`,
+      present: true
     });
   }
 
@@ -522,7 +594,7 @@ function collectArtifactDirs(args: Args): string[] {
   return [...new Set(candidates)];
 }
 
-export function buildReleaseHealthTrendBaselineReport(args: Args): ReleaseHealthTrendBaselineReport {
+function collectSortedCandidates(args: Args): CandidateTrendEntry[] {
   const artifactDirs = collectArtifactDirs(args);
   const candidates = artifactDirs.map((artifactDir) => loadCandidateArtifactDir(artifactDir));
   const sortedCandidates = candidates
@@ -533,6 +605,64 @@ export function buildReleaseHealthTrendBaselineReport(args: Args): ReleaseHealth
     fail("No candidate artifacts were available after sorting.");
   }
 
+  return sortedCandidates;
+}
+
+function calculateMedian(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middleIndex = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middleIndex] ?? 0;
+  }
+  return Math.round(((sorted[middleIndex - 1] ?? 0) + (sorted[middleIndex] ?? 0)) / 2);
+}
+
+function chooseBaselineCandidates(sortedCandidates: CandidateTrendEntry[]): {
+  selection: "non-blocking-history" | "all-history-fallback";
+  candidates: CandidateTrendEntry[];
+} {
+  const history = sortedCandidates.slice(1);
+  const nonBlocking = history.filter((candidate) => candidate.releaseHealth.status !== "blocking");
+  if (nonBlocking.length > 0) {
+    return {
+      selection: "non-blocking-history",
+      candidates: nonBlocking
+    };
+  }
+  return {
+    selection: "all-history-fallback",
+    candidates: history
+  };
+}
+
+function buildBaselineSignalExpectation(spec: (typeof SIGNAL_SPECS)[number], baselineCandidates: CandidateTrendEntry[]): BaselineSignalExpectation {
+  const statuses = baselineCandidates.map((candidate) => spec.select(candidate));
+  const passCount = statuses.filter((signal) => signal.status === "pass").length;
+  const warnOrBetterCount = statuses.filter((signal) => getSignalRank(signal.status) >= getSignalRank("warn")).length;
+  const required = Math.ceil(baselineCandidates.length / 2);
+  const expectedStatus =
+    passCount >= required ? "pass" : warnOrBetterCount >= required ? "warn" : "fail";
+
+  return {
+    id: spec.id,
+    label: spec.label,
+    expectedStatus,
+    presentCount: statuses.filter((signal) => signal.present).length,
+    candidateCount: baselineCandidates.length,
+    candidateRevisions: baselineCandidates.map((candidate) => candidate.candidateRevision),
+    statuses: baselineCandidates.map((candidate, index) => ({
+      candidateRevision: candidate.candidateRevision,
+      status: statuses[index]?.status ?? "fail",
+      present: statuses[index]?.present ?? false
+    }))
+  };
+}
+
+export function buildReleaseHealthTrendBaselineReport(args: Args): ReleaseHealthTrendBaselineReport {
+  const sortedCandidates = collectSortedCandidates(args);
   const [current, previous] = sortedCandidates;
   const currentBlockersById = new Map(current.blockers.map((blocker) => [blocker.id, blocker]));
   const previousBlockersById = new Map((previous?.blockers ?? []).map((blocker) => [blocker.id, blocker]));
@@ -590,6 +720,112 @@ export function buildReleaseHealthTrendBaselineReport(args: Args): ReleaseHealth
     },
     signalTrends,
     candidates: sortedCandidates
+  };
+}
+
+export function buildReleaseHealthTrendBaselineComparisonReport(args: Args): ReleaseHealthTrendBaselineComparisonReport {
+  const sortedCandidates = collectSortedCandidates(args);
+  const [current] = sortedCandidates;
+  const baselineSelection = chooseBaselineCandidates(sortedCandidates);
+
+  if (baselineSelection.candidates.length === 0) {
+    fail("Comparison mode requires at least one baseline candidate in addition to the current candidate.");
+  }
+
+  const blockerCountMedian = calculateMedian(baselineSelection.candidates.map((candidate) => candidate.releaseHealth.blockerCount));
+  const warningCountMedian = calculateMedian(baselineSelection.candidates.map((candidate) => candidate.releaseHealth.warningCount));
+  const signalExpectations = SIGNAL_SPECS.map((spec) => buildBaselineSignalExpectation(spec, baselineSelection.candidates));
+  const findings: ReleaseHealthTrendComparisonFinding[] = [];
+  const baselineCandidates = baselineSelection.candidates.map((candidate) => candidate.candidateRevision);
+
+  if (current.releaseHealth.blockerCount > blockerCountMedian) {
+    findings.push({
+      id: "blocker-count-regressed",
+      category: "blocker-count",
+      severity: "blocking",
+      summary: `Current candidate ${current.candidateRevision} has ${current.releaseHealth.blockerCount} blockers versus a baseline median of ${blockerCountMedian}.`,
+      currentCandidate: current.candidateRevision,
+      baselineCandidates,
+      currentValue: current.releaseHealth.blockerCount,
+      baselineValue: blockerCountMedian
+    });
+  }
+
+  if (current.releaseHealth.warningCount > warningCountMedian) {
+    findings.push({
+      id: "warning-count-regressed",
+      category: "warning-count",
+      severity: "warning",
+      summary: `Current candidate ${current.candidateRevision} has ${current.releaseHealth.warningCount} warnings versus a baseline median of ${warningCountMedian}.`,
+      currentCandidate: current.candidateRevision,
+      baselineCandidates,
+      currentValue: current.releaseHealth.warningCount,
+      baselineValue: warningCountMedian
+    });
+  }
+
+  for (const expectation of signalExpectations) {
+    const currentSignal = SIGNAL_SPECS.find((spec) => spec.id === expectation.id)?.select(current);
+    if (!currentSignal) {
+      continue;
+    }
+    if (!currentSignal.present && expectation.presentCount >= Math.ceil(expectation.candidateCount / 2)) {
+      findings.push({
+        id: `missing-evidence:${expectation.id}`,
+        category: "missing-evidence",
+        severity: "warning",
+        signalId: expectation.id,
+        summary: `${expectation.label} is missing for ${current.candidateRevision}; it was present in ${expectation.presentCount}/${expectation.candidateCount} baseline candidates.`,
+        currentCandidate: current.candidateRevision,
+        baselineCandidates
+      });
+      continue;
+    }
+    if (getSignalRank(currentSignal.status) < getSignalRank(expectation.expectedStatus)) {
+      findings.push({
+        id: `signal-regression:${expectation.id}`,
+        category: "signal-regression",
+        severity: expectation.id === "release-health" || expectation.id === "candidate-readiness" ? "blocking" : "warning",
+        signalId: expectation.id,
+        summary: `${expectation.label} is ${currentSignal.status.toUpperCase()} for ${current.candidateRevision}; baseline expectation from ${baselineCandidates.join(", ")} is ${expectation.expectedStatus.toUpperCase()}.`,
+        currentCandidate: current.candidateRevision,
+        baselineCandidates,
+        currentValue: currentSignal.status,
+        baselineValue: expectation.expectedStatus
+      });
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    summary: {
+      status: findings.some((finding) => finding.severity === "blocking")
+        ? "fail"
+        : findings.length > 0
+          ? "warn"
+          : "pass",
+      currentCandidate: current.candidateRevision,
+      baselineCandidateCount: baselineSelection.candidates.length,
+      baselineCandidates,
+      baselineSelection: baselineSelection.selection,
+      totalFindings: findings.length,
+      blockingFindings: findings.filter((finding) => finding.severity === "blocking").length,
+      warningFindings: findings.filter((finding) => finding.severity === "warning").length
+    },
+    inputs: {
+      artifactDirs: sortedCandidates.map((candidate) => candidate.artifactDir),
+      ...(args.cacheDir ? { cacheDir: path.resolve(args.cacheDir) } : {}),
+      limit: args.limit
+    },
+    current,
+    baseline: {
+      candidates: baselineSelection.candidates,
+      blockerCountMedian,
+      warningCountMedian,
+      signalExpectations
+    },
+    findings
   };
 }
 
@@ -674,9 +910,65 @@ export function renderMarkdown(report: ReleaseHealthTrendBaselineReport): string
   return `${lines.join("\n").trim()}\n`;
 }
 
+export function renderComparisonMarkdown(report: ReleaseHealthTrendBaselineComparisonReport): string {
+  const lines = [
+    "# Release Health Trend Compare",
+    "",
+    `- Generated at: \`${report.generatedAt}\``,
+    `- Current candidate: \`${report.summary.currentCandidate}\``,
+    `- Baseline candidates: ${report.summary.baselineCandidates.map((candidate) => `\`${candidate}\``).join(", ")}`,
+    `- Baseline selection: \`${report.summary.baselineSelection}\``,
+    `- Compare status: **${report.summary.status.toUpperCase()}**`,
+    ""
+  ];
+
+  lines.push("## Findings", "");
+  if (report.findings.length === 0) {
+    lines.push("- No regressions detected against the selected trend baseline.");
+  } else {
+    for (const finding of report.findings) {
+      lines.push(
+        ...renderReviewerFacingMarkdownEntry(
+          finding.signalId ? `${finding.category}:${finding.signalId}` : finding.category,
+          finding.summary,
+          {
+            status: finding.severity === "blocking" ? "fail" : "warn",
+            artifacts: [{ path: report.current.artifactDir }, ...report.baseline.candidates.map((candidate) => ({ path: candidate.artifactDir }))],
+            toDisplayPath
+          }
+        )
+      );
+    }
+  }
+  lines.push("");
+
+  lines.push("## Baseline Heuristics", "");
+  lines.push("- The baseline pool uses earlier non-blocking candidates within the selected history window; if none exist, it falls back to all earlier candidates.");
+  lines.push(`- Blocker count regresses when the current candidate exceeds the baseline median of ${report.baseline.blockerCountMedian}.`);
+  lines.push(`- Warning count regresses when the current candidate exceeds the baseline median of ${report.baseline.warningCountMedian}.`);
+  lines.push("- Missing evidence is flagged when a tracked signal is absent for the current candidate after appearing in at least half of baseline candidates.");
+  lines.push("- A tracked signal regresses when the current status falls below the highest status reached by at least half of baseline candidates.");
+  lines.push("");
+
+  lines.push("## Baseline Signals", "");
+  for (const expectation of report.baseline.signalExpectations) {
+    lines.push(
+      `- \`${expectation.id}\`: expected=${expectation.expectedStatus}, present=${expectation.presentCount}/${expectation.candidateCount}, history=${expectation.statuses
+        .map((entry) => `${entry.candidateRevision}:${entry.present ? entry.status : "missing"}`)
+        .join(" -> ")}`
+    );
+  }
+  lines.push("");
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
 function defaultOutputPath(args: Args): string {
   if (args.outputPath) {
     return path.resolve(args.outputPath);
+  }
+  if (args.compareCurrent) {
+    return path.join(DEFAULT_OUTPUT_DIR, COMPARE_OUTPUT_FILENAME);
   }
   return path.join(DEFAULT_OUTPUT_DIR, "release-health-trend-baseline.json");
 }
@@ -685,15 +977,26 @@ function defaultMarkdownOutputPath(args: Args): string {
   if (args.markdownOutputPath) {
     return path.resolve(args.markdownOutputPath);
   }
+  if (args.compareCurrent) {
+    return path.join(DEFAULT_OUTPUT_DIR, COMPARE_MARKDOWN_OUTPUT_FILENAME);
+  }
   return path.join(DEFAULT_OUTPUT_DIR, "release-health-trend-baseline.md");
 }
 
 function main(): void {
   const args = parseArgs(process.argv);
-  const report = buildReleaseHealthTrendBaselineReport(args);
   const outputPath = defaultOutputPath(args);
   const markdownOutputPath = defaultMarkdownOutputPath(args);
+  if (args.compareCurrent) {
+    const report = buildReleaseHealthTrendBaselineComparisonReport(args);
+    writeJsonFile(outputPath, report);
+    writeFile(markdownOutputPath, renderComparisonMarkdown(report));
+    console.log(`Wrote release health trend compare JSON: ${toDisplayPath(outputPath)}`);
+    console.log(`Wrote release health trend compare Markdown: ${toDisplayPath(markdownOutputPath)}`);
+    return;
+  }
 
+  const report = buildReleaseHealthTrendBaselineReport(args);
   writeJsonFile(outputPath, report);
   writeFile(markdownOutputPath, renderMarkdown(report));
 

--- a/scripts/test/release-health-trend-baseline.test.ts
+++ b/scripts/test/release-health-trend-baseline.test.ts
@@ -5,7 +5,12 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { buildReleaseHealthTrendBaselineReport, renderMarkdown } from "../release-health-trend-baseline.ts";
+import {
+  buildReleaseHealthTrendBaselineComparisonReport,
+  buildReleaseHealthTrendBaselineReport,
+  renderComparisonMarkdown,
+  renderMarkdown
+} from "../release-health-trend-baseline.ts";
 
 const repoRoot = path.resolve(__dirname, "../..");
 
@@ -25,10 +30,13 @@ function createCandidateDir(
     generatedAt: string;
     candidateRevision: string;
     releaseHealthStatus: "healthy" | "warning" | "blocking";
+    warningCount?: number;
     dashboardDecision: "ready" | "pending" | "blocked";
     blockers: Array<{ signalId: string; title: string; summary: string }>;
     releaseGateStatuses: Partial<Record<"h5-release-candidate-smoke" | "multiplayer-reconnect-soak" | "wechat-release", "passed" | "failed">>;
     dashboardStatuses: Partial<Record<"server-health" | "auth-readiness", "pass" | "warn" | "fail">>;
+    omittedReleaseGateIds?: Array<"h5-release-candidate-smoke" | "multiplayer-reconnect-soak" | "wechat-release">;
+    omittedDashboardGateIds?: Array<"server-health" | "auth-readiness">;
   }
 ): string {
   const dir = path.join(workspace, name);
@@ -42,7 +50,7 @@ function createCandidateDir(
     summary: {
       status: options.releaseHealthStatus,
       blockerCount: options.blockers.length,
-      warningCount: options.releaseHealthStatus === "warning" ? 1 : 0,
+      warningCount: options.warningCount ?? (options.releaseHealthStatus === "warning" ? 1 : 0),
       infoCount: 3
     },
     triage: {
@@ -73,7 +81,7 @@ function createCandidateDir(
         status: options.releaseGateStatuses["wechat-release"] ?? "passed",
         summary: "WeChat gate"
       }
-    ]
+    ].filter((gate) => !options.omittedReleaseGateIds?.includes(gate.id as "h5-release-candidate-smoke" | "multiplayer-reconnect-soak" | "wechat-release"))
   });
   writeJson(path.join(dir, "release-readiness-dashboard.json"), {
     generatedAt: options.generatedAt,
@@ -95,7 +103,7 @@ function createCandidateDir(
         status: options.dashboardStatuses["auth-readiness"] ?? "pass",
         summary: "Auth readiness gate"
       }
-    ]
+    ].filter((gate) => !options.omittedDashboardGateIds?.includes(gate.id as "server-health" | "auth-readiness"))
   });
   writeJson(path.join(dir, "source-run.json"), {
     runId: name,
@@ -270,4 +278,140 @@ test("release:health:trend-baseline CLI scans the cache dir and writes stable ou
   assert.equal(report.summary.candidateCount, 2);
   assert.equal(report.summary.currentCandidate, "cur1234");
   assert.equal(report.summary.previousCandidate, "prev9876");
+});
+
+test("compare mode flags blocker, warning, missing-evidence, and signal regressions against the baseline", () => {
+  const workspace = createTempWorkspace();
+  const currentDir = createCandidateDir(workspace, "current", {
+    generatedAt: "2026-04-03T09:00:00.000Z",
+    candidateRevision: "cur1234",
+    releaseHealthStatus: "blocking",
+    warningCount: 3,
+    dashboardDecision: "blocked",
+    blockers: [
+      {
+        signalId: "release-gate",
+        title: "Release gate summary",
+        summary: "Release gate summary failed: WeChat validation failed"
+      },
+      {
+        signalId: "sync-governance",
+        title: "Sync governance",
+        summary: "Sync governance matrix is failing."
+      }
+    ],
+    releaseGateStatuses: {
+      "h5-release-candidate-smoke": "passed",
+      "multiplayer-reconnect-soak": "passed"
+    },
+    omittedReleaseGateIds: ["wechat-release"],
+    dashboardStatuses: {
+      "server-health": "warn",
+      "auth-readiness": "fail"
+    }
+  });
+  const baselineA = createCandidateDir(workspace, "baseline-a", {
+    generatedAt: "2026-04-02T09:00:00.000Z",
+    candidateRevision: "base111",
+    releaseHealthStatus: "healthy",
+    dashboardDecision: "ready",
+    blockers: [],
+    releaseGateStatuses: {
+      "h5-release-candidate-smoke": "passed",
+      "multiplayer-reconnect-soak": "passed",
+      "wechat-release": "passed"
+    },
+    dashboardStatuses: {
+      "server-health": "pass",
+      "auth-readiness": "pass"
+    }
+  });
+  const baselineB = createCandidateDir(workspace, "baseline-b", {
+    generatedAt: "2026-04-01T09:00:00.000Z",
+    candidateRevision: "base222",
+    releaseHealthStatus: "warning",
+    dashboardDecision: "pending",
+    blockers: [],
+    releaseGateStatuses: {
+      "h5-release-candidate-smoke": "passed",
+      "multiplayer-reconnect-soak": "passed",
+      "wechat-release": "passed"
+    },
+    dashboardStatuses: {
+      "server-health": "pass",
+      "auth-readiness": "warn"
+    }
+  });
+
+  const report = buildReleaseHealthTrendBaselineComparisonReport({
+    artifactDirs: [currentDir, baselineA, baselineB],
+    limit: 3,
+    compareCurrent: true
+  });
+
+  assert.equal(report.summary.status, "fail");
+  assert.deepEqual(report.summary.baselineCandidates, ["base111", "base222"]);
+  assert.equal(report.summary.baselineSelection, "non-blocking-history");
+  assert.equal(report.baseline.blockerCountMedian, 0);
+  assert.equal(report.baseline.warningCountMedian, 1);
+  assert.equal(report.findings.find((finding) => finding.category === "blocker-count")?.severity, "blocking");
+  assert.equal(report.findings.find((finding) => finding.category === "warning-count")?.severity, "warning");
+  assert.equal(report.findings.find((finding) => finding.category === "missing-evidence")?.signalId, "wechat-release");
+  assert.equal(report.findings.find((finding) => finding.signalId === "candidate-readiness")?.severity, "blocking");
+  assert.equal(report.findings.find((finding) => finding.signalId === "server-health")?.severity, "warning");
+
+  const markdown = renderComparisonMarkdown(report);
+  assert.match(markdown, /## Findings/);
+  assert.match(markdown, /Current candidate: `cur1234`/);
+  assert.match(markdown, /baseline median of 0/);
+  assert.match(markdown, /WeChat release validation is missing for cur1234; it was present in 2\/2 baseline candidates\./);
+  assert.match(markdown, /## Baseline Heuristics/);
+});
+
+test("compare CLI writes compare artifacts with stable default filenames", () => {
+  const workspace = createTempWorkspace();
+  const cacheDir = path.join(workspace, "cache");
+  createCandidateDir(cacheDir, "run-101", {
+    generatedAt: "2026-04-03T09:00:00.000Z",
+    candidateRevision: "cur1234",
+    releaseHealthStatus: "warning",
+    dashboardDecision: "pending",
+    blockers: [],
+    releaseGateStatuses: {
+      "h5-release-candidate-smoke": "passed",
+      "multiplayer-reconnect-soak": "passed"
+    },
+    dashboardStatuses: {
+      "server-health": "pass",
+      "auth-readiness": "warn"
+    }
+  });
+  createCandidateDir(cacheDir, "run-100", {
+    generatedAt: "2026-04-02T09:00:00.000Z",
+    candidateRevision: "prev9876",
+    releaseHealthStatus: "healthy",
+    dashboardDecision: "ready",
+    blockers: [],
+    releaseGateStatuses: {
+      "h5-release-candidate-smoke": "passed",
+      "multiplayer-reconnect-soak": "passed",
+      "wechat-release": "passed"
+    },
+    dashboardStatuses: {
+      "server-health": "pass",
+      "auth-readiness": "pass"
+    }
+  });
+
+  const result = spawnSync("node", ["--import", "tsx", "./scripts/release-health-trend-baseline.ts", "--cache-dir", cacheDir, "--limit", "2", "--compare-current"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+  assert.match(result.stdout, /Wrote release health trend compare JSON:/);
+  assert.equal(fs.existsSync(path.join(repoRoot, "artifacts", "release-readiness", "release-health-trend-compare.json")), true);
+  assert.equal(fs.existsSync(path.join(repoRoot, "artifacts", "release-readiness", "release-health-trend-compare.md")), true);
+  fs.rmSync(path.join(repoRoot, "artifacts", "release-readiness", "release-health-trend-compare.json"), { force: true });
+  fs.rmSync(path.join(repoRoot, "artifacts", "release-readiness", "release-health-trend-compare.md"), { force: true });
 });


### PR DESCRIPTION
## Summary
- add a compare mode for release-health trend history that emits dedicated JSON and Markdown delta artifacts
- flag structured blocker, warning, missing-evidence, and signal-regression findings for the current candidate against the selected baseline pool
- document the compare command and its baseline heuristics, and cover the new mode with targeted tests

## Validation
- npm run test:release-health-trend-baseline

Closes #707