### PR TITLE
[codex] Add Wild faction units and flying support

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-battle-replay-center.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-replay-center.ts
@@ -175,7 +175,7 @@ function buildReplaySessionUpdate(replay: PlayerBattleReplaySummary, playback: B
       },
       playerId: replay.playerId
     },
-    battle: playback.currentState,
+    battle: playback.currentState as SessionUpdate["battle"],
     events: [],
     movementPlan: null,
     reachableTiles: []

--- a/apps/cocos-client/assets/scripts/project-shared/battle.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle.ts
@@ -12,8 +12,10 @@ import type {
   BattleStatusEffectState,
   HeroState,
   NeutralArmyState,
+  TerrainType,
   UnitStack,
-  ValidationResult
+  ValidationResult,
+  WorldState
 } from "./models.ts";
 import { validateAction } from "./action-precheck.ts";
 import { nextDeterministicRandom } from "./deterministic-rng.ts";
@@ -136,7 +138,7 @@ function normalizeBattleCooldowns(
   );
 }
 
-function normalizeBattleState(state: BattleState): BattleState {
+export function normalizeBattleState(state: BattleState): BattleState {
   const normalizedUnits = Object.fromEntries(
     Object.entries(state.units).map(([unitId, unit]) => [unitId, withNormalizedCollections(unit)])
   );
@@ -213,7 +215,9 @@ function createStatusEffectState(
     defenseModifier: definition.defenseModifier,
     damagePerTurn: definition.damagePerTurn,
     initiativeModifier: definition.initiativeModifier ?? 0,
-    blocksActiveSkills: definition.blocksActiveSkills ?? false
+    blocksActiveSkills: definition.blocksActiveSkills ?? false,
+    preventsAction: definition.preventsAction ?? false,
+    forcedAttackSource: definition.forcedAttackSource ?? false
   }, "sourceUnitId", sourceUnitId);
 }
 
@@ -250,6 +254,18 @@ function effectiveInitiative(unit: UnitStack): number {
 
 function canUseActiveSkills(unit: UnitStack): boolean {
   return statusEffectsOf(unit).every((status) => !status.blocksActiveSkills);
+}
+
+function preventsAction(unit: UnitStack): boolean {
+  return statusEffectsOf(unit).some((status) => status.preventsAction);
+}
+
+function hasBattleSkill(unit: UnitStack, skillId: BattleSkillId): boolean {
+  return skillsOf(unit).some((skill) => skill.id === skillId);
+}
+
+function battlefieldTerrainOf(state: BattleState): TerrainType {
+  return state.battlefieldTerrain ?? "grass";
 }
 
 function describeHazard(hazard: BattleHazardState, catalogIndex: BattleCatalogIndex = getBattleCatalogIndex()): string {
@@ -363,11 +379,25 @@ function totalDefenseModifier(unit: UnitStack): number {
   return statusEffectsOf(unit).reduce((total, status) => total + status.defenseModifier, 0);
 }
 
-function estimateDamage(attacker: UnitStack, defender: UnitStack, randomValue: number, multiplier = 1): number {
+function terrainDefenseBonus(unit: UnitStack, state: BattleState): number {
+  return hasBattleSkill(unit, "terrain_mastery") && battlefieldTerrainOf(state) === "water" ? 2 : 0;
+}
+
+function terrainDamageMultiplier(unit: UnitStack, state: BattleState): number {
+  return hasBattleSkill(unit, "terrain_mastery") && battlefieldTerrainOf(state) === "grass" ? 1.1 : 1;
+}
+
+function estimateDamage(
+  attacker: UnitStack,
+  defender: UnitStack,
+  randomValue: number,
+  state: BattleState,
+  multiplier = 1
+): number {
   const balance = getBattleBalanceConfig().damage;
   const defenseBonus = defender.defending ? balance.defendingDefenseBonus : 0;
   const effectiveAttack = attacker.attack + totalAttackModifier(attacker);
-  const effectiveDefense = defender.defense + totalDefenseModifier(defender) + defenseBonus;
+  const effectiveDefense = defender.defense + totalDefenseModifier(defender) + defenseBonus + terrainDefenseBonus(defender, state);
   const offenseModifier = 1 + (effectiveAttack - effectiveDefense) * balance.offenseAdvantageStep;
   const variance = balance.varianceBase + randomValue * balance.varianceRange;
   return Math.max(
@@ -377,7 +407,8 @@ function estimateDamage(attacker: UnitStack, defender: UnitStack, randomValue: n
         averageDamage(attacker) *
         Math.max(balance.minimumOffenseMultiplier, offenseModifier) *
         variance *
-        multiplier
+        multiplier *
+        terrainDamageMultiplier(attacker, state)
     )
   );
 }
@@ -399,6 +430,22 @@ function applyDamage(target: UnitStack, damage: number): UnitStack {
     ...target,
     count: survivingCount,
     currentHp
+  };
+}
+
+function applyHealing(target: UnitStack, amount: number): UnitStack {
+  if (target.count <= 0 || amount <= 0) {
+    return target;
+  }
+
+  const hpPool = (target.count - 1) * target.maxHp + target.currentHp;
+  const maxHpPool = target.count * target.maxHp;
+  const healedHpPool = Math.min(maxHpPool, hpPool + amount);
+  const currentHp = healedHpPool - (target.count - 1) * target.maxHp;
+
+  return {
+    ...target,
+    currentHp: currentHp > 0 ? currentHp : target.maxHp
   };
 }
 
@@ -559,6 +606,50 @@ function hasStatusEffect(unit: UnitStack, statusId: BattleStatusEffectId): boole
   return statusEffectsOf(unit).some((status) => status.id === statusId);
 }
 
+function isNegativeStatusEffect(status: BattleStatusEffectState): boolean {
+  return !!(
+    status.attackModifier < 0 ||
+    status.defenseModifier < 0 ||
+    status.damagePerTurn > 0 ||
+    status.initiativeModifier < 0 ||
+    status.blocksActiveSkills ||
+    status.preventsAction ||
+    status.forcedAttackSource
+  );
+}
+
+function removeFirstNegativeStatus(unit: UnitStack): { unit: UnitStack; removedStatus?: BattleStatusEffectState } {
+  const statuses = statusEffectsOf(unit);
+  const removedStatus = statuses.find(isNegativeStatusEffect);
+  if (!removedStatus) {
+    return { unit };
+  }
+
+  return {
+    unit: {
+      ...unit,
+      statusEffects: statuses.filter((status) => status !== removedStatus)
+    },
+    removedStatus
+  };
+}
+
+function forcedAttackTargetId(unit: UnitStack, state: BattleState): string | null {
+  const forcedStatus = [...statusEffectsOf(unit)]
+    .reverse()
+    .find((status) => status.forcedAttackSource && status.sourceUnitId);
+  if (!forcedStatus?.sourceUnitId) {
+    return null;
+  }
+
+  const source = state.units[forcedStatus.sourceUnitId];
+  if (!source || source.count <= 0 || source.camp === unit.camp) {
+    return null;
+  }
+
+  return source.id;
+}
+
 function isActiveSkillReady(skill: BattleSkillState): boolean {
   return skill.kind === "active" && skill.remainingCooldown === 0;
 }
@@ -600,6 +691,15 @@ export function pickAutomatedBattleAction(state: BattleState): BattleAction | nu
   }
 
   const catalogIndex = getBattleCatalogIndex();
+  const forcedTargetId = forcedAttackTargetId(activeUnit, state);
+  if (forcedTargetId) {
+    return {
+      type: "battle.attack",
+      attackerId: activeUnit.id,
+      defenderId: forcedTargetId
+    };
+  }
+
   const readySkills = canUseActiveSkills(activeUnit)
     ? skillsOf(activeUnit).filter((skill) => {
         if (!isActiveSkillReady(skill)) {
@@ -609,6 +709,52 @@ export function pickAutomatedBattleAction(state: BattleState): BattleAction | nu
         return isSkillAvailableThisRound(skillDefinitionFor(skill.id, catalogIndex), state.round);
       })
     : [];
+  const alliedUnits = Object.values(state.units).filter((unit) => unit.camp === activeUnit.camp && unit.count > 0);
+
+  for (const skill of readySkills) {
+    if (skill.target !== "ally") {
+      continue;
+    }
+
+    if (skill.id === "field_mending") {
+      const woundedTarget = alliedUnits
+        .filter((unit) => unit.currentHp < unit.maxHp)
+        .sort((left, right) => left.currentHp - right.currentHp)[0];
+      if (woundedTarget) {
+        return {
+          type: "battle.skill",
+          unitId: activeUnit.id,
+          skillId: skill.id,
+          targetId: woundedTarget.id
+        };
+      }
+      continue;
+    }
+
+    if (skill.id === "rally_morale") {
+      const cleansableTarget = alliedUnits.find((unit) => statusEffectsOf(unit).some(isNegativeStatusEffect));
+      if (cleansableTarget) {
+        return {
+          type: "battle.skill",
+          unitId: activeUnit.id,
+          skillId: skill.id,
+          targetId: cleansableTarget.id
+        };
+      }
+
+      const woundedTarget = alliedUnits
+        .filter((unit) => unit.currentHp < unit.maxHp)
+        .sort((left, right) => left.currentHp - right.currentHp)[0];
+      if (woundedTarget) {
+        return {
+          type: "battle.skill",
+          unitId: activeUnit.id,
+          skillId: skill.id,
+          targetId: woundedTarget.id
+        };
+      }
+    }
+  }
 
   for (const skill of readySkills) {
     if (skill.target !== "self") {
@@ -849,6 +995,7 @@ function prepareStateForActiveUnit(state: BattleState): BattleState {
   while (nextState.activeUnitId && remainingIterations > 0) {
     remainingIterations -= 1;
     const activeUnit = nextState.units[nextState.activeUnitId]!;
+    const unitPreventsAction = preventsAction(activeUnit);
 
     const processed = processTurnStartForUnit(activeUnit);
     nextState = withUpdatedUnitCooldowns(
@@ -858,6 +1005,15 @@ function prepareStateForActiveUnit(state: BattleState): BattleState {
       },
       processed.unit
     );
+
+    if (processed.unit.count > 0 && unitPreventsAction) {
+      nextState = {
+        ...nextState,
+        log: nextState.log.concat(`${processed.unit.stackName} 因负面状态跳过行动`)
+      };
+      nextState = advanceTurnInternal(nextState, activeUnit.id, false);
+      continue;
+    }
 
     if (processed.unit.count > 0) {
       break;
@@ -1011,7 +1167,13 @@ function applyAttackSequence(
   const attacker = preparedState.state.units[attackerId]!;
   const defender = preparedState.state.units[defenderId]!;
   const attackRoll = nextDeterministicRandom(preparedState.state.rng.seed);
-  const attackDamage = estimateDamage(attacker, defender, attackRoll.value, options?.damageMultiplier ?? 1);
+  const attackDamage = estimateDamage(
+    attacker,
+    defender,
+    attackRoll.value,
+    preparedState.state,
+    options?.damageMultiplier ?? 1
+  );
   const nextUnits: Record<string, UnitStack> = {
     ...preparedState.state.units,
     [defender.id]: applyDamage(defender, attackDamage)
@@ -1055,7 +1217,7 @@ function applyAttackSequence(
 
   if ((options?.allowRetaliation ?? true) && damagedDefender.count > 0 && !damagedDefender.hasRetaliated) {
     const retaliationRoll = nextDeterministicRandom(nextRngState.seed);
-    const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value);
+    const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value, preparedState.state);
     let damagedAttacker = applyDamage(attacker, retaliationDamage);
     damagedAttacker = applyOnHitStatuses(damagedDefender, damagedAttacker, log, catalogIndex);
     nextUnits[attacker.id] = damagedAttacker;
@@ -1109,7 +1271,51 @@ export function executeBattleSkill(
   const casterWithCooldown = setSkillCooldown(caster, skillId);
   const stateWithCooldown = withUpdatedUnitCooldowns(normalizedState, casterWithCooldown);
 
+  if (skillDefinition.target === "ally" && targetId) {
+    const allyTarget = normalizedState.units[targetId]!;
+    let nextTarget = allyTarget;
+    const log = [...normalizedState.log];
+
+    if (skillId === "field_mending") {
+      const healingAmount = Math.max(2, 4 + (caster.power ?? 0) * 3);
+      nextTarget = applyHealing(nextTarget, healingAmount);
+      log.push(`${caster.stackName} 施放 ${skillDefinition.name}，为 ${allyTarget.stackName} 恢复 ${healingAmount} 生命`);
+    } else if (skillId === "rally_morale") {
+      const healingAmount = Math.max(1, 2 + (caster.power ?? 0) * 2);
+      nextTarget = applyHealing(nextTarget, healingAmount);
+      const moraleResult = removeFirstNegativeStatus(nextTarget);
+      nextTarget = moraleResult.unit;
+      log.push(
+        moraleResult.removedStatus
+          ? `${caster.stackName} 施放 ${skillDefinition.name}，为 ${allyTarget.stackName} 恢复 ${healingAmount} 生命并解除 ${moraleResult.removedStatus.name}`
+          : `${caster.stackName} 施放 ${skillDefinition.name}，为 ${allyTarget.stackName} 恢复 ${healingAmount} 生命`
+      );
+    } else {
+      log.push(`${caster.stackName} 施放 ${skillDefinition.name}`);
+    }
+
+    return advanceTurn(
+      {
+        ...withUpdatedUnitCooldowns(stateWithCooldown, casterWithCooldown),
+        units: {
+          ...stateWithCooldown.units,
+          [nextTarget.id]: nextTarget
+        },
+        log
+      },
+      caster.id,
+      false
+    );
+  }
+
   if (skillDefinition.target === "enemy" && targetId) {
+    if (skillId === "bog_ambush" && battlefieldTerrainOf(normalizedState) !== "water") {
+      return {
+        ...stateWithCooldown,
+        log: normalizedState.log.concat(`Action rejected: skill_requires_water_terrain`)
+      };
+    }
+
     return applyAttackSequence(
       {
         ...stateWithCooldown
@@ -1117,7 +1323,10 @@ export function executeBattleSkill(
       caster.id,
       targetId,
       {
-        damageMultiplier: skillDefinition.effects?.damageMultiplier ?? 1,
+        damageMultiplier:
+          skillId === "bog_ambush"
+            ? 2
+            : skillDefinition.effects?.damageMultiplier ?? 1,
         allowRetaliation: skillDefinition.effects?.allowRetaliation ?? true,
         delivery: isContactSkillDefinition(skillDefinition) ? "contact" : "ranged",
         logPrefix: `${caster.stackName} 施放 ${skillDefinition.name}，对 ${normalizedState.units[targetId]!.stackName}`,
@@ -1168,6 +1377,10 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
       return { valid: false, reason: "unit_not_available" };
     }
 
+    if (forcedAttackTargetId(unit, state)) {
+      return { valid: false, reason: "taunted_must_attack_source" };
+    }
+
     return { valid: true };
   }
 
@@ -1197,10 +1410,34 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
       return { valid: false, reason: "skill_round_expired" };
     }
 
+    const forcedTargetId = forcedAttackTargetId(unit, state);
+    if (forcedTargetId) {
+      if (skill.target !== "enemy" || action.targetId !== forcedTargetId) {
+        return { valid: false, reason: "taunted_must_attack_source" };
+      }
+    }
+
     if (skill.target === "self") {
       if (action.targetId && action.targetId !== unit.id) {
         return { valid: false, reason: "invalid_skill_target" };
       }
+      return { valid: true };
+    }
+
+    if (skill.target === "ally") {
+      if (!action.targetId) {
+        return { valid: false, reason: "skill_target_missing" };
+      }
+
+      const target = state.units[action.targetId];
+      if (!target || target.count <= 0) {
+        return { valid: false, reason: "ally_not_available" };
+      }
+
+      if (target.camp !== unit.camp) {
+        return { valid: false, reason: "invalid_skill_target" };
+      }
+
       return { valid: true };
     }
 
@@ -1232,6 +1469,11 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
 
   if (!defender || defender.count <= 0) {
     return { valid: false, reason: "defender_not_available" };
+  }
+
+  const forcedTargetId = attacker ? forcedAttackTargetId(attacker, state) : null;
+  if (forcedTargetId && forcedTargetId !== action.defenderId) {
+    return { valid: false, reason: "taunted_must_attack_source" };
   }
 
   if (attacker.camp === defender.camp) {
@@ -1327,11 +1569,23 @@ export function createDemoBattleState(): BattleState {
     rng: {
       seed: 4242,
       cursor: 0
-    }
+    },
+    battlefieldTerrain: "grass"
   };
 }
 
-export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralArmyState, seed: number): BattleState {
+function terrainAtPosition(world: WorldState | undefined, position: { x: number; y: number }): TerrainType {
+  return world?.map.tiles.find(
+    (tile) => tile.position.x === position.x && tile.position.y === position.y
+  )?.terrain ?? "grass";
+}
+
+export function createNeutralBattleState(
+  hero: HeroState,
+  neutralArmy: NeutralArmyState,
+  seed: number,
+  world?: WorldState
+): BattleState {
   const units: Record<string, UnitStack> = {};
   const catalog = getDefaultUnitCatalog();
   const battleCatalogIndex = getBattleCatalogIndex();
@@ -1361,6 +1615,7 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
       count: hero.armyCount,
       currentHp: heroTemplate.maxHp,
       maxHp: heroTemplate.maxHp,
+      power: hero.stats.power,
       hasRetaliated: false,
       defending: false
     },
@@ -1415,11 +1670,17 @@ export function createNeutralBattleState(hero: HeroState, neutralArmy: NeutralAr
     },
     worldHeroId: hero.id,
     neutralArmyId: neutralArmy.id,
-    encounterPosition: neutralArmy.position
+    encounterPosition: neutralArmy.position,
+    battlefieldTerrain: terrainAtPosition(world, neutralArmy.position)
   };
 }
 
-export function createHeroBattleState(attackerHero: HeroState, defenderHero: HeroState, seed: number): BattleState {
+export function createHeroBattleState(
+  attackerHero: HeroState,
+  defenderHero: HeroState,
+  seed: number,
+  world?: WorldState
+): BattleState {
   const catalog = getDefaultUnitCatalog();
   const battleCatalogIndex = getBattleCatalogIndex();
   const templateById = new Map(catalog.templates.map((template) => [template.id, template]));
@@ -1456,6 +1717,7 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
         count: attackerHero.armyCount,
         currentHp: attackerTemplate.maxHp,
         maxHp: attackerTemplate.maxHp,
+        power: attackerHero.stats.power,
         hasRetaliated: false,
         defending: false
       },
@@ -1477,6 +1739,7 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
         count: defenderHero.armyCount,
         currentHp: defenderTemplate.maxHp,
         maxHp: defenderTemplate.maxHp,
+        power: defenderHero.stats.power,
         hasRetaliated: false,
         defending: false
       },
@@ -1506,7 +1769,8 @@ export function createHeroBattleState(attackerHero: HeroState, defenderHero: Her
     },
     worldHeroId: attackerHero.id,
     defenderHeroId: defenderHero.id,
-    encounterPosition: defenderHero.position
+    encounterPosition: defenderHero.position,
+    battlefieldTerrain: terrainAtPosition(world, defenderHero.position)
   };
 }
 

--- a/apps/cocos-client/assets/scripts/project-shared/map.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map.ts
@@ -42,6 +42,7 @@ import {
 } from "./models.ts";
 import { getRuntimeConfigBundleForRoom } from "./world-config.ts";
 import {
+  getDefaultUnitCatalog,
   validateMapObjectsConfig,
   validateWorldConfig
 } from "./world-config.ts";
@@ -84,6 +85,26 @@ function tileKey(position: Vec2): string {
 
 function tileIndex(map: WorldMapState, position: Vec2): number {
   return position.y * map.width + position.x;
+}
+
+function templateHasBattleSkill(templateId: string, skillId: string): boolean {
+  const template = getDefaultUnitCatalog().templates.find((item) => item.id === templateId);
+  return template?.battleSkills?.includes(skillId) ?? false;
+}
+
+function heroCanFlyOverWater(hero: Pick<HeroState, "armyTemplateId">): boolean {
+  return templateHasBattleSkill(hero.armyTemplateId, "skybound");
+}
+
+function neutralArmyCanFlyOverWater(neutralArmy: NeutralArmyState): boolean {
+  return neutralArmy.stacks.some((stack) => templateHasBattleSkill(stack.templateId, "skybound"));
+}
+
+function isTraversableTile(
+  tile: Pick<TileState, "walkable" | "terrain"> | Pick<PlayerTileView, "walkable" | "terrain">,
+  canFlyOverWater: boolean
+): boolean {
+  return tile.walkable || (canFlyOverWater && tile.terrain === "water");
 }
 
 function maybeAwardBattleEquipmentDrop(
@@ -642,7 +663,8 @@ function getPlayerNeighbors(view: PlayerWorldView, position: Vec2): Vec2[] {
 
 function isBlockedForPlayerView(view: PlayerWorldView, heroId: string, position: Vec2, destination: Vec2): boolean {
   const tile = findPlayerTile(view, position);
-  if (!tile || tile.fog === "hidden" || !tile.walkable) {
+  const hero = view.ownHeroes.find((item) => item.id === heroId);
+  if (!tile || !hero || tile.fog === "hidden" || !isTraversableTile(tile, heroCanFlyOverWater(hero))) {
     return true;
   }
 
@@ -757,7 +779,8 @@ function getNeighbors(map: WorldMapState, position: Vec2): Vec2[] {
 
 function isBlockedForHero(state: WorldState, heroId: string, position: Vec2, destination: Vec2): boolean {
   const tile = findTile(state.map, position);
-  if (!tile || !tile.walkable) {
+  const hero = findHero(state, heroId);
+  if (!tile || !hero || !isTraversableTile(tile, heroCanFlyOverWater(hero))) {
     return true;
   }
 
@@ -777,7 +800,8 @@ function isBlockedForNeutral(
   targetHeroId?: string
 ): boolean {
   const tile = findTile(state.map, position);
-  if (!tile || !tile.walkable || tile.building) {
+  const neutralArmy = state.neutralArmies[neutralArmyId];
+  if (!tile || !neutralArmy || !isTraversableTile(tile, neutralArmyCanFlyOverWater(neutralArmy)) || tile.building) {
     return true;
   }
 
@@ -1248,7 +1272,7 @@ export function planPlayerViewMovement(
   }
 
   const destinationTile = findPlayerTile(view, destination);
-  if (!destinationTile || destinationTile.fog === "hidden" || !destinationTile.walkable) {
+  if (!destinationTile || destinationTile.fog === "hidden" || !isTraversableTile(destinationTile, heroCanFlyOverWater(hero))) {
     return undefined;
   }
 
@@ -1515,7 +1539,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
       };
     }
 
-    if (!destinationTile.walkable || destinationTile.fog === "hidden") {
+    if (!isTraversableTile(destinationTile, heroCanFlyOverWater(hero)) || destinationTile.fog === "hidden") {
       return {
         world: view,
         movementPlan: null,
@@ -1912,7 +1936,7 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
       return { valid: false, reason: "destination_not_found" };
     }
 
-    if (!tile.walkable) {
+    if (!isTraversableTile(tile, heroCanFlyOverWater(hero))) {
       return { valid: false, reason: "destination_blocked" };
     }
 

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -419,7 +419,7 @@ export interface MovementPlan {
 
 export type BattleSkillId = string;
 export type BattleSkillKind = "active" | "passive";
-export type BattleSkillTarget = "enemy" | "self";
+export type BattleSkillTarget = "enemy" | "self" | "ally";
 export type BattleSkillDelivery = "contact" | "ranged";
 export type BattleStatusEffectId = string;
 
@@ -444,6 +444,8 @@ export interface BattleStatusEffectState {
   damagePerTurn: number;
   initiativeModifier: number;
   blocksActiveSkills: boolean;
+  preventsAction?: boolean;
+  forcedAttackSource?: boolean;
   sourceUnitId?: string;
 }
 
@@ -461,6 +463,7 @@ export interface UnitStack {
   count: number;
   currentHp: number;
   maxHp: number;
+  power?: number;
   hasRetaliated: boolean;
   defending: boolean;
   skills?: BattleSkillState[];
@@ -514,6 +517,7 @@ export interface BattleState {
   neutralArmyId?: string;
   defenderHeroId?: string;
   encounterPosition?: Vec2;
+  battlefieldTerrain?: TerrainType;
 }
 
 export type WorldAction =
@@ -1013,6 +1017,8 @@ export interface BattleStatusEffectConfig {
   damagePerTurn: number;
   initiativeModifier?: number;
   blocksActiveSkills?: boolean;
+  preventsAction?: boolean;
+  forcedAttackSource?: boolean;
 }
 
 export interface BattleSkillCatalogConfig {

--- a/configs/battle-skills-v1.1.json
+++ b/configs/battle-skills-v1.1.json
@@ -177,6 +177,38 @@
       }
     },
     {
+      "id": "cave_bear_cleave",
+      "name": "裂岩横扫",
+      "description": "洞熊正面撕咬主目标，并以蛮力横扫相邻敌军。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 1.1,
+        "splashDamageMultiplier": 0.5
+      }
+    },
+    {
+      "id": "serpent_venom",
+      "name": "蛇毒獠牙",
+      "description": "命中时注入更持久的蛇毒，让目标持续失血。",
+      "kind": "passive",
+      "target": "enemy",
+      "cooldown": 0,
+      "effects": {
+        "onHitStatusId": "serpent_poison"
+      }
+    },
+    {
+      "id": "skybound",
+      "name": "鹰翼凌空",
+      "description": "借助飞行机动越过地形阻隔，可跨越水域移动。",
+      "kind": "passive",
+      "target": "self",
+      "cooldown": 0,
+      "effects": {}
+    },
+    {
       "id": "field_mending",
       "name": "战地缝合",
       "description": "根据施法者的 power 恢复己方单位生命。",
@@ -201,6 +233,20 @@
       }
     },
     {
+      "id": "taunt_shout",
+      "name": "嘲阵怒喝",
+      "description": "激怒敌军，迫使其下次行动优先攻击施放者。",
+      "kind": "active",
+      "target": "enemy",
+      "delivery": "ranged",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 0.6,
+        "allowRetaliation": false,
+        "onHitStatusId": "taunted"
+      }
+    },
+    {
       "id": "rally_morale",
       "name": "鼓舞军心",
       "description": "恢复少量生命，并解除一个负面状态。",
@@ -220,6 +266,17 @@
       "attackModifier": 0,
       "defenseModifier": 0,
       "damagePerTurn": 2,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "serpent_poison",
+      "name": "蛇毒",
+      "description": "蛇毒会持续侵蚀生命，持续时间更长。",
+      "duration": 3,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 3,
       "initiativeModifier": 0,
       "blocksActiveSkills": false
     },
@@ -277,6 +334,18 @@
       "damagePerTurn": 0,
       "initiativeModifier": 0,
       "blocksActiveSkills": false
+    },
+    {
+      "id": "taunted",
+      "name": "嘲讽",
+      "description": "下次行动会被迫优先攻击施放者。",
+      "duration": 2,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 0,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false,
+      "forcedAttackSource": true
     },
     {
       "id": "slowed",

--- a/configs/battle-skills.json
+++ b/configs/battle-skills.json
@@ -177,6 +177,38 @@
       }
     },
     {
+      "id": "cave_bear_cleave",
+      "name": "裂岩横扫",
+      "description": "洞熊正面撕咬主目标，并以蛮力横扫相邻敌军。",
+      "kind": "active",
+      "target": "enemy",
+      "cooldown": 3,
+      "effects": {
+        "damageMultiplier": 1.1,
+        "splashDamageMultiplier": 0.5
+      }
+    },
+    {
+      "id": "serpent_venom",
+      "name": "蛇毒獠牙",
+      "description": "命中时注入更持久的蛇毒，让目标持续失血。",
+      "kind": "passive",
+      "target": "enemy",
+      "cooldown": 0,
+      "effects": {
+        "onHitStatusId": "serpent_poison"
+      }
+    },
+    {
+      "id": "skybound",
+      "name": "鹰翼凌空",
+      "description": "借助飞行机动越过地形阻隔，可跨越水域移动。",
+      "kind": "passive",
+      "target": "self",
+      "cooldown": 0,
+      "effects": {}
+    },
+    {
       "id": "war_cry",
       "name": "战吼震荡",
       "description": "正面打击主目标，并以余波震伤相邻敌军。",
@@ -275,6 +307,17 @@
       "attackModifier": 0,
       "defenseModifier": 0,
       "damagePerTurn": 2,
+      "initiativeModifier": 0,
+      "blocksActiveSkills": false
+    },
+    {
+      "id": "serpent_poison",
+      "name": "蛇毒",
+      "description": "蛇毒会持续侵蚀生命，持续时间更长。",
+      "duration": 3,
+      "attackModifier": 0,
+      "defenseModifier": 0,
+      "damagePerTurn": 3,
       "initiativeModifier": 0,
       "blocksActiveSkills": false
     },

--- a/configs/phase2-map-objects-contested-basin.json
+++ b/configs/phase2-map-objects-contested-basin.json
@@ -125,8 +125,8 @@
         "x": 1,
         "y": 3
       },
-      "label": "峡湾征募站",
-      "unitTemplateId": "crown_field_chaplain",
+      "label": "峡湾鹰骑岗",
+      "unitTemplateId": "wild_hawk_rider",
       "recruitCount": 4,
       "cost": {
         "gold": 220,

--- a/configs/units.json
+++ b/configs/units.json
@@ -129,6 +129,68 @@
         "shield_bash",
         "watcher_stance"
       ]
+    },
+    {
+      "id": "wild_cave_bear",
+      "stackName": "洞穴巨熊",
+      "faction": "wild",
+      "rarity": "elite",
+      "initiative": 6,
+      "attack": 7,
+      "defense": 5,
+      "minDamage": 3,
+      "maxDamage": 6,
+      "maxHp": 18,
+      "battleSkills": [
+        "cave_bear_cleave"
+      ]
+    },
+    {
+      "id": "wild_serpent",
+      "stackName": "毒蛇猎手",
+      "faction": "wild",
+      "rarity": "common",
+      "initiative": 14,
+      "attack": 6,
+      "defense": 2,
+      "minDamage": 2,
+      "maxDamage": 4,
+      "maxHp": 6,
+      "battleSkills": [
+        "serpent_venom"
+      ]
+    },
+    {
+      "id": "wild_hawk_rider",
+      "stackName": "鹰击骑兵",
+      "faction": "wild",
+      "rarity": "elite",
+      "initiative": 13,
+      "attack": 5,
+      "defense": 4,
+      "minDamage": 2,
+      "maxDamage": 4,
+      "maxHp": 9,
+      "battleSkills": [
+        "skybound",
+        "pinning_javelin"
+      ]
+    },
+    {
+      "id": "wild_cave_troll",
+      "stackName": "洞穴巨魔",
+      "faction": "wild",
+      "rarity": "elite",
+      "initiative": 5,
+      "attack": 5,
+      "defense": 8,
+      "minDamage": 3,
+      "maxDamage": 5,
+      "maxHp": 20,
+      "battleSkills": [
+        "taunt_shout",
+        "watcher_stance"
+      ]
     }
   ]
 }

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -42,6 +42,7 @@ import {
 } from "./models.ts";
 import { getRuntimeConfigBundleForRoom } from "./world-config.ts";
 import {
+  getDefaultUnitCatalog,
   validateMapObjectsConfig,
   validateWorldConfig
 } from "./world-config.ts";
@@ -84,6 +85,26 @@ function tileKey(position: Vec2): string {
 
 function tileIndex(map: WorldMapState, position: Vec2): number {
   return position.y * map.width + position.x;
+}
+
+function templateHasBattleSkill(templateId: string, skillId: string): boolean {
+  const template = getDefaultUnitCatalog().templates.find((item) => item.id === templateId);
+  return template?.battleSkills?.includes(skillId) ?? false;
+}
+
+function heroCanFlyOverWater(hero: Pick<HeroState, "armyTemplateId">): boolean {
+  return templateHasBattleSkill(hero.armyTemplateId, "skybound");
+}
+
+function neutralArmyCanFlyOverWater(neutralArmy: NeutralArmyState): boolean {
+  return neutralArmy.stacks.some((stack) => templateHasBattleSkill(stack.templateId, "skybound"));
+}
+
+function isTraversableTile(
+  tile: Pick<TileState, "walkable" | "terrain"> | Pick<PlayerTileView, "walkable" | "terrain">,
+  canFlyOverWater: boolean
+): boolean {
+  return tile.walkable || (canFlyOverWater && tile.terrain === "water");
 }
 
 function maybeAwardBattleEquipmentDrop(
@@ -642,7 +663,8 @@ function getPlayerNeighbors(view: PlayerWorldView, position: Vec2): Vec2[] {
 
 function isBlockedForPlayerView(view: PlayerWorldView, heroId: string, position: Vec2, destination: Vec2): boolean {
   const tile = findPlayerTile(view, position);
-  if (!tile || tile.fog === "hidden" || !tile.walkable) {
+  const hero = view.ownHeroes.find((item) => item.id === heroId);
+  if (!tile || !hero || tile.fog === "hidden" || !isTraversableTile(tile, heroCanFlyOverWater(hero))) {
     return true;
   }
 
@@ -757,7 +779,8 @@ function getNeighbors(map: WorldMapState, position: Vec2): Vec2[] {
 
 function isBlockedForHero(state: WorldState, heroId: string, position: Vec2, destination: Vec2): boolean {
   const tile = findTile(state.map, position);
-  if (!tile || !tile.walkable) {
+  const hero = findHero(state, heroId);
+  if (!tile || !hero || !isTraversableTile(tile, heroCanFlyOverWater(hero))) {
     return true;
   }
 
@@ -777,7 +800,8 @@ function isBlockedForNeutral(
   targetHeroId?: string
 ): boolean {
   const tile = findTile(state.map, position);
-  if (!tile || !tile.walkable || tile.building) {
+  const neutralArmy = state.neutralArmies[neutralArmyId];
+  if (!tile || !neutralArmy || !isTraversableTile(tile, neutralArmyCanFlyOverWater(neutralArmy)) || tile.building) {
     return true;
   }
 
@@ -1252,7 +1276,7 @@ export function planPlayerViewMovement(
   }
 
   const destinationTile = findPlayerTile(view, destination);
-  if (!destinationTile || destinationTile.fog === "hidden" || !destinationTile.walkable) {
+  if (!destinationTile || destinationTile.fog === "hidden" || !isTraversableTile(destinationTile, heroCanFlyOverWater(hero))) {
     return undefined;
   }
 
@@ -1519,7 +1543,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
       };
     }
 
-    if (!destinationTile.walkable || destinationTile.fog === "hidden") {
+    if (!isTraversableTile(destinationTile, heroCanFlyOverWater(hero)) || destinationTile.fog === "hidden") {
       return {
         world: view,
         movementPlan: null,
@@ -1916,7 +1940,7 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
       return { valid: false, reason: "destination_not_found" };
     }
 
-    if (!tile.walkable) {
+    if (!isTraversableTile(tile, heroCanFlyOverWater(hero))) {
       return { valid: false, reason: "destination_blocked" };
     }
 

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -67,6 +67,7 @@ import {
   normalizePlayerBattleReplaySummaries,
   pauseBattleReplayPlayback,
   pickAutomatedBattleAction,
+  planHeroMovement,
   planPlayerViewMovement,
   playBattleReplayPlayback,
   predictPlayerWorldAction,
@@ -2411,12 +2412,29 @@ test("createInitialWorldState selects the contested basin variant with the new c
   assert.equal(state.meta.mapVariantId, "contested_basin");
   assert.equal(state.heroes[0]?.position.x, 1);
   assert.equal(state.heroes[0]?.position.y, 2);
+  assert.equal(state.buildings["recruit-post-basin-1"]?.kind, "recruitment_post");
+  assert.equal(state.buildings["recruit-post-basin-1"]?.unitTemplateId, "wild_hawk_rider");
   assert.equal(state.buildings["watchtower-basin-1"]?.kind, "watchtower");
   assert.equal(state.buildings["watchtower-basin-1"]?.visionBonus, 2);
   assert.equal(state.neutralArmies["neutral-reed-patrol"]?.behavior?.mode, "patrol");
   assert.equal(state.neutralArmies["neutral-watch-guard"]?.behavior?.mode, "guard");
   assert.equal(state.neutralArmies["neutral-watch-guard"]?.stacks[0]?.templateId, "iron_walker");
   assert.equal(state.neutralArmies["neutral-reed-patrol"]?.stacks[0]?.templateId, "moss_stalker");
+});
+
+test("issue 784 wild templates and battle catalog entries are available", () => {
+  const unitCatalog = getDefaultUnitCatalog();
+  const templateById = new Map(unitCatalog.templates.map((template) => [template.id, template]));
+  const battleCatalog = getDefaultBattleSkillCatalog();
+
+  assert.deepEqual(templateById.get("wild_cave_bear")?.battleSkills, ["cave_bear_cleave"]);
+  assert.deepEqual(templateById.get("wild_serpent")?.battleSkills, ["serpent_venom"]);
+  assert.deepEqual(templateById.get("wild_hawk_rider")?.battleSkills, ["skybound", "pinning_javelin"]);
+  assert.deepEqual(templateById.get("wild_cave_troll")?.battleSkills, ["taunt_shout", "watcher_stance"]);
+  assert.ok(battleCatalog.skills.some((skill) => skill.id === "cave_bear_cleave"));
+  assert.ok(battleCatalog.skills.some((skill) => skill.id === "serpent_venom"));
+  assert.ok(battleCatalog.skills.some((skill) => skill.id === "skybound"));
+  assert.ok(battleCatalog.statuses.some((status) => status.id === "serpent_poison"));
 });
 
 test("createInitialWorldState selects the ridgeway crossing variant with the new Phase 1 content pack", () => {
@@ -4212,6 +4230,48 @@ test("planPlayerViewMovement stops at the tile before a visible neutral encounte
   assert.equal(plan?.moveCost, 1);
 });
 
+test("hawk rider armies can path across water tiles in world and player views", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    armyTemplateId: "wild_hawk_rider",
+    position: { x: 0, y: 1 },
+    move: { total: 6, remaining: 6 }
+  });
+  const state = createWorldState({
+    width: 3,
+    height: 3,
+    heroes: [hero],
+    tiles: [
+      createTile(0, 0),
+      createTile(1, 0),
+      createTile(2, 0),
+      createTile(0, 1, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(1, 1, { walkable: false, terrain: "water" }),
+      createTile(2, 1),
+      createTile(0, 2),
+      createTile(1, 2),
+      createTile(2, 2)
+    ],
+    visibilityByPlayer: {
+      "player-1": new Array(9).fill("visible")
+    }
+  });
+  const view = createPlayerWorldView(state, "player-1");
+
+  assert.deepEqual(planHeroMovement(state, "hero-1", { x: 2, y: 1 })?.path, [
+    { x: 0, y: 1 },
+    { x: 1, y: 1 },
+    { x: 2, y: 1 }
+  ]);
+  assert.deepEqual(planPlayerViewMovement(view, "hero-1", { x: 2, y: 1 })?.path, [
+    { x: 0, y: 1 },
+    { x: 1, y: 1 },
+    { x: 2, y: 1 }
+  ]);
+});
+
 test("predictPlayerWorldAction updates the player view immediately for move and collect", () => {
   const hero = createHero({
     id: "hero-1",
@@ -4723,6 +4783,74 @@ test("applyBattleAction resolves war cry splash onto adjacent enemy lanes withou
   assert.ok(getUnitHpPool(next.units["wolf-side"]!) < getUnitHpPool(state.units["wolf-side"]!));
   assert.equal(getUnitHpPool(next.units["ally-side"]!), getUnitHpPool(state.units["ally-side"]!));
   assert.match(next.log.join("\n"), /波及 侧翼恶狼/);
+});
+
+test("cave bear cleave uses splash support against adjacent enemies", () => {
+  const caveBearTemplate = getDefaultUnitCatalog().templates.find((template) => template.id === "wild_cave_bear");
+  const cleaveSkill = getDefaultBattleSkillCatalog().skills.find((skill) => skill.id === "cave_bear_cleave");
+  assert.ok(caveBearTemplate);
+  assert.ok(cleaveSkill);
+
+  const state = createDemoBattleState();
+  state.activeUnitId = "bear-a";
+  state.turnOrder = ["bear-a", "wolf-d", "wolf-side", "ally-side"];
+  state.units["bear-a"] = {
+    ...cloneBattleUnit(state.units["pikeman-a"]!),
+    id: "bear-a",
+    templateId: caveBearTemplate.id,
+    stackName: caveBearTemplate.stackName,
+    initiative: caveBearTemplate.initiative,
+    attack: caveBearTemplate.attack,
+    defense: caveBearTemplate.defense,
+    minDamage: caveBearTemplate.minDamage,
+    maxDamage: caveBearTemplate.maxDamage,
+    count: 4,
+    currentHp: caveBearTemplate.maxHp,
+    maxHp: caveBearTemplate.maxHp,
+    lane: 1,
+    skills: [
+      {
+        id: cleaveSkill.id,
+        name: cleaveSkill.name,
+        description: cleaveSkill.description,
+        kind: cleaveSkill.kind,
+        target: cleaveSkill.target,
+        cooldown: cleaveSkill.cooldown,
+        remainingCooldown: 0
+      }
+    ]
+  };
+  state.units["wolf-d"] = {
+    ...state.units["wolf-d"]!,
+    lane: 1,
+    hasRetaliated: true
+  };
+  state.units["wolf-side"] = {
+    ...cloneBattleUnit(state.units["wolf-d"]!),
+    id: "wolf-side",
+    lane: 2,
+    stackName: "侧翼恶狼",
+    hasRetaliated: true
+  };
+  state.units["ally-side"] = {
+    ...cloneBattleUnit(state.units["pikeman-a"]!),
+    id: "ally-side",
+    lane: 0,
+    stackName: "友军枪兵"
+  };
+  state.unitCooldowns["bear-a"] = {};
+
+  const next = applyBattleAction(state, {
+    type: "battle.skill",
+    unitId: "bear-a",
+    skillId: "cave_bear_cleave",
+    targetId: "wolf-d"
+  });
+
+  assert.ok(getUnitHpPool(next.units["wolf-d"]!) < getUnitHpPool(state.units["wolf-d"]!));
+  assert.ok(getUnitHpPool(next.units["wolf-side"]!) < getUnitHpPool(state.units["wolf-side"]!));
+  assert.equal(getUnitHpPool(next.units["ally-side"]!), getUnitHpPool(state.units["ally-side"]!));
+  assert.match(next.log.join("\n"), /裂岩横扫波及 侧翼恶狼/);
 });
 
 test("ally battle skills heal wounded units and can cleanse one negative status", () => {


### PR DESCRIPTION
## Summary
- add four new Wild unit templates: `wild_cave_bear`, `wild_serpent`, `wild_hawk_rider`, and `wild_cave_troll`
- add the missing battle-skill/status config needed for cave bear splash damage, serpent poison, and hawk rider flying traversal support
- teach shared and Cocos runtime pathing/battle mirrors to respect flying-over-water and taunt-targeting rules, and wire the contested basin recruitment post to the new hawk rider template

## Validation
- `node --import tsx --test packages/shared/test/shared-core.test.ts --test-name-pattern='issue 784|hawk rider armies|cave bear cleave|contested basin variant|battle-skills-v1.1 preset validates'`
- `npm run validate:content-pack:all`
- `npm run typecheck:shared`
- `npm run typecheck:cocos`

Closes #784