### PR TITLE
feat: award season rewards on close

### DIFF
--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -1,5 +1,7 @@
 import {
+  DEFAULT_ELO_RATING,
   appendEventLogEntries,
+  getTierForRating,
   getEquipmentDefinition,
   normalizeEloRating,
   normalizeEventLogEntries,
@@ -40,12 +42,14 @@ import {
   type PlayerEventHistoryQuery,
   type PlayerEventHistorySnapshot
   ,
+  type SeasonCloseSummary,
   type SeasonListOptions,
   type SeasonSnapshot,
   type ShopPurchaseMutationInput,
   type ShopPurchaseResult
 } from "./persistence";
 import type { RoomPersistenceSnapshot } from "./index";
+import { computeSeasonResetEloRating, resolveSeasonRewardConfig } from "./season-rewards";
 
 function cloneAccount(account: PlayerAccountSnapshot): PlayerAccountSnapshot {
   return structuredClone(account);
@@ -1080,11 +1084,38 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     return structuredClone(season);
   }
 
-  async closeSeason(seasonId: string): Promise<void> {
+  async closeSeason(seasonId: string): Promise<SeasonCloseSummary> {
     const normalizedSeasonId = seasonId.trim();
     const existing = this.seasons.get(normalizedSeasonId);
-    if (!existing) {
-      return;
+    if (!existing || existing.status === "closed") {
+      return {
+        seasonId: normalizedSeasonId,
+        playersRewarded: 0,
+        totalGemsGranted: 0
+      };
+    }
+
+    const rewardConfig = resolveSeasonRewardConfig();
+    const rankedAccounts = Array.from(this.accounts.values())
+      .filter((account) => account.eloRating != null)
+      .sort(
+        (left, right) =>
+          normalizeEloRating(right.eloRating ?? DEFAULT_ELO_RATING) - normalizeEloRating(left.eloRating ?? DEFAULT_ELO_RATING) ||
+          left.playerId.localeCompare(right.playerId)
+      );
+
+    let totalGemsGranted = 0;
+    for (const account of rankedAccounts) {
+      const rating = normalizeEloRating(account.eloRating ?? DEFAULT_ELO_RATING);
+      const tier = getTierForRating(rating);
+      const rewardAmount = rewardConfig[tier];
+      totalGemsGranted += rewardAmount;
+      if (rewardAmount > 0) {
+        await this.creditGems(account.playerId, rewardAmount, "reward", `season:${normalizedSeasonId}`);
+      }
+      await this.savePlayerAccountProgress(account.playerId, {
+        eloRating: computeSeasonResetEloRating(rating)
+      });
     }
 
     this.seasons.set(normalizedSeasonId, {
@@ -1092,6 +1123,12 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       status: "closed",
       endedAt: new Date().toISOString()
     });
+
+    return {
+      seasonId: normalizedSeasonId,
+      playersRewarded: rankedAccounts.length,
+      totalGemsGranted
+    };
   }
 
   async close(): Promise<void> {}

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -2,7 +2,9 @@ import { randomUUID } from "node:crypto";
 import { createPool, type Pool, type PoolConnection, type ResultSetHeader, type RowDataPacket } from "mysql2/promise";
 import {
   appendEventLogEntries,
+  DEFAULT_ELO_RATING,
   getEquipmentDefinition,
+  getTierForRating,
   appendPlayerBattleReplaySummaries,
   normalizeEloRating,
   normalizeEventLogQuery,
@@ -23,6 +25,7 @@ import {
   type WorldState
 } from "../../../packages/shared/src/index";
 import type { RoomPersistenceSnapshot } from "./index";
+import { computeSeasonResetEloRating, resolveSeasonRewardConfig } from "./season-rewards";
 
 export interface SeasonSnapshot {
   seasonId: string;
@@ -34,6 +37,12 @@ export interface SeasonSnapshot {
 export interface SeasonListOptions {
   status?: "active" | "closed" | "all";
   limit?: number;
+}
+
+export interface SeasonCloseSummary {
+  seasonId: string;
+  playersRewarded: number;
+  totalGemsGranted: number;
 }
 
 export interface RoomSnapshotStore {
@@ -98,7 +107,7 @@ export interface RoomSnapshotStore {
   getCurrentSeason(): Promise<SeasonSnapshot | null>;
   listSeasons?(options?: SeasonListOptions): Promise<SeasonSnapshot[]>;
   createSeason(seasonId: string): Promise<SeasonSnapshot>;
-  closeSeason(seasonId: string): Promise<void>;
+  closeSeason(seasonId: string): Promise<SeasonCloseSummary>;
   save(roomId: string, snapshot: RoomPersistenceSnapshot): Promise<void>;
   delete(roomId: string): Promise<void>;
   pruneExpired(referenceTime?: Date): Promise<number>;
@@ -4779,29 +4788,108 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     };
   }
 
-  async closeSeason(seasonId: string): Promise<void> {
+  async closeSeason(seasonId: string): Promise<SeasonCloseSummary> {
     const normalizedId = seasonId.trim();
-    // Archive top 100 player ratings
-    const [accounts] = await this.pool.query<RowDataPacket[]>(
-      `SELECT player_id, elo_rating FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ORDER BY elo_rating DESC LIMIT 100`
-    );
-    const now = new Date();
-    if (accounts.length > 0) {
-      const values = accounts.map((a, idx) => [normalizedId, String(a.player_id), Number(a.elo_rating), "bronze", idx + 1, now]);
-      await this.pool.query(
-        `INSERT IGNORE INTO \`veil_season_rankings\` (season_id, player_id, final_rating, tier, rank_position, archived_at) VALUES ?`,
-        [values]
-      );
+    if (!normalizedId) {
+      throw new Error("seasonId must not be empty");
     }
-    // Soft reset ELO ratings
-    await this.pool.query(
-      `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` SET elo_rating = 1000 + FLOOR((elo_rating - 1000) * 0.5)`
-    );
-    // Close the season
-    await this.pool.query(
-      `UPDATE \`veil_seasons\` SET status = 'closed', ended_at = ? WHERE season_id = ?`,
-      [now, normalizedId]
-    );
+
+    const rewardConfig = resolveSeasonRewardConfig();
+    const now = new Date();
+    const connection = await this.pool.getConnection();
+
+    try {
+      await connection.beginTransaction();
+
+      const [seasonRows] = await connection.query<RowDataPacket[]>(
+        `SELECT season_id, status
+         FROM \`veil_seasons\`
+         WHERE season_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [normalizedId]
+      );
+      const seasonRow = seasonRows[0] as { season_id: string; status: "active" | "closed" } | undefined;
+      if (!seasonRow || seasonRow.status === "closed") {
+        await connection.rollback();
+        return {
+          seasonId: normalizedId,
+          playersRewarded: 0,
+          totalGemsGranted: 0
+        };
+      }
+
+      const [accountRows] = await connection.query<RowDataPacket[]>(
+        `SELECT player_id, elo_rating, gems
+         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         WHERE elo_rating IS NOT NULL
+         ORDER BY elo_rating DESC, player_id ASC
+         FOR UPDATE`
+      );
+
+      let playersRewarded = 0;
+      let totalGemsGranted = 0;
+      const rankingValues: Array<[string, string, number, string, number, Date]> = [];
+
+      for (const [index, row] of accountRows.entries()) {
+        const playerId = String(row.player_id);
+        const rating = normalizeEloRating(Number(row.elo_rating));
+        const currentGems = normalizeGemAmount((row as { gems?: number | null }).gems);
+        const tier = getTierForRating(rating);
+        const rewardAmount = rewardConfig[tier];
+        const resetEloRating = computeSeasonResetEloRating(rating);
+
+        rankingValues.push([normalizedId, playerId, rating, tier, index + 1, now]);
+        playersRewarded += 1;
+        totalGemsGranted += rewardAmount;
+
+        await connection.query(
+          `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+           SET gems = ?,
+               elo_rating = ?,
+               version = version + 1
+           WHERE player_id = ?`,
+          [currentGems + rewardAmount, resetEloRating, playerId]
+        );
+
+        if (rewardAmount > 0) {
+          await appendGemLedgerEntry(connection, {
+            entryId: randomUUID(),
+            playerId,
+            delta: rewardAmount,
+            reason: "reward",
+            refId: `season:${normalizedId}`
+          });
+        }
+      }
+
+      if (rankingValues.length > 0) {
+        await connection.query(
+          `INSERT INTO \`veil_season_rankings\` (season_id, player_id, final_rating, tier, rank_position, archived_at) VALUES ?`,
+          [rankingValues]
+        );
+      }
+
+      await connection.query(
+        `UPDATE \`veil_seasons\`
+         SET status = 'closed',
+             ended_at = ?
+         WHERE season_id = ?`,
+        [now, normalizedId]
+      );
+
+      await connection.commit();
+      return {
+        seasonId: normalizedId,
+        playersRewarded,
+        totalGemsGranted
+      };
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
   }
 
   async close(): Promise<void> {

--- a/apps/server/src/season-rewards.ts
+++ b/apps/server/src/season-rewards.ts
@@ -1,0 +1,58 @@
+import shopConfigDocument from "../../../configs/shop-config.json";
+import { DEFAULT_ELO_RATING, getTierForRating, normalizeEloRating, type PlayerTier, type SeasonRewardConfig } from "../../../packages/shared/src/index";
+
+interface ShopConfigDocument {
+  seasonRewards?: Partial<SeasonRewardConfig> | null;
+}
+
+const PLAYER_TIERS: PlayerTier[] = ["bronze", "silver", "gold", "platinum", "diamond"];
+
+export interface ResolvedSeasonRewardConfig extends SeasonRewardConfig {}
+
+export interface SeasonRewardComputation {
+  tier: PlayerTier;
+  gems: number;
+  resetEloRating: number;
+}
+
+function normalizeNonNegativeInteger(value: number, field: string): number {
+  const normalized = Math.floor(value);
+  if (!Number.isFinite(value) || normalized < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+
+  return normalized;
+}
+
+export function normalizeSeasonRewardConfig(rawConfig?: Partial<SeasonRewardConfig> | null): ResolvedSeasonRewardConfig {
+  const config = rawConfig ?? {};
+
+  return {
+    bronze: normalizeNonNegativeInteger(config.bronze ?? 0, "seasonRewards.bronze"),
+    silver: normalizeNonNegativeInteger(config.silver ?? 0, "seasonRewards.silver"),
+    gold: normalizeNonNegativeInteger(config.gold ?? 0, "seasonRewards.gold"),
+    platinum: normalizeNonNegativeInteger(config.platinum ?? 0, "seasonRewards.platinum"),
+    diamond: normalizeNonNegativeInteger(config.diamond ?? 0, "seasonRewards.diamond")
+  };
+}
+
+export function resolveSeasonRewardConfig(): ResolvedSeasonRewardConfig {
+  return normalizeSeasonRewardConfig((shopConfigDocument as ShopConfigDocument).seasonRewards);
+}
+
+export function computeSeasonResetEloRating(rating: number): number {
+  const normalizedRating = normalizeEloRating(rating);
+  return DEFAULT_ELO_RATING + Math.floor((normalizedRating - DEFAULT_ELO_RATING) * 0.5);
+}
+
+export function computeSeasonReward(rating: number, rewardConfig = resolveSeasonRewardConfig()): SeasonRewardComputation {
+  const tier = getTierForRating(rating);
+
+  return {
+    tier,
+    gems: rewardConfig[tier],
+    resetEloRating: computeSeasonResetEloRating(rating)
+  };
+}
+
+export { PLAYER_TIERS };

--- a/apps/server/src/seasons.ts
+++ b/apps/server/src/seasons.ts
@@ -194,8 +194,8 @@ export function registerSeasonRoutes(
         sendJson(response, 404, { error: { code: "no_active_season", message: "No active season found" } });
         return;
       }
-      await store.closeSeason(currentSeason.seasonId);
-      sendJson(response, 200, { closed: true, seasonId: currentSeason.seasonId });
+      const summary = await store.closeSeason(currentSeason.seasonId);
+      sendJson(response, 200, { closed: true, ...summary });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/src/shop.ts
+++ b/apps/server/src/shop.ts
@@ -1,8 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import shopConfigDocument from "../../../configs/shop-config.json";
-import { getEquipmentDefinition, type ResourceLedger } from "../../../packages/shared/src/index";
+import { getEquipmentDefinition, type ResourceLedger, type SeasonRewardConfig } from "../../../packages/shared/src/index";
 import { validateAuthSessionFromRequest } from "./auth";
 import type { RoomSnapshotStore } from "./persistence";
+import { normalizeSeasonRewardConfig, type ResolvedSeasonRewardConfig } from "./season-rewards";
 
 export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle";
 
@@ -24,6 +25,7 @@ export interface ShopProduct {
 
 interface ShopConfigDocument {
   products?: Partial<ShopProduct>[] | null;
+  seasonRewards?: Partial<SeasonRewardConfig> | null;
 }
 
 export interface RegisterShopRoutesOptions {
@@ -161,6 +163,10 @@ function normalizeShopProducts(rawProducts?: Partial<ShopProduct>[] | null): Sho
 export function resolveShopProducts(options?: RegisterShopRoutesOptions): ShopProduct[] {
   const configuredProducts = options?.products ?? (shopConfigDocument as ShopConfigDocument).products;
   return normalizeShopProducts(configuredProducts);
+}
+
+export function resolveSeasonRewardsConfig(): ResolvedSeasonRewardConfig {
+  return normalizeSeasonRewardConfig((shopConfigDocument as ShopConfigDocument).seasonRewards);
 }
 
 function sendUnauthorized(

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -134,7 +134,9 @@ class MemoryAuthStore implements RoomSnapshotStore {
     };
   }
 
-  async closeSeason(): Promise<void> {}
+  async closeSeason() {
+    return { seasonId: "", playersRewarded: 0, totalGemsGranted: 0 };
+  }
 
   async touchPlayerAccountAuthSession(playerId: string, sessionId: string, lastUsedAt?: string): Promise<void> {
     const sessions = this.authSessionsByPlayerId.get(playerId.trim());

--- a/apps/server/test/memory-room-snapshot-store.test.ts
+++ b/apps/server/test/memory-room-snapshot-store.test.ts
@@ -188,3 +188,38 @@ test("memory room snapshot store lists closed seasons and retains active season 
   assert.equal(allSeasons?.find((season) => season.seasonId === "season-1")?.status, "closed");
   assert.ok(allSeasons?.find((season) => season.seasonId === "season-1")?.endedAt);
 });
+
+test("memory room snapshot store grants season rewards, soft-resets elo, and prevents double grant", async () => {
+  const store = createMemoryRoomSnapshotStore();
+  await store.ensurePlayerAccount({ playerId: "diamond-player", displayName: "Diamond" });
+  await store.ensurePlayerAccount({ playerId: "gold-player", displayName: "Gold" });
+  await store.ensurePlayerAccount({ playerId: "bronze-player", displayName: "Bronze" });
+  await store.savePlayerAccountProgress("diamond-player", { eloRating: 1820 });
+  await store.savePlayerAccountProgress("gold-player", { eloRating: 1380 });
+  await store.savePlayerAccountProgress("bronze-player", { eloRating: 1040 });
+  await store.createSeason("season-rewards");
+
+  const firstClose = await store.closeSeason("season-rewards");
+  const secondClose = await store.closeSeason("season-rewards");
+  const diamond = await store.loadPlayerAccount("diamond-player");
+  const gold = await store.loadPlayerAccount("gold-player");
+  const bronze = await store.loadPlayerAccount("bronze-player");
+
+  assert.deepEqual(firstClose, {
+    seasonId: "season-rewards",
+    playersRewarded: 3,
+    totalGemsGranted: 375
+  });
+  assert.equal(diamond?.gems, 250);
+  assert.equal(gold?.gems, 100);
+  assert.equal(bronze?.gems, 25);
+  assert.equal(diamond?.eloRating, 1410);
+  assert.equal(gold?.eloRating, 1190);
+  assert.equal(bronze?.eloRating, 1020);
+  assert.deepEqual(secondClose, {
+    seasonId: "season-rewards",
+    playersRewarded: 0,
+    totalGemsGranted: 0
+  });
+  assert.equal((await store.loadPlayerAccount("diamond-player"))?.gems, 250);
+});

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -294,6 +294,99 @@ test("listSeasons supports status=all without a status filter", async () => {
   assert.deepEqual(queries[0].params, [5]);
 });
 
+test("closeSeason grants tier rewards, soft-resets elo, and is idempotent", async () => {
+  const seasonState = { seasonId: "season-live", status: "active" as "active" | "closed" };
+  const accounts = new Map([
+    ["diamond-player", { eloRating: 1820, gems: 10 }],
+    ["gold-player", { eloRating: 1380, gems: 5 }],
+    ["bronze-player", { eloRating: 1040, gems: 0 }]
+  ]);
+  const rankingRows: Array<{ seasonId: string; playerId: string; finalRating: number; tier: string; rankPosition: number }> = [];
+  const gemLedgerEntries: Array<{ playerId: string; delta: number; refId: string }> = [];
+
+  const connection = {
+    async beginTransaction() {},
+    async query(sql: string, params: unknown[] = []) {
+      if (/FROM `veil_seasons`/.test(sql) && /FOR UPDATE/.test(sql)) {
+        return [[{ season_id: seasonState.seasonId, status: seasonState.status }]];
+      }
+      if (/FROM `player_accounts`/.test(sql) && /ORDER BY elo_rating DESC/.test(sql)) {
+        const rows = [...accounts.entries()]
+          .sort((left, right) => right[1].eloRating - left[1].eloRating || left[0].localeCompare(right[0]))
+          .map(([playerId, account]) => ({
+            player_id: playerId,
+            elo_rating: account.eloRating,
+            gems: account.gems
+          }));
+        return [rows];
+      }
+      if (/INSERT INTO `veil_season_rankings`/.test(sql)) {
+        const values = params[0] as Array<[string, string, number, string, number]>;
+        for (const [seasonId, playerId, finalRating, tier, rankPosition] of values) {
+          rankingRows.push({ seasonId, playerId, finalRating, tier, rankPosition });
+        }
+        return [{ affectedRows: values.length }];
+      }
+      if (/UPDATE `player_accounts`/.test(sql) && /SET gems = \?,\s+elo_rating = \?/.test(sql)) {
+        const [gems, eloRating, playerId] = params as [number, number, string];
+        accounts.set(playerId, { gems, eloRating });
+        return [{ affectedRows: 1 }];
+      }
+      if (/INSERT INTO `gem_ledger`/.test(sql)) {
+        const [, playerId, delta, , refId] = params as [string, string, number, string, string];
+        gemLedgerEntries.push({ playerId, delta, refId });
+        return [{ affectedRows: 1 }];
+      }
+      if (/UPDATE `veil_seasons`/.test(sql) && /status = 'closed'/.test(sql)) {
+        seasonState.status = "closed";
+        return [{ affectedRows: 1 }];
+      }
+
+      throw new Error(`Unexpected SQL in closeSeason test: ${sql}`);
+    },
+    async commit() {},
+    async rollback() {},
+    release() {}
+  };
+
+  const store = new MySqlRoomSnapshotStore({
+    getConnection: async () => connection,
+    query: async () => {
+      throw new Error("pool.query should not be used by closeSeason");
+    }
+  } as never);
+
+  const firstClose = await store.closeSeason("season-live");
+  const secondClose = await store.closeSeason("season-live");
+
+  assert.deepEqual(firstClose, {
+    seasonId: "season-live",
+    playersRewarded: 3,
+    totalGemsGranted: 375
+  });
+  assert.deepEqual(secondClose, {
+    seasonId: "season-live",
+    playersRewarded: 0,
+    totalGemsGranted: 0
+  });
+  assert.deepEqual(accounts.get("diamond-player"), { eloRating: 1410, gems: 260 });
+  assert.deepEqual(accounts.get("gold-player"), { eloRating: 1190, gems: 105 });
+  assert.deepEqual(accounts.get("bronze-player"), { eloRating: 1020, gems: 25 });
+  assert.deepEqual(
+    rankingRows.map((row) => ({ playerId: row.playerId, tier: row.tier, rankPosition: row.rankPosition, finalRating: row.finalRating })),
+    [
+      { playerId: "diamond-player", tier: "diamond", rankPosition: 1, finalRating: 1820 },
+      { playerId: "gold-player", tier: "gold", rankPosition: 2, finalRating: 1380 },
+      { playerId: "bronze-player", tier: "bronze", rankPosition: 3, finalRating: 1040 }
+    ]
+  );
+  assert.deepEqual(gemLedgerEntries, [
+    { playerId: "diamond-player", delta: 250, refId: "season:season-live" },
+    { playerId: "gold-player", delta: 100, refId: "season:season-live" },
+    { playerId: "bronze-player", delta: 25, refId: "season:season-live" }
+  ]);
+});
+
 test("mysql player event history query applies inclusive timestamp filters", async () => {
   const queries: Array<{ sql: string; params: unknown[] | undefined }> = [];
   const store = new MySqlRoomSnapshotStore({

--- a/apps/server/test/player-account-battle-replay-detail-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-detail-routes.test.ts
@@ -127,7 +127,9 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     };
   }
 
-  async closeSeason(): Promise<void> {}
+  async closeSeason() {
+    return { seasonId: "", playersRewarded: 0, totalGemsGranted: 0 };
+  }
 
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
     const existing = this.accounts.get(input.playerId);

--- a/apps/server/test/player-account-battle-replay-playback-routes.test.ts
+++ b/apps/server/test/player-account-battle-replay-playback-routes.test.ts
@@ -118,7 +118,9 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     };
   }
 
-  async closeSeason(): Promise<void> {}
+  async closeSeason() {
+    return { seasonId: "", playersRewarded: 0, totalGemsGranted: 0 };
+  }
 
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
     const existing = this.accounts.get(input.playerId);

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -155,7 +155,9 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     };
   }
 
-  async closeSeason(): Promise<void> {}
+  async closeSeason() {
+    return { seasonId: "", playersRewarded: 0, totalGemsGranted: 0 };
+  }
 
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
     const existing = this.accounts.get(input.playerId);

--- a/apps/server/test/season-routes.test.ts
+++ b/apps/server/test/season-routes.test.ts
@@ -8,6 +8,7 @@ type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void
 
 function createTestApp() {
   const gets = new Map<string, RouteHandler>();
+  const posts = new Map<string, RouteHandler>();
 
   return {
     app: {
@@ -15,9 +16,12 @@ function createTestApp() {
       get(path: string, handler: RouteHandler) {
         gets.set(path, handler);
       },
-      post(_path: string, _handler: RouteHandler) {}
+      post(path: string, handler: RouteHandler) {
+        posts.set(path, handler);
+      }
     },
-    gets
+    gets,
+    posts
   };
 }
 
@@ -76,7 +80,13 @@ function createSeasonStore(seasons: SeasonSnapshot[], calls: SeasonListOptions[]
         startedAt: new Date().toISOString()
       };
     },
-    async closeSeason() {},
+    async closeSeason(seasonId: string) {
+      return {
+        seasonId,
+        playersRewarded: 2,
+        totalGemsGranted: 75
+      };
+    },
     async load() {
       return null;
     },
@@ -173,9 +183,9 @@ function withAdminToken(t: TestContext, token = "season-admin-token"): string {
 }
 
 function registerRoutes(store: RoomSnapshotStore | null) {
-  const { app, gets } = createTestApp();
+  const { app, gets, posts } = createTestApp();
   registerSeasonRoutes(app, store);
-  return { gets };
+  return { gets, posts };
 }
 
 test("GET /api/seasons returns closed seasons and caps limit at 100", async () => {
@@ -250,5 +260,33 @@ test("GET /api/admin/seasons supports status=all and caps limit at 100", async (
       { seasonId: "season-4", status: "active", startedAt: "2026-04-01T00:00:00.000Z" },
       { seasonId: "season-3", status: "closed", startedAt: "2026-03-01T00:00:00.000Z", endedAt: "2026-03-15T00:00:00.000Z" }
     ]
+  });
+});
+
+test("POST /api/admin/seasons/close returns the reward distribution summary", async (t) => {
+  const token = withAdminToken(t);
+  const store = createSeasonStore([
+    { seasonId: "season-9", status: "active", startedAt: "2026-04-01T00:00:00.000Z" }
+  ], []);
+  const { posts } = registerRoutes(store);
+  const handler = posts.get("/api/admin/seasons/close");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      url: "/api/admin/seasons/close",
+      headers: { "x-veil-admin-token": token }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(JSON.parse(response.body), {
+    closed: true,
+    seasonId: "season-9",
+    playersRewarded: 2,
+    totalGemsGranted: 75
   });
 });

--- a/configs/shop-config.json
+++ b/configs/shop-config.json
@@ -1,4 +1,11 @@
 {
+  "seasonRewards": {
+    "bronze": 25,
+    "silver": 50,
+    "gold": 100,
+    "platinum": 150,
+    "diamond": 250
+  },
   "products": [
     {
       "productId": "resource-bundle-starter",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -123,6 +123,14 @@ export interface BattleBalanceConfig {
   };
 }
 
+export interface SeasonRewardConfig {
+  bronze: number;
+  silver: number;
+  gold: number;
+  platinum: number;
+  diamond: number;
+}
+
 export interface MovePoints {
   total: number;
   remaining: number;


### PR DESCRIPTION
## Summary
- distribute season-end gem rewards for every ranked player when an admin closes the active season
- soft-reset ELO after reward distribution and return the close summary from the admin endpoint
- cover the memory store, MySQL store, and season close route with targeted tests

## Validation
- node --import tsx --test apps/server/test/season-routes.test.ts apps/server/test/memory-room-snapshot-store.test.ts apps/server/test/persistence-account-credentials.test.ts
- npm run typecheck:server

Closes #823