### PR TITLE
feat: expand map pool with plains and canyon maps batch 1

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -2,13 +2,21 @@ import defaultBattleSkillsConfig from "../../../../../configs/battle-skills.json
 import defaultBattleBalanceConfig from "../../../../../configs/battle-balance.json";
 import defaultHeroSkillTreesConfig from "../../../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../../../configs/phase2-map-objects-contested-basin.json";
+import amberFieldsMapObjectsConfig from "../../../../../configs/phase1-map-objects-amber-fields.json";
 import frontierBasinMapObjectsConfig from "../../../../../configs/phase1-map-objects-frontier-basin.json";
+import highlandReachMapObjectsConfig from "../../../../../configs/phase1-map-objects-highland-reach.json";
+import ironpassGorgeMapObjectsConfig from "../../../../../configs/phase1-map-objects-ironpass-gorge.json";
+import splitrockCanyonMapObjectsConfig from "../../../../../configs/phase1-map-objects-splitrock-canyon.json";
 import stonewatchForkMapObjectsConfig from "../../../../../configs/phase1-map-objects-stonewatch-fork.json";
 import ridgewayCrossingMapObjectsConfig from "../../../../../configs/phase1-map-objects-ridgeway-crossing.json";
 import defaultMapObjectsConfig from "../../../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../../../configs/units.json";
+import amberFieldsWorldConfig from "../../../../../configs/phase1-world-amber-fields.json";
 import contestedBasinWorldConfig from "../../../../../configs/phase2-contested-basin.json";
 import frontierBasinWorldConfig from "../../../../../configs/phase1-world-frontier-basin.json";
+import highlandReachWorldConfig from "../../../../../configs/phase1-world-highland-reach.json";
+import ironpassGorgeWorldConfig from "../../../../../configs/phase1-world-ironpass-gorge.json";
+import splitrockCanyonWorldConfig from "../../../../../configs/phase1-world-splitrock-canyon.json";
 import stonewatchForkWorldConfig from "../../../../../configs/phase1-world-stonewatch-fork.json";
 import ridgewayCrossingWorldConfig from "../../../../../configs/phase1-world-ridgeway-crossing.json";
 import defaultWorldConfig from "../../../../../configs/phase1-world.json";
@@ -38,6 +46,10 @@ export const DEFAULT_MAP_VARIANT_ID = "phase1";
 export const FRONTIER_BASIN_MAP_VARIANT_ID = "frontier_basin";
 export const STONEWATCH_FORK_MAP_VARIANT_ID = "stonewatch_fork";
 export const RIDGEWAY_CROSSING_MAP_VARIANT_ID = "ridgeway_crossing";
+export const HIGHLAND_REACH_MAP_VARIANT_ID = "highland_reach";
+export const AMBER_FIELDS_MAP_VARIANT_ID = "amber_fields";
+export const IRONPASS_GORGE_MAP_VARIANT_ID = "ironpass_gorge";
+export const SPLITROCK_CANYON_MAP_VARIANT_ID = "splitrock_canyon";
 export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
 
 export interface RuntimeConfigBundle {
@@ -736,6 +748,10 @@ function getAvailableMapVariantIds(): string[] {
     FRONTIER_BASIN_MAP_VARIANT_ID,
     STONEWATCH_FORK_MAP_VARIANT_ID,
     RIDGEWAY_CROSSING_MAP_VARIANT_ID,
+    HIGHLAND_REACH_MAP_VARIANT_ID,
+    AMBER_FIELDS_MAP_VARIANT_ID,
+    IRONPASS_GORGE_MAP_VARIANT_ID,
+    SPLITROCK_CANYON_MAP_VARIANT_ID,
     CONTESTED_BASIN_MAP_VARIANT_ID
   ];
 }
@@ -754,6 +770,10 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     requested === FRONTIER_BASIN_MAP_VARIANT_ID ||
     requested === STONEWATCH_FORK_MAP_VARIANT_ID ||
     requested === RIDGEWAY_CROSSING_MAP_VARIANT_ID ||
+    requested === HIGHLAND_REACH_MAP_VARIANT_ID ||
+    requested === AMBER_FIELDS_MAP_VARIANT_ID ||
+    requested === IRONPASS_GORGE_MAP_VARIANT_ID ||
+    requested === SPLITROCK_CANYON_MAP_VARIANT_ID ||
     requested === CONTESTED_BASIN_MAP_VARIANT_ID
   ) {
     return requested;
@@ -774,6 +794,14 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneWorldConfig(stonewatchForkWorldConfig as WorldGenerationConfig)
       : mapVariantId === RIDGEWAY_CROSSING_MAP_VARIANT_ID
         ? cloneWorldConfig(ridgewayCrossingWorldConfig as WorldGenerationConfig)
+      : mapVariantId === HIGHLAND_REACH_MAP_VARIANT_ID
+        ? cloneWorldConfig(highlandReachWorldConfig as WorldGenerationConfig)
+      : mapVariantId === AMBER_FIELDS_MAP_VARIANT_ID
+        ? cloneWorldConfig(amberFieldsWorldConfig as WorldGenerationConfig)
+      : mapVariantId === IRONPASS_GORGE_MAP_VARIANT_ID
+        ? cloneWorldConfig(ironpassGorgeWorldConfig as WorldGenerationConfig)
+      : mapVariantId === SPLITROCK_CANYON_MAP_VARIANT_ID
+        ? cloneWorldConfig(splitrockCanyonWorldConfig as WorldGenerationConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
         : getDefaultWorldConfig();
@@ -784,6 +812,14 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneMapObjectsConfig(stonewatchForkMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === RIDGEWAY_CROSSING_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(ridgewayCrossingMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === HIGHLAND_REACH_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(highlandReachMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === AMBER_FIELDS_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(amberFieldsMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === IRONPASS_GORGE_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(ironpassGorgeMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === SPLITROCK_CANYON_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(splitrockCanyonMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
         : getDefaultMapObjectsConfig();

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -3,8 +3,16 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolve } from "node:path";
 import { createPool, type Pool, type RowDataPacket } from "mysql2/promise";
 import * as XLSX from "xlsx";
+import amberFieldsMapObjectsConfig from "../../../configs/phase1-map-objects-amber-fields.json";
+import amberFieldsWorldConfig from "../../../configs/phase1-world-amber-fields.json";
 import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
 import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
+import highlandReachMapObjectsConfig from "../../../configs/phase1-map-objects-highland-reach.json";
+import highlandReachWorldConfig from "../../../configs/phase1-world-highland-reach.json";
+import ironpassGorgeMapObjectsConfig from "../../../configs/phase1-map-objects-ironpass-gorge.json";
+import ironpassGorgeWorldConfig from "../../../configs/phase1-world-ironpass-gorge.json";
+import splitrockCanyonMapObjectsConfig from "../../../configs/phase1-map-objects-splitrock-canyon.json";
+import splitrockCanyonWorldConfig from "../../../configs/phase1-world-splitrock-canyon.json";
 import stonewatchForkMapObjectsConfig from "../../../configs/phase1-map-objects-stonewatch-fork.json";
 import stonewatchForkWorldConfig from "../../../configs/phase1-world-stonewatch-fork.json";
 import ridgewayCrossingMapObjectsConfig from "../../../configs/phase1-map-objects-ridgeway-crossing.json";
@@ -452,6 +460,10 @@ const BUILTIN_WORLD_LAYOUT_PRESETS = [
   "layout_frontier_basin",
   "layout_stonewatch_fork",
   "layout_ridgeway_crossing",
+  "layout_highland_reach",
+  "layout_amber_fields",
+  "layout_ironpass_gorge",
+  "layout_splitrock_canyon",
   "layout_contested_basin"
 ] as const;
 const BUILTIN_MAP_OBJECT_LAYOUT_PRESETS = [
@@ -459,6 +471,10 @@ const BUILTIN_MAP_OBJECT_LAYOUT_PRESETS = [
   "layout_frontier_basin",
   "layout_stonewatch_fork",
   "layout_ridgeway_crossing",
+  "layout_highland_reach",
+  "layout_amber_fields",
+  "layout_ironpass_gorge",
+  "layout_splitrock_canyon",
   "layout_contested_basin"
 ] as const;
 const CONFIG_SCHEMA_VERSION = "2026-03-26";
@@ -1800,6 +1816,14 @@ function buildLayoutPresetSummary(id: typeof BUILTIN_WORLD_LAYOUT_PRESETS[number
         ? "Stonewatch Fork"
       : id === "layout_ridgeway_crossing"
         ? "Ridgeway Crossing"
+      : id === "layout_highland_reach"
+        ? "Highland Reach"
+      : id === "layout_amber_fields"
+        ? "Amber Fields"
+      : id === "layout_ironpass_gorge"
+        ? "Ironpass Gorge"
+      : id === "layout_splitrock_canyon"
+        ? "Splitrock Canyon"
       : id === "layout_contested_basin"
         ? "Contested Basin"
         : "Phase 1";
@@ -1810,6 +1834,14 @@ function buildLayoutPresetSummary(id: typeof BUILTIN_WORLD_LAYOUT_PRESETS[number
         ? "切换为石望岔路布局，适合验证双招募点、分叉矿线与南北奖励节奏。"
       : id === "layout_ridgeway_crossing"
         ? "切换为第二个 Phase 1 岭桥布局，适合验证中央渡口争夺、双招募点和木矿/矿井分流。"
+      : id === "layout_highland_reach"
+        ? "切换为高地平原布局，适合验证大尺寸对称开阔地与中央高台争夺。"
+      : id === "layout_amber_fields"
+        ? "切换为琥珀田布局，适合验证多资源点分布与中路高地争夺。"
+      : id === "layout_ironpass_gorge"
+        ? "切换为铁关峡谷布局，适合验证狭窄通道、峡口守军与双侧矿线。"
+      : id === "layout_splitrock_canyon"
+        ? "切换为裂岩峡谷布局，适合验证非对称出生点与双线路径压迫。"
       : id === "layout_contested_basin"
         ? "切换为争夺盆地布局，包含新巡逻守军与瞭望塔。"
         : "恢复默认 Phase 1 地图布局。";
@@ -1856,6 +1888,18 @@ function resolveBuiltinPresetContent(id: ConfigDocumentId, currentContent: strin
     if (presetId === "layout_ridgeway_crossing") {
       return normalizeJsonContent(ridgewayCrossingWorldConfig as WorldGenerationConfig);
     }
+    if (presetId === "layout_highland_reach") {
+      return normalizeJsonContent(highlandReachWorldConfig as WorldGenerationConfig);
+    }
+    if (presetId === "layout_amber_fields") {
+      return normalizeJsonContent(amberFieldsWorldConfig as WorldGenerationConfig);
+    }
+    if (presetId === "layout_ironpass_gorge") {
+      return normalizeJsonContent(ironpassGorgeWorldConfig as WorldGenerationConfig);
+    }
+    if (presetId === "layout_splitrock_canyon") {
+      return normalizeJsonContent(splitrockCanyonWorldConfig as WorldGenerationConfig);
+    }
     if (presetId === "layout_contested_basin") {
       return normalizeJsonContent(contestedBasinWorldConfig as WorldGenerationConfig);
     }
@@ -1873,6 +1917,18 @@ function resolveBuiltinPresetContent(id: ConfigDocumentId, currentContent: strin
     }
     if (presetId === "layout_ridgeway_crossing") {
       return normalizeJsonContent(ridgewayCrossingMapObjectsConfig as MapObjectsConfig);
+    }
+    if (presetId === "layout_highland_reach") {
+      return normalizeJsonContent(highlandReachMapObjectsConfig as MapObjectsConfig);
+    }
+    if (presetId === "layout_amber_fields") {
+      return normalizeJsonContent(amberFieldsMapObjectsConfig as MapObjectsConfig);
+    }
+    if (presetId === "layout_ironpass_gorge") {
+      return normalizeJsonContent(ironpassGorgeMapObjectsConfig as MapObjectsConfig);
+    }
+    if (presetId === "layout_splitrock_canyon") {
+      return normalizeJsonContent(splitrockCanyonMapObjectsConfig as MapObjectsConfig);
     }
     if (presetId === "layout_contested_basin") {
       return normalizeJsonContent(contestedBasinMapObjectsConfig as MapObjectsConfig);

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -519,14 +519,23 @@ test("config center exposes built-in layout presets for the additional map varia
   assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_stonewatch_fork"));
   assert.ok(worldPresets.some((preset) => preset.id === "layout_ridgeway_crossing"));
   assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_ridgeway_crossing"));
+  assert.ok(worldPresets.some((preset) => preset.id === "layout_highland_reach"));
+  assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_highland_reach"));
+  assert.ok(worldPresets.some((preset) => preset.id === "layout_amber_fields"));
+  assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_amber_fields"));
+  assert.ok(worldPresets.some((preset) => preset.id === "layout_ironpass_gorge"));
+  assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_ironpass_gorge"));
+  assert.ok(worldPresets.some((preset) => preset.id === "layout_splitrock_canyon"));
+  assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_splitrock_canyon"));
   assert.ok(worldPresets.some((preset) => preset.id === "layout_contested_basin"));
   assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_contested_basin"));
 
-  const stonewatchWorldDocument = await store.applyPreset("world", "layout_stonewatch_fork");
-  const stonewatchMapObjectsDocument = await store.applyPreset("mapObjects", "layout_stonewatch_fork");
+  const highlandWorldDocument = await store.applyPreset("world", "layout_highland_reach");
+  const highlandMapObjectsDocument = await store.applyPreset("mapObjects", "layout_highland_reach");
 
-  assert.match(stonewatchWorldDocument.content, /"position": \{\s+"x": 1,\s+"y": 5/s);
-  assert.match(stonewatchMapObjectsDocument.content, /"id": "shrine-power-1"/);
+  assert.match(highlandWorldDocument.content, /"width": 10/);
+  assert.match(highlandWorldDocument.content, /"position": \{\s+"x": 1,\s+"y": 4/s);
+  assert.match(highlandMapObjectsDocument.content, /"id": "mine-ore-1"/);
 });
 
 test("config center diff classifies added, removed, and type changes", async () => {

--- a/configs/phase1-map-objects-amber-fields.json
+++ b/configs/phase1-map-objects-amber-fields.json
@@ -1,0 +1,235 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": {
+        "x": 4,
+        "y": 3
+      },
+      "reward": {
+        "kind": "wood",
+        "amount": 6
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 6
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [
+          { "x": 4, "y": 3 },
+          { "x": 5, "y": 3 },
+          { "x": 5, "y": 4 },
+          { "x": 4, "y": 4 }
+        ],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": {
+        "x": 5,
+        "y": 6
+      },
+      "reward": {
+        "kind": "ore",
+        "amount": 5
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 5
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": {
+        "x": 3,
+        "y": 4
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 240
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 5
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolRadius": 2,
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": {
+        "x": 6,
+        "y": 5
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 260
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 4
+        },
+        {
+          "templateId": "wolf_pack",
+          "count": 2
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    {
+      "position": {
+        "x": 2,
+        "y": 2
+      },
+      "resource": {
+        "kind": "wood",
+        "amount": 5
+      }
+    },
+    {
+      "position": {
+        "x": 7,
+        "y": 7
+      },
+      "resource": {
+        "kind": "ore",
+        "amount": 4
+      }
+    },
+    {
+      "position": {
+        "x": 2,
+        "y": 7
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 200
+      }
+    },
+    {
+      "position": {
+        "x": 7,
+        "y": 2
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 200
+      }
+    }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 1,
+        "y": 3
+      },
+      "label": "琥珀田前哨",
+      "unitTemplateId": "crown_crossbowman",
+      "recruitCount": 4,
+      "cost": {
+        "gold": 240,
+        "wood": 0,
+        "ore": 0
+      }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 8,
+        "y": 6
+      },
+      "label": "麦垄补员所",
+      "unitTemplateId": "crown_heavy_cavalry",
+      "recruitCount": 3,
+      "cost": {
+        "gold": 180,
+        "wood": 1,
+        "ore": 0
+      }
+    },
+    {
+      "id": "shrine-power-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 4,
+        "y": 4
+      },
+      "label": "金穗观象坛",
+      "bonus": {
+        "attack": 0,
+        "defense": 0,
+        "power": 1,
+        "knowledge": 1
+      }
+    },
+    {
+      "id": "shrine-knowledge-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 5,
+        "y": 5
+      },
+      "label": "丰岁识见坛",
+      "bonus": {
+        "attack": 0,
+        "defense": 0,
+        "power": 0,
+        "knowledge": 2
+      }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 2,
+        "y": 6
+      },
+      "label": "谷仓林场",
+      "resourceKind": "wood",
+      "income": 4
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 7,
+        "y": 3
+      },
+      "label": "田脊矿井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-map-objects-highland-reach.json
+++ b/configs/phase1-map-objects-highland-reach.json
@@ -1,0 +1,235 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": {
+        "x": 4,
+        "y": 2
+      },
+      "reward": {
+        "kind": "wood",
+        "amount": 6
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 6
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [
+          { "x": 4, "y": 2 },
+          { "x": 5, "y": 2 },
+          { "x": 5, "y": 3 },
+          { "x": 4, "y": 3 }
+        ],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": {
+        "x": 5,
+        "y": 7
+      },
+      "reward": {
+        "kind": "ore",
+        "amount": 4
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 5
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": {
+        "x": 3,
+        "y": 6
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 280
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 5
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolRadius": 2,
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": {
+        "x": 6,
+        "y": 3
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 240
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 4
+        },
+        {
+          "templateId": "wolf_pack",
+          "count": 2
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    {
+      "position": {
+        "x": 1,
+        "y": 2
+      },
+      "resource": {
+        "kind": "wood",
+        "amount": 5
+      }
+    },
+    {
+      "position": {
+        "x": 8,
+        "y": 7
+      },
+      "resource": {
+        "kind": "ore",
+        "amount": 4
+      }
+    },
+    {
+      "position": {
+        "x": 2,
+        "y": 7
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 200
+      }
+    },
+    {
+      "position": {
+        "x": 7,
+        "y": 2
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 200
+      }
+    }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 1,
+        "y": 1
+      },
+      "label": "高地征募站",
+      "unitTemplateId": "crown_crossbowman",
+      "recruitCount": 4,
+      "cost": {
+        "gold": 240,
+        "wood": 0,
+        "ore": 0
+      }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 8,
+        "y": 8
+      },
+      "label": "边垒补员营",
+      "unitTemplateId": "crown_light_outrider",
+      "recruitCount": 3,
+      "cost": {
+        "gold": 180,
+        "wood": 1,
+        "ore": 0
+      }
+    },
+    {
+      "id": "shrine-attack-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 4,
+        "y": 4
+      },
+      "label": "长风战旗坛",
+      "bonus": {
+        "attack": 2,
+        "defense": 0,
+        "power": 0,
+        "knowledge": 0
+      }
+    },
+    {
+      "id": "shrine-defense-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 5,
+        "y": 5
+      },
+      "label": "高垣守誓坛",
+      "bonus": {
+        "attack": 0,
+        "defense": 2,
+        "power": 0,
+        "knowledge": 0
+      }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 2,
+        "y": 5
+      },
+      "label": "高坡伐木场",
+      "resourceKind": "wood",
+      "income": 4
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 7,
+        "y": 4
+      },
+      "label": "风口铁矿井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-map-objects-ironpass-gorge.json
+++ b/configs/phase1-map-objects-ironpass-gorge.json
@@ -1,0 +1,240 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": {
+        "x": 5,
+        "y": 6
+      },
+      "reward": {
+        "kind": "ore",
+        "amount": 5
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 5
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": {
+        "x": 6,
+        "y": 3
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 300
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 7
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [
+          { "x": 6, "y": 3 },
+          { "x": 6, "y": 4 },
+          { "x": 5, "y": 4 },
+          { "x": 5, "y": 3 }
+        ],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": {
+        "x": 2,
+        "y": 5
+      },
+      "reward": {
+        "kind": "wood",
+        "amount": 6
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 4
+        },
+        {
+          "templateId": "wolf_pack",
+          "count": 2
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": {
+        "x": 9,
+        "y": 4
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 260
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 6
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [
+          { "x": 9, "y": 4 },
+          { "x": 10, "y": 4 },
+          { "x": 10, "y": 5 },
+          { "x": 9, "y": 5 }
+        ],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    {
+      "position": {
+        "x": 2,
+        "y": 2
+      },
+      "resource": {
+        "kind": "wood",
+        "amount": 5
+      }
+    },
+    {
+      "position": {
+        "x": 9,
+        "y": 7
+      },
+      "resource": {
+        "kind": "ore",
+        "amount": 4
+      }
+    },
+    {
+      "position": {
+        "x": 5,
+        "y": 2
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 220
+      }
+    },
+    {
+      "position": {
+        "x": 6,
+        "y": 7
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 220
+      }
+    }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 1,
+        "y": 3
+      },
+      "label": "铁关前哨营",
+      "unitTemplateId": "crown_crossbowman",
+      "recruitCount": 4,
+      "cost": {
+        "gold": 240,
+        "wood": 0,
+        "ore": 0
+      }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 10,
+        "y": 6
+      },
+      "label": "峡口补员站",
+      "unitTemplateId": "crown_heavy_cavalry",
+      "recruitCount": 3,
+      "cost": {
+        "gold": 180,
+        "wood": 1,
+        "ore": 0
+      }
+    },
+    {
+      "id": "shrine-defense-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 5,
+        "y": 4
+      },
+      "label": "隘口守望坛",
+      "bonus": {
+        "attack": 0,
+        "defense": 2,
+        "power": 0,
+        "knowledge": 0
+      }
+    },
+    {
+      "id": "shrine-attack-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 6,
+        "y": 5
+      },
+      "label": "断崖战意坛",
+      "bonus": {
+        "attack": 2,
+        "defense": 0,
+        "power": 0,
+        "knowledge": 0
+      }
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 2,
+        "y": 7
+      },
+      "label": "铁关矿井",
+      "resourceKind": "ore",
+      "income": 4
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 9,
+        "y": 2
+      },
+      "label": "峡谷林场",
+      "resourceKind": "wood",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-map-objects-splitrock-canyon.json
+++ b/configs/phase1-map-objects-splitrock-canyon.json
@@ -1,0 +1,240 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": {
+        "x": 4,
+        "y": 5
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 260
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 6
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [
+          { "x": 4, "y": 5 },
+          { "x": 4, "y": 6 },
+          { "x": 3, "y": 6 },
+          { "x": 3, "y": 5 }
+        ],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": {
+        "x": 6,
+        "y": 2
+      },
+      "reward": {
+        "kind": "wood",
+        "amount": 6
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 5
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": {
+        "x": 7,
+        "y": 7
+      },
+      "reward": {
+        "kind": "ore",
+        "amount": 5
+      },
+      "stacks": [
+        {
+          "templateId": "hero_guard_basic",
+          "count": 4
+        },
+        {
+          "templateId": "wolf_pack",
+          "count": 2
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": {
+        "x": 9,
+        "y": 5
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 320
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 6
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [
+          { "x": 9, "y": 5 },
+          { "x": 10, "y": 5 },
+          { "x": 10, "y": 4 },
+          { "x": 9, "y": 4 }
+        ],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    {
+      "position": {
+        "x": 1,
+        "y": 5
+      },
+      "resource": {
+        "kind": "wood",
+        "amount": 5
+      }
+    },
+    {
+      "position": {
+        "x": 5,
+        "y": 1
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 200
+      }
+    },
+    {
+      "position": {
+        "x": 6,
+        "y": 8
+      },
+      "resource": {
+        "kind": "ore",
+        "amount": 4
+      }
+    },
+    {
+      "position": {
+        "x": 10,
+        "y": 4
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 180
+      }
+    }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 2,
+        "y": 1
+      },
+      "label": "裂岩前营",
+      "unitTemplateId": "crown_heavy_cavalry",
+      "recruitCount": 4,
+      "cost": {
+        "gold": 240,
+        "wood": 0,
+        "ore": 0
+      }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 10,
+        "y": 8
+      },
+      "label": "峡尾补员站",
+      "unitTemplateId": "crown_field_chaplain",
+      "recruitCount": 3,
+      "cost": {
+        "gold": 170,
+        "wood": 0,
+        "ore": 1
+      }
+    },
+    {
+      "id": "shrine-power-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 4,
+        "y": 2
+      },
+      "label": "裂隙星坛",
+      "bonus": {
+        "attack": 0,
+        "defense": 0,
+        "power": 1,
+        "knowledge": 1
+      }
+    },
+    {
+      "id": "shrine-defense-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 7,
+        "y": 6
+      },
+      "label": "峭壁守誓坛",
+      "bonus": {
+        "attack": 0,
+        "defense": 2,
+        "power": 0,
+        "knowledge": 0
+      }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 2,
+        "y": 6
+      },
+      "label": "裂谷林场",
+      "resourceKind": "wood",
+      "income": 4
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 9,
+        "y": 3
+      },
+      "label": "分岩矿井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-world-amber-fields.json
+++ b/configs/phase1-world-amber-fields.json
@@ -1,0 +1,171 @@
+{
+  "width": 10,
+  "height": 10,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": {
+        "x": 1,
+        "y": 1
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "militia_pike",
+          "vanguard_blade",
+          "padded_gambeson",
+          "scout_compass"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": {
+        "x": 8,
+        "y": 8
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "oak_longbow",
+          "tower_shield_mail",
+          "scribe_charm",
+          "captains_insignia"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.06,
+    "woodChance": 0.08,
+    "oreChance": 0.08
+  },
+  "terrainOverrides": [
+    {
+      "position": { "x": 0, "y": 4 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 0, "y": 5 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 9, "y": 4 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 9, "y": 5 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 3 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 3 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 3, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 4, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 6, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 3, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 4, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 6, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 4, "y": 6 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 6 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 2, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 7, "y": 5 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 2, "y": 5 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 7, "y": 4 },
+      "terrain": "sand"
+    }
+  ]
+}

--- a/configs/phase1-world-highland-reach.json
+++ b/configs/phase1-world-highland-reach.json
@@ -1,0 +1,171 @@
+{
+  "width": 10,
+  "height": 10,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": {
+        "x": 1,
+        "y": 4
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "militia_pike",
+          "vanguard_blade",
+          "padded_gambeson",
+          "scout_compass"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": {
+        "x": 8,
+        "y": 5
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "oak_longbow",
+          "tower_shield_mail",
+          "scribe_charm",
+          "captains_insignia"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.05,
+    "woodChance": 0.07,
+    "oreChance": 0.07
+  },
+  "terrainOverrides": [
+    {
+      "position": { "x": 2, "y": 1 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 2, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 7 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 8 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 3 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 3 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 3, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 4, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 6, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 3, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 4, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 6, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 4, "y": 6 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 5, "y": 6 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 1, "y": 3 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 2, "y": 3 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 7, "y": 6 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 8, "y": 6 },
+      "terrain": "sand"
+    }
+  ]
+}

--- a/configs/phase1-world-ironpass-gorge.json
+++ b/configs/phase1-world-ironpass-gorge.json
@@ -1,0 +1,251 @@
+{
+  "width": 12,
+  "height": 10,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": {
+        "x": 1,
+        "y": 4
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "militia_pike",
+          "vanguard_blade",
+          "padded_gambeson",
+          "scout_compass"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": {
+        "x": 10,
+        "y": 5
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "oak_longbow",
+          "tower_shield_mail",
+          "scribe_charm",
+          "captains_insignia"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.04,
+    "woodChance": 0.06,
+    "oreChance": 0.08
+  },
+  "terrainOverrides": [
+    {
+      "position": { "x": 3, "y": 0 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 1 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 3 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 6 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 7 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 8 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 9 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 0 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 1 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 7 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 8 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 9 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 0 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 1 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 7 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 8 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 9 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 0 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 1 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 3 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 6 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 7 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 8 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 9 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 5, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 6, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 7, "y": 4 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 4, "y": 5 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 5, "y": 5 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 6, "y": 5 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 7, "y": 5 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 2, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 3, "y": 4 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 8, "y": 5 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 9, "y": 5 },
+      "terrain": "dirt"
+    }
+  ]
+}

--- a/configs/phase1-world-splitrock-canyon.json
+++ b/configs/phase1-world-splitrock-canyon.json
@@ -1,0 +1,191 @@
+{
+  "width": 12,
+  "height": 10,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": {
+        "x": 1,
+        "y": 2
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "militia_pike",
+          "vanguard_blade",
+          "padded_gambeson",
+          "scout_compass"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": {
+        "x": 9,
+        "y": 7
+      },
+      "vision": 2,
+      "move": {
+        "total": 6,
+        "remaining": 6
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "oak_longbow",
+          "tower_shield_mail",
+          "scribe_charm",
+          "captains_insignia"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.05,
+    "woodChance": 0.06,
+    "oreChance": 0.08
+  },
+  "terrainOverrides": [
+    {
+      "position": { "x": 3, "y": 1 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 3 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 3, "y": 4 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 5, "y": 3 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 5, "y": 4 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 5, "y": 5 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 5, "y": 6 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 5 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 6 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 7 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 8, "y": 8 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 1 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 7, "y": 2 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 7 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 4, "y": 8 },
+      "terrain": "water"
+    },
+    {
+      "position": { "x": 2, "y": 3 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 4, "y": 2 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 6, "y": 2 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 7, "y": 6 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 9, "y": 6 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 10, "y": 5 },
+      "terrain": "sand"
+    },
+    {
+      "position": { "x": 2, "y": 1 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 6, "y": 7 },
+      "terrain": "dirt"
+    },
+    {
+      "position": { "x": 9, "y": 4 },
+      "terrain": "dirt"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "validate:quickstart": "node ./scripts/validate-local-dev-quickstart.mjs",
     "validate:e2e:fixtures": "node --import tsx ./scripts/validate-e2e-config-fixtures.ts",
     "validate:content-pack": "node --import tsx ./scripts/validate-content-pack.ts",
-    "validate:content-pack:all": "node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack stonewatch-fork --map-pack ridgeway-crossing --map-pack phase2",
+    "validate:content-pack:all": "node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack stonewatch-fork --map-pack ridgeway-crossing --map-pack highland-reach --map-pack amber-fields --map-pack ironpass-gorge --map-pack splitrock-canyon --map-pack phase2",
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
     "stress:rooms:baseline": "node --import tsx ./scripts/stress-concurrent-rooms.ts --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --artifact-path=artifacts/release-readiness/stress-rooms-runtime-metrics.json",
     "stress:rooms:reconnect-soak": "node --import tsx ./scripts/stress-concurrent-rooms.ts --scenarios=reconnect_soak --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --reconnect-cycles=8",

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -2,13 +2,21 @@ import defaultBattleSkillsConfig from "../../../configs/battle-skills.json";
 import defaultBattleBalanceConfig from "../../../configs/battle-balance.json";
 import defaultHeroSkillTreesConfig from "../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
+import amberFieldsMapObjectsConfig from "../../../configs/phase1-map-objects-amber-fields.json";
 import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
+import highlandReachMapObjectsConfig from "../../../configs/phase1-map-objects-highland-reach.json";
+import ironpassGorgeMapObjectsConfig from "../../../configs/phase1-map-objects-ironpass-gorge.json";
+import splitrockCanyonMapObjectsConfig from "../../../configs/phase1-map-objects-splitrock-canyon.json";
 import stonewatchForkMapObjectsConfig from "../../../configs/phase1-map-objects-stonewatch-fork.json";
 import ridgewayCrossingMapObjectsConfig from "../../../configs/phase1-map-objects-ridgeway-crossing.json";
 import defaultMapObjectsConfig from "../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../configs/units.json";
+import amberFieldsWorldConfig from "../../../configs/phase1-world-amber-fields.json";
 import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
 import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
+import highlandReachWorldConfig from "../../../configs/phase1-world-highland-reach.json";
+import ironpassGorgeWorldConfig from "../../../configs/phase1-world-ironpass-gorge.json";
+import splitrockCanyonWorldConfig from "../../../configs/phase1-world-splitrock-canyon.json";
 import stonewatchForkWorldConfig from "../../../configs/phase1-world-stonewatch-fork.json";
 import ridgewayCrossingWorldConfig from "../../../configs/phase1-world-ridgeway-crossing.json";
 import defaultWorldConfig from "../../../configs/phase1-world.json";
@@ -38,6 +46,10 @@ export const DEFAULT_MAP_VARIANT_ID = "phase1";
 export const FRONTIER_BASIN_MAP_VARIANT_ID = "frontier_basin";
 export const STONEWATCH_FORK_MAP_VARIANT_ID = "stonewatch_fork";
 export const RIDGEWAY_CROSSING_MAP_VARIANT_ID = "ridgeway_crossing";
+export const HIGHLAND_REACH_MAP_VARIANT_ID = "highland_reach";
+export const AMBER_FIELDS_MAP_VARIANT_ID = "amber_fields";
+export const IRONPASS_GORGE_MAP_VARIANT_ID = "ironpass_gorge";
+export const SPLITROCK_CANYON_MAP_VARIANT_ID = "splitrock_canyon";
 export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
 
 export interface RuntimeConfigBundle {
@@ -752,6 +764,10 @@ function getAvailableMapVariantIds(): string[] {
     FRONTIER_BASIN_MAP_VARIANT_ID,
     STONEWATCH_FORK_MAP_VARIANT_ID,
     RIDGEWAY_CROSSING_MAP_VARIANT_ID,
+    HIGHLAND_REACH_MAP_VARIANT_ID,
+    AMBER_FIELDS_MAP_VARIANT_ID,
+    IRONPASS_GORGE_MAP_VARIANT_ID,
+    SPLITROCK_CANYON_MAP_VARIANT_ID,
     CONTESTED_BASIN_MAP_VARIANT_ID
   ];
 }
@@ -770,6 +786,10 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     requested === FRONTIER_BASIN_MAP_VARIANT_ID ||
     requested === STONEWATCH_FORK_MAP_VARIANT_ID ||
     requested === RIDGEWAY_CROSSING_MAP_VARIANT_ID ||
+    requested === HIGHLAND_REACH_MAP_VARIANT_ID ||
+    requested === AMBER_FIELDS_MAP_VARIANT_ID ||
+    requested === IRONPASS_GORGE_MAP_VARIANT_ID ||
+    requested === SPLITROCK_CANYON_MAP_VARIANT_ID ||
     requested === CONTESTED_BASIN_MAP_VARIANT_ID
   ) {
     return requested;
@@ -790,6 +810,14 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneWorldConfig(stonewatchForkWorldConfig as WorldGenerationConfig)
       : mapVariantId === RIDGEWAY_CROSSING_MAP_VARIANT_ID
         ? cloneWorldConfig(ridgewayCrossingWorldConfig as WorldGenerationConfig)
+      : mapVariantId === HIGHLAND_REACH_MAP_VARIANT_ID
+        ? cloneWorldConfig(highlandReachWorldConfig as WorldGenerationConfig)
+      : mapVariantId === AMBER_FIELDS_MAP_VARIANT_ID
+        ? cloneWorldConfig(amberFieldsWorldConfig as WorldGenerationConfig)
+      : mapVariantId === IRONPASS_GORGE_MAP_VARIANT_ID
+        ? cloneWorldConfig(ironpassGorgeWorldConfig as WorldGenerationConfig)
+      : mapVariantId === SPLITROCK_CANYON_MAP_VARIANT_ID
+        ? cloneWorldConfig(splitrockCanyonWorldConfig as WorldGenerationConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
         : getDefaultWorldConfig();
@@ -800,6 +828,14 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneMapObjectsConfig(stonewatchForkMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === RIDGEWAY_CROSSING_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(ridgewayCrossingMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === HIGHLAND_REACH_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(highlandReachMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === AMBER_FIELDS_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(amberFieldsMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === IRONPASS_GORGE_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(ironpassGorgeMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === SPLITROCK_CANYON_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(splitrockCanyonMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
         : getDefaultMapObjectsConfig();

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -2,10 +2,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import assetConfig from "../../../configs/assets.json";
+import amberFieldsMapObjectsConfig from "../../../configs/phase1-map-objects-amber-fields.json";
 import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
+import highlandReachMapObjectsConfig from "../../../configs/phase1-map-objects-highland-reach.json";
+import ironpassGorgeMapObjectsConfig from "../../../configs/phase1-map-objects-ironpass-gorge.json";
+import splitrockCanyonMapObjectsConfig from "../../../configs/phase1-map-objects-splitrock-canyon.json";
 import stonewatchForkMapObjectsConfig from "../../../configs/phase1-map-objects-stonewatch-fork.json";
 import ridgewayCrossingMapObjectsConfig from "../../../configs/phase1-map-objects-ridgeway-crossing.json";
+import amberFieldsWorldConfig from "../../../configs/phase1-world-amber-fields.json";
 import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
+import highlandReachWorldConfig from "../../../configs/phase1-world-highland-reach.json";
+import ironpassGorgeWorldConfig from "../../../configs/phase1-world-ironpass-gorge.json";
+import splitrockCanyonWorldConfig from "../../../configs/phase1-world-splitrock-canyon.json";
 import stonewatchForkWorldConfig from "../../../configs/phase1-world-stonewatch-fork.json";
 import ridgewayCrossingWorldConfig from "../../../configs/phase1-world-ridgeway-crossing.json";
 import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
@@ -16,6 +24,7 @@ import {
   appendEventLogEntries,
   appendPlayerBattleReplaySummaries,
   applyBattleOutcomeToWorld,
+  AMBER_FIELDS_MAP_VARIANT_ID,
   applyAchievementMetricDelta,
   applyAchievementProgressValue,
   buildPlayerBattleReportCenter,
@@ -60,7 +69,9 @@ import {
   getLatestProgressedAchievement,
   getLatestUnlockedAchievement,
   HERO_EQUIPMENT_INVENTORY_CAPACITY,
+  HIGHLAND_REACH_MAP_VARIANT_ID,
   hasFullyExploredMap,
+  IRONPASS_GORGE_MAP_VARIANT_ID,
   normalizeAchievementProgressQuery,
   normalizeEventLogQuery,
   normalizePlayerAccountReadModel,
@@ -76,6 +87,7 @@ import {
   RIDGEWAY_CROSSING_MAP_VARIANT_ID,
   simulateAutomatedBattle,
   simulateAutomatedBattles,
+  SPLITROCK_CANYON_MAP_VARIANT_ID,
   STONEWATCH_FORK_MAP_VARIANT_ID,
   summarizeAssetMetadata,
   stepBattleReplayPlayback,
@@ -2465,6 +2477,63 @@ test("createInitialWorldState selects the stonewatch fork variant with the addit
   assert.equal(state.neutralArmies["neutral-4"]?.behavior?.mode, "patrol");
 });
 
+test("createInitialWorldState selects the highland reach variant with the wider plains layout", () => {
+  const state = createInitialWorldState(1001, "preview-highland[map:highland_reach]");
+
+  assert.equal(state.meta.mapVariantId, "highland_reach");
+  assert.equal(state.map.tiles.length, 100);
+  assert.equal(state.heroes[0]?.position.x, 1);
+  assert.equal(state.heroes[0]?.position.y, 4);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 2 && tile.position.y === 1)?.terrain, "water");
+  assert.equal(state.buildings["mine-ore-1"]?.resourceKind, "ore");
+  assert.equal(state.buildings["shrine-defense-1"]?.kind, "attribute_shrine");
+  assert.equal(state.neutralArmies["neutral-2"]?.reward?.kind, "ore");
+  assert.equal(state.neutralArmies["neutral-3"]?.behavior?.mode, "patrol");
+});
+
+test("createInitialWorldState selects the amber fields variant with the central resource contest", () => {
+  const state = createInitialWorldState(1001, "preview-amber[map:amber_fields]");
+
+  assert.equal(state.meta.mapVariantId, "amber_fields");
+  assert.equal(state.map.tiles.length, 100);
+  assert.equal(state.heroes[1]?.position.x, 8);
+  assert.equal(state.heroes[1]?.position.y, 8);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 4 && tile.position.y === 4)?.terrain, "dirt");
+  assert.equal(state.buildings["shrine-power-1"]?.kind, "attribute_shrine");
+  assert.equal(state.buildings["mine-wood-1"]?.resourceKind, "wood");
+  assert.equal(state.neutralArmies["neutral-1"]?.reward?.kind, "wood");
+  assert.equal(state.neutralArmies["neutral-4"]?.reward?.amount, 260);
+});
+
+test("createInitialWorldState selects the ironpass gorge variant with a narrow canyon corridor", () => {
+  const state = createInitialWorldState(1001, "preview-ironpass[map:ironpass_gorge]");
+
+  assert.equal(state.meta.mapVariantId, "ironpass_gorge");
+  assert.equal(state.map.tiles.length, 120);
+  assert.equal(state.heroes[0]?.position.x, 1);
+  assert.equal(state.heroes[0]?.position.y, 4);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 3 && tile.position.y === 0)?.terrain, "water");
+  assert.equal(state.buildings["shrine-defense-1"]?.kind, "attribute_shrine");
+  assert.equal(state.buildings["mine-ore-1"]?.resourceKind, "ore");
+  assert.equal(state.neutralArmies["neutral-2"]?.behavior?.mode, "patrol");
+  assert.equal(state.neutralArmies["neutral-3"]?.reward?.kind, "wood");
+});
+
+test("createInitialWorldState selects the splitrock canyon variant with asymmetric starts", () => {
+  const state = createInitialWorldState(1001, "preview-splitrock[map:splitrock_canyon]");
+
+  assert.equal(state.meta.mapVariantId, "splitrock_canyon");
+  assert.equal(state.map.tiles.length, 120);
+  assert.equal(state.heroes[0]?.position.x, 1);
+  assert.equal(state.heroes[0]?.position.y, 2);
+  assert.equal(state.heroes[1]?.position.x, 9);
+  assert.equal(state.heroes[1]?.position.y, 7);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 3 && tile.position.y === 1)?.terrain, "water");
+  assert.equal(state.buildings["mine-ore-1"]?.resourceKind, "ore");
+  assert.equal(state.buildings["recruit-post-2"]?.kind, "recruitment_post");
+  assert.equal(state.neutralArmies["neutral-4"]?.behavior?.mode, "patrol");
+});
+
 test("frontier basin generates a distinct layout from the default phase1 variant", () => {
   const seed = 5124;
   const defaultRoomId = "preview-default";
@@ -2573,6 +2642,62 @@ test("stonewatch fork configs validate alongside the existing Phase 1 variants",
   assert.doesNotThrow(() => {
     validateWorldConfig(stonewatchWorld);
     validateMapObjectsConfig(stonewatchMapObjects, stonewatchWorld, units);
+  });
+});
+
+test("highland reach configs validate alongside the expanded Phase 1 variants", () => {
+  const units = getDefaultUnitCatalog();
+  const highlandWorld = highlandReachWorldConfig as WorldGenerationConfig;
+  const highlandMapObjects = highlandReachMapObjectsConfig as MapObjectsConfig;
+  const bundle = getRuntimeConfigBundleForRoom("preview-highland[map:highland_reach]", 5124);
+
+  assert.equal(bundle.mapVariantId, HIGHLAND_REACH_MAP_VARIANT_ID);
+
+  assert.doesNotThrow(() => {
+    validateWorldConfig(highlandWorld);
+    validateMapObjectsConfig(highlandMapObjects, highlandWorld, units);
+  });
+});
+
+test("amber fields configs validate alongside the expanded Phase 1 variants", () => {
+  const units = getDefaultUnitCatalog();
+  const amberWorld = amberFieldsWorldConfig as WorldGenerationConfig;
+  const amberMapObjects = amberFieldsMapObjectsConfig as MapObjectsConfig;
+  const bundle = getRuntimeConfigBundleForRoom("preview-amber[map:amber_fields]", 5124);
+
+  assert.equal(bundle.mapVariantId, AMBER_FIELDS_MAP_VARIANT_ID);
+
+  assert.doesNotThrow(() => {
+    validateWorldConfig(amberWorld);
+    validateMapObjectsConfig(amberMapObjects, amberWorld, units);
+  });
+});
+
+test("ironpass gorge configs validate alongside the expanded Phase 1 variants", () => {
+  const units = getDefaultUnitCatalog();
+  const ironpassWorld = ironpassGorgeWorldConfig as WorldGenerationConfig;
+  const ironpassMapObjects = ironpassGorgeMapObjectsConfig as MapObjectsConfig;
+  const bundle = getRuntimeConfigBundleForRoom("preview-ironpass[map:ironpass_gorge]", 5124);
+
+  assert.equal(bundle.mapVariantId, IRONPASS_GORGE_MAP_VARIANT_ID);
+
+  assert.doesNotThrow(() => {
+    validateWorldConfig(ironpassWorld);
+    validateMapObjectsConfig(ironpassMapObjects, ironpassWorld, units);
+  });
+});
+
+test("splitrock canyon configs validate alongside the expanded Phase 1 variants", () => {
+  const units = getDefaultUnitCatalog();
+  const splitrockWorld = splitrockCanyonWorldConfig as WorldGenerationConfig;
+  const splitrockMapObjects = splitrockCanyonMapObjectsConfig as MapObjectsConfig;
+  const bundle = getRuntimeConfigBundleForRoom("preview-splitrock[map:splitrock_canyon]", 5124);
+
+  assert.equal(bundle.mapVariantId, SPLITROCK_CANYON_MAP_VARIANT_ID);
+
+  assert.doesNotThrow(() => {
+    validateWorldConfig(splitrockWorld);
+    validateMapObjectsConfig(splitrockMapObjects, splitrockWorld, units);
   });
 });
 

--- a/scripts/content-pack-map-packs.ts
+++ b/scripts/content-pack-map-packs.ts
@@ -37,6 +37,34 @@ export const EXTRA_CONTENT_PACK_MAP_PACKS: ContentPackMapPackDefinition[] = [
     aliases: ["ridgeway_crossing", "ridgeway"]
   },
   {
+    id: "highland-reach",
+    worldFileName: "phase1-world-highland-reach.json",
+    mapObjectsFileName: "phase1-map-objects-highland-reach.json",
+    phase: "phase1",
+    aliases: ["highland_reach", "highland"]
+  },
+  {
+    id: "amber-fields",
+    worldFileName: "phase1-world-amber-fields.json",
+    mapObjectsFileName: "phase1-map-objects-amber-fields.json",
+    phase: "phase1",
+    aliases: ["amber_fields", "amber"]
+  },
+  {
+    id: "ironpass-gorge",
+    worldFileName: "phase1-world-ironpass-gorge.json",
+    mapObjectsFileName: "phase1-map-objects-ironpass-gorge.json",
+    phase: "phase1",
+    aliases: ["ironpass_gorge", "ironpass"]
+  },
+  {
+    id: "splitrock-canyon",
+    worldFileName: "phase1-world-splitrock-canyon.json",
+    mapObjectsFileName: "phase1-map-objects-splitrock-canyon.json",
+    phase: "phase1",
+    aliases: ["splitrock_canyon", "splitrock"]
+  },
+  {
     id: "phase2",
     worldFileName: "phase2-contested-basin.json",
     mapObjectsFileName: "phase2-map-objects-contested-basin.json",

--- a/scripts/test/validate-content-pack.test.ts
+++ b/scripts/test/validate-content-pack.test.ts
@@ -28,6 +28,14 @@ async function seedContentPackRoot(tempDir: string): Promise<void> {
       "phase1-map-objects-stonewatch-fork.json",
       "phase1-world-ridgeway-crossing.json",
       "phase1-map-objects-ridgeway-crossing.json",
+      "phase1-world-highland-reach.json",
+      "phase1-map-objects-highland-reach.json",
+      "phase1-world-amber-fields.json",
+      "phase1-map-objects-amber-fields.json",
+      "phase1-world-ironpass-gorge.json",
+      "phase1-map-objects-ironpass-gorge.json",
+      "phase1-world-splitrock-canyon.json",
+      "phase1-map-objects-splitrock-canyon.json",
       "phase2-contested-basin.json",
       "phase2-map-objects-contested-basin.json",
       "units.json",
@@ -53,15 +61,27 @@ test("validate-content-pack validates all shipped map packs with CLI presets", a
       "--map-pack",
       "ridgeway-crossing",
       "--map-pack",
+      "highland-reach",
+      "--map-pack",
+      "amber-fields",
+      "--map-pack",
+      "ironpass-gorge",
+      "--map-pack",
+      "splitrock-canyon",
+      "--map-pack",
       "phase2"
     ],
     { cwd: repoRoot }
   );
 
-  assert.match(stdout, /Bundles: 5/);
+  assert.match(stdout, /Bundles: 9/);
   assert.match(stdout, /Bundle: frontier-basin/);
   assert.match(stdout, /Bundle: stonewatch-fork/);
   assert.match(stdout, /Bundle: ridgeway-crossing/);
+  assert.match(stdout, /Bundle: highland-reach/);
+  assert.match(stdout, /Bundle: amber-fields/);
+  assert.match(stdout, /Bundle: ironpass-gorge/);
+  assert.match(stdout, /Bundle: splitrock-canyon/);
   assert.match(stdout, /Bundle: phase2/);
   assert.match(stdout, /Result: PASS/);
 });

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -95,7 +95,7 @@ function parseArgs(argv: string[]): {
       const definition = resolveContentPackMapPack(presetId);
       if (!definition) {
         throw new Error(
-          `Unknown map pack "${presetId}". Supported values: default, frontier-basin, stonewatch-fork, ridgeway-crossing, phase2.`
+          `Unknown map pack "${presetId}". Supported values: default, frontier-basin, stonewatch-fork, ridgeway-crossing, highland-reach, amber-fields, ironpass-gorge, splitrock-canyon, phase2.`
         );
       }
       if (definition.id !== DEFAULT_CONTENT_PACK_MAP_PACK.id) {


### PR DESCRIPTION
## Summary
- add four Phase 1 content packs for the new plains and canyon map batch
- register the new map packs across shared runtime selection, cocos runtime selection, config-center presets, and content-pack validation
- extend targeted tests for content-pack validation, config-center presets, and shared runtime map loading

## Validation
- npm run validate:content-pack:all
- node --import tsx --test ./scripts/test/validate-content-pack.test.ts
- node --import tsx --test ./apps/server/test/config-center.test.ts
- node --import tsx --test ./packages/shared/test/shared-core.test.ts
- npm run typecheck:shared
- npm run typecheck:server
- npm run typecheck:cocos

Closes #781
