### PR TITLE
feat: add Crown faction unit templates

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/battle.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle.ts
@@ -221,6 +221,10 @@ function isContactSkillDefinition(skill: BattleSkillConfig): boolean {
   return skill.target === "enemy" && skill.delivery !== "ranged";
 }
 
+function isSkillAvailableThisRound(skill: BattleSkillConfig, round: number): boolean {
+  return (skill.effects?.maxRound ?? Number.POSITIVE_INFINITY) >= round;
+}
+
 function buildFormationLanes(unitCount: number, totalLanes: number): number[] {
   if (unitCount <= 0) {
     return [];
@@ -596,7 +600,15 @@ export function pickAutomatedBattleAction(state: BattleState): BattleAction | nu
   }
 
   const catalogIndex = getBattleCatalogIndex();
-  const readySkills = canUseActiveSkills(activeUnit) ? skillsOf(activeUnit).filter(isActiveSkillReady) : [];
+  const readySkills = canUseActiveSkills(activeUnit)
+    ? skillsOf(activeUnit).filter((skill) => {
+        if (!isActiveSkillReady(skill)) {
+          return false;
+        }
+
+        return isSkillAvailableThisRound(skillDefinitionFor(skill.id, catalogIndex), state.round);
+      })
+    : [];
 
   for (const skill of readySkills) {
     if (skill.target !== "self") {
@@ -1022,6 +1034,25 @@ function applyAttackSequence(
   );
   nextUnits[defender.id] = damagedDefender;
 
+  const splashSkillDefinition = options?.skillId ? skillDefinitionFor(options.skillId, catalogIndex) : null;
+  const splashMultiplier =
+    splashSkillDefinition && damagedDefender.count > 0
+      ? splashSkillDefinition.id === "war_cry"
+        ? splashSkillDefinition.effects?.splashDamageMultiplier ?? splashSkillDefinition.effects?.damageMultiplier ?? 0.5
+        : splashSkillDefinition.effects?.splashDamageMultiplier ?? 0
+      : 0;
+  if (splashMultiplier > 0) {
+    const adjacentEnemies = Object.values(nextUnits)
+      .filter((unit) => unit.camp === damagedDefender.camp && unit.id !== damagedDefender.id && unit.count > 0)
+      .filter((unit) => Math.abs(unit.lane - damagedDefender.lane) === 1);
+
+    for (const adjacentEnemy of adjacentEnemies) {
+      const splashDamage = Math.max(1, Math.floor(attackDamage * splashMultiplier));
+      nextUnits[adjacentEnemy.id] = applyDamage(adjacentEnemy, splashDamage);
+      log.push(`${attacker.stackName} 的${splashSkillDefinition!.name}波及 ${adjacentEnemy.stackName}，造成 ${splashDamage} 伤害`);
+    }
+  }
+
   if ((options?.allowRetaliation ?? true) && damagedDefender.count > 0 && !damagedDefender.hasRetaliated) {
     const retaliationRoll = nextDeterministicRandom(nextRngState.seed);
     const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value);
@@ -1161,6 +1192,9 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
 
     if (normalizedCooldownValue(state.unitCooldowns[action.unitId]?.[action.skillId]) > 0) {
       return { valid: false, reason: "skill_on_cooldown" };
+    }
+    if (!isSkillAvailableThisRound(skillDefinitionFor(skill.id, getBattleCatalogIndex()), state.round)) {
+      return { valid: false, reason: "skill_round_expired" };
     }
 
     if (skill.target === "self") {

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -988,6 +988,8 @@ export interface BattleSkillEffectConfig {
   allowRetaliation?: boolean;
   grantedStatusId?: BattleStatusEffectId;
   onHitStatusId?: BattleStatusEffectId;
+  splashDamageMultiplier?: number;
+  maxRound?: number;
 }
 
 export interface BattleSkillConfig {

--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -296,8 +296,17 @@ export function validateBattleSkillCatalog(config: BattleSkillCatalogConfig): vo
     if (effects.damageMultiplier !== undefined && (!isFiniteNumber(effects.damageMultiplier) || effects.damageMultiplier <= 0)) {
       throw new Error(`Battle skill ${skill.id} damageMultiplier must be a positive number`);
     }
+    if (
+      effects.splashDamageMultiplier !== undefined &&
+      (!isFiniteNumber(effects.splashDamageMultiplier) || effects.splashDamageMultiplier <= 0)
+    ) {
+      throw new Error(`Battle skill ${skill.id} splashDamageMultiplier must be a positive number`);
+    }
     if (effects.allowRetaliation !== undefined && typeof effects.allowRetaliation !== "boolean") {
       throw new Error(`Battle skill ${skill.id} allowRetaliation must be boolean`);
+    }
+    if (effects.maxRound !== undefined && (!Number.isInteger(effects.maxRound) || effects.maxRound <= 0)) {
+      throw new Error(`Battle skill ${skill.id} maxRound must be a positive integer`);
     }
     if (effects.grantedStatusId !== undefined && !statusIds.has(effects.grantedStatusId)) {
       throw new Error(`Battle skill ${skill.id} references unknown granted status: ${effects.grantedStatusId}`);

--- a/configs/battle-skills-v1.1.json
+++ b/configs/battle-skills-v1.1.json
@@ -175,6 +175,40 @@
       "effects": {
         "grantedStatusId": "watchful_guard"
       }
+    },
+    {
+      "id": "field_mending",
+      "name": "战地缝合",
+      "description": "根据施法者的 power 恢复己方单位生命。",
+      "kind": "active",
+      "target": "ally",
+      "delivery": "ranged",
+      "cooldown": 2,
+      "effects": {}
+    },
+    {
+      "id": "royal_charge",
+      "name": "皇家冲锋",
+      "description": "仅可在首回合发动的重骑冲锋，猛击主目标并穿透波及相邻敌军。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 4,
+      "effects": {
+        "damageMultiplier": 1.25,
+        "onHitStatusId": "armor_break",
+        "splashDamageMultiplier": 0.5,
+        "maxRound": 1
+      }
+    },
+    {
+      "id": "rally_morale",
+      "name": "鼓舞军心",
+      "description": "恢复少量生命，并解除一个负面状态。",
+      "kind": "active",
+      "target": "ally",
+      "delivery": "ranged",
+      "cooldown": 3,
+      "effects": {}
     }
   ],
   "statuses": [

--- a/configs/battle-skills.json
+++ b/configs/battle-skills.json
@@ -198,6 +198,20 @@
       "effects": {}
     },
     {
+      "id": "royal_charge",
+      "name": "皇家冲锋",
+      "description": "仅可在首回合发动的重骑冲锋，猛击主目标并穿透波及相邻敌军。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 4,
+      "effects": {
+        "damageMultiplier": 1.25,
+        "onHitStatusId": "armor_break",
+        "splashDamageMultiplier": 0.5,
+        "maxRound": 1
+      }
+    },
+    {
       "id": "rally_morale",
       "name": "鼓舞军心",
       "description": "恢复少量生命，并解除一个负面状态。",

--- a/configs/phase1-map-objects-frontier-basin.json
+++ b/configs/phase1-map-objects-frontier-basin.json
@@ -130,7 +130,7 @@
         "y": 3
       },
       "label": "前线招募所",
-      "unitTemplateId": "hero_guard_basic",
+      "unitTemplateId": "crown_crossbowman",
       "recruitCount": 4,
       "cost": {
         "gold": 240,
@@ -172,7 +172,7 @@
         "y": 1
       },
       "label": "峡口哨募站",
-      "unitTemplateId": "hero_guard_basic",
+      "unitTemplateId": "crown_light_outrider",
       "recruitCount": 3,
       "cost": {
         "gold": 180,

--- a/configs/phase1-map-objects-ridgeway-crossing.json
+++ b/configs/phase1-map-objects-ridgeway-crossing.json
@@ -145,7 +145,7 @@
         "y": 3
       },
       "label": "前线招募所",
-      "unitTemplateId": "hero_guard_basic",
+      "unitTemplateId": "crown_crossbowman",
       "recruitCount": 4,
       "cost": {
         "gold": 240,
@@ -187,7 +187,7 @@
         "y": 4
       },
       "label": "渡桥补员点",
-      "unitTemplateId": "hero_guard_basic",
+      "unitTemplateId": "crown_heavy_cavalry",
       "recruitCount": 3,
       "cost": {
         "gold": 180,

--- a/configs/phase1-map-objects-stonewatch-fork.json
+++ b/configs/phase1-map-objects-stonewatch-fork.json
@@ -158,7 +158,7 @@
         "y": 2
       },
       "label": "石望征募站",
-      "unitTemplateId": "hero_guard_basic",
+      "unitTemplateId": "crown_heavy_cavalry",
       "recruitCount": 4,
       "cost": {
         "gold": 240,
@@ -174,7 +174,7 @@
         "y": 4
       },
       "label": "岔路补员营",
-      "unitTemplateId": "hero_guard_basic",
+      "unitTemplateId": "crown_field_chaplain",
       "recruitCount": 3,
       "cost": {
         "gold": 170,

--- a/configs/phase2-map-objects-contested-basin.json
+++ b/configs/phase2-map-objects-contested-basin.json
@@ -126,7 +126,7 @@
         "y": 3
       },
       "label": "峡湾征募站",
-      "unitTemplateId": "hero_guard_basic",
+      "unitTemplateId": "crown_field_chaplain",
       "recruitCount": 4,
       "cost": {
         "gold": 220,

--- a/configs/units.json
+++ b/configs/units.json
@@ -19,6 +19,70 @@
       ]
     },
     {
+      "id": "crown_heavy_cavalry",
+      "stackName": "皇家重骑",
+      "faction": "crown",
+      "rarity": "elite",
+      "initiative": 6,
+      "attack": 7,
+      "defense": 6,
+      "minDamage": 3,
+      "maxDamage": 6,
+      "maxHp": 16,
+      "battleSkills": [
+        "royal_charge",
+        "guardian_oath"
+      ]
+    },
+    {
+      "id": "crown_field_chaplain",
+      "stackName": "战场牧师",
+      "faction": "crown",
+      "rarity": "common",
+      "initiative": 8,
+      "attack": 3,
+      "defense": 4,
+      "minDamage": 1,
+      "maxDamage": 3,
+      "maxHp": 11,
+      "battleSkills": [
+        "field_mending",
+        "rally_morale"
+      ]
+    },
+    {
+      "id": "crown_crossbowman",
+      "stackName": "十字弩手",
+      "faction": "crown",
+      "rarity": "common",
+      "initiative": 8,
+      "attack": 6,
+      "defense": 3,
+      "minDamage": 3,
+      "maxDamage": 5,
+      "maxHp": 8,
+      "battleSkills": [
+        "power_shot",
+        "sundering_spear"
+      ]
+    },
+    {
+      "id": "crown_light_outrider",
+      "stackName": "轻骑斥候",
+      "faction": "crown",
+      "rarity": "common",
+      "initiative": 12,
+      "attack": 4,
+      "defense": 3,
+      "minDamage": 1,
+      "maxDamage": 2,
+      "maxHp": 8,
+      "battleSkills": [
+        "pinning_javelin",
+        "battle_focus"
+      ]
+    },
+    {
       "id": "wolf_pack",
       "stackName": "恶狼",
       "faction": "wild",

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -225,6 +225,10 @@ function isContactSkillDefinition(skill: BattleSkillConfig): boolean {
   return skill.target === "enemy" && skill.delivery !== "ranged";
 }
 
+function isSkillAvailableThisRound(skill: BattleSkillConfig, round: number): boolean {
+  return (skill.effects?.maxRound ?? Number.POSITIVE_INFINITY) >= round;
+}
+
 function buildFormationLanes(unitCount: number, totalLanes: number): number[] {
   if (unitCount <= 0) {
     return [];
@@ -696,7 +700,15 @@ export function pickAutomatedBattleAction(state: BattleState): BattleAction | nu
     };
   }
 
-  const readySkills = canUseActiveSkills(activeUnit) ? skillsOf(activeUnit).filter(isActiveSkillReady) : [];
+  const readySkills = canUseActiveSkills(activeUnit)
+    ? skillsOf(activeUnit).filter((skill) => {
+        if (!isActiveSkillReady(skill)) {
+          return false;
+        }
+
+        return isSkillAvailableThisRound(skillDefinitionFor(skill.id, catalogIndex), state.round);
+      })
+    : [];
   const alliedUnits = Object.values(state.units).filter((unit) => unit.camp === activeUnit.camp && unit.count > 0);
 
   for (const skill of readySkills) {
@@ -1184,13 +1196,12 @@ function applyAttackSequence(
   );
   nextUnits[defender.id] = damagedDefender;
 
-  const splashSkillDefinition =
-    options?.skillId && options.skillId === "war_cry"
-      ? skillDefinitionFor(options.skillId, catalogIndex)
-      : null;
+  const splashSkillDefinition = options?.skillId ? skillDefinitionFor(options.skillId, catalogIndex) : null;
   const splashMultiplier =
     splashSkillDefinition && damagedDefender.count > 0
-      ? splashSkillDefinition.effects?.damageMultiplier ?? 0.5
+      ? splashSkillDefinition.id === "war_cry"
+        ? splashSkillDefinition.effects?.splashDamageMultiplier ?? splashSkillDefinition.effects?.damageMultiplier ?? 0.5
+        : splashSkillDefinition.effects?.splashDamageMultiplier ?? 0
       : 0;
   if (splashMultiplier > 0) {
     const adjacentEnemies = Object.values(nextUnits)
@@ -1394,6 +1405,9 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
 
     if (normalizedCooldownValue(state.unitCooldowns[action.unitId]?.[action.skillId]) > 0) {
       return { valid: false, reason: "skill_on_cooldown" };
+    }
+    if (!isSkillAvailableThisRound(skillDefinitionFor(skill.id, getBattleCatalogIndex()), state.round)) {
+      return { valid: false, reason: "skill_round_expired" };
     }
 
     const forcedTargetId = forcedAttackTargetId(unit, state);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -995,6 +995,8 @@ export interface BattleSkillEffectConfig {
   allowRetaliation?: boolean;
   grantedStatusId?: BattleStatusEffectId;
   onHitStatusId?: BattleStatusEffectId;
+  splashDamageMultiplier?: number;
+  maxRound?: number;
 }
 
 export interface BattleSkillConfig {

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -308,8 +308,17 @@ export function validateBattleSkillCatalog(config: BattleSkillCatalogConfig): vo
     if (effects.damageMultiplier !== undefined && (!isFiniteNumber(effects.damageMultiplier) || effects.damageMultiplier <= 0)) {
       throw new Error(`Battle skill ${skill.id} damageMultiplier must be a positive number`);
     }
+    if (
+      effects.splashDamageMultiplier !== undefined &&
+      (!isFiniteNumber(effects.splashDamageMultiplier) || effects.splashDamageMultiplier <= 0)
+    ) {
+      throw new Error(`Battle skill ${skill.id} splashDamageMultiplier must be a positive number`);
+    }
     if (effects.allowRetaliation !== undefined && typeof effects.allowRetaliation !== "boolean") {
       throw new Error(`Battle skill ${skill.id} allowRetaliation must be boolean`);
+    }
+    if (effects.maxRound !== undefined && (!Number.isInteger(effects.maxRound) || effects.maxRound <= 0)) {
+      throw new Error(`Battle skill ${skill.id} maxRound must be a positive integer`);
     }
     if (effects.grantedStatusId !== undefined && !statusIds.has(effects.grantedStatusId)) {
       throw new Error(`Battle skill ${skill.id} references unknown granted status: ${effects.grantedStatusId}`);

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -4815,6 +4815,121 @@ test("ally battle skills heal wounded units and can cleanse one negative status"
   assert.match(rallied.log.at(-1) ?? "", /解除 削弱/);
 });
 
+test("round-limited splash skills only work on their allowed opening round", () => {
+  const customCatalog = getDefaultBattleSkillCatalog();
+  customCatalog.skills.push({
+    id: "royal_charge_test",
+    name: "皇家冲锋测试",
+    description: "首回合冲锋并波及相邻目标。",
+    kind: "active",
+    target: "enemy",
+    cooldown: 4,
+    effects: {
+      damageMultiplier: 1.2,
+      splashDamageMultiplier: 0.5,
+      maxRound: 1
+    }
+  });
+
+  try {
+    setBattleSkillCatalog(customCatalog);
+
+    const openingState = createDemoBattleState();
+    openingState.activeUnitId = "pikeman-a";
+    openingState.turnOrder = ["pikeman-a", "wolf-d", "wolf-side"];
+    openingState.units["pikeman-a"] = {
+      ...openingState.units["pikeman-a"]!,
+      skills: [
+        {
+          id: "royal_charge_test",
+          name: "皇家冲锋测试",
+          description: "首回合冲锋并波及相邻目标。",
+          kind: "active",
+          target: "enemy",
+          cooldown: 4,
+          remainingCooldown: 0
+        }
+      ],
+      lane: 1
+    };
+    openingState.units["wolf-d"] = {
+      ...openingState.units["wolf-d"]!,
+      lane: 1,
+      hasRetaliated: true
+    };
+    openingState.units["wolf-side"] = {
+      ...cloneBattleUnit(openingState.units["wolf-d"]!),
+      id: "wolf-side",
+      lane: 2,
+      stackName: "侧翼恶狼",
+      hasRetaliated: true
+    };
+
+    const charged = applyBattleAction(openingState, {
+      type: "battle.skill",
+      unitId: "pikeman-a",
+      skillId: "royal_charge_test",
+      targetId: "wolf-d"
+    });
+
+    assert.ok(getUnitHpPool(charged.units["wolf-d"]!) < getUnitHpPool(openingState.units["wolf-d"]!));
+    assert.ok(getUnitHpPool(charged.units["wolf-side"]!) < getUnitHpPool(openingState.units["wolf-side"]!));
+    assert.match(charged.log.join("\n"), /波及 侧翼恶狼/);
+
+    const expiredState = createDemoBattleState();
+    expiredState.round = 2;
+    expiredState.activeUnitId = "pikeman-a";
+    expiredState.turnOrder = ["pikeman-a", "wolf-d", "wolf-side"];
+    expiredState.units["pikeman-a"] = {
+      ...expiredState.units["pikeman-a"]!,
+      skills: [
+        {
+          id: "royal_charge_test",
+          name: "皇家冲锋测试",
+          description: "首回合冲锋并波及相邻目标。",
+          kind: "active",
+          target: "enemy",
+          cooldown: 4,
+          remainingCooldown: 0
+        }
+      ],
+      lane: 1
+    };
+    expiredState.units["wolf-d"] = {
+      ...expiredState.units["wolf-d"]!,
+      lane: 1,
+      hasRetaliated: true
+    };
+    expiredState.units["wolf-side"] = {
+      ...cloneBattleUnit(expiredState.units["wolf-d"]!),
+      id: "wolf-side",
+      lane: 2,
+      stackName: "侧翼恶狼",
+      hasRetaliated: true
+    };
+
+    assert.deepEqual(
+      validateBattleAction(expiredState, {
+        type: "battle.skill",
+        unitId: "pikeman-a",
+        skillId: "royal_charge_test",
+        targetId: "wolf-d"
+      }),
+      {
+        valid: false,
+        reason: "skill_round_expired"
+      }
+    );
+    assert.deepEqual(pickAutomatedBattleAction(expiredState), {
+      type: "battle.attack",
+      attackerId: "pikeman-a",
+      defenderId: "wolf-d"
+    });
+  } finally {
+    resetRuntimeConfigs();
+  }
+});
+
 test("stunning blow skips the target's next action", () => {
   const state = createDemoBattleState();
   state.activeUnitId = "pikeman-a";


### PR DESCRIPTION
## Summary
- add 4 new Crown unit templates for heavy cavalry, chaplain, crossbowman, and outrider roles
- add royal_charge plus shared runtime support for round-limited splash skills, and mirror the schema updates into the Cocos shared copies
- wire recruitment posts across the map configs so the new Crown units are recruitable

## Validation
- npm run typecheck:shared
- npm run typecheck:cocos
- node --import tsx --test ./packages/shared/test/content-pack-validation.test.ts
- node --import tsx --test ./packages/shared/test/shared-core.test.ts --test-name-pattern="round-limited splash skills only work on their allowed opening round"
- npm run validate:content-pack:all
- npm run validate:battle -- --count=1000 --scenario=all

Closes #783