### PR TITLE
Add server-side WeChat Pay receipt verification

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -192,6 +192,7 @@ import {
 import {
   createCocosWechatPaymentOrder,
   requestCocosWechatPayment,
+  verifyCocosWechatPayment,
   type CocosWechatPaymentRuntimeLike
 } from "./cocos-wechat-payment.ts";
 
@@ -1833,7 +1834,16 @@ export class VeilRoot extends Component {
           (globalThis as { wx?: CocosWechatPaymentRuntimeLike | null }).wx,
           order
         );
-        this.lobbyShopStatus = paymentResult.message;
+        const verification = await verifyCocosWechatPayment(this.remoteUrl, order.orderId, {
+          authToken: this.authToken
+        });
+        this.lobbyShopStatus =
+          verification.seasonPassPremium
+            ? `${product.name} 购买成功，赛季高级通行证已解锁。`
+            : `${product.name} 购买成功，当前宝石 ${verification.gemsBalance}。`;
+        if (paymentResult.available) {
+          await this.refreshLobbyAccountProfile();
+        }
       } else {
         const result = await resolveVeilRootRuntime().purchaseShopProduct(this.remoteUrl, productId, {
           getAuthToken: () => this.authToken

--- a/apps/cocos-client/assets/scripts/cocos-wechat-payment.ts
+++ b/apps/cocos-client/assets/scripts/cocos-wechat-payment.ts
@@ -11,6 +11,15 @@ export interface CocosWechatPaymentOrder {
   paySign: string;
 }
 
+export interface CocosWechatPaymentVerification {
+  orderId: string;
+  status: string;
+  credited: boolean;
+  paidAt?: string;
+  gemsBalance: number;
+  seasonPassPremium: boolean;
+}
+
 export interface CocosWechatPaymentRuntimeLike {
   requestPayment?: ((options: {
     timeStamp: string;
@@ -93,4 +102,37 @@ export async function requestCocosWechatPayment(
       }
     });
   });
+}
+
+export async function verifyCocosWechatPayment(
+  remoteUrl: string,
+  orderId: string,
+  options?: {
+    fetchImpl?: FetchLike;
+    authToken?: string | null;
+  }
+): Promise<CocosWechatPaymentVerification> {
+  const response = await getFetchImpl(options?.fetchImpl)(`${resolveCocosApiBaseUrl(remoteUrl)}/api/payments/wechat/verify`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...buildCocosAuthHeaders(options?.authToken)
+    },
+    body: JSON.stringify({
+      orderId
+    })
+  });
+
+  if (!response.ok) {
+    let errorCode = "unknown";
+    try {
+      const payload = (await readJsonResponse(response)) as { error?: { code?: string } };
+      errorCode = payload.error?.code?.trim() || errorCode;
+    } catch {
+      errorCode = "unknown";
+    }
+    throw new Error(`cocos_request_failed:${response.status}:${errorCode}`);
+  }
+
+  return (await readJsonResponse(response)) as CocosWechatPaymentVerification;
 }

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -21,6 +21,7 @@ import {
   MAX_PLAYER_DISPLAY_NAME_LENGTH,
   type PaymentOrderCompleteInput,
   type PaymentOrderCreateInput,
+  type PaymentReceiptSnapshot,
   type PaymentOrderSettlement,
   type PaymentOrderSnapshot,
   type RoomSnapshotStore,
@@ -130,6 +131,8 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly guilds = new Map<string, GuildState>();
   private readonly guildIdByPlayerId = new Map<string, string>();
   private readonly paymentOrders = new Map<string, PaymentOrderSnapshot>();
+  private readonly paymentReceiptsByOrderId = new Map<string, PaymentReceiptSnapshot>();
+  private readonly paymentReceiptOrderIdByTransactionId = new Map<string, string>();
   private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
@@ -174,6 +177,28 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
 
     const order = this.paymentOrders.get(normalizedOrderId);
     return order ? structuredClone(order) : null;
+  }
+
+  async loadPaymentReceiptByOrderId(orderId: string): Promise<PaymentReceiptSnapshot | null> {
+    const normalizedOrderId = orderId.trim();
+    if (!normalizedOrderId) {
+      throw new Error("orderId must not be empty");
+    }
+
+    const receipt = this.paymentReceiptsByOrderId.get(normalizedOrderId);
+    return receipt ? structuredClone(receipt) : null;
+  }
+
+  async countVerifiedPaymentReceiptsSince(playerId: string, since: string): Promise<number> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const sinceDate = new Date(since);
+    if (Number.isNaN(sinceDate.getTime())) {
+      throw new Error("since must be a valid ISO timestamp");
+    }
+
+    return Array.from(this.paymentReceiptsByOrderId.values()).filter(
+      (receipt) => receipt.playerId === normalizedPlayerId && new Date(receipt.verifiedAt).getTime() >= sinceDate.getTime()
+    ).length;
   }
 
   async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
@@ -592,8 +617,8 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     if (!Number.isFinite(input.amount) || amount <= 0) {
       throw new Error("amount must be a positive integer");
     }
-    if (!Number.isFinite(input.gemAmount) || gemAmount <= 0) {
-      throw new Error("gemAmount must be a positive integer");
+    if (!Number.isFinite(input.gemAmount) || gemAmount < 0) {
+      throw new Error("gemAmount must be a non-negative integer");
     }
 
     await this.ensurePlayerAccount({ playerId });
@@ -615,11 +640,15 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   async completePaymentOrder(orderId: string, input: PaymentOrderCompleteInput): Promise<PaymentOrderSettlement> {
     const normalizedOrderId = orderId.trim();
     const normalizedWechatOrderId = input.wechatOrderId.trim();
+    const normalizedProductName = input.productName.trim();
     if (!normalizedOrderId) {
       throw new Error("orderId must not be empty");
     }
     if (!normalizedWechatOrderId) {
       throw new Error("wechatOrderId must not be empty");
+    }
+    if (!normalizedProductName) {
+      throw new Error("productName must not be empty");
     }
 
     const existingOrder = this.paymentOrders.get(normalizedOrderId);
@@ -628,15 +657,40 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     }
 
     const account = await this.ensurePlayerAccount({ playerId: existingOrder.playerId });
-    if (existingOrder.status === "paid") {
+    const existingReceipt = this.paymentReceiptsByOrderId.get(normalizedOrderId);
+    if (existingOrder.status === "paid" || existingReceipt) {
       return {
         order: structuredClone(existingOrder),
         account,
-        credited: false
+        credited: false,
+        ...(existingReceipt ? { receipt: structuredClone(existingReceipt) } : {})
+      };
+    }
+    const duplicateOrderId = this.paymentReceiptOrderIdByTransactionId.get(normalizedWechatOrderId);
+    if (duplicateOrderId && duplicateOrderId !== normalizedOrderId) {
+      return {
+        order: structuredClone(existingOrder),
+        account,
+        credited: false,
+        ...(this.paymentReceiptsByOrderId.get(duplicateOrderId)
+          ? { receipt: structuredClone(this.paymentReceiptsByOrderId.get(duplicateOrderId)!) }
+          : {})
       };
     }
 
     const paidAt = new Date(input.paidAt ?? Date.now()).toISOString();
+    const verifiedAt = new Date(input.verifiedAt ?? paidAt).toISOString();
+    const normalizedGrant = {
+      gems: Math.max(0, Math.floor(input.grant.gems ?? existingOrder.gemAmount ?? 0)),
+      resources: {
+        gold: Math.max(0, Math.floor(input.grant.resources?.gold ?? 0)),
+        wood: Math.max(0, Math.floor(input.grant.resources?.wood ?? 0)),
+        ore: Math.max(0, Math.floor(input.grant.resources?.ore ?? 0))
+      },
+      seasonPassPremium: input.grant.seasonPassPremium === true,
+      cosmeticIds: (input.grant.cosmeticIds ?? []).map((cosmeticId) => cosmeticId.trim()).filter(Boolean),
+      equipmentIds: (input.grant.equipmentIds ?? []).map((equipmentId) => equipmentId.trim()).filter(Boolean)
+    };
     const nextOrder: PaymentOrderSnapshot = {
       ...structuredClone(existingOrder),
       status: "paid",
@@ -646,16 +700,47 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     };
     const nextAccount: PlayerAccountSnapshot = {
       ...account,
-      gems: (account.gems ?? 0) + existingOrder.gemAmount,
+      gems: (account.gems ?? 0) + normalizedGrant.gems,
+      seasonPassPremium: account.seasonPassPremium === true || normalizedGrant.seasonPassPremium,
+      cosmeticInventory: normalizeCosmeticInventory({
+        ownedIds: [...(account.cosmeticInventory?.ownedIds ?? []), ...normalizedGrant.cosmeticIds]
+      }),
+      globalResources: normalizeResourceLedger({
+        gold: (account.globalResources.gold ?? 0) + normalizedGrant.resources.gold,
+        wood: (account.globalResources.wood ?? 0) + normalizedGrant.resources.wood,
+        ore: (account.globalResources.ore ?? 0) + normalizedGrant.resources.ore
+      }),
+      recentEventLog: appendEventLogEntries(account.recentEventLog, [
+        {
+          id: `${existingOrder.playerId}:${paidAt}:shop:${existingOrder.productId}:1`,
+          timestamp: paidAt,
+          roomId: "shop",
+          playerId: existingOrder.playerId,
+          category: "account",
+          description: `Purchased ${normalizedProductName} x1.`,
+          rewards: []
+        }
+      ]),
       updatedAt: paidAt
     };
+    const receipt: PaymentReceiptSnapshot = {
+      transactionId: normalizedWechatOrderId,
+      orderId: normalizedOrderId,
+      playerId: existingOrder.playerId,
+      productId: existingOrder.productId,
+      amount: existingOrder.amount,
+      verifiedAt
+    };
     this.paymentOrders.set(normalizedOrderId, structuredClone(nextOrder));
+    this.paymentReceiptsByOrderId.set(normalizedOrderId, structuredClone(receipt));
+    this.paymentReceiptOrderIdByTransactionId.set(normalizedWechatOrderId, normalizedOrderId);
     this.accounts.set(existingOrder.playerId, cloneAccount(nextAccount));
 
     return {
       order: structuredClone(nextOrder),
       account: cloneAccount(nextAccount),
-      credited: true
+      credited: true,
+      receipt: structuredClone(receipt)
     };
   }
 

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -101,6 +101,8 @@ export interface RoomSnapshotStore {
   loadGuild?(guildId: string): Promise<GuildState | null>;
   loadGuildByMemberPlayerId?(playerId: string): Promise<GuildState | null>;
   loadPaymentOrder?(orderId: string): Promise<PaymentOrderSnapshot | null>;
+  loadPaymentReceiptByOrderId?(orderId: string): Promise<PaymentReceiptSnapshot | null>;
+  countVerifiedPaymentReceiptsSince?(playerId: string, since: string): Promise<number>;
   loadPlayerReport?(reportId: string): Promise<PlayerReportRecord | null>;
   loadPlayerBan?(playerId: string): Promise<PlayerAccountBanSnapshot | null>;
   createPlayerReport?(input: PlayerReportCreateInput): Promise<PlayerReportRecord>;
@@ -364,6 +366,15 @@ interface PaymentOrderRow extends RowDataPacket {
   updated_at: Date | string;
 }
 
+interface PaymentReceiptRow extends RowDataPacket {
+  transaction_id: string;
+  order_id: string;
+  player_id: string;
+  product_id: string;
+  amount: number;
+  verified_at: Date | string;
+}
+
 interface GuildRow extends RowDataPacket {
   guild_id: string;
   name: string;
@@ -529,12 +540,25 @@ export interface PaymentOrderCreateInput {
 export interface PaymentOrderCompleteInput {
   wechatOrderId: string;
   paidAt?: string;
+  verifiedAt?: string;
+  productName: string;
+  grant: ShopPurchaseGrant;
 }
 
 export interface PaymentOrderSettlement {
   order: PaymentOrderSnapshot;
   account: PlayerAccountSnapshot;
   credited: boolean;
+  receipt?: PaymentReceiptSnapshot;
+}
+
+export interface PaymentReceiptSnapshot {
+  transactionId: string;
+  orderId: string;
+  playerId: string;
+  productId: string;
+  amount: number;
+  verifiedAt: string;
 }
 
 export interface GemLedgerEntry {
@@ -729,6 +753,9 @@ export const MYSQL_SHOP_PURCHASE_TABLE = "shop_purchases";
 export const MYSQL_PAYMENT_ORDER_TABLE = "orders";
 export const MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX = "idx_orders_player_created";
 export const MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX = "uidx_orders_wechat_order_id";
+export const MYSQL_PAYMENT_RECEIPT_TABLE = "payment_receipts";
+export const MYSQL_PAYMENT_RECEIPT_ORDER_ID_INDEX = "uidx_payment_receipts_order_id";
+export const MYSQL_PAYMENT_RECEIPT_PLAYER_VERIFIED_INDEX = "idx_payment_receipts_player_verified";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_TABLE = "player_account_sessions";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX = "idx_player_account_sessions_player_last_used";
 export const MYSQL_PLAYER_BAN_HISTORY_TABLE = "player_ban_history";
@@ -859,6 +886,17 @@ function toPaymentOrderSnapshot(row: PaymentOrderRow): PaymentOrderSnapshot {
   };
 }
 
+function toPaymentReceiptSnapshot(row: PaymentReceiptRow): PaymentReceiptSnapshot {
+  return {
+    transactionId: normalizeWechatOrderId(row.transaction_id),
+    orderId: normalizePaymentOrderId(row.order_id),
+    playerId: normalizePlayerId(row.player_id),
+    productId: normalizeShopProductId(row.product_id),
+    amount: normalizePaymentAmount(row.amount),
+    verifiedAt: formatTimestamp(row.verified_at) ?? new Date(0).toISOString()
+  };
+}
+
 function normalizeShopProductId(productId: string): string {
   const normalized = productId.trim();
   if (!normalized) {
@@ -980,6 +1018,139 @@ function createShopPurchaseEventLogEntry(playerId: string, input: {
         : `Purchased ${input.productName} x${input.quantity}.`,
     rewards: resourceRewards
   };
+}
+
+async function applyVerifiedPaymentGrantToAccount(
+  connection: PoolConnection,
+  currentAccount: PlayerAccountSnapshot,
+  input: {
+    playerId: string;
+    productId: string;
+    productName: string;
+    grant: ShopPurchaseGrant;
+    refId: string;
+    processedAt: string;
+  }
+): Promise<PlayerAccountSnapshot> {
+  const normalizedGrant = normalizeShopPurchaseGrant(input.grant);
+
+  let nextHeroArchive: PlayerHeroArchiveSnapshot | null = null;
+  if (normalizedGrant.equipmentIds.length > 0) {
+    const [heroArchiveRows] = await connection.query<PlayerHeroArchiveRow[]>(
+      `SELECT player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, inventory_json, updated_at
+       FROM \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
+       WHERE player_id = ?
+       ORDER BY updated_at DESC, hero_id ASC
+       LIMIT 1
+       FOR UPDATE`,
+      [input.playerId]
+    );
+    const currentArchive = heroArchiveRows[0] ? toPlayerHeroArchiveSnapshot(heroArchiveRows[0]) : null;
+    if (!currentArchive) {
+      throw new Error("player hero archive not found");
+    }
+
+    let nextInventory = [...currentArchive.hero.loadout.inventory];
+    for (const equipmentId of normalizedGrant.equipmentIds) {
+      const inventoryUpdate = tryAddEquipmentToInventory(nextInventory, equipmentId);
+      if (!inventoryUpdate.stored) {
+        throw new Error("equipment inventory full");
+      }
+      nextInventory = inventoryUpdate.inventory;
+    }
+
+    nextHeroArchive = {
+      ...currentArchive,
+      hero: normalizeHeroState({
+        ...currentArchive.hero,
+        loadout: {
+          ...currentArchive.hero.loadout,
+          inventory: nextInventory
+        }
+      })
+    };
+  }
+
+  const nextRecentEventLog = appendEventLogEntries(currentAccount.recentEventLog, [
+    createShopPurchaseEventLogEntry(input.playerId, {
+      productId: input.productId,
+      productName: input.productName,
+      quantity: 1,
+      granted: normalizedGrant,
+      processedAt: input.processedAt
+    })
+  ]);
+  const nextGlobalResources = addResourceLedgers(currentAccount.globalResources, normalizedGrant.resources);
+  const nextGems = normalizeGemAmount(currentAccount.gems) + normalizedGrant.gems;
+  const nextSeasonPassPremium = currentAccount.seasonPassPremium === true || normalizedGrant.seasonPassPremium;
+  const nextCosmeticInventory = applyOwnedCosmetics(currentAccount.cosmeticInventory, normalizedGrant.cosmeticIds);
+
+  await connection.query(
+    `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+     SET gems = ?,
+         season_pass_premium = ?,
+         cosmetic_inventory_json = ?,
+         global_resources_json = ?,
+         recent_event_log_json = ?,
+         version = version + 1
+     WHERE player_id = ?`,
+    [
+      nextGems,
+      nextSeasonPassPremium ? 1 : 0,
+      JSON.stringify(nextCosmeticInventory),
+      JSON.stringify(nextGlobalResources),
+      JSON.stringify(nextRecentEventLog),
+      input.playerId
+    ]
+  );
+
+  if (normalizedGrant.gems > 0) {
+    await appendGemLedgerEntry(connection, {
+      entryId: randomUUID(),
+      playerId: input.playerId,
+      delta: normalizedGrant.gems,
+      reason: "purchase",
+      refId: input.refId
+    });
+  }
+
+  if (nextHeroArchive) {
+    await connection.query(
+      `INSERT INTO \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
+         (player_id, hero_id, hero_json, army_template_id, army_count, learned_skills_json, equipment_json, inventory_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         hero_json = VALUES(hero_json),
+         army_template_id = VALUES(army_template_id),
+         army_count = VALUES(army_count),
+         learned_skills_json = VALUES(learned_skills_json),
+         equipment_json = VALUES(equipment_json),
+         inventory_json = VALUES(inventory_json),
+         updated_at = CURRENT_TIMESTAMP`,
+      [
+        nextHeroArchive.playerId,
+        nextHeroArchive.heroId,
+        JSON.stringify(nextHeroArchive.hero),
+        nextHeroArchive.hero.armyTemplateId,
+        nextHeroArchive.hero.armyCount,
+        JSON.stringify(nextHeroArchive.hero.loadout.learnedSkills),
+        JSON.stringify(nextHeroArchive.hero.loadout.equipment),
+        JSON.stringify(nextHeroArchive.hero.loadout.inventory)
+      ]
+    );
+  }
+
+  await appendPlayerEventHistoryEntries(connection, input.playerId, nextRecentEventLog.slice(0, 1));
+
+  return normalizePlayerAccountSnapshot({
+    ...currentAccount,
+    gems: nextGems,
+    seasonPassPremium: nextSeasonPassPremium,
+    cosmeticInventory: nextCosmeticInventory,
+    globalResources: nextGlobalResources,
+    recentEventLog: nextRecentEventLog,
+    updatedAt: input.processedAt
+  });
 }
 
 function createBattlePassClaimEventLogEntry(playerId: string, input: {
@@ -1939,6 +2110,17 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PAYMENT_ORDER_TABLE}\` (
   PRIMARY KEY (order_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS \`${MYSQL_PAYMENT_RECEIPT_TABLE}\` (
+  transaction_id VARCHAR(191) NOT NULL,
+  order_id VARCHAR(191) NOT NULL,
+  player_id VARCHAR(191) NOT NULL,
+  product_id VARCHAR(191) NOT NULL,
+  amount INT NOT NULL,
+  verified_at DATETIME NOT NULL,
+  PRIMARY KEY (transaction_id),
+  UNIQUE KEY \`${MYSQL_PAYMENT_RECEIPT_ORDER_ID_INDEX}\` (order_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
   session_id VARCHAR(64) NOT NULL,
@@ -2887,6 +3069,24 @@ PREPARE veil_payment_orders_wechat_order_idx_stmt FROM @veil_payment_orders_wech
 EXECUTE veil_payment_orders_wechat_order_idx_stmt;
 DEALLOCATE PREPARE veil_payment_orders_wechat_order_idx_stmt;
 
+SET @veil_payment_receipts_player_verified_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_RECEIPT_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PAYMENT_RECEIPT_PLAYER_VERIFIED_INDEX}'
+);
+
+SET @veil_payment_receipts_player_verified_idx_sql := IF(
+  @veil_payment_receipts_player_verified_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_PAYMENT_RECEIPT_PLAYER_VERIFIED_INDEX}\` ON \`${MYSQL_PAYMENT_RECEIPT_TABLE}\` (player_id, verified_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_receipts_player_verified_idx_stmt FROM @veil_payment_receipts_player_verified_idx_sql;
+EXECUTE veil_payment_receipts_player_verified_idx_stmt;
+DEALLOCATE PREPARE veil_payment_receipts_player_verified_idx_stmt;
+
 SET @veil_player_ban_history_idx_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.STATISTICS
@@ -3788,6 +3988,44 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const row = rows[0];
     return row ? toPaymentOrderSnapshot(row) : null;
+  }
+
+  async loadPaymentReceiptByOrderId(orderId: string): Promise<PaymentReceiptSnapshot | null> {
+    const normalizedOrderId = normalizePaymentOrderId(orderId);
+    const [rows] = await this.pool.query<PaymentReceiptRow[]>(
+      `SELECT
+         transaction_id,
+         order_id,
+         player_id,
+         product_id,
+         amount,
+         verified_at
+       FROM \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+       WHERE order_id = ?
+       LIMIT 1`,
+      [normalizedOrderId]
+    );
+
+    const row = rows[0];
+    return row ? toPaymentReceiptSnapshot(row) : null;
+  }
+
+  async countVerifiedPaymentReceiptsSince(playerId: string, since: string): Promise<number> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const sinceDate = new Date(since);
+    if (Number.isNaN(sinceDate.getTime())) {
+      throw new Error("since must be a valid ISO timestamp");
+    }
+
+    const [rows] = await this.pool.query<Array<RowDataPacket & { total: number }>>(
+      `SELECT COUNT(*) AS total
+       FROM \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+       WHERE player_id = ?
+         AND verified_at >= ?`,
+      [normalizedPlayerId, sinceDate]
+    );
+
+    return Math.max(0, Math.floor(rows[0]?.total ?? 0));
   }
 
   async loadPlayerBan(playerId: string): Promise<PlayerAccountBanSnapshot | null> {
@@ -4840,7 +5078,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     const playerId = normalizePlayerId(input.playerId);
     const productId = normalizeShopProductId(input.productId);
     const amount = normalizePaymentAmount(input.amount);
-    const gemAmount = normalizePositiveGemDelta(input.gemAmount);
+    const gemAmount = normalizeGemAmount(input.gemAmount);
 
     await this.ensurePlayerAccount({ playerId });
 
@@ -4867,8 +5105,13 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     const normalizedOrderId = normalizePaymentOrderId(orderId);
     const normalizedWechatOrderId = normalizeWechatOrderId(input.wechatOrderId);
     const paidAt = input.paidAt ? new Date(input.paidAt) : new Date();
+    const verifiedAt = input.verifiedAt ? new Date(input.verifiedAt) : paidAt;
+    const normalizedProductName = normalizeShopProductName(input.productName);
     if (Number.isNaN(paidAt.getTime())) {
       throw new Error("paidAt must be a valid ISO timestamp");
+    }
+    if (Number.isNaN(verifiedAt.getTime())) {
+      throw new Error("verifiedAt must be a valid ISO timestamp");
     }
 
     const connection = await this.pool.getConnection();
@@ -4917,6 +5160,19 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
             });
 
       if (currentOrder.status === "paid") {
+        const [receiptRows] = await connection.query<PaymentReceiptRow[]>(
+          `SELECT
+             transaction_id,
+             order_id,
+             player_id,
+             product_id,
+             amount,
+             verified_at
+           FROM \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+           WHERE order_id = ?
+           LIMIT 1`,
+          [currentOrder.orderId]
+        );
         await connection.commit();
         return {
           order: {
@@ -4925,24 +5181,63 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
             ...(currentOrder.paidAt ? { paidAt: currentOrder.paidAt } : { paidAt: paidAt.toISOString() })
           },
           account: currentAccount,
-          credited: false
+          credited: false,
+          ...(receiptRows[0] ? { receipt: toPaymentReceiptSnapshot(receiptRows[0]) } : {})
         };
       }
 
-      const nextGems = normalizeGemAmount(currentAccount.gems) + currentOrder.gemAmount;
-      await connection.query(
-        `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
-         SET gems = ?,
-             version = version + 1
-         WHERE player_id = ?`,
-        [nextGems, currentOrder.playerId]
-      );
-      await appendGemLedgerEntry(connection, {
-        entryId: randomUUID(),
+      let receipt: PaymentReceiptSnapshot;
+      try {
+        await connection.query(
+          `INSERT INTO \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+             (transaction_id, order_id, player_id, product_id, amount, verified_at)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [normalizedWechatOrderId, currentOrder.orderId, currentOrder.playerId, currentOrder.productId, currentOrder.amount, verifiedAt]
+        );
+        receipt = {
+          transactionId: normalizedWechatOrderId,
+          orderId: currentOrder.orderId,
+          playerId: currentOrder.playerId,
+          productId: currentOrder.productId,
+          amount: currentOrder.amount,
+          verifiedAt: verifiedAt.toISOString()
+        };
+      } catch (error) {
+        if (!isMySqlDuplicateEntryError(error)) {
+          throw error;
+        }
+
+        const [receiptRows] = await connection.query<PaymentReceiptRow[]>(
+          `SELECT
+             transaction_id,
+             order_id,
+             player_id,
+             product_id,
+             amount,
+             verified_at
+           FROM \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+           WHERE order_id = ?
+              OR transaction_id = ?
+           LIMIT 1`,
+          [currentOrder.orderId, normalizedWechatOrderId]
+        );
+        const existingReceipt = receiptRows[0];
+        await connection.commit();
+        return {
+          order: currentOrder,
+          account: currentAccount,
+          credited: false,
+          ...(existingReceipt ? { receipt: toPaymentReceiptSnapshot(existingReceipt) } : {})
+        };
+      }
+
+      const nextAccount = await applyVerifiedPaymentGrantToAccount(connection, currentAccount, {
         playerId: currentOrder.playerId,
-        delta: currentOrder.gemAmount,
-        reason: "purchase",
-        refId: currentOrder.orderId
+        productId: currentOrder.productId,
+        productName: normalizedProductName,
+        grant: input.grant,
+        refId: currentOrder.orderId,
+        processedAt: paidAt.toISOString()
       });
       await connection.query(
         `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
@@ -4955,12 +5250,6 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
       await connection.commit();
 
-      const nextAccount =
-        (await this.loadPlayerAccount(currentOrder.playerId)) ??
-        normalizePlayerAccountSnapshot({
-          ...currentAccount,
-          gems: nextGems
-        });
       const nextOrder =
         (await this.loadPaymentOrder(currentOrder.orderId)) ??
         ({
@@ -4974,7 +5263,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       return {
         order: nextOrder,
         account: nextAccount,
-        credited: true
+        credited: true,
+        receipt
       };
     } catch (error) {
       await connection.rollback();

--- a/apps/server/src/wechat-pay.ts
+++ b/apps/server/src/wechat-pay.ts
@@ -1,8 +1,9 @@
 import { createCipheriv, createDecipheriv, createSign, createVerify, randomBytes, randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { emitAnalyticsEvent } from "./analytics";
 import { validateAuthSessionFromRequest } from "./auth";
 import type { PaymentOrderSnapshot, RoomSnapshotStore } from "./persistence";
-import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct } from "./shop";
+import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct, type ShopProductGrant } from "./shop";
 
 interface HttpApp {
   use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
@@ -19,6 +20,7 @@ interface WechatPayRuntimeConfig {
   apiV3Key: string;
   notifyUrl: string;
   transactionsJsapiUrl: string;
+  transactionsOutTradeNoUrlTemplate: string;
 }
 
 interface RegisterWechatPayRoutesOptions extends RegisterShopRoutesOptions {
@@ -30,6 +32,22 @@ interface RegisterWechatPayRoutesOptions extends RegisterShopRoutesOptions {
 
 interface WechatPayTransactionsJsapiResponse {
   prepay_id?: string;
+}
+
+interface WechatPayTransactionQueryResponse {
+  appid?: string;
+  mchid?: string;
+  out_trade_no?: string;
+  transaction_id?: string;
+  trade_state?: string;
+  success_time?: string;
+  amount?: {
+    total?: number;
+    payer_total?: number;
+  } | null;
+  payer?: {
+    openid?: string;
+  } | null;
 }
 
 interface WechatPayCallbackEnvelope {
@@ -118,7 +136,10 @@ function readWechatPayRuntimeConfig(env: NodeJS.ProcessEnv = process.env): Wecha
     platformPublicKey,
     apiV3Key,
     notifyUrl,
-    transactionsJsapiUrl: env.VEIL_WECHAT_PAY_TRANSACTIONS_JSAPI_URL?.trim() || "https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi"
+    transactionsJsapiUrl: env.VEIL_WECHAT_PAY_TRANSACTIONS_JSAPI_URL?.trim() || "https://api.mch.weixin.qq.com/v3/pay/transactions/jsapi",
+    transactionsOutTradeNoUrlTemplate:
+      env.VEIL_WECHAT_PAY_TRANSACTIONS_OUT_TRADE_NO_URL_TEMPLATE?.trim() ||
+      "https://api.mch.weixin.qq.com/v3/pay/transactions/out-trade-no/{out_trade_no}?mchid={mchid}"
   };
 }
 
@@ -164,21 +185,23 @@ function normalizeProductId(productId?: string | null): string {
   return normalized;
 }
 
-function normalizeWechatPayProduct(product: ShopProduct | undefined): ShopProduct & { wechatPriceFen: number; grant: { gems: number } } {
+function normalizeWechatPayProduct(
+  product: ShopProduct | undefined
+): ShopProduct & { wechatPriceFen: number; grant: ShopProductGrant } {
   if (!product) {
     throw new Error("product_not_found");
   }
-  if (product.type !== "gem_pack") {
-    throw new Error("wechat_pay_requires_gem_pack");
+  if (product.type !== "gem_pack" && product.type !== "season_pass_premium") {
+    throw new Error("wechat_pay_requires_supported_product");
   }
   if (!product.wechatPriceFen || product.wechatPriceFen <= 0) {
     throw new Error("wechat_pay_price_not_configured");
   }
-  if (!product.grant.gems || product.grant.gems <= 0) {
-    throw new Error("wechat_pay_gem_grant_not_configured");
+  if ((product.grant.gems ?? 0) <= 0 && product.grant.seasonPassPremium !== true) {
+    throw new Error("wechat_pay_grant_not_configured");
   }
 
-  return product as ShopProduct & { wechatPriceFen: number; grant: { gems: number } };
+  return product as ShopProduct & { wechatPriceFen: number; grant: ShopProductGrant };
 }
 
 function randomNonce(): string {
@@ -207,6 +230,42 @@ function buildWechatAuthorization(
 
 function buildClientPaySign(config: WechatPayRuntimeConfig, timeStamp: string, nonceStr: string, packageValue: string): string {
   return signWithMerchantKey(config, `${config.appId}\n${timeStamp}\n${nonceStr}\n${packageValue}\n`);
+}
+
+function buildWechatTransactionQueryUrl(config: WechatPayRuntimeConfig, orderId: string): URL {
+  const template = config.transactionsOutTradeNoUrlTemplate
+    .replace("{out_trade_no}", encodeURIComponent(orderId))
+    .replace("{mchid}", encodeURIComponent(config.merchantId));
+  return new URL(template);
+}
+
+function resolveVerifiedPaidAmount(
+  amount: WechatPayCallbackTransaction["amount"] | WechatPayTransactionQueryResponse["amount"]
+): number {
+  const payerTotal = amount && "payer_total" in amount ? amount.payer_total : undefined;
+  return Math.max(0, Math.floor(payerTotal ?? amount?.total ?? 0));
+}
+
+function emitPaymentFraudSignal(
+  playerId: string,
+  signal: string,
+  payload: {
+    orderId: string;
+    productId: string;
+    [key: string]: unknown;
+  }
+): void {
+  try {
+    emitAnalyticsEvent("payment_fraud_signal", {
+      playerId,
+      payload: {
+        signal,
+        ...payload
+      }
+    });
+  } catch {
+    // Fraud logging must not break legitimate payment handling.
+  }
 }
 
 function verifyWechatCallbackSignature(
@@ -298,8 +357,19 @@ function sendCallbackResponse(response: ServerResponse, statusCode: number, payl
 }
 
 function isPaymentStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
-  Required<Pick<RoomSnapshotStore, "createPaymentOrder" | "completePaymentOrder" | "loadPaymentOrder">> {
-  return Boolean(store?.createPaymentOrder && store.completePaymentOrder && store.loadPaymentOrder);
+  Required<
+    Pick<
+      RoomSnapshotStore,
+      "createPaymentOrder" | "completePaymentOrder" | "loadPaymentOrder" | "loadPaymentReceiptByOrderId" | "countVerifiedPaymentReceiptsSince"
+    >
+  > {
+  return Boolean(
+    store?.createPaymentOrder &&
+      store.completePaymentOrder &&
+      store.loadPaymentOrder &&
+      store.loadPaymentReceiptByOrderId &&
+      store.countVerifiedPaymentReceiptsSince
+  );
 }
 
 function findProduct(products: ShopProduct[], productId: string): ShopProduct | undefined {
@@ -326,6 +396,73 @@ function normalizeSuccessTimestamp(value?: string): string {
     throw new Error("invalid_wechat_payment_success_time");
   }
   return parsed.toISOString();
+}
+
+async function queryWechatPaymentByOutTradeNo(
+  config: WechatPayRuntimeConfig,
+  fetchImpl: typeof fetch,
+  now: () => Date,
+  orderId: string
+): Promise<WechatPayTransactionQueryResponse> {
+  const requestUrl = buildWechatTransactionQueryUrl(config, orderId);
+  const timestamp = String(Math.floor(now().getTime() / 1000));
+  const nonce = randomNonce();
+  const response = await fetchImpl(requestUrl, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      Authorization: buildWechatAuthorization(config, "GET", requestUrl, "", timestamp, nonce)
+    }
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(errorText || "wechat_order_query_failed");
+  }
+
+  return (await response.json()) as WechatPayTransactionQueryResponse;
+}
+
+async function verifyPaymentReceipt(input: {
+  config: WechatPayRuntimeConfig;
+  fetchImpl: typeof fetch;
+  now: () => Date;
+  order: PaymentOrderSnapshot;
+}): Promise<Required<Pick<WechatPayTransactionQueryResponse, "transaction_id" | "success_time">> &
+  WechatPayTransactionQueryResponse & { paidAmount: number; payerOpenId: string }> {
+  const transaction = await queryWechatPaymentByOutTradeNo(input.config, input.fetchImpl, input.now, input.order.orderId);
+  if (transaction.trade_state !== "SUCCESS") {
+    throw new Error("wechat_payment_not_success");
+  }
+  if (
+    transaction.appid?.trim() !== input.config.appId ||
+    transaction.mchid?.trim() !== input.config.merchantId ||
+    transaction.out_trade_no?.trim() !== input.order.orderId
+  ) {
+    throw new Error("wechat_payment_identity_mismatch");
+  }
+
+  const transactionId = transaction.transaction_id?.trim();
+  if (!transactionId) {
+    throw new Error("wechat_payment_transaction_id_missing");
+  }
+
+  const payerOpenId = transaction.payer?.openid?.trim() || "";
+  const paidAmount = resolveVerifiedPaidAmount(transaction.amount);
+  if (paidAmount !== input.order.amount) {
+    throw new Error("wechat_payment_amount_mismatch");
+  }
+  if (!payerOpenId) {
+    throw new Error("wechat_payment_openid_missing");
+  }
+
+  return {
+    ...transaction,
+    transaction_id: transactionId,
+    success_time: normalizeSuccessTimestamp(transaction.success_time),
+    paidAmount,
+    payerOpenId
+  };
 }
 
 export function registerWechatPayRoutes(
@@ -398,7 +535,7 @@ export function registerWechatPayRoutes(
         playerId: authSession.playerId,
         productId: product.productId,
         amount: product.wechatPriceFen,
-        gemAmount: product.grant.gems
+        gemAmount: product.grant.gems ?? 0
       });
 
       const createdAt = now();
@@ -473,6 +610,186 @@ export function registerWechatPayRoutes(
     }
   });
 
+  app.post("/api/payments/wechat/verify", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+    if (!runtimeConfig) {
+      sendJson(response, 503, {
+        error: {
+          code: "wechat_pay_not_configured",
+          message: "WeChat Pay runtime configuration is incomplete"
+        }
+      });
+      return;
+    }
+    if (!isPaymentStoreReady(store)) {
+      sendJson(response, 503, {
+        error: {
+          code: "payment_persistence_unavailable",
+          message: "Payment verification requires configured persistence storage"
+        }
+      });
+      return;
+    }
+
+    let order: PaymentOrderSnapshot | null = null;
+    try {
+      const body = (await readJsonBody(request)) as { orderId?: string | null };
+      const orderId = body.orderId?.trim();
+      if (!orderId) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_order_id",
+            message: "orderId is required"
+          }
+        });
+        return;
+      }
+
+      order = await store.loadPaymentOrder(orderId);
+      if (!order || order.playerId !== authSession.playerId) {
+        sendJson(response, 404, {
+          error: {
+            code: "payment_order_not_found",
+            message: "Payment order was not found"
+          }
+        });
+        return;
+      }
+
+      const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+      if (order.status === "paid" || existingReceipt) {
+        emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
+          orderId: order.orderId,
+          productId: order.productId
+        });
+        sendJson(response, 409, {
+          error: {
+            code: "payment_already_verified",
+            message: "Payment order has already been verified"
+          }
+        });
+        return;
+      }
+
+      const product = normalizeWechatPayProduct(findProduct(products, order.productId));
+      const account = await store.loadPlayerAccount(order.playerId);
+      const expectedOpenId = account?.wechatMiniGameOpenId?.trim();
+      if (!expectedOpenId) {
+        sendJson(response, 400, {
+          error: {
+            code: "wechat_open_id_required",
+            message: "Player must bind a WeChat mini-game identity before verifying a payment order"
+          }
+        });
+        return;
+      }
+
+      const verified = await verifyPaymentReceipt({
+        config: runtimeConfig,
+        fetchImpl,
+        now,
+        order
+      });
+      if (verified.payerOpenId !== expectedOpenId) {
+        emitPaymentFraudSignal(order.playerId, "openid_mismatch", {
+          orderId: order.orderId,
+          productId: order.productId,
+          expectedOpenId,
+          receivedOpenId: verified.payerOpenId,
+          transactionId: verified.transaction_id
+        });
+        sendJson(response, 409, {
+          error: {
+            code: "wechat_payment_openid_mismatch",
+            message: "wechat_payment_openid_mismatch"
+          }
+        });
+        return;
+      }
+
+      const settlement = await store.completePaymentOrder(order.orderId, {
+        wechatOrderId: verified.transaction_id,
+        paidAt: verified.success_time,
+        verifiedAt: now().toISOString(),
+        productName: product.name,
+        grant: product.grant
+      });
+      if (!settlement.credited) {
+        emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
+          orderId: order.orderId,
+          productId: order.productId,
+          transactionId: verified.transaction_id
+        });
+        sendJson(response, 409, {
+          error: {
+            code: "payment_already_verified",
+            message: "Payment order has already been verified"
+          }
+        });
+        return;
+      }
+
+      emitAnalyticsEvent("purchase", {
+        playerId: order.playerId,
+        payload: {
+          purchaseId: order.orderId,
+          productId: order.productId,
+          quantity: 1,
+          totalPrice: order.amount
+        }
+      });
+
+      const recentVerifiedCount = await store.countVerifiedPaymentReceiptsSince(
+        order.playerId,
+        new Date(now().getTime() - 60_000).toISOString()
+      );
+      if (recentVerifiedCount > 3) {
+        emitPaymentFraudSignal(order.playerId, "high_velocity_purchases", {
+          orderId: order.orderId,
+          productId: order.productId,
+          recentVerifiedCount
+        });
+      }
+
+      sendJson(response, 200, {
+        orderId: settlement.order.orderId,
+        status: settlement.order.status,
+        credited: settlement.credited,
+        paidAt: settlement.order.paidAt,
+        gemsBalance: settlement.account.gems ?? 0,
+        seasonPassPremium: settlement.account.seasonPassPremium === true
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const statusCode =
+        message === "wechat_payment_not_success"
+          ? 409
+          : message === "wechat_payment_amount_mismatch"
+            ? 400
+            : message === "wechat_payment_identity_mismatch" ||
+                message === "wechat_payment_openid_missing" ||
+                message === "wechat_payment_openid_mismatch"
+              ? 400
+              : 502;
+      if (message === "wechat_payment_amount_mismatch" && order) {
+        emitPaymentFraudSignal(order.playerId, "amount_mismatch", {
+          orderId: order.orderId,
+          productId: order.productId,
+          expectedAmount: order.amount
+        });
+      }
+      sendJson(response, statusCode, {
+        error: {
+          code: message,
+          message
+        }
+      });
+    }
+  });
+
   app.post("/api/payments/wechat/callback", async (request, response) => {
     if (!runtimeConfig) {
       sendCallbackResponse(response, 503, {
@@ -519,8 +836,7 @@ export function registerWechatPayRoutes(
       }
 
       const orderId = transaction.out_trade_no?.trim();
-      const wechatOrderId = transaction.transaction_id?.trim();
-      if (!orderId || !wechatOrderId) {
+      if (!orderId) {
         sendCallbackResponse(response, 400, {
           code: "FAIL",
           message: "order identifiers are missing"
@@ -537,16 +853,9 @@ export function registerWechatPayRoutes(
         return;
       }
 
-      if ((transaction.amount?.total ?? 0) !== order.amount) {
-        sendCallbackResponse(response, 400, {
-          code: "FAIL",
-          message: "payment amount mismatch"
-        });
-        return;
-      }
-
       const account = await store.loadPlayerAccount(order.playerId);
-      if (!account?.wechatMiniGameOpenId || transaction.payer?.openid?.trim() !== account.wechatMiniGameOpenId) {
+      const expectedOpenId = account?.wechatMiniGameOpenId?.trim();
+      if (!expectedOpenId) {
         sendCallbackResponse(response, 400, {
           code: "FAIL",
           message: "payer validation failed"
@@ -554,10 +863,62 @@ export function registerWechatPayRoutes(
         return;
       }
 
-      await store.completePaymentOrder(order.orderId, {
-        wechatOrderId,
-        paidAt: normalizeSuccessTimestamp(transaction.success_time)
+      const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+      if (order.status === "paid" || existingReceipt) {
+        emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
+          orderId: order.orderId,
+          productId: order.productId
+        });
+        sendCallbackResponse(response, 200);
+        return;
+      }
+
+      const product = normalizeWechatPayProduct(findProduct(products, order.productId));
+      const verified = await verifyPaymentReceipt({
+        config: runtimeConfig,
+        fetchImpl,
+        now,
+        order
       });
+      if (verified.payerOpenId !== expectedOpenId || transaction.payer?.openid?.trim() !== expectedOpenId) {
+        emitPaymentFraudSignal(order.playerId, "openid_mismatch", {
+          orderId: order.orderId,
+          productId: order.productId,
+          expectedOpenId,
+          callbackOpenId: transaction.payer?.openid?.trim() || "",
+          verifiedOpenId: verified.payerOpenId
+        });
+        sendCallbackResponse(response, 200);
+        return;
+      }
+
+      if (resolveVerifiedPaidAmount(transaction.amount) !== order.amount) {
+        emitPaymentFraudSignal(order.playerId, "amount_mismatch", {
+          orderId: order.orderId,
+          productId: order.productId,
+          expectedAmount: order.amount,
+          receivedAmount: resolveVerifiedPaidAmount(transaction.amount)
+        });
+      }
+
+      const settlement = await store.completePaymentOrder(order.orderId, {
+        wechatOrderId: verified.transaction_id,
+        paidAt: verified.success_time,
+        verifiedAt: now().toISOString(),
+        productName: product.name,
+        grant: product.grant
+      });
+      if (settlement.credited) {
+        emitAnalyticsEvent("purchase", {
+          playerId: order.playerId,
+          payload: {
+            purchaseId: order.orderId,
+            productId: order.productId,
+            quantity: 1,
+            totalPrice: order.amount
+          }
+        });
+      }
       sendCallbackResponse(response, 200);
     } catch (error) {
       sendCallbackResponse(response, 400, {

--- a/apps/server/test/wechat-pay-routes.test.ts
+++ b/apps/server/test/wechat-pay-routes.test.ts
@@ -115,18 +115,80 @@ function createWechatPayConfig(): WechatPayRuntimeConfig & { platformPrivateKey:
     platformPrivateKey: platformKeys.privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
     apiV3Key: "0123456789abcdef0123456789abcdef",
     notifyUrl: "https://veil.example.test/api/payments/wechat/callback",
-    transactionsJsapiUrl: "https://wechat.example.test/v3/pay/transactions/jsapi"
+    transactionsJsapiUrl: "https://wechat.example.test/v3/pay/transactions/jsapi",
+    transactionsOutTradeNoUrlTemplate: "https://wechat.example.test/v3/pay/transactions/out-trade-no/{out_trade_no}?mchid={mchid}"
   };
 }
 
-test("wechat pay create route creates a pending order and returns JSAPI payment parameters", async () => {
-  const app = new TestApp();
+function issueWechatSession() {
+  return issueAccountAuthSession({
+    playerId: "wechat-player",
+    displayName: "暮潮守望",
+    loginId: "wechat-player",
+    provider: "wechat-mini-game"
+  });
+}
+
+async function createVerifiedTestStore(): Promise<MemoryRoomSnapshotStore> {
   const store = new MemoryRoomSnapshotStore();
-  const runtimeConfig = createWechatPayConfig();
   await store.bindPlayerAccountWechatMiniGameIdentity("wechat-player", {
     openId: "wx-openid-player",
     displayName: "暮潮守望"
   });
+  return store;
+}
+
+function buildVerifyFetch(
+  transaction: Partial<{
+    appid: string;
+    mchid: string;
+    out_trade_no: string;
+    transaction_id: string;
+    trade_state: string;
+    success_time: string;
+    payer_total: number;
+    openid: string;
+  }>
+): typeof fetch {
+  return (async (_input, init) => {
+    if (String(init?.method ?? "GET").toUpperCase() === "POST") {
+      return new Response(JSON.stringify({ prepay_id: "wx-prepay-123" }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        appid: transaction.appid ?? "wx-test-app",
+        mchid: transaction.mchid ?? "1900000109",
+        out_trade_no: transaction.out_trade_no ?? "wechat-order-1",
+        transaction_id: transaction.transaction_id ?? "wechat-transaction-123",
+        trade_state: transaction.trade_state ?? "SUCCESS",
+        success_time: transaction.success_time ?? "2026-04-04T01:02:03Z",
+        amount: {
+          payer_total: transaction.payer_total ?? 600
+        },
+        payer: {
+          openid: transaction.openid ?? "wx-openid-player"
+        }
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+  }) as typeof fetch;
+}
+
+test("wechat pay create route creates a pending order and returns JSAPI payment parameters", async () => {
+  const app = new TestApp();
+  const store = await createVerifiedTestStore();
+  const runtimeConfig = createWechatPayConfig();
 
   let capturedBody = "";
   let capturedAuthorization = "";
@@ -144,12 +206,7 @@ test("wechat pay create route creates a pending order and returns JSAPI payment 
       });
     }
   });
-  const session = issueAccountAuthSession({
-    playerId: "wechat-player",
-    displayName: "暮潮守望",
-    loginId: "wechat-player",
-    provider: "wechat-mini-game"
-  });
+  const session = issueWechatSession();
 
   const response = await app.invoke("/api/payments/wechat/create", {
     headers: {
@@ -204,14 +261,10 @@ test("wechat pay create route creates a pending order and returns JSAPI payment 
   });
 });
 
-test("wechat pay callback verifies, decrypts, and credits gems only once for duplicate notifications", async () => {
+test("wechat pay verify route grants a successful verified payment and stores the receipt", async () => {
   const app = new TestApp();
-  const store = new MemoryRoomSnapshotStore();
+  const store = await createVerifiedTestStore();
   const runtimeConfig = createWechatPayConfig();
-  await store.bindPlayerAccountWechatMiniGameIdentity("wechat-player", {
-    openId: "wx-openid-player",
-    displayName: "暮潮守望"
-  });
   const order = await store.createPaymentOrder({
     orderId: "wechat-order-1",
     playerId: "wechat-player",
@@ -221,7 +274,216 @@ test("wechat pay callback verifies, decrypts, and credits gems only once for dup
   });
   registerWechatPayRoutes(app as never, store, {
     products: TEST_PRODUCTS,
-    runtimeConfig
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({
+      out_trade_no: order.orderId
+    })
+  });
+  const session = issueWechatSession();
+
+  const response = await app.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: order.orderId
+    })
+  });
+  const account = await store.loadPlayerAccount("wechat-player");
+  const paidOrder = await store.loadPaymentOrder(order.orderId);
+  const receipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(account?.gems, 120);
+  assert.equal(paidOrder?.status, "paid");
+  assert.equal(paidOrder?.wechatOrderId, "wechat-transaction-123");
+  assert.equal(paidOrder?.paidAt, "2026-04-04T01:02:03.000Z");
+  assert.equal(receipt?.transactionId, "wechat-transaction-123");
+});
+
+test("wechat pay verify route rejects failed verification without granting rewards", async () => {
+  const app = new TestApp();
+  const store = await createVerifiedTestStore();
+  const runtimeConfig = createWechatPayConfig();
+  const order = await store.createPaymentOrder({
+    orderId: "wechat-order-1",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({
+      out_trade_no: order.orderId,
+      trade_state: "USERPAYING"
+    })
+  });
+  const session = issueWechatSession();
+
+  const response = await app.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: order.orderId
+    })
+  });
+  const payload = response.json as { error: { code: string } };
+  const account = await store.loadPlayerAccount("wechat-player");
+
+  assert.equal(response.statusCode, 409);
+  assert.equal(payload.error.code, "wechat_payment_not_success");
+  assert.equal(account?.gems ?? 0, 0);
+});
+
+test("wechat pay verify route rejects duplicate submissions with 409 and does not double-credit", async () => {
+  const app = new TestApp();
+  const store = await createVerifiedTestStore();
+  const runtimeConfig = createWechatPayConfig();
+  const order = await store.createPaymentOrder({
+    orderId: "wechat-order-1",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({
+      out_trade_no: order.orderId
+    })
+  });
+  const session = issueWechatSession();
+
+  const firstResponse = await app.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: order.orderId
+    })
+  });
+  const secondResponse = await app.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: order.orderId
+    })
+  });
+  const duplicatePayload = secondResponse.json as { error: { code: string } };
+  const account = await store.loadPlayerAccount("wechat-player");
+
+  assert.equal(firstResponse.statusCode, 200);
+  assert.equal(secondResponse.statusCode, 409);
+  assert.equal(duplicatePayload.error.code, "payment_already_verified");
+  assert.equal(account?.gems, 120);
+});
+
+test("wechat pay verify route rejects amount mismatches", async () => {
+  const app = new TestApp();
+  const store = await createVerifiedTestStore();
+  const runtimeConfig = createWechatPayConfig();
+  const order = await store.createPaymentOrder({
+    orderId: "wechat-order-1",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({
+      out_trade_no: order.orderId,
+      payer_total: 599
+    })
+  });
+  const session = issueWechatSession();
+
+  const response = await app.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: order.orderId
+    })
+  });
+  const payload = response.json as { error: { code: string } };
+  const account = await store.loadPlayerAccount("wechat-player");
+
+  assert.equal(response.statusCode, 400);
+  assert.equal(payload.error.code, "wechat_payment_amount_mismatch");
+  assert.equal(account?.gems ?? 0, 0);
+});
+
+test("wechat pay verify route rejects payer openid mismatches without granting rewards", async () => {
+  const app = new TestApp();
+  const store = await createVerifiedTestStore();
+  const runtimeConfig = createWechatPayConfig();
+  const order = await store.createPaymentOrder({
+    orderId: "wechat-order-1",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({
+      out_trade_no: order.orderId,
+      openid: "wx-openid-other-player"
+    })
+  });
+  const session = issueWechatSession();
+
+  const response = await app.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: order.orderId
+    })
+  });
+  const payload = response.json as { error: { code: string } };
+  const account = await store.loadPlayerAccount("wechat-player");
+  const paidOrder = await store.loadPaymentOrder(order.orderId);
+  const receipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+
+  assert.equal(response.statusCode, 409);
+  assert.equal(payload.error.code, "wechat_payment_openid_mismatch");
+  assert.equal(account?.gems ?? 0, 0);
+  assert.equal(paidOrder?.status, "pending");
+  assert.equal(receipt, null);
+});
+
+test("wechat pay callback verifies, credits once, and ignores duplicate notifications", async () => {
+  const app = new TestApp();
+  const store = await createVerifiedTestStore();
+  const runtimeConfig = createWechatPayConfig();
+  const order = await store.createPaymentOrder({
+    orderId: "wechat-order-1",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({
+      out_trade_no: order.orderId
+    })
   });
 
   const transaction = {
@@ -253,29 +515,99 @@ test("wechat pay callback verifies, decrypts, and credits gems only once for dup
   const nonce = "signature-nonce-1";
   const signature = signWechatCallbackForTest(runtimeConfig.platformPrivateKey, timestamp, nonce, body);
 
-  const sendCallback = async (wechatpaySignature: string) =>
+  const sendCallback = async () =>
     app.invoke("/api/payments/wechat/callback", {
       headers: {
         "content-type": "application/json",
         "wechatpay-timestamp": timestamp,
         "wechatpay-nonce": nonce,
         "wechatpay-serial": runtimeConfig.platformCertificateSerial,
-        "wechatpay-signature": wechatpaySignature
+        "wechatpay-signature": signature
       },
       body
     });
 
-  const firstResponse = await sendCallback(signature);
-  const secondResponse = await sendCallback(signature);
+  const firstResponse = await sendCallback();
+  const secondResponse = await sendCallback();
   const account = await store.loadPlayerAccount("wechat-player");
   const paidOrder = await store.loadPaymentOrder(order.orderId);
+  const receipt = await store.loadPaymentReceiptByOrderId(order.orderId);
 
   assert.equal(firstResponse.statusCode, 200);
   assert.equal(secondResponse.statusCode, 200);
   assert.equal(account?.gems, 120);
   assert.equal(paidOrder?.status, "paid");
   assert.equal(paidOrder?.wechatOrderId, "wechat-transaction-123");
-  assert.equal(paidOrder?.paidAt, "2026-04-04T01:02:03.000Z");
+  assert.equal(receipt?.transactionId, "wechat-transaction-123");
+});
+
+test("wechat pay callback logs payer mismatches and does not grant rewards", async () => {
+  const app = new TestApp();
+  const store = await createVerifiedTestStore();
+  const runtimeConfig = createWechatPayConfig();
+  const order = await store.createPaymentOrder({
+    orderId: "wechat-order-1",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({
+      out_trade_no: order.orderId,
+      openid: "wx-openid-other-player"
+    })
+  });
+
+  const transaction = {
+    appid: runtimeConfig.appId,
+    mchid: runtimeConfig.merchantId,
+    out_trade_no: order.orderId,
+    transaction_id: "wechat-transaction-123",
+    trade_state: "SUCCESS",
+    success_time: "2026-04-04T01:02:03Z",
+    amount: {
+      total: 600
+    },
+    payer: {
+      openid: "wx-openid-other-player"
+    }
+  };
+  const resource = encryptWechatCallbackResourceForTest(
+    runtimeConfig.apiV3Key,
+    JSON.stringify(transaction),
+    "callback-nonce2"
+  );
+  const body = JSON.stringify({
+    id: "evt-2",
+    event_type: "TRANSACTION.SUCCESS",
+    resource_type: "encrypt-resource",
+    resource
+  });
+  const timestamp = "1712197201";
+  const nonce = "signature-nonce-2";
+  const signature = signWechatCallbackForTest(runtimeConfig.platformPrivateKey, timestamp, nonce, body);
+
+  const response = await app.invoke("/api/payments/wechat/callback", {
+    headers: {
+      "content-type": "application/json",
+      "wechatpay-timestamp": timestamp,
+      "wechatpay-nonce": nonce,
+      "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+      "wechatpay-signature": signature
+    },
+    body
+  });
+  const account = await store.loadPlayerAccount("wechat-player");
+  const paidOrder = await store.loadPaymentOrder(order.orderId);
+  const receipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(account?.gems ?? 0, 0);
+  assert.equal(paidOrder?.status, "pending");
+  assert.equal(receipt, null);
 });
 
 test("wechat pay callback rejects invalid signatures", async () => {

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -65,6 +65,11 @@ export const ANALYTICS_EVENT_CATALOG = {
     quantity: 1,
     totalPrice: 100
   }),
+  payment_fraud_signal: defineAnalyticsEvent("payment_fraud_signal", 1, "Potential payment fraud or integrity anomaly detected.", {
+    signal: "duplicate_out_trade_no",
+    orderId: "wechat-order-1",
+    productId: "gem_pack_small"
+  }),
   tutorial_step: defineAnalyticsEvent("tutorial_step", 1, "Tutorial milestone advanced by the player.", {
     stepId: "movement_intro",
     status: "completed"

--- a/scripts/migrations/0019_add_payment_receipts_table.ts
+++ b/scripts/migrations/0019_add_payment_receipts_table.ts
@@ -1,0 +1,46 @@
+import {
+  dropIndexIfExists,
+  dropTableIfExists,
+  ensureIndexExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_PAYMENT_RECEIPT_ORDER_ID_INDEX,
+  MYSQL_PAYMENT_RECEIPT_PLAYER_VERIFIED_INDEX,
+  MYSQL_PAYMENT_RECEIPT_TABLE
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureTableExists(
+    connection,
+    MYSQL_PAYMENT_RECEIPT_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_PAYMENT_RECEIPT_TABLE}\` (
+      transaction_id VARCHAR(191) NOT NULL,
+      order_id VARCHAR(191) NOT NULL,
+      player_id VARCHAR(191) NOT NULL,
+      product_id VARCHAR(191) NOT NULL,
+      amount INT NOT NULL,
+      verified_at DATETIME NOT NULL,
+      PRIMARY KEY (transaction_id),
+      UNIQUE KEY \`${MYSQL_PAYMENT_RECEIPT_ORDER_ID_INDEX}\` (order_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_PAYMENT_RECEIPT_TABLE,
+    MYSQL_PAYMENT_RECEIPT_PLAYER_VERIFIED_INDEX,
+    `CREATE INDEX \`${MYSQL_PAYMENT_RECEIPT_PLAYER_VERIFIED_INDEX}\` ON \`${MYSQL_PAYMENT_RECEIPT_TABLE}\` (player_id, verified_at DESC)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await dropIndexIfExists(connection, database, MYSQL_PAYMENT_RECEIPT_TABLE, MYSQL_PAYMENT_RECEIPT_PLAYER_VERIFIED_INDEX);
+  await dropTableIfExists(connection, MYSQL_PAYMENT_RECEIPT_TABLE);
+}


### PR DESCRIPTION
## Summary
- add server-side WeChat Pay receipt verification backed by persisted payment receipts
- block settlement on payer identity mismatches and emit fraud detection analytics signals
- wire the Cocos WeChat purchase flow to call the verification endpoint and cover the new paths with tests

Closes #903