### PR TITLE
feat: add admin minor-protection preview endpoint

### DIFF
--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -13,6 +13,7 @@ import { registerConfigViewerRoutes } from "./config-viewer";
 import { registerLeaderboardRoutes } from "./leaderboard";
 import { registerLobbyRoutes } from "./lobby";
 import { registerMatchmakingRoutes } from "./matchmaking";
+import { registerMinorProtectionPreviewRoutes } from "./minor-protection-preview";
 import { createMemoryRoomSnapshotStore } from "./memory-room-snapshot-store";
 import {
   buildPrometheusMetricsDocument,
@@ -117,6 +118,7 @@ export interface DevServerBootstrapDependencies {
   registerWechatPayRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerLobbyRoutes(app: unknown, dependencies: { listRooms: typeof listLobbyRooms }): void;
   registerMatchmakingRoutes(app: unknown, dependencies: { store: DevServerRoomSnapshotStore }): void;
+  registerMinorProtectionPreviewRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerLeaderboardRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerSeasonRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerRuntimeObservabilityRoutes(app: unknown, options?: { store?: DevServerRoomSnapshotStore }): void;
@@ -183,6 +185,8 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerLobbyRoutes: (app, dependencies) => registerLobbyRoutes(app as never, dependencies),
     registerMatchmakingRoutes: (app, dependencies) =>
       registerMatchmakingRoutes(app as never, { store: dependencies.store as RoomSnapshotStore }),
+    registerMinorProtectionPreviewRoutes: (app, store) =>
+      registerMinorProtectionPreviewRoutes(app as never, store as RoomSnapshotStore | null),
     registerLeaderboardRoutes: (app, store) => registerLeaderboardRoutes(app as never, store as RoomSnapshotStore | null),
     registerSeasonRoutes: (app, store) => registerSeasonRoutes(app as never, store as RoomSnapshotStore | null),
     registerRuntimeObservabilityRoutes: (app, options) => registerRuntimeObservabilityRoutes(app as never, options),
@@ -247,6 +251,7 @@ export async function startDevServer(
   deps.registerWechatPayRoutes(expressApp, effectiveSnapshotStore);
   deps.registerLobbyRoutes(expressApp, { listRooms: listLobbyRooms });
   deps.registerMatchmakingRoutes(expressApp, { store: effectiveSnapshotStore });
+  deps.registerMinorProtectionPreviewRoutes(expressApp, effectiveSnapshotStore);
   deps.registerLeaderboardRoutes(expressApp, effectiveSnapshotStore);
   deps.registerSeasonRoutes(expressApp, effectiveSnapshotStore);
   deps.registerRuntimeObservabilityRoutes(expressApp, { store: effectiveSnapshotStore });

--- a/apps/server/src/minor-protection-preview.ts
+++ b/apps/server/src/minor-protection-preview.ts
@@ -1,0 +1,124 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { evaluateMinorProtectionState, getMinorProtectionDateKey, readMinorProtectionConfig } from "./minor-protection";
+import type { PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
+
+interface PreviewApp {
+  use(handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void): void;
+  get(path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>): void;
+}
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+function isAdminAuthorized(request: IncomingMessage): boolean {
+  const adminToken = process.env.VEIL_ADMIN_TOKEN?.trim();
+  return Boolean(adminToken) && request.headers["x-veil-admin-token"] === adminToken;
+}
+
+function readOptionalTrimmedQueryParam(request: IncomingMessage, key: string): string | undefined {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const value = url.searchParams.get(key)?.trim();
+  return value ? value : undefined;
+}
+
+function readOptionalDateQueryParam(request: IncomingMessage, key: string): Date | undefined {
+  const value = readOptionalTrimmedQueryParam(request, key);
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`"${key}" must be a valid ISO-8601 datetime`);
+  }
+
+  return parsed;
+}
+
+function readOptionalIntegerQueryParam(request: IncomingMessage, key: string): number | undefined {
+  const value = readOptionalTrimmedQueryParam(request, key);
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`"${key}" must be a finite integer`);
+  }
+
+  return Math.max(0, Math.floor(parsed));
+}
+
+export function registerMinorProtectionPreviewRoutes(app: PreviewApp, store: RoomSnapshotStore | null): void {
+  app.use((request, response, next) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type,X-Veil-Admin-Token");
+
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    next();
+  });
+
+  app.get("/api/admin/minor-protection/preview", async (request, response) => {
+    try {
+      if (!isAdminAuthorized(request)) {
+        sendJson(response, 401, {
+          error: {
+            code: "unauthorized",
+            message: "Invalid admin token"
+          }
+        });
+        return;
+      }
+
+      const playerId = readOptionalTrimmedQueryParam(request, "playerId");
+      if (!playerId) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_request",
+            message: '"playerId" is required'
+          }
+        });
+        return;
+      }
+
+      const at = readOptionalDateQueryParam(request, "at") ?? new Date();
+      const dailyPlayMinutesOverride = readOptionalIntegerQueryParam(request, "dailyPlayMinutes");
+      const account = (await store?.loadPlayerAccount(playerId)) ?? null;
+      const config = readMinorProtectionConfig();
+      const overrideLocalDate = dailyPlayMinutesOverride == null ? undefined : getMinorProtectionDateKey(at, config.timeZone);
+      const evaluationInput: Pick<PlayerAccountSnapshot, "isMinor" | "dailyPlayMinutes" | "lastPlayDate"> = {};
+      const effectiveDailyPlayMinutes = dailyPlayMinutesOverride ?? account?.dailyPlayMinutes;
+      const effectiveLastPlayDate = overrideLocalDate ?? account?.lastPlayDate;
+
+      if (account?.isMinor !== undefined) {
+        evaluationInput.isMinor = account.isMinor;
+      }
+      if (effectiveDailyPlayMinutes !== undefined) {
+        evaluationInput.dailyPlayMinutes = effectiveDailyPlayMinutes;
+      }
+      if (effectiveLastPlayDate !== undefined) {
+        evaluationInput.lastPlayDate = effectiveLastPlayDate;
+      }
+
+      const evaluation = evaluateMinorProtectionState(evaluationInput, at, config);
+
+      sendJson(response, 200, evaluation);
+    } catch (error) {
+      sendJson(response, 400, {
+        error: {
+          code: "invalid_request",
+          message: error instanceof Error ? error.message : String(error)
+        }
+      });
+    }
+  });
+}

--- a/apps/server/src/minor-protection.ts
+++ b/apps/server/src/minor-protection.ts
@@ -24,6 +24,11 @@ export interface MinorProtectionState {
   dailyLimitReached: boolean;
 }
 
+export interface MinorProtectionEvaluation extends MinorProtectionState {
+  wouldBlock: boolean;
+  reason: "minor_restricted_hours" | "minor_daily_limit_reached" | null;
+}
+
 function parseEnvInteger(value: string | undefined, fallback: number, minimum: number, maximum?: number): number {
   const parsed = Number(value?.trim());
   if (!Number.isFinite(parsed)) {
@@ -173,6 +178,21 @@ export function deriveMinorProtectionState(
     dailyLimitMinutes,
     restrictedHours,
     dailyLimitReached: normalizedDailyPlayMinutes >= dailyLimitMinutes
+  };
+}
+
+export function evaluateMinorProtectionState(
+  account: Pick<PlayerAccountSnapshot, "isMinor" | "dailyPlayMinutes" | "lastPlayDate">,
+  now = new Date(),
+  config = readMinorProtectionConfig()
+): MinorProtectionEvaluation {
+  const state = deriveMinorProtectionState(account, now, config);
+  const wouldBlock = state.enforced && (state.restrictedHours || state.dailyLimitReached);
+
+  return {
+    ...state,
+    wouldBlock,
+    reason: !wouldBlock ? null : state.restrictedHours ? "minor_restricted_hours" : "minor_daily_limit_reached"
   };
 }
 

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -223,6 +223,11 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
       matchmakingStore = dependencies.store;
       base.routeCalls.push("matchmaking");
     },
+    registerMinorProtectionPreviewRoutes: (app, store) => {
+      assert.equal(app, base.expressApp);
+      assert.equal(store, memoryStore);
+      base.routeCalls.push("minor-protection-preview");
+    },
     registerPrometheusMetricsMiddleware: (app) => {
       assert.equal(app, base.expressApp);
       base.routeCalls.push("prometheus-middleware");
@@ -280,6 +285,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
     "wechat-pay",
     "lobby",
     "matchmaking",
+    "minor-protection-preview",
     "leaderboard",
     "seasons",
     "runtime-observability",
@@ -344,7 +350,11 @@ test("dev server logs process-level failures, closes stores, and exits non-zero"
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerPrometheusMetricsMiddleware: () => undefined,\n    registerPrometheusMetricsRoute: () => undefined,\n    registerLeaderboardRoutes: () => undefined,\n    registerSeasonRoutes: () => undefined,
+    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
+    registerLeaderboardRoutes: () => undefined,
+    registerSeasonRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -403,7 +413,11 @@ test("dev server logs uncaught exceptions, closes stores, and exits non-zero", a
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerPrometheusMetricsMiddleware: () => undefined,\n    registerPrometheusMetricsRoute: () => undefined,\n    registerLeaderboardRoutes: () => undefined,\n    registerSeasonRoutes: () => undefined,
+    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
+    registerLeaderboardRoutes: () => undefined,
+    registerSeasonRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -484,7 +498,11 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerPrometheusMetricsMiddleware: () => undefined,\n    registerPrometheusMetricsRoute: () => undefined,\n    registerLeaderboardRoutes: () => undefined,\n    registerSeasonRoutes: () => undefined,
+    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
+    registerLeaderboardRoutes: () => undefined,
+    registerSeasonRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -551,8 +569,11 @@ test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL 
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
+    registerMinorProtectionPreviewRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
     registerPrometheusMetricsRoute: () => undefined,
+    registerLeaderboardRoutes: () => undefined,
+    registerSeasonRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
@@ -638,7 +659,11 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerPrometheusMetricsMiddleware: () => undefined,\n    registerPrometheusMetricsRoute: () => undefined,\n    registerLeaderboardRoutes: () => undefined,\n    registerSeasonRoutes: () => undefined,
+    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
+    registerLeaderboardRoutes: () => undefined,
+    registerSeasonRoutes: () => undefined,
     registerRuntimeObservabilityRoutes: () => undefined,
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {

--- a/apps/server/test/minor-protection-preview.test.ts
+++ b/apps/server/test/minor-protection-preview.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { evaluateMinorProtectionState, readMinorProtectionConfig } from "../src/minor-protection";
+import { registerMinorProtectionPreviewRoutes } from "../src/minor-protection-preview";
+import type { RoomSnapshotStore } from "../src/persistence";
+
+type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void | Promise<void>;
+
+function createRequest(options: {
+  method?: string;
+  headers?: Record<string, string | undefined>;
+  url?: string;
+} = {}): IncomingMessage {
+  async function* iterateBody() {}
+
+  const request = iterateBody() as IncomingMessage;
+  Object.assign(request, {
+    method: options.method ?? "GET",
+    headers: options.headers ?? {},
+    url: options.url ?? "/"
+  });
+  return request;
+}
+
+function createResponse(): ServerResponse & {
+  body: string;
+  headers: Record<string, string>;
+} {
+  const headers: Record<string, string> = {};
+  let body = "";
+
+  return {
+    statusCode: 200,
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+      return this;
+    },
+    end(chunk?: string | Buffer) {
+      body = chunk === undefined ? "" : Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      return this;
+    },
+    get body() {
+      return body;
+    },
+    headers
+  } as ServerResponse & { body: string; headers: Record<string, string> };
+}
+
+function createTestApp() {
+  const gets = new Map<string, RouteHandler>();
+
+  return {
+    app: {
+      use(_handler: unknown) {},
+      get(path: string, handler: RouteHandler) {
+        gets.set(path, handler);
+      }
+    },
+    gets
+  };
+}
+
+test("evaluateMinorProtectionState flags night lockout", () => {
+  const config = readMinorProtectionConfig({
+    VEIL_MINOR_PROTECTION_HOLIDAY_DATES: "",
+    VEIL_MINOR_PROTECTION_TIME_ZONE: "Asia/Shanghai"
+  });
+
+  const evaluation = evaluateMinorProtectionState(
+    {
+      isMinor: true,
+      dailyPlayMinutes: 10,
+      lastPlayDate: "2026-04-03"
+    },
+    new Date("2026-04-03T14:30:00.000Z"),
+    config
+  );
+
+  assert.equal(evaluation.restrictedHours, true);
+  assert.equal(evaluation.wouldBlock, true);
+  assert.equal(evaluation.reason, "minor_restricted_hours");
+});
+
+test("evaluateMinorProtectionState flags daily limit reached", () => {
+  const config = readMinorProtectionConfig({
+    VEIL_MINOR_PROTECTION_HOLIDAY_DATES: "",
+    VEIL_MINOR_PROTECTION_TIME_ZONE: "Asia/Shanghai"
+  });
+
+  const evaluation = evaluateMinorProtectionState(
+    {
+      isMinor: true,
+      dailyPlayMinutes: 90,
+      lastPlayDate: "2026-04-03"
+    },
+    new Date("2026-04-03T01:00:00.000Z"),
+    config
+  );
+
+  assert.equal(evaluation.dailyLimitReached, true);
+  assert.equal(evaluation.wouldBlock, true);
+  assert.equal(evaluation.reason, "minor_daily_limit_reached");
+});
+
+test("evaluateMinorProtectionState applies holiday override", () => {
+  const config = readMinorProtectionConfig({
+    VEIL_MINOR_PROTECTION_HOLIDAY_DATES: "2026-04-06",
+    VEIL_MINOR_PROTECTION_TIME_ZONE: "Asia/Shanghai"
+  });
+
+  const evaluation = evaluateMinorProtectionState(
+    {
+      isMinor: true,
+      dailyPlayMinutes: 100,
+      lastPlayDate: "2026-04-06"
+    },
+    new Date("2026-04-06T01:00:00.000Z"),
+    config
+  );
+
+  assert.equal(evaluation.localDate, "2026-04-06");
+  assert.equal(evaluation.dailyLimitMinutes, 180);
+  assert.equal(evaluation.dailyLimitReached, false);
+  assert.equal(evaluation.wouldBlock, false);
+  assert.equal(evaluation.reason, null);
+});
+
+test("GET /api/admin/minor-protection/preview requires the admin token", async (t) => {
+  const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = "preview-token";
+  t.after(() => {
+    if (originalAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+      return;
+    }
+    process.env.VEIL_ADMIN_TOKEN = originalAdminToken;
+  });
+
+  const { app, gets } = createTestApp();
+  registerMinorProtectionPreviewRoutes(app, null);
+  const handler = gets.get("/api/admin/minor-protection/preview");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      url: "/api/admin/minor-protection/preview?playerId=minor-player"
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 401);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: {
+      code: "unauthorized",
+      message: "Invalid admin token"
+    }
+  });
+});
+
+test("GET /api/admin/minor-protection/preview returns 400 when playerId is missing", async (t) => {
+  const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = "preview-token";
+  t.after(() => {
+    if (originalAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+      return;
+    }
+    process.env.VEIL_ADMIN_TOKEN = originalAdminToken;
+  });
+
+  const { app, gets } = createTestApp();
+  registerMinorProtectionPreviewRoutes(app, null);
+  const handler = gets.get("/api/admin/minor-protection/preview");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      headers: {
+        "x-veil-admin-token": "preview-token"
+      },
+      url: "/api/admin/minor-protection/preview"
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: {
+      code: "invalid_request",
+      message: '"playerId" is required'
+    }
+  });
+});
+
+test("GET /api/admin/minor-protection/preview honors at and dailyPlayMinutes overrides", async (t) => {
+  const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = "preview-token";
+  t.after(() => {
+    if (originalAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+      return;
+    }
+    process.env.VEIL_ADMIN_TOKEN = originalAdminToken;
+  });
+
+  const store = {
+    async loadPlayerAccount(playerId: string) {
+      return {
+        playerId,
+        isMinor: true,
+        dailyPlayMinutes: 10,
+        lastPlayDate: "2026-04-02"
+      };
+    }
+  } as Pick<RoomSnapshotStore, "loadPlayerAccount"> as RoomSnapshotStore;
+
+  const { app, gets } = createTestApp();
+  registerMinorProtectionPreviewRoutes(app, store);
+  const handler = gets.get("/api/admin/minor-protection/preview");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      headers: {
+        "x-veil-admin-token": "preview-token"
+      },
+      url: "/api/admin/minor-protection/preview?playerId=minor-player&at=2026-04-03T14:30:00.000Z&dailyPlayMinutes=90"
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(JSON.parse(response.body), {
+    enforced: true,
+    localDate: "2026-04-03",
+    normalizedDailyPlayMinutes: 90,
+    dailyLimitMinutes: 90,
+    restrictedHours: true,
+    dailyLimitReached: true,
+    wouldBlock: true,
+    reason: "minor_restricted_hours"
+  });
+});


### PR DESCRIPTION
## Summary
- add an admin preview endpoint for minor-protection state by player and simulated timestamp
- extract a reusable minor-protection evaluation result with blocking reason
- cover route auth/validation/override behavior and dev-server registration

## Testing
- node --import tsx --test ./apps/server/test/minor-protection-preview.test.ts
- node --import tsx --test ./apps/server/test/dev-server.test.ts
- npm run typecheck:server

Closes #828