### PR TITLE
[codex] issue #860 daily quest scaffold

### DIFF
--- a/apps/client/src/account-history.ts
+++ b/apps/client/src/account-history.ts
@@ -397,6 +397,75 @@ export function renderAchievementProgress(account: PlayerAccountProfile): string
   </div>`;
 }
 
+export function renderDailyQuestBoard(
+  account: PlayerAccountProfile,
+  options: {
+    claimingQuestId?: string | null;
+  } = {}
+): string {
+  const board = account.dailyQuestBoard;
+  if (!board?.enabled) {
+    return "";
+  }
+
+  const pendingRewardSummary = [
+    board.pendingRewards.gems > 0 ? `宝石 +${board.pendingRewards.gems}` : "",
+    board.pendingRewards.gold > 0 ? `金币 +${board.pendingRewards.gold}` : ""
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const resetLabel = board.resetAt ? `重置 ${formatTimestamp(board.resetAt)}` : "每日重置";
+
+  return `<div class="account-subsection account-daily-quests">
+    <div class="account-daily-quests-head">
+      <div>
+        <strong>每日任务</strong>
+        <p class="account-meta">${escapeHtml(
+          board.availableClaims > 0
+            ? `可领取 ${board.availableClaims} 项 · ${pendingRewardSummary || "奖励待领取"}`
+            : `${resetLabel} · 今日目标进行中`
+        )}</p>
+      </div>
+      <span class="account-badge">${escapeHtml(resetLabel)}</span>
+    </div>
+    <div class="account-daily-quest-list">
+      ${board.quests
+        .map((quest) => {
+          const isClaiming = options.claimingQuestId === quest.id;
+          const progressPercent = Math.max(0, Math.min(100, Math.floor((quest.current / quest.target) * 100)));
+          const rewardSummary = [
+            quest.reward.gems > 0 ? `宝石 +${quest.reward.gems}` : "",
+            quest.reward.gold > 0 ? `金币 +${quest.reward.gold}` : ""
+          ]
+            .filter(Boolean)
+            .join(" · ");
+          return `<div class="account-daily-quest ${quest.claimed ? "is-claimed" : quest.completed ? "is-complete" : ""}">
+            <div class="account-daily-quest-head">
+              <strong>${escapeHtml(quest.title)}</strong>
+              <span class="account-achievement-status">${escapeHtml(
+                quest.claimed ? "已领取" : quest.completed ? "可领取" : `${quest.current}/${quest.target}`
+              )}</span>
+            </div>
+            <p>${escapeHtml(quest.description)}</p>
+            <div class="account-achievement-meta">
+              <span>${escapeHtml(rewardSummary)}</span>
+              <span>${progressPercent}%</span>
+            </div>
+            <div class="account-achievement-bar"><span style="width:${progressPercent}%"></span></div>
+            ${
+              quest.completed
+                ? `<button class="account-save account-daily-quest-claim" data-claim-daily-quest="${escapeHtml(quest.id)}" ${
+                    quest.claimed || isClaiming ? "disabled" : ""
+                  }>${quest.claimed ? "已领取" : isClaiming ? "领取中..." : "领取奖励"}</button>`
+                : `<div class="account-daily-quest-foot">${escapeHtml(`还差 ${Math.max(0, quest.target - quest.current)} 步`)}</div>`
+            }
+          </div>`;
+        })
+        .join("")}
+    </div>
+  </div>`;
+}
+
 export function renderRecentAccountEvents(account: PlayerAccountProfile): string {
   if (account.recentEventLog.length === 0) {
     return '<div class="account-subsection"><strong>世界事件日志</strong><p class="account-meta">尚未记录关键事件。</p></div>';

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -14,6 +14,7 @@ import {
   formatEquipmentRarityLabel,
   getDefaultBattleSkillCatalog,
   getEquipmentDefinition,
+  normalizeDailyQuestBoard,
   pauseBattleReplayPlayback,
   predictPlayerWorldAction,
   playBattleReplayPlayback,
@@ -33,6 +34,7 @@ import {
   type PlayerWorldView,
   type RuntimeDiagnosticsConnectionStatus,
   type RuntimeDiagnosticsTriageSection,
+  type DailyQuestBoard,
   validateAccountLifecycleConfirm,
   validateAccountLifecycleRequest,
   validateAccountPassword,
@@ -56,6 +58,7 @@ import {
   confirmAccountRegistration,
   confirmPasswordRecovery,
   deleteCurrentPlayerAccount,
+  buildAuthHeaders,
   loginGuestAuthSession,
   loginPasswordAuthSession,
   logoutCurrentAuthSession,
@@ -88,6 +91,7 @@ import {
 import {
   renderAchievementProgress,
   renderBattleReportReplayCenter,
+  renderDailyQuestBoard,
   renderRecentAccountEvents
 } from "./account-history";
 import {
@@ -224,6 +228,7 @@ interface AppState {
   accountSaving: boolean;
   accountBinding: boolean;
   accountStatus: string;
+  dailyQuestClaimingId: string | null;
   accountSessions: PlayerAccountSessionDevice[];
   accountSessionsLoading: boolean;
   accountSessionRevokingId: string | null;
@@ -343,6 +348,7 @@ const state: AppState = {
   accountSaving: false,
   accountBinding: false,
   accountStatus: "游客账号资料将在连接后自动同步。",
+  dailyQuestClaimingId: null,
   accountSessions: [],
   accountSessionsLoading: false,
   accountSessionRevokingId: null,
@@ -3086,6 +3092,7 @@ async function refreshAccountProfileFromServer(): Promise<void> {
   accountRefreshPromise = (async () => {
     const account = await loadAccountProfileWithProgression(playerId, roomId);
     state.account = account;
+    await syncDailyQuestBoard();
     syncAchievementToastFeed(account, hasHydratedAchievementFeed);
     hasHydratedAchievementFeed = true;
     if (state.achievementPanel.open) {
@@ -3101,6 +3108,37 @@ async function refreshAccountProfileFromServer(): Promise<void> {
   });
 
   return accountRefreshPromise;
+}
+
+async function loadDailyQuestBoardFromServer(): Promise<DailyQuestBoard | undefined> {
+  const authSession = readStoredAuthSession();
+  if (!authSession?.token) {
+    return undefined;
+  }
+  const httpProtocol = window.location.protocol === "https:" ? "https" : "http";
+
+  try {
+    const response = await fetch(`${httpProtocol}://${window.location.hostname || "127.0.0.1"}:2567/api/player-accounts/me/daily-quests`, {
+      headers: buildAuthHeaders(authSession.token)
+    });
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const payload = (await response.json()) as {
+      dailyQuestBoard?: Partial<DailyQuestBoard>;
+    };
+    return normalizeDailyQuestBoard(payload.dailyQuestBoard);
+  } catch {
+    return undefined;
+  }
+}
+
+async function syncDailyQuestBoard(): Promise<void> {
+  const board = await loadDailyQuestBoardFromServer();
+  if (board) {
+    state.account.dailyQuestBoard = board;
+  }
 }
 
 async function previewTile(x: number, y: number): Promise<void> {
@@ -4849,6 +4887,9 @@ function render(): void {
           <p class="account-meta">${escapeHtml(formatCredentialBinding(state.account))}</p>
           <p class="account-meta">${escapeHtml(formatAccountLastSeen(state.account))}</p>
           <p class="account-meta">${escapeHtml(formatGlobalVault(state.account))}</p>
+          ${renderDailyQuestBoard(state.account, {
+            claimingQuestId: state.dailyQuestClaimingId
+          })}
           ${renderAchievementProgress(state.account)}
           ${renderBattleReportReplayCenter({
             account: state.account,
@@ -5248,6 +5289,15 @@ function render(): void {
     });
   }
 
+  for (const claimDailyQuestButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-claim-daily-quest]"))) {
+    claimDailyQuestButton.addEventListener("click", () => {
+      const questId = claimDailyQuestButton.dataset.claimDailyQuest;
+      if (questId) {
+        void onClaimDailyQuestReward(questId);
+      }
+    });
+  }
+
   for (const bindAccountButton of Array.from(root.querySelectorAll<HTMLButtonElement>("[data-bind-account]"))) {
     bindAccountButton.addEventListener("click", () => {
       void onBindAccountProfile();
@@ -5323,6 +5373,68 @@ async function onRevokeAccountSession(sessionId: string): Promise<void> {
   } catch (error) {
     state.accountSessionRevokingId = null;
     state.accountStatus = error instanceof Error ? error.message : "account_session_revoke_failed";
+    render();
+  }
+}
+
+async function onClaimDailyQuestReward(questId: string): Promise<void> {
+  const authSession = readStoredAuthSession();
+  if (!authSession?.token) {
+    state.accountStatus = "每日任务领取需要已登录的远端账号会话。";
+    render();
+    return;
+  }
+
+  state.dailyQuestClaimingId = questId;
+  state.accountStatus = "正在领取每日任务奖励...";
+  render();
+  const httpProtocol = window.location.protocol === "https:" ? "https" : "http";
+
+  try {
+    const response = await fetch(
+      `${httpProtocol}://${window.location.hostname || "127.0.0.1"}:2567/api/player-accounts/me/daily-quests/${encodeURIComponent(questId)}/claim`,
+      {
+      method: "POST",
+      headers: buildAuthHeaders(authSession.token)
+      }
+    );
+    const payload = (await response.json()) as {
+      claimed?: boolean;
+      reason?: string;
+      reward?: { gems?: number; gold?: number };
+      dailyQuestBoard?: Partial<DailyQuestBoard>;
+      error?: { message?: string };
+    };
+
+    if (!response.ok) {
+      throw new Error(payload.error?.message ?? "daily_quest_claim_failed");
+    }
+
+    const board = normalizeDailyQuestBoard(payload.dailyQuestBoard);
+    if (board) {
+      state.account.dailyQuestBoard = board;
+    }
+
+    if (payload.claimed) {
+      await refreshAccountProfileFromServer();
+      state.accountStatus = `每日任务奖励已入账：宝石 +${Math.max(0, Math.floor(payload.reward?.gems ?? 0))} · 金币 +${Math.max(
+        0,
+        Math.floor(payload.reward?.gold ?? 0)
+      )}`;
+    } else {
+      state.accountStatus =
+        payload.reason === "already_claimed"
+          ? "该每日任务奖励已领取。"
+          : payload.reason === "quest_incomplete"
+            ? "当前每日任务尚未完成。"
+            : payload.reason === "daily_quests_disabled"
+              ? "每日任务当前未启用。"
+              : "每日任务奖励暂时无法领取。";
+    }
+  } catch (error) {
+    state.accountStatus = error instanceof Error ? error.message : "daily_quest_claim_failed";
+  } finally {
+    state.dailyQuestClaimingId = null;
     render();
   }
 }
@@ -5460,6 +5572,9 @@ export function startMainH5Boot(overrides: StartMainH5BootOverrides = {}): void 
         syncAchievementToastFeed(runtimeState.account, false);
         hasHydratedAchievementFeed = true;
         runtimeState.achievementPanel.items = runtimeState.account.achievements;
+        void syncDailyQuestBoard().then(() => {
+          render();
+        });
       }),
     window: overrides.window ?? window,
     devDiagnosticsEnabled: overrides.devDiagnosticsEnabled ?? DEV_DIAGNOSTICS_ENABLED,

--- a/apps/client/src/styles.css
+++ b/apps/client/src/styles.css
@@ -492,6 +492,50 @@ h1 {
   gap: 8px;
 }
 
+.account-daily-quests {
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(78, 58, 42, 0.08);
+  background: rgba(255, 248, 240, 0.72);
+}
+
+.account-daily-quests-head,
+.account-daily-quest-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.account-daily-quest-list {
+  display: grid;
+  gap: 10px;
+}
+
+.account-daily-quest {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(78, 58, 42, 0.1);
+  background: rgba(255, 255, 255, 0.84);
+}
+
+.account-daily-quest.is-complete {
+  border-color: rgba(47, 110, 91, 0.18);
+}
+
+.account-daily-quest.is-claimed {
+  opacity: 0.72;
+}
+
+.account-daily-quest-claim {
+  margin-top: 8px;
+}
+
+.account-daily-quest-foot {
+  font-size: 12px;
+  color: var(--muted);
+}
+
 .account-replay-center {
   padding: 12px;
   border-radius: 14px;

--- a/apps/client/test/account-history-render.test.ts
+++ b/apps/client/test/account-history-render.test.ts
@@ -4,6 +4,7 @@ import {
   renderAchievementProgress,
   renderBattleReportReplayCenter,
   renderBattleReplayInspector,
+  renderDailyQuestBoard,
   renderRecentAccountEvents,
   renderRecentBattleReplays
 } from "../src/account-history";
@@ -33,6 +34,44 @@ function createProfile(): PlayerAccountProfile {
       gold: 12,
       wood: 4,
       ore: 2
+    },
+    dailyQuestBoard: {
+      enabled: true,
+      cycleKey: "2026-03-27",
+      resetAt: "2026-03-27T23:59:59.999Z",
+      availableClaims: 1,
+      pendingRewards: {
+        gems: 5,
+        gold: 60
+      },
+      quests: [
+        {
+          id: "daily_explore_frontier",
+          title: "侦察前线",
+          description: "完成 3 次探索移动。",
+          current: 3,
+          target: 3,
+          completed: true,
+          claimed: false,
+          reward: {
+            gems: 3,
+            gold: 40
+          }
+        },
+        {
+          id: "daily_battle_victory",
+          title: "凯旋号角",
+          description: "取得 1 场战斗胜利。",
+          current: 0,
+          target: 1,
+          completed: false,
+          claimed: false,
+          reward: {
+            gems: 5,
+            gold: 60
+          }
+        }
+      ]
     },
     achievements: [
       {
@@ -154,6 +193,19 @@ test("account history renderer shows unlocked achievement state and footnotes", 
   assert.match(html, /解锁于/);
   assert.match(html, /最近推进/);
   assert.match(html, /还差 1 点进度/);
+});
+
+test("account history renderer shows daily quest progress and claim action", () => {
+  const html = renderDailyQuestBoard(createProfile(), {
+    claimingQuestId: "daily_explore_frontier"
+  });
+
+  assert.match(html, /每日任务/);
+  assert.match(html, /可领取 1 项/);
+  assert.match(html, /侦察前线/);
+  assert.match(html, /领取中\.\.\./);
+  assert.match(html, /凯旋号角/);
+  assert.match(html, /还差 1 步/);
 });
 
 test("account history renderer shows readable event metadata, category summary, and reward chips", () => {

--- a/apps/server/src/daily-quests.ts
+++ b/apps/server/src/daily-quests.ts
@@ -1,0 +1,82 @@
+import {
+  buildDailyQuestBoard,
+  createEmptyDailyQuestReward,
+  getDailyQuestDefinitions,
+  type DailyQuestBoard,
+  type DailyQuestDefinition,
+  type DailyQuestId,
+  type EventLogEntry
+} from "../../../packages/shared/src/index";
+import type { PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
+
+const DAILY_QUEST_ID_SET = new Set(getDailyQuestDefinitions().map((definition) => definition.id));
+
+export function readDailyQuestFeatureEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const normalized = env.VEIL_DAILY_QUESTS_ENABLED?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function getDailyQuestCycleKey(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+export function getDailyQuestResetAt(cycleKey = getDailyQuestCycleKey()): string {
+  return `${cycleKey}T23:59:59.999Z`;
+}
+
+export function createDailyQuestClaimEventLogEntry(
+  playerId: string,
+  roomId: string,
+  definition: DailyQuestDefinition,
+  timestamp: string,
+  sequence = 1
+): EventLogEntry {
+  return {
+    id: `${playerId}:${timestamp}:daily-quest-claim:${sequence}:${definition.id}`,
+    timestamp,
+    roomId,
+    playerId,
+    category: "account",
+    description: `领取每日任务：${definition.title}`,
+    rewards: [
+      ...(definition.reward.gems > 0 ? [{ type: "resource" as const, label: "gems", amount: definition.reward.gems }] : []),
+      ...(definition.reward.gold > 0 ? [{ type: "resource" as const, label: "gold", amount: definition.reward.gold }] : [])
+    ]
+  };
+}
+
+export async function loadDailyQuestBoard(
+  store: RoomSnapshotStore,
+  account: PlayerAccountSnapshot,
+  now = new Date(),
+  enabled = readDailyQuestFeatureEnabled()
+): Promise<DailyQuestBoard> {
+  if (!enabled) {
+    return {
+      enabled: false,
+      availableClaims: 0,
+      pendingRewards: createEmptyDailyQuestReward(),
+      quests: []
+    };
+  }
+
+  const cycleKey = getDailyQuestCycleKey(now);
+  const history = await store.loadPlayerEventHistory(account.playerId, {
+    since: `${cycleKey}T00:00:00.000Z`
+  });
+
+  return buildDailyQuestBoard(history.items, {
+    enabled: true,
+    cycleKey,
+    resetAt: getDailyQuestResetAt(cycleKey)
+  });
+}
+
+export function findDailyQuestDefinition(questId?: string | null): DailyQuestDefinition | null {
+  const normalizedQuestId = questId?.trim() as DailyQuestId | undefined;
+  if (!normalizedQuestId || !DAILY_QUEST_ID_SET.has(normalizedQuestId)) {
+    return null;
+  }
+
+  return getDailyQuestDefinitions().find((definition) => definition.id === normalizedQuestId) ?? null;
+}

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -14,6 +14,12 @@ import {
   type PlayerBattleReplaySummary
 } from "../../../packages/shared/src/index";
 import {
+  createDailyQuestClaimEventLogEntry,
+  findDailyQuestDefinition,
+  loadDailyQuestBoard,
+  readDailyQuestFeatureEnabled
+} from "./daily-quests";
+import {
   cachePlayerAccountAuthState,
   hashAccountPassword,
   issueNextAuthSession,
@@ -279,6 +285,20 @@ function withBattleReportCenter(account: PlayerAccountSnapshot): PlayerAccountSn
   return {
     ...account,
     battleReportCenter: buildPlayerBattleReportCenter(account.recentBattleReplays, account.recentEventLog)
+  };
+}
+
+async function withDailyQuestBoard(
+  account: PlayerAccountSnapshot,
+  store: RoomSnapshotStore | null
+): Promise<PlayerAccountSnapshot> {
+  if (!store) {
+    return account;
+  }
+
+  return {
+    ...account,
+    dailyQuestBoard: await loadDailyQuestBoard(store, account)
   };
 }
 
@@ -647,7 +667,7 @@ export function registerPlayerAccountRoutes(
           displayName: authSession.displayName
         }));
       sendJson(response, 200, {
-        account: withBattleReportCenter(account),
+        account: await withDailyQuestBoard(withBattleReportCenter(account), store),
         session: issueNextAuthSession(account, authSession)
       });
     } catch (error) {
@@ -705,6 +725,137 @@ export function registerPlayerAccountRoutes(
         claimed: true,
         streak,
         reward
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/player-accounts/me/daily-quests/:questId/claim", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 200, {
+        claimed: false,
+        reason: "persistence_unavailable"
+      });
+      return;
+    }
+
+    if (!readDailyQuestFeatureEnabled()) {
+      sendJson(response, 200, {
+        claimed: false,
+        reason: "daily_quests_disabled"
+      });
+      return;
+    }
+
+    const definition = findDailyQuestDefinition(request.params.questId);
+    if (!definition) {
+      sendJson(response, 404, {
+        error: {
+          code: "daily_quest_not_found",
+          message: "Daily quest was not found"
+        }
+      });
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      const board = await loadDailyQuestBoard(store, account);
+      const quest = board.quests.find((item) => item.id === definition.id);
+
+      if (!quest) {
+        sendJson(response, 404, {
+          error: {
+            code: "daily_quest_not_found",
+            message: "Daily quest was not found"
+          }
+        });
+        return;
+      }
+
+      if (!quest.completed) {
+        sendJson(response, 200, {
+          claimed: false,
+          reason: "quest_incomplete",
+          dailyQuestBoard: board
+        });
+        return;
+      }
+
+      if (quest.claimed) {
+        sendJson(response, 200, {
+          claimed: false,
+          reason: "already_claimed",
+          dailyQuestBoard: board
+        });
+        return;
+      }
+
+      const timestamp = new Date().toISOString();
+      const claimEntry = createDailyQuestClaimEventLogEntry(
+        account.playerId,
+        account.lastRoomId ?? "daily-quests",
+        definition,
+        timestamp
+      );
+      const nextAccount = await store.savePlayerAccountProgress(account.playerId, {
+        gems: (account.gems ?? 0) + definition.reward.gems,
+        globalResources: {
+          ...account.globalResources,
+          gold: (account.globalResources.gold ?? 0) + definition.reward.gold
+        },
+        recentEventLog: appendEventLogEntries(account.recentEventLog, [claimEntry])
+      });
+
+      sendJson(response, 200, {
+        claimed: true,
+        questId: definition.id,
+        reward: definition.reward,
+        dailyQuestBoard: await loadDailyQuestBoard(store, nextAccount)
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/me/daily-quests", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 200, {
+        dailyQuestBoard: {
+          enabled: false,
+          availableClaims: 0,
+          pendingRewards: { gems: 0, gold: 0 },
+          quests: []
+        }
+      });
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      sendJson(response, 200, {
+        dailyQuestBoard: await loadDailyQuestBoard(store, account)
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
@@ -1219,7 +1370,10 @@ export function registerPlayerAccountRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
-      sendJson(response, 200, toProgressionResponse(account, parseLimit(request)));
+      sendJson(response, 200, {
+        ...toProgressionResponse(account, parseLimit(request)),
+        dailyQuestBoard: await loadDailyQuestBoard(store, account)
+      });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -532,6 +532,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   async savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot> {
     const existing = await this.ensurePlayerAccount({ playerId });
+    const previousHistory = this.eventHistoryByPlayerId.get(playerId) ?? [];
     const account: PlayerAccountSnapshot = {
       ...existing,
       ...(patch.gems !== undefined ? { gems: Math.max(0, Math.floor(patch.gems ?? 0)) } : {}),
@@ -556,6 +557,14 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       updatedAt: new Date().toISOString()
     };
     this.accounts.set(playerId, account);
+    this.eventHistoryByPlayerId.set(
+      playerId,
+      structuredClone([
+        ...((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? [])
+          .filter((entry) => !previousHistory.some((existingEntry) => existingEntry.id === entry.id)),
+        ...previousHistory
+      ])
+    );
     return account;
   }
 
@@ -2902,6 +2911,190 @@ test("daily claim rejects duplicate claims on the same day", async (t) => {
   assert.equal(account?.gems, 9);
   assert.equal(account?.globalResources.gold, 18);
   assert.equal(account?.loginStreak, 3);
+});
+
+test("daily quest board derives same-day progress and ignores prior-day events", async (t) => {
+  const port = 44930 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  const today = getDailyRewardDateKey();
+  const yesterday = getPreviousDailyRewardDateKey(today);
+  const todayStart = `${today}T09:00:00.000Z`;
+  const yesterdayStart = `${yesterday}T09:00:00.000Z`;
+  process.env.VEIL_DAILY_QUESTS_ENABLED = "true";
+  t.after(() => {
+    delete process.env.VEIL_DAILY_QUESTS_ENABLED;
+  });
+  await store.ensurePlayerAccount({
+    playerId: "daily-quest-player",
+    displayName: "界碑斥候"
+  });
+  store.seedEventHistory("daily-quest-player", [
+    {
+      id: `daily-quest-player:${yesterdayStart}:hero.moved:1`,
+      timestamp: yesterdayStart,
+      roomId: "room-alpha",
+      playerId: "daily-quest-player",
+      category: "movement",
+      description: "昨天的探索移动。",
+      worldEventType: "hero.moved",
+      rewards: []
+    },
+    {
+      id: `daily-quest-player:${todayStart}:hero.moved:1`,
+      timestamp: todayStart,
+      roomId: "room-alpha",
+      playerId: "daily-quest-player",
+      category: "movement",
+      description: "今日探索移动。",
+      worldEventType: "hero.moved",
+      rewards: []
+    },
+    {
+      id: `daily-quest-player:${today}T09:03:00.000Z:hero.moved:2`,
+      timestamp: `${today}T09:03:00.000Z`,
+      roomId: "room-alpha",
+      playerId: "daily-quest-player",
+      category: "movement",
+      description: "今日探索移动。",
+      worldEventType: "hero.moved",
+      rewards: []
+    },
+    {
+      id: `daily-quest-player:${today}T09:06:00.000Z:hero.collected:3`,
+      timestamp: `${today}T09:06:00.000Z`,
+      roomId: "room-alpha",
+      playerId: "daily-quest-player",
+      category: "building",
+      description: "今日收集资源。",
+      worldEventType: "hero.collected",
+      rewards: [{ type: "resource", label: "gold", amount: 20 }]
+    }
+  ]);
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "daily-quest-player",
+    displayName: "界碑斥候"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const boardResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/daily-quests`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const boardPayload = (await boardResponse.json()) as {
+    dailyQuestBoard: {
+      enabled: boolean;
+      cycleKey: string;
+      availableClaims: number;
+      quests: Array<{ id: string; current: number; completed: boolean }>;
+    };
+  };
+
+  assert.equal(boardResponse.status, 200);
+  assert.equal(boardPayload.dailyQuestBoard.enabled, true);
+  assert.equal(boardPayload.dailyQuestBoard.cycleKey, today);
+  assert.deepEqual(
+    boardPayload.dailyQuestBoard.quests.map((quest) => ({ id: quest.id, current: quest.current, completed: quest.completed })),
+    [
+      { id: "daily_explore_frontier", current: 2, completed: false },
+      { id: "daily_battle_victory", current: 0, completed: false },
+      { id: "daily_resource_run", current: 1, completed: false }
+    ]
+  );
+});
+
+test("daily quest claim grants rewards once and returns already_claimed on repeat", async (t) => {
+  const port = 44932 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  const today = getDailyRewardDateKey();
+  process.env.VEIL_DAILY_QUESTS_ENABLED = "true";
+  t.after(() => {
+    delete process.env.VEIL_DAILY_QUESTS_ENABLED;
+  });
+  await store.ensurePlayerAccount({
+    playerId: "daily-quest-claim",
+    displayName: "白塔军需官"
+  });
+  store.seedEventHistory("daily-quest-claim", [
+    {
+      id: `daily-quest-claim:${today}T08:00:00.000Z:hero.collected:1`,
+      timestamp: `${today}T08:00:00.000Z`,
+      roomId: "room-alpha",
+      playerId: "daily-quest-claim",
+      category: "building",
+      description: "今日收集资源。",
+      worldEventType: "hero.collected",
+      rewards: [{ type: "resource", label: "gold", amount: 15 }]
+    },
+    {
+      id: `daily-quest-claim:${today}T08:05:00.000Z:hero.collected:2`,
+      timestamp: `${today}T08:05:00.000Z`,
+      roomId: "room-alpha",
+      playerId: "daily-quest-claim",
+      category: "building",
+      description: "今日收集资源。",
+      worldEventType: "hero.collected",
+      rewards: [{ type: "resource", label: "gold", amount: 25 }]
+    }
+  ]);
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "daily-quest-claim",
+    displayName: "白塔军需官"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const claimResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/daily-quests/daily_resource_run/claim`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const claimPayload = (await claimResponse.json()) as {
+    claimed: boolean;
+    reward: { gems: number; gold: number };
+    dailyQuestBoard: { availableClaims: number };
+  };
+
+  assert.equal(claimResponse.status, 200);
+  assert.equal(claimPayload.claimed, true);
+  assert.deepEqual(claimPayload.reward, { gems: 2, gold: 35 });
+  assert.equal(claimPayload.dailyQuestBoard.availableClaims, 0);
+
+  const repeatResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/daily-quests/daily_resource_run/claim`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const repeatPayload = (await repeatResponse.json()) as {
+    claimed: boolean;
+    reason: string;
+    dailyQuestBoard: { availableClaims: number };
+  };
+
+  assert.equal(repeatResponse.status, 200);
+  assert.equal(repeatPayload.claimed, false);
+  assert.equal(repeatPayload.reason, "already_claimed");
+  assert.equal(repeatPayload.dailyQuestBoard.availableClaims, 0);
+
+  const account = await store.loadPlayerAccount("daily-quest-claim");
+  assert.equal(account?.gems, 2);
+  assert.equal(account?.globalResources.gold, 35);
+  assert.match(account?.recentEventLog[0]?.description ?? "", /领取每日任务：补给回收/);
 });
 
 test("referral endpoint rejects double-claiming for the same referrer and new player", async (t) => {

--- a/packages/shared/src/daily-quests.ts
+++ b/packages/shared/src/daily-quests.ts
@@ -1,0 +1,199 @@
+import type { EventLogEntry } from "./event-log.ts";
+
+export type DailyQuestId = "daily_explore_frontier" | "daily_battle_victory" | "daily_resource_run";
+export type DailyQuestMetric = "hero_moves" | "battle_wins" | "resource_collections";
+
+export interface DailyQuestReward {
+  gems: number;
+  gold: number;
+}
+
+export interface DailyQuestDefinition {
+  id: DailyQuestId;
+  title: string;
+  description: string;
+  metric: DailyQuestMetric;
+  target: number;
+  reward: DailyQuestReward;
+}
+
+export interface DailyQuestProgress {
+  id: DailyQuestId;
+  title: string;
+  description: string;
+  target: number;
+  current: number;
+  completed: boolean;
+  claimed: boolean;
+  reward: DailyQuestReward;
+}
+
+export interface DailyQuestBoard {
+  enabled: boolean;
+  cycleKey?: string;
+  resetAt?: string;
+  availableClaims: number;
+  pendingRewards: DailyQuestReward;
+  quests: DailyQuestProgress[];
+}
+
+const DAILY_QUEST_DEFINITIONS: DailyQuestDefinition[] = [
+  {
+    id: "daily_explore_frontier",
+    title: "侦察前线",
+    description: "完成 3 次探索移动。",
+    metric: "hero_moves",
+    target: 3,
+    reward: { gems: 3, gold: 40 }
+  },
+  {
+    id: "daily_battle_victory",
+    title: "凯旋号角",
+    description: "取得 1 场战斗胜利。",
+    metric: "battle_wins",
+    target: 1,
+    reward: { gems: 5, gold: 60 }
+  },
+  {
+    id: "daily_resource_run",
+    title: "补给回收",
+    description: "完成 2 次资源收集。",
+    metric: "resource_collections",
+    target: 2,
+    reward: { gems: 2, gold: 35 }
+  }
+];
+
+export function getDailyQuestDefinitions(): DailyQuestDefinition[] {
+  return DAILY_QUEST_DEFINITIONS.map((definition) => ({ ...definition, reward: { ...definition.reward } }));
+}
+
+export function createEmptyDailyQuestReward(): DailyQuestReward {
+  return { gems: 0, gold: 0 };
+}
+
+function hasClaimMarker(entry: Pick<EventLogEntry, "id">, questId: DailyQuestId): boolean {
+  return entry.id.includes(`daily-quest-claim:`) && entry.id.endsWith(`:${questId}`);
+}
+
+function countQuestMetric(events: Pick<EventLogEntry, "id" | "worldEventType" | "description">[], metric: DailyQuestMetric): number {
+  switch (metric) {
+    case "hero_moves":
+      return events.filter((entry) => entry.worldEventType === "hero.moved").length;
+    case "battle_wins":
+      return events.filter(
+        (entry) => entry.worldEventType === "battle.resolved" && entry.description.includes("胜利")
+      ).length;
+    case "resource_collections":
+      return events.filter((entry) => entry.worldEventType === "hero.collected").length;
+    default:
+      return 0;
+  }
+}
+
+export function buildDailyQuestBoard(
+  events: Pick<EventLogEntry, "id" | "worldEventType" | "description">[],
+  options: {
+    enabled: boolean;
+    cycleKey?: string;
+    resetAt?: string;
+  }
+): DailyQuestBoard {
+  if (!options.enabled) {
+    return {
+      enabled: false,
+      availableClaims: 0,
+      pendingRewards: createEmptyDailyQuestReward(),
+      quests: []
+    };
+  }
+
+  const quests = DAILY_QUEST_DEFINITIONS.map((definition) => {
+    const current = Math.min(definition.target, countQuestMetric(events, definition.metric));
+    const completed = current >= definition.target;
+    const claimed = events.some((entry) => hasClaimMarker(entry, definition.id));
+    return {
+      id: definition.id,
+      title: definition.title,
+      description: definition.description,
+      target: definition.target,
+      current,
+      completed,
+      claimed,
+      reward: { ...definition.reward }
+    } satisfies DailyQuestProgress;
+  });
+
+  const pendingRewards = quests.reduce(
+    (totals, quest) => {
+      if (!quest.completed || quest.claimed) {
+        return totals;
+      }
+
+      totals.gems += quest.reward.gems;
+      totals.gold += quest.reward.gold;
+      return totals;
+    },
+    createEmptyDailyQuestReward()
+  );
+
+  return {
+    enabled: true,
+    ...(options.cycleKey ? { cycleKey: options.cycleKey } : {}),
+    ...(options.resetAt ? { resetAt: options.resetAt } : {}),
+    availableClaims: quests.filter((quest) => quest.completed && !quest.claimed).length,
+    pendingRewards,
+    quests
+  };
+}
+
+export function normalizeDailyQuestBoard(board?: Partial<DailyQuestBoard> | null): DailyQuestBoard | undefined {
+  if (board?.enabled !== true) {
+    return undefined;
+  }
+
+  const definitions = new Map(DAILY_QUEST_DEFINITIONS.map((definition) => [definition.id, definition] as const));
+  const quests = (board.quests ?? [])
+    .map((quest) => {
+      const definition = quest?.id ? definitions.get(quest.id) : undefined;
+      if (!definition) {
+        return null;
+      }
+
+      const current = Math.max(0, Math.min(definition.target, Math.floor(quest.current ?? 0)));
+      const completed = current >= definition.target || quest.completed === true;
+      return {
+        id: definition.id,
+        title: definition.title,
+        description: definition.description,
+        target: definition.target,
+        current,
+        completed,
+        claimed: quest.claimed === true,
+        reward: { ...definition.reward }
+      } satisfies DailyQuestProgress;
+    })
+    .filter((quest): quest is DailyQuestProgress => Boolean(quest));
+
+  const pendingRewards = quests.reduce(
+    (totals, quest) => {
+      if (!quest.completed || quest.claimed) {
+        return totals;
+      }
+
+      totals.gems += quest.reward.gems;
+      totals.gold += quest.reward.gold;
+      return totals;
+    },
+    createEmptyDailyQuestReward()
+  );
+
+  return {
+    enabled: true,
+    ...(board.cycleKey ? { cycleKey: String(board.cycleKey) } : {}),
+    ...(board.resetAt ? { resetAt: String(board.resetAt) } : {}),
+    availableClaims: quests.filter((quest) => quest.completed && !quest.claimed).length,
+    pendingRewards,
+    quests
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,7 @@ export * from "./battle.ts";
 export * from "./battle-report.ts";
 export * from "./battle-replay.ts";
 export * from "./content-pack-validation.ts";
+export * from "./daily-quests.ts";
 export * from "./deterministic-rng.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -9,6 +9,7 @@ import {
   type EventLogEntry,
   type PlayerAchievementProgress
 } from "./event-log.ts";
+import { normalizeDailyQuestBoard, type DailyQuestBoard } from "./daily-quests.ts";
 import { normalizePlayerBattleReplaySummaries, type PlayerBattleReplaySummary } from "./battle-replay.ts";
 import { normalizeEloRating } from "./matchmaking.ts";
 import type { ResourceLedger } from "./models.ts";
@@ -28,6 +29,7 @@ export interface PlayerAccountReadModel {
   recentEventLog: EventLogEntry[];
   recentBattleReplays?: PlayerBattleReplaySummary[];
   battleReportCenter?: PlayerBattleReportCenter;
+  dailyQuestBoard?: DailyQuestBoard;
   loginId?: string;
   credentialBoundAt?: string;
   privacyConsentAt?: string;
@@ -57,6 +59,7 @@ export interface PlayerAccountReadModelInput {
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
   battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
+  dailyQuestBoard?: Partial<DailyQuestBoard> | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
   privacyConsentAt?: string | undefined;
@@ -105,6 +108,7 @@ export function normalizePlayerAccountReadModel(
   const lastSeenAt = account?.lastSeenAt?.trim();
   const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
   const recentBattleReplays = normalizePlayerBattleReplaySummaries(account?.recentBattleReplays);
+  const dailyQuestBoard = normalizeDailyQuestBoard(account?.dailyQuestBoard);
 
   return {
     playerId,
@@ -126,6 +130,7 @@ export function normalizePlayerAccountReadModel(
       replays: recentBattleReplays,
       eventLog: recentEventLog
     }),
+    ...(dailyQuestBoard ? { dailyQuestBoard } : {}),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(privacyConsentAt ? { privacyConsentAt } : {}),

--- a/packages/shared/test/daily-quests.test.ts
+++ b/packages/shared/test/daily-quests.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildDailyQuestBoard } from "../src/index.ts";
+
+test("daily quest board derives progress and pending rewards from event history", () => {
+  const board = buildDailyQuestBoard(
+    [
+      {
+        id: "event-move-1",
+        worldEventType: "hero.moved",
+        description: "侦察移动"
+      },
+      {
+        id: "event-move-2",
+        worldEventType: "hero.moved",
+        description: "侦察移动"
+      },
+      {
+        id: "event-move-3",
+        worldEventType: "hero.moved",
+        description: "侦察移动"
+      },
+      {
+        id: "event-battle-win",
+        worldEventType: "battle.resolved",
+        description: "战斗结果为 胜利。"
+      },
+      {
+        id: "player-1:2026-04-04T12:10:00.000Z:daily-quest-claim:1:daily_explore_frontier",
+        worldEventType: undefined,
+        description: "领取每日任务：侦察前线"
+      }
+    ],
+    {
+      enabled: true,
+      cycleKey: "2026-04-04",
+      resetAt: "2026-04-04T23:59:59.999Z"
+    }
+  );
+
+  assert.equal(board.enabled, true);
+  assert.equal(board.availableClaims, 1);
+  assert.deepEqual(board.pendingRewards, {
+    gems: 5,
+    gold: 60
+  });
+  assert.deepEqual(
+    board.quests.map((quest) => ({ id: quest.id, current: quest.current, completed: quest.completed, claimed: quest.claimed })),
+    [
+      { id: "daily_explore_frontier", current: 3, completed: true, claimed: true },
+      { id: "daily_battle_victory", current: 1, completed: true, claimed: false },
+      { id: "daily_resource_run", current: 0, completed: false, claimed: false }
+    ]
+  );
+});
+
+test("daily quest board marks claims by deterministic claim event id", () => {
+  const board = buildDailyQuestBoard(
+    [
+      {
+        id: "player-1:2026-04-04T12:00:00.000Z:hero.collected:1",
+        worldEventType: "hero.collected",
+        description: "完成资源收集"
+      },
+      {
+        id: "player-1:2026-04-04T12:05:00.000Z:hero.collected:2",
+        worldEventType: "hero.collected",
+        description: "完成资源收集"
+      },
+      {
+        id: "player-1:2026-04-04T12:06:00.000Z:daily-quest-claim:1:daily_resource_run",
+        worldEventType: undefined,
+        description: "领取每日任务：补给回收"
+      }
+    ],
+    { enabled: true }
+  );
+
+  const resourceQuest = board.quests.find((quest) => quest.id === "daily_resource_run");
+  assert.equal(resourceQuest?.completed, true);
+  assert.equal(resourceQuest?.claimed, true);
+  assert.deepEqual(board.pendingRewards, { gems: 0, gold: 0 });
+});


### PR DESCRIPTION
## Summary
Implements issue #860 with a scoped daily quest scaffold for the Phase 1 retention loop.

## What changed
- added shared daily quest definitions and board/reward contracts
- derived quest progress from same-day player event history behind `VEIL_DAILY_QUESTS_ENABLED` (default off)
- added authenticated server routes to read the board and claim completed quest rewards deterministically
- added H5 client account-card presentation and claim actions for the daily quest board
- added focused shared, server, and client tests for progress derivation, reset timing, claim idempotency, and UI rendering

## Validation
- `node --import tsx --test packages/shared/test/daily-quests.test.ts`
- `node --import tsx --test apps/client/test/account-history-render.test.ts`
- `node --import tsx --test apps/server/test/player-account-routes.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `npm run typecheck:client:h5`