### PR TITLE
[codex] Implement competitive season progression

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -68,6 +68,16 @@ export interface LeaderboardEntry {
   displayName: string;
   eloRating: number;
   tier: LeaderboardTier;
+  division?: string;
+  promotionSeries?: {
+    wins: number;
+    losses: number;
+    winsRequired: number;
+    lossesAllowed: number;
+  } | null;
+  demotionShield?: {
+    remainingMatches: number;
+  } | null;
 }
 
 export type FogState = "hidden" | "explored" | "visible";
@@ -541,6 +551,16 @@ interface LeaderboardApiPayload {
     displayName?: string;
     eloRating?: number;
     tier?: LeaderboardTier;
+    division?: string;
+    promotionSeries?: {
+      wins?: number;
+      losses?: number;
+      winsRequired?: number;
+      lossesAllowed?: number;
+    } | null;
+    demotionShield?: {
+      remainingMatches?: number;
+    } | null;
   }>;
 }
 
@@ -971,7 +991,25 @@ async function fetchLeaderboardEntries(remoteUrl?: string, limit = 50): Promise<
       rank: index + 1,
       displayName: player.displayName?.trim() || player.playerId?.trim() || `玩家 ${index + 1}`,
       eloRating,
-      tier: normalizeLeaderboardTier(player.tier)
+      tier: normalizeLeaderboardTier(player.tier),
+      ...(player.division?.trim() ? { division: player.division.trim() } : {}),
+      ...(player.promotionSeries
+        ? {
+            promotionSeries: {
+              wins: Math.max(0, Math.floor(player.promotionSeries.wins ?? 0)),
+              losses: Math.max(0, Math.floor(player.promotionSeries.losses ?? 0)),
+              winsRequired: Math.max(1, Math.floor(player.promotionSeries.winsRequired ?? 3)),
+              lossesAllowed: Math.max(1, Math.floor(player.promotionSeries.lossesAllowed ?? 2))
+            }
+          }
+        : {}),
+      ...(player.demotionShield
+        ? {
+            demotionShield: {
+              remainingMatches: Math.max(0, Math.floor(player.demotionShield.remainingMatches ?? 0))
+            }
+          }
+        : {})
     };
   });
 }

--- a/apps/cocos-client/assets/scripts/cocos-leaderboard-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-leaderboard-panel.ts
@@ -47,9 +47,24 @@ function formatTierBadge(row: LeaderboardRowView | null, fallbackTier?: Leaderbo
   return fallbackTier ? formatTierLabel(fallbackTier).toUpperCase() : "UNRANKED";
 }
 
+function formatDivisionLabel(entry: LeaderboardEntry): string {
+  return entry.division?.trim() ? entry.division.trim().replace(/_/g, " ").toUpperCase() : formatTierLabel(entry.tier);
+}
+
+function formatPromotionSummary(entry: LeaderboardEntry): string {
+  if (entry.promotionSeries) {
+    return `晋级赛 ${entry.promotionSeries.wins}/${entry.promotionSeries.winsRequired} 胜 · ${entry.promotionSeries.losses}/${entry.promotionSeries.lossesAllowed} 负`;
+  }
+  if (entry.demotionShield && entry.demotionShield.remainingMatches > 0) {
+    return `降级保护 ${entry.demotionShield.remainingMatches} 场`;
+  }
+  return "";
+}
+
 export function buildCocosLeaderboardPanelView(input: CocosLeaderboardPanelInput): CocosLeaderboardPanelView {
   const rows = input.entries.map<LeaderboardRowView>((entry) => {
-    const tierLabel = formatTierLabel(entry.tier);
+    const tierLabel = formatDivisionLabel(entry);
+    const promotionSummary = formatPromotionSummary(entry);
     const isCurrentPlayer = entry.playerId === input.myPlayerId;
     return {
       playerId: entry.playerId,
@@ -58,7 +73,7 @@ export function buildCocosLeaderboardPanelView(input: CocosLeaderboardPanelInput
       displayName: entry.displayName.trim() || entry.playerId,
       ratingLabel: `ELO ${entry.eloRating}`,
       tierLabel,
-      summary: `#${entry.rank} ${entry.displayName.trim() || entry.playerId} · ELO ${entry.eloRating} · ${tierLabel}`,
+      summary: `#${entry.rank} ${entry.displayName.trim() || entry.playerId} · ELO ${entry.eloRating} · ${tierLabel}${promotionSummary ? ` · ${promotionSummary}` : ""}`,
       isCurrentPlayer
     };
   });

--- a/apps/server/src/competitive-season.ts
+++ b/apps/server/src/competitive-season.ts
@@ -1,0 +1,238 @@
+import {
+  addUtcDays,
+  didPlayerWinReplay,
+  getRankDivisionForRating,
+  getRankDivisionIndex,
+  getSoftDecayDivision,
+  getTierForDivision,
+  getTierFloorDivision,
+  getUtcWeekStart,
+  isPromotionSeriesBoundary,
+  resolveRankedSeasonConfig,
+  type PlayerBattleReplaySummary,
+  type RankDivisionId
+} from "../../../packages/shared/src/index";
+import type { PlayerAccountSnapshot, PlayerAccountProgressPatch } from "./persistence";
+
+function uniqueNewReplays(
+  existing: PlayerAccountSnapshot,
+  nextReplays: NonNullable<PlayerAccountSnapshot["recentBattleReplays"]>
+): PlayerBattleReplaySummary[] {
+  const existingIds = new Set((existing.recentBattleReplays ?? []).map((replay) => replay.id));
+  return nextReplays
+    .filter((replay) => !existingIds.has(replay.id))
+    .sort((left, right) => left.completedAt.localeCompare(right.completedAt) || left.id.localeCompare(right.id));
+}
+
+function toHeroPvpReplays(replays: PlayerBattleReplaySummary[]): PlayerBattleReplaySummary[] {
+  return replays.filter((replay) => replay.battleKind === "hero");
+}
+
+function updateWeeklyProgress(
+  account: PlayerAccountSnapshot,
+  newReplays: PlayerBattleReplaySummary[],
+  referenceTime = new Date()
+): NonNullable<PlayerAccountSnapshot["rankedWeeklyProgress"]> {
+  const currentWeekStartsAt = getUtcWeekStart(referenceTime);
+  const existing = account.rankedWeeklyProgress;
+  const previousWeekStartsAt = addUtcDays(currentWeekStartsAt, -7);
+  const next = {
+    currentWeekStartsAt,
+    currentWeekWins: 0,
+    ...(existing?.currentWeekStartsAt === previousWeekStartsAt
+      ? {
+          previousWeekStartsAt: existing.currentWeekStartsAt,
+          previousWeekWins: existing.currentWeekWins
+        }
+      : existing?.previousWeekStartsAt === previousWeekStartsAt
+        ? {
+            previousWeekStartsAt,
+            previousWeekWins: existing.previousWeekWins ?? 0
+          }
+        : {})
+  };
+
+  if (existing?.currentWeekStartsAt === currentWeekStartsAt) {
+    next.currentWeekWins = existing.currentWeekWins;
+    if (existing.previousWeekStartsAt === previousWeekStartsAt) {
+      next.previousWeekStartsAt = existing.previousWeekStartsAt;
+      next.previousWeekWins = existing.previousWeekWins ?? 0;
+    }
+  }
+
+  for (const replay of toHeroPvpReplays(newReplays)) {
+    if (!didPlayerWinReplay(replay)) {
+      continue;
+    }
+    const replayWeekStartsAt = getUtcWeekStart(replay.completedAt);
+    if (replayWeekStartsAt === next.currentWeekStartsAt) {
+      next.currentWeekWins += 1;
+      continue;
+    }
+    if (replayWeekStartsAt === previousWeekStartsAt) {
+      next.previousWeekStartsAt = previousWeekStartsAt;
+      next.previousWeekWins = (next.previousWeekWins ?? 0) + 1;
+    }
+  }
+
+  return next;
+}
+
+export function resolveCompetitiveProgression(
+  existing: PlayerAccountSnapshot,
+  patch: PlayerAccountProgressPatch,
+  nextReplays: NonNullable<PlayerAccountSnapshot["recentBattleReplays"]>,
+  nextRating: number,
+  referenceTime = new Date()
+): Pick<
+  PlayerAccountSnapshot,
+  "rankDivision" | "peakRankDivision" | "promotionSeries" | "demotionShield" | "rankedWeeklyProgress"
+> {
+  const config = resolveRankedSeasonConfig();
+  const newReplays = uniqueNewReplays(existing, nextReplays);
+  const heroPvpReplays = toHeroPvpReplays(newReplays);
+  let rankDivision = existing.rankDivision ?? getRankDivisionForRating(existing.eloRating ?? 1000);
+  let peakRankDivision = existing.peakRankDivision ?? rankDivision;
+  let promotionSeries = existing.promotionSeries;
+  let demotionShield = existing.demotionShield;
+  const targetDivision = patch.eloRating !== undefined ? getRankDivisionForRating(nextRating) : rankDivision;
+
+  if (patch.eloRating !== undefined && isPromotionSeriesBoundary(rankDivision, targetDivision)) {
+    if (!promotionSeries || promotionSeries.targetDivision !== targetDivision) {
+      promotionSeries = {
+        targetDivision,
+        wins: 0,
+        losses: 0,
+        winsRequired: config.promotionSeries.winsRequired,
+        lossesAllowed: config.promotionSeries.lossesAllowed
+      };
+    }
+  } else if (patch.eloRating !== undefined && getTierForDivision(targetDivision) === getTierForDivision(rankDivision)) {
+    rankDivision = targetDivision;
+    promotionSeries = undefined;
+  } else if (patch.eloRating !== undefined && getRankDivisionIndex(targetDivision) < getRankDivisionIndex(rankDivision)) {
+    if (demotionShield && demotionShield.remainingMatches > 0 && demotionShield.tier === getTierForDivision(rankDivision)) {
+      demotionShield = {
+        ...demotionShield,
+        remainingMatches: Math.max(0, demotionShield.remainingMatches - heroPvpReplays.length)
+      };
+      if (demotionShield.remainingMatches <= 0) {
+        demotionShield = undefined;
+        rankDivision = targetDivision;
+      }
+    } else {
+      rankDivision = targetDivision;
+    }
+    promotionSeries = undefined;
+  }
+
+  for (const replay of heroPvpReplays) {
+    if (promotionSeries) {
+      if (didPlayerWinReplay(replay)) {
+        promotionSeries = {
+          ...promotionSeries,
+          wins: promotionSeries.wins + 1
+        };
+      } else {
+        promotionSeries = {
+          ...promotionSeries,
+          losses: promotionSeries.losses + 1
+        };
+      }
+
+      if (promotionSeries.wins >= promotionSeries.winsRequired) {
+        rankDivision = promotionSeries.targetDivision;
+        peakRankDivision =
+          getRankDivisionIndex(rankDivision) > getRankDivisionIndex(peakRankDivision) ? rankDivision : peakRankDivision;
+        demotionShield = {
+          tier: getTierForDivision(rankDivision),
+          remainingMatches: config.demotionShield.games
+        };
+        promotionSeries = undefined;
+      } else if (promotionSeries.losses >= promotionSeries.lossesAllowed) {
+        promotionSeries = undefined;
+      }
+      continue;
+    }
+
+    if (demotionShield && demotionShield.remainingMatches > 0) {
+      demotionShield = {
+        ...demotionShield,
+        remainingMatches: Math.max(0, demotionShield.remainingMatches - 1)
+      };
+      if (demotionShield.remainingMatches <= 0) {
+        demotionShield = undefined;
+      }
+    }
+  }
+
+  if (getRankDivisionIndex(rankDivision) > getRankDivisionIndex(peakRankDivision)) {
+    peakRankDivision = rankDivision;
+  }
+
+  return {
+    rankDivision,
+    peakRankDivision,
+    ...(promotionSeries ? { promotionSeries } : {}),
+    ...(demotionShield ? { demotionShield } : {}),
+    rankedWeeklyProgress: updateWeeklyProgress(existing, newReplays, referenceTime)
+  };
+}
+
+export function applySeasonSoftDecay(account: PlayerAccountSnapshot): Pick<
+  PlayerAccountSnapshot,
+  "eloRating" | "rankDivision" | "peakRankDivision" | "promotionSeries" | "demotionShield"
+> {
+  const nextDivision = getSoftDecayDivision(account.rankDivision ?? getRankDivisionForRating(account.eloRating ?? 1000));
+  return {
+    eloRating: decayDivisionToRating(nextDivision),
+    rankDivision: nextDivision,
+    peakRankDivision: nextDivision
+  };
+}
+
+export function getCurrentAndPreviousWeeklyEntries(accounts: PlayerAccountSnapshot[], referenceTime = new Date()) {
+  const currentWeekStartsAt = getUtcWeekStart(referenceTime);
+  const previousWeekStartsAt = addUtcDays(currentWeekStartsAt, -7);
+
+  const current = accounts
+    .map((account) => ({
+      playerId: account.playerId,
+      displayName: account.displayName,
+      wins: account.rankedWeeklyProgress?.currentWeekStartsAt === currentWeekStartsAt
+        ? account.rankedWeeklyProgress.currentWeekWins
+        : 0,
+      weekStartsAt: currentWeekStartsAt,
+      weekEndsAt: addUtcDays(currentWeekStartsAt, 7),
+      rankDivision: account.rankDivision ?? getRankDivisionForRating(account.eloRating ?? 1000)
+    }))
+    .filter((entry) => entry.wins > 0)
+    .sort((left, right) => right.wins - left.wins || left.playerId.localeCompare(right.playerId))
+    .slice(0, 100);
+
+  const previous = accounts
+    .map((account) => ({
+      playerId: account.playerId,
+      displayName: account.displayName,
+      wins:
+        account.rankedWeeklyProgress?.previousWeekStartsAt === previousWeekStartsAt
+          ? account.rankedWeeklyProgress.previousWeekWins ?? 0
+          : 0,
+      weekStartsAt: previousWeekStartsAt,
+      weekEndsAt: currentWeekStartsAt,
+      rankDivision: account.rankDivision ?? getRankDivisionForRating(account.eloRating ?? 1000)
+    }))
+    .filter((entry) => entry.wins > 0)
+    .sort((left, right) => right.wins - left.wins || left.playerId.localeCompare(right.playerId))
+    .slice(0, 100);
+
+  return { current, previous };
+}
+
+export function decayDivisionToRating(division: RankDivisionId): number {
+  return resolveRankedSeasonConfig().divisionThresholds[division];
+}
+
+export function getDivisionTierFloor(division: RankDivisionId): RankDivisionId {
+  return getTierFloorDivision(getTierForDivision(division));
+}

--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { getTierForRating } from "../../../packages/shared/src/index";
+import { getRankDivisionForRating, getTierForRating } from "../../../packages/shared/src/index";
+import { getCurrentAndPreviousWeeklyEntries } from "./competitive-season";
 import type { RoomSnapshotStore } from "./persistence";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -62,10 +63,47 @@ export function registerLeaderboardRoutes(
         playerId: account.playerId,
         displayName: account.displayName,
         eloRating: account.eloRating,
-        tier: getTierForRating(account.eloRating ?? 1000)
+        tier: getTierForRating(account.eloRating ?? 1000),
+        division: account.rankDivision ?? getRankDivisionForRating(account.eloRating ?? 1000),
+        promotionSeries: account.promotionSeries ?? null,
+        demotionShield: account.demotionShield ?? null
       }));
 
       sendJson(response, 200, { players });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/leaderboard/weekly", async (_request, response) => {
+    try {
+      if (!store) {
+        sendJson(response, 200, { current: [], previous: [] });
+        return;
+      }
+      const accounts = await store.listPlayerAccounts({ limit: 500, orderBy: "eloRating" });
+      const { current, previous } = getCurrentAndPreviousWeeklyEntries(accounts);
+      sendJson(response, 200, { current, previous });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player/:id/season-history", async (request, response) => {
+    try {
+      if (!store) {
+        sendJson(response, 200, { history: [] });
+        return;
+      }
+      const url = request.url ?? "/";
+      const match = url.match(/\/api\/player\/([^/]+)\/season-history/);
+      const playerId = match?.[1] ? decodeURIComponent(match[1]) : "";
+      if (!playerId) {
+        sendJson(response, 400, { error: { code: "invalid_player_id", message: "Player id is required" } });
+        return;
+      }
+      const account = await store.loadPlayerAccount(playerId);
+      sendJson(response, 200, { history: account?.seasonHistory ?? [] });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -2,6 +2,7 @@ import {
   appendEventLogEntries,
   DEFAULT_TUTORIAL_STEP,
   getEquipmentDefinition,
+  getTierForDivision,
   normalizeEloRating,
   normalizeEventLogEntries,
   normalizeEventLogQuery,
@@ -53,6 +54,7 @@ import {
   resolveBattlePassTier,
   toBattlePassRewardGrant
 } from "./battle-pass";
+import { applySeasonSoftDecay, decayDivisionToRating, getCurrentAndPreviousWeeklyEntries, resolveCompetitiveProgression } from "./competitive-season";
 import { computeSeasonReward, resolveSeasonRewardConfig } from "./season-rewards";
 
 function cloneAccount(account: PlayerAccountSnapshot): PlayerAccountSnapshot {
@@ -1035,6 +1037,17 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     const battlePassConfig = resolveBattlePassConfig();
     const existing = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
     const battlePassProgress = applyBattlePassXp(battlePassConfig, existing, patch.seasonXpDelta ?? 0);
+    const mergedReplays = structuredClone(
+      (patch.recentBattleReplays as PlayerAccountSnapshot["recentBattleReplays"] | undefined) ??
+        existing.recentBattleReplays ??
+        []
+    );
+    const competitiveProgression = resolveCompetitiveProgression(
+      existing,
+      patch,
+      mergedReplays,
+      patch.eloRating ?? existing.eloRating ?? 1000
+    );
     const nextAccount: PlayerAccountSnapshot = {
       ...existing,
       ...(patch.gems !== undefined ? { gems: Math.max(0, Math.floor(patch.gems)) } : {}),
@@ -1061,11 +1074,33 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       ),
       achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
       recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
-      recentBattleReplays: structuredClone(
-        (patch.recentBattleReplays as PlayerAccountSnapshot["recentBattleReplays"] | undefined) ??
-          existing.recentBattleReplays ??
-          []
-      ),
+      recentBattleReplays: mergedReplays,
+      ...((patch.rankDivision ?? competitiveProgression.rankDivision)
+        ? { rankDivision: (patch.rankDivision ?? competitiveProgression.rankDivision)! }
+        : {}),
+      ...((patch.peakRankDivision ?? competitiveProgression.peakRankDivision)
+        ? { peakRankDivision: (patch.peakRankDivision ?? competitiveProgression.peakRankDivision)! }
+        : {}),
+      ...(patch.promotionSeries !== undefined
+        ? patch.promotionSeries
+          ? { promotionSeries: structuredClone(patch.promotionSeries) }
+          : {}
+        : competitiveProgression.promotionSeries
+          ? { promotionSeries: structuredClone(competitiveProgression.promotionSeries) }
+          : {}),
+      ...(patch.demotionShield !== undefined
+        ? patch.demotionShield
+          ? { demotionShield: structuredClone(patch.demotionShield) }
+          : {}
+        : competitiveProgression.demotionShield
+          ? { demotionShield: structuredClone(competitiveProgression.demotionShield) }
+          : {}),
+      seasonHistory: structuredClone((patch.seasonHistory as PlayerAccountSnapshot["seasonHistory"] | undefined) ?? existing.seasonHistory ?? []),
+      ...(patch.rankedWeeklyProgress !== undefined
+        ? patch.rankedWeeklyProgress
+          ? { rankedWeeklyProgress: structuredClone(patch.rankedWeeklyProgress) }
+          : {}
+        : { rankedWeeklyProgress: structuredClone(competitiveProgression.rankedWeeklyProgress) }),
       ...(patch.dailyDungeonState !== undefined
         ? patch.dailyDungeonState
           ? { dailyDungeonState: structuredClone(patch.dailyDungeonState) }
@@ -1286,6 +1321,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     const distributedAt = new Date().toISOString();
     let playersRewarded = 0;
     let totalGemsGranted = 0;
+    const rewardedPlayerIds = new Set<string>();
     for (const [index, account] of rankedAccounts.entries()) {
       const reward = computeSeasonReward(index + 1, rankedAccounts.length, rewardConfig);
       if (!reward) {
@@ -1306,6 +1342,30 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       });
       playersRewarded += 1;
       totalGemsGranted += reward.gems;
+      rewardedPlayerIds.add(account.playerId);
+    }
+
+    for (const account of rankedAccounts) {
+      const current = this.accounts.get(account.playerId) ?? account;
+      const decay = applySeasonSoftDecay(current);
+      await this.savePlayerAccountProgress(account.playerId, {
+        eloRating: decayDivisionToRating(decay.rankDivision ?? current.rankDivision ?? "bronze_i"),
+        rankDivision: decay.rankDivision,
+        peakRankDivision: decay.peakRankDivision,
+        promotionSeries: null,
+        demotionShield: null,
+        seasonHistory: [
+          {
+            seasonId: normalizedSeasonId,
+            peakDivision: current.peakRankDivision ?? current.rankDivision ?? "bronze_i",
+            finalDivision: current.rankDivision ?? "bronze_i",
+            rewardTier: getTierForDivision(current.rankDivision ?? "bronze_i"),
+            rewardClaimed: rewardedPlayerIds.has(account.playerId),
+            archivedAt: distributedAt
+          },
+          ...(current.seasonHistory ?? [])
+        ].slice(0, 20)
+      });
     }
 
     this.seasons.set(normalizedSeasonId, {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -6,6 +6,7 @@ import {
   getEquipmentDefinition,
   getTierForRating,
   appendPlayerBattleReplaySummaries,
+  getRankDivisionForRating,
   normalizeEloRating,
   normalizeEventLogQuery,
   normalizeAchievementProgress,
@@ -21,7 +22,9 @@ import {
   type PlayerAccountReadModel,
   type PlayerBattleReplaySummary,
   type PlayerAchievementProgress,
+  type RankedWeeklyProgress,
   type ResourceLedger,
+  type SeasonArchiveEntry,
   type WorldState
 } from "../../../packages/shared/src/index";
 import type { RoomPersistenceSnapshot } from "./index";
@@ -32,6 +35,7 @@ import {
   toBattlePassRewardGrant,
   type BattlePassRewardGrant
 } from "./battle-pass";
+import { applySeasonSoftDecay, decayDivisionToRating, resolveCompetitiveProgression } from "./competitive-season";
 import { computeSeasonReward, resolveSeasonRewardConfig } from "./season-rewards";
 
 export interface SeasonSnapshot {
@@ -190,6 +194,12 @@ interface PlayerAccountRow extends RowDataPacket {
   display_name: string | null;
   avatar_url: string | null;
   elo_rating: number | null;
+  rank_division: string | null;
+  peak_rank_division: string | null;
+  promotion_series_json: string | PlayerAccountSnapshot["promotionSeries"] | null;
+  demotion_shield_json: string | PlayerAccountSnapshot["demotionShield"] | null;
+  season_history_json: string | SeasonArchiveEntry[] | null;
+  ranked_weekly_progress_json: string | RankedWeeklyProgress | null;
   gems: number | null;
   season_xp: number | null;
   season_pass_tier: number | null;
@@ -528,6 +538,12 @@ export interface PlayerAccountProgressPatch {
   seasonPassPremium?: boolean;
   seasonPassClaimedTiers?: number[] | null;
   seasonBadges?: string[] | null;
+  rankDivision?: PlayerAccountSnapshot["rankDivision"];
+  peakRankDivision?: PlayerAccountSnapshot["peakRankDivision"];
+  promotionSeries?: PlayerAccountSnapshot["promotionSeries"] | null;
+  demotionShield?: PlayerAccountSnapshot["demotionShield"] | null;
+  seasonHistory?: PlayerAccountSnapshot["seasonHistory"] | null;
+  rankedWeeklyProgress?: PlayerAccountSnapshot["rankedWeeklyProgress"] | null;
   campaignProgress?: PlayerAccountSnapshot["campaignProgress"] | null;
   globalResources?: Partial<ResourceLedger> | null;
   achievements?: Partial<PlayerAchievementProgress>[] | null;
@@ -1157,6 +1173,12 @@ function normalizePlayerAccountSnapshot(account: {
   displayName?: string | null | undefined;
   avatarUrl?: string | null | undefined;
   eloRating?: number | null | undefined;
+  rankDivision?: PlayerAccountSnapshot["rankDivision"] | null | undefined;
+  peakRankDivision?: PlayerAccountSnapshot["peakRankDivision"] | null | undefined;
+  promotionSeries?: PlayerAccountSnapshot["promotionSeries"] | null | undefined;
+  demotionShield?: PlayerAccountSnapshot["demotionShield"] | null | undefined;
+  seasonHistory?: PlayerAccountSnapshot["seasonHistory"] | null | undefined;
+  rankedWeeklyProgress?: PlayerAccountSnapshot["rankedWeeklyProgress"] | null | undefined;
   gems?: number | null | undefined;
   seasonXp?: number | null | undefined;
   seasonPassTier?: number | null | undefined;
@@ -1206,6 +1228,15 @@ function normalizePlayerAccountSnapshot(account: {
       displayName: normalizePlayerDisplayName(playerId, account.displayName),
       avatarUrl: normalizePlayerAvatarUrl(account.avatarUrl),
       eloRating: normalizeEloRating(account.eloRating),
+      rankDivision: account.rankDivision ?? getRankDivisionForRating(account.eloRating ?? 1000),
+      peakRankDivision:
+        account.peakRankDivision ??
+        account.rankDivision ??
+        getRankDivisionForRating(account.eloRating ?? 1000),
+      promotionSeries: account.promotionSeries ?? undefined,
+      demotionShield: account.demotionShield ?? undefined,
+      seasonHistory: account.seasonHistory ?? undefined,
+      rankedWeeklyProgress: account.rankedWeeklyProgress ?? undefined,
       gems: normalizeGemAmount(account.gems),
       seasonXp: Math.max(0, Math.floor(account.seasonXp ?? 0)),
       seasonPassTier: Math.max(1, Math.floor(account.seasonPassTier ?? 1)),
@@ -1507,6 +1538,12 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   display_name VARCHAR(80) NULL,
   avatar_url VARCHAR(512) NULL,
   elo_rating INT NOT NULL DEFAULT 1000,
+  rank_division VARCHAR(32) NULL,
+  peak_rank_division VARCHAR(32) NULL,
+  promotion_series_json LONGTEXT NULL,
+  demotion_shield_json LONGTEXT NULL,
+  season_history_json LONGTEXT NULL,
+  ranked_weekly_progress_json LONGTEXT NULL,
   gems INT NOT NULL DEFAULT 0,
   season_xp INT NOT NULL DEFAULT 0,
   season_pass_tier INT NOT NULL DEFAULT 1,
@@ -1779,6 +1816,114 @@ SET @veil_player_accounts_elo_rating_sql := IF(
 PREPARE veil_player_accounts_elo_rating_stmt FROM @veil_player_accounts_elo_rating_sql;
 EXECUTE veil_player_accounts_elo_rating_stmt;
 DEALLOCATE PREPARE veil_player_accounts_elo_rating_stmt;
+
+SET @veil_player_accounts_rank_division_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'rank_division'
+);
+
+SET @veil_player_accounts_rank_division_sql := IF(
+  @veil_player_accounts_rank_division_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`rank_division\` VARCHAR(32) NULL AFTER \`elo_rating\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_rank_division_stmt FROM @veil_player_accounts_rank_division_sql;
+EXECUTE veil_player_accounts_rank_division_stmt;
+DEALLOCATE PREPARE veil_player_accounts_rank_division_stmt;
+
+SET @veil_player_accounts_peak_rank_division_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'peak_rank_division'
+);
+
+SET @veil_player_accounts_peak_rank_division_sql := IF(
+  @veil_player_accounts_peak_rank_division_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`peak_rank_division\` VARCHAR(32) NULL AFTER \`rank_division\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_peak_rank_division_stmt FROM @veil_player_accounts_peak_rank_division_sql;
+EXECUTE veil_player_accounts_peak_rank_division_stmt;
+DEALLOCATE PREPARE veil_player_accounts_peak_rank_division_stmt;
+
+SET @veil_player_accounts_promotion_series_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'promotion_series_json'
+);
+
+SET @veil_player_accounts_promotion_series_sql := IF(
+  @veil_player_accounts_promotion_series_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`promotion_series_json\` LONGTEXT NULL AFTER \`peak_rank_division\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_promotion_series_stmt FROM @veil_player_accounts_promotion_series_sql;
+EXECUTE veil_player_accounts_promotion_series_stmt;
+DEALLOCATE PREPARE veil_player_accounts_promotion_series_stmt;
+
+SET @veil_player_accounts_demotion_shield_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'demotion_shield_json'
+);
+
+SET @veil_player_accounts_demotion_shield_sql := IF(
+  @veil_player_accounts_demotion_shield_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`demotion_shield_json\` LONGTEXT NULL AFTER \`promotion_series_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_demotion_shield_stmt FROM @veil_player_accounts_demotion_shield_sql;
+EXECUTE veil_player_accounts_demotion_shield_stmt;
+DEALLOCATE PREPARE veil_player_accounts_demotion_shield_stmt;
+
+SET @veil_player_accounts_season_history_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'season_history_json'
+);
+
+SET @veil_player_accounts_season_history_sql := IF(
+  @veil_player_accounts_season_history_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`season_history_json\` LONGTEXT NULL AFTER \`demotion_shield_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_season_history_stmt FROM @veil_player_accounts_season_history_sql;
+EXECUTE veil_player_accounts_season_history_stmt;
+DEALLOCATE PREPARE veil_player_accounts_season_history_stmt;
+
+SET @veil_player_accounts_ranked_weekly_progress_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'ranked_weekly_progress_json'
+);
+
+SET @veil_player_accounts_ranked_weekly_progress_sql := IF(
+  @veil_player_accounts_ranked_weekly_progress_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`ranked_weekly_progress_json\` LONGTEXT NULL AFTER \`season_history_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_ranked_weekly_progress_stmt FROM @veil_player_accounts_ranked_weekly_progress_sql;
+EXECUTE veil_player_accounts_ranked_weekly_progress_stmt;
+DEALLOCATE PREPARE veil_player_accounts_ranked_weekly_progress_stmt;
 
 SET @veil_player_accounts_gems_exists := (
   SELECT COUNT(*)
@@ -2700,6 +2845,24 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     playerId: row.player_id,
     ...(row.avatar_url ? { avatarUrl: row.avatar_url } : {}),
     ...(row.elo_rating != null ? { eloRating: row.elo_rating } : {}),
+    ...(row.rank_division ? { rankDivision: row.rank_division as PlayerAccountSnapshot["rankDivision"] } : {}),
+    ...(row.peak_rank_division ? { peakRankDivision: row.peak_rank_division as PlayerAccountSnapshot["peakRankDivision"] } : {}),
+    promotionSeries:
+      row.promotion_series_json != null
+        ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["promotionSeries"]>>(row.promotion_series_json)
+        : undefined,
+    demotionShield:
+      row.demotion_shield_json != null
+        ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["demotionShield"]>>(row.demotion_shield_json)
+        : undefined,
+    seasonHistory:
+      row.season_history_json != null
+        ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["seasonHistory"]>>(row.season_history_json)
+        : undefined,
+    rankedWeeklyProgress:
+      row.ranked_weekly_progress_json != null
+        ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["rankedWeeklyProgress"]>>(row.ranked_weekly_progress_json)
+        : undefined,
     gems: normalizeGemAmount(row.gems),
     seasonXp: Math.max(0, Math.floor(row.season_xp ?? 0)),
     seasonPassTier: Math.max(1, Math.floor(row.season_pass_tier ?? 1)),
@@ -3002,6 +3165,12 @@ async function savePlayerAccounts(
          player_id,
          display_name,
          elo_rating,
+         rank_division,
+         peak_rank_division,
+         promotion_series_json,
+         demotion_shield_json,
+         season_history_json,
+         ranked_weekly_progress_json,
          gems,
          season_xp,
          season_pass_tier,
@@ -3018,10 +3187,16 @@ async function savePlayerAccounts(
          tutorial_step,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(display_name, VALUES(display_name)),
          elo_rating = COALESCE(elo_rating, VALUES(elo_rating)),
+         rank_division = COALESCE(rank_division, VALUES(rank_division)),
+         peak_rank_division = COALESCE(peak_rank_division, VALUES(peak_rank_division)),
+         promotion_series_json = COALESCE(promotion_series_json, VALUES(promotion_series_json)),
+         demotion_shield_json = COALESCE(demotion_shield_json, VALUES(demotion_shield_json)),
+         season_history_json = COALESCE(season_history_json, VALUES(season_history_json)),
+         ranked_weekly_progress_json = COALESCE(ranked_weekly_progress_json, VALUES(ranked_weekly_progress_json)),
          gems = VALUES(gems),
          season_xp = VALUES(season_xp),
          season_pass_tier = VALUES(season_pass_tier),
@@ -3041,6 +3216,12 @@ async function savePlayerAccounts(
         normalizedAccount.playerId,
         normalizedAccount.displayName,
         normalizedAccount.eloRating,
+        normalizedAccount.rankDivision ?? null,
+        normalizedAccount.peakRankDivision ?? null,
+        JSON.stringify(normalizedAccount.promotionSeries ?? null),
+        JSON.stringify(normalizedAccount.demotionShield ?? null),
+        JSON.stringify(normalizedAccount.seasonHistory ?? []),
+        JSON.stringify(normalizedAccount.rankedWeeklyProgress ?? null),
         normalizedAccount.gems,
         Math.max(0, Math.floor(normalizedAccount.seasonXp ?? 0)),
         Math.max(1, Math.floor(normalizedAccount.seasonPassTier ?? 1)),
@@ -3282,6 +3463,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          display_name,
          avatar_url,
          elo_rating,
+         rank_division,
+         peak_rank_division,
+         promotion_series_json,
+         demotion_shield_json,
+         season_history_json,
+         ranked_weekly_progress_json,
          gems,
          season_xp,
          season_pass_tier,
@@ -3339,6 +3526,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          display_name,
          avatar_url,
          elo_rating,
+         rank_division,
+         peak_rank_division,
+         promotion_series_json,
+         demotion_shield_json,
+         season_history_json,
+         ranked_weekly_progress_json,
          gems,
          season_xp,
          season_pass_tier,
@@ -3480,6 +3673,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          display_name,
          avatar_url,
          elo_rating,
+         rank_division,
+         peak_rank_division,
+         promotion_series_json,
+         demotion_shield_json,
+         season_history_json,
+         ranked_weekly_progress_json,
          gems,
          season_xp,
          season_pass_tier,
@@ -3631,6 +3830,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          player_id,
          display_name,
          elo_rating,
+         rank_division,
+         peak_rank_division,
+         promotion_series_json,
+         demotion_shield_json,
+         season_history_json,
+         ranked_weekly_progress_json,
          gems,
          season_xp,
          season_pass_tier,
@@ -3647,7 +3852,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_room_id,
          last_seen_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(?, display_name),
          last_room_id = COALESCE(?, last_room_id),
@@ -3657,12 +3862,16 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         playerId,
         insertDisplayName,
         normalizeEloRating(undefined),
+        getRankDivisionForRating(undefined),
+        getRankDivisionForRating(undefined),
+        JSON.stringify(null),
+        JSON.stringify(null),
+        JSON.stringify([]),
+        JSON.stringify(null),
         0,
         0,
         1,
         0,
-        JSON.stringify([]),
-        JSON.stringify([]),
         JSON.stringify(null),
         JSON.stringify(normalizeResourceLedger()),
         JSON.stringify(normalizeAchievementProgress()),
@@ -4986,6 +5195,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          display_name,
          avatar_url,
          elo_rating,
+         rank_division,
+         peak_rank_division,
+         promotion_series_json,
+         demotion_shield_json,
+         season_history_json,
+         ranked_weekly_progress_json,
          gems,
          season_xp,
          season_pass_tier,
@@ -5004,11 +5219,17 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number,
          phone_number_bound_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = VALUES(avatar_url),
          elo_rating = VALUES(elo_rating),
+         rank_division = VALUES(rank_division),
+         peak_rank_division = VALUES(peak_rank_division),
+         promotion_series_json = VALUES(promotion_series_json),
+         demotion_shield_json = VALUES(demotion_shield_json),
+         season_history_json = VALUES(season_history_json),
+         ranked_weekly_progress_json = VALUES(ranked_weekly_progress_json),
          season_xp = VALUES(season_xp),
          season_pass_tier = VALUES(season_pass_tier),
          season_pass_premium = VALUES(season_pass_premium),
@@ -5031,6 +5252,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         nextAccount.displayName,
         nextAccount.avatarUrl ?? null,
         nextAccount.eloRating,
+        nextAccount.rankDivision ?? null,
+        nextAccount.peakRankDivision ?? null,
+        JSON.stringify(nextAccount.promotionSeries ?? null),
+        JSON.stringify(nextAccount.demotionShield ?? null),
+        JSON.stringify(nextAccount.seasonHistory ?? []),
+        JSON.stringify(nextAccount.rankedWeeklyProgress ?? null),
         nextAccount.gems,
         Math.max(0, Math.floor(nextAccount.seasonXp ?? 0)),
         Math.max(1, Math.floor(nextAccount.seasonPassTier ?? 1)),
@@ -5071,6 +5298,13 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         globalResources: normalizeResourceLedger()
       });
     const battlePassProgress = applyBattlePassXp(battlePassConfig, existing, patch.seasonXpDelta ?? 0);
+    const mergedReplays = appendPlayerBattleReplaySummaries([], patch.recentBattleReplays ?? existing.recentBattleReplays);
+    const competitiveProgression = resolveCompetitiveProgression(
+      existing,
+      patch,
+      mergedReplays,
+      patch.eloRating ?? existing.eloRating ?? 1000
+    );
 
     const nextAccount = normalizePlayerAccountSnapshot({
       ...existing,
@@ -5085,7 +5319,13 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       globalResources: patch.globalResources ?? existing.globalResources,
       achievements: patch.achievements ?? existing.achievements,
       recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
-      recentBattleReplays: patch.recentBattleReplays ?? existing.recentBattleReplays,
+      recentBattleReplays: mergedReplays,
+      rankDivision: patch.rankDivision ?? competitiveProgression.rankDivision,
+      peakRankDivision: patch.peakRankDivision ?? competitiveProgression.peakRankDivision,
+      promotionSeries: patch.promotionSeries ?? competitiveProgression.promotionSeries,
+      demotionShield: patch.demotionShield ?? competitiveProgression.demotionShield,
+      seasonHistory: patch.seasonHistory ?? existing.seasonHistory,
+      rankedWeeklyProgress: patch.rankedWeeklyProgress ?? competitiveProgression.rankedWeeklyProgress,
       dailyDungeonState: patch.dailyDungeonState ?? existing.dailyDungeonState,
       tutorialStep: patch.tutorialStep !== undefined ? patch.tutorialStep : existing.tutorialStep,
       dailyPlayMinutes:
@@ -5110,6 +5350,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          display_name,
          avatar_url,
          elo_rating,
+         rank_division,
+         peak_rank_division,
+         promotion_series_json,
+         demotion_shield_json,
+         season_history_json,
+         ranked_weekly_progress_json,
          gems,
          season_xp,
          season_pass_tier,
@@ -5131,7 +5377,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_play_date,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = COALESCE(avatar_url, VALUES(avatar_url)),
@@ -5143,6 +5389,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_badges_json = VALUES(season_badges_json),
          campaign_progress_json = VALUES(campaign_progress_json),
          elo_rating = VALUES(elo_rating),
+         rank_division = VALUES(rank_division),
+         peak_rank_division = VALUES(peak_rank_division),
+         promotion_series_json = VALUES(promotion_series_json),
+         demotion_shield_json = VALUES(demotion_shield_json),
+         season_history_json = VALUES(season_history_json),
+         ranked_weekly_progress_json = VALUES(ranked_weekly_progress_json),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = VALUES(achievements_json),
          recent_event_log_json = VALUES(recent_event_log_json),
@@ -5162,6 +5414,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         nextAccount.displayName,
         nextAccount.avatarUrl ?? null,
         nextAccount.eloRating,
+        nextAccount.rankDivision ?? null,
+        nextAccount.peakRankDivision ?? null,
+        JSON.stringify(nextAccount.promotionSeries ?? null),
+        JSON.stringify(nextAccount.demotionShield ?? null),
+        JSON.stringify(nextAccount.seasonHistory ?? []),
+        JSON.stringify(nextAccount.rankedWeeklyProgress ?? null),
         nextAccount.gems,
         Math.max(0, Math.floor(nextAccount.seasonXp ?? 0)),
         Math.max(1, Math.floor(nextAccount.seasonPassTier ?? 1)),
@@ -5213,6 +5471,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          display_name,
          avatar_url,
          elo_rating,
+         rank_division,
+         peak_rank_division,
+         promotion_series_json,
+         demotion_shield_json,
+         season_history_json,
+         ranked_weekly_progress_json,
          gems,
          season_xp,
          season_pass_tier,
@@ -5582,6 +5846,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
       let playersRewarded = 0;
       let totalGemsGranted = 0;
+      const rewardedPlayerIds = new Set<string>();
       for (const rankedPlayer of rankedPlayers) {
         const reward = computeSeasonReward(rankedPlayer.rankPosition, rankedPlayers.length, rewardConfig);
         if (!reward) {
@@ -5632,6 +5897,61 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
         playersRewarded += 1;
         totalGemsGranted += reward.gems;
+        rewardedPlayerIds.add(rankedPlayer.playerId);
+      }
+
+      for (const rankedPlayer of rankedPlayers) {
+        const [accountRows] = await connection.query<PlayerAccountRow[]>(
+          `SELECT *
+           FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+           WHERE player_id = ?
+           LIMIT 1
+           FOR UPDATE`,
+          [rankedPlayer.playerId]
+        );
+        const currentAccount =
+          accountRows[0] != null
+            ? toPlayerAccountSnapshot(accountRows[0])
+            : normalizePlayerAccountSnapshot({
+                playerId: rankedPlayer.playerId,
+                displayName: rankedPlayer.playerId,
+                globalResources: normalizeResourceLedger()
+              });
+        const currentDivision = currentAccount.rankDivision ?? getRankDivisionForRating(currentAccount.eloRating ?? rankedPlayer.finalRating);
+        const peakDivision = currentAccount.peakRankDivision ?? currentDivision;
+        const decay = applySeasonSoftDecay(currentAccount);
+        const seasonHistory = [
+          {
+            seasonId: normalizedId,
+            peakDivision,
+            finalDivision: currentDivision,
+            rewardTier: getTierForRating(rankedPlayer.finalRating),
+            rewardClaimed: rewardedPlayerIds.has(rankedPlayer.playerId),
+            archivedAt: now.toISOString()
+          },
+          ...(currentAccount.seasonHistory ?? [])
+        ].slice(0, 20);
+
+        await connection.query(
+          `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+           SET elo_rating = ?,
+               rank_division = ?,
+               peak_rank_division = ?,
+               promotion_series_json = ?,
+               demotion_shield_json = ?,
+               season_history_json = ?,
+               version = version + 1
+           WHERE player_id = ?`,
+          [
+            decayDivisionToRating(decay.rankDivision ?? currentDivision),
+            decay.rankDivision ?? currentDivision,
+            decay.peakRankDivision ?? decay.rankDivision ?? currentDivision,
+            JSON.stringify(null),
+            JSON.stringify(null),
+            JSON.stringify(seasonHistory),
+            rankedPlayer.playerId
+          ]
+        );
       }
 
       await connection.query(

--- a/configs/ranked-season.json
+++ b/configs/ranked-season.json
@@ -1,0 +1,30 @@
+{
+  "divisionThresholds": {
+    "bronze_i": 0,
+    "bronze_ii": 350,
+    "bronze_iii": 725,
+    "silver_i": 1100,
+    "silver_ii": 1175,
+    "silver_iii": 1235,
+    "gold_i": 1300,
+    "gold_ii": 1375,
+    "gold_iii": 1435,
+    "platinum_i": 1500,
+    "platinum_ii": 1600,
+    "platinum_iii": 1700,
+    "diamond_i": 1800,
+    "diamond_ii": 1900,
+    "diamond_iii": 2000
+  },
+  "promotionSeries": {
+    "winsRequired": 3,
+    "lossesAllowed": 2
+  },
+  "demotionShield": {
+    "games": 3
+  },
+  "softDecay": {
+    "diamond": "platinum_i",
+    "platinum": "gold_i"
+  }
+}

--- a/packages/shared/src/competitive-season.ts
+++ b/packages/shared/src/competitive-season.ts
@@ -1,0 +1,161 @@
+import rankedSeasonConfigDocument from "../../../configs/ranked-season.json";
+import { normalizeEloRating, type PlayerTier, type RankDivisionId } from "./matchmaking.ts";
+import type { PlayerBattleReplaySummary } from "./battle-replay.ts";
+
+interface RankedSeasonConfigDocument {
+  divisionThresholds?: Partial<Record<RankDivisionId, number>> | null;
+  promotionSeries?: {
+    winsRequired?: number | null;
+    lossesAllowed?: number | null;
+  } | null;
+  demotionShield?: {
+    games?: number | null;
+  } | null;
+  softDecay?: Partial<Record<PlayerTier, RankDivisionId>> | null;
+}
+
+export interface RankedSeasonConfig {
+  divisionThresholds: Record<RankDivisionId, number>;
+  promotionSeries: {
+    winsRequired: number;
+    lossesAllowed: number;
+  };
+  demotionShield: {
+    games: number;
+  };
+  softDecay: Partial<Record<PlayerTier, RankDivisionId>>;
+}
+
+export const RANK_DIVISION_ORDER: RankDivisionId[] = [
+  "bronze_i",
+  "bronze_ii",
+  "bronze_iii",
+  "silver_i",
+  "silver_ii",
+  "silver_iii",
+  "gold_i",
+  "gold_ii",
+  "gold_iii",
+  "platinum_i",
+  "platinum_ii",
+  "platinum_iii",
+  "diamond_i",
+  "diamond_ii",
+  "diamond_iii"
+];
+
+const DIVISION_TO_TIER: Record<RankDivisionId, PlayerTier> = {
+  bronze_i: "bronze",
+  bronze_ii: "bronze",
+  bronze_iii: "bronze",
+  silver_i: "silver",
+  silver_ii: "silver",
+  silver_iii: "silver",
+  gold_i: "gold",
+  gold_ii: "gold",
+  gold_iii: "gold",
+  platinum_i: "platinum",
+  platinum_ii: "platinum",
+  platinum_iii: "platinum",
+  diamond_i: "diamond",
+  diamond_ii: "diamond",
+  diamond_iii: "diamond"
+};
+
+function normalizePositiveInteger(value: number | null | undefined, fallback: number): number {
+  const normalized = Math.floor(value ?? Number.NaN);
+  return Number.isFinite(normalized) && normalized > 0 ? normalized : fallback;
+}
+
+export function resolveRankedSeasonConfig(
+  document: RankedSeasonConfigDocument = rankedSeasonConfigDocument as RankedSeasonConfigDocument
+): RankedSeasonConfig {
+  const divisionThresholds = Object.fromEntries(
+    RANK_DIVISION_ORDER.map((division, index) => {
+      const configured = document.divisionThresholds?.[division];
+      const fallback = index === 0 ? 0 : index * 100;
+      return [division, Math.max(0, Math.floor(configured ?? fallback))];
+    })
+  ) as Record<RankDivisionId, number>;
+
+  return {
+    divisionThresholds,
+    promotionSeries: {
+      winsRequired: normalizePositiveInteger(document.promotionSeries?.winsRequired, 3),
+      lossesAllowed: normalizePositiveInteger(document.promotionSeries?.lossesAllowed, 2)
+    },
+    demotionShield: {
+      games: normalizePositiveInteger(document.demotionShield?.games, 3)
+    },
+    softDecay: document.softDecay ?? {}
+  };
+}
+
+export function getRankDivisionThreshold(division: RankDivisionId): number {
+  return resolveRankedSeasonConfig().divisionThresholds[division];
+}
+
+export function getRankDivisionIndex(division: RankDivisionId): number {
+  return RANK_DIVISION_ORDER.indexOf(division);
+}
+
+export function getRankDivisionForRating(rating: number | undefined | null): RankDivisionId {
+  const normalized = normalizeEloRating(rating);
+  const config = resolveRankedSeasonConfig();
+  let current: RankDivisionId = "bronze_i";
+  for (const division of RANK_DIVISION_ORDER) {
+    if (normalized >= config.divisionThresholds[division]) {
+      current = division;
+      continue;
+    }
+    break;
+  }
+  return current;
+}
+
+export function getTierForDivision(division: RankDivisionId): PlayerTier {
+  return DIVISION_TO_TIER[division];
+}
+
+export function getDivisionLabel(division: RankDivisionId): string {
+  const parts = division.split("_");
+  const tier = parts[0] || "bronze";
+  const roman = parts[1] || "i";
+  return `${tier.toUpperCase()} ${roman.toUpperCase()}`;
+}
+
+export function getTierFloorDivision(tier: PlayerTier): RankDivisionId {
+  return RANK_DIVISION_ORDER.find((division) => DIVISION_TO_TIER[division] === tier) ?? "bronze_i";
+}
+
+export function getSoftDecayDivision(division: RankDivisionId): RankDivisionId {
+  const config = resolveRankedSeasonConfig();
+  return config.softDecay[getTierForDivision(division)] ?? division;
+}
+
+export function isPromotionSeriesBoundary(currentDivision: RankDivisionId, nextDivision: RankDivisionId): boolean {
+  return getTierForDivision(currentDivision) !== getTierForDivision(nextDivision) && getRankDivisionIndex(nextDivision) > getRankDivisionIndex(currentDivision);
+}
+
+export function didPlayerWinReplay(replay: Pick<PlayerBattleReplaySummary, "playerCamp" | "result">): boolean {
+  return (
+    (replay.playerCamp === "attacker" && replay.result === "attacker_victory") ||
+    (replay.playerCamp === "defender" && replay.result === "defender_victory")
+  );
+}
+
+export function getUtcWeekStart(referenceTime: Date | string = new Date()): string {
+  const reference = typeof referenceTime === "string" ? new Date(referenceTime) : new Date(referenceTime.getTime());
+  const normalized = Number.isNaN(reference.getTime()) ? new Date() : reference;
+  const day = normalized.getUTCDay();
+  const distanceToMonday = (day + 6) % 7;
+  normalized.setUTCHours(0, 0, 0, 0);
+  normalized.setUTCDate(normalized.getUTCDate() - distanceToMonday);
+  return normalized.toISOString();
+}
+
+export function addUtcDays(timestamp: string, days: number): string {
+  const date = new Date(timestamp);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString();
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./assets-config.ts";
 export * from "./battle.ts";
 export * from "./battle-report.ts";
 export * from "./battle-replay.ts";
+export * from "./competitive-season.ts";
 export * from "./analytics-events.ts";
 export * from "./content-pack-validation.ts";
 export * from "./daily-quests.ts";

--- a/packages/shared/src/matchmaking.ts
+++ b/packages/shared/src/matchmaking.ts
@@ -194,6 +194,35 @@ export function applyEloMatchResult(
 }
 
 export type PlayerTier = "bronze" | "silver" | "gold" | "platinum" | "diamond";
+export type RankDivisionId =
+  | "bronze_i"
+  | "bronze_ii"
+  | "bronze_iii"
+  | "silver_i"
+  | "silver_ii"
+  | "silver_iii"
+  | "gold_i"
+  | "gold_ii"
+  | "gold_iii"
+  | "platinum_i"
+  | "platinum_ii"
+  | "platinum_iii"
+  | "diamond_i"
+  | "diamond_ii"
+  | "diamond_iii";
+
+export interface PromotionSeriesState {
+  targetDivision: RankDivisionId;
+  wins: number;
+  losses: number;
+  winsRequired: number;
+  lossesAllowed: number;
+}
+
+export interface DemotionShieldState {
+  tier: PlayerTier;
+  remainingMatches: number;
+}
 
 export function getTierForRating(rating: number): PlayerTier {
   const normalized = normalizeEloRating(rating);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,3 +1,5 @@
+import type { PlayerTier, RankDivisionId } from "./matchmaking.ts";
+
 export type TerrainType = "grass" | "dirt" | "sand" | "water" | "swamp";
 export type FogState = "hidden" | "explored" | "visible";
 export type ResourceKind = "gold" | "wood" | "ore";
@@ -182,6 +184,31 @@ export interface SeasonRewardBracket {
 
 export interface SeasonRewardConfig {
   brackets: SeasonRewardBracket[];
+}
+
+export interface SeasonArchiveEntry {
+  seasonId: string;
+  peakDivision: RankDivisionId;
+  finalDivision: RankDivisionId;
+  rewardTier: PlayerTier;
+  rewardClaimed: boolean;
+  archivedAt: string;
+}
+
+export interface WeeklyLeaderboardEntry {
+  playerId: string;
+  displayName: string;
+  wins: number;
+  weekStartsAt: string;
+  weekEndsAt: string;
+  rankDivision: RankDivisionId;
+}
+
+export interface RankedWeeklyProgress {
+  currentWeekStartsAt: string;
+  currentWeekWins: number;
+  previousWeekStartsAt?: string;
+  previousWeekWins?: number;
 }
 
 export interface MovePoints {

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -11,8 +11,23 @@ import {
 } from "./event-log.ts";
 import { normalizeDailyQuestBoard, type DailyQuestBoard } from "./daily-quests.ts";
 import { normalizePlayerBattleReplaySummaries, type PlayerBattleReplaySummary } from "./battle-replay.ts";
-import { normalizeEloRating } from "./matchmaking.ts";
-import type { CampaignProgressState, DailyDungeonState, ResourceLedger } from "./models.ts";
+import {
+  getRankDivisionForRating,
+  getUtcWeekStart
+} from "./competitive-season.ts";
+import {
+  normalizeEloRating,
+  type DemotionShieldState,
+  type PromotionSeriesState,
+  type RankDivisionId
+} from "./matchmaking.ts";
+import type {
+  CampaignProgressState,
+  DailyDungeonState,
+  RankedWeeklyProgress,
+  ResourceLedger,
+  SeasonArchiveEntry
+} from "./models.ts";
 import { normalizeTutorialStep } from "./tutorial.ts";
 
 export type PlayerBanStatus = "none" | "temporary" | "permanent";
@@ -22,6 +37,12 @@ export interface PlayerAccountReadModel {
   displayName: string;
   avatarUrl?: string;
   eloRating?: number;
+  rankDivision?: RankDivisionId;
+  peakRankDivision?: RankDivisionId;
+  promotionSeries?: PromotionSeriesState;
+  demotionShield?: DemotionShieldState;
+  seasonHistory?: SeasonArchiveEntry[];
+  rankedWeeklyProgress?: RankedWeeklyProgress;
   gems?: number;
   loginStreak?: number;
   seasonXp?: number;
@@ -59,6 +80,12 @@ export interface PlayerAccountReadModelInput {
   displayName?: string | undefined;
   avatarUrl?: string | undefined;
   eloRating?: number | undefined;
+  rankDivision?: RankDivisionId | undefined;
+  peakRankDivision?: RankDivisionId | undefined;
+  promotionSeries?: PromotionSeriesState | null | undefined;
+  demotionShield?: DemotionShieldState | null | undefined;
+  seasonHistory?: SeasonArchiveEntry[] | null | undefined;
+  rankedWeeklyProgress?: RankedWeeklyProgress | null | undefined;
   gems?: number | undefined;
   loginStreak?: number | undefined;
   seasonXp?: number | undefined;
@@ -133,6 +160,54 @@ export function normalizePlayerAccountReadModel(
   const lastSeenAt = account?.lastSeenAt?.trim();
   const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
   const recentBattleReplays = normalizePlayerBattleReplaySummaries(account?.recentBattleReplays);
+  const rankDivision = account?.rankDivision ?? getRankDivisionForRating(account?.eloRating);
+  const peakRankDivision = account?.peakRankDivision ?? rankDivision;
+  const promotionSeries =
+    account?.promotionSeries &&
+    account.promotionSeries.targetDivision &&
+    Number.isFinite(account.promotionSeries.wins) &&
+    Number.isFinite(account.promotionSeries.losses)
+      ? {
+          targetDivision: account.promotionSeries.targetDivision,
+          wins: Math.max(0, Math.floor(account.promotionSeries.wins)),
+          losses: Math.max(0, Math.floor(account.promotionSeries.losses)),
+          winsRequired: Math.max(1, Math.floor(account.promotionSeries.winsRequired ?? 3)),
+          lossesAllowed: Math.max(1, Math.floor(account.promotionSeries.lossesAllowed ?? 2))
+        }
+      : undefined;
+  const demotionShield =
+    account?.demotionShield && account.demotionShield.remainingMatches > 0 && account.demotionShield.tier
+      ? {
+          tier: account.demotionShield.tier,
+          remainingMatches: Math.max(0, Math.floor(account.demotionShield.remainingMatches))
+        }
+      : undefined;
+  const seasonHistory = (account?.seasonHistory ?? [])
+    .filter((entry): entry is SeasonArchiveEntry => Boolean(entry?.seasonId && entry?.peakDivision && entry?.finalDivision))
+    .map((entry) => ({
+      seasonId: entry.seasonId.trim(),
+      peakDivision: entry.peakDivision,
+      finalDivision: entry.finalDivision,
+      rewardTier: entry.rewardTier,
+      rewardClaimed: entry.rewardClaimed === true,
+      archivedAt: normalizeTimestamp(entry.archivedAt) ?? new Date(0).toISOString()
+    }))
+    .sort((left, right) => right.archivedAt.localeCompare(left.archivedAt) || left.seasonId.localeCompare(right.seasonId));
+  let rankedWeeklyProgress: RankedWeeklyProgress | undefined;
+  if (account?.rankedWeeklyProgress?.currentWeekStartsAt) {
+    rankedWeeklyProgress = {
+      currentWeekStartsAt: normalizeTimestamp(account.rankedWeeklyProgress.currentWeekStartsAt) ?? getUtcWeekStart(),
+      currentWeekWins: Math.max(0, Math.floor(account.rankedWeeklyProgress.currentWeekWins ?? 0))
+    };
+    const previousWeekStartsAt = normalizeTimestamp(account.rankedWeeklyProgress.previousWeekStartsAt);
+    if (previousWeekStartsAt) {
+      rankedWeeklyProgress.previousWeekStartsAt = previousWeekStartsAt;
+    }
+    const previousWeekWins = Math.max(0, Math.floor(account.rankedWeeklyProgress.previousWeekWins ?? 0));
+    if (previousWeekWins > 0) {
+      rankedWeeklyProgress.previousWeekWins = previousWeekWins;
+    }
+  }
   const dailyQuestBoard = normalizeDailyQuestBoard(account?.dailyQuestBoard);
   const campaignProgress = normalizeCampaignProgressState(account?.campaignProgress);
   const dailyDungeonState = normalizeDailyDungeonState(account?.dailyDungeonState);
@@ -143,6 +218,12 @@ export function normalizePlayerAccountReadModel(
     displayName: displayName || playerId || "player",
     ...(avatarUrl ? { avatarUrl } : {}),
     eloRating: normalizeEloRating(account?.eloRating),
+    rankDivision,
+    peakRankDivision,
+    ...(promotionSeries ? { promotionSeries } : {}),
+    ...(demotionShield ? { demotionShield } : {}),
+    ...(seasonHistory.length > 0 ? { seasonHistory } : {}),
+    ...(rankedWeeklyProgress ? { rankedWeeklyProgress } : {}),
     gems: Math.max(0, Math.floor(account?.gems ?? 0)),
     ...(loginStreak > 0 ? { loginStreak } : {}),
     ...(seasonXp > 0 ? { seasonXp } : {}),


### PR DESCRIPTION
## Summary
- add ranked season config plus shared division/promotion helpers for the 15-division ladder
- persist competitive account state for rank divisions, promotion series, demotion shield, season archive history, and weekly reset progress
- extend leaderboard APIs and Cocos leaderboard rendering to surface division-level competitive data

## Validation
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `npm run typecheck:cocos`
- `node --import tsx --test apps/server/test/memory-room-snapshot-store.test.ts`
- `node --import tsx --test apps/server/test/season-routes.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-leaderboard-panel.test.ts apps/cocos-client/test/cocos-session-orchestration.test.ts`

Closes #881