### PR TITLE
feat(cocos): clarify battle settlement handoff

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -104,7 +104,7 @@ export function buildBattleTransitionFeedback(
 
     const settlement = buildBattleSettlementSummary(previousBattle, update, heroId);
     return {
-      title: previousBattle?.defenderHeroId ? "PVP 结算同步中" : "战斗收束",
+      title: previousBattle?.defenderHeroId ? "PVP 结果回写中" : "战果回写中",
       detail: settlement.detail,
       badge: "SETTLE",
       tone: "neutral"
@@ -263,7 +263,7 @@ function buildBattleSettlementSummary(
     encounterStatus,
     fieldStatus,
     rewards.length > 0 ? rewards.join(" / ") : null,
-    previousBattle?.defenderHeroId ? "准备回写 PVP 世界态" : "准备返回世界地图"
+    buildSettlementHandoffLabel(previousBattle, resolved)
   ].filter((part): part is string => Boolean(part));
 
   return {
@@ -409,6 +409,17 @@ function describeSettlementEncounterState(
   return didHoldField
     ? `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇`
     : `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在房间地图上`;
+}
+
+function buildSettlementHandoffLabel(
+  previousBattle: BattleState | null,
+  resolved: BattleResolvedView | null
+): string {
+  if (previousBattle?.defenderHeroId) {
+    return resolved ? "房间胜负已确认，等待回写 PVP 世界态" : "等待房间确认胜负并回写 PVP 世界态";
+  }
+
+  return resolved ? "奖励已确认，准备返回世界地图" : "等待世界地图确认奖励、占位与结算结果";
 }
 
 function didHeroWinResolution(resolved: BattleResolvedView | null, heroId: string | null): boolean | null {

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
@@ -327,7 +327,7 @@ function resolvePresentationLabel(moment: CocosBattlePresentationMoment, fallbac
     case "active_skill":
       return "技能结算";
     case "result_settlement":
-      return "战斗收束";
+      return "结果回写中";
     case "result_victory":
       return "战斗胜利";
     case "result_defeat":

--- a/apps/cocos-client/test/cocos-battle-feedback.test.ts
+++ b/apps/cocos-client/test/cocos-battle-feedback.test.ts
@@ -220,7 +220,8 @@ test("battle feedback summarizes action, progress, and outcome", () => {
   );
   assert.equal(unsettledFeedback?.tone, "neutral");
   assert.equal(unsettledFeedback?.badge, "SETTLE");
-  assert.match(unsettledFeedback?.detail ?? "", /准备返回世界地图/);
+  assert.equal(unsettledFeedback?.title, "战果回写中");
+  assert.match(unsettledFeedback?.detail ?? "", /等待世界地图确认奖励、占位与结算结果/);
 });
 
 test("battle feedback calls out pvp encounter identity and settlement state", () => {
@@ -261,9 +262,9 @@ test("battle feedback calls out pvp encounter identity and settlement state", ()
     "hero-1",
     pvpBattle
   );
-  assert.equal(pvpSettlement?.title, "PVP 结算同步中");
+  assert.equal(pvpSettlement?.title, "PVP 结果回写中");
   assert.match(pvpSettlement?.detail ?? "", /PVP 结算：对手 hero-9/);
-  assert.match(pvpSettlement?.detail ?? "", /准备回写 PVP 世界态/);
+  assert.match(pvpSettlement?.detail ?? "", /等待房间确认胜负并回写 PVP 世界态/);
 });
 
 test("battle transition feedback summarizes settlement rewards and field state", () => {

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -149,8 +149,8 @@ test("buildBattlePanelViewModel keeps neutral settlement in the battle result sh
     selectedTargetId: null,
     actionPending: false,
     feedback: {
-      title: "战斗收束",
-      detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图",
+      title: "战果回写中",
+      detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 等待世界地图确认奖励、占位与结算结果",
       badge: "SETTLE",
       tone: "neutral"
     },
@@ -158,14 +158,14 @@ test("buildBattlePanelViewModel keeps neutral settlement in the battle result sh
       battleId: "battle-1",
       phase: "resolution",
       moment: "result_settlement",
-      label: "战斗收束",
-      detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图",
+      label: "结果回写中",
+      detail: "PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 等待世界地图确认奖励、占位与结算结果",
       badge: "SETTLE",
       tone: "neutral",
       result: null,
       summaryLines: [
         "反馈层：动画 待机",
-        "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 准备返回世界地图"
+        "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 1 队 · 等待世界地图确认奖励、占位与结算结果"
       ],
       feedbackLayer: {
         animation: "idle",
@@ -178,7 +178,7 @@ test("buildBattlePanelViewModel keeps neutral settlement in the battle result sh
 
   assert.equal(view.idle, true);
   assert.equal(view.title, "战斗结算");
-  assert.equal(view.summaryLines[0], "战斗收束");
+  assert.equal(view.summaryLines[0], "结果回写中");
 });
 
 test("buildBattlePanelViewModel shows an explicit settlement recovery path while reconnecting", () => {

--- a/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
+++ b/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
@@ -256,7 +256,7 @@ test("battle presentation controller formalizes command, casualty, and result fl
   assertState(controller.getState(), {
     phase: "resolution",
     moment: "result_settlement",
-    label: "战斗收束",
+    label: "结果回写中",
     tone: "neutral",
     result: null
   });

--- a/apps/cocos-client/test/cocos-battle-presentation.test.ts
+++ b/apps/cocos-client/test/cocos-battle-presentation.test.ts
@@ -219,7 +219,7 @@ test("battle presentation plan formalizes command, enter, impact, and resolution
   assert.equal(resolutionPlan.transition?.copy.badge, "VICTORY");
   assert.deepEqual(resolutionPlan.state.summaryLines.slice(0, 2), [
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
-    "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 准备返回世界地图"
+    "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 奖励已确认，准备返回世界地图"
   ]);
 
   const unsettledResolutionPlan = buildBattlePresentationPlan(
@@ -232,8 +232,10 @@ test("battle presentation plan formalizes command, enter, impact, and resolution
   );
   assert.equal(unsettledResolutionPlan.phase, "resolution");
   assert.equal(unsettledResolutionPlan.moment, "result_settlement");
+  assert.equal(unsettledResolutionPlan.state.label, "结果回写中");
   assert.equal(unsettledResolutionPlan.cue, null);
   assert.equal(unsettledResolutionPlan.animation, "idle");
   assert.equal(unsettledResolutionPlan.transition, null);
   assert.equal(unsettledResolutionPlan.feedback?.badge, "SETTLE");
+  assert.equal(unsettledResolutionPlan.feedback?.title, "战果回写中");
 });

--- a/docs/cocos-phase1-presentation-signoff.md
+++ b/docs/cocos-phase1-presentation-signoff.md
@@ -93,6 +93,19 @@ The generated candidate artifact already fills this header. Review and correct i
 - Blocking items, if any:
 - Controlled-test gaps, if any:
 
+## Battle Journey Manual Verification
+
+Use this short path when reviewing the battle presentation slice for a candidate:
+
+1. Start from the same candidate revision used for the RC snapshot and launch the main Cocos client flow.
+2. Enter one encounter from the world map and capture the battle-entry overlay showing terrain/context plus encounter identity.
+3. Execute at least one command that produces visible impact feedback, then capture the battle panel while the command/impact labels and badges are on screen.
+4. Finish the encounter and capture the settlement shell twice if possible:
+   first on the pending handoff state (`结果回写中` or `PVP 结果回写中`), then on the final victory/defeat result once the authoritative event arrives.
+5. Confirm the settlement copy makes the world handoff explicit without looking at logs:
+   `等待世界地图确认奖励、占位与结算结果` for PVE, or `等待房间确认胜负并回写 PVP 世界态` for PVP.
+6. Attach the screenshots/video to the candidate RC bundle and classify any remaining placeholder or fallback item in the generated sign-off artifact.
+
 ## Exit Standard
 
 For Phase 1 exit, this checklist should end in one of two states:


### PR DESCRIPTION
## Summary
- tighten the Cocos battle settlement copy so pending handoff reads as explicit world-sync/result-writeback instead of generic fallback wording
- keep the result shell reviewer-legible across PVE and PVP settlement states
- add a short manual verification path for the battle journey in the Phase 1 presentation sign-off doc

## Validation
- `node --import tsx --test apps/cocos-client/test/cocos-battle-feedback.test.ts apps/cocos-client/test/cocos-battle-presentation.test.ts apps/cocos-client/test/cocos-battle-presentation-controller.test.ts apps/cocos-client/test/cocos-battle-panel-model.test.ts`

Advances #714.