### PR TITLE
Add direct H5 main.ts boot regression coverage

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -7,7 +7,6 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="/src/main-browser.ts"></script>
   </body>
   </html>
-

--- a/apps/client/src/main-browser.ts
+++ b/apps/client/src/main-browser.ts
@@ -1,0 +1,2 @@
+import "./styles.css";
+import "./main";

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,4 +1,3 @@
-import "./styles.css";
 import {
   buildAchievementUiItems,
   groupAchievementUiItems,
@@ -140,9 +139,11 @@ declare global {
     render_diagnostic_snapshot_to_text?: () => string;
     advanceTime?: (ms: number) => Promise<void>;
   }
+
+  var __PROJECT_VEIL_MAIN_SKIP_AUTO_BOOT__: boolean | undefined;
 }
 
-const DEV_DIAGNOSTICS_ENABLED = import.meta.env.DEV;
+const DEV_DIAGNOSTICS_ENABLED = Boolean(import.meta.env?.DEV);
 
 interface BattleModalState {
   visible: boolean;
@@ -263,6 +264,35 @@ interface ScheduledUiTask {
   runAt: number;
   callback: () => void;
   canceled: boolean;
+}
+
+interface StartMainH5BootOverrides {
+  state?: AppState;
+  shouldBootGame?: boolean;
+  queryPlayerId?: string;
+  roomId?: string;
+  playerId?: string;
+  bindKeyboardShortcuts?: () => void;
+  render?: () => void;
+  syncCurrentAuthSession?: typeof syncCurrentAuthSession;
+  refreshLobbyRoomList?: typeof refreshLobbyRoomList;
+  logoutGuestSession?: typeof logoutGuestSession;
+  readStoredSessionReplay?: typeof readStoredSessionReplay;
+  applyReplayedUpdate?: typeof applyReplayedUpdate;
+  getSession?: typeof getSession;
+  applyUpdate?: typeof applyUpdate;
+  loadAccountProfileWithProgression?: typeof loadAccountProfileWithProgression;
+  loadPlayerAccountSessions?: typeof loadPlayerAccountSessions;
+  readStoredAuthSession?: typeof readStoredAuthSession;
+  clearReplayDetail?: typeof clearReplayDetail;
+  onPlayerAccountProfileSynced?: () => void;
+  window?: Window;
+  devDiagnosticsEnabled?: boolean;
+  renderGameToText?: typeof renderGameToText;
+  exportDiagnosticSnapshot?: typeof exportDiagnosticSnapshot;
+  renderDiagnosticSnapshotToText?: typeof renderDiagnosticSnapshotToText;
+  advanceUiTime?: typeof advanceUiTime;
+  launchMainH5AppImpl?: typeof launchMainH5App;
 }
 
 const state: AppState = {
@@ -5118,34 +5148,47 @@ async function onBindAccountProfile(): Promise<void> {
   }
 }
 
-launchMainH5App({
-  state,
-  shouldBootGame,
-  queryPlayerId,
-  roomId,
-  playerId,
-  bindKeyboardShortcuts,
-  render,
-  syncCurrentAuthSession,
-  refreshLobbyRoomList,
-  logoutGuestSession,
-  readStoredSessionReplay,
-  applyReplayedUpdate,
-  getSession,
-  applyUpdate,
-  loadAccountProfileWithProgression,
-  loadPlayerAccountSessions,
-  readStoredAuthSession,
-  clearReplayDetail,
-  onPlayerAccountProfileSynced: () => {
-    syncAchievementToastFeed(state.account, false);
-    hasHydratedAchievementFeed = true;
-    state.achievementPanel.items = state.account.achievements;
-  },
-  window,
-  devDiagnosticsEnabled: DEV_DIAGNOSTICS_ENABLED,
-  renderGameToText,
-  exportDiagnosticSnapshot,
-  renderDiagnosticSnapshotToText,
-  advanceUiTime
-});
+// Keep the entrypoint boot wiring in one place so node-level tests can import
+// `main.ts` directly, override the volatile runtime edges, and execute the real
+// H5 boot pipeline without the browser-only auto-start.
+export function startMainH5Boot(overrides: StartMainH5BootOverrides = {}): void {
+  const runtimeState = overrides.state ?? state;
+
+  (overrides.launchMainH5AppImpl ?? launchMainH5App)({
+    state: runtimeState,
+    shouldBootGame: overrides.shouldBootGame ?? shouldBootGame,
+    queryPlayerId: overrides.queryPlayerId ?? queryPlayerId,
+    roomId: overrides.roomId ?? roomId,
+    playerId: overrides.playerId ?? playerId,
+    bindKeyboardShortcuts: overrides.bindKeyboardShortcuts ?? bindKeyboardShortcuts,
+    render: overrides.render ?? render,
+    syncCurrentAuthSession: overrides.syncCurrentAuthSession ?? syncCurrentAuthSession,
+    refreshLobbyRoomList: overrides.refreshLobbyRoomList ?? refreshLobbyRoomList,
+    logoutGuestSession: overrides.logoutGuestSession ?? logoutGuestSession,
+    readStoredSessionReplay: overrides.readStoredSessionReplay ?? readStoredSessionReplay,
+    applyReplayedUpdate: overrides.applyReplayedUpdate ?? applyReplayedUpdate,
+    getSession: overrides.getSession ?? getSession,
+    applyUpdate: overrides.applyUpdate ?? applyUpdate,
+    loadAccountProfileWithProgression: overrides.loadAccountProfileWithProgression ?? loadAccountProfileWithProgression,
+    loadPlayerAccountSessions: overrides.loadPlayerAccountSessions ?? loadPlayerAccountSessions,
+    readStoredAuthSession: overrides.readStoredAuthSession ?? readStoredAuthSession,
+    clearReplayDetail: overrides.clearReplayDetail ?? clearReplayDetail,
+    onPlayerAccountProfileSynced:
+      overrides.onPlayerAccountProfileSynced ??
+      (() => {
+        syncAchievementToastFeed(runtimeState.account, false);
+        hasHydratedAchievementFeed = true;
+        runtimeState.achievementPanel.items = runtimeState.account.achievements;
+      }),
+    window: overrides.window ?? window,
+    devDiagnosticsEnabled: overrides.devDiagnosticsEnabled ?? DEV_DIAGNOSTICS_ENABLED,
+    renderGameToText: overrides.renderGameToText ?? renderGameToText,
+    exportDiagnosticSnapshot: overrides.exportDiagnosticSnapshot ?? exportDiagnosticSnapshot,
+    renderDiagnosticSnapshotToText: overrides.renderDiagnosticSnapshotToText ?? renderDiagnosticSnapshotToText,
+    advanceUiTime: overrides.advanceUiTime ?? advanceUiTime
+  });
+}
+
+if (!globalThis.__PROJECT_VEIL_MAIN_SKIP_AUTO_BOOT__) {
+  startMainH5Boot();
+}

--- a/apps/client/test/main.test.ts
+++ b/apps/client/test/main.test.ts
@@ -1,0 +1,359 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { SessionUpdate } from "../src/local-session";
+import type { StoredAuthSession } from "../src/auth-session";
+import { createFallbackPlayerAccountProfile } from "../src/player-account";
+
+function createSessionUpdate(reason: string): SessionUpdate {
+  return {
+    world: {
+      meta: {
+        roomId: "room-alpha",
+        seed: 1001,
+        day: 2
+      },
+      map: {
+        width: 1,
+        height: 1,
+        tiles: []
+      },
+      ownHeroes: [],
+      visibleHeroes: [],
+      resources: {
+        gold: 50,
+        wood: 3,
+        ore: 1
+      },
+      playerId: "player-auth"
+    },
+    battle: null,
+    events: [],
+    movementPlan: null,
+    reachableTiles: [{ x: 0, y: 0 }],
+    reason
+  };
+}
+
+function createStoredSession(overrides: Partial<StoredAuthSession> = {}): StoredAuthSession {
+  return {
+    token: "signed.token",
+    playerId: "player-auth",
+    displayName: "访客骑士",
+    authMode: "account",
+    loginId: "veil-ranger",
+    source: "remote",
+    ...overrides
+  };
+}
+
+function createState() {
+  return {
+    account: createFallbackPlayerAccountProfile("player-auth", "room-alpha", "本地昵称"),
+    lobby: {
+      playerId: "player-auth",
+      displayName: "本地昵称",
+      loginId: "",
+      authSession: null
+    },
+    accountDraftName: "本地昵称",
+    accountLoginId: "",
+    accountStatus: "游客账号资料将在连接后自动同步。",
+    accountSessions: [],
+    accountSessionsLoading: false,
+    replayDetail: {
+      selectedReplayId: null
+    },
+    diagnostics: {
+      connectionStatus: "connecting" as const
+    },
+    achievementPanel: {
+      items: []
+    },
+    log: ["正在连接本地会话服务...", "old-line"]
+  };
+}
+
+function installFakeBrowser(): void {
+  const storage = {
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined
+  };
+  const fakeWindow = {
+    location: {
+      search: "",
+      protocol: "http:",
+      hostname: "127.0.0.1",
+      href: "http://127.0.0.1:4173/"
+    },
+    localStorage: storage,
+    setTimeout,
+    clearTimeout
+  };
+  const fakeElement = () => ({
+    style: {},
+    append: () => undefined,
+    click: () => undefined,
+    remove: () => undefined,
+    setAttribute: () => undefined,
+    addEventListener: () => undefined,
+    querySelectorAll: () => [],
+    querySelector: () => null,
+    innerHTML: "",
+    textContent: "",
+    id: ""
+  });
+
+  Object.assign(globalThis, {
+    window: fakeWindow,
+    document: {
+      createElement: fakeElement,
+      body: {
+        appendChild: () => undefined
+      },
+      querySelector: () => null,
+      addEventListener: () => undefined
+    }
+  });
+}
+
+async function loadMainModule(): Promise<typeof import("../src/main")> {
+  globalThis.__PROJECT_VEIL_MAIN_SKIP_AUTO_BOOT__ = true;
+  installFakeBrowser();
+  return import("../src/main");
+}
+
+test("startMainH5Boot covers cached-session boot and exposes automation hooks before boot settles", async () => {
+  const { startMainH5Boot } = await loadMainModule();
+  const replayed = createSessionUpdate("cached");
+  const initial = createSessionUpdate("snapshot");
+  const events: string[] = [];
+  const state = createState();
+  const remoteAccount = {
+    ...createFallbackPlayerAccountProfile("player-auth", "room-alpha", "访客骑士"),
+    loginId: "veil-ranger",
+    source: "remote" as const
+  };
+  const hookedWindow: {
+    render_game_to_text?: () => string;
+    export_diagnostic_snapshot?: () => string;
+    render_diagnostic_snapshot_to_text?: () => string;
+    advanceTime?: (ms: number) => Promise<void>;
+  } = {};
+  let resolveAuthSession!: (value: StoredAuthSession | null) => void;
+  const authSessionPromise = new Promise<StoredAuthSession | null>((resolve) => {
+    resolveAuthSession = resolve;
+  });
+  let resolveSyncedProfile!: () => void;
+  const syncedProfile = new Promise<void>((resolve) => {
+    resolveSyncedProfile = resolve;
+  });
+
+  startMainH5Boot({
+    state: state as never,
+    shouldBootGame: true,
+    queryPlayerId: "player-auth",
+    roomId: "room-alpha",
+    playerId: "player-auth",
+    bindKeyboardShortcuts: () => {
+      events.push("bindKeyboardShortcuts");
+    },
+    render: () => {
+      events.push("render");
+    },
+    syncCurrentAuthSession: async () => {
+      events.push("syncCurrentAuthSession");
+      return authSessionPromise;
+    },
+    refreshLobbyRoomList: async () => {
+      events.push("refreshLobbyRoomList");
+    },
+    logoutGuestSession: () => {
+      events.push("logoutGuestSession");
+    },
+    readStoredSessionReplay: (roomId, playerId) => {
+      events.push(`readStoredSessionReplay:${roomId}:${playerId}`);
+      return replayed;
+    },
+    applyReplayedUpdate: (update) => {
+      events.push(`applyReplayedUpdate:${update.reason}`);
+    },
+    getSession: async () => {
+      events.push("getSession");
+      return {
+        snapshot: async () => {
+          events.push("snapshot");
+          return initial;
+        }
+      };
+    },
+    applyUpdate: (update, source) => {
+      events.push(`applyUpdate:${source}:${update.reason}`);
+    },
+    loadAccountProfileWithProgression: async (playerId, roomId) => {
+      events.push(`loadAccountProfileWithProgression:${playerId}:${roomId}`);
+      return remoteAccount;
+    },
+    loadPlayerAccountSessions: async () => {
+      events.push("loadPlayerAccountSessions");
+      return [];
+    },
+    readStoredAuthSession: () => createStoredSession(),
+    clearReplayDetail: () => {
+      events.push("clearReplayDetail");
+    },
+    onPlayerAccountProfileSynced: () => {
+      events.push("onPlayerAccountProfileSynced");
+      resolveSyncedProfile();
+    },
+    window: hookedWindow as Window,
+    devDiagnosticsEnabled: true,
+    renderGameToText: () => "rendered",
+    exportDiagnosticSnapshot: () => "diagnostic",
+    renderDiagnosticSnapshotToText: () => "diagnostic-text",
+    advanceUiTime: async (ms) => {
+      events.push(`advanceUiTime:${ms}`);
+    }
+  });
+
+  assert.deepEqual(events, ["bindKeyboardShortcuts", "render", "syncCurrentAuthSession"]);
+  assert.equal(hookedWindow.render_game_to_text?.(), "rendered");
+  assert.equal(hookedWindow.export_diagnostic_snapshot?.(), "diagnostic");
+  assert.equal(hookedWindow.render_diagnostic_snapshot_to_text?.(), "diagnostic-text");
+  await assert.doesNotReject(async () => hookedWindow.advanceTime?.(16));
+  assert.deepEqual(events, ["bindKeyboardShortcuts", "render", "syncCurrentAuthSession", "advanceUiTime:16"]);
+
+  resolveAuthSession(createStoredSession());
+  await syncedProfile;
+  await Promise.resolve();
+
+  assert.deepEqual(events, [
+    "bindKeyboardShortcuts",
+    "render",
+    "syncCurrentAuthSession",
+    "advanceUiTime:16",
+    "readStoredSessionReplay:room-alpha:player-auth",
+    "applyReplayedUpdate:cached",
+    "getSession",
+    "snapshot",
+    "applyUpdate:system:snapshot",
+    "loadAccountProfileWithProgression:player-auth:room-alpha",
+    "loadPlayerAccountSessions",
+    "render",
+    "onPlayerAccountProfileSynced"
+  ]);
+  assert.equal(state.lobby.displayName, "访客骑士");
+  assert.equal(state.accountDraftName, "访客骑士");
+  assert.equal(state.accountLoginId, "veil-ranger");
+  assert.equal(state.diagnostics.connectionStatus, "connected");
+  assert.deepEqual(state.log, ["会话已连接。Room room-alpha / Player player-auth", "old-line"]);
+
+});
+
+test("startMainH5Boot keeps cached local state visible when the remote session is unavailable", async () => {
+  const { startMainH5Boot } = await loadMainModule();
+  const replayed = createSessionUpdate("cached");
+  const events: string[] = [];
+  const state = createState();
+  const hookedWindow: {
+    render_game_to_text?: () => string;
+    export_diagnostic_snapshot?: () => string;
+    render_diagnostic_snapshot_to_text?: () => string;
+    advanceTime?: (ms: number) => Promise<void>;
+  } = {
+    export_diagnostic_snapshot: () => "stale-export",
+    render_diagnostic_snapshot_to_text: () => "stale-text"
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    startMainH5Boot({
+      state: state as never,
+      shouldBootGame: true,
+      queryPlayerId: "player-auth",
+      roomId: "room-alpha",
+      playerId: "player-auth",
+      bindKeyboardShortcuts: () => {
+        events.push("bindKeyboardShortcuts");
+      },
+      render: () => {
+        events.push("render");
+        if (events.includes("getSession")) {
+          resolve();
+        }
+      },
+      syncCurrentAuthSession: async () => {
+        events.push("syncCurrentAuthSession");
+        return createStoredSession({ source: "local" });
+      },
+      refreshLobbyRoomList: async () => {
+        events.push("refreshLobbyRoomList");
+      },
+      logoutGuestSession: () => {
+        events.push("logoutGuestSession");
+      },
+      readStoredSessionReplay: () => {
+        events.push("readStoredSessionReplay");
+        return replayed;
+      },
+      applyReplayedUpdate: (update) => {
+        events.push(`applyReplayedUpdate:${update.reason}`);
+      },
+      getSession: async () => {
+        events.push("getSession");
+        throw new Error("session_unavailable");
+      },
+      applyUpdate: () => {
+        events.push("applyUpdate");
+      },
+      loadAccountProfileWithProgression: async () => {
+        events.push("loadAccountProfileWithProgression");
+        return state.account;
+      },
+      loadPlayerAccountSessions: async () => {
+        events.push("loadPlayerAccountSessions");
+        return [];
+      },
+      readStoredAuthSession: () => createStoredSession({ source: "local" }),
+      clearReplayDetail: () => {
+        events.push("clearReplayDetail");
+      },
+      onPlayerAccountProfileSynced: () => {
+        events.push("onPlayerAccountProfileSynced");
+      },
+      window: hookedWindow as Window,
+      devDiagnosticsEnabled: false,
+      renderGameToText: () => "rendered",
+      exportDiagnosticSnapshot: () => "diagnostic",
+      renderDiagnosticSnapshotToText: () => "diagnostic-text",
+      advanceUiTime: async (ms) => {
+        events.push(`advanceUiTime:${ms}`);
+      }
+    });
+  });
+
+  assert.deepEqual(events, [
+    "bindKeyboardShortcuts",
+    "render",
+    "syncCurrentAuthSession",
+    "readStoredSessionReplay",
+    "applyReplayedUpdate:cached",
+    "getSession",
+    "render"
+  ]);
+  assert.equal(state.diagnostics.connectionStatus, "reconnect_failed");
+  assert.deepEqual(state.log, ["远端会话暂不可用，当前仅展示最近缓存状态。", "old-line"]);
+  assert.equal(hookedWindow.render_game_to_text?.(), "rendered");
+  assert.equal(hookedWindow.export_diagnostic_snapshot, undefined);
+  assert.equal(hookedWindow.render_diagnostic_snapshot_to_text, undefined);
+  await assert.doesNotReject(async () => hookedWindow.advanceTime?.(16));
+  assert.deepEqual(events, [
+    "bindKeyboardShortcuts",
+    "render",
+    "syncCurrentAuthSession",
+    "readStoredSessionReplay",
+    "applyReplayedUpdate:cached",
+    "getSession",
+    "render",
+    "advanceUiTime:16"
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a direct node-level regression suite for `apps/client/src/main.ts`
- expose a small `startMainH5Boot` seam so tests can import the entrypoint and run the real H5 boot wiring with injected fakes
- move the browser-only CSS/bootstrap import into `apps/client/src/main-browser.ts` so `main.ts` stays importable under the standard node test runner

## Testing
- `node --import tsx --test ./apps/client/test/main.test.ts`
- `node --import tsx --test ./apps/client/test/main.test.ts ./apps/client/test/main-bootstrap-launch.test.ts ./apps/client/test/main-launch.test.ts ./apps/client/test/main-entry.test.ts ./apps/client/test/main-boot.test.ts`
- `npm test` *(currently fails in unrelated existing suites outside this change set, including `apps/client/test/auth-session-storage.test.ts`, `apps/client/test/local-session.test.ts`, `apps/client/test/player-account-storage.test.ts`, `apps/cocos-client/test/cocos-primary-runtime-smoke.test.ts`, `apps/cocos-client/test/release-readiness-dashboard.test.ts`, `apps/server/test/authoritative-room.test.ts`, and several release-tooling tests under `scripts/test/`)*
- `npm run typecheck:client:h5` *(currently fails in unrelated existing code at `packages/shared/src/content-pack-validation.ts:109` and `packages/shared/src/content-pack-validation.ts:113`)*

Closes #744
