### PR TITLE
Implement minor protection enforcement

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -28,6 +28,7 @@ import {
   setPendingAuthRegistrationCount,
   upsertAuthAccountSession
 } from "./observability";
+import { deriveWechatMinorProtection } from "./minor-protection";
 import { isPlayerBanActive, type PlayerAccountBanSnapshot, type RoomSnapshotStore } from "./persistence";
 
 export type AuthMode = "guest" | "account";
@@ -861,6 +862,9 @@ async function handleWechatLogin(
     playerId?: string | null;
     displayName?: string | null;
     avatarUrl?: string | null;
+    ageVerified?: boolean | null;
+    isAdult?: boolean | null;
+    ageRange?: string | null;
   };
 
   if (body.code !== undefined && body.code !== null && typeof body.code !== "string") {
@@ -903,8 +907,43 @@ async function handleWechatLogin(
     return;
   }
 
+  if (body.ageVerified !== undefined && body.ageVerified !== null && typeof body.ageVerified !== "boolean") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional boolean field: ageVerified"
+      }
+    });
+    return;
+  }
+
+  if (body.isAdult !== undefined && body.isAdult !== null && typeof body.isAdult !== "boolean") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional boolean field: isAdult"
+      }
+    });
+    return;
+  }
+
+  if (body.ageRange !== undefined && body.ageRange !== null && typeof body.ageRange !== "string") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional string field: ageRange"
+      }
+    });
+    return;
+  }
+
   const code = normalizeWechatMiniGameCode(body.code);
   const avatarUrl = normalizeAvatarUrl(body.avatarUrl);
+  const minorProtection = deriveWechatMinorProtection({
+    ...(body.ageVerified !== undefined ? { ageVerified: body.ageVerified } : {}),
+    ...(body.isAdult !== undefined ? { isAdult: body.isAdult } : {}),
+    ...(body.ageRange !== undefined ? { ageRange: body.ageRange } : {})
+  });
   const wechatConfig = readWechatMiniGameLoginConfig();
 
   let identity: WechatMiniGameIdentity;
@@ -971,7 +1010,8 @@ async function handleWechatLogin(
         openId: identity.openId,
         ...(identity.unionId ? { unionId: identity.unionId } : {}),
         ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
-        ...(avatarUrl ? { avatarUrl } : {})
+        ...(avatarUrl ? { avatarUrl } : {}),
+        ...minorProtection
       });
       playerId = syncedAccount.playerId;
       displayName = syncedAccount.displayName;
@@ -982,7 +1022,8 @@ async function handleWechatLogin(
         openId: identity.openId,
         ...(identity.unionId ? { unionId: identity.unionId } : {}),
         ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
-        ...(avatarUrl ? { avatarUrl } : {})
+        ...(avatarUrl ? { avatarUrl } : {}),
+        ...minorProtection
       });
       playerId = boundAccountResult.playerId;
       displayName = boundAccountResult.displayName;

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -30,6 +30,7 @@ import {
 import { registerConfigUpdateListener } from "./config-center";
 import { applyPlayerEventLogAndAchievements } from "./player-achievements";
 import { resolveGuestAuthSession } from "./auth";
+import { deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
 import {
   recordBattleActionMessage,
   recordConnectMessage,
@@ -62,6 +63,7 @@ const MAP_SYNC_CHUNK_PADDING = 1;
 const DEFAULT_WS_ACTION_RATE_LIMIT_WINDOW_MS = 1_000;
 const DEFAULT_WS_ACTION_RATE_LIMIT_MAX = 8;
 const DEFAULT_PLAYER_SLOT_ID = /^player-(\d+)$/;
+const MINOR_PROTECTION_TICK_MS = 60_000;
 let configuredRoomSnapshotStore: RoomSnapshotStore | null = null;
 const lobbyRoomSummaries = new Map<string, LobbyRoomSummary>();
 const lobbyRoomOwnerTokens = new Map<string, number>();
@@ -237,6 +239,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
 
   public worldRoom!: AuthoritativeWorldRoom;
   private readonly wsActionRateLimitConfig = readWebSocketActionRateLimitConfig();
+  private readonly minorProtectionConfig = readMinorProtectionConfig();
   private readonly lobbyRoomOwnerToken = nextLobbyRoomOwnerToken++;
   private readonly playerIdBySessionId = new Map<string, string>();
   private readonly reconnectedAtByPlayerId = new Map<string, string>();
@@ -287,6 +290,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         });
       }
     });
+    this.clock.setInterval(() => {
+      void this.tickMinorPlaytime();
+    }, MINOR_PROTECTION_TICK_MS);
 
     this.onMessage("connect", async (client, message: Extract<ClientMessage, { type: "connect" }>) => {
       recordConnectMessage();
@@ -325,6 +331,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       if (isPlayerBanActive(ensuredAccount)) {
         sendMessage(client, "error", { requestId: message.requestId, reason: "account_banned" });
         client.leave(CloseCode.WITH_ERROR, "account_banned");
+        return;
+      }
+      if (await this.enforceMinorProtectionForClient(client, playerId, ensuredAccount, message.requestId)) {
         return;
       }
       await this.ensurePlayerWorldSlot(playerId, ensuredAccount);
@@ -488,6 +497,11 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
           return;
         }
       }
+      if (await this.enforceMinorProtectionForClient(reconnectedClient, playerId, null, "push")) {
+        this.playerIdBySessionId.delete(client.sessionId);
+        this.publishLobbyRoomSummary();
+        return;
+      }
       this.playerIdBySessionId.delete(client.sessionId);
       this.playerIdBySessionId.set(reconnectedClient.sessionId, playerId);
       this.reconnectedAtByPlayerId.set(playerId, new Date().toISOString());
@@ -539,6 +553,127 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     timestamps.push(now);
     this.wsActionTimestampsByPlayerId.set(playerId, timestamps);
     return true;
+  }
+
+  private getConnectedPlayerIds(): string[] {
+    return Array.from(new Set(this.playerIdBySessionId.values()));
+  }
+
+  private async syncMinorProtectionAccount(
+    playerId: string,
+    account: PlayerAccountSnapshot
+  ): Promise<PlayerAccountSnapshot> {
+    const store = configuredRoomSnapshotStore;
+    if (!store) {
+      return account;
+    }
+
+    const state = deriveMinorProtectionState(account, new Date(), this.minorProtectionConfig);
+    if (
+      account.lastPlayDate === state.localDate &&
+      (account.dailyPlayMinutes ?? 0) === state.normalizedDailyPlayMinutes
+    ) {
+      return account;
+    }
+
+    return store.savePlayerAccountProgress(playerId, {
+      dailyPlayMinutes: state.normalizedDailyPlayMinutes,
+      lastPlayDate: state.localDate,
+      lastRoomId: this.metadata.logicalRoomId
+    });
+  }
+
+  private async enforceMinorProtectionForClient(
+    client: ColyseusClient,
+    playerId: string,
+    ensuredAccount: PlayerAccountSnapshot | null,
+    requestId: string
+  ): Promise<boolean> {
+    const store = configuredRoomSnapshotStore;
+    const account =
+      ensuredAccount ??
+      (store
+        ? await store.ensurePlayerAccount({
+            playerId,
+            lastRoomId: this.metadata.logicalRoomId
+          })
+        : null);
+
+    if (!account || account.isMinor !== true) {
+      return false;
+    }
+
+    const syncedAccount = await this.syncMinorProtectionAccount(playerId, account);
+    const state = deriveMinorProtectionState(syncedAccount, new Date(), this.minorProtectionConfig);
+    if (state.restrictedHours) {
+      sendMessage(client, "error", { requestId, reason: "minor_restricted_hours" });
+      client.leave(CloseCode.WITH_ERROR, "minor_restricted_hours");
+      return true;
+    }
+
+    if (state.dailyLimitReached) {
+      sendMessage(client, "error", { requestId, reason: "minor_daily_limit_reached" });
+      client.leave(CloseCode.WITH_ERROR, "minor_daily_limit_reached");
+      return true;
+    }
+
+    return false;
+  }
+
+  private async tickMinorPlaytime(): Promise<void> {
+    const store = configuredRoomSnapshotStore;
+    if (!store) {
+      return;
+    }
+
+    const playerIds = this.getConnectedPlayerIds();
+    if (playerIds.length === 0) {
+      return;
+    }
+
+    try {
+      const loadedAccounts = await store.loadPlayerAccounts(playerIds);
+      const accountsByPlayerId = new Map(loadedAccounts.map((account) => [account.playerId, account] as const));
+
+      await Promise.all(
+        playerIds.map(async (playerId) => {
+          const account =
+            accountsByPlayerId.get(playerId) ??
+            (await store.ensurePlayerAccount({
+              playerId,
+              lastRoomId: this.metadata.logicalRoomId
+            }));
+          if (account.isMinor !== true) {
+            return;
+          }
+
+          const state = deriveMinorProtectionState(account, new Date(), this.minorProtectionConfig);
+          if (state.restrictedHours) {
+            await store.savePlayerAccountProgress(playerId, {
+              dailyPlayMinutes: state.normalizedDailyPlayMinutes,
+              lastPlayDate: state.localDate,
+              lastRoomId: this.metadata.logicalRoomId
+            });
+            this.disconnectPlayer(playerId, "minor_restricted_hours");
+            return;
+          }
+          const nextMinutes = state.normalizedDailyPlayMinutes + 1;
+          await store.savePlayerAccountProgress(playerId, {
+            dailyPlayMinutes: nextMinutes,
+            lastPlayDate: state.localDate,
+            lastRoomId: this.metadata.logicalRoomId
+          });
+          if (nextMinutes >= state.dailyLimitMinutes) {
+            this.disconnectPlayer(playerId, "minor_daily_limit_reached");
+          }
+        })
+      );
+    } catch (error) {
+      console.error("[VeilRoom] Failed to update minor playtime", {
+        roomId: this.metadata.logicalRoomId,
+        error
+      });
+    }
   }
 
   private async persistRoomState(): Promise<void> {

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -206,6 +206,10 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
           : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
+      ...(existing?.ageVerified ? { ageVerified: existing.ageVerified } : {}),
+      ...(existing?.isMinor ? { isMinor: existing.isMinor } : {}),
+      ...(existing?.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
+      ...(existing?.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
       ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
       ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
       ...(existing?.banReason ? { banReason: existing.banReason } : {}),
@@ -486,6 +490,8 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       ...(normalizedAvatarUrl ? { avatarUrl: normalizedAvatarUrl } : existing.avatarUrl ? { avatarUrl: existing.avatarUrl } : {}),
       wechatMiniGameOpenId: normalizedOpenId,
       ...(normalizedUnionId ? { wechatMiniGameUnionId: normalizedUnionId } : {}),
+      ...(input.ageVerified !== undefined ? { ageVerified: input.ageVerified } : existing.ageVerified ? { ageVerified: existing.ageVerified } : {}),
+      ...(input.isMinor !== undefined ? { isMinor: input.isMinor } : existing.isMinor ? { isMinor: existing.isMinor } : {}),
       wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -552,6 +558,8 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
           existing.recentBattleReplays ??
           []
       ),
+      ...(patch.dailyPlayMinutes !== undefined ? { dailyPlayMinutes: Math.max(0, Math.floor(patch.dailyPlayMinutes ?? 0)) } : existing.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
+      ...(patch.lastPlayDate !== undefined ? (patch.lastPlayDate ? { lastPlayDate: patch.lastPlayDate.trim() } : {}) : existing.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId?.trim()
           ? { lastRoomId: patch.lastRoomId.trim() }
@@ -584,6 +592,10 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         achievements: structuredClone(previous?.achievements ?? account.achievements),
         recentEventLog: structuredClone(previous?.recentEventLog ?? account.recentEventLog),
         recentBattleReplays: structuredClone(previous?.recentBattleReplays ?? account.recentBattleReplays ?? []),
+        ...(previous?.ageVerified ? { ageVerified: previous.ageVerified } : {}),
+        ...(previous?.isMinor ? { isMinor: previous.isMinor } : {}),
+        ...(previous?.dailyPlayMinutes ? { dailyPlayMinutes: previous.dailyPlayMinutes } : {}),
+        ...(previous?.lastPlayDate ? { lastPlayDate: previous.lastPlayDate } : {}),
         ...(previous?.loginId ? { loginId: previous.loginId } : {}),
         ...(previous?.accountSessionVersion != null ? { accountSessionVersion: previous.accountSessionVersion } : {}),
         ...(previous?.refreshSessionId ? { refreshSessionId: previous.refreshSessionId } : {}),

--- a/apps/server/src/minor-protection.ts
+++ b/apps/server/src/minor-protection.ts
@@ -1,0 +1,208 @@
+import type { PlayerAccountSnapshot } from "./persistence";
+
+const DEFAULT_MINOR_PROTECTION_TIME_ZONE = "Asia/Shanghai";
+const DEFAULT_MINOR_WEEKDAY_LIMIT_MINUTES = 90;
+const DEFAULT_MINOR_HOLIDAY_LIMIT_MINUTES = 180;
+const DEFAULT_MINOR_LOCKOUT_START_HOUR = 22;
+const DEFAULT_MINOR_LOCKOUT_END_HOUR = 8;
+
+export interface MinorProtectionConfig {
+  timeZone: string;
+  weekdayDailyLimitMinutes: number;
+  holidayDailyLimitMinutes: number;
+  restrictedStartHour: number;
+  restrictedEndHour: number;
+  holidayDates: Set<string>;
+}
+
+export interface MinorProtectionState {
+  enforced: boolean;
+  localDate: string;
+  normalizedDailyPlayMinutes: number;
+  dailyLimitMinutes: number;
+  restrictedHours: boolean;
+  dailyLimitReached: boolean;
+}
+
+function parseEnvInteger(value: string | undefined, fallback: number, minimum: number, maximum?: number): number {
+  const parsed = Number(value?.trim());
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  const normalized = Math.floor(parsed);
+  if (normalized < minimum) {
+    return fallback;
+  }
+
+  if (maximum != null && normalized > maximum) {
+    return fallback;
+  }
+
+  return normalized;
+}
+
+function getDateParts(date: Date, timeZone: string): { year: string; month: string; day: string } {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).formatToParts(date);
+
+  return {
+    year: parts.find((part) => part.type === "year")?.value ?? "1970",
+    month: parts.find((part) => part.type === "month")?.value ?? "01",
+    day: parts.find((part) => part.type === "day")?.value ?? "01"
+  };
+}
+
+function getHourInTimeZone(date: Date, timeZone: string): number {
+  const hourPart = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "2-digit",
+    hourCycle: "h23"
+  })
+    .formatToParts(date)
+    .find((part) => part.type === "hour")?.value;
+
+  return Number(hourPart ?? "0");
+}
+
+function getWeekdayInTimeZone(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "short"
+  }).format(date);
+}
+
+function normalizeDateKey(value?: string | null): string | undefined {
+  const normalized = value?.trim();
+  return normalized && /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : undefined;
+}
+
+function isMinorAgeRange(ageRange: string): boolean | undefined {
+  const normalized = ageRange.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+
+  if (normalized.includes("adult") || normalized.includes("18+")) {
+    return false;
+  }
+
+  if (normalized.includes("minor") || normalized.includes("under18") || normalized.includes("<18")) {
+    return true;
+  }
+
+  const rangeMatch = normalized.match(/^(\d{1,2})\s*[-~]\s*(\d{1,2})$/);
+  if (!rangeMatch) {
+    return undefined;
+  }
+
+  const maxAge = Number(rangeMatch[2]);
+  if (!Number.isFinite(maxAge)) {
+    return undefined;
+  }
+
+  return maxAge < 18;
+}
+
+export function readMinorProtectionConfig(env: NodeJS.ProcessEnv = process.env): MinorProtectionConfig {
+  const holidayDates = new Set(
+    (env.VEIL_MINOR_PROTECTION_HOLIDAY_DATES ?? "")
+      .split(",")
+      .map((value) => normalizeDateKey(value))
+      .filter((value): value is string => Boolean(value))
+  );
+
+  return {
+    timeZone: env.VEIL_MINOR_PROTECTION_TIME_ZONE?.trim() || DEFAULT_MINOR_PROTECTION_TIME_ZONE,
+    weekdayDailyLimitMinutes: parseEnvInteger(
+      env.VEIL_MINOR_PROTECTION_WEEKDAY_LIMIT_MINUTES,
+      DEFAULT_MINOR_WEEKDAY_LIMIT_MINUTES,
+      1
+    ),
+    holidayDailyLimitMinutes: parseEnvInteger(
+      env.VEIL_MINOR_PROTECTION_HOLIDAY_LIMIT_MINUTES,
+      DEFAULT_MINOR_HOLIDAY_LIMIT_MINUTES,
+      1
+    ),
+    restrictedStartHour: parseEnvInteger(
+      env.VEIL_MINOR_PROTECTION_RESTRICTED_START_HOUR,
+      DEFAULT_MINOR_LOCKOUT_START_HOUR,
+      0,
+      23
+    ),
+    restrictedEndHour: parseEnvInteger(
+      env.VEIL_MINOR_PROTECTION_RESTRICTED_END_HOUR,
+      DEFAULT_MINOR_LOCKOUT_END_HOUR,
+      0,
+      23
+    ),
+    holidayDates
+  };
+}
+
+export function getMinorProtectionDateKey(date: Date, timeZone: string): string {
+  const parts = getDateParts(date, timeZone);
+  return `${parts.year}-${parts.month}-${parts.day}`;
+}
+
+export function deriveMinorProtectionState(
+  account: Pick<PlayerAccountSnapshot, "isMinor" | "dailyPlayMinutes" | "lastPlayDate">,
+  now = new Date(),
+  config = readMinorProtectionConfig()
+): MinorProtectionState {
+  const localDate = getMinorProtectionDateKey(now, config.timeZone);
+  const normalizedDailyPlayMinutes =
+    account.lastPlayDate === localDate ? Math.max(0, Math.floor(account.dailyPlayMinutes ?? 0)) : 0;
+  const weekday = getWeekdayInTimeZone(now, config.timeZone);
+  const isHoliday = config.holidayDates.has(localDate) || weekday === "Sat" || weekday === "Sun";
+  const dailyLimitMinutes = isHoliday ? config.holidayDailyLimitMinutes : config.weekdayDailyLimitMinutes;
+  const hour = getHourInTimeZone(now, config.timeZone);
+  const restrictedHours =
+    config.restrictedStartHour > config.restrictedEndHour
+      ? hour >= config.restrictedStartHour || hour < config.restrictedEndHour
+      : hour >= config.restrictedStartHour && hour < config.restrictedEndHour;
+
+  return {
+    enforced: account.isMinor === true,
+    localDate,
+    normalizedDailyPlayMinutes,
+    dailyLimitMinutes,
+    restrictedHours,
+    dailyLimitReached: normalizedDailyPlayMinutes >= dailyLimitMinutes
+  };
+}
+
+export function deriveWechatMinorProtection(input: {
+  ageVerified?: boolean | null;
+  isAdult?: boolean | null;
+  ageRange?: string | null;
+}): { ageVerified?: boolean; isMinor?: boolean } {
+  if (typeof input.isAdult === "boolean") {
+    return {
+      ageVerified: true,
+      isMinor: !input.isAdult
+    };
+  }
+
+  if (typeof input.ageRange === "string") {
+    const isMinor = isMinorAgeRange(input.ageRange);
+    if (typeof isMinor === "boolean") {
+      return {
+        ageVerified: true,
+        isMinor
+      };
+    }
+  }
+
+  if (typeof input.ageVerified === "boolean") {
+    return {
+      ageVerified: input.ageVerified
+    };
+  }
+
+  return {};
+}

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -125,6 +125,10 @@ interface PlayerAccountRow extends RowDataPacket {
   last_room_id: string | null;
   last_seen_at: Date | string | null;
   login_id: string | null;
+  age_verified: number | boolean | null;
+  is_minor: number | boolean | null;
+  daily_play_minutes: number | null;
+  last_play_date: Date | string | null;
   ban_status: string | null;
   ban_expiry: Date | string | null;
   ban_reason: string | null;
@@ -285,6 +289,8 @@ export interface PlayerAccountProgressPatch {
   achievements?: Partial<PlayerAchievementProgress>[] | null;
   recentEventLog?: Partial<EventLogEntry>[] | null;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null;
+  dailyPlayMinutes?: number | null;
+  lastPlayDate?: string | null;
   lastRoomId?: string | null;
 }
 
@@ -312,6 +318,8 @@ export interface PlayerAccountWechatMiniGameIdentityInput {
   unionId?: string;
   displayName?: string;
   avatarUrl?: string | null;
+  ageVerified?: boolean;
+  isMinor?: boolean;
 }
 
 export interface PlayerAccountListOptions {
@@ -491,6 +499,52 @@ function normalizePlayerAvatarUrl(avatarUrl?: string | null): string | undefined
   return normalized ? normalized.slice(0, MAX_PLAYER_AVATAR_URL_LENGTH) : undefined;
 }
 
+function normalizePlayerAgeVerified(ageVerified?: boolean | number | null): boolean | undefined {
+  if (ageVerified == null) {
+    return undefined;
+  }
+
+  return ageVerified === true || ageVerified === 1;
+}
+
+function normalizePlayerIsMinor(isMinor?: boolean | number | null): boolean | undefined {
+  if (isMinor == null) {
+    return undefined;
+  }
+
+  return isMinor === true || isMinor === 1;
+}
+
+function normalizeDailyPlayMinutes(minutes?: number | null): number {
+  return Math.max(0, Math.floor(minutes ?? 0));
+}
+
+function normalizeLastPlayDate(value?: string | Date | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+      return normalized;
+    }
+
+    const parsed = new Date(normalized);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString().slice(0, 10);
+    }
+
+    throw new Error("lastPlayDate must be a valid date string");
+  }
+
+  if (Number.isNaN(value.getTime())) {
+    throw new Error("lastPlayDate must be a valid date");
+  }
+
+  return value.toISOString().slice(0, 10);
+}
+
 export function normalizePlayerLoginId(loginId: string): string {
   const normalized = loginId.trim().toLowerCase();
   if (!/^[a-z0-9][a-z0-9_-]{2,39}$/.test(normalized)) {
@@ -568,6 +622,10 @@ function normalizePlayerAccountSnapshot(account: {
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
   loginId?: string | null | undefined;
+  ageVerified?: boolean | number | null | undefined;
+  isMinor?: boolean | number | null | undefined;
+  dailyPlayMinutes?: number | null | undefined;
+  lastPlayDate?: string | Date | null | undefined;
   banStatus?: PlayerBanStatus | null | undefined;
   banExpiry?: string | undefined;
   banReason?: string | null | undefined;
@@ -600,6 +658,10 @@ function normalizePlayerAccountSnapshot(account: {
       lastSeenAt: account.lastSeenAt,
       loginId: account.loginId ? normalizePlayerLoginId(account.loginId) : undefined,
       credentialBoundAt: account.credentialBoundAt,
+      ageVerified: normalizePlayerAgeVerified(account.ageVerified),
+      isMinor: normalizePlayerIsMinor(account.isMinor),
+      dailyPlayMinutes: normalizeDailyPlayMinutes(account.dailyPlayMinutes),
+      lastPlayDate: normalizeLastPlayDate(account.lastPlayDate),
       banStatus: normalizePlayerBanStatus(account.banStatus),
       banExpiry: normalizePlayerBanExpiry(account.banExpiry),
       banReason: normalizePlayerBanReason(account.banReason)
@@ -881,6 +943,10 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   last_room_id VARCHAR(191) NULL,
   last_seen_at DATETIME NULL DEFAULT NULL,
   login_id VARCHAR(40) NULL,
+  age_verified TINYINT(1) NOT NULL DEFAULT 0,
+  is_minor TINYINT(1) NOT NULL DEFAULT 0,
+  daily_play_minutes INT NOT NULL DEFAULT 0,
+  last_play_date DATE NULL DEFAULT NULL,
   ban_status VARCHAR(16) NOT NULL DEFAULT 'none',
   ban_expiry DATETIME NULL DEFAULT NULL,
   ban_reason VARCHAR(512) NULL,
@@ -1114,6 +1180,78 @@ SET @veil_player_accounts_login_id_sql := IF(
 PREPARE veil_player_accounts_login_id_stmt FROM @veil_player_accounts_login_id_sql;
 EXECUTE veil_player_accounts_login_id_stmt;
 DEALLOCATE PREPARE veil_player_accounts_login_id_stmt;
+
+SET @veil_player_accounts_age_verified_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'age_verified'
+);
+
+SET @veil_player_accounts_age_verified_sql := IF(
+  @veil_player_accounts_age_verified_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`age_verified\` TINYINT(1) NOT NULL DEFAULT 0 AFTER \`login_id\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_age_verified_stmt FROM @veil_player_accounts_age_verified_sql;
+EXECUTE veil_player_accounts_age_verified_stmt;
+DEALLOCATE PREPARE veil_player_accounts_age_verified_stmt;
+
+SET @veil_player_accounts_is_minor_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'is_minor'
+);
+
+SET @veil_player_accounts_is_minor_sql := IF(
+  @veil_player_accounts_is_minor_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`is_minor\` TINYINT(1) NOT NULL DEFAULT 0 AFTER \`age_verified\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_is_minor_stmt FROM @veil_player_accounts_is_minor_sql;
+EXECUTE veil_player_accounts_is_minor_stmt;
+DEALLOCATE PREPARE veil_player_accounts_is_minor_stmt;
+
+SET @veil_player_accounts_daily_play_minutes_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'daily_play_minutes'
+);
+
+SET @veil_player_accounts_daily_play_minutes_sql := IF(
+  @veil_player_accounts_daily_play_minutes_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`daily_play_minutes\` INT NOT NULL DEFAULT 0 AFTER \`is_minor\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_daily_play_minutes_stmt FROM @veil_player_accounts_daily_play_minutes_sql;
+EXECUTE veil_player_accounts_daily_play_minutes_stmt;
+DEALLOCATE PREPARE veil_player_accounts_daily_play_minutes_stmt;
+
+SET @veil_player_accounts_last_play_date_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'last_play_date'
+);
+
+SET @veil_player_accounts_last_play_date_sql := IF(
+  @veil_player_accounts_last_play_date_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`last_play_date\` DATE NULL DEFAULT NULL AFTER \`daily_play_minutes\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_last_play_date_stmt FROM @veil_player_accounts_last_play_date_sql;
+EXECUTE veil_player_accounts_last_play_date_stmt;
+DEALLOCATE PREPARE veil_player_accounts_last_play_date_stmt;
 
 SET @veil_player_accounts_ban_status_exists := (
   SELECT COUNT(*)
@@ -1605,6 +1743,14 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(row.display_name ? { displayName: row.display_name } : {}),
     ...(row.last_room_id ? { lastRoomId: row.last_room_id } : {}),
     ...(row.login_id ? { loginId: row.login_id } : {}),
+    ...(normalizePlayerAgeVerified(row.age_verified) !== undefined
+      ? { ageVerified: normalizePlayerAgeVerified(row.age_verified) }
+      : {}),
+    ...(normalizePlayerIsMinor(row.is_minor) !== undefined ? { isMinor: normalizePlayerIsMinor(row.is_minor) } : {}),
+    ...(normalizeDailyPlayMinutes(row.daily_play_minutes) > 0
+      ? { dailyPlayMinutes: normalizeDailyPlayMinutes(row.daily_play_minutes) }
+      : {}),
+    ...(normalizeLastPlayDate(row.last_play_date) ? { lastPlayDate: normalizeLastPlayDate(row.last_play_date) } : {}),
     banStatus: normalizePlayerBanStatus(row.ban_status),
     ...(banExpiry ? { banExpiry } : {}),
     ...(row.ban_reason ? { banReason: row.ban_reason } : {}),
@@ -1995,6 +2141,10 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         age_verified,
+         is_minor,
+         daily_play_minutes,
+         last_play_date,
          ban_status,
          ban_expiry,
          ban_reason,
@@ -2035,6 +2185,10 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         age_verified,
+         is_minor,
+         daily_play_minutes,
+         last_play_date,
          ban_status,
          ban_expiry,
          ban_reason,
@@ -2159,6 +2313,10 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         age_verified,
+         is_minor,
+         daily_play_minutes,
+         last_play_date,
          ban_status,
          ban_expiry,
          ban_reason,
@@ -2627,6 +2785,9 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       ? normalizePlayerDisplayName(normalizedPlayerId, input.displayName)
       : null;
     const boundAt = existingAccount.wechatMiniGameBoundAt ?? new Date().toISOString();
+    const ageVerified =
+      input.ageVerified !== undefined ? normalizePlayerAgeVerified(input.ageVerified) : existingAccount.ageVerified;
+    const isMinor = input.isMinor !== undefined ? normalizePlayerIsMinor(input.isMinor) : existingAccount.isMinor;
 
     try {
       await this.pool.query(
@@ -2638,6 +2799,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
              wechat_mini_game_open_id = ?,
              wechat_mini_game_union_id = COALESCE(?, wechat_mini_game_union_id),
              wechat_mini_game_bound_at = COALESCE(wechat_mini_game_bound_at, ?),
+             age_verified = COALESCE(?, age_verified),
+             is_minor = COALESCE(?, is_minor),
              version = version + 1
          WHERE player_id = ?`,
         [
@@ -2648,6 +2811,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
           normalizedOpenId,
           normalizedUnionId ?? null,
           new Date(boundAt),
+          ageVerified != null ? (ageVerified ? 1 : 0) : null,
+          isMinor != null ? (isMinor ? 1 : 0) : null,
           normalizedPlayerId
         ]
       );
@@ -2667,6 +2832,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         ...(normalizedAvatarUrl ? { avatarUrl: normalizedAvatarUrl } : {}),
         wechatMiniGameOpenId: normalizedOpenId,
         ...(normalizedUnionId ? { wechatMiniGameUnionId: normalizedUnionId } : {}),
+        ...(ageVerified !== undefined ? { ageVerified } : {}),
+        ...(isMinor !== undefined ? { isMinor } : {}),
         wechatMiniGameBoundAt: boundAt
       })
     );
@@ -2769,6 +2936,10 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       achievements: patch.achievements ?? existing.achievements,
       recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
       recentBattleReplays: patch.recentBattleReplays ?? existing.recentBattleReplays,
+      dailyPlayMinutes:
+        patch.dailyPlayMinutes !== undefined ? normalizeDailyPlayMinutes(patch.dailyPlayMinutes) : existing.dailyPlayMinutes,
+      lastPlayDate:
+        patch.lastPlayDate !== undefined ? normalizeLastPlayDate(patch.lastPlayDate) : existing.lastPlayDate,
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId
           ? { lastRoomId: patch.lastRoomId.trim() }
@@ -2790,9 +2961,13 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          last_room_id,
-         last_seen_at
+         last_seen_at,
+         age_verified,
+         is_minor,
+         daily_play_minutes,
+         last_play_date
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = COALESCE(avatar_url, VALUES(avatar_url)),
@@ -2803,6 +2978,10 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_battle_replays_json = VALUES(recent_battle_replays_json),
          last_room_id = VALUES(last_room_id),
          last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
+         age_verified = VALUES(age_verified),
+         is_minor = VALUES(is_minor),
+         daily_play_minutes = VALUES(daily_play_minutes),
+         last_play_date = VALUES(last_play_date),
          version = version + 1`,
       [
         nextAccount.playerId,
@@ -2814,7 +2993,11 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.recentEventLog),
         JSON.stringify(nextAccount.recentBattleReplays),
         nextAccount.lastRoomId ?? null,
-        existing.lastSeenAt ? new Date(existing.lastSeenAt) : null
+        existing.lastSeenAt ? new Date(existing.lastSeenAt) : null,
+        nextAccount.ageVerified === true ? 1 : 0,
+        nextAccount.isMinor === true ? 1 : 0,
+        normalizeDailyPlayMinutes(nextAccount.dailyPlayMinutes),
+        nextAccount.lastPlayDate ? new Date(nextAccount.lastPlayDate) : null
       ]
     );
     await appendPlayerEventHistoryEntries(this.pool, normalizedPlayerId, newHistoryEntries);
@@ -2852,6 +3035,10 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at,
          login_id,
+         age_verified,
+         is_minor,
+         daily_play_minutes,
+         last_play_date,
          ban_status,
          ban_expiry,
          ban_reason,

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -149,6 +149,10 @@ class MemoryAuthStore implements RoomSnapshotStore {
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
+      ...(existing?.ageVerified ? { ageVerified: existing.ageVerified } : {}),
+      ...(existing?.isMinor ? { isMinor: existing.isMinor } : {}),
+      ...(existing?.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
+      ...(existing?.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
       ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
       ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
       ...(existing?.banReason ? { banReason: existing.banReason } : {}),
@@ -312,7 +316,7 @@ class MemoryAuthStore implements RoomSnapshotStore {
 
   async bindPlayerAccountWechatMiniGameIdentity(
     playerId: string,
-    input: { openId: string; unionId?: string; displayName?: string; avatarUrl?: string | null }
+    input: { openId: string; unionId?: string; displayName?: string; avatarUrl?: string | null; ageVerified?: boolean; isMinor?: boolean }
   ): Promise<PlayerAccountSnapshot> {
     const existing = await this.ensurePlayerAccount({
       playerId,
@@ -330,6 +334,8 @@ class MemoryAuthStore implements RoomSnapshotStore {
       ...(input.avatarUrl?.trim() ? { avatarUrl: input.avatarUrl.trim() } : existing.avatarUrl ? { avatarUrl: existing.avatarUrl } : {}),
       wechatMiniGameOpenId: normalizedOpenId,
       ...(input.unionId?.trim() ? { wechatMiniGameUnionId: input.unionId.trim() } : existing.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
+      ...(input.ageVerified !== undefined ? { ageVerified: input.ageVerified } : existing.ageVerified ? { ageVerified: existing.ageVerified } : {}),
+      ...(input.isMinor !== undefined ? { isMinor: input.isMinor } : existing.isMinor ? { isMinor: existing.isMinor } : {}),
       wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -381,6 +387,8 @@ class MemoryAuthStore implements RoomSnapshotStore {
       ),
       achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
       recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      ...(patch.dailyPlayMinutes !== undefined ? { dailyPlayMinutes: Math.max(0, Math.floor(patch.dailyPlayMinutes ?? 0)) } : existing.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
+      ...(patch.lastPlayDate !== undefined ? (patch.lastPlayDate ? { lastPlayDate: patch.lastPlayDate.trim() } : {}) : existing.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId?.trim()
           ? { lastRoomId: patch.lastRoomId.trim() }
@@ -2754,6 +2762,59 @@ test("wechat mini game production exchange binds code2Session identity onto an a
   assert.equal(storedAccount?.wechatMiniGameOpenId, "wx-openid-prod");
   assert.equal(storedAccount?.wechatMiniGameUnionId, "wx-union-prod");
   assert.equal(storedAccount?.loginId, "veil-ranger");
+});
+
+test("wechat mini game login stores verified minor status when age data is provided", { concurrency: false }, async (t) => {
+  const port = 44980 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+  const originalFetch = globalThis.fetch;
+
+  t.after(async () => {
+    globalThis.fetch = originalFetch;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
+    delete process.env.WECHAT_APP_ID;
+    delete process.env.WECHAT_APP_SECRET;
+    delete process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL;
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "production";
+  process.env.WECHAT_APP_ID = "wx-prod-app";
+  process.env.WECHAT_APP_SECRET = "wx-prod-secret";
+  process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL = "https://wechat.example.test/code2session";
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        openid: "wx-openid-minor",
+        session_key: "session-key"
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+  const response = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      code: "wx-prod-code",
+      playerId: "wechat-minor",
+      displayName: "夜巡学员",
+      isAdult: false
+    })
+  });
+
+  assert.equal(response.status, 200);
+  const storedAccount = await store.loadPlayerAccount("wechat-minor");
+  assert.equal(storedAccount?.ageVerified, true);
+  assert.equal(storedAccount?.isMinor, true);
 });
 
 test("wechat mini game login reuses the bound player even when later requests spoof another playerId", { concurrency: false }, async (t) => {

--- a/apps/server/test/colyseus-room-ban-enforcement.test.ts
+++ b/apps/server/test/colyseus-room-ban-enforcement.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 import { ClientState, matchMaker } from "colyseus";
 import type { Client } from "colyseus";
 import type { ServerMessage } from "../../../packages/shared/src/index";
@@ -102,6 +102,35 @@ async function emitRoomMessage(room: VeilColyseusRoom, type: string, client: Fak
   await flushAsyncWork();
 }
 
+function mockSystemTime(t: TestContext, isoTimestamp: string): { advance(ms: number): void } {
+  const RealDate = Date;
+  let currentTime = new RealDate(isoTimestamp).getTime();
+
+  class MockDate extends RealDate {
+    constructor(value?: string | number | Date) {
+      super(value ?? currentTime);
+    }
+
+    static override now(): number {
+      return currentTime;
+    }
+  }
+
+  Object.setPrototypeOf(MockDate, RealDate);
+  // @ts-expect-error test-only date override
+  globalThis.Date = MockDate;
+  t.after(() => {
+    // @ts-expect-error test-only date override
+    globalThis.Date = RealDate;
+  });
+
+  return {
+    advance(ms: number) {
+      currentTime += ms;
+    }
+  };
+}
+
 test("room connect re-checks persisted ban state and rejects banned players", async (t) => {
   resetLobbyRoomRegistry();
   const store = new MemoryRoomSnapshotStore();
@@ -131,4 +160,94 @@ test("room connect re-checks persisted ban state and rejects banned players", as
 
   assert.equal(client.sent.some((message) => message.type === "error" && message.reason === "account_banned"), true);
   assert.equal(client.sent.some((message) => message.type === "session.state"), false);
+});
+
+test("room connect rejects minors during restricted hours", async (t) => {
+  mockSystemTime(t, "2026-04-03T14:30:00.000Z");
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  await store.bindPlayerAccountWechatMiniGameIdentity("minor-player", {
+    openId: "wx-minor-hours",
+    ageVerified: true,
+    isMinor: true
+  });
+  const room = await createTestRoom(`minor-hours-${Date.now()}`);
+  const client = createFakeClient("minor-hours-session");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  room.clients.push(client);
+  room.onJoin(client, { playerId: "minor-player" });
+  await emitRoomMessage(room, "connect", client, {
+    type: "connect",
+    requestId: "connect-minor-hours",
+    roomId: room.roomId,
+    playerId: "minor-player"
+  });
+
+  assert.equal(client.sent.some((message) => message.type === "error" && message.reason === "minor_restricted_hours"), true);
+  assert.equal(client.sent.some((message) => message.type === "session.state"), false);
+});
+
+test("room timer kicks minors after reaching the daily playtime limit and blocks rejoin", async (t) => {
+  const clock = mockSystemTime(t, "2026-04-03T01:00:00.000Z");
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  await store.bindPlayerAccountWechatMiniGameIdentity("minor-limit", {
+    openId: "wx-minor-limit",
+    ageVerified: true,
+    isMinor: true
+  });
+  await store.savePlayerAccountProgress("minor-limit", {
+    dailyPlayMinutes: 89,
+    lastPlayDate: "2026-04-03"
+  });
+  const room = await createTestRoom(`minor-limit-${Date.now()}`);
+  const client = createFakeClient("minor-limit-session");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  room.clients.push(client);
+  room.onJoin(client, { playerId: "minor-limit" });
+  await emitRoomMessage(room, "connect", client, {
+    type: "connect",
+    requestId: "connect-minor-limit",
+    roomId: room.roomId,
+    playerId: "minor-limit"
+  });
+
+  assert.equal(client.sent.some((message) => message.type === "session.state"), true);
+
+  clock.advance(60_000);
+  room.clock.tick();
+  await flushAsyncWork();
+
+  assert.equal(client.sent.some((message) => message.type === "error" && message.reason === "minor_daily_limit_reached"), true);
+  assert.equal((await store.loadPlayerAccount("minor-limit"))?.dailyPlayMinutes, 90);
+
+  const secondClient = createFakeClient("minor-limit-session-2");
+  room.clients.push(secondClient);
+  room.onJoin(secondClient, { playerId: "minor-limit" });
+  await emitRoomMessage(room, "connect", secondClient, {
+    type: "connect",
+    requestId: "connect-minor-limit-retry",
+    roomId: room.roomId,
+    playerId: "minor-limit"
+  });
+
+  assert.equal(
+    secondClient.sent.some((message) => message.type === "error" && message.reason === "minor_daily_limit_reached"),
+    true
+  );
+  assert.equal(secondClient.sent.some((message) => message.type === "session.state"), false);
 });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -150,6 +150,10 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
+      ...(existing?.ageVerified ? { ageVerified: existing.ageVerified } : {}),
+      ...(existing?.isMinor ? { isMinor: existing.isMinor } : {}),
+      ...(existing?.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
+      ...(existing?.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
       ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
       ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
       ...(existing?.banReason ? { banReason: existing.banReason } : {}),
@@ -312,7 +316,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async bindPlayerAccountWechatMiniGameIdentity(
     playerId: string,
-    input: { openId: string; unionId?: string; displayName?: string; avatarUrl?: string | null }
+    input: { openId: string; unionId?: string; displayName?: string; avatarUrl?: string | null; ageVerified?: boolean; isMinor?: boolean }
   ): Promise<PlayerAccountSnapshot> {
     const existing = await this.ensurePlayerAccount({
       playerId,
@@ -336,6 +340,8 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
           : {}),
       wechatMiniGameOpenId: normalizedOpenId,
       ...(input.unionId?.trim() ? { wechatMiniGameUnionId: input.unionId.trim() } : existing.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
+      ...(input.ageVerified !== undefined ? { ageVerified: input.ageVerified } : existing.ageVerified ? { ageVerified: existing.ageVerified } : {}),
+      ...(input.isMinor !== undefined ? { isMinor: input.isMinor } : existing.isMinor ? { isMinor: existing.isMinor } : {}),
       wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -390,6 +396,8 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       recentBattleReplays: structuredClone(
         (patch.recentBattleReplays as PlayerAccountSnapshot["recentBattleReplays"] | undefined) ?? existing.recentBattleReplays
       ),
+      ...(patch.dailyPlayMinutes !== undefined ? { dailyPlayMinutes: Math.max(0, Math.floor(patch.dailyPlayMinutes ?? 0)) } : existing.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
+      ...(patch.lastPlayDate !== undefined ? (patch.lastPlayDate ? { lastPlayDate: patch.lastPlayDate.trim() } : {}) : existing.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId?.trim()
           ? { lastRoomId: patch.lastRoomId.trim() }

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -27,6 +27,10 @@ export interface PlayerAccountReadModel {
   battleReportCenter?: PlayerBattleReportCenter;
   loginId?: string;
   credentialBoundAt?: string;
+  ageVerified?: boolean;
+  isMinor?: boolean;
+  dailyPlayMinutes?: number;
+  lastPlayDate?: string;
   banStatus?: PlayerBanStatus;
   banExpiry?: string;
   banReason?: string;
@@ -46,6 +50,10 @@ export interface PlayerAccountReadModelInput {
   battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
+  ageVerified?: boolean | undefined;
+  isMinor?: boolean | undefined;
+  dailyPlayMinutes?: number | undefined;
+  lastPlayDate?: string | undefined;
   banStatus?: PlayerBanStatus | undefined;
   banExpiry?: string | undefined;
   banReason?: string | undefined;
@@ -61,6 +69,12 @@ export function normalizePlayerAccountReadModel(
   const avatarUrl = account?.avatarUrl?.trim();
   const loginId = account?.loginId?.trim().toLowerCase();
   const credentialBoundAt = account?.credentialBoundAt?.trim();
+  const ageVerified = account?.ageVerified === true;
+  const isMinor = account?.isMinor === true;
+  const dailyPlayMinutes = Math.max(0, Math.floor(account?.dailyPlayMinutes ?? 0));
+  const lastPlayDate = /^\d{4}-\d{2}-\d{2}$/.test(account?.lastPlayDate?.trim() ?? "")
+    ? account?.lastPlayDate?.trim()
+    : undefined;
   const banStatus = account?.banStatus === "temporary" || account?.banStatus === "permanent" ? account.banStatus : "none";
   const banExpiry = account?.banExpiry?.trim();
   const banReason = account?.banReason?.trim();
@@ -88,6 +102,10 @@ export function normalizePlayerAccountReadModel(
     }),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
+    ...(ageVerified ? { ageVerified } : {}),
+    ...(isMinor ? { isMinor } : {}),
+    ...(dailyPlayMinutes > 0 ? { dailyPlayMinutes } : {}),
+    ...(lastPlayDate ? { lastPlayDate } : {}),
     ...(banStatus !== "none" ? { banStatus } : {}),
     ...(banExpiry ? { banExpiry } : {}),
     ...(banReason ? { banReason } : {}),

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1330,6 +1330,22 @@ test("player account read model helper normalizes progression, replays, and reso
   assert.equal(account.battleReportCenter.items[0]?.result, "victory");
 });
 
+test("player account read model helper normalizes minor protection fields", () => {
+  const account = normalizePlayerAccountReadModel({
+    playerId: "player-minor",
+    displayName: "Minor",
+    ageVerified: true,
+    isMinor: true,
+    dailyPlayMinutes: 91.8,
+    lastPlayDate: " 2026-04-03 "
+  });
+
+  assert.equal(account.ageVerified, true);
+  assert.equal(account.isMinor, true);
+  assert.equal(account.dailyPlayMinutes, 91);
+  assert.equal(account.lastPlayDate, "2026-04-03");
+});
+
 test("player account read model helper falls back to empty progression collections", () => {
   const account = normalizePlayerAccountReadModel();
 


### PR DESCRIPTION
## Summary
- add minor-protection account fields and persist WeChat age verification state
- enforce minor join/play restrictions for 22:00-08:00 lockout and daily play limits with per-minute accounting
- add focused coverage for account normalization, WeChat auth persistence, and room enforcement

## Testing
- `npm run test:shared -- --test-name-pattern='player account read model helper'`
- `node --import tsx --test apps/server/test/auth-guest-login.test.ts --test-name-pattern='wechat mini game'`
- `node --import tsx --test apps/server/test/colyseus-room-ban-enforcement.test.ts`
- `node --import tsx --test apps/server/test/player-account-routes.test.ts`
- `node --import tsx --test apps/server/test/persistence-account-credentials.test.ts`
- `npm run typecheck:server`

Closes #779