### PR TITLE
[codex] Expand talent tiers and set bonus progress

### DIFF
--- a/configs/hero-skill-trees-full.json
+++ b/configs/hero-skill-trees-full.json
@@ -28,12 +28,14 @@
         {
           "rank": 1,
           "description": "解锁主动技能“号令突进”。",
-          "battleSkillIds": ["commanding_shout"]
+          "battleSkillIds": ["commanding_shout"],
+          "statBonuses": { "attack": 1 }
         },
         {
           "rank": 2,
           "description": "追加被动技能“裂甲追击”。",
-          "battleSkillIds": ["rending_mark"]
+          "battleSkillIds": ["rending_mark"],
+          "statBonuses": { "attack": 1 }
         }
       ]
     },
@@ -112,12 +114,14 @@
         {
           "rank": 1,
           "description": "解锁主动技能“持盾列阵”。",
-          "battleSkillIds": ["phalanx_command"]
+          "battleSkillIds": ["phalanx_command"],
+          "statBonuses": { "defense": 1, "maxHp": 2 }
         },
         {
           "rank": 2,
           "description": "追加主动技能“钉锁投枪”。",
-          "battleSkillIds": ["pinning_javelin"]
+          "battleSkillIds": ["pinning_javelin"],
+          "statBonuses": { "defense": 1, "maxHp": 2 }
         }
       ]
     },
@@ -149,7 +153,8 @@
         {
           "rank": 1,
           "description": "解锁主动技能“护甲术”。",
-          "battleSkillIds": ["armor_spell"]
+          "battleSkillIds": ["armor_spell"],
+          "statBonuses": { "power": 1, "knowledge": 1 }
         }
       ]
     },

--- a/packages/shared/src/equipment.ts
+++ b/packages/shared/src/equipment.ts
@@ -605,7 +605,19 @@ export interface HeroEquipmentSlotView {
 
 export interface HeroEquipmentLoadoutView {
   slots: HeroEquipmentSlotView[];
+  setBonuses: HeroEquipmentSetProgressView[];
   summary: HeroEquipmentBonusSummary;
+}
+
+export interface HeroEquipmentSetProgressView {
+  setId: string;
+  name: string;
+  piecesRequired: number;
+  equippedPieces: number;
+  active: boolean;
+  description: string;
+  bonusSummary: string;
+  specialEffectSummary: string | null;
 }
 
 export interface RolledEquipmentDrop {
@@ -632,7 +644,13 @@ function resolveEquipmentDefinition(id: string | undefined): EquipmentDefinition
 }
 
 function resolveActiveSetBonuses(resolvedItems: EquipmentDefinition[]): EquipmentSetBonusConfig[] {
-  const countsBySetId = resolvedItems.reduce<Record<string, number>>((counts, item) => {
+  const countsBySetId = countEquippedSetPieces(resolvedItems);
+
+  return SET_BONUSES.filter((entry) => (countsBySetId[entry.setId] ?? 0) >= entry.piecesRequired);
+}
+
+function countEquippedSetPieces(resolvedItems: EquipmentDefinition[]): Record<string, number> {
+  return resolvedItems.reduce<Record<string, number>>((counts, item) => {
     if (!item.setId) {
       return counts;
     }
@@ -640,8 +658,6 @@ function resolveActiveSetBonuses(resolvedItems: EquipmentDefinition[]): Equipmen
     counts[item.setId] = (counts[item.setId] ?? 0) + 1;
     return counts;
   }, {});
-
-  return SET_BONUSES.filter((entry) => (countsBySetId[entry.setId] ?? 0) >= entry.piecesRequired);
 }
 
 function percentageDelta(base: number, percent: number): number {
@@ -873,6 +889,13 @@ export function createHeroEquipmentBonusSummary(
 export function createHeroEquipmentLoadoutView(
   hero: Pick<HeroState, "stats" | "loadout">
 ): HeroEquipmentLoadoutView {
+  const resolvedItems = [
+    resolveEquipmentDefinition(hero.loadout.equipment.weaponId),
+    resolveEquipmentDefinition(hero.loadout.equipment.armorId),
+    resolveEquipmentDefinition(hero.loadout.equipment.accessoryId)
+  ].filter((entry): entry is EquipmentDefinition => Boolean(entry));
+  const countsBySetId = countEquippedSetPieces(resolvedItems);
+
   return {
     slots: EQUIPMENT_SLOT_META.map(({ slot, label, key }) => {
       const itemId = hero.loadout.equipment[key];
@@ -917,6 +940,18 @@ export function createHeroEquipmentLoadoutView(
         specialEffectSummary: item.specialEffect ? `${item.specialEffect.name}: ${item.specialEffect.description}` : null
       };
     }),
+    setBonuses: SET_BONUSES.map((setBonus) => ({
+      setId: setBonus.setId,
+      name: setBonus.name,
+      piecesRequired: setBonus.piecesRequired,
+      equippedPieces: countsBySetId[setBonus.setId] ?? 0,
+      active: (countsBySetId[setBonus.setId] ?? 0) >= setBonus.piecesRequired,
+      description: setBonus.description,
+      bonusSummary: formatEquipmentBonusSummary(setBonus.bonuses),
+      specialEffectSummary: setBonus.specialEffect
+        ? `${setBonus.specialEffect.name}: ${setBonus.specialEffect.description}`
+        : null
+    })),
     summary: createHeroEquipmentBonusSummary(hero)
   };
 }

--- a/packages/shared/src/hero-progression.ts
+++ b/packages/shared/src/hero-progression.ts
@@ -1,4 +1,5 @@
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
+import { createHeroSkillBonusSummary } from "./hero-skills.ts";
 import type { HeroState, PlayerWorldView } from "./models.ts";
 import { experienceRequiredForNextLevel, totalExperienceRequiredForLevel } from "./models.ts";
 
@@ -112,10 +113,11 @@ export function createHeroProgressMeterView(
 }
 
 export function createHeroAttributeBreakdown(
-  hero: Pick<HeroState, "id" | "stats" | "progression" | "loadout">,
+  hero: Pick<HeroState, "id" | "stats" | "progression" | "loadout" | "learnedSkills">,
   world?: Pick<PlayerWorldView, "map"> | null
 ): HeroAttributeBreakdownRow[] {
   const equipment = createHeroEquipmentBonusSummary(hero);
+  const skillBonuses = createHeroSkillBonusSummary(hero);
   const sources: HeroAttributeSourceSet = {
     progression: buildProgressionContribution(hero),
     buildings: buildBuildingContribution(world, hero.id),
@@ -126,7 +128,13 @@ export function createHeroAttributeBreakdown(
       knowledge: equipment.knowledge,
       maxHp: equipment.maxHp
     },
-    skills: createEmptyAttributeValues()
+    skills: {
+      attack: skillBonuses.attack,
+      defense: skillBonuses.defense,
+      power: skillBonuses.power,
+      knowledge: skillBonuses.knowledge,
+      maxHp: skillBonuses.maxHp
+    }
   };
 
   return ATTRIBUTE_ROWS.map(({ key, label }) => {

--- a/packages/shared/src/hero-skills.ts
+++ b/packages/shared/src/hero-skills.ts
@@ -1,4 +1,5 @@
 import type {
+  HeroAttributeBonuses,
   BattleSkillId,
   HeroSkillBranchConfig,
   HeroSkillConfig,
@@ -18,6 +19,7 @@ export interface HeroSkillView {
   id: string;
   branchId: string;
   branchName: string;
+  tier: number;
   name: string;
   description: string;
   requiredLevel: number;
@@ -29,7 +31,15 @@ export interface HeroSkillView {
   reason?: string;
   grantedBattleSkillIds: BattleSkillId[];
   nextGrantedBattleSkillIds: BattleSkillId[];
+  grantedStatBonuses: HeroAttributeBonuses;
+  nextGrantedStatBonuses: HeroAttributeBonuses;
   ranks: HeroSkillRankView[];
+}
+
+export interface HeroSkillTierView {
+  tier: number;
+  requiredLevel: number;
+  skills: HeroSkillView[];
 }
 
 export interface HeroSkillBranchView {
@@ -37,6 +47,7 @@ export interface HeroSkillBranchView {
   name: string;
   description: string;
   skills: HeroSkillView[];
+  tiers: HeroSkillTierView[];
 }
 
 export interface HeroSkillTreeView {
@@ -62,6 +73,68 @@ function rankConfigFor(skill: HeroSkillConfig, rank: number): HeroSkillRankConfi
 
 function battleSkillIdsGrantedAtRank(skill: HeroSkillConfig, rank: number): BattleSkillId[] {
   return [...new Set(rankConfigFor(skill, rank)?.battleSkillIds ?? [])];
+}
+
+function createEmptyHeroAttributeBonuses(): HeroAttributeBonuses {
+  return {
+    attack: 0,
+    defense: 0,
+    power: 0,
+    knowledge: 0,
+    maxHp: 0
+  };
+}
+
+function numericBonus(value: number | undefined): number {
+  return Number.isFinite(value) ? Number(value) : 0;
+}
+
+function statBonusesGrantedAtRank(skill: HeroSkillConfig, rank: number): HeroAttributeBonuses {
+  const bonuses = rankConfigFor(skill, rank)?.statBonuses;
+  return {
+    attack: numericBonus(bonuses?.attack),
+    defense: numericBonus(bonuses?.defense),
+    power: numericBonus(bonuses?.power),
+    knowledge: numericBonus(bonuses?.knowledge),
+    maxHp: numericBonus(bonuses?.maxHp)
+  };
+}
+
+function addHeroAttributeBonuses(
+  base: HeroAttributeBonuses,
+  delta: HeroAttributeBonuses
+): HeroAttributeBonuses {
+  return {
+    attack: base.attack + delta.attack,
+    defense: base.defense + delta.defense,
+    power: base.power + delta.power,
+    knowledge: base.knowledge + delta.knowledge,
+    maxHp: base.maxHp + delta.maxHp
+  };
+}
+
+function subtractHeroAttributeBonuses(
+  left: HeroAttributeBonuses,
+  right: HeroAttributeBonuses
+): HeroAttributeBonuses {
+  return {
+    attack: left.attack - right.attack,
+    defense: left.defense - right.defense,
+    power: left.power - right.power,
+    knowledge: left.knowledge - right.knowledge,
+    maxHp: left.maxHp - right.maxHp
+  };
+}
+
+function accumulatedStatBonuses(skill: HeroSkillConfig, rank: number): HeroAttributeBonuses {
+  let bonuses = createEmptyHeroAttributeBonuses();
+  const clampedRank = clampRank(skill, rank);
+
+  for (let currentRank = 1; currentRank <= clampedRank; currentRank += 1) {
+    bonuses = addHeroAttributeBonuses(bonuses, statBonusesGrantedAtRank(skill, currentRank));
+  }
+
+  return bonuses;
 }
 
 function accumulatedBattleSkillIds(skill: HeroSkillConfig, rank: number): BattleSkillId[] {
@@ -148,9 +221,21 @@ export function applyHeroSkillSelection(
   const newRank = currentRank + 1;
   const previousBattleSkillIds = new Set(accumulatedBattleSkillIds(skill, currentRank));
   const nextBattleSkillIds = accumulatedBattleSkillIds(skill, newRank);
+  const previousStatBonuses = accumulatedStatBonuses(skill, currentRank);
+  const nextStatBonuses = accumulatedStatBonuses(skill, newRank);
+  const gainedStatBonuses = subtractHeroAttributeBonuses(nextStatBonuses, previousStatBonuses);
 
   const heroWithSkill = normalizeHeroState({
     ...hero,
+    stats: {
+      ...hero.stats,
+      attack: hero.stats.attack + gainedStatBonuses.attack,
+      defense: hero.stats.defense + gainedStatBonuses.defense,
+      power: hero.stats.power + gainedStatBonuses.power,
+      knowledge: hero.stats.knowledge + gainedStatBonuses.knowledge,
+      maxHp: hero.stats.maxHp + gainedStatBonuses.maxHp,
+      hp: Math.min(hero.stats.maxHp + gainedStatBonuses.maxHp, hero.stats.hp + gainedStatBonuses.maxHp)
+    },
     progression: {
       ...hero.progression,
       skillPoints: Math.max(0, (hero.progression.skillPoints ?? 0) - 1)
@@ -193,6 +278,25 @@ export function grantedHeroBattleSkillIds(
   return [...grantedSkillIds];
 }
 
+export function createHeroSkillBonusSummary(
+  hero: Pick<HeroState, "learnedSkills">,
+  config: HeroSkillTreeConfig = getDefaultHeroSkillTreeConfig()
+): HeroAttributeBonuses {
+  const { skillById } = indexHeroSkillTree(config);
+  let totals = createEmptyHeroAttributeBonuses();
+
+  for (const learnedSkill of hero.learnedSkills ?? []) {
+    const skill = skillById.get(learnedSkill.skillId);
+    if (!skill) {
+      continue;
+    }
+
+    totals = addHeroAttributeBonuses(totals, accumulatedStatBonuses(skill, learnedSkill.rank));
+  }
+
+  return totals;
+}
+
 export function createHeroSkillTreeView(
   hero: HeroState,
   config: HeroSkillTreeConfig = getDefaultHeroSkillTreeConfig()
@@ -201,38 +305,50 @@ export function createHeroSkillTreeView(
 
   return {
     availableSkillPoints: hero.progression.skillPoints ?? 0,
-    branches: config.branches.map((branch) => ({
-      ...branch,
-      skills: config.skills
-        .filter((skill) => skill.branchId === branch.id)
-        .map((skill) => {
-          const validation = validateHeroSkillSelection(hero, skill.id, config);
-          const currentRank = heroSkillRankFor(hero, skill.id);
-          const nextRank = currentRank < skill.maxRank ? currentRank + 1 : null;
-          return {
-            id: skill.id,
-            branchId: skill.branchId,
-            branchName: branchById.get(skill.branchId)?.name ?? skill.branchId,
-            name: skill.name,
-            description: skill.description,
-            requiredLevel: skill.requiredLevel,
-            prerequisites: [...(skill.prerequisites ?? [])],
-            currentRank,
-            maxRank: skill.maxRank,
-            nextRank,
-            canLearn: validation.valid,
-            ...(validation.reason ? { reason: validation.reason } : {}),
-            grantedBattleSkillIds: accumulatedBattleSkillIds(skill, currentRank),
-            nextGrantedBattleSkillIds: nextRank ? battleSkillIdsGrantedAtRank(skill, nextRank) : [],
-            ranks: skill.ranks
-              .slice()
-              .sort((left, right) => left.rank - right.rank)
-              .map((rank) => ({
-                ...rank,
-                unlocked: currentRank >= rank.rank
-              }))
-          };
-        })
-    }))
+    branches: config.branches.map((branch) => {
+      const branchSkills = config.skills.filter((skill) => skill.branchId === branch.id);
+      const tierLevels = [...new Set(branchSkills.map((skill) => skill.requiredLevel))].sort((left, right) => left - right);
+      const skills = branchSkills.map((skill) => {
+        const validation = validateHeroSkillSelection(hero, skill.id, config);
+        const currentRank = heroSkillRankFor(hero, skill.id);
+        const nextRank = currentRank < skill.maxRank ? currentRank + 1 : null;
+        return {
+          id: skill.id,
+          branchId: skill.branchId,
+          branchName: branchById.get(skill.branchId)?.name ?? skill.branchId,
+          tier: Math.max(1, tierLevels.indexOf(skill.requiredLevel) + 1),
+          name: skill.name,
+          description: skill.description,
+          requiredLevel: skill.requiredLevel,
+          prerequisites: [...(skill.prerequisites ?? [])],
+          currentRank,
+          maxRank: skill.maxRank,
+          nextRank,
+          canLearn: validation.valid,
+          ...(validation.reason ? { reason: validation.reason } : {}),
+          grantedBattleSkillIds: accumulatedBattleSkillIds(skill, currentRank),
+          nextGrantedBattleSkillIds: nextRank ? battleSkillIdsGrantedAtRank(skill, nextRank) : [],
+          grantedStatBonuses: accumulatedStatBonuses(skill, currentRank),
+          nextGrantedStatBonuses: nextRank ? statBonusesGrantedAtRank(skill, nextRank) : createEmptyHeroAttributeBonuses(),
+          ranks: skill.ranks
+            .slice()
+            .sort((left, right) => left.rank - right.rank)
+            .map((rank) => ({
+              ...rank,
+              unlocked: currentRank >= rank.rank
+            }))
+        };
+      });
+
+      return {
+        ...branch,
+        skills,
+        tiers: tierLevels.map((requiredLevel, index) => ({
+          tier: index + 1,
+          requiredLevel,
+          skills: skills.filter((skill) => skill.requiredLevel === requiredLevel)
+        }))
+      };
+    })
   };
 }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -22,6 +22,7 @@ export interface HeroStats {
 }
 
 export type HeroStatBonus = Pick<HeroStats, "attack" | "defense" | "power" | "knowledge">;
+export type HeroAttributeBonuses = Pick<HeroStats, "attack" | "defense" | "power" | "knowledge" | "maxHp">;
 
 export type HeroSkillId = string;
 export type HeroSkillBranchId = string;
@@ -81,6 +82,7 @@ export interface HeroSkillRankConfig {
   rank: number;
   description: string;
   battleSkillIds?: BattleSkillId[];
+  statBonuses?: Partial<HeroAttributeBonuses>;
 }
 
 export interface HeroSkillConfig {

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -474,6 +474,15 @@ export function validateHeroSkillTreeConfig(
         throw new Error(`Hero skill ${skill.id} rank ${rank.rank} must define a description`);
       }
 
+      for (const [key, value] of Object.entries(rank.statBonuses ?? {})) {
+        if (!["attack", "defense", "power", "knowledge", "maxHp"].includes(key)) {
+          throw new Error(`Hero skill ${skill.id} rank ${rank.rank} has unknown stat bonus: ${key}`);
+        }
+        if (!Number.isInteger(value) || value < 0) {
+          throw new Error(`Hero skill ${skill.id} rank ${rank.rank} stat bonus ${key} must be a non-negative integer`);
+        }
+      }
+
       for (const battleSkillId of rank.battleSkillIds ?? []) {
         if (!battleSkillIds.has(battleSkillId)) {
           throw new Error(`Hero skill ${skill.id} rank ${rank.rank} references unknown battle skill: ${battleSkillId}`);

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -2047,7 +2047,67 @@ test("hero equipment loadout view resolves slot metadata for equipped and empty 
   assert.equal(view.slots[1]?.itemName, "未装备");
   assert.equal(view.slots[1]?.bonusSummary, "等待拾取或替换");
   assert.equal(view.slots[2]?.specialEffectSummary, "引导: 为后续技能结算预留更高的法术上限。");
+  assert.equal(view.setBonuses.find((bonus) => bonus.setId === "warhost")?.active, false);
   assert.deepEqual(view.summary.resolvedItemIds, ["sunforged_spear", "oracle_lens"]);
+});
+
+test("hero equipment loadout view tracks warhost and bulwark set progress", () => {
+  const warhostHero = createHero({
+    id: "hero-warhost-view",
+    playerId: "player-1",
+    name: "战团视图",
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        weaponId: "siege_maul",
+        armorId: "assault_cuirass",
+        trinketIds: []
+      }
+    }
+  });
+  const bulwarkHero = createHero({
+    id: "hero-bulwark-view",
+    playerId: "player-1",
+    name: "磐垒视图",
+    loadout: {
+      learnedSkills: [],
+      equipment: {
+        armorId: "bulwark_plate",
+        accessoryId: "sentinel_badge",
+        trinketIds: []
+      }
+    }
+  });
+
+  const warhostView = createHeroEquipmentLoadoutView(warhostHero);
+  const bulwarkView = createHeroEquipmentLoadoutView(bulwarkHero);
+
+  assert.deepEqual(
+    warhostView.setBonuses.find((bonus) => bonus.setId === "warhost"),
+    {
+      setId: "warhost",
+      name: "战团突袭套",
+      piecesRequired: 2,
+      equippedPieces: 2,
+      active: true,
+      description: "2 件：攻击 +8% / 力量 +1，并获得击杀回血。",
+      bonusSummary: "攻击 +8% / 力量 +1",
+      specialEffectSummary: "嗜血: 击杀敌方单位后恢复自身生命。"
+    }
+  );
+  assert.deepEqual(
+    bulwarkView.setBonuses.find((bonus) => bonus.setId === "bulwark"),
+    {
+      setId: "bulwark",
+      name: "磐垒守御套",
+      piecesRequired: 2,
+      equippedPieces: 2,
+      active: true,
+      description: "2 件：防御 +10% / 生命上限 +4，并获得反伤。",
+      bonusSummary: "防御 +10% / 生命上限 +4",
+      specialEffectSummary: "反刺: 受到近战攻击时，对攻击者造成反伤。"
+    }
+  );
 });
 
 test("hero equipment loadout view tolerates archived ids missing from the equipment catalog", () => {
@@ -3085,6 +3145,7 @@ test("resolveWorldAction lets heroes learn and upgrade long-term skills after le
 
   assert.equal(learned.state.heroes[0]?.progression.skillPoints, 1);
   assert.deepEqual(learned.state.heroes[0]?.learnedSkills, [{ skillId: "war_banner", rank: 1 }]);
+  assert.equal(learned.state.heroes[0]?.stats.attack, hero.stats.attack + 1);
   assert.deepEqual(learned.events, [
     {
       type: "hero.skillLearned",
@@ -3108,6 +3169,7 @@ test("resolveWorldAction lets heroes learn and upgrade long-term skills after le
 
   assert.equal(upgraded.state.heroes[0]?.progression.skillPoints, 0);
   assert.deepEqual(upgraded.state.heroes[0]?.learnedSkills, [{ skillId: "war_banner", rank: 2 }]);
+  assert.equal(upgraded.state.heroes[0]?.stats.attack, hero.stats.attack + 2);
   assert.deepEqual(validateWorldAction(upgraded.state, {
     type: "hero.learnSkill",
     heroId: "hero-1",
@@ -3154,9 +3216,24 @@ test("hero skill tree view and resolveWorldAction advance branch prerequisites i
   });
 
   const initialView = createHeroSkillTreeView(hero);
+  const warpathBranch = initialView.branches.find((branch) => branch.id === "warpath");
   const initialLearnableIds = initialView.branches.flatMap((branch) => branch.skills.filter((skill) => skill.canLearn).map((skill) => skill.id));
   assert.ok(initialLearnableIds.includes("war_banner"));
   assert.ok(!initialLearnableIds.includes("spearhead_assault"));
+  assert.deepEqual(
+    warpathBranch?.tiers.map((tier) => [tier.tier, tier.requiredLevel, tier.skills.map((skill) => skill.id)]),
+    [
+      [1, 2, ["war_banner"]],
+      [2, 3, ["spearhead_assault"]],
+      [3, 4, ["battle_drill"]],
+      [4, 5, ["hunter_volley"]],
+      [5, 6, ["ravager_doctrine"]]
+    ]
+  );
+  assert.deepEqual(
+    warpathBranch?.skills.find((skill) => skill.id === "war_banner")?.nextGrantedStatBonuses,
+    { attack: 1, defense: 0, power: 0, knowledge: 0, maxHp: 0 }
+  );
 
   const firstLearn = resolveWorldAction(state, {
     type: "hero.learnSkill",
@@ -3196,6 +3273,39 @@ test("hero skill tree view and resolveWorldAction advance branch prerequisites i
       newlyGrantedBattleSkillIds: ["sundering_spear"]
     }
   ]);
+});
+
+test("hero attribute breakdown attributes learned passive talent bonuses to skills", () => {
+  const hero = createHero({
+    id: "hero-skill-breakdown",
+    playerId: "player-1",
+    name: "技能拆解",
+    progression: {
+      ...createDefaultHeroProgression(),
+      level: 2,
+      experience: 120,
+      skillPoints: 1
+    }
+  });
+  const state = createWorldState({
+    width: 1,
+    height: 1,
+    heroes: [hero],
+    tiles: [createTile(0, 0, { occupant: { kind: "hero", refId: "hero-skill-breakdown" } })],
+    visibilityByPlayer: {
+      "player-1": ["visible"]
+    }
+  });
+
+  const learned = resolveWorldAction(state, {
+    type: "hero.learnSkill",
+    heroId: "hero-skill-breakdown",
+    skillId: "war_banner"
+  });
+  const breakdown = createHeroAttributeBreakdown(learned.state.heroes[0]!);
+
+  assert.equal(breakdown.find((row) => row.key === "attack")?.skills, 1);
+  assert.match(breakdown.find((row) => row.key === "attack")?.formula ?? "", /技能 \+1/);
 });
 
 test("createHeroBattleState carries learned hero skill tree rewards into battle", () => {


### PR DESCRIPTION
## Summary
- add passive stat bonuses to selected hero skill ranks and expose explicit talent tiers in the shared skill tree view
- attribute learned talent bonuses in hero progression breakdowns so the new long-term build power is visible in shared projections
- surface equipment set progress in the shared loadout view and cover both warhost and bulwark two-piece bonuses with tests

## Validation
- `node --import tsx --test packages/shared/test/shared-core.test.ts`
- `npm run typecheck:shared`
- `npm run test:shared` *(currently blocked by an existing unrelated failure in `packages/shared/test/move-distance-cap.test.ts`)*

Closes #876.
