### PR TITLE
[codex] test: expand cocos-client campaign coverage

### DIFF
--- a/apps/cocos-client/test/VeilCampaignPanel.test.ts
+++ b/apps/cocos-client/test/VeilCampaignPanel.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { VeilCampaignPanel } from "../assets/scripts/VeilCampaignPanel.ts";
+import type { CocosCampaignPanelInput } from "../assets/scripts/cocos-campaign-panel.ts";
+import type { CocosCampaignSummary } from "../assets/scripts/cocos-lobby.ts";
+import { createComponentHarness, findNode, pressNode, readCardLabel } from "./helpers/cocos-panel-harness.ts";
+
+function createCampaignSummary(): CocosCampaignSummary {
+  return {
+    completedCount: 0,
+    totalMissions: 2,
+    nextMissionId: "chapter1-ember-watch",
+    completionPercent: 0,
+    missions: [
+      {
+        id: "chapter1-ember-watch",
+        missionId: "chapter1-ember-watch",
+        chapterId: "chapter1",
+        order: 1,
+        mapId: "ember-watch",
+        name: "余烬哨站",
+        description: "夺回哨站并建立第一条补给线。",
+        recommendedHeroLevel: 3,
+        enemyArmyTemplateId: "orc_warrior",
+        enemyArmyCount: 2,
+        enemyStatMultiplier: 1,
+        objectives: [
+          {
+            id: "hold-gate",
+            description: "守住南门两回合",
+            kind: "hold",
+            gate: "start"
+          }
+        ],
+        reward: {
+          gems: 25
+        },
+        introDialogue: [
+          {
+            id: "intro-1",
+            speakerId: "captain",
+            speakerName: "守望队长",
+            text: "先把火线稳住。"
+          }
+        ],
+        outroDialogue: [],
+        attempts: 0,
+        status: "available"
+      },
+      {
+        id: "chapter1-thornwall-road",
+        missionId: "chapter1-thornwall-road",
+        chapterId: "chapter1",
+        order: 2,
+        mapId: "thornwall-road",
+        name: "荆墙驿路",
+        description: "打通商道。",
+        recommendedHeroLevel: 4,
+        enemyArmyTemplateId: "wolf_rider",
+        enemyArmyCount: 2,
+        enemyStatMultiplier: 1.05,
+        objectives: [
+          {
+            id: "escort",
+            description: "护送补给车",
+            kind: "escort",
+            gate: "end"
+          }
+        ],
+        reward: {},
+        attempts: 0,
+        status: "locked",
+        unlockRequirements: [
+          {
+            type: "mission_complete",
+            description: "Complete 余烬哨站.",
+            missionId: "chapter1-ember-watch",
+            chapterId: "chapter1",
+            satisfied: false
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function createInput(): CocosCampaignPanelInput {
+  return {
+    campaign: createCampaignSummary(),
+    selectedMissionId: "chapter1-ember-watch",
+    activeMissionId: null,
+    dialogue: null,
+    statusMessage: "战役面板已就绪。",
+    loading: false,
+    pendingAction: null
+  };
+}
+
+test("VeilCampaignPanel renders campaign cards and routes enabled mission actions", () => {
+  const { component, node } = createComponentHarness(VeilCampaignPanel, {
+    name: "CampaignPanelRoot",
+    width: 460,
+    height: 560
+  });
+  const state = createInput();
+  let started = 0;
+  let closed = 0;
+
+  component.configure({
+    onStartMission: () => {
+      started += 1;
+    },
+    onClose: () => {
+      closed += 1;
+    }
+  });
+  component.render(state);
+
+  assert.match(readCardLabel(node, "CampaignPanelHeader"), /战役任务/);
+  assert.match(readCardLabel(node, "CampaignPanelMission"), /余烬哨站 · 可进行/);
+  assert.match(readCardLabel(node, "CampaignPanelObjectives"), /守住南门两回合/);
+  assert.match(readCardLabel(node, "CampaignPanelReward"), /宝石 \+25/);
+  assert.match(readCardLabel(node, "CampaignPanelStatus"), /战役面板已就绪/);
+
+  pressNode(findNode(node, "CampaignPanelAction-start"));
+  pressNode(findNode(node, "CampaignPanelAction-close"));
+
+  assert.equal(started, 1);
+  assert.equal(closed, 1);
+});
+
+test("VeilCampaignPanel disables unavailable actions after mission start and keeps dialogue/status cards in sync", () => {
+  const { component, node } = createComponentHarness(VeilCampaignPanel, {
+    name: "CampaignPanelRoot",
+    width: 460,
+    height: 560
+  });
+  const state = createInput();
+  state.activeMissionId = "chapter1-ember-watch";
+  state.dialogue = {
+    missionId: "chapter1-ember-watch",
+    sequence: "intro",
+    lineIndex: 0
+  };
+
+  let started = 0;
+  let advanced = 0;
+  component.configure({
+    onStartMission: () => {
+      started += 1;
+    },
+    onAdvanceDialogue: () => {
+      advanced += 1;
+    }
+  });
+  component.render(state);
+
+  assert.match(readCardLabel(node, "CampaignPanelDialogue"), /开场对话 1\/1/);
+  assert.match(readCardLabel(node, "CampaignPanelStatus"), /任务序号 1\/2/);
+
+  pressNode(findNode(node, "CampaignPanelAction-start"));
+  pressNode(findNode(node, "CampaignPanelAction-advance-dialogue"));
+
+  assert.equal(started, 0);
+  assert.equal(advanced, 1);
+});

--- a/apps/cocos-client/test/cocos-campaign-panel.test.ts
+++ b/apps/cocos-client/test/cocos-campaign-panel.test.ts
@@ -158,3 +158,75 @@ test("buildCocosCampaignPanelView exposes complete action once an active mission
   assert.equal(view.actions.find((action) => action.id === "complete")?.enabled, true);
   assert.match(view.rewardLines.join("\n"), /宝石 \+25/);
 });
+
+test("buildCocosCampaignPanelView surfaces loading fallback copy before campaign data is ready", () => {
+  const view = buildCocosCampaignPanelView({
+    campaign: null,
+    selectedMissionId: null,
+    activeMissionId: null,
+    dialogue: null,
+    statusMessage: "",
+    loading: true,
+    pendingAction: null
+  });
+
+  assert.equal(view.subtitle, "正在同步战役面板...");
+  assert.deepEqual(view.progressLines, ["战役数据未加载", "请稍后重试。"]);
+  assert.deepEqual(view.objectiveLines, ["等待任务目标。"]);
+  assert.deepEqual(view.rewardLines, ["等待任务奖励。"]);
+  assert.deepEqual(view.dialogueLines, ["等待任务对话。"]);
+  assert.equal(view.actions.find((action) => action.id === "refresh")?.enabled, false);
+  assert.equal(view.actions.find((action) => action.id === "focus-next")?.enabled, false);
+});
+
+test("buildCocosCampaignPanelView highlights locked missions and clamps outro dialogue to the last line", () => {
+  const input = createInput();
+  input.selectedMissionId = "chapter1-thornwall-road";
+  input.dialogue = {
+    missionId: "chapter1-thornwall-road",
+    sequence: "outro",
+    lineIndex: 99
+  };
+  input.campaign!.missions[1]!.outroDialogue = [
+    {
+      id: "outro-locked",
+      speakerId: "quartermaster",
+      speakerName: "军需官",
+      mood: "冷静",
+      text: "补给线已经重新接通。"
+    }
+  ];
+
+  const view = buildCocosCampaignPanelView(input);
+
+  assert.match(view.missionLines.join("\n"), /荆墙驿路 · 未解锁/);
+  assert.match(view.missionLines.join("\n"), /解锁条件 Complete 余烬哨站\./);
+  assert.match(view.rewardLines.join("\n"), /暂无额外奖励/);
+  assert.match(view.dialogueLines.join("\n"), /结算对话 100\/1/);
+  assert.match(view.dialogueLines.join("\n"), /军需官 · 冷静/);
+  assert.equal(view.actions.find((action) => action.id === "advance-dialogue")?.enabled, true);
+  assert.equal(view.actions.find((action) => action.id === "start")?.enabled, false);
+});
+
+test("buildCocosCampaignPanelView resolves completed active missions and pending completion state", () => {
+  const input = createInput();
+  input.selectedMissionId = "missing";
+  input.activeMissionId = "chapter1-ember-watch";
+  input.pendingAction = "complete";
+  input.campaign!.nextMissionId = null;
+  input.campaign!.missions[0] = {
+    ...input.campaign!.missions[0]!,
+    status: "completed",
+    completedAt: "2026-04-05T10:00:00.000Z"
+  };
+
+  const view = buildCocosCampaignPanelView(input);
+
+  assert.match(view.progressLines.join("\n"), /下一任务 当前战役线已全部完成/);
+  assert.match(view.progressLines.join("\n"), /进行中 余烬哨站/);
+  assert.match(view.missionLines.join("\n"), /完成于 2026-04-05T10:00:00.000Z/);
+  assert.match(view.statusLines.join("\n"), /正在提交任务完成/);
+  assert.equal(view.actions.find((action) => action.id === "next")?.enabled, true);
+  assert.equal(view.actions.find((action) => action.id === "focus-next")?.enabled, false);
+  assert.equal(view.actions.find((action) => action.id === "complete")?.enabled, false);
+});


### PR DESCRIPTION
## Summary
- add direct `VeilCampaignPanel` component coverage using the existing `cc-runtime-stub` panel harness
- expand `cocos-campaign-panel` model coverage for loading, locked mission, outro dialogue, and completed mission branches
- keep the change scoped to `apps/cocos-client/test/` so the issue work stays isolated

## Validation
- `node --import tsx --test apps/cocos-client/test/cocos-campaign-panel.test.ts apps/cocos-client/test/VeilCampaignPanel.test.ts apps/cocos-client/test/cocos-tilemap-renderer.test.ts apps/cocos-client/test/cocos-hud-panel.test.ts apps/cocos-client/test/cocos-primary-client-telemetry.test.ts`
- `node --import tsx --test --experimental-test-coverage --test-coverage-include='apps/cocos-client/assets/scripts/{cocos-campaign-panel.ts,VeilCampaignPanel.ts,VeilTilemapRenderer.ts,VeilHudPanel.ts,cocos-primary-client-telemetry.ts}' apps/cocos-client/test/cocos-campaign-panel.test.ts apps/cocos-client/test/VeilCampaignPanel.test.ts apps/cocos-client/test/cocos-tilemap-renderer.test.ts apps/cocos-client/test/cocos-hud-panel.test.ts apps/cocos-client/test/cocos-primary-client-telemetry.test.ts`
- `npm run test:coverage:ci` (currently fails in pre-existing `scripts/test/wechat-release-artifacts.test.ts` assertions unrelated to this change)

Closes #924