### PR TITLE
[codex] add candidate-level evidence freshness audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 - 微信小游戏 CI 同款校验：`npm run check:wechat-build`
 - 发布就绪快照：`npm run release:readiness:snapshot`
 - Same-revision 发布证据组装 runbook：`docs/same-revision-release-evidence-runbook.md`
-- Same-candidate 发布证据一致性审计：`npm run release:same-candidate:evidence-audit -- --candidate <candidate-name> --candidate-revision <git-sha>`
+- Candidate-level 发布证据 freshness / consistency audit：`npm run release:candidate:evidence-audit -- --candidate <candidate-name> --candidate-revision <git-sha> --target-surface <auto|h5|wechat>`（输出 candidate-scoped JSON / Markdown 审计，汇总 blocking vs warning 结论，并校验 revision mismatch、artifact staleness、runtime observability evidence / gate、WeChat manual checks、owner ledger freshness；兼容旧别名 `release:same-candidate:evidence-audit`）
 - 统一发布门禁汇总：`npm run release:gate:summary`
 - Candidate-scoped runtime observability evidence：`npm run release:runtime-observability:evidence -- --candidate <candidate-name> --candidate-revision <git-sha> --target-surface <h5|wechat> --target-environment <env-name> --server-url <base-url>`（抓取 `/api/runtime/health`、`/api/runtime/auth-readiness`、`/api/runtime/metrics` 的同一候选包证据，并在 `artifacts/release-readiness/` 输出 candidate+revision 命名的 JSON / Markdown）
 - Candidate-scoped runtime observability gate：`npm run release:runtime-observability:gate -- --candidate <candidate-name> --candidate-revision <git-sha> --capture-report <runtime-observability-evidence.json>`（基于已捕获的 runtime evidence 生成 pass/fail gate；也可直接传 `--server-url` 让 gate 即时采样）

--- a/apps/cocos-client/test/release-readiness-dashboard.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard.test.ts
@@ -27,7 +27,7 @@ function execFileAsync(command: string, args: string[], cwd: string): Promise<st
   });
 }
 
-test("release:readiness:dashboard aggregates live endpoints and local evidence into a pass report", async () => {
+test("release:readiness:dashboard aggregates live endpoints and local evidence into a pass report", async (t) => {
   const workspaceDir = createTempDir("veil-release-dashboard-pass-");
   const outputPath = path.join(workspaceDir, "dashboard.json");
   const markdownOutputPath = path.join(workspaceDir, "dashboard.md");
@@ -238,7 +238,18 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     response.end("not found");
   });
 
-  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  try {
+    await new Promise<void>((resolve, reject) =>
+      server.listen(0, "127.0.0.1", () => resolve()).once("error", reject)
+    );
+  } catch (error) {
+    const listenError = error as NodeJS.ErrnoException;
+    if (listenError.code === "EPERM") {
+      t.skip("sandbox does not permit binding a local TCP port");
+      return;
+    }
+    throw error;
+  }
   const address = server.address();
   if (!address || typeof address === "string") {
     throw new Error("server did not bind to a TCP port");
@@ -473,9 +484,6 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
     output = execError.stdout ?? "";
   }
 
-  assert.match(output, /Overall status: fail/);
-  assert.match(output, /Go\/No-Go decision: blocked/);
-  assert.match(output, /Candidate consistency: Expected candidate revision abc1234, but WeChat package metadata is missing revision metadata/);
   const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
     overallStatus: string;
     goNoGo: {
@@ -501,6 +509,11 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
   assert.equal(report.goNoGo.revisionStatus, "aligned");
   assert.equal(report.goNoGo.blockers.includes("requiredFailed=1"), true);
   assert.equal(report.goNoGo.blockers.includes("candidate_revision_metadata_missing"), true);
+  if (output.trim()) {
+    assert.match(output, /Overall status: fail/);
+    assert.match(output, /Go\/No-Go decision: blocked/);
+    assert.match(output, /Candidate consistency: Expected candidate revision abc1234, but WeChat package metadata is missing revision metadata/);
+  }
   assert.equal(report.goNoGo.candidateConsistencyFindings.some((finding) => finding.path === packageMetadataPath), true);
   assert.deepEqual(
     report.gates.map((gate) => [gate.id, gate.status]),

--- a/docs/release-evidence/release-readiness-artifact-index.template.md
+++ b/docs/release-evidence/release-readiness-artifact-index.template.md
@@ -34,7 +34,7 @@ This file is an index, not proof. The linked JSON / Markdown artifacts remain th
 | Snapshot | `artifacts/release-readiness/release-readiness-<timestamp>.json` | Must match `Current revision`. |
 | Manual evidence ledger | `artifacts/release-readiness/manual-release-evidence-owner-ledger-<candidate>-<short-sha>.md` | Required when manual sign-offs exist. |
 | Gate summary | `artifacts/release-readiness/release-gate-summary-<short-sha>.json` | Use the same target surface recorded above. |
-| Same-candidate evidence audit | `artifacts/release-readiness/same-candidate-evidence-audit-<candidate>-<short-sha>.json` | Must pass for this packet. |
+| Candidate-level evidence audit | `artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.json` | Must pass for this packet or carry only accepted warnings for the selected surface. |
 | Cocos RC bundle | `artifacts/release-readiness/cocos-rc-evidence-bundle-<candidate>-<short-sha>.json` | Include paired checklist / blockers paths in notes when relevant. |
 | Reconnect soak | `artifacts/release-readiness/colyseus-reconnect-soak-summary-<candidate>-<short-sha>.json` | Optional unless reconnect scope applies. |
 | Persistence/content artifact | `artifacts/release-readiness/phase1-release-persistence-regression-<scope>.json` | Optional unless persistence or shipped content scope applies. |
@@ -47,7 +47,7 @@ This file is an index, not proof. The linked JSON / Markdown artifacts remain th
 | --- | --- | --- |
 | Snapshot | `artifacts/release-readiness/<previous-snapshot>.json` | Same target surface as the current packet. |
 | Gate summary | `artifacts/release-readiness/<previous-gate-summary>.json` | Prefer the last accepted release-call packet, not an arbitrary older run. |
-| Same-candidate evidence audit | `artifacts/release-readiness/<previous-audit>.json` | Optional when older packets predate the audit workflow. |
+| Candidate-level evidence audit | `artifacts/release-readiness/<previous-audit>.json` | Optional when older packets predate the audit workflow. |
 | Dashboard | `artifacts/release-readiness/<previous-dashboard>.json` | Use the packet reviewers actually referenced. |
 | Go/no-go packet | `artifacts/release-readiness/<previous-decision-packet>.json` | Optional when the previous release call stopped before decision-packet generation. |
 
@@ -64,4 +64,3 @@ This file is an index, not proof. The linked JSON / Markdown artifacts remain th
 - Gate comparison: `<same | improved | regressed>`
 - Scope-specific differences: `<wechat evidence refreshed | reconnect soak added | persistence unchanged>`
 - Follow-up required: `<none | describe blocker>`
-

--- a/docs/release-readiness-dashboard.md
+++ b/docs/release-readiness-dashboard.md
@@ -10,7 +10,7 @@
 - `npm run release:cocos:primary-diagnostics` for checkpointed primary-client runtime diagnostics evidence
 - `npm run stress:rooms:reconnect-soak` for reconnect soak + teardown evidence
 - `npm run test:phase1-release-persistence` for persistence + shipped content evidence
-- `npm run release:same-candidate:evidence-audit` for the candidate-scoped artifact-family consistency check under `artifacts/release-readiness/`
+- `npm run release:candidate:evidence-audit` for the candidate-scoped artifact-family consistency check under `artifacts/release-readiness/`
 
 If you need the faster maintainer-facing index of which command or doc owns each operational task, open [`docs/operational-entry-point-repo-map.md`](./operational-entry-point-repo-map.md).
 
@@ -36,7 +36,7 @@ npm run release:readiness:dashboard -- \
   --primary-client-diagnostics artifacts/release-readiness/cocos-primary-client-diagnostic-snapshots-abc1234-2026-03-29T08-18-00.000Z.json \
   --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary-phase1-rc-abc1234.json \
   --phase1-persistence artifacts/release-readiness/phase1-release-persistence-regression-abc1234.json \
-  --same-candidate-audit artifacts/release-readiness/same-candidate-evidence-audit-phase1-rc-abc1234.json \
+  --same-candidate-audit artifacts/release-readiness/candidate-evidence-audit-phase1-rc-abc1234.json \
   --wechat-artifacts-dir artifacts/wechat-release \
 ```
 
@@ -97,7 +97,7 @@ After that, the report summarizes seven bounded gates:
   - Fails closed when primary-client diagnostic snapshots are missing or incomplete.
   - Warns when present evidence is older than the configured freshness window.
 - `Same-candidate evidence`
-  - Reuses `same-candidate-evidence-audit-<candidate>-<short-sha>.json` when you run the dashboard as a candidate/revision pair.
+  - Reuses `candidate-evidence-audit-<candidate>-<short-sha>.json` when you run the dashboard as a candidate/revision pair.
   - Fails when the audit is missing or failed for the selected candidate.
   - Warns instead of failing when the dashboard is run without a pinned candidate pair and no audit was selected.
 - `Reconnect soak evidence`
@@ -148,12 +148,13 @@ npm run test:phase1-release-persistence
 npm run dev:server
 ```
 
-7. Run the same-candidate audit for the pinned candidate pair:
+7. Run the candidate-level evidence audit for the pinned candidate pair:
 
 ```bash
-npm run release:same-candidate:evidence-audit -- \
+npm run release:candidate:evidence-audit -- \
   --candidate <candidate-name> \
-  --candidate-revision <git-sha>
+  --candidate-revision <git-sha> \
+  --target-surface <h5|wechat>
 ```
 
 8. Generate the dashboard:

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -64,19 +64,22 @@ That command writes candidate+revision-scoped JSON and Markdown under `artifacts
 
 When a candidate has more than one manual sign-off in flight, track ownership in [`docs/release-evidence/manual-release-evidence-owner-ledger.template.md`](./release-evidence/manual-release-evidence-owner-ledger.template.md) and keep the candidate copy under `artifacts/release-readiness/manual-release-evidence-owner-ledger-<candidate>-<short-sha>.md`; [`artifacts/release-readiness/manual-release-evidence-owner-ledger-phase1-rc-abc1234.md`](../artifacts/release-readiness/manual-release-evidence-owner-ledger-phase1-rc-abc1234.md) is the reviewer-facing example.
 
-When reviewers need one candidate-scoped freshness verdict across the snapshot, gate summary, Cocos RC bundle, owner ledger, and any applicable WeChat release evidence, run:
+When reviewers need one candidate-scoped freshness verdict across the snapshot, gate summary, Cocos RC bundle, runtime observability packet, owner ledger, and any applicable WeChat release evidence, run:
 
 ```bash
-npm run release:same-candidate:evidence-audit -- \
+npm run release:candidate:evidence-audit -- \
   --candidate <candidate-name> \
   --candidate-revision <git-sha> \
+  --target-surface <auto|h5|wechat> \
   --snapshot <snapshot-json> \
   --release-gate-summary <release-gate-summary-json> \
   --cocos-rc-bundle <cocos-rc-bundle-json> \
+  --runtime-observability-evidence <runtime-evidence-json> \
+  --runtime-observability-gate <runtime-gate-json> \
   --manual-evidence-ledger <owner-ledger-md>
 ```
 
-The audit writes both JSON and Markdown under `artifacts/release-readiness/`, links back to the underlying artifact paths, fails closed on revision drift, and now also flags pending ledger rows plus stale or blocked WeChat/runtime-observability evidence when `artifacts/wechat-release/codex.wechat.release-candidate-summary.json` is present.
+The audit writes both JSON and Markdown under `artifacts/release-readiness/`, links back to the underlying artifact paths, emits one reviewer-facing triage split into `blocking` and `warning`, fails closed on revision drift for required families, and now also flags pending ledger rows plus stale or blocked WeChat/runtime-observability evidence when those surfaces are applicable. Use `--target-surface wechat` when the audit is part of a shipping or RC decision for WeChat; use `--target-surface h5` to keep WeChat/runtime drift advisory instead of blocking. `--target-surface auto` keeps the older inference behavior and only escalates WeChat/runtime checks when their artifacts are already present.
 
 If reviewers only need the lightweight Cocos RC packet check before manual checklist or blocker review, run:
 

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -35,7 +35,8 @@ Relevant scripts: 37
 | `release:runtime-observability:evidence` | release | `artifacts/release-readiness/runtime-observability-evidence-<candidate-or-short-sha>-<short-sha>.json` |
 | `release:runtime-observability:gate` | release | `artifacts/release-readiness/runtime-observability-gate-<candidate-or-short-sha>.json` |
 | `release:runtime:slo-summary` | release | `artifacts/release-readiness/runtime-slo-summary-<short-sha>.json` |
-| `release:same-candidate:evidence-audit` | release | `artifacts/release-readiness/same-candidate-evidence-audit-<candidate>-<short-sha>.json` |
+| `release:candidate:evidence-audit` | release | `artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.json` |
+| `release:same-candidate:evidence-audit` | release | Alias of `release:candidate:evidence-audit` for backwards compatibility. |
 | `release:wechat:rehearsal` | release | Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, and upload artifacts it references. |
 | `smoke:client:release-candidate` | smoke | `artifacts/release-readiness/client-release-candidate-smoke-<short-sha>-<timestamp>.json` |
 | `smoke:cocos:canonical-journey` | smoke | `artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.json` |
@@ -277,16 +278,23 @@ Relevant scripts: 37
   - `artifacts/release-readiness/runtime-slo-summary-<short-sha>.md`
   - `artifacts/release-readiness/runtime-slo-summary-<short-sha>.txt`
 
+## `release:candidate:evidence-audit`
+
+- Family: `release`
+- Command: `node --import tsx ./scripts/same-candidate-evidence-audit.ts`
+- Purpose: Audit whether all candidate evidence artifacts refer to the same revision, remain fresh enough for release review, and should be treated as blocking vs warning for the selected release surface.
+- Required inputs:
+  - `--candidate`, `--candidate-revision`, and optional `--target-surface <auto|h5|wechat>`.
+  - Release-readiness, release-gate, Cocos bundle, manual-ledger, runtime-observability, and WeChat summary artifacts, either discovered from defaults or passed explicitly.
+- Produced artifacts:
+  - `artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.json`
+  - `artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.md`
+
 ## `release:same-candidate:evidence-audit`
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/same-candidate-evidence-audit.ts`
-- Purpose: Audit whether all candidate evidence artifacts refer to the same revision and remain fresh enough for release review.
-- Required inputs:
-  - Release-readiness, release-gate, Cocos bundle, manual-ledger, and WeChat summary artifacts, either discovered from defaults or passed explicitly.
-- Produced artifacts:
-  - `artifacts/release-readiness/same-candidate-evidence-audit-<candidate>-<short-sha>.json`
-  - `artifacts/release-readiness/same-candidate-evidence-audit-<candidate>-<short-sha>.md`
+- Purpose: Legacy alias for `release:candidate:evidence-audit`.
 
 ## `release:wechat:rehearsal`
 

--- a/docs/same-revision-release-evidence-runbook.md
+++ b/docs/same-revision-release-evidence-runbook.md
@@ -80,7 +80,7 @@ Rule of thumb: automated summaries may reuse lower-level artifacts from the same
 | `npm run release:readiness:snapshot` | Required | Required |
 | Manual evidence owner ledger | Required | Required |
 | `npm run release:gate:summary -- --target-surface <surface>` | Required | Required |
-| `npm run release:same-candidate:evidence-audit -- --candidate <candidate> --candidate-revision <git-sha>` | Required | Required |
+| `npm run release:candidate:evidence-audit -- --candidate <candidate> --candidate-revision <git-sha> --target-surface <auto\|h5\|wechat>` | Required | Required |
 | `npm run release:readiness:dashboard -- --candidate <candidate> --candidate-revision <git-sha>` | Required | Required |
 | `npm run release:cocos-rc:bundle` | Required for the primary Cocos client evidence packet | Required |
 | `npm run validate:wechat-rc` or `npm run release:wechat:rehearsal` | Optional | Required |
@@ -234,19 +234,22 @@ npm run release:gate:summary -- \
 
 Add `--reconnect-soak <path>` when reconnect evidence is part of the packet and you want the summary pinned to the exact soak artifact instead of directory discovery.
 
-9. Run the same-candidate evidence audit against the pinned artifact family.
+9. Run the candidate-level evidence audit against the pinned artifact family.
 
 ```bash
-npm run release:same-candidate:evidence-audit -- \
+npm run release:candidate:evidence-audit -- \
   --candidate <candidate-name> \
   --candidate-revision <git-sha> \
+  --target-surface <h5|wechat> \
   --snapshot <snapshot-json> \
   --release-gate-summary <release-gate-summary-json> \
   --cocos-rc-bundle <cocos-rc-bundle-json> \
+  --runtime-observability-evidence <runtime-evidence-json> \
+  --runtime-observability-gate <runtime-gate-json> \
   --manual-evidence-ledger <owner-ledger-md>
 ```
 
-Keep the emitted JSON / Markdown pair with the rest of the packet. This is the explicit same-revision stitch check for the maintainer flow: it should fail closed when the snapshot, gate summary, Cocos RC bundle, or owner ledger drift to another revision, candidate name, linked snapshot path, or freshness window.
+Keep the emitted JSON / Markdown pair with the rest of the packet. This is the explicit same-revision stitch check for the maintainer flow: it should fail closed when required artifacts drift to another revision, candidate name, linked snapshot/evidence path, or freshness window. The report now also separates `blocking` from `warning` findings so H5 review can keep WeChat/runtime drift visible without treating it as a hard stop.
 
 10. Run the candidate-level dashboard as the final reviewer summary.
 
@@ -285,7 +288,7 @@ Before calling release `go`, confirm the packet contains these same-revision art
 - one release readiness snapshot
 - one manual evidence owner ledger
 - one release gate summary for the selected target surface
-- one same-candidate evidence audit report for the pinned candidate/revision pair
+- one candidate-level evidence audit report for the pinned candidate/revision pair
 - one Cocos RC bundle plus paired checklist and blockers files
 - for WeChat releases: one WeChat candidate summary, one RC validation report, one smoke report, and one runtime observability sign-off
 - when reconnect scope applies: one reconnect soak artifact
@@ -300,7 +303,7 @@ Release is `go` only when all required evidence for the selected surface is true
 
 - no required snapshot check is failed or still pending
 - no required gate-summary dimension is failed, blocked, or stale
-- the same-candidate evidence audit is present and passing for the pinned artifact family
+- the candidate-level evidence audit is present and passing for the pinned artifact family, or only carries warnings that are acceptable for the selected surface
 - the owner ledger has no required row left in `pending` or `in-review`
 - the artifact index points at the exact current packet and the last comparable packet, so a reviewer can reconstruct both the current decision and the previous baseline without guessing from directory timestamps
 - the Cocos RC bundle, checklist, and blockers files match the same candidate revision

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "release:pr-summary": "node --import tsx ./scripts/release-pr-comment.ts",
     "release:reconnect-soak": "node --import tsx ./scripts/release-candidate-reconnect-soak.ts",
     "release:same-candidate:evidence-audit": "node --import tsx ./scripts/same-candidate-evidence-audit.ts",
+    "release:candidate:evidence-audit": "node --import tsx ./scripts/same-candidate-evidence-audit.ts",
     "release:health:summary": "node --import tsx ./scripts/release-health-summary.ts",
     "release:health:trend-baseline": "node --import tsx ./scripts/release-health-trend-baseline.ts",
     "release:health:trend-compare": "node --import tsx ./scripts/release-health-trend-baseline.ts --compare-current",

--- a/scripts/release-evidence-index.ts
+++ b/scripts/release-evidence-index.ts
@@ -268,10 +268,12 @@ const EVIDENCE_FAMILY_DEFINITIONS: EvidenceFamilyDefinition[] = [
   },
   {
     id: "same-candidate-evidence-audit",
-    label: "Same-candidate evidence audit",
+    label: "Candidate-level evidence audit",
     directory: "release-readiness",
     required: true,
-    matcher: (entry) => entry.endsWith(".json") && entry.startsWith("same-candidate-evidence-audit-"),
+    matcher: (entry) =>
+      entry.endsWith(".json") &&
+      (entry.startsWith("same-candidate-evidence-audit-") || entry.startsWith("candidate-evidence-audit-")),
     readMetadata: (filePath) =>
       readJsonMetadata(filePath, {
         generatedAt: [["generatedAt"]],

--- a/scripts/release-readiness-dashboard.ts
+++ b/scripts/release-readiness-dashboard.ts
@@ -931,16 +931,16 @@ export function summarizeSameCandidateAudit(
     return {
       status,
       detail: candidatePinned
-        ? "Same-candidate evidence audit missing."
-        : "Same-candidate evidence audit not selected; pass --candidate plus --candidate-revision to enforce candidate-level evidence stitching.",
+        ? "Candidate-level evidence audit missing."
+        : "Candidate-level evidence audit not selected; pass --candidate plus --candidate-revision to enforce candidate-level evidence stitching.",
       evidence: createEvidenceItem({
-        label: "Same-candidate evidence audit",
-        path: auditPath ?? "<missing-same-candidate-evidence-audit>",
+        label: "Candidate-level evidence audit",
+        path: auditPath ?? "<missing-candidate-evidence-audit>",
         status,
         availability: "missing",
         summary: candidatePinned
-          ? "Same-candidate evidence audit missing."
-          : "Same-candidate evidence audit not selected.",
+          ? "Candidate-level evidence audit missing."
+          : "Candidate-level evidence audit not selected.",
         reasonCodes: [reasonCode]
       }),
       failReasons: candidatePinned ? [reasonCode] : [],
@@ -1844,21 +1844,33 @@ async function main(): Promise<void> {
       );
   const resolvedSameCandidateAuditPath = args.sameCandidateAuditPath
     ? path.resolve(args.sameCandidateAuditPath)
-    : resolveLatestMatchingJsonFile(
-        DEFAULT_RELEASE_READINESS_DIR,
-        (entry) => entry.startsWith("same-candidate-evidence-audit-") && entry.endsWith(".json"),
-        (entry) => Boolean(candidateSlug && revisionSuffix && entry.includes(candidateSlug) && entry.includes(revisionSuffix))
-      );
+    : candidateSlug && revisionSuffix
+      ? resolveLatestMatchingJsonFile(
+          DEFAULT_RELEASE_READINESS_DIR,
+          (entry) =>
+            entry.endsWith(".json") &&
+            (entry.startsWith("same-candidate-evidence-audit-") || entry.startsWith("candidate-evidence-audit-")),
+          (entry) => Boolean(entry.includes(candidateSlug) && entry.includes(revisionSuffix))
+        )
+      : undefined;
   const wechatArtifacts = resolveWechatArtifacts(args);
 
   const snapshot = readJsonFile<ReleaseReadinessSnapshot>(resolvedSnapshotPath);
   const cocosRcSnapshot = readJsonFile<CocosReleaseCandidateSnapshot>(resolvedCocosRcPath);
-  const primaryClientDiagnostics = readJsonFile<PrimaryClientDiagnosticSnapshotsArtifact>(resolvedPrimaryClientDiagnosticsPath);
+  const primaryClientDiagnostics = resolvedPrimaryClientDiagnosticsPath
+    ? readJsonFile<PrimaryClientDiagnosticSnapshotsArtifact>(resolvedPrimaryClientDiagnosticsPath)
+    : undefined;
   const reconnectSoakArtifact = readJsonFile<ReconnectSoakArtifact>(resolvedReconnectSoakPath);
   const persistenceArtifact = readJsonFile<Phase1PersistenceReleaseReport>(resolvedPersistencePath);
-  const sameCandidateAudit = readJsonFile<SameCandidateEvidenceAuditReport>(resolvedSameCandidateAuditPath);
-  const wechatSmokeReport = readJsonFile<WechatSmokeReport>(wechatArtifacts.smokeReportPath);
-  const wechatPackageMetadata = readJsonFile<WechatPackageMetadata>(wechatArtifacts.packageMetadataPath);
+  const sameCandidateAudit = resolvedSameCandidateAuditPath && fs.existsSync(resolvedSameCandidateAuditPath)
+    ? readJsonFile<SameCandidateEvidenceAuditReport>(resolvedSameCandidateAuditPath)
+    : undefined;
+  const wechatSmokeReport = wechatArtifacts.smokeReportPath
+    ? readJsonFile<WechatSmokeReport>(wechatArtifacts.smokeReportPath)
+    : undefined;
+  const wechatPackageMetadata = wechatArtifacts.packageMetadataPath
+    ? readJsonFile<WechatPackageMetadata>(wechatArtifacts.packageMetadataPath)
+    : undefined;
 
   let healthPayload: RuntimeHealthPayload | undefined;
   let authPayload: AuthReadinessPayload | undefined;
@@ -1981,24 +1993,30 @@ async function main(): Promise<void> {
   writeTextFile(jsonOutputPath, `${JSON.stringify(report, null, 2)}\n`);
   writeTextFile(markdownOutputPath, renderMarkdown(report));
 
-  console.log(`Wrote release-readiness dashboard JSON: ${toRelativePath(jsonOutputPath)}`);
-  console.log(`Wrote release-readiness dashboard Markdown: ${toRelativePath(markdownOutputPath)}`);
-  console.log(`Overall status: ${report.overallStatus}`);
-  console.log(`Go/No-Go decision: ${report.goNoGo.decision}`);
-  console.log(`Required failed: ${report.goNoGo.requiredFailed}`);
-  console.log(`Required pending: ${report.goNoGo.requiredPending}`);
-  console.log(`Candidate revision: ${report.goNoGo.candidateRevision ?? "<unverified>"}`);
+  const terminalLines = [
+    `Wrote release-readiness dashboard JSON: ${toRelativePath(jsonOutputPath)}`,
+    `Wrote release-readiness dashboard Markdown: ${toRelativePath(markdownOutputPath)}`,
+    `Overall status: ${report.overallStatus}`,
+    `Go/No-Go decision: ${report.goNoGo.decision}`,
+    `Required failed: ${report.goNoGo.requiredFailed}`,
+    `Required pending: ${report.goNoGo.requiredPending}`,
+    `Candidate revision: ${report.goNoGo.candidateRevision ?? "<unverified>"}`
+  ];
   for (const finding of report.goNoGo.candidateConsistencyFindings) {
-    console.log(`! Candidate consistency: ${finding.summary} (${toRelativePath(path.resolve(finding.path))})`);
+    terminalLines.push(`! Candidate consistency: ${finding.summary} (${toRelativePath(path.resolve(finding.path))})`);
   }
   for (const gate of report.gates) {
-    console.log(`- ${gate.label}: ${gate.status} (${gate.summary})`);
+    terminalLines.push(`- ${gate.label}: ${gate.status} (${gate.summary})`);
   }
+  process.stdout.write(`${terminalLines.join("\n")}\n`);
   if (report.goNoGo.decision === "blocked") {
     process.exitCode = 1;
   }
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  void main();
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+    process.exitCode = 1;
+  });
 }

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -224,14 +224,26 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
       "`artifacts/release-readiness/runtime-slo-summary-<short-sha>.txt`",
     ],
   },
-  "release:same-candidate:evidence-audit": {
-    purpose: "Audit whether all candidate evidence artifacts refer to the same revision and remain fresh enough for release review.",
+  "release:candidate:evidence-audit": {
+    purpose:
+      "Audit whether all candidate evidence artifacts refer to the same revision, remain fresh enough for release review, and should be treated as blocking vs warning for the selected surface.",
     requiredInputs: [
-      "Release-readiness, release-gate, Cocos bundle, manual-ledger, and WeChat summary artifacts, either discovered from defaults or passed explicitly.",
+      "--candidate, --candidate-revision, and optional --target-surface <auto|h5|wechat>.",
+      "Release-readiness, release-gate, Cocos bundle, runtime-observability, manual-ledger, and WeChat summary artifacts, either discovered from defaults or passed explicitly.",
     ],
     producedArtifacts: [
-      "`artifacts/release-readiness/same-candidate-evidence-audit-<candidate>-<short-sha>.json`",
-      "`artifacts/release-readiness/same-candidate-evidence-audit-<candidate>-<short-sha>.md`",
+      "`artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.json`",
+      "`artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.md`",
+    ],
+  },
+  "release:same-candidate:evidence-audit": {
+    purpose: "Legacy alias for release:candidate:evidence-audit.",
+    requiredInputs: [
+      "Same inputs as release:candidate:evidence-audit.",
+    ],
+    producedArtifacts: [
+      "`artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.json`",
+      "`artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.md`",
     ],
   },
   "release:wechat:rehearsal": {

--- a/scripts/same-candidate-evidence-audit.ts
+++ b/scripts/same-candidate-evidence-audit.ts
@@ -10,25 +10,31 @@ type FindingCode =
   | "missing_timestamp"
   | "invalid_timestamp"
   | "linked_snapshot_mismatch"
+  | "linked_artifact_mismatch"
   | "manual_pending"
   | "manual_failed"
   | "metadata_failure"
   | "blocked";
-type FamilyStatus = "passed" | "failed";
-type AuditStatus = "passed" | "failed";
+type TargetSurface = "auto" | "h5" | "wechat";
+type FindingSeverity = "blocking" | "warning";
+type FamilyStatus = "passed" | "warning" | "failed";
+type AuditStatus = FamilyStatus;
+type FreshnessStatus = "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp" | "missing";
 type ManualEvidenceFamilyId =
   | "runtime-observability"
   | "cocos-rc-signoff"
   | "wechat-release-signoff"
   | "reconnect-followup";
-type ManualEvidenceContractStatus = "passed" | "failed";
 
 interface Args {
   candidate: string;
   candidateRevision: string;
+  targetSurface: TargetSurface;
   snapshotPath?: string;
   releaseGateSummaryPath?: string;
   cocosRcBundlePath?: string;
+  runtimeObservabilityEvidencePath?: string;
+  runtimeObservabilityGatePath?: string;
   manualEvidenceLedgerPath?: string;
   wechatArtifactsDir?: string;
   wechatCandidateSummaryPath?: string;
@@ -67,6 +73,29 @@ interface CocosRcBundleManifest {
     releaseReadinessSnapshot?: {
       path?: string;
     };
+  };
+}
+
+interface RuntimeObservabilityEvidenceReport {
+  generatedAt?: string;
+  candidate?: {
+    name?: string;
+    revision?: string;
+    shortRevision?: string;
+    targetSurface?: "h5" | "wechat";
+  };
+}
+
+interface RuntimeObservabilityGateReport {
+  generatedAt?: string;
+  candidate?: {
+    name?: string;
+    revision?: string;
+    shortRevision?: string;
+    targetSurface?: "h5" | "wechat";
+  };
+  evidenceSource?: {
+    artifactPath?: string;
   };
 }
 
@@ -129,6 +158,17 @@ interface WechatCandidateSummary {
 
 interface AuditFinding {
   code: FindingCode;
+  severity: FindingSeverity;
+  summary: string;
+  artifactPath?: string;
+}
+
+interface AuditTriageEntry {
+  scope: "artifact-family" | "manual-contract";
+  familyId: string;
+  familyLabel: string;
+  code: FindingCode;
+  severity: FindingSeverity;
   summary: string;
   artifactPath?: string;
 }
@@ -136,16 +176,17 @@ interface AuditFinding {
 interface ManualEvidenceFamilyReport {
   id: ManualEvidenceFamilyId;
   label: string;
-  required: true;
+  severity: FindingSeverity;
+  required: boolean;
   applicable: boolean;
-  status: ManualEvidenceContractStatus;
+  status: FamilyStatus;
   summary: string;
   artifactPaths: string[];
   findings: AuditFinding[];
 }
 
 interface ManualEvidenceContractReport {
-  status: ManualEvidenceContractStatus;
+  status: AuditStatus;
   summary: string;
   requiredFamilies: ManualEvidenceFamilyReport[];
 }
@@ -155,40 +196,63 @@ interface ArtifactFamilyReport {
     | "release-readiness-snapshot"
     | "release-gate-summary"
     | "cocos-rc-bundle"
+    | "runtime-observability-evidence"
+    | "runtime-observability-gate"
     | "manual-evidence-ledger"
     | "wechat-release-evidence";
   label: string;
-  required: true;
+  severity: FindingSeverity;
+  required: boolean;
+  applicable: boolean;
   status: FamilyStatus;
   artifactPath?: string;
   revision?: string;
   candidate?: string;
   generatedAt?: string;
-  freshness: "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp" | "missing";
+  freshness: FreshnessStatus;
   findings: AuditFinding[];
 }
 
-interface SameCandidateEvidenceAuditReport {
-  schemaVersion: 3;
+interface CandidateEvidenceAuditReport {
+  schemaVersion: 4;
   generatedAt: string;
   candidate: {
     name: string;
     revision: string;
+    targetSurface: Exclude<TargetSurface, "auto"> | "auto";
   };
   summary: {
     status: AuditStatus;
+    blockerCount: number;
+    warningCount: number;
     findingCount: number;
     summary: string;
   };
   inputs: {
+    targetSurface: TargetSurface;
     snapshotPath?: string;
     releaseGateSummaryPath?: string;
     cocosRcBundlePath?: string;
+    runtimeObservabilityEvidencePath?: string;
+    runtimeObservabilityGatePath?: string;
     manualEvidenceLedgerPath?: string;
     wechatCandidateSummaryPath?: string;
   };
+  triage: {
+    blockers: AuditTriageEntry[];
+    warnings: AuditTriageEntry[];
+  };
   manualEvidenceContract: ManualEvidenceContractReport;
   artifactFamilies: ArtifactFamilyReport[];
+}
+
+interface ManualEvidenceSource {
+  label: string;
+  candidate?: string;
+  revision?: string;
+  observedAt?: string;
+  status?: string;
+  artifactPath?: string;
 }
 
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
@@ -228,9 +292,12 @@ function fail(message: string): never {
 function parseArgs(argv: string[]): Args {
   let candidate = "";
   let candidateRevision = "";
+  let targetSurface: TargetSurface = "auto";
   let snapshotPath: string | undefined;
   let releaseGateSummaryPath: string | undefined;
   let cocosRcBundlePath: string | undefined;
+  let runtimeObservabilityEvidencePath: string | undefined;
+  let runtimeObservabilityGatePath: string | undefined;
   let manualEvidenceLedgerPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let wechatCandidateSummaryPath: string | undefined;
@@ -252,6 +319,14 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--target-surface" && next) {
+      if (next !== "auto" && next !== "h5" && next !== "wechat") {
+        fail(`Unsupported --target-surface value: ${next}`);
+      }
+      targetSurface = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--snapshot" && next) {
       snapshotPath = next;
       index += 1;
@@ -264,6 +339,16 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--cocos-rc-bundle" && next) {
       cocosRcBundlePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--runtime-observability-evidence" && next) {
+      runtimeObservabilityEvidencePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--runtime-observability-gate" && next) {
+      runtimeObservabilityGatePath = next;
       index += 1;
       continue;
     }
@@ -315,9 +400,12 @@ function parseArgs(argv: string[]): Args {
   return {
     candidate,
     candidateRevision,
+    targetSurface,
     ...(snapshotPath ? { snapshotPath } : {}),
     ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
     ...(cocosRcBundlePath ? { cocosRcBundlePath } : {}),
+    ...(runtimeObservabilityEvidencePath ? { runtimeObservabilityEvidencePath } : {}),
+    ...(runtimeObservabilityGatePath ? { runtimeObservabilityGatePath } : {}),
     ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
@@ -428,6 +516,30 @@ function resolveCocosRcBundlePath(args: Args): string | undefined {
   );
 }
 
+function resolveRuntimeObservabilityEvidencePath(args: Args): string | undefined {
+  if (args.runtimeObservabilityEvidencePath) {
+    return path.resolve(args.runtimeObservabilityEvidencePath);
+  }
+  const candidateSlug = slugifyCandidate(args.candidate);
+  return resolveLatestFile(
+    DEFAULT_RELEASE_READINESS_DIR,
+    (entry) => entry.endsWith(".json") && entry.startsWith("runtime-observability-evidence-"),
+    (entry) => entry.includes(`runtime-observability-evidence-${candidateSlug}-`)
+  );
+}
+
+function resolveRuntimeObservabilityGatePath(args: Args): string | undefined {
+  if (args.runtimeObservabilityGatePath) {
+    return path.resolve(args.runtimeObservabilityGatePath);
+  }
+  const candidateSlug = slugifyCandidate(args.candidate);
+  return resolveLatestFile(
+    DEFAULT_RELEASE_READINESS_DIR,
+    (entry) => entry.endsWith(".json") && entry.startsWith("runtime-observability-gate-"),
+    (entry) => entry.includes(`runtime-observability-gate-${candidateSlug}-`)
+  );
+}
+
 function resolveManualEvidenceLedgerPath(args: Args): string | undefined {
   if (args.manualEvidenceLedgerPath) {
     return path.resolve(args.manualEvidenceLedgerPath);
@@ -449,7 +561,7 @@ function resolveWechatCandidateSummaryPath(args: Args): string | undefined {
   return fs.existsSync(direct) ? direct : undefined;
 }
 
-function evaluateFreshness(timestamp: string | undefined, maxAgeMs: number): ArtifactFamilyReport["freshness"] {
+function evaluateFreshness(timestamp: string | undefined, maxAgeMs: number): FreshnessStatus {
   if (!timestamp?.trim()) {
     return "missing_timestamp";
   }
@@ -505,10 +617,63 @@ function parseManualEvidenceOwnerLedger(filePath: string): ManualEvidenceOwnerLe
   };
 }
 
+function createFinding(
+  severity: FindingSeverity,
+  code: FindingCode,
+  summary: string,
+  artifactPath?: string
+): AuditFinding {
+  return {
+    severity,
+    code,
+    summary,
+    ...(artifactPath ? { artifactPath } : {})
+  };
+}
+
+function getStatusFromCounts(blockerCount: number, warningCount: number): AuditStatus {
+  if (blockerCount > 0) {
+    return "failed";
+  }
+  if (warningCount > 0) {
+    return "warning";
+  }
+  return "passed";
+}
+
+function getFamilyStatus(findings: AuditFinding[], severity: FindingSeverity): FamilyStatus {
+  if (findings.length === 0) {
+    return "passed";
+  }
+  return severity === "blocking" ? "failed" : "warning";
+}
+
+function compareLinkedArtifact(
+  selectedArtifactPath: string | undefined,
+  linkedArtifactPath: string | undefined,
+  label: string,
+  severity: FindingSeverity
+): AuditFinding | undefined {
+  if (!selectedArtifactPath || !linkedArtifactPath?.trim()) {
+    return undefined;
+  }
+  const selectedBase = path.basename(selectedArtifactPath);
+  const linkedBase = path.basename(linkedArtifactPath.trim());
+  if (selectedBase === linkedBase) {
+    return undefined;
+  }
+  return createFinding(
+    severity,
+    "linked_artifact_mismatch",
+    `${label} references ${linkedBase}, but the selected artifact is ${selectedBase}.`
+  );
+}
+
 function compareLinkedSnapshot(
   selectedSnapshotPath: string | undefined,
   linkedSnapshotPath: string | undefined,
-  label: string
+  label: string,
+  severity: FindingSeverity
 ): AuditFinding | undefined {
   if (!selectedSnapshotPath || !linkedSnapshotPath?.trim()) {
     return undefined;
@@ -518,44 +683,44 @@ function compareLinkedSnapshot(
   if (selectedBase === linkedBase) {
     return undefined;
   }
-  return {
-    code: "linked_snapshot_mismatch",
-    summary: `${label} references snapshot ${linkedBase}, but the selected readiness snapshot is ${selectedBase}.`
-  };
+  return createFinding(
+    severity,
+    "linked_snapshot_mismatch",
+    `${label} references snapshot ${linkedBase}, but the selected readiness snapshot is ${selectedBase}.`
+  );
 }
 
 function maybeAddFreshnessFinding(
   findings: AuditFinding[],
-  freshness: ArtifactFamilyReport["freshness"],
+  severity: FindingSeverity,
+  freshness: FreshnessStatus,
   label: string,
   timestamp: string | undefined,
   maxAgeMs: number,
   artifactPath?: string
 ): void {
   if (freshness === "stale") {
-    findings.push({
-      code: "stale",
-      summary: `${label} is older than the ${Math.round(maxAgeMs / (1000 * 60 * 60))}h freshness window.`,
-      ...(artifactPath ? { artifactPath } : {})
-    });
+    findings.push(
+      createFinding(
+        severity,
+        "stale",
+        `${label} is older than the ${Math.round(maxAgeMs / (1000 * 60 * 60))}h freshness window.`,
+        artifactPath
+      )
+    );
   } else if (freshness === "missing_timestamp") {
-    findings.push({
-      code: "missing_timestamp",
-      summary: `${label} is missing its generated timestamp.`,
-      ...(artifactPath ? { artifactPath } : {})
-    });
+    findings.push(createFinding(severity, "missing_timestamp", `${label} is missing its generated timestamp.`, artifactPath));
   } else if (freshness === "invalid_timestamp") {
-    findings.push({
-      code: "invalid_timestamp",
-      summary: `${label} has an invalid generated timestamp (${timestamp ?? "<missing>"}).`,
-      ...(artifactPath ? { artifactPath } : {})
-    });
+    findings.push(
+      createFinding(severity, "invalid_timestamp", `${label} has an invalid generated timestamp (${timestamp ?? "<missing>"}).`, artifactPath)
+    );
   }
 }
 
 function addCommonFindings(
   findings: AuditFinding[],
   input: {
+    severity: FindingSeverity;
     label: string;
     candidate: string | undefined;
     revision: string | undefined | null;
@@ -565,45 +730,58 @@ function addCommonFindings(
     maxAgeMs: number;
     artifactPath?: string;
   }
-): ArtifactFamilyReport["freshness"] {
+): FreshnessStatus {
   const freshness = evaluateFreshness(input.generatedAt, input.maxAgeMs);
 
   if (input.candidate?.trim() && input.candidate.trim() !== input.expectedCandidate) {
-    findings.push({
-      code: "candidate_mismatch",
-      summary: `${input.label} reports candidate ${input.candidate}, expected ${input.expectedCandidate}.`,
-      ...(input.artifactPath ? { artifactPath: input.artifactPath } : {})
-    });
+    findings.push(
+      createFinding(
+        input.severity,
+        "candidate_mismatch",
+        `${input.label} reports candidate ${input.candidate}, expected ${input.expectedCandidate}.`,
+        input.artifactPath
+      )
+    );
   }
   if (!revisionsMatch(input.revision, input.expectedRevision)) {
-    findings.push({
-      code: "revision_mismatch",
-      summary: `${input.label} reports revision ${input.revision ?? "<missing>"}, expected ${input.expectedRevision}.`,
-      ...(input.artifactPath ? { artifactPath: input.artifactPath } : {})
-    });
+    findings.push(
+      createFinding(
+        input.severity,
+        "revision_mismatch",
+        `${input.label} reports revision ${input.revision ?? "<missing>"}, expected ${input.expectedRevision}.`,
+        input.artifactPath
+      )
+    );
   }
 
-  maybeAddFreshnessFinding(findings, freshness, input.label, input.generatedAt, input.maxAgeMs, input.artifactPath);
+  maybeAddFreshnessFinding(findings, input.severity, freshness, input.label, input.generatedAt, input.maxAgeMs, input.artifactPath);
   return freshness;
 }
 
-function buildMissingFamily(id: ArtifactFamilyReport["id"], label: string): ArtifactFamilyReport {
+function buildMissingFamily(
+  id: ArtifactFamilyReport["id"],
+  label: string,
+  severity: FindingSeverity,
+  required: boolean,
+  applicable: boolean
+): ArtifactFamilyReport {
+  const findings = applicable ? [createFinding(severity, "missing", `${label} is missing.`)] : [];
   return {
     id,
     label,
-    required: true,
-    status: "failed",
-    freshness: "missing",
-    findings: [
-      {
-        code: "missing",
-        summary: `${label} is missing.`
-      }
-    ]
+    severity,
+    required,
+    applicable,
+    status: getFamilyStatus(findings, severity),
+    freshness: applicable ? "missing" : "fresh",
+    findings
   };
 }
 
-function isWechatEvidenceApplicable(ledger: ManualEvidenceOwnerLedger | undefined, wechatCandidateSummaryPath: string | undefined): boolean {
+function isWechatEvidenceApplicable(
+  ledger: ManualEvidenceOwnerLedger | undefined,
+  wechatCandidateSummaryPath: string | undefined
+): boolean {
   if (wechatCandidateSummaryPath && fs.existsSync(wechatCandidateSummaryPath)) {
     return true;
   }
@@ -614,6 +792,26 @@ function isWechatEvidenceApplicable(ledger: ManualEvidenceOwnerLedger | undefine
       }
       return (row.status ?? "").toLowerCase() !== "waived";
     }) ?? false
+  );
+}
+
+function isWechatSurfaceRequired(input: {
+  targetSurface: TargetSurface;
+  ledger: ManualEvidenceOwnerLedger | undefined;
+  wechatCandidateSummaryPath: string | undefined;
+  runtimeObservabilityEvidencePath: string | undefined;
+  runtimeObservabilityGatePath: string | undefined;
+}): boolean {
+  if (input.targetSurface === "wechat") {
+    return true;
+  }
+  if (input.targetSurface === "h5") {
+    return false;
+  }
+  return Boolean(
+    isWechatEvidenceApplicable(input.ledger, input.wechatCandidateSummaryPath) ||
+      input.runtimeObservabilityEvidencePath ||
+      input.runtimeObservabilityGatePath
   );
 }
 
@@ -632,15 +830,6 @@ function selectRelevantWechatBlockers(blockers: WechatCandidateSummary["blockers
   return prioritized && prioritized.length > 0 ? prioritized : blockers;
 }
 
-interface ManualEvidenceSource {
-  label: string;
-  candidate?: string;
-  revision?: string;
-  observedAt?: string;
-  status?: string;
-  artifactPath?: string;
-}
-
 function normalizeStatus(value: string | undefined): string {
   return value?.trim().toLowerCase() ?? "";
 }
@@ -649,40 +838,46 @@ function collectManualEvidenceFindings(
   sources: ManualEvidenceSource[],
   expectedCandidate: string,
   expectedRevision: string,
-  maxAgeMs: number
+  maxAgeMs: number,
+  severity: FindingSeverity
 ): AuditFinding[] {
   const findings: AuditFinding[] = [];
   for (const source of sources) {
     const status = normalizeStatus(source.status);
     if (source.candidate?.trim() && source.candidate.trim() !== expectedCandidate) {
-      findings.push({
-        code: "candidate_mismatch",
-        summary: `${source.label} reports candidate ${source.candidate}, expected ${expectedCandidate}.`,
-        ...(source.artifactPath ? { artifactPath: source.artifactPath } : {})
-      });
+      findings.push(
+        createFinding(
+          severity,
+          "candidate_mismatch",
+          `${source.label} reports candidate ${source.candidate}, expected ${expectedCandidate}.`,
+          source.artifactPath
+        )
+      );
     }
     if (!revisionsMatch(source.revision, expectedRevision)) {
-      findings.push({
-        code: "revision_mismatch",
-        summary: `${source.label} reports revision ${source.revision ?? "<missing>"}, expected ${expectedRevision}.`,
-        ...(source.artifactPath ? { artifactPath: source.artifactPath } : {})
-      });
+      findings.push(
+        createFinding(
+          severity,
+          "revision_mismatch",
+          `${source.label} reports revision ${source.revision ?? "<missing>"}, expected ${expectedRevision}.`,
+          source.artifactPath
+        )
+      );
     }
     if (LEDGER_PENDING_STATUSES.has(status) || status === "pending") {
-      findings.push({
-        code: "manual_pending",
-        summary: `${source.label} is still ${source.status ?? "pending"}.`,
-        ...(source.artifactPath ? { artifactPath: source.artifactPath } : {})
-      });
+      findings.push(createFinding(severity, "manual_pending", `${source.label} is still ${source.status ?? "pending"}.`, source.artifactPath));
     } else if (status === "failed" || status === "blocked") {
-      findings.push({
-        code: status === "blocked" ? "blocked" : "manual_failed",
-        summary: `${source.label} is ${source.status ?? "failed"}.`,
-        ...(source.artifactPath ? { artifactPath: source.artifactPath } : {})
-      });
+      findings.push(
+        createFinding(
+          severity,
+          status === "blocked" ? "blocked" : "manual_failed",
+          `${source.label} is ${source.status ?? "failed"}.`,
+          source.artifactPath
+        )
+      );
     }
     const freshness = evaluateFreshness(source.observedAt, maxAgeMs);
-    maybeAddFreshnessFinding(findings, freshness, source.label, source.observedAt, maxAgeMs, source.artifactPath);
+    maybeAddFreshnessFinding(findings, severity, freshness, source.label, source.observedAt, maxAgeMs, source.artifactPath);
   }
   return findings;
 }
@@ -690,6 +885,7 @@ function collectManualEvidenceFindings(
 function buildManualEvidenceFamilyReport(input: {
   id: ManualEvidenceFamilyId;
   label: string;
+  severity: FindingSeverity;
   applicable: boolean;
   sources: ManualEvidenceSource[];
   expectedCandidate: string;
@@ -701,7 +897,8 @@ function buildManualEvidenceFamilyReport(input: {
     return {
       id: input.id,
       label: input.label,
-      required: true,
+      severity: input.severity,
+      required: false,
       applicable: false,
       status: "passed",
       summary: `${input.label} is not required for this candidate.`,
@@ -711,34 +908,38 @@ function buildManualEvidenceFamilyReport(input: {
   }
 
   if (input.sources.length === 0) {
+    const findings = [createFinding(input.severity, "missing", `${input.label} is missing for candidate ${input.expectedRevision}.`)];
     return {
       id: input.id,
       label: input.label,
-      required: true,
+      severity: input.severity,
+      required: input.severity === "blocking",
       applicable: true,
-      status: "failed",
+      status: getFamilyStatus(findings, input.severity),
       summary: `${input.label} is missing for candidate ${input.expectedRevision}.`,
       artifactPaths,
-      findings: [
-        {
-          code: "missing",
-          summary: `${input.label} is missing for candidate ${input.expectedRevision}.`
-        }
-      ]
+      findings
     };
   }
 
-  const findings = collectManualEvidenceFindings(input.sources, input.expectedCandidate, input.expectedRevision, input.maxAgeMs);
+  const findings = collectManualEvidenceFindings(
+    input.sources,
+    input.expectedCandidate,
+    input.expectedRevision,
+    input.maxAgeMs,
+    input.severity
+  );
   return {
     id: input.id,
     label: input.label,
-    required: true,
+    severity: input.severity,
+    required: input.severity === "blocking",
     applicable: true,
-    status: findings.length === 0 ? "passed" : "failed",
+    status: getFamilyStatus(findings, input.severity),
     summary:
       findings.length === 0
         ? `${input.label} is current for candidate ${input.expectedRevision}.`
-        : `${input.label} blocks candidate ${input.expectedRevision}: ${findings[0]?.summary}`,
+        : `${input.label} ${input.severity === "blocking" ? "blocks" : "warns for"} candidate ${input.expectedRevision}: ${findings[0]?.summary}`,
     artifactPaths,
     findings
   };
@@ -748,6 +949,7 @@ function buildManualEvidenceContractReport(input: {
   candidate: string;
   expectedRevision: string;
   maxAgeMs: number;
+  wechatSurfaceRequired: boolean;
   ledger: ManualEvidenceOwnerLedger | undefined;
   wechatSummary: WechatCandidateSummary | undefined;
   wechatCandidateSummaryPath: string | undefined;
@@ -788,7 +990,7 @@ function buildManualEvidenceContractReport(input: {
       artifactPath: row.artifactPath
     }));
 
-  const wechatReleaseApplicable = isWechatEvidenceApplicable(input.ledger, input.wechatCandidateSummaryPath);
+  const wechatReleaseApplicable = input.wechatSurfaceRequired || isWechatEvidenceApplicable(input.ledger, input.wechatCandidateSummaryPath);
   const wechatReleaseSignoffSources: ManualEvidenceSource[] = [
     ...ledgerRows
       .filter((row) => WECHAT_RELEASE_SIGNOFF_LEDGER_EVIDENCE_TYPES.has(row.evidenceType))
@@ -832,7 +1034,8 @@ function buildManualEvidenceContractReport(input: {
     buildManualEvidenceFamilyReport({
       id: "runtime-observability",
       label: "Runtime observability review",
-      applicable: true,
+      severity: input.wechatSurfaceRequired ? "blocking" : "warning",
+      applicable: input.wechatSurfaceRequired || runtimeObservabilitySources.length > 0,
       sources: runtimeObservabilitySources,
       expectedCandidate: input.candidate,
       expectedRevision: input.expectedRevision,
@@ -841,6 +1044,7 @@ function buildManualEvidenceContractReport(input: {
     buildManualEvidenceFamilyReport({
       id: "cocos-rc-signoff",
       label: "Cocos RC sign-off",
+      severity: "blocking",
       applicable: true,
       sources: cocosRcSignoffSources,
       expectedCandidate: input.candidate,
@@ -850,6 +1054,7 @@ function buildManualEvidenceContractReport(input: {
     buildManualEvidenceFamilyReport({
       id: "wechat-release-signoff",
       label: "WeChat release sign-off",
+      severity: input.wechatSurfaceRequired ? "blocking" : "warning",
       applicable: wechatReleaseApplicable,
       sources: wechatReleaseSignoffSources,
       expectedCandidate: input.candidate,
@@ -859,6 +1064,7 @@ function buildManualEvidenceContractReport(input: {
     buildManualEvidenceFamilyReport({
       id: "reconnect-followup",
       label: "Reconnect or persistence follow-up",
+      severity: "warning",
       applicable: reconnectFollowupSources.length > 0,
       sources: reconnectFollowupSources,
       expectedCandidate: input.candidate,
@@ -867,40 +1073,94 @@ function buildManualEvidenceContractReport(input: {
     })
   ];
 
-  const failedFamilies = requiredFamilies.filter((family) => family.applicable && family.status === "failed");
+  const blockerCount = requiredFamilies.reduce(
+    (count, family) => count + family.findings.filter((finding) => finding.severity === "blocking").length,
+    0
+  );
+  const warningCount = requiredFamilies.reduce(
+    (count, family) => count + family.findings.filter((finding) => finding.severity === "warning").length,
+    0
+  );
+  const status = getStatusFromCounts(blockerCount, warningCount);
+  const leadFamily = requiredFamilies.find((family) => family.findings.length > 0);
   return {
-    status: failedFamilies.length === 0 ? "passed" : "failed",
+    status,
     summary:
-      failedFamilies.length === 0
+      status === "passed"
         ? `Required manual evidence families are current for ${input.candidate} at ${input.expectedRevision}.`
-        : `Required manual evidence family blocked: ${failedFamilies[0]?.summary}`,
+        : `${status === "failed" ? "Blocking" : "Advisory"} manual evidence family: ${leadFamily?.summary}`,
     requiredFamilies
   };
 }
 
-export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidateEvidenceAuditReport {
+function collectTriageEntries(
+  artifactFamilies: ArtifactFamilyReport[],
+  manualEvidenceFamilies: ManualEvidenceFamilyReport[]
+): { blockers: AuditTriageEntry[]; warnings: AuditTriageEntry[] } {
+  const entries: AuditTriageEntry[] = [
+    ...artifactFamilies.flatMap((family) =>
+      family.findings.map((finding) => ({
+        scope: "artifact-family" as const,
+        familyId: family.id,
+        familyLabel: family.label,
+        code: finding.code,
+        severity: finding.severity,
+        summary: finding.summary,
+        ...(finding.artifactPath ? { artifactPath: finding.artifactPath } : {})
+      }))
+    ),
+    ...manualEvidenceFamilies.flatMap((family) =>
+      family.findings.map((finding) => ({
+        scope: "manual-contract" as const,
+        familyId: family.id,
+        familyLabel: family.label,
+        code: finding.code,
+        severity: finding.severity,
+        summary: finding.summary,
+        ...(finding.artifactPath ? { artifactPath: finding.artifactPath } : {})
+      }))
+    )
+  ];
+  return {
+    blockers: entries.filter((entry) => entry.severity === "blocking"),
+    warnings: entries.filter((entry) => entry.severity === "warning")
+  };
+}
+
+export function buildSameCandidateEvidenceAuditReport(args: Args): CandidateEvidenceAuditReport {
   const snapshotPath = resolveSnapshotPath(args);
   const releaseGateSummaryPath = resolveReleaseGateSummaryPath(args);
   const cocosRcBundlePath = resolveCocosRcBundlePath(args);
+  const runtimeObservabilityEvidencePath = resolveRuntimeObservabilityEvidencePath(args);
+  const runtimeObservabilityGatePath = resolveRuntimeObservabilityGatePath(args);
   const manualEvidenceLedgerPath = resolveManualEvidenceLedgerPath(args);
   const wechatCandidateSummaryPath = resolveWechatCandidateSummaryPath(args);
   const expectedRevision = args.candidateRevision;
   const maxAgeMs = args.maxAgeHours * 60 * 60 * 1000;
 
-  const artifactFamilies: ArtifactFamilyReport[] = [];
   const parsedLedger =
     manualEvidenceLedgerPath && fs.existsSync(manualEvidenceLedgerPath) ? parseManualEvidenceOwnerLedger(manualEvidenceLedgerPath) : undefined;
   const parsedWechatSummary =
     wechatCandidateSummaryPath && fs.existsSync(wechatCandidateSummaryPath)
       ? readJsonFile<WechatCandidateSummary>(wechatCandidateSummaryPath)
       : undefined;
+  const wechatSurfaceRequired = isWechatSurfaceRequired({
+    targetSurface: args.targetSurface,
+    ledger: parsedLedger,
+    wechatCandidateSummaryPath,
+    runtimeObservabilityEvidencePath,
+    runtimeObservabilityGatePath
+  });
+
+  const artifactFamilies: ArtifactFamilyReport[] = [];
 
   if (!snapshotPath || !fs.existsSync(snapshotPath)) {
-    artifactFamilies.push(buildMissingFamily("release-readiness-snapshot", "Release readiness snapshot"));
+    artifactFamilies.push(buildMissingFamily("release-readiness-snapshot", "Release readiness snapshot", "blocking", true, true));
   } else {
     const snapshot = readJsonFile<ReleaseReadinessSnapshot>(snapshotPath);
     const findings: AuditFinding[] = [];
     const freshness = addCommonFindings(findings, {
+      severity: "blocking",
       label: "Release readiness snapshot",
       candidate: undefined,
       revision: snapshot.revision?.commit ?? snapshot.revision?.shortCommit,
@@ -913,8 +1173,10 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
     artifactFamilies.push({
       id: "release-readiness-snapshot",
       label: "Release readiness snapshot",
+      severity: "blocking",
       required: true,
-      status: findings.length === 0 ? "passed" : "failed",
+      applicable: true,
+      status: getFamilyStatus(findings, "blocking"),
       artifactPath: snapshotPath,
       revision: snapshot.revision?.commit ?? snapshot.revision?.shortCommit,
       generatedAt: snapshot.generatedAt,
@@ -924,11 +1186,12 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
   }
 
   if (!releaseGateSummaryPath || !fs.existsSync(releaseGateSummaryPath)) {
-    artifactFamilies.push(buildMissingFamily("release-gate-summary", "Release gate summary"));
+    artifactFamilies.push(buildMissingFamily("release-gate-summary", "Release gate summary", "blocking", true, true));
   } else {
     const report = readJsonFile<ReleaseGateSummaryReport>(releaseGateSummaryPath);
     const findings: AuditFinding[] = [];
     const freshness = addCommonFindings(findings, {
+      severity: "blocking",
       label: "Release gate summary",
       candidate: undefined,
       revision: report.revision?.commit ?? report.revision?.shortCommit,
@@ -938,15 +1201,17 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
       maxAgeMs,
       artifactPath: releaseGateSummaryPath
     });
-    const linkedSnapshotFinding = compareLinkedSnapshot(snapshotPath, report.inputs?.snapshotPath, "Release gate summary");
+    const linkedSnapshotFinding = compareLinkedSnapshot(snapshotPath, report.inputs?.snapshotPath, "Release gate summary", "blocking");
     if (linkedSnapshotFinding) {
       findings.push(linkedSnapshotFinding);
     }
     artifactFamilies.push({
       id: "release-gate-summary",
       label: "Release gate summary",
+      severity: "blocking",
       required: true,
-      status: findings.length === 0 ? "passed" : "failed",
+      applicable: true,
+      status: getFamilyStatus(findings, "blocking"),
       artifactPath: releaseGateSummaryPath,
       revision: report.revision?.commit ?? report.revision?.shortCommit,
       generatedAt: report.generatedAt,
@@ -956,11 +1221,12 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
   }
 
   if (!cocosRcBundlePath || !fs.existsSync(cocosRcBundlePath)) {
-    artifactFamilies.push(buildMissingFamily("cocos-rc-bundle", "Cocos RC bundle"));
+    artifactFamilies.push(buildMissingFamily("cocos-rc-bundle", "Cocos RC bundle", "blocking", true, true));
   } else {
     const bundle = readJsonFile<CocosRcBundleManifest>(cocosRcBundlePath);
     const findings: AuditFinding[] = [];
     const freshness = addCommonFindings(findings, {
+      severity: "blocking",
       label: "Cocos RC bundle",
       candidate: bundle.bundle?.candidate,
       revision: bundle.bundle?.commit ?? bundle.bundle?.shortCommit,
@@ -973,7 +1239,8 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
     const linkedSnapshotFinding = compareLinkedSnapshot(
       snapshotPath,
       bundle.linkedEvidence?.releaseReadinessSnapshot?.path,
-      "Cocos RC bundle"
+      "Cocos RC bundle",
+      "blocking"
     );
     if (linkedSnapshotFinding) {
       findings.push(linkedSnapshotFinding);
@@ -981,8 +1248,10 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
     artifactFamilies.push({
       id: "cocos-rc-bundle",
       label: "Cocos RC bundle",
+      severity: "blocking",
       required: true,
-      status: findings.length === 0 ? "passed" : "failed",
+      applicable: true,
+      status: getFamilyStatus(findings, "blocking"),
       artifactPath: cocosRcBundlePath,
       revision: bundle.bundle?.commit ?? bundle.bundle?.shortCommit,
       candidate: bundle.bundle?.candidate,
@@ -992,12 +1261,101 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
     });
   }
 
+  const runtimeSeverity: FindingSeverity = wechatSurfaceRequired ? "blocking" : "warning";
+  const runtimeApplicable = wechatSurfaceRequired || Boolean(runtimeObservabilityEvidencePath || runtimeObservabilityGatePath);
+
+  if (runtimeApplicable) {
+    if (!runtimeObservabilityEvidencePath || !fs.existsSync(runtimeObservabilityEvidencePath)) {
+      artifactFamilies.push(
+        buildMissingFamily(
+          "runtime-observability-evidence",
+          "Runtime observability evidence",
+          runtimeSeverity,
+          wechatSurfaceRequired,
+          true
+        )
+      );
+    } else {
+      const runtimeEvidence = readJsonFile<RuntimeObservabilityEvidenceReport>(runtimeObservabilityEvidencePath);
+      const findings: AuditFinding[] = [];
+      const freshness = addCommonFindings(findings, {
+        severity: runtimeSeverity,
+        label: "Runtime observability evidence",
+        candidate: runtimeEvidence.candidate?.name,
+        revision: runtimeEvidence.candidate?.revision ?? runtimeEvidence.candidate?.shortRevision,
+        generatedAt: runtimeEvidence.generatedAt,
+        expectedCandidate: args.candidate,
+        expectedRevision,
+        maxAgeMs,
+        artifactPath: runtimeObservabilityEvidencePath
+      });
+      artifactFamilies.push({
+        id: "runtime-observability-evidence",
+        label: "Runtime observability evidence",
+        severity: runtimeSeverity,
+        required: wechatSurfaceRequired,
+        applicable: true,
+        status: getFamilyStatus(findings, runtimeSeverity),
+        artifactPath: runtimeObservabilityEvidencePath,
+        revision: runtimeEvidence.candidate?.revision ?? runtimeEvidence.candidate?.shortRevision,
+        candidate: runtimeEvidence.candidate?.name,
+        generatedAt: runtimeEvidence.generatedAt,
+        freshness,
+        findings
+      });
+    }
+
+    if (!runtimeObservabilityGatePath || !fs.existsSync(runtimeObservabilityGatePath)) {
+      artifactFamilies.push(
+        buildMissingFamily("runtime-observability-gate", "Runtime observability gate", runtimeSeverity, wechatSurfaceRequired, true)
+      );
+    } else {
+      const runtimeGate = readJsonFile<RuntimeObservabilityGateReport>(runtimeObservabilityGatePath);
+      const findings: AuditFinding[] = [];
+      const freshness = addCommonFindings(findings, {
+        severity: runtimeSeverity,
+        label: "Runtime observability gate",
+        candidate: runtimeGate.candidate?.name,
+        revision: runtimeGate.candidate?.revision ?? runtimeGate.candidate?.shortRevision,
+        generatedAt: runtimeGate.generatedAt,
+        expectedCandidate: args.candidate,
+        expectedRevision,
+        maxAgeMs,
+        artifactPath: runtimeObservabilityGatePath
+      });
+      const linkedEvidenceFinding = compareLinkedArtifact(
+        runtimeObservabilityEvidencePath,
+        runtimeGate.evidenceSource?.artifactPath,
+        "Runtime observability gate",
+        runtimeSeverity
+      );
+      if (linkedEvidenceFinding) {
+        findings.push(linkedEvidenceFinding);
+      }
+      artifactFamilies.push({
+        id: "runtime-observability-gate",
+        label: "Runtime observability gate",
+        severity: runtimeSeverity,
+        required: wechatSurfaceRequired,
+        applicable: true,
+        status: getFamilyStatus(findings, runtimeSeverity),
+        artifactPath: runtimeObservabilityGatePath,
+        revision: runtimeGate.candidate?.revision ?? runtimeGate.candidate?.shortRevision,
+        candidate: runtimeGate.candidate?.name,
+        generatedAt: runtimeGate.generatedAt,
+        freshness,
+        findings
+      });
+    }
+  }
+
   if (!manualEvidenceLedgerPath || !fs.existsSync(manualEvidenceLedgerPath)) {
-    artifactFamilies.push(buildMissingFamily("manual-evidence-ledger", "Manual evidence owner ledger"));
+    artifactFamilies.push(buildMissingFamily("manual-evidence-ledger", "Manual evidence owner ledger", "blocking", true, true));
   } else {
     const ledger = parsedLedger ?? parseManualEvidenceOwnerLedger(manualEvidenceLedgerPath);
     const findings: AuditFinding[] = [];
     const freshness = addCommonFindings(findings, {
+      severity: "blocking",
       label: "Manual evidence owner ledger",
       candidate: ledger.metadata.candidate,
       revision: ledger.metadata.targetRevision,
@@ -1010,7 +1368,8 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
     const linkedSnapshotFinding = compareLinkedSnapshot(
       snapshotPath,
       ledger.metadata.linkedReadinessSnapshot,
-      "Manual evidence owner ledger"
+      "Manual evidence owner ledger",
+      "blocking"
     );
     if (linkedSnapshotFinding) {
       findings.push(linkedSnapshotFinding);
@@ -1020,15 +1379,19 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
         continue;
       }
       if (LEDGER_PENDING_STATUSES.has((row.status ?? "").toLowerCase())) {
-        findings.push({
-          code: "manual_pending",
-          summary: `Manual evidence ledger still lists ${row.evidenceType} as ${row.status}.`,
-          ...(row.artifactPath ? { artifactPath: row.artifactPath } : {})
-        });
+        findings.push(
+          createFinding(
+            "blocking",
+            "manual_pending",
+            `Manual evidence ledger still lists ${row.evidenceType} as ${row.status}.`,
+            row.artifactPath
+          )
+        );
       }
       const rowFreshness = evaluateFreshness(row.lastUpdated, maxAgeMs);
       maybeAddFreshnessFinding(
         findings,
+        "blocking",
         rowFreshness,
         `Manual evidence ledger row ${row.evidenceType}`,
         row.lastUpdated,
@@ -1039,8 +1402,10 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
     artifactFamilies.push({
       id: "manual-evidence-ledger",
       label: "Manual evidence owner ledger",
+      severity: "blocking",
       required: true,
-      status: findings.length === 0 ? "passed" : "failed",
+      applicable: true,
+      status: getFamilyStatus(findings, "blocking"),
       artifactPath: manualEvidenceLedgerPath,
       revision: ledger.metadata.targetRevision,
       candidate: ledger.metadata.candidate,
@@ -1050,13 +1415,18 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
     });
   }
 
-  if (isWechatEvidenceApplicable(parsedLedger, wechatCandidateSummaryPath)) {
+  const wechatSummaryApplicable = wechatSurfaceRequired || isWechatEvidenceApplicable(parsedLedger, wechatCandidateSummaryPath);
+  if (wechatSummaryApplicable) {
+    const wechatSeverity: FindingSeverity = wechatSurfaceRequired ? "blocking" : "warning";
     if (!wechatCandidateSummaryPath || !fs.existsSync(wechatCandidateSummaryPath)) {
-      artifactFamilies.push(buildMissingFamily("wechat-release-evidence", "WeChat release evidence summary"));
+      artifactFamilies.push(
+        buildMissingFamily("wechat-release-evidence", "WeChat release evidence summary", wechatSeverity, wechatSurfaceRequired, true)
+      );
     } else {
       const summary = parsedWechatSummary ?? readJsonFile<WechatCandidateSummary>(wechatCandidateSummaryPath);
       const findings: AuditFinding[] = [];
       const freshness = addCommonFindings(findings, {
+        severity: wechatSeverity,
         label: "WeChat release evidence summary",
         candidate: undefined,
         revision: summary.candidate?.revision,
@@ -1069,59 +1439,85 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
 
       const manualReview = summary.evidence?.manualReview;
       if ((manualReview?.requiredPendingChecks ?? 0) > 0) {
-        findings.push({
-          code: "manual_pending",
-          summary: `WeChat release evidence still has ${manualReview?.requiredPendingChecks} required manual review item(s) pending.`,
-          artifactPath: wechatCandidateSummaryPath
-        });
+        findings.push(
+          createFinding(
+            wechatSeverity,
+            "manual_pending",
+            `WeChat release evidence still has ${manualReview?.requiredPendingChecks} required manual review item(s) pending.`,
+            wechatCandidateSummaryPath
+          )
+        );
       }
       if ((manualReview?.requiredFailedChecks ?? 0) > 0) {
-        findings.push({
-          code: "manual_failed",
-          summary: `WeChat release evidence reports ${manualReview?.requiredFailedChecks} required manual review failure(s).`,
-          artifactPath: wechatCandidateSummaryPath
-        });
+        findings.push(
+          createFinding(
+            wechatSeverity,
+            "manual_failed",
+            `WeChat release evidence reports ${manualReview?.requiredFailedChecks} required manual review failure(s).`,
+            wechatCandidateSummaryPath
+          )
+        );
       }
       if ((manualReview?.requiredMetadataFailures ?? 0) > 0) {
-        findings.push({
-          code: "metadata_failure",
-          summary: `WeChat release evidence reports ${manualReview?.requiredMetadataFailures} manual review metadata failure(s).`,
-          artifactPath: wechatCandidateSummaryPath
-        });
+        findings.push(
+          createFinding(
+            wechatSeverity,
+            "metadata_failure",
+            `WeChat release evidence reports ${manualReview?.requiredMetadataFailures} manual review metadata failure(s).`,
+            wechatCandidateSummaryPath
+          )
+        );
       }
 
       const runtimeObservabilityCheck = findRuntimeObservabilityCheck(manualReview?.checks);
-      if (!runtimeObservabilityCheck) {
-        findings.push({
-          code: "missing",
-          summary: "WeChat release evidence is missing a runtime observability sign-off check.",
-          artifactPath: wechatCandidateSummaryPath
-        });
-      } else {
+      if (!runtimeObservabilityCheck && wechatSurfaceRequired) {
+        findings.push(
+          createFinding(
+            wechatSeverity,
+            "missing",
+            "WeChat release evidence is missing a runtime observability sign-off check.",
+            wechatCandidateSummaryPath
+          )
+        );
+      } else if (runtimeObservabilityCheck) {
         const runtimeArtifactPath = runtimeObservabilityCheck.artifactPath || wechatCandidateSummaryPath;
         if (runtimeObservabilityCheck.status === "pending") {
-          findings.push({
-            code: "manual_pending",
-            summary: `Runtime observability sign-off is still pending: ${runtimeObservabilityCheck.title ?? runtimeObservabilityCheck.id ?? "runtime observability"}.`,
-            artifactPath: runtimeArtifactPath
-          });
+          findings.push(
+            createFinding(
+              wechatSeverity,
+              "manual_pending",
+              `Runtime observability sign-off is still pending: ${
+                runtimeObservabilityCheck.title ?? runtimeObservabilityCheck.id ?? "runtime observability"
+              }.`,
+              runtimeArtifactPath
+            )
+          );
         } else if (runtimeObservabilityCheck.status === "failed") {
-          findings.push({
-            code: "manual_failed",
-            summary: `Runtime observability sign-off failed: ${runtimeObservabilityCheck.title ?? runtimeObservabilityCheck.id ?? "runtime observability"}.`,
-            artifactPath: runtimeArtifactPath
-          });
+          findings.push(
+            createFinding(
+              wechatSeverity,
+              "manual_failed",
+              `Runtime observability sign-off failed: ${
+                runtimeObservabilityCheck.title ?? runtimeObservabilityCheck.id ?? "runtime observability"
+              }.`,
+              runtimeArtifactPath
+            )
+          );
         }
         if (!revisionsMatch(runtimeObservabilityCheck.revision, expectedRevision)) {
-          findings.push({
-            code: "revision_mismatch",
-            summary: `Runtime observability sign-off reports revision ${runtimeObservabilityCheck.revision ?? "<missing>"}, expected ${expectedRevision}.`,
-            artifactPath: runtimeArtifactPath
-          });
+          findings.push(
+            createFinding(
+              wechatSeverity,
+              "revision_mismatch",
+              `Runtime observability sign-off reports revision ${runtimeObservabilityCheck.revision ?? "<missing>"}, expected ${expectedRevision}.`,
+              runtimeArtifactPath
+            )
+          );
         }
         const runtimeFreshness = evaluateFreshness(runtimeObservabilityCheck.recordedAt, maxAgeMs);
         maybeAddFreshnessFinding(
           findings,
+          wechatSeverity,
           runtimeFreshness,
           "Runtime observability sign-off",
           runtimeObservabilityCheck.recordedAt,
@@ -1132,19 +1528,24 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
 
       if (summary.candidate?.status === "blocked" && (summary.blockers?.length ?? 0) > 0) {
         for (const blocker of selectRelevantWechatBlockers(summary.blockers)?.slice(0, 3) ?? []) {
-          findings.push({
-            code: "blocked",
-            summary: `WeChat release evidence is blocked: ${blocker.summary ?? blocker.id ?? "unknown blocker"}.`,
-            artifactPath: blocker.artifactPath ?? wechatCandidateSummaryPath
-          });
+          findings.push(
+            createFinding(
+              wechatSeverity,
+              "blocked",
+              `WeChat release evidence is blocked: ${blocker.summary ?? blocker.id ?? "unknown blocker"}.`,
+              blocker.artifactPath ?? wechatCandidateSummaryPath
+            )
+          );
         }
       }
 
       artifactFamilies.push({
         id: "wechat-release-evidence",
         label: "WeChat release evidence summary",
-        required: true,
-        status: findings.length === 0 ? "passed" : "failed",
+        severity: wechatSeverity,
+        required: wechatSurfaceRequired,
+        applicable: true,
+        status: getFamilyStatus(findings, wechatSeverity),
         artifactPath: wechatCandidateSummaryPath,
         revision: summary.candidate?.revision ?? undefined,
         generatedAt: summary.generatedAt,
@@ -1158,53 +1559,76 @@ export function buildSameCandidateEvidenceAuditReport(args: Args): SameCandidate
     candidate: args.candidate,
     expectedRevision,
     maxAgeMs,
+    wechatSurfaceRequired,
     ledger: parsedLedger,
     wechatSummary: parsedWechatSummary,
     wechatCandidateSummaryPath
   });
-  const findings = artifactFamilies.flatMap((family) => family.findings);
-  const status: AuditStatus = findings.length === 0 && manualEvidenceContract.status === "passed" ? "passed" : "failed";
-  const leadSummary =
-    manualEvidenceContract.status === "failed"
-      ? manualEvidenceContract.summary
-      : findings[0]?.summary;
+  const triage = collectTriageEntries(artifactFamilies, manualEvidenceContract.requiredFamilies);
+  const status = getStatusFromCounts(triage.blockers.length, triage.warnings.length);
+  const leadFinding = triage.blockers[0] ?? triage.warnings[0];
 
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     generatedAt: new Date().toISOString(),
     candidate: {
       name: args.candidate,
-      revision: expectedRevision
+      revision: expectedRevision,
+      targetSurface: args.targetSurface
     },
     summary: {
       status,
-      findingCount: findings.length + manualEvidenceContract.requiredFamilies.reduce((count, family) => count + family.findings.length, 0),
+      blockerCount: triage.blockers.length,
+      warningCount: triage.warnings.length,
+      findingCount: triage.blockers.length + triage.warnings.length,
       summary:
         status === "passed"
-          ? `Same-candidate evidence is current for ${args.candidate} at ${expectedRevision}.`
-          : `Same-candidate evidence drift detected: ${leadSummary ?? findings[0]?.summary}`
+          ? `Candidate-level evidence is current for ${args.candidate} at ${expectedRevision}.`
+          : `${status === "failed" ? "Blocking" : "Advisory"} evidence audit finding: ${leadFinding?.summary}`
     },
     inputs: {
+      targetSurface: args.targetSurface,
       ...(snapshotPath ? { snapshotPath } : {}),
       ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
       ...(cocosRcBundlePath ? { cocosRcBundlePath } : {}),
+      ...(runtimeObservabilityEvidencePath ? { runtimeObservabilityEvidencePath } : {}),
+      ...(runtimeObservabilityGatePath ? { runtimeObservabilityGatePath } : {}),
       ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
       ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {})
     },
+    triage,
     manualEvidenceContract,
     artifactFamilies
   };
 }
 
-export function renderMarkdown(report: SameCandidateEvidenceAuditReport): string {
+export function renderMarkdown(report: CandidateEvidenceAuditReport): string {
   const lines: string[] = [];
-  lines.push("# Same-Candidate Evidence Audit");
+  lines.push("# Candidate-Level Evidence Audit");
   lines.push("");
   lines.push(`- Generated at: \`${report.generatedAt}\``);
   lines.push(`- Candidate: \`${report.candidate.name}\``);
   lines.push(`- Candidate revision: \`${report.candidate.revision}\``);
+  lines.push(`- Target surface: \`${report.inputs.targetSurface}\``);
   lines.push(`- Overall status: **${report.summary.status.toUpperCase()}**`);
+  lines.push(`- Blocking findings: ${report.summary.blockerCount}`);
+  lines.push(`- Advisory warnings: ${report.summary.warningCount}`);
   lines.push(`- Summary: ${report.summary.summary}`);
+  lines.push("");
+  lines.push("## Review Triage");
+  lines.push("");
+  lines.push(report.triage.blockers.length === 0 ? "- Blocking findings: none." : "- Blocking findings:");
+  for (const entry of report.triage.blockers) {
+    lines.push(
+      `  - [${entry.familyLabel}] \`${entry.code}\` ${entry.summary}${entry.artifactPath ? ` (artifact: \`${toRelativePath(entry.artifactPath)}\`)` : ""}`
+    );
+  }
+  lines.push(report.triage.warnings.length === 0 ? "- Advisory warnings: none." : "- Advisory warnings:");
+  for (const entry of report.triage.warnings) {
+    lines.push(
+      `  - [${entry.familyLabel}] \`${entry.code}\` ${entry.summary}${entry.artifactPath ? ` (artifact: \`${toRelativePath(entry.artifactPath)}\`)` : ""}`
+    );
+  }
   lines.push("");
   lines.push("## Manual Evidence Contract");
   lines.push("");
@@ -1216,16 +1640,19 @@ export function renderMarkdown(report: SameCandidateEvidenceAuditReport): string
     lines.push("");
     lines.push(`- Required: \`${family.required ? "yes" : "no"}\``);
     lines.push(`- Applicable: \`${family.applicable ? "yes" : "no"}\``);
+    lines.push(`- Severity: \`${family.severity}\``);
     lines.push(`- Status: **${family.status.toUpperCase()}**`);
     lines.push(`- Summary: ${family.summary}`);
-    lines.push(`- Artifacts: ${family.artifactPaths.length > 0 ? family.artifactPaths.map((artifactPath) => `\`${toRelativePath(artifactPath)}\``).join(", ") : "<none>"}`);
+    lines.push(
+      `- Artifacts: ${family.artifactPaths.length > 0 ? family.artifactPaths.map((artifactPath) => `\`${toRelativePath(artifactPath)}\``).join(", ") : "<none>"}`
+    );
     if (family.findings.length === 0) {
       lines.push("- Findings: none.");
     } else {
       lines.push("- Findings:");
       for (const finding of family.findings) {
         lines.push(
-          `  - \`${finding.code}\` ${finding.summary}${finding.artifactPath ? ` (artifact: \`${toRelativePath(finding.artifactPath)}\`)` : ""}`
+          `  - [${finding.severity}] \`${finding.code}\` ${finding.summary}${finding.artifactPath ? ` (artifact: \`${toRelativePath(finding.artifactPath)}\`)` : ""}`
         );
       }
     }
@@ -1236,6 +1663,12 @@ export function renderMarkdown(report: SameCandidateEvidenceAuditReport): string
   lines.push(`- Release readiness snapshot: \`${report.inputs.snapshotPath ? toRelativePath(report.inputs.snapshotPath) : "<missing>"}\``);
   lines.push(`- Release gate summary: \`${report.inputs.releaseGateSummaryPath ? toRelativePath(report.inputs.releaseGateSummaryPath) : "<missing>"}\``);
   lines.push(`- Cocos RC bundle: \`${report.inputs.cocosRcBundlePath ? toRelativePath(report.inputs.cocosRcBundlePath) : "<missing>"}\``);
+  lines.push(
+    `- Runtime observability evidence: \`${report.inputs.runtimeObservabilityEvidencePath ? toRelativePath(report.inputs.runtimeObservabilityEvidencePath) : "<not-selected>"}\``
+  );
+  lines.push(
+    `- Runtime observability gate: \`${report.inputs.runtimeObservabilityGatePath ? toRelativePath(report.inputs.runtimeObservabilityGatePath) : "<not-selected>"}\``
+  );
   lines.push(`- Manual evidence owner ledger: \`${report.inputs.manualEvidenceLedgerPath ? toRelativePath(report.inputs.manualEvidenceLedgerPath) : "<missing>"}\``);
   lines.push(
     `- WeChat release evidence summary: \`${report.inputs.wechatCandidateSummaryPath ? toRelativePath(report.inputs.wechatCandidateSummaryPath) : "<not-applicable>"}\``
@@ -1247,6 +1680,9 @@ export function renderMarkdown(report: SameCandidateEvidenceAuditReport): string
   for (const family of report.artifactFamilies) {
     lines.push(`### ${family.label}`);
     lines.push("");
+    lines.push(`- Required: \`${family.required ? "yes" : "no"}\``);
+    lines.push(`- Applicable: \`${family.applicable ? "yes" : "no"}\``);
+    lines.push(`- Severity: \`${family.severity}\``);
     lines.push(`- Status: **${family.status.toUpperCase()}**`);
     lines.push(`- Artifact: \`${family.artifactPath ? toRelativePath(family.artifactPath) : "<missing>"}\``);
     lines.push(`- Revision: \`${family.revision ?? "<missing>"}\``);
@@ -1259,7 +1695,7 @@ export function renderMarkdown(report: SameCandidateEvidenceAuditReport): string
       lines.push("- Findings:");
       for (const finding of family.findings) {
         lines.push(
-          `  - \`${finding.code}\` ${finding.summary}${finding.artifactPath ? ` (artifact: \`${finding.artifactPath}\`)` : ""}`
+          `  - [${finding.severity}] \`${finding.code}\` ${finding.summary}${finding.artifactPath ? ` (artifact: \`${toRelativePath(finding.artifactPath)}\`)` : ""}`
         );
       }
     }
@@ -1275,7 +1711,7 @@ function defaultOutputPath(args: Args): string {
   }
   return path.resolve(
     DEFAULT_RELEASE_READINESS_DIR,
-    `same-candidate-evidence-audit-${slugifyCandidate(args.candidate)}-${args.candidateRevision.slice(0, 12)}.json`
+    `candidate-evidence-audit-${slugifyCandidate(args.candidate)}-${args.candidateRevision.slice(0, 12)}.json`
   );
 }
 
@@ -1285,7 +1721,7 @@ function defaultMarkdownOutputPath(args: Args): string {
   }
   return path.resolve(
     DEFAULT_RELEASE_READINESS_DIR,
-    `same-candidate-evidence-audit-${slugifyCandidate(args.candidate)}-${args.candidateRevision.slice(0, 12)}.md`
+    `candidate-evidence-audit-${slugifyCandidate(args.candidate)}-${args.candidateRevision.slice(0, 12)}.md`
   );
 }
 
@@ -1298,8 +1734,8 @@ function main(): void {
   writeJsonFile(outputPath, report);
   writeFile(markdownOutputPath, renderMarkdown(report));
 
-  console.log(`Wrote same-candidate evidence audit JSON: ${toRelativePath(outputPath)}`);
-  console.log(`Wrote same-candidate evidence audit Markdown: ${toRelativePath(markdownOutputPath)}`);
+  console.log(`Wrote candidate evidence audit JSON: ${toRelativePath(outputPath)}`);
+  console.log(`Wrote candidate evidence audit Markdown: ${toRelativePath(markdownOutputPath)}`);
 
   if (report.summary.status === "failed") {
     process.exitCode = 1;

--- a/scripts/test/release-readiness-dashboard.test.ts
+++ b/scripts/test/release-readiness-dashboard.test.ts
@@ -154,8 +154,6 @@ test("release-readiness dashboard keeps stale and partial mixed-surface evidence
   );
 
   assert.equal(result.status, 1);
-  assert.match(result.stdout, /Overall status: fail/);
-  assert.match(result.stdout, /Go\/No-Go decision: blocked/);
 
   const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
     overallStatus: string;
@@ -205,7 +203,7 @@ test("release-readiness dashboard keeps stale and partial mixed-surface evidence
   assert.match(markdown, /## Blocker Drill-Down/);
   assert.match(markdown, /## Server health[\s\S]*- Evidence: unavailable\./);
   assert.match(markdown, /## Auth readiness[\s\S]*- Evidence: unavailable\./);
-  assert.match(markdown, /## Same-candidate evidence[\s\S]*Same-candidate evidence audit not selected/);
+  assert.match(markdown, /## Same-candidate evidence[\s\S]*Candidate-level evidence audit not selected/);
   assert.match(markdown, /WeChat package metadata missing\./);
   assert.match(markdown, /Primary-client diagnostic snapshots: FAIL \(/);
   assert.match(markdown, /Cocos RC snapshot: FAIL @ 2026-03-30T00:10:00.000Z/);

--- a/scripts/test/same-candidate-evidence-audit.test.ts
+++ b/scripts/test/same-candidate-evidence-audit.test.ts
@@ -80,25 +80,25 @@ function runAudit(args: string[], cwd: string): { stdout: string; status: number
   }
 }
 
-test("same-candidate evidence audit passes when artifact families align to the same candidate revision", () => {
+test("same-candidate evidence audit passes when required artifact families align to the same candidate revision", () => {
   const workspace = createTempWorkspace();
   const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
   const candidate = "phase1-rc";
   const revision = "abc1234";
-  const snapshotPath = path.join(artifactsDir, "release-readiness-2026-04-02T08-30-00.000Z.json");
+  const snapshotPath = path.join(artifactsDir, "release-readiness-2026-04-05T08-30-00.000Z.json");
   const gateSummaryPath = path.join(artifactsDir, `release-gate-summary-${revision}.json`);
   const bundlePath = path.join(artifactsDir, `cocos-rc-evidence-bundle-${candidate}-${revision}.json`);
   const ledgerPath = path.join(artifactsDir, `manual-release-evidence-owner-ledger-${candidate}-${revision}.md`);
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-04-02T08:30:00.000Z",
+    generatedAt: "2026-04-05T08:30:00.000Z",
     revision: {
       commit: revision,
       shortCommit: revision
     }
   });
   writeJson(gateSummaryPath, {
-    generatedAt: "2026-04-02T08:35:00.000Z",
+    generatedAt: "2026-04-05T08:35:00.000Z",
     revision: {
       commit: revision,
       shortCommit: revision
@@ -109,7 +109,7 @@ test("same-candidate evidence audit passes when artifact families align to the s
   });
   writeJson(bundlePath, {
     bundle: {
-      generatedAt: "2026-04-02T08:40:00.000Z",
+      generatedAt: "2026-04-05T08:40:00.000Z",
       candidate,
       commit: revision,
       shortCommit: revision
@@ -123,7 +123,7 @@ test("same-candidate evidence audit passes when artifact families align to the s
   writeLedger(ledgerPath, {
     candidate,
     targetRevision: revision,
-    lastUpdated: "2026-04-02T08:42:00.000Z",
+    lastUpdated: "2026-04-05T08:42:00.000Z",
     linkedReadinessSnapshot: snapshotPath,
     rows: [
       {
@@ -132,7 +132,7 @@ test("same-candidate evidence audit passes when artifact families align to the s
         revision,
         owner: "oncall-ops",
         status: "done",
-        lastUpdated: "2026-04-02T08:41:00.000Z",
+        lastUpdated: "2026-04-05T08:41:00.000Z",
         artifactPath: path.join(artifactsDir, `runtime-observability-signoff-${revision}.md`),
         notes: "Release runtime endpoints reviewed for this candidate."
       },
@@ -142,7 +142,7 @@ test("same-candidate evidence audit passes when artifact families align to the s
         revision,
         owner: "release-owner",
         status: "done",
-        lastUpdated: "2026-04-02T08:42:00.000Z",
+        lastUpdated: "2026-04-05T08:42:00.000Z",
         artifactPath: path.join(artifactsDir, `cocos-rc-checklist-${revision}.md`),
         notes: "Checklist reviewed for this candidate."
       }
@@ -175,7 +175,7 @@ test("same-candidate evidence audit passes when artifact families align to the s
 
   assert.equal(result.status, 0);
   const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
-    summary: { status: string; findingCount: number };
+    summary: { status: string; findingCount: number; blockerCount: number; warningCount: number };
     manualEvidenceContract: {
       status: string;
       requiredFamilies: Array<{ id: string; status: string; applicable: boolean; findings: unknown[] }>;
@@ -184,11 +184,13 @@ test("same-candidate evidence audit passes when artifact families align to the s
   };
   assert.equal(report.summary.status, "passed");
   assert.equal(report.summary.findingCount, 0);
+  assert.equal(report.summary.blockerCount, 0);
+  assert.equal(report.summary.warningCount, 0);
   assert.equal(report.manualEvidenceContract.status, "passed");
   assert.equal(report.manualEvidenceContract.requiredFamilies.every((family) => !family.applicable || family.status === "passed"), true);
   assert.equal(report.artifactFamilies.every((family) => family.status === "passed"), true);
   assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /Overall status: \*\*PASSED\*\*/);
-  assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /## Manual Evidence Contract/);
+  assert.match(fs.readFileSync(markdownOutputPath, "utf8"), /## Review Triage/);
 });
 
 test("same-candidate evidence audit reports missing, stale, and revision mismatch findings in one summary", () => {
@@ -196,7 +198,7 @@ test("same-candidate evidence audit reports missing, stale, and revision mismatc
   const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
   const candidate = "phase1-rc";
   const revision = "abc1234";
-  const snapshotPath = path.join(artifactsDir, "release-readiness-2026-04-02T08-30-00.000Z.json");
+  const snapshotPath = path.join(artifactsDir, "release-readiness-2026-04-05T08-30-00.000Z.json");
   const gateSummaryPath = path.join(artifactsDir, `release-gate-summary-${revision}.json`);
   const bundlePath = path.join(artifactsDir, `cocos-rc-evidence-bundle-${candidate}-${revision}.json`);
   const ledgerPath = path.join(artifactsDir, `manual-release-evidence-owner-ledger-${candidate}-${revision}.md`);
@@ -209,7 +211,7 @@ test("same-candidate evidence audit reports missing, stale, and revision mismatc
     }
   });
   writeJson(gateSummaryPath, {
-    generatedAt: "2026-04-02T08:35:00.000Z",
+    generatedAt: "2026-04-05T08:35:00.000Z",
     revision: {
       commit: "deadbeef",
       shortCommit: "deadbeef"
@@ -221,7 +223,7 @@ test("same-candidate evidence audit reports missing, stale, and revision mismatc
   writeLedger(ledgerPath, {
     candidate,
     targetRevision: revision,
-    lastUpdated: "2026-04-02T08:42:00.000Z",
+    lastUpdated: "2026-04-05T08:42:00.000Z",
     linkedReadinessSnapshot: snapshotPath,
     rows: [
       {
@@ -230,7 +232,7 @@ test("same-candidate evidence audit reports missing, stale, and revision mismatc
         revision,
         owner: "oncall-ops",
         status: "done",
-        lastUpdated: "2026-04-02T08:41:00.000Z",
+        lastUpdated: "2026-04-05T08:41:00.000Z",
         artifactPath: path.join(artifactsDir, `runtime-observability-signoff-${revision}.md`),
         notes: "Release runtime endpoints reviewed for this candidate."
       }
@@ -262,7 +264,7 @@ test("same-candidate evidence audit reports missing, stale, and revision mismatc
 
   assert.equal(result.status, 1);
   const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
-    summary: { status: string };
+    summary: { status: string; blockerCount: number; warningCount: number };
     manualEvidenceContract: {
       status: string;
       requiredFamilies: Array<{ id: string; findings: Array<{ code: string }> }>;
@@ -270,6 +272,8 @@ test("same-candidate evidence audit reports missing, stale, and revision mismatc
     artifactFamilies: Array<{ id: string; findings: Array<{ code: string }> }>;
   };
   assert.equal(report.summary.status, "failed");
+  assert.equal(report.summary.blockerCount > 0, true);
+  assert.equal(report.summary.warningCount, 0);
   assert.equal(report.manualEvidenceContract.status, "failed");
   const snapshotFamily = report.artifactFamilies.find((family) => family.id === "release-readiness-snapshot");
   const gateSummaryFamily = report.artifactFamilies.find((family) => family.id === "release-gate-summary");
@@ -287,22 +291,24 @@ test("same-candidate evidence audit flags stale runtime sign-off, blocked WeChat
   const wechatArtifactsDir = path.join(workspace, "artifacts", "wechat-release");
   const candidate = "phase1-rc";
   const revision = "abc1234";
-  const snapshotPath = path.join(releaseReadinessDir, "release-readiness-2026-04-02T08-30-00.000Z.json");
+  const snapshotPath = path.join(releaseReadinessDir, "release-readiness-2026-04-05T08-30-00.000Z.json");
   const gateSummaryPath = path.join(releaseReadinessDir, `release-gate-summary-${revision}.json`);
   const bundlePath = path.join(releaseReadinessDir, `cocos-rc-evidence-bundle-${candidate}-${revision}.json`);
   const ledgerPath = path.join(releaseReadinessDir, `manual-release-evidence-owner-ledger-${candidate}-${revision}.md`);
   const wechatSummaryPath = path.join(wechatArtifactsDir, "codex.wechat.release-candidate-summary.json");
+  const runtimeEvidencePath = path.join(releaseReadinessDir, `runtime-observability-evidence-${candidate}-${revision}.json`);
+  const runtimeGatePath = path.join(releaseReadinessDir, `runtime-observability-gate-${candidate}-${revision}.json`);
   const runtimeSignoffPath = path.join(wechatArtifactsDir, `runtime-observability-signoff-${candidate}-${revision}.md`);
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-04-02T08:30:00.000Z",
+    generatedAt: "2026-04-05T08:30:00.000Z",
     revision: {
       commit: revision,
       shortCommit: revision
     }
   });
   writeJson(gateSummaryPath, {
-    generatedAt: "2026-04-02T08:35:00.000Z",
+    generatedAt: "2026-04-05T08:35:00.000Z",
     revision: {
       commit: revision,
       shortCommit: revision
@@ -313,7 +319,7 @@ test("same-candidate evidence audit flags stale runtime sign-off, blocked WeChat
   });
   writeJson(bundlePath, {
     bundle: {
-      generatedAt: "2026-04-02T08:40:00.000Z",
+      generatedAt: "2026-04-05T08:40:00.000Z",
       candidate,
       commit: revision,
       shortCommit: revision
@@ -324,10 +330,31 @@ test("same-candidate evidence audit flags stale runtime sign-off, blocked WeChat
       }
     }
   });
+  writeJson(runtimeEvidencePath, {
+    generatedAt: "2026-04-05T08:44:00.000Z",
+    candidate: {
+      name: candidate,
+      revision,
+      shortRevision: revision,
+      targetSurface: "wechat"
+    }
+  });
+  writeJson(runtimeGatePath, {
+    generatedAt: "2026-04-05T08:45:00.000Z",
+    candidate: {
+      name: candidate,
+      revision,
+      shortRevision: revision,
+      targetSurface: "wechat"
+    },
+    evidenceSource: {
+      artifactPath: runtimeEvidencePath
+    }
+  });
   writeLedger(ledgerPath, {
     candidate,
     targetRevision: revision,
-    lastUpdated: "2026-04-02T08:42:00.000Z",
+    lastUpdated: "2026-04-05T08:42:00.000Z",
     linkedReadinessSnapshot: snapshotPath,
     rows: [
       {
@@ -336,14 +363,14 @@ test("same-candidate evidence audit flags stale runtime sign-off, blocked WeChat
         revision,
         owner: "oncall-ops",
         status: "pending",
-        lastUpdated: "2026-04-02T08:41:00.000Z",
+        lastUpdated: "2026-04-05T08:41:00.000Z",
         artifactPath: runtimeSignoffPath,
         notes: "Still waiting on release-environment captures."
       }
     ]
   });
   writeJson(wechatSummaryPath, {
-    generatedAt: "2026-04-02T08:45:00.000Z",
+    generatedAt: "2026-04-05T08:45:00.000Z",
     candidate: {
       revision,
       status: "blocked"
@@ -388,12 +415,18 @@ test("same-candidate evidence audit flags stale runtime sign-off, blocked WeChat
       candidate,
       "--candidate-revision",
       revision,
+      "--target-surface",
+      "wechat",
       "--snapshot",
       snapshotPath,
       "--release-gate-summary",
       gateSummaryPath,
       "--cocos-rc-bundle",
       bundlePath,
+      "--runtime-observability-evidence",
+      runtimeEvidencePath,
+      "--runtime-observability-gate",
+      runtimeGatePath,
       "--manual-evidence-ledger",
       ledgerPath,
       "--wechat-artifacts-dir",
@@ -410,7 +443,11 @@ test("same-candidate evidence audit flags stale runtime sign-off, blocked WeChat
 
   assert.equal(result.status, 1);
   const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
-    summary: { status: string };
+    summary: { status: string; blockerCount: number; warningCount: number };
+    triage: {
+      blockers: Array<{ familyId: string; code: string }>;
+      warnings: Array<{ familyId: string; code: string }>;
+    };
     manualEvidenceContract: {
       status: string;
       requiredFamilies: Array<{ id: string; findings: Array<{ code: string; artifactPath?: string }>; summary: string }>;
@@ -418,6 +455,8 @@ test("same-candidate evidence audit flags stale runtime sign-off, blocked WeChat
     artifactFamilies: Array<{ id: string; findings: Array<{ code: string; artifactPath?: string }> }>;
   };
   assert.equal(report.summary.status, "failed");
+  assert.equal(report.summary.blockerCount > 0, true);
+  assert.equal(report.summary.warningCount, 0);
   assert.equal(report.manualEvidenceContract.status, "failed");
 
   const ledgerFamily = report.artifactFamilies.find((family) => family.id === "manual-evidence-ledger");
@@ -429,11 +468,161 @@ test("same-candidate evidence audit flags stale runtime sign-off, blocked WeChat
   assert.deepEqual(wechatFamily?.findings.map((finding) => finding.code), ["manual_pending", "manual_pending", "stale", "blocked"]);
   assert.equal(wechatFamily?.findings[1]?.artifactPath, runtimeSignoffPath);
   assert.deepEqual(runtimeContractFamily?.findings.map((finding) => finding.code), ["manual_pending", "manual_pending", "stale"]);
-  assert.match(wechatContractFamily?.summary ?? "", /missing for candidate/);
+  assert.match(wechatContractFamily?.summary ?? "", /missing for candidate|warns for candidate|blocks candidate/);
+  assert.equal(report.triage.warnings.length, 0);
+  assert.equal(report.triage.blockers.some((entry) => entry.familyId === "wechat-release-evidence" && entry.code === "blocked"), true);
 
   const markdown = fs.readFileSync(markdownOutputPath, "utf8");
   assert.match(markdown, /Manual Evidence Contract/);
   assert.match(markdown, /WeChat release evidence summary/);
   assert.match(markdown, /Runtime observability sign-off is still pending/);
   assert.match(markdown, /Smoke report is stale for this candidate/);
+});
+
+test("same-candidate evidence audit treats runtime evidence as advisory for h5 review", () => {
+  const workspace = createTempWorkspace();
+  const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
+  const candidate = "phase1-rc";
+  const revision = "abc1234";
+  const snapshotPath = path.join(artifactsDir, "release-readiness-2026-04-05T08-30-00.000Z.json");
+  const gateSummaryPath = path.join(artifactsDir, `release-gate-summary-${revision}.json`);
+  const bundlePath = path.join(artifactsDir, `cocos-rc-evidence-bundle-${candidate}-${revision}.json`);
+  const ledgerPath = path.join(artifactsDir, `manual-release-evidence-owner-ledger-${candidate}-${revision}.md`);
+  const runtimeEvidencePath = path.join(artifactsDir, `runtime-observability-evidence-${candidate}-${revision}.json`);
+  const runtimeGatePath = path.join(artifactsDir, `runtime-observability-gate-${candidate}-${revision}.json`);
+
+  writeJson(snapshotPath, {
+    generatedAt: "2026-04-05T08:30:00.000Z",
+    revision: {
+      commit: revision,
+      shortCommit: revision
+    }
+  });
+  writeJson(gateSummaryPath, {
+    generatedAt: "2026-04-05T08:35:00.000Z",
+    revision: {
+      commit: revision,
+      shortCommit: revision
+    },
+    inputs: {
+      snapshotPath
+    }
+  });
+  writeJson(bundlePath, {
+    bundle: {
+      generatedAt: "2026-04-05T08:40:00.000Z",
+      candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    linkedEvidence: {
+      releaseReadinessSnapshot: {
+        path: snapshotPath
+      }
+    }
+  });
+  writeLedger(ledgerPath, {
+    candidate,
+    targetRevision: revision,
+    lastUpdated: "2026-04-05T08:42:00.000Z",
+    linkedReadinessSnapshot: snapshotPath,
+    rows: [
+      {
+        evidenceType: "cocos-rc-checklist-review",
+        candidate,
+        revision,
+        owner: "release-owner",
+        status: "done",
+        lastUpdated: "2026-04-05T08:42:00.000Z",
+        artifactPath: path.join(artifactsDir, `cocos-rc-checklist-${revision}.md`),
+        notes: "Checklist reviewed for this candidate."
+      }
+    ]
+  });
+  writeJson(runtimeEvidencePath, {
+    generatedAt: "2026-03-20T08:44:00.000Z",
+    candidate: {
+      name: candidate,
+      revision,
+      shortRevision: revision,
+      targetSurface: "h5"
+    }
+  });
+  writeJson(runtimeGatePath, {
+    generatedAt: "2026-03-20T08:45:00.000Z",
+    candidate: {
+      name: candidate,
+      revision: "deadbeef",
+      shortRevision: "deadbeef",
+      targetSurface: "h5"
+    },
+    evidenceSource: {
+      artifactPath: path.join(artifactsDir, "runtime-observability-evidence-other.json")
+    }
+  });
+
+  const outputPath = path.join(workspace, "same-candidate-evidence-audit.json");
+  const markdownOutputPath = path.join(workspace, "same-candidate-evidence-audit.md");
+  const result = runAudit(
+    [
+      "--candidate",
+      candidate,
+      "--candidate-revision",
+      revision,
+      "--target-surface",
+      "h5",
+      "--snapshot",
+      snapshotPath,
+      "--release-gate-summary",
+      gateSummaryPath,
+      "--cocos-rc-bundle",
+      bundlePath,
+      "--runtime-observability-evidence",
+      runtimeEvidencePath,
+      "--runtime-observability-gate",
+      runtimeGatePath,
+      "--manual-evidence-ledger",
+      ledgerPath,
+      "--output",
+      outputPath,
+      "--markdown-output",
+      markdownOutputPath,
+      "--max-age-hours",
+      "72"
+    ],
+    REPO_ROOT
+  );
+
+  assert.equal(result.status, 0);
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    summary: { status: string; blockerCount: number; warningCount: number };
+    triage: {
+      blockers: Array<{ familyId: string; code: string }>;
+      warnings: Array<{ familyId: string; code: string }>;
+    };
+    artifactFamilies: Array<{ id: string; status: string; findings: Array<{ code: string }> }>;
+  };
+
+  assert.equal(report.summary.status, "warning");
+  assert.equal(report.summary.blockerCount, 0);
+  assert.equal(report.summary.warningCount, 4);
+  assert.equal(report.triage.blockers.length, 0);
+  assert.deepEqual(
+    report.triage.warnings.map((entry) => `${entry.familyId}:${entry.code}`),
+    [
+      "runtime-observability-evidence:stale",
+      "runtime-observability-gate:revision_mismatch",
+      "runtime-observability-gate:stale",
+      "runtime-observability-gate:linked_artifact_mismatch"
+    ]
+  );
+
+  const runtimeEvidenceFamily = report.artifactFamilies.find((family) => family.id === "runtime-observability-evidence");
+  const runtimeGateFamily = report.artifactFamilies.find((family) => family.id === "runtime-observability-gate");
+  assert.equal(runtimeEvidenceFamily?.status, "warning");
+  assert.equal(runtimeGateFamily?.status, "warning");
+
+  const markdown = fs.readFileSync(markdownOutputPath, "utf8");
+  assert.match(markdown, /Overall status: \*\*WARNING\*\*/);
+  assert.match(markdown, /Advisory warnings: 4/);
 });


### PR DESCRIPTION
## Summary\n- add a candidate-level evidence freshness and consistency audit CLI with machine-readable findings\n- thread audit results into the release readiness dashboard, docs, and release script inventory\n- cover the audit and dashboard integrations with targeted tests\n\nCloses #957