### PR TITLE
[codex] Add guild roster workflow domain

### DIFF
--- a/packages/shared/src/guilds.ts
+++ b/packages/shared/src/guilds.ts
@@ -1,0 +1,614 @@
+import type {
+  GuildInviteState,
+  GuildInviteStatus,
+  GuildJoinRequestState,
+  GuildJoinRequestStatus,
+  GuildMemberState,
+  GuildRole,
+  GuildState
+} from "./models.ts";
+
+export const DEFAULT_GUILD_MEMBER_LIMIT = 20;
+
+const GUILD_ROLE_ORDER: Record<GuildRole, number> = {
+  owner: 0,
+  officer: 1,
+  member: 2
+};
+
+const GUILD_ROLE_LABELS: Record<GuildRole, string> = {
+  owner: "Owner",
+  officer: "Officer",
+  member: "Member"
+};
+
+export interface GuildRosterEntry {
+  playerId: string;
+  displayName: string;
+  role: GuildRole;
+  roleLabel: string;
+  rolePriority: number;
+  joinedAt: string;
+  invitedByPlayerId?: string;
+}
+
+export interface GuildJoinRequestView {
+  requestId: string;
+  playerId: string;
+  displayName: string;
+  requestedAt: string;
+  status: GuildJoinRequestStatus;
+}
+
+export interface GuildRosterView {
+  guildId: string;
+  name: string;
+  tag: string;
+  description?: string;
+  level: number;
+  xp: number;
+  memberCount: number;
+  memberLimit: number;
+  availableSeats: number;
+  members: GuildRosterEntry[];
+  pendingJoinRequests: GuildJoinRequestView[];
+}
+
+export interface GuildMembershipEvent {
+  type:
+    | "guild.member.join_requested"
+    | "guild.member.join_approved"
+    | "guild.member.join_rejected"
+    | "guild.member.invited"
+    | "guild.member.invite_accepted"
+    | "guild.member.invite_declined"
+    | "guild.member.role_changed"
+    | "guild.member.owner_transferred";
+  guildId: string;
+  actorPlayerId: string;
+  subjectPlayerId: string;
+  occurredAt: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+export interface GuildMutationResult {
+  guild: GuildState;
+  events: GuildMembershipEvent[];
+}
+
+export interface GuildJoinRequestInput {
+  playerId: string;
+  displayName: string;
+  requestId?: string;
+  requestedAt?: string;
+}
+
+export interface GuildJoinReviewInput {
+  actorPlayerId: string;
+  requestId: string;
+  approve: boolean;
+  reviewedAt?: string;
+  rejectionReason?: string;
+}
+
+export interface GuildInviteInput {
+  actorPlayerId: string;
+  playerId: string;
+  inviteId?: string;
+  createdAt?: string;
+}
+
+export interface GuildInviteResponseInput {
+  playerId: string;
+  inviteId: string;
+  accept: boolean;
+  respondedAt?: string;
+}
+
+export interface GuildRoleAssignmentInput {
+  actorPlayerId: string;
+  targetPlayerId: string;
+  role: GuildRole;
+  changedAt?: string;
+}
+
+function normalizeTimestamp(value?: string | null, fallback = new Date().toISOString()): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return fallback;
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed.toISOString();
+}
+
+function normalizeDisplayName(value: string | undefined, fallback: string): string {
+  const normalized = value?.trim();
+  return normalized ? normalized.slice(0, 40) : fallback;
+}
+
+function ensureGuildMemberLimit(value?: number | null): number {
+  return Math.max(1, Math.floor(value ?? DEFAULT_GUILD_MEMBER_LIMIT));
+}
+
+function normalizeGuildMember(member: Partial<GuildMemberState>): GuildMemberState | null {
+  const playerId = member.playerId?.trim();
+  if (!playerId) {
+    return null;
+  }
+
+  const role = member.role === "owner" || member.role === "officer" ? member.role : "member";
+  const invitedByPlayerId = member.invitedByPlayerId?.trim();
+  return {
+    playerId,
+    displayName: normalizeDisplayName(member.displayName, playerId),
+    role,
+    joinedAt: normalizeTimestamp(member.joinedAt),
+    ...(invitedByPlayerId ? { invitedByPlayerId } : {})
+  };
+}
+
+function normalizeGuildJoinRequest(request: Partial<GuildJoinRequestState>): GuildJoinRequestState | null {
+  const requestId = request.requestId?.trim();
+  const playerId = request.playerId?.trim();
+  if (!requestId || !playerId) {
+    return null;
+  }
+
+  const status: GuildJoinRequestStatus =
+    request.status === "approved" || request.status === "rejected" || request.status === "cancelled"
+      ? request.status
+      : "pending";
+  const reviewedByPlayerId = request.reviewedByPlayerId?.trim();
+  const rejectionReason = request.rejectionReason?.trim();
+  return {
+    requestId,
+    playerId,
+    displayName: normalizeDisplayName(request.displayName, playerId),
+    requestedAt: normalizeTimestamp(request.requestedAt),
+    status,
+    ...(request.reviewedAt ? { reviewedAt: normalizeTimestamp(request.reviewedAt) } : {}),
+    ...(reviewedByPlayerId ? { reviewedByPlayerId } : {}),
+    ...(rejectionReason ? { rejectionReason } : {})
+  };
+}
+
+function normalizeGuildInvite(invite: Partial<GuildInviteState>): GuildInviteState | null {
+  const inviteId = invite.inviteId?.trim();
+  const playerId = invite.playerId?.trim();
+  const invitedByPlayerId = invite.invitedByPlayerId?.trim();
+  if (!inviteId || !playerId || !invitedByPlayerId) {
+    return null;
+  }
+
+  const status: GuildInviteStatus =
+    invite.status === "accepted" || invite.status === "declined" || invite.status === "revoked" ? invite.status : "pending";
+  return {
+    inviteId,
+    playerId,
+    invitedByPlayerId,
+    createdAt: normalizeTimestamp(invite.createdAt),
+    status,
+    ...(invite.respondedAt ? { respondedAt: normalizeTimestamp(invite.respondedAt) } : {})
+  };
+}
+
+export function normalizeGuildState(input?: Partial<GuildState> | null): GuildState {
+  const id = input?.id?.trim() ?? "";
+  const name = input?.name?.trim() ?? id;
+  const tag = input?.tag?.trim().toUpperCase() ?? "";
+  const description = input?.description?.trim();
+  const members = Array.from(
+    new Map(
+      (input?.members ?? [])
+        .map((member) => normalizeGuildMember(member))
+        .filter((member): member is GuildMemberState => Boolean(member))
+        .map((member) => [member.playerId, member] as const)
+    ).values()
+  ).sort((left, right) => {
+    const roleOrder = GUILD_ROLE_ORDER[left.role] - GUILD_ROLE_ORDER[right.role];
+    return roleOrder || left.joinedAt.localeCompare(right.joinedAt) || left.playerId.localeCompare(right.playerId);
+  });
+  const joinRequests = Array.from(
+    new Map(
+      (input?.joinRequests ?? [])
+        .map((request) => normalizeGuildJoinRequest(request))
+        .filter((request): request is GuildJoinRequestState => Boolean(request))
+        .map((request) => [request.requestId, request] as const)
+    ).values()
+  ).sort((left, right) => left.requestedAt.localeCompare(right.requestedAt) || left.requestId.localeCompare(right.requestId));
+  const invites = Array.from(
+    new Map(
+      (input?.invites ?? [])
+        .map((invite) => normalizeGuildInvite(invite))
+        .filter((invite): invite is GuildInviteState => Boolean(invite))
+        .map((invite) => [invite.inviteId, invite] as const)
+    ).values()
+  ).sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.inviteId.localeCompare(right.inviteId));
+
+  return {
+    id,
+    name: name || "Guild",
+    tag: tag.slice(0, 4),
+    ...(description ? { description } : {}),
+    memberLimit: ensureGuildMemberLimit(input?.memberLimit),
+    level: Math.max(1, Math.floor(input?.level ?? 1)),
+    xp: Math.max(0, Math.floor(input?.xp ?? 0)),
+    createdAt: normalizeTimestamp(input?.createdAt),
+    updatedAt: normalizeTimestamp(input?.updatedAt),
+    members,
+    joinRequests,
+    invites
+  };
+}
+
+function cloneGuild(guild: GuildState): GuildState {
+  return normalizeGuildState(structuredClone(guild));
+}
+
+function getGuildMember(guild: GuildState, playerId: string): GuildMemberState | undefined {
+  return guild.members.find((member) => member.playerId === playerId);
+}
+
+function hasPendingJoinRequestForPlayer(guild: GuildState, playerId: string): boolean {
+  return guild.joinRequests.some((request) => request.playerId === playerId && request.status === "pending");
+}
+
+function hasPendingInviteForPlayer(guild: GuildState, playerId: string): boolean {
+  return guild.invites.some((invite) => invite.playerId === playerId && invite.status === "pending");
+}
+
+function assertCanReviewJoinRequests(guild: GuildState, actorPlayerId: string): GuildMemberState {
+  const actor = getGuildMember(guild, actorPlayerId);
+  if (!actor || (actor.role !== "owner" && actor.role !== "officer")) {
+    throw new Error("guild_join_review_forbidden");
+  }
+  return actor;
+}
+
+function assertCanManageInvites(guild: GuildState, actorPlayerId: string): GuildMemberState {
+  const actor = getGuildMember(guild, actorPlayerId);
+  if (!actor || (actor.role !== "owner" && actor.role !== "officer")) {
+    throw new Error("guild_invite_forbidden");
+  }
+  return actor;
+}
+
+function assertCanManageRoles(guild: GuildState, actorPlayerId: string): GuildMemberState {
+  const actor = getGuildMember(guild, actorPlayerId);
+  if (!actor || actor.role !== "owner") {
+    throw new Error("guild_role_assignment_forbidden");
+  }
+  return actor;
+}
+
+function assertGuildHasCapacity(guild: GuildState): void {
+  if (guild.members.length >= guild.memberLimit) {
+    throw new Error("guild_member_limit_reached");
+  }
+}
+
+function appendEvent(
+  events: GuildMembershipEvent[],
+  event: Omit<GuildMembershipEvent, "guildId" | "occurredAt">,
+  guildId: string,
+  occurredAt: string
+): void {
+  events.push({
+    guildId,
+    occurredAt,
+    ...event
+  });
+}
+
+function settleMatchingPendingInvite(guild: GuildState, playerId: string, status: Exclude<GuildInviteStatus, "pending">, respondedAt: string): void {
+  const pendingInvite = guild.invites.find((invite) => invite.playerId === playerId && invite.status === "pending");
+  if (!pendingInvite) {
+    return;
+  }
+
+  pendingInvite.status = status;
+  pendingInvite.respondedAt = respondedAt;
+}
+
+function addMember(guild: GuildState, member: GuildMemberState): void {
+  guild.members = guild.members
+    .filter((existing) => existing.playerId !== member.playerId)
+    .concat(member)
+    .sort((left, right) => {
+      const roleOrder = GUILD_ROLE_ORDER[left.role] - GUILD_ROLE_ORDER[right.role];
+      return roleOrder || left.joinedAt.localeCompare(right.joinedAt) || left.playerId.localeCompare(right.playerId);
+    });
+}
+
+export function createGuildRosterView(guildInput: GuildState): GuildRosterView {
+  const guild = normalizeGuildState(guildInput);
+  return {
+    guildId: guild.id,
+    name: guild.name,
+    tag: guild.tag,
+    ...(guild.description ? { description: guild.description } : {}),
+    level: guild.level,
+    xp: guild.xp,
+    memberCount: guild.members.length,
+    memberLimit: guild.memberLimit,
+    availableSeats: Math.max(0, guild.memberLimit - guild.members.length),
+    members: guild.members.map((member) => ({
+      playerId: member.playerId,
+      displayName: member.displayName,
+      role: member.role,
+      roleLabel: GUILD_ROLE_LABELS[member.role],
+      rolePriority: GUILD_ROLE_ORDER[member.role],
+      joinedAt: member.joinedAt,
+      ...(member.invitedByPlayerId ? { invitedByPlayerId: member.invitedByPlayerId } : {})
+    })),
+    pendingJoinRequests: guild.joinRequests
+      .filter((request) => request.status === "pending")
+      .map((request) => ({
+        requestId: request.requestId,
+        playerId: request.playerId,
+        displayName: request.displayName,
+        requestedAt: request.requestedAt,
+        status: request.status
+      }))
+  };
+}
+
+export function createGuildJoinRequest(guildInput: GuildState, input: GuildJoinRequestInput): GuildMutationResult {
+  const guild = cloneGuild(guildInput);
+  const playerId = input.playerId.trim();
+  if (!playerId) {
+    throw new Error("guild_join_request_player_required");
+  }
+  if (getGuildMember(guild, playerId)) {
+    throw new Error("guild_join_request_already_member");
+  }
+  if (hasPendingJoinRequestForPlayer(guild, playerId)) {
+    throw new Error("guild_join_request_pending");
+  }
+
+  const occurredAt = normalizeTimestamp(input.requestedAt);
+  const requestId = input.requestId?.trim() || `join-${playerId}-${occurredAt}`;
+  guild.joinRequests = guild.joinRequests.concat({
+    requestId,
+    playerId,
+    displayName: normalizeDisplayName(input.displayName, playerId),
+    requestedAt: occurredAt,
+    status: "pending"
+  });
+  guild.updatedAt = occurredAt;
+
+  const events: GuildMembershipEvent[] = [];
+  appendEvent(
+    events,
+    {
+      type: "guild.member.join_requested",
+      actorPlayerId: playerId,
+      subjectPlayerId: playerId,
+      metadata: { requestId }
+    },
+    guild.id,
+    occurredAt
+  );
+
+  return { guild: normalizeGuildState(guild), events };
+}
+
+export function reviewGuildJoinRequest(guildInput: GuildState, input: GuildJoinReviewInput): GuildMutationResult {
+  const guild = cloneGuild(guildInput);
+  const actor = assertCanReviewJoinRequests(guild, input.actorPlayerId.trim());
+  const request = guild.joinRequests.find((entry) => entry.requestId === input.requestId.trim());
+  if (!request || request.status !== "pending") {
+    throw new Error("guild_join_request_not_found");
+  }
+
+  const occurredAt = normalizeTimestamp(input.reviewedAt);
+  request.reviewedAt = occurredAt;
+  request.reviewedByPlayerId = actor.playerId;
+  const events: GuildMembershipEvent[] = [];
+
+  if (input.approve) {
+    assertGuildHasCapacity(guild);
+    request.status = "approved";
+    addMember(guild, {
+      playerId: request.playerId,
+      displayName: request.displayName,
+      role: "member",
+      joinedAt: occurredAt
+    });
+    settleMatchingPendingInvite(guild, request.playerId, "accepted", occurredAt);
+    appendEvent(
+      events,
+      {
+        type: "guild.member.join_approved",
+        actorPlayerId: actor.playerId,
+        subjectPlayerId: request.playerId,
+        metadata: { requestId: request.requestId }
+      },
+      guild.id,
+      occurredAt
+    );
+  } else {
+    request.status = "rejected";
+    if (input.rejectionReason?.trim()) {
+      request.rejectionReason = input.rejectionReason.trim();
+    }
+    appendEvent(
+      events,
+      {
+        type: "guild.member.join_rejected",
+        actorPlayerId: actor.playerId,
+        subjectPlayerId: request.playerId,
+        metadata: {
+          requestId: request.requestId,
+          hasReason: Boolean(request.rejectionReason)
+        }
+      },
+      guild.id,
+      occurredAt
+    );
+  }
+
+  guild.updatedAt = occurredAt;
+  return { guild: normalizeGuildState(guild), events };
+}
+
+export function createGuildInvite(guildInput: GuildState, input: GuildInviteInput): GuildMutationResult {
+  const guild = cloneGuild(guildInput);
+  const actor = assertCanManageInvites(guild, input.actorPlayerId.trim());
+  const playerId = input.playerId.trim();
+  if (!playerId) {
+    throw new Error("guild_invite_player_required");
+  }
+  if (getGuildMember(guild, playerId)) {
+    throw new Error("guild_invite_already_member");
+  }
+  if (hasPendingInviteForPlayer(guild, playerId)) {
+    throw new Error("guild_invite_pending");
+  }
+
+  const occurredAt = normalizeTimestamp(input.createdAt);
+  const inviteId = input.inviteId?.trim() || `invite-${playerId}-${occurredAt}`;
+  guild.invites = guild.invites.concat({
+    inviteId,
+    playerId,
+    invitedByPlayerId: actor.playerId,
+    createdAt: occurredAt,
+    status: "pending"
+  });
+  guild.updatedAt = occurredAt;
+
+  const events: GuildMembershipEvent[] = [];
+  appendEvent(
+    events,
+    {
+      type: "guild.member.invited",
+      actorPlayerId: actor.playerId,
+      subjectPlayerId: playerId,
+      metadata: { inviteId }
+    },
+    guild.id,
+    occurredAt
+  );
+
+  return { guild: normalizeGuildState(guild), events };
+}
+
+export function respondToGuildInvite(guildInput: GuildState, input: GuildInviteResponseInput): GuildMutationResult {
+  const guild = cloneGuild(guildInput);
+  const playerId = input.playerId.trim();
+  const invite = guild.invites.find((entry) => entry.inviteId === input.inviteId.trim());
+  if (!invite || invite.status !== "pending") {
+    throw new Error("guild_invite_not_found");
+  }
+  if (invite.playerId !== playerId) {
+    throw new Error("guild_invite_response_forbidden");
+  }
+  if (getGuildMember(guild, playerId)) {
+    throw new Error("guild_invite_already_member");
+  }
+
+  const occurredAt = normalizeTimestamp(input.respondedAt);
+  invite.respondedAt = occurredAt;
+  const events: GuildMembershipEvent[] = [];
+
+  if (input.accept) {
+    assertGuildHasCapacity(guild);
+    invite.status = "accepted";
+    addMember(guild, {
+      playerId,
+      displayName: playerId,
+      role: "member",
+      joinedAt: occurredAt,
+      invitedByPlayerId: invite.invitedByPlayerId
+    });
+    appendEvent(
+      events,
+      {
+        type: "guild.member.invite_accepted",
+        actorPlayerId: playerId,
+        subjectPlayerId: playerId,
+        metadata: { inviteId: invite.inviteId, invitedByPlayerId: invite.invitedByPlayerId }
+      },
+      guild.id,
+      occurredAt
+    );
+  } else {
+    invite.status = "declined";
+    appendEvent(
+      events,
+      {
+        type: "guild.member.invite_declined",
+        actorPlayerId: playerId,
+        subjectPlayerId: playerId,
+        metadata: { inviteId: invite.inviteId, invitedByPlayerId: invite.invitedByPlayerId }
+      },
+      guild.id,
+      occurredAt
+    );
+  }
+
+  guild.updatedAt = occurredAt;
+  return { guild: normalizeGuildState(guild), events };
+}
+
+export function assignGuildMemberRole(guildInput: GuildState, input: GuildRoleAssignmentInput): GuildMutationResult {
+  const guild = cloneGuild(guildInput);
+  const actor = assertCanManageRoles(guild, input.actorPlayerId.trim());
+  const target = getGuildMember(guild, input.targetPlayerId.trim());
+  if (!target) {
+    throw new Error("guild_role_assignment_target_not_found");
+  }
+  if (target.playerId === actor.playerId && input.role !== "owner") {
+    throw new Error("guild_role_assignment_self_forbidden");
+  }
+  if (target.role === input.role) {
+    throw new Error("guild_role_assignment_noop");
+  }
+
+  const occurredAt = normalizeTimestamp(input.changedAt);
+  const events: GuildMembershipEvent[] = [];
+
+  if (input.role === "owner") {
+    target.role = "owner";
+    actor.role = "officer";
+    appendEvent(
+      events,
+      {
+        type: "guild.member.owner_transferred",
+        actorPlayerId: actor.playerId,
+        subjectPlayerId: target.playerId,
+        metadata: {
+          previousOwnerPlayerId: actor.playerId,
+          newOwnerPlayerId: target.playerId
+        }
+      },
+      guild.id,
+      occurredAt
+    );
+  } else {
+    const previousRole = target.role;
+    target.role = input.role;
+    appendEvent(
+      events,
+      {
+        type: "guild.member.role_changed",
+        actorPlayerId: actor.playerId,
+        subjectPlayerId: target.playerId,
+        metadata: {
+          previousRole,
+          nextRole: input.role
+        }
+      },
+      guild.id,
+      occurredAt
+    );
+  }
+
+  guild.updatedAt = occurredAt;
+  guild.members.sort((left, right) => {
+    const roleOrder = GUILD_ROLE_ORDER[left.role] - GUILD_ROLE_ORDER[right.role];
+    return roleOrder || left.joinedAt.localeCompare(right.joinedAt) || left.playerId.localeCompare(right.playerId);
+  });
+  return { guild: normalizeGuildState(guild), events };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,6 +14,7 @@ export * from "./equipment.ts";
 export * from "./event-log.ts";
 export * from "./feature-flags.ts";
 export * from "./feedback.ts";
+export * from "./guilds.ts";
 export * from "./hero-skills.ts";
 export * from "./hero-progression.ts";
 export * from "./map.ts";

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -6,10 +6,56 @@ export type BuildingKind = "recruitment_post" | "attribute_shrine" | "resource_m
 export type BuildingUpgradeTrackId = "castle" | "mine";
 export type ResourceLedger = Record<ResourceKind, number>;
 export type WorldResourceLedger = Record<string, ResourceLedger>;
+export type GuildRole = "owner" | "officer" | "member";
+export type GuildJoinRequestStatus = "pending" | "approved" | "rejected" | "cancelled";
+export type GuildInviteStatus = "pending" | "accepted" | "declined" | "revoked";
 
 export interface Vec2 {
   x: number;
   y: number;
+}
+
+export interface GuildMemberState {
+  playerId: string;
+  displayName: string;
+  role: GuildRole;
+  joinedAt: string;
+  invitedByPlayerId?: string;
+}
+
+export interface GuildJoinRequestState {
+  requestId: string;
+  playerId: string;
+  displayName: string;
+  requestedAt: string;
+  status: GuildJoinRequestStatus;
+  reviewedAt?: string;
+  reviewedByPlayerId?: string;
+  rejectionReason?: string;
+}
+
+export interface GuildInviteState {
+  inviteId: string;
+  playerId: string;
+  invitedByPlayerId: string;
+  createdAt: string;
+  status: GuildInviteStatus;
+  respondedAt?: string;
+}
+
+export interface GuildState {
+  id: string;
+  name: string;
+  tag: string;
+  description?: string;
+  memberLimit: number;
+  level: number;
+  xp: number;
+  createdAt: string;
+  updatedAt: string;
+  members: GuildMemberState[];
+  joinRequests: GuildJoinRequestState[];
+  invites: GuildInviteState[];
 }
 
 export interface HeroStats {

--- a/packages/shared/test/guilds.test.ts
+++ b/packages/shared/test/guilds.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assignGuildMemberRole,
+  createGuildInvite,
+  createGuildJoinRequest,
+  createGuildRosterView,
+  normalizeGuildState,
+  respondToGuildInvite,
+  reviewGuildJoinRequest,
+  type GuildState
+} from "../src/index";
+
+function createGuild(overrides?: Partial<GuildState>): GuildState {
+  return normalizeGuildState({
+    id: "guild-nightwatch",
+    name: "Nightwatch",
+    tag: "NITE",
+    description: "Frontier sentinels",
+    memberLimit: 4,
+    level: 3,
+    xp: 2250,
+    createdAt: "2026-04-01T10:00:00.000Z",
+    updatedAt: "2026-04-01T10:00:00.000Z",
+    members: [
+      {
+        playerId: "owner-1",
+        displayName: "Owner",
+        role: "owner",
+        joinedAt: "2026-04-01T10:00:00.000Z"
+      },
+      {
+        playerId: "officer-1",
+        displayName: "Officer",
+        role: "officer",
+        joinedAt: "2026-04-01T10:05:00.000Z"
+      },
+      {
+        playerId: "member-1",
+        displayName: "Member",
+        role: "member",
+        joinedAt: "2026-04-01T10:10:00.000Z"
+      }
+    ],
+    joinRequests: [],
+    invites: [],
+    ...overrides
+  });
+}
+
+test("guild roster view exposes stable role metadata in rank order", () => {
+  const roster = createGuildRosterView(
+    createGuild({
+      members: [
+        {
+          playerId: "member-2",
+          displayName: "Scout",
+          role: "member",
+          joinedAt: "2026-04-01T10:20:00.000Z"
+        },
+        {
+          playerId: "owner-1",
+          displayName: "Owner",
+          role: "owner",
+          joinedAt: "2026-04-01T10:00:00.000Z"
+        },
+        {
+          playerId: "officer-1",
+          displayName: "Officer",
+          role: "officer",
+          joinedAt: "2026-04-01T10:05:00.000Z"
+        }
+      ]
+    })
+  );
+
+  assert.deepEqual(
+    roster.members.map((member) => [member.playerId, member.role, member.roleLabel, member.rolePriority]),
+    [
+      ["owner-1", "owner", "Owner", 0],
+      ["officer-1", "officer", "Officer", 1],
+      ["member-2", "member", "Member", 2]
+    ]
+  );
+  assert.equal(roster.availableSeats, 1);
+});
+
+test("owner can promote a member to officer and emit a structured membership event", () => {
+  const result = assignGuildMemberRole(createGuild(), {
+    actorPlayerId: "owner-1",
+    targetPlayerId: "member-1",
+    role: "officer",
+    changedAt: "2026-04-02T09:00:00.000Z"
+  });
+
+  const promoted = result.guild.members.find((member) => member.playerId === "member-1");
+  assert.equal(promoted?.role, "officer");
+  assert.deepEqual(result.events[0], {
+    type: "guild.member.role_changed",
+    guildId: "guild-nightwatch",
+    actorPlayerId: "owner-1",
+    subjectPlayerId: "member-1",
+    occurredAt: "2026-04-02T09:00:00.000Z",
+    metadata: {
+      previousRole: "member",
+      nextRole: "officer"
+    }
+  });
+});
+
+test("officer cannot change guild roles", () => {
+  assert.throws(
+    () =>
+      assignGuildMemberRole(createGuild(), {
+        actorPlayerId: "officer-1",
+        targetPlayerId: "member-1",
+        role: "officer"
+      }),
+    /guild_role_assignment_forbidden/
+  );
+});
+
+test("owner transfer promotes the new owner and demotes the previous owner to officer", () => {
+  const result = assignGuildMemberRole(createGuild(), {
+    actorPlayerId: "owner-1",
+    targetPlayerId: "officer-1",
+    role: "owner",
+    changedAt: "2026-04-02T09:30:00.000Z"
+  });
+
+  assert.equal(result.guild.members.find((member) => member.playerId === "officer-1")?.role, "owner");
+  assert.equal(result.guild.members.find((member) => member.playerId === "owner-1")?.role, "officer");
+  assert.equal(result.events[0]?.type, "guild.member.owner_transferred");
+});
+
+test("officer can approve a pending join request and add the player to the roster", () => {
+  const requested = createGuildJoinRequest(createGuild(), {
+    playerId: "applicant-1",
+    displayName: "Applicant",
+    requestId: "join-1",
+    requestedAt: "2026-04-02T08:00:00.000Z"
+  });
+
+  const approved = reviewGuildJoinRequest(requested.guild, {
+    actorPlayerId: "officer-1",
+    requestId: "join-1",
+    approve: true,
+    reviewedAt: "2026-04-02T08:15:00.000Z"
+  });
+
+  assert.equal(approved.guild.joinRequests[0]?.status, "approved");
+  assert.equal(approved.guild.members.find((member) => member.playerId === "applicant-1")?.role, "member");
+  assert.deepEqual(approved.events[0], {
+    type: "guild.member.join_approved",
+    guildId: "guild-nightwatch",
+    actorPlayerId: "officer-1",
+    subjectPlayerId: "applicant-1",
+    occurredAt: "2026-04-02T08:15:00.000Z",
+    metadata: {
+      requestId: "join-1"
+    }
+  });
+});
+
+test("members cannot approve join requests", () => {
+  const requested = createGuildJoinRequest(createGuild(), {
+    playerId: "applicant-1",
+    displayName: "Applicant",
+    requestId: "join-1",
+    requestedAt: "2026-04-02T08:00:00.000Z"
+  });
+
+  assert.throws(
+    () =>
+      reviewGuildJoinRequest(requested.guild, {
+        actorPlayerId: "member-1",
+        requestId: "join-1",
+        approve: true
+      }),
+    /guild_join_review_forbidden/
+  );
+});
+
+test("join rejection preserves the applicant outside the roster and records the rejection", () => {
+  const requested = createGuildJoinRequest(createGuild(), {
+    playerId: "applicant-2",
+    displayName: "Applicant",
+    requestId: "join-2",
+    requestedAt: "2026-04-02T08:00:00.000Z"
+  });
+
+  const rejected = reviewGuildJoinRequest(requested.guild, {
+    actorPlayerId: "owner-1",
+    requestId: "join-2",
+    approve: false,
+    reviewedAt: "2026-04-02T08:20:00.000Z",
+    rejectionReason: "guild_full"
+  });
+
+  assert.equal(rejected.guild.members.some((member) => member.playerId === "applicant-2"), false);
+  assert.equal(rejected.guild.joinRequests[0]?.status, "rejected");
+  assert.equal(rejected.guild.joinRequests[0]?.rejectionReason, "guild_full");
+  assert.equal(rejected.events[0]?.type, "guild.member.join_rejected");
+});
+
+test("invited players can accept or decline their invite, while others cannot respond for them", () => {
+  const invited = createGuildInvite(createGuild(), {
+    actorPlayerId: "officer-1",
+    playerId: "friend-1",
+    inviteId: "invite-1",
+    createdAt: "2026-04-02T07:00:00.000Z"
+  });
+
+  assert.throws(
+    () =>
+      respondToGuildInvite(invited.guild, {
+        playerId: "intruder-1",
+        inviteId: "invite-1",
+        accept: true
+      }),
+    /guild_invite_response_forbidden/
+  );
+
+  const accepted = respondToGuildInvite(invited.guild, {
+    playerId: "friend-1",
+    inviteId: "invite-1",
+    accept: true,
+    respondedAt: "2026-04-02T07:30:00.000Z"
+  });
+  assert.equal(accepted.guild.members.find((member) => member.playerId === "friend-1")?.invitedByPlayerId, "officer-1");
+  assert.equal(accepted.events[0]?.type, "guild.member.invite_accepted");
+
+  const declined = respondToGuildInvite(invited.guild, {
+    playerId: "friend-1",
+    inviteId: "invite-1",
+    accept: false,
+    respondedAt: "2026-04-02T07:45:00.000Z"
+  });
+  assert.equal(declined.guild.invites[0]?.status, "declined");
+  assert.equal(declined.events[0]?.type, "guild.member.invite_declined");
+});


### PR DESCRIPTION
## Summary
- add shared guild state types for members, join requests, and invites
- add a shared guild workflow module for roster queries, role assignment, invite handling, and join approval or rejection
- add focused shared tests covering role permissions, roster metadata, and membership state transitions

Closes #873

## Validation
- `npm run typecheck:shared`
- `node --import tsx --test packages/shared/test/guilds.test.ts`
- `npm run typecheck:ci`
- `npm run test:shared` *(fails on existing unrelated test: `packages/shared/test/move-distance-cap.test.ts` expecting `not_enough_move_points` but receiving `{ valid: true }`)*