### PR TITLE
fix(ci): surface coverage threshold failures

### DIFF
--- a/.github/workflows/phase1-candidate-rehearsal.yml
+++ b/.github/workflows/phase1-candidate-rehearsal.yml
@@ -67,6 +67,13 @@ jobs:
           npm run stress:rooms:reconnect-soak -- \
             --artifact-path "${RUNNER_TEMP}/release-readiness/colyseus-reconnect-soak-summary-${GITHUB_SHA}.json"
 
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          if [[ -f .coverage/summary.md ]]; then
+            cat .coverage/summary.md >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
       - name: Upload V8 coverage artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/ci-v8-coverage.ts
+++ b/scripts/ci-v8-coverage.ts
@@ -256,9 +256,21 @@ export function printFailureReport(summaries: CoverageSummary[]): void {
     return;
   }
 
+  printGithubAnnotations(failedSummaries);
   process.stderr.write("\nCoverage threshold failures:\n");
   for (const line of renderFailureSection(failedSummaries).slice(2)) {
     process.stderr.write(`${line}\n`);
+  }
+}
+
+export function printGithubAnnotations(failedSummaries: CoverageSummary[]): void {
+  if (process.env.GITHUB_ACTIONS !== "true") {
+    return;
+  }
+
+  for (const { suite, failures } of failedSummaries) {
+    const details = failures.map((failure) => formatFailure(failure)).join("; ");
+    process.stderr.write(`::error title=Coverage threshold failure::${suite.name}: ${details}\n`);
   }
 }
 

--- a/scripts/test/ci-v8-coverage.test.ts
+++ b/scripts/test/ci-v8-coverage.test.ts
@@ -7,6 +7,7 @@ import {
   buildCoverageSummary,
   coverageRoot,
   parseCoverageMetrics,
+  printGithubAnnotations,
   renderFailureSection,
   writeSummary,
 } from "../ci-v8-coverage.ts";
@@ -140,4 +141,48 @@ test("writeSummary includes overall status and explicit threshold failures", asy
       functions: 80.69,
     },
   });
+});
+
+test("printGithubAnnotations emits GitHub Actions error annotations per failed scope", () => {
+  const originalGithubActions = process.env.GITHUB_ACTIONS;
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  let output = "";
+
+  process.env.GITHUB_ACTIONS = "true";
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    output += chunk.toString();
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    printGithubAnnotations([
+      buildCoverageSummary(
+        {
+          name: "server",
+          include: "apps/server/src/**/*.ts",
+          lineThreshold: 75,
+          branchThreshold: 65,
+          functionThreshold: 75,
+          tests: ["apps/server/test/**/*.test.ts"],
+        },
+        {
+          lines: 77.25,
+          branches: 64.99,
+          functions: 74.5,
+        },
+      ),
+    ]);
+  } finally {
+    process.stderr.write = originalWrite;
+    if (originalGithubActions === undefined) {
+      delete process.env.GITHUB_ACTIONS;
+    } else {
+      process.env.GITHUB_ACTIONS = originalGithubActions;
+    }
+  }
+
+  assert.match(
+    output,
+    /::error title=Coverage threshold failure::server: branches 64\.99% below 65% floor; functions 74\.50% below 75% floor/,
+  );
 });


### PR DESCRIPTION
## Summary
- surface per-scope coverage threshold misses as GitHub Actions error annotations so branch/function regressions are obvious without digging through logs
- publish `.coverage/summary.md` in the phase 1 candidate rehearsal workflow even when coverage fails
- keep the change narrow with focused coverage-script test coverage

## Testing
- node --import tsx --test ./scripts/test/ci-v8-coverage.test.ts

Closes #725
