### PR TITLE
Harden fog-of-war filtering before network serialization

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/map-sync.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map-sync.ts
@@ -109,6 +109,34 @@ function tileIndex(width: number, x: number, y: number): number {
   return y * width + x;
 }
 
+function sanitizeTileForSync(tile: PlayerTileView): PlayerTileView {
+  if (tile.fog === "hidden") {
+    return {
+      position: tile.position,
+      fog: tile.fog,
+      terrain: "unknown",
+      walkable: false,
+      resource: undefined,
+      occupant: undefined,
+      building: undefined
+    };
+  }
+
+  if (tile.fog === "explored") {
+    return {
+      position: tile.position,
+      fog: tile.fog,
+      terrain: tile.terrain,
+      walkable: tile.walkable,
+      resource: undefined,
+      occupant: undefined,
+      building: tile.building
+    };
+  }
+
+  return tile;
+}
+
 function createPatchedTile(
   view: PlayerWorldViewPayload | PlayerWorldView,
   bounds: EncodedPlayerMapBounds,
@@ -149,7 +177,7 @@ export function encodePlayerWorldView(
   let localIndex = 0;
   for (let y = bounds.y; y < bounds.y + bounds.height; y += 1) {
     for (let x = bounds.x; x < bounds.x + bounds.width; x += 1) {
-      const tile = view.map.tiles[tileIndex(view.map.width, x, y)]!;
+      const tile = sanitizeTileForSync(view.map.tiles[tileIndex(view.map.width, x, y)]!);
       terrain[localIndex] = TERRAIN_CODES[tile.terrain];
       fog[localIndex] = FOG_CODES[tile.fog];
       walkable[localIndex] = tile.walkable ? 1 : 0;

--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { ResourceLedger, WorldState } from "../../../packages/shared/src/index";
+import type { ResourceLedger, ServerMessage, WorldState } from "../../../packages/shared/src/index";
 import type { PlayerReportResolveInput, PlayerReportStatus, RoomSnapshotStore } from "./persistence";
 import { listLobbyRooms, getActiveRoomInstances } from "./colyseus-room";
 
@@ -318,6 +318,17 @@ export function registerAdminRoutes(
 
       for (const [roomId, vRoom] of activeRooms) {
         if (vRoom.worldRoom) {
+          const roomInternals = vRoom as unknown as {
+            getPlayerId(client: { sessionId?: string }, fallback?: string): string | undefined;
+            buildStatePayload(
+              playerId: string,
+              extras?: {
+                events?: Array<{ type: "system.announcement"; text: string; tone: "system" }>;
+                movementPlan?: null;
+                reason?: string;
+              }
+            ): ServerMessage extends { type: "session.state"; payload: infer T } ? T : never;
+          };
           const internalState = vRoom.worldRoom.getInternalState() as WorldState & {
             playerResources?: Record<string, ResourceLedger>;
           };
@@ -336,15 +347,14 @@ export function registerAdminRoutes(
           snapshot.state.resources = { ...nextResources };
 
           for (const client of vRoom.clients) {
+            const clientPlayerId = roomInternals.getPlayerId(client, playerId) ?? playerId;
             client.send("session.state", {
+              requestId: "push",
               delivery: "push",
-              payload: {
-                world: snapshot.state,
-                battle: null,
+              payload: roomInternals.buildStatePayload(clientPlayerId, {
                 events: [{ type: "system.announcement", text: "资源已更新", tone: "system" }],
-                movementPlan: null,
-                reachableTiles: []
-              }
+                movementPlan: null
+              })
             });
           }
 

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -437,8 +437,31 @@ test("POST /api/admin/players/:id/resources adds and clamps resources and syncs 
     battle: { turn: 1 }
   };
   const sentMessages: Array<{ type: string; payload: unknown }> = [];
+  const buildStatePayloadCalls: string[] = [];
 
   getActiveRoomInstances().set("room-alpha", {
+    getPlayerId(client: { sessionId?: string }) {
+      return client.sessionId === "session-player-2" ? "player-2" : "player-1";
+    },
+    buildStatePayload(playerId: string) {
+      buildStatePayloadCalls.push(playerId);
+      return {
+        world: {
+          playerId,
+          resources: { gold: 0, wood: 7, ore: 3 }
+        },
+        battle: null,
+        events: [{ type: "system.announcement", text: "资源已更新", tone: "system" }],
+        movementPlan: null,
+        reachableTiles: [],
+        featureFlags: {
+          quest_system_enabled: false,
+          battle_pass_enabled: false,
+          pve_enabled: true,
+          tutorial_enabled: false
+        }
+      };
+    },
     worldRoom: {
       getInternalState() {
         return internalState;
@@ -450,6 +473,13 @@ test("POST /api/admin/players/:id/resources adds and clamps resources and syncs 
     },
     clients: [
       {
+        sessionId: "session-player-1",
+        send(type: string, payload: unknown) {
+          sentMessages.push({ type, payload });
+        }
+      },
+      {
+        sessionId: "session-player-2",
         send(type: string, payload: unknown) {
           sentMessages.push({ type, payload });
         }
@@ -485,7 +515,8 @@ test("POST /api/admin/players/:id/resources adds and clamps resources and syncs 
   assert.deepEqual(internalState.resources["player-1"], { gold: 0, wood: 7, ore: 3 });
   assert.deepEqual(internalState.playerResources["player-1"], { gold: 0, wood: 7, ore: 3 });
   assert.deepEqual(snapshot.state.resources, { gold: 0, wood: 7, ore: 3 });
-  assert.equal(sentMessages.length, 1);
+  assert.deepEqual(buildStatePayloadCalls, ["player-1", "player-2"]);
+  assert.equal(sentMessages.length, 2);
   assert.equal(sentMessages[0]?.type, "session.state");
 });
 
@@ -643,7 +674,7 @@ test("POST /api/admin/players/:id/ban bans the player and POST /unban clears it"
       },
       body: JSON.stringify({
         banStatus: "temporary",
-        banExpiry: "2026-04-05T00:00:00.000Z",
+        banExpiry: "2026-05-05T00:00:00.000Z",
         banReason: "Chargeback abuse"
       })
     }),
@@ -658,7 +689,7 @@ test("POST /api/admin/players/:id/ban bans the player and POST /unban clears it"
   };
   assert.equal(banPayload.ok, true);
   assert.equal(banPayload.account.banStatus, "temporary");
-  assert.equal(banPayload.account.banExpiry, "2026-04-05T00:00:00.000Z");
+  assert.equal(banPayload.account.banExpiry, "2026-05-05T00:00:00.000Z");
   assert.equal(banPayload.account.banReason, "Chargeback abuse");
   assert.equal(banPayload.disconnectedClients, 0);
 

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { ClientState, matchMaker } from "colyseus";
 import type { Client } from "colyseus";
-import { applyEloMatchResult } from "../../../packages/shared/src/index";
+import { applyEloMatchResult, decodePlayerWorldView } from "../../../packages/shared/src/index";
 import type { BattleState, ServerMessage, WorldEvent } from "../../../packages/shared/src/index";
 import { resolveBattlePassConfig } from "../src/battle-pass";
 import {
@@ -334,6 +334,41 @@ test("room creation and connect reflect one connected player in room state", asy
 
   assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 1);
   assert.equal(lastSessionState(client, "reply").payload.world.ownHeroes[0]?.playerId, "player-1");
+});
+
+test("session.state redacts fog-hidden enemy occupants from serialized player snapshots", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-fog-redaction-${Date.now()}`);
+  const attackerClient = createFakeClient("session-fog-player-1");
+  const defenderClient = createFakeClient("session-fog-player-2");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, attackerClient, "player-1", "connect-player-1");
+  await connectPlayer(room, defenderClient, "player-2", "connect-player-2");
+
+  const attackerWorld = decodePlayerWorldView(lastSessionState(attackerClient, "reply").payload.world);
+  const defenderWorld = decodePlayerWorldView(lastSessionState(defenderClient, "reply").payload.world);
+  const defenderPosition = defenderWorld.ownHeroes[0]?.position;
+
+  assert.ok(defenderPosition, "expected player-2 own hero position");
+  const hiddenTile = attackerWorld.map.tiles.find(
+    (tile) => tile.position.x === defenderPosition.x && tile.position.y === defenderPosition.y
+  );
+
+  assert.ok(hiddenTile, "expected player-1 snapshot tile for player-2 position");
+  assert.equal(hiddenTile.fog, "hidden");
+  assert.equal(hiddenTile.terrain, "unknown");
+  assert.equal(hiddenTile.walkable, false);
+  assert.equal(hiddenTile.occupant, undefined);
+  assert.equal(hiddenTile.resource, undefined);
+  assert.equal(hiddenTile.building, undefined);
+  assert.equal(attackerWorld.visibleHeroes.some((hero) => hero.playerId === "player-2"), false);
 });
 
 test("persisted room bootstrap rebinds the default slot to the joining player and hydrates the saved state", async (t) => {

--- a/docs/runtime-contract-cocos-h5.md
+++ b/docs/runtime-contract-cocos-h5.md
@@ -37,6 +37,13 @@ Use these rules when deciding where new work belongs:
 - Any fix that only "works in H5" while leaving the primary Cocos runtime broken.
 - Any release checklist that treats H5 success as proof that the shipped client is ready.
 
+### Authoritative fog-of-war rule
+
+- `session.state` and any other room-driven world snapshot must be redacted on the server before network serialization, not just hidden by client rendering.
+- Hidden fog tiles must serialize as `terrain: "unknown"`, `walkable: false`, and no `resource`, `occupant`, or `building` payload.
+- Explored fog tiles may keep terrain/building memory, but they must not serialize live `resource` or `occupant` data.
+- H5 and Cocos should both treat these payloads as already-authoritative; client code may further hide presentation details, but it must not rely on the UI layer as the anti-cheat boundary.
+
 ## Journey Split
 
 Treat the following journeys as the default routing guide.

--- a/packages/shared/src/map-sync.ts
+++ b/packages/shared/src/map-sync.ts
@@ -109,6 +109,34 @@ function tileIndex(width: number, x: number, y: number): number {
   return y * width + x;
 }
 
+function sanitizeTileForSync(tile: PlayerTileView): PlayerTileView {
+  if (tile.fog === "hidden") {
+    return {
+      position: tile.position,
+      fog: tile.fog,
+      terrain: "unknown",
+      walkable: false,
+      resource: undefined,
+      occupant: undefined,
+      building: undefined
+    };
+  }
+
+  if (tile.fog === "explored") {
+    return {
+      position: tile.position,
+      fog: tile.fog,
+      terrain: tile.terrain,
+      walkable: tile.walkable,
+      resource: undefined,
+      occupant: undefined,
+      building: tile.building
+    };
+  }
+
+  return tile;
+}
+
 function createPatchedTile(
   view: PlayerWorldViewPayload | PlayerWorldView,
   bounds: EncodedPlayerMapBounds,
@@ -149,7 +177,7 @@ export function encodePlayerWorldView(
   let localIndex = 0;
   for (let y = bounds.y; y < bounds.y + bounds.height; y += 1) {
     for (let x = bounds.x; x < bounds.x + bounds.width; x += 1) {
-      const tile = view.map.tiles[tileIndex(view.map.width, x, y)]!;
+      const tile = sanitizeTileForSync(view.map.tiles[tileIndex(view.map.width, x, y)]!);
       terrain[localIndex] = TERRAIN_CODES[tile.terrain];
       fog[localIndex] = FOG_CODES[tile.fog];
       walkable[localIndex] = tile.walkable ? 1 : 0;

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -318,6 +318,58 @@ test("typed-array world map payload can emit Uint8Array grids for Colyseus trans
   assert.deepEqual(decodePlayerWorldView(encoded), view);
 });
 
+test("typed-array world map payload redacts hidden and explored overlays before serialization", () => {
+  const view = createLargePlayerWorldView();
+  const hiddenIndex = view.map.tiles.findIndex((tile) => tile.fog === "hidden");
+  const exploredIndex = view.map.tiles.findIndex((tile) => tile.fog === "explored");
+
+  assert.ok(hiddenIndex >= 0);
+  assert.ok(exploredIndex >= 0);
+
+  view.map.tiles[hiddenIndex] = {
+    ...view.map.tiles[hiddenIndex]!,
+    terrain: "grass",
+    walkable: true,
+    resource: { kind: "gold", amount: 500 },
+    occupant: { kind: "hero", refId: "hero-2" },
+    building: {
+      id: "watchtower-hidden",
+      kind: "watchtower",
+      label: "Hidden Watchtower"
+    }
+  };
+  view.map.tiles[exploredIndex] = {
+    ...view.map.tiles[exploredIndex]!,
+    resource: { kind: "wood", amount: 5 },
+    occupant: { kind: "neutral", refId: "neutral-1" },
+    building: {
+      id: "watchtower-explored",
+      kind: "watchtower",
+      label: "Explored Watchtower"
+    }
+  };
+
+  const decoded = decodePlayerWorldView(encodePlayerWorldView(view));
+  const hiddenTile = decoded.map.tiles[hiddenIndex]!;
+  const exploredTile = decoded.map.tiles[exploredIndex]!;
+
+  assert.equal(hiddenTile.fog, "hidden");
+  assert.equal(hiddenTile.terrain, "unknown");
+  assert.equal(hiddenTile.walkable, false);
+  assert.equal(hiddenTile.resource, undefined);
+  assert.equal(hiddenTile.occupant, undefined);
+  assert.equal(hiddenTile.building, undefined);
+
+  assert.equal(exploredTile.fog, "explored");
+  assert.equal(exploredTile.resource, undefined);
+  assert.equal(exploredTile.occupant, undefined);
+  assert.deepEqual(exploredTile.building, {
+    id: "watchtower-explored",
+    kind: "watchtower",
+    label: "Explored Watchtower"
+  });
+});
+
 test("asset config passes schema validation", () => {
   assert.deepEqual(getAssetConfigValidationErrors(assetConfig), []);
 });


### PR DESCRIPTION
## Summary
- harden typed-array world serialization so hidden and explored fog tiles cannot leak live occupants/resources during network sync
- cover the Colyseus `session.state` path with a regression test proving player A cannot read player B from hidden fog
- route admin resource sync pushes through per-client room payload building and document the server-side fog redaction contract

## Validation
- node --import tsx --test ./packages/shared/test/shared-core.test.ts
- node --import tsx --test ./apps/server/test/colyseus-room-lifecycle.test.ts
- node --import tsx --test ./apps/server/test/admin-console.test.ts
- npm run typecheck:server
- npm run typecheck:shared
- npm run typecheck:cocos

closes #981