### PR TITLE
feat: wire Cocos matchmaking queue polling

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -1,5 +1,11 @@
 import { sys } from "cc";
 import type { EquipmentType } from "./project-shared/index.ts";
+import {
+  cancelCocosMatchmaking,
+  enqueueCocosMatchmaking,
+  readCocosMatchmakingStatus,
+  type CocosMatchmakingStatus
+} from "./cocos-matchmaking.ts";
 
 export interface Vec2 {
   x: number;
@@ -452,6 +458,7 @@ export interface SessionUpdate {
 }
 
 export type ConnectionEvent = "reconnecting" | "reconnected" | "reconnect_failed";
+export type MatchmakingStatusResponse = CocosMatchmakingStatus;
 
 export interface VeilCocosSessionOptions {
   remoteUrl?: string;
@@ -1582,7 +1589,10 @@ class RecoverableRemoteGameSession {
 export class VeilCocosSession {
   private constructor(
     private readonly remoteSession: RecoverableRemoteGameSession,
-    private readonly remoteUrl?: string
+    private readonly playerId: string,
+    private readonly remoteUrl?: string,
+    private readonly getDisplayName?: (() => string | null) | undefined,
+    private readonly getAuthToken?: (() => string | null) | undefined
   ) {}
 
   static readStoredReplay(roomId: string, playerId: string): SessionUpdate | null {
@@ -1596,11 +1606,72 @@ export class VeilCocosSession {
     options?: VeilCocosSessionOptions
   ): Promise<VeilCocosSession> {
     const remoteSession = await RecoverableRemoteGameSession.create(roomId, playerId, seed, options);
-    return new VeilCocosSession(remoteSession, options?.remoteUrl);
+    return new VeilCocosSession(remoteSession, playerId, options?.remoteUrl, options?.getDisplayName, options?.getAuthToken);
   }
 
   static async fetchLeaderboard(remoteUrl?: string, limit = 50): Promise<LeaderboardEntry[]> {
     return fetchLeaderboardEntries(remoteUrl, limit);
+  }
+
+  static async enqueueForMatchmaking(
+    remoteUrl: string,
+    playerId: string,
+    rating: number,
+    options?: {
+      getDisplayName?: (() => string | null) | undefined;
+      getAuthToken?: (() => string | null) | undefined;
+    }
+  ): Promise<MatchmakingStatusResponse> {
+    const token = options?.getAuthToken?.() ?? null;
+    return enqueueCocosMatchmaking(remoteUrl, {
+      authSession: {
+        playerId,
+        displayName: options?.getDisplayName?.() ?? playerId,
+        authMode: "guest",
+        ...(token ? { token } : {}),
+        source: "remote"
+      }
+    });
+  }
+
+  static async getMatchmakingStatus(
+    remoteUrl: string,
+    playerId: string,
+    options?: {
+      getDisplayName?: (() => string | null) | undefined;
+      getAuthToken?: (() => string | null) | undefined;
+    }
+  ): Promise<MatchmakingStatusResponse> {
+    const token = options?.getAuthToken?.() ?? null;
+    return readCocosMatchmakingStatus(remoteUrl, {
+      authSession: {
+        playerId,
+        displayName: options?.getDisplayName?.() ?? playerId,
+        authMode: "guest",
+        ...(token ? { token } : {}),
+        source: "remote"
+      }
+    });
+  }
+
+  static async cancelMatchmaking(
+    remoteUrl: string,
+    playerId: string,
+    options?: {
+      getDisplayName?: (() => string | null) | undefined;
+      getAuthToken?: (() => string | null) | undefined;
+    }
+  ): Promise<"dequeued" | "idle"> {
+    const token = options?.getAuthToken?.() ?? null;
+    return cancelCocosMatchmaking(remoteUrl, {
+      authSession: {
+        playerId,
+        displayName: options?.getDisplayName?.() ?? playerId,
+        authMode: "guest",
+        ...(token ? { token } : {}),
+        source: "remote"
+      }
+    });
   }
 
   async snapshot(reason?: string): Promise<SessionUpdate> {
@@ -1657,6 +1728,27 @@ export class VeilCocosSession {
 
   async fetchLeaderboard(limit = 50): Promise<LeaderboardEntry[]> {
     return fetchLeaderboardEntries(this.remoteUrl, limit);
+  }
+
+  async enqueueForMatchmaking(rating: number): Promise<MatchmakingStatusResponse> {
+    return VeilCocosSession.enqueueForMatchmaking(this.remoteUrl ?? "", this.playerId, rating, {
+      getDisplayName: this.getDisplayName,
+      getAuthToken: this.getAuthToken
+    });
+  }
+
+  async getMatchmakingStatus(): Promise<MatchmakingStatusResponse> {
+    return VeilCocosSession.getMatchmakingStatus(this.remoteUrl ?? "", this.playerId, {
+      getDisplayName: this.getDisplayName,
+      getAuthToken: this.getAuthToken
+    });
+  }
+
+  async cancelMatchmaking(): Promise<"dequeued" | "idle"> {
+    return VeilCocosSession.cancelMatchmaking(this.remoteUrl ?? "", this.playerId, {
+      getDisplayName: this.getDisplayName,
+      getAuthToken: this.getAuthToken
+    });
   }
 
   async dispose(): Promise<void> {

--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -48,6 +48,7 @@ import {
   type BattleReplayPlaybackState,
   type PlayerBattleReplaySummary
 } from "./project-shared/battle-replay.ts";
+import type { MatchmakingStatusView } from "./cocos-matchmaking-status.ts";
 
 const { ccclass } = _decorator;
 const H_ALIGN_LEFT = 0;
@@ -121,6 +122,9 @@ export interface VeilLobbyRenderState {
   loading: boolean;
   entering: boolean;
   status: string;
+  matchmaking?: MatchmakingStatusView;
+  matchmakingSearching?: boolean;
+  matchmakingBusy?: boolean;
   rooms: CocosLobbyRoomSummary[];
   accountFlow: CocosAccountLifecyclePanelView | null;
   presentationReadiness: CocosPresentationReadiness;
@@ -134,6 +138,8 @@ export interface VeilLobbyPanelOptions {
   onTogglePrivacyConsent?: () => void;
   onRefresh?: () => void;
   onEnterRoom?: () => void;
+  onEnterMatchmaking?: () => void;
+  onCancelMatchmaking?: () => void;
   onLoginAccount?: () => void;
   onRegisterAccount?: () => void;
   onRecoverAccount?: () => void;
@@ -171,6 +177,8 @@ export class VeilLobbyPanel extends Component {
   private onTogglePrivacyConsent: (() => void) | undefined;
   private onRefresh: (() => void) | undefined;
   private onEnterRoom: (() => void) | undefined;
+  private onEnterMatchmaking: (() => void) | undefined;
+  private onCancelMatchmaking: (() => void) | undefined;
   private onLoginAccount: (() => void) | undefined;
   private onRegisterAccount: (() => void) | undefined;
   private onRecoverAccount: (() => void) | undefined;
@@ -204,6 +212,8 @@ export class VeilLobbyPanel extends Component {
     this.onTogglePrivacyConsent = options.onTogglePrivacyConsent;
     this.onRefresh = options.onRefresh;
     this.onEnterRoom = options.onEnterRoom;
+    this.onEnterMatchmaking = options.onEnterMatchmaking;
+    this.onCancelMatchmaking = options.onCancelMatchmaking;
     this.onLoginAccount = options.onLoginAccount;
     this.onRegisterAccount = options.onRegisterAccount;
     this.onRecoverAccount = options.onRecoverAccount;
@@ -225,6 +235,16 @@ export class VeilLobbyPanel extends Component {
     this.currentState = state;
     this.syncReplayPlaybackState(state);
     this.ensureShowcaseTicker();
+    const matchmaking = state.matchmaking ?? {
+      statusLabel: "未在匹配",
+      queuePositionLabel: "位置 -",
+      waitEstimateLabel: "预计 --",
+      matchedLabel: "",
+      canCancel: false,
+      isMatched: false
+    };
+    const matchmakingSearching = state.matchmakingSearching ?? false;
+    const matchmakingBusy = state.matchmakingBusy ?? false;
     const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
     const width = transform.width || 760;
     const height = transform.height || 620;
@@ -376,6 +396,29 @@ export class VeilLobbyPanel extends Component {
       16
     );
 
+    leftCursorY = this.renderCard(
+      "LobbyMatchmakingStatus",
+      leftX,
+      leftCursorY,
+      leftWidth,
+      96,
+      [
+        "PVP 匹配",
+        matchmaking.statusLabel,
+        matchmaking.queuePositionLabel,
+        matchmaking.waitEstimateLabel,
+        matchmaking.matchedLabel || "等待进入队列"
+      ],
+      {
+        fill: new Color(46, 56, 88, 186),
+        stroke: new Color(214, 226, 244, 70),
+        accent: new Color(122, 172, 228, 202)
+      },
+      null,
+      13,
+      16
+    );
+
     this.renderActionButton(
       "LobbyRefresh",
       leftX,
@@ -402,12 +445,40 @@ export class VeilLobbyPanel extends Component {
         stroke: new Color(228, 244, 229, 124),
         accent: new Color(226, 244, 230, 116)
       },
-      state.entering ? null : this.onEnterRoom ?? null
+      state.entering || matchmakingSearching ? null : this.onEnterRoom ?? null
+    );
+    this.renderActionButton(
+      "LobbyMatchmakingEnter",
+      leftX,
+      leftCursorY - 86,
+      leftWidth,
+      28,
+      matchmakingBusy ? "匹配处理中..." : matchmakingSearching ? "匹配中..." : "PVP 匹配",
+      {
+        fill: ACTION_ACCOUNT_REVIEW_ACTIVE,
+        stroke: new Color(228, 244, 229, 124),
+        accent: new Color(226, 244, 230, 116)
+      },
+      state.entering || matchmakingSearching ? null : this.onEnterMatchmaking ?? null
+    );
+    this.renderActionButton(
+      "LobbyMatchmakingCancel",
+      leftX,
+      leftCursorY - 120,
+      leftWidth,
+      28,
+      matchmakingBusy ? "处理中..." : "取消匹配",
+      {
+        fill: ACTION_LOGOUT,
+        stroke: new Color(247, 232, 226, 118),
+        accent: new Color(250, 234, 228, 110)
+      },
+      matchmaking.canCancel && !matchmakingBusy ? this.onCancelMatchmaking ?? null : null
     );
     this.renderActionButton(
       "LobbyAccountEnter",
       leftX,
-      leftCursorY - 86,
+      leftCursorY - 154,
       leftWidth,
       28,
       state.entering ? "登录中..." : state.loginActionLabel || (state.authMode === "account" ? "账号进入" : "账号登录并进入"),
@@ -416,12 +487,12 @@ export class VeilLobbyPanel extends Component {
         stroke: new Color(228, 236, 248, 120),
         accent: new Color(220, 230, 244, 112)
       },
-      state.entering ? null : this.onLoginAccount ?? null
+      state.entering || matchmakingSearching ? null : this.onLoginAccount ?? null
     );
     this.renderActionButton(
       "LobbyRegisterAccount",
       leftX,
-      leftCursorY - 120,
+      leftCursorY - 188,
       leftWidth,
       28,
       "正式注册",
@@ -430,12 +501,12 @@ export class VeilLobbyPanel extends Component {
         stroke: new Color(228, 236, 248, 120),
         accent: new Color(220, 230, 244, 112)
       },
-      state.entering ? null : this.onRegisterAccount ?? null
+      state.entering || matchmakingSearching ? null : this.onRegisterAccount ?? null
     );
     this.renderActionButton(
       "LobbyRecoverAccount",
       leftX,
-      leftCursorY - 154,
+      leftCursorY - 222,
       leftWidth,
       28,
       "密码找回",
@@ -444,12 +515,12 @@ export class VeilLobbyPanel extends Component {
         stroke: new Color(228, 236, 248, 120),
         accent: new Color(220, 230, 244, 112)
       },
-      state.entering ? null : this.onRecoverAccount ?? null
+      state.entering || matchmakingSearching ? null : this.onRecoverAccount ?? null
     );
     this.renderActionButton(
       "LobbyConfigCenter",
       leftX,
-      leftCursorY - 188,
+      leftCursorY - 256,
       leftWidth,
       28,
       "打开配置台",
@@ -458,12 +529,12 @@ export class VeilLobbyPanel extends Component {
         stroke: new Color(234, 240, 228, 116),
         accent: new Color(226, 236, 220, 108)
       },
-      state.entering ? null : this.onOpenConfigCenter ?? null
+      state.entering || matchmakingSearching ? null : this.onOpenConfigCenter ?? null
     );
     this.renderActionButton(
       "LobbyLogout",
       leftX,
-      leftCursorY - 222,
+      leftCursorY - 290,
       leftWidth,
       28,
       state.authMode === "account" ? "退出账号会话" : "退出游客会话",
@@ -472,12 +543,12 @@ export class VeilLobbyPanel extends Component {
         stroke: new Color(247, 232, 226, 118),
         accent: new Color(250, 234, 228, 110)
       },
-      state.entering || state.sessionSource === "none" ? null : this.onLogout ?? null
+      state.entering || state.sessionSource === "none" || matchmakingSearching ? null : this.onLogout ?? null
     );
     this.renderActionButton(
       "LobbyAccountReview",
       leftX,
-      leftCursorY - 256,
+      leftCursorY - 324,
       leftWidth,
       28,
       this.showAccountReview ? "收起资料回顾" : "资料回顾 · 战报 / 事件 / 成就",

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -3,6 +3,7 @@ import { getEquipmentDefinition, type EquipmentType } from "./project-shared/ind
 import {
   type BattleAction,
   type LeaderboardEntry,
+  type MatchmakingStatusResponse,
   type PlayerReportReason,
   VeilCocosSession,
   type VeilCocosSessionOptions,
@@ -64,6 +65,14 @@ import {
 import { buildHeroProgressNotice, type HeroProgressNotice } from "./cocos-hero-progression.ts";
 import { VeilHudPanel, type VeilHudRenderState } from "./VeilHudPanel.ts";
 import { VeilLobbyPanel } from "./VeilLobbyPanel.ts";
+import {
+  startCocosMatchmakingStatusPolling,
+  type CocosMatchmakingPollController
+} from "./cocos-matchmaking.ts";
+import {
+  buildMatchmakingStatusView,
+  type MatchmakingStatusView
+} from "./cocos-matchmaking-status.ts";
 import {
   buildCocosAccountLifecyclePanelView,
   type CocosAccountLifecycleDeliveryMode,
@@ -157,6 +166,10 @@ interface BattleSettlementSnapshot {
 interface VeilRootRuntime {
   createSession: typeof VeilCocosSession.create;
   loadLeaderboard: typeof VeilCocosSession.fetchLeaderboard;
+  enqueueMatchmaking: typeof VeilCocosSession.enqueueForMatchmaking;
+  getMatchmakingStatus: typeof VeilCocosSession.getMatchmakingStatus;
+  cancelMatchmaking: typeof VeilCocosSession.cancelMatchmaking;
+  startMatchmakingPolling: typeof startCocosMatchmakingStatusPolling;
   readStoredReplay: typeof VeilCocosSession.readStoredReplay;
   loadLobbyRooms: typeof loadCocosLobbyRooms;
   syncAuthSession: typeof syncCurrentCocosAuthSession;
@@ -171,6 +184,10 @@ interface VeilRootRuntime {
 const defaultVeilRootRuntime: VeilRootRuntime = {
   createSession: (...args) => VeilCocosSession.create(...args),
   loadLeaderboard: (...args) => VeilCocosSession.fetchLeaderboard(...args),
+  enqueueMatchmaking: (...args) => VeilCocosSession.enqueueForMatchmaking(...args),
+  getMatchmakingStatus: (...args) => VeilCocosSession.getMatchmakingStatus(...args),
+  cancelMatchmaking: (...args) => VeilCocosSession.cancelMatchmaking(...args),
+  startMatchmakingPolling: (...args) => startCocosMatchmakingStatusPolling(...args),
   readStoredReplay: (...args) => VeilCocosSession.readStoredReplay(...args),
   loadLobbyRooms: (...args) => loadCocosLobbyRooms(...args),
   syncAuthSession: (...args) => syncCurrentCocosAuthSession(...args),
@@ -268,6 +285,12 @@ export class VeilRoot extends Component {
   private lobbyStatus = "请选择一个房间，或手动输入新的房间 ID。";
   private lobbyLoading = false;
   private lobbyEntering = false;
+  private matchmakingStatus: MatchmakingStatusResponse = { status: "idle" };
+  private matchmakingPollController: CocosMatchmakingPollController | null = null;
+  private matchmakingTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  private matchmakingTimeoutMs = 120_000;
+  private matchmakingView: MatchmakingStatusView = buildMatchmakingStatusView({ status: "idle" });
+  private matchmakingJoinInFlight = false;
   private lobbyLeaderboardEntries: LeaderboardEntry[] = [];
   private lobbyLeaderboardStatus: "idle" | "loading" | "ready" | "error" = "idle";
   private lobbyLeaderboardError: string | null = null;
@@ -346,6 +369,7 @@ export class VeilRoot extends Component {
 
   onDestroy(): void {
     this.unscheduleAllCallbacks();
+    this.stopMatchmakingPolling();
     this.audioRuntime.dispose();
     this.stopRuntimeMemoryWarnings?.();
     this.stopRuntimeMemoryWarnings = null;
@@ -790,6 +814,12 @@ export class VeilRoot extends Component {
       onEnterRoom: () => {
         void this.enterLobbyRoom();
       },
+      onEnterMatchmaking: () => {
+        void this.enterLobbyMatchmaking();
+      },
+      onCancelMatchmaking: () => {
+        void this.cancelLobbyMatchmaking();
+      },
       onLoginAccount: () => {
         void this.loginLobbyAccount();
       },
@@ -1074,6 +1104,9 @@ export class VeilRoot extends Component {
         loading: this.lobbyLoading,
         entering: this.lobbyEntering,
         status: this.lobbyStatus,
+        matchmaking: this.matchmakingView,
+        matchmakingSearching: this.isMatchmakingActive(),
+        matchmakingBusy: this.lobbyEntering || this.matchmakingJoinInFlight,
         rooms: this.lobbyRooms,
         accountFlow: this.buildActiveAccountFlowPanelView(),
         presentationReadiness: cocosPresentationReadiness
@@ -2213,6 +2246,12 @@ export class VeilRoot extends Component {
       return;
     }
 
+    if (this.isMatchmakingActive()) {
+      this.lobbyStatus = "正在匹配中，请先取消当前队列。";
+      this.renderView();
+      return;
+    }
+
     if (!this.ensurePrivacyConsentAccepted()) {
       return;
     }
@@ -2303,6 +2342,225 @@ export class VeilRoot extends Component {
     } finally {
       this.lobbyEntering = false;
     }
+  }
+
+  private isMatchmakingActive(): boolean {
+    return this.matchmakingStatus.status === "queued" || this.matchmakingJoinInFlight;
+  }
+
+  private updateMatchmakingStatus(status: MatchmakingStatusResponse, lobbyStatus?: string): void {
+    this.matchmakingStatus = status;
+    this.matchmakingView = buildMatchmakingStatusView(status);
+    if (lobbyStatus) {
+      this.lobbyStatus = lobbyStatus;
+    }
+  }
+
+  private stopMatchmakingPolling(): void {
+    this.matchmakingPollController?.stop();
+    this.matchmakingPollController = null;
+    if (this.matchmakingTimeoutHandle) {
+      clearTimeout(this.matchmakingTimeoutHandle);
+      this.matchmakingTimeoutHandle = null;
+    }
+  }
+
+  private startMatchmakingPolling(): void {
+    this.stopMatchmakingPolling();
+    this.matchmakingPollController = resolveVeilRootRuntime().startMatchmakingPolling(
+      this.remoteUrl,
+      (status) => {
+        void this.handleMatchmakingStatusUpdate(status);
+      },
+      {
+        pollIntervalMs: 3000,
+        stopOnMatched: true,
+        authSession: this.authToken
+          ? {
+              token: this.authToken,
+              playerId: this.playerId,
+              displayName: this.displayName || this.playerId,
+              authMode: this.authMode,
+              ...(this.loginId ? { loginId: this.loginId } : {}),
+              source: "remote"
+            }
+          : null
+      }
+    );
+    this.matchmakingTimeoutHandle = setTimeout(() => {
+      void this.handleMatchmakingTimeout();
+    }, this.matchmakingTimeoutMs);
+  }
+
+  private async ensureMatchmakingAuthSession(): Promise<void> {
+    const storage = this.readWebStorage();
+    if (this.authMode === "account" && this.authToken) {
+      const syncedSession = await resolveVeilRootRuntime().syncAuthSession(this.remoteUrl, {
+        storage,
+        session: readStoredCocosAuthSession(storage)
+      });
+      if (!syncedSession) {
+        throw new Error("cocos_request_failed:401");
+      }
+      this.authToken = syncedSession.token ?? null;
+      this.playerId = syncedSession.playerId;
+      this.displayName = syncedSession.displayName;
+      this.authMode = syncedSession.authMode;
+      this.authProvider = syncedSession.provider ?? "account-password";
+      this.loginId = syncedSession.loginId ?? "";
+      this.sessionSource = syncedSession.source;
+      return;
+    }
+
+    const authSession = await resolveVeilRootRuntime().loginGuestAuthSession(
+      this.remoteUrl,
+      this.playerId,
+      this.displayName || this.playerId,
+      {
+        storage,
+        privacyConsentAccepted: this.privacyConsentAccepted
+      }
+    );
+    this.authToken = authSession.token ?? null;
+    this.playerId = authSession.playerId;
+    this.displayName = authSession.displayName;
+    this.authMode = authSession.authMode;
+    this.authProvider = authSession.provider ?? "guest";
+    this.loginId = authSession.loginId ?? "";
+    this.sessionSource = authSession.source;
+  }
+
+  private async enterLobbyMatchmaking(): Promise<void> {
+    if (this.lobbyEntering || this.isMatchmakingActive()) {
+      return;
+    }
+
+    if (!this.ensurePrivacyConsentAccepted()) {
+      return;
+    }
+
+    this.lobbyEntering = true;
+    this.updateMatchmakingStatus({ status: "idle" }, "正在进入 PVP 匹配队列...");
+    this.renderView();
+
+    try {
+      await this.ensureMatchmakingAuthSession();
+      const rating = this.lobbyAccountProfile.eloRating ?? 1000;
+      const status = await resolveVeilRootRuntime().enqueueMatchmaking(this.remoteUrl, this.playerId, rating, {
+        getDisplayName: () => this.displayName || this.playerId,
+        getAuthToken: () => this.authToken
+      });
+      this.updateMatchmakingStatus(status, this.describeMatchmakingStatus(status));
+      this.startMatchmakingPolling();
+    } catch (error) {
+      this.updateMatchmakingStatus({ status: "idle" });
+      this.lobbyStatus = this.describeMatchmakingError(error);
+    } finally {
+      this.lobbyEntering = false;
+      this.renderView();
+    }
+  }
+
+  private async cancelLobbyMatchmaking(): Promise<void> {
+    if (!this.isMatchmakingActive() || this.lobbyEntering) {
+      return;
+    }
+
+    this.lobbyEntering = true;
+    this.lobbyStatus = "正在取消 PVP 匹配...";
+    this.renderView();
+
+    try {
+      await resolveVeilRootRuntime().cancelMatchmaking(this.remoteUrl, this.playerId, {
+        getDisplayName: () => this.displayName || this.playerId,
+        getAuthToken: () => this.authToken
+      });
+      this.stopMatchmakingPolling();
+      this.updateMatchmakingStatus({ status: "idle" }, "已取消当前匹配队列。");
+    } catch (error) {
+      this.lobbyStatus = this.describeMatchmakingError(error);
+    } finally {
+      this.lobbyEntering = false;
+      this.renderView();
+    }
+  }
+
+  private async handleMatchmakingStatusUpdate(status: MatchmakingStatusResponse): Promise<void> {
+    if (status.status === "idle") {
+      this.stopMatchmakingPolling();
+    }
+    this.updateMatchmakingStatus(status, this.describeMatchmakingStatus(status));
+    this.renderView();
+
+    if (status.status === "matched" && !this.matchmakingJoinInFlight) {
+      await this.enterMatchedRoom(status);
+    }
+  }
+
+  private async handleMatchmakingTimeout(): Promise<void> {
+    if (!this.isMatchmakingActive()) {
+      return;
+    }
+
+    this.stopMatchmakingPolling();
+    try {
+      await resolveVeilRootRuntime().cancelMatchmaking(this.remoteUrl, this.playerId, {
+        getDisplayName: () => this.displayName || this.playerId,
+        getAuthToken: () => this.authToken
+      });
+    } catch {
+      // Keep the timeout surfaced locally even if remote dequeue fails.
+    }
+    this.updateMatchmakingStatus({ status: "idle" }, "匹配超时，请稍后重试。");
+    this.renderView();
+  }
+
+  private async enterMatchedRoom(status: Extract<MatchmakingStatusResponse, { status: "matched" }>): Promise<void> {
+    this.matchmakingJoinInFlight = true;
+    this.stopMatchmakingPolling();
+    this.lobbyStatus = `匹配成功，正在进入房间 ${status.roomId}...`;
+    this.renderView();
+
+    try {
+      this.roomId = status.roomId;
+      this.seed = status.seedOverride;
+      this.resetSessionViewport(`正在进入匹配房间 ${status.roomId} ...`);
+      this.showLobby = false;
+      this.syncBrowserRoomQuery(status.roomId);
+      this.syncWechatShareBridge();
+      await this.connect();
+      if (!this.session && !this.lastUpdate) {
+        throw new Error("enter_room_failed");
+      }
+      this.updateMatchmakingStatus({ status: "idle" }, `已进入匹配房间 ${status.roomId}。`);
+    } catch (error) {
+      this.showLobby = true;
+      this.updateMatchmakingStatus({ status: "idle" }, this.describeMatchmakingError(error));
+    } finally {
+      this.matchmakingJoinInFlight = false;
+      this.renderView();
+    }
+  }
+
+  private describeMatchmakingStatus(status: MatchmakingStatusResponse): string {
+    const view = buildMatchmakingStatusView(status);
+    if (status.status === "queued") {
+      return `${view.statusLabel} ${view.queuePositionLabel}，${view.waitEstimateLabel}`;
+    }
+    if (status.status === "matched") {
+      return view.matchedLabel ? `${view.statusLabel} · ${view.matchedLabel}` : view.statusLabel;
+    }
+    return view.statusLabel;
+  }
+
+  private describeMatchmakingError(error: unknown): string {
+    if (error instanceof Error && error.message === "cocos_request_failed:401") {
+      return "匹配会话已失效，请重新登录后再试。";
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return "matchmaking_failed";
   }
 
   private async loginLobbyAccount(): Promise<void> {
@@ -2534,6 +2792,8 @@ export class VeilRoot extends Component {
     const storage = this.readWebStorage();
     saveCocosLobbyPreferences(this.playerId, this.roomId, undefined, storage);
     this.displayName = rememberPreferredCocosDisplayName(this.playerId, this.displayName || this.playerId, storage);
+    this.stopMatchmakingPolling();
+    this.updateMatchmakingStatus({ status: "idle" });
     await this.disposeCurrentSession();
     this.resetSessionViewport("已返回 Cocos Lobby。");
     this.gameplayAccountReviewPanelOpen = false;
@@ -2547,6 +2807,8 @@ export class VeilRoot extends Component {
   }
 
   private async logoutAuthSession(): Promise<void> {
+    this.stopMatchmakingPolling();
+    this.updateMatchmakingStatus({ status: "idle" });
     await logoutCurrentCocosAuthSession(this.remoteUrl, {
       storage: this.readWebStorage()
     });
@@ -2933,6 +3195,7 @@ export class VeilRoot extends Component {
 
   private async disposeCurrentSession(): Promise<void> {
     this.bumpSessionEpoch();
+    this.stopMatchmakingPolling();
     const currentSession = this.session;
     this.session = null;
     if (currentSession) {
@@ -3091,6 +3354,8 @@ export class VeilRoot extends Component {
   }
 
   private hydrateLaunchIdentity(): void {
+    this.stopMatchmakingPolling();
+    this.updateMatchmakingStatus({ status: "idle" });
     const storage = this.readWebStorage();
     const launchIdentity = resolveCocosLaunchIdentity({
       defaultRoomId: this.roomId,

--- a/apps/cocos-client/assets/scripts/cocos-matchmaking-status.ts
+++ b/apps/cocos-client/assets/scripts/cocos-matchmaking-status.ts
@@ -1,0 +1,43 @@
+import type { CocosMatchmakingStatusResponse } from "./cocos-matchmaking.ts";
+
+export interface MatchmakingStatusView {
+  statusLabel: string;
+  queuePositionLabel: string;
+  waitEstimateLabel: string;
+  matchedLabel: string;
+  canCancel: boolean;
+  isMatched: boolean;
+}
+
+export function buildMatchmakingStatusView(status: CocosMatchmakingStatusResponse): MatchmakingStatusView {
+  if (status.status === "queued") {
+    return {
+      statusLabel: "正在匹配…",
+      queuePositionLabel: `位置 #${Math.max(1, Math.floor(status.position))}`,
+      waitEstimateLabel: `预计 ${Math.max(0, Math.floor(status.estimatedWaitSeconds))}s`,
+      matchedLabel: "",
+      canCancel: true,
+      isMatched: false
+    };
+  }
+
+  if (status.status === "matched") {
+    return {
+      statusLabel: "匹配成功",
+      queuePositionLabel: "位置 -",
+      waitEstimateLabel: "预计 0s",
+      matchedLabel: `房间 ${status.roomId} · 玩家 ${status.playerIds.join(" vs ")}`,
+      canCancel: false,
+      isMatched: true
+    };
+  }
+
+  return {
+    statusLabel: "未在匹配",
+    queuePositionLabel: "位置 -",
+    waitEstimateLabel: "预计 --",
+    matchedLabel: "",
+    canCancel: false,
+    isMatched: false
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-matchmaking-status.ts.meta
+++ b/apps/cocos-client/assets/scripts/cocos-matchmaking-status.ts.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "4.0.24",
+  "importer": "typescript",
+  "imported": true,
+  "uuid": "e20e6c6f-edf7-4f71-a04c-981afd8bbf57",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/apps/cocos-client/assets/scripts/cocos-matchmaking.ts
+++ b/apps/cocos-client/assets/scripts/cocos-matchmaking.ts
@@ -1,0 +1,156 @@
+import { readStoredCocosAuthSession, type CocosStoredAuthSession } from "./cocos-session-launch.ts";
+import { resolveCocosApiBaseUrl, buildCocosAuthHeaders } from "./cocos-lobby.ts";
+
+type FetchLike = typeof fetch;
+
+export type CocosMatchmakingIdleStatus = { status: "idle" };
+export type CocosMatchmakingQueuedStatus = { status: "queued"; position: number; estimatedWaitSeconds: number };
+export type CocosMatchmakingMatchedStatus = {
+  status: "matched";
+  roomId: string;
+  playerIds: [string, string];
+  seedOverride: number;
+};
+
+export type CocosMatchmakingStatus =
+  | CocosMatchmakingIdleStatus
+  | CocosMatchmakingQueuedStatus
+  | CocosMatchmakingMatchedStatus;
+export type CocosMatchmakingStatusResponse = CocosMatchmakingStatus;
+
+export interface CocosMatchmakingPollController {
+  stop(): void;
+}
+
+async function fetchJson(url: string, init?: RequestInit, fetchImpl: FetchLike = fetch): Promise<unknown> {
+  const response = await fetchImpl(url, init);
+  if (!response.ok) {
+    let errorCode = "unknown";
+    try {
+      const payload = (await response.json()) as { error?: { code?: string } };
+      errorCode = payload.error?.code?.trim() || errorCode;
+    } catch {
+      errorCode = "unknown";
+    }
+    throw new Error(`cocos_request_failed:${response.status}:${errorCode}`);
+  }
+  return (await response.json()) as unknown;
+}
+
+function authSessionFromOptions(
+  storage: Pick<Storage, "getItem"> | null | undefined,
+  explicit: CocosStoredAuthSession | null | undefined
+): CocosStoredAuthSession | null {
+  return explicit ?? readStoredCocosAuthSession(storage ?? null);
+}
+
+export async function readCocosMatchmakingStatus(
+  remoteUrl: string,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<CocosMatchmakingStatus> {
+  const storage = options?.storage ?? null;
+  const authSession = authSessionFromOptions(storage, options?.authSession ?? null);
+  const endpoint = resolveCocosApiBaseUrl(remoteUrl) + "/api/matchmaking/status";
+  const payload = (await fetchJson(
+    endpoint,
+    { headers: buildCocosAuthHeaders(authSession?.token) },
+    options?.fetchImpl
+  )) as CocosMatchmakingStatus;
+  return payload;
+}
+
+export async function enqueueCocosMatchmaking(
+  remoteUrl: string,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<CocosMatchmakingStatus> {
+  const storage = options?.storage ?? null;
+  const authSession = authSessionFromOptions(storage, options?.authSession ?? null);
+  const endpoint = resolveCocosApiBaseUrl(remoteUrl) + "/api/matchmaking/enqueue";
+  const payload = (await fetchJson(
+    endpoint,
+    { method: "POST", headers: { "Content-Type": "application/json", ...buildCocosAuthHeaders(authSession?.token) } },
+    options?.fetchImpl
+  )) as CocosMatchmakingStatus;
+  return payload;
+}
+
+export async function cancelCocosMatchmaking(
+  remoteUrl: string,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<"dequeued" | "idle"> {
+  const storage = options?.storage ?? null;
+  const authSession = authSessionFromOptions(storage, options?.authSession ?? null);
+  const endpoint = resolveCocosApiBaseUrl(remoteUrl) + "/api/matchmaking/cancel";
+  const payload = (await fetchJson(
+    endpoint,
+    { method: "DELETE", headers: buildCocosAuthHeaders(authSession?.token) },
+    options?.fetchImpl
+  )) as { status?: string };
+  return payload.status === "dequeued" ? "dequeued" : "idle";
+}
+
+export function startCocosMatchmakingStatusPolling(
+  remoteUrl: string,
+  onUpdate: (status: CocosMatchmakingStatus) => void,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+    pollIntervalMs?: number;
+    stopOnMatched?: boolean;
+    stopOnIdle?: boolean;
+  }
+): CocosMatchmakingPollController {
+  const pollIntervalMs = Math.max(250, Math.floor(options?.pollIntervalMs ?? 1500));
+  const stopOnMatched = options?.stopOnMatched ?? true;
+  const stopOnIdle = options?.stopOnIdle ?? false;
+  let stopped = false;
+  let terminal = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    try {
+      const status = await readCocosMatchmakingStatus(remoteUrl, {
+        ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        storage: options?.storage ?? null,
+        authSession: options?.authSession ?? null
+      });
+      onUpdate(status);
+      if ((stopOnMatched && status.status === "matched") || (stopOnIdle && status.status === "idle")) {
+        terminal = true;
+        return;
+      }
+    } catch {
+      // ignore and retry
+    } finally {
+      if (!stopped && !terminal) {
+        timer = setTimeout(tick, pollIntervalMs);
+      }
+    }
+  }
+
+  void tick();
+
+  return {
+    stop(): void {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    }
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-matchmaking.ts.meta
+++ b/apps/cocos-client/assets/scripts/cocos-matchmaking.ts.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "4.0.24",
+  "importer": "typescript",
+  "imported": true,
+  "uuid": "0d415e28-412f-4119-9c87-a1dd834e9c14",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/apps/cocos-client/test/cocos-matchmaking-status.test.ts
+++ b/apps/cocos-client/test/cocos-matchmaking-status.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildMatchmakingStatusView } from "../assets/scripts/cocos-matchmaking-status.ts";
+
+test("buildMatchmakingStatusView formats queued queue position and wait labels", () => {
+  const view = buildMatchmakingStatusView({
+    status: "queued",
+    position: 4,
+    estimatedWaitSeconds: 27
+  });
+
+  assert.deepEqual(view, {
+    statusLabel: "正在匹配…",
+    queuePositionLabel: "位置 #4",
+    waitEstimateLabel: "预计 27s",
+    matchedLabel: "",
+    canCancel: true,
+    isMatched: false
+  });
+});
+
+test("buildMatchmakingStatusView formats matched room and player labels", () => {
+  const view = buildMatchmakingStatusView({
+    status: "matched",
+    roomId: "pvp-match-7",
+    playerIds: ["player-1", "player-2"],
+    seedOverride: 1007
+  });
+
+  assert.equal(view.statusLabel, "匹配成功");
+  assert.equal(view.queuePositionLabel, "位置 -");
+  assert.equal(view.waitEstimateLabel, "预计 0s");
+  assert.match(view.matchedLabel, /房间 pvp-match-7/);
+  assert.match(view.matchedLabel, /player-1 vs player-2/);
+  assert.equal(view.canCancel, false);
+  assert.equal(view.isMatched, true);
+});
+
+test("buildMatchmakingStatusView falls back to an idle shell", () => {
+  assert.deepEqual(buildMatchmakingStatusView({ status: "idle" }), {
+    statusLabel: "未在匹配",
+    queuePositionLabel: "位置 -",
+    waitEstimateLabel: "预计 --",
+    matchedLabel: "",
+    canCancel: false,
+    isMatched: false
+  });
+});

--- a/apps/cocos-client/test/cocos-matchmaking.test.ts
+++ b/apps/cocos-client/test/cocos-matchmaking.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cancelCocosMatchmaking,
+  enqueueCocosMatchmaking,
+  readCocosMatchmakingStatus,
+  startCocosMatchmakingStatusPolling,
+  type CocosMatchmakingStatus
+} from "../assets/scripts/cocos-matchmaking.ts";
+
+function okJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+
+test("readCocosMatchmakingStatus reads queue status with auth from storage", async () => {
+  const requests: Array<{ url: string; auth: string | null }> = [];
+  const storage = {
+    getItem(): string {
+      return JSON.stringify({
+        playerId: "player-1",
+        displayName: "One",
+        authMode: "guest",
+        token: "token-123",
+        source: "remote"
+      });
+    }
+  };
+
+  const status = await readCocosMatchmakingStatus("ws://127.0.0.1:2567/ws", {
+    storage,
+    fetchImpl: async (input, init) => {
+      requests.push({
+        url: String(input),
+        auth: new Headers(init?.headers).get("Authorization")
+      });
+      return okJson({
+        status: "queued",
+        position: 3,
+        estimatedWaitSeconds: 18
+      });
+    }
+  });
+
+  assert.deepEqual(status, {
+    status: "queued",
+    position: 3,
+    estimatedWaitSeconds: 18
+  });
+  assert.deepEqual(requests, [
+    {
+      url: "http://127.0.0.1:2567/api/matchmaking/status",
+      auth: "Bearer token-123"
+    }
+  ]);
+});
+
+test("enqueueCocosMatchmaking posts to the enqueue endpoint", async () => {
+  const requests: Array<{ url: string; method: string; auth: string | null; contentType: string | null }> = [];
+
+  const status = await enqueueCocosMatchmaking("http://127.0.0.1:2567", {
+    authSession: {
+      playerId: "player-1",
+      displayName: "One",
+      authMode: "guest",
+      token: "token-abc",
+      source: "remote"
+    },
+    fetchImpl: async (input, init) => {
+      requests.push({
+        url: String(input),
+        method: init?.method ?? "GET",
+        auth: new Headers(init?.headers).get("Authorization"),
+        contentType: new Headers(init?.headers).get("Content-Type")
+      });
+      return okJson({
+        status: "queued",
+        position: 1,
+        estimatedWaitSeconds: 12
+      });
+    }
+  });
+
+  assert.equal(status.status, "queued");
+  assert.deepEqual(requests, [
+    {
+      url: "http://127.0.0.1:2567/api/matchmaking/enqueue",
+      method: "POST",
+      auth: "Bearer token-abc",
+      contentType: "application/json"
+    }
+  ]);
+});
+
+test("cancelCocosMatchmaking deletes the queue entry and normalizes the response", async () => {
+  const requests: Array<{ url: string; method: string; auth: string | null }> = [];
+
+  const result = await cancelCocosMatchmaking("http://127.0.0.1:2567", {
+    authSession: {
+      playerId: "player-1",
+      displayName: "One",
+      authMode: "guest",
+      token: "token-cancel",
+      source: "remote"
+    },
+    fetchImpl: async (input, init) => {
+      requests.push({
+        url: String(input),
+        method: init?.method ?? "GET",
+        auth: new Headers(init?.headers).get("Authorization")
+      });
+      return okJson({ status: "dequeued" });
+    }
+  });
+
+  assert.equal(result, "dequeued");
+  assert.deepEqual(requests, [
+    {
+      url: "http://127.0.0.1:2567/api/matchmaking/cancel",
+      method: "DELETE",
+      auth: "Bearer token-cancel"
+    }
+  ]);
+});
+
+test("matchmaking requests expose server error codes in thrown errors", async () => {
+  await assert.rejects(
+    () =>
+      readCocosMatchmakingStatus("http://127.0.0.1:2567", {
+        fetchImpl: async () =>
+          okJson(
+            {
+              error: {
+                code: "token_expired"
+              }
+            },
+            401
+          )
+      }),
+    /cocos_request_failed:401:token_expired/
+  );
+});
+
+test("startCocosMatchmakingStatusPolling stops scheduling after a matched response", async () => {
+  const seen: CocosMatchmakingStatus[] = [];
+  let fetchCount = 0;
+
+  startCocosMatchmakingStatusPolling(
+    "http://127.0.0.1:2567",
+    (status) => {
+      seen.push(status);
+    },
+    {
+      pollIntervalMs: 250,
+      fetchImpl: async () => {
+        fetchCount += 1;
+        return okJson({
+          status: "matched",
+          roomId: "pvp-match-1",
+          playerIds: ["player-1", "player-2"],
+          seedOverride: 1001
+        });
+      }
+    }
+  );
+
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 400));
+
+  assert.equal(fetchCount, 1);
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0]?.status, "matched");
+});
+
+test("startCocosMatchmakingStatusPolling can stop after an idle response when configured", async () => {
+  const seen: CocosMatchmakingStatus[] = [];
+  let fetchCount = 0;
+
+  startCocosMatchmakingStatusPolling(
+    "http://127.0.0.1:2567",
+    (status) => {
+      seen.push(status);
+    },
+    {
+      stopOnIdle: true,
+      pollIntervalMs: 250,
+      fetchImpl: async () => {
+        fetchCount += 1;
+        return okJson({ status: "idle" });
+      }
+    }
+  );
+
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 400));
+
+  assert.equal(fetchCount, 1);
+  assert.deepEqual(seen, [{ status: "idle" }]);
+});
+
+test("startCocosMatchmakingStatusPolling retries after transient errors until stopped", async () => {
+  const seen: CocosMatchmakingStatus[] = [];
+  let fetchCount = 0;
+
+  const controller = startCocosMatchmakingStatusPolling(
+    "http://127.0.0.1:2567",
+    (status) => {
+      seen.push(status);
+    },
+    {
+      pollIntervalMs: 250,
+      fetchImpl: async () => {
+        fetchCount += 1;
+        if (fetchCount === 1) {
+          throw new Error("network_down");
+        }
+        return okJson({
+          status: "queued",
+          position: 2,
+          estimatedWaitSeconds: 9
+        });
+      }
+    }
+  );
+
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 320));
+  controller.stop();
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 320));
+
+  assert.equal(fetchCount, 2);
+  assert.deepEqual(seen, [
+    {
+      status: "queued",
+      position: 2,
+      estimatedWaitSeconds: 9
+    }
+  ]);
+});
+
+test("startCocosMatchmakingStatusPolling stop cancels the next scheduled poll", async () => {
+  let fetchCount = 0;
+
+  const controller = startCocosMatchmakingStatusPolling(
+    "http://127.0.0.1:2567",
+    () => undefined,
+    {
+      pollIntervalMs: 250,
+      fetchImpl: async () => {
+        fetchCount += 1;
+        return okJson({
+          status: "queued",
+          position: 1,
+          estimatedWaitSeconds: 5
+        });
+      }
+    }
+  );
+
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
+  controller.stop();
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 350));
+
+  assert.equal(fetchCount, 1);
+});

--- a/apps/cocos-client/test/cocos-veil-root.test.ts
+++ b/apps/cocos-client/test/cocos-veil-root.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
 import { sys } from "cc";
 import { VeilRoot } from "../assets/scripts/VeilRoot.ts";
-import type { SessionUpdate } from "../assets/scripts/VeilCocosSession.ts";
+import type { MatchmakingStatusResponse, SessionUpdate } from "../assets/scripts/VeilCocosSession.ts";
 import { createMemoryStorage, createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
 import { createVeilRootHarness, installVeilRootRuntime, resetVeilRootRuntime } from "./helpers/veil-root-harness.ts";
 
@@ -424,4 +424,125 @@ test("VeilRoot refreshes WeChat share metadata after a battle resolves back to w
   assert.match(payload.title, /第 4 天 探索房间 room-recover/);
   assert.match(payload.query, /shareScene=world/);
   assert.match(payload.query, /day=4/);
+});
+
+test("VeilRoot enters a matched room from lobby matchmaking and stops polling", async () => {
+  const root = createVeilRootHarness();
+  root.showLobby = true;
+  root.privacyConsentAccepted = true;
+  root.playerId = "player-1";
+  root.displayName = "One";
+  root.roomId = "room-alpha";
+
+  let pollUpdate: ((status: MatchmakingStatusResponse) => void) | null = null;
+  let pollStops = 0;
+  const joinedUpdate = createSessionUpdate(1, "pvp-match-7", "player-1");
+
+  installVeilRootRuntime({
+    loginGuestAuthSession: async () => ({
+      token: "guest.token",
+      playerId: "player-1",
+      displayName: "One",
+      authMode: "guest",
+      provider: "guest",
+      source: "remote"
+    }),
+    enqueueMatchmaking: async () => ({
+      status: "queued",
+      position: 2,
+      estimatedWaitSeconds: 18
+    }),
+    startMatchmakingPolling: (_remoteUrl, onUpdate) => {
+      pollUpdate = onUpdate;
+      return {
+        stop() {
+          pollStops += 1;
+        }
+      };
+    },
+    createSession: async () =>
+      ({
+        async snapshot() {
+          return joinedUpdate;
+        },
+        async dispose() {}
+      }) as never
+  });
+
+  await root.enterLobbyMatchmaking();
+  assert.equal(root.matchmakingStatus.status, "queued");
+  assert.ok(pollUpdate);
+
+  await pollUpdate?.({
+    status: "matched",
+    roomId: "pvp-match-7",
+    playerIds: ["player-1", "player-2"],
+    seedOverride: 2007
+  });
+  await flushMicrotasks();
+
+  assert.equal(pollStops, 1);
+  assert.equal(root.showLobby, false);
+  assert.equal(root.roomId, "pvp-match-7");
+  assert.equal(root.seed, 2007);
+  assert.equal(root.matchmakingStatus.status, "idle");
+  assert.equal(root.lastUpdate?.world.meta.roomId, "pvp-match-7");
+});
+
+test("VeilRoot cancelLobbyMatchmaking stops polling and clears the queue state", async () => {
+  const root = createVeilRootHarness();
+  root.showLobby = true;
+  root.playerId = "player-1";
+  root.displayName = "One";
+  root.authToken = "guest.token";
+  root.matchmakingStatus = {
+    status: "queued",
+    position: 3,
+    estimatedWaitSeconds: 21
+  };
+  root.matchmakingView = {
+    statusLabel: "正在匹配…",
+    queuePositionLabel: "位置 #3",
+    waitEstimateLabel: "预计 21s",
+    matchedLabel: "",
+    canCancel: true,
+    isMatched: false
+  };
+
+  let cancelCalls = 0;
+  let pollStops = 0;
+  root.matchmakingPollController = {
+    stop() {
+      pollStops += 1;
+    }
+  };
+
+  installVeilRootRuntime({
+    cancelMatchmaking: async () => {
+      cancelCalls += 1;
+      return "dequeued";
+    }
+  });
+
+  await root.cancelLobbyMatchmaking();
+
+  assert.equal(cancelCalls, 1);
+  assert.equal(pollStops, 1);
+  assert.deepEqual(root.matchmakingStatus, { status: "idle" });
+  assert.match(String(root.lobbyStatus), /已取消当前匹配队列/);
+});
+
+test("VeilRoot onDestroy stops matchmaking polling to avoid timer leaks", () => {
+  const root = createVeilRootHarness();
+  let pollStops = 0;
+  root.matchmakingPollController = {
+    stop() {
+      pollStops += 1;
+    }
+  };
+
+  root.onDestroy();
+
+  assert.equal(pollStops, 1);
+  assert.equal(root.matchmakingPollController, null);
 });


### PR DESCRIPTION
## Summary
- wire the Cocos lobby into PvP matchmaking enqueue, polling, cancel, timeout, and matched-room handoff flows
- surface queue status and cancel controls in the lobby UI while ensuring polling is stopped on cancel, match, logout, and component teardown
- add focused matchmaking helper and VeilRoot tests covering request wiring, status rendering, poll shutdown, and matched room entry

## Validation
- `node --import tsx --test ./apps/cocos-client/test/cocos-matchmaking.test.ts ./apps/cocos-client/test/cocos-matchmaking-status.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts`
- `npm run typecheck:cocos`

Closes #827