### PR TITLE
Add canonical Cocos journey smoke evidence command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,9 +250,12 @@ jobs:
             --markdown-output "${RUNNER_TEMP}/release-readiness/cocos-primary-delivery-audit-${GITHUB_SHA}.md" \
             --github-step-summary "${GITHUB_STEP_SUMMARY}"
 
-      - name: Run primary Cocos client journey regression gate
+      - name: Run canonical primary Cocos journey smoke
         if: always() && github.event_name == 'pull_request' && steps.cocos-release-packaging.outputs.touched == 'true'
-        run: npm run test:cocos:primary-journey
+        run: |
+          npm run smoke:cocos:canonical-journey -- \
+            --output "${RUNNER_TEMP}/release-readiness/cocos-primary-journey-smoke-${GITHUB_SHA}.json" \
+            --markdown-output "${RUNNER_TEMP}/release-readiness/cocos-primary-journey-smoke-${GITHUB_SHA}.md"
 
       - name: Capture primary Cocos diagnostics evidence
         if: always() && github.event_name == 'pull_request' && steps.cocos-release-packaging.outputs.touched == 'true'
@@ -287,12 +290,14 @@ jobs:
           changed_paths="${RUNNER_TEMP}/release-readiness/cocos-release-packaging-changed-paths-${GITHUB_SHA}.txt"
           audit_json="${RUNNER_TEMP}/release-readiness/cocos-primary-delivery-audit-${GITHUB_SHA}.json"
           audit_md="${RUNNER_TEMP}/release-readiness/cocos-primary-delivery-audit-${GITHUB_SHA}.md"
+          smoke_json="${RUNNER_TEMP}/release-readiness/cocos-primary-journey-smoke-${GITHUB_SHA}.json"
+          smoke_md="${RUNNER_TEMP}/release-readiness/cocos-primary-journey-smoke-${GITHUB_SHA}.md"
           diagnostics_json="${RUNNER_TEMP}/release-readiness/cocos-primary-client-diagnostics-${GITHUB_SHA}.json"
           diagnostics_md="${RUNNER_TEMP}/release-readiness/cocos-primary-client-diagnostics-${GITHUB_SHA}.md"
           summary_path="${BUNDLE_DIR}/SUMMARY.md"
 
           cp "${changed_paths}" "${BUNDLE_DIR}/changed-paths.txt"
-          for candidate in "${audit_json}" "${audit_md}" "${diagnostics_json}" "${diagnostics_md}"; do
+          for candidate in "${audit_json}" "${audit_md}" "${smoke_json}" "${smoke_md}" "${diagnostics_json}" "${diagnostics_md}"; do
             if [[ -f "${candidate}" ]]; then
               cp "${candidate}" "${BUNDLE_DIR}/"
             fi
@@ -311,6 +316,11 @@ jobs:
               echo "- Delivery audit: present"
             else
               echo "- Delivery audit: missing. Regressed command: \`npm run audit:cocos-primary-delivery -- --output-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir \\\"\${WECHAT_RELEASE_ARTIFACTS_DIR}\\\" --expect-exported-runtime --expected-revision \\\"\${GITHUB_SHA}\\\"\`"
+            fi
+            if [[ -f "${smoke_json}" && -f "${smoke_md}" ]]; then
+              echo "- Canonical Cocos journey smoke: present"
+            else
+              echo "- Canonical Cocos journey smoke: missing. Regressed command: \`npm run smoke:cocos:canonical-journey -- --output <json> --markdown-output <md>\`"
             fi
             if [[ -f "${diagnostics_json}" && -f "${diagnostics_md}" ]]; then
               echo "- Primary-client diagnostics: present"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ npm run dev:client:h5
 - 终端逻辑演示：`npm run demo:flow`
 - 主客户端入口说明：`npm run client:primary`
 - Cocos 主客户端类型检查：`npm run typecheck:client`
+- Cocos canonical journey smoke：`npm run smoke:cocos:canonical-journey`（输出 `artifacts/release-readiness/` 下的结构化 JSON / Markdown / milestone diagnostics，并在失败时打印具体 stage）
 - 微信小游戏模板刷新：`npm run prepare:wechat-build`
 - 微信小游戏 CI 同款校验：`npm run check:wechat-build`
 - 发布就绪快照：`npm run release:readiness:snapshot`

--- a/apps/cocos-client/test/release-readiness-snapshot.test.ts
+++ b/apps/cocos-client/test/release-readiness-snapshot.test.ts
@@ -145,7 +145,7 @@ test("release-readiness snapshot CLI includes the Cocos primary journey as a req
   assert.equal(primaryJourneyCheck.required, true);
   assert.equal(primaryJourneyCheck.kind, "automated");
   assert.equal(primaryJourneyCheck.status, "pending");
-  assert.equal(primaryJourneyCheck.command, "npm run test:cocos:primary-journey");
+  assert.equal(primaryJourneyCheck.command, "npm run smoke:cocos:canonical-journey");
   assert.equal(primaryJourneyCheck.notes, "Skipped command execution via --no-run.");
   assert.deepEqual(primaryJourneyCheck.evidence, []);
   assert.equal(primaryJourneyCheck.source, "default");

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -256,4 +256,4 @@
 当前仍未完成：
 
 - 短信 / 独立验证码供应商通道
-- 更完整的前端自动化回归矩阵；当前已补上 `npm run test:cocos:primary-journey` 这条 primary Cocos client 的账号会话 -> Lobby -> 首次进房自动化切片，但更广的交互矩阵仍待继续扩充
+- 更完整的前端自动化回归矩阵；当前已补上 `npm run smoke:cocos:canonical-journey` 这条 primary Cocos client 的账号会话 -> Lobby -> 首次进房自动化切片，但更广的交互矩阵仍待继续扩充

--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -7,10 +7,10 @@ This checklist is the maintained delivery baseline for the primary client at [`a
 Run the account -> lobby -> room-entry automation slice before packaging or signing off the primary client:
 
 ```bash
-npm run test:cocos:primary-journey
+npm run smoke:cocos:canonical-journey
 ```
 
-The command exercises the Cocos `VeilRoot` launch path in CI-friendly node-based automation, reuses the existing runtime/session harness, and records artifact-rich assertion payloads when it fails so contributors can tell apart:
+The command exercises the Cocos `VeilRoot` launch path in CI-friendly node-based automation, reuses the existing runtime/session harness, and emits JSON + Markdown evidence under `artifacts/release-readiness/`. On failure it prints the failed stage plus the exact diagnostic artifact path so contributors can tell apart:
 
 - lobby/bootstrap environment issues
 - stale or unavailable auth session bootstrap
@@ -43,7 +43,7 @@ The command emits a concise JSON plus Markdown summary under `artifacts/release-
 
 For PRs that touch Cocos release-packaging surfaces, GitHub Actions now treats this audit as part of the merge gate. The same run also executes:
 
-- `npm run test:cocos:primary-journey`
+- `npm run smoke:cocos:canonical-journey`
 - `npm run release:cocos:primary-diagnostics`
 
 CI then uploads a single reviewer-facing artifact named `cocos-release-packaging-evidence-<sha>`. Its `SUMMARY.md` calls out whether the delivery audit or primary-client diagnostics evidence was missing so regressions are actionable without digging through raw logs first.
@@ -93,7 +93,7 @@ Keep these manual items short and attach evidence through the existing release e
 ## Related Commands
 
 - Export template refresh: `npm run prepare:wechat-build`
-- Primary client journey regression: `npm run test:cocos:primary-journey`
+- Primary client canonical smoke evidence: `npm run smoke:cocos:canonical-journey`
 - Export validation: `npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
 - Package artifact: `npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime --source-revision <git-sha>`
 - RC artifact validation: `npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> --expected-revision <git-sha>`

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -126,7 +126,7 @@
 建议证据：
 
 - `npm test`
-- `npm run test:cocos:primary-journey`
+- `npm run smoke:cocos:canonical-journey`
 - `npm run check:cocos-release-readiness`
 - `npm run release:cocos-rc:snapshot -- --output <snapshot-path>`
 - `docs/cocos-phase1-presentation-signoff.md`

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -186,7 +186,7 @@ Sample output:
       "id": "cocos-primary-journey",
       "kind": "automated",
       "status": "passed",
-      "command": "npm run test:cocos:primary-journey"
+      "command": "npm run smoke:cocos:canonical-journey"
     },
     {
       "id": "wechat-device-smoke",

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -13,7 +13,7 @@
 - 当前自动化可把已校验导出目录打成确定性的 `tar.gz` 发布包，并输出 sidecar 元数据 `codex.wechat.package.json`
   - sidecar 会记录归档文件名、SHA-256、字节数、导出目录来源，以及归档内文件清单摘要
 - 当前自动化还会运行 `npm run audit:cocos-primary-delivery`，把 primary client 的导出校验与 artifact 校验收口成一份简明 JSON / Markdown 摘要
-- 当 PR 改动 `apps/cocos-client/**`、`scripts/cocos-*`、`scripts/*release*`、`docs/cocos-*` 或微信小游戏打包路径时，CI 会额外运行 `npm run test:cocos:primary-journey` 与 `npm run release:cocos:primary-diagnostics`
+- 当 PR 改动 `apps/cocos-client/**`、`scripts/cocos-*`、`scripts/*release*`、`docs/cocos-*` 或微信小游戏打包路径时，CI 会额外运行 `npm run smoke:cocos:canonical-journey` 与 `npm run release:cocos:primary-diagnostics`
   - 结果会统一上传为 GitHub Actions artifact `cocos-release-packaging-evidence-<sha>`，其中固定包含 `SUMMARY.md`，并在成功时附带 primary delivery audit 与 primary-client diagnostics 的 JSON / Markdown 证据
   - 若任一证据缺失，`SUMMARY.md` 会明确指出缺失的是 delivery audit 还是 diagnostics artifact，并给出对应回归命令
 - CI 会把上述归档与 sidecar 元数据作为 GitHub Actions artifact `wechat-release-<sha>` 上传，供提审前下载、留档与回滚追溯

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "release:cocos-rc:snapshot": "node --import tsx ./scripts/cocos-release-candidate-snapshot.ts",
     "release:cocos-rc:bundle": "node --import tsx ./scripts/cocos-rc-evidence-bundle.ts",
     "release:cocos:primary-journey-evidence": "node --import tsx ./scripts/cocos-primary-client-journey-evidence.ts",
+    "smoke:cocos:canonical-journey": "node --import tsx ./scripts/cocos-primary-client-journey-evidence.ts",
     "release:cocos:primary-diagnostics": "node --import tsx ./scripts/cocos-primary-client-diagnostic-snapshots.ts",
     "audit:cocos-primary-delivery": "node --import tsx ./scripts/audit-cocos-primary-delivery.ts",
     "check:wechat-build": "node --import tsx ./scripts/prepare-wechat-minigame-build.ts --check && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/build-templates/wechatgame && node --import tsx ./scripts/validate-wechat-minigame-build.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime && node --import tsx ./scripts/prepare-wechat-minigame-release.ts --output-dir apps/cocos-client/test/fixtures/wechatgame-export --expect-exported-runtime --check",

--- a/scripts/cocos-primary-client-journey-evidence.ts
+++ b/scripts/cocos-primary-client-journey-evidence.ts
@@ -914,6 +914,12 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
 
     writeJson(jsonOutputPath, artifact);
     writeText(markdownOutputPath, renderMarkdown(artifact));
+    console.error(`Primary-client journey smoke failed at stage: ${currentStep}`);
+    console.error(`Journey evidence JSON: ${toRepoRelative(jsonOutputPath)}`);
+    console.error(`Journey evidence Markdown: ${toRepoRelative(markdownOutputPath)}`);
+    if (failedArtifactPath) {
+      console.error(`Stage diagnostics artifact: ${failedArtifactPath}`);
+    }
     throw error;
   } finally {
     if (root) {

--- a/scripts/release-readiness-snapshot.ts
+++ b/scripts/release-readiness-snapshot.ts
@@ -123,7 +123,7 @@ const AUTOMATED_CHECKS: Array<Pick<ReleaseReadinessCheck, "id" | "title" | "comm
   {
     id: "cocos-primary-journey",
     title: "Cocos primary journey regression",
-    command: "npm run test:cocos:primary-journey",
+    command: "npm run smoke:cocos:canonical-journey",
     required: true
   },
   {


### PR DESCRIPTION
## Summary
- add `npm run smoke:cocos:canonical-journey` as the canonical Cocos journey smoke entrypoint backed by the existing evidence exporter
- print stage-specific failure signals plus JSON/Markdown artifact paths when the smoke fails
- wire the canonical command into release-readiness docs and the PR Cocos packaging evidence flow

## Validation
- node --import tsx --test ./scripts/test/cocos-primary-client-journey-evidence.test.ts
- node --import tsx --test ./apps/cocos-client/test/release-readiness-snapshot.test.ts
- npm run smoke:cocos:canonical-journey -- --output artifacts/release-readiness/codex-issue-738-canonical-smoke.json --markdown-output artifacts/release-readiness/codex-issue-738-canonical-smoke.md --owner codex

Closes #738