### PR TITLE
[codex] fail fast on unsupported quickstart runtimes

### DIFF
--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -452,7 +452,7 @@ Relevant scripts: 41
 ## `validate:quickstart:contract`
 
 - Family: `validate`
-- Command: `node --import tsx ./scripts/contributor-quickstart-contract.ts`
+- Command: `node ./scripts/run-contributor-quickstart-contract.mjs`
 - Purpose: Audit the contributor quickstart contract by checking README/package alignment, then running the documented doctor and quickstart validator commands.
 - Required inputs:
   - A repo checkout with `README.md`, `package.json`, the quickstart validator script, and a bootable local dev environment unless `--skip-runtime` is used.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "validate:content-pack": "node --import tsx ./scripts/validate-content-pack.ts",
     "validate:content-pack:all": "node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack stonewatch-fork --map-pack ridgeway-crossing --map-pack highland-reach --map-pack amber-fields --map-pack ironpass-gorge --map-pack splitrock-canyon --map-pack bogfen-crossing --map-pack murkveil-delta --map-pack frostwatch-ridge --map-pack ashpeak-ascent --map-pack thornwall-divide --map-pack phase2",
     "validate:analytics-schema": "node --import tsx ./scripts/validate-analytics-schema.ts",
-    "validate:quickstart:contract": "node --import tsx ./scripts/contributor-quickstart-contract.ts",
+    "validate:quickstart:contract": "node ./scripts/run-contributor-quickstart-contract.mjs",
     "analytics:onboarding:funnel": "node --import tsx ./scripts/onboarding-funnel-report.ts",
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
     "stress:rooms:baseline": "node --import tsx ./scripts/stress-concurrent-rooms.ts --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --artifact-path=artifacts/release-readiness/stress-rooms-runtime-metrics.json",

--- a/scripts/repo-doctor.mjs
+++ b/scripts/repo-doctor.mjs
@@ -2,6 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import {
+  createRuntimePreflightCheckRecords,
+  detectRuntimeVersions,
+  evaluateRuntimePreflight,
+  loadRuntimeContract,
+  parsePackageManagerVersion,
+} from "./runtime-preflight.mjs";
 
 const STATUS_ORDER = ["pass", "info", "warn", "fail"];
 const FLOW_ALIASES = new Map([
@@ -26,40 +33,6 @@ function readJson(filePath) {
 
 function readTextIfExists(filePath) {
   return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : null;
-}
-
-function normalizeVersion(version) {
-  return version.replace(/^v/i, "").trim();
-}
-
-function parseMajor(version) {
-  const match = normalizeVersion(version).match(/^(\d+)/);
-  return match ? Number(match[1]) : null;
-}
-
-function parsePackageManagerVersion(packageManager) {
-  const match = packageManager?.match(/^npm@(.+)$/);
-  return match ? normalizeVersion(match[1]) : null;
-}
-
-function parseRange(range) {
-  const match = range?.match(/^>=\s*(\d+)\s*<\s*(\d+)$/);
-  if (!match) {
-    return null;
-  }
-  return { minInclusive: Number(match[1]), maxExclusive: Number(match[2]) };
-}
-
-function versionSatisfiesMajorRange(version, range) {
-  const major = parseMajor(version);
-  if (major == null) {
-    return false;
-  }
-  const parsedRange = parseRange(range);
-  if (!parsedRange) {
-    return true;
-  }
-  return major >= parsedRange.minInclusive && major < parsedRange.maxExclusive;
 }
 
 function parseArgs(argv) {
@@ -182,96 +155,6 @@ function relativeRepoPath(rootDir, targetPath) {
 
 function createCheck(id, title, status, summary, details = [], remediation = []) {
   return { id, title, status, summary, details, remediation };
-}
-
-function collectNodeAndNpmChecks(pkg, nvmrcValue, npmVersion, nodeVersion) {
-  const checks = [];
-
-  if (!versionSatisfiesMajorRange(nodeVersion, pkg.engines?.node)) {
-    checks.push(
-      createCheck(
-        "node-engine",
-        "Node.js version",
-        "fail",
-        `Current Node ${nodeVersion} does not satisfy package.json engines.node (${pkg.engines?.node ?? "unspecified"}).`,
-        [],
-        ["Install the repo runtime from `.nvmrc` and rerun `nvm use`."]
-      )
-    );
-  } else if (nvmrcValue && parseMajor(nodeVersion) !== parseMajor(nvmrcValue)) {
-    checks.push(
-      createCheck(
-        "node-nvmrc",
-        "Node.js alignment",
-        "warn",
-        `Current Node ${nodeVersion} satisfies engines but differs from .nvmrc (${nvmrcValue}).`,
-        ["CI and the README quickstart both target the .nvmrc runtime."],
-        ["Run `nvm use` to switch to the repo's preferred Node version."]
-      )
-    );
-  } else {
-    checks.push(
-      createCheck(
-        "node-nvmrc",
-        "Node.js alignment",
-        "pass",
-        `Current Node ${nodeVersion} matches the repo runtime target${nvmrcValue ? ` (${nvmrcValue})` : ""}.`
-      )
-    );
-  }
-
-  const expectedNpmVersion = parsePackageManagerVersion(pkg.packageManager);
-  if (!npmVersion) {
-    checks.push(
-      createCheck(
-        "npm-version",
-        "npm availability",
-        "fail",
-        "npm is not available on PATH.",
-        [],
-        ["Install npm and rerun `npm --version`.", "If you use nvm, `nvm use` should restore the bundled npm."]
-      )
-    );
-    return checks;
-  }
-
-  if (!versionSatisfiesMajorRange(npmVersion, pkg.engines?.npm)) {
-    checks.push(
-      createCheck(
-        "npm-version",
-        "npm version",
-        "fail",
-        `Current npm ${npmVersion} does not satisfy package.json engines.npm (${pkg.engines?.npm ?? "unspecified"}).`,
-        [],
-        [`Install npm ${expectedNpmVersion ?? "10.x"} or use the npm bundled with the repo's Node runtime.`]
-      )
-    );
-    return checks;
-  }
-
-  if (expectedNpmVersion && normalizeVersion(npmVersion) !== expectedNpmVersion) {
-    checks.push(
-      createCheck(
-        "npm-version",
-        "npm alignment",
-        "warn",
-        `Current npm ${npmVersion} satisfies engines but differs from packageManager (${pkg.packageManager}).`,
-        ["Exact npm drift can change lockfile/install behavior compared with CI."],
-        [`Use npm ${expectedNpmVersion} for the closest CI match.`]
-      )
-    );
-  } else {
-    checks.push(
-      createCheck(
-        "npm-version",
-        "npm alignment",
-        "pass",
-        `Current npm ${npmVersion} matches the repo expectation${expectedNpmVersion ? ` (${expectedNpmVersion})` : ""}.`
-      )
-    );
-  }
-
-  return checks;
 }
 
 function collectDependencyCheck(context) {
@@ -658,26 +541,43 @@ function collectReleaseChecks(context) {
 }
 
 function createSystemContext(overrides = {}) {
-  const envFile = parseEnvFile(path.join(repoRoot, ".env"));
-  const npmFromUserAgent =
-    process.env.npm_config_user_agent?.match(/\bnpm\/([^\s]+)/)?.[1] ??
-    process.env.npm_package_manager?.match(/^npm@(.+)$/)?.[1] ??
-    null;
-  const npmVersionResult = npmFromUserAgent ? null : runCommand("npm", ["--version"]);
-  const npmVersion = npmVersionResult?.status === 0 ? npmVersionResult.stdout.trim() : null;
+  const resolvedRepoRoot = overrides.repoRoot ?? repoRoot;
+  const envFile = parseEnvFile(path.join(resolvedRepoRoot, ".env"));
+  const runtimeContract =
+    overrides.runtimeContract ??
+    (overrides.packageJson
+      ? {
+          repoRoot: resolvedRepoRoot,
+          packageJsonPath: path.join(resolvedRepoRoot, "package.json"),
+          nvmrcPath: path.join(resolvedRepoRoot, ".nvmrc"),
+          readmePath: path.join(resolvedRepoRoot, "README.md"),
+          packageJson: overrides.packageJson,
+          nvmrcValue: overrides.nvmrcValue ?? null,
+          readmePrerequisites: overrides.readmePrerequisites ?? { node: null, npm: null },
+          nodeEngine: overrides.packageJson.engines?.node ?? null,
+          npmEngine: overrides.packageJson.engines?.npm ?? null,
+          packageManager: overrides.packageJson.packageManager ?? null,
+          expectedNpmVersion: parsePackageManagerVersion(overrides.packageJson.packageManager)
+        }
+      : loadRuntimeContract(resolvedRepoRoot));
+  const detectedRuntime = detectRuntimeVersions({
+    repoRoot: resolvedRepoRoot,
+    env: process.env,
+    runCommandImpl: runCommand
+  });
 
   return {
-    repoRoot,
-    packageJson: readJson(path.join(repoRoot, "package.json")),
-    nvmrcValue: readTextIfExists(path.join(repoRoot, ".nvmrc"))?.trim() ?? null,
+    repoRoot: resolvedRepoRoot,
+    packageJson: runtimeContract.packageJson,
+    runtimeContract,
     envFile,
     env: process.env,
-    nodeVersion: process.version,
-    npmVersion: npmFromUserAgent ?? npmVersion,
+    nodeVersion: detectedRuntime.nodeVersion,
+    npmVersion: detectedRuntime.npmVersion,
     commandExists: (command) => commandExists(command),
-    localBinPath: (name) => resolveLocalBin(repoRoot, name),
-    packageInstalled: (name) => resolvePackageInstalled(repoRoot, name),
-    playwrightCliPath: resolvePlaywrightCli(repoRoot),
+    localBinPath: (name) => resolveLocalBin(resolvedRepoRoot, name),
+    packageInstalled: (name) => resolvePackageInstalled(resolvedRepoRoot, name),
+    playwrightCliPath: resolvePlaywrightCli(resolvedRepoRoot),
     runCommand,
     ...overrides
   };
@@ -686,9 +586,16 @@ function createSystemContext(overrides = {}) {
 export function collectDoctorReport(options = {}, contextOverrides = {}) {
   const parsedArgs = options.flows ? { help: false, flows: options.flows } : parseArgs(process.argv.slice(2));
   const context = createSystemContext(contextOverrides);
+  const runtimeReport = evaluateRuntimePreflight({
+    contract: context.runtimeContract,
+    nodeVersion: context.nodeVersion,
+    npmVersion: context.npmVersion
+  });
 
   const checks = [
-    ...collectNodeAndNpmChecks(context.packageJson, context.nvmrcValue, context.npmVersion, context.nodeVersion),
+    ...createRuntimePreflightCheckRecords(runtimeReport).map((check) =>
+      createCheck(check.id, check.title, check.status, check.summary, check.details, check.remediation)
+    ),
     ...collectDependencyCheck(context),
     ...collectBaselineHintChecks(context)
   ];

--- a/scripts/run-contributor-quickstart-contract.mjs
+++ b/scripts/run-contributor-quickstart-contract.mjs
@@ -1,0 +1,45 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { assertSupportedRuntime } from "./runtime-preflight.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+
+export function runContributorQuickstartContractCli(
+  argv,
+  deps = {
+    assertSupportedRuntimeImpl: assertSupportedRuntime,
+    spawnSyncImpl: spawnSync
+  }
+) {
+  deps.assertSupportedRuntimeImpl({
+    commandName: "npm run validate:quickstart:contract",
+    repoRoot
+  });
+
+  const result = deps.spawnSyncImpl(
+    process.execPath,
+    ["--import", "tsx", "./scripts/contributor-quickstart-contract.ts", ...argv],
+    {
+      cwd: repoRoot,
+      stdio: "inherit"
+    }
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exitCode = result.status ?? 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    runContributorQuickstartContractCli(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/runtime-preflight.mjs
+++ b/scripts/runtime-preflight.mjs
@@ -1,0 +1,321 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultRepoRoot = path.resolve(scriptDir, "..");
+
+function readTextIfExists(filePath) {
+  return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : null;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+export function normalizeVersion(version) {
+  return version.replace(/^v/i, "").trim();
+}
+
+export function parseMajor(version) {
+  const match = normalizeVersion(version).match(/^(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+export function parsePackageManagerVersion(packageManager) {
+  const match = packageManager?.match(/^npm@(.+)$/);
+  return match ? normalizeVersion(match[1]) : null;
+}
+
+export function parseRange(range) {
+  const boundedMatch = range?.match(/^>=\s*(\d+)\s*<\s*(\d+)$/);
+  if (boundedMatch) {
+    return { minInclusive: Number(boundedMatch[1]), maxExclusive: Number(boundedMatch[2]) };
+  }
+
+  const lowerBoundMatch = range?.match(/^>=\s*(\d+)$/);
+  if (lowerBoundMatch) {
+    return { minInclusive: Number(lowerBoundMatch[1]), maxExclusive: null };
+  }
+
+  const upperBoundMatch = range?.match(/^<\s*(\d+)$/);
+  if (upperBoundMatch) {
+    return { minInclusive: null, maxExclusive: Number(upperBoundMatch[1]) };
+  }
+
+  if (!range) {
+    return null;
+  }
+  return null;
+}
+
+export function versionSatisfiesMajorRange(version, range) {
+  const major = parseMajor(version);
+  if (major == null) {
+    return false;
+  }
+  const parsedRange = parseRange(range);
+  if (!parsedRange) {
+    return true;
+  }
+  return (
+    (parsedRange.minInclusive == null || major >= parsedRange.minInclusive) &&
+    (parsedRange.maxExclusive == null || major < parsedRange.maxExclusive)
+  );
+}
+
+function readReadmePrerequisites(readmeText) {
+  if (!readmeText) {
+    return { node: null, npm: null };
+  }
+
+  const match = readmeText.match(/### Prerequisites\s+([\s\S]*?)\n### /);
+  const block = match?.[1] ?? readmeText;
+  const nodeLine = block.match(/^- (Node\.js[^\n]+)/m)?.[1] ?? null;
+  const npmLine = block.match(/^- (npm[^\n]+)/m)?.[1] ?? null;
+  return { node: nodeLine, npm: npmLine };
+}
+
+function detectNpmVersionFromEnvironment(env = process.env) {
+  return (
+    env.npm_config_user_agent?.match(/\bnpm\/([^\s]+)/)?.[1] ??
+    env.npm_package_manager?.match(/^npm@(.+)$/)?.[1] ??
+    null
+  );
+}
+
+function runCommand(command, args, cwd, env = process.env) {
+  return spawnSync(command, args, {
+    cwd,
+    env,
+    encoding: "utf8"
+  });
+}
+
+export function loadRuntimeContract(repoRoot = defaultRepoRoot) {
+  const packageJsonPath = path.join(repoRoot, "package.json");
+  const nvmrcPath = path.join(repoRoot, ".nvmrc");
+  const readmePath = path.join(repoRoot, "README.md");
+  const packageJson = readJson(packageJsonPath);
+  const nvmrcValue = readTextIfExists(nvmrcPath)?.trim() ?? null;
+  const readmePrerequisites = readReadmePrerequisites(readTextIfExists(readmePath));
+
+  return {
+    repoRoot,
+    packageJsonPath,
+    nvmrcPath,
+    readmePath,
+    packageJson,
+    nvmrcValue,
+    readmePrerequisites,
+    nodeEngine: packageJson.engines?.node ?? null,
+    npmEngine: packageJson.engines?.npm ?? null,
+    packageManager: packageJson.packageManager ?? null,
+    expectedNpmVersion: parsePackageManagerVersion(packageJson.packageManager)
+  };
+}
+
+export function detectRuntimeVersions({
+  repoRoot = defaultRepoRoot,
+  env = process.env,
+  nodeVersion = process.version,
+  npmVersion,
+  runCommandImpl = runCommand
+} = {}) {
+  const npmFromEnvironment = npmVersion ?? detectNpmVersionFromEnvironment(env);
+  if (npmFromEnvironment) {
+    return {
+      nodeVersion,
+      npmVersion: npmFromEnvironment
+    };
+  }
+
+  const npmResult = runCommandImpl("npm", ["--version"], repoRoot, env);
+  return {
+    nodeVersion,
+    npmVersion: npmResult.status === 0 ? npmResult.stdout.trim() : null
+  };
+}
+
+export function evaluateRuntimePreflight({
+  contract,
+  nodeVersion,
+  npmVersion
+}) {
+  const expectedNodeFromNvmrc = contract.nvmrcValue ? normalizeVersion(contract.nvmrcValue) : null;
+  const expectedNpmVersion = contract.expectedNpmVersion;
+  const checks = [];
+
+  if (!versionSatisfiesMajorRange(nodeVersion, contract.nodeEngine)) {
+    checks.push({
+      id: "node-engine",
+      title: "Node.js version",
+      status: "fail",
+      summary: `Current Node ${nodeVersion} does not satisfy package.json engines.node (${contract.nodeEngine ?? "unspecified"}).`
+    });
+  } else if (expectedNodeFromNvmrc && parseMajor(nodeVersion) !== parseMajor(expectedNodeFromNvmrc)) {
+    checks.push({
+      id: "node-nvmrc",
+      title: "Node.js alignment",
+      status: "warn",
+      summary: `Current Node ${nodeVersion} satisfies engines but differs from .nvmrc (${contract.nvmrcValue}).`
+    });
+  } else {
+    checks.push({
+      id: "node-nvmrc",
+      title: "Node.js alignment",
+      status: "pass",
+      summary: `Current Node ${nodeVersion} matches the repo runtime target${contract.nvmrcValue ? ` (${contract.nvmrcValue})` : ""}.`
+    });
+  }
+
+  if (!npmVersion) {
+    checks.push({
+      id: "npm-version",
+      title: "npm availability",
+      status: "fail",
+      summary: "npm is not available on PATH."
+    });
+  } else if (!versionSatisfiesMajorRange(npmVersion, contract.npmEngine)) {
+    checks.push({
+      id: "npm-version",
+      title: "npm version",
+      status: "fail",
+      summary: `Current npm ${npmVersion} does not satisfy package.json engines.npm (${contract.npmEngine ?? "unspecified"}).`
+    });
+  } else if (expectedNpmVersion && normalizeVersion(npmVersion) !== expectedNpmVersion) {
+    checks.push({
+      id: "npm-version",
+      title: "npm alignment",
+      status: "warn",
+      summary: `Current npm ${npmVersion} satisfies engines but differs from packageManager (${contract.packageManager}).`
+    });
+  } else {
+    checks.push({
+      id: "npm-version",
+      title: "npm alignment",
+      status: "pass",
+      summary: `Current npm ${npmVersion} matches the repo expectation${expectedNpmVersion ? ` (${expectedNpmVersion})` : ""}.`
+    });
+  }
+
+  const counts = {
+    pass: checks.filter((check) => check.status === "pass").length,
+    warn: checks.filter((check) => check.status === "warn").length,
+    fail: checks.filter((check) => check.status === "fail").length
+  };
+
+  return {
+    contract,
+    nodeVersion,
+    npmVersion,
+    checks,
+    counts,
+    isSupported: counts.fail === 0
+  };
+}
+
+export function remediationSteps(commandName, report) {
+  const steps = [];
+  if (report.contract.nvmrcValue) {
+    steps.push(`Run \`nvm use\` from the repo root to switch to Node ${report.contract.nvmrcValue}.`);
+  } else if (report.contract.readmePrerequisites.node) {
+    steps.push(`Install the README runtime: ${report.contract.readmePrerequisites.node}.`);
+  }
+
+  if (report.contract.expectedNpmVersion) {
+    steps.push(
+      `Confirm \`npm --version\` reports ${report.contract.expectedNpmVersion} (or another npm major that satisfies ${report.contract.npmEngine ?? "the repo requirement"}).`
+    );
+  } else if (report.contract.readmePrerequisites.npm) {
+    steps.push(`Confirm the npm version matches the README prerequisite: ${report.contract.readmePrerequisites.npm}.`);
+  }
+
+  steps.push(`Rerun \`npm ci --no-audit --no-fund\`, then retry \`${commandName}\`.`);
+  return steps;
+}
+
+export function formatUnsupportedRuntimeMessage(commandName, report) {
+  const lines = [
+    `[runtime-preflight] Unsupported runtime for \`${commandName}\`.`,
+    `Detected Node: ${report.nodeVersion}`,
+    `Detected npm: ${report.npmVersion ?? "unavailable"}`,
+    "",
+    "Repo-supported runtime:",
+    ...(report.contract.readmePrerequisites.node ? [`- README.md prerequisites: ${report.contract.readmePrerequisites.node}`] : []),
+    ...(report.contract.readmePrerequisites.npm ? [`- README.md prerequisites: ${report.contract.readmePrerequisites.npm}`] : []),
+    ...(report.contract.nvmrcValue ? [`- .nvmrc: ${report.contract.nvmrcValue}`] : []),
+    ...(report.contract.nodeEngine ? [`- package.json engines.node: ${report.contract.nodeEngine}`] : []),
+    ...(report.contract.npmEngine ? [`- package.json engines.npm: ${report.contract.npmEngine}`] : []),
+    ...(report.contract.packageManager ? [`- package.json packageManager: ${report.contract.packageManager}`] : []),
+    "",
+    "Runtime check failures:"
+  ];
+
+  for (const check of report.checks.filter((entry) => entry.status === "fail")) {
+    lines.push(`- ${check.summary}`);
+  }
+
+  lines.push("", "Remediation:");
+  for (const step of remediationSteps(commandName, report)) {
+    lines.push(`- ${step}`);
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function createRuntimePreflightCheckRecords(report) {
+  return report.checks.map((check) => {
+    const remediation = check.status === "fail" ? remediationSteps("npm run doctor", report) : check.status === "warn"
+      ? [
+          report.contract.nvmrcValue
+            ? `Run \`nvm use\` to align with .nvmrc (${report.contract.nvmrcValue}).`
+            : "Align with the README runtime guidance before validating the quickstart path.",
+          report.contract.expectedNpmVersion
+            ? `Use npm ${report.contract.expectedNpmVersion} for the closest CI match.`
+            : "Use the npm version documented in README/package metadata."
+        ]
+      : [];
+
+    return {
+      id: check.id,
+      title: check.title,
+      status: check.status,
+      summary: check.summary,
+      details: [],
+      remediation
+    };
+  });
+}
+
+export function assertSupportedRuntime({
+  commandName,
+  repoRoot = defaultRepoRoot,
+  env = process.env,
+  nodeVersion = process.version,
+  npmVersion,
+  runCommandImpl = runCommand
+} = {}) {
+  const contract = loadRuntimeContract(repoRoot);
+  const detected = detectRuntimeVersions({
+    repoRoot,
+    env,
+    nodeVersion,
+    npmVersion,
+    runCommandImpl
+  });
+  const report = evaluateRuntimePreflight({
+    contract,
+    nodeVersion: detected.nodeVersion,
+    npmVersion: detected.npmVersion
+  });
+
+  if (!report.isSupported) {
+    const error = new Error(formatUnsupportedRuntimeMessage(commandName, report));
+    error.report = report;
+    throw error;
+  }
+
+  return report;
+}

--- a/scripts/test/repo-doctor.test.ts
+++ b/scripts/test/repo-doctor.test.ts
@@ -97,6 +97,38 @@ test("doctor warns on Node and npm drift even when engines still pass", () => {
   assert.match(output, /Doctor result: passed with warnings/);
 });
 
+test("doctor fails with runtime remediation when Node/npm are unsupported", () => {
+  const repoRoot = makeTempRepo();
+  const report = collectDoctorReport(
+    {
+      flows: ["baseline"]
+    },
+    {
+      repoRoot,
+      packageJson: basePackageJson(),
+      nvmrcValue: "22",
+      readmePrerequisites: {
+        node: "Node.js 22 LTS",
+        npm: "npm 10+"
+      },
+      envFile: {},
+      env: { HOME: repoRoot },
+      nodeVersion: "v20.11.1",
+      npmVersion: "9.8.1",
+      packageInstalled: () => true,
+      commandExists: () => false,
+      runCommand: () => ({ status: 1, stdout: "", stderr: "", error: null })
+    }
+  );
+
+  assert.equal(report.counts.fail, 2);
+  assert.equal(report.overallStatus, "fail");
+  const output = renderDoctorReport(report);
+  assert.match(output, /Doctor result: failed/);
+  assert.match(output, /Run `nvm use` from the repo root to switch to Node 22/);
+  assert.match(output, /npm ci --no-audit --no-fund/);
+});
+
 test("doctor prints actionable remediation when optional flow prerequisites are missing", () => {
   const repoRoot = makeTempRepo();
   writeFile(path.join(repoRoot, "apps/cocos-client/wechat-minigame.build.json"), "{}\n");

--- a/scripts/test/run-contributor-quickstart-contract.test.ts
+++ b/scripts/test/run-contributor-quickstart-contract.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runContributorQuickstartContractCli } from "../run-contributor-quickstart-contract.mjs";
+
+test("contract wrapper fails before invoking tsx when runtime preflight fails", () => {
+  let spawnCalled = false;
+
+  assert.throws(
+    () =>
+      runContributorQuickstartContractCli(["--skip-runtime"], {
+        assertSupportedRuntimeImpl: () => {
+          throw new Error("unsupported runtime");
+        },
+        spawnSyncImpl: () => {
+          spawnCalled = true;
+          return { status: 0 };
+        }
+      }),
+    /unsupported runtime/
+  );
+
+  assert.equal(spawnCalled, false);
+});
+
+test("contract wrapper forwards args into the tsx entrypoint after preflight passes", () => {
+  let receivedArgs: string[] | null = null;
+
+  runContributorQuickstartContractCli(["--skip-runtime", "--output", "artifact.json"], {
+    assertSupportedRuntimeImpl: () => undefined,
+    spawnSyncImpl: (_command, args) => {
+      receivedArgs = args;
+      return { status: 0 };
+    }
+  });
+
+  assert.deepEqual(receivedArgs, [
+    "--import",
+    "tsx",
+    "./scripts/contributor-quickstart-contract.ts",
+    "--skip-runtime",
+    "--output",
+    "artifact.json"
+  ]);
+});

--- a/scripts/test/runtime-preflight.test.ts
+++ b/scripts/test/runtime-preflight.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateRuntimePreflight,
+  formatUnsupportedRuntimeMessage
+} from "../runtime-preflight.mjs";
+
+function createContract() {
+  return {
+    repoRoot: "/tmp/project-veil",
+    packageJsonPath: "/tmp/project-veil/package.json",
+    nvmrcPath: "/tmp/project-veil/.nvmrc",
+    readmePath: "/tmp/project-veil/README.md",
+    packageJson: {
+      packageManager: "npm@10.9.3",
+      engines: {
+        node: ">=22 <25",
+        npm: ">=10"
+      }
+    },
+    nvmrcValue: "22",
+    readmePrerequisites: {
+      node: "Node.js 22 LTS（CI 同款；仓库提供 `.nvmrc`）",
+      npm: "npm 10+"
+    },
+    nodeEngine: ">=22 <25",
+    npmEngine: ">=10",
+    packageManager: "npm@10.9.3",
+    expectedNpmVersion: "10.9.3"
+  };
+}
+
+test("runtime preflight formats actionable remediation for unsupported Node/npm", () => {
+  const report = evaluateRuntimePreflight({
+    contract: createContract(),
+    nodeVersion: "v20.12.2",
+    npmVersion: "9.9.0"
+  });
+
+  assert.equal(report.isSupported, false);
+  const output = formatUnsupportedRuntimeMessage("npm run validate:quickstart", report);
+
+  assert.match(output, /Unsupported runtime for `npm run validate:quickstart`/);
+  assert.match(output, /README\.md prerequisites: Node\.js 22 LTS/);
+  assert.match(output, /\.nvmrc: 22/);
+  assert.match(output, /package\.json engines\.node: >=22 <25/);
+  assert.match(output, /package\.json packageManager: npm@10\.9\.3/);
+  assert.match(output, /Current Node v20\.12\.2 does not satisfy package\.json engines\.node/);
+  assert.match(output, /Current npm 9\.9\.0 does not satisfy package\.json engines\.npm/);
+  assert.match(output, /Run `nvm use` from the repo root to switch to Node 22/);
+  assert.match(output, /Rerun `npm ci --no-audit --no-fund`, then retry `npm run validate:quickstart`/);
+});

--- a/scripts/validate-local-dev-quickstart.mjs
+++ b/scripts/validate-local-dev-quickstart.mjs
@@ -1,7 +1,9 @@
 import { spawn } from "node:child_process";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { assertSupportedRuntime } from "./runtime-preflight.mjs";
 
 const rootDir = new URL("../", import.meta.url);
+const rootDirPath = fileURLToPath(rootDir);
 export const QUICKSTART_DOCTOR_SCRIPT = "doctor";
 export const QUICKSTART_VALIDATE_SCRIPT = "validate:quickstart";
 export const QUICKSTART_H5_BUILD_SCRIPT = "build:client:h5";
@@ -68,11 +70,11 @@ async function verifyEndpoints() {
   }
 }
 
-async function main() {
-  const majorNodeVersion = Number(process.versions.node.split(".")[0]);
-  if (Number.isNaN(majorNodeVersion) || majorNodeVersion < 22) {
-    throw new Error(`Node.js 22+ is required; found ${process.version}`);
-  }
+export async function main() {
+  assertSupportedRuntime({
+    commandName: "npm run validate:quickstart",
+    repoRoot: rootDirPath
+  });
 
   logStep(`using Node ${process.version}`);
   logStep("validating e2e config fixtures");


### PR DESCRIPTION
## Summary
- add a shared quickstart runtime preflight that reads README/.nvmrc/package.json metadata and produces actionable remediation for unsupported Node/npm versions
- run `doctor` and `validate:quickstart` through that shared preflight, and place `validate:quickstart:contract` behind a plain-Node wrapper so unsupported runtimes fail before invoking `tsx`
- add regression tests for the unsupported-runtime path and update the script inventory command reference

## Root cause
- the quickstart entrypoints validated runtime requirements in different ways, and the contract command loaded `tsx` before any runtime compatibility check ran

## Validation
- `node --import tsx --test ./scripts/test/runtime-preflight.test.ts ./scripts/test/run-contributor-quickstart-contract.test.ts ./scripts/test/repo-doctor.test.ts ./scripts/test/contributor-quickstart-contract.test.ts`
- `npm run doctor`
- `npm run validate:quickstart`
- `npm run validate:quickstart:contract`

closes #970
