### PR TITLE
[codex] Add candidate revision triage digest

### DIFF
--- a/apps/client/src/runtime-diagnostics.ts
+++ b/apps/client/src/runtime-diagnostics.ts
@@ -1,9 +1,11 @@
-import type {
+import {
   BattleState,
   PlayerWorldView,
   RuntimeDiagnosticsConnectionStatus,
+  RuntimeDiagnosticsErrorEvent,
   RuntimeDiagnosticsMode,
-  RuntimeDiagnosticsSnapshot
+  RuntimeDiagnosticsSnapshot,
+  summarizeRuntimeDiagnosticsErrors
 } from "../../../packages/shared/src/index";
 import type { PlayerAccountProfile } from "./player-account";
 
@@ -26,6 +28,7 @@ interface ReplaySnapshotInput {
 
 export interface H5RuntimeDiagnosticsSnapshotInput {
   exportedAt?: string;
+  candidateRevision?: string | null;
   devOnly: boolean;
   mode: RuntimeDiagnosticsMode;
   room: {
@@ -58,6 +61,7 @@ export interface H5RuntimeDiagnosticsSnapshotInput {
     predictionStatus: string;
     pendingUiTasks: number;
     replay: ReplaySnapshotInput | null;
+    errorEvents?: RuntimeDiagnosticsErrorEvent[];
   };
 }
 
@@ -116,6 +120,11 @@ function buildBattleSnapshot(input: NonNullable<H5RuntimeDiagnosticsSnapshotInpu
 export function buildH5RuntimeDiagnosticsSnapshot(
   input: H5RuntimeDiagnosticsSnapshotInput
 ): RuntimeDiagnosticsSnapshot {
+  const errorEvents = (input.diagnostics.errorEvents ?? []).map((event) => ({
+    ...event,
+    candidateRevision: event.candidateRevision ?? input.candidateRevision ?? null
+  }));
+
   return {
     schemaVersion: 1,
     exportedAt: input.exportedAt ?? new Date().toISOString(),
@@ -157,7 +166,9 @@ export function buildH5RuntimeDiagnosticsSnapshot(
       predictionStatus: input.diagnostics.predictionStatus || null,
       pendingUiTasks: input.diagnostics.pendingUiTasks,
       replay: input.diagnostics.replay ? { ...input.diagnostics.replay } : null,
-      primaryClientTelemetry: []
+      primaryClientTelemetry: [],
+      errorEvents,
+      errorSummary: summarizeRuntimeDiagnosticsErrors(errorEvents)
     }
   };
 }

--- a/apps/client/test/runtime-diagnostics.test.ts
+++ b/apps/client/test/runtime-diagnostics.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildRuntimeDiagnosticsErrorEvent,
   renderRuntimeDiagnosticsSnapshotText,
   serializeRuntimeDiagnosticsSnapshot,
   type PlayerBattleReplaySummary
@@ -66,6 +67,7 @@ function createAccountProfile(): PlayerAccountProfile {
 test("buildH5RuntimeDiagnosticsSnapshot creates a stable export payload for dev workflows", () => {
   const snapshot = buildH5RuntimeDiagnosticsSnapshot({
     exportedAt: "2026-03-29T06:09:00.000Z",
+    candidateRevision: "abc1234",
     devOnly: true,
     mode: "world",
     room: {
@@ -233,7 +235,31 @@ test("buildH5RuntimeDiagnosticsSnapshot creates a stable export payload for dev 
         status: "paused",
         currentStepIndex: 0,
         totalSteps: 3
-      }
+      },
+      errorEvents: [
+        buildRuntimeDiagnosticsErrorEvent({
+          id: "client-auth-1",
+          recordedAt: "2026-03-29T06:08:30.000Z",
+          source: "client",
+          surface: "h5",
+          candidateRevision: null,
+          featureArea: "login",
+          ownerArea: "account",
+          severity: "error",
+          errorCode: "auth_request_failed",
+          message: "Login refresh failed with 401.",
+          context: {
+            roomId: "room-alpha",
+            playerId: "player-1",
+            requestId: "request-1",
+            route: "/api/auth/refresh",
+            action: "session.refresh",
+            statusCode: 401,
+            crash: false,
+            detail: "refresh token expired"
+          }
+        })
+      ]
     }
   });
 
@@ -250,6 +276,9 @@ test("buildH5RuntimeDiagnosticsSnapshot creates a stable export payload for dev 
   assert.equal(snapshot.diagnostics.recoverySummary, "权威房间状态已恢复，战后结果与地图状态已经重新对齐。");
   assert.equal(snapshot.diagnostics.predictionStatus, null);
   assert.equal(snapshot.diagnostics.replay?.totalSteps, 3);
+  assert.equal(snapshot.diagnostics.errorEvents[0]?.candidateRevision, "abc1234");
+  assert.equal(snapshot.diagnostics.errorSummary.totalEvents, 1);
+  assert.equal(snapshot.diagnostics.errorSummary.topFingerprints[0]?.featureArea, "login");
 
   const serialized = serializeRuntimeDiagnosticsSnapshot(snapshot);
   assert.match(serialized, /"schemaVersion": 1/);
@@ -257,8 +286,11 @@ test("buildH5RuntimeDiagnosticsSnapshot creates a stable export payload for dev 
   assert.match(serialized, /"reachableTileCount": 2/);
   assert.match(serialized, /"recoverySummary": "权威房间状态已恢复，战后结果与地图状态已经重新对齐。"/);
   assert.match(serialized, /"predictionStatus": null/);
+  assert.match(serialized, /"errorCode": "auth_request_failed"/);
 
   const summary = renderRuntimeDiagnosticsSnapshotText(snapshot);
+  assert.match(summary, /Errors 1 \/ fingerprints 1 \/ fatal 0 \/ crashes 0/);
+  assert.match(summary, /Error login\/auth_request_failed 1x on h5 \(account\)/);
   assert.match(summary, /Room room-alpha \/ Player player-1 \/ Sync connected/);
   assert.match(summary, /Resources gold=150 wood=10 ore=4/);
   assert.match(summary, /Events battle.started, battle.resolved/);

--- a/apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts
+++ b/apps/cocos-client/assets/scripts/cocos-runtime-diagnostics.ts
@@ -3,9 +3,11 @@ import {
   type CocosAccountLifecycleDraft
 } from "./cocos-account-lifecycle.ts";
 import {
+  summarizeRuntimeDiagnosticsErrors,
   type PrimaryClientTelemetryEvent,
   buildRuntimeDiagnosticsTriageView,
   type RuntimeDiagnosticsConnectionStatus,
+  type RuntimeDiagnosticsErrorEvent,
   type RuntimeDiagnosticsMode,
   type RuntimeDiagnosticsSnapshot
 } from "../../../../packages/shared/src/index.ts";
@@ -38,6 +40,7 @@ export interface CocosRuntimeDiagnosticsSnapshotInput {
   predictionStatus: string;
   recoverySummary: string | null;
   primaryClientTelemetry: PrimaryClientTelemetryEvent[];
+  errorEvents?: RuntimeDiagnosticsErrorEvent[];
   accountLifecycleDraft?: CocosAccountLifecycleDraft | null;
 }
 
@@ -84,6 +87,7 @@ export function buildCocosRuntimeDiagnosticsSnapshot(
 ): RuntimeDiagnosticsSnapshot {
   const update = input.update;
   const hero = update?.world.ownHeroes[0] ?? null;
+  const errorEvents = input.errorEvents ?? [];
 
   return {
     schemaVersion: 1,
@@ -162,7 +166,9 @@ export function buildCocosRuntimeDiagnosticsSnapshot(
       predictionStatus: input.predictionStatus || null,
       pendingUiTasks: 0,
       replay: null,
-      primaryClientTelemetry: input.primaryClientTelemetry.slice(0, 8)
+      primaryClientTelemetry: input.primaryClientTelemetry.slice(0, 8),
+      errorEvents,
+      errorSummary: summarizeRuntimeDiagnosticsErrors(errorEvents)
     }
   };
 }

--- a/apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
+++ b/apps/cocos-client/test/cocos-runtime-diagnostics.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { buildRuntimeDiagnosticsErrorEvent } from "../../../packages/shared/src/index.ts";
 import { buildCocosRuntimeDiagnosticsSnapshot, buildCocosRuntimeTriageSummaryLines } from "../assets/scripts/cocos-runtime-diagnostics.ts";
 import { createFallbackCocosPlayerAccountProfile } from "../assets/scripts/cocos-lobby.ts";
 import { createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
@@ -47,6 +48,30 @@ test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage",
         battleId: "battle-1",
         battleKind: "neutral"
       }
+    ],
+    errorEvents: [
+      buildRuntimeDiagnosticsErrorEvent({
+        id: "cocos-room-sync-1",
+        recordedAt: "2026-03-29T08:59:43.000Z",
+        source: "client",
+        surface: "cocos",
+        candidateRevision: "abc1234",
+        featureArea: "room_sync",
+        ownerArea: "multiplayer",
+        severity: "error",
+        errorCode: "reconnect_failed",
+        message: "Cocos runtime fell back to cached snapshot after reconnect failed.",
+        context: {
+          roomId: "room-alpha",
+          playerId: "player-1",
+          requestId: null,
+          route: null,
+          action: "room.reconnect",
+          statusCode: null,
+          crash: false,
+          detail: "cached snapshot replay"
+        }
+      })
     ]
   });
 
@@ -55,6 +80,7 @@ test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage",
   assert.equal(snapshot.world?.hero?.id, "hero-1");
   assert.equal(snapshot.world?.visibleHeroes[0]?.playerId, "player-2");
   assert.equal(snapshot.diagnostics.recoverySummary, "已回放缓存状态，等待房间同步...");
+  assert.equal(snapshot.diagnostics.errorSummary.totalEvents, 1);
   assert.equal(snapshot.account?.accountReadiness?.status, "missing");
   assert.match(snapshot.account?.accountReadiness?.detail ?? "", /缺少正式账号登录态/);
 
@@ -76,7 +102,8 @@ test("Cocos runtime diagnostics reuse the shared snapshot shape for HUD triage",
       logLines: ["连接已中断，正在尝试重连...", "已回放缓存状态，等待房间同步..."],
       predictionStatus: "已回放缓存状态，等待房间同步...",
       recoverySummary: "已回放缓存状态，等待房间同步...",
-      primaryClientTelemetry: []
+      primaryClientTelemetry: [],
+      errorEvents: []
     },
     "2026-03-29T09:00:20.000Z"
   );

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -1,6 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  buildRuntimeDiagnosticsErrorEvent,
   renderRuntimeDiagnosticsSnapshotText,
+  summarizeRuntimeDiagnosticsErrors,
+  type RuntimeDiagnosticsErrorEvent,
   type RuntimeDiagnosticsSnapshot
 } from "../../../packages/shared/src/index";
 import { resetGuestAuthSessions } from "./auth";
@@ -111,6 +114,7 @@ interface ReconnectObservabilityCounters {
 interface RuntimeObservabilityState {
   startedAt: number;
   rooms: Map<string, RuntimeRoomSnapshot>;
+  errorEvents: RuntimeDiagnosticsErrorEvent[];
   counters: RuntimeObservabilityCounters;
   prometheus: {
     battleDurationSeconds: HistogramMetricState;
@@ -222,6 +226,7 @@ function createHistogramMetricState(buckets: number[]): HistogramMetricState {
 const runtimeObservability: RuntimeObservabilityState = {
   startedAt: Date.now(),
   rooms: new Map<string, RuntimeRoomSnapshot>(),
+  errorEvents: [],
   counters: {
     connectMessagesTotal: 0,
     worldActionsTotal: 0,
@@ -516,6 +521,7 @@ function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): Runtim
     (left, right) => right.updatedAt.localeCompare(left.updatedAt) || left.roomId.localeCompare(right.roomId)
   );
   const checkedAt = new Date().toISOString();
+  const errorEvents = runtimeObservability.errorEvents.map((event) => ({ ...event }));
 
   return {
     schemaVersion: 1,
@@ -572,7 +578,9 @@ function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): Runtim
       predictionStatus: "server-observability",
       pendingUiTasks: 0,
       replay: null,
-      primaryClientTelemetry: []
+      primaryClientTelemetry: [],
+      errorEvents,
+      errorSummary: summarizeRuntimeDiagnosticsErrors(errorEvents)
     }
   };
 }
@@ -1115,6 +1123,15 @@ export function recordRuntimeRoom(snapshot: RuntimeRoomSnapshot): void {
   runtimeObservability.rooms.set(snapshot.roomId, { ...snapshot });
 }
 
+export function recordRuntimeErrorEvent(
+  input: Omit<RuntimeDiagnosticsErrorEvent, "fingerprint" | "tags"> & { fingerprint?: string; tags?: string[] }
+): void {
+  runtimeObservability.errorEvents.unshift(buildRuntimeDiagnosticsErrorEvent(input));
+  if (runtimeObservability.errorEvents.length > 100) {
+    runtimeObservability.errorEvents.length = 100;
+  }
+}
+
 export function removeRuntimeRoom(roomId: string): void {
   runtimeObservability.rooms.delete(roomId);
 }
@@ -1330,6 +1347,7 @@ export function recordReconnectWindowResolved(outcome: "success" | "failure"): v
 export function resetRuntimeObservability(): void {
   runtimeObservability.startedAt = Date.now();
   runtimeObservability.rooms.clear();
+  runtimeObservability.errorEvents.length = 0;
   runtimeObservability.counters.connectMessagesTotal = 0;
   runtimeObservability.counters.worldActionsTotal = 0;
   runtimeObservability.counters.battleActionsTotal = 0;

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -7,6 +7,7 @@ import { resetAccountTokenDeliveryState } from "../src/account-token-delivery";
 import { configureRoomSnapshotStore, resetLobbyRoomRegistry, VeilColyseusRoom } from "../src/colyseus-room";
 import { registerPrometheusMetricsMiddleware, registerPrometheusMetricsRoute } from "../src/dev-server";
 import {
+  recordRuntimeErrorEvent,
   recordMatchmakingRateLimited,
   registerRuntimeObservabilityRoutes,
   resetRuntimeObservability
@@ -122,6 +123,28 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   await wait(100);
   recordMatchmakingRateLimited();
   recordMatchmakingRateLimited();
+  recordRuntimeErrorEvent({
+    id: "server-payment-1",
+    recordedAt: "2026-04-03T08:35:00.000Z",
+    source: "server",
+    surface: "server",
+    candidateRevision: "abc1234",
+    featureArea: "payment",
+    ownerArea: "commerce",
+    severity: "error",
+    errorCode: "wechat_pay_timeout",
+    message: "WeChat payment confirmation timed out.",
+    context: {
+      roomId: "room-observability-alpha",
+      playerId: "player-1",
+      requestId: "pay-1",
+      route: "/api/wechat/pay/confirm",
+      action: "payment.confirm",
+      statusCode: 504,
+      crash: false,
+      detail: "upstream timeout"
+    }
+  });
 
   const healthResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/health`);
   const healthPayload = (await healthResponse.json()) as {
@@ -194,6 +217,13 @@ test("runtime observability routes expose live room counts and gameplay traffic"
     diagnostics: {
       predictionStatus: string | null;
       logTail: string[];
+      errorSummary: {
+        totalEvents: number;
+        topFingerprints: Array<{
+          errorCode: string;
+          featureArea: string;
+        }>;
+      };
     };
   };
 
@@ -207,6 +237,9 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(diagnosticPayload.overview.roomSummaries[0]?.day, 1);
   assert.equal(diagnosticPayload.overview.roomSummaries[0]?.connectedPlayers, 1);
   assert.equal(diagnosticPayload.diagnostics.predictionStatus, "server-observability");
+  assert.equal(diagnosticPayload.diagnostics.errorSummary.totalEvents, 1);
+  assert.equal(diagnosticPayload.diagnostics.errorSummary.topFingerprints[0]?.errorCode, "wechat_pay_timeout");
+  assert.equal(diagnosticPayload.diagnostics.errorSummary.topFingerprints[0]?.featureArea, "payment");
   assert.match(diagnosticPayload.diagnostics.logTail[0] ?? "", /rooms=1 connections=1/);
 
   const diagnosticTextResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot?format=text`);
@@ -216,6 +249,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(diagnosticTextResponse.headers.get("content-type") ?? "", /^text\/plain/);
   assert.match(diagnosticText, /Mode server \(server-observability\)/);
   assert.match(diagnosticText, /Runtime rooms 1 \/ connections 1 \/ battles 0/);
+  assert.match(diagnosticText, /Errors 1 \/ fingerprints 1 \/ fatal 0 \/ crashes 0/);
   assert.match(diagnosticText, /Room summary room-observability-alpha \/ day 1 \/ players 1/);
 
   const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);

--- a/docs/candidate-revision-triage-digest.md
+++ b/docs/candidate-revision-triage-digest.md
@@ -1,0 +1,54 @@
+# Candidate Revision Triage Digest
+
+`npm run release:candidate-triage:digest` builds a candidate-scoped error aggregation digest from runtime diagnostics snapshots or raw error-event bundles. The script writes both JSON and Markdown artifacts so release review and on-call can read the same summary.
+
+## Inputs
+
+- Server example: `/api/runtime/diagnostic-snapshot` exports now include `diagnostics.errorEvents` and `diagnostics.errorSummary`.
+- Client example: H5 runtime diagnostics exports now include the same error event envelope, including `errorCode`, `featureArea`, `candidateRevision`, and `room/request` context.
+- Raw bundle fallback: any JSON payload with `{ "errorEvents": [...] }`.
+
+## Release Review
+
+Use the digest when a candidate is blocked by crash spikes, repeated runtime exceptions, or unclear owner routing.
+
+```bash
+npm run release:candidate-triage:digest -- \
+  --candidate phase1-rc \
+  --candidate-revision "$(git rev-parse HEAD)" \
+  --input artifacts/runtime/server-diagnostic-snapshot.json \
+  --input artifacts/runtime/h5-diagnostic-snapshot.json
+```
+
+Expected outputs land under `artifacts/release-readiness/` by default:
+
+- `candidate-revision-triage-digest-<candidate>-<revision>.json`
+- `candidate-revision-triage-digest-<candidate>-<revision>.md`
+
+Review the Markdown first:
+
+- Confirm the top fingerprints actually match the pinned candidate revision.
+- Check `featureArea` and `suggested owner` before escalating.
+- Compare `last reproduced` against the latest smoke/release evidence to decide whether the issue is still active.
+
+## On-Call Triage
+
+Use the JSON artifact when you need stable machine-readable context for handoff or incident notes.
+
+- `topFingerprints[*].fingerprint` is stable enough for paging, issue updates, and PR validation notes.
+- `firstSeenRevision` shows whether the fingerprint predates the current candidate or was introduced here.
+- `sampleContext` carries the minimal room/request/action metadata needed to route the issue without digging through raw logs first.
+
+## Minimum Classification Dictionary
+
+The digest keeps the owner routing intentionally small:
+
+- `login` -> `account`
+- `payment` -> `commerce`
+- `room_sync` -> `multiplayer`
+- `rewards`, `season`, `quests` -> `progression`
+- `share`, `guild` -> `social`
+- `battle` -> `combat`
+- `runtime`, `shop`, `unknown` -> `platform` unless an event already provides a more specific owner
+
+If a producer already knows the real owner area, set `ownerArea` on the event and the digest will preserve it.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ingest:wechat-smoke-evidence": "node --import tsx ./scripts/smoke-wechat-minigame-release.ts",
     "release:readiness:snapshot": "node --import tsx ./scripts/release-readiness-snapshot.ts",
     "release:readiness:dashboard": "node --import tsx ./scripts/release-readiness-dashboard.ts",
+    "release:candidate-triage:digest": "node --import tsx ./scripts/candidate-revision-triage-digest.ts",
     "release:runtime-observability:gate": "node --import tsx ./scripts/runtime-observability-gate.ts",
     "release:runtime:slo-summary": "node --import tsx ./scripts/runtime-slo-summary.ts",
     "release:gate:summary": "node --import tsx ./scripts/release-gate-summary.ts",

--- a/packages/shared/src/runtime-diagnostics.ts
+++ b/packages/shared/src/runtime-diagnostics.ts
@@ -131,6 +131,79 @@ export interface RuntimeDiagnosticsReplaySnapshot {
   totalSteps: number;
 }
 
+export type RuntimeDiagnosticsErrorSource = "server" | "client";
+
+export type RuntimeDiagnosticsErrorSeverity = "warn" | "error" | "fatal";
+
+export type RuntimeDiagnosticsFeatureArea =
+  | "login"
+  | "payment"
+  | "room_sync"
+  | "rewards"
+  | "share"
+  | "runtime"
+  | "battle"
+  | "guild"
+  | "shop"
+  | "season"
+  | "quests"
+  | "unknown";
+
+export interface RuntimeDiagnosticsErrorEvent {
+  id: string;
+  recordedAt: string;
+  source: RuntimeDiagnosticsErrorSource;
+  surface: string;
+  candidateRevision: string | null;
+  featureArea: RuntimeDiagnosticsFeatureArea;
+  ownerArea: string;
+  severity: RuntimeDiagnosticsErrorSeverity;
+  errorCode: string;
+  fingerprint: string;
+  message: string;
+  tags: string[];
+  context: {
+    roomId: string | null;
+    playerId: string | null;
+    requestId: string | null;
+    route: string | null;
+    action: string | null;
+    statusCode: number | null;
+    crash: boolean;
+    detail: string | null;
+  };
+}
+
+export interface RuntimeDiagnosticsErrorFingerprintSummary {
+  fingerprint: string;
+  errorCode: string;
+  featureArea: RuntimeDiagnosticsFeatureArea;
+  ownerArea: string;
+  source: RuntimeDiagnosticsErrorSource;
+  surface: string;
+  severity: RuntimeDiagnosticsErrorSeverity;
+  candidateRevision: string | null;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  count: number;
+  crashCount: number;
+  latestMessage: string;
+  sampleContext: RuntimeDiagnosticsErrorEvent["context"];
+}
+
+export interface RuntimeDiagnosticsErrorSummary {
+  totalEvents: number;
+  uniqueFingerprints: number;
+  fatalCount: number;
+  crashCount: number;
+  latestRecordedAt: string | null;
+  byFeatureArea: Array<{
+    featureArea: RuntimeDiagnosticsFeatureArea;
+    count: number;
+  }>;
+  topFingerprints: RuntimeDiagnosticsErrorFingerprintSummary[];
+}
+
 export type PrimaryClientTelemetryCategory = "progression" | "inventory" | "combat";
 
 export type PrimaryClientTelemetryStatus = "info" | "success" | "failure" | "blocked";
@@ -181,6 +254,8 @@ export interface RuntimeDiagnosticsSnapshot {
     pendingUiTasks: number;
     replay: RuntimeDiagnosticsReplaySnapshot | null;
     primaryClientTelemetry: PrimaryClientTelemetryEvent[];
+    errorEvents: RuntimeDiagnosticsErrorEvent[];
+    errorSummary: RuntimeDiagnosticsErrorSummary;
   };
 }
 
@@ -207,6 +282,131 @@ export interface RuntimeDiagnosticsTriageSection {
 export interface RuntimeDiagnosticsTriageView {
   alerts: RuntimeDiagnosticsTriageAlert[];
   sections: RuntimeDiagnosticsTriageSection[];
+}
+
+function normalizeTimestamp(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+export function buildRuntimeErrorFingerprint(input: {
+  source: RuntimeDiagnosticsErrorSource;
+  surface: string;
+  featureArea: RuntimeDiagnosticsFeatureArea;
+  errorCode: string;
+  route?: string | null;
+  action?: string | null;
+  statusCode?: number | null;
+}): string {
+  return [
+    input.source.trim() || "unknown",
+    input.surface.trim() || "unknown",
+    input.featureArea,
+    input.errorCode.trim() || "unknown_error",
+    input.route?.trim() || "no-route",
+    input.action?.trim() || "no-action",
+    input.statusCode == null ? "na" : String(input.statusCode)
+  ].join("|");
+}
+
+export function buildRuntimeDiagnosticsErrorEvent(
+  input: Omit<RuntimeDiagnosticsErrorEvent, "fingerprint" | "tags"> & { fingerprint?: string; tags?: string[] }
+): RuntimeDiagnosticsErrorEvent {
+  const fingerprint =
+    input.fingerprint?.trim() ||
+    buildRuntimeErrorFingerprint({
+      source: input.source,
+      surface: input.surface,
+      featureArea: input.featureArea,
+      errorCode: input.errorCode,
+      route: input.context.route,
+      action: input.context.action,
+      statusCode: input.context.statusCode
+    });
+
+  return {
+    ...input,
+    fingerprint,
+    tags: [...(input.tags ?? [])].map((tag) => tag.trim()).filter((tag) => tag.length > 0)
+  };
+}
+
+export function summarizeRuntimeDiagnosticsErrors(
+  events: RuntimeDiagnosticsErrorEvent[]
+): RuntimeDiagnosticsErrorSummary {
+  const fingerprintMap = new Map<string, RuntimeDiagnosticsErrorFingerprintSummary>();
+  const featureAreaCounts = new Map<RuntimeDiagnosticsFeatureArea, number>();
+  let fatalCount = 0;
+  let crashCount = 0;
+  let latestRecordedAt: string | null = null;
+
+  for (const event of events) {
+    featureAreaCounts.set(event.featureArea, (featureAreaCounts.get(event.featureArea) ?? 0) + 1);
+    if (event.severity === "fatal") {
+      fatalCount += 1;
+    }
+    if (event.context.crash) {
+      crashCount += 1;
+    }
+    if (latestRecordedAt == null || normalizeTimestamp(event.recordedAt) > normalizeTimestamp(latestRecordedAt)) {
+      latestRecordedAt = event.recordedAt;
+    }
+
+    const existing = fingerprintMap.get(event.fingerprint);
+    if (existing) {
+      existing.count += 1;
+      existing.crashCount += event.context.crash ? 1 : 0;
+      if (normalizeTimestamp(event.recordedAt) < normalizeTimestamp(existing.firstSeenAt)) {
+        existing.firstSeenAt = event.recordedAt;
+      }
+      if (normalizeTimestamp(event.recordedAt) >= normalizeTimestamp(existing.lastSeenAt)) {
+        existing.lastSeenAt = event.recordedAt;
+        existing.latestMessage = event.message;
+        existing.sampleContext = { ...event.context };
+      }
+      continue;
+    }
+
+    fingerprintMap.set(event.fingerprint, {
+      fingerprint: event.fingerprint,
+      errorCode: event.errorCode,
+      featureArea: event.featureArea,
+      ownerArea: event.ownerArea,
+      source: event.source,
+      surface: event.surface,
+      severity: event.severity,
+      candidateRevision: event.candidateRevision,
+      firstSeenAt: event.recordedAt,
+      lastSeenAt: event.recordedAt,
+      count: 1,
+      crashCount: event.context.crash ? 1 : 0,
+      latestMessage: event.message,
+      sampleContext: { ...event.context }
+    });
+  }
+
+  return {
+    totalEvents: events.length,
+    uniqueFingerprints: fingerprintMap.size,
+    fatalCount,
+    crashCount,
+    latestRecordedAt,
+    byFeatureArea: Array.from(featureAreaCounts.entries())
+      .map(([featureArea, count]) => ({ featureArea, count }))
+      .sort((left, right) => right.count - left.count || compareStrings(left.featureArea, right.featureArea)),
+    topFingerprints: Array.from(fingerprintMap.values())
+      .sort(
+        (left, right) =>
+          right.count - left.count ||
+          normalizeTimestamp(right.lastSeenAt) - normalizeTimestamp(left.lastSeenAt) ||
+          compareStrings(left.fingerprint, right.fingerprint)
+      )
+      .slice(0, 5)
+  };
 }
 
 function formatSyncAge(ms: number): string {
@@ -449,6 +649,13 @@ export function buildRuntimeDiagnosticsTriageView(
       title: "最近事件",
       items: [
         {
+          label: "错误摘要",
+          value:
+            snapshot.diagnostics.errorSummary.totalEvents > 0
+              ? `${snapshot.diagnostics.errorSummary.totalEvents} 条错误 / ${snapshot.diagnostics.errorSummary.uniqueFingerprints} 个指纹`
+              : "无"
+        },
+        {
           label: "时间线",
           value:
             snapshot.diagnostics.timelineTail.length > 0
@@ -562,6 +769,18 @@ export function buildRuntimeDiagnosticsSummaryLines(snapshot: RuntimeDiagnostics
 
   for (const entry of snapshot.diagnostics.primaryClientTelemetry.slice(0, 2)) {
     lines.push(`Telemetry ${entry.category}/${entry.checkpoint} (${entry.status}) ${entry.detail}`);
+  }
+
+  if (snapshot.diagnostics.errorSummary.totalEvents > 0) {
+    lines.push(
+      `Errors ${snapshot.diagnostics.errorSummary.totalEvents} / fingerprints ${snapshot.diagnostics.errorSummary.uniqueFingerprints} / fatal ${snapshot.diagnostics.errorSummary.fatalCount} / crashes ${snapshot.diagnostics.errorSummary.crashCount}`
+    );
+  }
+
+  for (const entry of snapshot.diagnostics.errorSummary.topFingerprints.slice(0, 2)) {
+    lines.push(
+      `Error ${entry.featureArea}/${entry.errorCode} ${entry.count}x on ${entry.surface} (${entry.ownerArea}) last=${entry.lastSeenAt}`
+    );
   }
 
   lines.push(`Pending UI tasks ${snapshot.diagnostics.pendingUiTasks}`);

--- a/packages/shared/test/fixtures/contract-snapshots/runtime-diagnostics-snapshot.json
+++ b/packages/shared/test/fixtures/contract-snapshots/runtime-diagnostics-snapshot.json
@@ -155,6 +155,16 @@
         "itemCount": 2
       }
     ],
+    "errorEvents": [],
+    "errorSummary": {
+      "totalEvents": 0,
+      "uniqueFingerprints": 0,
+      "fatalCount": 0,
+      "crashCount": 0,
+      "latestRecordedAt": null,
+      "byFeatureArea": [],
+      "topFingerprints": []
+    },
     "pendingUiTasks": 1,
     "replay": {
       "replayId": "room-contract:battle-demo:player-1",

--- a/packages/shared/test/runtime-diagnostics.test.ts
+++ b/packages/shared/test/runtime-diagnostics.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildRuntimeDiagnosticsErrorEvent,
   buildRuntimeDiagnosticsTriageView,
   buildRuntimeDiagnosticsSummaryLines,
   getRuntimeDiagnosticsLastSyncAgeMs,
@@ -110,6 +111,65 @@ function createRuntimeDiagnosticsSnapshot(): RuntimeDiagnosticsSnapshot {
           result: "attacker_victory"
         }
       ],
+      errorEvents: [
+        buildRuntimeDiagnosticsErrorEvent({
+          id: "client-room-sync-1",
+          recordedAt: "2026-03-29T07:09:08.000Z",
+          source: "client",
+          surface: "h5",
+          candidateRevision: "abc1234",
+          featureArea: "room_sync",
+          ownerArea: "multiplayer",
+          severity: "error",
+          errorCode: "reconnect_failed",
+          message: "Reconnect window expired while replay sync was still pending.",
+          context: {
+            roomId: "room-alpha",
+            playerId: "player-1",
+            requestId: "sync-1",
+            route: null,
+            action: "room.reconnect",
+            statusCode: null,
+            crash: false,
+            detail: "local fallback engaged"
+          }
+        })
+      ],
+      errorSummary: {
+        totalEvents: 1,
+        uniqueFingerprints: 1,
+        fatalCount: 0,
+        crashCount: 0,
+        latestRecordedAt: "2026-03-29T07:09:08.000Z",
+        byFeatureArea: [{ featureArea: "room_sync", count: 1 }],
+        topFingerprints: [
+          {
+            fingerprint: "client|h5|room_sync|reconnect_failed|no-route|room.reconnect|na",
+            errorCode: "reconnect_failed",
+            featureArea: "room_sync",
+            ownerArea: "multiplayer",
+            source: "client",
+            surface: "h5",
+            severity: "error",
+            candidateRevision: "abc1234",
+            firstSeenAt: "2026-03-29T07:09:08.000Z",
+            lastSeenAt: "2026-03-29T07:09:08.000Z",
+            count: 1,
+            crashCount: 0,
+            latestMessage: "Reconnect window expired while replay sync was still pending.",
+            sampleContext: {
+              roomId: "room-alpha",
+              playerId: "player-1",
+              requestId: "sync-1",
+              route: null,
+              action: "room.reconnect",
+              statusCode: null,
+              crash: false,
+              detail: "local fallback engaged"
+            }
+          }
+        ]
+      },
       pendingUiTasks: 2,
       replay: {
         replayId: "room-alpha:battle-1:player-1",
@@ -140,6 +200,8 @@ test("runtime diagnostics summary text stays stable for panel and automation con
   assert.match(rendered, /Account readiness ready \/ 正式账号会话已绑定/);
   assert.match(rendered, /Recovery 连接已恢复，当前地图与战斗状态来自最新权威快照。/);
   assert.match(rendered, /Telemetry combat\/encounter\.resolved \(success\) Battle battle-1 resolved as attacker_victory\./);
+  assert.match(rendered, /Errors 1 \/ fingerprints 1 \/ fatal 0 \/ crashes 0/);
+  assert.match(rendered, /Error room_sync\/reconnect_failed 1x on h5 \(multiplayer\)/);
   assert.match(rendered, /Replay room-alpha:battle-1:player-1 \/ paused \/ step 1\/3/);
   assert.match(rendered, /Timeline \[push\/battle\] Room room-alpha finished battle battle-1/);
 });
@@ -195,6 +257,16 @@ test("runtime diagnostics summary text supports aggregate server snapshots", () 
       recoverySummary: null,
       predictionStatus: "server-observability",
       primaryClientTelemetry: [],
+      errorEvents: [],
+      errorSummary: {
+        totalEvents: 0,
+        uniqueFingerprints: 0,
+        fatalCount: 0,
+        crashCount: 0,
+        latestRecordedAt: null,
+        byFeatureArea: [],
+        topFingerprints: []
+      },
       pendingUiTasks: 0,
       replay: null
     }

--- a/packages/shared/test/support/multiplayer-protocol-fixtures.ts
+++ b/packages/shared/test/support/multiplayer-protocol-fixtures.ts
@@ -431,6 +431,16 @@ export function createRuntimeDiagnosticsSnapshotFixture(): RuntimeDiagnosticsSna
           itemCount: 2
         }
       ],
+      errorEvents: [],
+      errorSummary: {
+        totalEvents: 0,
+        uniqueFingerprints: 0,
+        fatalCount: 0,
+        crashCount: 0,
+        latestRecordedAt: null,
+        byFeatureArea: [],
+        topFingerprints: []
+      },
       pendingUiTasks: 1,
       replay: {
         replayId: "room-contract:battle-demo:player-1",

--- a/scripts/candidate-revision-triage-digest.ts
+++ b/scripts/candidate-revision-triage-digest.ts
@@ -1,0 +1,431 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  summarizeRuntimeDiagnosticsErrors,
+  type RuntimeDiagnosticsErrorEvent,
+  type RuntimeDiagnosticsErrorFingerprintSummary,
+  type RuntimeDiagnosticsFeatureArea,
+  type RuntimeDiagnosticsSnapshot
+} from "../packages/shared/src/index.ts";
+
+interface Args {
+  candidate?: string;
+  candidateRevision?: string;
+  inputPaths: string[];
+  outputPath?: string;
+  markdownOutputPath?: string;
+}
+
+interface GitRevision {
+  commit: string;
+  shortCommit: string;
+  branch: string;
+  dirty: boolean;
+}
+
+interface CandidateRevisionTriageDigest {
+  schemaVersion: 1;
+  generatedAt: string;
+  candidate: {
+    name: string;
+    revision: string;
+    shortRevision: string;
+    branch: string;
+    dirty: boolean;
+  };
+  summary: {
+    headline: string;
+    totalEvents: number;
+    uniqueFingerprints: number;
+    fatalCount: number;
+    crashCount: number;
+    topFeatureAreas: Array<{
+      featureArea: RuntimeDiagnosticsFeatureArea;
+      count: number;
+      ownerArea: string;
+    }>;
+  };
+  artifacts: Array<{
+    path: string;
+    sourceType: "runtime-diagnostics-snapshot" | "error-event-bundle";
+    surface: string;
+    eventCount: number;
+    matchedEventCount: number;
+  }>;
+  topFingerprints: Array<{
+    fingerprint: string;
+    errorCode: string;
+    featureArea: RuntimeDiagnosticsFeatureArea;
+    ownerArea: string;
+    source: string;
+    surface: string;
+    severity: string;
+    firstSeenAt: string;
+    firstSeenRevision: string | null;
+    lastSeenAt: string;
+    latestMessage: string;
+    count: number;
+    crashCount: number;
+    suggestedOwner: string;
+    sampleContext: RuntimeDiagnosticsErrorEvent["context"];
+  }>;
+}
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+const DEFAULT_OUTPUT_DIR = path.resolve("artifacts", "release-readiness");
+const FEATURE_OWNER_MAP: Record<RuntimeDiagnosticsFeatureArea, string> = {
+  login: "account",
+  payment: "commerce",
+  room_sync: "multiplayer",
+  rewards: "progression",
+  share: "social",
+  runtime: "platform",
+  battle: "combat",
+  guild: "social",
+  shop: "commerce",
+  season: "progression",
+  quests: "progression",
+  unknown: "platform"
+};
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  const inputPaths: string[] = [];
+  let candidate: string | undefined;
+  let candidateRevision: string | undefined;
+  let outputPath: string | undefined;
+  let markdownOutputPath: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--candidate" && next) {
+      candidate = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--candidate-revision" && next) {
+      candidateRevision = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--input" && next) {
+      inputPaths.push(next);
+      index += 1;
+      continue;
+    }
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--markdown-output" && next) {
+      markdownOutputPath = next;
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  if (inputPaths.length === 0) {
+    fail("Provide at least one --input <path> with a runtime diagnostics snapshot or error-event bundle.");
+  }
+
+  return {
+    ...(candidate ? { candidate } : {}),
+    ...(candidateRevision ? { candidateRevision } : {}),
+    inputPaths,
+    ...(outputPath ? { outputPath } : {}),
+    ...(markdownOutputPath ? { markdownOutputPath } : {})
+  };
+}
+
+function readGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function getRevision(candidateRevision?: string): GitRevision {
+  const commit = candidateRevision?.trim() || readGitValue(["rev-parse", "HEAD"]);
+  return {
+    commit,
+    shortCommit: commit.slice(0, 7),
+    branch: readGitValue(["rev-parse", "--abbrev-ref", "HEAD"]),
+    dirty: readGitValue(["status", "--porcelain"]).length > 0
+  };
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "candidate";
+}
+
+function ensureDirectory(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function writeJsonFile(filePath: string, payload: JsonValue | object): void {
+  ensureDirectory(filePath);
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function toRelativePath(filePath: string): string {
+  return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+}
+
+function readJson(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+}
+
+function isRuntimeDiagnosticsSnapshot(value: unknown): value is RuntimeDiagnosticsSnapshot {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<RuntimeDiagnosticsSnapshot>;
+  return Boolean(candidate.source && candidate.diagnostics && "errorEvents" in candidate.diagnostics);
+}
+
+function extractEventsFromInput(payload: unknown): {
+  sourceType: "runtime-diagnostics-snapshot" | "error-event-bundle";
+  surface: string;
+  events: RuntimeDiagnosticsErrorEvent[];
+} {
+  if (isRuntimeDiagnosticsSnapshot(payload)) {
+    return {
+      sourceType: "runtime-diagnostics-snapshot",
+      surface: payload.source.surface,
+      events: payload.diagnostics.errorEvents
+    };
+  }
+
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "errorEvents" in payload &&
+    Array.isArray((payload as { errorEvents?: unknown }).errorEvents)
+  ) {
+    const errorEvents = (payload as { errorEvents: RuntimeDiagnosticsErrorEvent[] }).errorEvents;
+    return {
+      sourceType: "error-event-bundle",
+      surface: errorEvents[0]?.surface ?? "unknown",
+      events: errorEvents
+    };
+  }
+
+  fail("Input JSON must be a runtime diagnostics snapshot or an object with an errorEvents array.");
+}
+
+function compareTimestamp(left: string, right: string): number {
+  return Date.parse(left) - Date.parse(right);
+}
+
+function buildTopFingerprints(events: RuntimeDiagnosticsErrorEvent[]): CandidateRevisionTriageDigest["topFingerprints"] {
+  const summary = summarizeRuntimeDiagnosticsErrors(events);
+  const earliestRevisionByFingerprint = new Map<string, { recordedAt: string; candidateRevision: string | null }>();
+
+  for (const event of events) {
+    const existing = earliestRevisionByFingerprint.get(event.fingerprint);
+    if (!existing || compareTimestamp(event.recordedAt, existing.recordedAt) < 0) {
+      earliestRevisionByFingerprint.set(event.fingerprint, {
+        recordedAt: event.recordedAt,
+        candidateRevision: event.candidateRevision
+      });
+    }
+  }
+
+  return summary.topFingerprints.map((entry) => ({
+    fingerprint: entry.fingerprint,
+    errorCode: entry.errorCode,
+    featureArea: entry.featureArea,
+    ownerArea: entry.ownerArea,
+    source: entry.source,
+    surface: entry.surface,
+    severity: entry.severity,
+    firstSeenAt: entry.firstSeenAt,
+    firstSeenRevision: earliestRevisionByFingerprint.get(entry.fingerprint)?.candidateRevision ?? entry.candidateRevision,
+    lastSeenAt: entry.lastSeenAt,
+    latestMessage: entry.latestMessage,
+    count: entry.count,
+    crashCount: entry.crashCount,
+    suggestedOwner: entry.ownerArea || FEATURE_OWNER_MAP[entry.featureArea],
+    sampleContext: entry.sampleContext
+  }));
+}
+
+function buildDigest(
+  args: Args,
+  revision: GitRevision,
+  inputs: Array<{
+    path: string;
+    sourceType: "runtime-diagnostics-snapshot" | "error-event-bundle";
+    surface: string;
+    events: RuntimeDiagnosticsErrorEvent[];
+    matchedEvents: RuntimeDiagnosticsErrorEvent[];
+  }>
+): CandidateRevisionTriageDigest {
+  const events = inputs.flatMap((input) => input.matchedEvents).sort(
+    (left, right) => compareTimestamp(left.recordedAt, right.recordedAt)
+  );
+  const summary = summarizeRuntimeDiagnosticsErrors(events);
+  const topFingerprints = buildTopFingerprints(events);
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    candidate: {
+      name: args.candidate?.trim() || revision.branch,
+      revision: revision.commit,
+      shortRevision: revision.shortCommit,
+      branch: revision.branch,
+      dirty: revision.dirty
+    },
+    summary: {
+      headline:
+        events.length > 0
+          ? `${events.length} error event(s) across ${summary.uniqueFingerprints} fingerprint(s) for candidate ${revision.shortCommit}.`
+          : `No matching error events were found for candidate ${revision.shortCommit}.`,
+      totalEvents: summary.totalEvents,
+      uniqueFingerprints: summary.uniqueFingerprints,
+      fatalCount: summary.fatalCount,
+      crashCount: summary.crashCount,
+      topFeatureAreas: summary.byFeatureArea.slice(0, 5).map((entry) => ({
+        featureArea: entry.featureArea,
+        count: entry.count,
+        ownerArea: FEATURE_OWNER_MAP[entry.featureArea]
+      }))
+    },
+    artifacts: inputs.map((input) => ({
+      path: input.path,
+      sourceType: input.sourceType,
+      surface: input.surface,
+      eventCount: input.events.length,
+      matchedEventCount: input.matchedEvents.length
+    })),
+    topFingerprints
+  };
+}
+
+export function renderMarkdown(digest: CandidateRevisionTriageDigest): string {
+  const lines = [
+    "# Candidate Revision Triage Digest",
+    "",
+    `- Candidate: \`${digest.candidate.name}\``,
+    `- Revision: \`${digest.candidate.revision}\``,
+    `- Branch: \`${digest.candidate.branch}\``,
+    `- Generated: \`${digest.generatedAt}\``,
+    `- Summary: ${digest.summary.headline}`,
+    ""
+  ];
+
+  if (digest.summary.topFeatureAreas.length > 0) {
+    lines.push("## Area Hotspots", "");
+    for (const area of digest.summary.topFeatureAreas) {
+      lines.push(`- \`${area.featureArea}\`: ${area.count} event(s), suggested owner \`${area.ownerArea}\``);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Top Fingerprints", "");
+  if (digest.topFingerprints.length === 0) {
+    lines.push("- No matching error fingerprints.");
+  } else {
+    for (const entry of digest.topFingerprints) {
+      lines.push(`### \`${entry.errorCode}\` on \`${entry.surface}\``);
+      lines.push(`- Feature area: \`${entry.featureArea}\``);
+      lines.push(`- Suggested owner: \`${entry.suggestedOwner}\``);
+      lines.push(`- Count: ${entry.count}`);
+      lines.push(`- First seen revision: \`${entry.firstSeenRevision ?? "unknown"}\``);
+      lines.push(`- Last reproduced: \`${entry.lastSeenAt}\``);
+      lines.push(`- Latest message: ${entry.latestMessage}`);
+      lines.push(
+        `- Context: room=\`${entry.sampleContext.roomId ?? "n/a"}\` route=\`${entry.sampleContext.route ?? "n/a"}\` action=\`${entry.sampleContext.action ?? "n/a"}\``
+      );
+      lines.push("");
+    }
+  }
+
+  lines.push("## Artifacts", "");
+  for (const artifact of digest.artifacts) {
+    lines.push(
+      `- \`${toRelativePath(artifact.path)}\` (${artifact.sourceType}, surface \`${artifact.surface}\`, matched ${artifact.matchedEventCount}/${artifact.eventCount})`
+    );
+  }
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+export function buildCandidateRevisionTriageDigestFromPaths(args: Args): CandidateRevisionTriageDigest {
+  const revision = getRevision(args.candidateRevision);
+  const inputs = args.inputPaths.map((inputPath) => {
+    const resolvedPath = path.resolve(inputPath);
+    const extracted = extractEventsFromInput(readJson(resolvedPath));
+    const matchedEvents = extracted.events.filter(
+      (event) => (event.candidateRevision ?? revision.commit) === revision.commit
+    );
+    return {
+      path: resolvedPath,
+      sourceType: extracted.sourceType,
+      surface: extracted.surface,
+      events: extracted.events,
+      matchedEvents: matchedEvents.map((event) => ({
+        ...event,
+        ownerArea: event.ownerArea || FEATURE_OWNER_MAP[event.featureArea]
+      }))
+    };
+  });
+
+  return buildDigest(args, revision, inputs);
+}
+
+function getDefaultOutputPaths(candidate: string, revision: string): { outputPath: string; markdownOutputPath: string } {
+  const baseName = `candidate-revision-triage-digest-${slugify(candidate)}-${revision.slice(0, 12)}`;
+  return {
+    outputPath: path.join(DEFAULT_OUTPUT_DIR, `${baseName}.json`),
+    markdownOutputPath: path.join(DEFAULT_OUTPUT_DIR, `${baseName}.md`)
+  };
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const digest = buildCandidateRevisionTriageDigestFromPaths(args);
+  const outputDefaults = getDefaultOutputPaths(digest.candidate.name, digest.candidate.revision);
+  const outputPath = path.resolve(args.outputPath ?? outputDefaults.outputPath);
+  const markdownOutputPath = path.resolve(args.markdownOutputPath ?? outputDefaults.markdownOutputPath);
+
+  writeJsonFile(outputPath, digest);
+  ensureDirectory(markdownOutputPath);
+  fs.writeFileSync(markdownOutputPath, renderMarkdown(digest), "utf8");
+
+  console.log(`Wrote candidate triage digest JSON: ${toRelativePath(outputPath)}`);
+  console.log(`Wrote candidate triage digest Markdown: ${toRelativePath(markdownOutputPath)}`);
+  console.log(digest.summary.headline);
+}
+
+const invokedScript = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const currentScript = path.resolve(process.cwd(), "scripts", "candidate-revision-triage-digest.ts");
+
+if (invokedScript === currentScript) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`candidate triage digest failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/test/candidate-revision-triage-digest.test.ts
+++ b/scripts/test/candidate-revision-triage-digest.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildRuntimeDiagnosticsErrorEvent } from "../../packages/shared/src/index.ts";
+import {
+  buildCandidateRevisionTriageDigestFromPaths,
+  renderMarkdown
+} from "../candidate-revision-triage-digest.ts";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+function createTempWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "veil-candidate-triage-"));
+}
+
+function writeJson(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+test("candidate triage digest aggregates server and h5 fingerprint summaries for one candidate revision", () => {
+  const workspace = createTempWorkspace();
+  const serverSnapshotPath = path.join(workspace, "server-runtime-diagnostic.json");
+  const clientSnapshotPath = path.join(workspace, "client-runtime-diagnostic.json");
+
+  writeJson(serverSnapshotPath, {
+    schemaVersion: 1,
+    exportedAt: "2026-04-04T10:00:00.000Z",
+    source: { surface: "server-observability", devOnly: false, mode: "server" },
+    room: null,
+    world: null,
+    battle: null,
+    account: null,
+    overview: null,
+    diagnostics: {
+      eventTypes: [],
+      timelineTail: [],
+      logTail: [],
+      recoverySummary: null,
+      predictionStatus: "server-observability",
+      pendingUiTasks: 0,
+      replay: null,
+      primaryClientTelemetry: [],
+      errorEvents: [
+        buildRuntimeDiagnosticsErrorEvent({
+          id: "server-share-1",
+          recordedAt: "2026-04-04T09:59:00.000Z",
+          source: "server",
+          surface: "server",
+          candidateRevision: "abc1234",
+          featureArea: "share",
+          ownerArea: "social",
+          severity: "error",
+          errorCode: "share_webhook_failed",
+          message: "Share webhook returned 502.",
+          context: {
+            roomId: "room-share",
+            playerId: "player-1",
+            requestId: "share-1",
+            route: "/api/share/publish",
+            action: "share.publish",
+            statusCode: 502,
+            crash: false,
+            detail: "upstream gateway failure"
+          }
+        })
+      ],
+      errorSummary: {
+        totalEvents: 1,
+        uniqueFingerprints: 1,
+        fatalCount: 0,
+        crashCount: 0,
+        latestRecordedAt: "2026-04-04T09:59:00.000Z",
+        byFeatureArea: [{ featureArea: "share", count: 1 }],
+        topFingerprints: []
+      }
+    }
+  });
+
+  writeJson(clientSnapshotPath, {
+    schemaVersion: 1,
+    exportedAt: "2026-04-04T10:01:00.000Z",
+    source: { surface: "h5-debug-shell", devOnly: true, mode: "world" },
+    room: null,
+    world: null,
+    battle: null,
+    account: null,
+    overview: null,
+    diagnostics: {
+      eventTypes: [],
+      timelineTail: [],
+      logTail: [],
+      recoverySummary: null,
+      predictionStatus: null,
+      pendingUiTasks: 1,
+      replay: null,
+      primaryClientTelemetry: [],
+      errorEvents: [
+        buildRuntimeDiagnosticsErrorEvent({
+          id: "client-login-1",
+          recordedAt: "2026-04-04T10:00:30.000Z",
+          source: "client",
+          surface: "h5",
+          candidateRevision: "abc1234",
+          featureArea: "login",
+          ownerArea: "account",
+          severity: "fatal",
+          errorCode: "auth_request_failed",
+          message: "Login request failed and crashed the shell.",
+          context: {
+            roomId: null,
+            playerId: "player-2",
+            requestId: "auth-1",
+            route: "/api/auth/login",
+            action: "login.submit",
+            statusCode: 500,
+            crash: true,
+            detail: "uncaught error boundary"
+          }
+        }),
+        buildRuntimeDiagnosticsErrorEvent({
+          id: "client-login-2",
+          recordedAt: "2026-04-04T10:00:45.000Z",
+          source: "client",
+          surface: "h5",
+          candidateRevision: "abc1234",
+          featureArea: "login",
+          ownerArea: "account",
+          severity: "error",
+          errorCode: "auth_request_failed",
+          message: "Login request failed again.",
+          context: {
+            roomId: null,
+            playerId: "player-3",
+            requestId: "auth-2",
+            route: "/api/auth/login",
+            action: "login.submit",
+            statusCode: 500,
+            crash: false,
+            detail: "same server 500"
+          }
+        })
+      ],
+      errorSummary: {
+        totalEvents: 2,
+        uniqueFingerprints: 1,
+        fatalCount: 1,
+        crashCount: 1,
+        latestRecordedAt: "2026-04-04T10:00:45.000Z",
+        byFeatureArea: [{ featureArea: "login", count: 2 }],
+        topFingerprints: []
+      }
+    }
+  });
+
+  const digest = buildCandidateRevisionTriageDigestFromPaths({
+    candidate: "phase1-rc",
+    candidateRevision: "abc1234",
+    inputPaths: [serverSnapshotPath, clientSnapshotPath]
+  });
+
+  assert.equal(digest.summary.totalEvents, 3);
+  assert.equal(digest.summary.uniqueFingerprints, 2);
+  assert.equal(digest.summary.fatalCount, 1);
+  assert.equal(digest.summary.crashCount, 1);
+  assert.equal(digest.topFingerprints[0]?.errorCode, "auth_request_failed");
+  assert.equal(digest.topFingerprints[0]?.count, 2);
+  assert.equal(digest.topFingerprints[0]?.suggestedOwner, "account");
+  assert.equal(digest.artifacts[0]?.matchedEventCount, 1);
+  assert.equal(digest.artifacts[1]?.matchedEventCount, 2);
+
+  const markdown = renderMarkdown(digest);
+  assert.match(markdown, /Candidate: `phase1-rc`/);
+  assert.match(markdown, /`login`: 2 event\(s\), suggested owner `account`/);
+  assert.match(markdown, /First seen revision: `abc1234`/);
+});
+
+test("candidate triage digest CLI writes json and markdown artifacts", () => {
+  const workspace = createTempWorkspace();
+  const inputPath = path.join(workspace, "client-errors.json");
+  const outputPath = path.join(workspace, "candidate-triage.json");
+  const markdownOutputPath = path.join(workspace, "candidate-triage.md");
+
+  writeJson(inputPath, {
+    errorEvents: [
+      buildRuntimeDiagnosticsErrorEvent({
+        id: "reward-1",
+        recordedAt: "2026-04-04T11:00:00.000Z",
+        source: "client",
+        surface: "h5",
+        candidateRevision: "abc1234",
+        featureArea: "rewards",
+        ownerArea: "progression",
+        severity: "error",
+        errorCode: "daily_reward_claim_failed",
+        message: "Daily reward claim failed for one candidate.",
+        context: {
+          roomId: "room-alpha",
+          playerId: "player-9",
+          requestId: "reward-1",
+          route: "/api/player-account/daily-reward",
+          action: "reward.claim",
+          statusCode: 409,
+          crash: false,
+          detail: "stale reward state"
+        }
+      })
+    ]
+  });
+
+  const result = spawnSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/candidate-revision-triage-digest.ts",
+      "--candidate",
+      "phase1-rc",
+      "--candidate-revision",
+      "abc1234",
+      "--input",
+      inputPath,
+      "--output",
+      outputPath,
+      "--markdown-output",
+      markdownOutputPath
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 0, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+  assert.equal(fs.existsSync(outputPath), true);
+  assert.equal(fs.existsSync(markdownOutputPath), true);
+});


### PR DESCRIPTION
## Summary
- add structured runtime diagnostics error events and aggregated error summaries to shared, H5, Cocos, and server observability snapshots
- add a candidate-revision triage digest CLI plus docs to aggregate snapshot or bundle inputs into JSON and Markdown release artifacts
- cover the new diagnostics and triage digest behavior with focused tests across shared, client, cocos, server, and script surfaces

## Root Cause
Runtime diagnostics snapshots did not preserve candidate-scoped crash/runtime exception evidence in a consistent structure, which made it difficult to triage repeated failures across candidate revisions and route them to the right owner quickly.

## Validation
- `node --import tsx --test packages/shared/test/runtime-diagnostics.test.ts scripts/test/candidate-revision-triage-digest.test.ts apps/client/test/runtime-diagnostics.test.ts apps/cocos-client/test/cocos-runtime-diagnostics.test.ts apps/server/test/runtime-observability-routes.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:client:h5`
- `npm run typecheck:cocos`
- `npm run typecheck:server`

Closes #892