### PR TITLE
feat(cocos): add shop and gem purchase UI

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -1,5 +1,6 @@
 import { sys } from "cc";
 import type { EquipmentType } from "./project-shared/index.ts";
+import { buildCocosAuthHeaders, resolveCocosApiBaseUrl } from "./cocos-lobby.ts";
 import {
   cancelCocosMatchmaking,
   enqueueCocosMatchmaking,
@@ -16,6 +17,40 @@ export interface ResourceLedger {
   gold: number;
   wood: number;
   ore: number;
+}
+
+export interface ShopProductGrant {
+  gems?: number;
+  resources?: Partial<ResourceLedger>;
+  equipmentIds?: string[];
+}
+
+export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle";
+
+export interface ShopProduct {
+  productId: string;
+  name: string;
+  type: ShopProductType;
+  price: number;
+  wechatPriceFen?: number;
+  enabled: boolean;
+  grant: ShopProductGrant;
+}
+
+export interface ShopPurchaseResult {
+  purchaseId: string;
+  productId: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+  granted: {
+    gems: number;
+    resources: ResourceLedger;
+    equipmentIds: string[];
+    heroId?: string;
+  };
+  gemsBalance: number;
+  processedAt: string;
 }
 
 export type LeaderboardTier = "bronze" | "silver" | "gold" | "platinum" | "diamond";
@@ -865,6 +900,26 @@ function getLeaderboardFetch(): typeof fetch {
   return testFetchOverride ?? fetch;
 }
 
+function getApiFetch(): typeof fetch {
+  return testFetchOverride ?? fetch;
+}
+
+async function fetchApiJson(url: string, init?: RequestInit): Promise<unknown> {
+  const response = await getApiFetch()(url, init);
+  if (!response.ok) {
+    let errorCode = "unknown";
+    try {
+      const payload = (await response.json()) as { error?: { code?: string } };
+      errorCode = payload.error?.code?.trim() || errorCode;
+    } catch {
+      errorCode = "unknown";
+    }
+    throw new Error(`cocos_request_failed:${response.status}:${errorCode}`);
+  }
+
+  return (await response.json()) as unknown;
+}
+
 function normalizeLeaderboardTier(value: unknown): LeaderboardTier {
   switch (value) {
     case "silver":
@@ -900,6 +955,73 @@ async function fetchLeaderboardEntries(remoteUrl?: string, limit = 50): Promise<
       tier: normalizeLeaderboardTier(player.tier)
     };
   });
+}
+
+function normalizeShopProductGrant(value: unknown): ShopProductGrant {
+  const raw = typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+  const resources = typeof raw.resources === "object" && raw.resources !== null
+    ? (raw.resources as Record<string, unknown>)
+    : null;
+  const equipmentIds = Array.isArray(raw.equipmentIds)
+    ? raw.equipmentIds.map((entry) => String(entry).trim()).filter(Boolean)
+    : [];
+
+  return {
+    ...(typeof raw.gems === "number" && Number.isFinite(raw.gems) ? { gems: Math.max(0, Math.floor(raw.gems)) } : {}),
+    ...(resources
+      ? {
+          resources: {
+            gold: typeof resources.gold === "number" && Number.isFinite(resources.gold) ? Math.max(0, Math.floor(resources.gold)) : 0,
+            wood: typeof resources.wood === "number" && Number.isFinite(resources.wood) ? Math.max(0, Math.floor(resources.wood)) : 0,
+            ore: typeof resources.ore === "number" && Number.isFinite(resources.ore) ? Math.max(0, Math.floor(resources.ore)) : 0
+          }
+        }
+      : {}),
+    ...(equipmentIds.length > 0 ? { equipmentIds } : {})
+  };
+}
+
+function normalizeShopProduct(raw: unknown, index: number): ShopProduct {
+  const value = typeof raw === "object" && raw !== null ? (raw as Record<string, unknown>) : {};
+  return {
+    productId: typeof value.productId === "string" && value.productId.trim() ? value.productId.trim() : `shop-product-${index + 1}`,
+    name: typeof value.name === "string" && value.name.trim() ? value.name.trim() : `Shop Product ${index + 1}`,
+    type: value.type === "equipment" || value.type === "resource_bundle" ? value.type : "gem_pack",
+    price: typeof value.price === "number" && Number.isFinite(value.price) ? Math.max(0, Math.floor(value.price)) : 0,
+    ...(typeof value.wechatPriceFen === "number" && Number.isFinite(value.wechatPriceFen)
+      ? { wechatPriceFen: Math.max(0, Math.floor(value.wechatPriceFen)) }
+      : {}),
+    enabled: value.enabled !== false,
+    grant: normalizeShopProductGrant(value.grant)
+  };
+}
+
+async function fetchShopProducts(remoteUrl?: string): Promise<ShopProduct[]> {
+  const payload = (await fetchApiJson(`${resolveCocosApiBaseUrl(remoteUrl ?? "")}/api/shop/products`)) as {
+    items?: unknown[];
+  };
+  return (payload.items ?? []).map((item, index) => normalizeShopProduct(item, index));
+}
+
+async function purchaseShopProduct(
+  remoteUrl: string | undefined,
+  productId: string,
+  getAuthToken?: (() => string | null) | undefined
+): Promise<ShopPurchaseResult> {
+  const token = getAuthToken?.()?.trim() ?? "";
+  const purchaseId = `cocos-${productId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return (await fetchApiJson(`${resolveCocosApiBaseUrl(remoteUrl ?? "")}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...buildCocosAuthHeaders(token)
+    },
+    body: JSON.stringify({
+      productId,
+      quantity: 1,
+      purchaseId
+    })
+  })) as ShopPurchaseResult;
 }
 
 function wait(ms: number): Promise<void> {
@@ -1704,6 +1826,20 @@ export class VeilCocosSession {
     return fetchLeaderboardEntries(remoteUrl, limit);
   }
 
+  static async fetchShopProducts(remoteUrl?: string): Promise<ShopProduct[]> {
+    return fetchShopProducts(remoteUrl);
+  }
+
+  static async purchaseShopProduct(
+    remoteUrl: string,
+    productId: string,
+    options?: {
+      getAuthToken?: (() => string | null) | undefined;
+    }
+  ): Promise<ShopPurchaseResult> {
+    return purchaseShopProduct(remoteUrl, productId, options?.getAuthToken);
+  }
+
   static async enqueueForMatchmaking(
     remoteUrl: string,
     playerId: string,
@@ -1827,6 +1963,14 @@ export class VeilCocosSession {
 
   async fetchLeaderboard(limit = 50): Promise<LeaderboardEntry[]> {
     return fetchLeaderboardEntries(this.remoteUrl, limit);
+  }
+
+  async fetchShopProducts(): Promise<ShopProduct[]> {
+    return fetchShopProducts(this.remoteUrl);
+  }
+
+  async purchaseShopProduct(productId: string): Promise<ShopPurchaseResult> {
+    return purchaseShopProduct(this.remoteUrl, productId, this.getAuthToken);
   }
 
   async enqueueForMatchmaking(rating: number): Promise<MatchmakingStatusResponse> {

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -575,7 +575,7 @@ export class VeilHudPanel extends Component {
     );
 
     if (resources) {
-      this.renderResourceChips(`${CARD_PREFIX}-resources`, resources.gold, resources.wood, resources.ore);
+      this.renderResourceChips(`${CARD_PREFIX}-resources`, resources.gold, resources.wood, resources.ore, state.account.gems ?? 0);
     } else {
       this.hideCardDecorations(`${CARD_PREFIX}-resources`, CHIP_PREFIX);
     }
@@ -1002,7 +1002,7 @@ export class VeilHudPanel extends Component {
     label.color = new Color(255, 247, 228, 255);
   }
 
-  private renderResourceChips(cardName: string, gold: number, wood: number, ore: number): void {
+  private renderResourceChips(cardName: string, gold: number, wood: number, ore: number, gems: number): void {
     const cardNode = this.node.getChildByName(cardName);
     if (!cardNode) {
       return;
@@ -1011,15 +1011,16 @@ export class VeilHudPanel extends Component {
     const frameSet = getPixelSpriteAssets()?.icons;
     const cardTransform = cardNode.getComponent(UITransform) ?? cardNode.addComponent(UITransform);
     const gap = 6;
-    const chipWidth = Math.max(46, Math.floor((cardTransform.width - 22 - gap * 2) / 3));
+    const chipWidth = Math.max(46, Math.floor((cardTransform.width - 28 - gap * 3) / 4));
     const chipHeight = 30;
-    const totalWidth = chipWidth * 3 + gap * 2;
+    const totalWidth = chipWidth * 4 + gap * 3;
     const startX = -totalWidth / 2 + chipWidth / 2;
     const y = -10;
 
     this.renderMetricChip(cardNode, "gold", startX, y, chipWidth, chipHeight, frameSet?.gold ?? null, "金币", `${gold}`, new Color(183, 142, 72, 236));
     this.renderMetricChip(cardNode, "wood", startX + chipWidth + gap, y, chipWidth, chipHeight, frameSet?.wood ?? null, "木材", `${wood}`, new Color(90, 128, 92, 236));
     this.renderMetricChip(cardNode, "ore", startX + (chipWidth + gap) * 2, y, chipWidth, chipHeight, frameSet?.ore ?? null, "矿石", `${ore}`, new Color(96, 118, 144, 236));
+    this.renderMetricChip(cardNode, "gems", startX + (chipWidth + gap) * 3, y, chipWidth, chipHeight, null, "宝石", `${Math.max(0, Math.floor(gems))}`, new Color(126, 178, 222, 236));
   }
 
   private renderMetricChip(

--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -11,6 +11,7 @@ import type { CocosLobbyRoomSummary, CocosPlayerAccountProfile } from "./cocos-l
 import { getPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
 import { assignUiLayer } from "./cocos-ui-layer.ts";
 import { buildCocosBattleReplayTimelineView } from "./cocos-battle-replay-timeline.ts";
+import { buildCocosShopPanelView, type CocosShopPanelView } from "./cocos-shop-panel.ts";
 import {
   buildCocosBattleReplayCenterView,
   type CocosBattleReplayCenterControlAction
@@ -134,6 +135,9 @@ export interface VeilLobbyRenderState {
   lobbySkillPanel: LobbySkillPanelView | null;
   battleActive: boolean;
   skillPanelBusy?: boolean;
+  shop: CocosShopPanelView;
+  shopStatus: string;
+  shopLoading?: boolean;
 }
 
 export interface VeilLobbyPanelOptions {
@@ -164,6 +168,7 @@ export interface VeilLobbyPanelOptions {
   onOpenLobbySkillPanel?: () => void;
   onCloseLobbySkillPanel?: () => void;
   onLearnLobbySkill?: (skillId: string) => void;
+  onPurchaseShopProduct?: (productId: string) => void;
 }
 
 interface PanelCardTone {
@@ -206,6 +211,7 @@ export class VeilLobbyPanel extends Component {
   private onOpenLobbySkillPanel: (() => void) | undefined;
   private onCloseLobbySkillPanel: (() => void) | undefined;
   private onLearnLobbySkill: ((skillId: string) => void) | undefined;
+  private onPurchaseShopProduct: ((productId: string) => void) | undefined;
   private replayPlayback: BattleReplayPlaybackState | null = null;
   private replayPlaybackReplayId: string | null = null;
   private replayPlaybackStatus = "选择一场最近战斗，即可查看逐步回放。";
@@ -245,6 +251,7 @@ export class VeilLobbyPanel extends Component {
     this.onOpenLobbySkillPanel = options.onOpenLobbySkillPanel;
     this.onCloseLobbySkillPanel = options.onCloseLobbySkillPanel;
     this.onLearnLobbySkill = options.onLearnLobbySkill;
+    this.onPurchaseShopProduct = options.onPurchaseShopProduct;
   }
 
   render(state: VeilLobbyRenderState): void {
@@ -737,6 +744,7 @@ export class VeilLobbyPanel extends Component {
       this.hideBattleReplayTimelineCard();
       rightCursorY = this.renderHeroSection(rightX, rightCursorY, rightWidth, state, skillPanelBusy);
       rightCursorY = this.renderLeaderboardSection(rightX, rightCursorY, rightWidth, state);
+      rightCursorY = this.renderShopSection(rightX, rightCursorY, rightWidth, state);
       rightCursorY = this.renderCard(
         "LobbyRoomsHeader",
         rightX,
@@ -821,6 +829,92 @@ export class VeilLobbyPanel extends Component {
       this.renderSkillPanelModal(width, height, state, skillPanelBusy);
     } else {
       this.hideSkillPanelModal();
+    }
+  }
+
+  private renderShopSection(centerX: number, topY: number, width: number, state: VeilLobbyRenderState): number {
+    const shop = state.shop ?? buildCocosShopPanelView({
+      products: [],
+      gemBalance: state.account.gems ?? 0,
+      pendingProductId: null
+    });
+    let cursorY = this.renderCard(
+      "LobbyShopHeader",
+      centerX,
+      topY,
+      width,
+      84,
+      [
+        "商店",
+        shop.gemBalanceLabel,
+        state.shopLoading ? "正在同步商品..." : state.shopStatus || "可购买资源包、装备与宝石。"
+      ],
+      {
+        fill: new Color(46, 64, 82, 188),
+        stroke: new Color(220, 232, 244, 56),
+        accent: new Color(104, 182, 210, 206)
+      },
+      null,
+      14,
+      18
+    );
+
+    if (shop.emptyLabel) {
+      this.hideExtraCards("LobbyShop-", 0);
+      return this.renderCard(
+        "LobbyShopEmpty",
+        centerX,
+        cursorY,
+        width,
+        74,
+        ["商店暂空", shop.emptyLabel, "刷新大厅可重新拉取商品目录。"],
+        {
+          fill: MUTED_FILL,
+          stroke: new Color(214, 224, 238, 42),
+          accent: new Color(128, 146, 170, 156)
+        },
+        null,
+        13,
+        18
+      );
+    }
+
+    const emptyNode = this.node.getChildByName("LobbyShopEmpty");
+    if (emptyNode) {
+      emptyNode.active = false;
+    }
+
+    shop.rows.slice(0, 4).forEach((row, index) => {
+      cursorY = this.renderCard(
+        `LobbyShop-${index}`,
+        centerX,
+        cursorY,
+        width,
+        72,
+        [row.name, row.grantLabel, `${row.priceLabel} · ${row.affordabilityLabel}`],
+        {
+          fill: row.enabled ? new Color(42, 70, 76, 188) : MUTED_FILL,
+          stroke: new Color(214, 226, 244, 52),
+          accent: row.usesWechatPayment ? new Color(114, 194, 168, 196) : new Color(218, 187, 122, 194)
+        },
+        row.enabled && !state.entering ? () => {
+          this.onPurchaseShopProduct?.(row.productId);
+        } : null,
+        13,
+        18
+      );
+    });
+
+    this.hideExtraCards("LobbyShop-", Math.min(4, shop.rows.length));
+    return cursorY;
+  }
+
+  private hideExtraCards(prefix: string, visibleCount: number): void {
+    for (let index = visibleCount; index < 6; index += 1) {
+      const node = this.node.getChildByName(`${prefix}${index}`);
+      if (node) {
+        node.active = false;
+      }
     }
   }
 

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -128,6 +128,7 @@ import {
   resolveCocosLaunchIdentity,
   type CocosAuthProvider
 } from "./cocos-session-launch.ts";
+import { buildCocosShopPanelView, type ShopProduct } from "./cocos-shop-panel.ts";
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
 import { VeilProgressionPanel } from "./VeilProgressionPanel.ts";
 import { VeilEquipmentPanel } from "./VeilEquipmentPanel.ts";
@@ -168,6 +169,11 @@ import {
   validateAccountPassword,
   validatePrivacyConsentAccepted
 } from "../../../../packages/shared/src/index.ts";
+import {
+  createCocosWechatPaymentOrder,
+  requestCocosWechatPayment,
+  type CocosWechatPaymentRuntimeLike
+} from "./cocos-wechat-payment.ts";
 
 const { ccclass, property } = _decorator;
 
@@ -212,6 +218,8 @@ interface VeilRootRuntime {
   postPlayerReferral: typeof postCocosPlayerReferral;
   logoutAuthSession: typeof logoutCurrentCocosAuthSession;
   deletePlayerAccount: typeof deleteCurrentCocosPlayerAccount;
+  loadShopProducts: typeof VeilCocosSession.fetchShopProducts;
+  purchaseShopProduct: typeof VeilCocosSession.purchaseShopProduct;
 }
 
 const defaultVeilRootRuntime: VeilRootRuntime = {
@@ -232,7 +240,9 @@ const defaultVeilRootRuntime: VeilRootRuntime = {
   loginGuestAuthSession: (...args) => loginCocosGuestAuthSession(...args),
   postPlayerReferral: (...args) => postCocosPlayerReferral(...args),
   logoutAuthSession: (...args) => logoutCurrentCocosAuthSession(...args),
-  deletePlayerAccount: (...args) => deleteCurrentCocosPlayerAccount(...args)
+  deletePlayerAccount: (...args) => deleteCurrentCocosPlayerAccount(...args),
+  loadShopProducts: (...args) => VeilCocosSession.fetchShopProducts(...args),
+  purchaseShopProduct: (...args) => VeilCocosSession.purchaseShopProduct(...args)
 };
 
 let testVeilRootRuntimeOverrides: Partial<VeilRootRuntime> | null = null;
@@ -332,6 +342,10 @@ export class VeilRoot extends Component {
   private lobbyLeaderboardStatus: "idle" | "loading" | "ready" | "error" = "idle";
   private lobbyLeaderboardError: string | null = null;
   private lobbyAccountProfile: CocosPlayerAccountProfile = createFallbackCocosPlayerAccountProfile("player-1", "test-room");
+  private lobbyShopProducts: ShopProduct[] = [];
+  private lobbyShopLoading = false;
+  private lobbyShopStatus = "可用商品会在这里显示。";
+  private pendingShopProductId: string | null = null;
   private lobbyAccountReviewState: CocosAccountReviewState = createCocosAccountReviewState(this.lobbyAccountProfile);
   private lobbyAccountEpoch = 0;
   private gameplayAccountRefreshInFlight = false;
@@ -943,6 +957,9 @@ export class VeilRoot extends Component {
       },
       onLearnLobbySkill: (skillId) => {
         void this.learnHeroSkill(skillId);
+      },
+      onPurchaseShopProduct: (productId) => {
+        void this.purchaseLobbyShopProduct(productId);
       }
     });
 
@@ -1229,7 +1246,14 @@ export class VeilRoot extends Component {
           ? buildLobbySkillPanelView(toLobbySkillPanelHeroState(activeHero), runtimeBundle)
           : null,
         battleActive: Boolean(this.lastUpdate?.battle),
-        skillPanelBusy: this.moveInFlight || this.battleActionInFlight
+        skillPanelBusy: this.moveInFlight || this.battleActionInFlight,
+        shop: buildCocosShopPanelView({
+          products: this.lobbyShopProducts,
+          gemBalance: this.lobbyAccountProfile.gems ?? 0,
+          pendingProductId: this.pendingShopProductId
+        }),
+        shopStatus: this.lobbyShopStatus,
+        shopLoading: this.lobbyShopLoading
       });
       this.renderSettingsOverlay();
       return;
@@ -1351,7 +1375,7 @@ export class VeilRoot extends Component {
 
   private formatLobbyVaultSummary(): string {
     const resources = this.lobbyAccountProfile.globalResources;
-    return `全局仓库 金币 ${resources.gold} / 木材 ${resources.wood} / 矿石 ${resources.ore}`;
+    return `全局仓库 金币 ${resources.gold} / 木材 ${resources.wood} / 矿石 ${resources.ore} / 宝石 ${this.lobbyAccountProfile.gems ?? 0}`;
   }
 
   private ensurePixelSpriteGroup(group: "boot" | "battle"): void {
@@ -1399,6 +1423,8 @@ export class VeilRoot extends Component {
     const requestEpoch = this.bumpLobbyAccountEpoch();
     this.lobbyLeaderboardStatus = "loading";
     this.lobbyLeaderboardError = null;
+    this.lobbyShopLoading = true;
+    this.lobbyShopStatus = "正在同步商店商品...";
     this.renderView();
     const storedSession = readStoredCocosAuthSession(storage);
     const activeSession = storedSession?.playerId === this.playerId ? storedSession : null;
@@ -1427,7 +1453,7 @@ export class VeilRoot extends Component {
       this.sessionSource = "none";
     }
 
-    const [profile, leaderboardResult] = await Promise.all([
+    const [profile, leaderboardResult, shopProductsResult] = await Promise.all([
       resolveVeilRootRuntime().loadAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
         storage,
         authSession: syncedSession
@@ -1435,6 +1461,10 @@ export class VeilRoot extends Component {
       resolveVeilRootRuntime()
         .loadLeaderboard(this.remoteUrl, 50)
         .then((entries) => ({ ok: true as const, entries }))
+        .catch((error: unknown) => ({ ok: false as const, error })),
+      resolveVeilRootRuntime()
+        .loadShopProducts(this.remoteUrl)
+        .then((products) => ({ ok: true as const, products }))
         .catch((error: unknown) => ({ ok: false as const, error }))
     ]);
     if (!this.isActiveLobbyAccountEpoch(requestEpoch)) {
@@ -1452,12 +1482,96 @@ export class VeilRoot extends Component {
       this.lobbyLeaderboardError =
         leaderboardResult.error instanceof Error ? leaderboardResult.error.message : "leaderboard_unavailable";
     }
+    if (shopProductsResult.ok) {
+      this.lobbyShopProducts = shopProductsResult.products;
+      this.lobbyShopStatus =
+        shopProductsResult.products.length > 0
+          ? "点击商品卡片即可购买；微信商品会在小游戏环境拉起支付。"
+          : "当前没有上架商品。";
+    } else {
+      this.lobbyShopProducts = [];
+      this.lobbyShopStatus =
+        shopProductsResult.error instanceof Error ? shopProductsResult.error.message : "shop_unavailable";
+    }
+    this.lobbyShopLoading = false;
     if (profile.source === "remote") {
       this.displayName = profile.displayName;
       this.loginId = profile.loginId ?? this.loginId;
     }
     this.syncWechatShareBridge();
     this.renderView();
+  }
+
+  private describeShopError(error: unknown): string {
+    if (!(error instanceof Error)) {
+      return "商品购买失败，请稍后重试。";
+    }
+
+    switch (error.message) {
+      case "cocos_request_failed:401:unauthorized":
+      case "cocos_request_failed:401:token_expired":
+        return "购买需要有效账号会话，请重新登录后再试。";
+      case "cocos_request_failed:409:insufficient_gems":
+        return "宝石不足，无法完成本次购买。";
+      case "cocos_request_failed:409:product_not_available":
+        return "该商品当前未上架。";
+      case "cocos_request_failed:409:equipment_inventory_full":
+        return "背包已满，暂时无法领取该装备。";
+      case "cocos_request_failed:400:wechat_open_id_required":
+        return "微信支付需要先绑定小游戏身份。";
+      case "cocos_request_failed:503:wechat_pay_not_configured":
+        return "服务器尚未配置微信支付。";
+      default:
+        return error.message.startsWith("cocos_request_failed:")
+          ? "商品购买失败，请稍后重试。"
+          : error.message;
+    }
+  }
+
+  private async purchaseLobbyShopProduct(productId: string): Promise<void> {
+    if (this.pendingShopProductId || this.lobbyEntering) {
+      return;
+    }
+
+    const product = this.lobbyShopProducts.find((entry) => entry.productId === productId);
+    if (!product) {
+      this.lobbyShopStatus = "未找到要购买的商品。";
+      this.renderView();
+      return;
+    }
+    if (!this.authToken) {
+      this.lobbyShopStatus = "购买需要有效会话，请先重新进入大厅。";
+      this.renderView();
+      return;
+    }
+
+    this.pendingShopProductId = productId;
+    this.lobbyShopStatus = product.wechatPriceFen ? `正在创建微信订单 ${product.name}...` : `正在购买 ${product.name}...`;
+    this.renderView();
+
+    try {
+      if (product.wechatPriceFen) {
+        const order = await createCocosWechatPaymentOrder(this.remoteUrl, productId, {
+          authToken: this.authToken
+        });
+        const paymentResult = await requestCocosWechatPayment(
+          (globalThis as { wx?: CocosWechatPaymentRuntimeLike | null }).wx,
+          order
+        );
+        this.lobbyShopStatus = paymentResult.message;
+      } else {
+        const result = await resolveVeilRootRuntime().purchaseShopProduct(this.remoteUrl, productId, {
+          getAuthToken: () => this.authToken
+        });
+        this.lobbyShopStatus = `${product.name} 购买成功，当前宝石 ${result.gemsBalance}。`;
+        await this.refreshLobbyAccountProfile();
+      }
+    } catch (error) {
+      this.lobbyShopStatus = this.describeShopError(error);
+    } finally {
+      this.pendingShopProductId = null;
+      this.renderView();
+    }
   }
 
   private async refreshActiveAccountReviewSection(section = this.lobbyAccountReviewState.activeSection): Promise<void> {

--- a/apps/cocos-client/assets/scripts/cocos-shop-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-shop-panel.ts
@@ -1,0 +1,120 @@
+export interface ShopProductGrant {
+  gems?: number;
+  resources?: {
+    gold?: number;
+    wood?: number;
+    ore?: number;
+  };
+  equipmentIds?: string[];
+}
+
+export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle";
+
+export interface ShopProduct {
+  productId: string;
+  name: string;
+  type: ShopProductType;
+  price: number;
+  wechatPriceFen?: number;
+  enabled: boolean;
+  grant: ShopProductGrant;
+}
+
+export interface ShopProductRowView {
+  productId: string;
+  name: string;
+  grantLabel: string;
+  priceLabel: string;
+  affordabilityLabel: string;
+  actionLabel: string;
+  enabled: boolean;
+  affordable: boolean;
+  usesWechatPayment: boolean;
+}
+
+export interface CocosShopPanelView {
+  gemBalanceLabel: string;
+  rows: ShopProductRowView[];
+  emptyLabel: string | null;
+}
+
+export interface BuildCocosShopPanelInput {
+  products: ShopProduct[];
+  gemBalance: number;
+  pendingProductId: string | null;
+}
+
+function formatResourceGrant(resources?: ShopProductGrant["resources"]): string | null {
+  if (!resources) {
+    return null;
+  }
+
+  const parts = [
+    (resources.gold ?? 0) > 0 ? `金币 +${Math.floor(resources.gold ?? 0)}` : null,
+    (resources.wood ?? 0) > 0 ? `木材 +${Math.floor(resources.wood ?? 0)}` : null,
+    (resources.ore ?? 0) > 0 ? `矿石 +${Math.floor(resources.ore ?? 0)}` : null
+  ].filter(Boolean);
+  return parts.length > 0 ? parts.join(" / ") : null;
+}
+
+function formatPriceLabel(product: ShopProduct): string {
+  const gemPrice = Math.max(0, Math.floor(product.price ?? 0));
+  const wechatPriceFen = Math.max(0, Math.floor(product.wechatPriceFen ?? 0));
+  if (wechatPriceFen > 0 && gemPrice > 0) {
+    return `微信 ¥${(wechatPriceFen / 100).toFixed(2)} / ${gemPrice} 宝石`;
+  }
+  if (wechatPriceFen > 0) {
+    return `微信 ¥${(wechatPriceFen / 100).toFixed(2)}`;
+  }
+  return `${gemPrice} 宝石`;
+}
+
+function formatGrantLabel(product: ShopProduct): string {
+  const resources = formatResourceGrant(product.grant.resources);
+  if ((product.grant.gems ?? 0) > 0) {
+    return `宝石 x${Math.floor(product.grant.gems ?? 0)}`;
+  }
+  if ((product.grant.equipmentIds?.length ?? 0) > 0) {
+    return `装备 ${product.grant.equipmentIds?.length ?? 0} 件`;
+  }
+  if (resources) {
+    return resources;
+  }
+  return product.type === "equipment" ? "装备奖励" : "奖励待同步";
+}
+
+export function buildCocosShopPanelView(input: BuildCocosShopPanelInput): CocosShopPanelView {
+  const gemBalance = Math.max(0, Math.floor(input.gemBalance ?? 0));
+  const rows = input.products.map<ShopProductRowView>((product) => {
+    const usesWechatPayment = Math.max(0, Math.floor(product.wechatPriceFen ?? 0)) > 0;
+    const affordable = usesWechatPayment ? true : gemBalance >= Math.max(0, Math.floor(product.price ?? 0));
+    const pending = input.pendingProductId === product.productId;
+    const enabled = product.enabled && !pending && (usesWechatPayment || affordable);
+
+    return {
+      productId: product.productId,
+      name: product.name.trim() || product.productId,
+      grantLabel: formatGrantLabel(product),
+      priceLabel: formatPriceLabel(product),
+      affordabilityLabel: pending
+        ? "订单处理中..."
+        : !product.enabled
+          ? "暂未上架"
+          : usesWechatPayment
+            ? "需拉起微信支付"
+            : affordable
+              ? `可购买，余额 ${gemBalance - Math.max(0, Math.floor(product.price ?? 0))} 宝石`
+              : `宝石不足，还差 ${Math.max(0, Math.floor(product.price ?? 0)) - gemBalance}`,
+      actionLabel: pending ? "购买中..." : usesWechatPayment ? "微信购买" : "购买",
+      enabled,
+      affordable,
+      usesWechatPayment
+    };
+  });
+
+  return {
+    gemBalanceLabel: `宝石 ${gemBalance}`,
+    rows,
+    emptyLabel: rows.length === 0 ? "当前没有可购买商品。" : null
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-wechat-payment.ts
+++ b/apps/cocos-client/assets/scripts/cocos-wechat-payment.ts
@@ -1,0 +1,96 @@
+import { buildCocosAuthHeaders, resolveCocosApiBaseUrl } from "./cocos-lobby.ts";
+
+type FetchLike = typeof fetch;
+
+export interface CocosWechatPaymentOrder {
+  orderId: string;
+  timeStamp: string;
+  nonceStr: string;
+  package: string;
+  signType: string;
+  paySign: string;
+}
+
+export interface CocosWechatPaymentRuntimeLike {
+  requestPayment?: ((options: {
+    timeStamp: string;
+    nonceStr: string;
+    package: string;
+    signType: string;
+    paySign: string;
+    success?: (result: { errMsg?: string }) => void;
+    fail?: (error: { errMsg?: string }) => void;
+  }) => void) | undefined;
+}
+
+function getFetchImpl(fetchImpl?: FetchLike): FetchLike {
+  return fetchImpl ?? fetch;
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  return (await response.json()) as unknown;
+}
+
+export async function createCocosWechatPaymentOrder(
+  remoteUrl: string,
+  productId: string,
+  options?: {
+    fetchImpl?: FetchLike;
+    authToken?: string | null;
+  }
+): Promise<CocosWechatPaymentOrder> {
+  const response = await getFetchImpl(options?.fetchImpl)(`${resolveCocosApiBaseUrl(remoteUrl)}/api/payments/wechat/create`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...buildCocosAuthHeaders(options?.authToken)
+    },
+    body: JSON.stringify({
+      productId
+    })
+  });
+
+  if (!response.ok) {
+    let errorCode = "unknown";
+    try {
+      const payload = (await readJsonResponse(response)) as { error?: { code?: string } };
+      errorCode = payload.error?.code?.trim() || errorCode;
+    } catch {
+      errorCode = "unknown";
+    }
+    throw new Error(`cocos_request_failed:${response.status}:${errorCode}`);
+  }
+
+  return (await readJsonResponse(response)) as CocosWechatPaymentOrder;
+}
+
+export async function requestCocosWechatPayment(
+  runtime: CocosWechatPaymentRuntimeLike | null | undefined,
+  order: CocosWechatPaymentOrder
+): Promise<{ available: boolean; message: string }> {
+  if (typeof runtime?.requestPayment !== "function") {
+    return {
+      available: false,
+      message: "当前环境未暴露 wx.requestPayment。"
+    };
+  }
+
+  return new Promise((resolve, reject) => {
+    runtime.requestPayment?.({
+      timeStamp: order.timeStamp,
+      nonceStr: order.nonceStr,
+      package: order.package,
+      signType: order.signType,
+      paySign: order.paySign,
+      success: () => {
+        resolve({
+          available: true,
+          message: `微信订单 ${order.orderId} 已发起，等待服务端到账确认。`
+        });
+      },
+      fail: (error) => {
+        reject(new Error(error.errMsg?.trim() || "wechat_payment_failed"));
+      }
+    });
+  });
+}

--- a/apps/cocos-client/test/cocos-shop-panel.test.ts
+++ b/apps/cocos-client/test/cocos-shop-panel.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCocosShopPanelView } from "../assets/scripts/cocos-shop-panel";
+
+test("buildCocosShopPanelView formats gem purchases, WeChat purchases, and pending state", () => {
+  const view = buildCocosShopPanelView({
+    gemBalance: 30,
+    pendingProductId: "equipment-sunforged-kit",
+    products: [
+      {
+        productId: "resource-bundle-starter",
+        name: "Starter Supply Cache",
+        type: "resource_bundle",
+        price: 25,
+        enabled: true,
+        grant: {
+          resources: {
+            gold: 250,
+            wood: 40,
+            ore: 20
+          }
+        }
+      },
+      {
+        productId: "equipment-sunforged-kit",
+        name: "Sunforged Kit",
+        type: "equipment",
+        price: 40,
+        enabled: true,
+        grant: {
+          equipmentIds: ["sunforged_spear"]
+        }
+      },
+      {
+        productId: "gem-pack-premium",
+        name: "Premium Gem Cache",
+        type: "gem_pack",
+        price: 0,
+        wechatPriceFen: 600,
+        enabled: true,
+        grant: {
+          gems: 120
+        }
+      }
+    ]
+  });
+
+  assert.equal(view.gemBalanceLabel, "宝石 30");
+  assert.equal(view.emptyLabel, null);
+  assert.deepEqual(view.rows, [
+    {
+      productId: "resource-bundle-starter",
+      name: "Starter Supply Cache",
+      grantLabel: "金币 +250 / 木材 +40 / 矿石 +20",
+      priceLabel: "25 宝石",
+      affordabilityLabel: "可购买，余额 5 宝石",
+      actionLabel: "购买",
+      enabled: true,
+      affordable: true,
+      usesWechatPayment: false
+    },
+    {
+      productId: "equipment-sunforged-kit",
+      name: "Sunforged Kit",
+      grantLabel: "装备 1 件",
+      priceLabel: "40 宝石",
+      affordabilityLabel: "订单处理中...",
+      actionLabel: "购买中...",
+      enabled: false,
+      affordable: false,
+      usesWechatPayment: false
+    },
+    {
+      productId: "gem-pack-premium",
+      name: "Premium Gem Cache",
+      grantLabel: "宝石 x120",
+      priceLabel: "微信 ¥6.00",
+      affordabilityLabel: "需拉起微信支付",
+      actionLabel: "微信购买",
+      enabled: true,
+      affordable: true,
+      usesWechatPayment: true
+    }
+  ]);
+});
+
+test("buildCocosShopPanelView reports insufficient gems and empty states", () => {
+  const insufficient = buildCocosShopPanelView({
+    gemBalance: 3,
+    pendingProductId: null,
+    products: [
+      {
+        productId: "resource-bundle-starter",
+        name: "Starter Supply Cache",
+        type: "resource_bundle",
+        price: 25,
+        enabled: true,
+        grant: {
+          resources: {
+            gold: 250
+          }
+        }
+      }
+    ]
+  });
+
+  assert.equal(insufficient.rows[0]?.affordabilityLabel, "宝石不足，还差 22");
+  assert.equal(insufficient.rows[0]?.enabled, false);
+
+  const empty = buildCocosShopPanelView({
+    gemBalance: 8,
+    pendingProductId: null,
+    products: []
+  });
+
+  assert.equal(empty.emptyLabel, "当前没有可购买商品。");
+  assert.deepEqual(empty.rows, []);
+});


### PR DESCRIPTION
## Summary
- add a pure `cocos-shop-panel` view-model with Node.js tests for pricing, affordability, and pending purchase states
- wire shop product fetch and gem-purchase calls into `VeilCocosSession`, plus a WeChat payment helper for JSAPI order creation and `wx.requestPayment`
- render gem balance in the HUD and add a lobby shop section with purchase status/error handling

## Testing
- `node --import tsx --test ./apps/cocos-client/test/cocos-shop-panel.test.ts`
- `node --import tsx --test ./apps/cocos-client/test/cocos-lobby-panel.test.ts`
- `node --import tsx --test ./apps/cocos-client/test/cocos-root-orchestration.test.ts`
- `npm run typecheck:cocos`

Closes #825