### PR TITLE
feat: add in-game settings panel

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -230,6 +230,7 @@ function getSessionIndicatorBadge(indicators: VeilHudSessionIndicator[]): string
 export interface VeilHudPanelOptions {
   onNewRun?: () => void;
   onRefresh?: () => void;
+  onToggleSettings?: () => void;
   onToggleInventory?: () => void;
   onToggleAchievements?: () => void;
   onToggleReport?: () => void;
@@ -339,6 +340,7 @@ export class VeilHudPanel extends Component {
   private requestedIcons = false;
   private onNewRun: (() => void) | undefined;
   private onRefresh: (() => void) | undefined;
+  private onToggleSettings: (() => void) | undefined;
   private onToggleInventory: (() => void) | undefined;
   private onToggleAchievements: (() => void) | undefined;
   private onToggleReport: (() => void) | undefined;
@@ -357,6 +359,7 @@ export class VeilHudPanel extends Component {
   configure(options: VeilHudPanelOptions): void {
     this.onNewRun = options.onNewRun;
     this.onRefresh = options.onRefresh;
+    this.onToggleSettings = options.onToggleSettings;
     this.onToggleInventory = options.onToggleInventory;
     this.onToggleAchievements = options.onToggleAchievements;
     this.onToggleReport = options.onToggleReport;
@@ -652,6 +655,7 @@ export class VeilHudPanel extends Component {
     const chromeActions: Array<{ nodeName: string; debugLabel: string; callback: (() => void) | null }> = [
       { nodeName: "HudNewRun", debugLabel: "new-run", callback: this.onNewRun ?? null },
       { nodeName: "HudRefresh", debugLabel: "refresh", callback: this.onRefresh ?? null },
+      { nodeName: "HudSettings", debugLabel: "settings", callback: this.onToggleSettings ?? null },
       { nodeName: "HudInventory", debugLabel: "inventory", callback: this.onToggleInventory ?? null },
       { nodeName: "HudAchievements", debugLabel: "achievements", callback: this.onToggleAchievements ?? null },
       { nodeName: "HudReportPlayer", debugLabel: "report-player", callback: this.onToggleReport ?? null },
@@ -1593,6 +1597,7 @@ export class VeilHudPanel extends Component {
 
     this.ensureActionButton(actionsNode, "HudNewRun", "新开一局");
     this.ensureActionButton(actionsNode, "HudRefresh", "刷新状态");
+    this.ensureActionButton(actionsNode, "HudSettings", "设置");
     this.ensureActionButton(actionsNode, "HudInventory", "装备背包");
     this.ensureActionButton(actionsNode, "HudAchievements", "战报中心");
     this.ensureActionButton(actionsNode, "HudReportPlayer", "举报玩家");
@@ -1612,6 +1617,7 @@ export class VeilHudPanel extends Component {
     const buttons: HudActionButtonState[] = [
       { name: "HudNewRun", label: "新开一局", callback: this.onNewRun ?? null },
       { name: "HudRefresh", label: "刷新状态", callback: this.onRefresh ?? null },
+      { name: "HudSettings", label: "设置", callback: this.onToggleSettings ?? null },
       { name: "HudInventory", label: "装备背包", callback: this.onToggleInventory ?? null },
       { name: "HudAchievements", label: "战报中心", callback: this.onToggleAchievements ?? null },
       { name: "HudReportPlayer", label: "举报玩家", callback: this.onToggleReport ?? null },

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -24,6 +24,7 @@ import {
   confirmCocosAccountRegistration,
   confirmCocosPasswordRecovery,
   createFallbackCocosPlayerAccountProfile,
+  deleteCurrentCocosPlayerAccount,
   createCocosGuestPlayerId,
   loadCocosBattleReplayHistoryPage,
   createCocosLobbyPreferences,
@@ -124,6 +125,16 @@ import {
 } from "./cocos-battle-presentation-controller.ts";
 import { createCocosAudioRuntime } from "./cocos-audio-runtime.ts";
 import { createCocosAudioAssetBridge } from "./cocos-audio-resources.ts";
+import {
+  applySettingsUpdate,
+  CocosSettingsPanel,
+  createDefaultCocosSettingsView,
+  readPersistedCocosSettings,
+  resolveCocosPrivacyPolicyUrl,
+  writePersistedCocosSettings,
+  type CocosSettingsPanelUpdate,
+  type CocosSettingsPanelView
+} from "./cocos-settings-panel.ts";
 import { buildCocosRuntimeTriageSummaryLines } from "./cocos-runtime-diagnostics.ts";
 import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
 import { cocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
@@ -152,6 +163,8 @@ const TIMELINE_NODE_NAME = "ProjectVeilTimelinePanel";
 const LOBBY_NODE_NAME = "ProjectVeilLobbyPanel";
 const ACCOUNT_REVIEW_PANEL_NODE_NAME = "ProjectVeilAccountReviewPanel";
 const EQUIPMENT_PANEL_NODE_NAME = "ProjectVeilEquipmentPanel";
+const SETTINGS_PANEL_NODE_NAME = "ProjectVeilSettingsPanel";
+const SETTINGS_BUTTON_NODE_NAME = "ProjectVeilSettingsButton";
 const DEFAULT_MAP_WIDTH_TILES = 8;
 const DEFAULT_MAP_HEIGHT_TILES = 8;
 const BATTLE_FEEDBACK_DURATION_MS = 2600;
@@ -181,6 +194,8 @@ interface VeilRootRuntime {
   loadEventHistory: typeof loadCocosPlayerEventHistory;
   loadBattleReplayHistoryPage: typeof loadCocosBattleReplayHistoryPage;
   loginGuestAuthSession: typeof loginCocosGuestAuthSession;
+  logoutAuthSession: typeof logoutCurrentCocosAuthSession;
+  deletePlayerAccount: typeof deleteCurrentCocosPlayerAccount;
 }
 
 const defaultVeilRootRuntime: VeilRootRuntime = {
@@ -198,7 +213,9 @@ const defaultVeilRootRuntime: VeilRootRuntime = {
   loadAchievementProgress: (...args) => loadCocosPlayerAchievementProgress(...args),
   loadEventHistory: (...args) => loadCocosPlayerEventHistory(...args),
   loadBattleReplayHistoryPage: (...args) => loadCocosBattleReplayHistoryPage(...args),
-  loginGuestAuthSession: (...args) => loginCocosGuestAuthSession(...args)
+  loginGuestAuthSession: (...args) => loginCocosGuestAuthSession(...args),
+  logoutAuthSession: (...args) => logoutCurrentCocosAuthSession(...args),
+  deletePlayerAccount: (...args) => deleteCurrentCocosPlayerAccount(...args)
 };
 
 let testVeilRootRuntimeOverrides: Partial<VeilRootRuntime> | null = null;
@@ -304,6 +321,8 @@ export class VeilRoot extends Component {
   private gameplayAccountReviewPanelOpen = false;
   private gameplayEquipmentPanel: VeilEquipmentPanel | null = null;
   private gameplayEquipmentPanelOpen = false;
+  private settingsPanel: CocosSettingsPanel | null = null;
+  private settingsView: CocosSettingsPanelView = createDefaultCocosSettingsView();
   private activeAccountFlow: CocosAccountLifecycleKind | null = null;
   private registrationDisplayName = "";
   private registrationToken = "";
@@ -350,6 +369,7 @@ export class VeilRoot extends Component {
     this.hydrateRuntimePlatform();
     this.bindRuntimeMemoryWarnings();
     this.hydrateLaunchIdentity();
+    this.hydrateSettings();
     this.syncWechatShareBridge();
     this.ensureUiCameraVisibility();
     this.ensureViewNodes();
@@ -756,6 +776,9 @@ export class VeilRoot extends Component {
       onRefresh: () => {
         void this.refreshSnapshot();
       },
+      onToggleSettings: () => {
+        this.toggleSettingsPanel();
+      },
       onToggleInventory: () => {
         this.toggleGameplayEquipmentPanel();
       },
@@ -1008,6 +1031,45 @@ export class VeilRoot extends Component {
       }
     });
 
+    let settingsPanelNode = this.node.getChildByName(SETTINGS_PANEL_NODE_NAME);
+    if (!settingsPanelNode) {
+      settingsPanelNode = new Node(SETTINGS_PANEL_NODE_NAME);
+      settingsPanelNode.parent = this.node;
+    }
+    assignUiLayer(settingsPanelNode);
+    const settingsPanelTransform = settingsPanelNode.getComponent(UITransform) ?? settingsPanelNode.addComponent(UITransform);
+    settingsPanelTransform.setContentSize(Math.max(360, Math.min(460, visibleSize.width - 64)), Math.max(440, visibleSize.height - 96));
+    this.settingsPanel = settingsPanelNode.getComponent(CocosSettingsPanel) ?? settingsPanelNode.addComponent(CocosSettingsPanel);
+    this.settingsPanel.configure({
+      onClose: () => {
+        this.toggleSettingsPanel(false);
+      },
+      onUpdate: (update) => {
+        this.updateSettings(update);
+      },
+      onLogout: () => {
+        void this.handleSettingsLogout();
+      },
+      onDeleteAccount: () => {
+        void this.handleSettingsDeleteAccount();
+      },
+      onWithdrawConsent: () => {
+        void this.handleSettingsWithdrawConsent();
+      },
+      onOpenPrivacyPolicy: () => {
+        this.openSettingsPrivacyPolicy();
+      }
+    });
+
+    let settingsButtonNode = this.node.getChildByName(SETTINGS_BUTTON_NODE_NAME);
+    if (!settingsButtonNode) {
+      settingsButtonNode = new Node(SETTINGS_BUTTON_NODE_NAME);
+      settingsButtonNode.parent = this.node;
+    }
+    assignUiLayer(settingsButtonNode);
+    const settingsButtonTransform = settingsButtonNode.getComponent(UITransform) ?? settingsButtonNode.addComponent(UITransform);
+    settingsButtonTransform.setContentSize(58, 58);
+
     this.battleTransition = this.node.getComponent(VeilBattleTransition) ?? this.node.addComponent(VeilBattleTransition);
     this.updateLayout();
   }
@@ -1069,6 +1131,8 @@ export class VeilRoot extends Component {
     const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
     const accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
     const equipmentPanelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
+    const settingsPanelNode = this.node.getChildByName(SETTINGS_PANEL_NODE_NAME);
+    const settingsButtonNode = this.node.getChildByName(SETTINGS_BUTTON_NODE_NAME);
     const showingGame = !this.showLobby;
 
     if (lobbyNode) {
@@ -1091,6 +1155,12 @@ export class VeilRoot extends Component {
     }
     if (equipmentPanelNode) {
       equipmentPanelNode.active = showingGame && this.gameplayEquipmentPanelOpen;
+    }
+    if (settingsPanelNode) {
+      settingsPanelNode.active = this.settingsView.open;
+    }
+    if (settingsButtonNode) {
+      settingsButtonNode.active = true;
     }
 
     if (this.showLobby) {
@@ -1125,6 +1195,7 @@ export class VeilRoot extends Component {
         accountFlow: this.buildActiveAccountFlowPanelView(),
         presentationReadiness: cocosPresentationReadiness
       });
+      this.renderSettingsOverlay();
       return;
     }
 
@@ -1180,6 +1251,7 @@ export class VeilRoot extends Component {
       },
       presentation: this.buildHudPresentationState()
     });
+    this.renderSettingsOverlay();
     this.mapBoard?.render(this.lastUpdate);
     this.battlePanel?.render({
       update: this.lastUpdate,
@@ -1779,6 +1851,8 @@ export class VeilRoot extends Component {
     const lobbyNode = this.node.getChildByName(LOBBY_NODE_NAME);
     const accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
     const equipmentPanelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
+    const settingsPanelNode = this.node.getChildByName(SETTINGS_PANEL_NODE_NAME);
+    const settingsButtonNode = this.node.getChildByName(SETTINGS_BUTTON_NODE_NAME);
 
     this.mapBoard?.configure({
       tileSize: effectiveTileSize,
@@ -1801,6 +1875,9 @@ export class VeilRoot extends Component {
         },
         onRefresh: () => {
           void this.refreshSnapshot();
+        },
+        onToggleSettings: () => {
+          this.toggleSettingsPanel();
         },
         onToggleInventory: () => {
           this.toggleGameplayEquipmentPanel();
@@ -1890,14 +1967,24 @@ export class VeilRoot extends Component {
       equipmentPanelTransform.setContentSize(Math.max(360, Math.min(460, visibleSize.width - 56)), Math.max(420, visibleSize.height - 96));
       equipmentPanelNode.setPosition(0, 0, 4);
     }
+
+    if (settingsPanelNode) {
+      const settingsPanelTransform =
+        settingsPanelNode.getComponent(UITransform) ?? settingsPanelNode.addComponent(UITransform);
+      settingsPanelTransform.setContentSize(Math.max(360, Math.min(460, visibleSize.width - 64)), Math.max(440, visibleSize.height - 96));
+      settingsPanelNode.setPosition(0, 0, 6);
+    }
+
+    if (settingsButtonNode) {
+      const buttonTransform = settingsButtonNode.getComponent(UITransform) ?? settingsButtonNode.addComponent(UITransform);
+      buttonTransform.setContentSize(58, 58);
+      settingsButtonNode.setPosition(visibleSize.width / 2 - margin - 34, visibleSize.height / 2 - margin - 34, 7);
+      this.renderSettingsButton();
+    }
   }
 
   private handleHudActionInput(...args: unknown[]): void {
     this.audioRuntime.unlock();
-    if (this.showLobby) {
-      return;
-    }
-
     const event = args[0] as EventTouch | EventMouse | undefined;
     if (!event) {
       return;
@@ -1906,6 +1993,36 @@ export class VeilRoot extends Component {
     const visibleSize = view.getVisibleSize();
     const centeredX = event.getUILocation().x - visibleSize.width / 2;
     const centeredY = event.getUILocation().y - visibleSize.height / 2;
+    const settingsButtonNode = this.node.getChildByName(SETTINGS_BUTTON_NODE_NAME);
+    if (this.pointInRootNode(centeredX, centeredY, settingsButtonNode)) {
+      this.toggleSettingsPanel();
+      this.inputDebug = "button settings-fab";
+      return;
+    }
+
+    const settingsPanelNode = this.node.getChildByName(SETTINGS_PANEL_NODE_NAME);
+    const settingsPanelTransform = settingsPanelNode?.getComponent(UITransform) ?? null;
+    if (this.settingsView.open && settingsPanelNode && settingsPanelTransform) {
+      const settingsLocalX = centeredX - settingsPanelNode.position.x;
+      const settingsLocalY = centeredY - settingsPanelNode.position.y;
+      if (
+        settingsLocalX >= -settingsPanelTransform.width / 2
+        && settingsLocalX <= settingsPanelTransform.width / 2
+        && settingsLocalY >= -settingsPanelTransform.height / 2
+        && settingsLocalY <= settingsPanelTransform.height / 2
+      ) {
+        const action = this.settingsPanel?.dispatchPointerUp(settingsLocalX, settingsLocalY) ?? null;
+        if (action) {
+          this.inputDebug = `button ${action}`;
+        }
+        return;
+      }
+    }
+
+    if (this.showLobby) {
+      return;
+    }
+
     const hudNode = this.node.getChildByName(HUD_NODE_NAME);
     const hudTransform = hudNode?.getComponent(UITransform) ?? null;
     if (!hudNode || !hudTransform) {
@@ -2915,10 +3032,112 @@ export class VeilRoot extends Component {
     await this.syncLobbyBootstrap();
   }
 
+  private toggleSettingsPanel(open = !this.settingsView.open): void {
+    this.settingsView = applySettingsUpdate(this.settingsView, {
+      open,
+      deleteAccountPending: false,
+      withdrawConsentPending: false,
+      statusMessage: open ? null : this.settingsView.statusMessage
+    });
+    this.renderView();
+  }
+
+  private updateSettings(update: CocosSettingsPanelUpdate): void {
+    const resetPending = update.bgmVolume !== undefined || update.sfxVolume !== undefined || update.frameRateCap !== undefined;
+    this.settingsView = applySettingsUpdate(this.settingsView, {
+      ...update,
+      ...(resetPending ? { deleteAccountPending: false, withdrawConsentPending: false } : {})
+    });
+    this.persistSettings();
+    this.applyRuntimeSettings();
+    this.renderView();
+  }
+
+  private openSettingsPrivacyPolicy(): void {
+    const wxRuntime = (globalThis as {
+      wx?: {
+        openPrivacyContract?: (options?: { success?: () => void; fail?: (error?: unknown) => void }) => void;
+      } | null;
+    }).wx;
+    if (wxRuntime?.openPrivacyContract) {
+      wxRuntime.openPrivacyContract({
+        success: () => {
+          this.updateSettings({ statusMessage: "已打开微信隐私说明。" });
+        },
+        fail: () => {
+          this.updateSettings({ statusMessage: `隐私说明入口 ${this.settingsView.privacyPolicyUrl}` });
+        }
+      });
+      return;
+    }
+
+    const open = (globalThis as { open?: (url: string, target?: string) => void }).open;
+    if (typeof open === "function") {
+      open(this.settingsView.privacyPolicyUrl, "_blank");
+      this.updateSettings({ statusMessage: `已打开隐私说明 ${this.settingsView.privacyPolicyUrl}` });
+      return;
+    }
+
+    this.updateSettings({ statusMessage: `隐私说明 ${this.settingsView.privacyPolicyUrl}` });
+  }
+
+  private async handleSettingsLogout(): Promise<void> {
+    this.updateSettings({ statusMessage: "正在退出当前会话..." });
+    await this.logoutAuthSession();
+    this.settingsView = applySettingsUpdate(this.settingsView, {
+      open: false,
+      deleteAccountPending: false,
+      withdrawConsentPending: false,
+      statusMessage: "已退出当前会话。"
+    });
+    this.renderView();
+  }
+
+  private async handleSettingsDeleteAccount(): Promise<void> {
+    if (!this.settingsView.deleteAccountPending) {
+      this.updateSettings({
+        deleteAccountPending: true,
+        withdrawConsentPending: false,
+        statusMessage: "再次点击“删除账号”确认删除当前账号。"
+      });
+      return;
+    }
+
+    this.updateSettings({
+      statusMessage: "正在删除当前账号并撤销会话...",
+      deleteAccountPending: false
+    });
+
+    await this.deleteCurrentPlayerAccount();
+  }
+
+  private async handleSettingsWithdrawConsent(): Promise<void> {
+    if (!this.settingsView.withdrawConsentPending) {
+      this.updateSettings({
+        withdrawConsentPending: true,
+        deleteAccountPending: false,
+        statusMessage: "再次点击“撤回同意”以清除本地同意状态并退出当前会话。"
+      });
+      return;
+    }
+
+    this.privacyConsentAccepted = false;
+    this.updateSettings({
+      withdrawConsentPending: false,
+      statusMessage: "已撤回本地隐私同意，正在退出当前会话..."
+    });
+    await this.logoutAuthSession();
+    this.settingsView = applySettingsUpdate(this.settingsView, {
+      open: false,
+      statusMessage: "已撤回本地隐私同意；下次进入前请重新确认隐私说明。"
+    });
+    this.renderView();
+  }
+
   private async logoutAuthSession(): Promise<void> {
     this.stopMatchmakingPolling();
     this.updateMatchmakingStatus({ status: "idle" });
-    await logoutCurrentCocosAuthSession(this.remoteUrl, {
+    await resolveVeilRootRuntime().logoutAuthSession(this.remoteUrl, {
       storage: this.readWebStorage()
     });
     this.authToken = null;
@@ -2931,6 +3150,35 @@ export class VeilRoot extends Component {
     this.syncWechatShareBridge();
     this.lobbyStatus = "已退出当前会话，请重新选择游客身份或使用正式账号进入。";
     this.renderView();
+  }
+
+  private async deleteCurrentPlayerAccount(): Promise<void> {
+    this.stopMatchmakingPolling();
+    this.updateMatchmakingStatus({ status: "idle" });
+    await resolveVeilRootRuntime().deletePlayerAccount(this.remoteUrl, {
+      storage: this.readWebStorage()
+    });
+    this.authToken = null;
+    this.authMode = "guest";
+    this.authProvider = "guest";
+    this.loginId = "";
+    this.sessionSource = "none";
+    this.privacyConsentAccepted = false;
+    this.displayName = readPreferredCocosDisplayName(this.playerId, this.readWebStorage());
+    this.commitAccountProfile(createFallbackCocosPlayerAccountProfile(this.playerId, this.roomId, this.displayName), false);
+    await this.disposeCurrentSession();
+    this.resetSessionViewport("账号已删除。");
+    this.showLobby = true;
+    this.lobbyStatus = "账号已删除，原会话已撤销。请重新确认隐私说明后再创建新档。";
+    this.syncBrowserRoomQuery(null);
+    this.settingsView = applySettingsUpdate(this.settingsView, {
+      open: false,
+      deleteAccountPending: false,
+      withdrawConsentPending: false,
+      statusMessage: "账号已删除。"
+    });
+    this.renderView();
+    await this.syncLobbyBootstrap();
   }
 
   private buildActiveAccountFlowPanelView() {
@@ -3540,6 +3788,105 @@ export class VeilRoot extends Component {
     return `分享：${this.wechatShareStatus}`;
   }
 
+  private hydrateSettings(): void {
+    const wxRuntime = (globalThis as { wx?: unknown }).wx as { getStorageSync?: (key: string) => unknown } | null | undefined;
+    const persisted = readPersistedCocosSettings({
+      localStorage: this.readWebStorage(),
+      ...(wxRuntime ? { wx: wxRuntime } : {})
+    });
+    this.settingsView = applySettingsUpdate(this.settingsView, {
+      ...persisted,
+      privacyPolicyUrl: resolveCocosPrivacyPolicyUrl(globalThis.location)
+    });
+    this.applyRuntimeSettings();
+  }
+
+  private applyRuntimeSettings(): void {
+    this.audioRuntime.setBgmVolume(this.settingsView.bgmVolume);
+    this.audioRuntime.setSfxVolume(this.settingsView.sfxVolume);
+    const gameRuntime = (globalThis as {
+      game?: {
+        frameRate?: number;
+        setFrameRate?: (value: number) => void;
+      };
+    }).game;
+    if (typeof gameRuntime?.setFrameRate === "function") {
+      gameRuntime.setFrameRate(this.settingsView.frameRateCap);
+    } else {
+      const fallbackRuntime = (gameRuntime ?? (globalThis as { frameRate?: number })) as { frameRate?: number };
+      fallbackRuntime.frameRate = this.settingsView.frameRateCap;
+    }
+  }
+
+  private persistSettings(): void {
+    const wxRuntime = (globalThis as { wx?: unknown }).wx as { setStorageSync?: (key: string, value: string) => void } | null | undefined;
+    writePersistedCocosSettings(
+      {
+        bgmVolume: this.settingsView.bgmVolume,
+        sfxVolume: this.settingsView.sfxVolume,
+        frameRateCap: this.settingsView.frameRateCap
+      },
+      {
+        localStorage: this.readWebStorage(),
+        ...(wxRuntime ? { wx: wxRuntime } : {})
+      }
+    );
+  }
+
+  private buildSettingsView(): CocosSettingsPanelView {
+    return applySettingsUpdate(this.settingsView, {
+      displayName: this.displayName || this.playerId,
+      loginId: this.loginId,
+      authMode: this.authMode,
+      privacyConsentAccepted: this.privacyConsentAccepted,
+      privacyPolicyUrl: resolveCocosPrivacyPolicyUrl(globalThis.location)
+    });
+  }
+
+  private renderSettingsOverlay(): void {
+    this.settingsView = this.buildSettingsView();
+    this.settingsPanel?.render(this.settingsView);
+    this.renderSettingsButton();
+  }
+
+  private renderSettingsButton(): void {
+    const buttonNode = this.node.getChildByName(SETTINGS_BUTTON_NODE_NAME);
+    if (!buttonNode) {
+      return;
+    }
+
+    assignUiLayer(buttonNode);
+    const transform = buttonNode.getComponent(UITransform) ?? buttonNode.addComponent(UITransform);
+    const width = transform.width || 58;
+    const height = transform.height || 58;
+    const graphics = buttonNode.getComponent(Graphics) ?? buttonNode.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = this.settingsView.open ? new Color(108, 88, 54, 244) : new Color(52, 68, 92, 236);
+    graphics.strokeColor = this.settingsView.open ? new Color(244, 225, 180, 164) : new Color(226, 236, 248, 96);
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 16);
+    graphics.fill();
+    graphics.stroke();
+    graphics.fillColor = new Color(255, 255, 255, 18);
+    graphics.roundRect(-width / 2 + 10, height / 2 - 14, width - 20, 4, 2);
+    graphics.fill();
+
+    const labelNode = buttonNode.getChildByName("Label") ?? new Node("Label");
+    labelNode.parent = buttonNode;
+    assignUiLayer(labelNode);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(width - 8, height - 8);
+    labelNode.setPosition(0, 0, 1);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = "⚙";
+    label.fontSize = 26;
+    label.lineHeight = 28;
+    label.horizontalAlign = 1;
+    label.verticalAlign = 1;
+    label.enableWrapText = false;
+    label.color = new Color(244, 247, 252, 255);
+  }
+
   private syncWechatShareBridge(immediate = false) {
     const payload = buildCocosWechatSharePayload({
       roomId: this.roomId,
@@ -3577,6 +3924,24 @@ export class VeilRoot extends Component {
   private readWebStorage(): Storage | null {
     const webStorage = (sys as unknown as { localStorage?: Storage }).localStorage;
     return webStorage ?? null;
+  }
+
+  private pointInRootNode(centeredX: number, centeredY: number, node: Node | null): boolean {
+    if (!node || !node.active) {
+      return false;
+    }
+
+    const transform = node.getComponent(UITransform) ?? null;
+    if (!transform) {
+      return false;
+    }
+
+    return (
+      centeredX >= node.position.x - transform.width / 2
+      && centeredX <= node.position.x + transform.width / 2
+      && centeredY >= node.position.y - transform.height / 2
+      && centeredY <= node.position.y + transform.height / 2
+    );
   }
 
   private syncBrowserRoomQuery(roomId: string | null): void {

--- a/apps/cocos-client/assets/scripts/cocos-audio-runtime.ts
+++ b/apps/cocos-client/assets/scripts/cocos-audio-runtime.ts
@@ -66,12 +66,16 @@ export interface CocosAudioRuntimeState {
   cueCount: number;
   musicMode: CocosAudioPlaybackMode;
   cueMode: Exclude<CocosAudioPlaybackMode, "pending">;
+  bgmVolume: number;
+  sfxVolume: number;
 }
 
 export interface CocosAudioRuntime {
   unlock(): void;
   setScene(scene: CocosMusicScene | null): void;
   playCue(cue: CocosAudioCue): void;
+  setBgmVolume(volume: number): void;
+  setSfxVolume(volume: number): void;
   dispose(): void;
   getState(): CocosAudioRuntimeState;
 }
@@ -96,7 +100,21 @@ export function createCocosAudioRuntime(
   let cueCount = 0;
   let musicMode: CocosAudioPlaybackMode = "idle";
   let cueMode: Exclude<CocosAudioPlaybackMode, "pending"> = "idle";
+  let bgmVolume = 100;
+  let sfxVolume = 100;
   const assetClipCache = new Map<string, Promise<CocosAudioAssetClip | null>>();
+
+  function clampPercent(volume: number): number {
+    if (!Number.isFinite(volume)) {
+      return 100;
+    }
+
+    return Math.min(100, Math.max(0, Math.round(volume)));
+  }
+
+  function resolveScaledVolume(baseVolume: number, percent: number): number {
+    return baseVolume * (clampPercent(percent) / 100);
+  }
 
   function ensureContext(): AudioContextLike | null {
     if (!AudioContextCtor) {
@@ -220,7 +238,7 @@ export function createCocosAudioRuntime(
       if (clip) {
         clearLoop();
         assetBridge.stopMusic();
-        assetBridge.playMusic(clip, sequence.assetVolume);
+        assetBridge.playMusic(clip, resolveScaledVolume(sequence.assetVolume, bgmVolume));
         musicMode = "asset";
         notifyStateChange();
         return;
@@ -281,7 +299,7 @@ export function createCocosAudioRuntime(
       if (assetBridge && unlocked && sequence.assetPath) {
         void loadAssetClip(sequence.assetPath).then((clip) => {
           if (clip) {
-            assetBridge.playCue(clip, sequence.assetVolume);
+            assetBridge.playCue(clip, resolveScaledVolume(sequence.assetVolume, sfxVolume));
             cueMode = "asset";
             notifyStateChange();
             return;
@@ -296,6 +314,31 @@ export function createCocosAudioRuntime(
       cueMode = unlocked && AudioContextCtor ? "synth" : "idle";
       notifyStateChange();
       playSequence(sequence);
+    },
+    setBgmVolume(volume) {
+      const nextVolume = clampPercent(volume);
+      if (nextVolume === bgmVolume) {
+        return;
+      }
+
+      bgmVolume = nextVolume;
+      if (currentScene) {
+        activeToken += 1;
+        stopMusicPlayback();
+        if (unlocked || !supportsAnyPlayback()) {
+          void playSceneWithBestPath(currentScene, activeToken);
+        }
+      }
+      notifyStateChange();
+    },
+    setSfxVolume(volume) {
+      const nextVolume = clampPercent(volume);
+      if (nextVolume === sfxVolume) {
+        return;
+      }
+
+      sfxVolume = nextVolume;
+      notifyStateChange();
     },
     dispose() {
       stopMusicPlayback();
@@ -318,7 +361,9 @@ export function createCocosAudioRuntime(
         lastCue,
         cueCount,
         musicMode,
-        cueMode
+        cueMode,
+        bgmVolume,
+        sfxVolume
       };
     }
   };

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -918,6 +918,41 @@ export async function logoutCurrentCocosAuthSession(
   }
 }
 
+export async function deleteCurrentCocosPlayerAccount(
+  remoteUrl: string,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "removeItem"> | null;
+  }
+): Promise<{ playerId: string; displayName: string; deletedAt?: string } | null> {
+  const storage = options?.storage ?? getCocosStorage();
+  const currentSession = readStoredCocosAuthSession(storage);
+  if (!currentSession?.token) {
+    throw new Error("auth_session_required");
+  }
+
+  const payload = (await fetchJson(
+    `${resolveCocosApiBaseUrl(remoteUrl)}/api/players/me/delete`,
+    {
+      method: "POST",
+      headers: buildCocosAuthHeaders(currentSession.token)
+    },
+    options?.fetchImpl
+  )) as {
+    deleted?: {
+      playerId: string;
+      displayName: string;
+      deletedAt?: string;
+    } | null;
+  };
+
+  if (storage) {
+    clearStoredCocosAuthSession(storage);
+  }
+
+  return payload.deleted ?? null;
+}
+
 export function resolveCocosApiBaseUrl(
   remoteUrl: string,
   locationLike: Pick<Location, "protocol" | "hostname"> | null | undefined = globalThis.location

--- a/apps/cocos-client/assets/scripts/cocos-settings-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-settings-panel.ts
@@ -1,0 +1,568 @@
+import { _decorator, Color, Component, Graphics, Label, Node, UITransform } from "cc";
+import { assignUiLayer } from "./cocos-ui-layer.ts";
+
+const { ccclass } = _decorator;
+
+const H_ALIGN_LEFT = 0;
+const H_ALIGN_CENTER = 1;
+const V_ALIGN_TOP = 0;
+const V_ALIGN_MIDDLE = 1;
+const OVERFLOW_RESIZE_HEIGHT = 3;
+const SETTINGS_STORAGE_KEY = "veil_settings";
+const SETTINGS_PANEL_BG = new Color(18, 25, 38, 244);
+const SETTINGS_PANEL_BORDER = new Color(235, 241, 248, 96);
+const SETTINGS_ACCENT = new Color(214, 184, 124, 255);
+const SETTINGS_CARD_BG = new Color(34, 46, 66, 224);
+const SETTINGS_CARD_BORDER = new Color(232, 240, 248, 52);
+const SETTINGS_TRACK_BG = new Color(58, 72, 94, 220);
+const SETTINGS_TEXT = new Color(244, 247, 252, 255);
+const SETTINGS_MUTED_TEXT = new Color(213, 222, 236, 220);
+const SETTINGS_DANGER = new Color(144, 78, 70, 236);
+const SETTINGS_CONFIRM = new Color(108, 84, 52, 236);
+const SETTINGS_BUTTON = new Color(72, 95, 124, 236);
+
+export interface CocosStoredSettings {
+  bgmVolume: number;
+  sfxVolume: number;
+  frameRateCap: 30 | 60;
+}
+
+export interface CocosSettingsPanelView extends CocosStoredSettings {
+  open: boolean;
+  displayName: string;
+  loginId: string;
+  authMode: "guest" | "account";
+  privacyConsentAccepted: boolean;
+  statusMessage: string | null;
+  deleteAccountPending: boolean;
+  withdrawConsentPending: boolean;
+  privacyPolicyUrl: string;
+}
+
+export interface CocosSettingsPanelUpdate {
+  open?: boolean;
+  bgmVolume?: number;
+  sfxVolume?: number;
+  frameRateCap?: 30 | 60 | number;
+  displayName?: string;
+  loginId?: string;
+  authMode?: "guest" | "account";
+  privacyConsentAccepted?: boolean;
+  statusMessage?: string | null;
+  deleteAccountPending?: boolean;
+  withdrawConsentPending?: boolean;
+  privacyPolicyUrl?: string;
+}
+
+interface CocosSettingsLocalStorageLike {
+  getItem?(key: string): string | null;
+  setItem?(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+interface CocosSettingsWechatRuntimeLike {
+  getStorageSync?(key: string): unknown;
+  setStorageSync?(key: string, value: string): void;
+  removeStorageSync?(key: string): void;
+  openPrivacyContract?(
+    options?: {
+      success?: () => void;
+      fail?: (error?: unknown) => void;
+    }
+  ): void;
+}
+
+export interface CocosSettingsPersistenceRuntime {
+  localStorage?: CocosSettingsLocalStorageLike | null;
+  wx?: CocosSettingsWechatRuntimeLike | null;
+}
+
+export interface CocosSettingsPanelOptions {
+  onClose?: () => void;
+  onUpdate?: (update: CocosSettingsPanelUpdate) => void;
+  onLogout?: () => void;
+  onDeleteAccount?: () => void;
+  onWithdrawConsent?: () => void;
+  onOpenPrivacyPolicy?: () => void;
+}
+
+export function createDefaultCocosSettingsView(
+  update: Partial<CocosSettingsPanelView> = {}
+): CocosSettingsPanelView {
+  return applySettingsUpdate(
+    {
+      open: false,
+      bgmVolume: 54,
+      sfxVolume: 76,
+      frameRateCap: 60,
+      displayName: "",
+      loginId: "",
+      authMode: "guest",
+      privacyConsentAccepted: false,
+      statusMessage: null,
+      deleteAccountPending: false,
+      withdrawConsentPending: false,
+      privacyPolicyUrl: resolveCocosPrivacyPolicyUrl()
+    },
+    update
+  );
+}
+
+export function getCocosSettingsStorageKey(): string {
+  return SETTINGS_STORAGE_KEY;
+}
+
+export function clampSettingsVolume(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.min(100, Math.max(0, Math.round(value)));
+}
+
+function normalizeFrameRateCap(value: unknown, fallback: 30 | 60): 30 | 60 {
+  return value === 30 ? 30 : value === 60 ? 60 : fallback;
+}
+
+export function applySettingsUpdate(
+  state: CocosSettingsPanelView,
+  update: CocosSettingsPanelUpdate
+): CocosSettingsPanelView {
+  return {
+    ...state,
+    ...update,
+    bgmVolume: clampSettingsVolume(update.bgmVolume ?? state.bgmVolume, state.bgmVolume),
+    sfxVolume: clampSettingsVolume(update.sfxVolume ?? state.sfxVolume, state.sfxVolume),
+    frameRateCap: normalizeFrameRateCap(update.frameRateCap ?? state.frameRateCap, state.frameRateCap)
+  };
+}
+
+export function serializeCocosSettings(settings: CocosStoredSettings): string {
+  return JSON.stringify({
+    bgmVolume: clampSettingsVolume(settings.bgmVolume, 54),
+    sfxVolume: clampSettingsVolume(settings.sfxVolume, 76),
+    frameRateCap: normalizeFrameRateCap(settings.frameRateCap, 60)
+  });
+}
+
+export function deserializeCocosSettings(raw: unknown): CocosStoredSettings {
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  const candidate = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+  return {
+    bgmVolume: clampSettingsVolume(
+      typeof candidate.bgmVolume === "number" ? candidate.bgmVolume : Number(candidate.bgmVolume),
+      54
+    ),
+    sfxVolume: clampSettingsVolume(
+      typeof candidate.sfxVolume === "number" ? candidate.sfxVolume : Number(candidate.sfxVolume),
+      76
+    ),
+    frameRateCap: normalizeFrameRateCap(candidate.frameRateCap, 60)
+  };
+}
+
+export function readPersistedCocosSettings(
+  runtime: CocosSettingsPersistenceRuntime = globalThis as CocosSettingsPersistenceRuntime
+): CocosStoredSettings {
+  const wxRuntime = runtime.wx ?? null;
+  if (wxRuntime?.getStorageSync) {
+    return deserializeCocosSettings(wxRuntime.getStorageSync(SETTINGS_STORAGE_KEY));
+  }
+
+  const localStorage = runtime.localStorage ?? null;
+  return deserializeCocosSettings(localStorage?.getItem?.(SETTINGS_STORAGE_KEY) ?? null);
+}
+
+export function writePersistedCocosSettings(
+  settings: CocosStoredSettings,
+  runtime: CocosSettingsPersistenceRuntime = globalThis as CocosSettingsPersistenceRuntime
+): void {
+  const serialized = serializeCocosSettings(settings);
+  const wxRuntime = runtime.wx ?? null;
+  if (wxRuntime?.setStorageSync) {
+    wxRuntime.setStorageSync(SETTINGS_STORAGE_KEY, serialized);
+    return;
+  }
+
+  runtime.localStorage?.setItem?.(SETTINGS_STORAGE_KEY, serialized);
+}
+
+export function resolveCocosPrivacyPolicyUrl(
+  locationLike: Pick<Location, "href"> | null | undefined = globalThis.location
+): string {
+  try {
+    return new URL("/config-center.html", locationLike?.href ?? "https://project-veil.invalid/").toString();
+  } catch {
+    return "/config-center.html";
+  }
+}
+
+function ensureLabel(
+  parent: Node,
+  name: string,
+  width: number,
+  height: number,
+  fontSize: number,
+  lineHeight: number,
+  align: number,
+  verticalAlign: number,
+  color = SETTINGS_TEXT
+): Label {
+  let node = parent.getChildByName(name);
+  if (!node) {
+    node = new Node(name);
+    node.parent = parent;
+  }
+  assignUiLayer(node);
+  const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+  transform.setContentSize(width, height);
+  const label = node.getComponent(Label) ?? node.addComponent(Label);
+  label.fontSize = fontSize;
+  label.lineHeight = lineHeight;
+  label.horizontalAlign = align;
+  label.verticalAlign = verticalAlign;
+  label.overflow = OVERFLOW_RESIZE_HEIGHT;
+  label.enableWrapText = true;
+  label.color = color;
+  return label;
+}
+
+function pointInNode(localX: number, localY: number, root: Node, node: Node | null): boolean {
+  if (!node || !node.active) {
+    return false;
+  }
+
+  const transform = node.getComponent(UITransform) ?? null;
+  if (!transform) {
+    return false;
+  }
+
+  let centerX = 0;
+  let centerY = 0;
+  let current: Node | null = node;
+  while (current && current !== root) {
+    centerX += current.position.x;
+    centerY += current.position.y;
+    current = current.parent;
+  }
+
+  if (current !== root) {
+    return false;
+  }
+
+  return (
+    localX >= centerX - transform.width / 2
+    && localX <= centerX + transform.width / 2
+    && localY >= centerY - transform.height / 2
+    && localY <= centerY + transform.height / 2
+  );
+}
+
+function renderCard(parent: Node, name: string, centerY: number, width: number, height: number): Node {
+  let cardNode = parent.getChildByName(name);
+  if (!cardNode) {
+    cardNode = new Node(name);
+    cardNode.parent = parent;
+  }
+  assignUiLayer(cardNode);
+  const transform = cardNode.getComponent(UITransform) ?? cardNode.addComponent(UITransform);
+  transform.setContentSize(width, height);
+  cardNode.setPosition(0, centerY, 0.5);
+  const graphics = cardNode.getComponent(Graphics) ?? cardNode.addComponent(Graphics);
+  graphics.clear();
+  graphics.fillColor = SETTINGS_CARD_BG;
+  graphics.strokeColor = SETTINGS_CARD_BORDER;
+  graphics.lineWidth = 2;
+  graphics.roundRect(-width / 2, -height / 2, width, height, 16);
+  graphics.fill();
+  graphics.stroke();
+  graphics.fillColor = new Color(255, 255, 255, 18);
+  graphics.roundRect(-width / 2 + 14, height / 2 - 16, width - 28, 4, 2);
+  graphics.fill();
+  graphics.fillColor = SETTINGS_ACCENT;
+  graphics.roundRect(-width / 2 + 16, height / 2 - 14, Math.min(86, width * 0.28), 2, 1);
+  graphics.fill();
+  return cardNode;
+}
+
+function renderActionButton(
+  parent: Node,
+  name: string,
+  labelText: string,
+  centerX: number,
+  centerY: number,
+  width: number,
+  height: number,
+  fillColor: Color,
+  strokeColor: Color
+): void {
+  let buttonNode = parent.getChildByName(name);
+  if (!buttonNode) {
+    buttonNode = new Node(name);
+    buttonNode.parent = parent;
+  }
+  assignUiLayer(buttonNode);
+  buttonNode.active = true;
+
+  const transform = buttonNode.getComponent(UITransform) ?? buttonNode.addComponent(UITransform);
+  transform.setContentSize(width, height);
+  buttonNode.setPosition(centerX, centerY, 1);
+  const graphics = buttonNode.getComponent(Graphics) ?? buttonNode.addComponent(Graphics);
+  graphics.clear();
+  graphics.fillColor = fillColor;
+  graphics.strokeColor = strokeColor;
+  graphics.lineWidth = 2;
+  graphics.roundRect(-width / 2, -height / 2, width, height, 10);
+  graphics.fill();
+  graphics.stroke();
+  const label = ensureLabel(buttonNode, "Label", width - 16, height - 8, 12, 14, H_ALIGN_CENTER, V_ALIGN_MIDDLE);
+  label.node.setPosition(0, 0, 1);
+  label.string = labelText;
+}
+
+function renderSlider(parent: Node, name: string, labelText: string, value: number, centerY: number, width: number): void {
+  const trackNode = renderCard(parent, name, centerY, width, 72);
+  const title = ensureLabel(trackNode, "Title", width - 28, 18, 13, 15, H_ALIGN_LEFT, V_ALIGN_MIDDLE);
+  title.node.setPosition(0, 18, 1);
+  title.string = `${labelText} ${value}`;
+
+  let trackHitbox = trackNode.getChildByName("Track");
+  if (!trackHitbox) {
+    trackHitbox = new Node("Track");
+    trackHitbox.parent = trackNode;
+  }
+  assignUiLayer(trackHitbox);
+  const trackTransform = trackHitbox.getComponent(UITransform) ?? trackHitbox.addComponent(UITransform);
+  trackTransform.setContentSize(width - 40, 18);
+  trackHitbox.setPosition(0, -10, 1);
+  const graphics = trackHitbox.getComponent(Graphics) ?? trackHitbox.addComponent(Graphics);
+  const trackWidth = trackTransform.width;
+  graphics.clear();
+  graphics.fillColor = SETTINGS_TRACK_BG;
+  graphics.roundRect(-trackWidth / 2, -9, trackWidth, 18, 9);
+  graphics.fill();
+  graphics.fillColor = new Color(255, 255, 255, 18);
+  graphics.roundRect(-trackWidth / 2 + 2, -7, trackWidth - 4, 5, 2);
+  graphics.fill();
+  graphics.fillColor = SETTINGS_ACCENT;
+  graphics.roundRect(-trackWidth / 2, -9, Math.max(18, Math.round(trackWidth * (value / 100))), 18, 9);
+  graphics.fill();
+
+  let thumbNode = trackHitbox.getChildByName("Thumb");
+  if (!thumbNode) {
+    thumbNode = new Node("Thumb");
+    thumbNode.parent = trackHitbox;
+  }
+  assignUiLayer(thumbNode);
+  const thumbTransform = thumbNode.getComponent(UITransform) ?? thumbNode.addComponent(UITransform);
+  thumbTransform.setContentSize(18, 18);
+  thumbNode.setPosition(-trackWidth / 2 + trackWidth * (value / 100), 0, 1);
+  const thumbGraphics = thumbNode.getComponent(Graphics) ?? thumbNode.addComponent(Graphics);
+  thumbGraphics.clear();
+  thumbGraphics.fillColor = new Color(250, 246, 236, 255);
+  thumbGraphics.circle(0, 0, 7);
+  thumbGraphics.fill();
+}
+
+@ccclass("CocosSettingsPanel")
+export class CocosSettingsPanel extends Component {
+  private currentState: CocosSettingsPanelView = createDefaultCocosSettingsView();
+  private onClose: (() => void) | undefined;
+  private onUpdate: ((update: CocosSettingsPanelUpdate) => void) | undefined;
+  private onLogout: (() => void) | undefined;
+  private onDeleteAccount: (() => void) | undefined;
+  private onWithdrawConsent: (() => void) | undefined;
+  private onOpenPrivacyPolicy: (() => void) | undefined;
+
+  configure(options: CocosSettingsPanelOptions): void {
+    this.onClose = options.onClose;
+    this.onUpdate = options.onUpdate;
+    this.onLogout = options.onLogout;
+    this.onDeleteAccount = options.onDeleteAccount;
+    this.onWithdrawConsent = options.onWithdrawConsent;
+    this.onOpenPrivacyPolicy = options.onOpenPrivacyPolicy;
+  }
+
+  render(state: CocosSettingsPanelView): void {
+    this.currentState = state;
+    this.node.active = state.open;
+    if (!state.open) {
+      return;
+    }
+
+    const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const width = transform.width || 420;
+    const height = transform.height || 520;
+    const graphics = this.node.getComponent(Graphics) ?? this.node.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = SETTINGS_PANEL_BG;
+    graphics.strokeColor = SETTINGS_PANEL_BORDER;
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 22);
+    graphics.fill();
+    graphics.stroke();
+
+    const title = ensureLabel(this.node, "Title", width - 92, 48, 22, 24, H_ALIGN_LEFT, V_ALIGN_MIDDLE);
+    title.node.setPosition(-18, height / 2 - 34, 1);
+    title.string = "设置";
+
+    const subtitle = ensureLabel(this.node, "Subtitle", width - 92, 24, 11, 13, H_ALIGN_LEFT, V_ALIGN_MIDDLE, SETTINGS_MUTED_TEXT);
+    subtitle.node.setPosition(-18, height / 2 - 58, 1);
+    subtitle.string = "音频、显示、账号与隐私";
+
+    renderActionButton(
+      this.node,
+      "SettingsClose",
+      "关闭",
+      width / 2 - 46,
+      height / 2 - 42,
+      74,
+      30,
+      new Color(74, 90, 112, 236),
+      new Color(223, 233, 244, 94)
+    );
+
+    renderSlider(this.node, "SettingsBgm", "音频 BGM", state.bgmVolume, 150, width - 36);
+    renderSlider(this.node, "SettingsSfx", "音频 SFX", state.sfxVolume, 68, width - 36);
+
+    const displayCard = renderCard(this.node, "SettingsDisplay", -20, width - 36, 84);
+    const displayLabel = ensureLabel(displayCard, "DisplayTitle", width - 64, 20, 13, 15, H_ALIGN_LEFT, V_ALIGN_MIDDLE);
+    displayLabel.node.setPosition(0, 22, 1);
+    displayLabel.string = `显示 帧率上限 ${state.frameRateCap} fps`;
+    renderActionButton(
+      displayCard,
+      "SettingsFps30",
+      "30 FPS",
+      -70,
+      -10,
+      110,
+      30,
+      state.frameRateCap === 30 ? SETTINGS_ACCENT : SETTINGS_BUTTON,
+      new Color(245, 228, 182, state.frameRateCap === 30 ? 146 : 72)
+    );
+    renderActionButton(
+      displayCard,
+      "SettingsFps60",
+      "60 FPS",
+      70,
+      -10,
+      110,
+      30,
+      state.frameRateCap === 60 ? SETTINGS_ACCENT : SETTINGS_BUTTON,
+      new Color(245, 228, 182, state.frameRateCap === 60 ? 146 : 72)
+    );
+
+    const accountCard = renderCard(this.node, "SettingsAccount", -126, width - 36, 108);
+    const accountLabel = ensureLabel(accountCard, "AccountLabel", width - 64, 44, 13, 16, H_ALIGN_LEFT, V_ALIGN_TOP);
+    accountLabel.node.setPosition(0, 18, 1);
+    accountLabel.string = `账号 ${state.displayName || "未命名玩家"}\n${state.authMode === "account" ? `登录 ${state.loginId || state.displayName}` : "游客会话"}`;
+    renderActionButton(accountCard, "SettingsLogout", "退出登录", -76, -22, 118, 30, SETTINGS_BUTTON, new Color(221, 232, 246, 88));
+    renderActionButton(
+      accountCard,
+      "SettingsDelete",
+      state.deleteAccountPending ? "确认删除" : "删除账号",
+      76,
+      -22,
+      118,
+      30,
+      state.deleteAccountPending ? SETTINGS_CONFIRM : SETTINGS_DANGER,
+      new Color(246, 224, 208, 104)
+    );
+
+    const privacyCard = renderCard(this.node, "SettingsPrivacy", -244, width - 36, 118);
+    const privacyLabel = ensureLabel(privacyCard, "PrivacyLabel", width - 64, 42, 13, 16, H_ALIGN_LEFT, V_ALIGN_TOP);
+    privacyLabel.node.setPosition(0, 26, 1);
+    privacyLabel.string = `隐私 ${state.privacyConsentAccepted ? "已记录同意" : "未记录同意"}\n可重新查看说明或撤回本地同意状态`;
+    renderActionButton(privacyCard, "SettingsPrivacyLink", "隐私说明", -76, -20, 118, 30, SETTINGS_BUTTON, new Color(221, 232, 246, 88));
+    renderActionButton(
+      privacyCard,
+      "SettingsWithdraw",
+      state.withdrawConsentPending ? "确认撤回" : "撤回同意",
+      76,
+      -20,
+      118,
+      30,
+      state.withdrawConsentPending ? SETTINGS_CONFIRM : SETTINGS_DANGER,
+      new Color(246, 224, 208, 104)
+    );
+
+    const status = ensureLabel(this.node, "Status", width - 44, 44, 11, 14, H_ALIGN_LEFT, V_ALIGN_TOP, SETTINGS_MUTED_TEXT);
+    status.node.setPosition(0, -height / 2 + 34, 1);
+    status.string =
+      state.statusMessage
+      ?? `存储键 ${SETTINGS_STORAGE_KEY} · 隐私说明 ${state.privacyPolicyUrl}`;
+  }
+
+  dispatchPointerUp(localX: number, localY: number): string | null {
+    if (!this.currentState.open) {
+      return null;
+    }
+
+    const closeButton = this.node.getChildByName("SettingsClose");
+    if (pointInNode(localX, localY, this.node, closeButton)) {
+      this.onClose?.();
+      return "settings-close";
+    }
+
+    const bgmTrack = this.node.getChildByName("SettingsBgm")?.getChildByName("Track") ?? null;
+    if (pointInNode(localX, localY, this.node, bgmTrack)) {
+      const transform = bgmTrack?.getComponent(UITransform) ?? null;
+      if (transform) {
+        const relative = Math.min(1, Math.max(0, (localX - (bgmTrack?.position.x ?? 0) + transform.width / 2) / transform.width));
+        this.onUpdate?.({
+          bgmVolume: Math.round(relative * 100),
+          statusMessage: null
+        });
+        return "settings-bgm";
+      }
+    }
+
+    const sfxTrack = this.node.getChildByName("SettingsSfx")?.getChildByName("Track") ?? null;
+    if (pointInNode(localX, localY, this.node, sfxTrack)) {
+      const transform = sfxTrack?.getComponent(UITransform) ?? null;
+      if (transform) {
+        const relative = Math.min(1, Math.max(0, (localX - (sfxTrack?.position.x ?? 0) + transform.width / 2) / transform.width));
+        this.onUpdate?.({
+          sfxVolume: Math.round(relative * 100),
+          statusMessage: null
+        });
+        return "settings-sfx";
+      }
+    }
+
+    const clickableActions: Array<{ name: string; result: string; callback: (() => void) | undefined }> = [
+      { name: "SettingsFps30", result: "settings-fps-30", callback: () => this.onUpdate?.({ frameRateCap: 30, statusMessage: null }) },
+      { name: "SettingsFps60", result: "settings-fps-60", callback: () => this.onUpdate?.({ frameRateCap: 60, statusMessage: null }) },
+      { name: "SettingsLogout", result: "settings-logout", callback: this.onLogout },
+      { name: "SettingsDelete", result: "settings-delete", callback: this.onDeleteAccount },
+      { name: "SettingsPrivacyLink", result: "settings-privacy-link", callback: this.onOpenPrivacyPolicy },
+      { name: "SettingsWithdraw", result: "settings-withdraw", callback: this.onWithdrawConsent }
+    ];
+
+    for (const action of clickableActions) {
+      let node: Node | null = this.node.getChildByName(action.name);
+      if (!node) {
+        for (const child of this.node.children ?? []) {
+          node = child.getChildByName(action.name);
+          if (node) {
+            break;
+          }
+        }
+      }
+      if (pointInNode(localX, localY, this.node, node)) {
+        action.callback?.();
+        return action.result;
+      }
+    }
+
+    return null;
+  }
+}

--- a/apps/cocos-client/test/cocos-audio-runtime.test.ts
+++ b/apps/cocos-client/test/cocos-audio-runtime.test.ts
@@ -25,7 +25,9 @@ test("audio runtime keeps scene and cue state when AudioContext is unavailable",
     lastCue: null,
     cueCount: 0,
     musicMode: "idle",
-    cueMode: "idle"
+    cueMode: "idle",
+    bgmVolume: 100,
+    sfxVolume: 100
   });
 
   runtime.setScene("explore");
@@ -109,7 +111,9 @@ test("audio runtime waits for a user gesture before creating WebAudio context", 
     lastCue: "attack",
     cueCount: 1,
     musicMode: "pending",
-    cueMode: "idle"
+    cueMode: "idle",
+    bgmVolume: 100,
+    sfxVolume: 100
   });
   assert.equal(audioContextCount, 0);
   assert.equal(starts.length, 0);

--- a/apps/cocos-client/test/cocos-hud-panel.test.ts
+++ b/apps/cocos-client/test/cocos-hud-panel.test.ts
@@ -60,7 +60,9 @@ function createHudState(): VeilHudRenderState {
         lastCue: null,
         cueCount: 0,
         musicMode: "idle",
-        cueMode: "idle"
+        cueMode: "idle",
+        bgmVolume: 100,
+        sfxVolume: 100
       },
       pixelAssets: {
         phase: "idle",

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -234,6 +234,44 @@ test("VeilRoot toggles a dedicated gameplay equipment panel from the HUD flow", 
   assert.equal(root.gameplayEquipmentPanelOpen, false);
 });
 
+test("VeilRoot settings logout routes through the auth revoke path", async () => {
+  const storage = createMemoryStorage();
+  (sys as unknown as { localStorage: Storage }).localStorage = storage;
+
+  const root = createVeilRootHarness();
+  root.remoteUrl = "http://127.0.0.1:2567";
+  root.playerId = "player-settings";
+  root.displayName = "雾港旅人";
+  root.authToken = "signed.token";
+  root.authMode = "account";
+  root.loginId = "veil-ranger";
+  root.settingsView = {
+    ...root.settingsView,
+    open: true
+  };
+
+  const logoutCalls: Array<{ remoteUrl: string; hasStorage: boolean }> = [];
+  installVeilRootRuntime({
+    logoutAuthSession: async (remoteUrl, options) => {
+      logoutCalls.push({
+        remoteUrl,
+        hasStorage: Boolean(options?.storage)
+      });
+    }
+  });
+
+  await root.handleSettingsLogout();
+
+  assert.deepEqual(logoutCalls, [
+    {
+      remoteUrl: "http://127.0.0.1:2567",
+      hasStorage: true
+    }
+  ]);
+  assert.equal(root.authToken, null);
+  assert.equal(root.authMode, "guest");
+});
+
 test("VeilRoot emits primary-client telemetry for progression, inventory, and combat checkpoints", async () => {
   const root = createVeilRootHarness();
   root.roomId = "room-telemetry";
@@ -436,6 +474,7 @@ test("VeilRoot gameplay account refresh skips remote profile loads for local ses
 
 test("VeilRoot account lifecycle flow switches panels and surfaces validation feedback", async () => {
   const root = createVeilRootHarness();
+  root.privacyConsentAccepted = true;
 
   await root.registerLobbyAccount();
   assert.equal(root.activeAccountFlow, "registration");
@@ -846,6 +885,7 @@ test("VeilRoot lobby handoff enters a room with the authenticated session and li
   root.roomId = "room-bravo";
   root.playerId = "guest-7";
   root.displayName = "Guest 7";
+  root.privacyConsentAccepted = true;
 
   const liveUpdate = createSessionUpdate(4, "room-bravo", "guest-7");
   const fakeSession = {
@@ -908,6 +948,7 @@ test("VeilRoot keeps the lobby visible and explains when an account session has 
   root.authProvider = "account-password";
   root.loginId = "veil-ranger";
   root.sessionSource = "remote";
+  root.privacyConsentAccepted = true;
 
   installVeilRootRuntime({
     syncAuthSession: async () => null
@@ -1090,7 +1131,9 @@ test("VeilRoot battle flow switches transition state and fallback audio scenes t
     lastCue: null,
     cueCount: 0,
     musicMode: "synth",
-    cueMode: "idle"
+    cueMode: "idle",
+    bgmVolume: 100,
+    sfxVolume: 100
   });
   assert.equal(root.battlePresentation.getState().phase, "enter");
 
@@ -1106,7 +1149,9 @@ test("VeilRoot battle flow switches transition state and fallback audio scenes t
     lastCue: "victory",
     cueCount: 1,
     musicMode: "synth",
-    cueMode: "idle"
+    cueMode: "idle",
+    bgmVolume: 100,
+    sfxVolume: 100
   });
   assert.equal(root.battlePresentation.getState().phase, "resolution");
   root.audioRuntime.dispose();

--- a/apps/cocos-client/test/cocos-settings-panel.test.ts
+++ b/apps/cocos-client/test/cocos-settings-panel.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applySettingsUpdate,
+  createDefaultCocosSettingsView,
+  deserializeCocosSettings,
+  serializeCocosSettings
+} from "../assets/scripts/cocos-settings-panel.ts";
+
+test("applySettingsUpdate clamps volume between 0 and 100", () => {
+  const state = createDefaultCocosSettingsView();
+
+  assert.equal(applySettingsUpdate(state, { bgmVolume: -14 }).bgmVolume, 0);
+  assert.equal(applySettingsUpdate(state, { sfxVolume: 148 }).sfxVolume, 100);
+  assert.equal(applySettingsUpdate(state, { bgmVolume: 49.6 }).bgmVolume, 50);
+});
+
+test("settings round-trip through storage serialization correctly", () => {
+  const serialized = serializeCocosSettings({
+    bgmVolume: 22,
+    sfxVolume: 91,
+    frameRateCap: 30
+  });
+
+  assert.deepEqual(deserializeCocosSettings(serialized), {
+    bgmVolume: 22,
+    sfxVolume: 91,
+    frameRateCap: 30
+  });
+  assert.deepEqual(deserializeCocosSettings("{\"bgmVolume\":-10,\"sfxVolume\":400,\"frameRateCap\":120}"), {
+    bgmVolume: 0,
+    sfxVolume: 100,
+    frameRateCap: 60
+  });
+});

--- a/packages/cc-runtime-stub/index.js
+++ b/packages/cc-runtime-stub/index.js
@@ -362,6 +362,13 @@ export const input = {
   off() {}
 };
 
+export const game = {
+  frameRate: 60,
+  setFrameRate(value) {
+    this.frameRate = value;
+  }
+};
+
 export const resources = {
   load(_path, Type, callback) {
     callback(null, new Type());


### PR DESCRIPTION
## Summary
- add a Cocos in-game settings overlay with audio, display, account, and privacy sections plus persisted H5/WeChat settings
- surface settings entry points from the floating gear button and the HUD action bar, and apply audio/frame-rate settings during boot
- cover the pure settings reducer/storage round-trip and the settings logout auth revoke path with focused Cocos tests

## Validation
- `node --import tsx --test apps/cocos-client/test/cocos-settings-panel.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-audio-runtime.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-hud-panel.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-root-orchestration.test.ts`
- `npm run typecheck:cocos`

Closes #837
