### PR TITLE
feat(cocos): harden battle panel presentation context

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -93,7 +93,11 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
     const presentationSummary = state.recovery
       ? state.recovery.summaryLines
       : state.presentationState
-        ? [state.presentationState.label, ...state.presentationState.summaryLines]
+        ? [
+            state.presentationState.label,
+            ...buildBattleResultContextLines(state.presentationState),
+            ...state.presentationState.summaryLines
+          ]
         : ["当前没有战斗。"];
     return {
       title: state.recovery ? "结算恢复" : state.presentationState?.phase === "resolution" ? "战斗结算" : "战斗面板",
@@ -185,14 +189,16 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
     : [];
   const skillSummaryLines = activeUnit ? buildSkillSummaryLines(activeUnit) : [];
   const statusSummary = activeUnit ? buildStatusSummary(activeUnit) : "无异常";
+  const stage = buildBattleStageView(state.update, battle);
+  const presentationLines = buildBattlePresentationContextLines(state.update, battle, state.presentationState, canAct, state.actionPending);
 
   return {
-    title: state.presentationState?.phase === "enter" ? "战斗展开" : "战斗面板",
-    stage: buildBattleStageView(state.update, battle),
+    title: resolveBattlePanelTitle(state.presentationState),
+    stage,
     feedback: state.feedback,
     summaryLines: [
       `${battle.id} · 第 ${battle.round} 回合`,
-      `流程：${state.presentationState?.label ?? "战斗进行中"}`,
+      ...presentationLines,
       ...(state.presentationState?.summaryLines ?? []),
       `阵营：${controlLabel}`,
       `阶段：${turnLabel}`,
@@ -209,6 +215,21 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
     actions,
     idle: false
   };
+}
+
+function resolveBattlePanelTitle(presentationState: CocosBattlePresentationState | null): string {
+  switch (presentationState?.phase) {
+    case "enter":
+      return "战斗展开";
+    case "command":
+      return "战斗指令";
+    case "impact":
+      return "战斗反馈";
+    case "resolution":
+      return "战斗结算";
+    default:
+      return "战斗面板";
+  }
 }
 
 export function buildBattlePanelSections(state: BattlePanelInput): BattlePanelSections {
@@ -238,6 +259,59 @@ function buildBattleStageView(update: SessionUpdate | null, battle: BattleState)
     subtitle: subtitleParts.join(" · "),
     badge: battle.defenderHeroId ? "PVP" : battle.neutralArmyId ? "PVE" : "BATTLE"
   };
+}
+
+function buildBattlePresentationContextLines(
+  update: SessionUpdate | null,
+  battle: BattleState,
+  presentationState: CocosBattlePresentationState | null,
+  canAct: boolean,
+  actionPending: boolean
+): string[] {
+  const roomId = update?.world.meta.roomId ?? "unknown-room";
+  return [
+    `会话：${roomId}/${battle.id} · ${formatEncounterLabel(battle)}`,
+    `表现：${presentationState?.badge ?? "LIVE"} · ${presentationState?.label ?? "战斗进行中"}`,
+    `下一步：${resolveBattleNextStepLine(presentationState, canAct, actionPending)}`
+  ];
+}
+
+function buildBattleResultContextLines(presentationState: CocosBattlePresentationState): string[] {
+  const battleId = presentationState.battleId ? `会话：${presentationState.battleId} · ${presentationState.badge}` : null;
+  return [battleId, `下一步：${resolveBattleResultNextStepLine(presentationState)}`].filter((line): line is string => Boolean(line));
+}
+
+function resolveBattleNextStepLine(
+  presentationState: CocosBattlePresentationState | null,
+  canAct: boolean,
+  actionPending: boolean
+): string {
+  if (actionPending) {
+    return "等待权威结算当前指令";
+  }
+
+  switch (presentationState?.phase) {
+    case "enter":
+      return "确认遭遇信息后选择目标并下达首个指令";
+    case "command":
+      return "等待本次指令返回伤害、状态或技能结果";
+    case "impact":
+      return canAct ? "确认受击结果后继续选择目标或技能" : "等待下一行动方接管回合";
+    case "resolution":
+      return resolveBattleResultNextStepLine(presentationState);
+    default:
+      return canAct ? "选择目标并下达指令" : "等待对方行动或权威同步";
+  }
+}
+
+function resolveBattleResultNextStepLine(presentationState: CocosBattlePresentationState): string {
+  if (presentationState.result === "victory") {
+    return "返回世界地图并继续推进当前回合";
+  }
+  if (presentationState.result === "defeat") {
+    return "等待世界地图回写后调整部队与下一行动";
+  }
+  return "等待世界地图确认奖励、占位与最终结算";
 }
 
 function resolveEncounterPosition(update: SessionUpdate | null, battle: BattleState): Vec2 | null {

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -135,6 +135,8 @@ test("buildBattlePanelViewModel surfaces settlement and presentation layer summa
   assert.equal(view.title, "战斗结算");
   assert.deepEqual(view.summaryLines, [
     "战斗胜利",
+    "会话：battle-1 · WIN",
+    "下一步：返回世界地图并继续推进当前回合",
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
     "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
     "战利品：金币 +12"
@@ -179,6 +181,8 @@ test("buildBattlePanelViewModel keeps neutral settlement in the battle result sh
   assert.equal(view.idle, true);
   assert.equal(view.title, "战斗结算");
   assert.equal(view.summaryLines[0], "结果回写中");
+  assert.equal(view.summaryLines[1], "会话：battle-1 · SETTLE");
+  assert.equal(view.summaryLines[2], "下一步：等待世界地图确认奖励、占位与最终结算");
 });
 
 test("buildBattlePanelViewModel shows an explicit settlement recovery path while reconnecting", () => {
@@ -230,6 +234,104 @@ test("buildBattlePanelViewModel shows an explicit settlement recovery path while
     "最近结算：战斗胜利",
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
     "战利品：金币 +12"
+  ]);
+});
+
+test("buildBattlePanelViewModel surfaces reviewer-facing session and next-step context during live battle impact", () => {
+  const update = createBaseUpdate();
+  update.world.meta.roomId = "room-battle";
+  update.battle = {
+    id: "battle-1",
+    round: 2,
+    lanes: 1,
+    activeUnitId: "hero-1-stack",
+    turnOrder: ["hero-1-stack", "neutral-1-stack"],
+    units: {
+      "hero-1-stack": {
+        id: "hero-1-stack",
+        templateId: "hero_guard_basic",
+        camp: "attacker",
+        lane: 0,
+        stackName: "Guard",
+        initiative: 7,
+        attack: 4,
+        defense: 4,
+        minDamage: 1,
+        maxDamage: 2,
+        count: 12,
+        currentHp: 10,
+        maxHp: 10,
+        hasRetaliated: false,
+        defending: false,
+        skills: [],
+        statusEffects: []
+      },
+      "neutral-1-stack": {
+        id: "neutral-1-stack",
+        templateId: "orc_warrior",
+        camp: "defender",
+        lane: 0,
+        stackName: "Orc",
+        initiative: 5,
+        attack: 3,
+        defense: 3,
+        minDamage: 1,
+        maxDamage: 3,
+        count: 5,
+        currentHp: 4,
+        maxHp: 9,
+        hasRetaliated: true,
+        defending: false,
+        skills: [],
+        statusEffects: []
+      }
+    },
+    environment: [],
+    log: ["Guard 对 Orc 造成 7 伤害"],
+    rng: { seed: 1, cursor: 0 },
+    worldHeroId: "hero-1",
+    neutralArmyId: "neutral-1",
+    encounterPosition: { x: 0, y: 0 }
+  };
+
+  const view = buildBattlePanelViewModel({
+    update,
+    timelineEntries: [],
+    controlledCamp: "attacker",
+    selectedTargetId: "neutral-1-stack",
+    actionPending: false,
+    feedback: {
+      title: "Orc 受到打击",
+      detail: "Guard 对 Orc 造成 7 伤害",
+      badge: "HIT",
+      tone: "hit"
+    },
+    presentationState: {
+      battleId: "battle-1",
+      phase: "impact",
+      moment: "impact_hit",
+      label: "命中反馈",
+      detail: "Guard 对 Orc 造成 7 伤害",
+      badge: "HIT",
+      tone: "hit",
+      result: null,
+      summaryLines: ["反馈层：动画 受击 / 音效 受击"],
+      feedbackLayer: {
+        animation: "hit",
+        cue: "hit",
+        transition: null,
+        durationMs: null
+      }
+    }
+  });
+
+  assert.equal(view.idle, false);
+  assert.equal(view.title, "战斗反馈");
+  assert.deepEqual(view.summaryLines.slice(0, 4), [
+    "battle-1 · 第 2 回合",
+    "会话：room-battle/battle-1 · 中立遭遇",
+    "表现：HIT · 命中反馈",
+    "下一步：确认受击结果后继续选择目标或技能"
   ]);
 });
 
@@ -343,11 +445,14 @@ test("buildBattlePanelViewModel enables attack actions on the player's turn", ()
     subtitle: "坐标 (0,0) · 1 陷阱",
     badge: "PVE"
   });
-  assert.equal(view.summaryLines[2], "阵营：我方先攻");
-  assert.equal(view.summaryLines[3], "阶段：轮到我方");
-  assert.equal(view.summaryLines[5], "技能1：投矛射击[敌/就绪] / 护甲术[自/就绪]");
-  assert.equal(view.summaryLines[6], "状态：无异常");
-  assert.equal(view.summaryLines[7], "环境1：1线 捕兽夹陷阱 · 2伤 · 1次");
+  assert.equal(view.summaryLines[1], "会话：room-alpha/battle-hero-1-vs-neutral-1 · 中立遭遇");
+  assert.equal(view.summaryLines[2], "表现：LIVE · 战斗进行中");
+  assert.equal(view.summaryLines[3], "下一步：选择目标并下达指令");
+  assert.equal(view.summaryLines[4], "阵营：我方先攻");
+  assert.equal(view.summaryLines[5], "阶段：轮到我方");
+  assert.equal(view.summaryLines[7], "技能1：投矛射击[敌/就绪] / 护甲术[自/就绪]");
+  assert.equal(view.summaryLines[8], "状态：无异常");
+  assert.equal(view.summaryLines[9], "环境1：1线 捕兽夹陷阱 · 2伤 · 1次");
   assert.equal(view.orderLines[0], "行动顺序");
   assert.equal(view.orderLines[1], "> Guard x12");
   assert.equal(view.orderLines[2], "2. Orc x8 (DEF/RET)");
@@ -470,10 +575,13 @@ test("buildBattlePanelViewModel disables commands during enemy turns", () => {
     subtitle: "坐标 (0,0) · 无额外障碍",
     badge: "PVP"
   });
-  assert.equal(view.summaryLines[2], "阵营：我方先攻");
-  assert.equal(view.summaryLines[3], "阶段：轮到对方");
-  assert.equal(view.summaryLines[5], "技能：普通攻击");
-  assert.equal(view.summaryLines[6], "状态：无异常");
+  assert.equal(view.summaryLines[1], "会话：room-alpha/battle-hero-1-vs-hero-2 · 英雄对决");
+  assert.equal(view.summaryLines[2], "表现：LIVE · 战斗进行中");
+  assert.equal(view.summaryLines[3], "下一步：等待对方行动或权威同步");
+  assert.equal(view.summaryLines[4], "阵营：我方先攻");
+  assert.equal(view.summaryLines[5], "阶段：轮到对方");
+  assert.equal(view.summaryLines[7], "技能：普通攻击");
+  assert.equal(view.summaryLines[8], "状态：无异常");
   assert.equal(view.orderLines[1], "> Raider x11");
   assert.equal(view.orderItems[0]!.badge, "行动中");
   assert.equal(view.orderItems[1]!.badge, "2");


### PR DESCRIPTION
## Summary
- surface explicit battle-panel context for reviewers with session, presentation badge, and next-step guidance during live battle flow
- keep settlement shells legible after battle exit by showing result context and follow-up guidance without relying on logs
- cover the new battle-panel baseline with focused Cocos battle-panel model tests

## Validation
- `node --import tsx --test ./apps/cocos-client/test/cocos-battle-panel-model.test.ts ./apps/cocos-client/test/cocos-battle-panel.test.ts ./apps/cocos-client/test/cocos-battle-presentation.test.ts ./apps/cocos-client/test/cocos-battle-presentation-controller.test.ts`
- `npm run check:wechat-build`
- `npm run typecheck:cocos` currently fails on pre-existing unrelated issues in `apps/cocos-client/assets/scripts/cocos-lobby.ts` and `packages/shared/src/content-pack-validation.ts`

## Manual Verification
1. Start the Cocos primary client journey and enter one battle from the world map.
2. Confirm the battle panel now shows encounter session context, the current presentation badge/label, and a clear next-step line during entry or impact.
3. Resolve the battle and confirm the settlement shell retains result context plus next-step guidance after the battle payload clears.

Refs #714
