### PR TITLE
Fix config validation drift checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,9 @@ jobs:
       - name: Validate content-pack consistency
         run: npm run validate:content-pack -- --report-path "${RUNNER_TEMP}/content-pack-validation-report.json"
 
+      - name: Validate all shipped content-pack variants
+        run: npm run validate:content-pack:all
+
       - name: Test With V8 Coverage
         run: npm run test:coverage:ci
 

--- a/packages/shared/src/equipment.ts
+++ b/packages/shared/src/equipment.ts
@@ -12,6 +12,7 @@ import {
 } from "./models.ts";
 
 export const HERO_EQUIPMENT_INVENTORY_CAPACITY = 6;
+const EQUIPMENT_STAT_KEYS = ["attackPercent", "defensePercent", "power", "knowledge", "maxHp"] as const;
 
 export interface EquipmentSetDefinition {
   setId: string;
@@ -699,8 +700,47 @@ export function formatEquipmentBonusSummary(
   return parts.join(" / ") || "无属性加成";
 }
 
+function validateEquipmentBonusRecord(
+  bonuses: Partial<EquipmentStatBonuses>,
+  context: string
+): void {
+  for (const [key, value] of Object.entries(bonuses)) {
+    if (!EQUIPMENT_STAT_KEYS.includes(key as (typeof EQUIPMENT_STAT_KEYS)[number])) {
+      throw new Error(`${context} has unknown equipment stat bonus: ${key}`);
+    }
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      throw new Error(`${context} bonus ${key} must be a finite number`);
+    }
+  }
+}
+
+export function validateEquipmentCatalog(config: EquipmentCatalogConfig): void {
+  const ids = new Set<string>();
+
+  for (const entry of config.entries) {
+    if (!entry.id.trim()) {
+      throw new Error("Equipment entry id must be a non-empty string");
+    }
+    if (ids.has(entry.id)) {
+      throw new Error(`Duplicate equipment entry id: ${entry.id}`);
+    }
+    if (entry.type !== "weapon" && entry.type !== "armor" && entry.type !== "accessory") {
+      throw new Error(`Equipment entry ${entry.id} has invalid type: ${String(entry.type)}`);
+    }
+    if (entry.rarity !== "common" && entry.rarity !== "rare" && entry.rarity !== "epic") {
+      throw new Error(`Equipment entry ${entry.id} has invalid rarity: ${String(entry.rarity)}`);
+    }
+    validateEquipmentBonusRecord(entry.bonuses, `Equipment entry ${entry.id}`);
+    ids.add(entry.id);
+  }
+
+  for (const setBonus of EQUIPMENT_SET_DEFINITIONS) {
+    validateEquipmentBonusRecord(setBonus.bonus, `Equipment set ${setBonus.setId}`);
+  }
+}
+
 export function getDefaultEquipmentCatalog(): EquipmentCatalogConfig {
-  return {
+  const config = {
     entries: DEFAULT_EQUIPMENT_CATALOG.entries.map((entry) => ({
       ...entry,
       bonuses: { ...entry.bonuses },
@@ -708,6 +748,9 @@ export function getDefaultEquipmentCatalog(): EquipmentCatalogConfig {
       ...(entry.specialEffect ? { specialEffect: { ...entry.specialEffect } } : {})
     }))
   };
+
+  validateEquipmentCatalog(config);
+  return config;
 }
 
 export function getEquipmentDefinition(equipmentId: string): EquipmentDefinition | undefined {

--- a/packages/shared/test/equipment.test.ts
+++ b/packages/shared/test/equipment.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getDefaultEquipmentCatalog, validateEquipmentCatalog } from "../src/index.ts";
+
+test("validateEquipmentCatalog accepts the shipped catalog", () => {
+  assert.doesNotThrow(() => validateEquipmentCatalog(getDefaultEquipmentCatalog()));
+});
+
+test("validateEquipmentCatalog rejects stale equipment stat keys", () => {
+  const catalog = getDefaultEquipmentCatalog();
+  const brokenEntry = {
+    ...catalog.entries[0]!,
+    bonuses: {
+      ...catalog.entries[0]!.bonuses,
+      magicResist: 4
+    }
+  };
+
+  assert.throws(
+    () =>
+      validateEquipmentCatalog({
+        entries: [brokenEntry, ...catalog.entries.slice(1)]
+      }),
+    /unknown equipment stat bonus: magicResist/
+  );
+});

--- a/scripts/test/validate-content-pack.test.ts
+++ b/scripts/test/validate-content-pack.test.ts
@@ -40,7 +40,9 @@ async function seedContentPackRoot(tempDir: string): Promise<void> {
       "phase2-map-objects-contested-basin.json",
       "units.json",
       "battle-skills.json",
-      "battle-balance.json"
+      "battle-balance.json",
+      "hero-skills.json",
+      "hero-skill-trees-full.json"
     ].map((fileName) => copyConfigFixture(tempDir, fileName))
   );
 }
@@ -199,6 +201,30 @@ test("validate-content-pack fails on typed hero progression and equipment author
       assert.match(error.stdout ?? "", /hero_equipment_legacy_trinket_ids/);
       assert.match(error.stdout ?? "", /hero_inventory_capacity_exceeded/);
       assert.match(error.stdout ?? "", /Suggestion:/);
+      return true;
+    }
+  );
+});
+
+test("validate-content-pack fails on unknown hero skill battle-skill references", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "veil-content-pack-"));
+  await seedContentPackRoot(tempDir);
+
+  const heroSkillsPath = join(tempDir, "hero-skill-trees-full.json");
+  const heroSkills = JSON.parse(await readFile(heroSkillsPath, "utf8")) as {
+    skills: Array<{ ranks: Array<{ battleSkillIds?: string[] }> }>;
+  };
+
+  heroSkills.skills[0]!.ranks[0]!.battleSkillIds = ["missing_skill"];
+  await writeFile(heroSkillsPath, `${JSON.stringify(heroSkills, null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    execFileAsync("node", ["--import", "tsx", scriptPath, "--root-dir", tempDir], { cwd: repoRoot }),
+    (error: NodeJS.ErrnoException & { stdout?: string }) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stdout ?? "", /Authoring config validation: 1 issue\(s\)/);
+      assert.match(error.stdout ?? "", /\[heroSkills\] hero-skill-trees-full\.json/);
+      assert.match(error.stdout ?? "", /references unknown battle skill: missing_skill/);
       return true;
     }
   );

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -2,10 +2,13 @@ import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  getDefaultEquipmentCatalog,
   getDefaultBattleBalanceConfig,
   validateBattleBalanceConfig,
   validateBattleSkillCatalog,
   validateContentPackConsistency,
+  validateEquipmentCatalog,
+  validateHeroSkillTreeConfig,
   validateMapObjectsConfig,
   validateUnitCatalog,
   validateWorldConfig,
@@ -13,6 +16,7 @@ import {
   type BattleSkillCatalogConfig,
   type ContentPackDocumentId,
   type ContentPackValidationIssue,
+  type HeroSkillTreeConfig,
   type MapObjectsConfig,
   type RuntimeConfigBundle,
   type UnitCatalogConfig,
@@ -24,9 +28,11 @@ import {
   type ContentPackMapPackDefinition
 } from "./content-pack-map-packs.ts";
 
+type ValidationDocumentId = ContentPackDocumentId | "heroSkills" | "equipment";
+
 interface DocumentValidationIssue {
   bundleId: string;
-  documentId: ContentPackDocumentId;
+  documentId: ValidationDocumentId;
   path: string;
   message: string;
 }
@@ -60,6 +66,11 @@ export interface ContentPackCliReport {
   valid: boolean;
   bundleCount: number;
   documentValidation: {
+    valid: boolean;
+    issueCount: number;
+    issues: DocumentValidationIssue[];
+  };
+  authoringValidation: {
     valid: boolean;
     issueCount: number;
     issues: DocumentValidationIssue[];
@@ -174,12 +185,43 @@ async function loadBundle(rootDir: string, definition: ContentPackMapPackDefinit
   };
 }
 
+async function validateAuthoringConfigs(
+  rootDir: string,
+  battleSkills: BattleSkillCatalogConfig
+): Promise<DocumentValidationIssue[]> {
+  const issues: DocumentValidationIssue[] = [];
+  const capture = (documentId: ValidationDocumentId, path: string, callback: () => void) => {
+    try {
+      callback();
+    } catch (error) {
+      issues.push({
+        bundleId: "global",
+        documentId,
+        path,
+        message: error instanceof Error ? error.message : "Unknown validation error"
+      });
+    }
+  };
+
+  const [compactHeroSkills, fullHeroSkills] = await Promise.all([
+    readJsonConfig<HeroSkillTreeConfig>(rootDir, "hero-skills.json"),
+    readJsonConfig<HeroSkillTreeConfig>(rootDir, "hero-skill-trees-full.json")
+  ]);
+
+  capture("heroSkills", "hero-skills.json", () => validateHeroSkillTreeConfig(compactHeroSkills, battleSkills));
+  capture("heroSkills", "hero-skill-trees-full.json", () => validateHeroSkillTreeConfig(fullHeroSkills, battleSkills));
+  capture("equipment", "packages/shared/src/equipment.ts", () => validateEquipmentCatalog(getDefaultEquipmentCatalog()));
+
+  return issues;
+}
+
 export async function buildContentPackCliReport(options: {
   rootDir?: string;
   extraMapPacks?: ContentPackMapPackDefinition[];
 } = {}): Promise<ContentPackCliReport> {
   const rootDir = options.rootDir ?? resolve(process.cwd(), "configs");
   const bundleDefinitions = [DEFAULT_CONTENT_PACK_MAP_PACK, ...(options.extraMapPacks ?? [])];
+  const battleSkills = await readJsonConfig<BattleSkillCatalogConfig>(rootDir, "battle-skills.json");
   const bundles = await Promise.all(
     bundleDefinitions.map(async (definition): Promise<BundleValidationReport> => {
       const bundle = await loadBundle(rootDir, definition);
@@ -210,17 +252,23 @@ export async function buildContentPackCliReport(options: {
   );
 
   const documentIssues = bundles.flatMap((bundle) => bundle.documentValidation.issues);
+  const authoringIssues = await validateAuthoringConfigs(rootDir, battleSkills);
   const contentPackIssues = bundles.flatMap((bundle) => bundle.contentPack.issues);
   return {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
     rootDir,
-    valid: bundles.every((bundle) => bundle.valid),
+    valid: bundles.every((bundle) => bundle.valid) && authoringIssues.length === 0,
     bundleCount: bundles.length,
     documentValidation: {
       valid: documentIssues.length === 0,
       issueCount: documentIssues.length,
       issues: documentIssues
+    },
+    authoringValidation: {
+      valid: authoringIssues.length === 0,
+      issueCount: authoringIssues.length,
+      issues: authoringIssues
     },
     contentPack: {
       valid: contentPackIssues.length === 0,
@@ -246,6 +294,7 @@ async function main(): Promise<void> {
   console.log(`Root: ${rootDir}`);
   console.log(`Bundles: ${report.bundleCount}`);
   console.log(`Result: ${report.valid ? "PASS" : "FAIL"}`);
+  printIssues("Authoring config validation", report.authoringValidation.issues);
   for (const bundle of report.bundles) {
     console.log(
       `Bundle: ${bundle.id} (${bundle.worldFileName} + ${bundle.mapObjectsFileName})`


### PR DESCRIPTION
## Summary
- extend content-pack validation to check authored hero-skill tree battle skill references alongside bundle consistency
- add runtime validation for equipment stat bonus keys and cover it with shared tests
- fail CI when any shipped content-pack variant drifts by running the all-pack validation step

## Validation
- `node --import tsx --test packages/shared/test/equipment.test.ts`
- `node --import tsx --test scripts/test/validate-content-pack.test.ts`
- `npm run validate:content-pack`
- `npm run validate:content-pack:all`
- `npm run typecheck:ci`
- `npm test` currently fails in pre-existing unrelated suites outside this change (H5 session fallback, Cocos runtime/smoke, release-readiness dashboard, admin ban/lifecycle tests)

Closes #926
