### PR TITLE
[codex] add player report workflow

### DIFF
--- a/apps/client/admin.html
+++ b/apps/client/admin.html
@@ -31,6 +31,15 @@
         #status { padding: 10px; border-radius: 8px; margin-bottom: 16px; display: none; white-space: pre-wrap; word-break: break-all; }
         .status-error { background: #fee2e2; color: #991b1b; display: block !important; }
         .status-success { background: #dcfce7; color: var(--success); display: block !important; }
+        .report-row { border: 1px solid var(--border); border-radius: 12px; padding: 14px; background: rgba(255, 255, 255, 0.65); display: grid; gap: 10px; }
+        .report-row p { margin: 0; color: var(--muted); }
+        .report-row strong { color: var(--text); }
+        .report-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+        .report-actions button[data-status="dismissed"] { background: #7a6b5d; }
+        .report-actions button[data-status="warned"] { background: #c77b22; }
+        .report-actions button[data-status="banned"] { background: #a32020; }
+        #reportList { display: grid; gap: 12px; }
+        .empty-state { color: var(--muted); }
     </style>
 </head>
 <body>
@@ -67,11 +76,29 @@
             </div>
             <button onclick="modifyResources()">确认修改并强制同步</button>
         </div>
+
+        <div class="card">
+            <h2>举报审核队列</h2>
+            <div class="grid">
+                <div class="form-group">
+                    <label>状态筛选</label>
+                    <select id="reportStatusFilter">
+                        <option value="pending">待处理</option>
+                        <option value="dismissed">已驳回</option>
+                        <option value="warned">已警告</option>
+                        <option value="banned">已封禁</option>
+                    </select>
+                </div>
+            </div>
+            <div id="reportList"><div class="empty-state">正在加载举报队列...</div></div>
+        </div>
     </main>
 
     <script>
         const secretInput = document.getElementById('adminSecret');
         const statusDiv = document.getElementById('status');
+        const reportFilter = document.getElementById('reportStatusFilter');
+        const reportList = document.getElementById('reportList');
 
         function showStatus(msg, type) {
             statusDiv.textContent = msg;
@@ -121,8 +148,80 @@
             }
         }
 
+        function renderReports(items) {
+            if (!items.length) {
+                reportList.innerHTML = '<div class="empty-state">当前筛选下没有举报记录。</div>';
+                return;
+            }
+
+            reportList.innerHTML = items.map((report) => `
+                <div class="report-row">
+                    <div><strong>${report.reportId}</strong> · ${report.reporterId} -> ${report.targetId}</div>
+                    <p>原因：${report.reason} · 房间：${report.roomId} · 状态：${report.status}</p>
+                    <p>创建时间：${report.createdAt}${report.description ? `\n说明：${report.description}` : ''}</p>
+                    ${report.status === 'pending' ? `
+                        <div class="report-actions">
+                            <button data-report-id="${report.reportId}" data-status="dismissed">驳回</button>
+                            <button data-report-id="${report.reportId}" data-status="warned">警告</button>
+                            <button data-report-id="${report.reportId}" data-status="banned">封禁</button>
+                        </div>
+                    ` : ''}
+                </div>
+            `).join('');
+
+            for (const button of reportList.querySelectorAll('[data-report-id]')) {
+                button.addEventListener('click', async () => {
+                    const reportId = button.dataset.reportId;
+                    const status = button.dataset.status;
+                    if (!reportId || !status) {
+                        return;
+                    }
+                    showStatus(`正在处理举报 ${reportId}...`, 'success');
+                    try {
+                        const res = await fetch(`/api/admin/reports/${reportId}/resolve`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'x-veil-admin-secret': secretInput.value
+                            },
+                            body: JSON.stringify({ status })
+                        });
+                        const data = await res.json();
+                        if (!res.ok) {
+                            showStatus(`处理失败：${data.error || res.status}`, 'error');
+                            return;
+                        }
+                        showStatus(`举报 ${reportId} 已更新为 ${data.report.status}`, 'success');
+                        await fetchReports();
+                    } catch (e) {
+                        showStatus(`网络错误: ${e.message}`, 'error');
+                    }
+                });
+            }
+        }
+
+        async function fetchReports() {
+            try {
+                const status = reportFilter.value;
+                const res = await fetch(`/api/admin/reports?status=${encodeURIComponent(status)}`, {
+                    headers: { 'x-veil-admin-secret': secretInput.value }
+                });
+                if (!res.ok) {
+                    const data = await res.json();
+                    reportList.innerHTML = `<div class="empty-state">加载失败：${data.error || res.status}</div>`;
+                    return;
+                }
+                const data = await res.json();
+                renderReports(data.items || []);
+            } catch (e) {
+                reportList.innerHTML = `<div class="empty-state">网络错误：${e.message}</div>`;
+            }
+        }
+
         setInterval(fetchOverview, 5000);
+        reportFilter.addEventListener('change', () => { void fetchReports(); });
         fetchOverview();
+        fetchReports();
     </script>
 </body>
 </html>

--- a/apps/client/src/local-session.ts
+++ b/apps/client/src/local-session.ts
@@ -12,6 +12,7 @@ import type {
   ClientMessage,
   EquipmentType,
   MovementPlan,
+  PlayerReportReason,
   PlayerWorldView,
   RuntimeConfigBundle,
   ServerMessage,
@@ -43,6 +44,17 @@ export interface GameSession {
   claimMine(heroId: string, buildingId: string): Promise<SessionUpdate>;
   endDay(): Promise<SessionUpdate>;
   actInBattle(action: BattleAction): Promise<SessionUpdate>;
+  reportPlayer(input: {
+    targetPlayerId: string;
+    reason: PlayerReportReason;
+    description?: string;
+  }): Promise<{
+    reportId: string;
+    targetPlayerId: string;
+    reason: PlayerReportReason;
+    status: "pending";
+    createdAt: string;
+  }>;
   previewMovement(heroId: string, destination: Vec2): Promise<MovementPlan | null>;
   listReachable(heroId: string): Promise<Vec2[]>;
 }
@@ -475,6 +487,10 @@ class LocalGameSession implements GameSession {
     };
   }
 
+  async reportPlayer(): Promise<never> {
+    throw new Error("reporting_unavailable");
+  }
+
   async previewMovement(heroId: string, destination: Vec2): Promise<MovementPlan | null> {
     return planHeroMovement(this.room.getInternalState(), heroId, destination) ?? null;
   }
@@ -854,6 +870,37 @@ class RemoteGameSession implements GameSession {
     return update;
   }
 
+  async reportPlayer(input: {
+    targetPlayerId: string;
+    reason: PlayerReportReason;
+    description?: string;
+  }): Promise<{
+    reportId: string;
+    targetPlayerId: string;
+    reason: PlayerReportReason;
+    status: "pending";
+    createdAt: string;
+  }> {
+    const response = await this.send<Extract<ServerMessage, { type: "report.player" }>>(
+      {
+        type: "report.player",
+        requestId: this.nextRequestId(),
+        targetPlayerId: input.targetPlayerId,
+        reason: input.reason,
+        ...(input.description?.trim() ? { description: input.description.trim() } : {})
+      },
+      "report.player"
+    );
+
+    return {
+      reportId: response.reportId,
+      targetPlayerId: response.targetPlayerId,
+      reason: response.reason,
+      status: "pending",
+      createdAt: response.createdAt
+    };
+  }
+
   async previewMovement(heroId: string, destination: Vec2): Promise<MovementPlan | null> {
     const response = await this.send<Extract<ServerMessage, { type: "world.preview" }>>(
       {
@@ -1106,6 +1153,20 @@ class RecoverableRemoteGameSession implements GameSession {
 
   async actInBattle(action: BattleAction): Promise<SessionUpdate> {
     return this.runWithSession((session) => session.actInBattle(action));
+  }
+
+  async reportPlayer(input: {
+    targetPlayerId: string;
+    reason: PlayerReportReason;
+    description?: string;
+  }): Promise<{
+    reportId: string;
+    targetPlayerId: string;
+    reason: PlayerReportReason;
+    status: "pending";
+    createdAt: string;
+  }> {
+    return this.runWithSession((session) => session.reportPlayer(input));
   }
 
   async previewMovement(heroId: string, destination: Vec2): Promise<MovementPlan | null> {

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -28,6 +28,7 @@ import {
   type BattleState,
   type EquipmentType,
   type MovementPlan,
+  type PlayerReportReason,
   type PlayerTileView,
   type PlayerWorldView,
   type RuntimeDiagnosticsConnectionStatus,
@@ -204,6 +205,14 @@ interface LobbyViewState {
   status: string;
 }
 
+interface BattleReportComposerState {
+  open: boolean;
+  targetPlayerId: string | null;
+  reason: PlayerReportReason;
+  description: string;
+  submitting: boolean;
+}
+
 interface AppState {
   world: PlayerWorldView;
   battle: BattleState | null;
@@ -232,6 +241,7 @@ interface AppState {
   previewPlan: MovementPlan | null;
   reachableTiles: Array<{ x: number; y: number }>;
   selectedBattleTargetId: string | null;
+  battleReport: BattleReportComposerState;
   feedbackTone: "idle" | "move" | "battle" | "loot";
   animatedPath: Array<{ x: number; y: number }>;
   animatedPathIndex: number;
@@ -350,6 +360,13 @@ const state: AppState = {
   previewPlan: null,
   reachableTiles: [],
   selectedBattleTargetId: null,
+  battleReport: {
+    open: false,
+    targetPlayerId: null,
+    reason: "afk",
+    description: "",
+    submitting: false
+  },
   feedbackTone: "idle",
   animatedPath: [],
   animatedPathIndex: -1,
@@ -1756,6 +1773,40 @@ function battleShortcutContext():
   };
 }
 
+function resolveBattleReportTargetPlayerId(
+  battle: BattleState | null = state.battle,
+  world: PlayerWorldView = state.world
+): string | null {
+  if (!battle?.worldHeroId || !battle.defenderHeroId) {
+    return null;
+  }
+
+  const playerCamp = controlledBattleCamp(battle, world);
+  if (!playerCamp) {
+    return null;
+  }
+
+  const heroes = [...world.ownHeroes, ...world.visibleHeroes];
+  const attacker = heroes.find((hero) => hero.id === battle.worldHeroId);
+  const defender = heroes.find((hero) => hero.id === battle.defenderHeroId);
+  if (!attacker?.playerId || !defender?.playerId) {
+    return null;
+  }
+
+  return playerCamp === "attacker" ? defender.playerId : attacker.playerId;
+}
+
+function battleReportReasonLabel(reason: PlayerReportReason): string {
+  switch (reason) {
+    case "cheating":
+      return "作弊";
+    case "harassment":
+      return "骚扰";
+    case "afk":
+      return "挂机";
+  }
+}
+
 function cycleBattleTarget(offset: number): void {
   const context = battleShortcutContext();
   if (!context || context.enemies.length === 0) {
@@ -2915,6 +2966,10 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
   state.selectedHeroId = update.world.ownHeroes[0]?.id ?? state.selectedHeroId;
   if (!update.battle) {
     state.selectedBattleTargetId = null;
+    state.battleReport.open = false;
+    state.battleReport.targetPlayerId = null;
+    state.battleReport.description = "";
+    state.battleReport.submitting = false;
   } else {
     const playerCamp = controlledBattleCamp(update.battle, update.world);
     const enemyCamp = opposingBattleCamp(playerCamp);
@@ -2922,6 +2977,7 @@ function applyUpdate(update: SessionUpdate, source: TimelineEntry["source"] = "l
     if (!state.selectedBattleTargetId || !enemies.some((unit) => unit.id === state.selectedBattleTargetId)) {
       state.selectedBattleTargetId = enemies[0]?.id ?? null;
     }
+    state.battleReport.targetPlayerId = resolveBattleReportTargetPlayerId(update.battle, update.world);
   }
   appendLog(update);
   pushTimeline(buildTimelineEntries(update, source));
@@ -3352,6 +3408,55 @@ async function onBattleAction(action: BattleAction): Promise<void> {
   state.pendingBattleAction = action;
   const session = await getSession();
   applyUpdate(await session.actInBattle(action));
+}
+
+function toggleBattleReportComposer(open: boolean): void {
+  state.battleReport.open = open;
+  state.battleReport.targetPlayerId = resolveBattleReportTargetPlayerId();
+  if (!open) {
+    state.battleReport.description = "";
+  }
+  render();
+}
+
+async function submitBattleReport(): Promise<void> {
+  const targetPlayerId = resolveBattleReportTargetPlayerId();
+  if (!targetPlayerId) {
+    openBattleModal("举报不可用", "当前只有与其他玩家交战时才能提交举报。");
+    return;
+  }
+
+  state.battleReport.submitting = true;
+  render();
+
+  try {
+    const session = await getSession();
+    const report = await session.reportPlayer({
+      targetPlayerId,
+      reason: state.battleReport.reason,
+      description: state.battleReport.description
+    });
+    state.battleReport.open = false;
+    state.battleReport.description = "";
+    state.battleReport.submitting = false;
+    openBattleModal(
+      "举报已提交",
+      `已提交对玩家 ${report.targetPlayerId} 的${battleReportReasonLabel(report.reason)}举报，管理员审核队列已收到该记录。`
+    );
+    render();
+  } catch (error) {
+    state.battleReport.submitting = false;
+    const message =
+      error instanceof Error && error.message === "duplicate_player_report"
+        ? "同一房间内你已经举报过这名玩家。"
+        : error instanceof Error && error.message === "report_target_unavailable"
+          ? "当前无法定位这个举报目标，请在战斗进行中重试。"
+          : error instanceof Error && error.message === "reporting_unavailable"
+            ? "当前服务器未启用举报存储，暂时无法提交。"
+            : "举报提交失败，请稍后再试。";
+    openBattleModal("举报提交失败", message);
+    render();
+  }
 }
 
 async function triggerBattleAttackShortcut(): Promise<void> {
@@ -3865,6 +3970,7 @@ function renderBattleActions(): string {
   const enemyCamp = opposingBattleCamp(playerCamp);
   const enemies = Object.values(state.battle.units).filter((unit) => unit.camp === enemyCamp && unit.count > 0);
   const selectedTarget = enemies.find((enemy) => enemy.id === state.selectedBattleTargetId) ?? enemies[0];
+  const reportTargetPlayerId = resolveBattleReportTargetPlayerId();
   const skillButtons = (active.skills ?? [])
     .filter((skill) => skill.kind === "active")
     .map((skill) => {
@@ -3900,6 +4006,50 @@ function renderBattleActions(): string {
       ${skillButtons}
       <button data-testid="battle-wait" data-battle-action="wait" data-unit="${active.id}">等待</button>
       <button data-testid="battle-defend" data-battle-action="defend" data-unit="${active.id}" ${active.defending ? "disabled" : ""}>防御</button>
+      <button
+        type="button"
+        data-battle-report-toggle="${state.battleReport.open ? "close" : "open"}"
+        ${reportTargetPlayerId ? "" : "disabled"}
+      >
+        ${reportTargetPlayerId ? `举报玩家 ${escapeHtml(reportTargetPlayerId)}` : "当前无法举报"}
+      </button>
+      ${
+        state.battleReport.open && reportTargetPlayerId
+          ? `
+        <div class="battle-report-form" data-testid="battle-report-form">
+          <div class="battle-report-head">
+            <strong>举报对手 ${escapeHtml(reportTargetPlayerId)}</strong>
+            <span>同一房间同一目标仅允许提交一次。</span>
+          </div>
+          <label>
+            原因
+            <select data-battle-report-reason ${state.battleReport.submitting ? "disabled" : ""}>
+              ${(["afk", "harassment", "cheating"] as const)
+                .map(
+                  (reason) =>
+                    `<option value="${reason}" ${state.battleReport.reason === reason ? "selected" : ""}>${battleReportReasonLabel(reason)}</option>`
+                )
+                .join("")}
+            </select>
+          </label>
+          <label>
+            说明
+            <textarea
+              data-battle-report-description
+              maxlength="512"
+              placeholder="补充时间点、行为描述或可复现线索（可选）"
+              ${state.battleReport.submitting ? "disabled" : ""}
+            >${escapeHtml(state.battleReport.description)}</textarea>
+          </label>
+          <div class="battle-report-actions">
+            <button type="button" data-battle-report-submit ${state.battleReport.submitting ? "disabled" : ""}>
+              ${state.battleReport.submitting ? "提交中..." : "提交举报"}
+            </button>
+            <button type="button" data-battle-report-toggle="close" ${state.battleReport.submitting ? "disabled" : ""}>取消</button>
+          </div>
+        </div>`
+          : ""
+      }
     </div>
   `;
 }
@@ -4940,6 +5090,33 @@ function render(): void {
         type: "battle.defend",
         unitId: actionButton.dataset.unit!
       });
+    });
+  }
+
+  for (const toggleButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-battle-report-toggle]"))) {
+    toggleButton.addEventListener("click", () => {
+      toggleBattleReportComposer(toggleButton.dataset.battleReportToggle === "open");
+    });
+  }
+
+  for (const reasonSelect of Array.from(root.querySelectorAll<HTMLSelectElement>("[data-battle-report-reason]"))) {
+    reasonSelect.addEventListener("change", () => {
+      const reason = reasonSelect.value;
+      if (reason === "cheating" || reason === "harassment" || reason === "afk") {
+        state.battleReport.reason = reason;
+      }
+    });
+  }
+
+  for (const descriptionInput of Array.from(root.querySelectorAll<HTMLTextAreaElement>("[data-battle-report-description]"))) {
+    descriptionInput.addEventListener("input", () => {
+      state.battleReport.description = descriptionInput.value;
+    });
+  }
+
+  for (const submitButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-battle-report-submit]"))) {
+    submitButton.addEventListener("click", () => {
+      void submitBattleReport();
     });
   }
 

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -1777,6 +1777,55 @@ h1 {
   opacity: 0.45;
 }
 
+.battle-report-form {
+  flex: 1 1 100%;
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 16px;
+  background: rgba(71, 28, 19, 0.08);
+  border: 1px solid rgba(154, 68, 38, 0.24);
+}
+
+.battle-report-head {
+  display: grid;
+  gap: 4px;
+}
+
+.battle-report-head span {
+  font-size: 13px;
+  color: #6c4c42;
+}
+
+.battle-report-form label {
+  display: grid;
+  gap: 6px;
+  font-size: 14px;
+  color: #52362b;
+}
+
+.battle-report-form select,
+.battle-report-form textarea {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(82, 54, 43, 0.18);
+  background: rgba(255, 251, 246, 0.94);
+  color: #2b1e19;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.battle-report-form textarea {
+  min-height: 88px;
+  resize: vertical;
+}
+
+.battle-report-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
 .room-status-panel,
 .battle-settlement-panel {
   margin-top: 14px;

--- a/apps/client/test/local-session.test.ts
+++ b/apps/client/test/local-session.test.ts
@@ -484,6 +484,54 @@ test("remote game sessions clear persisted replay and reconnection token after a
   }
 });
 
+test("remote game sessions send player reports through the websocket protocol", { concurrency: false }, async () => {
+  const storage = createMemoryStorage();
+  const restoreWindow = installWindow(storage);
+  const room = new FakeRoom("token-report");
+
+  try {
+    const session = localSessionTestHooks.createRemoteGameSession(
+      room as unknown as ColyseusRoom,
+      "room-alpha",
+      "player-1"
+    );
+    const reportPromise = session.reportPlayer({
+      targetPlayerId: "player-2",
+      reason: "harassment",
+      description: "Repeated abuse in battle chat"
+    });
+
+    assert.equal(room.sent[0]?.type, "report.player");
+    assert.deepEqual(room.sent[0]?.payload, {
+      type: "report.player",
+      requestId: "req-1",
+      targetPlayerId: "player-2",
+      reason: "harassment",
+      description: "Repeated abuse in battle chat"
+    });
+
+    room.emitMessage({
+      type: "report.player",
+      requestId: "req-1",
+      reportId: "report-1",
+      targetPlayerId: "player-2",
+      reason: "harassment",
+      status: "pending",
+      createdAt: "2026-04-03T12:00:00.000Z"
+    });
+
+    assert.deepEqual(await reportPromise, {
+      reportId: "report-1",
+      targetPlayerId: "player-2",
+      reason: "harassment",
+      status: "pending",
+      createdAt: "2026-04-03T12:00:00.000Z"
+    });
+  } finally {
+    restoreWindow();
+  }
+});
+
 test("recoverable remote sessions retry after room loss and replay the recovered snapshot", { concurrency: false }, async () => {
   const storage = createMemoryStorage([
     [getReconnectionStorageKey("room-alpha", "player-1"), "stale-token"] as const

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -13,7 +13,7 @@ export interface ResourceLedger {
 }
 
 export type FogState = "hidden" | "explored" | "visible";
-export type TerrainType = "grass" | "dirt" | "sand" | "water" | "unknown";
+export type TerrainType = "grass" | "dirt" | "sand" | "water" | "swamp" | "unknown";
 export type OccupantKind = "hero" | "neutral" | "building";
 export type BuildingKind = "recruitment_post" | "attribute_shrine" | "resource_mine" | "watchtower";
 
@@ -59,6 +59,15 @@ export interface HeroLoadout {
 }
 
 export type EquipmentRarity = "common" | "rare" | "epic";
+export type PlayerReportReason = "cheating" | "harassment" | "afk";
+export type PlayerReportStatus = "pending" | "dismissed" | "warned" | "banned";
+export interface PlayerReportReceipt {
+  reportId: string;
+  targetPlayerId: string;
+  reason: PlayerReportReason;
+  status: PlayerReportStatus;
+  createdAt: string;
+}
 
 export type HeroStatBonus = Pick<HeroStats, "attack" | "defense" | "power" | "knowledge">;
 
@@ -562,6 +571,13 @@ type ClientMessage =
       type: "world.reachable";
       requestId: string;
       heroId: string;
+    }
+  | {
+      type: "report.player";
+      requestId: string;
+      targetPlayerId: string;
+      reason: PlayerReportReason;
+      description?: string;
     };
 
 interface SessionStatePayload {
@@ -589,6 +605,15 @@ type ServerMessage =
       type: "error";
       requestId: string;
       reason: string;
+    }
+  | {
+      type: "report.player";
+      requestId: string;
+      reportId: string;
+      targetPlayerId: string;
+      reason: PlayerReportReason;
+      status: PlayerReportStatus;
+      createdAt: string;
     };
 
 const RECONNECTION_TOKEN_PREFIX = "project-veil:cocos:reconnection";
@@ -1201,6 +1226,27 @@ class RemoteGameSession {
     return response.reachableTiles;
   }
 
+  async reportPlayer(targetPlayerId: string, reason: PlayerReportReason, description?: string): Promise<PlayerReportReceipt> {
+    const response = await this.send<Extract<ServerMessage, { type: "report.player" }>>(
+      {
+        type: "report.player",
+        requestId: this.nextRequestId(),
+        targetPlayerId,
+        reason,
+        ...(description?.trim() ? { description: description.trim() } : {})
+      },
+      "report.player"
+    );
+
+    return {
+      reportId: response.reportId,
+      targetPlayerId: response.targetPlayerId,
+      reason: response.reason,
+      status: response.status,
+      createdAt: response.createdAt
+    };
+  }
+
   private persistReconnectionToken(): void {
     if (this.room.reconnectionToken) {
       writeReconnectionToken(this.roomId, this.playerId, this.room.reconnectionToken);
@@ -1365,6 +1411,10 @@ class RecoverableRemoteGameSession {
     return this.runWithSession((session) => session.endDay());
   }
 
+  async reportPlayer(targetPlayerId: string, reason: PlayerReportReason, description?: string): Promise<PlayerReportReceipt> {
+    return this.runWithSession((session) => session.reportPlayer(targetPlayerId, reason, description));
+  }
+
   async actInBattle(action: BattleAction): Promise<SessionUpdate> {
     return this.runWithSession((session) => session.actInBattle(action));
   }
@@ -1505,6 +1555,10 @@ export class VeilCocosSession {
 
   async endDay(): Promise<SessionUpdate> {
     return this.remoteSession.endDay();
+  }
+
+  async reportPlayer(targetPlayerId: string, reason: PlayerReportReason, description?: string): Promise<PlayerReportReceipt> {
+    return this.remoteSession.reportPlayer(targetPlayerId, reason, description);
   }
 
   async actInBattle(action: BattleAction): Promise<SessionUpdate> {

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -5,7 +5,7 @@ import {
   type EquipmentType,
   getLatestUnlockedAchievement
 } from "./project-shared/index.ts";
-import type { SessionUpdate } from "./VeilCocosSession.ts";
+import type { PlayerReportReason, SessionUpdate } from "./VeilCocosSession.ts";
 import type { CocosPlayerAccountProfile } from "./cocos-lobby.ts";
 import { getPixelSpriteAssets, loadPixelSpriteAssets, type PixelSpriteLoadStatus } from "./cocos-pixel-sprites.ts";
 import {
@@ -65,6 +65,7 @@ const HERO_PROGRESS_PREFIX = "HudHeroProgress";
 const SKILL_BUTTON_PREFIX = "HudSkillButton";
 const EQUIPMENT_BUTTON_PREFIX = "HudEquipButton";
 const ACHIEVEMENT_NOTICE_NODE_NAME = "HudAchievementNotice";
+const REPORT_DIALOG_NODE_NAME = "HudReportDialog";
 
 interface HudActionButtonState {
   name: string;
@@ -180,6 +181,13 @@ export interface VeilHudRenderState {
     title: string;
     detail: string;
   } | null;
+  reporting: {
+    open: boolean;
+    available: boolean;
+    targetLabel: string | null;
+    status: string | null;
+    submitting: boolean;
+  };
   presentation: {
     audio: CocosAudioRuntimeState;
     pixelAssets: PixelSpriteLoadStatus;
@@ -212,6 +220,9 @@ export interface VeilHudPanelOptions {
   onRefresh?: () => void;
   onToggleInventory?: () => void;
   onToggleAchievements?: () => void;
+  onToggleReport?: () => void;
+  onSubmitReport?: (reason: PlayerReportReason) => void;
+  onCancelReport?: () => void;
   onLearnSkill?: (skillId: string) => void;
   onEquipItem?: (slot: EquipmentType, equipmentId: string) => void;
   onUnequipItem?: (slot: EquipmentType) => void;
@@ -314,6 +325,9 @@ export class VeilHudPanel extends Component {
   private onRefresh: (() => void) | undefined;
   private onToggleInventory: (() => void) | undefined;
   private onToggleAchievements: (() => void) | undefined;
+  private onToggleReport: (() => void) | undefined;
+  private onSubmitReport: ((reason: PlayerReportReason) => void) | undefined;
+  private onCancelReport: (() => void) | undefined;
   private onLearnSkill: ((skillId: string) => void) | undefined;
   private onEquipItem: ((slot: EquipmentType, equipmentId: string) => void) | undefined;
   private onUnequipItem: ((slot: EquipmentType) => void) | undefined;
@@ -326,6 +340,9 @@ export class VeilHudPanel extends Component {
     this.onRefresh = options.onRefresh;
     this.onToggleInventory = options.onToggleInventory;
     this.onToggleAchievements = options.onToggleAchievements;
+    this.onToggleReport = options.onToggleReport;
+    this.onSubmitReport = options.onSubmitReport;
+    this.onCancelReport = options.onCancelReport;
     this.onLearnSkill = options.onLearnSkill;
     this.onEquipItem = options.onEquipItem;
     this.onUnequipItem = options.onUnequipItem;
@@ -544,6 +561,7 @@ export class VeilHudPanel extends Component {
 
     this.renderStatusBadge(`${CARD_PREFIX}-status`, statusBadge);
     this.renderAchievementNotice(state.achievementNotice);
+    this.renderReportDialog(state.reporting);
 
     const showDebug = false;
     if (showDebug) {
@@ -607,9 +625,27 @@ export class VeilHudPanel extends Component {
       { nodeName: "HudRefresh", debugLabel: "refresh", callback: this.onRefresh ?? null },
       { nodeName: "HudInventory", debugLabel: "inventory", callback: this.onToggleInventory ?? null },
       { nodeName: "HudAchievements", debugLabel: "achievements", callback: this.onToggleAchievements ?? null },
+      { nodeName: "HudReportPlayer", debugLabel: "report-player", callback: this.onToggleReport ?? null },
       { nodeName: "HudEndDay", debugLabel: "end-day", callback: this.onEndDay ?? null },
       { nodeName: "HudReturnLobby", debugLabel: "return-lobby", callback: this.onReturnLobby ?? null }
     ];
+
+    const reportDialogActions: Array<{ nodeName: string; debugLabel: string; callback: (() => void) | null }> = [
+      { nodeName: "HudReportReason-cheating", debugLabel: "report-reason:cheating", callback: this.onSubmitReport ? () => this.onSubmitReport?.("cheating") : null },
+      { nodeName: "HudReportReason-harassment", debugLabel: "report-reason:harassment", callback: this.onSubmitReport ? () => this.onSubmitReport?.("harassment") : null },
+      { nodeName: "HudReportReason-afk", debugLabel: "report-reason:afk", callback: this.onSubmitReport ? () => this.onSubmitReport?.("afk") : null },
+      { nodeName: "HudReportCancel", debugLabel: "report-cancel", callback: this.onCancelReport ?? null }
+    ];
+    const reportDialogNode = this.node.getChildByName(REPORT_DIALOG_NODE_NAME);
+    for (const action of reportDialogActions) {
+      const node = reportDialogNode?.getChildByName(action.nodeName) ?? null;
+      if (this.pointInNode(localX, localY, node)) {
+        return {
+          debugLabel: action.debugLabel,
+          callback: action.callback
+        };
+      }
+    }
 
     const actionsNode = this.node.getChildByName(ACTIONS_NODE_NAME);
     for (const action of chromeActions) {
@@ -1438,6 +1474,7 @@ export class VeilHudPanel extends Component {
       HEADER_ICON_NODE_NAME,
       WATERMARK_NODE_NAME,
       ACTIONS_NODE_NAME,
+      REPORT_DIALOG_NODE_NAME,
       `${CARD_PREFIX}-title`,
       `${CARD_PREFIX}-resources`,
       `${CARD_PREFIX}-hero`,
@@ -1466,6 +1503,7 @@ export class VeilHudPanel extends Component {
     this.ensureActionButton(actionsNode, "HudRefresh", "刷新状态");
     this.ensureActionButton(actionsNode, "HudInventory", "装备背包");
     this.ensureActionButton(actionsNode, "HudAchievements", "战报中心");
+    this.ensureActionButton(actionsNode, "HudReportPlayer", "举报玩家");
     this.ensureActionButton(actionsNode, "HudEndDay", "推进一天");
     this.ensureActionButton(actionsNode, "HudReturnLobby", "返回大厅");
   }
@@ -1479,7 +1517,7 @@ export class VeilHudPanel extends Component {
     }
 
     const actionsTransform = actionsNode.getComponent(UITransform) ?? actionsNode.addComponent(UITransform);
-    actionsTransform.setContentSize(Math.max(164, transform.width - 28), 206);
+    actionsTransform.setContentSize(Math.max(164, transform.width - 28), 246);
     actionsNode.setPosition(0, transform.height / 2 - 118, 1);
 
     const buttons: HudActionButtonState[] = [
@@ -1487,6 +1525,7 @@ export class VeilHudPanel extends Component {
       { name: "HudRefresh", label: "刷新状态", callback: this.onRefresh ?? null },
       { name: "HudInventory", label: "装备背包", callback: this.onToggleInventory ?? null },
       { name: "HudAchievements", label: "战报中心", callback: this.onToggleAchievements ?? null },
+      { name: "HudReportPlayer", label: "举报玩家", callback: this.onToggleReport ?? null },
       { name: "HudEndDay", label: "推进一天", callback: this.onEndDay ?? null },
       { name: "HudReturnLobby", label: "返回大厅", callback: this.onReturnLobby ?? null }
     ];
@@ -1589,5 +1628,98 @@ export class VeilHudPanel extends Component {
     assignUiLayer(labelNode);
     const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
     label.string = labelText;
+  }
+
+  private renderReportDialog(state: VeilHudRenderState["reporting"]): void {
+    let dialogNode = this.node.getChildByName(REPORT_DIALOG_NODE_NAME);
+    if (!state.open) {
+      if (dialogNode) {
+        dialogNode.active = false;
+      }
+      return;
+    }
+
+    if (!dialogNode) {
+      dialogNode = new Node(REPORT_DIALOG_NODE_NAME);
+      dialogNode.parent = this.node;
+    }
+    assignUiLayer(dialogNode);
+    dialogNode.active = true;
+
+    const rootTransform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const dialogTransform = dialogNode.getComponent(UITransform) ?? dialogNode.addComponent(UITransform);
+    const width = Math.max(176, rootTransform.width - 38);
+    const height = 188;
+    dialogTransform.setContentSize(width, height);
+    dialogNode.setPosition(0, 8, 6);
+
+    const graphics = dialogNode.getComponent(Graphics) ?? dialogNode.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = new Color(26, 34, 48, 238);
+    graphics.strokeColor = new Color(248, 229, 197, 148);
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 16);
+    graphics.fill();
+    graphics.stroke();
+
+    const titleNode = dialogNode.getChildByName("Label") ?? new Node("Label");
+    titleNode.parent = dialogNode;
+    assignUiLayer(titleNode);
+    const titleTransform = titleNode.getComponent(UITransform) ?? titleNode.addComponent(UITransform);
+    titleTransform.setContentSize(width - 24, 62);
+    titleNode.setPosition(0, 50, 1);
+    const title = titleNode.getComponent(Label) ?? titleNode.addComponent(Label);
+    title.string = `举报玩家\n${state.targetLabel ?? "当前没有可举报目标"}${state.status ? `\n${state.status}` : state.submitting ? "\n正在提交举报..." : ""}`;
+    title.fontSize = 13;
+    title.lineHeight = 16;
+    title.horizontalAlign = H_ALIGN_CENTER;
+    title.verticalAlign = V_ALIGN_MIDDLE;
+    title.overflow = OVERFLOW_RESIZE_HEIGHT;
+    title.enableWrapText = true;
+    title.color = new Color(248, 244, 233, 255);
+
+    const buttons: Array<{ name: string; label: string; enabled: boolean }> = [
+      { name: "HudReportReason-cheating", label: "作弊", enabled: state.available && !state.submitting },
+      { name: "HudReportReason-harassment", label: "骚扰", enabled: state.available && !state.submitting },
+      { name: "HudReportReason-afk", label: "挂机", enabled: state.available && !state.submitting },
+      { name: "HudReportCancel", label: "取消", enabled: !state.submitting }
+    ];
+
+    buttons.forEach((button, index) => {
+      this.renderDialogButton(dialogNode!, button.name, button.label, 14 - index * 30, button.enabled);
+    });
+  }
+
+  private renderDialogButton(parent: Node, name: string, labelText: string, y: number, enabled: boolean): void {
+    const buttonNode = parent.getChildByName(name) ?? new Node(name);
+    buttonNode.parent = parent;
+    assignUiLayer(buttonNode);
+    const transform = buttonNode.getComponent(UITransform) ?? buttonNode.addComponent(UITransform);
+    transform.setContentSize(136, 24);
+    buttonNode.setPosition(0, y, 1);
+
+    const graphics = buttonNode.getComponent(Graphics) ?? buttonNode.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = enabled ? new Color(91, 70, 54, 236) : new Color(70, 74, 82, 168);
+    graphics.strokeColor = enabled ? new Color(248, 224, 180, 124) : new Color(214, 220, 228, 76);
+    graphics.lineWidth = 2;
+    graphics.roundRect(-68, -12, 136, 24, 8);
+    graphics.fill();
+    graphics.stroke();
+
+    const labelNode = buttonNode.getChildByName("Label") ?? new Node("Label");
+    labelNode.parent = buttonNode;
+    assignUiLayer(labelNode);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(120, 18);
+    labelNode.setPosition(0, 0, 0.1);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = labelText;
+    label.fontSize = 12;
+    label.lineHeight = 14;
+    label.horizontalAlign = H_ALIGN_CENTER;
+    label.verticalAlign = V_ALIGN_MIDDLE;
+    label.enableWrapText = false;
+    label.color = enabled ? new Color(248, 244, 233, 255) : new Color(199, 204, 212, 255);
   }
 }

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -2,6 +2,7 @@ import { _decorator, Camera, Canvas, Color, Component, EventMouse, EventTouch, G
 import { getEquipmentDefinition, type EquipmentType } from "./project-shared/index.ts";
 import {
   type BattleAction,
+  type PlayerReportReason,
   VeilCocosSession,
   type VeilCocosSessionOptions,
   type ConnectionEvent,
@@ -300,6 +301,9 @@ export class VeilRoot extends Component {
   private stopRuntimeMemoryWarnings: (() => void) | null = null;
   private battlePresentation = createCocosBattlePresentationController();
   private lastBattleSettlementSnapshot: BattleSettlementSnapshot | null = null;
+  private reportDialogOpen = false;
+  private reportSubmitting = false;
+  private reportStatusMessage: string | null = null;
 
   onLoad(): void {
     this.audioRuntime.dispose();
@@ -723,6 +727,15 @@ export class VeilRoot extends Component {
       onToggleAchievements: () => {
         void this.openGameplayBattleReportCenter();
       },
+      onToggleReport: () => {
+        this.toggleReportDialog();
+      },
+      onSubmitReport: (reason) => {
+        void this.submitPlayerReport(reason);
+      },
+      onCancelReport: () => {
+        this.closeReportDialog();
+      },
       onLearnSkill: (skillId) => {
         void this.learnHeroSkill(skillId);
       },
@@ -1095,6 +1108,13 @@ export class VeilRoot extends Component {
       achievementNotice: this.achievementNotice
         ? { title: this.achievementNotice.title, detail: this.achievementNotice.detail }
         : null,
+      reporting: {
+        open: this.reportDialogOpen,
+        available: Boolean(this.resolveReportTarget()),
+        targetLabel: this.resolveReportTarget()?.name ?? null,
+        status: this.reportStatusMessage,
+        submitting: this.reportSubmitting
+      },
       presentation: this.buildHudPresentationState()
     });
     this.mapBoard?.render(this.lastUpdate);
@@ -1356,6 +1376,78 @@ export class VeilRoot extends Component {
     this.renderView();
   }
 
+  private resolveReportTarget(): { playerId: string; name: string } | null {
+    const target = this.lastUpdate?.world.visibleHeroes.find((hero) => hero.playerId !== this.playerId) ?? null;
+    return target ? { playerId: target.playerId, name: `${target.name} · ${target.playerId}` } : null;
+  }
+
+  private toggleReportDialog(): void {
+    if (this.reportSubmitting) {
+      return;
+    }
+
+    const target = this.resolveReportTarget();
+    if (!target) {
+      this.reportDialogOpen = false;
+      this.reportStatusMessage = "当前没有可举报的对手。";
+      this.predictionStatus = this.reportStatusMessage;
+      this.renderView();
+      return;
+    }
+
+    this.reportDialogOpen = !this.reportDialogOpen;
+    this.reportStatusMessage = this.reportDialogOpen ? `目标 ${target.name} · ${target.playerId}` : null;
+    this.renderView();
+  }
+
+  private closeReportDialog(): void {
+    if (this.reportSubmitting) {
+      return;
+    }
+
+    this.reportDialogOpen = false;
+    this.reportStatusMessage = null;
+    this.renderView();
+  }
+
+  private async submitPlayerReport(reason: PlayerReportReason): Promise<void> {
+    const target = this.resolveReportTarget();
+    if (!this.session || !target) {
+      this.reportDialogOpen = false;
+      this.reportStatusMessage = "当前没有可举报的对手。";
+      this.renderView();
+      return;
+    }
+
+    this.reportSubmitting = true;
+    this.reportStatusMessage = `正在举报 ${target.name}...`;
+    this.renderView();
+
+    try {
+      await this.session.reportPlayer(target.playerId, reason);
+      this.reportDialogOpen = false;
+      this.reportStatusMessage = `已提交举报：${target.name}`;
+      this.predictionStatus = "举报已提交，等待管理员审核。";
+      this.pushLog(`已举报 ${target.name}：${reason}`);
+    } catch (error) {
+      this.reportStatusMessage = error instanceof Error
+        ? error.message === "duplicate_player_report"
+          ? "同一场对局中已举报过该玩家。"
+          : error.message === "report_target_unavailable"
+            ? "目标玩家已不在当前对局中。"
+            : error.message === "reporting_unavailable"
+              ? "当前服务器未启用举报存储。"
+              : error.message === "report_submit_failed"
+                ? "举报提交失败。"
+            : "举报提交失败。"
+        : "举报提交失败。";
+      this.predictionStatus = this.reportStatusMessage;
+    } finally {
+      this.reportSubmitting = false;
+      this.renderView();
+    }
+  }
+
   private async openGameplayBattleReportCenter(): Promise<void> {
     this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
       type: "section.selected",
@@ -1554,6 +1646,15 @@ export class VeilRoot extends Component {
         },
         onToggleAchievements: () => {
           void this.openGameplayBattleReportCenter();
+        },
+        onToggleReport: () => {
+          this.toggleReportDialog();
+        },
+        onSubmitReport: (reason) => {
+          void this.submitPlayerReport(reason);
+        },
+        onCancelReport: () => {
+          this.closeReportDialog();
         },
         onLearnSkill: (skillId) => {
           void this.learnHeroSkill(skillId);

--- a/apps/cocos-client/assets/scripts/project-shared/protocol.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/protocol.ts
@@ -10,6 +10,9 @@ export interface SessionStatePayload {
   reason?: string;
 }
 
+export type PlayerReportReason = "cheating" | "harassment" | "afk";
+export type PlayerReportStatus = "pending" | "dismissed" | "warned" | "banned";
+
 export type ClientMessage =
   | {
       type: "connect";
@@ -40,6 +43,13 @@ export type ClientMessage =
       type: "world.reachable";
       requestId: string;
       heroId: string;
+    }
+  | {
+      type: "report.player";
+      requestId: string;
+      targetPlayerId: string;
+      reason: PlayerReportReason;
+      description?: string;
     };
 
 export type ServerMessage =
@@ -63,4 +73,13 @@ export type ServerMessage =
       type: "error";
       requestId: string;
       reason: string;
+    }
+  | {
+      type: "report.player";
+      requestId: string;
+      reportId: string;
+      targetPlayerId: string;
+      reason: PlayerReportReason;
+      status: PlayerReportStatus;
+      createdAt: string;
     };

--- a/apps/cocos-client/test/cocos-report-session.test.ts
+++ b/apps/cocos-client/test/cocos-report-session.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import {
+  resetVeilCocosSessionRuntimeForTests,
+  setVeilCocosSessionRuntimeForTests,
+  VeilCocosSession
+} from "../assets/scripts/VeilCocosSession.ts";
+import {
+  createMemoryStorage,
+  createReportReply,
+  createSdkLoader,
+  createSessionUpdate,
+  FakeColyseusRoom
+} from "./helpers/cocos-session-fixtures.ts";
+
+afterEach(() => {
+  resetVeilCocosSessionRuntimeForTests();
+});
+
+test("VeilCocosSession sends player reports through the websocket protocol", async () => {
+  const storage = createMemoryStorage();
+  const room = new FakeColyseusRoom(
+    [createSessionUpdate(2)],
+    "report-token",
+    {
+      "report.player": [
+        createReportReply({
+          reportId: "report-1",
+          targetPlayerId: "player-2",
+          reason: "harassment",
+          createdAt: "2026-04-04T08:00:00.000Z"
+        })
+      ]
+    }
+  );
+
+  setVeilCocosSessionRuntimeForTests({
+    storage,
+    loadSdk: createSdkLoader({
+      joinRooms: [room]
+    })
+  });
+
+  const session = await VeilCocosSession.create("room-alpha", "player-1", 1001);
+  await session.snapshot();
+
+  const receipt = await session.reportPlayer("player-2", "harassment", "Repeated abuse in PvP.");
+
+  assert.deepEqual(room.sentMessages.at(-1), {
+    type: "report.player",
+    payload: {
+      type: "report.player",
+      requestId: "cocos-req-2",
+      targetPlayerId: "player-2",
+      reason: "harassment",
+      description: "Repeated abuse in PvP."
+    }
+  });
+  assert.deepEqual(receipt, {
+    reportId: "report-1",
+    targetPlayerId: "player-2",
+    reason: "harassment",
+    status: "pending",
+    createdAt: "2026-04-04T08:00:00.000Z"
+  });
+
+  await session.dispose();
+});

--- a/apps/cocos-client/test/helpers/cocos-session-fixtures.ts
+++ b/apps/cocos-client/test/helpers/cocos-session-fixtures.ts
@@ -8,6 +8,14 @@ type FakeRoomReply =
       delivery?: "reply" | "push";
     }
   | {
+      kind: "report";
+      reportId: string;
+      targetPlayerId: string;
+      reason: "cheating" | "harassment" | "afk";
+      status: "pending" | "dismissed" | "warned" | "banned";
+      createdAt: string;
+    }
+  | {
       kind: "reachable";
       reachableTiles: Array<{ x: number; y: number }>;
     }
@@ -184,6 +192,23 @@ export function createReachableReply(reachableTiles: Array<{ x: number; y: numbe
   };
 }
 
+export function createReportReply(input: {
+  reportId: string;
+  targetPlayerId: string;
+  reason: "cheating" | "harassment" | "afk";
+  status?: "pending" | "dismissed" | "warned" | "banned";
+  createdAt: string;
+}): FakeRoomReply {
+  return {
+    kind: "report",
+    reportId: input.reportId,
+    targetPlayerId: input.targetPlayerId,
+    reason: input.reason,
+    status: input.status ?? "pending",
+    createdAt: input.createdAt
+  };
+}
+
 type MessageHandler = (type: string, payload: unknown) => void;
 
 export class FakeColyseusRoom {
@@ -249,6 +274,11 @@ export class FakeColyseusRoom {
         return;
       }
 
+      if (reply.kind === "report") {
+        this.emitReport(payload.requestId, reply);
+        return;
+      }
+
       this.emitState(reply.payload, reply.delivery ?? "reply", payload.requestId);
       return;
     }
@@ -282,6 +312,27 @@ export class FakeColyseusRoom {
       type: "world.reachable",
       requestId,
       reachableTiles
+    });
+  }
+
+  emitReport(
+    requestId: string,
+    report: {
+      reportId: string;
+      targetPlayerId: string;
+      reason: "cheating" | "harassment" | "afk";
+      status: "pending" | "dismissed" | "warned" | "banned";
+      createdAt: string;
+    }
+  ): void {
+    this.messageHandler?.("report.player", {
+      type: "report.player",
+      requestId,
+      reportId: report.reportId,
+      targetPlayerId: report.targetPlayerId,
+      reason: report.reason,
+      status: report.status,
+      createdAt: report.createdAt
     });
   }
 

--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ResourceLedger, WorldState } from "../../../packages/shared/src/index";
-import type { RoomSnapshotStore } from "./persistence";
+import type { PlayerReportResolveInput, PlayerReportStatus, RoomSnapshotStore } from "./persistence";
 import { listLobbyRooms, getActiveRoomInstances } from "./colyseus-room";
 
 class InvalidAdminJsonError extends Error {
@@ -68,6 +68,13 @@ function hasBanModerationStore(
 ): store is RoomSnapshotStore &
   Required<Pick<RoomSnapshotStore, "loadPlayerBan" | "listPlayerBanHistory" | "savePlayerBan" | "clearPlayerBan">> {
   return Boolean(store?.loadPlayerBan && store.listPlayerBanHistory && store.savePlayerBan && store.clearPlayerBan);
+}
+
+function hasPlayerReportStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore &
+  Required<Pick<RoomSnapshotStore, "createPlayerReport" | "listPlayerReports" | "resolvePlayerReport">> {
+  return Boolean(store?.createPlayerReport && store.listPlayerReports && store.resolvePlayerReport);
 }
 
 function sendInvalidJson(response: ServerResponse): void {
@@ -197,6 +204,34 @@ function parseBroadcastBody(value: unknown): { message: string; type: string } {
     message: message.trim(),
     type: typeof announcementType === "string" ? announcementType.trim() : "info"
   };
+}
+
+function parseReportStatus(value: string | null | undefined, fallback: PlayerReportStatus = "pending"): PlayerReportStatus {
+  if (!value || value.trim() === "") {
+    return fallback;
+  }
+
+  const normalized = value.trim();
+  if (normalized === "pending" || normalized === "dismissed" || normalized === "warned" || normalized === "banned") {
+    return normalized;
+  }
+
+  throw new InvalidAdminPayloadError('"status" must be "pending", "dismissed", "warned", or "banned"');
+}
+
+function parseResolveReportBody(value: unknown): PlayerReportResolveInput {
+  const payload = readRequiredObjectBody(value);
+  const status = parseReportStatus(readOptionalTrimmedString(payload, "status"), "pending");
+  if (status === "pending") {
+    throw new InvalidAdminPayloadError('"status" must be "dismissed", "warned", or "banned"');
+  }
+
+  return { status };
+}
+
+function readReportStatusFilter(request: IncomingMessage): PlayerReportStatus {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  return parseReportStatus(url.searchParams.get("status"), "pending");
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
@@ -416,6 +451,63 @@ export function registerAdminRoutes(
       const currentBan = await store.loadPlayerBan(playerId);
       sendJson(response, 200, { items, currentBan });
     } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.get("/api/admin/reports", async (request, response) => {
+    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
+    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!hasPlayerReportStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const status = readReportStatusFilter(request);
+      const items = await store.listPlayerReports({ status, limit: readLimit(request, 50) });
+      sendJson(response, 200, { items, status });
+    } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/reports/:id/resolve", async (request, response) => {
+    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
+    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!hasPlayerReportStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const reportId = readRequiredParam(request, "id");
+      const input = parseResolveReportBody(await readJsonBody(request));
+      const report = await store.resolvePlayerReport(reportId, input);
+      if (!report) {
+        sendJson(response, 404, { error: "Report not found" });
+        return;
+      }
+
+      let disconnectedClients = 0;
+      if (input.status === "banned" && hasBanModerationStore(store)) {
+        await store.savePlayerBan(report.targetId, {
+          banStatus: "permanent",
+          banReason: `Resolved from player report ${report.reportId}`
+        });
+        for (const room of getActiveRoomInstances().values()) {
+          disconnectedClients += room.disconnectPlayer(report.targetId, "account_banned");
+        }
+      }
+
+      sendJson(response, 200, { ok: true, report, disconnectedClients });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
       if (error instanceof InvalidAdminPayloadError) {
         sendInvalidPayload(response, error.message);
         return;

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -75,6 +75,12 @@ interface WebSocketActionRateLimitConfig {
   max: number;
 }
 
+function hasPlayerReportStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "createPlayerReport">> {
+  return Boolean(store?.createPlayerReport);
+}
+
 export interface LobbyRoomSummary {
   roomId: string;
   seed: number;
@@ -459,6 +465,48 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         movementPlan: null
       });
     });
+
+    this.onMessage("report.player", async (client, message: Extract<ClientMessage, { type: "report.player" }>) => {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "not_connected" });
+        return;
+      }
+      if (!hasPlayerReportStore(configuredRoomSnapshotStore)) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "reporting_unavailable" });
+        return;
+      }
+
+      const targetPlayerId = this.resolveReportTargetPlayerId(playerId, message.targetPlayerId);
+      if (!targetPlayerId) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "report_target_unavailable" });
+        return;
+      }
+
+      try {
+        const report = await configuredRoomSnapshotStore.createPlayerReport({
+          reporterId: playerId,
+          targetId: targetPlayerId,
+          reason: message.reason,
+          ...(message.description?.trim() ? { description: message.description.trim() } : {}),
+          roomId: logicalRoomId
+        });
+        sendMessage(client, "report.player", {
+          requestId: message.requestId,
+          reportId: report.reportId,
+          targetPlayerId: report.targetId,
+          reason: report.reason,
+          status: report.status,
+          createdAt: report.createdAt
+        });
+      } catch (error) {
+        const reason =
+          error instanceof Error && error.message === "duplicate_player_report"
+            ? "duplicate_player_report"
+            : "report_submit_failed";
+        sendMessage(client, "error", { requestId: message.requestId, reason });
+      }
+    });
   }
 
   onJoin(client: ColyseusClient, options?: JoinOptions): void {
@@ -737,6 +785,27 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     playerId: string
   ): PlayerBattleReplaySummary[] {
     return buildPlayerBattleReplaySummariesForPlayer(replay, playerId);
+  }
+
+  private resolveReportTargetPlayerId(playerId: string, requestedTargetPlayerId: string): string | null {
+    const targetPlayerId = requestedTargetPlayerId.trim();
+    if (!targetPlayerId || targetPlayerId === playerId) {
+      return null;
+    }
+
+    const battle = this.worldRoom.getBattleForPlayer(playerId);
+    if (!battle?.worldHeroId || !battle.defenderHeroId) {
+      return null;
+    }
+
+    const internalState = this.worldRoom.getInternalState();
+    const attackerHero = internalState.heroes.find((hero) => hero.id === battle.worldHeroId);
+    const defenderHero = internalState.heroes.find((hero) => hero.id === battle.defenderHeroId);
+    const participantPlayerIds = new Set(
+      [attackerHero?.playerId, defenderHero?.playerId].filter((value): value is string => Boolean(value))
+    );
+
+    return participantPlayerIds.has(targetPlayerId) ? targetPlayerId : null;
   }
 
   private publishLobbyRoomSummary(): void {

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -25,6 +25,10 @@ import {
   type PlayerAccountProfilePatch,
   type PlayerAccountProgressPatch,
   type PlayerAccountSnapshot,
+  type PlayerReportCreateInput,
+  type PlayerReportListOptions,
+  type PlayerReportRecord,
+  type PlayerReportResolveInput,
   type PlayerHeroArchiveSnapshot,
   type PlayerEventHistoryQuery,
   type PlayerEventHistorySnapshot
@@ -84,6 +88,8 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
   private readonly heroArchives = new Map<string, PlayerHeroArchiveSnapshot>();
+  private readonly reports = new Map<string, PlayerReportRecord>();
+  private nextReportId = 1;
 
   async load(roomId: string): Promise<RoomPersistenceSnapshot | null> {
     const snapshot = this.snapshots.get(roomId);
@@ -130,6 +136,38 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     return account ? cloneAccount(account) : null;
   }
 
+  async createPlayerReport(input: PlayerReportCreateInput): Promise<PlayerReportRecord> {
+    const reporterId = normalizePlayerId(input.reporterId);
+    const targetId = normalizePlayerId(input.targetId);
+    const roomId = input.roomId.trim();
+    if (!roomId) {
+      throw new Error("roomId must not be empty");
+    }
+    if (reporterId === targetId) {
+      throw new Error("reporterId must not match targetId");
+    }
+
+    const duplicate = Array.from(this.reports.values()).find(
+      (report) => report.roomId === roomId && report.reporterId === reporterId && report.targetId === targetId
+    );
+    if (duplicate) {
+      throw new Error("duplicate_player_report");
+    }
+
+    const report: PlayerReportRecord = {
+      reportId: String(this.nextReportId++),
+      reporterId,
+      targetId,
+      reason: input.reason,
+      ...(input.description?.trim() ? { description: input.description.trim().slice(0, 512) } : {}),
+      roomId,
+      status: "pending",
+      createdAt: new Date().toISOString()
+    };
+    this.reports.set(report.reportId, structuredClone(report));
+    return structuredClone(report);
+  }
+
   async loadPlayerEventHistory(
     playerId: string,
     query: PlayerEventHistoryQuery = {}
@@ -167,6 +205,18 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       .map((playerId) => this.accounts.get(normalizePlayerId(playerId)))
       .filter((account): account is PlayerAccountSnapshot => Boolean(account))
       .map((account) => cloneAccount(account));
+  }
+
+  async listPlayerReports(options: PlayerReportListOptions = {}): Promise<PlayerReportRecord[]> {
+    const safeLimit = Math.max(1, Math.floor(options.limit ?? 50));
+    return Array.from(this.reports.values())
+      .filter((report) => !options.status || report.status === options.status)
+      .filter((report) => !options.roomId || report.roomId === options.roomId)
+      .filter((report) => !options.reporterId || report.reporterId === options.reporterId)
+      .filter((report) => !options.targetId || report.targetId === options.targetId)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt) || left.reportId.localeCompare(right.reportId))
+      .slice(0, safeLimit)
+      .map((report) => structuredClone(report));
   }
 
   async loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null> {
@@ -578,6 +628,26 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     delete nextAccount.wechatMiniGameBoundAt;
     this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     return cloneAccount(nextAccount);
+  }
+
+  async resolvePlayerReport(reportId: string, input: PlayerReportResolveInput): Promise<PlayerReportRecord | null> {
+    const normalizedReportId = reportId.trim();
+    if (!normalizedReportId) {
+      throw new Error("reportId must not be empty");
+    }
+
+    const existing = this.reports.get(normalizedReportId);
+    if (!existing) {
+      return null;
+    }
+
+    const next: PlayerReportRecord = {
+      ...existing,
+      status: input.status,
+      resolvedAt: new Date().toISOString()
+    };
+    this.reports.set(normalizedReportId, structuredClone(next));
+    return structuredClone(next);
   }
 
   async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -22,11 +22,14 @@ import type { RoomPersistenceSnapshot } from "./index";
 export interface RoomSnapshotStore {
   load(roomId: string): Promise<RoomPersistenceSnapshot | null>;
   loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null>;
+  loadPlayerReport?(reportId: string): Promise<PlayerReportRecord | null>;
   loadPlayerBan?(playerId: string): Promise<PlayerAccountBanSnapshot | null>;
+  createPlayerReport?(input: PlayerReportCreateInput): Promise<PlayerReportRecord>;
   loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null>;
   loadPlayerAccountByWechatMiniGameOpenId(openId: string): Promise<PlayerAccountSnapshot | null>;
   loadPlayerEventHistory(playerId: string, query?: PlayerEventHistoryQuery): Promise<PlayerEventHistorySnapshot>;
   loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]>;
+  listPlayerReports?(options?: PlayerReportListOptions): Promise<PlayerReportRecord[]>;
   listPlayerBanHistory?(playerId: string, options?: PlayerAccountBanHistoryListOptions): Promise<PlayerBanHistoryRecord[]>;
   loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerAccountAuthByPlayerId(playerId: string): Promise<PlayerAccountAuthSnapshot | null>;
@@ -65,6 +68,7 @@ export interface RoomSnapshotStore {
     playerId: string,
     input?: PlayerAccountDeleteInput
   ): Promise<PlayerAccountSnapshot | null>;
+  resolvePlayerReport?(reportId: string, input: PlayerReportResolveInput): Promise<PlayerReportRecord | null>;
   savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot>;
   savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot>;
   listPlayerAccounts(options?: PlayerAccountListOptions): Promise<PlayerAccountSnapshot[]>;
@@ -219,6 +223,18 @@ interface PlayerHeroArchiveRow extends RowDataPacket {
   updated_at: Date | string;
 }
 
+interface PlayerReportRow extends RowDataPacket {
+  report_id: string | number;
+  reporter_id: string;
+  target_id: string;
+  reason: string;
+  description: string | null;
+  room_id: string;
+  status: string;
+  created_at: Date | string;
+  resolved_at: Date | string | null;
+}
+
 export interface RoomSnapshotSummary {
   roomId: string;
   version: number;
@@ -289,6 +305,41 @@ export interface PlayerAccountEnsureInput {
   playerId: string;
   displayName?: string;
   lastRoomId?: string;
+}
+
+export type PlayerReportReason = "cheating" | "harassment" | "afk";
+export type PlayerReportStatus = "pending" | "dismissed" | "warned" | "banned";
+
+export interface PlayerReportRecord {
+  reportId: string;
+  reporterId: string;
+  targetId: string;
+  reason: PlayerReportReason;
+  description?: string;
+  roomId: string;
+  status: PlayerReportStatus;
+  createdAt: string;
+  resolvedAt?: string;
+}
+
+export interface PlayerReportCreateInput {
+  reporterId: string;
+  targetId: string;
+  reason: PlayerReportReason;
+  description?: string;
+  roomId: string;
+}
+
+export interface PlayerReportListOptions {
+  status?: PlayerReportStatus;
+  roomId?: string;
+  reporterId?: string;
+  targetId?: string;
+  limit?: number;
+}
+
+export interface PlayerReportResolveInput {
+  status: Exclude<PlayerReportStatus, "pending">;
 }
 
 export interface PlayerAccountProfilePatch {
@@ -417,6 +468,9 @@ export const MYSQL_PLAYER_EVENT_HISTORY_TABLE = "player_event_history";
 export const MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX = "idx_player_event_history_player_time";
 export const MYSQL_PLAYER_HERO_ARCHIVE_TABLE = "player_hero_archives";
 export const MYSQL_PLAYER_HERO_ARCHIVE_UPDATED_AT_INDEX = "idx_player_hero_archives_updated_at";
+export const MYSQL_PLAYER_REPORT_TABLE = "player_reports";
+export const MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX = "idx_player_reports_status_created";
+export const MYSQL_PLAYER_REPORT_ROOM_REPORTER_TARGET_INDEX = "uidx_player_reports_room_reporter_target";
 export const MYSQL_CONFIG_DOCUMENT_TABLE = "config_documents";
 export const MYSQL_CONFIG_DOCUMENT_UPDATED_AT_INDEX = "idx_config_documents_updated_at";
 export const DEFAULT_SNAPSHOT_TTL_HOURS = 72;
@@ -481,6 +535,54 @@ function normalizePlayerBanExpiry(expiry?: string | Date | null): string | undef
   }
 
   return parsed.toISOString();
+}
+
+function normalizePlayerReportReason(reason?: string | null): PlayerReportReason {
+  if (reason === "cheating" || reason === "harassment" || reason === "afk") {
+    return reason;
+  }
+
+  throw new Error("report reason must be cheating, harassment, or afk");
+}
+
+function normalizePlayerReportStatus(status?: string | null): PlayerReportStatus {
+  if (status === "pending" || status === "dismissed" || status === "warned" || status === "banned") {
+    return status;
+  }
+
+  throw new Error("report status must be pending, dismissed, warned, or banned");
+}
+
+function normalizePlayerReportDescription(description?: string | null): string | undefined {
+  const normalized = description?.trim();
+  return normalized ? normalized.slice(0, 512) : undefined;
+}
+
+function normalizePlayerReportRecord(record: {
+  reportId: string | number;
+  reporterId: string;
+  targetId: string;
+  reason: string;
+  description?: string | null;
+  roomId: string;
+  status: string;
+  createdAt: string | Date;
+  resolvedAt?: string | Date | null;
+}): PlayerReportRecord {
+  const description = normalizePlayerReportDescription(record.description);
+  const resolvedAt = formatTimestamp(record.resolvedAt);
+
+  return {
+    reportId: String(record.reportId),
+    reporterId: normalizePlayerId(record.reporterId),
+    targetId: normalizePlayerId(record.targetId),
+    reason: normalizePlayerReportReason(record.reason),
+    ...(description ? { description } : {}),
+    roomId: record.roomId.trim(),
+    status: normalizePlayerReportStatus(record.status),
+    createdAt: formatTimestamp(record.createdAt) ?? new Date(0).toISOString(),
+    ...(resolvedAt ? { resolvedAt } : {})
+  };
 }
 
 export function isPlayerBanActive(
@@ -1049,6 +1151,20 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (
   PRIMARY KEY (player_id, event_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_REPORT_TABLE}\` (
+  report_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  reporter_id VARCHAR(191) NOT NULL,
+  target_id VARCHAR(191) NOT NULL,
+  reason VARCHAR(32) NOT NULL,
+  description VARCHAR(512) NULL,
+  room_id VARCHAR(191) NOT NULL,
+  status VARCHAR(16) NOT NULL DEFAULT 'pending',
+  resolved_at DATETIME NULL DEFAULT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (report_id),
+  UNIQUE KEY \`${MYSQL_PLAYER_REPORT_ROOM_REPORTER_TARGET_INDEX}\` (room_id, reporter_id, target_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 SET @veil_player_accounts_display_name_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.COLUMNS
@@ -1084,6 +1200,24 @@ SET @veil_player_event_history_idx_sql := IF(
 PREPARE veil_player_event_history_idx_stmt FROM @veil_player_event_history_idx_sql;
 EXECUTE veil_player_event_history_idx_stmt;
 DEALLOCATE PREPARE veil_player_event_history_idx_stmt;
+
+SET @veil_player_reports_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_REPORT_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX}'
+);
+
+SET @veil_player_reports_idx_sql := IF(
+  @veil_player_reports_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX}\` ON \`${MYSQL_PLAYER_REPORT_TABLE}\` (status, created_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_reports_idx_stmt FROM @veil_player_reports_idx_sql;
+EXECUTE veil_player_reports_idx_stmt;
+DEALLOCATE PREPARE veil_player_reports_idx_stmt;
 
 SET @veil_player_accounts_achievements_exists := (
   SELECT COUNT(*)
@@ -1964,6 +2098,20 @@ function toPlayerBanHistoryRecord(row: PlayerBanHistoryRow): PlayerBanHistoryRec
   };
 }
 
+function toPlayerReportRecord(row: PlayerReportRow): PlayerReportRecord {
+  return normalizePlayerReportRecord({
+    reportId: row.report_id,
+    reporterId: row.reporter_id,
+    targetId: row.target_id,
+    reason: row.reason,
+    description: row.description,
+    roomId: row.room_id,
+    status: row.status,
+    createdAt: row.created_at,
+    resolvedAt: row.resolved_at
+  });
+}
+
 async function appendPlayerEventHistoryEntries(
   queryable: Pick<Pool, "query"> | Pick<PoolConnection, "query">,
   playerId: string,
@@ -2233,6 +2381,65 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     return row ? toPlayerBanSnapshot(row) : null;
   }
 
+  async createPlayerReport(input: PlayerReportCreateInput): Promise<PlayerReportRecord> {
+    const reporterId = normalizePlayerId(input.reporterId);
+    const targetId = normalizePlayerId(input.targetId);
+    const roomId = input.roomId.trim();
+    if (!roomId) {
+      throw new Error("roomId must not be empty");
+    }
+    if (reporterId === targetId) {
+      throw new Error("reporterId must not match targetId");
+    }
+
+    const reason = normalizePlayerReportReason(input.reason);
+    const description = normalizePlayerReportDescription(input.description);
+
+    try {
+      const [result] = await this.pool.query<ResultSetHeader>(
+        `INSERT INTO \`${MYSQL_PLAYER_REPORT_TABLE}\` (
+           reporter_id,
+           target_id,
+           reason,
+           description,
+           room_id,
+           status
+         )
+         VALUES (?, ?, ?, ?, ?, 'pending')`,
+        [reporterId, targetId, reason, description ?? null, roomId]
+      );
+      const [rows] = await this.pool.query<PlayerReportRow[]>(
+        `SELECT
+           report_id,
+           reporter_id,
+           target_id,
+           reason,
+           description,
+           room_id,
+           status,
+           created_at,
+           resolved_at
+         FROM \`${MYSQL_PLAYER_REPORT_TABLE}\`
+         WHERE report_id = ?
+         LIMIT 1`,
+        [result.insertId]
+      );
+
+      const row = rows[0];
+      if (!row) {
+        throw new Error("player report insert failed");
+      }
+
+      return toPlayerReportRecord(row);
+    } catch (error) {
+      if (isMySqlDuplicateEntryError(error)) {
+        throw new Error("duplicate_player_report");
+      }
+
+      throw error;
+    }
+  }
+
   async loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null> {
     const normalizedLoginId = normalizePlayerLoginId(loginId);
     const [rows] = await this.pool.query<PlayerAccountRow[]>(
@@ -2454,6 +2661,50 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     );
 
     return rows.map((row) => toPlayerAccountSnapshot(row));
+  }
+
+  async listPlayerReports(options: PlayerReportListOptions = {}): Promise<PlayerReportRecord[]> {
+    const safeLimit = Math.max(1, Math.floor(options.limit ?? 50));
+    const clauses: string[] = [];
+    const params: Array<string | number> = [];
+
+    if (options.status) {
+      clauses.push("status = ?");
+      params.push(normalizePlayerReportStatus(options.status));
+    }
+    if (options.roomId?.trim()) {
+      clauses.push("room_id = ?");
+      params.push(options.roomId.trim());
+    }
+    if (options.reporterId?.trim()) {
+      clauses.push("reporter_id = ?");
+      params.push(normalizePlayerId(options.reporterId));
+    }
+    if (options.targetId?.trim()) {
+      clauses.push("target_id = ?");
+      params.push(normalizePlayerId(options.targetId));
+    }
+
+    const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const [rows] = await this.pool.query<PlayerReportRow[]>(
+      `SELECT
+         report_id,
+         reporter_id,
+         target_id,
+         reason,
+         description,
+         room_id,
+         status,
+         created_at,
+         resolved_at
+       FROM \`${MYSQL_PLAYER_REPORT_TABLE}\`
+       ${whereClause}
+       ORDER BY created_at DESC, report_id DESC
+       LIMIT ?`,
+      [...params, safeLimit]
+    );
+
+    return rows.map((row) => toPlayerReportRecord(row));
   }
 
   async loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null> {
@@ -3050,6 +3301,50 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     ]);
 
     return this.loadPlayerAccount(normalizedPlayerId);
+  }
+
+  async resolvePlayerReport(reportId: string, input: PlayerReportResolveInput): Promise<PlayerReportRecord | null> {
+    const normalizedReportId = reportId.trim();
+    if (!normalizedReportId) {
+      throw new Error("reportId must not be empty");
+    }
+
+    const status = normalizePlayerReportStatus(input.status);
+    if (status === "pending") {
+      throw new Error("resolved report status must not be pending");
+    }
+
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `UPDATE \`${MYSQL_PLAYER_REPORT_TABLE}\`
+       SET status = ?,
+           resolved_at = ?
+       WHERE report_id = ?`,
+      [status, new Date(), normalizedReportId]
+    );
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    const [rows] = await this.pool.query<PlayerReportRow[]>(
+      `SELECT
+         report_id,
+         reporter_id,
+         target_id,
+         reason,
+         description,
+         room_id,
+         status,
+         created_at,
+         resolved_at
+       FROM \`${MYSQL_PLAYER_REPORT_TABLE}\`
+       WHERE report_id = ?
+       LIMIT 1`,
+      [normalizedReportId]
+    );
+
+    const row = rows[0];
+    return row ? toPlayerReportRecord(row) : null;
   }
 
   async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -31,6 +31,7 @@ function createRequest(options: {
   headers?: Record<string, string | undefined>;
   params?: Record<string, string>;
   body?: string;
+  url?: string;
 } = {}): IncomingMessage & {
   params: Record<string, string>;
 } {
@@ -44,7 +45,8 @@ function createRequest(options: {
   Object.assign(request, {
     method: options.method ?? "GET",
     headers: options.headers ?? {},
-    params: options.params ?? {}
+    params: options.params ?? {},
+    url: options.url ?? "/"
   });
   return request;
 }
@@ -106,12 +108,53 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     ])
   );
   const banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
+  const reports = new Map<string, {
+    reportId: string;
+    reporterId: string;
+    targetId: string;
+    reason: "cheating" | "harassment" | "afk";
+    description?: string;
+    roomId: string;
+    status: "pending" | "dismissed" | "warned" | "banned";
+    createdAt: string;
+    resolvedAt?: string;
+  }>();
   const saveCalls: Array<{ playerId: string; globalResources: { gold: number; wood: number; ore: number } }> = [];
+  let nextReportId = 1;
 
   const store = {
     saveCalls,
     async loadPlayerAccount(playerId: string) {
       return accounts.get(playerId) ?? null;
+    },
+    async createPlayerReport(input: {
+      reporterId: string;
+      targetId: string;
+      reason: "cheating" | "harassment" | "afk";
+      description?: string;
+      roomId: string;
+    }) {
+      const duplicate = Array.from(reports.values()).find(
+        (report) =>
+          report.reporterId === input.reporterId &&
+          report.targetId === input.targetId &&
+          report.roomId === input.roomId
+      );
+      if (duplicate) {
+        throw new Error("duplicate_player_report");
+      }
+      const report = {
+        reportId: String(nextReportId++),
+        reporterId: input.reporterId,
+        targetId: input.targetId,
+        reason: input.reason,
+        ...(input.description ? { description: input.description } : {}),
+        roomId: input.roomId,
+        status: "pending" as const,
+        createdAt: new Date().toISOString()
+      };
+      reports.set(report.reportId, report);
+      return report;
     },
     async loadPlayerBan(playerId: string) {
       const account = accounts.get(playerId);
@@ -197,12 +240,34 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     },
     async listPlayerBanHistory(playerId: string, options: { limit?: number } = {}) {
       return (banHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
+    },
+    async listPlayerReports(options: {
+      status?: "pending" | "dismissed" | "warned" | "banned";
+      limit?: number;
+    } = {}) {
+      return Array.from(reports.values())
+        .filter((report) => !options.status || report.status === options.status)
+        .sort((left, right) => right.createdAt.localeCompare(left.createdAt) || left.reportId.localeCompare(right.reportId))
+        .slice(0, Math.max(1, Math.floor(options.limit ?? 50)));
+    },
+    async resolvePlayerReport(reportId: string, input: { status: "dismissed" | "warned" | "banned" }) {
+      const report = reports.get(reportId);
+      if (!report) {
+        return null;
+      }
+      const next = {
+        ...report,
+        status: input.status,
+        resolvedAt: new Date().toISOString()
+      };
+      reports.set(reportId, next);
+      return next;
     }
   };
 
   return store as Pick<
     RoomSnapshotStore,
-    "loadPlayerAccount" | "loadPlayerBan" | "ensurePlayerAccount" | "savePlayerAccountProgress" | "savePlayerBan" | "clearPlayerBan" | "listPlayerBanHistory"
+    "loadPlayerAccount" | "createPlayerReport" | "loadPlayerBan" | "ensurePlayerAccount" | "savePlayerAccountProgress" | "savePlayerBan" | "clearPlayerBan" | "listPlayerBanHistory" | "listPlayerReports" | "resolvePlayerReport"
   > & {
     saveCalls: Array<{ playerId: string; globalResources: { gold: number; wood: number; ore: number } }>;
   };
@@ -655,4 +720,125 @@ test("GET /api/admin/players/:id/ban-history returns current ban state and histo
   assert.ok(payload.items.length >= 1);
   assert.equal(payload.items[0]?.action, "unban");
   assert.equal(payload.items[0]?.banReason, "Manual review");
+});
+
+test("GET /api/admin/reports returns filtered player reports", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore();
+  await store.createPlayerReport({
+    reporterId: "player-1",
+    targetId: "player-2",
+    reason: "cheating",
+    roomId: "room-report"
+  });
+  const report = await store.createPlayerReport({
+    reporterId: "player-3",
+    targetId: "player-4",
+    reason: "harassment",
+    roomId: "room-report"
+  });
+  await store.resolvePlayerReport(report.reportId, { status: "dismissed" });
+
+  const { gets } = registerRoutes(store as RoomSnapshotStore);
+  const handler = gets.get("/api/admin/reports");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      url: "/api/admin/reports?status=pending",
+      headers: {
+        "x-veil-admin-secret": secret
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body) as {
+    status: string;
+    items: Array<{ reporterId: string; status: string }>;
+  };
+  assert.equal(payload.status, "pending");
+  assert.equal(payload.items.length, 1);
+  assert.equal(payload.items[0]?.reporterId, "player-1");
+  assert.equal(payload.items[0]?.status, "pending");
+});
+
+test("POST /api/admin/reports/:id/resolve marks a report resolved", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore();
+  const report = await store.createPlayerReport({
+    reporterId: "player-1",
+    targetId: "player-2",
+    reason: "afk",
+    roomId: "room-report"
+  });
+
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/reports/:id/resolve");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: report.reportId },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({ status: "warned" })
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body) as {
+    ok: boolean;
+    report: { status: string; resolvedAt?: string };
+  };
+  assert.equal(payload.ok, true);
+  assert.equal(payload.report.status, "warned");
+  assert.ok(payload.report.resolvedAt);
+});
+
+test("POST /api/admin/reports/:id/resolve with banned also bans the reported player", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore();
+  const report = await store.createPlayerReport({
+    reporterId: "player-1",
+    targetId: "player-2",
+    reason: "cheating",
+    roomId: "room-report"
+  });
+
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/reports/:id/resolve");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: report.reportId },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({ status: "banned" })
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body) as {
+    ok: boolean;
+    disconnectedClients: number;
+    report: { status: string; targetId: string };
+  };
+  const currentBan = await store.loadPlayerBan("player-2");
+  assert.equal(payload.ok, true);
+  assert.equal(payload.report.status, "banned");
+  assert.equal(payload.disconnectedClients, 0);
+  assert.equal(currentBan?.banStatus, "permanent");
+  assert.match(currentBan?.banReason ?? "", /player report/);
 });

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -1086,6 +1086,70 @@ test("pvp replay persistence captures both attacker and defender accounts from r
   );
 });
 
+test("room report player flow persists one report per room target pair and rejects duplicates", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-report-pvp-${Date.now()}`);
+  const attackerClient = createFakeClient("session-report-attacker");
+  const defenderClient = createFakeClient("session-report-defender");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, attackerClient, "player-1", "connect-report-attacker");
+  await connectPlayer(room, defenderClient, "player-2", "connect-report-defender");
+
+  await emitRoomMessage(room, "world.action", attackerClient, {
+    type: "world.action",
+    requestId: "move-report-attacker",
+    action: {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 3, y: 4 }
+    }
+  });
+  await emitRoomMessage(room, "world.action", defenderClient, {
+    type: "world.action",
+    requestId: "move-report-defender",
+    action: {
+      type: "hero.move",
+      heroId: "hero-2",
+      destination: { x: 3, y: 4 }
+    }
+  });
+
+  await emitRoomMessage(room, "report.player", attackerClient, {
+    type: "report.player",
+    requestId: "report-once",
+    targetPlayerId: "player-2",
+    reason: "afk",
+    description: "Stopped acting during the PvP encounter."
+  });
+
+  const reports = await store.listPlayerReports({ status: "pending" });
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0]?.reporterId, "player-1");
+  assert.equal(reports[0]?.targetId, "player-2");
+  assert.equal(attackerClient.sent.some((message) => message.type === "report.player" && message.targetPlayerId === "player-2"), true);
+
+  await emitRoomMessage(room, "report.player", attackerClient, {
+    type: "report.player",
+    requestId: "report-twice",
+    targetPlayerId: "player-2",
+    reason: "cheating"
+  });
+
+  assert.equal(
+    attackerClient.sent.some((message) => message.type === "error" && message.requestId === "report-twice" && message.reason === "duplicate_player_report"),
+    true
+  );
+  assert.equal((await store.listPlayerReports({ status: "pending" })).length, 1);
+});
+
 test("room at maxClients capacity rejects a new join reservation", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
@@ -1105,4 +1169,59 @@ test("room at maxClients capacity rejects a new join reservation", async (t) => 
   }
 
   assert.equal(await internalRoom._reserveSeat("overflow-session", { playerId: "player-9" }), false);
+});
+
+test("room player reports are persisted once per target within the same room", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`report-room-${Date.now()}`);
+  const reporterClient = createFakeClient("reporter-session");
+  const targetClient = createFakeClient("target-session");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, reporterClient, "player-1", "connect-reporter");
+  await connectPlayer(room, targetClient, "player-2", "connect-target");
+
+  await emitRoomMessage(room, "report.player", reporterClient, {
+    type: "report.player",
+    requestId: "report-1",
+    targetPlayerId: "player-2",
+    reason: "cheating"
+  });
+
+  const reports = await store.listPlayerReports({ status: "pending" });
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0]?.reporterId, "player-1");
+  assert.equal(reports[0]?.targetId, "player-2");
+  assert.equal(reports[0]?.roomId, room.roomId);
+  assert.equal(
+    reporterClient.sent.some(
+      (message) =>
+        message.type === "session.state" &&
+        message.requestId === "report-1" &&
+        message.payload.reason === "report_submitted"
+    ),
+    true
+  );
+
+  await emitRoomMessage(room, "report.player", reporterClient, {
+    type: "report.player",
+    requestId: "report-2",
+    targetPlayerId: "player-2",
+    reason: "afk"
+  });
+
+  assert.equal((await store.listPlayerReports({ status: "pending" })).length, 1);
+  assert.equal(
+    reporterClient.sent.some(
+      (message) => message.type === "error" && message.requestId === "report-2" && message.reason === "duplicate_player_report"
+    ),
+    true
+  );
 });

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -11,6 +11,9 @@ export interface SessionStatePayload {
   reason?: string;
 }
 
+export type PlayerReportReason = "cheating" | "harassment" | "afk";
+export type PlayerReportStatus = "pending" | "dismissed" | "warned" | "banned";
+
 export type ClientMessage =
   | {
       type: "connect";
@@ -41,6 +44,13 @@ export type ClientMessage =
       type: "world.reachable";
       requestId: string;
       heroId: string;
+    }
+  | {
+      type: "report.player";
+      requestId: string;
+      targetPlayerId: string;
+      reason: PlayerReportReason;
+      description?: string;
     };
 
 export type ServerMessage =
@@ -64,6 +74,15 @@ export type ServerMessage =
       type: "error";
       requestId: string;
       reason: string;
+    }
+  | {
+      type: "report.player";
+      requestId: string;
+      reportId: string;
+      targetPlayerId: string;
+      reason: PlayerReportReason;
+      status: PlayerReportStatus;
+      createdAt: string;
     }
   | {
       type: "config.update";

--- a/scripts/migrations/0011_add_player_reports.ts
+++ b/scripts/migrations/0011_add_player_reports.ts
@@ -1,0 +1,48 @@
+import {
+  dropIndexIfExists,
+  dropTableIfExists,
+  ensureIndexExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_PLAYER_REPORT_ROOM_REPORTER_TARGET_INDEX,
+  MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX,
+  MYSQL_PLAYER_REPORT_TABLE
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureTableExists(
+    connection,
+    MYSQL_PLAYER_REPORT_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_REPORT_TABLE}\` (
+      report_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+      reporter_id VARCHAR(191) NOT NULL,
+      target_id VARCHAR(191) NOT NULL,
+      reason VARCHAR(32) NOT NULL,
+      description VARCHAR(512) NULL,
+      room_id VARCHAR(191) NOT NULL,
+      status VARCHAR(16) NOT NULL DEFAULT 'pending',
+      resolved_at DATETIME NULL DEFAULT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (report_id),
+      UNIQUE KEY \`${MYSQL_PLAYER_REPORT_ROOM_REPORTER_TARGET_INDEX}\` (room_id, reporter_id, target_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_PLAYER_REPORT_TABLE,
+    MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX,
+    `CREATE INDEX \`${MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX}\` ON \`${MYSQL_PLAYER_REPORT_TABLE}\` (status, created_at DESC)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+  await dropIndexIfExists(connection, database, MYSQL_PLAYER_REPORT_TABLE, MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX);
+  await dropTableIfExists(connection, MYSQL_PLAYER_REPORT_TABLE);
+}


### PR DESCRIPTION
Closes #791

## Summary
- add the player reporting websocket protocol, room persistence, and MySQL migration for `player_reports`
- add admin review APIs and admin console UI for listing and resolving reports
- add H5 and Cocos in-game report flows plus focused regression coverage for the new report transport

## Validation
- `node --import tsx --test ./apps/server/test/admin-console.test.ts`
- `node --import tsx --test --test-name-pattern "room report player flow persists one report per room target pair and rejects duplicates" ./apps/server/test/colyseus-room-lifecycle.test.ts`
- `node --import tsx --test --test-name-pattern "remote game sessions send player reports through the websocket protocol" ./apps/client/test/local-session.test.ts`
- `node --import tsx --test ./apps/cocos-client/test/cocos-report-session.test.ts`
- `npm run typecheck:client:h5`
- `npm run typecheck:cocos`

## Notes
- `npm run typecheck:server` still fails on the existing unrelated `TerrainType` coverage error in `apps/server/src/config-center.ts`.
- The full `apps/server/test/colyseus-room-lifecycle.test.ts` file still has unrelated pre-existing failures outside the report flow.