### PR TITLE
feat: implement daily login rewards

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -98,8 +98,8 @@ import {
   triggerCocosRuntimeGc
 } from "./cocos-runtime-memory.ts";
 import {
-  buildCocosAchievementUnlockNotice,
-  collectAchievementUnlockEventIds,
+  buildCocosProfileNotice,
+  collectProfileNoticeEventIds,
   shouldRefreshGameplayAccountProfileForEvents
 } from "./cocos-achievements.ts";
 import {
@@ -320,7 +320,7 @@ export class VeilRoot extends Component {
   private loginProviders: CocosLoginProviderDescriptor[] = [];
   private audioRuntime = createCocosAudioRuntime(cocosPresentationConfig.audio);
   private pendingPixelSpriteGroups = new Set<"boot" | "battle">();
-  private seenAchievementUnlockEventIds = new Set<string>();
+  private seenProfileNoticeEventIds = new Set<string>();
   private wechatShareStatus = "分享功能仅在微信小游戏可用。";
   private wechatShareAvailable = false;
   private runtimeMemoryNotice = "";
@@ -3791,11 +3791,11 @@ export class VeilRoot extends Component {
 
   private commitAccountProfile(profile: CocosPlayerAccountProfile, allowAchievementNotice: boolean): void {
     if (profile.playerId !== this.lobbyAccountProfile.playerId) {
-      this.seenAchievementUnlockEventIds.clear();
+      this.seenProfileNoticeEventIds.clear();
     }
 
     if (allowAchievementNotice) {
-      const notice = buildCocosAchievementUnlockNotice(profile.recentEventLog, this.seenAchievementUnlockEventIds);
+      const notice = buildCocosProfileNotice(profile.recentEventLog, this.seenProfileNoticeEventIds);
       if (notice) {
         this.achievementNotice = {
           ...notice,
@@ -3805,8 +3805,8 @@ export class VeilRoot extends Component {
       }
     }
 
-    for (const eventId of collectAchievementUnlockEventIds(profile.recentEventLog)) {
-      this.seenAchievementUnlockEventIds.add(eventId);
+    for (const eventId of collectProfileNoticeEventIds(profile.recentEventLog)) {
+      this.seenProfileNoticeEventIds.add(eventId);
     }
 
     this.lobbyAccountProfile = profile;

--- a/apps/cocos-client/assets/scripts/cocos-achievements.ts
+++ b/apps/cocos-client/assets/scripts/cocos-achievements.ts
@@ -23,6 +23,7 @@ export interface CocosAchievementUnlockNotice {
 }
 
 const ACHIEVEMENT_UNLOCK_PREFIX = "解锁成就：";
+const DAILY_LOGIN_REWARD_PREFIX = "每日签到奖励：";
 const GAMEPLAY_ACCOUNT_REFRESH_EVENT_TYPES = new Set([
   "battle.started",
   "battle.resolved",
@@ -75,6 +76,34 @@ export function buildCocosAchievementUnlockNotice(
 
 export function collectAchievementUnlockEventIds(recentEventLog: EventLogEntry[]): string[] {
   return recentEventLog.filter(isAchievementUnlockedEventLogEntry).map((entry) => entry.id);
+}
+
+export function isDailyLoginRewardEventLogEntry(entry: EventLogEntry): boolean {
+  return entry.category === "account" && entry.description.startsWith(DAILY_LOGIN_REWARD_PREFIX);
+}
+
+export function buildCocosProfileNotice(
+  recentEventLog: EventLogEntry[],
+  seenEntryIds: ReadonlySet<string>
+): CocosAchievementUnlockNotice | null {
+  const dailyRewardEntry = recentEventLog.find(
+    (entry) => isDailyLoginRewardEventLogEntry(entry) && !seenEntryIds.has(entry.id)
+  );
+  if (dailyRewardEntry) {
+    return {
+      eventId: dailyRewardEntry.id,
+      title: "每日签到",
+      detail: dailyRewardEntry.description.slice(DAILY_LOGIN_REWARD_PREFIX.length).trim()
+    };
+  }
+
+  return buildCocosAchievementUnlockNotice(recentEventLog, seenEntryIds);
+}
+
+export function collectProfileNoticeEventIds(recentEventLog: EventLogEntry[]): string[] {
+  return recentEventLog
+    .filter((entry) => isDailyLoginRewardEventLogEntry(entry) || isAchievementUnlockedEventLogEntry(entry))
+    .map((entry) => entry.id);
 }
 
 export function shouldRefreshGameplayAccountProfileForEvents(eventTypes: string[]): boolean {

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -6,6 +6,7 @@ import {
   writeStoredCocosAuthSession
 } from "./cocos-session-launch.ts";
 import {
+  appendEventLogEntries,
   normalizePlayerBattleReportCenter,
   normalizePlayerBattleReplaySummaries,
   normalizePlayerAccountReadModel,
@@ -82,6 +83,8 @@ interface PlayerAccountApiPayload extends AuthSessionApiPayload {
     displayName?: string;
     avatarUrl?: string;
     eloRating?: number;
+    gems?: number;
+    loginStreak?: number;
     globalResources?: {
       gold?: number;
       wood?: number;
@@ -94,6 +97,16 @@ interface PlayerAccountApiPayload extends AuthSessionApiPayload {
     credentialBoundAt?: string;
     lastRoomId?: string;
     lastSeenAt?: string;
+  };
+}
+
+interface DailyClaimApiPayload {
+  claimed?: boolean;
+  reason?: string;
+  streak?: number;
+  reward?: {
+    gems?: number;
+    gold?: number;
   };
 }
 
@@ -379,6 +392,8 @@ function asCocosPlayerAccountProfile(
   const accountProfile = normalizePlayerAccountReadModel({
     playerId,
     displayName: normalizeDisplayName(playerId, account?.displayName ?? fallbackDisplayName),
+    gems: account?.gems,
+    loginStreak: account?.loginStreak,
     globalResources: account?.globalResources,
     eloRating: account?.eloRating,
     achievements: account?.achievements,
@@ -395,6 +410,93 @@ function asCocosPlayerAccountProfile(
     ...accountProfile,
     recentBattleReplays: accountProfile.recentBattleReplays ?? [],
     source
+  };
+}
+
+function createCocosDailyRewardEventLogEntry(
+  playerId: string,
+  roomId: string,
+  streak: number,
+  reward: { gems: number; gold: number },
+  timestamp = new Date().toISOString()
+): EventLogEntry {
+  const rewardSummary = [
+    reward.gems > 0 ? `宝石 x${reward.gems}` : null,
+    reward.gold > 0 ? `金币 x${reward.gold}` : null
+  ]
+    .filter((entry): entry is string => Boolean(entry))
+    .join("、");
+
+  return {
+    id: `${playerId}:${timestamp}:daily-login:${streak}:client`,
+    timestamp,
+    roomId,
+    playerId,
+    category: "account",
+    description: `每日签到奖励：连签第 ${streak} 天，获得 ${rewardSummary || "奖励已发放"}。`,
+    rewards: [
+      ...(reward.gems > 0 ? [{ type: "resource" as const, label: "gems", amount: reward.gems }] : []),
+      ...(reward.gold > 0 ? [{ type: "resource" as const, label: "gold", amount: reward.gold }] : [])
+    ]
+  };
+}
+
+async function claimCocosDailyLoginReward(
+  remoteUrl: string,
+  authSession: CocosStoredAuthSession,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "setItem" | "removeItem"> | null;
+  }
+): Promise<DailyClaimApiPayload | null> {
+  try {
+    return (await fetchCocosAuthJson(
+      remoteUrl,
+      `${resolveCocosApiBaseUrl(remoteUrl)}/api/player/daily-claim`,
+      {
+        method: "POST"
+      },
+      authSession,
+      {
+        ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        ...(options?.storage !== undefined ? { storage: options.storage } : {})
+      }
+    )) as DailyClaimApiPayload;
+  } catch {
+    return null;
+  }
+}
+
+function applyDailyClaimToProfile(
+  profile: CocosPlayerAccountProfile,
+  claim: DailyClaimApiPayload | null
+): CocosPlayerAccountProfile {
+  if (!claim?.claimed || !claim.reward) {
+    return profile;
+  }
+
+  const reward = {
+    gems: Math.max(0, Math.floor(claim.reward.gems ?? 0)),
+    gold: Math.max(0, Math.floor(claim.reward.gold ?? 0))
+  };
+  const streak = Math.max(1, Math.floor(claim.streak ?? 1));
+  const eventEntry = createCocosDailyRewardEventLogEntry(
+    profile.playerId,
+    profile.lastRoomId ?? "daily-login",
+    streak,
+    reward,
+    profile.recentEventLog[0]?.timestamp ?? new Date().toISOString()
+  );
+
+  return {
+    ...profile,
+    gems: (profile.gems ?? 0) + reward.gems,
+    loginStreak: streak,
+    globalResources: {
+      ...profile.globalResources,
+      gold: profile.globalResources.gold + reward.gold
+    },
+    recentEventLog: appendEventLogEntries(profile.recentEventLog, [eventEntry])
   };
 }
 
@@ -1300,8 +1402,19 @@ export async function loadCocosPlayerAccountProfile(
       battleReportCenter
     );
 
+    const profileWithDailyClaim =
+      authSession?.token && authSession
+        ? applyDailyClaimToProfile(
+            profile,
+            await claimCocosDailyLoginReward(remoteUrl, authSession, {
+              ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+              storage
+            })
+          )
+        : profile;
+
     if (storage?.setItem) {
-      storage.setItem(getCocosPlayerAccountStorageKey(profile.playerId), profile.displayName);
+      storage.setItem(getCocosPlayerAccountStorageKey(profileWithDailyClaim.playerId), profileWithDailyClaim.displayName);
     }
 
     if (authSession?.token && payload.session && storage) {
@@ -1309,7 +1422,7 @@ export async function loadCocosPlayerAccountProfile(
     }
 
     return {
-      ...profile,
+      ...profileWithDailyClaim,
       recentBattleReplays
     };
   } catch (error) {

--- a/apps/cocos-client/assets/scripts/project-shared/event-log.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/event-log.ts
@@ -1,7 +1,7 @@
 import { formatEquipmentRarityLabel } from "./equipment.ts";
 import type { FogState, ResourceKind, WorldEvent, WorldState } from "./models.ts";
 
-export type EventLogCategory = "movement" | "combat" | "building" | "skill" | "achievement";
+export type EventLogCategory = "movement" | "combat" | "building" | "skill" | "achievement" | "account";
 export type EventLogRewardType = "resource" | "experience" | "skill_point" | "badge";
 export type AchievementId = "first_battle" | "enemy_slayer" | "skill_scholar" | "world_explorer" | "epic_collector";
 export type AchievementMetric =

--- a/apps/cocos-client/assets/scripts/project-shared/player-account.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/player-account.ts
@@ -22,6 +22,8 @@ export interface PlayerAccountReadModel {
   displayName: string;
   avatarUrl?: string;
   eloRating?: number;
+  gems?: number;
+  loginStreak?: number;
   globalResources: ResourceLedger;
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
@@ -39,6 +41,8 @@ export interface PlayerAccountReadModelInput {
   displayName?: string | undefined;
   avatarUrl?: string | undefined;
   eloRating?: number | undefined;
+  gems?: number | undefined;
+  loginStreak?: number | undefined;
   globalResources?: Partial<ResourceLedger> | null | undefined;
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
@@ -60,6 +64,7 @@ export function normalizePlayerAccountReadModel(
   const loginId = account?.loginId?.trim().toLowerCase();
   const credentialBoundAt = account?.credentialBoundAt?.trim();
   const privacyConsentAt = account?.privacyConsentAt?.trim();
+  const loginStreak = Math.max(0, Math.floor(account?.loginStreak ?? 0));
   const lastRoomId = account?.lastRoomId?.trim();
   const lastSeenAt = account?.lastSeenAt?.trim();
   const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
@@ -70,6 +75,8 @@ export function normalizePlayerAccountReadModel(
     displayName: displayName || playerId || "player",
     ...(avatarUrl ? { avatarUrl } : {}),
     eloRating: normalizeEloRating(account?.eloRating),
+    gems: Math.max(0, Math.floor(account?.gems ?? 0)),
+    ...(loginStreak > 0 ? { loginStreak } : {}),
     globalResources: {
       gold: Math.max(0, Math.floor(account?.globalResources?.gold ?? 0)),
       wood: Math.max(0, Math.floor(account?.globalResources?.wood ?? 0)),

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -573,6 +573,8 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
             account: {
               playerId: "account-player",
               displayName: "暮潮守望",
+              gems: 12,
+              loginStreak: 4,
               loginId: "veil-ranger",
               lastRoomId: "room-beta",
               achievements: [
@@ -656,6 +658,25 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         );
       }
 
+      if (url.endsWith("/api/player/daily-claim")) {
+        return new Response(
+          JSON.stringify({
+            claimed: true,
+            streak: 5,
+            reward: {
+              gems: 5,
+              gold: 75
+            }
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json"
+            }
+          }
+        );
+      }
+
       return new Response(
         JSON.stringify({
           items: [
@@ -717,14 +738,17 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
   assert.deepEqual(requestedUrls, [
     "http://127.0.0.1:2567/api/player-accounts/me",
     "http://127.0.0.1:2567/api/player-accounts/me/battle-replays",
-    "http://127.0.0.1:2567/api/player-accounts/me/battle-reports"
+    "http://127.0.0.1:2567/api/player-accounts/me/battle-reports",
+    "http://127.0.0.1:2567/api/player/daily-claim"
   ]);
   assert.deepEqual(profile, {
     playerId: "account-player",
     displayName: "暮潮守望",
     eloRating: 1000,
+    gems: 17,
+    loginStreak: 5,
     globalResources: {
-      gold: 320,
+      gold: 395,
       wood: 5,
       ore: 2
     },
@@ -789,6 +813,18 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         description: "解锁成就：初次交锋",
         achievementId: "first_battle",
         rewards: [{ type: "badge", label: "初次交锋" }]
+      },
+      {
+        id: "account-player:2026-03-25T13:00:00.000Z:daily-login:5:client",
+        timestamp: "2026-03-25T13:00:00.000Z",
+        roomId: "room-beta",
+        playerId: "account-player",
+        category: "account",
+        description: "每日签到奖励：连签第 5 天，获得 宝石 x5、金币 x75。",
+        rewards: [
+          { type: "resource", label: "gems", amount: 5 },
+          { type: "resource", label: "gold", amount: 75 }
+        ]
       }
     ],
     recentBattleReplays: [

--- a/apps/server/src/daily-rewards.ts
+++ b/apps/server/src/daily-rewards.ts
@@ -1,0 +1,77 @@
+import dailyRewardsDocument from "../../../configs/daily-rewards.json";
+import { getMinorProtectionDateKey } from "./minor-protection";
+
+const DAILY_REWARD_TIME_ZONE = "Asia/Shanghai";
+
+export interface DailyRewardTier {
+  day: number;
+  gems: number;
+  gold: number;
+}
+
+interface DailyRewardsConfigDocument {
+  rewards?: Partial<DailyRewardTier>[] | null;
+}
+
+export interface DailyRewardGrant {
+  gems: number;
+  gold: number;
+}
+
+function normalizeNonNegativeInteger(value: number, field: string): number {
+  const normalized = Math.floor(value);
+  if (!Number.isFinite(value) || normalized < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
+  }
+
+  return normalized;
+}
+
+export function normalizeDailyRewardConfig(rawConfig?: Partial<DailyRewardsConfigDocument> | null): DailyRewardTier[] {
+  const rewards = rawConfig?.rewards ?? [];
+  if (rewards.length === 0) {
+    throw new Error("daily rewards config must define at least one reward");
+  }
+
+  return rewards.map((reward, index) => {
+    const day = Math.max(1, Math.floor(reward.day ?? index + 1));
+    return {
+      day,
+      gems: normalizeNonNegativeInteger(reward.gems ?? 0, `rewards[${index}].gems`),
+      gold: normalizeNonNegativeInteger(reward.gold ?? 0, `rewards[${index}].gold`)
+    };
+  });
+}
+
+export function resolveDailyRewardConfig(): DailyRewardTier[] {
+  return normalizeDailyRewardConfig(dailyRewardsDocument as DailyRewardsConfigDocument);
+}
+
+export function getDailyRewardDateKey(date = new Date()): string {
+  return getMinorProtectionDateKey(date, DAILY_REWARD_TIME_ZONE);
+}
+
+export function getPreviousDailyRewardDateKey(dateKey: string): string {
+  const parsed = new Date(`${dateKey}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("dateKey must be a valid YYYY-MM-DD date");
+  }
+  parsed.setUTCDate(parsed.getUTCDate() - 1);
+  return parsed.toISOString().slice(0, 10);
+}
+
+export function resolveDailyRewardForStreak(
+  streak: number,
+  rewardConfig: DailyRewardTier[] = resolveDailyRewardConfig()
+): DailyRewardGrant {
+  const safeStreak = Math.max(1, Math.floor(streak));
+  const reward = rewardConfig[(safeStreak - 1) % rewardConfig.length];
+  if (!reward) {
+    throw new Error("daily rewards config must define at least one reward");
+  }
+
+  return {
+    gems: reward.gems,
+    gold: reward.gold
+  };
+}

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -178,6 +178,7 @@ interface PlayerAccountRow extends RowDataPacket {
   is_minor: number | boolean | null;
   daily_play_minutes: number | null;
   last_play_date: Date | string | null;
+  login_streak: number | null;
   ban_status: string | null;
   ban_expiry: Date | string | null;
   ban_reason: string | null;
@@ -488,12 +489,14 @@ export interface PlayerAccountProfilePatch {
 }
 
 export interface PlayerAccountProgressPatch {
+  gems?: number;
   globalResources?: Partial<ResourceLedger> | null;
   achievements?: Partial<PlayerAchievementProgress>[] | null;
   recentEventLog?: Partial<EventLogEntry>[] | null;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null;
   dailyPlayMinutes?: number | null;
   lastPlayDate?: string | null;
+  loginStreak?: number | null;
   lastRoomId?: string | null;
   eloRating?: number;
 }
@@ -950,6 +953,10 @@ function normalizeDailyPlayMinutes(minutes?: number | null): number {
   return Math.max(0, Math.floor(minutes ?? 0));
 }
 
+function normalizeLoginStreak(streak?: number | null): number {
+  return Math.max(0, Math.floor(streak ?? 0));
+}
+
 function normalizeGemAmount(amount?: number | null): number {
   return Math.max(0, Math.floor(amount ?? 0));
 }
@@ -1088,6 +1095,7 @@ function normalizePlayerAccountSnapshot(account: {
   isMinor?: boolean | number | null | undefined;
   dailyPlayMinutes?: number | null | undefined;
   lastPlayDate?: string | Date | null | undefined;
+  loginStreak?: number | null | undefined;
   banStatus?: PlayerBanStatus | null | undefined;
   banExpiry?: string | undefined;
   banReason?: string | null | undefined;
@@ -1132,6 +1140,7 @@ function normalizePlayerAccountSnapshot(account: {
       isMinor: normalizePlayerIsMinor(account.isMinor),
       dailyPlayMinutes: normalizeDailyPlayMinutes(account.dailyPlayMinutes),
       lastPlayDate: normalizeLastPlayDate(account.lastPlayDate),
+      loginStreak: normalizeLoginStreak(account.loginStreak),
       banStatus: normalizePlayerBanStatus(account.banStatus),
       banExpiry: normalizePlayerBanExpiry(account.banExpiry),
       banReason: normalizePlayerBanReason(account.banReason)
@@ -1420,6 +1429,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   is_minor TINYINT(1) NOT NULL DEFAULT 0,
   daily_play_minutes INT NOT NULL DEFAULT 0,
   last_play_date DATE NULL DEFAULT NULL,
+  login_streak INT NOT NULL DEFAULT 0,
   ban_status VARCHAR(16) NOT NULL DEFAULT 'none',
   ban_expiry DATETIME NULL DEFAULT NULL,
   ban_reason VARCHAR(512) NULL,
@@ -1814,6 +1824,24 @@ SET @veil_player_accounts_last_play_date_sql := IF(
 PREPARE veil_player_accounts_last_play_date_stmt FROM @veil_player_accounts_last_play_date_sql;
 EXECUTE veil_player_accounts_last_play_date_stmt;
 DEALLOCATE PREPARE veil_player_accounts_last_play_date_stmt;
+
+SET @veil_player_accounts_login_streak_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'login_streak'
+);
+
+SET @veil_player_accounts_login_streak_sql := IF(
+  @veil_player_accounts_login_streak_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`login_streak\` INT NOT NULL DEFAULT 0 AFTER \`last_play_date\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_login_streak_stmt FROM @veil_player_accounts_login_streak_sql;
+EXECUTE veil_player_accounts_login_streak_stmt;
+DEALLOCATE PREPARE veil_player_accounts_login_streak_stmt;
 
 SET @veil_player_accounts_ban_status_exists := (
   SELECT COUNT(*)
@@ -2462,6 +2490,7 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
       ? { dailyPlayMinutes: normalizeDailyPlayMinutes(row.daily_play_minutes) }
       : {}),
     ...(normalizeLastPlayDate(row.last_play_date) ? { lastPlayDate: normalizeLastPlayDate(row.last_play_date) } : {}),
+    ...(normalizeLoginStreak(row.login_streak) > 0 ? { loginStreak: normalizeLoginStreak(row.login_streak) } : {}),
     banStatus: normalizePlayerBanStatus(row.ban_status),
     ...(banExpiry ? { banExpiry } : {}),
     ...(row.ban_reason ? { banReason: row.ban_reason } : {}),
@@ -2723,9 +2752,10 @@ async function savePlayerAccounts(
          achievements_json,
          recent_event_log_json
          ,
-         recent_battle_replays_json
+         recent_battle_replays_json,
+         login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(display_name, VALUES(display_name)),
          elo_rating = COALESCE(elo_rating, VALUES(elo_rating)),
@@ -2734,6 +2764,7 @@ async function savePlayerAccounts(
          achievements_json = COALESCE(achievements_json, VALUES(achievements_json)),
          recent_event_log_json = COALESCE(recent_event_log_json, VALUES(recent_event_log_json)),
          recent_battle_replays_json = COALESCE(recent_battle_replays_json, VALUES(recent_battle_replays_json)),
+         login_streak = VALUES(login_streak),
          version = version + 1`,
       [
         normalizedAccount.playerId,
@@ -2743,7 +2774,8 @@ async function savePlayerAccounts(
         JSON.stringify(normalizedAccount.globalResources),
         JSON.stringify(normalizedAccount.achievements),
         JSON.stringify(normalizedAccount.recentEventLog),
-        JSON.stringify(normalizedAccount.recentBattleReplays)
+        JSON.stringify(normalizedAccount.recentBattleReplays),
+        normalizeLoginStreak(normalizedAccount.loginStreak)
       ]
     );
     await appendPlayerEventHistoryEntries(connection, normalizedAccount.playerId, normalizedAccount.recentEventLog);
@@ -2983,6 +3015,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          is_minor,
          daily_play_minutes,
          last_play_date,
+         login_streak,
          ban_status,
          ban_expiry,
          ban_reason,
@@ -3031,6 +3064,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          is_minor,
          daily_play_minutes,
          last_play_date,
+         login_streak,
          ban_status,
          ban_expiry,
          ban_reason,
@@ -3163,6 +3197,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          is_minor,
          daily_play_minutes,
          last_play_date,
+         login_streak,
          ban_status,
          ban_expiry,
          ban_reason,
@@ -4230,6 +4265,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
            is_minor = 0,
            daily_play_minutes = 0,
            last_play_date = NULL,
+           login_streak = 0,
            ban_status = 'none',
            ban_expiry = NULL,
            ban_reason = NULL,
@@ -4420,6 +4456,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     const nextAccount = normalizePlayerAccountSnapshot({
       ...existing,
       playerId: normalizedPlayerId,
+      ...(patch.gems !== undefined ? { gems: patch.gems } : {}),
       globalResources: patch.globalResources ?? existing.globalResources,
       achievements: patch.achievements ?? existing.achievements,
       recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
@@ -4428,6 +4465,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         patch.dailyPlayMinutes !== undefined ? normalizeDailyPlayMinutes(patch.dailyPlayMinutes) : existing.dailyPlayMinutes,
       lastPlayDate:
         patch.lastPlayDate !== undefined ? normalizeLastPlayDate(patch.lastPlayDate) : existing.lastPlayDate,
+      loginStreak: patch.loginStreak !== undefined ? normalizeLoginStreak(patch.loginStreak) : existing.loginStreak,
       ...(patch.eloRating !== undefined ? { eloRating: patch.eloRating } : {}),
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId
@@ -4455,12 +4493,14 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          age_verified,
          is_minor,
          daily_play_minutes,
-         last_play_date
+         last_play_date,
+         login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = COALESCE(avatar_url, VALUES(avatar_url)),
+         gems = VALUES(gems),
          elo_rating = VALUES(elo_rating),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = VALUES(achievements_json),
@@ -4472,6 +4512,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          is_minor = VALUES(is_minor),
          daily_play_minutes = VALUES(daily_play_minutes),
          last_play_date = VALUES(last_play_date),
+         login_streak = VALUES(login_streak),
          version = version + 1`,
       [
         nextAccount.playerId,
@@ -4488,7 +4529,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         nextAccount.ageVerified === true ? 1 : 0,
         nextAccount.isMinor === true ? 1 : 0,
         normalizeDailyPlayMinutes(nextAccount.dailyPlayMinutes),
-        nextAccount.lastPlayDate ? new Date(nextAccount.lastPlayDate) : null
+        nextAccount.lastPlayDate ? new Date(nextAccount.lastPlayDate) : null,
+        normalizeLoginStreak(nextAccount.loginStreak)
       ]
     );
     await appendPlayerEventHistoryEntries(this.pool, normalizedPlayerId, newHistoryEntries);

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  appendEventLogEntries,
   applyBattleReplayPlaybackCommand,
   buildPlayerBattleReportCenter,
   buildPlayerProgressionSnapshot,
@@ -28,6 +29,7 @@ import type {
   PlayerEventHistoryQuery,
   RoomSnapshotStore
 } from "./persistence";
+import { getDailyRewardDateKey, getPreviousDailyRewardDateKey, resolveDailyRewardForStreak } from "./daily-rewards";
 import { decryptWechatPhoneNumber, validateWechatSignature } from "./wechat-session-key";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -467,6 +469,33 @@ function sendForbidden(response: ServerResponse): void {
   });
 }
 
+function createDailyRewardEventLogEntry(
+  playerId: string,
+  streak: number,
+  reward: { gems: number; gold: number },
+  timestamp = new Date().toISOString()
+) {
+  const rewardSummary = [
+    reward.gems > 0 ? `宝石 x${reward.gems}` : null,
+    reward.gold > 0 ? `金币 x${reward.gold}` : null
+  ]
+    .filter((entry): entry is string => Boolean(entry))
+    .join("、");
+
+  return {
+    id: `${playerId}:${timestamp}:daily-login:${streak}`,
+    timestamp,
+    roomId: "daily-login",
+    playerId,
+    category: "account" as const,
+    description: `每日签到奖励：连签第 ${streak} 天，获得 ${rewardSummary || "奖励已发放"}。`,
+    rewards: [
+      ...(reward.gems > 0 ? [{ type: "resource" as const, label: "gems", amount: reward.gems }] : []),
+      ...(reward.gold > 0 ? [{ type: "resource" as const, label: "gold", amount: reward.gold }] : [])
+    ]
+  };
+}
+
 async function requireAuthSession(
   request: IncomingMessage,
   response: ServerResponse,
@@ -620,6 +649,62 @@ export function registerPlayerAccountRoutes(
       sendJson(response, 200, {
         account: withBattleReportCenter(account),
         session: issueNextAuthSession(account, authSession)
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/player/daily-claim", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 200, {
+        claimed: false,
+        reason: "persistence_unavailable"
+      });
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      const today = getDailyRewardDateKey();
+      if (account.lastPlayDate === today) {
+        sendJson(response, 200, {
+          claimed: false,
+          reason: "already_claimed_today"
+        });
+        return;
+      }
+
+      const streak = account.lastPlayDate === getPreviousDailyRewardDateKey(today) ? Math.max(0, account.loginStreak ?? 0) + 1 : 1;
+      const reward = resolveDailyRewardForStreak(streak);
+      const eventEntry = createDailyRewardEventLogEntry(account.playerId, streak, reward);
+
+      await store.savePlayerAccountProgress(account.playerId, {
+        gems: (account.gems ?? 0) + reward.gems,
+        globalResources: {
+          ...account.globalResources,
+          gold: (account.globalResources.gold ?? 0) + reward.gold
+        },
+        recentEventLog: appendEventLogEntries(account.recentEventLog, [eventEntry]),
+        lastPlayDate: today,
+        dailyPlayMinutes: 0,
+        loginStreak: streak
+      });
+
+      sendJson(response, 200, {
+        claimed: true,
+        streak,
+        reward
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -3,6 +3,7 @@ import { createCipheriv, createHash } from "node:crypto";
 import test from "node:test";
 import { Server, WebSocketTransport } from "colyseus";
 import { issueAccountAuthSession, issueGuestAuthSession, issueWechatMiniGameAuthSession, hashAccountPassword } from "../src/auth";
+import { getDailyRewardDateKey, getPreviousDailyRewardDateKey } from "../src/daily-rewards";
 import { applyPlayerEventLogAndAchievements } from "../src/player-achievements";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import { cacheWechatSessionKey, resetWechatSessionKeyCache } from "../src/wechat-session-key";
@@ -36,6 +37,12 @@ import {
   type PlayerBattleReplaySummary,
   type WorldState
 } from "../../../packages/shared/src/index";
+
+function getRelativeDailyRewardDateKey(baseDateKey: string, deltaDays: number): string {
+  const parsed = new Date(`${baseDateKey}T00:00:00.000Z`);
+  parsed.setUTCDate(parsed.getUTCDate() + deltaDays);
+  return parsed.toISOString().slice(0, 10);
+}
 
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
@@ -177,6 +184,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ...(existing?.isMinor ? { isMinor: existing.isMinor } : {}),
       ...(existing?.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
       ...(existing?.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
+      ...(existing?.loginStreak ? { loginStreak: existing.loginStreak } : {}),
       ...(existing?.banStatus ? { banStatus: existing.banStatus } : {}),
       ...(existing?.banExpiry ? { banExpiry: existing.banExpiry } : {}),
       ...(existing?.banReason ? { banReason: existing.banReason } : {}),
@@ -483,6 +491,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     const existing = await this.ensurePlayerAccount({ playerId });
     const account: PlayerAccountSnapshot = {
       ...existing,
+      ...(patch.gems !== undefined ? { gems: Math.max(0, Math.floor(patch.gems ?? 0)) } : {}),
       globalResources: structuredClone(
         (patch.globalResources as PlayerAccountSnapshot["globalResources"] | undefined) ?? existing.globalResources
       ),
@@ -493,6 +502,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ),
       ...(patch.dailyPlayMinutes !== undefined ? { dailyPlayMinutes: Math.max(0, Math.floor(patch.dailyPlayMinutes ?? 0)) } : existing.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
       ...(patch.lastPlayDate !== undefined ? (patch.lastPlayDate ? { lastPlayDate: patch.lastPlayDate.trim() } : {}) : existing.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
+      ...(patch.loginStreak !== undefined ? { loginStreak: Math.max(0, Math.floor(patch.loginStreak ?? 0)) } : existing.loginStreak ? { loginStreak: existing.loginStreak } : {}),
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId?.trim()
           ? { lastRoomId: patch.lastRoomId.trim() }
@@ -2662,4 +2672,191 @@ test("player deletion anonymizes personal data, clears wechat bindings, and revo
   };
   assert.equal(meResponse.status, 401);
   assert.equal(mePayload.error.code, "session_revoked");
+});
+
+test("daily claim increments streak and grants the configured consecutive-day reward", async (t) => {
+  const port = 44860 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  const today = getDailyRewardDateKey();
+  const yesterday = getPreviousDailyRewardDateKey(today);
+  await store.ensurePlayerAccount({
+    playerId: "daily-streak",
+    displayName: "晨星巡游者"
+  });
+  await store.savePlayerAccountProgress("daily-streak", {
+    gems: 20,
+    globalResources: { gold: 100, wood: 0, ore: 0 },
+    lastPlayDate: yesterday,
+    loginStreak: 1,
+    dailyPlayMinutes: 33
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "daily-streak",
+    displayName: "晨星巡游者"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const claimResponse = await fetch(`http://127.0.0.1:${port}/api/player/daily-claim`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const claimPayload = (await claimResponse.json()) as {
+    claimed: boolean;
+    streak: number;
+    reward: { gems: number; gold: number };
+  };
+
+  assert.equal(claimResponse.status, 200);
+  assert.equal(claimPayload.claimed, true);
+  assert.equal(claimPayload.streak, 2);
+  assert.deepEqual(claimPayload.reward, { gems: 5, gold: 75 });
+
+  const account = await store.loadPlayerAccount("daily-streak");
+  assert.equal(account?.gems, 25);
+  assert.equal(account?.globalResources.gold, 175);
+  assert.equal(account?.loginStreak, 2);
+  assert.equal(account?.lastPlayDate, today);
+  assert.equal(account?.dailyPlayMinutes, 0);
+  assert.match(account?.recentEventLog[0]?.description ?? "", /^每日签到奖励：连签第 2 天/);
+});
+
+test("daily claim resets the streak after a gap", async (t) => {
+  const port = 44880 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  const today = getDailyRewardDateKey();
+  const twoDaysAgo = getRelativeDailyRewardDateKey(today, -2);
+  await store.ensurePlayerAccount({
+    playerId: "daily-reset",
+    displayName: "断潮旅者"
+  });
+  await store.savePlayerAccountProgress("daily-reset", {
+    gems: 40,
+    globalResources: { gold: 10, wood: 0, ore: 0 },
+    lastPlayDate: twoDaysAgo,
+    loginStreak: 6
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "daily-reset",
+    displayName: "断潮旅者"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const claimResponse = await fetch(`http://127.0.0.1:${port}/api/player/daily-claim`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const claimPayload = (await claimResponse.json()) as {
+    claimed: boolean;
+    streak: number;
+    reward: { gems: number; gold: number };
+  };
+
+  assert.equal(claimPayload.claimed, true);
+  assert.equal(claimPayload.streak, 1);
+  assert.deepEqual(claimPayload.reward, { gems: 5, gold: 50 });
+
+  const account = await store.loadPlayerAccount("daily-reset");
+  assert.equal(account?.loginStreak, 1);
+  assert.equal(account?.gems, 45);
+  assert.equal(account?.globalResources.gold, 60);
+});
+
+test("daily claim cycles reward tiers after day seven", async (t) => {
+  const port = 44900 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  const yesterday = getPreviousDailyRewardDateKey(getDailyRewardDateKey());
+  await store.ensurePlayerAccount({
+    playerId: "daily-cycle",
+    displayName: "七曜守门人"
+  });
+  await store.savePlayerAccountProgress("daily-cycle", {
+    gems: 0,
+    globalResources: { gold: 0, wood: 0, ore: 0 },
+    lastPlayDate: yesterday,
+    loginStreak: 7
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "daily-cycle",
+    displayName: "七曜守门人"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const claimResponse = await fetch(`http://127.0.0.1:${port}/api/player/daily-claim`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const claimPayload = (await claimResponse.json()) as {
+    claimed: boolean;
+    streak: number;
+    reward: { gems: number; gold: number };
+  };
+
+  assert.equal(claimPayload.claimed, true);
+  assert.equal(claimPayload.streak, 8);
+  assert.deepEqual(claimPayload.reward, { gems: 5, gold: 50 });
+});
+
+test("daily claim rejects duplicate claims on the same day", async (t) => {
+  const port = 44920 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  const today = getDailyRewardDateKey();
+  await store.ensurePlayerAccount({
+    playerId: "daily-claimed",
+    displayName: "雾港登记员"
+  });
+  await store.savePlayerAccountProgress("daily-claimed", {
+    gems: 9,
+    globalResources: { gold: 18, wood: 0, ore: 0 },
+    lastPlayDate: today,
+    loginStreak: 3
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "daily-claimed",
+    displayName: "雾港登记员"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const claimResponse = await fetch(`http://127.0.0.1:${port}/api/player/daily-claim`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const claimPayload = (await claimResponse.json()) as {
+    claimed: boolean;
+    reason: string;
+  };
+
+  assert.equal(claimResponse.status, 200);
+  assert.deepEqual(claimPayload, {
+    claimed: false,
+    reason: "already_claimed_today"
+  });
+
+  const account = await store.loadPlayerAccount("daily-claimed");
+  assert.equal(account?.gems, 9);
+  assert.equal(account?.globalResources.gold, 18);
+  assert.equal(account?.loginStreak, 3);
 });

--- a/configs/daily-rewards.json
+++ b/configs/daily-rewards.json
@@ -1,0 +1,11 @@
+{
+  "rewards": [
+    { "day": 1, "gems": 5, "gold": 50 },
+    { "day": 2, "gems": 5, "gold": 75 },
+    { "day": 3, "gems": 10, "gold": 100 },
+    { "day": 4, "gems": 5, "gold": 75 },
+    { "day": 5, "gems": 5, "gold": 75 },
+    { "day": 6, "gems": 10, "gold": 100 },
+    { "day": 7, "gems": 30, "gold": 200 }
+  ]
+}

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -21,6 +21,7 @@ export interface PlayerAccountReadModel {
   avatarUrl?: string;
   eloRating?: number;
   gems?: number;
+  loginStreak?: number;
   globalResources: ResourceLedger;
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
@@ -48,6 +49,7 @@ export interface PlayerAccountReadModelInput {
   avatarUrl?: string | undefined;
   eloRating?: number | undefined;
   gems?: number | undefined;
+  loginStreak?: number | undefined;
   globalResources?: Partial<ResourceLedger> | null | undefined;
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
@@ -83,6 +85,7 @@ export function normalizePlayerAccountReadModel(
   const ageVerified = account?.ageVerified === true;
   const isMinor = account?.isMinor === true;
   const dailyPlayMinutes = Math.max(0, Math.floor(account?.dailyPlayMinutes ?? 0));
+  const loginStreak = Math.max(0, Math.floor(account?.loginStreak ?? 0));
   const lastPlayDate = /^\d{4}-\d{2}-\d{2}$/.test(account?.lastPlayDate?.trim() ?? "")
     ? account?.lastPlayDate?.trim()
     : undefined;
@@ -100,6 +103,7 @@ export function normalizePlayerAccountReadModel(
     ...(avatarUrl ? { avatarUrl } : {}),
     eloRating: normalizeEloRating(account?.eloRating),
     gems: Math.max(0, Math.floor(account?.gems ?? 0)),
+    ...(loginStreak > 0 ? { loginStreak } : {}),
     globalResources: {
       gold: Math.max(0, Math.floor(account?.globalResources?.gold ?? 0)),
       wood: Math.max(0, Math.floor(account?.globalResources?.wood ?? 0)),

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1410,13 +1410,15 @@ test("player account read model helper normalizes minor protection fields", () =
     ageVerified: true,
     isMinor: true,
     dailyPlayMinutes: 91.8,
-    lastPlayDate: " 2026-04-03 "
+    lastPlayDate: " 2026-04-03 ",
+    loginStreak: 4.9
   });
 
   assert.equal(account.ageVerified, true);
   assert.equal(account.isMinor, true);
   assert.equal(account.dailyPlayMinutes, 91);
   assert.equal(account.lastPlayDate, "2026-04-03");
+  assert.equal(account.loginStreak, 4);
 });
 
 test("player account read model helper falls back to empty progression collections", () => {


### PR DESCRIPTION
## Summary
- add a new authenticated `/api/player/daily-claim` route with UTC+8 streak tracking and looping gem/gold reward tiers
- persist `loginStreak` on player accounts, update the reward config, and append a daily-login account event when a claim succeeds
- trigger the claim from the Cocos lobby profile load and surface the reward through the existing profile notice flow

## Validation
- `node --import tsx --test ./packages/shared/test/shared-core.test.ts`
- `node --import tsx --test ./apps/server/test/player-account-routes.test.ts`
- `node --import tsx --test ./apps/cocos-client/test/cocos-lobby.test.ts`
- `npm run typecheck:server`
- `npm run typecheck:cocos`
- `npm run typecheck:shared`

Closes #831.
