### PR TITLE
Fix validateWorldAction movement distance cap

### DIFF
--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -951,6 +951,10 @@ function getMovementPlan(state: WorldState, heroId: string, destination: Vec2): 
   return undefined;
 }
 
+function getMovementDistance(plan: Pick<MovementPlan, "path">): number {
+  return Math.max(0, plan.path.length - 1);
+}
+
 function buildNextWorldState(
   base: WorldState,
   heroes: HeroState[],
@@ -1409,7 +1413,7 @@ export function listReachableTiles(state: WorldState, heroId: string): Vec2[] {
   return state.map.tiles
     .filter((tile) => {
       const plan = planHeroMovement(state, heroId, tile.position);
-      return Boolean(plan && plan.moveCost <= hero.move.remaining);
+      return Boolean(plan && getMovementDistance(plan) <= hero.move.remaining);
     })
     .map((tile) => tile.position);
 }
@@ -1423,7 +1427,7 @@ export function listReachableTilesInPlayerView(view: PlayerWorldView, heroId: st
   return view.map.tiles
     .filter((tile) => {
       const plan = planPlayerViewMovement(view, heroId, tile.position);
-      return Boolean(plan && plan.moveCost <= hero.move.remaining);
+      return Boolean(plan && getMovementDistance(plan) <= hero.move.remaining);
     })
     .map((tile) => tile.position);
 }
@@ -1546,7 +1550,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
       };
     }
 
-    if (plan.moveCost > hero.move.remaining) {
+    if (getMovementDistance(plan) > hero.move.remaining) {
       return {
         world: view,
         movementPlan: null,
@@ -1928,7 +1932,7 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
       return { valid: false, reason: "path_not_found" };
     }
 
-    if (plan.moveCost > hero.move.remaining) {
+    if (getMovementDistance(plan) > hero.move.remaining) {
       return { valid: false, reason: "not_enough_move_points" };
     }
 

--- a/packages/shared/test/move-distance-cap.test.ts
+++ b/packages/shared/test/move-distance-cap.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createDefaultHeroLoadout,
+  createDefaultHeroProgression,
+  createPlayerWorldView,
+  predictPlayerWorldAction,
+  validateWorldAction,
+  type HeroState,
+  type NeutralArmyState,
+  type ResourceNode,
+  type TileState,
+  type WorldState
+} from "../src/index";
+
+function createHero(overrides: Partial<HeroState> & Pick<HeroState, "id" | "playerId" | "name">): HeroState {
+  return {
+    id: overrides.id,
+    playerId: overrides.playerId,
+    name: overrides.name,
+    position: overrides.position ?? { x: 0, y: 0 },
+    vision: overrides.vision ?? 2,
+    move: overrides.move ?? { total: 6, remaining: 6 },
+    stats: overrides.stats ?? {
+      attack: 2,
+      defense: 2,
+      power: 1,
+      knowledge: 1,
+      hp: 30,
+      maxHp: 30
+    },
+    progression: overrides.progression ?? createDefaultHeroProgression(),
+    loadout: overrides.loadout ?? createDefaultHeroLoadout(),
+    armyTemplateId: overrides.armyTemplateId ?? "hero_guard_basic",
+    armyCount: overrides.armyCount ?? 12,
+    learnedSkills: overrides.learnedSkills ?? []
+  };
+}
+
+function createTile(
+  x: number,
+  y: number,
+  options?: {
+    walkable?: boolean;
+    terrain?: TileState["terrain"];
+    resource?: ResourceNode;
+    occupant?: TileState["occupant"];
+    building?: TileState["building"];
+  }
+): TileState {
+  return {
+    position: { x, y },
+    terrain: options?.terrain ?? "grass",
+    walkable: options?.walkable ?? true,
+    resource: options?.resource,
+    occupant: options?.occupant,
+    building: options?.building
+  };
+}
+
+function createWorldState(options?: {
+  width?: number;
+  height?: number;
+  tiles?: TileState[];
+  heroes?: HeroState[];
+  neutralArmies?: Record<string, NeutralArmyState>;
+  buildings?: WorldState["buildings"];
+  resources?: WorldState["resources"];
+  visibilityByPlayer?: WorldState["visibilityByPlayer"];
+}): WorldState {
+  const width = options?.width ?? 3;
+  const height = options?.height ?? 3;
+  const tiles =
+    options?.tiles ??
+    Array.from({ length: width * height }, (_, index) => createTile(index % width, Math.floor(index / width)));
+  const heroes = options?.heroes ?? [];
+
+  return {
+    meta: {
+      roomId: "test-room",
+      seed: 1001,
+      day: 1
+    },
+    map: {
+      width,
+      height,
+      tiles
+    },
+    heroes,
+    neutralArmies: options?.neutralArmies ?? {},
+    buildings: options?.buildings ?? {},
+    resources:
+      options?.resources ??
+      Object.fromEntries(
+        Array.from(new Set(heroes.map((hero) => hero.playerId))).map((playerId) => [
+          playerId,
+          {
+            gold: 0,
+            wood: 0,
+            ore: 0
+          }
+        ])
+      ),
+    visibilityByPlayer: options?.visibilityByPlayer ?? {}
+  };
+}
+
+function createEncounterState(remainingMove: number): WorldState {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 0 },
+    move: { total: 6, remaining: remainingMove }
+  });
+  const neutralArmy: NeutralArmyState = {
+    id: "neutral-1",
+    position: { x: 2, y: 0 },
+    reward: { kind: "gold", amount: 300 },
+    stacks: [{ templateId: "wolf_pack", count: 8 }]
+  };
+
+  return createWorldState({
+    width: 3,
+    height: 1,
+    heroes: [hero],
+    neutralArmies: { "neutral-1": neutralArmy },
+    tiles: [
+      createTile(0, 0, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(1, 0),
+      createTile(2, 0, { occupant: { kind: "neutral", refId: "neutral-1" } })
+    ],
+    visibilityByPlayer: {
+      "player-1": ["visible", "visible", "visible"]
+    }
+  });
+}
+
+test("validateWorldAction rejects encounter moves beyond the remaining full path distance", () => {
+  const state = createEncounterState(1);
+
+  assert.deepEqual(validateWorldAction(state, {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 }
+  }), {
+    valid: false,
+    reason: "not_enough_move_points"
+  });
+  assert.equal(
+    predictPlayerWorldAction(createPlayerWorldView(state, "player-1"), {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 2, y: 0 }
+    }).reason,
+    "not_enough_move_points"
+  );
+});
+
+test("validateWorldAction allows encounter moves within the remaining full path distance", () => {
+  const state = createEncounterState(2);
+
+  assert.deepEqual(validateWorldAction(state, {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 2, y: 0 }
+  }), {
+    valid: true
+  });
+  assert.equal(
+    predictPlayerWorldAction(createPlayerWorldView(state, "player-1"), {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 2, y: 0 }
+    }).reason,
+    undefined
+  );
+});


### PR DESCRIPTION
Closes #775

## Summary
- enforce movement range checks against full path distance in shared move validation
- keep shared prediction and reachable-tile checks aligned with the same cap
- add focused shared regression coverage for over-range and in-range encounter moves

## Testing
- node --import tsx --test packages/shared/test/move-distance-cap.test.ts
- npm run test:shared