### PR TITLE
feat(cocos): automate canonical main-client journey evidence

### DIFF
--- a/scripts/minimal-validation-plan.ts
+++ b/scripts/minimal-validation-plan.ts
@@ -278,6 +278,21 @@ const SURFACE_RULES: SurfaceRule[] = [
     prefixes: ["apps/cocos-client/"]
   },
   {
+    id: "cocos-release-evidence",
+    label: "Cocos release evidence",
+    rationale: "Canonical main-client journey evidence and RC bundle scripts should keep the release-facing artifact path executable.",
+    requiredStepIds: ["release-cocos-rc-bundle"],
+    optionalStepIds: ["validate-wechat-rc"],
+    humanOverride:
+      "If the change only affects one evidence stage, keep the bundle rebuild as the default end-to-end check and widen to WeChat RC validation only when the touched path changes imported device evidence semantics.",
+    exact: [
+      "scripts/cocos-primary-client-journey-evidence.ts",
+      "scripts/cocos-rc-evidence-bundle.ts",
+      "scripts/cocos-release-candidate-snapshot.ts",
+      "docs/cocos-release-evidence-template.md"
+    ]
+  },
+  {
     id: "release-packaging",
     label: "Release packaging or candidate evidence",
     rationale: "Packaging and reviewer-facing candidate assembly should point back to the existing WeChat and release bundle commands.",

--- a/scripts/test/minimal-validation-plan.test.ts
+++ b/scripts/test/minimal-validation-plan.test.ts
@@ -60,6 +60,18 @@ test("flags release packaging and observability diagnostics without inventing ne
   assert.ok(plan.optionalSteps.every((step) => step.command?.startsWith("npm run") ?? true));
 });
 
+test("maps canonical cocos journey evidence scripts to the RC bundle validation path", () => {
+  const plan = inferValidationPlan([
+    "scripts/cocos-primary-client-journey-evidence.ts",
+    "scripts/cocos-rc-evidence-bundle.ts"
+  ]);
+
+  assert.deepEqual(plan.matchedSurfaces.map((surface) => surface.id), ["cocos-release-evidence"]);
+  assert.deepEqual(plan.requiredSteps.map((step) => step.command), ["npm run release:cocos-rc:bundle"]);
+  assert.ok(plan.optionalSteps.some((step) => step.command === "npm run validate:wechat-rc"));
+  assert.deepEqual(plan.unmatchedPaths, []);
+});
+
 test("keeps unmatched paths visible so humans can widen the plan", () => {
   const plan = inferValidationPlan(["unknown/path.txt"]);
 


### PR DESCRIPTION
## Summary
- map canonical Cocos journey evidence and RC bundle scripts to the maintained release-evidence validation surface
- recommend `npm run release:cocos-rc:bundle` as the default end-to-end check for those paths
- cover the new mapping with a focused minimal-validation-plan regression test

Closes #696