### PR TITLE
feat: add WeChat battle result sharing and referrals

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -200,6 +200,9 @@ export interface VeilHudRenderState {
     status: string | null;
     submitting: boolean;
   };
+  sharing: {
+    available: boolean;
+  };
   presentation: {
     audio: CocosAudioRuntimeState;
     pixelAssets: PixelSpriteLoadStatus;
@@ -235,6 +238,7 @@ export interface VeilHudPanelOptions {
   onToggleAchievements?: () => void;
   onToggleReport?: () => void;
   onToggleSurrender?: () => void;
+  onShareBattleResult?: () => void;
   onSubmitReport?: (reason: PlayerReportReason) => void;
   onCancelReport?: () => void;
   onConfirmSurrender?: () => void;
@@ -345,6 +349,7 @@ export class VeilHudPanel extends Component {
   private onToggleAchievements: (() => void) | undefined;
   private onToggleReport: (() => void) | undefined;
   private onToggleSurrender: (() => void) | undefined;
+  private onShareBattleResult: (() => void) | undefined;
   private onSubmitReport: ((reason: PlayerReportReason) => void) | undefined;
   private onCancelReport: (() => void) | undefined;
   private onConfirmSurrender: (() => void) | undefined;
@@ -364,6 +369,7 @@ export class VeilHudPanel extends Component {
     this.onToggleAchievements = options.onToggleAchievements;
     this.onToggleReport = options.onToggleReport;
     this.onToggleSurrender = options.onToggleSurrender;
+    this.onShareBattleResult = options.onShareBattleResult;
     this.onSubmitReport = options.onSubmitReport;
     this.onCancelReport = options.onCancelReport;
     this.onConfirmSurrender = options.onConfirmSurrender;
@@ -660,6 +666,7 @@ export class VeilHudPanel extends Component {
       { nodeName: "HudAchievements", debugLabel: "achievements", callback: this.onToggleAchievements ?? null },
       { nodeName: "HudReportPlayer", debugLabel: "report-player", callback: this.onToggleReport ?? null },
       { nodeName: "HudSurrender", debugLabel: "surrender", callback: this.onToggleSurrender ?? null },
+      { nodeName: "HudShareBattleResult", debugLabel: "share-battle-result", callback: this.onShareBattleResult ?? null },
       { nodeName: "HudEndDay", debugLabel: "end-day", callback: this.onEndDay ?? null },
       { nodeName: "HudReturnLobby", debugLabel: "return-lobby", callback: this.onReturnLobby ?? null }
     ];
@@ -1602,6 +1609,7 @@ export class VeilHudPanel extends Component {
     this.ensureActionButton(actionsNode, "HudAchievements", "战报中心");
     this.ensureActionButton(actionsNode, "HudReportPlayer", "举报玩家");
     this.ensureActionButton(actionsNode, "HudSurrender", "认输");
+    this.ensureActionButton(actionsNode, "HudShareBattleResult", "分享战绩");
     this.ensureActionButton(actionsNode, "HudEndDay", "推进一天");
     this.ensureActionButton(actionsNode, "HudReturnLobby", "返回大厅");
   }
@@ -1626,6 +1634,12 @@ export class VeilHudPanel extends Component {
         label: "认输",
         callback: this.onToggleSurrender ?? null,
         visible: this.currentState?.surrendering.available ?? false
+      },
+      {
+        name: "HudShareBattleResult",
+        label: "分享战绩",
+        callback: this.onShareBattleResult ?? null,
+        visible: this.currentState?.sharing.available ?? false
       },
       { name: "HudEndDay", label: "推进一天", callback: this.onEndDay ?? null },
       { name: "HudReturnLobby", label: "返回大厅", callback: this.onReturnLobby ?? null }

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -35,6 +35,7 @@ import {
   loadCocosPlayerProgressionSnapshot,
   loginCocosGuestAuthSession,
   logoutCurrentCocosAuthSession,
+  postCocosPlayerReferral,
   readPreferredCocosDisplayName,
   rememberPreferredCocosDisplayName,
   requestCocosAccountRegistration,
@@ -103,6 +104,14 @@ import {
   collectProfileNoticeEventIds,
   shouldRefreshGameplayAccountProfileForEvents
 } from "./cocos-achievements.ts";
+import {
+  buildBattleResultShareSummary,
+  buildShareCardPayload,
+  copyTextToClipboard,
+  readLaunchReferrerId,
+  shouldOfferBattleResultShare,
+  type WechatSharePayload
+} from "./cocos-share-card.ts";
 import {
   buildCocosWechatSharePayload,
   syncCocosWechatShareBridge,
@@ -194,6 +203,7 @@ interface VeilRootRuntime {
   loadEventHistory: typeof loadCocosPlayerEventHistory;
   loadBattleReplayHistoryPage: typeof loadCocosBattleReplayHistoryPage;
   loginGuestAuthSession: typeof loginCocosGuestAuthSession;
+  postPlayerReferral: typeof postCocosPlayerReferral;
   logoutAuthSession: typeof logoutCurrentCocosAuthSession;
   deletePlayerAccount: typeof deleteCurrentCocosPlayerAccount;
 }
@@ -214,6 +224,7 @@ const defaultVeilRootRuntime: VeilRootRuntime = {
   loadEventHistory: (...args) => loadCocosPlayerEventHistory(...args),
   loadBattleReplayHistoryPage: (...args) => loadCocosBattleReplayHistoryPage(...args),
   loginGuestAuthSession: (...args) => loginCocosGuestAuthSession(...args),
+  postPlayerReferral: (...args) => postCocosPlayerReferral(...args),
   logoutAuthSession: (...args) => logoutCurrentCocosAuthSession(...args),
   deletePlayerAccount: (...args) => deleteCurrentCocosPlayerAccount(...args)
 };
@@ -357,6 +368,8 @@ export class VeilRoot extends Component {
   private surrenderDialogOpen = false;
   private surrenderSubmitting = false;
   private surrenderStatusMessage: string | null = null;
+  private launchReferrerId: string | null = null;
+  private lastReferralClaimKey: string | null = null;
 
   onLoad(): void {
     this.audioRuntime.dispose();
@@ -790,6 +803,9 @@ export class VeilRoot extends Component {
       },
       onToggleSurrender: () => {
         this.toggleSurrenderDialog();
+      },
+      onShareBattleResult: () => {
+        void this.handleBattleResultShare();
       },
       onSubmitReport: (reason) => {
         void this.submitPlayerReport(reason);
@@ -1249,6 +1265,9 @@ export class VeilRoot extends Component {
         status: this.surrenderStatusMessage,
         submitting: this.surrenderSubmitting
       },
+      sharing: {
+        available: this.canShareLatestBattleResult()
+      },
       presentation: this.buildHudPresentationState()
     });
     this.renderSettingsOverlay();
@@ -1378,6 +1397,7 @@ export class VeilRoot extends Component {
       this.sessionSource = syncedSession.source;
       this.playerId = syncedSession.playerId;
       this.displayName = syncedSession.displayName;
+      await this.maybeClaimLaunchReferral(syncedSession);
     } else if (this.sessionSource !== "manual") {
       this.authToken = null;
       this.authMode = "guest";
@@ -2519,6 +2539,7 @@ export class VeilRoot extends Component {
       this.authProvider = authSession.provider ?? "guest";
       this.loginId = authSession.loginId ?? "";
       this.sessionSource = authSession.source;
+      await this.maybeClaimLaunchReferral(authSession);
       saveCocosLobbyPreferences(authSession.playerId, preferences.roomId, undefined, storage);
       this.resetSessionViewport(`正在进入房间 ${preferences.roomId} ...`);
       this.showLobby = false;
@@ -2635,6 +2656,7 @@ export class VeilRoot extends Component {
       this.authProvider = syncedSession.provider ?? "account-password";
       this.loginId = syncedSession.loginId ?? "";
       this.sessionSource = syncedSession.source;
+      await this.maybeClaimLaunchReferral(syncedSession);
       return;
     }
 
@@ -2654,6 +2676,7 @@ export class VeilRoot extends Component {
     this.authProvider = authSession.provider ?? "guest";
     this.loginId = authSession.loginId ?? "";
     this.sessionSource = authSession.source;
+    await this.maybeClaimLaunchReferral(authSession);
   }
 
   private async enterLobbyMatchmaking(): Promise<void> {
@@ -3721,6 +3744,7 @@ export class VeilRoot extends Component {
       search: this.readLaunchSearch(),
       storedSession: readStoredCocosAuthSession(storage)
     });
+    this.launchReferrerId = readLaunchReferrerId(this.readLaunchSearch());
 
     if (launchIdentity.shouldOpenLobby) {
       const storedSession = readStoredCocosAuthSession(storage);
@@ -3774,6 +3798,100 @@ export class VeilRoot extends Component {
 
     if (launchIdentity.roomId !== "test-room") {
       this.pushLog(`已从启动参数载入房间 ${launchIdentity.roomId}。`);
+    }
+  }
+
+  private latestShareableBattleReplay() {
+    const replay = this.lobbyAccountProfile?.recentBattleReplays?.[0] ?? null;
+    if (!shouldOfferBattleResultShare(replay)) {
+      return null;
+    }
+    if (!this.lastBattleSettlementSnapshot || this.lastBattleSettlementSnapshot.tone !== "victory") {
+      return null;
+    }
+    return replay;
+  }
+
+  private canShareLatestBattleResult(): boolean {
+    return Boolean(this.latestShareableBattleReplay());
+  }
+
+  private async handleBattleResultShare(): Promise<void> {
+    const replay = this.latestShareableBattleReplay();
+    if (!replay) {
+      this.predictionStatus = "当前没有可分享的 PVP 胜利战报。";
+      this.renderView();
+      return;
+    }
+
+    if (this.runtimePlatform === "wechat-game") {
+      const payload = buildShareCardPayload(replay, this.displayName || this.playerId);
+      const wxRuntime = (globalThis as {
+        wx?: {
+          shareAppMessage?: (sharePayload: WechatSharePayload) => void;
+        } | null;
+      }).wx;
+      if (typeof wxRuntime?.shareAppMessage === "function") {
+        wxRuntime.shareAppMessage(payload);
+        this.predictionStatus = "已拉起微信分享面板。";
+      } else {
+        this.predictionStatus = "当前微信小游戏环境未提供 shareAppMessage。";
+      }
+      this.renderView();
+      return;
+    }
+
+    const copied = await copyTextToClipboard(buildBattleResultShareSummary(replay, this.displayName || this.playerId));
+    this.predictionStatus = copied ? "已复制战绩摘要，可直接粘贴分享。" : "当前 H5 运行环境不支持剪贴板复制。";
+    this.renderView();
+  }
+
+  private async maybeClaimLaunchReferral(authSession: {
+    playerId: string;
+    displayName: string;
+    authMode: "guest" | "account";
+    provider?: string;
+    loginId?: string;
+    token?: string;
+    source: "remote" | "local";
+  }): Promise<void> {
+    const referrerId = this.launchReferrerId?.trim() ?? "";
+    if (!referrerId || authSession.source !== "remote" || !authSession.token) {
+      return;
+    }
+
+    const claimKey = `${referrerId}:${authSession.playerId}`;
+    if (this.lastReferralClaimKey === claimKey) {
+      return;
+    }
+
+    try {
+      const result = await resolveVeilRootRuntime().postPlayerReferral(
+        this.remoteUrl,
+        { referrerId },
+        {
+          storage: this.readWebStorage(),
+          authSession: {
+            token: authSession.token,
+            playerId: authSession.playerId,
+            displayName: authSession.displayName,
+            authMode: authSession.authMode,
+            ...(authSession.provider ? { provider: authSession.provider as never } : {}),
+            ...(authSession.loginId ? { loginId: authSession.loginId } : {}),
+            source: "remote"
+          }
+        }
+      );
+      this.lastReferralClaimKey = claimKey;
+      if (result.claimed) {
+        this.pushLog(`已完成推荐奖励绑定：邀请人 ${referrerId} 与新玩家 ${authSession.playerId} 各获得 20 宝石。`);
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message === "cocos_request_failed:409:referral_already_claimed") {
+        this.lastReferralClaimKey = claimKey;
+        return;
+      }
+      throw error;
     }
   }
 

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -110,6 +110,13 @@ interface DailyClaimApiPayload {
   };
 }
 
+interface PlayerReferralApiPayload {
+  claimed: boolean;
+  rewardGems: number;
+  referrerId: string;
+  newPlayerId: string;
+}
+
 interface LobbyRoomsApiPayload {
   items?: CocosLobbyRoomSummary[];
 }
@@ -465,6 +472,35 @@ async function claimCocosDailyLoginReward(
   } catch {
     return null;
   }
+}
+
+export async function postCocosPlayerReferral(
+  remoteUrl: string,
+  input: { referrerId: string },
+  options: {
+    authSession: CocosStoredAuthSession;
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "removeItem"> | null;
+  }
+): Promise<PlayerReferralApiPayload> {
+  return (await fetchCocosAuthJson(
+    remoteUrl,
+    `${resolveCocosApiBaseUrl(remoteUrl)}/api/player/referral`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        referrerId: input.referrerId
+      })
+    },
+    options.authSession,
+    {
+      ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+      ...(options.storage !== undefined ? { storage: options.storage } : {})
+    }
+  )) as PlayerReferralApiPayload;
 }
 
 function applyDailyClaimToProfile(

--- a/apps/cocos-client/assets/scripts/cocos-share-card.ts
+++ b/apps/cocos-client/assets/scripts/cocos-share-card.ts
@@ -1,0 +1,125 @@
+import assetConfigJson from "../../../../configs/assets.json";
+import type { PlayerBattleReplaySummary } from "./project-shared/battle-replay.ts";
+
+export interface WechatSharePayload {
+  title: string;
+  imageUrl: string;
+  path: string;
+}
+
+interface ShareCardAssetConfig {
+  shareCard?: {
+    battleVictory?: unknown;
+  };
+}
+
+interface ClipboardEnvironmentLike {
+  navigator?: {
+    clipboard?: {
+      writeText?: (text: string) => Promise<void>;
+    };
+  };
+  document?: {
+    body?: {
+      appendChild?: (node: unknown) => void;
+      removeChild?: (node: unknown) => void;
+    };
+    createElement?: (tagName: string) => {
+      value: string;
+      style: {
+        position: string;
+        opacity: string;
+      };
+      focus: () => void;
+      select: () => void;
+    };
+    execCommand?: (command: string) => boolean;
+  };
+}
+
+function normalizeString(value?: string | null): string {
+  return value?.trim() ?? "";
+}
+
+export function shouldOfferBattleResultShare(result: PlayerBattleReplaySummary | null | undefined): boolean {
+  return (
+    Boolean(result)
+    && result?.battleKind === "hero"
+    && result.playerCamp === "attacker"
+    && result.result === "attacker_victory"
+  );
+}
+
+export function buildShareCardPayload(
+  result: PlayerBattleReplaySummary,
+  playerDisplayName: string
+): WechatSharePayload {
+  const roomId = normalizeString(result.roomId) || "room-alpha";
+  const playerId = normalizeString(result.playerId) || "guest";
+  const displayName = normalizeString(playerDisplayName) || playerId;
+  const imageUrl =
+    normalizeString((assetConfigJson as ShareCardAssetConfig).shareCard?.battleVictory as string | undefined)
+    || "https://cdn.example.com/assets/share-card/battle-victory.png";
+
+  return {
+    title: `${displayName} 赢得了天梯对战！`,
+    imageUrl,
+    path: `?roomId=${encodeURIComponent(roomId)}&referrer=${encodeURIComponent(playerId)}`
+  };
+}
+
+export function buildBattleResultShareSummary(
+  result: PlayerBattleReplaySummary,
+  playerDisplayName: string
+): string {
+  const payload = buildShareCardPayload(result, playerDisplayName);
+  return `${payload.title}\n房间 ${result.roomId}\n邀请链接 ${payload.path}`;
+}
+
+export function readLaunchReferrerId(search?: string | null): string | null {
+  const normalizedSearch = normalizeString(search);
+  const params = new URLSearchParams(
+    normalizedSearch.startsWith("?") ? normalizedSearch : normalizedSearch ? `?${normalizedSearch}` : ""
+  );
+  const referrerId = normalizeString(params.get("referrer"));
+  return referrerId || null;
+}
+
+export async function copyTextToClipboard(
+  text: string,
+  environment: ClipboardEnvironmentLike = globalThis as ClipboardEnvironmentLike
+): Promise<boolean> {
+  const normalizedText = normalizeString(text);
+  if (!normalizedText) {
+    return false;
+  }
+
+  if (typeof environment.navigator?.clipboard?.writeText === "function") {
+    await environment.navigator.clipboard.writeText(normalizedText);
+    return true;
+  }
+
+  const documentRef = environment.document;
+  if (
+    typeof documentRef?.createElement !== "function"
+    || typeof documentRef.body?.appendChild !== "function"
+    || typeof documentRef.body?.removeChild !== "function"
+    || typeof documentRef.execCommand !== "function"
+  ) {
+    return false;
+  }
+
+  const textarea = documentRef.createElement("textarea");
+  textarea.value = normalizedText;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  documentRef.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    return documentRef.execCommand("copy");
+  } finally {
+    documentRef.body.removeChild(textarea);
+  }
+}

--- a/apps/cocos-client/test/cocos-share-card.test.ts
+++ b/apps/cocos-client/test/cocos-share-card.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildShareCardPayload,
+  readLaunchReferrerId,
+  shouldOfferBattleResultShare
+} from "../assets/scripts/cocos-share-card.ts";
+import type { PlayerBattleReplaySummary } from "../assets/scripts/project-shared/battle-replay.ts";
+
+function createReplay(overrides: Partial<PlayerBattleReplaySummary> = {}): PlayerBattleReplaySummary {
+  return {
+    id: "replay-1",
+    roomId: "ranked-room",
+    playerId: "player-7",
+    battleId: "battle-1",
+    battleKind: "hero",
+    playerCamp: "attacker",
+    heroId: "hero-1",
+    opponentHeroId: "hero-2",
+    startedAt: "2026-04-04T10:00:00.000Z",
+    completedAt: "2026-04-04T10:03:00.000Z",
+    initialState: {
+      battleId: "battle-1",
+      attackerHeroId: "hero-1",
+      defenderHeroId: "hero-2",
+      battlefield: [],
+      turn: "attacker",
+      round: 1,
+      activeUnitId: "unit-1",
+      queue: [],
+      attacker: [],
+      defender: []
+    },
+    steps: [],
+    result: "attacker_victory",
+    ...overrides
+  };
+}
+
+test("buildShareCardPayload generates the battle result title and referral path", () => {
+  const payload = buildShareCardPayload(createReplay(), "雾林司灯");
+
+  assert.equal(payload.title, "雾林司灯 赢得了天梯对战！");
+  assert.equal(payload.path, "?roomId=ranked-room&referrer=player-7");
+  assert.match(payload.imageUrl, /^https:\/\/cdn\.example\.com\/assets\/share-card\/battle-victory\.png$/);
+});
+
+test("shouldOfferBattleResultShare only enables attacker PVP victories", () => {
+  assert.equal(shouldOfferBattleResultShare(createReplay()), true);
+  assert.equal(shouldOfferBattleResultShare(createReplay({ battleKind: "neutral" })), false);
+  assert.equal(shouldOfferBattleResultShare(createReplay({ playerCamp: "defender" })), false);
+  assert.equal(shouldOfferBattleResultShare(createReplay({ result: "defender_victory" })), false);
+});
+
+test("readLaunchReferrerId reads the referral query parameter", () => {
+  assert.equal(readLaunchReferrerId("?roomId=ranked-room&referrer=player-9"), "player-9");
+  assert.equal(readLaunchReferrerId("?roomId=ranked-room"), null);
+});

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -116,6 +116,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly shopPurchases = new Map<string, ShopPurchaseResult>();
   private readonly reports = new Map<string, PlayerReportRecord>();
   private readonly seasons = new Map<string, SeasonSnapshot>();
+  private readonly referrals = new Set<string>();
   private nextReportId = 1;
 
   async load(roomId: string): Promise<RoomPersistenceSnapshot | null> {
@@ -359,6 +360,45 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     };
     this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     return cloneAccount(nextAccount);
+  }
+
+  async claimPlayerReferral(referrerId: string, newPlayerId: string, rewardGems: number) {
+    const normalizedReferrerId = normalizePlayerId(referrerId);
+    const normalizedNewPlayerId = normalizePlayerId(newPlayerId);
+    const normalizedRewardGems = Math.floor(rewardGems);
+    if (!Number.isFinite(rewardGems) || normalizedRewardGems <= 0) {
+      throw new Error("rewardGems must be a positive integer");
+    }
+    if (normalizedReferrerId === normalizedNewPlayerId) {
+      throw new Error("self_referral_forbidden");
+    }
+
+    const referralKey = `${normalizedReferrerId}:${normalizedNewPlayerId}`;
+    if (this.referrals.has(referralKey)) {
+      throw new Error("duplicate_referral");
+    }
+
+    const referrer = await this.ensurePlayerAccount({ playerId: normalizedReferrerId });
+    const newPlayer = await this.ensurePlayerAccount({ playerId: normalizedNewPlayerId });
+    this.referrals.add(referralKey);
+
+    this.accounts.set(normalizedReferrerId, {
+      ...referrer,
+      gems: (referrer.gems ?? 0) + normalizedRewardGems,
+      updatedAt: new Date().toISOString()
+    });
+    this.accounts.set(normalizedNewPlayerId, {
+      ...newPlayer,
+      gems: (newPlayer.gems ?? 0) + normalizedRewardGems,
+      updatedAt: new Date().toISOString()
+    });
+
+    return {
+      claimed: true,
+      rewardGems: normalizedRewardGems,
+      referrerId: normalizedReferrerId,
+      newPlayerId: normalizedNewPlayerId
+    };
   }
 
   async createPaymentOrder(input: PaymentOrderCreateInput): Promise<PaymentOrderSnapshot> {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -45,6 +45,13 @@ export interface SeasonCloseSummary {
   totalGemsGranted: number;
 }
 
+export interface PlayerReferralClaimResult {
+  claimed: boolean;
+  rewardGems: number;
+  referrerId: string;
+  newPlayerId: string;
+}
+
 export interface RoomSnapshotStore {
   load(roomId: string): Promise<RoomPersistenceSnapshot | null>;
   loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null>;
@@ -72,6 +79,7 @@ export interface RoomSnapshotStore {
   completePaymentOrder?(orderId: string, input: PaymentOrderCompleteInput): Promise<PaymentOrderSettlement>;
   creditGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
   debitGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
+  claimPlayerReferral?(referrerId: string, newPlayerId: string, rewardGems: number): Promise<PlayerReferralClaimResult>;
   purchaseShopProduct?(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult>;
   savePlayerAccountPrivacyConsent(
     playerId: string,
@@ -604,6 +612,8 @@ export const MYSQL_PLAYER_ACCOUNT_WECHAT_OPEN_ID_INDEX = "uidx_player_accounts_w
 export const MYSQL_PLAYER_ACCOUNT_WECHAT_IDP_OPEN_ID_INDEX = "uidx_player_accounts_wechat_idp_open_id";
 export const MYSQL_GEM_LEDGER_TABLE = "gem_ledger";
 export const MYSQL_GEM_LEDGER_PLAYER_CREATED_INDEX = "idx_gem_ledger_player_created";
+export const MYSQL_PLAYER_REFERRAL_TABLE = "referrals";
+export const MYSQL_PLAYER_REFERRAL_REFERRER_CREATED_INDEX = "idx_referrals_referrer_created";
 export const MYSQL_SHOP_PURCHASE_TABLE = "shop_purchases";
 export const MYSQL_PAYMENT_ORDER_TABLE = "orders";
 export const MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX = "idx_orders_player_created";
@@ -1459,6 +1469,16 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_GEM_LEDGER_TABLE}\` (
   PRIMARY KEY (entry_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_REFERRAL_TABLE}\` (
+  id VARCHAR(191) NOT NULL,
+  referrer_id VARCHAR(191) NOT NULL,
+  new_player_id VARCHAR(191) NOT NULL,
+  reward_gems INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY \`uidx_referrals_referrer_new_player\` (referrer_id, new_player_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS \`${MYSQL_SHOP_PURCHASE_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
   purchase_id VARCHAR(191) NOT NULL,
@@ -1590,6 +1610,24 @@ SET @veil_player_reports_idx_sql := IF(
 PREPARE veil_player_reports_idx_stmt FROM @veil_player_reports_idx_sql;
 EXECUTE veil_player_reports_idx_stmt;
 DEALLOCATE PREPARE veil_player_reports_idx_stmt;
+
+SET @veil_player_referrals_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_REFERRAL_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PLAYER_REFERRAL_REFERRER_CREATED_INDEX}'
+);
+
+SET @veil_player_referrals_idx_sql := IF(
+  @veil_player_referrals_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_PLAYER_REFERRAL_REFERRER_CREATED_INDEX}\` ON \`${MYSQL_PLAYER_REFERRAL_TABLE}\` (referrer_id, created_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_referrals_idx_stmt FROM @veil_player_referrals_idx_sql;
+EXECUTE veil_player_referrals_idx_stmt;
+DEALLOCATE PREPARE veil_player_referrals_idx_stmt;
 
 SET @veil_player_accounts_achievements_exists := (
   SELECT COUNT(*)
@@ -3613,6 +3651,91 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     }
 
     return this.mutateGems(playerId, -normalizePositiveGemDelta(amount), normalizedReason, refId);
+  }
+
+  async claimPlayerReferral(
+    referrerId: string,
+    newPlayerId: string,
+    rewardGems: number
+  ): Promise<PlayerReferralClaimResult> {
+    const normalizedReferrerId = normalizePlayerId(referrerId);
+    const normalizedNewPlayerId = normalizePlayerId(newPlayerId);
+    const normalizedRewardGems = normalizePositiveGemDelta(rewardGems);
+    if (normalizedReferrerId === normalizedNewPlayerId) {
+      throw new Error("self_referral_forbidden");
+    }
+
+    await this.ensurePlayerAccount({ playerId: normalizedReferrerId });
+    await this.ensurePlayerAccount({ playerId: normalizedNewPlayerId });
+
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      await connection.query<RowDataPacket[]>(
+        `SELECT player_id
+         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         WHERE player_id IN (?, ?)
+         FOR UPDATE`,
+        [normalizedReferrerId, normalizedNewPlayerId]
+      );
+
+      const referralId = randomUUID();
+      try {
+        await connection.query(
+          `INSERT INTO \`${MYSQL_PLAYER_REFERRAL_TABLE}\`
+             (id, referrer_id, new_player_id, reward_gems)
+           VALUES (?, ?, ?, ?)`,
+          [referralId, normalizedReferrerId, normalizedNewPlayerId, normalizedRewardGems]
+        );
+      } catch (error) {
+        if (isMySqlDuplicateEntryError(error)) {
+          throw new Error("duplicate_referral");
+        }
+        throw error;
+      }
+
+      const rewardedPlayers = [
+        {
+          playerId: normalizedReferrerId,
+          refId: `referral:${referralId}:referrer`
+        },
+        {
+          playerId: normalizedNewPlayerId,
+          refId: `referral:${referralId}:new-player`
+        }
+      ];
+
+      for (const player of rewardedPlayers) {
+        await connection.query(
+          `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+           SET gems = gems + ?,
+               version = version + 1
+           WHERE player_id = ?`,
+          [normalizedRewardGems, player.playerId]
+        );
+        await appendGemLedgerEntry(connection, {
+          entryId: randomUUID(),
+          playerId: player.playerId,
+          delta: normalizedRewardGems,
+          reason: "reward",
+          refId: player.refId
+        });
+      }
+
+      await connection.commit();
+      return {
+        claimed: true,
+        rewardGems: normalizedRewardGems,
+        referrerId: normalizedReferrerId,
+        newPlayerId: normalizedNewPlayerId
+      };
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
   }
 
   async createPaymentOrder(input: PaymentOrderCreateInput): Promise<PaymentOrderSnapshot> {

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -711,6 +711,69 @@ export function registerPlayerAccountRoutes(
     }
   });
 
+  app.post("/api/player/referral", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store?.claimPlayerReferral) {
+      sendJson(response, 200, {
+        claimed: false,
+        reason: "persistence_unavailable"
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        referrerId?: string;
+      };
+      const referrerId = body.referrerId?.trim() ?? "";
+      if (!referrerId) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_referrer_id",
+            message: "referrerId must not be empty"
+          }
+        });
+        return;
+      }
+
+      const result = await store.claimPlayerReferral(referrerId, authSession.playerId, 20);
+      sendJson(response, 200, result);
+    } catch (error) {
+      if (error instanceof Error && error.message === "duplicate_referral") {
+        sendJson(response, 409, {
+          error: {
+            code: "referral_already_claimed",
+            message: "Referral rewards were already claimed for this pair"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "self_referral_forbidden") {
+        sendJson(response, 400, {
+          error: {
+            code: "self_referral_forbidden",
+            message: "referrerId must be different from the current player"
+          }
+        });
+        return;
+      }
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, {
+          error: {
+            code: error.name,
+            message: error.message
+          }
+        });
+        return;
+      }
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
   app.get("/api/player-accounts/me/sessions", async (request, response) => {
     const authSession = await requireAuthSession(request, response, store);
     if (!authSession) {

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -51,6 +51,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
   private readonly eventHistoryByPlayerId = new Map<string, PlayerAccountSnapshot["recentEventLog"]>();
+  private readonly referrals = new Set<string>();
 
   async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
     return null;
@@ -241,6 +242,48 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     };
     this.accounts.set(playerId, account);
     return account;
+  }
+
+  async claimPlayerReferral(referrerId: string, newPlayerId: string, rewardGems: number) {
+    const normalizedReferrerId = referrerId.trim();
+    const normalizedNewPlayerId = newPlayerId.trim();
+    const normalizedRewardGems = Math.floor(rewardGems);
+    if (!normalizedReferrerId) {
+      throw new Error("invalid_referrer_id");
+    }
+    if (normalizedReferrerId === normalizedNewPlayerId) {
+      throw new Error("self_referral_forbidden");
+    }
+    if (!Number.isFinite(rewardGems) || normalizedRewardGems <= 0) {
+      throw new Error("rewardGems must be a positive integer");
+    }
+
+    const referralKey = `${normalizedReferrerId}:${normalizedNewPlayerId}`;
+    if (this.referrals.has(referralKey)) {
+      throw new Error("duplicate_referral");
+    }
+
+    const referrer = await this.ensurePlayerAccount({ playerId: normalizedReferrerId });
+    const newPlayer = await this.ensurePlayerAccount({ playerId: normalizedNewPlayerId });
+    this.referrals.add(referralKey);
+
+    this.accounts.set(normalizedReferrerId, {
+      ...referrer,
+      gems: (referrer.gems ?? 0) + normalizedRewardGems,
+      updatedAt: new Date().toISOString()
+    });
+    this.accounts.set(normalizedNewPlayerId, {
+      ...newPlayer,
+      gems: (newPlayer.gems ?? 0) + normalizedRewardGems,
+      updatedAt: new Date().toISOString()
+    });
+
+    return {
+      claimed: true,
+      rewardGems: normalizedRewardGems,
+      referrerId: normalizedReferrerId,
+      newPlayerId: normalizedNewPlayerId
+    };
   }
 
   async listPlayerBanHistory(
@@ -2859,4 +2902,105 @@ test("daily claim rejects duplicate claims on the same day", async (t) => {
   assert.equal(account?.gems, 9);
   assert.equal(account?.globalResources.gold, 18);
   assert.equal(account?.loginStreak, 3);
+});
+
+test("referral endpoint rejects double-claiming for the same referrer and new player", async (t) => {
+  const port = 44940 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  await store.ensurePlayerAccount({
+    playerId: "referrer-1",
+    displayName: "先驱旅者"
+  });
+  await store.ensurePlayerAccount({
+    playerId: "new-player-1",
+    displayName: "新雾行者"
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "new-player-1",
+    displayName: "新雾行者"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstResponse = await fetch(`http://127.0.0.1:${port}/api/player/referral`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      referrerId: "referrer-1"
+    })
+  });
+  assert.equal(firstResponse.status, 200);
+
+  const secondResponse = await fetch(`http://127.0.0.1:${port}/api/player/referral`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      referrerId: "referrer-1"
+    })
+  });
+  const secondPayload = (await secondResponse.json()) as {
+    error: { code: string };
+  };
+
+  assert.equal(secondResponse.status, 409);
+  assert.equal(secondPayload.error.code, "referral_already_claimed");
+});
+
+test("referral endpoint credits both accounts exactly once", async (t) => {
+  const port = 44960 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  await store.savePlayerAccountProgress("referrer-2", {
+    gems: 11
+  });
+  await store.savePlayerAccountProgress("new-player-2", {
+    gems: 3
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "new-player-2",
+    displayName: "新雾行者"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/player/referral`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      referrerId: "referrer-2"
+    })
+  });
+  const payload = (await response.json()) as {
+    claimed: boolean;
+    rewardGems: number;
+    referrerId: string;
+    newPlayerId: string;
+  };
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(payload, {
+    claimed: true,
+    rewardGems: 20,
+    referrerId: "referrer-2",
+    newPlayerId: "new-player-2"
+  });
+
+  const referrer = await store.loadPlayerAccount("referrer-2");
+  const newPlayer = await store.loadPlayerAccount("new-player-2");
+  assert.equal(referrer?.gems, 31);
+  assert.equal(newPlayer?.gems, 23);
 });

--- a/configs/assets.json
+++ b/configs/assets.json
@@ -615,5 +615,8 @@
   "showcaseBuildings": {
     "forge_hall": "/assets/pixel/buildings/forge-hall.png",
     "watchtower": "/assets/pixel/buildings/forge-hall.png"
+  },
+  "shareCard": {
+    "battleVictory": "https://cdn.example.com/assets/share-card/battle-victory.png"
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated WeChat battle-result share-card helper and wire a post-settlement `分享战绩` action into the Cocos HUD
- call `wx.shareAppMessage` on WeChat with the CDN-configured victory card and fall back to clipboard copy on H5
- add `POST /api/player/referral` with idempotent referral persistence and one-time 20 gem grants for both players

## Why
- Project Veil did not expose a WeChat battle-result share flow after PVP wins
- launch-time `referrer` deep links were not tracked or rewarded on first remote login

## Validation
- `node --import tsx --test apps/cocos-client/test/cocos-share-card.test.ts`
- `node --import tsx --test apps/server/test/player-account-routes.test.ts`
- `npm run typecheck:cocos`
- `npm run typecheck:server`

Closes #838.
