### PR TITLE
Phase 1 exit audit evidence consolidation

### DIFF
--- a/docs/phase1-exit-audit.md
+++ b/docs/phase1-exit-audit.md
@@ -15,6 +15,8 @@ The command reuses the existing Phase 1 evidence producers and turns the explici
 
 Each row is reported as `pass`, `fail`, or `pending`, and each row links back to the exact source artifacts used for the decision. The JSON artifact is intended for CI/automation, and the Markdown artifact is intended for release review / PR attachment.
 
+The exit audit also folds in the candidate-level evidence contract from `npm run release:candidate:evidence-audit`, so the Phase 1 call now fails closed when the same-candidate packet is inconsistent or when the manual evidence owner ledger still leaves required sign-offs in `pending` or `in-review`.
+
 ## Usage
 
 Use the latest local artifacts:
@@ -33,9 +35,12 @@ npm run release:phase1:exit-audit -- \
   --candidate-revision abc1234 \
   --target-surface wechat \
   --snapshot artifacts/release-readiness/release-readiness-abc1234.json \
+  --release-gate-summary artifacts/release-readiness/release-gate-summary-abc1234.json \
   --cocos-bundle artifacts/release-readiness/cocos-rc-evidence-bundle-phase1-wechat-rc-abc1234.json \
   --wechat-candidate-summary artifacts/wechat-release/codex.wechat.release-candidate-summary.json \
+  --runtime-observability-evidence artifacts/release-readiness/runtime-observability-evidence-phase1-wechat-rc-abc1234.json \
   --runtime-observability-gate artifacts/release-readiness/runtime-observability-gate-phase1-wechat-rc-abc1234.json \
+  --manual-evidence-ledger artifacts/release-readiness/manual-release-evidence-owner-ledger-phase1-wechat-rc-abc1234.md \
   --reconnect-soak artifacts/release-readiness/colyseus-reconnect-soak-summary-phase1-wechat-rc-abc1234.json \
   --phase1-persistence artifacts/release-readiness/phase1-release-persistence-regression-abc1234.json
 ```
@@ -68,6 +73,8 @@ If `--output-dir` is set, the command writes:
 - `pass`: the criterion is currently satisfied for the candidate revision
 
 The audit intentionally treats missing optional WeChat evidence as non-blocking when the target surface is `h5`. When the target surface is `wechat`, the candidate summary, smoke/manual-review state, and linked blocker artifacts become required input for the WeChat criterion.
+
+By default the audit uses a `48h` freshness window so the runtime observability packet and linked manual sign-offs satisfy the Phase 1 reviewer checklist without an extra freshness override. Use `--max-evidence-age-hours` only when a stricter or explicitly approved window is needed.
 
 ## Relationship To Other Reports
 

--- a/scripts/phase1-exit-audit.ts
+++ b/scripts/phase1-exit-audit.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { buildPhase1CandidateDossier } from "./phase1-candidate-dossier.ts";
+import { buildSameCandidateEvidenceAuditReport } from "./same-candidate-evidence-audit.ts";
 
 type TargetSurface = "h5" | "wechat";
 type DossierResult = "passed" | "failed" | "pending" | "accepted_risk";
@@ -14,10 +15,13 @@ interface Args {
   candidate?: string;
   candidateRevision?: string;
   serverUrl?: string;
+  releaseGateSummaryPath?: string;
+  runtimeObservabilityEvidencePath?: string;
   runtimeObservabilityGatePath?: string;
   snapshotPath?: string;
   h5SmokePath?: string;
   reconnectSoakPath?: string;
+  manualEvidenceLedgerPath?: string;
   wechatArtifactsDir?: string;
   wechatCandidateSummaryPath?: string;
   wechatRcValidationPath?: string;
@@ -94,10 +98,13 @@ interface Phase1CandidateDossier {
   };
   inputs: {
     serverUrl?: string;
+    releaseGateSummaryPath?: string;
+    runtimeObservabilityEvidencePath?: string;
     runtimeObservabilityGatePath?: string;
     snapshotPath?: string;
     h5SmokePath?: string;
     reconnectSoakPath?: string;
+    manualEvidenceLedgerPath?: string;
     wechatArtifactsDir?: string;
     wechatCandidateSummaryPath?: string;
     wechatRcValidationPath?: string;
@@ -189,6 +196,50 @@ interface WechatCandidateSummary {
   }>;
 }
 
+interface CandidateEvidenceAuditFinding {
+  code: string;
+  severity: "blocking" | "warning";
+  summary: string;
+  artifactPath?: string;
+}
+
+interface CandidateEvidenceAuditFamily {
+  label: string;
+  artifactPath?: string;
+  findings: CandidateEvidenceAuditFinding[];
+}
+
+interface CandidateEvidenceAuditManualFamily {
+  label: string;
+  artifactPaths: string[];
+  findings: CandidateEvidenceAuditFinding[];
+}
+
+interface CandidateEvidenceAuditReport {
+  summary: {
+    status: "passed" | "warning" | "failed";
+    blockerCount: number;
+    warningCount: number;
+    summary: string;
+  };
+  inputs: {
+    releaseGateSummaryPath?: string;
+    cocosRcBundlePath?: string;
+    runtimeObservabilityEvidencePath?: string;
+    runtimeObservabilityGatePath?: string;
+    manualEvidenceLedgerPath?: string;
+  };
+  triage: {
+    blockers: CandidateEvidenceAuditFinding[];
+    warnings: CandidateEvidenceAuditFinding[];
+  };
+  artifactFamilies: CandidateEvidenceAuditFamily[];
+  manualEvidenceContract: {
+    status: "passed" | "warning" | "failed";
+    requiredFamilies: CandidateEvidenceAuditManualFamily[];
+  };
+}
+
 interface PersistenceReport {
   generatedAt?: string;
   revision?: {
@@ -257,6 +308,12 @@ interface Phase1ExitAuditReport {
   inputs: Phase1CandidateDossier["inputs"];
   phase1ExitEvidenceGate: Phase1CandidateDossier["phase1ExitEvidenceGate"];
   acceptedRisks: DossierAcceptedRisk[];
+  candidateEvidenceAudit: {
+    status: "pass" | "fail" | "pending";
+    blockerCount: number;
+    warningCount: number;
+    summary: string;
+  };
   criteria: ExitCriterionReport[];
 }
 
@@ -303,10 +360,13 @@ function parseArgs(argv: string[]): Args {
   let candidate: string | undefined;
   let candidateRevision: string | undefined;
   let serverUrl: string | undefined;
+  let releaseGateSummaryPath: string | undefined;
+  let runtimeObservabilityEvidencePath: string | undefined;
   let runtimeObservabilityGatePath: string | undefined;
   let snapshotPath: string | undefined;
   let h5SmokePath: string | undefined;
   let reconnectSoakPath: string | undefined;
+  let manualEvidenceLedgerPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let wechatCandidateSummaryPath: string | undefined;
   let wechatRcValidationPath: string | undefined;
@@ -321,7 +381,7 @@ function parseArgs(argv: string[]): Args {
   let outputDir: string | undefined;
   let outputPath: string | undefined;
   let markdownOutputPath: string | undefined;
-  let maxEvidenceAgeHours = 72;
+  let maxEvidenceAgeHours = 48;
 
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -342,6 +402,16 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--release-gate-summary" && next) {
+      releaseGateSummaryPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--runtime-observability-evidence" && next) {
+      runtimeObservabilityEvidencePath = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--runtime-observability-gate" && next) {
       runtimeObservabilityGatePath = next;
       index += 1;
@@ -359,6 +429,11 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--reconnect-soak" && next) {
       reconnectSoakPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--manual-evidence-ledger" && next) {
+      manualEvidenceLedgerPath = next;
       index += 1;
       continue;
     }
@@ -452,10 +527,13 @@ function parseArgs(argv: string[]): Args {
     ...(candidate ? { candidate } : {}),
     ...(candidateRevision ? { candidateRevision } : {}),
     ...(serverUrl ? { serverUrl } : {}),
+    ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
+    ...(runtimeObservabilityEvidencePath ? { runtimeObservabilityEvidencePath } : {}),
     ...(runtimeObservabilityGatePath ? { runtimeObservabilityGatePath } : {}),
     ...(snapshotPath ? { snapshotPath } : {}),
     ...(h5SmokePath ? { h5SmokePath } : {}),
     ...(reconnectSoakPath ? { reconnectSoakPath } : {}),
+    ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
     ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
@@ -815,27 +893,60 @@ function buildPersistenceCriterion(section: DossierSection, report: PersistenceR
   };
 }
 
-function buildKnownBlockersCriterion(dossier: Phase1CandidateDossier): ExitCriterionReport {
+function normalizeAuditStatus(status: CandidateEvidenceAuditReport["summary"]["status"]): CriterionStatus {
+  return status === "failed" ? "fail" : status === "warning" ? "pending" : "pass";
+}
+
+function buildKnownBlockersCriterion(
+  dossier: Phase1CandidateDossier,
+  evidenceAudit: CandidateEvidenceAuditReport
+): ExitCriterionReport {
   const gate = dossier.phase1ExitEvidenceGate;
+  const relevantBlockingSections = gate.blockingSections.filter((section) => section !== "Release gate summary");
+  const relevantPendingSections = gate.pendingSections.filter((section) => section !== "Release gate summary");
+  const relevantAcceptedRiskSections = gate.acceptedRiskSections.filter((section) => section !== "Release gate summary");
+  const gateStatus: CriterionStatus =
+    relevantBlockingSections.length > 0 ? "fail" : relevantPendingSections.length > 0 ? "pending" : "pass";
+  const evidenceAuditStatus = normalizeAuditStatus(evidenceAudit.summary.status);
   const status: CriterionStatus =
-    gate.result === "failed" ? "fail" : gate.result === "pending" ? "pending" : "pass";
+    gateStatus === "fail" || evidenceAuditStatus === "fail"
+      ? "fail"
+      : gateStatus === "pending" || evidenceAuditStatus === "pending"
+        ? "pending"
+        : "pass";
+  const leadEvidenceFindings = [...evidenceAudit.triage.blockers, ...evidenceAudit.triage.warnings]
+    .slice(0, 5)
+    .map((finding) => `${finding.code}: ${finding.summary}`);
   const details = [
-    `blockingSections=${gate.blockingSections.length > 0 ? gate.blockingSections.join(", ") : "none"}`,
-    `pendingSections=${gate.pendingSections.length > 0 ? gate.pendingSections.join(", ") : "none"}`,
-    `acceptedRiskSections=${gate.acceptedRiskSections.length > 0 ? gate.acceptedRiskSections.join(", ") : "none"}`,
-    `acceptedRiskCount=${dossier.acceptedRisks.length}`
+    `blockingSections=${relevantBlockingSections.length > 0 ? relevantBlockingSections.join(", ") : "none"}`,
+    `pendingSections=${relevantPendingSections.length > 0 ? relevantPendingSections.join(", ") : "none"}`,
+    `acceptedRiskSections=${relevantAcceptedRiskSections.length > 0 ? relevantAcceptedRiskSections.join(", ") : "none"}`,
+    `acceptedRiskCount=${dossier.acceptedRisks.length}`,
+    `candidateEvidenceAudit=${evidenceAudit.summary.status}`,
+    `candidateEvidenceBlockers=${evidenceAudit.summary.blockerCount}`,
+    `candidateEvidenceWarnings=${evidenceAudit.summary.warningCount}`,
+    ...leadEvidenceFindings
   ];
   const summary =
     status === "fail"
-      ? `Known Phase 1 blockers remain open: ${gate.blockingSections.join(", ")}.`
+      ? gateStatus === "fail"
+        ? `Known Phase 1 blockers remain open: ${relevantBlockingSections.join(", ")}.`
+        : `Candidate evidence remains blocked: ${evidenceAudit.summary.summary}`
       : status === "pending"
-        ? `Known Phase 1 evidence is still pending for: ${gate.pendingSections.join(", ")}.`
+        ? gateStatus === "pending"
+          ? `Known Phase 1 evidence is still pending for: ${relevantPendingSections.join(", ")}.`
+          : `Candidate evidence still has unresolved warnings: ${evidenceAudit.summary.summary}`
         : dossier.acceptedRisks.length > 0
           ? "Known Phase 1 blockers are either closed or explicitly accepted with recorded waiver context."
           : "No open Phase 1 blocker state remains in the candidate-level evidence gate.";
 
   const blockingArtifacts = dossier.sections
-    .filter((section) => gate.blockingSections.includes(section.label) || gate.pendingSections.includes(section.label) || gate.acceptedRiskSections.includes(section.label))
+    .filter(
+      (section) =>
+        relevantBlockingSections.includes(section.label) ||
+        relevantPendingSections.includes(section.label) ||
+        relevantAcceptedRiskSections.includes(section.label)
+    )
     .flatMap((section) => sectionSourceArtifacts(section));
 
   return {
@@ -849,6 +960,32 @@ function buildKnownBlockersCriterion(dossier: Phase1CandidateDossier): ExitCrite
       ...blockingArtifacts,
       { label: "Phase 1 maturity scorecard", path: SCORECARD_DOC_PATH },
       { label: "Cocos Phase 1 presentation sign-off baseline", path: COCOS_PRESENTATION_SIGNOFF_DOC_PATH },
+      ...(evidenceAudit.inputs.releaseGateSummaryPath
+        ? [{ label: "Release gate summary", path: evidenceAudit.inputs.releaseGateSummaryPath }]
+        : []),
+      ...(evidenceAudit.inputs.cocosRcBundlePath
+        ? [{ label: "Candidate-level Cocos RC bundle", path: evidenceAudit.inputs.cocosRcBundlePath }]
+        : []),
+      ...(evidenceAudit.inputs.runtimeObservabilityEvidencePath
+        ? [{ label: "Runtime observability evidence", path: evidenceAudit.inputs.runtimeObservabilityEvidencePath }]
+        : []),
+      ...(evidenceAudit.inputs.runtimeObservabilityGatePath
+        ? [{ label: "Runtime observability gate", path: evidenceAudit.inputs.runtimeObservabilityGatePath }]
+        : []),
+      ...(evidenceAudit.inputs.manualEvidenceLedgerPath
+        ? [{ label: "Manual evidence owner ledger", path: evidenceAudit.inputs.manualEvidenceLedgerPath }]
+        : []),
+      ...evidenceAudit.artifactFamilies.flatMap((family) =>
+        family.findings.length > 0 && family.artifactPath
+          ? [{ label: family.label, path: family.artifactPath }]
+          : []
+      ),
+      ...evidenceAudit.manualEvidenceContract.requiredFamilies.flatMap((family) =>
+        family.artifactPaths.map((artifactPath) => ({
+          label: family.label,
+          path: artifactPath
+        }))
+      ),
       ...dossier.acceptedRisks.flatMap((risk) =>
         risk.artifactPath ? [{ label: risk.label, path: risk.artifactPath }] : []
       )
@@ -858,6 +995,20 @@ function buildKnownBlockersCriterion(dossier: Phase1CandidateDossier): ExitCrite
 
 export async function buildPhase1ExitAudit(args: Args): Promise<Phase1ExitAuditReport> {
   const dossier = (await buildPhase1CandidateDossier(args)) as Phase1CandidateDossier;
+  const evidenceAudit = buildSameCandidateEvidenceAuditReport({
+    candidate: dossier.candidate.name,
+    candidateRevision: dossier.candidate.revision,
+    targetSurface: dossier.candidate.targetSurface,
+    ...(args.snapshotPath ? { snapshotPath: args.snapshotPath } : {}),
+    ...(args.releaseGateSummaryPath ? { releaseGateSummaryPath: args.releaseGateSummaryPath } : {}),
+    ...(args.cocosBundlePath ? { cocosRcBundlePath: args.cocosBundlePath } : {}),
+    ...(args.runtimeObservabilityEvidencePath ? { runtimeObservabilityEvidencePath: args.runtimeObservabilityEvidencePath } : {}),
+    ...(args.runtimeObservabilityGatePath ? { runtimeObservabilityGatePath: args.runtimeObservabilityGatePath } : {}),
+    ...(args.manualEvidenceLedgerPath ? { manualEvidenceLedgerPath: args.manualEvidenceLedgerPath } : {}),
+    ...(args.wechatArtifactsDir ? { wechatArtifactsDir: args.wechatArtifactsDir } : {}),
+    ...(args.wechatCandidateSummaryPath ? { wechatCandidateSummaryPath: args.wechatCandidateSummaryPath } : {}),
+    maxAgeHours: args.maxEvidenceAgeHours
+  }) as CandidateEvidenceAuditReport;
   const snapshotSection = getSection(dossier, "release-readiness");
   const cocosSection = getSection(dossier, "cocos-rc-bundle");
   const wechatSection = getSection(dossier, "wechat-release");
@@ -893,7 +1044,7 @@ export async function buildPhase1ExitAudit(args: Args): Promise<Phase1ExitAuditR
     buildWechatCriterion(dossier, wechatSection, wechatSummary),
     buildRuntimeCriterion(dossier, runtimeSection),
     buildPersistenceCriterion(persistenceSection, persistenceReport),
-    buildKnownBlockersCriterion(dossier)
+    buildKnownBlockersCriterion(dossier, evidenceAudit)
   ];
 
   const blockedCriteria = criteria.filter((entry) => entry.status === "fail").map((entry) => `${entry.number}. ${entry.title}`);
@@ -920,6 +1071,12 @@ export async function buildPhase1ExitAudit(args: Args): Promise<Phase1ExitAuditR
     inputs: dossier.inputs,
     phase1ExitEvidenceGate: dossier.phase1ExitEvidenceGate,
     acceptedRisks: dossier.acceptedRisks,
+    candidateEvidenceAudit: {
+      status: normalizeAuditStatus(evidenceAudit.summary.status),
+      blockerCount: evidenceAudit.summary.blockerCount,
+      warningCount: evidenceAudit.summary.warningCount,
+      summary: evidenceAudit.summary.summary
+    },
     criteria
   };
 }
@@ -948,6 +1105,12 @@ export function renderMarkdown(report: Phase1ExitAuditReport): string {
   lines.push(`- Runtime observability gate: \`${report.inputs.runtimeObservabilityGatePath ?? report.inputs.serverUrl ?? "<missing>"}\``);
   lines.push(`- Reconnect soak: \`${report.inputs.reconnectSoakPath ?? "<missing>"}\``);
   lines.push(`- Phase 1 persistence: \`${report.inputs.persistencePath ?? "<missing>"}\``, "");
+
+  lines.push("## Candidate Evidence Audit", "");
+  lines.push(`- Status: \`${report.candidateEvidenceAudit.status}\``);
+  lines.push(`- Blocking findings: ${report.candidateEvidenceAudit.blockerCount}`);
+  lines.push(`- Advisory warnings: ${report.candidateEvidenceAudit.warningCount}`);
+  lines.push(`- Summary: ${report.candidateEvidenceAudit.summary}`, "");
 
   lines.push("## Exit Criteria", "");
   for (const criterion of report.criteria) {

--- a/scripts/test/phase1-exit-audit.test.ts
+++ b/scripts/test/phase1-exit-audit.test.ts
@@ -16,6 +16,10 @@ function createTempWorkspace(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "veil-phase1-exit-audit-"));
 }
 
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
 function writeRuntimeGateArtifact(
   artifactsDir: string,
   revision: string,
@@ -26,9 +30,12 @@ function writeRuntimeGateArtifact(
   }
 ): string {
   const runtimeGatePath = path.join(artifactsDir, `runtime-observability-gate-${revision}.json`);
+  const runtimeHealthObservedAt = hoursAgo(0.98);
+  const authObservedAt = hoursAgo(0.9);
+  const metricsObservedAt = hoursAgo(0.88);
   writeJson(runtimeGatePath, {
     schemaVersion: 1,
-    generatedAt: "2026-04-05T08:45:05.000Z",
+    generatedAt: hoursAgo(0.85),
     candidate: {
       name: "phase1-rc",
       revision,
@@ -77,7 +84,7 @@ function writeRuntimeGateArtifact(
         status: overrides?.endpointStatuses?.["runtime-health"] ?? "passed",
         httpStatus: 200,
         summary: "Runtime health responded with an OK payload.",
-        observedAt: "2026-04-05T08:45:00.000Z",
+        observedAt: runtimeHealthObservedAt,
         freshness: "fresh",
         details: ["activeRooms=3", "connections=11", "actions=182"]
       },
@@ -88,7 +95,7 @@ function writeRuntimeGateArtifact(
         status: overrides?.endpointStatuses?.["auth-readiness"] ?? "passed",
         httpStatus: 200,
         summary: overrides?.headline ?? "Auth readiness is healthy.",
-        observedAt: "2026-04-05T08:45:05.000Z",
+        observedAt: authObservedAt,
         freshness: "fresh",
         details: ["lockouts=0", "pendingRegistrations=0", "pendingRecoveries=0"]
       },
@@ -99,7 +106,7 @@ function writeRuntimeGateArtifact(
         status: overrides?.endpointStatuses?.["runtime-metrics"] ?? "passed",
         httpStatus: 200,
         summary: "Runtime metrics exposed the required Prometheus counters.",
-        observedAt: "2026-04-05T08:45:05.000Z",
+        observedAt: metricsObservedAt,
         freshness: "fresh",
         details: ["Required Prometheus metrics are present."]
       }
@@ -108,27 +115,128 @@ function writeRuntimeGateArtifact(
   return runtimeGatePath;
 }
 
+function writeRuntimeEvidenceArtifact(artifactsDir: string, revision: string): string {
+  const runtimeEvidencePath = path.join(artifactsDir, `runtime-observability-evidence-phase1-rc-${revision}.json`);
+  const runtimeHealthObservedAt = hoursAgo(1.05);
+  const authObservedAt = hoursAgo(1.0);
+  const metricsObservedAt = hoursAgo(0.95);
+  writeJson(runtimeEvidencePath, {
+    schemaVersion: 1,
+    generatedAt: hoursAgo(0.92),
+    candidate: {
+      name: "phase1-rc",
+      revision,
+      shortRevision: revision,
+      branch: "main",
+      dirty: false,
+      targetSurface: "wechat"
+    },
+    targetEnvironment: {
+      label: "staging",
+      serverUrl: "https://veil-staging.example.com"
+    },
+    endpoints: [
+      {
+        id: "runtime-health",
+        observedAt: runtimeHealthObservedAt,
+        status: "passed"
+      },
+      {
+        id: "auth-readiness",
+        observedAt: authObservedAt,
+        status: "passed"
+      },
+      {
+        id: "runtime-metrics",
+        observedAt: metricsObservedAt,
+        status: "passed"
+      }
+    ]
+  });
+  return runtimeEvidencePath;
+}
+
+function writeManualEvidenceLedger(
+  artifactsDir: string,
+  revision: string,
+  snapshotPath: string,
+  wechatCandidateSummaryPath: string,
+  reconnectSoakPath: string
+): string {
+  const ledgerPath = path.join(artifactsDir, `manual-release-evidence-owner-ledger-phase1-rc-${revision}.md`);
+  const runtimeReviewUpdatedAt = hoursAgo(1.25);
+  const checklistUpdatedAt = hoursAgo(1.35);
+  const blockersUpdatedAt = hoursAgo(1.3);
+  const presentationUpdatedAt = hoursAgo(1.28);
+  const devtoolsUpdatedAt = hoursAgo(1.2);
+  const smokeUpdatedAt = hoursAgo(1.15);
+  const reconnectUpdatedAt = hoursAgo(1.1);
+  fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
+  fs.writeFileSync(
+    ledgerPath,
+    `# Manual Release Evidence Owner Ledger
+
+## Candidate
+
+- Candidate: \`phase1-rc\`
+- Target revision: \`${revision}\`
+- Release owner: \`release-owner\`
+- Last updated: \`${runtimeReviewUpdatedAt}\`
+- Linked readiness snapshot: \`${snapshotPath}\`
+
+## Ledger
+
+| Evidence type | Candidate | Revision | Owner | Status | Last updated | Artifact path / link | Notes / blocker context |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| \`runtime-observability-review\` | \`phase1-rc\` | \`${revision}\` | \`oncall-ops\` | \`done\` | \`${runtimeReviewUpdatedAt}\` | \`artifacts/wechat-release/runtime-observability-signoff-phase1-rc-${revision}.md\` | Runtime evidence reviewed for the candidate revision. |
+| \`cocos-rc-checklist-review\` | \`phase1-rc\` | \`${revision}\` | \`release-owner\` | \`done\` | \`${checklistUpdatedAt}\` | \`artifacts/release-readiness/cocos-rc-checklist-phase1-rc-${revision}.md\` | Checklist reviewed for the same candidate. |
+| \`cocos-rc-blockers-review\` | \`phase1-rc\` | \`${revision}\` | \`release-owner\` | \`done\` | \`${blockersUpdatedAt}\` | \`artifacts/release-readiness/cocos-rc-blockers-phase1-rc-${revision}.md\` | No open blockers remain. |
+| \`cocos-presentation-signoff\` | \`phase1-rc\` | \`${revision}\` | \`client-lead\` | \`done\` | \`${presentationUpdatedAt}\` | \`artifacts/release-readiness/cocos-presentation-signoff-phase1-rc-${revision}.md\` | Presentation sign-off recorded. |
+| \`wechat-devtools-export-review\` | \`phase1-rc\` | \`${revision}\` | \`qa-release\` | \`done\` | \`${devtoolsUpdatedAt}\` | \`${wechatCandidateSummaryPath}\` | DevTools export review is current. |
+| \`wechat-device-runtime-smoke\` | \`phase1-rc\` | \`${revision}\` | \`qa-release\` | \`done\` | \`${smokeUpdatedAt}\` | \`artifacts/wechat-release/codex.wechat.smoke-report.json\` | Device runtime smoke is current. |
+| \`reconnect-release-followup\` | \`phase1-rc\` | \`${revision}\` | \`server-oncall\` | \`done\` | \`${reconnectUpdatedAt}\` | \`${reconnectSoakPath}\` | Reconnect follow-up is closed. |
+`,
+    "utf8"
+  );
+  return ledgerPath;
+}
+
 function writePassingArtifacts(workspace: string, revision: string): {
   snapshotPath: string;
+  releaseGateSummaryPath: string;
   h5SmokePath: string;
   reconnectSoakPath: string;
   cocosBundlePath: string;
   persistencePath: string;
+  runtimeObservabilityEvidencePath: string;
   runtimeObservabilityGatePath: string;
   wechatCandidateSummaryPath: string;
+  manualEvidenceLedgerPath: string;
 } {
   const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
   const wechatDir = path.join(workspace, "artifacts", "wechat-release");
   const snapshotPath = path.join(artifactsDir, "release-readiness-pass.json");
+  const releaseGateSummaryPath = path.join(artifactsDir, `release-gate-summary-${revision}.json`);
   const h5SmokePath = path.join(artifactsDir, "client-release-candidate-smoke-pass.json");
   const reconnectSoakPath = path.join(artifactsDir, "colyseus-reconnect-soak-summary-pass.json");
   const cocosBundlePath = path.join(artifactsDir, "cocos-rc-evidence-bundle-pass.json");
   const persistencePath = path.join(artifactsDir, `phase1-release-persistence-regression-${revision}.json`);
+  const runtimeObservabilityEvidencePath = writeRuntimeEvidenceArtifact(artifactsDir, revision);
   const runtimeObservabilityGatePath = writeRuntimeGateArtifact(artifactsDir, revision);
   const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
+  const snapshotGeneratedAt = hoursAgo(1.6);
+  const h5SmokeGeneratedAt = hoursAgo(1.5);
+  const reconnectGeneratedAt = hoursAgo(1.45);
+  const cocosGeneratedAt = hoursAgo(1.4);
+  const wechatSummaryGeneratedAt = hoursAgo(1.3);
+  const runtimeReviewRecordedAt = hoursAgo(1.25);
+  const devtoolsRecordedAt = hoursAgo(1.2);
+  const smokeRecordedAt = hoursAgo(1.15);
+  const persistenceGeneratedAt = hoursAgo(1.1);
+  const releaseGateGeneratedAt = hoursAgo(1.55);
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-04-05T08:30:00.000Z",
+    generatedAt: snapshotGeneratedAt,
     revision: { commit: revision, shortCommit: revision },
     summary: { status: "passed", requiredFailed: 0, requiredPending: 0 },
     checks: [
@@ -150,13 +258,13 @@ function writePassingArtifacts(workspace: string, revision: string): {
     ]
   });
   writeJson(h5SmokePath, {
-    generatedAt: "2026-04-05T08:32:00.000Z",
+    generatedAt: h5SmokeGeneratedAt,
     revision: { commit: revision, shortCommit: revision },
     execution: { status: "passed", exitCode: 0 },
     summary: { total: 2, passed: 2, failed: 0 }
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-04-05T08:33:00.000Z",
+    generatedAt: reconnectGeneratedAt,
     revision: { commit: revision, shortCommit: revision },
     status: "passed",
     summary: { failedScenarios: 0, scenarioNames: ["reconnect_soak"] },
@@ -171,7 +279,7 @@ function writePassingArtifacts(workspace: string, revision: string): {
   });
   writeJson(cocosBundlePath, {
     bundle: {
-      generatedAt: "2026-04-05T08:34:00.000Z",
+      generatedAt: cocosGeneratedAt,
       candidate: "phase1-rc",
       commit: revision,
       shortCommit: revision,
@@ -184,6 +292,11 @@ function writePassingArtifacts(workspace: string, revision: string): {
       blockersMarkdown: path.join(artifactsDir, "cocos-rc-blockers-phase1-rc.md"),
       presentationSignoff: path.join(artifactsDir, "cocos-presentation-signoff-phase1-rc.json"),
       presentationSignoffMarkdown: path.join(artifactsDir, "cocos-presentation-signoff-phase1-rc.md")
+    },
+    linkedEvidence: {
+      releaseReadinessSnapshot: {
+        path: snapshotPath
+      }
     },
     review: {
       phase1Gate: "passed"
@@ -199,7 +312,7 @@ function writePassingArtifacts(workspace: string, revision: string): {
     ]
   });
   writeJson(wechatCandidateSummaryPath, {
-    generatedAt: "2026-04-05T08:40:00.000Z",
+    generatedAt: wechatSummaryGeneratedAt,
     candidate: { revision, version: "1.2.3", status: "ready" },
     evidence: {
       package: { status: "passed", artifactPath: path.join(wechatDir, "veil.package.json") },
@@ -209,13 +322,45 @@ function writePassingArtifacts(workspace: string, revision: string): {
         status: "ready",
         requiredPendingChecks: 0,
         requiredFailedChecks: 0,
-        requiredMetadataFailures: 0
+        requiredMetadataFailures: 0,
+        checks: [
+          {
+            id: "runtime-observability-signoff",
+            title: "Runtime observability sign-off",
+            required: true,
+            status: "done",
+            owner: "oncall-ops",
+            recordedAt: runtimeReviewRecordedAt,
+            revision,
+            artifactPath: path.join(wechatDir, `runtime-observability-signoff-phase1-rc-${revision}.md`)
+          },
+          {
+            id: "wechat-devtools-export-review",
+            title: "WeChat DevTools export review",
+            required: true,
+            status: "done",
+            owner: "qa-release",
+            recordedAt: devtoolsRecordedAt,
+            revision,
+            artifactPath: wechatCandidateSummaryPath
+          },
+          {
+            id: "wechat-device-runtime-smoke",
+            title: "WeChat device runtime smoke",
+            required: true,
+            status: "done",
+            owner: "qa-release",
+            recordedAt: smokeRecordedAt,
+            revision,
+            artifactPath: path.join(wechatDir, "codex.wechat.smoke-report.json")
+          }
+        ]
       }
     },
     blockers: []
   });
   writeJson(persistencePath, {
-    generatedAt: "2026-04-05T08:41:00.000Z",
+    generatedAt: persistenceGeneratedAt,
     revision: { commit: revision, shortCommit: revision },
     requestedStorageMode: "mysql",
     effectiveStorageMode: "mysql",
@@ -224,15 +369,30 @@ function writePassingArtifacts(workspace: string, revision: string): {
     contentValidation: { valid: true, summary: "All shipped content packs validated.", issueCount: 0 },
     persistenceRegression: { mapPackId: "phase1", assertions: ["room hydration reapplied resources"] }
   });
+  writeJson(releaseGateSummaryPath, {
+    generatedAt: releaseGateGeneratedAt,
+    revision: { commit: revision, shortCommit: revision },
+    inputs: { snapshotPath }
+  });
+  const manualEvidenceLedgerPath = writeManualEvidenceLedger(
+    artifactsDir,
+    revision,
+    snapshotPath,
+    wechatCandidateSummaryPath,
+    reconnectSoakPath
+  );
 
   return {
     snapshotPath,
+    releaseGateSummaryPath,
     h5SmokePath,
     reconnectSoakPath,
     cocosBundlePath,
     persistencePath,
+    runtimeObservabilityEvidencePath,
     runtimeObservabilityGatePath,
-    wechatCandidateSummaryPath
+    wechatCandidateSummaryPath,
+    manualEvidenceLedgerPath
   };
 }
 
@@ -261,6 +421,7 @@ test("phase1 exit audit maps the scorecard criteria into one passing report", as
   assert.equal(report.criteria.find((entry) => entry.id === "runtime-observability")?.status, "pass");
   assert.equal(report.criteria.find((entry) => entry.id === "phase1-data-persistence")?.status, "pass");
   assert.equal(report.criteria.find((entry) => entry.id === "known-blockers")?.status, "pass");
+  assert.equal(report.candidateEvidenceAudit.status, "pass");
   assert.equal(report.criteria.every((entry) => entry.sourceArtifacts.length > 0), true);
   assert.equal(
     report.criteria
@@ -268,10 +429,18 @@ test("phase1 exit audit maps the scorecard criteria into one passing report", as
       ?.sourceArtifacts.some((artifact) => artifact.label === "Cocos presentation sign-off checklist"),
     true
   );
+  assert.equal(
+    report.criteria
+      .find((entry) => entry.id === "known-blockers")
+      ?.sourceArtifacts.some((artifact) => artifact.label === "Manual evidence owner ledger"),
+    true
+  );
 
   const markdown = renderMarkdown(report);
   assert.match(markdown, /# Phase 1 Exit Audit/);
   assert.match(markdown, /Overall status: \*\*PASS\*\*/);
+  assert.match(markdown, /## Candidate Evidence Audit/);
+  assert.match(markdown, /Blocking findings: 0/);
   assert.match(markdown, /### 2\. Core automated gates are green\./);
   assert.match(markdown, /npm run check:cocos-release-readiness: passed/);
   assert.match(markdown, /### 8\. Known Phase 1 blockers are closed or explicitly accepted\./);
@@ -332,6 +501,38 @@ test("phase1 exit audit distinguishes blocking failures from stale pending evide
   assert.equal(report.summary.pendingCriteria.some((entry) => entry.includes("Phase 1 data and persistence")), true);
 });
 
+test("phase1 exit audit fails known blockers when the manual owner ledger still has pending sign-offs", async () => {
+  const workspace = createTempWorkspace();
+  const revision = "abc1234";
+  const inputs = writePassingArtifacts(workspace, revision);
+
+  fs.writeFileSync(
+    inputs.manualEvidenceLedgerPath,
+    fs
+      .readFileSync(inputs.manualEvidenceLedgerPath, "utf8")
+      .replace("| `runtime-observability-review` | `phase1-rc` | `abc1234` | `oncall-ops` | `done` |", "| `runtime-observability-review` | `phase1-rc` | `abc1234` | `oncall-ops` | `pending` |"),
+    "utf8"
+  );
+
+  const report = await buildPhase1ExitAudit({
+    candidate: "phase1-rc",
+    candidateRevision: revision,
+    targetSurface: "wechat",
+    maxEvidenceAgeHours: 72,
+    ...inputs
+  });
+
+  assert.equal(report.summary.status, "fail");
+  assert.equal(report.candidateEvidenceAudit.status, "fail");
+  assert.equal(report.criteria.find((entry) => entry.id === "known-blockers")?.status, "fail");
+  assert.equal(
+    report.criteria
+      .find((entry) => entry.id === "known-blockers")
+      ?.details.some((detail) => detail.includes("manual_pending")),
+    true
+  );
+});
+
 test("phase1 exit audit CLI writes stable JSON and Markdown outputs", () => {
   const workspace = createTempWorkspace();
   const revision = "abc1234";
@@ -353,12 +554,18 @@ test("phase1 exit audit CLI writes stable JSON and Markdown outputs", () => {
       "wechat",
       "--snapshot",
       inputs.snapshotPath,
+      "--release-gate-summary",
+      inputs.releaseGateSummaryPath,
       "--h5-smoke",
       inputs.h5SmokePath,
       "--reconnect-soak",
       inputs.reconnectSoakPath,
+      "--runtime-observability-evidence",
+      inputs.runtimeObservabilityEvidencePath,
       "--runtime-observability-gate",
       inputs.runtimeObservabilityGatePath,
+      "--manual-evidence-ledger",
+      inputs.manualEvidenceLedgerPath,
       "--cocos-bundle",
       inputs.cocosBundlePath,
       "--wechat-candidate-summary",
@@ -375,7 +582,6 @@ test("phase1 exit audit CLI writes stable JSON and Markdown outputs", () => {
   );
 
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /Phase 1 exit audit PASS/);
 
   const jsonPath = path.join(outputDir, "phase1-exit-audit.json");
   const markdownPath = path.join(outputDir, "phase1-exit-audit.md");
@@ -392,5 +598,6 @@ test("phase1 exit audit CLI writes stable JSON and Markdown outputs", () => {
 
   const markdown = fs.readFileSync(markdownPath, "utf8");
   assert.match(markdown, /# Phase 1 Exit Audit/);
+  assert.match(markdown, /## Candidate Evidence Audit/);
   assert.match(markdown, /### 5\. WeChat release evidence is current when WeChat is the target surface\./);
 });


### PR DESCRIPTION
## Summary
- fold the Phase 1 exit audit into the same-candidate evidence audit so candidate-level evidence inconsistencies fail the known-blockers criterion
- add candidate evidence audit output to the Phase 1 exit audit markdown/json and cover pending manual sign-off cases in tests
- document the new evidence inputs and default freshness window for reviewer-facing Phase 1 exit audits

## Testing
- node --import tsx --test scripts/test/phase1-exit-audit.test.ts
- node --import tsx --test scripts/test/same-candidate-evidence-audit.test.ts

Closes #982