### PR TITLE
feat: config center publish history and rollback snapshots

### DIFF
--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -99,6 +99,8 @@ interface ConfigPublishHistoryEntry {
   documentId: ConfigDocumentId;
   author: string;
   summary: string;
+  candidate: string | null;
+  revision: string | null;
   publishedAt: string;
   fromVersion: number;
   toVersion: number;
@@ -127,6 +129,8 @@ interface ConfigPublishAuditEvent {
   id: string;
   author: string;
   summary: string;
+  candidate: string | null;
+  revision: string | null;
   publishedAt: string;
   resultStatus: ConfigPublishResultStatus;
   resultMessage: string;
@@ -272,6 +276,8 @@ interface AppState {
   publishAuditHistory: ConfigPublishAuditEvent[];
   publishAuditFilterId: ConfigDocumentId | "all";
   publishAuditFilterStatus: ConfigPublishResultStatus | "all";
+  publishAuditFilterCandidate: string;
+  publishAuditFilterRevision: string;
   publishStage: ConfigStageState | null;
   publishStageLoading: boolean;
 }
@@ -400,6 +406,8 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     publishAuditHistory: [],
     publishAuditFilterId: "all",
     publishAuditFilterStatus: "all",
+    publishAuditFilterCandidate: "",
+    publishAuditFilterRevision: "",
     publishStage: null,
     publishStageLoading: false
   };
@@ -641,12 +649,20 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
   function setPublishAuditFilters(filters: {
     documentId?: ConfigDocumentId | "all";
     resultStatus?: ConfigPublishResultStatus | "all";
+    candidate?: string;
+    revision?: string;
   }): void {
     if (filters.documentId) {
       state.publishAuditFilterId = filters.documentId;
     }
     if (filters.resultStatus) {
       state.publishAuditFilterStatus = filters.resultStatus;
+    }
+    if (typeof filters.candidate === "string") {
+      state.publishAuditFilterCandidate = filters.candidate;
+    }
+    if (typeof filters.revision === "string") {
+      state.publishAuditFilterRevision = filters.revision;
     }
     notify();
   }
@@ -794,6 +810,9 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       return;
     }
 
+    const candidate = promptImpl("候选标识（可选，用于历史检索）", "")?.trim() ?? "";
+    const revision = promptImpl("Revision（可选，用于历史检索）", "")?.trim() ?? "";
+
     const publishedDocumentIds = stage.documents.map((document) => document.id);
     state.publishStageLoading = true;
     state.statusTone = "neutral";
@@ -818,7 +837,9 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
         },
         body: JSON.stringify({
           author,
-          summary
+          summary,
+          candidate,
+          revision
         })
       });
       state.storageMode = response.storage;

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -160,6 +160,8 @@ interface ConfigPublishHistoryEntry {
   documentId: ConfigDocumentId;
   author: string;
   summary: string;
+  candidate: string | null;
+  revision: string | null;
   publishedAt: string;
   fromVersion: number;
   toVersion: number;
@@ -188,6 +190,8 @@ interface ConfigPublishAuditEvent {
   id: string;
   author: string;
   summary: string;
+  candidate: string | null;
+  revision: string | null;
   publishedAt: string;
   resultStatus: ConfigPublishResultStatus;
   resultMessage: string;
@@ -330,6 +334,8 @@ interface AppState {
   publishAuditHistory: ConfigPublishAuditEvent[];
   publishAuditFilterId: ConfigDocumentId | "all";
   publishAuditFilterStatus: ConfigPublishResultStatus | "all";
+  publishAuditFilterCandidate: string;
+  publishAuditFilterRevision: string;
   publishStage: ConfigStageState | null;
   publishStageLoading: boolean;
 }
@@ -402,6 +408,8 @@ interface ConfigCenterPublishHistorySectionInput {
   publishAuditHistory: ConfigPublishAuditEvent[];
   publishAuditFilterId: ConfigDocumentId | "all";
   publishAuditFilterStatus: ConfigPublishResultStatus | "all";
+  publishAuditFilterCandidate: string;
+  publishAuditFilterRevision: string;
   historyLoading: boolean;
 }
 
@@ -600,15 +608,23 @@ export function renderConfigCenterPublishHistoryList({
   publishAuditHistory,
   publishAuditFilterId,
   publishAuditFilterStatus,
+  publishAuditFilterCandidate,
+  publishAuditFilterRevision,
   historyLoading
 }: ConfigCenterPublishHistorySectionInput): string {
+  const candidateQuery = publishAuditFilterCandidate.trim().toLowerCase();
+  const revisionQuery = publishAuditFilterRevision.trim().toLowerCase();
   const entries = publishAuditHistory.filter((entry) => {
     const matchesDocument =
       publishAuditFilterId === "all" ||
       entry.changes.some((change) => change.documentId === publishAuditFilterId);
     const matchesResult =
       publishAuditFilterStatus === "all" || entry.resultStatus === publishAuditFilterStatus;
-    return matchesDocument && matchesResult;
+    const matchesCandidate =
+      candidateQuery.length === 0 || (entry.candidate ?? "").toLowerCase().includes(candidateQuery);
+    const matchesRevision =
+      revisionQuery.length === 0 || (entry.revision ?? "").toLowerCase().includes(revisionQuery);
+    return matchesDocument && matchesResult && matchesCandidate && matchesRevision;
   });
   if (historyLoading && entries.length === 0 && publishAuditHistory.length === 0) {
     return `<div class="world-preview-empty">正在加载发布记录...</div>`;
@@ -640,6 +656,14 @@ export function renderConfigCenterPublishHistoryList({
               <option value="applied" ${publishAuditFilterStatus === "applied" ? "selected" : ""}>已应用</option>
               <option value="failed" ${publishAuditFilterStatus === "failed" ? "selected" : ""}>失败</option>
             </select>
+          </label>
+          <label>
+            <span>Candidate</span>
+            <input data-role="publish-filter-candidate" value="${escapeHtml(publishAuditFilterCandidate)}" placeholder="phase1-rc" />
+          </label>
+          <label>
+            <span>Revision</span>
+            <input data-role="publish-filter-revision" value="${escapeHtml(publishAuditFilterRevision)}" placeholder="abc1234" />
           </label>
         </div>
         <div class="world-preview-empty">暂无匹配的发布记录，先使用“发布草稿”功能再回来查看。</div>
@@ -673,6 +697,14 @@ export function renderConfigCenterPublishHistoryList({
             <option value="failed" ${publishAuditFilterStatus === "failed" ? "selected" : ""}>失败</option>
           </select>
         </label>
+        <label>
+          <span>Candidate</span>
+          <input data-role="publish-filter-candidate" value="${escapeHtml(publishAuditFilterCandidate)}" placeholder="phase1-rc" />
+        </label>
+        <label>
+          <span>Revision</span>
+          <input data-role="publish-filter-revision" value="${escapeHtml(publishAuditFilterRevision)}" placeholder="abc1234" />
+        </label>
       </div>
       <div class="publish-history-list">
         ${entries
@@ -688,6 +720,16 @@ export function renderConfigCenterPublishHistoryList({
                   <span class="publish-result-pill is-${entry.resultStatus}">${entry.resultStatus === "applied" ? "已应用" : "失败"}</span>
                 </div>
                 <small>${escapeHtml(entry.resultMessage)}</small>
+                ${
+                  entry.candidate || entry.revision
+                    ? `
+                        <div class="config-badge-row">
+                          ${entry.candidate ? `<span class="config-badge">Candidate · ${escapeHtml(entry.candidate)}</span>` : ""}
+                          ${entry.revision ? `<span class="config-badge">Revision · ${escapeHtml(entry.revision)}</span>` : ""}
+                        </div>
+                      `
+                    : ""
+                }
                 <div class="config-badge-row">
                   ${entry.changes.map((change) => `<span class="config-badge">${escapeHtml(change.title)} · v${change.fromVersion}→v${change.toVersion}</span>`).join("")}
                 </div>
@@ -1701,6 +1743,8 @@ function renderPublishHistoryList(): string {
     publishAuditHistory: state.publishAuditHistory,
     publishAuditFilterId: state.publishAuditFilterId,
     publishAuditFilterStatus: state.publishAuditFilterStatus,
+    publishAuditFilterCandidate: state.publishAuditFilterCandidate,
+    publishAuditFilterRevision: state.publishAuditFilterRevision,
     historyLoading: state.historyLoading
   });
 }
@@ -2090,6 +2134,20 @@ function bindPublishStageControls(): void {
   statusFilter?.addEventListener("change", () => {
     setPublishAuditFilters({
       resultStatus: (statusFilter.value || "all") as ConfigPublishResultStatus | "all"
+    });
+  });
+
+  const candidateFilter = document.querySelector<HTMLInputElement>("[data-role='publish-filter-candidate']");
+  candidateFilter?.addEventListener("input", () => {
+    setPublishAuditFilters({
+      candidate: candidateFilter.value
+    });
+  });
+
+  const revisionFilter = document.querySelector<HTMLInputElement>("[data-role='publish-filter-revision']");
+  revisionFilter?.addEventListener("input", () => {
+    setPublishAuditFilters({
+      revision: revisionFilter.value
     });
   });
 

--- a/apps/client/test/config-center-render.test.ts
+++ b/apps/client/test/config-center-render.test.ts
@@ -102,6 +102,8 @@ test("config center render shows publish history changes with impact summary and
         id: "publish-1",
         author: "ConfigOps",
         summary: "扩图并补资源",
+        candidate: "phase1-rc",
+        revision: "abc1234",
         publishedAt: "2026-03-30T05:00:00.000Z",
         resultStatus: "applied",
         resultMessage: "运行时配置已刷新",
@@ -145,10 +147,14 @@ test("config center render shows publish history changes with impact summary and
     ],
     publishAuditFilterId: "world",
     publishAuditFilterStatus: "applied",
+    publishAuditFilterCandidate: "phase1",
+    publishAuditFilterRevision: "abc",
     historyLoading: false
   });
 
   assert.match(html, /发布审计历史/);
+  assert.match(html, /phase1-rc/);
+  assert.match(html, /abc1234/);
   assert.match(html, /地图扩图会影响世界预览与出生点分布/);
   assert.match(html, /width/);
   assert.match(html, /快速回滚/);

--- a/apps/client/test/config-center.test.ts
+++ b/apps/client/test/config-center.test.ts
@@ -644,6 +644,8 @@ test("config center publish audit history supports filters and snapshot inspecti
               id: "publish-1",
               author: "ConfigOps",
               summary: "扩图并补资源",
+              candidate: "phase1-rc",
+              revision: "abc1234",
               publishedAt: "2026-03-30T05:00:00.000Z",
               resultStatus: "applied",
               resultMessage: "运行时配置已刷新",
@@ -777,6 +779,9 @@ test("config center publish audit history supports filters and snapshot inspecti
   controller.setPublishAuditFilters({ documentId: "world", resultStatus: "applied" });
   assert.equal(controller.state.publishAuditFilterId, "world");
   assert.equal(controller.state.publishAuditFilterStatus, "applied");
+  controller.setPublishAuditFilters({ candidate: "phase1", revision: "abc" });
+  assert.equal(controller.state.publishAuditFilterCandidate, "phase1");
+  assert.equal(controller.state.publishAuditFilterRevision, "abc");
 
   await controller.inspectPublishedSnapshot("world", "snapshot-world-3");
 
@@ -788,6 +793,121 @@ test("config center publish audit history supports filters and snapshot inspecti
     requests.some((request) => request.url === "/api/config-center/configs/world/diff" && request.method === "POST"),
     true
   );
+});
+
+test("config center publish stage sends optional candidate and revision metadata", async () => {
+  const prompts = ["ConfigOps", "扩图并补资源", "phase1-rc", "abc1234"];
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/publish-stage/publish" && request.method === "POST") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          stage: null,
+          publish: {
+            id: "publish-1",
+            author: "ConfigOps",
+            summary: "扩图并补资源",
+            publishedAt: "2026-03-30T05:00:00.000Z",
+            changes: [{ documentId: "world" }]
+          }
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/publish-history") {
+      return new Response(JSON.stringify({ storage: "filesystem", history: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs") {
+      return new Response(JSON.stringify({ storage: "filesystem", items: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          document: createDocument("world", "{\n  \"width\": 10,\n  \"height\": 8\n}\n", { version: 3 })
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots") {
+      return new Response(JSON.stringify({ storage: "filesystem", snapshots: [], publishHistory: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/presets") {
+      return new Response(JSON.stringify({ storage: "filesystem", presets: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({
+    fetch,
+    prompt: () => prompts.shift() ?? null
+  });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8,\n  \"height\": 8\n}\n", { version: 2 });
+  controller.state.publishStage = {
+    id: "stage-1",
+    createdAt: "2026-03-30T05:00:00.000Z",
+    updatedAt: "2026-03-30T05:00:00.000Z",
+    valid: true,
+    documents: [
+      {
+        id: "world",
+        title: "世界配置",
+        fileName: "phase1-world.json",
+        content: "{\n  \"width\": 10,\n  \"height\": 8\n}\n",
+        updatedAt: "2026-03-30T05:00:00.000Z",
+        validation: createValidationReport(true)
+      }
+    ]
+  };
+
+  await controller.publishStageDrafts();
+
+  const publishRequest = requests.find(
+    (request) => request.url === "/api/config-center/publish-stage/publish" && request.method === "POST"
+  );
+  assert.notEqual(publishRequest, undefined);
+  assert.deepEqual(JSON.parse(publishRequest?.body ?? "{}"), {
+    author: "ConfigOps",
+    summary: "扩图并补资源",
+    candidate: "phase1-rc",
+    revision: "abc1234"
+  });
 });
 
 test("config center builtin presets apply the expected field changes", async () => {

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -173,6 +173,8 @@ export interface ConfigPublishHistoryEntry {
   documentId: ConfigDocumentId;
   author: string;
   summary: string;
+  candidate: string | null;
+  revision: string | null;
   publishedAt: string;
   fromVersion: number;
   toVersion: number;
@@ -201,6 +203,8 @@ export interface ConfigPublishAuditEvent {
   id: string;
   author: string;
   summary: string;
+  candidate: string | null;
+  revision: string | null;
   publishedAt: string;
   resultStatus: ConfigPublishResultStatus;
   resultMessage: string;
@@ -350,7 +354,12 @@ export interface ConfigCenterStore {
   importDocumentFromWorkbook(id: ConfigDocumentId, workbook: Buffer): Promise<ConfigDocument>;
   getStagedDraft(): Promise<ConfigStageState | null>;
   saveStagedDraft(documents: ConfigStageDocumentInput[]): Promise<ConfigStageState | null>;
-  publishStagedDraft(metadata: { author: string; summary: string }): Promise<{
+  publishStagedDraft(metadata: {
+    author: string;
+    summary: string;
+    candidate?: string | null;
+    revision?: string | null;
+  }): Promise<{
     stage: ConfigStageState | null;
     publish: ConfigPublishEventSummary;
   }>;
@@ -2940,12 +2949,22 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
 
   async listPublishHistory(id: ConfigDocumentId): Promise<ConfigPublishHistoryEntry[]> {
     const state = await this.readLibraryState();
-    return [...(state.publishHistory[id] ?? [])];
+    return [...(state.publishHistory[id] ?? [])].map((entry) => ({
+      ...entry,
+      candidate: entry.candidate ?? null,
+      revision: entry.revision ?? null
+    }));
   }
 
   async listPublishAuditHistory(): Promise<ConfigPublishAuditEvent[]> {
     const state = await this.readLibraryState();
-    return [...(state.publishAuditHistory ?? [])].sort((left, right) => right.publishedAt.localeCompare(left.publishedAt));
+    return [...(state.publishAuditHistory ?? [])]
+      .map((entry) => ({
+        ...entry,
+        candidate: entry.candidate ?? null,
+        revision: entry.revision ?? null
+      }))
+      .sort((left, right) => right.publishedAt.localeCompare(left.publishedAt));
   }
 
   async getStagedDraft(): Promise<ConfigStageState | null> {
@@ -2967,7 +2986,12 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     return this.mapStageRecordToState(stageRecord);
   }
 
-  async publishStagedDraft(metadata: { author: string; summary: string }): Promise<{
+  async publishStagedDraft(metadata: {
+    author: string;
+    summary: string;
+    candidate?: string | null;
+    revision?: string | null;
+  }): Promise<{
     stage: ConfigStageState | null;
     publish: ConfigPublishEventSummary;
   }> {
@@ -2983,6 +3007,8 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
 
     const publishId = createId("publish");
     const publishedAt = new Date().toISOString();
+    const candidate = metadata.candidate?.trim() ? metadata.candidate.trim() : null;
+    const revision = metadata.revision?.trim() ? metadata.revision.trim() : null;
     const publishChanges: ConfigPublishChangeSummary[] = [];
     const historyEntries: ConfigPublishHistoryEntry[] = [];
     const auditChanges: ConfigPublishAuditChange[] = [];
@@ -2994,6 +3020,22 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
       const structuralCount = diffEntries.filter((entry) => entry.kind !== "value").length;
       const definition = configDefinitionFor(stagedDocument.id);
       const fromVersion = current.version ?? 1;
+      const existingRollbackSnapshot = (state.snapshots[stagedDocument.id] ?? []).find(
+        (snapshot) => snapshot.version === fromVersion
+      );
+      const rollbackSnapshot =
+        existingRollbackSnapshot ??
+        (() => {
+          const snapshot: ConfigSnapshotRecord = {
+            id: createId("snapshot"),
+            label: `${definition?.title ?? stagedDocument.id} v${fromVersion}（发布前回滚点）`,
+            createdAt: publishedAt,
+            version: fromVersion,
+            content: current.content
+          };
+          state.snapshots[stagedDocument.id] = [snapshot, ...(state.snapshots[stagedDocument.id] ?? [])].slice(0, 30);
+          return snapshot;
+        })();
       auditChanges.push({
         documentId: stagedDocument.id,
         title: definition?.title ?? stagedDocument.id,
@@ -3001,7 +3043,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         toVersion: fromVersion,
         changeCount: diffEntries.length,
         structuralChangeCount: structuralCount,
-        snapshotId: null,
+        snapshotId: rollbackSnapshot.id,
         runtimeStatus: "pending",
         runtimeMessage: "等待运行时应用",
         diffSummary: diffEntries.slice(0, 4),
@@ -3022,10 +3064,8 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
 
         const saved = await this.saveDocument(auditChange.documentId, nextContent);
         const toVersion = saved.version ?? auditChange.fromVersion;
-        const snapshot = await this.findSnapshotByVersion(auditChange.documentId, toVersion);
 
         auditChange.toVersion = toVersion;
-        auditChange.snapshotId = snapshot?.id ?? null;
         auditChange.runtimeStatus = "applied";
         auditChange.runtimeMessage = "运行时已刷新";
         publishChanges.push({
@@ -3041,6 +3081,8 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
           documentId: auditChange.documentId,
           author: metadata.author,
           summary: metadata.summary,
+          candidate,
+          revision,
           publishedAt,
           fromVersion: auditChange.fromVersion,
           toVersion,
@@ -3059,6 +3101,8 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         id: publishId,
         author: metadata.author,
         summary: metadata.summary,
+        candidate,
+        revision,
         publishedAt,
         resultStatus: "applied",
         resultMessage: "运行时配置已刷新",
@@ -3092,6 +3136,8 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         id: publishId,
         author: metadata.author,
         summary: metadata.summary,
+        candidate,
+        revision,
         publishedAt,
         resultStatus: "failed",
         resultMessage: failedMessage,
@@ -3682,7 +3728,12 @@ export function registerConfigCenterRoutes(
 
   app.post("/api/config-center/publish-stage/publish", async (request, response) => {
     try {
-      const body = (await readJsonBody(request)) as { author?: string; summary?: string };
+      const body = (await readJsonBody(request)) as {
+        author?: string;
+        summary?: string;
+        candidate?: string | null;
+        revision?: string | null;
+      };
       if (typeof body.author !== "string" || !body.author.trim() || typeof body.summary !== "string" || !body.summary.trim()) {
         sendJson(response, 400, {
           error: {
@@ -3695,7 +3746,9 @@ export function registerConfigCenterRoutes(
 
       const result = await store.publishStagedDraft({
         author: body.author.trim(),
-        summary: body.summary.trim()
+        summary: body.summary.trim(),
+        candidate: typeof body.candidate === "string" ? body.candidate : null,
+        revision: typeof body.revision === "string" ? body.revision : null
       });
       sendJson(response, 200, {
         storage: store.mode,

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -211,7 +211,9 @@ const BATTLE_BALANCE_CONFIG = {
   },
   pvp: {
     eloK: 32
-  }
+  },
+  turnTimerSeconds: 30,
+  afkStrikesBeforeForfeit: 2
 };
 
 async function seedConfigRoot(rootDir: string): Promise<void> {
@@ -731,7 +733,12 @@ test("config center staged publish applies bundled drafts and records publish hi
   assert.equal(staged?.documents.length, 2);
   assert.equal(staged?.valid, true);
 
-  const published = await store.publishStagedDraft({ author: "ConfigOps", summary: "调大地图并补齐资源" });
+  const published = await store.publishStagedDraft({
+    author: "ConfigOps",
+    summary: "调大地图并补齐资源",
+    candidate: "phase1-rc",
+    revision: "abc1234"
+  });
   assert.equal(published.stage, null);
   assert.equal(published.publish.changes.length, 2);
   assert.equal(published.publish.author, "ConfigOps");
@@ -742,6 +749,8 @@ test("config center staged publish applies bundled drafts and records publish hi
   const worldHistory = await store.listPublishHistory("world");
   assert.equal(worldHistory[0]?.author, "ConfigOps");
   assert.equal(worldHistory[0]?.summary, "调大地图并补齐资源");
+  assert.equal(worldHistory[0]?.candidate, "phase1-rc");
+  assert.equal(worldHistory[0]?.revision, "abc1234");
   assert.equal((worldHistory[0]?.changeCount ?? 0) > 0, true);
 
   const mapHistory = await store.listPublishHistory("mapObjects");
@@ -750,6 +759,8 @@ test("config center staged publish applies bundled drafts and records publish hi
 
   const auditHistory = await store.listPublishAuditHistory();
   assert.equal(auditHistory[0]?.author, "ConfigOps");
+  assert.equal(auditHistory[0]?.candidate, "phase1-rc");
+  assert.equal(auditHistory[0]?.revision, "abc1234");
   assert.equal(auditHistory[0]?.resultStatus, "applied");
   assert.equal(auditHistory[0]?.changes.length, 2);
   assert.equal(auditHistory[0]?.changes[0]?.runtimeStatus, "applied");
@@ -759,6 +770,11 @@ test("config center staged publish applies bundled drafts and records publish hi
   assert.equal((auditHistory[0]?.changes[0]?.impactSummary?.changedFields.length ?? 0) > 0, true);
   assert.equal((auditHistory[0]?.changes[0]?.impactSummary?.impactedModules.length ?? 0) > 0, true);
   assert.equal((auditHistory[0]?.changes[0]?.impactSummary?.riskHints.length ?? 0) > 0, true);
+
+  const rollbackSnapshotId = auditHistory[0]?.changes.find((change) => change.documentId === "world")?.snapshotId;
+  assert.equal(typeof rollbackSnapshotId, "string");
+  const rolledBack = await store.rollbackToSnapshot("world", rollbackSnapshotId ?? "");
+  assert.equal(JSON.parse(rolledBack.content).width, WORLD_CONFIG.width);
 
   const stageAfter = await store.getStagedDraft();
   assert.equal(stageAfter, null);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "db:profiles:list": "node --import tsx ./scripts/manage-player-room-profiles.ts list",
     "db:profiles:delete": "node --import tsx ./scripts/manage-player-room-profiles.ts delete",
     "db:profiles:prune": "node --import tsx ./scripts/manage-player-room-profiles.ts prune",
+    "config-center:restore": "node --import tsx ./scripts/config-center-restore.ts",
     "ops:codex-branches": "node --import tsx ./scripts/audit-codex-automation-branches.ts",
     "plan:validation:minimal": "node --import tsx ./scripts/minimal-validation-plan.ts",
     "demo:flow": "node --import tsx ./scripts/demo.ts",

--- a/scripts/config-center-restore.ts
+++ b/scripts/config-center-restore.ts
@@ -1,0 +1,147 @@
+import path from "node:path";
+import { FileSystemConfigCenterStore } from "../apps/server/src/config-center";
+
+type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
+
+interface CliArgs {
+  configRoot: string;
+  documentId: ConfigDocumentId | null;
+  snapshotId: string | null;
+  publishId: string | null;
+  help: boolean;
+}
+
+const VALID_DOCUMENT_IDS: ConfigDocumentId[] = ["world", "mapObjects", "units", "battleSkills", "battleBalance"];
+
+function printUsage(): void {
+  console.log(`Usage: npm run config-center:restore -- --document <id> [--snapshot-id <snapshot>] [--publish-id <publish>]
+
+Options:
+  --document <id>       Config document id: ${VALID_DOCUMENT_IDS.join(", ")}
+  --snapshot-id <id>    Roll back directly to a known snapshot id
+  --publish-id <id>     Resolve the rollback snapshot recorded for a publish event
+  --config-root <path>  Override config root (default: ./configs)
+  --help                Show this help message
+`);
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    configRoot: path.resolve(process.cwd(), "configs"),
+    documentId: null,
+    snapshotId: null,
+    publishId: null,
+    help: false
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token) {
+      continue;
+    }
+
+    if (token === "--help" || token === "-h") {
+      args.help = true;
+      continue;
+    }
+
+    const nextValue = argv[index + 1];
+    if ((token === "--config-root" || token === "--document" || token === "--snapshot-id" || token === "--publish-id") && !nextValue) {
+      throw new Error(`Missing value for ${token}`);
+    }
+
+    if (token === "--config-root") {
+      args.configRoot = path.resolve(process.cwd(), nextValue ?? "");
+      index += 1;
+      continue;
+    }
+
+    if (token === "--document") {
+      if (!VALID_DOCUMENT_IDS.includes((nextValue ?? "") as ConfigDocumentId)) {
+        throw new Error(`Unsupported document id: ${nextValue ?? ""}`);
+      }
+      args.documentId = (nextValue ?? "") as ConfigDocumentId;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--snapshot-id") {
+      args.snapshotId = nextValue ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (token === "--publish-id") {
+      args.publishId = nextValue ?? null;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  return args;
+}
+
+async function resolveSnapshotId(
+  store: FileSystemConfigCenterStore,
+  documentId: ConfigDocumentId,
+  publishId: string | null,
+  snapshotId: string | null
+): Promise<string> {
+  if (snapshotId) {
+    return snapshotId;
+  }
+
+  if (!publishId) {
+    throw new Error("Provide either --snapshot-id or --publish-id.");
+  }
+
+  const history = await store.listPublishAuditHistory();
+  const publishEvent = history.find((entry) => entry.id === publishId);
+  if (!publishEvent) {
+    throw new Error(`Publish event not found: ${publishId}`);
+  }
+
+  const change = publishEvent.changes.find((entry) => entry.documentId === documentId);
+  if (!change) {
+    throw new Error(`Publish event ${publishId} does not include document ${documentId}`);
+  }
+  if (!change.snapshotId) {
+    throw new Error(`Publish event ${publishId} has no rollback snapshot for ${documentId}`);
+  }
+
+  return change.snapshotId;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  if (!args.documentId) {
+    throw new Error("Missing required argument: --document");
+  }
+  if (args.snapshotId && args.publishId) {
+    throw new Error("Use either --snapshot-id or --publish-id, not both.");
+  }
+
+  const store = new FileSystemConfigCenterStore(args.configRoot);
+  try {
+    const resolvedSnapshotId = await resolveSnapshotId(store, args.documentId, args.publishId, args.snapshotId);
+    const restored = await store.rollbackToSnapshot(args.documentId, resolvedSnapshotId);
+    console.log(
+      `Restored ${restored.id} to snapshot ${resolvedSnapshotId} at version ${restored.version ?? "unknown"} (${restored.updatedAt})`
+    );
+  } finally {
+    await store.close();
+  }
+}
+
+void main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exitCode = 1;
+});

--- a/scripts/test/config-center-restore.test.ts
+++ b/scripts/test/config-center-restore.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { FileSystemConfigCenterStore } from "../../apps/server/src/config-center";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+const WORLD_CONFIG = {
+  width: 8,
+  height: 8,
+  heroes: [
+    {
+      id: "hero-1",
+      playerId: "player-1",
+      name: "凯琳",
+      position: { x: 1, y: 1 },
+      vision: 2,
+      move: { total: 6, remaining: 6 },
+      stats: {
+        attack: 2,
+        defense: 2,
+        power: 1,
+        knowledge: 1,
+        hp: 30,
+        maxHp: 30
+      },
+      progression: {
+        level: 1,
+        experience: 0,
+        battlesWon: 0,
+        neutralBattlesWon: 0,
+        pvpBattlesWon: 0
+      },
+      armyTemplateId: "hero_guard_basic",
+      armyCount: 12
+    }
+  ],
+  resourceSpawn: {
+    goldChance: 0.06,
+    woodChance: 0.06,
+    oreChance: 0.06
+  }
+};
+
+const MAP_OBJECTS_CONFIG = {
+  neutralArmies: [],
+  guaranteedResources: [],
+  buildings: []
+};
+
+const UNIT_CONFIG = {
+  templates: [
+    {
+      id: "hero_guard_basic",
+      stackName: "枪兵",
+      faction: "crown",
+      rarity: "common",
+      initiative: 6,
+      attack: 4,
+      defense: 4,
+      minDamage: 1,
+      maxDamage: 3,
+      maxHp: 10
+    }
+  ]
+};
+
+const BATTLE_SKILL_CONFIG = {
+  skills: [
+    {
+      id: "power_shot",
+      name: "投矛射击",
+      description: "远程压制目标。",
+      kind: "active",
+      target: "enemy",
+      cooldown: 2,
+      effects: {
+        damageMultiplier: 0.85,
+        allowRetaliation: false
+      }
+    }
+  ],
+  statuses: []
+};
+
+const BATTLE_BALANCE_CONFIG = {
+  damage: {
+    defendingDefenseBonus: 5,
+    offenseAdvantageStep: 0.05,
+    minimumOffenseMultiplier: 0.3,
+    varianceBase: 0.9,
+    varianceRange: 0.2
+  },
+  environment: {
+    blockerSpawnThreshold: 0.62,
+    blockerDurability: 1,
+    trapSpawnThreshold: 0.58,
+    trapDamage: 1,
+    trapCharges: 1
+  },
+  pvp: {
+    eloK: 32
+  },
+  turnTimerSeconds: 30,
+  afkStrikesBeforeForfeit: 2
+};
+
+function writeJson(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function createConfigRoot(): string {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "veil-config-center-restore-"));
+  writeJson(path.join(rootDir, "phase1-world.json"), WORLD_CONFIG);
+  writeJson(path.join(rootDir, "phase1-map-objects.json"), MAP_OBJECTS_CONFIG);
+  writeJson(path.join(rootDir, "units.json"), UNIT_CONFIG);
+  writeJson(path.join(rootDir, "battle-skills.json"), BATTLE_SKILL_CONFIG);
+  writeJson(path.join(rootDir, "battle-balance.json"), BATTLE_BALANCE_CONFIG);
+  return rootDir;
+}
+
+function runRestore(args: string[]) {
+  return spawnSync("node", ["--import", "tsx", "./scripts/config-center-restore.ts", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+}
+
+test("config-center:restore rolls back from a publish event snapshot", async () => {
+  const configRoot = createConfigRoot();
+  const store = new FileSystemConfigCenterStore(configRoot);
+  await store.initializeRuntimeConfigs();
+  await store.saveStagedDraft([
+    {
+      id: "world",
+      content: JSON.stringify({
+        ...WORLD_CONFIG,
+        width: 10
+      })
+    }
+  ]);
+
+  const published = await store.publishStagedDraft({
+    author: "ConfigOps",
+    summary: "扩图并补资源",
+    candidate: "phase1-rc",
+    revision: "abc1234"
+  });
+  await store.close();
+
+  const publishId = published.publish.id;
+  const result = runRestore(["--config-root", configRoot, "--document", "world", "--publish-id", publishId]);
+
+  assert.equal(result.status, 0, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+
+  const restored = JSON.parse(fs.readFileSync(path.join(configRoot, "phase1-world.json"), "utf8")) as { width: number };
+  assert.equal(restored.width, WORLD_CONFIG.width);
+});


### PR DESCRIPTION
## Summary
- record candidate/revision metadata in config-center publish history and expose searchable publish audit filters in the client UI
- persist publish-time rollback snapshots so publish events keep an immutable restore point and surface that snapshot in history-driven rollback flows
- add a `config-center:restore` CLI path for snapshot or publish-id based rollback recovery

## Testing
- `npm run test:client:config-center`
- `node --import tsx --test ./apps/server/test/config-center.test.ts`
- `node --import tsx --test ./scripts/test/config-center-restore.test.ts`

Closes #858