### PR TITLE
docs(release): require same-candidate audit in same-revision evidence flow

### DIFF
--- a/docs/same-revision-release-evidence-runbook.md
+++ b/docs/same-revision-release-evidence-runbook.md
@@ -46,6 +46,7 @@ Rule of thumb: automated summaries may reuse lower-level artifacts from the same
 | `npm run release:readiness:snapshot` | Required | Required |
 | Manual evidence owner ledger | Required | Required |
 | `npm run release:gate:summary -- --target-surface <surface>` | Required | Required |
+| `npm run release:same-candidate:evidence-audit -- --candidate <candidate> --candidate-revision <git-sha>` | Required | Required |
 | `npm run release:readiness:dashboard -- --candidate <candidate> --candidate-revision <git-sha>` | Required | Required |
 | `npm run release:cocos-rc:bundle` | Required for the primary Cocos client evidence packet | Required |
 | `npm run validate:wechat-rc` or `npm run release:wechat:rehearsal` | Optional | Required |
@@ -197,7 +198,21 @@ npm run release:gate:summary -- \
 
 Add `--reconnect-soak <path>` when reconnect evidence is part of the packet and you want the summary pinned to the exact soak artifact instead of directory discovery.
 
-9. Run the candidate-level dashboard as the last consistency check.
+9. Run the same-candidate evidence audit against the pinned artifact family.
+
+```bash
+npm run release:same-candidate:evidence-audit -- \
+  --candidate <candidate-name> \
+  --candidate-revision <git-sha> \
+  --snapshot <snapshot-json> \
+  --release-gate-summary <release-gate-summary-json> \
+  --cocos-rc-bundle <cocos-rc-bundle-json> \
+  --manual-evidence-ledger <owner-ledger-md>
+```
+
+Keep the emitted JSON / Markdown pair with the rest of the packet. This is the explicit same-revision stitch check for the maintainer flow: it should fail closed when the snapshot, gate summary, Cocos RC bundle, or owner ledger drift to another revision, candidate name, linked snapshot path, or freshness window.
+
+10. Run the candidate-level dashboard as the final reviewer summary.
 
 ```bash
 npm run release:readiness:dashboard -- \
@@ -208,7 +223,7 @@ npm run release:readiness:dashboard -- \
 
 Add `--server-url <url>` when you want the dashboard to probe the live candidate environment in the same pass.
 
-10. Build the maintainer-facing decision packet when the underlying evidence is coherent.
+11. Build the maintainer-facing decision packet when the underlying evidence is coherent.
 
 ```bash
 npm run release:go-no-go-packet -- \
@@ -225,6 +240,7 @@ Before calling release `go`, confirm the packet contains these same-revision art
 - one release readiness snapshot
 - one manual evidence owner ledger
 - one release gate summary for the selected target surface
+- one same-candidate evidence audit report for the pinned candidate/revision pair
 - one Cocos RC bundle plus paired checklist and blockers files
 - for WeChat releases: one WeChat candidate summary, one RC validation report, one smoke report, and one runtime observability sign-off
 - when reconnect scope applies: one reconnect soak artifact
@@ -238,6 +254,7 @@ Release is `go` only when all required evidence for the selected surface is true
 
 - no required snapshot check is failed or still pending
 - no required gate-summary dimension is failed, blocked, or stale
+- the same-candidate evidence audit is present and passing for the pinned artifact family
 - the owner ledger has no required row left in `pending` or `in-review`
 - the Cocos RC bundle, checklist, and blockers files match the same candidate revision
 - WeChat release calls also have current smoke, manual-review, and runtime observability evidence


### PR DESCRIPTION
## Summary
- add the same-candidate evidence audit to the same-revision release-evidence runbook required-steps matrix
- insert the audit into the assembly sequence before the final dashboard and go/no-go packet
- include the audit report in the minimum artifact packet and go/no-go criteria

## Validation
- `npm run check:wechat-build`
- `npm run test:same-candidate-evidence-audit` *(fails on `origin/main` as well: the unchanged test expects a missing Cocos bundle, but the current script reports `candidate_mismatch` and `revision_mismatch`)*

Closes #730