### PR TITLE
feat: close the Cocos inventory, equipment, and loot loop

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -5875,6 +5875,7 @@ export class VeilRoot extends Component {
     this.lastRoomUpdateReason = update.reason ?? "snapshot";
     this.lastRoomUpdateAtMs = Date.now();
     this.lastUpdate = update;
+    this.maybeOpenGameplayEquipmentPanelForLoot(update);
     const eventEntries = buildTimelineEntriesFromUpdate(update);
     if (eventEntries.length > 0) {
       this.timelineEntries = collapseAdjacentEntries([...eventEntries, ...this.timelineEntries]).slice(0, 12);
@@ -5919,6 +5920,7 @@ export class VeilRoot extends Component {
       void this.refreshGameplayAccountProfile();
     }
     this.syncSelectedBattleTarget();
+    this.renderView();
     this.playMapFeedbackForUpdate(update);
     this.maybeShowHeroProgressNotice(update);
     this.setBattleFeedback(presentation.feedback, presentation.feedbackDurationMs ?? BATTLE_FEEDBACK_DURATION_MS);
@@ -5939,6 +5941,23 @@ export class VeilRoot extends Component {
 
     this.syncWechatShareBridge();
     this.renderView();
+  }
+
+  private maybeOpenGameplayEquipmentPanelForLoot(update: SessionUpdate): void {
+    if (this.showLobby || update.battle) {
+      return;
+    }
+
+    const controlledHeroIds = new Set(update.world.ownHeroes.map((hero) => hero.id));
+    const hasOwnedLoot = update.events.some(
+      (event) => event.type === "hero.equipmentFound" && controlledHeroIds.has(event.heroId)
+    );
+    if (!hasOwnedLoot) {
+      return;
+    }
+
+    this.gameplayEquipmentPanelOpen = true;
+    this.gameplayCampaignPanelOpen = false;
   }
 
   private async refreshGameplayAccountProfile(): Promise<void> {

--- a/apps/cocos-client/assets/scripts/VeilUnitAnimator.ts
+++ b/apps/cocos-client/assets/scripts/VeilUnitAnimator.ts
@@ -81,6 +81,7 @@ export class VeilUnitAnimator extends Component {
   private currentState: UnitAnimationState = "idle";
   private lastPixelFallbackReady = false;
   private pixelSequenceToken = 0;
+  private pixelSequenceTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   applyProfile(profile: CocosAnimationProfile, templateId = this.templateId): void {
     const templateChanged = this.templateId !== templateId;
@@ -114,6 +115,7 @@ export class VeilUnitAnimator extends Component {
 
   play(state: UnitAnimationState): void {
     this.unscheduleAllCallbacks();
+    this.clearPixelSequenceTimeout();
     this.currentState = state;
     this.renderCurrentState();
 
@@ -141,6 +143,7 @@ export class VeilUnitAnimator extends Component {
 
   private renderCurrentState(): void {
     this.pixelSequenceToken += 1;
+    this.clearPixelSequenceTimeout();
     if (
       !this.playSpine(this.currentState)
       && !this.playTimeline(this.currentState)
@@ -234,6 +237,10 @@ export class VeilUnitAnimator extends Component {
     }
 
     const token = this.pixelSequenceToken;
+    if (sequence.loop && this.shouldFreezeLoopingPixelSequence()) {
+      return true;
+    }
+
     let frameIndex = 0;
     const advanceFrame = (): void => {
       if (token !== this.pixelSequenceToken) {
@@ -247,12 +254,36 @@ export class VeilUnitAnimator extends Component {
       frameIndex = sequence.loop ? (frameIndex + 1) % sequence.frames.length : Math.min(frameIndex + 1, sequence.frames.length - 1);
       targetSprite.spriteFrame = sequence.frames[frameIndex] ?? null;
       if (sequence.loop || frameIndex < sequence.frames.length - 1) {
-        this.scheduleOnce(advanceFrame, sequence.frameDurationSeconds);
+        this.schedulePixelSequenceFrame(advanceFrame, sequence.frameDurationSeconds);
       }
     };
 
-    this.scheduleOnce(advanceFrame, sequence.frameDurationSeconds);
+    this.schedulePixelSequenceFrame(advanceFrame, sequence.frameDurationSeconds);
     return true;
+  }
+
+  private schedulePixelSequenceFrame(callback: () => void, delaySeconds: number): void {
+    if (this.shouldFreezeLoopingPixelSequence()) {
+      const delayMs = Math.max(1, Math.round(delaySeconds * 1_000));
+      this.pixelSequenceTimeoutId = setTimeout(() => {
+        this.pixelSequenceTimeoutId = null;
+        callback();
+      }, delayMs);
+      return;
+    }
+
+    this.scheduleOnce(callback, delaySeconds);
+  }
+
+  private clearPixelSequenceTimeout(): void {
+    if (this.pixelSequenceTimeoutId !== null) {
+      clearTimeout(this.pixelSequenceTimeoutId);
+      this.pixelSequenceTimeoutId = null;
+    }
+  }
+
+  private shouldFreezeLoopingPixelSequence(): boolean {
+    return typeof window === "undefined";
   }
 
   private resolvePixelFallbackScale(state: UnitAnimationState): number {

--- a/apps/cocos-client/assets/scripts/cocos-hero-equipment.ts
+++ b/apps/cocos-client/assets/scripts/cocos-hero-equipment.ts
@@ -47,6 +47,7 @@ export interface CocosEquipmentInspectItem {
   bonusSummary: string;
   description: string;
   count: number;
+  combatImpactSummary: string;
   specialEffectSummary?: string;
 }
 
@@ -56,6 +57,33 @@ interface CocosRecentLootEvent {
   equipmentName: string;
   rarity: EquipmentRarity;
   overflowed?: boolean;
+}
+
+function buildCombatImpactSummary(values: {
+  attack?: number | undefined;
+  defense?: number | undefined;
+  power?: number | undefined;
+  knowledge?: number | undefined;
+  maxHp?: number | undefined;
+  specialEffects?: string[] | undefined;
+}): string {
+  const tags: string[] = [];
+  if ((values.attack ?? 0) > 0) {
+    tags.push("强化兵团压制");
+  }
+  if ((values.defense ?? 0) > 0 || (values.maxHp ?? 0) > 0) {
+    tags.push("提升前线承伤");
+  }
+  if ((values.power ?? 0) > 0) {
+    tags.push("放大技能爆发");
+  }
+  if ((values.knowledge ?? 0) > 0) {
+    tags.push("扩大战术容错");
+  }
+  if ((values.specialEffects?.length ?? 0) > 0) {
+    tags.push(`激活特效 ${values.specialEffects!.join("/")}`);
+  }
+  return tags.length > 0 ? tags.join(" / ") : "当前更偏向基础属性补强";
 }
 
 function toHeroState(hero: HeroView): HeroState {
@@ -184,6 +212,14 @@ export function buildEquipmentInspectItems(hero: HeroView | null): CocosEquipmen
       bonusSummary: slot.bonusSummary,
       description: slot.description ?? "装备目录缺失说明。",
       count: 1,
+      combatImpactSummary: buildCombatImpactSummary({
+        attack: slot.item?.bonuses.attackPercent,
+        defense: slot.item?.bonuses.defensePercent,
+        power: slot.item?.bonuses.power,
+        knowledge: slot.item?.bonuses.knowledge,
+        maxHp: slot.item?.bonuses.maxHp,
+        specialEffects: slot.specialEffectSummary ? [slot.specialEffectSummary] : []
+      }),
       ...(slot.specialEffectSummary ? { specialEffectSummary: slot.specialEffectSummary } : {})
     }));
 
@@ -199,6 +235,14 @@ export function buildEquipmentInspectItems(hero: HeroView | null): CocosEquipmen
       bonusSummary: item.bonusSummary,
       description: item.description,
       count: item.count,
+      combatImpactSummary: buildCombatImpactSummary({
+        attack: definition?.bonuses.attackPercent,
+        defense: definition?.bonuses.defensePercent,
+        power: definition?.bonuses.power,
+        knowledge: definition?.bonuses.knowledge,
+        maxHp: definition?.bonuses.maxHp,
+        specialEffects: definition?.specialEffect ? [definition.specialEffect.name] : []
+      }),
       ...(definition?.specialEffect
         ? { specialEffectSummary: `${definition.specialEffect.name}: ${definition.specialEffect.description}` }
         : {})
@@ -213,10 +257,12 @@ export function formatEquipmentInspectLines(item: CocosEquipmentInspectItem | nu
     return ["当前暂无可查看的装备物品。"];
   }
 
+  const combatImpactSummary = item.combatImpactSummary || "当前更偏向基础属性补强";
   return [
     `${item.slotLabel} ${item.name} · ${item.rarityLabel}`,
     `来源 ${item.source === "equipped" ? "当前已穿戴" : `背包中 ${item.count} 件`}`,
     `加成 ${item.bonusSummary}`,
+    `战斗影响 ${combatImpactSummary}`,
     ...(item.specialEffectSummary ? [`特效 ${item.specialEffectSummary}`] : []),
     `说明 ${item.description}`
   ];
@@ -284,11 +330,19 @@ export function formatEquipmentOverviewLines(hero: HeroView | null): string[] {
   const summaryLine = summary.length > 0
     ? `装备总加成 ${summary.map((entry) => `${entry.label} +${entry.value}`).join("  ·  ")}`
     : "装备总加成 当前无额外属性";
+  const combatImpactLine = `战斗影响 ${buildCombatImpactSummary({
+    attack: summary.find((entry) => entry.label === "攻")?.value,
+    defense: summary.find((entry) => entry.label === "防")?.value,
+    power: summary.find((entry) => entry.label === "力")?.value,
+    knowledge: summary.find((entry) => entry.label === "知")?.value,
+    maxHp: summary.find((entry) => entry.label === "生命")?.value,
+    specialEffects: loadout.summary.specialEffects.map((effect) => effect.name)
+  })}`;
   const effects = loadout.summary.specialEffects.length > 0
     ? [`特效 ${loadout.summary.specialEffects.map((effect) => effect.name).join(" / ")}`]
     : [];
 
-  return [`装备 ${equipped.join("  ·  ")}`, ...detail, summaryLine, ...effects, ...descriptions];
+  return [`装备 ${equipped.join("  ·  ")}`, ...detail, summaryLine, combatImpactLine, ...effects, ...descriptions];
 }
 
 function formatSessionLootDescription(

--- a/apps/cocos-client/test/cocos-equipment-panel.test.ts
+++ b/apps/cocos-client/test/cocos-equipment-panel.test.ts
@@ -88,10 +88,12 @@ test("VeilEquipmentPanel supports inspecting equipped and bag items in a dedicat
 
   assert.match(readCardLabel(node, "EquipmentPanelInspect"), /武器 先锋战刃 · 稀有/);
   assert.match(readCardLabel(node, "EquipmentPanelInspect"), /来源 当前已穿戴/);
+  assert.match(readCardLabel(node, "EquipmentPanelInspect"), /战斗影响/);
 
   pressNode(findNode(node, "EquipmentPanelInspect-inventory-accessory-scout_compass"));
 
   assert.match(readCardLabel(node, "EquipmentPanelInspect"), /饰品 斥候罗盘 · 普通/);
   assert.match(readCardLabel(node, "EquipmentPanelInspect"), /来源 背包中 2 件/);
+  assert.match(readCardLabel(node, "EquipmentPanelInspect"), /扩大战术容错/);
   assert.match(readCardLabel(node, "EquipmentPanelInspect"), /说明 帮助英雄更快判断战场破绽/);
 });

--- a/apps/cocos-client/test/cocos-hero-equipment.test.ts
+++ b/apps/cocos-client/test/cocos-hero-equipment.test.ts
@@ -212,6 +212,7 @@ test("formatEquipmentOverviewLines exposes slot metadata and resolved equipment 
       "护甲 厚绗布甲 · 普通 · 防御 +6% / 生命上限 +2",
       "饰品 未装备 · 等待拾取或替换",
       "装备总加成 生命 +2",
+      "战斗影响 提升前线承伤 / 激活特效 抢攻",
       "特效 抢攻",
       "武器 说明 鼓励先手突击的军团佩剑。",
       "护甲 说明 最基础的防护甲衣。"
@@ -270,12 +271,14 @@ test("formatEquipmentInspectLines provides stable item detail copy for the panel
       bonusSummary: "攻击 +10%",
       description: "鼓励先手突击的军团佩剑。",
       count: 1,
+      combatImpactSummary: "强化兵团压制 / 激活特效 抢攻",
       specialEffectSummary: "抢攻: 在开战后的第一轮拥有更强的压制力。"
     }),
     [
       "武器 先锋战刃 · 稀有",
       "来源 当前已穿戴",
       "加成 攻击 +10%",
+      "战斗影响 强化兵团压制 / 激活特效 抢攻",
       "特效 抢攻: 在开战后的第一轮拥有更强的压制力。",
       "说明 鼓励先手突击的军团佩剑。"
     ]

--- a/apps/cocos-client/test/cocos-primary-client-journey.test.ts
+++ b/apps/cocos-client/test/cocos-primary-client-journey.test.ts
@@ -981,15 +981,14 @@ test("primary cocos client journey closes the loot, inventory, and equip loop af
   room.emitPush(createJourneyLootSettlementUpdate(roomId, playerId));
 
   await waitFor(
-    () => root.lastUpdate?.events.some((event) => event.type === "hero.equipmentFound") === true,
+    () =>
+      root.lastUpdate?.events.some((event) => event.type === "hero.equipmentFound") === true
+      && root.gameplayEquipmentPanelOpen === true,
     () => ({
       phase: "loot-settlement",
       ...captureJourneyUiState(rootNode)
     })
   );
-
-  (root as RootState).toggleGameplayEquipmentPanel();
-  root.renderView();
 
   const inventoryTextBeforeEquip = readNodeLabel(findNode(rootNode, "EquipmentPanelInventory")?.getChildByName("Label"));
   const lootTextBeforeEquip = readNodeLabel(findNode(rootNode, "EquipmentPanelLoot")?.getChildByName("Label"));

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -240,6 +240,28 @@ test("VeilRoot toggles a dedicated gameplay equipment panel from the HUD flow", 
   assert.equal(root.gameplayEquipmentPanelOpen, false);
 });
 
+test("VeilRoot auto-opens the gameplay equipment panel when owned loot settles into the client", async () => {
+  const root = createVeilRootHarness();
+  const lootUpdate = createSessionUpdate(1, "room-equipment", "player-1");
+  root.showLobby = false;
+  lootUpdate.battle = null;
+  lootUpdate.events = [
+    {
+      type: "hero.equipmentFound",
+      heroId: "hero-1",
+      battleId: "battle-1",
+      battleKind: "neutral",
+      equipmentId: "scout_compass",
+      equipmentName: "斥候罗盘",
+      rarity: "common"
+    }
+  ];
+
+  root.maybeOpenGameplayEquipmentPanelForLoot(lootUpdate);
+
+  assert.equal(root.gameplayEquipmentPanelOpen, true);
+});
+
 test("VeilRoot loads campaign state and advances the manual campaign dialogue/start/complete slice", async () => {
   const root = createVeilRootHarness();
   root.remoteUrl = "http://127.0.0.1:2567";


### PR DESCRIPTION
## Summary
- auto-open the gameplay equipment panel when owned loot settles so the primary journey exposes loot review on the main path
- add combat-impact summaries to equipment overview and inspect cards so stat and effect changes are immediately legible in the client
- harden pixel-sequence playback under the Node test runtime and extend journey/orchestration coverage for the loot -> equip -> stat-update loop

## Validation
- `node --import tsx --test ./apps/cocos-client/test/cocos-hero-equipment.test.ts ./apps/cocos-client/test/cocos-equipment-panel.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts ./apps/cocos-client/test/cocos-primary-client-journey.test.ts`
- `node --import tsx --test ./apps/cocos-client/test/cocos-unit-animator.test.ts`

Closes #952
