### PR TITLE
Expand map pool with swamp, snowfield, and asymmetric batch 2 maps

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -608,7 +608,7 @@ interface StoredSessionReplayEnvelope {
   update: SessionUpdate;
 }
 
-const TERRAIN_VALUES: TerrainType[] = ["grass", "dirt", "sand", "water", "unknown"];
+const TERRAIN_VALUES = ["grass", "dirt", "sand", "water", "swamp", "unknown"] as const;
 const FOG_VALUES: FogState[] = ["hidden", "explored", "visible"];
 
 function decodeBase64Bytes(encoded: string): Uint8Array {

--- a/apps/cocos-client/assets/scripts/cocos-pixel-sprite-manifest.ts
+++ b/apps/cocos-client/assets/scripts/cocos-pixel-sprite-manifest.ts
@@ -11,6 +11,7 @@ export interface PixelTileSpriteManifest {
   dirt: string[];
   sand: string[];
   water: string[];
+  swamp: string[];
   unknown: string[];
   hidden: string[];
 }
@@ -74,6 +75,7 @@ export const pixelSpriteManifest: PixelSpriteManifest = {
     dirt: requireResourceSeries(assetConfig.terrain.dirt.variants, "terrain.dirt.variants"),
     sand: requireResourceSeries(assetConfig.terrain.sand.variants, "terrain.sand.variants"),
     water: requireResourceSeries(assetConfig.terrain.water.variants, "terrain.water.variants"),
+    swamp: requireResourceSeries(assetConfig.terrain.swamp.variants, "terrain.swamp.variants"),
     unknown: requireResourceSeries(assetConfig.terrain.unknown.variants, "terrain.unknown.variants"),
     hidden: ["pixel/terrain/hidden-tile", "pixel/terrain/hidden-tile-alt", "pixel/terrain/hidden-tile-deep"]
   },

--- a/apps/cocos-client/assets/scripts/cocos-pixel-sprites.ts
+++ b/apps/cocos-client/assets/scripts/cocos-pixel-sprites.ts
@@ -12,6 +12,7 @@ export interface PixelTileSprites {
   dirt: Array<SpriteFrame | null>;
   sand: Array<SpriteFrame | null>;
   water: Array<SpriteFrame | null>;
+  swamp: Array<SpriteFrame | null>;
   unknown: Array<SpriteFrame | null>;
   hidden: Array<SpriteFrame | null>;
 }
@@ -213,6 +214,7 @@ function buildPixelSpriteAssetsSnapshot(): PixelSpriteAssets {
       dirt: readSpriteSeries(pixelSpriteManifest.tiles.dirt),
       sand: readSpriteSeries(pixelSpriteManifest.tiles.sand),
       water: readSpriteSeries(pixelSpriteManifest.tiles.water),
+      swamp: readSpriteSeries(pixelSpriteManifest.tiles.swamp),
       unknown: readSpriteSeries(pixelSpriteManifest.tiles.unknown),
       hidden: readSpriteSeries(pixelSpriteManifest.tiles.hidden)
     },

--- a/apps/cocos-client/assets/scripts/cocos-placeholder-sprite-plan.ts
+++ b/apps/cocos-client/assets/scripts/cocos-placeholder-sprite-plan.ts
@@ -5,6 +5,7 @@ export const PLACEHOLDER_TILE_PATHS = {
   dirt: ["placeholder/tiles/dirt-1", "placeholder/tiles/dirt-2", "placeholder/tiles/dirt-3"],
   sand: ["placeholder/tiles/sand-1", "placeholder/tiles/sand-2"],
   water: ["placeholder/tiles/water-1", "placeholder/tiles/water-2"],
+  swamp: ["placeholder/tiles/dirt-1", "placeholder/tiles/dirt-2", "placeholder/tiles/dirt-3"],
   unknown: ["placeholder/tiles/unknown-1"],
   hidden: ["placeholder/tiles/hidden-1", "placeholder/tiles/hidden-2", "placeholder/tiles/hidden-3"]
 } as const;
@@ -29,6 +30,7 @@ export const PLACEHOLDER_SCOPE_PATHS = {
     ...PLACEHOLDER_TILE_PATHS.dirt,
     ...PLACEHOLDER_TILE_PATHS.sand,
     ...PLACEHOLDER_TILE_PATHS.water,
+    ...PLACEHOLDER_TILE_PATHS.swamp,
     ...PLACEHOLDER_TILE_PATHS.unknown,
     ...PLACEHOLDER_TILE_PATHS.hidden,
     PLACEHOLDER_ICON_PATHS.wood,

--- a/apps/cocos-client/assets/scripts/cocos-placeholder-sprites.ts
+++ b/apps/cocos-client/assets/scripts/cocos-placeholder-sprites.ts
@@ -14,6 +14,7 @@ export interface PlaceholderTileSprites {
   dirt: Array<SpriteFrame | null>;
   sand: Array<SpriteFrame | null>;
   water: Array<SpriteFrame | null>;
+  swamp: Array<SpriteFrame | null>;
   unknown: Array<SpriteFrame | null>;
   hidden: Array<SpriteFrame | null>;
 }
@@ -79,6 +80,7 @@ function createEmptyPlaceholderSpriteAssets(): PlaceholderSpriteAssets {
       dirt: PLACEHOLDER_TILE_PATHS.dirt.map(() => null),
       sand: PLACEHOLDER_TILE_PATHS.sand.map(() => null),
       water: PLACEHOLDER_TILE_PATHS.water.map(() => null),
+      swamp: PLACEHOLDER_TILE_PATHS.swamp.map(() => null),
       unknown: PLACEHOLDER_TILE_PATHS.unknown.map(() => null),
       hidden: PLACEHOLDER_TILE_PATHS.hidden.map(() => null)
     },

--- a/apps/cocos-client/assets/scripts/project-shared/assets-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/assets-config.ts
@@ -50,7 +50,7 @@ export interface AssetConfig {
   };
 }
 
-const TERRAIN_KEYS = ["grass", "dirt", "sand", "water", "unknown"] as const;
+const TERRAIN_KEYS = ["grass", "dirt", "sand", "water", "swamp", "unknown"] as const;
 const RESOURCE_KEYS = ["gold", "wood", "ore"] as const;
 const BUILDING_KEYS = ["recruitment_post", "attribute_shrine", "resource_mine", "watchtower"] as const;
 const MARKER_KEYS = ["hero", "neutral"] as const;

--- a/apps/cocos-client/assets/scripts/project-shared/map-sync.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map-sync.ts
@@ -49,10 +49,11 @@ const TERRAIN_CODES: Record<PlayerTileView["terrain"], number> = {
   dirt: 1,
   sand: 2,
   water: 3,
-  unknown: 4
+  swamp: 4,
+  unknown: 5
 };
 
-const TERRAIN_VALUES: PlayerTileView["terrain"][] = ["grass", "dirt", "sand", "water", "unknown"];
+const TERRAIN_VALUES: PlayerTileView["terrain"][] = ["grass", "dirt", "sand", "water", "swamp", "unknown"];
 const FOG_CODES: Record<FogState, number> = {
   hidden: 0,
   explored: 1,

--- a/apps/cocos-client/assets/scripts/project-shared/map.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map.ts
@@ -107,6 +107,10 @@ function isTraversableTile(
   return tile.walkable || (canFlyOverWater && tile.terrain === "water");
 }
 
+function terrainMoveCost(terrain: TileState["terrain"] | PlayerTileView["terrain"]): number {
+  return terrain === "swamp" ? 2 : 1;
+}
+
 function maybeAwardBattleEquipmentDrop(
   hero: HeroState,
   state: WorldState,
@@ -940,7 +944,10 @@ function getMovementPlan(state: WorldState, heroId: string, destination: Vec2): 
             : "none";
       const endsInEncounter = encounterKind !== "none";
       const travelPath = endsInEncounter ? path.slice(0, -1) : path;
-      const moveCost = Math.max(0, travelPath.length - 1);
+      const moveCost = travelPath.slice(1).reduce((total, step) => {
+        const tile = findTile(state.map, step);
+        return total + (tile ? terrainMoveCost(tile.terrain) : 1);
+      }, 0);
       return {
         heroId,
         destination,
@@ -958,7 +965,9 @@ function getMovementPlan(state: WorldState, heroId: string, destination: Vec2): 
         continue;
       }
 
-      const tentative = (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + 1;
+      const neighborTile = findTile(state.map, neighbor);
+      const tentative =
+        (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + terrainMoveCost(neighborTile?.terrain ?? "grass");
       if (tentative >= (gScore.get(tileKey(neighbor)) ?? Number.POSITIVE_INFINITY)) {
         continue;
       }
@@ -1294,7 +1303,10 @@ export function planPlayerViewMovement(
             : "none";
       const endsInEncounter = encounterKind !== "none";
       const travelPath = endsInEncounter ? path.slice(0, -1) : path;
-      const moveCost = Math.max(0, travelPath.length - 1);
+      const moveCost = travelPath.slice(1).reduce((total, step) => {
+        const tile = findPlayerTile(view, step);
+        return total + (tile ? terrainMoveCost(tile.terrain) : 1);
+      }, 0);
       return {
         heroId,
         destination,
@@ -1312,7 +1324,9 @@ export function planPlayerViewMovement(
         continue;
       }
 
-      const tentative = (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + 1;
+      const neighborTile = findPlayerTile(view, neighbor);
+      const tentative =
+        (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + terrainMoveCost(neighborTile?.terrain ?? "grass");
       if (tentative >= (gScore.get(tileKey(neighbor)) ?? Number.POSITIVE_INFINITY)) {
         continue;
       }

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -1,4 +1,4 @@
-export type TerrainType = "grass" | "dirt" | "sand" | "water";
+export type TerrainType = "grass" | "dirt" | "sand" | "water" | "swamp";
 export type FogState = "hidden" | "explored" | "visible";
 export type ResourceKind = "gold" | "wood" | "ore";
 export type OccupantKind = "hero" | "neutral" | "building";

--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -3,21 +3,31 @@ import defaultBattleBalanceConfig from "../../../../../configs/battle-balance.js
 import defaultHeroSkillTreesConfig from "../../../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../../../configs/phase2-map-objects-contested-basin.json";
 import amberFieldsMapObjectsConfig from "../../../../../configs/phase1-map-objects-amber-fields.json";
+import ashpeakAscentMapObjectsConfig from "../../../../../configs/phase1-map-objects-ashpeak-ascent.json";
+import bogfenCrossingMapObjectsConfig from "../../../../../configs/phase1-map-objects-bogfen-crossing.json";
 import frontierBasinMapObjectsConfig from "../../../../../configs/phase1-map-objects-frontier-basin.json";
+import frostwatchRidgeMapObjectsConfig from "../../../../../configs/phase1-map-objects-frostwatch-ridge.json";
 import highlandReachMapObjectsConfig from "../../../../../configs/phase1-map-objects-highland-reach.json";
 import ironpassGorgeMapObjectsConfig from "../../../../../configs/phase1-map-objects-ironpass-gorge.json";
+import murkveilDeltaMapObjectsConfig from "../../../../../configs/phase1-map-objects-murkveil-delta.json";
 import splitrockCanyonMapObjectsConfig from "../../../../../configs/phase1-map-objects-splitrock-canyon.json";
 import stonewatchForkMapObjectsConfig from "../../../../../configs/phase1-map-objects-stonewatch-fork.json";
+import thornwallDivideMapObjectsConfig from "../../../../../configs/phase1-map-objects-thornwall-divide.json";
 import ridgewayCrossingMapObjectsConfig from "../../../../../configs/phase1-map-objects-ridgeway-crossing.json";
 import defaultMapObjectsConfig from "../../../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../../../configs/units.json";
 import amberFieldsWorldConfig from "../../../../../configs/phase1-world-amber-fields.json";
+import ashpeakAscentWorldConfig from "../../../../../configs/phase1-world-ashpeak-ascent.json";
+import bogfenCrossingWorldConfig from "../../../../../configs/phase1-world-bogfen-crossing.json";
 import contestedBasinWorldConfig from "../../../../../configs/phase2-contested-basin.json";
 import frontierBasinWorldConfig from "../../../../../configs/phase1-world-frontier-basin.json";
+import frostwatchRidgeWorldConfig from "../../../../../configs/phase1-world-frostwatch-ridge.json";
 import highlandReachWorldConfig from "../../../../../configs/phase1-world-highland-reach.json";
 import ironpassGorgeWorldConfig from "../../../../../configs/phase1-world-ironpass-gorge.json";
+import murkveilDeltaWorldConfig from "../../../../../configs/phase1-world-murkveil-delta.json";
 import splitrockCanyonWorldConfig from "../../../../../configs/phase1-world-splitrock-canyon.json";
 import stonewatchForkWorldConfig from "../../../../../configs/phase1-world-stonewatch-fork.json";
+import thornwallDivideWorldConfig from "../../../../../configs/phase1-world-thornwall-divide.json";
 import ridgewayCrossingWorldConfig from "../../../../../configs/phase1-world-ridgeway-crossing.json";
 import defaultWorldConfig from "../../../../../configs/phase1-world.json";
 import type {
@@ -50,6 +60,11 @@ export const HIGHLAND_REACH_MAP_VARIANT_ID = "highland_reach";
 export const AMBER_FIELDS_MAP_VARIANT_ID = "amber_fields";
 export const IRONPASS_GORGE_MAP_VARIANT_ID = "ironpass_gorge";
 export const SPLITROCK_CANYON_MAP_VARIANT_ID = "splitrock_canyon";
+export const BOGFEN_CROSSING_MAP_VARIANT_ID = "bogfen_crossing";
+export const MURKVEIL_DELTA_MAP_VARIANT_ID = "murkveil_delta";
+export const FROSTWATCH_RIDGE_MAP_VARIANT_ID = "frostwatch_ridge";
+export const ASHPEAK_ASCENT_MAP_VARIANT_ID = "ashpeak_ascent";
+export const THORNWALL_DIVIDE_MAP_VARIANT_ID = "thornwall_divide";
 export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
 
 export interface RuntimeConfigBundle {
@@ -152,7 +167,7 @@ function isResourceKind(value: unknown): value is "gold" | "wood" | "ore" {
 }
 
 function isTerrainType(value: unknown): value is TerrainType {
-  return value === "grass" || value === "dirt" || value === "sand" || value === "water";
+  return value === "grass" || value === "dirt" || value === "sand" || value === "water" || value === "swamp";
 }
 
 function isNeutralBehaviorMode(value: unknown): value is NeutralBehaviorMode {
@@ -752,6 +767,11 @@ function getAvailableMapVariantIds(): string[] {
     AMBER_FIELDS_MAP_VARIANT_ID,
     IRONPASS_GORGE_MAP_VARIANT_ID,
     SPLITROCK_CANYON_MAP_VARIANT_ID,
+    BOGFEN_CROSSING_MAP_VARIANT_ID,
+    MURKVEIL_DELTA_MAP_VARIANT_ID,
+    FROSTWATCH_RIDGE_MAP_VARIANT_ID,
+    ASHPEAK_ASCENT_MAP_VARIANT_ID,
+    THORNWALL_DIVIDE_MAP_VARIANT_ID,
     CONTESTED_BASIN_MAP_VARIANT_ID
   ];
 }
@@ -774,6 +794,11 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     requested === AMBER_FIELDS_MAP_VARIANT_ID ||
     requested === IRONPASS_GORGE_MAP_VARIANT_ID ||
     requested === SPLITROCK_CANYON_MAP_VARIANT_ID ||
+    requested === BOGFEN_CROSSING_MAP_VARIANT_ID ||
+    requested === MURKVEIL_DELTA_MAP_VARIANT_ID ||
+    requested === FROSTWATCH_RIDGE_MAP_VARIANT_ID ||
+    requested === ASHPEAK_ASCENT_MAP_VARIANT_ID ||
+    requested === THORNWALL_DIVIDE_MAP_VARIANT_ID ||
     requested === CONTESTED_BASIN_MAP_VARIANT_ID
   ) {
     return requested;
@@ -802,6 +827,16 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneWorldConfig(ironpassGorgeWorldConfig as WorldGenerationConfig)
       : mapVariantId === SPLITROCK_CANYON_MAP_VARIANT_ID
         ? cloneWorldConfig(splitrockCanyonWorldConfig as WorldGenerationConfig)
+      : mapVariantId === BOGFEN_CROSSING_MAP_VARIANT_ID
+        ? cloneWorldConfig(bogfenCrossingWorldConfig as WorldGenerationConfig)
+      : mapVariantId === MURKVEIL_DELTA_MAP_VARIANT_ID
+        ? cloneWorldConfig(murkveilDeltaWorldConfig as WorldGenerationConfig)
+      : mapVariantId === FROSTWATCH_RIDGE_MAP_VARIANT_ID
+        ? cloneWorldConfig(frostwatchRidgeWorldConfig as WorldGenerationConfig)
+      : mapVariantId === ASHPEAK_ASCENT_MAP_VARIANT_ID
+        ? cloneWorldConfig(ashpeakAscentWorldConfig as WorldGenerationConfig)
+      : mapVariantId === THORNWALL_DIVIDE_MAP_VARIANT_ID
+        ? cloneWorldConfig(thornwallDivideWorldConfig as WorldGenerationConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
         : getDefaultWorldConfig();
@@ -820,6 +855,16 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneMapObjectsConfig(ironpassGorgeMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === SPLITROCK_CANYON_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(splitrockCanyonMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === BOGFEN_CROSSING_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(bogfenCrossingMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === MURKVEIL_DELTA_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(murkveilDeltaMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === FROSTWATCH_RIDGE_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(frostwatchRidgeMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === ASHPEAK_ASCENT_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(ashpeakAscentMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === THORNWALL_DIVIDE_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(thornwallDivideMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
         : getDefaultMapObjectsConfig();

--- a/configs/assets.json
+++ b/configs/assets.json
@@ -28,6 +28,13 @@
         "/assets/pixel/terrain/water-tile-alt.png"
       ]
     },
+    "swamp": {
+      "default": "/assets/pixel/terrain/dirt-tile.png",
+      "variants": [
+        "/assets/pixel/terrain/dirt-tile.png",
+        "/assets/pixel/terrain/dirt-tile-alt.png"
+      ]
+    },
     "unknown": {
       "default": "/assets/pixel/terrain/fog-tile.png",
       "variants": [

--- a/configs/phase1-map-objects-ashpeak-ascent.json
+++ b/configs/phase1-map-objects-ashpeak-ascent.json
@@ -1,0 +1,110 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": { "x": 4, "y": 6 },
+      "reward": { "kind": "wood", "amount": 6 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 6 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 4, "y": 6 }, { "x": 5, "y": 6 }, { "x": 5, "y": 7 }, { "x": 4, "y": 7 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": { "x": 7, "y": 4 },
+      "reward": { "kind": "ore", "amount": 5 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 5 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": { "x": 2, "y": 9 },
+      "reward": { "kind": "gold", "amount": 240 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 4 }, { "templateId": "wolf_pack", "count": 2 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": { "x": 9, "y": 5 },
+      "reward": { "kind": "gold", "amount": 320 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 7 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 9, "y": 5 }, { "x": 10, "y": 5 }, { "x": 10, "y": 4 }, { "x": 9, "y": 4 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    { "position": { "x": 1, "y": 6 }, "resource": { "kind": "wood", "amount": 5 } },
+    { "position": { "x": 10, "y": 2 }, "resource": { "kind": "ore", "amount": 4 } },
+    { "position": { "x": 6, "y": 6 }, "resource": { "kind": "gold", "amount": 220 } },
+    { "position": { "x": 9, "y": 3 }, "resource": { "kind": "gold", "amount": 220 } }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": { "x": 2, "y": 8 },
+      "label": "火山麓前营",
+      "unitTemplateId": "crown_heavy_cavalry",
+      "recruitCount": 4,
+      "cost": { "gold": 240, "wood": 0, "ore": 0 }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": { "x": 9, "y": 2 },
+      "label": "灰峰守军营",
+      "unitTemplateId": "crown_crossbowman",
+      "recruitCount": 3,
+      "cost": { "gold": 180, "wood": 1, "ore": 0 }
+    },
+    {
+      "id": "shrine-defense-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 8, "y": 3 },
+      "label": "灰峰守誓坛",
+      "bonus": { "attack": 0, "defense": 2, "power": 0, "knowledge": 0 }
+    },
+    {
+      "id": "shrine-attack-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 5, "y": 7 },
+      "label": "登峰战旗坛",
+      "bonus": { "attack": 2, "defense": 0, "power": 0, "knowledge": 0 }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": { "x": 3, "y": 10 },
+      "label": "山麓林场",
+      "resourceKind": "wood",
+      "income": 4
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": { "x": 8, "y": 1 },
+      "label": "灰峰矿井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-map-objects-bogfen-crossing.json
+++ b/configs/phase1-map-objects-bogfen-crossing.json
@@ -1,0 +1,110 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": { "x": 4, "y": 3 },
+      "reward": { "kind": "wood", "amount": 6 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 6 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 4, "y": 3 }, { "x": 4, "y": 4 }, { "x": 3, "y": 4 }, { "x": 3, "y": 3 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": { "x": 7, "y": 8 },
+      "reward": { "kind": "ore", "amount": 5 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 5 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": { "x": 3, "y": 8 },
+      "reward": { "kind": "gold", "amount": 260 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 4 }, { "templateId": "wolf_pack", "count": 2 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": { "x": 8, "y": 3 },
+      "reward": { "kind": "gold", "amount": 300 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 7 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 8, "y": 3 }, { "x": 9, "y": 3 }, { "x": 9, "y": 4 }, { "x": 8, "y": 4 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    { "position": { "x": 1, "y": 3 }, "resource": { "kind": "wood", "amount": 5 } },
+    { "position": { "x": 10, "y": 8 }, "resource": { "kind": "ore", "amount": 4 } },
+    { "position": { "x": 4, "y": 6 }, "resource": { "kind": "gold", "amount": 220 } },
+    { "position": { "x": 7, "y": 5 }, "resource": { "kind": "gold", "amount": 220 } }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": { "x": 1, "y": 7 },
+      "label": "苇湾前哨营",
+      "unitTemplateId": "crown_crossbowman",
+      "recruitCount": 4,
+      "cost": { "gold": 240, "wood": 0, "ore": 0 }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": { "x": 10, "y": 4 },
+      "label": "泥岸补员站",
+      "unitTemplateId": "crown_light_outrider",
+      "recruitCount": 3,
+      "cost": { "gold": 180, "wood": 1, "ore": 0 }
+    },
+    {
+      "id": "shrine-defense-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 5, "y": 5 },
+      "label": "淤潮守誓坛",
+      "bonus": { "attack": 0, "defense": 2, "power": 0, "knowledge": 0 }
+    },
+    {
+      "id": "shrine-attack-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 6, "y": 6 },
+      "label": "渗沼战意坛",
+      "bonus": { "attack": 2, "defense": 0, "power": 0, "knowledge": 0 }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": { "x": 2, "y": 8 },
+      "label": "苇滩伐木场",
+      "resourceKind": "wood",
+      "income": 4
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": { "x": 9, "y": 3 },
+      "label": "泥港铁井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-map-objects-frostwatch-ridge.json
+++ b/configs/phase1-map-objects-frostwatch-ridge.json
@@ -1,0 +1,110 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": { "x": 5, "y": 3 },
+      "reward": { "kind": "wood", "amount": 5 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 6 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 5, "y": 3 }, { "x": 6, "y": 3 }, { "x": 6, "y": 2 }, { "x": 5, "y": 2 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": { "x": 8, "y": 6 },
+      "reward": { "kind": "ore", "amount": 5 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 5 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": { "x": 4, "y": 6 },
+      "reward": { "kind": "gold", "amount": 280 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 4 }, { "templateId": "wolf_pack", "count": 2 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": { "x": 9, "y": 3 },
+      "reward": { "kind": "gold", "amount": 300 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 7 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 9, "y": 3 }, { "x": 10, "y": 3 }, { "x": 10, "y": 4 }, { "x": 9, "y": 4 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    { "position": { "x": 2, "y": 2 }, "resource": { "kind": "wood", "amount": 5 } },
+    { "position": { "x": 11, "y": 7 }, "resource": { "kind": "ore", "amount": 4 } },
+    { "position": { "x": 6, "y": 4 }, "resource": { "kind": "gold", "amount": 200 } },
+    { "position": { "x": 7, "y": 5 }, "resource": { "kind": "gold", "amount": 200 } }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": { "x": 2, "y": 4 },
+      "label": "霜岭前营",
+      "unitTemplateId": "crown_crossbowman",
+      "recruitCount": 4,
+      "cost": { "gold": 240, "wood": 0, "ore": 0 }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": { "x": 11, "y": 5 },
+      "label": "冻脊补员营",
+      "unitTemplateId": "crown_heavy_cavalry",
+      "recruitCount": 3,
+      "cost": { "gold": 180, "wood": 1, "ore": 0 }
+    },
+    {
+      "id": "shrine-attack-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 6, "y": 3 },
+      "label": "霜锋战旗坛",
+      "bonus": { "attack": 2, "defense": 0, "power": 0, "knowledge": 0 }
+    },
+    {
+      "id": "shrine-defense-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 7, "y": 6 },
+      "label": "寒垒守望坛",
+      "bonus": { "attack": 0, "defense": 2, "power": 0, "knowledge": 0 }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": { "x": 3, "y": 7 },
+      "label": "霜原林场",
+      "resourceKind": "wood",
+      "income": 4
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": { "x": 10, "y": 2 },
+      "label": "白脊矿井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-map-objects-murkveil-delta.json
+++ b/configs/phase1-map-objects-murkveil-delta.json
@@ -1,0 +1,110 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": { "x": 2, "y": 3 },
+      "reward": { "kind": "wood", "amount": 6 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 6 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 2, "y": 3 }, { "x": 2, "y": 4 }, { "x": 1, "y": 4 }, { "x": 1, "y": 3 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": { "x": 7, "y": 3 },
+      "reward": { "kind": "gold", "amount": 280 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 5 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": { "x": 4, "y": 10 },
+      "reward": { "kind": "ore", "amount": 5 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 4 }, { "templateId": "wolf_pack", "count": 2 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": { "x": 7, "y": 7 },
+      "reward": { "kind": "gold", "amount": 260 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 6 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 7, "y": 7 }, { "x": 8, "y": 7 }, { "x": 8, "y": 6 }, { "x": 7, "y": 6 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    { "position": { "x": 1, "y": 1 }, "resource": { "kind": "wood", "amount": 5 } },
+    { "position": { "x": 8, "y": 10 }, "resource": { "kind": "ore", "amount": 4 } },
+    { "position": { "x": 4, "y": 7 }, "resource": { "kind": "gold", "amount": 220 } },
+    { "position": { "x": 6, "y": 5 }, "resource": { "kind": "gold", "amount": 220 } }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": { "x": 1, "y": 5 },
+      "label": "雾港募兵点",
+      "unitTemplateId": "crown_light_outrider",
+      "recruitCount": 4,
+      "cost": { "gold": 240, "wood": 0, "ore": 0 }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": { "x": 8, "y": 6 },
+      "label": "暗洲补员营",
+      "unitTemplateId": "crown_field_chaplain",
+      "recruitCount": 3,
+      "cost": { "gold": 170, "wood": 0, "ore": 1 }
+    },
+    {
+      "id": "shrine-power-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 4, "y": 6 },
+      "label": "雾潮星坛",
+      "bonus": { "attack": 0, "defense": 0, "power": 1, "knowledge": 1 }
+    },
+    {
+      "id": "shrine-defense-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 5, "y": 7 },
+      "label": "暗汊守誓坛",
+      "bonus": { "attack": 0, "defense": 2, "power": 0, "knowledge": 0 }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": { "x": 2, "y": 10 },
+      "label": "黑芦林场",
+      "resourceKind": "wood",
+      "income": 4
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": { "x": 7, "y": 2 },
+      "label": "泥角矿井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-map-objects-thornwall-divide.json
+++ b/configs/phase1-map-objects-thornwall-divide.json
@@ -1,0 +1,110 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-1",
+      "position": { "x": 2, "y": 6 },
+      "reward": { "kind": "wood", "amount": 6 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 6 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 2, "y": 6 }, { "x": 3, "y": 6 }, { "x": 3, "y": 7 }, { "x": 2, "y": 7 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-2",
+      "position": { "x": 8, "y": 5 },
+      "reward": { "kind": "ore", "amount": 5 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 5 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-3",
+      "position": { "x": 5, "y": 8 },
+      "reward": { "kind": "gold", "amount": 260 },
+      "stacks": [{ "templateId": "hero_guard_basic", "count": 4 }, { "templateId": "wolf_pack", "count": 2 }],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 2,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-4",
+      "position": { "x": 9, "y": 7 },
+      "reward": { "kind": "gold", "amount": 300 },
+      "stacks": [{ "templateId": "wolf_pack", "count": 7 }],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [{ "x": 9, "y": 7 }, { "x": 10, "y": 7 }, { "x": 10, "y": 6 }, { "x": 9, "y": 6 }],
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    { "position": { "x": 1, "y": 1 }, "resource": { "kind": "wood", "amount": 5 } },
+    { "position": { "x": 2, "y": 2 }, "resource": { "kind": "gold", "amount": 180 } },
+    { "position": { "x": 9, "y": 10 }, "resource": { "kind": "ore", "amount": 4 } },
+    { "position": { "x": 8, "y": 9 }, "resource": { "kind": "gold", "amount": 220 } }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-1",
+      "kind": "recruitment_post",
+      "position": { "x": 1, "y": 5 },
+      "label": "荆墙外营",
+      "unitTemplateId": "crown_field_chaplain",
+      "recruitCount": 4,
+      "cost": { "gold": 220, "wood": 0, "ore": 0 }
+    },
+    {
+      "id": "recruit-post-2",
+      "kind": "recruitment_post",
+      "position": { "x": 10, "y": 6 },
+      "label": "分界补员站",
+      "unitTemplateId": "crown_crossbowman",
+      "recruitCount": 3,
+      "cost": { "gold": 180, "wood": 1, "ore": 0 }
+    },
+    {
+      "id": "shrine-power-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 3, "y": 7 },
+      "label": "荆隘星坛",
+      "bonus": { "attack": 0, "defense": 0, "power": 1, "knowledge": 1 }
+    },
+    {
+      "id": "shrine-defense-1",
+      "kind": "attribute_shrine",
+      "position": { "x": 8, "y": 6 },
+      "label": "界墙守誓坛",
+      "bonus": { "attack": 0, "defense": 2, "power": 0, "knowledge": 0 }
+    },
+    {
+      "id": "mine-wood-1",
+      "kind": "resource_mine",
+      "position": { "x": 1, "y": 8 },
+      "label": "荆原林场",
+      "resourceKind": "wood",
+      "income": 4
+    },
+    {
+      "id": "mine-ore-1",
+      "kind": "resource_mine",
+      "position": { "x": 9, "y": 3 },
+      "label": "刺壁矿井",
+      "resourceKind": "ore",
+      "income": 4
+    }
+  ]
+}

--- a/configs/phase1-world-ashpeak-ascent.json
+++ b/configs/phase1-world-ashpeak-ascent.json
@@ -1,0 +1,104 @@
+{
+  "width": 12,
+  "height": 12,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": { "x": 1, "y": 8 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["militia_pike", "vanguard_blade", "padded_gambeson", "scout_compass"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": { "x": 10, "y": 3 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["oak_longbow", "tower_shield_mail", "scribe_charm", "captains_insignia"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.04,
+    "woodChance": 0.06,
+    "oreChance": 0.09
+  },
+  "terrainOverrides": [
+    { "position": { "x": 3, "y": 1 }, "terrain": "water" },
+    { "position": { "x": 3, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 8, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 8, "y": 10 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 1 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 1 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 1 }, "terrain": "dirt" },
+    { "position": { "x": 5, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 6, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 9, "y": 2 }, "terrain": "dirt" },
+    { "position": { "x": 4, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 5, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 6, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 9, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 4, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 5, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 6, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 9, "y": 4 }, "terrain": "dirt" },
+    { "position": { "x": 5, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 6, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 2, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 3, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 4, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 5, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 4, "y": 8 }, "terrain": "sand" },
+    { "position": { "x": 5, "y": 8 }, "terrain": "sand" },
+    { "position": { "x": 6, "y": 8 }, "terrain": "sand" }
+  ]
+}

--- a/configs/phase1-world-bogfen-crossing.json
+++ b/configs/phase1-world-bogfen-crossing.json
@@ -1,0 +1,111 @@
+{
+  "width": 12,
+  "height": 12,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": { "x": 1, "y": 5 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["militia_pike", "vanguard_blade", "padded_gambeson", "scout_compass"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": { "x": 10, "y": 6 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["oak_longbow", "tower_shield_mail", "scribe_charm", "captains_insignia"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.04,
+    "woodChance": 0.08,
+    "oreChance": 0.08
+  },
+  "terrainOverrides": [
+    { "position": { "x": 2, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 2, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 0 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 1 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 3 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 8 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 10 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 11 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 0 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 1 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 10 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 11 }, "terrain": "water" },
+    { "position": { "x": 9, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 9, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 3, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 5, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 6, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 7, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 8, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 3, "y": 5 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 5 }, "terrain": "swamp" },
+    { "position": { "x": 7, "y": 5 }, "terrain": "swamp" },
+    { "position": { "x": 8, "y": 5 }, "terrain": "swamp" },
+    { "position": { "x": 3, "y": 6 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 6 }, "terrain": "swamp" },
+    { "position": { "x": 7, "y": 6 }, "terrain": "swamp" },
+    { "position": { "x": 8, "y": 6 }, "terrain": "swamp" },
+    { "position": { "x": 3, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 5, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 6, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 7, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 8, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 5, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 6, "y": 5 }, "terrain": "dirt" },
+    { "position": { "x": 5, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 6, "y": 6 }, "terrain": "dirt" }
+  ]
+}

--- a/configs/phase1-world-frostwatch-ridge.json
+++ b/configs/phase1-world-frostwatch-ridge.json
@@ -1,0 +1,105 @@
+{
+  "width": 14,
+  "height": 10,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": { "x": 1, "y": 4 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["militia_pike", "vanguard_blade", "padded_gambeson", "scout_compass"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": { "x": 12, "y": 5 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["oak_longbow", "tower_shield_mail", "scribe_charm", "captains_insignia"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.05,
+    "woodChance": 0.06,
+    "oreChance": 0.08
+  },
+  "terrainOverrides": [
+    { "position": { "x": 6, "y": 0 }, "terrain": "water" },
+    { "position": { "x": 7, "y": 0 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 7, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 4, "y": 2 }, "terrain": "sand" },
+    { "position": { "x": 5, "y": 2 }, "terrain": "sand" },
+    { "position": { "x": 6, "y": 2 }, "terrain": "sand" },
+    { "position": { "x": 7, "y": 2 }, "terrain": "sand" },
+    { "position": { "x": 8, "y": 2 }, "terrain": "sand" },
+    { "position": { "x": 9, "y": 2 }, "terrain": "sand" },
+    { "position": { "x": 3, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 4, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 5, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 6, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 7, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 8, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 9, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 10, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 3, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 4, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 5, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 6, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 7, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 8, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 9, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 10, "y": 5 }, "terrain": "sand" },
+    { "position": { "x": 4, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 5, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 6, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 7, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 8, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 9, "y": 7 }, "terrain": "sand" },
+    { "position": { "x": 6, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 3 }, "terrain": "dirt" },
+    { "position": { "x": 6, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 6 }, "terrain": "dirt" }
+  ]
+}

--- a/configs/phase1-world-murkveil-delta.json
+++ b/configs/phase1-world-murkveil-delta.json
@@ -1,0 +1,106 @@
+{
+  "width": 10,
+  "height": 12,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": { "x": 1, "y": 2 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["militia_pike", "vanguard_blade", "padded_gambeson", "scout_compass"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": { "x": 8, "y": 9 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["oak_longbow", "tower_shield_mail", "scribe_charm", "captains_insignia"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.04,
+    "woodChance": 0.08,
+    "oreChance": 0.09
+  },
+  "terrainOverrides": [
+    { "position": { "x": 3, "y": 1 }, "terrain": "water" },
+    { "position": { "x": 4, "y": 1 }, "terrain": "water" },
+    { "position": { "x": 3, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 4, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 3 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 3 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 4 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 4 }, "terrain": "water" },
+    { "position": { "x": 2, "y": 6 }, "terrain": "water" },
+    { "position": { "x": 3, "y": 6 }, "terrain": "water" },
+    { "position": { "x": 2, "y": 7 }, "terrain": "water" },
+    { "position": { "x": 3, "y": 7 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 8 }, "terrain": "water" },
+    { "position": { "x": 7, "y": 8 }, "terrain": "water" },
+    { "position": { "x": 6, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 7, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 4, "y": 5 }, "terrain": "water" },
+    { "position": { "x": 5, "y": 6 }, "terrain": "water" },
+    { "position": { "x": 1, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 2, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 3, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 7, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 8, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 1, "y": 8 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 8 }, "terrain": "swamp" },
+    { "position": { "x": 5, "y": 8 }, "terrain": "swamp" },
+    { "position": { "x": 8, "y": 8 }, "terrain": "swamp" },
+    { "position": { "x": 1, "y": 9 }, "terrain": "swamp" },
+    { "position": { "x": 2, "y": 9 }, "terrain": "swamp" },
+    { "position": { "x": 3, "y": 9 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 9 }, "terrain": "swamp" },
+    { "position": { "x": 5, "y": 9 }, "terrain": "swamp" },
+    { "position": { "x": 8, "y": 9 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 4, "y": 7 }, "terrain": "dirt" },
+    { "position": { "x": 5, "y": 7 }, "terrain": "dirt" }
+  ]
+}

--- a/configs/phase1-world-thornwall-divide.json
+++ b/configs/phase1-world-thornwall-divide.json
@@ -1,0 +1,94 @@
+{
+  "width": 12,
+  "height": 12,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": { "x": 1, "y": 3 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["militia_pike", "vanguard_blade", "padded_gambeson", "scout_compass"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": { "x": 10, "y": 8 },
+      "vision": 2,
+      "move": { "total": 6, "remaining": 6 },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": ["oak_longbow", "tower_shield_mail", "scribe_charm", "captains_insignia"]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.04,
+    "woodChance": 0.07,
+    "oreChance": 0.08
+  },
+  "terrainOverrides": [
+    { "position": { "x": 4, "y": 1 }, "terrain": "water" },
+    { "position": { "x": 4, "y": 2 }, "terrain": "water" },
+    { "position": { "x": 7, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 7, "y": 10 }, "terrain": "water" },
+    { "position": { "x": 3, "y": 3 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 3 }, "terrain": "swamp" },
+    { "position": { "x": 5, "y": 3 }, "terrain": "swamp" },
+    { "position": { "x": 3, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 5, "y": 4 }, "terrain": "swamp" },
+    { "position": { "x": 3, "y": 5 }, "terrain": "swamp" },
+    { "position": { "x": 4, "y": 5 }, "terrain": "swamp" },
+    { "position": { "x": 5, "y": 5 }, "terrain": "swamp" },
+    { "position": { "x": 6, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 6 }, "terrain": "dirt" },
+    { "position": { "x": 6, "y": 7 }, "terrain": "dirt" },
+    { "position": { "x": 7, "y": 7 }, "terrain": "dirt" },
+    { "position": { "x": 8, "y": 7 }, "terrain": "dirt" },
+    { "position": { "x": 2, "y": 8 }, "terrain": "sand" },
+    { "position": { "x": 3, "y": 8 }, "terrain": "sand" },
+    { "position": { "x": 4, "y": 8 }, "terrain": "sand" },
+    { "position": { "x": 7, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 8, "y": 4 }, "terrain": "sand" },
+    { "position": { "x": 9, "y": 4 }, "terrain": "sand" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "validate:quickstart": "node ./scripts/validate-local-dev-quickstart.mjs",
     "validate:e2e:fixtures": "node --import tsx ./scripts/validate-e2e-config-fixtures.ts",
     "validate:content-pack": "node --import tsx ./scripts/validate-content-pack.ts",
-    "validate:content-pack:all": "node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack stonewatch-fork --map-pack ridgeway-crossing --map-pack highland-reach --map-pack amber-fields --map-pack ironpass-gorge --map-pack splitrock-canyon --map-pack phase2",
+    "validate:content-pack:all": "node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack stonewatch-fork --map-pack ridgeway-crossing --map-pack highland-reach --map-pack amber-fields --map-pack ironpass-gorge --map-pack splitrock-canyon --map-pack bogfen-crossing --map-pack murkveil-delta --map-pack frostwatch-ridge --map-pack ashpeak-ascent --map-pack thornwall-divide --map-pack phase2",
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
     "stress:rooms:baseline": "node --import tsx ./scripts/stress-concurrent-rooms.ts --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --artifact-path=artifacts/release-readiness/stress-rooms-runtime-metrics.json",
     "stress:rooms:reconnect-soak": "node --import tsx ./scripts/stress-concurrent-rooms.ts --scenarios=reconnect_soak --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --reconnect-cycles=8",

--- a/packages/shared/src/assets-config.ts
+++ b/packages/shared/src/assets-config.ts
@@ -50,7 +50,7 @@ export interface AssetConfig {
   };
 }
 
-const TERRAIN_KEYS = ["grass", "dirt", "sand", "water", "unknown"] as const;
+const TERRAIN_KEYS = ["grass", "dirt", "sand", "water", "swamp", "unknown"] as const;
 const RESOURCE_KEYS = ["gold", "wood", "ore"] as const;
 const BUILDING_KEYS = ["recruitment_post", "attribute_shrine", "resource_mine", "watchtower"] as const;
 const MARKER_KEYS = ["hero", "neutral"] as const;

--- a/packages/shared/src/map-sync.ts
+++ b/packages/shared/src/map-sync.ts
@@ -49,10 +49,11 @@ const TERRAIN_CODES: Record<PlayerTileView["terrain"], number> = {
   dirt: 1,
   sand: 2,
   water: 3,
-  unknown: 4
+  swamp: 4,
+  unknown: 5
 };
 
-const TERRAIN_VALUES: PlayerTileView["terrain"][] = ["grass", "dirt", "sand", "water", "unknown"];
+const TERRAIN_VALUES: PlayerTileView["terrain"][] = ["grass", "dirt", "sand", "water", "swamp", "unknown"];
 const FOG_CODES: Record<FogState, number> = {
   hidden: 0,
   explored: 1,

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -107,6 +107,10 @@ function isTraversableTile(
   return tile.walkable || (canFlyOverWater && tile.terrain === "water");
 }
 
+function terrainMoveCost(terrain: TileState["terrain"] | PlayerTileView["terrain"]): number {
+  return terrain === "swamp" ? 2 : 1;
+}
+
 function maybeAwardBattleEquipmentDrop(
   hero: HeroState,
   state: WorldState,
@@ -940,7 +944,10 @@ function getMovementPlan(state: WorldState, heroId: string, destination: Vec2): 
             : "none";
       const endsInEncounter = encounterKind !== "none";
       const travelPath = endsInEncounter ? path.slice(0, -1) : path;
-      const moveCost = Math.max(0, travelPath.length - 1);
+      const moveCost = travelPath.slice(1).reduce((total, step) => {
+        const tile = findTile(state.map, step);
+        return total + (tile ? terrainMoveCost(tile.terrain) : 1);
+      }, 0);
       return {
         heroId,
         destination,
@@ -958,7 +965,9 @@ function getMovementPlan(state: WorldState, heroId: string, destination: Vec2): 
         continue;
       }
 
-      const tentative = (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + 1;
+      const neighborTile = findTile(state.map, neighbor);
+      const tentative =
+        (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + terrainMoveCost(neighborTile?.terrain ?? "grass");
       if (tentative >= (gScore.get(tileKey(neighbor)) ?? Number.POSITIVE_INFINITY)) {
         continue;
       }
@@ -1298,7 +1307,10 @@ export function planPlayerViewMovement(
             : "none";
       const endsInEncounter = encounterKind !== "none";
       const travelPath = endsInEncounter ? path.slice(0, -1) : path;
-      const moveCost = Math.max(0, travelPath.length - 1);
+      const moveCost = travelPath.slice(1).reduce((total, step) => {
+        const tile = findPlayerTile(view, step);
+        return total + (tile ? terrainMoveCost(tile.terrain) : 1);
+      }, 0);
       return {
         heroId,
         destination,
@@ -1316,7 +1328,9 @@ export function planPlayerViewMovement(
         continue;
       }
 
-      const tentative = (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + 1;
+      const neighborTile = findPlayerTile(view, neighbor);
+      const tentative =
+        (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + terrainMoveCost(neighborTile?.terrain ?? "grass");
       if (tentative >= (gScore.get(tileKey(neighbor)) ?? Number.POSITIVE_INFINITY)) {
         continue;
       }
@@ -1437,7 +1451,7 @@ export function listReachableTiles(state: WorldState, heroId: string): Vec2[] {
   return state.map.tiles
     .filter((tile) => {
       const plan = planHeroMovement(state, heroId, tile.position);
-      return Boolean(plan && getMovementDistance(plan) <= hero.move.remaining);
+      return Boolean(plan && plan.moveCost <= hero.move.remaining);
     })
     .map((tile) => tile.position);
 }
@@ -1451,7 +1465,7 @@ export function listReachableTilesInPlayerView(view: PlayerWorldView, heroId: st
   return view.map.tiles
     .filter((tile) => {
       const plan = planPlayerViewMovement(view, heroId, tile.position);
-      return Boolean(plan && getMovementDistance(plan) <= hero.move.remaining);
+      return Boolean(plan && plan.moveCost <= hero.move.remaining);
     })
     .map((tile) => tile.position);
 }
@@ -1574,7 +1588,7 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
       };
     }
 
-    if (getMovementDistance(plan) > hero.move.remaining) {
+    if (plan.moveCost > hero.move.remaining) {
       return {
         world: view,
         movementPlan: null,
@@ -1956,7 +1970,7 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
       return { valid: false, reason: "path_not_found" };
     }
 
-    if (getMovementDistance(plan) > hero.move.remaining) {
+    if (plan.moveCost > hero.move.remaining) {
       return { valid: false, reason: "not_enough_move_points" };
     }
 

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,4 +1,4 @@
-export type TerrainType = "grass" | "dirt" | "sand" | "water";
+export type TerrainType = "grass" | "dirt" | "sand" | "water" | "swamp";
 export type FogState = "hidden" | "explored" | "visible";
 export type ResourceKind = "gold" | "wood" | "ore";
 export type OccupantKind = "hero" | "neutral" | "building";

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -3,21 +3,31 @@ import defaultBattleBalanceConfig from "../../../configs/battle-balance.json";
 import defaultHeroSkillTreesConfig from "../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
 import amberFieldsMapObjectsConfig from "../../../configs/phase1-map-objects-amber-fields.json";
+import ashpeakAscentMapObjectsConfig from "../../../configs/phase1-map-objects-ashpeak-ascent.json";
+import bogfenCrossingMapObjectsConfig from "../../../configs/phase1-map-objects-bogfen-crossing.json";
 import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
+import frostwatchRidgeMapObjectsConfig from "../../../configs/phase1-map-objects-frostwatch-ridge.json";
 import highlandReachMapObjectsConfig from "../../../configs/phase1-map-objects-highland-reach.json";
 import ironpassGorgeMapObjectsConfig from "../../../configs/phase1-map-objects-ironpass-gorge.json";
+import murkveilDeltaMapObjectsConfig from "../../../configs/phase1-map-objects-murkveil-delta.json";
 import splitrockCanyonMapObjectsConfig from "../../../configs/phase1-map-objects-splitrock-canyon.json";
 import stonewatchForkMapObjectsConfig from "../../../configs/phase1-map-objects-stonewatch-fork.json";
+import thornwallDivideMapObjectsConfig from "../../../configs/phase1-map-objects-thornwall-divide.json";
 import ridgewayCrossingMapObjectsConfig from "../../../configs/phase1-map-objects-ridgeway-crossing.json";
 import defaultMapObjectsConfig from "../../../configs/phase1-map-objects.json";
 import defaultUnitsConfig from "../../../configs/units.json";
 import amberFieldsWorldConfig from "../../../configs/phase1-world-amber-fields.json";
+import ashpeakAscentWorldConfig from "../../../configs/phase1-world-ashpeak-ascent.json";
+import bogfenCrossingWorldConfig from "../../../configs/phase1-world-bogfen-crossing.json";
 import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
 import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
+import frostwatchRidgeWorldConfig from "../../../configs/phase1-world-frostwatch-ridge.json";
 import highlandReachWorldConfig from "../../../configs/phase1-world-highland-reach.json";
 import ironpassGorgeWorldConfig from "../../../configs/phase1-world-ironpass-gorge.json";
+import murkveilDeltaWorldConfig from "../../../configs/phase1-world-murkveil-delta.json";
 import splitrockCanyonWorldConfig from "../../../configs/phase1-world-splitrock-canyon.json";
 import stonewatchForkWorldConfig from "../../../configs/phase1-world-stonewatch-fork.json";
+import thornwallDivideWorldConfig from "../../../configs/phase1-world-thornwall-divide.json";
 import ridgewayCrossingWorldConfig from "../../../configs/phase1-world-ridgeway-crossing.json";
 import defaultWorldConfig from "../../../configs/phase1-world.json";
 import type {
@@ -50,6 +60,11 @@ export const HIGHLAND_REACH_MAP_VARIANT_ID = "highland_reach";
 export const AMBER_FIELDS_MAP_VARIANT_ID = "amber_fields";
 export const IRONPASS_GORGE_MAP_VARIANT_ID = "ironpass_gorge";
 export const SPLITROCK_CANYON_MAP_VARIANT_ID = "splitrock_canyon";
+export const BOGFEN_CROSSING_MAP_VARIANT_ID = "bogfen_crossing";
+export const MURKVEIL_DELTA_MAP_VARIANT_ID = "murkveil_delta";
+export const FROSTWATCH_RIDGE_MAP_VARIANT_ID = "frostwatch_ridge";
+export const ASHPEAK_ASCENT_MAP_VARIANT_ID = "ashpeak_ascent";
+export const THORNWALL_DIVIDE_MAP_VARIANT_ID = "thornwall_divide";
 export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
 
 export interface RuntimeConfigBundle {
@@ -152,7 +167,7 @@ function isResourceKind(value: unknown): value is "gold" | "wood" | "ore" {
 }
 
 function isTerrainType(value: unknown): value is TerrainType {
-  return value === "grass" || value === "dirt" || value === "sand" || value === "water";
+  return value === "grass" || value === "dirt" || value === "sand" || value === "water" || value === "swamp";
 }
 
 function isNeutralBehaviorMode(value: unknown): value is NeutralBehaviorMode {
@@ -768,6 +783,11 @@ function getAvailableMapVariantIds(): string[] {
     AMBER_FIELDS_MAP_VARIANT_ID,
     IRONPASS_GORGE_MAP_VARIANT_ID,
     SPLITROCK_CANYON_MAP_VARIANT_ID,
+    BOGFEN_CROSSING_MAP_VARIANT_ID,
+    MURKVEIL_DELTA_MAP_VARIANT_ID,
+    FROSTWATCH_RIDGE_MAP_VARIANT_ID,
+    ASHPEAK_ASCENT_MAP_VARIANT_ID,
+    THORNWALL_DIVIDE_MAP_VARIANT_ID,
     CONTESTED_BASIN_MAP_VARIANT_ID
   ];
 }
@@ -790,6 +810,11 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     requested === AMBER_FIELDS_MAP_VARIANT_ID ||
     requested === IRONPASS_GORGE_MAP_VARIANT_ID ||
     requested === SPLITROCK_CANYON_MAP_VARIANT_ID ||
+    requested === BOGFEN_CROSSING_MAP_VARIANT_ID ||
+    requested === MURKVEIL_DELTA_MAP_VARIANT_ID ||
+    requested === FROSTWATCH_RIDGE_MAP_VARIANT_ID ||
+    requested === ASHPEAK_ASCENT_MAP_VARIANT_ID ||
+    requested === THORNWALL_DIVIDE_MAP_VARIANT_ID ||
     requested === CONTESTED_BASIN_MAP_VARIANT_ID
   ) {
     return requested;
@@ -818,6 +843,16 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneWorldConfig(ironpassGorgeWorldConfig as WorldGenerationConfig)
       : mapVariantId === SPLITROCK_CANYON_MAP_VARIANT_ID
         ? cloneWorldConfig(splitrockCanyonWorldConfig as WorldGenerationConfig)
+      : mapVariantId === BOGFEN_CROSSING_MAP_VARIANT_ID
+        ? cloneWorldConfig(bogfenCrossingWorldConfig as WorldGenerationConfig)
+      : mapVariantId === MURKVEIL_DELTA_MAP_VARIANT_ID
+        ? cloneWorldConfig(murkveilDeltaWorldConfig as WorldGenerationConfig)
+      : mapVariantId === FROSTWATCH_RIDGE_MAP_VARIANT_ID
+        ? cloneWorldConfig(frostwatchRidgeWorldConfig as WorldGenerationConfig)
+      : mapVariantId === ASHPEAK_ASCENT_MAP_VARIANT_ID
+        ? cloneWorldConfig(ashpeakAscentWorldConfig as WorldGenerationConfig)
+      : mapVariantId === THORNWALL_DIVIDE_MAP_VARIANT_ID
+        ? cloneWorldConfig(thornwallDivideWorldConfig as WorldGenerationConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
         : getDefaultWorldConfig();
@@ -836,6 +871,16 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneMapObjectsConfig(ironpassGorgeMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === SPLITROCK_CANYON_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(splitrockCanyonMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === BOGFEN_CROSSING_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(bogfenCrossingMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === MURKVEIL_DELTA_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(murkveilDeltaMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === FROSTWATCH_RIDGE_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(frostwatchRidgeMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === ASHPEAK_ASCENT_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(ashpeakAscentMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === THORNWALL_DIVIDE_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(thornwallDivideMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
         : getDefaultMapObjectsConfig();

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -3,18 +3,28 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import assetConfig from "../../../configs/assets.json";
 import amberFieldsMapObjectsConfig from "../../../configs/phase1-map-objects-amber-fields.json";
+import ashpeakAscentMapObjectsConfig from "../../../configs/phase1-map-objects-ashpeak-ascent.json";
+import bogfenCrossingMapObjectsConfig from "../../../configs/phase1-map-objects-bogfen-crossing.json";
 import frontierBasinMapObjectsConfig from "../../../configs/phase1-map-objects-frontier-basin.json";
+import frostwatchRidgeMapObjectsConfig from "../../../configs/phase1-map-objects-frostwatch-ridge.json";
 import highlandReachMapObjectsConfig from "../../../configs/phase1-map-objects-highland-reach.json";
 import ironpassGorgeMapObjectsConfig from "../../../configs/phase1-map-objects-ironpass-gorge.json";
+import murkveilDeltaMapObjectsConfig from "../../../configs/phase1-map-objects-murkveil-delta.json";
 import splitrockCanyonMapObjectsConfig from "../../../configs/phase1-map-objects-splitrock-canyon.json";
 import stonewatchForkMapObjectsConfig from "../../../configs/phase1-map-objects-stonewatch-fork.json";
+import thornwallDivideMapObjectsConfig from "../../../configs/phase1-map-objects-thornwall-divide.json";
 import ridgewayCrossingMapObjectsConfig from "../../../configs/phase1-map-objects-ridgeway-crossing.json";
 import amberFieldsWorldConfig from "../../../configs/phase1-world-amber-fields.json";
+import ashpeakAscentWorldConfig from "../../../configs/phase1-world-ashpeak-ascent.json";
+import bogfenCrossingWorldConfig from "../../../configs/phase1-world-bogfen-crossing.json";
 import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
+import frostwatchRidgeWorldConfig from "../../../configs/phase1-world-frostwatch-ridge.json";
 import highlandReachWorldConfig from "../../../configs/phase1-world-highland-reach.json";
 import ironpassGorgeWorldConfig from "../../../configs/phase1-world-ironpass-gorge.json";
+import murkveilDeltaWorldConfig from "../../../configs/phase1-world-murkveil-delta.json";
 import splitrockCanyonWorldConfig from "../../../configs/phase1-world-splitrock-canyon.json";
 import stonewatchForkWorldConfig from "../../../configs/phase1-world-stonewatch-fork.json";
+import thornwallDivideWorldConfig from "../../../configs/phase1-world-thornwall-divide.json";
 import ridgewayCrossingWorldConfig from "../../../configs/phase1-world-ridgeway-crossing.json";
 import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
 import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
@@ -25,8 +35,10 @@ import {
   appendPlayerBattleReplaySummaries,
   applyBattleOutcomeToWorld,
   AMBER_FIELDS_MAP_VARIANT_ID,
+  ASHPEAK_ASCENT_MAP_VARIANT_ID,
   applyAchievementMetricDelta,
   applyAchievementProgressValue,
+  BOGFEN_CROSSING_MAP_VARIANT_ID,
   buildPlayerBattleReportCenter,
   buildPlayerProgressionSnapshot,
   queryAchievementProgress,
@@ -54,6 +66,7 @@ import {
   decodePlayerWorldView,
   encodePlayerWorldView,
   filterWorldEventsForPlayer,
+  FROSTWATCH_RIDGE_MAP_VARIANT_ID,
   FRONTIER_BASIN_MAP_VARIANT_ID,
   getBattleBalanceConfig,
   getAchievementDefinitions,
@@ -72,6 +85,7 @@ import {
   HIGHLAND_REACH_MAP_VARIANT_ID,
   hasFullyExploredMap,
   IRONPASS_GORGE_MAP_VARIANT_ID,
+  MURKVEIL_DELTA_MAP_VARIANT_ID,
   normalizeAchievementProgressQuery,
   normalizeEventLogQuery,
   normalizePlayerAccountReadModel,
@@ -96,6 +110,7 @@ import {
   rollEquipmentDrop,
   setBattleBalanceConfig,
   setBattleSkillCatalog,
+  THORNWALL_DIVIDE_MAP_VARIANT_ID,
   setUnitCatalog,
   getRuntimeConfigBundleForRoom,
   validateMapObjectsConfig,
@@ -214,7 +229,7 @@ function createLargePlayerWorldView(): PlayerWorldView {
   const tiles = Array.from({ length: width * height }, (_, index) => {
     const x = index % width;
     const y = Math.floor(index / width);
-    const terrain = (["grass", "dirt", "sand", "water"] as const)[(x + y) % 4] ?? "grass";
+    const terrain = (["grass", "dirt", "sand", "water", "swamp"] as const)[(x + y) % 5] ?? "grass";
     const resource = index % 47 === 0 ? { kind: "wood" as const, amount: 5 } : undefined;
     const occupant = index === width + 1 ? { kind: "hero" as const, refId: "hero-1" } : undefined;
 
@@ -335,6 +350,10 @@ test("asset config validation reports missing terrain variants and bad asset roo
         default: "/assets/terrain/water-tile.svg",
         variants: ["/assets/terrain/water-tile.svg"]
       },
+      swamp: {
+        default: "/assets/terrain/dirt-tile.svg",
+        variants: ["/assets/terrain/dirt-tile.svg"]
+      },
       unknown: {
         default: "/assets/terrain/fog-tile.svg",
         variants: []
@@ -425,6 +444,10 @@ test("asset config validation accepts prototype stage and open-source provenance
       water: {
         default: "/assets/terrain/water-tile.png",
         variants: ["/assets/terrain/water-tile.png"]
+      },
+      swamp: {
+        default: "/assets/terrain/dirt-tile.png",
+        variants: ["/assets/terrain/dirt-tile.png"]
       },
       unknown: {
         default: "/assets/terrain/fog-tile.png",
@@ -705,6 +728,10 @@ test("asset config validation reports missing metadata coverage and duplicate sl
         default: "/assets/terrain/water-tile.svg",
         variants: ["/assets/terrain/water-tile.svg"]
       },
+      swamp: {
+        default: "/assets/terrain/dirt-tile.svg",
+        variants: ["/assets/terrain/dirt-tile.svg"]
+      },
       unknown: {
         default: "/assets/terrain/fog-tile.svg",
         variants: ["/assets/terrain/fog-tile.svg"]
@@ -790,6 +817,10 @@ test("asset config validation reports missing metadata coverage", () => {
       water: {
         default: "/assets/pixel/terrain/water-tile.png",
         variants: ["/assets/pixel/terrain/water-tile.png"]
+      },
+      swamp: {
+        default: "/assets/pixel/terrain/dirt-tile.png",
+        variants: ["/assets/pixel/terrain/dirt-tile.png"]
       },
       unknown: {
         default: "/assets/pixel/terrain/fog-tile.png",
@@ -2403,7 +2434,7 @@ test("createWorldStateFromConfigs produces a valid frontier basin world", () => 
   const state = createWorldStateFromConfigs(bundle.world, bundle.mapObjects, seed, roomId);
   assert.ok(state.map.tiles.length > 0);
 
-  const validTerrains = new Set(["grass", "dirt", "sand", "water"]);
+  const validTerrains = new Set(["grass", "dirt", "sand", "water", "swamp"]);
   assert.ok(
     state.map.tiles.every((tile) => validTerrains.has(tile.terrain)),
     "frontier basin tiles must have a valid terrain type"
@@ -2532,6 +2563,87 @@ test("createInitialWorldState selects the splitrock canyon variant with asymmetr
   assert.equal(state.buildings["mine-ore-1"]?.resourceKind, "ore");
   assert.equal(state.buildings["recruit-post-2"]?.kind, "recruitment_post");
   assert.equal(state.neutralArmies["neutral-4"]?.behavior?.mode, "patrol");
+});
+
+test("issue 782 batch 2 world and map-object configs pass schema validation", () => {
+  const unitCatalog = getDefaultUnitCatalog();
+  const variants: Array<[WorldGenerationConfig, MapObjectsConfig]> = [
+    [bogfenCrossingWorldConfig as WorldGenerationConfig, bogfenCrossingMapObjectsConfig as MapObjectsConfig],
+    [murkveilDeltaWorldConfig as WorldGenerationConfig, murkveilDeltaMapObjectsConfig as MapObjectsConfig],
+    [frostwatchRidgeWorldConfig as WorldGenerationConfig, frostwatchRidgeMapObjectsConfig as MapObjectsConfig],
+    [ashpeakAscentWorldConfig as WorldGenerationConfig, ashpeakAscentMapObjectsConfig as MapObjectsConfig],
+    [thornwallDivideWorldConfig as WorldGenerationConfig, thornwallDivideMapObjectsConfig as MapObjectsConfig]
+  ];
+
+  for (const [world, mapObjects] of variants) {
+    validateWorldConfig(world);
+    validateMapObjectsConfig(mapObjects, world, unitCatalog);
+  }
+});
+
+test("createInitialWorldState selects the bogfen crossing variant with passable swamp lanes", () => {
+  const state = createInitialWorldState(1001, "preview-bogfen[map:bogfen_crossing]");
+
+  assert.equal(state.meta.mapVariantId, BOGFEN_CROSSING_MAP_VARIANT_ID);
+  assert.equal(state.map.tiles.length, 144);
+  assert.equal(state.heroes[0]?.position.x, 1);
+  assert.equal(state.heroes[0]?.position.y, 5);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 3 && tile.position.y === 4)?.terrain, "swamp");
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 5 && tile.position.y === 0)?.terrain, "water");
+  assert.equal(state.buildings["mine-wood-1"]?.resourceKind, "wood");
+  assert.equal(state.neutralArmies["neutral-4"]?.behavior?.mode, "patrol");
+});
+
+test("createInitialWorldState selects the murkveil delta variant with island resources", () => {
+  const state = createInitialWorldState(1001, "preview-murkveil[map:murkveil_delta]");
+
+  assert.equal(state.meta.mapVariantId, MURKVEIL_DELTA_MAP_VARIANT_ID);
+  assert.equal(state.map.tiles.length, 120);
+  assert.equal(state.heroes[1]?.position.x, 8);
+  assert.equal(state.heroes[1]?.position.y, 9);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 3 && tile.position.y === 1)?.terrain, "water");
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 1 && tile.position.y === 4)?.terrain, "swamp");
+  assert.equal(state.buildings["shrine-power-1"]?.kind, "attribute_shrine");
+  assert.equal(state.neutralArmies["neutral-3"]?.reward?.kind, "ore");
+});
+
+test("createInitialWorldState selects the frostwatch ridge variant with a broad central lane", () => {
+  const state = createInitialWorldState(1001, "preview-frostwatch[map:frostwatch_ridge]");
+
+  assert.equal(state.meta.mapVariantId, FROSTWATCH_RIDGE_MAP_VARIANT_ID);
+  assert.equal(state.map.tiles.length, 140);
+  assert.equal(state.heroes[0]?.position.x, 1);
+  assert.equal(state.heroes[0]?.position.y, 4);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 6 && tile.position.y === 4)?.terrain, "sand");
+  assert.equal(state.buildings["mine-ore-1"]?.resourceKind, "ore");
+  assert.equal(state.neutralArmies["neutral-2"]?.reward?.kind, "ore");
+});
+
+test("createInitialWorldState selects the ashpeak ascent variant with defender-favored high ground", () => {
+  const state = createInitialWorldState(1001, "preview-ashpeak[map:ashpeak_ascent]");
+
+  assert.equal(state.meta.mapVariantId, ASHPEAK_ASCENT_MAP_VARIANT_ID);
+  assert.equal(state.map.tiles.length, 144);
+  assert.equal(state.heroes[0]?.position.x, 1);
+  assert.equal(state.heroes[0]?.position.y, 8);
+  assert.equal(state.heroes[1]?.position.x, 10);
+  assert.equal(state.heroes[1]?.position.y, 3);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 8 && tile.position.y === 3)?.terrain, "dirt");
+  assert.equal(state.buildings["shrine-defense-1"]?.kind, "attribute_shrine");
+  assert.equal(state.neutralArmies["neutral-4"]?.behavior?.mode, "patrol");
+});
+
+test("createInitialWorldState selects the thornwall divide variant with asymmetric resource access", () => {
+  const state = createInitialWorldState(1001, "preview-thornwall[map:thornwall_divide]");
+
+  assert.equal(state.meta.mapVariantId, THORNWALL_DIVIDE_MAP_VARIANT_ID);
+  assert.equal(state.map.tiles.length, 144);
+  assert.equal(state.heroes[0]?.position.x, 1);
+  assert.equal(state.heroes[0]?.position.y, 3);
+  assert.equal(state.map.tiles.find((tile) => tile.position.x === 3 && tile.position.y === 3)?.terrain, "swamp");
+  assert.equal(state.buildings["mine-wood-1"]?.resourceKind, "wood");
+  assert.equal(state.buildings["mine-ore-1"]?.resourceKind, "ore");
+  assert.equal(state.neutralArmies["neutral-2"]?.reward?.kind, "ore");
 });
 
 test("frontier basin generates a distinct layout from the default phase1 variant", () => {
@@ -2816,13 +2928,13 @@ test("applyBattleOutcomeToWorld grants PvP experience to the winning hero", () =
     heroes: [attacker, defender],
     tiles: [
       createTile(0, 0),
-      createTile(1, 0),
+      createTile(1, 0, { walkable: false, terrain: "water" }),
       createTile(2, 0),
       createTile(0, 1),
       createTile(1, 1, { occupant: { kind: "hero", refId: "hero-1" } }),
       createTile(2, 1, { occupant: { kind: "hero", refId: "hero-2" } }),
       createTile(0, 2),
-      createTile(1, 2),
+      createTile(1, 2, { walkable: false, terrain: "water" }),
       createTile(2, 2)
     ]
   });
@@ -4395,6 +4507,58 @@ test("hawk rider armies can path across water tiles in world and player views", 
     { x: 1, y: 1 },
     { x: 2, y: 1 }
   ]);
+});
+
+test("swamp tiles stay traversable but cost extra movement in world and player views", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 1 },
+    move: { total: 3, remaining: 3 }
+  });
+  const state = createWorldState({
+    width: 3,
+    height: 3,
+    heroes: [hero],
+    tiles: [
+      createTile(0, 0),
+      createTile(1, 0),
+      createTile(2, 0),
+      createTile(0, 1, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(1, 1, { terrain: "swamp" }),
+      createTile(2, 1),
+      createTile(0, 2),
+      createTile(1, 2),
+      createTile(2, 2)
+    ],
+    visibilityByPlayer: {
+      "player-1": new Array(9).fill("visible")
+    }
+  });
+  const view = createPlayerWorldView(state, "player-1");
+  const worldPlan = planHeroMovement(state, "hero-1", { x: 2, y: 1 });
+  const viewPlan = planPlayerViewMovement(view, "hero-1", { x: 2, y: 1 });
+
+  assert.deepEqual(worldPlan?.path, [
+    { x: 0, y: 1 },
+    { x: 1, y: 1 },
+    { x: 2, y: 1 }
+  ]);
+  assert.equal(worldPlan?.moveCost, 3);
+  assert.equal(viewPlan?.moveCost, 3);
+  assert.equal(validateWorldAction(state, { type: "hero.move", heroId: "hero-1", destination: { x: 2, y: 1 } }).valid, true);
+
+  const exhaustedState = {
+    ...state,
+    heroes: state.heroes.map((item) =>
+      item.id === "hero-1" ? { ...item, move: { ...item.move, remaining: 2 } } : item
+    )
+  };
+  assert.equal(
+    validateWorldAction(exhaustedState, { type: "hero.move", heroId: "hero-1", destination: { x: 2, y: 1 } }).valid,
+    false
+  );
 });
 
 test("predictPlayerWorldAction updates the player view immediately for move and collect", () => {

--- a/scripts/content-pack-map-packs.ts
+++ b/scripts/content-pack-map-packs.ts
@@ -65,6 +65,41 @@ export const EXTRA_CONTENT_PACK_MAP_PACKS: ContentPackMapPackDefinition[] = [
     aliases: ["splitrock_canyon", "splitrock"]
   },
   {
+    id: "bogfen-crossing",
+    worldFileName: "phase1-world-bogfen-crossing.json",
+    mapObjectsFileName: "phase1-map-objects-bogfen-crossing.json",
+    phase: "phase1",
+    aliases: ["bogfen_crossing", "bogfen"]
+  },
+  {
+    id: "murkveil-delta",
+    worldFileName: "phase1-world-murkveil-delta.json",
+    mapObjectsFileName: "phase1-map-objects-murkveil-delta.json",
+    phase: "phase1",
+    aliases: ["murkveil_delta", "murkveil"]
+  },
+  {
+    id: "frostwatch-ridge",
+    worldFileName: "phase1-world-frostwatch-ridge.json",
+    mapObjectsFileName: "phase1-map-objects-frostwatch-ridge.json",
+    phase: "phase1",
+    aliases: ["frostwatch_ridge", "frostwatch"]
+  },
+  {
+    id: "ashpeak-ascent",
+    worldFileName: "phase1-world-ashpeak-ascent.json",
+    mapObjectsFileName: "phase1-map-objects-ashpeak-ascent.json",
+    phase: "phase1",
+    aliases: ["ashpeak_ascent", "ashpeak"]
+  },
+  {
+    id: "thornwall-divide",
+    worldFileName: "phase1-world-thornwall-divide.json",
+    mapObjectsFileName: "phase1-map-objects-thornwall-divide.json",
+    phase: "phase1",
+    aliases: ["thornwall_divide", "thornwall"]
+  },
+  {
     id: "phase2",
     worldFileName: "phase2-contested-basin.json",
     mapObjectsFileName: "phase2-map-objects-contested-basin.json",

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -95,7 +95,7 @@ function parseArgs(argv: string[]): {
       const definition = resolveContentPackMapPack(presetId);
       if (!definition) {
         throw new Error(
-          `Unknown map pack "${presetId}". Supported values: default, frontier-basin, stonewatch-fork, ridgeway-crossing, highland-reach, amber-fields, ironpass-gorge, splitrock-canyon, phase2.`
+          `Unknown map pack "${presetId}". Supported values: default, frontier-basin, stonewatch-fork, ridgeway-crossing, highland-reach, amber-fields, ironpass-gorge, splitrock-canyon, bogfen-crossing, murkveil-delta, frostwatch-ridge, ashpeak-ascent, thornwall-divide, phase2.`
         );
       }
       if (definition.id !== DEFAULT_CONTENT_PACK_MAP_PACK.id) {


### PR DESCRIPTION
## Summary
- add five new Phase 1 map packs for bogfen crossing, murkveil delta, frostwatch ridge, ashpeak ascent, and thornwall divide
- add passable `swamp` terrain with extra movement cost and wire the new map packs through runtime/config validation paths
- extend shared-core coverage for the new variants and swamp movement behavior

Closes #782