### PR TITLE
perf(memory-store): eliminate redundant clones and chained filters by claude

### DIFF
--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -117,12 +117,15 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     const normalizedPlayerId = normalizePlayerId(playerId);
     const normalizedQuery = normalizeEventLogQuery(query);
     const items = normalizeEventLogEntries(this.accounts.get(normalizedPlayerId)?.recentEventLog)
-      .filter((entry) => (normalizedQuery.category ? entry.category === normalizedQuery.category : true))
-      .filter((entry) => (normalizedQuery.heroId ? entry.heroId === normalizedQuery.heroId : true))
-      .filter((entry) => (normalizedQuery.achievementId ? entry.achievementId === normalizedQuery.achievementId : true))
-      .filter((entry) => (normalizedQuery.worldEventType ? entry.worldEventType === normalizedQuery.worldEventType : true))
-      .filter((entry) => (normalizedQuery.since ? entry.timestamp >= normalizedQuery.since : true))
-      .filter((entry) => (normalizedQuery.until ? entry.timestamp <= normalizedQuery.until : true))
+      .filter(
+        (entry) =>
+          (!normalizedQuery.category || entry.category === normalizedQuery.category) &&
+          (!normalizedQuery.heroId || entry.heroId === normalizedQuery.heroId) &&
+          (!normalizedQuery.achievementId || entry.achievementId === normalizedQuery.achievementId) &&
+          (!normalizedQuery.worldEventType || entry.worldEventType === normalizedQuery.worldEventType) &&
+          (!normalizedQuery.since || entry.timestamp >= normalizedQuery.since) &&
+          (!normalizedQuery.until || entry.timestamp <= normalizedQuery.until)
+      )
       .sort(
         (left: EventLogEntry, right: EventLogEntry) =>
           right.timestamp.localeCompare(left.timestamp) || left.id.localeCompare(right.id)
@@ -172,10 +175,10 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       displayName: normalizeDisplayName(playerId, input.displayName ?? existing?.displayName),
       ...(existing?.avatarUrl ? { avatarUrl: existing.avatarUrl } : {}),
       eloRating: normalizeEloRating(existing?.eloRating),
-      globalResources: structuredClone(existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 }),
-      achievements: structuredClone(existing?.achievements ?? []),
-      recentEventLog: structuredClone(existing?.recentEventLog ?? []),
-      recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
+      globalResources: existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 },
+      achievements: existing?.achievements ?? [],
+      recentEventLog: existing?.recentEventLog ?? [],
+      recentBattleReplays: existing?.recentBattleReplays ?? [],
       ...(input.lastRoomId?.trim()
         ? { lastRoomId: input.lastRoomId.trim() }
         : existing?.lastRoomId
@@ -193,8 +196,9 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
-    this.accounts.set(playerId, cloneAccount(nextAccount));
-    return cloneAccount(nextAccount);
+    const stored = structuredClone(nextAccount);
+    this.accounts.set(playerId, stored);
+    return structuredClone(stored);
   }
 
   async bindPlayerAccountCredentials(


### PR DESCRIPTION
## Summary

- **#754** — Merges 6 chained `.filter()` calls in `loadPlayerEventHistory` into a single pass using short-circuit `&&`, reducing worst-case iteration from 6× to 1× (with early exit when early conditions fail).
- **#755** — Removes per-field `structuredClone` calls inside `ensurePlayerAccount`. The intermediate `nextAccount` object is now built from raw references to `existing`, then cloned exactly once into storage (`stored`) and once for the return value — cutting clone count from N+2 to 2 per call.

## Test plan

- [ ] `npm run test:shared` passes (159 tests, 0 failures)
- [ ] Typecheck errors in `content-pack-validation.ts` are pre-existing and unrelated to this change
- [ ] Manually verify event log queries with multiple filter fields return correct results
- [ ] Verify `ensurePlayerAccount` callers cannot mutate stored account state (two independent clones)

Closes #754
Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)