### PR TITLE
feat: expand equipment catalog to 40 items with set bonuses

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/battle.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle.ts
@@ -10,6 +10,7 @@ import type {
   BattleStatusEffectConfig,
   BattleStatusEffectId,
   BattleStatusEffectState,
+  EquipmentSpecialEffectId,
   HeroState,
   NeutralArmyState,
   TerrainType,
@@ -52,6 +53,10 @@ function skillsOf(unit: UnitStack): BattleSkillState[] {
 
 function statusEffectsOf(unit: UnitStack): BattleStatusEffectState[] {
   return unit.statusEffects ?? [];
+}
+
+function equipmentEffectsOf(unit: UnitStack): EquipmentSpecialEffectId[] {
+  return unit.equipmentEffects ?? [];
 }
 
 function withNormalizedCollections(unit: UnitStack): UnitStack {
@@ -447,6 +452,18 @@ function applyHealing(target: UnitStack, amount: number): UnitStack {
     ...target,
     currentHp: currentHp > 0 ? currentHp : target.maxHp
   };
+}
+
+function hasEquipmentEffect(unit: UnitStack, effectId: EquipmentSpecialEffectId): boolean {
+  return equipmentEffectsOf(unit).includes(effectId);
+}
+
+function lifestealHealingAmount(unit: UnitStack): number {
+  return Math.max(2, Math.ceil(unit.maxHp * 0.2));
+}
+
+function thornsDamageAmount(incomingDamage: number): number {
+  return Math.max(1, Math.floor(incomingDamage * 0.2));
 }
 
 function buildUnitStack(
@@ -1187,6 +1204,7 @@ function applyAttackSequence(
   );
 
   let damagedDefender = nextUnits[defender.id]!;
+  let nextAttacker = attacker;
   damagedDefender = applyOnHitStatuses(
     attacker,
     damagedDefender,
@@ -1195,6 +1213,20 @@ function applyAttackSequence(
     options?.skillId ? [options.skillId] : []
   );
   nextUnits[defender.id] = damagedDefender;
+
+  if ((options?.delivery ?? "contact") === "contact" && damagedDefender.count > 0 && hasEquipmentEffect(damagedDefender, "thorns")) {
+    const reflectedDamage = thornsDamageAmount(attackDamage);
+    nextAttacker = applyDamage(nextAttacker, reflectedDamage);
+    nextUnits[attacker.id] = nextAttacker;
+    log.push(`${damagedDefender.stackName} 的反刺对 ${attacker.stackName} 造成 ${reflectedDamage} 伤害`);
+  }
+
+  if (damagedDefender.count === 0 && hasEquipmentEffect(nextAttacker, "lifesteal")) {
+    const healingAmount = lifestealHealingAmount(nextAttacker);
+    nextAttacker = applyHealing(nextAttacker, healingAmount);
+    nextUnits[attacker.id] = nextAttacker;
+    log.push(`${nextAttacker.stackName} 触发嗜血，恢复 ${healingAmount} 生命`);
+  }
 
   const splashSkillDefinition = options?.skillId ? skillDefinitionFor(options.skillId, catalogIndex) : null;
   const splashMultiplier =
@@ -1217,19 +1249,33 @@ function applyAttackSequence(
 
   if ((options?.allowRetaliation ?? true) && damagedDefender.count > 0 && !damagedDefender.hasRetaliated) {
     const retaliationRoll = nextDeterministicRandom(nextRngState.seed);
-    const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value, preparedState.state);
-    let damagedAttacker = applyDamage(attacker, retaliationDamage);
+    const retaliationDamage = estimateDamage(damagedDefender, nextAttacker, retaliationRoll.value, preparedState.state);
+    let damagedAttacker = applyDamage(nextAttacker, retaliationDamage);
     damagedAttacker = applyOnHitStatuses(damagedDefender, damagedAttacker, log, catalogIndex);
+    let retaliatingDefender = damagedDefender;
+
+    if (damagedAttacker.count > 0 && hasEquipmentEffect(damagedAttacker, "thorns")) {
+      const reflectedDamage = thornsDamageAmount(retaliationDamage);
+      retaliatingDefender = applyDamage(retaliatingDefender, reflectedDamage);
+      log.push(`${damagedAttacker.stackName} 的反刺对 ${retaliatingDefender.stackName} 造成 ${reflectedDamage} 伤害`);
+    }
+
+    if (damagedAttacker.count === 0 && hasEquipmentEffect(retaliatingDefender, "lifesteal")) {
+      const healingAmount = lifestealHealingAmount(retaliatingDefender);
+      retaliatingDefender = applyHealing(retaliatingDefender, healingAmount);
+      log.push(`${retaliatingDefender.stackName} 触发嗜血，恢复 ${healingAmount} 生命`);
+    }
+
     nextUnits[attacker.id] = damagedAttacker;
     nextUnits[defender.id] = {
-      ...damagedDefender,
+      ...retaliatingDefender,
       hasRetaliated: true
     };
     nextRngState = {
       seed: retaliationRoll.nextSeed,
       cursor: nextRngState.cursor + 1
     };
-    log.push(`${damagedDefender.stackName} 反击 ${attacker.stackName}，造成 ${retaliationDamage} 伤害`);
+    log.push(`${retaliatingDefender.stackName} 反击 ${attacker.stackName}，造成 ${retaliationDamage} 伤害`);
   }
 
   return advanceTurn(
@@ -1616,6 +1662,7 @@ export function createNeutralBattleState(
       currentHp: heroTemplate.maxHp,
       maxHp: heroTemplate.maxHp,
       power: hero.stats.power,
+      equipmentEffects: heroEquipment.specialEffects.map((effect) => effect.id),
       hasRetaliated: false,
       defending: false
     },
@@ -1718,6 +1765,7 @@ export function createHeroBattleState(
         currentHp: attackerTemplate.maxHp,
         maxHp: attackerTemplate.maxHp,
         power: attackerHero.stats.power,
+        equipmentEffects: attackerEquipment.specialEffects.map((effect) => effect.id),
         hasRetaliated: false,
         defending: false
       },
@@ -1740,6 +1788,7 @@ export function createHeroBattleState(
         currentHp: defenderTemplate.maxHp,
         maxHp: defenderTemplate.maxHp,
         power: defenderHero.stats.power,
+        equipmentEffects: defenderEquipment.specialEffects.map((effect) => effect.id),
         hasRetaliated: false,
         defending: false
       },

--- a/apps/cocos-client/assets/scripts/project-shared/equipment.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/equipment.ts
@@ -4,6 +4,7 @@ import {
   type EquipmentId,
   type EquipmentDefinition,
   type EquipmentRarity,
+  type EquipmentSpecialEffectConfig,
   type EquipmentStatBonuses,
   type EquipmentType,
   type HeroState,
@@ -95,6 +96,87 @@ const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
       }
     },
     {
+      id: "emberwood_staff",
+      name: "烬木法杖",
+      type: "weapon",
+      rarity: "common",
+      description: "在廉价木杖中嵌入火纹碎片，适合初阶施法者。",
+      bonuses: {
+        power: 1,
+        knowledge: 1
+      }
+    },
+    {
+      id: "windrider_javelin",
+      name: "逐风标枪",
+      type: "weapon",
+      rarity: "common",
+      description: "轻型投枪便于远距离压制和追击。",
+      bonuses: {
+        attackPercent: 5
+      }
+    },
+    {
+      id: "ironbound_greatblade",
+      name: "铁缚巨刃",
+      type: "weapon",
+      rarity: "common",
+      description: "双手重刃以笨重换取稳定的破甲能力。",
+      bonuses: {
+        attackPercent: 9
+      }
+    },
+    {
+      id: "runeshard_staff",
+      name: "符晶法杖",
+      type: "weapon",
+      rarity: "rare",
+      description: "杖首的符晶会在法术聚焦时放大破坏力。",
+      bonuses: {
+        attackPercent: 4,
+        power: 2
+      }
+    },
+    {
+      id: "siege_maul",
+      name: "攻城战锤",
+      type: "weapon",
+      rarity: "rare",
+      description: "以重击撕开防线的冲锋武器。",
+      bonuses: {
+        attackPercent: 14
+      },
+      setId: "warhost"
+    },
+    {
+      id: "frostfang_javelin",
+      name: "霜牙飞枪",
+      type: "weapon",
+      rarity: "rare",
+      description: "投掷时带着寒雾轨迹，擅长抢先压低敌军气势。",
+      bonuses: {
+        attackPercent: 7,
+        knowledge: 1
+      },
+      specialEffect: {
+        id: "initiative_edge",
+        name: "抢攻",
+        description: "在开战后的第一轮拥有更强的压制力。"
+      }
+    },
+    {
+      id: "titanbreaker_greatsword",
+      name: "裂岳巨剑",
+      type: "weapon",
+      rarity: "epic",
+      description: "专为突破重甲阵列打造的双手巨剑。",
+      bonuses: {
+        attackPercent: 18,
+        defensePercent: 2
+      },
+      setId: "warhost"
+    },
+    {
       id: "padded_gambeson",
       name: "厚绗布甲",
       type: "armor",
@@ -170,6 +252,90 @@ const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
         defensePercent: 14,
         maxHp: 5
       }
+    },
+    {
+      id: "leather_brigandine",
+      name: "轻革战衣",
+      type: "armor",
+      rarity: "common",
+      description: "轻甲结构在保留机动性的同时提供基础防护。",
+      bonuses: {
+        attackPercent: 3,
+        defensePercent: 6,
+        maxHp: 2
+      }
+    },
+    {
+      id: "duskweave_robes",
+      name: "暮纱法袍",
+      type: "armor",
+      rarity: "common",
+      description: "袍摆的暗纹有助于稳定施法节奏。",
+      bonuses: {
+        power: 1,
+        knowledge: 1,
+        maxHp: 2
+      }
+    },
+    {
+      id: "skirmisher_cuirass",
+      name: "游斗胸甲",
+      type: "armor",
+      rarity: "common",
+      description: "偏向攻守均衡的前哨轻甲。",
+      bonuses: {
+        attackPercent: 4,
+        defensePercent: 5,
+        maxHp: 2
+      }
+    },
+    {
+      id: "runic_vestments",
+      name: "符印法衣",
+      type: "armor",
+      rarity: "rare",
+      description: "由多层符印布面缝制，能承载更多法术波动。",
+      bonuses: {
+        defensePercent: 4,
+        power: 2,
+        knowledge: 1
+      }
+    },
+    {
+      id: "assault_cuirass",
+      name: "突袭胸甲",
+      type: "armor",
+      rarity: "rare",
+      description: "为破阵先锋打造的轻重混编胸甲。",
+      bonuses: {
+        attackPercent: 6,
+        defensePercent: 8,
+        maxHp: 3
+      },
+      setId: "warhost"
+    },
+    {
+      id: "thornhide_cape",
+      name: "棘皮披风",
+      type: "armor",
+      rarity: "rare",
+      description: "外层的硬棘纤维能分散近身冲击。",
+      bonuses: {
+        defensePercent: 9,
+        maxHp: 4
+      }
+    },
+    {
+      id: "bulwark_plate",
+      name: "磐垒重铠",
+      type: "armor",
+      rarity: "epic",
+      description: "重装守军的压阵护甲，越久战越难被击穿。",
+      bonuses: {
+        defensePercent: 18,
+        maxHp: 7
+      },
+      setId: "bulwark"
     },
     {
       id: "scout_compass",
@@ -248,9 +414,142 @@ const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
         name: "引导",
         description: "为后续技能结算预留更高的法术上限。"
       }
+    },
+    {
+      id: "trailblazer_lantern",
+      name: "拓路灯盏",
+      type: "accessory",
+      rarity: "common",
+      description: "发光符灯能帮助部队更早识别前路威胁。",
+      bonuses: {
+        attackPercent: 2,
+        knowledge: 1
+      }
+    },
+    {
+      id: "wayfinder_map",
+      name: "行路图卷",
+      type: "accessory",
+      rarity: "common",
+      description: "一卷不断修订的地图草图，适合长期行军。",
+      bonuses: {
+        defensePercent: 2,
+        knowledge: 1
+      }
+    },
+    {
+      id: "restorers_kit",
+      name: "复原急救包",
+      type: "accessory",
+      rarity: "common",
+      description: "包含绷带与药膏的随身套件，适合持久战。",
+      bonuses: {
+        defensePercent: 2,
+        maxHp: 2
+      }
+    },
+    {
+      id: "blood_oath_emblem",
+      name: "血誓徽印",
+      type: "accessory",
+      rarity: "rare",
+      description: "战团先锋间流转的誓约信物。",
+      bonuses: {
+        attackPercent: 6,
+        power: 1
+      },
+      setId: "warhost"
+    },
+    {
+      id: "sentinel_badge",
+      name: "守卫徽章",
+      type: "accessory",
+      rarity: "rare",
+      description: "常由城防指挥官佩戴，用以稳住整条阵线。",
+      bonuses: {
+        defensePercent: 7
+      },
+      setId: "bulwark"
+    },
+    {
+      id: "cartographer_monocle",
+      name: "绘界单片镜",
+      type: "accessory",
+      rarity: "rare",
+      description: "经常被探索队长用于快速判定地形与射界。",
+      bonuses: {
+        attackPercent: 3,
+        knowledge: 2
+      }
+    },
+    {
+      id: "phoenix_feather",
+      name: "炎凰羽饰",
+      type: "accessory",
+      rarity: "epic",
+      description: "燃尽后仍有余辉的羽饰，能提升战意与专注。",
+      bonuses: {
+        attackPercent: 4,
+        power: 1,
+        maxHp: 3
+      }
+    },
+    {
+      id: "briar_heart_charm",
+      name: "荆心护符",
+      type: "accessory",
+      rarity: "epic",
+      description: "镶着硬棘核心的护符，擅长将冲击返还给来敌。",
+      bonuses: {
+        defensePercent: 6,
+        maxHp: 4
+      },
+      setId: "bulwark"
     }
   ]
 };
+
+export interface EquipmentSetBonusConfig {
+  setId: string;
+  name: string;
+  piecesRequired: number;
+  description: string;
+  bonuses: Partial<EquipmentStatBonuses>;
+  specialEffect?: EquipmentSpecialEffectConfig;
+}
+
+export const SET_BONUSES: EquipmentSetBonusConfig[] = [
+  {
+    setId: "warhost",
+    name: "战团突袭套",
+    piecesRequired: 2,
+    description: "2 件：攻击 +8% / 力量 +1，并获得击杀回血。",
+    bonuses: {
+      attackPercent: 8,
+      power: 1
+    },
+    specialEffect: {
+      id: "lifesteal",
+      name: "嗜血",
+      description: "击杀敌方单位后恢复自身生命。"
+    }
+  },
+  {
+    setId: "bulwark",
+    name: "磐垒守御套",
+    piecesRequired: 2,
+    description: "2 件：防御 +10% / 生命上限 +4，并获得反伤。",
+    bonuses: {
+      defensePercent: 10,
+      maxHp: 4
+    },
+    specialEffect: {
+      id: "thorns",
+      name: "反刺",
+      description: "受到近战攻击时，对攻击者造成反伤。"
+    }
+  }
+];
 
 const DEFAULT_EQUIPMENT_BY_ID = new Map(
   DEFAULT_EQUIPMENT_CATALOG.entries.map((entry) => [entry.id, entry] as const)
@@ -266,6 +565,7 @@ export interface HeroEquipmentBonusSummary extends EquipmentStatBonuses {
   attack: number;
   defense: number;
   resolvedItemIds: string[];
+  activeSetBonuses: EquipmentSetBonusConfig[];
   specialEffects: NonNullable<EquipmentDefinition["specialEffect"]>[];
 }
 
@@ -307,6 +607,19 @@ function numericBonus(value: number | undefined): number {
 
 function resolveEquipmentDefinition(id: string | undefined): EquipmentDefinition | undefined {
   return id ? DEFAULT_EQUIPMENT_BY_ID.get(id) : undefined;
+}
+
+function resolveActiveSetBonuses(resolvedItems: EquipmentDefinition[]): EquipmentSetBonusConfig[] {
+  const countsBySetId = resolvedItems.reduce<Record<string, number>>((counts, item) => {
+    if (!item.setId) {
+      return counts;
+    }
+
+    counts[item.setId] = (counts[item.setId] ?? 0) + 1;
+    return counts;
+  }, {});
+
+  return SET_BONUSES.filter((entry) => (countsBySetId[entry.setId] ?? 0) >= entry.piecesRequired);
 }
 
 function percentageDelta(base: number, percent: number): number {
@@ -353,6 +666,7 @@ export function getDefaultEquipmentCatalog(): EquipmentCatalogConfig {
     entries: DEFAULT_EQUIPMENT_CATALOG.entries.map((entry) => ({
       ...entry,
       bonuses: { ...entry.bonuses },
+      ...(entry.setId ? { setId: entry.setId } : {}),
       ...(entry.specialEffect ? { specialEffect: { ...entry.specialEffect } } : {})
     }))
   };
@@ -497,6 +811,7 @@ export function createHeroEquipmentBonusSummary(
     resolveEquipmentDefinition(hero.loadout.equipment.armorId),
     resolveEquipmentDefinition(hero.loadout.equipment.accessoryId)
   ].filter((entry): entry is EquipmentDefinition => Boolean(entry));
+  const activeSetBonuses = resolveActiveSetBonuses(resolvedItems);
 
   for (const item of resolvedItems) {
     bonuses.attackPercent += numericBonus(item.bonuses.attackPercent);
@@ -505,6 +820,19 @@ export function createHeroEquipmentBonusSummary(
     bonuses.knowledge += numericBonus(item.bonuses.knowledge);
     bonuses.maxHp += numericBonus(item.bonuses.maxHp);
   }
+
+  for (const setBonus of activeSetBonuses) {
+    bonuses.attackPercent += numericBonus(setBonus.bonuses.attackPercent);
+    bonuses.defensePercent += numericBonus(setBonus.bonuses.defensePercent);
+    bonuses.power += numericBonus(setBonus.bonuses.power);
+    bonuses.knowledge += numericBonus(setBonus.bonuses.knowledge);
+    bonuses.maxHp += numericBonus(setBonus.bonuses.maxHp);
+  }
+
+  const specialEffects = resolvedItems
+    .flatMap((item) => (item.specialEffect ? [item.specialEffect] : []))
+    .concat(activeSetBonuses.flatMap((setBonus) => (setBonus.specialEffect ? [setBonus.specialEffect] : [])))
+    .filter((effect, index, effects) => effects.findIndex((item) => item.id === effect.id) === index);
 
   return {
     attack: percentageDelta(hero.stats.attack, bonuses.attackPercent),
@@ -515,9 +843,8 @@ export function createHeroEquipmentBonusSummary(
     knowledge: bonuses.knowledge,
     maxHp: bonuses.maxHp,
     resolvedItemIds: resolvedItems.map((item) => item.id),
-    specialEffects: resolvedItems
-      .flatMap((item) => (item.specialEffect ? [item.specialEffect] : []))
-      .filter((effect, index, effects) => effects.findIndex((item) => item.id === effect.id) === index)
+    activeSetBonuses,
+    specialEffects
   };
 }
 

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -27,7 +27,14 @@ export type HeroSkillBranchId = string;
 export type EquipmentId = string;
 export type EquipmentType = "weapon" | "armor" | "accessory";
 export type EquipmentRarity = "common" | "rare" | "epic";
-export type EquipmentSpecialEffectId = "initiative_edge" | "brace" | "channeling" | "momentum" | "ward";
+export type EquipmentSpecialEffectId =
+  | "initiative_edge"
+  | "brace"
+  | "channeling"
+  | "momentum"
+  | "ward"
+  | "lifesteal"
+  | "thorns";
 
 export interface EquipmentStatBonuses {
   attackPercent: number;
@@ -50,6 +57,7 @@ export interface EquipmentDefinition {
   rarity: EquipmentRarity;
   description: string;
   bonuses: Partial<EquipmentStatBonuses>;
+  setId?: string;
   specialEffect?: EquipmentSpecialEffectConfig;
 }
 
@@ -110,6 +118,9 @@ export interface BattleEnvironmentBalanceConfig {
 export interface BattleBalanceConfig {
   damage: BattleDamageBalanceConfig;
   environment: BattleEnvironmentBalanceConfig;
+  pvp: {
+    eloK: number;
+  };
 }
 
 export interface MovePoints {
@@ -466,6 +477,7 @@ export interface UnitStack {
   power?: number;
   hasRetaliated: boolean;
   defending: boolean;
+  equipmentEffects?: EquipmentSpecialEffectId[];
   skills?: BattleSkillState[];
   statusEffects?: BattleStatusEffectState[];
 }

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -10,6 +10,7 @@ import type {
   BattleStatusEffectConfig,
   BattleStatusEffectId,
   BattleStatusEffectState,
+  EquipmentSpecialEffectId,
   HeroState,
   NeutralArmyState,
   TerrainType,
@@ -52,6 +53,10 @@ function skillsOf(unit: UnitStack): BattleSkillState[] {
 
 function statusEffectsOf(unit: UnitStack): BattleStatusEffectState[] {
   return unit.statusEffects ?? [];
+}
+
+function equipmentEffectsOf(unit: UnitStack): EquipmentSpecialEffectId[] {
+  return unit.equipmentEffects ?? [];
 }
 
 function withNormalizedCollections(unit: UnitStack): UnitStack {
@@ -447,6 +452,18 @@ function applyHealing(target: UnitStack, amount: number): UnitStack {
     ...target,
     currentHp: currentHp > 0 ? currentHp : target.maxHp
   };
+}
+
+function hasEquipmentEffect(unit: UnitStack, effectId: EquipmentSpecialEffectId): boolean {
+  return equipmentEffectsOf(unit).includes(effectId);
+}
+
+function lifestealHealingAmount(unit: UnitStack): number {
+  return Math.max(2, Math.ceil(unit.maxHp * 0.2));
+}
+
+function thornsDamageAmount(incomingDamage: number): number {
+  return Math.max(1, Math.floor(incomingDamage * 0.2));
 }
 
 function buildUnitStack(
@@ -1187,6 +1204,7 @@ function applyAttackSequence(
   );
 
   let damagedDefender = nextUnits[defender.id]!;
+  let nextAttacker = attacker;
   damagedDefender = applyOnHitStatuses(
     attacker,
     damagedDefender,
@@ -1195,6 +1213,20 @@ function applyAttackSequence(
     options?.skillId ? [options.skillId] : []
   );
   nextUnits[defender.id] = damagedDefender;
+
+  if ((options?.delivery ?? "contact") === "contact" && damagedDefender.count > 0 && hasEquipmentEffect(damagedDefender, "thorns")) {
+    const reflectedDamage = thornsDamageAmount(attackDamage);
+    nextAttacker = applyDamage(nextAttacker, reflectedDamage);
+    nextUnits[attacker.id] = nextAttacker;
+    log.push(`${damagedDefender.stackName} 的反刺对 ${attacker.stackName} 造成 ${reflectedDamage} 伤害`);
+  }
+
+  if (damagedDefender.count === 0 && hasEquipmentEffect(nextAttacker, "lifesteal")) {
+    const healingAmount = lifestealHealingAmount(nextAttacker);
+    nextAttacker = applyHealing(nextAttacker, healingAmount);
+    nextUnits[attacker.id] = nextAttacker;
+    log.push(`${nextAttacker.stackName} 触发嗜血，恢复 ${healingAmount} 生命`);
+  }
 
   const splashSkillDefinition = options?.skillId ? skillDefinitionFor(options.skillId, catalogIndex) : null;
   const splashMultiplier =
@@ -1217,19 +1249,33 @@ function applyAttackSequence(
 
   if ((options?.allowRetaliation ?? true) && damagedDefender.count > 0 && !damagedDefender.hasRetaliated) {
     const retaliationRoll = nextDeterministicRandom(nextRngState.seed);
-    const retaliationDamage = estimateDamage(damagedDefender, attacker, retaliationRoll.value, preparedState.state);
-    let damagedAttacker = applyDamage(attacker, retaliationDamage);
+    const retaliationDamage = estimateDamage(damagedDefender, nextAttacker, retaliationRoll.value, preparedState.state);
+    let damagedAttacker = applyDamage(nextAttacker, retaliationDamage);
     damagedAttacker = applyOnHitStatuses(damagedDefender, damagedAttacker, log, catalogIndex);
+    let retaliatingDefender = damagedDefender;
+
+    if (damagedAttacker.count > 0 && hasEquipmentEffect(damagedAttacker, "thorns")) {
+      const reflectedDamage = thornsDamageAmount(retaliationDamage);
+      retaliatingDefender = applyDamage(retaliatingDefender, reflectedDamage);
+      log.push(`${damagedAttacker.stackName} 的反刺对 ${retaliatingDefender.stackName} 造成 ${reflectedDamage} 伤害`);
+    }
+
+    if (damagedAttacker.count === 0 && hasEquipmentEffect(retaliatingDefender, "lifesteal")) {
+      const healingAmount = lifestealHealingAmount(retaliatingDefender);
+      retaliatingDefender = applyHealing(retaliatingDefender, healingAmount);
+      log.push(`${retaliatingDefender.stackName} 触发嗜血，恢复 ${healingAmount} 生命`);
+    }
+
     nextUnits[attacker.id] = damagedAttacker;
     nextUnits[defender.id] = {
-      ...damagedDefender,
+      ...retaliatingDefender,
       hasRetaliated: true
     };
     nextRngState = {
       seed: retaliationRoll.nextSeed,
       cursor: nextRngState.cursor + 1
     };
-    log.push(`${damagedDefender.stackName} 反击 ${attacker.stackName}，造成 ${retaliationDamage} 伤害`);
+    log.push(`${retaliatingDefender.stackName} 反击 ${attacker.stackName}，造成 ${retaliationDamage} 伤害`);
   }
 
   return advanceTurn(
@@ -1616,6 +1662,7 @@ export function createNeutralBattleState(
       currentHp: heroTemplate.maxHp,
       maxHp: heroTemplate.maxHp,
       power: hero.stats.power,
+      equipmentEffects: heroEquipment.specialEffects.map((effect) => effect.id),
       hasRetaliated: false,
       defending: false
     },
@@ -1712,15 +1759,16 @@ export function createHeroBattleState(
         initiative: attackerTemplate.initiative,
         attack: attackerTemplate.attack + attackerHero.stats.attack + attackerEquipment.attack,
         defense: attackerTemplate.defense + attackerHero.stats.defense + attackerEquipment.defense,
-      minDamage: attackerTemplate.minDamage,
-      maxDamage: attackerTemplate.maxDamage,
-      count: attackerHero.armyCount,
-      currentHp: attackerTemplate.maxHp,
-      maxHp: attackerTemplate.maxHp,
-      power: attackerHero.stats.power,
-      hasRetaliated: false,
-      defending: false
-    },
+        minDamage: attackerTemplate.minDamage,
+        maxDamage: attackerTemplate.maxDamage,
+        count: attackerHero.armyCount,
+        currentHp: attackerTemplate.maxHp,
+        maxHp: attackerTemplate.maxHp,
+        power: attackerHero.stats.power,
+        equipmentEffects: attackerEquipment.specialEffects.map((effect) => effect.id),
+        hasRetaliated: false,
+        defending: false
+      },
       attackerBattleSkills,
       battleCatalogIndex
     ),
@@ -1734,15 +1782,16 @@ export function createHeroBattleState(
         initiative: defenderTemplate.initiative,
         attack: defenderTemplate.attack + defenderHero.stats.attack + defenderEquipment.attack,
         defense: defenderTemplate.defense + defenderHero.stats.defense + defenderEquipment.defense,
-      minDamage: defenderTemplate.minDamage,
-      maxDamage: defenderTemplate.maxDamage,
-      count: defenderHero.armyCount,
-      currentHp: defenderTemplate.maxHp,
-      maxHp: defenderTemplate.maxHp,
-      power: defenderHero.stats.power,
-      hasRetaliated: false,
-      defending: false
-    },
+        minDamage: defenderTemplate.minDamage,
+        maxDamage: defenderTemplate.maxDamage,
+        count: defenderHero.armyCount,
+        currentHp: defenderTemplate.maxHp,
+        maxHp: defenderTemplate.maxHp,
+        power: defenderHero.stats.power,
+        equipmentEffects: defenderEquipment.specialEffects.map((effect) => effect.id),
+        hasRetaliated: false,
+        defending: false
+      },
       defenderBattleSkills,
       battleCatalogIndex
     )

--- a/packages/shared/src/equipment.ts
+++ b/packages/shared/src/equipment.ts
@@ -4,6 +4,7 @@ import {
   type EquipmentId,
   type EquipmentDefinition,
   type EquipmentRarity,
+  type EquipmentSpecialEffectConfig,
   type EquipmentStatBonuses,
   type EquipmentType,
   type HeroState,
@@ -95,6 +96,87 @@ const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
       }
     },
     {
+      id: "emberwood_staff",
+      name: "烬木法杖",
+      type: "weapon",
+      rarity: "common",
+      description: "在廉价木杖中嵌入火纹碎片，适合初阶施法者。",
+      bonuses: {
+        power: 1,
+        knowledge: 1
+      }
+    },
+    {
+      id: "windrider_javelin",
+      name: "逐风标枪",
+      type: "weapon",
+      rarity: "common",
+      description: "轻型投枪便于远距离压制和追击。",
+      bonuses: {
+        attackPercent: 5
+      }
+    },
+    {
+      id: "ironbound_greatblade",
+      name: "铁缚巨刃",
+      type: "weapon",
+      rarity: "common",
+      description: "双手重刃以笨重换取稳定的破甲能力。",
+      bonuses: {
+        attackPercent: 9
+      }
+    },
+    {
+      id: "runeshard_staff",
+      name: "符晶法杖",
+      type: "weapon",
+      rarity: "rare",
+      description: "杖首的符晶会在法术聚焦时放大破坏力。",
+      bonuses: {
+        attackPercent: 4,
+        power: 2
+      }
+    },
+    {
+      id: "siege_maul",
+      name: "攻城战锤",
+      type: "weapon",
+      rarity: "rare",
+      description: "以重击撕开防线的冲锋武器。",
+      bonuses: {
+        attackPercent: 14
+      },
+      setId: "warhost"
+    },
+    {
+      id: "frostfang_javelin",
+      name: "霜牙飞枪",
+      type: "weapon",
+      rarity: "rare",
+      description: "投掷时带着寒雾轨迹，擅长抢先压低敌军气势。",
+      bonuses: {
+        attackPercent: 7,
+        knowledge: 1
+      },
+      specialEffect: {
+        id: "initiative_edge",
+        name: "抢攻",
+        description: "在开战后的第一轮拥有更强的压制力。"
+      }
+    },
+    {
+      id: "titanbreaker_greatsword",
+      name: "裂岳巨剑",
+      type: "weapon",
+      rarity: "epic",
+      description: "专为突破重甲阵列打造的双手巨剑。",
+      bonuses: {
+        attackPercent: 18,
+        defensePercent: 2
+      },
+      setId: "warhost"
+    },
+    {
       id: "padded_gambeson",
       name: "厚绗布甲",
       type: "armor",
@@ -170,6 +252,90 @@ const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
         defensePercent: 14,
         maxHp: 5
       }
+    },
+    {
+      id: "leather_brigandine",
+      name: "轻革战衣",
+      type: "armor",
+      rarity: "common",
+      description: "轻甲结构在保留机动性的同时提供基础防护。",
+      bonuses: {
+        attackPercent: 3,
+        defensePercent: 6,
+        maxHp: 2
+      }
+    },
+    {
+      id: "duskweave_robes",
+      name: "暮纱法袍",
+      type: "armor",
+      rarity: "common",
+      description: "袍摆的暗纹有助于稳定施法节奏。",
+      bonuses: {
+        power: 1,
+        knowledge: 1,
+        maxHp: 2
+      }
+    },
+    {
+      id: "skirmisher_cuirass",
+      name: "游斗胸甲",
+      type: "armor",
+      rarity: "common",
+      description: "偏向攻守均衡的前哨轻甲。",
+      bonuses: {
+        attackPercent: 4,
+        defensePercent: 5,
+        maxHp: 2
+      }
+    },
+    {
+      id: "runic_vestments",
+      name: "符印法衣",
+      type: "armor",
+      rarity: "rare",
+      description: "由多层符印布面缝制，能承载更多法术波动。",
+      bonuses: {
+        defensePercent: 4,
+        power: 2,
+        knowledge: 1
+      }
+    },
+    {
+      id: "assault_cuirass",
+      name: "突袭胸甲",
+      type: "armor",
+      rarity: "rare",
+      description: "为破阵先锋打造的轻重混编胸甲。",
+      bonuses: {
+        attackPercent: 6,
+        defensePercent: 8,
+        maxHp: 3
+      },
+      setId: "warhost"
+    },
+    {
+      id: "thornhide_cape",
+      name: "棘皮披风",
+      type: "armor",
+      rarity: "rare",
+      description: "外层的硬棘纤维能分散近身冲击。",
+      bonuses: {
+        defensePercent: 9,
+        maxHp: 4
+      }
+    },
+    {
+      id: "bulwark_plate",
+      name: "磐垒重铠",
+      type: "armor",
+      rarity: "epic",
+      description: "重装守军的压阵护甲，越久战越难被击穿。",
+      bonuses: {
+        defensePercent: 18,
+        maxHp: 7
+      },
+      setId: "bulwark"
     },
     {
       id: "scout_compass",
@@ -248,9 +414,142 @@ const DEFAULT_EQUIPMENT_CATALOG: EquipmentCatalogConfig = {
         name: "引导",
         description: "为后续技能结算预留更高的法术上限。"
       }
+    },
+    {
+      id: "trailblazer_lantern",
+      name: "拓路灯盏",
+      type: "accessory",
+      rarity: "common",
+      description: "发光符灯能帮助部队更早识别前路威胁。",
+      bonuses: {
+        attackPercent: 2,
+        knowledge: 1
+      }
+    },
+    {
+      id: "wayfinder_map",
+      name: "行路图卷",
+      type: "accessory",
+      rarity: "common",
+      description: "一卷不断修订的地图草图，适合长期行军。",
+      bonuses: {
+        defensePercent: 2,
+        knowledge: 1
+      }
+    },
+    {
+      id: "restorers_kit",
+      name: "复原急救包",
+      type: "accessory",
+      rarity: "common",
+      description: "包含绷带与药膏的随身套件，适合持久战。",
+      bonuses: {
+        defensePercent: 2,
+        maxHp: 2
+      }
+    },
+    {
+      id: "blood_oath_emblem",
+      name: "血誓徽印",
+      type: "accessory",
+      rarity: "rare",
+      description: "战团先锋间流转的誓约信物。",
+      bonuses: {
+        attackPercent: 6,
+        power: 1
+      },
+      setId: "warhost"
+    },
+    {
+      id: "sentinel_badge",
+      name: "守卫徽章",
+      type: "accessory",
+      rarity: "rare",
+      description: "常由城防指挥官佩戴，用以稳住整条阵线。",
+      bonuses: {
+        defensePercent: 7
+      },
+      setId: "bulwark"
+    },
+    {
+      id: "cartographer_monocle",
+      name: "绘界单片镜",
+      type: "accessory",
+      rarity: "rare",
+      description: "经常被探索队长用于快速判定地形与射界。",
+      bonuses: {
+        attackPercent: 3,
+        knowledge: 2
+      }
+    },
+    {
+      id: "phoenix_feather",
+      name: "炎凰羽饰",
+      type: "accessory",
+      rarity: "epic",
+      description: "燃尽后仍有余辉的羽饰，能提升战意与专注。",
+      bonuses: {
+        attackPercent: 4,
+        power: 1,
+        maxHp: 3
+      }
+    },
+    {
+      id: "briar_heart_charm",
+      name: "荆心护符",
+      type: "accessory",
+      rarity: "epic",
+      description: "镶着硬棘核心的护符，擅长将冲击返还给来敌。",
+      bonuses: {
+        defensePercent: 6,
+        maxHp: 4
+      },
+      setId: "bulwark"
     }
   ]
 };
+
+export interface EquipmentSetBonusConfig {
+  setId: string;
+  name: string;
+  piecesRequired: number;
+  description: string;
+  bonuses: Partial<EquipmentStatBonuses>;
+  specialEffect?: EquipmentSpecialEffectConfig;
+}
+
+export const SET_BONUSES: EquipmentSetBonusConfig[] = [
+  {
+    setId: "warhost",
+    name: "战团突袭套",
+    piecesRequired: 2,
+    description: "2 件：攻击 +8% / 力量 +1，并获得击杀回血。",
+    bonuses: {
+      attackPercent: 8,
+      power: 1
+    },
+    specialEffect: {
+      id: "lifesteal",
+      name: "嗜血",
+      description: "击杀敌方单位后恢复自身生命。"
+    }
+  },
+  {
+    setId: "bulwark",
+    name: "磐垒守御套",
+    piecesRequired: 2,
+    description: "2 件：防御 +10% / 生命上限 +4，并获得反伤。",
+    bonuses: {
+      defensePercent: 10,
+      maxHp: 4
+    },
+    specialEffect: {
+      id: "thorns",
+      name: "反刺",
+      description: "受到近战攻击时，对攻击者造成反伤。"
+    }
+  }
+];
 
 const DEFAULT_EQUIPMENT_BY_ID = new Map(
   DEFAULT_EQUIPMENT_CATALOG.entries.map((entry) => [entry.id, entry] as const)
@@ -266,6 +565,7 @@ export interface HeroEquipmentBonusSummary extends EquipmentStatBonuses {
   attack: number;
   defense: number;
   resolvedItemIds: string[];
+  activeSetBonuses: EquipmentSetBonusConfig[];
   specialEffects: NonNullable<EquipmentDefinition["specialEffect"]>[];
 }
 
@@ -307,6 +607,19 @@ function numericBonus(value: number | undefined): number {
 
 function resolveEquipmentDefinition(id: string | undefined): EquipmentDefinition | undefined {
   return id ? DEFAULT_EQUIPMENT_BY_ID.get(id) : undefined;
+}
+
+function resolveActiveSetBonuses(resolvedItems: EquipmentDefinition[]): EquipmentSetBonusConfig[] {
+  const countsBySetId = resolvedItems.reduce<Record<string, number>>((counts, item) => {
+    if (!item.setId) {
+      return counts;
+    }
+
+    counts[item.setId] = (counts[item.setId] ?? 0) + 1;
+    return counts;
+  }, {});
+
+  return SET_BONUSES.filter((entry) => (countsBySetId[entry.setId] ?? 0) >= entry.piecesRequired);
 }
 
 function percentageDelta(base: number, percent: number): number {
@@ -353,6 +666,7 @@ export function getDefaultEquipmentCatalog(): EquipmentCatalogConfig {
     entries: DEFAULT_EQUIPMENT_CATALOG.entries.map((entry) => ({
       ...entry,
       bonuses: { ...entry.bonuses },
+      ...(entry.setId ? { setId: entry.setId } : {}),
       ...(entry.specialEffect ? { specialEffect: { ...entry.specialEffect } } : {})
     }))
   };
@@ -497,6 +811,7 @@ export function createHeroEquipmentBonusSummary(
     resolveEquipmentDefinition(hero.loadout.equipment.armorId),
     resolveEquipmentDefinition(hero.loadout.equipment.accessoryId)
   ].filter((entry): entry is EquipmentDefinition => Boolean(entry));
+  const activeSetBonuses = resolveActiveSetBonuses(resolvedItems);
 
   for (const item of resolvedItems) {
     bonuses.attackPercent += numericBonus(item.bonuses.attackPercent);
@@ -505,6 +820,19 @@ export function createHeroEquipmentBonusSummary(
     bonuses.knowledge += numericBonus(item.bonuses.knowledge);
     bonuses.maxHp += numericBonus(item.bonuses.maxHp);
   }
+
+  for (const setBonus of activeSetBonuses) {
+    bonuses.attackPercent += numericBonus(setBonus.bonuses.attackPercent);
+    bonuses.defensePercent += numericBonus(setBonus.bonuses.defensePercent);
+    bonuses.power += numericBonus(setBonus.bonuses.power);
+    bonuses.knowledge += numericBonus(setBonus.bonuses.knowledge);
+    bonuses.maxHp += numericBonus(setBonus.bonuses.maxHp);
+  }
+
+  const specialEffects = resolvedItems
+    .flatMap((item) => (item.specialEffect ? [item.specialEffect] : []))
+    .concat(activeSetBonuses.flatMap((setBonus) => (setBonus.specialEffect ? [setBonus.specialEffect] : [])))
+    .filter((effect, index, effects) => effects.findIndex((item) => item.id === effect.id) === index);
 
   return {
     attack: percentageDelta(hero.stats.attack, bonuses.attackPercent),
@@ -515,9 +843,8 @@ export function createHeroEquipmentBonusSummary(
     knowledge: bonuses.knowledge,
     maxHp: bonuses.maxHp,
     resolvedItemIds: resolvedItems.map((item) => item.id),
-    specialEffects: resolvedItems
-      .flatMap((item) => (item.specialEffect ? [item.specialEffect] : []))
-      .filter((effect, index, effects) => effects.findIndex((item) => item.id === effect.id) === index)
+    activeSetBonuses,
+    specialEffects
   };
 }
 

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -27,7 +27,14 @@ export type HeroSkillBranchId = string;
 export type EquipmentId = string;
 export type EquipmentType = "weapon" | "armor" | "accessory";
 export type EquipmentRarity = "common" | "rare" | "epic";
-export type EquipmentSpecialEffectId = "initiative_edge" | "brace" | "channeling" | "momentum" | "ward";
+export type EquipmentSpecialEffectId =
+  | "initiative_edge"
+  | "brace"
+  | "channeling"
+  | "momentum"
+  | "ward"
+  | "lifesteal"
+  | "thorns";
 
 export interface EquipmentStatBonuses {
   attackPercent: number;
@@ -50,6 +57,7 @@ export interface EquipmentDefinition {
   rarity: EquipmentRarity;
   description: string;
   bonuses: Partial<EquipmentStatBonuses>;
+  setId?: string;
   specialEffect?: EquipmentSpecialEffectConfig;
 }
 
@@ -469,6 +477,7 @@ export interface UnitStack {
   power?: number;
   hasRetaliated: boolean;
   defending: boolean;
+  equipmentEffects?: EquipmentSpecialEffectId[];
   skills?: BattleSkillState[];
   statusEffects?: BattleStatusEffectState[];
 }

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1929,19 +1929,54 @@ test("equipment catalog exposes the minimum foundation set and resolves hero bon
 
   const bonuses = createHeroEquipmentBonusSummary(hero);
 
-  assert.equal(countsByType.weapon, 6);
-  assert.equal(countsByType.armor, 6);
-  assert.equal(countsByType.accessory, 6);
+  assert.equal(catalog.entries.length, 40);
+  assert.equal(countsByType.weapon, 13);
+  assert.equal(countsByType.armor, 13);
+  assert.equal(countsByType.accessory, 14);
   assert.equal(bonuses.attack, 1);
   assert.equal(bonuses.defense, 1);
   assert.equal(bonuses.power, 2);
   assert.equal(bonuses.knowledge, 2);
   assert.equal(bonuses.maxHp, 6);
   assert.deepEqual(bonuses.resolvedItemIds, ["sunforged_spear", "warden_aegis", "oracle_lens"]);
+  assert.deepEqual(bonuses.activeSetBonuses, []);
   assert.deepEqual(
     bonuses.specialEffects.map((effect) => effect.id).sort(),
     ["channeling", "momentum", "ward"]
   );
+});
+
+test("equipment set bonuses activate at two matching pieces and add special effects", () => {
+  const hero = createHero({
+    id: "hero-warhost",
+    playerId: "player-1",
+    name: "突袭指挥官",
+    stats: {
+      attack: 5,
+      defense: 4,
+      power: 1,
+      knowledge: 2,
+      hp: 30,
+      maxHp: 30
+    },
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "siege_maul",
+        armorId: "assault_cuirass",
+        trinketIds: []
+      }
+    }
+  });
+
+  const bonuses = createHeroEquipmentBonusSummary(hero);
+
+  assert.deepEqual(bonuses.resolvedItemIds, ["siege_maul", "assault_cuirass"]);
+  assert.deepEqual(bonuses.activeSetBonuses.map((bonus) => bonus.setId), ["warhost"]);
+  assert.equal(bonuses.attackPercent, 28);
+  assert.equal(bonuses.power, 1);
+  assert.equal(bonuses.maxHp, 3);
+  assert.deepEqual(bonuses.specialEffects.map((effect) => effect.id), ["lifesteal"]);
 });
 
 test("hero equipment loadout view resolves slot metadata for equipped and empty slots", () => {
@@ -2078,8 +2113,8 @@ test("hero equip and unequip actions rotate items between slots and inventory", 
 test("equipment drops respect rarity pools and battle victories add loot to hero inventory", () => {
   assert.equal(rollEquipmentDrop(0.9, 0.1, 0.1), null);
   assert.deepEqual(rollEquipmentDrop(0.01, 0.98, 0.9), {
-    itemId: "oracle_lens",
-    item: getDefaultEquipmentCatalog().entries.find((entry) => entry.id === "oracle_lens")
+    itemId: "briar_heart_charm",
+    item: getDefaultEquipmentCatalog().entries.find((entry) => entry.id === "briar_heart_charm")
   });
 
   const hero = createHero({
@@ -2112,15 +2147,15 @@ test("equipment drops respect rarity pools and battle victories add loot to hero
     survivingDefenders: []
   });
 
-  assert.deepEqual(outcome.state.heroes[0]?.loadout.inventory, ["tower_shield_mail"]);
+  assert.deepEqual(outcome.state.heroes[0]?.loadout.inventory, ["skirmisher_cuirass"]);
   assert.deepEqual(outcome.events.slice(-1), [
     {
       type: "hero.equipmentFound",
       heroId: "hero-1",
       battleId: "battle-neutral-1",
       battleKind: "neutral",
-      equipmentId: "tower_shield_mail",
-      equipmentName: "塔盾链甲",
+      equipmentId: "skirmisher_cuirass",
+      equipmentName: "游斗胸甲",
       rarity: "common"
     }
   ]);
@@ -2174,8 +2209,8 @@ test("equipment drops overflow cleanly when the backpack is already full", () =>
       heroId: "hero-1",
       battleId: "battle-neutral-1",
       battleKind: "neutral",
-      equipmentId: "tower_shield_mail",
-      equipmentName: "塔盾链甲",
+      equipmentId: "skirmisher_cuirass",
+      equipmentName: "游斗胸甲",
       rarity: "common",
       overflowed: true
     }
@@ -3235,6 +3270,140 @@ test("battle state builders fold equipped item bonuses into hero-led stacks", ()
     battle.units["hero-2-stack"]?.defense,
     (baselineBattle.units["hero-2-stack"]?.defense ?? 0) + defenderBonuses.defense
   );
+});
+
+test("battle attacks apply lifesteal from an active equipment set after a kill", () => {
+  const state: BattleState = {
+    id: "battle-lifesteal",
+    round: 1,
+    lanes: 1,
+    activeUnitId: "attacker",
+    turnOrder: ["attacker", "defender"],
+    units: {
+      attacker: {
+        id: "attacker",
+        templateId: "hero_guard_basic",
+        camp: "attacker",
+        lane: 0,
+        stackName: "先锋队",
+        initiative: 10,
+        attack: 9,
+        defense: 4,
+        minDamage: 8,
+        maxDamage: 8,
+        count: 1,
+        currentHp: 6,
+        maxHp: 10,
+        hasRetaliated: false,
+        defending: false,
+        equipmentEffects: ["lifesteal"]
+      },
+      defender: {
+        id: "defender",
+        templateId: "hero_guard_basic",
+        camp: "defender",
+        lane: 0,
+        stackName: "守军",
+        initiative: 5,
+        attack: 2,
+        defense: 1,
+        minDamage: 1,
+        maxDamage: 1,
+        count: 1,
+        currentHp: 5,
+        maxHp: 5,
+        hasRetaliated: false,
+        defending: false
+      }
+    },
+    unitCooldowns: {
+      attacker: {},
+      defender: {}
+    },
+    environment: [],
+    log: [],
+    rng: {
+      seed: 1,
+      cursor: 0
+    }
+  };
+
+  const next = applyBattleAction(state, {
+    type: "battle.attack",
+    attackerId: "attacker",
+    defenderId: "defender"
+  });
+
+  assert.equal(next.units.defender?.count, 0);
+  assert.equal(next.units.attacker?.currentHp, 8);
+  assert.match(next.log.join("\n"), /恢复 2 生命/);
+});
+
+test("battle attacks apply thorns from an active equipment set on contact damage", () => {
+  const state: BattleState = {
+    id: "battle-thorns",
+    round: 1,
+    lanes: 1,
+    activeUnitId: "attacker",
+    turnOrder: ["attacker", "defender"],
+    units: {
+      attacker: {
+        id: "attacker",
+        templateId: "hero_guard_basic",
+        camp: "attacker",
+        lane: 0,
+        stackName: "攻方",
+        initiative: 10,
+        attack: 6,
+        defense: 3,
+        minDamage: 6,
+        maxDamage: 6,
+        count: 1,
+        currentHp: 10,
+        maxHp: 10,
+        hasRetaliated: false,
+        defending: false
+      },
+      defender: {
+        id: "defender",
+        templateId: "hero_guard_basic",
+        camp: "defender",
+        lane: 0,
+        stackName: "守方",
+        initiative: 4,
+        attack: 3,
+        defense: 3,
+        minDamage: 1,
+        maxDamage: 1,
+        count: 1,
+        currentHp: 20,
+        maxHp: 20,
+        hasRetaliated: false,
+        defending: false,
+        equipmentEffects: ["thorns"]
+      }
+    },
+    unitCooldowns: {
+      attacker: {},
+      defender: {}
+    },
+    environment: [],
+    log: [],
+    rng: {
+      seed: 1,
+      cursor: 0
+    }
+  };
+
+  const next = applyBattleAction(state, {
+    type: "battle.attack",
+    attackerId: "attacker",
+    defenderId: "defender"
+  });
+
+  assert.ok((next.units.defender?.currentHp ?? 0) < 20);
+  assert.ok((next.units.attacker?.currentHp ?? 0) < 10);
+  assert.match(next.log.join("\n"), /反刺/);
 });
 
 test("createPlayerWorldView returns player-scoped resources after collection", () => {


### PR DESCRIPTION
closes #786

## Summary
- expand the shared equipment catalog from 18 to 40 items, including new staff, two-handed, throwing, light-armor, robe, and accessory variants
- add `setId` support plus two-piece `SET_BONUSES` for the offensive `warhost` and defensive `bulwark` sets
- apply set-derived `lifesteal` and `thorns` effects in battle resolution and mirror the shared runtime updates into the Cocos project-shared layer
- extend shared-core coverage for catalog counts, active set bonuses, and the new combat effects while updating deterministic loot expectations

## Verification
- `node --import tsx --test packages/shared/test/shared-core.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-hero-equipment.test.ts apps/cocos-client/test/cocos-ui-formatters.test.ts`
