### PR TITLE
Implement account ban and suspension enforcement

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -59,6 +59,17 @@ function sendAdminSecretNotConfigured(response: ServerResponse): void {
   sendJson(response, 503, { error: "ADMIN_SECRET is not configured" });
 }
 
+function sendStoreUnavailable(response: ServerResponse): void {
+  sendJson(response, 503, { error: "Player moderation requires configured room persistence storage" });
+}
+
+function hasBanModerationStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore &
+  Required<Pick<RoomSnapshotStore, "loadPlayerBan" | "listPlayerBanHistory" | "savePlayerBan" | "clearPlayerBan">> {
+  return Boolean(store?.loadPlayerBan && store.listPlayerBanHistory && store.savePlayerBan && store.clearPlayerBan);
+}
+
 function sendInvalidJson(response: ServerResponse): void {
   sendJson(response, 400, { error: "Invalid JSON body" });
 }
@@ -95,6 +106,70 @@ function readOptionalIntegerField(payload: Record<string, unknown>, key: keyof R
     throw new InvalidAdminPayloadError(`"${key}" must be a finite integer`);
   }
   return value;
+}
+
+function readOptionalTrimmedString(payload: Record<string, unknown>, key: string): string | undefined {
+  const value = payload[key];
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new InvalidAdminPayloadError(`"${key}" must be a string`);
+  }
+  const normalized = value.trim();
+  return normalized ? normalized : undefined;
+}
+
+function parseIsoTimestamp(value: string, key: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new InvalidAdminPayloadError(`"${key}" must be a valid ISO timestamp`);
+  }
+  return parsed.toISOString();
+}
+
+function parseBanBody(value: unknown): { banStatus: "temporary" | "permanent"; banReason: string; banExpiry?: string } {
+  const payload = readRequiredObjectBody(value);
+  const banStatus = readOptionalTrimmedString(payload, "banStatus");
+  const banReason = readOptionalTrimmedString(payload, "banReason");
+  const banExpiry = readOptionalTrimmedString(payload, "banExpiry");
+
+  if (banStatus !== "temporary" && banStatus !== "permanent") {
+    throw new InvalidAdminPayloadError('"banStatus" must be "temporary" or "permanent"');
+  }
+  if (!banReason) {
+    throw new InvalidAdminPayloadError('"banReason" must be a non-empty string');
+  }
+  if (banStatus === "temporary") {
+    if (!banExpiry) {
+      throw new InvalidAdminPayloadError('"banExpiry" is required for temporary bans');
+    }
+    const normalizedExpiry = parseIsoTimestamp(banExpiry, "banExpiry");
+    if (new Date(normalizedExpiry).getTime() <= Date.now()) {
+      throw new InvalidAdminPayloadError('"banExpiry" must be in the future');
+    }
+    return { banStatus, banReason, banExpiry: normalizedExpiry };
+  }
+
+  return { banStatus, banReason };
+}
+
+function parseUnbanBody(value: unknown): { reason?: string } {
+  if (value === undefined || value === null || value === "") {
+    return {};
+  }
+  const payload = readRequiredObjectBody(value);
+  const reason = readOptionalTrimmedString(payload, "reason");
+  return reason ? { reason } : {};
+}
+
+function readLimit(request: IncomingMessage, fallback = 20): number {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const parsed = Number(url.searchParams.get("limit"));
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(parsed));
 }
 
 function parseResourceDeltaBody(value: unknown): ResourceLedger {
@@ -277,6 +352,75 @@ export function registerAdminRoutes(
         return;
       }
       sendJson(response, 500, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/players/:id/ban", async (request, response) => {
+    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
+    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!hasBanModerationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request, "id");
+      const input = parseBanBody(await readJsonBody(request));
+      const account = await store.savePlayerBan(playerId, input);
+      let disconnectedClients = 0;
+      for (const room of getActiveRoomInstances().values()) {
+        disconnectedClients += room.disconnectPlayer(playerId, "account_banned");
+      }
+      sendJson(response, 200, { ok: true, account, disconnectedClients });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/players/:id/unban", async (request, response) => {
+    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
+    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!hasBanModerationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request, "id");
+      const input = parseUnbanBody(await readJsonBody(request));
+      const account = await store.clearPlayerBan(playerId, input);
+      sendJson(response, 200, { ok: true, account });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.get("/api/admin/players/:id/ban-history", async (request, response) => {
+    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
+    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!hasBanModerationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request as AdminRequest, "id");
+      const items = await store.listPlayerBanHistory(playerId, { limit: readLimit(request) });
+      const currentBan = await store.loadPlayerBan(playerId);
+      sendJson(response, 200, { items, currentBan });
+    } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
     }
   });
 }

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -28,7 +28,7 @@ import {
   setPendingAuthRegistrationCount,
   upsertAuthAccountSession
 } from "./observability";
-import type { RoomSnapshotStore } from "./persistence";
+import { isPlayerBanActive, type PlayerAccountBanSnapshot, type RoomSnapshotStore } from "./persistence";
 
 export type AuthMode = "guest" | "account";
 export type AuthProvider = "guest" | "account-password" | "wechat-mini-game";
@@ -75,7 +75,8 @@ interface AuthRuntimeConfig {
 
 interface ValidateAuthSessionResult {
   session: GuestAuthSession | null;
-  errorCode?: "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked";
+  errorCode?: "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked" | "account_banned";
+  ban?: PlayerAccountBanSnapshot;
 }
 
 interface RateLimitResult {
@@ -484,6 +485,22 @@ async function appendAccountAuditLog(
   });
 }
 
+async function resolveActiveBanForPlayer(
+  store: RoomSnapshotStore | null,
+  playerId: string
+): Promise<PlayerAccountBanSnapshot | null> {
+  if (!store) {
+    return null;
+  }
+
+  if (!store.loadPlayerBan) {
+    return null;
+  }
+
+  const ban = await store.loadPlayerBan(playerId);
+  return isPlayerBanActive(ban) ? ban : null;
+}
+
 function createPasswordRecoveryToken(): string {
   return randomBytes(24).toString("base64url");
 }
@@ -834,7 +851,7 @@ async function handleWechatLogin(
   if (authToken) {
     const validation = await validateAuthToken(authToken, store);
     if (!validation.session) {
-      sendAuthFailure(response, validation.errorCode);
+      sendAuthFailure(response, validation.errorCode, validation.ban);
       return;
     }
     authSession = validation.session;
@@ -974,6 +991,12 @@ async function handleWechatLogin(
   } else if (!authSession && body.playerId?.trim()) {
     playerId = normalizePlayerId(body.playerId);
     displayName = normalizeDisplayName(playerId, body.displayName);
+  }
+
+  const activeBan = await resolveActiveBanForPlayer(store, playerId);
+  if (activeBan) {
+    sendAuthFailure(response, "account_banned", activeBan);
+    return;
   }
 
   sendJson(response, 200, {
@@ -1188,6 +1211,11 @@ async function validateAuthToken(
     }
 
     if (session.authMode === "guest") {
+      const activeBan = await resolveActiveBanForPlayer(store, session.playerId);
+      if (activeBan) {
+        recordAuthSessionFailure("account_banned");
+        return { session: null, errorCode: "account_banned", ban: activeBan };
+      }
       if (session.sessionId) {
         const touchedSession = touchGuestSession(session.sessionId, normalizedToken);
         if (!touchedSession) {
@@ -1201,6 +1229,12 @@ async function validateAuthToken(
 
     if (!store) {
       return { session };
+    }
+
+    const activeBan = await resolveActiveBanForPlayer(store, session.playerId);
+    if (activeBan) {
+      recordAuthSessionFailure("account_banned");
+      return { session: null, errorCode: "account_banned", ban: activeBan };
     }
 
     const authAccount = await store.loadPlayerAccountAuthByPlayerId(session.playerId);
@@ -1404,9 +1438,22 @@ function sendAccountTokenDeliveryFailure(
 function sendAuthFailure(
   response: ServerResponse,
   errorCode: ValidateAuthSessionResult["errorCode"],
+  ban?: PlayerAccountBanSnapshot | null,
   fallbackMessage = "Guest auth session is missing or invalid"
 ): void {
   const code = errorCode ?? "unauthorized";
+  if (code === "account_banned") {
+    sendJson(response, 403, {
+      error: {
+        code,
+        message: "Account is banned",
+        reason: ban?.banReason ?? "No reason provided",
+        ...(ban?.banExpiry ? { expiry: ban.banExpiry } : {})
+      }
+    });
+    return;
+  }
+
   const message =
     code === "token_expired"
       ? "Auth token has expired"
@@ -1592,9 +1639,9 @@ export function registerAuthRoutes(
 
   app.get("/api/auth/session", async (request, response) => {
     try {
-      const { session: authSession, errorCode } = await validateAuthSessionFromRequest(request, store);
+      const { session: authSession, errorCode, ban } = await validateAuthSessionFromRequest(request, store);
       if (!authSession) {
-        sendAuthFailure(response, errorCode);
+        sendAuthFailure(response, errorCode, ban);
         return;
       }
 
@@ -1631,9 +1678,9 @@ export function registerAuthRoutes(
     }
 
     try {
-      const { session: refreshSession, errorCode } = await validateAuthSessionFromRequest(request, store, "refresh");
+      const { session: refreshSession, errorCode, ban } = await validateAuthSessionFromRequest(request, store, "refresh");
       if (!refreshSession || refreshSession.authMode !== "account" || !refreshSession.loginId) {
-        sendAuthFailure(response, errorCode, "Refresh token is missing or invalid");
+        sendAuthFailure(response, errorCode, ban, "Refresh token is missing or invalid");
         return;
       }
 
@@ -1658,9 +1705,9 @@ export function registerAuthRoutes(
 
   app.post("/api/auth/logout", async (request, response) => {
     try {
-      const { session: authSession, errorCode } = await validateAuthSessionFromRequest(request, store);
+      const { session: authSession, errorCode, ban } = await validateAuthSessionFromRequest(request, store);
       if (!authSession) {
-        sendAuthFailure(response, errorCode);
+        sendAuthFailure(response, errorCode, ban);
         return;
       }
 
@@ -1724,6 +1771,11 @@ export function registerAuthRoutes(
           playerId,
           displayName
         });
+        const activeBan = await resolveActiveBanForPlayer(store, account.playerId);
+        if (activeBan) {
+          sendAuthFailure(response, "account_banned", activeBan);
+          return;
+        }
         playerId = account.playerId;
         displayName = account.displayName;
       }
@@ -1796,6 +1848,11 @@ export function registerAuthRoutes(
           playerId: loginId,
           displayName: loginId
         }) || { playerId: loginId, displayName: loginId };
+        const activeBan = await resolveActiveBanForPlayer(store, account.playerId);
+        if (activeBan) {
+          sendAuthFailure(response, "account_banned", activeBan);
+          return;
+        }
         
         sendJson(response, 200, {
           account,
@@ -1835,6 +1892,11 @@ export function registerAuthRoutes(
         playerId: authAccount.playerId,
         displayName: authAccount.displayName
       });
+      const activeBan = await resolveActiveBanForPlayer(store, account.playerId);
+      if (activeBan) {
+        sendAuthFailure(response, "account_banned", activeBan);
+        return;
+      }
       sendJson(response, 200, {
         account,
         session: await createAccountSessionBundle(store, {
@@ -2236,9 +2298,9 @@ export function registerAuthRoutes(
     }
 
     try {
-      const { session: authSession, errorCode } = await validateAuthSessionFromRequest(request, store);
+      const { session: authSession, errorCode, ban } = await validateAuthSessionFromRequest(request, store);
       if (!authSession) {
-        sendAuthFailure(response, errorCode);
+        sendAuthFailure(response, errorCode, ban);
         return;
       }
 

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -23,6 +23,7 @@ import {
 import {
   applyPlayerAccountsToWorldState,
   applyPlayerHeroArchivesToWorldState,
+  isPlayerBanActive,
   type PlayerAccountSnapshot,
   type RoomSnapshotStore
 } from "./persistence";
@@ -321,6 +322,11 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
           ensuredAccount = null;
         }
       }
+      if (isPlayerBanActive(ensuredAccount)) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "account_banned" });
+        client.leave(CloseCode.WITH_ERROR, "account_banned");
+        return;
+      }
       await this.ensurePlayerWorldSlot(playerId, ensuredAccount);
       this.publishLobbyRoomSummary();
 
@@ -451,6 +457,20 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     this.publishLobbyRoomSummary();
   }
 
+  disconnectPlayer(playerId: string, reason = "account_banned"): number {
+    let disconnected = 0;
+    for (const client of this.clients) {
+      if (this.playerIdBySessionId.get(client.sessionId) !== playerId) {
+        continue;
+      }
+
+      sendMessage(client, "error", { requestId: "push", reason });
+      client.leave(CloseCode.WITH_ERROR, reason);
+      disconnected += 1;
+    }
+    return disconnected;
+  }
+
   async onDrop(client: ColyseusClient): Promise<void> {
     const playerId = this.playerIdBySessionId.get(client.sessionId);
     if (!playerId) {
@@ -459,6 +479,15 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
 
     try {
       const reconnectedClient = await this.allowReconnection(client, RECONNECTION_WINDOW_SECONDS);
+      if (configuredRoomSnapshotStore?.loadPlayerBan) {
+        const ban = await configuredRoomSnapshotStore.loadPlayerBan(playerId);
+        if (isPlayerBanActive(ban)) {
+          this.playerIdBySessionId.delete(client.sessionId);
+          reconnectedClient.leave(CloseCode.WITH_ERROR, "account_banned");
+          this.publishLobbyRoomSummary();
+          return;
+        }
+      }
       this.playerIdBySessionId.delete(client.sessionId);
       this.playerIdBySessionId.set(reconnectedClient.sessionId, playerId);
       this.reconnectedAtByPlayerId.set(playerId, new Date().toISOString());

--- a/apps/server/src/matchmaking.ts
+++ b/apps/server/src/matchmaking.ts
@@ -145,6 +145,18 @@ async function requireAuthSession(
     return result.session;
   }
 
+  if (result.errorCode === "account_banned") {
+    sendJson(response, 403, {
+      error: {
+        code: "account_banned",
+        message: "Account is banned",
+        reason: result.ban?.banReason ?? "No reason provided",
+        ...(result.ban?.banExpiry ? { expiry: result.ban.banExpiry } : {})
+      }
+    });
+    return null;
+  }
+
   sendJson(response, 401, {
     error: {
       code: result.errorCode ?? "unauthorized",

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -9,6 +9,9 @@ import {
   MAX_PLAYER_AVATAR_URL_LENGTH,
   MAX_PLAYER_DISPLAY_NAME_LENGTH,
   type RoomSnapshotStore,
+  type PlayerAccountBanHistoryListOptions,
+  type PlayerAccountBanInput,
+  type PlayerAccountBanSnapshot,
   type PlayerAccountAuthSnapshot,
   type PlayerAccountAuthRevokeInput,
   type PlayerAccountAuthSessionInput,
@@ -16,6 +19,8 @@ import {
   type PlayerAccountCredentialInput,
   type PlayerAccountEnsureInput,
   type PlayerAccountListOptions,
+  type PlayerAccountUnbanInput,
+  type PlayerBanHistoryRecord,
   type PlayerAccountWechatMiniGameIdentityInput,
   type PlayerAccountProfilePatch,
   type PlayerAccountProgressPatch,
@@ -74,6 +79,7 @@ function normalizeSessionId(sessionId: string): string {
 export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly snapshots = new Map<string, RoomPersistenceSnapshot>();
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+  private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
@@ -87,6 +93,20 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     const account = this.accounts.get(normalizePlayerId(playerId));
     return account ? cloneAccount(account) : null;
+  }
+
+  async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
+    const account = await this.loadPlayerAccount(playerId);
+    if (!account) {
+      return null;
+    }
+
+    return {
+      playerId: account.playerId,
+      banStatus: account.banStatus ?? "none",
+      ...(account.banExpiry ? { banExpiry: account.banExpiry } : {}),
+      ...(account.banReason ? { banReason: account.banReason } : {})
+    };
   }
 
   async loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null> {
@@ -186,6 +206,9 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
           : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
+      ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
+      ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
+      ...(existing?.banReason ? { banReason: existing.banReason } : {}),
       ...(existing?.accountSessionVersion != null ? { accountSessionVersion: existing.accountSessionVersion } : {}),
       ...(existing?.refreshSessionId ? { refreshSessionId: existing.refreshSessionId } : {}),
       ...(existing?.refreshTokenExpiresAt ? { refreshTokenExpiresAt: existing.refreshTokenExpiresAt } : {}),
@@ -199,6 +222,80 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     const stored = structuredClone(nextAccount);
     this.accounts.set(playerId, stored);
     return structuredClone(stored);
+  }
+
+  async listPlayerBanHistory(
+    playerId: string,
+    options: PlayerAccountBanHistoryListOptions = {}
+  ): Promise<PlayerBanHistoryRecord[]> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const safeLimit = Math.max(1, Math.floor(options.limit ?? 20));
+    return structuredClone((this.banHistoryByPlayerId.get(normalizedPlayerId) ?? []).slice(0, safeLimit));
+  }
+
+  async savePlayerBan(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existing = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const banReason = input.banReason.trim();
+    if (!banReason) {
+      throw new Error("banReason must not be empty");
+    }
+    if (input.banStatus === "temporary") {
+      if (!input.banExpiry) {
+        throw new Error("temporary bans require banExpiry");
+      }
+      if (new Date(input.banExpiry).getTime() <= Date.now()) {
+        throw new Error("banExpiry must be in the future");
+      }
+    }
+
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: input.banStatus,
+      ...(input.banStatus === "temporary" && input.banExpiry ? { banExpiry: new Date(input.banExpiry).toISOString() } : {}),
+      banReason,
+      updatedAt: new Date().toISOString()
+    };
+    if (input.banStatus === "permanent") {
+      delete account.banExpiry;
+    }
+    this.accounts.set(normalizedPlayerId, cloneAccount(account));
+    const history = this.banHistoryByPlayerId.get(normalizedPlayerId) ?? [];
+    history.unshift({
+      id: (history[0]?.id ?? 0) + 1,
+      playerId: normalizedPlayerId,
+      action: "ban",
+      banStatus: input.banStatus,
+      ...(input.banStatus === "temporary" && input.banExpiry ? { banExpiry: new Date(input.banExpiry).toISOString() } : {}),
+      banReason,
+      createdAt: new Date().toISOString()
+    });
+    this.banHistoryByPlayerId.set(normalizedPlayerId, history);
+    return cloneAccount(account);
+  }
+
+  async clearPlayerBan(playerId: string, input: PlayerAccountUnbanInput = {}): Promise<PlayerAccountSnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existing = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: "none",
+      updatedAt: new Date().toISOString()
+    };
+    delete account.banExpiry;
+    delete account.banReason;
+    this.accounts.set(normalizedPlayerId, cloneAccount(account));
+    const history = this.banHistoryByPlayerId.get(normalizedPlayerId) ?? [];
+    history.unshift({
+      id: (history[0]?.id ?? 0) + 1,
+      playerId: normalizedPlayerId,
+      action: "unban",
+      banStatus: "none",
+      ...(input.reason?.trim() ? { banReason: input.reason.trim() } : {}),
+      createdAt: new Date().toISOString()
+    });
+    this.banHistoryByPlayerId.set(normalizedPlayerId, history);
+    return cloneAccount(account);
   }
 
   async bindPlayerAccountCredentials(

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -44,7 +44,12 @@ interface MatchmakingObservabilityCounters {
   rateLimitedTotal: number;
 }
 
-type AuthSessionFailureReason = "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked";
+type AuthSessionFailureReason =
+  | "unauthorized"
+  | "token_expired"
+  | "token_kind_invalid"
+  | "session_revoked"
+  | "account_banned";
 type AuthTokenDeliveryFailureReason =
   | "misconfigured"
   | "timeout"
@@ -208,7 +213,8 @@ const runtimeObservability: RuntimeObservabilityState = {
       unauthorized: 0,
       token_expired: 0,
       token_kind_invalid: 0,
-      session_revoked: 0
+      session_revoked: 0,
+      account_banned: 0
     },
     tokenDeliveryQueueCount: 0,
     tokenDeliveryDeadLetterCount: 0,

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -10,6 +10,7 @@ import {
   normalizeHeroState,
   type EventLogEntry,
   type HeroState,
+  type PlayerBanStatus,
   type PlayerAccountReadModel,
   type PlayerBattleReplaySummary,
   type PlayerAchievementProgress,
@@ -21,14 +22,18 @@ import type { RoomPersistenceSnapshot } from "./index";
 export interface RoomSnapshotStore {
   load(roomId: string): Promise<RoomPersistenceSnapshot | null>;
   loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null>;
+  loadPlayerBan?(playerId: string): Promise<PlayerAccountBanSnapshot | null>;
   loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null>;
   loadPlayerAccountByWechatMiniGameOpenId(openId: string): Promise<PlayerAccountSnapshot | null>;
   loadPlayerEventHistory(playerId: string, query?: PlayerEventHistoryQuery): Promise<PlayerEventHistorySnapshot>;
   loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]>;
+  listPlayerBanHistory?(playerId: string, options?: PlayerAccountBanHistoryListOptions): Promise<PlayerBanHistoryRecord[]>;
   loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerAccountAuthByPlayerId(playerId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerHeroArchives(playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]>;
   ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot>;
+  savePlayerBan?(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot>;
+  clearPlayerBan?(playerId: string, input?: PlayerAccountUnbanInput): Promise<PlayerAccountSnapshot>;
   bindPlayerAccountCredentials(
     playerId: string,
     input: PlayerAccountCredentialInput
@@ -120,6 +125,9 @@ interface PlayerAccountRow extends RowDataPacket {
   last_room_id: string | null;
   last_seen_at: Date | string | null;
   login_id: string | null;
+  ban_status: string | null;
+  ban_expiry: Date | string | null;
+  ban_reason: string | null;
   account_session_version: number;
   refresh_session_id: string | null;
   refresh_token_hash: string | null;
@@ -161,6 +169,16 @@ interface PlayerEventHistoryRow extends RowDataPacket {
 
 interface PlayerEventHistoryCountRow extends RowDataPacket {
   total: number;
+}
+
+interface PlayerBanHistoryRow extends RowDataPacket {
+  id: number;
+  player_id: string;
+  action: string;
+  ban_status: string;
+  ban_expiry: Date | string | null;
+  ban_reason: string | null;
+  created_at: Date | string;
 }
 
 interface PlayerAccountDeviceSessionRow extends RowDataPacket {
@@ -212,6 +230,13 @@ export interface PlayerAccountSnapshot extends PlayerAccountReadModel {
   wechatMiniGameBoundAt?: string;
   createdAt?: string;
   updatedAt?: string;
+}
+
+export interface PlayerAccountBanSnapshot {
+  playerId: string;
+  banStatus: PlayerBanStatus;
+  banExpiry?: string;
+  banReason?: string;
 }
 
 export interface PlayerAccountAuthSnapshot {
@@ -313,6 +338,30 @@ export interface PlayerEventHistorySnapshot {
   total: number;
 }
 
+export interface PlayerAccountBanInput {
+  banStatus: Exclude<PlayerBanStatus, "none">;
+  banExpiry?: string;
+  banReason: string;
+}
+
+export interface PlayerAccountUnbanInput {
+  reason?: string;
+}
+
+export interface PlayerBanHistoryRecord {
+  id: number;
+  playerId: string;
+  action: "ban" | "unban";
+  banStatus: PlayerBanStatus;
+  banExpiry?: string;
+  banReason?: string;
+  createdAt: string;
+}
+
+export interface PlayerAccountBanHistoryListOptions {
+  limit?: number;
+}
+
 export interface PlayerRoomProfileListOptions {
   limit?: number;
   roomId?: string;
@@ -331,6 +380,8 @@ export const MYSQL_PLAYER_ACCOUNT_WECHAT_OPEN_ID_INDEX = "uidx_player_accounts_w
 export const MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX = "uidx_player_accounts_wechat_idp_open_id";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_TABLE = "player_account_sessions";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX = "idx_player_account_sessions_player_last_used";
+export const MYSQL_PLAYER_BAN_HISTORY_TABLE = "player_ban_history";
+export const MYSQL_PLAYER_BAN_HISTORY_PLAYER_CREATED_INDEX = "idx_player_ban_history_player_created";
 export const MYSQL_PLAYER_EVENT_HISTORY_TABLE = "player_event_history";
 export const MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX = "idx_player_event_history_player_time";
 export const MYSQL_PLAYER_HERO_ARCHIVE_TABLE = "player_hero_archives";
@@ -377,6 +428,43 @@ function normalizeResourceLedger(resources?: Partial<ResourceLedger>): ResourceL
     ore: 0,
     ...resources
   };
+}
+
+function normalizePlayerBanStatus(status?: string | null): PlayerBanStatus {
+  return status === "temporary" || status === "permanent" ? status : "none";
+}
+
+function normalizePlayerBanReason(reason?: string | null): string | undefined {
+  const normalized = reason?.trim();
+  return normalized ? normalized.slice(0, 512) : undefined;
+}
+
+function normalizePlayerBanExpiry(expiry?: string | Date | null): string | undefined {
+  if (!expiry) {
+    return undefined;
+  }
+
+  const parsed = expiry instanceof Date ? expiry : new Date(expiry);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("banExpiry must be a valid ISO timestamp");
+  }
+
+  return parsed.toISOString();
+}
+
+export function isPlayerBanActive(
+  ban: Pick<PlayerAccountBanSnapshot, "banStatus" | "banExpiry"> | Pick<PlayerAccountSnapshot, "banStatus" | "banExpiry"> | null | undefined
+): boolean {
+  if (!ban || (ban.banStatus ?? "none") === "none") {
+    return false;
+  }
+
+  if (ban.banStatus === "permanent") {
+    return true;
+  }
+
+  const expiry = ban.banExpiry ? new Date(ban.banExpiry) : null;
+  return Boolean(expiry && !Number.isNaN(expiry.getTime()) && expiry.getTime() > Date.now());
 }
 
 function normalizePlayerId(playerId: string): string {
@@ -480,6 +568,9 @@ function normalizePlayerAccountSnapshot(account: {
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
   loginId?: string | null | undefined;
+  banStatus?: PlayerBanStatus | null | undefined;
+  banExpiry?: string | undefined;
+  banReason?: string | null | undefined;
   wechatMiniGameOpenId?: string | null | undefined;
   wechatMiniGameUnionId?: string | null | undefined;
   wechatMiniGameBoundAt?: string | undefined;
@@ -508,7 +599,10 @@ function normalizePlayerAccountSnapshot(account: {
       lastRoomId: account.lastRoomId,
       lastSeenAt: account.lastSeenAt,
       loginId: account.loginId ? normalizePlayerLoginId(account.loginId) : undefined,
-      credentialBoundAt: account.credentialBoundAt
+      credentialBoundAt: account.credentialBoundAt,
+      banStatus: normalizePlayerBanStatus(account.banStatus),
+      banExpiry: normalizePlayerBanExpiry(account.banExpiry),
+      banReason: normalizePlayerBanReason(account.banReason)
     }),
     ...(normalizedWechatMiniGameOpenId ? { wechatMiniGameOpenId: normalizedWechatMiniGameOpenId } : {}),
     ...(normalizedWechatMiniGameUnionId ? { wechatMiniGameUnionId: normalizedWechatMiniGameUnionId } : {}),
@@ -787,6 +881,9 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   last_room_id VARCHAR(191) NULL,
   last_seen_at DATETIME NULL DEFAULT NULL,
   login_id VARCHAR(40) NULL,
+  ban_status VARCHAR(16) NOT NULL DEFAULT 'none',
+  ban_expiry DATETIME NULL DEFAULT NULL,
+  ban_reason VARCHAR(512) NULL,
   wechat_open_id VARCHAR(191) NULL,
   wechat_union_id VARCHAR(191) NULL,
   wechat_mini_game_open_id VARCHAR(191) NULL,
@@ -811,6 +908,17 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\` (
   last_used_at DATETIME NOT NULL,
   PRIMARY KEY (session_id),
   KEY \`${MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX}\` (player_id, last_used_at DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_BAN_HISTORY_TABLE}\` (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  player_id VARCHAR(191) NOT NULL,
+  action VARCHAR(16) NOT NULL,
+  ban_status VARCHAR(16) NOT NULL,
+  ban_expiry DATETIME NULL DEFAULT NULL,
+  ban_reason VARCHAR(512) NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (
@@ -1006,6 +1114,60 @@ SET @veil_player_accounts_login_id_sql := IF(
 PREPARE veil_player_accounts_login_id_stmt FROM @veil_player_accounts_login_id_sql;
 EXECUTE veil_player_accounts_login_id_stmt;
 DEALLOCATE PREPARE veil_player_accounts_login_id_stmt;
+
+SET @veil_player_accounts_ban_status_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'ban_status'
+);
+
+SET @veil_player_accounts_ban_status_sql := IF(
+  @veil_player_accounts_ban_status_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`ban_status\` VARCHAR(16) NOT NULL DEFAULT ''none'' AFTER \`login_id\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_ban_status_stmt FROM @veil_player_accounts_ban_status_sql;
+EXECUTE veil_player_accounts_ban_status_stmt;
+DEALLOCATE PREPARE veil_player_accounts_ban_status_stmt;
+
+SET @veil_player_accounts_ban_expiry_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'ban_expiry'
+);
+
+SET @veil_player_accounts_ban_expiry_sql := IF(
+  @veil_player_accounts_ban_expiry_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`ban_expiry\` DATETIME NULL DEFAULT NULL AFTER \`ban_status\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_ban_expiry_stmt FROM @veil_player_accounts_ban_expiry_sql;
+EXECUTE veil_player_accounts_ban_expiry_stmt;
+DEALLOCATE PREPARE veil_player_accounts_ban_expiry_stmt;
+
+SET @veil_player_accounts_ban_reason_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'ban_reason'
+);
+
+SET @veil_player_accounts_ban_reason_sql := IF(
+  @veil_player_accounts_ban_reason_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`ban_reason\` VARCHAR(512) NULL AFTER \`ban_expiry\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_ban_reason_stmt FROM @veil_player_accounts_ban_reason_sql;
+EXECUTE veil_player_accounts_ban_reason_stmt;
+DEALLOCATE PREPARE veil_player_accounts_ban_reason_stmt;
 
 SET @veil_player_accounts_password_hash_exists := (
   SELECT COUNT(*)
@@ -1205,6 +1367,24 @@ PREPARE veil_player_accounts_wechat_idp_open_id_idx_stmt FROM @veil_player_accou
 EXECUTE veil_player_accounts_wechat_idp_open_id_idx_stmt;
 DEALLOCATE PREPARE veil_player_accounts_wechat_idp_open_id_idx_stmt;
 
+SET @veil_player_ban_history_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_BAN_HISTORY_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PLAYER_BAN_HISTORY_PLAYER_CREATED_INDEX}'
+);
+
+SET @veil_player_ban_history_idx_sql := IF(
+  @veil_player_ban_history_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_PLAYER_BAN_HISTORY_PLAYER_CREATED_INDEX}\` ON \`${MYSQL_PLAYER_BAN_HISTORY_TABLE}\` (player_id, created_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_ban_history_idx_stmt FROM @veil_player_ban_history_idx_sql;
+EXECUTE veil_player_ban_history_idx_stmt;
+DEALLOCATE PREPARE veil_player_ban_history_idx_stmt;
+
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
   hero_id VARCHAR(191) NOT NULL,
@@ -1396,6 +1576,7 @@ function toPlayerHeroArchiveSnapshot(row: PlayerHeroArchiveRow): PlayerHeroArchi
 
 function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
   const lastSeenAt = formatTimestamp(row.last_seen_at);
+  const banExpiry = formatTimestamp(row.ban_expiry);
   const refreshTokenExpiresAt = formatTimestamp(row.refresh_token_expires_at);
   const wechatMiniGameBoundAt = formatTimestamp(row.wechat_mini_game_bound_at);
   const credentialBoundAt = formatTimestamp(row.credential_bound_at);
@@ -1424,6 +1605,9 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(row.display_name ? { displayName: row.display_name } : {}),
     ...(row.last_room_id ? { lastRoomId: row.last_room_id } : {}),
     ...(row.login_id ? { loginId: row.login_id } : {}),
+    banStatus: normalizePlayerBanStatus(row.ban_status),
+    ...(banExpiry ? { banExpiry } : {}),
+    ...(row.ban_reason ? { banReason: row.ban_reason } : {}),
     ...(row.account_session_version > 0 ? { accountSessionVersion: row.account_session_version } : {}),
     ...(row.refresh_session_id ? { refreshSessionId: row.refresh_session_id } : {}),
     ...(refreshTokenExpiresAt ? { refreshTokenExpiresAt } : {}),
@@ -1435,6 +1619,18 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(createdAt ? { createdAt } : {}),
     ...(updatedAt ? { updatedAt } : {})
   });
+}
+
+function toPlayerBanSnapshot(row: Pick<PlayerAccountRow, "player_id" | "ban_status" | "ban_expiry" | "ban_reason">): PlayerAccountBanSnapshot {
+  const banStatus = normalizePlayerBanStatus(row.ban_status);
+  const banExpiry = formatTimestamp(row.ban_expiry);
+
+  return {
+    playerId: normalizePlayerId(row.player_id),
+    banStatus,
+    ...(banExpiry ? { banExpiry } : {}),
+    ...(row.ban_reason ? { banReason: row.ban_reason } : {})
+  };
 }
 
 function toPlayerAccountAuthSnapshot(row: PlayerAccountAuthRow): PlayerAccountAuthSnapshot | null {
@@ -1497,6 +1693,24 @@ function toPlayerAccountDeviceSessionSnapshot(
   };
 }
 
+function toPlayerBanHistoryRecord(row: PlayerBanHistoryRow): PlayerBanHistoryRecord {
+  const createdAt = formatTimestamp(row.created_at);
+  if (!createdAt) {
+    throw new Error("player ban history created_at must be present");
+  }
+
+  const banExpiry = formatTimestamp(row.ban_expiry);
+  return {
+    id: Math.max(0, Math.floor(row.id)),
+    playerId: normalizePlayerId(row.player_id),
+    action: row.action === "unban" ? "unban" : "ban",
+    banStatus: normalizePlayerBanStatus(row.ban_status),
+    ...(banExpiry ? { banExpiry } : {}),
+    ...(row.ban_reason ? { banReason: row.ban_reason } : {}),
+    createdAt
+  };
+}
+
 async function appendPlayerEventHistoryEntries(
   queryable: Pick<Pool, "query"> | Pick<PoolConnection, "query">,
   playerId: string,
@@ -1531,6 +1745,34 @@ async function appendPlayerEventHistoryEntries(
       ]
     );
   }
+}
+
+async function appendPlayerBanHistoryEntry(
+  queryable: Pick<Pool, "query"> | Pick<PoolConnection, "query">,
+  playerId: string,
+  entry: {
+    action: "ban" | "unban";
+    banStatus: PlayerBanStatus;
+    banExpiry?: string;
+    banReason?: string;
+  }
+): Promise<void> {
+  const banExpiry = entry.banExpiry ? new Date(entry.banExpiry) : null;
+  if (entry.banExpiry && (!banExpiry || Number.isNaN(banExpiry.getTime()))) {
+    throw new Error("banExpiry must be a valid ISO timestamp");
+  }
+
+  await queryable.query(
+    `INSERT INTO \`${MYSQL_PLAYER_BAN_HISTORY_TABLE}\` (
+       player_id,
+       action,
+       ban_status,
+       ban_expiry,
+       ban_reason
+     )
+     VALUES (?, ?, ?, ?, ?)`,
+    [playerId, entry.action, entry.banStatus, banExpiry, entry.banReason ?? null]
+  );
 }
 
 async function deletePlayerProfilesForRoom(connection: PoolConnection, roomId: string): Promise<void> {
@@ -1720,6 +1962,24 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     return accounts[0] ?? null;
   }
 
+  async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const [rows] = await this.pool.query<PlayerAccountRow[]>(
+      `SELECT
+         player_id,
+         ban_status,
+         ban_expiry,
+         ban_reason
+       FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+       WHERE player_id = ?
+       LIMIT 1`,
+      [normalizedPlayerId]
+    );
+
+    const row = rows[0];
+    return row ? toPlayerBanSnapshot(row) : null;
+  }
+
   async loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null> {
     const normalizedLoginId = normalizePlayerLoginId(loginId);
     const [rows] = await this.pool.query<PlayerAccountRow[]>(
@@ -1735,6 +1995,9 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         ban_status,
+         ban_expiry,
+         ban_reason,
          account_session_version,
          refresh_session_id,
          refresh_token_hash,
@@ -1772,6 +2035,9 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         ban_status,
+         ban_expiry,
+         ban_reason,
          account_session_version,
          refresh_session_id,
          refresh_token_hash,
@@ -1893,6 +2159,9 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         ban_status,
+         ban_expiry,
+         ban_reason,
          account_session_version,
          refresh_session_id,
          refresh_token_hash,
@@ -1934,6 +2203,31 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const row = rows[0];
     return row ? toPlayerAccountAuthSnapshot(row) : null;
+  }
+
+  async listPlayerBanHistory(
+    playerId: string,
+    options: PlayerAccountBanHistoryListOptions = {}
+  ): Promise<PlayerBanHistoryRecord[]> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const safeLimit = Math.max(1, Math.floor(options.limit ?? 20));
+    const [rows] = await this.pool.query<PlayerBanHistoryRow[]>(
+      `SELECT
+         id,
+         player_id,
+         action,
+         ban_status,
+         ban_expiry,
+         ban_reason,
+         created_at
+       FROM \`${MYSQL_PLAYER_BAN_HISTORY_TABLE}\`
+       WHERE player_id = ?
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`,
+      [normalizedPlayerId, safeLimit]
+    );
+
+    return rows.map((row) => toPlayerBanHistoryRecord(row));
   }
 
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
@@ -1988,6 +2282,83 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         recentBattleReplays: appendPlayerBattleReplaySummaries([], []),
         ...(lastRoomId ? { lastRoomId } : {}),
         lastSeenAt: lastSeenAt.toISOString()
+      })
+    );
+  }
+
+  async savePlayerBan(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existingAccount = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const banStatus = normalizePlayerBanStatus(input.banStatus);
+    const banReason = normalizePlayerBanReason(input.banReason);
+    const banExpiry = normalizePlayerBanExpiry(input.banExpiry);
+    if (banStatus === "none") {
+      throw new Error("banStatus must be temporary or permanent");
+    }
+    if (!banReason) {
+      throw new Error("banReason must not be empty");
+    }
+    if (banStatus === "temporary") {
+      if (!banExpiry) {
+        throw new Error("temporary bans require banExpiry");
+      }
+      if (new Date(banExpiry).getTime() <= Date.now()) {
+        throw new Error("banExpiry must be in the future");
+      }
+    }
+
+    await this.pool.query(
+      `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+       SET ban_status = ?,
+           ban_expiry = ?,
+           ban_reason = ?,
+           version = version + 1
+       WHERE player_id = ?`,
+      [banStatus, banStatus === "temporary" ? new Date(banExpiry!) : null, banReason, normalizedPlayerId]
+    );
+    await appendPlayerBanHistoryEntry(this.pool, normalizedPlayerId, {
+      action: "ban",
+      banStatus,
+      ...(banStatus === "temporary" && banExpiry ? { banExpiry } : {}),
+      banReason
+    });
+
+    return (
+      (await this.loadPlayerAccount(normalizedPlayerId)) ??
+      normalizePlayerAccountSnapshot({
+        ...existingAccount,
+        banStatus,
+        ...(banStatus === "temporary" && banExpiry ? { banExpiry } : {}),
+        banReason
+      })
+    );
+  }
+
+  async clearPlayerBan(playerId: string, input: PlayerAccountUnbanInput = {}): Promise<PlayerAccountSnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existingAccount = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const reason = normalizePlayerBanReason(input.reason);
+
+    await this.pool.query(
+      `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+       SET ban_status = 'none',
+           ban_expiry = NULL,
+           ban_reason = NULL,
+           version = version + 1
+       WHERE player_id = ?`,
+      [normalizedPlayerId]
+    );
+    await appendPlayerBanHistoryEntry(this.pool, normalizedPlayerId, {
+      action: "unban",
+      banStatus: "none",
+      ...(reason ? { banReason: reason } : {})
+    });
+
+    return (
+      (await this.loadPlayerAccount(normalizedPlayerId)) ??
+      normalizePlayerAccountSnapshot({
+        ...existingAccount,
+        banStatus: "none"
       })
     );
   }
@@ -2481,6 +2852,9 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         ban_status,
+         ban_expiry,
+         ban_reason,
          wechat_open_id,
          wechat_union_id,
          wechat_mini_game_open_id,

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -394,6 +394,17 @@ function sendUnauthorized(
   });
 }
 
+function sendAccountBanned(response: ServerResponse, ban?: { banReason?: string; banExpiry?: string } | null): void {
+  sendJson(response, 403, {
+    error: {
+      code: "account_banned",
+      message: "Account is banned",
+      reason: ban?.banReason ?? "No reason provided",
+      ...(ban?.banExpiry ? { expiry: ban.banExpiry } : {})
+    }
+  });
+}
+
 function sendForbidden(response: ServerResponse): void {
   sendJson(response, 403, {
     error: {
@@ -410,6 +421,10 @@ async function requireAuthSession(
 ) {
   const result = await validateAuthSessionFromRequest(request, store);
   if (!result.session) {
+    if (result.errorCode === "account_banned") {
+      sendAccountBanned(response, result.ban);
+      return null;
+    }
     sendUnauthorized(response, result.errorCode ?? "unauthorized");
     return null;
   }
@@ -445,13 +460,22 @@ function toPublicPlayerAccount(
   account: PlayerAccountSnapshot
 ): Omit<
   PlayerAccountSnapshot,
-  "loginId" | "credentialBoundAt" | "wechatMiniGameOpenId" | "wechatMiniGameUnionId"
+  | "loginId"
+  | "credentialBoundAt"
+  | "wechatMiniGameOpenId"
+  | "wechatMiniGameUnionId"
+  | "banStatus"
+  | "banExpiry"
+  | "banReason"
 > {
   const {
     loginId: _loginId,
     credentialBoundAt: _credentialBoundAt,
     wechatMiniGameOpenId: _wechatMiniGameOpenId,
     wechatMiniGameUnionId: _wechatMiniGameUnionId,
+    banStatus: _banStatus,
+    banExpiry: _banExpiry,
+    banReason: _banReason,
     ...publicAccount
   } = account;
   return publicAccount;
@@ -1560,6 +1584,10 @@ export function registerPlayerAccountRoutes(
     const authResult = await validateAuthSessionFromRequest(request, store);
     const authSession = authResult.session;
     if (!authSession && readGuestAuthTokenFromRequest(request)) {
+      if (authResult.errorCode === "account_banned") {
+        sendAccountBanned(response, authResult.ban);
+        return;
+      }
       sendUnauthorized(response, authResult.errorCode ?? "unauthorized");
       return;
     }
@@ -1627,6 +1655,10 @@ export function registerPlayerAccountRoutes(
       }
 
       if (!authSession) {
+        if (authResult.errorCode === "account_banned") {
+          sendAccountBanned(response, authResult.ban);
+          return;
+        }
         sendUnauthorized(response, authResult.errorCode ?? "unauthorized");
         return;
       }

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -3,7 +3,7 @@ import test, { type TestContext } from "node:test";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { registerAdminRoutes } from "../src/admin-console";
 import { getActiveRoomInstances } from "../src/colyseus-room";
-import type { RoomSnapshotStore } from "../src/persistence";
+import type { PlayerBanHistoryRecord, RoomSnapshotStore } from "../src/persistence";
 
 type RouteHandler = (request: any, response: ServerResponse) => void | Promise<void>;
 
@@ -105,12 +105,25 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
       }
     ])
   );
+  const banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   const saveCalls: Array<{ playerId: string; globalResources: { gold: number; wood: number; ore: number } }> = [];
 
   const store = {
     saveCalls,
     async loadPlayerAccount(playerId: string) {
       return accounts.get(playerId) ?? null;
+    },
+    async loadPlayerBan(playerId: string) {
+      const account = accounts.get(playerId);
+      if (!account) {
+        return null;
+      }
+      return {
+        playerId: account.playerId,
+        banStatus: account.banStatus ?? "none",
+        ...(account.banExpiry ? { banExpiry: account.banExpiry } : {}),
+        ...(account.banReason ? { banReason: account.banReason } : {})
+      };
     },
     async ensurePlayerAccount(input: { playerId: string; displayName?: string }) {
       const existing = accounts.get(input.playerId);
@@ -120,7 +133,8 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
       const created = {
         playerId: input.playerId,
         displayName: input.displayName ?? input.playerId,
-        globalResources: { gold: 0, wood: 0, ore: 0 }
+        globalResources: { gold: 0, wood: 0, ore: 0 },
+        banStatus: "none" as const
       };
       accounts.set(input.playerId, created);
       return created;
@@ -135,10 +149,61 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
       account.globalResources = { ...account.globalResources, ...patch.globalResources };
       saveCalls.push({ playerId, globalResources: { ...account.globalResources } });
       return account;
+    },
+    async savePlayerBan(playerId: string, input: { banStatus: "temporary" | "permanent"; banReason: string; banExpiry?: string }) {
+      const account =
+        (await this.loadPlayerAccount(playerId)) ??
+        (await this.ensurePlayerAccount({
+          playerId,
+          displayName: playerId
+        }));
+      account.banStatus = input.banStatus;
+      account.banReason = input.banReason;
+      account.banExpiry = input.banStatus === "temporary" ? input.banExpiry : undefined;
+      const history = banHistoryByPlayerId.get(playerId) ?? [];
+      history.unshift({
+        id: (history[0]?.id ?? 0) + 1,
+        playerId,
+        action: "ban",
+        banStatus: input.banStatus,
+        ...(input.banExpiry ? { banExpiry: input.banExpiry } : {}),
+        banReason: input.banReason,
+        createdAt: new Date().toISOString()
+      });
+      banHistoryByPlayerId.set(playerId, history);
+      return account;
+    },
+    async clearPlayerBan(playerId: string, input: { reason?: string } = {}) {
+      const account =
+        (await this.loadPlayerAccount(playerId)) ??
+        (await this.ensurePlayerAccount({
+          playerId,
+          displayName: playerId
+        }));
+      account.banStatus = "none";
+      delete account.banReason;
+      delete account.banExpiry;
+      const history = banHistoryByPlayerId.get(playerId) ?? [];
+      history.unshift({
+        id: (history[0]?.id ?? 0) + 1,
+        playerId,
+        action: "unban",
+        banStatus: "none",
+        ...(input.reason ? { banReason: input.reason } : {}),
+        createdAt: new Date().toISOString()
+      });
+      banHistoryByPlayerId.set(playerId, history);
+      return account;
+    },
+    async listPlayerBanHistory(playerId: string, options: { limit?: number } = {}) {
+      return (banHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
     }
   };
 
-  return store as Pick<RoomSnapshotStore, "loadPlayerAccount" | "ensurePlayerAccount" | "savePlayerAccountProgress"> & {
+  return store as Pick<
+    RoomSnapshotStore,
+    "loadPlayerAccount" | "loadPlayerBan" | "ensurePlayerAccount" | "savePlayerAccountProgress" | "savePlayerBan" | "clearPlayerBan" | "listPlayerBanHistory"
+  > & {
     saveCalls: Array<{ playerId: string; globalResources: { gold: number; wood: number; ore: number } }>;
   };
 }
@@ -490,4 +555,104 @@ test("POST /api/admin/broadcast returns 400 for invalid payload types", async (t
 
   assert.equal(invalidMessageResponse.statusCode, 400);
   assert.deepEqual(JSON.parse(invalidMessageResponse.body), { error: '"message" must be a non-empty string' });
+});
+
+test("POST /api/admin/players/:id/ban bans the player and POST /unban clears it", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore({
+    "player-7": { gold: 1, wood: 2, ore: 3 }
+  });
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const banHandler = posts.get("/api/admin/players/:id/ban");
+  const unbanHandler = posts.get("/api/admin/players/:id/unban");
+  assert.ok(banHandler);
+  assert.ok(unbanHandler);
+
+  const banResponse = createResponse();
+  await banHandler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-7" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({
+        banStatus: "temporary",
+        banExpiry: "2026-04-05T00:00:00.000Z",
+        banReason: "Chargeback abuse"
+      })
+    }),
+    banResponse
+  );
+
+  assert.equal(banResponse.statusCode, 200);
+  const banPayload = JSON.parse(banResponse.body) as {
+    ok: boolean;
+    account: { banStatus: string; banExpiry?: string; banReason?: string };
+    disconnectedClients: number;
+  };
+  assert.equal(banPayload.ok, true);
+  assert.equal(banPayload.account.banStatus, "temporary");
+  assert.equal(banPayload.account.banExpiry, "2026-04-05T00:00:00.000Z");
+  assert.equal(banPayload.account.banReason, "Chargeback abuse");
+  assert.equal(banPayload.disconnectedClients, 0);
+
+  const unbanResponse = createResponse();
+  await unbanHandler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-7" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({ reason: "Appeal approved" })
+    }),
+    unbanResponse
+  );
+
+  assert.equal(unbanResponse.statusCode, 200);
+  const unbanPayload = JSON.parse(unbanResponse.body) as {
+    ok: boolean;
+    account: { banStatus: string; banExpiry?: string; banReason?: string };
+  };
+  assert.equal(unbanPayload.ok, true);
+  assert.equal(unbanPayload.account.banStatus, "none");
+  assert.equal("banExpiry" in unbanPayload.account, false);
+  assert.equal("banReason" in unbanPayload.account, false);
+});
+
+test("GET /api/admin/players/:id/ban-history returns current ban state and history records", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore();
+  await store.savePlayerBan("player-history", {
+    banStatus: "permanent",
+    banReason: "Botting"
+  });
+  await store.clearPlayerBan("player-history", {
+    reason: "Manual review"
+  });
+  const { gets } = registerRoutes(store as RoomSnapshotStore);
+  const handler = gets.get("/api/admin/players/:id/ban-history");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      params: { id: "player-history" },
+      headers: {
+        "x-veil-admin-secret": secret
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body) as {
+    items: PlayerBanHistoryRecord[];
+    currentBan: { banStatus: string };
+  };
+  assert.equal(payload.currentBan.banStatus, "none");
+  assert.ok(payload.items.length >= 1);
+  assert.equal(payload.items[0]?.action, "unban");
+  assert.equal(payload.items[0]?.banReason, "Manual review");
 });

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -17,6 +17,9 @@ import { configureRoomSnapshotStore, VeilColyseusRoom } from "../src/colyseus-ro
 import { registerRuntimeObservabilityRoutes, resetRuntimeObservability } from "../src/observability";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import type {
+  PlayerAccountBanHistoryListOptions,
+  PlayerAccountBanInput,
+  PlayerAccountBanSnapshot,
   PlayerAccountProgressPatch,
   PlayerAccountAuthSnapshot,
   PlayerAccountDeviceSessionSnapshot,
@@ -25,6 +28,8 @@ import type {
   PlayerEventHistoryQuery,
   PlayerEventHistorySnapshot,
   PlayerAccountListOptions,
+  PlayerAccountUnbanInput,
+  PlayerBanHistoryRecord,
   PlayerAccountProfilePatch,
   PlayerAccountSnapshot,
   PlayerHeroArchiveSnapshot,
@@ -35,6 +40,7 @@ import { queryEventLogEntries } from "../../../packages/shared/src/index";
 
 class MemoryAuthStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+  private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
@@ -45,6 +51,19 @@ class MemoryAuthStore implements RoomSnapshotStore {
 
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     return this.accounts.get(playerId) ?? null;
+  }
+
+  async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
+    const account = this.accounts.get(playerId);
+    if (!account) {
+      return null;
+    }
+    return {
+      playerId: account.playerId,
+      banStatus: account.banStatus ?? "none",
+      ...(account.banExpiry ? { banExpiry: account.banExpiry } : {}),
+      ...(account.banReason ? { banReason: account.banReason } : {})
+    };
   }
 
   async loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null> {
@@ -130,6 +149,9 @@ class MemoryAuthStore implements RoomSnapshotStore {
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
+      ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
+      ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
+      ...(existing?.banReason ? { banReason: existing.banReason } : {}),
       ...(existing?.wechatMiniGameOpenId ? { wechatMiniGameOpenId: existing.wechatMiniGameOpenId } : {}),
       ...(existing?.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
@@ -138,6 +160,63 @@ class MemoryAuthStore implements RoomSnapshotStore {
       updatedAt: new Date().toISOString()
     };
     this.accounts.set(playerId, account);
+    return account;
+  }
+
+  async listPlayerBanHistory(
+    playerId: string,
+    options: PlayerAccountBanHistoryListOptions = {}
+  ): Promise<PlayerBanHistoryRecord[]> {
+    return (this.banHistoryByPlayerId.get(playerId.trim()) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
+  }
+
+  async savePlayerBan(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: input.banStatus,
+      ...(input.banStatus === "temporary" && input.banExpiry ? { banExpiry: new Date(input.banExpiry).toISOString() } : {}),
+      banReason: input.banReason.trim(),
+      updatedAt: new Date().toISOString()
+    };
+    if (input.banStatus === "permanent") {
+      delete account.banExpiry;
+    }
+    this.accounts.set(account.playerId, account);
+    const history = this.banHistoryByPlayerId.get(account.playerId) ?? [];
+    history.unshift({
+      id: (history[0]?.id ?? 0) + 1,
+      playerId: account.playerId,
+      action: "ban",
+      banStatus: input.banStatus,
+      ...(account.banExpiry ? { banExpiry: account.banExpiry } : {}),
+      banReason: account.banReason,
+      createdAt: new Date().toISOString()
+    });
+    this.banHistoryByPlayerId.set(account.playerId, history);
+    return account;
+  }
+
+  async clearPlayerBan(playerId: string, input: PlayerAccountUnbanInput = {}): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: "none",
+      updatedAt: new Date().toISOString()
+    };
+    delete account.banExpiry;
+    delete account.banReason;
+    this.accounts.set(account.playerId, account);
+    const history = this.banHistoryByPlayerId.get(account.playerId) ?? [];
+    history.unshift({
+      id: (history[0]?.id ?? 0) + 1,
+      playerId: account.playerId,
+      action: "unban",
+      banStatus: "none",
+      ...(input.reason?.trim() ? { banReason: input.reason.trim() } : {}),
+      createdAt: new Date().toISOString()
+    });
+    this.banHistoryByPlayerId.set(account.playerId, history);
     return account;
   }
 
@@ -2785,4 +2864,73 @@ test("wechat mock mode stays disabled outside NODE_ENV=test", { concurrency: fal
 
   assert.equal(response.status, 501);
   assert.equal(payload.error.code, "wechat_login_not_enabled");
+});
+
+test("banned accounts are blocked on account-login and subsequent session checks with reason and expiry", async (t) => {
+  const port = 45120 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  await store.ensurePlayerAccount({
+    playerId: "banned-player",
+    displayName: "Banned Ranger"
+  });
+  await store.bindPlayerAccountCredentials("banned-player", {
+    loginId: "banned-ranger",
+    passwordHash: hashAccountPassword("secret-pass")
+  });
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const initialLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "banned-ranger",
+      password: "secret-pass"
+    })
+  });
+  const initialLoginPayload = (await initialLoginResponse.json()) as { session: GuestAuthSession };
+  assert.equal(initialLoginResponse.status, 200);
+
+  await store.savePlayerBan("banned-player", {
+    banStatus: "temporary",
+    banExpiry: "2026-04-06T00:00:00.000Z",
+    banReason: "Harassment"
+  });
+
+  const sessionResponse = await fetch(`http://127.0.0.1:${port}/api/auth/session`, {
+    headers: {
+      Authorization: `Bearer ${initialLoginPayload.session.token}`
+    }
+  });
+  const sessionPayload = (await sessionResponse.json()) as {
+    error: { code: string; reason: string; expiry?: string };
+  };
+  assert.equal(sessionResponse.status, 403);
+  assert.equal(sessionPayload.error.code, "account_banned");
+  assert.equal(sessionPayload.error.reason, "Harassment");
+  assert.equal(sessionPayload.error.expiry, "2026-04-06T00:00:00.000Z");
+
+  const reloginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "banned-ranger",
+      password: "secret-pass"
+    })
+  });
+  const reloginPayload = (await reloginResponse.json()) as {
+    error: { code: string; reason: string; expiry?: string };
+  };
+  assert.equal(reloginResponse.status, 403);
+  assert.equal(reloginPayload.error.code, "account_banned");
+  assert.equal(reloginPayload.error.reason, "Harassment");
+  assert.equal(reloginPayload.error.expiry, "2026-04-06T00:00:00.000Z");
 });

--- a/apps/server/test/colyseus-room-ban-enforcement.test.ts
+++ b/apps/server/test/colyseus-room-ban-enforcement.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ClientState, matchMaker } from "colyseus";
+import type { Client } from "colyseus";
+import type { ServerMessage } from "../../../packages/shared/src/index";
+import {
+  VeilColyseusRoom,
+  configureRoomSnapshotStore,
+  resetLobbyRoomRegistry
+} from "../src/colyseus-room";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+
+interface FakeClient extends Client {
+  sent: ServerMessage[];
+}
+
+function createFakeClient(sessionId: string): FakeClient {
+  return {
+    sessionId,
+    state: ClientState.JOINED,
+    sent: [],
+    ref: {
+      removeAllListeners() {},
+      removeListener() {},
+      once() {}
+    },
+    send(type: string | number, payload?: unknown) {
+      this.sent.push({ type, ...(payload as object) } as ServerMessage);
+    },
+    leave() {},
+    enqueueRaw() {},
+    raw() {}
+  } as FakeClient;
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function createTestRoom(logicalRoomId: string, seed = 1001): Promise<VeilColyseusRoom> {
+  await matchMaker.setup(
+    undefined,
+    {
+      async update() {},
+      async remove() {},
+      async persist() {}
+    } as never,
+    "http://127.0.0.1"
+  );
+
+  const room = new VeilColyseusRoom();
+  const internalRoom = room as VeilColyseusRoom & {
+    __init(): void;
+    _listing: Record<string, unknown>;
+    _internalState: number;
+  };
+
+  internalRoom.roomId = logicalRoomId;
+  internalRoom.roomName = "veil";
+  internalRoom._listing = {
+    roomId: logicalRoomId,
+    clients: 0,
+    locked: false,
+    private: false,
+    unlisted: false,
+    metadata: {}
+  };
+
+  internalRoom.__init();
+  await room.onCreate({ logicalRoomId, seed });
+  internalRoom._internalState = 1;
+  return room;
+}
+
+function cleanupRoom(room: VeilColyseusRoom): void {
+  const internalRoom = room as VeilColyseusRoom & {
+    _autoDisposeTimeout?: NodeJS.Timeout;
+    _events: {
+      emit(event: string): void;
+    };
+  };
+
+  if (internalRoom._autoDisposeTimeout) {
+    clearTimeout(internalRoom._autoDisposeTimeout);
+    internalRoom._autoDisposeTimeout = undefined;
+  }
+
+  internalRoom._events.emit("dispose");
+  room.clock.clear();
+  room.clock.stop();
+}
+
+async function emitRoomMessage(room: VeilColyseusRoom, type: string, client: FakeClient, payload: object): Promise<void> {
+  const internalRoom = room as VeilColyseusRoom & {
+    onMessageEvents: {
+      emit(event: string, ...args: unknown[]): void;
+    };
+  };
+
+  internalRoom.onMessageEvents.emit(type, client, payload);
+  await flushAsyncWork();
+}
+
+test("room connect re-checks persisted ban state and rejects banned players", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  await store.savePlayerBan("player-banned", {
+    banStatus: "temporary",
+    banExpiry: "2026-04-05T00:00:00.000Z",
+    banReason: "Exploit abuse"
+  });
+  const room = await createTestRoom(`ban-enforcement-${Date.now()}`);
+  const client = createFakeClient("banned-session");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  room.clients.push(client);
+  room.onJoin(client, { playerId: "player-banned" });
+  await emitRoomMessage(room, "connect", client, {
+    type: "connect",
+    requestId: "connect-ban",
+    roomId: room.roomId,
+    playerId: "player-banned"
+  });
+
+  assert.equal(client.sent.some((message) => message.type === "error" && message.reason === "account_banned"), true);
+  assert.equal(client.sent.some((message) => message.type === "session.state"), false);
+});

--- a/apps/server/test/player-account-battle-replay-detail-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-detail-routes.test.ts
@@ -8,6 +8,9 @@ import { VeilColyseusRoom, configureRoomSnapshotStore, resetLobbyRoomRegistry } 
 import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import type {
+  PlayerAccountBanHistoryListOptions,
+  PlayerAccountBanInput,
+  PlayerAccountBanSnapshot,
   PlayerAccountAuthSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
@@ -18,6 +21,8 @@ import type {
   PlayerAccountProgressPatch,
   PlayerAccountSnapshot,
   PlayerHeroArchiveSnapshot,
+  PlayerAccountUnbanInput,
+  PlayerBanHistoryRecord,
   RoomSnapshotStore
 } from "../src/persistence";
 import type { RoomPersistenceSnapshot } from "../src/index";
@@ -35,6 +40,7 @@ interface FakeClient extends Client {
 
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+  private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
 
   async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
     return null;
@@ -42,6 +48,19 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     return this.accounts.get(playerId) ?? null;
+  }
+
+  async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
+    const account = this.accounts.get(playerId);
+    if (!account) {
+      return null;
+    }
+    return {
+      playerId: account.playerId,
+      banStatus: account.banStatus ?? "none",
+      ...(account.banExpiry ? { banExpiry: account.banExpiry } : {}),
+      ...(account.banReason ? { banReason: account.banReason } : {})
+    };
   }
 
   async loadPlayerAccountByLoginId(_loginId: string): Promise<PlayerAccountSnapshot | null> {
@@ -101,6 +120,9 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       achievements: structuredClone(existing?.achievements ?? []),
       recentEventLog: structuredClone(existing?.recentEventLog ?? []),
       recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
+      ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
+      ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
+      ...(existing?.banReason ? { banReason: existing.banReason } : {}),
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -110,6 +132,42 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async bindPlayerAccountCredentials(_playerId: string, _input: PlayerAccountCredentialInput): Promise<PlayerAccountSnapshot> {
     throw new Error("not implemented");
+  }
+
+  async listPlayerBanHistory(
+    playerId: string,
+    options: PlayerAccountBanHistoryListOptions = {}
+  ): Promise<PlayerBanHistoryRecord[]> {
+    return (this.banHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
+  }
+
+  async savePlayerBan(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: input.banStatus,
+      ...(input.banStatus === "temporary" && input.banExpiry ? { banExpiry: new Date(input.banExpiry).toISOString() } : {}),
+      banReason: input.banReason.trim(),
+      updatedAt: new Date().toISOString()
+    };
+    if (input.banStatus === "permanent") {
+      delete account.banExpiry;
+    }
+    this.accounts.set(playerId, account);
+    return account;
+  }
+
+  async clearPlayerBan(playerId: string, _input: PlayerAccountUnbanInput = {}): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: "none",
+      updatedAt: new Date().toISOString()
+    };
+    delete account.banExpiry;
+    delete account.banReason;
+    this.accounts.set(playerId, account);
+    return account;
   }
 
   async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {

--- a/apps/server/test/player-account-battle-replay-playback-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-playback-routes.test.ts
@@ -4,6 +4,9 @@ import { Server, WebSocketTransport } from "colyseus";
 import { issueGuestAuthSession } from "../src/auth";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import type {
+  PlayerAccountBanHistoryListOptions,
+  PlayerAccountBanInput,
+  PlayerAccountBanSnapshot,
   PlayerAccountAuthSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
@@ -14,6 +17,8 @@ import type {
   PlayerAccountProgressPatch,
   PlayerAccountSnapshot,
   PlayerHeroArchiveSnapshot,
+  PlayerAccountUnbanInput,
+  PlayerBanHistoryRecord,
   RoomSnapshotStore
 } from "../src/persistence";
 import type { RoomPersistenceSnapshot } from "../src/index";
@@ -26,6 +31,7 @@ import {
 
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+  private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
 
   async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
     return null;
@@ -33,6 +39,19 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     return this.accounts.get(playerId) ?? null;
+  }
+
+  async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
+    const account = this.accounts.get(playerId);
+    if (!account) {
+      return null;
+    }
+    return {
+      playerId: account.playerId,
+      banStatus: account.banStatus ?? "none",
+      ...(account.banExpiry ? { banExpiry: account.banExpiry } : {}),
+      ...(account.banReason ? { banReason: account.banReason } : {})
+    };
   }
 
   async loadPlayerAccountByLoginId(_loginId: string): Promise<PlayerAccountSnapshot | null> {
@@ -92,6 +111,9 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       achievements: structuredClone(existing?.achievements ?? []),
       recentEventLog: structuredClone(existing?.recentEventLog ?? []),
       recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
+      ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
+      ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
+      ...(existing?.banReason ? { banReason: existing.banReason } : {}),
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -101,6 +123,42 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async bindPlayerAccountCredentials(_playerId: string, _input: PlayerAccountCredentialInput): Promise<PlayerAccountSnapshot> {
     throw new Error("not implemented");
+  }
+
+  async listPlayerBanHistory(
+    playerId: string,
+    options: PlayerAccountBanHistoryListOptions = {}
+  ): Promise<PlayerBanHistoryRecord[]> {
+    return (this.banHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
+  }
+
+  async savePlayerBan(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: input.banStatus,
+      ...(input.banStatus === "temporary" && input.banExpiry ? { banExpiry: new Date(input.banExpiry).toISOString() } : {}),
+      banReason: input.banReason.trim(),
+      updatedAt: new Date().toISOString()
+    };
+    if (input.banStatus === "permanent") {
+      delete account.banExpiry;
+    }
+    this.accounts.set(playerId, account);
+    return account;
+  }
+
+  async clearPlayerBan(playerId: string, _input: PlayerAccountUnbanInput = {}): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: "none",
+      updatedAt: new Date().toISOString()
+    };
+    delete account.banExpiry;
+    delete account.banReason;
+    this.accounts.set(playerId, account);
+    return account;
   }
 
   async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -5,6 +5,9 @@ import { issueAccountAuthSession, issueGuestAuthSession, issueWechatMiniGameAuth
 import { applyPlayerEventLogAndAchievements } from "../src/player-achievements";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import type {
+  PlayerAccountBanHistoryListOptions,
+  PlayerAccountBanInput,
+  PlayerAccountBanSnapshot,
   PlayerAccountProgressPatch,
   PlayerAccountAuthSnapshot,
   PlayerAccountDeviceSessionSnapshot,
@@ -13,6 +16,8 @@ import type {
   PlayerEventHistoryQuery,
   PlayerEventHistorySnapshot,
   PlayerAccountListOptions,
+  PlayerAccountUnbanInput,
+  PlayerBanHistoryRecord,
   PlayerAccountProfilePatch,
   PlayerAccountSnapshot,
   PlayerHeroArchiveSnapshot,
@@ -32,6 +37,7 @@ import {
 
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+  private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
@@ -43,6 +49,19 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     return this.accounts.get(playerId) ?? null;
+  }
+
+  async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
+    const account = this.accounts.get(playerId);
+    if (!account) {
+      return null;
+    }
+    return {
+      playerId: account.playerId,
+      banStatus: account.banStatus ?? "none",
+      ...(account.banExpiry ? { banExpiry: account.banExpiry } : {}),
+      ...(account.banReason ? { banReason: account.banReason } : {})
+    };
   }
 
   async loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null> {
@@ -131,6 +150,9 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
+      ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
+      ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
+      ...(existing?.banReason ? { banReason: existing.banReason } : {}),
       ...(existing?.wechatMiniGameOpenId ? { wechatMiniGameOpenId: existing.wechatMiniGameOpenId } : {}),
       ...(existing?.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
@@ -139,6 +161,63 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       updatedAt: new Date().toISOString()
     };
     this.accounts.set(account.playerId, account);
+    return account;
+  }
+
+  async listPlayerBanHistory(
+    playerId: string,
+    options: PlayerAccountBanHistoryListOptions = {}
+  ): Promise<PlayerBanHistoryRecord[]> {
+    return (this.banHistoryByPlayerId.get(playerId.trim()) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
+  }
+
+  async savePlayerBan(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: input.banStatus,
+      ...(input.banStatus === "temporary" && input.banExpiry ? { banExpiry: new Date(input.banExpiry).toISOString() } : {}),
+      banReason: input.banReason.trim(),
+      updatedAt: new Date().toISOString()
+    };
+    if (input.banStatus === "permanent") {
+      delete account.banExpiry;
+    }
+    this.accounts.set(account.playerId, account);
+    const history = this.banHistoryByPlayerId.get(account.playerId) ?? [];
+    history.unshift({
+      id: (history[0]?.id ?? 0) + 1,
+      playerId: account.playerId,
+      action: "ban",
+      banStatus: input.banStatus,
+      ...(account.banExpiry ? { banExpiry: account.banExpiry } : {}),
+      banReason: account.banReason,
+      createdAt: new Date().toISOString()
+    });
+    this.banHistoryByPlayerId.set(account.playerId, history);
+    return account;
+  }
+
+  async clearPlayerBan(playerId: string, input: PlayerAccountUnbanInput = {}): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      banStatus: "none",
+      updatedAt: new Date().toISOString()
+    };
+    delete account.banExpiry;
+    delete account.banReason;
+    this.accounts.set(account.playerId, account);
+    const history = this.banHistoryByPlayerId.get(account.playerId) ?? [];
+    history.unshift({
+      id: (history[0]?.id ?? 0) + 1,
+      playerId: account.playerId,
+      action: "unban",
+      banStatus: "none",
+      ...(input.reason?.trim() ? { banReason: input.reason.trim() } : {}),
+      createdAt: new Date().toISOString()
+    });
+    this.banHistoryByPlayerId.set(account.playerId, history);
     return account;
   }
 

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -13,6 +13,8 @@ import { normalizePlayerBattleReplaySummaries, type PlayerBattleReplaySummary } 
 import { normalizeEloRating } from "./matchmaking.ts";
 import type { ResourceLedger } from "./models.ts";
 
+export type PlayerBanStatus = "none" | "temporary" | "permanent";
+
 export interface PlayerAccountReadModel {
   playerId: string;
   displayName: string;
@@ -25,6 +27,9 @@ export interface PlayerAccountReadModel {
   battleReportCenter?: PlayerBattleReportCenter;
   loginId?: string;
   credentialBoundAt?: string;
+  banStatus?: PlayerBanStatus;
+  banExpiry?: string;
+  banReason?: string;
   lastRoomId?: string;
   lastSeenAt?: string;
 }
@@ -41,6 +46,9 @@ export interface PlayerAccountReadModelInput {
   battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
+  banStatus?: PlayerBanStatus | undefined;
+  banExpiry?: string | undefined;
+  banReason?: string | undefined;
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
 }
@@ -53,6 +61,9 @@ export function normalizePlayerAccountReadModel(
   const avatarUrl = account?.avatarUrl?.trim();
   const loginId = account?.loginId?.trim().toLowerCase();
   const credentialBoundAt = account?.credentialBoundAt?.trim();
+  const banStatus = account?.banStatus === "temporary" || account?.banStatus === "permanent" ? account.banStatus : "none";
+  const banExpiry = account?.banExpiry?.trim();
+  const banReason = account?.banReason?.trim();
   const lastRoomId = account?.lastRoomId?.trim();
   const lastSeenAt = account?.lastSeenAt?.trim();
   const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
@@ -77,6 +88,9 @@ export function normalizePlayerAccountReadModel(
     }),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
+    ...(banStatus !== "none" ? { banStatus } : {}),
+    ...(banExpiry ? { banExpiry } : {}),
+    ...(banReason ? { banReason } : {}),
     ...(lastRoomId ? { lastRoomId } : {}),
     ...(lastSeenAt ? { lastSeenAt } : {})
   };


### PR DESCRIPTION
## Summary
- add persisted player ban fields and append-only ban history storage/query support
- add admin ban, unban, and ban-history APIs guarded by the admin secret
- block banned users in auth/session flows and re-check ban state on Colyseus room connect

## Validation
- npm run typecheck:server
- node --import tsx --test apps/server/test/admin-console.test.ts apps/server/test/colyseus-room-ban-enforcement.test.ts
- node --import tsx --test --test-name-pattern "banned accounts are blocked on account-login and subsequent session checks with reason and expiry" apps/server/test/auth-guest-login.test.ts

Closes #778