### PR TITLE
[codex] Implement weekly division decay and promotion cutoffs

### DIFF
--- a/apps/server/src/competitive-season.ts
+++ b/apps/server/src/competitive-season.ts
@@ -3,12 +3,15 @@ import {
   didPlayerWinReplay,
   getRankDivisionForRating,
   getRankDivisionIndex,
+  getPreviousRankDivision,
+  getPromotionSeriesTargetDivision,
   getSoftDecayDivision,
   getTierForDivision,
   getTierFloorDivision,
   getUtcWeekStart,
-  isPromotionSeriesBoundary,
+  rollRankedWeeklyProgress,
   resolveRankedSeasonConfig,
+  shouldApplyWeeklyDivisionDecay,
   type PlayerBattleReplaySummary,
   type RankDivisionId
 } from "../../../packages/shared/src/index";
@@ -34,48 +37,52 @@ function updateWeeklyProgress(
   referenceTime = new Date()
 ): NonNullable<PlayerAccountSnapshot["rankedWeeklyProgress"]> {
   const currentWeekStartsAt = getUtcWeekStart(referenceTime);
-  const existing = account.rankedWeeklyProgress;
   const previousWeekStartsAt = addUtcDays(currentWeekStartsAt, -7);
-  const next = {
-    currentWeekStartsAt,
-    currentWeekWins: 0,
-    ...(existing?.currentWeekStartsAt === previousWeekStartsAt
-      ? {
-          previousWeekStartsAt: existing.currentWeekStartsAt,
-          previousWeekWins: existing.currentWeekWins
-        }
-      : existing?.previousWeekStartsAt === previousWeekStartsAt
-        ? {
-            previousWeekStartsAt,
-            previousWeekWins: existing.previousWeekWins ?? 0
-          }
-        : {})
-  };
-
-  if (existing?.currentWeekStartsAt === currentWeekStartsAt) {
-    next.currentWeekWins = existing.currentWeekWins;
-    if (existing.previousWeekStartsAt === previousWeekStartsAt) {
-      next.previousWeekStartsAt = existing.previousWeekStartsAt;
-      next.previousWeekWins = existing.previousWeekWins ?? 0;
-    }
-  }
+  const next = rollRankedWeeklyProgress(account.rankedWeeklyProgress, referenceTime);
 
   for (const replay of toHeroPvpReplays(newReplays)) {
-    if (!didPlayerWinReplay(replay)) {
-      continue;
-    }
     const replayWeekStartsAt = getUtcWeekStart(replay.completedAt);
     if (replayWeekStartsAt === next.currentWeekStartsAt) {
-      next.currentWeekWins += 1;
+      next.currentWeekBattles += 1;
+      if (didPlayerWinReplay(replay)) {
+        next.currentWeekWins += 1;
+      }
       continue;
     }
     if (replayWeekStartsAt === previousWeekStartsAt) {
       next.previousWeekStartsAt = previousWeekStartsAt;
-      next.previousWeekWins = (next.previousWeekWins ?? 0) + 1;
+      next.previousWeekBattles = (next.previousWeekBattles ?? 0) + 1;
+      if (didPlayerWinReplay(replay)) {
+        next.previousWeekWins = (next.previousWeekWins ?? 0) + 1;
+      }
     }
   }
 
   return next;
+}
+
+function applyWeeklyDivisionDecay(
+  account: PlayerAccountSnapshot,
+  rankDivision: RankDivisionId,
+  peakRankDivision: RankDivisionId,
+  referenceTime = new Date()
+): Pick<PlayerAccountSnapshot, "rankDivision" | "peakRankDivision" | "promotionSeries" | "demotionShield" | "rankedWeeklyProgress"> {
+  const rankedWeeklyProgress = rollRankedWeeklyProgress(account.rankedWeeklyProgress, referenceTime);
+  if (!shouldApplyWeeklyDivisionDecay(rankDivision, account.rankedWeeklyProgress, referenceTime)) {
+    return {
+      rankDivision,
+      peakRankDivision,
+      ...(account.promotionSeries ? { promotionSeries: account.promotionSeries } : {}),
+      ...(account.demotionShield ? { demotionShield: account.demotionShield } : {}),
+      rankedWeeklyProgress
+    };
+  }
+
+  return {
+    rankDivision: getPreviousRankDivision(rankDivision) ?? rankDivision,
+    peakRankDivision,
+    rankedWeeklyProgress
+  };
 }
 
 export function resolveCompetitiveProgression(
@@ -95,22 +102,14 @@ export function resolveCompetitiveProgression(
   let peakRankDivision = existing.peakRankDivision ?? rankDivision;
   let promotionSeries = existing.promotionSeries;
   let demotionShield = existing.demotionShield;
+  const weeklyDecay = applyWeeklyDivisionDecay(existing, rankDivision, peakRankDivision, referenceTime);
+  rankDivision = weeklyDecay.rankDivision ?? rankDivision;
+  peakRankDivision = weeklyDecay.peakRankDivision ?? peakRankDivision;
+  promotionSeries = weeklyDecay.promotionSeries;
+  demotionShield = weeklyDecay.demotionShield;
   const targetDivision = patch.eloRating !== undefined ? getRankDivisionForRating(nextRating) : rankDivision;
 
-  if (patch.eloRating !== undefined && isPromotionSeriesBoundary(rankDivision, targetDivision)) {
-    if (!promotionSeries || promotionSeries.targetDivision !== targetDivision) {
-      promotionSeries = {
-        targetDivision,
-        wins: 0,
-        losses: 0,
-        winsRequired: config.promotionSeries.winsRequired,
-        lossesAllowed: config.promotionSeries.lossesAllowed
-      };
-    }
-  } else if (patch.eloRating !== undefined && getTierForDivision(targetDivision) === getTierForDivision(rankDivision)) {
-    rankDivision = targetDivision;
-    promotionSeries = undefined;
-  } else if (patch.eloRating !== undefined && getRankDivisionIndex(targetDivision) < getRankDivisionIndex(rankDivision)) {
+  if (patch.eloRating !== undefined && getRankDivisionIndex(targetDivision) < getRankDivisionIndex(rankDivision)) {
     if (demotionShield && demotionShield.remainingMatches > 0 && demotionShield.tier === getTierForDivision(rankDivision)) {
       demotionShield = {
         ...demotionShield,
@@ -124,6 +123,19 @@ export function resolveCompetitiveProgression(
       rankDivision = targetDivision;
     }
     promotionSeries = undefined;
+  } else if (patch.eloRating !== undefined) {
+    const promotionTarget = getPromotionSeriesTargetDivision(rankDivision, nextRating);
+    if (promotionTarget && (!promotionSeries || promotionSeries.targetDivision !== promotionTarget)) {
+      promotionSeries = {
+        targetDivision: promotionTarget,
+        wins: 0,
+        losses: 0,
+        winsRequired: config.promotionSeries.winsRequired,
+        lossesAllowed: config.promotionSeries.lossesAllowed
+      };
+    } else if (!promotionTarget && getRankDivisionIndex(targetDivision) === getRankDivisionIndex(rankDivision)) {
+      promotionSeries = undefined;
+    }
   }
 
   for (const replay of heroPvpReplays) {
@@ -175,7 +187,18 @@ export function resolveCompetitiveProgression(
     peakRankDivision,
     ...(promotionSeries ? { promotionSeries } : {}),
     ...(demotionShield ? { demotionShield } : {}),
-    rankedWeeklyProgress: updateWeeklyProgress(existing, newReplays, referenceTime)
+    rankedWeeklyProgress: updateWeeklyProgress(
+      {
+        ...existing,
+        rankDivision,
+        peakRankDivision,
+        ...(promotionSeries ? { promotionSeries } : {}),
+        ...(demotionShield ? { demotionShield } : {}),
+        ...(weeklyDecay.rankedWeeklyProgress ? { rankedWeeklyProgress: weeklyDecay.rankedWeeklyProgress } : {})
+      },
+      newReplays,
+      referenceTime
+    )
   };
 }
 

--- a/apps/server/test/competitive-season.test.ts
+++ b/apps/server/test/competitive-season.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveCompetitiveProgression } from "../src/competitive-season";
+import type { PlayerAccountSnapshot } from "../src/persistence";
+
+function createAccount(overrides: Partial<PlayerAccountSnapshot> = {}): PlayerAccountSnapshot {
+  return {
+    playerId: overrides.playerId ?? "player-1",
+    displayName: overrides.displayName ?? "player-1",
+    globalResources: overrides.globalResources ?? { gold: 0, wood: 0, ore: 0 },
+    achievements: overrides.achievements ?? [],
+    recentEventLog: overrides.recentEventLog ?? [],
+    recentBattleReplays: overrides.recentBattleReplays ?? [],
+    eloRating: overrides.eloRating ?? 1000,
+    rankDivision: overrides.rankDivision ?? "bronze_i",
+    peakRankDivision: overrides.peakRankDivision ?? (overrides.rankDivision ?? "bronze_i"),
+    ...(overrides.promotionSeries ? { promotionSeries: overrides.promotionSeries } : {}),
+    ...(overrides.demotionShield ? { demotionShield: overrides.demotionShield } : {}),
+    ...(overrides.rankedWeeklyProgress ? { rankedWeeklyProgress: overrides.rankedWeeklyProgress } : {})
+  };
+}
+
+test("competitive progression starts a promotion series at the next division cutoff", () => {
+  const result = resolveCompetitiveProgression(
+    createAccount({
+      eloRating: 340,
+      rankDivision: "bronze_i",
+      peakRankDivision: "bronze_i"
+    }),
+    { eloRating: 350 },
+    [],
+    350,
+    new Date("2026-04-06T12:00:00.000Z")
+  );
+
+  assert.equal(result.rankDivision, "bronze_i");
+  assert.deepEqual(result.promotionSeries, {
+    targetDivision: "bronze_ii",
+    wins: 0,
+    losses: 0,
+    winsRequired: 3,
+    lossesAllowed: 2
+  });
+});
+
+test("competitive progression applies one-step weekly decay after an inactive week", () => {
+  const result = resolveCompetitiveProgression(
+    createAccount({
+      eloRating: 1180,
+      rankDivision: "silver_ii",
+      peakRankDivision: "silver_iii",
+      rankedWeeklyProgress: {
+        currentWeekStartsAt: "2026-03-30T00:00:00.000Z",
+        currentWeekBattles: 0,
+        currentWeekWins: 0
+      }
+    }),
+    {},
+    [],
+    1180,
+    new Date("2026-04-06T12:00:00.000Z")
+  );
+
+  assert.equal(result.rankDivision, "silver_i");
+  assert.equal(result.peakRankDivision, "silver_iii");
+  assert.deepEqual(result.rankedWeeklyProgress, {
+    currentWeekStartsAt: "2026-04-06T00:00:00.000Z",
+    currentWeekBattles: 0,
+    currentWeekWins: 0,
+    previousWeekStartsAt: "2026-03-30T00:00:00.000Z"
+  });
+});
+
+test("competitive progression counts losses as activity for weekly decay immunity", () => {
+  const result = resolveCompetitiveProgression(
+    createAccount({
+      eloRating: 1180,
+      rankDivision: "silver_ii",
+      peakRankDivision: "silver_ii",
+      rankedWeeklyProgress: {
+        currentWeekStartsAt: "2026-03-30T00:00:00.000Z",
+        currentWeekBattles: 1,
+        currentWeekWins: 0
+      }
+    }),
+    {},
+    [],
+    1180,
+    new Date("2026-04-06T12:00:00.000Z")
+  );
+
+  assert.equal(result.rankDivision, "silver_ii");
+});

--- a/apps/server/test/leaderboard-routes.test.ts
+++ b/apps/server/test/leaderboard-routes.test.ts
@@ -233,8 +233,10 @@ test("GET /api/leaderboard/weekly returns current and previous weekly standings"
     rankDivision: "gold_i",
     rankedWeeklyProgress: {
       currentWeekStartsAt,
+      currentWeekBattles: 5,
       currentWeekWins: 5,
       previousWeekStartsAt,
+      previousWeekBattles: 1,
       previousWeekWins: 1
     }
   });
@@ -244,8 +246,10 @@ test("GET /api/leaderboard/weekly returns current and previous weekly standings"
     rankDivision: "gold_i",
     rankedWeeklyProgress: {
       currentWeekStartsAt,
+      currentWeekBattles: 1,
       currentWeekWins: 0,
       previousWeekStartsAt,
+      previousWeekBattles: 4,
       previousWeekWins: 4
     }
   });

--- a/packages/shared/src/competitive-season.ts
+++ b/packages/shared/src/competitive-season.ts
@@ -1,6 +1,7 @@
 import rankedSeasonConfigDocument from "../../../configs/ranked-season.json";
 import { normalizeEloRating, type PlayerTier, type RankDivisionId } from "./matchmaking.ts";
 import type { PlayerBattleReplaySummary } from "./battle-replay.ts";
+import type { RankedWeeklyProgress } from "./models.ts";
 
 interface RankedSeasonConfigDocument {
   divisionThresholds?: Partial<Record<RankDivisionId, number>> | null;
@@ -99,6 +100,16 @@ export function getRankDivisionIndex(division: RankDivisionId): number {
   return RANK_DIVISION_ORDER.indexOf(division);
 }
 
+export function getNextRankDivision(division: RankDivisionId): RankDivisionId | null {
+  const index = getRankDivisionIndex(division);
+  return index >= 0 && index < RANK_DIVISION_ORDER.length - 1 ? RANK_DIVISION_ORDER[index + 1]! : null;
+}
+
+export function getPreviousRankDivision(division: RankDivisionId): RankDivisionId | null {
+  const index = getRankDivisionIndex(division);
+  return index > 0 ? RANK_DIVISION_ORDER[index - 1]! : null;
+}
+
 export function getRankDivisionForRating(rating: number | undefined | null): RankDivisionId {
   const normalized = normalizeEloRating(rating);
   const config = resolveRankedSeasonConfig();
@@ -133,8 +144,99 @@ export function getSoftDecayDivision(division: RankDivisionId): RankDivisionId {
   return config.softDecay[getTierForDivision(division)] ?? division;
 }
 
+export function getPromotionSeriesTargetDivision(
+  currentDivision: RankDivisionId,
+  rating: number | undefined | null
+): RankDivisionId | null {
+  const nextDivision = getNextRankDivision(currentDivision);
+  if (!nextDivision) {
+    return null;
+  }
+
+  return normalizeEloRating(rating) >= getRankDivisionThreshold(nextDivision) ? nextDivision : null;
+}
+
 export function isPromotionSeriesBoundary(currentDivision: RankDivisionId, nextDivision: RankDivisionId): boolean {
   return getTierForDivision(currentDivision) !== getTierForDivision(nextDivision) && getRankDivisionIndex(nextDivision) > getRankDivisionIndex(currentDivision);
+}
+
+export function rollRankedWeeklyProgress(
+  progress: RankedWeeklyProgress | undefined,
+  referenceTime: Date | string = new Date()
+): RankedWeeklyProgress {
+  const currentWeekStartsAt = getUtcWeekStart(referenceTime);
+  const previousWeekStartsAt = addUtcDays(currentWeekStartsAt, -7);
+  const next: RankedWeeklyProgress = {
+    currentWeekStartsAt,
+    currentWeekBattles: 0,
+    currentWeekWins: 0
+  };
+
+  if (!progress) {
+    return next;
+  }
+
+  if (progress.currentWeekStartsAt === currentWeekStartsAt) {
+    next.currentWeekBattles = Math.max(0, Math.floor(progress.currentWeekBattles ?? 0));
+    next.currentWeekWins = Math.max(0, Math.floor(progress.currentWeekWins ?? 0));
+    if (progress.previousWeekStartsAt === previousWeekStartsAt) {
+      const previousWeekBattles = Math.max(0, Math.floor(progress.previousWeekBattles ?? 0));
+      const previousWeekWins = Math.max(0, Math.floor(progress.previousWeekWins ?? 0));
+      next.previousWeekStartsAt = previousWeekStartsAt;
+      if (previousWeekBattles > 0) {
+        next.previousWeekBattles = previousWeekBattles;
+      }
+      if (previousWeekWins > 0) {
+        next.previousWeekWins = previousWeekWins;
+      }
+    }
+    return next;
+  }
+
+  const previousWeek =
+    progress.currentWeekStartsAt === previousWeekStartsAt
+      ? {
+          battles: Math.max(0, Math.floor(progress.currentWeekBattles ?? 0)),
+          wins: Math.max(0, Math.floor(progress.currentWeekWins ?? 0))
+        }
+      : progress.previousWeekStartsAt === previousWeekStartsAt
+        ? {
+            battles: Math.max(0, Math.floor(progress.previousWeekBattles ?? 0)),
+            wins: Math.max(0, Math.floor(progress.previousWeekWins ?? 0))
+          }
+        : null;
+
+  if (previousWeek) {
+    next.previousWeekStartsAt = previousWeekStartsAt;
+    if (previousWeek.battles > 0) {
+      next.previousWeekBattles = previousWeek.battles;
+    }
+    if (previousWeek.wins > 0) {
+      next.previousWeekWins = previousWeek.wins;
+    }
+  }
+
+  return next;
+}
+
+export function shouldApplyWeeklyDivisionDecay(
+  division: RankDivisionId,
+  progress: RankedWeeklyProgress | undefined,
+  referenceTime: Date | string = new Date()
+): boolean {
+  const currentWeekStartsAt = getUtcWeekStart(referenceTime);
+  if (!progress || progress.currentWeekStartsAt === currentWeekStartsAt || division === "bronze_i") {
+    return false;
+  }
+
+  const previousWeekStartsAt = addUtcDays(currentWeekStartsAt, -7);
+  if (progress.currentWeekStartsAt === previousWeekStartsAt) {
+    return Math.max(0, Math.floor(progress.currentWeekBattles ?? 0)) < 1;
+  }
+  if (progress.previousWeekStartsAt === previousWeekStartsAt) {
+    return Math.max(0, Math.floor(progress.previousWeekBattles ?? 0)) < 1;
+  }
+  return true;
 }
 
 export function didPlayerWinReplay(replay: Pick<PlayerBattleReplaySummary, "playerCamp" | "result">): boolean {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -258,8 +258,10 @@ export interface WeeklyLeaderboardEntry {
 
 export interface RankedWeeklyProgress {
   currentWeekStartsAt: string;
+  currentWeekBattles: number;
   currentWeekWins: number;
   previousWeekStartsAt?: string;
+  previousWeekBattles?: number;
   previousWeekWins?: number;
 }
 

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -254,11 +254,16 @@ export function normalizePlayerAccountReadModel(
   if (account?.rankedWeeklyProgress?.currentWeekStartsAt) {
     rankedWeeklyProgress = {
       currentWeekStartsAt: normalizeTimestamp(account.rankedWeeklyProgress.currentWeekStartsAt) ?? getUtcWeekStart(),
+      currentWeekBattles: Math.max(0, Math.floor(account.rankedWeeklyProgress.currentWeekBattles ?? 0)),
       currentWeekWins: Math.max(0, Math.floor(account.rankedWeeklyProgress.currentWeekWins ?? 0))
     };
     const previousWeekStartsAt = normalizeTimestamp(account.rankedWeeklyProgress.previousWeekStartsAt);
     if (previousWeekStartsAt) {
       rankedWeeklyProgress.previousWeekStartsAt = previousWeekStartsAt;
+    }
+    const previousWeekBattles = Math.max(0, Math.floor(account.rankedWeeklyProgress.previousWeekBattles ?? 0));
+    if (previousWeekBattles > 0) {
+      rankedWeeklyProgress.previousWeekBattles = previousWeekBattles;
     }
     const previousWeekWins = Math.max(0, Math.floor(account.rankedWeeklyProgress.previousWeekWins ?? 0));
     if (previousWeekWins > 0) {

--- a/packages/shared/test/competitive-season.test.ts
+++ b/packages/shared/test/competitive-season.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getPromotionSeriesTargetDivision,
+  rollRankedWeeklyProgress,
+  shouldApplyWeeklyDivisionDecay
+} from "../src/index";
+
+test("promotion cutoffs use the next division threshold", () => {
+  assert.equal(getPromotionSeriesTargetDivision("bronze_i", 349), null);
+  assert.equal(getPromotionSeriesTargetDivision("bronze_i", 350), "bronze_ii");
+  assert.equal(getPromotionSeriesTargetDivision("silver_iii", 1300), "gold_i");
+  assert.equal(getPromotionSeriesTargetDivision("diamond_iii", 5000), null);
+});
+
+test("weekly progress rolls stale weeks forward and preserves last week's totals", () => {
+  assert.deepEqual(
+    rollRankedWeeklyProgress(
+      {
+        currentWeekStartsAt: "2026-03-30T00:00:00.000Z",
+        currentWeekBattles: 4,
+        currentWeekWins: 2
+      },
+      "2026-04-06T12:00:00.000Z"
+    ),
+    {
+      currentWeekStartsAt: "2026-04-06T00:00:00.000Z",
+      currentWeekBattles: 0,
+      currentWeekWins: 0,
+      previousWeekStartsAt: "2026-03-30T00:00:00.000Z",
+      previousWeekBattles: 4,
+      previousWeekWins: 2
+    }
+  );
+});
+
+test("weekly decay requires a crossed week boundary, inactivity, and a non-bottom division", () => {
+  assert.equal(
+    shouldApplyWeeklyDivisionDecay(
+      "silver_i",
+      {
+        currentWeekStartsAt: "2026-03-30T00:00:00.000Z",
+        currentWeekBattles: 0,
+        currentWeekWins: 0
+      },
+      "2026-04-06T12:00:00.000Z"
+    ),
+    true
+  );
+  assert.equal(
+    shouldApplyWeeklyDivisionDecay(
+      "silver_i",
+      {
+        currentWeekStartsAt: "2026-03-30T00:00:00.000Z",
+        currentWeekBattles: 1,
+        currentWeekWins: 0
+      },
+      "2026-04-06T12:00:00.000Z"
+    ),
+    false
+  );
+  assert.equal(
+    shouldApplyWeeklyDivisionDecay(
+      "bronze_i",
+      {
+        currentWeekStartsAt: "2026-03-30T00:00:00.000Z",
+        currentWeekBattles: 0,
+        currentWeekWins: 0
+      },
+      "2026-04-06T12:00:00.000Z"
+    ),
+    false
+  );
+});


### PR DESCRIPTION
## Summary
- add shared competitive season helpers for next-division promotion cutoffs and weekly ranked activity rollovers
- apply one-step weekly division decay for inactive players while keeping Bronze I exempt and counting any ranked battle as activity
- cover the new promotion cutoff and weekly decay behavior with shared and server tests

## Validation
- `node --import tsx --test packages/shared/test/competitive-season.test.ts apps/server/test/competitive-season.test.ts apps/server/test/leaderboard-routes.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`

Closes #925