### PR TITLE
[codex] Add WeChat Pay order flow

### DIFF
--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -30,6 +30,7 @@ import { registerAdminRoutes } from "./admin-console";
 import { registerShopRoutes } from "./shop";
 import { formatSchemaMigrationWarning, getSchemaMigrationStatus } from "./schema-migrations";
 import { closeRedisResource, createRedisDriver, createRedisPresence, readRedisUrl } from "./redis";
+import { registerWechatPayRoutes } from "./wechat-pay";
 
 loadEnv();
 
@@ -111,6 +112,7 @@ export interface DevServerBootstrapDependencies {
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerPlayerAccountRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerShopRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
+  registerWechatPayRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerLobbyRoutes(app: unknown, dependencies: { listRooms: typeof listLobbyRooms }): void;
   registerMatchmakingRoutes(app: unknown, dependencies: { store: DevServerRoomSnapshotStore }): void;
   registerRuntimeObservabilityRoutes(app: unknown, options?: { store?: DevServerRoomSnapshotStore }): void;
@@ -173,6 +175,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
     registerPlayerAccountRoutes: (app, store) => registerPlayerAccountRoutes(app as never, store as RoomSnapshotStore),
     registerShopRoutes: (app, store) => registerShopRoutes(app as never, store as RoomSnapshotStore),
+    registerWechatPayRoutes: (app, store) => registerWechatPayRoutes(app as never, store as RoomSnapshotStore),
     registerLobbyRoutes: (app, dependencies) => registerLobbyRoutes(app as never, dependencies),
     registerMatchmakingRoutes: (app, dependencies) =>
       registerMatchmakingRoutes(app as never, { store: dependencies.store as RoomSnapshotStore }),
@@ -235,6 +238,7 @@ export async function startDevServer(
   deps.registerConfigViewerRoutes(expressApp, configCenterStore);
   deps.registerPlayerAccountRoutes(expressApp, effectiveSnapshotStore);
   deps.registerShopRoutes(expressApp, effectiveSnapshotStore);
+  deps.registerWechatPayRoutes(expressApp, effectiveSnapshotStore);
   deps.registerLobbyRoutes(expressApp, { listRooms: listLobbyRooms });
   deps.registerMatchmakingRoutes(expressApp, { store: effectiveSnapshotStore });
   deps.registerRuntimeObservabilityRoutes(expressApp, { store: effectiveSnapshotStore });
@@ -253,6 +257,7 @@ export async function startDevServer(
   deps.logger.log(`Player account API available at http://${host}:${port}/api/player-accounts`);
   deps.logger.log(`Guest auth API available at http://${host}:${port}/api/auth/guest-login`);
   deps.logger.log(`WeChat auth API available at http://${host}:${port}/api/auth/wechat-login`);
+  deps.logger.log(`WeChat Pay API available at http://${host}:${port}/api/payments/wechat/create`);
   deps.logger.log(`Lobby API available at http://${host}:${port}/api/lobby/rooms`);
   deps.logger.log(`Matchmaking API available at http://${host}:${port}/api/matchmaking/status`);
   deps.logger.log(`Runtime health available at http://${host}:${port}/api/runtime/health`);

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -11,6 +11,10 @@ import {
   createPlayerAccountsFromWorldState,
   MAX_PLAYER_AVATAR_URL_LENGTH,
   MAX_PLAYER_DISPLAY_NAME_LENGTH,
+  type PaymentOrderCompleteInput,
+  type PaymentOrderCreateInput,
+  type PaymentOrderSettlement,
+  type PaymentOrderSnapshot,
   type RoomSnapshotStore,
   type PlayerAccountBanHistoryListOptions,
   type PlayerAccountBanInput,
@@ -97,6 +101,7 @@ function normalizeResourceLedger(resources?: PlayerAccountSnapshot["globalResour
 export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly snapshots = new Map<string, RoomPersistenceSnapshot>();
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+  private readonly paymentOrders = new Map<string, PaymentOrderSnapshot>();
   private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
@@ -114,6 +119,16 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     const account = this.accounts.get(normalizePlayerId(playerId));
     return account ? cloneAccount(account) : null;
+  }
+
+  async loadPaymentOrder(orderId: string): Promise<PaymentOrderSnapshot | null> {
+    const normalizedOrderId = orderId.trim();
+    if (!normalizedOrderId) {
+      throw new Error("orderId must not be empty");
+    }
+
+    const order = this.paymentOrders.get(normalizedOrderId);
+    return order ? structuredClone(order) : null;
   }
 
   async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
@@ -337,6 +352,88 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     };
     this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     return cloneAccount(nextAccount);
+  }
+
+  async createPaymentOrder(input: PaymentOrderCreateInput): Promise<PaymentOrderSnapshot> {
+    const orderId = input.orderId.trim();
+    const playerId = normalizePlayerId(input.playerId);
+    const productId = input.productId.trim();
+    const amount = Math.floor(input.amount);
+    const gemAmount = Math.floor(input.gemAmount);
+    if (!orderId) {
+      throw new Error("orderId must not be empty");
+    }
+    if (!productId) {
+      throw new Error("productId must not be empty");
+    }
+    if (!Number.isFinite(input.amount) || amount <= 0) {
+      throw new Error("amount must be a positive integer");
+    }
+    if (!Number.isFinite(input.gemAmount) || gemAmount <= 0) {
+      throw new Error("gemAmount must be a positive integer");
+    }
+
+    await this.ensurePlayerAccount({ playerId });
+    const now = new Date().toISOString();
+    const order: PaymentOrderSnapshot = {
+      orderId,
+      playerId,
+      productId,
+      status: "pending",
+      amount,
+      gemAmount,
+      createdAt: now,
+      updatedAt: now
+    };
+    this.paymentOrders.set(orderId, structuredClone(order));
+    return structuredClone(order);
+  }
+
+  async completePaymentOrder(orderId: string, input: PaymentOrderCompleteInput): Promise<PaymentOrderSettlement> {
+    const normalizedOrderId = orderId.trim();
+    const normalizedWechatOrderId = input.wechatOrderId.trim();
+    if (!normalizedOrderId) {
+      throw new Error("orderId must not be empty");
+    }
+    if (!normalizedWechatOrderId) {
+      throw new Error("wechatOrderId must not be empty");
+    }
+
+    const existingOrder = this.paymentOrders.get(normalizedOrderId);
+    if (!existingOrder) {
+      throw new Error("payment_order_not_found");
+    }
+
+    const account = await this.ensurePlayerAccount({ playerId: existingOrder.playerId });
+    if (existingOrder.status === "paid") {
+      return {
+        order: structuredClone(existingOrder),
+        account,
+        credited: false
+      };
+    }
+
+    const paidAt = new Date(input.paidAt ?? Date.now()).toISOString();
+    const nextOrder: PaymentOrderSnapshot = {
+      ...structuredClone(existingOrder),
+      status: "paid",
+      wechatOrderId: normalizedWechatOrderId,
+      paidAt,
+      updatedAt: paidAt
+    };
+    const nextAccount: PlayerAccountSnapshot = {
+      ...account,
+      gems: (account.gems ?? 0) + existingOrder.gemAmount,
+      updatedAt: paidAt
+    };
+    this.paymentOrders.set(normalizedOrderId, structuredClone(nextOrder));
+    this.accounts.set(existingOrder.playerId, cloneAccount(nextAccount));
+
+    return {
+      order: structuredClone(nextOrder),
+      account: cloneAccount(nextAccount),
+      credited: true
+    };
   }
 
   async purchaseShopProduct(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult> {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -27,6 +27,7 @@ import type { RoomPersistenceSnapshot } from "./index";
 export interface RoomSnapshotStore {
   load(roomId: string): Promise<RoomPersistenceSnapshot | null>;
   loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null>;
+  loadPaymentOrder?(orderId: string): Promise<PaymentOrderSnapshot | null>;
   loadPlayerReport?(reportId: string): Promise<PlayerReportRecord | null>;
   loadPlayerBan?(playerId: string): Promise<PlayerAccountBanSnapshot | null>;
   createPlayerReport?(input: PlayerReportCreateInput): Promise<PlayerReportRecord>;
@@ -46,6 +47,8 @@ export interface RoomSnapshotStore {
     playerId: string,
     input: PlayerAccountCredentialInput
   ): Promise<PlayerAccountSnapshot>;
+  createPaymentOrder?(input: PaymentOrderCreateInput): Promise<PaymentOrderSnapshot>;
+  completePaymentOrder?(orderId: string, input: PaymentOrderCompleteInput): Promise<PaymentOrderSettlement>;
   creditGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
   debitGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
   purchaseShopProduct?(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult>;
@@ -243,6 +246,19 @@ interface ShopPurchaseRow extends RowDataPacket {
   created_at: Date | string;
 }
 
+interface PaymentOrderRow extends RowDataPacket {
+  order_id: string;
+  player_id: string;
+  product_id: string;
+  wechat_order_id: string | null;
+  status: string;
+  amount: number;
+  gem_amount: number;
+  created_at: Date | string;
+  paid_at: Date | string | null;
+  updated_at: Date | string;
+}
+
 interface PlayerReportRow extends RowDataPacket {
   report_id: string | number;
   reporter_id: string;
@@ -358,6 +374,40 @@ export interface ShopPurchaseResult {
   };
   gemsBalance: number;
   processedAt: string;
+}
+
+export type PaymentOrderStatus = "pending" | "paid";
+
+export interface PaymentOrderSnapshot {
+  orderId: string;
+  playerId: string;
+  productId: string;
+  status: PaymentOrderStatus;
+  amount: number;
+  gemAmount: number;
+  createdAt: string;
+  updatedAt: string;
+  wechatOrderId?: string;
+  paidAt?: string;
+}
+
+export interface PaymentOrderCreateInput {
+  orderId: string;
+  playerId: string;
+  productId: string;
+  amount: number;
+  gemAmount: number;
+}
+
+export interface PaymentOrderCompleteInput {
+  wechatOrderId: string;
+  paidAt?: string;
+}
+
+export interface PaymentOrderSettlement {
+  order: PaymentOrderSnapshot;
+  account: PlayerAccountSnapshot;
+  credited: boolean;
 }
 
 export interface GemLedgerEntry {
@@ -525,6 +575,9 @@ export const MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX = "uidx_player_accoun
 export const MYSQL_GEM_LEDGER_TABLE = "gem_ledger";
 export const MYSQL_GEM_LEDGER_PLAYER_CREATED_INDEX = "idx_gem_ledger_player_created";
 export const MYSQL_SHOP_PURCHASE_TABLE = "shop_purchases";
+export const MYSQL_PAYMENT_ORDER_TABLE = "orders";
+export const MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX = "idx_orders_player_created";
+export const MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX = "uidx_orders_wechat_order_id";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_TABLE = "player_account_sessions";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX = "idx_player_account_sessions_player_last_used";
 export const MYSQL_PLAYER_BAN_HISTORY_TABLE = "player_ban_history";
@@ -595,6 +648,56 @@ function normalizeShopPurchaseId(purchaseId: string): string {
   }
 
   return normalized.slice(0, 191);
+}
+
+function normalizePaymentOrderId(orderId: string): string {
+  const normalized = orderId.trim();
+  if (!normalized) {
+    throw new Error("orderId must not be empty");
+  }
+
+  return normalized.slice(0, 191);
+}
+
+function normalizePaymentOrderStatus(status?: string | null): PaymentOrderStatus {
+  return status === "paid" ? "paid" : "pending";
+}
+
+function normalizeWechatOrderId(wechatOrderId: string): string {
+  const normalized = wechatOrderId.trim();
+  if (!normalized) {
+    throw new Error("wechatOrderId must not be empty");
+  }
+
+  return normalized.slice(0, 191);
+}
+
+function normalizePaymentAmount(amount: number): number {
+  const normalized = Math.floor(amount);
+  if (!Number.isFinite(amount) || normalized <= 0) {
+    throw new Error("amount must be a positive integer");
+  }
+
+  return normalized;
+}
+
+function toPaymentOrderSnapshot(row: PaymentOrderRow): PaymentOrderSnapshot {
+  const createdAt = formatTimestamp(row.created_at) ?? new Date(0).toISOString();
+  const updatedAt = formatTimestamp(row.updated_at) ?? createdAt;
+  const paidAt = formatTimestamp(row.paid_at);
+
+  return {
+    orderId: normalizePaymentOrderId(row.order_id),
+    playerId: normalizePlayerId(row.player_id),
+    productId: normalizeShopProductId(row.product_id),
+    status: normalizePaymentOrderStatus(row.status),
+    amount: normalizePaymentAmount(row.amount),
+    gemAmount: normalizeGemAmount(row.gem_amount),
+    createdAt,
+    updatedAt,
+    ...(row.wechat_order_id ? { wechatOrderId: normalizeWechatOrderId(row.wechat_order_id) } : {}),
+    ...(paidAt ? { paidAt } : {})
+  };
 }
 
 function normalizeShopProductId(productId: string): string {
@@ -1331,6 +1434,20 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_SHOP_PURCHASE_TABLE}\` (
   PRIMARY KEY (player_id, purchase_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS \`${MYSQL_PAYMENT_ORDER_TABLE}\` (
+  order_id VARCHAR(191) NOT NULL,
+  player_id VARCHAR(191) NOT NULL,
+  product_id VARCHAR(191) NOT NULL,
+  wechat_order_id VARCHAR(191) NULL,
+  status VARCHAR(16) NOT NULL DEFAULT 'pending',
+  amount INT NOT NULL,
+  gem_amount INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  paid_at DATETIME NULL DEFAULT NULL,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (order_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
   session_id VARCHAR(64) NOT NULL,
@@ -1994,6 +2111,42 @@ SET @veil_gem_ledger_idx_sql := IF(
 PREPARE veil_gem_ledger_idx_stmt FROM @veil_gem_ledger_idx_sql;
 EXECUTE veil_gem_ledger_idx_stmt;
 DEALLOCATE PREPARE veil_gem_ledger_idx_stmt;
+
+SET @veil_payment_orders_player_created_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX}'
+);
+
+SET @veil_payment_orders_player_created_idx_sql := IF(
+  @veil_payment_orders_player_created_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX}\` ON \`${MYSQL_PAYMENT_ORDER_TABLE}\` (player_id, created_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_player_created_idx_stmt FROM @veil_payment_orders_player_created_idx_sql;
+EXECUTE veil_payment_orders_player_created_idx_stmt;
+DEALLOCATE PREPARE veil_payment_orders_player_created_idx_stmt;
+
+SET @veil_payment_orders_wechat_order_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX}'
+);
+
+SET @veil_payment_orders_wechat_order_idx_sql := IF(
+  @veil_payment_orders_wechat_order_idx_exists = 0,
+  'CREATE UNIQUE INDEX \`${MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX}\` ON \`${MYSQL_PAYMENT_ORDER_TABLE}\` (wechat_order_id)',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_wechat_order_idx_stmt FROM @veil_payment_orders_wechat_order_idx_sql;
+EXECUTE veil_payment_orders_wechat_order_idx_stmt;
+DEALLOCATE PREPARE veil_payment_orders_wechat_order_idx_stmt;
 
 SET @veil_player_ban_history_idx_exists := (
   SELECT COUNT(*)
@@ -2661,6 +2814,30 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     const normalizedPlayerId = normalizePlayerId(playerId);
     const accounts = await this.loadPlayerAccounts([normalizedPlayerId]);
     return accounts[0] ?? null;
+  }
+
+  async loadPaymentOrder(orderId: string): Promise<PaymentOrderSnapshot | null> {
+    const normalizedOrderId = normalizePaymentOrderId(orderId);
+    const [rows] = await this.pool.query<PaymentOrderRow[]>(
+      `SELECT
+         order_id,
+         player_id,
+         product_id,
+         wechat_order_id,
+         status,
+         amount,
+         gem_amount,
+         created_at,
+         paid_at,
+         updated_at
+       FROM \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+       WHERE order_id = ?
+       LIMIT 1`,
+      [normalizedOrderId]
+    );
+
+    const row = rows[0];
+    return row ? toPaymentOrderSnapshot(row) : null;
   }
 
   async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
@@ -3355,6 +3532,155 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     }
 
     return this.mutateGems(playerId, -normalizePositiveGemDelta(amount), normalizedReason, refId);
+  }
+
+  async createPaymentOrder(input: PaymentOrderCreateInput): Promise<PaymentOrderSnapshot> {
+    const orderId = normalizePaymentOrderId(input.orderId);
+    const playerId = normalizePlayerId(input.playerId);
+    const productId = normalizeShopProductId(input.productId);
+    const amount = normalizePaymentAmount(input.amount);
+    const gemAmount = normalizePositiveGemDelta(input.gemAmount);
+
+    await this.ensurePlayerAccount({ playerId });
+
+    await this.pool.query(
+      `INSERT INTO \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+         (order_id, player_id, product_id, status, amount, gem_amount)
+       VALUES (?, ?, ?, 'pending', ?, ?)`,
+      [orderId, playerId, productId, amount, gemAmount]
+    );
+
+    return {
+      orderId,
+      playerId,
+      productId,
+      status: "pending",
+      amount,
+      gemAmount,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+  }
+
+  async completePaymentOrder(orderId: string, input: PaymentOrderCompleteInput): Promise<PaymentOrderSettlement> {
+    const normalizedOrderId = normalizePaymentOrderId(orderId);
+    const normalizedWechatOrderId = normalizeWechatOrderId(input.wechatOrderId);
+    const paidAt = input.paidAt ? new Date(input.paidAt) : new Date();
+    if (Number.isNaN(paidAt.getTime())) {
+      throw new Error("paidAt must be a valid ISO timestamp");
+    }
+
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      const [orderRows] = await connection.query<PaymentOrderRow[]>(
+        `SELECT
+           order_id,
+           player_id,
+           product_id,
+           wechat_order_id,
+           status,
+           amount,
+           gem_amount,
+           created_at,
+           paid_at,
+           updated_at
+         FROM \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+         WHERE order_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [normalizedOrderId]
+      );
+      const currentOrderRow = orderRows[0];
+      if (!currentOrderRow) {
+        throw new Error("payment_order_not_found");
+      }
+
+      const currentOrder = toPaymentOrderSnapshot(currentOrderRow);
+      const [accountRows] = await connection.query<PlayerAccountRow[]>(
+        `SELECT *
+         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         WHERE player_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [currentOrder.playerId]
+      );
+      const currentAccount =
+        accountRows[0] != null
+          ? toPlayerAccountSnapshot(accountRows[0])
+          : normalizePlayerAccountSnapshot({
+              playerId: currentOrder.playerId,
+              displayName: currentOrder.playerId,
+              globalResources: normalizeResourceLedger()
+            });
+
+      if (currentOrder.status === "paid") {
+        await connection.commit();
+        return {
+          order: {
+            ...currentOrder,
+            ...(currentOrder.wechatOrderId ? { wechatOrderId: currentOrder.wechatOrderId } : { wechatOrderId: normalizedWechatOrderId }),
+            ...(currentOrder.paidAt ? { paidAt: currentOrder.paidAt } : { paidAt: paidAt.toISOString() })
+          },
+          account: currentAccount,
+          credited: false
+        };
+      }
+
+      const nextGems = normalizeGemAmount(currentAccount.gems) + currentOrder.gemAmount;
+      await connection.query(
+        `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         SET gems = ?,
+             version = version + 1
+         WHERE player_id = ?`,
+        [nextGems, currentOrder.playerId]
+      );
+      await appendGemLedgerEntry(connection, {
+        entryId: randomUUID(),
+        playerId: currentOrder.playerId,
+        delta: currentOrder.gemAmount,
+        reason: "purchase",
+        refId: currentOrder.orderId
+      });
+      await connection.query(
+        `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+         SET wechat_order_id = ?,
+             status = 'paid',
+             paid_at = ?
+         WHERE order_id = ?`,
+        [normalizedWechatOrderId, paidAt, currentOrder.orderId]
+      );
+
+      await connection.commit();
+
+      const nextAccount =
+        (await this.loadPlayerAccount(currentOrder.playerId)) ??
+        normalizePlayerAccountSnapshot({
+          ...currentAccount,
+          gems: nextGems
+        });
+      const nextOrder =
+        (await this.loadPaymentOrder(currentOrder.orderId)) ??
+        ({
+          ...currentOrder,
+          status: "paid",
+          wechatOrderId: normalizedWechatOrderId,
+          paidAt: paidAt.toISOString(),
+          updatedAt: paidAt.toISOString()
+        } satisfies PaymentOrderSnapshot);
+
+      return {
+        order: nextOrder,
+        account: nextAccount,
+        credited: true
+      };
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
   }
 
   async purchaseShopProduct(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult> {

--- a/apps/server/src/shop.ts
+++ b/apps/server/src/shop.ts
@@ -17,6 +17,7 @@ export interface ShopProduct {
   name: string;
   type: ShopProductType;
   price: number;
+  wechatPriceFen?: number;
   enabled: boolean;
   grant: ShopProductGrant;
 }
@@ -25,7 +26,7 @@ interface ShopConfigDocument {
   products?: Partial<ShopProduct>[] | null;
 }
 
-interface RegisterShopRoutesOptions {
+export interface RegisterShopRoutesOptions {
   products?: Partial<ShopProduct>[];
 }
 
@@ -148,13 +149,16 @@ function normalizeShopProducts(rawProducts?: Partial<ShopProduct>[] | null): Sho
       name,
       type: rawProduct.type,
       price: normalizePositiveInteger(rawProduct.price ?? Number.NaN, `shop product ${productId} price`, true),
+      ...(rawProduct.wechatPriceFen != null
+        ? { wechatPriceFen: normalizePositiveInteger(rawProduct.wechatPriceFen, `shop product ${productId} wechatPriceFen`) }
+        : {}),
       enabled: rawProduct.enabled !== false,
       grant
     };
   });
 }
 
-function resolveShopProducts(options?: RegisterShopRoutesOptions): ShopProduct[] {
+export function resolveShopProducts(options?: RegisterShopRoutesOptions): ShopProduct[] {
   const configuredProducts = options?.products ?? (shopConfigDocument as ShopConfigDocument).products;
   return normalizeShopProducts(configuredProducts);
 }

--- a/apps/server/src/wechat-pay.ts
+++ b/apps/server/src/wechat-pay.ts
@@ -1,0 +1,598 @@
+import { createCipheriv, createDecipheriv, createSign, createVerify, randomBytes, randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { validateAuthSessionFromRequest } from "./auth";
+import type { PaymentOrderSnapshot, RoomSnapshotStore } from "./persistence";
+import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct } from "./shop";
+
+interface HttpApp {
+  use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
+  post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+}
+
+interface WechatPayRuntimeConfig {
+  appId: string;
+  merchantId: string;
+  merchantCertificateSerial: string;
+  merchantPrivateKey: string;
+  platformCertificateSerial: string;
+  platformPublicKey: string;
+  apiV3Key: string;
+  notifyUrl: string;
+  transactionsJsapiUrl: string;
+}
+
+interface RegisterWechatPayRoutesOptions extends RegisterShopRoutesOptions {
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  orderIdGenerator?: () => string;
+  runtimeConfig?: WechatPayRuntimeConfig | null;
+}
+
+interface WechatPayTransactionsJsapiResponse {
+  prepay_id?: string;
+}
+
+interface WechatPayCallbackEnvelope {
+  id?: string;
+  event_type?: string;
+  resource_type?: string;
+  resource?: {
+    algorithm?: string;
+    ciphertext?: string;
+    nonce?: string;
+    associated_data?: string;
+  } | null;
+}
+
+interface WechatPayCallbackTransaction {
+  appid?: string;
+  mchid?: string;
+  out_trade_no?: string;
+  transaction_id?: string;
+  trade_state?: string;
+  success_time?: string;
+  amount?: {
+    total?: number;
+  } | null;
+  payer?: {
+    openid?: string;
+  } | null;
+}
+
+const MAX_JSON_BODY_BYTES = 64 * 1024;
+const SUCCESS_CALLBACK_BODY = { code: "SUCCESS", message: "success" };
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+function normalizePemValue(value: string): string {
+  return value.replace(/\\n/g, "\n").trim();
+}
+
+function readPemValue(env: NodeJS.ProcessEnv, key: string): string | null {
+  const direct = env[key]?.trim();
+  if (direct) {
+    return normalizePemValue(direct);
+  }
+
+  const base64Value = env[`${key}_BASE64`]?.trim();
+  if (!base64Value) {
+    return null;
+  }
+
+  return normalizePemValue(Buffer.from(base64Value, "base64").toString("utf8"));
+}
+
+function readWechatPayRuntimeConfig(env: NodeJS.ProcessEnv = process.env): WechatPayRuntimeConfig | null {
+  const appId = env.VEIL_WECHAT_PAY_APP_ID?.trim();
+  const merchantId = env.VEIL_WECHAT_PAY_MERCHANT_ID?.trim();
+  const merchantCertificateSerial = env.VEIL_WECHAT_PAY_CERT_SERIAL?.trim();
+  const platformCertificateSerial = env.VEIL_WECHAT_PAY_PLATFORM_SERIAL?.trim();
+  const apiV3Key = env.VEIL_WECHAT_PAY_API_V3_KEY?.trim();
+  const notifyUrl = env.VEIL_WECHAT_PAY_NOTIFY_URL?.trim();
+  const merchantPrivateKey = readPemValue(env, "VEIL_WECHAT_PAY_PRIVATE_KEY");
+  const platformPublicKey = readPemValue(env, "VEIL_WECHAT_PAY_PLATFORM_PUBLIC_KEY");
+
+  if (
+    !appId ||
+    !merchantId ||
+    !merchantCertificateSerial ||
+    !platformCertificateSerial ||
+    !apiV3Key ||
+    !notifyUrl ||
+    !merchantPrivateKey ||
+    !platformPublicKey
+  ) {
+    return null;
+  }
+
+  return {
+    appId,
+    merchantId,
+    merchantCertificateSerial,
+    merchantPrivateKey,
+    platformCertificateSerial,
+    platformPublicKey,
+    apiV3Key,
+    notifyUrl,
+    transactionsJsapiUrl: env.VEIL_WECHAT_PAY_TRANSACTIONS_JSAPI_URL?.trim() || "https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi"
+  };
+}
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+async function readRawBody(request: IncomingMessage): Promise<Buffer> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    request.resume();
+    throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+    }
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const body = await readRawBody(request);
+  return body.byteLength > 0 ? JSON.parse(body.toString("utf8")) : {};
+}
+
+function normalizeProductId(productId?: string | null): string {
+  const normalized = productId?.trim();
+  if (!normalized) {
+    throw new Error("productId is required");
+  }
+
+  return normalized;
+}
+
+function normalizeWechatPayProduct(product: ShopProduct | undefined): ShopProduct & { wechatPriceFen: number; grant: { gems: number } } {
+  if (!product) {
+    throw new Error("product_not_found");
+  }
+  if (product.type !== "gem_pack") {
+    throw new Error("wechat_pay_requires_gem_pack");
+  }
+  if (!product.wechatPriceFen || product.wechatPriceFen <= 0) {
+    throw new Error("wechat_pay_price_not_configured");
+  }
+  if (!product.grant.gems || product.grant.gems <= 0) {
+    throw new Error("wechat_pay_gem_grant_not_configured");
+  }
+
+  return product as ShopProduct & { wechatPriceFen: number; grant: { gems: number } };
+}
+
+function randomNonce(): string {
+  return randomBytes(16).toString("hex");
+}
+
+function signWithMerchantKey(config: WechatPayRuntimeConfig, message: string): string {
+  const signer = createSign("RSA-SHA256");
+  signer.update(message);
+  signer.end();
+  return signer.sign(config.merchantPrivateKey, "base64");
+}
+
+function buildWechatAuthorization(
+  config: WechatPayRuntimeConfig,
+  method: string,
+  requestUrl: URL,
+  body: string,
+  timestamp: string,
+  nonce: string
+): string {
+  const message = `${method}\n${requestUrl.pathname}${requestUrl.search}\n${timestamp}\n${nonce}\n${body}\n`;
+  const signature = signWithMerchantKey(config, message);
+  return `WECHATPAY2-SHA256-RSA2048 mchid="${config.merchantId}",nonce_str="${nonce}",timestamp="${timestamp}",serial_no="${config.merchantCertificateSerial}",signature="${signature}"`;
+}
+
+function buildClientPaySign(config: WechatPayRuntimeConfig, timeStamp: string, nonceStr: string, packageValue: string): string {
+  return signWithMerchantKey(config, `${config.appId}\n${timeStamp}\n${nonceStr}\n${packageValue}\n`);
+}
+
+function verifyWechatCallbackSignature(
+  config: WechatPayRuntimeConfig,
+  headers: IncomingMessage["headers"],
+  body: string
+): boolean {
+  const signature = headers["wechatpay-signature"];
+  const nonce = headers["wechatpay-nonce"];
+  const timestamp = headers["wechatpay-timestamp"];
+  const serial = headers["wechatpay-serial"];
+  if (
+    typeof signature !== "string" ||
+    typeof nonce !== "string" ||
+    typeof timestamp !== "string" ||
+    typeof serial !== "string" ||
+    serial.trim() !== config.platformCertificateSerial
+  ) {
+    return false;
+  }
+
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(`${timestamp}\n${nonce}\n${body}\n`);
+  verifier.end();
+  return verifier.verify(config.platformPublicKey, signature, "base64");
+}
+
+function decryptWechatCallbackResource(config: WechatPayRuntimeConfig, envelope: WechatPayCallbackEnvelope): WechatPayCallbackTransaction {
+  const resource = envelope.resource;
+  if (
+    !resource ||
+    resource.algorithm !== "AEAD_AES_256_GCM" ||
+    typeof resource.ciphertext !== "string" ||
+    typeof resource.nonce !== "string"
+  ) {
+    throw new Error("invalid_wechat_callback_resource");
+  }
+
+  const apiV3Key = Buffer.from(config.apiV3Key, "utf8");
+  if (apiV3Key.byteLength !== 32) {
+    throw new Error("invalid_wechat_pay_api_v3_key");
+  }
+
+  const ciphertext = Buffer.from(resource.ciphertext, "base64");
+  const authTag = ciphertext.subarray(ciphertext.byteLength - 16);
+  const encrypted = ciphertext.subarray(0, ciphertext.byteLength - 16);
+  const decipher = createDecipheriv("aes-256-gcm", apiV3Key, Buffer.from(resource.nonce, "utf8"));
+  if (resource.associated_data) {
+    decipher.setAAD(Buffer.from(resource.associated_data, "utf8"));
+  }
+  decipher.setAuthTag(authTag);
+
+  const plainText = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+  return JSON.parse(plainText) as WechatPayCallbackTransaction;
+}
+
+function sendUnauthorized(
+  response: ServerResponse,
+  errorCode: "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked" = "unauthorized"
+): void {
+  sendJson(response, 401, {
+    error: {
+      code: errorCode,
+      message:
+        errorCode === "token_expired"
+          ? "Auth token has expired"
+          : errorCode === "session_revoked"
+            ? "Auth session has been revoked"
+            : "Guest auth session is missing or invalid"
+    }
+  });
+}
+
+function sendAccountBanned(response: ServerResponse, ban?: { banReason?: string; banExpiry?: string } | null): void {
+  sendJson(response, 403, {
+    error: {
+      code: "account_banned",
+      message: "Account is banned",
+      reason: ban?.banReason ?? "No reason provided",
+      ...(ban?.banExpiry ? { expiry: ban.banExpiry } : {})
+    }
+  });
+}
+
+function sendCallbackResponse(response: ServerResponse, statusCode: number, payload = SUCCESS_CALLBACK_BODY): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+function isPaymentStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
+  Required<Pick<RoomSnapshotStore, "createPaymentOrder" | "completePaymentOrder" | "loadPaymentOrder">> {
+  return Boolean(store?.createPaymentOrder && store.completePaymentOrder && store.loadPaymentOrder);
+}
+
+function findProduct(products: ShopProduct[], productId: string): ShopProduct | undefined {
+  return products.find((product) => product.productId === productId);
+}
+
+async function requireAuthSession(request: IncomingMessage, response: ServerResponse, store: RoomSnapshotStore | null) {
+  const result = await validateAuthSessionFromRequest(request, store);
+  if (!result.session) {
+    if (result.errorCode === "account_banned") {
+      sendAccountBanned(response, result.ban);
+      return null;
+    }
+    sendUnauthorized(response, result.errorCode ?? "unauthorized");
+    return null;
+  }
+
+  return result.session;
+}
+
+function normalizeSuccessTimestamp(value?: string): string {
+  const parsed = value ? new Date(value) : new Date();
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("invalid_wechat_payment_success_time");
+  }
+  return parsed.toISOString();
+}
+
+export function registerWechatPayRoutes(
+  app: HttpApp,
+  store: RoomSnapshotStore | null,
+  options: RegisterWechatPayRoutesOptions = {}
+): void {
+  const products = resolveShopProducts(options);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => new Date());
+  const orderIdGenerator = options.orderIdGenerator ?? randomUUID;
+  const runtimeConfig = options.runtimeConfig ?? readWechatPayRuntimeConfig();
+
+  app.use((request, response, next) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
+
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    next();
+  });
+
+  app.post("/api/payments/wechat/create", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+    if (!runtimeConfig) {
+      sendJson(response, 503, {
+        error: {
+          code: "wechat_pay_not_configured",
+          message: "WeChat Pay runtime configuration is incomplete"
+        }
+      });
+      return;
+    }
+    if (!isPaymentStoreReady(store)) {
+      sendJson(response, 503, {
+        error: {
+          code: "payment_persistence_unavailable",
+          message: "Payment orders require configured persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as { productId?: string | null };
+      const productId = normalizeProductId(body.productId);
+      const product = normalizeWechatPayProduct(findProduct(products, productId));
+      const account = await store.loadPlayerAccount(authSession.playerId);
+      const openId = account?.wechatMiniGameOpenId?.trim();
+      if (!openId) {
+        sendJson(response, 400, {
+          error: {
+            code: "wechat_open_id_required",
+            message: "Player must bind a WeChat mini-game identity before creating a payment order"
+          }
+        });
+        return;
+      }
+
+      const order = await store.createPaymentOrder({
+        orderId: orderIdGenerator(),
+        playerId: authSession.playerId,
+        productId: product.productId,
+        amount: product.wechatPriceFen,
+        gemAmount: product.grant.gems
+      });
+
+      const createdAt = now();
+      const payload = {
+        appid: runtimeConfig.appId,
+        mchid: runtimeConfig.merchantId,
+        description: product.name,
+        out_trade_no: order.orderId,
+        notify_url: runtimeConfig.notifyUrl,
+        amount: {
+          total: order.amount,
+          currency: "CNY"
+        },
+        payer: {
+          openid: openId
+        }
+      };
+      const requestUrl = new URL(runtimeConfig.transactionsJsapiUrl);
+      const bodyText = JSON.stringify(payload);
+      const timestamp = String(Math.floor(createdAt.getTime() / 1000));
+      const nonce = randomNonce();
+      const wechatResponse = await fetchImpl(requestUrl, {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          Authorization: buildWechatAuthorization(runtimeConfig, "POST", requestUrl, bodyText, timestamp, nonce)
+        },
+        body: bodyText
+      });
+      if (!wechatResponse.ok) {
+        const errorText = await wechatResponse.text();
+        sendJson(response, 502, {
+          error: {
+            code: "wechat_order_create_failed",
+            message: errorText || "WeChat Pay order creation failed"
+          }
+        });
+        return;
+      }
+
+      const wechatPayload = (await wechatResponse.json()) as WechatPayTransactionsJsapiResponse;
+      const prepayId = wechatPayload.prepay_id?.trim();
+      if (!prepayId) {
+        sendJson(response, 502, {
+          error: {
+            code: "wechat_order_create_invalid_response",
+            message: "WeChat Pay response did not include prepay_id"
+          }
+        });
+        return;
+      }
+
+      const timeStamp = timestamp;
+      const nonceStr = randomNonce();
+      const packageValue = `prepay_id=${prepayId}`;
+      sendJson(response, 200, {
+        orderId: order.orderId,
+        timeStamp,
+        nonceStr,
+        package: packageValue,
+        signType: "RSA",
+        paySign: buildClientPaySign(runtimeConfig, timeStamp, nonceStr, packageValue)
+      });
+    } catch (error) {
+      sendJson(response, 400, {
+        error: {
+          code: error instanceof Error ? error.name || "bad_request" : "bad_request",
+          message: error instanceof Error ? error.message : String(error)
+        }
+      });
+    }
+  });
+
+  app.post("/api/payments/wechat/callback", async (request, response) => {
+    if (!runtimeConfig) {
+      sendCallbackResponse(response, 503, {
+        code: "FAIL",
+        message: "WeChat Pay runtime configuration is incomplete"
+      });
+      return;
+    }
+    if (!isPaymentStoreReady(store)) {
+      sendCallbackResponse(response, 503, {
+        code: "FAIL",
+        message: "Payment persistence is unavailable"
+      });
+      return;
+    }
+
+    try {
+      const rawBody = await readRawBody(request);
+      const bodyText = rawBody.toString("utf8");
+      if (!verifyWechatCallbackSignature(runtimeConfig, request.headers, bodyText)) {
+        sendCallbackResponse(response, 401, {
+          code: "FAIL",
+          message: "signature verification failed"
+        });
+        return;
+      }
+
+      const envelope = JSON.parse(bodyText) as WechatPayCallbackEnvelope;
+      const transaction = decryptWechatCallbackResource(runtimeConfig, envelope);
+      if (transaction.trade_state !== "SUCCESS") {
+        sendCallbackResponse(response, 400, {
+          code: "FAIL",
+          message: "unsupported trade state"
+        });
+        return;
+      }
+
+      if (transaction.appid?.trim() !== runtimeConfig.appId || transaction.mchid?.trim() !== runtimeConfig.merchantId) {
+        sendCallbackResponse(response, 400, {
+          code: "FAIL",
+          message: "merchant validation failed"
+        });
+        return;
+      }
+
+      const orderId = transaction.out_trade_no?.trim();
+      const wechatOrderId = transaction.transaction_id?.trim();
+      if (!orderId || !wechatOrderId) {
+        sendCallbackResponse(response, 400, {
+          code: "FAIL",
+          message: "order identifiers are missing"
+        });
+        return;
+      }
+
+      const order = await store.loadPaymentOrder(orderId);
+      if (!order) {
+        sendCallbackResponse(response, 404, {
+          code: "FAIL",
+          message: "payment order not found"
+        });
+        return;
+      }
+
+      if ((transaction.amount?.total ?? 0) !== order.amount) {
+        sendCallbackResponse(response, 400, {
+          code: "FAIL",
+          message: "payment amount mismatch"
+        });
+        return;
+      }
+
+      const account = await store.loadPlayerAccount(order.playerId);
+      if (!account?.wechatMiniGameOpenId || transaction.payer?.openid?.trim() !== account.wechatMiniGameOpenId) {
+        sendCallbackResponse(response, 400, {
+          code: "FAIL",
+          message: "payer validation failed"
+        });
+        return;
+      }
+
+      await store.completePaymentOrder(order.orderId, {
+        wechatOrderId,
+        paidAt: normalizeSuccessTimestamp(transaction.success_time)
+      });
+      sendCallbackResponse(response, 200);
+    } catch (error) {
+      sendCallbackResponse(response, 400, {
+        code: "FAIL",
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  });
+}
+
+export function encryptWechatCallbackResourceForTest(
+  apiV3Key: string,
+  plaintext: string,
+  nonce: string,
+  associatedData = "transaction"
+): { ciphertext: string; nonce: string; associated_data: string; algorithm: "AEAD_AES_256_GCM" } {
+  const keyBuffer = Buffer.from(apiV3Key, "utf8");
+  const encryptedCipher = createCipheriv("aes-256-gcm", keyBuffer, Buffer.from(nonce, "utf8"));
+  encryptedCipher.setAAD(Buffer.from(associatedData, "utf8"));
+  const encrypted = Buffer.concat([encryptedCipher.update(plaintext, "utf8"), encryptedCipher.final()]);
+  const authTag = encryptedCipher.getAuthTag();
+
+  return {
+    algorithm: "AEAD_AES_256_GCM",
+    nonce,
+    associated_data: associatedData,
+    ciphertext: Buffer.concat([encrypted, authTag]).toString("base64")
+  };
+}
+
+export function signWechatCallbackForTest(privateKey: string, timestamp: string, nonce: string, body: string): string {
+  const signer = createSign("RSA-SHA256");
+  signer.update(`${timestamp}\n${nonce}\n${body}\n`);
+  signer.end();
+  return signer.sign(privateKey, "base64");
+}
+
+export type { RegisterWechatPayRoutesOptions, WechatPayRuntimeConfig, PaymentOrderSnapshot };

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -203,6 +203,16 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
       playerAccountStore = store;
       base.routeCalls.push("player-accounts");
     },
+    registerShopRoutes: (app, store) => {
+      assert.equal(app, base.expressApp);
+      assert.equal(store, memoryStore);
+      base.routeCalls.push("shop");
+    },
+    registerWechatPayRoutes: (app, store) => {
+      assert.equal(app, base.expressApp);
+      assert.equal(store, memoryStore);
+      base.routeCalls.push("wechat-pay");
+    },
     registerLobbyRoutes: (app, dependencies) => {
       assert.equal(app, base.expressApp);
       lobbyListRooms = dependencies.listRooms;
@@ -258,6 +268,8 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
     "config-center",
     "config-viewer",
     "player-accounts",
+    "shop",
+    "wechat-pay",
     "lobby",
     "matchmaking",
     "runtime-observability",
@@ -272,6 +284,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
   assert.equal(base.logger.errors.length, 0);
   assertStartupLogIncludes(base.logger, [
     /Project Veil Colyseus dev server listening on ws:\/\/0\.0\.0\.0:3101/,
+    /WeChat Pay API available at http:\/\/0\.0\.0\.0:3101\/api\/payments\/wechat\/create/,
     /Runtime health available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/auth-readiness/,
     /Runtime diagnostic snapshot available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/diagnostic-snapshot/,
@@ -317,6 +330,8 @@ test("dev server logs process-level failures, closes stores, and exits non-zero"
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
+    registerShopRoutes: () => undefined,
+    registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
@@ -375,6 +390,8 @@ test("dev server logs uncaught exceptions, closes stores, and exits non-zero", a
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
+    registerShopRoutes: () => undefined,
+    registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
@@ -455,6 +472,8 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
+    registerShopRoutes: () => undefined,
+    registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
@@ -521,6 +540,8 @@ test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL 
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
+    registerShopRoutes: () => undefined,
+    registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
@@ -606,6 +627,8 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
+    registerShopRoutes: () => undefined,
+    registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,

--- a/apps/server/test/wechat-pay-routes.test.ts
+++ b/apps/server/test/wechat-pay-routes.test.ts
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { generateKeyPairSync } from "node:crypto";
+import { Readable } from "node:stream";
+import test from "node:test";
+import { issueAccountAuthSession } from "../src/auth";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import {
+  encryptWechatCallbackResourceForTest,
+  registerWechatPayRoutes,
+  signWechatCallbackForTest,
+  type WechatPayRuntimeConfig
+} from "../src/wechat-pay";
+import type { ShopProduct } from "../src/shop";
+
+const TEST_PRODUCTS: Partial<ShopProduct>[] = [
+  {
+    productId: "gem-pack-premium",
+    name: "Premium Gem Cache",
+    type: "gem_pack",
+    price: 0,
+    wechatPriceFen: 600,
+    enabled: false,
+    grant: {
+      gems: 120
+    }
+  }
+];
+
+class TestResponse extends EventEmitter {
+  statusCode = 200;
+  readonly headers = new Map<string, string>();
+  body = "";
+
+  setHeader(name: string, value: string): void {
+    this.headers.set(name.toLowerCase(), value);
+  }
+
+  end(chunk?: string | Buffer): void {
+    if (chunk != null) {
+      this.body += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+    }
+    this.emit("finish");
+  }
+}
+
+class TestApp {
+  private readonly middlewares: Array<(request: never, response: never, next: () => void) => void> = [];
+  private readonly postHandlers = new Map<string, (request: never, response: never) => void | Promise<void>>();
+
+  use(handler: (request: never, response: never, next: () => void) => void): void {
+    this.middlewares.push(handler);
+  }
+
+  post(path: string, handler: (request: never, response: never) => void | Promise<void>): void {
+    this.postHandlers.set(path, handler);
+  }
+
+  async invoke(path: string, options: { body?: string; headers?: Record<string, string> } = {}) {
+    const routeHandler = this.postHandlers.get(path);
+    if (!routeHandler) {
+      throw new Error(`No POST handler registered for ${path}`);
+    }
+
+    const request = Readable.from(options.body ? [Buffer.from(options.body, "utf8")] : []) as Readable & {
+      headers: Record<string, string>;
+      method: string;
+      url: string;
+    };
+    request.headers = Object.fromEntries(
+      Object.entries(options.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+    );
+    request.method = "POST";
+    request.url = path;
+
+    const response = new TestResponse();
+    const handlers = [...this.middlewares, async (req: never, res: never) => routeHandler(req, res)];
+    let index = 0;
+
+    const next = (): void => {
+      const handler = handlers[index];
+      index += 1;
+      if (!handler) {
+        return;
+      }
+      void handler(request as never, response as never, next);
+    };
+
+    next();
+    await EventEmitter.once(response, "finish");
+
+    return {
+      statusCode: response.statusCode,
+      headers: response.headers,
+      json: response.body ? (JSON.parse(response.body) as unknown) : null
+    };
+  }
+}
+
+function createWechatPayConfig(): WechatPayRuntimeConfig & { platformPrivateKey: string } {
+  const merchantKeys = generateKeyPairSync("rsa", {
+    modulusLength: 2048
+  });
+  const platformKeys = generateKeyPairSync("rsa", {
+    modulusLength: 2048
+  });
+
+  return {
+    appId: "wx-test-app",
+    merchantId: "1900000109",
+    merchantCertificateSerial: "merchant-serial-001",
+    merchantPrivateKey: merchantKeys.privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    platformCertificateSerial: "platform-serial-001",
+    platformPublicKey: platformKeys.publicKey.export({ type: "spki", format: "pem" }).toString(),
+    platformPrivateKey: platformKeys.privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    apiV3Key: "0123456789abcdef0123456789abcdef",
+    notifyUrl: "https://veil.example.test/api/payments/wechat/callback",
+    transactionsJsapiUrl: "https://wechat.example.test/v3/pay/transactions/jsapi"
+  };
+}
+
+test("wechat pay create route creates a pending order and returns JSAPI payment parameters", async () => {
+  const app = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  const runtimeConfig = createWechatPayConfig();
+  await store.bindPlayerAccountWechatMiniGameIdentity("wechat-player", {
+    openId: "wx-openid-player",
+    displayName: "暮潮守望"
+  });
+
+  let capturedBody = "";
+  let capturedAuthorization = "";
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: async (_input, init) => {
+      capturedBody = String(init?.body ?? "");
+      capturedAuthorization = String((init?.headers as Record<string, string>)?.Authorization ?? "");
+      return new Response(JSON.stringify({ prepay_id: "wx-prepay-123" }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+  });
+  const session = issueAccountAuthSession({
+    playerId: "wechat-player",
+    displayName: "暮潮守望",
+    loginId: "wechat-player",
+    provider: "wechat-mini-game"
+  });
+
+  const response = await app.invoke("/api/payments/wechat/create", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "gem-pack-premium"
+    })
+  });
+  const payload = response.json as {
+    orderId: string;
+    timeStamp: string;
+    nonceStr: string;
+    package: string;
+    signType: string;
+    paySign: string;
+  };
+  const order = await store.loadPaymentOrder(payload.orderId);
+
+  assert.equal(response.statusCode, 200);
+  assert.ok(payload.orderId);
+  assert.equal(payload.package, "prepay_id=wx-prepay-123");
+  assert.equal(payload.signType, "RSA");
+  assert.ok(payload.timeStamp);
+  assert.ok(payload.nonceStr);
+  assert.ok(payload.paySign);
+  assert.match(capturedAuthorization, /^WECHATPAY2-SHA256-RSA2048 /);
+  assert.deepEqual(JSON.parse(capturedBody), {
+    appid: runtimeConfig.appId,
+    mchid: runtimeConfig.merchantId,
+    description: "Premium Gem Cache",
+    out_trade_no: payload.orderId,
+    notify_url: runtimeConfig.notifyUrl,
+    amount: {
+      total: 600,
+      currency: "CNY"
+    },
+    payer: {
+      openid: "wx-openid-player"
+    }
+  });
+  assert.deepEqual(order, {
+    orderId: payload.orderId,
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    status: "pending",
+    amount: 600,
+    gemAmount: 120,
+    createdAt: order?.createdAt,
+    updatedAt: order?.updatedAt
+  });
+});
+
+test("wechat pay callback verifies, decrypts, and credits gems only once for duplicate notifications", async () => {
+  const app = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  const runtimeConfig = createWechatPayConfig();
+  await store.bindPlayerAccountWechatMiniGameIdentity("wechat-player", {
+    openId: "wx-openid-player",
+    displayName: "暮潮守望"
+  });
+  const order = await store.createPaymentOrder({
+    orderId: "wechat-order-1",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig
+  });
+
+  const transaction = {
+    appid: runtimeConfig.appId,
+    mchid: runtimeConfig.merchantId,
+    out_trade_no: order.orderId,
+    transaction_id: "wechat-transaction-123",
+    trade_state: "SUCCESS",
+    success_time: "2026-04-04T01:02:03Z",
+    amount: {
+      total: 600
+    },
+    payer: {
+      openid: "wx-openid-player"
+    }
+  };
+  const resource = encryptWechatCallbackResourceForTest(
+    runtimeConfig.apiV3Key,
+    JSON.stringify(transaction),
+    "callback-nonce1"
+  );
+  const body = JSON.stringify({
+    id: "evt-1",
+    event_type: "TRANSACTION.SUCCESS",
+    resource_type: "encrypt-resource",
+    resource
+  });
+  const timestamp = "1712197200";
+  const nonce = "signature-nonce-1";
+  const signature = signWechatCallbackForTest(runtimeConfig.platformPrivateKey, timestamp, nonce, body);
+
+  const sendCallback = async (wechatpaySignature: string) =>
+    app.invoke("/api/payments/wechat/callback", {
+      headers: {
+        "content-type": "application/json",
+        "wechatpay-timestamp": timestamp,
+        "wechatpay-nonce": nonce,
+        "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+        "wechatpay-signature": wechatpaySignature
+      },
+      body
+    });
+
+  const firstResponse = await sendCallback(signature);
+  const secondResponse = await sendCallback(signature);
+  const account = await store.loadPlayerAccount("wechat-player");
+  const paidOrder = await store.loadPaymentOrder(order.orderId);
+
+  assert.equal(firstResponse.statusCode, 200);
+  assert.equal(secondResponse.statusCode, 200);
+  assert.equal(account?.gems, 120);
+  assert.equal(paidOrder?.status, "paid");
+  assert.equal(paidOrder?.wechatOrderId, "wechat-transaction-123");
+  assert.equal(paidOrder?.paidAt, "2026-04-04T01:02:03.000Z");
+});
+
+test("wechat pay callback rejects invalid signatures", async () => {
+  const app = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  const runtimeConfig = createWechatPayConfig();
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig
+  });
+
+  const response = await app.invoke("/api/payments/wechat/callback", {
+    headers: {
+      "content-type": "application/json",
+      "wechatpay-timestamp": "1712197200",
+      "wechatpay-nonce": "bad-signature-nonce",
+      "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+      "wechatpay-signature": "invalid-signature"
+    },
+    body: JSON.stringify({
+      id: "evt-invalid",
+      event_type: "TRANSACTION.SUCCESS",
+      resource_type: "encrypt-resource",
+      resource: null
+    })
+  });
+  const payload = response.json as { code: string; message: string };
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(payload.code, "FAIL");
+  assert.match(payload.message, /signature verification failed/);
+});

--- a/configs/shop-config.json
+++ b/configs/shop-config.json
@@ -29,6 +29,7 @@
       "name": "Scout Gem Cache",
       "type": "gem_pack",
       "price": 5,
+      "wechatPriceFen": 600,
       "enabled": false,
       "grant": {
         "gems": 15

--- a/scripts/migrations/0013_add_payment_orders.ts
+++ b/scripts/migrations/0013_add_payment_orders.ts
@@ -1,0 +1,58 @@
+import {
+  dropIndexIfExists,
+  dropTableIfExists,
+  ensureIndexExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX,
+  MYSQL_PAYMENT_ORDER_TABLE,
+  MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureTableExists(
+    connection,
+    MYSQL_PAYMENT_ORDER_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_PAYMENT_ORDER_TABLE}\` (
+      order_id VARCHAR(191) NOT NULL,
+      player_id VARCHAR(191) NOT NULL,
+      product_id VARCHAR(191) NOT NULL,
+      wechat_order_id VARCHAR(191) NULL,
+      status VARCHAR(16) NOT NULL DEFAULT 'pending',
+      amount INT NOT NULL,
+      gem_amount INT NOT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      paid_at DATETIME NULL DEFAULT NULL,
+      updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      PRIMARY KEY (order_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_PAYMENT_ORDER_TABLE,
+    MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX,
+    `CREATE INDEX \`${MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX}\` ON \`${MYSQL_PAYMENT_ORDER_TABLE}\` (player_id, created_at DESC)`
+  );
+
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_PAYMENT_ORDER_TABLE,
+    MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX,
+    `CREATE UNIQUE INDEX \`${MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX}\` ON \`${MYSQL_PAYMENT_ORDER_TABLE}\` (wechat_order_id)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await dropIndexIfExists(connection, database, MYSQL_PAYMENT_ORDER_TABLE, MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX);
+  await dropIndexIfExists(connection, database, MYSQL_PAYMENT_ORDER_TABLE, MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX);
+  await dropTableIfExists(connection, MYSQL_PAYMENT_ORDER_TABLE);
+}


### PR DESCRIPTION
## Summary
Add WeChat Pay order creation and callback handling for gem pack purchases.
Persist payment orders with idempotent settlement so duplicate callbacks do not credit gems twice.
Wire the new payment routes into the dev server and add the required migration/config updates.

## Validation
Focused tests passed:
- `node --import tsx --test ./apps/server/test/wechat-pay-routes.test.ts ./apps/server/test/dev-server.test.ts`

Additional note:
- `npm run typecheck:server` is currently failing on unrelated existing repo debt in `apps/server/src/config-center.ts:1946` because the `swamp` terrain key is missing.

Closes #794.