### PR TITLE
[codex] quality(cocos): add repeatable primary journey RC evidence timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 - 终端逻辑演示：`npm run demo:flow`
 - 主客户端入口说明：`npm run client:primary`
 - Cocos 主客户端类型检查：`npm run typecheck:client`
-- Cocos canonical journey smoke：`npm run smoke:cocos:canonical-journey`（输出 `artifacts/release-readiness/` 下的结构化 JSON / Markdown / milestone diagnostics，并在失败时打印具体 stage）
+- Cocos canonical journey smoke：`npm run smoke:cocos:canonical-journey`（输出 `artifacts/release-readiness/` 下的结构化 JSON / Markdown / milestone diagnostics，并记录 stage pass/fail、timing 与 failure diagnostics；失败时打印具体 stage）
+- Cocos primary-client RC canonical evidence：`npm run release:cocos:primary-journey-evidence -- --candidate <candidate-name>`（Cocos 主客户端 release gate / RC review 的 canonical source，生成 candidate+revision 命名的 JSON / Markdown main-path evidence）
 - 微信小游戏模板刷新：`npm run prepare:wechat-build`
 - 微信小游戏 CI 同款校验：`npm run check:wechat-build`
 - 发布就绪快照：`npm run release:readiness:snapshot`

--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -151,7 +151,7 @@ function isBattleSkillKind(value: unknown): value is BattleSkillKind {
 }
 
 function isBattleSkillTarget(value: unknown): value is BattleSkillTarget {
-  return value === "enemy" || value === "self";
+  return value === "enemy" || value === "self" || value === "ally";
 }
 
 function isFiniteNumber(value: unknown): value is number {

--- a/apps/cocos-client/test/cocos-primary-client-journey.test.ts
+++ b/apps/cocos-client/test/cocos-primary-client-journey.test.ts
@@ -482,6 +482,7 @@ test("primary cocos client journey reuses an account session from lobby bootstra
   assert.equal(root.authMode, "account");
   assert.equal(root.loginId, "veil-ranger");
   assert.equal(root.lobbyRooms[0]?.roomId, "room-journey");
+  (root as typeof root & { privacyConsentAccepted: boolean }).privacyConsentAccepted = true;
   await root.enterLobbyRoom("room-journey");
 
   await waitFor(
@@ -591,6 +592,7 @@ test("primary cocos client journey gates lobby entry, world exploration, battle 
     () => root.showLobby === true && root.lobbyRooms.length === 1 && root.sessionSource === "remote",
     () => captureJourneyArtifact({ root, phase: "lobby-bootstrap", joinedOptions, room: initialRoom })
   );
+  (root as typeof root & { privacyConsentAccepted: boolean }).privacyConsentAccepted = true;
 
   await root.enterLobbyRoom(roomId);
 
@@ -752,6 +754,7 @@ test("primary cocos client journey surfaces stale stored account sessions before
 
   const { root } = createRootHarness();
   root.onLoad();
+  (root as typeof root & { privacyConsentAccepted: boolean }).privacyConsentAccepted = true;
 
   await root.enterLobbyRoom("room-expired");
 
@@ -833,6 +836,7 @@ test("primary cocos client journey renders actionable HUD and battle-panel contr
       ...captureJourneyUiState(rootNode)
     })
   );
+  (root as typeof root & { privacyConsentAccepted: boolean }).privacyConsentAccepted = true;
 
   await root.enterLobbyRoom(roomId);
 
@@ -955,6 +959,7 @@ test("primary cocos client journey closes the loot, inventory, and equip loop af
       ...captureJourneyUiState(rootNode)
     })
   );
+  (root as typeof root & { privacyConsentAccepted: boolean }).privacyConsentAccepted = true;
 
   await root.enterLobbyRoom(roomId);
 
@@ -1094,6 +1099,7 @@ test("primary cocos client journey resumes interrupted loot settlement and conve
       ...captureJourneyUiState(rootNode)
     })
   );
+  (root as typeof root & { privacyConsentAccepted: boolean }).privacyConsentAccepted = true;
 
   await root.enterLobbyRoom(roomId);
 

--- a/docs/cocos-release-evidence-template.md
+++ b/docs/cocos-release-evidence-template.md
@@ -1,6 +1,6 @@
 # Cocos Release Evidence Template
 
-本模板现在以 `npm run release:cocos-rc:bundle` 生成的 candidate-level evidence bundle 为主，内部会先自动执行 `npm run release:cocos:primary-journey-evidence`，再复用 `npm run release:cocos-rc:snapshot` 作为 machine-readable JSON。目标是把 Cocos 主客户端的 canonical `Lobby -> room -> world explore -> first battle -> settlement -> reconnect/session recovery` 证据，与微信小游戏 RC 的补充证据收口到同一份可归档、可校验、可对比的快照里，并自动补齐可直接附到 CI artifact / PR 评论的 Markdown 摘要、检查清单与 blocker 记录。
+本模板现在以 `npm run release:cocos-rc:bundle` 生成的 candidate-level evidence bundle 为主，内部会先自动执行 `npm run release:cocos:primary-journey-evidence`，再复用 `npm run release:cocos-rc:snapshot` 作为 machine-readable JSON。`release:cocos:primary-journey-evidence` 是 primary client main path 的 canonical RC evidence source；release gate review、PR artifact、和 candidate dossier 都应直接引用它生成的 candidate+revision JSON / Markdown，而不是再补 ad hoc 截图或另起格式。目标是把 Cocos 主客户端的 canonical `Lobby -> room -> world explore -> first battle -> settlement -> reconnect/session recovery` 证据，与微信小游戏 RC 的补充证据收口到同一份可归档、可校验、可对比的快照里，并自动补齐可直接附到 CI artifact / PR 评论的 Markdown 摘要、检查清单与 blocker 记录。
 
 相关文档：
 
@@ -18,9 +18,9 @@
 每个 Cocos / WeChat release candidate 都固定产出同一组证据，并统一落在 `artifacts/release-readiness/`：
 
 1. `artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.json`
-   - headless primary-client canonical journey 结构化结果，固定带每个 milestone 的 runtime diagnostics JSON
+   - headless primary-client canonical journey 结构化结果，固定带每个 milestone 的 runtime diagnostics JSON，以及 stage pass/fail、timing、failure diagnostics
 2. `artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.md`
-   - 同一 primary journey 的 reviewer 摘要，说明当前使用的是 headless runtime diagnostics fallback
+   - 同一 primary journey 的 reviewer 摘要，说明当前使用的是 headless runtime diagnostics fallback，并可直接作为 release gate review 的 canonical main-path handoff
 3. `artifacts/release-readiness/cocos-rc-evidence-bundle-<candidate>-<short-sha>.json`
    - candidate-scoped bundle manifest，适合挂 CI artifact 或 PR 机器人
 4. `artifacts/release-readiness/cocos-rc-evidence-bundle-<candidate>-<short-sha>.md`
@@ -144,6 +144,7 @@ npm run release:cocos-rc:snapshot -- \
 Headless primary journey automation 默认补：
 
 - 每个 milestone 一份 runtime diagnostics JSON
+- 每个 stage 的 pass/fail、startedAt/completedAt、durationMs
 - `roomId`、首战结算、恢复提示、恢复后状态四个结构化字段
 - 一份可直接附到 PR / RC issue 的 Markdown 摘要
 

--- a/scripts/cocos-primary-client-journey-evidence.ts
+++ b/scripts/cocos-primary-client-journey-evidence.ts
@@ -62,6 +62,11 @@ interface JourneyStepSummary {
   title: string;
   status: StepStatus;
   summary: string;
+  timing?: {
+    startedAt: string;
+    completedAt: string;
+    durationMs: number;
+  };
   evidence: string[];
 }
 
@@ -85,6 +90,7 @@ interface PrimaryJourneyEvidenceArtifact {
     owner: string;
     startedAt: string;
     completedAt: string;
+    durationMs: number;
     overallStatus: "passed" | "failed";
     summary: string;
     failure?: FailureSummary;
@@ -550,13 +556,19 @@ function renderMarkdown(artifact: PrimaryJourneyEvidenceArtifact): string {
   lines.push(`- Owner: ${artifact.execution.owner || "_unassigned_"}`);
   lines.push(`- Server: \`${artifact.environment.server}\``);
   lines.push(`- Evidence mode: \`${artifact.environment.evidenceMode}\``);
+  lines.push(`- Duration: \`${artifact.execution.durationMs}ms\``);
   lines.push("");
   lines.push("## Journey");
   lines.push("");
-  lines.push("| Step | Status | Evidence |");
-  lines.push("| --- | --- | --- |");
+  lines.push("| Step | Status | Timing | Evidence |");
+  lines.push("| --- | --- | --- | --- |");
   for (const step of artifact.journey) {
-    lines.push(`| ${step.title} | \`${step.status}\` | ${step.evidence.map((entry) => `\`${entry}\``).join("<br>") || "_none_"} |`);
+    const timing = step.timing
+      ? `\`${step.timing.durationMs}ms\`<br><sub>${step.timing.startedAt} -> ${step.timing.completedAt}</sub>`
+      : "_n/a_";
+    lines.push(
+      `| ${step.title} | \`${step.status}\` | ${timing} | ${step.evidence.map((entry) => `\`${entry}\``).join("<br>") || "_none_"} |`
+    );
   }
   lines.push("");
   lines.push("## Required Evidence");
@@ -607,6 +619,14 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
   const stepArtifacts = new Map<JourneyStepId, string[]>();
   const artifactSummaries = new Map<JourneyStepId, string>();
   const stepStatus = new Map<JourneyStepId, StepStatus>(STEP_METADATA.map((entry) => [entry.id, "pending"]));
+  const stepTimings = new Map<
+    JourneyStepId,
+    {
+      startedAt: string;
+      completedAt: string;
+      durationMs: number;
+    }
+  >();
   const roomId = "room-primary-journey";
   const playerId = "player-account";
   const syncedAuthSession = {
@@ -629,7 +649,15 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
   );
   const recoveredRoom = new FakeColyseusRoom([createJourneyReconnectRecoveryUpdate(roomId, playerId)], "journey-recovered-token");
   let currentStep: JourneyStepId = "lobby-entry";
+  let currentStepStartedAt = startedAt;
+  let currentStepStartedAtMs = Date.now();
   let root: RootState | null = null;
+
+  const beginStep = (stepId: JourneyStepId) => {
+    currentStep = stepId;
+    currentStepStartedAtMs = Date.now();
+    currentStepStartedAt = new Date(currentStepStartedAtMs).toISOString();
+  };
 
   const setRequiredEvidence = (fieldId: CanonicalEvidenceId, value: string, evidence: string[]) => {
     const field = requiredEvidence.find((entry) => entry.id === fieldId);
@@ -644,6 +672,8 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
     if (!root) {
       fail("Cannot record a journey step before the runtime is initialized.");
     }
+    const completedAtMs = Date.now();
+    const completedAt = new Date(completedAtMs).toISOString();
     const index = STEP_METADATA.findIndex((entry) => entry.id === stepId);
     const artifactPath = path.join(milestoneDir, `${String(index + 1).padStart(2, "0")}-${stepId}.json`);
     writeJson(
@@ -658,6 +688,11 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
     stepArtifacts.set(stepId, [toRepoRelative(artifactPath)]);
     stepStatus.set(stepId, "passed");
     artifactSummaries.set(stepId, summary);
+    stepTimings.set(stepId, {
+      startedAt: currentStepStartedAt,
+      completedAt,
+      durationMs: completedAtMs - currentStepStartedAtMs
+    });
     return toRepoRelative(artifactPath);
   };
 
@@ -707,14 +742,15 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
     root.onLoad();
     root.start();
 
-    currentStep = "lobby-entry";
+    beginStep("lobby-entry");
     await waitFor(
       () => root!.showLobby === true && root!.lobbyRooms.length === 1 && root!.sessionSource === "remote",
       () => captureJourneyArtifact({ root: root!, phase: "lobby-bootstrap", joinedOptions, room: initialRoom })
     );
     recordStep("lobby-entry", "Cold start reused the account session and reached the lobby room list.", initialRoom, "lobby-bootstrap");
+    root.privacyConsentAccepted = true;
 
-    currentStep = "room-join";
+    beginStep("room-join");
     await root.enterLobbyRoom(roomId);
     await waitFor(
       () => root!.showLobby === false && root!.lastUpdate?.world.meta.roomId === roomId,
@@ -728,7 +764,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
     );
     setRequiredEvidence("roomId", roomId, [roomJoinArtifact]);
 
-    currentStep = "map-explore";
+    beginStep("map-explore");
     await root.moveHeroToTile(root.lastUpdate.world.map.tiles[1]);
     await waitFor(
       () => root!.lastUpdate?.reason === "journey.world.explore" && root!.lastUpdate.world.ownHeroes[0]?.position.x === 1,
@@ -741,7 +777,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
       "world-explore"
     );
 
-    currentStep = "first-battle";
+    beginStep("first-battle");
     await root.moveHeroToTile(root.lastUpdate.world.map.tiles[3]);
     await waitFor(
       () => root!.lastUpdate?.battle?.id === "battle-neutral-journey",
@@ -754,7 +790,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
       "battle-start"
     );
 
-    currentStep = "battle-settlement";
+    beginStep("battle-settlement");
     await root.actInBattle({
       type: "battle.attack",
       attackerId: "hero-1-stack",
@@ -772,7 +808,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
     );
     setRequiredEvidence("firstBattleResult", "attacker_victory; gold +12; experience +25", [settlementArtifact]);
 
-    currentStep = "reconnect-restore";
+    beginStep("reconnect-restore");
     initialRoom.emitLeave(4002);
     await waitFor(
       () => root!.lastUpdate?.reason === "journey.reconnect.restore" && root!.lastUpdate.world.meta.day === 5,
@@ -792,7 +828,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
       [reconnectArtifact]
     );
 
-    currentStep = "return-to-world";
+    beginStep("return-to-world");
     recordStep(
       "return-to-world",
       "Recovered world HUD remained in the room with preserved resources, hero position, and progression.",
@@ -811,6 +847,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
     }
 
     const completedAt = new Date().toISOString();
+    const durationMs = Date.now() - Date.parse(startedAt);
     const artifact: PrimaryJourneyEvidenceArtifact = {
       schemaVersion: 1,
       candidate: {
@@ -824,6 +861,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
         owner: args.owner || "",
         startedAt,
         completedAt,
+        durationMs,
         overallStatus: "passed",
         summary:
           "Headless primary-client journey evidence passed for lobby entry, room join, world explore, first battle, settlement, reconnect recovery, and restored world state."
@@ -842,6 +880,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
         title: entry.title,
         status: stepStatus.get(entry.id) ?? "pending",
         summary: artifactSummaries.get(entry.id) ?? "",
+        ...(stepTimings.get(entry.id) ? { timing: stepTimings.get(entry.id) } : {}),
         evidence: stepArtifacts.get(entry.id) ?? []
       })),
       requiredEvidence
@@ -852,6 +891,8 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
     return artifact;
   } catch (error) {
     const completedAt = new Date().toISOString();
+    const completedAtMs = Date.now();
+    const durationMs = completedAtMs - Date.parse(startedAt);
     let failedArtifactPath: string | undefined;
     if (root) {
       const index = STEP_METADATA.findIndex((entry) => entry.id === currentStep);
@@ -870,6 +911,11 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
     stepStatus.set(currentStep, "failed");
     const failureMessage = error instanceof Error ? error.message : String(error);
     artifactSummaries.set(currentStep, failureMessage);
+    stepTimings.set(currentStep, {
+      startedAt: currentStepStartedAt,
+      completedAt,
+      durationMs: completedAtMs - currentStepStartedAtMs
+    });
 
     const artifact: PrimaryJourneyEvidenceArtifact = {
       schemaVersion: 1,
@@ -884,6 +930,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
         owner: args.owner || "",
         startedAt,
         completedAt,
+        durationMs,
         overallStatus: "failed",
         summary: `Primary-client journey evidence failed during ${currentStep}.`,
         failure: {
@@ -907,6 +954,7 @@ async function buildArtifact(args: Args): Promise<PrimaryJourneyEvidenceArtifact
         title: entry.title,
         status: stepStatus.get(entry.id) ?? "pending",
         summary: artifactSummaries.get(entry.id) ?? "",
+        ...(stepTimings.get(entry.id) ? { timing: stepTimings.get(entry.id) } : {}),
         evidence: stepArtifacts.get(entry.id) ?? []
       })),
       requiredEvidence

--- a/scripts/test/cocos-primary-client-journey-evidence.test.ts
+++ b/scripts/test/cocos-primary-client-journey-evidence.test.ts
@@ -42,10 +42,15 @@ test("release:cocos:primary-journey-evidence exports candidate-scoped JSON, mark
 
   const artifact = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
     candidate: { name: string };
-    execution: { owner: string; overallStatus: string; summary: string };
+    execution: { owner: string; overallStatus: string; summary: string; durationMs: number };
     environment: { evidenceMode: string };
     artifacts: { milestoneDir: string };
-    journey: Array<{ id: string; status: string; evidence: string[] }>;
+    journey: Array<{
+      id: string;
+      status: string;
+      evidence: string[];
+      timing?: { startedAt: string; completedAt: string; durationMs: number };
+    }>;
     requiredEvidence: Array<{ id: string; value: string; evidence: string[] }>;
   };
 
@@ -53,12 +58,15 @@ test("release:cocos:primary-journey-evidence exports candidate-scoped JSON, mark
   assert.equal(artifact.execution.owner, "codex");
   assert.equal(artifact.execution.overallStatus, "passed");
   assert.match(artifact.execution.summary, /Headless primary-client journey evidence passed/);
+  assert.ok(artifact.execution.durationMs >= 0);
   assert.equal(artifact.environment.evidenceMode, "headless-runtime-diagnostics");
   assert.deepEqual(
     artifact.journey.map((step) => step.id),
     ["lobby-entry", "room-join", "map-explore", "first-battle", "battle-settlement", "reconnect-restore", "return-to-world"]
   );
   assert.ok(artifact.journey.every((step) => step.status === "passed"));
+  assert.ok(artifact.journey.every((step) => (step.timing?.durationMs ?? -1) >= 0));
+  assert.ok(artifact.journey.every((step) => Boolean(step.timing?.startedAt) && Boolean(step.timing?.completedAt)));
   assert.equal(artifact.requiredEvidence.find((field) => field.id === "roomId")?.value, "room-primary-journey");
   assert.match(artifact.requiredEvidence.find((field) => field.id === "reconnectPrompt")?.value ?? "", /连接已恢复/);
   assert.equal(
@@ -81,5 +89,7 @@ test("release:cocos:primary-journey-evidence exports candidate-scoped JSON, mark
   const markdown = fs.readFileSync(markdownOutputPath, "utf8");
   assert.match(markdown, /# Cocos Primary-Client Journey Evidence/);
   assert.match(markdown, /Battle settlement/);
+  assert.match(markdown, /Duration: `\d+ms`/);
+  assert.match(markdown, /Timing/);
   assert.match(markdown, /headless-runtime-diagnostics/);
 });


### PR DESCRIPTION
## Summary
- add stage timing metadata to the primary Cocos journey RC evidence JSON and Markdown outputs
- align the canonical journey automation and related journey tests with the current privacy-consent gate
- document `release:cocos:primary-journey-evidence` as the canonical primary-client RC evidence source for release review

## Validation
- `node --import tsx --test ./scripts/test/cocos-primary-client-journey-evidence.test.ts`
- `node --import tsx --test ./scripts/test/cocos-rc-evidence-bundle.test.ts`
- `npm run test:cocos:primary-journey`
- `npm run typecheck:cocos`
- `npm run release:cocos:primary-journey-evidence -- --candidate issue-820-verify --output-dir <tmpdir> --owner codex`

Closes #820