### PR TITLE
[codex] fix: track skill cooldowns server-side

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/battle.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle.ts
@@ -64,13 +64,95 @@ function hazardsOf(state: BattleState): BattleHazardState[] {
   return state.environment ?? [];
 }
 
+function normalizeBattleRngState(state: BattleState): BattleState["rng"] {
+  const rng = state.rng;
+  return {
+    seed: Number.isFinite(rng?.seed) ? Math.floor(rng.seed) >>> 0 : 1,
+    cursor: Number.isFinite(rng?.cursor) ? Math.max(0, Math.floor(rng.cursor)) : 0
+  };
+}
+
+function normalizedCooldownValue(value: unknown): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(Number(value)));
+}
+
+function buildCooldownStateFromSkills(unit: UnitStack): Record<string, number> {
+  const cooldowns: Record<string, number> = {};
+
+  for (const skill of skillsOf(unit)) {
+    if (skill.kind !== "active") {
+      continue;
+    }
+
+    const remainingCooldown = normalizedCooldownValue(skill.remainingCooldown);
+    if (remainingCooldown > 0) {
+      cooldowns[skill.id] = remainingCooldown;
+    }
+  }
+
+  return cooldowns;
+}
+
+function withSynchronizedSkillCooldowns(unit: UnitStack, cooldowns: Record<string, number>): UnitStack {
+  const skills = skillsOf(unit);
+  if (skills.length === 0) {
+    return unit;
+  }
+
+  return {
+    ...unit,
+    skills: skills.map((skill) => ({
+      ...skill,
+      remainingCooldown: skill.kind === "active" ? normalizedCooldownValue(cooldowns[skill.id]) : 0
+    }))
+  };
+}
+
+function normalizeBattleCooldowns(
+  units: Record<string, UnitStack>,
+  existingCooldowns?: BattleState["unitCooldowns"]
+): BattleState["unitCooldowns"] {
+  return Object.fromEntries(
+    Object.entries(units).map(([unitId, unit]) => {
+      const fallbackCooldowns = buildCooldownStateFromSkills(unit);
+      const unitCooldowns = existingCooldowns?.[unitId];
+
+      if (!unitCooldowns) {
+        return [unitId, fallbackCooldowns];
+      }
+
+      const normalizedCooldowns = Object.fromEntries(
+        Object.entries(unitCooldowns)
+          .map(([skillId, remainingTurns]) => [skillId, normalizedCooldownValue(remainingTurns)] as const)
+          .filter(([, remainingTurns]) => remainingTurns > 0)
+      );
+
+      return [unitId, Object.keys(normalizedCooldowns).length > 0 ? normalizedCooldowns : fallbackCooldowns];
+    })
+  );
+}
+
 function normalizeBattleState(state: BattleState): BattleState {
+  const normalizedUnits = Object.fromEntries(
+    Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
+  );
+  const normalizedCooldowns = normalizeBattleCooldowns(normalizedUnits, state.unitCooldowns);
+
   return {
     ...state,
     units: Object.fromEntries(
-      Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
+      Object.entries(normalizedUnits).map(([unitId, unit]) => [
+        unitId,
+        withSynchronizedSkillCooldowns(unit, normalizedCooldowns[unitId] ?? {})
+      ])
     ),
-    environment: hazardsOf(state).map(cloneHazardState)
+    unitCooldowns: normalizedCooldowns,
+    environment: hazardsOf(state).map(cloneHazardState),
+    rng: normalizeBattleRngState(state)
   };
 }
 
@@ -350,6 +432,20 @@ function tickUnitSkillCooldowns(unit: UnitStack): UnitStack {
     skills: skills.map((skill) =>
       skill.remainingCooldown > 0 ? { ...skill, remainingCooldown: skill.remainingCooldown - 1 } : skill
     )
+  };
+}
+
+function withUpdatedUnitCooldowns(state: BattleState, unit: UnitStack): BattleState {
+  return {
+    ...state,
+    units: {
+      ...state.units,
+      [unit.id]: unit
+    },
+    unitCooldowns: {
+      ...state.unitCooldowns,
+      [unit.id]: buildCooldownStateFromSkills(unit)
+    }
   };
 }
 
@@ -743,14 +839,13 @@ function prepareStateForActiveUnit(state: BattleState): BattleState {
     const activeUnit = nextState.units[nextState.activeUnitId]!;
 
     const processed = processTurnStartForUnit(activeUnit);
-    nextState = {
-      ...nextState,
-      units: {
-        ...nextState.units,
-        [activeUnit.id]: processed.unit
+    nextState = withUpdatedUnitCooldowns(
+      {
+        ...nextState,
+        log: processed.log.length > 0 ? nextState.log.concat(processed.log) : nextState.log
       },
-      log: processed.log.length > 0 ? nextState.log.concat(processed.log) : nextState.log
-    };
+      processed.unit
+    );
 
     if (processed.unit.count > 0) {
       break;
@@ -962,13 +1057,7 @@ export function executeBattleSkill(
   skillId: BattleSkillId,
   targetId?: string
 ): BattleState {
-  const normalizedState: BattleState = {
-    ...state,
-    units: Object.fromEntries(
-      Object.entries(state.units).map(([currentUnitId, unit]) => [currentUnitId, withNormalizedCollections(unit)])
-    ),
-    environment: hazardsOf(state).map(cloneHazardState)
-  };
+  const normalizedState = normalizeBattleState(state);
   const action: BattleAction = {
     type: "battle.skill",
     unitId,
@@ -987,15 +1076,12 @@ export function executeBattleSkill(
   const caster = normalizedState.units[unitId]!;
   const skillDefinition = skillDefinitionFor(skillId, catalogIndex);
   const casterWithCooldown = setSkillCooldown(caster, skillId);
+  const stateWithCooldown = withUpdatedUnitCooldowns(normalizedState, casterWithCooldown);
 
   if (skillDefinition.target === "enemy" && targetId) {
     return applyAttackSequence(
       {
-        ...normalizedState,
-        units: {
-          ...normalizedState.units,
-          [caster.id]: casterWithCooldown
-        }
+        ...stateWithCooldown
       },
       caster.id,
       targetId,
@@ -1020,11 +1106,7 @@ export function executeBattleSkill(
     );
     return advanceTurn(
       {
-        ...normalizedState,
-        units: {
-          ...normalizedState.units,
-          [caster.id]: empoweredCaster
-        },
+        ...withUpdatedUnitCooldowns(stateWithCooldown, empoweredCaster),
         log: normalizedState.log.concat(
           `${caster.stackName} 施放 ${skillDefinition.name}，获得 ${describeGrantedStatus(grantedStatus)}`
         )
@@ -1036,11 +1118,7 @@ export function executeBattleSkill(
 
   return advanceTurn(
     {
-      ...normalizedState,
-      units: {
-        ...normalizedState.units,
-        [caster.id]: casterWithCooldown
-      },
+      ...stateWithCooldown,
       log: normalizedState.log.concat(`${caster.stackName} 施放 ${skillDefinition.name}`)
     },
     caster.id,
@@ -1081,7 +1159,7 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
       return { valid: false, reason: "skill_disabled" };
     }
 
-    if (skill.remainingCooldown > 0) {
+    if (normalizedCooldownValue(state.unitCooldowns[action.unitId]?.[action.skillId]) > 0) {
       return { valid: false, reason: "skill_on_cooldown" };
     }
 
@@ -1137,6 +1215,7 @@ export function createEmptyBattleState(): BattleState {
     activeUnitId: null,
     turnOrder: [],
     units: {},
+    unitCooldowns: {},
     environment: [],
     log: [],
     rng: {
@@ -1208,6 +1287,7 @@ export function createDemoBattleState(): BattleState {
     activeUnitId: turnOrder[0] ?? null,
     turnOrder,
     units,
+    unitCooldowns: Object.fromEntries(Object.keys(units).map((unitId) => [unitId, {}])),
     environment: [],
     log: ["战斗开始"],
     rng: {
@@ -1292,6 +1372,7 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
     activeUnitId: turnOrder[0] ?? null,
     turnOrder,
     units,
+    unitCooldowns: Object.fromEntries(Object.keys(units).map((unitId) => [unitId, {}])),
     environment,
     log: [`${hero.name} 遭遇 ${neutralArmy.id}`, ...visibleEnvironmentLog(environment, battleCatalogIndex)],
     rng: {
@@ -1379,6 +1460,7 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
     activeUnitId: turnOrder[0] ?? null,
     turnOrder,
     units,
+    unitCooldowns: Object.fromEntries(Object.keys(units).map((unitId) => [unitId, {}])),
     environment,
     log: [
       `${attackerHero.name} 遭遇 ${defenderHero.name}`,

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -506,6 +506,7 @@ export interface BattleState {
   activeUnitId: string | null;
   turnOrder: string[];
   units: Record<string, UnitStack>;
+  unitCooldowns: Record<string, Record<string, number>>;
   environment: BattleHazardState[];
   log: string[];
   rng: DeterministicRngState;

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -72,12 +72,85 @@ function normalizeBattleRngState(state: BattleState): BattleState["rng"] {
   };
 }
 
+function normalizedCooldownValue(value: unknown): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(Number(value)));
+}
+
+function buildCooldownStateFromSkills(unit: UnitStack): Record<string, number> {
+  const cooldowns: Record<string, number> = {};
+
+  for (const skill of skillsOf(unit)) {
+    if (skill.kind !== "active") {
+      continue;
+    }
+
+    const remainingCooldown = normalizedCooldownValue(skill.remainingCooldown);
+    if (remainingCooldown > 0) {
+      cooldowns[skill.id] = remainingCooldown;
+    }
+  }
+
+  return cooldowns;
+}
+
+function withSynchronizedSkillCooldowns(unit: UnitStack, cooldowns: Record<string, number>): UnitStack {
+  const skills = skillsOf(unit);
+  if (skills.length === 0) {
+    return unit;
+  }
+
+  return {
+    ...unit,
+    skills: skills.map((skill) => ({
+      ...skill,
+      remainingCooldown: skill.kind === "active" ? normalizedCooldownValue(cooldowns[skill.id]) : 0
+    }))
+  };
+}
+
+function normalizeBattleCooldowns(
+  units: Record<string, UnitStack>,
+  existingCooldowns?: BattleState["unitCooldowns"]
+): BattleState["unitCooldowns"] {
+  return Object.fromEntries(
+    Object.entries(units).map(([unitId, unit]) => {
+      const fallbackCooldowns = buildCooldownStateFromSkills(unit);
+      const unitCooldowns = existingCooldowns?.[unitId];
+
+      if (!unitCooldowns) {
+        return [unitId, fallbackCooldowns];
+      }
+
+      const normalizedCooldowns = Object.fromEntries(
+        Object.entries(unitCooldowns)
+          .map(([skillId, remainingTurns]) => [skillId, normalizedCooldownValue(remainingTurns)] as const)
+          .filter(([, remainingTurns]) => remainingTurns > 0)
+      );
+
+      return [unitId, Object.keys(normalizedCooldowns).length > 0 ? normalizedCooldowns : fallbackCooldowns];
+    })
+  );
+}
+
 export function normalizeBattleState(state: BattleState): BattleState {
+  const normalizedUnits = Object.fromEntries(
+    Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
+  );
+  const normalizedCooldowns = normalizeBattleCooldowns(normalizedUnits, state.unitCooldowns);
+
   return {
     ...state,
     units: Object.fromEntries(
-      Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
+      Object.entries(normalizedUnits).map(([unitId, unit]) => [
+        unitId,
+        withSynchronizedSkillCooldowns(unit, normalizedCooldowns[unitId] ?? {})
+      ])
     ),
+    unitCooldowns: normalizedCooldowns,
     environment: hazardsOf(state).map(cloneHazardState),
     rng: normalizeBattleRngState(state)
   };
@@ -359,6 +432,20 @@ function tickUnitSkillCooldowns(unit: UnitStack): UnitStack {
     skills: skills.map((skill) =>
       skill.remainingCooldown > 0 ? { ...skill, remainingCooldown: skill.remainingCooldown - 1 } : skill
     )
+  };
+}
+
+function withUpdatedUnitCooldowns(state: BattleState, unit: UnitStack): BattleState {
+  return {
+    ...state,
+    units: {
+      ...state.units,
+      [unit.id]: unit
+    },
+    unitCooldowns: {
+      ...state.unitCooldowns,
+      [unit.id]: buildCooldownStateFromSkills(unit)
+    }
   };
 }
 
@@ -752,14 +839,13 @@ function prepareStateForActiveUnit(state: BattleState): BattleState {
     const activeUnit = nextState.units[nextState.activeUnitId]!;
 
     const processed = processTurnStartForUnit(activeUnit);
-    nextState = {
-      ...nextState,
-      units: {
-        ...nextState.units,
-        [activeUnit.id]: processed.unit
+    nextState = withUpdatedUnitCooldowns(
+      {
+        ...nextState,
+        log: processed.log.length > 0 ? nextState.log.concat(processed.log) : nextState.log
       },
-      log: processed.log.length > 0 ? nextState.log.concat(processed.log) : nextState.log
-    };
+      processed.unit
+    );
 
     if (processed.unit.count > 0) {
       break;
@@ -971,13 +1057,7 @@ export function executeBattleSkill(
   skillId: BattleSkillId,
   targetId?: string
 ): BattleState {
-  const normalizedState: BattleState = {
-    ...state,
-    units: Object.fromEntries(
-      Object.entries(state.units).map(([currentUnitId, unit]) => [currentUnitId, withNormalizedCollections(unit)])
-    ),
-    environment: hazardsOf(state).map(cloneHazardState)
-  };
+  const normalizedState = normalizeBattleState(state);
   const action: BattleAction = {
     type: "battle.skill",
     unitId,
@@ -996,15 +1076,12 @@ export function executeBattleSkill(
   const caster = normalizedState.units[unitId]!;
   const skillDefinition = skillDefinitionFor(skillId, catalogIndex);
   const casterWithCooldown = setSkillCooldown(caster, skillId);
+  const stateWithCooldown = withUpdatedUnitCooldowns(normalizedState, casterWithCooldown);
 
   if (skillDefinition.target === "enemy" && targetId) {
     return applyAttackSequence(
       {
-        ...normalizedState,
-        units: {
-          ...normalizedState.units,
-          [caster.id]: casterWithCooldown
-        }
+        ...stateWithCooldown
       },
       caster.id,
       targetId,
@@ -1029,11 +1106,7 @@ export function executeBattleSkill(
     );
     return advanceTurn(
       {
-        ...normalizedState,
-        units: {
-          ...normalizedState.units,
-          [caster.id]: empoweredCaster
-        },
+        ...withUpdatedUnitCooldowns(stateWithCooldown, empoweredCaster),
         log: normalizedState.log.concat(
           `${caster.stackName} 施放 ${skillDefinition.name}，获得 ${describeGrantedStatus(grantedStatus)}`
         )
@@ -1045,11 +1118,7 @@ export function executeBattleSkill(
 
   return advanceTurn(
     {
-      ...normalizedState,
-      units: {
-        ...normalizedState.units,
-        [caster.id]: casterWithCooldown
-      },
+      ...stateWithCooldown,
       log: normalizedState.log.concat(`${caster.stackName} 施放 ${skillDefinition.name}`)
     },
     caster.id,
@@ -1090,7 +1159,7 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
       return { valid: false, reason: "skill_disabled" };
     }
 
-    if (skill.remainingCooldown > 0) {
+    if (normalizedCooldownValue(state.unitCooldowns[action.unitId]?.[action.skillId]) > 0) {
       return { valid: false, reason: "skill_on_cooldown" };
     }
 
@@ -1146,6 +1215,7 @@ export function createEmptyBattleState(): BattleState {
     activeUnitId: null,
     turnOrder: [],
     units: {},
+    unitCooldowns: {},
     environment: [],
     log: [],
     rng: {
@@ -1217,6 +1287,7 @@ export function createDemoBattleState(): BattleState {
     activeUnitId: turnOrder[0] ?? null,
     turnOrder,
     units,
+    unitCooldowns: Object.fromEntries(Object.keys(units).map((unitId) => [unitId, {}])),
     environment: [],
     log: ["战斗开始"],
     rng: {
@@ -1301,6 +1372,7 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
     activeUnitId: turnOrder[0] ?? null,
     turnOrder,
     units,
+    unitCooldowns: Object.fromEntries(Object.keys(units).map((unitId) => [unitId, {}])),
     environment,
     log: [`${hero.name} 遭遇 ${neutralArmy.id}`, ...visibleEnvironmentLog(environment, battleCatalogIndex)],
     rng: {
@@ -1388,6 +1460,7 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
     activeUnitId: turnOrder[0] ?? null,
     turnOrder,
     units,
+    unitCooldowns: Object.fromEntries(Object.keys(units).map((unitId) => [unitId, {}])),
     environment,
     log: [
       `${attackerHero.name} 遭遇 ${defenderHero.name}`,

--- a/packages/shared/src/content-pack-validation.ts
+++ b/packages/shared/src/content-pack-validation.ts
@@ -106,11 +106,11 @@ function validateWorldReferences(
 }
 
 function isNonNegativeInteger(value: unknown): value is number {
-  return Number.isInteger(value) && value >= 0;
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
 function isPositiveInteger(value: unknown): value is number {
-  return Number.isInteger(value) && value > 0;
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
 }
 
 function heroPath(heroIndex: number, suffix: string): string {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -509,6 +509,7 @@ export interface BattleState {
   activeUnitId: string | null;
   turnOrder: string[];
   units: Record<string, UnitStack>;
+  unitCooldowns: Record<string, Record<string, number>>;
   environment: BattleHazardState[];
   log: string[];
   rng: DeterministicRngState;

--- a/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
+++ b/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
@@ -225,6 +225,10 @@
             "statusEffects": []
           }
         },
+        "unitCooldowns": {
+          "pikeman-a": {},
+          "wolf-d": {}
+        },
         "environment": [],
         "log": [
           "战斗开始"

--- a/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
+++ b/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
@@ -220,6 +220,10 @@
         "statusEffects": []
       }
     },
+    "unitCooldowns": {
+      "pikeman-a": {},
+      "wolf-d": {}
+    },
     "environment": [],
     "log": [
       "战斗开始"

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -4603,6 +4603,7 @@ test("applyBattleAction supports active ranged skills without retaliation", () =
   assert.equal(next.units["pikeman-a"]?.count, 12);
   assert.equal(next.units["wolf-d"]?.count, 6);
   assert.equal(next.units["wolf-d"]?.hasRetaliated, false);
+  assert.equal(next.unitCooldowns["pikeman-a"]?.power_shot, 2);
   assert.equal(next.units["pikeman-a"]?.skills?.find((skill) => skill.id === "power_shot")?.remainingCooldown, 2);
   assert.match(next.log.at(-1) ?? "", /投矛射击/);
 });
@@ -4615,6 +4616,7 @@ test("executeBattleSkill resolves enemy and self-target skills through the share
   const rangedNext = executeBattleSkill(rangedState, "pikeman-a", "power_shot", "wolf-d");
 
   assert.equal(rangedNext.activeUnitId, "wolf-d");
+  assert.equal(rangedNext.unitCooldowns["pikeman-a"]?.power_shot, 2);
   assert.equal(rangedNext.units["pikeman-a"]?.skills?.find((skill) => skill.id === "power_shot")?.remainingCooldown, 2);
   assert.equal(rangedNext.units["wolf-d"]?.hasRetaliated, false);
   assert.match(rangedNext.log.at(-1) ?? "", /投矛射击/);
@@ -4627,6 +4629,7 @@ test("executeBattleSkill resolves enemy and self-target skills through the share
 
   assert.equal(buffNext.activeUnitId, "wolf-d");
   assert.equal(buffNext.units["pikeman-a"]?.statusEffects?.[0]?.id, "arcane_armor");
+  assert.equal(buffNext.unitCooldowns["pikeman-a"]?.armor_spell, 3);
   assert.equal(buffNext.units["pikeman-a"]?.skills?.find((skill) => skill.id === "armor_spell")?.remainingCooldown, 3);
   assert.match(buffNext.log.at(-1) ?? "", /护甲术/);
 });
@@ -4646,6 +4649,7 @@ test("applyBattleAction supports armor spell buffs on the acting unit", () => {
   assert.equal(next.activeUnitId, "wolf-d");
   assert.equal(next.units["pikeman-a"]?.statusEffects?.[0]?.id, "arcane_armor");
   assert.equal(next.units["pikeman-a"]?.statusEffects?.[0]?.defenseModifier, 3);
+  assert.equal(next.unitCooldowns["pikeman-a"]?.armor_spell, 3);
   assert.equal(next.units["pikeman-a"]?.skills?.find((skill) => skill.id === "armor_spell")?.remainingCooldown, 3);
   assert.match(next.log.at(-1) ?? "", /护甲术/);
 });
@@ -4788,11 +4792,9 @@ test("validateBattleAction covers wait and skill rejection branches", () => {
   const cooldownState = cloneBattleState(initial);
   cooldownState.activeUnitId = "pikeman-a";
   cooldownState.turnOrder = ["pikeman-a", "wolf-d"];
-  cooldownState.units["pikeman-a"] = {
-    ...cooldownState.units["pikeman-a"]!,
-    skills: cooldownState.units["pikeman-a"]!.skills?.map((skill) =>
-      skill.id === "power_shot" ? { ...skill, remainingCooldown: 1 } : skill
-    )
+  cooldownState.unitCooldowns["pikeman-a"] = {
+    ...cooldownState.unitCooldowns["pikeman-a"],
+    power_shot: 1
   };
   assert.deepEqual(
     validateBattleAction(cooldownState, {
@@ -4885,6 +4887,34 @@ test("validateBattleAction covers wait and skill rejection branches", () => {
     {
       valid: false,
       reason: "friendly_fire_blocked"
+    }
+  );
+});
+
+test("validateBattleAction rejects skills from server-side cooldown state even when unit skill data looks ready", () => {
+  const state = createDemoBattleState();
+  state.activeUnitId = "pikeman-a";
+  state.turnOrder = ["pikeman-a", "wolf-d"];
+  state.unitCooldowns["pikeman-a"] = {
+    power_shot: 1
+  };
+  state.units["pikeman-a"] = {
+    ...state.units["pikeman-a"]!,
+    skills: state.units["pikeman-a"]!.skills?.map((skill) =>
+      skill.id === "power_shot" ? { ...skill, remainingCooldown: 0 } : skill
+    )
+  };
+
+  assert.deepEqual(
+    validateBattleAction(state, {
+      type: "battle.skill",
+      unitId: "pikeman-a",
+      skillId: "power_shot",
+      targetId: "wolf-d"
+    }),
+    {
+      valid: false,
+      reason: "skill_on_cooldown"
     }
   );
 });
@@ -5017,6 +5047,9 @@ test("applyBattleAction resolves wait plus turn-start poison death and cooldown 
   const initial = createDemoBattleState();
   initial.activeUnitId = "pikeman-a";
   initial.turnOrder = ["pikeman-a", "wolf-d"];
+  initial.unitCooldowns["wolf-d"] = {
+    crippling_howl: 1
+  };
   initial.units["wolf-d"] = {
     ...initial.units["wolf-d"]!,
     count: 1,
@@ -5048,9 +5081,75 @@ test("applyBattleAction resolves wait plus turn-start poison death and cooldown 
   assert.deepEqual(next.turnOrder, ["pikeman-a"]);
   assert.equal(next.units["wolf-d"]?.count, 0);
   assert.equal(next.units["wolf-d"]?.currentHp, 0);
+  assert.deepEqual(next.unitCooldowns["wolf-d"], {});
   assert.equal(next.units["wolf-d"]?.skills?.find((skill) => skill.id === "crippling_howl")?.remainingCooldown, 0);
   assert.deepEqual(next.units["wolf-d"]?.statusEffects, []);
   assert.deepEqual(next.log.slice(-3), ["pikeman-a 选择等待", "恶狼 受到中毒影响，损失 2 生命", "恶狼 的中毒结束"]);
+});
+
+test("skill cooldowns are stored on battle state, decremented on each acting turn, and cleared when ready", () => {
+  const initial = createDemoBattleState();
+  initial.activeUnitId = "pikeman-a";
+  initial.turnOrder = ["pikeman-a", "wolf-d"];
+  initial.units["pikeman-a"] = {
+    ...initial.units["pikeman-a"]!,
+    initiative: 12
+  };
+  initial.units["wolf-d"] = {
+    ...initial.units["wolf-d"]!,
+    initiative: 8
+  };
+
+  const afterUse = applyBattleAction(initial, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "power_shot",
+    targetId: "wolf-d"
+  });
+
+  assert.equal(afterUse.unitCooldowns["pikeman-a"]?.power_shot, 2);
+  assert.equal(afterUse.units["pikeman-a"]?.skills?.find((skill) => skill.id === "power_shot")?.remainingCooldown, 2);
+
+  const afterEnemyTurn = applyBattleAction(afterUse, {
+    type: "battle.defend",
+    unitId: "wolf-d"
+  });
+
+  assert.equal(afterEnemyTurn.activeUnitId, "pikeman-a");
+  assert.equal(afterEnemyTurn.unitCooldowns["pikeman-a"]?.power_shot, 1);
+  assert.equal(
+    validateBattleAction(afterEnemyTurn, {
+      type: "battle.skill",
+      unitId: "pikeman-a",
+      skillId: "power_shot",
+      targetId: "wolf-d"
+    }).reason,
+    "skill_on_cooldown"
+  );
+
+  const afterWait = applyBattleAction(afterEnemyTurn, {
+    type: "battle.wait",
+    unitId: "pikeman-a"
+  });
+  const afterSecondEnemyTurn = applyBattleAction(afterWait, {
+    type: "battle.defend",
+    unitId: "wolf-d"
+  });
+
+  assert.equal(afterSecondEnemyTurn.activeUnitId, "pikeman-a");
+  assert.deepEqual(afterSecondEnemyTurn.unitCooldowns["pikeman-a"], {});
+  assert.equal(afterSecondEnemyTurn.units["pikeman-a"]?.skills?.find((skill) => skill.id === "power_shot")?.remainingCooldown, 0);
+  assert.deepEqual(
+    validateBattleAction(afterSecondEnemyTurn, {
+      type: "battle.skill",
+      unitId: "pikeman-a",
+      skillId: "power_shot",
+      targetId: "wolf-d"
+    }),
+    {
+      valid: true
+    }
+  );
 });
 
 test("applyBattleAction advances into turn-start processing even when the next unit has no skills", () => {
@@ -5286,6 +5385,7 @@ test("createEmptyBattleState returns the minimal neutral battle shell", () => {
     activeUnitId: null,
     turnOrder: [],
     units: {},
+    unitCooldowns: {},
     environment: [],
     log: [],
     rng: {


### PR DESCRIPTION
## Summary
- add `BattleState.unitCooldowns` and keep it synchronized with battle skill state so cooldowns are tracked server-side
- decrement cooldown counters when a unit's turn starts, set cooldowns from `battle-skills.json` after skill use, and reject `battle.skill` actions in `validateBattleAction` while cooldowns remain
- add focused shared battle tests for server-side cooldown enforcement, decrement behavior, and refresh shared contract snapshots for the new battle payload field

Closes #776

## Testing
- `npm run typecheck:shared`
- `node --import tsx --test packages/shared/test/shared-core.test.ts`
- `npm run test:contracts`