### PR TITLE
feat(cocos): formalize battle presentation readiness

### DIFF
--- a/apps/cocos-client/README.md
+++ b/apps/cocos-client/README.md
@@ -85,7 +85,8 @@
 - `assets/scripts/cocos-presentation-readiness.ts`
   - 负责汇总像素图、资源音频和动画交付状态
   - 当前会统一输出 `表现 像素 ... · 音频 ... · 动画 ...` 这条摘要，供 Lobby 画册和 HUD 状态卡复用
-  - 也会给出 `待替换 正式像素美术 / 真实 BGM-SFX / Spine Skeleton` 这类后续收口提示
+  - 同时会把 `战斗流程 正式 4/4` 作为 battle journey 基线写入 readiness，明确 `进场 / 指令 / 受击 / 结算` 已在 copy/state 层正式化，剩余风险只继续记在资产层
+  - 也会给出 `战斗流程 正式 4/4 · 待替换 正式像素美术 / 真实 BGM-SFX / Spine Skeleton` 这类后续收口提示
   - 发布门禁可通过 `npm run check:cocos-release-readiness` 强制要求表现资源达到 release-ready，再串接微信小游戏构建校验
 - `assets/scripts/cocos-audio-runtime.ts`
   - 轻量合成音频运行时

--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -270,6 +270,7 @@ function buildBattlePresentationContextLines(
 ): string[] {
   const roomId = update?.world.meta.roomId ?? "unknown-room";
   return [
+    `流程：${formatBattleJourneyLine(presentationState)}`,
     `会话：${roomId}/${battle.id} · ${formatEncounterLabel(battle)}`,
     `表现：${presentationState?.badge ?? "LIVE"} · ${presentationState?.label ?? "战斗进行中"}`,
     `下一步：${resolveBattleNextStepLine(presentationState, canAct, actionPending)}`
@@ -278,7 +279,31 @@ function buildBattlePresentationContextLines(
 
 function buildBattleResultContextLines(presentationState: CocosBattlePresentationState): string[] {
   const battleId = presentationState.battleId ? `会话：${presentationState.battleId} · ${presentationState.badge}` : null;
-  return [battleId, `下一步：${resolveBattleResultNextStepLine(presentationState)}`].filter((line): line is string => Boolean(line));
+  return [
+    `流程：${formatBattleJourneyLine(presentationState)}`,
+    battleId,
+    `下一步：${resolveBattleResultNextStepLine(presentationState)}`
+  ].filter((line): line is string => Boolean(line));
+}
+
+function formatBattleJourneyLine(presentationState: CocosBattlePresentationState | null): string {
+  const activePhase = resolveBattleJourneyPhaseLabel(presentationState);
+  return `进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 ${activePhase}`;
+}
+
+function resolveBattleJourneyPhaseLabel(presentationState: CocosBattlePresentationState | null): string {
+  switch (presentationState?.phase) {
+    case "enter":
+      return "进场确认";
+    case "command":
+      return "指令下达";
+    case "impact":
+      return "受击反馈";
+    case "resolution":
+      return "战果结算";
+    default:
+      return "现场回合";
+  }
 }
 
 function resolveBattleNextStepLine(

--- a/apps/cocos-client/assets/scripts/cocos-presentation-readiness.ts
+++ b/apps/cocos-client/assets/scripts/cocos-presentation-readiness.ts
@@ -24,12 +24,17 @@ export interface CocosAnimationReadinessSection extends CocosPresentationReadine
   deliveryModes: Record<CocosAnimationDeliveryMode, number>;
 }
 
+export interface CocosBattleJourneyReadinessSection extends CocosPresentationReadinessSection {
+  verifiedStages: Array<"entry" | "command" | "impact" | "resolution">;
+}
+
 export interface CocosPresentationReadiness {
   summary: string;
   nextStep: string;
   pixel: CocosPresentationReadinessSection;
   audio: CocosPresentationReadinessSection;
   animation: CocosAnimationReadinessSection;
+  battleJourney: CocosBattleJourneyReadinessSection;
 }
 
 export interface CocosPresentationReleaseGate {
@@ -130,25 +135,46 @@ function buildAnimationReadiness(): CocosAnimationReadinessSection {
   };
 }
 
-function buildNextStep(pixel: CocosPresentationReadinessSection, audio: CocosPresentationReadinessSection, animation: CocosAnimationReadinessSection): string {
+function buildBattleJourneyReadiness(): CocosBattleJourneyReadinessSection {
+  const verifiedStages: CocosBattleJourneyReadinessSection["verifiedStages"] = ["entry", "command", "impact", "resolution"];
+  return {
+    label: "战斗流程",
+    stage: "production",
+    headline: "战斗主流程已正式化 · 进场 / 指令 / 受击 / 结算",
+    detail: "Battle panel 与 transition feedback 已明确暴露阶段标签、badge、下一步提示与中性结算回写壳，剩余占位风险转入资产层追踪",
+    shortLabel: "战斗流程 正式 4/4",
+    verifiedStages
+  };
+}
+
+function buildNextStep(
+  pixel: CocosPresentationReadinessSection,
+  audio: CocosPresentationReadinessSection,
+  animation: CocosAnimationReadinessSection,
+  battleJourney: CocosBattleJourneyReadinessSection
+): string {
   const blockers = getCocosPresentationReleaseGate({
     pixel,
     audio,
     animation
   }).blockers;
-  return blockers.length > 0 ? `待替换 ${blockers.join(" / ")}` : "已达到正式表现资源阶段";
+  return blockers.length > 0
+    ? `${battleJourney.shortLabel} · 待替换 ${blockers.join(" / ")}`
+    : "战斗流程与表现资源均已达到正式阶段";
 }
 
 export function buildCocosPresentationReadiness(): CocosPresentationReadiness {
   const pixel = buildPixelReadiness();
   const audio = buildAudioReadiness();
   const animation = buildAnimationReadiness();
+  const battleJourney = buildBattleJourneyReadiness();
   return {
     pixel,
     audio,
     animation,
+    battleJourney,
     summary: formatPresentationReadinessSummary({ pixel, audio, animation }),
-    nextStep: buildNextStep(pixel, audio, animation)
+    nextStep: buildNextStep(pixel, audio, animation, battleJourney)
   };
 }
 

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -135,6 +135,7 @@ test("buildBattlePanelViewModel surfaces settlement and presentation layer summa
   assert.equal(view.title, "战斗结算");
   assert.deepEqual(view.summaryLines, [
     "战斗胜利",
+    "流程：进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 战果结算",
     "会话：battle-1 · WIN",
     "下一步：返回世界地图并继续推进当前回合",
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
@@ -181,8 +182,9 @@ test("buildBattlePanelViewModel keeps neutral settlement in the battle result sh
   assert.equal(view.idle, true);
   assert.equal(view.title, "战斗结算");
   assert.equal(view.summaryLines[0], "结果回写中");
-  assert.equal(view.summaryLines[1], "会话：battle-1 · SETTLE");
-  assert.equal(view.summaryLines[2], "下一步：等待世界地图确认奖励、占位与最终结算");
+  assert.equal(view.summaryLines[1], "流程：进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 战果结算");
+  assert.equal(view.summaryLines[2], "会话：battle-1 · SETTLE");
+  assert.equal(view.summaryLines[3], "下一步：等待世界地图确认奖励、占位与最终结算");
 });
 
 test("buildBattlePanelViewModel shows an explicit settlement recovery path while reconnecting", () => {
@@ -329,10 +331,11 @@ test("buildBattlePanelViewModel surfaces reviewer-facing session and next-step c
   assert.equal(view.title, "战斗反馈");
   assert.deepEqual(view.summaryLines.slice(0, 4), [
     "battle-1 · 第 2 回合",
+    "流程：进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 受击反馈",
     "会话：room-battle/battle-1 · 中立遭遇",
-    "表现：HIT · 命中反馈",
-    "下一步：确认受击结果后继续选择目标或技能"
+    "表现：HIT · 命中反馈"
   ]);
+  assert.equal(view.summaryLines[4], "下一步：确认受击结果后继续选择目标或技能");
 });
 
 test("buildBattlePanelViewModel enables attack actions on the player's turn", () => {
@@ -445,14 +448,15 @@ test("buildBattlePanelViewModel enables attack actions on the player's turn", ()
     subtitle: "坐标 (0,0) · 1 陷阱",
     badge: "PVE"
   });
-  assert.equal(view.summaryLines[1], "会话：room-alpha/battle-hero-1-vs-neutral-1 · 中立遭遇");
-  assert.equal(view.summaryLines[2], "表现：LIVE · 战斗进行中");
-  assert.equal(view.summaryLines[3], "下一步：选择目标并下达指令");
-  assert.equal(view.summaryLines[4], "阵营：我方先攻");
-  assert.equal(view.summaryLines[5], "阶段：轮到我方");
-  assert.equal(view.summaryLines[7], "技能1：投矛射击[敌/就绪] / 护甲术[自/就绪]");
-  assert.equal(view.summaryLines[8], "状态：无异常");
-  assert.equal(view.summaryLines[9], "环境1：1线 捕兽夹陷阱 · 2伤 · 1次");
+  assert.equal(view.summaryLines[1], "流程：进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 现场回合");
+  assert.equal(view.summaryLines[2], "会话：room-alpha/battle-hero-1-vs-neutral-1 · 中立遭遇");
+  assert.equal(view.summaryLines[3], "表现：LIVE · 战斗进行中");
+  assert.equal(view.summaryLines[4], "下一步：选择目标并下达指令");
+  assert.equal(view.summaryLines[5], "阵营：我方先攻");
+  assert.equal(view.summaryLines[6], "阶段：轮到我方");
+  assert.equal(view.summaryLines[8], "技能1：投矛射击[敌/就绪] / 护甲术[自/就绪]");
+  assert.equal(view.summaryLines[9], "状态：无异常");
+  assert.equal(view.summaryLines[10], "环境1：1线 捕兽夹陷阱 · 2伤 · 1次");
   assert.equal(view.orderLines[0], "行动顺序");
   assert.equal(view.orderLines[1], "> Guard x12");
   assert.equal(view.orderLines[2], "2. Orc x8 (DEF/RET)");
@@ -575,13 +579,14 @@ test("buildBattlePanelViewModel disables commands during enemy turns", () => {
     subtitle: "坐标 (0,0) · 无额外障碍",
     badge: "PVP"
   });
-  assert.equal(view.summaryLines[1], "会话：room-alpha/battle-hero-1-vs-hero-2 · 英雄对决");
-  assert.equal(view.summaryLines[2], "表现：LIVE · 战斗进行中");
-  assert.equal(view.summaryLines[3], "下一步：等待对方行动或权威同步");
-  assert.equal(view.summaryLines[4], "阵营：我方先攻");
-  assert.equal(view.summaryLines[5], "阶段：轮到对方");
-  assert.equal(view.summaryLines[7], "技能：普通攻击");
-  assert.equal(view.summaryLines[8], "状态：无异常");
+  assert.equal(view.summaryLines[1], "流程：进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 现场回合");
+  assert.equal(view.summaryLines[2], "会话：room-alpha/battle-hero-1-vs-hero-2 · 英雄对决");
+  assert.equal(view.summaryLines[3], "表现：LIVE · 战斗进行中");
+  assert.equal(view.summaryLines[4], "下一步：等待对方行动或权威同步");
+  assert.equal(view.summaryLines[5], "阵营：我方先攻");
+  assert.equal(view.summaryLines[6], "阶段：轮到对方");
+  assert.equal(view.summaryLines[8], "技能：普通攻击");
+  assert.equal(view.summaryLines[9], "状态：无异常");
   assert.equal(view.orderLines[1], "> Raider x11");
   assert.equal(view.orderItems[0]!.badge, "行动中");
   assert.equal(view.orderItems[1]!.badge, "2");

--- a/apps/cocos-client/test/cocos-presentation-readiness.test.ts
+++ b/apps/cocos-client/test/cocos-presentation-readiness.test.ts
@@ -9,6 +9,9 @@ import {
 
 test("presentation readiness summarizes placeholder pixel, audio and fallback animation coverage", () => {
   const readiness = buildCocosPresentationReadiness();
+  assert.equal(readiness.battleJourney.stage, "production");
+  assert.deepEqual(readiness.battleJourney.verifiedStages, ["entry", "command", "impact", "resolution"]);
+  assert.match(readiness.battleJourney.detail, /中性结算回写壳/);
   assert.equal(readiness.pixel.stage, "placeholder");
   assert.match(readiness.pixel.headline, /5 地形 \/ 4 英雄 \/ 10 单位 \/ 5 建筑/);
   assert.equal(readiness.audio.stage, "mixed");
@@ -16,6 +19,7 @@ test("presentation readiness summarizes placeholder pixel, audio and fallback an
   assert.match(readiness.audio.detail, /2 正式 \/ 6 占位/);
   assert.equal(readiness.animation.deliveryModes.fallback, 2);
   assert.equal(readiness.animation.deliveryModes.spine, 0);
+  assert.match(readiness.nextStep, /战斗流程 正式 4\/4/);
   assert.match(readiness.nextStep, /正式像素美术/);
   assert.match(readiness.nextStep, /Spine Skeleton/);
   assert.deepEqual(getCocosPresentationReleaseGate(readiness), {

--- a/docs/cocos-phase1-presentation-signoff.md
+++ b/docs/cocos-phase1-presentation-signoff.md
@@ -55,6 +55,7 @@ When the sign-off conclusion changes, mirror the same owner, revision, timestamp
 This table is the single maintained inventory of Cocos presentation fallbacks still allowed during Phase 1 hardening. The current repo-backed baseline remains:
 
 - `cocos-presentation-readiness`: `像素 占位`, `音频 混合 2/8`, `动画 回退 2/2`
+- `cocos-presentation-readiness`: `战斗流程 正式 4/4`，表示 battle journey 的 `进场 / 指令 / 受击 / 结算` 已在状态/copy 层正式化，剩余 debt 继续按资产 fallback 管理
 - `configs/cocos-presentation.json`: `explore` / `battle` music plus `attack` / `skill` / `hit` / `level_up` cues are still `placeholder`, while `hero_guard_basic` and `wolf_pack` still ship as `deliveryMode: fallback`
 
 Unless a candidate-specific artifact proves otherwise, treat every row below as `waived-controlled-test`.


### PR DESCRIPTION
## Summary
- add an explicit battle-journey phase line to the Cocos battle panel so entry, command, impact, and settlement stay legible in-panel
- teach cocos presentation readiness to report the battle journey as formalized separately from remaining asset placeholders/fallbacks
- update reviewer docs and tests to lock the new baseline and manual verification framing

## Verification
- node --import tsx --test apps/cocos-client/test/cocos-battle-panel-model.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-presentation-readiness.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-battle-presentation.test.ts

Closes #714