### PR TITLE
[codex] add campaign chapters 2-4 and progression gating

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -7,8 +7,10 @@ import {
   canSkipTutorial,
   DEFAULT_TUTORIAL_STEP,
   findPlayerBattleReplaySummary,
+  getRankDivisionForRating,
   getAchievementDefinitions,
   isTutorialComplete,
+  normalizeCosmeticInventory,
   normalizeAchievementProgressQuery,
   normalizeEventLogQuery,
   queryPlayerBattleReplaySummaries,
@@ -52,6 +54,7 @@ import {
 import { resolveFeatureEntitlementsForPlayer, resolveFeatureFlagsForPlayer } from "./feature-flags";
 import {
   buildCampaignMissionStates,
+  type CampaignAccessContext,
   buildDailyDungeonSummary,
   claimDailyDungeonRunReward,
   completeCampaignMission,
@@ -512,8 +515,8 @@ function toSeasonProgressResponse(account: PlayerAccountSnapshot, battlePassEnab
   };
 }
 
-function toCampaignResponse(account: PlayerAccountSnapshot) {
-  const missionStates = buildCampaignMissionStates(resolveCampaignConfig(), account.campaignProgress);
+function toCampaignResponse(account: PlayerAccountSnapshot, accessContext?: CampaignAccessContext | null) {
+  const missionStates = buildCampaignMissionStates(resolveCampaignConfig(), account.campaignProgress, accessContext);
   const completedCount = missionStates.filter((mission) => mission.status === "completed").length;
 
   return {
@@ -537,19 +540,37 @@ function toDailyDungeonResponse(account: PlayerAccountSnapshot, now = new Date()
   return buildDailyDungeonSummary(resolvePrimaryDailyDungeon(), account.dailyDungeonState, now);
 }
 
-function toRewardMutation(account: PlayerAccountSnapshot, reward?: { gems?: number; resources?: Partial<PlayerAccountSnapshot["globalResources"]> }) {
+function toRewardMutation(
+  account: PlayerAccountSnapshot,
+  reward?: { gems?: number; resources?: Partial<PlayerAccountSnapshot["globalResources"]>; cosmeticId?: string }
+) {
   const gems = Math.max(0, Math.floor(reward?.gems ?? 0));
   const gold = Math.max(0, Math.floor(reward?.resources?.gold ?? 0));
   const wood = Math.max(0, Math.floor(reward?.resources?.wood ?? 0));
   const ore = Math.max(0, Math.floor(reward?.resources?.ore ?? 0));
+  const cosmeticId = reward?.cosmeticId?.trim();
 
   return {
     gems: (account.gems ?? 0) + gems,
+    cosmeticInventory: normalizeCosmeticInventory({
+      ownedIds: [...(account.cosmeticInventory?.ownedIds ?? []), ...(cosmeticId ? [cosmeticId] : [])]
+    }),
     globalResources: {
       gold: (account.globalResources.gold ?? 0) + gold,
       wood: (account.globalResources.wood ?? 0) + wood,
       ore: (account.globalResources.ore ?? 0) + ore
     }
+  };
+}
+
+async function loadCampaignAccessContext(
+  store: RoomSnapshotStore | null,
+  account: PlayerAccountSnapshot
+): Promise<CampaignAccessContext> {
+  const heroArchives = store ? await store.loadPlayerHeroArchives([account.playerId]) : [];
+  return {
+    highestHeroLevel: Math.max(1, ...heroArchives.map((archive) => Math.max(1, Math.floor(archive.hero.progression.level ?? 1)))),
+    rankDivision: account.rankDivision ?? getRankDivisionForRating(account.eloRating ?? 1000)
   };
 }
 
@@ -1741,9 +1762,73 @@ export function registerPlayerAccountRoutes(
             displayName: authSession.displayName,
             ...(authSession.loginId ? { loginId: authSession.loginId } : {})
           });
+      const accessContext = await loadCampaignAccessContext(store, account);
 
       sendJson(response, 200, {
-        campaign: toCampaignResponse(account)
+        campaign: toCampaignResponse(account, accessContext)
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/campaigns/:campaignId/missions/:missionId/start", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    const campaignId = request.params.campaignId?.trim();
+    const missionId = request.params.missionId?.trim();
+    if (!campaignId || !missionId) {
+      sendNotFound(response);
+      return;
+    }
+
+    if (!store) {
+      sendJson(response, 503, {
+        error: {
+          code: "campaign_persistence_unavailable",
+          message: "Campaign progression requires configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const account =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      const accessContext = await loadCampaignAccessContext(store, account);
+      const mission = buildCampaignMissionStates(resolveCampaignConfig(), account.campaignProgress, accessContext).find(
+        (entry) => entry.id === missionId && entry.chapterId === campaignId
+      );
+      if (!mission) {
+        sendJson(response, 404, {
+          error: {
+            code: "campaign_mission_not_found",
+            message: "Campaign mission was not found"
+          }
+        });
+        return;
+      }
+      if (mission.status === "locked") {
+        sendJson(response, 403, {
+          error: {
+            code: "campaign_mission_locked",
+            message: "Campaign mission is not unlocked yet"
+          },
+          unlock_requirements: (mission.unlockRequirements ?? []).filter((requirement) => requirement.satisfied !== true)
+        });
+        return;
+      }
+
+      sendJson(response, 200, {
+        started: true,
+        mission
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
@@ -1784,14 +1869,16 @@ export function registerPlayerAccountRoutes(
       const nextAccount = await store.savePlayerAccountProgress(account.playerId, {
         campaignProgress: result.campaignProgress,
         gems: rewardMutation.gems,
+        cosmeticInventory: rewardMutation.cosmeticInventory,
         globalResources: rewardMutation.globalResources
       });
+      const accessContext = await loadCampaignAccessContext(store, nextAccount);
 
       sendJson(response, 200, {
         completed: true,
         mission: result.mission,
         reward: result.reward,
-        campaign: toCampaignResponse(nextAccount)
+        campaign: toCampaignResponse(nextAccount, accessContext)
       });
     } catch (error) {
       if (error instanceof Error && error.message === "campaign_mission_not_found") {
@@ -2511,6 +2598,7 @@ export function registerPlayerAccountRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
+      const accessContext = await loadCampaignAccessContext(store, account);
       sendJson(response, 200, {
         ...toProgressionResponse(account, parseLimit(request)),
         dailyQuestBoard: await loadDailyQuestBoard(
@@ -2519,7 +2607,7 @@ export function registerPlayerAccountRoutes(
           new Date(),
           featureFlags.quest_system_enabled && isTutorialComplete(account.tutorialStep)
         ),
-        campaign: toCampaignResponse(account),
+        campaign: toCampaignResponse(account, accessContext),
         dailyDungeon: toDailyDungeonResponse(account)
       });
     } catch (error) {

--- a/apps/server/src/pve-content.ts
+++ b/apps/server/src/pve-content.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
 import campaignDocument from "../../../configs/campaign-chapter1.json";
+import campaignChapter2Document from "../../../configs/campaign-chapter2.json";
+import campaignChapter3Document from "../../../configs/campaign-chapter3.json";
+import campaignChapter4Document from "../../../configs/campaign-chapter4.json";
 import dailyDungeonsDocument from "../../../configs/daily-dungeons.json";
 import type {
   CampaignMission,
+  CampaignUnlockRequirement,
   CampaignMissionProgress,
   CampaignMissionState,
   CampaignProgressState,
@@ -12,8 +16,10 @@ import type {
   DailyDungeonRunRecord,
   DailyDungeonState,
   DialogueLine,
-  MissionObjective
+  MissionObjective,
+  RankDivisionId
 } from "../../../packages/shared/src/index";
+import { getRankDivisionIndex, resolveCosmeticCatalog } from "../../../packages/shared/src/index";
 import { getDailyRewardDateKey } from "./daily-rewards";
 
 interface CampaignConfigMissionDocument {
@@ -27,9 +33,11 @@ interface CampaignConfigMissionDocument {
   enemyArmyTemplateId?: string | null;
   enemyArmyCount?: number | null;
   enemyStatMultiplier?: number | null;
+  bossEncounterName?: string | null;
   unlockMissionId?: string | null;
-  reward?: DailyDungeonReward | null;
+  reward?: (DailyDungeonReward & { cosmeticId?: string | null }) | null;
   introDialogue?: Partial<DialogueLine>[] | null;
+  midDialogue?: Partial<DialogueLine>[] | null;
   outroDialogue?: Partial<DialogueLine>[] | null;
   objectives?: Partial<MissionObjective>[] | null;
 }
@@ -40,6 +48,33 @@ interface CampaignConfigDocument {
 
 interface DailyDungeonConfigDocument {
   dungeons?: Array<Partial<DailyDungeonDefinition> & { floors?: Partial<DailyDungeonFloor>[] | null }> | null;
+}
+
+export interface CampaignAccessContext {
+  highestHeroLevel?: number | null;
+  rankDivision?: RankDivisionId | null;
+}
+
+const DEFAULT_CAMPAIGN_DOCUMENTS: CampaignConfigDocument[] = [
+  campaignDocument as CampaignConfigDocument,
+  campaignChapter2Document as CampaignConfigDocument,
+  campaignChapter3Document as CampaignConfigDocument,
+  campaignChapter4Document as CampaignConfigDocument
+];
+
+const BASIC_CAMPAIGN_ENEMY_TEMPLATES = new Set(["wolf_pack", "hero_guard_basic"]);
+const CHAPTER_FINAL_MISSION_IDS: Record<string, string> = {
+  chapter1: "chapter1-defend-bridge",
+  chapter2: "chapter2-break-the-ring",
+  chapter3: "chapter3-tempest-crown",
+  chapter4: "chapter4-veilfall-throne"
+};
+const CHAPTER_MINIMUM_RANK: Partial<Record<string, RankDivisionId>> = {
+  chapter4: "silver_i"
+};
+
+function resolveCampaignDocuments(document: CampaignConfigDocument | CampaignConfigDocument[]): CampaignConfigDocument[] {
+  return Array.isArray(document) ? document : [document];
 }
 
 function normalizeNonNegativeInteger(value: number | null | undefined, field: string, minimum = 0): number {
@@ -58,11 +93,18 @@ function normalizePositiveNumber(value: number | null | undefined, field: string
   return normalized;
 }
 
-function normalizeReward(rawReward: DailyDungeonReward | undefined, field: string): DailyDungeonReward {
+function normalizeReward(
+  rawReward: (DailyDungeonReward & { cosmeticId?: string | null }) | undefined,
+  field: string
+): CampaignMission["reward"] {
   const gems = normalizeNonNegativeInteger(rawReward?.gems ?? 0, `${field}.gems`);
   const gold = normalizeNonNegativeInteger(rawReward?.resources?.gold ?? 0, `${field}.resources.gold`);
   const wood = normalizeNonNegativeInteger(rawReward?.resources?.wood ?? 0, `${field}.resources.wood`);
   const ore = normalizeNonNegativeInteger(rawReward?.resources?.ore ?? 0, `${field}.resources.ore`);
+  const cosmeticId = rawReward?.cosmeticId?.trim();
+  if (cosmeticId && !resolveCosmeticCatalog().some((entry) => entry.id === cosmeticId)) {
+    throw new Error(`${field}.cosmeticId references unknown cosmetic ${cosmeticId}`);
+  }
 
   return {
     ...(gems > 0 ? { gems } : {}),
@@ -74,7 +116,8 @@ function normalizeReward(rawReward: DailyDungeonReward | undefined, field: strin
             ...(ore > 0 ? { ore } : {})
           }
         }
-      : {})
+      : {}),
+    ...(cosmeticId ? { cosmeticId } : {})
   };
 }
 
@@ -129,9 +172,9 @@ function normalizeMissionObjective(rawObjective: Partial<MissionObjective> | nul
 }
 
 export function resolveCampaignConfig(
-  document: CampaignConfigDocument = campaignDocument as CampaignConfigDocument
+  document: CampaignConfigDocument | CampaignConfigDocument[] = DEFAULT_CAMPAIGN_DOCUMENTS
 ): CampaignMission[] {
-  const rawMissions = document.missions ?? [];
+  const rawMissions = resolveCampaignDocuments(document).flatMap((entry) => entry.missions ?? []);
   if (rawMissions.length === 0) {
     throw new Error("campaign config must define at least one mission");
   }
@@ -143,6 +186,7 @@ export function resolveCampaignConfig(
     const name = rawMission.name?.trim();
     const description = rawMission.description?.trim();
     const enemyArmyTemplateId = rawMission.enemyArmyTemplateId?.trim();
+    const bossEncounterName = rawMission.bossEncounterName?.trim();
     if (!id || !chapterId || !mapId || !name || !description || !enemyArmyTemplateId) {
       throw new Error(
         `campaign mission[${index}] must define id, chapterId, mapId, name, description, and enemyArmyTemplateId`
@@ -176,6 +220,9 @@ export function resolveCampaignConfig(
     const introDialogue = (rawMission.introDialogue ?? []).map((line, lineIndex) =>
       normalizeDialogueLine(line, `campaign mission ${id} introDialogue[${lineIndex}]`)
     );
+    const midDialogue = (rawMission.midDialogue ?? []).map((line, lineIndex) =>
+      normalizeDialogueLine(line, `campaign mission ${id} midDialogue[${lineIndex}]`)
+    );
     const outroDialogue = (rawMission.outroDialogue ?? []).map((line, lineIndex) =>
       normalizeDialogueLine(line, `campaign mission ${id} outroDialogue[${lineIndex}]`)
     );
@@ -197,8 +244,10 @@ export function resolveCampaignConfig(
         rawMission.enemyStatMultiplier,
         `campaign mission ${id} enemyStatMultiplier`
       ),
+      ...(bossEncounterName ? { bossEncounterName } : {}),
       ...(unlockMissionId ? { unlockMissionId } : {}),
       ...(introDialogue.length > 0 ? { introDialogue } : {}),
+      ...(midDialogue.length > 0 ? { midDialogue } : {}),
       ...(outroDialogue.length > 0 ? { outroDialogue } : {}),
       objectives,
       reward: normalizeReward(rawMission.reward ?? undefined, `campaign mission ${id} reward`)
@@ -213,25 +262,117 @@ export function resolveCampaignConfig(
     ids.add(mission.id);
   }
 
+  const missionsByChapter = new Map<string, CampaignMission[]>();
+  for (const mission of missions) {
+    missionsByChapter.set(mission.chapterId, [...(missionsByChapter.get(mission.chapterId) ?? []), mission]);
+  }
+  for (const chapterId of ["chapter2", "chapter3", "chapter4"]) {
+    const chapterMissions = missionsByChapter.get(chapterId) ?? [];
+    if (chapterMissions.length < 6 || chapterMissions.length > 8) {
+      throw new Error(`${chapterId} must define 6-8 missions`);
+    }
+    const bossMissions = chapterMissions.filter((mission) => mission.bossEncounterName);
+    if (bossMissions.length === 0) {
+      throw new Error(`${chapterId} must define a named boss encounter`);
+    }
+    if (bossMissions.some((mission) => BASIC_CAMPAIGN_ENEMY_TEMPLATES.has(mission.enemyArmyTemplateId))) {
+      throw new Error(`${chapterId} boss encounters must use a distinct unit composition`);
+    }
+    if (!chapterMissions.some((mission) => mission.reward.cosmeticId)) {
+      throw new Error(`${chapterId} must define a unique map cosmetic reward`);
+    }
+  }
+
   return [...missions].sort((left, right) => left.order - right.order || left.id.localeCompare(right.id));
+}
+
+function getMissionCompleted(
+  progressByMissionId: Map<string, CampaignMissionProgress>,
+  missionId: string | undefined
+): boolean {
+  return missionId ? Boolean(progressByMissionId.get(missionId)?.completedAt) : true;
+}
+
+function getChapterUnlockRequirements(
+  missions: CampaignMission[],
+  mission: CampaignMission,
+  progressByMissionId: Map<string, CampaignMissionProgress>,
+  accessContext?: CampaignAccessContext | null
+): CampaignUnlockRequirement[] {
+  const requirements: CampaignUnlockRequirement[] = [];
+  const missionsById = new Map(missions.map((entry) => [entry.id, entry] as const));
+
+  if (mission.unlockMissionId) {
+    requirements.push({
+      type: "mission_complete",
+      description: `Complete ${missionsById.get(mission.unlockMissionId)?.name ?? mission.unlockMissionId}.`,
+      satisfied: getMissionCompleted(progressByMissionId, mission.unlockMissionId),
+      missionId: mission.unlockMissionId
+    });
+  }
+
+  const previousChapterFinalMissionId =
+    mission.chapterId === "chapter2"
+      ? CHAPTER_FINAL_MISSION_IDS.chapter1
+      : mission.chapterId === "chapter3"
+        ? CHAPTER_FINAL_MISSION_IDS.chapter2
+        : mission.chapterId === "chapter4"
+          ? CHAPTER_FINAL_MISSION_IDS.chapter3
+          : undefined;
+  if (previousChapterFinalMissionId) {
+    requirements.push({
+      type: "mission_complete",
+      description: `Complete ${missionsById.get(previousChapterFinalMissionId)?.name ?? previousChapterFinalMissionId}.`,
+      satisfied: getMissionCompleted(progressByMissionId, previousChapterFinalMissionId),
+      missionId: previousChapterFinalMissionId,
+      chapterId: mission.chapterId
+    });
+  }
+
+  if (mission.chapterId === "chapter3") {
+    requirements.push({
+      type: "hero_level",
+      description: "Reach hero level 15.",
+      satisfied: Math.max(1, Math.floor(accessContext?.highestHeroLevel ?? 1)) >= 15,
+      minimumHeroLevel: 15,
+      chapterId: mission.chapterId
+    });
+  }
+
+  const minimumRankDivision = CHAPTER_MINIMUM_RANK[mission.chapterId];
+  if (minimumRankDivision) {
+    const currentRankDivision = accessContext?.rankDivision ?? "bronze_i";
+    requirements.push({
+      type: "rank_division",
+      description: "Reach Silver rank or higher.",
+      satisfied: getRankDivisionIndex(currentRankDivision) >= getRankDivisionIndex(minimumRankDivision),
+      minimumRankDivision,
+      chapterId: mission.chapterId
+    });
+  }
+
+  return requirements;
 }
 
 export function buildCampaignMissionStates(
   missions: CampaignMission[],
-  campaignProgress?: CampaignProgressState | null
+  campaignProgress?: CampaignProgressState | null,
+  accessContext?: CampaignAccessContext | null
 ): CampaignMissionState[] {
   const progressByMissionId = new Map((campaignProgress?.missions ?? []).map((progress) => [progress.missionId, progress] as const));
 
   return missions.map((mission) => {
     const progress = progressByMissionId.get(mission.id);
     const completed = Boolean(progress?.completedAt);
-    const unlocked = !mission.unlockMissionId || Boolean(progressByMissionId.get(mission.unlockMissionId)?.completedAt);
+    const unlockRequirements = getChapterUnlockRequirements(missions, mission, progressByMissionId, accessContext);
+    const unlocked = unlockRequirements.every((requirement) => requirement.satisfied === true);
 
     return {
       ...mission,
       missionId: mission.id,
       attempts: Math.max(0, progress?.attempts ?? 0),
       ...(progress?.completedAt ? { completedAt: progress.completedAt } : {}),
+      ...(unlockRequirements.length > 0 ? { unlockRequirements } : {}),
       status: completed ? "completed" : unlocked ? "available" : "locked"
     };
   });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -54,6 +54,7 @@ function getRelativeDailyRewardDateKey(baseDateKey: string, deltaDays: number): 
 
 class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
+  private readonly heroArchives = new Map<string, PlayerHeroArchiveSnapshot>();
   private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
@@ -151,8 +152,8 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
     return this.authSessionsByPlayerId.get(playerId.trim())?.delete(sessionId.trim()) ?? false;
   }
 
-  async loadPlayerHeroArchives(_playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
-    return [];
+  async loadPlayerHeroArchives(playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
+    return Array.from(this.heroArchives.values()).filter((archive) => playerIds.includes(archive.playerId));
   }
 
   async getCurrentSeason() {
@@ -837,6 +838,10 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
 
   seedEventHistory(playerId: string, entries: PlayerAccountSnapshot["recentEventLog"]): void {
     this.eventHistoryByPlayerId.set(playerId, structuredClone(entries));
+  }
+
+  seedHeroArchive(archive: PlayerHeroArchiveSnapshot): void {
+    this.heroArchives.set(`${archive.playerId}:${archive.heroId}`, structuredClone(archive));
   }
 }
 
@@ -3823,7 +3828,7 @@ test("campaign mission completion unlocks the next chapter 1 mission and grants 
   };
 
   assert.equal(initialResponse.status, 200);
-  assert.equal(initialPayload.campaign.totalMissions, 6);
+  assert.equal(initialPayload.campaign.totalMissions, 27);
   assert.equal(initialPayload.campaign.nextMissionId, "chapter1-ember-watch");
   assert.equal(initialPayload.campaign.missions[0]?.status, "available");
   assert.equal(initialPayload.campaign.missions[1]?.status, "locked");
@@ -3862,6 +3867,100 @@ test("campaign mission completion unlocks the next chapter 1 mission and grants 
   assert.equal(account?.gems, 12);
   assert.equal(account?.globalResources.gold, 140);
   assert.equal(account?.campaignProgress?.missions[0]?.missionId, "chapter1-ember-watch");
+});
+
+test("campaign mission start returns 403 unlock requirements until chapter gates are satisfied", async (t) => {
+  const port = 44990 + Math.floor(Math.random() * 1000);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "gated-campaign-player",
+    displayName: "Ranked Commander",
+    rankDivision: "bronze_iii",
+    gems: 0,
+    globalResources: { gold: 0, wood: 0, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [],
+    campaignProgress: {
+      missions: [{ missionId: "chapter3-tempest-crown", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    tutorialStep: DEFAULT_TUTORIAL_STEP,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  });
+  store.seedHeroArchive({
+    playerId: "gated-campaign-player",
+    heroId: "hero-ranked",
+    hero: {
+      ...createAccountTrackingWorldState().heroes[0]!,
+      id: "hero-ranked",
+      playerId: "gated-campaign-player",
+      progression: {
+        ...createDefaultHeroProgression(),
+        level: 18
+      }
+    }
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueAccountAuthSession({
+    playerId: "gated-campaign-player",
+    displayName: "Ranked Commander",
+    loginId: "gated-campaign-player"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const lockedResponse = await fetch(
+    `http://127.0.0.1:${port}/api/campaigns/chapter4/missions/chapter4-basin-breach/start`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const lockedPayload = (await lockedResponse.json()) as {
+    error: { code: string };
+    unlock_requirements: Array<{ type: string; minimumRankDivision?: string; description: string }>;
+  };
+
+  assert.equal(lockedResponse.status, 403);
+  assert.equal(lockedPayload.error.code, "campaign_mission_locked");
+  assert.equal(lockedPayload.unlock_requirements.some((requirement) => requirement.type === "rank_division"), true);
+  assert.equal(
+    lockedPayload.unlock_requirements.find((requirement) => requirement.type === "rank_division")?.minimumRankDivision,
+    "silver_i"
+  );
+
+  const unlockedAccount = await store.loadPlayerAccount("gated-campaign-player");
+  assert.ok(unlockedAccount);
+  store.seedAccount({
+    ...unlockedAccount,
+    rankDivision: "silver_i",
+    peakRankDivision: "silver_i",
+    updatedAt: new Date().toISOString()
+  });
+
+  const unlockedResponse = await fetch(
+    `http://127.0.0.1:${port}/api/campaigns/chapter4/missions/chapter4-basin-breach/start`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    }
+  );
+  const unlockedPayload = (await unlockedResponse.json()) as {
+    started: boolean;
+    mission: { id: string; chapterId: string; status: string };
+  };
+
+  assert.equal(unlockedResponse.status, 200);
+  assert.equal(unlockedPayload.started, true);
+  assert.equal(unlockedPayload.mission.id, "chapter4-basin-breach");
+  assert.equal(unlockedPayload.mission.chapterId, "chapter4");
 });
 
 test("daily dungeon attempts are capped per day and rewards can only be claimed once per run", async (t) => {

--- a/apps/server/test/pve-content.test.ts
+++ b/apps/server/test/pve-content.test.ts
@@ -13,13 +13,68 @@ import {
 test("campaign config exposes a 6-mission chapter 1 arc with dialogue and sequential unlocks", () => {
   const missions = resolveCampaignConfig();
   const states = buildCampaignMissionStates(missions, undefined);
+  const chapter1 = missions.filter((mission) => mission.chapterId === "chapter1");
+  const chapter2 = missions.filter((mission) => mission.chapterId === "chapter2");
+  const chapter3 = missions.filter((mission) => mission.chapterId === "chapter3");
+  const chapter4 = missions.filter((mission) => mission.chapterId === "chapter4");
 
-  assert.equal(missions.length, 6);
+  assert.equal(missions.length, 27);
+  assert.equal(chapter1.length, 6);
+  assert.equal(chapter2.length, 7);
+  assert.equal(chapter3.length, 7);
+  assert.equal(chapter4.length, 7);
   assert.equal(missions[0]?.introDialogue?.length, 2);
+  assert.equal(chapter2.at(-1)?.bossEncounterName, "Captain Veyr, Ringbreaker");
+  assert.equal(chapter3.at(-1)?.midDialogue?.length, 3);
+  assert.equal(chapter4.at(-1)?.reward.cosmeticId, "border-veilfall-throne");
   assert.equal(missions[0]?.objectives[0]?.id, "c1m1-clear-patrol");
   assert.equal(states[0]?.status, "available");
   assert.equal(states[1]?.unlockMissionId, states[0]?.id);
   assert.equal(states[1]?.status, "locked");
+  assert.equal(states.find((mission) => mission.id === "chapter2-highland-muster")?.status, "locked");
+});
+
+test("campaign chapter gates require prior chapter clears, hero level 15, and silver rank", () => {
+  const missions = resolveCampaignConfig();
+  const chapter2Mission = buildCampaignMissionStates(missions, {
+    missions: [{ missionId: "chapter1-defend-bridge", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+  }) .find((mission) => mission.id === "chapter2-highland-muster");
+  const chapter3Locked = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter2-break-the-ring", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 14, rankDivision: "silver_i" }
+  ).find((mission) => mission.id === "chapter3-ridgefire-scouts");
+  const chapter3Unlocked = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter2-break-the-ring", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 15, rankDivision: "bronze_iii" }
+  ).find((mission) => mission.id === "chapter3-ridgefire-scouts");
+  const chapter4Locked = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter3-tempest-crown", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 18, rankDivision: "bronze_iii" }
+  ).find((mission) => mission.id === "chapter4-basin-breach");
+  const chapter4Unlocked = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter3-tempest-crown", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 18, rankDivision: "silver_i" }
+  ).find((mission) => mission.id === "chapter4-basin-breach");
+
+  assert.equal(chapter2Mission?.status, "available");
+  assert.equal(chapter3Locked?.status, "locked");
+  assert.equal(chapter3Locked?.unlockRequirements?.find((requirement) => requirement.type === "hero_level")?.satisfied, false);
+  assert.equal(chapter3Unlocked?.status, "available");
+  assert.equal(chapter4Locked?.status, "locked");
+  assert.equal(chapter4Locked?.unlockRequirements?.find((requirement) => requirement.type === "rank_division")?.satisfied, false);
+  assert.equal(chapter4Unlocked?.status, "available");
 });
 
 test("daily dungeon state resets by date key and enforces one-time reward claims per run", () => {

--- a/configs/campaign-chapter2.json
+++ b/configs/campaign-chapter2.json
@@ -1,0 +1,386 @@
+{
+  "missions": [
+    {
+      "id": "chapter2-highland-muster",
+      "chapterId": "chapter2",
+      "order": 7,
+      "mapId": "highland-reach",
+      "name": "Highland Muster",
+      "description": "Rally the frontier guild banners and reopen the ridge depots for a counteroffensive.",
+      "recommendedHeroLevel": 5,
+      "enemyArmyTemplateId": "crown_light_outrider",
+      "enemyArmyCount": 24,
+      "enemyStatMultiplier": 1.74,
+      "introDialogue": [
+        {
+          "id": "c2m1-intro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "The bridge held. Now every guild on the ridge wants payback.",
+          "mood": "defiant"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c2m1-outro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Good. A counterstroke needs supply, scouts, and people willing to move first.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c2m1-secure-banners",
+          "description": "Secure the guild rally banners",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 3
+        },
+        {
+          "id": "c2m1-break-pickets",
+          "description": "Break the outrider pickets on the ridge",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 30, "resources": { "gold": 420, "wood": 26 } }
+    },
+    {
+      "id": "chapter2-bogfen-oath",
+      "chapterId": "chapter2",
+      "order": 8,
+      "mapId": "bogfen-crossing",
+      "name": "Bogfen Oath",
+      "description": "Escort allied guild wardens through the fen and swear the river pact in person.",
+      "recommendedHeroLevel": 6,
+      "enemyArmyTemplateId": "moss_stalker",
+      "enemyArmyCount": 26,
+      "enemyStatMultiplier": 1.88,
+      "unlockMissionId": "chapter2-highland-muster",
+      "introDialogue": [
+        {
+          "id": "c2m2-intro-1",
+          "speakerId": "fen-warden-isa",
+          "speakerName": "Warden Isa",
+          "text": "The guild boats will move once the crossing is ours. Until then, we walk through mud and teeth.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c2m2-outro-1",
+          "speakerId": "fen-warden-isa",
+          "speakerName": "Warden Isa",
+          "text": "The river pact stands. Send for arrows, resin, and every healer you can spare.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c2m2-escort-wardens",
+          "description": "Escort the guild wardens to the crossing",
+          "kind": "escort",
+          "gate": "start"
+        },
+        {
+          "id": "c2m2-clear-fen",
+          "description": "Clear the fen ambushers around the ford",
+          "kind": "defeat",
+          "gate": "mid",
+          "targetCount": 2
+        }
+      ],
+      "reward": { "gems": 32, "resources": { "gold": 460, "wood": 30, "ore": 12 } }
+    },
+    {
+      "id": "chapter2-murkveil-conclave",
+      "chapterId": "chapter2",
+      "order": 9,
+      "mapId": "murkveil-delta",
+      "name": "Murkveil Conclave",
+      "description": "Hold the delta long enough for rival guild captains to agree on a shared battle line.",
+      "recommendedHeroLevel": 7,
+      "enemyArmyTemplateId": "crown_crossbowman",
+      "enemyArmyCount": 28,
+      "enemyStatMultiplier": 2.02,
+      "unlockMissionId": "chapter2-bogfen-oath",
+      "introDialogue": [
+        {
+          "id": "c2m3-intro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "Guilds do not agree unless somebody survives long enough to count the cost.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c2m3-outro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "They signed. I never thought paperwork would smell this much like swamp water.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c2m3-hold-delta",
+          "description": "Hold the conclave circle",
+          "kind": "hold",
+          "gate": "start"
+        },
+        {
+          "id": "c2m3-cut-bolts",
+          "description": "Silence the crossbow nests on the levee",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 34, "resources": { "gold": 500, "ore": 18 } }
+    },
+    {
+      "id": "chapter2-splitrock-liaison",
+      "chapterId": "chapter2",
+      "order": 10,
+      "mapId": "splitrock-canyon",
+      "name": "Splitrock Liaison",
+      "description": "Link the highland and river guild columns before the enemy can cut the canyon road.",
+      "recommendedHeroLevel": 8,
+      "enemyArmyTemplateId": "iron_walker",
+      "enemyArmyCount": 30,
+      "enemyStatMultiplier": 2.14,
+      "unlockMissionId": "chapter2-murkveil-conclave",
+      "introDialogue": [
+        {
+          "id": "c2m4-intro-1",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "If the liaison column dies in Splitrock, every promise we bought in the delta dies with it.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c2m4-outro-1",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "Both columns made contact. Now we can hit something bigger than scouts and roadblocks.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c2m4-reach-liaison",
+          "description": "Reach the liaison column at Splitrock",
+          "kind": "escort",
+          "gate": "start"
+        },
+        {
+          "id": "c2m4-destroy-barricades",
+          "description": "Destroy the canyon barricades",
+          "kind": "secure",
+          "gate": "mid",
+          "targetCount": 2
+        }
+      ],
+      "reward": { "gems": 36, "resources": { "gold": 540, "wood": 24, "ore": 20 } }
+    },
+    {
+      "id": "chapter2-frostwatch-drill",
+      "chapterId": "chapter2",
+      "order": 11,
+      "mapId": "frostwatch-ridge",
+      "name": "Frostwatch Drill",
+      "description": "Run the newly joined guild companies through live-fire positioning before the enemy spearhead arrives.",
+      "recommendedHeroLevel": 9,
+      "enemyArmyTemplateId": "crown_field_chaplain",
+      "enemyArmyCount": 32,
+      "enemyStatMultiplier": 2.28,
+      "unlockMissionId": "chapter2-splitrock-liaison",
+      "introDialogue": [
+        {
+          "id": "c2m5-intro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "If our lines break the first time they take a charge, the guild pact is just a prettier way to lose.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c2m5-outro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "They held formation. That is rarer than courage and twice as useful.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c2m5-hold-line",
+          "description": "Hold the Frostwatch line through repeated assaults",
+          "kind": "hold",
+          "gate": "start"
+        },
+        {
+          "id": "c2m5-save-standard",
+          "description": "Keep the allied standard company alive",
+          "kind": "survive",
+          "gate": "end"
+        }
+      ],
+      "reward": { "gems": 38, "resources": { "gold": 580, "ore": 24 } }
+    },
+    {
+      "id": "chapter2-ashpeak-anvil",
+      "chapterId": "chapter2",
+      "order": 12,
+      "mapId": "ashpeak-ascent",
+      "name": "Ashpeak Anvil",
+      "description": "Pin the crown vanguard against the ascent while the guild cavalry loops for the hammer strike.",
+      "recommendedHeroLevel": 10,
+      "enemyArmyTemplateId": "crown_heavy_cavalry",
+      "enemyArmyCount": 34,
+      "enemyStatMultiplier": 2.42,
+      "unlockMissionId": "chapter2-frostwatch-drill",
+      "introDialogue": [
+        {
+          "id": "c2m6-intro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "Heavy horse on a mountain road. Either they are desperate or they think we are fools.",
+          "mood": "defiant"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c2m6-outro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "Their vanguard cracked. One more push and the whole ring around the basin comes loose.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c2m6-pin-vanguard",
+          "description": "Pin the vanguard on the ascent",
+          "kind": "hold",
+          "gate": "start"
+        },
+        {
+          "id": "c2m6-open-flank",
+          "description": "Open the road for the guild cavalry flank",
+          "kind": "secure",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 40, "resources": { "gold": 620, "wood": 28, "ore": 26 } }
+    },
+    {
+      "id": "chapter2-break-the-ring",
+      "chapterId": "chapter2",
+      "order": 13,
+      "mapId": "frontier-basin",
+      "name": "Break The Ring",
+      "description": "Lead the full guild coalition into the basin and shatter the commander holding the siege ring together.",
+      "recommendedHeroLevel": 11,
+      "enemyArmyTemplateId": "crown_heavy_cavalry",
+      "enemyArmyCount": 38,
+      "enemyStatMultiplier": 2.64,
+      "bossEncounterName": "Captain Veyr, Ringbreaker",
+      "unlockMissionId": "chapter2-ashpeak-anvil",
+      "introDialogue": [
+        {
+          "id": "c2m7-intro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Captain Veyr built the siege ring. Break him and the whole front stops breathing for a day.",
+          "mood": "grim"
+        },
+        {
+          "id": "c2m7-intro-2",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "A day is enough. The guilds can turn a day into a campaign if someone opens the door.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c2m7-intro-3",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "Then open it hard.",
+          "mood": "defiant"
+        }
+      ],
+      "midDialogue": [
+        {
+          "id": "c2m7-mid-1",
+          "speakerId": "captain-veyr",
+          "speakerName": "Captain Veyr",
+          "text": "You brought guild militias against crown steel. That is either bravery or bookkeeping gone mad.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c2m7-mid-2",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "It is a debt call, captain. The frontier has kept receipts.",
+          "mood": "grim"
+        },
+        {
+          "id": "c2m7-mid-3",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Press the center. His reserve is already burning.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c2m7-outro-1",
+          "speakerId": "narrator",
+          "speakerName": "Narrator",
+          "text": "The siege ring splinters under the guild assault, leaving the frontier room to breathe and regroup.",
+          "mood": "hopeful"
+        },
+        {
+          "id": "c2m7-outro-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Chapter 3 begins where breathing stops being enough. The hazards ahead will kill the careless faster than any army.",
+          "mood": "grim"
+        },
+        {
+          "id": "c2m7-outro-3",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "Then we send only the commanders who learned something here.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c2m7-break-screen",
+          "description": "Break Captain Veyr's forward screen",
+          "kind": "defeat",
+          "gate": "start"
+        },
+        {
+          "id": "c2m7-hold-center",
+          "description": "Hold the coalition center while the flank closes",
+          "kind": "hold",
+          "gate": "mid"
+        },
+        {
+          "id": "c2m7-drop-veyr",
+          "description": "Defeat Captain Veyr, Ringbreaker",
+          "kind": "defeat",
+          "gate": "end"
+        }
+      ],
+      "reward": { "gems": 52, "resources": { "gold": 760, "ore": 34 }, "cosmeticId": "border-guild-vanguard" }
+    }
+  ]
+}

--- a/configs/campaign-chapter3.json
+++ b/configs/campaign-chapter3.json
@@ -1,0 +1,387 @@
+{
+  "missions": [
+    {
+      "id": "chapter3-ridgefire-scouts",
+      "chapterId": "chapter3",
+      "order": 14,
+      "mapId": "frostwatch-ridge",
+      "name": "Ridgefire Scouts",
+      "description": "Probe the storm-split ridge where whiteout winds now turn every skirmish into an endurance test.",
+      "recommendedHeroLevel": 12,
+      "enemyArmyTemplateId": "wild_hawk_rider",
+      "enemyArmyCount": 36,
+      "enemyStatMultiplier": 2.78,
+      "introDialogue": [
+        {
+          "id": "c3m1-intro-1",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "The ridge wind strips banners, arrows, and weak plans in the same breath.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c3m1-outro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Good. If we can move here, we can move anywhere in the hazard line.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c3m1-mark-safe-route",
+          "description": "Mark a safe route across the ridgefire line",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 3
+        },
+        {
+          "id": "c3m1-clear-scouts",
+          "description": "Clear the hawk riders harrying the route",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 44, "resources": { "gold": 700, "ore": 26 } }
+    },
+    {
+      "id": "chapter3-sundered-ford",
+      "chapterId": "chapter3",
+      "order": 15,
+      "mapId": "contested-basin",
+      "name": "Sundered Ford",
+      "description": "Cross a basin ford under constant surge water and keep the hazard engineers alive.",
+      "recommendedHeroLevel": 13,
+      "enemyArmyTemplateId": "iron_walker",
+      "enemyArmyCount": 38,
+      "enemyStatMultiplier": 2.92,
+      "unlockMissionId": "chapter3-ridgefire-scouts",
+      "introDialogue": [
+        {
+          "id": "c3m2-intro-1",
+          "speakerId": "engineer-toma",
+          "speakerName": "Engineer Toma",
+          "text": "The ford is passable for minutes at a time. Waste one window and we start counting bodies instead of planks.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c3m2-outro-1",
+          "speakerId": "engineer-toma",
+          "speakerName": "Engineer Toma",
+          "text": "Bridge anchors held. I hate that this counts as a victory now.",
+          "mood": "grim"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c3m2-escort-engineers",
+          "description": "Escort the hazard engineers across the ford",
+          "kind": "escort",
+          "gate": "start"
+        },
+        {
+          "id": "c3m2-secure-anchors",
+          "description": "Secure the basin anchors before the surge returns",
+          "kind": "secure",
+          "gate": "mid",
+          "targetCount": 2
+        }
+      ],
+      "reward": { "gems": 46, "resources": { "gold": 740, "wood": 30, "ore": 28 } }
+    },
+    {
+      "id": "chapter3-murkveil-static",
+      "chapterId": "chapter3",
+      "order": 16,
+      "mapId": "murkveil-delta",
+      "name": "Murkveil Static",
+      "description": "Advance through the delta while veil-charged fog disrupts vision and command relays.",
+      "recommendedHeroLevel": 14,
+      "enemyArmyTemplateId": "shadow_hexer",
+      "enemyArmyCount": 40,
+      "enemyStatMultiplier": 3.06,
+      "unlockMissionId": "chapter3-sundered-ford",
+      "introDialogue": [
+        {
+          "id": "c3m3-intro-1",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "The fog is listening now. Keep your orders short and your courage shorter.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c3m3-outro-1",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "The static thinned where they fell. Someone is feeding the delta from farther inland.",
+          "mood": "urgent"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c3m3-silence-hexers",
+          "description": "Silence the hexers empowering the fog",
+          "kind": "defeat",
+          "gate": "start"
+        },
+        {
+          "id": "c3m3-recover-relays",
+          "description": "Recover the drowned signal relays",
+          "kind": "secure",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 48, "resources": { "gold": 780, "ore": 30 } }
+    },
+    {
+      "id": "chapter3-splitrock-fault",
+      "chapterId": "chapter3",
+      "order": 17,
+      "mapId": "splitrock-canyon",
+      "name": "Splitrock Fault",
+      "description": "Fight through a collapsing canyon lane before the unstable shelves bury your supply line.",
+      "recommendedHeroLevel": 15,
+      "enemyArmyTemplateId": "wild_cave_troll",
+      "enemyArmyCount": 42,
+      "enemyStatMultiplier": 3.2,
+      "unlockMissionId": "chapter3-murkveil-static",
+      "introDialogue": [
+        {
+          "id": "c3m4-intro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "Every aftershock costs us carts. Clear the fault or we starve before the enemy ever reaches us.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c3m4-outro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "The road still exists. Barely. I will count that as your best work this week.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c3m4-clear-fault",
+          "description": "Clear the canyon fault line",
+          "kind": "defeat",
+          "gate": "start"
+        },
+        {
+          "id": "c3m4-save-convoy",
+          "description": "Keep the supply convoy moving through the slides",
+          "kind": "escort",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 50, "resources": { "gold": 820, "wood": 24, "ore": 34 } }
+    },
+    {
+      "id": "chapter3-bogfen-lightning",
+      "chapterId": "chapter3",
+      "order": 18,
+      "mapId": "bogfen-crossing",
+      "name": "Bogfen Lightning",
+      "description": "Advance through floodglass pools where every strike from above turns the marsh itself against you.",
+      "recommendedHeroLevel": 16,
+      "enemyArmyTemplateId": "wild_serpent",
+      "enemyArmyCount": 44,
+      "enemyStatMultiplier": 3.34,
+      "unlockMissionId": "chapter3-splitrock-fault",
+      "introDialogue": [
+        {
+          "id": "c3m5-intro-1",
+          "speakerId": "fen-warden-isa",
+          "speakerName": "Warden Isa",
+          "text": "Do not step where the water shines. That glow is not moonlight and it does not forgive mistakes.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c3m5-outro-1",
+          "speakerId": "fen-warden-isa",
+          "speakerName": "Warden Isa",
+          "text": "The storm line moved east. Something higher up is calling it onward.",
+          "mood": "urgent"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c3m5-cross-marsh",
+          "description": "Cross the charged marsh without losing the lead cohort",
+          "kind": "escort",
+          "gate": "start"
+        },
+        {
+          "id": "c3m5-break-nests",
+          "description": "Break the serpent nests along the crossing",
+          "kind": "defeat",
+          "gate": "mid",
+          "targetCount": 2
+        }
+      ],
+      "reward": { "gems": 52, "resources": { "gold": 860, "ore": 36 } }
+    },
+    {
+      "id": "chapter3-ashpeak-conductor",
+      "chapterId": "chapter3",
+      "order": 19,
+      "mapId": "ashpeak-ascent",
+      "name": "Ashpeak Conductor",
+      "description": "Seize the storm conductors on Ashpeak before the enemy turns the summit into a killing field.",
+      "recommendedHeroLevel": 17,
+      "enemyArmyTemplateId": "shadow_wraith",
+      "enemyArmyCount": 46,
+      "enemyStatMultiplier": 3.48,
+      "unlockMissionId": "chapter3-bogfen-lightning",
+      "introDialogue": [
+        {
+          "id": "c3m6-intro-1",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "Those conductors are not machines. They are anchors for a weather rite, and someone is very close to finishing it.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c3m6-outro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Then the summit is next. End the rite and the whole hazard front finally breaks in our favor.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c3m6-capture-conductors",
+          "description": "Capture the Ashpeak storm conductors",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 3
+        },
+        {
+          "id": "c3m6-clear-wraiths",
+          "description": "Clear the wraith honor guard around the summit path",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 54, "resources": { "gold": 900, "wood": 28, "ore": 38 } }
+    },
+    {
+      "id": "chapter3-tempest-crown",
+      "chapterId": "chapter3",
+      "order": 20,
+      "mapId": "highland-reach",
+      "name": "Tempest Crown",
+      "description": "Climb through the heart of the hazard line and defeat the ritual commander binding the storm to the front.",
+      "recommendedHeroLevel": 18,
+      "enemyArmyTemplateId": "shadow_wraith",
+      "enemyArmyCount": 50,
+      "enemyStatMultiplier": 3.7,
+      "bossEncounterName": "Mist-Seer Vael",
+      "unlockMissionId": "chapter3-ashpeak-conductor",
+      "introDialogue": [
+        {
+          "id": "c3m7-intro-1",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "Vael is not commanding the storm. She is wearing it like armor.",
+          "mood": "grim"
+        },
+        {
+          "id": "c3m7-intro-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Then strip it away. We did not survive the line just to kneel at the summit.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c3m7-intro-3",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "Eyes open. The fog moves when she speaks.",
+          "mood": "urgent"
+        }
+      ],
+      "midDialogue": [
+        {
+          "id": "c3m7-mid-1",
+          "speakerId": "mist-seer-vael",
+          "speakerName": "Mist-Seer Vael",
+          "text": "You learned to endure the weather and mistook that for mastery.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c3m7-mid-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "No. We learned to keep walking while it killed better people.",
+          "mood": "grim"
+        },
+        {
+          "id": "c3m7-mid-3",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "Her shield is thinning. Strike the crown marks now.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c3m7-outro-1",
+          "speakerId": "narrator",
+          "speakerName": "Narrator",
+          "text": "The storm crown breaks apart over the ridge, scattering blue fire across the stones and leaving the sky suddenly human again.",
+          "mood": "hopeful"
+        },
+        {
+          "id": "c3m7-outro-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Chapter 4 lies beyond this line. From here on, the war belongs to veterans and ranked commanders only.",
+          "mood": "grim"
+        },
+        {
+          "id": "c3m7-outro-3",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "Then let us bring veterans.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c3m7-break-crown",
+          "description": "Break the storm crown around Mist-Seer Vael",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c3m7-survive-tempest",
+          "description": "Survive the summit tempest while the rite collapses",
+          "kind": "hold",
+          "gate": "mid"
+        },
+        {
+          "id": "c3m7-defeat-vael",
+          "description": "Defeat Mist-Seer Vael",
+          "kind": "defeat",
+          "gate": "end"
+        }
+      ],
+      "reward": { "gems": 66, "resources": { "gold": 1040, "ore": 44 }, "cosmeticId": "recolor-tempest-legion" }
+    }
+  ]
+}

--- a/configs/campaign-chapter4.json
+++ b/configs/campaign-chapter4.json
@@ -1,0 +1,386 @@
+{
+  "missions": [
+    {
+      "id": "chapter4-basin-breach",
+      "chapterId": "chapter4",
+      "order": 21,
+      "mapId": "contested-basin",
+      "name": "Basin Breach",
+      "description": "Lead the ranked vanguard through the first breach into the enemy's inner basin defenses.",
+      "recommendedHeroLevel": 19,
+      "enemyArmyTemplateId": "shadow_skeleton",
+      "enemyArmyCount": 48,
+      "enemyStatMultiplier": 3.86,
+      "introDialogue": [
+        {
+          "id": "c4m1-intro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "No recruits beyond this line. Everyone here has already survived something they should not have.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c4m1-outro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "The breach is open. What waits behind it was built for officers, not scouts.",
+          "mood": "grim"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c4m1-open-breach",
+          "description": "Open the inner basin breach",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c4m1-clear-guard",
+          "description": "Clear the skeletal honor guard",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 58, "resources": { "gold": 960, "ore": 32 } }
+    },
+    {
+      "id": "chapter4-shadow-conduit",
+      "chapterId": "chapter4",
+      "order": 22,
+      "mapId": "murkveil-delta",
+      "name": "Shadow Conduit",
+      "description": "Sever the conduit feeding the inner court with harvested veil energy from the delta.",
+      "recommendedHeroLevel": 20,
+      "enemyArmyTemplateId": "shadow_hexer",
+      "enemyArmyCount": 50,
+      "enemyStatMultiplier": 4,
+      "unlockMissionId": "chapter4-basin-breach",
+      "introDialogue": [
+        {
+          "id": "c4m2-intro-1",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "The court below drinks from this conduit. Break it and every defense ahead flickers for a breath.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c4m2-outro-1",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "The conduit snapped. They will feel that loss immediately.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c4m2-break-conduit",
+          "description": "Break the shadow conduit",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c4m2-hold-relay",
+          "description": "Hold the relay ground while the conduit burns out",
+          "kind": "hold",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 60, "resources": { "gold": 1000, "wood": 32, "ore": 36 } }
+    },
+    {
+      "id": "chapter4-throne-road",
+      "chapterId": "chapter4",
+      "order": 23,
+      "mapId": "stonewatch-fork",
+      "name": "Throne Road",
+      "description": "Seize the road forts guarding the final march toward the Veilfall court.",
+      "recommendedHeroLevel": 21,
+      "enemyArmyTemplateId": "crown_crossbowman",
+      "enemyArmyCount": 52,
+      "enemyStatMultiplier": 4.14,
+      "unlockMissionId": "chapter4-shadow-conduit",
+      "introDialogue": [
+        {
+          "id": "c4m3-intro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "Road forts, kill lanes, ranked guards. Whoever planned this expected us to come eventually.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c4m3-outro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "Then let the record show their preparations were expensive and ineffective.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c4m3-take-forts",
+          "description": "Take the throne road forts",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 2
+        },
+        {
+          "id": "c4m3-silence-arches",
+          "description": "Silence the crossbow galleries",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 62, "resources": { "gold": 1040, "ore": 38 } }
+    },
+    {
+      "id": "chapter4-iron-souls",
+      "chapterId": "chapter4",
+      "order": 24,
+      "mapId": "ironpass-gorge",
+      "name": "Iron Souls",
+      "description": "Fight through the gorge foundries where fallen elites are being reforged into the court's last reserve.",
+      "recommendedHeroLevel": 22,
+      "enemyArmyTemplateId": "iron_walker",
+      "enemyArmyCount": 54,
+      "enemyStatMultiplier": 4.28,
+      "unlockMissionId": "chapter4-throne-road",
+      "introDialogue": [
+        {
+          "id": "c4m4-intro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "This is where their reserve comes from. Not recruits. Reassembled veterans.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c4m4-outro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "Foundries are down. Their reserve just became a shortage.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c4m4-break-foundries",
+          "description": "Break the foundry cores",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 2
+        },
+        {
+          "id": "c4m4-clear-reserve",
+          "description": "Clear the reforged reserve companies",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 64, "resources": { "gold": 1080, "wood": 22, "ore": 42 } }
+    },
+    {
+      "id": "chapter4-veil-steps",
+      "chapterId": "chapter4",
+      "order": 25,
+      "mapId": "ashpeak-ascent",
+      "name": "Veil Steps",
+      "description": "Climb the ceremonial ascent under relentless pressure from the inner court's chosen guard.",
+      "recommendedHeroLevel": 23,
+      "enemyArmyTemplateId": "crown_heavy_cavalry",
+      "enemyArmyCount": 56,
+      "enemyStatMultiplier": 4.42,
+      "unlockMissionId": "chapter4-iron-souls",
+      "introDialogue": [
+        {
+          "id": "c4m5-intro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "These steps were built to make an assault look foolish. Let us be efficient fools.",
+          "mood": "defiant"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c4m5-outro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "The court gate is exposed. One last line remains between us and the throne itself.",
+          "mood": "grim"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c4m5-climb-steps",
+          "description": "Climb the Veil Steps under fire",
+          "kind": "hold",
+          "gate": "start"
+        },
+        {
+          "id": "c4m5-break-chosen",
+          "description": "Break the chosen guard at the gate",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 66, "resources": { "gold": 1120, "ore": 44 } }
+    },
+    {
+      "id": "chapter4-court-of-embers",
+      "chapterId": "chapter4",
+      "order": 26,
+      "mapId": "highland-reach",
+      "name": "Court Of Embers",
+      "description": "Secure the ember courts surrounding the throne so the final duel cannot be drowned in reinforcements.",
+      "recommendedHeroLevel": 24,
+      "enemyArmyTemplateId": "shadow_wraith",
+      "enemyArmyCount": 58,
+      "enemyStatMultiplier": 4.56,
+      "unlockMissionId": "chapter4-veil-steps",
+      "introDialogue": [
+        {
+          "id": "c4m6-intro-1",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "Three ember courts, three reinforcement lanes. Leave even one open and the throne room becomes a furnace.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c4m6-outro-1",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "The courts are ours. Whatever sits on that throne now stands alone enough for it to matter.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c4m6-secure-courts",
+          "description": "Secure the ember courts",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 3
+        },
+        {
+          "id": "c4m6-cut-reinforcements",
+          "description": "Cut off the reinforcement lanes",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 68, "resources": { "gold": 1160, "wood": 34, "ore": 46 } }
+    },
+    {
+      "id": "chapter4-veilfall-throne",
+      "chapterId": "chapter4",
+      "order": 27,
+      "mapId": "frontier-basin",
+      "name": "Veilfall Throne",
+      "description": "Enter the final chamber and defeat the ruler binding the war together before the court can close around you.",
+      "recommendedHeroLevel": 25,
+      "enemyArmyTemplateId": "shadow_death_knight",
+      "enemyArmyCount": 62,
+      "enemyStatMultiplier": 4.82,
+      "bossEncounterName": "High Regent Severa",
+      "unlockMissionId": "chapter4-court-of-embers",
+      "introDialogue": [
+        {
+          "id": "c4m7-intro-1",
+          "speakerId": "high-regent-severa",
+          "speakerName": "High Regent Severa",
+          "text": "You climbed over soldiers, weather, and ghosts just to arrive tired at my door.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c4m7-intro-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Tired is fine. We only need one clean victory.",
+          "mood": "grim"
+        },
+        {
+          "id": "c4m7-intro-3",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "And the door is already open.",
+          "mood": "defiant"
+        }
+      ],
+      "midDialogue": [
+        {
+          "id": "c4m7-mid-1",
+          "speakerId": "high-regent-severa",
+          "speakerName": "High Regent Severa",
+          "text": "Look closely. This throne is not furniture. It is consent, fear, and the habit of losing.",
+          "mood": "grim"
+        },
+        {
+          "id": "c4m7-mid-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Then we break the habit first.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c4m7-mid-3",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "The throne seal is failing. End this before it rewrites the room again.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c4m7-outro-1",
+          "speakerId": "narrator",
+          "speakerName": "Narrator",
+          "text": "The Veilfall throne shatters under the final blow, and the court's last command dies with the echo.",
+          "mood": "hopeful"
+        },
+        {
+          "id": "c4m7-outro-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "The campaign is won. What comes next is rebuilding a frontier that now knows it can answer.",
+          "mood": "grim"
+        },
+        {
+          "id": "c4m7-outro-3",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "Then let us leave them a better ending than the one we inherited.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c4m7-break-seal",
+          "description": "Break the throne seal around High Regent Severa",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c4m7-survive-court",
+          "description": "Survive the court's collapsing counterattack",
+          "kind": "hold",
+          "gate": "mid"
+        },
+        {
+          "id": "c4m7-defeat-severa",
+          "description": "Defeat High Regent Severa",
+          "kind": "defeat",
+          "gate": "end"
+        }
+      ],
+      "reward": { "gems": 84, "resources": { "gold": 1320, "ore": 60 }, "cosmeticId": "border-veilfall-throne" }
+    }
+  ]
+}

--- a/configs/cosmetics.json
+++ b/configs/cosmetics.json
@@ -99,6 +99,36 @@
       "price": 40,
       "unlockCondition": "shop",
       "previewAsset": "emotes/taunt-veil"
+    },
+    {
+      "id": "border-guild-vanguard",
+      "name": "Guild Vanguard Border",
+      "category": "profile_border",
+      "rarity": "rare",
+      "description": "A campaign reward honoring commanders who rallied the frontier guilds.",
+      "price": 0,
+      "unlockCondition": "campaign_reward",
+      "previewAsset": "borders/guild-vanguard"
+    },
+    {
+      "id": "recolor-tempest-legion",
+      "name": "Tempest Legion Trim",
+      "category": "unit_recolor",
+      "rarity": "epic",
+      "description": "Storm-blue armor trim carried by veterans of the hazard line.",
+      "price": 0,
+      "unlockCondition": "campaign_reward",
+      "previewAsset": "units/tempest-legion"
+    },
+    {
+      "id": "border-veilfall-throne",
+      "name": "Veilfall Throne Border",
+      "category": "profile_border",
+      "rarity": "legendary",
+      "description": "An endgame frame awarded for breaking the court behind the Veilfall gate.",
+      "price": 0,
+      "unlockCondition": "campaign_reward",
+      "previewAsset": "borders/veilfall-throne"
     }
   ]
 }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1273,6 +1273,19 @@ export interface BattleSkillCatalogConfig {
 export interface CampaignReward {
   gems?: number;
   resources?: Partial<ResourceLedger>;
+  cosmeticId?: CosmeticId;
+}
+
+export type CampaignUnlockRequirementType = "mission_complete" | "hero_level" | "rank_division";
+
+export interface CampaignUnlockRequirement {
+  type: CampaignUnlockRequirementType;
+  description: string;
+  satisfied?: boolean;
+  missionId?: string;
+  chapterId?: string;
+  minimumHeroLevel?: number;
+  minimumRankDivision?: RankDivisionId;
 }
 
 export interface CampaignMission {
@@ -1286,8 +1299,10 @@ export interface CampaignMission {
   enemyArmyTemplateId: string;
   enemyArmyCount: number;
   enemyStatMultiplier: number;
+  bossEncounterName?: string;
   unlockMissionId?: string;
   introDialogue?: DialogueLine[];
+  midDialogue?: DialogueLine[];
   outroDialogue?: DialogueLine[];
   objectives: MissionObjective[];
   reward: CampaignReward;
@@ -1307,6 +1322,7 @@ export type CampaignMissionStatus = "locked" | "available" | "completed";
 
 export interface CampaignMissionState extends CampaignMissionProgress, CampaignMission {
   status: CampaignMissionStatus;
+  unlockRequirements?: CampaignUnlockRequirement[];
 }
 
 export interface DailyDungeonReward {


### PR DESCRIPTION
## Summary
- add campaign chapters 2-4 configs with 7 missions each, boss encounters, dialogue sequences, and campaign cosmetic rewards
- aggregate the chapter configs in server PvE content resolution and validate chapter content requirements
- enforce chapter unlock gates on mission start and expose unlock requirements in campaign state and `403` responses
- cover the new content and gating with PvE and route tests

## Why
Players were blocked after chapter 1 because no follow-on campaign content or chapter-gate enforcement existed.

## Impact
Chapter progression now extends through chapter 4, the server prevents premature starts, and locked content exposes the unlock hints needed by the client.

## Validation
- `npm run typecheck:server`
- `node --import tsx --test ./apps/server/test/pve-content.test.ts ./apps/server/test/player-account-routes.test.ts`
- `npm run validate:content-pack`

Closes #902