### PR TITLE
Implement chapter 1 narrative and seasonal event slice

### DIFF
--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -10,6 +10,7 @@ import {
 } from "./config-center";
 import { configureRoomSnapshotStore, listLobbyRooms, VeilColyseusRoom } from "./colyseus-room";
 import { registerConfigViewerRoutes } from "./config-viewer";
+import { registerEventRoutes } from "./event-engine";
 import { registerLeaderboardRoutes } from "./leaderboard";
 import { registerLobbyRoutes } from "./lobby";
 import { registerMatchmakingRoutes } from "./matchmaking";
@@ -108,6 +109,7 @@ export interface DevServerBootstrapDependencies {
   registerAuthRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerConfigCenterRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
+  registerEventRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerPlayerAccountRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerShopRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerWechatPayRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
@@ -175,6 +177,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerAuthRoutes: (app, store) => registerAuthRoutes(app as never, store as RoomSnapshotStore),
     registerConfigCenterRoutes: (app, store) => registerConfigCenterRoutes(app as never, store as ConfigCenterStore),
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
+    registerEventRoutes: (app, store) => registerEventRoutes(app as never, store as RoomSnapshotStore | null),
     registerPlayerAccountRoutes: (app, store) => registerPlayerAccountRoutes(app as never, store as RoomSnapshotStore),
     registerShopRoutes: (app, store) => registerShopRoutes(app as never, store as RoomSnapshotStore),
     registerWechatPayRoutes: (app, store) => registerWechatPayRoutes(app as never, store as RoomSnapshotStore),
@@ -244,6 +247,9 @@ export async function startDevServer(
   deps.registerAuthRoutes(expressApp, effectiveSnapshotStore);
   deps.registerConfigCenterRoutes(expressApp, configCenterStore);
   deps.registerConfigViewerRoutes(expressApp, configCenterStore);
+  if ("use" in (expressApp as object) && "get" in (expressApp as object)) {
+    deps.registerEventRoutes(expressApp, effectiveSnapshotStore);
+  }
   deps.registerPlayerAccountRoutes(expressApp, effectiveSnapshotStore);
   deps.registerShopRoutes(expressApp, effectiveSnapshotStore);
   deps.registerWechatPayRoutes(expressApp, effectiveSnapshotStore);

--- a/apps/server/src/event-engine.ts
+++ b/apps/server/src/event-engine.ts
@@ -1,0 +1,623 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import defendTheBridgeDocument from "../../../configs/event-defend-the-bridge.json";
+import seasonalEventsDocument from "../../../configs/seasonal-events.json";
+import type {
+  EventLeaderboardEntry,
+  SeasonalEventDefinition,
+  SeasonalEventLeaderboardRewardTier,
+  SeasonalEventObjective,
+  SeasonalEventReward,
+  SeasonalEventState
+} from "../../../packages/shared/src/index";
+import { validateAuthSessionFromRequest } from "./auth";
+import type { PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
+
+interface SeasonalEventSummaryDocument {
+  id?: string | null;
+  name?: string | null;
+  description?: string | null;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  durationDays?: number | null;
+  bannerText?: string | null;
+  leaderboard?: {
+    size?: number | null;
+  } | null;
+}
+
+interface SeasonalEventsDocument {
+  events?: SeasonalEventSummaryDocument[] | null;
+}
+
+interface SeasonalEventDefinitionDocument {
+  id?: string | null;
+  name?: string | null;
+  description?: string | null;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  durationDays?: number | null;
+  bannerText?: string | null;
+  objectives?: Partial<SeasonalEventObjective>[] | null;
+  rewards?: Partial<SeasonalEventReward>[] | null;
+  leaderboard?: {
+    size?: number | null;
+    rewardTiers?: Partial<SeasonalEventLeaderboardRewardTier>[] | null;
+  } | null;
+}
+
+export interface RegisterEventRoutesOptions {
+  now?: () => Date;
+  eventIndexDocument?: SeasonalEventsDocument;
+  eventDocuments?: Record<string, SeasonalEventDefinitionDocument>;
+}
+
+export interface SeasonalEventActionInput {
+  actionId: string;
+  actionType: SeasonalEventObjective["actionType"];
+  dungeonId?: string;
+  occurredAt?: string;
+}
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+function toErrorPayload(error: unknown): { code: string; message: string } {
+  return {
+    code: error instanceof Error ? error.name || "error" : "error",
+    message: error instanceof Error ? error.message : String(error)
+  };
+}
+
+function sendUnauthorized(
+  response: ServerResponse,
+  errorCode: "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked" = "unauthorized"
+): void {
+  sendJson(response, 401, {
+    error: {
+      code: errorCode,
+      message:
+        errorCode === "token_expired"
+          ? "Auth token has expired"
+          : errorCode === "session_revoked"
+            ? "Auth session has been revoked"
+            : "Guest auth session is missing or invalid"
+    }
+  });
+}
+
+function sendAccountBanned(response: ServerResponse, ban?: { banReason?: string; banExpiry?: string } | null): void {
+  sendJson(response, 403, {
+    error: {
+      code: "account_banned",
+      message: "Account is banned",
+      reason: ban?.banReason ?? "No reason provided",
+      ...(ban?.banExpiry ? { expiry: ban.banExpiry } : {})
+    }
+  });
+}
+
+async function requireAuthSession(request: IncomingMessage, response: ServerResponse, store: RoomSnapshotStore | null) {
+  const result = await validateAuthSessionFromRequest(request, store);
+  if (!result.session) {
+    if (result.errorCode === "account_banned") {
+      sendAccountBanned(response, result.ban);
+      return null;
+    }
+    sendUnauthorized(response, result.errorCode ?? "unauthorized");
+    return null;
+  }
+
+  return result.session;
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function normalizeTimestamp(value: string | null | undefined, field: string): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`${field} is required`);
+  }
+
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${field} must be a valid timestamp`);
+  }
+
+  return parsed.toISOString();
+}
+
+function normalizeNonNegativeInteger(value: number | null | undefined, field: string, minimum = 0): number {
+  const normalized = Math.floor(value ?? Number.NaN);
+  if (!Number.isFinite(normalized) || normalized < minimum) {
+    throw new Error(`${field} must be an integer >= ${minimum}`);
+  }
+  return normalized;
+}
+
+function normalizeEventReward(rawReward: Partial<SeasonalEventReward> | null | undefined, field: string): SeasonalEventReward {
+  const candidate = rawReward ?? {};
+  const id = candidate.id?.trim();
+  const name = candidate.name?.trim();
+  if (!id || !name) {
+    throw new Error(`${field} must define id and name`);
+  }
+
+  return {
+    id,
+    name,
+    pointsRequired: normalizeNonNegativeInteger(candidate.pointsRequired, `${field}.pointsRequired`, 1),
+    kind: candidate.kind ?? "gems",
+    ...(candidate.gems != null ? { gems: normalizeNonNegativeInteger(candidate.gems, `${field}.gems`) } : {}),
+    ...(candidate.resources
+      ? {
+          resources: {
+            ...(candidate.resources.gold != null
+              ? { gold: normalizeNonNegativeInteger(candidate.resources.gold, `${field}.resources.gold`) }
+              : {}),
+            ...(candidate.resources.wood != null
+              ? { wood: normalizeNonNegativeInteger(candidate.resources.wood, `${field}.resources.wood`) }
+              : {}),
+            ...(candidate.resources.ore != null
+              ? { ore: normalizeNonNegativeInteger(candidate.resources.ore, `${field}.resources.ore`) }
+              : {})
+          }
+        }
+      : {}),
+    ...(candidate.badge?.trim() ? { badge: candidate.badge.trim() } : {}),
+    ...(candidate.cosmeticId?.trim() ? { cosmeticId: candidate.cosmeticId.trim() } : {})
+  };
+}
+
+function normalizeLeaderboardRewardTier(
+  rawTier: Partial<SeasonalEventLeaderboardRewardTier> | null | undefined,
+  field: string
+): SeasonalEventLeaderboardRewardTier {
+  const candidate = rawTier ?? {};
+  const title = candidate.title?.trim();
+  if (!title) {
+    throw new Error(`${field}.title is required`);
+  }
+
+  return {
+    rankStart: normalizeNonNegativeInteger(candidate.rankStart, `${field}.rankStart`, 1),
+    rankEnd: normalizeNonNegativeInteger(candidate.rankEnd, `${field}.rankEnd`, 1),
+    title,
+    ...(candidate.badge?.trim() ? { badge: candidate.badge.trim() } : {}),
+    ...(candidate.cosmeticId?.trim() ? { cosmeticId: candidate.cosmeticId.trim() } : {})
+  };
+}
+
+function normalizeObjective(
+  rawObjective: Partial<SeasonalEventObjective> | null | undefined,
+  field: string
+): SeasonalEventObjective {
+  const candidate = rawObjective ?? {};
+  const id = candidate.id?.trim();
+  const description = candidate.description?.trim();
+  if (!id || !description) {
+    throw new Error(`${field} must define id and description`);
+  }
+
+  return {
+    id,
+    description,
+    actionType: candidate.actionType ?? "daily_dungeon_reward_claimed",
+    points: normalizeNonNegativeInteger(candidate.points, `${field}.points`, 1),
+    ...(candidate.dungeonId?.trim() ? { dungeonId: candidate.dungeonId.trim() } : {})
+  };
+}
+
+const DEFAULT_EVENT_DOCUMENTS: Record<string, SeasonalEventDefinitionDocument> = {
+  "defend-the-bridge": defendTheBridgeDocument as SeasonalEventDefinitionDocument
+};
+
+export function resolveSeasonalEvents(
+  eventIndexDocument: SeasonalEventsDocument = seasonalEventsDocument as SeasonalEventsDocument,
+  eventDocuments: Record<string, SeasonalEventDefinitionDocument> = DEFAULT_EVENT_DOCUMENTS
+): SeasonalEventDefinition[] {
+  const summaries = eventIndexDocument.events ?? [];
+  if (summaries.length === 0) {
+    return [];
+  }
+
+  return summaries.map((summary, index) => {
+    const id = summary.id?.trim();
+    if (!id) {
+      throw new Error(`seasonal event summary[${index}] id is required`);
+    }
+
+    const detail = eventDocuments[id];
+    if (!detail) {
+      throw new Error(`seasonal event ${id} is missing a detail document`);
+    }
+
+    const rewardTiers = (detail.leaderboard?.rewardTiers ?? []).map((tier, tierIndex) =>
+      normalizeLeaderboardRewardTier(tier, `seasonal event ${id} leaderboard.rewardTiers[${tierIndex}]`)
+    );
+
+    return {
+      id,
+      name: detail.name?.trim() || summary.name?.trim() || id,
+      description: detail.description?.trim() || summary.description?.trim() || "",
+      startsAt: normalizeTimestamp(detail.startsAt ?? summary.startsAt, `seasonal event ${id}.startsAt`),
+      endsAt: normalizeTimestamp(detail.endsAt ?? summary.endsAt, `seasonal event ${id}.endsAt`),
+      durationDays: normalizeNonNegativeInteger(
+        detail.durationDays ?? summary.durationDays,
+        `seasonal event ${id}.durationDays`,
+        1
+      ),
+      bannerText: detail.bannerText?.trim() || summary.bannerText?.trim() || "",
+      objectives: (detail.objectives ?? []).map((objective, objectiveIndex) =>
+        normalizeObjective(objective, `seasonal event ${id} objective[${objectiveIndex}]`)
+      ),
+      rewards: (detail.rewards ?? []).map((reward, rewardIndex) =>
+        normalizeEventReward(reward, `seasonal event ${id} reward[${rewardIndex}]`)
+      ),
+      leaderboard: {
+        size: normalizeNonNegativeInteger(
+          detail.leaderboard?.size ?? summary.leaderboard?.size,
+          `seasonal event ${id}.leaderboard.size`,
+          1
+        ),
+        rewardTiers
+      }
+    };
+  });
+}
+
+export function getActiveSeasonalEvents(events: SeasonalEventDefinition[], now = new Date()): SeasonalEventDefinition[] {
+  const currentTime = now.getTime();
+  return events.filter((event) => {
+    const startsAt = new Date(event.startsAt).getTime();
+    const endsAt = new Date(event.endsAt).getTime();
+    return startsAt <= currentTime && currentTime < endsAt;
+  });
+}
+
+export function findSeasonalEventState(
+  seasonalEventStates: SeasonalEventState[] | null | undefined,
+  eventId: string
+): SeasonalEventState | undefined {
+  return seasonalEventStates?.find((state) => state.eventId === eventId);
+}
+
+function upsertSeasonalEventState(
+  seasonalEventStates: SeasonalEventState[] | null | undefined,
+  nextState: SeasonalEventState
+): SeasonalEventState[] {
+  const remainingStates = (seasonalEventStates ?? []).filter((state) => state.eventId !== nextState.eventId);
+  return [...remainingStates, nextState].sort((left, right) => left.eventId.localeCompare(right.eventId));
+}
+
+export function applySeasonalEventProgress(
+  event: SeasonalEventDefinition,
+  currentState: SeasonalEventState | null | undefined,
+  action: SeasonalEventActionInput,
+  now = new Date()
+): { state: SeasonalEventState; objective: SeasonalEventObjective; delta: number } | null {
+  const objective = event.objectives.find(
+    (entry) =>
+      entry.actionType === action.actionType && (!entry.dungeonId || !action.dungeonId || entry.dungeonId === action.dungeonId)
+  );
+  if (!objective) {
+    return null;
+  }
+
+  const actionId = action.actionId.trim();
+  if (!actionId) {
+    throw new Error("seasonal_event_action_id_required");
+  }
+
+  if (currentState?.appliedActionIds.includes(actionId)) {
+    return null;
+  }
+
+  const appliedActionIds = Array.from(new Set([...(currentState?.appliedActionIds ?? []), actionId])).sort((left, right) =>
+    left.localeCompare(right)
+  );
+  const lastUpdatedAt = action.occurredAt ? normalizeTimestamp(action.occurredAt, "seasonal event action occurredAt") : now.toISOString();
+
+  return {
+    objective,
+    delta: objective.points,
+    state: {
+      eventId: event.id,
+      points: Math.max(0, (currentState?.points ?? 0) + objective.points),
+      claimedRewardIds: [...(currentState?.claimedRewardIds ?? [])],
+      appliedActionIds,
+      lastUpdatedAt
+    }
+  };
+}
+
+export function claimSeasonalEventReward(
+  event: SeasonalEventDefinition,
+  currentState: SeasonalEventState | null | undefined,
+  rewardId: string,
+  now = new Date()
+): { state: SeasonalEventState; reward: SeasonalEventReward } {
+  const reward = event.rewards.find((entry) => entry.id === rewardId.trim());
+  if (!reward) {
+    throw new Error("seasonal_event_reward_not_found");
+  }
+
+  const state = currentState;
+  if (!state) {
+    throw new Error("seasonal_event_reward_locked");
+  }
+  if (state.points < reward.pointsRequired) {
+    throw new Error("seasonal_event_reward_locked");
+  }
+  if (state.claimedRewardIds.includes(reward.id)) {
+    throw new Error("seasonal_event_reward_already_claimed");
+  }
+
+  return {
+    reward,
+    state: {
+      ...state,
+      claimedRewardIds: [...state.claimedRewardIds, reward.id].sort((left, right) => left.localeCompare(right)),
+      lastUpdatedAt: now.toISOString()
+    }
+  };
+}
+
+function rewardPreviewForRank(
+  leaderboardRewardTiers: SeasonalEventDefinition["leaderboard"]["rewardTiers"],
+  rank: number
+): string | undefined {
+  return leaderboardRewardTiers.find((tier) => tier.rankStart <= rank && rank <= tier.rankEnd)?.title;
+}
+
+export function buildEventLeaderboard(
+  event: SeasonalEventDefinition,
+  accounts: PlayerAccountSnapshot[],
+  limit = event.leaderboard.size
+): EventLeaderboardEntry[] {
+  return accounts
+    .map((account) => {
+      const state = findSeasonalEventState(account.seasonalEventStates, event.id);
+      if (!state || state.points <= 0) {
+        return null;
+      }
+
+      return {
+        playerId: account.playerId,
+        displayName: account.displayName,
+        points: state.points,
+        lastUpdatedAt: state.lastUpdatedAt
+      };
+    })
+    .filter(
+      (
+        entry
+      ): entry is {
+        playerId: string;
+        displayName: string;
+        points: number;
+        lastUpdatedAt: string;
+      } => Boolean(entry)
+    )
+    .sort(
+      (left, right) =>
+        right.points - left.points ||
+        left.lastUpdatedAt.localeCompare(right.lastUpdatedAt) ||
+        left.playerId.localeCompare(right.playerId)
+    )
+    .slice(0, Math.max(1, limit))
+    .map((entry, index) => {
+      const rewardPreview = rewardPreviewForRank(event.leaderboard.rewardTiers, index + 1);
+      return {
+        rank: index + 1,
+        ...entry,
+        ...(rewardPreview ? { rewardPreview } : {})
+      };
+    });
+}
+
+function toEventResponse(event: SeasonalEventDefinition, account: PlayerAccountSnapshot, leaderboard: EventLeaderboardEntry[], now: Date) {
+  const state = findSeasonalEventState(account.seasonalEventStates, event.id);
+  return {
+    ...event,
+    remainingMs: Math.max(0, new Date(event.endsAt).getTime() - now.getTime()),
+    player: {
+      points: state?.points ?? 0,
+      claimedRewardIds: state?.claimedRewardIds ?? [],
+      claimableRewardIds: event.rewards
+        .filter((reward) => (state?.points ?? 0) >= reward.pointsRequired && !(state?.claimedRewardIds ?? []).includes(reward.id))
+        .map((reward) => reward.id)
+    },
+    leaderboard: {
+      entries: leaderboard,
+      topThree: leaderboard.slice(0, 3)
+    }
+  };
+}
+
+export function registerEventRoutes(
+  app: {
+    use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
+    get: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+    post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+  },
+  store: RoomSnapshotStore | null,
+  options: RegisterEventRoutesOptions = {}
+): void {
+  const nowFactory = options.now ?? (() => new Date());
+  const events = resolveSeasonalEvents(options.eventIndexDocument, options.eventDocuments);
+
+  app.use((request, response, next) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
+
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    next();
+  });
+
+  app.get("/api/events/active", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const now = nowFactory();
+      const activeEvents = getActiveSeasonalEvents(events, now);
+      const account = store
+        ? ((await store.loadPlayerAccount(authSession.playerId)) ??
+          (await store.ensurePlayerAccount({
+            playerId: authSession.playerId,
+            displayName: authSession.displayName
+          })))
+        : {
+            playerId: authSession.playerId,
+            displayName: authSession.displayName,
+            globalResources: { gold: 0, wood: 0, ore: 0 },
+            achievements: [],
+            recentEventLog: [],
+            createdAt: now.toISOString(),
+            updatedAt: now.toISOString()
+          };
+      const accounts = store ? await store.listPlayerAccounts() : [];
+
+      sendJson(response, 200, {
+        events: activeEvents.map((event) => toEventResponse(event, account, buildEventLeaderboard(event, accounts), now))
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/events/claim", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 503, {
+        error: {
+          code: "seasonal_event_persistence_unavailable",
+          message: "Seasonal event claims require configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as { eventId?: string | null; rewardId?: string | null };
+      const eventId = body.eventId?.trim();
+      const rewardId = body.rewardId?.trim();
+      if (!eventId || !rewardId) {
+        sendJson(response, 400, {
+          error: {
+            code: "seasonal_event_claim_invalid",
+            message: "eventId and rewardId are required"
+          }
+        });
+        return;
+      }
+
+      const now = nowFactory();
+      const event = getActiveSeasonalEvents(events, now).find((entry) => entry.id === eventId);
+      if (!event) {
+        sendJson(response, 404, {
+          error: {
+            code: "seasonal_event_not_found",
+            message: "Seasonal event was not found or is not active"
+          }
+        });
+        return;
+      }
+
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      const claim = claimSeasonalEventReward(event, findSeasonalEventState(account.seasonalEventStates, event.id), rewardId, now);
+      const nextResources = {
+        gold: Math.max(0, (account.globalResources.gold ?? 0) + (claim.reward.resources?.gold ?? 0)),
+        wood: Math.max(0, (account.globalResources.wood ?? 0) + (claim.reward.resources?.wood ?? 0)),
+        ore: Math.max(0, (account.globalResources.ore ?? 0) + (claim.reward.resources?.ore ?? 0))
+      };
+      const nextAccount = await store.savePlayerAccountProgress(account.playerId, {
+        gems: Math.max(0, (account.gems ?? 0) + (claim.reward.gems ?? 0)),
+        globalResources: nextResources,
+        ...(claim.reward.badge
+          ? {
+              seasonBadges: Array.from(new Set([...(account.seasonBadges ?? []), claim.reward.badge])).sort((left, right) =>
+                left.localeCompare(right)
+              )
+            }
+          : {}),
+        seasonalEventStates: upsertSeasonalEventState(account.seasonalEventStates, claim.state)
+      });
+
+      sendJson(response, 200, {
+        claimed: true,
+        reward: claim.reward,
+        event: toEventResponse(event, nextAccount, buildEventLeaderboard(event, await store.listPlayerAccounts()), now)
+      });
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_json",
+            message: "Request body must be valid JSON"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "seasonal_event_reward_not_found") {
+        sendJson(response, 404, {
+          error: {
+            code: "seasonal_event_reward_not_found",
+            message: "Seasonal event reward was not found"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "seasonal_event_reward_locked") {
+        sendJson(response, 409, {
+          error: {
+            code: "seasonal_event_reward_locked",
+            message: "Seasonal event reward is not claimable yet"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "seasonal_event_reward_already_claimed") {
+        sendJson(response, 409, {
+          error: {
+            code: "seasonal_event_reward_already_claimed",
+            message: "Seasonal event reward has already been claimed"
+          }
+        });
+        return;
+      }
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+}

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -24,6 +24,7 @@ import {
   type PlayerAchievementProgress,
   type RankedWeeklyProgress,
   type ResourceLedger,
+  type SeasonalEventState,
   type SeasonArchiveEntry,
   type WorldState
 } from "../../../packages/shared/src/index";
@@ -207,6 +208,7 @@ interface PlayerAccountRow extends RowDataPacket {
   season_pass_claimed_tiers_json: string | number[] | null;
   season_badges_json: string | string[] | null;
   campaign_progress_json: string | PlayerAccountSnapshot["campaignProgress"] | null;
+  seasonal_event_states_json: string | PlayerAccountSnapshot["seasonalEventStates"] | null;
   global_resources_json: string | ResourceLedger;
   achievements_json: string | PlayerAchievementProgress[] | null;
   recent_event_log_json: string | EventLogEntry[] | null;
@@ -545,6 +547,7 @@ export interface PlayerAccountProgressPatch {
   seasonHistory?: PlayerAccountSnapshot["seasonHistory"] | null;
   rankedWeeklyProgress?: PlayerAccountSnapshot["rankedWeeklyProgress"] | null;
   campaignProgress?: PlayerAccountSnapshot["campaignProgress"] | null;
+  seasonalEventStates?: SeasonalEventState[] | null;
   globalResources?: Partial<ResourceLedger> | null;
   achievements?: Partial<PlayerAchievementProgress>[] | null;
   recentEventLog?: Partial<EventLogEntry>[] | null;
@@ -1186,6 +1189,7 @@ function normalizePlayerAccountSnapshot(account: {
   seasonPassClaimedTiers?: number[] | null | undefined;
   seasonBadges?: string[] | null | undefined;
   campaignProgress?: PlayerAccountSnapshot["campaignProgress"] | null | undefined;
+  seasonalEventStates?: PlayerAccountSnapshot["seasonalEventStates"] | null | undefined;
   globalResources?: Partial<ResourceLedger>;
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
@@ -1244,6 +1248,7 @@ function normalizePlayerAccountSnapshot(account: {
       seasonPassClaimedTiers: account.seasonPassClaimedTiers ?? [],
       seasonBadges: account.seasonBadges,
       campaignProgress: account.campaignProgress,
+      seasonalEventStates: account.seasonalEventStates,
       globalResources: normalizeResourceLedger(account.globalResources),
       achievements: account.achievements,
       recentEventLog: account.recentEventLog,
@@ -1551,6 +1556,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   season_pass_claimed_tiers_json LONGTEXT NULL,
   season_badges_json LONGTEXT NULL,
   campaign_progress_json LONGTEXT NULL,
+  seasonal_event_states_json LONGTEXT NULL,
   global_resources_json LONGTEXT NOT NULL,
   achievements_json LONGTEXT NULL,
   recent_event_log_json LONGTEXT NULL,
@@ -1978,6 +1984,22 @@ SET @veil_player_accounts_campaign_progress_sql := IF(
 PREPARE veil_player_accounts_campaign_progress_stmt FROM @veil_player_accounts_campaign_progress_sql;
 EXECUTE veil_player_accounts_campaign_progress_stmt;
 DEALLOCATE PREPARE veil_player_accounts_campaign_progress_stmt;
+
+SET @veil_player_accounts_seasonal_event_states_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'seasonal_event_states_json'
+);
+SET @veil_player_accounts_seasonal_event_states_sql := IF(
+  @veil_player_accounts_seasonal_event_states_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`seasonal_event_states_json\` LONGTEXT NULL AFTER \`campaign_progress_json\`',
+  'SELECT 1'
+);
+PREPARE veil_player_accounts_seasonal_event_states_stmt FROM @veil_player_accounts_seasonal_event_states_sql;
+EXECUTE veil_player_accounts_seasonal_event_states_stmt;
+DEALLOCATE PREPARE veil_player_accounts_seasonal_event_states_stmt;
 
 SET @veil_player_accounts_event_log_exists := (
   SELECT COUNT(*)
@@ -2879,6 +2901,10 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
       row.campaign_progress_json != null
         ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["campaignProgress"]>>(row.campaign_progress_json)
         : undefined,
+    seasonalEventStates:
+      row.seasonal_event_states_json != null
+        ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["seasonalEventStates"]>>(row.seasonal_event_states_json)
+        : undefined,
     globalResources: parseJsonColumn<ResourceLedger>(row.global_resources_json),
     achievements:
       row.achievements_json != null
@@ -3178,6 +3204,7 @@ async function savePlayerAccounts(
          season_pass_claimed_tiers_json,
          season_badges_json,
          campaign_progress_json,
+         seasonal_event_states_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json
@@ -3187,7 +3214,7 @@ async function savePlayerAccounts(
          tutorial_step,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(display_name, VALUES(display_name)),
          elo_rating = COALESCE(elo_rating, VALUES(elo_rating)),
@@ -3204,6 +3231,7 @@ async function savePlayerAccounts(
          season_pass_claimed_tiers_json = VALUES(season_pass_claimed_tiers_json),
          season_badges_json = COALESCE(season_badges_json, VALUES(season_badges_json)),
          campaign_progress_json = COALESCE(campaign_progress_json, VALUES(campaign_progress_json)),
+         seasonal_event_states_json = COALESCE(seasonal_event_states_json, VALUES(seasonal_event_states_json)),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = COALESCE(achievements_json, VALUES(achievements_json)),
          recent_event_log_json = COALESCE(recent_event_log_json, VALUES(recent_event_log_json)),
@@ -3229,6 +3257,7 @@ async function savePlayerAccounts(
         JSON.stringify(normalizedAccount.seasonPassClaimedTiers ?? []),
         JSON.stringify(normalizedAccount.seasonBadges ?? []),
         JSON.stringify(normalizedAccount.campaignProgress ?? null),
+        JSON.stringify(normalizedAccount.seasonalEventStates ?? null),
         JSON.stringify(normalizedAccount.globalResources),
         JSON.stringify(normalizedAccount.achievements),
         JSON.stringify(normalizedAccount.recentEventLog),
@@ -3476,6 +3505,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json,
          season_badges_json,
          campaign_progress_json,
+         seasonal_event_states_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3539,6 +3569,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json,
          season_badges_json,
          campaign_progress_json,
+         seasonal_event_states_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3686,6 +3717,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json,
          season_badges_json,
          campaign_progress_json,
+         seasonal_event_states_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3843,6 +3875,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json,
          season_badges_json,
          campaign_progress_json,
+         seasonal_event_states_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -5219,7 +5252,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number,
          phone_number_bound_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = VALUES(avatar_url),
@@ -5236,6 +5269,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json = VALUES(season_pass_claimed_tiers_json),
          season_badges_json = COALESCE(season_badges_json, VALUES(season_badges_json)),
          campaign_progress_json = COALESCE(campaign_progress_json, VALUES(campaign_progress_json)),
+         seasonal_event_states_json = COALESCE(seasonal_event_states_json, VALUES(seasonal_event_states_json)),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = VALUES(achievements_json),
          recent_event_log_json = VALUES(recent_event_log_json),
@@ -5265,6 +5299,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.seasonPassClaimedTiers ?? []),
         JSON.stringify(nextAccount.seasonBadges ?? []),
         JSON.stringify(nextAccount.campaignProgress ?? null),
+        JSON.stringify(nextAccount.seasonalEventStates ?? null),
         JSON.stringify(nextAccount.globalResources),
         JSON.stringify(nextAccount.achievements),
         JSON.stringify(nextAccount.recentEventLog),
@@ -5316,6 +5351,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       seasonPassClaimedTiers: patch.seasonPassClaimedTiers ?? existing.seasonPassClaimedTiers,
       seasonBadges: patch.seasonBadges ?? existing.seasonBadges,
       campaignProgress: patch.campaignProgress ?? existing.campaignProgress,
+      seasonalEventStates: patch.seasonalEventStates ?? existing.seasonalEventStates,
       globalResources: patch.globalResources ?? existing.globalResources,
       achievements: patch.achievements ?? existing.achievements,
       recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
@@ -5363,6 +5399,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json,
          season_badges_json,
          campaign_progress_json,
+         seasonal_event_states_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -5377,7 +5414,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_play_date,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = COALESCE(avatar_url, VALUES(avatar_url)),
@@ -5388,6 +5425,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json = VALUES(season_pass_claimed_tiers_json),
          season_badges_json = VALUES(season_badges_json),
          campaign_progress_json = VALUES(campaign_progress_json),
+         seasonal_event_states_json = VALUES(seasonal_event_states_json),
          elo_rating = VALUES(elo_rating),
          rank_division = VALUES(rank_division),
          peak_rank_division = VALUES(peak_rank_division),
@@ -5427,6 +5465,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.seasonPassClaimedTiers ?? []),
         JSON.stringify(nextAccount.seasonBadges ?? []),
         JSON.stringify(nextAccount.campaignProgress ?? null),
+        JSON.stringify(nextAccount.seasonalEventStates ?? null),
         JSON.stringify(nextAccount.globalResources),
         JSON.stringify(nextAccount.achievements),
         JSON.stringify(nextAccount.recentEventLog),
@@ -5484,6 +5523,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json,
          season_badges_json,
          campaign_progress_json,
+         seasonal_event_states_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -14,8 +14,9 @@ import {
   queryPlayerBattleReplaySummaries,
   queryAchievementProgress,
   queryEventLogEntries,
-  type TutorialProgressAction,
-  type PlayerBattleReplaySummary
+  type PlayerBattleReplaySummary,
+  type SeasonalEventState,
+  type TutorialProgressAction
 } from "../../../packages/shared/src/index";
 import {
   createDailyQuestClaimEventLogEntry,
@@ -40,6 +41,12 @@ import type {
   RoomSnapshotStore
 } from "./persistence";
 import { getDailyRewardDateKey, getPreviousDailyRewardDateKey, resolveDailyRewardForStreak } from "./daily-rewards";
+import {
+  applySeasonalEventProgress,
+  findSeasonalEventState,
+  getActiveSeasonalEvents,
+  resolveSeasonalEvents
+} from "./event-engine";
 import { resolveFeatureFlagsForPlayer } from "./feature-flags";
 import {
   buildCampaignMissionStates,
@@ -480,6 +487,45 @@ function toRewardMutation(account: PlayerAccountSnapshot, reward?: { gems?: numb
       ore: (account.globalResources.ore ?? 0) + ore
     }
   };
+}
+
+function upsertSeasonalEventState(
+  seasonalEventStates: SeasonalEventState[] | undefined,
+  nextState: SeasonalEventState
+): SeasonalEventState[] {
+  return [...(seasonalEventStates ?? []).filter((state) => state.eventId !== nextState.eventId), nextState].sort((left, right) =>
+    left.eventId.localeCompare(right.eventId)
+  );
+}
+
+function applyActiveSeasonalEventProgress(
+  account: PlayerAccountSnapshot,
+  action: Parameters<typeof applySeasonalEventProgress>[2],
+  now = new Date()
+): {
+  seasonalEventStates: SeasonalEventState[] | undefined;
+  eventProgress: Array<{ eventId: string; delta: number; points: number; objectiveId: string }>;
+} {
+  const activeEvents = getActiveSeasonalEvents(resolveSeasonalEvents(), now);
+  let seasonalEventStates = account.seasonalEventStates;
+  const eventProgress: Array<{ eventId: string; delta: number; points: number; objectiveId: string }> = [];
+
+  for (const event of activeEvents) {
+    const progress = applySeasonalEventProgress(event, findSeasonalEventState(seasonalEventStates, event.id), action, now);
+    if (!progress) {
+      continue;
+    }
+
+    seasonalEventStates = upsertSeasonalEventState(seasonalEventStates, progress.state);
+    eventProgress.push({
+      eventId: event.id,
+      delta: progress.delta,
+      points: progress.state.points,
+      objectiveId: progress.objective.id
+    });
+  }
+
+  return { seasonalEventStates, eventProgress };
 }
 
 function normalizePlayerId(playerId?: string | null): string {
@@ -1370,17 +1416,29 @@ export function registerPlayerAccountRoutes(
       const dungeon = resolvePrimaryDailyDungeon();
       const result = claimDailyDungeonRunReward(dungeon, account.dailyDungeonState, runId);
       const rewardMutation = toRewardMutation(account, result.floor.reward);
+      const eventMutation = applyActiveSeasonalEventProgress(
+        account,
+        {
+          actionId: result.run.runId,
+          actionType: "daily_dungeon_reward_claimed",
+          dungeonId: result.run.dungeonId,
+          ...(result.run.rewardClaimedAt ? { occurredAt: result.run.rewardClaimedAt } : {})
+        },
+        new Date(result.run.rewardClaimedAt ?? new Date().toISOString())
+      );
       const nextAccount = await store.savePlayerAccountProgress(account.playerId, {
         dailyDungeonState: result.dailyDungeonState,
         gems: rewardMutation.gems,
-        globalResources: rewardMutation.globalResources
+        globalResources: rewardMutation.globalResources,
+        ...(eventMutation.seasonalEventStates ? { seasonalEventStates: eventMutation.seasonalEventStates } : {})
       });
 
       sendJson(response, 200, {
         claimed: true,
         run: result.run,
         reward: result.floor.reward,
-        dailyDungeon: toDailyDungeonResponse(nextAccount)
+        dailyDungeon: toDailyDungeonResponse(nextAccount),
+        ...(eventMutation.eventProgress.length > 0 ? { eventProgress: eventMutation.eventProgress } : {})
       });
     } catch (error) {
       if (error instanceof Error && error.message === "daily_dungeon_run_not_found") {

--- a/apps/server/src/pve-content.ts
+++ b/apps/server/src/pve-content.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import campaignDocument from "../../../configs/campaign.json";
+import campaignDocument from "../../../configs/campaign-chapter1.json";
 import dailyDungeonsDocument from "../../../configs/daily-dungeons.json";
 import type {
   CampaignMission,
@@ -10,12 +10,32 @@ import type {
   DailyDungeonFloor,
   DailyDungeonReward,
   DailyDungeonRunRecord,
-  DailyDungeonState
+  DailyDungeonState,
+  DialogueLine,
+  MissionObjective
 } from "../../../packages/shared/src/index";
 import { getDailyRewardDateKey } from "./daily-rewards";
 
+interface CampaignConfigMissionDocument {
+  id?: string | null;
+  chapterId?: string | null;
+  order?: number | null;
+  mapId?: string | null;
+  name?: string | null;
+  description?: string | null;
+  recommendedHeroLevel?: number | null;
+  enemyArmyTemplateId?: string | null;
+  enemyArmyCount?: number | null;
+  enemyStatMultiplier?: number | null;
+  unlockMissionId?: string | null;
+  reward?: DailyDungeonReward | null;
+  introDialogue?: Partial<DialogueLine>[] | null;
+  outroDialogue?: Partial<DialogueLine>[] | null;
+  objectives?: Partial<MissionObjective>[] | null;
+}
+
 interface CampaignConfigDocument {
-  missions?: Partial<CampaignMission>[] | null;
+  missions?: CampaignConfigMissionDocument[] | null;
 }
 
 interface DailyDungeonConfigDocument {
@@ -58,6 +78,56 @@ function normalizeReward(rawReward: DailyDungeonReward | undefined, field: strin
   };
 }
 
+function normalizeDialogueLine(rawLine: Partial<DialogueLine> | null | undefined, field: string): DialogueLine {
+  const id = rawLine?.id?.trim();
+  const speakerId = rawLine?.speakerId?.trim();
+  const speakerName = rawLine?.speakerName?.trim();
+  const text = rawLine?.text?.trim();
+  const portraitId = rawLine?.portraitId?.trim();
+
+  if (!id || !speakerId || !speakerName || !text) {
+    throw new Error(`${field} must define id, speakerId, speakerName, and text`);
+  }
+
+  return {
+    id,
+    speakerId,
+    speakerName,
+    text,
+    ...(portraitId ? { portraitId } : {}),
+    ...(rawLine?.mood ? { mood: rawLine.mood } : {})
+  };
+}
+
+function normalizeMissionObjective(rawObjective: Partial<MissionObjective> | null | undefined, field: string): MissionObjective {
+  const candidate = rawObjective ?? {};
+  const id = candidate.id?.trim();
+  const description = candidate.description?.trim();
+  if (!id || !description) {
+    throw new Error(`${field} must define id and description`);
+  }
+
+  const unlocksObjectiveIds = Array.from(
+    new Set(
+      (candidate.unlocksObjectiveIds ?? [])
+        .map((objectiveId) => objectiveId?.trim())
+        .filter((objectiveId): objectiveId is string => Boolean(objectiveId))
+    )
+  ).sort((left, right) => left.localeCompare(right));
+
+  return {
+    id,
+    description,
+    kind: candidate.kind ?? "defeat",
+    ...(candidate.gate ? { gate: candidate.gate } : {}),
+    ...(candidate.optional === true ? { optional: true } : {}),
+    ...(candidate.targetCount != null
+      ? { targetCount: normalizeNonNegativeInteger(candidate.targetCount, `${field}.targetCount`, 1) }
+      : {}),
+    ...(unlocksObjectiveIds.length > 0 ? { unlocksObjectiveIds } : {})
+  };
+}
+
 export function resolveCampaignConfig(
   document: CampaignConfigDocument = campaignDocument as CampaignConfigDocument
 ): CampaignMission[] {
@@ -69,18 +139,51 @@ export function resolveCampaignConfig(
   const missions = rawMissions.map((rawMission, index) => {
     const id = rawMission.id?.trim();
     const chapterId = rawMission.chapterId?.trim();
+    const mapId = rawMission.mapId?.trim();
     const name = rawMission.name?.trim();
     const description = rawMission.description?.trim();
     const enemyArmyTemplateId = rawMission.enemyArmyTemplateId?.trim();
-    if (!id || !chapterId || !name || !description || !enemyArmyTemplateId) {
-      throw new Error(`campaign mission[${index}] must define id, chapterId, name, description, and enemyArmyTemplateId`);
+    if (!id || !chapterId || !mapId || !name || !description || !enemyArmyTemplateId) {
+      throw new Error(
+        `campaign mission[${index}] must define id, chapterId, mapId, name, description, and enemyArmyTemplateId`
+      );
     }
 
     const unlockMissionId = rawMission.unlockMissionId?.trim();
+    const objectives = (rawMission.objectives ?? []).map((objective, objectiveIndex) =>
+      normalizeMissionObjective(objective, `campaign mission ${id} objective[${objectiveIndex}]`)
+    );
+    if (objectives.length === 0) {
+      throw new Error(`campaign mission ${id} must define at least one objective`);
+    }
+
+    const objectiveIds = new Set<string>();
+    for (const objective of objectives) {
+      if (objectiveIds.has(objective.id)) {
+        throw new Error(`campaign mission ${id} objective ids must be unique: ${objective.id}`);
+      }
+      objectiveIds.add(objective.id);
+    }
+
+    for (const objective of objectives) {
+      for (const unlockedObjectiveId of objective.unlocksObjectiveIds ?? []) {
+        if (!objectiveIds.has(unlockedObjectiveId)) {
+          throw new Error(`campaign mission ${id} objective ${objective.id} unlock references unknown objective ${unlockedObjectiveId}`);
+        }
+      }
+    }
+
+    const introDialogue = (rawMission.introDialogue ?? []).map((line, lineIndex) =>
+      normalizeDialogueLine(line, `campaign mission ${id} introDialogue[${lineIndex}]`)
+    );
+    const outroDialogue = (rawMission.outroDialogue ?? []).map((line, lineIndex) =>
+      normalizeDialogueLine(line, `campaign mission ${id} outroDialogue[${lineIndex}]`)
+    );
     return {
       id,
       chapterId,
       order: normalizeNonNegativeInteger(rawMission.order, `campaign mission ${id} order`, 1),
+      mapId,
       name,
       description,
       recommendedHeroLevel: normalizeNonNegativeInteger(
@@ -95,7 +198,10 @@ export function resolveCampaignConfig(
         `campaign mission ${id} enemyStatMultiplier`
       ),
       ...(unlockMissionId ? { unlockMissionId } : {}),
-      reward: normalizeReward(rawMission.reward, `campaign mission ${id} reward`)
+      ...(introDialogue.length > 0 ? { introDialogue } : {}),
+      ...(outroDialogue.length > 0 ? { outroDialogue } : {}),
+      objectives,
+      reward: normalizeReward(rawMission.reward ?? undefined, `campaign mission ${id} reward`)
     } satisfies CampaignMission;
   });
 

--- a/apps/server/test/event-engine.test.ts
+++ b/apps/server/test/event-engine.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applySeasonalEventProgress,
+  buildEventLeaderboard,
+  claimSeasonalEventReward,
+  getActiveSeasonalEvents,
+  resolveSeasonalEvents
+} from "../src/event-engine";
+import type { PlayerAccountSnapshot } from "../src/persistence";
+
+test("seasonal events resolve the active defend-the-bridge window", () => {
+  const events = resolveSeasonalEvents();
+  const activeEvents = getActiveSeasonalEvents(events, new Date("2026-04-04T12:00:00.000Z"));
+
+  assert.equal(events.length, 1);
+  assert.equal(activeEvents.length, 1);
+  assert.equal(activeEvents[0]?.id, "defend-the-bridge");
+  assert.equal(activeEvents[0]?.leaderboard.size, 100);
+});
+
+test("seasonal event progress accumulates once per claimed dungeon run", () => {
+  const [event] = getActiveSeasonalEvents(resolveSeasonalEvents(), new Date("2026-04-04T12:00:00.000Z"));
+  assert.ok(event);
+
+  const first = applySeasonalEventProgress(
+    event,
+    undefined,
+    {
+      actionId: "run-1",
+      actionType: "daily_dungeon_reward_claimed",
+      dungeonId: "shadow-archives",
+      occurredAt: "2026-04-04T12:05:00.000Z"
+    },
+    new Date("2026-04-04T12:05:00.000Z")
+  );
+  const duplicate = applySeasonalEventProgress(
+    event,
+    first?.state,
+    {
+      actionId: "run-1",
+      actionType: "daily_dungeon_reward_claimed",
+      dungeonId: "shadow-archives",
+      occurredAt: "2026-04-04T12:06:00.000Z"
+    },
+    new Date("2026-04-04T12:06:00.000Z")
+  );
+  const second = applySeasonalEventProgress(
+    event,
+    first?.state,
+    {
+      actionId: "run-2",
+      actionType: "daily_dungeon_reward_claimed",
+      dungeonId: "shadow-archives",
+      occurredAt: "2026-04-04T13:00:00.000Z"
+    },
+    new Date("2026-04-04T13:00:00.000Z")
+  );
+
+  assert.equal(first?.delta, 40);
+  assert.equal(first?.state.points, 40);
+  assert.equal(duplicate, null);
+  assert.equal(second?.state.points, 80);
+});
+
+test("seasonal event reward claims validate thresholds and idempotency", () => {
+  const [event] = getActiveSeasonalEvents(resolveSeasonalEvents(), new Date("2026-04-04T12:00:00.000Z"));
+  assert.ok(event);
+
+  assert.throws(() => claimSeasonalEventReward(event, undefined, "bridge-ration-cache"), /seasonal_event_reward_locked/);
+
+  const initialState = {
+    eventId: event.id,
+    points: 120,
+    claimedRewardIds: [],
+    appliedActionIds: ["run-1", "run-2", "run-3"],
+    lastUpdatedAt: "2026-04-04T12:10:00.000Z"
+  };
+  const claim = claimSeasonalEventReward(event, initialState, "bridge-ration-cache", new Date("2026-04-04T12:11:00.000Z"));
+
+  assert.equal(claim.reward.kind, "resources");
+  assert.equal(claim.state.claimedRewardIds[0], "bridge-ration-cache");
+  assert.throws(
+    () => claimSeasonalEventReward(event, claim.state, "bridge-ration-cache", new Date("2026-04-04T12:12:00.000Z")),
+    /seasonal_event_reward_already_claimed/
+  );
+});
+
+test("event leaderboard sorts players by points then oldest update time", () => {
+  const [event] = getActiveSeasonalEvents(resolveSeasonalEvents(), new Date("2026-04-04T12:00:00.000Z"));
+  assert.ok(event);
+
+  const account = (playerId: string, displayName: string, points: number, lastUpdatedAt: string): PlayerAccountSnapshot => ({
+    playerId,
+    displayName,
+    globalResources: { gold: 0, wood: 0, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    seasonalEventStates: [
+      {
+        eventId: event.id,
+        points,
+        claimedRewardIds: [],
+        appliedActionIds: [],
+        lastUpdatedAt
+      }
+    ],
+    createdAt: "2026-04-04T00:00:00.000Z",
+    updatedAt: lastUpdatedAt
+  });
+
+  const leaderboard = buildEventLeaderboard(event, [
+    account("player-1", "Lyra", 120, "2026-04-04T09:00:00.000Z"),
+    account("player-2", "Serin", 160, "2026-04-04T09:10:00.000Z"),
+    account("player-3", "Hale", 120, "2026-04-04T08:55:00.000Z")
+  ]);
+
+  assert.equal(leaderboard[0]?.playerId, "player-2");
+  assert.equal(leaderboard[1]?.playerId, "player-3");
+  assert.equal(leaderboard[2]?.playerId, "player-1");
+  assert.equal(leaderboard[0]?.rewardPreview, "Bridge Champion");
+});

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -180,6 +180,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       recentEventLog: structuredClone(existing?.recentEventLog ?? []),
       recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
       ...(existing?.campaignProgress ? { campaignProgress: structuredClone(existing.campaignProgress) } : {}),
+      ...(existing?.seasonalEventStates ? { seasonalEventStates: structuredClone(existing.seasonalEventStates) } : {}),
       ...(existing?.dailyDungeonState ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) } : {}),
       ...(existing?.tutorialStep !== undefined ? { tutorialStep: existing.tutorialStep } : { tutorialStep: DEFAULT_TUTORIAL_STEP }),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
@@ -546,6 +547,13 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
           : {}
         : existing.campaignProgress
           ? { campaignProgress: structuredClone(existing.campaignProgress) }
+          : {}),
+      ...(patch.seasonalEventStates !== undefined
+        ? patch.seasonalEventStates
+          ? { seasonalEventStates: structuredClone(patch.seasonalEventStates) }
+          : {}
+        : existing.seasonalEventStates
+          ? { seasonalEventStates: structuredClone(existing.seasonalEventStates) }
           : {}),
       globalResources: structuredClone(
         (patch.globalResources as PlayerAccountSnapshot["globalResources"] | undefined) ?? existing.globalResources
@@ -3314,7 +3322,7 @@ test("referral endpoint credits both accounts exactly once", async (t) => {
   assert.equal(newPlayer?.gems, 23);
 });
 
-test("campaign mission completion unlocks the next scaffold mission and grants rewards", async (t) => {
+test("campaign mission completion unlocks the next chapter 1 mission and grants rewards", async (t) => {
   const port = 44980 + Math.floor(Math.random() * 1000);
   const store = new MemoryPlayerAccountStore();
   await store.ensurePlayerAccount({
@@ -3346,13 +3354,13 @@ test("campaign mission completion unlocks the next scaffold mission and grants r
   };
 
   assert.equal(initialResponse.status, 200);
-  assert.equal(initialPayload.campaign.totalMissions, 10);
-  assert.equal(initialPayload.campaign.nextMissionId, "campaign_tutorial_1");
+  assert.equal(initialPayload.campaign.totalMissions, 6);
+  assert.equal(initialPayload.campaign.nextMissionId, "chapter1-ember-watch");
   assert.equal(initialPayload.campaign.missions[0]?.status, "available");
   assert.equal(initialPayload.campaign.missions[1]?.status, "locked");
 
   const completeResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/me/campaign/campaign_tutorial_1/complete`,
+    `http://127.0.0.1:${port}/api/player-accounts/me/campaign/chapter1-ember-watch/complete`,
     {
       method: "POST",
       headers: {
@@ -3372,19 +3380,19 @@ test("campaign mission completion unlocks the next scaffold mission and grants r
 
   assert.equal(completeResponse.status, 200);
   assert.equal(completePayload.completed, true);
-  assert.equal(completePayload.reward.gems, 10);
-  assert.equal(completePayload.reward.resources.gold, 120);
+  assert.equal(completePayload.reward.gems, 12);
+  assert.equal(completePayload.reward.resources.gold, 140);
   assert.equal(completePayload.campaign.completedCount, 1);
-  assert.equal(completePayload.campaign.nextMissionId, "campaign_tutorial_2");
+  assert.equal(completePayload.campaign.nextMissionId, "chapter1-thornwall-road");
   assert.equal(
-    completePayload.campaign.missions.find((mission) => mission.id === "campaign_tutorial_2")?.status,
+    completePayload.campaign.missions.find((mission) => mission.id === "chapter1-thornwall-road")?.status,
     "available"
   );
 
   const account = await store.loadPlayerAccount("campaign-player");
-  assert.equal(account?.gems, 10);
-  assert.equal(account?.globalResources.gold, 120);
-  assert.equal(account?.campaignProgress?.missions[0]?.missionId, "campaign_tutorial_1");
+  assert.equal(account?.gems, 12);
+  assert.equal(account?.globalResources.gold, 140);
+  assert.equal(account?.campaignProgress?.missions[0]?.missionId, "chapter1-ember-watch");
 });
 
 test("daily dungeon attempts are capped per day and rewards can only be claimed once per run", async (t) => {
@@ -3457,6 +3465,7 @@ test("daily dungeon attempts are capped per day and rewards can only be claimed 
     claimed: boolean;
     reward: { gems: number; resources: { gold: number; ore: number } };
     dailyDungeon: { attemptsRemaining: number };
+    eventProgress?: Array<{ eventId: string; delta: number; points: number; objectiveId: string }>;
   };
   const claimAgainPayload = (await claimAgainResponse.json()) as { error: { code: string } };
 
@@ -3466,6 +3475,9 @@ test("daily dungeon attempts are capped per day and rewards can only be claimed 
   assert.equal(claimPayload.reward.resources.gold, 220);
   assert.equal(claimPayload.reward.resources.ore, 10);
   assert.equal(claimPayload.dailyDungeon.attemptsRemaining, 0);
+  assert.equal(claimPayload.eventProgress?.[0]?.eventId, "defend-the-bridge");
+  assert.equal(claimPayload.eventProgress?.[0]?.delta, 40);
+  assert.equal(claimPayload.eventProgress?.[0]?.points, 40);
   assert.equal(claimAgainResponse.status, 409);
   assert.equal(claimAgainPayload.error.code, "daily_dungeon_reward_already_claimed");
 
@@ -3475,4 +3487,6 @@ test("daily dungeon attempts are capped per day and rewards can only be claimed 
   assert.equal(account?.globalResources.ore, 10);
   assert.equal(account?.dailyDungeonState?.attemptsUsed, 3);
   assert.equal(account?.dailyDungeonState?.claimedRunIds.includes(firstRunPayload.run.runId), true);
+  assert.equal(account?.seasonalEventStates?.[0]?.eventId, "defend-the-bridge");
+  assert.equal(account?.seasonalEventStates?.[0]?.points, 40);
 });

--- a/apps/server/test/pve-content.test.ts
+++ b/apps/server/test/pve-content.test.ts
@@ -10,11 +10,13 @@ import {
   startDailyDungeonRun
 } from "../src/pve-content";
 
-test("campaign config exposes a 10-mission scaffold with sequential unlocks", () => {
+test("campaign config exposes a 6-mission chapter 1 arc with dialogue and sequential unlocks", () => {
   const missions = resolveCampaignConfig();
   const states = buildCampaignMissionStates(missions, undefined);
 
-  assert.equal(missions.length, 10);
+  assert.equal(missions.length, 6);
+  assert.equal(missions[0]?.introDialogue?.length, 2);
+  assert.equal(missions[0]?.objectives[0]?.id, "c1m1-clear-patrol");
   assert.equal(states[0]?.status, "available");
   assert.equal(states[1]?.unlockMissionId, states[0]?.id);
   assert.equal(states[1]?.status, "locked");

--- a/configs/campaign-chapter1.json
+++ b/configs/campaign-chapter1.json
@@ -1,0 +1,305 @@
+{
+  "missions": [
+    {
+      "id": "chapter1-ember-watch",
+      "chapterId": "chapter1",
+      "order": 1,
+      "mapId": "amber-fields",
+      "name": "Ash At First Light",
+      "description": "Scout the burned farmlands and learn why the frontier beacons went dark.",
+      "recommendedHeroLevel": 1,
+      "enemyArmyTemplateId": "wolf_pack",
+      "enemyArmyCount": 10,
+      "enemyStatMultiplier": 1,
+      "introDialogue": [
+        {
+          "id": "c1m1-intro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "The smoke is fresh. Something pushed through Ember Watch before dawn.",
+          "mood": "grim"
+        },
+        {
+          "id": "c1m1-intro-2",
+          "speakerId": "serin",
+          "speakerName": "Scout Serin",
+          "text": "Tracks split toward the river. If we do not move now, the whole road opens.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c1m1-outro-1",
+          "speakerId": "serin",
+          "speakerName": "Scout Serin",
+          "text": "These raiders were screening for a larger force. The bridge is their real target.",
+          "mood": "grim"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c1m1-clear-patrol",
+          "description": "Break the screening patrol",
+          "kind": "defeat",
+          "gate": "start"
+        },
+        {
+          "id": "c1m1-secure-flare",
+          "description": "Secure the signal flare cache",
+          "kind": "secure",
+          "gate": "end",
+          "optional": true
+        }
+      ],
+      "reward": { "gems": 12, "resources": { "gold": 140 } }
+    },
+    {
+      "id": "chapter1-thornwall-road",
+      "chapterId": "chapter1",
+      "order": 2,
+      "mapId": "thornwall-divide",
+      "name": "Signals In The Mist",
+      "description": "Fight uphill through the divide and relight the road lanterns before dusk.",
+      "recommendedHeroLevel": 2,
+      "enemyArmyTemplateId": "wolf_pack",
+      "enemyArmyCount": 12,
+      "enemyStatMultiplier": 1.12,
+      "unlockMissionId": "chapter1-ember-watch",
+      "introDialogue": [
+        {
+          "id": "c1m2-intro-1",
+          "speakerId": "bridge-warden",
+          "speakerName": "Warden Hale",
+          "text": "No lanterns means no reinforcements. Relight the road and the garrison can hold.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c1m2-outro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Good. Now the bridge wardens know the attack is coming.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c1m2-light-lanterns",
+          "description": "Relight the thornwall lantern chain",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 3,
+          "unlocksObjectiveIds": ["c1m2-break-blockade"]
+        },
+        {
+          "id": "c1m2-break-blockade",
+          "description": "Break the raider blockade at the pass",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 14, "resources": { "gold": 170, "wood": 12 } }
+    },
+    {
+      "id": "chapter1-stonewatch",
+      "chapterId": "chapter1",
+      "order": 3,
+      "mapId": "stonewatch-fork",
+      "name": "Stonewatch Fork",
+      "description": "Retake the fork tower and free the trapped scouts before the enemy scouts escape.",
+      "recommendedHeroLevel": 2,
+      "enemyArmyTemplateId": "hero_guard_basic",
+      "enemyArmyCount": 14,
+      "enemyStatMultiplier": 1.22,
+      "unlockMissionId": "chapter1-thornwall-road",
+      "introDialogue": [
+        {
+          "id": "c1m3-intro-1",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "If Stonewatch falls, the enemy owns every crossing from here to the river.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c1m3-outro-1",
+          "speakerId": "rescued-scout",
+          "speakerName": "Rescued Scout",
+          "text": "They kept asking about the bridge supports. They know exactly where to strike.",
+          "mood": "grim"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c1m3-retake-tower",
+          "description": "Retake Stonewatch tower",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c1m3-rescue-scouts",
+          "description": "Escort the trapped scouts to safety",
+          "kind": "escort",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 16, "resources": { "gold": 210, "ore": 10 } }
+    },
+    {
+      "id": "chapter1-ridgeway",
+      "chapterId": "chapter1",
+      "order": 4,
+      "mapId": "ridgeway-crossing",
+      "name": "Ridgeway Intercept",
+      "description": "Intercept the enemy engineers before they can seed the bridge charges.",
+      "recommendedHeroLevel": 3,
+      "enemyArmyTemplateId": "hero_guard_basic",
+      "enemyArmyCount": 16,
+      "enemyStatMultiplier": 1.34,
+      "unlockMissionId": "chapter1-stonewatch",
+      "introDialogue": [
+        {
+          "id": "c1m4-intro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "Engineers with black powder crossed Ridgeway an hour ago. Stop them before they reach the piers.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c1m4-outro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "We stopped one team. The main column is still marching for the bridgehead.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c1m4-kill-engineers",
+          "description": "Eliminate the bridge engineers",
+          "kind": "defeat",
+          "gate": "start"
+        },
+        {
+          "id": "c1m4-hold-slope",
+          "description": "Hold the ridge while charges are dismantled",
+          "kind": "hold",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 18, "resources": { "gold": 250, "wood": 16 } }
+    },
+    {
+      "id": "chapter1-ironpass",
+      "chapterId": "chapter1",
+      "order": 5,
+      "mapId": "ironpass-gorge",
+      "name": "Last Convoy To Ironpass",
+      "description": "Escort the supply convoy through the gorge so the bridge garrison can survive the siege.",
+      "recommendedHeroLevel": 3,
+      "enemyArmyTemplateId": "hero_guard_basic",
+      "enemyArmyCount": 18,
+      "enemyStatMultiplier": 1.46,
+      "unlockMissionId": "chapter1-ridgeway",
+      "introDialogue": [
+        {
+          "id": "c1m5-intro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "Food, arrow bundles, brace timber. Lose this convoy and the bridge is finished by morning.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c1m5-outro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "The convoy made it. Now all that remains is to survive what comes next.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c1m5-escort-convoy",
+          "description": "Escort the supply convoy through Ironpass",
+          "kind": "escort",
+          "gate": "start"
+        },
+        {
+          "id": "c1m5-clear-ambush",
+          "description": "Clear the gorge ambush nests",
+          "kind": "defeat",
+          "gate": "mid",
+          "targetCount": 2
+        }
+      ],
+      "reward": { "gems": 20, "resources": { "gold": 290, "wood": 20, "ore": 12 } }
+    },
+    {
+      "id": "chapter1-defend-bridge",
+      "chapterId": "chapter1",
+      "order": 6,
+      "mapId": "frontier-basin",
+      "name": "Defend The Bridge",
+      "description": "Hold the bridgehead through the opening assault and deny the enemy a path into the basin.",
+      "recommendedHeroLevel": 4,
+      "enemyArmyTemplateId": "hero_guard_basic",
+      "enemyArmyCount": 22,
+      "enemyStatMultiplier": 1.6,
+      "unlockMissionId": "chapter1-ironpass",
+      "introDialogue": [
+        {
+          "id": "c1m6-intro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "No more retreats. If the bridge falls, the whole frontier burns with it.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c1m6-intro-2",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "Then we hold here. Let the river carry away anyone who tries to cross.",
+          "mood": "defiant"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c1m6-outro-1",
+          "speakerId": "narrator",
+          "speakerName": "Narrator",
+          "text": "The bridge still stands, but the enemy has seen the frontier answer. Chapter 2 begins with the counterstroke.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c1m6-hold-bridge",
+          "description": "Hold the bridge through the opening assault",
+          "kind": "hold",
+          "gate": "start"
+        },
+        {
+          "id": "c1m6-break-vanguard",
+          "description": "Break the enemy vanguard at the bridgehead",
+          "kind": "defeat",
+          "gate": "mid"
+        },
+        {
+          "id": "c1m6-save-sappers",
+          "description": "Keep both sapper teams alive",
+          "kind": "survive",
+          "gate": "end",
+          "optional": true,
+          "targetCount": 2
+        }
+      ],
+      "reward": { "gems": 28, "resources": { "gold": 360, "ore": 18 } }
+    }
+  ]
+}

--- a/configs/event-defend-the-bridge.json
+++ b/configs/event-defend-the-bridge.json
@@ -1,0 +1,69 @@
+{
+  "id": "defend-the-bridge",
+  "name": "Defend the Bridge",
+  "description": "Clear the Shadow Archives during the siege week to earn bridge defense points and claim frontier rewards.",
+  "startsAt": "2026-04-01T00:00:00.000Z",
+  "endsAt": "2026-04-08T00:00:00.000Z",
+  "durationDays": 7,
+  "bannerText": "Hold the bridge. Every daily dungeon clear sends supplies to the garrison.",
+  "objectives": [
+    {
+      "id": "bridge-dungeon-clear",
+      "description": "Claim rewards from a Shadow Archives run",
+      "actionType": "daily_dungeon_reward_claimed",
+      "dungeonId": "shadow-archives",
+      "points": 40
+    }
+  ],
+  "rewards": [
+    {
+      "id": "bridge-ration-cache",
+      "name": "Ration Cache",
+      "pointsRequired": 40,
+      "kind": "resources",
+      "resources": {
+        "gold": 180,
+        "wood": 20
+      }
+    },
+    {
+      "id": "bridge-relief-fund",
+      "name": "Relief Fund",
+      "pointsRequired": 120,
+      "kind": "gems",
+      "gems": 35
+    },
+    {
+      "id": "bridge-vanguard-badge",
+      "name": "Bridge Vanguard",
+      "pointsRequired": 200,
+      "kind": "badge",
+      "badge": "bridge_vanguard_2026"
+    }
+  ],
+  "leaderboard": {
+    "size": 100,
+    "rewardTiers": [
+      {
+        "rankStart": 1,
+        "rankEnd": 1,
+        "title": "Bridge Champion",
+        "badge": "bridge_champion_2026",
+        "cosmeticId": "bridge-champion-border"
+      },
+      {
+        "rankStart": 2,
+        "rankEnd": 3,
+        "title": "Frontier Defender",
+        "badge": "frontier_defender_2026",
+        "cosmeticId": "bridge-warden-banner"
+      },
+      {
+        "rankStart": 4,
+        "rankEnd": 100,
+        "title": "Siege Veteran",
+        "badge": "siege_veteran_2026"
+      }
+    ]
+  }
+}

--- a/configs/seasonal-events.json
+++ b/configs/seasonal-events.json
@@ -1,0 +1,16 @@
+{
+  "events": [
+    {
+      "id": "defend-the-bridge",
+      "name": "Defend the Bridge",
+      "description": "A frontier-wide push to keep the basin bridge standing for seven days.",
+      "startsAt": "2026-04-01T00:00:00.000Z",
+      "endsAt": "2026-04-08T00:00:00.000Z",
+      "durationDays": 7,
+      "bannerText": "Daily dungeon clears reinforce the bridgehead.",
+      "leaderboard": {
+        "size": 100
+      }
+    }
+  ]
+}

--- a/packages/shared/src/campaign.ts
+++ b/packages/shared/src/campaign.ts
@@ -1,0 +1,23 @@
+export type DialogueMood = "calm" | "urgent" | "grim" | "hopeful" | "defiant";
+
+export interface DialogueLine {
+  id: string;
+  speakerId: string;
+  speakerName: string;
+  text: string;
+  portraitId?: string;
+  mood?: DialogueMood;
+}
+
+export type MissionObjectiveKind = "defeat" | "hold" | "escort" | "secure" | "survive" | (string & {});
+export type MissionObjectiveGate = "start" | "mid" | "end";
+
+export interface MissionObjective {
+  id: string;
+  description: string;
+  kind: MissionObjectiveKind;
+  gate?: MissionObjectiveGate;
+  optional?: boolean;
+  targetCount?: number;
+  unlocksObjectiveIds?: string[];
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,6 +5,7 @@ export * from "./assets-config.ts";
 export * from "./battle.ts";
 export * from "./battle-report.ts";
 export * from "./battle-replay.ts";
+export * from "./campaign.ts";
 export * from "./competitive-season.ts";
 export * from "./analytics-events.ts";
 export * from "./content-pack-validation.ts";

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1,5 +1,7 @@
 import type { PlayerTier, RankDivisionId } from "./matchmaking.ts";
 
+import type { DialogueLine, MissionObjective } from "./campaign.ts";
+
 export type TerrainType = "grass" | "dirt" | "sand" | "water" | "swamp";
 export type FogState = "hidden" | "explored" | "visible";
 export type ResourceKind = "gold" | "wood" | "ore";
@@ -1197,6 +1199,7 @@ export interface CampaignMission {
   id: string;
   chapterId: string;
   order: number;
+  mapId: string;
   name: string;
   description: string;
   recommendedHeroLevel: number;
@@ -1204,6 +1207,9 @@ export interface CampaignMission {
   enemyArmyCount: number;
   enemyStatMultiplier: number;
   unlockMissionId?: string;
+  introDialogue?: DialogueLine[];
+  outroDialogue?: DialogueLine[];
+  objectives: MissionObjective[];
   reward: CampaignReward;
 }
 
@@ -1258,4 +1264,67 @@ export interface DailyDungeonState {
   attemptsUsed: number;
   claimedRunIds: string[];
   runs: DailyDungeonRunRecord[];
+}
+
+export type SeasonalEventActionType = "daily_dungeon_reward_claimed" | (string & {});
+export type SeasonalEventRewardKind = "gems" | "resources" | "badge" | "cosmetic";
+
+export interface SeasonalEventObjective {
+  id: string;
+  description: string;
+  actionType: SeasonalEventActionType;
+  points: number;
+  dungeonId?: string;
+}
+
+export interface SeasonalEventReward {
+  id: string;
+  name: string;
+  pointsRequired: number;
+  kind: SeasonalEventRewardKind;
+  gems?: number;
+  resources?: Partial<ResourceLedger>;
+  badge?: string;
+  cosmeticId?: string;
+}
+
+export interface SeasonalEventLeaderboardRewardTier {
+  rankStart: number;
+  rankEnd: number;
+  title: string;
+  badge?: string;
+  cosmeticId?: string;
+}
+
+export interface SeasonalEventDefinition {
+  id: string;
+  name: string;
+  description: string;
+  startsAt: string;
+  endsAt: string;
+  durationDays: number;
+  bannerText: string;
+  objectives: SeasonalEventObjective[];
+  rewards: SeasonalEventReward[];
+  leaderboard: {
+    size: number;
+    rewardTiers: SeasonalEventLeaderboardRewardTier[];
+  };
+}
+
+export interface SeasonalEventState {
+  eventId: string;
+  points: number;
+  claimedRewardIds: string[];
+  appliedActionIds: string[];
+  lastUpdatedAt: string;
+}
+
+export interface EventLeaderboardEntry {
+  rank: number;
+  playerId: string;
+  displayName: string;
+  points: number;
+  lastUpdatedAt: string;
+  rewardPreview?: string;
 }

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -24,6 +24,7 @@ import {
 import type {
   CampaignProgressState,
   DailyDungeonState,
+  SeasonalEventState,
   RankedWeeklyProgress,
   ResourceLedger,
   SeasonArchiveEntry
@@ -58,6 +59,7 @@ export interface PlayerAccountReadModel {
   dailyQuestBoard?: DailyQuestBoard;
   campaignProgress?: CampaignProgressState;
   dailyDungeonState?: DailyDungeonState;
+  seasonalEventStates?: SeasonalEventState[];
   tutorialStep?: number | null;
   loginId?: string;
   credentialBoundAt?: string;
@@ -101,6 +103,7 @@ export interface PlayerAccountReadModelInput {
   dailyQuestBoard?: Partial<DailyQuestBoard> | null | undefined;
   campaignProgress?: Partial<CampaignProgressState> | null | undefined;
   dailyDungeonState?: Partial<DailyDungeonState> | null | undefined;
+  seasonalEventStates?: Partial<SeasonalEventState>[] | null | undefined;
   tutorialStep?: number | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
@@ -211,6 +214,7 @@ export function normalizePlayerAccountReadModel(
   const dailyQuestBoard = normalizeDailyQuestBoard(account?.dailyQuestBoard);
   const campaignProgress = normalizeCampaignProgressState(account?.campaignProgress);
   const dailyDungeonState = normalizeDailyDungeonState(account?.dailyDungeonState);
+  const seasonalEventStates = normalizeSeasonalEventStates(account?.seasonalEventStates);
   const tutorialStep = normalizeTutorialStep(account?.tutorialStep);
 
   return {
@@ -246,6 +250,7 @@ export function normalizePlayerAccountReadModel(
     ...(dailyQuestBoard ? { dailyQuestBoard } : {}),
     ...(campaignProgress ? { campaignProgress } : {}),
     ...(dailyDungeonState ? { dailyDungeonState } : {}),
+    ...(seasonalEventStates ? { seasonalEventStates } : {}),
     ...(account?.tutorialStep !== undefined ? { tutorialStep } : {}),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
@@ -362,4 +367,47 @@ function normalizeDailyDungeonState(
         runs
       }
     : undefined;
+}
+
+function normalizeSeasonalEventStates(
+  seasonalEventStates?: Partial<SeasonalEventState>[] | null
+): SeasonalEventState[] | undefined {
+  const states = Array.from(
+    new Map(
+      (seasonalEventStates ?? [])
+        .map((state) => {
+          const eventId = state.eventId?.trim();
+          const lastUpdatedAt = normalizeTimestamp(state.lastUpdatedAt);
+          if (!eventId || !lastUpdatedAt) {
+            return null;
+          }
+
+          return [
+            eventId,
+            {
+              eventId,
+              points: Math.max(0, Math.floor(state.points ?? 0)),
+              claimedRewardIds: Array.from(
+                new Set(
+                  (state.claimedRewardIds ?? [])
+                    .map((rewardId) => rewardId?.trim())
+                    .filter((rewardId): rewardId is string => Boolean(rewardId))
+                )
+              ).sort((left, right) => left.localeCompare(right)),
+              appliedActionIds: Array.from(
+                new Set(
+                  (state.appliedActionIds ?? [])
+                    .map((actionId) => actionId?.trim())
+                    .filter((actionId): actionId is string => Boolean(actionId))
+                )
+              ).sort((left, right) => left.localeCompare(right)),
+              lastUpdatedAt
+            }
+          ] as const;
+        })
+        .filter((entry): entry is readonly [string, SeasonalEventState] => Boolean(entry))
+    ).values()
+  ).sort((left, right) => left.eventId.localeCompare(right.eventId));
+
+  return states.length > 0 ? states : undefined;
 }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -10,6 +10,19 @@ export interface TutorialProgressAction {
   reason?: "advance" | "skip" | "complete";
 }
 
+export interface CampaignDialogueAckAction {
+  missionId: string;
+  sequence: "intro" | "outro";
+  dialogueLineId: string;
+}
+
+export interface EventProgressUpdatePayload {
+  eventId: string;
+  points: number;
+  delta: number;
+  objectiveId: string;
+}
+
 export interface SessionStatePayload {
   world: PlayerWorldViewPayload;
   battle: BattleState | null;
@@ -65,6 +78,11 @@ export type ClientMessage =
       type: "tutorial.progress";
       requestId: string;
       action: TutorialProgressAction;
+    }
+  | {
+      type: "campaign.dialogue.ack";
+      requestId: string;
+      action: CampaignDialogueAckAction;
     };
 
 export type ServerMessage =
@@ -110,4 +128,10 @@ export type ServerMessage =
       requestId: "push";
       delivery: "push";
       payload: { bundle: RuntimeConfigBundle };
+    }
+  | {
+      type: "event.progress.update";
+      requestId: "push";
+      delivery: "push";
+      payload: EventProgressUpdatePayload;
     };

--- a/packages/shared/test/fixtures/contract-snapshots/multiplayer-client-messages.json
+++ b/packages/shared/test/fixtures/contract-snapshots/multiplayer-client-messages.json
@@ -42,5 +42,14 @@
     "type": "world.reachable",
     "requestId": "req-world-reachable-001",
     "heroId": "hero-1"
+  },
+  {
+    "type": "campaign.dialogue.ack",
+    "requestId": "req-campaign-dialogue-001",
+    "action": {
+      "missionId": "chapter1-ember-watch",
+      "sequence": "intro",
+      "dialogueLineId": "c1m1-intro-1"
+    }
   }
 ]

--- a/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
+++ b/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
@@ -410,5 +410,16 @@
     "type": "error",
     "requestId": "req-world-action-002",
     "reason": "destination_occupied"
+  },
+  {
+    "type": "event.progress.update",
+    "requestId": "push",
+    "delivery": "push",
+    "payload": {
+      "eventId": "defend-the-bridge",
+      "points": 40,
+      "delta": 40,
+      "objectiveId": "bridge-dungeon-clear"
+    }
   }
 ]

--- a/packages/shared/test/support/multiplayer-protocol-fixtures.ts
+++ b/packages/shared/test/support/multiplayer-protocol-fixtures.ts
@@ -482,6 +482,15 @@ export function createClientMessageFixtures(): ClientMessage[] {
       type: "world.reachable",
       requestId: "req-world-reachable-001",
       heroId: "hero-1"
+    },
+    {
+      type: "campaign.dialogue.ack",
+      requestId: "req-campaign-dialogue-001",
+      action: {
+        missionId: "chapter1-ember-watch",
+        sequence: "intro",
+        dialogueLineId: "c1m1-intro-1"
+      }
     }
   ];
 }
@@ -517,6 +526,17 @@ export function createServerMessageFixtures(): ServerMessage[] {
       type: "error",
       requestId: "req-world-action-002",
       reason: "destination_occupied"
+    },
+    {
+      type: "event.progress.update",
+      requestId: "push",
+      delivery: "push",
+      payload: {
+        eventId: "defend-the-bridge",
+        points: 40,
+        delta: 40,
+        objectiveId: "bridge-dungeon-clear"
+      }
     }
   ];
 }


### PR DESCRIPTION
Refs #878

## What's included
- replace the placeholder PvE scaffold with a 6-mission Chapter 1 campaign config carrying map refs, dialogue beats, and objective gates
- add shared campaign/seasonal-event contracts plus protocol payloads for dialogue ack and event progress updates
- add a server seasonal event engine with active-event resolution, top-100 leaderboard sorting, reward claims, and persistent player event state
- award Defend the Bridge event points from daily dungeon reward claims and expose the active-event route surface
- add focused tests for campaign content, event activation/progress/claim behavior, player-account integration, and contract snapshots

## Validation
- npm run typecheck:shared
- npm run typecheck:server
- node --import tsx --test ./apps/server/test/pve-content.test.ts ./apps/server/test/event-engine.test.ts
- node --import tsx --test ./apps/server/test/player-account-routes.test.ts
- npm run test:contracts

## Remaining gaps
- client mission selection, dialogue overlay, and event banner UI from #878 are not part of this slice
- the event leaderboard is returned through GET /api/events/active rather than a separate endpoint
- daily dungeon reward claims are the current progress hook; battle-complete hooks can be added later if the PvE runtime grows deeper event telemetry