### PR TITLE
feat: add battle AOE, healing, control, and terrain skills

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -339,7 +339,8 @@ export class AuthoritativeWorldRoom {
         const battle = createNeutralBattleState(
           hero,
           neutralArmy,
-          this.createBattleSeed(battleEvent.battleId)
+          this.createBattleSeed(battleEvent.battleId),
+          this.state
         );
         this.trackStartedBattle(battle);
         startedBattleIds.push(battle.id);
@@ -355,7 +356,8 @@ export class AuthoritativeWorldRoom {
         const battle = createHeroBattleState(
           hero,
           defenderHero,
-          this.createBattleSeed(battleEvent.battleId)
+          this.createBattleSeed(battleEvent.battleId),
+          this.state
         );
         this.trackStartedBattle(battle);
         startedBattleIds.push(battle.id);

--- a/configs/battle-skills.json
+++ b/configs/battle-skills.json
@@ -175,6 +175,81 @@
       "effects": {
         "grantedStatusId": "watchful_guard"
       }
+    },
+    {
+      "id": "war_cry",
+      "name": "战吼震荡",
+      "description": "正面打击主目标，并以余波震伤相邻敌军。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 0.5
+      }
+    },
+    {
+      "id": "field_mending",
+      "name": "战地缝合",
+      "description": "根据施法者的 power 恢复己方单位生命。",
+      "kind": "active",
+      "target": "ally",
+      "delivery": "ranged",
+      "cooldown": 2,
+      "effects": {}
+    },
+    {
+      "id": "rally_morale",
+      "name": "鼓舞军心",
+      "description": "恢复少量生命，并解除一个负面状态。",
+      "kind": "active",
+      "target": "ally",
+      "delivery": "ranged",
+      "cooldown": 3,
+      "effects": {}
+    },
+    {
+      "id": "stunning_blow",
+      "name": "震荡猛击",
+      "description": "重击敌军并附加短暂眩晕。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 0.9,
+        "onHitStatusId": "stunned"
+      }
+    },
+    {
+      "id": "taunt_shout",
+      "name": "嘲阵怒喝",
+      "description": "激怒敌军，迫使其下次行动优先攻击施放者。",
+      "kind": "active",
+      "target": "enemy",
+      "delivery": "ranged",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 0.6,
+        "allowRetaliation": false,
+        "onHitStatusId": "taunted"
+      }
+    },
+    {
+      "id": "terrain_mastery",
+      "name": "地形精通",
+      "description": "在草地上进攻更猛，在水泽地带更耐打。",
+      "kind": "passive",
+      "target": "self",
+      "cooldown": 0,
+      "effects": {}
+    },
+    {
+      "id": "bog_ambush",
+      "name": "泥沼伏袭",
+      "description": "只有在水泽地形中才能发动，伤害显著提升。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 3,
+      "effects": {}
     }
   ],
   "statuses": [
@@ -287,6 +362,30 @@
       "damagePerTurn": 0,
       "initiativeModifier": -1,
       "blocksActiveSkills": false
+    },
+    {
+      "id": "stunned",
+      "name": "眩晕",
+      "description": "本回合无法行动。",
+      "duration": 1,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false,
+      "preventsAction": true
+    },
+    {
+      "id": "taunted",
+      "name": "嘲讽",
+      "description": "下次行动会被迫优先攻击施放者。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false,
+      "forcedAttackSource": true
     }
   ]
 }

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -12,8 +12,10 @@ import type {
   BattleStatusEffectState,
   HeroState,
   NeutralArmyState,
+  TerrainType,
   UnitStack,
-  ValidationResult
+  ValidationResult,
+  WorldState
 } from "./models.ts";
 import { validateAction } from "./action-precheck.ts";
 import { nextDeterministicRandom } from "./deterministic-rng.ts";
@@ -213,7 +215,9 @@ function createStatusEffectState(
     defenseModifier: definition.defenseModifier,
     damagePerTurn: definition.damagePerTurn,
     initiativeModifier: definition.initiativeModifier ?? 0,
-    blocksActiveSkills: definition.blocksActiveSkills ?? false
+    blocksActiveSkills: definition.blocksActiveSkills ?? false,
+    preventsAction: definition.preventsAction ?? false,
+    forcedAttackSource: definition.forcedAttackSource ?? false
   }, "sourceUnitId", sourceUnitId);
 }
 
@@ -246,6 +250,18 @@ function effectiveInitiative(unit: UnitStack): number {
 
 function canUseActiveSkills(unit: UnitStack): boolean {
   return statusEffectsOf(unit).every((status) => !status.blocksActiveSkills);
+}
+
+function preventsAction(unit: UnitStack): boolean {
+  return statusEffectsOf(unit).some((status) => status.preventsAction);
+}
+
+function hasBattleSkill(unit: UnitStack, skillId: BattleSkillId): boolean {
+  return skillsOf(unit).some((skill) => skill.id === skillId);
+}
+
+function battlefieldTerrainOf(state: BattleState): TerrainType {
+  return state.battlefieldTerrain ?? "grass";
 }
 
 function describeHazard(hazard: BattleHazardState, catalogIndex: BattleCatalogIndex = getBattleCatalogIndex()): string {
@@ -359,11 +375,25 @@ function totalDefenseModifier(unit: UnitStack): number {
   return statusEffectsOf(unit).reduce((total, status) => total + status.defenseModifier, 0);
 }
 
-function estimateDamage(attacker: UnitStack, defender: UnitStack, randomValue: number, multiplier = 1): number {
+function terrainDefenseBonus(unit: UnitStack, state: BattleState): number {
+  return hasBattleSkill(unit, "terrain_mastery") && battlefieldTerrainOf(state) === "water" ? 2 : 0;
+}
+
+function terrainDamageMultiplier(unit: UnitStack, state: BattleState): number {
+  return hasBattleSkill(unit, "terrain_mastery") && battlefieldTerrainOf(state) === "grass" ? 1.1 : 1;
+}
+
+function estimateDamage(
+  attacker: UnitStack,
+  defender: UnitStack,
+  randomValue: number,
+  state: BattleState,
+  multiplier = 1
+): number {
   const balance = getBattleBalanceConfig().damage;
   const defenseBonus = defender.defending ? balance.defendingDefenseBonus : 0;
   const effectiveAttack = attacker.attack + totalAttackModifier(attacker);
-  const effectiveDefense = defender.defense + totalDefenseModifier(defender) + defenseBonus;
+  const effectiveDefense = defender.defense + totalDefenseModifier(defender) + defenseBonus + terrainDefenseBonus(defender, state);
   const offenseModifier = 1 + (effectiveAttack - effectiveDefense) * balance.offenseAdvantageStep;
   const variance = balance.varianceBase + randomValue * balance.varianceRange;
   return Math.max(
@@ -373,7 +403,8 @@ function estimateDamage(attacker: UnitStack, defender: UnitStack, randomValue: n
         averageDamage(attacker) *
         Math.max(balance.minimumOffenseMultiplier, offenseModifier) *
         variance *
-        multiplier
+        multiplier *
+        terrainDamageMultiplier(attacker, state)
     )
   );
 }
@@ -395,6 +426,22 @@ function applyDamage(target: UnitStack, damage: number): UnitStack {
     ...target,
     count: survivingCount,
     currentHp
+  };
+}
+
+function applyHealing(target: UnitStack, amount: number): UnitStack {
+  if (target.count <= 0 || amount <= 0) {
+    return target;
+  }
+
+  const hpPool = (target.count - 1) * target.maxHp + target.currentHp;
+  const maxHpPool = target.count * target.maxHp;
+  const healedHpPool = Math.min(maxHpPool, hpPool + amount);
+  const currentHp = healedHpPool - (target.count - 1) * target.maxHp;
+
+  return {
+    ...target,
+    currentHp: currentHp > 0 ? currentHp : target.maxHp
   };
 }
 
@@ -555,6 +602,50 @@ function hasStatusEffect(unit: UnitStack, statusId: BattleStatusEffectId): boole
   return statusEffectsOf(unit).some((status) => status.id === statusId);
 }
 
+function isNegativeStatusEffect(status: BattleStatusEffectState): boolean {
+  return !!(
+    status.attackModifier < 0 ||
+    status.defenseModifier < 0 ||
+    status.damagePerTurn > 0 ||
+    status.initiativeModifier < 0 ||
+    status.blocksActiveSkills ||
+    status.preventsAction ||
+    status.forcedAttackSource
+  );
+}
+
+function removeFirstNegativeStatus(unit: UnitStack): { unit: UnitStack; removedStatus?: BattleStatusEffectState } {
+  const statuses = statusEffectsOf(unit);
+  const removedStatus = statuses.find(isNegativeStatusEffect);
+  if (!removedStatus) {
+    return { unit };
+  }
+
+  return {
+    unit: {
+      ...unit,
+      statusEffects: statuses.filter((status) => status !== removedStatus)
+    },
+    removedStatus
+  };
+}
+
+function forcedAttackTargetId(unit: UnitStack, state: BattleState): string | null {
+  const forcedStatus = [...statusEffectsOf(unit)]
+    .reverse()
+    .find((status) => status.forcedAttackSource && status.sourceUnitId);
+  if (!forcedStatus?.sourceUnitId) {
+    return null;
+  }
+
+  const source = state.units[forcedStatus.sourceUnitId];
+  if (!source || source.count <= 0 || source.camp === unit.camp) {
+    return null;
+  }
+
+  return source.id;
+}
+
 function isActiveSkillReady(skill: BattleSkillState): boolean {
   return skill.kind === "active" && skill.remainingCooldown === 0;
 }
@@ -596,7 +687,62 @@ export function pickAutomatedBattleAction(state: BattleState): BattleAction | nu
   }
 
   const catalogIndex = getBattleCatalogIndex();
+  const forcedTargetId = forcedAttackTargetId(activeUnit, state);
+  if (forcedTargetId) {
+    return {
+      type: "battle.attack",
+      attackerId: activeUnit.id,
+      defenderId: forcedTargetId
+    };
+  }
+
   const readySkills = canUseActiveSkills(activeUnit) ? skillsOf(activeUnit).filter(isActiveSkillReady) : [];
+  const alliedUnits = Object.values(state.units).filter((unit) => unit.camp === activeUnit.camp && unit.count > 0);
+
+  for (const skill of readySkills) {
+    if (skill.target !== "ally") {
+      continue;
+    }
+
+    if (skill.id === "field_mending") {
+      const woundedTarget = alliedUnits
+        .filter((unit) => unit.currentHp < unit.maxHp)
+        .sort((left, right) => left.currentHp - right.currentHp)[0];
+      if (woundedTarget) {
+        return {
+          type: "battle.skill",
+          unitId: activeUnit.id,
+          skillId: skill.id,
+          targetId: woundedTarget.id
+        };
+      }
+      continue;
+    }
+
+    if (skill.id === "rally_morale") {
+      const cleansableTarget = alliedUnits.find((unit) => statusEffectsOf(unit).some(isNegativeStatusEffect));
+      if (cleansableTarget) {
+        return {
+          type: "battle.skill",
+          unitId: activeUnit.id,
+          skillId: skill.id,
+          targetId: cleansableTarget.id
+        };
+      }
+
+      const woundedTarget = alliedUnits
+        .filter((unit) => unit.currentHp < unit.maxHp)
+        .sort((left, right) => left.currentHp - right.currentHp)[0];
+      if (woundedTarget) {
+        return {
+          type: "battle.skill",
+          unitId: activeUnit.id,
+          skillId: skill.id,
+          targetId: woundedTarget.id
+        };
+      }
+    }
+  }
 
   for (const skill of readySkills) {
     if (skill.target !== "self") {
@@ -837,6 +983,7 @@ function prepareStateForActiveUnit(state: BattleState): BattleState {
   while (nextState.activeUnitId && remainingIterations > 0) {
     remainingIterations -= 1;
     const activeUnit = nextState.units[nextState.activeUnitId]!;
+    const unitPreventsAction = preventsAction(activeUnit);
 
     const processed = processTurnStartForUnit(activeUnit);
     nextState = withUpdatedUnitCooldowns(
@@ -846,6 +993,15 @@ function prepareStateForActiveUnit(state: BattleState): BattleState {
       },
       processed.unit
     );
+
+    if (processed.unit.count > 0 && unitPreventsAction) {
+      nextState = {
+        ...nextState,
+        log: nextState.log.concat(`${processed.unit.stackName} 因负面状态跳过行动`)
+      };
+      nextState = advanceTurnInternal(nextState, activeUnit.id, false);
+      continue;
+    }
 
     if (processed.unit.count > 0) {
       break;
@@ -999,7 +1155,13 @@ function applyAttackSequence(
   const attacker = preparedState.state.units[attackerId]!;
   const defender = preparedState.state.units[defenderId]!;
   const attackRoll = nextDeterministicRandom(preparedState.state.rng.seed);
-  const attackDamage = estimateDamage(attacker, defender, attackRoll.value, options?.damageMultiplier ?? 1);
+  const attackDamage = estimateDamage(
+    attacker,
+    defender,
+    attackRoll.value,
+    preparedState.state,
+    options?.damageMultiplier ?? 1
+  );
   const nextUnits: Record<string, UnitStack> = {
     ...preparedState.state.units,
     [defender.id]: applyDamage(defender, attackDamage)
@@ -1022,9 +1184,29 @@ function applyAttackSequence(
   );
   nextUnits[defender.id] = damagedDefender;
 
+  const splashSkillDefinition =
+    options?.skillId && options.skillId === "war_cry"
+      ? skillDefinitionFor(options.skillId, catalogIndex)
+      : null;
+  const splashMultiplier =
+    splashSkillDefinition && damagedDefender.count > 0
+      ? splashSkillDefinition.effects?.damageMultiplier ?? 0.5
+      : 0;
+  if (splashMultiplier > 0) {
+    const adjacentEnemies = Object.values(nextUnits)
+      .filter((unit) => unit.camp === damagedDefender.camp && unit.id !== damagedDefender.id && unit.count > 0)
+      .filter((unit) => Math.abs(unit.lane - damagedDefender.lane) === 1);
+
+    for (const adjacentEnemy of adjacentEnemies) {
+      const splashDamage = Math.max(1, Math.floor(attackDamage * splashMultiplier));
+      nextUnits[adjacentEnemy.id] = applyDamage(adjacentEnemy, splashDamage);
+      log.push(`${attacker.stackName} 的${splashSkillDefinition!.name}波及 ${adjacentEnemy.stackName}，造成 ${splashDamage} 伤害`);
+    }
+  }
+
   if ((options?.allowRetaliation ?? true) && damagedDefender.count > 0 && !damagedDefender.hasRetaliated) {
     const retaliationRoll = nextDeterministicRandom(nextRngState.seed);
-    const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value);
+    const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value, preparedState.state);
     let damagedAttacker = applyDamage(attacker, retaliationDamage);
     damagedAttacker = applyOnHitStatuses(damagedDefender, damagedAttacker, log, catalogIndex);
     nextUnits[attacker.id] = damagedAttacker;
@@ -1078,7 +1260,51 @@ export function executeBattleSkill(
   const casterWithCooldown = setSkillCooldown(caster, skillId);
   const stateWithCooldown = withUpdatedUnitCooldowns(normalizedState, casterWithCooldown);
 
+  if (skillDefinition.target === "ally" && targetId) {
+    const allyTarget = normalizedState.units[targetId]!;
+    let nextTarget = allyTarget;
+    const log = [...normalizedState.log];
+
+    if (skillId === "field_mending") {
+      const healingAmount = Math.max(2, 4 + (caster.power ?? 0) * 3);
+      nextTarget = applyHealing(nextTarget, healingAmount);
+      log.push(`${caster.stackName} 施放 ${skillDefinition.name}，为 ${allyTarget.stackName} 恢复 ${healingAmount} 生命`);
+    } else if (skillId === "rally_morale") {
+      const healingAmount = Math.max(1, 2 + (caster.power ?? 0) * 2);
+      nextTarget = applyHealing(nextTarget, healingAmount);
+      const moraleResult = removeFirstNegativeStatus(nextTarget);
+      nextTarget = moraleResult.unit;
+      log.push(
+        moraleResult.removedStatus
+          ? `${caster.stackName} 施放 ${skillDefinition.name}，为 ${allyTarget.stackName} 恢复 ${healingAmount} 生命并解除 ${moraleResult.removedStatus.name}`
+          : `${caster.stackName} 施放 ${skillDefinition.name}，为 ${allyTarget.stackName} 恢复 ${healingAmount} 生命`
+      );
+    } else {
+      log.push(`${caster.stackName} 施放 ${skillDefinition.name}`);
+    }
+
+    return advanceTurn(
+      {
+        ...withUpdatedUnitCooldowns(stateWithCooldown, casterWithCooldown),
+        units: {
+          ...stateWithCooldown.units,
+          [nextTarget.id]: nextTarget
+        },
+        log
+      },
+      caster.id,
+      false
+    );
+  }
+
   if (skillDefinition.target === "enemy" && targetId) {
+    if (skillId === "bog_ambush" && battlefieldTerrainOf(normalizedState) !== "water") {
+      return {
+        ...stateWithCooldown,
+        log: normalizedState.log.concat(`Action rejected: skill_requires_water_terrain`)
+      };
+    }
+
     return applyAttackSequence(
       {
         ...stateWithCooldown
@@ -1086,7 +1312,10 @@ export function executeBattleSkill(
       caster.id,
       targetId,
       {
-        damageMultiplier: skillDefinition.effects?.damageMultiplier ?? 1,
+        damageMultiplier:
+          skillId === "bog_ambush"
+            ? 2
+            : skillDefinition.effects?.damageMultiplier ?? 1,
         allowRetaliation: skillDefinition.effects?.allowRetaliation ?? true,
         delivery: isContactSkillDefinition(skillDefinition) ? "contact" : "ranged",
         logPrefix: `${caster.stackName} 施放 ${skillDefinition.name}，对 ${normalizedState.units[targetId]!.stackName}`,
@@ -1137,6 +1366,10 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
       return { valid: false, reason: "unit_not_available" };
     }
 
+    if (forcedAttackTargetId(unit, state)) {
+      return { valid: false, reason: "taunted_must_attack_source" };
+    }
+
     return { valid: true };
   }
 
@@ -1163,10 +1396,34 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
       return { valid: false, reason: "skill_on_cooldown" };
     }
 
+    const forcedTargetId = forcedAttackTargetId(unit, state);
+    if (forcedTargetId) {
+      if (skill.target !== "enemy" || action.targetId !== forcedTargetId) {
+        return { valid: false, reason: "taunted_must_attack_source" };
+      }
+    }
+
     if (skill.target === "self") {
       if (action.targetId && action.targetId !== unit.id) {
         return { valid: false, reason: "invalid_skill_target" };
       }
+      return { valid: true };
+    }
+
+    if (skill.target === "ally") {
+      if (!action.targetId) {
+        return { valid: false, reason: "skill_target_missing" };
+      }
+
+      const target = state.units[action.targetId];
+      if (!target || target.count <= 0) {
+        return { valid: false, reason: "ally_not_available" };
+      }
+
+      if (target.camp !== unit.camp) {
+        return { valid: false, reason: "invalid_skill_target" };
+      }
+
       return { valid: true };
     }
 
@@ -1198,6 +1455,11 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
 
   if (!defender || defender.count <= 0) {
     return { valid: false, reason: "defender_not_available" };
+  }
+
+  const forcedTargetId = attacker ? forcedAttackTargetId(attacker, state) : null;
+  if (forcedTargetId && forcedTargetId !== action.defenderId) {
+    return { valid: false, reason: "taunted_must_attack_source" };
   }
 
   if (attacker.camp === defender.camp) {
@@ -1293,11 +1555,23 @@ export function createDemoBattleState(): BattleState {
     rng: {
       seed: 4242,
       cursor: 0
-    }
+    },
+    battlefieldTerrain: "grass"
   };
 }
 
-export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralArmyState, seed: number): BattleState {
+function terrainAtPosition(world: WorldState | undefined, position: { x: number; y: number }): TerrainType {
+  return world?.map.tiles.find(
+    (tile) => tile.position.x === position.x && tile.position.y === position.y
+  )?.terrain ?? "grass";
+}
+
+export function createNeutralBattleState(
+  hero: HeroState,
+  neutralArmy: NeutralArmyState,
+  seed: number,
+  world?: WorldState
+): BattleState {
   const units: Record<string, UnitStack> = {};
   const catalog = getDefaultUnitCatalog();
   const battleCatalogIndex = getBattleCatalogIndex();
@@ -1327,6 +1601,7 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
       count: hero.armyCount,
       currentHp: heroTemplate.maxHp,
       maxHp: heroTemplate.maxHp,
+      power: hero.stats.power,
       hasRetaliated: false,
       defending: false
     },
@@ -1381,11 +1656,17 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
     },
     worldHeroId: hero.id,
     neutralArmyId: neutralArmy.id,
-    encounterPosition: neutralArmy.position
+    encounterPosition: neutralArmy.position,
+    battlefieldTerrain: terrainAtPosition(world, neutralArmy.position)
   };
 }
 
-export function createHeroBattleState(attackerHero: HeroState, defenderHero: HeroState, seed: number): BattleState {
+export function createHeroBattleState(
+  attackerHero: HeroState,
+  defenderHero: HeroState,
+  seed: number,
+  world?: WorldState
+): BattleState {
   const catalog = getDefaultUnitCatalog();
   const battleCatalogIndex = getBattleCatalogIndex();
   const templateById = new Map(catalog.templates.map((template) => [template.id, template]));
@@ -1417,14 +1698,15 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
         initiative: attackerTemplate.initiative,
         attack: attackerTemplate.attack + attackerHero.stats.attack + attackerEquipment.attack,
         defense: attackerTemplate.defense + attackerHero.stats.defense + attackerEquipment.defense,
-        minDamage: attackerTemplate.minDamage,
-        maxDamage: attackerTemplate.maxDamage,
-        count: attackerHero.armyCount,
-        currentHp: attackerTemplate.maxHp,
-        maxHp: attackerTemplate.maxHp,
-        hasRetaliated: false,
-        defending: false
-      },
+      minDamage: attackerTemplate.minDamage,
+      maxDamage: attackerTemplate.maxDamage,
+      count: attackerHero.armyCount,
+      currentHp: attackerTemplate.maxHp,
+      maxHp: attackerTemplate.maxHp,
+      power: attackerHero.stats.power,
+      hasRetaliated: false,
+      defending: false
+    },
       attackerBattleSkills,
       battleCatalogIndex
     ),
@@ -1438,14 +1720,15 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
         initiative: defenderTemplate.initiative,
         attack: defenderTemplate.attack + defenderHero.stats.attack + defenderEquipment.attack,
         defense: defenderTemplate.defense + defenderHero.stats.defense + defenderEquipment.defense,
-        minDamage: defenderTemplate.minDamage,
-        maxDamage: defenderTemplate.maxDamage,
-        count: defenderHero.armyCount,
-        currentHp: defenderTemplate.maxHp,
-        maxHp: defenderTemplate.maxHp,
-        hasRetaliated: false,
-        defending: false
-      },
+      minDamage: defenderTemplate.minDamage,
+      maxDamage: defenderTemplate.maxDamage,
+      count: defenderHero.armyCount,
+      currentHp: defenderTemplate.maxHp,
+      maxHp: defenderTemplate.maxHp,
+      power: defenderHero.stats.power,
+      hasRetaliated: false,
+      defending: false
+    },
       defenderBattleSkills,
       battleCatalogIndex
     )
@@ -1472,7 +1755,8 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
     },
     worldHeroId: attackerHero.id,
     defenderHeroId: defenderHero.id,
-    encounterPosition: defenderHero.position
+    encounterPosition: defenderHero.position,
+    battlefieldTerrain: terrainAtPosition(world, defenderHero.position)
   };
 }
 

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -422,7 +422,7 @@ export interface MovementPlan {
 
 export type BattleSkillId = string;
 export type BattleSkillKind = "active" | "passive";
-export type BattleSkillTarget = "enemy" | "self";
+export type BattleSkillTarget = "enemy" | "self" | "ally";
 export type BattleSkillDelivery = "contact" | "ranged";
 export type BattleStatusEffectId = string;
 
@@ -447,6 +447,8 @@ export interface BattleStatusEffectState {
   damagePerTurn: number;
   initiativeModifier: number;
   blocksActiveSkills: boolean;
+  preventsAction?: boolean;
+  forcedAttackSource?: boolean;
   sourceUnitId?: string;
 }
 
@@ -464,6 +466,7 @@ export interface UnitStack {
   count: number;
   currentHp: number;
   maxHp: number;
+  power?: number;
   hasRetaliated: boolean;
   defending: boolean;
   skills?: BattleSkillState[];
@@ -517,6 +520,7 @@ export interface BattleState {
   neutralArmyId?: string;
   defenderHeroId?: string;
   encounterPosition?: Vec2;
+  battlefieldTerrain?: TerrainType;
 }
 
 export type WorldAction =
@@ -1014,6 +1018,8 @@ export interface BattleStatusEffectConfig {
   damagePerTurn: number;
   initiativeModifier?: number;
   blocksActiveSkills?: boolean;
+  preventsAction?: boolean;
+  forcedAttackSource?: boolean;
 }
 
 export interface BattleSkillCatalogConfig {

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -124,7 +124,7 @@ function isBattleSkillKind(value: unknown): value is BattleSkillKind {
 }
 
 function isBattleSkillTarget(value: unknown): value is BattleSkillTarget {
-  return value === "enemy" || value === "self";
+  return value === "enemy" || value === "self" || value === "ally";
 }
 
 function isFiniteNumber(value: unknown): value is number {
@@ -259,6 +259,12 @@ export function validateBattleSkillCatalog(config: BattleSkillCatalogConfig): vo
     }
     if (status.blocksActiveSkills !== undefined && typeof status.blocksActiveSkills !== "boolean") {
       throw new Error(`Battle status ${status.id} blocksActiveSkills must be boolean`);
+    }
+    if (status.preventsAction !== undefined && typeof status.preventsAction !== "boolean") {
+      throw new Error(`Battle status ${status.id} preventsAction must be boolean`);
+    }
+    if (status.forcedAttackSource !== undefined && typeof status.forcedAttackSource !== "boolean") {
+      throw new Error(`Battle status ${status.id} forcedAttackSource must be boolean`);
     }
 
     statusIds.add(status.id);

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -4670,6 +4670,368 @@ test("applyBattleAction supports armor spell buffs on the acting unit", () => {
   assert.match(next.log.at(-1) ?? "", /护甲术/);
 });
 
+test("applyBattleAction resolves war cry splash onto adjacent enemy lanes without hitting allies", () => {
+  const state = createDemoBattleState();
+  state.lanes = 3;
+  state.activeUnitId = "pikeman-a";
+  state.turnOrder = ["pikeman-a", "wolf-d", "wolf-side", "ally-side"];
+  state.units["pikeman-a"] = {
+    ...state.units["pikeman-a"]!,
+    skills: [
+      {
+        id: "war_cry",
+        name: "战吼震荡",
+        description: "正面打击主目标，并以余波震伤相邻敌军。",
+        kind: "active",
+        target: "enemy",
+        cooldown: 3,
+        remainingCooldown: 0
+      }
+    ],
+    lane: 1,
+    count: 5,
+    minDamage: 4,
+    maxDamage: 4
+  };
+  state.units["wolf-d"] = {
+    ...state.units["wolf-d"]!,
+    lane: 1,
+    hasRetaliated: true
+  };
+  state.units["wolf-side"] = {
+    ...cloneBattleUnit(state.units["wolf-d"]!),
+    id: "wolf-side",
+    lane: 2,
+    stackName: "侧翼恶狼",
+    hasRetaliated: true
+  };
+  state.units["ally-side"] = {
+    ...cloneBattleUnit(state.units["pikeman-a"]!),
+    id: "ally-side",
+    lane: 0,
+    stackName: "侧翼枪兵"
+  };
+  state.unitCooldowns["pikeman-a"] = {};
+
+  const next = applyBattleAction(state, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "war_cry",
+    targetId: "wolf-d"
+  });
+
+  assert.ok(getUnitHpPool(next.units["wolf-side"]!) < getUnitHpPool(state.units["wolf-side"]!));
+  assert.equal(getUnitHpPool(next.units["ally-side"]!), getUnitHpPool(state.units["ally-side"]!));
+  assert.match(next.log.join("\n"), /波及 侧翼恶狼/);
+});
+
+test("ally battle skills heal wounded units and can cleanse one negative status", () => {
+  const state = createDemoBattleState();
+  state.activeUnitId = "pikeman-a";
+  state.turnOrder = ["pikeman-a", "ally-a", "wolf-d"];
+  state.units["pikeman-a"] = {
+    ...state.units["pikeman-a"]!,
+    power: 3,
+    skills: [
+      {
+        id: "field_mending",
+        name: "战地缝合",
+        description: "根据施法者的 power 恢复己方单位生命。",
+        kind: "active",
+        target: "ally",
+        delivery: "ranged",
+        cooldown: 2,
+        remainingCooldown: 0
+      },
+      {
+        id: "rally_morale",
+        name: "鼓舞军心",
+        description: "恢复少量生命，并解除一个负面状态。",
+        kind: "active",
+        target: "ally",
+        delivery: "ranged",
+        cooldown: 3,
+        remainingCooldown: 0
+      }
+    ]
+  };
+  state.units["ally-a"] = {
+    ...cloneBattleUnit(state.units["pikeman-a"]!),
+    id: "ally-a",
+    stackName: "友军枪兵",
+    currentHp: 4,
+    statusEffects: [
+      {
+        id: "weakened",
+        name: "削弱",
+        description: "暂时降低攻击力。",
+        durationRemaining: 2,
+        attackModifier: -2,
+        defenseModifier: 0,
+        damagePerTurn: 0,
+        initiativeModifier: 0,
+        blocksActiveSkills: false,
+        preventsAction: false,
+        forcedAttackSource: false
+      }
+    ]
+  };
+
+  const mended = applyBattleAction(state, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "field_mending",
+    targetId: "ally-a"
+  });
+
+  assert.ok(mended.units["ally-a"]!.currentHp > state.units["ally-a"]!.currentHp);
+  assert.equal(mended.units["ally-a"]?.statusEffects?.length, 1);
+
+  const ralliedBase = cloneBattleState(state);
+  ralliedBase.units["pikeman-a"] = {
+    ...ralliedBase.units["pikeman-a"]!,
+    skills: [
+      {
+        id: "rally_morale",
+        name: "鼓舞军心",
+        description: "恢复少量生命，并解除一个负面状态。",
+        kind: "active",
+        target: "ally",
+        delivery: "ranged",
+        cooldown: 3,
+        remainingCooldown: 0
+      }
+    ]
+  };
+  const rallied = applyBattleAction(ralliedBase, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "rally_morale",
+    targetId: "ally-a"
+  });
+
+  assert.ok(rallied.units["ally-a"]!.currentHp > ralliedBase.units["ally-a"]!.currentHp);
+  assert.deepEqual(rallied.units["ally-a"]?.statusEffects, []);
+  assert.match(rallied.log.at(-1) ?? "", /解除 削弱/);
+});
+
+test("stunning blow skips the target's next action", () => {
+  const state = createDemoBattleState();
+  state.activeUnitId = "pikeman-a";
+  state.turnOrder = ["pikeman-a", "wolf-d"];
+  state.units["pikeman-a"] = {
+    ...state.units["pikeman-a"]!,
+    skills: [
+      {
+        id: "stunning_blow",
+        name: "震荡猛击",
+        description: "重击敌军并附加短暂眩晕。",
+        kind: "active",
+        target: "enemy",
+        cooldown: 3,
+        remainingCooldown: 0
+      }
+    ]
+  };
+  state.units["wolf-d"] = {
+    ...state.units["wolf-d"]!,
+    hasRetaliated: true
+  };
+
+  const next = applyBattleAction(state, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "stunning_blow",
+    targetId: "wolf-d"
+  });
+
+  assert.equal(next.round, 2);
+  assert.equal(next.activeUnitId, "wolf-d");
+  assert.deepEqual(next.units["wolf-d"]?.statusEffects, []);
+  assert.match(next.log.join("\n"), /陷入眩晕/);
+  assert.match(next.log.join("\n"), /跳过行动/);
+});
+
+test("taunt shout constrains the target to attack the taunter on its next action", () => {
+  const state = createDemoBattleState();
+  state.activeUnitId = "pikeman-a";
+  state.turnOrder = ["pikeman-a", "wolf-d", "ally-a"];
+  state.units["pikeman-a"] = {
+    ...state.units["pikeman-a"]!,
+    skills: [
+      {
+        id: "taunt_shout",
+        name: "嘲阵怒喝",
+        description: "激怒敌军，迫使其下次行动优先攻击施放者。",
+        kind: "active",
+        target: "enemy",
+        delivery: "ranged",
+        cooldown: 3,
+        remainingCooldown: 0
+      }
+    ]
+  };
+  state.units["ally-a"] = {
+    ...cloneBattleUnit(state.units["pikeman-a"]!),
+    id: "ally-a",
+    stackName: "友军枪兵"
+  };
+
+  const taunted = applyBattleAction(state, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "taunt_shout",
+    targetId: "wolf-d"
+  });
+
+  assert.equal(taunted.activeUnitId, "wolf-d");
+  assert.equal(taunted.units["wolf-d"]?.statusEffects?.[0]?.id, "taunted");
+  assert.deepEqual(pickAutomatedBattleAction(taunted), {
+    type: "battle.attack",
+    attackerId: "wolf-d",
+    defenderId: "pikeman-a"
+  });
+  assert.deepEqual(
+    validateBattleAction(taunted, {
+      type: "battle.attack",
+      attackerId: "wolf-d",
+      defenderId: "ally-a"
+    }),
+    {
+      valid: false,
+      reason: "taunted_must_attack_source"
+    }
+  );
+});
+
+test("terrain-linked battle skills use battlefield terrain snapshots", () => {
+  const grassState = createDemoBattleState();
+  grassState.activeUnitId = "pikeman-a";
+  grassState.turnOrder = ["pikeman-a", "wolf-d"];
+  grassState.battlefieldTerrain = "grass";
+  grassState.units["pikeman-a"] = {
+    ...grassState.units["pikeman-a"]!,
+    minDamage: 5,
+    maxDamage: 5,
+    count: 4,
+    skills: [
+      {
+        id: "terrain_mastery",
+        name: "地形精通",
+        description: "在草地上进攻更猛，在水泽地带更耐打。",
+        kind: "passive",
+        target: "self",
+        cooldown: 0,
+        remainingCooldown: 0
+      }
+    ]
+  };
+  grassState.units["wolf-d"] = {
+    ...grassState.units["wolf-d"]!,
+    hasRetaliated: true
+  };
+
+  const waterState = cloneBattleState(grassState);
+  waterState.battlefieldTerrain = "water";
+  waterState.units["pikeman-a"] = {
+    ...waterState.units["pikeman-a"]!,
+    skills: [
+      ...(waterState.units["pikeman-a"]?.skills ?? []),
+      {
+        id: "bog_ambush",
+        name: "泥沼伏袭",
+        description: "只有在水泽地形中才能发动，伤害显著提升。",
+        kind: "active",
+        target: "enemy",
+        cooldown: 3,
+        remainingCooldown: 0
+      }
+    ]
+  };
+
+  const grassResult = applyBattleAction(cloneBattleState(grassState), {
+    type: "battle.attack",
+    attackerId: "pikeman-a",
+    defenderId: "wolf-d"
+  });
+  const neutralResult = applyBattleAction(
+    {
+      ...cloneBattleState(grassState),
+      units: {
+        ...cloneBattleState(grassState).units,
+        "pikeman-a": {
+          ...cloneBattleState(grassState).units["pikeman-a"]!,
+          skills: []
+        }
+      }
+    },
+    {
+      type: "battle.attack",
+      attackerId: "pikeman-a",
+      defenderId: "wolf-d"
+    }
+  );
+  const ambushResult = applyBattleAction(waterState, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "bog_ambush",
+    targetId: "wolf-d"
+  });
+  const rejectedAmbush = applyBattleAction(
+    {
+      ...cloneBattleState(waterState),
+      battlefieldTerrain: "grass"
+    },
+    {
+      type: "battle.skill",
+      unitId: "pikeman-a",
+      skillId: "bog_ambush",
+      targetId: "wolf-d"
+    }
+  );
+
+  assert.ok(getUnitHpPool(grassResult.units["wolf-d"]!) < getUnitHpPool(neutralResult.units["wolf-d"]!));
+  assert.ok(getUnitHpPool(ambushResult.units["wolf-d"]!) < getUnitHpPool(waterState.units["wolf-d"]!));
+  assert.equal(rejectedAmbush.log.at(-1), "Action rejected: skill_requires_water_terrain");
+});
+
+test("battle state builders read battlefield terrain from world state", () => {
+  const hero = createHero({
+    id: "hero-terrain-a",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 0 }
+  });
+  const defender = createHero({
+    id: "hero-terrain-b",
+    playerId: "player-2",
+    name: "罗安",
+    position: { x: 1, y: 0 }
+  });
+  const neutralArmy: NeutralArmyState = {
+    id: "neutral-terrain",
+    position: { x: 2, y: 0 },
+    reward: { kind: "ore", amount: 2 },
+    stacks: [{ templateId: "wolf_pack", count: 4 }]
+  };
+  const world = createWorldState({
+    width: 3,
+    height: 1,
+    heroes: [hero, defender],
+    neutralArmies: {
+      [neutralArmy.id]: neutralArmy
+    },
+    tiles: [
+      createTile(0, 0, { terrain: "grass" }),
+      createTile(1, 0, { terrain: "water" }),
+      createTile(2, 0, { terrain: "water" })
+    ]
+  });
+
+  assert.equal(createNeutralBattleState(hero, neutralArmy, 1001, world).battlefieldTerrain, "water");
+  assert.equal(createHeroBattleState(hero, defender, 1002, world).battlefieldTerrain, "water");
+});
+
 test("applyBattleAction reduces damage against defending targets", () => {
   const baselineState = createDemoBattleState();
   baselineState.activeUnitId = "wolf-d";


### PR DESCRIPTION
## Summary
- add the new battle skills and status definitions for AOE, healing, stun, taunt, and terrain-linked resolution
- extend the shared battle engine with ally-target skills, splash damage, cleanse/heal resolution, taunt/stun enforcement, and terrain-aware battle snapshots
- cover the new resolution paths with shared battle tests and pass shared/server typechecks

Closes #787