### PR TITLE
perf(matchmaking): cache queue positions for status checks

### DIFF
--- a/apps/server/src/matchmaking.ts
+++ b/apps/server/src/matchmaking.ts
@@ -199,6 +199,8 @@ type MatchmakingStatusResponse = MatchmakingStatusQueued | MatchmakingStatusMatc
 
 export class MatchmakingService {
   private readonly queueByPlayerId = new Map<string, MatchmakingRequest>();
+  private readonly queueOrder: string[] = [];
+  private readonly queuePositionByPlayerId = new Map<string, number>();
   private readonly resultsByPlayerId = new Map<string, MatchResult>();
   private nextMatchSequence = 1;
 
@@ -206,7 +208,9 @@ export class MatchmakingService {
     const normalized = normalizeMatchmakingRequest(request);
     this.resultsByPlayerId.delete(normalized.playerId);
 
+    this.removeQueuedPlayer(normalized.playerId);
     this.queueByPlayerId.set(normalized.playerId, normalized);
+    this.insertQueuedPlayer(normalized);
     const status = this.getQueuedStatus(normalized.playerId);
     this.matchQueuedPlayers(now);
     if (!status) {
@@ -218,7 +222,7 @@ export class MatchmakingService {
   dequeue(playerId: string): boolean {
     const normalizedPlayerId = playerId.trim();
     this.resultsByPlayerId.delete(normalizedPlayerId);
-    return this.queueByPlayerId.delete(normalizedPlayerId);
+    return this.removeQueuedPlayer(normalizedPlayerId);
   }
 
   getStatus(playerId: string): MatchmakingStatusResponse {
@@ -238,18 +242,15 @@ export class MatchmakingService {
 
   private getQueuedStatus(playerId: string): MatchmakingStatusQueued | null {
     const normalizedPlayerId = playerId.trim();
-    const queue = Array.from(this.queueByPlayerId.values()).sort(
-      (left, right) => left.enqueuedAt.localeCompare(right.enqueuedAt) || left.playerId.localeCompare(right.playerId)
-    );
-    const position = queue.findIndex((entry) => entry.playerId === normalizedPlayerId);
-    if (position < 0) {
+    const position = this.queuePositionByPlayerId.get(normalizedPlayerId);
+    if (position == null) {
       return null;
     }
 
     return {
       status: "queued",
-      position: position + 1,
-      estimatedWaitSeconds: estimateMatchmakingWaitSeconds(position + 1)
+      position,
+      estimatedWaitSeconds: estimateMatchmakingWaitSeconds(position)
     };
   }
 
@@ -274,8 +275,8 @@ export class MatchmakingService {
       }
 
       const [left, right] = selection.players;
-      this.queueByPlayerId.delete(left.playerId);
-      this.queueByPlayerId.delete(right.playerId);
+      this.removeQueuedPlayer(left.playerId);
+      this.removeQueuedPlayer(right.playerId);
 
       const result = this.createMatchResult([left, right], now);
       this.resultsByPlayerId.set(left.playerId, result);
@@ -296,13 +297,55 @@ export class MatchmakingService {
     for (const [playerId, request] of this.queueByPlayerId.entries()) {
       const enqueuedAtMs = new Date(request.enqueuedAt).getTime();
       if (Number.isNaN(enqueuedAtMs) || referenceTime - enqueuedAtMs > maxAgeMs) {
-        this.queueByPlayerId.delete(playerId);
+        this.removeQueuedPlayer(playerId);
         this.resultsByPlayerId.delete(playerId);
         removed += 1;
       }
     }
     return removed;
   }
+
+  private insertQueuedPlayer(request: MatchmakingRequest): void {
+    let insertAt = this.queueOrder.length;
+    for (let index = 0; index < this.queueOrder.length; index += 1) {
+      const existingPlayerId = this.queueOrder[index];
+      const existingRequest = existingPlayerId ? this.queueByPlayerId.get(existingPlayerId) : null;
+      if (!existingRequest || compareQueuedPlayers(request, existingRequest) < 0) {
+        insertAt = index;
+        break;
+      }
+    }
+
+    this.queueOrder.splice(insertAt, 0, request.playerId);
+    this.reindexQueuePositions(insertAt);
+  }
+
+  private removeQueuedPlayer(playerId: string): boolean {
+    const normalizedPlayerId = playerId.trim();
+    const hadRequest = this.queueByPlayerId.delete(normalizedPlayerId);
+    const queuedPosition = this.queuePositionByPlayerId.get(normalizedPlayerId);
+    if (queuedPosition == null) {
+      return hadRequest;
+    }
+
+    this.queueOrder.splice(queuedPosition - 1, 1);
+    this.queuePositionByPlayerId.delete(normalizedPlayerId);
+    this.reindexQueuePositions(queuedPosition - 1);
+    return true;
+  }
+
+  private reindexQueuePositions(startIndex = 0): void {
+    for (let index = startIndex; index < this.queueOrder.length; index += 1) {
+      const playerId = this.queueOrder[index];
+      if (playerId) {
+        this.queuePositionByPlayerId.set(playerId, index + 1);
+      }
+    }
+  }
+}
+
+function compareQueuedPlayers(left: MatchmakingRequest, right: MatchmakingRequest): number {
+  return left.enqueuedAt.localeCompare(right.enqueuedAt) || left.playerId.localeCompare(right.playerId);
 }
 
 let configuredMatchmakingService = new MatchmakingService();

--- a/apps/server/test/matchmaking-routes.test.ts
+++ b/apps/server/test/matchmaking-routes.test.ts
@@ -110,11 +110,23 @@ function seedQueue(service: MatchmakingService, requests: MatchmakingRequest[]):
     string,
     MatchmakingRequest
   >;
+  const queueOrder = Reflect.get(service as Record<string, unknown>, "queueOrder") as string[];
+  const queuePositionByPlayerId = Reflect.get(service as Record<string, unknown>, "queuePositionByPlayerId") as Map<
+    string,
+    number
+  >;
   const results = Reflect.get(service as Record<string, unknown>, "resultsByPlayerId") as Map<string, unknown>;
   queue.clear();
+  queueOrder.length = 0;
+  queuePositionByPlayerId.clear();
   results?.clear();
-  for (const request of requests) {
+  const sortedRequests = [...requests].sort(
+    (left, right) => left.enqueuedAt.localeCompare(right.enqueuedAt) || left.playerId.localeCompare(right.playerId)
+  );
+  for (const [index, request] of sortedRequests.entries()) {
     queue.set(request.playerId, request);
+    queueOrder.push(request.playerId);
+    queuePositionByPlayerId.set(request.playerId, index + 1);
   }
 }
 

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createDefaultHeroLoadout,
+  createDefaultHeroProgression,
+  createMatchmakingHeroSnapshot,
+  type HeroState,
+  type MatchmakingRequest
+} from "../../../packages/shared/src/index";
+import { MatchmakingService } from "../src/matchmaking";
+
+function createHero(playerId: string, heroId: string): HeroState {
+  return {
+    id: heroId,
+    playerId,
+    name: `Hero ${playerId}`,
+    position: { x: 0, y: 0 },
+    vision: 2,
+    move: { total: 6, remaining: 6 },
+    stats: {
+      attack: 2,
+      defense: 2,
+      power: 1,
+      knowledge: 1,
+      hp: 30,
+      maxHp: 30
+    },
+    progression: createDefaultHeroProgression(),
+    loadout: createDefaultHeroLoadout(),
+    armyTemplateId: "hero_guard_basic",
+    armyCount: 12,
+    learnedSkills: []
+  };
+}
+
+function createQueueRequest(playerId: string, enqueuedAt: string): MatchmakingRequest {
+  return {
+    playerId,
+    heroSnapshot: createMatchmakingHeroSnapshot(createHero(playerId, `${playerId}-hero`)),
+    rating: 1000,
+    enqueuedAt
+  };
+}
+
+function seedQueue(service: MatchmakingService, requests: MatchmakingRequest[]): void {
+  const queue = Reflect.get(service as Record<string, unknown>, "queueByPlayerId") as Map<
+    string,
+    MatchmakingRequest
+  >;
+  const queueOrder = Reflect.get(service as Record<string, unknown>, "queueOrder") as string[];
+  const queuePositionByPlayerId = Reflect.get(service as Record<string, unknown>, "queuePositionByPlayerId") as Map<
+    string,
+    number
+  >;
+
+  queue.clear();
+  queueOrder.length = 0;
+  queuePositionByPlayerId.clear();
+
+  const sortedRequests = [...requests].sort(
+    (left, right) => left.enqueuedAt.localeCompare(right.enqueuedAt) || left.playerId.localeCompare(right.playerId)
+  );
+  for (const [index, request] of sortedRequests.entries()) {
+    queue.set(request.playerId, request);
+    queueOrder.push(request.playerId);
+    queuePositionByPlayerId.set(request.playerId, index + 1);
+  }
+}
+
+test("matchmaking service reports queued positions from maintained queue state", () => {
+  const service = new MatchmakingService();
+
+  seedQueue(service, [
+    createQueueRequest("player-alpha", "2026-03-28T08:00:05.000Z"),
+    createQueueRequest("player-beta", "2026-03-28T08:00:10.000Z"),
+    createQueueRequest("player-earlier", "2026-03-28T08:00:01.000Z")
+  ]);
+
+  assert.deepEqual(service.getStatus("player-earlier"), {
+    status: "queued",
+    position: 1,
+    estimatedWaitSeconds: 0
+  });
+  assert.deepEqual(service.getStatus("player-alpha"), {
+    status: "queued",
+    position: 2,
+    estimatedWaitSeconds: 15
+  });
+  assert.deepEqual(service.getStatus("player-beta"), {
+    status: "queued",
+    position: 3,
+    estimatedWaitSeconds: 30
+  });
+});
+
+test("matchmaking service updates maintained positions after dequeue and prune", () => {
+  const service = new MatchmakingService();
+
+  seedQueue(service, [
+    createQueueRequest("player-alpha", "2026-03-28T08:00:05.000Z"),
+    createQueueRequest("player-beta", "2026-03-28T08:00:10.000Z"),
+    createQueueRequest("player-earlier", "2026-03-28T08:00:01.000Z")
+  ]);
+
+  assert.equal(service.dequeue("player-alpha"), true);
+  assert.deepEqual(service.getStatus("player-earlier"), {
+    status: "queued",
+    position: 1,
+    estimatedWaitSeconds: 0
+  });
+  assert.deepEqual(service.getStatus("player-beta"), {
+    status: "queued",
+    position: 2,
+    estimatedWaitSeconds: 15
+  });
+
+  const removed = service.pruneStaleEntries(5_000, new Date("2026-03-28T08:00:07.000Z"));
+  assert.equal(removed, 1);
+  assert.equal(service.getStatus("player-earlier").status, "idle");
+  assert.deepEqual(service.getStatus("player-beta"), {
+    status: "queued",
+    position: 1,
+    estimatedWaitSeconds: 0
+  });
+});


### PR DESCRIPTION
## Summary
- maintain queue order and cached player positions inside the matchmaking service so status reads avoid re-sorting the queue
- update route test seeding for the maintained queue state and add direct service coverage for queued position updates
- validate the focused matchmaking service and route tests for this change

Closes #753