### PR TITLE
docs: inventory phase 1 presentation fallbacks

### DIFF
--- a/docs/cocos-phase1-presentation-signoff.md
+++ b/docs/cocos-phase1-presentation-signoff.md
@@ -8,6 +8,8 @@ It does not replace the broader RC snapshot, checklist, or blocker log. It narro
 
 For the primary-client battle path, reviewers should treat `encounter entry -> command/impact feedback -> result settlement` as one continuous presentation surface. Evidence is incomplete if it only shows the map shell or only the final settlement shell.
 
+The maintained baseline for current in-repo debt lives in the inventory below. Candidate-scoped `cocos-presentation-signoff-<candidate>-<short-sha>.json/.md` artifacts should start from this baseline, then tighten each row to the exact status for that candidate instead of inventing a fresh checklist each time.
+
 ## When To Use This
 
 Use this checklist whenever a candidate is being reviewed for:
@@ -37,7 +39,7 @@ That command now emits:
 
 Those files are the attachable per-candidate sign-off record. This doc defines how to review and, if needed, edit the generated checklist before the candidate is widened beyond controlled internal testing.
 
-When the sign-off conclusion changes, mirror the same owner, revision, timestamp, artifact path, and follow-up summary into the manual evidence owner ledger. The ledger should show whether `cocos-presentation-signoff` is still pending or stale without reopening the full artifact.
+When the sign-off conclusion changes, mirror the same owner, revision, timestamp, artifact path, and follow-up summary into the manual evidence owner ledger. The ledger should show whether `cocos-presentation-signoff` is still pending or stale without reopening the full artifact. Start from the maintained inventory in this doc, then record any candidate-specific deviation or closure in the generated artifact and ledger.
 
 ## Sign-Off Rules
 
@@ -47,6 +49,24 @@ When the sign-off conclusion changes, mirror the same owner, revision, timestamp
 - `fail` means the candidate is not presentation-ready for wider external evaluation.
 - Phase 1 exit is not signed off until no row remains ambiguous or undocumented.
 - If `cocos-presentation-readiness` or RC evidence reports a new substitution, add it to the candidate artifact rather than burying it in free-form notes.
+
+## Maintained Phase 1 Fallback Inventory
+
+This table is the single maintained inventory of Cocos presentation fallbacks still allowed during Phase 1 hardening. The current repo-backed baseline remains:
+
+- `cocos-presentation-readiness`: `像素 占位`, `音频 混合 2/8`, `动画 回退 2/2`
+- `configs/cocos-presentation.json`: `explore` / `battle` music plus `attack` / `skill` / `hit` / `level_up` cues are still `placeholder`, while `hero_guard_basic` and `wolf_pack` still ship as `deliveryMode: fallback`
+
+Unless a candidate-specific artifact proves otherwise, treat every row below as `waived-controlled-test`.
+
+| Surface | Current allowed fallback item | Current status | Owner | Next action |
+| --- | --- | --- | --- | --- |
+| Battle entry / transition | `VeilBattleTransition` still uses the lightweight overlay shell with retained placeholder terrain preview assets instead of final authored transition art/motion. Keep encounter identity, terrain/context, and chips visible in RC capture. | `waived-controlled-test` | `client-lead` | Refresh the battle-entry capture in the candidate sign-off artifact and replace the overlay chrome/terrain preview when production transition art is ready. |
+| Impact / resolution feedback | Battle command, hit, skill, and resolution beats are copy-first badge/label feedback from `cocos-battle-feedback` and diagnostics, not a final authored VFX-heavy impact pass. | `waived-controlled-test` | `client-lead` | Keep one command/impact capture in the candidate bundle and upgrade the impact pass only when it can preserve the same readable command/result summary. |
+| Settlement shell / authoritative handoff | The pending handoff shell (`结果回写中` / `PVP 结果回写中`) is intentionally kept as a neutral fallback state while authority resolves the final result; it is acceptable only if the same review also captures the final victory/defeat settlement. | `waived-controlled-test` | `client-lead` | Keep paired pending-handoff and final-settlement evidence in the candidate artifact; do not sign off a candidate that only shows the neutral shell. |
+| Placeholder art | `cocos-presentation-readiness` still reports pixel art as `placeholder`, so terrain / hero / unit / building presentation remains a controlled-test placeholder surface rather than production art. | `waived-controlled-test` | `client-lead` | Re-run `npm run check:cocos-release-readiness`, attach the updated readiness summary, and only close this row when the readiness output is no longer placeholder. |
+| Audio substitutions | Audio remains mixed: `victory` and `defeat` are production, while `explore`, `battle`, `attack`, `skill`, `hit`, and `level_up` still use placeholder asset/synth substitution paths. | `waived-controlled-test` | `client-lead` | Keep device or preview notes on audible substitutions in the candidate sign-off and update `configs/cocos-presentation.json` as cues are replaced with production assets. |
+| Animation fallback modes | Animation delivery is still fallback-only for `hero_guard_basic` and `wolf_pack`; no current profile ships as `clip` or `spine`. | `waived-controlled-test` | `client-lead` | Track each template conversion in the candidate sign-off and only close this row after the config moves the shipped profiles off `deliveryMode: fallback`. |
 
 ## Blocking Vs Controlled-Test Gaps
 

--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -1,6 +1,6 @@
 # Primary Cocos Client Delivery Checklist
 
-This checklist is the maintained delivery baseline for the primary client at [`apps/cocos-client`](/home/gpt/project/ProjectVeil/apps/cocos-client). It keeps the release path small and stable by splitting regression validation into one runtime-journey guard, two automated artifact audits, and a short manual sign-off list. For remaining placeholder or fallback presentation debt, use the canonical reviewer checklist in [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) rather than tracking those items ad hoc in PR comments.
+This checklist is the maintained delivery baseline for the primary client at [`apps/cocos-client`](/home/gpt/project/ProjectVeil/apps/cocos-client). It keeps the release path small and stable by splitting regression validation into one runtime-journey guard, two automated artifact audits, and a short manual sign-off list. For remaining placeholder or fallback presentation debt, use the canonical reviewer checklist and maintained fallback inventory in [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) rather than tracking those items ad hoc in PR comments.
 
 ## Primary Client Regression Gate
 
@@ -84,7 +84,7 @@ Keep these manual items short and attach evidence through the existing release e
 1. Complete the current candidate snapshot with `npm run release:cocos-rc:snapshot`.
 2. Refresh the primary-client diagnostic artifact with `npm run release:cocos:primary-diagnostics`.
 3. Run `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface <surface>` and keep the generated `cocos-presentation-signoff-<candidate>-<short-sha>.json/.md` with the rest of the candidate bundle.
-   Review that artifact using [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md), and classify each presentation row as `pass`, `waived-controlled-test`, or `fail` so reviewers can distinguish functional RC pass from presentation risk.
+   Review that artifact using [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md), starting from the maintained Phase 1 fallback inventory there, and classify each presentation row as `pass`, `waived-controlled-test`, or `fail` so reviewers can distinguish functional RC pass from presentation risk.
    The same candidate evidence should explicitly show one polished battle journey covering encounter entry, at least one command/impact beat, and a stable victory or defeat settlement state before reconnect review.
 4. Copy and fill the RC checklist/template files in [`docs/release-evidence`](./release-evidence/), reusing the generated presentation sign-off artifact instead of free-form PR notes.
 5. Record any open risk in the blocker template before sign-off.

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -24,7 +24,7 @@
 - Phase 1 发布就绪看板：`npm run release:readiness:dashboard`
 - Cocos RC 证据快照：`npm run release:cocos-rc:snapshot`
 - Cocos 发布证据模板：`docs/cocos-release-evidence-template.md`
-- Cocos Phase 1 占位 / fallback 表现签核：`docs/cocos-phase1-presentation-signoff.md`
+- Cocos Phase 1 占位 / fallback 表现签核（含 maintained fallback inventory）：`docs/cocos-phase1-presentation-signoff.md`
 - Cocos / WeChat RC 检查清单模板：`docs/release-evidence/cocos-wechat-rc-checklist.template.md`
 - Cocos / WeChat RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
 - WeChat runtime observability 签核模板：`docs/release-evidence/wechat-runtime-observability-signoff.template.md`
@@ -120,7 +120,7 @@
 
 `P1 follow-up`
 
-- [ ] Cocos 脚本层的展示配置、图集、动画 fallback 与资源清单在每次 release candidate 上重新核对一次，并通过 [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) 明确记录为已关闭、可接受非阻断，或仍然阻断。
+- [ ] Cocos 脚本层的展示配置、图集、动画 fallback 与资源清单在每次 release candidate 上重新核对一次，并以 [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) 的 maintained fallback inventory 为基线，明确记录为已关闭、可接受非阻断，或仍然阻断。
 - [ ] H5 与 Cocos 对同一 shared 规则的表现差异有记录，避免“规则一致但表现不一致”。
 
 建议证据：

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -38,7 +38,7 @@
 - 统一断线恢复门禁：`docs/reconnect-smoke-gate.md`
 - 统一 Cocos RC candidate bundle：`npm run release:cocos-rc:bundle`（会自动先跑 `npm run release:cocos:primary-journey-evidence`）
 - Primary client delivery checklist：`docs/cocos-primary-client-delivery.md`
-- Cocos Phase 1 占位 / fallback 表现签核：`docs/cocos-phase1-presentation-signoff.md`
+- Cocos Phase 1 占位 / fallback 表现签核（含当前允许 fallback inventory）：`docs/cocos-phase1-presentation-signoff.md`
 - WeChat runtime observability 签核：`docs/wechat-runtime-observability-signoff.md`
 - WeChat runtime observability 签核模板：`docs/release-evidence/wechat-runtime-observability-signoff.template.md`
 - Primary client delivery audit：`npm run audit:cocos-primary-delivery -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--expected-revision <git-sha>]`


### PR DESCRIPTION
## Summary
- add a maintained Phase 1 Cocos presentation fallback inventory to the sign-off doc
- seed the inventory with current battle, settlement, art, audio, and animation fallback items plus status/owner/next action
- wire the inventory into the existing sign-off, delivery, release-readiness, and WeChat release docs

Closes #739