### PR TITLE
Add Prometheus metrics export and alerting thresholds

### DIFF
--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { Server, WebSocketTransport } from "colyseus";
 import { config as loadEnv } from "dotenv";
 import { registerAuthRoutes } from "./auth";
@@ -12,7 +13,11 @@ import { registerConfigViewerRoutes } from "./config-viewer";
 import { registerLobbyRoutes } from "./lobby";
 import { registerMatchmakingRoutes } from "./matchmaking";
 import { createMemoryRoomSnapshotStore } from "./memory-room-snapshot-store";
-import { registerRuntimeObservabilityRoutes } from "./observability";
+import {
+  buildPrometheusMetricsDocument,
+  recordHttpRequestDuration,
+  registerRuntimeObservabilityRoutes
+} from "./observability";
 import {
   MySqlRoomSnapshotStore,
   readMySqlPersistenceConfig,
@@ -29,6 +34,11 @@ loadEnv();
 
 interface DevServerTransport {
   getExpressApp(): unknown;
+}
+
+interface DevServerHttpApp {
+  use(handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void): void;
+  get(path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>): void;
 }
 
 interface DevServerDefinitionChain {
@@ -102,6 +112,8 @@ export interface DevServerBootstrapDependencies {
   registerLobbyRoutes(app: unknown, dependencies: { listRooms: typeof listLobbyRooms }): void;
   registerMatchmakingRoutes(app: unknown, dependencies: { store: DevServerRoomSnapshotStore }): void;
   registerRuntimeObservabilityRoutes(app: unknown, options?: { store?: DevServerRoomSnapshotStore }): void;
+  registerPrometheusMetricsMiddleware(app: unknown): void;
+  registerPrometheusMetricsRoute(app: unknown): void;
   registerAdminRoutes(app: unknown, store: DevServerRoomSnapshotStore, gameServer: DevServerGameServer): void;
   createGameServer(transport: DevServerTransport, realtimeOptions?: DevServerRealtimeOptions): DevServerGameServer;
   logger: DevServerLogger;
@@ -109,6 +121,35 @@ export interface DevServerBootstrapDependencies {
   setInterval(handler: () => void, delayMs: number): CleanupTimerHandle;
   clearInterval(timer: CleanupTimerHandle): void;
   isMySqlSnapshotStore(store: DevServerRoomSnapshotStore): store is DevServerMySqlSnapshotStore;
+}
+
+export function registerPrometheusMetricsMiddleware(app: DevServerHttpApp): void {
+  app.use((request, response, next) => {
+    const startedAt = process.hrtime.bigint();
+    let recorded = false;
+
+    const recordDuration = (): void => {
+      if (recorded) {
+        return;
+      }
+
+      recorded = true;
+      const durationSeconds = Number(process.hrtime.bigint() - startedAt) / 1_000_000_000;
+      recordHttpRequestDuration(durationSeconds);
+    };
+
+    response.once("finish", recordDuration);
+    response.once("close", recordDuration);
+    next();
+  });
+}
+
+export function registerPrometheusMetricsRoute(app: DevServerHttpApp): void {
+  app.get("/metrics", async (_request, response) => {
+    response.statusCode = 200;
+    response.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
+    response.end(`${buildPrometheusMetricsDocument()}\n`);
+  });
 }
 
 function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDependencies {
@@ -133,6 +174,8 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerMatchmakingRoutes: (app, dependencies) =>
       registerMatchmakingRoutes(app as never, { store: dependencies.store as RoomSnapshotStore }),
     registerRuntimeObservabilityRoutes: (app, options) => registerRuntimeObservabilityRoutes(app as never, options),
+    registerPrometheusMetricsMiddleware: (app) => registerPrometheusMetricsMiddleware(app as DevServerHttpApp),
+    registerPrometheusMetricsRoute: (app) => registerPrometheusMetricsRoute(app as DevServerHttpApp),
     registerAdminRoutes: (app, store, gameServer) =>
       registerAdminRoutes(app as never, store as RoomSnapshotStore, gameServer),
     createGameServer: (transport, realtimeOptions) =>
@@ -182,6 +225,8 @@ export async function startDevServer(
 
   const transport = deps.createTransport();
   const expressApp = transport.getExpressApp();
+  deps.registerPrometheusMetricsMiddleware(expressApp);
+  deps.registerPrometheusMetricsRoute(expressApp);
   deps.registerAuthRoutes(expressApp, effectiveSnapshotStore);
   deps.registerConfigCenterRoutes(expressApp, configCenterStore);
   deps.registerConfigViewerRoutes(expressApp, configCenterStore);
@@ -209,6 +254,7 @@ export async function startDevServer(
   deps.logger.log(`Runtime health available at http://${host}:${port}/api/runtime/health`);
   deps.logger.log(`Auth readiness available at http://${host}:${port}/api/runtime/auth-readiness`);
   deps.logger.log(`Runtime diagnostic snapshot available at http://${host}:${port}/api/runtime/diagnostic-snapshot`);
+  deps.logger.log(`Prometheus metrics available at http://${host}:${port}/metrics`);
   deps.logger.log(`Runtime metrics available at http://${host}:${port}/api/runtime/metrics`);
   deps.logger.log(`Config center storage: ${configCenterStore.mode}`);
   if (redisUrl) {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -28,6 +28,7 @@ import {
   type CompletedBattleReplayCapture,
   type OngoingBattleReplayCapture
 } from "./battle-replays";
+import { recordActionValidationFailure, recordBattleDuration } from "./observability";
 
 export interface RoomSnapshot {
   roomId: string;
@@ -69,6 +70,7 @@ function hashBattleSeed(value: string): number {
 export class AuthoritativeWorldRoom {
   private state: WorldState;
   private readonly battles = new Map<string, BattleState>();
+  private readonly battleStartedAtByBattleId = new Map<string, number>();
   private readonly battleIdByHeroId = new Map<string, string>();
   private readonly battleReplayByBattleId = new Map<string, OngoingBattleReplayCapture>();
   private readonly completedBattleReplays: CompletedBattleReplayCapture[] = [];
@@ -158,6 +160,9 @@ export class AuthoritativeWorldRoom {
 
   private setBattle(battle: BattleState): void {
     this.battles.set(battle.id, battle);
+    if (!this.battleStartedAtByBattleId.has(battle.id)) {
+      this.battleStartedAtByBattleId.set(battle.id, Date.now());
+    }
     if (battle.worldHeroId) {
       this.battleIdByHeroId.set(battle.worldHeroId, battle.id);
     }
@@ -168,6 +173,7 @@ export class AuthoritativeWorldRoom {
 
   private clearBattle(battle: BattleState): void {
     this.battles.delete(battle.id);
+    this.battleStartedAtByBattleId.delete(battle.id);
     if (battle.worldHeroId) {
       this.battleIdByHeroId.delete(battle.worldHeroId);
     }
@@ -223,6 +229,15 @@ export class AuthoritativeWorldRoom {
     }
   }
 
+  private recordCompletedBattleDuration(battleId: string): void {
+    const startedAt = this.battleStartedAtByBattleId.get(battleId);
+    if (startedAt == null) {
+      return;
+    }
+
+    recordBattleDuration((Date.now() - startedAt) / 1_000);
+  }
+
   getSnapshot(playerId: string): RoomSnapshot {
     return {
       roomId: this.state.meta.roomId,
@@ -258,6 +273,7 @@ export class AuthoritativeWorldRoom {
       const outcome = getBattleOutcome(battle);
       if (outcome.status !== "in_progress") {
         this.finalizeBattleReplay(battle, outcome);
+        this.recordCompletedBattleDuration(battle.id);
         if (battle.worldHeroId) {
           const worldOutcome = applyBattleOutcomeToWorld(
             this.state,
@@ -294,6 +310,7 @@ export class AuthoritativeWorldRoom {
     if ("heroId" in action) {
       const hero = this.state.heroes.find((item) => item.id === action.heroId);
       if (!hero || hero.playerId !== playerId) {
+        recordActionValidationFailure("world", "hero_not_owned_by_player");
         return {
           ok: false,
           reason: "hero_not_owned_by_player",
@@ -302,6 +319,7 @@ export class AuthoritativeWorldRoom {
       }
 
       if (this.getBattleIdForHero(hero.id)) {
+        recordActionValidationFailure("world", "hero_in_battle");
         return {
           ok: false,
           reason: "hero_in_battle",
@@ -313,6 +331,7 @@ export class AuthoritativeWorldRoom {
 
     const validation = validateWorldAction(this.state, action);
     if (!validation.valid) {
+      recordActionValidationFailure("world", validation.reason ?? "world_action_invalid");
       return {
         ok: false,
         ...(validation.reason ? { reason: validation.reason } : {}),
@@ -380,6 +399,7 @@ export class AuthoritativeWorldRoom {
   dispatchBattle(playerId: string, action: BattleAction): BattleDispatchResult {
     const activeBattle = this.getBattleForPlayer(playerId);
     if (!activeBattle) {
+      recordActionValidationFailure("battle", "battle_not_active");
       return {
         ok: false,
         reason: "battle_not_active",
@@ -389,6 +409,7 @@ export class AuthoritativeWorldRoom {
 
     const controllingCamp = this.getControllingCamp(playerId, activeBattle);
     if (!controllingCamp) {
+      recordActionValidationFailure("battle", "battle_not_owned_by_player");
       return {
         ok: false,
         reason: "battle_not_owned_by_player",
@@ -399,6 +420,7 @@ export class AuthoritativeWorldRoom {
     const actingUnitId = action.type === "battle.attack" ? action.attackerId : action.unitId;
     const actingUnit = activeBattle.units[actingUnitId];
     if (!actingUnit || actingUnit.camp !== controllingCamp) {
+      recordActionValidationFailure("battle", "unit_not_player_controlled");
       return {
         ok: false,
         reason: "unit_not_player_controlled",
@@ -409,6 +431,7 @@ export class AuthoritativeWorldRoom {
 
     const validation = validateBattleAction(activeBattle, action);
     if (!validation.valid) {
+      recordActionValidationFailure("battle", validation.reason ?? "battle_action_invalid");
       return {
         ok: false,
         ...(validation.reason ? { reason: validation.reason } : {}),

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -44,6 +44,15 @@ interface MatchmakingObservabilityCounters {
   rateLimitedTotal: number;
 }
 
+type ActionValidationScope = "world" | "battle";
+
+interface HistogramMetricState {
+  buckets: number[];
+  bucketCounts: number[];
+  count: number;
+  sum: number;
+}
+
 type AuthSessionFailureReason =
   | "unauthorized"
   | "token_expired"
@@ -95,6 +104,11 @@ interface RuntimeObservabilityState {
   startedAt: number;
   rooms: Map<string, RuntimeRoomSnapshot>;
   counters: RuntimeObservabilityCounters;
+  prometheus: {
+    battleDurationSeconds: HistogramMetricState;
+    httpRequestDurationSeconds: HistogramMetricState;
+    actionValidationFailuresTotal: Map<string, number>;
+  };
   auth: AuthObservabilityState;
   matchmaking: {
     counters: MatchmakingObservabilityCounters;
@@ -175,6 +189,17 @@ interface AuthTokenDeliveryPayload {
 }
 
 const RECENT_TOKEN_DELIVERY_ATTEMPTS_LIMIT = 25;
+const BATTLE_DURATION_SECONDS_BUCKETS = [1, 5, 10, 30, 60, 120, 300, 600];
+const HTTP_REQUEST_DURATION_SECONDS_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
+
+function createHistogramMetricState(buckets: number[]): HistogramMetricState {
+  return {
+    buckets: [...buckets].sort((left, right) => left - right),
+    bucketCounts: new Array(buckets.length).fill(0),
+    count: 0,
+    sum: 0
+  };
+}
 
 const runtimeObservability: RuntimeObservabilityState = {
   startedAt: Date.now(),
@@ -185,6 +210,11 @@ const runtimeObservability: RuntimeObservabilityState = {
     battleActionsTotal: 0,
     websocketActionRateLimitedTotal: 0,
     websocketActionKickTotal: 0
+  },
+  prometheus: {
+    battleDurationSeconds: createHistogramMetricState(BATTLE_DURATION_SECONDS_BUCKETS),
+    httpRequestDurationSeconds: createHistogramMetricState(HTTP_REQUEST_DURATION_SECONDS_BUCKETS),
+    actionValidationFailuresTotal: new Map<string, number>()
   },
   auth: {
     counters: {
@@ -249,6 +279,51 @@ function toErrorPayload(error: unknown): { code: string; message: string } {
     code: error instanceof Error ? error.name || "error" : "error",
     message: error instanceof Error ? error.message : String(error)
   };
+}
+
+function escapePrometheusLabelValue(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"").replaceAll("\n", "\\n");
+}
+
+function formatPrometheusLabels(labels: Record<string, string>): string {
+  const entries = Object.entries(labels).filter(([, value]) => value.length > 0);
+  if (entries.length === 0) {
+    return "";
+  }
+
+  return `{${entries
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}="${escapePrometheusLabelValue(value)}"`)
+    .join(",")}}`;
+}
+
+function observeHistogram(state: HistogramMetricState, value: number): void {
+  const normalized = Number.isFinite(value) ? Math.max(0, value) : 0;
+  state.count += 1;
+  state.sum += normalized;
+
+  for (let index = 0; index < state.buckets.length; index += 1) {
+    if (normalized <= state.buckets[index]!) {
+      state.bucketCounts[index] = (state.bucketCounts[index] ?? 0) + 1;
+    }
+  }
+}
+
+function resetHistogram(state: HistogramMetricState): void {
+  state.bucketCounts.fill(0);
+  state.count = 0;
+  state.sum = 0;
+}
+
+function renderHistogramMetric(name: string, help: string, state: HistogramMetricState): string[] {
+  const lines = [`# HELP ${name} ${help}`, `# TYPE ${name} histogram`];
+  for (let index = 0; index < state.buckets.length; index += 1) {
+    lines.push(`${name}_bucket{le="${state.buckets[index]}"}` + ` ${state.bucketCounts[index]}`);
+  }
+  lines.push(`${name}_bucket{le="+Inf"} ${state.count}`);
+  lines.push(`${name}_sum ${state.sum}`);
+  lines.push(`${name}_count ${state.count}`);
+  return lines;
 }
 
 function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPayload {
@@ -468,13 +543,56 @@ function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): Runtim
   };
 }
 
-function buildMetricsDocument(): string {
+export function buildPrometheusMetricsDocument(): string {
   const health = buildHealthPayload();
-
-  return [
+  const lines = [
     "# HELP veil_up Process health status.",
     "# TYPE veil_up gauge",
     "veil_up 1",
+    "# HELP veil_active_rooms Active room count.",
+    "# TYPE veil_active_rooms gauge",
+    `veil_active_rooms ${health.runtime.activeRoomCount}`,
+    "# HELP veil_connected_players Connected player count across active rooms.",
+    "# TYPE veil_connected_players gauge",
+    `veil_connected_players ${health.runtime.connectionCount}`
+  ];
+
+  lines.push(
+    ...renderHistogramMetric(
+      "veil_battle_duration_seconds",
+      "Battle duration from start until resolution.",
+      runtimeObservability.prometheus.battleDurationSeconds
+    )
+  );
+
+  lines.push("# HELP veil_action_validation_failures_total Total rejected gameplay actions.");
+  lines.push("# TYPE veil_action_validation_failures_total counter");
+  const actionValidationEntries = Array.from(runtimeObservability.prometheus.actionValidationFailuresTotal.entries()).sort(
+    ([left], [right]) => left.localeCompare(right)
+  );
+  if (actionValidationEntries.length === 0) {
+    lines.push("veil_action_validation_failures_total 0");
+  } else {
+    for (const [key, value] of actionValidationEntries) {
+      const [scope, reason] = key.split("::");
+      lines.push(
+        `veil_action_validation_failures_total${formatPrometheusLabels({
+          reason: reason ?? "unknown",
+          scope: scope ?? "unknown"
+        })} ${value}`
+      );
+    }
+  }
+
+  lines.push(
+    ...renderHistogramMetric(
+      "veil_http_request_duration_seconds",
+      "HTTP request duration for the dev server.",
+      runtimeObservability.prometheus.httpRequestDurationSeconds
+    )
+  );
+
+  lines.push(
     "# HELP veil_active_room_count Active room count.",
     "# TYPE veil_active_room_count gauge",
     `veil_active_room_count ${health.runtime.activeRoomCount}`,
@@ -610,7 +728,9 @@ function buildMetricsDocument(): string {
     "# HELP veil_auth_session_failures_session_revoked_total Total auth session failures caused by revoked sessions.",
     "# TYPE veil_auth_session_failures_session_revoked_total counter",
     `veil_auth_session_failures_session_revoked_total ${health.runtime.auth.sessionFailureReasons.session_revoked}`
-  ].join("\n");
+  );
+
+  return lines.join("\n");
 }
 
 export function recordRuntimeRoom(snapshot: RuntimeRoomSnapshot): void {
@@ -631,6 +751,23 @@ export function recordWorldActionMessage(): void {
 
 export function recordBattleActionMessage(): void {
   runtimeObservability.counters.battleActionsTotal += 1;
+}
+
+export function recordBattleDuration(durationSeconds: number): void {
+  observeHistogram(runtimeObservability.prometheus.battleDurationSeconds, durationSeconds);
+}
+
+export function recordActionValidationFailure(scope: ActionValidationScope, reason: string): void {
+  const normalizedReason = reason.trim() || "unknown";
+  const key = `${scope}::${normalizedReason}`;
+  runtimeObservability.prometheus.actionValidationFailuresTotal.set(
+    key,
+    (runtimeObservability.prometheus.actionValidationFailuresTotal.get(key) ?? 0) + 1
+  );
+}
+
+export function recordHttpRequestDuration(durationSeconds: number): void {
+  observeHistogram(runtimeObservability.prometheus.httpRequestDurationSeconds, durationSeconds);
 }
 
 export function recordWebSocketActionRateLimited(): void {
@@ -796,6 +933,9 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.counters.battleActionsTotal = 0;
   runtimeObservability.counters.websocketActionRateLimitedTotal = 0;
   runtimeObservability.counters.websocketActionKickTotal = 0;
+  resetHistogram(runtimeObservability.prometheus.battleDurationSeconds);
+  resetHistogram(runtimeObservability.prometheus.httpRequestDurationSeconds);
+  runtimeObservability.prometheus.actionValidationFailuresTotal.clear();
   runtimeObservability.auth.counters.sessionChecksTotal = 0;
   runtimeObservability.auth.counters.sessionFailuresTotal = 0;
   runtimeObservability.auth.counters.guestLoginsTotal = 0;
@@ -875,7 +1015,7 @@ export function registerRuntimeObservabilityRoutes(
     try {
       response.statusCode = 200;
       response.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
-      response.end(`${buildMetricsDocument()}\n`);
+      response.end(`${buildPrometheusMetricsDocument()}\n`);
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -1,6 +1,35 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createRoom } from "../src/index";
+import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "../src/observability";
+
+function resolveBattle(room: ReturnType<typeof createRoom>, playerId: string): void {
+  let steps = 0;
+  while (steps < 20) {
+    const battle = room.getBattleForPlayer(playerId);
+    if (!battle) {
+      return;
+    }
+
+    const activeUnitId = battle.activeUnitId;
+    const activeUnit = activeUnitId ? battle.units[activeUnitId] : undefined;
+    const target = activeUnit
+      ? Object.values(battle.units).find((unit) => unit.camp !== activeUnit.camp && unit.count > 0)
+      : undefined;
+
+    assert.ok(activeUnitId);
+    assert.ok(target);
+
+    room.dispatchBattle(playerId, {
+      type: "battle.attack",
+      attackerId: activeUnitId,
+      defenderId: target.id
+    });
+    steps += 1;
+  }
+
+  assert.fail(`expected battle for ${playerId} to resolve within 20 actions`);
+}
 
 test("battle start auto-resolves defender opener before state is returned to the player", () => {
   const room = createRoom("room-auto-open", 1001);
@@ -96,6 +125,7 @@ test("player battle actions are followed by automated defender turns until contr
 });
 
 test("server rejects battle actions sent for non-player-controlled defender units", () => {
+  resetRuntimeObservability();
   const room = createRoom("room-control-check", 1001);
   room.dispatch("player-1", {
     type: "hero.move",
@@ -112,6 +142,27 @@ test("server rejects battle actions sent for non-player-controlled defender unit
   assert.equal(result.ok, false);
   assert.equal(result.reason, "unit_not_player_controlled");
   assert.ok(result.battle);
+  assert.match(
+    buildPrometheusMetricsDocument(),
+    /^veil_action_validation_failures_total\{reason="unit_not_player_controlled",scope="battle"\} 1$/m
+  );
+});
+
+test("completed battles contribute to Prometheus battle duration observations", () => {
+  resetRuntimeObservability();
+  const room = createRoom("room-battle-duration", 1001);
+
+  room.dispatch("player-1", {
+    type: "hero.move",
+    heroId: "hero-1",
+    destination: { x: 5, y: 4 }
+  });
+
+  resolveBattle(room, "player-1");
+
+  const metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_battle_duration_seconds_count 1$/m);
+  assert.match(metrics, /^veil_battle_duration_seconds_bucket\{le="1"\} 1$/m);
 });
 
 test("room supports concurrent neutral battles and returns player-specific battle snapshots", () => {

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -213,6 +213,14 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
       matchmakingStore = dependencies.store;
       base.routeCalls.push("matchmaking");
     },
+    registerPrometheusMetricsMiddleware: (app) => {
+      assert.equal(app, base.expressApp);
+      base.routeCalls.push("prometheus-middleware");
+    },
+    registerPrometheusMetricsRoute: (app) => {
+      assert.equal(app, base.expressApp);
+      base.routeCalls.push("prometheus-route");
+    },
     registerRuntimeObservabilityRoutes: (app) => {
       assert.equal(app, base.expressApp);
       base.routeCalls.push("runtime-observability");
@@ -244,6 +252,8 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
   assert.equal(matchmakingStore, memoryStore);
   assert.equal(lobbyListRooms, listLobbyRooms);
   assert.deepEqual(base.routeCalls, [
+    "prometheus-middleware",
+    "prometheus-route",
     "auth",
     "config-center",
     "config-viewer",
@@ -265,6 +275,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
     /Runtime health available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/auth-readiness/,
     /Runtime diagnostic snapshot available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/diagnostic-snapshot/,
+    /Prometheus metrics available at http:\/\/0\.0\.0\.0:3101\/metrics/,
     /Runtime metrics available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/metrics/,
     /Config center storage: filesystem/,
     /Local in-memory Colyseus presence\/driver enabled/,
@@ -308,6 +319,8 @@ test("dev server logs process-level failures, closes stores, and exits non-zero"
     registerPlayerAccountRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -364,6 +377,8 @@ test("dev server logs uncaught exceptions, closes stores, and exits non-zero", a
     registerPlayerAccountRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -442,6 +457,8 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     registerPlayerAccountRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -466,6 +483,7 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     /Runtime health available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/auth-readiness/,
     /Runtime diagnostic snapshot available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/diagnostic-snapshot/,
+    /Prometheus metrics available at http:\/\/127\.0\.0\.1:3202\/metrics/,
     /Runtime metrics available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/metrics/,
     /Config center storage: filesystem/,
     /Local in-memory Colyseus presence\/driver enabled/,
@@ -505,6 +523,8 @@ test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL 
     registerPlayerAccountRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -588,6 +608,8 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     registerPlayerAccountRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -622,6 +644,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     /Runtime health available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/auth-readiness/,
     /Runtime diagnostic snapshot available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/diagnostic-snapshot/,
+    /Prometheus metrics available at http:\/\/127\.0\.0\.2:3303\/metrics/,
     /Runtime metrics available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/metrics/,
     /Config center storage: mysql/,
     /Local in-memory Colyseus presence\/driver enabled/,

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -5,6 +5,7 @@ import { Server, WebSocketTransport } from "colyseus";
 import type { ClientMessage, ServerMessage } from "../../../packages/shared/src/index";
 import { resetAccountTokenDeliveryState } from "../src/account-token-delivery";
 import { configureRoomSnapshotStore, resetLobbyRoomRegistry, VeilColyseusRoom } from "../src/colyseus-room";
+import { registerPrometheusMetricsMiddleware, registerPrometheusMetricsRoute } from "../src/dev-server";
 import {
   recordMatchmakingRateLimited,
   registerRuntimeObservabilityRoutes,
@@ -22,7 +23,10 @@ async function startObservabilityServer(port: number): Promise<Server> {
   resetRuntimeObservability();
 
   const transport = new WebSocketTransport();
-  registerRuntimeObservabilityRoutes(transport.getExpressApp() as never);
+  const app = transport.getExpressApp() as never;
+  registerPrometheusMetricsMiddleware(app);
+  registerPrometheusMetricsRoute(app);
+  registerRuntimeObservabilityRoutes(app);
   const server = new Server({ transport });
   server.define("veil", VeilColyseusRoom).filterBy(["logicalRoomId"]);
   await server.listen(port, "127.0.0.1");
@@ -220,6 +224,8 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(metricsResponse.status, 200);
   assert.match(metricsResponse.headers.get("content-type") ?? "", /^text\/plain/);
   assert.match(metricsText, /^veil_up 1$/m);
+  assert.match(metricsText, /^veil_active_rooms 1$/m);
+  assert.match(metricsText, /^veil_connected_players 1$/m);
   assert.match(metricsText, /^veil_active_room_count 1$/m);
   assert.match(metricsText, /^veil_connection_count 1$/m);
   assert.match(metricsText, /^veil_connect_messages_total 1$/m);
@@ -229,4 +235,15 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(metricsText, /^veil_auth_account_sessions 0$/m);
   assert.match(metricsText, /^veil_auth_session_checks_total 0$/m);
   assert.match(metricsText, /^veil_matchmaking_rate_limited_total 2$/m);
+
+  const prometheusResponse = await fetch(`http://127.0.0.1:${port}/metrics`);
+  const prometheusText = await prometheusResponse.text();
+
+  assert.equal(prometheusResponse.status, 200);
+  assert.match(prometheusResponse.headers.get("content-type") ?? "", /^text\/plain/);
+  assert.match(prometheusText, /^veil_active_rooms 1$/m);
+  assert.match(prometheusText, /^veil_connected_players 1$/m);
+  assert.match(prometheusText, /^veil_action_validation_failures_total 0$/m);
+  assert.match(prometheusText, /^veil_http_request_duration_seconds_count [1-9]\d*$/m);
+  assert.match(prometheusText, /^veil_battle_duration_seconds_count 0$/m);
 });

--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -1,0 +1,53 @@
+groups:
+  - name: project-veil-prometheus
+    interval: 30s
+    rules:
+      - alert: VeilConnectedPlayersHigh
+        expr: veil_connected_players > 150
+        for: 10m
+        labels:
+          severity: warning
+          service: project-veil-server
+        annotations:
+          summary: Project Veil connected player count is elevated
+          description: veil_connected_players has been above 150 for 10 minutes. Add capacity or shed test traffic before matchmaking and room latency degrade.
+
+      - alert: VeilRoomsHot
+        expr: (veil_connected_players / clamp_min(veil_active_rooms, 1)) > 12
+        for: 10m
+        labels:
+          severity: warning
+          service: project-veil-server
+        annotations:
+          summary: Project Veil room density is high
+          description: Average connected players per active room has stayed above 12 for 10 minutes, which indicates hot shards or uneven room placement.
+
+      - alert: VeilBattleDurationP95High
+        expr: histogram_quantile(0.95, sum(rate(veil_battle_duration_seconds_bucket[30m])) by (le)) > 180
+        for: 15m
+        labels:
+          severity: warning
+          service: project-veil-server
+        annotations:
+          summary: Project Veil battles are taking too long to resolve
+          description: The 95th percentile battle duration has exceeded 180 seconds for 15 minutes, which usually means turn processing stalls or players are stuck in combat loops.
+
+      - alert: VeilActionValidationFailuresHigh
+        expr: sum(rate(veil_action_validation_failures_total[15m])) > 0.5
+        for: 15m
+        labels:
+          severity: warning
+          service: project-veil-server
+        annotations:
+          summary: Project Veil is rejecting gameplay actions at an abnormal rate
+          description: veil_action_validation_failures_total is averaging more than 0.5 rejected actions per second over 15 minutes. Check recent deploys, protocol drift, and client desync.
+
+      - alert: VeilHttpRequestLatencyP95High
+        expr: histogram_quantile(0.95, sum(rate(veil_http_request_duration_seconds_bucket[15m])) by (le)) > 0.75
+        for: 10m
+        labels:
+          severity: warning
+          service: project-veil-server
+        annotations:
+          summary: Project Veil HTTP latency is elevated
+          description: The 95th percentile HTTP request latency has exceeded 750ms for 10 minutes. Inspect runtime saturation, downstream auth/config dependencies, and noisy operators.


### PR DESCRIPTION
## Summary
- add a top-level `/metrics` Prometheus endpoint and request-duration instrumentation in the dev server
- export room, player, battle duration, and action validation Prometheus metrics from runtime observability
- add alerting rules for player load, room density, battle duration, validation failures, and HTTP latency

Closes #788