### PR TITLE
Add Cocos runtime harness coverage for VeilRoot and VeilCocosSession

### DIFF
--- a/apps/cocos-client/test/cocos-runtime-harness.test.ts
+++ b/apps/cocos-client/test/cocos-runtime-harness.test.ts
@@ -284,6 +284,7 @@ test("Cocos lifecycle harness replays cached local boot state before VeilRoot op
   assert.equal(harness.root.authToken, "guest.local.token");
   assert.deepEqual(order, ["replay:2", "live:3"]);
   assert.equal(harness.root.lastUpdate?.world.meta.day, 3);
+  assert.equal(VeilCocosSession.readStoredReplay("room-local", "local-player")?.world.meta.day, 3);
   assert.deepEqual(room.sentMessages, [
     {
       type: "connect",

--- a/apps/cocos-client/test/helpers/cocos-runtime-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-runtime-harness.ts
@@ -131,6 +131,12 @@ export function createVeilRootSessionLifecycleHarness(options?: {
   // This is the closest CI harness to a Cocos client launch: VeilRoot uses the
   // real VeilCocosSession orchestration, while only storage/network boundaries
   // are faked to avoid needing a live editor/runtime session.
+  //
+  // Assumptions for node:test:
+  // - no scene graph or native runtime is available, so rendering is stubbed by
+  //   createVeilRootHarness and only lifecycle/state transitions are asserted.
+  // - join/reconnect behavior must be driven through FakeColyseusRoom doubles so
+  //   reconnect handoff and replay rehydration still execute production logic.
   const storage = options?.storage ?? createMemoryStorage();
   const reconnectTokens: string[] = [];
   const endpoints: string[] = [];


### PR DESCRIPTION
## Summary
- document the node:test runtime assumptions for the Cocos lifecycle harness near the helper
- strengthen the local boot lifecycle test to assert that replay state is rehydrated into VeilRoot and refreshed to the authoritative live snapshot
- keep the coverage focused on the VeilRoot and VeilCocosSession runtime harness path

## Testing
- `node --import tsx --test apps/cocos-client/test/cocos-runtime-harness.test.ts apps/cocos-client/test/cocos-veil-root.test.ts apps/cocos-client/test/cocos-session-orchestration.test.ts`

Closes #745