### PR TITLE
release: add a single Phase 1 exit audit for one candidate revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 - 发布健康度聚合摘要：`npm run release:health:summary`
 - 最近候选包发布健康趋势基线：`npm run release:health:trend-baseline`
 - 当前候选包对比最近发布健康基线：`npm run release:health:trend-compare`
+- Phase 1 exit audit：`npm run release:phase1:exit-audit -- --candidate <candidate-name> --candidate-revision <git-sha> [--target-surface h5|wechat] [--output-dir artifacts/release-readiness/phase1-exit-audit-<candidate>-<git-sha>]`（把 `docs/phase1-maturity-scorecard.md` 的 8 条显式退出标准映射成一个 candidate-scoped `pass|fail|pending` JSON / Markdown 审计，并附上每条结论引用的源 artifact）
 - Phase 1 candidate dossier + single exit evidence gate：`npm run release:phase1:candidate-dossier -- --candidate <candidate-name> --candidate-revision <git-sha> [--server-url http://127.0.0.1:2567] [--output-dir artifacts/release-dossiers/<candidate>-<git-sha>]`
 - 打包 H5 客户端 RC 冒烟：`npm run smoke:client:release-candidate`
 - 微信小游戏真实导出校验：`npm run validate:wechat-build -- --output-dir <wechatgame-build-dir> --expect-exported-runtime`
@@ -243,6 +244,7 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 - 仓库成熟度基线与独立 follow-up slices：`docs/repo-maturity-baseline.md`
 - 核心玩法发布门禁清单：`docs/core-gameplay-release-readiness.md`
 - 发布就绪快照说明：`docs/release-readiness-snapshot.md`
+- Phase 1 exit audit：`docs/phase1-exit-audit.md`
 - Phase 1 candidate dossier：`docs/phase1-candidate-dossier.md`
 - 发布健康度聚合说明：`docs/release-health-summary.md`
 - 最近候选包发布健康趋势基线：`docs/release-health-trend-baseline.md`

--- a/docs/phase1-candidate-dossier.md
+++ b/docs/phase1-candidate-dossier.md
@@ -4,6 +4,8 @@
 
 It now also emits one explicit candidate-level `Phase 1 exit evidence gate` so reviewers can make the final pass/pending/fail call from one object instead of re-interpreting each evidence section by hand.
 
+If reviewers need the eight explicit scorecard exit criteria as first-class `pass|fail|pending` rows instead of the dossier's broader section-level gate, use [`docs/phase1-exit-audit.md`](./phase1-exit-audit.md) and `npm run release:phase1:exit-audit`.
+
 The same run also emits a smaller runtime observability dossier that keeps the target-environment runtime probes and reconnect/session-recovery evidence in one reviewer-facing artifact for the same candidate revision.
 
 For release-time target-environment enforcement, use `npm run release:runtime-observability:gate`. The dossier can either sample the live endpoints directly with `--server-url` or reuse a previously written gate report with `--runtime-observability-gate`.

--- a/docs/phase1-exit-audit.md
+++ b/docs/phase1-exit-audit.md
@@ -1,0 +1,76 @@
+# Phase 1 Exit Audit
+
+`npm run release:phase1:exit-audit` emits the single reviewer-facing Phase 1 exit call for one candidate revision.
+
+The command reuses the existing Phase 1 evidence producers and turns the explicit exit criteria from [`docs/phase1-maturity-scorecard.md`](./phase1-maturity-scorecard.md) into first-class audited rows:
+
+1. bounded scope remains intact
+2. core automated gates are green
+3. release readiness snapshot has no required failures or pending required checks
+4. Cocos primary-client evidence is current
+5. WeChat release evidence is current when WeChat is the target surface
+6. runtime observability is proven
+7. Phase 1 persistence/content evidence is current
+8. known blockers are closed or explicitly accepted
+
+Each row is reported as `pass`, `fail`, or `pending`, and each row links back to the exact source artifacts used for the decision. The JSON artifact is intended for CI/automation, and the Markdown artifact is intended for release review / PR attachment.
+
+## Usage
+
+Use the latest local artifacts:
+
+```bash
+npm run release:phase1:exit-audit -- \
+  --candidate <candidate-name> \
+  --candidate-revision <git-sha>
+```
+
+Pin the exact upstream artifacts when CI or a rehearsal job already produced stable paths:
+
+```bash
+npm run release:phase1:exit-audit -- \
+  --candidate phase1-wechat-rc \
+  --candidate-revision abc1234 \
+  --target-surface wechat \
+  --snapshot artifacts/release-readiness/release-readiness-abc1234.json \
+  --cocos-bundle artifacts/release-readiness/cocos-rc-evidence-bundle-phase1-wechat-rc-abc1234.json \
+  --wechat-candidate-summary artifacts/wechat-release/codex.wechat.release-candidate-summary.json \
+  --runtime-observability-gate artifacts/release-readiness/runtime-observability-gate-phase1-wechat-rc-abc1234.json \
+  --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary-phase1-wechat-rc-abc1234.json \
+  --phase1-persistence artifacts/release-readiness/phase1-release-persistence-regression-abc1234.json
+```
+
+Write into one stable candidate directory:
+
+```bash
+npm run release:phase1:exit-audit -- \
+  --candidate phase1-wechat-rc \
+  --candidate-revision abc1234 \
+  --output-dir artifacts/release-readiness/phase1-exit-audit-phase1-wechat-rc-abc1234
+```
+
+## Outputs
+
+Default outputs:
+
+- `artifacts/release-readiness/phase1-exit-audit-<candidate>-<short-sha>.json`
+- `artifacts/release-readiness/phase1-exit-audit-<candidate>-<short-sha>.md`
+
+If `--output-dir` is set, the command writes:
+
+- `phase1-exit-audit.json`
+- `phase1-exit-audit.md`
+
+## Decision Model
+
+- `fail`: the candidate is blocked on one or more required exit criteria
+- `pending`: no current blocker is recorded, but required evidence is stale or otherwise not fresh enough to close the criterion
+- `pass`: the criterion is currently satisfied for the candidate revision
+
+The audit intentionally treats missing optional WeChat evidence as non-blocking when the target surface is `h5`. When the target surface is `wechat`, the candidate summary, smoke/manual-review state, and linked blocker artifacts become required input for the WeChat criterion.
+
+## Relationship To Other Reports
+
+- Use [`docs/phase1-candidate-dossier.md`](./phase1-candidate-dossier.md) when reviewers need the broader section-by-section drill-down.
+- Use this exit audit when reviewers want the explicit scorecard criteria mapped into one top-level release decision input.
+- Use [`docs/release-go-no-go-decision-packet.md`](./release-go-no-go-decision-packet.md) after the lower-level artifacts already exist and the release owner wants the final operator packet.

--- a/docs/phase1-maturity-scorecard.md
+++ b/docs/phase1-maturity-scorecard.md
@@ -78,6 +78,8 @@ The shipped config/content pack validates cleanly, and `npm run test:phase1-rele
 8. `Known Phase 1 blockers are closed or explicitly accepted.`
 Any remaining Cocos presentation fallback, reconnect risk, multiplayer divergence risk, or release-process blocker is either fixed or recorded as a conscious non-blocking acceptance with owner and rationale.
 
+To audit these eight criteria directly for one candidate revision, run [`npm run release:phase1:exit-audit`](../package.json) and see [`docs/phase1-exit-audit.md`](./phase1-exit-audit.md).
+
 ## Battle Presentation Baseline
 
 For the primary Cocos client battle path, the following now count as `production-intent` presentation behavior rather than fallback:

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "release:health:trend-baseline": "node --import tsx ./scripts/release-health-trend-baseline.ts",
     "release:health:trend-compare": "node --import tsx ./scripts/release-health-trend-baseline.ts --compare-current",
     "release:phase1:same-revision-evidence-bundle": "node --import tsx ./scripts/phase1-same-revision-evidence-bundle.ts",
+    "release:phase1:exit-audit": "node --import tsx ./scripts/phase1-exit-audit.ts",
     "release:phase1:candidate-dossier": "node --import tsx ./scripts/phase1-candidate-dossier.ts",
     "release:phase1:candidate-rehearsal": "node --import tsx ./scripts/phase1-candidate-rehearsal.ts",
     "release:wechat:rehearsal": "node --import tsx ./scripts/wechat-release-rehearsal.ts",

--- a/scripts/phase1-exit-audit.ts
+++ b/scripts/phase1-exit-audit.ts
@@ -1,0 +1,1034 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { buildPhase1CandidateDossier } from "./phase1-candidate-dossier.ts";
+
+type TargetSurface = "h5" | "wechat";
+type DossierResult = "passed" | "failed" | "pending" | "accepted_risk";
+type CriterionStatus = "pass" | "fail" | "pending";
+type OverallStatus = CriterionStatus;
+type EvidenceFreshness = "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp" | "unknown";
+
+interface Args {
+  candidate?: string;
+  candidateRevision?: string;
+  serverUrl?: string;
+  runtimeObservabilityGatePath?: string;
+  snapshotPath?: string;
+  h5SmokePath?: string;
+  reconnectSoakPath?: string;
+  wechatArtifactsDir?: string;
+  wechatCandidateSummaryPath?: string;
+  wechatRcValidationPath?: string;
+  wechatSmokeReportPath?: string;
+  cocosBundlePath?: string;
+  persistencePath?: string;
+  syncGovernancePath?: string;
+  ciTrendSummaryPath?: string;
+  coverageSummaryPath?: string;
+  configCenterLibraryPath?: string;
+  targetSurface: TargetSurface;
+  outputDir?: string;
+  outputPath?: string;
+  markdownOutputPath?: string;
+  maxEvidenceAgeHours: number;
+}
+
+interface DossierEvidenceRef {
+  label: string;
+  path: string;
+  summary: string;
+  observedAt?: string;
+  revision?: string;
+  freshness: EvidenceFreshness;
+}
+
+interface DossierSection {
+  id: string;
+  label: string;
+  required: boolean;
+  result: DossierResult;
+  summary: string;
+  artifactPath?: string;
+  observedAt?: string;
+  freshness: EvidenceFreshness;
+  revision?: string;
+  details: string[];
+  evidence: DossierEvidenceRef[];
+}
+
+interface DossierAcceptedRisk {
+  id: string;
+  label: string;
+  reason: string;
+  approvedBy?: string;
+  approvedAt?: string;
+  expiresAt?: string;
+  artifactPath?: string;
+  revision?: string;
+}
+
+interface Phase1CandidateDossier {
+  generatedAt: string;
+  candidate: {
+    name: string;
+    revision: string;
+    shortRevision: string;
+    branch: string;
+    dirty: boolean;
+    targetSurface: TargetSurface;
+  };
+  summary: {
+    status: DossierResult;
+    requiredFailed: string[];
+    requiredPending: string[];
+    acceptedRiskCount: number;
+  };
+  phase1ExitEvidenceGate: {
+    result: DossierResult;
+    summary: string;
+    blockingSections: string[];
+    pendingSections: string[];
+    acceptedRiskSections: string[];
+  };
+  inputs: {
+    serverUrl?: string;
+    runtimeObservabilityGatePath?: string;
+    snapshotPath?: string;
+    h5SmokePath?: string;
+    reconnectSoakPath?: string;
+    wechatArtifactsDir?: string;
+    wechatCandidateSummaryPath?: string;
+    wechatRcValidationPath?: string;
+    wechatSmokeReportPath?: string;
+    cocosBundlePath?: string;
+    persistencePath?: string;
+    syncGovernancePath?: string;
+    ciTrendSummaryPath?: string;
+    coverageSummaryPath?: string;
+    configCenterLibraryPath?: string;
+  };
+  sections: DossierSection[];
+  acceptedRisks: DossierAcceptedRisk[];
+}
+
+interface SnapshotCheck {
+  id?: string;
+  title?: string;
+  status?: "passed" | "failed" | "pending" | "not_applicable";
+  command?: string;
+}
+
+interface ReleaseReadinessSnapshot {
+  generatedAt?: string;
+  revision?: {
+    commit?: string;
+    shortCommit?: string;
+  };
+  summary?: {
+    status?: string;
+    requiredFailed?: number;
+    requiredPending?: number;
+  };
+  checks?: SnapshotCheck[];
+}
+
+interface CocosRcBundleManifest {
+  bundle?: {
+    generatedAt?: string;
+    candidate?: string;
+    commit?: string;
+    shortCommit?: string;
+    overallStatus?: string;
+    summary?: string;
+  };
+  review?: {
+    phase1Gate?: string;
+    attachHint?: string;
+  };
+  journey?: Array<{
+    id?: string;
+    title?: string;
+    status?: string;
+  }>;
+  requiredEvidence?: Array<{
+    id?: string;
+    label?: string;
+    filled?: boolean;
+  }>;
+  artifacts?: {
+    snapshot?: string;
+    summaryMarkdown?: string;
+    checklistMarkdown?: string;
+    blockersMarkdown?: string;
+    presentationSignoff?: string;
+  };
+}
+
+interface WechatCandidateSummary {
+  generatedAt?: string;
+  candidate?: {
+    revision?: string | null;
+    version?: string | null;
+    status?: "ready" | "blocked";
+  };
+  evidence?: {
+    manualReview?: {
+      status?: "ready" | "blocked";
+      requiredPendingChecks?: number;
+      requiredFailedChecks?: number;
+      requiredMetadataFailures?: number;
+    };
+  };
+  blockers?: Array<{
+    id?: string;
+    summary?: string;
+    artifactPath?: string;
+  }>;
+}
+
+interface PersistenceReport {
+  generatedAt?: string;
+  revision?: {
+    commit?: string;
+    shortCommit?: string;
+  };
+  requestedStorageMode?: string;
+  effectiveStorageMode?: string;
+  storageDescription?: string;
+  summary?: {
+    status?: string;
+    assertionCount?: number;
+  };
+  contentValidation?: {
+    valid?: boolean;
+    summary?: string;
+    issueCount?: number;
+  };
+  persistenceRegression?: {
+    mapPackId?: string;
+    assertions?: string[];
+  };
+}
+
+interface SourceArtifact {
+  label: string;
+  path: string;
+}
+
+interface ExitCriterionReport {
+  number: number;
+  id:
+    | "bounded-scope"
+    | "core-automated-gates"
+    | "release-readiness-snapshot"
+    | "cocos-primary-client-evidence"
+    | "wechat-release-evidence"
+    | "runtime-observability"
+    | "phase1-data-persistence"
+    | "known-blockers";
+  title: string;
+  status: CriterionStatus;
+  summary: string;
+  details: string[];
+  sourceArtifacts: SourceArtifact[];
+}
+
+interface Phase1ExitAuditReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  candidate: {
+    name: string;
+    revision: string;
+    shortRevision: string;
+    branch: string;
+    dirty: boolean;
+    targetSurface: TargetSurface;
+  };
+  summary: {
+    status: OverallStatus;
+    blockedCriteria: string[];
+    pendingCriteria: string[];
+    acceptedRiskCount: number;
+    summary: string;
+  };
+  inputs: Phase1CandidateDossier["inputs"];
+  phase1ExitEvidenceGate: Phase1CandidateDossier["phase1ExitEvidenceGate"];
+  acceptedRisks: DossierAcceptedRisk[];
+  criteria: ExitCriterionReport[];
+}
+
+const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
+const SCORECARD_DOC_PATH = path.resolve("docs", "phase1-maturity-scorecard.md");
+const README_PATH = path.resolve("README.md");
+const PHASE1_DESIGN_DOC_PATH = path.resolve("docs", "phase1-design.md");
+const COCOS_PRESENTATION_SIGNOFF_DOC_PATH = path.resolve("docs", "cocos-phase1-presentation-signoff.md");
+const WECHAT_RELEASE_DOC_PATH = path.resolve("docs", "wechat-minigame-release.md");
+
+const REQUIRED_CORE_GATES = [
+  {
+    label: "npm test",
+    command: "npm test",
+    aliases: ["npm-test"]
+  },
+  {
+    label: "npm run typecheck:ci",
+    command: "npm run typecheck:ci",
+    aliases: ["typecheck-ci"]
+  },
+  {
+    label: "npm run test:e2e:smoke",
+    command: "npm run test:e2e:smoke",
+    aliases: ["e2e-smoke"]
+  },
+  {
+    label: "npm run test:e2e:multiplayer:smoke",
+    command: "npm run test:e2e:multiplayer:smoke",
+    aliases: ["e2e-multiplayer-smoke"]
+  },
+  {
+    label: "npm run check:cocos-release-readiness",
+    command: "npm run check:cocos-release-readiness",
+    aliases: ["cocos-release-readiness", "check-cocos-release-readiness"]
+  }
+] as const;
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let candidate: string | undefined;
+  let candidateRevision: string | undefined;
+  let serverUrl: string | undefined;
+  let runtimeObservabilityGatePath: string | undefined;
+  let snapshotPath: string | undefined;
+  let h5SmokePath: string | undefined;
+  let reconnectSoakPath: string | undefined;
+  let wechatArtifactsDir: string | undefined;
+  let wechatCandidateSummaryPath: string | undefined;
+  let wechatRcValidationPath: string | undefined;
+  let wechatSmokeReportPath: string | undefined;
+  let cocosBundlePath: string | undefined;
+  let persistencePath: string | undefined;
+  let syncGovernancePath: string | undefined;
+  let ciTrendSummaryPath: string | undefined;
+  let coverageSummaryPath: string | undefined;
+  let configCenterLibraryPath: string | undefined;
+  let targetSurface: TargetSurface = "wechat";
+  let outputDir: string | undefined;
+  let outputPath: string | undefined;
+  let markdownOutputPath: string | undefined;
+  let maxEvidenceAgeHours = 72;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--candidate" && next) {
+      candidate = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--candidate-revision" && next) {
+      candidateRevision = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--server-url" && next) {
+      serverUrl = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--runtime-observability-gate" && next) {
+      runtimeObservabilityGatePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--snapshot" && next) {
+      snapshotPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--h5-smoke" && next) {
+      h5SmokePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--reconnect-soak" && next) {
+      reconnectSoakPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--wechat-artifacts-dir" && next) {
+      wechatArtifactsDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--wechat-candidate-summary" && next) {
+      wechatCandidateSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--wechat-rc-validation" && next) {
+      wechatRcValidationPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--wechat-smoke-report" && next) {
+      wechatSmokeReportPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--cocos-bundle" && next) {
+      cocosBundlePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--phase1-persistence" && next) {
+      persistencePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--sync-governance" && next) {
+      syncGovernancePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--ci-trend-summary" && next) {
+      ciTrendSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--coverage-summary" && next) {
+      coverageSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--config-center-library" && next) {
+      configCenterLibraryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--target-surface" && next) {
+      if (next !== "h5" && next !== "wechat") {
+        fail(`Unsupported --target-surface value: ${next}`);
+      }
+      targetSurface = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output-dir" && next) {
+      outputDir = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--markdown-output" && next) {
+      markdownOutputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--max-evidence-age-hours" && next) {
+      const parsed = Number(next);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        fail(`--max-evidence-age-hours must be a positive number, received: ${next}`);
+      }
+      maxEvidenceAgeHours = parsed;
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    ...(candidate ? { candidate } : {}),
+    ...(candidateRevision ? { candidateRevision } : {}),
+    ...(serverUrl ? { serverUrl } : {}),
+    ...(runtimeObservabilityGatePath ? { runtimeObservabilityGatePath } : {}),
+    ...(snapshotPath ? { snapshotPath } : {}),
+    ...(h5SmokePath ? { h5SmokePath } : {}),
+    ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
+    ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
+    ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
+    ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
+    ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
+    ...(cocosBundlePath ? { cocosBundlePath } : {}),
+    ...(persistencePath ? { persistencePath } : {}),
+    ...(syncGovernancePath ? { syncGovernancePath } : {}),
+    ...(ciTrendSummaryPath ? { ciTrendSummaryPath } : {}),
+    ...(coverageSummaryPath ? { coverageSummaryPath } : {}),
+    ...(configCenterLibraryPath ? { configCenterLibraryPath } : {}),
+    targetSurface,
+    ...(outputDir ? { outputDir } : {}),
+    ...(outputPath ? { outputPath } : {}),
+    ...(markdownOutputPath ? { markdownOutputPath } : {}),
+    maxEvidenceAgeHours
+  };
+}
+
+function readJsonFile<T>(filePath: string | undefined): T | undefined {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return undefined;
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function ensureDir(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function writeFile(filePath: string, content: string): void {
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function normalizeStatus(result: DossierResult): CriterionStatus {
+  if (result === "failed") {
+    return "fail";
+  }
+  if (result === "pending") {
+    return "pending";
+  }
+  return "pass";
+}
+
+function getSection(dossier: Phase1CandidateDossier, id: string): DossierSection {
+  const section = dossier.sections.find((entry) => entry.id === id);
+  if (!section) {
+    fail(`Phase 1 candidate dossier is missing section: ${id}`);
+  }
+  return section;
+}
+
+function uniqueSourceArtifacts(entries: Array<SourceArtifact | undefined>): SourceArtifact[] {
+  const seen = new Set<string>();
+  const result: SourceArtifact[] = [];
+  for (const entry of entries) {
+    if (!entry || !entry.path.trim()) {
+      continue;
+    }
+    const key = `${entry.label}::${entry.path}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(entry);
+  }
+  return result;
+}
+
+function sectionSourceArtifacts(section: DossierSection): SourceArtifact[] {
+  return uniqueSourceArtifacts([
+    section.artifactPath ? { label: section.label, path: section.artifactPath } : undefined,
+    ...section.evidence.map((entry) => ({ label: entry.label, path: entry.path }))
+  ]);
+}
+
+function resolveOutputPaths(args: Args, dossier: Phase1CandidateDossier): { outputPath: string; markdownOutputPath: string } {
+  const outputDir = path.resolve(
+    args.outputDir ?? DEFAULT_RELEASE_READINESS_DIR,
+    args.outputDir ? "" : "."
+  );
+  const defaultJsonPath = args.outputDir
+    ? path.join(outputDir, "phase1-exit-audit.json")
+    : path.join(DEFAULT_RELEASE_READINESS_DIR, `phase1-exit-audit-${slugify(dossier.candidate.name)}-${dossier.candidate.shortRevision}.json`);
+  const defaultMarkdownPath = args.outputDir
+    ? path.join(outputDir, "phase1-exit-audit.md")
+    : path.join(DEFAULT_RELEASE_READINESS_DIR, `phase1-exit-audit-${slugify(dossier.candidate.name)}-${dossier.candidate.shortRevision}.md`);
+  return {
+    outputPath: path.resolve(args.outputPath ?? defaultJsonPath),
+    markdownOutputPath: path.resolve(args.markdownOutputPath ?? defaultMarkdownPath)
+  };
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80) || "candidate";
+}
+
+function matchRequiredCoreCheck(check: SnapshotCheck, requirement: (typeof REQUIRED_CORE_GATES)[number]): boolean {
+  const command = check.command?.trim();
+  if (command && command === requirement.command) {
+    return true;
+  }
+  const id = check.id?.trim().toLowerCase();
+  return Boolean(id && requirement.aliases.includes(id));
+}
+
+function formatCheckStatus(status: SnapshotCheck["status"] | "missing"): string {
+  return status ?? "missing";
+}
+
+function buildCoreAutomatedGatesCriterion(snapshot: ReleaseReadinessSnapshot | undefined, snapshotPath: string | undefined): ExitCriterionReport {
+  const details: string[] = [];
+  let status: CriterionStatus = "pass";
+
+  if (!snapshot) {
+    return {
+      number: 2,
+      id: "core-automated-gates",
+      title: "Core automated gates are green.",
+      status: "fail",
+      summary: "Release readiness snapshot is missing, so the required Phase 1 automated gate set cannot be verified.",
+      details: ["Missing release readiness snapshot input."],
+      sourceArtifacts: uniqueSourceArtifacts([
+        snapshotPath ? { label: "Release readiness snapshot", path: snapshotPath } : undefined
+      ])
+    };
+  }
+
+  for (const requirement of REQUIRED_CORE_GATES) {
+    const check = snapshot.checks?.find((entry) => matchRequiredCoreCheck(entry, requirement));
+    const checkStatus = check?.status ?? "missing";
+    details.push(`${requirement.label}: ${formatCheckStatus(checkStatus)}`);
+    if (checkStatus === "failed") {
+      status = "fail";
+      continue;
+    }
+    if (checkStatus !== "passed" && status !== "fail") {
+      status = "pending";
+    }
+  }
+
+  const summary =
+    status === "fail"
+      ? "One or more required Phase 1 automated gates failed in the release readiness snapshot."
+      : status === "pending"
+        ? "At least one required Phase 1 automated gate is missing or not yet marked passed in the release readiness snapshot."
+        : "All required Phase 1 automated gates are recorded as passed in the release readiness snapshot.";
+
+  return {
+    number: 2,
+    id: "core-automated-gates",
+    title: "Core automated gates are green.",
+    status,
+    summary,
+    details,
+    sourceArtifacts: uniqueSourceArtifacts([
+      snapshotPath ? { label: "Release readiness snapshot", path: snapshotPath } : undefined
+    ])
+  };
+}
+
+function buildSnapshotCriterion(snapshot: ReleaseReadinessSnapshot | undefined, snapshotSection: DossierSection): ExitCriterionReport {
+  const requiredFailed = snapshot?.summary?.requiredFailed ?? 0;
+  const requiredPending = snapshot?.summary?.requiredPending ?? 0;
+  const freshness = snapshotSection.freshness;
+  let status: CriterionStatus = "pass";
+
+  if (!snapshotSection.artifactPath) {
+    status = "fail";
+  } else if (requiredFailed > 0 || requiredPending > 0) {
+    status = "fail";
+  } else if (freshness !== "fresh") {
+    status = "pending";
+  }
+
+  const details = [
+    `snapshotStatus=${snapshot?.summary?.status ?? "missing"}`,
+    `requiredFailed=${requiredFailed}`,
+    `requiredPending=${requiredPending}`,
+    `freshness=${freshness}`
+  ];
+
+  const summary =
+    status === "fail"
+      ? requiredFailed > 0 || requiredPending > 0
+        ? "Release readiness snapshot is blocked by required failures or required pending checks."
+        : "Release readiness snapshot artifact is missing, so this required exit criterion cannot be verified."
+      : status === "pending"
+        ? "Release readiness snapshot currently passes required checks, but the linked artifact is stale or missing freshness metadata."
+        : "Release readiness snapshot shows no required failed checks, no required pending checks, and the artifact is fresh.";
+
+  return {
+    number: 3,
+    id: "release-readiness-snapshot",
+    title: "Release snapshot status is not blocked by required failures or pending required checks.",
+    status,
+    summary,
+    details,
+    sourceArtifacts: sectionSourceArtifacts(snapshotSection)
+  };
+}
+
+function buildCocosCriterion(section: DossierSection, manifest: CocosRcBundleManifest | undefined): ExitCriterionReport {
+  const status = !section.artifactPath ? "fail" : normalizeStatus(section.result);
+  const passedJourneyCount = (manifest?.journey ?? []).filter((entry) => entry.status === "passed").length;
+  const requiredEvidenceTotal = manifest?.requiredEvidence?.length ?? 0;
+  const requiredEvidenceFilled = (manifest?.requiredEvidence ?? []).filter((entry) => entry.filled).length;
+  const details = [
+    `bundleStatus=${manifest?.bundle?.overallStatus ?? "missing"}`,
+    `phase1Gate=${manifest?.review?.phase1Gate ?? "missing"}`,
+    `journeyPassed=${passedJourneyCount}/${manifest?.journey?.length ?? 0}`,
+    `requiredEvidenceFilled=${requiredEvidenceFilled}/${requiredEvidenceTotal}`,
+    `freshness=${section.freshness}`
+  ];
+  const summary =
+    status === "fail"
+      ? section.summary
+      : status === "pending"
+        ? "Candidate-specific Cocos RC evidence exists, but it is stale or still incomplete for the selected revision."
+        : "Candidate-specific Cocos RC evidence is current and the linked main-journey bundle is ready for Phase 1 review.";
+
+  return {
+    number: 4,
+    id: "cocos-primary-client-evidence",
+    title: "Cocos primary-client evidence is current.",
+    status,
+    summary,
+    details,
+    sourceArtifacts: uniqueSourceArtifacts([
+      ...sectionSourceArtifacts(section),
+      manifest?.artifacts?.snapshot ? { label: "Cocos RC snapshot", path: manifest.artifacts.snapshot } : undefined,
+      manifest?.artifacts?.checklistMarkdown ? { label: "Cocos RC checklist", path: manifest.artifacts.checklistMarkdown } : undefined,
+      manifest?.artifacts?.blockersMarkdown ? { label: "Cocos RC blockers", path: manifest.artifacts.blockersMarkdown } : undefined,
+      manifest?.artifacts?.presentationSignoff ? { label: "Cocos presentation sign-off", path: manifest.artifacts.presentationSignoff } : undefined,
+      { label: "Cocos Phase 1 presentation sign-off baseline", path: COCOS_PRESENTATION_SIGNOFF_DOC_PATH }
+    ])
+  };
+}
+
+function buildWechatCriterion(
+  dossier: Phase1CandidateDossier,
+  section: DossierSection,
+  summaryArtifact: WechatCandidateSummary | undefined
+): ExitCriterionReport {
+  if (dossier.candidate.targetSurface !== "wechat") {
+    return {
+      number: 5,
+      id: "wechat-release-evidence",
+      title: "WeChat release evidence is current when WeChat is the target surface.",
+      status: "pass",
+      summary: "This candidate targets H5, so WeChat-specific release evidence is not required for the Phase 1 exit call.",
+      details: ["targetSurface=h5"],
+      sourceArtifacts: uniqueSourceArtifacts([{ label: "WeChat release contract", path: WECHAT_RELEASE_DOC_PATH }])
+    };
+  }
+
+  const status = !section.artifactPath ? "fail" : normalizeStatus(section.result);
+  const details = [
+    `candidateStatus=${summaryArtifact?.candidate?.status ?? "missing"}`,
+    `requiredPendingChecks=${summaryArtifact?.evidence?.manualReview?.requiredPendingChecks ?? "missing"}`,
+    `requiredFailedChecks=${summaryArtifact?.evidence?.manualReview?.requiredFailedChecks ?? "missing"}`,
+    `requiredMetadataFailures=${summaryArtifact?.evidence?.manualReview?.requiredMetadataFailures ?? "missing"}`,
+    `blockers=${summaryArtifact?.blockers?.length ?? 0}`,
+    `freshness=${section.freshness}`
+  ];
+  const summary =
+    status === "fail"
+      ? "WeChat is the target surface, and the candidate-level package/verify/smoke/manual-review evidence is still blocked or missing."
+      : status === "pending"
+        ? "WeChat candidate evidence exists, but it is stale or still incomplete for the selected revision."
+        : "WeChat candidate evidence is current for this revision, including the required manual review state.";
+
+  return {
+    number: 5,
+    id: "wechat-release-evidence",
+    title: "WeChat release evidence is current when WeChat is the target surface.",
+    status,
+    summary,
+    details,
+    sourceArtifacts: uniqueSourceArtifacts([
+      ...sectionSourceArtifacts(section),
+      { label: "WeChat release contract", path: WECHAT_RELEASE_DOC_PATH },
+      ...((summaryArtifact?.blockers ?? []).flatMap((entry) =>
+        entry.artifactPath ? [{ label: entry.id ?? "WeChat blocker artifact", path: entry.artifactPath }] : []
+      ))
+    ])
+  };
+}
+
+function buildRuntimeCriterion(dossier: Phase1CandidateDossier, section: DossierSection): ExitCriterionReport {
+  const status = dossier.inputs.runtimeObservabilityGatePath || dossier.inputs.serverUrl ? normalizeStatus(section.result) : "fail";
+  const details = [
+    `runtimeSource=${dossier.inputs.runtimeObservabilityGatePath ?? dossier.inputs.serverUrl ?? "missing"}`,
+    `freshness=${section.freshness}`,
+    ...section.details
+  ];
+  const summary =
+    status === "fail"
+      ? "Runtime observability evidence is missing or blocking for the selected candidate revision."
+      : status === "pending"
+        ? "Runtime observability evidence exists, but it is stale or still incomplete for the selected candidate revision."
+        : "Runtime health, auth-readiness, and metrics evidence is current for the selected candidate revision.";
+
+  return {
+    number: 6,
+    id: "runtime-observability",
+    title: "Runtime observability is proven in the target environment.",
+    status,
+    summary,
+    details,
+    sourceArtifacts: uniqueSourceArtifacts([
+      ...sectionSourceArtifacts(section),
+      dossier.inputs.serverUrl ? { label: "Runtime environment", path: dossier.inputs.serverUrl } : undefined
+    ])
+  };
+}
+
+function buildPersistenceCriterion(section: DossierSection, report: PersistenceReport | undefined): ExitCriterionReport {
+  const status = !section.artifactPath ? "fail" : normalizeStatus(section.result);
+  const details = [
+    `summaryStatus=${report?.summary?.status ?? "missing"}`,
+    `verifiedStorage=${report?.effectiveStorageMode ?? "missing"}`,
+    `requestedStorage=${report?.requestedStorageMode ?? "missing"}`,
+    `contentValid=${report?.contentValidation?.valid ?? "missing"}`,
+    `assertions=${report?.summary?.assertionCount ?? "missing"}`,
+    `mapPack=${report?.persistenceRegression?.mapPackId ?? "missing"}`,
+    `freshness=${section.freshness}`
+  ];
+  const summary =
+    status === "fail"
+      ? "Phase 1 persistence or shipped-content evidence is missing or blocking for the selected candidate revision."
+      : status === "pending"
+        ? "Phase 1 persistence or shipped-content evidence exists, but it is stale for the selected candidate revision."
+        : "Phase 1 persistence/content validation evidence is current and the verified storage path is recorded for this candidate revision.";
+
+  return {
+    number: 7,
+    id: "phase1-data-persistence",
+    title: "Phase 1 data and persistence are verified on the intended storage path.",
+    status,
+    summary,
+    details,
+    sourceArtifacts: sectionSourceArtifacts(section)
+  };
+}
+
+function buildKnownBlockersCriterion(dossier: Phase1CandidateDossier): ExitCriterionReport {
+  const gate = dossier.phase1ExitEvidenceGate;
+  const status: CriterionStatus =
+    gate.result === "failed" ? "fail" : gate.result === "pending" ? "pending" : "pass";
+  const details = [
+    `blockingSections=${gate.blockingSections.length > 0 ? gate.blockingSections.join(", ") : "none"}`,
+    `pendingSections=${gate.pendingSections.length > 0 ? gate.pendingSections.join(", ") : "none"}`,
+    `acceptedRiskSections=${gate.acceptedRiskSections.length > 0 ? gate.acceptedRiskSections.join(", ") : "none"}`,
+    `acceptedRiskCount=${dossier.acceptedRisks.length}`
+  ];
+  const summary =
+    status === "fail"
+      ? `Known Phase 1 blockers remain open: ${gate.blockingSections.join(", ")}.`
+      : status === "pending"
+        ? `Known Phase 1 evidence is still pending for: ${gate.pendingSections.join(", ")}.`
+        : dossier.acceptedRisks.length > 0
+          ? "Known Phase 1 blockers are either closed or explicitly accepted with recorded waiver context."
+          : "No open Phase 1 blocker state remains in the candidate-level evidence gate.";
+
+  const blockingArtifacts = dossier.sections
+    .filter((section) => gate.blockingSections.includes(section.label) || gate.pendingSections.includes(section.label) || gate.acceptedRiskSections.includes(section.label))
+    .flatMap((section) => sectionSourceArtifacts(section));
+
+  return {
+    number: 8,
+    id: "known-blockers",
+    title: "Known Phase 1 blockers are closed or explicitly accepted.",
+    status,
+    summary,
+    details,
+    sourceArtifacts: uniqueSourceArtifacts([
+      ...blockingArtifacts,
+      { label: "Phase 1 maturity scorecard", path: SCORECARD_DOC_PATH },
+      { label: "Cocos Phase 1 presentation sign-off baseline", path: COCOS_PRESENTATION_SIGNOFF_DOC_PATH },
+      ...dossier.acceptedRisks.flatMap((risk) =>
+        risk.artifactPath ? [{ label: risk.label, path: risk.artifactPath }] : []
+      )
+    ])
+  };
+}
+
+export async function buildPhase1ExitAudit(args: Args): Promise<Phase1ExitAuditReport> {
+  const dossier = (await buildPhase1CandidateDossier(args)) as Phase1CandidateDossier;
+  const snapshotSection = getSection(dossier, "release-readiness");
+  const cocosSection = getSection(dossier, "cocos-rc-bundle");
+  const wechatSection = getSection(dossier, "wechat-release");
+  const runtimeSection = getSection(dossier, "runtime-health");
+  const persistenceSection = getSection(dossier, "phase1-persistence");
+
+  const snapshot = readJsonFile<ReleaseReadinessSnapshot>(dossier.inputs.snapshotPath);
+  const cocosManifest = readJsonFile<CocosRcBundleManifest>(dossier.inputs.cocosBundlePath);
+  const wechatSummary = readJsonFile<WechatCandidateSummary>(dossier.inputs.wechatCandidateSummaryPath);
+  const persistenceReport = readJsonFile<PersistenceReport>(dossier.inputs.persistencePath);
+
+  const criteria: ExitCriterionReport[] = [
+    {
+      number: 1,
+      id: "bounded-scope",
+      title: "Bounded scope remains intact.",
+      status: "pass",
+      summary:
+        "Phase 1 scope stays anchored to the documented lobby/world/battle/settlement loop. This criterion is inferred from the current repo documentation rather than a candidate-specific automation artifact.",
+      details: [
+        "Inference: README.md, docs/phase1-design.md, and docs/phase1-maturity-scorecard.md still describe the bounded Phase 1 loop.",
+        `targetSurface=${dossier.candidate.targetSurface}`
+      ],
+      sourceArtifacts: uniqueSourceArtifacts([
+        { label: "Repository overview", path: README_PATH },
+        { label: "Phase 1 design", path: PHASE1_DESIGN_DOC_PATH },
+        { label: "Phase 1 maturity scorecard", path: SCORECARD_DOC_PATH }
+      ])
+    },
+    buildCoreAutomatedGatesCriterion(snapshot, dossier.inputs.snapshotPath),
+    buildSnapshotCriterion(snapshot, snapshotSection),
+    buildCocosCriterion(cocosSection, cocosManifest),
+    buildWechatCriterion(dossier, wechatSection, wechatSummary),
+    buildRuntimeCriterion(dossier, runtimeSection),
+    buildPersistenceCriterion(persistenceSection, persistenceReport),
+    buildKnownBlockersCriterion(dossier)
+  ];
+
+  const blockedCriteria = criteria.filter((entry) => entry.status === "fail").map((entry) => `${entry.number}. ${entry.title}`);
+  const pendingCriteria = criteria.filter((entry) => entry.status === "pending").map((entry) => `${entry.number}. ${entry.title}`);
+  const status: OverallStatus = blockedCriteria.length > 0 ? "fail" : pendingCriteria.length > 0 ? "pending" : "pass";
+  const summary =
+    status === "fail"
+      ? `Phase 1 exit is blocked for ${dossier.candidate.name}: ${blockedCriteria.join("; ")}`
+      : status === "pending"
+        ? `Phase 1 exit is not yet clear for ${dossier.candidate.name}: ${pendingCriteria.join("; ")}`
+        : `Phase 1 exit criteria are currently satisfied for ${dossier.candidate.name} at ${dossier.candidate.shortRevision}.`;
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    candidate: dossier.candidate,
+    summary: {
+      status,
+      blockedCriteria,
+      pendingCriteria,
+      acceptedRiskCount: dossier.acceptedRisks.length,
+      summary
+    },
+    inputs: dossier.inputs,
+    phase1ExitEvidenceGate: dossier.phase1ExitEvidenceGate,
+    acceptedRisks: dossier.acceptedRisks,
+    criteria
+  };
+}
+
+function formatStatus(status: CriterionStatus | OverallStatus): string {
+  return status.toUpperCase();
+}
+
+export function renderMarkdown(report: Phase1ExitAuditReport): string {
+  const lines: string[] = [];
+  lines.push("# Phase 1 Exit Audit", "");
+  lines.push(`- Generated at: \`${report.generatedAt}\``);
+  lines.push(`- Candidate: \`${report.candidate.name}\``);
+  lines.push(`- Revision: \`${report.candidate.revision}\``);
+  lines.push(`- Branch: \`${report.candidate.branch}\``);
+  lines.push(`- Git tree: \`${report.candidate.dirty ? "dirty" : "clean"}\``);
+  lines.push(`- Target surface: \`${report.candidate.targetSurface}\``);
+  lines.push(`- Overall status: **${formatStatus(report.summary.status)}**`);
+  lines.push(`- Summary: ${report.summary.summary}`);
+  lines.push(`- Accepted risks: ${report.summary.acceptedRiskCount}`, "");
+
+  lines.push("## Inputs", "");
+  lines.push(`- Release readiness snapshot: \`${report.inputs.snapshotPath ?? "<missing>"}\``);
+  lines.push(`- Cocos RC bundle: \`${report.inputs.cocosBundlePath ?? "<missing>"}\``);
+  lines.push(`- WeChat candidate summary: \`${report.inputs.wechatCandidateSummaryPath ?? "<missing>"}\``);
+  lines.push(`- Runtime observability gate: \`${report.inputs.runtimeObservabilityGatePath ?? report.inputs.serverUrl ?? "<missing>"}\``);
+  lines.push(`- Reconnect soak: \`${report.inputs.reconnectSoakPath ?? "<missing>"}\``);
+  lines.push(`- Phase 1 persistence: \`${report.inputs.persistencePath ?? "<missing>"}\``, "");
+
+  lines.push("## Exit Criteria", "");
+  for (const criterion of report.criteria) {
+    lines.push(`### ${criterion.number}. ${criterion.title}`, "");
+    lines.push(`- Status: \`${criterion.status}\``);
+    lines.push(`- Summary: ${criterion.summary}`);
+    if (criterion.details.length > 0) {
+      lines.push("- Details:");
+      for (const detail of criterion.details) {
+        lines.push(`  - ${detail}`);
+      }
+    }
+    if (criterion.sourceArtifacts.length > 0) {
+      lines.push("- Source artifacts:");
+      for (const source of criterion.sourceArtifacts) {
+        lines.push(`  - ${source.label}: \`${source.path}\``);
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push("## Candidate Gate", "");
+  lines.push(`- Result: \`${report.phase1ExitEvidenceGate.result}\``);
+  lines.push(`- Summary: ${report.phase1ExitEvidenceGate.summary}`);
+  lines.push(
+    `- Blocking sections: ${report.phase1ExitEvidenceGate.blockingSections.length > 0 ? report.phase1ExitEvidenceGate.blockingSections.join(", ") : "none"}`
+  );
+  lines.push(
+    `- Pending sections: ${report.phase1ExitEvidenceGate.pendingSections.length > 0 ? report.phase1ExitEvidenceGate.pendingSections.join(", ") : "none"}`
+  );
+  lines.push(
+    `- Accepted-risk sections: ${report.phase1ExitEvidenceGate.acceptedRiskSections.length > 0 ? report.phase1ExitEvidenceGate.acceptedRiskSections.join(", ") : "none"}`
+  );
+  lines.push("");
+
+  lines.push("## Accepted Risks", "");
+  if (report.acceptedRisks.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const risk of report.acceptedRisks) {
+      const metadata = [risk.approvedBy ? `approvedBy=${risk.approvedBy}` : "", risk.approvedAt ? `approvedAt=${risk.approvedAt}` : ""]
+        .filter((value) => value.length > 0)
+        .join(" ");
+      lines.push(`- ${risk.label}: ${risk.reason}${metadata ? ` (${metadata})` : ""}`);
+      if (risk.artifactPath) {
+        lines.push(`  Artifact: \`${risk.artifactPath}\``);
+      }
+    }
+  }
+  lines.push("");
+
+  return `${lines.join("\n").trim()}\n`;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  const report = await buildPhase1ExitAudit(args);
+  const outputPaths = resolveOutputPaths(args, {
+    candidate: report.candidate,
+    inputs: report.inputs,
+    generatedAt: report.generatedAt,
+    summary: {
+      status: report.summary.status === "pass" ? "passed" : report.summary.status === "fail" ? "failed" : "pending",
+      requiredFailed: [],
+      requiredPending: [],
+      acceptedRiskCount: report.summary.acceptedRiskCount
+    },
+    phase1ExitEvidenceGate: report.phase1ExitEvidenceGate,
+    sections: [],
+    acceptedRisks: report.acceptedRisks
+  } as Phase1CandidateDossier);
+
+  writeJsonFile(outputPaths.outputPath, report);
+  writeFile(outputPaths.markdownOutputPath, renderMarkdown(report));
+
+  console.log(`Phase 1 exit audit ${formatStatus(report.summary.status)}`);
+  console.log(`Candidate: ${report.candidate.name}`);
+  console.log(`Revision: ${report.candidate.revision}`);
+  console.log(`JSON: ${path.relative(process.cwd(), outputPaths.outputPath).replace(/\\/g, "/")}`);
+  console.log(`Markdown: ${path.relative(process.cwd(), outputPaths.markdownOutputPath).replace(/\\/g, "/")}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(`Phase 1 exit audit failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test/phase1-candidate-dossier.test.ts
+++ b/scripts/test/phase1-candidate-dossier.test.ts
@@ -28,7 +28,7 @@ function writeRuntimeGateArtifact(
   const runtimeGatePath = path.join(artifactsDir, `runtime-observability-gate-${revision}.json`);
   writeJson(runtimeGatePath, {
     schemaVersion: 1,
-    generatedAt: "2026-04-02T08:45:05.000Z",
+    generatedAt: "2026-04-05T08:45:05.000Z",
     candidate: {
       name: "phase1-rc",
       revision,
@@ -77,7 +77,7 @@ function writeRuntimeGateArtifact(
         status: overrides?.endpointStatuses?.["runtime-health"] ?? "passed",
         httpStatus: 200,
         summary: "Runtime health responded with an OK payload.",
-        observedAt: "2026-04-02T08:45:00.000Z",
+        observedAt: "2026-04-05T08:45:00.000Z",
         freshness: "fresh",
         details: ["activeRooms=3", "connections=11", "actions=182"],
         keyReadinessFields: {
@@ -93,7 +93,7 @@ function writeRuntimeGateArtifact(
         status: overrides?.endpointStatuses?.["auth-readiness"] ?? "passed",
         httpStatus: 200,
         summary: overrides?.headline ?? "Auth readiness is healthy.",
-        observedAt: "2026-04-02T08:45:05.000Z",
+        observedAt: "2026-04-05T08:45:05.000Z",
         freshness: "fresh",
         details: ["lockouts=0", "pendingRegistrations=0", "pendingRecoveries=0"],
         keyReadinessFields: {
@@ -109,7 +109,7 @@ function writeRuntimeGateArtifact(
         status: overrides?.endpointStatuses?.["runtime-metrics"] ?? "passed",
         httpStatus: 200,
         summary: "Runtime metrics exposed the required Prometheus counters.",
-        observedAt: "2026-04-02T08:45:05.000Z",
+        observedAt: "2026-04-05T08:45:05.000Z",
         freshness: "fresh",
         details: ["Required Prometheus metrics are present."],
         keyReadinessFields: {
@@ -143,7 +143,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
   const configCenterLibraryPath = path.join(workspace, "configs", ".config-center-library.json");
   const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
   writeJson(snapshotPath, {
-    generatedAt: "2026-04-02T08:30:00.000Z",
+    generatedAt: "2026-04-05T08:30:00.000Z",
     revision: {
       commit: revision,
       shortCommit: revision
@@ -161,7 +161,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
         status: "passed",
         waiver: {
           approvedBy: "release-manager",
-          approvedAt: "2026-04-02T08:20:00.000Z",
+          approvedAt: "2026-04-05T08:20:00.000Z",
           reason: "Documented flaky shard accepted for this RC only."
         }
       },
@@ -173,7 +173,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     ]
   });
   writeJson(h5SmokePath, {
-    generatedAt: "2026-04-02T08:32:00.000Z",
+    generatedAt: "2026-04-05T08:32:00.000Z",
     revision: {
       commit: revision,
       shortCommit: revision
@@ -189,7 +189,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     }
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-04-02T08:33:00.000Z",
+    generatedAt: "2026-04-05T08:33:00.000Z",
     revision: {
       commit: revision,
       shortCommit: revision
@@ -218,7 +218,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
   });
   writeJson(cocosBundlePath, {
     bundle: {
-      generatedAt: "2026-04-02T08:34:00.000Z",
+      generatedAt: "2026-04-05T08:34:00.000Z",
       candidate: "phase1-rc",
       commit: revision,
       shortCommit: revision,
@@ -251,7 +251,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     ]
   });
   writeJson(wechatCandidateSummaryPath, {
-    generatedAt: "2026-04-02T08:40:00.000Z",
+    generatedAt: "2026-04-05T08:40:00.000Z",
     candidate: {
       revision,
       version: "1.2.3",
@@ -290,7 +290,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
             required: true,
             status: "passed",
             owner: "release-oncall",
-            recordedAt: "2026-04-02T08:39:00.000Z",
+            recordedAt: "2026-04-05T08:39:00.000Z",
             revision,
             artifactPath: path.join(wechatDir, "devtools-export-review.json")
           },
@@ -300,7 +300,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
             required: true,
             status: "passed",
             owner: "release-oncall",
-            recordedAt: "2026-04-02T08:40:00.000Z",
+            recordedAt: "2026-04-05T08:40:00.000Z",
             revision,
             artifactPath: path.join(wechatDir, "device-runtime-review.json")
           }
@@ -310,7 +310,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     blockers: []
   });
   writeJson(persistencePath, {
-    generatedAt: "2026-04-02T08:41:00.000Z",
+    generatedAt: "2026-04-05T08:41:00.000Z",
     revision: {
       commit: revision,
       shortCommit: revision
@@ -334,7 +334,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     }
   });
   writeJson(syncGovernancePath, {
-    generatedAt: "2026-04-02T08:42:00.000Z",
+    generatedAt: "2026-04-05T08:42:00.000Z",
     execution: {
       status: "passed"
     },
@@ -351,7 +351,7 @@ test("phase1 candidate dossier aggregates Phase 1 evidence into one accepted-ris
     ]
   });
   writeJson(ciTrendSummaryPath, {
-    generatedAt: "2026-04-02T08:43:00.000Z",
+    generatedAt: "2026-04-05T08:43:00.000Z",
     summary: {
       overallStatus: "passed",
       totalFindings: 0,
@@ -466,20 +466,20 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
   });
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-04-02T08:30:00.000Z",
+    generatedAt: "2026-04-05T08:30:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
     checks: [{ id: "npm-test", required: true, status: "passed" }]
   });
   writeJson(h5SmokePath, {
-    generatedAt: "2026-04-02T08:32:00.000Z",
+    generatedAt: "2026-04-05T08:32:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     execution: { status: "passed", exitCode: 0 },
     summary: { total: 2, passed: 2, failed: 0 }
   });
   writeJson(cocosBundlePath, {
     bundle: {
-      generatedAt: "2026-04-02T08:34:00.000Z",
+      generatedAt: "2026-04-05T08:34:00.000Z",
       candidate: "phase1-rc",
       commit: revision,
       shortCommit: revision,
@@ -491,7 +491,7 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
     requiredEvidence: [{ id: "roomId", label: "Room id recorded", filled: true }]
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-04-02T08:33:00.000Z",
+    generatedAt: "2026-04-05T08:33:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     status: "failed",
     summary: { failedScenarios: 1, scenarioNames: ["reconnect_soak"] },
@@ -510,7 +510,7 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
     ]
   });
   writeJson(wechatCandidateSummaryPath, {
-    generatedAt: "2026-04-02T08:40:00.000Z",
+    generatedAt: "2026-04-05T08:40:00.000Z",
     candidate: { revision, status: "ready" },
     evidence: {
       smoke: { status: "passed", artifactPath: path.join(wechatDir, "codex.wechat.smoke-report.json") },
@@ -525,7 +525,7 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
             required: true,
             status: "passed",
             owner: "release-oncall",
-            recordedAt: "2026-04-02T08:39:00.000Z",
+            recordedAt: "2026-04-05T08:39:00.000Z",
             revision,
             artifactPath: path.join(wechatDir, "devtools-export-review.json")
           },
@@ -534,7 +534,7 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
             required: true,
             status: "passed",
             owner: "release-oncall",
-            recordedAt: "2026-04-02T08:40:00.000Z",
+            recordedAt: "2026-04-05T08:40:00.000Z",
             revision,
             artifactPath: path.join(wechatDir, "device-runtime-review.json")
           }
@@ -544,7 +544,7 @@ test("phase1 candidate dossier fails the single exit evidence gate when the rele
     blockers: []
   });
   writeJson(persistencePath, {
-    generatedAt: "2026-04-02T08:41:00.000Z",
+    generatedAt: "2026-04-05T08:41:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     requestedStorageMode: "memory",
     effectiveStorageMode: "memory",
@@ -590,19 +590,19 @@ test("phase1 candidate dossier marks stale persistence evidence as pending and k
   const runtimeObservabilityGatePath = writeRuntimeGateArtifact(artifactsDir, revision);
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-04-02T08:30:00.000Z",
+    generatedAt: "2026-04-05T08:30:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
     checks: [{ id: "npm-test", required: true, status: "passed" }]
   });
   writeJson(h5SmokePath, {
-    generatedAt: "2026-04-02T08:32:00.000Z",
+    generatedAt: "2026-04-05T08:32:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     execution: { status: "passed", exitCode: 0 },
     summary: { total: 2, passed: 2, failed: 0 }
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-04-02T08:33:00.000Z",
+    generatedAt: "2026-04-05T08:33:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     status: "passed",
     summary: { failedScenarios: 0, scenarioNames: ["reconnect_soak"] },
@@ -622,7 +622,7 @@ test("phase1 candidate dossier marks stale persistence evidence as pending and k
   });
   writeJson(cocosBundlePath, {
     bundle: {
-      generatedAt: "2026-04-02T08:34:00.000Z",
+      generatedAt: "2026-04-05T08:34:00.000Z",
       candidate: "phase1-rc",
       commit: revision,
       shortCommit: revision,
@@ -692,19 +692,19 @@ test("phase1 candidate dossier blocks Phase 1 sign-off when required WeChat manu
   const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-04-02T08:30:00.000Z",
+    generatedAt: "2026-04-05T08:30:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
     checks: [{ id: "npm-test", required: true, status: "passed" }]
   });
   writeJson(h5SmokePath, {
-    generatedAt: "2026-04-02T08:32:00.000Z",
+    generatedAt: "2026-04-05T08:32:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     execution: { status: "passed", exitCode: 0 },
     summary: { total: 2, passed: 2, failed: 0 }
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-04-02T08:33:00.000Z",
+    generatedAt: "2026-04-05T08:33:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     status: "passed",
     summary: { failedScenarios: 0, scenarioNames: ["reconnect_soak"] },
@@ -719,7 +719,7 @@ test("phase1 candidate dossier blocks Phase 1 sign-off when required WeChat manu
   });
   writeJson(cocosBundlePath, {
     bundle: {
-      generatedAt: "2026-04-02T08:34:00.000Z",
+      generatedAt: "2026-04-05T08:34:00.000Z",
       candidate: "phase1-rc",
       commit: revision,
       shortCommit: revision,
@@ -731,7 +731,7 @@ test("phase1 candidate dossier blocks Phase 1 sign-off when required WeChat manu
     requiredEvidence: [{ id: "roomId", label: "Room id recorded", filled: true }]
   });
   writeJson(wechatCandidateSummaryPath, {
-    generatedAt: "2026-04-02T08:40:00.000Z",
+    generatedAt: "2026-04-05T08:40:00.000Z",
     candidate: { revision, status: "blocked" },
     evidence: {
       package: {
@@ -769,7 +769,7 @@ test("phase1 candidate dossier blocks Phase 1 sign-off when required WeChat manu
     blockers: [{ id: "manual:wechat-devtools-export-review", summary: "Manual review pending: Real WeChat export imported and launched in Developer Tools." }]
   });
   writeJson(persistencePath, {
-    generatedAt: "2026-04-02T08:41:00.000Z",
+    generatedAt: "2026-04-05T08:41:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     requestedStorageMode: "memory",
     effectiveStorageMode: "memory",
@@ -824,19 +824,19 @@ test("phase1 candidate dossier CLI writes a stable candidate bundle directory wi
   const runtimeObservabilityGatePath = writeRuntimeGateArtifact(artifactsDir, revision);
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-04-02T08:30:00.000Z",
+    generatedAt: "2026-04-05T08:30:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
     checks: [{ id: "npm-test", required: true, status: "passed" }]
   });
   writeJson(h5SmokePath, {
-    generatedAt: "2026-04-02T08:32:00.000Z",
+    generatedAt: "2026-04-05T08:32:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     execution: { status: "passed", exitCode: 0 },
     summary: { total: 2, passed: 2, failed: 0 }
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-04-02T08:33:00.000Z",
+    generatedAt: "2026-04-05T08:33:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     status: "passed",
     summary: { failedScenarios: 0, scenarioNames: ["reconnect_soak"] },
@@ -856,7 +856,7 @@ test("phase1 candidate dossier CLI writes a stable candidate bundle directory wi
   });
   writeJson(cocosBundlePath, {
     bundle: {
-      generatedAt: "2026-04-02T08:34:00.000Z",
+      generatedAt: "2026-04-05T08:34:00.000Z",
       candidate: "phase1-rc",
       commit: revision,
       shortCommit: revision,
@@ -868,7 +868,7 @@ test("phase1 candidate dossier CLI writes a stable candidate bundle directory wi
     requiredEvidence: [{ id: "roomId", label: "Room id recorded", filled: true }]
   });
   writeJson(persistencePath, {
-    generatedAt: "2026-04-02T08:41:00.000Z",
+    generatedAt: "2026-04-05T08:41:00.000Z",
     revision: { commit: revision, shortCommit: revision },
     requestedStorageMode: "memory",
     effectiveStorageMode: "memory",
@@ -878,13 +878,13 @@ test("phase1 candidate dossier CLI writes a stable candidate bundle directory wi
     persistenceRegression: { mapPackId: "phase1", assertions: ["room hydration reapplied resources"] }
   });
   writeJson(syncGovernancePath, {
-    generatedAt: "2026-04-02T08:42:00.000Z",
+    generatedAt: "2026-04-05T08:42:00.000Z",
     execution: { status: "passed" },
     summary: { passed: 2, failed: 0, skipped: 0 },
     scenarios: [{ id: "room-push-redaction", status: "passed" }]
   });
   writeJson(ciTrendSummaryPath, {
-    generatedAt: "2026-04-02T08:43:00.000Z",
+    generatedAt: "2026-04-05T08:43:00.000Z",
     summary: {
       overallStatus: "passed",
       totalFindings: 0,

--- a/scripts/test/phase1-exit-audit.test.ts
+++ b/scripts/test/phase1-exit-audit.test.ts
@@ -1,0 +1,387 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { buildPhase1ExitAudit, renderMarkdown } from "../phase1-exit-audit.ts";
+
+function writeJson(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function createTempWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "veil-phase1-exit-audit-"));
+}
+
+function writeRuntimeGateArtifact(
+  artifactsDir: string,
+  revision: string,
+  overrides?: {
+    status?: "passed" | "failed";
+    headline?: string;
+    endpointStatuses?: Partial<Record<"runtime-health" | "auth-readiness" | "runtime-metrics", "passed" | "warn" | "failed">>;
+  }
+): string {
+  const runtimeGatePath = path.join(artifactsDir, `runtime-observability-gate-${revision}.json`);
+  writeJson(runtimeGatePath, {
+    schemaVersion: 1,
+    generatedAt: "2026-04-05T08:45:05.000Z",
+    candidate: {
+      name: "phase1-rc",
+      revision,
+      shortRevision: revision,
+      branch: "main",
+      dirty: false,
+      targetSurface: "wechat"
+    },
+    targetEnvironment: {
+      label: "staging",
+      serverUrl: "https://veil-staging.example.com"
+    },
+    summary: {
+      status: overrides?.status ?? "passed",
+      headline: overrides?.headline ?? "Runtime health, auth readiness, and metrics passed for the target environment.",
+      endpointStatuses: {
+        "runtime-health": overrides?.endpointStatuses?.["runtime-health"] ?? "passed",
+        "auth-readiness": overrides?.endpointStatuses?.["auth-readiness"] ?? "passed",
+        "runtime-metrics": overrides?.endpointStatuses?.["runtime-metrics"] ?? "passed"
+      }
+    },
+    readiness: {
+      activeRoomCount: 3,
+      connectionCount: 11,
+      activeBattleCount: 1,
+      heroCount: 5,
+      actionMessagesTotal: 182,
+      worldActionsTotal: 140,
+      battleActionsTotal: 42,
+      activeGuestSessionCount: 4,
+      activeAccountSessionCount: 7,
+      activeAccountLockCount: 0,
+      pendingRegistrationCount: 0,
+      pendingRecoveryCount: 0,
+      tokenDeliveryQueueCount: 0,
+      tokenDeliveryDeadLetterCount: 0,
+      wechatLoginMode: "production",
+      wechatCredentialsStatus: "configured",
+      authHeadline: "Auth readiness is healthy."
+    },
+    endpoints: [
+      {
+        id: "runtime-health",
+        label: "Runtime health",
+        url: "https://veil-staging.example.com/api/runtime/health",
+        status: overrides?.endpointStatuses?.["runtime-health"] ?? "passed",
+        httpStatus: 200,
+        summary: "Runtime health responded with an OK payload.",
+        observedAt: "2026-04-05T08:45:00.000Z",
+        freshness: "fresh",
+        details: ["activeRooms=3", "connections=11", "actions=182"]
+      },
+      {
+        id: "auth-readiness",
+        label: "Auth readiness",
+        url: "https://veil-staging.example.com/api/runtime/auth-readiness",
+        status: overrides?.endpointStatuses?.["auth-readiness"] ?? "passed",
+        httpStatus: 200,
+        summary: overrides?.headline ?? "Auth readiness is healthy.",
+        observedAt: "2026-04-05T08:45:05.000Z",
+        freshness: "fresh",
+        details: ["lockouts=0", "pendingRegistrations=0", "pendingRecoveries=0"]
+      },
+      {
+        id: "runtime-metrics",
+        label: "Runtime metrics",
+        url: "https://veil-staging.example.com/api/runtime/metrics",
+        status: overrides?.endpointStatuses?.["runtime-metrics"] ?? "passed",
+        httpStatus: 200,
+        summary: "Runtime metrics exposed the required Prometheus counters.",
+        observedAt: "2026-04-05T08:45:05.000Z",
+        freshness: "fresh",
+        details: ["Required Prometheus metrics are present."]
+      }
+    ]
+  });
+  return runtimeGatePath;
+}
+
+function writePassingArtifacts(workspace: string, revision: string): {
+  snapshotPath: string;
+  h5SmokePath: string;
+  reconnectSoakPath: string;
+  cocosBundlePath: string;
+  persistencePath: string;
+  runtimeObservabilityGatePath: string;
+  wechatCandidateSummaryPath: string;
+} {
+  const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
+  const wechatDir = path.join(workspace, "artifacts", "wechat-release");
+  const snapshotPath = path.join(artifactsDir, "release-readiness-pass.json");
+  const h5SmokePath = path.join(artifactsDir, "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(artifactsDir, "colyseus-reconnect-soak-summary-pass.json");
+  const cocosBundlePath = path.join(artifactsDir, "cocos-rc-evidence-bundle-pass.json");
+  const persistencePath = path.join(artifactsDir, `phase1-release-persistence-regression-${revision}.json`);
+  const runtimeObservabilityGatePath = writeRuntimeGateArtifact(artifactsDir, revision);
+  const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-04-05T08:30:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
+    checks: [
+      { id: "npm-test", title: "Unit and integration regression", required: true, status: "passed", command: "npm test" },
+      { id: "typecheck-ci", required: true, status: "passed", command: "npm run typecheck:ci" },
+      { id: "e2e-smoke", required: true, status: "passed", command: "npm run test:e2e:smoke" },
+      {
+        id: "e2e-multiplayer-smoke",
+        required: true,
+        status: "passed",
+        command: "npm run test:e2e:multiplayer:smoke"
+      },
+      {
+        id: "cocos-release-readiness",
+        required: true,
+        status: "passed",
+        command: "npm run check:cocos-release-readiness"
+      }
+    ]
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: "2026-04-05T08:32:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    execution: { status: "passed", exitCode: 0 },
+    summary: { total: 2, passed: 2, failed: 0 }
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: "2026-04-05T08:33:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    status: "passed",
+    summary: { failedScenarios: 0, scenarioNames: ["reconnect_soak"] },
+    soakSummary: { reconnectAttempts: 256, invariantChecks: 1024 },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: { activeRoomCount: 0, connectionCount: 0, activeBattleCount: 0, heroCount: 0 }
+      }
+    ]
+  });
+  writeJson(cocosBundlePath, {
+    bundle: {
+      generatedAt: "2026-04-05T08:34:00.000Z",
+      candidate: "phase1-rc",
+      commit: revision,
+      shortCommit: revision,
+      overallStatus: "passed",
+      summary: "Cocos RC evidence is complete."
+    },
+    artifacts: {
+      snapshot: path.join(artifactsDir, "cocos-rc-snapshot-phase1-rc.json"),
+      checklistMarkdown: path.join(artifactsDir, "cocos-rc-checklist-phase1-rc.md"),
+      blockersMarkdown: path.join(artifactsDir, "cocos-rc-blockers-phase1-rc.md")
+    },
+    review: {
+      phase1Gate: "passed"
+    },
+    journey: [
+      { id: "lobby-entry", title: "Lobby entry", status: "passed" },
+      { id: "world-journey", title: "World exploration", status: "passed" },
+      { id: "battle-journey", title: "Battle settlement", status: "passed" }
+    ],
+    requiredEvidence: [
+      { id: "roomId", label: "Room id recorded", filled: true },
+      { id: "presentationSignoff", label: "Presentation sign-off", filled: true }
+    ]
+  });
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: "2026-04-05T08:40:00.000Z",
+    candidate: { revision, version: "1.2.3", status: "ready" },
+    evidence: {
+      package: { status: "passed", artifactPath: path.join(wechatDir, "veil.package.json") },
+      validation: { status: "passed", artifactPath: path.join(wechatDir, "codex.wechat.rc-validation-report.json") },
+      smoke: { status: "passed", artifactPath: path.join(wechatDir, "codex.wechat.smoke-report.json") },
+      manualReview: {
+        status: "ready",
+        requiredPendingChecks: 0,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0
+      }
+    },
+    blockers: []
+  });
+  writeJson(persistencePath, {
+    generatedAt: "2026-04-05T08:41:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    requestedStorageMode: "mysql",
+    effectiveStorageMode: "mysql",
+    storageDescription: "MySQL snapshot store backed by VEIL_MYSQL_*.",
+    summary: { status: "passed", assertionCount: 6 },
+    contentValidation: { valid: true, summary: "All shipped content packs validated.", issueCount: 0 },
+    persistenceRegression: { mapPackId: "phase1", assertions: ["room hydration reapplied resources"] }
+  });
+
+  return {
+    snapshotPath,
+    h5SmokePath,
+    reconnectSoakPath,
+    cocosBundlePath,
+    persistencePath,
+    runtimeObservabilityGatePath,
+    wechatCandidateSummaryPath
+  };
+}
+
+test("phase1 exit audit maps the scorecard criteria into one passing report", async () => {
+  const workspace = createTempWorkspace();
+  const revision = "abc1234";
+  const inputs = writePassingArtifacts(workspace, revision);
+
+  const report = await buildPhase1ExitAudit({
+    candidate: "phase1-rc",
+    candidateRevision: revision,
+    targetSurface: "wechat",
+    maxEvidenceAgeHours: 72,
+    ...inputs
+  });
+
+  assert.equal(report.summary.status, "pass");
+  assert.deepEqual(report.summary.blockedCriteria, []);
+  assert.deepEqual(report.summary.pendingCriteria, []);
+  assert.equal(report.criteria.length, 8);
+  assert.equal(report.criteria.find((entry) => entry.id === "bounded-scope")?.status, "pass");
+  assert.equal(report.criteria.find((entry) => entry.id === "core-automated-gates")?.status, "pass");
+  assert.equal(report.criteria.find((entry) => entry.id === "release-readiness-snapshot")?.status, "pass");
+  assert.equal(report.criteria.find((entry) => entry.id === "cocos-primary-client-evidence")?.status, "pass");
+  assert.equal(report.criteria.find((entry) => entry.id === "wechat-release-evidence")?.status, "pass");
+  assert.equal(report.criteria.find((entry) => entry.id === "runtime-observability")?.status, "pass");
+  assert.equal(report.criteria.find((entry) => entry.id === "phase1-data-persistence")?.status, "pass");
+  assert.equal(report.criteria.find((entry) => entry.id === "known-blockers")?.status, "pass");
+  assert.equal(report.criteria.every((entry) => entry.sourceArtifacts.length > 0), true);
+
+  const markdown = renderMarkdown(report);
+  assert.match(markdown, /# Phase 1 Exit Audit/);
+  assert.match(markdown, /Overall status: \*\*PASS\*\*/);
+  assert.match(markdown, /### 2\. Core automated gates are green\./);
+  assert.match(markdown, /npm run check:cocos-release-readiness: passed/);
+  assert.match(markdown, /### 8\. Known Phase 1 blockers are closed or explicitly accepted\./);
+});
+
+test("phase1 exit audit distinguishes blocking failures from stale pending evidence", async () => {
+  const workspace = createTempWorkspace();
+  const revision = "abc1234";
+  const inputs = writePassingArtifacts(workspace, revision);
+
+  writeJson(inputs.snapshotPath, {
+    generatedAt: "2026-04-05T08:30:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    summary: { status: "failed", requiredFailed: 1, requiredPending: 0 },
+    checks: [
+      { id: "npm-test", required: true, status: "failed", command: "npm test" },
+      { id: "typecheck-ci", required: true, status: "passed", command: "npm run typecheck:ci" },
+      { id: "e2e-smoke", required: true, status: "passed", command: "npm run test:e2e:smoke" },
+      {
+        id: "e2e-multiplayer-smoke",
+        required: true,
+        status: "passed",
+        command: "npm run test:e2e:multiplayer:smoke"
+      },
+      {
+        id: "cocos-release-readiness",
+        required: true,
+        status: "passed",
+        command: "npm run check:cocos-release-readiness"
+      }
+    ]
+  });
+  writeJson(inputs.persistencePath, {
+    generatedAt: "2026-03-20T08:41:00.000Z",
+    revision: { commit: revision, shortCommit: revision },
+    requestedStorageMode: "mysql",
+    effectiveStorageMode: "mysql",
+    storageDescription: "MySQL snapshot store backed by VEIL_MYSQL_*.",
+    summary: { status: "passed", assertionCount: 6 },
+    contentValidation: { valid: true, summary: "All shipped content packs validated.", issueCount: 0 },
+    persistenceRegression: { mapPackId: "phase1", assertions: ["room hydration reapplied resources"] }
+  });
+
+  const report = await buildPhase1ExitAudit({
+    candidate: "phase1-rc",
+    candidateRevision: revision,
+    targetSurface: "wechat",
+    maxEvidenceAgeHours: 72,
+    ...inputs
+  });
+
+  assert.equal(report.summary.status, "fail");
+  assert.equal(report.criteria.find((entry) => entry.id === "core-automated-gates")?.status, "fail");
+  assert.equal(report.criteria.find((entry) => entry.id === "release-readiness-snapshot")?.status, "fail");
+  assert.equal(report.criteria.find((entry) => entry.id === "phase1-data-persistence")?.status, "pending");
+  assert.equal(report.summary.blockedCriteria.some((entry) => entry.includes("Core automated gates")), true);
+  assert.equal(report.summary.pendingCriteria.some((entry) => entry.includes("Phase 1 data and persistence")), true);
+});
+
+test("phase1 exit audit CLI writes stable JSON and Markdown outputs", () => {
+  const workspace = createTempWorkspace();
+  const revision = "abc1234";
+  const inputs = writePassingArtifacts(workspace, revision);
+  const outputDir = path.join(workspace, "artifacts", "release-readiness", "phase1-exit-audit");
+  const repoRoot = path.resolve(process.cwd());
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      "./scripts/phase1-exit-audit.ts",
+      "--candidate",
+      "phase1-rc",
+      "--candidate-revision",
+      revision,
+      "--target-surface",
+      "wechat",
+      "--snapshot",
+      inputs.snapshotPath,
+      "--h5-smoke",
+      inputs.h5SmokePath,
+      "--reconnect-soak",
+      inputs.reconnectSoakPath,
+      "--runtime-observability-gate",
+      inputs.runtimeObservabilityGatePath,
+      "--cocos-bundle",
+      inputs.cocosBundlePath,
+      "--wechat-candidate-summary",
+      inputs.wechatCandidateSummaryPath,
+      "--phase1-persistence",
+      inputs.persistencePath,
+      "--output-dir",
+      outputDir
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Phase 1 exit audit PASS/);
+
+  const jsonPath = path.join(outputDir, "phase1-exit-audit.json");
+  const markdownPath = path.join(outputDir, "phase1-exit-audit.md");
+  assert.equal(fs.existsSync(jsonPath), true);
+  assert.equal(fs.existsSync(markdownPath), true);
+
+  const report = JSON.parse(fs.readFileSync(jsonPath, "utf8")) as {
+    summary: { status: string };
+    criteria: Array<{ number: number; status: string; sourceArtifacts: Array<{ path: string }> }>;
+  };
+  assert.equal(report.summary.status, "pass");
+  assert.equal(report.criteria.length, 8);
+  assert.equal(report.criteria.every((entry) => entry.sourceArtifacts.length > 0), true);
+
+  const markdown = fs.readFileSync(markdownPath, "utf8");
+  assert.match(markdown, /# Phase 1 Exit Audit/);
+  assert.match(markdown, /### 5\. WeChat release evidence is current when WeChat is the target surface\./);
+});


### PR DESCRIPTION
## Summary
- add a dedicated `release:phase1:exit-audit` command that maps the eight Phase 1 scorecard criteria to `pass|fail|pending` for one candidate revision
- emit JSON and Markdown outputs with direct source-artifact links, plus focused unit and CLI coverage
- document the new audit entrypoint in the README and Phase 1 release docs

## Testing
- node --import tsx --test ./scripts/test/phase1-candidate-dossier.test.ts ./scripts/test/phase1-exit-audit.test.ts

Closes #950