### PR TITLE
[codex] release(wechat): gate phase1 sign-off on candidate evidence

### DIFF
--- a/docs/phase1-candidate-dossier.md
+++ b/docs/phase1-candidate-dossier.md
@@ -109,6 +109,7 @@ The dossier surfaces:
 - one `Generated Bundle` block so PR/release巡检 reviewers can stay inside the dossier directory
 - one runtime observability companion dossier that ties `/api/runtime/health`, `/api/runtime/auth-readiness`, `/api/runtime/metrics`, and reconnect soak evidence to the same candidate revision
 - one `phase1ExitEvidenceGate` result with blocking/pending/accepted-risk section lists
+- for WeChat targets, candidate-level package / verify / smoke / manual-review evidence is surfaced explicitly, and missing required manual checks keep the exit gate blocked instead of being treated as build-only success
 - `requiredFailed`
 - `requiredPending`
 - `acceptedRisks`

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -61,6 +61,8 @@
 
 这条 contract 的核心区别是：桌面 / H5 / Creator 调试面通过，只能证明对应 surface 的验证完成，不能替代 WeChat 目标面的放行证据。
 
+`npm run release:gate:summary -- --target-surface wechat` 的 `Target Surface Contract` 会显式列出 WeChat package、verify、smoke、candidate summary 与 manual review 的 `passed` / `failed` / `pending` 状态；只要 required manual review 仍是 `pending`，Phase 1 sign-off 就保持 blocked。
+
 WeChat checklist / blockers 至少要覆盖以下证据面：
 
 - package / verify / RC validation 产物

--- a/scripts/phase1-candidate-dossier.ts
+++ b/scripts/phase1-candidate-dossier.ts
@@ -1162,6 +1162,14 @@ function buildWechatSection(
     const summary = readJsonFile<WechatCandidateSummary>(candidateSummaryPath);
     const freshness = evaluateFreshness(summary.generatedAt, maxAgeMs);
     const manualReview = summary.evidence?.manualReview;
+    const packageStatus = summary.evidence?.package?.status ?? "skipped";
+    const validationStatus = summary.evidence?.validation?.status ?? "skipped";
+    const smokeStatus = summary.evidence?.smoke?.status ?? "skipped";
+    const pendingCandidateEvidence =
+      packageStatus !== "passed" ||
+      validationStatus !== "passed" ||
+      smokeStatus !== "passed" ||
+      (manualReview?.requiredPendingChecks ?? 0) > 0;
     const details = [...(summary.blockers ?? []).map((blocker) => blocker.summary?.trim()).filter((value): value is string => Boolean(value))];
     const acceptedRisks = (manualReview?.checks ?? [])
       .filter((check) => check.waiver?.reason?.trim())
@@ -1178,6 +1186,9 @@ function buildWechatSection(
         )
       );
 
+    details.push(`package status=${packageStatus}`);
+    details.push(`verify status=${validationStatus}`);
+    details.push(`smoke status=${smokeStatus}`);
     if ((manualReview?.requiredPendingChecks ?? 0) > 0) {
       details.push(`manual review pending=${manualReview?.requiredPendingChecks}`);
     }
@@ -1197,16 +1208,15 @@ function buildWechatSection(
     let result: DossierResult = "passed";
     if (
       summary.candidate?.status === "blocked" &&
-      ((manualReview?.requiredFailedChecks ?? 0) > 0 ||
+      (pendingCandidateEvidence ||
+        (manualReview?.requiredFailedChecks ?? 0) > 0 ||
         (manualReview?.requiredMetadataFailures ?? 0) > 0 ||
-        summary.evidence?.smoke?.status === "failed" ||
+        smokeStatus === "failed" ||
         !commitsMatch(summary.candidate?.revision ?? undefined, candidateRevision))
     ) {
       result = "failed";
     } else if (
       summary.candidate?.status !== "ready" ||
-      (manualReview?.requiredPendingChecks ?? 0) > 0 ||
-      summary.evidence?.smoke?.status === "skipped" ||
       freshness !== "fresh"
     ) {
       result = "pending";
@@ -1221,6 +1231,30 @@ function buildWechatSection(
         summary: `candidate=${summary.candidate?.status ?? "missing"}`,
         observedAt: summary.generatedAt,
         freshness,
+        revision: summary.candidate?.revision ?? undefined
+      },
+      {
+        label: "WeChat package evidence",
+        path: summary.evidence?.package?.artifactPath ?? candidateSummaryPath,
+        summary: `status=${packageStatus}`,
+        observedAt: summary.generatedAt,
+        freshness,
+        revision: summary.candidate?.revision ?? undefined
+      },
+      {
+        label: "WeChat verify evidence",
+        path: summary.artifacts?.validationReportPath ?? candidateSummaryPath,
+        summary: `status=${validationStatus}`,
+        observedAt: summary.generatedAt,
+        freshness,
+        revision: summary.candidate?.revision ?? undefined
+      },
+      {
+        label: "WeChat smoke evidence",
+        path: summary.evidence?.smoke?.artifactPath ?? summary.artifacts?.smokeReportPath ?? candidateSummaryPath,
+        summary: `status=${smokeStatus}`,
+        observedAt: summary.generatedAt,
+        freshness: summary.evidence?.deviceRuntime?.freshness ?? freshness,
         revision: summary.candidate?.revision ?? undefined
       }
     ];
@@ -1245,7 +1279,7 @@ function buildWechatSection(
       result,
       summary:
         result === "failed"
-          ? "WeChat candidate summary is blocked by failed or mismatched required evidence."
+          ? "WeChat candidate summary is blocked by missing, failed, or mismatched candidate-level package/verify/smoke/manual evidence."
           : result === "pending"
             ? "WeChat candidate summary exists, but required smoke/manual review evidence is still pending."
             : acceptedRisks.length > 0

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 type GateStatus = "passed" | "failed";
 type TargetSurface = "h5" | "wechat";
 type EvidenceFreshness = "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp" | "unknown";
+type ReleaseSurfaceEvidenceStatus = "passed" | "failed" | "pending";
 
 interface Args {
   snapshotPath?: string;
@@ -180,7 +181,7 @@ interface ReleaseSurfaceEvidenceItem {
   id: string;
   label: string;
   required: boolean;
-  status: GateStatus;
+  status: ReleaseSurfaceEvidenceStatus;
   summary: string;
   freshness: EvidenceFreshness;
   observedAt?: string;
@@ -1235,16 +1236,70 @@ function buildReleaseSurfaceContract(
       );
     } else {
       const summary = readJsonFile<WechatReleaseCandidateSummary>(wechatCandidateSummaryPath);
+      const packageStatus = summary.evidence?.package?.status ?? "skipped";
+      const validationStatus = summary.evidence?.validation?.status ?? "skipped";
+      const smokeStatus = summary.evidence?.smoke?.status ?? "skipped";
+      const pendingManualChecks = (summary.evidence?.manualReview?.requiredPendingChecks ?? 0) > 0;
+      const candidateStatus: ReleaseSurfaceEvidenceStatus =
+        summary.candidate?.status === "ready"
+          ? "passed"
+          : pendingManualChecks || smokeStatus === "skipped" || packageStatus === "skipped" || validationStatus === "skipped"
+            ? "pending"
+            : "failed";
+
+      evidence.push(
+        createSurfaceEvidenceItem({
+          id: "wechat-package-evidence",
+          label: "WeChat package evidence",
+          required: true,
+          status: packageStatus === "passed" ? "passed" : packageStatus === "skipped" ? "pending" : "failed",
+          summary: summary.evidence?.package?.summary ?? "WeChat package evidence is missing.",
+          freshness: evaluateFreshness(summary.generatedAt, MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS),
+          observedAt: summary.generatedAt,
+          revision: summary.candidate?.revision ?? undefined,
+          artifactPath: summary.evidence?.package?.artifactPath
+        })
+      );
+      evidence.push(
+        createSurfaceEvidenceItem({
+          id: "wechat-verify-evidence",
+          label: "WeChat verify evidence",
+          required: true,
+          status: validationStatus === "passed" ? "passed" : validationStatus === "skipped" ? "pending" : "failed",
+          summary: summary.evidence?.validation?.summary ?? "WeChat artifact verification evidence is missing.",
+          freshness: evaluateFreshness(summary.generatedAt, MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS),
+          observedAt: summary.generatedAt,
+          revision: summary.candidate?.revision ?? undefined,
+          artifactPath: summary.artifacts?.validationReportPath
+        })
+      );
+      evidence.push(
+        createSurfaceEvidenceItem({
+          id: "wechat-smoke-evidence",
+          label: "WeChat smoke evidence",
+          required: true,
+          status: smokeStatus === "passed" ? "passed" : smokeStatus === "skipped" ? "pending" : "failed",
+          summary: summary.evidence?.smoke?.summary ?? "WeChat smoke evidence is missing.",
+          freshness: summary.evidence?.deviceRuntime
+            ? summary.evidence.deviceRuntime.freshness ?? evaluateFreshness(summary.generatedAt, MAX_TARGET_SURFACE_REVIEW_AGE_MS)
+            : evaluateFreshness(summary.generatedAt, MAX_TARGET_SURFACE_REVIEW_AGE_MS),
+          observedAt: summary.evidence?.deviceRuntime?.execution?.executedAt ?? summary.generatedAt,
+          revision: summary.candidate?.revision ?? undefined,
+          artifactPath: summary.evidence?.smoke?.artifactPath
+        })
+      );
       evidence.push(
         createSurfaceEvidenceItem({
           id: "wechat-candidate-summary",
           label: "WeChat candidate summary",
           required: true,
-          status: summary.candidate?.status === "ready" ? "passed" : "failed",
+          status: candidateStatus,
           summary:
             summary.candidate?.status === "ready"
               ? "WeChat candidate summary is ready for release review."
-              : `WeChat candidate summary is ${JSON.stringify(summary.candidate?.status ?? "missing")}.`,
+              : candidateStatus === "pending"
+                ? "WeChat candidate summary is blocked pending required candidate-level package/verify/smoke/manual evidence."
+                : `WeChat candidate summary is ${JSON.stringify(summary.candidate?.status ?? "missing")}.`,
           freshness: evaluateFreshness(summary.generatedAt, MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS),
           observedAt: summary.generatedAt,
           revision: summary.candidate?.revision ?? undefined,
@@ -1267,11 +1322,18 @@ function buildReleaseSurfaceContract(
             id: `manual:${check.id ?? "unknown"}`,
             label: check.title ?? check.id ?? "WeChat manual review",
             required: true,
-            status: check.status === "passed" && metadataFailures.length === 0 ? "passed" : "failed",
+            status:
+              check.status === "passed" && metadataFailures.length === 0
+                ? "passed"
+                : check.status === "pending"
+                  ? "pending"
+                  : "failed",
             summary:
               check.status === "passed" && metadataFailures.length === 0
                 ? "Manual review is complete and current."
-                : `${JSON.stringify(check.status ?? "missing")} (${metadataFailures.join(", ") || "review unresolved"})`,
+                : check.status === "pending"
+                  ? `${JSON.stringify(check.status)} (${metadataFailures.join(", ") || "review unresolved"})`
+                  : `${JSON.stringify(check.status ?? "missing")} (${metadataFailures.join(", ") || "review unresolved"})`,
             freshness,
             observedAt: check.recordedAt,
             owner: check.owner,
@@ -1286,7 +1348,13 @@ function buildReleaseSurfaceContract(
   }
 
   const failures = evidence.filter(
-    (entry) => entry.required && (entry.status === "failed" || entry.freshness === "stale" || entry.freshness === "missing_timestamp" || entry.freshness === "invalid_timestamp")
+    (entry) =>
+      entry.required &&
+      (entry.status === "failed" ||
+        entry.status === "pending" ||
+        entry.freshness === "stale" ||
+        entry.freshness === "missing_timestamp" ||
+        entry.freshness === "invalid_timestamp")
   );
 
   return {

--- a/scripts/test/phase1-candidate-dossier.test.ts
+++ b/scripts/test/phase1-candidate-dossier.test.ts
@@ -677,6 +677,134 @@ test("phase1 candidate dossier marks stale persistence evidence as pending and k
   assert.match(markdown, /persistence freshness=stale/);
 });
 
+test("phase1 candidate dossier blocks Phase 1 sign-off when required WeChat manual evidence is still pending", async () => {
+  const workspace = createTempWorkspace();
+  const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
+  const wechatDir = path.join(workspace, "artifacts", "wechat-release");
+  const revision = "abc1234";
+
+  const snapshotPath = path.join(artifactsDir, "release-readiness-pass.json");
+  const h5SmokePath = path.join(artifactsDir, "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(artifactsDir, "colyseus-reconnect-soak-summary-pass.json");
+  const cocosBundlePath = path.join(artifactsDir, "cocos-rc-evidence-bundle-pass.json");
+  const persistencePath = path.join(artifactsDir, `phase1-release-persistence-regression-${revision}.json`);
+  const runtimeObservabilityGatePath = writeRuntimeGateArtifact(artifactsDir, revision);
+  const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-04-02T08:30:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [{ id: "npm-test", required: true, status: "passed" }]
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: "2026-04-02T08:32:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    execution: { status: "passed", exitCode: 0 },
+    summary: { total: 2, passed: 2, failed: 0 }
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-04-02T08:33:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    status: "passed",
+    summary: { failedScenarios: 0, scenarioNames: ["reconnect_soak"] },
+    soakSummary: { reconnectAttempts: 12, invariantChecks: 48 },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: { activeRoomCount: 0, connectionCount: 0, activeBattleCount: 0, heroCount: 0 }
+      }
+    ]
+  });
+  writeJson(cocosBundlePath, {
+    bundle: {
+      generatedAt: "2026-04-02T08:34:00.000Z",
+      candidate: "phase1-rc",
+      commit: revision,
+      shortCommit: revision,
+      overallStatus: "passed",
+      summary: "Cocos RC evidence is complete."
+    },
+    review: { phase1Gate: "passed" },
+    journey: [{ id: "lobby-entry", status: "passed" }],
+    requiredEvidence: [{ id: "roomId", label: "Room id recorded", filled: true }]
+  });
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: "2026-04-02T08:40:00.000Z",
+    candidate: { revision, status: "blocked" },
+    evidence: {
+      package: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: path.join(wechatDir, "codex.wechat.package.json")
+      },
+      validation: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: path.join(wechatDir, "codex.wechat.rc-validation-report.json")
+      },
+      smoke: {
+        status: "skipped",
+        summary: "Smoke report not present.",
+        artifactPath: path.join(wechatDir, "codex.wechat.smoke-report.json")
+      },
+      manualReview: {
+        status: "blocked",
+        requiredPendingChecks: 1,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: [
+          {
+            id: "wechat-devtools-export-review",
+            title: "Real WeChat export imported and launched in Developer Tools",
+            required: true,
+            status: "pending",
+            notes: "Import the packaged candidate into WeChat Developer Tools.",
+            artifactPath: path.join(wechatDir, "devtools-export-review.json")
+          }
+        ]
+      }
+    },
+    blockers: [{ id: "manual:wechat-devtools-export-review", summary: "Manual review pending: Real WeChat export imported and launched in Developer Tools." }]
+  });
+  writeJson(persistencePath, {
+    generatedAt: "2026-04-02T08:41:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    requestedStorageMode: "memory",
+    effectiveStorageMode: "memory",
+    storageDescription: "In-memory snapshot store.",
+    summary: { status: "passed", assertionCount: 6 },
+    contentValidation: { valid: true, bundleCount: 5, summary: "All shipped content packs validated.", issueCount: 0 },
+    persistenceRegression: { mapPackId: "phase1", assertions: ["room hydration reapplied resources"] }
+  });
+
+  const dossier = await buildPhase1CandidateDossier({
+    candidate: "phase1-rc",
+    candidateRevision: revision,
+    runtimeObservabilityGatePath,
+    snapshotPath,
+    h5SmokePath,
+    reconnectSoakPath,
+    wechatCandidateSummaryPath,
+    cocosBundlePath,
+    persistencePath,
+    targetSurface: "wechat",
+    maxEvidenceAgeHours: 72
+  });
+
+  const wechatSection = dossier.sections.find((section) => section.id === "wechat-release");
+  assert.equal(wechatSection?.result, "failed");
+  assert.match(wechatSection?.summary ?? "", /blocked by missing, failed, or mismatched candidate-level package\/verify\/smoke\/manual evidence/);
+  assert.match(wechatSection?.details.join("\n") ?? "", /package status=passed/);
+  assert.match(wechatSection?.details.join("\n") ?? "", /verify status=passed/);
+  assert.match(wechatSection?.details.join("\n") ?? "", /smoke status=skipped/);
+  assert.match(wechatSection?.details.join("\n") ?? "", /manual review pending=1/);
+  assert.equal(dossier.phase1ExitEvidenceGate.result, "failed");
+  assert.match(dossier.phase1ExitEvidenceGate.summary, /blocked by WeChat release evidence/);
+  assert.match(renderMarkdown(dossier), /Phase 1 exit evidence gate: `failed`/);
+});
+
 test("phase1 candidate dossier CLI writes a stable candidate bundle directory with supporting summaries", () => {
   const workspace = createTempWorkspace();
   const artifactsDir = path.join(workspace, "artifacts", "release-readiness");

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -121,7 +121,18 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
       status: "ready"
     },
     evidence: {
+      package: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: path.join(wechatArtifactsDir, "codex.wechat.package.json")
+      },
+      validation: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: wechatRcValidationPath
+      },
       smoke: {
+        summary: "ok",
         status: "passed",
         artifactPath: path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json")
       },
@@ -265,6 +276,9 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /### Manual Evidence Ownership/);
   assert.match(renderMarkdown(report), /owner=release-oncall/);
   assert.match(renderMarkdown(report), /artifact=artifacts\/wechat-release\/device-runtime-review\.json/);
+  assert.match(renderMarkdown(report), /WeChat package evidence: ok \[required=yes status=passed/);
+  assert.match(renderMarkdown(report), /WeChat verify evidence: ok \[required=yes status=passed/);
+  assert.match(renderMarkdown(report), /WeChat smoke evidence: ok \[required=yes status=passed/);
   assert.match(renderMarkdown(report), /Config Change Risk Summary/);
   assert.match(renderMarkdown(report), /Recommend rehearsal: yes/);
 });
@@ -498,20 +512,124 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
   );
 
   assert.equal(report.summary.status, "failed");
-  assert.deepEqual(report.summary.failedGateIds, ["release-readiness", "wechat-release"]);
+  assert.deepEqual(report.summary.failedGateIds, ["release-readiness", "wechat-release", "phase1-evidence-consistency"]);
   assert.deepEqual(
     report.triage.blockers.map((entry) => entry.gateId),
-    ["release-readiness", "wechat-release"]
+    ["release-readiness", "wechat-release", "phase1-evidence-consistency"]
   );
   assert.match(report.triage.blockers[0]?.nextStep ?? "", /release:gate:summary -- --target-surface wechat/);
   assert.match(report.triage.blockers[1]?.summary ?? "", /blocked wechat/i);
   assert.match(report.gates[0]?.summary ?? "", /not release-ready/);
   assert.match(report.gates[3]?.summary ?? "", /blocked/i);
   assert.match(report.gates[3]?.failures.join("\n") ?? "", /blocked pending device evidence|WeChat smoke case is blocked/);
-  assert.match(renderMarkdown(report), /### Blockers \(2\)/);
+  assert.match(renderMarkdown(report), /### Blockers \(3\)/);
   assert.match(renderMarkdown(report), /Release readiness snapshot blocked wechat/);
   assert.match(renderMarkdown(report), /### Manual Evidence Ownership/);
   assert.match(renderMarkdown(report), /No required manual evidence items are attached to the target surface/);
+});
+
+test("buildReleaseGateSummaryReport marks pending candidate-level WeChat evidence before sign-off", () => {
+  const workspace = createTempWorkspace();
+  const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
+  const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
+  const wechatArtifactsDir = path.join(workspace, "artifacts", "wechat-release");
+  const wechatRcValidationPath = path.join(wechatArtifactsDir, "codex.wechat.rc-validation-report.json");
+  const wechatCandidateSummaryPath = path.join(wechatArtifactsDir, "codex.wechat.release-candidate-summary.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-04-02T08:30:00.000Z",
+    revision: { commit: "abc123", shortCommit: "abc123", branch: "test-branch", dirty: false },
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [{ id: "e2e-smoke", required: true, status: "passed" }]
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: "2026-04-02T08:32:00.000Z",
+    revision: { commit: "abc123", shortCommit: "abc123", branch: "test-branch", dirty: false },
+    execution: { status: "passed", exitCode: 0 },
+    summary: { total: 2, passed: 2, failed: 0 }
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-04-02T08:33:00.000Z",
+    revision: { commit: "abc123", shortCommit: "abc123" },
+    status: "passed",
+    summary: { failedScenarios: 0, scenarioNames: ["reconnect_soak"] },
+    soakSummary: { reconnectAttempts: 384, invariantChecks: 2304 },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: { activeRoomCount: 0, connectionCount: 0, activeBattleCount: 0, heroCount: 0 }
+      }
+    ]
+  });
+  writeJson(wechatRcValidationPath, {
+    generatedAt: "2026-04-02T08:35:00.000Z",
+    commit: "abc123",
+    summary: { status: "passed", failedChecks: 0, failureSummary: [] }
+  });
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: "2026-04-02T08:40:00.000Z",
+    candidate: { revision: "abc123", status: "blocked" },
+    evidence: {
+      package: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: path.join(wechatArtifactsDir, "codex.wechat.package.json")
+      },
+      validation: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: wechatRcValidationPath
+      },
+      smoke: {
+        status: "skipped",
+        summary: "Smoke report not present.",
+        artifactPath: path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json")
+      },
+      manualReview: {
+        status: "blocked",
+        requiredPendingChecks: 1,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: [
+          {
+            id: "wechat-devtools-export-review",
+            title: "Real WeChat export imported and launched in Developer Tools",
+            required: true,
+            status: "pending",
+            artifactPath: "artifacts/wechat-release/devtools-export-review.json"
+          }
+        ]
+      }
+    },
+    blockers: [{ id: "manual:wechat-devtools-export-review", summary: "Manual review pending: Real WeChat export imported and launched in Developer Tools." }]
+  });
+
+  const report = buildReleaseGateSummaryReport(
+    {
+      snapshotPath,
+      h5SmokePath,
+      reconnectSoakPath,
+      wechatArtifactsDir,
+      targetSurface: "wechat"
+    },
+    {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    }
+  );
+
+  assert.equal(report.summary.status, "failed");
+  assert.equal(report.releaseSurface.status, "failed");
+  assert.equal(report.releaseSurface.evidence.find((entry) => entry.id === "wechat-candidate-summary")?.status, "pending");
+  assert.equal(report.releaseSurface.evidence.find((entry) => entry.id === "wechat-smoke-evidence")?.status, "pending");
+  assert.equal(report.releaseSurface.evidence.find((entry) => entry.id === "manual:wechat-devtools-export-review")?.status, "pending");
+  assert.match(renderMarkdown(report), /WeChat candidate summary is blocked pending required candidate-level package\/verify\/smoke\/manual evidence/);
+  assert.match(renderMarkdown(report), /WeChat smoke evidence: Smoke report not present\. \[required=yes status=pending/);
+  assert.match(renderMarkdown(report), /Real WeChat export imported and launched in Developer Tools: "pending"/);
 });
 
 test("evaluateWechatGate prefers RC validation and falls back to smoke report", () => {


### PR DESCRIPTION
## Summary
- expose candidate-level WeChat package, verify, smoke, and manual-review status in the release gate target-surface summary
- block the Phase 1 dossier WeChat section when required candidate evidence is still missing or pending
- document the operator inputs and add focused regression coverage

## Testing
- node --import tsx --test scripts/test/release-gate-summary.test.ts
- node --import tsx --test scripts/test/phase1-candidate-dossier.test.ts

Closes #821