### PR TITLE
Add seasonal event panel and automatic progress sync

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -760,6 +760,17 @@ type ServerMessage =
       createdAt: string;
     }
   | {
+      type: "event.progress.update";
+      requestId: "push";
+      delivery: "push";
+      payload: {
+        eventId: string;
+        points: number;
+        delta: number;
+        objectiveId: string;
+      };
+    }
+  | {
       type: "COSMETIC_APPLIED";
       requestId: string;
       delivery?: "reply" | "push";

--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -209,6 +209,7 @@ export interface VeilHudRenderState {
     available: boolean;
   };
   battlePassEnabled: boolean;
+  seasonalEventAvailable: boolean;
   interaction: {
     title: string;
     detail: string;
@@ -248,6 +249,7 @@ export interface VeilHudPanelOptions {
   onToggleInventory?: () => void;
   onToggleAchievements?: () => void;
   onToggleProgression?: () => void;
+  onToggleSeasonalEvent?: () => void;
   onToggleReport?: () => void;
   onToggleSurrender?: () => void;
   onShareBattleResult?: () => void;
@@ -361,6 +363,7 @@ export class VeilHudPanel extends Component {
   private onToggleInventory: (() => void) | undefined;
   private onToggleAchievements: (() => void) | undefined;
   private onToggleProgression: (() => void) | undefined;
+  private onToggleSeasonalEvent: (() => void) | undefined;
   private onToggleReport: (() => void) | undefined;
   private onToggleSurrender: (() => void) | undefined;
   private onShareBattleResult: (() => void) | undefined;
@@ -383,6 +386,7 @@ export class VeilHudPanel extends Component {
     this.onToggleInventory = options.onToggleInventory;
     this.onToggleAchievements = options.onToggleAchievements;
     this.onToggleProgression = options.onToggleProgression;
+    this.onToggleSeasonalEvent = options.onToggleSeasonalEvent;
     this.onToggleReport = options.onToggleReport;
     this.onToggleSurrender = options.onToggleSurrender;
     this.onShareBattleResult = options.onShareBattleResult;
@@ -684,6 +688,7 @@ export class VeilHudPanel extends Component {
       { nodeName: "HudInventory", debugLabel: "inventory", callback: this.onToggleInventory ?? null },
       { nodeName: "HudAchievements", debugLabel: "achievements", callback: this.onToggleAchievements ?? null },
       { nodeName: "HudBattlePass", debugLabel: "battle-pass", callback: this.onToggleProgression ?? null },
+      { nodeName: "HudSeasonalEvent", debugLabel: "seasonal-event", callback: this.onToggleSeasonalEvent ?? null },
       { nodeName: "HudReportPlayer", debugLabel: "report-player", callback: this.onToggleReport ?? null },
       { nodeName: "HudSurrender", debugLabel: "surrender", callback: this.onToggleSurrender ?? null },
       { nodeName: "HudShareBattleResult", debugLabel: "share-battle-result", callback: this.onShareBattleResult ?? null },
@@ -1634,6 +1639,7 @@ export class VeilHudPanel extends Component {
     this.ensureActionButton(actionsNode, "HudInventory", "装备背包");
     this.ensureActionButton(actionsNode, "HudAchievements", "战报中心");
     this.ensureActionButton(actionsNode, "HudBattlePass", "赛季通行证");
+    this.ensureActionButton(actionsNode, "HudSeasonalEvent", "赛季活动");
     this.ensureActionButton(actionsNode, "HudReportPlayer", "举报玩家");
     this.ensureActionButton(actionsNode, "HudSurrender", "认输");
     this.ensureActionButton(actionsNode, "HudShareBattleResult", "分享战绩");
@@ -1666,6 +1672,12 @@ export class VeilHudPanel extends Component {
         label: "赛季通行证",
         callback: this.onToggleProgression ?? null,
         visible: this.currentState?.battlePassEnabled ?? false
+      },
+      {
+        name: "HudSeasonalEvent",
+        label: "赛季活动",
+        callback: this.onToggleSeasonalEvent ?? null,
+        visible: this.currentState?.seasonalEventAvailable ?? false
       },
       { name: "HudReportPlayer", label: "举报玩家", callback: this.onToggleReport ?? null },
       {

--- a/apps/cocos-client/assets/scripts/VeilProgressionPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilProgressionPanel.ts
@@ -1,5 +1,6 @@
 import { _decorator, Color, Component, Graphics, Label, Node, UITransform } from "cc";
 import { type CocosAccountReviewPage, type CocosAccountReviewSection } from "./cocos-account-review.ts";
+import { type CocosEventLeaderboardPanelView } from "./cocos-event-leaderboard-panel.ts";
 import { type CocosBattlePassPanelView } from "./cocos-progression-panel.ts";
 import { assignUiLayer } from "./cocos-ui-layer.ts";
 
@@ -28,6 +29,9 @@ export type VeilProgressionPanelRenderState =
     }
   | {
       battlePass: CocosBattlePassPanelView;
+    }
+  | {
+      eventLeaderboard: CocosEventLeaderboardPanelView;
     };
 
 export interface VeilProgressionPanelOptions {
@@ -69,6 +73,10 @@ export class VeilProgressionPanel extends Component {
 
   render(state: VeilProgressionPanelRenderState): void {
     this.currentState = state;
+    if ("eventLeaderboard" in state) {
+      this.renderEventLeaderboard(state.eventLeaderboard);
+      return;
+    }
     if ("battlePass" in state) {
       this.renderBattlePass(state.battlePass);
       return;
@@ -76,6 +84,7 @@ export class VeilProgressionPanel extends Component {
 
     this.node.active = true;
     this.hideBattlePassNodes();
+    this.hideEventLeaderboardNodes();
     this.renderAccountReview(state.page);
   }
 
@@ -258,6 +267,7 @@ export class VeilProgressionPanel extends Component {
 
     this.node.active = true;
     this.hideAccountReviewNodes();
+    this.hideEventLeaderboardNodes();
 
     const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
     const width = transform.width || 380;
@@ -384,6 +394,110 @@ export class VeilProgressionPanel extends Component {
     });
 
     this.hideExtraBattlePassItems(view.tiers.length);
+  }
+
+  private renderEventLeaderboard(view: CocosEventLeaderboardPanelView): void {
+    if (!view.visible) {
+      this.node.active = false;
+      return;
+    }
+
+    this.node.active = true;
+    this.hideAccountReviewNodes();
+    this.hideBattlePassNodes();
+
+    const transform = this.node.getComponent(UITransform) ?? this.node.addComponent(UITransform);
+    const width = transform.width || 380;
+    const height = transform.height || 440;
+    const contentWidth = width - 30;
+    let cursorY = height / 2 - 16;
+
+    this.syncChrome(width, height);
+
+    this.renderButton(
+      "EventLeaderboardClose",
+      contentWidth / 2 - 12,
+      height / 2 - 18,
+      72,
+      24,
+      "关闭",
+      {
+        fill: NEGATIVE_FILL,
+        stroke: new Color(244, 226, 214, 114)
+      },
+      this.onClose ?? null
+    );
+
+    cursorY = this.renderCard(
+      "EventLeaderboardHeader",
+      0,
+      cursorY,
+      contentWidth,
+      92,
+      [view.title, view.subtitle, `${view.countdownLabel} · ${view.playerScoreLabel} · ${view.playerRankLabel}`],
+      {
+        fill: CARD_HIGHLIGHT_FILL,
+        stroke: new Color(244, 236, 208, 82)
+      },
+      null,
+      14,
+      17
+    );
+
+    cursorY = this.renderCard(
+      "EventLeaderboardStatus",
+      0,
+      cursorY,
+      contentWidth,
+      56,
+      [view.leaderboardTitle, view.statusLabel],
+      {
+        fill: CARD_FILL,
+        stroke: new Color(220, 230, 244, 56)
+      },
+      null,
+      13,
+      16
+    );
+
+    view.topRows.forEach((row, index) => {
+      cursorY = this.renderCard(
+        `EventLeaderboardRow-${index}`,
+        0,
+        cursorY,
+        contentWidth,
+        56,
+        [row.summary, `${row.scoreLabel} · ${row.rewardPreviewLabel}${row.isCurrentPlayer ? " · 你" : ""}`],
+        {
+          fill: row.isCurrentPlayer ? CARD_HIGHLIGHT_FILL : CARD_FILL,
+          stroke: row.isCurrentPlayer ? new Color(236, 244, 216, 96) : new Color(220, 230, 244, 56)
+        },
+        null,
+        12,
+        15
+      );
+    });
+
+    view.rewardTiers.forEach((tier, index) => {
+      this.renderCard(
+        `EventRewardTier-${index}`,
+        0,
+        cursorY,
+        contentWidth,
+        60,
+        [tier.title, `${tier.rankLabel} · ${tier.rewardLabel}`, tier.stateLabel],
+        {
+          fill: tier.unlocked ? FREE_TRACK_FILL : MUTED_FILL,
+          stroke: tier.unlocked ? new Color(220, 242, 226, 82) : new Color(220, 230, 244, 56)
+        },
+        null,
+        12,
+        15
+      );
+      cursorY -= Math.max(60, 24 + 3 * 15) + 8;
+    });
+
+    this.hideExtraEventLeaderboardItems(view.topRows.length, view.rewardTiers.length);
   }
 
   private syncChrome(width: number, height: number): void {
@@ -577,12 +691,32 @@ export class VeilProgressionPanel extends Component {
     }
   }
 
+  private hideExtraEventLeaderboardItems(visibleRows: number, visibleRewardTiers: number): void {
+    for (let index = visibleRows; index < 10; index += 1) {
+      const rowNode = this.node.getChildByName(`EventLeaderboardRow-${index}`);
+      if (rowNode) {
+        rowNode.active = false;
+      }
+    }
+
+    for (let index = visibleRewardTiers; index < 6; index += 1) {
+      const rewardNode = this.node.getChildByName(`EventRewardTier-${index}`);
+      if (rewardNode) {
+        rewardNode.active = false;
+      }
+    }
+  }
+
   private hideAccountReviewNodes(): void {
     this.hideNodesByPrefix(["ProgressionHeader", "ProgressionBanner", "ProgressionClose", "ProgressionPrev", "ProgressionNext", "ProgressionRetry", "ProgressionTab-", "ProgressionItem-"]);
   }
 
   private hideBattlePassNodes(): void {
     this.hideNodesByPrefix(["BattlePassHeader", "BattlePassNextReward", "BattlePassMeter", "BattlePassPremiumAction", "BattlePassClose", "BattlePassTier-", "BattlePassTrack-"]);
+  }
+
+  private hideEventLeaderboardNodes(): void {
+    this.hideNodesByPrefix(["EventLeaderboardHeader", "EventLeaderboardStatus", "EventLeaderboardClose", "EventLeaderboardRow-", "EventRewardTier-"]);
   }
 
   private hideNodesByPrefix(prefixes: string[]): void {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -41,6 +41,7 @@ import {
   loadCocosPlayerAchievementProgress,
   loadCocosPlayerEventHistory,
   loadCocosPlayerProgressionSnapshot,
+  loadCocosActiveSeasonalEvents,
   loadCocosSeasonProgress,
   loginCocosGuestAuthSession,
   logoutCurrentCocosAuthSession,
@@ -52,10 +53,12 @@ import {
   requestCocosPasswordRecovery,
   resolveCocosConfigCenterUrl,
   saveCocosLobbyPreferences,
+  submitCocosSeasonalEventProgress,
   syncCurrentCocosAuthSession,
   updateCocosTutorialProgress,
   type CocosLobbyRoomSummary,
-  type CocosPlayerAccountProfile
+  type CocosPlayerAccountProfile,
+  type CocosSeasonalEvent
 } from "./cocos-lobby.ts";
 import {
   loginWithCocosProvider,
@@ -139,6 +142,7 @@ import {
   type CocosAuthProvider
 } from "./cocos-session-launch.ts";
 import { buildCocosShopPanelView, type ShopProduct } from "./cocos-shop-panel.ts";
+import { buildCocosEventLeaderboardPanelView } from "./cocos-event-leaderboard-panel.ts";
 import { buildCocosBattlePassPanelView, type CocosSeasonProgress } from "./cocos-progression-panel.ts";
 import { VeilTimelinePanel } from "./VeilTimelinePanel.ts";
 import { VeilProgressionPanel } from "./VeilProgressionPanel.ts";
@@ -234,6 +238,8 @@ interface VeilRootRuntime {
   loadEventHistory: typeof loadCocosPlayerEventHistory;
   loadBattleReplayHistoryPage: typeof loadCocosBattleReplayHistoryPage;
   loadSeasonProgress: typeof loadCocosSeasonProgress;
+  loadActiveSeasonalEvents: typeof loadCocosActiveSeasonalEvents;
+  submitSeasonalEventProgress: typeof submitCocosSeasonalEventProgress;
   claimSeasonTier: typeof claimCocosSeasonTier;
   loginGuestAuthSession: typeof loginCocosGuestAuthSession;
   postPlayerReferral: typeof postCocosPlayerReferral;
@@ -262,6 +268,8 @@ const defaultVeilRootRuntime: VeilRootRuntime = {
   loadEventHistory: (...args) => loadCocosPlayerEventHistory(...args),
   loadBattleReplayHistoryPage: (...args) => loadCocosBattleReplayHistoryPage(...args),
   loadSeasonProgress: (...args) => loadCocosSeasonProgress(...args),
+  loadActiveSeasonalEvents: (...args) => loadCocosActiveSeasonalEvents(...args),
+  submitSeasonalEventProgress: (...args) => submitCocosSeasonalEventProgress(...args),
   claimSeasonTier: (...args) => claimCocosSeasonTier(...args),
   loginGuestAuthSession: (...args) => loginCocosGuestAuthSession(...args),
   postPlayerReferral: (...args) => postCocosPlayerReferral(...args),
@@ -377,6 +385,10 @@ export class VeilRoot extends Component {
   private pendingShopProductId: string | null = null;
   private seasonProgress: CocosSeasonProgress | null = null;
   private seasonProgressStatus = "赛季进度待同步。";
+  private activeSeasonalEvent: CocosSeasonalEvent | null = null;
+  private seasonalEventStatus = "赛季活动待同步。";
+  private gameplaySeasonalEventPanelOpen = false;
+  private pendingSeasonalEventBattleIds = new Set<string>();
   private pendingSeasonClaimTier: number | null = null;
   private seasonPremiumPurchaseInFlight = false;
   private mailboxClaimingMessageId: string | null = null;
@@ -528,6 +540,9 @@ export class VeilRoot extends Component {
 
       this.pushLog("房间快照已加载，点击地块即可移动。");
       await this.applySessionUpdate(this.lastUpdate);
+      if (this.sessionSource === "remote") {
+        void this.refreshGameplayAccountProfile();
+      }
     } catch (error) {
       if (!this.isActiveSessionEpoch(sessionEpoch)) {
         if (nextSession) {
@@ -866,6 +881,9 @@ export class VeilRoot extends Component {
       onToggleProgression: () => {
         void this.toggleGameplayBattlePassPanel();
       },
+      onToggleSeasonalEvent: () => {
+        void this.toggleGameplaySeasonalEventPanel();
+      },
       onToggleReport: () => {
         this.toggleReportDialog();
       },
@@ -1105,6 +1123,10 @@ export class VeilRoot extends Component {
           void this.toggleGameplayBattlePassPanel(false);
           return;
         }
+        if (this.gameplaySeasonalEventPanelOpen) {
+          void this.toggleGameplaySeasonalEventPanel(false);
+          return;
+        }
         void this.toggleGameplayAccountReviewPanel(false);
       },
       onSelectSection: (section) => {
@@ -1277,7 +1299,8 @@ export class VeilRoot extends Component {
       timelineNode.active = showingGame;
     }
     if (accountReviewPanelNode) {
-      accountReviewPanelNode.active = showingGame && (this.gameplayAccountReviewPanelOpen || this.gameplayBattlePassPanelOpen);
+      accountReviewPanelNode.active =
+        showingGame && (this.gameplayAccountReviewPanelOpen || this.gameplayBattlePassPanelOpen || this.gameplaySeasonalEventPanelOpen);
     }
     if (equipmentPanelNode) {
       equipmentPanelNode.active = showingGame && this.gameplayEquipmentPanelOpen;
@@ -1411,6 +1434,7 @@ export class VeilRoot extends Component {
         available: this.canShareLatestBattleResult()
       },
       battlePassEnabled: this.lastUpdate?.featureFlags?.battle_pass_enabled === true,
+      seasonalEventAvailable: this.activeSeasonalEvent != null,
       interaction: this.buildHudInteractionState(),
       presentation: this.buildHudPresentationState()
     });
@@ -1468,7 +1492,7 @@ export class VeilRoot extends Component {
       return;
     }
 
-    if (!this.gameplayAccountReviewPanelOpen && !this.gameplayBattlePassPanelOpen) {
+    if (!this.gameplayAccountReviewPanelOpen && !this.gameplayBattlePassPanelOpen && !this.gameplaySeasonalEventPanelOpen) {
       panelNode.active = false;
       return;
     }
@@ -1481,6 +1505,17 @@ export class VeilRoot extends Component {
           pendingClaimTier: this.pendingSeasonClaimTier,
           pendingPremiumPurchase: this.seasonPremiumPurchaseInFlight,
           statusLabel: this.seasonProgressStatus
+        })
+      });
+      return;
+    }
+
+    if (this.gameplaySeasonalEventPanelOpen) {
+      this.gameplayAccountReviewPanel?.render({
+        eventLeaderboard: buildCocosEventLeaderboardPanelView({
+          event: this.activeSeasonalEvent,
+          playerId: this.playerId,
+          statusLabel: this.seasonalEventStatus
         })
       });
       return;
@@ -1573,7 +1608,7 @@ export class VeilRoot extends Component {
       this.sessionSource = "none";
     }
 
-    const [profile, leaderboardResult, shopProductsResult] = await Promise.all([
+    const [profile, leaderboardResult, shopProductsResult, activeEventsResult] = await Promise.all([
       resolveVeilRootRuntime().loadAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
         storage,
         authSession: syncedSession
@@ -1599,7 +1634,16 @@ export class VeilRoot extends Component {
       resolveVeilRootRuntime()
         .loadShopProducts(this.remoteUrl)
         .then((products) => ({ ok: true as const, products }))
-        .catch((error: unknown) => ({ ok: false as const, error }))
+        .catch((error: unknown) => ({ ok: false as const, error })),
+      syncedSession?.token
+        ? resolveVeilRootRuntime()
+            .loadActiveSeasonalEvents(this.remoteUrl, {
+              storage,
+              authSession: syncedSession
+            })
+            .then((events) => ({ ok: true as const, events }))
+            .catch((error: unknown) => ({ ok: false as const, error }))
+        : Promise.resolve({ ok: true as const, events: [] as CocosSeasonalEvent[] })
     ]);
     if (!this.isActiveLobbyAccountEpoch(requestEpoch)) {
       return;
@@ -1634,6 +1678,16 @@ export class VeilRoot extends Component {
       this.lobbyShopProducts = [];
       this.lobbyShopStatus =
         shopProductsResult.error instanceof Error ? shopProductsResult.error.message : "shop_unavailable";
+    }
+    if (activeEventsResult.ok) {
+      this.activeSeasonalEvent = activeEventsResult.events[0] ?? null;
+      this.seasonalEventStatus = this.activeSeasonalEvent
+        ? `已同步 ${this.activeSeasonalEvent.name} · 当前积分 ${this.activeSeasonalEvent.player.points}`
+        : "当前没有进行中的赛季活动。";
+    } else {
+      this.activeSeasonalEvent = null;
+      this.seasonalEventStatus =
+        activeEventsResult.error instanceof Error ? activeEventsResult.error.message : "seasonal_event_unavailable";
     }
     this.lobbyShopLoading = false;
     if (profile.source === "remote") {
@@ -1892,6 +1946,7 @@ export class VeilRoot extends Component {
   private async toggleGameplayAccountReviewPanel(forceOpen?: boolean): Promise<void> {
     const nextOpen = forceOpen ?? !this.gameplayAccountReviewPanelOpen;
     this.gameplayBattlePassPanelOpen = false;
+    this.gameplaySeasonalEventPanelOpen = false;
     this.gameplayAccountReviewPanelOpen = nextOpen;
     if (!nextOpen) {
       this.renderView();
@@ -1912,6 +1967,7 @@ export class VeilRoot extends Component {
 
     const nextOpen = forceOpen ?? !this.gameplayBattlePassPanelOpen;
     this.gameplayAccountReviewPanelOpen = false;
+    this.gameplaySeasonalEventPanelOpen = false;
     this.gameplayBattlePassPanelOpen = nextOpen;
     if (!nextOpen) {
       this.renderView();
@@ -1921,6 +1977,20 @@ export class VeilRoot extends Component {
     this.seasonProgress = this.snapshotSeasonProgressFromProfile();
     this.renderView();
     await this.refreshSeasonProgress();
+  }
+
+  private async toggleGameplaySeasonalEventPanel(forceOpen?: boolean): Promise<void> {
+    const nextOpen = forceOpen ?? !this.gameplaySeasonalEventPanelOpen;
+    this.gameplayAccountReviewPanelOpen = false;
+    this.gameplayBattlePassPanelOpen = false;
+    this.gameplaySeasonalEventPanelOpen = nextOpen;
+    if (!nextOpen) {
+      this.renderView();
+      return;
+    }
+
+    this.renderView();
+    await this.refreshActiveSeasonalEvent();
   }
 
   private snapshotSeasonProgressFromProfile(): CocosSeasonProgress {
@@ -1955,6 +2025,163 @@ export class VeilRoot extends Component {
         : "点击金色按钮可购买高级通行证。";
     } catch (error) {
       this.seasonProgressStatus = error instanceof Error ? error.message : "season_progress_unavailable";
+    }
+    this.renderView();
+  }
+
+  private async refreshActiveSeasonalEvent(): Promise<void> {
+    if (!this.remoteUrl?.trim()) {
+      this.activeSeasonalEvent = null;
+      this.seasonalEventStatus = "赛季活动服务地址未配置。";
+      this.renderView();
+      return;
+    }
+
+    const storage = this.readWebStorage();
+    const authSession = this.currentLobbyAuthSession();
+    if (!authSession?.token) {
+      this.activeSeasonalEvent = null;
+      this.seasonalEventStatus = "赛季活动需要有效账号会话。";
+      this.renderView();
+      return;
+    }
+
+    this.seasonalEventStatus = "正在同步赛季活动...";
+    this.renderView();
+    try {
+      const [event] = await resolveVeilRootRuntime().loadActiveSeasonalEvents(this.remoteUrl, {
+        storage,
+        authSession,
+        throwOnError: true
+      });
+      this.activeSeasonalEvent = event ?? null;
+      this.seasonalEventStatus = event
+        ? `已同步 ${event.name} · 当前积分 ${event.player.points}`
+        : "当前没有进行中的赛季活动。";
+    } catch (error) {
+      this.seasonalEventStatus = error instanceof Error ? error.message : "seasonal_event_unavailable";
+    }
+    this.renderView();
+  }
+
+  private async submitBattleProgressForActiveEvents(update: SessionUpdate): Promise<void> {
+    if (this.sessionSource !== "remote" || !this.authToken) {
+      return;
+    }
+
+    const authSession = this.currentLobbyAuthSession();
+    if (!authSession?.token) {
+      return;
+    }
+
+    const resolvedBattles = update.events.filter(
+      (event): event is Extract<SessionUpdate["events"][number], { type: "battle.resolved" }> => event.type === "battle.resolved"
+    );
+    const ownResolvedBattle = resolvedBattles.find((event) => update.world.ownHeroes.some((hero) => hero.id === event.heroId)) ?? null;
+    if (!ownResolvedBattle) {
+      return;
+    }
+
+    const actionId = `${update.world.playerId}:${ownResolvedBattle.battleId}`;
+    if (this.pendingSeasonalEventBattleIds.has(actionId)) {
+      return;
+    }
+
+    this.pendingSeasonalEventBattleIds.add(actionId);
+    try {
+      const events =
+        this.activeSeasonalEvent ? [this.activeSeasonalEvent] : await resolveVeilRootRuntime().loadActiveSeasonalEvents(this.remoteUrl, {
+          storage: this.readWebStorage(),
+          authSession,
+          throwOnError: false
+        });
+      if (events.length === 0) {
+        if (!this.activeSeasonalEvent) {
+          this.seasonalEventStatus = "当前没有进行中的赛季活动。";
+          this.renderView();
+        }
+        return;
+      }
+
+      for (const seasonalEvent of events) {
+        const result = await resolveVeilRootRuntime().submitSeasonalEventProgress(
+          this.remoteUrl,
+          seasonalEvent.id,
+          {
+            actionId,
+            actionType: "battle_resolved",
+            battleId: ownResolvedBattle.battleId,
+            occurredAt: new Date().toISOString()
+          },
+          {
+            storage: this.readWebStorage(),
+            authSession
+          }
+        );
+        if (result.event) {
+          this.activeSeasonalEvent = result.event;
+        }
+        if (result.eventProgress) {
+          this.seasonalEventStatus = `${seasonalEvent.name} +${result.eventProgress.delta} 分 · 当前 ${result.eventProgress.points} 分`;
+        }
+      }
+      this.renderView();
+    } catch (error) {
+      this.seasonalEventStatus = error instanceof Error ? error.message : "seasonal_event_progress_failed";
+      this.renderView();
+    } finally {
+      this.pendingSeasonalEventBattleIds.delete(actionId);
+    }
+  }
+
+  private handleSeasonalEventProgressPush(message: {
+    payload: {
+      eventId: string;
+      points: number;
+      delta: number;
+      objectiveId: string;
+    };
+  }): void {
+    const eventId = message.payload.eventId.trim();
+    if (!eventId) {
+      return;
+    }
+
+    if (this.activeSeasonalEvent?.id === eventId) {
+      const previousRank =
+        this.activeSeasonalEvent.leaderboard.entries.find((entry) => entry.playerId === this.playerId)?.rank ?? null;
+      const currentEntries = this.activeSeasonalEvent.leaderboard.entries.filter((entry) => entry.playerId !== this.playerId);
+      currentEntries.push({
+        rank: previousRank ?? currentEntries.length + 1,
+        playerId: this.playerId,
+        displayName: this.displayName || this.playerId,
+        points: Math.max(0, Math.floor(message.payload.points)),
+        lastUpdatedAt: new Date().toISOString()
+      });
+      currentEntries.sort(
+        (left, right) =>
+          right.points - left.points || left.lastUpdatedAt.localeCompare(right.lastUpdatedAt) || left.playerId.localeCompare(right.playerId)
+      );
+
+      this.activeSeasonalEvent = {
+        ...this.activeSeasonalEvent,
+        player: {
+          ...this.activeSeasonalEvent.player,
+          points: Math.max(0, Math.floor(message.payload.points))
+        },
+        leaderboard: {
+          ...this.activeSeasonalEvent.leaderboard,
+          entries: currentEntries.map((entry, index) => ({
+            ...entry,
+            rank: index + 1
+          }))
+        }
+      };
+    }
+
+    this.seasonalEventStatus = `赛季活动推进：${message.payload.objectiveId} +${message.payload.delta} 分`;
+    if (this.gameplaySeasonalEventPanelOpen) {
+      void this.refreshActiveSeasonalEvent();
     }
     this.renderView();
   }
@@ -3749,6 +3976,7 @@ export class VeilRoot extends Component {
     this.resetSessionViewport("已返回 Cocos Lobby。");
     this.gameplayAccountReviewPanelOpen = false;
     this.gameplayBattlePassPanelOpen = false;
+    this.gameplaySeasonalEventPanelOpen = false;
     this.gameplayEquipmentPanelOpen = false;
     this.seasonProgress = null;
     this.showLobby = true;
@@ -4402,6 +4630,12 @@ export class VeilRoot extends Component {
             };
           }
           this.renderView();
+          return;
+        }
+
+        if (message.type === "event.progress.update") {
+          this.pushLog(`赛季活动推进：${message.payload.objectiveId} +${message.payload.delta} 分`);
+          this.handleSeasonalEventProgressPush(message);
         }
       },
       onConnectionEvent: (event) => {
@@ -5100,6 +5334,9 @@ export class VeilRoot extends Component {
         }, update.world.meta.roomId);
       }
     }
+    if (update.events.some((event) => event.type === "battle.resolved")) {
+      void this.submitBattleProgressForActiveEvents(update);
+    }
     if (shouldRefreshGameplayAccountProfileForEvents(update.events.map((event) => event.type))) {
       void this.refreshGameplayAccountProfile();
     }
@@ -5135,22 +5372,39 @@ export class VeilRoot extends Component {
       return;
     }
 
+    if (!this.remoteUrl?.trim()) {
+      return;
+    }
+
     this.gameplayAccountRefreshInFlight = true;
     try {
-      const profile = await resolveVeilRootRuntime().loadAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
-        storage: this.readWebStorage(),
-        authSession: this.authToken
-          ? {
-              token: this.authToken,
-              playerId: this.playerId,
-              displayName: this.displayName || this.playerId,
-              authMode: this.authMode,
-              ...(this.loginId ? { loginId: this.loginId } : {}),
-              source: "remote"
-            }
-          : null
-      });
+      const authSession = this.authToken
+        ? {
+            token: this.authToken,
+            playerId: this.playerId,
+            displayName: this.displayName || this.playerId,
+            authMode: this.authMode,
+            ...(this.loginId ? { loginId: this.loginId } : {}),
+            source: "remote" as const
+          }
+        : null;
+      const [profile, activeEvents] = await Promise.all([
+        resolveVeilRootRuntime().loadAccountProfile(this.remoteUrl, this.playerId, this.roomId, {
+          storage: this.readWebStorage(),
+          authSession
+        }),
+        authSession?.token
+          ? resolveVeilRootRuntime().loadActiveSeasonalEvents(this.remoteUrl, {
+              storage: this.readWebStorage(),
+              authSession
+            })
+          : Promise.resolve([])
+      ]);
       this.commitAccountProfile(profile, true);
+      this.activeSeasonalEvent = activeEvents[0] ?? null;
+      if (this.activeSeasonalEvent) {
+        this.seasonalEventStatus = `已同步 ${this.activeSeasonalEvent.name} · 当前积分 ${this.activeSeasonalEvent.player.points}`;
+      }
       this.renderView();
     } finally {
       this.gameplayAccountRefreshInFlight = false;

--- a/apps/cocos-client/assets/scripts/cocos-event-leaderboard-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-event-leaderboard-panel.ts
@@ -1,0 +1,111 @@
+import type { CocosSeasonalEvent } from "./cocos-lobby.ts";
+
+export interface CocosEventLeaderboardRowView {
+  rank: number;
+  rankLabel: string;
+  displayName: string;
+  scoreLabel: string;
+  rewardPreviewLabel: string;
+  isCurrentPlayer: boolean;
+  summary: string;
+}
+
+export interface CocosEventRewardTierView {
+  title: string;
+  rankLabel: string;
+  rewardLabel: string;
+  stateLabel: string;
+  unlocked: boolean;
+}
+
+export interface CocosEventLeaderboardPanelView {
+  visible: boolean;
+  title: string;
+  subtitle: string;
+  countdownLabel: string;
+  playerScoreLabel: string;
+  playerRankLabel: string;
+  leaderboardTitle: string;
+  statusLabel: string;
+  topRows: CocosEventLeaderboardRowView[];
+  rewardTiers: CocosEventRewardTierView[];
+}
+
+export interface BuildCocosEventLeaderboardPanelInput {
+  event: CocosSeasonalEvent | null;
+  playerId: string;
+  statusLabel: string;
+  now?: Date;
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  if (days > 0) {
+    return `${days} 天 ${String(hours).padStart(2, "0")} 时`;
+  }
+  return `${String(hours).padStart(2, "0")} 时 ${String(minutes).padStart(2, "0")} 分`;
+}
+
+function formatRewardLabel(tier: CocosSeasonalEvent["leaderboard"]["rewardTiers"][number]): string {
+  const parts = [tier.badge?.trim() ? `徽记 ${tier.badge.trim()}` : null, tier.cosmeticId?.trim() ? `外观 ${tier.cosmeticId.trim()}` : null]
+    .filter((entry): entry is string => Boolean(entry));
+  return parts.length > 0 ? parts.join(" / ") : "奖励待同步";
+}
+
+export function buildCocosEventLeaderboardPanelView(
+  input: BuildCocosEventLeaderboardPanelInput
+): CocosEventLeaderboardPanelView {
+  const event = input.event;
+  if (!event) {
+    return {
+      visible: false,
+      title: "赛季活动",
+      subtitle: "当前没有进行中的赛季活动。",
+      countdownLabel: "未检测到活动",
+      playerScoreLabel: "个人积分 0",
+      playerRankLabel: "当前排名 未上榜",
+      leaderboardTitle: "排行榜",
+      statusLabel: input.statusLabel,
+      topRows: [],
+      rewardTiers: []
+    };
+  }
+
+  const nowMs = input.now?.getTime() ?? Date.now();
+  const myRow = event.leaderboard.entries.find((entry) => entry.playerId === input.playerId) ?? null;
+  const remainingMs = Math.max(0, new Date(event.endsAt).getTime() - nowMs);
+  const topRows = event.leaderboard.entries.slice(0, 10).map<CocosEventLeaderboardRowView>((entry) => ({
+    rank: entry.rank,
+    rankLabel: `#${entry.rank}`,
+    displayName: entry.displayName,
+    scoreLabel: `${entry.points} 分`,
+    rewardPreviewLabel: entry.rewardPreview?.trim() || "无额外头衔",
+    isCurrentPlayer: entry.playerId === input.playerId,
+    summary: `#${entry.rank} ${entry.displayName} · ${entry.points} 分${entry.rewardPreview ? ` · ${entry.rewardPreview}` : ""}`
+  }));
+
+  return {
+    visible: true,
+    title: event.name,
+    subtitle: event.bannerText || event.description || "赛季活动排行榜",
+    countdownLabel: remainingMs > 0 ? `剩余 ${formatDuration(remainingMs)}` : "活动已结束，奖励将通过邮箱发放",
+    playerScoreLabel: `个人积分 ${event.player.points}`,
+    playerRankLabel: myRow ? `当前排名 #${myRow.rank}` : "当前排名 未上榜",
+    leaderboardTitle: `前 ${Math.min(10, Math.max(1, event.leaderboard.entries.length || 10))} 名排行榜`,
+    statusLabel: input.statusLabel,
+    topRows,
+    rewardTiers: event.leaderboard.rewardTiers.map((tier) => {
+      const unlocked = Boolean(myRow && tier.rankStart <= myRow.rank && myRow.rank <= tier.rankEnd);
+      return {
+        title: tier.title,
+        rankLabel: tier.rankStart === tier.rankEnd ? `排名 #${tier.rankStart}` : `排名 #${tier.rankStart}-#${tier.rankEnd}`,
+        rewardLabel: formatRewardLabel(tier),
+        stateLabel: unlocked ? "已解锁" : myRow ? "未达成" : "未上榜",
+        unlocked
+      };
+    })
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -177,6 +177,74 @@ interface PlayerSeasonProgressApiPayload {
   seasonPassClaimedTiers?: number[];
 }
 
+interface SeasonalEventLeaderboardEntryApiPayload {
+  rank?: number;
+  playerId?: string;
+  displayName?: string;
+  points?: number;
+  lastUpdatedAt?: string;
+  rewardPreview?: string;
+}
+
+interface SeasonalEventRewardTierApiPayload {
+  rankStart?: number;
+  rankEnd?: number;
+  title?: string;
+  badge?: string;
+  cosmeticId?: string;
+}
+
+interface SeasonalEventRewardApiPayload {
+  id?: string;
+  name?: string;
+  pointsRequired?: number;
+  kind?: "gems" | "resources" | "badge" | "cosmetic";
+  gems?: number;
+  resources?: Partial<PlayerAccountReadModel["globalResources"]>;
+  badge?: string;
+  cosmeticId?: string;
+}
+
+interface SeasonalEventPlayerApiPayload {
+  points?: number;
+  claimedRewardIds?: string[];
+  claimableRewardIds?: string[];
+}
+
+interface SeasonalEventApiPayload {
+  id?: string;
+  name?: string;
+  description?: string;
+  startsAt?: string;
+  endsAt?: string;
+  durationDays?: number;
+  bannerText?: string;
+  remainingMs?: number;
+  rewards?: SeasonalEventRewardApiPayload[];
+  player?: SeasonalEventPlayerApiPayload;
+  leaderboard?: {
+    size?: number;
+    rewardTiers?: SeasonalEventRewardTierApiPayload[];
+    entries?: SeasonalEventLeaderboardEntryApiPayload[];
+    topThree?: SeasonalEventLeaderboardEntryApiPayload[];
+  };
+}
+
+interface SeasonalEventsApiPayload {
+  events?: SeasonalEventApiPayload[];
+}
+
+interface SeasonalEventProgressApiPayload {
+  applied?: boolean;
+  event?: SeasonalEventApiPayload | null;
+  eventProgress?: {
+    eventId?: string;
+    delta?: number;
+    points?: number;
+    objectiveId?: string;
+  } | null;
+}
+
 export interface CocosAccountRegistrationRequestResult {
   status: string;
   expiresAt?: string;
@@ -204,6 +272,70 @@ export interface CocosEventHistoryPage {
   hasMore: boolean;
 }
 
+export interface CocosSeasonalEventLeaderboardEntry {
+  rank: number;
+  playerId: string;
+  displayName: string;
+  points: number;
+  lastUpdatedAt: string;
+  rewardPreview?: string;
+}
+
+export interface CocosSeasonalEventRewardTier {
+  rankStart: number;
+  rankEnd: number;
+  title: string;
+  badge?: string;
+  cosmeticId?: string;
+}
+
+export interface CocosSeasonalEventReward {
+  id: string;
+  name: string;
+  pointsRequired: number;
+  kind: "gems" | "resources" | "badge" | "cosmetic";
+  gems?: number;
+  resources?: PlayerAccountReadModel["globalResources"];
+  badge?: string;
+  cosmeticId?: string;
+}
+
+export interface CocosSeasonalEventPlayerProgress {
+  points: number;
+  claimedRewardIds: string[];
+  claimableRewardIds: string[];
+}
+
+export interface CocosSeasonalEvent {
+  id: string;
+  name: string;
+  description: string;
+  startsAt: string;
+  endsAt: string;
+  durationDays: number;
+  bannerText: string;
+  remainingMs: number;
+  rewards: CocosSeasonalEventReward[];
+  player: CocosSeasonalEventPlayerProgress;
+  leaderboard: {
+    size: number;
+    rewardTiers: CocosSeasonalEventRewardTier[];
+    entries: CocosSeasonalEventLeaderboardEntry[];
+    topThree: CocosSeasonalEventLeaderboardEntry[];
+  };
+}
+
+export interface CocosSeasonalEventProgressResult {
+  applied: boolean;
+  event: CocosSeasonalEvent | null;
+  eventProgress: {
+    eventId: string;
+    delta: number;
+    points: number;
+    objectiveId: string;
+  } | null;
+}
+
 function normalizeSeasonProgress(payload?: PlayerSeasonProgressApiPayload | null): CocosSeasonProgress {
   const seasonPassClaimedTiers = Array.from(
     new Set(
@@ -219,6 +351,124 @@ function normalizeSeasonProgress(payload?: PlayerSeasonProgressApiPayload | null
     seasonPassTier: Math.max(1, Math.floor(payload?.seasonPassTier ?? 1)),
     seasonPassPremium: payload?.seasonPassPremium === true,
     seasonPassClaimedTiers
+  };
+}
+
+function normalizeEventTimestamp(value?: string | null): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return new Date(0).toISOString();
+  }
+
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? new Date(0).toISOString() : parsed.toISOString();
+}
+
+function normalizeSeasonalEventLeaderboardEntry(
+  payload?: SeasonalEventLeaderboardEntryApiPayload | null
+): CocosSeasonalEventLeaderboardEntry | null {
+  const playerId = payload?.playerId?.trim();
+  if (!playerId) {
+    return null;
+  }
+
+  const rank = Math.max(1, Math.floor(payload?.rank ?? 1));
+  return {
+    rank,
+    playerId,
+    displayName: normalizeDisplayName(playerId, payload?.displayName),
+    points: Math.max(0, Math.floor(payload?.points ?? 0)),
+    lastUpdatedAt: normalizeEventTimestamp(payload?.lastUpdatedAt),
+    ...(payload?.rewardPreview?.trim() ? { rewardPreview: payload.rewardPreview.trim() } : {})
+  };
+}
+
+function normalizeSeasonalEventRewardTier(payload?: SeasonalEventRewardTierApiPayload | null): CocosSeasonalEventRewardTier | null {
+  const title = payload?.title?.trim();
+  if (!title) {
+    return null;
+  }
+
+  return {
+    rankStart: Math.max(1, Math.floor(payload?.rankStart ?? 1)),
+    rankEnd: Math.max(1, Math.floor(payload?.rankEnd ?? payload?.rankStart ?? 1)),
+    title,
+    ...(payload?.badge?.trim() ? { badge: payload.badge.trim() } : {}),
+    ...(payload?.cosmeticId?.trim() ? { cosmeticId: payload.cosmeticId.trim() } : {})
+  };
+}
+
+function normalizeSeasonalEventReward(payload?: SeasonalEventRewardApiPayload | null): CocosSeasonalEventReward | null {
+  const id = payload?.id?.trim();
+  const name = payload?.name?.trim();
+  if (!id || !name) {
+    return null;
+  }
+
+  return {
+    id,
+    name,
+    pointsRequired: Math.max(0, Math.floor(payload?.pointsRequired ?? 0)),
+    kind: payload?.kind ?? "gems",
+    ...(Math.max(0, Math.floor(payload?.gems ?? 0)) > 0 ? { gems: Math.max(0, Math.floor(payload?.gems ?? 0)) } : {}),
+    ...((payload?.resources?.gold ?? 0) > 0 || (payload?.resources?.wood ?? 0) > 0 || (payload?.resources?.ore ?? 0) > 0
+      ? {
+          resources: {
+            gold: Math.max(0, Math.floor(payload?.resources?.gold ?? 0)),
+            wood: Math.max(0, Math.floor(payload?.resources?.wood ?? 0)),
+            ore: Math.max(0, Math.floor(payload?.resources?.ore ?? 0))
+          }
+        }
+      : {}),
+    ...(payload?.badge?.trim() ? { badge: payload.badge.trim() } : {}),
+    ...(payload?.cosmeticId?.trim() ? { cosmeticId: payload.cosmeticId.trim() } : {})
+  };
+}
+
+function normalizeSeasonalEvent(payload?: SeasonalEventApiPayload | null): CocosSeasonalEvent | null {
+  const id = payload?.id?.trim();
+  if (!id) {
+    return null;
+  }
+
+  const entries = (payload?.leaderboard?.entries ?? [])
+    .map((entry) => normalizeSeasonalEventLeaderboardEntry(entry))
+    .filter((entry): entry is CocosSeasonalEventLeaderboardEntry => Boolean(entry))
+    .sort((left, right) => left.rank - right.rank || left.playerId.localeCompare(right.playerId));
+  const topThree = (payload?.leaderboard?.topThree ?? [])
+    .map((entry) => normalizeSeasonalEventLeaderboardEntry(entry))
+    .filter((entry): entry is CocosSeasonalEventLeaderboardEntry => Boolean(entry))
+    .sort((left, right) => left.rank - right.rank || left.playerId.localeCompare(right.playerId));
+
+  return {
+    id,
+    name: payload?.name?.trim() || id,
+    description: payload?.description?.trim() || "",
+    startsAt: normalizeEventTimestamp(payload?.startsAt),
+    endsAt: normalizeEventTimestamp(payload?.endsAt),
+    durationDays: Math.max(1, Math.floor(payload?.durationDays ?? 1)),
+    bannerText: payload?.bannerText?.trim() || "",
+    remainingMs: Math.max(0, Math.floor(payload?.remainingMs ?? 0)),
+    rewards: (payload?.rewards ?? [])
+      .map((reward) => normalizeSeasonalEventReward(reward))
+      .filter((reward): reward is CocosSeasonalEventReward => Boolean(reward))
+      .sort((left, right) => left.pointsRequired - right.pointsRequired || left.id.localeCompare(right.id)),
+    player: {
+      points: Math.max(0, Math.floor(payload?.player?.points ?? 0)),
+      claimedRewardIds: Array.from(new Set((payload?.player?.claimedRewardIds ?? []).map((entry) => entry?.trim()).filter(Boolean))),
+      claimableRewardIds: Array.from(
+        new Set((payload?.player?.claimableRewardIds ?? []).map((entry) => entry?.trim()).filter(Boolean))
+      )
+    },
+    leaderboard: {
+      size: Math.max(1, Math.floor(payload?.leaderboard?.size ?? Math.max(entries.length, 10))),
+      rewardTiers: (payload?.leaderboard?.rewardTiers ?? [])
+        .map((tier) => normalizeSeasonalEventRewardTier(tier))
+        .filter((tier): tier is CocosSeasonalEventRewardTier => Boolean(tier))
+        .sort((left, right) => left.rankStart - right.rankStart || left.rankEnd - right.rankEnd),
+      entries,
+      topThree
+    }
   };
 }
 
@@ -1985,4 +2235,103 @@ export async function claimCocosSeasonTier(
       ...(storage !== undefined ? { storage } : {})
     }
   );
+}
+
+export async function loadCocosActiveSeasonalEvents(
+  remoteUrl: string,
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "setItem" | "removeItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+    throwOnError?: boolean;
+  }
+): Promise<CocosSeasonalEvent[]> {
+  const storage = options?.storage ?? getCocosStorage();
+  const authSession =
+    options && "authSession" in options ? options.authSession ?? null : readStoredCocosAuthSession(storage);
+
+  try {
+    const payload = (await fetchCocosAuthJson(
+      remoteUrl,
+      `${resolveCocosApiBaseUrl(remoteUrl)}/api/events/active`,
+      {
+        ...(authSession?.token ? { headers: buildCocosAuthHeaders(authSession.token) } : {})
+      },
+      authSession,
+      {
+        ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        ...(storage !== undefined ? { storage } : {})
+      }
+    )) as SeasonalEventsApiPayload;
+    return (payload.events ?? [])
+      .map((event) => normalizeSeasonalEvent(event))
+      .filter((event): event is CocosSeasonalEvent => Boolean(event))
+      .sort((left, right) => left.endsAt.localeCompare(right.endsAt) || left.id.localeCompare(right.id));
+  } catch (error) {
+    if (authSession?.token && error instanceof Error && error.message.startsWith("cocos_request_failed:401:") && storage) {
+      clearStoredCocosAuthSession(storage);
+    }
+    if (options?.throwOnError) {
+      throw error;
+    }
+    return [];
+  }
+}
+
+export async function submitCocosSeasonalEventProgress(
+  remoteUrl: string,
+  eventId: string,
+  action: {
+    actionId: string;
+    actionType: string;
+    battleId?: string;
+    dungeonId?: string;
+    occurredAt?: string;
+  },
+  options?: {
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "getItem" | "setItem" | "removeItem"> | null;
+    authSession?: CocosStoredAuthSession | null;
+  }
+): Promise<CocosSeasonalEventProgressResult> {
+  const storage = options?.storage ?? getCocosStorage();
+  const authSession =
+    options && "authSession" in options ? options.authSession ?? null : readStoredCocosAuthSession(storage);
+
+  const payload = (await fetchCocosAuthJson(
+    remoteUrl,
+    `${resolveCocosApiBaseUrl(remoteUrl)}/api/events/${encodeURIComponent(eventId)}/progress`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(authSession?.token ? buildCocosAuthHeaders(authSession.token) : {})
+      },
+      body: JSON.stringify({
+        actionId: action.actionId,
+        actionType: action.actionType,
+        ...(action.battleId?.trim() ? { battleId: action.battleId.trim() } : {}),
+        ...(action.dungeonId?.trim() ? { dungeonId: action.dungeonId.trim() } : {}),
+        ...(action.occurredAt?.trim() ? { occurredAt: action.occurredAt.trim() } : {})
+      })
+    },
+    authSession,
+    {
+      ...(options?.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+      ...(storage !== undefined ? { storage } : {})
+    }
+  )) as SeasonalEventProgressApiPayload;
+
+  return {
+    applied: payload.applied === true,
+    event: normalizeSeasonalEvent(payload.event),
+    eventProgress: payload.eventProgress?.eventId?.trim()
+      ? {
+          eventId: payload.eventProgress.eventId.trim(),
+          delta: Math.max(0, Math.floor(payload.eventProgress.delta ?? 0)),
+          points: Math.max(0, Math.floor(payload.eventProgress.points ?? 0)),
+          objectiveId: payload.eventProgress.objectiveId?.trim() || "objective"
+        }
+      : null
+  };
 }

--- a/apps/cocos-client/assets/scripts/project-shared/player-account.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/player-account.ts
@@ -56,6 +56,7 @@ export interface PlayerMailboxGrant {
   resources?: Partial<ResourceLedger>;
   equipmentIds?: string[];
   cosmeticIds?: string[];
+  seasonBadges?: string[];
   seasonPassPremium?: boolean;
 }
 
@@ -228,6 +229,9 @@ function normalizePlayerMailboxGrant(grant?: Partial<PlayerMailboxGrant> | null)
       : {}),
     ...((grant.cosmeticIds?.length ?? 0) > 0
       ? { cosmeticIds: Array.from(new Set((grant.cosmeticIds ?? []).map((entry) => entry?.trim()).filter(Boolean))) }
+      : {}),
+    ...((grant.seasonBadges?.length ?? 0) > 0
+      ? { seasonBadges: Array.from(new Set((grant.seasonBadges ?? []).map((entry) => entry?.trim()).filter(Boolean))) }
       : {}),
     ...(grant.seasonPassPremium === true ? { seasonPassPremium: true } : {})
   };

--- a/apps/cocos-client/assets/scripts/project-shared/protocol.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/protocol.ts
@@ -133,6 +133,17 @@ export type ServerMessage =
       createdAt: string;
     }
   | {
+      type: "event.progress.update";
+      requestId: "push";
+      delivery: "push";
+      payload: {
+        eventId: string;
+        points: number;
+        delta: number;
+        objectiveId: string;
+      };
+    }
+  | {
       type: "COSMETIC_APPLIED";
       requestId: string;
       delivery: "reply" | "push";

--- a/apps/cocos-client/test/cocos-event-leaderboard-panel.test.ts
+++ b/apps/cocos-client/test/cocos-event-leaderboard-panel.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCocosEventLeaderboardPanelView } from "../assets/scripts/cocos-event-leaderboard-panel.ts";
+import type { CocosSeasonalEvent } from "../assets/scripts/cocos-lobby.ts";
+
+function createEvent(overrides: Partial<CocosSeasonalEvent> = {}): CocosSeasonalEvent {
+  return {
+    id: "defend-the-bridge",
+    name: "Defend the Bridge",
+    description: "Bridge defense event",
+    startsAt: "2026-04-01T00:00:00.000Z",
+    endsAt: "2026-04-08T00:00:00.000Z",
+    durationDays: 7,
+    bannerText: "Hold the crossing.",
+    remainingMs: 86_400_000,
+    rewards: [],
+    player: {
+      points: 160,
+      claimedRewardIds: [],
+      claimableRewardIds: []
+    },
+    leaderboard: {
+      size: 100,
+      rewardTiers: [
+        {
+          rankStart: 1,
+          rankEnd: 1,
+          title: "Bridge Champion",
+          badge: "bridge_champion_2026",
+          cosmeticId: "bridge-champion-border"
+        },
+        {
+          rankStart: 2,
+          rankEnd: 3,
+          title: "Frontier Defender",
+          badge: "frontier_defender_2026"
+        }
+      ],
+      entries: [
+        {
+          rank: 1,
+          playerId: "player-1",
+          displayName: "Lyra",
+          points: 220,
+          lastUpdatedAt: "2026-04-04T09:00:00.000Z",
+          rewardPreview: "Bridge Champion"
+        },
+        {
+          rank: 2,
+          playerId: "player-2",
+          displayName: "Serin",
+          points: 160,
+          lastUpdatedAt: "2026-04-04T09:10:00.000Z",
+          rewardPreview: "Frontier Defender"
+        }
+      ],
+      topThree: []
+    },
+    ...overrides
+  };
+}
+
+test("buildCocosEventLeaderboardPanelView formats player standing and reward tier unlock state", () => {
+  const view = buildCocosEventLeaderboardPanelView({
+    event: createEvent(),
+    playerId: "player-2",
+    statusLabel: "已同步赛季活动。",
+    now: new Date("2026-04-07T00:00:00.000Z")
+  });
+
+  assert.equal(view.visible, true);
+  assert.match(view.playerScoreLabel, /160/);
+  assert.match(view.playerRankLabel, /#2/);
+  assert.equal(view.topRows[1]?.isCurrentPlayer, true);
+  assert.equal(view.rewardTiers[1]?.unlocked, true);
+  assert.equal(view.rewardTiers[0]?.unlocked, false);
+});
+
+test("buildCocosEventLeaderboardPanelView hides itself without an active event", () => {
+  const view = buildCocosEventLeaderboardPanelView({
+    event: null,
+    playerId: "player-2",
+    statusLabel: "当前没有进行中的赛季活动。"
+  });
+
+  assert.equal(view.visible, false);
+  assert.equal(view.topRows.length, 0);
+  assert.equal(view.rewardTiers.length, 0);
+});

--- a/apps/cocos-client/test/cocos-veil-root.test.ts
+++ b/apps/cocos-client/test/cocos-veil-root.test.ts
@@ -3,6 +3,7 @@ import { afterEach, test } from "node:test";
 import { sys } from "cc";
 import { VeilRoot } from "../assets/scripts/VeilRoot.ts";
 import { createFallbackCocosPlayerAccountProfile } from "../assets/scripts/cocos-lobby.ts";
+import type { CocosSeasonalEvent } from "../assets/scripts/cocos-lobby.ts";
 import type { MatchmakingStatusResponse, SessionUpdate } from "../assets/scripts/VeilCocosSession.ts";
 import { createMemoryStorage, createSessionUpdate } from "./helpers/cocos-session-fixtures.ts";
 import { createVeilRootHarness, installVeilRootRuntime, resetVeilRootRuntime } from "./helpers/veil-root-harness.ts";
@@ -92,6 +93,40 @@ function createBattleUpdate(): SessionUpdate {
     encounterPosition: { x: 1, y: 0 }
   };
   return update;
+}
+
+function createSeasonalEvent(overrides: Partial<CocosSeasonalEvent> = {}): CocosSeasonalEvent {
+  return {
+    id: "defend-the-bridge",
+    name: "Defend the Bridge",
+    description: "Bridge defense event",
+    startsAt: "2026-04-01T00:00:00.000Z",
+    endsAt: "2026-04-08T00:00:00.000Z",
+    durationDays: 7,
+    bannerText: "Hold the crossing.",
+    remainingMs: 86_400_000,
+    rewards: [],
+    player: {
+      points: 40,
+      claimedRewardIds: [],
+      claimableRewardIds: []
+    },
+    leaderboard: {
+      size: 100,
+      rewardTiers: [],
+      entries: [
+        {
+          rank: 4,
+          playerId: "account-player",
+          displayName: "雾林司灯",
+          points: 40,
+          lastUpdatedAt: "2026-04-04T09:00:00.000Z"
+        }
+      ],
+      topThree: []
+    },
+    ...overrides
+  };
 }
 
 test("VeilRoot cold boot falls back to a guest lobby identity when no stored session exists", () => {
@@ -222,6 +257,98 @@ test("VeilRoot applies cosmetic push messages to lobby profile state and logs ba
   assert.equal(renderCount, 2);
   assert.match(String(root.logLines[0]), /战斗表情：player-2 使用了 emote-cheer-spark/);
   assert.match(String(root.logLines[1]), /外观同步：account-player 装备 border-shadowcourt/);
+});
+
+test("VeilRoot handles seasonal event progress push updates and refreshes local panel state", () => {
+  const root = createVeilRootHarness();
+  let renderCount = 0;
+  root.renderView = () => {
+    renderCount += 1;
+  };
+  root.playerId = "account-player";
+  root.displayName = "雾林司灯";
+  root.sessionEpoch = 4;
+  root.activeSeasonalEvent = createSeasonalEvent();
+  root.gameplaySeasonalEventPanelOpen = false;
+
+  const options = (root as VeilRoot & {
+    createSessionOptions(epoch: number): {
+      onServerMessage(message: {
+        type: "event.progress.update";
+        payload: { eventId: string; points: number; delta: number; objectiveId: string };
+      }): void;
+    };
+  }).createSessionOptions(4);
+
+  options.onServerMessage({
+    type: "event.progress.update",
+    payload: {
+      eventId: "defend-the-bridge",
+      points: 120,
+      delta: 80,
+      objectiveId: "bridge-dungeon-clear"
+    }
+  });
+
+  assert.equal(root.activeSeasonalEvent?.player.points, 120);
+  assert.equal(root.activeSeasonalEvent?.leaderboard.entries[0]?.rank, 1);
+  assert.match(String(root.seasonalEventStatus), /\+80 分/);
+  assert.equal(renderCount, 1);
+});
+
+test("VeilRoot submits seasonal event progress after an owned battle resolves", async () => {
+  const root = createVeilRootHarness();
+  root.applySessionUpdate = VeilRoot.prototype.applySessionUpdate.bind(root);
+  root.refreshGameplayAccountProfile = async () => undefined;
+  root.playerId = "account-player";
+  root.displayName = "雾林司灯";
+  root.sessionSource = "remote";
+  root.authToken = "auth.token";
+  root.activeSeasonalEvent = createSeasonalEvent();
+
+  const resolvedUpdate = createSessionUpdate(4, "room-recover", "account-player");
+  resolvedUpdate.events = [
+    {
+      type: "battle.resolved",
+      battleId: "battle-42",
+      battleKind: "neutral",
+      heroId: "hero-1",
+      result: "attacker_victory",
+      resourcesGained: { gold: 0, wood: 0, ore: 0 },
+      experienceGained: 10,
+      skillPointsAwarded: 0
+    }
+  ];
+
+  const submissions: string[] = [];
+  installVeilRootRuntime({
+    submitSeasonalEventProgress: async (_remoteUrl, eventId, action) => {
+      submissions.push(`${eventId}:${action.actionId}:${action.actionType}`);
+      return {
+        applied: true,
+        event: createSeasonalEvent({
+          player: {
+            points: 80,
+            claimedRewardIds: [],
+            claimableRewardIds: []
+          }
+        }),
+        eventProgress: {
+          eventId,
+          delta: 40,
+          points: 80,
+          objectiveId: "battle_resolved"
+        }
+      };
+    }
+  });
+
+  await root.applySessionUpdate(resolvedUpdate);
+  await flushMicrotasks();
+
+  assert.deepEqual(submissions, ["defend-the-bridge:account-player:battle-42:battle_resolved"]);
+  assert.equal(root.activeSeasonalEvent?.player.points, 80);
+  assert.match(String(root.seasonalEventStatus), /\+40 分/);
 });
 
 test("VeilRoot warm boot keeps direct room resume in auto-connect mode", () => {

--- a/apps/server/src/event-engine.ts
+++ b/apps/server/src/event-engine.ts
@@ -620,4 +620,114 @@ export function registerEventRoutes(
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });
+
+  app.post("/api/events/:eventId/progress", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 503, {
+        error: {
+          code: "seasonal_event_persistence_unavailable",
+          message: "Seasonal event progress requires configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const routeRequest = request as IncomingMessage & { params?: Record<string, string | undefined> };
+      const eventId = routeRequest.params?.eventId?.trim();
+      if (!eventId) {
+        sendJson(response, 400, {
+          error: {
+            code: "seasonal_event_progress_invalid",
+            message: "eventId is required"
+          }
+        });
+        return;
+      }
+
+      const body = (await readJsonBody(request)) as {
+        actionId?: string | null;
+        actionType?: SeasonalEventObjective["actionType"] | null;
+        dungeonId?: string | null;
+        occurredAt?: string | null;
+      };
+      const actionId = body.actionId?.trim();
+      const actionType = body.actionType?.trim();
+      if (!actionId || !actionType) {
+        sendJson(response, 400, {
+          error: {
+            code: "seasonal_event_progress_invalid",
+            message: "actionId and actionType are required"
+          }
+        });
+        return;
+      }
+
+      const now = body.occurredAt ? new Date(normalizeTimestamp(body.occurredAt, "occurredAt")) : nowFactory();
+      const event = getActiveSeasonalEvents(events, now).find((entry) => entry.id === eventId);
+      if (!event) {
+        sendJson(response, 404, {
+          error: {
+            code: "seasonal_event_not_found",
+            message: "Seasonal event was not found or is not active"
+          }
+        });
+        return;
+      }
+
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      const progress = applySeasonalEventProgress(
+        event,
+        findSeasonalEventState(account.seasonalEventStates, event.id),
+        {
+          actionId,
+          actionType,
+          ...(body.dungeonId?.trim() ? { dungeonId: body.dungeonId.trim() } : {}),
+          occurredAt: now.toISOString()
+        },
+        now
+      );
+
+      const nextAccount = progress
+        ? await store.savePlayerAccountProgress(account.playerId, {
+            seasonalEventStates: upsertSeasonalEventState(account.seasonalEventStates, progress.state)
+          })
+        : account;
+      sendJson(response, 200, {
+        applied: Boolean(progress),
+        ...(progress
+          ? {
+              eventProgress: {
+                eventId: event.id,
+                delta: progress.delta,
+                points: progress.state.points,
+                objectiveId: progress.objective.id
+              }
+            }
+          : {}),
+        event: toEventResponse(event, nextAccount, buildEventLeaderboard(event, await store.listPlayerAccounts()), now)
+      });
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_json",
+            message: "Request body must be valid JSON"
+          }
+        });
+        return;
+      }
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
 }

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -1026,6 +1026,7 @@ async function applyMailboxClaimsToAccount(
       resources: addResourceLedgers(accumulator.resources, claim.granted.resources),
       equipmentIds: [...accumulator.equipmentIds, ...claim.granted.equipmentIds],
       cosmeticIds: [...accumulator.cosmeticIds, ...claim.granted.cosmeticIds],
+      seasonBadges: [...accumulator.seasonBadges, ...claim.granted.seasonBadges],
       seasonPassPremium: accumulator.seasonPassPremium || claim.granted.seasonPassPremium
     }),
     {
@@ -1033,6 +1034,7 @@ async function applyMailboxClaimsToAccount(
       resources: normalizeResourceLedger(),
       equipmentIds: [] as EquipmentId[],
       cosmeticIds: [] as CosmeticId[],
+      seasonBadges: [] as string[],
       seasonPassPremium: false
     }
   );
@@ -1082,11 +1084,15 @@ async function applyMailboxClaimsToAccount(
   const nextGems = normalizeGemAmount(currentAccount.gems) + totalGrant.gems;
   const nextSeasonPassPremium = currentAccount.seasonPassPremium === true || totalGrant.seasonPassPremium;
   const nextCosmeticInventory = applyOwnedCosmetics(currentAccount.cosmeticInventory, totalGrant.cosmeticIds);
+  const nextSeasonBadges = Array.from(new Set([...(currentAccount.seasonBadges ?? []), ...totalGrant.seasonBadges])).sort((left, right) =>
+    left.localeCompare(right)
+  );
 
   await connection.query(
     `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
      SET gems = ?,
          season_pass_premium = ?,
+         season_badges_json = ?,
          cosmetic_inventory_json = ?,
          global_resources_json = ?,
          recent_event_log_json = ?,
@@ -1096,6 +1102,7 @@ async function applyMailboxClaimsToAccount(
     [
       nextGems,
       nextSeasonPassPremium ? 1 : 0,
+      JSON.stringify(nextSeasonBadges),
       JSON.stringify(nextCosmeticInventory),
       JSON.stringify(nextGlobalResources),
       JSON.stringify(nextRecentEventLog),

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -44,6 +44,7 @@ import type {
 import { getDailyRewardDateKey, getPreviousDailyRewardDateKey, resolveDailyRewardForStreak } from "./daily-rewards";
 import {
   applySeasonalEventProgress,
+  buildEventLeaderboard,
   findSeasonalEventState,
   getActiveSeasonalEvents,
   resolveSeasonalEvents
@@ -560,6 +561,58 @@ function toMailboxResponse(account: PlayerAccountSnapshot, now = new Date()) {
   };
 }
 
+async function surfaceEndedSeasonalEventRewards(
+  store: RoomSnapshotStore,
+  account: PlayerAccountSnapshot,
+  now = new Date()
+): Promise<PlayerAccountSnapshot> {
+  if (!store.deliverPlayerMailbox) {
+    return account;
+  }
+
+  const endedEvents = resolveSeasonalEvents().filter((event) => new Date(event.endsAt).getTime() <= now.getTime());
+  if (endedEvents.length === 0) {
+    return account;
+  }
+
+  let nextAccount = account;
+  const allAccounts = await store.listPlayerAccounts();
+  for (const event of endedEvents) {
+    const rank = buildEventLeaderboard(event, allAccounts, event.leaderboard.size).find((entry) => entry.playerId === account.playerId)?.rank;
+    if (!rank) {
+      continue;
+    }
+
+    const rewardTier = event.leaderboard.rewardTiers.find((tier) => tier.rankStart <= rank && rank <= tier.rankEnd);
+    if (!rewardTier) {
+      continue;
+    }
+
+    const delivery = await store.deliverPlayerMailbox({
+      playerIds: [account.playerId],
+      message: normalizePlayerMailboxMessage({
+        id: `seasonal-event:${event.id}:leaderboard`,
+        kind: "system",
+        title: `${event.name} 结算奖励`,
+        body: `你在 ${event.name} 中获得 ${rewardTier.title}（排名 #${rank}），奖励已发放到邮箱附件。`,
+        sentAt: now.toISOString(),
+        expiresAt: new Date(now.getTime() + 1000 * 60 * 60 * 24 * 30).toISOString(),
+        grant: {
+          ...(rewardTier.badge ? { seasonBadges: [rewardTier.badge] } : {}),
+          ...(rewardTier.cosmeticId ? { cosmeticIds: [rewardTier.cosmeticId] } : {})
+        }
+      })
+    });
+    if (delivery.deliveredPlayerIds.includes(account.playerId)) {
+      nextAccount =
+        (await store.loadPlayerAccount(account.playerId)) ??
+        nextAccount;
+    }
+  }
+
+  return nextAccount;
+}
+
 function upsertSeasonalEventState(
   seasonalEventStates: SeasonalEventState[] | undefined,
   nextState: SeasonalEventState
@@ -878,18 +931,19 @@ export function registerPlayerAccountRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
+      const hydratedAccount = await surfaceEndedSeasonalEventRewards(store, account);
       emitExperimentExposureForSurface(
-        account.playerId,
-        account.lastRoomId ?? "account-profile",
+        hydratedAccount.playerId,
+        hydratedAccount.lastRoomId ?? "account-profile",
         "player_account_profile",
         entitlements.experiments
       );
       sendJson(response, 200, {
         account: {
-          ...(await withDailyQuestBoard(withBattleReportCenter(account), store, featureFlags.quest_system_enabled)),
+          ...(await withDailyQuestBoard(withBattleReportCenter(hydratedAccount), store, featureFlags.quest_system_enabled)),
           experiments: entitlements.experiments
         },
-        session: issueNextAuthSession(account, authSession)
+        session: issueNextAuthSession(hydratedAccount, authSession)
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
@@ -943,7 +997,8 @@ export function registerPlayerAccountRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
-      sendJson(response, 200, toMailboxResponse(account));
+      const hydratedAccount = await surfaceEndedSeasonalEventRewards(store, account);
+      sendJson(response, 200, toMailboxResponse(hydratedAccount));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/src/player-mailbox.ts
+++ b/apps/server/src/player-mailbox.ts
@@ -17,6 +17,7 @@ export interface NormalizedMailboxGrant {
   resources: ResourceLedger;
   equipmentIds: EquipmentId[];
   cosmeticIds: CosmeticId[];
+  seasonBadges: string[];
   seasonPassPremium: boolean;
 }
 
@@ -101,6 +102,7 @@ export function normalizePlayerMailboxGrant(grant?: PlayerMailboxGrant | null): 
       throw new Error(`unknown mailbox cosmetic grant: ${cosmeticId}`);
     }
   }
+  const seasonBadges = Array.from(new Set((grant?.seasonBadges ?? []).map((badge) => badge?.trim()).filter(Boolean)));
 
   return {
     gems: Math.max(0, Math.floor(grant?.gems ?? 0)),
@@ -111,6 +113,7 @@ export function normalizePlayerMailboxGrant(grant?: PlayerMailboxGrant | null): 
     },
     equipmentIds,
     cosmeticIds,
+    seasonBadges,
     seasonPassPremium: grant?.seasonPassPremium === true
   };
 }
@@ -124,6 +127,7 @@ export function hasMailboxGrant(grant?: PlayerMailboxGrant | null): boolean {
     normalized.resources.ore > 0 ||
     normalized.equipmentIds.length > 0 ||
     normalized.cosmeticIds.length > 0 ||
+    normalized.seasonBadges.length > 0 ||
     normalized.seasonPassPremium
   );
 }
@@ -153,6 +157,7 @@ export function normalizePlayerMailboxMessage(
               : {}),
             ...(normalizedGrant.equipmentIds.length > 0 ? { equipmentIds: normalizedGrant.equipmentIds } : {}),
             ...(normalizedGrant.cosmeticIds.length > 0 ? { cosmeticIds: normalizedGrant.cosmeticIds } : {}),
+            ...(normalizedGrant.seasonBadges.length > 0 ? { seasonBadges: normalizedGrant.seasonBadges } : {}),
             ...(normalizedGrant.seasonPassPremium ? { seasonPassPremium: true } : {})
           }
         }
@@ -304,7 +309,8 @@ export function createMailboxClaimEventLogEntry(
     granted.resources.wood > 0 ? { type: "resource" as const, label: "wood", amount: granted.resources.wood } : null,
     granted.resources.ore > 0 ? { type: "resource" as const, label: "ore", amount: granted.resources.ore } : null,
     ...granted.equipmentIds.map((equipmentId) => ({ type: "badge" as const, label: equipmentId })),
-    ...granted.cosmeticIds.map((cosmeticId) => ({ type: "badge" as const, label: cosmeticId }))
+    ...granted.cosmeticIds.map((cosmeticId) => ({ type: "badge" as const, label: cosmeticId })),
+    ...granted.seasonBadges.map((badge) => ({ type: "badge" as const, label: badge }))
   ].filter((reward): reward is NonNullable<typeof reward> => Boolean(reward));
 
   return {

--- a/configs/cosmetics.json
+++ b/configs/cosmetics.json
@@ -61,6 +61,26 @@
       "previewAsset": "borders/vanguard"
     },
     {
+      "id": "bridge-champion-border",
+      "name": "Bridge Champion Border",
+      "category": "profile_border",
+      "rarity": "epic",
+      "description": "A commemorative border awarded to the top defender of the bridge season.",
+      "price": 0,
+      "unlockCondition": "event_reward",
+      "previewAsset": "borders/bridge-champion"
+    },
+    {
+      "id": "bridge-warden-banner",
+      "name": "Bridge Warden Banner",
+      "category": "profile_border",
+      "rarity": "rare",
+      "description": "A frontier campaign banner granted to high-ranking bridge defenders.",
+      "price": 0,
+      "unlockCondition": "event_reward",
+      "previewAsset": "borders/bridge-warden"
+    },
+    {
       "id": "emote-cheer-spark",
       "name": "Spark Cheer",
       "category": "battle_emote",

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -46,6 +46,7 @@ export interface PlayerMailboxGrant {
   resources?: Partial<ResourceLedger>;
   equipmentIds?: EquipmentId[];
   cosmeticIds?: CosmeticId[];
+  seasonBadges?: string[];
   seasonPassPremium?: boolean;
 }
 
@@ -367,6 +368,13 @@ function normalizePlayerMailboxGrant(grant?: Partial<PlayerMailboxGrant> | null)
         .filter((cosmeticId): cosmeticId is CosmeticId => Boolean(cosmeticId))
     )
   );
+  const seasonBadges = Array.from(
+    new Set(
+      (grant.seasonBadges ?? [])
+        .map((badge) => badge?.trim())
+        .filter((badge): badge is string => Boolean(badge))
+    )
+  );
   const normalizedResources = {
     gold: Math.max(0, Math.floor(grant.resources?.gold ?? 0)),
     wood: Math.max(0, Math.floor(grant.resources?.wood ?? 0)),
@@ -379,6 +387,7 @@ function normalizePlayerMailboxGrant(grant?: Partial<PlayerMailboxGrant> | null)
       : {}),
     ...(equipmentIds.length > 0 ? { equipmentIds } : {}),
     ...(cosmeticIds.length > 0 ? { cosmeticIds } : {}),
+    ...(seasonBadges.length > 0 ? { seasonBadges } : {}),
     ...(grant.seasonPassPremium === true ? { seasonPassPremium: true } : {})
   };
 


### PR DESCRIPTION
## Summary
- add seasonal event loading, progress submission, and `event.progress.update` handling in the Cocos client
- add a dedicated seasonal event leaderboard panel view with score, rank, top-10 rows, reward tier state, and countdown
- add server support for seasonal event progress submission and mailbox delivery of ended leaderboard rewards

## Testing
- `npm run typecheck:cocos`
- `npm run typecheck:server`
- `npm run typecheck:shared`
- `node --import tsx --test ./apps/cocos-client/test/cocos-event-leaderboard-panel.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts`
- `node --import tsx --test ./apps/server/test/event-engine.test.ts ./apps/server/test/player-mailbox.test.ts`

Closes #901