### PR TITLE
[codex] Add CI gate for README npm scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quickstart:
+  readme-script-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: contributor quickstart
+            command: npm run validate:quickstart
+          - label: config center regression
+            command: npm run test:client:config-center
+          - label: shared contract snapshots
+            command: npm run test:contracts
 
     steps:
       - name: Checkout
@@ -56,8 +66,19 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: Validate contributor quickstart
-        run: npm run validate:quickstart
+      - name: Gate README command: ${{ matrix.command }}
+        run: ${{ matrix.command }}
+
+      - name: Summarize README command gate
+        if: always()
+        run: |
+          {
+            echo "## README Script Gate"
+            echo
+            echo "- README command: \`${{ matrix.command }}\`"
+            echo "- Gate label: \`${{ matrix.label }}\`"
+            echo "- Workflow job: \`readme-script-gate\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   ops-tooling-typecheck:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 - `npm test` 会通过 `git ls-files` 自动发现所有已检入仓库的 `*.test.ts` Node 测试文件并统一执行；新增此类测试时不需要手动维护根脚本列表。
 - 若测试没有被 `npm test` 自动拾取，先检查文件名是否为 `*.test.ts` 且已经 `git add`；`tests/e2e/**/*.spec.ts` 仍由 Playwright 入口负责，不属于根 `node:test` 流程。
 - 共享客户端载荷 contract 快照：`npm run test:contracts`
+- GitHub Actions `readme-script-gate` 会阻塞 `npm run validate:quickstart`、`npm run test:client:config-center` 与 `npm run test:contracts` 的回归；若其中任一 README 命令失效，失败日志会直接标出对应命令
 - 并发房间压测会按 `world_progression / battle_settlement / reconnect` 三种场景分开跑数，并输出 CPU、内存、房间吞吐、动作吞吐等指标；可通过 `--scenarios=world_progression,reconnect` 等参数缩小范围
 - 当前客户端边界：`apps/cocos-client` 负责主玩法运行时；`apps/client` 只保留浏览器调试、配置联调和回归验证。
 - 微信小游戏构建 / 发布 / 回滚说明：`docs/wechat-minigame-release.md`


### PR DESCRIPTION
## Summary
- replace the single quickstart job with a focused `readme-script-gate` matrix for the highest-value README npm commands
- gate `npm run validate:quickstart`, `npm run test:client:config-center`, and `npm run test:contracts` with command-specific job names and step summaries
- document `readme-script-gate` in the README as the authoritative CI gate for those documented commands

## Validation
- `npm run test:contracts`
- `npm run test:client:config-center`
- `npm run validate:quickstart` *(fails on the current codebase: `npm run build:client:h5` errors because `apps/server/src/account-token-delivery.ts` pulls server-only `node:tls` / `node:net` imports into the Vite bundle)*
- `npx -p node@22 -p npm@10.9.3 -c 'npm run build:client:h5'` *(same pre-existing failure as above)*
- `git diff --check`

fixes #913