### PR TITLE
[codex] Add client analytics instrumentation

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -170,7 +170,9 @@ import { getPixelSpriteLoadStatus, loadPixelSpriteAssets } from "./cocos-pixel-s
 import {
   appendPrimaryClientTelemetry,
   buildPrimaryClientTelemetryFromUpdate,
-  createPrimaryClientTelemetryEvent
+  createPrimaryClientTelemetryEvent,
+  emitClientAnalyticsEvent,
+  type ClientAnalyticsContext
 } from "./cocos-primary-client-telemetry.ts";
 import {
   describeAccountAuthFailure,
@@ -414,6 +416,9 @@ export class VeilRoot extends Component {
   private lastRoomUpdateReason: string | null = null;
   private lastRoomUpdateAtMs: number | null = null;
   private primaryClientTelemetry: PrimaryClientTelemetryEvent[] = [];
+  private analyticsSessionId: string | null = null;
+  private emittedExperimentExposureKeys = new Set<string>();
+  private emittedShopOpenSessionId: string | null = null;
   private stopRuntimeMemoryWarnings: (() => void) | null = null;
   private battlePresentation = createCocosBattlePresentationController();
   private lastBattleSettlementSnapshot: BattleSettlementSnapshot | null = null;
@@ -510,6 +515,11 @@ export class VeilRoot extends Component {
       }
 
       this.session = nextSession;
+      this.trackClientAnalyticsEvent("session_start", {
+        roomId: this.roomId,
+        authMode: this.authMode,
+        platform: "wechat"
+      });
       this.lastUpdate = await nextSession.snapshot();
       if (!this.isActiveSessionEpoch(sessionEpoch)) {
         await nextSession.dispose().catch(() => undefined);
@@ -1619,6 +1629,7 @@ export class VeilRoot extends Component {
         shopProductsResult.products.length > 0
           ? "点击商品卡片即可购买；微信商品会在小游戏环境拉起支付。"
           : "当前没有上架商品。";
+      this.maybeEmitShopOpenAnalytics();
     } else {
       this.lobbyShopProducts = [];
       this.lobbyShopStatus =
@@ -1753,6 +1764,7 @@ export class VeilRoot extends Component {
     this.renderView();
 
     try {
+      this.trackPurchaseInitiated(product, "lobby");
       if (product.type === "cosmetic" && alreadyOwned && cosmeticId) {
         await resolveVeilRootRuntime().equipShopCosmetic(this.remoteUrl, cosmeticId, {
           getAuthToken: () => this.authToken
@@ -1992,6 +2004,7 @@ export class VeilRoot extends Component {
     this.seasonProgressStatus = `正在购买 ${premiumProduct.name}...`;
     this.renderView();
     try {
+      this.trackPurchaseInitiated(premiumProduct, "battle_pass");
       await resolveVeilRootRuntime().purchaseShopProduct(this.remoteUrl, premiumProduct.productId, {
         getAuthToken: () => this.authToken
       });
@@ -2566,12 +2579,129 @@ export class VeilRoot extends Component {
     this.primaryClientTelemetry = appendPrimaryClientTelemetry(this.primaryClientTelemetry, event);
   }
 
+  private ensureAnalyticsSessionId(): string {
+    if (!this.analyticsSessionId) {
+      this.analyticsSessionId = `cocos-session-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+    return this.analyticsSessionId;
+  }
+
+  private createClientAnalyticsContext(roomId = this.roomId): ClientAnalyticsContext {
+    return {
+      remoteUrl: this.remoteUrl,
+      playerId: this.playerId,
+      sessionId: this.ensureAnalyticsSessionId(),
+      roomId,
+      platform: "wechat"
+    };
+  }
+
+  private trackClientAnalyticsEvent<Name extends
+    | "session_start"
+    | "battle_start"
+    | "battle_end"
+    | "quest_complete"
+    | "tutorial_step"
+    | "experiment_exposure"
+    | "shop_open"
+    | "purchase_initiated"
+  >(
+    name: Name,
+    payload: Record<string, unknown>,
+    roomId = this.roomId
+  ): void {
+    emitClientAnalyticsEvent(name, this.createClientAnalyticsContext(roomId), payload as never);
+  }
+
   private createTelemetryContext(heroId?: string | null): { roomId: string; playerId: string; heroId?: string } {
     return {
       roomId: this.roomId,
       playerId: this.playerId,
       ...(heroId ? { heroId } : {})
     };
+  }
+
+  private maybeEmitShopOpenAnalytics(): void {
+    if (!this.showLobby || this.lobbyShopProducts.length === 0) {
+      return;
+    }
+
+    const sessionId = this.ensureAnalyticsSessionId();
+    if (this.emittedShopOpenSessionId === sessionId) {
+      return;
+    }
+
+    this.emittedShopOpenSessionId = sessionId;
+    this.trackClientAnalyticsEvent("shop_open", {
+      roomId: this.roomId,
+      surface: "lobby"
+    });
+  }
+
+  private maybeEmitExperimentExposureAnalytics(profile: CocosPlayerAccountProfile): void {
+    const experiments = (profile as CocosPlayerAccountProfile & {
+      experiments?: Array<{
+        experimentKey: string;
+        experimentName: string;
+        owner: string;
+        bucket: number;
+        variant: string;
+      }>;
+    }).experiments ?? [];
+
+    for (const experiment of experiments) {
+      if (this.emittedExperimentExposureKeys.has(experiment.experimentKey)) {
+        continue;
+      }
+
+      this.emittedExperimentExposureKeys.add(experiment.experimentKey);
+      this.trackClientAnalyticsEvent(
+        "experiment_exposure",
+        {
+          experimentKey: experiment.experimentKey,
+          experimentName: experiment.experimentName,
+          variant: experiment.variant,
+          bucket: experiment.bucket,
+          surface: "player_account_profile",
+          owner: experiment.owner
+        },
+        profile.lastRoomId ?? this.roomId
+      );
+    }
+  }
+
+  private maybeEmitQuestCompleteAnalytics(previousProfile: CocosPlayerAccountProfile, profile: CocosPlayerAccountProfile): void {
+    const previousClaims = new Map(
+      (previousProfile.dailyQuestBoard?.quests ?? []).map((quest) => [quest.id, quest.claimed === true] as const)
+    );
+
+    for (const quest of profile.dailyQuestBoard?.quests ?? []) {
+      if (quest.claimed !== true || previousClaims.get(quest.id) === true) {
+        continue;
+      }
+
+      this.trackClientAnalyticsEvent(
+        "quest_complete",
+        {
+          roomId: profile.lastRoomId ?? this.roomId,
+          questId: quest.id,
+          reward: quest.reward
+        },
+        profile.lastRoomId ?? this.roomId
+      );
+    }
+  }
+
+  private trackPurchaseInitiated(product: ShopProduct, surface: "lobby" | "battle_pass"): void {
+    const price = Math.max(0, Math.floor(product.wechatPriceFen ?? product.price ?? 0));
+    this.trackClientAnalyticsEvent("purchase_initiated", {
+      roomId: this.roomId,
+      productId: product.productId,
+      productType: product.type,
+      currency: product.wechatPriceFen ? "wechat_fen" : "gems",
+      price,
+      surface
+    });
   }
 
   private setBattleFeedback(feedback: CocosBattleFeedbackView | null, durationMs = BATTLE_FEEDBACK_DURATION_MS): void {
@@ -4649,6 +4779,19 @@ export class VeilRoot extends Component {
             : "新手引导已完成，每日任务已解锁。"
           : `新手引导推进至第 ${action.step} 步。`
       );
+      this.trackClientAnalyticsEvent(
+        "tutorial_step",
+        {
+          stepId:
+            action.step == null
+              ? action.reason === "skip"
+                ? "tutorial_skipped"
+                : "tutorial_completed"
+              : `step_${action.step}`,
+          status: action.reason === "skip" ? "skipped" : action.step == null ? "completed" : "active"
+        },
+        profile.lastRoomId ?? this.roomId
+      );
     } finally {
       this.tutorialProgressInFlight = false;
       this.renderView();
@@ -4928,6 +5071,35 @@ export class VeilRoot extends Component {
     this.emitPrimaryClientTelemetry(
       buildPrimaryClientTelemetryFromUpdate(update, this.createTelemetryContext(heroId))
     );
+    for (const event of update.events) {
+      const ownsEventHero =
+        "heroId" in event && typeof event.heroId === "string"
+          ? update.world.ownHeroes.some((hero) => hero.id === event.heroId)
+          : false;
+
+      if (event.type === "battle.started" && ownsEventHero) {
+        this.trackClientAnalyticsEvent("battle_start", {
+          roomId: update.world.meta.roomId,
+          battleId: event.battleId,
+          encounterKind: event.encounterKind,
+          heroId: event.heroId
+        }, update.world.meta.roomId);
+      }
+
+      if (event.type === "battle.resolved" && ownsEventHero) {
+        this.trackClientAnalyticsEvent("battle_end", {
+          roomId: update.world.meta.roomId,
+          battleId: event.battleId,
+          result: event.result,
+          heroId: event.heroId,
+          battleKind: "battleKind" in event && (event.battleKind === "neutral" || event.battleKind === "hero")
+            ? event.battleKind
+            : previousBattle?.defenderHeroId
+              ? "hero"
+              : "neutral"
+        }, update.world.meta.roomId);
+      }
+    }
     if (shouldRefreshGameplayAccountProfileForEvents(update.events.map((event) => event.type))) {
       void this.refreshGameplayAccountProfile();
     }
@@ -5002,6 +5174,7 @@ export class VeilRoot extends Component {
   }
 
   private commitAccountProfile(profile: CocosPlayerAccountProfile, allowAchievementNotice: boolean): void {
+    const previousProfile = this.lobbyAccountProfile;
     if (profile.playerId !== this.lobbyAccountProfile.playerId) {
       this.seenProfileNoticeEventIds.clear();
     }
@@ -5022,6 +5195,8 @@ export class VeilRoot extends Component {
     }
 
     this.lobbyAccountProfile = profile;
+    this.maybeEmitExperimentExposureAnalytics(profile);
+    this.maybeEmitQuestCompleteAnalytics(previousProfile, profile);
     if (this.gameplayBattlePassPanelOpen || this.seasonProgress) {
       this.seasonProgress = this.snapshotSeasonProgressFromProfile();
     }

--- a/apps/cocos-client/assets/scripts/cocos-primary-client-telemetry.ts
+++ b/apps/cocos-client/assets/scripts/cocos-primary-client-telemetry.ts
@@ -1,8 +1,163 @@
-import type { PrimaryClientTelemetryEvent, PrimaryClientTelemetryStatus } from "../../../../packages/shared/src/index.ts";
+import {
+  createAnalyticsEvent,
+  type AnalyticsEvent,
+  type AnalyticsEventName,
+  type PrimaryClientTelemetryEvent,
+  type PrimaryClientTelemetryStatus
+} from "../../../../packages/shared/src/index.ts";
 import type { SessionUpdate, WorldEvent } from "./VeilCocosSession.ts";
 import type { EquipmentType } from "./project-shared/index.ts";
+import { resolveCocosApiBaseUrl } from "./cocos-lobby.ts";
 
 const PRIMARY_CLIENT_TELEMETRY_LIMIT = 12;
+const CLIENT_ANALYTICS_FLUSH_SIZE = 20;
+const CLIENT_ANALYTICS_FLUSH_DELAY_MS = 250;
+
+export interface ClientAnalyticsContext {
+  remoteUrl: string;
+  playerId: string;
+  sessionId: string;
+  roomId?: string;
+  platform?: string;
+  at?: string;
+}
+
+interface PendingClientAnalyticsEvent {
+  endpoint: string;
+  event: AnalyticsEvent;
+}
+
+interface ClientAnalyticsRuntimeDependencies {
+  fetch(input: string, init?: RequestInit): Promise<{ ok: boolean; status: number }>;
+  error(message: string, error?: unknown): void;
+  getNodeEnv(): string | undefined;
+  setTimeout(handler: () => void, delayMs: number): ReturnType<typeof globalThis.setTimeout>;
+  clearTimeout(handle: ReturnType<typeof globalThis.setTimeout>): void;
+}
+
+const defaultClientAnalyticsRuntimeDependencies: ClientAnalyticsRuntimeDependencies = {
+  fetch: (input, init) => fetch(input, init),
+  error: (message, error) => console.error(message, error),
+  getNodeEnv: () => globalThis.process?.env?.NODE_ENV,
+  setTimeout: (handler, delayMs) => globalThis.setTimeout(handler, delayMs),
+  clearTimeout: (handle) => globalThis.clearTimeout(handle)
+};
+
+let clientAnalyticsRuntimeDependencies = defaultClientAnalyticsRuntimeDependencies;
+let pendingClientAnalyticsEvents: PendingClientAnalyticsEvent[] = [];
+let pendingClientAnalyticsTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+
+export function configureClientAnalyticsRuntimeDependencies(
+  overrides: Partial<ClientAnalyticsRuntimeDependencies>
+): void {
+  clientAnalyticsRuntimeDependencies = {
+    ...clientAnalyticsRuntimeDependencies,
+    ...overrides
+  };
+}
+
+export function resetClientAnalyticsRuntimeDependencies(): void {
+  clientAnalyticsRuntimeDependencies = defaultClientAnalyticsRuntimeDependencies;
+  pendingClientAnalyticsEvents = [];
+  if (pendingClientAnalyticsTimer) {
+    clientAnalyticsRuntimeDependencies.clearTimeout(pendingClientAnalyticsTimer);
+  }
+  pendingClientAnalyticsTimer = null;
+}
+
+function shouldEmitClientAnalytics(): boolean {
+  return clientAnalyticsRuntimeDependencies.getNodeEnv() === "production";
+}
+
+async function flushClientAnalyticsEvents(): Promise<void> {
+  if (pendingClientAnalyticsEvents.length === 0) {
+    return;
+  }
+
+  const batch = pendingClientAnalyticsEvents;
+  pendingClientAnalyticsEvents = [];
+  if (pendingClientAnalyticsTimer) {
+    clientAnalyticsRuntimeDependencies.clearTimeout(pendingClientAnalyticsTimer);
+    pendingClientAnalyticsTimer = null;
+  }
+
+  const batchesByEndpoint = new Map<string, AnalyticsEvent[]>();
+  for (const entry of batch) {
+    const events = batchesByEndpoint.get(entry.endpoint) ?? [];
+    events.push(entry.event);
+    batchesByEndpoint.set(entry.endpoint, events);
+  }
+
+  await Promise.all(
+    Array.from(batchesByEndpoint.entries(), async ([endpoint, events]) => {
+      try {
+        const response = await clientAnalyticsRuntimeDependencies.fetch(endpoint, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json; charset=utf-8"
+          },
+          body: JSON.stringify({
+            schemaVersion: 1,
+            emittedAt: new Date().toISOString(),
+            events
+          })
+        });
+        if (!response.ok) {
+          clientAnalyticsRuntimeDependencies.error(`[Analytics] Failed to flush client analytics batch: ${response.status}`);
+        }
+      } catch (error) {
+        clientAnalyticsRuntimeDependencies.error("[Analytics] Failed to flush client analytics batch", error);
+      }
+    })
+  );
+}
+
+function scheduleClientAnalyticsFlush(): void {
+  if (pendingClientAnalyticsEvents.length >= CLIENT_ANALYTICS_FLUSH_SIZE) {
+    void flushClientAnalyticsEvents();
+    return;
+  }
+
+  if (pendingClientAnalyticsTimer) {
+    return;
+  }
+
+  pendingClientAnalyticsTimer = clientAnalyticsRuntimeDependencies.setTimeout(() => {
+    pendingClientAnalyticsTimer = null;
+    void flushClientAnalyticsEvents();
+  }, CLIENT_ANALYTICS_FLUSH_DELAY_MS);
+}
+
+export function emitClientAnalyticsEvent<Name extends AnalyticsEventName>(
+  name: Name,
+  context: ClientAnalyticsContext,
+  payload: Parameters<typeof createAnalyticsEvent<Name>>[1]["payload"]
+): AnalyticsEvent<Name> {
+  const event = createAnalyticsEvent(name, {
+    ...(context.at ? { at: context.at } : {}),
+    playerId: context.playerId,
+    source: "cocos-client",
+    sessionId: context.sessionId,
+    platform: context.platform ?? "wechat",
+    ...(context.roomId ? { roomId: context.roomId } : {}),
+    payload
+  });
+
+  if (!shouldEmitClientAnalytics()) {
+    return event;
+  }
+
+  pendingClientAnalyticsEvents.push({
+    endpoint: `${resolveCocosApiBaseUrl(context.remoteUrl)}/api/analytics/events`,
+    event
+  });
+  scheduleClientAnalyticsFlush();
+  return event;
+}
+
+export function flushClientAnalyticsEventsForTest(): Promise<void> {
+  return flushClientAnalyticsEvents();
+}
 
 interface PrimaryClientTelemetryContext {
   roomId: string;

--- a/apps/cocos-client/test/cocos-primary-client-telemetry.test.ts
+++ b/apps/cocos-client/test/cocos-primary-client-telemetry.test.ts
@@ -1,12 +1,20 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { afterEach } from "node:test";
 import {
   appendPrimaryClientTelemetry,
   buildPrimaryClientTelemetryFromUpdate,
-  createPrimaryClientTelemetryEvent
+  configureClientAnalyticsRuntimeDependencies,
+  createPrimaryClientTelemetryEvent,
+  emitClientAnalyticsEvent,
+  flushClientAnalyticsEventsForTest,
+  resetClientAnalyticsRuntimeDependencies
 } from "../assets/scripts/cocos-primary-client-telemetry.ts";
 import type { PrimaryClientTelemetryEvent } from "../../../packages/shared/src/index.ts";
 import { createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
+
+afterEach(() => {
+  resetClientAnalyticsRuntimeDependencies();
+});
 
 function createTelemetryEntry(checkpoint: string): PrimaryClientTelemetryEvent {
   return {
@@ -158,4 +166,73 @@ test("buildPrimaryClientTelemetryFromUpdate maps supported world events with her
   assert.equal(entries[4]?.result, "attacker_victory");
   assert.equal(entries[4]?.battleKind, undefined);
   assert(entries.every((entry) => entry.at === "2026-04-02T12:00:00.000Z"));
+});
+
+test("emitClientAnalyticsEvent batches production client events to the analytics endpoint", async () => {
+  const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
+  configureClientAnalyticsRuntimeDependencies({
+    getNodeEnv: () => "production",
+    fetch: async (input, init) => {
+      fetchCalls.push({ input, init });
+      return {
+        ok: true,
+        status: 202
+      };
+    }
+  });
+
+  const event = emitClientAnalyticsEvent(
+    "shop_open",
+    {
+      remoteUrl: "http://127.0.0.1:2567",
+      playerId: "player-1",
+      sessionId: "session-1",
+      roomId: "room-telemetry"
+    },
+    {
+      roomId: "room-telemetry",
+      surface: "lobby"
+    }
+  );
+  await flushClientAnalyticsEventsForTest();
+
+  assert.equal(event.source, "cocos-client");
+  assert.equal(event.platform, "wechat");
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0]?.input, "http://127.0.0.1:2567/api/analytics/events");
+  assert.match(String(fetchCalls[0]?.init?.body), /"name":"shop_open"/);
+  assert.match(String(fetchCalls[0]?.init?.body), /"sessionId":"session-1"/);
+});
+
+test("emitClientAnalyticsEvent stays quiet outside production mode", async () => {
+  let fetchCalls = 0;
+  configureClientAnalyticsRuntimeDependencies({
+    getNodeEnv: () => "test",
+    fetch: async () => {
+      fetchCalls += 1;
+      return {
+        ok: true,
+        status: 202
+      };
+    }
+  });
+
+  emitClientAnalyticsEvent(
+    "battle_start",
+    {
+      remoteUrl: "http://127.0.0.1:2567",
+      playerId: "player-1",
+      sessionId: "session-1",
+      roomId: "room-telemetry"
+    },
+    {
+      roomId: "room-telemetry",
+      battleId: "battle-1",
+      encounterKind: "neutral",
+      heroId: "hero-1"
+    }
+  );
+  await flushClientAnalyticsEventsForTest();
+
+  assert.equal(fetchCalls, 0);
 });

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -8,6 +8,11 @@ import {
 } from "../assets/scripts/cocos-account-review.ts";
 import { createCocosAudioRuntime } from "../assets/scripts/cocos-audio-runtime.ts";
 import { cocosPresentationConfig } from "../assets/scripts/cocos-presentation-config.ts";
+import {
+  configureClientAnalyticsRuntimeDependencies,
+  flushClientAnalyticsEventsForTest,
+  resetClientAnalyticsRuntimeDependencies
+} from "../assets/scripts/cocos-primary-client-telemetry.ts";
 import { VeilRoot } from "../assets/scripts/VeilRoot.ts";
 import { createMemoryStorage, createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
 import { createVeilRootHarness, installVeilRootRuntime, resetVeilRootRuntime } from "./helpers/veil-root-harness.ts";
@@ -15,6 +20,7 @@ import type { BattleAction, BattleState, SessionUpdate, VeilCocosSessionOptions 
 
 afterEach(() => {
   resetVeilRootRuntime();
+  resetClientAnalyticsRuntimeDependencies();
   (sys as unknown as { localStorage: Storage | null }).localStorage = null;
 });
 
@@ -377,6 +383,209 @@ test("VeilRoot emits primary-client telemetry for progression, inventory, and co
   assert.equal(root.primaryClientTelemetry[1]?.itemCount, 2);
   assert.equal(root.primaryClientTelemetry[4]?.status, "success");
   assert.equal(root.primaryClientTelemetry[5]?.reason, "in_battle");
+});
+
+test("VeilRoot batches client analytics across session and battle lifecycle hooks", async () => {
+  const root = createVeilRootHarness();
+  root.roomId = "room-analytics";
+  root.playerId = "player-1";
+  root.displayName = "暮潮守望";
+  root.remoteUrl = "http://127.0.0.1:2567";
+  root.authMode = "account";
+  root.lastUpdate = createSessionUpdate(1, "room-analytics", "player-1");
+  root.applySessionUpdate = VeilRoot.prototype["applySessionUpdate"].bind(root);
+
+  const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
+  configureClientAnalyticsRuntimeDependencies({
+    getNodeEnv: () => "production",
+    fetch: async (input, init) => {
+      fetchCalls.push({ input, init });
+      return {
+        ok: true,
+        status: 202
+      };
+    }
+  });
+
+  installVeilRootRuntime({
+    createSession: async () =>
+      ({
+        async snapshot() {
+          return createSessionUpdate(2, "room-analytics", "player-1");
+        },
+        async dispose() {}
+      }) as never
+  });
+
+  await root.connect();
+  await root.applySessionUpdate(createFirstBattleUpdate());
+  await root.applySessionUpdate(createReturnToWorldUpdate());
+  await flushClientAnalyticsEventsForTest();
+
+  assert.equal(fetchCalls.length, 1);
+  const body = String(fetchCalls[0]?.init?.body);
+  assert.match(body, /"name":"session_start"/);
+  assert.match(body, /"name":"battle_start"/);
+  assert.match(body, /"name":"battle_end"/);
+  assert.match(body, /"platform":"wechat"/);
+  assert.match(body, /"sessionId":"cocos-session-/);
+});
+
+test("VeilRoot emits shop, tutorial, quest, and experiment analytics once per session", async () => {
+  const root = createVeilRootHarness();
+  root.roomId = "room-analytics";
+  root.playerId = "player-1";
+  root.displayName = "暮潮守望";
+  root.remoteUrl = "http://127.0.0.1:2567";
+  root.authToken = "account.token";
+  root.authMode = "account";
+  root.showLobby = true;
+  root.lobbyShopProducts = [
+    {
+      productId: "gem-pack-small",
+      name: "Gem Pack Small",
+      type: "gem_pack",
+      price: 60,
+      enabled: true,
+      grant: {
+        gems: 60
+      }
+    }
+  ];
+
+  const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
+  configureClientAnalyticsRuntimeDependencies({
+    getNodeEnv: () => "production",
+    fetch: async (input, init) => {
+      fetchCalls.push({ input, init });
+      return {
+        ok: true,
+        status: 202
+      };
+    }
+  });
+
+  installVeilRootRuntime({
+    purchaseShopProduct: async () => ({
+      purchaseId: "purchase-1",
+      productId: "gem-pack-small",
+      quantity: 1,
+      unitPrice: 60,
+      totalPrice: 60,
+      granted: {
+        gems: 60,
+        resources: { gold: 0, wood: 0, ore: 0 },
+        equipmentIds: [],
+        cosmeticIds: []
+      },
+      gemsBalance: 120,
+      processedAt: "2026-04-05T00:00:00.000Z"
+    }),
+    updateTutorialProgress: async () => ({
+      ...root.lobbyAccountProfile,
+      playerId: "player-1",
+      displayName: "暮潮守望",
+      source: "remote",
+      tutorialStep: 2,
+      recentBattleReplays: []
+    })
+  });
+
+  root.maybeEmitShopOpenAnalytics();
+  await root.purchaseLobbyShopProduct("gem-pack-small");
+  root.commitAccountProfile(
+    {
+      ...root.lobbyAccountProfile,
+      playerId: "player-1",
+      displayName: "暮潮守望",
+      lastRoomId: "room-analytics",
+      dailyQuestBoard: {
+        enabled: true,
+        availableClaims: 1,
+        pendingRewards: { gems: 10, gold: 50 },
+        quests: [
+          {
+            id: "daily_explore_frontier",
+            title: "Explore",
+            description: "Explore frontier",
+            current: 1,
+            target: 1,
+            completed: true,
+            claimed: false,
+            reward: { gems: 10, gold: 50 }
+          }
+        ]
+      },
+      experiments: [
+        {
+          experimentKey: "account_portal_copy",
+          experimentName: "Account Portal Upgrade Copy",
+          owner: "growth",
+          bucket: 42,
+          variant: "upgrade",
+          fallbackVariant: "control",
+          assigned: true,
+          reason: "bucket"
+        }
+      ]
+    },
+    false
+  );
+  root.commitAccountProfile(
+    {
+      ...root.lobbyAccountProfile,
+      playerId: "player-1",
+      displayName: "暮潮守望",
+      lastRoomId: "room-analytics",
+      dailyQuestBoard: {
+        enabled: true,
+        availableClaims: 0,
+        pendingRewards: { gems: 0, gold: 0 },
+        quests: [
+          {
+            id: "daily_explore_frontier",
+            title: "Explore",
+            description: "Explore frontier",
+            current: 1,
+            target: 1,
+            completed: true,
+            claimed: true,
+            reward: { gems: 10, gold: 50 }
+          }
+        ]
+      },
+      experiments: [
+        {
+          experimentKey: "account_portal_copy",
+          experimentName: "Account Portal Upgrade Copy",
+          owner: "growth",
+          bucket: 42,
+          variant: "upgrade",
+          fallbackVariant: "control",
+          assigned: true,
+          reason: "bucket"
+        }
+      ]
+    },
+    false
+  );
+  root.lobbyAccountProfile = {
+    ...root.lobbyAccountProfile,
+    playerId: "player-1",
+    displayName: "暮潮守望",
+    source: "remote",
+    tutorialStep: 1
+  };
+  await root.advanceTutorialFlow();
+  await flushClientAnalyticsEventsForTest();
+
+  const body = fetchCalls.map((call) => String(call.init?.body)).join("\n");
+  assert.match(body, /"name":"shop_open"/);
+  assert.match(body, /"name":"purchase_initiated"/);
+  assert.match(body, /"name":"experiment_exposure"/);
+  assert.match(body, /"name":"quest_complete"/);
+  assert.match(body, /"name":"tutorial_step"/);
+  assert.equal((body.match(/"name":"experiment_exposure"/g) ?? []).length, 1);
 });
 
 test("VeilRoot gameplay account refresh uses the injected loader for remote equipment and loot updates", async () => {

--- a/apps/server/src/analytics.ts
+++ b/apps/server/src/analytics.ts
@@ -3,6 +3,7 @@ import {
   type AnalyticsEvent,
   type AnalyticsEventName
 } from "../../../packages/shared/src/index";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 const ANALYTICS_BUFFER_FLUSH_SIZE = 20;
 const ANALYTICS_BUFFER_FLUSH_DELAY_MS = 250;
@@ -26,6 +27,53 @@ const defaultAnalyticsRuntimeDependencies: AnalyticsRuntimeDependencies = {
 let analyticsRuntimeDependencies = defaultAnalyticsRuntimeDependencies;
 let pendingEvents: AnalyticsEvent[] = [];
 let flushTimer: NodeJS.Timeout | null = null;
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+function toErrorPayload(error: unknown): { code: string; message: string } {
+  return {
+    code: error instanceof Error ? error.name || "error" : "error",
+    message: error instanceof Error ? error.message : String(error)
+  };
+}
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+const MAX_ANALYTICS_REQUEST_BYTES = 256 * 1024;
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_ANALYTICS_REQUEST_BYTES) {
+    request.resume();
+    throw new PayloadTooLargeError(MAX_ANALYTICS_REQUEST_BYTES);
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_ANALYTICS_REQUEST_BYTES) {
+      throw new PayloadTooLargeError(MAX_ANALYTICS_REQUEST_BYTES);
+    }
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
 
 export function configureAnalyticsRuntimeDependencies(overrides: Partial<AnalyticsRuntimeDependencies>): void {
   analyticsRuntimeDependencies = {
@@ -114,4 +162,48 @@ export function emitAnalyticsEvent<Name extends AnalyticsEventName>(
 
 export function flushAnalyticsEventsForTest(env: NodeJS.ProcessEnv = process.env): Promise<void> {
   return flushEvents(env);
+}
+
+export function registerAnalyticsRoutes(
+  app: {
+    use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
+    post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+  }
+): void {
+  app.use((request, response, next) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    next();
+  });
+
+  app.post("/api/analytics/events", async (request, response) => {
+    try {
+      const payload = await readJsonBody(request);
+      analyticsRuntimeDependencies.log(`[Analytics] ${JSON.stringify(payload)}`);
+      sendJson(response, 202, {
+        accepted: Array.isArray((payload as { events?: unknown[] } | null)?.events)
+          ? (payload as { events: unknown[] }).events.length
+          : 0
+      });
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, {
+          error: toErrorPayload(error)
+        });
+        return;
+      }
+
+      sendJson(response, 400, {
+        error: toErrorPayload(error)
+      });
+    }
+  });
 }

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { Server, WebSocketTransport } from "colyseus";
 import { config as loadEnv } from "dotenv";
 import { registerAuthRoutes } from "./auth";
+import { registerAnalyticsRoutes } from "./analytics";
 import {
   FileSystemConfigCenterStore,
   MySqlConfigCenterStore,
@@ -41,6 +42,7 @@ interface DevServerTransport {
 interface DevServerHttpApp {
   use(handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void): void;
   get(path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>): void;
+  post(path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>): void;
 }
 
 interface DevServerDefinitionChain {
@@ -108,6 +110,7 @@ export interface DevServerBootstrapDependencies {
   createRedisPresence(redisUrl: string): { shutdown(): Promise<void> | void };
   createRedisDriver(redisUrl: string): { shutdown(): Promise<void> | void };
   registerAuthRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
+  registerAnalyticsRoutes(app: unknown): void;
   registerConfigCenterRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerEventRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
@@ -177,6 +180,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     createRedisPresence,
     createRedisDriver,
     registerAuthRoutes: (app, store) => registerAuthRoutes(app as never, store as RoomSnapshotStore),
+    registerAnalyticsRoutes: (app) => registerAnalyticsRoutes(app as never),
     registerConfigCenterRoutes: (app, store) => registerConfigCenterRoutes(app as never, store as ConfigCenterStore),
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
     registerEventRoutes: (app, store) => registerEventRoutes(app as never, store as RoomSnapshotStore | null),
@@ -248,6 +252,7 @@ export async function startDevServer(
   deps.registerPrometheusMetricsMiddleware(expressApp);
   deps.registerPrometheusMetricsRoute(expressApp);
   deps.registerAuthRoutes(expressApp, effectiveSnapshotStore);
+  deps.registerAnalyticsRoutes(expressApp);
   deps.registerConfigCenterRoutes(expressApp, configCenterStore);
   deps.registerConfigViewerRoutes(expressApp, configCenterStore);
   if ("use" in (expressApp as object) && "get" in (expressApp as object)) {

--- a/apps/server/test/analytics.test.ts
+++ b/apps/server/test/analytics.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import test, { afterEach } from "node:test";
+import {
+  configureAnalyticsRuntimeDependencies,
+  registerAnalyticsRoutes,
+  resetAnalyticsRuntimeDependencies
+} from "../src/analytics";
+
+afterEach(() => {
+  resetAnalyticsRuntimeDependencies();
+});
+
+interface TestResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  ended: boolean;
+  setHeader(name: string, value: string): void;
+  end(body?: string): void;
+}
+
+function createResponse(): TestResponse {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    ended: false,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    end(body = "") {
+      this.body = body;
+      this.ended = true;
+    }
+  };
+}
+
+function createRequest(method: string, body?: string): Readable & {
+  method: string;
+  headers: Record<string, string>;
+  resume(): void;
+} {
+  const request = Readable.from(body == null ? [] : [body]) as Readable & {
+    method: string;
+    headers: Record<string, string>;
+    resume(): void;
+  };
+  request.method = method;
+  request.headers = body == null ? {} : { "content-length": Buffer.byteLength(body).toString() };
+  request.resume = () => {
+    request.read();
+  };
+  return request;
+}
+
+test("registerAnalyticsRoutes accepts analytics batches and logs the payload", async () => {
+  let middleware:
+    | ((request: never, response: TestResponse, next: () => void) => void)
+    | undefined;
+  let handler:
+    | ((request: never, response: TestResponse) => void | Promise<void>)
+    | undefined;
+  const logs: string[] = [];
+
+  configureAnalyticsRuntimeDependencies({
+    log: (message) => {
+      logs.push(message);
+    }
+  });
+
+  registerAnalyticsRoutes({
+    use(nextMiddleware) {
+      middleware = nextMiddleware as never;
+    },
+    post(path, nextHandler) {
+      assert.equal(path, "/api/analytics/events");
+      handler = nextHandler as never;
+    }
+  });
+
+  assert(middleware);
+  assert(handler);
+
+  const requestBody = JSON.stringify({
+    schemaVersion: 1,
+    emittedAt: "2026-04-05T00:00:00.000Z",
+    events: [{ name: "shop_open" }, { name: "battle_start" }]
+  });
+  const request = createRequest("POST", requestBody);
+  const response = createResponse();
+
+  let nextCalled = false;
+  middleware(request as never, response, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, true);
+
+  await handler(request as never, response);
+
+  assert.equal(response.statusCode, 202);
+  assert.equal(response.headers["Access-Control-Allow-Origin"], "*");
+  assert.equal(response.headers["Content-Type"], "application/json; charset=utf-8");
+  assert.deepEqual(JSON.parse(response.body), { accepted: 2 });
+  assert.equal(logs.length, 1);
+  assert.match(logs[0] ?? "", /"shop_open"/);
+});
+
+test("registerAnalyticsRoutes rejects malformed analytics payloads", async () => {
+  let handler:
+    | ((request: never, response: TestResponse) => void | Promise<void>)
+    | undefined;
+
+  registerAnalyticsRoutes({
+    use() {},
+    post(_path, nextHandler) {
+      handler = nextHandler as never;
+    }
+  });
+
+  assert(handler);
+
+  const request = createRequest("POST", "{");
+  const response = createResponse();
+
+  await handler(request as never, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.headers["Content-Type"], "application/json; charset=utf-8");
+  assert.match(response.body, /"code":"SyntaxError"/);
+});

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -25,7 +25,7 @@ export const ANALYTICS_EVENT_CATALOG = {
   session_start: defineAnalyticsEvent("session_start", 1, "Player session established through the room transport.", {
     roomId: "room-contract",
     authMode: "guest",
-    platform: "colyseus"
+    platform: "wechat"
   }),
   battle_start: defineAnalyticsEvent("battle_start", 1, "Player entered a battle encounter.", {
     roomId: "room-contract",
@@ -47,6 +47,17 @@ export const ANALYTICS_EVENT_CATALOG = {
       gems: 10,
       gold: 50
     }
+  }),
+  shop_open: defineAnalyticsEvent("shop_open", 1, "Player opened the shop surface.", {
+    roomId: "room-contract",
+    surface: "lobby"
+  }),
+  purchase_initiated: defineAnalyticsEvent("purchase_initiated", 1, "Player initiated a shop purchase from the client.", {
+    roomId: "room-contract",
+    productId: "gem_pack_small",
+    productType: "gem_pack",
+    currency: "wechat_fen",
+    price: 600
   }),
   purchase: defineAnalyticsEvent("purchase", 1, "Shop purchase completed successfully.", {
     purchaseId: "purchase-1",
@@ -93,7 +104,9 @@ export type AnalyticsEvent<Name extends AnalyticsEventName = AnalyticsEventName>
   version: (typeof ANALYTICS_EVENT_CATALOG)[Name]["version"];
   at: string;
   playerId: string;
-  source: "server";
+  source: "server" | "cocos-client";
+  sessionId?: string;
+  platform?: string;
   roomId?: string;
   payload: AnalyticsEventPayloadByName[Name];
 };
@@ -103,6 +116,9 @@ export function createAnalyticsEvent<Name extends AnalyticsEventName>(
   input: {
     at?: string;
     playerId: string;
+    source?: AnalyticsEvent<Name>["source"];
+    sessionId?: string;
+    platform?: string;
     roomId?: string;
     payload: AnalyticsEventPayloadByName[Name];
   }
@@ -113,7 +129,9 @@ export function createAnalyticsEvent<Name extends AnalyticsEventName>(
     version: ANALYTICS_EVENT_CATALOG[name].version,
     at: input.at ?? new Date().toISOString(),
     playerId: input.playerId,
-    source: "server",
+    source: input.source ?? "server",
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.platform ? { platform: input.platform } : {}),
     ...(input.roomId ? { roomId: input.roomId } : {}),
     payload: input.payload
   };


### PR DESCRIPTION
## Summary
- instrument the Cocos client to emit the issue #900 analytics events across session, battle, shop, purchase, tutorial, quest, and experiment flows
- batch client events to `POST /api/analytics/events` with `sessionId`, `playerId`, and `platform: "wechat"`, while staying fire-and-forget and disabled outside production
- add the server analytics ingest route plus focused client and server tests for the new telemetry behavior

## Why
Issue #900 requires client-side analytics coverage for core gameplay and monetization funnels so live-ops can see player behavior from the WeChat client.

## Validation
- `node --import tsx --test ./apps/cocos-client/test/cocos-primary-client-telemetry.test.ts`
- `node --import tsx --test ./apps/cocos-client/test/cocos-root-orchestration.test.ts`
- `node --import tsx --test ./apps/server/test/analytics.test.ts`

Closes #900