### PR TITLE
feat: add daily quest rotation live ops config

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/daily-quests.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/daily-quests.ts
@@ -1,6 +1,6 @@
 import type { EventLogEntry } from "./event-log.ts";
 
-export type DailyQuestId = "daily_explore_frontier" | "daily_battle_victory" | "daily_resource_run";
+export type DailyQuestId = string;
 export type DailyQuestMetric = "hero_moves" | "battle_wins" | "resource_collections";
 
 export interface DailyQuestReward {
@@ -37,33 +37,6 @@ export interface DailyQuestBoard {
   quests: DailyQuestProgress[];
 }
 
-const DAILY_QUEST_DEFINITIONS: DailyQuestDefinition[] = [
-  {
-    id: "daily_explore_frontier",
-    title: "侦察前线",
-    description: "完成 3 次探索移动。",
-    metric: "hero_moves",
-    target: 3,
-    reward: { gems: 3, gold: 40 }
-  },
-  {
-    id: "daily_battle_victory",
-    title: "凯旋号角",
-    description: "取得 1 场战斗胜利。",
-    metric: "battle_wins",
-    target: 1,
-    reward: { gems: 5, gold: 60 }
-  },
-  {
-    id: "daily_resource_run",
-    title: "补给回收",
-    description: "完成 2 次资源收集。",
-    metric: "resource_collections",
-    target: 2,
-    reward: { gems: 2, gold: 35 }
-  }
-];
-
 export function createEmptyDailyQuestReward(): DailyQuestReward {
   return { gems: 0, gold: 0 };
 }
@@ -73,25 +46,27 @@ export function normalizeDailyQuestBoard(board?: Partial<DailyQuestBoard> | null
     return undefined;
   }
 
-  const definitions = new Map(DAILY_QUEST_DEFINITIONS.map((definition) => [definition.id, definition] as const));
   const quests = (board.quests ?? [])
     .map((quest) => {
-      const definition = quest?.id ? definitions.get(quest.id) : undefined;
-      if (!definition) {
+      if (!quest?.id || typeof quest.title !== "string" || typeof quest.description !== "string") {
         return null;
       }
 
-      const current = Math.max(0, Math.min(definition.target, Math.floor(quest.current ?? 0)));
-      const completed = current >= definition.target || quest.completed === true;
+      const target = Math.max(1, Math.floor(quest.target ?? 0));
+      const current = Math.max(0, Math.min(target, Math.floor(quest.current ?? 0)));
+      const completed = current >= target || quest.completed === true;
       return {
-        id: definition.id,
-        title: definition.title,
-        description: definition.description,
-        target: definition.target,
+        id: String(quest.id),
+        title: quest.title,
+        description: quest.description,
+        target,
         current,
         completed,
         claimed: quest.claimed === true,
-        reward: { ...definition.reward }
+        reward: {
+          gems: Math.max(0, Math.floor(quest.reward?.gems ?? 0)),
+          gold: Math.max(0, Math.floor(quest.reward?.gold ?? 0))
+        }
       } satisfies DailyQuestProgress;
     })
     .filter((quest): quest is DailyQuestProgress => Boolean(quest));

--- a/apps/server/src/daily-quest-rotations.ts
+++ b/apps/server/src/daily-quest-rotations.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs";
+import path from "node:path";
+import dailyQuestRotationsDocument from "../../../configs/daily-quest-rotations.json";
+import {
+  DEFAULT_DAILY_QUEST_ROTATION_CONFIG,
+  findNextDailyQuestRotation,
+  normalizeDailyQuestRotationConfigDocument,
+  selectDailyQuestRotationForDate,
+  summarizeDailyQuestRotation,
+  validateDailyQuestRotationConfigDocument,
+  type DailyQuestRotationConfigDocument,
+  type DailyQuestRotationDefinition,
+  type FeatureFlags
+} from "../../../packages/shared/src/index";
+
+const DEFAULT_DAILY_QUEST_ROTATIONS_PATH = path.resolve(process.cwd(), "configs/daily-quest-rotations.json");
+
+interface DailyQuestRotationRuntimeDependencies {
+  readFileSync(filePath: string, encoding: BufferEncoding): string;
+}
+
+const defaultDailyQuestRotationRuntimeDependencies: DailyQuestRotationRuntimeDependencies = {
+  readFileSync: (filePath, encoding) => fs.readFileSync(filePath, encoding)
+};
+
+let dailyQuestRotationRuntimeDependencies = defaultDailyQuestRotationRuntimeDependencies;
+let cachedDailyQuestRotationConfig: DailyQuestRotationConfigDocument | null = null;
+
+export interface DailyQuestRotationPreview {
+  generatedAt: string;
+  activeDate: string;
+  enabledFlags: string[];
+  activeRotation: {
+    id: string;
+    label: string;
+    summary: string;
+  } | null;
+  nextRotation: {
+    id: string;
+    label: string;
+    startsOn: string;
+    summary: string;
+  } | null;
+}
+
+function getEnabledFlagKeys(flags?: Partial<FeatureFlags> | null): string[] {
+  return Object.entries(flags ?? {})
+    .filter(([, value]) => value === true)
+    .map(([key]) => key)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function parseDailyQuestRotationOverride(rawValue: string | undefined): DailyQuestRotationConfigDocument | null {
+  if (!rawValue?.trim()) {
+    return null;
+  }
+
+  try {
+    return normalizeDailyQuestRotationConfigDocument(JSON.parse(rawValue) as DailyQuestRotationConfigDocument);
+  } catch (error) {
+    console.warn("[DailyQuestRotations] Failed to parse VEIL_DAILY_QUEST_ROTATIONS_JSON override", error);
+    return null;
+  }
+}
+
+function validateOrFallback(document: DailyQuestRotationConfigDocument, sourceLabel: string): DailyQuestRotationConfigDocument {
+  const issues = validateDailyQuestRotationConfigDocument(document);
+  if (!issues.length) {
+    return document;
+  }
+
+  console.warn(
+    `[DailyQuestRotations] Falling back after invalid config from ${sourceLabel}: ${issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ")}`
+  );
+  return normalizeDailyQuestRotationConfigDocument(DEFAULT_DAILY_QUEST_ROTATION_CONFIG);
+}
+
+export function configureDailyQuestRotationRuntimeDependencies(
+  overrides: Partial<DailyQuestRotationRuntimeDependencies>
+): void {
+  dailyQuestRotationRuntimeDependencies = {
+    ...dailyQuestRotationRuntimeDependencies,
+    ...overrides
+  };
+}
+
+export function resetDailyQuestRotationRuntimeDependencies(): void {
+  dailyQuestRotationRuntimeDependencies = defaultDailyQuestRotationRuntimeDependencies;
+}
+
+export function clearCachedDailyQuestRotationConfig(): void {
+  cachedDailyQuestRotationConfig = null;
+}
+
+export function loadDailyQuestRotationConfig(env: NodeJS.ProcessEnv = process.env): DailyQuestRotationConfigDocument {
+  const override = parseDailyQuestRotationOverride(env.VEIL_DAILY_QUEST_ROTATIONS_JSON);
+  if (override) {
+    return validateOrFallback(override, "VEIL_DAILY_QUEST_ROTATIONS_JSON");
+  }
+
+  if (cachedDailyQuestRotationConfig) {
+    return cachedDailyQuestRotationConfig;
+  }
+
+  const configuredPath = env.VEIL_DAILY_QUEST_ROTATIONS_PATH?.trim() || DEFAULT_DAILY_QUEST_ROTATIONS_PATH;
+
+  try {
+    const raw = dailyQuestRotationRuntimeDependencies.readFileSync(configuredPath, "utf8");
+    cachedDailyQuestRotationConfig = validateOrFallback(
+      normalizeDailyQuestRotationConfigDocument(JSON.parse(raw) as DailyQuestRotationConfigDocument),
+      configuredPath
+    );
+  } catch (error) {
+    console.warn(`[DailyQuestRotations] Falling back to bundled defaults after failing to load ${configuredPath}`, error);
+    cachedDailyQuestRotationConfig = normalizeDailyQuestRotationConfigDocument(
+      dailyQuestRotationsDocument as DailyQuestRotationConfigDocument
+    );
+  }
+
+  return cachedDailyQuestRotationConfig;
+}
+
+export function resolveDailyQuestRotation(
+  now = new Date(),
+  flags?: Partial<FeatureFlags> | null,
+  env: NodeJS.ProcessEnv = process.env
+): DailyQuestRotationDefinition | null {
+  return selectDailyQuestRotationForDate(loadDailyQuestRotationConfig(env), now, getEnabledFlagKeys(flags));
+}
+
+export function findNextScheduledDailyQuestRotation(
+  now = new Date(),
+  flags?: Partial<FeatureFlags> | null,
+  env: NodeJS.ProcessEnv = process.env
+) {
+  return findNextDailyQuestRotation(loadDailyQuestRotationConfig(env), now, getEnabledFlagKeys(flags));
+}
+
+export function createDailyQuestRotationPreview(
+  now = new Date(),
+  flags?: Partial<FeatureFlags> | null,
+  env: NodeJS.ProcessEnv = process.env
+): DailyQuestRotationPreview {
+  const activeRotation = resolveDailyQuestRotation(now, flags, env);
+  const nextRotation = findNextScheduledDailyQuestRotation(now, flags, env);
+
+  return {
+    generatedAt: now.toISOString(),
+    activeDate: now.toISOString().slice(0, 10),
+    enabledFlags: getEnabledFlagKeys(flags),
+    activeRotation: activeRotation
+      ? {
+          id: activeRotation.id,
+          label: activeRotation.label,
+          summary: summarizeDailyQuestRotation(activeRotation)
+        }
+      : null,
+    nextRotation: nextRotation
+      ? {
+          id: nextRotation.rotation.id,
+          label: nextRotation.rotation.label,
+          startsOn: nextRotation.dateKey,
+          summary: summarizeDailyQuestRotation(nextRotation.rotation)
+        }
+      : null
+  };
+}

--- a/apps/server/src/daily-quests.ts
+++ b/apps/server/src/daily-quests.ts
@@ -1,15 +1,13 @@
 import {
   buildDailyQuestBoard,
   createEmptyDailyQuestReward,
-  getDailyQuestDefinitions,
   type DailyQuestBoard,
   type DailyQuestDefinition,
-  type DailyQuestId,
-  type EventLogEntry
+  type EventLogEntry,
+  type FeatureFlags
 } from "../../../packages/shared/src/index";
 import type { PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
-
-const DAILY_QUEST_ID_SET = new Set(getDailyQuestDefinitions().map((definition) => definition.id));
+import { resolveDailyQuestRotation } from "./daily-quest-rotations";
 
 export function readDailyQuestFeatureEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const normalized = env.VEIL_DAILY_QUESTS_ENABLED?.trim().toLowerCase();
@@ -27,7 +25,7 @@ export function getDailyQuestResetAt(cycleKey = getDailyQuestCycleKey()): string
 export function createDailyQuestClaimEventLogEntry(
   playerId: string,
   roomId: string,
-  definition: DailyQuestDefinition,
+  definition: Pick<DailyQuestDefinition, "id" | "title" | "reward">,
   timestamp: string,
   sequence = 1
 ): EventLogEntry {
@@ -49,8 +47,14 @@ export async function loadDailyQuestBoard(
   store: RoomSnapshotStore,
   account: PlayerAccountSnapshot,
   now = new Date(),
-  enabled = readDailyQuestFeatureEnabled()
+  options:
+    | boolean
+    | {
+        enabled: boolean;
+        featureFlags?: Partial<FeatureFlags>;
+      } = readDailyQuestFeatureEnabled()
 ): Promise<DailyQuestBoard> {
+  const enabled = typeof options === "boolean" ? options : options.enabled;
   if (!enabled) {
     return {
       enabled: false,
@@ -64,19 +68,13 @@ export async function loadDailyQuestBoard(
   const history = await store.loadPlayerEventHistory(account.playerId, {
     since: `${cycleKey}T00:00:00.000Z`
   });
+  const activeRotation =
+    resolveDailyQuestRotation(now, typeof options === "boolean" ? undefined : options.featureFlags) ?? null;
 
   return buildDailyQuestBoard(history.items, {
     enabled: true,
     cycleKey,
-    resetAt: getDailyQuestResetAt(cycleKey)
+    resetAt: getDailyQuestResetAt(cycleKey),
+    ...(activeRotation ? { definitions: activeRotation.quests } : {})
   });
-}
-
-export function findDailyQuestDefinition(questId?: string | null): DailyQuestDefinition | null {
-  const normalizedQuestId = questId?.trim() as DailyQuestId | undefined;
-  if (!normalizedQuestId || !DAILY_QUEST_ID_SET.has(normalizedQuestId)) {
-    return null;
-  }
-
-  return getDailyQuestDefinitions().find((definition) => definition.id === normalizedQuestId) ?? null;
 }

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -19,7 +19,6 @@ import {
 } from "../../../packages/shared/src/index";
 import {
   createDailyQuestClaimEventLogEntry,
-  findDailyQuestDefinition,
   loadDailyQuestBoard
 } from "./daily-quests";
 import { resolveBattlePassConfig } from "./battle-pass";
@@ -926,17 +925,6 @@ export function registerPlayerAccountRoutes(
       return;
     }
 
-    const definition = findDailyQuestDefinition(request.params.questId);
-    if (!definition) {
-      sendJson(response, 404, {
-        error: {
-          code: "daily_quest_not_found",
-          message: "Daily quest was not found"
-        }
-      });
-      return;
-    }
-
     try {
       const account =
         (await store.loadPlayerAccount(authSession.playerId)) ??
@@ -948,7 +936,10 @@ export function registerPlayerAccountRoutes(
         store,
         account,
         new Date(),
-        featureFlags.quest_system_enabled && isTutorialComplete(account.tutorialStep)
+        {
+          enabled: featureFlags.quest_system_enabled && isTutorialComplete(account.tutorialStep),
+          featureFlags
+        }
       );
       if (!board.enabled) {
         sendJson(response, 409, {
@@ -958,7 +949,7 @@ export function registerPlayerAccountRoutes(
         });
         return;
       }
-      const quest = board.quests.find((item) => item.id === definition.id);
+      const quest = board.quests.find((item) => item.id === request.params.questId);
 
       if (!quest) {
         sendJson(response, 404, {
@@ -992,14 +983,14 @@ export function registerPlayerAccountRoutes(
       const claimEntry = createDailyQuestClaimEventLogEntry(
         account.playerId,
         account.lastRoomId ?? "daily-quests",
-        definition,
+        quest,
         timestamp
       );
       const nextAccount = await store.savePlayerAccountProgress(account.playerId, {
-        gems: (account.gems ?? 0) + definition.reward.gems,
+        gems: (account.gems ?? 0) + quest.reward.gems,
         globalResources: {
           ...account.globalResources,
-          gold: (account.globalResources.gold ?? 0) + definition.reward.gold
+          gold: (account.globalResources.gold ?? 0) + quest.reward.gold
         },
         recentEventLog: appendEventLogEntries(account.recentEventLog, [claimEntry])
       });
@@ -1008,20 +999,23 @@ export function registerPlayerAccountRoutes(
         roomId: account.lastRoomId ?? "daily-quests",
         payload: {
           roomId: account.lastRoomId ?? "daily-quests",
-          questId: definition.id,
-          reward: definition.reward
+          questId: quest.id,
+          reward: quest.reward
         }
       });
 
       sendJson(response, 200, {
         claimed: true,
-        questId: definition.id,
-        reward: definition.reward,
+        questId: quest.id,
+        reward: quest.reward,
         dailyQuestBoard: await loadDailyQuestBoard(
           store,
           nextAccount,
           new Date(),
-          featureFlags.quest_system_enabled && isTutorialComplete(nextAccount.tutorialStep)
+          {
+            enabled: featureFlags.quest_system_enabled && isTutorialComplete(nextAccount.tutorialStep),
+            featureFlags
+          }
         )
       });
     } catch (error) {

--- a/configs/daily-quest-rotations.json
+++ b/configs/daily-quest-rotations.json
@@ -1,0 +1,183 @@
+{
+  "schemaVersion": 1,
+  "rotations": [
+    {
+      "id": "spring-weekday-patrol",
+      "label": "Spring Weekday Patrol",
+      "schedule": {
+        "startDate": "2026-04-01",
+        "endDate": "2026-04-30",
+        "weekdays": ["mon", "tue", "wed", "thu", "fri"]
+      },
+      "quests": [
+        {
+          "id": "daily_explore_frontier",
+          "title": "侦察前线",
+          "description": "完成 3 次探索移动。",
+          "metric": "hero_moves",
+          "target": 3,
+          "reward": {
+            "gems": 3,
+            "gold": 40
+          }
+        },
+        {
+          "id": "daily_resource_run",
+          "title": "补给回收",
+          "description": "完成 2 次资源收集。",
+          "metric": "resource_collections",
+          "target": 2,
+          "reward": {
+            "gems": 2,
+            "gold": 35
+          }
+        },
+        {
+          "id": "daily_battle_victory",
+          "title": "凯旋号角",
+          "description": "取得 1 场战斗胜利。",
+          "metric": "battle_wins",
+          "target": 1,
+          "reward": {
+            "gems": 5,
+            "gold": 60
+          }
+        }
+      ]
+    },
+    {
+      "id": "spring-weekend-surge",
+      "label": "Spring Weekend Surge",
+      "schedule": {
+        "startDate": "2026-04-01",
+        "endDate": "2026-04-30",
+        "weekdays": ["sun", "sat"]
+      },
+      "quests": [
+        {
+          "id": "daily_explore_frontier",
+          "title": "侦察前线",
+          "description": "完成 3 次探索移动。",
+          "metric": "hero_moves",
+          "target": 3,
+          "reward": {
+            "gems": 3,
+            "gold": 40
+          }
+        },
+        {
+          "id": "daily_battle_victory",
+          "title": "凯旋号角",
+          "description": "取得 1 场战斗胜利。",
+          "metric": "battle_wins",
+          "target": 1,
+          "reward": {
+            "gems": 5,
+            "gold": 60
+          }
+        },
+        {
+          "id": "daily_resource_run",
+          "title": "补给回收",
+          "description": "完成 2 次资源收集。",
+          "metric": "resource_collections",
+          "target": 2,
+          "reward": {
+            "gems": 2,
+            "gold": 35
+          }
+        }
+      ]
+    },
+    {
+      "id": "pve-launch-weekday",
+      "label": "PvE Launch Weekday Rotation",
+      "schedule": {
+        "startDate": "2026-05-01",
+        "endDate": "2026-05-31",
+        "weekdays": ["mon", "tue", "wed", "thu", "fri"],
+        "requiredFlags": ["pve_enabled"]
+      },
+      "quests": [
+        {
+          "id": "daily_explore_frontier",
+          "title": "远征探路",
+          "description": "完成 4 次探索移动。",
+          "metric": "hero_moves",
+          "target": 4,
+          "reward": {
+            "gems": 4,
+            "gold": 55
+          }
+        },
+        {
+          "id": "daily_battle_victory",
+          "title": "征战回响",
+          "description": "取得 2 场战斗胜利。",
+          "metric": "battle_wins",
+          "target": 2,
+          "reward": {
+            "gems": 8,
+            "gold": 85
+          }
+        },
+        {
+          "id": "daily_resource_run",
+          "title": "前线补给线",
+          "description": "完成 3 次资源收集。",
+          "metric": "resource_collections",
+          "target": 3,
+          "reward": {
+            "gems": 3,
+            "gold": 45
+          }
+        }
+      ]
+    },
+    {
+      "id": "pve-launch-weekend",
+      "label": "PvE Launch Weekend Rotation",
+      "schedule": {
+        "startDate": "2026-05-01",
+        "endDate": "2026-05-31",
+        "weekdays": ["sun", "sat"],
+        "requiredFlags": ["pve_enabled"]
+      },
+      "quests": [
+        {
+          "id": "daily_explore_frontier",
+          "title": "远征探路",
+          "description": "完成 4 次探索移动。",
+          "metric": "hero_moves",
+          "target": 4,
+          "reward": {
+            "gems": 4,
+            "gold": 55
+          }
+        },
+        {
+          "id": "daily_battle_victory",
+          "title": "征战回响",
+          "description": "取得 2 场战斗胜利。",
+          "metric": "battle_wins",
+          "target": 2,
+          "reward": {
+            "gems": 8,
+            "gold": 85
+          }
+        },
+        {
+          "id": "daily_resource_run",
+          "title": "前线补给线",
+          "description": "完成 3 次资源收集。",
+          "metric": "resource_collections",
+          "target": 3,
+          "reward": {
+            "gems": 3,
+            "gold": 45
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/output/daily-quest-rotation-preview.md
+++ b/output/daily-quest-rotation-preview.md
@@ -1,0 +1,25 @@
+# Daily Quest Rotation Preview
+
+Generated at: 2026-04-04T09:00:00.000Z
+Active date: 2026-04-04
+Enabled flags: tutorial_enabled
+
+## Active Rotation
+- Spring Weekend Surge [spring-weekend-surge]
+
+```text
+Spring Weekend Surge (2026-04-01 -> 2026-04-30 | sun, sat)
+- 侦察前线 [daily_explore_frontier] target=3 metric=hero_moves reward=3 gems/40 gold
+- 凯旋号角 [daily_battle_victory] target=1 metric=battle_wins reward=5 gems/60 gold
+- 补给回收 [daily_resource_run] target=2 metric=resource_collections reward=2 gems/35 gold
+```
+
+## Next Rotation
+- Spring Weekday Patrol [spring-weekday-patrol] starts 2026-04-06
+
+```text
+Spring Weekday Patrol (2026-04-01 -> 2026-04-30 | mon, tue, wed, thu, fri)
+- 侦察前线 [daily_explore_frontier] target=3 metric=hero_moves reward=3 gems/40 gold
+- 补给回收 [daily_resource_run] target=2 metric=resource_collections reward=2 gems/35 gold
+- 凯旋号角 [daily_battle_victory] target=1 metric=battle_wins reward=5 gems/60 gold
+```

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ops:codex-branches": "node --import tsx ./scripts/audit-codex-automation-branches.ts",
     "plan:validation:minimal": "node --import tsx ./scripts/minimal-validation-plan.ts",
     "demo:flow": "node --import tsx ./scripts/demo.ts",
+    "preview:daily-quest-rotation": "node --import tsx ./scripts/daily-quest-rotation-preview.ts",
     "validate:quickstart": "node ./scripts/validate-local-dev-quickstart.mjs",
     "validate:redis-scaling": "node --import tsx ./scripts/validate-redis-scaling.ts",
     "validate:e2e:fixtures": "node --import tsx ./scripts/validate-e2e-config-fixtures.ts",

--- a/packages/shared/src/daily-quest-rotation.ts
+++ b/packages/shared/src/daily-quest-rotation.ts
@@ -1,0 +1,534 @@
+const DAILY_QUEST_WEEKDAYS = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const;
+
+export type DailyQuestId = string;
+export type DailyQuestMetric = "hero_moves" | "battle_wins" | "resource_collections";
+export type DailyQuestWeekday = (typeof DAILY_QUEST_WEEKDAYS)[number];
+
+export interface DailyQuestReward {
+  gems: number;
+  gold: number;
+}
+
+export interface DailyQuestDefinition {
+  id: DailyQuestId;
+  title: string;
+  description: string;
+  metric: DailyQuestMetric;
+  target: number;
+  reward: DailyQuestReward;
+}
+
+export interface DailyQuestSchedule {
+  startDate?: string;
+  endDate?: string;
+  weekdays?: DailyQuestWeekday[];
+  requiredFlags?: string[];
+}
+
+export interface DailyQuestRotationDefinition {
+  id: string;
+  label: string;
+  schedule?: DailyQuestSchedule;
+  quests: DailyQuestDefinition[];
+}
+
+export interface DailyQuestRotationConfigDocument {
+  schemaVersion: 1;
+  rotations: DailyQuestRotationDefinition[];
+}
+
+export interface DailyQuestRotationValidationIssue {
+  path: string;
+  message: string;
+}
+
+export interface DailyQuestRotationSelection {
+  rotation: DailyQuestRotationDefinition;
+  dateKey: string;
+}
+
+const DEFAULT_DAILY_QUEST_DEFINITIONS: DailyQuestDefinition[] = [
+  {
+    id: "daily_explore_frontier",
+    title: "侦察前线",
+    description: "完成 3 次探索移动。",
+    metric: "hero_moves",
+    target: 3,
+    reward: { gems: 3, gold: 40 }
+  },
+  {
+    id: "daily_battle_victory",
+    title: "凯旋号角",
+    description: "取得 1 场战斗胜利。",
+    metric: "battle_wins",
+    target: 1,
+    reward: { gems: 5, gold: 60 }
+  },
+  {
+    id: "daily_resource_run",
+    title: "补给回收",
+    description: "完成 2 次资源收集。",
+    metric: "resource_collections",
+    target: 2,
+    reward: { gems: 2, gold: 35 }
+  }
+];
+
+export const DEFAULT_DAILY_QUEST_ROTATION_CONFIG: DailyQuestRotationConfigDocument = {
+  schemaVersion: 1,
+  rotations: [
+    {
+      id: "spring-weekday-patrol",
+      label: "Spring Weekday Patrol",
+      schedule: {
+        startDate: "2026-04-01",
+        endDate: "2026-04-30",
+        weekdays: ["mon", "tue", "wed", "thu", "fri"]
+      },
+      quests: [
+        {
+          id: "daily_explore_frontier",
+          title: "侦察前线",
+          description: "完成 3 次探索移动。",
+          metric: "hero_moves",
+          target: 3,
+          reward: { gems: 3, gold: 40 }
+        },
+        {
+          id: "daily_resource_run",
+          title: "补给回收",
+          description: "完成 2 次资源收集。",
+          metric: "resource_collections",
+          target: 2,
+          reward: { gems: 2, gold: 35 }
+        },
+        {
+          id: "daily_battle_victory",
+          title: "凯旋号角",
+          description: "取得 1 场战斗胜利。",
+          metric: "battle_wins",
+          target: 1,
+          reward: { gems: 5, gold: 60 }
+        }
+      ]
+    },
+    {
+      id: "spring-weekend-surge",
+      label: "Spring Weekend Surge",
+      schedule: {
+        startDate: "2026-04-01",
+        endDate: "2026-04-30",
+        weekdays: ["sun", "sat"]
+      },
+      quests: DEFAULT_DAILY_QUEST_DEFINITIONS
+    },
+    {
+      id: "pve-launch-weekday",
+      label: "PvE Launch Weekday Rotation",
+      schedule: {
+        startDate: "2026-05-01",
+        endDate: "2026-05-31",
+        weekdays: ["mon", "tue", "wed", "thu", "fri"],
+        requiredFlags: ["pve_enabled"]
+      },
+      quests: [
+        {
+          id: "daily_explore_frontier",
+          title: "远征探路",
+          description: "完成 4 次探索移动。",
+          metric: "hero_moves",
+          target: 4,
+          reward: { gems: 4, gold: 55 }
+        },
+        {
+          id: "daily_battle_victory",
+          title: "征战回响",
+          description: "取得 2 场战斗胜利。",
+          metric: "battle_wins",
+          target: 2,
+          reward: { gems: 8, gold: 85 }
+        },
+        {
+          id: "daily_resource_run",
+          title: "前线补给线",
+          description: "完成 3 次资源收集。",
+          metric: "resource_collections",
+          target: 3,
+          reward: { gems: 3, gold: 45 }
+        }
+      ]
+    },
+    {
+      id: "pve-launch-weekend",
+      label: "PvE Launch Weekend Rotation",
+      schedule: {
+        startDate: "2026-05-01",
+        endDate: "2026-05-31",
+        weekdays: ["sun", "sat"],
+        requiredFlags: ["pve_enabled"]
+      },
+      quests: [
+        {
+          id: "daily_explore_frontier",
+          title: "远征探路",
+          description: "完成 4 次探索移动。",
+          metric: "hero_moves",
+          target: 4,
+          reward: { gems: 4, gold: 55 }
+        },
+        {
+          id: "daily_battle_victory",
+          title: "征战回响",
+          description: "取得 2 场战斗胜利。",
+          metric: "battle_wins",
+          target: 2,
+          reward: { gems: 8, gold: 85 }
+        },
+        {
+          id: "daily_resource_run",
+          title: "前线补给线",
+          description: "完成 3 次资源收集。",
+          metric: "resource_collections",
+          target: 3,
+          reward: { gems: 3, gold: 45 }
+        }
+      ]
+    }
+  ]
+};
+
+const VALID_METRICS = new Set<DailyQuestMetric>(["hero_moves", "battle_wins", "resource_collections"]);
+const VALID_WEEKDAYS = new Set<DailyQuestWeekday>(DAILY_QUEST_WEEKDAYS);
+const MIN_TARGET = 1;
+const MAX_TARGET = 50;
+const MIN_REWARD = 0;
+const MAX_GEMS_REWARD = 25;
+const MAX_GOLD_REWARD = 500;
+const MAX_CONFLICT_SCAN_DAYS = 400;
+
+function cloneReward(reward: DailyQuestReward): DailyQuestReward {
+  return {
+    gems: reward.gems,
+    gold: reward.gold
+  };
+}
+
+export function cloneDailyQuestDefinition(definition: DailyQuestDefinition): DailyQuestDefinition {
+  return {
+    ...definition,
+    reward: cloneReward(definition.reward)
+  };
+}
+
+export function cloneDailyQuestRotation(rotation: DailyQuestRotationDefinition): DailyQuestRotationDefinition {
+  return {
+    ...rotation,
+    ...(rotation.schedule ? { schedule: { ...rotation.schedule, ...(rotation.schedule.weekdays ? { weekdays: [...rotation.schedule.weekdays] } : {}), ...(rotation.schedule.requiredFlags ? { requiredFlags: [...rotation.schedule.requiredFlags] } : {}) } } : {}),
+    quests: rotation.quests.map(cloneDailyQuestDefinition)
+  };
+}
+
+export function getDefaultDailyQuestDefinitions(): DailyQuestDefinition[] {
+  return DEFAULT_DAILY_QUEST_DEFINITIONS.map(cloneDailyQuestDefinition);
+}
+
+export function normalizeDailyQuestRotationConfigDocument(
+  input?: Partial<DailyQuestRotationConfigDocument> | null
+): DailyQuestRotationConfigDocument {
+  if (!input || !Array.isArray(input.rotations) || input.rotations.length === 0) {
+    return {
+      schemaVersion: 1,
+      rotations: DEFAULT_DAILY_QUEST_ROTATION_CONFIG.rotations.map(cloneDailyQuestRotation)
+    };
+  }
+
+  return {
+    schemaVersion: 1,
+    rotations: input.rotations
+      .filter((rotation): rotation is DailyQuestRotationDefinition => Boolean(rotation && typeof rotation === "object"))
+      .map((rotation, index) => ({
+        id: typeof rotation.id === "string" && rotation.id.trim() ? rotation.id.trim() : `rotation-${index + 1}`,
+        label: typeof rotation.label === "string" && rotation.label.trim() ? rotation.label.trim() : `Rotation ${index + 1}`,
+        ...(rotation.schedule
+          ? {
+              schedule: {
+                ...(typeof rotation.schedule.startDate === "string" && rotation.schedule.startDate.trim()
+                  ? { startDate: rotation.schedule.startDate.trim() }
+                  : {}),
+                ...(typeof rotation.schedule.endDate === "string" && rotation.schedule.endDate.trim()
+                  ? { endDate: rotation.schedule.endDate.trim() }
+                  : {}),
+                ...(Array.isArray(rotation.schedule.weekdays)
+                  ? {
+                      weekdays: rotation.schedule.weekdays
+                        .filter((weekday): weekday is DailyQuestWeekday => typeof weekday === "string")
+                        .map((weekday) => weekday.trim().toLowerCase() as DailyQuestWeekday)
+                    }
+                  : {}),
+                ...(Array.isArray(rotation.schedule.requiredFlags)
+                  ? {
+                      requiredFlags: rotation.schedule.requiredFlags
+                        .filter((flag): flag is string => typeof flag === "string")
+                        .map((flag) => flag.trim())
+                        .filter((flag) => flag.length > 0)
+                    }
+                  : {})
+              }
+            }
+          : {}),
+        quests: Array.isArray(rotation.quests)
+          ? rotation.quests
+              .filter((quest): quest is DailyQuestDefinition => Boolean(quest && typeof quest === "object"))
+              .map((quest) => ({
+                id: typeof quest.id === "string" && quest.id.trim() ? quest.id.trim() : "",
+                title: typeof quest.title === "string" ? quest.title : "",
+                description: typeof quest.description === "string" ? quest.description : "",
+                metric: VALID_METRICS.has(quest.metric) ? quest.metric : "hero_moves",
+                target: Number.isFinite(quest.target) ? Math.floor(quest.target) : 0,
+                reward: {
+                  gems: Number.isFinite(quest.reward?.gems) ? Math.floor(quest.reward.gems) : 0,
+                  gold: Number.isFinite(quest.reward?.gold) ? Math.floor(quest.reward.gold) : 0
+                }
+              }))
+          : []
+      }))
+  };
+}
+
+function isValidDateKey(value: string | undefined): boolean {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(`${value}T00:00:00.000Z`));
+}
+
+function getDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function normalizeFlagSet(enabledFlags: Iterable<string>): Set<string> {
+  return new Set(Array.from(enabledFlags, (flag) => String(flag).trim()).filter((flag) => flag.length > 0));
+}
+
+function scheduleAllowsDate(schedule: DailyQuestSchedule | undefined, dateKey: string, enabledFlags: Set<string>): boolean {
+  if (!schedule) {
+    return true;
+  }
+
+  if (schedule.startDate && dateKey < schedule.startDate) {
+    return false;
+  }
+
+  if (schedule.endDate && dateKey > schedule.endDate) {
+    return false;
+  }
+
+  if (schedule.weekdays?.length) {
+    const weekday = DAILY_QUEST_WEEKDAYS[new Date(`${dateKey}T00:00:00.000Z`).getUTCDay()];
+    if (!weekday || !schedule.weekdays.includes(weekday)) {
+      return false;
+    }
+  }
+
+  if (schedule.requiredFlags?.length) {
+    return schedule.requiredFlags.every((flag) => enabledFlags.has(flag));
+  }
+
+  return true;
+}
+
+export function validateDailyQuestRotationConfigDocument(
+  document: DailyQuestRotationConfigDocument
+): DailyQuestRotationValidationIssue[] {
+  const issues: DailyQuestRotationValidationIssue[] = [];
+  const rotationIds = new Set<string>();
+
+  for (const [rotationIndex, rotation] of document.rotations.entries()) {
+    const rotationPath = `rotations[${rotationIndex}]`;
+    if (!rotation.id.trim()) {
+      issues.push({ path: `${rotationPath}.id`, message: "Rotation id is required." });
+    } else if (rotationIds.has(rotation.id)) {
+      issues.push({ path: `${rotationPath}.id`, message: `Duplicate rotation id "${rotation.id}".` });
+    } else {
+      rotationIds.add(rotation.id);
+    }
+
+    if (!rotation.label.trim()) {
+      issues.push({ path: `${rotationPath}.label`, message: "Rotation label is required." });
+    }
+
+    if (!rotation.quests.length) {
+      issues.push({ path: `${rotationPath}.quests`, message: "Rotation must define at least one quest." });
+    }
+
+    if (rotation.schedule?.startDate && !isValidDateKey(rotation.schedule.startDate)) {
+      issues.push({ path: `${rotationPath}.schedule.startDate`, message: "startDate must use YYYY-MM-DD." });
+    }
+
+    if (rotation.schedule?.endDate && !isValidDateKey(rotation.schedule.endDate)) {
+      issues.push({ path: `${rotationPath}.schedule.endDate`, message: "endDate must use YYYY-MM-DD." });
+    }
+
+    if (
+      rotation.schedule?.startDate &&
+      rotation.schedule?.endDate &&
+      isValidDateKey(rotation.schedule.startDate) &&
+      isValidDateKey(rotation.schedule.endDate) &&
+      rotation.schedule.startDate > rotation.schedule.endDate
+    ) {
+      issues.push({ path: `${rotationPath}.schedule`, message: "startDate cannot be later than endDate." });
+    }
+
+    for (const [weekdayIndex, weekday] of rotation.schedule?.weekdays?.entries() ?? []) {
+      if (!VALID_WEEKDAYS.has(weekday)) {
+        issues.push({
+          path: `${rotationPath}.schedule.weekdays[${weekdayIndex}]`,
+          message: `Invalid weekday "${weekday}".`
+        });
+      }
+    }
+
+    const questIds = new Set<string>();
+    for (const [questIndex, quest] of rotation.quests.entries()) {
+      const questPath = `${rotationPath}.quests[${questIndex}]`;
+      if (!quest.id.trim()) {
+        issues.push({ path: `${questPath}.id`, message: "Quest id is required." });
+      } else if (questIds.has(quest.id)) {
+        issues.push({ path: `${questPath}.id`, message: `Duplicate quest id "${quest.id}" in rotation "${rotation.id}".` });
+      } else {
+        questIds.add(quest.id);
+      }
+
+      if (!quest.title.trim()) {
+        issues.push({ path: `${questPath}.title`, message: "Quest title is required." });
+      }
+      if (!quest.description.trim()) {
+        issues.push({ path: `${questPath}.description`, message: "Quest description is required." });
+      }
+      if (!VALID_METRICS.has(quest.metric)) {
+        issues.push({ path: `${questPath}.metric`, message: `Unsupported metric "${quest.metric}".` });
+      }
+      if (!Number.isInteger(quest.target) || quest.target < MIN_TARGET || quest.target > MAX_TARGET) {
+        issues.push({
+          path: `${questPath}.target`,
+          message: `Quest target must be an integer between ${MIN_TARGET} and ${MAX_TARGET}.`
+        });
+      }
+      if (!Number.isInteger(quest.reward.gems) || quest.reward.gems < MIN_REWARD || quest.reward.gems > MAX_GEMS_REWARD) {
+        issues.push({
+          path: `${questPath}.reward.gems`,
+          message: `Gem reward must be an integer between ${MIN_REWARD} and ${MAX_GEMS_REWARD}.`
+        });
+      }
+      if (!Number.isInteger(quest.reward.gold) || quest.reward.gold < MIN_REWARD || quest.reward.gold > MAX_GOLD_REWARD) {
+        issues.push({
+          path: `${questPath}.reward.gold`,
+          message: `Gold reward must be an integer between ${MIN_REWARD} and ${MAX_GOLD_REWARD}.`
+        });
+      }
+    }
+  }
+
+  for (let leftIndex = 0; leftIndex < document.rotations.length - 1; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < document.rotations.length; rightIndex += 1) {
+      const left = document.rotations[leftIndex]!;
+      const right = document.rotations[rightIndex]!;
+      const fallbackStart = "2026-01-01";
+      const windowStart =
+        left.schedule?.startDate && right.schedule?.startDate
+          ? (left.schedule.startDate > right.schedule.startDate ? left.schedule.startDate : right.schedule.startDate)
+          : left.schedule?.startDate ?? right.schedule?.startDate ?? fallbackStart;
+      const inferredEnd = addUtcDays(new Date(`${windowStart}T00:00:00.000Z`), MAX_CONFLICT_SCAN_DAYS).toISOString().slice(0, 10);
+      const windowEnd =
+        left.schedule?.endDate && right.schedule?.endDate
+          ? (left.schedule.endDate < right.schedule.endDate ? left.schedule.endDate : right.schedule.endDate)
+          : left.schedule?.endDate ?? right.schedule?.endDate ?? inferredEnd;
+      if (windowStart > windowEnd) {
+        continue;
+      }
+
+      const start = new Date(`${windowStart}T00:00:00.000Z`);
+      const end = new Date(`${windowEnd}T00:00:00.000Z`);
+      const days = Math.min(
+        MAX_CONFLICT_SCAN_DAYS,
+        Math.max(0, Math.floor((end.getTime() - start.getTime()) / 86_400_000))
+      );
+      const enabledFlags = normalizeFlagSet([...(left.schedule?.requiredFlags ?? []), ...(right.schedule?.requiredFlags ?? [])]);
+
+      for (let dayOffset = 0; dayOffset <= days; dayOffset += 1) {
+        const dateKey = getDateKey(addUtcDays(start, dayOffset));
+        if (scheduleAllowsDate(left.schedule, dateKey, enabledFlags) && scheduleAllowsDate(right.schedule, dateKey, enabledFlags)) {
+          issues.push({
+            path: `rotations[${rightIndex}].schedule`,
+            message: `Rotation "${right.id}" conflicts with "${left.id}" on ${dateKey}.`
+          });
+          break;
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function selectDailyQuestRotationForDate(
+  document: DailyQuestRotationConfigDocument,
+  now = new Date(),
+  enabledFlags: Iterable<string> = []
+): DailyQuestRotationDefinition | null {
+  const dateKey = getDateKey(now);
+  const flags = normalizeFlagSet(enabledFlags);
+  return document.rotations.find((rotation) => scheduleAllowsDate(rotation.schedule, dateKey, flags)) ?? null;
+}
+
+export function findNextDailyQuestRotation(
+  document: DailyQuestRotationConfigDocument,
+  now = new Date(),
+  enabledFlags: Iterable<string> = [],
+  maxDays = MAX_CONFLICT_SCAN_DAYS
+): DailyQuestRotationSelection | null {
+  const flags = normalizeFlagSet(enabledFlags);
+  const activeRotation = selectDailyQuestRotationForDate(document, now, flags);
+  const start = addUtcDays(new Date(`${getDateKey(now)}T00:00:00.000Z`), 1);
+
+  for (let dayOffset = 0; dayOffset <= maxDays; dayOffset += 1) {
+    const candidateDate = addUtcDays(start, dayOffset);
+    const dateKey = getDateKey(candidateDate);
+    const rotation = document.rotations.find((entry) => scheduleAllowsDate(entry.schedule, dateKey, flags));
+    if (!rotation) {
+      continue;
+    }
+    if (rotation.id === activeRotation?.id) {
+      continue;
+    }
+    return {
+      rotation,
+      dateKey
+    };
+  }
+
+  return null;
+}
+
+export function summarizeDailyQuestRotation(rotation: DailyQuestRotationDefinition): string {
+  const scheduleParts: string[] = [];
+  if (rotation.schedule?.startDate || rotation.schedule?.endDate) {
+    scheduleParts.push(`${rotation.schedule?.startDate ?? "open"} -> ${rotation.schedule?.endDate ?? "open"}`);
+  }
+  if (rotation.schedule?.weekdays?.length) {
+    scheduleParts.push(rotation.schedule.weekdays.join(", "));
+  }
+  if (rotation.schedule?.requiredFlags?.length) {
+    scheduleParts.push(`flags: ${rotation.schedule.requiredFlags.join(", ")}`);
+  }
+
+  const header = scheduleParts.length ? `${rotation.label} (${scheduleParts.join(" | ")})` : rotation.label;
+  const lines = rotation.quests.map(
+    (quest) =>
+      `- ${quest.title} [${quest.id}] target=${quest.target} metric=${quest.metric} reward=${quest.reward.gems} gems/${quest.reward.gold} gold`
+  );
+  return [header, ...lines].join("\n");
+}

--- a/packages/shared/src/daily-quests.ts
+++ b/packages/shared/src/daily-quests.ts
@@ -1,21 +1,12 @@
 import type { EventLogEntry } from "./event-log.ts";
-
-export type DailyQuestId = "daily_explore_frontier" | "daily_battle_victory" | "daily_resource_run";
-export type DailyQuestMetric = "hero_moves" | "battle_wins" | "resource_collections";
-
-export interface DailyQuestReward {
-  gems: number;
-  gold: number;
-}
-
-export interface DailyQuestDefinition {
-  id: DailyQuestId;
-  title: string;
-  description: string;
-  metric: DailyQuestMetric;
-  target: number;
-  reward: DailyQuestReward;
-}
+import {
+  cloneDailyQuestDefinition,
+  getDefaultDailyQuestDefinitions,
+  type DailyQuestDefinition,
+  type DailyQuestId,
+  type DailyQuestMetric,
+  type DailyQuestReward
+} from "./daily-quest-rotation.ts";
 
 export interface DailyQuestProgress {
   id: DailyQuestId;
@@ -37,35 +28,8 @@ export interface DailyQuestBoard {
   quests: DailyQuestProgress[];
 }
 
-const DAILY_QUEST_DEFINITIONS: DailyQuestDefinition[] = [
-  {
-    id: "daily_explore_frontier",
-    title: "侦察前线",
-    description: "完成 3 次探索移动。",
-    metric: "hero_moves",
-    target: 3,
-    reward: { gems: 3, gold: 40 }
-  },
-  {
-    id: "daily_battle_victory",
-    title: "凯旋号角",
-    description: "取得 1 场战斗胜利。",
-    metric: "battle_wins",
-    target: 1,
-    reward: { gems: 5, gold: 60 }
-  },
-  {
-    id: "daily_resource_run",
-    title: "补给回收",
-    description: "完成 2 次资源收集。",
-    metric: "resource_collections",
-    target: 2,
-    reward: { gems: 2, gold: 35 }
-  }
-];
-
 export function getDailyQuestDefinitions(): DailyQuestDefinition[] {
-  return DAILY_QUEST_DEFINITIONS.map((definition) => ({ ...definition, reward: { ...definition.reward } }));
+  return getDefaultDailyQuestDefinitions();
 }
 
 export function createEmptyDailyQuestReward(): DailyQuestReward {
@@ -97,6 +61,7 @@ export function buildDailyQuestBoard(
     enabled: boolean;
     cycleKey?: string;
     resetAt?: string;
+    definitions?: DailyQuestDefinition[];
   }
 ): DailyQuestBoard {
   if (!options.enabled) {
@@ -108,7 +73,8 @@ export function buildDailyQuestBoard(
     };
   }
 
-  const quests = DAILY_QUEST_DEFINITIONS.map((definition) => {
+  const definitions = (options.definitions?.length ? options.definitions : getDefaultDailyQuestDefinitions()).map(cloneDailyQuestDefinition);
+  const quests = definitions.map((definition) => {
     const current = Math.min(definition.target, countQuestMetric(events, definition.metric));
     const completed = current >= definition.target;
     const claimed = events.some((entry) => hasClaimMarker(entry, definition.id));
@@ -152,25 +118,26 @@ export function normalizeDailyQuestBoard(board?: Partial<DailyQuestBoard> | null
     return undefined;
   }
 
-  const definitions = new Map(DAILY_QUEST_DEFINITIONS.map((definition) => [definition.id, definition] as const));
   const quests = (board.quests ?? [])
     .map((quest) => {
-      const definition = quest?.id ? definitions.get(quest.id) : undefined;
-      if (!definition) {
+      if (!quest?.id || typeof quest.title !== "string" || typeof quest.description !== "string") {
         return null;
       }
-
-      const current = Math.max(0, Math.min(definition.target, Math.floor(quest.current ?? 0)));
-      const completed = current >= definition.target || quest.completed === true;
+      const target = Math.max(1, Math.floor(quest.target ?? 0));
+      const current = Math.max(0, Math.min(target, Math.floor(quest.current ?? 0)));
+      const completed = current >= target || quest.completed === true;
       return {
-        id: definition.id,
-        title: definition.title,
-        description: definition.description,
-        target: definition.target,
+        id: String(quest.id),
+        title: quest.title,
+        description: quest.description,
+        target,
         current,
         completed,
         claimed: quest.claimed === true,
-        reward: { ...definition.reward }
+        reward: {
+          gems: Math.max(0, Math.floor(quest.reward?.gems ?? 0)),
+          gold: Math.max(0, Math.floor(quest.reward?.gold ?? 0))
+        }
       } satisfies DailyQuestProgress;
     })
     .filter((quest): quest is DailyQuestProgress => Boolean(quest));

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from "./battle-replay.ts";
 export * from "./analytics-events.ts";
 export * from "./content-pack-validation.ts";
 export * from "./daily-quests.ts";
+export * from "./daily-quest-rotation.ts";
 export * from "./deterministic-rng.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";

--- a/packages/shared/test/daily-quest-rotation.test.ts
+++ b/packages/shared/test/daily-quest-rotation.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  findNextDailyQuestRotation,
+  normalizeDailyQuestRotationConfigDocument,
+  selectDailyQuestRotationForDate,
+  validateDailyQuestRotationConfigDocument
+} from "../src/index.ts";
+
+test("daily quest rotation selection honors weekday and feature-flag schedule gates", () => {
+  const document = normalizeDailyQuestRotationConfigDocument({
+    schemaVersion: 1,
+    rotations: [
+      {
+        id: "weekday-core",
+        label: "Weekday Core",
+        schedule: {
+          startDate: "2026-04-01",
+          endDate: "2026-04-30",
+          weekdays: ["mon", "tue", "wed", "thu", "fri"]
+        },
+        quests: [
+          {
+            id: "weekday-scout",
+            title: "Weekday Scout",
+            description: "Move 3 times.",
+            metric: "hero_moves",
+            target: 3,
+            reward: { gems: 3, gold: 40 }
+          }
+        ]
+      },
+      {
+        id: "pve-weekend",
+        label: "PvE Weekend",
+        schedule: {
+          startDate: "2026-05-01",
+          endDate: "2026-05-31",
+          weekdays: ["sun", "sat"],
+          requiredFlags: ["pve_enabled"]
+        },
+        quests: [
+          {
+            id: "weekend-battle",
+            title: "Weekend Battle",
+            description: "Win 2 battles.",
+            metric: "battle_wins",
+            target: 2,
+            reward: { gems: 8, gold: 85 }
+          }
+        ]
+      }
+    ]
+  });
+
+  const weekdayRotation = selectDailyQuestRotationForDate(document, new Date("2026-04-06T10:00:00.000Z"));
+  assert.equal(weekdayRotation?.id, "weekday-core");
+
+  const missingFlagRotation = selectDailyQuestRotationForDate(document, new Date("2026-05-02T10:00:00.000Z"));
+  assert.equal(missingFlagRotation, null);
+
+  const flaggedRotation = selectDailyQuestRotationForDate(document, new Date("2026-05-02T10:00:00.000Z"), ["pve_enabled"]);
+  assert.equal(flaggedRotation?.id, "pve-weekend");
+
+  const nextRotation = findNextDailyQuestRotation(document, new Date("2026-04-29T10:00:00.000Z"), ["pve_enabled"]);
+  assert.equal(nextRotation?.rotation.id, "pve-weekend");
+  assert.equal(nextRotation?.dateKey, "2026-05-02");
+});
+
+test("daily quest rotation validation catches duplicate quests, reward range violations and overlapping schedules", () => {
+  const document = normalizeDailyQuestRotationConfigDocument({
+    schemaVersion: 1,
+    rotations: [
+      {
+        id: "overlap-a",
+        label: "Overlap A",
+        schedule: {
+          startDate: "2026-04-01",
+          endDate: "2026-04-07",
+          weekdays: ["wed"]
+        },
+        quests: [
+          {
+            id: "duplicate-quest",
+            title: "Quest A",
+            description: "Move 3 times.",
+            metric: "hero_moves",
+            target: 3,
+            reward: { gems: 3, gold: 40 }
+          },
+          {
+            id: "duplicate-quest",
+            title: "Quest B",
+            description: "Collect twice.",
+            metric: "resource_collections",
+            target: 2,
+            reward: { gems: 30, gold: 40 }
+          }
+        ]
+      },
+      {
+        id: "overlap-b",
+        label: "Overlap B",
+        schedule: {
+          startDate: "2026-04-01",
+          endDate: "2026-04-07",
+          weekdays: ["wed"]
+        },
+        quests: [
+          {
+            id: "battle-quest",
+            title: "Quest C",
+            description: "Win once.",
+            metric: "battle_wins",
+            target: 1,
+            reward: { gems: 5, gold: 60 }
+          }
+        ]
+      }
+    ]
+  });
+
+  const issueSummary = validateDailyQuestRotationConfigDocument(document)
+    .map((issue) => issue.message)
+    .join("\n");
+  assert.match(issueSummary, /Duplicate quest id "duplicate-quest"/);
+  assert.match(issueSummary, /Gem reward must be an integer between 0 and 25/);
+  assert.match(issueSummary, /conflicts with "overlap-a" on 2026-04-01/);
+});

--- a/scripts/daily-quest-rotation-preview.ts
+++ b/scripts/daily-quest-rotation-preview.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createDailyQuestRotationPreview } from "../apps/server/src/daily-quest-rotations.ts";
+import type { FeatureFlags } from "../packages/shared/src/index.ts";
+
+interface Args {
+  at?: string;
+  outputPath: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    outputPath: path.resolve(process.cwd(), "output/daily-quest-rotation-preview.md")
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === "--at") {
+      args.at = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (value === "--output") {
+      const output = argv[index + 1];
+      if (output) {
+        args.outputPath = path.resolve(process.cwd(), output);
+      }
+      index += 1;
+    }
+  }
+
+  return args;
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function resolvePreviewFlags(env: NodeJS.ProcessEnv = process.env): Partial<FeatureFlags> {
+  return {
+    quest_system_enabled: isTruthyEnv(env.VEIL_DAILY_QUESTS_ENABLED),
+    battle_pass_enabled: isTruthyEnv(env.VEIL_BATTLE_PASS_ENABLED),
+    pve_enabled: isTruthyEnv(env.VEIL_PVE_ENABLED),
+    tutorial_enabled: !["0", "false", "no", "off"].includes(env.VEIL_TUTORIAL_ENABLED?.trim().toLowerCase() ?? "")
+  };
+}
+
+export function renderDailyQuestRotationPreviewMarkdown(
+  preview: ReturnType<typeof createDailyQuestRotationPreview>
+): string {
+  const lines = [
+    "# Daily Quest Rotation Preview",
+    "",
+    `Generated at: ${preview.generatedAt}`,
+    `Active date: ${preview.activeDate}`,
+    `Enabled flags: ${preview.enabledFlags.length ? preview.enabledFlags.join(", ") : "none"}`,
+    "",
+    "## Active Rotation",
+    preview.activeRotation ? `- ${preview.activeRotation.label} [${preview.activeRotation.id}]` : "- none",
+    ...(preview.activeRotation ? ["", "```text", preview.activeRotation.summary, "```"] : []),
+    "",
+    "## Next Rotation",
+    preview.nextRotation
+      ? `- ${preview.nextRotation.label} [${preview.nextRotation.id}] starts ${preview.nextRotation.startsOn}`
+      : "- none",
+    ...(preview.nextRotation ? ["", "```text", preview.nextRotation.summary, "```"] : []),
+    ""
+  ];
+
+  return lines.join("\n");
+}
+
+export function generateDailyQuestRotationPreviewArtifact(
+  now = new Date(),
+  outputPath = path.resolve(process.cwd(), "output/daily-quest-rotation-preview.md"),
+  flags = resolvePreviewFlags()
+): string {
+  const preview = createDailyQuestRotationPreview(now, flags);
+  const markdown = renderDailyQuestRotationPreviewMarkdown(preview);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, markdown, "utf8");
+  return markdown;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2));
+  const now = args.at ? new Date(args.at) : new Date();
+  if (Number.isNaN(now.getTime())) {
+    throw new Error(`invalid --at value: ${args.at}`);
+  }
+
+  process.stdout.write(generateDailyQuestRotationPreviewArtifact(now, args.outputPath));
+}

--- a/scripts/test/daily-quest-rotation-preview.test.ts
+++ b/scripts/test/daily-quest-rotation-preview.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  generateDailyQuestRotationPreviewArtifact,
+  renderDailyQuestRotationPreviewMarkdown
+} from "../daily-quest-rotation-preview.ts";
+import { createDailyQuestRotationPreview } from "../../apps/server/src/daily-quest-rotations.ts";
+
+test("daily quest rotation preview renders the active and next scheduled rotations", () => {
+  const preview = createDailyQuestRotationPreview(
+    new Date("2026-04-04T09:00:00.000Z"),
+    {
+      quest_system_enabled: true,
+      pve_enabled: true
+    }
+  );
+  const markdown = renderDailyQuestRotationPreviewMarkdown(preview);
+
+  assert.match(markdown, /Spring Weekend Surge/);
+  assert.match(markdown, /Spring Weekday Patrol/);
+  assert.match(markdown, /starts 2026-04-06/);
+});
+
+test("daily quest rotation preview artifact writes markdown output", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-daily-quest-preview-"));
+  const outputPath = path.join(workspace, "preview.md");
+
+  generateDailyQuestRotationPreviewArtifact(
+    new Date("2026-04-04T09:00:00.000Z"),
+    outputPath,
+    {
+      quest_system_enabled: true
+    }
+  );
+
+  const written = fs.readFileSync(outputPath, "utf8");
+  assert.match(written, /Daily Quest Rotation Preview/);
+  assert.match(written, /Spring Weekend Surge/);
+});


### PR DESCRIPTION
## Summary
- add a shared daily quest rotation config model with validation and schedule selection helpers
- wire the server daily quest runtime to load rotation configs and generate preview data
- add a CLI preview artifact plus tests covering config validation, selection, and preview rendering

## Testing
- node --import tsx --test packages/shared/test/daily-quest-rotation.test.ts scripts/test/daily-quest-rotation-preview.test.ts
- npm run typecheck:shared
- npm run typecheck:server
- npm run preview:daily-quest-rotation -- --at 2026-04-04T09:00:00.000Z

Closes #874
EOF
