### PR TITLE
[codex] add battle pass progression panel

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -31,9 +31,10 @@ export interface ShopProductGrant {
   resources?: Partial<ResourceLedger>;
   equipmentIds?: string[];
   cosmeticIds?: string[];
+  seasonPassPremium?: boolean;
 }
 
-export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle" | "cosmetic";
+export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle" | "season_pass_premium" | "cosmetic";
 
 export interface ShopProduct {
   productId: string;
@@ -56,6 +57,7 @@ export interface ShopPurchaseResult {
     resources: ResourceLedger;
     equipmentIds: string[];
     cosmeticIds: string[];
+    seasonPassPremium?: boolean;
     heroId?: string;
   };
   gemsBalance: number;
@@ -1100,7 +1102,8 @@ function normalizeShopProductGrant(value: unknown): ShopProductGrant {
         }
       : {}),
     ...(equipmentIds.length > 0 ? { equipmentIds } : {}),
-    ...(cosmeticIds.length > 0 ? { cosmeticIds } : {})
+    ...(cosmeticIds.length > 0 ? { cosmeticIds } : {}),
+    ...(raw.seasonPassPremium === true ? { seasonPassPremium: true } : {})
   };
 }
 
@@ -1110,7 +1113,10 @@ function normalizeShopProduct(raw: unknown, index: number): ShopProduct {
     productId: typeof value.productId === "string" && value.productId.trim() ? value.productId.trim() : `shop-product-${index + 1}`,
     name: typeof value.name === "string" && value.name.trim() ? value.name.trim() : `Shop Product ${index + 1}`,
     type:
-      value.type === "equipment" || value.type === "resource_bundle" || value.type === "cosmetic"
+      value.type === "equipment" ||
+      value.type === "resource_bundle" ||
+      value.type === "season_pass_premium" ||
+      value.type === "cosmetic"
         ? value.type
         : "gem_pack",
     price: typeof value.price === "number" && Number.isFinite(value.price) ? Math.max(0, Math.floor(value.price)) : 0,

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -208,6 +208,7 @@ export interface VeilHudRenderState {
   sharing: {
     available: boolean;
   };
+  battlePassEnabled: boolean;
   interaction: {
     title: string;
     detail: string;
@@ -246,6 +247,7 @@ export interface VeilHudPanelOptions {
   onToggleSettings?: () => void;
   onToggleInventory?: () => void;
   onToggleAchievements?: () => void;
+  onToggleProgression?: () => void;
   onToggleReport?: () => void;
   onToggleSurrender?: () => void;
   onShareBattleResult?: () => void;
@@ -358,6 +360,7 @@ export class VeilHudPanel extends Component {
   private onToggleSettings: (() => void) | undefined;
   private onToggleInventory: (() => void) | undefined;
   private onToggleAchievements: (() => void) | undefined;
+  private onToggleProgression: (() => void) | undefined;
   private onToggleReport: (() => void) | undefined;
   private onToggleSurrender: (() => void) | undefined;
   private onShareBattleResult: (() => void) | undefined;
@@ -379,6 +382,7 @@ export class VeilHudPanel extends Component {
     this.onToggleSettings = options.onToggleSettings;
     this.onToggleInventory = options.onToggleInventory;
     this.onToggleAchievements = options.onToggleAchievements;
+    this.onToggleProgression = options.onToggleProgression;
     this.onToggleReport = options.onToggleReport;
     this.onToggleSurrender = options.onToggleSurrender;
     this.onShareBattleResult = options.onShareBattleResult;
@@ -679,6 +683,7 @@ export class VeilHudPanel extends Component {
       { nodeName: "HudSettings", debugLabel: "settings", callback: this.onToggleSettings ?? null },
       { nodeName: "HudInventory", debugLabel: "inventory", callback: this.onToggleInventory ?? null },
       { nodeName: "HudAchievements", debugLabel: "achievements", callback: this.onToggleAchievements ?? null },
+      { nodeName: "HudBattlePass", debugLabel: "battle-pass", callback: this.onToggleProgression ?? null },
       { nodeName: "HudReportPlayer", debugLabel: "report-player", callback: this.onToggleReport ?? null },
       { nodeName: "HudSurrender", debugLabel: "surrender", callback: this.onToggleSurrender ?? null },
       { nodeName: "HudShareBattleResult", debugLabel: "share-battle-result", callback: this.onShareBattleResult ?? null },
@@ -1628,6 +1633,7 @@ export class VeilHudPanel extends Component {
     this.ensureActionButton(actionsNode, "HudSettings", "设置");
     this.ensureActionButton(actionsNode, "HudInventory", "装备背包");
     this.ensureActionButton(actionsNode, "HudAchievements", "战报中心");
+    this.ensureActionButton(actionsNode, "HudBattlePass", "赛季通行证");
     this.ensureActionButton(actionsNode, "HudReportPlayer", "举报玩家");
     this.ensureActionButton(actionsNode, "HudSurrender", "认输");
     this.ensureActionButton(actionsNode, "HudShareBattleResult", "分享战绩");
@@ -1655,6 +1661,12 @@ export class VeilHudPanel extends Component {
       { name: "HudSettings", label: "设置", callback: this.onToggleSettings ?? null },
       { name: "HudInventory", label: "装备背包", callback: this.onToggleInventory ?? null },
       { name: "HudAchievements", label: "战报中心", callback: this.onToggleAchievements ?? null },
+      {
+        name: "HudBattlePass",
+        label: "赛季通行证",
+        callback: this.onToggleProgression ?? null,
+        visible: this.currentState?.battlePassEnabled ?? false
+      },
       { name: "HudReportPlayer", label: "举报玩家", callback: this.onToggleReport ?? null },
       {
         name: "HudSurrender",

--- a/apps/cocos-client/assets/scripts/VeilProgressionPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilProgressionPanel.ts
@@ -1,5 +1,6 @@
 import { _decorator, Color, Component, Graphics, Label, Node, UITransform } from "cc";
 import { type CocosAccountReviewPage, type CocosAccountReviewSection } from "./cocos-account-review.ts";
+import { type CocosBattlePassPanelView } from "./cocos-progression-panel.ts";
 import { assignUiLayer } from "./cocos-ui-layer.ts";
 
 const { ccclass } = _decorator;
@@ -18,16 +19,24 @@ const NEGATIVE_FILL = new Color(112, 72, 64, 220);
 const CARD_FILL = new Color(34, 46, 64, 186);
 const CARD_HIGHLIGHT_FILL = new Color(56, 74, 102, 208);
 const MUTED_FILL = new Color(28, 38, 52, 168);
+const FREE_TRACK_FILL = new Color(64, 96, 76, 216);
+const PREMIUM_TRACK_FILL = new Color(132, 104, 44, 226);
 
-export interface VeilProgressionPanelRenderState {
-  page: CocosAccountReviewPage;
-}
+export type VeilProgressionPanelRenderState =
+  | {
+      page: CocosAccountReviewPage;
+    }
+  | {
+      battlePass: CocosBattlePassPanelView;
+    };
 
 export interface VeilProgressionPanelOptions {
   onClose?: () => void;
   onSelectSection?: (section: CocosAccountReviewSection) => void;
   onSelectPage?: (section: "battle-replays" | "event-history", page: number) => void;
   onRetrySection?: (section: CocosAccountReviewSection) => void;
+  onClaimTier?: (tier: number) => void;
+  onPurchasePremium?: () => void;
 }
 
 interface PanelButtonTone {
@@ -46,22 +55,37 @@ export class VeilProgressionPanel extends Component {
   private onSelectSection: ((section: CocosAccountReviewSection) => void) | undefined;
   private onSelectPage: ((section: "battle-replays" | "event-history", page: number) => void) | undefined;
   private onRetrySection: ((section: CocosAccountReviewSection) => void) | undefined;
+  private onClaimTier: ((tier: number) => void) | undefined;
+  private onPurchasePremium: (() => void) | undefined;
 
   configure(options: VeilProgressionPanelOptions): void {
     this.onClose = options.onClose;
     this.onSelectSection = options.onSelectSection;
     this.onSelectPage = options.onSelectPage;
     this.onRetrySection = options.onRetrySection;
+    this.onClaimTier = options.onClaimTier;
+    this.onPurchasePremium = options.onPurchasePremium;
   }
 
   render(state: VeilProgressionPanelRenderState): void {
     this.currentState = state;
+    if ("battlePass" in state) {
+      this.renderBattlePass(state.battlePass);
+      return;
+    }
+
+    this.node.active = true;
+    this.hideBattlePassNodes();
+    this.renderAccountReview(state.page);
+  }
+
+  private renderAccountReview(page: CocosAccountReviewPage): void {
     const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
     const width = transform.width || 380;
     const height = transform.height || 440;
     const contentWidth = width - 30;
     const centerX = 0;
-    const pagedSection = isPagedSection(state.page.section) ? state.page.section : null;
+    const pagedSection = isPagedSection(page.section) ? page.section : null;
     let cursorY = height / 2 - 16;
 
     this.syncChrome(width, height);
@@ -72,11 +96,7 @@ export class VeilProgressionPanel extends Component {
       cursorY,
       contentWidth,
       80,
-      [
-        state.page.title,
-        state.page.subtitle,
-        `当前页 ${state.page.pageLabel}`
-      ],
+      [page.title, page.subtitle, `当前页 ${page.pageLabel}`],
       {
         fill: CARD_HIGHLIGHT_FILL,
         stroke: new Color(244, 236, 208, 82)
@@ -86,9 +106,9 @@ export class VeilProgressionPanel extends Component {
       18
     );
 
-    const tabWidth = Math.floor((contentWidth - 18) / Math.max(1, state.page.tabs.length));
+    const tabWidth = Math.floor((contentWidth - 18) / Math.max(1, page.tabs.length));
     const tabStartX = centerX - contentWidth / 2 + tabWidth / 2;
-    state.page.tabs.forEach((tab, index) => {
+    page.tabs.forEach((tab, index) => {
       this.renderButton(
         `ProgressionTab-${tab.section}`,
         tabStartX + index * (tabWidth + 6),
@@ -96,7 +116,7 @@ export class VeilProgressionPanel extends Component {
         tabWidth,
         26,
         `${tab.label} ${tab.count}`,
-        tab.section === state.page.section
+        tab.section === page.section
           ? {
               fill: TAB_ACTIVE_FILL,
               stroke: new Color(230, 244, 222, 116)
@@ -134,9 +154,7 @@ export class VeilProgressionPanel extends Component {
         fill: ACTION_FILL,
         stroke: new Color(224, 236, 248, 108)
       },
-      state.page.hasPreviousPage && pagedSection
-        ? () => this.onSelectPage?.(pagedSection, state.page.page - 1)
-        : null
+      page.hasPreviousPage && pagedSection ? () => this.onSelectPage?.(pagedSection, page.page - 1) : null
     );
 
     this.renderButton(
@@ -150,9 +168,7 @@ export class VeilProgressionPanel extends Component {
         fill: ACTION_FILL,
         stroke: new Color(224, 236, 248, 108)
       },
-      state.page.hasNextPage && pagedSection
-        ? () => this.onSelectPage?.(pagedSection, state.page.page + 1)
-        : null
+      page.hasNextPage && pagedSection ? () => this.onSelectPage?.(pagedSection, page.page + 1) : null
     );
 
     this.renderButton(
@@ -166,19 +182,19 @@ export class VeilProgressionPanel extends Component {
         fill: ACTION_FILL,
         stroke: new Color(224, 236, 248, 108)
       },
-      state.page.showRetry ? () => this.onRetrySection?.(state.page.section) : null
+      page.showRetry ? () => this.onRetrySection?.(page.section) : null
     );
 
     let cardsTop = cursorY - 100;
-    if (state.page.banner) {
+    if (page.banner) {
       cardsTop = this.renderCard(
         "ProgressionBanner",
         centerX,
         cardsTop,
         contentWidth,
         62,
-        [state.page.banner.title, state.page.banner.detail],
-        state.page.banner.tone === "negative"
+        [page.banner.title, page.banner.detail],
+        page.banner.tone === "negative"
           ? {
               fill: NEGATIVE_FILL,
               stroke: new Color(248, 228, 220, 112)
@@ -198,12 +214,12 @@ export class VeilProgressionPanel extends Component {
       }
     }
 
-    const items = state.page.items.length > 0
-      ? state.page.items
+    const items = page.items.length > 0
+      ? page.items
       : [
           {
             title: "当前暂无内容",
-            detail: state.page.subtitle,
+            detail: page.subtitle,
             footnote: "渲染面板已就绪，等待数据同步。",
             emphasis: "neutral" as const
           }
@@ -223,7 +239,7 @@ export class VeilProgressionPanel extends Component {
               stroke: new Color(224, 240, 220, 78)
             }
           : {
-              fill: state.page.items.length > 0 ? CARD_FILL : MUTED_FILL,
+              fill: page.items.length > 0 ? CARD_FILL : MUTED_FILL,
               stroke: new Color(220, 230, 244, 56)
             },
         null,
@@ -232,6 +248,142 @@ export class VeilProgressionPanel extends Component {
       );
     });
     this.hideExtraItems(items.length);
+  }
+
+  private renderBattlePass(view: CocosBattlePassPanelView): void {
+    if (!view.visible) {
+      this.node.active = false;
+      return;
+    }
+
+    this.node.active = true;
+    this.hideAccountReviewNodes();
+
+    const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const width = transform.width || 380;
+    const height = transform.height || 440;
+    const contentWidth = width - 30;
+    let cursorY = height / 2 - 16;
+
+    this.syncChrome(width, height);
+
+    this.renderButton(
+      "BattlePassClose",
+      contentWidth / 2 - 12,
+      height / 2 - 18,
+      72,
+      24,
+      "关闭",
+      {
+        fill: NEGATIVE_FILL,
+        stroke: new Color(244, 226, 214, 114)
+      },
+      this.onClose ?? null
+    );
+
+    cursorY = this.renderCard(
+      "BattlePassHeader",
+      0,
+      cursorY,
+      contentWidth,
+      88,
+      [view.title, view.subtitle, view.progressLabel],
+      {
+        fill: CARD_HIGHLIGHT_FILL,
+        stroke: new Color(244, 236, 208, 82)
+      },
+      null,
+      15,
+      18
+    );
+
+    cursorY = this.renderCard(
+      "BattlePassNextReward",
+      0,
+      cursorY,
+      contentWidth,
+      62,
+      ["奖励预览", view.nextRewardLabel, view.statusLabel],
+      {
+        fill: CARD_FILL,
+        stroke: new Color(220, 230, 244, 56)
+      },
+      null,
+      13,
+      16
+    );
+
+    this.renderProgressBar("BattlePassMeter", 0, cursorY - 18, contentWidth, 16, view.progressRatio);
+    cursorY -= 34;
+
+    this.renderButton(
+      "BattlePassPremiumAction",
+      0,
+      cursorY - 12,
+      contentWidth,
+      26,
+      `${view.premiumActionLabel} · ${view.premiumStatusLabel}`,
+      {
+        fill: PREMIUM_TRACK_FILL,
+        stroke: new Color(248, 230, 184, 118)
+      },
+      view.premiumPurchaseEnabled ? this.onPurchasePremium ?? null : null
+    );
+    cursorY -= 34;
+
+    view.tiers.forEach((tier, index) => {
+      cursorY = this.renderCard(
+        `BattlePassTier-${index}`,
+        0,
+        cursorY,
+        contentWidth,
+        44,
+        [`${tier.tierLabel} · ${tier.xpLabel}`],
+        {
+          fill: MUTED_FILL,
+          stroke: new Color(220, 230, 244, 56)
+        },
+        null,
+        13,
+        16
+      );
+
+      const trackWidth = Math.floor((contentWidth - 8) / 2);
+      const trackY = cursorY - 42;
+      this.renderCard(
+        `BattlePassTrack-${index}-free`,
+        -trackWidth / 2 - 4,
+        trackY,
+        trackWidth,
+        82,
+        [tier.freeTrack.label, tier.freeTrack.detail, tier.freeTrack.claimLabel],
+        {
+          fill: FREE_TRACK_FILL,
+          stroke: new Color(220, 242, 226, 82)
+        },
+        tier.freeTrack.claimable ? () => this.onClaimTier?.(tier.tier) : null,
+        12,
+        15
+      );
+      this.renderCard(
+        `BattlePassTrack-${index}-premium`,
+        trackWidth / 2 + 4,
+        trackY,
+        trackWidth,
+        82,
+        [tier.premiumTrack.label, tier.premiumTrack.detail, tier.premiumTrack.claimLabel],
+        {
+          fill: PREMIUM_TRACK_FILL,
+          stroke: new Color(248, 230, 184, 96)
+        },
+        tier.premiumTrack.claimable ? () => this.onClaimTier?.(tier.tier) : null,
+        12,
+        15
+      );
+      cursorY = trackY - 90;
+    });
+
+    this.hideExtraBattlePassItems(view.tiers.length);
   }
 
   private syncChrome(width: number, height: number): void {
@@ -245,6 +397,35 @@ export class VeilProgressionPanel extends Component {
     graphics.stroke();
     graphics.fillColor = PANEL_INNER;
     graphics.roundRect(-width / 2 + 14, height / 2 - 22, width - 28, 6, 3);
+    graphics.fill();
+  }
+
+  private renderProgressBar(
+    name: string,
+    centerX: number,
+    centerY: number,
+    width: number,
+    height: number,
+    ratio: number
+  ): void {
+    let node = this.node.getChildByName(name);
+    if (!node) {
+      node = new Node(name);
+      node.parent = this.node;
+    }
+    assignUiLayer(node);
+    node.active = true;
+    const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+    transform.setContentSize(width, height);
+    node.setPosition(centerX, centerY, 0.2);
+
+    const graphics = node.getComponent(Graphics) ?? node.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = new Color(40, 52, 70, 220);
+    graphics.roundRect(-width / 2, -height / 2, width, height, 8);
+    graphics.fill();
+    graphics.fillColor = new Color(214, 184, 124, 232);
+    graphics.roundRect(-width / 2, -height / 2, Math.max(8, width * Math.max(0, Math.min(1, ratio))), height, 8);
     graphics.fill();
   }
 
@@ -375,6 +556,39 @@ export class VeilProgressionPanel extends Component {
       const node = this.node.getChildByName(`ProgressionItem-${index}`);
       if (node) {
         node.active = false;
+      }
+    }
+  }
+
+  private hideExtraBattlePassItems(visibleCount: number): void {
+    for (let index = visibleCount; index < 4; index += 1) {
+      const tierNode = this.node.getChildByName(`BattlePassTier-${index}`);
+      if (tierNode) {
+        tierNode.active = false;
+      }
+      const freeNode = this.node.getChildByName(`BattlePassTrack-${index}-free`);
+      if (freeNode) {
+        freeNode.active = false;
+      }
+      const premiumNode = this.node.getChildByName(`BattlePassTrack-${index}-premium`);
+      if (premiumNode) {
+        premiumNode.active = false;
+      }
+    }
+  }
+
+  private hideAccountReviewNodes(): void {
+    this.hideNodesByPrefix(["ProgressionHeader", "ProgressionBanner", "ProgressionClose", "ProgressionPrev", "ProgressionNext", "ProgressionRetry", "ProgressionTab-", "ProgressionItem-"]);
+  }
+
+  private hideBattlePassNodes(): void {
+    this.hideNodesByPrefix(["BattlePassHeader", "BattlePassNextReward", "BattlePassMeter", "BattlePassPremiumAction", "BattlePassClose", "BattlePassTier-", "BattlePassTrack-"]);
+  }
+
+  private hideNodesByPrefix(prefixes: string[]): void {
+    for (const child of this.node.children) {
+      if (prefixes.some((prefix) => child.name.startsWith(prefix))) {
+        child.active = false;
       }
     }
   }

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -26,6 +26,7 @@ import {
   type CocosAccountReviewState
 } from "./cocos-account-review.ts";
 import {
+  claimCocosSeasonTier,
   claimAllCocosMailboxMessages,
   claimCocosMailboxMessage,
   confirmCocosAccountRegistration,
@@ -40,6 +41,7 @@ import {
   loadCocosPlayerAchievementProgress,
   loadCocosPlayerEventHistory,
   loadCocosPlayerProgressionSnapshot,
+  loadCocosSeasonProgress,
   loginCocosGuestAuthSession,
   logoutCurrentCocosAuthSession,
   postCocosPlayerReferral,
@@ -137,6 +139,7 @@ import {
   type CocosAuthProvider
 } from "./cocos-session-launch.ts";
 import { buildCocosShopPanelView, type ShopProduct } from "./cocos-shop-panel.ts";
+import { buildCocosBattlePassPanelView, type CocosSeasonProgress } from "./cocos-progression-panel.ts";
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
 import { VeilProgressionPanel } from "./VeilProgressionPanel.ts";
 import { VeilEquipmentPanel } from "./VeilEquipmentPanel.ts";
@@ -228,6 +231,8 @@ interface VeilRootRuntime {
   loadAchievementProgress: typeof loadCocosPlayerAchievementProgress;
   loadEventHistory: typeof loadCocosPlayerEventHistory;
   loadBattleReplayHistoryPage: typeof loadCocosBattleReplayHistoryPage;
+  loadSeasonProgress: typeof loadCocosSeasonProgress;
+  claimSeasonTier: typeof claimCocosSeasonTier;
   loginGuestAuthSession: typeof loginCocosGuestAuthSession;
   postPlayerReferral: typeof postCocosPlayerReferral;
   logoutAuthSession: typeof logoutCurrentCocosAuthSession;
@@ -254,6 +259,8 @@ const defaultVeilRootRuntime: VeilRootRuntime = {
   loadAchievementProgress: (...args) => loadCocosPlayerAchievementProgress(...args),
   loadEventHistory: (...args) => loadCocosPlayerEventHistory(...args),
   loadBattleReplayHistoryPage: (...args) => loadCocosBattleReplayHistoryPage(...args),
+  loadSeasonProgress: (...args) => loadCocosSeasonProgress(...args),
+  claimSeasonTier: (...args) => claimCocosSeasonTier(...args),
   loginGuestAuthSession: (...args) => loginCocosGuestAuthSession(...args),
   postPlayerReferral: (...args) => postCocosPlayerReferral(...args),
   logoutAuthSession: (...args) => logoutCurrentCocosAuthSession(...args),
@@ -366,6 +373,10 @@ export class VeilRoot extends Component {
   private lobbyShopLoading = false;
   private lobbyShopStatus = "可用商品会在这里显示。";
   private pendingShopProductId: string | null = null;
+  private seasonProgress: CocosSeasonProgress | null = null;
+  private seasonProgressStatus = "赛季进度待同步。";
+  private pendingSeasonClaimTier: number | null = null;
+  private seasonPremiumPurchaseInFlight = false;
   private mailboxClaimingMessageId: string | null = null;
   private mailboxClaimAllInFlight = false;
   private lobbyAccountReviewState: CocosAccountReviewState = createCocosAccountReviewState(this.lobbyAccountProfile);
@@ -373,6 +384,7 @@ export class VeilRoot extends Component {
   private gameplayAccountRefreshInFlight = false;
   private gameplayAccountReviewPanel: VeilProgressionPanel | null = null;
   private gameplayAccountReviewPanelOpen = false;
+  private gameplayBattlePassPanelOpen = false;
   private gameplayEquipmentPanel: VeilEquipmentPanel | null = null;
   private gameplayEquipmentPanelOpen = false;
   private settingsPanel: CocosSettingsPanel | null = null;
@@ -841,6 +853,9 @@ export class VeilRoot extends Component {
       onToggleAchievements: () => {
         void this.openGameplayBattleReportCenter();
       },
+      onToggleProgression: () => {
+        void this.toggleGameplayBattlePassPanel();
+      },
       onToggleReport: () => {
         this.toggleReportDialog();
       },
@@ -1076,6 +1091,10 @@ export class VeilRoot extends Component {
       accountReviewPanelNode.getComponent(VeilProgressionPanel) ?? accountReviewPanelNode.addComponent(VeilProgressionPanel);
     this.gameplayAccountReviewPanel.configure({
       onClose: () => {
+        if (this.gameplayBattlePassPanelOpen) {
+          void this.toggleGameplayBattlePassPanel(false);
+          return;
+        }
         void this.toggleGameplayAccountReviewPanel(false);
       },
       onSelectSection: (section) => {
@@ -1096,6 +1115,12 @@ export class VeilRoot extends Component {
       },
       onRetrySection: (section) => {
         void this.refreshActiveAccountReviewSection(section);
+      },
+      onClaimTier: (tier) => {
+        void this.claimGameplaySeasonTier(tier);
+      },
+      onPurchasePremium: () => {
+        void this.purchaseGameplaySeasonPremium();
       }
     });
 
@@ -1242,7 +1267,7 @@ export class VeilRoot extends Component {
       timelineNode.active = showingGame;
     }
     if (accountReviewPanelNode) {
-      accountReviewPanelNode.active = showingGame && this.gameplayAccountReviewPanelOpen;
+      accountReviewPanelNode.active = showingGame && (this.gameplayAccountReviewPanelOpen || this.gameplayBattlePassPanelOpen);
     }
     if (equipmentPanelNode) {
       equipmentPanelNode.active = showingGame && this.gameplayEquipmentPanelOpen;
@@ -1303,6 +1328,7 @@ export class VeilRoot extends Component {
           gemBalance: this.lobbyAccountProfile.gems ?? 0,
           pendingProductId: this.pendingShopProductId,
           ownedCosmeticIds: this.lobbyAccountProfile.cosmeticInventory?.ownedIds ?? [],
+          seasonPassPremiumOwned: this.lobbyAccountProfile.seasonPassPremium === true,
           ...(this.lobbyAccountProfile.equippedCosmetics ? { equippedCosmetics: this.lobbyAccountProfile.equippedCosmetics } : {})
         }),
         shopStatus: this.lobbyShopStatus,
@@ -1374,6 +1400,7 @@ export class VeilRoot extends Component {
       sharing: {
         available: this.canShareLatestBattleResult()
       },
+      battlePassEnabled: this.lastUpdate?.featureFlags?.battle_pass_enabled === true,
       interaction: this.buildHudInteractionState(),
       presentation: this.buildHudPresentationState()
     });
@@ -1431,12 +1458,24 @@ export class VeilRoot extends Component {
       return;
     }
 
-    if (!this.gameplayAccountReviewPanelOpen) {
+    if (!this.gameplayAccountReviewPanelOpen && !this.gameplayBattlePassPanelOpen) {
       panelNode.active = false;
       return;
     }
 
     panelNode.active = true;
+    if (this.gameplayBattlePassPanelOpen) {
+      this.gameplayAccountReviewPanel?.render({
+        battlePass: buildCocosBattlePassPanelView({
+          progress: this.seasonProgress,
+          pendingClaimTier: this.pendingSeasonClaimTier,
+          pendingPremiumPurchase: this.seasonPremiumPurchaseInFlight,
+          statusLabel: this.seasonProgressStatus
+        })
+      });
+      return;
+    }
+
     this.gameplayAccountReviewPanel?.render({
       page: buildCocosAccountReviewPage(this.lobbyAccountReviewState)
     });
@@ -1840,6 +1879,7 @@ export class VeilRoot extends Component {
 
   private async toggleGameplayAccountReviewPanel(forceOpen?: boolean): Promise<void> {
     const nextOpen = forceOpen ?? !this.gameplayAccountReviewPanelOpen;
+    this.gameplayBattlePassPanelOpen = false;
     this.gameplayAccountReviewPanelOpen = nextOpen;
     if (!nextOpen) {
       this.renderView();
@@ -1848,6 +1888,123 @@ export class VeilRoot extends Component {
 
     this.renderView();
     await this.refreshActiveAccountReviewSection();
+  }
+
+  private async toggleGameplayBattlePassPanel(forceOpen?: boolean): Promise<void> {
+    if (this.lastUpdate?.featureFlags?.battle_pass_enabled !== true) {
+      this.gameplayBattlePassPanelOpen = false;
+      this.seasonProgressStatus = "battle_pass_enabled = false";
+      this.renderView();
+      return;
+    }
+
+    const nextOpen = forceOpen ?? !this.gameplayBattlePassPanelOpen;
+    this.gameplayAccountReviewPanelOpen = false;
+    this.gameplayBattlePassPanelOpen = nextOpen;
+    if (!nextOpen) {
+      this.renderView();
+      return;
+    }
+
+    this.seasonProgress = this.snapshotSeasonProgressFromProfile();
+    this.renderView();
+    await this.refreshSeasonProgress();
+  }
+
+  private snapshotSeasonProgressFromProfile(): CocosSeasonProgress {
+    return {
+      battlePassEnabled: this.lastUpdate?.featureFlags?.battle_pass_enabled === true,
+      seasonXp: Math.max(0, Math.floor(this.lobbyAccountProfile.seasonXp ?? 0)),
+      seasonPassTier: Math.max(1, Math.floor(this.lobbyAccountProfile.seasonPassTier ?? 1)),
+      seasonPassPremium: this.lobbyAccountProfile.seasonPassPremium === true,
+      seasonPassClaimedTiers: this.lobbyAccountProfile.seasonPassClaimedTiers ?? []
+    };
+  }
+
+  private async refreshSeasonProgress(): Promise<void> {
+    const storage = this.readWebStorage();
+    const authSession = this.currentLobbyAuthSession();
+    if (!authSession?.token) {
+      this.seasonProgressStatus = "赛季进度需要有效账号会话。";
+      this.renderView();
+      return;
+    }
+
+    this.seasonProgressStatus = "正在同步赛季进度...";
+    this.renderView();
+    try {
+      this.seasonProgress = await resolveVeilRootRuntime().loadSeasonProgress(this.remoteUrl, {
+        storage,
+        authSession,
+        throwOnError: true
+      });
+      this.seasonProgressStatus = this.seasonProgress.seasonPassPremium
+        ? "高级通行证已激活，可领取高级轨道奖励。"
+        : "点击金色按钮可购买高级通行证。";
+    } catch (error) {
+      this.seasonProgressStatus = error instanceof Error ? error.message : "season_progress_unavailable";
+    }
+    this.renderView();
+  }
+
+  private async claimGameplaySeasonTier(tier: number): Promise<void> {
+    const storage = this.readWebStorage();
+    const authSession = this.currentLobbyAuthSession();
+    if (!authSession?.token || this.pendingSeasonClaimTier != null) {
+      return;
+    }
+
+    this.pendingSeasonClaimTier = Math.max(1, Math.floor(tier));
+    this.seasonProgressStatus = `正在领取 T${this.pendingSeasonClaimTier} 奖励...`;
+    this.renderView();
+    try {
+      await resolveVeilRootRuntime().claimSeasonTier(this.remoteUrl, this.pendingSeasonClaimTier, {
+        storage,
+        authSession
+      });
+      await this.refreshLobbyAccountProfile();
+      await this.refreshSeasonProgress();
+      this.seasonProgressStatus = `T${this.pendingSeasonClaimTier} 奖励已领取。`;
+    } catch (error) {
+      this.seasonProgressStatus = error instanceof Error ? error.message : "season_claim_failed";
+    } finally {
+      this.pendingSeasonClaimTier = null;
+      this.renderView();
+    }
+  }
+
+  private async purchaseGameplaySeasonPremium(): Promise<void> {
+    if (this.seasonPremiumPurchaseInFlight) {
+      return;
+    }
+
+    const premiumProduct =
+      this.lobbyShopProducts.find((entry) => entry.type === "season_pass_premium" && entry.enabled)
+      ?? this.lobbyShopProducts.find((entry) => entry.productId === "season-pass-premium");
+    if (!premiumProduct) {
+      this.seasonProgressStatus = "未找到高级通行证商品配置。";
+      this.renderView();
+      return;
+    }
+
+    this.seasonPremiumPurchaseInFlight = true;
+    this.pendingShopProductId = premiumProduct.productId;
+    this.seasonProgressStatus = `正在购买 ${premiumProduct.name}...`;
+    this.renderView();
+    try {
+      await resolveVeilRootRuntime().purchaseShopProduct(this.remoteUrl, premiumProduct.productId, {
+        getAuthToken: () => this.authToken
+      });
+      await this.refreshLobbyAccountProfile();
+      await this.refreshSeasonProgress();
+      this.seasonProgressStatus = "高级通行证已解锁。";
+    } catch (error) {
+      this.seasonProgressStatus = this.describeShopError(error);
+    } finally {
+      this.seasonPremiumPurchaseInFlight = false;
+      this.pendingShopProductId = null;
+      this.renderView();
+    }
   }
 
   private toggleGameplayEquipmentPanel(forceOpen?: boolean): void {
@@ -2209,6 +2366,9 @@ export class VeilRoot extends Component {
         },
         onToggleAchievements: () => {
           void this.openGameplayBattleReportCenter();
+        },
+        onToggleProgression: () => {
+          void this.toggleGameplayBattlePassPanel();
         },
         onToggleReport: () => {
           this.toggleReportDialog();
@@ -3458,7 +3618,9 @@ export class VeilRoot extends Component {
     await this.disposeCurrentSession();
     this.resetSessionViewport("已返回 Cocos Lobby。");
     this.gameplayAccountReviewPanelOpen = false;
+    this.gameplayBattlePassPanelOpen = false;
     this.gameplayEquipmentPanelOpen = false;
+    this.seasonProgress = null;
     this.showLobby = true;
     this.syncWechatShareBridge();
     this.lobbyStatus = "已返回大厅，可继续选房或创建新实例。";
@@ -4860,6 +5022,9 @@ export class VeilRoot extends Component {
     }
 
     this.lobbyAccountProfile = profile;
+    if (this.gameplayBattlePassPanelOpen || this.seasonProgress) {
+      this.seasonProgress = this.snapshotSeasonProgressFromProfile();
+    }
     this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
       type: "account.synced",
       account: profile

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -26,6 +26,7 @@ import {
   type PlayerAchievementProgress,
   type TutorialProgressAction
 } from "./project-shared/index.ts";
+import type { CocosSeasonProgress } from "./cocos-progression-panel.ts";
 import { detectCocosRuntimePlatform } from "./cocos-runtime-platform.ts";
 
 const LOBBY_PREFERENCES_STORAGE_KEY = "project-veil:lobby-preferences";
@@ -168,6 +169,14 @@ interface PlayerAchievementListApiPayload {
   items?: Partial<PlayerAchievementProgress>[];
 }
 
+interface PlayerSeasonProgressApiPayload {
+  battlePassEnabled?: boolean;
+  seasonXp?: number;
+  seasonPassTier?: number;
+  seasonPassPremium?: boolean;
+  seasonPassClaimedTiers?: number[];
+}
+
 export interface CocosAccountRegistrationRequestResult {
   status: string;
   expiresAt?: string;
@@ -193,6 +202,24 @@ export interface CocosEventHistoryPage {
   offset: number;
   limit: number;
   hasMore: boolean;
+}
+
+function normalizeSeasonProgress(payload?: PlayerSeasonProgressApiPayload | null): CocosSeasonProgress {
+  const seasonPassClaimedTiers = Array.from(
+    new Set(
+      (payload?.seasonPassClaimedTiers ?? [])
+        .map((tier) => Math.floor(tier))
+        .filter((tier) => Number.isFinite(tier) && tier > 0)
+    )
+  ).sort((left, right) => left - right);
+
+  return {
+    battlePassEnabled: payload?.battlePassEnabled === true,
+    seasonXp: Math.max(0, Math.floor(payload?.seasonXp ?? 0)),
+    seasonPassTier: Math.max(1, Math.floor(payload?.seasonPassTier ?? 1)),
+    seasonPassPremium: payload?.seasonPassPremium === true,
+    seasonPassClaimedTiers
+  };
 }
 
 type PlayerProgressionApiPayload = Partial<PlayerProgressionSnapshot>;
@@ -1886,4 +1913,76 @@ export async function loadCocosPlayerProgressionSnapshot(
     }
     return normalizePlayerProgressionSnapshot();
   }
+}
+
+export async function loadCocosSeasonProgress(
+  remoteUrl: string,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "removeItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+    throwOnError?: boolean;
+  }
+): Promise<CocosSeasonProgress> {
+  const storage = options?.storage ?? getCocosStorage();
+  const authSession =
+    options && "authSession" in options ? options.authSession ?? null : readStoredCocosAuthSession(storage);
+
+  try {
+    const payload = (await fetchCocosAuthJson(
+      remoteUrl,
+      `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/season/progress`,
+      {
+        ...(authSession?.token ? { headers: buildCocosAuthHeaders(authSession.token) } : {})
+      },
+      authSession,
+      {
+        ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        ...(storage !== undefined ? { storage } : {})
+      }
+    )) as PlayerSeasonProgressApiPayload;
+    return normalizeSeasonProgress(payload);
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && storage) {
+      clearStoredCocosAuthSession(storage);
+    }
+    if (options?.throwOnError) {
+      throw error;
+    }
+    return normalizeSeasonProgress();
+  }
+}
+
+export async function claimCocosSeasonTier(
+  remoteUrl: string,
+  tier: number,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "removeItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<void> {
+  const storage = options?.storage ?? getCocosStorage();
+  const authSession =
+    options && "authSession" in options ? options.authSession ?? null : readStoredCocosAuthSession(storage);
+
+  await fetchCocosAuthJson(
+    remoteUrl,
+    `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/season/claim-tier`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(authSession?.token ? buildCocosAuthHeaders(authSession.token) : {})
+      },
+      body: JSON.stringify({
+        tier: Math.max(1, Math.floor(tier))
+      })
+    },
+    authSession,
+    {
+      ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+      ...(storage !== undefined ? { storage } : {})
+    }
+  );
 }

--- a/apps/cocos-client/assets/scripts/cocos-progression-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-progression-panel.ts
@@ -1,0 +1,194 @@
+import { getBattlePassConfig, type BattlePassRewardConfig, type BattlePassTierConfig } from "./project-shared/world-config.ts";
+
+export interface CocosSeasonProgress {
+  battlePassEnabled: boolean;
+  seasonXp: number;
+  seasonPassTier: number;
+  seasonPassPremium: boolean;
+  seasonPassClaimedTiers: number[];
+}
+
+export interface CocosBattlePassTrackView {
+  label: string;
+  detail: string;
+  claimLabel: string;
+  claimable: boolean;
+  claimed: boolean;
+}
+
+export interface CocosBattlePassTierView {
+  tier: number;
+  tierLabel: string;
+  xpLabel: string;
+  freeTrack: CocosBattlePassTrackView;
+  premiumTrack: CocosBattlePassTrackView;
+}
+
+export interface CocosBattlePassPanelView {
+  visible: boolean;
+  title: string;
+  subtitle: string;
+  progressLabel: string;
+  progressRatio: number;
+  nextRewardLabel: string;
+  premiumStatusLabel: string;
+  premiumActionLabel: string;
+  premiumPurchaseEnabled: boolean;
+  statusLabel: string;
+  tiers: CocosBattlePassTierView[];
+}
+
+export interface BuildCocosBattlePassPanelInput {
+  progress: CocosSeasonProgress | null;
+  pendingClaimTier: number | null;
+  pendingPremiumPurchase: boolean;
+  statusLabel: string;
+}
+
+function formatRewardLabel(reward: BattlePassRewardConfig): string {
+  if ((reward.gems ?? 0) > 0) {
+    return `宝石 x${Math.floor(reward.gems ?? 0)}`;
+  }
+  if ((reward.gold ?? 0) > 0 || (reward.wood ?? 0) > 0 || (reward.ore ?? 0) > 0) {
+    const parts = [
+      (reward.gold ?? 0) > 0 ? `金币 +${Math.floor(reward.gold ?? 0)}` : null,
+      (reward.wood ?? 0) > 0 ? `木材 +${Math.floor(reward.wood ?? 0)}` : null,
+      (reward.ore ?? 0) > 0 ? `矿石 +${Math.floor(reward.ore ?? 0)}` : null
+    ].filter(Boolean);
+    return parts.join(" / ");
+  }
+  if (reward.equipmentId?.trim()) {
+    return `装备 ${reward.equipmentId.trim()}`;
+  }
+  return "奖励待同步";
+}
+
+function formatTrackClaimLabel(
+  tier: BattlePassTierConfig,
+  progress: CocosSeasonProgress,
+  pendingClaimTier: number | null,
+  premiumTrack: boolean
+): string {
+  const claimed = progress.seasonPassClaimedTiers.includes(tier.tier);
+  if (pendingClaimTier === tier.tier) {
+    return "领取中...";
+  }
+  if (claimed) {
+    return "已领取";
+  }
+  if (tier.tier > progress.seasonPassTier) {
+    return "未解锁";
+  }
+  if (premiumTrack && !progress.seasonPassPremium) {
+    return "需高级通行证";
+  }
+  return "点击领取";
+}
+
+function isTrackClaimable(tier: BattlePassTierConfig, progress: CocosSeasonProgress, premiumTrack: boolean): boolean {
+  if (progress.seasonPassClaimedTiers.includes(tier.tier)) {
+    return false;
+  }
+  if (tier.tier > progress.seasonPassTier) {
+    return false;
+  }
+  if (premiumTrack && !progress.seasonPassPremium) {
+    return false;
+  }
+  return true;
+}
+
+function resolveVisibleTiers(config: ReturnType<typeof getBattlePassConfig>, progress: CocosSeasonProgress): BattlePassTierConfig[] {
+  const startTier = Math.max(1, Math.min(progress.seasonPassTier, Math.max(1, config.tiers.length - 3)));
+  return config.tiers.filter((tier) => tier.tier >= startTier).slice(0, 4);
+}
+
+function resolveProgressRatio(config: ReturnType<typeof getBattlePassConfig>, progress: CocosSeasonProgress): { label: string; ratio: number } {
+  const currentTier = config.tiers.find((tier) => tier.tier === progress.seasonPassTier) ?? config.tiers[0];
+  const nextTier = config.tiers.find((tier) => tier.tier === progress.seasonPassTier + 1) ?? null;
+  const currentXp = Math.max(0, progress.seasonXp);
+  if (!currentTier || !nextTier) {
+    return {
+      label: `通行证等级 ${progress.seasonPassTier} · 已达成赛季上限`,
+      ratio: 1
+    };
+  }
+
+  const floorXp = Math.max(0, currentTier.xpRequired);
+  const ceilingXp = Math.max(floorXp + 1, nextTier.xpRequired);
+  const gainedWithinTier = Math.max(0, currentXp - floorXp);
+  const totalWithinTier = Math.max(1, ceilingXp - floorXp);
+  return {
+    label: `等级 ${progress.seasonPassTier} · 赛季经验 ${currentXp}/${ceilingXp}`,
+    ratio: Math.max(0, Math.min(1, gainedWithinTier / totalWithinTier))
+  };
+}
+
+function resolveNextRewardLabel(config: ReturnType<typeof getBattlePassConfig>, progress: CocosSeasonProgress): string {
+  const nextTier =
+    config.tiers.find((tier) => !progress.seasonPassClaimedTiers.includes(tier.tier) && tier.tier >= progress.seasonPassTier)
+    ?? config.tiers.find((tier) => tier.tier > progress.seasonPassTier)
+    ?? config.tiers[config.tiers.length - 1];
+  if (!nextTier) {
+    return "当前赛季奖励已全部同步。";
+  }
+
+  return `下一奖励 T${nextTier.tier} · 免费 ${formatRewardLabel(nextTier.freeReward)} · 高级 ${formatRewardLabel(nextTier.premiumReward)}`;
+}
+
+export function buildCocosBattlePassPanelView(input: BuildCocosBattlePassPanelInput): CocosBattlePassPanelView {
+  const progress = input.progress;
+  if (!progress || !progress.battlePassEnabled) {
+    return {
+      visible: false,
+      title: "赛季通行证",
+      subtitle: "当前账号未开放此功能。",
+      progressLabel: "未开放",
+      progressRatio: 0,
+      nextRewardLabel: "功能关闭时不展示面板。",
+      premiumStatusLabel: "battle_pass_enabled = false",
+      premiumActionLabel: "未开放",
+      premiumPurchaseEnabled: false,
+      statusLabel: input.statusLabel,
+      tiers: []
+    };
+  }
+
+  const config = getBattlePassConfig();
+  const progressMeter = resolveProgressRatio(config, progress);
+  return {
+    visible: true,
+    title: "赛季通行证",
+    subtitle: `当前等级 T${progress.seasonPassTier} · ${progress.seasonPassPremium ? "高级通行证已激活" : "免费通行证"}`,
+    progressLabel: progressMeter.label,
+    progressRatio: progressMeter.ratio,
+    nextRewardLabel: resolveNextRewardLabel(config, progress),
+    premiumStatusLabel: progress.seasonPassPremium ? "高级通行证已解锁全部高级轨道。" : "解锁高级轨道可领取金色奖励。", 
+    premiumActionLabel: input.pendingPremiumPurchase
+      ? "购买中..."
+      : progress.seasonPassPremium
+        ? "已解锁"
+        : "解锁高级通行证",
+    premiumPurchaseEnabled: !input.pendingPremiumPurchase && !progress.seasonPassPremium,
+    statusLabel: input.statusLabel,
+    tiers: resolveVisibleTiers(config, progress).map((tier) => ({
+      tier: tier.tier,
+      tierLabel: `T${tier.tier}`,
+      xpLabel: `${tier.xpRequired} XP`,
+      freeTrack: {
+        label: "免费奖励",
+        detail: formatRewardLabel(tier.freeReward),
+        claimLabel: formatTrackClaimLabel(tier, progress, input.pendingClaimTier, false),
+        claimable: input.pendingClaimTier == null && isTrackClaimable(tier, progress, false),
+        claimed: progress.seasonPassClaimedTiers.includes(tier.tier)
+      },
+      premiumTrack: {
+        label: "高级奖励",
+        detail: formatRewardLabel(tier.premiumReward),
+        claimLabel: formatTrackClaimLabel(tier, progress, input.pendingClaimTier, true),
+        claimable: input.pendingClaimTier == null && isTrackClaimable(tier, progress, true),
+        claimed: progress.seasonPassClaimedTiers.includes(tier.tier)
+      }
+    }))
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-shop-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-shop-panel.ts
@@ -7,9 +7,10 @@ export interface ShopProductGrant {
   };
   equipmentIds?: string[];
   cosmeticIds?: string[];
+  seasonPassPremium?: boolean;
 }
 
-export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle" | "cosmetic";
+export type ShopProductType = "gem_pack" | "equipment" | "resource_bundle" | "season_pass_premium" | "cosmetic";
 
 export interface ShopProduct {
   productId: string;
@@ -50,6 +51,7 @@ export interface BuildCocosShopPanelInput {
     profileBorderId?: string;
     battleEmoteId?: string;
   };
+  seasonPassPremiumOwned?: boolean;
 }
 
 function formatResourceGrant(resources?: ShopProductGrant["resources"]): string | null {
@@ -88,10 +90,19 @@ function formatGrantLabel(product: ShopProduct): string {
   if ((product.grant.cosmeticIds?.length ?? 0) > 0) {
     return `外观 ${product.grant.cosmeticIds?.length ?? 0} 件`;
   }
+  if (product.grant.seasonPassPremium === true) {
+    return "高级通行证";
+  }
   if (resources) {
     return resources;
   }
-  return product.type === "equipment" ? "装备奖励" : product.type === "cosmetic" ? "外观奖励" : "奖励待同步";
+  return product.type === "equipment"
+    ? "装备奖励"
+    : product.type === "cosmetic"
+      ? "外观奖励"
+      : product.type === "season_pass_premium"
+        ? "高级通行证"
+        : "奖励待同步";
 }
 
 export function buildCocosShopPanelView(input: BuildCocosShopPanelInput): CocosShopPanelView {
@@ -114,10 +125,13 @@ export function buildCocosShopPanelView(input: BuildCocosShopPanelInput): CocosS
     const cosmeticId = product.grant.cosmeticIds?.[0];
     const cosmeticOwned = cosmeticId ? ownedCosmeticIds.has(cosmeticId) : false;
     const cosmeticEquipped = cosmeticId ? equippedCosmeticIds.has(cosmeticId) : false;
+    const seasonPassPremiumOwned = product.type === "season_pass_premium" && input.seasonPassPremiumOwned === true;
     const enabled =
       product.enabled &&
       !pending &&
-      (product.type === "cosmetic"
+      (product.type === "season_pass_premium"
+        ? !seasonPassPremiumOwned && (usesWechatPayment || affordable)
+        : product.type === "cosmetic"
         ? cosmeticEquipped
           ? false
           : cosmeticOwned || usesWechatPayment || affordable
@@ -132,6 +146,8 @@ export function buildCocosShopPanelView(input: BuildCocosShopPanelInput): CocosS
         ? "订单处理中..."
         : !product.enabled
           ? "暂未上架"
+          : seasonPassPremiumOwned
+            ? "高级通行证已激活"
           : product.type === "cosmetic" && cosmeticEquipped
             ? "已装备"
             : product.type === "cosmetic" && cosmeticOwned
@@ -142,7 +158,15 @@ export function buildCocosShopPanelView(input: BuildCocosShopPanelInput): CocosS
               ? `可购买，余额 ${gemBalance - Math.max(0, Math.floor(product.price ?? 0))} 宝石`
               : `宝石不足，还差 ${Math.max(0, Math.floor(product.price ?? 0)) - gemBalance}`,
       actionLabel:
-        pending ? "购买中..." : product.type === "cosmetic" && cosmeticOwned ? "装备" : usesWechatPayment ? "微信购买" : "购买",
+        pending
+          ? "购买中..."
+          : seasonPassPremiumOwned
+            ? "已解锁"
+            : product.type === "cosmetic" && cosmeticOwned
+              ? "装备"
+              : usesWechatPayment
+                ? "微信购买"
+                : "购买",
       enabled,
       affordable,
       usesWechatPayment

--- a/apps/cocos-client/assets/scripts/project-shared/player-account.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/player-account.ts
@@ -27,9 +27,13 @@ export interface PlayerAccountReadModel {
   eloRating?: number;
   gems?: number;
   loginStreak?: number;
+  seasonXp?: number;
+  seasonPassTier?: number;
+  seasonPassPremium?: boolean;
   cosmeticInventory?: CosmeticInventory;
   equippedCosmetics?: EquippedCosmetics;
   currentShopRotation?: ShopRotation;
+  seasonPassClaimedTiers?: number[];
   globalResources: ResourceLedger;
   achievements: PlayerAchievementProgress[];
   recentEventLog: EventLogEntry[];
@@ -81,9 +85,13 @@ export interface PlayerAccountReadModelInput {
   eloRating?: number | undefined;
   gems?: number | undefined;
   loginStreak?: number | undefined;
+  seasonXp?: number | undefined;
+  seasonPassTier?: number | undefined;
+  seasonPassPremium?: boolean | undefined;
   cosmeticInventory?: Partial<CosmeticInventory> | null | undefined;
   equippedCosmetics?: Partial<EquippedCosmetics> | null | undefined;
   currentShopRotation?: ShopRotation | null | undefined;
+  seasonPassClaimedTiers?: number[] | null | undefined;
   globalResources?: Partial<ResourceLedger> | null | undefined;
   achievements?: Partial<PlayerAchievementProgress>[] | null | undefined;
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
@@ -112,8 +120,18 @@ export function normalizePlayerAccountReadModel(
   const privacyConsentAt = account?.privacyConsentAt?.trim();
   const notificationPreferences = normalizeNotificationPreferences(account?.notificationPreferences);
   const loginStreak = Math.max(0, Math.floor(account?.loginStreak ?? 0));
+  const seasonXp = Math.max(0, Math.floor(account?.seasonXp ?? 0));
+  const seasonPassTier = Math.max(1, Math.floor(account?.seasonPassTier ?? 1));
+  const seasonPassPremium = account?.seasonPassPremium === true;
   const cosmeticInventory = normalizeCosmeticInventory(account?.cosmeticInventory);
   const equippedCosmetics = normalizeEquippedCosmetics(account?.equippedCosmetics);
+  const seasonPassClaimedTiers = Array.from(
+    new Set(
+      (account?.seasonPassClaimedTiers ?? [])
+        .map((tier) => Math.floor(tier))
+        .filter((tier) => Number.isFinite(tier) && tier > 0)
+    )
+  ).sort((left, right) => left - right);
   const lastRoomId = account?.lastRoomId?.trim();
   const lastSeenAt = account?.lastSeenAt?.trim();
   const recentEventLog = normalizeEventLogEntries(account?.recentEventLog);
@@ -130,9 +148,13 @@ export function normalizePlayerAccountReadModel(
     eloRating: normalizeEloRating(account?.eloRating),
     gems: Math.max(0, Math.floor(account?.gems ?? 0)),
     ...(loginStreak > 0 ? { loginStreak } : {}),
+    ...(seasonXp > 0 ? { seasonXp } : {}),
+    ...(seasonPassTier > 1 ? { seasonPassTier } : {}),
+    ...(seasonPassPremium ? { seasonPassPremium } : {}),
     ...(cosmeticInventory.ownedIds.length > 0 ? { cosmeticInventory } : {}),
     ...(Object.keys(equippedCosmetics).length > 0 ? { equippedCosmetics } : {}),
     ...(account?.currentShopRotation ? { currentShopRotation: account.currentShopRotation } : {}),
+    ...(seasonPassClaimedTiers.length > 0 ? { seasonPassClaimedTiers } : {}),
     globalResources: {
       gold: Math.max(0, Math.floor(account?.globalResources?.gold ?? 0)),
       wood: Math.max(0, Math.floor(account?.globalResources?.wood ?? 0)),

--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -1,5 +1,6 @@
 import defaultBattleSkillsConfig from "../../../../../configs/battle-skills.json";
 import defaultBattleBalanceConfig from "../../../../../configs/battle-balance.json";
+import defaultBattlePassConfig from "../../../../../configs/battle-pass.json";
 import defaultBuildingUpgradeConfig from "../../../../../configs/building-upgrades.json";
 import defaultHeroSkillTreesConfig from "../../../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../../../configs/phase2-map-objects-contested-basin.json";
@@ -52,8 +53,31 @@ let runtimeMapObjectsConfig: MapObjectsConfig = structuredClone(defaultMapObject
 let runtimeUnitCatalog: UnitCatalogConfig = structuredClone(defaultUnitsConfig as UnitCatalogConfig);
 let runtimeBattleSkillCatalog: BattleSkillCatalogConfig = structuredClone(defaultBattleSkillsConfig as BattleSkillCatalogConfig);
 let runtimeBattleBalanceConfig: BattleBalanceConfig = structuredClone(defaultBattleBalanceConfig as BattleBalanceConfig);
+let runtimeBattlePassConfig: BattlePassConfig = structuredClone(defaultBattlePassConfig as BattlePassConfig);
 let runtimeBuildingUpgradeConfig: BuildingUpgradeConfig = structuredClone(defaultBuildingUpgradeConfig as BuildingUpgradeConfig);
 let runtimeHeroSkillTree: HeroSkillTreeConfig = structuredClone(defaultHeroSkillTreesConfig as HeroSkillTreeConfig);
+
+export interface BattlePassRewardConfig {
+  gold?: number;
+  wood?: number;
+  ore?: number;
+  gems?: number;
+  equipmentId?: string;
+}
+
+export interface BattlePassTierConfig {
+  tier: number;
+  xpRequired: number;
+  freeReward: BattlePassRewardConfig;
+  premiumReward: BattlePassRewardConfig;
+}
+
+export interface BattlePassConfig {
+  seasonXpPerWin: number;
+  seasonXpPerLoss: number;
+  seasonXpDailyLoginBonus: number;
+  tiers: BattlePassTierConfig[];
+}
 
 export const DEFAULT_MAP_VARIANT_ID = "phase1";
 export const FRONTIER_BASIN_MAP_VARIANT_ID = "frontier_basin";
@@ -813,6 +837,10 @@ export function getBattleBalanceConfig(): BattleBalanceConfig {
   return config;
 }
 
+export function getBattlePassConfig(): BattlePassConfig {
+  return structuredClone(runtimeBattlePassConfig);
+}
+
 export function getBuildingUpgradeConfig(): BuildingUpgradeConfig {
   const config = cloneBuildingUpgradeConfig(runtimeBuildingUpgradeConfig);
   validateBuildingUpgradeConfig(config);
@@ -1034,6 +1062,7 @@ export function resetRuntimeConfigs(): void {
   runtimeUnitCatalog = structuredClone(defaultUnitsConfig as UnitCatalogConfig);
   runtimeBattleSkillCatalog = structuredClone(defaultBattleSkillsConfig as BattleSkillCatalogConfig);
   runtimeBattleBalanceConfig = structuredClone(defaultBattleBalanceConfig as BattleBalanceConfig);
+  runtimeBattlePassConfig = structuredClone(defaultBattlePassConfig as BattlePassConfig);
   runtimeBuildingUpgradeConfig = structuredClone(defaultBuildingUpgradeConfig as BuildingUpgradeConfig);
   runtimeHeroSkillTree = structuredClone(defaultHeroSkillTreesConfig as HeroSkillTreeConfig);
 }

--- a/apps/cocos-client/test/cocos-hud-panel.test.ts
+++ b/apps/cocos-client/test/cocos-hud-panel.test.ts
@@ -51,6 +51,11 @@ function createHudState(): VeilHudRenderState {
       status: null,
       submitting: false
     },
+    sharing: {
+      available: false
+    },
+    battlePassEnabled: true,
+    interaction: null,
     presentation: {
       audio: {
         supported: false,

--- a/apps/cocos-client/test/cocos-progression-panel.test.ts
+++ b/apps/cocos-client/test/cocos-progression-panel.test.ts
@@ -1,42 +1,30 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { buildCocosBattlePassPanelView } from "../assets/scripts/cocos-progression-panel.ts";
 import { VeilProgressionPanel } from "../assets/scripts/VeilProgressionPanel.ts";
-import {
-  createBattleReplaySummary,
-  createComponentHarness,
-  createProgressionPanelPage,
-  findNode,
-  pressNode,
-  readCardLabel,
-  readLabelString
-} from "./helpers/cocos-panel-harness.ts";
+import { createComponentHarness, findNode, pressNode, readCardLabel, readLabelString } from "./helpers/cocos-panel-harness.ts";
 
-test("VeilProgressionPanel switches sections through rendered tab buttons", () => {
-  const selectedSections: string[] = [];
-  const { component, node } = createComponentHarness(VeilProgressionPanel, {
-    name: "ProgressionPanelRoot",
-    width: 380,
-    height: 440
+test("buildCocosBattlePassPanelView hides the panel when battle_pass_enabled is false", () => {
+  const view = buildCocosBattlePassPanelView({
+    progress: {
+      battlePassEnabled: false,
+      seasonXp: 0,
+      seasonPassTier: 1,
+      seasonPassPremium: false,
+      seasonPassClaimedTiers: []
+    },
+    pendingClaimTier: null,
+    pendingPremiumPurchase: false,
+    statusLabel: "battle_pass_enabled = false"
   });
 
-  component.configure({
-    onSelectSection: (section) => {
-      selectedSections.push(section);
-    }
-  });
-  component.render({ page: createProgressionPanelPage() });
-
-  assert.match(readCardLabel(node, "ProgressionHeader"), /账号成长/);
-  assert.equal(readLabelString(findNode(node, "ProgressionTab-progression")), "成长 3");
-
-  pressNode(findNode(node, "ProgressionTab-battle-replays"));
-  pressNode(findNode(node, "ProgressionTab-achievements"));
-
-  assert.deepEqual(selectedSections, ["battle-replays", "achievements"]);
+  assert.equal(view.visible, false);
+  assert.equal(view.premiumPurchaseEnabled, false);
 });
 
-test("VeilProgressionPanel emits paged navigation callbacks for event history", () => {
-  const pageSelections: Array<[string, number]> = [];
+test("VeilProgressionPanel renders battle pass rewards and routes taps to claim and premium actions", () => {
+  const claimedTiers: number[] = [];
+  let premiumPurchaseCount = 0;
   const { component, node } = createComponentHarness(VeilProgressionPanel, {
     name: "ProgressionPanelRoot",
     width: 380,
@@ -44,69 +32,44 @@ test("VeilProgressionPanel emits paged navigation callbacks for event history", 
   });
 
   component.configure({
-    onSelectPage: (section, page) => {
-      pageSelections.push([section, page]);
+    onClaimTier: (tier) => {
+      claimedTiers.push(tier);
+    },
+    onPurchasePremium: () => {
+      premiumPurchaseCount += 1;
     }
   });
+
   component.render({
-    page: createProgressionPanelPage([
-      { type: "section.selected", section: "event-history" },
-      {
-        type: "event-history.loaded",
-        items: [
-          {
-            id: "event-page-4",
-            timestamp: "2026-03-28T12:08:00.000Z",
-            roomId: "room-alpha",
-            playerId: "guest-1001",
-            category: "combat",
-            description: "完成了第四条事件",
-            worldEventType: "battle.resolved",
-            rewards: []
-          },
-          {
-            id: "event-page-5",
-            timestamp: "2026-03-28T12:09:00.000Z",
-            roomId: "room-alpha",
-            playerId: "guest-1001",
-            category: "movement",
-            description: "完成了第五条事件",
-            worldEventType: "hero.moved",
-            rewards: []
-          },
-          {
-            id: "event-page-6",
-            timestamp: "2026-03-28T12:10:00.000Z",
-            roomId: "room-alpha",
-            playerId: "guest-1001",
-            category: "achievement",
-            description: "完成了第六条事件",
-            achievementId: "first_battle",
-            rewards: []
-          }
-        ],
-        page: 1,
-        pageSize: 3,
-        total: 7,
-        hasMore: true
-      }
-    ])
+    battlePass: buildCocosBattlePassPanelView({
+      progress: {
+        battlePassEnabled: true,
+        seasonXp: 1200,
+        seasonPassTier: 3,
+        seasonPassPremium: false,
+        seasonPassClaimedTiers: [1]
+      },
+      pendingClaimTier: null,
+      pendingPremiumPurchase: false,
+      statusLabel: "可领取当前解锁奖励。"
+    })
   });
 
-  assert.match(readCardLabel(node, "ProgressionHeader"), /当前页 2\/3/);
-  pressNode(findNode(node, "ProgressionPrev"));
-  pressNode(findNode(node, "ProgressionNext"));
+  assert.match(readCardLabel(node, "BattlePassHeader"), /赛季通行证/);
+  assert.match(readCardLabel(node, "BattlePassNextReward"), /下一奖励/);
+  assert.match(readCardLabel(node, "BattlePassTrack-0-free"), /免费奖励/);
+  assert.match(readCardLabel(node, "BattlePassTrack-0-premium"), /高级奖励/);
+  assert.match(readLabelString(findNode(node, "BattlePassPremiumAction")), /解锁高级通行证/);
 
-  assert.deepEqual(pageSelections, [
-    ["event-history", 0],
-    ["event-history", 2]
-  ]);
+  pressNode(findNode(node, "BattlePassTrack-0-free"));
+  pressNode(findNode(node, "BattlePassPremiumAction"));
+
+  assert.deepEqual(claimedTiers, [3]);
+  assert.equal(premiumPurchaseCount, 1);
 });
 
-test("VeilProgressionPanel refreshes render callbacks across rerenders", () => {
-  const pageSelections: Array<[string, number]> = [];
-  const retriedSections: string[] = [];
-  let closeCount = 0;
+test("VeilProgressionPanel disables taps while a tier claim is pending", () => {
+  const claimedTiers: number[] = [];
   const { component, node } = createComponentHarness(VeilProgressionPanel, {
     name: "ProgressionPanelRoot",
     width: 380,
@@ -114,65 +77,28 @@ test("VeilProgressionPanel refreshes render callbacks across rerenders", () => {
   });
 
   component.configure({
-    onClose: () => {
-      closeCount += 1;
-    },
-    onRetrySection: (section) => {
-      retriedSections.push(section);
-    },
-    onSelectPage: (section, page) => {
-      pageSelections.push([section, page]);
+    onClaimTier: (tier) => {
+      claimedTiers.push(tier);
     }
   });
 
   component.render({
-    page: createProgressionPanelPage([
-      { type: "section.selected", section: "battle-replays" },
-      {
-        type: "battle-replays.loaded",
-        items: [
-          {
-            ...createBattleReplaySummary(),
-            id: "replay-page-2",
-            battleId: "battle-page-2",
-            neutralArmyId: "neutral-2",
-            startedAt: "2026-03-28T12:10:00.000Z",
-            completedAt: "2026-03-28T12:11:00.000Z",
-            steps: [],
-            result: "attacker_victory"
-          }
-        ],
-        page: 1,
-        pageSize: 1,
-        hasMore: false
-      }
-    ])
+    battlePass: buildCocosBattlePassPanelView({
+      progress: {
+        battlePassEnabled: true,
+        seasonXp: 2200,
+        seasonPassTier: 5,
+        seasonPassPremium: true,
+        seasonPassClaimedTiers: [1, 2, 3]
+      },
+      pendingClaimTier: 5,
+      pendingPremiumPurchase: false,
+      statusLabel: "正在领取奖励..."
+    })
   });
 
-  pressNode(findNode(node, "ProgressionPrev"));
-  pressNode(findNode(node, "ProgressionClose"));
+  assert.match(readCardLabel(node, "BattlePassTrack-0-free"), /领取中/);
+  pressNode(findNode(node, "BattlePassTrack-0-free"));
 
-  component.render({
-    page: createProgressionPanelPage([
-      { type: "section.selected", section: "event-history" },
-      {
-        type: "section.failed",
-        section: "event-history",
-        message: "history_fetch_failed"
-      }
-    ])
-  });
-
-  assert.equal(findNode(node, "ProgressionBanner")?.active, true);
-  pressNode(findNode(node, "ProgressionRetry"));
-  pressNode(findNode(node, "ProgressionNext"));
-  pressNode(findNode(node, "ProgressionClose"));
-
-  component.render({ page: createProgressionPanelPage() });
-  pressNode(findNode(node, "ProgressionRetry"));
-  pressNode(findNode(node, "ProgressionNext"));
-
-  assert.deepEqual(pageSelections, [["battle-replays", 0]]);
-  assert.deepEqual(retriedSections, ["event-history"]);
-  assert.equal(closeCount, 2);
+  assert.deepEqual(claimedTiers, []);
 });

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -499,6 +499,18 @@ function toProgressionResponse(
   return buildPlayerProgressionSnapshot(account.achievements, account.recentEventLog, limit);
 }
 
+function toSeasonProgressResponse(account: PlayerAccountSnapshot, battlePassEnabled: boolean) {
+  const battlePassConfig = resolveBattlePassConfig();
+  return {
+    battlePassEnabled,
+    seasonXp: Math.max(0, Math.floor(account.seasonXp ?? 0)),
+    seasonPassTier: Math.max(1, Math.floor(account.seasonPassTier ?? 1)),
+    seasonPassPremium: account.seasonPassPremium === true,
+    seasonPassClaimedTiers: account.seasonPassClaimedTiers ?? [],
+    tiers: battlePassConfig.tiers
+  };
+}
+
 function toCampaignResponse(account: PlayerAccountSnapshot) {
   const missionStates = buildCampaignMissionStates(resolveCampaignConfig(), account.campaignProgress);
   const completedCount = missionStates.filter((mission) => mission.status === "completed").length;
@@ -1251,6 +1263,91 @@ export function registerPlayerAccountRoutes(
   });
 
   app.post("/api/player/battle-pass/claim", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store?.claimBattlePassTier) {
+      sendJson(response, 503, {
+        error: {
+          code: "battle_pass_persistence_unavailable",
+          message: "Battle pass claims require configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as { tier?: number | null };
+      const tier = Math.floor(body.tier ?? Number.NaN);
+      if (!Number.isFinite(tier) || tier <= 0) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_battle_pass_tier",
+            message: "tier must be a positive integer"
+          }
+        });
+        return;
+      }
+
+      const result = await store.claimBattlePassTier(authSession.playerId, tier);
+      sendJson(response, 200, result);
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
+      if (error instanceof SyntaxError) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_json",
+            message: "Request body must be valid JSON"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "battle_pass_tier_not_found") {
+        sendJson(response, 404, {
+          error: {
+            code: "battle_pass_tier_not_found",
+            message: "Battle pass tier was not found"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "battle_pass_tier_locked") {
+        sendJson(response, 409, {
+          error: {
+            code: "battle_pass_tier_locked",
+            message: "Battle pass tier is not unlocked yet"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "battle_pass_tier_already_claimed") {
+        sendJson(response, 409, {
+          error: {
+            code: "battle_pass_tier_already_claimed",
+            message: "Battle pass tier has already been claimed"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "equipment_inventory_full") {
+        sendJson(response, 409, {
+          error: {
+            code: "equipment_inventory_full",
+            message: error.message
+          }
+        });
+        return;
+      }
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/player-accounts/me/season/claim-tier", async (request, response) => {
     const authSession = await requireAuthSession(request, response, store);
     if (!authSession) {
       return;
@@ -2370,6 +2467,42 @@ export function registerPlayerAccountRoutes(
         campaign: toCampaignResponse(account),
         dailyDungeon: toDailyDungeonResponse(account)
       });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/player-accounts/me/season/progress", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    const featureFlags = resolveFeatureFlagsForPlayer(authSession.playerId);
+    if (!store) {
+      sendJson(
+        response,
+        200,
+        toSeasonProgressResponse(
+          createLocalModeAccount({
+            playerId: authSession.playerId,
+            displayName: authSession.displayName,
+            ...(authSession.loginId ? { loginId: authSession.loginId } : {})
+          }),
+          featureFlags.battle_pass_enabled
+        )
+      );
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      sendJson(response, 200, toSeasonProgressResponse(account, featureFlags.battle_pass_enabled));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -191,6 +191,10 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ...(existing?.mailbox ? { mailbox: structuredClone(existing.mailbox) } : {}),
       ...(existing?.dailyDungeonState ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) } : {}),
       ...(existing?.tutorialStep !== undefined ? { tutorialStep: existing.tutorialStep } : { tutorialStep: DEFAULT_TUTORIAL_STEP }),
+      ...(existing?.seasonXp ? { seasonXp: existing.seasonXp } : {}),
+      ...(existing?.seasonPassTier && existing.seasonPassTier > 1 ? { seasonPassTier: existing.seasonPassTier } : {}),
+      ...(existing?.seasonPassPremium ? { seasonPassPremium: true } : {}),
+      ...(existing?.seasonPassClaimedTiers?.length ? { seasonPassClaimedTiers: structuredClone(existing.seasonPassClaimedTiers) } : {}),
       ...(input.lastRoomId?.trim() ? { lastRoomId: input.lastRoomId.trim() } : existing?.lastRoomId ? { lastRoomId: existing.lastRoomId } : {}),
       lastSeenAt: new Date().toISOString(),
       ...(existing?.loginId ? { loginId: existing.loginId } : {}),
@@ -681,6 +685,36 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ...(patch.dailyPlayMinutes !== undefined ? { dailyPlayMinutes: Math.max(0, Math.floor(patch.dailyPlayMinutes ?? 0)) } : existing.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
       ...(patch.lastPlayDate !== undefined ? (patch.lastPlayDate ? { lastPlayDate: patch.lastPlayDate.trim() } : {}) : existing.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
       ...(patch.loginStreak !== undefined ? { loginStreak: Math.max(0, Math.floor(patch.loginStreak ?? 0)) } : existing.loginStreak ? { loginStreak: existing.loginStreak } : {}),
+      ...(patch.seasonXp !== undefined
+        ? { seasonXp: Math.max(0, Math.floor(patch.seasonXp ?? 0)) }
+        : patch.seasonXpDelta !== undefined
+          ? { seasonXp: Math.max(0, Math.floor(existing.seasonXp ?? 0) + Math.max(0, Math.floor(patch.seasonXpDelta ?? 0))) }
+          : existing.seasonXp
+            ? { seasonXp: existing.seasonXp }
+            : {}),
+      ...(patch.seasonPassTier !== undefined
+        ? { seasonPassTier: Math.max(1, Math.floor(patch.seasonPassTier ?? 1)) }
+        : existing.seasonPassTier && existing.seasonPassTier > 1
+          ? { seasonPassTier: existing.seasonPassTier }
+          : {}),
+      ...(patch.seasonPassPremium !== undefined
+        ? { seasonPassPremium: patch.seasonPassPremium === true }
+        : existing.seasonPassPremium
+          ? { seasonPassPremium: true }
+          : {}),
+      ...(patch.seasonPassClaimedTiers !== undefined
+        ? {
+            seasonPassClaimedTiers: Array.from(
+              new Set(
+                (patch.seasonPassClaimedTiers ?? [])
+                  .map((tier) => Math.floor(tier))
+                  .filter((tier) => Number.isFinite(tier) && tier > 0)
+              )
+            ).sort((left, right) => left - right)
+          }
+        : existing.seasonPassClaimedTiers && existing.seasonPassClaimedTiers.length > 0
+          ? { seasonPassClaimedTiers: structuredClone(existing.seasonPassClaimedTiers) }
+          : {}),
       ...(patch.lastRoomId !== undefined
         ? patch.lastRoomId?.trim()
           ? { lastRoomId: patch.lastRoomId.trim() }
@@ -700,6 +734,39 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ])
     );
     return account;
+  }
+
+  async claimBattlePassTier(playerId: string, tier: number) {
+    const account = await this.ensurePlayerAccount({ playerId });
+    const normalizedTier = Math.max(1, Math.floor(tier));
+    if ((account.seasonPassTier ?? 1) < normalizedTier) {
+      throw new Error("battle_pass_tier_locked");
+    }
+    if ((account.seasonPassClaimedTiers ?? []).includes(normalizedTier)) {
+      throw new Error("battle_pass_tier_already_claimed");
+    }
+
+    const nextClaimedTiers = [...(account.seasonPassClaimedTiers ?? []), normalizedTier].sort((left, right) => left - right);
+    await this.savePlayerAccountProgress(playerId, {
+      seasonPassClaimedTiers: nextClaimedTiers
+    });
+
+    return {
+      tier: normalizedTier,
+      granted: {
+        gems: 0,
+        resources: {
+          gold: 0,
+          wood: 0,
+          ore: 0
+        },
+        equipmentIds: [],
+        cosmeticIds: [],
+        seasonPassPremium: account.seasonPassPremium === true
+      },
+      seasonPassPremiumApplied: account.seasonPassPremium === true,
+      processedAt: new Date().toISOString()
+    };
   }
 
   async deletePlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
@@ -1986,6 +2053,88 @@ test("player account progression routes return a compact achievement and event r
   assert.equal(mePayload.achievements[1]?.id, "enemy_slayer");
   assert.equal(mePayload.achievements[1]?.current, 2);
   assert.equal(mePayload.achievements[1]?.progressUpdatedAt, "2026-03-27T12:02:00.000Z");
+});
+
+test("season progress and claim-tier routes expose battle pass state for the authenticated player", async (t) => {
+  const port = 40029 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  await store.ensurePlayerAccount({
+    playerId: "player-season",
+    displayName: "赛季旅者"
+  });
+  await store.savePlayerAccountProgress("player-season", {
+    seasonXpDelta: 2000,
+    seasonPassTier: 5,
+    seasonPassPremium: true,
+    seasonPassClaimedTiers: [2, 3]
+  });
+  const session = issueGuestAuthSession({
+    playerId: "player-season",
+    displayName: "赛季旅者"
+  });
+
+  process.env.VEIL_FEATURE_FLAGS_JSON = JSON.stringify({
+    schemaVersion: 1,
+    flags: {
+      battle_pass_enabled: {
+        type: "boolean",
+        value: true,
+        defaultValue: false,
+        enabled: true,
+        rollout: 1
+      }
+    }
+  });
+  t.after(() => {
+    delete process.env.VEIL_FEATURE_FLAGS_JSON;
+  });
+
+  const server = await startAccountRouteServer(port, store);
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const progressResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/season/progress`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const progressPayload = (await progressResponse.json()) as {
+    battlePassEnabled: boolean;
+    seasonXp: number;
+    seasonPassTier: number;
+    seasonPassPremium: boolean;
+    seasonPassClaimedTiers: number[];
+    tiers: Array<{ tier: number }>;
+  };
+  assert.equal(progressResponse.status, 200);
+  assert.equal(progressPayload.battlePassEnabled, true);
+  assert.equal(progressPayload.seasonXp, 2000);
+  assert.equal(progressPayload.seasonPassTier, 5);
+  assert.equal(progressPayload.seasonPassPremium, true);
+  assert.deepEqual(progressPayload.seasonPassClaimedTiers, [2, 3]);
+  assert.equal(progressPayload.tiers[0]?.tier, 1);
+
+  const claimResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/season/claim-tier`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      tier: 5
+    })
+  });
+  const claimPayload = (await claimResponse.json()) as {
+    tier: number;
+    seasonPassPremiumApplied: boolean;
+  };
+  assert.equal(claimResponse.status, 200);
+  assert.equal(claimPayload.tier, 5);
+  assert.equal(claimPayload.seasonPassPremiumApplied, true);
+
+  const updatedAccount = await store.loadPlayerAccount("player-season");
+  assert.deepEqual(updatedAccount?.seasonPassClaimedTiers, [2, 3, 5]);
 });
 
 test("player achievement tracker appends logs and unlocks milestones", () => {


### PR DESCRIPTION
## Summary
- add a Cocos battle pass panel/view model with season progress, XP meter, free vs premium reward tracks, claim actions, and premium purchase entry
- wire the gameplay HUD to open the panel only when `battle_pass_enabled` is true and fetch/claim season progress through new client/server integration
- add server season progress and claim-tier routes plus focused Cocos/server tests for the new behavior

## Testing
- npm run typecheck:cocos
- npm run typecheck:server
- node --import tsx --test apps/cocos-client/test/cocos-progression-panel.test.ts apps/cocos-client/test/cocos-hud-panel.test.ts
- node --import tsx --test apps/server/test/player-account-routes.test.ts
