### PR TITLE
feat: add guild foundation routes and persistence

### DIFF
--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -11,6 +11,7 @@ import {
 import { configureRoomSnapshotStore, listLobbyRooms, VeilColyseusRoom } from "./colyseus-room";
 import { registerConfigViewerRoutes } from "./config-viewer";
 import { registerEventRoutes } from "./event-engine";
+import { registerGuildRoutes } from "./guilds";
 import { registerLeaderboardRoutes } from "./leaderboard";
 import { registerLobbyRoutes } from "./lobby";
 import { registerMatchmakingRoutes } from "./matchmaking";
@@ -110,6 +111,7 @@ export interface DevServerBootstrapDependencies {
   registerConfigCenterRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerEventRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
+  registerGuildRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerPlayerAccountRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerShopRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerWechatPayRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
@@ -178,6 +180,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerConfigCenterRoutes: (app, store) => registerConfigCenterRoutes(app as never, store as ConfigCenterStore),
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
     registerEventRoutes: (app, store) => registerEventRoutes(app as never, store as RoomSnapshotStore | null),
+    registerGuildRoutes: (app, store) => registerGuildRoutes(app as never, store as RoomSnapshotStore),
     registerPlayerAccountRoutes: (app, store) => registerPlayerAccountRoutes(app as never, store as RoomSnapshotStore),
     registerShopRoutes: (app, store) => registerShopRoutes(app as never, store as RoomSnapshotStore),
     registerWechatPayRoutes: (app, store) => registerWechatPayRoutes(app as never, store as RoomSnapshotStore),
@@ -250,6 +253,7 @@ export async function startDevServer(
   if ("use" in (expressApp as object) && "get" in (expressApp as object)) {
     deps.registerEventRoutes(expressApp, effectiveSnapshotStore);
   }
+  deps.registerGuildRoutes(expressApp, effectiveSnapshotStore);
   deps.registerPlayerAccountRoutes(expressApp, effectiveSnapshotStore);
   deps.registerShopRoutes(expressApp, effectiveSnapshotStore);
   deps.registerWechatPayRoutes(expressApp, effectiveSnapshotStore);
@@ -275,6 +279,7 @@ export async function startDevServer(
   deps.logger.log(`Config center API available at http://${host}:${port}/api/config-center/configs`);
   deps.logger.log(`Config viewer available at http://${host}:${port}/config-viewer`);
   deps.logger.log(`Player account API available at http://${host}:${port}/api/player-accounts`);
+  deps.logger.log(`Guild API available at http://${host}:${port}/api/guilds`);
   deps.logger.log(`Guest auth API available at http://${host}:${port}/api/auth/guest-login`);
   deps.logger.log(`WeChat auth API available at http://${host}:${port}/api/auth/wechat-login`);
   deps.logger.log(`WeChat Pay API available at http://${host}:${port}/api/payments/wechat/create`);

--- a/apps/server/src/guilds.ts
+++ b/apps/server/src/guilds.ts
@@ -1,0 +1,389 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  createGuild,
+  createGuildRosterView,
+  createGuildSummaryView,
+  joinGuild,
+  leaveGuild,
+  type GuildCreateAction,
+  type GuildState
+} from "../../../packages/shared/src/index";
+import { validateAuthSessionFromRequest } from "./auth";
+import type { RoomSnapshotStore } from "./persistence";
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+const MAX_JSON_BODY_BYTES = 16 * 1024;
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    request.resume();
+    throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+    }
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function parseLimit(request: IncomingMessage): number | undefined {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const value = url.searchParams.get("limit");
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+async function requireAuthSession(
+  request: IncomingMessage,
+  response: ServerResponse,
+  store: RoomSnapshotStore | null
+): Promise<{ playerId: string; displayName: string } | null> {
+  const result = await validateAuthSessionFromRequest(request, store);
+  if (result.session) {
+    return result.session;
+  }
+
+  if (result.errorCode === "account_banned") {
+    sendJson(response, 403, {
+      error: {
+        code: "account_banned",
+        message: "Account is banned",
+        reason: result.ban?.banReason ?? "No reason provided",
+        ...(result.ban?.banExpiry ? { expiry: result.ban.banExpiry } : {})
+      }
+    });
+    return null;
+  }
+
+  sendJson(response, 401, {
+    error: {
+      code: result.errorCode ?? "unauthorized",
+      message: "Authentication required"
+    }
+  });
+  return null;
+}
+
+function mapGuildError(error: unknown): { status: number; code: string; message: string } {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (
+    /guild_create_.*required|guild_join_player_required|guild_leave_player_required|payload_too_large|Unexpected token/.test(
+      message
+    )
+  ) {
+    return { status: 400, code: "invalid_request", message };
+  }
+  if (/guild_not_found/.test(message)) {
+    return { status: 404, code: "guild_not_found", message };
+  }
+  if (/guild_member_not_found|guild_leave_member_not_found/.test(message)) {
+    return { status: 409, code: "guild_membership_invalid", message };
+  }
+  if (/guild_already_member|guild_join_already_member|guild_member_limit_reached|guild_tag_taken/.test(message)) {
+    return { status: 409, code: "guild_conflict", message };
+  }
+  if (/guild_store_unavailable/.test(message)) {
+    return { status: 503, code: "guild_store_unavailable", message };
+  }
+
+  return { status: 500, code: "guild_error", message };
+}
+
+class GuildService {
+  constructor(private readonly store: RoomSnapshotStore | null) {}
+
+  private requireStore(): {
+    ensurePlayerAccount: RoomSnapshotStore["ensurePlayerAccount"];
+    loadGuild: NonNullable<RoomSnapshotStore["loadGuild"]>;
+    loadGuildByMemberPlayerId: NonNullable<RoomSnapshotStore["loadGuildByMemberPlayerId"]>;
+    listGuilds: NonNullable<RoomSnapshotStore["listGuilds"]>;
+    saveGuild: NonNullable<RoomSnapshotStore["saveGuild"]>;
+    deleteGuild: NonNullable<RoomSnapshotStore["deleteGuild"]>;
+  } {
+    if (
+      !this.store ||
+      !this.store.loadGuild ||
+      !this.store.loadGuildByMemberPlayerId ||
+      !this.store.listGuilds ||
+      !this.store.saveGuild ||
+      !this.store.deleteGuild
+    ) {
+      throw new Error("guild_store_unavailable");
+    }
+
+    return {
+      ensurePlayerAccount: this.store.ensurePlayerAccount.bind(this.store),
+      loadGuild: this.store.loadGuild.bind(this.store),
+      loadGuildByMemberPlayerId: this.store.loadGuildByMemberPlayerId.bind(this.store),
+      listGuilds: this.store.listGuilds.bind(this.store),
+      saveGuild: this.store.saveGuild.bind(this.store),
+      deleteGuild: this.store.deleteGuild.bind(this.store)
+    };
+  }
+
+  async listGuilds(limit?: number): Promise<GuildState[]> {
+    const store = this.requireStore();
+    return store.listGuilds({ ...(limit != null ? { limit } : {}) });
+  }
+
+  async getGuild(guildId: string): Promise<GuildState> {
+    const store = this.requireStore();
+    const guild = await store.loadGuild(guildId);
+    if (!guild) {
+      throw new Error("guild_not_found");
+    }
+
+    return guild;
+  }
+
+  async createGuildForPlayer(
+    authSession: { playerId: string; displayName: string },
+    action: GuildCreateAction
+  ): Promise<GuildState> {
+    const store = this.requireStore();
+    await store.ensurePlayerAccount({
+      playerId: authSession.playerId,
+      displayName: authSession.displayName
+    });
+
+    const existingGuild = await store.loadGuildByMemberPlayerId(authSession.playerId);
+    if (existingGuild) {
+      throw new Error("guild_already_member");
+    }
+
+    const existingTag = (await store.listGuilds({ limit: 200 })).find(
+      (guild) => guild.tag.toUpperCase() === action.tag.trim().toUpperCase()
+    );
+    if (existingTag) {
+      throw new Error("guild_tag_taken");
+    }
+
+    const created = createGuild({
+      ownerPlayerId: authSession.playerId,
+      ownerDisplayName: authSession.displayName,
+      guildId: `guild-${randomUUID()}`,
+      name: action.name,
+      tag: action.tag,
+      ...(action.description != null ? { description: action.description } : {}),
+      ...(action.memberLimit != null ? { memberLimit: action.memberLimit } : {})
+    });
+
+    return store.saveGuild(created.guild);
+  }
+
+  async joinGuildForPlayer(authSession: { playerId: string; displayName: string }, guildId: string): Promise<GuildState> {
+    const store = this.requireStore();
+    await store.ensurePlayerAccount({
+      playerId: authSession.playerId,
+      displayName: authSession.displayName
+    });
+
+    const existingGuild = await store.loadGuildByMemberPlayerId(authSession.playerId);
+    if (existingGuild) {
+      if (existingGuild.id === guildId.trim()) {
+        throw new Error("guild_join_already_member");
+      }
+      throw new Error("guild_already_member");
+    }
+
+    const guild = await store.loadGuild(guildId);
+    if (!guild) {
+      throw new Error("guild_not_found");
+    }
+
+    const joined = joinGuild(guild, {
+      playerId: authSession.playerId,
+      displayName: authSession.displayName
+    });
+    return store.saveGuild(joined.guild);
+  }
+
+  async leaveGuildForPlayer(authSession: { playerId: string; displayName: string }, guildId: string): Promise<{
+    guild: GuildState;
+    deleted: boolean;
+  }> {
+    const store = this.requireStore();
+    const guild = await store.loadGuild(guildId);
+    if (!guild) {
+      throw new Error("guild_not_found");
+    }
+
+    if (!guild.members.some((member) => member.playerId === authSession.playerId)) {
+      throw new Error("guild_leave_member_not_found");
+    }
+
+    const result = leaveGuild(guild, {
+      playerId: authSession.playerId
+    });
+    if (result.deleted) {
+      await store.deleteGuild(guild.id);
+      return { guild: result.guild, deleted: true };
+    }
+
+    return {
+      guild: await store.saveGuild(result.guild),
+      deleted: false
+    };
+  }
+}
+
+export function registerGuildRoutes(
+  app: {
+    use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
+    get: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
+    post: (path: string, handler: (request: IncomingMessage & { params: Record<string, string> }, response: ServerResponse) => void | Promise<void>) => void;
+  },
+  store: RoomSnapshotStore | null
+): void {
+  const service = new GuildService(store);
+
+  app.use((request, response, next) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
+
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    next();
+  });
+
+  app.get("/api/guilds", async (request, response) => {
+    try {
+      const items = await service.listGuilds(parseLimit(request));
+      sendJson(response, 200, {
+        items: items.map((guild) => createGuildSummaryView(guild))
+      });
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.get("/api/guilds/:guildId", async (request, response) => {
+    try {
+      const guildId = request.params.guildId ?? "";
+      const guild = await service.getGuild(guildId);
+      sendJson(response, 200, {
+        guild: createGuildSummaryView(guild)
+      });
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.get("/api/guilds/:guildId/roster", async (request, response) => {
+    try {
+      const guildId = request.params.guildId ?? "";
+      const guild = await service.getGuild(guildId);
+      sendJson(response, 200, {
+        roster: createGuildRosterView(guild)
+      });
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.post("/api/guilds", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const payload = (await readJsonBody(request)) as GuildCreateAction;
+      const guild = await service.createGuildForPlayer(authSession, payload);
+      sendJson(response, 201, {
+        guild: createGuildSummaryView(guild),
+        roster: createGuildRosterView(guild)
+      });
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.post("/api/guilds/:guildId/join", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const guildId = request.params.guildId ?? "";
+      const guild = await service.joinGuildForPlayer(authSession, guildId);
+      sendJson(response, 200, {
+        guild: createGuildSummaryView(guild),
+        roster: createGuildRosterView(guild)
+      });
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.post("/api/guilds/:guildId/leave", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const guildId = request.params.guildId ?? "";
+      const result = await service.leaveGuildForPlayer(authSession, guildId);
+      sendJson(
+        response,
+        200,
+        result.deleted
+          ? {
+              guildId,
+              deleted: true
+            }
+          : {
+              guild: createGuildSummaryView(result.guild),
+              roster: createGuildRosterView(result.guild),
+              deleted: false
+            }
+      );
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+}

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -3,14 +3,17 @@ import {
   DEFAULT_TUTORIAL_STEP,
   getEquipmentDefinition,
   getTierForDivision,
+  normalizeGuildState,
   normalizeEloRating,
   normalizeEventLogEntries,
   normalizeEventLogQuery,
   tryAddEquipmentToInventory,
-  type EventLogEntry
+  type EventLogEntry,
+  type GuildState
 } from "../../../packages/shared/src/index";
 import {
   createPlayerAccountsFromWorldState,
+  type GuildListOptions,
   MAX_PLAYER_AVATAR_URL_LENGTH,
   MAX_PLAYER_DISPLAY_NAME_LENGTH,
   type PaymentOrderCompleteInput,
@@ -113,6 +116,8 @@ function normalizeResourceLedger(resources?: PlayerAccountSnapshot["globalResour
 export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly snapshots = new Map<string, RoomPersistenceSnapshot>();
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+  private readonly guilds = new Map<string, GuildState>();
+  private readonly guildIdByPlayerId = new Map<string, string>();
   private readonly paymentOrders = new Map<string, PaymentOrderSnapshot>();
   private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
@@ -134,6 +139,20 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     const account = this.accounts.get(normalizePlayerId(playerId));
     return account ? cloneAccount(account) : null;
+  }
+
+  async loadGuild(guildId: string): Promise<GuildState | null> {
+    const guild = this.guilds.get(guildId.trim());
+    return guild ? normalizeGuildState(structuredClone(guild)) : null;
+  }
+
+  async loadGuildByMemberPlayerId(playerId: string): Promise<GuildState | null> {
+    const guildId = this.guildIdByPlayerId.get(normalizePlayerId(playerId));
+    if (!guildId) {
+      return null;
+    }
+
+    return this.loadGuild(guildId);
   }
 
   async loadPaymentOrder(orderId: string): Promise<PaymentOrderSnapshot | null> {
@@ -250,6 +269,20 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       .map((playerId) => this.accounts.get(normalizePlayerId(playerId)))
       .filter((account): account is PlayerAccountSnapshot => Boolean(account))
       .map((account) => cloneAccount(account));
+  }
+
+  async listGuilds(options: GuildListOptions = {}): Promise<GuildState[]> {
+    const safeLimit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 50)));
+    return Array.from(this.guilds.values())
+      .filter((guild) => !options.playerId || guild.members.some((member) => member.playerId === options.playerId))
+      .sort(
+        (left, right) =>
+          right.members.length - left.members.length ||
+          right.updatedAt.localeCompare(left.updatedAt) ||
+          left.id.localeCompare(right.id)
+      )
+      .slice(0, safeLimit)
+      .map((guild) => normalizeGuildState(structuredClone(guild)));
   }
 
   async listPlayerReports(options: PlayerReportListOptions = {}): Promise<PlayerReportRecord[]> {
@@ -1265,8 +1298,38 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     }
   }
 
+  async saveGuild(guildInput: GuildState): Promise<GuildState> {
+    const guild = normalizeGuildState(guildInput);
+    const existing = this.guilds.get(guild.id);
+    if (existing) {
+      for (const member of existing.members) {
+        this.guildIdByPlayerId.delete(member.playerId);
+      }
+    }
+
+    this.guilds.set(guild.id, normalizeGuildState(structuredClone(guild)));
+    for (const member of guild.members) {
+      this.guildIdByPlayerId.set(member.playerId, guild.id);
+    }
+
+    return normalizeGuildState(structuredClone(guild));
+  }
+
   async delete(roomId: string): Promise<void> {
     this.snapshots.delete(roomId);
+  }
+
+  async deleteGuild(guildId: string): Promise<void> {
+    const normalizedGuildId = guildId.trim();
+    const existing = this.guilds.get(normalizedGuildId);
+    if (!existing) {
+      return;
+    }
+
+    for (const member of existing.members) {
+      this.guildIdByPlayerId.delete(member.playerId);
+    }
+    this.guilds.delete(normalizedGuildId);
   }
 
   async pruneExpired(): Promise<number> {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -6,6 +6,7 @@ import {
   getEquipmentDefinition,
   getTierForRating,
   appendPlayerBattleReplaySummaries,
+  normalizeGuildState,
   getRankDivisionForRating,
   normalizeEloRating,
   normalizeEventLogQuery,
@@ -17,6 +18,7 @@ import {
   normalizeHeroState,
   type EventLogEntry,
   type EquipmentId,
+  type GuildState,
   type HeroState,
   type PlayerBanStatus,
   type PlayerAccountReadModel,
@@ -75,6 +77,8 @@ export interface BattlePassClaimResult {
 export interface RoomSnapshotStore {
   load(roomId: string): Promise<RoomPersistenceSnapshot | null>;
   loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null>;
+  loadGuild?(guildId: string): Promise<GuildState | null>;
+  loadGuildByMemberPlayerId?(playerId: string): Promise<GuildState | null>;
   loadPaymentOrder?(orderId: string): Promise<PaymentOrderSnapshot | null>;
   loadPlayerReport?(reportId: string): Promise<PlayerReportRecord | null>;
   loadPlayerBan?(playerId: string): Promise<PlayerAccountBanSnapshot | null>;
@@ -88,7 +92,9 @@ export interface RoomSnapshotStore {
   loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerAccountAuthByPlayerId(playerId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerHeroArchives(playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]>;
+  listGuilds?(options?: GuildListOptions): Promise<GuildState[]>;
   ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot>;
+  saveGuild?(guild: GuildState): Promise<GuildState>;
   savePlayerBan?(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot>;
   clearPlayerBan?(playerId: string, input?: PlayerAccountUnbanInput): Promise<PlayerAccountSnapshot>;
   bindPlayerAccountCredentials(
@@ -138,6 +144,7 @@ export interface RoomSnapshotStore {
   createSeason(seasonId: string): Promise<SeasonSnapshot>;
   closeSeason(seasonId: string): Promise<SeasonCloseSummary>;
   save(roomId: string, snapshot: RoomPersistenceSnapshot): Promise<void>;
+  deleteGuild?(guildId: string): Promise<void>;
   delete(roomId: string): Promise<void>;
   pruneExpired(referenceTime?: Date): Promise<number>;
   close(): Promise<void>;
@@ -329,6 +336,18 @@ interface PaymentOrderRow extends RowDataPacket {
   updated_at: Date | string;
 }
 
+interface GuildRow extends RowDataPacket {
+  guild_id: string;
+  name: string;
+  tag: string;
+  description: string | null;
+  owner_player_id: string | null;
+  member_count: number;
+  state_json: string | GuildState;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
 interface PlayerReportRow extends RowDataPacket {
   report_id: string | number;
   reporter_id: string;
@@ -411,6 +430,11 @@ export interface PlayerAccountEnsureInput {
   playerId: string;
   displayName?: string;
   lastRoomId?: string;
+}
+
+export interface GuildListOptions {
+  limit?: number;
+  playerId?: string;
 }
 
 export type GemLedgerReason = "purchase" | "reward" | "spend";
@@ -681,6 +705,11 @@ export const MYSQL_PLAYER_HERO_ARCHIVE_UPDATED_AT_INDEX = "idx_player_hero_archi
 export const MYSQL_PLAYER_REPORT_TABLE = "player_reports";
 export const MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX = "idx_player_reports_status_created";
 export const MYSQL_PLAYER_REPORT_ROOM_REPORTER_TARGET_INDEX = "uidx_player_reports_room_reporter_target";
+export const MYSQL_GUILD_TABLE = "guilds";
+export const MYSQL_GUILD_UPDATED_AT_INDEX = "idx_guilds_updated_at";
+export const MYSQL_GUILD_TAG_INDEX = "uidx_guilds_tag";
+export const MYSQL_GUILD_MEMBERSHIP_TABLE = "guild_memberships";
+export const MYSQL_GUILD_MEMBERSHIP_PLAYER_INDEX = "uidx_guild_memberships_player";
 export const MYSQL_CONFIG_DOCUMENT_TABLE = "config_documents";
 export const MYSQL_CONFIG_DOCUMENT_UPDATED_AT_INDEX = "idx_config_documents_updated_at";
 export const MYSQL_SEASON_TABLE = "veil_seasons";
@@ -802,6 +831,28 @@ function normalizeShopProductId(productId: string): string {
   }
 
   return normalized.slice(0, 191);
+}
+
+function normalizeGuildId(guildId: string): string {
+  const normalized = guildId.trim();
+  if (!normalized) {
+    throw new Error("guildId must not be empty");
+  }
+
+  return normalized.slice(0, 191);
+}
+
+function toGuildState(row: GuildRow): GuildState {
+  const parsed = normalizeGuildState(parseJsonColumn<GuildState>(row.state_json));
+  return {
+    ...parsed,
+    id: normalizeGuildId(row.guild_id),
+    name: row.name.trim() || parsed.name,
+    tag: row.tag.trim().toUpperCase() || parsed.tag,
+    ...(row.description?.trim() ? { description: row.description.trim() } : {}),
+    createdAt: formatTimestamp(row.created_at) ?? parsed.createdAt,
+    updatedAt: formatTimestamp(row.updated_at) ?? parsed.updatedAt
+  };
 }
 
 function normalizeShopProductName(productName: string): string {
@@ -3377,6 +3428,54 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     };
   }
 
+  async loadGuild(guildId: string): Promise<GuildState | null> {
+    const normalizedGuildId = normalizeGuildId(guildId);
+    const [rows] = await this.pool.query<GuildRow[]>(
+      `SELECT
+         guild_id,
+         name,
+         tag,
+         description,
+         owner_player_id,
+         member_count,
+         state_json,
+         created_at,
+         updated_at
+       FROM \`${MYSQL_GUILD_TABLE}\`
+       WHERE guild_id = ?
+       LIMIT 1`,
+      [normalizedGuildId]
+    );
+
+    const row = rows[0];
+    return row ? toGuildState(row) : null;
+  }
+
+  async loadGuildByMemberPlayerId(playerId: string): Promise<GuildState | null> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const [rows] = await this.pool.query<GuildRow[]>(
+      `SELECT
+         guild.guild_id,
+         guild.name,
+         guild.tag,
+         guild.description,
+         guild.owner_player_id,
+         guild.member_count,
+         guild.state_json,
+         guild.created_at,
+         guild.updated_at
+       FROM \`${MYSQL_GUILD_TABLE}\` guild
+       INNER JOIN \`${MYSQL_GUILD_MEMBERSHIP_TABLE}\` membership
+         ON membership.guild_id = guild.guild_id
+       WHERE membership.player_id = ?
+       LIMIT 1`,
+      [normalizedPlayerId]
+    );
+
+    const row = rows[0];
+    return row ? toGuildState(row) : null;
+  }
+
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
     const normalizedPlayerId = normalizePlayerId(playerId);
     const accounts = await this.loadPlayerAccounts([normalizedPlayerId]);
@@ -3756,6 +3855,45 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     );
 
     return rows.map((row) => toPlayerAccountSnapshot(row));
+  }
+
+  async listGuilds(options: GuildListOptions = {}): Promise<GuildState[]> {
+    const clauses: string[] = [];
+    const params: Array<string | number> = [];
+    const safeLimit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 50)));
+
+    if (options.playerId?.trim()) {
+      clauses.push(
+        `EXISTS (
+          SELECT 1
+          FROM \`${MYSQL_GUILD_MEMBERSHIP_TABLE}\` membership
+          WHERE membership.guild_id = guild.guild_id
+            AND membership.player_id = ?
+        )`
+      );
+      params.push(normalizePlayerId(options.playerId));
+    }
+
+    const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const [rows] = await this.pool.query<GuildRow[]>(
+      `SELECT
+         guild.guild_id,
+         guild.name,
+         guild.tag,
+         guild.description,
+         guild.owner_player_id,
+         guild.member_count,
+         guild.state_json,
+         guild.created_at,
+         guild.updated_at
+       FROM \`${MYSQL_GUILD_TABLE}\` guild
+       ${whereClause}
+       ORDER BY guild.member_count DESC, guild.updated_at DESC, guild.guild_id ASC
+       LIMIT ?`,
+      [...params, safeLimit]
+    );
+
+    return rows.map((row) => toGuildState(row));
   }
 
   async listPlayerReports(options: PlayerReportListOptions = {}): Promise<PlayerReportRecord[]> {
@@ -5578,6 +5716,61 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     return rows.map((row) => toPlayerHeroArchiveSnapshot(row));
   }
 
+  async saveGuild(guildInput: GuildState): Promise<GuildState> {
+    const guild = normalizeGuildState(guildInput);
+    const guildId = normalizeGuildId(guild.id);
+    const owner = guild.members.find((member) => member.role === "owner");
+    const connection = await this.pool.getConnection();
+
+    try {
+      await connection.beginTransaction();
+      await connection.query(
+        `INSERT INTO \`${MYSQL_GUILD_TABLE}\` (
+           guild_id,
+           name,
+           tag,
+           description,
+           owner_player_id,
+           member_count,
+           state_json
+         )
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+           name = VALUES(name),
+           tag = VALUES(tag),
+           description = VALUES(description),
+           owner_player_id = VALUES(owner_player_id),
+           member_count = VALUES(member_count),
+           state_json = VALUES(state_json)`,
+        [
+          guildId,
+          guild.name,
+          guild.tag,
+          guild.description ?? null,
+          owner?.playerId ?? null,
+          guild.members.length,
+          JSON.stringify(guild)
+        ]
+      );
+      await connection.query(`DELETE FROM \`${MYSQL_GUILD_MEMBERSHIP_TABLE}\` WHERE guild_id = ?`, [guildId]);
+      if (guild.members.length > 0) {
+        await connection.query(
+          `INSERT INTO \`${MYSQL_GUILD_MEMBERSHIP_TABLE}\` (guild_id, player_id, role)
+           VALUES ${guild.members.map(() => "(?, ?, ?)").join(", ")}`,
+          guild.members.flatMap((member) => [guildId, normalizePlayerId(member.playerId), member.role])
+        );
+      }
+      await connection.commit();
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+
+    return (await this.loadGuild(guildId)) ?? guild;
+  }
+
   async save(roomId: string, snapshot: RoomPersistenceSnapshot): Promise<void> {
     const connection = await this.pool.getConnection();
 
@@ -5611,6 +5804,23 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       await connection.beginTransaction();
       await connection.query(`DELETE FROM \`${MYSQL_ROOM_SNAPSHOT_TABLE}\` WHERE room_id = ?`, [roomId]);
       await deletePlayerProfilesForRoom(connection, roomId);
+      await connection.commit();
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async deleteGuild(guildId: string): Promise<void> {
+    const normalizedGuildId = normalizeGuildId(guildId);
+    const connection = await this.pool.getConnection();
+
+    try {
+      await connection.beginTransaction();
+      await connection.query(`DELETE FROM \`${MYSQL_GUILD_MEMBERSHIP_TABLE}\` WHERE guild_id = ?`, [normalizedGuildId]);
+      await connection.query(`DELETE FROM \`${MYSQL_GUILD_TABLE}\` WHERE guild_id = ?`, [normalizedGuildId]);
       await connection.commit();
     } catch (error) {
       await connection.rollback();

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -164,6 +164,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
   const memoryStore = createMemoryStore();
   let configuredStore: unknown;
   let authStore: unknown;
+  let guildStore: unknown;
   let playerAccountStore: unknown;
   let matchmakingStore: unknown;
   let lobbyListRooms: unknown;
@@ -197,6 +198,11 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
       assert.equal(app, base.expressApp);
       assert.equal(store, configCenterStore);
       base.routeCalls.push("config-viewer");
+    },
+    registerGuildRoutes: (app, store) => {
+      assert.equal(app, base.expressApp);
+      guildStore = store;
+      base.routeCalls.push("guilds");
     },
     registerPlayerAccountRoutes: (app, store) => {
       assert.equal(app, base.expressApp);
@@ -271,6 +277,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
 
   assert.equal(configuredStore, memoryStore);
   assert.equal(authStore, memoryStore);
+  assert.equal(guildStore, memoryStore);
   assert.equal(playerAccountStore, memoryStore);
   assert.equal(matchmakingStore, memoryStore);
   assert.equal(lobbyListRooms, listLobbyRooms);
@@ -280,6 +287,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
     "auth",
     "config-center",
     "config-viewer",
+    "guilds",
     "player-accounts",
     "shop",
     "wechat-pay",
@@ -300,6 +308,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
   assert.equal(base.logger.errors.length, 0);
   assertStartupLogIncludes(base.logger, [
     /Project Veil Colyseus dev server listening on ws:\/\/0\.0\.0\.0:3101/,
+    /Guild API available at http:\/\/0\.0\.0\.0:3101\/api\/guilds/,
     /WeChat Pay API available at http:\/\/0\.0\.0\.0:3101\/api\/payments\/wechat\/create/,
     /Runtime health available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/auth-readiness/,
@@ -345,6 +354,7 @@ test("dev server logs process-level failures, closes stores, and exits non-zero"
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
+    registerGuildRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
     registerShopRoutes: () => undefined,
     registerWechatPayRoutes: () => undefined,
@@ -408,6 +418,7 @@ test("dev server logs uncaught exceptions, closes stores, and exits non-zero", a
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
+    registerGuildRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
     registerShopRoutes: () => undefined,
     registerWechatPayRoutes: () => undefined,
@@ -493,6 +504,7 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
+    registerGuildRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
     registerShopRoutes: () => undefined,
     registerWechatPayRoutes: () => undefined,
@@ -564,6 +576,7 @@ test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL 
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
+    registerGuildRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
     registerShopRoutes: () => undefined,
     registerWechatPayRoutes: () => undefined,
@@ -654,6 +667,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     registerAuthRoutes: () => undefined,
     registerConfigCenterRoutes: () => undefined,
     registerConfigViewerRoutes: () => undefined,
+    registerGuildRoutes: () => undefined,
     registerPlayerAccountRoutes: () => undefined,
     registerShopRoutes: () => undefined,
     registerWechatPayRoutes: () => undefined,

--- a/apps/server/test/guild-routes.test.ts
+++ b/apps/server/test/guild-routes.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Server, WebSocketTransport } from "colyseus";
+import { issueGuestAuthSession, resetGuestAuthSessions } from "../src/auth";
+import { registerGuildRoutes } from "../src/guilds";
+import { createMemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import type { RoomSnapshotStore } from "../src/persistence";
+
+async function startGuildRouteServer(store: RoomSnapshotStore, port: number): Promise<Server> {
+  const transport = new WebSocketTransport();
+  registerGuildRoutes(transport.getExpressApp() as never, store);
+  const server = new Server({ transport });
+  await server.listen(port, "127.0.0.1");
+  return server;
+}
+
+test("guild routes create, list, fetch, and expose rosters", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 44000 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const session = issueGuestAuthSession({ playerId: "founder-1", displayName: "Founder" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const created = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      name: "Nightwatch",
+      tag: "nite",
+      description: "Frontier sentinels"
+    })
+  });
+  const createdPayload = (await created.json()) as {
+    guild: { guildId: string; tag: string; ownerPlayerId?: string };
+    roster: { memberCount: number; members: Array<{ playerId: string }> };
+  };
+
+  assert.equal(created.status, 201);
+  assert.equal(createdPayload.guild.tag, "NITE");
+  assert.equal(createdPayload.guild.ownerPlayerId, "founder-1");
+  assert.equal(createdPayload.roster.memberCount, 1);
+
+  const listed = await fetch(`http://127.0.0.1:${port}/api/guilds`);
+  const listedPayload = (await listed.json()) as {
+    items: Array<{ guildId: string; memberCount: number }>;
+  };
+  assert.equal(listed.status, 200);
+  assert.equal(listedPayload.items[0]?.guildId, createdPayload.guild.guildId);
+  assert.equal(listedPayload.items[0]?.memberCount, 1);
+
+  const detail = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}`);
+  const detailPayload = (await detail.json()) as {
+    guild: { guildId: string; ownerPlayerId?: string };
+  };
+  assert.equal(detail.status, 200);
+  assert.equal(detailPayload.guild.ownerPlayerId, "founder-1");
+
+  const roster = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/roster`);
+  const rosterPayload = (await roster.json()) as {
+    roster: { members: Array<{ playerId: string }> };
+  };
+  assert.equal(roster.status, 200);
+  assert.deepEqual(rosterPayload.roster.members.map((member) => member.playerId), ["founder-1"]);
+});
+
+test("guild routes support join and leave, including disband on last member leave", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 45000 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const founderSession = issueGuestAuthSession({ playerId: "founder-2", displayName: "Founder Two" });
+  const recruitSession = issueGuestAuthSession({ playerId: "recruit-1", displayName: "Recruit" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const created = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({
+      name: "Skyforge",
+      tag: "SKY"
+    })
+  });
+  const createdPayload = (await created.json()) as { guild: { guildId: string } };
+  assert.equal(created.status, 201);
+
+  const joined = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/join`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${recruitSession.token}`
+    }
+  });
+  const joinedPayload = (await joined.json()) as {
+    roster: { memberCount: number; members: Array<{ playerId: string }> };
+  };
+  assert.equal(joined.status, 200);
+  assert.equal(joinedPayload.roster.memberCount, 2);
+  assert.deepEqual(joinedPayload.roster.members.map((member) => member.playerId), ["founder-2", "recruit-1"]);
+
+  const leftRecruit = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/leave`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${recruitSession.token}`
+    }
+  });
+  const leftRecruitPayload = (await leftRecruit.json()) as {
+    deleted: boolean;
+    roster: { memberCount: number };
+  };
+  assert.equal(leftRecruit.status, 200);
+  assert.equal(leftRecruitPayload.deleted, false);
+  assert.equal(leftRecruitPayload.roster.memberCount, 1);
+
+  const leftFounder = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/leave`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${founderSession.token}`
+    }
+  });
+  const leftFounderPayload = (await leftFounder.json()) as {
+    deleted: boolean;
+    guildId: string;
+  };
+  assert.equal(leftFounder.status, 200);
+  assert.equal(leftFounderPayload.deleted, true);
+  assert.equal(leftFounderPayload.guildId, createdPayload.guild.guildId);
+
+  const notFound = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}`);
+  assert.equal(notFound.status, 404);
+});

--- a/docs/mysql-persistence.sql
+++ b/docs/mysql-persistence.sql
@@ -177,6 +177,81 @@ PREPARE veil_player_event_history_idx_stmt FROM @veil_player_event_history_idx_s
 EXECUTE veil_player_event_history_idx_stmt;
 DEALLOCATE PREPARE veil_player_event_history_idx_stmt;
 
+CREATE TABLE IF NOT EXISTS `guilds` (
+  guild_id VARCHAR(191) NOT NULL,
+  name VARCHAR(80) NOT NULL,
+  tag VARCHAR(8) NOT NULL,
+  description VARCHAR(160) NULL,
+  owner_player_id VARCHAR(191) NULL,
+  member_count INT NOT NULL DEFAULT 0,
+  state_json LONGTEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (guild_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @veil_guilds_updated_at_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'guilds'
+    AND INDEX_NAME = 'idx_guilds_updated_at'
+);
+
+SET @veil_guilds_updated_at_idx_sql := IF(
+  @veil_guilds_updated_at_idx_exists = 0,
+  'CREATE INDEX `idx_guilds_updated_at` ON `guilds` (updated_at)',
+  'SELECT 1'
+);
+
+PREPARE veil_guilds_updated_at_idx_stmt FROM @veil_guilds_updated_at_idx_sql;
+EXECUTE veil_guilds_updated_at_idx_stmt;
+DEALLOCATE PREPARE veil_guilds_updated_at_idx_stmt;
+
+SET @veil_guilds_tag_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'guilds'
+    AND INDEX_NAME = 'uidx_guilds_tag'
+);
+
+SET @veil_guilds_tag_idx_sql := IF(
+  @veil_guilds_tag_idx_exists = 0,
+  'CREATE UNIQUE INDEX `uidx_guilds_tag` ON `guilds` (tag)',
+  'SELECT 1'
+);
+
+PREPARE veil_guilds_tag_idx_stmt FROM @veil_guilds_tag_idx_sql;
+EXECUTE veil_guilds_tag_idx_stmt;
+DEALLOCATE PREPARE veil_guilds_tag_idx_stmt;
+
+CREATE TABLE IF NOT EXISTS `guild_memberships` (
+  guild_id VARCHAR(191) NOT NULL,
+  player_id VARCHAR(191) NOT NULL,
+  role VARCHAR(16) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (guild_id, player_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @veil_guild_memberships_player_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'guild_memberships'
+    AND INDEX_NAME = 'uidx_guild_memberships_player'
+);
+
+SET @veil_guild_memberships_player_idx_sql := IF(
+  @veil_guild_memberships_player_idx_exists = 0,
+  'CREATE UNIQUE INDEX `uidx_guild_memberships_player` ON `guild_memberships` (player_id)',
+  'SELECT 1'
+);
+
+PREPARE veil_guild_memberships_player_idx_stmt FROM @veil_guild_memberships_player_idx_sql;
+EXECUTE veil_guild_memberships_player_idx_stmt;
+DEALLOCATE PREPARE veil_guild_memberships_player_idx_stmt;
+
 CREATE TABLE IF NOT EXISTS `config_documents` (
   document_id VARCHAR(64) NOT NULL,
   content_json LONGTEXT NOT NULL,

--- a/packages/shared/src/guilds.ts
+++ b/packages/shared/src/guilds.ts
@@ -54,8 +54,28 @@ export interface GuildRosterView {
   pendingJoinRequests: GuildJoinRequestView[];
 }
 
+export interface GuildSummaryView {
+  guildId: string;
+  name: string;
+  tag: string;
+  description?: string;
+  level: number;
+  xp: number;
+  memberCount: number;
+  memberLimit: number;
+  availableSeats: number;
+  ownerPlayerId?: string;
+  ownerDisplayName?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface GuildMembershipEvent {
   type:
+    | "guild.created"
+    | "guild.disbanded"
+    | "guild.member.joined"
+    | "guild.member.left"
     | "guild.member.join_requested"
     | "guild.member.join_approved"
     | "guild.member.join_rejected"
@@ -74,6 +94,23 @@ export interface GuildMembershipEvent {
 export interface GuildMutationResult {
   guild: GuildState;
   events: GuildMembershipEvent[];
+}
+
+export interface GuildCreateInput {
+  ownerPlayerId: string;
+  ownerDisplayName: string;
+  name: string;
+  tag: string;
+  guildId?: string;
+  description?: string;
+  memberLimit?: number;
+  createdAt?: string;
+}
+
+export interface GuildDirectJoinInput {
+  playerId: string;
+  displayName: string;
+  joinedAt?: string;
 }
 
 export interface GuildJoinRequestInput {
@@ -112,6 +149,15 @@ export interface GuildRoleAssignmentInput {
   changedAt?: string;
 }
 
+export interface GuildLeaveInput {
+  playerId: string;
+  leftAt?: string;
+}
+
+export interface GuildLeaveResult extends GuildMutationResult {
+  deleted: boolean;
+}
+
 function normalizeTimestamp(value?: string | null, fallback = new Date().toISOString()): string {
   const normalized = value?.trim();
   if (!normalized) {
@@ -125,6 +171,24 @@ function normalizeTimestamp(value?: string | null, fallback = new Date().toISOSt
 function normalizeDisplayName(value: string | undefined, fallback: string): string {
   const normalized = value?.trim();
   return normalized ? normalized.slice(0, 40) : fallback;
+}
+
+function normalizeGuildName(name: string): string {
+  const normalized = name.trim();
+  if (!normalized) {
+    throw new Error("guild_create_name_required");
+  }
+
+  return normalized.slice(0, 40);
+}
+
+function normalizeGuildTag(tag: string): string {
+  const normalized = tag.trim().toUpperCase();
+  if (!normalized) {
+    throw new Error("guild_create_tag_required");
+  }
+
+  return normalized.slice(0, 4);
 }
 
 function ensureGuildMemberLimit(value?: number | null): number {
@@ -321,6 +385,39 @@ function addMember(guild: GuildState, member: GuildMemberState): void {
     });
 }
 
+function removeMember(guild: GuildState, playerId: string): GuildMemberState | null {
+  const target = getGuildMember(guild, playerId);
+  if (!target) {
+    return null;
+  }
+
+  guild.members = guild.members.filter((member) => member.playerId !== playerId);
+  return target;
+}
+
+function findSuccessorOwner(guild: GuildState): GuildMemberState | undefined {
+  return guild.members.find((member) => member.role === "officer") ?? guild.members[0];
+}
+
+export function createGuildSummaryView(guildInput: GuildState): GuildSummaryView {
+  const guild = normalizeGuildState(guildInput);
+  const owner = guild.members.find((member) => member.role === "owner");
+  return {
+    guildId: guild.id,
+    name: guild.name,
+    tag: guild.tag,
+    ...(guild.description ? { description: guild.description } : {}),
+    level: guild.level,
+    xp: guild.xp,
+    memberCount: guild.members.length,
+    memberLimit: guild.memberLimit,
+    availableSeats: Math.max(0, guild.memberLimit - guild.members.length),
+    ...(owner ? { ownerPlayerId: owner.playerId, ownerDisplayName: owner.displayName } : {}),
+    createdAt: guild.createdAt,
+    updatedAt: guild.updatedAt
+  };
+}
+
 export function createGuildRosterView(guildInput: GuildState): GuildRosterView {
   const guild = normalizeGuildState(guildInput);
   return {
@@ -351,6 +448,164 @@ export function createGuildRosterView(guildInput: GuildState): GuildRosterView {
         requestedAt: request.requestedAt,
         status: request.status
       }))
+  };
+}
+
+export function createGuild(input: GuildCreateInput): GuildMutationResult {
+  const ownerPlayerId = input.ownerPlayerId.trim();
+  if (!ownerPlayerId) {
+    throw new Error("guild_create_owner_required");
+  }
+
+  const occurredAt = normalizeTimestamp(input.createdAt);
+  const guild = normalizeGuildState({
+    id: input.guildId?.trim() || `guild-${ownerPlayerId}-${occurredAt.slice(0, 10)}`,
+    name: normalizeGuildName(input.name),
+    tag: normalizeGuildTag(input.tag),
+    ...(input.description?.trim() ? { description: input.description.trim().slice(0, 160) } : {}),
+    memberLimit: ensureGuildMemberLimit(input.memberLimit),
+    level: 1,
+    xp: 0,
+    createdAt: occurredAt,
+    updatedAt: occurredAt,
+    members: [
+      {
+        playerId: ownerPlayerId,
+        displayName: normalizeDisplayName(input.ownerDisplayName, ownerPlayerId),
+        role: "owner",
+        joinedAt: occurredAt
+      }
+    ],
+    joinRequests: [],
+    invites: []
+  });
+
+  return {
+    guild,
+    events: [
+      {
+        type: "guild.created",
+        guildId: guild.id,
+        actorPlayerId: ownerPlayerId,
+        subjectPlayerId: ownerPlayerId,
+        occurredAt,
+        metadata: {
+          name: guild.name,
+          tag: guild.tag
+        }
+      }
+    ]
+  };
+}
+
+export function joinGuild(guildInput: GuildState, input: GuildDirectJoinInput): GuildMutationResult {
+  const guild = cloneGuild(guildInput);
+  const playerId = input.playerId.trim();
+  if (!playerId) {
+    throw new Error("guild_join_player_required");
+  }
+  if (getGuildMember(guild, playerId)) {
+    throw new Error("guild_join_already_member");
+  }
+
+  assertGuildHasCapacity(guild);
+  const occurredAt = normalizeTimestamp(input.joinedAt);
+  addMember(guild, {
+    playerId,
+    displayName: normalizeDisplayName(input.displayName, playerId),
+    role: "member",
+    joinedAt: occurredAt
+  });
+  settleMatchingPendingInvite(guild, playerId, "accepted", occurredAt);
+  guild.updatedAt = occurredAt;
+
+  return {
+    guild: normalizeGuildState(guild),
+    events: [
+      {
+        type: "guild.member.joined",
+        guildId: guild.id,
+        actorPlayerId: playerId,
+        subjectPlayerId: playerId,
+        occurredAt
+      }
+    ]
+  };
+}
+
+export function leaveGuild(guildInput: GuildState, input: GuildLeaveInput): GuildLeaveResult {
+  const guild = cloneGuild(guildInput);
+  const playerId = input.playerId.trim();
+  if (!playerId) {
+    throw new Error("guild_leave_player_required");
+  }
+
+  const removed = removeMember(guild, playerId);
+  if (!removed) {
+    throw new Error("guild_leave_member_not_found");
+  }
+
+  const occurredAt = normalizeTimestamp(input.leftAt);
+  guild.joinRequests = guild.joinRequests.filter((request) => request.playerId !== playerId);
+  guild.invites = guild.invites.filter((invite) => invite.playerId !== playerId);
+  guild.updatedAt = occurredAt;
+
+  const events: GuildMembershipEvent[] = [];
+  if (removed.role === "owner" && guild.members.length > 0) {
+    const successor = findSuccessorOwner(guild);
+    if (successor) {
+      successor.role = "owner";
+      appendEvent(
+        events,
+        {
+          type: "guild.member.owner_transferred",
+          actorPlayerId: removed.playerId,
+          subjectPlayerId: successor.playerId,
+          metadata: {
+            previousOwnerPlayerId: removed.playerId,
+            newOwnerPlayerId: successor.playerId
+          }
+        },
+        guild.id,
+        occurredAt
+      );
+    }
+  }
+
+  appendEvent(
+    events,
+    {
+      type: "guild.member.left",
+      actorPlayerId: removed.playerId,
+      subjectPlayerId: removed.playerId
+    },
+    guild.id,
+    occurredAt
+  );
+
+  const deleted = guild.members.length === 0;
+  if (deleted) {
+    appendEvent(
+      events,
+      {
+        type: "guild.disbanded",
+        actorPlayerId: removed.playerId,
+        subjectPlayerId: removed.playerId
+      },
+      guild.id,
+      occurredAt
+    );
+  }
+
+  guild.members.sort((left, right) => {
+    const roleOrder = GUILD_ROLE_ORDER[left.role] - GUILD_ROLE_ORDER[right.role];
+    return roleOrder || left.joinedAt.localeCompare(right.joinedAt) || left.playerId.localeCompare(right.playerId);
+  });
+
+  return {
+    guild: normalizeGuildState(guild),
+    events,
+    deleted
   };
 }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,5 +1,6 @@
 import type { BattleAction, BattleState, MovementPlan, Vec2, WorldAction, WorldEvent } from "./models.ts";
 import type { FeatureFlags } from "./feature-flags.ts";
+import type { GuildRosterView, GuildSummaryView } from "./guilds.ts";
 import type { PlayerWorldViewPayload } from "./map-sync.ts";
 import type { RuntimeConfigBundle } from "./world-config.ts";
 
@@ -35,6 +36,25 @@ export interface SessionStatePayload {
 
 export type PlayerReportReason = "cheating" | "harassment" | "afk";
 export type PlayerReportStatus = "pending" | "dismissed" | "warned" | "banned";
+
+export interface GuildCreateAction {
+  name: string;
+  tag: string;
+  description?: string;
+  memberLimit?: number;
+}
+
+export interface GuildJoinAction {
+  guildId: string;
+}
+
+export interface GuildLeaveAction {
+  guildId: string;
+}
+
+export interface GuildGetAction {
+  guildId: string;
+}
 
 export type ClientMessage =
   | {
@@ -83,6 +103,35 @@ export type ClientMessage =
       type: "campaign.dialogue.ack";
       requestId: string;
       action: CampaignDialogueAckAction;
+    }
+  | {
+      type: "guild.create";
+      requestId: string;
+      action: GuildCreateAction;
+    }
+  | {
+      type: "guild.join";
+      requestId: string;
+      action: GuildJoinAction;
+    }
+  | {
+      type: "guild.leave";
+      requestId: string;
+      action: GuildLeaveAction;
+    }
+  | {
+      type: "guild.list";
+      requestId: string;
+    }
+  | {
+      type: "guild.get";
+      requestId: string;
+      action: GuildGetAction;
+    }
+  | {
+      type: "guild.roster";
+      requestId: string;
+      action: GuildGetAction;
     };
 
 export type ServerMessage =
@@ -134,4 +183,19 @@ export type ServerMessage =
       requestId: "push";
       delivery: "push";
       payload: EventProgressUpdatePayload;
+    }
+  | {
+      type: "guild.list";
+      requestId: string;
+      items: GuildSummaryView[];
+    }
+  | {
+      type: "guild.get";
+      requestId: string;
+      guild: GuildSummaryView;
+    }
+  | {
+      type: "guild.roster";
+      requestId: string;
+      roster: GuildRosterView;
     };

--- a/packages/shared/test/guilds.test.ts
+++ b/packages/shared/test/guilds.test.ts
@@ -2,16 +2,20 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   assignGuildMemberRole,
+  createGuild,
   createGuildInvite,
   createGuildJoinRequest,
   createGuildRosterView,
+  createGuildSummaryView,
+  joinGuild,
+  leaveGuild,
   normalizeGuildState,
   respondToGuildInvite,
   reviewGuildJoinRequest,
   type GuildState
 } from "../src/index";
 
-function createGuild(overrides?: Partial<GuildState>): GuildState {
+function createExistingGuild(overrides?: Partial<GuildState>): GuildState {
   return normalizeGuildState({
     id: "guild-nightwatch",
     name: "Nightwatch",
@@ -50,7 +54,7 @@ function createGuild(overrides?: Partial<GuildState>): GuildState {
 
 test("guild roster view exposes stable role metadata in rank order", () => {
   const roster = createGuildRosterView(
-    createGuild({
+    createExistingGuild({
       members: [
         {
           playerId: "member-2",
@@ -85,8 +89,71 @@ test("guild roster view exposes stable role metadata in rank order", () => {
   assert.equal(roster.availableSeats, 1);
 });
 
+test("guild creation returns a summary with the owner seeded into the roster", () => {
+  const created = createGuild({
+    ownerPlayerId: "founder-1",
+    ownerDisplayName: "Founder",
+    name: "Skyforge",
+    tag: "SKY",
+    description: "Open frontier builders",
+    createdAt: "2026-04-02T06:00:00.000Z"
+  });
+
+  const summary = createGuildSummaryView(created.guild);
+  assert.equal(summary.ownerPlayerId, "founder-1");
+  assert.equal(summary.memberCount, 1);
+  assert.equal(created.events[0]?.type, "guild.created");
+});
+
+test("guild join adds a direct member when capacity remains", () => {
+  const joined = joinGuild(createExistingGuild(), {
+    playerId: "member-2",
+    displayName: "Scout",
+    joinedAt: "2026-04-02T10:00:00.000Z"
+  });
+
+  assert.equal(joined.guild.members.find((member) => member.playerId === "member-2")?.role, "member");
+  assert.equal(joined.events[0]?.type, "guild.member.joined");
+});
+
+test("owner leave transfers ownership and keeps the guild alive when members remain", () => {
+  const result = leaveGuild(createExistingGuild(), {
+    playerId: "owner-1",
+    leftAt: "2026-04-02T11:00:00.000Z"
+  });
+
+  assert.equal(result.deleted, false);
+  assert.equal(result.guild.members.some((member) => member.playerId === "owner-1"), false);
+  assert.equal(result.guild.members.find((member) => member.playerId === "officer-1")?.role, "owner");
+  assert.equal(result.events[0]?.type, "guild.member.owner_transferred");
+  assert.equal(result.events[1]?.type, "guild.member.left");
+});
+
+test("last member leave disbands the guild", () => {
+  const result = leaveGuild(
+    createExistingGuild({
+      members: [
+        {
+          playerId: "solo-1",
+          displayName: "Solo",
+          role: "owner",
+          joinedAt: "2026-04-01T10:00:00.000Z"
+        }
+      ]
+    }),
+    {
+      playerId: "solo-1",
+      leftAt: "2026-04-02T12:00:00.000Z"
+    }
+  );
+
+  assert.equal(result.deleted, true);
+  assert.equal(result.guild.members.length, 0);
+  assert.equal(result.events.at(-1)?.type, "guild.disbanded");
+});
+
 test("owner can promote a member to officer and emit a structured membership event", () => {
-  const result = assignGuildMemberRole(createGuild(), {
+  const result = assignGuildMemberRole(createExistingGuild(), {
     actorPlayerId: "owner-1",
     targetPlayerId: "member-1",
     role: "officer",
@@ -111,7 +178,7 @@ test("owner can promote a member to officer and emit a structured membership eve
 test("officer cannot change guild roles", () => {
   assert.throws(
     () =>
-      assignGuildMemberRole(createGuild(), {
+      assignGuildMemberRole(createExistingGuild(), {
         actorPlayerId: "officer-1",
         targetPlayerId: "member-1",
         role: "officer"
@@ -121,7 +188,7 @@ test("officer cannot change guild roles", () => {
 });
 
 test("owner transfer promotes the new owner and demotes the previous owner to officer", () => {
-  const result = assignGuildMemberRole(createGuild(), {
+  const result = assignGuildMemberRole(createExistingGuild(), {
     actorPlayerId: "owner-1",
     targetPlayerId: "officer-1",
     role: "owner",
@@ -134,7 +201,7 @@ test("owner transfer promotes the new owner and demotes the previous owner to of
 });
 
 test("officer can approve a pending join request and add the player to the roster", () => {
-  const requested = createGuildJoinRequest(createGuild(), {
+  const requested = createGuildJoinRequest(createExistingGuild(), {
     playerId: "applicant-1",
     displayName: "Applicant",
     requestId: "join-1",
@@ -163,7 +230,7 @@ test("officer can approve a pending join request and add the player to the roste
 });
 
 test("members cannot approve join requests", () => {
-  const requested = createGuildJoinRequest(createGuild(), {
+  const requested = createGuildJoinRequest(createExistingGuild(), {
     playerId: "applicant-1",
     displayName: "Applicant",
     requestId: "join-1",
@@ -182,7 +249,7 @@ test("members cannot approve join requests", () => {
 });
 
 test("join rejection preserves the applicant outside the roster and records the rejection", () => {
-  const requested = createGuildJoinRequest(createGuild(), {
+  const requested = createGuildJoinRequest(createExistingGuild(), {
     playerId: "applicant-2",
     displayName: "Applicant",
     requestId: "join-2",
@@ -204,7 +271,7 @@ test("join rejection preserves the applicant outside the roster and records the 
 });
 
 test("invited players can accept or decline their invite, while others cannot respond for them", () => {
-  const invited = createGuildInvite(createGuild(), {
+  const invited = createGuildInvite(createExistingGuild(), {
     actorPlayerId: "officer-1",
     playerId: "friend-1",
     inviteId: "invite-1",

--- a/scripts/migrations/0018_add_guild_tables.ts
+++ b/scripts/migrations/0018_add_guild_tables.ts
@@ -1,0 +1,77 @@
+import {
+  dropIndexIfExists,
+  dropTableIfExists,
+  ensureIndexExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_GUILD_MEMBERSHIP_PLAYER_INDEX,
+  MYSQL_GUILD_MEMBERSHIP_TABLE,
+  MYSQL_GUILD_TABLE,
+  MYSQL_GUILD_TAG_INDEX,
+  MYSQL_GUILD_UPDATED_AT_INDEX
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureTableExists(
+    connection,
+    MYSQL_GUILD_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_GUILD_TABLE}\` (
+      guild_id VARCHAR(191) NOT NULL,
+      name VARCHAR(80) NOT NULL,
+      tag VARCHAR(8) NOT NULL,
+      description VARCHAR(160) NULL,
+      owner_player_id VARCHAR(191) NULL,
+      member_count INT NOT NULL DEFAULT 0,
+      state_json LONGTEXT NOT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      PRIMARY KEY (guild_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_GUILD_TABLE,
+    MYSQL_GUILD_UPDATED_AT_INDEX,
+    `CREATE INDEX \`${MYSQL_GUILD_UPDATED_AT_INDEX}\` ON \`${MYSQL_GUILD_TABLE}\` (updated_at)`
+  );
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_GUILD_TABLE,
+    MYSQL_GUILD_TAG_INDEX,
+    `CREATE UNIQUE INDEX \`${MYSQL_GUILD_TAG_INDEX}\` ON \`${MYSQL_GUILD_TABLE}\` (tag)`
+  );
+
+  await ensureTableExists(
+    connection,
+    MYSQL_GUILD_MEMBERSHIP_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_GUILD_MEMBERSHIP_TABLE}\` (
+      guild_id VARCHAR(191) NOT NULL,
+      player_id VARCHAR(191) NOT NULL,
+      role VARCHAR(16) NOT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (guild_id, player_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_GUILD_MEMBERSHIP_TABLE,
+    MYSQL_GUILD_MEMBERSHIP_PLAYER_INDEX,
+    `CREATE UNIQUE INDEX \`${MYSQL_GUILD_MEMBERSHIP_PLAYER_INDEX}\` ON \`${MYSQL_GUILD_MEMBERSHIP_TABLE}\` (player_id)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+  await dropIndexIfExists(connection, database, MYSQL_GUILD_MEMBERSHIP_TABLE, MYSQL_GUILD_MEMBERSHIP_PLAYER_INDEX);
+  await dropTableIfExists(connection, MYSQL_GUILD_MEMBERSHIP_TABLE);
+  await dropIndexIfExists(connection, database, MYSQL_GUILD_TABLE, MYSQL_GUILD_TAG_INDEX);
+  await dropIndexIfExists(connection, database, MYSQL_GUILD_TABLE, MYSQL_GUILD_UPDATED_AT_INDEX);
+  await dropTableIfExists(connection, MYSQL_GUILD_TABLE);
+}


### PR DESCRIPTION
Closes #865.

## Summary
- add shared guild foundation types and protocol actions for create/join/leave/list/get/roster flows
- add server guild routes and service logic backed by memory and MySQL persistence
- add guild schema migration and focused route/shared coverage

## Test Notes
- `node --import tsx --test ./packages/shared/test/guilds.test.ts`
- `node --import tsx --test ./apps/server/test/guild-routes.test.ts ./apps/server/test/dev-server.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`

## Notes
- `npm run typecheck` currently fails on unrelated pre-existing client/scripts test typing issues outside this guild slice.