### PR TITLE
[codex] keep local Codex artifacts out of the git working tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist
 .turbo
 coverage
 .coverage
+.codex
+.codex-last-*.txt
+.codex-runs/
 *.log
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ npm run validate:quickstart
 - 构建 H5 调试壳
 - 以默认内存存储启动本地服务，并校验 `health` / `auth-readiness` / `lobby` 接口
 
+本地 Codex 会话如果把元数据写在仓库内，默认只允许落在仓库根目录的 `.codex`、`.codex-last-*.txt` 和 `.codex-runs/`。这些路径是本机临时产物，已被 `.gitignore` 排除，不应加入提交或作为发布证据目录使用。
+
 验证通过后，常用本地运行命令如下：
 
 ```bash

--- a/scripts/test/codex-local-artifacts-hygiene.test.ts
+++ b/scripts/test/codex-local-artifacts-hygiene.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = process.cwd();
+const gitignorePath = path.join(repoRoot, ".gitignore");
+const readmePath = path.join(repoRoot, "README.md");
+
+test("gitignore excludes local Codex workspace artifacts", () => {
+  const gitignore = fs.readFileSync(gitignorePath, "utf8");
+
+  assert.match(gitignore, /^\.codex$/m);
+  assert.match(gitignore, /^\.codex-last-\*\.txt$/m);
+  assert.match(gitignore, /^\.codex-runs\/$/m);
+});
+
+test("README documents the local Codex artifact home", () => {
+  const readme = fs.readFileSync(readmePath, "utf8");
+
+  assert.match(readme, /本地 Codex 会话/);
+  assert.match(readme, /`\.codex`、`\.codex-last-\*\.txt` 和 `\.codex-runs\/`/);
+  assert.match(readme, /已被 `\.gitignore` 排除/);
+});


### PR DESCRIPTION
## Summary
- ignore repo-root local Codex session artifacts so they do not dirty a clean checkout
- document the local-only Codex artifact paths in the contributor quickstart
- add a regression test that keeps the ignore rules and README note aligned

## Validation
- `node --import tsx --test ./scripts/test/codex-local-artifacts-hygiene.test.ts`
- `git status --short --branch`

Closes #944