### PR TITLE
feat: add shop purchase API

### DIFF
--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -27,6 +27,7 @@ import {
 } from "./persistence";
 import { registerPlayerAccountRoutes } from "./player-accounts";
 import { registerAdminRoutes } from "./admin-console";
+import { registerShopRoutes } from "./shop";
 import { formatSchemaMigrationWarning, getSchemaMigrationStatus } from "./schema-migrations";
 import { closeRedisResource, createRedisDriver, createRedisPresence, readRedisUrl } from "./redis";
 
@@ -109,6 +110,7 @@ export interface DevServerBootstrapDependencies {
   registerConfigCenterRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerPlayerAccountRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
+  registerShopRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerLobbyRoutes(app: unknown, dependencies: { listRooms: typeof listLobbyRooms }): void;
   registerMatchmakingRoutes(app: unknown, dependencies: { store: DevServerRoomSnapshotStore }): void;
   registerRuntimeObservabilityRoutes(app: unknown, options?: { store?: DevServerRoomSnapshotStore }): void;
@@ -170,6 +172,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerConfigCenterRoutes: (app, store) => registerConfigCenterRoutes(app as never, store as ConfigCenterStore),
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
     registerPlayerAccountRoutes: (app, store) => registerPlayerAccountRoutes(app as never, store as RoomSnapshotStore),
+    registerShopRoutes: (app, store) => registerShopRoutes(app as never, store as RoomSnapshotStore),
     registerLobbyRoutes: (app, dependencies) => registerLobbyRoutes(app as never, dependencies),
     registerMatchmakingRoutes: (app, dependencies) =>
       registerMatchmakingRoutes(app as never, { store: dependencies.store as RoomSnapshotStore }),
@@ -231,6 +234,7 @@ export async function startDevServer(
   deps.registerConfigCenterRoutes(expressApp, configCenterStore);
   deps.registerConfigViewerRoutes(expressApp, configCenterStore);
   deps.registerPlayerAccountRoutes(expressApp, effectiveSnapshotStore);
+  deps.registerShopRoutes(expressApp, effectiveSnapshotStore);
   deps.registerLobbyRoutes(expressApp, { listRooms: listLobbyRooms });
   deps.registerMatchmakingRoutes(expressApp, { store: effectiveSnapshotStore });
   deps.registerRuntimeObservabilityRoutes(expressApp, { store: effectiveSnapshotStore });

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -1,7 +1,10 @@
 import {
+  appendEventLogEntries,
+  getEquipmentDefinition,
   normalizeEloRating,
   normalizeEventLogEntries,
   normalizeEventLogQuery,
+  tryAddEquipmentToInventory,
   type EventLogEntry
 } from "../../../packages/shared/src/index";
 import {
@@ -32,6 +35,9 @@ import {
   type PlayerHeroArchiveSnapshot,
   type PlayerEventHistoryQuery,
   type PlayerEventHistorySnapshot
+  ,
+  type ShopPurchaseMutationInput,
+  type ShopPurchaseResult
 } from "./persistence";
 import type { RoomPersistenceSnapshot } from "./index";
 
@@ -80,6 +86,14 @@ function normalizeSessionId(sessionId: string): string {
   return normalized;
 }
 
+function normalizeResourceLedger(resources?: PlayerAccountSnapshot["globalResources"] | Partial<PlayerAccountSnapshot["globalResources"]>): PlayerAccountSnapshot["globalResources"] {
+  return {
+    gold: Math.max(0, Math.floor(resources?.gold ?? 0)),
+    wood: Math.max(0, Math.floor(resources?.wood ?? 0)),
+    ore: Math.max(0, Math.floor(resources?.ore ?? 0))
+  };
+}
+
 export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly snapshots = new Map<string, RoomPersistenceSnapshot>();
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
@@ -88,6 +102,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
   private readonly heroArchives = new Map<string, PlayerHeroArchiveSnapshot>();
+  private readonly shopPurchases = new Map<string, ShopPurchaseResult>();
   private readonly reports = new Map<string, PlayerReportRecord>();
   private nextReportId = 1;
 
@@ -322,6 +337,132 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     };
     this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     return cloneAccount(nextAccount);
+  }
+
+  async purchaseShopProduct(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const purchaseId = input.purchaseId.trim();
+    const productId = input.productId.trim();
+    const productName = input.productName.trim();
+    const quantity = Math.max(1, Math.floor(input.quantity));
+    const unitPrice = Math.max(0, Math.floor(input.unitPrice));
+    if (!purchaseId) {
+      throw new Error("purchaseId must not be empty");
+    }
+    if (!productId) {
+      throw new Error("productId must not be empty");
+    }
+    if (!productName) {
+      throw new Error("productName must not be empty");
+    }
+    if (!Number.isFinite(input.quantity) || quantity <= 0) {
+      throw new Error("quantity must be a positive integer");
+    }
+
+    const purchaseKey = `${normalizedPlayerId}:${purchaseId}`;
+    const existingPurchase = this.shopPurchases.get(purchaseKey);
+    if (existingPurchase) {
+      return structuredClone(existingPurchase);
+    }
+
+    const existingAccount = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const normalizedGrant = {
+      gems: Math.max(0, Math.floor(input.grant.gems ?? 0)) * quantity,
+      resources: {
+        gold: Math.max(0, Math.floor(input.grant.resources?.gold ?? 0)) * quantity,
+        wood: Math.max(0, Math.floor(input.grant.resources?.wood ?? 0)) * quantity,
+        ore: Math.max(0, Math.floor(input.grant.resources?.ore ?? 0)) * quantity
+      },
+      equipmentIds: Array.from({ length: quantity }, () => input.grant.equipmentIds ?? []).flat().map((equipmentId) => {
+        const normalizedEquipmentId = equipmentId.trim();
+        if (!normalizedEquipmentId || !getEquipmentDefinition(normalizedEquipmentId)) {
+          throw new Error(`unknown equipment grant: ${equipmentId}`);
+        }
+        return normalizedEquipmentId;
+      })
+    };
+    const totalPrice = unitPrice * quantity;
+    if ((existingAccount.gems ?? 0) < totalPrice) {
+      throw new Error("insufficient gems");
+    }
+
+    let heroId: string | undefined;
+    let updatedArchive: PlayerHeroArchiveSnapshot | undefined;
+    if (normalizedGrant.equipmentIds.length > 0) {
+      const currentArchive = Array.from(this.heroArchives.values())
+        .filter((archive) => archive.playerId === normalizedPlayerId)
+        .sort((left, right) => left.heroId.localeCompare(right.heroId))[0];
+      if (!currentArchive) {
+        throw new Error("player hero archive not found");
+      }
+
+      let nextInventory = [...currentArchive.hero.loadout.inventory];
+      for (const equipmentId of normalizedGrant.equipmentIds) {
+        const inventoryUpdate = tryAddEquipmentToInventory(nextInventory, equipmentId);
+        if (!inventoryUpdate.stored) {
+          throw new Error("equipment inventory full");
+        }
+        nextInventory = inventoryUpdate.inventory;
+      }
+
+      heroId = currentArchive.heroId;
+      updatedArchive = {
+        ...cloneArchive(currentArchive),
+        hero: {
+          ...cloneArchive(currentArchive).hero,
+          loadout: {
+            ...cloneArchive(currentArchive).hero.loadout,
+            inventory: nextInventory
+          }
+        }
+      };
+    }
+
+    const processedAt = new Date().toISOString();
+    const nextAccount: PlayerAccountSnapshot = {
+      ...existingAccount,
+      gems: (existingAccount.gems ?? 0) - totalPrice + normalizedGrant.gems,
+      globalResources: normalizeResourceLedger({
+        gold: (existingAccount.globalResources.gold ?? 0) + normalizedGrant.resources.gold,
+        wood: (existingAccount.globalResources.wood ?? 0) + normalizedGrant.resources.wood,
+        ore: (existingAccount.globalResources.ore ?? 0) + normalizedGrant.resources.ore
+      }),
+      recentEventLog: appendEventLogEntries(existingAccount.recentEventLog, [
+        {
+          id: `${normalizedPlayerId}:${processedAt}:shop:${productId}:${quantity}`,
+          timestamp: processedAt,
+          roomId: "shop",
+          playerId: normalizedPlayerId,
+          category: "account",
+          description: `Purchased ${productName} x${quantity}.`,
+          rewards: []
+        }
+      ]),
+      updatedAt: processedAt
+    };
+
+    this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
+    if (updatedArchive) {
+      this.heroArchives.set(`${updatedArchive.playerId}:${updatedArchive.heroId}`, cloneArchive(updatedArchive));
+    }
+
+    const result: ShopPurchaseResult = {
+      purchaseId,
+      productId,
+      quantity,
+      unitPrice,
+      totalPrice,
+      granted: {
+        gems: normalizedGrant.gems,
+        resources: normalizedGrant.resources,
+        equipmentIds: normalizedGrant.equipmentIds,
+        ...(heroId ? { heroId } : {})
+      },
+      gemsBalance: nextAccount.gems ?? 0,
+      processedAt
+    };
+    this.shopPurchases.set(purchaseKey, structuredClone(result));
+    return result;
   }
 
   async listPlayerBanHistory(
@@ -826,6 +967,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     this.authSessionsByPlayerId.clear();
     this.playerIdByWechatOpenId.clear();
     this.heroArchives.clear();
+    this.shopPurchases.clear();
   }
 }
 

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -1,15 +1,19 @@
 import { randomUUID } from "node:crypto";
 import { createPool, type Pool, type PoolConnection, type ResultSetHeader, type RowDataPacket } from "mysql2/promise";
 import {
+  appendEventLogEntries,
+  getEquipmentDefinition,
   appendPlayerBattleReplaySummaries,
   normalizeEloRating,
   normalizeEventLogQuery,
   normalizeAchievementProgress,
   normalizeEventLogEntries,
   normalizePlayerAccountReadModel,
+  tryAddEquipmentToInventory,
   type EventLogQuery,
   normalizeHeroState,
   type EventLogEntry,
+  type EquipmentId,
   type HeroState,
   type PlayerBanStatus,
   type PlayerAccountReadModel,
@@ -44,6 +48,7 @@ export interface RoomSnapshotStore {
   ): Promise<PlayerAccountSnapshot>;
   creditGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
   debitGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
+  purchaseShopProduct?(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult>;
   savePlayerAccountPrivacyConsent(
     playerId: string,
     input?: PlayerAccountPrivacyConsentInput
@@ -227,6 +232,17 @@ interface PlayerHeroArchiveRow extends RowDataPacket {
   updated_at: Date | string;
 }
 
+interface ShopPurchaseRow extends RowDataPacket {
+  player_id: string;
+  purchase_id: string;
+  product_id: string;
+  quantity: number;
+  unit_price: number;
+  total_price: number;
+  result_json: string | ShopPurchaseResult;
+  created_at: Date | string;
+}
+
 interface PlayerReportRow extends RowDataPacket {
   report_id: string | number;
   reporter_id: string;
@@ -312,6 +328,37 @@ export interface PlayerAccountEnsureInput {
 }
 
 export type GemLedgerReason = "purchase" | "reward" | "spend";
+
+export interface ShopPurchaseGrant {
+  gems?: number;
+  resources?: Partial<ResourceLedger>;
+  equipmentIds?: EquipmentId[];
+}
+
+export interface ShopPurchaseMutationInput {
+  purchaseId: string;
+  productId: string;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  grant: ShopPurchaseGrant;
+}
+
+export interface ShopPurchaseResult {
+  purchaseId: string;
+  productId: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+  granted: {
+    gems: number;
+    resources: ResourceLedger;
+    equipmentIds: EquipmentId[];
+    heroId?: string;
+  };
+  gemsBalance: number;
+  processedAt: string;
+}
 
 export interface GemLedgerEntry {
   entryId: string;
@@ -477,6 +524,7 @@ export const MYSQL_PLAYER_ACCOUNT_WECHAT_OPEN_ID_INDEX = "uidx_player_accounts_w
 export const MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX = "uidx_player_accounts_wechat_idp_open_id";
 export const MYSQL_GEM_LEDGER_TABLE = "gem_ledger";
 export const MYSQL_GEM_LEDGER_PLAYER_CREATED_INDEX = "idx_gem_ledger_player_created";
+export const MYSQL_SHOP_PURCHASE_TABLE = "shop_purchases";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_TABLE = "player_account_sessions";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX = "idx_player_account_sessions_player_last_used";
 export const MYSQL_PLAYER_BAN_HISTORY_TABLE = "player_ban_history";
@@ -529,6 +577,104 @@ function normalizeResourceLedger(resources?: Partial<ResourceLedger>): ResourceL
     wood: 0,
     ore: 0,
     ...resources
+  };
+}
+
+function addResourceLedgers(base: Partial<ResourceLedger>, delta: Partial<ResourceLedger>): ResourceLedger {
+  return {
+    gold: Math.max(0, Math.floor((base.gold ?? 0) + (delta.gold ?? 0))),
+    wood: Math.max(0, Math.floor((base.wood ?? 0) + (delta.wood ?? 0))),
+    ore: Math.max(0, Math.floor((base.ore ?? 0) + (delta.ore ?? 0)))
+  };
+}
+
+function normalizeShopPurchaseId(purchaseId: string): string {
+  const normalized = purchaseId.trim();
+  if (!normalized) {
+    throw new Error("purchaseId must not be empty");
+  }
+
+  return normalized.slice(0, 191);
+}
+
+function normalizeShopProductId(productId: string): string {
+  const normalized = productId.trim();
+  if (!normalized) {
+    throw new Error("productId must not be empty");
+  }
+
+  return normalized.slice(0, 191);
+}
+
+function normalizeShopProductName(productName: string): string {
+  const normalized = productName.trim();
+  if (!normalized) {
+    throw new Error("productName must not be empty");
+  }
+
+  return normalized.slice(0, 80);
+}
+
+function normalizeShopPurchaseQuantity(quantity: number): number {
+  const normalized = Math.floor(quantity);
+  if (!Number.isFinite(quantity) || normalized <= 0) {
+    throw new Error("quantity must be a positive integer");
+  }
+
+  return normalized;
+}
+
+function normalizeShopPurchaseGrant(grant: ShopPurchaseGrant): { gems: number; resources: ResourceLedger; equipmentIds: EquipmentId[] } {
+  const equipmentIds = (grant.equipmentIds ?? []).map((equipmentId) => equipmentId.trim()).filter(Boolean);
+  for (const equipmentId of equipmentIds) {
+    if (!getEquipmentDefinition(equipmentId)) {
+      throw new Error(`unknown equipment grant: ${equipmentId}`);
+    }
+  }
+
+  return {
+    gems: grant.gems != null ? normalizeGemAmount(grant.gems) : 0,
+    resources: normalizeResourceLedger(grant.resources),
+    equipmentIds
+  };
+}
+
+function multiplyShopPurchaseGrant(
+  grant: { gems: number; resources: ResourceLedger; equipmentIds: EquipmentId[] },
+  quantity: number
+): { gems: number; resources: ResourceLedger; equipmentIds: EquipmentId[] } {
+  return {
+    gems: grant.gems * quantity,
+    resources: {
+      gold: grant.resources.gold * quantity,
+      wood: grant.resources.wood * quantity,
+      ore: grant.resources.ore * quantity
+    },
+    equipmentIds: Array.from({ length: quantity }, () => grant.equipmentIds).flat()
+  };
+}
+
+function createShopPurchaseEventLogEntry(playerId: string, input: {
+  productId: string;
+  productName: string;
+  quantity: number;
+  granted: { gems: number; resources: ResourceLedger; equipmentIds: EquipmentId[] };
+  processedAt: string;
+}): EventLogEntry {
+  const resourceRewards = [
+    input.granted.resources.gold > 0 ? { type: "resource" as const, label: "gold", amount: input.granted.resources.gold } : null,
+    input.granted.resources.wood > 0 ? { type: "resource" as const, label: "wood", amount: input.granted.resources.wood } : null,
+    input.granted.resources.ore > 0 ? { type: "resource" as const, label: "ore", amount: input.granted.resources.ore } : null
+  ].filter((reward): reward is NonNullable<typeof reward> => Boolean(reward));
+
+  return {
+    id: `${playerId}:${input.processedAt}:shop:${input.productId}:${input.quantity}`,
+    timestamp: input.processedAt,
+    roomId: "shop",
+    playerId,
+    category: "account",
+    description: `Purchased ${input.productName} x${input.quantity}.`,
+    rewards: resourceRewards
   };
 }
 
@@ -1171,6 +1317,18 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_GEM_LEDGER_TABLE}\` (
   ref_id VARCHAR(191) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (entry_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS \`${MYSQL_SHOP_PURCHASE_TABLE}\` (
+  player_id VARCHAR(191) NOT NULL,
+  purchase_id VARCHAR(191) NOT NULL,
+  product_id VARCHAR(191) NOT NULL,
+  quantity INT NOT NULL,
+  unit_price INT NOT NULL,
+  total_price INT NOT NULL,
+  result_json LONGTEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (player_id, purchase_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\` (
@@ -2041,6 +2199,25 @@ function toPlayerHeroArchiveSnapshot(row: PlayerHeroArchiveRow): PlayerHeroArchi
             : archivedHero.loadout.inventory
       }
     })
+  };
+}
+
+function toShopPurchaseResult(row: ShopPurchaseRow): ShopPurchaseResult {
+  const result = parseJsonColumn<ShopPurchaseResult>(row.result_json);
+  return {
+    purchaseId: normalizeShopPurchaseId(result.purchaseId ?? row.purchase_id),
+    productId: normalizeShopProductId(result.productId ?? row.product_id),
+    quantity: normalizeShopPurchaseQuantity(result.quantity ?? row.quantity),
+    unitPrice: normalizePositiveGemDelta(result.unitPrice ?? row.unit_price),
+    totalPrice: normalizePositiveGemDelta(result.totalPrice ?? row.total_price),
+    granted: {
+      gems: normalizeGemAmount(result.granted?.gems),
+      resources: normalizeResourceLedger(result.granted?.resources),
+      equipmentIds: (result.granted?.equipmentIds ?? []).map((equipmentId) => equipmentId.trim()).filter(Boolean),
+      ...(result.granted?.heroId?.trim() ? { heroId: result.granted.heroId.trim() } : {})
+    },
+    gemsBalance: normalizeGemAmount(result.gemsBalance),
+    processedAt: formatTimestamp(result.processedAt) ?? formatTimestamp(row.created_at) ?? new Date(0).toISOString()
   };
 }
 
@@ -3178,6 +3355,207 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     }
 
     return this.mutateGems(playerId, -normalizePositiveGemDelta(amount), normalizedReason, refId);
+  }
+
+  async purchaseShopProduct(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const normalizedPurchaseId = normalizeShopPurchaseId(input.purchaseId);
+    const normalizedProductId = normalizeShopProductId(input.productId);
+    const normalizedProductName = normalizeShopProductName(input.productName);
+    const normalizedQuantity = normalizeShopPurchaseQuantity(input.quantity);
+    const normalizedUnitPrice = normalizeGemAmount(input.unitPrice);
+    const normalizedGrant = multiplyShopPurchaseGrant(normalizeShopPurchaseGrant(input.grant), normalizedQuantity);
+    const totalPrice = normalizedUnitPrice * normalizedQuantity;
+
+    await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      const [existingPurchaseRows] = await connection.query<ShopPurchaseRow[]>(
+        `SELECT player_id, purchase_id, product_id, quantity, unit_price, total_price, result_json, created_at
+         FROM \`${MYSQL_SHOP_PURCHASE_TABLE}\`
+         WHERE player_id = ? AND purchase_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [normalizedPlayerId, normalizedPurchaseId]
+      );
+      const existingPurchase = existingPurchaseRows[0];
+      if (existingPurchase) {
+        await connection.commit();
+        return toShopPurchaseResult(existingPurchase);
+      }
+
+      const [accountRows] = await connection.query<PlayerAccountRow[]>(
+        `SELECT *
+         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         WHERE player_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [normalizedPlayerId]
+      );
+      const currentAccount =
+        accountRows[0] != null
+          ? toPlayerAccountSnapshot(accountRows[0])
+          : normalizePlayerAccountSnapshot({
+              playerId: normalizedPlayerId,
+              displayName: normalizedPlayerId,
+              globalResources: normalizeResourceLedger()
+            });
+      const currentGems = normalizeGemAmount(currentAccount.gems);
+
+      if (currentGems < totalPrice) {
+        throw new Error("insufficient gems");
+      }
+
+      let grantedHeroId: string | undefined;
+      let nextHeroArchive: PlayerHeroArchiveSnapshot | null = null;
+      if (normalizedGrant.equipmentIds.length > 0) {
+        const [heroArchiveRows] = await connection.query<PlayerHeroArchiveRow[]>(
+          `SELECT player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, inventory_json, updated_at
+           FROM \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
+           WHERE player_id = ?
+           ORDER BY updated_at DESC, hero_id ASC
+           LIMIT 1
+           FOR UPDATE`,
+          [normalizedPlayerId]
+        );
+        const currentArchive = heroArchiveRows[0] ? toPlayerHeroArchiveSnapshot(heroArchiveRows[0]) : null;
+        if (!currentArchive) {
+          throw new Error("player hero archive not found");
+        }
+
+        let nextInventory = [...currentArchive.hero.loadout.inventory];
+        for (const equipmentId of normalizedGrant.equipmentIds) {
+          const inventoryUpdate = tryAddEquipmentToInventory(nextInventory, equipmentId);
+          if (!inventoryUpdate.stored) {
+            throw new Error("equipment inventory full");
+          }
+          nextInventory = inventoryUpdate.inventory;
+        }
+
+        grantedHeroId = currentArchive.heroId;
+        nextHeroArchive = {
+          ...currentArchive,
+          hero: normalizeHeroState({
+            ...currentArchive.hero,
+            loadout: {
+              ...currentArchive.hero.loadout,
+              inventory: nextInventory
+            }
+          })
+        };
+      }
+
+      const processedAt = new Date().toISOString();
+      const nextRecentEventLog = appendEventLogEntries(
+        currentAccount.recentEventLog,
+        [
+          createShopPurchaseEventLogEntry(normalizedPlayerId, {
+            productId: normalizedProductId,
+            productName: normalizedProductName,
+            quantity: normalizedQuantity,
+            granted: normalizedGrant,
+            processedAt
+          })
+        ]
+      );
+      const nextGlobalResources = addResourceLedgers(currentAccount.globalResources, normalizedGrant.resources);
+      const nextGems = currentGems - totalPrice + normalizedGrant.gems;
+
+      await connection.query(
+        `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         SET gems = ?,
+             global_resources_json = ?,
+             recent_event_log_json = ?,
+             version = version + 1
+         WHERE player_id = ?`,
+        [nextGems, JSON.stringify(nextGlobalResources), JSON.stringify(nextRecentEventLog), normalizedPlayerId]
+      );
+      await appendGemLedgerEntry(connection, {
+        entryId: randomUUID(),
+        playerId: normalizedPlayerId,
+        delta: -totalPrice,
+        reason: "spend",
+        refId: normalizedPurchaseId
+      });
+      if (normalizedGrant.gems > 0) {
+        await appendGemLedgerEntry(connection, {
+          entryId: randomUUID(),
+          playerId: normalizedPlayerId,
+          delta: normalizedGrant.gems,
+          reason: "reward",
+          refId: normalizedPurchaseId
+        });
+      }
+
+      if (nextHeroArchive) {
+        await connection.query(
+          `INSERT INTO \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
+             (player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, inventory_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           ON DUPLICATE KEY UPDATE
+             hero_json = VALUES(hero_json),
+             army_template_id = VALUES(army_template_id),
+             army_count = VALUES(army_count),
+             learned_skills_json = VALUES(learned_skills_json),
+             equipment_json = VALUES(equipment_json),
+             inventory_json = VALUES(inventory_json),
+             updated_at = CURRENT_TIMESTAMP`,
+          [
+            nextHeroArchive.playerId,
+            nextHeroArchive.heroId,
+            JSON.stringify(nextHeroArchive.hero),
+            nextHeroArchive.hero.armyTemplateId,
+            nextHeroArchive.hero.armyCount,
+            JSON.stringify(nextHeroArchive.hero.loadout.learnedSkills),
+            JSON.stringify(nextHeroArchive.hero.loadout.equipment),
+            JSON.stringify(nextHeroArchive.hero.loadout.inventory)
+          ]
+        );
+      }
+
+      const result: ShopPurchaseResult = {
+        purchaseId: normalizedPurchaseId,
+        productId: normalizedProductId,
+        quantity: normalizedQuantity,
+        unitPrice: normalizedUnitPrice,
+        totalPrice,
+        granted: {
+          gems: normalizedGrant.gems,
+          resources: normalizedGrant.resources,
+          equipmentIds: normalizedGrant.equipmentIds,
+          ...(grantedHeroId ? { heroId: grantedHeroId } : {})
+        },
+        gemsBalance: nextGems,
+        processedAt
+      };
+
+      await connection.query(
+        `INSERT INTO \`${MYSQL_SHOP_PURCHASE_TABLE}\`
+           (player_id, purchase_id, product_id, quantity, unit_price, total_price, result_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [
+          normalizedPlayerId,
+          normalizedPurchaseId,
+          normalizedProductId,
+          normalizedQuantity,
+          normalizedUnitPrice,
+          totalPrice,
+          JSON.stringify(result)
+        ]
+      );
+      await appendPlayerEventHistoryEntries(connection, normalizedPlayerId, nextRecentEventLog.slice(0, 1));
+
+      await connection.commit();
+      return result;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
   }
 
   private async mutateGems(

--- a/apps/server/src/shop.ts
+++ b/apps/server/src/shop.ts
@@ -1,0 +1,369 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import shopConfigDocument from "../../../configs/shop-config.json";
+import { getEquipmentDefinition, type ResourceLedger } from "../../../packages/shared/src/index";
+import { validateAuthSessionFromRequest } from "./auth";
+import type { RoomSnapshotStore } from "./persistence";
+
+export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle";
+
+export interface ShopProductGrant {
+  gems?: number;
+  resources?: Partial<ResourceLedger>;
+  equipmentIds?: string[];
+}
+
+export interface ShopProduct {
+  productId: string;
+  name: string;
+  type: ShopProductType;
+  price: number;
+  enabled: boolean;
+  grant: ShopProductGrant;
+}
+
+interface ShopConfigDocument {
+  products?: Partial<ShopProduct>[] | null;
+}
+
+interface RegisterShopRoutesOptions {
+  products?: Partial<ShopProduct>[];
+}
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+const MAX_JSON_BODY_BYTES = 32 * 1024;
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    request.resume();
+    throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+    }
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function toErrorPayload(error: unknown): { code: string; message: string } {
+  return {
+    code: error instanceof Error ? error.name || "error" : "error",
+    message: error instanceof Error ? error.message : String(error)
+  };
+}
+
+function normalizePositiveInteger(value: number, field: string, allowZero = false): number {
+  const normalized = Math.floor(value);
+  if (!Number.isFinite(value) || (!allowZero && normalized <= 0) || (allowZero && normalized < 0)) {
+    throw new Error(`${field} must be a ${allowZero ? "non-negative" : "positive"} integer`);
+  }
+
+  return normalized;
+}
+
+function normalizeResourceLedger(resources?: Partial<ResourceLedger> | null): ResourceLedger {
+  return {
+    gold: Math.max(0, Math.floor(resources?.gold ?? 0)),
+    wood: Math.max(0, Math.floor(resources?.wood ?? 0)),
+    ore: Math.max(0, Math.floor(resources?.ore ?? 0))
+  };
+}
+
+function normalizeGrant(rawGrant?: ShopProductGrant | null): ShopProductGrant {
+  const equipmentIds = (rawGrant?.equipmentIds ?? []).map((equipmentId) => equipmentId?.trim()).filter(Boolean) as string[];
+  for (const equipmentId of equipmentIds) {
+    if (!getEquipmentDefinition(equipmentId)) {
+      throw new Error(`shop product references unknown equipment: ${equipmentId}`);
+    }
+  }
+
+  return {
+    ...(rawGrant?.gems != null ? { gems: normalizePositiveInteger(rawGrant.gems, "grant.gems", true) } : {}),
+    ...(equipmentIds.length > 0 ? { equipmentIds } : {}),
+    ...(rawGrant?.resources ? { resources: normalizeResourceLedger(rawGrant.resources) } : {})
+  };
+}
+
+function normalizeShopProducts(rawProducts?: Partial<ShopProduct>[] | null): ShopProduct[] {
+  return (rawProducts ?? []).map((rawProduct, index) => {
+    const productId = rawProduct.productId?.trim();
+    if (!productId) {
+      throw new Error(`shop product[${index}] productId is required`);
+    }
+
+    const name = rawProduct.name?.trim();
+    if (!name) {
+      throw new Error(`shop product ${productId} name is required`);
+    }
+
+    if (rawProduct.type !== "gem_pack" && rawProduct.type !== "equipment" && rawProduct.type !== "resource_bundle") {
+      throw new Error(`shop product ${productId} type must be gem_pack, equipment, or resource_bundle`);
+    }
+
+    const grant = normalizeGrant(rawProduct.grant);
+    const hasGrant =
+      (grant.gems ?? 0) > 0 ||
+      (grant.equipmentIds?.length ?? 0) > 0 ||
+      ((grant.resources?.gold ?? 0) > 0 || (grant.resources?.wood ?? 0) > 0 || (grant.resources?.ore ?? 0) > 0);
+    if (!hasGrant) {
+      throw new Error(`shop product ${productId} grant must not be empty`);
+    }
+
+    if (rawProduct.type === "equipment" && (grant.equipmentIds?.length ?? 0) === 0) {
+      throw new Error(`shop product ${productId} equipment grants must include equipmentIds`);
+    }
+    if (rawProduct.type === "resource_bundle" && !grant.resources) {
+      throw new Error(`shop product ${productId} resource bundles must include resources`);
+    }
+    if (rawProduct.type === "gem_pack" && (grant.gems ?? 0) <= 0) {
+      throw new Error(`shop product ${productId} gem packs must include gems`);
+    }
+
+    return {
+      productId,
+      name,
+      type: rawProduct.type,
+      price: normalizePositiveInteger(rawProduct.price ?? Number.NaN, `shop product ${productId} price`, true),
+      enabled: rawProduct.enabled !== false,
+      grant
+    };
+  });
+}
+
+function resolveShopProducts(options?: RegisterShopRoutesOptions): ShopProduct[] {
+  const configuredProducts = options?.products ?? (shopConfigDocument as ShopConfigDocument).products;
+  return normalizeShopProducts(configuredProducts);
+}
+
+function sendUnauthorized(
+  response: ServerResponse,
+  errorCode: "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked" = "unauthorized"
+): void {
+  sendJson(response, 401, {
+    error: {
+      code: errorCode,
+      message:
+        errorCode === "token_expired"
+          ? "Auth token has expired"
+          : errorCode === "session_revoked"
+            ? "Auth session has been revoked"
+            : "Guest auth session is missing or invalid"
+    }
+  });
+}
+
+function sendAccountBanned(response: ServerResponse, ban?: { banReason?: string; banExpiry?: string } | null): void {
+  sendJson(response, 403, {
+    error: {
+      code: "account_banned",
+      message: "Account is banned",
+      reason: ban?.banReason ?? "No reason provided",
+      ...(ban?.banExpiry ? { expiry: ban.banExpiry } : {})
+    }
+  });
+}
+
+async function requireAuthSession(request: IncomingMessage, response: ServerResponse, store: RoomSnapshotStore | null) {
+  const result = await validateAuthSessionFromRequest(request, store);
+  if (!result.session) {
+    if (result.errorCode === "account_banned") {
+      sendAccountBanned(response, result.ban);
+      return null;
+    }
+    sendUnauthorized(response, result.errorCode ?? "unauthorized");
+    return null;
+  }
+
+  return result.session;
+}
+
+function findProductById(products: ShopProduct[], productId: string): ShopProduct | null {
+  const normalizedProductId = productId.trim();
+  return products.find((product) => product.productId === normalizedProductId) ?? null;
+}
+
+export function registerShopRoutes(
+  app: {
+    use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
+    get: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+    post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+  },
+  store: RoomSnapshotStore | null,
+  options: RegisterShopRoutesOptions = {}
+): void {
+  const products = resolveShopProducts(options);
+
+  app.use((request, response, next) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
+
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    next();
+  });
+
+  app.get("/api/shop/products", async (_request, response) => {
+    sendJson(response, 200, {
+      items: products.filter((product) => product.enabled)
+    });
+  });
+
+  app.post("/api/shop/purchase", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store?.purchaseShopProduct) {
+      sendJson(response, 503, {
+        error: {
+          code: "shop_persistence_unavailable",
+          message: "Shop purchases require configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        productId?: string | null;
+        quantity?: number | null;
+        purchaseId?: string | null;
+      };
+      const productId = body.productId?.trim();
+      const purchaseId = body.purchaseId?.trim();
+      const quantity = normalizePositiveInteger(body.quantity ?? Number.NaN, "quantity");
+
+      if (!productId) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_product_id",
+            message: "productId is required"
+          }
+        });
+        return;
+      }
+
+      if (!purchaseId) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_purchase_id",
+            message: "purchaseId is required"
+          }
+        });
+        return;
+      }
+
+      const product = findProductById(products, productId);
+      if (!product) {
+        sendJson(response, 404, {
+          error: {
+            code: "product_not_found",
+            message: `Shop product not found: ${productId}`
+          }
+        });
+        return;
+      }
+      if (!product.enabled) {
+        sendJson(response, 409, {
+          error: {
+            code: "product_not_available",
+            message: `Shop product is not currently on sale: ${productId}`
+          }
+        });
+        return;
+      }
+
+      const result = await store.purchaseShopProduct(authSession.playerId, {
+        purchaseId,
+        productId: product.productId,
+        productName: product.name,
+        quantity,
+        unitPrice: product.price,
+        grant: product.grant
+      });
+      sendJson(response, 200, result);
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
+
+      if (error instanceof SyntaxError) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_json",
+            message: "Request body must be valid JSON"
+          }
+        });
+        return;
+      }
+
+      if (error instanceof Error && error.message === "insufficient gems") {
+        sendJson(response, 409, {
+          error: {
+            code: "insufficient_gems",
+            message: error.message
+          }
+        });
+        return;
+      }
+
+      if (error instanceof Error && error.message === "equipment inventory full") {
+        sendJson(response, 409, {
+          error: {
+            code: "equipment_inventory_full",
+            message: error.message
+          }
+        });
+        return;
+      }
+
+      if (error instanceof Error && error.message === "player hero archive not found") {
+        sendJson(response, 409, {
+          error: {
+            code: "player_hero_archive_not_found",
+            message: error.message
+          }
+        });
+        return;
+      }
+
+      if (error instanceof Error && /must be/.test(error.message)) {
+        sendJson(response, 400, { error: toErrorPayload(error) });
+        return;
+      }
+
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+}

--- a/apps/server/test/shop-routes.test.ts
+++ b/apps/server/test/shop-routes.test.ts
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Server, WebSocketTransport } from "colyseus";
+import { issueAccountAuthSession } from "../src/auth";
+import type { RoomPersistenceSnapshot } from "../src/index";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import { registerShopRoutes, type ShopProduct } from "../src/shop";
+import {
+  createDefaultHeroLoadout,
+  createDefaultHeroProgression,
+  type PlayerAccountSnapshot
+} from "../../../packages/shared/src/index";
+
+function createShopWorldSnapshot(): RoomPersistenceSnapshot {
+  return {
+    state: {
+      meta: {
+        roomId: "shop-room",
+        seed: 1001,
+        day: 1
+      },
+      map: {
+        width: 1,
+        height: 1,
+        tiles: [
+          {
+            position: { x: 0, y: 0 },
+            terrain: "grass",
+            walkable: true,
+            resource: undefined,
+            occupant: undefined,
+            building: undefined
+          }
+        ]
+      },
+      heroes: [
+        {
+          id: "hero-1",
+          playerId: "shop-player",
+          name: "暮潮守望",
+          position: { x: 0, y: 0 },
+          vision: 2,
+          move: { total: 6, remaining: 6 },
+          stats: { attack: 2, defense: 2, power: 1, knowledge: 1, hp: 20, maxHp: 20 },
+          progression: createDefaultHeroProgression(),
+          loadout: createDefaultHeroLoadout(),
+          armyTemplateId: "hero_guard_basic",
+          armyCount: 12,
+          learnedSkills: []
+        }
+      ],
+      neutralArmies: {},
+      buildings: {},
+      resources: {
+        "shop-player": { gold: 0, wood: 0, ore: 0 }
+      },
+      visibilityByPlayer: {}
+    },
+    battles: []
+  };
+}
+
+async function startShopRouteServer(port: number, store: MemoryRoomSnapshotStore, products: Partial<ShopProduct>[]): Promise<Server> {
+  const transport = new WebSocketTransport();
+  registerShopRoutes(transport.getExpressApp() as never, store, { products });
+  const server = new Server({ transport });
+  await server.listen(port, "127.0.0.1");
+  return server;
+}
+
+const TEST_PRODUCTS: Partial<ShopProduct>[] = [
+  {
+    productId: "starter-bundle",
+    name: "Starter Bundle",
+    type: "resource_bundle",
+    price: 30,
+    enabled: true,
+    grant: {
+      resources: {
+        gold: 120,
+        wood: 10,
+        ore: 5
+      }
+    }
+  },
+  {
+    productId: "sunforged-spear",
+    name: "Sunforged Spear",
+    type: "equipment",
+    price: 20,
+    enabled: true,
+    grant: {
+      equipmentIds: ["sunforged_spear"]
+    }
+  },
+  {
+    productId: "hidden-pack",
+    name: "Hidden Pack",
+    type: "gem_pack",
+    price: 5,
+    enabled: false,
+    grant: {
+      gems: 10
+    }
+  }
+];
+
+test("shop products route returns only enabled items", async (t) => {
+  const port = 42400 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  const server = await startShopRouteServer(port, store, TEST_PRODUCTS);
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/shop/products`);
+  const payload = (await response.json()) as { items: ShopProduct[] };
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(payload.items.map((item) => item.productId), ["starter-bundle", "sunforged-spear"]);
+});
+
+test("shop purchase debits gems and grants resource bundles", async (t) => {
+  const port = 42420 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  await store.save("shop-room", createShopWorldSnapshot());
+  await store.creditGems("shop-player", 100, "purchase", "seed-gems");
+  const server = await startShopRouteServer(port, store, TEST_PRODUCTS);
+  const session = issueAccountAuthSession({
+    playerId: "shop-player",
+    displayName: "暮潮守望",
+    loginId: "shop-player"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "starter-bundle",
+      quantity: 2,
+      purchaseId: "purchase-resource-1"
+    })
+  });
+  const payload = (await response.json()) as {
+    totalPrice: number;
+    gemsBalance: number;
+    granted: {
+      resources: PlayerAccountSnapshot["globalResources"];
+    };
+  };
+
+  const account = await store.loadPlayerAccount("shop-player");
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.totalPrice, 60);
+  assert.equal(payload.gemsBalance, 40);
+  assert.deepEqual(payload.granted.resources, { gold: 240, wood: 20, ore: 10 });
+  assert.deepEqual(account?.globalResources, { gold: 240, wood: 20, ore: 10 });
+  assert.equal(account?.gems, 40);
+});
+
+test("shop purchase grants equipment and replays the original result for the same purchaseId", async (t) => {
+  const port = 42440 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  await store.save("shop-room", createShopWorldSnapshot());
+  await store.creditGems("shop-player", 100, "purchase", "seed-gems");
+  const server = await startShopRouteServer(port, store, TEST_PRODUCTS);
+  const session = issueAccountAuthSession({
+    playerId: "shop-player",
+    displayName: "暮潮守望",
+    loginId: "shop-player"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstResponse = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "sunforged-spear",
+      quantity: 1,
+      purchaseId: "purchase-equipment-1"
+    })
+  });
+  const firstPayload = await firstResponse.json();
+
+  const secondResponse = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "sunforged-spear",
+      quantity: 1,
+      purchaseId: "purchase-equipment-1"
+    })
+  });
+  const secondPayload = await secondResponse.json();
+
+  const account = await store.loadPlayerAccount("shop-player");
+  const archives = await store.loadPlayerHeroArchives(["shop-player"]);
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(secondResponse.status, 200);
+  assert.deepEqual(secondPayload, firstPayload);
+  assert.equal(account?.gems, 80);
+  assert.deepEqual(archives[0]?.hero.loadout.inventory, ["sunforged_spear"]);
+});
+
+test("shop purchase rejects insufficient gems without debiting or granting", async (t) => {
+  const port = 42460 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  await store.save("shop-room", createShopWorldSnapshot());
+  await store.creditGems("shop-player", 10, "purchase", "seed-gems");
+  const server = await startShopRouteServer(port, store, TEST_PRODUCTS);
+  const session = issueAccountAuthSession({
+    playerId: "shop-player",
+    displayName: "暮潮守望",
+    loginId: "shop-player"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "starter-bundle",
+      quantity: 1,
+      purchaseId: "purchase-fail-1"
+    })
+  });
+  const payload = (await response.json()) as {
+    error: {
+      code: string;
+    };
+  };
+
+  const account = await store.loadPlayerAccount("shop-player");
+  const archives = await store.loadPlayerHeroArchives(["shop-player"]);
+
+  assert.equal(response.status, 409);
+  assert.equal(payload.error.code, "insufficient_gems");
+  assert.equal(account?.gems, 10);
+  assert.deepEqual(account?.globalResources, { gold: 0, wood: 0, ore: 0 });
+  assert.deepEqual(archives[0]?.hero.loadout.inventory, []);
+});

--- a/configs/shop-config.json
+++ b/configs/shop-config.json
@@ -1,0 +1,38 @@
+{
+  "products": [
+    {
+      "productId": "resource-bundle-starter",
+      "name": "Starter Supply Cache",
+      "type": "resource_bundle",
+      "price": 25,
+      "enabled": true,
+      "grant": {
+        "resources": {
+          "gold": 250,
+          "wood": 40,
+          "ore": 20
+        }
+      }
+    },
+    {
+      "productId": "equipment-sunforged-kit",
+      "name": "Sunforged Kit",
+      "type": "equipment",
+      "price": 40,
+      "enabled": true,
+      "grant": {
+        "equipmentIds": ["sunforged_spear"]
+      }
+    },
+    {
+      "productId": "gem-pack-scout",
+      "name": "Scout Gem Cache",
+      "type": "gem_pack",
+      "price": 5,
+      "enabled": false,
+      "grant": {
+        "gems": 15
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add config-backed shop products and /api/shop/products plus /api/shop/purchase routes
- add idempotent purchase handling with atomic gem debit, resource grants, and hero archive equipment grants
- add focused server tests for listing, successful purchases, insufficient gems, and purchase replay

## Validation
- node --import tsx --test ./apps/server/test/shop-routes.test.ts
- npm run typecheck:server (currently fails on a pre-existing config-center terrain typing issue)

Closes #793