### PR TITLE
feat: expand campaign chapters 5 and 6

### DIFF
--- a/apps/server/src/pve-content.ts
+++ b/apps/server/src/pve-content.ts
@@ -3,6 +3,8 @@ import campaignDocument from "../../../configs/campaign-chapter1.json";
 import campaignChapter2Document from "../../../configs/campaign-chapter2.json";
 import campaignChapter3Document from "../../../configs/campaign-chapter3.json";
 import campaignChapter4Document from "../../../configs/campaign-chapter4.json";
+import campaignChapter5Document from "../../../configs/campaign-chapter5.json";
+import campaignChapter6Document from "../../../configs/campaign-chapter6.json";
 import dailyDungeonsDocument from "../../../configs/daily-dungeons.json";
 import type {
   CampaignMission,
@@ -21,6 +23,7 @@ import type {
 } from "../../../packages/shared/src/index";
 import {
   getDefaultBossEncounterTemplateCatalog,
+  getDivisionLabel,
   getRankDivisionIndex,
   resolveCosmeticCatalog,
   validateDailyDungeonConfigDocument
@@ -70,18 +73,30 @@ const DEFAULT_CAMPAIGN_DOCUMENTS: CampaignConfigDocument[] = [
   campaignDocument as CampaignConfigDocument,
   campaignChapter2Document as CampaignConfigDocument,
   campaignChapter3Document as CampaignConfigDocument,
-  campaignChapter4Document as CampaignConfigDocument
+  campaignChapter4Document as CampaignConfigDocument,
+  campaignChapter5Document as CampaignConfigDocument,
+  campaignChapter6Document as CampaignConfigDocument
 ];
 
 const BASIC_CAMPAIGN_ENEMY_TEMPLATES = new Set(["wolf_pack", "hero_guard_basic"]);
+const CHAPTER_SEQUENCE = ["chapter1", "chapter2", "chapter3", "chapter4", "chapter5", "chapter6"] as const;
 const CHAPTER_FINAL_MISSION_IDS: Record<string, string> = {
   chapter1: "chapter1-defend-bridge",
   chapter2: "chapter2-break-the-ring",
   chapter3: "chapter3-tempest-crown",
-  chapter4: "chapter4-veilfall-throne"
+  chapter4: "chapter4-veilfall-throne",
+  chapter5: "chapter5-ashen-regency",
+  chapter6: "chapter6-blackgate-dawn"
+};
+const CHAPTER_MINIMUM_HERO_LEVEL: Partial<Record<string, number>> = {
+  chapter3: 15,
+  chapter5: 22,
+  chapter6: 28
 };
 const CHAPTER_MINIMUM_RANK: Partial<Record<string, RankDivisionId>> = {
-  chapter4: "silver_i"
+  chapter4: "silver_i",
+  chapter5: "gold_i",
+  chapter6: "platinum_i"
 };
 
 function resolveCampaignDocuments(document: CampaignConfigDocument | CampaignConfigDocument[]): CampaignConfigDocument[] {
@@ -283,7 +298,7 @@ export function resolveCampaignConfig(
   for (const mission of missions) {
     missionsByChapter.set(mission.chapterId, [...(missionsByChapter.get(mission.chapterId) ?? []), mission]);
   }
-  for (const chapterId of ["chapter2", "chapter3", "chapter4"]) {
+  for (const chapterId of ["chapter2", "chapter3", "chapter4", "chapter5", "chapter6"]) {
     const chapterMissions = missionsByChapter.get(chapterId) ?? [];
     if (chapterMissions.length < 6 || chapterMissions.length > 8) {
       throw new Error(`${chapterId} must define 6-8 missions`);
@@ -328,14 +343,9 @@ function getChapterUnlockRequirements(
     });
   }
 
-  const previousChapterFinalMissionId =
-    mission.chapterId === "chapter2"
-      ? CHAPTER_FINAL_MISSION_IDS.chapter1
-      : mission.chapterId === "chapter3"
-        ? CHAPTER_FINAL_MISSION_IDS.chapter2
-        : mission.chapterId === "chapter4"
-          ? CHAPTER_FINAL_MISSION_IDS.chapter3
-          : undefined;
+  const chapterIndex = CHAPTER_SEQUENCE.indexOf(mission.chapterId as (typeof CHAPTER_SEQUENCE)[number]);
+  const previousChapterId = chapterIndex > 0 ? CHAPTER_SEQUENCE[chapterIndex - 1] : undefined;
+  const previousChapterFinalMissionId = previousChapterId ? CHAPTER_FINAL_MISSION_IDS[previousChapterId] : undefined;
   if (previousChapterFinalMissionId) {
     requirements.push({
       type: "mission_complete",
@@ -346,12 +356,13 @@ function getChapterUnlockRequirements(
     });
   }
 
-  if (mission.chapterId === "chapter3") {
+  const minimumHeroLevel = CHAPTER_MINIMUM_HERO_LEVEL[mission.chapterId];
+  if (minimumHeroLevel) {
     requirements.push({
       type: "hero_level",
-      description: "Reach hero level 15.",
-      satisfied: Math.max(1, Math.floor(accessContext?.highestHeroLevel ?? 1)) >= 15,
-      minimumHeroLevel: 15,
+      description: `Reach hero level ${minimumHeroLevel}.`,
+      satisfied: Math.max(1, Math.floor(accessContext?.highestHeroLevel ?? 1)) >= minimumHeroLevel,
+      minimumHeroLevel,
       chapterId: mission.chapterId
     });
   }
@@ -361,7 +372,7 @@ function getChapterUnlockRequirements(
     const currentRankDivision = accessContext?.rankDivision ?? "bronze_i";
     requirements.push({
       type: "rank_division",
-      description: "Reach Silver rank or higher.",
+      description: `Reach ${getDivisionLabel(minimumRankDivision)} rank or higher.`,
       satisfied: getRankDivisionIndex(currentRankDivision) >= getRankDivisionIndex(minimumRankDivision),
       minimumRankDivision,
       chapterId: mission.chapterId

--- a/apps/server/test/pve-content.test.ts
+++ b/apps/server/test/pve-content.test.ts
@@ -18,25 +18,33 @@ test("campaign config exposes a 6-mission chapter 1 arc with dialogue and sequen
   const chapter2 = missions.filter((mission) => mission.chapterId === "chapter2");
   const chapter3 = missions.filter((mission) => mission.chapterId === "chapter3");
   const chapter4 = missions.filter((mission) => mission.chapterId === "chapter4");
+  const chapter5 = missions.filter((mission) => mission.chapterId === "chapter5");
+  const chapter6 = missions.filter((mission) => mission.chapterId === "chapter6");
 
-  assert.equal(missions.length, 27);
+  assert.equal(missions.length, 41);
   assert.equal(chapter1.length, 6);
   assert.equal(chapter2.length, 7);
   assert.equal(chapter3.length, 7);
   assert.equal(chapter4.length, 7);
+  assert.equal(chapter5.length, 7);
+  assert.equal(chapter6.length, 7);
   assert.equal(missions[0]?.introDialogue?.length, 2);
   assert.equal(chapter2.at(-1)?.bossEncounterName, "Captain Veyr, Ringbreaker");
   assert.equal(chapter2.at(-1)?.bossTemplateId, "boss-shadow-warden");
   assert.equal(chapter3.at(-1)?.midDialogue?.length, 3);
   assert.equal(chapter4.at(-1)?.reward.cosmeticId, "border-veilfall-throne");
+  assert.equal(chapter5.at(-1)?.bossEncounterName, "Chancellor Morvane");
+  assert.equal(chapter6.at(-1)?.reward.cosmeticId, "border-dawnwatch-paragon");
   assert.equal(missions[0]?.objectives[0]?.id, "c1m1-clear-patrol");
   assert.equal(states[0]?.status, "available");
   assert.equal(states[1]?.unlockMissionId, states[0]?.id);
   assert.equal(states[1]?.status, "locked");
   assert.equal(states.find((mission) => mission.id === "chapter2-highland-muster")?.status, "locked");
+  assert.equal(states.find((mission) => mission.id === "chapter5-crownless-watch")?.status, "locked");
+  assert.equal(states.find((mission) => mission.id === "chapter6-glassfront-march")?.status, "locked");
 });
 
-test("campaign chapter gates require prior chapter clears, hero level 15, and silver rank", () => {
+test("campaign chapter gates require prior chapter clears, hero level thresholds, and ranked progression", () => {
   const missions = resolveCampaignConfig();
   const chapter2Mission = buildCampaignMissionStates(missions, {
     missions: [{ missionId: "chapter1-defend-bridge", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
@@ -69,6 +77,48 @@ test("campaign chapter gates require prior chapter clears, hero level 15, and si
     },
     { highestHeroLevel: 18, rankDivision: "silver_i" }
   ).find((mission) => mission.id === "chapter4-basin-breach");
+  const chapter5LockedByHeroLevel = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter4-veilfall-throne", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 21, rankDivision: "gold_i" }
+  ).find((mission) => mission.id === "chapter5-crownless-watch");
+  const chapter5LockedByRank = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter4-veilfall-throne", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 22, rankDivision: "silver_iii" }
+  ).find((mission) => mission.id === "chapter5-crownless-watch");
+  const chapter5Unlocked = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter4-veilfall-throne", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 22, rankDivision: "gold_i" }
+  ).find((mission) => mission.id === "chapter5-crownless-watch");
+  const chapter6LockedByHeroLevel = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter5-ashen-regency", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 27, rankDivision: "platinum_i" }
+  ).find((mission) => mission.id === "chapter6-glassfront-march");
+  const chapter6LockedByRank = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter5-ashen-regency", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 28, rankDivision: "gold_iii" }
+  ).find((mission) => mission.id === "chapter6-glassfront-march");
+  const chapter6Unlocked = buildCampaignMissionStates(
+    missions,
+    {
+      missions: [{ missionId: "chapter5-ashen-regency", attempts: 1, completedAt: "2026-04-05T00:00:00.000Z" }]
+    },
+    { highestHeroLevel: 28, rankDivision: "platinum_i" }
+  ).find((mission) => mission.id === "chapter6-glassfront-march");
 
   assert.equal(chapter2Mission?.status, "available");
   assert.equal(chapter3Locked?.status, "locked");
@@ -77,6 +127,16 @@ test("campaign chapter gates require prior chapter clears, hero level 15, and si
   assert.equal(chapter4Locked?.status, "locked");
   assert.equal(chapter4Locked?.unlockRequirements?.find((requirement) => requirement.type === "rank_division")?.satisfied, false);
   assert.equal(chapter4Unlocked?.status, "available");
+  assert.equal(chapter5LockedByHeroLevel?.status, "locked");
+  assert.equal(chapter5LockedByHeroLevel?.unlockRequirements?.find((requirement) => requirement.type === "hero_level")?.minimumHeroLevel, 22);
+  assert.equal(chapter5LockedByRank?.status, "locked");
+  assert.equal(chapter5LockedByRank?.unlockRequirements?.find((requirement) => requirement.type === "rank_division")?.minimumRankDivision, "gold_i");
+  assert.equal(chapter5Unlocked?.status, "available");
+  assert.equal(chapter6LockedByHeroLevel?.status, "locked");
+  assert.equal(chapter6LockedByHeroLevel?.unlockRequirements?.find((requirement) => requirement.type === "hero_level")?.minimumHeroLevel, 28);
+  assert.equal(chapter6LockedByRank?.status, "locked");
+  assert.equal(chapter6LockedByRank?.unlockRequirements?.find((requirement) => requirement.type === "rank_division")?.minimumRankDivision, "platinum_i");
+  assert.equal(chapter6Unlocked?.status, "available");
 });
 
 test("daily dungeon state resets by date key and enforces one-time reward claims per run", () => {

--- a/configs/campaign-chapter5.json
+++ b/configs/campaign-chapter5.json
@@ -1,0 +1,375 @@
+{
+  "missions": [
+    {
+      "id": "chapter5-crownless-watch",
+      "chapterId": "chapter5",
+      "order": 28,
+      "mapId": "frontier-basin",
+      "name": "Crownless Watch",
+      "description": "Push beyond the shattered throne and secure the watch posts where loyalist officers are trying to re-form the court.",
+      "recommendedHeroLevel": 26,
+      "enemyArmyTemplateId": "crown_field_chaplain",
+      "enemyArmyCount": 64,
+      "enemyStatMultiplier": 4.98,
+      "introDialogue": [
+        {
+          "id": "c5m1-intro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Breaking the throne was the easy part. What follows a broken throne is every opportunist with a banner.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c5m1-outro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "The watch posts are ours. The loyalists are organized, but not organized enough.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c5m1-secure-watchfires",
+          "description": "Secure the crownless watchfires",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 3
+        },
+        {
+          "id": "c5m1-break-rally",
+          "description": "Break the loyalist rally around the basin road",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 70, "resources": { "gold": 1200, "wood": 26, "ore": 48 } }
+    },
+    {
+      "id": "chapter5-ember-ledger",
+      "chapterId": "chapter5",
+      "order": 29,
+      "mapId": "highland-reach",
+      "name": "Ember Ledger",
+      "description": "Seize the court's tax ledgers before fleeing quartermasters can buy a second war with hidden stockpiles.",
+      "recommendedHeroLevel": 27,
+      "enemyArmyTemplateId": "crown_crossbowman",
+      "enemyArmyCount": 66,
+      "enemyStatMultiplier": 5.14,
+      "unlockMissionId": "chapter5-crownless-watch",
+      "introDialogue": [
+        {
+          "id": "c5m2-intro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "A kingdom can lose its ruler and still keep its books. Burn the wrong one and we lose the grain with the bribes.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c5m2-outro-1",
+          "speakerId": "quartermaster-ren",
+          "speakerName": "Quartermaster Ren",
+          "text": "Ledgers secured. I dislike the parts where their corruption is more organized than our repair work.",
+          "mood": "grim"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c5m2-secure-ledgers",
+          "description": "Secure the ember ledgers before they burn",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 2
+        },
+        {
+          "id": "c5m2-hold-granary",
+          "description": "Hold the granary square against the quartermaster guard",
+          "kind": "hold",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 72, "resources": { "gold": 1240, "wood": 36, "ore": 50 } }
+    },
+    {
+      "id": "chapter5-shroud-harbor",
+      "chapterId": "chapter5",
+      "order": 30,
+      "mapId": "murkveil-delta",
+      "name": "Shroud Harbor",
+      "description": "Clear the delta harbor where court remnants are funneling officers, relics, and prisoners into the fog.",
+      "recommendedHeroLevel": 28,
+      "enemyArmyTemplateId": "shadow_hexer",
+      "enemyArmyCount": 68,
+      "enemyStatMultiplier": 5.3,
+      "unlockMissionId": "chapter5-ember-ledger",
+      "introDialogue": [
+        {
+          "id": "c5m3-intro-1",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "They are not retreating. They are selecting what survives the fall and hiding it in the tide fog.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c5m3-outro-1",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "The fog here carries commands, not weather. Someone farther inland is still giving orders.",
+          "mood": "urgent"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c5m3-clear-piers",
+          "description": "Clear the shrouded harbor piers",
+          "kind": "defeat",
+          "gate": "start"
+        },
+        {
+          "id": "c5m3-free-prisoners",
+          "description": "Free the prisoners marked for transfer",
+          "kind": "secure",
+          "gate": "mid",
+          "targetCount": 3
+        }
+      ],
+      "reward": { "gems": 74, "resources": { "gold": 1280, "ore": 52 } }
+    },
+    {
+      "id": "chapter5-iron-oathbreakers",
+      "chapterId": "chapter5",
+      "order": 31,
+      "mapId": "ironpass-gorge",
+      "name": "Iron Oathbreakers",
+      "description": "Destroy the forge lines arming oathbreaker companies that refuse the war's end unless forced to see it.",
+      "recommendedHeroLevel": 29,
+      "enemyArmyTemplateId": "iron_walker",
+      "enemyArmyCount": 70,
+      "enemyStatMultiplier": 5.46,
+      "unlockMissionId": "chapter5-shroud-harbor",
+      "introDialogue": [
+        {
+          "id": "c5m4-intro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "They swore to the court, then to the regent, and now to whoever still pays in steel. Loyal men are easier to mourn than hired ones.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c5m4-outro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "Oathbreakers routed. Their forges can either heat homes or cool forever.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c5m4-break-anvils",
+          "description": "Break the oathbreaker forge anvils",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 2
+        },
+        {
+          "id": "c5m4-clear-companies",
+          "description": "Clear the oathbreaker companies in the gorge",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 76, "resources": { "gold": 1320, "wood": 24, "ore": 56 } }
+    },
+    {
+      "id": "chapter5-rift-cartographers",
+      "chapterId": "chapter5",
+      "order": 32,
+      "mapId": "splitrock-canyon",
+      "name": "Rift Cartographers",
+      "description": "Escort survey crews into the faulted passes and recover the maps hiding the court's evacuation corridors.",
+      "recommendedHeroLevel": 30,
+      "enemyArmyTemplateId": "wild_hawk_rider",
+      "enemyArmyCount": 72,
+      "enemyStatMultiplier": 5.62,
+      "unlockMissionId": "chapter5-iron-oathbreakers",
+      "introDialogue": [
+        {
+          "id": "c5m5-intro-1",
+          "speakerId": "engineer-toma",
+          "speakerName": "Engineer Toma",
+          "text": "If we do not map the rifts, we inherit every ambush route the court built for its own escape.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c5m5-outro-1",
+          "speakerId": "engineer-toma",
+          "speakerName": "Engineer Toma",
+          "text": "Routes confirmed. The last safe road they thought they owned is now just another road.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c5m5-escort-surveyors",
+          "description": "Escort the surveyors through the rift line",
+          "kind": "escort",
+          "gate": "start"
+        },
+        {
+          "id": "c5m5-recover-maps",
+          "description": "Recover the sealed evacuation maps",
+          "kind": "secure",
+          "gate": "mid",
+          "targetCount": 2
+        }
+      ],
+      "reward": { "gems": 78, "resources": { "gold": 1360, "wood": 30, "ore": 58 } }
+    },
+    {
+      "id": "chapter5-black-banner-keep",
+      "chapterId": "chapter5",
+      "order": 33,
+      "mapId": "stonewatch-fork",
+      "name": "Black Banner Keep",
+      "description": "Storm the keep where the surviving nobles are gathering black-banner companies for a counterclaim.",
+      "recommendedHeroLevel": 31,
+      "enemyArmyTemplateId": "crown_heavy_cavalry",
+      "enemyArmyCount": 74,
+      "enemyStatMultiplier": 5.78,
+      "unlockMissionId": "chapter5-rift-cartographers",
+      "introDialogue": [
+        {
+          "id": "c5m6-intro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "A dead court breeds live pretenders. Black banners mean they have already chosen who gets fed to the rumor mill first.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c5m6-outro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "The keep is open. Whoever still thinks the throne can be reassembled is out of excuses and walls.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c5m6-breach-keep",
+          "description": "Breach Black Banner Keep",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c5m6-break-cavalry",
+          "description": "Break the black-banner cavalry reserve",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 80, "resources": { "gold": 1400, "ore": 60 } }
+    },
+    {
+      "id": "chapter5-ashen-regency",
+      "chapterId": "chapter5",
+      "order": 34,
+      "mapId": "ashpeak-ascent",
+      "name": "Ashen Regency",
+      "description": "Defeat the regent of the surviving loyalist council before the court's remnants can crown a war of succession.",
+      "recommendedHeroLevel": 32,
+      "enemyArmyTemplateId": "shadow_wraith",
+      "enemyArmyCount": 78,
+      "enemyStatMultiplier": 6.02,
+      "bossEncounterName": "Chancellor Morvane",
+      "bossTemplateId": "boss-shadow-warden",
+      "unlockMissionId": "chapter5-black-banner-keep",
+      "introDialogue": [
+        {
+          "id": "c5m7-intro-1",
+          "speakerId": "chancellor-morvane",
+          "speakerName": "Chancellor Morvane",
+          "text": "You broke a throne and mistook collapse for victory. Power is a habit, and habits outlive furniture.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c5m7-intro-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Then let us correct the habit before it learns our names.",
+          "mood": "grim"
+        }
+      ],
+      "midDialogue": [
+        {
+          "id": "c5m7-mid-1",
+          "speakerId": "chancellor-morvane",
+          "speakerName": "Chancellor Morvane",
+          "text": "The court does not need a sovereign. It only needs enough frightened people to believe one is coming.",
+          "mood": "grim"
+        },
+        {
+          "id": "c5m7-mid-2",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "His ward lattice is borrowing strength from the old regency seals. Tear the marks down now.",
+          "mood": "urgent"
+        },
+        {
+          "id": "c5m7-mid-3",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "Then we break the story first and the man second.",
+          "mood": "defiant"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c5m7-outro-1",
+          "speakerId": "narrator",
+          "speakerName": "Narrator",
+          "text": "Morvane falls across the cracked regency dais, and the last organized claim to the court scatters into smoke and ash.",
+          "mood": "hopeful"
+        },
+        {
+          "id": "c5m7-outro-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Chapter 6 begins where ambition ends. Now we hunt the machine that taught all of them how to survive defeat.",
+          "mood": "grim"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c5m7-break-regency-seals",
+          "description": "Break the regency seals around Chancellor Morvane",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c5m7-hold-dais",
+          "description": "Hold the regency dais while the lattice collapses",
+          "kind": "hold",
+          "gate": "mid"
+        },
+        {
+          "id": "c5m7-defeat-morvane",
+          "description": "Defeat Chancellor Morvane",
+          "kind": "defeat",
+          "gate": "end"
+        }
+      ],
+      "reward": { "gems": 92, "resources": { "gold": 1560, "ore": 66 }, "cosmeticId": "recolor-crownless-vanguard" }
+    }
+  ]
+}

--- a/configs/campaign-chapter6.json
+++ b/configs/campaign-chapter6.json
@@ -1,0 +1,374 @@
+{
+  "missions": [
+    {
+      "id": "chapter6-glassfront-march",
+      "chapterId": "chapter6",
+      "order": 35,
+      "mapId": "highland-reach",
+      "name": "Glassfront March",
+      "description": "Advance into the sealed districts beyond the court where the war's true archivists are trying to erase the evidence of how it was fed.",
+      "recommendedHeroLevel": 33,
+      "enemyArmyTemplateId": "shadow_skeleton",
+      "enemyArmyCount": 80,
+      "enemyStatMultiplier": 6.18,
+      "introDialogue": [
+        {
+          "id": "c6m1-intro-1",
+          "speakerId": "scout-serin",
+          "speakerName": "Scout Serin",
+          "text": "The streets ahead look abandoned until the glass starts moving. That means the archivists know we are close.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c6m1-outro-1",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "These wards were not built to defend a throne. They were built to preserve a program.",
+          "mood": "urgent"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c6m1-secure-avenues",
+          "description": "Secure the glassfront avenues",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 3
+        },
+        {
+          "id": "c6m1-clear-curators",
+          "description": "Clear the skeletal curators guarding the archive road",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 84, "resources": { "gold": 1440, "wood": 28, "ore": 62 } }
+    },
+    {
+      "id": "chapter6-choir-of-cinders",
+      "chapterId": "chapter6",
+      "order": 36,
+      "mapId": "bogfen-crossing",
+      "name": "Choir Of Cinders",
+      "description": "Silence the cinder choir transmitting old court commands through the marsh beacons to anyone still willing to obey them.",
+      "recommendedHeroLevel": 34,
+      "enemyArmyTemplateId": "shadow_wraith",
+      "enemyArmyCount": 82,
+      "enemyStatMultiplier": 6.34,
+      "unlockMissionId": "chapter6-glassfront-march",
+      "introDialogue": [
+        {
+          "id": "c6m2-intro-1",
+          "speakerId": "fen-warden-isa",
+          "speakerName": "Warden Isa",
+          "text": "The marsh is singing orders in a dead language. I prefer enemies who need lungs for that.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c6m2-outro-1",
+          "speakerId": "fen-warden-isa",
+          "speakerName": "Warden Isa",
+          "text": "Choir quiet. The marsh sounds like weather again, which is all I ever asked of it.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c6m2-break-beacons",
+          "description": "Break the cinder choir beacons",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 2
+        },
+        {
+          "id": "c6m2-hold-marsh",
+          "description": "Hold the marsh crossing while the command echoes fade",
+          "kind": "hold",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 86, "resources": { "gold": 1480, "wood": 34, "ore": 64 } }
+    },
+    {
+      "id": "chapter6-stormvault-breach",
+      "chapterId": "chapter6",
+      "order": 37,
+      "mapId": "frostwatch-ridge",
+      "name": "Stormvault Breach",
+      "description": "Breach the vault ridge where the court stored storm engines capable of turning any ceasefire back into siege weather.",
+      "recommendedHeroLevel": 35,
+      "enemyArmyTemplateId": "wild_hawk_rider",
+      "enemyArmyCount": 84,
+      "enemyStatMultiplier": 6.5,
+      "unlockMissionId": "chapter6-choir-of-cinders",
+      "introDialogue": [
+        {
+          "id": "c6m3-intro-1",
+          "speakerId": "engineer-toma",
+          "speakerName": "Engineer Toma",
+          "text": "Those vault doors are mountain-grade. The only thing worse than opening them is letting the wrong people keep the keys.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c6m3-outro-1",
+          "speakerId": "engineer-toma",
+          "speakerName": "Engineer Toma",
+          "text": "Storm engines disabled. The sky can complain on its own time now.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c6m3-open-vault",
+          "description": "Open the stormvault breach",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c6m3-clear-ridge",
+          "description": "Clear the ridge riders covering the vault",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 88, "resources": { "gold": 1520, "ore": 66 } }
+    },
+    {
+      "id": "chapter6-dawnless-ford",
+      "chapterId": "chapter6",
+      "order": 38,
+      "mapId": "contested-basin",
+      "name": "Dawnless Ford",
+      "description": "Cross the blackwater ford into the sealed interior while the archive guard tries to drown the frontier's final witnesses.",
+      "recommendedHeroLevel": 36,
+      "enemyArmyTemplateId": "wild_serpent",
+      "enemyArmyCount": 86,
+      "enemyStatMultiplier": 6.66,
+      "unlockMissionId": "chapter6-stormvault-breach",
+      "introDialogue": [
+        {
+          "id": "c6m4-intro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "No sun reaches this ford. I assume that is policy, not weather.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c6m4-outro-1",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "Ford taken. If the archivists wanted anonymity, they picked the wrong river to defend it.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c6m4-escort-column",
+          "description": "Escort the witness column across the ford",
+          "kind": "escort",
+          "gate": "start"
+        },
+        {
+          "id": "c6m4-break-dams",
+          "description": "Break the flood dams feeding the crossing",
+          "kind": "secure",
+          "gate": "mid",
+          "targetCount": 2
+        }
+      ],
+      "reward": { "gems": 90, "resources": { "gold": 1560, "wood": 22, "ore": 68 } }
+    },
+    {
+      "id": "chapter6-last-harbor",
+      "chapterId": "chapter6",
+      "order": 39,
+      "mapId": "murkveil-delta",
+      "name": "Last Harbor",
+      "description": "Take the final harbor where the archivists are preparing to flee with sealed witness rolls and command relics.",
+      "recommendedHeroLevel": 37,
+      "enemyArmyTemplateId": "crown_crossbowman",
+      "enemyArmyCount": 88,
+      "enemyStatMultiplier": 6.82,
+      "unlockMissionId": "chapter6-dawnless-ford",
+      "introDialogue": [
+        {
+          "id": "c6m5-intro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "Every war ends with a ship captain who thinks paperwork outruns consequences.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c6m5-outro-1",
+          "speakerId": "guildmaster-oren",
+          "speakerName": "Guildmaster Oren",
+          "text": "No ships left, no ledgers gone. Consequences remain faster than boats.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c6m5-take-quays",
+          "description": "Take the last harbor quays",
+          "kind": "secure",
+          "gate": "start",
+          "targetCount": 3
+        },
+        {
+          "id": "c6m5-sink-flight",
+          "description": "Sink the archivists' flight convoy",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 92, "resources": { "gold": 1600, "wood": 30, "ore": 70 } }
+    },
+    {
+      "id": "chapter6-new-banner",
+      "chapterId": "chapter6",
+      "order": 40,
+      "mapId": "stonewatch-fork",
+      "name": "New Banner",
+      "description": "Hold the liberated fork long enough to raise the frontier banner before the last archive legions can retake the road.",
+      "recommendedHeroLevel": 38,
+      "enemyArmyTemplateId": "crown_heavy_cavalry",
+      "enemyArmyCount": 90,
+      "enemyStatMultiplier": 6.98,
+      "unlockMissionId": "chapter6-last-harbor",
+      "introDialogue": [
+        {
+          "id": "c6m6-intro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Winning is not enough. People need to see what replaced the thing that hurt them.",
+          "mood": "grim"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c6m6-outro-1",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Banner raised. Now the last command source has to look at the future before it dies.",
+          "mood": "defiant"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c6m6-raise-banner",
+          "description": "Raise the new frontier banner",
+          "kind": "hold",
+          "gate": "start"
+        },
+        {
+          "id": "c6m6-break-legions",
+          "description": "Break the archive legions on the fork road",
+          "kind": "defeat",
+          "gate": "mid"
+        }
+      ],
+      "reward": { "gems": 94, "resources": { "gold": 1640, "ore": 72 } }
+    },
+    {
+      "id": "chapter6-blackgate-dawn",
+      "chapterId": "chapter6",
+      "order": 41,
+      "mapId": "frontier-basin",
+      "name": "Blackgate Dawn",
+      "description": "Defeat the hidden sovereign intelligence behind the court archives and end the system that kept rebuilding the war after every victory.",
+      "recommendedHeroLevel": 39,
+      "enemyArmyTemplateId": "shadow_death_knight",
+      "enemyArmyCount": 94,
+      "enemyStatMultiplier": 7.24,
+      "bossEncounterName": "The Hollow Sovereign",
+      "bossTemplateId": "boss-lich-king",
+      "unlockMissionId": "chapter6-new-banner",
+      "introDialogue": [
+        {
+          "id": "c6m7-intro-1",
+          "speakerId": "hollow-sovereign",
+          "speakerName": "The Hollow Sovereign",
+          "text": "You keep killing masks and calling it peace. I am the hand that taught the masks how to fit.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c6m7-intro-2",
+          "speakerId": "seer-elan",
+          "speakerName": "Seer Elan",
+          "text": "That voice is everywhere in the gate lattice. Break the source and the whole archive goes quiet.",
+          "mood": "urgent"
+        }
+      ],
+      "midDialogue": [
+        {
+          "id": "c6m7-mid-1",
+          "speakerId": "hollow-sovereign",
+          "speakerName": "The Hollow Sovereign",
+          "text": "Order survives because grief prefers instructions to freedom.",
+          "mood": "grim"
+        },
+        {
+          "id": "c6m7-mid-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "Then we leave them something harder than instructions. We leave them each other.",
+          "mood": "defiant"
+        },
+        {
+          "id": "c6m7-mid-3",
+          "speakerId": "warden-hale",
+          "speakerName": "Warden Hale",
+          "text": "Gate core is exposed. Finish this before the basin learns to close again.",
+          "mood": "urgent"
+        }
+      ],
+      "outroDialogue": [
+        {
+          "id": "c6m7-outro-1",
+          "speakerId": "narrator",
+          "speakerName": "Narrator",
+          "text": "The Blackgate lattice collapses into sunrise-colored dust, and the war's last hidden author finally loses the ability to speak.",
+          "mood": "hopeful"
+        },
+        {
+          "id": "c6m7-outro-2",
+          "speakerId": "marshal-lyra",
+          "speakerName": "Marshal Lyra",
+          "text": "This frontier no longer needs a court to explain itself. Let that be the first law of what comes next.",
+          "mood": "hopeful"
+        }
+      ],
+      "objectives": [
+        {
+          "id": "c6m7-break-blackgate",
+          "description": "Break the Blackgate command lattice",
+          "kind": "secure",
+          "gate": "start"
+        },
+        {
+          "id": "c6m7-survive-collapse",
+          "description": "Survive the collapsing archive defenses",
+          "kind": "hold",
+          "gate": "mid"
+        },
+        {
+          "id": "c6m7-defeat-sovereign",
+          "description": "Defeat the Hollow Sovereign",
+          "kind": "defeat",
+          "gate": "end"
+        }
+      ],
+      "reward": { "gems": 104, "resources": { "gold": 1800, "ore": 80 }, "cosmeticId": "border-dawnwatch-paragon" }
+    }
+  ]
+}

--- a/configs/cosmetics.json
+++ b/configs/cosmetics.json
@@ -129,6 +129,26 @@
       "price": 0,
       "unlockCondition": "campaign_reward",
       "previewAsset": "borders/veilfall-throne"
+    },
+    {
+      "id": "recolor-crownless-vanguard",
+      "name": "Crownless Vanguard Trim",
+      "category": "unit_recolor",
+      "rarity": "legendary",
+      "description": "A smoke-and-ember recolor awarded for ending the regency war behind the fallen throne.",
+      "price": 0,
+      "unlockCondition": "campaign_reward",
+      "previewAsset": "units/crownless-vanguard"
+    },
+    {
+      "id": "border-dawnwatch-paragon",
+      "name": "Dawnwatch Paragon Border",
+      "category": "profile_border",
+      "rarity": "legendary",
+      "description": "A sunrise-forged border granted to commanders who ended the Blackgate command lattice for good.",
+      "price": 0,
+      "unlockCondition": "campaign_reward",
+      "previewAsset": "borders/dawnwatch-paragon"
     }
   ]
 }


### PR DESCRIPTION
## Summary\n- expand campaign content for chapters 5 and 6 with branching nodes, scenes, and metadata\n- add richer objectives, encounters, rewards, and unlock flows for the new chapters\n- keep content aligned with existing campaign structures and progression pacing\n\nCloses #922