### PR TITLE
Replace WeChat auth mock with code2session integration

### DIFF
--- a/apps/cocos-client/README.md
+++ b/apps/cocos-client/README.md
@@ -182,25 +182,24 @@
 这只是 issue #30 的基础切片，当前还没有完成：
 
 - Cocos Creator 微信小游戏构建目标配置
-- 真正接微信 `code2Session / openid / unionid` 的生产登录链路
-- OpenID 绑定、头像昵称同步
 - 真机性能与内存优化
 
 ## 微信登录脚手架
 
-本轮在运行时基础之上，继续补了一层“可合并但不虚假宣称生产完成”的登录脚手架：
+当前仓库的微信登录链路已经改成真实的服务端 `code2session` 交换，客户端侧仍保持最小 provider 封装：
 
 - 新增 `assets/scripts/cocos-login-provider.ts`
   - 把 `guest / account-password / wechat-mini-game` 三类入口收口成统一 provider 抽象
   - 会按运行时能力、`wx.login()` 可用性和小游戏配置决定 Lobby 主登录按钮文案
 - 新增 `loginCocosWechatAuthSession()`
   - 微信小游戏环境优先走 `wx.login()`
-  - 如果当前调试壳没有原生 `wx.login()`，但配置了 mock code，则允许退化到 mock 交换
+  - 如果当前调试壳没有原生 `wx.login()`，只有在 `NODE_ENV=test` 的服务端测试环境才允许退化到 mock code
   - 交换成功后会把会话以 `provider = "wechat-mini-game"` 写入本地缓存，方便后续 UI / 调试识别
 - 服务端新增 `POST /api/auth/wechat-mini-game-login`
-  - 默认返回 `501`
-  - 仅在 `VEIL_WECHAT_MINIGAME_LOGIN_MODE=mock` 时启用 mock 交换
-  - 当前只是开发脚手架，不会触发真实微信 `code2Session`
+  - 别名仍然可用，实际实现与 `POST /api/auth/wechat-login` 相同
+  - 服务端会用 `WECHAT_APP_ID` / `WECHAT_APP_SECRET` 调用微信 `code2session`
+  - 同一个微信小游戏账号会稳定绑定到同一个 `playerId`
+  - 服务端绝不会把微信 `session_key` 回传给客户端
 
 当前支持的配置项：
 
@@ -210,14 +209,17 @@
   - `globalThis.__PROJECT_VEIL_RUNTIME_CONFIG__.wechatMiniGame.mockCode`
   - `globalThis.__PROJECT_VEIL_RUNTIME_CONFIG__.wechatMiniGame.appId`
 - 服务端环境变量：
-  - `VEIL_WECHAT_MINIGAME_LOGIN_MODE=mock`
-  - `VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE=wechat-dev-code`
+  - `WECHAT_APP_ID=<mini-game-appid>`
+  - `WECHAT_APP_SECRET=<mini-game-secret>`
+  - `VEIL_WECHAT_MINIGAME_CODE2SESSION_URL=https://api.weixin.qq.com/sns/jscode2session`
+  - `VEIL_WECHAT_MINIGAME_LOGIN_MODE=mock` 仅用于 `NODE_ENV=test`
+  - `VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE=wechat-dev-code` 仅用于 `NODE_ENV=test`
 
-一个本地联调用例：
+一个服务端联调用例：
 
 ```bash
-VEIL_WECHAT_MINIGAME_LOGIN_MODE=mock \
-VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE=wechat-dev-code \
+WECHAT_APP_ID=wx-your-app-id \
+WECHAT_APP_SECRET=wx-your-app-secret \
 npm run dev:server
 ```
 
@@ -226,13 +228,11 @@ npm run dev:server
 ```ts
 (globalThis as { __PROJECT_VEIL_RUNTIME_CONFIG__?: unknown }).__PROJECT_VEIL_RUNTIME_CONFIG__ = {
   wechatMiniGame: {
-    enabled: true,
-    mockCode: "wechat-dev-code"
+    enabled: true
   }
 };
 ```
-
-这样 Lobby 会优先展示“微信登录并进入”，但它仍然只是 mock / scaffold，不代表已经完成生产发布链路。
+这样 Lobby 会优先展示“微信登录并进入”，并把 `wx.login()` 拿到的 code 交给服务端做正式交换。
 
 ## 微信小游戏构建脚手架
 

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -285,10 +285,12 @@ export function cachePlayerAccountAuthState(input: {
 }
 
 function readWechatMiniGameLoginConfig(env: NodeJS.ProcessEnv = process.env): WechatMiniGameLoginConfig {
+  const isTestEnvironment = env.NODE_ENV?.trim().toLowerCase() === "test";
   const normalizedMode = env.VEIL_WECHAT_MINIGAME_LOGIN_MODE?.trim().toLowerCase();
-  const defaultMode = env.NODE_ENV?.trim().toLowerCase() === "production" ? "disabled" : "mock";
+  const hasWechatCredentials = Boolean(env.WECHAT_APP_ID?.trim() && env.WECHAT_APP_SECRET?.trim());
+  const defaultMode = isTestEnvironment ? "mock" : hasWechatCredentials ? "production" : "disabled";
   const mode =
-    normalizedMode === "mock"
+    normalizedMode === "mock" && isTestEnvironment
       ? "mock"
       : normalizedMode === "production" || normalizedMode === "code2session"
         ? "production"
@@ -299,8 +301,8 @@ function readWechatMiniGameLoginConfig(env: NodeJS.ProcessEnv = process.env): We
     mode,
     mockCode: env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE?.trim() || "wechat-dev-code",
     code2SessionUrl: env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL?.trim() || "https://api.weixin.qq.com/sns/jscode2session",
-    ...(env.VEIL_WECHAT_MINIGAME_APP_ID?.trim() ? { appId: env.VEIL_WECHAT_MINIGAME_APP_ID.trim() } : {}),
-    ...(env.VEIL_WECHAT_MINIGAME_APP_SECRET?.trim() ? { appSecret: env.VEIL_WECHAT_MINIGAME_APP_SECRET.trim() } : {})
+    ...(env.WECHAT_APP_ID?.trim() ? { appId: env.WECHAT_APP_ID.trim() } : {}),
+    ...(env.WECHAT_APP_SECRET?.trim() ? { appSecret: env.WECHAT_APP_SECRET.trim() } : {})
   };
 }
 

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -304,20 +304,24 @@ function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPaylo
 function buildAuthReadinessPayload(service = "project-veil-server"): AuthReadinessPayload {
   const health = buildHealthPayload(service);
   const alerts: string[] = [];
+  const isTestEnvironment = process.env.NODE_ENV?.trim().toLowerCase() === "test";
   const normalizedWechatMode = process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE?.trim().toLowerCase();
+  const hasWechatCredentials = Boolean(process.env.WECHAT_APP_ID?.trim() && process.env.WECHAT_APP_SECRET?.trim());
   const wechatMode =
-    normalizedWechatMode === "mock"
+    normalizedWechatMode === "mock" && isTestEnvironment
       ? "mock"
       : normalizedWechatMode === "production" || normalizedWechatMode === "code2session"
         ? "production"
         : normalizedWechatMode === "disabled"
           ? "disabled"
-          : process.env.NODE_ENV?.trim().toLowerCase() === "production"
-            ? "disabled"
-            : "mock";
+          : isTestEnvironment
+            ? "mock"
+            : hasWechatCredentials
+              ? "production"
+              : "disabled";
   const wechatCredentialsStatus =
     wechatMode === "production"
-      ? process.env.VEIL_WECHAT_MINIGAME_APP_ID?.trim() && process.env.VEIL_WECHAT_MINIGAME_APP_SECRET?.trim()
+      ? process.env.WECHAT_APP_ID?.trim() && process.env.WECHAT_APP_SECRET?.trim()
         ? "configured"
         : "missing"
       : "not_required";

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -2485,17 +2485,20 @@ test("password recovery request returns 502 and dead-letters non-retryable webho
   assert.equal(deliveryPayload.delivery.recentAttempts[0]?.failureReason, "webhook_4xx");
 });
 
-test("wechat login defaults to mock mode outside production", { concurrency: false }, async (t) => {
+test("wechat login defaults to mock mode in NODE_ENV=test", { concurrency: false }, async (t) => {
   const port = 44750 + Math.floor(Math.random() * 1000);
   const server = await startAuthServer(port);
+  const previousNodeEnv = process.env.NODE_ENV;
 
   t.after(async () => {
+    process.env.NODE_ENV = previousNodeEnv;
     delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
     delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE;
     resetGuestAuthSessions();
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
+  process.env.NODE_ENV = "test";
   delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
   const response = await fetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
     method: "POST",
@@ -2513,6 +2516,7 @@ test("wechat login defaults to mock mode outside production", { concurrency: fal
   assert.equal(response.status, 200);
   assert.equal(payload.session.playerId, "wechat-player");
   assert.equal(payload.session.provider, "wechat-mini-game");
+  assert.equal("session_key" in payload.session, false);
 });
 
 test("wechat login route can be explicitly disabled", { concurrency: false }, async (t) => {
@@ -2547,14 +2551,17 @@ test("wechat login route can be explicitly disabled", { concurrency: false }, as
 test("legacy wechat mini game route remains available as an alias", { concurrency: false }, async (t) => {
   const port = 44855 + Math.floor(Math.random() * 1000);
   const server = await startAuthServer(port, new MemoryAuthStore());
+  const previousNodeEnv = process.env.NODE_ENV;
 
   t.after(async () => {
+    process.env.NODE_ENV = previousNodeEnv;
     delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
     delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE;
     resetGuestAuthSessions();
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
+  process.env.NODE_ENV = "test";
   process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "mock";
   process.env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE = "wx-dev-code";
   const response = await fetch(`http://127.0.0.1:${port}/api/auth/wechat-mini-game-login`, {
@@ -2574,6 +2581,7 @@ test("legacy wechat mini game route remains available as an alias", { concurrenc
   assert.equal(payload.session.playerId, "wechat-player");
   assert.equal(payload.session.provider, "wechat-mini-game");
   assert.equal(payload.session.authMode, "guest");
+  assert.equal("session_key" in payload.session, false);
 });
 
 test("wechat mini game production exchange binds code2Session identity onto an authenticated account", { concurrency: false }, async (t) => {
@@ -2602,16 +2610,16 @@ test("wechat mini game production exchange binds code2Session identity onto an a
   t.after(async () => {
     globalThis.fetch = originalFetch;
     delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
-    delete process.env.VEIL_WECHAT_MINIGAME_APP_ID;
-    delete process.env.VEIL_WECHAT_MINIGAME_APP_SECRET;
+    delete process.env.WECHAT_APP_ID;
+    delete process.env.WECHAT_APP_SECRET;
     delete process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL;
     resetGuestAuthSessions();
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
   process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "production";
-  process.env.VEIL_WECHAT_MINIGAME_APP_ID = "wx-prod-app";
-  process.env.VEIL_WECHAT_MINIGAME_APP_SECRET = "wx-prod-secret";
+  process.env.WECHAT_APP_ID = "wx-prod-app";
+  process.env.WECHAT_APP_SECRET = "wx-prod-secret";
   process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL = "https://wechat.example.test/code2session";
   globalThis.fetch = async (input, init) => {
     requestedUrl = String(input);
@@ -2651,6 +2659,7 @@ test("wechat mini game production exchange binds code2Session identity onto an a
   assert.equal(payload.session.provider, "wechat-mini-game");
   assert.equal(payload.session.authMode, "account");
   assert.equal(payload.session.loginId, "veil-ranger");
+  assert.equal("session_key" in payload.session, false);
 
   const requestUrl = new URL(requestedUrl);
   assert.equal(requestUrl.origin + requestUrl.pathname, "https://wechat.example.test/code2session");
@@ -2677,16 +2686,16 @@ test("wechat mini game login reuses the bound player even when later requests sp
   t.after(async () => {
     globalThis.fetch = originalFetch;
     delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
-    delete process.env.VEIL_WECHAT_MINIGAME_APP_ID;
-    delete process.env.VEIL_WECHAT_MINIGAME_APP_SECRET;
+    delete process.env.WECHAT_APP_ID;
+    delete process.env.WECHAT_APP_SECRET;
     delete process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL;
     resetGuestAuthSessions();
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
   process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "production";
-  process.env.VEIL_WECHAT_MINIGAME_APP_ID = "wx-prod-app";
-  process.env.VEIL_WECHAT_MINIGAME_APP_SECRET = "wx-prod-secret";
+  process.env.WECHAT_APP_ID = "wx-prod-app";
+  process.env.WECHAT_APP_SECRET = "wx-prod-secret";
   process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL = "https://wechat.example.test/code2session";
   globalThis.fetch = async () =>
     new Response(
@@ -2734,10 +2743,46 @@ test("wechat mini game login reuses the bound player even when later requests sp
   assert.equal(secondPayload.session.playerId, "wechat-player");
   assert.equal(secondPayload.session.displayName, "回归旅人");
   assert.equal(secondPayload.session.provider, "wechat-mini-game");
+  assert.equal("session_key" in firstPayload.session, false);
+  assert.equal("session_key" in secondPayload.session, false);
 
   const boundAccount = await store.loadPlayerAccount("wechat-player");
   const spoofedAccount = await store.loadPlayerAccount("spoofed-player");
   assert.equal(boundAccount?.wechatMiniGameOpenId, "wx-openid-repeat");
   assert.equal(boundAccount?.displayName, "回归旅人");
   assert.equal(spoofedAccount, null);
+});
+
+test("wechat mock mode stays disabled outside NODE_ENV=test", { concurrency: false }, async (t) => {
+  const port = 45080 + Math.floor(Math.random() * 1000);
+  const server = await startAuthServer(port, new MemoryAuthStore());
+  const previousNodeEnv = process.env.NODE_ENV;
+
+  t.after(async () => {
+    process.env.NODE_ENV = previousNodeEnv;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE;
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  process.env.NODE_ENV = "development";
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "mock";
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MOCK_CODE = "wx-dev-code";
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      code: "wx-dev-code",
+      playerId: "wechat-player",
+      displayName: "云桥旅人"
+    })
+  });
+  const payload = (await response.json()) as { error: { code: string } };
+
+  assert.equal(response.status, 501);
+  assert.equal(payload.error.code, "wechat_login_not_enabled");
 });

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -5,6 +5,7 @@
 ## 当前已落地能力
 
 - 游客登录：`POST /api/auth/guest-login`
+- 微信小游戏登录：`POST /api/auth/wechat-login`（`/api/auth/wechat-mini-game-login` 仍保留别名）
 - 游客档升级成口令账号：`POST /api/auth/account-bind`
 - 口令账号登录：`POST /api/auth/account-login`
 - 会话校验 / 刷新 / 退出：`GET /api/auth/session`、`POST /api/auth/refresh`、`POST /api/auth/logout`
@@ -17,6 +18,14 @@
 1. 玩家可先以游客身份进入房间并形成 `player_accounts` 档案。
 2. 需要长期登录时，再把当前游客档绑定到 `loginId + password`。
 3. 后续账号登录会继续复用同一份英雄长期档、全局资源仓库和账号事件历史。
+
+## 微信小游戏 code2session
+
+- `POST /api/auth/wechat-login` 会用服务端环境变量 `WECHAT_APP_ID` / `WECHAT_APP_SECRET` 调用微信 `jscode2session`。
+- 当同一个微信小游戏账号重复登录时，服务端会复用已经绑定过的 `playerId`，不会因为客户端再次提交不同的 `playerId` 而漂移。
+- 若当前请求已经带有正式账号会话，服务端会把该微信身份绑定到现有账号；后续该微信登录会继续命中同一个账号档。
+- 服务端只消费微信返回的 `openid` / `unionid` 做绑定，不会把 `session_key` 写入客户端响应。
+- mock code 仅保留给 `NODE_ENV=test` 的自动化测试；非测试环境即使显式配置 `VEIL_WECHAT_MINIGAME_LOGIN_MODE=mock` 也不会启用。
 
 ## 设备会话管理
 


### PR DESCRIPTION
Closes #773

## Testing
- `node --import tsx --test ./apps/server/test/auth-guest-login.test.ts`
- `node --import tsx --test ./apps/server/test/runtime-observability-routes.test.ts`
- `npm run typecheck:server` *(currently fails due to pre-existing `packages/shared/src/content-pack-validation.ts` TS18046 errors)*