### PR TITLE
docs(release): add manual evidence owner ledger guidance

### DIFF
--- a/docs/cocos-phase1-presentation-signoff.md
+++ b/docs/cocos-phase1-presentation-signoff.md
@@ -22,6 +22,7 @@ For the same candidate revision, keep this checklist next to the existing RC evi
 - [`docs/cocos-release-evidence-template.md`](./cocos-release-evidence-template.md)
 - [`docs/release-evidence/cocos-wechat-rc-checklist.template.md`](./release-evidence/cocos-wechat-rc-checklist.template.md)
 - [`docs/release-evidence/cocos-wechat-rc-blockers.template.md`](./release-evidence/cocos-wechat-rc-blockers.template.md)
+- [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md)
 
 Generate the candidate-scoped artifact with:
 
@@ -35,6 +36,8 @@ That command now emits:
 - `artifacts/release-readiness/cocos-presentation-signoff-<candidate>-<short-sha>.md`
 
 Those files are the attachable per-candidate sign-off record. This doc defines how to review and, if needed, edit the generated checklist before the candidate is widened beyond controlled internal testing.
+
+When the sign-off conclusion changes, mirror the same owner, revision, timestamp, artifact path, and follow-up summary into the manual evidence owner ledger. The ledger should show whether `cocos-presentation-signoff` is still pending or stale without reopening the full artifact.
 
 ## Sign-Off Rules
 

--- a/docs/release-evidence/cocos-wechat-rc-blockers.template.md
+++ b/docs/release-evidence/cocos-wechat-rc-blockers.template.md
@@ -15,6 +15,7 @@
 - Release decision: `ship | hold | ship-with-followups`
 - Release summary: `artifacts/release-readiness/release-gate-summary-<short-sha>.json`
 - WeChat candidate summary: `artifacts/wechat-release/codex.wechat.release-candidate-summary.json`
+- Related owner ledger: `artifacts/release-readiness/manual-release-evidence-owner-ledger-<short-sha>.md`
 
 ## Blocker Rules
 
@@ -48,3 +49,14 @@
 - 放行理由：
 - 若带风险放行，限制范围：
 - 回退动作：
+
+## Ledger Mirror
+
+Update the manual evidence owner ledger row for `cocos-rc-blockers-review` whenever this blocker register changes state.
+
+- `Owner`: `<name>`
+- `Status`: `pending | in-review | done | waived`
+- `Revision`: `<git-sha>`
+- `Last updated`: `<last-updated>`
+- `Artifact path / link`: `<this-file>`
+- `Notes / blocker context`: note whether open blockers still keep the candidate on hold

--- a/docs/release-evidence/cocos-wechat-rc-checklist.template.md
+++ b/docs/release-evidence/cocos-wechat-rc-checklist.template.md
@@ -18,6 +18,8 @@
   `artifacts/release-readiness/release-gate-summary-<short-sha>.json`
 - WeChat candidate summary:
   `artifacts/wechat-release/codex.wechat.release-candidate-summary.json`
+- Related owner ledger:
+  `artifacts/release-readiness/manual-release-evidence-owner-ledger-<short-sha>.md`
 
 ## Release-Surface Contract
 
@@ -129,3 +131,14 @@
 - Summary:
 - Remaining blockers doc:
 - Follow-ups / owners:
+
+## Ledger Mirror
+
+Update the manual evidence owner ledger row for `cocos-rc-checklist-review` whenever this checklist changes state.
+
+- `Owner`: `<name>`
+- `Status`: `pending | in-review | done | waived`
+- `Revision`: `<git-sha>`
+- `Last updated`: `<recorded-at>`
+- `Artifact path / link`: `<this-file>`
+- `Notes / blocker context`: summarize what is still pending, waived, or accepted

--- a/docs/release-evidence/manual-release-evidence-owner-ledger.template.md
+++ b/docs/release-evidence/manual-release-evidence-owner-ledger.template.md
@@ -2,7 +2,7 @@
 
 Use this ledger when one candidate still depends on manual release evidence that lives across multiple JSON artifacts, checklist files, or sign-off notes.
 
-Create one copy per candidate under `artifacts/release-readiness/` or attach the same table to the release PR. Keep it lightweight: the goal is to show, in one place, which manual sign-offs are still missing, who owns them, and which artifact proves completion.
+Create one copy per candidate under `artifacts/release-readiness/` or attach the same table to the release PR. Keep it lightweight: the goal is to show, in one place, which manual sign-offs are still missing, who owns them, whether they are still fresh for this candidate revision, and which artifact proves completion.
 
 ## Candidate
 
@@ -15,11 +15,13 @@ Create one copy per candidate under `artifacts/release-readiness/` or attach the
 ## Ledger
 
 | Evidence type | Candidate | Revision | Owner | Status | Last updated | Artifact path / link | Notes / blocker context |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 | `cocos-rc-checklist-review` | `rc-YYYY-MM-DD` | `abc123def456` | `release-owner` | `in-review` | `2026-04-02T09:40:00Z` | `artifacts/release-readiness/cocos-rc-checklist-rc-YYYY-MM-DD-abc123d.md` | Reviewing RC checklist and blocker register for this candidate. |
+| `cocos-rc-blockers-review` | `rc-YYYY-MM-DD` | `abc123def456` | `release-owner` | `in-review` | `2026-04-02T09:41:00Z` | `artifacts/release-readiness/cocos-rc-blockers-rc-YYYY-MM-DD-abc123d.md` | Blocker register updated after smoke follow-up; confirm no open P0 remains. |
 | `cocos-presentation-signoff` | `rc-YYYY-MM-DD` | `abc123def456` | `client-lead` | `pending` | `2026-04-02T09:42:00Z` | `artifacts/release-readiness/cocos-presentation-signoff-rc-YYYY-MM-DD-abc123d.md` | Refresh world-map capture after the latest fallback UI fix. |
 | `runtime-observability-review` | `rc-YYYY-MM-DD` | `abc123def456` | `oncall-ops` | `pending` | `2026-04-02T09:45:00Z` | `artifacts/wechat-release/runtime-observability-signoff-rc-YYYY-MM-DD-abc123d.md` | Capture `/api/runtime/health`, `/api/runtime/auth-readiness`, and `/api/runtime/metrics` in the release environment. |
-| `wechat-validation-review` | `rc-YYYY-MM-DD` | `abc123def456` | `qa-release` | `done` | `2026-04-02T09:55:00Z` | `artifacts/wechat-release/codex.wechat.release-candidate-summary.json` | Device runtime smoke and release rehearsal evidence are attached for the same revision. Use `waived` only when WeChat is not the target surface. |
+| `wechat-devtools-export-review` | `rc-YYYY-MM-DD` | `abc123def456` | `qa-release` | `done` | `2026-04-02T09:52:00Z` | `artifacts/wechat-release/codex.wechat.release-candidate-summary.json` | Real export opened in WeChat Developer Tools for the same revision. Use `waived` only when WeChat is not the target surface. |
+| `wechat-device-runtime-smoke` | `rc-YYYY-MM-DD` | `abc123def456` | `qa-release` | `done` | `2026-04-02T09:55:00Z` | `artifacts/wechat-release/codex.wechat.smoke-report.json` | Device runtime smoke evidence is current for the same candidate and revision. Use `waived` only when WeChat is not the target surface. |
 | `reconnect-release-followup` | `rc-YYYY-MM-DD` | `abc123def456` | `server-oncall` | `pending` | `2026-04-02T09:58:00Z` | `artifacts/release-readiness/colyseus-reconnect-soak-summary-rc-YYYY-MM-DD-abc123d.md` | Human review still needed on the reconnect warning before release call. |
 
 ## Rules
@@ -27,15 +29,28 @@ Create one copy per candidate under `artifacts/release-readiness/` or attach the
 - Keep one row per required manual evidence item for the candidate revision. Do not split ownership for one sign-off across multiple rows unless the evidence artifacts are genuinely separate.
 - `Status` must stay within `pending | in-review | done | waived`.
 - The ledger should cover at least the current manual Phase 1 release checks:
-  - `cocos-rc-checklist-review`
-  - `cocos-presentation-signoff` when presentation review applies to the candidate
   - `runtime-observability-review`
-  - `wechat-validation-review` or release rehearsal review when WeChat is the target surface
+  - `cocos-rc-checklist-review`
+  - `cocos-rc-blockers-review`
+  - `cocos-presentation-signoff` when presentation review applies to the candidate
+  - `wechat-devtools-export-review` when WeChat is the target surface
+  - `wechat-device-runtime-smoke` when WeChat is the target surface
   - `reconnect-release-followup` for reconnect or manual release-gate follow-ups that still require a human call
 - `Candidate` and `Revision` in each row must match the header and the linked readiness snapshot, WeChat summary, RC checklist, or sign-off artifact.
 - `Last updated` should be the latest timestamp at which the row status, owner, or linked artifact was confirmed.
 - `Artifact path / link` should point at the exact JSON, Markdown, PR comment, or checklist file used during the release call.
 - `Notes / blocker context` should answer the handoff question directly: what is waiting, who is blocked, or why the item is `waived`.
+- The ledger does not replace the source artifacts. Keep the checklist, blocker register, smoke report, and sign-off files as the canonical proof; use the ledger only as the candidate-level ownership and freshness index.
+
+## When To Update It
+
+Update the ledger at the same moments maintainers already touch the candidate packet:
+
+1. Right after generating or refreshing `release:readiness:snapshot`, create the candidate ledger and pre-fill the required manual evidence rows.
+2. After editing the Cocos / WeChat RC checklist or blocker register, update the matching ledger row with owner, status, timestamp, and artifact path.
+3. After reviewing or regenerating the Cocos presentation sign-off, update the `cocos-presentation-signoff` row.
+4. After completing WeChat Developer Tools export review, device runtime smoke, or runtime observability sign-off, update those rows immediately instead of waiting for the final release call.
+5. When a manual item becomes stale, blocked, waived, or complete, update the row in the same commit or PR comment that records the new evidence state.
 
 ## Minimal Operating Flow
 

--- a/docs/same-revision-release-evidence-runbook.md
+++ b/docs/same-revision-release-evidence-runbook.md
@@ -82,6 +82,16 @@ Copy [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](
 
 Pre-fill one row per required manual evidence item before continuing. This is the handoff tracker for the rest of the run.
 
+At minimum, create rows for:
+
+- runtime observability review
+- Cocos / WeChat RC checklist review
+- Cocos / WeChat blocker-register review
+- Cocos presentation sign-off when presentation review applies
+- WeChat Developer Tools export review when WeChat is the target surface
+- WeChat device/runtime smoke when WeChat is the target surface
+- reconnect follow-up when reconnect evidence still needs a human call
+
 4. Refresh scope-specific evidence only when the candidate needs it.
 
 Reconnect / room recovery scope:
@@ -121,6 +131,8 @@ npm run release:cocos-rc:bundle -- \
 ```
 
 Confirm the generated bundle, checklist, and blockers files all point at the same candidate and revision.
+
+After reviewing or editing the checklist / blockers files, update the matching rows in the owner ledger before moving on. The ledger is the release-call index; the checklist and blocker files remain the underlying evidence.
 
 6. Refresh the WeChat artifact family when WeChat is the release surface.
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -212,6 +212,7 @@ WeChat checklist / blockers 至少要覆盖以下证据面：
 5. 回填完成后执行 `npm run smoke:wechat-release -- --artifacts-dir <release-artifacts-dir> --check [--expected-revision <git-sha>]`
 6. 再执行 `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface wechat_preview --wechat-smoke-report <release-artifacts-dir>/codex.wechat.smoke-report.json`，把 `login-lobby`、`room-entry`、`reconnect-recovery` 自动映射到统一 RC 快照，同时保留同一 revision 的 primary-client canonical journey evidence，并在 `artifacts/release-readiness/` 生成可直接附到 CI artifact / PR 评论的 bundle 摘要；若设备 evidence 缺失，快照会标成 `blocked`，避免在 RC 汇总里被误判为通过。
 7. 回填同一 bundle 里的 checklist / blockers 文件，并同步附上 [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) 与 [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md) 的当前结论，确保 reviewer 能直接看到当前 RC 的设备、observability 结论与未关闭风险。
+8. 若当前 candidate 还有人工证据在流转，立即同步更新 [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md) 的当次 candidate 副本；至少回填 WeChat DevTools 导出复核、device/runtime smoke、runtime observability sign-off、RC checklist / blockers review 的 owner、status、timestamp、artifactPath 与 follow-up notes。不要等到最终 release call 才补记。
 
 ### 自动化 Runtime Evidence Schema
 


### PR DESCRIPTION
## Summary
- tighten the manual release evidence owner ledger template so it covers the key Phase 1 manual evidence families
- document when maintainers should update the ledger during the candidate cycle
- add explicit ledger mirror guidance to the RC checklist/blocker and presentation/WeChat docs

## Validation
- reviewed the rendered git diff
- verified the manual ledger table has consistent column counts

Closes #719