### PR TITLE
[codex] Add season history listing endpoints

### DIFF
--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -40,6 +40,8 @@ import {
   type PlayerEventHistoryQuery,
   type PlayerEventHistorySnapshot
   ,
+  type SeasonListOptions,
+  type SeasonSnapshot,
   type ShopPurchaseMutationInput,
   type ShopPurchaseResult
 } from "./persistence";
@@ -109,6 +111,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly heroArchives = new Map<string, PlayerHeroArchiveSnapshot>();
   private readonly shopPurchases = new Map<string, ShopPurchaseResult>();
   private readonly reports = new Map<string, PlayerReportRecord>();
+  private readonly seasons = new Map<string, SeasonSnapshot>();
   private nextReportId = 1;
 
   async load(roomId: string): Promise<RoomPersistenceSnapshot | null> {
@@ -1060,18 +1063,36 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   }
 
   async getCurrentSeason(): Promise<import("./persistence").SeasonSnapshot | null> {
-    return null;
+    return this.selectSeasons({ status: "active", limit: 1 })[0] ?? null;
+  }
+
+  async listSeasons(options: SeasonListOptions = {}): Promise<SeasonSnapshot[]> {
+    return this.selectSeasons(options);
   }
 
   async createSeason(seasonId: string): Promise<import("./persistence").SeasonSnapshot> {
-    return {
+    const season: SeasonSnapshot = {
       seasonId: seasonId.trim(),
       status: "active",
       startedAt: new Date().toISOString()
     };
+    this.seasons.set(season.seasonId, structuredClone(season));
+    return structuredClone(season);
   }
 
-  async closeSeason(_seasonId: string): Promise<void> {}
+  async closeSeason(seasonId: string): Promise<void> {
+    const normalizedSeasonId = seasonId.trim();
+    const existing = this.seasons.get(normalizedSeasonId);
+    if (!existing) {
+      return;
+    }
+
+    this.seasons.set(normalizedSeasonId, {
+      ...existing,
+      status: "closed",
+      endedAt: new Date().toISOString()
+    });
+  }
 
   async close(): Promise<void> {}
 
@@ -1084,6 +1105,19 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     this.playerIdByWechatOpenId.clear();
     this.heroArchives.clear();
     this.shopPurchases.clear();
+    this.seasons.clear();
+  }
+
+  private selectSeasons(options: SeasonListOptions): SeasonSnapshot[] {
+    const status = options.status ?? "closed";
+    const rawLimit = options.limit ?? 20;
+    const limit = Math.min(100, Math.max(1, Math.floor(rawLimit)));
+
+    return Array.from(this.seasons.values())
+      .filter((season) => status === "all" || season.status === status)
+      .sort((left, right) => right.startedAt.localeCompare(left.startedAt) || left.seasonId.localeCompare(right.seasonId))
+      .slice(0, limit)
+      .map((season) => structuredClone(season));
   }
 }
 

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -31,6 +31,11 @@ export interface SeasonSnapshot {
   endedAt?: string;
 }
 
+export interface SeasonListOptions {
+  status?: "active" | "closed" | "all";
+  limit?: number;
+}
+
 export interface RoomSnapshotStore {
   load(roomId: string): Promise<RoomPersistenceSnapshot | null>;
   loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null>;
@@ -91,6 +96,7 @@ export interface RoomSnapshotStore {
   savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot>;
   listPlayerAccounts(options?: PlayerAccountListOptions): Promise<PlayerAccountSnapshot[]>;
   getCurrentSeason(): Promise<SeasonSnapshot | null>;
+  listSeasons?(options?: SeasonListOptions): Promise<SeasonSnapshot[]>;
   createSeason(seasonId: string): Promise<SeasonSnapshot>;
   closeSeason(seasonId: string): Promise<void>;
   save(roomId: string, snapshot: RoomPersistenceSnapshot): Promise<void>;
@@ -4730,6 +4736,32 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       startedAt: formatTimestamp(row.started_at as Date | string) ?? new Date().toISOString()
     };
     return endedAtTimestamp ? { ...base, endedAt: endedAtTimestamp } : base;
+  }
+
+  async listSeasons(options: SeasonListOptions = {}): Promise<SeasonSnapshot[]> {
+    const status = options.status ?? "closed";
+    const rawLimit = options.limit ?? 20;
+    const limit = Math.min(100, Math.max(1, Math.floor(rawLimit)));
+    const clauses = status === "all" ? "" : "WHERE status = ?";
+    const params = status === "all" ? [limit] : [status, limit];
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT season_id, status, started_at, ended_at
+       FROM \`veil_seasons\`
+       ${clauses}
+       ORDER BY started_at DESC
+       LIMIT ?`,
+      params
+    );
+
+    return rows.map((row) => {
+      const endedAtTimestamp = row.ended_at ? formatTimestamp(row.ended_at as Date | string) : undefined;
+      const season: SeasonSnapshot = {
+        seasonId: String(row.season_id),
+        status: row.status as "active" | "closed",
+        startedAt: formatTimestamp(row.started_at as Date | string) ?? new Date().toISOString()
+      };
+      return endedAtTimestamp ? { ...season, endedAt: endedAtTimestamp } : season;
+    });
   }
 
   async createSeason(seasonId: string): Promise<SeasonSnapshot> {

--- a/apps/server/src/seasons.ts
+++ b/apps/server/src/seasons.ts
@@ -40,6 +40,28 @@ function readJsonBody(request: IncomingMessage): Promise<unknown> {
   });
 }
 
+function readLimit(request: IncomingMessage, fallback = 20): number {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const rawLimit = Number(url.searchParams.get("limit"));
+  if (!Number.isFinite(rawLimit)) {
+    return fallback;
+  }
+
+  return Math.min(100, Math.max(1, Math.floor(rawLimit)));
+}
+
+function readAdminSeasonStatus(request: IncomingMessage): "closed" | "all" {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const status = url.searchParams.get("status");
+  if (!status || status === "closed") {
+    return "closed";
+  }
+  if (status === "all") {
+    return "all";
+  }
+  throw new Error('status must be "closed" or "all"');
+}
+
 export function registerSeasonRoutes(
   app: {
     use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
@@ -70,6 +92,57 @@ export function registerSeasonRoutes(
       }
       const season = await store.getCurrentSeason();
       sendJson(response, 200, { season });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/seasons", async (request, response) => {
+    try {
+      if (!store) {
+        sendJson(response, 200, { seasons: [] });
+        return;
+      }
+      if (!store.listSeasons) {
+        sendJson(response, 200, { seasons: [] });
+        return;
+      }
+
+      const seasons = await store.listSeasons({
+        status: "closed",
+        limit: readLimit(request)
+      });
+      sendJson(response, 200, { seasons });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/admin/seasons", async (request, response) => {
+    try {
+      const adminToken = process.env.VEIL_ADMIN_TOKEN;
+      if (!adminToken) {
+        sendJson(response, 503, { error: { code: "not_configured", message: "Admin token not configured" } });
+        return;
+      }
+      if (!isAdminAuthorized(request)) {
+        sendJson(response, 403, { error: { code: "forbidden", message: "Invalid admin token" } });
+        return;
+      }
+      if (!store) {
+        sendJson(response, 503, { error: { code: "no_store", message: "No persistence store available" } });
+        return;
+      }
+      if (!store.listSeasons) {
+        sendJson(response, 503, { error: { code: "no_store", message: "No season history store available" } });
+        return;
+      }
+
+      const seasons = await store.listSeasons({
+        status: readAdminSeasonStatus(request),
+        limit: readLimit(request)
+      });
+      sendJson(response, 200, { seasons });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -118,6 +118,24 @@ class MemoryAuthStore implements RoomSnapshotStore {
     );
   }
 
+  async getCurrentSeason() {
+    return null;
+  }
+
+  async listSeasons() {
+    return [];
+  }
+
+  async createSeason(seasonId: string) {
+    return {
+      seasonId,
+      status: "active" as const,
+      startedAt: new Date().toISOString()
+    };
+  }
+
+  async closeSeason(): Promise<void> {}
+
   async touchPlayerAccountAuthSession(playerId: string, sessionId: string, lastUsedAt?: string): Promise<void> {
     const sessions = this.authSessionsByPlayerId.get(playerId.trim());
     const existing = sessions?.get(sessionId.trim());

--- a/apps/server/test/memory-room-snapshot-store.test.ts
+++ b/apps/server/test/memory-room-snapshot-store.test.ts
@@ -170,3 +170,21 @@ test("memory room snapshot store ensurePlayerAccount keeps stored snapshots isol
   assert.equal(second.recentEventLog.length, 0);
   assert.equal(second.recentBattleReplays.length, 0);
 });
+
+test("memory room snapshot store lists closed seasons and retains active season separately", async () => {
+  const store = createMemoryRoomSnapshotStore();
+  await store.createSeason("season-1");
+  await store.closeSeason("season-1");
+  await store.createSeason("season-2");
+
+  const currentSeason = await store.getCurrentSeason();
+  const closedSeasons = await store.listSeasons?.({ status: "closed", limit: 10 });
+  const allSeasons = await store.listSeasons?.({ status: "all", limit: 10 });
+
+  assert.equal(currentSeason?.seasonId, "season-2");
+  assert.deepEqual(closedSeasons?.map((season) => season.seasonId), ["season-1"]);
+  assert.deepEqual(new Set(allSeasons?.map((season) => season.seasonId)), new Set(["season-1", "season-2"]));
+  assert.equal(allSeasons?.find((season) => season.seasonId === "season-2")?.status, "active");
+  assert.equal(allSeasons?.find((season) => season.seasonId === "season-1")?.status, "closed");
+  assert.ok(allSeasons?.find((season) => season.seasonId === "season-1")?.endedAt);
+});

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -228,6 +228,72 @@ test("loadPlayerEventHistory returns paged rows and total count", async () => {
   assert.deepEqual(queries[1].params, ["player-1", "achievement", "hero-1", 1, 1]);
 });
 
+test("listSeasons reads closed seasons by default and caps the query limit at 100", async () => {
+  const store = createStoreHarness();
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+
+  store.pool = {
+    query: async (sql: string, params: unknown[]) => {
+      queries.push({ sql, params });
+      return [[
+        {
+          season_id: "season-2",
+          status: "closed",
+          started_at: "2026-03-01T00:00:00.000Z",
+          ended_at: "2026-03-15T00:00:00.000Z"
+        }
+      ]];
+    }
+  };
+
+  const seasons = await store.listSeasons({ limit: 999 });
+
+  assert.deepEqual(seasons, [
+    {
+      seasonId: "season-2",
+      status: "closed",
+      startedAt: "2026-03-01T00:00:00.000Z",
+      endedAt: "2026-03-15T00:00:00.000Z"
+    }
+  ]);
+  assert.equal(queries.length, 1);
+  assert.match(queries[0].sql, /FROM `veil_seasons`/);
+  assert.match(queries[0].sql, /WHERE status = \?/);
+  assert.deepEqual(queries[0].params, ["closed", 100]);
+});
+
+test("listSeasons supports status=all without a status filter", async () => {
+  const store = createStoreHarness();
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+
+  store.pool = {
+    query: async (sql: string, params: unknown[]) => {
+      queries.push({ sql, params });
+      return [[
+        {
+          season_id: "season-3",
+          status: "active",
+          started_at: "2026-04-01T00:00:00.000Z",
+          ended_at: null
+        }
+      ]];
+    }
+  };
+
+  const seasons = await store.listSeasons({ status: "all", limit: 5 });
+
+  assert.deepEqual(seasons, [
+    {
+      seasonId: "season-3",
+      status: "active",
+      startedAt: "2026-04-01T00:00:00.000Z"
+    }
+  ]);
+  assert.equal(queries.length, 1);
+  assert.doesNotMatch(queries[0].sql, /WHERE status = \?/);
+  assert.deepEqual(queries[0].params, [5]);
+});
+
 test("mysql player event history query applies inclusive timestamp filters", async () => {
   const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
   const store = new MySqlRoomSnapshotStore({

--- a/apps/server/test/player-account-battle-replay-detail-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-detail-routes.test.ts
@@ -111,6 +111,24 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return [];
   }
 
+  async getCurrentSeason() {
+    return null;
+  }
+
+  async listSeasons() {
+    return [];
+  }
+
+  async createSeason(seasonId: string) {
+    return {
+      seasonId,
+      status: "active" as const,
+      startedAt: new Date().toISOString()
+    };
+  }
+
+  async closeSeason(): Promise<void> {}
+
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
     const existing = this.accounts.get(input.playerId);
     const account: PlayerAccountSnapshot = {

--- a/apps/server/test/player-account-battle-replay-playback-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-playback-routes.test.ts
@@ -102,6 +102,24 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return [];
   }
 
+  async getCurrentSeason() {
+    return null;
+  }
+
+  async listSeasons() {
+    return [];
+  }
+
+  async createSeason(seasonId: string) {
+    return {
+      seasonId,
+      status: "active" as const,
+      startedAt: new Date().toISOString()
+    };
+  }
+
+  async closeSeason(): Promise<void> {}
+
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
     const existing = this.accounts.get(input.playerId);
     const account: PlayerAccountSnapshot = {

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -139,6 +139,24 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return [];
   }
 
+  async getCurrentSeason() {
+    return null;
+  }
+
+  async listSeasons() {
+    return [];
+  }
+
+  async createSeason(seasonId: string) {
+    return {
+      seasonId,
+      status: "active" as const,
+      startedAt: new Date().toISOString()
+    };
+  }
+
+  async closeSeason(): Promise<void> {}
+
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
     const existing = this.accounts.get(input.playerId);
     const account: PlayerAccountSnapshot = {

--- a/apps/server/test/season-routes.test.ts
+++ b/apps/server/test/season-routes.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { registerSeasonRoutes } from "../src/seasons";
+import type { RoomSnapshotStore, SeasonListOptions, SeasonSnapshot } from "../src/persistence";
+
+type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void | Promise<void>;
+
+function createTestApp() {
+  const gets = new Map<string, RouteHandler>();
+
+  return {
+    app: {
+      use(_handler: unknown) {},
+      get(path: string, handler: RouteHandler) {
+        gets.set(path, handler);
+      },
+      post(_path: string, _handler: RouteHandler) {}
+    },
+    gets
+  };
+}
+
+function createRequest(options: {
+  method?: string;
+  headers?: Record<string, string | undefined>;
+  url?: string;
+} = {}): IncomingMessage {
+  const request = {} as IncomingMessage;
+  Object.assign(request, {
+    method: options.method ?? "GET",
+    headers: options.headers ?? {},
+    url: options.url ?? "/"
+  });
+  return request;
+}
+
+function createResponse(): ServerResponse & { body: string; headers: Record<string, string> } {
+  const headers: Record<string, string> = {};
+  let body = "";
+
+  return {
+    statusCode: 200,
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+      return this;
+    },
+    end(chunk?: string | Buffer) {
+      body = chunk === undefined ? "" : Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      return this;
+    },
+    get body() {
+      return body;
+    },
+    headers
+  } as ServerResponse & { body: string; headers: Record<string, string> };
+}
+
+function createSeasonStore(seasons: SeasonSnapshot[], calls: SeasonListOptions[]): RoomSnapshotStore {
+  return {
+    async listSeasons(options: SeasonListOptions = {}) {
+      calls.push(options);
+      const status = options.status ?? "closed";
+      const limit = options.limit ?? 20;
+      return seasons
+        .filter((season) => status === "all" || season.status === status)
+        .slice(0, limit);
+    },
+    async getCurrentSeason() {
+      return seasons.find((season) => season.status === "active") ?? null;
+    },
+    async createSeason(seasonId: string) {
+      return {
+        seasonId,
+        status: "active",
+        startedAt: new Date().toISOString()
+      };
+    },
+    async closeSeason() {},
+    async load() {
+      return null;
+    },
+    async loadPlayerAccount() {
+      return null;
+    },
+    async loadPlayerAccountByLoginId() {
+      return null;
+    },
+    async loadPlayerAccountByWechatMiniGameOpenId() {
+      return null;
+    },
+    async loadPlayerEventHistory() {
+      return { items: [], total: 0 };
+    },
+    async loadPlayerAccounts() {
+      return [];
+    },
+    async loadPlayerAccountAuthByLoginId() {
+      return null;
+    },
+    async loadPlayerAccountAuthByPlayerId() {
+      return null;
+    },
+    async loadPlayerHeroArchives() {
+      return [];
+    },
+    async ensurePlayerAccount() {
+      throw new Error("not implemented");
+    },
+    async bindPlayerAccountCredentials() {
+      throw new Error("not implemented");
+    },
+    async creditGems() {
+      throw new Error("not implemented");
+    },
+    async debitGems() {
+      throw new Error("not implemented");
+    },
+    async savePlayerAccountPrivacyConsent() {
+      throw new Error("not implemented");
+    },
+    async savePlayerAccountAuthSession() {
+      return null;
+    },
+    async loadPlayerAccountAuthSession() {
+      return null;
+    },
+    async listPlayerAccountAuthSessions() {
+      return [];
+    },
+    async touchPlayerAccountAuthSession() {},
+    async revokePlayerAccountAuthSession() {
+      return false;
+    },
+    async revokePlayerAccountAuthSessions() {
+      return null;
+    },
+    async bindPlayerAccountWechatMiniGameIdentity() {
+      throw new Error("not implemented");
+    },
+    async deletePlayerAccount() {
+      return null;
+    },
+    async savePlayerAccountProfile() {
+      throw new Error("not implemented");
+    },
+    async savePlayerAccountProgress() {
+      throw new Error("not implemented");
+    },
+    async listPlayerAccounts() {
+      return [];
+    },
+    async save() {},
+    async delete() {},
+    async pruneExpired() {
+      return 0;
+    },
+    async close() {}
+  } as RoomSnapshotStore;
+}
+
+function withAdminToken(t: TestContext, token = "season-admin-token"): string {
+  const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = token;
+  t.after(() => {
+    if (originalAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+      return;
+    }
+    process.env.VEIL_ADMIN_TOKEN = originalAdminToken;
+  });
+  return token;
+}
+
+function registerRoutes(store: RoomSnapshotStore | null) {
+  const { app, gets } = createTestApp();
+  registerSeasonRoutes(app, store);
+  return { gets };
+}
+
+test("GET /api/seasons returns closed seasons and caps limit at 100", async () => {
+  const calls: SeasonListOptions[] = [];
+  const store = createSeasonStore([
+    { seasonId: "season-3", status: "closed", startedAt: "2026-03-03T00:00:00.000Z", endedAt: "2026-03-04T00:00:00.000Z" },
+    { seasonId: "season-2", status: "closed", startedAt: "2026-02-03T00:00:00.000Z", endedAt: "2026-02-04T00:00:00.000Z" },
+    { seasonId: "season-1", status: "active", startedAt: "2026-01-03T00:00:00.000Z" }
+  ], calls);
+  const { gets } = registerRoutes(store);
+  const handler = gets.get("/api/seasons");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(createRequest({ url: "/api/seasons?limit=999" }), response);
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(calls, [{ status: "closed", limit: 100 }]);
+  assert.deepEqual(JSON.parse(response.body), {
+    seasons: [
+      { seasonId: "season-3", status: "closed", startedAt: "2026-03-03T00:00:00.000Z", endedAt: "2026-03-04T00:00:00.000Z" },
+      { seasonId: "season-2", status: "closed", startedAt: "2026-02-03T00:00:00.000Z", endedAt: "2026-02-04T00:00:00.000Z" }
+    ]
+  });
+});
+
+test("GET /api/admin/seasons requires the admin token", async (t) => {
+  const token = withAdminToken(t);
+  const calls: SeasonListOptions[] = [];
+  const store = createSeasonStore([], calls);
+  const { gets } = registerRoutes(store);
+  const handler = gets.get("/api/admin/seasons");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({ url: "/api/admin/seasons", headers: { "x-veil-admin-token": `${token}-wrong` } }),
+    response
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: { code: "forbidden", message: "Invalid admin token" }
+  });
+  assert.deepEqual(calls, []);
+});
+
+test("GET /api/admin/seasons supports status=all and caps limit at 100", async (t) => {
+  const token = withAdminToken(t);
+  const calls: SeasonListOptions[] = [];
+  const store = createSeasonStore([
+    { seasonId: "season-4", status: "active", startedAt: "2026-04-01T00:00:00.000Z" },
+    { seasonId: "season-3", status: "closed", startedAt: "2026-03-01T00:00:00.000Z", endedAt: "2026-03-15T00:00:00.000Z" }
+  ], calls);
+  const { gets } = registerRoutes(store);
+  const handler = gets.get("/api/admin/seasons");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      url: "/api/admin/seasons?status=all&limit=500",
+      headers: { "x-veil-admin-token": token }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(calls, [{ status: "all", limit: 100 }]);
+  assert.deepEqual(JSON.parse(response.body), {
+    seasons: [
+      { seasonId: "season-4", status: "active", startedAt: "2026-04-01T00:00:00.000Z" },
+      { seasonId: "season-3", status: "closed", startedAt: "2026-03-01T00:00:00.000Z", endedAt: "2026-03-15T00:00:00.000Z" }
+    ]
+  });
+});


### PR DESCRIPTION
## Summary
- add `listSeasons` support to the season persistence contract and implement it in the MySQL and memory stores
- add `GET /api/seasons` for closed-season history and `GET /api/admin/seasons` with `status=all` support behind the admin token
- add focused server tests for the new route behavior and season-list store logic

## Validation
- `node --import tsx --test apps/server/test/season-routes.test.ts apps/server/test/memory-room-snapshot-store.test.ts apps/server/test/persistence-account-credentials.test.ts`
- `npm run typecheck:server`

Closes #826