### PR TITLE
fix(admin): validate admin API payloads

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -1,8 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { RoomSnapshotStore, PlayerAccountSnapshot } from "./persistence";
-import { LobbyRoomSummary, listLobbyRooms, getActiveRoomInstances } from "./colyseus-room";
+import type { ResourceLedger, WorldState } from "../../../packages/shared/src/index";
+import type { RoomSnapshotStore } from "./persistence";
+import { listLobbyRooms, getActiveRoomInstances } from "./colyseus-room";
 
 class InvalidAdminJsonError extends Error {
   constructor() {
@@ -10,6 +11,22 @@ class InvalidAdminJsonError extends Error {
     this.name = "InvalidAdminJsonError";
   }
 }
+
+class InvalidAdminPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidAdminPayloadError";
+  }
+}
+
+type AdminRequest = IncomingMessage & { params: Record<string, string> };
+type AdminMiddleware = (request: IncomingMessage, response: ServerResponse, next: () => void) => void;
+type AdminRouteHandler = (request: AdminRequest, response: ServerResponse) => void | Promise<void>;
+type AdminApp = {
+  use: (handler: AdminMiddleware) => void;
+  get: (path: string, handler: AdminRouteHandler) => void;
+  post: (path: string, handler: AdminRouteHandler) => void;
+};
 
 function readAdminSecret(): string | null {
   const secret = process.env.ADMIN_SECRET?.trim();
@@ -46,7 +63,68 @@ function sendInvalidJson(response: ServerResponse): void {
   sendJson(response, 400, { error: "Invalid JSON body" });
 }
 
-async function readJsonBody(request: IncomingMessage): Promise<any> {
+function sendInvalidPayload(response: ServerResponse, message: string): void {
+  sendJson(response, 400, { error: message });
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readRequiredObjectBody(value: unknown): Record<string, unknown> {
+  if (!isJsonObject(value)) {
+    throw new InvalidAdminPayloadError("JSON body must be an object");
+  }
+  return value;
+}
+
+function readRequiredParam(request: AdminRequest, key: string): string {
+  const value = request.params[key];
+  if (!value) {
+    throw new InvalidAdminPayloadError(`Missing route parameter "${key}"`);
+  }
+  return value;
+}
+
+function readOptionalIntegerField(payload: Record<string, unknown>, key: keyof ResourceLedger): number {
+  const value = payload[key];
+  if (value === undefined) {
+    return 0;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new InvalidAdminPayloadError(`"${key}" must be a finite integer`);
+  }
+  return value;
+}
+
+function parseResourceDeltaBody(value: unknown): ResourceLedger {
+  const payload = readRequiredObjectBody(value);
+  return {
+    gold: readOptionalIntegerField(payload, "gold"),
+    wood: readOptionalIntegerField(payload, "wood"),
+    ore: readOptionalIntegerField(payload, "ore")
+  };
+}
+
+function parseBroadcastBody(value: unknown): { message: string; type: string } {
+  const payload = readRequiredObjectBody(value);
+  const message = payload.message;
+  const announcementType = payload.type;
+
+  if (typeof message !== "string" || message.trim().length === 0) {
+    throw new InvalidAdminPayloadError('"message" must be a non-empty string');
+  }
+  if (announcementType !== undefined && (typeof announcementType !== "string" || announcementType.trim().length === 0)) {
+    throw new InvalidAdminPayloadError('"type" must be a non-empty string');
+  }
+
+  return {
+    message: message.trim(),
+    type: typeof announcementType === "string" ? announcementType.trim() : "info"
+  };
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const chunks: Buffer[] = [];
   for await (const chunk of request) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
@@ -59,23 +137,18 @@ async function readJsonBody(request: IncomingMessage): Promise<any> {
 }
 
 export function registerAdminRoutes(
-  app: {
-    use: (handler: any) => void;
-    get: (path: string, handler: (request: any, response: ServerResponse) => void | Promise<void>) => void;
-    post: (path: string, handler: (request: any, response: ServerResponse) => void | Promise<void>) => void;
-  },
+  app: AdminApp,
   store: RoomSnapshotStore | null,
-  gameServer?: any 
+  _gameServer?: unknown
 ): void {
-  
-  app.use((req: any, res: any, next: any) => {
-    if (req.method === 'OPTIONS') {
-        res.setHeader("Access-Control-Allow-Origin", "*");
-        res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
-        res.setHeader("Access-Control-Allow-Headers", "Content-Type, x-veil-admin-secret");
-        res.statusCode = 204;
-        res.end();
-        return;
+  app.use((request, response, next) => {
+    if (request.method === "OPTIONS") {
+      response.setHeader("Access-Control-Allow-Origin", "*");
+      response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+      response.setHeader("Access-Control-Allow-Headers", "Content-Type, x-veil-admin-secret");
+      response.statusCode = 204;
+      response.end();
+      return;
     }
     next();
   });
@@ -109,19 +182,23 @@ export function registerAdminRoutes(
     if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
     if (!isAuthorized(request)) return sendUnauthorized(response);
     try {
-      const playerId = request.params.id;
-      const { gold, wood, ore } = await readJsonBody(request);
-      let currentResources = { gold: 0, wood: 0, ore: 0 };
+      const playerId = readRequiredParam(request, "id");
+      const { gold, wood, ore } = parseResourceDeltaBody(await readJsonBody(request));
+      let currentResources: ResourceLedger = { gold: 0, wood: 0, ore: 0 };
       if (store) {
-          let account = await store.loadPlayerAccount(playerId);
-          if (!account) account = await store.ensurePlayerAccount({ playerId, displayName: playerId });
-          if (account && account.globalResources) currentResources = { ...account.globalResources };
+        let account = await store.loadPlayerAccount(playerId);
+        if (!account) {
+          account = await store.ensurePlayerAccount({ playerId, displayName: playerId });
+        }
+        if (account?.globalResources) {
+          currentResources = { ...account.globalResources };
+        }
       }
 
-      const nextResources = {
-        gold: Math.max(0, currentResources.gold + (gold || 0)),
-        wood: Math.max(0, currentResources.wood + (wood || 0)),
-        ore: Math.max(0, currentResources.ore + (ore || 0))
+      const nextResources: ResourceLedger = {
+        gold: Math.max(0, currentResources.gold + gold),
+        wood: Math.max(0, currentResources.wood + wood),
+        ore: Math.max(0, currentResources.ore + ore)
       };
 
       if (store) await store.savePlayerAccountProgress(playerId, { globalResources: nextResources });
@@ -130,43 +207,49 @@ export function registerAdminRoutes(
       const activeRooms = getActiveRoomInstances();
 
       for (const [roomId, vRoom] of activeRooms) {
-          if (vRoom.worldRoom) {
-              const internalState = vRoom.worldRoom.getInternalState();
-              
-              if (internalState.resources && internalState.resources[playerId]) {
-                  internalState.resources[playerId] = { ...nextResources };
-              }
-              
-              if (internalState.playerResources && internalState.playerResources[playerId]) {
-                  internalState.playerResources[playerId] = { ...nextResources };
-              }
+        if (vRoom.worldRoom) {
+          const internalState = vRoom.worldRoom.getInternalState() as WorldState & {
+            playerResources?: Record<string, ResourceLedger>;
+          };
 
-              console.log(`[Admin] Patched room ${roomId} for ${playerId}:`, nextResources);
-              
-              const snapshot = vRoom.worldRoom.getSnapshot(playerId);
-              snapshot.state.resources = { ...nextResources };
-              
-              for (const client of vRoom.clients) {
-                  client.send("session.state", {
-                      delivery: "push",
-                      payload: {
-                          world: snapshot.state,
-                          battle: snapshot.battle,
-                          events: [{ type: "system.announcement", text: "资源已更新", tone: "system" }],
-                          movementPlan: null,
-                          reachableTiles: []
-                      }
-                  });
-              }
-              
-              syncedToRoom = true;
+          if (internalState.resources && internalState.resources[playerId]) {
+            internalState.resources[playerId] = { ...nextResources };
           }
+
+          if (internalState.playerResources && internalState.playerResources[playerId]) {
+            internalState.playerResources[playerId] = { ...nextResources };
+          }
+
+          console.log(`[Admin] Patched room ${roomId} for ${playerId}:`, nextResources);
+
+          const snapshot = vRoom.worldRoom.getSnapshot(playerId);
+          snapshot.state.resources = { ...nextResources };
+
+          for (const client of vRoom.clients) {
+            client.send("session.state", {
+              delivery: "push",
+              payload: {
+                world: snapshot.state,
+                battle: null,
+                events: [{ type: "system.announcement", text: "资源已更新", tone: "system" }],
+                movementPlan: null,
+                reachableTiles: []
+              }
+            });
+          }
+
+          syncedToRoom = true;
+        }
       }
 
       sendJson(response, 200, { ok: true, resources: nextResources, syncedToRoom });
     } catch (error) {
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
         return;
       }
       console.error("[Admin] Sync error:", error);
@@ -178,15 +261,19 @@ export function registerAdminRoutes(
     if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
     if (!isAuthorized(request)) return sendUnauthorized(response);
     try {
-      const { message, type = "info" } = await readJsonBody(request);
+      const { message, type } = parseBroadcastBody(await readJsonBody(request));
       const activeRooms = getActiveRoomInstances();
       for (const [_, room] of activeRooms) {
-          room.broadcast("system.announcement", { text: message, type, timestamp: new Date().toISOString() });
+        room.broadcast("system.announcement", { text: message, type, timestamp: new Date().toISOString() });
       }
       sendJson(response, 200, { ok: true });
     } catch (error) {
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
         return;
       }
       sendJson(response, 500, { error: String(error) });

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -240,6 +240,49 @@ test("POST /api/admin/players/:id/resources returns 400 for malformed JSON", asy
   assert.deepEqual(JSON.parse(response.body), { error: "Invalid JSON body" });
 });
 
+test("POST /api/admin/players/:id/resources returns 400 for invalid resource payload types", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore({
+    "player-1": { gold: 10, wood: 4, ore: 1 }
+  });
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/resources");
+  assert.ok(handler);
+
+  const nonObjectResponse = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-1" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: "null"
+    }),
+    nonObjectResponse
+  );
+
+  assert.equal(nonObjectResponse.statusCode, 400);
+  assert.deepEqual(JSON.parse(nonObjectResponse.body), { error: "JSON body must be an object" });
+
+  const invalidFieldResponse = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-1" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({ gold: "drop table", wood: 2.5, ore: 1 })
+    }),
+    invalidFieldResponse
+  );
+
+  assert.equal(invalidFieldResponse.statusCode, 400);
+  assert.deepEqual(JSON.parse(invalidFieldResponse.body), { error: '"gold" must be a finite integer' });
+  assert.equal(store.saveCalls.length, 0);
+});
+
 test("POST /api/admin/players/:id/resources adds and clamps resources and syncs active rooms", async (t) => {
   const secret = withAdminSecret(t);
   const store = createStore({
@@ -410,4 +453,41 @@ test("POST /api/admin/broadcast broadcasts to all active rooms and succeeds when
 
   assert.equal(noRoomsResponse.statusCode, 200);
   assert.deepEqual(JSON.parse(noRoomsResponse.body), { ok: true });
+});
+
+test("POST /api/admin/broadcast returns 400 for invalid payload types", async (t) => {
+  const secret = withAdminSecret(t);
+  const { posts } = registerRoutes();
+  const handler = posts.get("/api/admin/broadcast");
+  assert.ok(handler);
+
+  const nonObjectResponse = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: "[]"
+    }),
+    nonObjectResponse
+  );
+
+  assert.equal(nonObjectResponse.statusCode, 400);
+  assert.deepEqual(JSON.parse(nonObjectResponse.body), { error: "JSON body must be an object" });
+
+  const invalidMessageResponse = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({ message: "   ", type: 42 })
+    }),
+    invalidMessageResponse
+  );
+
+  assert.equal(invalidMessageResponse.statusCode, 400);
+  assert.deepEqual(JSON.parse(invalidMessageResponse.body), { error: '"message" must be a non-empty string' });
 });


### PR DESCRIPTION
## Summary
- replace unsafe `any` route/request annotations in `apps/server/src/admin-console.ts` with local admin route types
- validate admin resource update bodies as JSON objects with optional finite integer deltas before mutating persisted or in-room state
- validate admin broadcast bodies so only non-empty string messages and announcement types are accepted, with focused unit coverage for invalid payloads

## Verification
- `node --import tsx --test apps/server/test/admin-console.test.ts`
- `npm run typecheck:server` *(currently fails in pre-existing code at `packages/shared/src/content-pack-validation.ts:109` and `:113`)*

Closes #756.