### PR TITLE
feat(ux): add battle report center fallback for H5 encounters

### DIFF
--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -216,6 +216,15 @@ function resolveBattleReportSummary(
   return resolveBattleReportCenter(account).items.find((report) => report.id === replay.id) ?? null;
 }
 
+function resolveBattleReportSummaryById(account: PlayerAccountProfile, reportId?: string | null) {
+  const normalizedReportId = reportId?.trim();
+  if (!normalizedReportId) {
+    return null;
+  }
+
+  return resolveBattleReportCenter(account).items.find((report) => report.id === normalizedReportId) ?? null;
+}
+
 function formatBattleReportEncounter(input: {
   battleKind: PlayerAccountProfile["recentBattleReplays"][number]["battleKind"];
   opponentHeroId?: string;
@@ -523,6 +532,7 @@ export function renderBattleReportReplayCenter(input: {
     })}
     ${renderBattleReplayInspector({
       account: input.account,
+      ...(input.selectedReplayId !== undefined ? { selectedReplayId: input.selectedReplayId } : {}),
       replay: input.replay,
       playback: input.playback,
       ...(input.loading !== undefined ? { loading: input.loading } : {}),
@@ -533,12 +543,59 @@ export function renderBattleReportReplayCenter(input: {
 
 export function renderBattleReplayInspector(input: {
   account: PlayerAccountProfile;
+  selectedReplayId?: string | null;
   replay: PlayerAccountProfile["recentBattleReplays"][number] | null;
   playback: BattleReplayPlaybackState | null;
   loading?: boolean;
   status?: string;
 }): string {
+  const selectedReport = resolveBattleReportSummaryById(input.account, input.selectedReplayId);
   if (!input.replay) {
+    if (selectedReport) {
+      return `<div class="account-subsection replay-inspector" data-testid="battle-replay-inspector">
+        <div class="account-replay-inspector-head">
+          <div>
+            <strong>战报详情</strong>
+            <p class="account-meta">${escapeHtml(
+              `${selectedReport.result === "victory" ? "胜利" : "失利"} · ${selectedReport.battleKind === "hero" ? "PVP" : "PVE"} · ${formatBattleReportEncounter(selectedReport)}`
+            )}</p>
+          </div>
+          <button type="button" class="account-replay-dismiss" data-clear-replay="true">收起</button>
+        </div>
+        <div class="account-replay-meta">
+          <span>房间 ${escapeHtml(selectedReport.roomId)}</span>
+          <span>英雄 ${escapeHtml(selectedReport.heroId)}</span>
+          <span>阵营 ${escapeHtml(selectedReport.playerCamp === "attacker" ? "攻方" : "守方")}</span>
+        </div>
+        <p class="account-meta">${escapeHtml(input.status?.trim() || "当前仅同步到战报摘要，完整回放暂不可用。")}</p>
+        <div class="account-replay-report-summary">
+          <div class="account-replay-summary-card">
+            <strong>结果概览</strong>
+            <p>${escapeHtml(`${selectedReport.turnCount} 回合 · ${selectedReport.actionCount} 步`)}</p>
+            <div class="account-replay-meta">
+              <span>${escapeHtml(`完成于 ${formatTimestamp(selectedReport.completedAt)}`)}</span>
+              <span>${escapeHtml(`回放证据 ${selectedReport.evidence.replay === "available" ? "可用" : "缺失"}`)}</span>
+            </div>
+          </div>
+          <div class="account-replay-summary-card">
+            <strong>战后收益</strong>
+            ${
+              selectedReport.rewards.length > 0
+                ? `<div class="account-event-rewards">${selectedReport.rewards
+                    .map((reward) => `<span class="account-reward-chip">${escapeHtml(formatBattleRewardChip(reward))}</span>`)
+                    .join("")}</div>`
+                : `<p class="account-meta">${
+                    selectedReport.evidence.rewards === "available" ? "收益证据同步中。" : "该战报暂未附带额外奖励记录。"
+                  }</p>`
+            }
+            <div class="account-replay-summary-notes">
+              <span class="account-meta">${escapeHtml(`收益证据 ${selectedReport.evidence.rewards === "available" ? "可用" : "缺失"}`)}</span>
+            </div>
+          </div>
+        </div>
+      </div>`;
+    }
+
     return `<div class="account-subsection">
       <strong>回放详情</strong>
       <p class="account-meta">${escapeHtml(input.status?.trim() || "选择一场最近战斗，即可查看逐步回放。")}</p>

--- a/apps/client/src/main-boot.ts
+++ b/apps/client/src/main-boot.ts
@@ -191,7 +191,8 @@ export async function syncH5PlayerAccountProfile({
       : "当前运行在本地游客档，昵称仅保存在浏览器。";
   if (
     state.replayDetail.selectedReplayId &&
-    !account.recentBattleReplays.some((replay) => replay.id === state.replayDetail.selectedReplayId)
+    !account.recentBattleReplays.some((replay) => replay.id === state.replayDetail.selectedReplayId) &&
+    !account.battleReportCenter?.items.some((report) => report.id === state.replayDetail.selectedReplayId)
   ) {
     clearReplayDetail("最近战报已刷新，当前选中的回放已不可用。");
   }

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -986,6 +986,15 @@ function findReplaySummary(replayId: string | null | undefined): PlayerBattleRep
   return state.account.recentBattleReplays.find((replay) => replay.id === normalizedReplayId) ?? null;
 }
 
+function hasBattleReportSummary(reportId: string | null | undefined): boolean {
+  const normalizedReportId = reportId?.trim();
+  if (!normalizedReportId) {
+    return false;
+  }
+
+  return state.account.battleReportCenter?.items.some((report) => report.id === normalizedReportId) ?? false;
+}
+
 function clearReplayPlaybackLoop(): void {
   if (replayPlaybackTaskId != null) {
     window.clearTimeout(replayPlaybackTaskId);
@@ -1027,8 +1036,21 @@ function clearReplayDetail(status = "选择一场最近战斗，即可查看逐�
 
 async function selectReplayDetail(replayId: string): Promise<void> {
   const summary = findReplaySummary(replayId);
-  if (!summary) {
+  if (!summary && !hasBattleReportSummary(replayId)) {
     clearReplayDetail("该回放已不在最近战报列表中。");
+    render();
+    return;
+  }
+
+  if (!summary) {
+    clearReplayPlaybackLoop();
+    state.replayDetail = {
+      selectedReplayId: replayId,
+      replay: null,
+      playback: null,
+      loading: false,
+      status: "当前仅同步到战报摘要，完整回放暂不可用。"
+    };
     render();
     return;
   }

--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -8,9 +8,11 @@ import {
 } from "./auth-session";
 import {
   restoreBattleReplayPlaybackState,
+  normalizePlayerBattleReportCenter,
   type BattleReplayPlaybackCommand,
   type BattleReplayPlaybackState,
   type AchievementProgressQuery,
+  type PlayerBattleReportCenter,
   type PlayerBattleReplayQuery,
   findPlayerBattleReplaySummary,
   normalizePlayerProgressionSnapshot,
@@ -97,6 +99,8 @@ interface PlayerEventLogListApiPayload {
 interface PlayerAchievementListApiPayload {
   items?: Partial<PlayerAchievementProgress>[];
 }
+
+interface PlayerBattleReportCenterApiPayload extends Partial<PlayerBattleReportCenter> {}
 
 interface PlayerProgressionApiPayload extends Partial<PlayerProgressionSnapshot> {}
 
@@ -325,7 +329,8 @@ function asPlayerAccountProfile(
   roomId: string,
   source: PlayerAccountProfile["source"],
   account?: PlayerAccountApiPayload["account"],
-  fallbackDisplayName?: string | null
+  fallbackDisplayName?: string | null,
+  battleReportCenter?: PlayerBattleReportCenter
 ): PlayerAccountProfile {
   const accountProfile = normalizePlayerAccountReadModel({
     playerId,
@@ -334,6 +339,7 @@ function asPlayerAccountProfile(
     achievements: account?.achievements,
     recentEventLog: account?.recentEventLog,
     recentBattleReplays: account?.recentBattleReplays,
+    ...(battleReportCenter ? { battleReportCenter } : {}),
     loginId: normalizeLoginId(account?.loginId),
     credentialBoundAt: account?.credentialBoundAt,
     lastRoomId: account?.lastRoomId ?? roomId,
@@ -367,6 +373,31 @@ async function loadPlayerBattleReplaySummariesWithSession(
       clearCurrentAuthSession();
     }
     return queryPlayerBattleReplaySummaries(undefined, query);
+  }
+}
+
+async function loadPlayerBattleReportCenterWithSession(
+  playerId: string,
+  authSession: StoredAuthSession | null,
+  query?: PlayerBattleReplayQuery
+): Promise<PlayerBattleReportCenter> {
+  const queryString = toBattleReplayQueryString(query);
+  const endpoint = authSession?.token
+    ? `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/me/battle-reports${queryString}`
+    : `${resolvePlayerAccountApiBaseUrl()}/api/player-accounts/${encodeURIComponent(playerId)}/battle-reports${queryString}`;
+
+  const fallback = query ? { query } : undefined;
+
+  try {
+    const payload = (await fetchPlayerAccountJson(endpoint, {
+      ...(authSession?.token ? { headers: buildAuthHeaders(authSession.token) } : {})
+    }, authSession)) as PlayerBattleReportCenterApiPayload;
+    return normalizePlayerBattleReportCenter(payload, fallback);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message.startsWith("player_account_request_failed:401:")) {
+      clearCurrentAuthSession();
+    }
+    return normalizePlayerBattleReportCenter(undefined, fallback);
   }
 }
 
@@ -452,9 +483,12 @@ export async function loadPlayerAccountProfile(playerId: string, roomId: string)
       ...(authSession?.token ? { headers: buildAuthHeaders(authSession.token) } : {})
     }, authSession)) as PlayerAccountApiPayload;
     const resolvedPlayerId = payload.account?.playerId?.trim() || authSession?.playerId || playerId;
-    const recentBattleReplays = await loadPlayerBattleReplaySummariesWithSession(resolvedPlayerId, authSession ?? null);
+    const [recentBattleReplays, battleReportCenter] = await Promise.all([
+      loadPlayerBattleReplaySummariesWithSession(resolvedPlayerId, authSession ?? null),
+      loadPlayerBattleReportCenterWithSession(resolvedPlayerId, authSession ?? null)
+    ]);
     const profile = {
-      ...asPlayerAccountProfile(resolvedPlayerId, roomId, "remote", payload.account, storedDisplayName),
+      ...asPlayerAccountProfile(resolvedPlayerId, roomId, "remote", payload.account, storedDisplayName, battleReportCenter),
       recentBattleReplays
     };
 

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -249,6 +249,52 @@ test("account history renderer shows replay inspector placeholder before a repla
   assert.match(html, /选择一场最近战斗/);
 });
 
+test("account history renderer shows report-only detail when replay evidence is unavailable", () => {
+  const profile = createProfile();
+  profile.recentBattleReplays = [];
+  profile.battleReportCenter = {
+    latestReportId: "report-only",
+    items: [
+      {
+        id: "report-only",
+        replayId: "report-only",
+        roomId: "room-report",
+        playerId: "player-1",
+        battleId: "battle-report",
+        battleKind: "hero",
+        playerCamp: "defender",
+        heroId: "hero-1",
+        opponentHeroId: "hero-9",
+        startedAt: "2026-03-27T12:20:00.000Z",
+        completedAt: "2026-03-27T12:22:00.000Z",
+        result: "defeat",
+        turnCount: 3,
+        actionCount: 5,
+        rewards: [],
+        evidence: {
+          replay: "missing",
+          rewards: "missing"
+        }
+      }
+    ]
+  };
+
+  const html = renderBattleReplayInspector({
+    account: profile,
+    selectedReplayId: "report-only",
+    replay: null,
+    playback: null,
+    status: "当前仅同步到战报摘要，完整回放暂不可用。"
+  });
+
+  assert.match(html, /战报详情/);
+  assert.match(html, /失利 · PVP · 敌方英雄 hero-9/);
+  assert.match(html, /3 回合 · 5 步/);
+  assert.match(html, /回放证据 缺失/);
+  assert.match(html, /收益证据 缺失/);
+  assert.match(html, /完整回放暂不可用/);
+});
+
 test("account history renderer shows replay center empty state without blank content", () => {
   const profile = createProfile();
   profile.recentBattleReplays = [];

--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -101,6 +101,10 @@ test("player account helpers can build a local fallback profile", () => {
     ],
     recentEventLog: [],
     recentBattleReplays: [],
+    battleReportCenter: {
+      latestReportId: null,
+      items: []
+    },
     lastRoomId: "room-beta",
     source: "local"
   });
@@ -227,6 +231,7 @@ test("player account loader can overlay progression snapshot onto base account p
     assert.deepEqual(requestedUrls, [
       "http://127.0.0.1:2567/api/player-accounts/player-1",
       "http://127.0.0.1:2567/api/player-accounts/player-1/battle-replays",
+      "http://127.0.0.1:2567/api/player-accounts/player-1/battle-reports",
       "http://127.0.0.1:2567/api/player-accounts/player-1/progression?limit=2"
     ]);
     assert.equal(account.displayName, "暮火侦骑");
@@ -1175,6 +1180,43 @@ test("player account profile loader merges recent battle replays from the dedica
       );
     }
 
+    if (url.endsWith("/api/player-accounts/player-1/battle-reports")) {
+      return new Response(
+        JSON.stringify({
+          latestReportId: "replay-newer",
+          items: [
+            {
+              id: "replay-newer",
+              replayId: "replay-newer",
+              roomId: "room-alpha",
+              playerId: "player-1",
+              battleId: "battle-2",
+              battleKind: "neutral",
+              playerCamp: "attacker",
+              heroId: "hero-1",
+              neutralArmyId: "neutral-1",
+              startedAt: "2026-03-27T12:01:00.000Z",
+              completedAt: "2026-03-27T12:02:00.000Z",
+              result: "victory",
+              turnCount: 1,
+              actionCount: 0,
+              rewards: [],
+              evidence: {
+                replay: "available",
+                rewards: "missing"
+              }
+            }
+          ]
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
     return new Response(
       JSON.stringify({
         items: [
@@ -1236,10 +1278,13 @@ test("player account profile loader merges recent battle replays from the dedica
     const profile = await loadPlayerAccountProfile("player-1", "room-alpha");
     assert.deepEqual(requestedUrls, [
       "http://127.0.0.1:2567/api/player-accounts/player-1",
-      "http://127.0.0.1:2567/api/player-accounts/player-1/battle-replays"
+      "http://127.0.0.1:2567/api/player-accounts/player-1/battle-replays",
+      "http://127.0.0.1:2567/api/player-accounts/player-1/battle-reports"
     ]);
     assert.equal(profile.displayName, "霜火游侠");
     assert.deepEqual(profile.recentBattleReplays.map((replay) => replay.id), ["replay-newer"]);
+    assert.equal(profile.battleReportCenter?.latestReportId, "replay-newer");
+    assert.equal(profile.battleReportCenter?.items[0]?.evidence.rewards, "missing");
   } finally {
     Object.defineProperty(globalThis, "window", {
       configurable: true,

--- a/progress.md
+++ b/progress.md
@@ -557,6 +557,20 @@ Original prompt: 你先学习下当前项目并给出开发的计划
   - 可以继续把当前 H5 回放详情区往“独立回放中心页面”推进
   - 或者把同一套 replay detail / playback 交互补到 Cocos 端入口上。
 
+## H5 battle report center parity - 2026-04-03
+
+- 已把 H5 最近遭遇入口补齐到和 Cocos 一致的战报读模型：
+  - `apps/client/src/player-account.ts`
+    - 账号资料加载时现在会并行请求 `/battle-reports`
+    - H5 资料卡不再只依赖本地从 replay + event log 推导的 fallback，可直接消费服务端战报中心返回的证据状态
+  - `apps/client/src/main.ts`
+    - 选择最近遭遇时，如果该条目只有战报摘要而没有 replay 详情，H5 会保留选中态并进入“战报详情”视图，而不是退回空白提示
+  - `apps/client/src/account-history.ts`
+    - 回放详情区新增 report-only 展示：可查看结果、回合/步数、收益证据与“完整回放暂不可用”提示
+- 新增 / 更新测试：
+  - `apps/client/test/player-account-storage.test.ts`
+  - `apps/client/test/account-history-render.test.ts`
+
 ## H5 pixel asset bundle - 2026-03-28
 
 - 已切到 `#33 高质量像素美术资源集成` 分支：`codex/issue-33-h5-pixel-assets`


### PR DESCRIPTION
## Summary
- load the dedicated `/battle-reports` read model when H5 account data refreshes
- keep recent encounter selection usable even when only battle-report evidence is available
- add H5 rendering/tests for report-only battle detail states and note the slice in progress tracking

## Validation
- `node --import tsx --test ./apps/client/test/account-history-render.test.ts`
- `node --import tsx <<'NODE'` loader validation snippet for `loadPlayerAccountProfile` battle-report fetch path
- `npm run typecheck:client:h5` *(fails on pre-existing `packages/shared/src/content-pack-validation.ts(109,37)` and `(113,37)` TS18046 errors)*
- `node --import tsx --test ./apps/client/test/player-account-storage.test.ts` *(still has pre-existing auth-session expectation failures unrelated to this slice; the updated `player account profile loader merges recent battle replays from the dedicated endpoint` assertion passes)*

Closes #724