### PR TITLE
Implement privacy consent flow and compliant account deletion

### DIFF
--- a/apps/client/src/auth-session.ts
+++ b/apps/client/src/auth-session.ts
@@ -40,6 +40,15 @@ interface AccountAuthApiPayload extends AuthSessionApiPayload {
   };
 }
 
+interface AccountDeletionApiPayload {
+  ok?: boolean;
+  deleted?: {
+    playerId?: string;
+    displayName?: string;
+    deletedAt?: string;
+  };
+}
+
 export interface AccountRegistrationRequestResult {
   status: string;
   expiresAt?: string;
@@ -124,8 +133,14 @@ async function fetchJson(url: string, init?: RequestInit): Promise<unknown> {
     });
 
     if (!response.ok) {
-      // ... 保持原有逻辑
-      throw new Error(`auth_request_failed:${response.status}`);
+      let errorCode = "unknown";
+      try {
+        const payload = (await response.clone().json()) as { error?: { code?: string } };
+        errorCode = payload.error?.code?.trim() || "unknown";
+      } catch {
+        errorCode = "unknown";
+      }
+      throw new Error(`auth_request_failed:${response.status}:${errorCode}`);
     }
 
     (window as any).updateDebugStatus?.("Auth Success", "#0f0");
@@ -314,7 +329,13 @@ export async function logoutCurrentAuthSession(): Promise<void> {
   clearCurrentAuthSession();
 }
 
-export async function loginGuestAuthSession(playerId: string, displayName: string): Promise<StoredAuthSession> {
+export async function loginGuestAuthSession(
+  playerId: string,
+  displayName: string,
+  options?: {
+    privacyConsentAccepted?: boolean;
+  }
+): Promise<StoredAuthSession> {
   const normalizedPlayerId = normalizePlayerId(playerId);
   const normalizedDisplayName = normalizeDisplayName(normalizedPlayerId, displayName);
 
@@ -327,7 +348,8 @@ export async function loginGuestAuthSession(playerId: string, displayName: strin
       },
       body: JSON.stringify({
         playerId: normalizedPlayerId,
-        displayName: normalizedDisplayName
+        displayName: normalizedDisplayName,
+        ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
       })
     })) as AuthSessionApiPayload;
     const session = asStoredAuthSession(payload.session, "remote", {
@@ -337,12 +359,21 @@ export async function loginGuestAuthSession(playerId: string, displayName: strin
     });
     return storeAuthSession(session);
   } catch (error) {
+    if (error instanceof Error && error.message.startsWith("auth_request_failed:")) {
+      throw error;
+    }
     console.error("[Auth] CRITICAL: Server connection failed. Local fallback DISABLED.", error);
     throw new Error("server_connection_failed");
   }
 }
 
-export async function loginPasswordAuthSession(loginId: string, password: string): Promise<StoredAuthSession> {
+export async function loginPasswordAuthSession(
+  loginId: string,
+  password: string,
+  options?: {
+    privacyConsentAccepted?: boolean;
+  }
+): Promise<StoredAuthSession> {
   const normalizedLoginId = normalizeLoginId(loginId);
   if (!normalizedLoginId) {
     throw new Error("loginId_required");
@@ -361,7 +392,8 @@ export async function loginPasswordAuthSession(loginId: string, password: string
     },
     body: JSON.stringify({
       loginId: normalizedLoginId,
-      password
+      password,
+      ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
     })
   })) as AuthSessionApiPayload;
 
@@ -404,7 +436,10 @@ export async function requestAccountRegistration(
 export async function confirmAccountRegistration(
   loginId: string,
   registrationToken: string,
-  password: string
+  password: string,
+  options?: {
+    privacyConsentAccepted?: boolean;
+  }
 ): Promise<StoredAuthSession> {
   const normalizedLoginId = normalizeLoginId(loginId);
   if (!normalizedLoginId) {
@@ -419,7 +454,8 @@ export async function confirmAccountRegistration(
     body: JSON.stringify({
       loginId: normalizedLoginId,
       registrationToken,
-      password
+      password,
+      ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
     })
   })) as AccountAuthApiPayload;
 
@@ -502,4 +538,24 @@ export async function syncCurrentAuthSession(): Promise<StoredAuthSession | null
 
     return currentSession;
   }
+}
+
+export async function deleteCurrentPlayerAccount(): Promise<AccountDeletionApiPayload["deleted"] | null> {
+  const currentSession = readStoredAuthSession();
+  if (!currentSession?.token) {
+    throw new Error("auth_session_required");
+  }
+
+  const payload = (await fetchAuthJson(
+    `${resolveAuthApiBaseUrl()}/api/players/me/delete`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      }
+    },
+    currentSession
+  )) as AccountDeletionApiPayload;
+  clearCurrentAuthSession();
+  return payload.deleted ?? null;
 }

--- a/apps/client/src/local-session.ts
+++ b/apps/client/src/local-session.ts
@@ -31,7 +31,7 @@ export interface SessionUpdate {
 
 export type ConnectionEvent = "reconnecting" | "reconnected" | "reconnect_failed";
 
-interface GameSession {
+export interface GameSession {
   snapshot(reason?: string): Promise<SessionUpdate>;
   moveHero(heroId: string, destination: Vec2): Promise<SessionUpdate>;
   collect(heroId: string, position: Vec2): Promise<SessionUpdate>;

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -34,7 +34,8 @@ import {
   type RuntimeDiagnosticsTriageSection,
   validateAccountLifecycleConfirm,
   validateAccountLifecycleRequest,
-  validateAccountPassword
+  validateAccountPassword,
+  validatePrivacyConsentAccepted
 } from "../../../packages/shared/src/index";
 import { createGameSession, readStoredSessionReplay, type SessionUpdate } from "./local-session";
 import { buildH5RuntimeDiagnosticsSnapshot } from "./runtime-diagnostics";
@@ -53,6 +54,7 @@ import { launchMainH5App } from "./main-bootstrap-launch";
 import {
   confirmAccountRegistration,
   confirmPasswordRecovery,
+  deleteCurrentPlayerAccount,
   loginGuestAuthSession,
   loginPasswordAuthSession,
   logoutCurrentAuthSession,
@@ -194,6 +196,7 @@ interface LobbyViewState {
   registrationPassword: string;
   recoveryToken: string;
   recoveryPassword: string;
+  privacyConsentAccepted: boolean;
   authSession: StoredAuthSession | null;
   rooms: LobbyRoomSummary[];
   loading: boolean;
@@ -317,6 +320,7 @@ const state: AppState = {
     registrationPassword: "",
     recoveryToken: "",
     recoveryPassword: "",
+    privacyConsentAccepted: false,
     authSession: storedAuthSession,
     rooms: [],
     loading: false,
@@ -3564,7 +3568,22 @@ function describeAccountFlowError(
   return error instanceof Error ? error.message : fallback;
 }
 
+function validateLobbyPrivacyConsent(): boolean {
+  const privacyConsentError = validatePrivacyConsentAccepted(state.lobby.privacyConsentAccepted);
+  if (!privacyConsentError) {
+    return true;
+  }
+
+  state.lobby.status = privacyConsentError.message;
+  render();
+  return false;
+}
+
 async function enterLobbyRoom(roomIdOverride?: string): Promise<void> {
+  if (!validateLobbyPrivacyConsent()) {
+    return;
+  }
+
   const preferences = saveLobbyPreferences(state.lobby.playerId, roomIdOverride ?? state.lobby.roomId);
   const displayName = rememberPreferredPlayerDisplayName(preferences.playerId, state.lobby.displayName);
   state.lobby.playerId = preferences.playerId;
@@ -3574,7 +3593,9 @@ async function enterLobbyRoom(roomIdOverride?: string): Promise<void> {
   state.lobby.status = `正在登录游客账号并进入房间 ${preferences.roomId}...`;
   render();
 
-  const authSession = await loginGuestAuthSession(preferences.playerId, displayName);
+  const authSession = await loginGuestAuthSession(preferences.playerId, displayName, {
+    privacyConsentAccepted: state.lobby.privacyConsentAccepted
+  });
   state.lobby.authSession = authSession;
   state.lobby.playerId = authSession.playerId;
   state.lobby.displayName = authSession.displayName;
@@ -3607,12 +3628,18 @@ async function loginLobbyAccount(roomIdOverride?: string): Promise<void> {
     return;
   }
 
+  if (!validateLobbyPrivacyConsent()) {
+    return;
+  }
+
   state.lobby.entering = true;
   state.lobby.status = `正在使用账号 ${loginId} 登录并进入房间 ${preferences.roomId}...`;
   render();
 
   try {
-    const authSession = await loginPasswordAuthSession(loginId, state.lobby.password);
+    const authSession = await loginPasswordAuthSession(loginId, state.lobby.password, {
+      privacyConsentAccepted: state.lobby.privacyConsentAccepted
+    });
     state.lobby.authSession = authSession;
     state.lobby.playerId = authSession.playerId;
     state.lobby.displayName = authSession.displayName;
@@ -3668,11 +3695,16 @@ async function confirmLobbyAccountRegistration(roomIdOverride?: string): Promise
   const validationError = validateAccountLifecycleConfirm("registration", {
     loginId,
     token: state.lobby.registrationToken,
-    password: state.lobby.registrationPassword
+    password: state.lobby.registrationPassword,
+    privacyConsentAccepted: state.lobby.privacyConsentAccepted
   });
   if (validationError) {
     state.lobby.status = validationError.message;
     render();
+    return;
+  }
+
+  if (!validateLobbyPrivacyConsent()) {
     return;
   }
 
@@ -3681,7 +3713,14 @@ async function confirmLobbyAccountRegistration(roomIdOverride?: string): Promise
   render();
 
   try {
-    const authSession = await confirmAccountRegistration(loginId, state.lobby.registrationToken, state.lobby.registrationPassword);
+    const authSession = await confirmAccountRegistration(
+      loginId,
+      state.lobby.registrationToken,
+      state.lobby.registrationPassword,
+      {
+        privacyConsentAccepted: state.lobby.privacyConsentAccepted
+      }
+    );
     state.lobby.authSession = authSession;
     state.lobby.playerId = authSession.playerId;
     state.lobby.displayName = authSession.displayName;
@@ -3741,7 +3780,8 @@ async function confirmLobbyPasswordRecovery(roomIdOverride?: string): Promise<vo
   const validationError = validateAccountLifecycleConfirm("recovery", {
     loginId,
     token: state.lobby.recoveryToken,
-    password: state.lobby.recoveryPassword
+    password: state.lobby.recoveryPassword,
+    privacyConsentAccepted: state.lobby.privacyConsentAccepted
   });
   if (validationError) {
     state.lobby.status = validationError.message;
@@ -3755,7 +3795,9 @@ async function confirmLobbyPasswordRecovery(roomIdOverride?: string): Promise<vo
 
   try {
     await confirmPasswordRecovery(loginId, state.lobby.recoveryToken, state.lobby.recoveryPassword);
-    const authSession = await loginPasswordAuthSession(loginId, state.lobby.recoveryPassword);
+      const authSession = await loginPasswordAuthSession(loginId, state.lobby.recoveryPassword, {
+        privacyConsentAccepted: state.lobby.privacyConsentAccepted
+      });
     state.lobby.authSession = authSession;
     state.lobby.playerId = authSession.playerId;
     state.lobby.displayName = authSession.displayName;
@@ -4352,6 +4394,17 @@ function renderLobby(): string {
               </div>
             </section>
           </div>
+          <label class="lobby-field muted">
+            <span>
+              <input
+                data-privacy-consent="true"
+                type="checkbox"
+                ${state.lobby.privacyConsentAccepted ? "checked" : ""}
+                ${state.lobby.entering ? "disabled" : ""}
+              />
+              我已阅读并同意隐私说明；首次登录、注册或绑定时会记录同意时间。
+            </span>
+          </label>
           <div class="lobby-actions">
             <button class="account-save" data-refresh-lobby="true" ${state.lobby.loading || state.lobby.entering ? "disabled" : ""}>
               ${state.lobby.loading ? "刷新中..." : "刷新房间"}
@@ -4504,6 +4557,12 @@ function render(): void {
         }
 
         void enterLobbyRoom();
+      });
+    }
+
+    for (const privacyConsentInput of Array.from(root.querySelectorAll<HTMLInputElement>("[data-privacy-consent]"))) {
+      privacyConsentInput.addEventListener("input", () => {
+        state.lobby.privacyConsentAccepted = privacyConsentInput.checked;
       });
     }
 
@@ -4695,6 +4754,9 @@ function render(): void {
               ${state.accountSaving || state.accountBinding || state.account.source !== "remote" ? "disabled" : ""}
             >${state.accountBinding ? "提交中..." : state.account.loginId ? "更新口令" : "绑定账号"}</button>
           </div>
+          <button class="session-link" data-delete-account="true" ${state.accountSaving || state.accountBinding || state.account.source !== "remote" ? "disabled" : ""}>
+            删除当前账号
+          </button>
           ${renderAccountSessionPanel()}
           <p class="muted account-status">${escapeHtml(state.accountStatus)}</p>
         </div>
@@ -5015,6 +5077,12 @@ function render(): void {
     });
   }
 
+  for (const deleteAccountButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-delete-account]"))) {
+    deleteAccountButton.addEventListener("click", () => {
+      void onDeleteAccountProfile();
+    });
+  }
+
   for (const revokeSessionButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-revoke-account-session]"))) {
     revokeSessionButton.addEventListener("click", () => {
       const sessionId = revokeSessionButton.dataset.revokeAccountSession?.trim();
@@ -5117,12 +5185,23 @@ async function onBindAccountProfile(): Promise<void> {
     return;
   }
 
+  if (!state.account.privacyConsentAt) {
+    const privacyConsentError = validatePrivacyConsentAccepted(state.lobby.privacyConsentAccepted);
+    if (privacyConsentError) {
+      state.accountStatus = privacyConsentError.message;
+      render();
+      return;
+    }
+  }
+
   state.accountBinding = true;
   state.accountStatus = state.account.loginId ? "正在更新账号口令..." : "正在绑定口令账号...";
   render();
 
   try {
-    const account = await bindAccountCredentials(loginId, state.accountPassword, roomId);
+    const account = await bindAccountCredentials(loginId, state.accountPassword, roomId, {
+      privacyConsentAccepted: state.lobby.privacyConsentAccepted
+    });
     state.account = account;
     state.accountSessions = await loadPlayerAccountSessions();
     state.accountLoginId = account.loginId ?? loginId;
@@ -5144,6 +5223,31 @@ async function onBindAccountProfile(): Promise<void> {
         : error instanceof Error
           ? error.message
           : "account_bind_failed";
+    render();
+  }
+}
+
+async function onDeleteAccountProfile(): Promise<void> {
+  const confirmDelete = globalThis.confirm;
+  if (typeof confirmDelete === "function" && !confirmDelete("删除后将移除账号个人资料并立即撤销当前会话。是否继续？")) {
+    return;
+  }
+
+  state.accountBinding = true;
+  state.accountStatus = "正在删除当前账号并撤销会话...";
+  render();
+
+  try {
+    await deleteCurrentPlayerAccount();
+    state.accountBinding = false;
+    state.lobby.authSession = null;
+    state.lobby.privacyConsentAccepted = false;
+    state.accountStatus = "账号已删除。";
+    state.lobby.status = "账号已删除，原会话已撤销。请重新确认隐私说明后再创建新档。";
+    await returnToLobby();
+  } catch (error) {
+    state.accountBinding = false;
+    state.accountStatus = error instanceof Error ? error.message : "account_delete_failed";
     render();
   }
 }

--- a/apps/client/src/player-account.ts
+++ b/apps/client/src/player-account.ts
@@ -60,6 +60,7 @@ interface PlayerAccountApiPayload {
     recentBattleReplays?: Partial<PlayerBattleReplaySummary>[];
     loginId?: string;
     credentialBoundAt?: string;
+    privacyConsentAt?: string;
     lastRoomId?: string;
     lastSeenAt?: string;
   };
@@ -692,7 +693,10 @@ export async function savePlayerAccountDisplayName(
 export async function bindPlayerAccountCredentials(
   loginId: string,
   password: string,
-  roomId: string
+  roomId: string,
+  options?: {
+    privacyConsentAccepted?: boolean;
+  }
 ): Promise<PlayerAccountProfile> {
   const authSession = readStoredAuthSession();
   if (!authSession?.token) {
@@ -707,7 +711,8 @@ export async function bindPlayerAccountCredentials(
     },
     body: JSON.stringify({
       loginId: normalizeLoginId(loginId),
-      password
+      password,
+      ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
     })
   }, authSession)) as PlayerAccountApiPayload;
 

--- a/apps/client/test/auth-privacy-consent.test.ts
+++ b/apps/client/test/auth-privacy-consent.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  confirmAccountRegistration,
+  deleteCurrentPlayerAccount,
+  getAuthSessionStorageKey,
+  loginGuestAuthSession,
+  loginPasswordAuthSession
+} from "../src/auth-session";
+
+test("h5 auth helpers forward privacy consent and clear storage after deletion", async () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+  const values = new Map<string, string>([
+    [
+      getAuthSessionStorageKey(),
+      JSON.stringify({
+        playerId: "player-auth",
+        displayName: "访客骑士",
+        authMode: "account",
+        loginId: "veil-ranger",
+        token: "account.token",
+        source: "remote"
+      })
+    ]
+  ]);
+  const requests: Array<{ url: string; body: string }> = [];
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        protocol: "http:",
+        hostname: "127.0.0.1"
+      },
+      setTimeout,
+      clearTimeout,
+      localStorage: {
+        getItem(key: string): string | null {
+          return values.get(key) ?? null;
+        },
+        setItem(key: string, value: string): void {
+          values.set(key, value);
+        },
+        removeItem(key: string): void {
+          values.delete(key);
+        }
+      }
+    }
+  });
+
+  let callIndex = 0;
+  globalThis.fetch = (async (input, init) => {
+    requests.push({
+      url: String(input),
+      body: String(init?.body ?? "")
+    });
+    callIndex += 1;
+
+    if (callIndex === 1) {
+      return new Response(
+        JSON.stringify({
+          session: {
+            token: "guest.token",
+            playerId: "guest-privacy",
+            displayName: "隐私旅人",
+            authMode: "guest"
+          }
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    if (callIndex === 2) {
+      return new Response(
+        JSON.stringify({
+          session: {
+            token: "account.token.next",
+            playerId: "account-player",
+            displayName: "隐私旅人",
+            authMode: "account",
+            loginId: "veil-ranger"
+          }
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    if (callIndex === 3) {
+      return new Response(
+        JSON.stringify({
+          account: {
+            playerId: "account-player",
+            displayName: "隐私旅人",
+            loginId: "veil-ranger"
+          },
+          session: {
+            token: "account.token.confirmed",
+            playerId: "account-player",
+            displayName: "隐私旅人",
+            authMode: "account",
+            loginId: "veil-ranger"
+          }
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        deleted: {
+          playerId: "account-player",
+          displayName: "deleted-account-player"
+        }
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }) as typeof fetch;
+
+  try {
+    await loginGuestAuthSession("guest-privacy", "隐私旅人", {
+      privacyConsentAccepted: true
+    });
+    await loginPasswordAuthSession("Veil-Ranger", "hunter2", {
+      privacyConsentAccepted: true
+    });
+    await confirmAccountRegistration("Veil-Ranger", "dev-registration-token", "hunter2", {
+      privacyConsentAccepted: true
+    });
+    const deleted = await deleteCurrentPlayerAccount();
+
+    assert.match(requests[0]?.body ?? "", /"privacyConsentAccepted":true/);
+    assert.match(requests[1]?.body ?? "", /"privacyConsentAccepted":true/);
+    assert.match(requests[2]?.body ?? "", /"privacyConsentAccepted":true/);
+    assert.equal(deleted?.playerId, "account-player");
+    assert.equal(values.has(getAuthSessionStorageKey()), false);
+  } finally {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow
+    });
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -95,6 +95,7 @@ export interface VeilLobbyRenderState {
   roomId: string;
   authMode: "guest" | "account";
   loginId: string;
+  privacyConsentAccepted: boolean;
   loginHint: string;
   loginActionLabel: string;
   shareHint: string;
@@ -119,6 +120,7 @@ export interface VeilLobbyPanelOptions {
   onEditDisplayName?: () => void;
   onEditRoomId?: () => void;
   onEditLoginId?: () => void;
+  onTogglePrivacyConsent?: () => void;
   onRefresh?: () => void;
   onEnterRoom?: () => void;
   onLoginAccount?: () => void;
@@ -155,6 +157,7 @@ export class VeilLobbyPanel extends Component {
   private onEditDisplayName: (() => void) | undefined;
   private onEditRoomId: (() => void) | undefined;
   private onEditLoginId: (() => void) | undefined;
+  private onTogglePrivacyConsent: (() => void) | undefined;
   private onRefresh: (() => void) | undefined;
   private onEnterRoom: (() => void) | undefined;
   private onLoginAccount: (() => void) | undefined;
@@ -187,6 +190,7 @@ export class VeilLobbyPanel extends Component {
     this.onEditDisplayName = options.onEditDisplayName;
     this.onEditRoomId = options.onEditRoomId;
     this.onEditLoginId = options.onEditLoginId;
+    this.onTogglePrivacyConsent = options.onTogglePrivacyConsent;
     this.onRefresh = options.onRefresh;
     this.onEnterRoom = options.onEnterRoom;
     this.onLoginAccount = options.onLoginAccount;
@@ -306,6 +310,25 @@ export class VeilLobbyPanel extends Component {
         accent: new Color(216, 182, 118, 196)
       },
       state.entering ? null : this.onEditLoginId ?? null
+    );
+
+    leftCursorY = this.renderCard(
+      "LobbyPrivacyConsent",
+      leftX,
+      leftCursorY,
+      leftWidth,
+      58,
+      [
+        "隐私同意",
+        state.privacyConsentAccepted ? "已同意" : "未同意",
+        "首次登录、注册或绑定前需要先确认。点击可切换状态。"
+      ],
+      {
+        fill: FIELD_FILL,
+        stroke: new Color(224, 235, 246, 52),
+        accent: new Color(112, 194, 164, 196)
+      },
+      state.entering ? null : this.onTogglePrivacyConsent ?? null
     );
 
     const sessionLabel =

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -126,7 +126,8 @@ import {
   type RuntimeDiagnosticsConnectionStatus,
   validateAccountLifecycleConfirm,
   validateAccountLifecycleRequest,
-  validateAccountPassword
+  validateAccountPassword,
+  validatePrivacyConsentAccepted
 } from "../../../../packages/shared/src/index.ts";
 
 const { ccclass, property } = _decorator;
@@ -254,6 +255,7 @@ export class VeilRoot extends Component {
   private authMode: "guest" | "account" = "guest";
   private authProvider: CocosAuthProvider = "guest";
   private loginId = "";
+  private privacyConsentAccepted = false;
   private sessionSource: "remote" | "local" | "manual" | "none" = "none";
   private levelUpNotice: (HeroProgressNotice & { expiresAt: number }) | null = null;
   private achievementNotice: ({ title: string; detail: string; expiresAt: number } & { eventId: string }) | null = null;
@@ -760,6 +762,9 @@ export class VeilRoot extends Component {
       onEditLoginId: () => {
         this.promptForLobbyField("loginId");
       },
+      onTogglePrivacyConsent: () => {
+        this.togglePrivacyConsent();
+      },
       onRefresh: () => {
         void this.refreshLobbyRoomList();
       },
@@ -1032,6 +1037,7 @@ export class VeilRoot extends Component {
         roomId: this.roomId,
         authMode: this.authMode,
         loginId: this.loginId,
+        privacyConsentAccepted: this.privacyConsentAccepted,
         loginHint: this.describeLobbyLoginHint(),
         loginActionLabel: this.primaryLoginProvider().label,
         shareHint: this.describeLobbyShareHint(),
@@ -2078,6 +2084,10 @@ export class VeilRoot extends Component {
       return;
     }
 
+    if (!this.ensurePrivacyConsentAccepted()) {
+      return;
+    }
+
     const storage = this.readWebStorage();
     const preferences = saveCocosLobbyPreferences(this.playerId, roomIdOverride ?? this.roomId, undefined, storage);
     const displayName = rememberPreferredCocosDisplayName(preferences.playerId, this.displayName || preferences.playerId, storage);
@@ -2104,7 +2114,8 @@ export class VeilRoot extends Component {
         authSession = syncedSession;
       } else {
         authSession = await resolveVeilRootRuntime().loginGuestAuthSession(this.remoteUrl, preferences.playerId, displayName, {
-          storage
+          storage,
+          privacyConsentAccepted: this.privacyConsentAccepted
         });
       }
       this.authToken = authSession.token ?? null;
@@ -2211,6 +2222,10 @@ export class VeilRoot extends Component {
       return;
     }
 
+    if (!this.ensurePrivacyConsentAccepted()) {
+      return;
+    }
+
     const storage = this.readWebStorage();
     this.lobbyEntering = true;
     this.lobbyStatus = `正在使用账号 ${nextLoginId.toLowerCase()} 登录并进入房间 ${this.roomId}...`;
@@ -2224,7 +2239,10 @@ export class VeilRoot extends Component {
           loginId: nextLoginId,
           password
         },
-        { storage }
+        {
+          storage,
+          privacyConsentAccepted: this.privacyConsentAccepted
+        }
       );
       this.authToken = authSession.token ?? null;
       this.playerId = authSession.playerId;
@@ -2283,6 +2301,17 @@ export class VeilRoot extends Component {
     return error instanceof Error ? error.message : fallback;
   }
 
+  private ensurePrivacyConsentAccepted(): boolean {
+    const privacyConsentError = validatePrivacyConsentAccepted(this.privacyConsentAccepted);
+    if (!privacyConsentError) {
+      return true;
+    }
+
+    this.lobbyStatus = privacyConsentError.message;
+    this.renderView();
+    return false;
+  }
+
   private async registerLobbyAccount(): Promise<void> {
     this.openLobbyAccountFlow("registration");
   }
@@ -2292,6 +2321,10 @@ export class VeilRoot extends Component {
   }
 
   private async loginLobbyWechatMiniGame(): Promise<void> {
+    if (!this.ensurePrivacyConsentAccepted()) {
+      return;
+    }
+
     const storage = this.readWebStorage();
     this.lobbyEntering = true;
     this.lobbyStatus = "正在调用 wx.login() 并交换小游戏会话...";
@@ -2309,7 +2342,8 @@ export class VeilRoot extends Component {
           storage,
           wx: (globalThis as { wx?: { login?: ((options: unknown) => void) | undefined } }).wx ?? null,
           config: this.loginRuntimeConfig,
-          authToken: this.authToken
+          authToken: this.authToken,
+          privacyConsentAccepted: this.privacyConsentAccepted
         }
       );
       this.authToken = authSession.token ?? null;
@@ -2453,6 +2487,12 @@ export class VeilRoot extends Component {
     this.renderView();
   }
 
+  private togglePrivacyConsent(): void {
+    this.privacyConsentAccepted = !this.privacyConsentAccepted;
+    this.lobbyStatus = this.privacyConsentAccepted ? "已同意隐私说明。" : "已取消隐私说明勾选。";
+    this.renderView();
+  }
+
   private promptForAccountFlowField(field: "loginId" | "displayName" | "token" | "password"): void {
     const promptRef = globalThis.prompt;
     if (typeof promptRef !== "function" || !this.activeAccountFlow) {
@@ -2579,7 +2619,8 @@ export class VeilRoot extends Component {
     const validationError = validateAccountLifecycleConfirm(this.activeAccountFlow, {
       loginId,
       token: this.activeAccountFlow === "registration" ? this.registrationToken : this.recoveryToken,
-      password: this.activeAccountFlow === "registration" ? this.registrationPassword : this.recoveryPassword
+      password: this.activeAccountFlow === "registration" ? this.registrationPassword : this.recoveryPassword,
+      privacyConsentAccepted: this.privacyConsentAccepted
     });
     if (validationError) {
       this.lobbyStatus = validationError.message;
@@ -2607,7 +2648,10 @@ export class VeilRoot extends Component {
         loginId,
         this.registrationToken,
         this.registrationPassword,
-        { storage }
+        {
+          storage,
+          privacyConsentAccepted: this.privacyConsentAccepted
+        }
       );
       this.authToken = authSession.token ?? null;
       this.playerId = authSession.playerId;
@@ -2652,7 +2696,10 @@ export class VeilRoot extends Component {
           loginId,
           password: this.recoveryPassword
         },
-        { storage }
+        {
+          storage,
+          privacyConsentAccepted: this.privacyConsentAccepted
+        }
       );
       this.authToken = authSession.token ?? null;
       this.playerId = authSession.playerId;

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -105,7 +105,8 @@ interface PlayerBattleReplayListApiPayload {
   items?: Partial<PlayerBattleReplaySummary>[];
 }
 
-interface PlayerBattleReportCenterApiPayload extends Partial<PlayerBattleReportCenter> {
+interface PlayerBattleReportCenterApiPayload {
+  latestReportId?: string | null;
   items?: Partial<PlayerBattleReportSummary>[];
 }
 
@@ -469,7 +470,7 @@ async function loadCocosBattleReportCenter(
         ...(options ? { storage: options.storage ?? null } : {})
       }
     )) as PlayerBattleReportCenterApiPayload;
-    return normalizePlayerBattleReportCenter(payload, query ? { query } : undefined);
+    return normalizePlayerBattleReportCenter(payload as Partial<PlayerBattleReportCenter>, query ? { query } : undefined);
   } catch (error) {
     if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && options?.storage) {
       clearStoredCocosAuthSession(options.storage);
@@ -893,6 +894,7 @@ export async function loginCocosGuestAuthSession(
   options?: {
     fetchImpl?: FetchLike;
     storage?: Pick<Storage, "setItem"> | null;
+    privacyConsentAccepted?: boolean;
   }
 ): Promise<CocosStoredAuthSession> {
   const normalizedPlayerId = normalizePlayerId(playerId) || createCocosGuestPlayerId();
@@ -909,7 +911,8 @@ export async function loginCocosGuestAuthSession(
         },
         body: JSON.stringify({
           playerId: normalizedPlayerId,
-          displayName: normalizedDisplayName
+          displayName: normalizedDisplayName,
+          ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
         })
       },
       options?.fetchImpl
@@ -947,6 +950,7 @@ export async function loginCocosPasswordAuthSession(
   options?: {
     fetchImpl?: FetchLike;
     storage?: Pick<Storage, "setItem"> | null;
+    privacyConsentAccepted?: boolean;
   }
 ): Promise<CocosStoredAuthSession> {
   const normalizedLoginId = normalizeLoginId(loginId);
@@ -963,7 +967,8 @@ export async function loginCocosPasswordAuthSession(
       },
       body: JSON.stringify({
         loginId: normalizedLoginId,
-        password
+        password,
+        ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
       })
     },
     options?.fetchImpl
@@ -1026,6 +1031,7 @@ export async function confirmCocosAccountRegistration(
   options?: {
     fetchImpl?: FetchLike;
     storage?: Pick<Storage, "setItem"> | null;
+    privacyConsentAccepted?: boolean;
   }
 ): Promise<CocosStoredAuthSession> {
   const normalizedLoginId = normalizeLoginId(loginId);
@@ -1043,7 +1049,8 @@ export async function confirmCocosAccountRegistration(
       body: JSON.stringify({
         loginId: normalizedLoginId,
         registrationToken,
-        password
+        password,
+        ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
       })
     },
     options?.fetchImpl
@@ -1142,6 +1149,7 @@ export async function loginCocosWechatAuthSession(
     exchangePath?: string;
     mockCode?: string;
     authToken?: string | null;
+    privacyConsentAccepted?: boolean;
   }
 ): Promise<CocosStoredAuthSession> {
   const normalizedPlayerId = normalizePlayerId(playerId) || createCocosGuestPlayerId();
@@ -1175,7 +1183,8 @@ export async function loginCocosWechatAuthSession(
         code,
         playerId: normalizedPlayerId,
         displayName: profile.displayName,
-        ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : {})
+        ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : {}),
+        ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
       })
     },
     options?.fetchImpl

--- a/apps/cocos-client/assets/scripts/cocos-login-provider.ts
+++ b/apps/cocos-client/assets/scripts/cocos-login-provider.ts
@@ -79,6 +79,7 @@ export interface CocosLoginOptions {
   wx?: CocosWechatMiniGameLike | null;
   config?: CocosLoginRuntimeConfig;
   authToken?: string | null;
+  privacyConsentAccepted?: boolean;
 }
 
 function normalizeBoolean(value: unknown): boolean | null {
@@ -196,7 +197,8 @@ export async function loginWithCocosProvider(
           ? { exchangePath: options.config.wechatMiniGame.exchangePath }
           : {}),
         ...(options?.config?.wechatMiniGame.mockCode ? { mockCode: options.config.wechatMiniGame.mockCode } : {}),
-        ...(options?.authToken ? { authToken: options.authToken } : {})
+        ...(options?.authToken ? { authToken: options.authToken } : {}),
+        ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
       });
   }
 }

--- a/apps/cocos-client/assets/scripts/project-shared/player-account.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/player-account.ts
@@ -29,6 +29,7 @@ export interface PlayerAccountReadModel {
   battleReportCenter?: PlayerBattleReportCenter;
   loginId?: string;
   credentialBoundAt?: string;
+  privacyConsentAt?: string;
   lastRoomId?: string;
   lastSeenAt?: string;
 }
@@ -45,6 +46,7 @@ export interface PlayerAccountReadModelInput {
   battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
+  privacyConsentAt?: string | undefined;
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
 }
@@ -57,6 +59,7 @@ export function normalizePlayerAccountReadModel(
   const avatarUrl = account?.avatarUrl?.trim();
   const loginId = account?.loginId?.trim().toLowerCase();
   const credentialBoundAt = account?.credentialBoundAt?.trim();
+  const privacyConsentAt = account?.privacyConsentAt?.trim();
   const lastRoomId = account?.lastRoomId?.trim();
   const lastSeenAt = account?.lastSeenAt?.trim();
   const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
@@ -81,6 +84,7 @@ export function normalizePlayerAccountReadModel(
     }),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
+    ...(privacyConsentAt ? { privacyConsentAt } : {}),
     ...(lastRoomId ? { lastRoomId } : {}),
     ...(lastSeenAt ? { lastSeenAt } : {})
   };

--- a/apps/cocos-client/test/cocos-auth-privacy-consent.test.ts
+++ b/apps/cocos-client/test/cocos-auth-privacy-consent.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  confirmCocosAccountRegistration,
+  loginCocosGuestAuthSession,
+  loginCocosPasswordAuthSession,
+  loginCocosWechatAuthSession
+} from "../assets/scripts/cocos-lobby.ts";
+
+test("cocos auth helpers forward privacy consent across guest, account, registration, and wechat flows", async () => {
+  const requests: Array<{ url: string; body: string }> = [];
+  let callIndex = 0;
+
+  const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push({
+      url: String(input),
+      body: String(init?.body ?? "")
+    });
+    callIndex += 1;
+
+    if (callIndex === 4) {
+      return new Response(
+        JSON.stringify({
+          session: {
+            token: "wechat.token",
+            playerId: "wechat-player",
+            displayName: "雾桥旅人",
+            authMode: "guest",
+            provider: "wechat-mini-game"
+          }
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        account: {
+          playerId: "account-player",
+          displayName: "雾桥旅人",
+          loginId: "veil-ranger"
+        },
+        session: {
+          token: "account.token",
+          playerId: "account-player",
+          displayName: "雾桥旅人",
+          authMode: "account",
+          loginId: "veil-ranger"
+        }
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+  };
+
+  await loginCocosGuestAuthSession("http://127.0.0.1:2567", "guest-privacy", "雾桥旅人", {
+    fetchImpl,
+    privacyConsentAccepted: true
+  });
+  await loginCocosPasswordAuthSession("http://127.0.0.1:2567", "Veil-Ranger", "hunter2", {
+    fetchImpl,
+    privacyConsentAccepted: true
+  });
+  await confirmCocosAccountRegistration("http://127.0.0.1:2567", "Veil-Ranger", "dev-registration-token", "hunter2", {
+    fetchImpl,
+    privacyConsentAccepted: true
+  });
+  await loginCocosWechatAuthSession("http://127.0.0.1:2567", "wechat-player", "雾桥旅人", {
+    fetchImpl,
+    privacyConsentAccepted: true,
+    wx: {
+      login: ({ success }) => {
+        success?.({ code: "wx-dev-code" });
+      }
+    }
+  });
+
+  assert.equal(requests.length, 4);
+  assert.match(requests[0]?.body ?? "", /"privacyConsentAccepted":true/);
+  assert.match(requests[1]?.body ?? "", /"privacyConsentAccepted":true/);
+  assert.match(requests[2]?.body ?? "", /"privacyConsentAccepted":true/);
+  assert.match(requests[3]?.body ?? "", /"privacyConsentAccepted":true/);
+});

--- a/apps/cocos-client/test/helpers/cocos-panel-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-panel-harness.ts
@@ -265,6 +265,7 @@ export function createLobbyState(overrides: Partial<VeilLobbyRenderState> = {}):
     roomId: "",
     authMode: "guest",
     loginId: "",
+    privacyConsentAccepted: false,
     loginHint: "游客模式",
     loginActionLabel: "账号登录并进入",
     shareHint: "共享存档未启用",

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -29,7 +29,12 @@ import {
   upsertAuthAccountSession
 } from "./observability";
 import { deriveWechatMinorProtection } from "./minor-protection";
-import { isPlayerBanActive, type PlayerAccountBanSnapshot, type RoomSnapshotStore } from "./persistence";
+import {
+  isPlayerBanActive,
+  type PlayerAccountBanSnapshot,
+  type PlayerAccountSnapshot,
+  type RoomSnapshotStore
+} from "./persistence";
 
 export type AuthMode = "guest" | "account";
 export type AuthProvider = "guest" | "account-password" | "wechat-mini-game";
@@ -621,6 +626,33 @@ function normalizeAvatarUrl(avatarUrl?: string | null): string | undefined {
   return normalized ? normalized : undefined;
 }
 
+function sendPrivacyConsentRequired(response: ServerResponse): void {
+  sendJson(response, 403, {
+    error: {
+      code: "privacy_consent_required",
+      message: "Privacy consent must be accepted before continuing"
+    }
+  });
+}
+
+async function ensurePlayerPrivacyConsent(
+  response: ServerResponse,
+  store: RoomSnapshotStore | null,
+  account: PlayerAccountSnapshot,
+  privacyConsentAccepted?: boolean | null
+): Promise<PlayerAccountSnapshot | null> {
+  if (!store || account.privacyConsentAt) {
+    return account;
+  }
+
+  if (privacyConsentAccepted !== true) {
+    sendPrivacyConsentRequired(response);
+    return null;
+  }
+
+  return store.savePlayerAccountPrivacyConsent(account.playerId);
+}
+
 export function createWechatMiniGamePlayerId(openId: string): string {
   const normalizedOpenId = openId.trim();
   if (!normalizedOpenId) {
@@ -862,6 +894,7 @@ async function handleWechatLogin(
     playerId?: string | null;
     displayName?: string | null;
     avatarUrl?: string | null;
+    privacyConsentAccepted?: boolean | null;
     ageVerified?: boolean | null;
     isAdult?: boolean | null;
     ageRange?: string | null;
@@ -902,6 +935,16 @@ async function handleWechatLogin(
       error: {
         code: "invalid_payload",
         message: "Expected optional string field: avatarUrl"
+      }
+    });
+    return;
+  }
+
+  if (body.privacyConsentAccepted !== undefined && body.privacyConsentAccepted !== null && typeof body.privacyConsentAccepted !== "boolean") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional boolean field: privacyConsentAccepted"
       }
     });
     return;
@@ -1006,25 +1049,35 @@ async function handleWechatLogin(
     }
 
     if (boundAccount) {
-      const syncedAccount = await store.bindPlayerAccountWechatMiniGameIdentity(boundAccount.playerId, {
+      let syncedAccount = await store.bindPlayerAccountWechatMiniGameIdentity(boundAccount.playerId, {
         openId: identity.openId,
         ...(identity.unionId ? { unionId: identity.unionId } : {}),
         ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
         ...(avatarUrl ? { avatarUrl } : {}),
         ...minorProtection
       });
+      const consentedAccount = await ensurePlayerPrivacyConsent(response, store, syncedAccount, body.privacyConsentAccepted);
+      if (!consentedAccount) {
+        return;
+      }
+      syncedAccount = consentedAccount;
       playerId = syncedAccount.playerId;
       displayName = syncedAccount.displayName;
       loginId = syncedAccount.loginId;
     } else {
       const targetPlayerId = authSession?.playerId ?? playerId;
-      const boundAccountResult = await store.bindPlayerAccountWechatMiniGameIdentity(targetPlayerId, {
+      let boundAccountResult = await store.bindPlayerAccountWechatMiniGameIdentity(targetPlayerId, {
         openId: identity.openId,
         ...(identity.unionId ? { unionId: identity.unionId } : {}),
         ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
         ...(avatarUrl ? { avatarUrl } : {}),
         ...minorProtection
       });
+      const consentedAccount = await ensurePlayerPrivacyConsent(response, store, boundAccountResult, body.privacyConsentAccepted);
+      if (!consentedAccount) {
+        return;
+      }
+      boundAccountResult = consentedAccount;
       playerId = boundAccountResult.playerId;
       displayName = boundAccountResult.displayName;
       loginId = boundAccountResult.loginId;
@@ -1646,6 +1699,12 @@ function touchGuestSession(sessionId: string, token: string): GuestAuthSession |
   return nextSession;
 }
 
+export function revokeGuestAuthSession(sessionId: string): boolean {
+  const revoked = guestSessionsById.delete(sessionId);
+  syncAuthStateTelemetry();
+  return revoked;
+}
+
 export function resetGuestAuthSessions(): void {
   authRateLimitCounters.clear();
   accountLockoutStateByLoginId.clear();
@@ -1782,6 +1841,7 @@ export function registerAuthRoutes(
       const body = (await readJsonBody(request)) as {
         playerId?: string | null;
         displayName?: string | null;
+        privacyConsentAccepted?: boolean | null;
       };
 
       if (body.playerId !== undefined && body.playerId !== null && typeof body.playerId !== "string") {
@@ -1804,14 +1864,29 @@ export function registerAuthRoutes(
         return;
       }
 
+      if (body.privacyConsentAccepted !== undefined && body.privacyConsentAccepted !== null && typeof body.privacyConsentAccepted !== "boolean") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected optional boolean field: privacyConsentAccepted"
+          }
+        });
+        return;
+      }
+
       let playerId = normalizePlayerId(body.playerId);
       let displayName = normalizeDisplayName(playerId, body.displayName);
 
       if (store) {
-        const account = await store.ensurePlayerAccount({
+        let account = await store.ensurePlayerAccount({
           playerId,
           displayName
         });
+        const consentedAccount = await ensurePlayerPrivacyConsent(response, store, account, body.privacyConsentAccepted);
+        if (!consentedAccount) {
+          return;
+        }
+        account = consentedAccount;
         const activeBan = await resolveActiveBanForPlayer(store, account.playerId);
         if (activeBan) {
           sendAuthFailure(response, "account_banned", activeBan);
@@ -1857,6 +1932,7 @@ export function registerAuthRoutes(
       const body = (await readJsonBody(request)) as {
         loginId?: string | null;
         password?: string | null;
+        privacyConsentAccepted?: boolean | null;
       };
 
       if (body.loginId !== undefined && body.loginId !== null && typeof body.loginId !== "string") {
@@ -1874,6 +1950,16 @@ export function registerAuthRoutes(
           error: {
             code: "invalid_payload",
             message: "Expected string field: password"
+          }
+        });
+        return;
+      }
+
+      if (body.privacyConsentAccepted !== undefined && body.privacyConsentAccepted !== null && typeof body.privacyConsentAccepted !== "boolean") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected optional boolean field: privacyConsentAccepted"
           }
         });
         return;
@@ -1929,10 +2015,15 @@ export function registerAuthRoutes(
       }
 
       clearAccountLoginFailures(loginId);
-      const account = await store.ensurePlayerAccount({
+      let account = await store.ensurePlayerAccount({
         playerId: authAccount.playerId,
         displayName: authAccount.displayName
       });
+      const consentedAccount = await ensurePlayerPrivacyConsent(response, store, account, body.privacyConsentAccepted);
+      if (!consentedAccount) {
+        return;
+      }
+      account = consentedAccount;
       const activeBan = await resolveActiveBanForPlayer(store, account.playerId);
       if (activeBan) {
         sendAuthFailure(response, "account_banned", activeBan);
@@ -2050,6 +2141,7 @@ export function registerAuthRoutes(
         loginId?: string | null;
         registrationToken?: string | null;
         password?: string | null;
+        privacyConsentAccepted?: boolean | null;
       };
 
       if (body.loginId !== undefined && body.loginId !== null && typeof body.loginId !== "string") {
@@ -2082,9 +2174,23 @@ export function registerAuthRoutes(
         return;
       }
 
+      if (body.privacyConsentAccepted !== undefined && body.privacyConsentAccepted !== null && typeof body.privacyConsentAccepted !== "boolean") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected optional boolean field: privacyConsentAccepted"
+          }
+        });
+        return;
+      }
+
       const loginId = normalizeAccountLoginId(body.loginId);
       const registrationToken = normalizeAccountRegistrationToken(body.registrationToken);
       const password = normalizeAccountPassword(body.password);
+      if (body.privacyConsentAccepted !== true) {
+        sendPrivacyConsentRequired(response);
+        return;
+      }
       const pendingRegistrationState = getAccountRegistrationState(loginId);
       if (!pendingRegistrationState) {
         sendJson(response, 401, {
@@ -2348,6 +2454,7 @@ export function registerAuthRoutes(
       const body = (await readJsonBody(request)) as {
         loginId?: string | null;
         password?: string | null;
+        privacyConsentAccepted?: boolean | null;
       };
 
       if (body.loginId !== undefined && body.loginId !== null && typeof body.loginId !== "string") {
@@ -2370,8 +2477,26 @@ export function registerAuthRoutes(
         return;
       }
 
+      if (body.privacyConsentAccepted !== undefined && body.privacyConsentAccepted !== null && typeof body.privacyConsentAccepted !== "boolean") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected optional boolean field: privacyConsentAccepted"
+          }
+        });
+        return;
+      }
+
       const loginId = normalizeAccountLoginId(body.loginId);
       const password = normalizeAccountPassword(body.password);
+      const existingAccount = await store.ensurePlayerAccount({
+        playerId: authSession.playerId,
+        displayName: authSession.displayName
+      });
+      const consentedAccount = await ensurePlayerPrivacyConsent(response, store, existingAccount, body.privacyConsentAccepted);
+      if (!consentedAccount) {
+        return;
+      }
       const account = await store.bindPlayerAccountCredentials(authSession.playerId, {
         loginId,
         passwordHash: hashAccountPassword(password)

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -220,6 +220,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       ...(existing?.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
       ...(existing?.credentialBoundAt ? { credentialBoundAt: existing.credentialBoundAt } : {}),
+      ...(existing?.privacyConsentAt ? { privacyConsentAt: existing.privacyConsentAt } : {}),
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -329,6 +330,22 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       accountSessionVersion: existing.accountSessionVersion ?? 0,
       ...(nextAccount.credentialBoundAt ? { credentialBoundAt: nextAccount.credentialBoundAt } : {})
     });
+    return cloneAccount(nextAccount);
+  }
+
+  async savePlayerAccountPrivacyConsent(
+    playerId: string,
+    input: { privacyConsentAt?: string } = {}
+  ): Promise<PlayerAccountSnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existing = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const privacyConsentAt = existing.privacyConsentAt ?? new Date(input.privacyConsentAt ?? Date.now()).toISOString();
+    const nextAccount: PlayerAccountSnapshot = {
+      ...existing,
+      privacyConsentAt,
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     return cloneAccount(nextAccount);
   }
 
@@ -506,6 +523,60 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         });
       }
     }
+    return cloneAccount(nextAccount);
+  }
+
+  async deletePlayerAccount(
+    playerId: string,
+    input: { deletedAt?: string } = {}
+  ): Promise<PlayerAccountSnapshot | null> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existing = await this.loadPlayerAccount(normalizedPlayerId);
+    if (!existing) {
+      return null;
+    }
+
+    if (existing.loginId) {
+      this.authByLoginId.delete(existing.loginId);
+    }
+    if (existing.wechatMiniGameOpenId) {
+      this.playerIdByWechatOpenId.delete(existing.wechatMiniGameOpenId);
+    }
+    this.authSessionsByPlayerId.delete(normalizedPlayerId);
+    for (const key of Array.from(this.heroArchives.keys())) {
+      if (key.startsWith(`${normalizedPlayerId}:`)) {
+        this.heroArchives.delete(key);
+      }
+    }
+
+    const deletedAt = new Date(input.deletedAt ?? Date.now()).toISOString();
+    const nextAccount: PlayerAccountSnapshot = {
+      ...existing,
+      displayName: `deleted-${normalizedPlayerId}`,
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      banStatus: "none",
+      accountSessionVersion: (existing.accountSessionVersion ?? 0) + 1,
+      updatedAt: deletedAt
+    };
+    delete nextAccount.avatarUrl;
+    delete nextAccount.lastSeenAt;
+    delete nextAccount.lastRoomId;
+    delete nextAccount.loginId;
+    delete nextAccount.credentialBoundAt;
+    delete nextAccount.privacyConsentAt;
+    delete nextAccount.ageVerified;
+    delete nextAccount.isMinor;
+    delete nextAccount.dailyPlayMinutes;
+    delete nextAccount.lastPlayDate;
+    delete nextAccount.banExpiry;
+    delete nextAccount.banReason;
+    delete nextAccount.refreshSessionId;
+    delete nextAccount.refreshTokenExpiresAt;
+    delete nextAccount.wechatMiniGameOpenId;
+    delete nextAccount.wechatMiniGameUnionId;
+    delete nextAccount.wechatMiniGameBoundAt;
+    this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     return cloneAccount(nextAccount);
   }
 

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -38,6 +38,10 @@ export interface RoomSnapshotStore {
     playerId: string,
     input: PlayerAccountCredentialInput
   ): Promise<PlayerAccountSnapshot>;
+  savePlayerAccountPrivacyConsent(
+    playerId: string,
+    input?: PlayerAccountPrivacyConsentInput
+  ): Promise<PlayerAccountSnapshot>;
   savePlayerAccountAuthSession(
     playerId: string,
     input: PlayerAccountAuthSessionInput
@@ -57,6 +61,10 @@ export interface RoomSnapshotStore {
     playerId: string,
     input: PlayerAccountWechatMiniGameIdentityInput
   ): Promise<PlayerAccountSnapshot>;
+  deletePlayerAccount(
+    playerId: string,
+    input?: PlayerAccountDeleteInput
+  ): Promise<PlayerAccountSnapshot | null>;
   savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot>;
   savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot>;
   listPlayerAccounts(options?: PlayerAccountListOptions): Promise<PlayerAccountSnapshot[]>;
@@ -142,6 +150,7 @@ interface PlayerAccountRow extends RowDataPacket {
   wechat_mini_game_union_id: string | null;
   wechat_mini_game_bound_at: Date | string | null;
   credential_bound_at: Date | string | null;
+  privacy_consent_at: Date | string | null;
   created_at: Date | string;
   updated_at: Date | string;
 }
@@ -299,6 +308,10 @@ export interface PlayerAccountCredentialInput {
   passwordHash: string;
 }
 
+export interface PlayerAccountPrivacyConsentInput {
+  privacyConsentAt?: string;
+}
+
 export interface PlayerAccountAuthSessionInput {
   refreshSessionId: string;
   refreshTokenHash: string;
@@ -320,6 +333,10 @@ export interface PlayerAccountWechatMiniGameIdentityInput {
   avatarUrl?: string | null;
   ageVerified?: boolean;
   isMinor?: boolean;
+}
+
+export interface PlayerAccountDeleteInput {
+  deletedAt?: string;
 }
 
 export interface PlayerAccountListOptions {
@@ -499,6 +516,19 @@ function normalizePlayerAvatarUrl(avatarUrl?: string | null): string | undefined
   return normalized ? normalized.slice(0, MAX_PLAYER_AVATAR_URL_LENGTH) : undefined;
 }
 
+function normalizePrivacyConsentAt(value?: string | Date | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("privacyConsentAt must be a valid ISO timestamp");
+  }
+
+  return parsed.toISOString();
+}
+
 function normalizePlayerAgeVerified(ageVerified?: boolean | number | null): boolean | undefined {
   if (ageVerified == null) {
     return undefined;
@@ -633,6 +663,7 @@ function normalizePlayerAccountSnapshot(account: {
   wechatMiniGameUnionId?: string | null | undefined;
   wechatMiniGameBoundAt?: string | undefined;
   credentialBoundAt?: string | undefined;
+  privacyConsentAt?: string | Date | null | undefined;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
 }): PlayerAccountSnapshot {
@@ -658,6 +689,7 @@ function normalizePlayerAccountSnapshot(account: {
       lastSeenAt: account.lastSeenAt,
       loginId: account.loginId ? normalizePlayerLoginId(account.loginId) : undefined,
       credentialBoundAt: account.credentialBoundAt,
+      privacyConsentAt: normalizePrivacyConsentAt(account.privacyConsentAt),
       ageVerified: normalizePlayerAgeVerified(account.ageVerified),
       isMinor: normalizePlayerIsMinor(account.isMinor),
       dailyPlayMinutes: normalizeDailyPlayMinutes(account.dailyPlayMinutes),
@@ -957,6 +989,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   wechat_mini_game_bound_at DATETIME NULL DEFAULT NULL,
   password_hash VARCHAR(255) NULL,
   credential_bound_at DATETIME NULL DEFAULT NULL,
+  privacy_consent_at DATETIME NULL DEFAULT NULL,
   version BIGINT UNSIGNED NOT NULL DEFAULT 1,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -1324,6 +1357,24 @@ SET @veil_player_accounts_password_hash_sql := IF(
 PREPARE veil_player_accounts_password_hash_stmt FROM @veil_player_accounts_password_hash_sql;
 EXECUTE veil_player_accounts_password_hash_stmt;
 DEALLOCATE PREPARE veil_player_accounts_password_hash_stmt;
+
+SET @veil_player_accounts_privacy_consent_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'privacy_consent_at'
+);
+
+SET @veil_player_accounts_privacy_consent_sql := IF(
+  @veil_player_accounts_privacy_consent_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`privacy_consent_at\` DATETIME NULL DEFAULT NULL AFTER \`credential_bound_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_privacy_consent_stmt FROM @veil_player_accounts_privacy_consent_sql;
+EXECUTE veil_player_accounts_privacy_consent_stmt;
+DEALLOCATE PREPARE veil_player_accounts_privacy_consent_stmt;
 
 SET @veil_player_accounts_wechat_idp_open_id_exists := (
   SELECT COUNT(*)
@@ -1718,6 +1769,7 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
   const refreshTokenExpiresAt = formatTimestamp(row.refresh_token_expires_at);
   const wechatMiniGameBoundAt = formatTimestamp(row.wechat_mini_game_bound_at);
   const credentialBoundAt = formatTimestamp(row.credential_bound_at);
+  const privacyConsentAt = formatTimestamp(row.privacy_consent_at);
   const createdAt = formatTimestamp(row.created_at);
   const updatedAt = formatTimestamp(row.updated_at);
   const wechatOpenId = row.wechat_open_id ?? row.wechat_mini_game_open_id;
@@ -1762,6 +1814,7 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(lastSeenAt ? { lastSeenAt } : {}),
     ...(wechatMiniGameBoundAt ? { wechatMiniGameBoundAt } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
+    ...(privacyConsentAt ? { privacyConsentAt } : {}),
     ...(createdAt ? { createdAt } : {}),
     ...(updatedAt ? { updatedAt } : {})
   });
@@ -2158,6 +2211,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
          credential_bound_at,
+         privacy_consent_at,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -2202,6 +2256,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
          credential_bound_at,
+         privacy_consent_at,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -2330,6 +2385,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
          credential_bound_at,
+         privacy_consent_at,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -2667,6 +2723,31 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     );
   }
 
+  async savePlayerAccountPrivacyConsent(
+    playerId: string,
+    input: PlayerAccountPrivacyConsentInput = {}
+  ): Promise<PlayerAccountSnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existingAccount = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const privacyConsentAt = normalizePrivacyConsentAt(input.privacyConsentAt) ?? new Date().toISOString();
+
+    await this.pool.query(
+      `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+       SET privacy_consent_at = COALESCE(privacy_consent_at, ?),
+           version = version + 1
+       WHERE player_id = ?`,
+      [new Date(privacyConsentAt), normalizedPlayerId]
+    );
+
+    return (
+      (await this.loadPlayerAccount(normalizedPlayerId)) ??
+      normalizePlayerAccountSnapshot({
+        ...existingAccount,
+        privacyConsentAt
+      })
+    );
+  }
+
   async savePlayerAccountAuthSession(
     playerId: string,
     input: PlayerAccountAuthSessionInput
@@ -2837,6 +2918,76 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         wechatMiniGameBoundAt: boundAt
       })
     );
+  }
+
+  async deletePlayerAccount(
+    playerId: string,
+    input: PlayerAccountDeleteInput = {}
+  ): Promise<PlayerAccountSnapshot | null> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const existingAccount = await this.loadPlayerAccount(normalizedPlayerId);
+    if (!existingAccount) {
+      return null;
+    }
+
+    const deletedAt = normalizePrivacyConsentAt(input.deletedAt) ?? new Date().toISOString();
+    const anonymizedDisplayName = `deleted-${normalizedPlayerId}`;
+
+    await this.pool.query(
+      `DELETE FROM \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\`
+       WHERE player_id = ?`,
+      [normalizedPlayerId]
+    );
+    await this.pool.query(
+      `DELETE FROM \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
+       WHERE player_id = ?`,
+      [normalizedPlayerId]
+    );
+    await this.pool.query(
+      `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+       SET display_name = ?,
+           avatar_url = NULL,
+           global_resources_json = ?,
+           achievements_json = ?,
+           last_room_id = NULL,
+           last_seen_at = NULL,
+           login_id = NULL,
+           password_hash = NULL,
+           credential_bound_at = NULL,
+           privacy_consent_at = NULL,
+           age_verified = 0,
+           is_minor = 0,
+           daily_play_minutes = 0,
+           last_play_date = NULL,
+           ban_status = 'none',
+           ban_expiry = NULL,
+           ban_reason = NULL,
+           account_session_version = account_session_version + 1,
+           refresh_session_id = NULL,
+           refresh_token_hash = NULL,
+           refresh_token_expires_at = NULL,
+           wechat_open_id = NULL,
+           wechat_union_id = NULL,
+           wechat_mini_game_open_id = NULL,
+           wechat_mini_game_union_id = NULL,
+           wechat_mini_game_bound_at = NULL,
+           version = version + 1
+       WHERE player_id = ?`,
+      [anonymizedDisplayName, JSON.stringify(normalizeResourceLedger()), JSON.stringify([]), normalizedPlayerId]
+    );
+    await appendPlayerEventHistoryEntries(this.pool, normalizedPlayerId, [
+      {
+        id: `${normalizedPlayerId}:${deletedAt}:account-deleted`,
+        timestamp: deletedAt,
+        roomId: "auth",
+        playerId: normalizedPlayerId,
+        category: "account",
+        description: "Account deleted and personal data anonymized.",
+        rewards: []
+      }
+    ]);
+
+    return this.loadPlayerAccount(normalizedPlayerId);
   }
 
   async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {
@@ -3048,6 +3199,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
          credential_bound_at,
+         privacy_consent_at,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -16,6 +16,7 @@ import {
   cachePlayerAccountAuthState,
   hashAccountPassword,
   issueNextAuthSession,
+  revokeGuestAuthSession,
   readGuestAuthTokenFromRequest,
   validateAuthSessionFromRequest,
   verifyAccountPassword
@@ -462,6 +463,7 @@ function toPublicPlayerAccount(
   PlayerAccountSnapshot,
   | "loginId"
   | "credentialBoundAt"
+  | "privacyConsentAt"
   | "wechatMiniGameOpenId"
   | "wechatMiniGameUnionId"
   | "banStatus"
@@ -485,6 +487,7 @@ export function registerPlayerAccountRoutes(
   app: {
     use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
     get: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
+    post: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
     delete: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
     put: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
   },
@@ -492,7 +495,7 @@ export function registerPlayerAccountRoutes(
 ): void {
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
-    response.setHeader("Access-Control-Allow-Methods", "GET,PUT,DELETE,OPTIONS");
+    response.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
     response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
 
     if (request.method === "OPTIONS") {
@@ -600,6 +603,53 @@ export function registerPlayerAccountRoutes(
           refreshExpiresAt: session.refreshTokenExpiresAt,
           current: authSession.sessionId === session.sessionId
         }))
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/players/me/delete", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      if (authSession.sessionId) {
+        revokeGuestAuthSession(authSession.sessionId);
+      }
+      sendJson(response, 200, { ok: true, deleted: null });
+      return;
+    }
+
+    try {
+      const deleted = await store.deletePlayerAccount(authSession.playerId, {
+        deletedAt: new Date().toISOString()
+      });
+      if (!deleted) {
+        sendJson(response, 404, {
+          error: {
+            code: "player_not_found",
+            message: `Player account not found: ${authSession.playerId}`
+          }
+        });
+        return;
+      }
+
+      if (authSession.authMode === "account") {
+        removeAuthAccountSessionsForPlayer(authSession.playerId);
+      } else if (authSession.sessionId) {
+        revokeGuestAuthSession(authSession.sessionId);
+      }
+
+      sendJson(response, 200, {
+        ok: true,
+        deleted: {
+          playerId: deleted.playerId,
+          displayName: deleted.displayName,
+          deletedAt: deleted.updatedAt ?? new Date().toISOString()
+        }
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -160,6 +160,7 @@ class MemoryAuthStore implements RoomSnapshotStore {
       ...(existing?.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
       ...(existing?.credentialBoundAt ? { credentialBoundAt: existing.credentialBoundAt } : {}),
+      ...(existing?.privacyConsentAt ? { privacyConsentAt: existing.privacyConsentAt } : {}),
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -250,6 +251,20 @@ class MemoryAuthStore implements RoomSnapshotStore {
       accountSessionVersion: existing.accountSessionVersion ?? 0,
       ...(account.credentialBoundAt ? { credentialBoundAt: account.credentialBoundAt } : {})
     });
+    return account;
+  }
+
+  async savePlayerAccountPrivacyConsent(
+    playerId: string,
+    input: { privacyConsentAt?: string } = {}
+  ): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      privacyConsentAt: existing.privacyConsentAt ?? new Date(input.privacyConsentAt ?? Date.now()).toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(account.playerId, account);
     return account;
   }
 
@@ -398,6 +413,48 @@ class MemoryAuthStore implements RoomSnapshotStore {
           : {}),
       updatedAt: new Date().toISOString()
     };
+    this.accounts.set(account.playerId, account);
+    return account;
+  }
+
+  async deletePlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
+    const existing = this.accounts.get(playerId.trim());
+    if (!existing) {
+      return null;
+    }
+    if (existing.loginId) {
+      this.authByLoginId.delete(existing.loginId);
+    }
+    if (existing.wechatMiniGameOpenId) {
+      this.playerIdByWechatOpenId.delete(existing.wechatMiniGameOpenId);
+    }
+    this.authSessionsByPlayerId.delete(playerId.trim());
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      displayName: `deleted-${existing.playerId.slice(0, 12)}`,
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      banStatus: "none",
+      accountSessionVersion: (existing.accountSessionVersion ?? 0) + 1,
+      updatedAt: new Date().toISOString()
+    };
+    delete account.avatarUrl;
+    delete account.lastRoomId;
+    delete account.lastSeenAt;
+    delete account.loginId;
+    delete account.credentialBoundAt;
+    delete account.privacyConsentAt;
+    delete account.ageVerified;
+    delete account.isMinor;
+    delete account.dailyPlayMinutes;
+    delete account.lastPlayDate;
+    delete account.banExpiry;
+    delete account.banReason;
+    delete account.refreshSessionId;
+    delete account.refreshTokenExpiresAt;
+    delete account.wechatMiniGameOpenId;
+    delete account.wechatMiniGameUnionId;
+    delete account.wechatMiniGameBoundAt;
     this.accounts.set(account.playerId, account);
     return account;
   }
@@ -683,7 +740,8 @@ test("guest auth route issues a signed session token", async (t) => {
     },
     body: JSON.stringify({
       playerId: "player-auth",
-      displayName: "访客骑士"
+      displayName: "访客骑士",
+      privacyConsentAccepted: true
     })
   });
   const payload = (await response.json()) as { session: GuestAuthSession };
@@ -705,7 +763,8 @@ test("auth session route resolves a bearer token into the current guest session"
     },
     body: JSON.stringify({
       playerId: "player-session",
-      displayName: "回声旅人"
+      displayName: "回声旅人",
+      privacyConsentAccepted: true
     })
   });
   const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
@@ -739,7 +798,8 @@ test("connect message prefers auth token identity over a spoofed playerId", asyn
     },
     body: JSON.stringify({
       playerId: "trusted-player",
-      displayName: "真正的访客"
+      displayName: "真正的访客",
+      privacyConsentAccepted: true
     })
   });
   const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
@@ -777,7 +837,8 @@ test("guest auth connect claims a default hero slot for non-template player ids"
     },
     body: JSON.stringify({
       playerId: "guest-rune",
-      displayName: "灰烬行者"
+      displayName: "灰烬行者",
+      privacyConsentAccepted: true
     })
   });
   const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
@@ -826,7 +887,8 @@ test("account bind upgrades a guest session into password login and account-logi
     },
     body: JSON.stringify({
       playerId: "account-player",
-      displayName: "暮潮守望"
+      displayName: "暮潮守望",
+      privacyConsentAccepted: true
     })
   });
   const guestLoginPayload = (await guestLoginResponse.json()) as { session: GuestAuthSession };
@@ -839,7 +901,8 @@ test("account bind upgrades a guest session into password login and account-logi
     },
     body: JSON.stringify({
       loginId: "veil-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const bindPayload = (await bindResponse.json()) as {
@@ -918,7 +981,8 @@ test("account access tokens expire with token_expired and can be rotated through
     },
     body: JSON.stringify({
       loginId: "expiry-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const loginPayload = (await loginResponse.json()) as {
@@ -974,7 +1038,8 @@ test("refresh rotation invalidates the previous refresh token and logout revokes
     },
     body: JSON.stringify({
       loginId: "rotate-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
@@ -1042,7 +1107,8 @@ test("auth readiness and metrics summarize auth posture for dashboards", async (
     },
     body: JSON.stringify({
       playerId: "metrics-guest",
-      displayName: "指标访客"
+      displayName: "指标访客",
+      privacyConsentAccepted: true
     })
   });
   const guestLoginPayload = (await guestLoginResponse.json()) as { session: GuestAuthSession };
@@ -1056,7 +1122,8 @@ test("auth readiness and metrics summarize auth posture for dashboards", async (
     },
     body: JSON.stringify({
       loginId: "metrics-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const accountLoginPayload = (await accountLoginResponse.json()) as { session: GuestAuthSession };
@@ -1086,7 +1153,8 @@ test("auth readiness and metrics summarize auth posture for dashboards", async (
     },
     body: JSON.stringify({
       loginId: "metrics-ranger",
-      password: "wrong-password"
+      password: "wrong-password",
+      privacyConsentAccepted: true
     })
   });
   assert.equal(invalidLoginResponse.status, 401);
@@ -1183,7 +1251,8 @@ test("revoking one device session leaves other account sessions active and block
     },
     body: JSON.stringify({
       loginId: "device-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const firstLoginPayload = (await firstLoginResponse.json()) as { session: GuestAuthSession };
@@ -1196,7 +1265,8 @@ test("revoking one device session leaves other account sessions active and block
     },
     body: JSON.stringify({
       loginId: "device-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const secondLoginPayload = (await secondLoginResponse.json()) as { session: GuestAuthSession };
@@ -1258,7 +1328,8 @@ test("password changes revoke the current account session family", async (t) => 
     },
     body: JSON.stringify({
       loginId: "password-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
@@ -1325,7 +1396,8 @@ test("guest auth route returns 429 after the per-IP rate limit is exceeded", asy
         "Content-Type": "application/json"
       },
       body: JSON.stringify({
-        playerId: `guest-rate-limit-${index}`
+        playerId: `guest-rate-limit-${index}`,
+        privacyConsentAccepted: true
       })
     });
     assert.equal(response.status, 200);
@@ -1337,7 +1409,8 @@ test("guest auth route returns 429 after the per-IP rate limit is exceeded", asy
       "Content-Type": "application/json"
     },
     body: JSON.stringify({
-      playerId: "guest-rate-limit-3"
+      playerId: "guest-rate-limit-3",
+      privacyConsentAccepted: true
     })
   });
   const limitedPayload = (await limitedResponse.json()) as { error: { code: string } };
@@ -1384,7 +1457,8 @@ test("account login locks after repeated invalid credentials and returns lockedU
       },
       body: JSON.stringify({
         loginId: "lockout-ranger",
-        password: "wrong-password"
+        password: "wrong-password",
+        privacyConsentAccepted: true
       })
     });
 
@@ -1408,7 +1482,8 @@ test("account login locks after repeated invalid credentials and returns lockedU
     },
     body: JSON.stringify({
       loginId: "lockout-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const lockedPayload = (await lockedResponse.json()) as { error: { code: string; lockedUntil?: string } };
@@ -1455,7 +1530,8 @@ test("account login lockout expires after the configured duration", async (t) =>
       },
       body: JSON.stringify({
         loginId: "expiry-ranger",
-        password: "wrong-password"
+        password: "wrong-password",
+        privacyConsentAccepted: true
       })
     });
   }
@@ -1469,7 +1545,8 @@ test("account login lockout expires after the configured duration", async (t) =>
     },
     body: JSON.stringify({
       loginId: "expiry-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const payload = (await response.json()) as {
@@ -1507,7 +1584,7 @@ test("guest auth session LRU eviction invalidates the oldest idle guest token", 
       headers: {
         "Content-Type": "application/json"
       },
-      body: JSON.stringify({ playerId })
+      body: JSON.stringify({ playerId, privacyConsentAccepted: true })
     });
     const payload = (await response.json()) as { session: GuestAuthSession };
     assert.equal(response.status, 200);
@@ -1572,7 +1649,8 @@ test("account registration request and confirm create a new formal account, sess
     body: JSON.stringify({
       loginId: "formal-ranger",
       registrationToken: requestPayload.registrationToken,
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const confirmPayload = (await confirmResponse.json()) as {
@@ -1601,7 +1679,8 @@ test("account registration request and confirm create a new formal account, sess
     },
     body: JSON.stringify({
       loginId: "formal-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   assert.equal(loginResponse.status, 200);
@@ -1671,7 +1750,8 @@ test("account registration confirm rejects invalid tokens", { concurrency: false
     body: JSON.stringify({
       loginId: "invalid-registration-ranger",
       registrationToken: "wrong-token",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const confirmPayload = (await confirmResponse.json()) as { error: { code: string } };
@@ -1737,7 +1817,8 @@ test("account registration request reuses the active token for the same loginId 
     body: JSON.stringify({
       loginId: "stable-registration-ranger",
       registrationToken: firstPayload.registrationToken,
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
 
@@ -1821,7 +1902,8 @@ test("password recovery request and confirm reset the password, revoke old sessi
     },
     body: JSON.stringify({
       loginId: "recovery-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
@@ -1879,7 +1961,8 @@ test("password recovery request and confirm reset the password, revoke old sessi
     },
     body: JSON.stringify({
       loginId: "recovery-ranger",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
   assert.equal(stalePasswordResponse.status, 401);
@@ -1891,7 +1974,8 @@ test("password recovery request and confirm reset the password, revoke old sessi
     },
     body: JSON.stringify({
       loginId: "recovery-ranger",
-      password: "hunter3"
+      password: "hunter3",
+      privacyConsentAccepted: true
     })
   });
   assert.equal(freshPasswordResponse.status, 200);
@@ -2161,7 +2245,8 @@ test("account registration request uses webhook delivery without leaking the tok
     body: JSON.stringify({
       loginId: "webhook-registration-ranger",
       registrationToken: webhook.requests[0]?.body.token,
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
 
@@ -2230,7 +2315,8 @@ test("account registration request uses smtp delivery without leaking the token"
     body: JSON.stringify({
       loginId: "smtp-registration-ranger",
       registrationToken: tokenMatch?.[1],
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     })
   });
 
@@ -2595,7 +2681,8 @@ test("wechat login defaults to mock mode in NODE_ENV=test", { concurrency: false
     body: JSON.stringify({
       code: "wechat-dev-code",
       playerId: "wechat-player",
-      displayName: "云桥旅人"
+      displayName: "云桥旅人",
+      privacyConsentAccepted: true
     })
   });
   const payload = (await response.json()) as { session: GuestAuthSession };
@@ -2626,7 +2713,8 @@ test("wechat login route can be explicitly disabled", { concurrency: false }, as
     body: JSON.stringify({
       code: "wx-dev-code",
       playerId: "wechat-player",
-      displayName: "云桥旅人"
+      displayName: "云桥旅人",
+      privacyConsentAccepted: true
     })
   });
   const payload = (await response.json()) as { error: { code: string } };
@@ -2659,7 +2747,8 @@ test("legacy wechat mini game route remains available as an alias", { concurrenc
     body: JSON.stringify({
       code: "wx-dev-code",
       playerId: "wechat-player",
-      displayName: "云桥旅人"
+      displayName: "云桥旅人",
+      privacyConsentAccepted: true
     })
   });
   const payload = (await response.json()) as { session: GuestAuthSession };
@@ -2735,7 +2824,8 @@ test("wechat mini game production exchange binds code2Session identity onto an a
     body: JSON.stringify({
       code: "wx-prod-code",
       displayName: "微信暮潮守望",
-      avatarUrl: " https://cdn.example.com/avatar.png "
+      avatarUrl: " https://cdn.example.com/avatar.png ",
+      privacyConsentAccepted: true
     })
   });
   const payload = (await response.json()) as { session: GuestAuthSession };
@@ -2807,7 +2897,8 @@ test("wechat mini game login stores verified minor status when age data is provi
       code: "wx-prod-code",
       playerId: "wechat-minor",
       displayName: "夜巡学员",
-      isAdult: false
+      isAdult: false,
+      privacyConsentAccepted: true
     })
   });
 
@@ -2859,7 +2950,8 @@ test("wechat mini game login reuses the bound player even when later requests sp
     body: JSON.stringify({
       code: "wx-prod-code",
       playerId: "wechat-player",
-      displayName: "初次旅人"
+      displayName: "初次旅人",
+      privacyConsentAccepted: true
     })
   });
   const firstPayload = (await firstResponse.json()) as { session: GuestAuthSession };
@@ -2872,7 +2964,8 @@ test("wechat mini game login reuses the bound player even when later requests sp
     body: JSON.stringify({
       code: "wx-prod-code",
       playerId: "spoofed-player",
-      displayName: "回归旅人"
+      displayName: "回归旅人",
+      privacyConsentAccepted: true
     })
   });
   const secondPayload = (await secondResponse.json()) as { session: GuestAuthSession };
@@ -2952,7 +3045,8 @@ test("banned accounts are blocked on account-login and subsequent session checks
     },
     body: JSON.stringify({
       loginId: "banned-ranger",
-      password: "secret-pass"
+      password: "secret-pass",
+      privacyConsentAccepted: true
     })
   });
   const initialLoginPayload = (await initialLoginResponse.json()) as { session: GuestAuthSession };
@@ -2984,7 +3078,8 @@ test("banned accounts are blocked on account-login and subsequent session checks
     },
     body: JSON.stringify({
       loginId: "banned-ranger",
-      password: "secret-pass"
+      password: "secret-pass",
+      privacyConsentAccepted: true
     })
   });
   const reloginPayload = (await reloginResponse.json()) as {
@@ -2994,4 +3089,86 @@ test("banned accounts are blocked on account-login and subsequent session checks
   assert.equal(reloginPayload.error.code, "account_banned");
   assert.equal(reloginPayload.error.reason, "Harassment");
   assert.equal(reloginPayload.error.expiry, "2026-04-06T00:00:00.000Z");
+});
+
+test("guest login requires privacy consent before issuing the first session", async (t) => {
+  const port = 45160 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const rejectedResponse = await fetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: "guest-consent",
+      displayName: "雾行者"
+    })
+  });
+  const rejectedPayload = (await rejectedResponse.json()) as { error: { code: string } };
+  assert.equal(rejectedResponse.status, 403);
+  assert.equal(rejectedPayload.error.code, "privacy_consent_required");
+
+  const acceptedResponse = await fetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: "guest-consent",
+      displayName: "雾行者",
+      privacyConsentAccepted: true
+    })
+  });
+  assert.equal(acceptedResponse.status, 200);
+  assert.ok((await store.loadPlayerAccount("guest-consent"))?.privacyConsentAt);
+});
+
+test("account registration confirmation requires privacy consent", async (t) => {
+  const port = 45180 + Math.floor(Math.random() * 1000);
+  const cleanup: Array<() => void> = [];
+  withEnvOverrides({ VEIL_ACCOUNT_REGISTRATION_DELIVERY_MODE: "dev-token" }, cleanup);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    while (cleanup.length > 0) {
+      cleanup.pop()?.();
+    }
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const requestResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/request`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "consent-ranger",
+      displayName: "同意旅人"
+    })
+  });
+  const requestPayload = (await requestResponse.json()) as { registrationToken?: string };
+
+  const confirmResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-registration/confirm`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "consent-ranger",
+      registrationToken: requestPayload.registrationToken,
+      password: "hunter2"
+    })
+  });
+  const confirmPayload = (await confirmResponse.json()) as { error: { code: string } };
+  assert.equal(confirmResponse.status, 403);
+  assert.equal(confirmPayload.error.code, "privacy_consent_required");
 });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -161,6 +161,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ...(existing?.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
       ...(existing?.credentialBoundAt ? { credentialBoundAt: existing.credentialBoundAt } : {}),
+      ...(existing?.privacyConsentAt ? { privacyConsentAt: existing.privacyConsentAt } : {}),
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -252,6 +253,20 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       accountSessionVersion: existing.accountSessionVersion ?? 0,
       credentialBoundAt
     });
+    return account;
+  }
+
+  async savePlayerAccountPrivacyConsent(
+    playerId: string,
+    input: { privacyConsentAt?: string } = {}
+  ): Promise<PlayerAccountSnapshot> {
+    const existing = await this.ensurePlayerAccount({ playerId });
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      privacyConsentAt: existing.privacyConsentAt ?? new Date(input.privacyConsentAt ?? Date.now()).toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    this.accounts.set(account.playerId, account);
     return account;
   }
 
@@ -408,6 +423,48 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       updatedAt: new Date().toISOString()
     };
     this.accounts.set(playerId, account);
+    return account;
+  }
+
+  async deletePlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
+    const existing = this.accounts.get(playerId.trim());
+    if (!existing) {
+      return null;
+    }
+    if (existing.loginId) {
+      this.authByLoginId.delete(existing.loginId);
+    }
+    if (existing.wechatMiniGameOpenId) {
+      this.playerIdByWechatOpenId.delete(existing.wechatMiniGameOpenId);
+    }
+    this.authSessionsByPlayerId.delete(playerId.trim());
+    const account: PlayerAccountSnapshot = {
+      ...existing,
+      displayName: `deleted-${existing.playerId}`,
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      banStatus: "none",
+      accountSessionVersion: (existing.accountSessionVersion ?? 0) + 1,
+      updatedAt: new Date().toISOString()
+    };
+    delete account.avatarUrl;
+    delete account.lastRoomId;
+    delete account.lastSeenAt;
+    delete account.loginId;
+    delete account.credentialBoundAt;
+    delete account.privacyConsentAt;
+    delete account.ageVerified;
+    delete account.isMinor;
+    delete account.dailyPlayMinutes;
+    delete account.lastPlayDate;
+    delete account.banExpiry;
+    delete account.banReason;
+    delete account.refreshSessionId;
+    delete account.refreshTokenExpiresAt;
+    delete account.wechatMiniGameOpenId;
+    delete account.wechatMiniGameUnionId;
+    delete account.wechatMiniGameBoundAt;
+    this.accounts.set(account.playerId, account);
     return account;
   }
 
@@ -2280,4 +2337,85 @@ test("player account update routes reject oversized JSON bodies with 413", async
   const stored = await store.loadPlayerAccount("player-oversized");
   assert.equal(stored?.displayName, "起始名册");
   assert.equal(stored?.lastRoomId, "room-start");
+});
+
+test("player deletion anonymizes personal data, clears wechat bindings, and revokes the current token", async (t) => {
+  const port = 44740 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  await store.ensurePlayerAccount({
+    playerId: "player-delete",
+    displayName: "雾海旅人"
+  });
+  await store.savePlayerAccountPrivacyConsent("player-delete", {
+    privacyConsentAt: "2026-03-27T12:00:00.000Z"
+  });
+  await store.bindPlayerAccountCredentials("player-delete", {
+    loginId: "delete-ranger",
+    passwordHash: "hashed-password"
+  });
+  await store.bindPlayerAccountWechatMiniGameIdentity("player-delete", {
+    openId: "wx-delete-openid",
+    displayName: "雾海旅人"
+  });
+  await store.savePlayerAccountProgress("player-delete", {
+    recentEventLog: [
+      {
+        id: "delete-event-1",
+        timestamp: "2026-03-27T12:01:00.000Z",
+        roomId: "room-delete",
+        playerId: "player-delete",
+        category: "combat",
+        description: "完成一场遭遇战",
+        rewards: []
+      }
+    ],
+    recentBattleReplays: [createReplaySummary("delete-replay-1", "2026-03-27T12:02:00.000Z")]
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueAccountAuthSession({
+    playerId: "player-delete",
+    displayName: "雾海旅人",
+    loginId: "delete-ranger",
+    sessionVersion: 0
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const deleteResponse = await fetch(`http://127.0.0.1:${port}/api/players/me/delete`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const deletePayload = (await deleteResponse.json()) as {
+    ok: boolean;
+    deleted: { playerId: string; displayName: string };
+  };
+  assert.equal(deleteResponse.status, 200);
+  assert.equal(deletePayload.ok, true);
+  assert.equal(deletePayload.deleted.playerId, "player-delete");
+  assert.match(deletePayload.deleted.displayName, /^deleted-player-delete/);
+
+  const deletedAccount = await store.loadPlayerAccount("player-delete");
+  assert.equal(deletedAccount?.loginId, undefined);
+  assert.equal(deletedAccount?.privacyConsentAt, undefined);
+  assert.equal(deletedAccount?.wechatMiniGameOpenId, undefined);
+  assert.equal(deletedAccount?.recentBattleReplays?.[0]?.id, "delete-replay-1");
+  assert.equal(deletedAccount?.recentEventLog[0]?.id, "delete-event-1");
+
+  const reloginOpenId = await store.loadPlayerAccountByWechatMiniGameOpenId("wx-delete-openid");
+  assert.equal(reloginOpenId, null);
+
+  const meResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const mePayload = (await meResponse.json()) as {
+    error: { code: string };
+  };
+  assert.equal(meResponse.status, 401);
+  assert.equal(mePayload.error.code, "session_revoked");
 });

--- a/packages/shared/src/auth-ui.ts
+++ b/packages/shared/src/auth-ui.ts
@@ -4,12 +4,13 @@ export interface AccountAuthRequestFailure {
 }
 
 export type AccountLifecycleKind = "registration" | "recovery";
-export type AccountLifecycleValidationField = "loginId" | "token" | "password";
+export type AccountLifecycleValidationField = "loginId" | "token" | "password" | "privacyConsent";
 
 export interface AccountLifecycleDraft {
   loginId: string;
   token: string;
   password: string;
+  privacyConsentAccepted?: boolean;
 }
 
 export interface AccountLifecycleValidationError {
@@ -19,6 +20,20 @@ export interface AccountLifecycleValidationError {
 
 const LOGIN_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{2,39}$/;
 const MIN_PASSWORD_LENGTH = 6;
+
+export function validatePrivacyConsentAccepted(
+  accepted: boolean | undefined,
+  message = "请先勾选并同意隐私说明后再继续。"
+): AccountLifecycleValidationError | null {
+  if (accepted) {
+    return null;
+  }
+
+  return {
+    field: "privacyConsent",
+    message
+  };
+}
 
 export function normalizeAccountLoginIdDraft(loginId: string): string {
   return loginId.trim().toLowerCase();
@@ -89,6 +104,11 @@ export function validateAccountLifecycleConfirm(
     };
   }
 
+  const privacyConsentError = validatePrivacyConsentAccepted(draft.privacyConsentAccepted);
+  if (privacyConsentError) {
+    return privacyConsentError;
+  }
+
   return validateAccountPassword(
     draft.password,
     "password",
@@ -107,6 +127,9 @@ export function describeAccountAuthFailure(
   }
   if (failure.status === 403 && failure.code === "account_locked") {
     return "该账号因连续失败已被临时锁定，请稍后再试。";
+  }
+  if (failure.status === 403 && failure.code === "privacy_consent_required") {
+    return "需先同意隐私说明，才能登录、注册或继续绑定账号。";
   }
   if (failure.status === 401 && options.invalidTokenCode && failure.code === options.invalidTokenCode) {
     return "令牌无效或已过期，请重新申请后再确认。";

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -27,6 +27,7 @@ export interface PlayerAccountReadModel {
   battleReportCenter?: PlayerBattleReportCenter;
   loginId?: string;
   credentialBoundAt?: string;
+  privacyConsentAt?: string;
   ageVerified?: boolean;
   isMinor?: boolean;
   dailyPlayMinutes?: number;
@@ -50,6 +51,7 @@ export interface PlayerAccountReadModelInput {
   battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
+  privacyConsentAt?: string | undefined;
   ageVerified?: boolean | undefined;
   isMinor?: boolean | undefined;
   dailyPlayMinutes?: number | undefined;
@@ -69,6 +71,7 @@ export function normalizePlayerAccountReadModel(
   const avatarUrl = account?.avatarUrl?.trim();
   const loginId = account?.loginId?.trim().toLowerCase();
   const credentialBoundAt = account?.credentialBoundAt?.trim();
+  const privacyConsentAt = account?.privacyConsentAt?.trim();
   const ageVerified = account?.ageVerified === true;
   const isMinor = account?.isMinor === true;
   const dailyPlayMinutes = Math.max(0, Math.floor(account?.dailyPlayMinutes ?? 0));
@@ -102,6 +105,7 @@ export function normalizePlayerAccountReadModel(
     }),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
+    ...(privacyConsentAt ? { privacyConsentAt } : {}),
     ...(ageVerified ? { ageVerified } : {}),
     ...(isMinor ? { isMinor } : {}),
     ...(dailyPlayMinutes > 0 ? { dailyPlayMinutes } : {}),

--- a/packages/shared/test/auth-ui.test.ts
+++ b/packages/shared/test/auth-ui.test.ts
@@ -5,7 +5,8 @@ import {
   normalizeAccountLoginIdDraft,
   validateAccountLifecycleConfirm,
   validateAccountLifecycleRequest,
-  validateAccountPassword
+  validateAccountPassword,
+  validatePrivacyConsentAccepted
 } from "../src/auth-ui.ts";
 
 test("auth ui helper normalizes login IDs and rejects malformed drafts", () => {
@@ -34,7 +35,8 @@ test("auth ui helper validates confirm drafts for registration and recovery", ()
     validateAccountLifecycleConfirm("recovery", {
       loginId: "veil-ranger",
       token: "dev-recovery-token",
-      password: "123"
+      password: "123",
+      privacyConsentAccepted: true
     }),
     {
       field: "password",
@@ -46,9 +48,23 @@ test("auth ui helper validates confirm drafts for registration and recovery", ()
     validateAccountLifecycleConfirm("registration", {
       loginId: "veil-ranger",
       token: "dev-registration-token",
-      password: "hunter2"
+      password: "hunter2",
+      privacyConsentAccepted: true
     }),
     null
+  );
+
+  assert.deepEqual(
+    validateAccountLifecycleConfirm("registration", {
+      loginId: "veil-ranger",
+      token: "dev-registration-token",
+      password: "hunter2",
+      privacyConsentAccepted: false
+    }),
+    {
+      field: "privacyConsent",
+      message: "请先勾选并同意隐私说明后再继续。"
+    }
   );
 });
 
@@ -57,10 +73,18 @@ test("auth ui helper validates password labels and maps server failures", () => 
     field: "password",
     message: "请输入账号口令。"
   });
+  assert.deepEqual(validatePrivacyConsentAccepted(false), {
+    field: "privacyConsent",
+    message: "请先勾选并同意隐私说明后再继续。"
+  });
 
   assert.equal(
     describeAccountAuthFailure({ status: 403, code: "account_locked" }),
     "该账号因连续失败已被临时锁定，请稍后再试。"
+  );
+  assert.equal(
+    describeAccountAuthFailure({ status: 403, code: "privacy_consent_required" }),
+    "需先同意隐私说明，才能登录、注册或继续绑定账号。"
   );
   assert.equal(
     describeAccountAuthFailure({ status: 429, code: "too_many_requests" }),

--- a/scripts/migrations/0010_add_player_account_privacy_consent.ts
+++ b/scripts/migrations/0010_add_player_account_privacy_consent.ts
@@ -1,0 +1,23 @@
+import {
+  ensureColumnExists,
+  dropColumnIfExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import { MYSQL_PLAYER_ACCOUNT_TABLE } from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureColumnExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_TABLE,
+    "privacy_consent_at",
+    "`privacy_consent_at` DATETIME NULL DEFAULT NULL AFTER `credential_bound_at`"
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+  await dropColumnIfExists(connection, database, MYSQL_PLAYER_ACCOUNT_TABLE, "privacy_consent_at");
+}


### PR DESCRIPTION
Closes #780

## Summary
- add `privacyConsentAt` to player account models, persistence, and migration paths
- require privacy consent on first guest login, registration confirmation, account login/bind for legacy accounts, and WeChat login flows
- add token-authenticated `POST /api/players/me/delete` with anonymization, token invalidation, and WeChat mapping removal
- add focused H5, Cocos, shared, and server test coverage for consent and deletion behavior

## Tests
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `npm run typecheck:client:h5`
- `npm run typecheck:cocos`
- `node --import tsx --test packages/shared/test/auth-ui.test.ts apps/server/test/auth-guest-login.test.ts apps/server/test/player-account-routes.test.ts apps/client/test/auth-privacy-consent.test.ts apps/cocos-client/test/cocos-auth-privacy-consent.test.ts`