### PR TITLE
feat: add Redis-backed Colyseus scaling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - Node.js 22 LTS（CI 同款；仓库提供 `.nvmrc`）
 - npm 10+
 - 可选：MySQL 8+（只有在你要验证持久化时才需要）
+- 可选：Redis 7+（只有在你要验证多节点 Colyseus / 跨节点匹配时才需要）
 
 ### 5-Minute Setup
 
@@ -90,8 +91,20 @@ npm run dev:client:h5
 - 配置台：`http://127.0.0.1:5173/config-center.html`
 - 服务端健康检查：`http://127.0.0.1:2567/api/runtime/health`
 - 匹配队列默认会把断线玩家 5 分钟后清理掉，可用 `VEIL_MATCHMAKING_QUEUE_TTL_SECONDS`（默认 `300` 秒）覆盖
+- 设置 `REDIS_URL` 后，Colyseus presence/driver 和 matchmaking 队列都会自动切到 Redis-backed 实现
 
 如果你要启用 MySQL 持久化，再复制 `.env.example` 到 `.env`，填入 `VEIL_MYSQL_*`，然后执行 `npm run db:migrate`。更多说明见 `docs/mysql-persistence.md`。
+
+如果你要验证 Redis-backed Colyseus scaling，可先启动根目录的 `docker-compose.redis.yml`，再用同一个 `REDIS_URL` 启两个服务节点：
+
+```bash
+docker compose -f docker-compose.redis.yml up -d
+REDIS_URL=redis://127.0.0.1:6379/0 PORT=2567 npm run dev:server
+REDIS_URL=redis://127.0.0.1:6379/0 PORT=2568 npm run dev:server
+REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
+```
+
+未设置 `REDIS_URL` 时，服务端保持现有单进程本地行为不变。完整部署说明见 `docs/redis-colyseus-scaling.md`。
 
 ## 当前仓库落地内容
 
@@ -201,6 +214,7 @@ npm run dev:client:h5
 - 微信小游戏构建 / 发布 / 回滚说明：`docs/wechat-minigame-release.md`
 - 微信小游戏 runtime observability 签核：`docs/wechat-runtime-observability-signoff.md`
 - 微信小游戏 runtime observability 签核模板：`docs/release-evidence/wechat-runtime-observability-signoff.template.md`
+- Redis-backed Colyseus 多节点部署：`docs/redis-colyseus-scaling.md`
 - Phase 1 成熟度记分卡与退出标准：`docs/phase1-maturity-scorecard.md`
 - 仓库成熟度基线与独立 follow-up slices：`docs/repo-maturity-baseline.md`
 - 核心玩法发布门禁清单：`docs/core-gameplay-release-readiness.md`

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -23,6 +23,7 @@ import {
 import { registerPlayerAccountRoutes } from "./player-accounts";
 import { registerAdminRoutes } from "./admin-console";
 import { formatSchemaMigrationWarning, getSchemaMigrationStatus } from "./schema-migrations";
+import { closeRedisResource, createRedisDriver, createRedisPresence, readRedisUrl } from "./redis";
 
 loadEnv();
 
@@ -37,6 +38,11 @@ interface DevServerDefinitionChain {
 interface DevServerGameServer {
   define(name: string, room: typeof VeilColyseusRoom): DevServerDefinitionChain;
   listen(port: number, host: string): Promise<void>;
+}
+
+interface DevServerRealtimeOptions {
+  driver?: unknown;
+  presence?: unknown;
 }
 
 interface DevServerLogger {
@@ -86,6 +92,9 @@ export interface DevServerBootstrapDependencies {
   createMemoryRoomSnapshotStore(): DevServerRoomSnapshotStore;
   configureRoomSnapshotStore(store: DevServerRoomSnapshotStore): void;
   createTransport(): DevServerTransport;
+  readRedisUrl(): string | null;
+  createRedisPresence(redisUrl: string): { shutdown(): Promise<void> | void };
+  createRedisDriver(redisUrl: string): { shutdown(): Promise<void> | void };
   registerAuthRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerConfigCenterRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
@@ -94,7 +103,7 @@ export interface DevServerBootstrapDependencies {
   registerMatchmakingRoutes(app: unknown, dependencies: { store: DevServerRoomSnapshotStore }): void;
   registerRuntimeObservabilityRoutes(app: unknown, options?: { store?: DevServerRoomSnapshotStore }): void;
   registerAdminRoutes(app: unknown, store: DevServerRoomSnapshotStore, gameServer: DevServerGameServer): void;
-  createGameServer(transport: DevServerTransport): DevServerGameServer;
+  createGameServer(transport: DevServerTransport, realtimeOptions?: DevServerRealtimeOptions): DevServerGameServer;
   logger: DevServerLogger;
   process: DevServerProcess;
   setInterval(handler: () => void, delayMs: number): CleanupTimerHandle;
@@ -113,6 +122,9 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     createMemoryRoomSnapshotStore: () => createMemoryRoomSnapshotStore(),
     configureRoomSnapshotStore: (store) => configureRoomSnapshotStore(store as RoomSnapshotStore),
     createTransport: () => new WebSocketTransport(),
+    readRedisUrl,
+    createRedisPresence,
+    createRedisDriver,
     registerAuthRoutes: (app, store) => registerAuthRoutes(app as never, store as RoomSnapshotStore),
     registerConfigCenterRoutes: (app, store) => registerConfigCenterRoutes(app as never, store as ConfigCenterStore),
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
@@ -123,9 +135,11 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerRuntimeObservabilityRoutes: (app, options) => registerRuntimeObservabilityRoutes(app as never, options),
     registerAdminRoutes: (app, store, gameServer) =>
       registerAdminRoutes(app as never, store as RoomSnapshotStore, gameServer),
-    createGameServer: (transport) =>
+    createGameServer: (transport, realtimeOptions) =>
       new Server({
-        transport: transport as WebSocketTransport
+        transport: transport as WebSocketTransport,
+        driver: realtimeOptions?.driver as never,
+        presence: realtimeOptions?.presence as never
       }),
     logger: console,
     process,
@@ -162,6 +176,9 @@ export async function startDevServer(
   const effectiveSnapshotStore = snapshotStore ?? deps.createMemoryRoomSnapshotStore();
   deps.configureRoomSnapshotStore(effectiveSnapshotStore);
   await configCenterStore.initializeRuntimeConfigs();
+  const redisUrl = deps.readRedisUrl();
+  const redisPresence = redisUrl ? deps.createRedisPresence(redisUrl) : null;
+  const redisDriver = redisUrl ? deps.createRedisDriver(redisUrl) : null;
 
   const transport = deps.createTransport();
   const expressApp = transport.getExpressApp();
@@ -173,7 +190,10 @@ export async function startDevServer(
   deps.registerMatchmakingRoutes(expressApp, { store: effectiveSnapshotStore });
   deps.registerRuntimeObservabilityRoutes(expressApp, { store: effectiveSnapshotStore });
 
-  const gameServer = deps.createGameServer(transport);
+  const gameServer = deps.createGameServer(transport, {
+    driver: redisDriver ?? undefined,
+    presence: redisPresence ?? undefined
+  });
   deps.registerAdminRoutes(expressApp, effectiveSnapshotStore, gameServer);
   gameServer.define("veil", VeilColyseusRoom).filterBy(["logicalRoomId"]);
   await gameServer.listen(port, host);
@@ -191,6 +211,11 @@ export async function startDevServer(
   deps.logger.log(`Runtime diagnostic snapshot available at http://${host}:${port}/api/runtime/diagnostic-snapshot`);
   deps.logger.log(`Runtime metrics available at http://${host}:${port}/api/runtime/metrics`);
   deps.logger.log(`Config center storage: ${configCenterStore.mode}`);
+  if (redisUrl) {
+    deps.logger.log("Redis-backed Colyseus presence/driver enabled via REDIS_URL");
+  } else {
+    deps.logger.log("Local in-memory Colyseus presence/driver enabled");
+  }
   if (snapshotStore) {
     deps.logger.log("MySQL room persistence enabled");
   } else {
@@ -232,10 +257,17 @@ export async function startDevServer(
     if (!snapshotStore) {
       await effectiveSnapshotStore.close();
       await configCenterStore.close();
+      await closeRedisResource(redisPresence);
+      await closeRedisResource(redisDriver);
       return;
     }
 
-    await Promise.all([effectiveSnapshotStore.close(), configCenterStore.close()]);
+    await Promise.all([
+      effectiveSnapshotStore.close(),
+      configCenterStore.close(),
+      closeRedisResource(redisPresence),
+      closeRedisResource(redisDriver)
+    ]);
   };
 
   let shutdownStarted = false;

--- a/apps/server/src/matchmaking.ts
+++ b/apps/server/src/matchmaking.ts
@@ -12,6 +12,7 @@ import {
 import { validateAuthSessionFromRequest } from "./auth";
 import { recordMatchmakingRateLimited } from "./observability";
 import type { RoomSnapshotStore } from "./persistence";
+import { createRedisClient, readRedisUrl, type RedisClientLike } from "./redis";
 
 export const DEFAULT_MATCHMAKING_QUEUE_TTL_SECONDS = 5 * 60;
 const DEFAULT_RATE_LIMIT_MATCHMAKING_WINDOW_MS = 60_000;
@@ -209,7 +210,23 @@ interface MatchmakingStatusIdle {
 
 type MatchmakingStatusResponse = MatchmakingStatusQueued | MatchmakingStatusMatched | MatchmakingStatusIdle;
 
-export class MatchmakingService {
+export interface MatchmakingServiceController {
+  enqueue(request: MatchmakingRequest, now?: Date): MatchmakingStatusQueued | Promise<MatchmakingStatusQueued>;
+  dequeue(playerId: string): boolean | Promise<boolean>;
+  getStatus(playerId: string): MatchmakingStatusResponse | Promise<MatchmakingStatusResponse>;
+  pruneStaleEntries(maxAgeMs: number, now?: Date): number | Promise<number>;
+  close?(): Promise<void>;
+}
+
+interface RedisMatchmakingServiceOptions {
+  redisUrl?: string;
+  redisClient?: RedisClientLike;
+  keyPrefix?: string;
+  lockTimeoutMs?: number;
+  lockRetryDelayMs?: number;
+}
+
+export class MatchmakingService implements MatchmakingServiceController {
   private readonly queueByPlayerId = new Map<string, MatchmakingRequest>();
   private readonly queueOrder: string[] = [];
   private readonly queuePositionByPlayerId = new Map<string, number>();
@@ -356,15 +373,271 @@ export class MatchmakingService {
   }
 }
 
+export class RedisMatchmakingService implements MatchmakingServiceController {
+  private readonly redis: RedisClientLike;
+  private readonly keyPrefix: string;
+  private readonly lockTimeoutMs: number;
+  private readonly lockRetryDelayMs: number;
+
+  constructor(options: RedisMatchmakingServiceOptions = {}) {
+    const redisUrl = options.redisUrl ?? readRedisUrl();
+    if (!options.redisClient && !redisUrl) {
+      throw new Error("REDIS_URL is required to enable Redis matchmaking");
+    }
+
+    this.redis = options.redisClient ?? createRedisClient(redisUrl!);
+    this.keyPrefix = options.keyPrefix?.trim() || "veil:matchmaking";
+    this.lockTimeoutMs = Math.max(250, Math.floor(options.lockTimeoutMs ?? 5_000));
+    this.lockRetryDelayMs = Math.max(10, Math.floor(options.lockRetryDelayMs ?? 50));
+  }
+
+  async enqueue(request: MatchmakingRequest, now = new Date()): Promise<MatchmakingStatusQueued> {
+    return this.withLock(async () => {
+      const normalized = normalizeMatchmakingRequest(request);
+      const requestsByPlayerId = await this.loadQueueRequests();
+
+      await this.redis.hdel(this.resultKey, normalized.playerId);
+      requestsByPlayerId.delete(normalized.playerId);
+      await this.redis.lrem(this.queueKey, 0, normalized.playerId);
+
+      const queueIds = await this.redis.lrange(this.queueKey, 0, -1);
+      const insertAt = this.findInsertIndex(
+        normalized,
+        queueIds.map((playerId) => requestsByPlayerId.get(playerId)).filter((value): value is MatchmakingRequest => value != null)
+      );
+
+      await this.redis.hset(this.requestKey, normalized.playerId, JSON.stringify(normalized));
+      if (insertAt >= queueIds.length) {
+        await this.redis.rpush(this.queueKey, normalized.playerId);
+      } else {
+        const pivotPlayerId = queueIds[insertAt];
+        if (!pivotPlayerId) {
+          await this.redis.rpush(this.queueKey, normalized.playerId);
+        } else {
+          await this.redis.linsert(this.queueKey, "BEFORE", pivotPlayerId, normalized.playerId);
+        }
+      }
+
+      const status = await this.getQueuedStatus(normalized.playerId);
+      await this.matchQueuedPlayers(now);
+      if (!status) {
+        throw new Error(`Failed to enqueue player for matchmaking: ${normalized.playerId}`);
+      }
+      return status;
+    });
+  }
+
+  async dequeue(playerId: string): Promise<boolean> {
+    return this.withLock(async () => {
+      const normalizedPlayerId = playerId.trim();
+      await this.redis.hdel(this.resultKey, normalizedPlayerId);
+      await this.redis.hdel(this.requestKey, normalizedPlayerId);
+      const removed = await this.redis.lrem(this.queueKey, 0, normalizedPlayerId);
+      return removed > 0;
+    });
+  }
+
+  async getStatus(playerId: string): Promise<MatchmakingStatusResponse> {
+    const normalizedPlayerId = playerId.trim();
+    const result = await this.redis.hget(this.resultKey, normalizedPlayerId);
+    if (result) {
+      const parsed = JSON.parse(result) as MatchResult;
+      return {
+        status: "matched",
+        roomId: parsed.roomId,
+        playerIds: parsed.playerIds,
+        seedOverride: parsed.seedOverride
+      };
+    }
+
+    return (await this.getQueuedStatus(normalizedPlayerId)) ?? { status: "idle" };
+  }
+
+  async pruneStaleEntries(maxAgeMs: number, now = new Date()): Promise<number> {
+    if (!Number.isFinite(maxAgeMs) || maxAgeMs <= 0) {
+      return 0;
+    }
+
+    const referenceTime = now.getTime();
+    if (!Number.isFinite(referenceTime)) {
+      return 0;
+    }
+
+    return this.withLock(async () => {
+      const requestsByPlayerId = await this.loadQueueRequests();
+      const queueIds = await this.redis.lrange(this.queueKey, 0, -1);
+      const expiredPlayerIds = queueIds.filter((playerId) => {
+        const request = requestsByPlayerId.get(playerId);
+        if (!request) {
+          return true;
+        }
+
+        const enqueuedAtMs = new Date(request.enqueuedAt).getTime();
+        return Number.isNaN(enqueuedAtMs) || referenceTime - enqueuedAtMs > maxAgeMs;
+      });
+
+      if (expiredPlayerIds.length === 0) {
+        return 0;
+      }
+
+      for (const playerId of expiredPlayerIds) {
+        await this.redis.lrem(this.queueKey, 0, playerId);
+        await this.redis.hdel(this.requestKey, playerId);
+        await this.redis.hdel(this.resultKey, playerId);
+      }
+      return expiredPlayerIds.length;
+    });
+  }
+
+  async close(): Promise<void> {
+    await this.redis.quit?.();
+  }
+
+  private get lockKey(): string {
+    return `${this.keyPrefix}:lock`;
+  }
+
+  private get queueKey(): string {
+    return `${this.keyPrefix}:queue`;
+  }
+
+  private get requestKey(): string {
+    return `${this.keyPrefix}:requests`;
+  }
+
+  private get resultKey(): string {
+    return `${this.keyPrefix}:results`;
+  }
+
+  private get sequenceKey(): string {
+    return `${this.keyPrefix}:sequence`;
+  }
+
+  private async getQueuedStatus(playerId: string): Promise<MatchmakingStatusQueued | null> {
+    const queueIds = await this.redis.lrange(this.queueKey, 0, -1);
+    const position = queueIds.indexOf(playerId.trim());
+    if (position < 0) {
+      return null;
+    }
+
+    return {
+      status: "queued",
+      position: position + 1,
+      estimatedWaitSeconds: estimateMatchmakingWaitSeconds(position + 1)
+    };
+  }
+
+  private async loadQueueRequests(): Promise<Map<string, MatchmakingRequest>> {
+    const queueIds = await this.redis.lrange(this.queueKey, 0, -1);
+    const requestsByPlayerId = new Map<string, MatchmakingRequest>();
+
+    for (const playerId of queueIds) {
+      const encoded = await this.redis.hget(this.requestKey, playerId);
+      if (encoded) {
+        requestsByPlayerId.set(playerId, JSON.parse(encoded) as MatchmakingRequest);
+      }
+    }
+
+    return requestsByPlayerId;
+  }
+
+  private findInsertIndex(request: MatchmakingRequest, queue: MatchmakingRequest[]): number {
+    for (let index = 0; index < queue.length; index += 1) {
+      const existingRequest = queue[index];
+      if (existingRequest && compareQueuedPlayers(request, existingRequest) < 0) {
+        return index;
+      }
+    }
+
+    return queue.length;
+  }
+
+  private async createMatchResult(players: [MatchmakingRequest, MatchmakingRequest], now: Date): Promise<MatchResult> {
+    const orderedPlayerIds = [players[0].playerId, players[1].playerId].sort() as [string, string];
+    const sequence = await this.redis.incr(this.sequenceKey);
+
+    return {
+      roomId: `pvp-match-${now.getTime()}-${sequence}`,
+      playerIds: orderedPlayerIds,
+      seedOverride: ((now.getTime() + sequence) >>> 0) || sequence
+    };
+  }
+
+  private async matchQueuedPlayers(now: Date): Promise<void> {
+    while ((await this.redis.llen(this.queueKey)) >= 2) {
+      const requestsByPlayerId = await this.loadQueueRequests();
+      const queue = Array.from(requestsByPlayerId.values());
+      const selection = selectBestMatchPair(queue, now);
+      if (!selection) {
+        return;
+      }
+
+      const [left, right] = selection.players;
+      await this.redis.lrem(this.queueKey, 0, left.playerId);
+      await this.redis.lrem(this.queueKey, 0, right.playerId);
+      await this.redis.hdel(this.requestKey, left.playerId, right.playerId);
+
+      const result = await this.createMatchResult([left, right], now);
+      const encodedResult = JSON.stringify(result);
+      await this.redis.hset(this.resultKey, left.playerId, encodedResult);
+      await this.redis.hset(this.resultKey, right.playerId, encodedResult);
+    }
+  }
+
+  private async withLock<T>(action: () => Promise<T>): Promise<T> {
+    const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+    const timeoutAt = Date.now() + this.lockTimeoutMs;
+
+    while (true) {
+      const acquired = await this.redis.set(this.lockKey, token, "PX", this.lockTimeoutMs, "NX");
+      if (acquired === "OK") {
+        break;
+      }
+
+      if (Date.now() >= timeoutAt) {
+        throw new Error("Timed out waiting for Redis matchmaking lock");
+      }
+
+      await delay(this.lockRetryDelayMs);
+    }
+
+    try {
+      return await action();
+    } finally {
+      await this.releaseLock(token);
+    }
+  }
+
+  private async releaseLock(token: string): Promise<void> {
+    await this.redis.eval(
+      [
+        "if redis.call('get', KEYS[1]) == ARGV[1] then",
+        "  return redis.call('del', KEYS[1])",
+        "end",
+        "return 0"
+      ].join("\n"),
+      1,
+      this.lockKey,
+      token
+    );
+  }
+}
+
 function compareQueuedPlayers(left: MatchmakingRequest, right: MatchmakingRequest): number {
   return left.enqueuedAt.localeCompare(right.enqueuedAt) || left.playerId.localeCompare(right.playerId);
 }
 
-let configuredMatchmakingService = new MatchmakingService();
+let configuredMatchmakingService: MatchmakingServiceController = createConfiguredMatchmakingService();
 
 export function resetMatchmakingService(): void {
-  configuredMatchmakingService = new MatchmakingService();
+  void configuredMatchmakingService.close?.();
+  configuredMatchmakingService = createConfiguredMatchmakingService();
   matchmakingRateLimitCounters.clear();
+}
+
+function createConfiguredMatchmakingService(env: NodeJS.ProcessEnv = process.env): MatchmakingServiceController {
+  const redisUrl = readRedisUrl(env);
+  return redisUrl ? new RedisMatchmakingService({ redisUrl }) : new MatchmakingService();
 }
 
 export function registerMatchmakingRoutes(
@@ -376,7 +649,7 @@ export function registerMatchmakingRoutes(
   },
   options: {
     store: RoomSnapshotStore | null;
-    service?: MatchmakingService;
+    service?: MatchmakingServiceController;
     queueTtlSeconds?: number;
   }
 ): void {
@@ -403,7 +676,7 @@ export function registerMatchmakingRoutes(
     }
 
     if (queueTtlMs > 0) {
-      service.pruneStaleEntries(queueTtlMs);
+      await Promise.resolve(service.pruneStaleEntries(queueTtlMs));
     }
 
     const authSession = await requireAuthSession(request, response, options.store);
@@ -439,12 +712,12 @@ export function registerMatchmakingRoutes(
         return;
       }
 
-      const queued = service.enqueue({
+      const queued = await Promise.resolve(service.enqueue({
         playerId: authSession.playerId,
         heroSnapshot: createMatchmakingHeroSnapshot(hero),
         rating: normalizeEloRating(account.eloRating),
         enqueuedAt: new Date().toISOString()
-      });
+      }));
       sendJson(response, 200, queued);
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
@@ -462,8 +735,9 @@ export function registerMatchmakingRoutes(
     }
 
     try {
+      const dequeued = await Promise.resolve(service.dequeue(authSession.playerId));
       sendJson(response, 200, {
-        status: service.dequeue(authSession.playerId) ? "dequeued" : "idle"
+        status: dequeued ? "dequeued" : "idle"
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
@@ -484,7 +758,7 @@ export function registerMatchmakingRoutes(
     }
 
     try {
-      sendJson(response, 200, service.getStatus(authSession.playerId));
+      sendJson(response, 200, await Promise.resolve(service.getStatus(authSession.playerId)));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
@@ -515,4 +789,8 @@ function normalizePositiveSeconds(value: number | undefined): number | null {
     return null;
   }
   return Math.floor(value);
+}
+
+function delay(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
 }

--- a/apps/server/src/redis.ts
+++ b/apps/server/src/redis.ts
@@ -1,0 +1,68 @@
+import { RedisDriver } from "@colyseus/redis-driver";
+import { RedisPresence } from "@colyseus/redis-presence";
+import Redis from "ioredis";
+
+export interface ClosableRedisResource {
+  shutdown?(): Promise<void> | void;
+  quit?(): Promise<void>;
+  disconnect?(): void;
+}
+
+export interface RedisClientLike {
+  del(...keys: string[]): Promise<number>;
+  eval(script: string, numKeys: number, ...args: string[]): Promise<unknown>;
+  get(key: string): Promise<string | null>;
+  hdel(key: string, ...fields: string[]): Promise<number>;
+  hget(key: string, field: string): Promise<string | null>;
+  hset(key: string, field: string, value: string): Promise<number>;
+  incr(key: string): Promise<number>;
+  lindex(key: string, index: number): Promise<string | null>;
+  linsert(key: string, direction: "BEFORE" | "AFTER", pivot: string, value: string): Promise<number>;
+  llen(key: string): Promise<number>;
+  lrange(key: string, start: number, stop: number): Promise<string[]>;
+  lrem(key: string, count: number, value: string): Promise<number>;
+  quit?(): Promise<unknown>;
+  rpush(key: string, ...values: string[]): Promise<number>;
+  set(
+    key: string,
+    value: string,
+    mode?: "PX",
+    durationMs?: number,
+    condition?: "NX"
+  ): Promise<"OK" | null>;
+}
+
+export function readRedisUrl(env: NodeJS.ProcessEnv = process.env): string | null {
+  const redisUrl = env.REDIS_URL?.trim();
+  return redisUrl ? redisUrl : null;
+}
+
+export function createRedisPresence(redisUrl: string): RedisPresence {
+  return new RedisPresence(redisUrl);
+}
+
+export function createRedisDriver(redisUrl: string): RedisDriver {
+  return new RedisDriver(redisUrl);
+}
+
+export function createRedisClient(redisUrl: string): RedisClientLike {
+  return new Redis(redisUrl) as unknown as RedisClientLike;
+}
+
+export async function closeRedisResource(resource: ClosableRedisResource | null | undefined): Promise<void> {
+  if (!resource) {
+    return;
+  }
+
+  if (typeof resource.shutdown === "function") {
+    await resource.shutdown();
+    return;
+  }
+
+  if (typeof resource.quit === "function") {
+    await resource.quit();
+    return;
+  }
+
+  resource.disconnect?.();
+}

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -121,6 +121,7 @@ function createBaseDependencies() {
     defineCalls: [] as Array<{ name: string; room: unknown }>,
     filterByCalls: [] as string[][],
     listenCalls: [] as Array<{ port: number; host: string }>,
+    realtimeOptions: [] as Array<{ driver?: unknown; presence?: unknown } | undefined>,
     define(name: string, room: unknown) {
       this.defineCalls.push({ name, room });
       return {
@@ -175,6 +176,13 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
       configuredStore = store;
     },
     createTransport: () => base.transport,
+    readRedisUrl: () => null,
+    createRedisPresence: () => {
+      throw new Error("createRedisPresence should not be used without REDIS_URL");
+    },
+    createRedisDriver: () => {
+      throw new Error("createRedisDriver should not be used without REDIS_URL");
+    },
     registerAuthRoutes: (app, store) => {
       assert.equal(app, base.expressApp);
       authStore = store;
@@ -215,7 +223,10 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
       assert.equal(gameServer, base.gameServer);
       base.routeCalls.push("admin");
     },
-    createGameServer: () => base.gameServer,
+    createGameServer: (_transport, realtimeOptions) => {
+      base.gameServer.realtimeOptions.push(realtimeOptions);
+      return base.gameServer;
+    },
     logger: base.logger,
     process: base.process,
     setInterval: () => {
@@ -245,6 +256,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
   assert.deepEqual(base.gameServer.defineCalls.map((call) => call.name), ["veil"]);
   assert.deepEqual(base.gameServer.filterByCalls, [["logicalRoomId"]]);
   assert.deepEqual(base.gameServer.listenCalls, [{ port: 3101, host: "0.0.0.0" }]);
+  assert.deepEqual(base.gameServer.realtimeOptions, [{ driver: undefined, presence: undefined }]);
   assert.equal(configCenterStore.initializeCalls, 1);
   assert.equal(base.logger.warnings.length, 0);
   assert.equal(base.logger.errors.length, 0);
@@ -255,6 +267,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
     /Runtime diagnostic snapshot available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/diagnostic-snapshot/,
     /Runtime metrics available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/metrics/,
     /Config center storage: filesystem/,
+    /Local in-memory Colyseus presence\/driver enabled/,
     /Local in-memory room persistence enabled/
   ]);
   assert.ok(base.process.handlers.SIGINT);
@@ -282,6 +295,13 @@ test("dev server logs process-level failures, closes stores, and exits non-zero"
     createMemoryRoomSnapshotStore: () => memoryStore,
     configureRoomSnapshotStore: () => undefined,
     createTransport: () => base.transport,
+    readRedisUrl: () => null,
+    createRedisPresence: () => {
+      throw new Error("createRedisPresence should not be used without REDIS_URL");
+    },
+    createRedisDriver: () => {
+      throw new Error("createRedisDriver should not be used without REDIS_URL");
+    },
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
@@ -290,7 +310,10 @@ test("dev server logs process-level failures, closes stores, and exits non-zero"
     registerMatchmakingRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
-    createGameServer: () => base.gameServer,
+    createGameServer: (_transport, realtimeOptions) => {
+      base.gameServer.realtimeOptions.push(realtimeOptions);
+      return base.gameServer;
+    },
     logger: base.logger,
     process: base.process,
     setInterval: () => {
@@ -328,6 +351,13 @@ test("dev server logs uncaught exceptions, closes stores, and exits non-zero", a
     createMemoryRoomSnapshotStore: () => memoryStore,
     configureRoomSnapshotStore: () => undefined,
     createTransport: () => base.transport,
+    readRedisUrl: () => null,
+    createRedisPresence: () => {
+      throw new Error("createRedisPresence should not be used without REDIS_URL");
+    },
+    createRedisDriver: () => {
+      throw new Error("createRedisDriver should not be used without REDIS_URL");
+    },
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
@@ -336,7 +366,10 @@ test("dev server logs uncaught exceptions, closes stores, and exits non-zero", a
     registerMatchmakingRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
-    createGameServer: () => base.gameServer,
+    createGameServer: (_transport, realtimeOptions) => {
+      base.gameServer.realtimeOptions.push(realtimeOptions);
+      return base.gameServer;
+    },
     logger: base.logger,
     process: base.process,
     setInterval: () => {
@@ -396,6 +429,13 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     createMemoryRoomSnapshotStore: () => memoryStore,
     configureRoomSnapshotStore: () => undefined,
     createTransport: () => base.transport,
+    readRedisUrl: () => null,
+    createRedisPresence: () => {
+      throw new Error("createRedisPresence should not be used without REDIS_URL");
+    },
+    createRedisDriver: () => {
+      throw new Error("createRedisDriver should not be used without REDIS_URL");
+    },
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
@@ -404,7 +444,10 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     registerMatchmakingRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
-    createGameServer: () => base.gameServer,
+    createGameServer: (_transport, realtimeOptions) => {
+      base.gameServer.realtimeOptions.push(realtimeOptions);
+      return base.gameServer;
+    },
     logger: base.logger,
     process: base.process,
     setInterval: () => {
@@ -425,8 +468,68 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     /Runtime diagnostic snapshot available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/diagnostic-snapshot/,
     /Runtime metrics available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/metrics/,
     /Config center storage: filesystem/,
+    /Local in-memory Colyseus presence\/driver enabled/,
     /Local in-memory room persistence enabled/
   ]);
+});
+
+test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL is set", async () => {
+  const base = createBaseDependencies();
+  const configCenterStore = createConfigCenterStore("filesystem");
+  const memoryStore = createMemoryStore();
+  const redisPresence = {
+    shutdownCalls: 0,
+    shutdown() {
+      this.shutdownCalls += 1;
+    }
+  };
+  const redisDriver = {
+    shutdownCalls: 0,
+    shutdown() {
+      this.shutdownCalls += 1;
+    }
+  };
+
+  await startDevServer(3123, "127.0.0.1", {
+    readMySqlPersistenceConfig: () => null,
+    createFileSystemConfigCenterStore: () => configCenterStore,
+    createMemoryRoomSnapshotStore: () => memoryStore,
+    configureRoomSnapshotStore: () => undefined,
+    createTransport: () => base.transport,
+    readRedisUrl: () => "redis://127.0.0.1:6379/0",
+    createRedisPresence: () => redisPresence,
+    createRedisDriver: () => redisDriver,
+    registerAuthRoutes: () => undefined,
+    registerConfigCenterRoutes: () => undefined,
+    registerConfigViewerRoutes: () => undefined,
+    registerPlayerAccountRoutes: () => undefined,
+    registerLobbyRoutes: () => undefined,
+    registerMatchmakingRoutes: () => undefined,
+    registerRuntimeObservabilityRoutes: () => undefined,
+    registerAdminRoutes: () => undefined,
+    createGameServer: (_transport, realtimeOptions) => {
+      base.gameServer.realtimeOptions.push(realtimeOptions);
+      return base.gameServer;
+    },
+    logger: base.logger,
+    process: base.process,
+    setInterval: () => {
+      throw new Error("setInterval should not be used for in-memory startup");
+    },
+    clearInterval: () => undefined,
+    isMySqlSnapshotStore: () => false
+  });
+
+  assert.deepEqual(base.gameServer.realtimeOptions, [{ driver: redisDriver, presence: redisPresence }]);
+  assertStartupLogIncludes(base.logger, [/Redis-backed Colyseus presence\/driver enabled via REDIS_URL/]);
+
+  base.process.handlers.SIGTERM?.();
+  await flushAsyncWork();
+
+  assert.equal(redisPresence.shutdownCalls, 1);
+  assert.equal(redisDriver.shutdownCalls, 1);
+  assert.equal(memoryStore.closeCalls, 1);
+  assert.equal(configCenterStore.closeCalls, 1);
 });
 
 test("dev server starts MySQL persistence, runs retention cleanup, schedules pruning, and clears the timer on SIGTERM", async () => {
@@ -472,6 +575,13 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
       assert.equal(store, mysqlStore);
     },
     createTransport: () => base.transport,
+    readRedisUrl: () => null,
+    createRedisPresence: () => {
+      throw new Error("createRedisPresence should not be used without REDIS_URL");
+    },
+    createRedisDriver: () => {
+      throw new Error("createRedisDriver should not be used without REDIS_URL");
+    },
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
@@ -480,7 +590,10 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     registerMatchmakingRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
-    createGameServer: () => base.gameServer,
+    createGameServer: (_transport, realtimeOptions) => {
+      base.gameServer.realtimeOptions.push(realtimeOptions);
+      return base.gameServer;
+    },
     logger: base.logger,
     process: base.process,
     setInterval: (callback, delayMs) => {
@@ -511,6 +624,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     /Runtime diagnostic snapshot available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/diagnostic-snapshot/,
     /Runtime metrics available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/metrics/,
     /Config center storage: mysql/,
+    /Local in-memory Colyseus presence\/driver enabled/,
     /MySQL room persistence enabled/,
     /Snapshot retention: ttl=48h \/ cleanup=15m/,
     /Pruned 2 expired room snapshot\(s\)/

--- a/apps/server/test/matchmaking-service.test.ts
+++ b/apps/server/test/matchmaking-service.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import Redis from "ioredis-mock";
 import {
   createDefaultHeroLoadout,
   createDefaultHeroProgression,
@@ -7,7 +8,7 @@ import {
   type HeroState,
   type MatchmakingRequest
 } from "../../../packages/shared/src/index";
-import { MatchmakingService } from "../src/matchmaking";
+import { MatchmakingService, RedisMatchmakingService } from "../src/matchmaking";
 
 function createHero(playerId: string, heroId: string): HeroState {
   return {
@@ -118,6 +119,82 @@ test("matchmaking service updates maintained positions after dequeue and prune",
   assert.equal(removed, 1);
   assert.equal(service.getStatus("player-earlier").status, "idle");
   assert.deepEqual(service.getStatus("player-beta"), {
+    status: "queued",
+    position: 1,
+    estimatedWaitSeconds: 0
+  });
+});
+
+test("redis matchmaking service shares queue state and match results across service instances", async (t) => {
+  const redis = new Redis();
+  const serviceA = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:shared",
+    lockRetryDelayMs: 1
+  });
+  const serviceB = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:shared",
+    lockRetryDelayMs: 1
+  });
+
+  t.after(async () => {
+    await serviceA.close();
+  });
+
+  const firstQueued = await serviceA.enqueue(createQueueRequest("player-alpha", "2026-03-28T08:00:00.000Z"));
+  const secondQueued = await serviceB.enqueue(createQueueRequest("player-beta", "2026-03-28T08:00:05.000Z"));
+
+  assert.deepEqual(firstQueued, {
+    status: "queued",
+    position: 1,
+    estimatedWaitSeconds: 0
+  });
+  assert.deepEqual(secondQueued, {
+    status: "queued",
+    position: 2,
+    estimatedWaitSeconds: 15
+  });
+
+  const statusA = await serviceA.getStatus("player-alpha");
+  const statusB = await serviceB.getStatus("player-beta");
+
+  assert.equal(statusA.status, "matched");
+  assert.equal(statusB.status, "matched");
+  assert.equal(statusA.roomId, statusB.roomId);
+  assert.deepEqual(statusA.playerIds, ["player-alpha", "player-beta"]);
+});
+
+test("redis matchmaking service prunes stale queue entries across shared instances", async (t) => {
+  const redis = new Redis();
+  const serviceA = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:prune",
+    lockRetryDelayMs: 1
+  });
+  const serviceB = new RedisMatchmakingService({
+    redisClient: redis as never,
+    keyPrefix: "test:matchmaking:prune",
+    lockRetryDelayMs: 1
+  });
+
+  t.after(async () => {
+    await serviceA.close();
+  });
+
+  await serviceA.enqueue(createQueueRequest("player-expired", "2026-03-28T08:00:00.000Z"));
+
+  const removed = await serviceB.pruneStaleEntries(2 * 60 * 1000, new Date("2026-03-28T08:05:00.000Z"));
+  assert.equal(removed, 1);
+  assert.equal((await serviceA.getStatus("player-expired")).status, "idle");
+
+  const freshQueued = await serviceB.enqueue(createQueueRequest("player-fresh", "2026-03-28T08:04:30.000Z"));
+  assert.deepEqual(freshQueued, {
+    status: "queued",
+    position: 1,
+    estimatedWaitSeconds: 0
+  });
+  assert.deepEqual(await serviceB.getStatus("player-fresh"), {
     status: "queued",
     position: 1,
     estimatedWaitSeconds: 0

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -1,0 +1,12 @@
+services:
+  redis:
+    image: redis:7.4-alpine
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:

--- a/docs/redis-colyseus-scaling.md
+++ b/docs/redis-colyseus-scaling.md
@@ -1,0 +1,57 @@
+# Redis-backed Colyseus Scaling
+
+Project Veil 现在支持通过 `REDIS_URL` 启用 Redis-backed Colyseus presence/driver，以及跨节点共享的匹配队列。
+
+## 本地单进程兼容
+
+不设置 `REDIS_URL` 时，服务端继续使用原有的本地内存实现：
+
+- Colyseus: in-memory presence/driver
+- Matchmaking: 进程内队列
+
+这条路径适合本地开发和最小化调试，不需要额外基础设施。
+
+## Docker Compose 启动 Redis
+
+仓库根目录提供了 [`docker-compose.redis.yml`](../docker-compose.redis.yml)：
+
+```bash
+docker compose -f docker-compose.redis.yml up -d
+```
+
+默认会在本机暴露 `6379` 端口。
+
+## 启动双节点
+
+两个节点只要共享同一个 `REDIS_URL`，就会共享 Colyseus 房间发现与匹配队列：
+
+```bash
+REDIS_URL=redis://127.0.0.1:6379/0 PORT=2567 npm run dev:server
+REDIS_URL=redis://127.0.0.1:6379/0 PORT=2568 npm run dev:server
+```
+
+说明：
+
+- Colyseus `presence` / `driver` 会自动切到 Redis 实现
+- `/api/matchmaking/*` 会自动切到 Redis-backed 队列
+- 不设置 `REDIS_URL` 时不会触发这些 Redis 依赖
+
+## 验证共享匹配
+
+如果本机或环境里已经有 Redis，可直接运行：
+
+```bash
+REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
+```
+
+该脚本会创建两个独立的 matchmaking service 实例，并验证：
+
+- 两个节点共享等待队列
+- 两个节点能读取到同一个匹配结果
+- 同一个房间 ID 会返回给双方玩家
+
+## 部署建议
+
+- `REDIS_URL` 指向可被所有游戏节点访问的同一 Redis 实例或集群
+- 多节点部署时，保持所有节点的 `REDIS_URL`、MySQL 配置和版本一致
+- 如需更严格的持久化/高可用，建议把 Redis 替换为托管 Redis 或带 Sentinel/Cluster 的拓扑

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,13 @@
       "name": "project-veil",
       "version": "0.1.0",
       "dependencies": {
+        "@colyseus/redis-driver": "^0.17.7",
+        "@colyseus/redis-presence": "^0.17.7",
         "@colyseus/sdk": "^0.17.35",
         "cc": "file:packages/cc-runtime-stub",
         "colyseus": "^0.17.8",
         "dotenv": "^17.3.1",
+        "ioredis": "^5.10.1",
         "mysql2": "^3.20.0",
         "xlsx": "^0.18.5"
       },
@@ -20,6 +23,7 @@
         "@types/node": "^24.5.2",
         "@types/ws": "^8.18.1",
         "esbuild": "^0.25.12",
+        "ioredis-mock": "^8.13.1",
         "miniprogram-ci": "^2.1.31",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2",
@@ -3020,22 +3024,22 @@
       }
     },
     "node_modules/@colyseus/redis-driver": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@colyseus/redis-driver/-/redis-driver-0.17.6.tgz",
-      "integrity": "sha512-/wWGHoBprVUseDdTPE8XZxUrMjVwL6dPOkDKFjsiZTnCNurOWuST8AoEX+hRpt6ow3/c4nlBoas/yXNj5BpSUA==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@colyseus/redis-driver/-/redis-driver-0.17.7.tgz",
+      "integrity": "sha512-JEu8KaeGondwyu+42ZLHLzaeVO7TST2lbTietcvPvWGgaRx4EfbgkxNNKqSq5CY293DtWv/BFCXwiZxtm1AVTw==",
       "license": "MIT",
       "dependencies": {
-        "@colyseus/core": "^0.17.22",
+        "@colyseus/core": "^0.17.39",
         "ioredis": "^5.3.2"
       }
     },
     "node_modules/@colyseus/redis-presence": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@colyseus/redis-presence/-/redis-presence-0.17.6.tgz",
-      "integrity": "sha512-gtgDmPHDNVzIFou3bo1Z3togUW/ihMvLCHZZMvMqbnAZGEvlhcriJad5+8z8kv2UIjGMnOGcNlg7IomGEiy6Cg==",
+      "version": "0.17.7",
+      "resolved": "https://registry.npmjs.org/@colyseus/redis-presence/-/redis-presence-0.17.7.tgz",
+      "integrity": "sha512-N3QHKod90NidKzMbkIV2hNEnQl2GyiBzb2pQ+zGJZc87oKH6hdNmUThOqrUIN5bqqZky4HPzEsQbX/qjBDDT4A==",
       "license": "MIT",
       "dependencies": {
-        "@colyseus/core": "^0.17.22",
+        "@colyseus/core": "^0.17.39",
         "ioredis": "^5.3.2"
       }
     },
@@ -3829,6 +3833,13 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/@ioredis/as-callback": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/as-callback/-/as-callback-3.0.0.tgz",
+      "integrity": "sha512-Kqv1rZ3WbgOrS+hgzJ5xG5WQuhvzzSTRYvNeyPMLOAM78MHSnuKI20JeJGbpuAt//LCuP0vsexZcorqW7kWhJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ioredis/commands": {
       "version": "1.5.1",
@@ -5553,6 +5564,17 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ioredis-mock": {
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/@types/ioredis-mock/-/ioredis-mock-8.2.7.tgz",
+      "integrity": "sha512-YsGiaOIYBKeVvu/7GYziAD8qX3LJem5LK00d5PKykzsQJMLysAqXA61AkNuYWCekYl64tbMTqVOMF4SYoCPbQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "ioredis": ">=5"
+      }
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
@@ -10088,6 +10110,38 @@
         }
       }
     },
+    "node_modules/fengari": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.5.tgz",
+      "integrity": "sha512-0DS4Nn4rV8qyFlQCpKK8brT61EUtswynrpfFTcgLErcilBIBskSMQ86fO2WVuybr14ywyKdRjv91FiRZwnEuvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readline-sync": "^1.4.10",
+        "sprintf-js": "^1.1.3",
+        "tmp": "^0.2.5"
+      }
+    },
+    "node_modules/fengari-interop": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.4.tgz",
+      "integrity": "sha512-4/CW/3PJUo3ebD4ACgE1g/3NGEYSq7OQAyETyypsAl/WeySDBbxExikkayNkZzbpgyC9GyJp8v1DU2VOXxNq7Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "fengari": "^0.1.0"
+      }
+    },
+    "node_modules/fengari/node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11456,9 +11510,9 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.0.tgz",
-      "integrity": "sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "1.5.1",
@@ -11477,6 +11531,40 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis-mock": {
+      "version": "8.13.1",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-8.13.1.tgz",
+      "integrity": "sha512-Wsi50AU+cMiI32nAgfwpUaJVBtb4iQdVsOHl9M6R3tePCO/8vGsToCVIG82XWAxN4Se55TZoOzVseu+QngFLyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/as-callback": "^3.0.0",
+        "@ioredis/commands": "^1.4.0",
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.3",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": ">=12.22"
+      },
+      "peerDependencies": {
+        "@types/ioredis-mock": "^8",
+        "ioredis": "^5"
+      }
+    },
+    "node_modules/ioredis-mock/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/iota-array": {
@@ -15103,6 +15191,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -16083,6 +16181,13 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/sql-escaper": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "plan:validation:minimal": "node --import tsx ./scripts/minimal-validation-plan.ts",
     "demo:flow": "node --import tsx ./scripts/demo.ts",
     "validate:quickstart": "node ./scripts/validate-local-dev-quickstart.mjs",
+    "validate:redis-scaling": "node --import tsx ./scripts/validate-redis-scaling.ts",
     "validate:e2e:fixtures": "node --import tsx ./scripts/validate-e2e-config-fixtures.ts",
     "validate:content-pack": "node --import tsx ./scripts/validate-content-pack.ts",
     "validate:content-pack:all": "node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack stonewatch-fork --map-pack ridgeway-crossing --map-pack highland-reach --map-pack amber-fields --map-pack ironpass-gorge --map-pack splitrock-canyon --map-pack bogfen-crossing --map-pack murkveil-delta --map-pack frostwatch-ridge --map-pack ashpeak-ascent --map-pack thornwall-divide --map-pack phase2",
@@ -125,6 +126,7 @@
     "@types/node": "^24.5.2",
     "@types/ws": "^8.18.1",
     "esbuild": "^0.25.12",
+    "ioredis-mock": "^8.13.1",
     "miniprogram-ci": "^2.1.31",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2",
@@ -132,10 +134,13 @@
     "ws": "^8.18.3"
   },
   "dependencies": {
+    "@colyseus/redis-driver": "^0.17.7",
+    "@colyseus/redis-presence": "^0.17.7",
     "@colyseus/sdk": "^0.17.35",
     "cc": "file:packages/cc-runtime-stub",
     "colyseus": "^0.17.8",
     "dotenv": "^17.3.1",
+    "ioredis": "^5.10.1",
     "mysql2": "^3.20.0",
     "xlsx": "^0.18.5"
   }

--- a/scripts/validate-redis-scaling.ts
+++ b/scripts/validate-redis-scaling.ts
@@ -1,0 +1,84 @@
+import process from "node:process";
+import {
+  createDefaultHeroLoadout,
+  createDefaultHeroProgression,
+  createMatchmakingHeroSnapshot,
+  type HeroState,
+  type MatchmakingRequest
+} from "../packages/shared/src/index";
+import { RedisMatchmakingService } from "../apps/server/src/matchmaking";
+import { readRedisUrl } from "../apps/server/src/redis";
+
+function createHero(playerId: string): HeroState {
+  return {
+    id: `${playerId}-hero`,
+    playerId,
+    name: `Hero ${playerId}`,
+    position: { x: 0, y: 0 },
+    vision: 2,
+    move: { total: 6, remaining: 6 },
+    stats: {
+      attack: 2,
+      defense: 2,
+      power: 1,
+      knowledge: 1,
+      hp: 30,
+      maxHp: 30
+    },
+    progression: createDefaultHeroProgression(),
+    loadout: createDefaultHeroLoadout(),
+    armyTemplateId: "hero_guard_basic",
+    armyCount: 12,
+    learnedSkills: []
+  };
+}
+
+function createRequest(playerId: string, enqueuedAt: string): MatchmakingRequest {
+  return {
+    playerId,
+    heroSnapshot: createMatchmakingHeroSnapshot(createHero(playerId)),
+    rating: 1000,
+    enqueuedAt
+  };
+}
+
+async function main(): Promise<void> {
+  const redisUrl = readRedisUrl();
+  if (!redisUrl) {
+    throw new Error("REDIS_URL is required. Example: REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling");
+  }
+
+  const keyPrefix = process.env.VEIL_REDIS_MATCHMAKING_PREFIX?.trim() || `veil:validate:${Date.now()}`;
+  const nodeA = new RedisMatchmakingService({ redisUrl, keyPrefix });
+  const nodeB = new RedisMatchmakingService({ redisUrl, keyPrefix });
+
+  try {
+    const queuedA = await nodeA.enqueue(createRequest("player-a", new Date().toISOString()));
+    const queuedB = await nodeB.enqueue(createRequest("player-b", new Date(Date.now() + 1_000).toISOString()));
+    const statusA = await nodeA.getStatus("player-a");
+    const statusB = await nodeB.getStatus("player-b");
+
+    if (queuedA.status !== "queued" || queuedA.position !== 1) {
+      throw new Error(`Unexpected first enqueue result: ${JSON.stringify(queuedA)}`);
+    }
+
+    if (queuedB.status !== "queued" || queuedB.position < 2) {
+      throw new Error(`Unexpected second enqueue result: ${JSON.stringify(queuedB)}`);
+    }
+
+    if (statusA.status !== "matched" || statusB.status !== "matched" || statusA.roomId !== statusB.roomId) {
+      throw new Error(
+        `Cross-node matchmaking failed. nodeA=${JSON.stringify(statusA)} nodeB=${JSON.stringify(statusB)}`
+      );
+    }
+
+    console.log(JSON.stringify({ ok: true, keyPrefix, roomId: statusA.roomId, playerIds: statusA.playerIds }, null, 2));
+  } finally {
+    await Promise.all([nodeA.close(), nodeB.close()]);
+  }
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
closes #789

## Summary
- switch Colyseus dev server to `RedisPresence` + `RedisDriver` whenever `REDIS_URL` is configured, while preserving the existing in-memory fallback when it is absent
- add a Redis-backed matchmaking service so queue state and match results can be shared across multiple server nodes
- add Redis scaling docs, a Docker Compose example, and a `validate:redis-scaling` verification script for shared-queue smoke checks

## Test / Validation
- `node --import tsx --test ./apps/server/test/matchmaking-service.test.ts ./apps/server/test/matchmaking-routes.test.ts ./apps/server/test/dev-server.test.ts`
- `npx tsc -p apps/server/tsconfig.json --noEmit --pretty false 2>&1 | rg "apps/server/src/(matchmaking|dev-server|redis)\\.ts|apps/server/test/(matchmaking-service|dev-server)" -n || true`
- `npm run typecheck:server` is still blocked by a pre-existing error in `apps/server/src/config-center.ts:1946` (`TerrainType` -> missing `swamp` mapping), unrelated to this change
