### PR TITLE
feat: add PvP surrender flow

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -550,6 +550,10 @@ type WorldAction =
       slot: EquipmentType;
     }
   | {
+      type: "world.surrender";
+      heroId: string;
+    }
+  | {
       type: "turn.endDay";
     };
 
@@ -612,7 +616,7 @@ interface SessionStatePayload {
   events: WorldEvent[];
   movementPlan: MovementPlan | null;
   reachableTiles: Vec2[];
-  reason?: string;
+  reason?: "surrender" | "afk_forfeit" | "normal" | (string & {});
 }
 
 type ServerMessage =
@@ -1333,6 +1337,25 @@ class RemoteGameSession {
     };
   }
 
+  async surrender(heroId: string): Promise<SessionUpdate> {
+    const response = await this.send<Extract<ServerMessage, { type: "session.state" }>>(
+      {
+        type: "world.action",
+        requestId: this.nextRequestId(),
+        action: {
+          type: "world.surrender",
+          heroId
+        }
+      },
+      "session.state"
+    );
+
+    const update = fromPayload(response.payload, this.latestWorld);
+    this.latestWorld = update.world;
+    writeSessionReplay(this.roomId, this.playerId, update);
+    return update;
+  }
+
   private persistReconnectionToken(): void {
     if (this.room.reconnectionToken) {
       writeReconnectionToken(this.roomId, this.playerId, this.room.reconnectionToken);
@@ -1499,6 +1522,10 @@ class RecoverableRemoteGameSession {
 
   async reportPlayer(targetPlayerId: string, reason: PlayerReportReason, description?: string): Promise<PlayerReportReceipt> {
     return this.runWithSession((session) => session.reportPlayer(targetPlayerId, reason, description));
+  }
+
+  async surrender(heroId: string): Promise<SessionUpdate> {
+    return this.runWithSession((session) => session.surrender(heroId));
   }
 
   async actInBattle(action: BattleAction): Promise<SessionUpdate> {
@@ -1716,6 +1743,10 @@ export class VeilCocosSession {
 
   async reportPlayer(targetPlayerId: string, reason: PlayerReportReason, description?: string): Promise<PlayerReportReceipt> {
     return this.remoteSession.reportPlayer(targetPlayerId, reason, description);
+  }
+
+  async surrender(heroId: string): Promise<SessionUpdate> {
+    return this.remoteSession.surrender(heroId);
   }
 
   async actInBattle(action: BattleAction): Promise<SessionUpdate> {

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -66,11 +66,13 @@ const SKILL_BUTTON_PREFIX = "HudSkillButton";
 const EQUIPMENT_BUTTON_PREFIX = "HudEquipButton";
 const ACHIEVEMENT_NOTICE_NODE_NAME = "HudAchievementNotice";
 const REPORT_DIALOG_NODE_NAME = "HudReportDialog";
+const SURRENDER_DIALOG_NODE_NAME = "HudSurrenderDialog";
 
 interface HudActionButtonState {
   name: string;
   label: string;
   callback: (() => void) | null;
+  visible?: boolean;
 }
 
 interface HudEquipmentButtonState {
@@ -188,6 +190,13 @@ export interface VeilHudRenderState {
     status: string | null;
     submitting: boolean;
   };
+  surrendering: {
+    open: boolean;
+    available: boolean;
+    targetLabel: string | null;
+    status: string | null;
+    submitting: boolean;
+  };
   presentation: {
     audio: CocosAudioRuntimeState;
     pixelAssets: PixelSpriteLoadStatus;
@@ -221,8 +230,11 @@ export interface VeilHudPanelOptions {
   onToggleInventory?: () => void;
   onToggleAchievements?: () => void;
   onToggleReport?: () => void;
+  onToggleSurrender?: () => void;
   onSubmitReport?: (reason: PlayerReportReason) => void;
   onCancelReport?: () => void;
+  onConfirmSurrender?: () => void;
+  onCancelSurrender?: () => void;
   onLearnSkill?: (skillId: string) => void;
   onEquipItem?: (slot: EquipmentType, equipmentId: string) => void;
   onUnequipItem?: (slot: EquipmentType) => void;
@@ -326,8 +338,11 @@ export class VeilHudPanel extends Component {
   private onToggleInventory: (() => void) | undefined;
   private onToggleAchievements: (() => void) | undefined;
   private onToggleReport: (() => void) | undefined;
+  private onToggleSurrender: (() => void) | undefined;
   private onSubmitReport: ((reason: PlayerReportReason) => void) | undefined;
   private onCancelReport: (() => void) | undefined;
+  private onConfirmSurrender: (() => void) | undefined;
+  private onCancelSurrender: (() => void) | undefined;
   private onLearnSkill: ((skillId: string) => void) | undefined;
   private onEquipItem: ((slot: EquipmentType, equipmentId: string) => void) | undefined;
   private onUnequipItem: ((slot: EquipmentType) => void) | undefined;
@@ -341,8 +356,11 @@ export class VeilHudPanel extends Component {
     this.onToggleInventory = options.onToggleInventory;
     this.onToggleAchievements = options.onToggleAchievements;
     this.onToggleReport = options.onToggleReport;
+    this.onToggleSurrender = options.onToggleSurrender;
     this.onSubmitReport = options.onSubmitReport;
     this.onCancelReport = options.onCancelReport;
+    this.onConfirmSurrender = options.onConfirmSurrender;
+    this.onCancelSurrender = options.onCancelSurrender;
     this.onLearnSkill = options.onLearnSkill;
     this.onEquipItem = options.onEquipItem;
     this.onUnequipItem = options.onUnequipItem;
@@ -562,6 +580,7 @@ export class VeilHudPanel extends Component {
     this.renderStatusBadge(`${CARD_PREFIX}-status`, statusBadge);
     this.renderAchievementNotice(state.achievementNotice);
     this.renderReportDialog(state.reporting);
+    this.renderSurrenderDialog(state.surrendering);
 
     const showDebug = false;
     if (showDebug) {
@@ -626,6 +645,7 @@ export class VeilHudPanel extends Component {
       { nodeName: "HudInventory", debugLabel: "inventory", callback: this.onToggleInventory ?? null },
       { nodeName: "HudAchievements", debugLabel: "achievements", callback: this.onToggleAchievements ?? null },
       { nodeName: "HudReportPlayer", debugLabel: "report-player", callback: this.onToggleReport ?? null },
+      { nodeName: "HudSurrender", debugLabel: "surrender", callback: this.onToggleSurrender ?? null },
       { nodeName: "HudEndDay", debugLabel: "end-day", callback: this.onEndDay ?? null },
       { nodeName: "HudReturnLobby", debugLabel: "return-lobby", callback: this.onReturnLobby ?? null }
     ];
@@ -639,6 +659,21 @@ export class VeilHudPanel extends Component {
     const reportDialogNode = this.node.getChildByName(REPORT_DIALOG_NODE_NAME);
     for (const action of reportDialogActions) {
       const node = reportDialogNode?.getChildByName(action.nodeName) ?? null;
+      if (this.pointInNode(localX, localY, node)) {
+        return {
+          debugLabel: action.debugLabel,
+          callback: action.callback
+        };
+      }
+    }
+
+    const surrenderDialogActions: Array<{ nodeName: string; debugLabel: string; callback: (() => void) | null }> = [
+      { nodeName: "HudSurrenderConfirm", debugLabel: "surrender-confirm", callback: this.onConfirmSurrender ?? null },
+      { nodeName: "HudSurrenderCancel", debugLabel: "surrender-cancel", callback: this.onCancelSurrender ?? null }
+    ];
+    const surrenderDialogNode = this.node.getChildByName(SURRENDER_DIALOG_NODE_NAME);
+    for (const action of surrenderDialogActions) {
+      const node = surrenderDialogNode?.getChildByName(action.nodeName) ?? null;
       if (this.pointInNode(localX, localY, node)) {
         return {
           debugLabel: action.debugLabel,
@@ -1475,6 +1510,7 @@ export class VeilHudPanel extends Component {
       WATERMARK_NODE_NAME,
       ACTIONS_NODE_NAME,
       REPORT_DIALOG_NODE_NAME,
+      SURRENDER_DIALOG_NODE_NAME,
       `${CARD_PREFIX}-title`,
       `${CARD_PREFIX}-resources`,
       `${CARD_PREFIX}-hero`,
@@ -1504,6 +1540,7 @@ export class VeilHudPanel extends Component {
     this.ensureActionButton(actionsNode, "HudInventory", "装备背包");
     this.ensureActionButton(actionsNode, "HudAchievements", "战报中心");
     this.ensureActionButton(actionsNode, "HudReportPlayer", "举报玩家");
+    this.ensureActionButton(actionsNode, "HudSurrender", "认输");
     this.ensureActionButton(actionsNode, "HudEndDay", "推进一天");
     this.ensureActionButton(actionsNode, "HudReturnLobby", "返回大厅");
   }
@@ -1516,25 +1553,32 @@ export class VeilHudPanel extends Component {
       return;
     }
 
-    const actionsTransform = actionsNode.getComponent(UITransform) ?? actionsNode.addComponent(UITransform);
-    actionsTransform.setContentSize(Math.max(164, transform.width - 28), 246);
-    actionsNode.setPosition(0, transform.height / 2 - 118, 1);
-
     const buttons: HudActionButtonState[] = [
       { name: "HudNewRun", label: "新开一局", callback: this.onNewRun ?? null },
       { name: "HudRefresh", label: "刷新状态", callback: this.onRefresh ?? null },
       { name: "HudInventory", label: "装备背包", callback: this.onToggleInventory ?? null },
       { name: "HudAchievements", label: "战报中心", callback: this.onToggleAchievements ?? null },
       { name: "HudReportPlayer", label: "举报玩家", callback: this.onToggleReport ?? null },
+      {
+        name: "HudSurrender",
+        label: "认输",
+        callback: this.onToggleSurrender ?? null,
+        visible: this.currentState?.surrendering.available ?? false
+      },
       { name: "HudEndDay", label: "推进一天", callback: this.onEndDay ?? null },
       { name: "HudReturnLobby", label: "返回大厅", callback: this.onReturnLobby ?? null }
     ];
+    const visibleButtons = buttons.filter((button) => button.visible !== false);
+    const actionsTransform = actionsNode.getComponent(UITransform) ?? actionsNode.addComponent(UITransform);
+    actionsTransform.setContentSize(Math.max(164, transform.width - 28), Math.max(246, 66 + visibleButtons.length * 30));
+    actionsNode.setPosition(0, transform.height / 2 - 118, 1);
 
-    buttons.forEach((button, index) => {
+    visibleButtons.forEach((button, index) => {
       const node = actionsNode.getChildByName(button.name);
       if (!node) {
         return;
       }
+      node.active = true;
 
       const buttonTransform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
       const buttonWidth = Math.floor(actionsTransform.width - 8);
@@ -1611,6 +1655,13 @@ export class VeilHudPanel extends Component {
         });
       }
     });
+
+    for (const button of buttons.filter((candidate) => candidate.visible === false)) {
+      const hiddenNode = actionsNode.getChildByName(button.name);
+      if (hiddenNode) {
+        hiddenNode.active = false;
+      }
+    }
   }
 
   private ensureActionButton(parent: Node, name: string, labelText: string): void {
@@ -1688,6 +1739,58 @@ export class VeilHudPanel extends Component {
     buttons.forEach((button, index) => {
       this.renderDialogButton(dialogNode!, button.name, button.label, 14 - index * 30, button.enabled);
     });
+  }
+
+  private renderSurrenderDialog(state: VeilHudRenderState["surrendering"]): void {
+    let dialogNode = this.node.getChildByName(SURRENDER_DIALOG_NODE_NAME);
+    if (!state.open) {
+      if (dialogNode) {
+        dialogNode.active = false;
+      }
+      return;
+    }
+
+    if (!dialogNode) {
+      dialogNode = new Node(SURRENDER_DIALOG_NODE_NAME);
+      dialogNode.parent = this.node;
+    }
+    assignUiLayer(dialogNode);
+    dialogNode.active = true;
+
+    const rootTransform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const dialogTransform = dialogNode.getComponent(UITransform) ?? dialogNode.addComponent(UITransform);
+    const width = Math.max(176, rootTransform.width - 38);
+    const height = 156;
+    dialogTransform.setContentSize(width, height);
+    dialogNode.setPosition(0, 8, 6);
+
+    const graphics = dialogNode.getComponent(Graphics) ?? dialogNode.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = new Color(34, 30, 30, 238);
+    graphics.strokeColor = new Color(244, 203, 173, 148);
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 16);
+    graphics.fill();
+    graphics.stroke();
+
+    const titleNode = dialogNode.getChildByName("Label") ?? new Node("Label");
+    titleNode.parent = dialogNode;
+    assignUiLayer(titleNode);
+    const titleTransform = titleNode.getComponent(UITransform) ?? titleNode.addComponent(UITransform);
+    titleTransform.setContentSize(width - 24, 70);
+    titleNode.setPosition(0, 34, 1);
+    const title = titleNode.getComponent(Label) ?? titleNode.addComponent(Label);
+    title.string = `确认认输\n${state.targetLabel ?? "当前没有可结算的对手"}${state.status ? `\n${state.status}` : ""}`;
+    title.fontSize = 13;
+    title.lineHeight = 16;
+    title.horizontalAlign = H_ALIGN_CENTER;
+    title.verticalAlign = V_ALIGN_MIDDLE;
+    title.overflow = OVERFLOW_RESIZE_HEIGHT;
+    title.enableWrapText = true;
+    title.color = new Color(248, 244, 233, 255);
+
+    this.renderDialogButton(dialogNode, "HudSurrenderConfirm", "确认认输", -18, state.available && !state.submitting);
+    this.renderDialogButton(dialogNode, "HudSurrenderCancel", "取消", -48, !state.submitting);
   }
 
   private renderDialogButton(parent: Node, name: string, labelText: string, y: number, enabled: boolean): void {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -60,7 +60,9 @@ import {
   buildTimelineEntriesFromUpdate,
   describeMoveAttemptFeedback,
   describeSessionActionOutcome,
-  formatSessionActionReason
+  formatSessionActionReason,
+  formatSessionSettlementReason,
+  isSessionSettlementReason
 } from "./cocos-ui-formatters.ts";
 import { buildHeroProgressNotice, type HeroProgressNotice } from "./cocos-hero-progression.ts";
 import { VeilHudPanel, type VeilHudRenderState } from "./VeilHudPanel.ts";
@@ -333,6 +335,9 @@ export class VeilRoot extends Component {
   private reportDialogOpen = false;
   private reportSubmitting = false;
   private reportStatusMessage: string | null = null;
+  private surrenderDialogOpen = false;
+  private surrenderSubmitting = false;
+  private surrenderStatusMessage: string | null = null;
 
   onLoad(): void {
     this.audioRuntime.dispose();
@@ -760,11 +765,20 @@ export class VeilRoot extends Component {
       onToggleReport: () => {
         this.toggleReportDialog();
       },
+      onToggleSurrender: () => {
+        this.toggleSurrenderDialog();
+      },
       onSubmitReport: (reason) => {
         void this.submitPlayerReport(reason);
       },
       onCancelReport: () => {
         this.closeReportDialog();
+      },
+      onConfirmSurrender: () => {
+        void this.confirmSurrender();
+      },
+      onCancelSurrender: () => {
+        this.closeSurrenderDialog();
       },
       onLearnSkill: (skillId) => {
         void this.learnHeroSkill(skillId);
@@ -1157,6 +1171,13 @@ export class VeilRoot extends Component {
         status: this.reportStatusMessage,
         submitting: this.reportSubmitting
       },
+      surrendering: {
+        open: this.surrenderDialogOpen,
+        available: this.isSurrenderAvailable(),
+        targetLabel: this.resolveSurrenderTarget()?.name ?? null,
+        status: this.surrenderStatusMessage,
+        submitting: this.surrenderSubmitting
+      },
       presentation: this.buildHudPresentationState()
     });
     this.mapBoard?.render(this.lastUpdate);
@@ -1442,6 +1463,15 @@ export class VeilRoot extends Component {
     return target ? { playerId: target.playerId, name: `${target.name} · ${target.playerId}` } : null;
   }
 
+  private resolveSurrenderTarget(): { playerId: string; name: string } | null {
+    const target = this.lastUpdate?.world.visibleHeroes.find((hero) => hero.playerId !== this.playerId) ?? null;
+    return target ? { playerId: target.playerId, name: `${target.name} · ${target.playerId}` } : null;
+  }
+
+  private isSurrenderAvailable(): boolean {
+    return Boolean(this.activeHero() && this.resolveSurrenderTarget() && !this.lastUpdate?.battle);
+  }
+
   private toggleReportDialog(): void {
     if (this.reportSubmitting) {
       return;
@@ -1468,6 +1498,35 @@ export class VeilRoot extends Component {
 
     this.reportDialogOpen = false;
     this.reportStatusMessage = null;
+    this.renderView();
+  }
+
+  private toggleSurrenderDialog(): void {
+    if (this.surrenderSubmitting) {
+      return;
+    }
+
+    if (!this.isSurrenderAvailable()) {
+      this.surrenderDialogOpen = false;
+      this.surrenderStatusMessage = "当前不满足认输条件。";
+      this.predictionStatus = this.surrenderStatusMessage;
+      this.renderView();
+      return;
+    }
+
+    const target = this.resolveSurrenderTarget();
+    this.surrenderDialogOpen = !this.surrenderDialogOpen;
+    this.surrenderStatusMessage = this.surrenderDialogOpen ? `认输后将判负给 ${target?.name ?? "当前对手"}。` : null;
+    this.renderView();
+  }
+
+  private closeSurrenderDialog(): void {
+    if (this.surrenderSubmitting) {
+      return;
+    }
+
+    this.surrenderDialogOpen = false;
+    this.surrenderStatusMessage = null;
     this.renderView();
   }
 
@@ -1505,6 +1564,47 @@ export class VeilRoot extends Component {
       this.predictionStatus = this.reportStatusMessage;
     } finally {
       this.reportSubmitting = false;
+      this.renderView();
+    }
+  }
+
+  private async confirmSurrender(): Promise<void> {
+    if (!this.session) {
+      await this.connect();
+      return;
+    }
+
+    const hero = this.activeHero();
+    const target = this.resolveSurrenderTarget();
+    if (!hero || !target || this.lastUpdate?.battle) {
+      this.surrenderDialogOpen = false;
+      this.surrenderStatusMessage = "当前不满足认输条件。";
+      this.predictionStatus = this.surrenderStatusMessage;
+      this.renderView();
+      return;
+    }
+
+    this.surrenderSubmitting = true;
+    this.surrenderStatusMessage = `正在向 ${target.name} 提交认输...`;
+    this.renderView();
+
+    try {
+      const update = await this.session.surrender(hero.id);
+      await this.applySessionUpdate(update);
+      if (update.reason && isSessionSettlementReason(update.reason)) {
+        const message = formatSessionSettlementReason(update.reason, false);
+        this.predictionStatus = message;
+        this.pushLog(message);
+      }
+      this.surrenderDialogOpen = false;
+      this.surrenderStatusMessage = "认输已提交。";
+    } catch (error) {
+      const failureMessage = this.describeSessionError(error, "认输失败。");
+      this.surrenderStatusMessage = failureMessage;
+      this.predictionStatus = failureMessage;
+      this.pushLog(failureMessage);
+    } finally {
+      this.surrenderSubmitting = false;
       this.renderView();
     }
   }
@@ -1711,11 +1811,20 @@ export class VeilRoot extends Component {
         onToggleReport: () => {
           this.toggleReportDialog();
         },
+        onToggleSurrender: () => {
+          this.toggleSurrenderDialog();
+        },
         onSubmitReport: (reason) => {
           void this.submitPlayerReport(reason);
         },
         onCancelReport: () => {
           this.closeReportDialog();
+        },
+        onConfirmSurrender: () => {
+          void this.confirmSurrender();
+        },
+        onCancelSurrender: () => {
+          this.closeSurrenderDialog();
         },
         onLearnSkill: (skillId) => {
           void this.learnHeroSkill(skillId);
@@ -3593,6 +3702,8 @@ export class VeilRoot extends Component {
 
     this.pendingPrediction = null;
     this.predictionStatus = "";
+    this.surrenderDialogOpen = false;
+    this.surrenderStatusMessage = null;
     this.diagnosticsConnectionStatus = "connected";
     this.lastRoomUpdateSource = "session";
     this.lastRoomUpdateReason = update.reason ?? "snapshot";
@@ -3616,6 +3727,10 @@ export class VeilRoot extends Component {
       this.audioRuntime.playCue(presentation.cue);
     }
     this.mapBoard?.playHeroAnimation(presentation.animation);
+
+    if (update.reason && isSessionSettlementReason(update.reason)) {
+      this.predictionStatus = formatSessionSettlementReason(update.reason, !this.surrenderSubmitting);
+    }
 
     if (presentation.transition?.kind === "enter") {
       await this.battleTransition?.playEnter(presentation.transition.copy);

--- a/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
+++ b/apps/cocos-client/assets/scripts/cocos-ui-formatters.ts
@@ -29,9 +29,29 @@ function formatNeutralMoveReason(reason: string): string {
   return reason === "chase" ? "主动追击" : reason === "return" ? "返回守位" : "沿巡逻路线移动";
 }
 
+export function isSessionSettlementReason(reason?: string | null): reason is "surrender" | "afk_forfeit" | "normal" {
+  return reason === "surrender" || reason === "afk_forfeit" || reason === "normal";
+}
+
+export function formatSessionSettlementReason(reason: "surrender" | "afk_forfeit" | "normal", didWin: boolean): string {
+  if (reason === "surrender") {
+    return didWin ? "对手已认输，本局结算完成。" : "你已认输，本局结算完成。";
+  }
+
+  if (reason === "afk_forfeit") {
+    return didWin ? "对手因挂机判负，本局结算完成。" : "你因挂机判负，本局结算完成。";
+  }
+
+  return didWin ? "对局已正常结算。" : "对局已结束。";
+}
+
 export function formatSessionActionReason(reason: string): string {
   if (!reason) {
     return "未知原因";
+  }
+
+  if (isSessionSettlementReason(reason)) {
+    return reason === "surrender" ? "对局已按认输结算" : reason === "afk_forfeit" ? "对局已按挂机判负结算" : "对局已正常结算";
   }
 
   if (reason.startsWith("equipment_")) {
@@ -41,6 +61,10 @@ export function formatSessionActionReason(reason: string): string {
   switch (reason) {
     case "hero_not_found":
       return "当前英雄不存在";
+    case "hero_not_owned_by_player":
+      return "当前英雄不属于你";
+    case "hero_in_battle":
+      return "战斗结算前不能认输";
     case "hero_not_on_building":
       return "英雄没有站在目标建筑上";
     case "hero_not_on_tile":
@@ -73,6 +97,8 @@ export function formatSessionActionReason(reason: string): string {
       return "当前找不到可行路径";
     case "not_enough_move_points":
       return "移动力不足";
+    case "surrender_opponent_not_found":
+      return "当前没有可结算的对手";
     case "unit_not_active":
     case "attacker_not_active":
       return "当前还没轮到这个单位行动";
@@ -121,6 +147,13 @@ export function describeSessionActionOutcome(
     return {
       accepted: true,
       message: options.successMessage
+    };
+  }
+
+  if (isSessionSettlementReason(update.reason)) {
+    return {
+      accepted: true,
+      message: formatSessionSettlementReason(update.reason, false)
     };
   }
 
@@ -259,7 +292,11 @@ export function buildTimelineEntriesFromUpdate(update: SessionUpdate): string[] 
   const entries: string[] = [];
 
   if (update.reason) {
-    entries.push(`系统：操作被拒绝，原因是 ${formatSessionActionReason(update.reason)}`);
+    entries.push(
+      isSessionSettlementReason(update.reason)
+        ? `系统：${formatSessionActionReason(update.reason)}。`
+        : `系统：操作被拒绝，原因是 ${formatSessionActionReason(update.reason)}`
+    );
   }
 
   if (update.movementPlan && update.movementPlan.travelPath.length > 1) {

--- a/apps/cocos-client/assets/scripts/project-shared/map.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map.ts
@@ -1878,6 +1878,15 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
     };
   }
 
+  if (action.type !== "hero.collect") {
+    return {
+      world: view,
+      movementPlan: null,
+      reachableTiles: listReachableTilesInPlayerView(view, hero.id),
+      reason: "prediction_not_supported"
+    };
+  }
+
   const tile = findPlayerTile(view, action.position);
   if (!tile) {
     return {
@@ -1934,7 +1943,11 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
   };
 }
 
-export function validateWorldAction(state: WorldState, action: WorldAction): ValidationResult {
+export function validateWorldAction(
+  state: WorldState,
+  action: WorldAction,
+  requestingPlayerId?: string
+): ValidationResult {
   if (action.type === "turn.endDay") {
     return { valid: true };
   }
@@ -1942,6 +1955,14 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
   const hero = state.heroes.find((item) => item.id === action.heroId);
   if (!hero) {
     return { valid: false, reason: "hero_not_found" };
+  }
+
+  if (requestingPlayerId && hero.playerId !== requestingPlayerId) {
+    return { valid: false, reason: "hero_not_owned_by_player" };
+  }
+
+  if (action.type === "world.surrender") {
+    return { valid: true };
   }
 
   if (action.type === "hero.move") {
@@ -2498,6 +2519,10 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
         }
       ]
     };
+  }
+
+  if (action.type !== "hero.collect") {
+    return { state, events: [] };
   }
 
   const hero = state.heroes.find((item) => item.id === action.heroId);

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -575,6 +575,10 @@ export type WorldAction =
       slot: EquipmentType;
     }
   | {
+      type: "world.surrender";
+      heroId: string;
+    }
+  | {
       type: "turn.endDay";
     };
 

--- a/apps/cocos-client/assets/scripts/project-shared/protocol.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/protocol.ts
@@ -1,13 +1,15 @@
 import type { BattleAction, BattleState, MovementPlan, Vec2, WorldAction, WorldEvent } from "./models.ts";
 import type { PlayerWorldViewPayload } from "./map-sync.ts";
 
+export type SessionStateReason = "surrender" | "afk_forfeit" | "normal" | (string & {});
+
 export interface SessionStatePayload {
   world: PlayerWorldViewPayload;
   battle: BattleState | null;
   events: WorldEvent[];
   movementPlan: MovementPlan | null;
   reachableTiles: Vec2[];
-  reason?: string;
+  reason?: SessionStateReason;
 }
 
 export type PlayerReportReason = "cheating" | "harassment" | "afk";

--- a/apps/cocos-client/test/cocos-hud-panel.test.ts
+++ b/apps/cocos-client/test/cocos-hud-panel.test.ts
@@ -36,6 +36,20 @@ function createHudState(): VeilHudRenderState {
     triageSummaryLines: [],
     levelUpNotice: null,
     achievementNotice: null,
+    reporting: {
+      open: false,
+      available: false,
+      targetLabel: null,
+      status: null,
+      submitting: false
+    },
+    surrendering: {
+      open: false,
+      available: false,
+      targetLabel: null,
+      status: null,
+      submitting: false
+    },
     presentation: {
       audio: {
         supported: false,
@@ -137,6 +151,39 @@ test("VeilHudPanel dispatchPointerUp routes the inventory chrome button", () => 
 
   assert.equal(action, "inventory");
   assert.equal(opened, 1);
+});
+
+test("VeilHudPanel shows the surrender action only when available and routes confirmation clicks", () => {
+  const { component, node } = createComponentHarness(VeilHudPanel, { name: "HudPanelRoot", width: 320, height: 720 });
+  const state = createHudState();
+  state.surrendering = {
+    open: true,
+    available: true,
+    targetLabel: "维恩 · player-2",
+    status: "确认后将直接判负。",
+    submitting: false
+  };
+
+  let confirmed = 0;
+  component.configure({
+    onToggleSurrender: () => undefined,
+    onConfirmSurrender: () => {
+      confirmed += 1;
+    }
+  });
+  component.render(state);
+
+  const surrenderButton = findNode(node, "HudSurrender");
+  assert.ok(surrenderButton);
+  assert.equal(surrenderButton.active, true);
+
+  const confirmButton = findNode(node, "HudSurrenderConfirm");
+  assert.ok(confirmButton);
+  const confirmCenter = toHudLocalPosition(node, confirmButton);
+  const action = component.dispatchPointerUp(confirmCenter.x, confirmCenter.y);
+
+  assert.equal(action, "surrender-confirm");
+  assert.equal(confirmed, 1);
 });
 
 test("VeilHudPanel surfaces reconnect, replay, resync, and degraded session indicators in the status card", () => {

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -8,10 +8,12 @@ import {
   listReachableTiles,
   normalizeEloRating,
   planHeroMovement,
+  validateWorldAction,
   type PlayerWorldView,
   type PlayerBattleReplaySummary,
   type ClientMessage,
   type MovementPlan,
+  type SessionStateReason,
   type ServerMessage,
   type SessionStatePayload,
   type WorldEvent
@@ -396,6 +398,14 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       }
 
       recordWorldActionMessage();
+      if (message.action.type === "world.surrender") {
+        const resolved = await this.handleSurrenderAction(client, playerId, message);
+        if (!resolved) {
+          sendMessage(client, "error", { requestId: message.requestId, reason: "surrender_failed" });
+        }
+        return;
+      }
+
       const previousSnapshot = this.worldRoom.serializePersistenceSnapshot();
       const result = this.worldRoom.dispatch(playerId, message.action);
       try {
@@ -808,6 +818,136 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     playerId: string
   ): PlayerBattleReplaySummary[] {
     return buildPlayerBattleReplaySummariesForPlayer(replay, playerId);
+  }
+
+  private async handleSurrenderAction(
+    sourceClient: ColyseusClient,
+    playerId: string,
+    message: Extract<ClientMessage, { type: "world.action" }>
+  ): Promise<boolean> {
+    const action = message.action;
+    if (action.type !== "world.surrender") {
+      return false;
+    }
+
+    const internalState = this.worldRoom.getInternalState();
+    if (this.worldRoom.getBattleForPlayer(playerId)) {
+      sendMessage(sourceClient, "error", { requestId: message.requestId, reason: "hero_in_battle" });
+      return true;
+    }
+
+    const validation = validateWorldAction(internalState, action, playerId);
+    if (!validation.valid) {
+      sendMessage(sourceClient, "error", {
+        requestId: message.requestId,
+        reason: validation.reason ?? "surrender_failed"
+      });
+      return true;
+    }
+
+    const surrenderingHero = internalState.heroes.find((hero) => hero.id === action.heroId);
+    if (!surrenderingHero || surrenderingHero.playerId !== playerId) {
+      sendMessage(sourceClient, "error", { requestId: message.requestId, reason: "hero_not_owned_by_player" });
+      return true;
+    }
+
+    const opponentPlayerIds = Array.from(
+      new Set(internalState.heroes.map((hero) => hero.playerId).filter((candidatePlayerId) => candidatePlayerId !== playerId))
+    );
+    if (opponentPlayerIds.length !== 1) {
+      sendMessage(sourceClient, "error", { requestId: message.requestId, reason: "surrender_opponent_not_found" });
+      return true;
+    }
+
+    const winnerPlayerId = opponentPlayerIds[0]!;
+    if (!(await this.applySurrenderEloResult(winnerPlayerId, playerId))) {
+      return false;
+    }
+
+    await this.broadcastSettlementAndCloseRoom(sourceClient, "surrender", message.requestId);
+    return true;
+  }
+
+  private async applySurrenderEloResult(winnerPlayerId: string, loserPlayerId: string): Promise<boolean> {
+    const store = configuredRoomSnapshotStore;
+    if (!store) {
+      return true;
+    }
+
+    try {
+      const accounts = await store.loadPlayerAccounts([winnerPlayerId, loserPlayerId]);
+      const winnerAccount = accounts.find((account) => account.playerId === winnerPlayerId);
+      const loserAccount = accounts.find((account) => account.playerId === loserPlayerId);
+      const { winnerRating, loserRating } = applyEloMatchResult(
+        normalizeEloRating(winnerAccount?.eloRating),
+        normalizeEloRating(loserAccount?.eloRating)
+      );
+
+      await Promise.all([
+        store.savePlayerAccountProgress(winnerPlayerId, {
+          eloRating: winnerRating,
+          lastRoomId: this.metadata.logicalRoomId
+        }),
+        store.savePlayerAccountProgress(loserPlayerId, {
+          eloRating: loserRating,
+          lastRoomId: this.metadata.logicalRoomId
+        })
+      ]);
+      return true;
+    } catch (error) {
+      console.error("[VeilRoom] Failed to persist surrender ELO result", {
+        roomId: this.metadata.logicalRoomId,
+        winnerPlayerId,
+        loserPlayerId,
+        error
+      });
+      return false;
+    }
+  }
+
+  private async broadcastSettlementAndCloseRoom(
+    sourceClient: ColyseusClient,
+    reason: SessionStateReason,
+    requestId: string
+  ): Promise<void> {
+    for (const client of [...this.clients]) {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        continue;
+      }
+
+      sendMessage(client, "session.state", {
+        requestId: client === sourceClient ? requestId : "push",
+        delivery: client === sourceClient ? "reply" : "push",
+        payload: this.buildStatePayload(playerId, {
+          movementPlan: null,
+          reason
+        })
+      });
+    }
+
+    if (configuredRoomSnapshotStore) {
+      try {
+        await configuredRoomSnapshotStore.delete(this.metadata.logicalRoomId);
+      } catch (error) {
+        console.error("[VeilRoom] Failed to delete surrendered room snapshot", {
+          roomId: this.metadata.logicalRoomId,
+          error
+        });
+      }
+    }
+
+    for (const client of [...this.clients]) {
+      this.playerIdBySessionId.delete(client.sessionId);
+      try {
+        void client.leave();
+      } catch {
+        // Ignore disconnect errors while retiring the room after settlement.
+      }
+    }
+    this.clients.splice(0, this.clients.length);
+    lobbyRoomSummaries.delete(this.metadata.logicalRoomId);
+    activeRoomInstances.delete(this.metadata.logicalRoomId);
   }
 
   private resolveReportTargetPlayerId(playerId: string, requestedTargetPlayerId: string): string | null {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -329,7 +329,7 @@ export class AuthoritativeWorldRoom {
       }
     }
 
-    const validation = validateWorldAction(this.state, action);
+    const validation = validateWorldAction(this.state, action, playerId);
     if (!validation.valid) {
       recordActionValidationFailure("world", validation.reason ?? "world_action_invalid");
       return {

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { ClientState, matchMaker } from "colyseus";
 import type { Client } from "colyseus";
+import { applyEloMatchResult } from "../../../packages/shared/src/index";
 import type { BattleState, ServerMessage, WorldEvent } from "../../../packages/shared/src/index";
 import {
   VeilColyseusRoom,
@@ -1084,6 +1085,46 @@ test("pvp replay persistence captures both attacker and defender accounts from r
     replaySaves.map((entry) => entry.playerId).sort(),
     ["player-1", "player-2"]
   );
+});
+
+test("surrender settles the room with the surrendering player as loser and persists ELO deltas", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new InstrumentedRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-surrender-${Date.now()}`);
+  const surrenderingClient = createFakeClient("session-surrender-loser");
+  const opponentClient = createFakeClient("session-surrender-winner");
+  const expectedRatings = applyEloMatchResult(1000, 1000);
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, surrenderingClient, "player-1", "connect-surrender-loser");
+  await connectPlayer(room, opponentClient, "player-2", "connect-surrender-winner");
+
+  await emitRoomMessage(room, "world.action", surrenderingClient, {
+    type: "world.action",
+    requestId: "surrender-room",
+    action: {
+      type: "world.surrender",
+      heroId: "hero-1"
+    }
+  });
+
+  const surrenderReply = lastSessionState(surrenderingClient, "reply");
+  const winnerPush = lastSessionState(opponentClient, "push");
+  const loserAccount = await store.loadPlayerAccount("player-1");
+  const winnerAccount = await store.loadPlayerAccount("player-2");
+
+  assert.equal(surrenderReply.requestId, "surrender-room");
+  assert.equal(surrenderReply.payload.reason, "surrender");
+  assert.equal(winnerPush.payload.reason, "surrender");
+  assert.equal(loserAccount?.eloRating, expectedRatings.loserRating);
+  assert.equal(winnerAccount?.eloRating, expectedRatings.winnerRating);
+  assert.equal(await store.load(room.roomId), null);
 });
 
 test("room report player flow persists one report per room target pair and rejects duplicates", async (t) => {

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -1882,6 +1882,15 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
     };
   }
 
+  if (action.type !== "hero.collect") {
+    return {
+      world: view,
+      movementPlan: null,
+      reachableTiles: listReachableTilesInPlayerView(view, hero.id),
+      reason: "prediction_not_supported"
+    };
+  }
+
   const tile = findPlayerTile(view, action.position);
   if (!tile) {
     return {
@@ -1938,7 +1947,11 @@ export function predictPlayerWorldAction(view: PlayerWorldView, action: WorldAct
   };
 }
 
-export function validateWorldAction(state: WorldState, action: WorldAction): ValidationResult {
+export function validateWorldAction(
+  state: WorldState,
+  action: WorldAction,
+  requestingPlayerId?: string
+): ValidationResult {
   if (action.type === "turn.endDay") {
     return { valid: true };
   }
@@ -1946,6 +1959,14 @@ export function validateWorldAction(state: WorldState, action: WorldAction): Val
   const hero = state.heroes.find((item) => item.id === action.heroId);
   if (!hero) {
     return { valid: false, reason: "hero_not_found" };
+  }
+
+  if (requestingPlayerId && hero.playerId !== requestingPlayerId) {
+    return { valid: false, reason: "hero_not_owned_by_player" };
+  }
+
+  if (action.type === "world.surrender") {
+    return { valid: true };
   }
 
   if (action.type === "hero.move") {
@@ -2502,6 +2523,10 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
         }
       ]
     };
+  }
+
+  if (action.type !== "hero.collect") {
+    return { state, events: [] };
   }
 
   const hero = state.heroes.find((item) => item.id === action.heroId);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -583,6 +583,10 @@ export type WorldAction =
       slot: EquipmentType;
     }
   | {
+      type: "world.surrender";
+      heroId: string;
+    }
+  | {
       type: "turn.endDay";
     };
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -2,13 +2,15 @@ import type { BattleAction, BattleState, MovementPlan, Vec2, WorldAction, WorldE
 import type { PlayerWorldViewPayload } from "./map-sync.ts";
 import type { RuntimeConfigBundle } from "./world-config.ts";
 
+export type SessionStateReason = "surrender" | "afk_forfeit" | "normal" | (string & {});
+
 export interface SessionStatePayload {
   world: PlayerWorldViewPayload;
   battle: BattleState | null;
   events: WorldEvent[];
   movementPlan: MovementPlan | null;
   reachableTiles: Vec2[];
-  reason?: string;
+  reason?: SessionStateReason;
 }
 
 export type PlayerReportReason = "cheating" | "harassment" | "afk";

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -4759,6 +4759,48 @@ test("swamp tiles stay traversable but cost extra movement in world and player v
   );
 });
 
+test("validateWorldAction allows surrender only for the requesting player's hero", () => {
+  const heroOne = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 0 }
+  });
+  const heroTwo = createHero({
+    id: "hero-2",
+    playerId: "player-2",
+    name: "维恩",
+    position: { x: 1, y: 0 }
+  });
+  const state = createWorldState({
+    width: 2,
+    height: 2,
+    heroes: [heroOne, heroTwo],
+    tiles: [
+      createTile(0, 0, { occupant: { kind: "hero", refId: "hero-1" } }),
+      createTile(1, 0, { occupant: { kind: "hero", refId: "hero-2" } }),
+      createTile(0, 1),
+      createTile(1, 1)
+    ],
+    visibilityByPlayer: {
+      "player-1": ["visible", "visible", "visible", "visible"],
+      "player-2": ["visible", "visible", "visible", "visible"]
+    }
+  });
+
+  assert.deepEqual(validateWorldAction(state, { type: "world.surrender", heroId: "hero-1" }, "player-1"), {
+    valid: true
+  });
+  assert.deepEqual(validateWorldAction(state, { type: "world.surrender", heroId: "hero-1" }, "player-2"), {
+    valid: false,
+    reason: "hero_not_owned_by_player"
+  });
+  assert.deepEqual(validateWorldAction(state, { type: "world.surrender", heroId: "missing-hero" }, "player-1"), {
+    valid: false,
+    reason: "hero_not_found"
+  });
+});
+
 test("predictPlayerWorldAction updates the player view immediately for move and collect", () => {
   const hero = createHero({
     id: "hero-1",


### PR DESCRIPTION
## Summary
- add `world.surrender` across shared and mirrored Cocos contracts, plus ownership-aware validation and typed settlement reasons
- handle surrender on the server by applying winner/loser ELO updates, broadcasting a `surrender` settlement, and retiring the room
- add the Cocos HUD surrender button, confirmation dialog, settlement copy, and focused test coverage

## Validation
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `npm run typecheck:cocos`
- `node --import tsx --test --test-name-pattern "validateWorldAction allows surrender only for the requesting player's hero" packages/shared/test/shared-core.test.ts`
- `node --import tsx --test --test-name-pattern "surrender settles the room with the surrendering player as loser and persists ELO deltas" apps/server/test/colyseus-room-lifecycle.test.ts`
- `node --import tsx --test --test-name-pattern "VeilHudPanel shows the surrender action only when available and routes confirmation clicks" apps/cocos-client/test/cocos-hud-panel.test.ts`

Closes #830