### PR TITLE
[codex] Implement boss encounter templates

### DIFF
--- a/apps/server/src/pve-content.ts
+++ b/apps/server/src/pve-content.ts
@@ -20,6 +20,7 @@ import type {
   RankDivisionId
 } from "../../../packages/shared/src/index";
 import {
+  getDefaultBossEncounterTemplateCatalog,
   getRankDivisionIndex,
   resolveCosmeticCatalog,
   validateDailyDungeonConfigDocument
@@ -38,6 +39,7 @@ interface CampaignConfigMissionDocument {
   enemyArmyCount?: number | null;
   enemyStatMultiplier?: number | null;
   bossEncounterName?: string | null;
+  bossTemplateId?: string | null;
   unlockMissionId?: string | null;
   reward?: (DailyDungeonReward & { cosmeticId?: string | null }) | null;
   introDialogue?: Partial<DialogueLine>[] | null;
@@ -187,6 +189,7 @@ export function resolveCampaignConfig(
   if (rawMissions.length === 0) {
     throw new Error("campaign config must define at least one mission");
   }
+  const bossTemplateIds = new Set(getDefaultBossEncounterTemplateCatalog().templates.map((template) => template.id));
 
   const missions = rawMissions.map((rawMission, index) => {
     const id = rawMission.id?.trim();
@@ -196,10 +199,14 @@ export function resolveCampaignConfig(
     const description = rawMission.description?.trim();
     const enemyArmyTemplateId = rawMission.enemyArmyTemplateId?.trim();
     const bossEncounterName = rawMission.bossEncounterName?.trim();
+    const bossTemplateId = rawMission.bossTemplateId?.trim();
     if (!id || !chapterId || !mapId || !name || !description || !enemyArmyTemplateId) {
       throw new Error(
         `campaign mission[${index}] must define id, chapterId, mapId, name, description, and enemyArmyTemplateId`
       );
+    }
+    if (bossTemplateId && !bossTemplateIds.has(bossTemplateId)) {
+      throw new Error(`campaign mission ${id} bossTemplateId references unknown template ${bossTemplateId}`);
     }
 
     const unlockMissionId = rawMission.unlockMissionId?.trim();
@@ -254,6 +261,7 @@ export function resolveCampaignConfig(
         `campaign mission ${id} enemyStatMultiplier`
       ),
       ...(bossEncounterName ? { bossEncounterName } : {}),
+      ...(bossTemplateId ? { bossTemplateId } : {}),
       ...(unlockMissionId ? { unlockMissionId } : {}),
       ...(introDialogue.length > 0 ? { introDialogue } : {}),
       ...(midDialogue.length > 0 ? { midDialogue } : {}),

--- a/apps/server/test/pve-content.test.ts
+++ b/apps/server/test/pve-content.test.ts
@@ -26,6 +26,7 @@ test("campaign config exposes a 6-mission chapter 1 arc with dialogue and sequen
   assert.equal(chapter4.length, 7);
   assert.equal(missions[0]?.introDialogue?.length, 2);
   assert.equal(chapter2.at(-1)?.bossEncounterName, "Captain Veyr, Ringbreaker");
+  assert.equal(chapter2.at(-1)?.bossTemplateId, "boss-shadow-warden");
   assert.equal(chapter3.at(-1)?.midDialogue?.length, 3);
   assert.equal(chapter4.at(-1)?.reward.cosmeticId, "border-veilfall-throne");
   assert.equal(missions[0]?.objectives[0]?.id, "c1m1-clear-patrol");

--- a/configs/boss-encounter-templates.json
+++ b/configs/boss-encounter-templates.json
@@ -1,0 +1,190 @@
+{
+  "templates": [
+    {
+      "id": "boss-lich-king",
+      "name": "Boss Lich King",
+      "bossUnitTemplateId": "shadow_death_knight",
+      "phases": [
+        {
+          "id": "phase-1-command",
+          "hpThreshold": 1,
+          "skillOverrides": {
+            "addSkillIds": ["grave_silence", "battle_focus"]
+          },
+          "scriptedAbilities": [
+            {
+              "id": "open-with-frenzy",
+              "timing": "pre_turn",
+              "skillId": "battle_focus",
+              "target": "self"
+            }
+          ]
+        },
+        {
+          "id": "phase-2-bone-wall",
+          "hpThreshold": 0.66,
+          "skillOverrides": {
+            "replaceSkillIds": ["grave_silence", "stunning_blow", "battle_focus"]
+          },
+          "environmentalEffects": [
+            {
+              "kind": "blocker",
+              "lane": 0,
+              "name": "Bone Rampart",
+              "description": "A ribcage barrier rises to shield the lich.",
+              "durability": 2
+            }
+          ]
+        },
+        {
+          "id": "phase-3-death-surge",
+          "hpThreshold": 0.33,
+          "skillOverrides": {
+            "replaceSkillIds": ["life_drain", "stunning_blow", "grave_silence", "battle_focus"]
+          },
+          "scriptedAbilities": [
+            {
+              "id": "surge-before-strike",
+              "timing": "pre_turn",
+              "skillId": "battle_focus",
+              "target": "self"
+            },
+            {
+              "id": "curse-after-strike",
+              "timing": "post_turn",
+              "skillId": "grave_silence",
+              "target": "first_enemy"
+            }
+          ],
+          "environmentalEffects": [
+            {
+              "kind": "trap",
+              "lane": 0,
+              "effect": "silence",
+              "name": "Grave Sigil",
+              "description": "Shadow sigils pulse around the throne edge.",
+              "damage": 0,
+              "charges": 2,
+              "grantedStatusId": "silenced",
+              "triggeredByCamp": "attacker",
+              "revealed": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "boss-dragon-ancient",
+      "name": "Boss Ancient Dragon",
+      "bossUnitTemplateId": "wild_cave_bear",
+      "phases": [
+        {
+          "id": "phase-1-wingbeat",
+          "hpThreshold": 1,
+          "skillOverrides": {
+            "replaceSkillIds": ["war_cry", "battle_focus"]
+          },
+          "scriptedAbilities": [
+            {
+              "id": "wingbeat-rally",
+              "timing": "pre_turn",
+              "skillId": "battle_focus",
+              "target": "self"
+            }
+          ]
+        },
+        {
+          "id": "phase-2-embers",
+          "hpThreshold": 0.5,
+          "skillOverrides": {
+            "replaceSkillIds": ["war_cry", "stunning_blow", "battle_focus"]
+          },
+          "environmentalEffects": [
+            {
+              "kind": "trap",
+              "lane": 0,
+              "effect": "damage",
+              "name": "Falling Embers",
+              "description": "Scattered flame patches burn advancing attackers.",
+              "damage": 3,
+              "charges": 3,
+              "triggeredByCamp": "attacker"
+            }
+          ]
+        },
+        {
+          "id": "phase-3-collapse",
+          "hpThreshold": 0.25,
+          "skillOverrides": {
+            "replaceSkillIds": ["war_cry", "cave_bear_cleave", "battle_focus"]
+          },
+          "scriptedAbilities": [
+            {
+              "id": "collapse-after-turn",
+              "timing": "post_turn",
+              "skillId": "war_cry",
+              "target": "first_enemy"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "boss-shadow-warden",
+      "name": "Boss Shadow Warden",
+      "bossUnitTemplateId": "shadow_hexer",
+      "phases": [
+        {
+          "id": "phase-1-veil",
+          "hpThreshold": 1,
+          "skillOverrides": {
+            "replaceSkillIds": ["grave_silence", "bog_veil"]
+          },
+          "scriptedAbilities": [
+            {
+              "id": "veil-on-open",
+              "timing": "pre_turn",
+              "skillId": "bog_veil",
+              "target": "self"
+            }
+          ]
+        },
+        {
+          "id": "phase-2-warden-grip",
+          "hpThreshold": 0.55,
+          "skillOverrides": {
+            "replaceSkillIds": ["grave_silence", "taunt_shout", "bog_veil"]
+          },
+          "scriptedAbilities": [
+            {
+              "id": "pin-the-frontline",
+              "timing": "post_turn",
+              "skillId": "taunt_shout",
+              "target": "first_enemy"
+            }
+          ],
+          "environmentalEffects": [
+            {
+              "kind": "trap",
+              "lane": 0,
+              "effect": "slow",
+              "name": "Veil Snare",
+              "description": "Mist-woven chains drag the front line down.",
+              "damage": 0,
+              "charges": 2,
+              "grantedStatusId": "slowed",
+              "triggeredByCamp": "attacker"
+            }
+          ]
+        },
+        {
+          "id": "phase-3-last-watch",
+          "hpThreshold": 0.25,
+          "skillOverrides": {
+            "replaceSkillIds": ["grave_silence", "stunning_blow", "bog_veil"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/configs/campaign-chapter2.json
+++ b/configs/campaign-chapter2.json
@@ -290,6 +290,7 @@
       "enemyArmyCount": 38,
       "enemyStatMultiplier": 2.64,
       "bossEncounterName": "Captain Veyr, Ringbreaker",
+      "bossTemplateId": "boss-shadow-warden",
       "unlockMissionId": "chapter2-ashpeak-anvil",
       "introDialogue": [
         {

--- a/configs/campaign-chapter3.json
+++ b/configs/campaign-chapter3.json
@@ -291,6 +291,7 @@
       "enemyArmyCount": 50,
       "enemyStatMultiplier": 3.7,
       "bossEncounterName": "Mist-Seer Vael",
+      "bossTemplateId": "boss-dragon-ancient",
       "unlockMissionId": "chapter3-ashpeak-conductor",
       "introDialogue": [
         {

--- a/configs/campaign-chapter4.json
+++ b/configs/campaign-chapter4.json
@@ -290,6 +290,7 @@
       "enemyArmyCount": 62,
       "enemyStatMultiplier": 4.82,
       "bossEncounterName": "High Regent Severa",
+      "bossTemplateId": "boss-lich-king",
       "unlockMissionId": "chapter4-court-of-embers",
       "introDialogue": [
         {

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -1,6 +1,9 @@
 import type {
   BattleAction,
   BattleHazardState,
+  BossEncounterPhaseConfig,
+  BossEncounterScriptedAbilityConfig,
+  BossEncounterTemplate,
   BattleSkillCatalogConfig,
   BattleSkillConfig,
   BattleOutcome,
@@ -23,7 +26,12 @@ import { nextDeterministicRandom } from "./deterministic-rng.ts";
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
 import { grantedHeroBattleSkillIds } from "./hero-skills.ts";
 import { requireValue, withOptionalProperty } from "./invariant.ts";
-import { getBattleBalanceConfig, getDefaultBattleSkillCatalog, getDefaultUnitCatalog } from "./world-config.ts";
+import {
+  getBattleBalanceConfig,
+  getDefaultBattleSkillCatalog,
+  getDefaultBossEncounterTemplateCatalog,
+  getDefaultUnitCatalog
+} from "./world-config.ts";
 
 interface ContactResolutionResult {
   state: BattleState;
@@ -172,6 +180,204 @@ function battleCatalogIndexFor(catalog: BattleSkillCatalogConfig): BattleCatalog
 
 function getBattleCatalogIndex(): BattleCatalogIndex {
   return battleCatalogIndexFor(getDefaultBattleSkillCatalog());
+}
+
+function getBossEncounterTemplateById(templateId: string): BossEncounterTemplate {
+  const catalog = getDefaultBossEncounterTemplateCatalog();
+  return requireValue(
+    catalog.templates.find((template) => template.id === templateId),
+    `Missing boss encounter template: ${templateId}`
+  );
+}
+
+function bossHazardIdPrefix(templateId: string): string {
+  return `boss-${templateId}-`;
+}
+
+function isBossHazardForTemplate(hazard: BattleHazardState, templateId: string): boolean {
+  return hazard.id.startsWith(bossHazardIdPrefix(templateId));
+}
+
+function totalUnitHitPoints(unit: UnitStack): number {
+  if (unit.count <= 0) {
+    return 0;
+  }
+
+  return Math.max(0, (unit.count - 1) * unit.maxHp + unit.currentHp);
+}
+
+function resolveBossEncounterPhase(template: BossEncounterTemplate, bossUnit: UnitStack, maxBossHp: number): BossEncounterPhaseConfig {
+  const ratio = maxBossHp > 0 ? totalUnitHitPoints(bossUnit) / maxBossHp : 0;
+  const resolvedPhase = template.phases.find((phase) => ratio >= phase.hpThreshold) ?? template.phases.at(-1);
+  return requireValue(resolvedPhase, `Boss encounter template ${template.id} must define at least one phase`);
+}
+
+function reconcileSkillStateIds(
+  unit: UnitStack,
+  desiredSkillIds: BattleSkillId[],
+  catalogIndex: BattleCatalogIndex = getBattleCatalogIndex()
+): UnitStack {
+  const remainingCooldownBySkillId = new Map(skillsOf(unit).map((skill) => [skill.id, skill.remainingCooldown] as const));
+  return {
+    ...unit,
+    skills: desiredSkillIds.map((skillId) => ({
+      ...createSkillState(skillId, catalogIndex),
+      remainingCooldown: normalizedCooldownValue(remainingCooldownBySkillId.get(skillId) ?? 0)
+    }))
+  };
+}
+
+function resolveBossPhaseSkillIds(
+  unit: UnitStack,
+  phase: BossEncounterPhaseConfig
+): BattleSkillId[] {
+  const templateById = new Map(getDefaultUnitCatalog().templates.map((template) => [template.id, template] as const));
+  const baseSkillIds = templateById.get(unit.templateId)?.battleSkills ?? skillsOf(unit).map((skill) => skill.id);
+  const override = phase.skillOverrides;
+  const nextSkillIds = override?.replaceSkillIds ? [...override.replaceSkillIds] : [...baseSkillIds];
+
+  for (const skillId of override?.addSkillIds ?? []) {
+    if (!nextSkillIds.includes(skillId)) {
+      nextSkillIds.push(skillId);
+    }
+  }
+
+  return nextSkillIds.filter((skillId) => !(override?.removeSkillIds ?? []).includes(skillId));
+}
+
+function buildBossPhaseEnvironment(
+  template: BossEncounterTemplate,
+  phase: BossEncounterPhaseConfig
+): BattleHazardState[] {
+  return (phase.environmentalEffects ?? []).map((effect, index) => {
+    const id = `${bossHazardIdPrefix(template.id)}${phase.id}-${index + 1}`;
+    if (effect.kind === "blocker") {
+      return {
+        id,
+        kind: "blocker",
+        lane: effect.lane,
+        name: effect.name,
+        description: effect.description,
+        durability: effect.durability,
+        maxDurability: effect.maxDurability ?? effect.durability
+      };
+    }
+
+    return {
+      id,
+      kind: "trap",
+      lane: effect.lane,
+      effect: effect.effect,
+      name: effect.name,
+      description: effect.description,
+      damage: effect.damage,
+      charges: effect.charges,
+      revealed: effect.revealed ?? false,
+      triggered: false,
+      ...(effect.grantedStatusId ? { grantedStatusId: effect.grantedStatusId } : {}),
+      ...(effect.triggeredByCamp ? { triggeredByCamp: effect.triggeredByCamp } : {})
+    };
+  });
+}
+
+function resolveBossScriptTarget(
+  state: BattleState,
+  bossUnit: UnitStack,
+  ability: BossEncounterScriptedAbilityConfig
+): string | undefined {
+  if (ability.target === "self") {
+    return bossUnit.id;
+  }
+
+  const candidates = Object.values(state.units)
+    .filter((unit) => unit.count > 0)
+    .filter((unit) => (ability.target === "lowest_hp_ally" ? unit.camp === bossUnit.camp : unit.camp !== bossUnit.camp));
+
+  if (ability.target === "first_enemy") {
+    return candidates
+      .sort((left, right) => left.lane - right.lane || left.id.localeCompare(right.id))[0]
+      ?.id;
+  }
+
+  return candidates
+    .sort((left, right) => totalUnitHitPoints(left) - totalUnitHitPoints(right) || left.id.localeCompare(right.id))[0]
+    ?.id;
+}
+
+export function attachBossEncounterTemplate(
+  state: BattleState,
+  templateId: string,
+  bossUnitId: string
+): BattleState {
+  const bossUnit = requireValue(state.units[bossUnitId], `Missing boss unit ${bossUnitId}`);
+  const template = getBossEncounterTemplateById(templateId);
+  if (template.bossUnitTemplateId && template.bossUnitTemplateId !== bossUnit.templateId) {
+    throw new Error(
+      `Boss encounter template ${templateId} requires unit template ${template.bossUnitTemplateId}, received ${bossUnit.templateId}`
+    );
+  }
+
+  const initialPhase = template.phases[0]!;
+  return resolveBossEncounterState({
+    ...state,
+    bossEncounter: {
+      templateId,
+      bossUnitId,
+      activePhaseId: initialPhase.id,
+      maxBossHp: totalUnitHitPoints(bossUnit),
+      triggeredAbilityKeys: []
+    }
+  });
+}
+
+export function resolveBossEncounterState(state: BattleState): BattleState {
+  if (!state.bossEncounter) {
+    return state;
+  }
+
+  const bossEncounter = state.bossEncounter;
+  const bossUnit = state.units[bossEncounter.bossUnitId];
+  if (!bossUnit) {
+    const { bossEncounter: _bossEncounter, ...nextState } = state;
+    return {
+      ...nextState,
+      environment: hazardsOf(state).filter((hazard) => !isBossHazardForTemplate(hazard, bossEncounter.templateId))
+    };
+  }
+
+  const template = getBossEncounterTemplateById(bossEncounter.templateId);
+  const phase = resolveBossEncounterPhase(template, bossUnit, bossEncounter.maxBossHp);
+  const desiredSkillIds = resolveBossPhaseSkillIds(bossUnit, phase);
+  const nextBossUnit = reconcileSkillStateIds(bossUnit, desiredSkillIds);
+  const phaseChanged = bossEncounter.activePhaseId !== phase.id;
+  const retainedEnvironment = hazardsOf(state).filter(
+    (hazard) => !isBossHazardForTemplate(hazard, bossEncounter.templateId)
+  );
+  const nextEnvironment = phaseChanged
+    ? retainedEnvironment.concat(buildBossPhaseEnvironment(template, phase))
+    : hazardsOf(state);
+  const nextLog =
+    phaseChanged && bossEncounter.activePhaseId
+      ? state.log.concat(`${nextBossUnit.stackName} 进入 ${phase.id}`)
+      : state.log;
+
+  return {
+    ...state,
+    units: {
+      ...state.units,
+      [nextBossUnit.id]: nextBossUnit
+    },
+    unitCooldowns: {
+      ...state.unitCooldowns,
+      [nextBossUnit.id]: buildCooldownStateFromSkills(nextBossUnit)
+    },
+    environment: nextEnvironment,
+    log: nextLog,
+    bossEncounter: {
+      ...bossEncounter,
+      activePhaseId: phase.id
+    }
+  };
 }
 
 function skillDefinitionFor(
@@ -1073,8 +1279,55 @@ function advanceTurnInternal(state: BattleState, actingUnitId: string, waited: b
   };
 }
 
-function prepareStateForActiveUnit(state: BattleState): BattleState {
+function resolveBossEncounterTimedAbilities(
+  state: BattleState,
+  actingUnitId: string,
+  timing: "pre_turn" | "post_turn"
+): BattleState {
+  const bossEncounter = state.bossEncounter;
+  if (!bossEncounter || bossEncounter.bossUnitId !== actingUnitId) {
+    return state;
+  }
+
+  const bossUnit = state.units[actingUnitId];
+  if (!bossUnit || bossUnit.count <= 0) {
+    return state;
+  }
+
+  const template = getBossEncounterTemplateById(bossEncounter.templateId);
+  const phase = template.phases.find((entry) => entry.id === bossEncounter.activePhaseId);
+  if (!phase) {
+    return state;
+  }
+
   let nextState = state;
+  for (const [abilityIndex, ability] of (phase.scriptedAbilities ?? []).entries()) {
+    if (ability.timing !== timing) {
+      continue;
+    }
+
+    const oncePerRound = ability.oncePerRound ?? true;
+    const triggerKey = `${phase.id}:${timing}:${nextState.round}:${ability.id || abilityIndex}`;
+    if (oncePerRound && nextState.bossEncounter?.triggeredAbilityKeys.includes(triggerKey)) {
+      continue;
+    }
+
+    const targetId = resolveBossScriptTarget(nextState, nextState.units[actingUnitId]!, ability);
+    const resolvedState = executeBattleSkillInternal(nextState, actingUnitId, ability.skillId, targetId, false);
+    nextState = {
+      ...resolvedState,
+      bossEncounter: {
+        ...resolvedState.bossEncounter!,
+        triggeredAbilityKeys: resolvedState.bossEncounter!.triggeredAbilityKeys.concat(triggerKey)
+      }
+    };
+  }
+
+  return nextState;
+}
+
+function prepareStateForActiveUnit(state: BattleState): BattleState {
+  let nextState = resolveBossEncounterState(state);
   let remainingIterations = Object.keys(state.units).length + 1;
 
   while (nextState.activeUnitId && remainingIterations > 0) {
@@ -1101,6 +1354,7 @@ function prepareStateForActiveUnit(state: BattleState): BattleState {
     }
 
     if (processed.unit.count > 0) {
+      nextState = resolveBossEncounterTimedAbilities(nextState, processed.unit.id, "pre_turn");
       break;
     }
 
@@ -1111,7 +1365,8 @@ function prepareStateForActiveUnit(state: BattleState): BattleState {
 }
 
 function advanceTurn(state: BattleState, actingUnitId: string, waited: boolean): BattleState {
-  return prepareStateForActiveUnit(advanceTurnInternal(state, actingUnitId, waited));
+  const postTurnState = resolveBossEncounterTimedAbilities(resolveBossEncounterState(state), actingUnitId, "post_turn");
+  return prepareStateForActiveUnit(resolveBossEncounterState(advanceTurnInternal(postTurnState, actingUnitId, waited)));
 }
 
 function triggerTrap(
@@ -1229,6 +1484,7 @@ function applyAttackSequence(
   attackerId: string,
   defenderId: string,
   options?: {
+    advanceTurnAfterAttack?: boolean;
     damageMultiplier?: number;
     allowRetaliation?: boolean;
     delivery?: "contact" | "ranged";
@@ -1376,25 +1632,23 @@ function applyAttackSequence(
     log.push(`${retaliatingDefender.stackName} 反击 ${attacker.stackName}，造成 ${retaliationDamage} 伤害`);
   }
 
-  return advanceTurn(
-    {
-      ...preparedState.state,
-      units: nextUnits,
-      log,
-      rng: nextRngState
-    },
-    attacker.id,
-    false
-  );
+  const nextState = resolveBossEncounterState({
+    ...preparedState.state,
+    units: nextUnits,
+    log,
+    rng: nextRngState
+  });
+  return options?.advanceTurnAfterAttack === false ? nextState : advanceTurn(nextState, attacker.id, false);
 }
 
-export function executeBattleSkill(
+function executeBattleSkillInternal(
   state: BattleState,
   unitId: string,
   skillId: BattleSkillId,
-  targetId?: string
+  targetId: string | undefined,
+  advanceTurnAfterCast: boolean
 ): BattleState {
-  const normalizedState = normalizeBattleState(state);
+  const normalizedState = resolveBossEncounterState(normalizeBattleState(state));
   const action: BattleAction = {
     type: "battle.skill",
     unitId,
@@ -1404,7 +1658,7 @@ export function executeBattleSkill(
   const validation = validateBattleAction(normalizedState, action);
   if (!validation.valid) {
     return {
-      ...normalizedState,
+      ...resolveBossEncounterState(normalizedState),
       log: normalizedState.log.concat(`Action rejected: ${validation.reason}`)
     };
   }
@@ -1438,18 +1692,15 @@ export function executeBattleSkill(
       log.push(`${caster.stackName} 施放 ${skillDefinition.name}`);
     }
 
-    return advanceTurn(
-      {
-        ...withUpdatedUnitCooldowns(stateWithCooldown, casterWithCooldown),
-        units: {
-          ...stateWithCooldown.units,
-          [nextTarget.id]: nextTarget
-        },
-        log
+    const nextState = resolveBossEncounterState({
+      ...withUpdatedUnitCooldowns(stateWithCooldown, casterWithCooldown),
+      units: {
+        ...stateWithCooldown.units,
+        [nextTarget.id]: nextTarget
       },
-      caster.id,
-      false
-    );
+      log
+    });
+    return advanceTurnAfterCast ? advanceTurn(nextState, caster.id, false) : nextState;
   }
 
   if (skillDefinition.target === "enemy" && targetId) {
@@ -1467,6 +1718,7 @@ export function executeBattleSkill(
       caster.id,
       targetId,
       {
+        advanceTurnAfterAttack: advanceTurnAfterCast,
         damageMultiplier:
           skillId === "bog_ambush"
             ? 2
@@ -1488,26 +1740,29 @@ export function executeBattleSkill(
       caster.id,
       catalogIndex
     );
-    return advanceTurn(
-      {
-        ...withUpdatedUnitCooldowns(stateWithCooldown, empoweredCaster),
-        log: normalizedState.log.concat(
-          `${caster.stackName} 施放 ${skillDefinition.name}，获得 ${describeGrantedStatus(grantedStatus)}`
-        )
-      },
-      caster.id,
-      false
-    );
+    const nextState = resolveBossEncounterState({
+      ...withUpdatedUnitCooldowns(stateWithCooldown, empoweredCaster),
+      log: normalizedState.log.concat(
+        `${caster.stackName} 施放 ${skillDefinition.name}，获得 ${describeGrantedStatus(grantedStatus)}`
+      )
+    });
+    return advanceTurnAfterCast ? advanceTurn(nextState, caster.id, false) : nextState;
   }
 
-  return advanceTurn(
-    {
-      ...stateWithCooldown,
-      log: normalizedState.log.concat(`${caster.stackName} 施放 ${skillDefinition.name}`)
-    },
-    caster.id,
-    false
-  );
+  const nextState = resolveBossEncounterState({
+    ...stateWithCooldown,
+    log: normalizedState.log.concat(`${caster.stackName} 施放 ${skillDefinition.name}`)
+  });
+  return advanceTurnAfterCast ? advanceTurn(nextState, caster.id, false) : nextState;
+}
+
+export function executeBattleSkill(
+  state: BattleState,
+  unitId: string,
+  skillId: BattleSkillId,
+  targetId?: string
+): BattleState {
+  return executeBattleSkillInternal(state, unitId, skillId, targetId, true);
 }
 
 export function validateBattleAction(state: BattleState, action: BattleAction): ValidationResult {
@@ -1728,7 +1983,11 @@ export function createNeutralBattleState(
   hero: HeroState,
   neutralArmy: NeutralArmyState,
   seed: number,
-  world?: WorldState
+  world?: WorldState,
+  options?: {
+    bossTemplateId?: string;
+    bossUnitId?: string;
+  }
 ): BattleState {
   const units: Record<string, UnitStack> = {};
   const catalog = getDefaultUnitCatalog();
@@ -1799,7 +2058,7 @@ export function createNeutralBattleState(
 
   const turnOrder = sortTurnOrder(units);
   const environment = createBattleEnvironmentState(lanes, seed);
-  return {
+  const baseState: BattleState = {
     id: `battle-${neutralArmy.id}`,
     round: 1,
     lanes,
@@ -1818,6 +2077,22 @@ export function createNeutralBattleState(
     encounterPosition: neutralArmy.position,
     battlefieldTerrain: terrainAtPosition(world, neutralArmy.position)
   };
+
+  if (!options?.bossTemplateId) {
+    return baseState;
+  }
+
+  const bossUnitId =
+    options.bossUnitId ??
+    Object.values(baseState.units)
+      .filter((unit) => unit.camp === "defender")
+      .sort((left, right) => totalUnitHitPoints(right) - totalUnitHitPoints(left) || left.id.localeCompare(right.id))[0]
+      ?.id;
+  if (!bossUnitId) {
+    return baseState;
+  }
+
+  return attachBossEncounterTemplate(baseState, options.bossTemplateId, bossUnitId);
 }
 
 export function createHeroBattleState(
@@ -1949,7 +2224,7 @@ export function applyBattleAction(state: BattleState, action: BattleAction): Bat
     state,
     action,
     validateBattleAction,
-    normalizeBattleState
+    (inputState) => resolveBossEncounterState(normalizeBattleState(inputState))
   );
   if (!validation.valid) {
     return {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -720,6 +720,69 @@ export interface BattleTrapState {
 
 export type BattleHazardState = BattleBlockerState | BattleTrapState;
 
+export interface BossEncounterPhaseSkillOverrides {
+  replaceSkillIds?: BattleSkillId[];
+  addSkillIds?: BattleSkillId[];
+  removeSkillIds?: BattleSkillId[];
+}
+
+export interface BossEncounterScriptedAbilityConfig {
+  id: string;
+  timing: "pre_turn" | "post_turn";
+  skillId: BattleSkillId;
+  target: "self" | "first_enemy" | "lowest_hp_enemy" | "lowest_hp_ally";
+  oncePerRound?: boolean;
+}
+
+export type BossEncounterEnvironmentalEffectConfig =
+  | {
+      kind: "blocker";
+      lane: number;
+      name: string;
+      description: string;
+      durability: number;
+      maxDurability?: number;
+    }
+  | {
+      kind: "trap";
+      lane: number;
+      effect: "damage" | "slow" | "silence";
+      name: string;
+      description: string;
+      damage: number;
+      charges: number;
+      grantedStatusId?: BattleStatusEffectId;
+      triggeredByCamp?: "attacker" | "defender" | "both";
+      revealed?: boolean;
+    };
+
+export interface BossEncounterPhaseConfig {
+  id: string;
+  hpThreshold: number;
+  skillOverrides?: BossEncounterPhaseSkillOverrides;
+  scriptedAbilities?: BossEncounterScriptedAbilityConfig[];
+  environmentalEffects?: BossEncounterEnvironmentalEffectConfig[];
+}
+
+export interface BossEncounterTemplate {
+  id: string;
+  name: string;
+  bossUnitTemplateId?: string;
+  phases: BossEncounterPhaseConfig[];
+}
+
+export interface BossEncounterTemplateCatalogConfig {
+  templates: BossEncounterTemplate[];
+}
+
+export interface BossEncounterState {
+  templateId: string;
+  bossUnitId: string;
+  activePhaseId: string;
+  maxBossHp: number;
+  triggeredAbilityKeys: string[];
+}
+
 export interface DeterministicRngState {
   seed: number;
   cursor: number;
@@ -741,6 +804,7 @@ export interface BattleState {
   defenderHeroId?: string;
   encounterPosition?: Vec2;
   battlefieldTerrain?: TerrainType;
+  bossEncounter?: BossEncounterState;
 }
 
 export type WorldAction =
@@ -1302,6 +1366,7 @@ export interface CampaignMission {
   enemyArmyCount: number;
   enemyStatMultiplier: number;
   bossEncounterName?: string;
+  bossTemplateId?: string;
   unlockMissionId?: string;
   introDialogue?: DialogueLine[];
   midDialogue?: DialogueLine[];
@@ -1338,6 +1403,7 @@ export interface DailyDungeonFloor {
   enemyArmyTemplateId: string;
   enemyArmyCount: number;
   enemyStatMultiplier: number;
+  bossTemplateId?: string;
   reward: DailyDungeonReward;
 }
 

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -1,5 +1,6 @@
 import defaultBattleSkillsConfig from "../../../configs/battle-skills.json";
 import defaultBattleBalanceConfig from "../../../configs/battle-balance.json";
+import defaultBossEncounterTemplatesConfig from "../../../configs/boss-encounter-templates.json";
 import defaultBuildingUpgradeConfig from "../../../configs/building-upgrades.json";
 import defaultHeroSkillTreesConfig from "../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
@@ -36,6 +37,8 @@ import type {
   BattleBalanceConfig,
   BattleSkillKind,
   BattleSkillTarget,
+  BossEncounterEnvironmentalEffectConfig,
+  BossEncounterTemplateCatalogConfig,
   BuildingUpgradeConfig,
   HeroSkillTreeConfig,
   MapObjectsConfig,
@@ -52,6 +55,9 @@ let runtimeMapObjectsConfig: MapObjectsConfig = structuredClone(defaultMapObject
 let runtimeUnitCatalog: UnitCatalogConfig = structuredClone(defaultUnitsConfig as UnitCatalogConfig);
 let runtimeBattleSkillCatalog: BattleSkillCatalogConfig = structuredClone(defaultBattleSkillsConfig as BattleSkillCatalogConfig);
 let runtimeBattleBalanceConfig: BattleBalanceConfig = structuredClone(defaultBattleBalanceConfig as BattleBalanceConfig);
+let runtimeBossEncounterTemplates: BossEncounterTemplateCatalogConfig = structuredClone(
+  defaultBossEncounterTemplatesConfig as BossEncounterTemplateCatalogConfig
+);
 let runtimeBuildingUpgradeConfig: BuildingUpgradeConfig = structuredClone(defaultBuildingUpgradeConfig as BuildingUpgradeConfig);
 let runtimeHeroSkillTree: HeroSkillTreeConfig = structuredClone(defaultHeroSkillTreesConfig as HeroSkillTreeConfig);
 
@@ -99,6 +105,10 @@ function cloneBattleSkillCatalog(config: BattleSkillCatalogConfig): BattleSkillC
 }
 
 function cloneBattleBalanceConfig(config: BattleBalanceConfig): BattleBalanceConfig {
+  return structuredClone(config);
+}
+
+function cloneBossEncounterTemplateCatalog(config: BossEncounterTemplateCatalogConfig): BossEncounterTemplateCatalogConfig {
   return structuredClone(config);
 }
 
@@ -187,6 +197,56 @@ function isBattleSkillDelivery(value: unknown): value is "contact" | "ranged" {
 
 function isBattleStatusEffectId(value: unknown): value is string {
   return isNonEmptyString(value);
+}
+
+function validateBossEncounterEnvironmentalEffect(
+  effect: BossEncounterEnvironmentalEffectConfig,
+  path: string,
+  statusIds: Set<string>
+): void {
+  if (!Number.isInteger(effect.lane) || effect.lane < 0) {
+    throw new Error(`${path}.lane must be a non-negative integer`);
+  }
+  if (!isNonEmptyString(effect.name)) {
+    throw new Error(`${path}.name must be a non-empty string`);
+  }
+  if (!isNonEmptyString(effect.description)) {
+    throw new Error(`${path}.description must be a non-empty string`);
+  }
+
+  if (effect.kind === "blocker") {
+    if (!Number.isInteger(effect.durability) || effect.durability <= 0) {
+      throw new Error(`${path}.durability must be a positive integer`);
+    }
+    if (effect.maxDurability !== undefined && (!Number.isInteger(effect.maxDurability) || effect.maxDurability <= 0)) {
+      throw new Error(`${path}.maxDurability must be a positive integer when provided`);
+    }
+    return;
+  }
+
+  if (effect.effect !== "damage" && effect.effect !== "slow" && effect.effect !== "silence") {
+    throw new Error(`${path}.effect has invalid value ${String(effect.effect)}`);
+  }
+  if (!Number.isInteger(effect.damage) || effect.damage < 0) {
+    throw new Error(`${path}.damage must be a non-negative integer`);
+  }
+  if (!Number.isInteger(effect.charges) || effect.charges <= 0) {
+    throw new Error(`${path}.charges must be a positive integer`);
+  }
+  if (effect.grantedStatusId !== undefined && !statusIds.has(effect.grantedStatusId)) {
+    throw new Error(`${path}.grantedStatusId references unknown battle status ${effect.grantedStatusId}`);
+  }
+  if (
+    effect.triggeredByCamp !== undefined &&
+    effect.triggeredByCamp !== "attacker" &&
+    effect.triggeredByCamp !== "defender" &&
+    effect.triggeredByCamp !== "both"
+  ) {
+    throw new Error(`${path}.triggeredByCamp has invalid value ${String(effect.triggeredByCamp)}`);
+  }
+  if (effect.revealed !== undefined && typeof effect.revealed !== "boolean") {
+    throw new Error(`${path}.revealed must be boolean when provided`);
+  }
 }
 
 export function validateBattleBalanceConfig(
@@ -368,6 +428,113 @@ export function validateBattleSkillCatalog(config: BattleSkillCatalogConfig): vo
     }
 
     skillIds.add(skill.id);
+  }
+}
+
+export function validateBossEncounterTemplateCatalog(
+  config: BossEncounterTemplateCatalogConfig,
+  battleSkillCatalog: BattleSkillCatalogConfig = runtimeBattleSkillCatalog,
+  unitCatalog: UnitCatalogConfig = runtimeUnitCatalog
+): void {
+  if (!Array.isArray(config.templates) || config.templates.length === 0) {
+    throw new Error("Boss encounter template catalog must contain a non-empty templates array");
+  }
+
+  const skillIds = new Set(battleSkillCatalog.skills.map((skill) => skill.id));
+  const statusIds = new Set(battleSkillCatalog.statuses.map((status) => status.id));
+  const unitIds = new Set(unitCatalog.templates.map((template) => template.id));
+  const templateIds = new Set<string>();
+
+  for (const template of config.templates) {
+    if (!isNonEmptyString(template.id)) {
+      throw new Error("Boss encounter template id must be a non-empty string");
+    }
+    if (templateIds.has(template.id)) {
+      throw new Error(`Duplicate boss encounter template id: ${template.id}`);
+    }
+    if (!isNonEmptyString(template.name)) {
+      throw new Error(`Boss encounter template ${template.id} must define a name`);
+    }
+    if (template.bossUnitTemplateId !== undefined && !unitIds.has(template.bossUnitTemplateId)) {
+      throw new Error(
+        `Boss encounter template ${template.id} references unknown unit template ${template.bossUnitTemplateId}`
+      );
+    }
+    if (!Array.isArray(template.phases) || template.phases.length === 0) {
+      throw new Error(`Boss encounter template ${template.id} must define at least one phase`);
+    }
+
+    let previousThreshold = Number.POSITIVE_INFINITY;
+    const phaseIds = new Set<string>();
+    for (const [phaseIndex, phase] of template.phases.entries()) {
+      const phasePath = `Boss encounter template ${template.id} phase[${phaseIndex}]`;
+      if (!isNonEmptyString(phase.id)) {
+        throw new Error(`${phasePath} must define a non-empty id`);
+      }
+      if (phaseIds.has(phase.id)) {
+        throw new Error(`Duplicate boss encounter phase id ${phase.id} in template ${template.id}`);
+      }
+      if (!isFiniteNumber(phase.hpThreshold) || phase.hpThreshold <= 0 || phase.hpThreshold > 1) {
+        throw new Error(`${phasePath}.hpThreshold must be within (0, 1]`);
+      }
+      if (phase.hpThreshold >= previousThreshold) {
+        throw new Error(`${phasePath}.hpThreshold must be in descending order`);
+      }
+
+      const overrideSkillLists = [
+        { path: `${phasePath}.skillOverrides.replaceSkillIds`, skillIds: phase.skillOverrides?.replaceSkillIds },
+        { path: `${phasePath}.skillOverrides.addSkillIds`, skillIds: phase.skillOverrides?.addSkillIds },
+        { path: `${phasePath}.skillOverrides.removeSkillIds`, skillIds: phase.skillOverrides?.removeSkillIds }
+      ];
+      for (const entry of overrideSkillLists) {
+        for (const skillId of entry.skillIds ?? []) {
+          if (!skillIds.has(skillId)) {
+            throw new Error(`${entry.path} references unknown battle skill ${skillId}`);
+          }
+        }
+      }
+
+      for (const [abilityIndex, ability] of (phase.scriptedAbilities ?? []).entries()) {
+        const abilityPath = `${phasePath}.scriptedAbilities[${abilityIndex}]`;
+        if (!isNonEmptyString(ability.id)) {
+          throw new Error(`${abilityPath}.id must be a non-empty string`);
+        }
+        if (!skillIds.has(ability.skillId)) {
+          throw new Error(`${abilityPath}.skillId references unknown battle skill ${ability.skillId}`);
+        }
+        if (ability.timing !== "pre_turn" && ability.timing !== "post_turn") {
+          throw new Error(`${abilityPath}.timing has invalid value ${String(ability.timing)}`);
+        }
+        if (
+          ability.target !== "self" &&
+          ability.target !== "first_enemy" &&
+          ability.target !== "lowest_hp_enemy" &&
+          ability.target !== "lowest_hp_ally"
+        ) {
+          throw new Error(`${abilityPath}.target has invalid value ${String(ability.target)}`);
+        }
+        if (ability.oncePerRound !== undefined && typeof ability.oncePerRound !== "boolean") {
+          throw new Error(`${abilityPath}.oncePerRound must be boolean when provided`);
+        }
+      }
+
+      for (const [effectIndex, effect] of (phase.environmentalEffects ?? []).entries()) {
+        validateBossEncounterEnvironmentalEffect(
+          effect,
+          `${phasePath}.environmentalEffects[${effectIndex}]`,
+          statusIds
+        );
+      }
+
+      phaseIds.add(phase.id);
+      previousThreshold = phase.hpThreshold;
+    }
+
+    if (template.phases[0]?.hpThreshold !== 1) {
+      throw new Error(`Boss encounter template ${template.id} must start with a phase at hpThreshold 1`);
+    }
+
+    templateIds.add(template.id);
   }
 }
 
@@ -822,6 +989,12 @@ export function getBattleBalanceConfig(): BattleBalanceConfig {
   return config;
 }
 
+export function getDefaultBossEncounterTemplateCatalog(): BossEncounterTemplateCatalogConfig {
+  const config = cloneBossEncounterTemplateCatalog(runtimeBossEncounterTemplates);
+  validateBossEncounterTemplateCatalog(config, runtimeBattleSkillCatalog, runtimeUnitCatalog);
+  return config;
+}
+
 export function getBuildingUpgradeConfig(): BuildingUpgradeConfig {
   const config = cloneBuildingUpgradeConfig(runtimeBuildingUpgradeConfig);
   validateBuildingUpgradeConfig(config);
@@ -1043,6 +1216,7 @@ export function resetRuntimeConfigs(): void {
   runtimeUnitCatalog = structuredClone(defaultUnitsConfig as UnitCatalogConfig);
   runtimeBattleSkillCatalog = structuredClone(defaultBattleSkillsConfig as BattleSkillCatalogConfig);
   runtimeBattleBalanceConfig = structuredClone(defaultBattleBalanceConfig as BattleBalanceConfig);
+  runtimeBossEncounterTemplates = structuredClone(defaultBossEncounterTemplatesConfig as BossEncounterTemplateCatalogConfig);
   runtimeBuildingUpgradeConfig = structuredClone(defaultBuildingUpgradeConfig as BuildingUpgradeConfig);
   runtimeHeroSkillTree = structuredClone(defaultHeroSkillTreesConfig as HeroSkillTreeConfig);
 }

--- a/packages/shared/test/battle.test.ts
+++ b/packages/shared/test/battle.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyBattleAction,
+  attachBossEncounterTemplate,
+  createEmptyBattleState,
+  resolveBossEncounterState,
+  type BattleState,
+  type UnitStack
+} from "../src/index.ts";
+
+function createUnit(base: Partial<UnitStack> & Pick<UnitStack, "id" | "templateId" | "camp" | "stackName">): UnitStack {
+  return {
+    id: base.id,
+    templateId: base.templateId,
+    camp: base.camp,
+    lane: base.lane ?? 0,
+    stackName: base.stackName,
+    initiative: base.initiative ?? 8,
+    attack: base.attack ?? 4,
+    defense: base.defense ?? 4,
+    minDamage: base.minDamage ?? 2,
+    maxDamage: base.maxDamage ?? 4,
+    count: base.count ?? 1,
+    currentHp: base.currentHp ?? 10,
+    maxHp: base.maxHp ?? 10,
+    hasRetaliated: false,
+    defending: false,
+    skills: base.skills ?? [],
+    statusEffects: base.statusEffects ?? []
+  };
+}
+
+function createBossBattle(): BattleState {
+  return attachBossEncounterTemplate(
+    {
+      ...createEmptyBattleState(),
+      id: "battle-boss-template",
+      round: 1,
+      activeUnitId: "boss",
+      turnOrder: ["boss", "hero"],
+      units: {
+        boss: createUnit({
+          id: "boss",
+          templateId: "shadow_hexer",
+          camp: "defender",
+          stackName: "Shadow Warden",
+          currentHp: 10,
+          maxHp: 10
+        }),
+        hero: createUnit({
+          id: "hero",
+          templateId: "hero_guard_basic",
+          camp: "attacker",
+          stackName: "Hero Guard",
+          initiative: 9
+        })
+      },
+      unitCooldowns: {
+        boss: {},
+        hero: {}
+      }
+    },
+    "boss-shadow-warden",
+    "boss"
+  );
+}
+
+test("resolveBossEncounterState transitions boss phases and swaps phase environment", () => {
+  const opening = createBossBattle();
+  assert.equal(opening.bossEncounter?.activePhaseId, "phase-1-veil");
+  assert.deepEqual(opening.units.boss?.skills?.map((skill) => skill.id), ["grave_silence", "bog_veil"]);
+  assert.equal(opening.environment.length, 0);
+
+  const phaseTwo = resolveBossEncounterState({
+    ...opening,
+    units: {
+      ...opening.units,
+      boss: {
+        ...opening.units.boss!,
+        currentHp: 6
+      }
+    }
+  });
+  assert.equal(phaseTwo.bossEncounter?.activePhaseId, "phase-2-warden-grip");
+  assert.deepEqual(phaseTwo.units.boss?.skills?.map((skill) => skill.id), ["grave_silence", "taunt_shout", "bog_veil"]);
+  assert.equal(phaseTwo.environment[0]?.kind, "trap");
+  assert.equal(phaseTwo.environment[0]?.name, "Veil Snare");
+
+  const phaseThree = resolveBossEncounterState({
+    ...phaseTwo,
+    units: {
+      ...phaseTwo.units,
+      boss: {
+        ...phaseTwo.units.boss!,
+        currentHp: 2
+      }
+    }
+  });
+  assert.equal(phaseThree.bossEncounter?.activePhaseId, "phase-3-last-watch");
+  assert.deepEqual(phaseThree.units.boss?.skills?.map((skill) => skill.id), ["grave_silence", "stunning_blow", "bog_veil"]);
+  assert.equal(phaseThree.environment.length, 0);
+});
+
+test("boss post-turn scripted abilities resolve through the shared battle path", () => {
+  const opening = createBossBattle();
+  const phaseTwo = resolveBossEncounterState({
+    ...opening,
+    units: {
+      ...opening.units,
+      boss: {
+        ...opening.units.boss!,
+        currentHp: 6
+      }
+    }
+  });
+
+  const next = applyBattleAction(phaseTwo, {
+    type: "battle.defend",
+    unitId: "boss"
+  });
+
+  assert.equal(next.activeUnitId, "hero");
+  assert.equal(next.units.hero?.statusEffects?.some((status) => status.id === "taunted"), true);
+  assert.equal(next.units.boss?.skills?.find((skill) => skill.id === "taunt_shout")?.remainingCooldown, 3);
+  assert.equal(next.bossEncounter?.triggeredAbilityKeys.length, 1);
+});

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -5,6 +5,7 @@ import {
   getDefaultEquipmentCatalog,
   getDefaultBattleBalanceConfig,
   validateBattleBalanceConfig,
+  validateBossEncounterTemplateCatalog,
   validateBattleSkillCatalog,
   validateDailyDungeonConfigDocument,
   validateContentPackConsistency,
@@ -15,6 +16,7 @@ import {
   validateWorldConfig,
   type BattleBalanceConfig,
   type BattleSkillCatalogConfig,
+  type BossEncounterTemplateCatalogConfig,
   type ContentPackDocumentId,
   type ContentPackValidationIssue,
   type DailyDungeonConfigDocument,
@@ -30,7 +32,7 @@ import {
   type ContentPackMapPackDefinition
 } from "./content-pack-map-packs.ts";
 
-type ValidationDocumentId = ContentPackDocumentId | "heroSkills" | "equipment" | "dailyDungeons";
+type ValidationDocumentId = ContentPackDocumentId | "heroSkills" | "equipment" | "dailyDungeons" | "bossTemplates";
 
 interface DocumentValidationIssue {
   bundleId: string;
@@ -205,10 +207,11 @@ async function validateAuthoringConfigs(
     }
   };
 
-  const [compactHeroSkills, fullHeroSkills, dailyDungeons] = await Promise.all([
+  const [compactHeroSkills, fullHeroSkills, dailyDungeons, bossTemplates] = await Promise.all([
     readJsonConfig<HeroSkillTreeConfig>(rootDir, "hero-skills.json"),
     readJsonConfig<HeroSkillTreeConfig>(rootDir, "hero-skill-trees-full.json"),
-    readJsonConfig<DailyDungeonConfigDocument>(rootDir, "daily-dungeons.json")
+    readJsonConfig<DailyDungeonConfigDocument>(rootDir, "daily-dungeons.json"),
+    readJsonConfig<BossEncounterTemplateCatalogConfig>(rootDir, "boss-encounter-templates.json")
   ]);
 
   capture("heroSkills", "hero-skills.json", () => validateHeroSkillTreeConfig(compactHeroSkills, battleSkills));
@@ -221,6 +224,9 @@ async function validateAuthoringConfigs(
       throw new Error(`${firstIssue?.path}: ${firstIssue?.message}`);
     }
   });
+  capture("bossTemplates", "boss-encounter-templates.json", () =>
+    validateBossEncounterTemplateCatalog(bossTemplates, battleSkills)
+  );
 
   return issues;
 }


### PR DESCRIPTION
## Summary
- add shared boss encounter template schema, default JSON configs, and authoring validation for boss templates
- resolve boss phases, phase-specific skills and hazards, and scripted boss ability activations in shared battle logic
- wire campaign boss template references into PvE content loading and cover the new behavior with focused tests

## Validation
- npm run typecheck:shared
- npm run typecheck:server
- node --import tsx --test packages/shared/test/battle.test.ts
- node --import tsx --test apps/server/test/pve-content.test.ts
- npm run validate:content-pack

Closes #921