### PR TITLE
Implement season close reward distribution

### DIFF
--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -1,7 +1,5 @@
 import {
-  DEFAULT_ELO_RATING,
   appendEventLogEntries,
-  getTierForRating,
   getEquipmentDefinition,
   normalizeEloRating,
   normalizeEventLogEntries,
@@ -40,8 +38,7 @@ import {
   type PlayerReportResolveInput,
   type PlayerHeroArchiveSnapshot,
   type PlayerEventHistoryQuery,
-  type PlayerEventHistorySnapshot
-  ,
+  type PlayerEventHistorySnapshot,
   type SeasonCloseSummary,
   type SeasonListOptions,
   type SeasonSnapshot,
@@ -49,7 +46,7 @@ import {
   type ShopPurchaseResult
 } from "./persistence";
 import type { RoomPersistenceSnapshot } from "./index";
-import { computeSeasonResetEloRating, resolveSeasonRewardConfig } from "./season-rewards";
+import { computeSeasonReward, resolveSeasonRewardConfig } from "./season-rewards";
 
 function cloneAccount(account: PlayerAccountSnapshot): PlayerAccountSnapshot {
   return structuredClone(account);
@@ -116,6 +113,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly shopPurchases = new Map<string, ShopPurchaseResult>();
   private readonly reports = new Map<string, PlayerReportRecord>();
   private readonly seasons = new Map<string, SeasonSnapshot>();
+  private readonly seasonRewardLog = new Map<string, { gems: number; badge: string; distributedAt: string }>();
   private readonly referrals = new Set<string>();
   private nextReportId = 1;
 
@@ -1019,6 +1017,8 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     const existing = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
     const nextAccount: PlayerAccountSnapshot = {
       ...existing,
+      ...(patch.gems !== undefined ? { gems: Math.max(0, Math.floor(patch.gems)) } : {}),
+      seasonBadges: structuredClone((patch.seasonBadges as string[] | undefined) ?? existing.seasonBadges ?? []),
       globalResources: structuredClone(
         (patch.globalResources as PlayerAccountSnapshot["globalResources"] | undefined) ?? existing.globalResources
       ),
@@ -1065,6 +1065,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         displayName: previous?.displayName ?? account.displayName,
         ...(previous?.avatarUrl ? { avatarUrl: previous.avatarUrl } : {}),
         eloRating: normalizeEloRating(previous?.eloRating ?? account.eloRating),
+        seasonBadges: structuredClone(previous?.seasonBadges ?? account.seasonBadges ?? []),
         achievements: structuredClone(previous?.achievements ?? account.achievements),
         recentEventLog: structuredClone(previous?.recentEventLog ?? account.recentEventLog),
         recentBattleReplays: structuredClone(previous?.recentBattleReplays ?? account.recentBattleReplays ?? []),
@@ -1127,7 +1128,14 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   async closeSeason(seasonId: string): Promise<SeasonCloseSummary> {
     const normalizedSeasonId = seasonId.trim();
     const existing = this.seasons.get(normalizedSeasonId);
-    if (!existing || existing.status === "closed") {
+    if (!existing) {
+      return {
+        seasonId: normalizedSeasonId,
+        playersRewarded: 0,
+        totalGemsGranted: 0
+      };
+    }
+    if (existing.status === "closed" && existing.rewardDistributedAt) {
       return {
         seasonId: normalizedSeasonId,
         playersRewarded: 0,
@@ -1140,33 +1148,45 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       .filter((account) => account.eloRating != null)
       .sort(
         (left, right) =>
-          normalizeEloRating(right.eloRating ?? DEFAULT_ELO_RATING) - normalizeEloRating(left.eloRating ?? DEFAULT_ELO_RATING) ||
+          normalizeEloRating(right.eloRating) - normalizeEloRating(left.eloRating) ||
           left.playerId.localeCompare(right.playerId)
       );
 
+    const distributedAt = new Date().toISOString();
+    let playersRewarded = 0;
     let totalGemsGranted = 0;
-    for (const account of rankedAccounts) {
-      const rating = normalizeEloRating(account.eloRating ?? DEFAULT_ELO_RATING);
-      const tier = getTierForRating(rating);
-      const rewardAmount = rewardConfig[tier];
-      totalGemsGranted += rewardAmount;
-      if (rewardAmount > 0) {
-        await this.creditGems(account.playerId, rewardAmount, "reward", `season:${normalizedSeasonId}`);
+    for (const [index, account] of rankedAccounts.entries()) {
+      const reward = computeSeasonReward(index + 1, rankedAccounts.length, rewardConfig);
+      if (!reward) {
+        continue;
       }
-      await this.savePlayerAccountProgress(account.playerId, {
-        eloRating: computeSeasonResetEloRating(rating)
+      const rewardLogKey = `${normalizedSeasonId}:${account.playerId}`;
+      if (this.seasonRewardLog.has(rewardLogKey)) {
+        continue;
+      }
+      this.seasonRewardLog.set(rewardLogKey, {
+        gems: reward.gems,
+        badge: reward.badge,
+        distributedAt
       });
+      await this.savePlayerAccountProgress(account.playerId, {
+        gems: (account.gems ?? 0) + reward.gems,
+        seasonBadges: Array.from(new Set([...(account.seasonBadges ?? []), reward.badge]))
+      });
+      playersRewarded += 1;
+      totalGemsGranted += reward.gems;
     }
 
     this.seasons.set(normalizedSeasonId, {
       ...existing,
       status: "closed",
-      endedAt: new Date().toISOString()
+      endedAt: existing.endedAt ?? distributedAt,
+      rewardDistributedAt: existing.rewardDistributedAt ?? distributedAt
     });
 
     return {
       seasonId: normalizedSeasonId,
-      playersRewarded: rankedAccounts.length,
+      playersRewarded,
       totalGemsGranted
     };
   }
@@ -1183,6 +1203,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     this.heroArchives.clear();
     this.shopPurchases.clear();
     this.seasons.clear();
+    this.seasonRewardLog.clear();
   }
 
   private selectSeasons(options: SeasonListOptions): SeasonSnapshot[] {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import { createPool, type Pool, type PoolConnection, type ResultSetHeader, type RowDataPacket } from "mysql2/promise";
 import {
   appendEventLogEntries,
-  DEFAULT_ELO_RATING,
   getEquipmentDefinition,
   getTierForRating,
   appendPlayerBattleReplaySummaries,
@@ -25,13 +24,14 @@ import {
   type WorldState
 } from "../../../packages/shared/src/index";
 import type { RoomPersistenceSnapshot } from "./index";
-import { computeSeasonResetEloRating, resolveSeasonRewardConfig } from "./season-rewards";
+import { computeSeasonReward, resolveSeasonRewardConfig } from "./season-rewards";
 
 export interface SeasonSnapshot {
   seasonId: string;
   status: "active" | "closed";
   startedAt: string;
   endedAt?: string;
+  rewardDistributedAt?: string;
 }
 
 export interface SeasonListOptions {
@@ -175,6 +175,7 @@ interface PlayerAccountRow extends RowDataPacket {
   avatar_url: string | null;
   elo_rating: number | null;
   gems: number | null;
+  season_badges_json: string | string[] | null;
   global_resources_json: string | ResourceLedger;
   achievements_json: string | PlayerAchievementProgress[] | null;
   recent_event_log_json: string | EventLogEntry[] | null;
@@ -498,6 +499,7 @@ export interface PlayerAccountProfilePatch {
 
 export interface PlayerAccountProgressPatch {
   gems?: number;
+  seasonBadges?: string[] | null;
   globalResources?: Partial<ResourceLedger> | null;
   achievements?: Partial<PlayerAchievementProgress>[] | null;
   recentEventLog?: Partial<EventLogEntry>[] | null;
@@ -631,6 +633,9 @@ export const MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX = "idx_player_reports_stat
 export const MYSQL_PLAYER_REPORT_ROOM_REPORTER_TARGET_INDEX = "uidx_player_reports_room_reporter_target";
 export const MYSQL_CONFIG_DOCUMENT_TABLE = "config_documents";
 export const MYSQL_CONFIG_DOCUMENT_UPDATED_AT_INDEX = "idx_config_documents_updated_at";
+export const MYSQL_SEASON_TABLE = "veil_seasons";
+export const MYSQL_SEASON_RANKINGS_TABLE = "veil_season_rankings";
+export const MYSQL_SEASON_REWARD_LOG_TABLE = "season_reward_log";
 export const DEFAULT_SNAPSHOT_TTL_HOURS = 72;
 export const DEFAULT_SNAPSHOT_CLEANUP_INTERVAL_MINUTES = 30;
 export const MAX_PLAYER_DISPLAY_NAME_LENGTH = 40;
@@ -1094,6 +1099,7 @@ function normalizePlayerAccountSnapshot(account: {
   avatarUrl?: string | null | undefined;
   eloRating?: number | null | undefined;
   gems?: number | null | undefined;
+  seasonBadges?: string[] | null | undefined;
   globalResources?: Partial<ResourceLedger>;
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
@@ -1135,6 +1141,7 @@ function normalizePlayerAccountSnapshot(account: {
       avatarUrl: normalizePlayerAvatarUrl(account.avatarUrl),
       eloRating: normalizeEloRating(account.eloRating),
       gems: normalizeGemAmount(account.gems),
+      seasonBadges: account.seasonBadges,
       globalResources: normalizeResourceLedger(account.globalResources),
       achievements: account.achievements,
       recentEventLog: account.recentEventLog,
@@ -1428,6 +1435,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   avatar_url VARCHAR(512) NULL,
   elo_rating INT NOT NULL DEFAULT 1000,
   gems INT NOT NULL DEFAULT 0,
+  season_badges_json LONGTEXT NULL,
   global_resources_json LONGTEXT NOT NULL,
   achievements_json LONGTEXT NULL,
   recent_event_log_json LONGTEXT NULL,
@@ -1467,6 +1475,15 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_GEM_LEDGER_TABLE}\` (
   ref_id VARCHAR(191) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (entry_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS \`${MYSQL_SEASON_REWARD_LOG_TABLE}\` (
+  season_id VARCHAR(64) NOT NULL,
+  player_id VARCHAR(64) NOT NULL,
+  gems INT NOT NULL,
+  badge VARCHAR(64) NOT NULL,
+  distributed_at DATETIME NOT NULL,
+  PRIMARY KEY (season_id, player_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_REFERRAL_TABLE}\` (
@@ -1700,6 +1717,24 @@ SET @veil_player_accounts_gems_sql := IF(
 PREPARE veil_player_accounts_gems_stmt FROM @veil_player_accounts_gems_sql;
 EXECUTE veil_player_accounts_gems_stmt;
 DEALLOCATE PREPARE veil_player_accounts_gems_stmt;
+
+SET @veil_player_accounts_season_badges_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'season_badges_json'
+);
+
+SET @veil_player_accounts_season_badges_sql := IF(
+  @veil_player_accounts_season_badges_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`season_badges_json\` LONGTEXT NULL AFTER \`gems\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_season_badges_stmt FROM @veil_player_accounts_season_badges_sql;
+EXECUTE veil_player_accounts_season_badges_stmt;
+DEALLOCATE PREPARE veil_player_accounts_season_badges_stmt;
 
 SET @veil_player_accounts_event_log_exists := (
   SELECT COUNT(*)
@@ -2410,22 +2445,50 @@ PREPARE veil_config_documents_idx_stmt FROM @veil_config_documents_idx_sql;
 EXECUTE veil_config_documents_idx_stmt;
 DEALLOCATE PREPARE veil_config_documents_idx_stmt;
 
-CREATE TABLE IF NOT EXISTS \`veil_seasons\` (
+CREATE TABLE IF NOT EXISTS \`${MYSQL_SEASON_TABLE}\` (
   \`season_id\` VARCHAR(64) NOT NULL,
   \`status\` ENUM('active','closed') NOT NULL DEFAULT 'active',
   \`started_at\` DATETIME NOT NULL,
   \`ended_at\` DATETIME NULL,
+  \`reward_distributed_at\` DATETIME NULL,
   \`created_at\` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (\`season_id\`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE IF NOT EXISTS \`veil_season_rankings\` (
+CREATE TABLE IF NOT EXISTS \`${MYSQL_SEASON_RANKINGS_TABLE}\` (
   \`season_id\` VARCHAR(64) NOT NULL,
   \`player_id\` VARCHAR(64) NOT NULL,
   \`final_rating\` INT NOT NULL,
   \`tier\` VARCHAR(32) NOT NULL,
   \`rank_position\` INT NOT NULL,
   \`archived_at\` DATETIME NOT NULL,
+  PRIMARY KEY (\`season_id\`, \`player_id\`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+SET @veil_seasons_reward_distributed_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_SEASON_TABLE}'
+    AND COLUMN_NAME = 'reward_distributed_at'
+);
+
+SET @veil_seasons_reward_distributed_sql := IF(
+  @veil_seasons_reward_distributed_exists = 0,
+  'ALTER TABLE \`${MYSQL_SEASON_TABLE}\` ADD COLUMN \`reward_distributed_at\` DATETIME NULL AFTER \`ended_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_seasons_reward_distributed_stmt FROM @veil_seasons_reward_distributed_sql;
+EXECUTE veil_seasons_reward_distributed_stmt;
+DEALLOCATE PREPARE veil_seasons_reward_distributed_stmt;
+
+CREATE TABLE IF NOT EXISTS \`${MYSQL_SEASON_REWARD_LOG_TABLE}\` (
+  \`season_id\` VARCHAR(64) NOT NULL,
+  \`player_id\` VARCHAR(64) NOT NULL,
+  \`gems\` INT NOT NULL,
+  \`badge\` VARCHAR(64) NOT NULL,
+  \`distributed_at\` DATETIME NOT NULL,
   PRIMARY KEY (\`season_id\`, \`player_id\`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 `.trim();
@@ -2504,6 +2567,10 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(row.avatar_url ? { avatarUrl: row.avatar_url } : {}),
     ...(row.elo_rating != null ? { eloRating: row.elo_rating } : {}),
     gems: normalizeGemAmount(row.gems),
+    seasonBadges:
+      row.season_badges_json != null
+        ? parseJsonColumn<string[]>(row.season_badges_json)
+        : [],
     globalResources: parseJsonColumn<ResourceLedger>(row.global_resources_json),
     achievements:
       row.achievements_json != null
@@ -2786,6 +2853,7 @@ async function savePlayerAccounts(
          display_name,
          elo_rating,
          gems,
+         season_badges_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json
@@ -2793,11 +2861,12 @@ async function savePlayerAccounts(
          recent_battle_replays_json,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(display_name, VALUES(display_name)),
          elo_rating = COALESCE(elo_rating, VALUES(elo_rating)),
          gems = VALUES(gems),
+         season_badges_json = COALESCE(season_badges_json, VALUES(season_badges_json)),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = COALESCE(achievements_json, VALUES(achievements_json)),
          recent_event_log_json = COALESCE(recent_event_log_json, VALUES(recent_event_log_json)),
@@ -2809,6 +2878,7 @@ async function savePlayerAccounts(
         normalizedAccount.displayName,
         normalizedAccount.eloRating,
         normalizedAccount.gems,
+        JSON.stringify(normalizedAccount.seasonBadges ?? []),
         JSON.stringify(normalizedAccount.globalResources),
         JSON.stringify(normalizedAccount.achievements),
         JSON.stringify(normalizedAccount.recentEventLog),
@@ -3042,6 +3112,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          avatar_url,
          elo_rating,
          gems,
+         season_badges_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3091,6 +3162,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          avatar_url,
          elo_rating,
          gems,
+         season_badges_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3224,6 +3296,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          avatar_url,
          elo_rating,
          gems,
+         season_badges_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3367,6 +3440,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          display_name,
          elo_rating,
          gems,
+         season_badges_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3374,7 +3448,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(?, display_name),
          last_room_id = COALESCE(?, last_room_id),
@@ -3385,6 +3459,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         insertDisplayName,
         normalizeEloRating(undefined),
         0,
+        JSON.stringify([]),
         JSON.stringify(normalizeResourceLedger()),
         JSON.stringify(normalizeAchievementProgress()),
         JSON.stringify(normalizeEventLogEntries()),
@@ -3402,6 +3477,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         playerId,
         displayName: insertDisplayName,
         eloRating: normalizeEloRating(undefined),
+        seasonBadges: [],
         globalResources: normalizeResourceLedger(),
         achievements: normalizeAchievementProgress(),
         recentEventLog: normalizeEventLogEntries(),
@@ -4517,6 +4593,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          avatar_url,
          elo_rating,
          gems,
+         season_badges_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -4526,11 +4603,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number,
          phone_number_bound_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = VALUES(avatar_url),
          elo_rating = VALUES(elo_rating),
+         season_badges_json = COALESCE(season_badges_json, VALUES(season_badges_json)),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = VALUES(achievements_json),
          recent_event_log_json = VALUES(recent_event_log_json),
@@ -4546,6 +4624,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         nextAccount.avatarUrl ?? null,
         nextAccount.eloRating,
         nextAccount.gems,
+        JSON.stringify(nextAccount.seasonBadges ?? []),
         JSON.stringify(nextAccount.globalResources),
         JSON.stringify(nextAccount.achievements),
         JSON.stringify(nextAccount.recentEventLog),
@@ -4580,6 +4659,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       ...existing,
       playerId: normalizedPlayerId,
       ...(patch.gems !== undefined ? { gems: patch.gems } : {}),
+      seasonBadges: patch.seasonBadges ?? existing.seasonBadges,
       globalResources: patch.globalResources ?? existing.globalResources,
       achievements: patch.achievements ?? existing.achievements,
       recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
@@ -4607,6 +4687,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          avatar_url,
          elo_rating,
          gems,
+         season_badges_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -4619,11 +4700,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_play_date,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = COALESCE(avatar_url, VALUES(avatar_url)),
          gems = VALUES(gems),
+         season_badges_json = VALUES(season_badges_json),
          elo_rating = VALUES(elo_rating),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = VALUES(achievements_json),
@@ -4643,6 +4725,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         nextAccount.avatarUrl ?? null,
         nextAccount.eloRating,
         nextAccount.gems,
+        JSON.stringify(nextAccount.seasonBadges ?? []),
         JSON.stringify(nextAccount.globalResources),
         JSON.stringify(nextAccount.achievements),
         JSON.stringify(nextAccount.recentEventLog),
@@ -4899,15 +4982,21 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
   async getCurrentSeason(): Promise<SeasonSnapshot | null> {
     const [rows] = await this.pool.query<RowDataPacket[]>(
-      `SELECT season_id, status, started_at, ended_at FROM \`veil_seasons\` WHERE status = 'active' ORDER BY started_at DESC LIMIT 1`
+      `SELECT season_id, status, started_at, ended_at, reward_distributed_at
+       FROM \`${MYSQL_SEASON_TABLE}\`
+       WHERE status = 'active'
+       ORDER BY started_at DESC
+       LIMIT 1`
     );
     const row = rows[0];
     if (!row) return null;
     const endedAtTimestamp = row.ended_at ? formatTimestamp(row.ended_at as Date | string) : undefined;
+    const rewardDistributedAt = row.reward_distributed_at ? formatTimestamp(row.reward_distributed_at as Date | string) : undefined;
     const base: SeasonSnapshot = {
       seasonId: String(row.season_id),
       status: row.status as "active" | "closed",
-      startedAt: formatTimestamp(row.started_at as Date | string) ?? new Date().toISOString()
+      startedAt: formatTimestamp(row.started_at as Date | string) ?? new Date().toISOString(),
+      ...(rewardDistributedAt ? { rewardDistributedAt } : {})
     };
     return endedAtTimestamp ? { ...base, endedAt: endedAtTimestamp } : base;
   }
@@ -4919,8 +5008,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     const clauses = status === "all" ? "" : "WHERE status = ?";
     const params = status === "all" ? [limit] : [status, limit];
     const [rows] = await this.pool.query<RowDataPacket[]>(
-      `SELECT season_id, status, started_at, ended_at
-       FROM \`veil_seasons\`
+      `SELECT season_id, status, started_at, ended_at, reward_distributed_at
+       FROM \`${MYSQL_SEASON_TABLE}\`
        ${clauses}
        ORDER BY started_at DESC
        LIMIT ?`,
@@ -4929,10 +5018,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     return rows.map((row) => {
       const endedAtTimestamp = row.ended_at ? formatTimestamp(row.ended_at as Date | string) : undefined;
+      const rewardDistributedAt = row.reward_distributed_at ? formatTimestamp(row.reward_distributed_at as Date | string) : undefined;
       const season: SeasonSnapshot = {
         seasonId: String(row.season_id),
         status: row.status as "active" | "closed",
-        startedAt: formatTimestamp(row.started_at as Date | string) ?? new Date().toISOString()
+        startedAt: formatTimestamp(row.started_at as Date | string) ?? new Date().toISOString(),
+        ...(rewardDistributedAt ? { rewardDistributedAt } : {})
       };
       return endedAtTimestamp ? { ...season, endedAt: endedAtTimestamp } : season;
     });
@@ -4943,7 +5034,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     if (!normalizedId) throw new Error("seasonId must not be empty");
     const startedAt = new Date();
     await this.pool.query(
-      `INSERT INTO \`veil_seasons\` (season_id, status, started_at) VALUES (?, 'active', ?)`,
+      `INSERT INTO \`${MYSQL_SEASON_TABLE}\` (season_id, status, started_at) VALUES (?, 'active', ?)`,
       [normalizedId, startedAt]
     );
     return {
@@ -4967,15 +5058,25 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       await connection.beginTransaction();
 
       const [seasonRows] = await connection.query<RowDataPacket[]>(
-        `SELECT season_id, status
-         FROM \`veil_seasons\`
+        `SELECT season_id, status, reward_distributed_at
+         FROM \`${MYSQL_SEASON_TABLE}\`
          WHERE season_id = ?
          LIMIT 1
          FOR UPDATE`,
         [normalizedId]
       );
-      const seasonRow = seasonRows[0] as { season_id: string; status: "active" | "closed" } | undefined;
-      if (!seasonRow || seasonRow.status === "closed") {
+      const seasonRow = seasonRows[0] as
+        | { season_id: string; status: "active" | "closed"; reward_distributed_at?: Date | string | null }
+        | undefined;
+      if (!seasonRow) {
+        await connection.rollback();
+        return {
+          seasonId: normalizedId,
+          playersRewarded: 0,
+          totalGemsGranted: 0
+        };
+      }
+      if (seasonRow.status === "closed" && seasonRow.reward_distributed_at) {
         await connection.rollback();
         return {
           seasonId: normalizedId,
@@ -4984,63 +5085,109 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         };
       }
 
-      const [accountRows] = await connection.query<RowDataPacket[]>(
-        `SELECT player_id, elo_rating, gems
-         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
-         WHERE elo_rating IS NOT NULL
-         ORDER BY elo_rating DESC, player_id ASC
-         FOR UPDATE`
+      const [existingRankingRows] = await connection.query<RowDataPacket[]>(
+        `SELECT player_id, final_rating, rank_position
+         FROM \`${MYSQL_SEASON_RANKINGS_TABLE}\`
+         WHERE season_id = ?
+         ORDER BY final_rating DESC, rank_position ASC, player_id ASC`,
+        [normalizedId]
       );
+
+      let rankedPlayers = existingRankingRows.map((row) => ({
+        playerId: String(row.player_id),
+        finalRating: normalizeEloRating(Number(row.final_rating)),
+        rankPosition: Math.max(1, Math.floor(Number(row.rank_position) || 0))
+      }));
+
+      if (rankedPlayers.length === 0) {
+        const [accountRows] = await connection.query<RowDataPacket[]>(
+          `SELECT player_id, elo_rating
+           FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+           WHERE elo_rating IS NOT NULL
+           ORDER BY elo_rating DESC, player_id ASC
+           FOR UPDATE`
+        );
+        const rankingValues: Array<[string, string, number, string, number, Date]> = [];
+        rankedPlayers = accountRows.map((row, index) => {
+          const playerId = String(row.player_id);
+          const finalRating = normalizeEloRating(Number(row.elo_rating));
+          rankingValues.push([normalizedId, playerId, finalRating, getTierForRating(finalRating), index + 1, now]);
+          return {
+            playerId,
+            finalRating,
+            rankPosition: index + 1
+          };
+        });
+
+        if (rankingValues.length > 0) {
+          await connection.query(
+            `INSERT INTO \`${MYSQL_SEASON_RANKINGS_TABLE}\` (season_id, player_id, final_rating, tier, rank_position, archived_at) VALUES ?`,
+            [rankingValues]
+          );
+        }
+      }
 
       let playersRewarded = 0;
       let totalGemsGranted = 0;
-      const rankingValues: Array<[string, string, number, string, number, Date]> = [];
+      for (const rankedPlayer of rankedPlayers) {
+        const reward = computeSeasonReward(rankedPlayer.rankPosition, rankedPlayers.length, rewardConfig);
+        if (!reward) {
+          continue;
+        }
 
-      for (const [index, row] of accountRows.entries()) {
-        const playerId = String(row.player_id);
-        const rating = normalizeEloRating(Number(row.elo_rating));
-        const currentGems = normalizeGemAmount((row as { gems?: number | null }).gems);
-        const tier = getTierForRating(rating);
-        const rewardAmount = rewardConfig[tier];
-        const resetEloRating = computeSeasonResetEloRating(rating);
+        const [rewardLogResult] = await connection.query<ResultSetHeader>(
+          `INSERT IGNORE INTO \`${MYSQL_SEASON_REWARD_LOG_TABLE}\` (
+             season_id,
+             player_id,
+             gems,
+             badge,
+             distributed_at
+           )
+           VALUES (?, ?, ?, ?, ?)`,
+          [normalizedId, rankedPlayer.playerId, reward.gems, reward.badge, now]
+        );
+        if (rewardLogResult.affectedRows === 0) {
+          continue;
+        }
 
-        rankingValues.push([normalizedId, playerId, rating, tier, index + 1, now]);
-        playersRewarded += 1;
-        totalGemsGranted += rewardAmount;
+        const [accountRows] = await connection.query<PlayerAccountRow[]>(
+          `SELECT *
+           FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+           WHERE player_id = ?
+           LIMIT 1
+           FOR UPDATE`,
+          [rankedPlayer.playerId]
+        );
+        const currentAccount =
+          accountRows[0] != null
+            ? toPlayerAccountSnapshot(accountRows[0])
+            : normalizePlayerAccountSnapshot({
+                playerId: rankedPlayer.playerId,
+                displayName: rankedPlayer.playerId,
+                globalResources: normalizeResourceLedger()
+              });
+        const seasonBadges = Array.from(new Set([...(currentAccount.seasonBadges ?? []), reward.badge]));
 
         await connection.query(
           `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
            SET gems = ?,
-               elo_rating = ?,
+               season_badges_json = ?,
                version = version + 1
            WHERE player_id = ?`,
-          [currentGems + rewardAmount, resetEloRating, playerId]
+          [normalizeGemAmount(currentAccount.gems) + reward.gems, JSON.stringify(seasonBadges), rankedPlayer.playerId]
         );
 
-        if (rewardAmount > 0) {
-          await appendGemLedgerEntry(connection, {
-            entryId: randomUUID(),
-            playerId,
-            delta: rewardAmount,
-            reason: "reward",
-            refId: `season:${normalizedId}`
-          });
-        }
-      }
-
-      if (rankingValues.length > 0) {
-        await connection.query(
-          `INSERT INTO \`veil_season_rankings\` (season_id, player_id, final_rating, tier, rank_position, archived_at) VALUES ?`,
-          [rankingValues]
-        );
+        playersRewarded += 1;
+        totalGemsGranted += reward.gems;
       }
 
       await connection.query(
-        `UPDATE \`veil_seasons\`
+        `UPDATE \`${MYSQL_SEASON_TABLE}\`
          SET status = 'closed',
-             ended_at = ?
+             ended_at = COALESCE(ended_at, ?),
+             reward_distributed_at = COALESCE(reward_distributed_at, ?)
          WHERE season_id = ?`,
-        [now, normalizedId]
+        [now, now, normalizedId]
       );
 
       await connection.commit();

--- a/apps/server/src/season-rewards.ts
+++ b/apps/server/src/season-rewards.ts
@@ -1,18 +1,16 @@
-import shopConfigDocument from "../../../configs/shop-config.json";
-import { DEFAULT_ELO_RATING, getTierForRating, normalizeEloRating, type PlayerTier, type SeasonRewardConfig } from "../../../packages/shared/src/index";
-
-interface ShopConfigDocument {
-  seasonRewards?: Partial<SeasonRewardConfig> | null;
-}
-
-const PLAYER_TIERS: PlayerTier[] = ["bronze", "silver", "gold", "platinum", "diamond"];
+import seasonRewardsDocument from "../../../configs/season-rewards.json";
+import { type SeasonRewardBracket, type SeasonRewardConfig } from "../../../packages/shared/src/index";
 
 export interface ResolvedSeasonRewardConfig extends SeasonRewardConfig {}
 
+export interface SeasonRewardBracketAssignment extends SeasonRewardBracket {
+  rankPosition: number;
+}
+
 export interface SeasonRewardComputation {
-  tier: PlayerTier;
   gems: number;
-  resetEloRating: number;
+  badge: string;
+  rankPosition: number;
 }
 
 function normalizeNonNegativeInteger(value: number, field: string): number {
@@ -24,35 +22,90 @@ function normalizeNonNegativeInteger(value: number, field: string): number {
   return normalized;
 }
 
-export function normalizeSeasonRewardConfig(rawConfig?: Partial<SeasonRewardConfig> | null): ResolvedSeasonRewardConfig {
-  const config = rawConfig ?? {};
+function normalizePositivePercentile(value: number, field: string): number {
+  if (!Number.isFinite(value) || value <= 0 || value > 100) {
+    throw new Error(`${field} must be within 0-100`);
+  }
+
+  return value;
+}
+
+function normalizeSeasonRewardBracket(
+  bracket: Partial<SeasonRewardBracket> | null | undefined,
+  index: number
+): SeasonRewardBracket {
+  const badge = bracket?.badge?.trim();
+  if (!badge) {
+    throw new Error(`seasonRewards.brackets[${index}].badge is required`);
+  }
 
   return {
-    bronze: normalizeNonNegativeInteger(config.bronze ?? 0, "seasonRewards.bronze"),
-    silver: normalizeNonNegativeInteger(config.silver ?? 0, "seasonRewards.silver"),
-    gold: normalizeNonNegativeInteger(config.gold ?? 0, "seasonRewards.gold"),
-    platinum: normalizeNonNegativeInteger(config.platinum ?? 0, "seasonRewards.platinum"),
-    diamond: normalizeNonNegativeInteger(config.diamond ?? 0, "seasonRewards.diamond")
+    topPercentile: normalizePositivePercentile(
+      bracket?.topPercentile ?? Number.NaN,
+      `seasonRewards.brackets[${index}].topPercentile`
+    ),
+    gems: normalizeNonNegativeInteger(bracket?.gems ?? 0, `seasonRewards.brackets[${index}].gems`),
+    badge
+  };
+}
+
+export function normalizeSeasonRewardConfig(rawConfig?: Partial<SeasonRewardConfig> | null): ResolvedSeasonRewardConfig {
+  const brackets = (rawConfig?.brackets ?? []).map((bracket, index) => normalizeSeasonRewardBracket(bracket, index));
+  if (brackets.length === 0) {
+    throw new Error("seasonRewards.brackets must define at least one reward bracket");
+  }
+
+  const sortedBrackets = [...brackets].sort((left, right) => left.topPercentile - right.topPercentile);
+  for (let index = 1; index < sortedBrackets.length; index += 1) {
+    if (sortedBrackets[index]!.topPercentile === sortedBrackets[index - 1]!.topPercentile) {
+      throw new Error("seasonRewards.brackets topPercentile values must be unique");
+    }
+  }
+
+  return {
+    brackets: sortedBrackets
   };
 }
 
 export function resolveSeasonRewardConfig(): ResolvedSeasonRewardConfig {
-  return normalizeSeasonRewardConfig((shopConfigDocument as ShopConfigDocument).seasonRewards);
+  return normalizeSeasonRewardConfig(seasonRewardsDocument as SeasonRewardConfig);
 }
 
-export function computeSeasonResetEloRating(rating: number): number {
-  const normalizedRating = normalizeEloRating(rating);
-  return DEFAULT_ELO_RATING + Math.floor((normalizedRating - DEFAULT_ELO_RATING) * 0.5);
+export function resolveSeasonRewardBracket(
+  rankPosition: number,
+  rankedPlayerCount: number,
+  rewardConfig = resolveSeasonRewardConfig()
+): SeasonRewardBracketAssignment | null {
+  if (!Number.isInteger(rankPosition) || rankPosition <= 0 || rankedPlayerCount <= 0) {
+    return null;
+  }
+
+  for (const bracket of rewardConfig.brackets) {
+    const maxRank = Math.max(1, Math.ceil((rankedPlayerCount * bracket.topPercentile) / 100));
+    if (rankPosition <= maxRank) {
+      return {
+        ...bracket,
+        rankPosition
+      };
+    }
+  }
+
+  return null;
 }
 
-export function computeSeasonReward(rating: number, rewardConfig = resolveSeasonRewardConfig()): SeasonRewardComputation {
-  const tier = getTierForRating(rating);
+export function computeSeasonReward(
+  rankPosition: number,
+  rankedPlayerCount: number,
+  rewardConfig = resolveSeasonRewardConfig()
+): SeasonRewardComputation | null {
+  const bracket = resolveSeasonRewardBracket(rankPosition, rankedPlayerCount, rewardConfig);
+  if (!bracket) {
+    return null;
+  }
 
   return {
-    tier,
-    gems: rewardConfig[tier],
-    resetEloRating: computeSeasonResetEloRating(rating)
+    gems: bracket.gems,
+    badge: bracket.badge,
+    rankPosition
   };
 }
-
-export { PLAYER_TIERS };

--- a/apps/server/src/shop.ts
+++ b/apps/server/src/shop.ts
@@ -1,9 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import shopConfigDocument from "../../../configs/shop-config.json";
-import { getEquipmentDefinition, type ResourceLedger, type SeasonRewardConfig } from "../../../packages/shared/src/index";
+import { getEquipmentDefinition, type ResourceLedger } from "../../../packages/shared/src/index";
 import { validateAuthSessionFromRequest } from "./auth";
 import type { RoomSnapshotStore } from "./persistence";
-import { normalizeSeasonRewardConfig, type ResolvedSeasonRewardConfig } from "./season-rewards";
 
 export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle";
 
@@ -25,7 +24,6 @@ export interface ShopProduct {
 
 interface ShopConfigDocument {
   products?: Partial<ShopProduct>[] | null;
-  seasonRewards?: Partial<SeasonRewardConfig> | null;
 }
 
 export interface RegisterShopRoutesOptions {
@@ -163,10 +161,6 @@ function normalizeShopProducts(rawProducts?: Partial<ShopProduct>[] | null): Sho
 export function resolveShopProducts(options?: RegisterShopRoutesOptions): ShopProduct[] {
   const configuredProducts = options?.products ?? (shopConfigDocument as ShopConfigDocument).products;
   return normalizeShopProducts(configuredProducts);
-}
-
-export function resolveSeasonRewardsConfig(): ResolvedSeasonRewardConfig {
-  return normalizeSeasonRewardConfig((shopConfigDocument as ShopConfigDocument).seasonRewards);
 }
 
 function sendUnauthorized(

--- a/apps/server/test/memory-room-snapshot-store.test.ts
+++ b/apps/server/test/memory-room-snapshot-store.test.ts
@@ -101,6 +101,21 @@ function createSnapshot(): RoomPersistenceSnapshot {
   };
 }
 
+function seedSeasonRewardAccounts(store: ReturnType<typeof createMemoryRoomSnapshotStore>, count = 100) {
+  return Promise.all(
+    Array.from({ length: count }, async (_, index) => {
+      const playerNumber = index + 1;
+      const playerId = `player-${String(playerNumber).padStart(3, "0")}`;
+      await store.ensurePlayerAccount({ playerId, displayName: playerId });
+      await store.savePlayerAccountProgress(playerId, {
+        gems: playerNumber,
+        eloRating: 2000 - index,
+        ...(playerNumber === 1 ? { seasonBadges: ["founder"] } : {})
+      });
+    })
+  );
+}
+
 test("memory room snapshot store persists room-derived accounts and later battle replay progress", async () => {
   const store = createMemoryRoomSnapshotStore();
   await store.save("room-memory", createSnapshot());
@@ -189,37 +204,35 @@ test("memory room snapshot store lists closed seasons and retains active season 
   assert.ok(allSeasons?.find((season) => season.seasonId === "season-1")?.endedAt);
 });
 
-test("memory room snapshot store grants season rewards, soft-resets elo, and prevents double grant", async () => {
+test("memory room snapshot store matches season reward bracket distribution and prevents double grant", async () => {
   const store = createMemoryRoomSnapshotStore();
-  await store.ensurePlayerAccount({ playerId: "diamond-player", displayName: "Diamond" });
-  await store.ensurePlayerAccount({ playerId: "gold-player", displayName: "Gold" });
-  await store.ensurePlayerAccount({ playerId: "bronze-player", displayName: "Bronze" });
-  await store.savePlayerAccountProgress("diamond-player", { eloRating: 1820 });
-  await store.savePlayerAccountProgress("gold-player", { eloRating: 1380 });
-  await store.savePlayerAccountProgress("bronze-player", { eloRating: 1040 });
+  await seedSeasonRewardAccounts(store);
   await store.createSeason("season-rewards");
 
   const firstClose = await store.closeSeason("season-rewards");
   const secondClose = await store.closeSeason("season-rewards");
-  const diamond = await store.loadPlayerAccount("diamond-player");
-  const gold = await store.loadPlayerAccount("gold-player");
-  const bronze = await store.loadPlayerAccount("bronze-player");
+  const first = await store.loadPlayerAccount("player-001");
+  const tenth = await store.loadPlayerAccount("player-010");
+  const twentyFifth = await store.loadPlayerAccount("player-025");
+  const twentySixth = await store.loadPlayerAccount("player-026");
 
   assert.deepEqual(firstClose, {
     seasonId: "season-rewards",
-    playersRewarded: 3,
-    totalGemsGranted: 375
+    playersRewarded: 25,
+    totalGemsGranted: 1850
   });
-  assert.equal(diamond?.gems, 250);
-  assert.equal(gold?.gems, 100);
-  assert.equal(bronze?.gems, 25);
-  assert.equal(diamond?.eloRating, 1410);
-  assert.equal(gold?.eloRating, 1190);
-  assert.equal(bronze?.eloRating, 1020);
+  assert.equal(first?.gems, 201);
+  assert.deepEqual(first?.seasonBadges, ["founder", "diamond_champion"]);
+  assert.equal(tenth?.gems, 110);
+  assert.deepEqual(tenth?.seasonBadges, ["platinum_rival"]);
+  assert.equal(twentyFifth?.gems, 75);
+  assert.deepEqual(twentyFifth?.seasonBadges, ["gold_contender"]);
+  assert.equal(twentySixth?.gems, 26);
+  assert.deepEqual(twentySixth?.seasonBadges, []);
   assert.deepEqual(secondClose, {
     seasonId: "season-rewards",
     playersRewarded: 0,
     totalGemsGranted: 0
   });
-  assert.equal((await store.loadPlayerAccount("diamond-player"))?.gems, 250);
+  assert.equal((await store.loadPlayerAccount("player-001"))?.gems, 201);
 });

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -39,6 +39,23 @@ function createStoreHarness() {
   };
 }
 
+function createSeasonRewardAccounts(count = 100) {
+  return new Map(
+    Array.from({ length: count }, (_, index) => {
+      const playerNumber = index + 1;
+      const playerId = `player-${String(playerNumber).padStart(3, "0")}`;
+      return [
+        playerId,
+        {
+          eloRating: 2000 - index,
+          gems: playerNumber,
+          seasonBadges: playerNumber === 1 ? ["founder"] : []
+        }
+      ];
+    })
+  );
+}
+
 test("bindPlayerAccountCredentials translates MySQL duplicate-key failures into a taken error", async () => {
   const existingAccount = createExistingAccount();
   const store = createStoreHarness();
@@ -294,29 +311,39 @@ test("listSeasons supports status=all without a status filter", async () => {
   assert.deepEqual(queries[0].params, [5]);
 });
 
-test("closeSeason grants tier rewards, soft-resets elo, and is idempotent", async () => {
-  const seasonState = { seasonId: "season-live", status: "active" as "active" | "closed" };
-  const accounts = new Map([
-    ["diamond-player", { eloRating: 1820, gems: 10 }],
-    ["gold-player", { eloRating: 1380, gems: 5 }],
-    ["bronze-player", { eloRating: 1040, gems: 0 }]
-  ]);
+test("closeSeason distributes bracket rewards once and records badges in the reward log", async () => {
+  const seasonState = {
+    seasonId: "season-live",
+    status: "active" as "active" | "closed",
+    rewardDistributedAt: null as Date | null
+  };
+  const accounts = createSeasonRewardAccounts();
   const rankingRows: Array<{ seasonId: string; playerId: string; finalRating: number; tier: string; rankPosition: number }> = [];
-  const gemLedgerEntries: Array<{ playerId: string; delta: number; refId: string }> = [];
+  const rewardLog = new Map<string, { gems: number; badge: string }>();
 
   const connection = {
     async beginTransaction() {},
     async query(sql: string, params: unknown[] = []) {
       if (/FROM `veil_seasons`/.test(sql) && /FOR UPDATE/.test(sql)) {
-        return [[{ season_id: seasonState.seasonId, status: seasonState.status }]];
+        return [[{
+          season_id: seasonState.seasonId,
+          status: seasonState.status,
+          reward_distributed_at: seasonState.rewardDistributedAt
+        }]];
+      }
+      if (/FROM `veil_season_rankings`/.test(sql) && /ORDER BY final_rating DESC/.test(sql)) {
+        return [rankingRows.map((row) => ({
+          player_id: row.playerId,
+          final_rating: row.finalRating,
+          rank_position: row.rankPosition
+        }))];
       }
       if (/FROM `player_accounts`/.test(sql) && /ORDER BY elo_rating DESC/.test(sql)) {
         const rows = [...accounts.entries()]
           .sort((left, right) => right[1].eloRating - left[1].eloRating || left[0].localeCompare(right[0]))
           .map(([playerId, account]) => ({
             player_id: playerId,
-            elo_rating: account.eloRating,
-            gems: account.gems
+            elo_rating: account.eloRating
           }));
         return [rows];
       }
@@ -327,18 +354,73 @@ test("closeSeason grants tier rewards, soft-resets elo, and is idempotent", asyn
         }
         return [{ affectedRows: values.length }];
       }
-      if (/UPDATE `player_accounts`/.test(sql) && /SET gems = \?,\s+elo_rating = \?/.test(sql)) {
-        const [gems, eloRating, playerId] = params as [number, number, string];
-        accounts.set(playerId, { gems, eloRating });
+      if (/INSERT IGNORE INTO `season_reward_log`/.test(sql)) {
+        const [seasonId, playerId, gems, badge] = params as [string, string, number, string];
+        const rewardKey = `${seasonId}:${playerId}`;
+        if (rewardLog.has(rewardKey)) {
+          return [{ affectedRows: 0 }];
+        }
+        rewardLog.set(rewardKey, { gems, badge });
         return [{ affectedRows: 1 }];
       }
-      if (/INSERT INTO `gem_ledger`/.test(sql)) {
-        const [, playerId, delta, , refId] = params as [string, string, number, string, string];
-        gemLedgerEntries.push({ playerId, delta, refId });
+      if (/SELECT \*/.test(sql) && /FROM `player_accounts`/.test(sql) && /FOR UPDATE/.test(sql)) {
+        const [playerId] = params as [string];
+        const account = accounts.get(playerId);
+        return [[account
+          ? {
+              player_id: playerId,
+              display_name: playerId,
+              avatar_url: null,
+              elo_rating: account.eloRating,
+              gems: account.gems,
+              season_badges_json: JSON.stringify(account.seasonBadges),
+              global_resources_json: JSON.stringify({ gold: 0, wood: 0, ore: 0 }),
+              achievements_json: JSON.stringify([]),
+              recent_event_log_json: JSON.stringify([]),
+              recent_battle_replays_json: JSON.stringify([]),
+              last_room_id: null,
+              last_seen_at: null,
+              login_id: null,
+              age_verified: 0,
+              is_minor: 0,
+              daily_play_minutes: 0,
+              last_play_date: null,
+              login_streak: 0,
+              ban_status: "none",
+              ban_expiry: null,
+              ban_reason: null,
+              account_session_version: 0,
+              refresh_session_id: null,
+              refresh_token_hash: null,
+              refresh_token_expires_at: null,
+              wechat_open_id: null,
+              wechat_union_id: null,
+              wechat_mini_game_open_id: null,
+              wechat_mini_game_union_id: null,
+              wechat_mini_game_bound_at: null,
+              credential_bound_at: null,
+              privacy_consent_at: null,
+              phone_number: null,
+              phone_number_bound_at: null,
+              created_at: "2026-03-20T00:00:00.000Z",
+              updated_at: "2026-03-20T00:00:00.000Z"
+            }
+          : undefined]];
+      }
+      if (/UPDATE `player_accounts`/.test(sql) && /season_badges_json = \?/.test(sql)) {
+        const [gems, seasonBadgesJson, playerId] = params as [number, string, string];
+        const account = accounts.get(playerId);
+        assert.ok(account);
+        accounts.set(playerId, {
+          ...account,
+          gems,
+          seasonBadges: JSON.parse(seasonBadgesJson)
+        });
         return [{ affectedRows: 1 }];
       }
-      if (/UPDATE `veil_seasons`/.test(sql) && /status = 'closed'/.test(sql)) {
+      if (/UPDATE `veil_seasons`/.test(sql) && /reward_distributed_at/.test(sql)) {
         seasonState.status = "closed";
+        seasonState.rewardDistributedAt = params[1] as Date;
         return [{ affectedRows: 1 }];
       }
 
@@ -361,30 +443,36 @@ test("closeSeason grants tier rewards, soft-resets elo, and is idempotent", asyn
 
   assert.deepEqual(firstClose, {
     seasonId: "season-live",
-    playersRewarded: 3,
-    totalGemsGranted: 375
+    playersRewarded: 25,
+    totalGemsGranted: 1850
   });
   assert.deepEqual(secondClose, {
     seasonId: "season-live",
     playersRewarded: 0,
     totalGemsGranted: 0
   });
-  assert.deepEqual(accounts.get("diamond-player"), { eloRating: 1410, gems: 260 });
-  assert.deepEqual(accounts.get("gold-player"), { eloRating: 1190, gems: 105 });
-  assert.deepEqual(accounts.get("bronze-player"), { eloRating: 1020, gems: 25 });
-  assert.deepEqual(
-    rankingRows.map((row) => ({ playerId: row.playerId, tier: row.tier, rankPosition: row.rankPosition, finalRating: row.finalRating })),
-    [
-      { playerId: "diamond-player", tier: "diamond", rankPosition: 1, finalRating: 1820 },
-      { playerId: "gold-player", tier: "gold", rankPosition: 2, finalRating: 1380 },
-      { playerId: "bronze-player", tier: "bronze", rankPosition: 3, finalRating: 1040 }
-    ]
-  );
-  assert.deepEqual(gemLedgerEntries, [
-    { playerId: "diamond-player", delta: 250, refId: "season:season-live" },
-    { playerId: "gold-player", delta: 100, refId: "season:season-live" },
-    { playerId: "bronze-player", delta: 25, refId: "season:season-live" }
-  ]);
+  assert.equal(accounts.get("player-001")?.gems, 201);
+  assert.deepEqual(accounts.get("player-001")?.seasonBadges, ["founder", "diamond_champion"]);
+  assert.equal(accounts.get("player-010")?.gems, 110);
+  assert.deepEqual(accounts.get("player-010")?.seasonBadges, ["platinum_rival"]);
+  assert.equal(accounts.get("player-025")?.gems, 75);
+  assert.deepEqual(accounts.get("player-025")?.seasonBadges, ["gold_contender"]);
+  assert.equal(accounts.get("player-026")?.gems, 26);
+  assert.deepEqual(accounts.get("player-026")?.seasonBadges, []);
+  assert.equal(rankingRows.length, 100);
+  assert.equal(rewardLog.size, 25);
+  assert.deepEqual(rewardLog.get("season-live:player-001"), {
+    gems: 200,
+    badge: "diamond_champion"
+  });
+  assert.deepEqual(rewardLog.get("season-live:player-010"), {
+    gems: 100,
+    badge: "platinum_rival"
+  });
+  assert.deepEqual(rewardLog.get("season-live:player-025"), {
+    gems: 50,
+    badge: "gold_contender"
+  });
 });
 
 test("mysql player event history query applies inclusive timestamp filters", async () => {

--- a/configs/season-rewards.json
+++ b/configs/season-rewards.json
@@ -1,0 +1,7 @@
+{
+  "brackets": [
+    { "topPercentile": 1, "gems": 200, "badge": "diamond_champion" },
+    { "topPercentile": 10, "gems": 100, "badge": "platinum_rival" },
+    { "topPercentile": 25, "gems": 50, "badge": "gold_contender" }
+  ]
+}

--- a/configs/shop-config.json
+++ b/configs/shop-config.json
@@ -1,11 +1,4 @@
 {
-  "seasonRewards": {
-    "bronze": 25,
-    "silver": 50,
-    "gold": 100,
-    "platinum": 150,
-    "diamond": 250
-  },
   "products": [
     {
       "productId": "resource-bundle-starter",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -126,12 +126,14 @@ export interface BattleBalanceConfig {
   };
 }
 
+export interface SeasonRewardBracket {
+  topPercentile: number;
+  gems: number;
+  badge: string;
+}
+
 export interface SeasonRewardConfig {
-  bronze: number;
-  silver: number;
-  gold: number;
-  platinum: number;
-  diamond: number;
+  brackets: SeasonRewardBracket[];
 }
 
 export interface MovePoints {

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -22,6 +22,7 @@ export interface PlayerAccountReadModel {
   eloRating?: number;
   gems?: number;
   loginStreak?: number;
+  seasonBadges?: string[];
   globalResources: ResourceLedger;
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
@@ -50,6 +51,7 @@ export interface PlayerAccountReadModelInput {
   eloRating?: number | undefined;
   gems?: number | undefined;
   loginStreak?: number | undefined;
+  seasonBadges?: string[] | null | undefined;
   globalResources?: Partial<ResourceLedger> | null | undefined;
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
@@ -86,6 +88,13 @@ export function normalizePlayerAccountReadModel(
   const isMinor = account?.isMinor === true;
   const dailyPlayMinutes = Math.max(0, Math.floor(account?.dailyPlayMinutes ?? 0));
   const loginStreak = Math.max(0, Math.floor(account?.loginStreak ?? 0));
+  const seasonBadges = Array.from(
+    new Set(
+      (account?.seasonBadges ?? [])
+        .map((badge) => badge?.trim())
+        .filter((badge): badge is string => Boolean(badge))
+    )
+  );
   const lastPlayDate = /^\d{4}-\d{2}-\d{2}$/.test(account?.lastPlayDate?.trim() ?? "")
     ? account?.lastPlayDate?.trim()
     : undefined;
@@ -104,6 +113,7 @@ export function normalizePlayerAccountReadModel(
     eloRating: normalizeEloRating(account?.eloRating),
     gems: Math.max(0, Math.floor(account?.gems ?? 0)),
     ...(loginStreak > 0 ? { loginStreak } : {}),
+    ...(seasonBadges.length > 0 ? { seasonBadges } : {}),
     globalResources: {
       gold: Math.max(0, Math.floor(account?.globalResources?.gold ?? 0)),
       wood: Math.max(0, Math.floor(account?.globalResources?.wood ?? 0)),

--- a/scripts/migrations/0014_add_season_close_rewards.ts
+++ b/scripts/migrations/0014_add_season_close_rewards.ts
@@ -1,0 +1,53 @@
+import {
+  dropColumnIfExists,
+  dropTableIfExists,
+  ensureColumnExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_PLAYER_ACCOUNT_TABLE,
+  MYSQL_SEASON_REWARD_LOG_TABLE,
+  MYSQL_SEASON_TABLE
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureColumnExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_TABLE,
+    "season_badges_json",
+    "`season_badges_json` LONGTEXT NULL AFTER `gems`"
+  );
+
+  await ensureColumnExists(
+    connection,
+    database,
+    MYSQL_SEASON_TABLE,
+    "reward_distributed_at",
+    "`reward_distributed_at` DATETIME NULL DEFAULT NULL AFTER `ended_at`"
+  );
+
+  await ensureTableExists(
+    connection,
+    MYSQL_SEASON_REWARD_LOG_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_SEASON_REWARD_LOG_TABLE}\` (
+      season_id VARCHAR(64) NOT NULL,
+      player_id VARCHAR(64) NOT NULL,
+      gems INT NOT NULL,
+      badge VARCHAR(64) NOT NULL,
+      distributed_at DATETIME NOT NULL,
+      PRIMARY KEY (season_id, player_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await dropTableIfExists(connection, MYSQL_SEASON_REWARD_LOG_TABLE);
+  await dropColumnIfExists(connection, database, MYSQL_SEASON_TABLE, "reward_distributed_at");
+  await dropColumnIfExists(connection, database, MYSQL_PLAYER_ACCOUNT_TABLE, "season_badges_json");
+}


### PR DESCRIPTION
Closes #832.

- distribute season-close rewards by percentile bracket
- persist season badges and reward logs for idempotency
- add MySQL and memory-store coverage