### PR TITLE
feat: add lobby hero skill tree panel

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -1,5 +1,6 @@
 import { _decorator, Color, Component, Graphics, Label, Node, Sprite, SpriteFrame, UITransform } from "cc";
 import { buildCocosLeaderboardPanelView } from "./cocos-leaderboard-panel.ts";
+import type { LobbySkillPanelView } from "./cocos-lobby-skill-panel.ts";
 import {
   type CocosAccountReviewItem,
   type CocosAccountReviewPage,
@@ -31,6 +32,7 @@ import {
 } from "./cocos-showcase-gallery.ts";
 import type { CocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
 import { HUD_ACCENT } from "./VeilHudPanel.ts";
+import type { HeroView } from "./VeilCocosSession.ts";
 import type {
   CocosAccountLifecycleFieldView,
   CocosAccountLifecyclePanelView,
@@ -128,6 +130,10 @@ export interface VeilLobbyRenderState {
   rooms: CocosLobbyRoomSummary[];
   accountFlow: CocosAccountLifecyclePanelView | null;
   presentationReadiness: CocosPresentationReadiness;
+  activeHero: HeroView | null;
+  lobbySkillPanel: LobbySkillPanelView | null;
+  battleActive: boolean;
+  skillPanelBusy?: boolean;
 }
 
 export interface VeilLobbyPanelOptions {
@@ -155,6 +161,9 @@ export interface VeilLobbyPanelOptions {
   onSelectAccountReviewPage?: (section: "battle-replays" | "event-history", page: number) => void;
   onRetryAccountReviewSection?: (section: CocosAccountReviewSection) => void;
   onSelectBattleReplayReview?: (replayId: string) => void;
+  onOpenLobbySkillPanel?: () => void;
+  onCloseLobbySkillPanel?: () => void;
+  onLearnLobbySkill?: (skillId: string) => void;
 }
 
 interface PanelCardTone {
@@ -194,10 +203,14 @@ export class VeilLobbyPanel extends Component {
   private onSelectAccountReviewPage: ((section: "battle-replays" | "event-history", page: number) => void) | undefined;
   private onRetryAccountReviewSection: ((section: CocosAccountReviewSection) => void) | undefined;
   private onSelectBattleReplayReview: ((replayId: string) => void) | undefined;
+  private onOpenLobbySkillPanel: (() => void) | undefined;
+  private onCloseLobbySkillPanel: (() => void) | undefined;
+  private onLearnLobbySkill: ((skillId: string) => void) | undefined;
   private replayPlayback: BattleReplayPlaybackState | null = null;
   private replayPlaybackReplayId: string | null = null;
   private replayPlaybackStatus = "选择一场最近战斗，即可查看逐步回放。";
   private replayPlaybackTimer: ReturnType<typeof setInterval> | null = null;
+  private showSkillPanel = false;
 
   onDestroy(): void {
     this.stopReplayPlaybackLoop();
@@ -229,6 +242,9 @@ export class VeilLobbyPanel extends Component {
     this.onSelectAccountReviewPage = options.onSelectAccountReviewPage;
     this.onRetryAccountReviewSection = options.onRetryAccountReviewSection;
     this.onSelectBattleReplayReview = options.onSelectBattleReplayReview;
+    this.onOpenLobbySkillPanel = options.onOpenLobbySkillPanel;
+    this.onCloseLobbySkillPanel = options.onCloseLobbySkillPanel;
+    this.onLearnLobbySkill = options.onLearnLobbySkill;
   }
 
   render(state: VeilLobbyRenderState): void {
@@ -245,6 +261,7 @@ export class VeilLobbyPanel extends Component {
     };
     const matchmakingSearching = state.matchmakingSearching ?? false;
     const matchmakingBusy = state.matchmakingBusy ?? false;
+    const skillPanelBusy = state.skillPanelBusy ?? false;
     const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
     const width = transform.width || 760;
     const height = transform.height || 620;
@@ -567,7 +584,10 @@ export class VeilLobbyPanel extends Component {
     );
 
     if (this.showAccountReview) {
+      this.showSkillPanel = false;
       this.hideAccountFlowPanel();
+      this.hideHeroSection();
+      this.hideSkillPanelModal();
       const review = state.accountReview;
       const hasBattleReplays = state.battleReplayItems.length > 0;
       const unlockedCount = state.account.achievements.filter((achievement) => achievement.unlocked).length;
@@ -703,15 +723,19 @@ export class VeilLobbyPanel extends Component {
       this.hideLobbyRooms();
       this.hideLeaderboardCards();
     } else if (state.accountFlow) {
+      this.showSkillPanel = false;
       this.hideAccountReviewCards();
       this.hideBattleReplayTimelineCard();
       this.hideLobbyRooms();
       this.hideLeaderboardCards();
+      this.hideHeroSection();
+      this.hideSkillPanelModal();
       this.renderAccountFlowPanel(rightX, rightCursorY, rightWidth, state.accountFlow, state.entering);
     } else {
       this.hideAccountFlowPanel();
       this.hideAccountReviewCards();
       this.hideBattleReplayTimelineCard();
+      rightCursorY = this.renderHeroSection(rightX, rightCursorY, rightWidth, state, skillPanelBusy);
       rightCursorY = this.renderLeaderboardSection(rightX, rightCursorY, rightWidth, state);
       rightCursorY = this.renderCard(
         "LobbyRoomsHeader",
@@ -791,6 +815,12 @@ export class VeilLobbyPanel extends Component {
       }
 
       this.renderPixelShowcase(rightX, showcaseTopY, rightWidth);
+    }
+
+    if (this.showSkillPanel && state.lobbySkillPanel && state.activeHero) {
+      this.renderSkillPanelModal(width, height, state, skillPanelBusy);
+    } else {
+      this.hideSkillPanelModal();
     }
   }
 
@@ -895,6 +925,76 @@ export class VeilLobbyPanel extends Component {
     }
   }
 
+  private renderHeroSection(
+    centerX: number,
+    topY: number,
+    width: number,
+    state: VeilLobbyRenderState,
+    skillPanelBusy: boolean
+  ): number {
+    const hero = state.activeHero;
+    if (!hero || !state.lobbySkillPanel) {
+      this.hideHeroSection();
+      this.showSkillPanel = false;
+      return topY;
+    }
+
+    const nextTopY = this.renderCard(
+      "LobbyHeroSummary",
+      centerX,
+      topY,
+      width,
+      84,
+      [
+        "当前英雄",
+        `${hero.name} · Lv ${hero.progression.level} · 兵力 ${hero.armyCount}`,
+        `技能点 ${state.lobbySkillPanel.availableSkillPoints} · ${state.battleActive ? "战斗中无法分配" : "房间空闲时可立即分配"}`
+      ],
+      {
+        fill: new Color(52, 66, 94, 190),
+        stroke: new Color(222, 232, 246, 64),
+        accent: new Color(128, 176, 226, 204)
+      },
+      null,
+      14,
+      18
+    );
+
+    this.renderActionButton(
+      "LobbyHeroSkillButton",
+      centerX,
+      nextTopY - 16,
+      width,
+      28,
+      skillPanelBusy ? "技能同步中..." : "技能",
+      {
+        fill: ACTION_ACCOUNT_REVIEW_ACTIVE,
+        stroke: new Color(228, 244, 229, 124),
+        accent: new Color(226, 244, 230, 116)
+      },
+      skillPanelBusy || state.entering
+        ? null
+        : () => {
+            this.showSkillPanel = true;
+            this.onOpenLobbySkillPanel?.();
+            if (this.currentState) {
+              this.render(this.currentState);
+            }
+          }
+    );
+
+    return nextTopY - 50;
+  }
+
+  private hideHeroSection(): void {
+    for (const name of ["LobbyHeroSummary", "LobbyHeroSkillButton"]) {
+      const node = this.node.getChildByName(name);
+      if (node) {
+        node.active = false;
+      }
+    }
+  }
+
   private ensureShowcaseTicker(): void {
     if (this.showcaseTickerStarted) {
       return;
@@ -930,6 +1030,173 @@ export class VeilLobbyPanel extends Component {
     graphics.fillColor = PANEL_INNER;
     graphics.roundRect(-width / 2 + 14, height / 2 - 24, width - 28, 10, 6);
     graphics.fill();
+  }
+
+  private renderSkillPanelModal(
+    width: number,
+    height: number,
+    state: VeilLobbyRenderState,
+    skillPanelBusy: boolean
+  ): void {
+    const view = state.lobbySkillPanel;
+    if (!view) {
+      this.hideSkillPanelModal();
+      return;
+    }
+
+    const modalWidth = Math.min(620, width - 48);
+    const modalCenterX = 0;
+    let topY = height / 2 - 54;
+
+    this.renderBackdrop("LobbySkillPanelBackdrop", width, height);
+    topY = this.renderCard(
+      "LobbySkillPanelHeader",
+      modalCenterX,
+      topY,
+      modalWidth,
+      96,
+      [
+        `技能规划 · ${view.heroName}`,
+        `等级 ${view.level} · 可用技能点 ${view.availableSkillPoints}`,
+        state.battleActive ? "战斗中无法分配" : "房间空闲时可直接分配技能点并即时写回房间状态。"
+      ],
+      {
+        fill: TITLE_FILL,
+        stroke: new Color(236, 228, 198, 72),
+        accent: new Color(214, 175, 112, 194)
+      },
+      null,
+      13,
+      17
+    );
+
+    view.branches.forEach((branch, index) => {
+      const lines = [
+        branch.name,
+        ...branch.skills.map((skill) => `${skill.name} ${skill.currentRank}/${skill.maxRank} · ${skill.summary}`)
+      ];
+      topY = this.renderCard(
+        `LobbySkillPanelBranch-${index}`,
+        modalCenterX,
+        topY,
+        modalWidth,
+        40 + lines.length * 16,
+        lines,
+        {
+          fill: ROOM_FILL,
+          stroke: new Color(220, 232, 244, 52),
+          accent: new Color(132, 186, 142, 186)
+        },
+        null,
+        12,
+        16
+      );
+    });
+    this.hideExtraSkillBranchCards(view.branches.length);
+
+    const buttonWidth = Math.floor((modalWidth - 10) / 2);
+    const buttonStartX = modalCenterX - modalWidth / 2 + buttonWidth / 2;
+    const actionCenterY = topY - 16;
+    view.actions.forEach((action, index) => {
+      const row = Math.floor(index / 2);
+      const col = index % 2;
+      this.renderActionButton(
+        `LobbySkillPanelAction-${index}`,
+        buttonStartX + col * (buttonWidth + 10),
+        actionCenterY - row * 34,
+        buttonWidth,
+        28,
+        `${action.label} · ${action.cost} 点`,
+        {
+          fill: ACTION_ENTER,
+          stroke: new Color(228, 244, 229, 124),
+          accent: new Color(226, 244, 230, 116)
+        },
+        state.battleActive || !action.canLearn || skillPanelBusy
+          ? null
+          : () => {
+              this.onLearnLobbySkill?.(action.skillId);
+            }
+      );
+    });
+    this.hideExtraSkillActionButtons(view.actions.length);
+
+    const actionRows = Math.ceil(view.actions.length / 2);
+    const closeCenterY = actionCenterY - actionRows * 34;
+    this.renderActionButton(
+      "LobbySkillPanelClose",
+      modalCenterX,
+      closeCenterY,
+      modalWidth,
+      28,
+      "收起技能面板",
+      {
+        fill: ACTION_LOGOUT,
+        stroke: new Color(247, 232, 226, 118),
+        accent: new Color(250, 234, 228, 110)
+      },
+      () => {
+        this.showSkillPanel = false;
+        this.onCloseLobbySkillPanel?.();
+        if (this.currentState) {
+          this.render(this.currentState);
+        }
+      }
+    );
+  }
+
+  private renderBackdrop(name: string, width: number, height: number): void {
+    let backdrop = this.node.getChildByName(name);
+    if (!backdrop) {
+      backdrop = new Node(name);
+      backdrop.parent = this.node;
+    }
+    assignUiLayer(backdrop);
+    backdrop.active = true;
+    const transform = backdrop.getComponent(UITransform) ?? backdrop.addComponent(UITransform);
+    transform.setContentSize(width, height);
+    backdrop.setPosition(0, 0, 2);
+    const graphics = backdrop.getComponent(Graphics) ?? backdrop.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = new Color(4, 7, 12, 184);
+    graphics.rect(-width / 2, -height / 2, width, height);
+    graphics.fill();
+    this.bindPress(backdrop, () => {
+      this.showSkillPanel = false;
+      this.onCloseLobbySkillPanel?.();
+      if (this.currentState) {
+        this.render(this.currentState);
+      }
+    });
+  }
+
+  private hideExtraSkillBranchCards(visibleCount: number): void {
+    for (let index = visibleCount; index < 8; index += 1) {
+      const node = this.node.getChildByName(`LobbySkillPanelBranch-${index}`);
+      if (node) {
+        node.active = false;
+      }
+    }
+  }
+
+  private hideExtraSkillActionButtons(visibleCount: number): void {
+    for (let index = visibleCount; index < 16; index += 1) {
+      const node = this.node.getChildByName(`LobbySkillPanelAction-${index}`);
+      if (node) {
+        node.active = false;
+      }
+    }
+  }
+
+  private hideSkillPanelModal(): void {
+    for (const name of ["LobbySkillPanelBackdrop", "LobbySkillPanelHeader", "LobbySkillPanelClose"]) {
+      const node = this.node.getChildByName(name);
+      if (node) {
+        node.active = false;
+      }
+    }
+    this.hideExtraSkillBranchCards(0);
+    this.hideExtraSkillActionButtons(0);
   }
 
   private renderCard(

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -1,5 +1,10 @@
 import { _decorator, Camera, Canvas, Color, Component, EventMouse, EventTouch, Graphics, input, Input, Label, Layers, Node, sys, UITransform, view } from "cc";
-import { getBuildingUpgradeConfig, getEquipmentDefinition, type EquipmentType } from "./project-shared/index.ts";
+import {
+  getBuildingUpgradeConfig,
+  getEquipmentDefinition,
+  getRuntimeConfigBundleForRoom,
+  type EquipmentType
+} from "./project-shared/index.ts";
 import {
   type BattleAction,
   type LeaderboardEntry,
@@ -128,6 +133,7 @@ import { VeilProgressionPanel } from "./VeilProgressionPanel.ts";
 import { VeilEquipmentPanel } from "./VeilEquipmentPanel.ts";
 import { formatEquipmentActionReason, formatEquipmentSlotLabel } from "./cocos-hero-equipment.ts";
 import { type CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
+import { buildLobbySkillPanelView, toLobbySkillPanelHeroState } from "./cocos-lobby-skill-panel.ts";
 import {
   createCocosBattlePresentationController,
   type CocosBattlePresentationState
@@ -934,6 +940,9 @@ export class VeilRoot extends Component {
           replayId
         });
         this.renderView();
+      },
+      onLearnLobbySkill: (skillId) => {
+        void this.learnHeroSkill(skillId);
       }
     });
 
@@ -1181,6 +1190,10 @@ export class VeilRoot extends Component {
     }
 
     if (this.showLobby) {
+      const activeHero = this.activeHero();
+      const runtimeBundle = this.lastUpdate
+        ? getRuntimeConfigBundleForRoom(this.lastUpdate.world.meta.roomId, this.lastUpdate.world.meta.seed)
+        : null;
       this.lobbyPanel?.render({
         playerId: this.playerId,
         displayName: this.displayName || this.playerId,
@@ -1210,7 +1223,13 @@ export class VeilRoot extends Component {
         matchmakingBusy: this.lobbyEntering || this.matchmakingJoinInFlight,
         rooms: this.lobbyRooms,
         accountFlow: this.buildActiveAccountFlowPanelView(),
-        presentationReadiness: cocosPresentationReadiness
+        presentationReadiness: cocosPresentationReadiness,
+        activeHero,
+        lobbySkillPanel: activeHero && runtimeBundle
+          ? buildLobbySkillPanelView(toLobbySkillPanelHeroState(activeHero), runtimeBundle)
+          : null,
+        battleActive: Boolean(this.lastUpdate?.battle),
+        skillPanelBusy: this.moveInFlight || this.battleActionInFlight
       });
       this.renderSettingsOverlay();
       return;

--- a/apps/cocos-client/assets/scripts/cocos-lobby-skill-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby-skill-panel.ts
@@ -1,0 +1,131 @@
+import type { HeroState } from "./project-shared/models.ts";
+import type { RuntimeConfigBundle } from "./project-shared/world-config.ts";
+import { createHeroSkillTreeView } from "./project-shared/hero-skills.ts";
+import type { HeroView } from "./VeilCocosSession.ts";
+
+const SKILL_POINT_COST = 1;
+
+export interface LobbySkillPanelAction {
+  skillId: string;
+  label: string;
+  canLearn: boolean;
+  cost: number;
+}
+
+export interface LobbySkillPanelSkillView {
+  skillId: string;
+  name: string;
+  currentRank: number;
+  maxRank: number;
+  nextRank: number | null;
+  canLearn: boolean;
+  summary: string;
+}
+
+export interface LobbySkillPanelBranchView {
+  id: string;
+  name: string;
+  skills: LobbySkillPanelSkillView[];
+}
+
+export interface LobbySkillPanelView {
+  heroName: string;
+  level: number;
+  availableSkillPoints: number;
+  branches: LobbySkillPanelBranchView[];
+  actions: LobbySkillPanelAction[];
+}
+
+function createBattleSkillLabelMap(bundle: RuntimeConfigBundle): Map<string, string> {
+  return new Map(bundle.battleSkills.skills.map((skill) => [skill.id, skill.name] as const));
+}
+
+function formatNextRankSummary(
+  nextRank: number | null,
+  nextDescription: string | undefined,
+  nextGrantedBattleSkillLabels: string[]
+): string {
+  if (!nextRank) {
+    return "已满级";
+  }
+
+  const detail = nextDescription?.trim() || "可提升当前长期技能效果。";
+  const unlockLabel = nextGrantedBattleSkillLabels.length > 0
+    ? ` · 解锁 ${nextGrantedBattleSkillLabels.join(" / ")}`
+    : "";
+  return `R${nextRank} · ${detail}${unlockLabel}`;
+}
+
+function buildActionLabel(skillName: string, nextRank: number | null): string {
+  if (!nextRank || nextRank <= 1) {
+    return `学习 ${skillName}`;
+  }
+  return `升级 ${skillName} R${nextRank}`;
+}
+
+export function toLobbySkillPanelHeroState(hero: HeroView): HeroState {
+  const loadout = hero.loadout ?? {
+    learnedSkills: [],
+    equipment: {
+      trinketIds: []
+    },
+    inventory: []
+  };
+  return {
+    id: hero.id,
+    playerId: hero.playerId,
+    name: hero.name,
+    position: { ...hero.position },
+    vision: hero.vision,
+    move: { ...hero.move },
+    stats: { ...hero.stats },
+    progression: { ...hero.progression },
+    loadout: {
+      learnedSkills: loadout.learnedSkills.map((skill) => ({ ...skill })),
+      equipment: {
+        ...loadout.equipment,
+        trinketIds: [...loadout.equipment.trinketIds]
+      },
+      inventory: [...loadout.inventory]
+    },
+    armyTemplateId: hero.armyTemplateId,
+    armyCount: hero.armyCount,
+    learnedSkills: hero.learnedSkills.map((skill) => ({ ...skill }))
+  };
+}
+
+export function buildLobbySkillPanelView(hero: HeroState, bundle: RuntimeConfigBundle): LobbySkillPanelView {
+  const tree = createHeroSkillTreeView(hero);
+  const battleSkillNames = createBattleSkillLabelMap(bundle);
+
+  return {
+    heroName: hero.name,
+    level: hero.progression.level,
+    availableSkillPoints: tree.availableSkillPoints,
+    branches: tree.branches.map((branch) => ({
+      id: branch.id,
+      name: branch.name,
+      skills: branch.skills.map((skill) => ({
+        skillId: skill.id,
+        name: skill.name,
+        currentRank: skill.currentRank,
+        maxRank: skill.maxRank,
+        nextRank: skill.nextRank,
+        canLearn: skill.canLearn,
+        summary: formatNextRankSummary(
+          skill.nextRank,
+          skill.ranks.find((rank) => rank.rank === skill.nextRank)?.description,
+          skill.nextGrantedBattleSkillIds.map((battleSkillId) => battleSkillNames.get(battleSkillId) ?? battleSkillId)
+        )
+      }))
+    })),
+    actions: tree.branches.flatMap((branch) =>
+      branch.skills.map((skill) => ({
+        skillId: skill.id,
+        label: buildActionLabel(skill.name, skill.nextRank),
+        canLearn: skill.canLearn,
+        cost: SKILL_POINT_COST
+      }))
+    )
+  };
+}

--- a/apps/cocos-client/test/cocos-lobby-panel.test.ts
+++ b/apps/cocos-client/test/cocos-lobby-panel.test.ts
@@ -10,12 +10,20 @@ import {
   createLobbyPanelTestAccount,
   summarizeLobbyShowcaseInventory
 } from "../assets/scripts/cocos-lobby-panel-model";
+import {
+  buildLobbySkillPanelView,
+  toLobbySkillPanelHeroState
+} from "../assets/scripts/cocos-lobby-skill-panel.ts";
+import { getRuntimeConfigBundleForRoom } from "../assets/scripts/project-shared/index.ts";
 import type { VeilLobbyRenderState } from "../assets/scripts/VeilLobbyPanel";
 import {
   createBattleReplaySummary,
+  createWorldUpdate,
   createComponentHarness,
   createErroredBattleReplayReviewState,
   createLobbyState,
+  findNode,
+  pressNode,
   createReplayReadyLobbyState,
   readCardLabel
 } from "./helpers/cocos-panel-harness.ts";
@@ -220,5 +228,33 @@ test("VeilLobbyPanel renders leaderboard rows and highlights the current player 
   assert.match(readCardLabel(node, "LobbyLeaderboardList"), /#2 Bravo · 我 · ELO 1524 · 铂金/);
   assert.match(readCardLabel(node, "LobbyLeaderboardMyRank"), /我的排名/);
   assert.match(readCardLabel(node, "LobbyLeaderboardMyRank"), /#2 Bravo/);
+  component.onDestroy();
+});
+
+test("VeilLobbyPanel opens the lobby skill modal and wires skill selections", () => {
+  const { node, component } = createComponentHarness(VeilLobbyPanel, { name: "LobbyPanelRoot", width: 760, height: 620 });
+  const update = createWorldUpdate();
+  const hero = update.world.ownHeroes[0]!;
+  const selectedSkillIds: string[] = [];
+
+  component.configure({
+    onLearnLobbySkill: (skillId) => {
+      selectedSkillIds.push(skillId);
+    }
+  });
+  component.scheduleOnce = () => undefined;
+  component.render(createLobbyState({
+    activeHero: hero,
+    lobbySkillPanel: buildLobbySkillPanelView(
+      toLobbySkillPanelHeroState(hero),
+      getRuntimeConfigBundleForRoom(update.world.meta.roomId, update.world.meta.seed)
+    )
+  }));
+
+  pressNode(findNode(node, "LobbyHeroSkillButton"));
+  assert.match(readCardLabel(node, "LobbySkillPanelHeader"), /技能规划/);
+
+  pressNode(findNode(node, "LobbySkillPanelAction-0"));
+  assert.deepEqual(selectedSkillIds, ["war_banner"]);
   component.onDestroy();
 });

--- a/apps/cocos-client/test/cocos-lobby-skill-panel.test.ts
+++ b/apps/cocos-client/test/cocos-lobby-skill-panel.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildLobbySkillPanelView,
+  toLobbySkillPanelHeroState
+} from "../assets/scripts/cocos-lobby-skill-panel.ts";
+import { getRuntimeConfigBundleForRoom } from "../assets/scripts/project-shared/index.ts";
+import type { HeroView } from "../assets/scripts/VeilCocosSession.ts";
+
+function createHero(skillPoints: number): HeroView {
+  return {
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 0 },
+    vision: 4,
+    move: {
+      total: 6,
+      remaining: 6
+    },
+    stats: {
+      attack: 2,
+      defense: 2,
+      power: 1,
+      knowledge: 1,
+      hp: 30,
+      maxHp: 30
+    },
+    progression: {
+      level: 3,
+      experience: 210,
+      skillPoints,
+      battlesWon: 2,
+      neutralBattlesWon: 2,
+      pvpBattlesWon: 0
+    },
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        trinketIds: []
+      },
+      inventory: []
+    },
+    armyCount: 12,
+    armyTemplateId: "hero_guard_basic",
+    learnedSkills: [
+      { skillId: "war_banner", rank: 1 },
+      { skillId: "field_alchemy", rank: 1 }
+    ]
+  };
+}
+
+test("buildLobbySkillPanelView renders available and locked skill actions for a level 3 hero with two spent points", () => {
+  const view = buildLobbySkillPanelView(
+    toLobbySkillPanelHeroState(createHero(1)),
+    getRuntimeConfigBundleForRoom("room-alpha", 1001)
+  );
+  const actionsBySkillId = new Map(view.actions.map((action) => [action.skillId, action]));
+  const warpath = view.branches.find((branch) => branch.id === "warpath");
+  const arcanum = view.branches.find((branch) => branch.id === "arcanum");
+
+  assert.equal(view.level, 3);
+  assert.equal(view.availableSkillPoints, 1);
+  assert.equal(actionsBySkillId.get("war_banner")?.canLearn, true);
+  assert.equal(actionsBySkillId.get("spearhead_assault")?.canLearn, true);
+  assert.equal(actionsBySkillId.get("shield_discipline")?.canLearn, true);
+  assert.equal(actionsBySkillId.get("crippling_hex")?.canLearn, true);
+  assert.equal(actionsBySkillId.get("field_alchemy")?.canLearn, false);
+  assert.equal(actionsBySkillId.get("guardian_oath_training")?.canLearn, false);
+  assert.match(actionsBySkillId.get("war_banner")?.label ?? "", /升级 战旗号令 R2/);
+  assert.match(
+    warpath?.skills.find((skill) => skill.skillId === "spearhead_assault")?.summary ?? "",
+    /R1/
+  );
+  assert.match(
+    arcanum?.skills.find((skill) => skill.skillId === "field_alchemy")?.summary ?? "",
+    /已满级/
+  );
+});
+
+test("buildLobbySkillPanelView marks every learn action unavailable when the hero has no skill points", () => {
+  const view = buildLobbySkillPanelView(
+    toLobbySkillPanelHeroState(createHero(0)),
+    getRuntimeConfigBundleForRoom("room-alpha", 1001)
+  );
+
+  assert.equal(view.availableSkillPoints, 0);
+  assert.equal(view.actions.some((action) => action.canLearn), false);
+});

--- a/apps/cocos-client/test/helpers/cocos-panel-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-panel-harness.ts
@@ -287,6 +287,10 @@ export function createLobbyState(overrides: Partial<VeilLobbyRenderState> = {}):
       summary: "等待表现资源",
       nextStep: "等待资源包"
     },
+    activeHero: null,
+    lobbySkillPanel: null,
+    battleActive: false,
+    skillPanelBusy: false,
     ...overrides
   };
 }


### PR DESCRIPTION
## Summary
- add a lobby skill tree view-model for pre-match hero planning
- wire the Cocos lobby hero section and modal to dispatch `hero.learnSkill`
- add focused lobby skill panel tests and validation

## Validation
- node --import tsx --test ./apps/cocos-client/test/cocos-lobby-skill-panel.test.ts ./apps/cocos-client/test/cocos-lobby-panel.test.ts
- npm run typecheck:cocos

Closes #835