### PR TITLE
Add weekly daily dungeon rotation

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -230,6 +230,10 @@ interface PlayerSeasonProgressApiPayload {
 interface DailyDungeonApiPayload {
   dailyDungeon?: {
     dungeon?: Partial<DailyDungeonDefinition> & {
+      activeWindow?: {
+        startDate?: string;
+        endDate?: string;
+      };
       floors?: Array<{
         floor?: number;
         recommendedHeroLevel?: number;
@@ -449,6 +453,9 @@ function normalizeDailyDungeonSummary(
   const dungeonId = payload?.dungeon?.id?.trim();
   const dungeonName = payload?.dungeon?.name?.trim();
   const dungeonDescription = payload?.dungeon?.description?.trim();
+  const dateKey = payload?.dateKey?.trim() || new Date().toISOString().slice(0, 10);
+  const activeWindowStartDate = payload?.dungeon?.activeWindow?.startDate?.trim() || dateKey;
+  const activeWindowEndDate = payload?.dungeon?.activeWindow?.endDate?.trim() || activeWindowStartDate;
   const rawFloors = payload?.dungeon?.floors ?? [];
   if (!dungeonId || !dungeonName || !dungeonDescription || rawFloors.length === 0) {
     return null;
@@ -482,9 +489,13 @@ function normalizeDailyDungeonSummary(
       name: dungeonName,
       description: dungeonDescription,
       attemptLimit: Math.max(1, Math.floor(payload?.dungeon?.attemptLimit ?? floors.length)),
+      activeWindow: {
+        startDate: activeWindowStartDate,
+        endDate: activeWindowEndDate
+      },
       floors
     },
-    dateKey: payload?.dateKey?.trim() || new Date().toISOString().slice(0, 10),
+    dateKey,
     attemptsUsed: Math.max(0, Math.floor(payload?.attemptsUsed ?? 0)),
     attemptsRemaining: Math.max(0, Math.floor(payload?.attemptsRemaining ?? 0)),
     runs: normalizeDailyDungeonRuns(payload?.runs)

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -59,7 +59,7 @@ import {
   claimDailyDungeonRunReward,
   completeCampaignMission,
   resolveCampaignConfig,
-  resolveDailyDungeonConfig,
+  resolveActiveDailyDungeon,
   startDailyDungeonRun
 } from "./pve-content";
 import { decryptWechatPhoneNumber, validateWechatSignature } from "./wechat-session-key";
@@ -528,8 +528,8 @@ function toCampaignResponse(account: PlayerAccountSnapshot, accessContext?: Camp
   };
 }
 
-function resolvePrimaryDailyDungeon() {
-  const [dungeon] = resolveDailyDungeonConfig();
+function resolvePrimaryDailyDungeon(now = new Date()) {
+  const dungeon = resolveActiveDailyDungeon(now);
   if (!dungeon) {
     throw new Error("daily_dungeon_not_configured");
   }
@@ -537,7 +537,7 @@ function resolvePrimaryDailyDungeon() {
 }
 
 function toDailyDungeonResponse(account: PlayerAccountSnapshot, now = new Date()) {
-  return buildDailyDungeonSummary(resolvePrimaryDailyDungeon(), account.dailyDungeonState, now);
+  return buildDailyDungeonSummary(resolvePrimaryDailyDungeon(now), account.dailyDungeonState, now);
 }
 
 function toRewardMutation(

--- a/apps/server/src/pve-content.ts
+++ b/apps/server/src/pve-content.ts
@@ -19,7 +19,11 @@ import type {
   MissionObjective,
   RankDivisionId
 } from "../../../packages/shared/src/index";
-import { getRankDivisionIndex, resolveCosmeticCatalog } from "../../../packages/shared/src/index";
+import {
+  getRankDivisionIndex,
+  resolveCosmeticCatalog,
+  validateDailyDungeonConfigDocument
+} from "../../../packages/shared/src/index";
 import { getDailyRewardDateKey } from "./daily-rewards";
 
 interface CampaignConfigMissionDocument {
@@ -47,7 +51,12 @@ interface CampaignConfigDocument {
 }
 
 interface DailyDungeonConfigDocument {
-  dungeons?: Array<Partial<DailyDungeonDefinition> & { floors?: Partial<DailyDungeonFloor>[] | null }> | null;
+  dungeons?: Array<
+    Partial<DailyDungeonDefinition> & {
+      activeWindow?: Partial<DailyDungeonDefinition["activeWindow"]> | null;
+      floors?: Partial<DailyDungeonFloor>[] | null;
+    }
+  > | null;
 }
 
 export interface CampaignAccessContext {
@@ -425,12 +434,18 @@ export function resolveDailyDungeonConfig(
     throw new Error("daily dungeon config must define at least one dungeon");
   }
 
-  return rawDungeons.map((rawDungeon, dungeonIndex) => {
+  const dungeons = rawDungeons.map((rawDungeon, dungeonIndex) => {
     const id = rawDungeon.id?.trim();
     const name = rawDungeon.name?.trim();
     const description = rawDungeon.description?.trim();
     if (!id || !name || !description) {
       throw new Error(`daily dungeon[${dungeonIndex}] must define id, name, and description`);
+    }
+
+    const startDate = rawDungeon.activeWindow?.startDate?.trim();
+    const endDate = rawDungeon.activeWindow?.endDate?.trim();
+    if (!startDate || !endDate) {
+      throw new Error(`daily dungeon ${id} must define activeWindow.startDate and activeWindow.endDate`);
     }
 
     const floors = (rawDungeon.floors ?? []).map((rawFloor, floorIndex) => {
@@ -469,9 +484,47 @@ export function resolveDailyDungeonConfig(
       name,
       description,
       attemptLimit: normalizeNonNegativeInteger(rawDungeon.attemptLimit, `daily dungeon ${id} attemptLimit`, 1),
+      activeWindow: {
+        startDate,
+        endDate
+      },
       floors: floors.sort((left, right) => left.floor - right.floor)
     } satisfies DailyDungeonDefinition;
   });
+
+  const issues = validateDailyDungeonConfigDocument({ dungeons });
+  if (issues.length > 0) {
+    const [firstIssue] = issues;
+    throw new Error(`daily dungeon config invalid at ${firstIssue?.path}: ${firstIssue?.message}`);
+  }
+
+  return dungeons.sort(
+    (left, right) =>
+      left.activeWindow.startDate.localeCompare(right.activeWindow.startDate) || left.id.localeCompare(right.id)
+  );
+}
+
+export function resolveActiveDailyDungeon(
+  now = new Date(),
+  document: DailyDungeonConfigDocument = dailyDungeonsDocument as DailyDungeonConfigDocument
+): DailyDungeonDefinition {
+  const dateKey = getDailyRewardDateKey(now);
+  const activeDungeons = resolveDailyDungeonConfig(document).filter(
+    (dungeon) => dateKey >= dungeon.activeWindow.startDate && dateKey <= dungeon.activeWindow.endDate
+  );
+  if (activeDungeons.length === 0) {
+    throw new Error(`daily_dungeon_not_active_for_${dateKey}`);
+  }
+  if (activeDungeons.length > 1) {
+    throw new Error(`daily_dungeon_rotation_overlap_for_${dateKey}`);
+  }
+
+  const [activeDungeon] = activeDungeons;
+  if (!activeDungeon) {
+    throw new Error(`daily_dungeon_not_active_for_${dateKey}`);
+  }
+
+  return activeDungeon;
 }
 
 export function getCurrentDailyDungeonState(state?: DailyDungeonState | null, now = new Date()): DailyDungeonState {

--- a/apps/server/test/pve-content.test.ts
+++ b/apps/server/test/pve-content.test.ts
@@ -5,6 +5,7 @@ import {
   buildDailyDungeonSummary,
   claimDailyDungeonRunReward,
   getCurrentDailyDungeonState,
+  resolveActiveDailyDungeon,
   resolveCampaignConfig,
   resolveDailyDungeonConfig,
   startDailyDungeonRun
@@ -78,7 +79,7 @@ test("campaign chapter gates require prior chapter clears, hero level 15, and si
 });
 
 test("daily dungeon state resets by date key and enforces one-time reward claims per run", () => {
-  const [dungeon] = resolveDailyDungeonConfig();
+  const dungeon = resolveActiveDailyDungeon(new Date("2026-04-06T02:00:00.000Z"));
   assert.ok(dungeon);
 
   const started = startDailyDungeonRun(dungeon, undefined, 2, new Date("2026-04-04T02:00:00.000Z"));
@@ -96,4 +97,113 @@ test("daily dungeon state resets by date key and enforces one-time reward claims
   assert.equal(reset.dateKey, "2026-04-05");
   assert.equal(reset.attemptsUsed, 0);
   assert.deepEqual(reset.runs, []);
+});
+
+test("daily dungeon config includes weekly windows and resolves the active rotation by date", () => {
+  const dungeons = resolveDailyDungeonConfig();
+
+  assert.equal(dungeons.length, 5);
+  assert.deepEqual(
+    dungeons.map((dungeon) => dungeon.id),
+    ["shadow-archives", "ember-forge", "tideworn-sanctum", "verdant-maze", "stormglass-spire"]
+  );
+  assert.deepEqual(
+    dungeons.map((dungeon) => dungeon.activeWindow.startDate),
+    ["2026-04-06", "2026-04-13", "2026-04-20", "2026-04-27", "2026-05-04"]
+  );
+  assert.equal(resolveActiveDailyDungeon(new Date("2026-04-08T12:00:00.000Z")).id, "shadow-archives");
+  assert.equal(resolveActiveDailyDungeon(new Date("2026-04-15T12:00:00.000Z")).id, "ember-forge");
+  assert.equal(resolveActiveDailyDungeon(new Date("2026-04-22T12:00:00.000Z")).id, "tideworn-sanctum");
+  assert.equal(resolveActiveDailyDungeon(new Date("2026-04-29T12:00:00.000Z")).id, "verdant-maze");
+  assert.equal(resolveActiveDailyDungeon(new Date("2026-05-06T12:00:00.000Z")).id, "stormglass-spire");
+});
+
+test("daily dungeon config validation rejects malformed weekly windows", () => {
+  assert.throws(
+    () =>
+      resolveDailyDungeonConfig({
+        dungeons: [
+          {
+            id: "broken-rotation",
+            name: "Broken Rotation",
+            description: "Invalid authored window",
+            attemptLimit: 3,
+            activeWindow: {
+              startDate: "2026-04-06",
+              endDate: "2026-04-10"
+            },
+            floors: [
+              {
+                floor: 1,
+                recommendedHeroLevel: 1,
+                enemyArmyTemplateId: "wolf_pack",
+                enemyArmyCount: 10,
+                enemyStatMultiplier: 1.1,
+                reward: { gems: 5 }
+              }
+            ]
+          }
+        ]
+      }),
+    /activeWindow must span exactly 7 calendar days/
+  );
+});
+
+test("daily dungeon rotation rejects gaps and overlapping active windows", () => {
+  assert.throws(
+    () => resolveActiveDailyDungeon(new Date("2026-04-05T12:00:00.000Z")),
+    /daily_dungeon_not_active_for_2026-04-05/
+  );
+
+  assert.throws(
+    () =>
+      resolveActiveDailyDungeon(
+        new Date("2026-04-08T12:00:00.000Z"),
+        {
+          dungeons: [
+            {
+              id: "shadow-archives",
+              name: "Shadow Archives",
+              description: "Baseline window",
+              attemptLimit: 3,
+              activeWindow: {
+                startDate: "2026-04-06",
+                endDate: "2026-04-12"
+              },
+              floors: [
+                {
+                  floor: 1,
+                  recommendedHeroLevel: 1,
+                  enemyArmyTemplateId: "wolf_pack",
+                  enemyArmyCount: 10,
+                  enemyStatMultiplier: 1.1,
+                  reward: { gems: 5 }
+                }
+              ]
+            },
+            {
+              id: "ember-forge",
+              name: "Ember Forge",
+              description: "Overlapping window",
+              attemptLimit: 3,
+              activeWindow: {
+                startDate: "2026-04-08",
+                endDate: "2026-04-14"
+              },
+              floors: [
+                {
+                  floor: 1,
+                  recommendedHeroLevel: 1,
+                  enemyArmyTemplateId: "hero_guard_basic",
+                  enemyArmyCount: 10,
+                  enemyStatMultiplier: 1.1,
+                  reward: { gems: 5 }
+                }
+              ]
+            }
+          ]
+        }
+      ),
+    /activeWindow overlaps with dungeon "shadow-archives"/
+  );
 });

--- a/configs/daily-dungeons.json
+++ b/configs/daily-dungeons.json
@@ -3,15 +3,19 @@
     {
       "id": "shadow-archives",
       "name": "Shadow Archives",
-      "description": "A rotating solo dungeon with limited daily entries and floor rewards.",
+      "description": "Dust-clogged shelves and sealed scriptoria where scouting parties disappear between lantern pools.",
       "attemptLimit": 3,
+      "activeWindow": {
+        "startDate": "2026-04-06",
+        "endDate": "2026-04-12"
+      },
       "floors": [
         {
           "floor": 1,
           "recommendedHeroLevel": 2,
           "enemyArmyTemplateId": "wolf_pack",
           "enemyArmyCount": 14,
-          "enemyStatMultiplier": 1.2,
+          "enemyStatMultiplier": 1.15,
           "reward": { "gems": 10, "resources": { "gold": 160 } }
         },
         {
@@ -19,16 +23,160 @@
           "recommendedHeroLevel": 3,
           "enemyArmyTemplateId": "hero_guard_basic",
           "enemyArmyCount": 18,
-          "enemyStatMultiplier": 1.45,
-          "reward": { "gems": 15, "resources": { "gold": 220, "ore": 10 } }
+          "enemyStatMultiplier": 1.4,
+          "reward": { "gems": 14, "resources": { "gold": 220, "ore": 10 } }
         },
         {
           "floor": 3,
           "recommendedHeroLevel": 4,
-          "enemyArmyTemplateId": "hero_guard_basic",
+          "enemyArmyTemplateId": "shadow_hexer",
           "enemyArmyCount": 22,
           "enemyStatMultiplier": 1.7,
           "reward": { "gems": 20, "resources": { "gold": 300, "wood": 15 } }
+        }
+      ]
+    },
+    {
+      "id": "ember-forge",
+      "name": "Ember Forge",
+      "description": "Collapsed smelting halls packed with heat blooms, armored sentries, and punishing attrition.",
+      "attemptLimit": 3,
+      "activeWindow": {
+        "startDate": "2026-04-13",
+        "endDate": "2026-04-19"
+      },
+      "floors": [
+        {
+          "floor": 1,
+          "recommendedHeroLevel": 4,
+          "enemyArmyTemplateId": "crown_crossbowman",
+          "enemyArmyCount": 20,
+          "enemyStatMultiplier": 1.35,
+          "reward": { "gems": 12, "resources": { "gold": 200, "ore": 12 } }
+        },
+        {
+          "floor": 2,
+          "recommendedHeroLevel": 5,
+          "enemyArmyTemplateId": "iron_walker",
+          "enemyArmyCount": 24,
+          "enemyStatMultiplier": 1.7,
+          "reward": { "gems": 18, "resources": { "gold": 280, "ore": 20 } }
+        },
+        {
+          "floor": 3,
+          "recommendedHeroLevel": 7,
+          "enemyArmyTemplateId": "crown_heavy_cavalry",
+          "enemyArmyCount": 26,
+          "enemyStatMultiplier": 2.05,
+          "reward": { "gems": 24, "resources": { "gold": 360, "wood": 18, "ore": 24 } }
+        }
+      ]
+    },
+    {
+      "id": "tideworn-sanctum",
+      "name": "Tideworn Sanctum",
+      "description": "A drowned shrine where each descent trades simple skirmishes for higher-count swarming pressure.",
+      "attemptLimit": 3,
+      "activeWindow": {
+        "startDate": "2026-04-20",
+        "endDate": "2026-04-26"
+      },
+      "floors": [
+        {
+          "floor": 1,
+          "recommendedHeroLevel": 5,
+          "enemyArmyTemplateId": "moss_stalker",
+          "enemyArmyCount": 18,
+          "enemyStatMultiplier": 1.3,
+          "reward": { "gems": 12, "resources": { "gold": 210, "wood": 14 } }
+        },
+        {
+          "floor": 2,
+          "recommendedHeroLevel": 6,
+          "enemyArmyTemplateId": "wild_serpent",
+          "enemyArmyCount": 25,
+          "enemyStatMultiplier": 1.55,
+          "reward": { "gems": 16, "resources": { "gold": 260, "wood": 22 } }
+        },
+        {
+          "floor": 3,
+          "recommendedHeroLevel": 8,
+          "enemyArmyTemplateId": "shadow_wraith",
+          "enemyArmyCount": 32,
+          "enemyStatMultiplier": 1.8,
+          "reward": { "gems": 22, "resources": { "gold": 340, "wood": 30, "ore": 12 } }
+        }
+      ]
+    },
+    {
+      "id": "verdant-maze",
+      "name": "Verdant Maze",
+      "description": "Overgrown battlements where the route stays manageable early, then spikes sharply at the canopy heart.",
+      "attemptLimit": 3,
+      "activeWindow": {
+        "startDate": "2026-04-27",
+        "endDate": "2026-05-03"
+      },
+      "floors": [
+        {
+          "floor": 1,
+          "recommendedHeroLevel": 3,
+          "enemyArmyTemplateId": "wild_hawk_rider",
+          "enemyArmyCount": 16,
+          "enemyStatMultiplier": 1.25,
+          "reward": { "gems": 11, "resources": { "gold": 180, "wood": 12 } }
+        },
+        {
+          "floor": 2,
+          "recommendedHeroLevel": 4,
+          "enemyArmyTemplateId": "moss_stalker",
+          "enemyArmyCount": 21,
+          "enemyStatMultiplier": 1.45,
+          "reward": { "gems": 15, "resources": { "gold": 240, "wood": 18, "ore": 8 } }
+        },
+        {
+          "floor": 3,
+          "recommendedHeroLevel": 7,
+          "enemyArmyTemplateId": "wild_cave_troll",
+          "enemyArmyCount": 23,
+          "enemyStatMultiplier": 2.15,
+          "reward": { "gems": 23, "resources": { "gold": 330, "wood": 26, "ore": 16 } }
+        }
+      ]
+    },
+    {
+      "id": "stormglass-spire",
+      "name": "Stormglass Spire",
+      "description": "A lightning-raked tower tuned as the hardest rotation, with every floor demanding stronger burst and sustain.",
+      "attemptLimit": 3,
+      "activeWindow": {
+        "startDate": "2026-05-04",
+        "endDate": "2026-05-10"
+      },
+      "floors": [
+        {
+          "floor": 1,
+          "recommendedHeroLevel": 6,
+          "enemyArmyTemplateId": "crown_field_chaplain",
+          "enemyArmyCount": 22,
+          "enemyStatMultiplier": 1.6,
+          "reward": { "gems": 14, "resources": { "gold": 230, "ore": 14 } }
+        },
+        {
+          "floor": 2,
+          "recommendedHeroLevel": 8,
+          "enemyArmyTemplateId": "shadow_wraith",
+          "enemyArmyCount": 27,
+          "enemyStatMultiplier": 1.95,
+          "reward": { "gems": 20, "resources": { "gold": 310, "wood": 18, "ore": 18 } }
+        },
+        {
+          "floor": 3,
+          "recommendedHeroLevel": 10,
+          "enemyArmyTemplateId": "shadow_death_knight",
+          "enemyArmyCount": 30,
+          "enemyStatMultiplier": 2.35,
+          "reward": { "gems": 28, "resources": { "gold": 420, "wood": 24, "ore": 30 } }
         }
       ]
     }

--- a/packages/shared/src/daily-dungeons.ts
+++ b/packages/shared/src/daily-dungeons.ts
@@ -1,0 +1,159 @@
+import type {
+  DailyDungeonActiveWindow,
+  DailyDungeonDefinition,
+  DailyDungeonFloor
+} from "./models.ts";
+
+export interface DailyDungeonConfigDocument {
+  dungeons: DailyDungeonDefinition[];
+}
+
+export interface DailyDungeonValidationIssue {
+  path: string;
+  message: string;
+}
+
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const SEVEN_DAY_WINDOW_MS = 6 * 24 * 60 * 60 * 1000;
+
+function isValidDateKey(value: string): boolean {
+  return DATE_KEY_PATTERN.test(value) && !Number.isNaN(Date.parse(`${value}T00:00:00.000Z`));
+}
+
+function toUtcMidnight(dateKey: string): number {
+  return Date.parse(`${dateKey}T00:00:00.000Z`);
+}
+
+function validateRewardPresence(path: string, floor: DailyDungeonFloor, issues: DailyDungeonValidationIssue[]): void {
+  const reward = floor.reward ?? {};
+  const gemCount = reward.gems ?? 0;
+  const hasGems = Number.isInteger(gemCount) && gemCount > 0;
+  const resources = reward.resources ?? {};
+  const hasResources = ["gold", "wood", "ore"].some((key) => {
+    const amount = resources[key as keyof typeof resources] ?? 0;
+    return Number.isInteger(amount) && amount > 0;
+  });
+  if (!hasGems && !hasResources) {
+    issues.push({ path: `${path}.reward`, message: "Floor reward must grant at least one positive gem or resource payout." });
+  }
+}
+
+function validateWindow(path: string, window: DailyDungeonActiveWindow, issues: DailyDungeonValidationIssue[]): void {
+  if (!isValidDateKey(window.startDate)) {
+    issues.push({ path: `${path}.startDate`, message: "startDate must use YYYY-MM-DD." });
+  }
+  if (!isValidDateKey(window.endDate)) {
+    issues.push({ path: `${path}.endDate`, message: "endDate must use YYYY-MM-DD." });
+  }
+  if (!isValidDateKey(window.startDate) || !isValidDateKey(window.endDate)) {
+    return;
+  }
+  if (window.startDate > window.endDate) {
+    issues.push({ path, message: "activeWindow.startDate cannot be later than activeWindow.endDate." });
+    return;
+  }
+  if (toUtcMidnight(window.endDate) - toUtcMidnight(window.startDate) !== SEVEN_DAY_WINDOW_MS) {
+    issues.push({ path, message: "activeWindow must span exactly 7 calendar days for weekly rotation." });
+  }
+}
+
+export function validateDailyDungeonDefinition(
+  definition: DailyDungeonDefinition,
+  path = "dungeon"
+): DailyDungeonValidationIssue[] {
+  const issues: DailyDungeonValidationIssue[] = [];
+  if (!definition.id.trim()) {
+    issues.push({ path: `${path}.id`, message: "Dungeon id is required." });
+  }
+  if (!definition.name.trim()) {
+    issues.push({ path: `${path}.name`, message: "Dungeon name is required." });
+  }
+  if (!definition.description.trim()) {
+    issues.push({ path: `${path}.description`, message: "Dungeon description is required." });
+  }
+  if (!Number.isInteger(definition.attemptLimit) || definition.attemptLimit < 1) {
+    issues.push({ path: `${path}.attemptLimit`, message: "attemptLimit must be a positive integer." });
+  }
+  validateWindow(`${path}.activeWindow`, definition.activeWindow, issues);
+
+  if (!definition.floors.length) {
+    issues.push({ path: `${path}.floors`, message: "Dungeon must define at least one floor." });
+    return issues;
+  }
+
+  const floorNumbers = new Set<number>();
+  let previousFloor = 0;
+  for (const [index, floor] of definition.floors.entries()) {
+    const floorPath = `${path}.floors[${index}]`;
+    if (!Number.isInteger(floor.floor) || floor.floor < 1) {
+      issues.push({ path: `${floorPath}.floor`, message: "floor must be a positive integer." });
+    }
+    if (floorNumbers.has(floor.floor)) {
+      issues.push({ path: `${floorPath}.floor`, message: `Duplicate floor number ${floor.floor}.` });
+    } else {
+      floorNumbers.add(floor.floor);
+    }
+    if (floor.floor !== previousFloor + 1) {
+      issues.push({ path: `${floorPath}.floor`, message: "Floors must be sequential starting at 1." });
+    }
+    previousFloor = floor.floor;
+
+    if (!Number.isInteger(floor.recommendedHeroLevel) || floor.recommendedHeroLevel < 1) {
+      issues.push({ path: `${floorPath}.recommendedHeroLevel`, message: "recommendedHeroLevel must be a positive integer." });
+    }
+    if (!floor.enemyArmyTemplateId.trim()) {
+      issues.push({ path: `${floorPath}.enemyArmyTemplateId`, message: "enemyArmyTemplateId is required." });
+    }
+    if (!Number.isInteger(floor.enemyArmyCount) || floor.enemyArmyCount < 1) {
+      issues.push({ path: `${floorPath}.enemyArmyCount`, message: "enemyArmyCount must be a positive integer." });
+    }
+    if (typeof floor.enemyStatMultiplier !== "number" || !Number.isFinite(floor.enemyStatMultiplier) || floor.enemyStatMultiplier <= 0) {
+      issues.push({ path: `${floorPath}.enemyStatMultiplier`, message: "enemyStatMultiplier must be a positive number." });
+    }
+    validateRewardPresence(floorPath, floor, issues);
+  }
+
+  return issues;
+}
+
+export function validateDailyDungeonConfigDocument(
+  document: DailyDungeonConfigDocument
+): DailyDungeonValidationIssue[] {
+  const issues: DailyDungeonValidationIssue[] = [];
+  if (!document.dungeons.length) {
+    return [{ path: "dungeons", message: "Config must define at least one dungeon." }];
+  }
+
+  const dungeonIds = new Set<string>();
+  const windows: Array<{ index: number; id: string; window: DailyDungeonActiveWindow }> = [];
+
+  for (const [index, dungeon] of document.dungeons.entries()) {
+    const path = `dungeons[${index}]`;
+    if (dungeonIds.has(dungeon.id)) {
+      issues.push({ path: `${path}.id`, message: `Duplicate dungeon id "${dungeon.id}".` });
+    } else {
+      dungeonIds.add(dungeon.id);
+    }
+    issues.push(...validateDailyDungeonDefinition(dungeon, path));
+    windows.push({ index, id: dungeon.id, window: dungeon.activeWindow });
+  }
+
+  const validWindows = windows.filter(({ window }) => isValidDateKey(window.startDate) && isValidDateKey(window.endDate));
+  validWindows.sort((left, right) => left.window.startDate.localeCompare(right.window.startDate) || left.id.localeCompare(right.id));
+
+  for (let index = 1; index < validWindows.length; index += 1) {
+    const previous = validWindows[index - 1];
+    const current = validWindows[index];
+    if (!previous || !current) {
+      continue;
+    }
+    if (current.window.startDate <= previous.window.endDate) {
+      issues.push({
+        path: `dungeons[${current.index}].activeWindow`,
+        message: `activeWindow overlaps with dungeon "${previous.id}".`
+      });
+    }
+  }
+
+  return issues;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from "./analytics-events.ts";
 export * from "./content-pack-validation.ts";
 export * from "./cosmetics.ts";
 export * from "./daily-quests.ts";
+export * from "./daily-dungeons.ts";
 export * from "./daily-quest-rotation.ts";
 export * from "./deterministic-rng.ts";
 export * from "./equipment.ts";

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1339,11 +1339,17 @@ export interface DailyDungeonFloor {
   reward: DailyDungeonReward;
 }
 
+export interface DailyDungeonActiveWindow {
+  startDate: string;
+  endDate: string;
+}
+
 export interface DailyDungeonDefinition {
   id: string;
   name: string;
   description: string;
   attemptLimit: number;
+  activeWindow: DailyDungeonActiveWindow;
   floors: DailyDungeonFloor[];
 }
 

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -6,6 +6,7 @@ import {
   getDefaultBattleBalanceConfig,
   validateBattleBalanceConfig,
   validateBattleSkillCatalog,
+  validateDailyDungeonConfigDocument,
   validateContentPackConsistency,
   validateEquipmentCatalog,
   validateHeroSkillTreeConfig,
@@ -16,6 +17,7 @@ import {
   type BattleSkillCatalogConfig,
   type ContentPackDocumentId,
   type ContentPackValidationIssue,
+  type DailyDungeonConfigDocument,
   type HeroSkillTreeConfig,
   type MapObjectsConfig,
   type RuntimeConfigBundle,
@@ -28,7 +30,7 @@ import {
   type ContentPackMapPackDefinition
 } from "./content-pack-map-packs.ts";
 
-type ValidationDocumentId = ContentPackDocumentId | "heroSkills" | "equipment";
+type ValidationDocumentId = ContentPackDocumentId | "heroSkills" | "equipment" | "dailyDungeons";
 
 interface DocumentValidationIssue {
   bundleId: string;
@@ -203,14 +205,22 @@ async function validateAuthoringConfigs(
     }
   };
 
-  const [compactHeroSkills, fullHeroSkills] = await Promise.all([
+  const [compactHeroSkills, fullHeroSkills, dailyDungeons] = await Promise.all([
     readJsonConfig<HeroSkillTreeConfig>(rootDir, "hero-skills.json"),
-    readJsonConfig<HeroSkillTreeConfig>(rootDir, "hero-skill-trees-full.json")
+    readJsonConfig<HeroSkillTreeConfig>(rootDir, "hero-skill-trees-full.json"),
+    readJsonConfig<DailyDungeonConfigDocument>(rootDir, "daily-dungeons.json")
   ]);
 
   capture("heroSkills", "hero-skills.json", () => validateHeroSkillTreeConfig(compactHeroSkills, battleSkills));
   capture("heroSkills", "hero-skill-trees-full.json", () => validateHeroSkillTreeConfig(fullHeroSkills, battleSkills));
   capture("equipment", "packages/shared/src/equipment.ts", () => validateEquipmentCatalog(getDefaultEquipmentCatalog()));
+  capture("dailyDungeons", "daily-dungeons.json", () => {
+    const issues = validateDailyDungeonConfigDocument(dailyDungeons);
+    if (issues.length > 0) {
+      const [firstIssue] = issues;
+      throw new Error(`${firstIssue?.path}: ${firstIssue?.message}`);
+    }
+  });
 
   return issues;
 }


### PR DESCRIPTION
## Summary
- add weekly active windows for daily dungeon rotations and author five scheduled rotations
- validate authored daily dungeon windows and expose the active rotation on the server and shared models
- preserve active-window data in client summaries and cover the rotation behavior with tests

## Validation
- `npm run validate:content-pack`
- `node --import tsx --test ./apps/server/test/pve-content.test.ts`