### PR TITLE
feat: implement PVP turn timer and AFK auto-forfeit

### DIFF
--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -54,6 +54,8 @@ interface BattleBalanceConfig {
     trapCharges: number;
     trapGrantedStatusId?: string;
   };
+  turnTimerSeconds: number;
+  afkStrikesBeforeForfeit: number;
   pvp: {
     eloK: number;
   };
@@ -1526,6 +1528,14 @@ function renderBattleBalanceEditorSection(): string {
               <span>ELO K 因子</span>
               <input type="number" min="1" step="1" value="${config.pvp.eloK}" data-role="battle-balance-field" data-section="pvp" data-field="eloK" />
             </label>
+            <label>
+              <span>回合计时 秒数</span>
+              <input type="number" min="1" step="1" value="${config.turnTimerSeconds}" data-role="battle-balance-field" data-section="root" data-field="turnTimerSeconds" />
+            </label>
+            <label>
+              <span>挂机判负阈值</span>
+              <input type="number" min="1" step="1" value="${config.afkStrikesBeforeForfeit}" data-role="battle-balance-field" data-section="root" data-field="afkStrikesBeforeForfeit" />
+            </label>
           </div>
         </article>
       </div>
@@ -1997,7 +2007,7 @@ function bindSkillEditorControls(): void {
 function bindBattleBalanceEditorControls(): void {
   document.querySelectorAll<HTMLInputElement>("[data-role='battle-balance-field']").forEach((field) => {
     field.onchange = () => {
-      const section = field.dataset.section as "damage" | "environment" | "pvp" | undefined;
+      const section = field.dataset.section as "damage" | "environment" | "pvp" | "root" | undefined;
       const key = field.dataset.field;
       if (!section || !key) {
         return;
@@ -2006,7 +2016,12 @@ function bindBattleBalanceEditorControls(): void {
       updateBattleBalanceDraft((config) => {
         const numericValue = Number(field.value);
         const nextValue =
-          key === "blockerDurability" || key === "trapDamage" || key === "trapCharges" || key === "eloK"
+          key === "blockerDurability" ||
+          key === "trapDamage" ||
+          key === "trapCharges" ||
+          key === "eloK" ||
+          key === "turnTimerSeconds" ||
+          key === "afkStrikesBeforeForfeit"
             ? Math.floor(Number.isFinite(numericValue) ? numericValue : 0)
             : Number.isFinite(numericValue)
               ? numericValue
@@ -2016,6 +2031,8 @@ function bindBattleBalanceEditorControls(): void {
           config.damage[key as keyof BattleBalanceConfig["damage"]] = nextValue;
         } else if (section === "environment") {
           config.environment[key as Exclude<keyof BattleBalanceConfig["environment"], "trapGrantedStatusId">] = nextValue;
+        } else if (section === "root") {
+          config[key as "turnTimerSeconds" | "afkStrikesBeforeForfeit"] = nextValue;
         } else {
           config.pvp[key as keyof BattleBalanceConfig["pvp"]] = nextValue;
         }

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -111,6 +111,7 @@ export interface PlayerWorldView {
     seed: number;
     day: number;
   };
+  turnDeadlineAt?: string;
   map: {
     width: number;
     height: number;
@@ -572,6 +573,10 @@ export type BattleAction =
       unitId: string;
     }
   | {
+      type: "battle.pass";
+      unitId: string;
+    }
+  | {
       type: "battle.skill";
       unitId: string;
       skillId: BattleSkillId;
@@ -625,6 +630,13 @@ type ServerMessage =
       requestId: string;
       delivery?: "reply" | "push";
       payload: SessionStatePayload;
+    }
+  | {
+      type: "turn.timer";
+      requestId: "push";
+      delivery: "push";
+      remainingMs: number;
+      turnOwnerPlayerId: string;
     }
   | {
       type: "world.reachable";

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -44,6 +44,8 @@ const HUD_INNER = new Color(39, 53, 74, 88);
 const HUD_BORDER = new Color(238, 244, 252, 78);
 export const HUD_ACCENT = new Color(214, 184, 124, 255);
 const HUD_ACCENT_SOFT = new Color(244, 225, 179, 96);
+const HUD_TIMER_WARNING = new Color(228, 78, 78, 255);
+const HUD_TIMER_WARNING_SOFT = new Color(255, 198, 198, 255);
 const HUD_CARD_RESOURCE = new Color(84, 118, 160, 176);
 const HUD_CARD_HERO = new Color(132, 112, 176, 172);
 const HUD_CARD_STATUS = new Color(204, 170, 106, 182);
@@ -54,6 +56,7 @@ const EQUIPMENT_NODE_NAME = "HudEquipment";
 const SKILLS_NODE_NAME = "HudSkills";
 const STATUS_NODE_NAME = "HudStatus";
 const DEBUG_NODE_NAME = "HudDebug";
+const TURN_TIMER_NODE_NAME = "HudTurnTimer";
 const HEADER_ICON_NODE_NAME = "HudHeaderIcon";
 const WATERMARK_NODE_NAME = "HudWatermark";
 const ACTIONS_NODE_NAME = "HudActions";
@@ -329,6 +332,7 @@ export class VeilHudPanel extends Component {
   private skillLabel: Label | null = null;
   private statusLabel: Label | null = null;
   private debugLabel: Label | null = null;
+  private turnTimerLabel: Label | null = null;
   private headerIconSprite: Sprite | null = null;
   private headerIconOpacity: UIOpacity | null = null;
   private currentState: VeilHudRenderState | null = null;
@@ -385,6 +389,7 @@ export class VeilHudPanel extends Component {
     this.syncHeaderIcon();
     this.syncActionButtons();
     this.ensureSectionLabels();
+    this.turnTimerLabel = this.ensureTurnTimerLabel();
     const hero = state.update?.world.ownHeroes[0] ?? null;
     const world = state.update?.world;
     const resources = world?.resources;
@@ -603,6 +608,11 @@ export class VeilHudPanel extends Component {
     if (debugCard) {
       debugCard.active = showDebug;
     }
+    this.refreshTurnTimerLabel();
+  }
+
+  update(): void {
+    this.refreshTurnTimerLabel();
   }
 
   dispatchPointerUp(localX: number, localY: number): string | null {
@@ -759,6 +769,52 @@ export class VeilHudPanel extends Component {
     this.skillLabel = this.ensureLabelNode(SKILLS_NODE_NAME, 16, 22, 92);
     this.statusLabel = this.ensureLabelNode(STATUS_NODE_NAME, 17, 22, 70);
     this.debugLabel = this.ensureLabelNode(DEBUG_NODE_NAME, 14, 18, 50);
+  }
+
+  private ensureTurnTimerLabel(): Label {
+    const existingNode = this.node.getChildByName(TURN_TIMER_NODE_NAME);
+    const node = existingNode ?? new Node(TURN_TIMER_NODE_NAME);
+    if (!existingNode) {
+      node.parent = this.node;
+    }
+    assignUiLayer(node);
+
+    const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+    transform.setContentSize(132, 28);
+    const label = node.getComponent(Label) ?? node.addComponent(Label);
+    label.fontSize = 16;
+    label.lineHeight = 20;
+    label.horizontalAlign = H_ALIGN_CENTER;
+    label.verticalAlign = V_ALIGN_MIDDLE;
+    label.enableWrapText = false;
+    label.string = "";
+    return label;
+  }
+
+  private refreshTurnTimerLabel(): void {
+    const label = this.turnTimerLabel ?? this.ensureTurnTimerLabel();
+    const deadlineAt = this.currentState?.update?.world.turnDeadlineAt ?? null;
+    if (!deadlineAt) {
+      label.node.active = false;
+      return;
+    }
+
+    const deadlineMs = Date.parse(deadlineAt);
+    if (Number.isNaN(deadlineMs)) {
+      label.node.active = false;
+      return;
+    }
+
+    const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const remainingMs = Math.max(0, deadlineMs - Date.now());
+    const remainingSeconds = Math.max(0, Math.ceil(remainingMs / 1_000));
+    const minutes = Math.floor(remainingSeconds / 60);
+    const seconds = remainingSeconds % 60;
+    const inWarningWindow = remainingMs <= 10_000;
+    label.node.active = true;
+    label.node.setPosition(transform.width / 2 - 82, transform.height / 2 - 62, 3);
+    label.string = `倒计时 ${minutes}:${seconds.toString().padStart(2, "0")}`;
+    label.color = inWarningWindow && Math.floor(Date.now() / 250) % 2 === 0 ? HUD_TIMER_WARNING : inWarningWindow ? HUD_TIMER_WARNING_SOFT : HUD_ACCENT;
   }
 
   private ensureLabelNode(name: string, fontSize: number, lineHeight: number, height: number): Label {

--- a/apps/cocos-client/assets/scripts/project-shared/battle.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle.ts
@@ -1413,7 +1413,7 @@ export function executeBattleSkill(
 }
 
 export function validateBattleAction(state: BattleState, action: BattleAction): ValidationResult {
-  if (action.type === "battle.wait" || action.type === "battle.defend") {
+  if (action.type === "battle.wait" || action.type === "battle.defend" || action.type === "battle.pass") {
     if (state.activeUnitId !== action.unitId) {
       return { valid: false, reason: "unit_not_active" };
     }
@@ -1883,6 +1883,17 @@ export function applyBattleAction(state: BattleState, action: BattleAction): Bat
           }
         },
         log: normalizedState.log.concat(`${action.unitId} 进入防御`)
+      },
+      action.unitId,
+      false
+    );
+  }
+
+  if (action.type === "battle.pass") {
+    return advanceTurn(
+      {
+        ...normalizedState,
+        log: normalizedState.log.concat(`${action.unitId} 选择跳过`)
       },
       action.unitId,
       false

--- a/apps/cocos-client/assets/scripts/project-shared/models.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/models.ts
@@ -118,6 +118,8 @@ export interface BattleEnvironmentBalanceConfig {
 export interface BattleBalanceConfig {
   damage: BattleDamageBalanceConfig;
   environment: BattleEnvironmentBalanceConfig;
+  turnTimerSeconds: number;
+  afkStrikesBeforeForfeit: number;
   pvp: {
     eloK: number;
   };
@@ -340,6 +342,8 @@ export interface WorldState {
   buildings: Record<string, MapBuildingState>;
   resources: WorldResourceLedger;
   visibilityByPlayer: Record<string, FogState[]>;
+  turnDeadlineAt?: string;
+  afkStrikes?: Record<string, number>;
 }
 
 export interface NeutralArmyStack {
@@ -394,6 +398,7 @@ export interface PlayerTileView {
 
 export interface PlayerWorldView {
   meta: WorldMetaState;
+  turnDeadlineAt?: string;
   map: {
     width: number;
     height: number;
@@ -594,6 +599,10 @@ export type BattleAction =
     }
   | {
       type: "battle.defend";
+      unitId: string;
+    }
+  | {
+      type: "battle.pass";
       unitId: string;
     }
   | {

--- a/apps/cocos-client/assets/scripts/project-shared/protocol.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/protocol.ts
@@ -62,6 +62,13 @@ export type ServerMessage =
       payload: SessionStatePayload;
     }
   | {
+      type: "turn.timer";
+      requestId: "push";
+      delivery: "push";
+      remainingMs: number;
+      turnOwnerPlayerId: string;
+    }
+  | {
       type: "world.preview";
       requestId: string;
       movementPlan: MovementPlan | null;

--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -196,6 +196,12 @@ export function validateBattleBalanceConfig(
   if (typeof config.environment !== "object" || config.environment === null) {
     throw new Error("Battle balance config must define environment");
   }
+  if (!Number.isInteger(config.turnTimerSeconds) || config.turnTimerSeconds <= 0) {
+    throw new Error("Battle balance turnTimerSeconds must be a positive integer");
+  }
+  if (!Number.isInteger(config.afkStrikesBeforeForfeit) || config.afkStrikesBeforeForfeit <= 0) {
+    throw new Error("Battle balance afkStrikesBeforeForfeit must be a positive integer");
+  }
 
   if (!isFiniteNumber(config.damage.defendingDefenseBonus)) {
     throw new Error("Battle balance damage.defendingDefenseBonus must be a finite number");

--- a/apps/cocos-client/test/cocos-hud-panel.test.ts
+++ b/apps/cocos-client/test/cocos-hud-panel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Label } from "cc";
 import { VeilHudPanel, type VeilHudRenderState } from "../assets/scripts/VeilHudPanel.ts";
 import { createLobbyPanelTestAccount } from "../assets/scripts/cocos-lobby-panel-model.ts";
 import { createComponentHarness, findNode, readLabelString } from "./helpers/cocos-panel-harness.ts";
@@ -253,4 +254,21 @@ test("VeilHudPanel renders equipment-adjusted hero totals and immediate session 
   assert.match(heroText, /生命上限 14 = 基础 12 装备 \+2/);
   assert.match(equipmentText, /战利品 最近 1 条/);
   assert.match(equipmentText, /凯琳 在战斗后发现了史诗装备 守誓圣铠，但背包已满，未能拾取。/);
+});
+
+test("VeilHudPanel renders a live turn timer label and flashes it red in the final 10 seconds", () => {
+  const { component, node } = createComponentHarness(VeilHudPanel, { name: "HudPanelRoot", width: 320, height: 720 });
+  const state = createHudState();
+  state.update!.world.turnDeadlineAt = new Date(Date.now() + 9_500).toISOString();
+
+  component.render(state);
+
+  const timerNode = findNode(node, "HudTurnTimer");
+  const timerLabel = timerNode?.getComponent(Label) ?? null;
+
+  assert.ok(timerNode);
+  assert.equal(timerNode.active, true);
+  assert.match(readLabelString(timerNode), /^倒计时 0:(0\d|10)$/);
+  assert.ok(timerLabel);
+  assert.ok(timerLabel.color.r > timerLabel.color.g, "expected warning tint in the final 10 seconds");
 });

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -5,6 +5,7 @@ import {
   createInitialWorldState,
   encodePlayerWorldView,
   filterWorldEventsForPlayer,
+  getBattleBalanceConfig,
   listReachableTiles,
   normalizeEloRating,
   planHeroMovement,
@@ -16,7 +17,9 @@ import {
   type SessionStateReason,
   type ServerMessage,
   type SessionStatePayload,
-  type WorldEvent
+  type WorldEvent,
+  type WorldAction,
+  type BattleAction
 } from "../../../packages/shared/src/index";
 import { createRoom, type AuthoritativeWorldRoom, type RoomPersistenceSnapshot } from "./index";
 import {
@@ -28,8 +31,8 @@ import {
   applyPlayerAccountsToWorldState,
   applyPlayerHeroArchivesToWorldState,
   isPlayerBanActive,
+  type RoomSnapshotStore,
   type PlayerAccountSnapshot,
-  type RoomSnapshotStore
 } from "./persistence";
 import { registerConfigUpdateListener } from "./config-center";
 import { applyPlayerEventLogAndAchievements } from "./player-achievements";
@@ -68,11 +71,32 @@ const DEFAULT_WS_ACTION_RATE_LIMIT_WINDOW_MS = 1_000;
 const DEFAULT_WS_ACTION_RATE_LIMIT_MAX = 8;
 const DEFAULT_PLAYER_SLOT_ID = /^player-(\d+)$/;
 const MINOR_PROTECTION_TICK_MS = 60_000;
+const TURN_TIMER_TICK_MS = 5_000;
 let configuredRoomSnapshotStore: RoomSnapshotStore | null = null;
 const lobbyRoomSummaries = new Map<string, LobbyRoomSummary>();
 const lobbyRoomOwnerTokens = new Map<string, number>();
 const activeRoomInstances = new Map<string, VeilColyseusRoom>();
 let nextLobbyRoomOwnerToken = 1;
+
+interface RoomTimerHandle {
+  unref?(): void;
+}
+
+interface RoomRuntimeDependencies {
+  setInterval(handler: () => void, delayMs: number): RoomTimerHandle;
+  clearInterval(handle: RoomTimerHandle): void;
+  isMySqlSnapshotStore(store: RoomSnapshotStore | null): boolean;
+  now(): number;
+}
+
+const defaultRoomRuntimeDependencies: RoomRuntimeDependencies = {
+  setInterval: (handler, delayMs) => globalThis.setInterval(handler, delayMs),
+  clearInterval: (handle) => globalThis.clearInterval(handle as ReturnType<typeof globalThis.setInterval>),
+  isMySqlSnapshotStore: (store) => Boolean(store && "getRetentionPolicy" in store),
+  now: () => Date.now()
+};
+
+let roomRuntimeDependencies: RoomRuntimeDependencies = defaultRoomRuntimeDependencies;
 
 interface WebSocketActionRateLimitConfig {
   windowMs: number;
@@ -97,6 +121,17 @@ export interface LobbyRoomSummary {
 
 export function configureRoomSnapshotStore(store: RoomSnapshotStore | null): void {
   configuredRoomSnapshotStore = store;
+}
+
+export function configureRoomRuntimeDependencies(overrides: Partial<RoomRuntimeDependencies>): void {
+  roomRuntimeDependencies = {
+    ...roomRuntimeDependencies,
+    ...overrides
+  };
+}
+
+export function resetRoomRuntimeDependencies(): void {
+  roomRuntimeDependencies = defaultRoomRuntimeDependencies;
 }
 
 export function listLobbyRooms(): LobbyRoomSummary[] {
@@ -207,11 +242,18 @@ function rebindWorldStatePlayerId(
     delete nextVisibilityByPlayer[previousPlayerId];
   }
 
+  const nextAfkStrikes = state.afkStrikes ? { ...state.afkStrikes } : undefined;
+  if (nextAfkStrikes?.[previousPlayerId] != null) {
+    nextAfkStrikes[nextPlayerId] = nextAfkStrikes[previousPlayerId]!;
+    delete nextAfkStrikes[previousPlayerId];
+  }
+
   return {
     ...state,
     heroes: nextHeroes,
     resources: nextResources,
-    visibilityByPlayer: nextVisibilityByPlayer
+    visibilityByPlayer: nextVisibilityByPlayer,
+    ...(nextAfkStrikes ? { afkStrikes: nextAfkStrikes } : {})
   };
 }
 
@@ -255,6 +297,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
   private readonly reconnectedAtByPlayerId = new Map<string, string>();
   private readonly wsActionTimestampsByPlayerId = new Map<string, number[]>();
   private unsubscribeConfigUpdate: (() => void) | null = null;
+  private turnTimerHandle: RoomTimerHandle | null = null;
+  private turnOwnerPlayerId: string | null = null;
+  private turnTimerTickInFlight = false;
 
   async onCreate(options: JoinOptions): Promise<void> {
     const logicalRoomId = options.logicalRoomId ?? "room-alpha";
@@ -290,6 +335,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
 
     await this.persistRoomState();
     this.publishLobbyRoomSummary();
+    this.ensureTurnTimerLoop();
 
     this.unsubscribeConfigUpdate = registerConfigUpdateListener((bundle) => {
       for (const client of this.clients) {
@@ -347,6 +393,10 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         return;
       }
       await this.ensurePlayerWorldSlot(playerId, ensuredAccount);
+      if (this.shouldRunTurnTimer()) {
+        this.ensureTurnTimerState();
+        await this.persistRoomState();
+      }
       this.publishLobbyRoomSummary();
 
       sendMessage(client, "session.state", {
@@ -408,10 +458,14 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
 
       const previousSnapshot = this.worldRoom.serializePersistenceSnapshot();
       const result = this.worldRoom.dispatch(playerId, message.action);
+      if (result.ok) {
+        this.afterSuccessfulWorldAction(playerId, message.action);
+      }
       try {
         await this.persistRoomState();
       } catch {
         this.restoreWorldRoom(previousSnapshot);
+        this.ensureTurnTimerState();
         this.publishLobbyRoomSummary();
         sendMessage(client, "error", { requestId: message.requestId, reason: "persistence_save_failed" });
         return;
@@ -452,10 +506,14 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       recordBattleActionMessage();
       const previousSnapshot = this.worldRoom.serializePersistenceSnapshot();
       const result = this.worldRoom.dispatchBattle(playerId, message.action);
+      if (result.ok) {
+        this.afterSuccessfulBattleAction(playerId);
+      }
       try {
         await this.persistRoomState();
       } catch {
         this.restoreWorldRoom(previousSnapshot);
+        this.ensureTurnTimerState();
         this.publishLobbyRoomSummary();
         sendMessage(client, "error", { requestId: message.requestId, reason: "persistence_save_failed" });
         return;
@@ -511,6 +569,14 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
           status: report.status,
           createdAt: report.createdAt
         });
+        sendMessage(client, "session.state", {
+          requestId: message.requestId,
+          delivery: "reply",
+          payload: this.buildStatePayload(playerId, {
+            movementPlan: null,
+            reason: "report_submitted"
+          })
+        });
       } catch (error) {
         const reason =
           error instanceof Error && error.message === "duplicate_player_report"
@@ -565,6 +631,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       this.playerIdBySessionId.delete(client.sessionId);
       this.playerIdBySessionId.set(reconnectedClient.sessionId, playerId);
       this.reconnectedAtByPlayerId.set(playerId, new Date().toISOString());
+      this.ensureTurnTimerState();
       this.publishLobbyRoomSummary();
       sendMessage(reconnectedClient, "session.state", {
         requestId: "push",
@@ -573,12 +640,14 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       });
     } catch {
       this.playerIdBySessionId.delete(client.sessionId);
+      this.ensureTurnTimerState();
       this.publishLobbyRoomSummary();
     }
   }
 
   onLeave(client: ColyseusClient): void {
     this.playerIdBySessionId.delete(client.sessionId);
+    this.ensureTurnTimerState();
     this.publishLobbyRoomSummary();
   }
 
@@ -586,6 +655,10 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     this.unsubscribeConfigUpdate?.();
     this.unsubscribeConfigUpdate = null;
     this.wsActionTimestampsByPlayerId.clear();
+    if (this.turnTimerHandle) {
+      roomRuntimeDependencies.clearInterval(this.turnTimerHandle);
+      this.turnTimerHandle = null;
+    }
 
     if (lobbyRoomOwnerTokens.get(this.metadata.logicalRoomId) !== this.lobbyRoomOwnerToken) {
       return;
@@ -619,6 +692,317 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     return Array.from(new Set(this.playerIdBySessionId.values()));
   }
 
+  private getTurnTimerSettings(): { turnTimerMs: number; afkStrikesBeforeForfeit: number } {
+    const config = getBattleBalanceConfig();
+    return {
+      turnTimerMs: config.turnTimerSeconds * 1_000,
+      afkStrikesBeforeForfeit: config.afkStrikesBeforeForfeit
+    };
+  }
+
+  private shouldRunTurnTimer(): boolean {
+    return roomRuntimeDependencies.isMySqlSnapshotStore(configuredRoomSnapshotStore);
+  }
+
+  private ensureTurnTimerLoop(): void {
+    if (!this.shouldRunTurnTimer() || this.turnTimerHandle) {
+      return;
+    }
+
+    this.turnTimerHandle = roomRuntimeDependencies.setInterval(() => {
+      void this.tickTurnTimer();
+    }, TURN_TIMER_TICK_MS);
+    this.turnTimerHandle.unref?.();
+  }
+
+  private listMatchPlayerIds(): string[] {
+    return Array.from(new Set(this.worldRoom.getInternalState().heroes.map((hero) => hero.playerId))).sort();
+  }
+
+  private findNextMatchPlayerId(playerId: string): string | null {
+    const playerIds = this.listMatchPlayerIds();
+    if (playerIds.length === 0) {
+      return null;
+    }
+
+    const currentIndex = playerIds.indexOf(playerId);
+    if (currentIndex < 0) {
+      return playerIds[0] ?? null;
+    }
+
+    return playerIds[(currentIndex + 1) % playerIds.length] ?? null;
+  }
+
+  private resolvePvPBattleTurnOwnerPlayerId(): string | null {
+    const battle = this.worldRoom.getActiveBattles().find((candidate) => candidate.defenderHeroId);
+    if (!battle?.activeUnitId) {
+      return null;
+    }
+
+    const activeUnit = battle.units[battle.activeUnitId];
+    if (!activeUnit) {
+      return null;
+    }
+
+    const internalState = this.worldRoom.getInternalState();
+    if (activeUnit.camp === "attacker") {
+      return battle.worldHeroId
+        ? internalState.heroes.find((hero) => hero.id === battle.worldHeroId)?.playerId ?? null
+        : null;
+    }
+
+    return battle.defenderHeroId
+      ? internalState.heroes.find((hero) => hero.id === battle.defenderHeroId)?.playerId ?? null
+      : null;
+  }
+
+  private resolveTurnContext(): { mode: "world" | "battle"; playerId: string } | null {
+    const battleOwnerPlayerId = this.resolvePvPBattleTurnOwnerPlayerId();
+    if (battleOwnerPlayerId) {
+      this.turnOwnerPlayerId = battleOwnerPlayerId;
+      return {
+        mode: "battle",
+        playerId: battleOwnerPlayerId
+      };
+    }
+
+    const playerIds = this.listMatchPlayerIds();
+    if (playerIds.length !== 2) {
+      return null;
+    }
+
+    const ownerPlayerId =
+      this.turnOwnerPlayerId && playerIds.includes(this.turnOwnerPlayerId) ? this.turnOwnerPlayerId : playerIds[0] ?? null;
+    if (!ownerPlayerId) {
+      return null;
+    }
+
+    this.turnOwnerPlayerId = ownerPlayerId;
+    return {
+      mode: "world",
+      playerId: ownerPlayerId
+    };
+  }
+
+  private setTurnDeadlineFor(playerId: string | null): void {
+    const state = this.worldRoom.getInternalState();
+    if (!playerId) {
+      this.turnOwnerPlayerId = null;
+      delete state.turnDeadlineAt;
+      return;
+    }
+
+    this.turnOwnerPlayerId = playerId;
+    state.turnDeadlineAt = new Date(roomRuntimeDependencies.now() + this.getTurnTimerSettings().turnTimerMs).toISOString();
+  }
+
+  private getAfkStrikeCount(playerId: string): number {
+    const current = this.worldRoom.getInternalState().afkStrikes?.[playerId];
+    return typeof current === "number" && Number.isFinite(current) ? current : 0;
+  }
+
+  private setAfkStrikeCount(playerId: string, nextValue: number): void {
+    const state = this.worldRoom.getInternalState();
+    const next = { ...(state.afkStrikes ?? {}) };
+    if (nextValue > 0) {
+      next[playerId] = nextValue;
+    } else {
+      delete next[playerId];
+    }
+
+    if (Object.keys(next).length > 0) {
+      state.afkStrikes = next;
+    } else {
+      delete state.afkStrikes;
+    }
+  }
+
+  private ensureTurnTimerState(): void {
+    if (!this.shouldRunTurnTimer()) {
+      this.setTurnDeadlineFor(null);
+      return;
+    }
+
+    const context = this.resolveTurnContext();
+    if (!context) {
+      this.setTurnDeadlineFor(null);
+      return;
+    }
+
+    const deadlineAt = this.worldRoom.getInternalState().turnDeadlineAt;
+    if (!deadlineAt || Number.isNaN(Date.parse(deadlineAt))) {
+      this.setTurnDeadlineFor(context.playerId);
+    } else {
+      this.turnOwnerPlayerId = context.playerId;
+    }
+
+    this.pushTurnTimerUpdate();
+  }
+
+  private pushTurnTimerUpdate(): void {
+    const context = this.resolveTurnContext();
+    const deadlineAt = this.worldRoom.getInternalState().turnDeadlineAt;
+    if (!context || !deadlineAt) {
+      return;
+    }
+
+    const remainingMs = Math.max(0, Date.parse(deadlineAt) - roomRuntimeDependencies.now());
+    for (const client of this.clients) {
+      sendMessage(client, "turn.timer", {
+        requestId: "push",
+        delivery: "push",
+        remainingMs,
+        turnOwnerPlayerId: context.playerId
+      });
+    }
+  }
+
+  private afterSuccessfulWorldAction(playerId: string, action: WorldAction): void {
+    if (!this.shouldRunTurnTimer()) {
+      return;
+    }
+
+    this.setAfkStrikeCount(playerId, 0);
+    const nextOwnerPlayerId = action.type === "turn.endDay" ? this.findNextMatchPlayerId(playerId) ?? playerId : playerId;
+    this.setTurnDeadlineFor(nextOwnerPlayerId);
+  }
+
+  private afterSuccessfulBattleAction(playerId: string): void {
+    if (!this.shouldRunTurnTimer()) {
+      return;
+    }
+
+    this.setAfkStrikeCount(playerId, 0);
+    this.setTurnDeadlineFor(this.resolvePvPBattleTurnOwnerPlayerId() ?? playerId);
+  }
+
+  private async tickTurnTimer(): Promise<void> {
+    if (!this.shouldRunTurnTimer() || this.turnTimerTickInFlight) {
+      return;
+    }
+
+    const deadlineAt = this.worldRoom.getInternalState().turnDeadlineAt;
+    if (!deadlineAt) {
+      this.ensureTurnTimerState();
+      return;
+    }
+
+    const context = this.resolveTurnContext();
+    if (!context) {
+      this.setTurnDeadlineFor(null);
+      return;
+    }
+
+    const remainingMs = Date.parse(deadlineAt) - roomRuntimeDependencies.now();
+    if (remainingMs > 0) {
+      this.pushTurnTimerUpdate();
+      return;
+    }
+
+    this.turnTimerTickInFlight = true;
+    try {
+      await this.handleTurnTimeout(context);
+    } finally {
+      this.turnTimerTickInFlight = false;
+    }
+  }
+
+  private async handleTurnTimeout(context: { mode: "world" | "battle"; playerId: string }): Promise<void> {
+    const nextStrikeCount = this.getAfkStrikeCount(context.playerId) + 1;
+    this.setAfkStrikeCount(context.playerId, nextStrikeCount);
+
+    if (nextStrikeCount >= this.getTurnTimerSettings().afkStrikesBeforeForfeit) {
+      await this.applyAfkForfeit(context.playerId);
+      return;
+    }
+
+    if (context.mode === "battle") {
+      await this.applyAutoBattlePass(context.playerId);
+      return;
+    }
+
+    await this.applyAutoEndDay(context.playerId);
+  }
+
+  private async applyAutoEndDay(playerId: string): Promise<void> {
+    const previousSnapshot = this.worldRoom.serializePersistenceSnapshot();
+    const result = this.worldRoom.dispatch(playerId, { type: "turn.endDay" });
+    if (!result.ok) {
+      this.ensureTurnTimerState();
+      return;
+    }
+
+    this.setTurnDeadlineFor(this.findNextMatchPlayerId(playerId) ?? playerId);
+    try {
+      await this.persistRoomState();
+    } catch {
+      this.restoreWorldRoom(previousSnapshot);
+      this.ensureTurnTimerState();
+      this.publishLobbyRoomSummary();
+      return;
+    }
+
+    await this.persistPlayerAccountProgress(result.events ?? [], this.worldRoom.consumeCompletedBattleReplays());
+    this.publishLobbyRoomSummary();
+    this.pushSessionStateToAll({
+      events: result.events ?? [],
+      movementPlan: result.movementPlan ?? null
+    });
+    this.pushTurnTimerUpdate();
+  }
+
+  private async applyAutoBattlePass(playerId: string): Promise<void> {
+    const battle = this.worldRoom.getBattleForPlayer(playerId);
+    const activeUnitId = battle?.activeUnitId ?? null;
+    if (!battle || !activeUnitId) {
+      this.ensureTurnTimerState();
+      return;
+    }
+
+    const previousSnapshot = this.worldRoom.serializePersistenceSnapshot();
+    const result = this.worldRoom.dispatchBattle(playerId, {
+      type: "battle.pass",
+      unitId: activeUnitId
+    });
+    if (!result.ok) {
+      this.ensureTurnTimerState();
+      return;
+    }
+
+    this.setTurnDeadlineFor(this.resolvePvPBattleTurnOwnerPlayerId() ?? playerId);
+    try {
+      await this.persistRoomState();
+    } catch {
+      this.restoreWorldRoom(previousSnapshot);
+      this.ensureTurnTimerState();
+      this.publishLobbyRoomSummary();
+      return;
+    }
+
+    await this.persistPlayerAccountProgress(result.events ?? [], this.worldRoom.consumeCompletedBattleReplays());
+    this.publishLobbyRoomSummary();
+    this.pushSessionStateToAll({
+      events: result.events ?? [],
+      movementPlan: null
+    });
+    this.pushTurnTimerUpdate();
+  }
+
+  private async applyAfkForfeit(loserPlayerId: string): Promise<void> {
+    const winnerPlayerId = this.listMatchPlayerIds().find((candidatePlayerId) => candidatePlayerId !== loserPlayerId);
+    if (!winnerPlayerId) {
+      this.ensureTurnTimerState();
+      return;
+    }
+
+    if (!(await this.applySurrenderEloResult(winnerPlayerId, loserPlayerId))) {
+      this.ensureTurnTimerState();
+      return;
+    }
+
+    await this.broadcastSettlementAndCloseRoom(null, "afk_forfeit", "push");
+  }
+
   private async syncMinorProtectionAccount(
     playerId: string,
     account: PlayerAccountSnapshot
@@ -650,14 +1034,17 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     requestId: string
   ): Promise<boolean> {
     const store = configuredRoomSnapshotStore;
-    const account =
-      ensuredAccount ??
-      (store
-        ? await store.ensurePlayerAccount({
-            playerId,
-            lastRoomId: this.metadata.logicalRoomId
-          })
-        : null);
+    let account = ensuredAccount;
+    if (!account && store) {
+      try {
+        account = await store.ensurePlayerAccount({
+          playerId,
+          lastRoomId: this.metadata.logicalRoomId
+        });
+      } catch {
+        account = null;
+      }
+    }
 
     if (!account || account.isMinor !== true) {
       return false;
@@ -906,7 +1293,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
   }
 
   private async broadcastSettlementAndCloseRoom(
-    sourceClient: ColyseusClient,
+    sourceClient: ColyseusClient | null,
     reason: SessionStateReason,
     requestId: string
   ): Promise<void> {
@@ -956,6 +1343,10 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       return null;
     }
 
+    if (this.getConnectedPlayerIds().includes(targetPlayerId)) {
+      return targetPlayerId;
+    }
+
     const battle = this.worldRoom.getBattleForPlayer(playerId);
     if (!battle?.worldHeroId || !battle.defenderHeroId) {
       return null;
@@ -997,6 +1388,25 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     }
 
     return playerId;
+  }
+
+  private pushSessionStateToAll(extras?: {
+    events?: WorldEvent[];
+    movementPlan?: MovementPlan | null;
+    reason?: string;
+  }): void {
+    for (const client of this.clients) {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        continue;
+      }
+
+      sendMessage(client, "session.state", {
+        requestId: "push",
+        delivery: "push",
+        payload: this.buildStatePayload(playerId, extras)
+      });
+    }
   }
 
   private async ensurePlayerWorldSlot(

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -782,7 +782,7 @@ const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
     type: "object",
     title: "Battle Balance Config",
     description: "战斗公式、环境生成阈值和 PVP 参数。",
-    required: ["damage", "environment", "pvp"],
+    required: ["damage", "environment", "turnTimerSeconds", "afkStrikesBeforeForfeit", "pvp"],
     properties: {
       damage: {
         type: "object",
@@ -821,6 +821,8 @@ const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
           trapGrantedStatusId: { type: "string", description: "伤害型陷阱附加的状态 id，可选。" }
         }
       },
+      turnTimerSeconds: { type: "integer", minimum: 1, description: "PVP 回合倒计时秒数。" },
+      afkStrikesBeforeForfeit: { type: "integer", minimum: 1, description: "同一局内累计几次挂机后直接判负。" },
       pvp: {
         type: "object",
         description: "PVP 匹配与结算参数。",
@@ -1578,7 +1580,7 @@ function buildSummary(id: ConfigDocumentId, parsed: unknown): string {
   }
 
   const config = parsed as BattleBalanceConfig;
-  return `damage/env/pvp · K=${config.pvp.eloK} · trap=${config.environment.trapDamage}`;
+  return `damage/env/timer/pvp · ${config.turnTimerSeconds}s/${config.afkStrikesBeforeForfeit} AFK · K=${config.pvp.eloK} · trap=${config.environment.trapDamage}`;
 }
 
 function normalizeJsonContent(
@@ -1782,6 +1784,8 @@ function applyBattleBalancePreset(
         ? { trapGrantedStatusId: config.environment.trapGrantedStatusId }
         : {})
     },
+    turnTimerSeconds: config.turnTimerSeconds,
+    afkStrikesBeforeForfeit: config.afkStrikesBeforeForfeit,
     pvp: {
       eloK: Math.max(1, config.pvp.eloK + (easier ? -4 : 4))
     }

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -6,9 +6,11 @@ import { applyEloMatchResult } from "../../../packages/shared/src/index";
 import type { BattleState, ServerMessage, WorldEvent } from "../../../packages/shared/src/index";
 import {
   VeilColyseusRoom,
+  configureRoomRuntimeDependencies,
   configureRoomSnapshotStore,
   getActiveRoomInstances,
   listLobbyRooms,
+  resetRoomRuntimeDependencies,
   resetLobbyRoomRegistry
 } from "../src/colyseus-room";
 import { createRoom, type RoomPersistenceSnapshot } from "../src/index";
@@ -72,6 +74,39 @@ function createFakeClient(sessionId: string): FakeClient {
 async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
   await new Promise((resolve) => setImmediate(resolve));
+}
+
+function createManualRoomTimer(startAtMs = 0): {
+  nowMs: number;
+  tick(): Promise<void>;
+} {
+  let nowMs = startAtMs;
+  let callback: (() => void | Promise<void>) | null = null;
+
+  configureRoomRuntimeDependencies({
+    setInterval: (handler) => {
+      callback = handler;
+      return {};
+    },
+    clearInterval: () => {
+      callback = null;
+    },
+    isMySqlSnapshotStore: () => true,
+    now: () => nowMs
+  });
+
+  return {
+    get nowMs() {
+      return nowMs;
+    },
+    set nowMs(value: number) {
+      nowMs = value;
+    },
+    async tick() {
+      await callback?.();
+      await flushAsyncWork();
+    }
+  };
 }
 
 async function createTestRoom(logicalRoomId: string, seed = 1001): Promise<VeilColyseusRoom> {
@@ -262,6 +297,15 @@ function lastSessionState(client: FakeClient, delivery?: "reply" | "push"): Extr
   );
   const latest = states.at(-1);
   assert.ok(latest, "expected a session.state message");
+  return latest;
+}
+
+function lastTurnTimer(client: FakeClient): Extract<ServerMessage, { type: "turn.timer" }> {
+  const timers = client.sent.filter(
+    (message): message is Extract<ServerMessage, { type: "turn.timer" }> => message.type === "turn.timer"
+  );
+  const latest = timers.at(-1);
+  assert.ok(latest, "expected a turn.timer message");
   return latest;
 }
 
@@ -1085,6 +1129,90 @@ test("pvp replay persistence captures both attacker and defender accounts from r
     replaySaves.map((entry) => entry.playerId).sort(),
     ["player-1", "player-2"]
   );
+});
+
+test("turn timer auto-applies end day on expiry and pushes countdown state", async (t) => {
+  resetLobbyRoomRegistry();
+  const timer = createManualRoomTimer(Date.parse("2026-04-04T00:00:00.000Z"));
+  const store = new InstrumentedRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-turn-timer-${Date.now()}`);
+  const attackerClient = createFakeClient("session-turn-timer-attacker");
+  const defenderClient = createFakeClient("session-turn-timer-defender");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+    resetRoomRuntimeDependencies();
+  });
+
+  await connectPlayer(room, attackerClient, "player-1", "connect-turn-timer-attacker");
+  await connectPlayer(room, defenderClient, "player-2", "connect-turn-timer-defender");
+
+  const initialTimer = lastTurnTimer(attackerClient);
+  assert.equal(initialTimer.turnOwnerPlayerId, "player-1");
+  assert.equal(initialTimer.remainingMs, 90_000);
+
+  timer.nowMs += 90_001;
+  await timer.tick();
+
+  const attackerPush = lastSessionState(attackerClient, "push");
+  const defenderPush = lastSessionState(defenderClient, "push");
+  const timerAfterExpiry = lastTurnTimer(defenderClient);
+
+  assert.equal(attackerPush.payload.world.meta.day, 2);
+  assert.equal(defenderPush.payload.world.meta.day, 2);
+  assert.deepEqual(attackerPush.payload.events.map((event) => event.type), ["turn.advanced"]);
+  assert.equal(attackerPush.payload.world.turnDeadlineAt, "2026-04-04T00:03:00.001Z");
+  assert.equal(timerAfterExpiry.turnOwnerPlayerId, "player-2");
+  assert.equal(timerAfterExpiry.remainingMs, 90_000);
+});
+
+test("two consecutive AFK strikes trigger afk_forfeit and persist surrender-path ELO deltas", async (t) => {
+  resetLobbyRoomRegistry();
+  const timer = createManualRoomTimer(Date.parse("2026-04-04T00:00:00.000Z"));
+  const store = new InstrumentedRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-afk-forfeit-${Date.now()}`);
+  const attackerClient = createFakeClient("session-afk-forfeit-attacker");
+  const defenderClient = createFakeClient("session-afk-forfeit-defender");
+  const expectedRatings = applyEloMatchResult(1000, 1000);
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+    resetRoomRuntimeDependencies();
+  });
+
+  await connectPlayer(room, attackerClient, "player-1", "connect-afk-forfeit-attacker");
+  await connectPlayer(room, defenderClient, "player-2", "connect-afk-forfeit-defender");
+
+  timer.nowMs += 90_001;
+  await timer.tick();
+
+  await emitRoomMessage(room, "world.action", defenderClient, {
+    type: "world.action",
+    requestId: "manual-end-day-after-first-timeout",
+    action: {
+      type: "turn.endDay"
+    }
+  });
+
+  timer.nowMs += 90_001;
+  await timer.tick();
+
+  const attackerPush = lastSessionState(attackerClient, "push");
+  const defenderPush = lastSessionState(defenderClient, "push");
+  const loserAccount = await store.loadPlayerAccount("player-1");
+  const winnerAccount = await store.loadPlayerAccount("player-2");
+
+  assert.equal(attackerPush.payload.reason, "afk_forfeit");
+  assert.equal(defenderPush.payload.reason, "afk_forfeit");
+  assert.equal(loserAccount?.eloRating, expectedRatings.loserRating);
+  assert.equal(winnerAccount?.eloRating, expectedRatings.winnerRating);
+  assert.equal(await store.load(room.roomId), null);
 });
 
 test("surrender settles the room with the surrendering player as loser and persists ELO deltas", async (t) => {

--- a/configs/battle-balance.json
+++ b/configs/battle-balance.json
@@ -14,6 +14,8 @@
     "trapCharges": 1,
     "trapGrantedStatusId": "weakened"
   },
+  "turnTimerSeconds": 90,
+  "afkStrikesBeforeForfeit": 2,
   "pvp": {
     "eloK": 32
   }

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -1511,7 +1511,7 @@ export function executeBattleSkill(
 }
 
 export function validateBattleAction(state: BattleState, action: BattleAction): ValidationResult {
-  if (action.type === "battle.wait" || action.type === "battle.defend") {
+  if (action.type === "battle.wait" || action.type === "battle.defend" || action.type === "battle.pass") {
     if (state.activeUnitId !== action.unitId) {
       return { valid: false, reason: "unit_not_active" };
     }
@@ -1981,6 +1981,17 @@ export function applyBattleAction(state: BattleState, action: BattleAction): Bat
           }
         },
         log: normalizedState.log.concat(`${action.unitId} 进入防御`)
+      },
+      action.unitId,
+      false
+    );
+  }
+
+  if (action.type === "battle.pass") {
+    return advanceTurn(
+      {
+        ...normalizedState,
+        log: normalizedState.log.concat(`${action.unitId} 选择跳过`)
       },
       action.unitId,
       false

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -2135,6 +2135,7 @@ export function createPlayerWorldView(state: WorldState, playerId: string): Play
 
   return {
     meta: state.meta,
+    ...(state.turnDeadlineAt ? { turnDeadlineAt: state.turnDeadlineAt } : {}),
     map: {
       width: state.map.width,
       height: state.map.height,
@@ -2221,6 +2222,8 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
           ...state.meta,
           day: state.meta.day + 1
         },
+        ...(state.turnDeadlineAt ? { turnDeadlineAt: state.turnDeadlineAt } : {}),
+        ...(state.afkStrikes ? { afkStrikes: state.afkStrikes } : {}),
         resources: state.resources
       },
       heroes,

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -118,6 +118,8 @@ export interface BattleEnvironmentBalanceConfig {
 export interface BattleBalanceConfig {
   damage: BattleDamageBalanceConfig;
   environment: BattleEnvironmentBalanceConfig;
+  turnTimerSeconds: number;
+  afkStrikesBeforeForfeit: number;
   pvp: {
     eloK: number;
   };
@@ -348,6 +350,8 @@ export interface WorldState {
   buildings: Record<string, MapBuildingState>;
   resources: WorldResourceLedger;
   visibilityByPlayer: Record<string, FogState[]>;
+  turnDeadlineAt?: string;
+  afkStrikes?: Record<string, number>;
 }
 
 export interface NeutralArmyStack {
@@ -402,6 +406,7 @@ export interface PlayerTileView {
 
 export interface PlayerWorldView {
   meta: WorldMetaState;
+  turnDeadlineAt?: string;
   map: {
     width: number;
     height: number;
@@ -602,6 +607,10 @@ export type BattleAction =
     }
   | {
       type: "battle.defend";
+      unitId: string;
+    }
+  | {
+      type: "battle.pass";
       unitId: string;
     }
   | {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -63,6 +63,13 @@ export type ServerMessage =
       payload: SessionStatePayload;
     }
   | {
+      type: "turn.timer";
+      requestId: "push";
+      delivery: "push";
+      remainingMs: number;
+      turnOwnerPlayerId: string;
+    }
+  | {
       type: "world.preview";
       requestId: string;
       movementPlan: MovementPlan | null;

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -196,6 +196,12 @@ export function validateBattleBalanceConfig(
   if (typeof config.environment !== "object" || config.environment === null) {
     throw new Error("Battle balance config must define environment");
   }
+  if (!Number.isInteger(config.turnTimerSeconds) || config.turnTimerSeconds <= 0) {
+    throw new Error("Battle balance turnTimerSeconds must be a positive integer");
+  }
+  if (!Number.isInteger(config.afkStrikesBeforeForfeit) || config.afkStrikesBeforeForfeit <= 0) {
+    throw new Error("Battle balance afkStrikesBeforeForfeit must be a positive integer");
+  }
   if (typeof config.pvp !== "object" || config.pvp === null) {
     throw new Error("Battle balance config must define pvp");
   }

--- a/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
+++ b/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
@@ -11,6 +11,7 @@
           "day": 7,
           "mapVariantId": "frontier-basin"
         },
+        "turnDeadlineAt": "2026-03-29T07:01:30.000Z",
         "map": {
           "width": 3,
           "height": 2,
@@ -236,7 +237,8 @@
         "rng": {
           "seed": 4242,
           "cursor": 0
-        }
+        },
+        "battlefieldTerrain": "grass"
       },
       "events": [
         {
@@ -329,6 +331,13 @@
       ],
       "reason": "battle.started"
     }
+  },
+  {
+    "type": "turn.timer",
+    "requestId": "push",
+    "delivery": "push",
+    "remainingMs": 90000,
+    "turnOwnerPlayerId": "player-1"
   },
   {
     "type": "world.preview",

--- a/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
+++ b/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
@@ -6,6 +6,7 @@
       "day": 7,
       "mapVariantId": "frontier-basin"
     },
+    "turnDeadlineAt": "2026-03-29T07:01:30.000Z",
     "map": {
       "width": 3,
       "height": 2,
@@ -231,7 +232,8 @@
     "rng": {
       "seed": 4242,
       "cursor": 0
-    }
+    },
+    "battlefieldTerrain": "grass"
   },
   "events": [
     {

--- a/packages/shared/test/support/multiplayer-protocol-fixtures.ts
+++ b/packages/shared/test/support/multiplayer-protocol-fixtures.ts
@@ -127,6 +127,7 @@ function createContractWorldState(): WorldState {
       "player-1": { gold: 180, wood: 12, ore: 5 },
       "player-2": { gold: 90, wood: 4, ore: 3 }
     },
+    turnDeadlineAt: "2026-03-29T07:01:30.000Z",
     visibilityByPlayer: {
       "player-1": ["visible", "visible", "explored", "visible", "visible", "visible"]
     }
@@ -492,6 +493,13 @@ export function createServerMessageFixtures(): ServerMessage[] {
       requestId: "req-session-state-001",
       delivery: "push",
       payload: sessionStatePayload
+    },
+    {
+      type: "turn.timer",
+      requestId: "push",
+      delivery: "push",
+      remainingMs: 90_000,
+      turnOwnerPlayerId: "player-1"
     },
     {
       type: "world.preview",


### PR DESCRIPTION
## Summary
- add a persistent PVP turn timer with 90s defaults, AFK strike tracking, automatic `turn.endDay` / `battle.pass`, and two-strike AFK forfeit settlement on the server
- extend the shared multiplayer protocol and config schema with `turn.timer`, `turnDeadlineAt`, `battle.pass`, and editable timer/forfeit balance fields
- render a live HUD countdown in the Cocos client, flashing red in the final 10 seconds, and cover the new behavior with focused room lifecycle, contract, and HUD tests

## Validation
- `node --import tsx --test apps/server/test/colyseus-room-lifecycle.test.ts`
- `node --import tsx --test packages/shared/test/client-payload-contracts.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-hud-panel.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `npm run typecheck:cocos`

Closes #829
