### PR TITLE
Add target-environment dossier bundle for Phase 1 RC

### DIFF
--- a/docs/phase1-candidate-dossier.md
+++ b/docs/phase1-candidate-dossier.md
@@ -4,6 +4,8 @@
 
 It now also emits one explicit candidate-level `Phase 1 exit evidence gate` so reviewers can make the final pass/pending/fail call from one object instead of re-interpreting each evidence section by hand.
 
+The same run also emits a smaller runtime observability dossier that keeps the target-environment runtime probes and reconnect/session-recovery evidence in one reviewer-facing artifact for the same candidate revision.
+
 The Markdown artifact is the canonical reviewer-facing attachment for one candidate revision: it records the candidate metadata, selected evidence inputs, the single Phase 1 exit gate decision, and the per-section drill-down in one place.
 
 The command stays intentionally thin and reuses the existing evidence producers:
@@ -69,6 +71,8 @@ If you do not pass output flags, the script writes one stable candidate bundle d
 
 - `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/phase1-candidate-dossier.json`
 - `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/phase1-candidate-dossier.md`
+- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/runtime-observability-dossier.json`
+- `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/runtime-observability-dossier.md`
 - `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/release-gate-summary.json`
 - `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/release-gate-summary.md`
 - `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/release-health-summary.json`
@@ -84,6 +88,7 @@ The dossier surfaces:
 - one candidate revision and target surface
 - one `Selected Inputs` block so reviewers can see the exact artifact paths and runtime URL that were used
 - one `Generated Bundle` block so PR/release巡检 reviewers can stay inside the dossier directory
+- one runtime observability companion dossier that ties `/api/runtime/health`, `/api/runtime/auth-readiness`, `/api/runtime/metrics`, and reconnect soak evidence to the same candidate revision
 - one `phase1ExitEvidenceGate` result with blocking/pending/accepted-risk section lists
 - `requiredFailed`
 - `requiredPending`

--- a/scripts/phase1-candidate-dossier.ts
+++ b/scripts/phase1-candidate-dossier.ts
@@ -376,6 +376,8 @@ interface Phase1CandidateDossier {
     outputDir: string;
     dossierJsonPath: string;
     dossierMarkdownPath: string;
+    runtimeObservabilityDossierPath: string;
+    runtimeObservabilityDossierMarkdownPath: string;
     releaseGateSummaryPath: string;
     releaseGateMarkdownPath: string;
     releaseHealthSummaryPath: string;
@@ -383,6 +385,26 @@ interface Phase1CandidateDossier {
   };
   sections: DossierSection[];
   acceptedRisks: DossierAcceptedRisk[];
+}
+
+interface RuntimeObservabilityDossier {
+  schemaVersion: 1;
+  generatedAt: string;
+  candidate: Phase1CandidateDossier["candidate"];
+  targetEnvironment: {
+    serverUrl?: string;
+  };
+  summary: {
+    status: DossierResult;
+    headline: string;
+    runtimeStatus: DossierResult;
+    reconnectStatus: DossierResult;
+  };
+  artifacts?: {
+    jsonPath: string;
+    markdownPath: string;
+  };
+  sections: Array<Pick<DossierSection, "id" | "label" | "result" | "summary" | "artifactPath" | "observedAt" | "freshness" | "revision" | "details" | "evidence">>;
 }
 
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
@@ -803,16 +825,26 @@ async function fetchText(url: string): Promise<string> {
   return response.text();
 }
 
-async function buildRuntimeSection(serverUrl: string | undefined, maxAgeMs: number): Promise<DossierSection> {
+async function buildRuntimeSection(
+  targetSurface: TargetSurface,
+  serverUrl: string | undefined,
+  maxAgeMs: number
+): Promise<DossierSection> {
   if (!serverUrl) {
     return {
       id: "runtime-health",
       label: "Runtime health/auth-readiness/metrics",
       required: true,
-      result: "pending",
-      summary: "Live runtime evidence was not sampled for this candidate.",
+      result: targetSurface === "wechat" ? "pending" : "passed",
+      summary:
+        targetSurface === "wechat"
+          ? "Live runtime evidence was not sampled for this candidate."
+          : "Live runtime sampling was not requested for this target surface.",
       freshness: "unknown",
-      details: ["Pass --server-url <base-url> to sample /api/runtime/health, /api/runtime/auth-readiness, and /api/runtime/metrics."],
+      details:
+        targetSurface === "wechat"
+          ? ["Pass --server-url <base-url> to sample /api/runtime/health, /api/runtime/auth-readiness, and /api/runtime/metrics."]
+          : ["No --server-url was provided; dossier relies on packaged-artifact and reconnect-soak evidence for this target surface."],
       evidence: [],
       acceptedRisks: []
     };
@@ -1618,6 +1650,62 @@ function replaceSectionEvidence(
   return sections.map((section) => (section.id === id ? { ...section, evidence } : section));
 }
 
+export function buildRuntimeObservabilityDossier(
+  dossier: Phase1CandidateDossier,
+  artifactPaths?: RuntimeObservabilityDossier["artifacts"]
+): RuntimeObservabilityDossier {
+  const runtimeSection = dossier.sections.find((section) => section.id === "runtime-health");
+  const reconnectSection = dossier.sections.find((section) => section.id === "reconnect-soak");
+  if (!runtimeSection || !reconnectSection) {
+    fail("Phase 1 candidate dossier is missing runtime-health or reconnect-soak sections.");
+  }
+
+  const summaryStatus =
+    runtimeSection.result === "failed" || reconnectSection.result === "failed"
+      ? "failed"
+      : runtimeSection.result === "pending" || reconnectSection.result === "pending"
+        ? "pending"
+        : runtimeSection.result === "accepted_risk" || reconnectSection.result === "accepted_risk"
+          ? "accepted_risk"
+          : "passed";
+  const headline =
+    summaryStatus === "failed"
+      ? "Target-environment runtime observability or reconnect evidence failed for this candidate."
+      : summaryStatus === "pending"
+        ? "Target-environment runtime observability is partially ready, but reviewer follow-up is still required."
+        : summaryStatus === "accepted_risk"
+          ? "Target-environment runtime observability passed with accepted risk."
+          : "Target-environment runtime observability and reconnect evidence are aligned with this candidate.";
+
+  return {
+    schemaVersion: 1,
+    generatedAt: dossier.generatedAt,
+    candidate: dossier.candidate,
+    targetEnvironment: {
+      ...(dossier.inputs.serverUrl ? { serverUrl: dossier.inputs.serverUrl } : {})
+    },
+    summary: {
+      status: summaryStatus,
+      headline,
+      runtimeStatus: runtimeSection.result,
+      reconnectStatus: reconnectSection.result
+    },
+    ...(artifactPaths ? { artifacts: artifactPaths } : {}),
+    sections: [runtimeSection, reconnectSection].map((section) => ({
+      id: section.id,
+      label: section.label,
+      result: section.result,
+      summary: section.summary,
+      ...(section.artifactPath ? { artifactPath: section.artifactPath } : {}),
+      ...(section.observedAt ? { observedAt: section.observedAt } : {}),
+      freshness: section.freshness,
+      ...(section.revision ? { revision: section.revision } : {}),
+      details: [...section.details],
+      evidence: section.evidence.map((entry) => ({ ...entry }))
+    }))
+  };
+}
+
 function buildSupportingReports(
   inputs: Phase1CandidateDossier["inputs"],
   args: Args,
@@ -1675,11 +1763,69 @@ function resolveBundlePaths(args: Args, dossier: Phase1CandidateDossier): Phase1
     outputDir: bundleDir,
     dossierJsonPath,
     dossierMarkdownPath,
+    runtimeObservabilityDossierPath: path.join(bundleDir, "runtime-observability-dossier.json"),
+    runtimeObservabilityDossierMarkdownPath: path.join(bundleDir, "runtime-observability-dossier.md"),
     releaseGateSummaryPath: path.join(bundleDir, "release-gate-summary.json"),
     releaseGateMarkdownPath: path.join(bundleDir, "release-gate-summary.md"),
     releaseHealthSummaryPath: path.join(bundleDir, "release-health-summary.json"),
     releaseHealthMarkdownPath: path.join(bundleDir, "release-health-summary.md")
   };
+}
+
+export function renderRuntimeObservabilityMarkdown(dossier: RuntimeObservabilityDossier): string {
+  const lines: string[] = [];
+  lines.push("# Runtime Observability Dossier", "");
+  lines.push(`- Generated at: \`${dossier.generatedAt}\``);
+  lines.push(`- Candidate: \`${dossier.candidate.name}\``);
+  lines.push(`- Revision: \`${dossier.candidate.revision}\``);
+  lines.push(`- Branch: \`${dossier.candidate.branch}\``);
+  lines.push(`- Target surface: \`${dossier.candidate.targetSurface}\``);
+  lines.push(`- Target environment: \`${dossier.targetEnvironment.serverUrl ?? "<missing>"}\``);
+  lines.push(`- Overall status: **${dossier.summary.status.toUpperCase()}**`);
+  lines.push(`- Headline: ${dossier.summary.headline}`);
+  lines.push(`- Runtime endpoint status: \`${dossier.summary.runtimeStatus}\``);
+  lines.push(`- Reconnect/session-recovery status: \`${dossier.summary.reconnectStatus}\``, "");
+
+  if (dossier.artifacts) {
+    lines.push("## Generated Bundle", "");
+    lines.push(`- JSON: \`${relativeArtifactPath(dossier.artifacts.jsonPath)}\``);
+    lines.push(`- Markdown: \`${relativeArtifactPath(dossier.artifacts.markdownPath)}\``, "");
+  }
+
+  lines.push("## Evidence Summary", "");
+  for (const section of dossier.sections) {
+    lines.push(`### ${section.label}`, "");
+    lines.push(`- Result: \`${section.result}\``);
+    lines.push(`- Summary: ${section.summary}`);
+    lines.push(`- Freshness: \`${section.freshness}\``);
+    if (section.observedAt) {
+      lines.push(`- Observed at: \`${section.observedAt}\``);
+    }
+    if (section.revision) {
+      lines.push(`- Revision: \`${section.revision}\``);
+    }
+    if (section.artifactPath) {
+      lines.push(`- Artifact: \`${relativeArtifactPath(section.artifactPath)}\``);
+    }
+    if (section.details.length > 0) {
+      lines.push("- Details:");
+      for (const detail of section.details) {
+        lines.push(`  - ${detail}`);
+      }
+    }
+    if (section.evidence.length > 0) {
+      lines.push("- Evidence:");
+      for (const entry of section.evidence) {
+        const extras = [entry.observedAt ? `observedAt=${entry.observedAt}` : "", entry.revision ? `revision=${entry.revision}` : "", `freshness=${entry.freshness}`]
+          .filter((value) => value.length > 0)
+          .join(" ");
+        lines.push(`  - ${entry.label}: \`${entry.path}\` (${entry.summary}${extras ? `; ${extras}` : ""})`);
+      }
+    }
+    lines.push("");
+  }
+
+  return `${lines.join("\n").trim()}\n`;
 }
 
 function buildPhase1ExitEvidenceGateSection(sections: DossierSection[], generatedAt: string | undefined): {
@@ -1778,6 +1924,8 @@ export function renderMarkdown(dossier: Phase1CandidateDossier): string {
     lines.push(`- Output dir: \`${relativeArtifactPath(dossier.artifacts.outputDir)}\``);
     lines.push(`- Dossier JSON: \`${relativeArtifactPath(dossier.artifacts.dossierJsonPath)}\``);
     lines.push(`- Dossier Markdown: \`${relativeArtifactPath(dossier.artifacts.dossierMarkdownPath)}\``);
+    lines.push(`- Runtime observability dossier JSON: \`${relativeArtifactPath(dossier.artifacts.runtimeObservabilityDossierPath)}\``);
+    lines.push(`- Runtime observability dossier Markdown: \`${relativeArtifactPath(dossier.artifacts.runtimeObservabilityDossierMarkdownPath)}\``);
     lines.push(`- Release gate summary JSON: \`${relativeArtifactPath(dossier.artifacts.releaseGateSummaryPath)}\``);
     lines.push(`- Release gate summary Markdown: \`${relativeArtifactPath(dossier.artifacts.releaseGateMarkdownPath)}\``);
     lines.push(`- Release health summary JSON: \`${relativeArtifactPath(dossier.artifacts.releaseHealthSummaryPath)}\``);
@@ -1894,7 +2042,7 @@ export async function buildPhase1CandidateDossier(args: Args): Promise<Phase1Can
     revision.commit,
     maxAgeMs
   );
-  const runtimeSection = await buildRuntimeSection(inputs.serverUrl, maxAgeMs);
+  const runtimeSection = await buildRuntimeSection(args.targetSurface, inputs.serverUrl, maxAgeMs);
   const reconnectSoakSection = buildReconnectSoakSection(inputs.reconnectSoakPath, revision.commit, maxAgeMs);
   const persistenceSection = buildPersistenceSection(inputs.persistencePath, revision.commit, maxAgeMs);
 
@@ -1999,11 +2147,17 @@ async function main(): Promise<void> {
   const { gateReport, healthReport } = buildSupportingReports(inputs, args, revision);
   let dossier = await buildPhase1CandidateDossier(args);
   const artifacts = resolveBundlePaths(args, dossier);
+  const runtimeObservabilityDossier = buildRuntimeObservabilityDossier(dossier, {
+    jsonPath: artifacts.runtimeObservabilityDossierPath,
+    markdownPath: artifacts.runtimeObservabilityDossierMarkdownPath
+  });
 
   writeJsonFile(artifacts.releaseGateSummaryPath, gateReport);
   writeFile(artifacts.releaseGateMarkdownPath, renderReleaseGateMarkdown(gateReport));
   writeJsonFile(artifacts.releaseHealthSummaryPath, healthReport);
   writeFile(artifacts.releaseHealthMarkdownPath, renderReleaseHealthMarkdown(healthReport));
+  writeJsonFile(artifacts.runtimeObservabilityDossierPath, runtimeObservabilityDossier);
+  writeFile(artifacts.runtimeObservabilityDossierMarkdownPath, renderRuntimeObservabilityMarkdown(runtimeObservabilityDossier));
 
   dossier = {
     ...dossier,
@@ -2059,6 +2213,7 @@ async function main(): Promise<void> {
   console.log(`Wrote Phase 1 candidate dossier bundle: ${path.relative(process.cwd(), artifacts.outputDir).replace(/\\/g, "/")}`);
   console.log(`Wrote Phase 1 candidate dossier JSON: ${path.relative(process.cwd(), artifacts.dossierJsonPath).replace(/\\/g, "/")}`);
   console.log(`Wrote Phase 1 candidate dossier Markdown: ${path.relative(process.cwd(), artifacts.dossierMarkdownPath).replace(/\\/g, "/")}`);
+  console.log(`Wrote runtime observability dossier JSON: ${path.relative(process.cwd(), artifacts.runtimeObservabilityDossierPath).replace(/\\/g, "/")}`);
   console.log(`Wrote release gate summary JSON: ${path.relative(process.cwd(), artifacts.releaseGateSummaryPath).replace(/\\/g, "/")}`);
   console.log(`Wrote release health summary JSON: ${path.relative(process.cwd(), artifacts.releaseHealthSummaryPath).replace(/\\/g, "/")}`);
   console.log(`Candidate: ${dossier.candidate.name}`);

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -356,7 +356,7 @@ const DEFAULT_WECHAT_ARTIFACTS_DIR = path.resolve("artifacts", "wechat-release")
 const DEFAULT_CONFIG_CENTER_LIBRARY_PATH = path.resolve("configs", ".config-center-library.json");
 const HEX_REVISION_PATTERN = /^[a-f0-9]+$/i;
 const MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS = 1000 * 60 * 60 * 72;
-const MAX_TARGET_SURFACE_REVIEW_AGE_MS = 1000 * 60 * 60 * 24;
+const MAX_TARGET_SURFACE_REVIEW_AGE_MS = 1000 * 60 * 60 * 72;
 const RISK_PRIORITY: Record<ConfigRiskLevel, number> = {
   low: 1,
   medium: 2,

--- a/scripts/release-go-no-go-decision-packet.ts
+++ b/scripts/release-go-no-go-decision-packet.ts
@@ -47,6 +47,8 @@ interface Phase1CandidateDossier {
     outputDir: string;
     dossierJsonPath: string;
     dossierMarkdownPath: string;
+    runtimeObservabilityDossierPath: string;
+    runtimeObservabilityDossierMarkdownPath: string;
     releaseGateSummaryPath: string;
     releaseGateMarkdownPath: string;
     releaseHealthSummaryPath: string;
@@ -211,6 +213,7 @@ interface GoNoGoDecisionPacket {
   };
   inputs: {
     dossierPath: string;
+    runtimeObservabilityDossierPath?: string;
     releaseGateSummaryPath: string;
     wechatCandidateSummaryPath?: string;
   };
@@ -524,6 +527,10 @@ export function buildGoNoGoDecisionPacket(args: Args): GoNoGoDecisionPacket {
       : dossier.artifacts?.releaseGateSummaryPath && fs.existsSync(dossier.artifacts.releaseGateSummaryPath)
         ? dossier.artifacts.releaseGateSummaryPath
         : resolveReleaseGateSummaryPath(args);
+  const runtimeObservabilityDossierPath =
+    dossier.artifacts?.runtimeObservabilityDossierPath && fs.existsSync(dossier.artifacts.runtimeObservabilityDossierPath)
+      ? dossier.artifacts.runtimeObservabilityDossierPath
+      : undefined;
   const releaseGate = readJsonFile<ReleaseGateSummaryReport>(releaseGateSummaryPath);
   const wechatCandidateSummaryPath = resolveWechatCandidateSummaryPath(args, releaseGateSummaryPath, dossier);
   const wechatCandidateSummary = wechatCandidateSummaryPath
@@ -688,6 +695,7 @@ export function buildGoNoGoDecisionPacket(args: Args): GoNoGoDecisionPacket {
     },
     inputs: {
       dossierPath,
+      ...(runtimeObservabilityDossierPath ? { runtimeObservabilityDossierPath } : {}),
       releaseGateSummaryPath,
       ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {})
     },
@@ -736,6 +744,9 @@ export function renderMarkdown(packet: GoNoGoDecisionPacket): string {
   lines.push("## Candidate Metadata");
   lines.push("");
   lines.push(`- Candidate dossier: \`${toDisplayPath(packet.inputs.dossierPath)}\``);
+  if (packet.inputs.runtimeObservabilityDossierPath) {
+    lines.push(`- Runtime observability dossier: \`${toDisplayPath(packet.inputs.runtimeObservabilityDossierPath)}\``);
+  }
   lines.push(`- Release gate summary: \`${toDisplayPath(packet.inputs.releaseGateSummaryPath)}\``);
   if (packet.inputs.wechatCandidateSummaryPath) {
     lines.push(`- WeChat candidate summary: \`${toDisplayPath(packet.inputs.wechatCandidateSummaryPath)}\``);

--- a/scripts/test/phase1-candidate-dossier.test.ts
+++ b/scripts/test/phase1-candidate-dossier.test.ts
@@ -822,6 +822,8 @@ test("phase1 candidate dossier CLI writes a stable candidate bundle directory wi
 
   const dossierJsonPath = path.join(outputDir, "phase1-candidate-dossier.json");
   const dossierMarkdownPath = path.join(outputDir, "phase1-candidate-dossier.md");
+  const runtimeObservabilityDossierPath = path.join(outputDir, "runtime-observability-dossier.json");
+  const runtimeObservabilityDossierMarkdownPath = path.join(outputDir, "runtime-observability-dossier.md");
   const releaseGateSummaryPath = path.join(outputDir, "release-gate-summary.json");
   const releaseGateMarkdownPath = path.join(outputDir, "release-gate-summary.md");
   const releaseHealthSummaryPath = path.join(outputDir, "release-health-summary.json");
@@ -830,6 +832,8 @@ test("phase1 candidate dossier CLI writes a stable candidate bundle directory wi
   for (const filePath of [
     dossierJsonPath,
     dossierMarkdownPath,
+    runtimeObservabilityDossierPath,
+    runtimeObservabilityDossierMarkdownPath,
     releaseGateSummaryPath,
     releaseGateMarkdownPath,
     releaseHealthSummaryPath,
@@ -841,19 +845,42 @@ test("phase1 candidate dossier CLI writes a stable candidate bundle directory wi
   const dossier = JSON.parse(fs.readFileSync(dossierJsonPath, "utf8")) as {
     artifacts?: {
       outputDir: string;
+      runtimeObservabilityDossierPath: string;
       releaseGateSummaryPath: string;
       releaseHealthSummaryPath: string;
     };
     sections: Array<{ id: string; artifactPath?: string }>;
   };
   assert.equal(dossier.artifacts?.outputDir, outputDir);
+  assert.equal(dossier.artifacts?.runtimeObservabilityDossierPath, runtimeObservabilityDossierPath);
   assert.equal(dossier.artifacts?.releaseGateSummaryPath, releaseGateSummaryPath);
   assert.equal(dossier.artifacts?.releaseHealthSummaryPath, releaseHealthSummaryPath);
   assert.equal(dossier.sections.find((section) => section.id === "release-gate")?.artifactPath, releaseGateSummaryPath);
   assert.equal(dossier.sections.find((section) => section.id === "release-health")?.artifactPath, releaseHealthSummaryPath);
 
+  const runtimeObservabilityDossier = JSON.parse(fs.readFileSync(runtimeObservabilityDossierPath, "utf8")) as {
+    summary: {
+      status: string;
+      runtimeStatus: string;
+      reconnectStatus: string;
+    };
+    sections: Array<{ id: string }>;
+  };
+  assert.equal(runtimeObservabilityDossier.summary.status, "passed");
+  assert.equal(runtimeObservabilityDossier.summary.runtimeStatus, "passed");
+  assert.equal(runtimeObservabilityDossier.summary.reconnectStatus, "passed");
+  assert.deepEqual(
+    runtimeObservabilityDossier.sections.map((section) => section.id),
+    ["runtime-health", "reconnect-soak"]
+  );
+
   const markdown = fs.readFileSync(dossierMarkdownPath, "utf8");
   assert.match(markdown, /## Generated Bundle/);
+  assert.match(markdown, /runtime-observability-dossier\.json/);
   assert.match(markdown, /release-gate-summary\.json/);
   assert.match(markdown, /release-health-summary\.json/);
+
+  const runtimeMarkdown = fs.readFileSync(runtimeObservabilityDossierMarkdownPath, "utf8");
+  assert.match(runtimeMarkdown, /# Runtime Observability Dossier/);
+  assert.match(runtimeMarkdown, /Reconnect\/session-recovery status: `passed`/);
 });

--- a/scripts/test/release-go-no-go-decision-packet.test.ts
+++ b/scripts/test/release-go-no-go-decision-packet.test.ts
@@ -22,8 +22,16 @@ test("buildGoNoGoDecisionPacket aggregates candidate, gate, and manual review ev
   const dossierDir = path.join(releaseDir, "phase1-candidate-dossier-phase1-rc-abc1234");
   const wechatDir = path.join(workspace, "artifacts", "wechat-release");
   const dossierPath = path.join(dossierDir, "phase1-candidate-dossier.json");
+  const runtimeObservabilityDossierPath = path.join(dossierDir, "runtime-observability-dossier.json");
   const releaseGateSummaryPath = path.join(releaseDir, "release-gate-summary-abc1234.json");
   const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
+
+  writeJson(runtimeObservabilityDossierPath, {
+    generatedAt: "2026-04-03T02:01:00.000Z",
+    summary: {
+      status: "passed"
+    }
+  });
 
   writeJson(dossierPath, {
     generatedAt: "2026-04-03T02:00:00.000Z",
@@ -53,6 +61,8 @@ test("buildGoNoGoDecisionPacket aggregates candidate, gate, and manual review ev
       outputDir: dossierDir,
       dossierJsonPath: dossierPath,
       dossierMarkdownPath: path.join(dossierDir, "phase1-candidate-dossier.md"),
+      runtimeObservabilityDossierPath,
+      runtimeObservabilityDossierMarkdownPath: path.join(dossierDir, "runtime-observability-dossier.md"),
       releaseGateSummaryPath,
       releaseGateMarkdownPath: path.join(dossierDir, "release-gate-summary.md"),
       releaseHealthSummaryPath: path.join(dossierDir, "release-health-summary.json"),
@@ -171,6 +181,7 @@ test("buildGoNoGoDecisionPacket aggregates candidate, gate, and manual review ev
 
   assert.equal(packet.decision.status, "no_go");
   assert.equal(packet.candidate.name, "phase1-rc");
+  assert.equal(packet.inputs.runtimeObservabilityDossierPath, runtimeObservabilityDossierPath);
   assert.equal(packet.sections.runtimeObservabilitySignoffLinks.length, 1);
   assert.equal(packet.sections.unresolvedManualChecks.length, 1);
   assert.match(packet.sections.validationSummary.summary, /Phase 1 exit evidence gate is accepted_risk/);
@@ -179,6 +190,7 @@ test("buildGoNoGoDecisionPacket aggregates candidate, gate, and manual review ev
 
   const markdown = renderMarkdown(packet);
   assert.match(markdown, /Decision: `no_go`/);
+  assert.match(markdown, /Runtime observability dossier: `.*runtime-observability-dossier\.json`/);
   assert.match(markdown, /## Runtime Observability Sign-Off Links/);
   assert.match(markdown, /WeChat runtime observability reviewed for this candidate/);
   assert.match(markdown, /## Unresolved Manual Checks \(1\)/);


### PR DESCRIPTION
## Summary
- add runtime observability dossier outputs to the Phase 1 candidate dossier bundle and surface the artifact in the go/no-go packet
- align WeChat manual-review freshness with the Phase 1 evidence window so accepted-risk candidate dossiers do not fail the derived release gate
- allow H5 dossier generation without a live runtime URL while preserving reconnect evidence in the generated runtime observability bundle

## Testing
- `node --import tsx --test scripts/test/phase1-candidate-dossier.test.ts`
- `node --import tsx --test scripts/test/release-go-no-go-decision-packet.test.ts`

Closes #752