### PR TITLE
[codex] Implement new player onboarding tutorial flow

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -49,6 +49,7 @@ import {
   resolveCocosConfigCenterUrl,
   saveCocosLobbyPreferences,
   syncCurrentCocosAuthSession,
+  updateCocosTutorialProgress,
   type CocosLobbyRoomSummary,
   type CocosPlayerAccountProfile
 } from "./cocos-lobby.ts";
@@ -133,6 +134,7 @@ import { buildCocosShopPanelView, type ShopProduct } from "./cocos-shop-panel.ts
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
 import { VeilProgressionPanel } from "./VeilProgressionPanel.ts";
 import { VeilEquipmentPanel } from "./VeilEquipmentPanel.ts";
+import { VeilTutorialOverlay, type TutorialOverlayView } from "./VeilTutorialOverlay.ts";
 import { formatEquipmentActionReason, formatEquipmentSlotLabel } from "./cocos-hero-equipment.ts";
 import { type CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
 import { buildLobbySkillPanelView, toLobbySkillPanelHeroState } from "./cocos-lobby-skill-panel.ts";
@@ -163,6 +165,8 @@ import {
 } from "./cocos-primary-client-telemetry.ts";
 import {
   describeAccountAuthFailure,
+  normalizeTutorialStep,
+  type TutorialProgressAction,
   type PrimaryClientTelemetryEvent,
   type RuntimeDiagnosticsConnectionStatus,
   validateAccountLifecycleConfirm,
@@ -183,6 +187,7 @@ const MAP_NODE_NAME = "ProjectVeilMap";
 const BATTLE_NODE_NAME = "ProjectVeilBattlePanel";
 const TIMELINE_NODE_NAME = "ProjectVeilTimelinePanel";
 const LOBBY_NODE_NAME = "ProjectVeilLobbyPanel";
+const TUTORIAL_OVERLAY_NODE_NAME = "ProjectVeilTutorialOverlay";
 const ACCOUNT_REVIEW_PANEL_NODE_NAME = "ProjectVeilAccountReviewPanel";
 const EQUIPMENT_PANEL_NODE_NAME = "ProjectVeilEquipmentPanel";
 const SETTINGS_PANEL_NODE_NAME = "ProjectVeilSettingsPanel";
@@ -211,6 +216,7 @@ interface VeilRootRuntime {
   loadLobbyRooms: typeof loadCocosLobbyRooms;
   syncAuthSession: typeof syncCurrentCocosAuthSession;
   loadAccountProfile: typeof loadCocosPlayerAccountProfile;
+  updateTutorialProgress: typeof updateCocosTutorialProgress;
   loadProgressionSnapshot: typeof loadCocosPlayerProgressionSnapshot;
   loadAchievementProgress: typeof loadCocosPlayerAchievementProgress;
   loadEventHistory: typeof loadCocosPlayerEventHistory;
@@ -234,6 +240,7 @@ const defaultVeilRootRuntime: VeilRootRuntime = {
   loadLobbyRooms: (...args) => loadCocosLobbyRooms(...args),
   syncAuthSession: (...args) => syncCurrentCocosAuthSession(...args),
   loadAccountProfile: (...args) => loadCocosPlayerAccountProfile(...args),
+  updateTutorialProgress: (...args) => updateCocosTutorialProgress(...args),
   loadProgressionSnapshot: (...args) => loadCocosPlayerProgressionSnapshot(...args),
   loadAchievementProgress: (...args) => loadCocosPlayerAchievementProgress(...args),
   loadEventHistory: (...args) => loadCocosPlayerEventHistory(...args),
@@ -343,6 +350,8 @@ export class VeilRoot extends Component {
   private lobbyLeaderboardStatus: "idle" | "loading" | "ready" | "error" = "idle";
   private lobbyLeaderboardError: string | null = null;
   private lobbyAccountProfile: CocosPlayerAccountProfile = createFallbackCocosPlayerAccountProfile("player-1", "test-room");
+  private tutorialOverlay: VeilTutorialOverlay | null = null;
+  private tutorialProgressInFlight = false;
   private lobbyShopProducts: ShopProduct[] = [];
   private lobbyShopLoading = false;
   private lobbyShopStatus = "可用商品会在这里显示。";
@@ -964,6 +973,25 @@ export class VeilRoot extends Component {
       }
     });
 
+    let tutorialOverlayNode = this.node.getChildByName(TUTORIAL_OVERLAY_NODE_NAME);
+    if (!tutorialOverlayNode) {
+      tutorialOverlayNode = new Node(TUTORIAL_OVERLAY_NODE_NAME);
+      tutorialOverlayNode.parent = this.node;
+    }
+    assignUiLayer(tutorialOverlayNode);
+    const tutorialOverlayTransform = tutorialOverlayNode.getComponent(UITransform) ?? tutorialOverlayNode.addComponent(UITransform);
+    tutorialOverlayTransform.setContentSize(visibleSize.width, visibleSize.height);
+    this.tutorialOverlay =
+      tutorialOverlayNode.getComponent(VeilTutorialOverlay) ?? tutorialOverlayNode.addComponent(VeilTutorialOverlay);
+    this.tutorialOverlay.configure({
+      onPrimaryAction: () => {
+        void this.advanceTutorialFlow();
+      },
+      onSecondaryAction: () => {
+        void this.skipTutorialFlow();
+      }
+    });
+
     let mapRoot = this.node.getChildByName(MAP_NODE_NAME);
     if (!mapRoot) {
       mapRoot = new Node(MAP_NODE_NAME);
@@ -1173,6 +1201,7 @@ export class VeilRoot extends Component {
     const mapNode = this.node.getChildByName(MAP_NODE_NAME);
     const battleNode = this.node.getChildByName(BATTLE_NODE_NAME);
     const timelineNode = this.node.getChildByName(TIMELINE_NODE_NAME);
+    const tutorialOverlayNode = this.node.getChildByName(TUTORIAL_OVERLAY_NODE_NAME);
     const accountReviewPanelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
     const equipmentPanelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
     const settingsPanelNode = this.node.getChildByName(SETTINGS_PANEL_NODE_NAME);
@@ -1205,6 +1234,9 @@ export class VeilRoot extends Component {
     }
     if (settingsButtonNode) {
       settingsButtonNode.active = true;
+    }
+    if (tutorialOverlayNode) {
+      tutorialOverlayNode.active = false;
     }
 
     if (this.showLobby) {
@@ -1256,6 +1288,13 @@ export class VeilRoot extends Component {
         shopStatus: this.lobbyShopStatus,
         shopLoading: this.lobbyShopLoading
       });
+      const tutorialOverlayView = this.buildTutorialOverlayView();
+      if (tutorialOverlayView) {
+        tutorialOverlayNode && (tutorialOverlayNode.active = true);
+        this.tutorialOverlay?.render(tutorialOverlayView);
+      } else {
+        this.tutorialOverlay?.render(null);
+      }
       this.renderSettingsOverlay();
       return;
     }
@@ -1316,6 +1355,13 @@ export class VeilRoot extends Component {
       interaction: this.buildHudInteractionState(),
       presentation: this.buildHudPresentationState()
     });
+    const tutorialOverlayView = this.buildTutorialOverlayView();
+    if (tutorialOverlayView) {
+      tutorialOverlayNode && (tutorialOverlayNode.active = true);
+      this.tutorialOverlay?.render(tutorialOverlayView);
+    } else {
+      this.tutorialOverlay?.render(null);
+    }
     this.renderSettingsOverlay();
     this.mapBoard?.render(this.lastUpdate);
     this.battlePanel?.render({
@@ -4192,6 +4238,138 @@ export class VeilRoot extends Component {
         ...(wxRuntime ? { wx: wxRuntime } : {})
       }
     );
+  }
+
+  private buildTutorialOverlayView(): TutorialOverlayView | null {
+    const tutorialStep = normalizeTutorialStep(this.lobbyAccountProfile.tutorialStep);
+    if (tutorialStep === null || this.sessionSource !== "remote") {
+      return null;
+    }
+
+    const inLobby = this.showLobby;
+    const stepLabel = `引导 ${tutorialStep}/3`;
+    const busy = this.tutorialProgressInFlight;
+    if (tutorialStep === 1) {
+      return {
+        badge: "初次登录",
+        stepLabel,
+        title: "欢迎来到 Project Veil",
+        body: "先用一分钟熟悉核心节奏，再进入正式对局。",
+        detailLines: [
+          "世界地图是你的主舞台，侦察、招募、战斗都会在这里展开。",
+          "完成引导后才会解锁每日任务，避免新号同时接收过多系统信息。",
+          "前 5 场 PVP 会启用新手保护，优先避开高强度对局。"
+        ],
+        primaryLabel: busy ? "同步中..." : "开始引导",
+        busy
+      };
+    }
+
+    if (tutorialStep === 2) {
+      return {
+        badge: inLobby ? "出征准备" : "地图导览",
+        stepLabel,
+        title: inLobby ? "先进入你的第一张地图" : "留意地图与 HUD 的反馈",
+        body: inLobby
+          ? "选择一个房间进入世界，前几步只需要专注于移动、招募和第一场战斗。"
+          : "左侧地图、右侧 HUD 和底部时间线会给出下一步决策线索，这就是新手阶段最重要的三个面板。",
+        detailLines: inLobby
+          ? [
+              "房间进入后会直接落在世界地图。",
+              "优先观察可移动格子、附近资源点和可交互建筑。",
+              "如果你已经熟悉流程，现在可以直接跳过剩余引导。"
+            ]
+          : [
+              "先用安全操作熟悉移动反馈，再尝试资源采集或建筑互动。",
+              "PVP 新手保护仍然生效，先把开局节奏跑顺。",
+              "如果你是回流玩家，可以直接跳过剩余引导。"
+            ],
+        primaryLabel: busy ? "同步中..." : "继续",
+        ...(busy ? {} : { secondaryLabel: "跳过引导" }),
+        busy
+      };
+    }
+
+    return {
+      badge: "最终确认",
+      stepLabel,
+      title: "完成引导后解锁每日任务",
+      body: "最后一步会关闭引导遮罩，并按正常账户节奏开放每日任务板。",
+      detailLines: [
+        "每日任务会在账号快照里持续可见，不会因重连丢失。",
+        "如果你愿意，也可以现在跳过并直接开始正常游玩。",
+        "完成后重新进入大厅或刷新资料都会保持已完成状态。"
+      ],
+      primaryLabel: busy ? "同步中..." : "完成引导",
+      ...(busy ? {} : { secondaryLabel: "跳过引导" }),
+      busy
+    };
+  }
+
+  private async submitTutorialProgress(action: TutorialProgressAction): Promise<void> {
+    if (this.tutorialProgressInFlight || !this.authToken) {
+      return;
+    }
+
+    this.tutorialProgressInFlight = true;
+    this.renderView();
+    try {
+      const profile = await resolveVeilRootRuntime().updateTutorialProgress(this.remoteUrl, this.roomId, action, {
+        authSession: {
+          token: this.authToken,
+          playerId: this.playerId,
+          displayName: this.displayName || this.playerId,
+          authMode: this.authMode,
+          ...(this.loginId ? { loginId: this.loginId } : {}),
+          source: "remote"
+        },
+        storage: this.readWebStorage()
+      });
+      this.commitAccountProfile(
+        {
+          ...profile,
+          recentBattleReplays: profile.recentBattleReplays.length > 0
+            ? profile.recentBattleReplays
+            : this.lobbyAccountProfile.recentBattleReplays
+        },
+        false
+      );
+      this.pushLog(
+        action.step == null
+          ? action.reason === "skip"
+            ? "已跳过新手引导。"
+            : "新手引导已完成，每日任务已解锁。"
+          : `新手引导推进至第 ${action.step} 步。`
+      );
+    } finally {
+      this.tutorialProgressInFlight = false;
+      this.renderView();
+    }
+  }
+
+  private async advanceTutorialFlow(): Promise<void> {
+    const tutorialStep = normalizeTutorialStep(this.lobbyAccountProfile.tutorialStep);
+    if (tutorialStep === null) {
+      return;
+    }
+
+    const nextStep = tutorialStep >= 3 ? null : tutorialStep + 1;
+    await this.submitTutorialProgress({
+      step: nextStep,
+      reason: nextStep == null ? "complete" : "advance"
+    });
+  }
+
+  private async skipTutorialFlow(): Promise<void> {
+    const tutorialStep = normalizeTutorialStep(this.lobbyAccountProfile.tutorialStep);
+    if (tutorialStep === null || tutorialStep < 2) {
+      return;
+    }
+
+    await this.submitTutorialProgress({
+      step: null,
+      reason: "skip"
+    });
   }
 
   private buildSettingsView(): CocosSettingsPanelView {

--- a/apps/cocos-client/assets/scripts/VeilTutorialOverlay.ts
+++ b/apps/cocos-client/assets/scripts/VeilTutorialOverlay.ts
@@ -1,0 +1,202 @@
+import { _decorator, Color, Component, Graphics, Label, Node, UITransform, view } from "cc";
+import { assignUiLayer } from "./cocos-ui-layer.ts";
+
+const { ccclass } = _decorator;
+
+export interface TutorialOverlayView {
+  title: string;
+  body: string;
+  detailLines: string[];
+  stepLabel: string;
+  primaryLabel: string;
+  secondaryLabel?: string;
+  badge?: string;
+  busy?: boolean;
+}
+
+@ccclass("ProjectVeilTutorialOverlay")
+export class VeilTutorialOverlay extends Component {
+  private currentView: TutorialOverlayView | null = null;
+  private onPrimaryAction: (() => void) | null = null;
+  private onSecondaryAction: (() => void) | null = null;
+
+  onLoad(): void {
+    this.node.on(Node.EventType.TOUCH_START, this.swallowPointerEvent, this);
+    this.node.on(Node.EventType.TOUCH_END, this.swallowPointerEvent, this);
+  }
+
+  onDestroy(): void {
+    this.node.off(Node.EventType.TOUCH_START, this.swallowPointerEvent, this);
+    this.node.off(Node.EventType.TOUCH_END, this.swallowPointerEvent, this);
+  }
+
+  configure(options: { onPrimaryAction?: (() => void) | null; onSecondaryAction?: (() => void) | null }): void {
+    this.onPrimaryAction = options.onPrimaryAction ?? null;
+    this.onSecondaryAction = options.onSecondaryAction ?? null;
+  }
+
+  render(viewModel: TutorialOverlayView | null): void {
+    this.currentView = viewModel;
+    this.node.active = Boolean(viewModel);
+    if (!viewModel) {
+      return;
+    }
+
+    assignUiLayer(this.node);
+    const rootTransform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const visibleSize = view.getVisibleSize();
+    rootTransform.setContentSize(visibleSize.width, visibleSize.height);
+
+    const overlayGraphics = this.node.getComponent(Graphics) ?? this.node.addComponent(Graphics);
+    overlayGraphics.clear();
+    overlayGraphics.fillColor = new Color(10, 16, 24, 190);
+    overlayGraphics.rect(-visibleSize.width / 2, -visibleSize.height / 2, visibleSize.width, visibleSize.height);
+    overlayGraphics.fill();
+
+    const cardWidth = Math.min(visibleSize.width - 56, 560);
+    const cardHeight = Math.min(visibleSize.height - 84, 410);
+    const cardNode = this.ensureChildNode(this.node, "Card");
+    assignUiLayer(cardNode);
+    cardNode.setPosition(0, 0, 2);
+    const cardTransform = cardNode.getComponent(UITransform) ?? cardNode.addComponent(UITransform);
+    cardTransform.setContentSize(cardWidth, cardHeight);
+    const cardGraphics = cardNode.getComponent(Graphics) ?? cardNode.addComponent(Graphics);
+    cardGraphics.clear();
+    cardGraphics.fillColor = new Color(22, 31, 44, 246);
+    cardGraphics.strokeColor = new Color(232, 205, 152, 164);
+    cardGraphics.lineWidth = 3;
+    cardGraphics.roundRect(-cardWidth / 2, -cardHeight / 2, cardWidth, cardHeight, 24);
+    cardGraphics.fill();
+    cardGraphics.stroke();
+
+    const badgeNode = this.ensureLabelNode(cardNode, "Badge", viewModel.badge ?? "新手引导", 18, new Color(244, 214, 150, 255));
+    badgeNode.setPosition(-cardWidth / 2 + 88, cardHeight / 2 - 32, 1);
+    const badgeTransform = badgeNode.getComponent(UITransform) ?? badgeNode.addComponent(UITransform);
+    badgeTransform.setContentSize(cardWidth - 72, 26);
+
+    const stepNode = this.ensureLabelNode(cardNode, "StepLabel", viewModel.stepLabel, 16, new Color(174, 196, 222, 255));
+    stepNode.setPosition(0, cardHeight / 2 - 66, 1);
+    const stepTransform = stepNode.getComponent(UITransform) ?? stepNode.addComponent(UITransform);
+    stepTransform.setContentSize(cardWidth - 72, 24);
+
+    const titleNode = this.ensureLabelNode(cardNode, "Title", viewModel.title, 30, new Color(247, 248, 251, 255));
+    titleNode.setPosition(0, cardHeight / 2 - 112, 1);
+    const titleTransform = titleNode.getComponent(UITransform) ?? titleNode.addComponent(UITransform);
+    titleTransform.setContentSize(cardWidth - 72, 40);
+
+    const bodyNode = this.ensureLabelNode(cardNode, "Body", viewModel.body, 20, new Color(222, 229, 239, 255));
+    bodyNode.setPosition(0, cardHeight / 2 - 170, 1);
+    const bodyTransform = bodyNode.getComponent(UITransform) ?? bodyNode.addComponent(UITransform);
+    bodyTransform.setContentSize(cardWidth - 84, 84);
+
+    const detailsNode = this.ensureLabelNode(
+      cardNode,
+      "Details",
+      viewModel.detailLines.map((line) => `• ${line}`).join("\n"),
+      17,
+      new Color(193, 205, 220, 255)
+    );
+    detailsNode.setPosition(0, 2, 1);
+    const detailsTransform = detailsNode.getComponent(UITransform) ?? detailsNode.addComponent(UITransform);
+    detailsTransform.setContentSize(cardWidth - 96, 138);
+
+    const primaryButton = this.ensureButton(cardNode, "PrimaryButton", () => {
+      if (!this.currentView?.busy) {
+        this.onPrimaryAction?.();
+      }
+    });
+    primaryButton.setPosition(viewModel.secondaryLabel ? 86 : 0, -cardHeight / 2 + 46, 1);
+    this.renderButton(primaryButton, 180, 54, viewModel.primaryLabel, !viewModel.busy, "primary");
+
+    const secondaryButton = this.ensureButton(cardNode, "SecondaryButton", () => {
+      if (!this.currentView?.busy) {
+        this.onSecondaryAction?.();
+      }
+    });
+    secondaryButton.active = Boolean(viewModel.secondaryLabel);
+    if (viewModel.secondaryLabel) {
+      secondaryButton.setPosition(-110, -cardHeight / 2 + 46, 1);
+      this.renderButton(secondaryButton, 148, 54, viewModel.secondaryLabel, !viewModel.busy, "secondary");
+    }
+  }
+
+  private swallowPointerEvent(): void {
+    return;
+  }
+
+  private ensureChildNode(parent: Node, name: string): Node {
+    const child = parent.getChildByName(name) ?? new Node(name);
+    child.parent = parent;
+    return child;
+  }
+
+  private ensureLabelNode(parent: Node, name: string, text: string, fontSize: number, color: Color): Node {
+    const node = this.ensureChildNode(parent, name);
+    assignUiLayer(node);
+    const label = node.getComponent(Label) ?? node.addComponent(Label);
+    label.string = text;
+    label.fontSize = fontSize;
+    label.lineHeight = fontSize + 8;
+    label.horizontalAlign = 1;
+    label.verticalAlign = 1;
+    label.enableWrapText = true;
+    label.color = color;
+    return node;
+  }
+
+  private ensureButton(parent: Node, name: string, onClick: () => void): Node {
+    const node = this.ensureChildNode(parent, name);
+    assignUiLayer(node);
+    if (!node.getComponent(UITransform)) {
+      node.addComponent(UITransform);
+    }
+    if (!(node as Node & { __veilTutorialButtonBound?: boolean }).__veilTutorialButtonBound) {
+      node.on(Node.EventType.TOUCH_END, () => {
+        onClick();
+      });
+      (node as Node & { __veilTutorialButtonBound?: boolean }).__veilTutorialButtonBound = true;
+    }
+    return node;
+  }
+
+  private renderButton(
+    buttonNode: Node,
+    width: number,
+    height: number,
+    labelText: string,
+    enabled: boolean,
+    tone: "primary" | "secondary"
+  ): void {
+    const transform = buttonNode.getComponent(UITransform) ?? buttonNode.addComponent(UITransform);
+    transform.setContentSize(width, height);
+    const graphics = buttonNode.getComponent(Graphics) ?? buttonNode.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor =
+      tone === "primary"
+        ? enabled
+          ? new Color(205, 148, 54, 255)
+          : new Color(112, 102, 92, 220)
+        : enabled
+          ? new Color(52, 68, 92, 232)
+          : new Color(55, 60, 68, 220);
+    graphics.strokeColor = tone === "primary" ? new Color(255, 227, 182, 220) : new Color(206, 218, 236, 140);
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 16);
+    graphics.fill();
+    graphics.stroke();
+
+    const labelNode = this.ensureChildNode(buttonNode, "Label");
+    assignUiLayer(labelNode);
+    labelNode.setPosition(0, 0, 1);
+    const labelTransform = labelNode.getComponent(UITransform) ?? labelNode.addComponent(UITransform);
+    labelTransform.setContentSize(width - 12, height - 8);
+    const label = labelNode.getComponent(Label) ?? labelNode.addComponent(Label);
+    label.string = labelText;
+    label.fontSize = 18;
+    label.lineHeight = 24;
+    label.horizontalAlign = 1;
+    label.verticalAlign = 1;
+    label.enableWrapText = false;
+    label.color = enabled ? new Color(249, 251, 255, 255) : new Color(214, 214, 214, 220);
+  }
+}

--- a/apps/cocos-client/assets/scripts/VeilTutorialOverlay.ts.meta
+++ b/apps/cocos-client/assets/scripts/VeilTutorialOverlay.ts.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "4.0.24",
+  "importer": "typescript",
+  "imported": true,
+  "uuid": "d8bc0f6d-2d43-4a11-a64c-f7f44b7bc863",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -23,7 +23,8 @@ import {
   type PlayerProgressionSnapshot,
   type PlayerBattleReplayQuery,
   type PlayerBattleReplaySummary,
-  type PlayerAchievementProgress
+  type PlayerAchievementProgress,
+  type TutorialProgressAction
 } from "./project-shared/index.ts";
 import { detectCocosRuntimePlatform } from "./cocos-runtime-platform.ts";
 
@@ -97,6 +98,8 @@ interface PlayerAccountApiPayload extends AuthSessionApiPayload {
     achievements?: Partial<PlayerAchievementProgress>[];
     recentEventLog?: Partial<EventLogEntry>[];
     recentBattleReplays?: Partial<PlayerBattleReplaySummary>[];
+    tutorialStep?: number | null;
+    dailyQuestBoard?: PlayerAccountReadModel["dailyQuestBoard"];
     loginId?: string;
     credentialBoundAt?: string;
     lastRoomId?: string;
@@ -425,6 +428,8 @@ function asCocosPlayerAccountProfile(
     achievements: account?.achievements,
     recentEventLog: account?.recentEventLog,
     recentBattleReplays: account?.recentBattleReplays,
+    tutorialStep: account?.tutorialStep,
+    dailyQuestBoard: account?.dailyQuestBoard,
     ...(battleReportCenter ? { battleReportCenter } : {}),
     loginId: normalizeLoginId(account?.loginId),
     credentialBoundAt: account?.credentialBoundAt,
@@ -520,6 +525,42 @@ export async function postCocosPlayerReferral(
       ...(options.storage !== undefined ? { storage: options.storage } : {})
     }
   )) as PlayerReferralApiPayload;
+}
+
+export async function updateCocosTutorialProgress(
+  remoteUrl: string,
+  roomId: string,
+  action: TutorialProgressAction,
+  options: {
+    authSession: CocosStoredAuthSession;
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "removeItem"> | null;
+  }
+): Promise<CocosPlayerAccountProfile> {
+  const payload = (await fetchCocosAuthJson(
+    remoteUrl,
+    `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/tutorial-progress`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(action)
+    },
+    options.authSession,
+    {
+      ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+      ...(options.storage !== undefined ? { storage: options.storage } : {})
+    }
+  )) as PlayerAccountApiPayload;
+
+  return asCocosPlayerAccountProfile(
+    payload.account?.playerId?.trim() || options.authSession.playerId,
+    roomId,
+    "remote",
+    payload.account,
+    options.authSession.displayName
+  );
 }
 
 function applyDailyClaimToProfile(

--- a/apps/cocos-client/assets/scripts/project-shared/daily-quests.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/daily-quests.ts
@@ -1,0 +1,126 @@
+import type { EventLogEntry } from "./event-log.ts";
+
+export type DailyQuestId = "daily_explore_frontier" | "daily_battle_victory" | "daily_resource_run";
+export type DailyQuestMetric = "hero_moves" | "battle_wins" | "resource_collections";
+
+export interface DailyQuestReward {
+  gems: number;
+  gold: number;
+}
+
+export interface DailyQuestDefinition {
+  id: DailyQuestId;
+  title: string;
+  description: string;
+  metric: DailyQuestMetric;
+  target: number;
+  reward: DailyQuestReward;
+}
+
+export interface DailyQuestProgress {
+  id: DailyQuestId;
+  title: string;
+  description: string;
+  target: number;
+  current: number;
+  completed: boolean;
+  claimed: boolean;
+  reward: DailyQuestReward;
+}
+
+export interface DailyQuestBoard {
+  enabled: boolean;
+  cycleKey?: string;
+  resetAt?: string;
+  availableClaims: number;
+  pendingRewards: DailyQuestReward;
+  quests: DailyQuestProgress[];
+}
+
+const DAILY_QUEST_DEFINITIONS: DailyQuestDefinition[] = [
+  {
+    id: "daily_explore_frontier",
+    title: "侦察前线",
+    description: "完成 3 次探索移动。",
+    metric: "hero_moves",
+    target: 3,
+    reward: { gems: 3, gold: 40 }
+  },
+  {
+    id: "daily_battle_victory",
+    title: "凯旋号角",
+    description: "取得 1 场战斗胜利。",
+    metric: "battle_wins",
+    target: 1,
+    reward: { gems: 5, gold: 60 }
+  },
+  {
+    id: "daily_resource_run",
+    title: "补给回收",
+    description: "完成 2 次资源收集。",
+    metric: "resource_collections",
+    target: 2,
+    reward: { gems: 2, gold: 35 }
+  }
+];
+
+export function createEmptyDailyQuestReward(): DailyQuestReward {
+  return { gems: 0, gold: 0 };
+}
+
+export function normalizeDailyQuestBoard(board?: Partial<DailyQuestBoard> | null): DailyQuestBoard | undefined {
+  if (board?.enabled !== true) {
+    return undefined;
+  }
+
+  const definitions = new Map(DAILY_QUEST_DEFINITIONS.map((definition) => [definition.id, definition] as const));
+  const quests = (board.quests ?? [])
+    .map((quest) => {
+      const definition = quest?.id ? definitions.get(quest.id) : undefined;
+      if (!definition) {
+        return null;
+      }
+
+      const current = Math.max(0, Math.min(definition.target, Math.floor(quest.current ?? 0)));
+      const completed = current >= definition.target || quest.completed === true;
+      return {
+        id: definition.id,
+        title: definition.title,
+        description: definition.description,
+        target: definition.target,
+        current,
+        completed,
+        claimed: quest.claimed === true,
+        reward: { ...definition.reward }
+      } satisfies DailyQuestProgress;
+    })
+    .filter((quest): quest is DailyQuestProgress => Boolean(quest));
+
+  const pendingRewards = quests.reduce(
+    (totals, quest) => {
+      if (!quest.completed || quest.claimed) {
+        return totals;
+      }
+
+      totals.gems += quest.reward.gems;
+      totals.gold += quest.reward.gold;
+      return totals;
+    },
+    createEmptyDailyQuestReward()
+  );
+
+  return {
+    enabled: true,
+    ...(board.cycleKey ? { cycleKey: String(board.cycleKey) } : {}),
+    ...(board.resetAt ? { resetAt: String(board.resetAt) } : {}),
+    availableClaims: quests.filter((quest) => quest.completed && !quest.claimed).length,
+    pendingRewards,
+    quests
+  };
+}
+
+export function normalizeDailyQuestEvents(
+  events: Pick<EventLogEntry, "id" | "worldEventType" | "description">[]
+): Pick<EventLogEntry, "id" | "worldEventType" | "description">[] {
+  return events;
+}

--- a/apps/cocos-client/assets/scripts/project-shared/daily-quests.ts.meta
+++ b/apps/cocos-client/assets/scripts/project-shared/daily-quests.ts.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "4.0.24",
+  "importer": "typescript",
+  "imported": true,
+  "uuid": "f5e42409-c0cb-4eb0-8df4-342f4197b5ce",
+  "files": [],
+  "subMetas": {},
+  "userData": {}
+}

--- a/apps/cocos-client/assets/scripts/project-shared/index.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/index.ts
@@ -15,4 +15,5 @@ export * from "./map-sync.ts";
 export * from "./models.ts";
 export * from "./protocol.ts";
 export * from "./player-account.ts";
+export * from "./tutorial.ts";
 export * from "./world-config.ts";

--- a/apps/cocos-client/assets/scripts/project-shared/player-account.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/player-account.ts
@@ -8,8 +8,10 @@ import {
   type EventLogEntry,
   type PlayerAchievementProgress
 } from "./event-log.ts";
+import { normalizeDailyQuestBoard, type DailyQuestBoard } from "./daily-quests.ts";
 import { normalizePlayerBattleReplaySummaries, type PlayerBattleReplaySummary } from "./battle-replay.ts";
 import type { ResourceLedger } from "./models.ts";
+import { normalizeTutorialStep } from "./tutorial.ts";
 
 const DEFAULT_ELO_RATING = 1000;
 
@@ -29,6 +31,8 @@ export interface PlayerAccountReadModel {
   recentEventLog: EventLogEntry[];
   recentBattleReplays?: PlayerBattleReplaySummary[];
   battleReportCenter?: PlayerBattleReportCenter;
+  dailyQuestBoard?: DailyQuestBoard;
+  tutorialStep?: number | null;
   loginId?: string;
   credentialBoundAt?: string;
   privacyConsentAt?: string;
@@ -48,6 +52,8 @@ export interface PlayerAccountReadModelInput {
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
   battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
+  dailyQuestBoard?: Partial<DailyQuestBoard> | null | undefined;
+  tutorialStep?: number | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
   privacyConsentAt?: string | undefined;
@@ -69,6 +75,8 @@ export function normalizePlayerAccountReadModel(
   const lastSeenAt = account?.lastSeenAt?.trim();
   const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
   const recentBattleReplays = normalizePlayerBattleReplaySummaries(account?.recentBattleReplays);
+  const dailyQuestBoard = normalizeDailyQuestBoard(account?.dailyQuestBoard);
+  const tutorialStep = normalizeTutorialStep(account?.tutorialStep);
 
   return {
     playerId,
@@ -89,6 +97,8 @@ export function normalizePlayerAccountReadModel(
       replays: recentBattleReplays,
       eventLog: recentEventLog
     }),
+    ...(dailyQuestBoard ? { dailyQuestBoard } : {}),
+    ...(account?.tutorialStep !== undefined ? { tutorialStep } : {}),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(privacyConsentAt ? { privacyConsentAt } : {}),

--- a/apps/cocos-client/assets/scripts/project-shared/protocol.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/protocol.ts
@@ -2,6 +2,10 @@ import type { BattleAction, BattleState, MovementPlan, Vec2, WorldAction, WorldE
 import type { PlayerWorldViewPayload } from "./map-sync.ts";
 
 export type SessionStateReason = "surrender" | "afk_forfeit" | "normal" | (string & {});
+export interface TutorialProgressAction {
+  step: number | null;
+  reason?: "advance" | "skip" | "complete";
+}
 export interface FeatureFlags {
   quest_system_enabled: boolean;
   battle_pass_enabled: boolean;
@@ -59,6 +63,11 @@ export type ClientMessage =
       targetPlayerId: string;
       reason: PlayerReportReason;
       description?: string;
+    }
+  | {
+      type: "tutorial.progress";
+      requestId: string;
+      action: TutorialProgressAction;
     };
 
 export type ServerMessage =

--- a/apps/cocos-client/assets/scripts/project-shared/tutorial.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/tutorial.ts
@@ -1,0 +1,42 @@
+import type { PlayerBattleReplaySummary } from "./battle-replay.ts";
+
+export const DEFAULT_TUTORIAL_STEP = 1;
+export const MIN_SKIP_TUTORIAL_STEP = 2;
+export const NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES = 5;
+export const STANDARD_MATCHMAKING_MAX_RATING_GAP = 200;
+export const PROTECTED_MATCHMAKING_MAX_RATING_GAP = 500;
+export const TOP_TIER_MATCHMAKING_RATING = 1500;
+
+export function normalizeTutorialStep(value?: number | null): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = Math.floor(value);
+  return Number.isFinite(normalized) && normalized > 0 ? normalized : DEFAULT_TUTORIAL_STEP;
+}
+
+export function isTutorialComplete(tutorialStep?: number | null): boolean {
+  return normalizeTutorialStep(tutorialStep) === null;
+}
+
+export function canSkipTutorial(tutorialStep?: number | null): boolean {
+  const normalized = normalizeTutorialStep(tutorialStep);
+  return normalized !== null && normalized >= MIN_SKIP_TUTORIAL_STEP;
+}
+
+export function countTrackedPvpMatches(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null,
+  limit = NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES
+): number {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  return (replays ?? []).filter((replay) => replay?.battleKind === "hero").slice(0, safeLimit).length;
+}
+
+export function countRemainingProtectedPvpMatches(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null,
+  limit = NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES
+): number {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  return Math.max(0, safeLimit - countTrackedPvpMatches(replays, safeLimit));
+}

--- a/apps/cocos-client/test/cocos-veil-root.test.ts
+++ b/apps/cocos-client/test/cocos-veil-root.test.ts
@@ -532,6 +532,46 @@ test("VeilRoot cancelLobbyMatchmaking stops polling and clears the queue state",
   assert.match(String(root.lobbyStatus), /已取消当前匹配队列/);
 });
 
+test("VeilRoot persists tutorial progression through the remote account profile flow", async () => {
+  const root = createVeilRootHarness();
+  root.sessionSource = "remote";
+  root.authMode = "account";
+  root.authToken = "tutorial.token";
+  root.playerId = "tutorial-player";
+  root.displayName = "雾幕新兵";
+  root.lobbyAccountProfile = {
+    ...root.lobbyAccountProfile,
+    playerId: "tutorial-player",
+    displayName: "雾幕新兵",
+    recentBattleReplays: [],
+    source: "remote",
+    tutorialStep: 1
+  };
+
+  const actions: Array<{ step: number | null; reason?: string }> = [];
+  installVeilRootRuntime({
+    updateTutorialProgress: async (_remoteUrl, _roomId, action) => {
+      actions.push(action);
+      return {
+        ...root.lobbyAccountProfile,
+        recentBattleReplays: [],
+        source: "remote",
+        tutorialStep: action.step
+      };
+    }
+  });
+
+  assert.ok(root.buildTutorialOverlayView());
+  await root.advanceTutorialFlow();
+  assert.deepEqual(actions[0], { step: 2, reason: "advance" });
+  assert.equal(root.lobbyAccountProfile.tutorialStep, 2);
+
+  await root.skipTutorialFlow();
+  assert.deepEqual(actions[1], { step: null, reason: "skip" });
+  assert.equal(root.lobbyAccountProfile.tutorialStep ?? null, null);
+  assert.equal(root.buildTutorialOverlayView(), null);
+});
+
 test("VeilRoot onDestroy stops matchmaking polling to avoid timer leaks", () => {
   const root = createVeilRootHarness();
   let pollStops = 0;

--- a/apps/server/src/matchmaking.ts
+++ b/apps/server/src/matchmaking.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  countRemainingProtectedPvpMatches,
   createMatchmakingHeroSnapshot,
   estimateMatchmakingWaitSeconds,
   normalizeEloRating,
@@ -793,7 +794,8 @@ export function registerMatchmakingRoutes(
         playerId: authSession.playerId,
         heroSnapshot: createMatchmakingHeroSnapshot(hero),
         rating: normalizeEloRating(account.eloRating),
-        enqueuedAt: new Date().toISOString()
+        enqueuedAt: new Date().toISOString(),
+        protectedPvpMatchesRemaining: countRemainingProtectedPvpMatches(account.recentBattleReplays)
       }));
       sendJson(response, 200, queued);
     } catch (error) {

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -1,5 +1,6 @@
 import {
   appendEventLogEntries,
+  DEFAULT_TUTORIAL_STEP,
   getEquipmentDefinition,
   normalizeEloRating,
   normalizeEventLogEntries,
@@ -299,6 +300,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       recentEventLog: existing?.recentEventLog ?? [],
       recentBattleReplays: existing?.recentBattleReplays ?? [],
       ...(existing?.dailyDungeonState ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) } : {}),
+      ...(existing?.tutorialStep !== undefined ? { tutorialStep: existing.tutorialStep } : { tutorialStep: DEFAULT_TUTORIAL_STEP }),
       ...(input.lastRoomId?.trim()
         ? { lastRoomId: input.lastRoomId.trim() }
         : existing?.lastRoomId
@@ -1070,6 +1072,11 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
           : {}
         : existing.dailyDungeonState
           ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) }
+          : {}),
+      ...(patch.tutorialStep !== undefined
+        ? { tutorialStep: patch.tutorialStep }
+        : existing.tutorialStep !== undefined
+          ? { tutorialStep: existing.tutorialStep }
           : {}),
       ...(patch.dailyPlayMinutes !== undefined ? { dailyPlayMinutes: Math.max(0, Math.floor(patch.dailyPlayMinutes ?? 0)) } : existing.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
       ...(patch.lastPlayDate !== undefined ? (patch.lastPlayDate ? { lastPlayDate: patch.lastPlayDate.trim() } : {}) : existing.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { createPool, type Pool, type PoolConnection, type ResultSetHeader, type RowDataPacket } from "mysql2/promise";
 import {
   appendEventLogEntries,
+  DEFAULT_TUTORIAL_STEP,
   getEquipmentDefinition,
   getTierForRating,
   appendPlayerBattleReplaySummaries,
@@ -201,6 +202,7 @@ interface PlayerAccountRow extends RowDataPacket {
   recent_event_log_json: string | EventLogEntry[] | null;
   recent_battle_replays_json: string | PlayerBattleReplaySummary[] | null;
   daily_dungeon_state_json: string | PlayerAccountSnapshot["dailyDungeonState"] | null;
+  tutorial_step: number | null;
   last_room_id: string | null;
   last_seen_at: Date | string | null;
   login_id: string | null;
@@ -532,6 +534,7 @@ export interface PlayerAccountProgressPatch {
   recentEventLog?: Partial<EventLogEntry>[] | null;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null;
   dailyDungeonState?: PlayerAccountSnapshot["dailyDungeonState"] | null;
+  tutorialStep?: number | null;
   dailyPlayMinutes?: number | null;
   lastPlayDate?: string | null;
   loginStreak?: number | null;
@@ -1166,6 +1169,7 @@ function normalizePlayerAccountSnapshot(account: {
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
   dailyDungeonState?: PlayerAccountSnapshot["dailyDungeonState"] | null | undefined;
+  tutorialStep?: number | null | undefined;
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
   loginId?: string | null | undefined;
@@ -1214,6 +1218,7 @@ function normalizePlayerAccountSnapshot(account: {
       recentEventLog: account.recentEventLog,
       recentBattleReplays: appendPlayerBattleReplaySummaries([], account.recentBattleReplays),
       dailyDungeonState: account.dailyDungeonState,
+      tutorialStep: account.tutorialStep,
       lastRoomId: account.lastRoomId,
       lastSeenAt: account.lastSeenAt,
       loginId: account.loginId ? normalizePlayerLoginId(account.loginId) : undefined,
@@ -1514,6 +1519,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   recent_event_log_json LONGTEXT NULL,
   recent_battle_replays_json LONGTEXT NULL,
   daily_dungeon_state_json LONGTEXT NULL,
+  tutorial_step INT NULL DEFAULT NULL,
   last_room_id VARCHAR(191) NULL,
   last_seen_at DATETIME NULL DEFAULT NULL,
   login_id VARCHAR(40) NULL,
@@ -1881,6 +1887,24 @@ SET @veil_player_accounts_daily_dungeon_sql := IF(
 PREPARE veil_player_accounts_daily_dungeon_stmt FROM @veil_player_accounts_daily_dungeon_sql;
 EXECUTE veil_player_accounts_daily_dungeon_stmt;
 DEALLOCATE PREPARE veil_player_accounts_daily_dungeon_stmt;
+
+SET @veil_player_accounts_tutorial_step_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'tutorial_step'
+);
+
+SET @veil_player_accounts_tutorial_step_sql := IF(
+  @veil_player_accounts_tutorial_step_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`tutorial_step\` INT NULL DEFAULT NULL AFTER \`daily_dungeon_state_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_tutorial_step_stmt FROM @veil_player_accounts_tutorial_step_sql;
+EXECUTE veil_player_accounts_tutorial_step_stmt;
+DEALLOCATE PREPARE veil_player_accounts_tutorial_step_stmt;
 
 SET @veil_player_accounts_last_room_exists := (
   SELECT COUNT(*)
@@ -2709,6 +2733,7 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
       row.daily_dungeon_state_json != null
         ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["dailyDungeonState"]>>(row.daily_dungeon_state_json)
         : undefined,
+    ...(row.tutorial_step != null ? { tutorialStep: row.tutorial_step } : {}),
     ...(row.display_name ? { displayName: row.display_name } : {}),
     ...(row.last_room_id ? { lastRoomId: row.last_room_id } : {}),
     ...(row.login_id ? { loginId: row.login_id } : {}),
@@ -2990,9 +3015,10 @@ async function savePlayerAccounts(
          ,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         tutorial_step,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(display_name, VALUES(display_name)),
          elo_rating = COALESCE(elo_rating, VALUES(elo_rating)),
@@ -3008,6 +3034,7 @@ async function savePlayerAccounts(
          recent_event_log_json = COALESCE(recent_event_log_json, VALUES(recent_event_log_json)),
          recent_battle_replays_json = COALESCE(recent_battle_replays_json, VALUES(recent_battle_replays_json)),
          daily_dungeon_state_json = COALESCE(daily_dungeon_state_json, VALUES(daily_dungeon_state_json)),
+         tutorial_step = COALESCE(tutorial_step, VALUES(tutorial_step)),
          login_streak = VALUES(login_streak),
          version = version + 1`,
       [
@@ -3026,6 +3053,7 @@ async function savePlayerAccounts(
         JSON.stringify(normalizedAccount.recentEventLog),
         JSON.stringify(normalizedAccount.recentBattleReplays),
         JSON.stringify(normalizedAccount.dailyDungeonState ?? null),
+        normalizedAccount.tutorialStep,
         normalizeLoginStreak(normalizedAccount.loginStreak)
       ]
     );
@@ -3266,6 +3294,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         tutorial_step,
          last_room_id,
          last_seen_at,
          login_id,
@@ -3322,6 +3351,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         tutorial_step,
          last_room_id,
          last_seen_at,
          login_id,
@@ -3462,6 +3492,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         tutorial_step,
          last_room_id,
          last_seen_at,
          login_id,
@@ -3612,10 +3643,11 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         tutorial_step,
          last_room_id,
          last_seen_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(?, display_name),
          last_room_id = COALESCE(?, last_room_id),
@@ -3637,6 +3669,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(normalizeEventLogEntries()),
         JSON.stringify(appendPlayerBattleReplaySummaries([], [])),
         JSON.stringify(null),
+        DEFAULT_TUTORIAL_STEP,
         lastRoomId,
         lastSeenAt,
         explicitDisplayName,
@@ -3657,6 +3690,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         achievements: normalizeAchievementProgress(),
         recentEventLog: normalizeEventLogEntries(),
         recentBattleReplays: appendPlayerBattleReplaySummaries([], []),
+        tutorialStep: DEFAULT_TUTORIAL_STEP,
         ...(lastRoomId ? { lastRoomId } : {}),
         lastSeenAt: lastSeenAt.toISOString()
       })
@@ -4964,12 +4998,13 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         tutorial_step,
          last_room_id,
          last_seen_at,
          phone_number,
          phone_number_bound_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = VALUES(avatar_url),
@@ -4985,6 +5020,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json = VALUES(recent_event_log_json),
          recent_battle_replays_json = VALUES(recent_battle_replays_json),
          daily_dungeon_state_json = COALESCE(daily_dungeon_state_json, VALUES(daily_dungeon_state_json)),
+         tutorial_step = COALESCE(tutorial_step, VALUES(tutorial_step)),
          last_room_id = VALUES(last_room_id),
          phone_number = VALUES(phone_number),
          phone_number_bound_at = VALUES(phone_number_bound_at),
@@ -5007,6 +5043,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.recentEventLog),
         JSON.stringify(nextAccount.recentBattleReplays),
         JSON.stringify(nextAccount.dailyDungeonState ?? null),
+        nextAccount.tutorialStep,
         nextAccount.lastRoomId ?? null,
         existing.lastSeenAt ? new Date(existing.lastSeenAt) : null,
         nextAccount.phoneNumber ?? null,
@@ -5050,6 +5087,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
       recentBattleReplays: patch.recentBattleReplays ?? existing.recentBattleReplays,
       dailyDungeonState: patch.dailyDungeonState ?? existing.dailyDungeonState,
+      tutorialStep: patch.tutorialStep !== undefined ? patch.tutorialStep : existing.tutorialStep,
       dailyPlayMinutes:
         patch.dailyPlayMinutes !== undefined ? normalizeDailyPlayMinutes(patch.dailyPlayMinutes) : existing.dailyPlayMinutes,
       lastPlayDate:
@@ -5084,6 +5122,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         tutorial_step,
          last_room_id,
          last_seen_at,
          age_verified,
@@ -5092,7 +5131,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_play_date,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = COALESCE(avatar_url, VALUES(avatar_url)),
@@ -5109,6 +5148,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json = VALUES(recent_event_log_json),
          recent_battle_replays_json = VALUES(recent_battle_replays_json),
          daily_dungeon_state_json = VALUES(daily_dungeon_state_json),
+         tutorial_step = VALUES(tutorial_step),
          last_room_id = VALUES(last_room_id),
          last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
          age_verified = VALUES(age_verified),
@@ -5134,6 +5174,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.recentEventLog),
         JSON.stringify(nextAccount.recentBattleReplays),
         JSON.stringify(nextAccount.dailyDungeonState ?? null),
+        nextAccount.tutorialStep,
         nextAccount.lastRoomId ?? null,
         existing.lastSeenAt ? new Date(existing.lastSeenAt) : null,
         nextAccount.ageVerified === true ? 1 : 0,
@@ -5184,6 +5225,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         tutorial_step,
          last_room_id,
          last_seen_at,
          login_id,

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -4,13 +4,17 @@ import {
   applyBattleReplayPlaybackCommand,
   buildPlayerBattleReportCenter,
   buildPlayerProgressionSnapshot,
+  canSkipTutorial,
+  DEFAULT_TUTORIAL_STEP,
   findPlayerBattleReplaySummary,
   getAchievementDefinitions,
+  isTutorialComplete,
   normalizeAchievementProgressQuery,
   normalizeEventLogQuery,
   queryPlayerBattleReplaySummaries,
   queryAchievementProgress,
   queryEventLogEntries,
+  type TutorialProgressAction,
   type PlayerBattleReplaySummary
 } from "../../../packages/shared/src/index";
 import {
@@ -310,7 +314,34 @@ async function withDailyQuestBoard(
 
   return {
     ...account,
-    dailyQuestBoard: await loadDailyQuestBoard(store, account, new Date(), enabled)
+    dailyQuestBoard: await loadDailyQuestBoard(
+      store,
+      account,
+      new Date(),
+      enabled && isTutorialComplete(account.tutorialStep)
+    )
+  };
+}
+
+function normalizeTutorialProgressAction(input: unknown, currentStep?: number | null): TutorialProgressAction {
+  const raw = input as Partial<TutorialProgressAction> | null | undefined;
+  const reason =
+    raw?.reason === "skip" || raw?.reason === "complete" || raw?.reason === "advance" ? raw.reason : "advance";
+  const step = raw?.step == null ? null : Math.floor(raw.step);
+
+  if (step !== null && (!Number.isFinite(step) || step <= 0)) {
+    throw new Error("tutorial_progress_invalid_step");
+  }
+  if (reason === "skip" && !canSkipTutorial(currentStep)) {
+    throw new Error("tutorial_skip_locked");
+  }
+  if (reason === "advance" && step === null) {
+    throw new Error("tutorial_progress_invalid_step");
+  }
+
+  return {
+    step,
+    reason
   };
 }
 
@@ -498,6 +529,7 @@ function createLocalModeAccount(input: {
     achievements: [],
     recentEventLog: [],
     recentBattleReplays: [],
+    tutorialStep: null,
     ...(avatarUrl ? { avatarUrl } : {}),
     ...(lastRoomId ? { lastRoomId } : {}),
     ...(loginId ? { loginId } : {}),
@@ -912,7 +944,20 @@ export function registerPlayerAccountRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
-      const board = await loadDailyQuestBoard(store, account, new Date(), featureFlags.quest_system_enabled);
+      const board = await loadDailyQuestBoard(
+        store,
+        account,
+        new Date(),
+        featureFlags.quest_system_enabled && isTutorialComplete(account.tutorialStep)
+      );
+      if (!board.enabled) {
+        sendJson(response, 409, {
+          claimed: false,
+          reason: "tutorial_incomplete",
+          dailyQuestBoard: board
+        });
+        return;
+      }
       const quest = board.quests.find((item) => item.id === definition.id);
 
       if (!quest) {
@@ -972,7 +1017,12 @@ export function registerPlayerAccountRoutes(
         claimed: true,
         questId: definition.id,
         reward: definition.reward,
-        dailyQuestBoard: await loadDailyQuestBoard(store, nextAccount, new Date(), featureFlags.quest_system_enabled)
+        dailyQuestBoard: await loadDailyQuestBoard(
+          store,
+          nextAccount,
+          new Date(),
+          featureFlags.quest_system_enabled && isTutorialComplete(nextAccount.tutorialStep)
+        )
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
@@ -1006,9 +1056,90 @@ export function registerPlayerAccountRoutes(
           displayName: authSession.displayName
         }));
       sendJson(response, 200, {
-        dailyQuestBoard: await loadDailyQuestBoard(store, account, new Date(), featureFlags.quest_system_enabled)
+        dailyQuestBoard: await loadDailyQuestBoard(
+          store,
+          account,
+          new Date(),
+          featureFlags.quest_system_enabled && isTutorialComplete(account.tutorialStep)
+        )
       });
     } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/player-accounts/me/tutorial-progress", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 200, {
+        account: withBattleReportCenter(
+          createLocalModeAccount({
+            playerId: authSession.playerId,
+            displayName: authSession.displayName,
+            ...(authSession.loginId ? { loginId: authSession.loginId } : {})
+          })
+        )
+      });
+      return;
+    }
+
+    try {
+      const featureFlags = resolveFeatureFlagsForPlayer(authSession.playerId);
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      const action = normalizeTutorialProgressAction(
+        await readJsonBody(request),
+        account.tutorialStep ?? DEFAULT_TUTORIAL_STEP
+      );
+      const nextAccount = await store.savePlayerAccountProgress(account.playerId, {
+        tutorialStep: action.step
+      });
+
+      emitAnalyticsEvent("tutorial_step", {
+        playerId: account.playerId,
+        roomId: account.lastRoomId ?? "lobby",
+        payload: {
+          stepId:
+            action.step == null
+              ? action.reason === "skip"
+                ? "tutorial_skipped"
+                : "tutorial_completed"
+              : `step_${action.step}`,
+          status: action.reason === "skip" ? "skipped" : action.step == null ? "completed" : "active"
+        }
+      });
+
+      sendJson(response, 200, {
+        action,
+        account: await withDailyQuestBoard(withBattleReportCenter(nextAccount), store, featureFlags.quest_system_enabled)
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === "tutorial_skip_locked") {
+        sendJson(response, 409, {
+          error: {
+            code: "tutorial_skip_locked",
+            message: "Tutorial skip unlocks after the initial onboarding step"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "tutorial_progress_invalid_step") {
+        sendJson(response, 400, {
+          error: {
+            code: "tutorial_progress_invalid_step",
+            message: "Tutorial progress payload is invalid"
+          }
+        });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });
@@ -1791,7 +1922,12 @@ export function registerPlayerAccountRoutes(
         }));
       sendJson(response, 200, {
         ...toProgressionResponse(account, parseLimit(request)),
-        dailyQuestBoard: await loadDailyQuestBoard(store, account, new Date(), featureFlags.quest_system_enabled),
+        dailyQuestBoard: await loadDailyQuestBoard(
+          store,
+          account,
+          new Date(),
+          featureFlags.quest_system_enabled && isTutorialComplete(account.tutorialStep)
+        ),
         campaign: toCampaignResponse(account),
         dailyDungeon: toDailyDungeonResponse(account)
       });

--- a/apps/server/test/matchmaking-routes.test.ts
+++ b/apps/server/test/matchmaking-routes.test.ts
@@ -233,6 +233,78 @@ test("matchmaking routes enqueue, match, report status, and dequeue cleanly", as
   assert.equal(dequeueOnePayload.status, "idle");
 });
 
+test("matchmaking keeps protected new players out of top-tier opponents", async (t) => {
+  const store = createMemoryRoomSnapshotStore();
+  await store.save(
+    "room-alpha",
+    createSnapshot("room-alpha", [createHero("player-1", "hero-1"), createHero("player-2", "hero-2")])
+  );
+  await store.savePlayerAccountProgress("player-1", {
+    lastRoomId: "room-alpha",
+    recentBattleReplays: []
+  });
+  await store.savePlayerAccountProgress("player-2", {
+    lastRoomId: "room-alpha",
+    eloRating: 1600,
+    recentBattleReplays: [
+      {
+        id: "pvp-1",
+        roomId: "room-alpha",
+        playerId: "player-2",
+        battleId: "battle-1",
+        battleKind: "hero",
+        playerCamp: "attacker",
+        heroId: "hero-2",
+        opponentHeroId: "hero-1",
+        startedAt: "2026-03-28T08:00:00.000Z",
+        completedAt: "2026-03-28T08:05:00.000Z",
+        initialState: {
+          id: "battle-1",
+          round: 1,
+          lanes: 1,
+          activeUnitId: "u-1",
+          turnOrder: ["u-1"],
+          units: {},
+          environment: [],
+          log: [],
+          rng: { seed: 1, cursor: 0 }
+        },
+        steps: [],
+        result: "attacker_victory"
+      }
+    ]
+  });
+
+  const port = 43100 + Math.floor(Math.random() * 1000);
+  const server = await startMatchmakingServer(store, port);
+  const protectedSession = issueGuestAuthSession({ playerId: "player-1", displayName: "One" });
+  const topTierSession = issueGuestAuthSession({ playerId: "player-2", displayName: "Two" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    resetMatchmakingService();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  await fetch(`http://127.0.0.1:${port}/api/matchmaking/enqueue`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${protectedSession.token}` }
+  });
+  await fetch(`http://127.0.0.1:${port}/api/matchmaking/enqueue`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${topTierSession.token}` }
+  });
+
+  const statusResponse = await fetch(`http://127.0.0.1:${port}/api/matchmaking/status`, {
+    headers: { Authorization: `Bearer ${protectedSession.token}` }
+  });
+  const statusPayload = (await statusResponse.json()) as { status: string };
+
+  assert.equal(statusResponse.status, 200);
+  assert.equal(statusPayload.status, "queued");
+});
+
 test("matchmaking enqueue prunes stale queue entries before adding new players", async (t) => {
   const store = createMemoryRoomSnapshotStore();
   await store.save(

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -28,6 +28,7 @@ import type {
 } from "../src/persistence";
 import type { RoomPersistenceSnapshot } from "../src/index";
 import {
+  DEFAULT_TUTORIAL_STEP,
   createDefaultHeroLoadout,
   createDefaultHeroProgression,
   queryEventLogEntries,
@@ -180,6 +181,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
       ...(existing?.campaignProgress ? { campaignProgress: structuredClone(existing.campaignProgress) } : {}),
       ...(existing?.dailyDungeonState ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) } : {}),
+      ...(existing?.tutorialStep !== undefined ? { tutorialStep: existing.tutorialStep } : { tutorialStep: DEFAULT_TUTORIAL_STEP }),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
@@ -559,6 +561,11 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
           : {}
         : existing.dailyDungeonState
           ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) }
+          : {}),
+      ...(patch.tutorialStep !== undefined
+        ? { tutorialStep: patch.tutorialStep }
+        : existing.tutorialStep !== undefined
+          ? { tutorialStep: existing.tutorialStep }
           : {}),
       ...(patch.dailyPlayMinutes !== undefined ? { dailyPlayMinutes: Math.max(0, Math.floor(patch.dailyPlayMinutes ?? 0)) } : existing.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
       ...(patch.lastPlayDate !== undefined ? (patch.lastPlayDate ? { lastPlayDate: patch.lastPlayDate.trim() } : {}) : existing.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
@@ -2944,6 +2951,9 @@ test("daily quest board derives same-day progress and ignores prior-day events",
     playerId: "daily-quest-player",
     displayName: "界碑斥候"
   });
+  await store.savePlayerAccountProgress("daily-quest-player", {
+    tutorialStep: null
+  });
   store.seedEventHistory("daily-quest-player", [
     {
       id: `daily-quest-player:${yesterdayStart}:hero.moved:1`,
@@ -3023,6 +3033,93 @@ test("daily quest board derives same-day progress and ignores prior-day events",
   );
 });
 
+test("tutorial progress gates daily quests until the player completes or skips onboarding", async (t) => {
+  const port = 44931 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  process.env.VEIL_DAILY_QUESTS_ENABLED = "true";
+  t.after(() => {
+    delete process.env.VEIL_DAILY_QUESTS_ENABLED;
+  });
+  await store.ensurePlayerAccount({
+    playerId: "tutorial-player",
+    displayName: "雾幕新兵"
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "tutorial-player",
+    displayName: "雾幕新兵"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const initialResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const initialPayload = (await initialResponse.json()) as {
+    account: {
+      tutorialStep?: number | null;
+      dailyQuestBoard?: { enabled: boolean };
+    };
+  };
+  assert.equal(initialResponse.status, 200);
+  assert.equal(initialPayload.account.tutorialStep, 1);
+  assert.equal(initialPayload.account.dailyQuestBoard?.enabled, false);
+
+  const lockedSkipResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/tutorial-progress`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      step: null,
+      reason: "skip"
+    })
+  });
+  assert.equal(lockedSkipResponse.status, 409);
+
+  const advanceResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/tutorial-progress`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      step: 2,
+      reason: "advance"
+    })
+  });
+  assert.equal(advanceResponse.status, 200);
+
+  const completeResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/tutorial-progress`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      step: null,
+      reason: "skip"
+    })
+  });
+  const completePayload = (await completeResponse.json()) as {
+    account: {
+      tutorialStep?: number | null;
+      dailyQuestBoard?: { enabled: boolean };
+    };
+  };
+  assert.equal(completeResponse.status, 200);
+  assert.equal(completePayload.account.tutorialStep ?? null, null);
+  assert.equal(completePayload.account.dailyQuestBoard?.enabled, true);
+
+  const account = await store.loadPlayerAccount("tutorial-player");
+  assert.equal(account?.tutorialStep ?? null, null);
+});
+
 test("daily quest claim grants rewards once and returns already_claimed on repeat", async (t) => {
   const port = 44932 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
@@ -3034,6 +3131,9 @@ test("daily quest claim grants rewards once and returns already_claimed on repea
   await store.ensurePlayerAccount({
     playerId: "daily-quest-claim",
     displayName: "白塔军需官"
+  });
+  await store.savePlayerAccountProgress("daily-quest-claim", {
+    tutorialStep: null
   });
   store.seedEventHistory("daily-quest-claim", [
     {

--- a/docs/mysql-persistence.sql
+++ b/docs/mysql-persistence.sql
@@ -77,6 +77,7 @@ CREATE TABLE IF NOT EXISTS `player_accounts` (
   recent_event_log_json LONGTEXT NULL,
   recent_battle_replays_json LONGTEXT NULL,
   daily_dungeon_state_json LONGTEXT NULL,
+  tutorial_step INT NULL DEFAULT NULL,
   last_room_id VARCHAR(191) NULL,
   last_seen_at DATETIME NULL DEFAULT NULL,
   login_id VARCHAR(40) NULL,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -22,4 +22,5 @@ export * from "./models.ts";
 export * from "./protocol.ts";
 export * from "./player-account.ts";
 export * from "./runtime-diagnostics.ts";
+export * from "./tutorial.ts";
 export * from "./world-config.ts";

--- a/packages/shared/src/matchmaking.ts
+++ b/packages/shared/src/matchmaking.ts
@@ -1,3 +1,8 @@
+import {
+  PROTECTED_MATCHMAKING_MAX_RATING_GAP,
+  STANDARD_MATCHMAKING_MAX_RATING_GAP,
+  TOP_TIER_MATCHMAKING_RATING
+} from "./tutorial.ts";
 import { getBattleBalanceConfig } from "./world-config";
 import type { HeroState } from "./models";
 
@@ -16,6 +21,7 @@ export interface MatchmakingRequest {
   heroSnapshot: MatchmakingHeroSnapshot;
   rating: number;
   enqueuedAt: string;
+  protectedPvpMatchesRemaining?: number;
 }
 
 export interface MatchResult {
@@ -75,8 +81,23 @@ export function normalizeMatchmakingRequest(input: Partial<MatchmakingRequest>):
       armyCount: normalizeFiniteInteger(heroSnapshot.armyCount, 0)
     },
     rating: normalizeEloRating(input.rating),
-    enqueuedAt: Number.isNaN(enqueuedAt.getTime()) ? new Date().toISOString() : enqueuedAt.toISOString()
+    enqueuedAt: Number.isNaN(enqueuedAt.getTime()) ? new Date().toISOString() : enqueuedAt.toISOString(),
+    protectedPvpMatchesRemaining: Math.max(0, Math.floor(input.protectedPvpMatchesRemaining ?? 0))
   };
+}
+
+function resolvePairRatingGapLimit(left: MatchmakingRequest, right: MatchmakingRequest): number {
+  return left.protectedPvpMatchesRemaining || right.protectedPvpMatchesRemaining
+    ? PROTECTED_MATCHMAKING_MAX_RATING_GAP
+    : STANDARD_MATCHMAKING_MAX_RATING_GAP;
+}
+
+function pairsIntoTopTierWhileProtected(left: MatchmakingRequest, right: MatchmakingRequest): boolean {
+  return (
+    (left.protectedPvpMatchesRemaining ?? 0) > 0 && normalizeEloRating(right.rating) >= TOP_TIER_MATCHMAKING_RATING
+  ) || (
+    (right.protectedPvpMatchesRemaining ?? 0) > 0 && normalizeEloRating(left.rating) >= TOP_TIER_MATCHMAKING_RATING
+  );
 }
 
 function waitingMillisFor(request: MatchmakingRequest, referenceTimeMs: number): number {
@@ -105,6 +126,9 @@ export function selectBestMatchPair(
       const left = requests[leftIndex]!;
       const right = requests[rightIndex]!;
       const ratingGap = Math.abs(normalizeEloRating(left.rating) - normalizeEloRating(right.rating));
+      if (ratingGap > resolvePairRatingGapLimit(left, right) || pairsIntoTopTierWhileProtected(left, right)) {
+        continue;
+      }
       const totalWait = waitingMillisFor(left, referenceTimeMs) + waitingMillisFor(right, referenceTimeMs);
       const oldestQueuedAt = Math.min(new Date(left.enqueuedAt).getTime(), new Date(right.enqueuedAt).getTime());
 

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -13,6 +13,7 @@ import { normalizeDailyQuestBoard, type DailyQuestBoard } from "./daily-quests.t
 import { normalizePlayerBattleReplaySummaries, type PlayerBattleReplaySummary } from "./battle-replay.ts";
 import { normalizeEloRating } from "./matchmaking.ts";
 import type { CampaignProgressState, DailyDungeonState, ResourceLedger } from "./models.ts";
+import { normalizeTutorialStep } from "./tutorial.ts";
 
 export type PlayerBanStatus = "none" | "temporary" | "permanent";
 
@@ -36,6 +37,7 @@ export interface PlayerAccountReadModel {
   dailyQuestBoard?: DailyQuestBoard;
   campaignProgress?: CampaignProgressState;
   dailyDungeonState?: DailyDungeonState;
+  tutorialStep?: number | null;
   loginId?: string;
   credentialBoundAt?: string;
   privacyConsentAt?: string;
@@ -72,6 +74,7 @@ export interface PlayerAccountReadModelInput {
   dailyQuestBoard?: Partial<DailyQuestBoard> | null | undefined;
   campaignProgress?: Partial<CampaignProgressState> | null | undefined;
   dailyDungeonState?: Partial<DailyDungeonState> | null | undefined;
+  tutorialStep?: number | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
   privacyConsentAt?: string | undefined;
@@ -133,6 +136,7 @@ export function normalizePlayerAccountReadModel(
   const dailyQuestBoard = normalizeDailyQuestBoard(account?.dailyQuestBoard);
   const campaignProgress = normalizeCampaignProgressState(account?.campaignProgress);
   const dailyDungeonState = normalizeDailyDungeonState(account?.dailyDungeonState);
+  const tutorialStep = normalizeTutorialStep(account?.tutorialStep);
 
   return {
     playerId,
@@ -161,6 +165,7 @@ export function normalizePlayerAccountReadModel(
     ...(dailyQuestBoard ? { dailyQuestBoard } : {}),
     ...(campaignProgress ? { campaignProgress } : {}),
     ...(dailyDungeonState ? { dailyDungeonState } : {}),
+    ...(account?.tutorialStep !== undefined ? { tutorialStep } : {}),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(privacyConsentAt ? { privacyConsentAt } : {}),

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -5,6 +5,11 @@ import type { RuntimeConfigBundle } from "./world-config.ts";
 
 export type SessionStateReason = "surrender" | "afk_forfeit" | "normal" | (string & {});
 
+export interface TutorialProgressAction {
+  step: number | null;
+  reason?: "advance" | "skip" | "complete";
+}
+
 export interface SessionStatePayload {
   world: PlayerWorldViewPayload;
   battle: BattleState | null;
@@ -55,6 +60,11 @@ export type ClientMessage =
       targetPlayerId: string;
       reason: PlayerReportReason;
       description?: string;
+    }
+  | {
+      type: "tutorial.progress";
+      requestId: string;
+      action: TutorialProgressAction;
     };
 
 export type ServerMessage =

--- a/packages/shared/src/tutorial.ts
+++ b/packages/shared/src/tutorial.ts
@@ -1,0 +1,42 @@
+import type { PlayerBattleReplaySummary } from "./battle-replay.ts";
+
+export const DEFAULT_TUTORIAL_STEP = 1;
+export const MIN_SKIP_TUTORIAL_STEP = 2;
+export const NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES = 5;
+export const STANDARD_MATCHMAKING_MAX_RATING_GAP = 200;
+export const PROTECTED_MATCHMAKING_MAX_RATING_GAP = 500;
+export const TOP_TIER_MATCHMAKING_RATING = 1500;
+
+export function normalizeTutorialStep(value?: number | null): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = Math.floor(value);
+  return Number.isFinite(normalized) && normalized > 0 ? normalized : DEFAULT_TUTORIAL_STEP;
+}
+
+export function isTutorialComplete(tutorialStep?: number | null): boolean {
+  return normalizeTutorialStep(tutorialStep) === null;
+}
+
+export function canSkipTutorial(tutorialStep?: number | null): boolean {
+  const normalized = normalizeTutorialStep(tutorialStep);
+  return normalized !== null && normalized >= MIN_SKIP_TUTORIAL_STEP;
+}
+
+export function countTrackedPvpMatches(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null,
+  limit = NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES
+): number {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  return (replays ?? []).filter((replay) => replay?.battleKind === "hero").slice(0, safeLimit).length;
+}
+
+export function countRemainingProtectedPvpMatches(
+  replays?: Partial<PlayerBattleReplaySummary>[] | null,
+  limit = NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES
+): number {
+  const safeLimit = Math.max(1, Math.floor(limit));
+  return Math.max(0, safeLimit - countTrackedPvpMatches(replays, safeLimit));
+}

--- a/packages/shared/test/matchmaking.test.ts
+++ b/packages/shared/test/matchmaking.test.ts
@@ -88,3 +88,38 @@ test("elo result applies symmetric rating changes using configured-style K facto
   assert.equal(result.loserRating, 984);
   assert.equal(estimateMatchmakingWaitSeconds(3), 30);
 });
+
+test("matchmaking rejects large rating gaps once players leave protected onboarding matches", () => {
+  const requests = [
+    createRequest("player-1", 1000, "2026-03-28T08:00:00.000Z"),
+    createRequest("player-2", 1305, "2026-03-28T08:01:00.000Z")
+  ];
+
+  assert.equal(selectBestMatchPair(requests, new Date("2026-03-28T08:20:00.000Z")), null);
+});
+
+test("matchmaking allows a wider gap during the first protected pvp matches", () => {
+  const requests = [
+    {
+      ...createRequest("player-1", 1000, "2026-03-28T08:00:00.000Z"),
+      protectedPvpMatchesRemaining: 5
+    },
+    createRequest("player-2", 1305, "2026-03-28T08:01:00.000Z")
+  ];
+
+  const selection = selectBestMatchPair(requests, new Date("2026-03-28T08:20:00.000Z"));
+  assert.ok(selection);
+  assert.equal(selection?.ratingGap, 305);
+});
+
+test("matchmaking keeps protected onboarding players out of top-tier pairings", () => {
+  const requests = [
+    {
+      ...createRequest("player-1", 1200, "2026-03-28T08:00:00.000Z"),
+      protectedPvpMatchesRemaining: 4
+    },
+    createRequest("player-2", 1520, "2026-03-28T08:01:00.000Z")
+  ];
+
+  assert.equal(selectBestMatchPair(requests, new Date("2026-03-28T08:20:00.000Z")), null);
+});

--- a/scripts/migrations/0017_add_tutorial_progress.ts
+++ b/scripts/migrations/0017_add_tutorial_progress.ts
@@ -1,0 +1,24 @@
+import {
+  dropColumnIfExists,
+  ensureColumnExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import { MYSQL_PLAYER_ACCOUNT_TABLE } from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureColumnExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_TABLE,
+    "tutorial_step",
+    "`tutorial_step` INT NULL DEFAULT NULL AFTER `daily_dungeon_state_json`"
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await dropColumnIfExists(connection, database, MYSQL_PLAYER_ACCOUNT_TABLE, "tutorial_step");
+}


### PR DESCRIPTION
## Summary
- add persisted tutorial progress to shared account models, protocol, in-memory/MySQL persistence, and a migration for `player_accounts.tutorial_step`
- add a scoped `/api/player-accounts/me/tutorial-progress` flow, lock daily quests until tutorial completion or skip, and apply first-5-match PvP protection in matchmaking
- add a Cocos `VeilTutorialOverlay` integrated with `VeilRoot` plus client API wiring so onboarding survives reconnects and can be skipped after the initial step

## Validation
- `npm run typecheck:ci`
- `node --import tsx --test packages/shared/test/matchmaking.test.ts`
- `node --import tsx --test apps/server/test/player-account-routes.test.ts`
- `node --import tsx --test apps/server/test/matchmaking-routes.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-veil-root.test.ts`

Closes #863