### PR TITLE
[codex] Implement daily quest rotation and tracking

### DIFF
--- a/apps/server/src/daily-quest-config.ts
+++ b/apps/server/src/daily-quest-config.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs";
+import path from "node:path";
+import dailyQuestsDocument from "../../../configs/daily-quests.json";
+import type { DailyQuestDefinition } from "../../../packages/shared/src/index";
+
+export type DailyQuestTier = "common" | "rare" | "epic";
+
+export interface DailyQuestConfigDefinition extends DailyQuestDefinition {
+  tier: DailyQuestTier;
+}
+
+export interface DailyQuestConfigDocument {
+  schemaVersion: 1;
+  quests: DailyQuestConfigDefinition[];
+}
+
+export interface DailyQuestConfigValidationIssue {
+  path: string;
+  message: string;
+}
+
+const DEFAULT_DAILY_QUESTS_PATH = path.resolve(process.cwd(), "configs/daily-quests.json");
+const VALID_METRICS = new Set<DailyQuestDefinition["metric"]>(["hero_moves", "battle_wins", "resource_collections"]);
+const VALID_TIERS = new Set<DailyQuestTier>(["common", "rare", "epic"]);
+
+interface DailyQuestConfigRuntimeDependencies {
+  readFileSync(filePath: string, encoding: BufferEncoding): string;
+}
+
+const defaultRuntimeDependencies: DailyQuestConfigRuntimeDependencies = {
+  readFileSync: (filePath, encoding) => fs.readFileSync(filePath, encoding)
+};
+
+let runtimeDependencies = defaultRuntimeDependencies;
+let cachedConfig: DailyQuestConfigDocument | null = null;
+
+function normalizeNonNegativeInteger(value: number | null | undefined, fallback = 0): number {
+  const normalized = Math.floor(value ?? Number.NaN);
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    return fallback;
+  }
+  return normalized;
+}
+
+function normalizePositiveInteger(value: number | null | undefined, fallback: number): number {
+  const normalized = Math.floor(value ?? Number.NaN);
+  if (!Number.isFinite(normalized) || normalized < 1) {
+    return fallback;
+  }
+  return normalized;
+}
+
+export function normalizeDailyQuestConfigDocument(input?: Partial<DailyQuestConfigDocument> | null): DailyQuestConfigDocument {
+  const quests = Array.isArray(input?.quests) ? input.quests : [];
+  return {
+    schemaVersion: 1,
+    quests: quests
+      .filter((quest): quest is DailyQuestConfigDefinition => Boolean(quest && typeof quest === "object"))
+      .map((quest, index) => ({
+        id: typeof quest.id === "string" && quest.id.trim() ? quest.id.trim() : `daily-quest-${index + 1}`,
+        title: typeof quest.title === "string" ? quest.title.trim() : "",
+        description: typeof quest.description === "string" ? quest.description.trim() : "",
+        metric: VALID_METRICS.has(quest.metric) ? quest.metric : "hero_moves",
+        target: normalizePositiveInteger(quest.target, 1),
+        tier: VALID_TIERS.has(quest.tier) ? quest.tier : "common",
+        reward: {
+          gems: normalizeNonNegativeInteger(quest.reward?.gems, 0),
+          gold: normalizeNonNegativeInteger(quest.reward?.gold, 0)
+        }
+      }))
+  };
+}
+
+export function validateDailyQuestConfigDocument(document: DailyQuestConfigDocument): DailyQuestConfigValidationIssue[] {
+  const issues: DailyQuestConfigValidationIssue[] = [];
+  if (document.quests.length < 15) {
+    issues.push({ path: "quests", message: "Config must define at least 15 quests." });
+  }
+
+  const ids = new Set<string>();
+  const tierCounts = {
+    common: 0,
+    rare: 0,
+    epic: 0
+  };
+
+  for (const [index, quest] of document.quests.entries()) {
+    const pathPrefix = `quests[${index}]`;
+    if (!quest.id.trim()) {
+      issues.push({ path: `${pathPrefix}.id`, message: "Quest id is required." });
+    } else if (ids.has(quest.id)) {
+      issues.push({ path: `${pathPrefix}.id`, message: `Duplicate quest id "${quest.id}".` });
+    } else {
+      ids.add(quest.id);
+    }
+
+    if (!quest.title.trim()) {
+      issues.push({ path: `${pathPrefix}.title`, message: "Quest title is required." });
+    }
+    if (!quest.description.trim()) {
+      issues.push({ path: `${pathPrefix}.description`, message: "Quest description is required." });
+    }
+    if (!VALID_METRICS.has(quest.metric)) {
+      issues.push({ path: `${pathPrefix}.metric`, message: `Unsupported metric "${quest.metric}".` });
+    }
+    if (!VALID_TIERS.has(quest.tier)) {
+      issues.push({ path: `${pathPrefix}.tier`, message: `Unsupported tier "${quest.tier}".` });
+    } else {
+      tierCounts[quest.tier] += 1;
+    }
+    if (!Number.isInteger(quest.target) || quest.target < 1) {
+      issues.push({ path: `${pathPrefix}.target`, message: "target must be a positive integer." });
+    }
+    if (!Number.isInteger(quest.reward.gems) || quest.reward.gems < 0) {
+      issues.push({ path: `${pathPrefix}.reward.gems`, message: "gems must be a non-negative integer." });
+    }
+    if (!Number.isInteger(quest.reward.gold) || quest.reward.gold < 0) {
+      issues.push({ path: `${pathPrefix}.reward.gold`, message: "gold must be a non-negative integer." });
+    }
+    if ((quest.reward.gems ?? 0) <= 0 && (quest.reward.gold ?? 0) <= 0) {
+      issues.push({ path: `${pathPrefix}.reward`, message: "Quest reward must grant positive gems or gold." });
+    }
+  }
+
+  for (const tier of ["common", "rare", "epic"] as const) {
+    if (tierCounts[tier] === 0) {
+      issues.push({ path: "quests", message: `Config must define at least one ${tier} quest.` });
+    }
+  }
+
+  return issues;
+}
+
+function validateOrFallback(document: DailyQuestConfigDocument, source: string): DailyQuestConfigDocument {
+  const issues = validateDailyQuestConfigDocument(document);
+  if (issues.length === 0) {
+    return document;
+  }
+
+  console.warn(
+    `[DailyQuestConfig] Falling back after invalid config from ${source}: ${issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ")}`
+  );
+  return normalizeDailyQuestConfigDocument(dailyQuestsDocument as DailyQuestConfigDocument);
+}
+
+export function configureDailyQuestConfigRuntimeDependencies(overrides: Partial<DailyQuestConfigRuntimeDependencies>): void {
+  runtimeDependencies = {
+    ...runtimeDependencies,
+    ...overrides
+  };
+}
+
+export function resetDailyQuestConfigRuntimeDependencies(): void {
+  runtimeDependencies = defaultRuntimeDependencies;
+  cachedConfig = null;
+}
+
+export function loadDailyQuestConfig(env: NodeJS.ProcessEnv = process.env): DailyQuestConfigDocument {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+
+  const configuredPath = env.VEIL_DAILY_QUESTS_PATH?.trim() || DEFAULT_DAILY_QUESTS_PATH;
+  try {
+    const raw = runtimeDependencies.readFileSync(configuredPath, "utf8");
+    cachedConfig = validateOrFallback(
+      normalizeDailyQuestConfigDocument(JSON.parse(raw) as DailyQuestConfigDocument),
+      configuredPath
+    );
+  } catch (error) {
+    console.warn(`[DailyQuestConfig] Falling back to bundled defaults after failing to load ${configuredPath}`, error);
+    cachedConfig = normalizeDailyQuestConfigDocument(dailyQuestsDocument as DailyQuestConfigDocument);
+  }
+
+  return cachedConfig;
+}

--- a/apps/server/src/daily-quests.ts
+++ b/apps/server/src/daily-quests.ts
@@ -6,8 +6,10 @@ import {
   type EventLogEntry,
   type FeatureFlags
 } from "../../../packages/shared/src/index";
-import type { PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
-import { resolveDailyQuestRotation } from "./daily-quest-rotations";
+import { emitAnalyticsEvent } from "./analytics";
+import { loadDailyQuestConfig, type DailyQuestConfigDefinition } from "./daily-quest-config";
+import { rotateDailyQuests } from "./event-engine";
+import type { PlayerAccountSnapshot, PlayerQuestState, RoomSnapshotStore } from "./persistence";
 
 export function readDailyQuestFeatureEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const normalized = env.VEIL_DAILY_QUESTS_ENABLED?.trim().toLowerCase();
@@ -43,6 +45,70 @@ export function createDailyQuestClaimEventLogEntry(
   };
 }
 
+function createDisabledBoard(): DailyQuestBoard {
+  return {
+    enabled: false,
+    availableClaims: 0,
+    pendingRewards: createEmptyDailyQuestReward(),
+    quests: []
+  };
+}
+
+function updateCompletionTracking(state: PlayerQuestState, board: DailyQuestBoard): PlayerQuestState {
+  const completedQuestIds = board.quests.filter((quest) => quest.completed).map((quest) => quest.id);
+  const claimedQuestIds = board.quests.filter((quest) => quest.claimed).map((quest) => quest.id);
+
+  return {
+    ...state,
+    rotations: state.rotations.map((entry) =>
+      entry.dateKey === board.cycleKey
+        ? {
+            ...entry,
+            completedQuestIds: Array.from(new Set(completedQuestIds)),
+            claimedQuestIds: Array.from(new Set(claimedQuestIds))
+          }
+        : entry
+    ),
+    updatedAt: new Date().toISOString()
+  };
+}
+
+async function resolveDailyQuestDefinitions(
+  store: RoomSnapshotStore,
+  playerId: string,
+  cycleKey: string
+): Promise<DailyQuestConfigDefinition[]> {
+  const rotation = rotateDailyQuests({
+    playerId,
+    dateKey: cycleKey,
+    questPool: loadDailyQuestConfig().quests,
+    questState: (await store.loadPlayerQuestState?.(playerId)) ?? null
+  });
+
+  if (rotation.rotated) {
+    await store.savePlayerQuestState?.(playerId, rotation.state);
+    const tierCounts = rotation.quests.reduce(
+      (counts, quest) => {
+        counts[quest.tier] += 1;
+        return counts;
+      },
+      { common: 0, rare: 0, epic: 0 }
+    );
+    emitAnalyticsEvent("QuestRotated", {
+      playerId,
+      roomId: "daily-quests",
+      payload: {
+        roomId: "daily-quests",
+        dateKey: cycleKey,
+        questIds: rotation.quests.map((quest) => quest.id),
+        tierCounts
+      }
+    });
+  }
+
+  return rotation.quests;
+}
+
 export async function loadDailyQuestBoard(
   store: RoomSnapshotStore,
   account: PlayerAccountSnapshot,
@@ -56,25 +122,33 @@ export async function loadDailyQuestBoard(
 ): Promise<DailyQuestBoard> {
   const enabled = typeof options === "boolean" ? options : options.enabled;
   if (!enabled) {
-    return {
-      enabled: false,
-      availableClaims: 0,
-      pendingRewards: createEmptyDailyQuestReward(),
-      quests: []
-    };
+    return createDisabledBoard();
   }
 
   const cycleKey = getDailyQuestCycleKey(now);
   const history = await store.loadPlayerEventHistory(account.playerId, {
     since: `${cycleKey}T00:00:00.000Z`
   });
-  const activeRotation =
-    resolveDailyQuestRotation(now, typeof options === "boolean" ? undefined : options.featureFlags) ?? null;
-
-  return buildDailyQuestBoard(history.items, {
+  const definitions = await resolveDailyQuestDefinitions(store, account.playerId, cycleKey);
+  const board = buildDailyQuestBoard(history.items, {
     enabled: true,
     cycleKey,
     resetAt: getDailyQuestResetAt(cycleKey),
-    ...(activeRotation ? { definitions: activeRotation.quests } : {})
+    definitions: definitions as DailyQuestDefinition[]
   });
+
+  const questState = await store.loadPlayerQuestState?.(account.playerId);
+  if (questState && board.cycleKey) {
+    const nextState = updateCompletionTracking(questState, board);
+    const currentEntry = questState.rotations.find((entry) => entry.dateKey === board.cycleKey);
+    const nextEntry = nextState.rotations.find((entry) => entry.dateKey === board.cycleKey);
+    if (
+      JSON.stringify(currentEntry?.completedQuestIds ?? []) !== JSON.stringify(nextEntry?.completedQuestIds ?? []) ||
+      JSON.stringify(currentEntry?.claimedQuestIds ?? []) !== JSON.stringify(nextEntry?.claimedQuestIds ?? [])
+    ) {
+      await store.savePlayerQuestState?.(account.playerId, nextState);
+    }
+  }
+
+  return board;
 }

--- a/apps/server/src/event-engine.ts
+++ b/apps/server/src/event-engine.ts
@@ -10,7 +10,8 @@ import type {
   SeasonalEventState
 } from "../../../packages/shared/src/index";
 import { validateAuthSessionFromRequest } from "./auth";
-import type { PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
+import type { DailyQuestConfigDefinition } from "./daily-quest-config";
+import type { PlayerAccountSnapshot, PlayerQuestRotationHistoryEntry, PlayerQuestState, RoomSnapshotStore } from "./persistence";
 
 interface SeasonalEventSummaryDocument {
   id?: string | null;
@@ -56,6 +57,170 @@ export interface SeasonalEventActionInput {
   actionType: SeasonalEventObjective["actionType"];
   dungeonId?: string;
   occurredAt?: string;
+}
+
+export interface RotateDailyQuestsInput {
+  playerId: string;
+  dateKey: string;
+  questPool: DailyQuestConfigDefinition[];
+  questState?: PlayerQuestState | null;
+}
+
+export interface RotateDailyQuestsResult {
+  quests: DailyQuestConfigDefinition[];
+  state: PlayerQuestState;
+  rotated: boolean;
+}
+
+const DAILY_QUEST_SELECTION_SIZE = 3;
+const DAILY_QUEST_NO_REPEAT_WINDOW_DAYS = 7;
+const DAILY_QUEST_TIER_WEIGHTS: Record<DailyQuestConfigDefinition["tier"], number> = {
+  common: 0.6,
+  rare: 0.3,
+  epic: 0.1
+};
+
+function isValidDateKey(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(`${value}T00:00:00.000Z`));
+}
+
+function toUtcDayIndex(dateKey: string): number {
+  return Math.floor(Date.parse(`${dateKey}T00:00:00.000Z`) / 86_400_000);
+}
+
+function createSeededRandom(seed: string): () => number {
+  let state = 2166136261;
+  for (let index = 0; index < seed.length; index += 1) {
+    state ^= seed.charCodeAt(index);
+    state = Math.imul(state, 16777619);
+  }
+
+  return () => {
+    state += 0x6d2b79f5;
+    let next = Math.imul(state ^ (state >>> 15), state | 1);
+    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+    return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function normalizeQuestIds(questIds: string[] | undefined): string[] {
+  return Array.from(new Set((questIds ?? []).map((questId) => questId?.trim()).filter((questId): questId is string => Boolean(questId))));
+}
+
+function normalizeQuestRotationEntry(entry: PlayerQuestRotationHistoryEntry): PlayerQuestRotationHistoryEntry {
+  return {
+    dateKey: entry.dateKey,
+    questIds: normalizeQuestIds(entry.questIds),
+    completedQuestIds: normalizeQuestIds(entry.completedQuestIds),
+    claimedQuestIds: normalizeQuestIds(entry.claimedQuestIds)
+  };
+}
+
+function trimQuestRotations(rotations: PlayerQuestRotationHistoryEntry[], dateKey: string): PlayerQuestRotationHistoryEntry[] {
+  const currentDayIndex = toUtcDayIndex(dateKey);
+  return rotations
+    .filter((entry) => isValidDateKey(entry.dateKey) && currentDayIndex - toUtcDayIndex(entry.dateKey) < DAILY_QUEST_NO_REPEAT_WINDOW_DAYS)
+    .map(normalizeQuestRotationEntry)
+    .sort((left, right) => left.dateKey.localeCompare(right.dateKey));
+}
+
+function pickWeightedQuest(
+  available: DailyQuestConfigDefinition[],
+  random: () => number
+): DailyQuestConfigDefinition {
+  const totalWeight = available.reduce((sum, quest) => sum + DAILY_QUEST_TIER_WEIGHTS[quest.tier], 0);
+  let cursor = random() * totalWeight;
+  for (const quest of available) {
+    cursor -= DAILY_QUEST_TIER_WEIGHTS[quest.tier];
+    if (cursor <= 0) {
+      return quest;
+    }
+  }
+
+  return available[available.length - 1]!;
+}
+
+function selectWeightedQuestSet(
+  questPool: DailyQuestConfigDefinition[],
+  random: () => number,
+  excludedQuestIds: Set<string>
+): DailyQuestConfigDefinition[] {
+  const selected: DailyQuestConfigDefinition[] = [];
+  let available = questPool.filter((quest) => !excludedQuestIds.has(quest.id)).sort((left, right) => left.id.localeCompare(right.id));
+  if (available.length < DAILY_QUEST_SELECTION_SIZE) {
+    available = questPool.slice().sort((left, right) => left.id.localeCompare(right.id));
+  }
+
+  while (selected.length < DAILY_QUEST_SELECTION_SIZE && available.length > 0) {
+    const choice = pickWeightedQuest(available, random);
+    selected.push(choice);
+    available = available.filter((quest) => quest.id !== choice.id);
+  }
+
+  return selected;
+}
+
+export function rotateDailyQuests(input: RotateDailyQuestsInput): RotateDailyQuestsResult {
+  if (!isValidDateKey(input.dateKey)) {
+    throw new Error(`rotateDailyQuests received invalid dateKey "${input.dateKey}"`);
+  }
+  if (input.questPool.length < DAILY_QUEST_SELECTION_SIZE) {
+    throw new Error("rotateDailyQuests requires at least three quest definitions");
+  }
+
+  const questPool = input.questPool.slice().sort((left, right) => left.id.localeCompare(right.id));
+  const existingState = input.questState ?? null;
+  const trimmedRotations = trimQuestRotations(existingState?.rotations ?? [], input.dateKey);
+  const currentRotation = trimmedRotations.find((entry) => entry.dateKey === input.dateKey);
+
+  if (currentRotation) {
+    const questById = new Map(questPool.map((quest) => [quest.id, quest]));
+    const quests = currentRotation.questIds
+      .map((questId) => questById.get(questId))
+      .filter((quest): quest is DailyQuestConfigDefinition => Boolean(quest));
+
+    return {
+      quests,
+      rotated: false,
+      state: {
+        playerId: input.playerId,
+        currentDateKey: input.dateKey,
+        activeQuestIds: currentRotation.questIds,
+        rotations: trimmedRotations,
+        updatedAt: existingState?.updatedAt ?? new Date().toISOString()
+      }
+    };
+  }
+
+  const excludedQuestIds = new Set(
+    trimmedRotations
+      .filter((entry) => entry.dateKey !== input.dateKey)
+      .flatMap((entry) => entry.questIds)
+  );
+  const selectedQuests = selectWeightedQuestSet(
+    questPool,
+    createSeededRandom(`${input.playerId}:${input.dateKey}`),
+    excludedQuestIds
+  );
+  const nextEntry: PlayerQuestRotationHistoryEntry = {
+    dateKey: input.dateKey,
+    questIds: selectedQuests.map((quest) => quest.id),
+    completedQuestIds: [],
+    claimedQuestIds: []
+  };
+  const nextRotations = trimQuestRotations([...trimmedRotations.filter((entry) => entry.dateKey !== input.dateKey), nextEntry], input.dateKey);
+
+  return {
+    quests: selectedQuests,
+    rotated: true,
+    state: {
+      playerId: input.playerId,
+      currentDateKey: input.dateKey,
+      activeQuestIds: nextEntry.questIds,
+      rotations: nextRotations,
+      updatedAt: new Date().toISOString()
+    }
+  };
 }
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -41,6 +41,7 @@ import {
   type PlayerAccountProfilePatch,
   type PlayerAccountProgressPatch,
   type PlayerAccountSnapshot,
+  type PlayerQuestState,
   type PlayerReportCreateInput,
   type PlayerReportListOptions,
   type PlayerReportRecord,
@@ -138,6 +139,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
   private readonly heroArchives = new Map<string, PlayerHeroArchiveSnapshot>();
+  private readonly playerQuestStates = new Map<string, PlayerQuestState>();
   private readonly shopPurchases = new Map<string, ShopPurchaseResult>();
   private readonly reports = new Map<string, PlayerReportRecord>();
   private readonly seasons = new Map<string, SeasonSnapshot>();
@@ -298,6 +300,10 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       total,
       items: structuredClone(sliced)
     };
+  }
+
+  async loadPlayerQuestState(playerId: string): Promise<PlayerQuestState | null> {
+    return structuredClone(this.playerQuestStates.get(normalizePlayerId(playerId)) ?? null);
   }
 
   async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {
@@ -1400,6 +1406,16 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     };
     this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     return cloneAccount(nextAccount);
+  }
+
+  async savePlayerQuestState(playerId: string, state: PlayerQuestState): Promise<PlayerQuestState> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const nextState: PlayerQuestState = {
+      ...structuredClone(state),
+      playerId: normalizedPlayerId
+    };
+    this.playerQuestStates.set(normalizedPlayerId, nextState);
+    return structuredClone(nextState);
   }
 
   async claimBattlePassTier(playerId: string, tier: number) {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -109,6 +109,7 @@ export interface RoomSnapshotStore {
   loadPlayerAccountByLoginId(loginId: string): Promise<PlayerAccountSnapshot | null>;
   loadPlayerAccountByWechatMiniGameOpenId(openId: string): Promise<PlayerAccountSnapshot | null>;
   loadPlayerEventHistory(playerId: string, query?: PlayerEventHistoryQuery): Promise<PlayerEventHistorySnapshot>;
+  loadPlayerQuestState?(playerId: string): Promise<PlayerQuestState | null>;
   loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]>;
   listPlayerReports?(options?: PlayerReportListOptions): Promise<PlayerReportRecord[]>;
   listPlayerBanHistory?(playerId: string, options?: PlayerAccountBanHistoryListOptions): Promise<PlayerBanHistoryRecord[]>;
@@ -164,6 +165,7 @@ export interface RoomSnapshotStore {
   resolvePlayerReport?(reportId: string, input: PlayerReportResolveInput): Promise<PlayerReportRecord | null>;
   savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot>;
   savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot>;
+  savePlayerQuestState?(playerId: string, state: PlayerQuestState): Promise<PlayerQuestState>;
   listPlayerAccounts(options?: PlayerAccountListOptions): Promise<PlayerAccountSnapshot[]>;
   getCurrentSeason(): Promise<SeasonSnapshot | null>;
   listSeasons?(options?: SeasonListOptions): Promise<SeasonSnapshot[]>;
@@ -307,6 +309,14 @@ interface PlayerEventHistoryRow extends RowDataPacket {
 
 interface PlayerEventHistoryCountRow extends RowDataPacket {
   total: number;
+}
+
+interface PlayerQuestStateRow extends RowDataPacket {
+  player_id: string;
+  current_date_key: string | null;
+  active_quest_ids_json: string | string[] | null;
+  rotations_json: string | PlayerQuestRotationHistoryEntry[] | null;
+  updated_at: Date | string;
 }
 
 interface PlayerBanHistoryRow extends RowDataPacket {
@@ -705,6 +715,21 @@ export interface PlayerEventHistorySnapshot {
   total: number;
 }
 
+export interface PlayerQuestRotationHistoryEntry {
+  dateKey: string;
+  questIds: string[];
+  completedQuestIds: string[];
+  claimedQuestIds: string[];
+}
+
+export interface PlayerQuestState {
+  playerId: string;
+  currentDateKey?: string;
+  activeQuestIds: string[];
+  rotations: PlayerQuestRotationHistoryEntry[];
+  updatedAt: string;
+}
+
 export interface PlayerAccountBanInput {
   banStatus: Exclude<PlayerBanStatus, "none">;
   banExpiry?: string;
@@ -762,6 +787,8 @@ export const MYSQL_PLAYER_BAN_HISTORY_TABLE = "player_ban_history";
 export const MYSQL_PLAYER_BAN_HISTORY_PLAYER_CREATED_INDEX = "idx_player_ban_history_player_created";
 export const MYSQL_PLAYER_EVENT_HISTORY_TABLE = "player_event_history";
 export const MYSQL_PLAYER_EVENT_HISTORY_TIMESTAMP_INDEX = "idx_player_event_history_player_time";
+export const MYSQL_PLAYER_QUEST_STATE_TABLE = "player_quest_states";
+export const MYSQL_PLAYER_QUEST_STATE_UPDATED_AT_INDEX = "idx_player_quest_states_updated_at";
 export const MYSQL_PLAYER_HERO_ARCHIVE_TABLE = "player_hero_archives";
 export const MYSQL_PLAYER_HERO_ARCHIVE_UPDATED_AT_INDEX = "idx_player_hero_archives_updated_at";
 export const MYSQL_PLAYER_REPORT_TABLE = "player_reports";
@@ -1748,6 +1775,59 @@ function normalizePlayerEventHistoryQuery(query: PlayerEventHistoryQuery = {}): 
   Pick<PlayerEventHistoryQuery, "category" | "heroId" | "achievementId" | "worldEventType" | "since" | "until"> &
   { limit?: number } {
   return normalizeEventLogQuery(query);
+}
+
+function normalizePlayerQuestState(state: Partial<PlayerQuestState> & Pick<PlayerQuestState, "playerId">): PlayerQuestState {
+  const playerId = normalizePlayerId(state.playerId);
+  const currentDateKey = /^\d{4}-\d{2}-\d{2}$/.test(state.currentDateKey?.trim() ?? "")
+    ? state.currentDateKey?.trim()
+    : undefined;
+  const activeQuestIds = Array.from(
+    new Set(
+      (state.activeQuestIds ?? [])
+        .map((questId) => questId?.trim())
+        .filter((questId): questId is string => Boolean(questId))
+    )
+  );
+  const rotations = (state.rotations ?? [])
+    .map((entry) => {
+      const dateKey = /^\d{4}-\d{2}-\d{2}$/.test(entry?.dateKey?.trim() ?? "") ? entry.dateKey.trim() : null;
+      if (!dateKey) {
+        return null;
+      }
+
+      const normalizeQuestIds = (questIds?: string[] | null) =>
+        Array.from(new Set((questIds ?? []).map((questId) => questId?.trim()).filter((questId): questId is string => Boolean(questId))));
+
+      return {
+        dateKey,
+        questIds: normalizeQuestIds(entry.questIds),
+        completedQuestIds: normalizeQuestIds(entry.completedQuestIds),
+        claimedQuestIds: normalizeQuestIds(entry.claimedQuestIds)
+      } satisfies PlayerQuestRotationHistoryEntry;
+    })
+    .filter((entry): entry is PlayerQuestRotationHistoryEntry => Boolean(entry))
+    .sort((left, right) => left.dateKey.localeCompare(right.dateKey));
+
+  return {
+    playerId,
+    ...(currentDateKey ? { currentDateKey } : {}),
+    activeQuestIds,
+    rotations,
+    updatedAt: formatTimestamp(state.updatedAt) ?? new Date().toISOString()
+  };
+}
+
+function toPlayerQuestState(row: PlayerQuestStateRow): PlayerQuestState {
+  const updatedAt = formatTimestamp(row.updated_at);
+  return normalizePlayerQuestState({
+    playerId: row.player_id,
+    ...(row.current_date_key ? { currentDateKey: row.current_date_key } : {}),
+    activeQuestIds:
+      row.active_quest_ids_json != null ? parseJsonColumn<string[]>(row.active_quest_ids_json) : [],
+    rotations: row.rotations_json != null ? parseJsonColumn<PlayerQuestRotationHistoryEntry[]>(row.rotations_json) : [],
+    ...(updatedAt ? { updatedAt } : {})
+  });
 }
 
 function extractNewPlayerEventHistoryEntries(
@@ -4316,6 +4396,25 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     };
   }
 
+  async loadPlayerQuestState(playerId: string): Promise<PlayerQuestState | null> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const [rows] = await this.pool.query<PlayerQuestStateRow[]>(
+      `SELECT
+         player_id,
+         current_date_key,
+         active_quest_ids_json,
+         rotations_json,
+         updated_at
+       FROM \`${MYSQL_PLAYER_QUEST_STATE_TABLE}\`
+       WHERE player_id = ?
+       LIMIT 1`,
+      [normalizedPlayerId]
+    );
+
+    const row = rows[0];
+    return row ? toPlayerQuestState(row) : null;
+  }
+
   async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {
     const safePlayerIds = Array.from(new Set(playerIds.map((playerId) => playerId.trim()).filter(Boolean)));
     if (safePlayerIds.length === 0) {
@@ -6380,6 +6479,37 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         ...(existing.lastSeenAt ? { lastSeenAt: existing.lastSeenAt } : {})
       })
     );
+  }
+
+  async savePlayerQuestState(playerId: string, state: PlayerQuestState): Promise<PlayerQuestState> {
+    const nextState = normalizePlayerQuestState({
+      ...state,
+      playerId
+    });
+
+    await this.pool.query(
+      `INSERT INTO \`${MYSQL_PLAYER_QUEST_STATE_TABLE}\` (
+         player_id,
+         current_date_key,
+         active_quest_ids_json,
+         rotations_json,
+         updated_at
+       ) VALUES (?, ?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE
+         current_date_key = VALUES(current_date_key),
+         active_quest_ids_json = VALUES(active_quest_ids_json),
+         rotations_json = VALUES(rotations_json),
+         updated_at = VALUES(updated_at)`,
+      [
+        nextState.playerId,
+        nextState.currentDateKey ?? null,
+        JSON.stringify(nextState.activeQuestIds),
+        JSON.stringify(nextState.rotations),
+        nextState.updatedAt
+      ]
+    );
+
+    return nextState;
   }
 
   async listPlayerAccounts(options: PlayerAccountListOptions = {}): Promise<PlayerAccountSnapshot[]> {

--- a/apps/server/test/event-engine.test.ts
+++ b/apps/server/test/event-engine.test.ts
@@ -5,9 +5,11 @@ import {
   buildEventLeaderboard,
   claimSeasonalEventReward,
   getActiveSeasonalEvents,
+  rotateDailyQuests,
   resolveSeasonalEvents
 } from "../src/event-engine";
-import type { PlayerAccountSnapshot } from "../src/persistence";
+import { loadDailyQuestConfig } from "../src/daily-quest-config";
+import type { PlayerAccountSnapshot, PlayerQuestState } from "../src/persistence";
 
 test("seasonal events resolve the active defend-the-bridge window", () => {
   const events = resolveSeasonalEvents();
@@ -119,4 +121,82 @@ test("event leaderboard sorts players by points then oldest update time", () => 
   assert.equal(leaderboard[1]?.playerId, "player-3");
   assert.equal(leaderboard[2]?.playerId, "player-1");
   assert.equal(leaderboard[0]?.rewardPreview, "Bridge Champion");
+});
+
+test("rotateDailyQuests is deterministic for a player and date seed", () => {
+  const config = loadDailyQuestConfig();
+  const first = rotateDailyQuests({
+    playerId: "quest-player",
+    dateKey: "2026-04-06",
+    questPool: config.quests
+  });
+  const second = rotateDailyQuests({
+    playerId: "quest-player",
+    dateKey: "2026-04-06",
+    questPool: config.quests
+  });
+
+  assert.deepEqual(
+    first.quests.map((quest) => quest.id),
+    second.quests.map((quest) => quest.id)
+  );
+  assert.equal(first.rotated, true);
+  assert.equal(second.rotated, true);
+});
+
+test("rotateDailyQuests enforces a 7-day no-repeat window per player", () => {
+  const config = loadDailyQuestConfig();
+  let state: PlayerQuestState | undefined;
+  const seenQuestIds = new Set<string>();
+
+  for (let day = 0; day < 7; day += 1) {
+    const date = new Date("2026-04-06T00:00:00.000Z");
+    date.setUTCDate(date.getUTCDate() + day);
+    const rotation = rotateDailyQuests({
+      playerId: "quest-player",
+      dateKey: date.toISOString().slice(0, 10),
+      questPool: config.quests,
+      questState: state
+    });
+
+    assert.equal(rotation.quests.length, 3);
+    for (const quest of rotation.quests) {
+      assert.equal(seenQuestIds.has(quest.id), false);
+      seenQuestIds.add(quest.id);
+    }
+    state = rotation.state;
+  }
+
+  assert.equal(seenQuestIds.size, 21);
+});
+
+test("rotateDailyQuests weighted selection favors common quests over rare and epic quests", () => {
+  const config = loadDailyQuestConfig();
+  const tierCounts = {
+    common: 0,
+    rare: 0,
+    epic: 0
+  };
+
+  for (let index = 0; index < 300; index += 1) {
+    const rotation = rotateDailyQuests({
+      playerId: `player-${index}`,
+      dateKey: "2026-04-06",
+      questPool: config.quests
+    });
+    for (const quest of rotation.quests) {
+      tierCounts[quest.tier] += 1;
+    }
+  }
+
+  assert.equal(tierCounts.common > tierCounts.rare, true);
+  assert.equal(tierCounts.rare > tierCounts.epic, true);
+});
+
+test("daily quest config ships at least 15 quests across common, rare, and epic tiers", () => {
+  const config = loadDailyQuestConfig();
+  const tiers = new Set(config.quests.map((quest) => quest.tier));
+
+  assert.equal(config.quests.length >= 15, true);
+  assert.deepEqual(Array.from(tiers).sort(), ["common", "epic", "rare"]);
 });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -13,6 +13,8 @@ import {
   normalizePlayerMailboxMessage
 } from "../src/player-mailbox";
 import { registerPlayerAccountRoutes } from "../src/player-accounts";
+import { loadDailyQuestConfig } from "../src/daily-quest-config";
+import { rotateDailyQuests } from "../src/event-engine";
 import { cacheWechatSessionKey, resetWechatSessionKeyCache } from "../src/wechat-session-key";
 import type {
   PlayerAccountBanHistoryListOptions,
@@ -31,6 +33,7 @@ import type {
   PlayerAccountProfilePatch,
   PlayerAccountSnapshot,
   PlayerHeroArchiveSnapshot,
+  PlayerQuestState,
   RoomSnapshotStore
 } from "../src/persistence";
 import type { RoomPersistenceSnapshot } from "../src/index";
@@ -60,6 +63,7 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
   private readonly eventHistoryByPlayerId = new Map<string, PlayerAccountSnapshot["recentEventLog"]>();
+  private readonly playerQuestStates = new Map<string, PlayerQuestState>();
   private readonly referrals = new Set<string>();
 
   async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
@@ -110,6 +114,10 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       items,
       total
     };
+  }
+
+  async loadPlayerQuestState(playerId: string): Promise<PlayerQuestState | null> {
+    return structuredClone(this.playerQuestStates.get(playerId.trim()) ?? null);
   }
 
   async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {
@@ -735,6 +743,16 @@ class MemoryPlayerAccountStore implements RoomSnapshotStore {
       ])
     );
     return account;
+  }
+
+  async savePlayerQuestState(playerId: string, state: PlayerQuestState): Promise<PlayerQuestState> {
+    const normalizedPlayerId = playerId.trim();
+    const nextState: PlayerQuestState = {
+      ...structuredClone(state),
+      playerId: normalizedPlayerId
+    };
+    this.playerQuestStates.set(normalizedPlayerId, nextState);
+    return structuredClone(nextState);
   }
 
   async claimBattlePassTier(playerId: string, tier: number) {
@@ -3358,14 +3376,24 @@ test("daily quest board derives same-day progress and ignores prior-day events",
 
   assert.equal(boardResponse.status, 200);
   assert.equal(boardPayload.dailyQuestBoard.enabled, true);
-  assert.equal(boardPayload.dailyQuestBoard.cycleKey, today);
+  const expectedRotation = rotateDailyQuests({
+    playerId: "daily-quest-player",
+    dateKey: boardPayload.dailyQuestBoard.cycleKey,
+    questPool: loadDailyQuestConfig().quests
+  });
+  assert.equal(boardPayload.dailyQuestBoard.cycleKey, expectedRotation.state.currentDateKey);
+  const expectedProgressByMetric = {
+    hero_moves: 2,
+    battle_wins: 0,
+    resource_collections: 1
+  } as const;
   assert.deepEqual(
     boardPayload.dailyQuestBoard.quests.map((quest) => ({ id: quest.id, current: quest.current, completed: quest.completed })),
-    [
-      { id: "daily_explore_frontier", current: 2, completed: false },
-      { id: "daily_battle_victory", current: 0, completed: false },
-      { id: "daily_resource_run", current: 1, completed: false }
-    ]
+    expectedRotation.quests.map((quest) => ({
+      id: quest.id,
+      current: Math.min(quest.target, expectedProgressByMetric[quest.metric]),
+      completed: expectedProgressByMetric[quest.metric] >= quest.target
+    }))
   );
 });
 
@@ -3472,26 +3500,36 @@ test("daily quest claim grants rewards once and returns already_claimed on repea
     tutorialStep: null
   });
   store.seedEventHistory("daily-quest-claim", [
-    {
-      id: `daily-quest-claim:${today}T08:00:00.000Z:hero.collected:1`,
-      timestamp: `${today}T08:00:00.000Z`,
+    ...Array.from({ length: 9 }, (_, index) => ({
+      id: `daily-quest-claim:${today}T08:${String(index).padStart(2, "0")}:00.000Z:hero.moved:${index + 1}`,
+      timestamp: `${today}T08:${String(index).padStart(2, "0")}:00.000Z`,
       roomId: "room-alpha",
       playerId: "daily-quest-claim",
-      category: "building",
-      description: "今日收集资源。",
-      worldEventType: "hero.collected",
-      rewards: [{ type: "resource", label: "gold", amount: 15 }]
-    },
-    {
-      id: `daily-quest-claim:${today}T08:05:00.000Z:hero.collected:2`,
-      timestamp: `${today}T08:05:00.000Z`,
+      category: "movement" as const,
+      description: "今日探索移动。",
+      worldEventType: "hero.moved" as const,
+      rewards: []
+    })),
+    ...Array.from({ length: 8 }, (_, index) => ({
+      id: `daily-quest-claim:${today}T09:${String(index).padStart(2, "0")}:00.000Z:hero.collected:${index + 1}`,
+      timestamp: `${today}T09:${String(index).padStart(2, "0")}:00.000Z`,
       roomId: "room-alpha",
       playerId: "daily-quest-claim",
-      category: "building",
+      category: "building" as const,
       description: "今日收集资源。",
-      worldEventType: "hero.collected",
-      rewards: [{ type: "resource", label: "gold", amount: 25 }]
-    }
+      worldEventType: "hero.collected" as const,
+      rewards: [{ type: "resource" as const, label: "gold", amount: 15 + index }]
+    })),
+    ...Array.from({ length: 5 }, (_, index) => ({
+      id: `daily-quest-claim:${today}T10:${String(index).padStart(2, "0")}:00.000Z:battle.resolved:${index + 1}`,
+      timestamp: `${today}T10:${String(index).padStart(2, "0")}:00.000Z`,
+      roomId: "room-alpha",
+      playerId: "daily-quest-claim",
+      category: "battle" as const,
+      description: "战斗胜利。",
+      worldEventType: "battle.resolved" as const,
+      rewards: []
+    }))
   ]);
   const server = await startAccountRouteServer(port, store);
   const session = issueGuestAuthSession({
@@ -3503,8 +3541,22 @@ test("daily quest claim grants rewards once and returns already_claimed on repea
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
+  const boardResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/daily-quests`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const boardPayload = (await boardResponse.json()) as {
+    dailyQuestBoard: {
+      availableClaims: number;
+      quests: Array<{ id: string; reward: { gems: number; gold: number }; completed: boolean; claimed: boolean }>;
+    };
+  };
+  const claimableQuest = boardPayload.dailyQuestBoard.quests.find((quest) => quest.completed && !quest.claimed);
+  assert.ok(claimableQuest);
+
   const claimResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/me/daily-quests/daily_resource_run/claim`,
+    `http://127.0.0.1:${port}/api/player-accounts/me/daily-quests/${claimableQuest.id}/claim`,
     {
       method: "POST",
       headers: {
@@ -3520,11 +3572,11 @@ test("daily quest claim grants rewards once and returns already_claimed on repea
 
   assert.equal(claimResponse.status, 200);
   assert.equal(claimPayload.claimed, true);
-  assert.deepEqual(claimPayload.reward, { gems: 2, gold: 35 });
-  assert.equal(claimPayload.dailyQuestBoard.availableClaims, 0);
+  assert.deepEqual(claimPayload.reward, claimableQuest.reward);
+  assert.equal(claimPayload.dailyQuestBoard.availableClaims, boardPayload.dailyQuestBoard.availableClaims - 1);
 
   const repeatResponse = await fetch(
-    `http://127.0.0.1:${port}/api/player-accounts/me/daily-quests/daily_resource_run/claim`,
+    `http://127.0.0.1:${port}/api/player-accounts/me/daily-quests/${claimableQuest.id}/claim`,
     {
       method: "POST",
       headers: {
@@ -3541,12 +3593,21 @@ test("daily quest claim grants rewards once and returns already_claimed on repea
   assert.equal(repeatResponse.status, 200);
   assert.equal(repeatPayload.claimed, false);
   assert.equal(repeatPayload.reason, "already_claimed");
-  assert.equal(repeatPayload.dailyQuestBoard.availableClaims, 0);
+  assert.equal(repeatPayload.dailyQuestBoard.availableClaims, claimPayload.dailyQuestBoard.availableClaims);
 
   const account = await store.loadPlayerAccount("daily-quest-claim");
-  assert.equal(account?.gems, 2);
-  assert.equal(account?.globalResources.gold, 35);
-  assert.match(account?.recentEventLog[0]?.description ?? "", /领取每日任务：补给回收/);
+  const questState = await store.loadPlayerQuestState("daily-quest-claim");
+  assert.equal(account?.gems, claimableQuest.reward.gems);
+  assert.equal(account?.globalResources.gold, claimableQuest.reward.gold);
+  assert.match(account?.recentEventLog[0]?.description ?? "", /领取每日任务：/);
+  assert.deepEqual(
+    questState?.rotations.find((entry) => entry.dateKey === questState?.currentDateKey)?.completedQuestIds.includes(claimableQuest.id),
+    true
+  );
+  assert.deepEqual(
+    questState?.rotations.find((entry) => entry.dateKey === questState?.currentDateKey)?.claimedQuestIds.includes(claimableQuest.id),
+    true
+  );
 });
 
 test("mailbox routes list delivered compensation and repeated claims stay idempotent", async (t) => {

--- a/configs/daily-quests.json
+++ b/configs/daily-quests.json
@@ -1,0 +1,194 @@
+{
+  "schemaVersion": 1,
+  "quests": [
+    {
+      "id": "daily_scouting_sweep",
+      "title": "侦察巡线",
+      "description": "完成 3 次探索移动。",
+      "metric": "hero_moves",
+      "target": 3,
+      "tier": "common",
+      "reward": { "gems": 2, "gold": 30 }
+    },
+    {
+      "id": "daily_supply_pickup",
+      "title": "补给拾取",
+      "description": "完成 2 次资源收集。",
+      "metric": "resource_collections",
+      "target": 2,
+      "tier": "common",
+      "reward": { "gems": 2, "gold": 35 }
+    },
+    {
+      "id": "daily_first_victory",
+      "title": "先声夺阵",
+      "description": "取得 1 场战斗胜利。",
+      "metric": "battle_wins",
+      "target": 1,
+      "tier": "common",
+      "reward": { "gems": 3, "gold": 40 }
+    },
+    {
+      "id": "daily_frontier_stride",
+      "title": "前线疾行",
+      "description": "完成 4 次探索移动。",
+      "metric": "hero_moves",
+      "target": 4,
+      "tier": "common",
+      "reward": { "gems": 3, "gold": 42 }
+    },
+    {
+      "id": "daily_salvage_route",
+      "title": "回收路线",
+      "description": "完成 3 次资源收集。",
+      "metric": "resource_collections",
+      "target": 3,
+      "tier": "common",
+      "reward": { "gems": 3, "gold": 45 }
+    },
+    {
+      "id": "daily_skirmish_secure",
+      "title": "小规模压制",
+      "description": "取得 1 场战斗胜利并稳住阵线。",
+      "metric": "battle_wins",
+      "target": 1,
+      "tier": "common",
+      "reward": { "gems": 3, "gold": 44 }
+    },
+    {
+      "id": "daily_pathfinder_push",
+      "title": "开路先锋",
+      "description": "完成 5 次探索移动。",
+      "metric": "hero_moves",
+      "target": 5,
+      "tier": "common",
+      "reward": { "gems": 4, "gold": 50 }
+    },
+    {
+      "id": "daily_cache_retrieval",
+      "title": "物资回收",
+      "description": "完成 4 次资源收集。",
+      "metric": "resource_collections",
+      "target": 4,
+      "tier": "common",
+      "reward": { "gems": 4, "gold": 52 }
+    },
+    {
+      "id": "daily_guard_break",
+      "title": "破阵突围",
+      "description": "取得 2 场战斗胜利。",
+      "metric": "battle_wins",
+      "target": 2,
+      "tier": "common",
+      "reward": { "gems": 4, "gold": 55 }
+    },
+    {
+      "id": "daily_fog_runner",
+      "title": "雾境急行",
+      "description": "完成 6 次探索移动。",
+      "metric": "hero_moves",
+      "target": 6,
+      "tier": "rare",
+      "reward": { "gems": 6, "gold": 75 }
+    },
+    {
+      "id": "daily_salvage_master",
+      "title": "资材老手",
+      "description": "完成 5 次资源收集。",
+      "metric": "resource_collections",
+      "target": 5,
+      "tier": "rare",
+      "reward": { "gems": 6, "gold": 78 }
+    },
+    {
+      "id": "daily_dual_conquest",
+      "title": "双线告捷",
+      "description": "取得 2 场战斗胜利。",
+      "metric": "battle_wins",
+      "target": 2,
+      "tier": "rare",
+      "reward": { "gems": 7, "gold": 82 }
+    },
+    {
+      "id": "daily_long_march",
+      "title": "远征长驱",
+      "description": "完成 7 次探索移动。",
+      "metric": "hero_moves",
+      "target": 7,
+      "tier": "rare",
+      "reward": { "gems": 7, "gold": 85 }
+    },
+    {
+      "id": "daily_convoy_guard",
+      "title": "护送补给",
+      "description": "完成 6 次资源收集。",
+      "metric": "resource_collections",
+      "target": 6,
+      "tier": "rare",
+      "reward": { "gems": 7, "gold": 88 }
+    },
+    {
+      "id": "daily_battle_chain",
+      "title": "连战连捷",
+      "description": "取得 3 场战斗胜利。",
+      "metric": "battle_wins",
+      "target": 3,
+      "tier": "rare",
+      "reward": { "gems": 8, "gold": 92 }
+    },
+    {
+      "id": "daily_horizon_breaker",
+      "title": "地平线突破",
+      "description": "完成 8 次探索移动。",
+      "metric": "hero_moves",
+      "target": 8,
+      "tier": "epic",
+      "reward": { "gems": 10, "gold": 120 }
+    },
+    {
+      "id": "daily_grand_salvage",
+      "title": "大规模回收",
+      "description": "完成 7 次资源收集。",
+      "metric": "resource_collections",
+      "target": 7,
+      "tier": "epic",
+      "reward": { "gems": 10, "gold": 125 }
+    },
+    {
+      "id": "daily_warpath",
+      "title": "战痕征途",
+      "description": "取得 4 场战斗胜利。",
+      "metric": "battle_wins",
+      "target": 4,
+      "tier": "epic",
+      "reward": { "gems": 11, "gold": 130 }
+    },
+    {
+      "id": "daily_void_scout",
+      "title": "裂隙探测",
+      "description": "完成 9 次探索移动。",
+      "metric": "hero_moves",
+      "target": 9,
+      "tier": "epic",
+      "reward": { "gems": 11, "gold": 134 }
+    },
+    {
+      "id": "daily_emergency_stockpile",
+      "title": "紧急储备",
+      "description": "完成 8 次资源收集。",
+      "metric": "resource_collections",
+      "target": 8,
+      "tier": "epic",
+      "reward": { "gems": 11, "gold": 138 }
+    },
+    {
+      "id": "daily_iron_vanguard",
+      "title": "钢铁先锋",
+      "description": "取得 5 场战斗胜利。",
+      "metric": "battle_wins",
+      "target": 5,
+      "tier": "epic",
+      "reward": { "gems": 12, "gold": 145 }
+    }
+  ]
+}

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -48,6 +48,16 @@ export const ANALYTICS_EVENT_CATALOG = {
       gold: 50
     }
   }),
+  QuestRotated: defineAnalyticsEvent("QuestRotated", 1, "Server rotated a new daily quest slate for the player.", {
+    roomId: "daily-quests",
+    dateKey: "2026-04-06",
+    questIds: ["daily_scouting_sweep", "daily_dual_conquest", "daily_warpath"],
+    tierCounts: {
+      common: 1,
+      rare: 1,
+      epic: 1
+    }
+  }),
   shop_open: defineAnalyticsEvent("shop_open", 1, "Player opened the shop surface.", {
     roomId: "room-contract",
     surface: "lobby"

--- a/scripts/migrations/0020_add_player_quest_states.ts
+++ b/scripts/migrations/0020_add_player_quest_states.ts
@@ -1,0 +1,36 @@
+import {
+  dropTableIfExists,
+  ensureIndexExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_PLAYER_QUEST_STATE_TABLE,
+  MYSQL_PLAYER_QUEST_STATE_UPDATED_AT_INDEX
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  await ensureTableExists(
+    connection,
+    MYSQL_PLAYER_QUEST_STATE_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_QUEST_STATE_TABLE}\` (
+      player_id VARCHAR(191) NOT NULL,
+      current_date_key VARCHAR(10) NULL,
+      active_quest_ids_json LONGTEXT NOT NULL,
+      rotations_json LONGTEXT NOT NULL,
+      updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      PRIMARY KEY (player_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+  await ensureIndexExists(
+    connection,
+    connection.config.database,
+    MYSQL_PLAYER_QUEST_STATE_TABLE,
+    MYSQL_PLAYER_QUEST_STATE_UPDATED_AT_INDEX,
+    `CREATE INDEX \`${MYSQL_PLAYER_QUEST_STATE_UPDATED_AT_INDEX}\` ON \`${MYSQL_PLAYER_QUEST_STATE_TABLE}\` (updated_at)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  await dropTableIfExists(connection, MYSQL_PLAYER_QUEST_STATE_TABLE);
+}


### PR DESCRIPTION
## Summary
- replace the static daily quest slate with deterministic per-player server rotation seeded by date
- add persisted `PlayerQuestState` storage and a migration so 7-day no-repeat history and completion/claim tracking survive across requests
- author a 21-quest weighted pool in `configs/daily-quests.json` and emit a `QuestRotated` analytics event when a new daily slate is created

## Why
Issue #923 called out that daily quests were effectively static and lacked authoritative server rotation, weighted tier selection, and per-player anti-repeat tracking.

## Validation
- `node --import tsx --test apps/server/test/event-engine.test.ts`
- `node --import tsx --test --test-name-pattern "daily quest" apps/server/test/player-account-routes.test.ts`
- `npm run typecheck:ci`