### PR TITLE
[codex] feat: player mailbox and compensation grant workflow

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -154,6 +154,8 @@ export interface VeilLobbyRenderState {
   shop: CocosShopPanelView;
   shopStatus: string;
   shopLoading?: boolean;
+  mailboxClaimingMessageId?: string | null;
+  mailboxClaimAllBusy?: boolean;
 }
 
 export interface VeilLobbyPanelOptions {
@@ -185,6 +187,8 @@ export interface VeilLobbyPanelOptions {
   onCloseLobbySkillPanel?: () => void;
   onLearnLobbySkill?: (skillId: string) => void;
   onPurchaseShopProduct?: (productId: string) => void;
+  onClaimMailboxMessage?: (messageId: string) => void;
+  onClaimAllMailbox?: () => void;
 }
 
 interface PanelCardTone {
@@ -228,6 +232,8 @@ export class VeilLobbyPanel extends Component {
   private onCloseLobbySkillPanel: (() => void) | undefined;
   private onLearnLobbySkill: ((skillId: string) => void) | undefined;
   private onPurchaseShopProduct: ((productId: string) => void) | undefined;
+  private onClaimMailboxMessage: ((messageId: string) => void) | undefined;
+  private onClaimAllMailbox: (() => void) | undefined;
   private replayPlayback: BattleReplayPlaybackState | null = null;
   private replayPlaybackReplayId: string | null = null;
   private replayPlaybackStatus = "选择一场最近战斗，即可查看逐步回放。";
@@ -268,6 +274,8 @@ export class VeilLobbyPanel extends Component {
     this.onCloseLobbySkillPanel = options.onCloseLobbySkillPanel;
     this.onLearnLobbySkill = options.onLearnLobbySkill;
     this.onPurchaseShopProduct = options.onPurchaseShopProduct;
+    this.onClaimMailboxMessage = options.onClaimMailboxMessage;
+    this.onClaimAllMailbox = options.onClaimAllMailbox;
   }
 
   render(state: VeilLobbyRenderState): void {
@@ -759,6 +767,7 @@ export class VeilLobbyPanel extends Component {
       this.hideAccountReviewCards();
       this.hideBattleReplayTimelineCard();
       rightCursorY = this.renderHeroSection(rightX, rightCursorY, rightWidth, state, skillPanelBusy);
+      rightCursorY = this.renderMailboxSection(rightX, rightCursorY, rightWidth, state);
       rightCursorY = this.renderLeaderboardSection(rightX, rightCursorY, rightWidth, state);
       rightCursorY = this.renderShopSection(rightX, rightCursorY, rightWidth, state);
       rightCursorY = this.renderCard(
@@ -923,6 +932,76 @@ export class VeilLobbyPanel extends Component {
 
     this.hideExtraCards("LobbyShop-", Math.min(4, shop.rows.length));
     return cursorY;
+  }
+
+  private renderMailboxSection(centerX: number, topY: number, width: number, state: VeilLobbyRenderState): number {
+    const mailbox = state.account.mailbox ?? [];
+    const summary = state.account.mailboxSummary ?? { totalCount: mailbox.length, unreadCount: 0, claimableCount: 0, expiredCount: 0 };
+    const activeMessages = mailbox.filter((message) => !message.claimedAt).slice(0, 2);
+    const lines = [
+      `系统邮箱 · 未读 ${summary.unreadCount}`,
+      `可领取 ${summary.claimableCount} · 已过期 ${summary.expiredCount}`,
+      ...(activeMessages.length > 0
+        ? activeMessages.flatMap((message, index) => [
+            `${index + 1}. ${message.title}`,
+            message.body,
+            `${message.grant?.gems ? `宝石 x${message.grant.gems}` : ""}${message.grant?.resources?.gold ? `${message.grant?.gems ? " · " : ""}金币 x${message.grant.resources.gold}` : ""}${message.expiresAt ? ` · ${message.expiresAt.slice(0, 10)} 到期` : ""}` ||
+              "无附件"
+          ])
+        : ["当前没有待处理系统邮件。"])
+    ];
+    const cardHeight = 100 + activeMessages.length * 74;
+    const nextY = this.renderCard(
+      "LobbyMailbox",
+      centerX,
+      topY,
+      width,
+      cardHeight,
+      lines,
+      {
+        fill: new Color(52, 68, 96, 188),
+        stroke: new Color(231, 240, 252, 76),
+        accent: summary.unreadCount > 0 ? new Color(238, 184, 94, 220) : new Color(124, 176, 226, 204)
+      },
+      null,
+      13,
+      16
+    );
+
+    this.renderActionButton(
+      "LobbyMailboxClaimAll",
+      centerX,
+      nextY - 18,
+      width,
+      28,
+      state.mailboxClaimAllBusy ? "领取中..." : summary.claimableCount > 0 ? "领取全部附件" : "邮箱已同步",
+      {
+        fill: summary.claimableCount > 0 ? ACTION_ACCOUNT_REVIEW_ACTIVE : MUTED_FILL,
+        stroke: new Color(234, 240, 228, 110),
+        accent: new Color(226, 236, 220, 102)
+      },
+      summary.claimableCount > 0 && !state.mailboxClaimAllBusy ? this.onClaimAllMailbox ?? null : null
+    );
+
+    activeMessages.forEach((message, index) => {
+      const claimable = !message.claimedAt && Boolean(message.grant);
+      this.renderActionButton(
+        `LobbyMailboxClaim-${index}`,
+        centerX,
+        nextY - 52 - index * 34,
+        width,
+        28,
+        state.mailboxClaimingMessageId === message.id ? "领取中..." : claimable ? `领取: ${message.title}` : `${message.title} · 无附件`,
+        {
+          fill: claimable ? ACTION_ACCOUNT : MUTED_FILL,
+          stroke: new Color(228, 236, 248, 108),
+          accent: new Color(220, 230, 244, 96)
+        },
+        claimable && state.mailboxClaimingMessageId !== message.id ? () => this.onClaimMailboxMessage?.(message.id) : null
+      );
+    });
+
+    return nextY - 60 - activeMessages.length * 34;
   }
 
   private hideExtraCards(prefix: string, visibleCount: number): void {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -26,6 +26,8 @@ import {
   type CocosAccountReviewState
 } from "./cocos-account-review.ts";
 import {
+  claimAllCocosMailboxMessages,
+  claimCocosMailboxMessage,
   confirmCocosAccountRegistration,
   confirmCocosPasswordRecovery,
   createFallbackCocosPlayerAccountProfile,
@@ -358,6 +360,8 @@ export class VeilRoot extends Component {
   private lobbyShopLoading = false;
   private lobbyShopStatus = "可用商品会在这里显示。";
   private pendingShopProductId: string | null = null;
+  private mailboxClaimingMessageId: string | null = null;
+  private mailboxClaimAllInFlight = false;
   private lobbyAccountReviewState: CocosAccountReviewState = createCocosAccountReviewState(this.lobbyAccountProfile);
   private lobbyAccountEpoch = 0;
   private gameplayAccountRefreshInFlight = false;
@@ -972,6 +976,12 @@ export class VeilRoot extends Component {
       },
       onPurchaseShopProduct: (productId) => {
         void this.purchaseLobbyShopProduct(productId);
+      },
+      onClaimMailboxMessage: (messageId) => {
+        void this.claimLobbyMailboxMessage(messageId);
+      },
+      onClaimAllMailbox: () => {
+        void this.claimAllLobbyMailboxMessages();
       }
     });
 
@@ -1290,7 +1300,9 @@ export class VeilRoot extends Component {
           ...(this.lobbyAccountProfile.equippedCosmetics ? { equippedCosmetics: this.lobbyAccountProfile.equippedCosmetics } : {})
         }),
         shopStatus: this.lobbyShopStatus,
-        shopLoading: this.lobbyShopLoading
+        shopLoading: this.lobbyShopLoading,
+        mailboxClaimingMessageId: this.mailboxClaimingMessageId,
+        mailboxClaimAllBusy: this.mailboxClaimAllInFlight
       });
       const tutorialOverlayView = this.buildTutorialOverlayView();
       if (tutorialOverlayView) {
@@ -1582,6 +1594,67 @@ export class VeilRoot extends Component {
         return error.message.startsWith("cocos_request_failed:")
           ? "商品购买失败，请稍后重试。"
           : error.message;
+    }
+  }
+
+  private async claimLobbyMailboxMessage(messageId: string): Promise<void> {
+    const storage = this.readWebStorage();
+    const authSession = readStoredCocosAuthSession(storage);
+    if (!authSession?.token) {
+      this.lobbyStatus = "系统邮箱领取需要先登录云端账号或游客会话。";
+      this.renderView();
+      return;
+    }
+
+    this.mailboxClaimingMessageId = messageId;
+    this.lobbyStatus = "正在领取邮件附件...";
+    this.renderView();
+    try {
+      const payload = await claimCocosMailboxMessage(this.remoteUrl, messageId, {
+        authSession,
+        storage
+      });
+      this.lobbyStatus =
+        payload.claimed
+          ? "邮件附件已领取，正在同步仓库状态。"
+          : payload.reason === "already_claimed"
+            ? "该邮件附件已经领取过。"
+            : payload.reason === "expired"
+              ? "该邮件已经过期。"
+              : "该邮件没有可领取附件。";
+      await this.refreshLobbyAccountProfile();
+    } catch (error) {
+      this.lobbyStatus = error instanceof Error ? error.message : "mailbox_claim_failed";
+    } finally {
+      this.mailboxClaimingMessageId = null;
+      this.renderView();
+    }
+  }
+
+  private async claimAllLobbyMailboxMessages(): Promise<void> {
+    const storage = this.readWebStorage();
+    const authSession = readStoredCocosAuthSession(storage);
+    if (!authSession?.token) {
+      this.lobbyStatus = "系统邮箱领取需要先登录云端账号或游客会话。";
+      this.renderView();
+      return;
+    }
+
+    this.mailboxClaimAllInFlight = true;
+    this.lobbyStatus = "正在领取全部邮件附件...";
+    this.renderView();
+    try {
+      const payload = await claimAllCocosMailboxMessages(this.remoteUrl, {
+        authSession,
+        storage
+      });
+      this.lobbyStatus = payload.claimed ? "邮件附件已全部领取，正在同步仓库状态。" : "当前没有可领取的邮件附件。";
+      await this.refreshLobbyAccountProfile();
+    } catch (error) {
+      this.lobbyStatus = error instanceof Error ? error.message : "mailbox_claim_all_failed";
+    } finally {
+      this.mailboxClaimAllInFlight = false;
+      this.renderView();
     }
   }
 

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -100,11 +100,21 @@ interface PlayerAccountApiPayload extends AuthSessionApiPayload {
     recentBattleReplays?: Partial<PlayerBattleReplaySummary>[];
     tutorialStep?: number | null;
     dailyQuestBoard?: PlayerAccountReadModel["dailyQuestBoard"];
+    mailbox?: PlayerAccountReadModel["mailbox"];
+    mailboxSummary?: PlayerAccountReadModel["mailboxSummary"];
     loginId?: string;
     credentialBoundAt?: string;
     lastRoomId?: string;
     lastSeenAt?: string;
   };
+}
+
+interface PlayerMailboxApiPayload {
+  items?: PlayerAccountReadModel["mailbox"];
+  summary?: PlayerAccountReadModel["mailboxSummary"];
+  claimed?: boolean;
+  claimedMessageIds?: string[];
+  reason?: string;
 }
 
 interface DailyClaimApiPayload {
@@ -430,6 +440,8 @@ function asCocosPlayerAccountProfile(
     recentBattleReplays: account?.recentBattleReplays,
     tutorialStep: account?.tutorialStep,
     dailyQuestBoard: account?.dailyQuestBoard,
+    mailbox: account?.mailbox,
+    mailboxSummary: account?.mailboxSummary,
     ...(battleReportCenter ? { battleReportCenter } : {}),
     loginId: normalizeLoginId(account?.loginId),
     credentialBoundAt: account?.credentialBoundAt,
@@ -525,6 +537,51 @@ export async function postCocosPlayerReferral(
       ...(options.storage !== undefined ? { storage: options.storage } : {})
     }
   )) as PlayerReferralApiPayload;
+}
+
+export async function claimCocosMailboxMessage(
+  remoteUrl: string,
+  messageId: string,
+  options: {
+    authSession: CocosStoredAuthSession;
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "removeItem"> | null;
+  }
+): Promise<PlayerMailboxApiPayload> {
+  return (await fetchCocosAuthJson(
+    remoteUrl,
+    `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/mailbox/${encodeURIComponent(messageId)}/claim`,
+    {
+      method: "POST"
+    },
+    options.authSession,
+    {
+      ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+      ...(options.storage !== undefined ? { storage: options.storage } : {})
+    }
+  )) as PlayerMailboxApiPayload;
+}
+
+export async function claimAllCocosMailboxMessages(
+  remoteUrl: string,
+  options: {
+    authSession: CocosStoredAuthSession;
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "removeItem"> | null;
+  }
+): Promise<PlayerMailboxApiPayload> {
+  return (await fetchCocosAuthJson(
+    remoteUrl,
+    `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/mailbox/claim-all`,
+    {
+      method: "POST"
+    },
+    options.authSession,
+    {
+      ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+      ...(options.storage !== undefined ? { storage: options.storage } : {})
+    }
+  )) as PlayerMailboxApiPayload;
 }
 
 export async function updateCocosTutorialProgress(

--- a/apps/cocos-client/assets/scripts/project-shared/player-account.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/player-account.ts
@@ -36,12 +36,41 @@ export interface PlayerAccountReadModel {
   recentBattleReplays?: PlayerBattleReplaySummary[];
   battleReportCenter?: PlayerBattleReportCenter;
   dailyQuestBoard?: DailyQuestBoard;
+  mailbox?: PlayerMailboxMessage[];
+  mailboxSummary?: PlayerMailboxSummary;
   tutorialStep?: number | null;
   loginId?: string;
   credentialBoundAt?: string;
   privacyConsentAt?: string;
   lastRoomId?: string;
   lastSeenAt?: string;
+}
+
+export interface PlayerMailboxGrant {
+  gems?: number;
+  resources?: Partial<ResourceLedger>;
+  equipmentIds?: string[];
+  cosmeticIds?: string[];
+  seasonPassPremium?: boolean;
+}
+
+export interface PlayerMailboxMessage {
+  id: string;
+  kind: "system" | "compensation" | "announcement";
+  title: string;
+  body: string;
+  sentAt: string;
+  expiresAt?: string;
+  readAt?: string;
+  claimedAt?: string;
+  grant?: PlayerMailboxGrant;
+}
+
+export interface PlayerMailboxSummary {
+  totalCount: number;
+  unreadCount: number;
+  claimableCount: number;
+  expiredCount: number;
 }
 
 export interface PlayerAccountReadModelInput {
@@ -60,6 +89,8 @@ export interface PlayerAccountReadModelInput {
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
   battleReportCenter?: Partial<PlayerBattleReportCenter> | null | undefined;
   dailyQuestBoard?: Partial<DailyQuestBoard> | null | undefined;
+  mailbox?: Partial<PlayerMailboxMessage>[] | null | undefined;
+  mailboxSummary?: Partial<PlayerMailboxSummary> | null | undefined;
   tutorialStep?: number | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
@@ -85,6 +116,8 @@ export function normalizePlayerAccountReadModel(
   const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
   const recentBattleReplays = normalizePlayerBattleReplaySummaries(account?.recentBattleReplays);
   const dailyQuestBoard = normalizeDailyQuestBoard(account?.dailyQuestBoard);
+  const mailbox = normalizePlayerMailboxMessages(account?.mailbox);
+  const mailboxSummary = normalizePlayerMailboxSummary(account?.mailboxSummary, mailbox);
   const tutorialStep = normalizeTutorialStep(account?.tutorialStep);
 
   return {
@@ -110,11 +143,128 @@ export function normalizePlayerAccountReadModel(
       eventLog: recentEventLog
     }),
     ...(dailyQuestBoard ? { dailyQuestBoard } : {}),
+    ...(mailbox.length > 0 ? { mailbox } : {}),
+    ...(mailboxSummary.totalCount > 0 ? { mailboxSummary } : {}),
     ...(account?.tutorialStep !== undefined ? { tutorialStep } : {}),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(privacyConsentAt ? { privacyConsentAt } : {}),
     ...(lastRoomId ? { lastRoomId } : {}),
     ...(lastSeenAt ? { lastSeenAt } : {})
+  };
+}
+
+function normalizeTimestamp(value?: string | null): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
+function normalizePlayerMailboxGrant(grant?: Partial<PlayerMailboxGrant> | null): PlayerMailboxGrant | undefined {
+  if (!grant) {
+    return undefined;
+  }
+
+  const normalized: PlayerMailboxGrant = {
+    ...(Math.max(0, Math.floor(grant.gems ?? 0)) > 0 ? { gems: Math.max(0, Math.floor(grant.gems ?? 0)) } : {}),
+    ...((grant.resources?.gold ?? 0) > 0 || (grant.resources?.wood ?? 0) > 0 || (grant.resources?.ore ?? 0) > 0
+      ? {
+          resources: {
+            gold: Math.max(0, Math.floor(grant.resources?.gold ?? 0)),
+            wood: Math.max(0, Math.floor(grant.resources?.wood ?? 0)),
+            ore: Math.max(0, Math.floor(grant.resources?.ore ?? 0))
+          }
+        }
+      : {}),
+    ...((grant.equipmentIds?.length ?? 0) > 0
+      ? { equipmentIds: Array.from(new Set((grant.equipmentIds ?? []).map((entry) => entry?.trim()).filter(Boolean))) }
+      : {}),
+    ...((grant.cosmeticIds?.length ?? 0) > 0
+      ? { cosmeticIds: Array.from(new Set((grant.cosmeticIds ?? []).map((entry) => entry?.trim()).filter(Boolean))) }
+      : {}),
+    ...(grant.seasonPassPremium === true ? { seasonPassPremium: true } : {})
+  };
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizePlayerMailboxMessages(mailbox?: Partial<PlayerMailboxMessage>[] | null): PlayerMailboxMessage[] {
+  return (mailbox ?? [])
+    .map((entry) => {
+      const id = entry?.id?.trim();
+      const title = entry?.title?.trim();
+      const body = entry?.body?.trim();
+      const sentAt = normalizeTimestamp(entry?.sentAt);
+      if (!id || !title || !body || !sentAt) {
+        return null;
+      }
+
+      const grant = normalizePlayerMailboxGrant(entry.grant);
+      return {
+        id,
+        kind: entry.kind === "compensation" || entry.kind === "announcement" ? entry.kind : "system",
+        title,
+        body,
+        sentAt,
+        ...(normalizeTimestamp(entry.expiresAt) ? { expiresAt: normalizeTimestamp(entry.expiresAt)! } : {}),
+        ...(normalizeTimestamp(entry.readAt) ? { readAt: normalizeTimestamp(entry.readAt)! } : {}),
+        ...(normalizeTimestamp(entry.claimedAt) ? { claimedAt: normalizeTimestamp(entry.claimedAt)! } : {}),
+        ...(grant ? { grant } : {})
+      } satisfies PlayerMailboxMessage;
+    })
+    .filter((entry): entry is PlayerMailboxMessage => Boolean(entry))
+    .sort((left, right) => right.sentAt.localeCompare(left.sentAt) || left.id.localeCompare(right.id));
+}
+
+export function isPlayerMailboxMessageExpired(message: Pick<PlayerMailboxMessage, "expiresAt">, now = new Date()): boolean {
+  if (!message.expiresAt) {
+    return false;
+  }
+
+  const expiresAt = new Date(message.expiresAt);
+  return !Number.isNaN(expiresAt.getTime()) && expiresAt.getTime() <= now.getTime();
+}
+
+export function summarizePlayerMailbox(mailbox?: Partial<PlayerMailboxMessage>[] | null, now = new Date()): PlayerMailboxSummary {
+  const normalizedMailbox = normalizePlayerMailboxMessages(mailbox);
+  let unreadCount = 0;
+  let claimableCount = 0;
+  let expiredCount = 0;
+
+  for (const entry of normalizedMailbox) {
+    const expired = isPlayerMailboxMessageExpired(entry, now);
+    if (expired) {
+      expiredCount += 1;
+    }
+    if (!entry.readAt && !entry.claimedAt && !expired) {
+      unreadCount += 1;
+    }
+    if (!entry.claimedAt && !expired && entry.grant) {
+      claimableCount += 1;
+    }
+  }
+
+  return {
+    totalCount: normalizedMailbox.length,
+    unreadCount,
+    claimableCount,
+    expiredCount
+  };
+}
+
+function normalizePlayerMailboxSummary(
+  summary?: Partial<PlayerMailboxSummary> | null,
+  mailbox?: Partial<PlayerMailboxMessage>[] | null
+): PlayerMailboxSummary {
+  const fallback = summarizePlayerMailbox(mailbox);
+  return {
+    totalCount: Math.max(0, Math.floor(summary?.totalCount ?? fallback.totalCount)),
+    unreadCount: Math.max(0, Math.floor(summary?.unreadCount ?? fallback.unreadCount)),
+    claimableCount: Math.max(0, Math.floor(summary?.claimableCount ?? fallback.claimableCount)),
+    expiredCount: Math.max(0, Math.floor(summary?.expiredCount ?? fallback.expiredCount))
   };
 }

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  claimAllCocosMailboxMessages,
+  claimCocosMailboxMessage,
   confirmCocosAccountRegistration,
   confirmCocosPasswordRecovery,
   clearCurrentCocosAuthSession,
@@ -902,6 +904,103 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
   });
   assert.ok(values.get("project-veil:auth-session")?.includes("\"loginId\":\"veil-ranger\""));
   assert.equal(values.get(getCocosPlayerAccountStorageKey("account-player")), "暮潮守望");
+});
+
+test("loadCocosPlayerAccountProfile preserves mailbox payload and summary from /me", async () => {
+  const profile = await loadCocosPlayerAccountProfile("http://127.0.0.1:2567", "account-player", "room-beta", {
+    authSession: {
+      token: "account.token",
+      playerId: "account-player",
+      displayName: "暮潮守望",
+      authMode: "account",
+      source: "remote"
+    },
+    fetchImpl: async (input) => {
+      const url = String(input);
+      if (url.endsWith("/api/player-accounts/me")) {
+        return new Response(
+          JSON.stringify({
+            account: {
+              playerId: "account-player",
+              displayName: "暮潮守望",
+              globalResources: { gold: 10, wood: 0, ore: 0 },
+              achievements: [],
+              recentEventLog: [],
+              mailbox: [
+                {
+                  id: "comp-1",
+                  kind: "compensation",
+                  title: "停机补偿",
+                  body: "补发资源。",
+                  sentAt: "2026-04-05T00:00:00.000Z",
+                  expiresAt: "2026-04-12T00:00:00.000Z",
+                  grant: {
+                    gems: 30,
+                    resources: { gold: 120 }
+                  }
+                }
+              ],
+              mailboxSummary: {
+                totalCount: 1,
+                unreadCount: 1,
+                claimableCount: 1,
+                expiredCount: 0
+              }
+            }
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+
+      return new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+  });
+
+  assert.equal(profile.mailbox?.[0]?.id, "comp-1");
+  assert.equal(profile.mailboxSummary?.claimableCount, 1);
+});
+
+test("mailbox claim helpers target the authenticated /me endpoints", async () => {
+  const requestedUrls: string[] = [];
+  const authSession = {
+    token: "account.token",
+    playerId: "account-player",
+    displayName: "暮潮守望",
+    authMode: "account" as const,
+    source: "remote" as const
+  };
+
+  const claimPayload = await claimCocosMailboxMessage("http://127.0.0.1:2567", "comp-1", {
+    authSession,
+    fetchImpl: async (input) => {
+      requestedUrls.push(String(input));
+      return new Response(JSON.stringify({ claimed: true, items: [], summary: { totalCount: 1, unreadCount: 0, claimableCount: 0, expiredCount: 0 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+  });
+
+  const claimAllPayload = await claimAllCocosMailboxMessages("http://127.0.0.1:2567", {
+    authSession,
+    fetchImpl: async (input) => {
+      requestedUrls.push(String(input));
+      return new Response(JSON.stringify({ claimed: true, claimedMessageIds: ["comp-1"], items: [], summary: { totalCount: 1, unreadCount: 0, claimableCount: 0, expiredCount: 0 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+  });
+
+  assert.equal(claimPayload.claimed, true);
+  assert.equal(claimAllPayload.claimed, true);
+  assert.deepEqual(requestedUrls, [
+    "http://127.0.0.1:2567/api/player-accounts/me/mailbox/comp-1/claim",
+    "http://127.0.0.1:2567/api/player-accounts/me/mailbox/claim-all"
+  ]);
 });
 
 test("loadCocosPlayerEventLog sends shared filters through the public query route", async () => {

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -62,6 +62,14 @@ import {
 } from "./battle-pass";
 import { applySeasonSoftDecay, decayDivisionToRating, getCurrentAndPreviousWeeklyEntries, resolveCompetitiveProgression } from "./competitive-season";
 import { computeSeasonReward, resolveSeasonRewardConfig } from "./season-rewards";
+import {
+  claimAllPlayerMailboxMessages,
+  claimPlayerMailboxMessage,
+  createMailboxClaimEventLogEntry,
+  deliverPlayerMailboxMessage,
+  normalizePlayerMailboxMessage,
+  pruneExpiredPlayerMailboxMessages
+} from "./player-mailbox";
 
 function cloneAccount(account: PlayerAccountSnapshot): PlayerAccountSnapshot {
   return structuredClone(account);
@@ -333,6 +341,8 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       ...(existing?.seasonPassClaimedTiers?.length ? { seasonPassClaimedTiers: [...existing.seasonPassClaimedTiers] } : {}),
       ...(existing?.seasonBadges?.length ? { seasonBadges: [...existing.seasonBadges] } : {}),
       ...(existing?.campaignProgress ? { campaignProgress: structuredClone(existing.campaignProgress) } : {}),
+      ...(existing?.seasonalEventStates ? { seasonalEventStates: structuredClone(existing.seasonalEventStates) } : {}),
+      ...(existing?.mailbox ? { mailbox: structuredClone(existing.mailbox) } : {}),
       globalResources: existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 },
       achievements: existing?.achievements ?? [],
       recentEventLog: existing?.recentEventLog ?? [],
@@ -450,6 +460,118 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       referrerId: normalizedReferrerId,
       newPlayerId: normalizedNewPlayerId
     };
+  }
+
+  async deliverPlayerMailbox(input: import("./player-mailbox").PlayerMailboxDeliveryInput) {
+    const message = normalizePlayerMailboxMessage(input.message);
+    const deliveredPlayerIds: string[] = [];
+    const skippedPlayerIds: string[] = [];
+
+    for (const playerId of Array.from(new Set(input.playerIds.map((entry) => normalizePlayerId(entry))))) {
+      const account = await this.ensurePlayerAccount({ playerId });
+      const result = deliverPlayerMailboxMessage(account.mailbox, message);
+      if (!result.delivered) {
+        skippedPlayerIds.push(playerId);
+        continue;
+      }
+
+      this.accounts.set(
+        playerId,
+        cloneAccount({
+          ...account,
+          mailbox: structuredClone(result.mailbox),
+          updatedAt: new Date().toISOString()
+        })
+      );
+      deliveredPlayerIds.push(playerId);
+    }
+
+    return { deliveredPlayerIds, skippedPlayerIds, message };
+  }
+
+  async claimPlayerMailboxMessage(playerId: string, messageId: string, claimedAt?: string) {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const account = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const now = claimedAt ? new Date(claimedAt) : new Date();
+    if (Number.isNaN(now.getTime())) {
+      throw new Error("claimedAt must be a valid ISO timestamp");
+    }
+
+    const result = claimPlayerMailboxMessage(account.mailbox, messageId, now);
+    if (!result.claimed || !result.message || !result.granted) {
+      return result;
+    }
+
+    const eventEntry = createMailboxClaimEventLogEntry(normalizedPlayerId, result.message, result.granted, result.message.claimedAt ?? now.toISOString());
+    this.accounts.set(
+      normalizedPlayerId,
+      cloneAccount({
+        ...account,
+        gems: (account.gems ?? 0) + result.granted.gems,
+        seasonPassPremium: account.seasonPassPremium === true || result.granted.seasonPassPremium,
+        mailbox: structuredClone(result.mailbox),
+        globalResources: {
+          gold: (account.globalResources.gold ?? 0) + result.granted.resources.gold,
+          wood: (account.globalResources.wood ?? 0) + result.granted.resources.wood,
+          ore: (account.globalResources.ore ?? 0) + result.granted.resources.ore
+        },
+        recentEventLog: appendEventLogEntries(account.recentEventLog, [eventEntry]),
+        updatedAt: now.toISOString()
+      })
+    );
+    return result;
+  }
+
+  async claimAllPlayerMailboxMessages(playerId: string, claimedAt?: string) {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const account = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const now = claimedAt ? new Date(claimedAt) : new Date();
+    if (Number.isNaN(now.getTime())) {
+      throw new Error("claimedAt must be a valid ISO timestamp");
+    }
+
+    const result = claimAllPlayerMailboxMessages(account.mailbox, now);
+    if (!result.claimed) {
+      return result;
+    }
+
+    const eventEntries = result.claimedMessageIds
+      .map((messageId, index) => {
+        const message = result.mailbox.find((entry) => entry.id === messageId);
+        const granted = result.granted[index];
+        return message && granted
+          ? createMailboxClaimEventLogEntry(normalizedPlayerId, message, granted, message.claimedAt ?? now.toISOString())
+          : null;
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+    const totalGrant = result.granted.reduce(
+      (accumulator, grant) => ({
+        gems: accumulator.gems + grant.gems,
+        gold: accumulator.gold + grant.resources.gold,
+        wood: accumulator.wood + grant.resources.wood,
+        ore: accumulator.ore + grant.resources.ore,
+        seasonPassPremium: accumulator.seasonPassPremium || grant.seasonPassPremium
+      }),
+      { gems: 0, gold: 0, wood: 0, ore: 0, seasonPassPremium: false }
+    );
+
+    this.accounts.set(
+      normalizedPlayerId,
+      cloneAccount({
+        ...account,
+        gems: (account.gems ?? 0) + totalGrant.gems,
+        seasonPassPremium: account.seasonPassPremium === true || totalGrant.seasonPassPremium,
+        mailbox: structuredClone(result.mailbox),
+        globalResources: {
+          gold: (account.globalResources.gold ?? 0) + totalGrant.gold,
+          wood: (account.globalResources.wood ?? 0) + totalGrant.wood,
+          ore: (account.globalResources.ore ?? 0) + totalGrant.ore
+        },
+        recentEventLog: appendEventLogEntries(account.recentEventLog, eventEntries),
+        updatedAt: now.toISOString()
+      })
+    );
+    return result;
   }
 
   async createPaymentOrder(input: PaymentOrderCreateInput): Promise<PaymentOrderSnapshot> {
@@ -1118,6 +1240,13 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         : existing.campaignProgress
           ? { campaignProgress: structuredClone(existing.campaignProgress) }
           : {}),
+      ...(patch.mailbox !== undefined
+        ? patch.mailbox
+          ? { mailbox: structuredClone(patch.mailbox) }
+          : {}
+        : existing.mailbox
+          ? { mailbox: structuredClone(existing.mailbox) }
+          : {}),
       globalResources: structuredClone(
         (patch.globalResources as PlayerAccountSnapshot["globalResources"] | undefined) ?? existing.globalResources
       ),
@@ -1349,7 +1478,24 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   }
 
   async pruneExpired(): Promise<number> {
-    return 0;
+    let removedCount = 0;
+    const now = new Date();
+    for (const [playerId, account] of this.accounts.entries()) {
+      const pruned = pruneExpiredPlayerMailboxMessages(account.mailbox, now);
+      if (pruned.removedCount === 0) {
+        continue;
+      }
+      removedCount += pruned.removedCount;
+      this.accounts.set(
+        playerId,
+        cloneAccount({
+          ...account,
+          mailbox: pruned.mailbox,
+          updatedAt: now.toISOString()
+        })
+      );
+    }
+    return removedCount;
   }
 
   async getCurrentSeason(): Promise<import("./persistence").SeasonSnapshot | null> {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -21,6 +21,7 @@ import {
   type EventLogQuery,
   type CosmeticId,
   normalizeHeroState,
+  summarizePlayerMailbox,
   type EventLogEntry,
   type EquipmentId,
   type GuildState,
@@ -29,6 +30,7 @@ import {
   type PlayerAccountReadModel,
   type PlayerBattleReplaySummary,
   type PlayerAchievementProgress,
+  type PlayerMailboxMessage,
   type RankedWeeklyProgress,
   type ResourceLedger,
   type SeasonalEventState,
@@ -36,6 +38,19 @@ import {
   type WorldState
 } from "../../../packages/shared/src/index";
 import type { RoomPersistenceSnapshot } from "./index";
+import {
+  claimAllPlayerMailboxMessages,
+  claimPlayerMailboxMessage,
+  createMailboxClaimEventLogEntry,
+  deliverPlayerMailboxMessage,
+  normalizePlayerMailboxGrant,
+  normalizePlayerMailboxMessage,
+  pruneExpiredPlayerMailboxMessages,
+  type PlayerMailboxClaimAllResult,
+  type PlayerMailboxClaimResult,
+  type PlayerMailboxDeliveryInput,
+  type PlayerMailboxDeliveryResult
+} from "./player-mailbox";
 import {
   applyBattlePassXp,
   resolveBattlePassConfig,
@@ -111,6 +126,9 @@ export interface RoomSnapshotStore {
   creditGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
   debitGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
   claimPlayerReferral?(referrerId: string, newPlayerId: string, rewardGems: number): Promise<PlayerReferralClaimResult>;
+  deliverPlayerMailbox?(input: PlayerMailboxDeliveryInput): Promise<PlayerMailboxDeliveryResult>;
+  claimPlayerMailboxMessage?(playerId: string, messageId: string, claimedAt?: string): Promise<PlayerMailboxClaimResult>;
+  claimAllPlayerMailboxMessages?(playerId: string, claimedAt?: string): Promise<PlayerMailboxClaimAllResult>;
   claimBattlePassTier?(playerId: string, tier: number): Promise<BattlePassClaimResult>;
   purchaseShopProduct?(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult>;
   savePlayerAccountPrivacyConsent(
@@ -221,6 +239,7 @@ interface PlayerAccountRow extends RowDataPacket {
   season_badges_json: string | string[] | null;
   campaign_progress_json: string | PlayerAccountSnapshot["campaignProgress"] | null;
   seasonal_event_states_json: string | PlayerAccountSnapshot["seasonalEventStates"] | null;
+  mailbox_json: string | PlayerAccountSnapshot["mailbox"] | null;
   global_resources_json: string | ResourceLedger;
   achievements_json: string | PlayerAchievementProgress[] | null;
   cosmetic_inventory_json: string | PlayerAccountSnapshot["cosmeticInventory"] | null;
@@ -385,6 +404,7 @@ export interface PlayerRoomProfileSnapshot {
 
 export interface PlayerAccountSnapshot extends PlayerAccountReadModel {
   recentBattleReplays?: PlayerBattleReplaySummary[];
+  mailbox?: PlayerMailboxMessage[];
   accountSessionVersion?: number;
   refreshSessionId?: string;
   refreshTokenExpiresAt?: string;
@@ -588,6 +608,7 @@ export interface PlayerAccountProgressPatch {
   recentEventLog?: Partial<EventLogEntry>[] | null;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null;
   dailyDungeonState?: PlayerAccountSnapshot["dailyDungeonState"] | null;
+  mailbox?: PlayerAccountSnapshot["mailbox"] | null;
   tutorialStep?: number | null;
   dailyPlayMinutes?: number | null;
   lastPlayDate?: string | null;
@@ -979,6 +1000,148 @@ function createBattlePassClaimEventLogEntry(playerId: string, input: {
   };
 }
 
+async function applyMailboxClaimsToAccount(
+  connection: PoolConnection,
+  currentAccount: PlayerAccountSnapshot,
+  input: {
+    playerId: string;
+    mailbox: PlayerMailboxMessage[];
+    claims: Array<{
+      message: PlayerMailboxMessage;
+      granted: ReturnType<typeof normalizePlayerMailboxGrant>;
+    }>;
+  }
+): Promise<void> {
+  if (input.claims.length === 0) {
+    return;
+  }
+
+  const nextMailbox = input.mailbox;
+  const totalGrant = input.claims.reduce(
+    (accumulator, claim) => ({
+      gems: accumulator.gems + claim.granted.gems,
+      resources: addResourceLedgers(accumulator.resources, claim.granted.resources),
+      equipmentIds: [...accumulator.equipmentIds, ...claim.granted.equipmentIds],
+      cosmeticIds: [...accumulator.cosmeticIds, ...claim.granted.cosmeticIds],
+      seasonPassPremium: accumulator.seasonPassPremium || claim.granted.seasonPassPremium
+    }),
+    {
+      gems: 0,
+      resources: normalizeResourceLedger(),
+      equipmentIds: [] as EquipmentId[],
+      cosmeticIds: [] as CosmeticId[],
+      seasonPassPremium: false
+    }
+  );
+
+  let nextHeroArchive: PlayerHeroArchiveSnapshot | null = null;
+  if (totalGrant.equipmentIds.length > 0) {
+    const [heroArchiveRows] = await connection.query<PlayerHeroArchiveRow[]>(
+      `SELECT player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, inventory_json, updated_at
+       FROM \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
+       WHERE player_id = ?
+       ORDER BY updated_at DESC, hero_id ASC
+       LIMIT 1
+       FOR UPDATE`,
+      [input.playerId]
+    );
+    const currentArchive = heroArchiveRows[0] ? toPlayerHeroArchiveSnapshot(heroArchiveRows[0]) : null;
+    if (!currentArchive) {
+      throw new Error("player hero archive not found");
+    }
+
+    let nextInventory = [...currentArchive.hero.loadout.inventory];
+    for (const equipmentId of totalGrant.equipmentIds) {
+      const inventoryUpdate = tryAddEquipmentToInventory(nextInventory, equipmentId);
+      if (!inventoryUpdate.stored) {
+        throw new Error("equipment inventory full");
+      }
+      nextInventory = inventoryUpdate.inventory;
+    }
+
+    nextHeroArchive = {
+      ...currentArchive,
+      hero: normalizeHeroState({
+        ...currentArchive.hero,
+        loadout: {
+          ...currentArchive.hero.loadout,
+          inventory: nextInventory
+        }
+      })
+    };
+  }
+
+  const eventEntries = input.claims.map((claim) =>
+    createMailboxClaimEventLogEntry(input.playerId, claim.message, claim.granted, claim.message.claimedAt ?? new Date().toISOString())
+  );
+  const nextRecentEventLog = appendEventLogEntries(currentAccount.recentEventLog, eventEntries);
+  const nextGlobalResources = addResourceLedgers(currentAccount.globalResources, totalGrant.resources);
+  const nextGems = normalizeGemAmount(currentAccount.gems) + totalGrant.gems;
+  const nextSeasonPassPremium = currentAccount.seasonPassPremium === true || totalGrant.seasonPassPremium;
+  const nextCosmeticInventory = applyOwnedCosmetics(currentAccount.cosmeticInventory, totalGrant.cosmeticIds);
+
+  await connection.query(
+    `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+     SET gems = ?,
+         season_pass_premium = ?,
+         cosmetic_inventory_json = ?,
+         global_resources_json = ?,
+         recent_event_log_json = ?,
+         mailbox_json = ?,
+         version = version + 1
+     WHERE player_id = ?`,
+    [
+      nextGems,
+      nextSeasonPassPremium ? 1 : 0,
+      JSON.stringify(nextCosmeticInventory),
+      JSON.stringify(nextGlobalResources),
+      JSON.stringify(nextRecentEventLog),
+      JSON.stringify(nextMailbox),
+      input.playerId
+    ]
+  );
+
+  for (const claim of input.claims) {
+    if (claim.granted.gems > 0) {
+      await appendGemLedgerEntry(connection, {
+        entryId: randomUUID(),
+        playerId: input.playerId,
+        delta: claim.granted.gems,
+        reason: "reward",
+        refId: `mailbox:${claim.message.id}`
+      });
+    }
+  }
+
+  if (nextHeroArchive) {
+    await connection.query(
+      `INSERT INTO \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
+         (player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, inventory_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         hero_json = VALUES(hero_json),
+         army_template_id = VALUES(army_template_id),
+         army_count = VALUES(army_count),
+         learned_skills_json = VALUES(learned_skills_json),
+         equipment_json = VALUES(equipment_json),
+         inventory_json = VALUES(inventory_json),
+         updated_at = CURRENT_TIMESTAMP`,
+      [
+        nextHeroArchive.playerId,
+        nextHeroArchive.heroId,
+        JSON.stringify(nextHeroArchive.hero),
+        nextHeroArchive.hero.armyTemplateId,
+        nextHeroArchive.hero.armyCount,
+        JSON.stringify(nextHeroArchive.hero.loadout.learnedSkills),
+        JSON.stringify(nextHeroArchive.hero.loadout.equipment),
+        JSON.stringify(nextHeroArchive.hero.loadout.inventory)
+      ]
+    );
+  }
+
+  await appendPlayerEventHistoryEntries(connection, input.playerId, eventEntries);
+}
+
 function applyOwnedCosmetics(
   current: PlayerAccountSnapshot["cosmeticInventory"],
   grantedIds: CosmeticId[]
@@ -1302,6 +1465,7 @@ function normalizePlayerAccountSnapshot(account: {
   seasonBadges?: string[] | null | undefined;
   campaignProgress?: PlayerAccountSnapshot["campaignProgress"] | null | undefined;
   seasonalEventStates?: PlayerAccountSnapshot["seasonalEventStates"] | null | undefined;
+  mailbox?: PlayerAccountSnapshot["mailbox"] | null | undefined;
   globalResources?: Partial<ResourceLedger>;
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
@@ -1364,6 +1528,7 @@ function normalizePlayerAccountSnapshot(account: {
       seasonBadges: account.seasonBadges,
       campaignProgress: account.campaignProgress,
       seasonalEventStates: account.seasonalEventStates,
+      mailbox: account.mailbox,
       globalResources: normalizeResourceLedger(account.globalResources),
       achievements: account.achievements,
       recentEventLog: account.recentEventLog,
@@ -1672,6 +1837,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   season_badges_json LONGTEXT NULL,
   campaign_progress_json LONGTEXT NULL,
   seasonal_event_states_json LONGTEXT NULL,
+  mailbox_json LONGTEXT NULL,
   global_resources_json LONGTEXT NOT NULL,
   achievements_json LONGTEXT NULL,
   recent_event_log_json LONGTEXT NULL,
@@ -2115,6 +2281,22 @@ SET @veil_player_accounts_seasonal_event_states_sql := IF(
 PREPARE veil_player_accounts_seasonal_event_states_stmt FROM @veil_player_accounts_seasonal_event_states_sql;
 EXECUTE veil_player_accounts_seasonal_event_states_stmt;
 DEALLOCATE PREPARE veil_player_accounts_seasonal_event_states_stmt;
+
+SET @veil_player_accounts_mailbox_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'mailbox_json'
+);
+SET @veil_player_accounts_mailbox_sql := IF(
+  @veil_player_accounts_mailbox_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`mailbox_json\` LONGTEXT NULL AFTER \`seasonal_event_states_json\`',
+  'SELECT 1'
+);
+PREPARE veil_player_accounts_mailbox_stmt FROM @veil_player_accounts_mailbox_sql;
+EXECUTE veil_player_accounts_mailbox_stmt;
+DEALLOCATE PREPARE veil_player_accounts_mailbox_stmt;
 
 SET @veil_player_accounts_event_log_exists := (
   SELECT COUNT(*)
@@ -3021,6 +3203,10 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
       row.seasonal_event_states_json != null
         ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["seasonalEventStates"]>>(row.seasonal_event_states_json)
         : undefined,
+    mailbox:
+      row.mailbox_json != null
+        ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["mailbox"]>>(row.mailbox_json)
+        : undefined,
     cosmeticInventory:
       row.cosmetic_inventory_json != null
         ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["cosmeticInventory"]>>(row.cosmetic_inventory_json)
@@ -3329,6 +3515,7 @@ async function savePlayerAccounts(
          season_badges_json,
          campaign_progress_json,
          seasonal_event_states_json,
+         mailbox_json,
          cosmetic_inventory_json,
          equipped_cosmetics_json,
          global_resources_json,
@@ -3340,7 +3527,7 @@ async function savePlayerAccounts(
          tutorial_step,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = COALESCE(display_name, VALUES(display_name)),
          elo_rating = COALESCE(elo_rating, VALUES(elo_rating)),
@@ -3357,8 +3544,9 @@ async function savePlayerAccounts(
          season_pass_claimed_tiers_json = VALUES(season_pass_claimed_tiers_json),
          season_badges_json = COALESCE(season_badges_json, VALUES(season_badges_json)),
          campaign_progress_json = COALESCE(campaign_progress_json, VALUES(campaign_progress_json)),
-        seasonal_event_states_json = COALESCE(seasonal_event_states_json, VALUES(seasonal_event_states_json)),
-        cosmetic_inventory_json = COALESCE(cosmetic_inventory_json, VALUES(cosmetic_inventory_json)),
+         seasonal_event_states_json = COALESCE(seasonal_event_states_json, VALUES(seasonal_event_states_json)),
+         mailbox_json = COALESCE(mailbox_json, VALUES(mailbox_json)),
+         cosmetic_inventory_json = COALESCE(cosmetic_inventory_json, VALUES(cosmetic_inventory_json)),
         equipped_cosmetics_json = COALESCE(equipped_cosmetics_json, VALUES(equipped_cosmetics_json)),
         global_resources_json = VALUES(global_resources_json),
          achievements_json = COALESCE(achievements_json, VALUES(achievements_json)),
@@ -3386,6 +3574,7 @@ async function savePlayerAccounts(
         JSON.stringify(normalizedAccount.seasonBadges ?? []),
         JSON.stringify(normalizedAccount.campaignProgress ?? null),
         JSON.stringify(normalizedAccount.seasonalEventStates ?? null),
+        JSON.stringify(normalizedAccount.mailbox ?? null),
         JSON.stringify(normalizedAccount.cosmeticInventory ?? { ownedIds: [] }),
         JSON.stringify(normalizedAccount.equippedCosmetics ?? {}),
         JSON.stringify(normalizedAccount.globalResources),
@@ -3684,6 +3873,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_badges_json,
          campaign_progress_json,
          seasonal_event_states_json,
+         mailbox_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3748,6 +3938,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_badges_json,
          campaign_progress_json,
          seasonal_event_states_json,
+         mailbox_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -3896,6 +4087,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_badges_json,
          campaign_progress_json,
          seasonal_event_states_json,
+         mailbox_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -4093,6 +4285,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_badges_json,
          campaign_progress_json,
          seasonal_event_states_json,
+         mailbox_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -4473,6 +4666,147 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         rewardGems: normalizedRewardGems,
         referrerId: normalizedReferrerId,
         newPlayerId: normalizedNewPlayerId
+      };
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async deliverPlayerMailbox(input: PlayerMailboxDeliveryInput): Promise<PlayerMailboxDeliveryResult> {
+    const playerIds = Array.from(new Set(input.playerIds.map((playerId) => normalizePlayerId(playerId)).filter(Boolean)));
+    if (playerIds.length === 0) {
+      throw new Error("playerIds must not be empty");
+    }
+
+    const message = normalizePlayerMailboxMessage(input.message);
+    const deliveredPlayerIds: string[] = [];
+    const skippedPlayerIds: string[] = [];
+
+    for (const playerId of playerIds) {
+      const account = await this.ensurePlayerAccount({ playerId });
+      const mailboxResult = deliverPlayerMailboxMessage(account.mailbox, message);
+      if (!mailboxResult.delivered) {
+        skippedPlayerIds.push(playerId);
+        continue;
+      }
+
+      await this.savePlayerAccountProgress(playerId, {
+        mailbox: mailboxResult.mailbox
+      });
+      deliveredPlayerIds.push(playerId);
+    }
+
+    return {
+      deliveredPlayerIds,
+      skippedPlayerIds,
+      message
+    };
+  }
+
+  async claimPlayerMailboxMessage(
+    playerId: string,
+    messageId: string,
+    claimedAt?: string
+  ): Promise<PlayerMailboxClaimResult> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const claimedAtDate = claimedAt ? new Date(claimedAt) : new Date();
+    if (Number.isNaN(claimedAtDate.getTime())) {
+      throw new Error("claimedAt must be a valid ISO timestamp");
+    }
+
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+      const [rows] = await connection.query<PlayerAccountRow[]>(
+        `SELECT *
+         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         WHERE player_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [normalizedPlayerId]
+      );
+      const currentAccount = rows[0] ? toPlayerAccountSnapshot(rows[0]) : null;
+      if (!currentAccount) {
+        throw new Error("player account not found");
+      }
+
+      const result = claimPlayerMailboxMessage(currentAccount.mailbox, messageId, claimedAtDate);
+      if (!result.claimed || !result.message || !result.granted) {
+        await connection.commit();
+        return result;
+      }
+
+      await applyMailboxClaimsToAccount(connection, currentAccount, {
+        playerId: normalizedPlayerId,
+        mailbox: result.mailbox,
+        claims: [{ message: result.message, granted: result.granted }]
+      });
+      await connection.commit();
+      return {
+        ...result,
+        mailbox: (await this.loadPlayerAccount(normalizedPlayerId))?.mailbox ?? result.mailbox,
+        summary: summarizePlayerMailbox((await this.loadPlayerAccount(normalizedPlayerId))?.mailbox ?? result.mailbox)
+      };
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async claimAllPlayerMailboxMessages(playerId: string, claimedAt?: string): Promise<PlayerMailboxClaimAllResult> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const claimedAtDate = claimedAt ? new Date(claimedAt) : new Date();
+    if (Number.isNaN(claimedAtDate.getTime())) {
+      throw new Error("claimedAt must be a valid ISO timestamp");
+    }
+
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+      const [rows] = await connection.query<PlayerAccountRow[]>(
+        `SELECT *
+         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         WHERE player_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [normalizedPlayerId]
+      );
+      const currentAccount = rows[0] ? toPlayerAccountSnapshot(rows[0]) : null;
+      if (!currentAccount) {
+        throw new Error("player account not found");
+      }
+
+      const result = claimAllPlayerMailboxMessages(currentAccount.mailbox, claimedAtDate);
+      if (!result.claimed) {
+        await connection.commit();
+        return result;
+      }
+
+      const claimedMessages = result.claimedMessageIds
+        .map((messageId) => result.mailbox.find((entry) => entry.id === messageId))
+        .filter((message): message is PlayerMailboxMessage => Boolean(message))
+        .map((message, index) => ({
+          message,
+          granted: result.granted[index] ?? normalizePlayerMailboxGrant(message.grant)
+        }));
+
+      await applyMailboxClaimsToAccount(connection, currentAccount, {
+        playerId: normalizedPlayerId,
+        mailbox: result.mailbox,
+        claims: claimedMessages
+      });
+      await connection.commit();
+      return {
+        ...result,
+        mailbox: (await this.loadPlayerAccount(normalizedPlayerId))?.mailbox ?? result.mailbox,
+        summary: summarizePlayerMailbox((await this.loadPlayerAccount(normalizedPlayerId))?.mailbox ?? result.mailbox)
       };
     } catch (error) {
       await connection.rollback();
@@ -5462,6 +5796,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_pass_claimed_tiers_json,
          season_badges_json,
          campaign_progress_json,
+         seasonal_event_states_json,
+         mailbox_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -5473,7 +5809,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number,
          phone_number_bound_at
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = VALUES(avatar_url),
@@ -5491,6 +5827,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_badges_json = COALESCE(season_badges_json, VALUES(season_badges_json)),
          campaign_progress_json = COALESCE(campaign_progress_json, VALUES(campaign_progress_json)),
          seasonal_event_states_json = COALESCE(seasonal_event_states_json, VALUES(seasonal_event_states_json)),
+         mailbox_json = COALESCE(mailbox_json, VALUES(mailbox_json)),
          global_resources_json = VALUES(global_resources_json),
          achievements_json = VALUES(achievements_json),
          recent_event_log_json = VALUES(recent_event_log_json),
@@ -5521,6 +5858,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.seasonBadges ?? []),
         JSON.stringify(nextAccount.campaignProgress ?? null),
         JSON.stringify(nextAccount.seasonalEventStates ?? null),
+        JSON.stringify(nextAccount.mailbox ?? null),
         JSON.stringify(nextAccount.globalResources),
         JSON.stringify(nextAccount.achievements),
         JSON.stringify(nextAccount.recentEventLog),
@@ -5575,6 +5913,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       seasonBadges: patch.seasonBadges ?? existing.seasonBadges,
       campaignProgress: patch.campaignProgress ?? existing.campaignProgress,
       seasonalEventStates: patch.seasonalEventStates ?? existing.seasonalEventStates,
+      mailbox: patch.mailbox ?? existing.mailbox,
       globalResources: patch.globalResources ?? existing.globalResources,
       achievements: patch.achievements ?? existing.achievements,
       recentEventLog: patch.recentEventLog ?? existing.recentEventLog,
@@ -5623,6 +5962,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_badges_json,
          campaign_progress_json,
          seasonal_event_states_json,
+         mailbox_json,
          cosmetic_inventory_json,
          equipped_cosmetics_json,
          global_resources_json,
@@ -5639,7 +5979,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_play_date,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = COALESCE(avatar_url, VALUES(avatar_url)),
@@ -5653,6 +5993,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          cosmetic_inventory_json = VALUES(cosmetic_inventory_json),
          equipped_cosmetics_json = VALUES(equipped_cosmetics_json),
          seasonal_event_states_json = VALUES(seasonal_event_states_json),
+         mailbox_json = VALUES(mailbox_json),
          elo_rating = VALUES(elo_rating),
          rank_division = VALUES(rank_division),
          peak_rank_division = VALUES(peak_rank_division),
@@ -5693,6 +6034,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.seasonBadges ?? []),
         JSON.stringify(nextAccount.campaignProgress ?? null),
         JSON.stringify(nextAccount.seasonalEventStates ?? null),
+        JSON.stringify(nextAccount.mailbox ?? null),
         JSON.stringify(nextAccount.cosmeticInventory ?? { ownedIds: [] }),
         JSON.stringify(nextAccount.equippedCosmetics ?? {}),
         JSON.stringify(nextAccount.globalResources),
@@ -5753,6 +6095,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          season_badges_json,
          campaign_progress_json,
          seasonal_event_states_json,
+         mailbox_json,
          global_resources_json,
          achievements_json,
          recent_event_log_json,
@@ -5922,12 +6265,13 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
   }
 
   async pruneExpired(referenceTime = new Date()): Promise<number> {
-    const [roomCount, profileCount] = await Promise.all([
+    const [roomCount, profileCount, mailboxCount] = await Promise.all([
       this.pruneExpiredRoomSnapshots(referenceTime),
-      this.pruneExpiredPlayerProfiles(referenceTime)
+      this.pruneExpiredPlayerProfiles(referenceTime),
+      this.pruneExpiredPlayerMailboxEntries(referenceTime)
     ]);
 
-    return roomCount + profileCount;
+    return roomCount + profileCount + mailboxCount;
   }
 
   async pruneExpiredRoomSnapshots(referenceTime = new Date()): Promise<number> {
@@ -5958,6 +6302,34 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     );
 
     return profileResult.affectedRows;
+  }
+
+  async pruneExpiredPlayerMailboxEntries(referenceTime = new Date()): Promise<number> {
+    const [rows] = await this.pool.query<Array<RowDataPacket & { player_id: string; mailbox_json: string | null }>>(
+      `SELECT player_id, mailbox_json
+       FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+       WHERE mailbox_json IS NOT NULL`
+    );
+
+    let removedCount = 0;
+    for (const row of rows) {
+      const mailbox = row.mailbox_json ? parseJsonColumn<PlayerMailboxMessage[]>(row.mailbox_json) : [];
+      const pruned = pruneExpiredPlayerMailboxMessages(mailbox, referenceTime);
+      if (pruned.removedCount === 0) {
+        continue;
+      }
+
+      removedCount += pruned.removedCount;
+      await this.pool.query(
+        `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         SET mailbox_json = ?,
+             version = version + 1
+         WHERE player_id = ?`,
+        [JSON.stringify(pruned.mailbox), row.player_id]
+      );
+    }
+
+    return removedCount;
   }
 
   async listSnapshots(limit = 20, referenceTime = new Date()): Promise<RoomSnapshotSummary[]> {

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -14,6 +14,7 @@ import {
   queryPlayerBattleReplaySummaries,
   queryAchievementProgress,
   queryEventLogEntries,
+  summarizePlayerMailbox,
   type PlayerBattleReplaySummary,
   type SeasonalEventState,
   type TutorialProgressAction
@@ -58,6 +59,7 @@ import {
   startDailyDungeonRun
 } from "./pve-content";
 import { decryptWechatPhoneNumber, validateWechatSignature } from "./wechat-session-key";
+import { normalizePlayerMailboxMessage } from "./player-mailbox";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -109,6 +111,11 @@ function sendWechatValidationForbidden(response: ServerResponse, message = "WeCh
       message
     }
   });
+}
+
+function isAdminAuthorized(request: IncomingMessage): boolean {
+  const adminToken = process.env.VEIL_ADMIN_TOKEN?.trim();
+  return Boolean(adminToken) && request.headers["x-veil-admin-token"] === adminToken;
 }
 
 function validateWechatSignatureEnvelope(
@@ -489,6 +496,14 @@ function toRewardMutation(account: PlayerAccountSnapshot, reward?: { gems?: numb
   };
 }
 
+function toMailboxResponse(account: PlayerAccountSnapshot, now = new Date()) {
+  const mailbox = account.mailbox ?? [];
+  return {
+    items: mailbox,
+    summary: summarizePlayerMailbox(mailbox, now)
+  };
+}
+
 function upsertSeasonalEventState(
   seasonalEventStates: SeasonalEventState[] | undefined,
   nextState: SeasonalEventState
@@ -702,6 +717,8 @@ function toPublicPlayerAccount(
   | "banStatus"
   | "banExpiry"
   | "banReason"
+  | "mailbox"
+  | "mailboxSummary"
 > {
   const {
     loginId: _loginId,
@@ -713,6 +730,8 @@ function toPublicPlayerAccount(
     banStatus: _banStatus,
     banExpiry: _banExpiry,
     banReason: _banReason,
+    mailbox: _mailbox,
+    mailboxSummary: _mailboxSummary,
     ...publicAccount
   } = account;
   return publicAccount;
@@ -731,7 +750,7 @@ export function registerPlayerAccountRoutes(
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
     response.setHeader("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
-    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth, X-Veil-Admin-Token");
 
     if (request.method === "OPTIONS") {
       response.statusCode = 204;
@@ -803,6 +822,195 @@ export function registerPlayerAccountRoutes(
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/me/mailbox", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 200, { items: [], summary: { totalCount: 0, unreadCount: 0, claimableCount: 0, expiredCount: 0 } });
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      sendJson(response, 200, toMailboxResponse(account));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/player-accounts/me/mailbox/:messageId/claim", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    const messageId = request.params.messageId?.trim();
+    if (!messageId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store?.claimPlayerMailboxMessage) {
+      sendJson(response, 503, {
+        error: {
+          code: "mailbox_persistence_unavailable",
+          message: "Mailbox claims require configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const result = await store.claimPlayerMailboxMessage(authSession.playerId, messageId, new Date().toISOString());
+      if (result.reason === "not_found") {
+        sendJson(response, 404, {
+          error: {
+            code: "mailbox_message_not_found",
+            message: "Mailbox message was not found"
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, {
+        claimed: result.claimed,
+        ...(result.reason ? { reason: result.reason } : {}),
+        ...(result.message ? { message: result.message } : {}),
+        summary: result.summary,
+        items: result.mailbox
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/player-accounts/me/mailbox/claim-all", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store?.claimAllPlayerMailboxMessages) {
+      sendJson(response, 503, {
+        error: {
+          code: "mailbox_persistence_unavailable",
+          message: "Mailbox claims require configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const result = await store.claimAllPlayerMailboxMessages(authSession.playerId, new Date().toISOString());
+      sendJson(response, 200, {
+        claimed: result.claimed,
+        claimedMessageIds: result.claimedMessageIds,
+        summary: result.summary,
+        items: result.mailbox
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/admin/player-mailbox/deliver", async (request, response) => {
+    const adminToken = process.env.VEIL_ADMIN_TOKEN?.trim();
+    if (!adminToken) {
+      sendJson(response, 503, {
+        error: {
+          code: "not_configured",
+          message: "Admin token not configured"
+        }
+      });
+      return;
+    }
+
+    if (!isAdminAuthorized(request)) {
+      sendJson(response, 403, {
+        error: {
+          code: "forbidden",
+          message: "Invalid admin token"
+        }
+      });
+      return;
+    }
+
+    if (!store?.deliverPlayerMailbox) {
+      sendJson(response, 503, {
+        error: {
+          code: "mailbox_persistence_unavailable",
+          message: "Mailbox delivery requires configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        playerIds?: string[];
+        message?: {
+          id?: string;
+          kind?: "system" | "compensation" | "announcement";
+          title?: string;
+          body?: string;
+          sentAt?: string;
+          expiresAt?: string;
+          grant?: PlayerAccountSnapshot["mailbox"] extends Array<infer T> ? T extends { grant?: infer G } ? G : never : never;
+        };
+      };
+      const playerIds = (body.playerIds ?? []).map((playerId) => playerId?.trim()).filter((playerId): playerId is string => Boolean(playerId));
+      if (playerIds.length === 0) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_player_ids",
+            message: "playerIds must not be empty"
+          }
+        });
+        return;
+      }
+
+      const message = normalizePlayerMailboxMessage({
+        id: body.message?.id ?? "",
+        title: body.message?.title ?? "",
+        body: body.message?.body ?? "",
+        ...(body.message?.kind ? { kind: body.message.kind } : {}),
+        ...(body.message?.sentAt ? { sentAt: body.message.sentAt } : {}),
+        ...(body.message?.expiresAt ? { expiresAt: body.message.expiresAt } : {}),
+        ...(body.message?.grant ? { grant: body.message.grant } : {})
+      });
+      const result = await store.deliverPlayerMailbox({
+        playerIds,
+        message
+      });
+      sendJson(response, 200, {
+        delivered: result.deliveredPlayerIds.length,
+        skipped: result.skippedPlayerIds.length,
+        deliveredPlayerIds: result.deliveredPlayerIds,
+        skippedPlayerIds: result.skippedPlayerIds,
+        message: result.message
+      });
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, {
+          error: {
+            code: error.name,
+            message: error.message
+          }
+        });
+        return;
+      }
+      sendJson(response, 400, { error: toErrorPayload(error) });
     }
   });
 

--- a/apps/server/src/player-mailbox.ts
+++ b/apps/server/src/player-mailbox.ts
@@ -1,0 +1,319 @@
+import {
+  getEquipmentDefinition,
+  resolveCosmeticCatalog,
+  summarizePlayerMailbox,
+  isPlayerMailboxMessageExpired,
+  type CosmeticId,
+  type EquipmentId,
+  type EventLogEntry,
+  type PlayerMailboxGrant,
+  type PlayerMailboxMessage,
+  type PlayerMailboxSummary,
+  type ResourceLedger
+} from "../../../packages/shared/src/index";
+
+export interface NormalizedMailboxGrant {
+  gems: number;
+  resources: ResourceLedger;
+  equipmentIds: EquipmentId[];
+  cosmeticIds: CosmeticId[];
+  seasonPassPremium: boolean;
+}
+
+export interface PlayerMailboxDeliveryInput {
+  playerIds: string[];
+  message: Partial<PlayerMailboxMessage> & Pick<PlayerMailboxMessage, "id" | "title" | "body">;
+}
+
+export interface PlayerMailboxDeliveryResult {
+  deliveredPlayerIds: string[];
+  skippedPlayerIds: string[];
+  message: PlayerMailboxMessage;
+}
+
+export interface PlayerMailboxClaimResult {
+  claimed: boolean;
+  reason?: "not_found" | "already_claimed" | "expired" | "no_grant";
+  message?: PlayerMailboxMessage;
+  mailbox: PlayerMailboxMessage[];
+  summary: PlayerMailboxSummary;
+  granted?: NormalizedMailboxGrant;
+}
+
+export interface PlayerMailboxClaimAllResult {
+  claimed: boolean;
+  claimedMessageIds: string[];
+  mailbox: PlayerMailboxMessage[];
+  summary: PlayerMailboxSummary;
+  granted: NormalizedMailboxGrant[];
+}
+
+function normalizeTimestamp(value: string | null | undefined, field: string, required = false): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) {
+    if (required) {
+      throw new Error(`${field} is required`);
+    }
+    return undefined;
+  }
+
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`${field} must be a valid ISO timestamp`);
+  }
+
+  return parsed.toISOString();
+}
+
+function normalizeMailboxText(value: string | null | undefined, field: string, maxLength: number): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new Error(`${field} must not be empty`);
+  }
+
+  return normalized.slice(0, maxLength);
+}
+
+export function normalizePlayerMailboxGrant(grant?: PlayerMailboxGrant | null): NormalizedMailboxGrant {
+  const equipmentIds = Array.from(
+    new Set(
+      (grant?.equipmentIds ?? [])
+        .map((equipmentId) => equipmentId?.trim())
+        .filter((equipmentId): equipmentId is EquipmentId => Boolean(equipmentId))
+    )
+  );
+  for (const equipmentId of equipmentIds) {
+    if (!getEquipmentDefinition(equipmentId)) {
+      throw new Error(`unknown mailbox equipment grant: ${equipmentId}`);
+    }
+  }
+
+  const cosmeticCatalogIds = new Set(resolveCosmeticCatalog().map((entry) => entry.id));
+  const cosmeticIds = Array.from(
+    new Set(
+      (grant?.cosmeticIds ?? [])
+        .map((cosmeticId) => cosmeticId?.trim())
+        .filter((cosmeticId): cosmeticId is CosmeticId => Boolean(cosmeticId))
+    )
+  );
+  for (const cosmeticId of cosmeticIds) {
+    if (!cosmeticCatalogIds.has(cosmeticId)) {
+      throw new Error(`unknown mailbox cosmetic grant: ${cosmeticId}`);
+    }
+  }
+
+  return {
+    gems: Math.max(0, Math.floor(grant?.gems ?? 0)),
+    resources: {
+      gold: Math.max(0, Math.floor(grant?.resources?.gold ?? 0)),
+      wood: Math.max(0, Math.floor(grant?.resources?.wood ?? 0)),
+      ore: Math.max(0, Math.floor(grant?.resources?.ore ?? 0))
+    },
+    equipmentIds,
+    cosmeticIds,
+    seasonPassPremium: grant?.seasonPassPremium === true
+  };
+}
+
+export function hasMailboxGrant(grant?: PlayerMailboxGrant | null): boolean {
+  const normalized = normalizePlayerMailboxGrant(grant);
+  return (
+    normalized.gems > 0 ||
+    normalized.resources.gold > 0 ||
+    normalized.resources.wood > 0 ||
+    normalized.resources.ore > 0 ||
+    normalized.equipmentIds.length > 0 ||
+    normalized.cosmeticIds.length > 0 ||
+    normalized.seasonPassPremium
+  );
+}
+
+export function normalizePlayerMailboxMessage(
+  message: Partial<PlayerMailboxMessage> & Pick<PlayerMailboxMessage, "id" | "title" | "body">,
+  now = new Date()
+): PlayerMailboxMessage {
+  const sentAt = normalizeTimestamp(message.sentAt, "message.sentAt") ?? now.toISOString();
+  const normalizedGrant = hasMailboxGrant(message.grant) ? normalizePlayerMailboxGrant(message.grant) : null;
+
+  return {
+    id: normalizeMailboxText(message.id, "message.id", 191),
+    kind: message.kind === "compensation" || message.kind === "announcement" ? message.kind : "system",
+    title: normalizeMailboxText(message.title, "message.title", 120),
+    body: normalizeMailboxText(message.body, "message.body", 4000),
+    sentAt,
+    ...(normalizeTimestamp(message.expiresAt, "message.expiresAt") ? { expiresAt: normalizeTimestamp(message.expiresAt, "message.expiresAt")! } : {}),
+    ...(normalizeTimestamp(message.readAt, "message.readAt") ? { readAt: normalizeTimestamp(message.readAt, "message.readAt")! } : {}),
+    ...(normalizeTimestamp(message.claimedAt, "message.claimedAt") ? { claimedAt: normalizeTimestamp(message.claimedAt, "message.claimedAt")! } : {}),
+    ...(normalizedGrant
+      ? {
+          grant: {
+            ...(normalizedGrant.gems > 0 ? { gems: normalizedGrant.gems } : {}),
+            ...(normalizedGrant.resources.gold > 0 || normalizedGrant.resources.wood > 0 || normalizedGrant.resources.ore > 0
+              ? { resources: normalizedGrant.resources }
+              : {}),
+            ...(normalizedGrant.equipmentIds.length > 0 ? { equipmentIds: normalizedGrant.equipmentIds } : {}),
+            ...(normalizedGrant.cosmeticIds.length > 0 ? { cosmeticIds: normalizedGrant.cosmeticIds } : {}),
+            ...(normalizedGrant.seasonPassPremium ? { seasonPassPremium: true } : {})
+          }
+        }
+      : {})
+  };
+}
+
+export function sortMailboxMessages(mailbox?: PlayerMailboxMessage[] | null): PlayerMailboxMessage[] {
+  return [...(mailbox ?? [])].sort((left, right) => right.sentAt.localeCompare(left.sentAt) || left.id.localeCompare(right.id));
+}
+
+export function deliverPlayerMailboxMessage(
+  mailbox: PlayerMailboxMessage[] | null | undefined,
+  message: PlayerMailboxMessage
+): { delivered: boolean; mailbox: PlayerMailboxMessage[] } {
+  const normalizedMailbox = sortMailboxMessages(mailbox);
+  if (normalizedMailbox.some((entry) => entry.id === message.id)) {
+    return {
+      delivered: false,
+      mailbox: normalizedMailbox
+    };
+  }
+
+  return {
+    delivered: true,
+    mailbox: sortMailboxMessages([...normalizedMailbox, message])
+  };
+}
+
+export function claimPlayerMailboxMessage(
+  mailbox: PlayerMailboxMessage[] | null | undefined,
+  messageId: string,
+  now = new Date()
+): PlayerMailboxClaimResult {
+  const normalizedMailbox = sortMailboxMessages(mailbox);
+  const normalizedMessageId = normalizeMailboxText(messageId, "messageId", 191);
+  const message = normalizedMailbox.find((entry) => entry.id === normalizedMessageId);
+  if (!message) {
+    return {
+      claimed: false,
+      reason: "not_found",
+      mailbox: normalizedMailbox,
+      summary: summarizePlayerMailbox(normalizedMailbox, now)
+    };
+  }
+
+  if (message.claimedAt) {
+    return {
+      claimed: false,
+      reason: "already_claimed",
+      message,
+      mailbox: normalizedMailbox,
+      summary: summarizePlayerMailbox(normalizedMailbox, now)
+    };
+  }
+
+  if (isPlayerMailboxMessageExpired(message, now)) {
+    return {
+      claimed: false,
+      reason: "expired",
+      message,
+      mailbox: normalizedMailbox,
+      summary: summarizePlayerMailbox(normalizedMailbox, now)
+    };
+  }
+
+  if (!hasMailboxGrant(message.grant)) {
+    return {
+      claimed: false,
+      reason: "no_grant",
+      message,
+      mailbox: normalizedMailbox,
+      summary: summarizePlayerMailbox(normalizedMailbox, now)
+    };
+  }
+
+  const claimedAt = now.toISOString();
+  const granted = normalizePlayerMailboxGrant(message.grant);
+  const nextMailbox = normalizedMailbox.map((entry) =>
+    entry.id === normalizedMessageId
+      ? {
+          ...entry,
+          ...(entry.readAt ? {} : { readAt: claimedAt }),
+          claimedAt
+        }
+      : entry
+  );
+  const nextMessage = nextMailbox.find((entry) => entry.id === normalizedMessageId);
+  if (!nextMessage) {
+    throw new Error("mailbox_claim_state_corrupted");
+  }
+
+  return {
+    claimed: true,
+    message: nextMessage,
+    mailbox: nextMailbox,
+    summary: summarizePlayerMailbox(nextMailbox, now),
+    granted
+  };
+}
+
+export function claimAllPlayerMailboxMessages(
+  mailbox: PlayerMailboxMessage[] | null | undefined,
+  now = new Date()
+): PlayerMailboxClaimAllResult {
+  let nextMailbox = sortMailboxMessages(mailbox);
+  const claimedMessageIds: string[] = [];
+  const granted: NormalizedMailboxGrant[] = [];
+
+  for (const entry of nextMailbox) {
+    const result = claimPlayerMailboxMessage(nextMailbox, entry.id, now);
+    if (!result.claimed || !result.message || !result.granted) {
+      continue;
+    }
+    nextMailbox = result.mailbox;
+    claimedMessageIds.push(result.message.id);
+    granted.push(result.granted);
+  }
+
+  return {
+    claimed: claimedMessageIds.length > 0,
+    claimedMessageIds,
+    mailbox: nextMailbox,
+    summary: summarizePlayerMailbox(nextMailbox, now),
+    granted
+  };
+}
+
+export function pruneExpiredPlayerMailboxMessages(
+  mailbox: PlayerMailboxMessage[] | null | undefined,
+  referenceTime = new Date()
+): { mailbox: PlayerMailboxMessage[]; removedCount: number } {
+  const nextMailbox = sortMailboxMessages(mailbox).filter((entry) => !isPlayerMailboxMessageExpired(entry, referenceTime));
+  return {
+    mailbox: nextMailbox,
+    removedCount: Math.max(0, (mailbox?.length ?? 0) - nextMailbox.length)
+  };
+}
+
+export function createMailboxClaimEventLogEntry(
+  playerId: string,
+  message: Pick<PlayerMailboxMessage, "id" | "title">,
+  granted: NormalizedMailboxGrant,
+  processedAt: string
+): EventLogEntry {
+  const rewards = [
+    granted.gems > 0 ? { type: "resource" as const, label: "gems", amount: granted.gems } : null,
+    granted.resources.gold > 0 ? { type: "resource" as const, label: "gold", amount: granted.resources.gold } : null,
+    granted.resources.wood > 0 ? { type: "resource" as const, label: "wood", amount: granted.resources.wood } : null,
+    granted.resources.ore > 0 ? { type: "resource" as const, label: "ore", amount: granted.resources.ore } : null,
+    ...granted.equipmentIds.map((equipmentId) => ({ type: "badge" as const, label: equipmentId })),
+    ...granted.cosmeticIds.map((cosmeticId) => ({ type: "badge" as const, label: cosmeticId }))
+  ].filter((reward): reward is NonNullable<typeof reward> => Boolean(reward));
+
+  return {
+    id: `${playerId}:${processedAt}:mailbox:${message.id}`,
+    timestamp: processedAt,
+    roomId: "mailbox",
+    playerId,
+    category: "account",
+    description: `Claimed mailbox reward: ${message.title}.`,
+    rewards
+  };
+}

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -5,6 +5,13 @@ import { Server, WebSocketTransport } from "colyseus";
 import { issueAccountAuthSession, issueGuestAuthSession, issueWechatMiniGameAuthSession, hashAccountPassword } from "../src/auth";
 import { getDailyRewardDateKey, getPreviousDailyRewardDateKey } from "../src/daily-rewards";
 import { applyPlayerEventLogAndAchievements } from "../src/player-achievements";
+import {
+  claimAllPlayerMailboxMessages,
+  claimPlayerMailboxMessage,
+  createMailboxClaimEventLogEntry,
+  deliverPlayerMailboxMessage,
+  normalizePlayerMailboxMessage
+} from "../src/player-mailbox";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
 import { cacheWechatSessionKey, resetWechatSessionKeyCache } from "../src/wechat-session-key";
 import type {
@@ -181,6 +188,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       recentBattleReplays: structuredClone(existing?.recentBattleReplays ?? []),
       ...(existing?.campaignProgress ? { campaignProgress: structuredClone(existing.campaignProgress) } : {}),
       ...(existing?.seasonalEventStates ? { seasonalEventStates: structuredClone(existing.seasonalEventStates) } : {}),
+      ...(existing?.mailbox ? { mailbox: structuredClone(existing.mailbox) } : {}),
       ...(existing?.dailyDungeonState ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) } : {}),
       ...(existing?.tutorialStep !== undefined ? { tutorialStep: existing.tutorialStep } : { tutorialStep: DEFAULT_TUTORIAL_STEP }),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
@@ -289,6 +297,94 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       referrerId: normalizedReferrerId,
       newPlayerId: normalizedNewPlayerId
     };
+  }
+
+  async deliverPlayerMailbox(input: import("../src/player-mailbox").PlayerMailboxDeliveryInput) {
+    const message = normalizePlayerMailboxMessage(input.message);
+    const deliveredPlayerIds: string[] = [];
+    const skippedPlayerIds: string[] = [];
+
+    for (const playerId of Array.from(new Set(input.playerIds.map((entry) => entry.trim()).filter(Boolean)))) {
+      const account = await this.ensurePlayerAccount({ playerId });
+      const result = deliverPlayerMailboxMessage(account.mailbox, message);
+      if (!result.delivered) {
+        skippedPlayerIds.push(playerId);
+        continue;
+      }
+      this.accounts.set(playerId, {
+        ...account,
+        mailbox: structuredClone(result.mailbox),
+        updatedAt: new Date().toISOString()
+      });
+      deliveredPlayerIds.push(playerId);
+    }
+
+    return { deliveredPlayerIds, skippedPlayerIds, message };
+  }
+
+  async claimPlayerMailboxMessage(playerId: string, messageId: string, claimedAt?: string) {
+    const account = await this.ensurePlayerAccount({ playerId });
+    const now = claimedAt ? new Date(claimedAt) : new Date();
+    const result = claimPlayerMailboxMessage(account.mailbox, messageId, now);
+    if (!result.claimed || !result.message || !result.granted) {
+      return result;
+    }
+
+    const eventEntry = createMailboxClaimEventLogEntry(playerId, result.message, result.granted, result.message.claimedAt ?? now.toISOString());
+    this.accounts.set(playerId, {
+      ...account,
+      gems: (account.gems ?? 0) + result.granted.gems,
+      mailbox: structuredClone(result.mailbox),
+      globalResources: {
+        gold: (account.globalResources.gold ?? 0) + result.granted.resources.gold,
+        wood: (account.globalResources.wood ?? 0) + result.granted.resources.wood,
+        ore: (account.globalResources.ore ?? 0) + result.granted.resources.ore
+      },
+      recentEventLog: [...account.recentEventLog, eventEntry],
+      updatedAt: now.toISOString()
+    });
+    return result;
+  }
+
+  async claimAllPlayerMailboxMessages(playerId: string, claimedAt?: string) {
+    const account = await this.ensurePlayerAccount({ playerId });
+    const now = claimedAt ? new Date(claimedAt) : new Date();
+    const result = claimAllPlayerMailboxMessages(account.mailbox, now);
+    if (!result.claimed) {
+      return result;
+    }
+
+    const totalGrant = result.granted.reduce(
+      (accumulator, grant) => ({
+        gems: accumulator.gems + grant.gems,
+        gold: accumulator.gold + grant.resources.gold,
+        wood: accumulator.wood + grant.resources.wood,
+        ore: accumulator.ore + grant.resources.ore
+      }),
+      { gems: 0, gold: 0, wood: 0, ore: 0 }
+    );
+    const eventEntries = result.claimedMessageIds
+      .map((messageId, index) => {
+        const message = result.mailbox.find((entry) => entry.id === messageId);
+        const granted = result.granted[index];
+        return message && granted
+          ? createMailboxClaimEventLogEntry(playerId, message, granted, message.claimedAt ?? now.toISOString())
+          : null;
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+    this.accounts.set(playerId, {
+      ...account,
+      gems: (account.gems ?? 0) + totalGrant.gems,
+      mailbox: structuredClone(result.mailbox),
+      globalResources: {
+        gold: (account.globalResources.gold ?? 0) + totalGrant.gold,
+        wood: (account.globalResources.wood ?? 0) + totalGrant.wood,
+        ore: (account.globalResources.ore ?? 0) + totalGrant.ore
+      },
+      recentEventLog: [...account.recentEventLog, ...eventEntries],
+      updatedAt: now.toISOString()
+    });
+    return result;
   }
 
   async listPlayerBanHistory(
@@ -554,6 +650,13 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
           : {}
         : existing.seasonalEventStates
           ? { seasonalEventStates: structuredClone(existing.seasonalEventStates) }
+          : {}),
+      ...(patch.mailbox !== undefined
+        ? patch.mailbox
+          ? { mailbox: structuredClone(patch.mailbox) }
+          : {}
+        : existing.mailbox
+          ? { mailbox: structuredClone(existing.mailbox) }
           : {}),
       globalResources: structuredClone(
         (patch.globalResources as PlayerAccountSnapshot["globalResources"] | undefined) ?? existing.globalResources
@@ -3219,6 +3322,152 @@ test("daily quest claim grants rewards once and returns already_claimed on repea
   assert.equal(account?.gems, 2);
   assert.equal(account?.globalResources.gold, 35);
   assert.match(account?.recentEventLog[0]?.description ?? "", /领取每日任务：补给回收/);
+});
+
+test("mailbox routes list delivered compensation and repeated claims stay idempotent", async (t) => {
+  const port = 44940 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  await store.ensurePlayerAccount({
+    playerId: "mailbox-player",
+    displayName: "Mailbox Player"
+  });
+  await store.deliverPlayerMailbox({
+    playerIds: ["mailbox-player"],
+    message: {
+      id: "comp-2026-04-05-restart",
+      kind: "compensation",
+      title: "停机补偿",
+      body: "补发宝石和金币。",
+      sentAt: "2026-04-05T00:00:00.000Z",
+      expiresAt: "2026-04-12T00:00:00.000Z",
+      grant: {
+        gems: 40,
+        resources: {
+          gold: 180
+        }
+      }
+    }
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueGuestAuthSession({
+    playerId: "mailbox-player",
+    displayName: "Mailbox Player"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const listResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/mailbox`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const listPayload = (await listResponse.json()) as {
+    items: Array<{ id: string }>;
+    summary: { claimableCount: number; unreadCount: number };
+  };
+
+  assert.equal(listResponse.status, 200);
+  assert.equal(listPayload.items[0]?.id, "comp-2026-04-05-restart");
+  assert.equal(listPayload.summary.claimableCount, 1);
+  assert.equal(listPayload.summary.unreadCount, 1);
+
+  const claimResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/mailbox/comp-2026-04-05-restart/claim`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const claimPayload = (await claimResponse.json()) as {
+    claimed: boolean;
+    summary: { claimableCount: number; unreadCount: number };
+  };
+
+  assert.equal(claimResponse.status, 200);
+  assert.equal(claimPayload.claimed, true);
+  assert.equal(claimPayload.summary.claimableCount, 0);
+  assert.equal(claimPayload.summary.unreadCount, 0);
+
+  const repeatClaimResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/mailbox/comp-2026-04-05-restart/claim`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const repeatClaimPayload = (await repeatClaimResponse.json()) as {
+    claimed: boolean;
+    reason: string;
+  };
+
+  assert.equal(repeatClaimResponse.status, 200);
+  assert.equal(repeatClaimPayload.claimed, false);
+  assert.equal(repeatClaimPayload.reason, "already_claimed");
+
+  const account = await store.loadPlayerAccount("mailbox-player");
+  assert.equal(account?.gems, 40);
+  assert.equal(account?.globalResources.gold, 180);
+});
+
+test("admin mailbox delivery route skips duplicate message ids for the same player", async (t) => {
+  process.env.VEIL_ADMIN_TOKEN = "test-admin-token";
+  t.after(() => {
+    delete process.env.VEIL_ADMIN_TOKEN;
+  });
+
+  const port = 44940 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  await store.ensurePlayerAccount({
+    playerId: "ops-player",
+    displayName: "Ops Player"
+  });
+  const server = await startAccountRouteServer(port, store);
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const requestBody = {
+    playerIds: ["ops-player"],
+    message: {
+      id: "ops-comp-001",
+      kind: "compensation",
+      title: "运营补偿",
+      body: "测试补发。",
+      sentAt: "2026-04-05T00:00:00.000Z",
+      grant: {
+        gems: 20
+      }
+    }
+  };
+
+  const firstResponse = await fetch(`http://127.0.0.1:${port}/api/admin/player-mailbox/deliver`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-veil-admin-token": "test-admin-token"
+    },
+    body: JSON.stringify(requestBody)
+  });
+  const firstPayload = (await firstResponse.json()) as { delivered: number; skipped: number };
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(firstPayload.delivered, 1);
+  assert.equal(firstPayload.skipped, 0);
+
+  const secondResponse = await fetch(`http://127.0.0.1:${port}/api/admin/player-mailbox/deliver`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-veil-admin-token": "test-admin-token"
+    },
+    body: JSON.stringify(requestBody)
+  });
+  const secondPayload = (await secondResponse.json()) as { delivered: number; skipped: number };
+
+  assert.equal(secondResponse.status, 200);
+  assert.equal(secondPayload.delivered, 0);
+  assert.equal(secondPayload.skipped, 1);
 });
 
 test("referral endpoint rejects double-claiming for the same referrer and new player", async (t) => {

--- a/apps/server/test/player-mailbox.test.ts
+++ b/apps/server/test/player-mailbox.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  claimAllPlayerMailboxMessages,
+  claimPlayerMailboxMessage,
+  deliverPlayerMailboxMessage,
+  normalizePlayerMailboxMessage,
+  pruneExpiredPlayerMailboxMessages
+} from "../src/player-mailbox";
+
+test("mailbox delivery is idempotent per player message id and single-claim is idempotent", () => {
+  const message = normalizePlayerMailboxMessage({
+    id: "comp-2026-04-05-restart",
+    kind: "compensation",
+    title: "停机补偿",
+    body: "由于早间维护延长，补发资源。",
+    sentAt: "2026-04-05T00:00:00.000Z",
+    expiresAt: "2026-04-12T00:00:00.000Z",
+    grant: {
+      gems: 50,
+      resources: {
+        gold: 200
+      }
+    }
+  });
+
+  const firstDelivery = deliverPlayerMailboxMessage([], message);
+  const secondDelivery = deliverPlayerMailboxMessage(firstDelivery.mailbox, message);
+  assert.equal(firstDelivery.delivered, true);
+  assert.equal(secondDelivery.delivered, false);
+
+  const firstClaim = claimPlayerMailboxMessage(firstDelivery.mailbox, message.id, new Date("2026-04-05T01:00:00.000Z"));
+  assert.equal(firstClaim.claimed, true);
+  assert.equal(firstClaim.granted?.gems, 50);
+  assert.equal(firstClaim.granted?.resources.gold, 200);
+
+  const secondClaim = claimPlayerMailboxMessage(firstClaim.mailbox, message.id, new Date("2026-04-05T01:01:00.000Z"));
+  assert.equal(secondClaim.claimed, false);
+  assert.equal(secondClaim.reason, "already_claimed");
+});
+
+test("mailbox claim-all skips expired messages and prune removes them", () => {
+  const activeMessage = normalizePlayerMailboxMessage({
+    id: "comp-active",
+    title: "活跃补偿",
+    body: "仍可领取。",
+    sentAt: "2026-04-05T00:00:00.000Z",
+    expiresAt: "2026-04-10T00:00:00.000Z",
+    grant: {
+      resources: {
+        gold: 100
+      }
+    }
+  });
+  const expiredMessage = normalizePlayerMailboxMessage({
+    id: "comp-expired",
+    title: "已过期补偿",
+    body: "不应再次发放。",
+    sentAt: "2026-04-01T00:00:00.000Z",
+    expiresAt: "2026-04-02T00:00:00.000Z",
+    grant: {
+      gems: 25
+    }
+  });
+
+  const result = claimAllPlayerMailboxMessages([activeMessage, expiredMessage], new Date("2026-04-05T02:00:00.000Z"));
+  assert.equal(result.claimed, true);
+  assert.deepEqual(result.claimedMessageIds, ["comp-active"]);
+  assert.equal(result.summary.expiredCount, 1);
+
+  const pruned = pruneExpiredPlayerMailboxMessages(result.mailbox, new Date("2026-04-05T02:00:00.000Z"));
+  assert.equal(pruned.removedCount, 1);
+  assert.deepEqual(
+    pruned.mailbox.map((entry) => entry.id),
+    ["comp-active"]
+  );
+});

--- a/docs/player-mailbox-compensation.md
+++ b/docs/player-mailbox-compensation.md
@@ -1,0 +1,72 @@
+# Player Mailbox And Compensation
+
+This vertical slice adds a minimal system mailbox for compensation and live-ops rewards.
+
+## Player APIs
+
+- `GET /api/player-accounts/me/mailbox`
+  - Returns `items` plus `summary { totalCount, unreadCount, claimableCount, expiredCount }`.
+- `POST /api/player-accounts/me/mailbox/:messageId/claim`
+  - Idempotent.
+  - Repeat calls return `claimed=false` with `reason=already_claimed`.
+- `POST /api/player-accounts/me/mailbox/claim-all`
+  - Claims every non-expired message that still has an attachment.
+
+Mailbox items are embedded in the player account snapshot for this first slice and expose:
+
+- `id`, `kind`, `title`, `body`
+- `sentAt`, optional `expiresAt`
+- optional `readAt`, `claimedAt`
+- optional `grant { gems, resources, equipmentIds, cosmeticIds, seasonPassPremium }`
+
+## Admin Delivery
+
+- `POST /api/admin/player-mailbox/deliver`
+- Requires `VEIL_ADMIN_TOKEN` on the server and `x-veil-admin-token` on the request.
+- Duplicate protection is per-player per-message-id. Re-sending the same `message.id` to the same player is skipped, not duplicated.
+
+Example payload:
+
+```json
+{
+  "playerIds": ["player-1", "player-2"],
+  "message": {
+    "id": "comp-2026-04-05-maintenance",
+    "kind": "compensation",
+    "title": "停机补偿",
+    "body": "由于维护延长，补发资源。",
+    "expiresAt": "2026-04-12T00:00:00.000Z",
+    "grant": {
+      "gems": 50,
+      "resources": {
+        "gold": 200
+      }
+    }
+  }
+}
+```
+
+## Ops Script
+
+Use [send-player-mailbox-compensation.ts](/home/gpt/project/ProjectVeil/scripts/send-player-mailbox-compensation.ts):
+
+```bash
+VEIL_SERVER_URL=http://127.0.0.1:2567 \
+VEIL_ADMIN_TOKEN=dev-admin-token \
+node --import tsx ./scripts/send-player-mailbox-compensation.ts \
+  --player player-1 \
+  --player player-2 \
+  --id comp-2026-04-05-maintenance \
+  --title "停机补偿" \
+  --body "由于维护延长，补发资源。" \
+  --gems 50 \
+  --gold 200 \
+  --expires-at 2026-04-12T00:00:00.000Z
+```
+
+## Notes
+
+- Claim mutation is atomic with account balance updates and mailbox state.
+- Expired messages are never granted by `claim` or `claim-all`.
+- `pruneExpired()` now removes expired mailbox entries from persistence-backed account state.
+- The Cocos lobby shows mailbox counts plus a basic claim surface with unread redpoint text.

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -23,8 +23,10 @@ import {
 } from "./matchmaking.ts";
 import type {
   CampaignProgressState,
+  CosmeticId,
   CosmeticInventory,
   DailyDungeonState,
+  EquipmentId,
   EquippedCosmetics,
   SeasonalEventState,
   RankedWeeklyProgress,
@@ -36,6 +38,33 @@ import { normalizeCosmeticInventory, normalizeEquippedCosmetics } from "./cosmet
 import { normalizeTutorialStep } from "./tutorial.ts";
 
 export type PlayerBanStatus = "none" | "temporary" | "permanent";
+
+export interface PlayerMailboxGrant {
+  gems?: number;
+  resources?: Partial<ResourceLedger>;
+  equipmentIds?: EquipmentId[];
+  cosmeticIds?: CosmeticId[];
+  seasonPassPremium?: boolean;
+}
+
+export interface PlayerMailboxMessage {
+  id: string;
+  kind: "system" | "compensation" | "announcement";
+  title: string;
+  body: string;
+  sentAt: string;
+  expiresAt?: string;
+  readAt?: string;
+  claimedAt?: string;
+  grant?: PlayerMailboxGrant;
+}
+
+export interface PlayerMailboxSummary {
+  totalCount: number;
+  unreadCount: number;
+  claimableCount: number;
+  expiredCount: number;
+}
 
 export interface PlayerAccountReadModel {
   playerId: string;
@@ -67,6 +96,8 @@ export interface PlayerAccountReadModel {
   campaignProgress?: CampaignProgressState;
   dailyDungeonState?: DailyDungeonState;
   seasonalEventStates?: SeasonalEventState[];
+  mailbox?: PlayerMailboxMessage[];
+  mailboxSummary?: PlayerMailboxSummary;
   tutorialStep?: number | null;
   loginId?: string;
   credentialBoundAt?: string;
@@ -114,6 +145,8 @@ export interface PlayerAccountReadModelInput {
   campaignProgress?: Partial<CampaignProgressState> | null | undefined;
   dailyDungeonState?: Partial<DailyDungeonState> | null | undefined;
   seasonalEventStates?: Partial<SeasonalEventState>[] | null | undefined;
+  mailbox?: Partial<PlayerMailboxMessage>[] | null | undefined;
+  mailboxSummary?: Partial<PlayerMailboxSummary> | null | undefined;
   tutorialStep?: number | null | undefined;
   loginId?: string | undefined;
   credentialBoundAt?: string | undefined;
@@ -227,6 +260,8 @@ export function normalizePlayerAccountReadModel(
   const campaignProgress = normalizeCampaignProgressState(account?.campaignProgress);
   const dailyDungeonState = normalizeDailyDungeonState(account?.dailyDungeonState);
   const seasonalEventStates = normalizeSeasonalEventStates(account?.seasonalEventStates);
+  const mailbox = normalizePlayerMailboxMessages(account?.mailbox);
+  const mailboxSummary = normalizePlayerMailboxSummary(account?.mailboxSummary, mailbox);
   const tutorialStep = normalizeTutorialStep(account?.tutorialStep);
 
   return {
@@ -266,6 +301,8 @@ export function normalizePlayerAccountReadModel(
     ...(campaignProgress ? { campaignProgress } : {}),
     ...(dailyDungeonState ? { dailyDungeonState } : {}),
     ...(seasonalEventStates ? { seasonalEventStates } : {}),
+    ...(mailbox.length > 0 ? { mailbox } : {}),
+    ...(mailboxSummary.totalCount > 0 ? { mailboxSummary } : {}),
     ...(account?.tutorialStep !== undefined ? { tutorialStep } : {}),
     ...(loginId ? { loginId } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
@@ -281,6 +318,122 @@ export function normalizePlayerAccountReadModel(
     ...(banReason ? { banReason } : {}),
     ...(lastRoomId ? { lastRoomId } : {}),
     ...(lastSeenAt ? { lastSeenAt } : {})
+  };
+}
+
+function normalizePlayerMailboxGrant(grant?: Partial<PlayerMailboxGrant> | null): PlayerMailboxGrant | undefined {
+  if (!grant) {
+    return undefined;
+  }
+
+  const equipmentIds = Array.from(
+    new Set(
+      (grant.equipmentIds ?? [])
+        .map((equipmentId) => equipmentId?.trim())
+        .filter((equipmentId): equipmentId is EquipmentId => Boolean(equipmentId))
+    )
+  );
+  const cosmeticIds = Array.from(
+    new Set(
+      (grant.cosmeticIds ?? [])
+        .map((cosmeticId) => cosmeticId?.trim())
+        .filter((cosmeticId): cosmeticId is CosmeticId => Boolean(cosmeticId))
+    )
+  );
+  const normalizedResources = {
+    gold: Math.max(0, Math.floor(grant.resources?.gold ?? 0)),
+    wood: Math.max(0, Math.floor(grant.resources?.wood ?? 0)),
+    ore: Math.max(0, Math.floor(grant.resources?.ore ?? 0))
+  };
+  const normalized: PlayerMailboxGrant = {
+    ...(Math.max(0, Math.floor(grant.gems ?? 0)) > 0 ? { gems: Math.max(0, Math.floor(grant.gems ?? 0)) } : {}),
+    ...(normalizedResources.gold > 0 || normalizedResources.wood > 0 || normalizedResources.ore > 0
+      ? { resources: normalizedResources }
+      : {}),
+    ...(equipmentIds.length > 0 ? { equipmentIds } : {}),
+    ...(cosmeticIds.length > 0 ? { cosmeticIds } : {}),
+    ...(grant.seasonPassPremium === true ? { seasonPassPremium: true } : {})
+  };
+
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizePlayerMailboxMessages(mailbox?: Partial<PlayerMailboxMessage>[] | null): PlayerMailboxMessage[] {
+  return (mailbox ?? [])
+    .map((entry) => {
+      const id = entry?.id?.trim();
+      const title = entry?.title?.trim();
+      const body = entry?.body?.trim();
+      const sentAt = normalizeTimestamp(entry?.sentAt);
+      if (!id || !title || !body || !sentAt) {
+        return null;
+      }
+
+      return {
+        id,
+        kind: entry.kind === "compensation" || entry.kind === "announcement" ? entry.kind : "system",
+        title,
+        body,
+        sentAt,
+        ...(normalizeTimestamp(entry.expiresAt) ? { expiresAt: normalizeTimestamp(entry.expiresAt)! } : {}),
+        ...(normalizeTimestamp(entry.readAt) ? { readAt: normalizeTimestamp(entry.readAt)! } : {}),
+        ...(normalizeTimestamp(entry.claimedAt) ? { claimedAt: normalizeTimestamp(entry.claimedAt)! } : {}),
+        ...(normalizePlayerMailboxGrant(entry.grant) ? { grant: normalizePlayerMailboxGrant(entry.grant)! } : {})
+      } satisfies PlayerMailboxMessage;
+    })
+    .filter((entry): entry is PlayerMailboxMessage => Boolean(entry))
+    .sort((left, right) => right.sentAt.localeCompare(left.sentAt) || left.id.localeCompare(right.id));
+}
+
+export function isPlayerMailboxMessageExpired(message: Pick<PlayerMailboxMessage, "expiresAt">, now = new Date()): boolean {
+  if (!message.expiresAt) {
+    return false;
+  }
+
+  const expiresAt = new Date(message.expiresAt);
+  return !Number.isNaN(expiresAt.getTime()) && expiresAt.getTime() <= now.getTime();
+}
+
+export function summarizePlayerMailbox(
+  mailbox?: Partial<PlayerMailboxMessage>[] | null,
+  now = new Date()
+): PlayerMailboxSummary {
+  const normalizedMailbox = normalizePlayerMailboxMessages(mailbox);
+  let unreadCount = 0;
+  let claimableCount = 0;
+  let expiredCount = 0;
+
+  for (const entry of normalizedMailbox) {
+    const expired = isPlayerMailboxMessageExpired(entry, now);
+    if (expired) {
+      expiredCount += 1;
+    }
+    if (!entry.readAt && !entry.claimedAt && !expired) {
+      unreadCount += 1;
+    }
+    if (!entry.claimedAt && !expired && entry.grant) {
+      claimableCount += 1;
+    }
+  }
+
+  return {
+    totalCount: normalizedMailbox.length,
+    unreadCount,
+    claimableCount,
+    expiredCount
+  };
+}
+
+function normalizePlayerMailboxSummary(
+  summary?: Partial<PlayerMailboxSummary> | null,
+  mailbox?: Partial<PlayerMailboxMessage>[] | null
+): PlayerMailboxSummary {
+  const fallback = summarizePlayerMailbox(mailbox);
+  return {
+    totalCount: Math.max(0, Math.floor(summary?.totalCount ?? fallback.totalCount)),
+    unreadCount: Math.max(0, Math.floor(summary?.unreadCount ?? fallback.unreadCount)),
+    claimableCount: Math.max(0, Math.floor(summary?.claimableCount ?? fallback.claimableCount)),
+    expiredCount: Math.max(0, Math.floor(summary?.expiredCount ?? fallback.expiredCount))
   };
 }
 

--- a/scripts/send-player-mailbox-compensation.ts
+++ b/scripts/send-player-mailbox-compensation.ts
@@ -1,0 +1,102 @@
+function readFlag(name: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < process.argv.length; index += 1) {
+    if (process.argv[index] !== `--${name}`) {
+      continue;
+    }
+    const value = process.argv[index + 1]?.trim();
+    if (value) {
+      values.push(value);
+    }
+  }
+  return values;
+}
+
+function readSingleFlag(name: string): string | undefined {
+  return readFlag(name)[0];
+}
+
+function readIntegerFlag(name: string): number | undefined {
+  const rawValue = readSingleFlag(name);
+  if (!rawValue) {
+    return undefined;
+  }
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`--${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function requireFlag(name: string): string {
+  const value = readSingleFlag(name);
+  if (!value) {
+    throw new Error(`Missing required flag --${name}`);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const serverUrl = process.env.VEIL_SERVER_URL?.trim() || "http://127.0.0.1:2567";
+  const adminToken = process.env.VEIL_ADMIN_TOKEN?.trim();
+  if (!adminToken) {
+    throw new Error("VEIL_ADMIN_TOKEN must be set");
+  }
+
+  const playerIds = readFlag("player");
+  if (playerIds.length === 0) {
+    throw new Error("At least one --player <playerId> flag is required");
+  }
+
+  const id = requireFlag("id");
+  const title = requireFlag("title");
+  const body = requireFlag("body");
+  const expiresAt = readSingleFlag("expires-at");
+  const gems = readIntegerFlag("gems");
+  const gold = readIntegerFlag("gold");
+  const wood = readIntegerFlag("wood");
+  const ore = readIntegerFlag("ore");
+
+  const response = await fetch(`${serverUrl.replace(/\/$/, "")}/api/admin/player-mailbox/deliver`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-veil-admin-token": adminToken
+    },
+    body: JSON.stringify({
+      playerIds,
+      message: {
+        id,
+        kind: "compensation",
+        title,
+        body,
+        ...(expiresAt ? { expiresAt } : {}),
+        ...(gems != null || gold != null || wood != null || ore != null
+          ? {
+              grant: {
+                ...(gems != null ? { gems } : {}),
+                ...(gold != null || wood != null || ore != null
+                  ? {
+                      resources: {
+                        ...(gold != null ? { gold } : {}),
+                        ...(wood != null ? { wood } : {}),
+                        ...(ore != null ? { ore } : {})
+                      }
+                    }
+                  : {})
+              }
+            }
+          : {})
+      }
+    })
+  });
+
+  const payload = (await response.json()) as Record<string, unknown>;
+  if (!response.ok) {
+    throw new Error(`mailbox_delivery_failed:${response.status}:${JSON.stringify(payload)}`);
+  }
+
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+await main();


### PR DESCRIPTION
## What changed
- added a minimal player mailbox model embedded in player account snapshots with unread, claimable, claimed, and expired state
- implemented authenticated mailbox list, single-claim, claim-all, and admin bulk-delivery routes with idempotent reward grants
- wired a basic Cocos lobby mailbox surface with unread redpoint text and claim actions
- added server and Cocos tests plus ops documentation and a delivery script

## Why
Issue #891 needs a first vertical slice for compensation and system mail so live-ops can deliver audited make-good rewards without ad hoc one-off scripts.

## Validation
- `npm run typecheck:shared -- --pretty false`
- `npm run typecheck:server -- --pretty false`
- `npm run typecheck:cocos -- --pretty false`
- `npm run typecheck:ops -- --pretty false`
- `node --import tsx --test apps/server/test/player-mailbox.test.ts`
- `node --import tsx --test apps/cocos-client/test/cocos-lobby.test.ts --test-name-pattern "mailbox|preserves mailbox"`

## Notes
- `apps/server/test/player-account-routes.test.ts` still has an existing unrelated failure in `daily quest board derives same-day progress and ignores prior-day events`; the new mailbox route assertions passed within that suite run.
