### PR TITLE
Add WeChat session_key validation for sensitive account operations

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -35,6 +35,7 @@ import {
   type PlayerAccountSnapshot,
   type RoomSnapshotStore
 } from "./persistence";
+import { cacheWechatSessionKey, readWechatSessionKeyTtlSeconds, resetWechatSessionKeyCache } from "./wechat-session-key";
 
 export type AuthMode = "guest" | "account";
 export type AuthProvider = "guest" | "account-password" | "wechat-mini-game";
@@ -114,6 +115,7 @@ interface WechatMiniGameCode2SessionPayload {
 interface WechatMiniGameIdentity {
   openId: string;
   unionId?: string;
+  sessionKey: string;
 }
 
 interface AccountAuthSessionState {
@@ -673,7 +675,8 @@ async function exchangeWechatMiniGameCode(
     }
 
     return {
-      openId: `mock-openid:${code}`
+      openId: `mock-openid:${code}`,
+      sessionKey: Buffer.from(`mock-session-key:${code}`, "utf8").toString("base64")
     };
   }
 
@@ -706,13 +709,15 @@ async function exchangeWechatMiniGameCode(
   }
 
   const openId = payload.openid?.trim();
-  if (!openId) {
+  const sessionKey = payload.session_key?.trim();
+  if (!openId || !sessionKey) {
     throw new Error("wechat_code2session_failed");
   }
 
   return {
     openId,
-    ...(payload.unionid?.trim() ? { unionId: payload.unionid.trim() } : {})
+    ...(payload.unionid?.trim() ? { unionId: payload.unionid.trim() } : {}),
+    sessionKey
   };
 }
 
@@ -1092,6 +1097,8 @@ async function handleWechatLogin(
     sendAuthFailure(response, "account_banned", activeBan);
     return;
   }
+
+  cacheWechatSessionKey(playerId, identity.sessionKey, readWechatSessionKeyTtlSeconds());
 
   sendJson(response, 200, {
     session:
@@ -1712,6 +1719,7 @@ export function resetGuestAuthSessions(): void {
   accountAuthStateByPlayerId.clear();
   accountRegistrationStateByLoginId.clear();
   passwordRecoveryStateByLoginId.clear();
+  resetWechatSessionKeyCache();
   syncAuthStateTelemetry();
 }
 
@@ -1800,6 +1808,79 @@ export function registerAuthRoutes(
       sendJson(response, 200, { session });
     } catch (error) {
       sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/auth/wechat-session-key/refresh", async (request, response) => {
+    try {
+      const { session: authSession, errorCode, ban } = await validateAuthSessionFromRequest(request, store);
+      if (!authSession) {
+        sendAuthFailure(response, errorCode, ban);
+        return;
+      }
+
+      const body = (await readJsonBody(request)) as {
+        code?: string | null;
+      };
+      if (body.code !== undefined && body.code !== null && typeof body.code !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string field: code"
+          }
+        });
+        return;
+      }
+
+      const identity = await exchangeWechatMiniGameCode(normalizeWechatMiniGameCode(body.code), readWechatMiniGameLoginConfig());
+      if (store) {
+        const boundAccount = await store.loadPlayerAccountByWechatMiniGameOpenId(identity.openId);
+        if (boundAccount && boundAccount.playerId !== authSession.playerId) {
+          sendJson(response, 409, {
+            error: {
+              code: "wechat_identity_already_bound",
+              message: "This WeChat identity is already bound to another account"
+            }
+          });
+          return;
+        }
+      }
+
+      const cached = cacheWechatSessionKey(authSession.playerId, identity.sessionKey, readWechatSessionKeyTtlSeconds());
+      sendJson(response, 200, {
+        ok: true,
+        playerId: authSession.playerId,
+        refreshedAt: new Date().toISOString(),
+        expiresAt: cached.expiresAt
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "wechat_session_key_refresh_failed";
+      if (message === "wechat_login_not_enabled") {
+        sendJson(response, 501, {
+          error: {
+            code: "wechat_login_not_enabled",
+            message: "WeChat login exchange exists, but code2Session is not configured"
+          }
+        });
+        return;
+      }
+
+      if (message === "invalid_wechat_code") {
+        sendJson(response, 401, {
+          error: {
+            code: "invalid_wechat_code",
+            message: "WeChat code is invalid or expired"
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 502, {
+        error: {
+          code: "wechat_code2session_failed",
+          message
+        }
+      });
     }
   });
 

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -151,6 +151,8 @@ interface PlayerAccountRow extends RowDataPacket {
   wechat_mini_game_bound_at: Date | string | null;
   credential_bound_at: Date | string | null;
   privacy_consent_at: Date | string | null;
+  phone_number: string | null;
+  phone_number_bound_at: Date | string | null;
   created_at: Date | string;
   updated_at: Date | string;
 }
@@ -243,6 +245,8 @@ export interface PlayerAccountSnapshot extends PlayerAccountReadModel {
   wechatMiniGameBoundAt?: string;
   createdAt?: string;
   updatedAt?: string;
+  phoneNumber?: string;
+  phoneNumberBoundAt?: string;
 }
 
 export interface PlayerAccountBanSnapshot {
@@ -291,6 +295,8 @@ export interface PlayerAccountProfilePatch {
   displayName?: string;
   avatarUrl?: string | null;
   lastRoomId?: string | null;
+  phoneNumber?: string | null;
+  phoneNumberBoundAt?: string | null;
 }
 
 export interface PlayerAccountProgressPatch {
@@ -664,6 +670,8 @@ function normalizePlayerAccountSnapshot(account: {
   wechatMiniGameBoundAt?: string | undefined;
   credentialBoundAt?: string | undefined;
   privacyConsentAt?: string | Date | null | undefined;
+  phoneNumber?: string | null | undefined;
+  phoneNumberBoundAt?: string | Date | null | undefined;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
 }): PlayerAccountSnapshot {
@@ -674,6 +682,7 @@ function normalizePlayerAccountSnapshot(account: {
   const normalizedWechatMiniGameUnionId = account.wechatMiniGameUnionId
     ? normalizeWechatMiniGameUnionId(account.wechatMiniGameUnionId)
     : undefined;
+  const phoneNumberBoundAt = formatTimestamp(account.phoneNumberBoundAt);
 
   return {
     ...normalizePlayerAccountReadModel({
@@ -690,6 +699,8 @@ function normalizePlayerAccountSnapshot(account: {
       loginId: account.loginId ? normalizePlayerLoginId(account.loginId) : undefined,
       credentialBoundAt: account.credentialBoundAt,
       privacyConsentAt: normalizePrivacyConsentAt(account.privacyConsentAt),
+      phoneNumber: account.phoneNumber?.trim() || undefined,
+      ...(phoneNumberBoundAt ? { phoneNumberBoundAt } : {}),
       ageVerified: normalizePlayerAgeVerified(account.ageVerified),
       isMinor: normalizePlayerIsMinor(account.isMinor),
       dailyPlayMinutes: normalizeDailyPlayMinutes(account.dailyPlayMinutes),
@@ -701,6 +712,8 @@ function normalizePlayerAccountSnapshot(account: {
     ...(normalizedWechatMiniGameOpenId ? { wechatMiniGameOpenId: normalizedWechatMiniGameOpenId } : {}),
     ...(normalizedWechatMiniGameUnionId ? { wechatMiniGameUnionId: normalizedWechatMiniGameUnionId } : {}),
     ...(account.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: account.wechatMiniGameBoundAt } : {}),
+    ...(account.phoneNumber?.trim() ? { phoneNumber: account.phoneNumber.trim() } : {}),
+    ...(phoneNumberBoundAt ? { phoneNumberBoundAt } : {}),
     ...(account.createdAt ? { createdAt: account.createdAt } : {}),
     ...(account.updatedAt ? { updatedAt: account.updatedAt } : {})
   };
@@ -990,6 +1003,8 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   password_hash VARCHAR(255) NULL,
   credential_bound_at DATETIME NULL DEFAULT NULL,
   privacy_consent_at DATETIME NULL DEFAULT NULL,
+  phone_number VARCHAR(32) NULL,
+  phone_number_bound_at DATETIME NULL DEFAULT NULL,
   version BIGINT UNSIGNED NOT NULL DEFAULT 1,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -1375,6 +1390,42 @@ SET @veil_player_accounts_privacy_consent_sql := IF(
 PREPARE veil_player_accounts_privacy_consent_stmt FROM @veil_player_accounts_privacy_consent_sql;
 EXECUTE veil_player_accounts_privacy_consent_stmt;
 DEALLOCATE PREPARE veil_player_accounts_privacy_consent_stmt;
+
+SET @veil_player_accounts_phone_number_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'phone_number'
+);
+
+SET @veil_player_accounts_phone_number_sql := IF(
+  @veil_player_accounts_phone_number_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`phone_number\` VARCHAR(32) NULL AFTER \`privacy_consent_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_phone_number_stmt FROM @veil_player_accounts_phone_number_sql;
+EXECUTE veil_player_accounts_phone_number_stmt;
+DEALLOCATE PREPARE veil_player_accounts_phone_number_stmt;
+
+SET @veil_player_accounts_phone_number_bound_at_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'phone_number_bound_at'
+);
+
+SET @veil_player_accounts_phone_number_bound_at_sql := IF(
+  @veil_player_accounts_phone_number_bound_at_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`phone_number_bound_at\` DATETIME NULL DEFAULT NULL AFTER \`phone_number\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_phone_number_bound_at_stmt FROM @veil_player_accounts_phone_number_bound_at_sql;
+EXECUTE veil_player_accounts_phone_number_bound_at_stmt;
+DEALLOCATE PREPARE veil_player_accounts_phone_number_bound_at_stmt;
 
 SET @veil_player_accounts_wechat_idp_open_id_exists := (
   SELECT COUNT(*)
@@ -1770,6 +1821,7 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
   const wechatMiniGameBoundAt = formatTimestamp(row.wechat_mini_game_bound_at);
   const credentialBoundAt = formatTimestamp(row.credential_bound_at);
   const privacyConsentAt = formatTimestamp(row.privacy_consent_at);
+  const phoneNumberBoundAt = formatTimestamp(row.phone_number_bound_at);
   const createdAt = formatTimestamp(row.created_at);
   const updatedAt = formatTimestamp(row.updated_at);
   const wechatOpenId = row.wechat_open_id ?? row.wechat_mini_game_open_id;
@@ -1815,6 +1867,8 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(wechatMiniGameBoundAt ? { wechatMiniGameBoundAt } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(privacyConsentAt ? { privacyConsentAt } : {}),
+    ...(row.phone_number ? { phoneNumber: row.phone_number } : {}),
+    ...(phoneNumberBoundAt ? { phoneNumberBoundAt } : {}),
     ...(createdAt ? { createdAt } : {}),
     ...(updatedAt ? { updatedAt } : {})
   });
@@ -2212,6 +2266,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_bound_at,
          credential_bound_at,
          privacy_consent_at,
+         phone_number,
+         phone_number_bound_at,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -2257,6 +2313,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_bound_at,
          credential_bound_at,
          privacy_consent_at,
+         phone_number,
+         phone_number_bound_at,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -2386,6 +2444,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_bound_at,
          credential_bound_at,
          privacy_consent_at,
+         phone_number,
+         phone_number_bound_at,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -2955,6 +3015,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
            password_hash = NULL,
            credential_bound_at = NULL,
            privacy_consent_at = NULL,
+           phone_number = NULL,
+           phone_number_bound_at = NULL,
            age_verified = 0,
            is_minor = 0,
            daily_play_minutes = 0,
@@ -3019,6 +3081,20 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
           : {}
         : existing.lastRoomId
           ? { lastRoomId: existing.lastRoomId }
+          : {}),
+      ...(patch.phoneNumber !== undefined
+        ? patch.phoneNumber
+          ? { phoneNumber: patch.phoneNumber.trim() }
+          : {}
+        : existing.phoneNumber
+          ? { phoneNumber: existing.phoneNumber }
+          : {}),
+      ...(patch.phoneNumberBoundAt !== undefined
+        ? patch.phoneNumberBoundAt
+          ? { phoneNumberBoundAt: new Date(patch.phoneNumberBoundAt).toISOString() }
+          : {}
+        : existing.phoneNumberBoundAt
+          ? { phoneNumberBoundAt: existing.phoneNumberBoundAt }
           : {})
     });
 
@@ -3033,9 +3109,11 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          last_room_id,
-         last_seen_at
+         last_seen_at,
+         phone_number,
+         phone_number_bound_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = VALUES(avatar_url),
@@ -3045,6 +3123,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json = VALUES(recent_event_log_json),
          recent_battle_replays_json = VALUES(recent_battle_replays_json),
          last_room_id = VALUES(last_room_id),
+         phone_number = VALUES(phone_number),
+         phone_number_bound_at = VALUES(phone_number_bound_at),
          last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
          version = version + 1`,
       [
@@ -3057,7 +3137,9 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.recentEventLog),
         JSON.stringify(nextAccount.recentBattleReplays),
         nextAccount.lastRoomId ?? null,
-        existing.lastSeenAt ? new Date(existing.lastSeenAt) : null
+        existing.lastSeenAt ? new Date(existing.lastSeenAt) : null,
+        nextAccount.phoneNumber ?? null,
+        nextAccount.phoneNumberBoundAt ? new Date(nextAccount.phoneNumberBoundAt) : null
       ]
     );
 
@@ -3200,6 +3282,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_bound_at,
          credential_bound_at,
          privacy_consent_at,
+         phone_number,
+         phone_number_bound_at,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -28,6 +28,7 @@ import type {
   PlayerEventHistoryQuery,
   RoomSnapshotStore
 } from "./persistence";
+import { decryptWechatPhoneNumber, validateWechatSignature } from "./wechat-session-key";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -56,6 +57,56 @@ class PayloadTooLargeError extends Error {
     super(`Request body exceeds ${maxBytes} bytes`);
     this.name = "payload_too_large";
   }
+}
+
+interface WechatSignatureEnvelope {
+  rawData?: string | null;
+  signature?: string | null;
+}
+
+function readExpectedWechatAppId(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const appId = env.WECHAT_APP_ID?.trim();
+  return appId ? appId : undefined;
+}
+
+function logWechatValidationFailure(playerId: string, operation: string, reason: string): void {
+  console.warn(`[WeChatValidation] player=${playerId} operation=${operation} reason=${reason}`);
+}
+
+function sendWechatValidationForbidden(response: ServerResponse, message = "WeChat signature validation failed"): void {
+  sendJson(response, 403, {
+    error: {
+      code: "wechat_signature_invalid",
+      message
+    }
+  });
+}
+
+function validateWechatSignatureEnvelope(
+  response: ServerResponse,
+  playerId: string,
+  operation: string,
+  signature?: WechatSignatureEnvelope | null
+): boolean {
+  if (!signature || typeof signature !== "object") {
+    logWechatValidationFailure(playerId, operation, "missing_signature");
+    sendWechatValidationForbidden(response);
+    return false;
+  }
+
+  if (typeof signature.rawData !== "string" || typeof signature.signature !== "string") {
+    logWechatValidationFailure(playerId, operation, "invalid_signature_payload");
+    sendWechatValidationForbidden(response);
+    return false;
+  }
+
+  if (!validateWechatSignature({ playerId, rawData: signature.rawData, signature: signature.signature })) {
+    logWechatValidationFailure(playerId, operation, "signature_mismatch_or_missing_session_key");
+    sendWechatValidationForbidden(response);
+    return false;
+  }
+
+  return true;
 }
 
 const MAX_JSON_BODY_BYTES = 64 * 1024;
@@ -464,6 +515,8 @@ function toPublicPlayerAccount(
   | "loginId"
   | "credentialBoundAt"
   | "privacyConsentAt"
+  | "phoneNumber"
+  | "phoneNumberBoundAt"
   | "wechatMiniGameOpenId"
   | "wechatMiniGameUnionId"
   | "banStatus"
@@ -473,6 +526,8 @@ function toPublicPlayerAccount(
   const {
     loginId: _loginId,
     credentialBoundAt: _credentialBoundAt,
+    phoneNumber: _phoneNumber,
+    phoneNumberBoundAt: _phoneNumberBoundAt,
     wechatMiniGameOpenId: _wechatMiniGameOpenId,
     wechatMiniGameUnionId: _wechatMiniGameUnionId,
     banStatus: _banStatus,
@@ -1447,6 +1502,85 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.post("/api/player-accounts/me/phone", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        encryptedData?: string | null;
+        iv?: string | null;
+      };
+      if (typeof body.encryptedData !== "string" || typeof body.iv !== "string") {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_payload",
+            message: "Expected string fields: encryptedData, iv"
+          }
+        });
+        return;
+      }
+
+      const decrypted = decryptWechatPhoneNumber({
+        playerId: authSession.playerId,
+        encryptedData: body.encryptedData,
+        iv: body.iv,
+        ...(readExpectedWechatAppId() ? { expectedAppId: readExpectedWechatAppId() } : {})
+      });
+      const phoneNumber = decrypted?.payload.phoneNumber?.trim() || decrypted?.payload.purePhoneNumber?.trim();
+      if (!decrypted || !phoneNumber) {
+        logWechatValidationFailure(authSession.playerId, "bind-phone", "decrypt_failed_or_missing_phone_number");
+        sendWechatValidationForbidden(response);
+        return;
+      }
+
+      const phoneNumberBoundAt = new Date().toISOString();
+      if (!store) {
+        const account = createLocalModeAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName,
+          ...(authSession.loginId ? { loginId: authSession.loginId } : {})
+        });
+        sendJson(response, 200, {
+          account: withBattleReportCenter({
+            ...account,
+            phoneNumber,
+            phoneNumberBoundAt
+          }),
+          phone: {
+            phoneNumber,
+            ...(decrypted.payload.countryCode?.trim() ? { countryCode: decrypted.payload.countryCode.trim() } : {}),
+            boundAt: phoneNumberBoundAt
+          },
+          session: issueNextAuthSession(account, authSession)
+        });
+        return;
+      }
+
+      const account = await store.savePlayerAccountProfile(authSession.playerId, {
+        phoneNumber,
+        phoneNumberBoundAt
+      });
+      sendJson(response, 200, {
+        account: withBattleReportCenter(account),
+        phone: {
+          phoneNumber,
+          ...(decrypted.payload.countryCode?.trim() ? { countryCode: decrypted.payload.countryCode.trim() } : {}),
+          boundAt: phoneNumberBoundAt
+        },
+        session: issueNextAuthSession(account, authSession)
+      });
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
   app.put("/api/player-accounts/me", async (request, response) => {
     const authSession = await requireAuthSession(request, response, store);
     if (!authSession) {
@@ -1460,6 +1594,7 @@ export function registerPlayerAccountRoutes(
         lastRoomId?: string | null;
         currentPassword?: string | null;
         newPassword?: string | null;
+        wechatSignature?: WechatSignatureEnvelope | null;
       };
 
       if (body.displayName !== undefined && body.displayName !== null && typeof body.displayName !== "string") {
@@ -1518,6 +1653,13 @@ export function registerPlayerAccountRoutes(
         ...(body.lastRoomId !== undefined ? { lastRoomId: body.lastRoomId } : {})
       };
       const wantsPasswordChange = body.currentPassword !== undefined || body.newPassword !== undefined;
+      const wantsSensitiveWechatValidation =
+        authSession.provider === "wechat-mini-game" &&
+        (body.displayName !== undefined || body.avatarUrl !== undefined || wantsPasswordChange);
+
+      if (wantsSensitiveWechatValidation && !validateWechatSignatureEnvelope(response, authSession.playerId, "update-profile", body.wechatSignature)) {
+        return;
+      }
 
       if (!store) {
         if (wantsPasswordChange) {
@@ -1651,6 +1793,7 @@ export function registerPlayerAccountRoutes(
         displayName?: string | null;
         avatarUrl?: string | null;
         lastRoomId?: string | null;
+        wechatSignature?: WechatSignatureEnvelope | null;
       };
 
       if (body.displayName !== undefined && body.displayName !== null && typeof body.displayName !== "string") {
@@ -1710,6 +1853,14 @@ export function registerPlayerAccountRoutes(
           return;
         }
         sendUnauthorized(response, authResult.errorCode ?? "unauthorized");
+        return;
+      }
+
+      if (
+        authSession.provider === "wechat-mini-game" &&
+        (body.displayName !== undefined || body.avatarUrl !== undefined) &&
+        !validateWechatSignatureEnvelope(response, authSession.playerId, "update-profile", body.wechatSignature)
+      ) {
         return;
       }
 

--- a/apps/server/src/wechat-session-key.ts
+++ b/apps/server/src/wechat-session-key.ts
@@ -1,0 +1,137 @@
+import { createDecipheriv, createHash } from "node:crypto";
+
+interface CachedWechatSessionKeyEntry {
+  sessionKey: string;
+  expiresAtMs: number;
+}
+
+export interface CachedWechatSessionKeySnapshot {
+  playerId: string;
+  sessionKey: string;
+  expiresAt: string;
+}
+
+export interface WechatPhoneNumberPayload {
+  phoneNumber?: string;
+  purePhoneNumber?: string;
+  countryCode?: string;
+  watermark?: {
+    appid?: string;
+  };
+}
+
+const DEFAULT_WECHAT_SESSION_KEY_TTL_SECONDS = 2 * 60 * 60;
+const wechatSessionKeyCache = new Map<string, CachedWechatSessionKeyEntry>();
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function normalizePlayerId(playerId: string): string {
+  const normalized = playerId.trim();
+  if (!normalized) {
+    throw new Error("playerId must not be empty");
+  }
+  return normalized;
+}
+
+function normalizeBase64Field(value: string, fieldName: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${fieldName} must not be empty`);
+  }
+  return normalized;
+}
+
+export function readWechatSessionKeyTtlSeconds(env: NodeJS.ProcessEnv = process.env): number {
+  const parsed = Number(env.VEIL_WECHAT_SESSION_KEY_TTL_SECONDS?.trim());
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_WECHAT_SESSION_KEY_TTL_SECONDS;
+  }
+  return Math.floor(parsed);
+}
+
+export function cacheWechatSessionKey(playerId: string, sessionKey: string, ttlSeconds = readWechatSessionKeyTtlSeconds()): CachedWechatSessionKeySnapshot {
+  const normalizedPlayerId = normalizePlayerId(playerId);
+  const normalizedSessionKey = normalizeBase64Field(sessionKey, "sessionKey");
+  const expiresAtMs = nowMs() + ttlSeconds * 1000;
+  wechatSessionKeyCache.set(normalizedPlayerId, {
+    sessionKey: normalizedSessionKey,
+    expiresAtMs
+  });
+  return {
+    playerId: normalizedPlayerId,
+    sessionKey: normalizedSessionKey,
+    expiresAt: new Date(expiresAtMs).toISOString()
+  };
+}
+
+export function getCachedWechatSessionKey(playerId: string): CachedWechatSessionKeySnapshot | null {
+  const normalizedPlayerId = normalizePlayerId(playerId);
+  const cached = wechatSessionKeyCache.get(normalizedPlayerId);
+  if (!cached) {
+    return null;
+  }
+  if (cached.expiresAtMs <= nowMs()) {
+    wechatSessionKeyCache.delete(normalizedPlayerId);
+    return null;
+  }
+  return {
+    playerId: normalizedPlayerId,
+    sessionKey: cached.sessionKey,
+    expiresAt: new Date(cached.expiresAtMs).toISOString()
+  };
+}
+
+export function clearCachedWechatSessionKey(playerId: string): boolean {
+  return wechatSessionKeyCache.delete(normalizePlayerId(playerId));
+}
+
+export function resetWechatSessionKeyCache(): void {
+  wechatSessionKeyCache.clear();
+}
+
+export function validateWechatSignature(input: {
+  playerId: string;
+  rawData: string;
+  signature: string;
+}): CachedWechatSessionKeySnapshot | null {
+  const cached = getCachedWechatSessionKey(input.playerId);
+  if (!cached) {
+    return null;
+  }
+  const digest = createHash("sha1").update(`${input.rawData}${cached.sessionKey}`, "utf8").digest("hex");
+  return digest === input.signature.trim().toLowerCase() ? cached : null;
+}
+
+export function decryptWechatPhoneNumber(input: {
+  playerId: string;
+  encryptedData: string;
+  iv: string;
+  expectedAppId?: string | undefined;
+}): { cache: CachedWechatSessionKeySnapshot; payload: WechatPhoneNumberPayload } | null {
+  const cache = getCachedWechatSessionKey(input.playerId);
+  if (!cache) {
+    return null;
+  }
+
+  try {
+    const sessionKeyBuffer = Buffer.from(normalizeBase64Field(cache.sessionKey, "sessionKey"), "base64");
+    const ivBuffer = Buffer.from(normalizeBase64Field(input.iv, "iv"), "base64");
+    const encryptedBuffer = Buffer.from(normalizeBase64Field(input.encryptedData, "encryptedData"), "base64");
+    const decipher = createDecipheriv("aes-128-cbc", sessionKeyBuffer, ivBuffer);
+    decipher.setAutoPadding(true);
+    const decoded = Buffer.concat([decipher.update(encryptedBuffer), decipher.final()]).toString("utf8");
+    const payload = JSON.parse(decoded) as WechatPhoneNumberPayload;
+    const appId = payload.watermark?.appid?.trim();
+    if (input.expectedAppId?.trim() && appId && appId !== input.expectedAppId.trim()) {
+      return null;
+    }
+    return {
+      cache,
+      payload
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createCipheriv } from "node:crypto";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
 import test from "node:test";
@@ -16,6 +17,7 @@ import {
 import { configureRoomSnapshotStore, VeilColyseusRoom } from "../src/colyseus-room";
 import { registerRuntimeObservabilityRoutes, resetRuntimeObservability } from "../src/observability";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
+import { resetWechatSessionKeyCache } from "../src/wechat-session-key";
 import type {
   PlayerAccountBanHistoryListOptions,
   PlayerAccountBanInput,
@@ -161,6 +163,8 @@ class MemoryAuthStore implements RoomSnapshotStore {
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
       ...(existing?.credentialBoundAt ? { credentialBoundAt: existing.credentialBoundAt } : {}),
       ...(existing?.privacyConsentAt ? { privacyConsentAt: existing.privacyConsentAt } : {}),
+      ...(existing?.phoneNumber ? { phoneNumber: existing.phoneNumber } : {}),
+      ...(existing?.phoneNumberBoundAt ? { phoneNumberBoundAt: existing.phoneNumberBoundAt } : {}),
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -378,6 +382,20 @@ class MemoryAuthStore implements RoomSnapshotStore {
         : existing.lastRoomId
           ? { lastRoomId: existing.lastRoomId }
           : {}),
+      ...(patch.phoneNumber !== undefined
+        ? patch.phoneNumber?.trim()
+          ? { phoneNumber: patch.phoneNumber.trim() }
+          : {}
+        : existing.phoneNumber
+          ? { phoneNumber: existing.phoneNumber }
+          : {}),
+      ...(patch.phoneNumberBoundAt !== undefined
+        ? patch.phoneNumberBoundAt?.trim()
+          ? { phoneNumberBoundAt: patch.phoneNumberBoundAt.trim() }
+          : {}
+        : existing.phoneNumberBoundAt
+          ? { phoneNumberBoundAt: existing.phoneNumberBoundAt }
+          : {}),
       updatedAt: new Date().toISOString()
     };
     this.accounts.set(account.playerId, account);
@@ -487,6 +505,32 @@ async function startAuthServer(port: number, store: RoomSnapshotStore | null = n
   server.define("veil", VeilColyseusRoom).filterBy(["logicalRoomId"]);
   await server.listen(port, "127.0.0.1");
   return server;
+}
+
+function createWechatPhonePayload(input: {
+  sessionKey: string;
+  appId: string;
+  phoneNumber: string;
+}): { encryptedData: string; iv: string } {
+  const iv = Buffer.from("1234567890abcdef", "utf8").toString("base64");
+  const cipher = createCipheriv(
+    "aes-128-cbc",
+    Buffer.from(input.sessionKey, "base64"),
+    Buffer.from(iv, "base64")
+  );
+  cipher.setAutoPadding(true);
+  const payload = JSON.stringify({
+    phoneNumber: input.phoneNumber,
+    purePhoneNumber: input.phoneNumber.replace(/^\+\d+/, ""),
+    countryCode: "86",
+    watermark: {
+      appid: input.appId
+    }
+  });
+  return {
+    encryptedData: Buffer.concat([cipher.update(payload, "utf8"), cipher.final()]).toString("base64"),
+    iv
+  };
 }
 
 async function joinRoom(port: number, logicalRoomId: string, playerId: string): Promise<ColyseusRoom> {
@@ -2984,6 +3028,119 @@ test("wechat mini game login reuses the bound player even when later requests sp
   assert.equal(boundAccount?.wechatMiniGameOpenId, "wx-openid-repeat");
   assert.equal(boundAccount?.displayName, "回归旅人");
   assert.equal(spoofedAccount, null);
+});
+
+test("wechat session key refresh restores phone binding after cached session expiry", { concurrency: false }, async (t) => {
+  const port = 45070 + Math.floor(Math.random() * 1000);
+  const previousAppId = process.env.WECHAT_APP_ID;
+  const previousTtl = process.env.VEIL_WECHAT_SESSION_KEY_TTL_SECONDS;
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+  const originalFetch = globalThis.fetch;
+
+  t.after(async () => {
+    globalThis.fetch = originalFetch;
+    process.env.WECHAT_APP_ID = previousAppId;
+    process.env.VEIL_WECHAT_SESSION_KEY_TTL_SECONDS = previousTtl;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
+    delete process.env.WECHAT_APP_SECRET;
+    delete process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL;
+    resetWechatSessionKeyCache();
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "production";
+  process.env.WECHAT_APP_ID = "wx-refresh-app";
+  process.env.WECHAT_APP_SECRET = "wx-refresh-secret";
+  process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL = "https://wechat.example.test/code2session";
+  process.env.VEIL_WECHAT_SESSION_KEY_TTL_SECONDS = "1";
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    const code = url.searchParams.get("js_code");
+    const sessionKey =
+      code === "wx-refresh-code"
+        ? Buffer.from("fedcba0987654321", "utf8").toString("base64")
+        : Buffer.from("1234567890abcdef", "utf8").toString("base64");
+    return new Response(
+      JSON.stringify({
+        openid: "wx-openid-refresh",
+        session_key: sessionKey
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+  };
+
+  const loginResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      code: "wx-login-code",
+      playerId: "wechat-refresh-player",
+      displayName: "刷新旅人",
+      privacyConsentAccepted: true
+    })
+  });
+  const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
+  assert.equal(loginResponse.status, 200);
+
+  await new Promise((resolve) => setTimeout(resolve, 1_100));
+
+  const expiredPhoneResponse = await originalFetch(`http://127.0.0.1:${port}/api/player-accounts/me/phone`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${loginPayload.session.token}`
+    },
+    body: JSON.stringify(
+      createWechatPhonePayload({
+        sessionKey: Buffer.from("1234567890abcdef", "utf8").toString("base64"),
+        appId: "wx-refresh-app",
+        phoneNumber: "+8613800138001"
+      })
+    )
+  });
+  assert.equal(expiredPhoneResponse.status, 403);
+
+  const refreshResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-session-key/refresh`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${loginPayload.session.token}`
+    },
+    body: JSON.stringify({
+      code: "wx-refresh-code"
+    })
+  });
+  assert.equal(refreshResponse.status, 200);
+
+  const reboundPhoneResponse = await originalFetch(`http://127.0.0.1:${port}/api/player-accounts/me/phone`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${loginPayload.session.token}`
+    },
+    body: JSON.stringify(
+      createWechatPhonePayload({
+        sessionKey: Buffer.from("fedcba0987654321", "utf8").toString("base64"),
+        appId: "wx-refresh-app",
+        phoneNumber: "+8613800138002"
+      })
+    )
+  });
+  const reboundPayload = (await reboundPhoneResponse.json()) as {
+    account: PlayerAccountSnapshot;
+  };
+
+  assert.equal(reboundPhoneResponse.status, 200);
+  assert.equal(reboundPayload.account.phoneNumber, "+8613800138002");
 });
 
 test("wechat mock mode stays disabled outside NODE_ENV=test", { concurrency: false }, async (t) => {

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
+import { createCipheriv, createHash } from "node:crypto";
 import test from "node:test";
 import { Server, WebSocketTransport } from "colyseus";
 import { issueAccountAuthSession, issueGuestAuthSession, issueWechatMiniGameAuthSession, hashAccountPassword } from "../src/auth";
 import { applyPlayerEventLogAndAchievements } from "../src/player-achievements";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
+import { cacheWechatSessionKey, resetWechatSessionKeyCache } from "../src/wechat-session-key";
 import type {
   PlayerAccountBanHistoryListOptions,
   PlayerAccountBanInput,
@@ -162,6 +164,8 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
       ...(existing?.credentialBoundAt ? { credentialBoundAt: existing.credentialBoundAt } : {}),
       ...(existing?.privacyConsentAt ? { privacyConsentAt: existing.privacyConsentAt } : {}),
+      ...(existing?.phoneNumber ? { phoneNumber: existing.phoneNumber } : {}),
+      ...(existing?.phoneNumberBoundAt ? { phoneNumberBoundAt: existing.phoneNumberBoundAt } : {}),
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -384,6 +388,20 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
         : existing.lastRoomId
           ? { lastRoomId: existing.lastRoomId }
           : {}),
+      ...(patch.phoneNumber !== undefined
+        ? patch.phoneNumber?.trim()
+          ? { phoneNumber: patch.phoneNumber.trim() }
+          : {}
+        : existing.phoneNumber
+          ? { phoneNumber: existing.phoneNumber }
+          : {}),
+      ...(patch.phoneNumberBoundAt !== undefined
+        ? patch.phoneNumberBoundAt?.trim()
+          ? { phoneNumberBoundAt: patch.phoneNumberBoundAt.trim() }
+          : {}
+        : existing.phoneNumberBoundAt
+          ? { phoneNumberBoundAt: existing.phoneNumberBoundAt }
+          : {}),
       updatedAt: new Date().toISOString()
     };
     this.accounts.set(playerId, account);
@@ -503,6 +521,39 @@ async function startAccountRouteServer(port: number, store: RoomSnapshotStore | 
   const server = new Server({ transport });
   await server.listen(port, "127.0.0.1");
   return server;
+}
+
+function createWechatProfileSignature(rawData: string, sessionKey: string): string {
+  return createHash("sha1").update(`${rawData}${sessionKey}`, "utf8").digest("hex");
+}
+
+function createWechatPhonePayload(input: {
+  sessionKey: string;
+  appId: string;
+  phoneNumber: string;
+  purePhoneNumber?: string;
+  countryCode?: string;
+}): { encryptedData: string; iv: string } {
+  const iv = Buffer.from("1234567890abcdef", "utf8").toString("base64");
+  const cipher = createCipheriv(
+    "aes-128-cbc",
+    Buffer.from(input.sessionKey, "base64"),
+    Buffer.from(iv, "base64")
+  );
+  cipher.setAutoPadding(true);
+  const payload = JSON.stringify({
+    phoneNumber: input.phoneNumber,
+    purePhoneNumber: input.purePhoneNumber ?? input.phoneNumber.replace(/^\+\d+/, ""),
+    countryCode: input.countryCode ?? "86",
+    watermark: {
+      appid: input.appId
+    }
+  });
+  const encryptedData = Buffer.concat([cipher.update(payload, "utf8"), cipher.final()]).toString("base64");
+  return {
+    encryptedData,
+    iv
+  };
 }
 
 function createAccountTrackingWorldState(): WorldState {
@@ -2005,6 +2056,135 @@ test("player account me routes resolve and update the current authenticated acco
   const stored = await store.loadPlayerAccount("player-me");
   assert.equal(stored?.displayName, "风暴司灯人");
   assert.equal(stored?.lastRoomId, "room-next");
+});
+
+test("wechat account profile updates require a valid cached session-key signature", async (t) => {
+  const port = 42040 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "wechat-profile",
+    displayName: "云潮旅人",
+    globalResources: { gold: 0, wood: 0, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    wechatMiniGameOpenId: "wx-openid-profile"
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueWechatMiniGameAuthSession({
+    playerId: "wechat-profile",
+    displayName: "云潮旅人"
+  });
+  const sessionKey = Buffer.from("1234567890abcdef", "utf8").toString("base64");
+
+  t.after(async () => {
+    resetWechatSessionKeyCache();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  cacheWechatSessionKey("wechat-profile", sessionKey, 60);
+
+  const invalidResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      displayName: "未授权改名",
+      wechatSignature: {
+        rawData: "{\"op\":\"profile-update\"}",
+        signature: "bad-signature"
+      }
+    })
+  });
+  assert.equal(invalidResponse.status, 403);
+
+  const rawData = "{\"op\":\"profile-update\"}";
+  const validResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      displayName: "已验签旅人",
+      wechatSignature: {
+        rawData,
+        signature: createWechatProfileSignature(rawData, sessionKey)
+      }
+    })
+  });
+  const validPayload = (await validResponse.json()) as {
+    account: PlayerAccountSnapshot;
+  };
+
+  assert.equal(validResponse.status, 200);
+  assert.equal(validPayload.account.displayName, "已验签旅人");
+});
+
+test("wechat phone binding returns 403 for invalid payloads and succeeds after validation", async (t) => {
+  const port = 42080 + Math.floor(Math.random() * 1000);
+  const previousAppId = process.env.WECHAT_APP_ID;
+  process.env.WECHAT_APP_ID = "wx-phone-test-app";
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "wechat-phone",
+    displayName: "手机号旅人",
+    globalResources: { gold: 0, wood: 0, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    wechatMiniGameOpenId: "wx-openid-phone"
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueWechatMiniGameAuthSession({
+    playerId: "wechat-phone",
+    displayName: "手机号旅人"
+  });
+  const sessionKey = Buffer.from("abcdef1234567890", "utf8").toString("base64");
+
+  t.after(async () => {
+    process.env.WECHAT_APP_ID = previousAppId;
+    resetWechatSessionKeyCache();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  cacheWechatSessionKey("wechat-phone", sessionKey, 60);
+
+  const invalidResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/phone`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      encryptedData: Buffer.from("invalid-phone-payload", "utf8").toString("base64"),
+      iv: Buffer.from("1234567890abcdef", "utf8").toString("base64")
+    })
+  });
+  assert.equal(invalidResponse.status, 403);
+
+  const encrypted = createWechatPhonePayload({
+    sessionKey,
+    appId: "wx-phone-test-app",
+    phoneNumber: "+8613800138000"
+  });
+  const successResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/phone`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify(encrypted)
+  });
+  const successPayload = (await successResponse.json()) as {
+    account: PlayerAccountSnapshot;
+    phone: { phoneNumber: string };
+  };
+
+  assert.equal(successResponse.status, 200);
+  assert.equal(successPayload.phone.phoneNumber, "+8613800138000");
+  assert.equal(successPayload.account.phoneNumber, "+8613800138000");
+  assert.match(successPayload.account.phoneNumberBoundAt ?? "", /^\d{4}-\d{2}-\d{2}T/);
 });
 
 test("player account me route preserves account-mode sessions and returns the global vault", async (t) => {

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -28,6 +28,8 @@ export interface PlayerAccountReadModel {
   loginId?: string;
   credentialBoundAt?: string;
   privacyConsentAt?: string;
+  phoneNumber?: string;
+  phoneNumberBoundAt?: string;
   ageVerified?: boolean;
   isMinor?: boolean;
   dailyPlayMinutes?: number;
@@ -52,6 +54,8 @@ export interface PlayerAccountReadModelInput {
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
   privacyConsentAt?: string | undefined;
+  phoneNumber?: string | undefined;
+  phoneNumberBoundAt?: string | undefined;
   ageVerified?: boolean | undefined;
   isMinor?: boolean | undefined;
   dailyPlayMinutes?: number | undefined;
@@ -72,6 +76,8 @@ export function normalizePlayerAccountReadModel(
   const loginId = account?.loginId?.trim().toLowerCase();
   const credentialBoundAt = account?.credentialBoundAt?.trim();
   const privacyConsentAt = account?.privacyConsentAt?.trim();
+  const phoneNumber = account?.phoneNumber?.trim();
+  const phoneNumberBoundAt = account?.phoneNumberBoundAt?.trim();
   const ageVerified = account?.ageVerified === true;
   const isMinor = account?.isMinor === true;
   const dailyPlayMinutes = Math.max(0, Math.floor(account?.dailyPlayMinutes ?? 0));
@@ -106,6 +112,8 @@ export function normalizePlayerAccountReadModel(
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(privacyConsentAt ? { privacyConsentAt } : {}),
+    ...(phoneNumber ? { phoneNumber } : {}),
+    ...(phoneNumberBoundAt ? { phoneNumberBoundAt } : {}),
     ...(ageVerified ? { ageVerified } : {}),
     ...(isMinor ? { isMinor } : {}),
     ...(dailyPlayMinutes > 0 ? { dailyPlayMinutes } : {}),


### PR DESCRIPTION
Closes #774

## Summary
- cache WeChat `session_key` values per player with TTL-aligned expiry on login and a dedicated refresh endpoint for re-login flows
- require cached WeChat session-key validation for sensitive account updates and add a phone binding endpoint that decrypts `wx.getPhoneNumber` payloads
- persist bound phone metadata on player accounts and log signature/decryption failures server-side

## Tests
- `npm run typecheck:server`
- `node --import tsx --test --test-name-pattern="wechat|player account me routes resolve and update the current authenticated account|player account me route preserves account-mode sessions and returns the global vault" apps/server/test/auth-guest-login.test.ts apps/server/test/player-account-routes.test.ts`