### PR TITLE
[codex] Wire action-precheck validation gate before state mutation

### DIFF
--- a/apps/client/src/local-session.ts
+++ b/apps/client/src/local-session.ts
@@ -8,6 +8,7 @@ import {
   replaceRuntimeConfigs
 } from "../../../packages/shared/src/index";
 import type {
+  ActionValidationFailure,
   BattleAction,
   BattleState,
   ClientMessage,
@@ -31,6 +32,7 @@ export interface SessionUpdate {
   reachableTiles: Vec2[];
   featureFlags?: FeatureFlags;
   reason?: string;
+  rejection?: ActionValidationFailure;
 }
 
 export type ConnectionEvent = "reconnecting" | "reconnected" | "reconnect_failed";
@@ -90,7 +92,8 @@ function fromPayload(payload: SessionStatePayload, previousWorld?: PlayerWorldVi
     movementPlan: payload.movementPlan,
     reachableTiles: payload.reachableTiles,
     featureFlags: normalizeFeatureFlags(payload.featureFlags),
-    ...(payload.reason ? { reason: payload.reason } : {})
+    ...(payload.reason ? { reason: payload.reason } : {}),
+    ...(payload.rejection ? { rejection: payload.rejection } : {})
   };
 }
 

--- a/apps/cocos-client/assets/scripts/project-shared/action-precheck.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/action-precheck.ts
@@ -1,8 +1,34 @@
 import type { ValidationResult } from "./models.ts";
 
+export type ActionValidationScope = "battle" | "world";
+
+export interface ActionValidationFailure {
+  scope: ActionValidationScope;
+  actionType: string;
+  reason: string;
+}
+
 export interface ActionPrecheckResult<TState> {
   state: TState;
   validation: ValidationResult;
+  rejection?: ActionValidationFailure;
+}
+
+export function createActionValidationFailure<TAction extends { type: string }>(
+  scope: ActionValidationScope,
+  action: TAction,
+  validation: ValidationResult,
+  fallbackReason = `${scope}_action_invalid`
+): ActionValidationFailure | undefined {
+  if (validation.valid) {
+    return undefined;
+  }
+
+  return {
+    scope,
+    actionType: action.type,
+    reason: validation.reason ?? fallbackReason
+  };
 }
 
 export function validateAction<TState, TAction>(

--- a/apps/cocos-client/assets/scripts/project-shared/battle.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/battle.ts
@@ -18,7 +18,11 @@ import type {
   ValidationResult,
   WorldState
 } from "./models.ts";
-import { validateAction } from "./action-precheck.ts";
+import {
+  createActionValidationFailure,
+  validateAction,
+  type ActionPrecheckResult
+} from "./action-precheck.ts";
 import { nextDeterministicRandom } from "./deterministic-rng.ts";
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
 import { grantedHeroBattleSkillIds } from "./hero-skills.ts";
@@ -29,6 +33,8 @@ interface ContactResolutionResult {
   state: BattleState;
   intercepted: boolean;
 }
+
+export type BattleActionPrecheckResult = ActionPrecheckResult<BattleState>;
 
 interface BattleCatalogIndex {
   skillById: Map<BattleSkillId, BattleSkillConfig>;
@@ -1529,6 +1535,15 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
   return { valid: true };
 }
 
+export function precheckBattleAction(state: BattleState, action: BattleAction): BattleActionPrecheckResult {
+  const result = validateAction(state, action, validateBattleAction, normalizeBattleState);
+  const rejection = createActionValidationFailure("battle", action, result.validation);
+  return {
+    ...result,
+    ...(rejection ? { rejection } : {})
+  };
+}
+
 export function createEmptyBattleState(): BattleState {
   return {
     id: "battle-empty",
@@ -1846,20 +1861,7 @@ export function getBattleOutcome(state: BattleState): BattleOutcome {
   };
 }
 
-export function applyBattleAction(state: BattleState, action: BattleAction): BattleState {
-  const { state: normalizedState, validation } = validateAction(
-    state,
-    action,
-    validateBattleAction,
-    normalizeBattleState
-  );
-  if (!validation.valid) {
-    return {
-      ...normalizedState,
-      log: normalizedState.log.concat(`Action rejected: ${validation.reason}`)
-    };
-  }
-
+function applyBattleActionUnchecked(normalizedState: BattleState, action: BattleAction): BattleState {
   if (action.type === "battle.wait") {
     return advanceTurn(
       {
@@ -1909,6 +1911,18 @@ export function applyBattleAction(state: BattleState, action: BattleAction): Bat
   }
 
   return applyAttackSequence(normalizedState, action.attackerId, action.defenderId);
+}
+
+export function applyBattleAction(state: BattleState, action: BattleAction): BattleState {
+  const { state: normalizedState, validation, rejection } = precheckBattleAction(state, action);
+  if (!validation.valid) {
+    return {
+      ...normalizedState,
+      log: normalizedState.log.concat(`Action rejected: ${rejection?.reason ?? "battle_action_invalid"}`)
+    };
+  }
+
+  return applyBattleActionUnchecked(normalizedState, action);
 }
 
 function visibleEnvironmentLog(environment: BattleHazardState[], catalogIndex: BattleCatalogIndex): string[] {

--- a/apps/cocos-client/assets/scripts/project-shared/map.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/map.ts
@@ -28,7 +28,11 @@ import type {
   WorldResourceLedger,
   WorldState
 } from "./models.ts";
-import { validateAction } from "./action-precheck.ts";
+import {
+  createActionValidationFailure,
+  validateAction,
+  type ActionPrecheckResult
+} from "./action-precheck.ts";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills.ts";
 import {
   applyHeroEquipmentChange,
@@ -47,6 +51,8 @@ import {
   validateMapObjectsConfig,
   validateWorldConfig
 } from "./world-config.ts";
+
+export type WorldActionPrecheckResult = ActionPrecheckResult<WorldState>;
 
 function makeRng(seed: number): () => number {
   let value = seed >>> 0;
@@ -2329,6 +2335,21 @@ export function validateWorldAction(
   return { valid: true };
 }
 
+export function precheckWorldAction(
+  state: WorldState,
+  action: WorldAction,
+  requestingPlayerId?: string
+): WorldActionPrecheckResult {
+  const result = validateAction(state, action, (inputState, nextAction) =>
+    validateWorldAction(inputState, nextAction, requestingPlayerId)
+  );
+  const rejection = createActionValidationFailure("world", action, result.validation);
+  return {
+    ...result,
+    ...(rejection ? { rejection } : {})
+  };
+}
+
 export function createPlayerWorldView(state: WorldState, playerId: string): PlayerWorldView {
   const visibility = state.visibilityByPlayer[playerId] ?? new Array<FogState>(state.map.tiles.length).fill("hidden");
   const tiles: PlayerTileView[] = state.map.tiles.map((tile, index) => {
@@ -2864,12 +2885,12 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
 }
 
 export function applyWorldAction(state: WorldState, action: WorldAction): WorldState {
-  const { validation } = validateAction(state, action, validateWorldAction);
+  const { state: nextState, validation } = precheckWorldAction(state, action);
   if (!validation.valid) {
-    return state;
+    return nextState;
   }
 
-  return resolveWorldAction(state, action).state;
+  return resolveWorldAction(nextState, action).state;
 }
 
 export function filterWorldEventsForPlayer(

--- a/apps/cocos-client/assets/scripts/project-shared/protocol.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/protocol.ts
@@ -8,6 +8,7 @@ import type {
   WorldAction,
   WorldEvent
 } from "./models.ts";
+import type { ActionValidationFailure } from "./action-precheck.ts";
 import type { PlayerWorldViewPayload } from "./map-sync.ts";
 
 export type SessionStateReason = "surrender" | "afk_forfeit" | "normal" | (string & {});
@@ -30,6 +31,7 @@ export interface SessionStatePayload {
   reachableTiles: Vec2[];
   featureFlags: FeatureFlags;
   reason?: SessionStateReason;
+  rejection?: ActionValidationFailure;
 }
 
 export type PlayerReportReason = "cheating" | "harassment" | "afk";

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -11,6 +11,7 @@ import {
   planHeroMovement,
   validateWorldAction,
   resolveCosmeticCatalog,
+  type ActionValidationFailure,
   type PlayerWorldView,
   type PlayerBattleReplaySummary,
   type ClientMessage,
@@ -487,9 +488,21 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       const previousSnapshot = this.worldRoom.serializePersistenceSnapshot();
       const previousTurnOwnerPlayerId = this.turnOwnerPlayerId;
       const result = this.worldRoom.dispatch(playerId, message.action);
-      if (result.ok) {
-        this.afterSuccessfulWorldAction(playerId, message.action);
+      if (!result.ok) {
+        sendMessage(client, "session.state", {
+          requestId: message.requestId,
+          delivery: "reply",
+          payload: this.buildStatePayload(playerId, {
+            events: [],
+            movementPlan: null,
+            ...(result.reason ? { reason: result.reason } : {}),
+            ...(result.rejection ? { rejection: result.rejection } : {})
+          })
+        });
+        return;
       }
+
+      this.afterSuccessfulWorldAction(playerId, message.action);
       try {
         await this.persistRoomState();
       } catch {
@@ -509,7 +522,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         payload: this.buildStatePayload(playerId, {
           events: result.events ?? [],
           movementPlan: result.movementPlan ?? null,
-          ...(result.reason ? { reason: result.reason } : {})
+          ...(result.reason ? { reason: result.reason } : {}),
+          ...(result.rejection ? { rejection: result.rejection } : {})
         })
       });
       this.broadcastState(client, {
@@ -538,9 +552,21 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       const previousSnapshot = this.worldRoom.serializePersistenceSnapshot();
       const previousTurnOwnerPlayerId = this.turnOwnerPlayerId;
       const result = this.worldRoom.dispatchBattle(playerId, message.action);
-      if (result.ok) {
-        this.afterSuccessfulBattleAction(playerId);
+      if (!result.ok) {
+        sendMessage(client, "session.state", {
+          requestId: message.requestId,
+          delivery: "reply",
+          payload: this.buildStatePayload(playerId, {
+            events: [],
+            movementPlan: null,
+            ...(result.reason ? { reason: result.reason } : {}),
+            ...(result.rejection ? { rejection: result.rejection } : {})
+          })
+        });
+        return;
       }
+
+      this.afterSuccessfulBattleAction(playerId);
       try {
         await this.persistRoomState();
       } catch {
@@ -560,7 +586,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         payload: this.buildStatePayload(playerId, {
           events: result.events ?? [],
           movementPlan: null,
-          ...(result.reason ? { reason: result.reason } : {})
+          ...(result.reason ? { reason: result.reason } : {}),
+          ...(result.rejection ? { rejection: result.rejection } : {})
         })
       });
       this.broadcastState(client, {
@@ -1544,6 +1571,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     events?: WorldEvent[];
     movementPlan?: MovementPlan | null;
     reason?: string;
+    rejection?: ActionValidationFailure;
   }): void {
     for (const client of this.clients) {
       const playerId = this.getPlayerId(client);
@@ -1611,6 +1639,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       events?: WorldEvent[];
       movementPlan?: MovementPlan | null;
       reason?: string;
+      rejection?: ActionValidationFailure;
     },
     options?: {
       mapBounds?: {
@@ -1638,7 +1667,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       movementPlan: extras?.movementPlan ?? null,
       reachableTiles: heroId && !battle ? listReachableTiles(this.worldRoom.getInternalState(), heroId) : [],
       featureFlags: this.resolvePlayerFeatureFlags(playerId),
-      ...(extras?.reason ? { reason: extras.reason } : {})
+      ...(extras?.reason ? { reason: extras.reason } : {}),
+      ...(extras?.rejection ? { rejection: extras.rejection } : {})
     };
   }
 
@@ -1683,6 +1713,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       events?: WorldEvent[];
       movementPlan?: MovementPlan | null;
       reason?: string;
+      rejection?: ActionValidationFailure;
     }
   ): void {
     for (const client of this.clients) {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,6 +1,7 @@
 import {
   applyBattleAction,
   applyBattleOutcomeToWorld,
+  createActionValidationFailure,
   createHeroBattleState,
   createNeutralBattleState,
   filterWorldEventsForPlayer,
@@ -9,9 +10,10 @@ import {
   getBattleOutcome,
   normalizeHeroState,
   pickAutomatedBattleAction,
+  precheckBattleAction,
+  precheckWorldAction,
   resolveWorldAction,
-  validateWorldAction,
-  validateBattleAction,
+  type ActionValidationFailure,
   type BattleState,
   type MovementPlan,
   type PlayerWorldView,
@@ -38,6 +40,7 @@ export interface RoomSnapshot {
 export interface DispatchResult {
   ok: boolean;
   reason?: string;
+  rejection?: ActionValidationFailure;
   snapshot: RoomSnapshot;
   events?: WorldEvent[];
   movementPlan?: MovementPlan;
@@ -47,6 +50,7 @@ export interface DispatchResult {
 export interface BattleDispatchResult {
   ok: boolean;
   reason?: string;
+  rejection?: ActionValidationFailure;
   battle?: BattleState;
   snapshot: RoomSnapshot;
   events?: WorldEvent[];
@@ -328,36 +332,49 @@ export class AuthoritativeWorldRoom {
     if ("heroId" in action) {
       const hero = this.state.heroes.find((item) => item.id === action.heroId);
       if (!hero || hero.playerId !== playerId) {
-        authoritativeRoomTelemetry.recordActionValidationFailure("world", "hero_not_owned_by_player");
+        const rejection = createActionValidationFailure("world", action, {
+          valid: false,
+          reason: "hero_not_owned_by_player"
+        })!;
+        authoritativeRoomTelemetry.recordActionValidationFailure("world", rejection.reason);
         return {
           ok: false,
-          reason: "hero_not_owned_by_player",
+          reason: rejection.reason,
+          rejection,
           snapshot: this.getSnapshot(playerId)
         };
       }
 
       if (this.getBattleIdForHero(hero.id)) {
-        authoritativeRoomTelemetry.recordActionValidationFailure("world", "hero_in_battle");
+        const rejection = createActionValidationFailure("world", action, {
+          valid: false,
+          reason: "hero_in_battle"
+        })!;
+        authoritativeRoomTelemetry.recordActionValidationFailure("world", rejection.reason);
         return {
           ok: false,
-          reason: "hero_in_battle",
+          reason: rejection.reason,
+          rejection,
           snapshot: this.getSnapshot(playerId),
           ...(this.getBattleForPlayer(playerId) ? { battle: this.getBattleForPlayer(playerId)! } : {})
         };
       }
     }
 
-    const validation = validateWorldAction(this.state, action, playerId);
-    if (!validation.valid) {
-      authoritativeRoomTelemetry.recordActionValidationFailure("world", validation.reason ?? "world_action_invalid");
+    const precheck = precheckWorldAction(this.state, action, playerId);
+    if (!precheck.validation.valid) {
+      authoritativeRoomTelemetry.recordActionValidationFailure(
+        "world",
+        precheck.rejection?.reason ?? "world_action_invalid"
+      );
       return {
         ok: false,
-        ...(validation.reason ? { reason: validation.reason } : {}),
+        ...(precheck.rejection ? { reason: precheck.rejection.reason, rejection: precheck.rejection } : {}),
         snapshot: this.getSnapshot(playerId)
       };
     }
 
-    const outcome = resolveWorldAction(this.state, action);
+    const outcome = resolveWorldAction(precheck.state, action);
     this.state = outcome.state;
 
     const startedBattleIds: string[] = [];
@@ -417,20 +434,30 @@ export class AuthoritativeWorldRoom {
   dispatchBattle(playerId: string, action: BattleAction): BattleDispatchResult {
     const activeBattle = this.getBattleForPlayer(playerId);
     if (!activeBattle) {
-      authoritativeRoomTelemetry.recordActionValidationFailure("battle", "battle_not_active");
+      const rejection = createActionValidationFailure("battle", action, {
+        valid: false,
+        reason: "battle_not_active"
+      })!;
+      authoritativeRoomTelemetry.recordActionValidationFailure("battle", rejection.reason);
       return {
         ok: false,
-        reason: "battle_not_active",
+        reason: rejection.reason,
+        rejection,
         snapshot: this.getSnapshot(playerId)
       };
     }
 
     const controllingCamp = this.getControllingCamp(playerId, activeBattle);
     if (!controllingCamp) {
-      authoritativeRoomTelemetry.recordActionValidationFailure("battle", "battle_not_owned_by_player");
+      const rejection = createActionValidationFailure("battle", action, {
+        valid: false,
+        reason: "battle_not_owned_by_player"
+      })!;
+      authoritativeRoomTelemetry.recordActionValidationFailure("battle", rejection.reason);
       return {
         ok: false,
-        reason: "battle_not_owned_by_player",
+        reason: rejection.reason,
+        rejection,
         snapshot: this.getSnapshot(playerId)
       };
     }
@@ -438,28 +465,36 @@ export class AuthoritativeWorldRoom {
     const actingUnitId = action.type === "battle.attack" ? action.attackerId : action.unitId;
     const actingUnit = activeBattle.units[actingUnitId];
     if (!actingUnit || actingUnit.camp !== controllingCamp) {
-      authoritativeRoomTelemetry.recordActionValidationFailure("battle", "unit_not_player_controlled");
+      const rejection = createActionValidationFailure("battle", action, {
+        valid: false,
+        reason: "unit_not_player_controlled"
+      })!;
+      authoritativeRoomTelemetry.recordActionValidationFailure("battle", rejection.reason);
       return {
         ok: false,
-        reason: "unit_not_player_controlled",
+        reason: rejection.reason,
+        rejection,
         battle: activeBattle,
         snapshot: this.getSnapshot(playerId)
       };
     }
 
-    const validation = validateBattleAction(activeBattle, action);
-    if (!validation.valid) {
-      authoritativeRoomTelemetry.recordActionValidationFailure("battle", validation.reason ?? "battle_action_invalid");
+    const precheck = precheckBattleAction(activeBattle, action);
+    if (!precheck.validation.valid) {
+      authoritativeRoomTelemetry.recordActionValidationFailure(
+        "battle",
+        precheck.rejection?.reason ?? "battle_action_invalid"
+      );
       return {
         ok: false,
-        ...(validation.reason ? { reason: validation.reason } : {}),
+        ...(precheck.rejection ? { reason: precheck.rejection.reason, rejection: precheck.rejection } : {}),
         battle: activeBattle,
         snapshot: this.getSnapshot(playerId)
       };
     }
 
     this.trackBattleAction(activeBattle.id, action, "player");
-    const nextBattle = applyBattleAction(activeBattle, action);
+    const nextBattle = applyBattleAction(precheck.state, action);
     this.setBattle(nextBattle);
     const automatedEvents = this.resolveAutomatedBattleTurns(nextBattle.id);
     const playerBattle = this.getBattleForPlayer(playerId);

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -928,6 +928,138 @@ test("battle replay persistence runs once at settlement and is drained from the 
   assert.deepEqual(internalRoom.worldRoom.consumeCompletedBattleReplays(), []);
 });
 
+test("invalid world actions return a structured rejection only to the originating client", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-world-rejection-${Date.now()}`);
+  const sourceClient = createFakeClient("session-world-rejection-source");
+  const observerClient = createFakeClient("session-world-rejection-observer");
+  const internalRoom = room as VeilColyseusRoom & {
+    worldRoom: {
+      getInternalState(): {
+        heroes: Array<{
+          id: string;
+          playerId: string;
+          move: { total: number; remaining: number };
+        }>;
+      };
+    };
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, sourceClient, "player-1", "connect-world-rejection-source");
+  await connectPlayer(room, observerClient, "player-2", "connect-world-rejection-observer");
+
+  const sourceHero = internalRoom.worldRoom.getInternalState().heroes.find((hero) => hero.playerId === "player-1");
+  assert.ok(sourceHero);
+  sourceHero.move.remaining = 1;
+
+  const observerPushCountBefore = observerClient.sent.filter(
+    (message) => message.type === "session.state" && message.delivery === "push"
+  ).length;
+
+  await emitRoomMessage(room, "world.action", sourceClient, {
+    type: "world.action",
+    requestId: "world-rejection",
+    action: {
+      type: "hero.move",
+      heroId: sourceHero.id,
+      destination: { x: 5, y: 4 }
+    }
+  });
+
+  const reply = lastSessionState(sourceClient, "reply");
+  const observerPushCountAfter = observerClient.sent.filter(
+    (message) => message.type === "session.state" && message.delivery === "push"
+  ).length;
+
+  assert.equal(reply.requestId, "world-rejection");
+  assert.equal(reply.payload.reason, "not_enough_move_points");
+  assert.deepEqual(reply.payload.rejection, {
+    scope: "world",
+    actionType: "hero.move",
+    reason: "not_enough_move_points"
+  });
+  assert.equal(reply.payload.events.length, 0);
+  assert.equal(observerPushCountAfter, observerPushCountBefore);
+});
+
+test("invalid battle actions return a structured rejection only to the originating client", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-battle-rejection-${Date.now()}`);
+  const sourceClient = createFakeClient("session-battle-rejection-source");
+  const observerClient = createFakeClient("session-battle-rejection-observer");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, sourceClient, "player-1", "connect-battle-rejection-source");
+  await connectPlayer(room, observerClient, "player-2", "connect-battle-rejection-observer");
+
+  await emitRoomMessage(room, "world.action", sourceClient, {
+    type: "world.action",
+    requestId: "battle-rejection-start",
+    action: {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 5, y: 4 }
+    }
+  });
+
+  const battle = getBattleForPlayer(room, "player-1");
+  assert.ok(battle);
+  const playerUnit = Object.values(battle.units).find((unit) => unit.camp === "attacker");
+  const opposingUnit = Object.values(battle.units).find((unit) => unit.camp === "defender");
+  assert.ok(playerUnit);
+  assert.ok(opposingUnit);
+
+  battle.activeUnitId = playerUnit.id;
+  battle.turnOrder = [playerUnit.id, opposingUnit.id];
+  battle.unitCooldowns[playerUnit.id] = {
+    ...battle.unitCooldowns[playerUnit.id],
+    power_shot: 1
+  };
+
+  const observerPushCountBefore = observerClient.sent.filter(
+    (message) => message.type === "session.state" && message.delivery === "push"
+  ).length;
+
+  await emitRoomMessage(room, "battle.action", sourceClient, {
+    type: "battle.action",
+    requestId: "battle-rejection",
+    action: {
+      type: "battle.skill",
+      unitId: playerUnit.id,
+      skillId: "power_shot",
+      targetId: opposingUnit.id
+    }
+  });
+
+  const reply = lastSessionState(sourceClient, "reply");
+  const observerPushCountAfter = observerClient.sent.filter(
+    (message) => message.type === "session.state" && message.delivery === "push"
+  ).length;
+
+  assert.equal(reply.requestId, "battle-rejection");
+  assert.equal(reply.payload.reason, "skill_on_cooldown");
+  assert.deepEqual(reply.payload.rejection, {
+    scope: "battle",
+    actionType: "battle.skill",
+    reason: "skill_on_cooldown"
+  });
+  assert.equal(reply.payload.events.length, 0);
+  assert.equal(observerPushCountAfter, observerPushCountBefore);
+});
+
 test("battle settlement grants configured season XP to the settled player account", async (t) => {
   resetLobbyRoomRegistry();
   const store = new InstrumentedRoomSnapshotStore();

--- a/packages/shared/src/action-precheck.ts
+++ b/packages/shared/src/action-precheck.ts
@@ -1,8 +1,34 @@
 import type { ValidationResult } from "./models.ts";
 
+export type ActionValidationScope = "battle" | "world";
+
+export interface ActionValidationFailure {
+  scope: ActionValidationScope;
+  actionType: string;
+  reason: string;
+}
+
 export interface ActionPrecheckResult<TState> {
   state: TState;
   validation: ValidationResult;
+  rejection?: ActionValidationFailure;
+}
+
+export function createActionValidationFailure<TAction extends { type: string }>(
+  scope: ActionValidationScope,
+  action: TAction,
+  validation: ValidationResult,
+  fallbackReason = `${scope}_action_invalid`
+): ActionValidationFailure | undefined {
+  if (validation.valid) {
+    return undefined;
+  }
+
+  return {
+    scope,
+    actionType: action.type,
+    reason: validation.reason ?? fallbackReason
+  };
 }
 
 export function validateAction<TState, TAction>(

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -21,7 +21,11 @@ import type {
   ValidationResult,
   WorldState
 } from "./models.ts";
-import { validateAction } from "./action-precheck.ts";
+import {
+  createActionValidationFailure,
+  validateAction,
+  type ActionPrecheckResult
+} from "./action-precheck.ts";
 import { nextDeterministicRandom } from "./deterministic-rng.ts";
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
 import { grantedHeroBattleSkillIds } from "./hero-skills.ts";
@@ -37,6 +41,8 @@ interface ContactResolutionResult {
   state: BattleState;
   intercepted: boolean;
 }
+
+export type BattleActionPrecheckResult = ActionPrecheckResult<BattleState>;
 
 interface BattleCatalogIndex {
   skillById: Map<BattleSkillId, BattleSkillConfig>;
@@ -1882,6 +1888,17 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
   return { valid: true };
 }
 
+export function precheckBattleAction(state: BattleState, action: BattleAction): BattleActionPrecheckResult {
+  const result = validateAction(state, action, validateBattleAction, (inputState) =>
+    resolveBossEncounterState(normalizeBattleState(inputState))
+  );
+  const rejection = createActionValidationFailure("battle", action, result.validation);
+  return {
+    ...result,
+    ...(rejection ? { rejection } : {})
+  };
+}
+
 export function createEmptyBattleState(): BattleState {
   return {
     id: "battle-empty",
@@ -2219,20 +2236,7 @@ export function getBattleOutcome(state: BattleState): BattleOutcome {
   };
 }
 
-export function applyBattleAction(state: BattleState, action: BattleAction): BattleState {
-  const { state: normalizedState, validation } = validateAction(
-    state,
-    action,
-    validateBattleAction,
-    (inputState) => resolveBossEncounterState(normalizeBattleState(inputState))
-  );
-  if (!validation.valid) {
-    return {
-      ...normalizedState,
-      log: normalizedState.log.concat(`Action rejected: ${validation.reason}`)
-    };
-  }
-
+function applyBattleActionUnchecked(normalizedState: BattleState, action: BattleAction): BattleState {
   if (action.type === "battle.wait") {
     return advanceTurn(
       {
@@ -2282,6 +2286,18 @@ export function applyBattleAction(state: BattleState, action: BattleAction): Bat
   }
 
   return applyAttackSequence(normalizedState, action.attackerId, action.defenderId);
+}
+
+export function applyBattleAction(state: BattleState, action: BattleAction): BattleState {
+  const { state: normalizedState, validation, rejection } = precheckBattleAction(state, action);
+  if (!validation.valid) {
+    return {
+      ...normalizedState,
+      log: normalizedState.log.concat(`Action rejected: ${rejection?.reason ?? "battle_action_invalid"}`)
+    };
+  }
+
+  return applyBattleActionUnchecked(normalizedState, action);
 }
 
 function visibleEnvironmentLog(environment: BattleHazardState[], catalogIndex: BattleCatalogIndex): string[] {

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -28,7 +28,11 @@ import type {
   WorldResourceLedger,
   WorldState
 } from "./models.ts";
-import { validateAction } from "./action-precheck.ts";
+import {
+  createActionValidationFailure,
+  validateAction,
+  type ActionPrecheckResult
+} from "./action-precheck.ts";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills.ts";
 import {
   applyHeroEquipmentChange,
@@ -47,6 +51,8 @@ import {
   validateMapObjectsConfig,
   validateWorldConfig
 } from "./world-config.ts";
+
+export type WorldActionPrecheckResult = ActionPrecheckResult<WorldState>;
 
 function makeRng(seed: number): () => number {
   let value = seed >>> 0;
@@ -2329,6 +2335,21 @@ export function validateWorldAction(
   return { valid: true };
 }
 
+export function precheckWorldAction(
+  state: WorldState,
+  action: WorldAction,
+  requestingPlayerId?: string
+): WorldActionPrecheckResult {
+  const result = validateAction(state, action, (inputState, nextAction) =>
+    validateWorldAction(inputState, nextAction, requestingPlayerId)
+  );
+  const rejection = createActionValidationFailure("world", action, result.validation);
+  return {
+    ...result,
+    ...(rejection ? { rejection } : {})
+  };
+}
+
 export function createPlayerWorldView(state: WorldState, playerId: string): PlayerWorldView {
   const visibility = state.visibilityByPlayer[playerId] ?? new Array<FogState>(state.map.tiles.length).fill("hidden");
   const tiles: PlayerTileView[] = state.map.tiles.map((tile, index) => {
@@ -2864,12 +2885,12 @@ export function resolveWorldAction(state: WorldState, action: WorldAction): Worl
 }
 
 export function applyWorldAction(state: WorldState, action: WorldAction): WorldState {
-  const { validation } = validateAction(state, action, validateWorldAction);
+  const { state: nextState, validation } = precheckWorldAction(state, action);
   if (!validation.valid) {
-    return state;
+    return nextState;
   }
 
-  return resolveWorldAction(state, action).state;
+  return resolveWorldAction(nextState, action).state;
 }
 
 export function filterWorldEventsForPlayer(

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -8,6 +8,7 @@ import type {
   WorldAction,
   WorldEvent
 } from "./models.ts";
+import type { ActionValidationFailure } from "./action-precheck.ts";
 import type { FeatureFlags } from "./feature-flags.ts";
 import type { GuildRosterView, GuildSummaryView } from "./guilds.ts";
 import type { PlayerWorldViewPayload } from "./map-sync.ts";
@@ -41,6 +42,7 @@ export interface SessionStatePayload {
   reachableTiles: Vec2[];
   featureFlags: FeatureFlags;
   reason?: SessionStateReason;
+  rejection?: ActionValidationFailure;
 }
 
 export type PlayerReportReason = "cheating" | "harassment" | "afk";

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -92,6 +92,8 @@ import {
   normalizePlayerBattleReplaySummaries,
   pauseBattleReplayPlayback,
   pickAutomatedBattleAction,
+  precheckBattleAction,
+  precheckWorldAction,
   planHeroMovement,
   planPlayerViewMovement,
   playBattleReplayPlayback,
@@ -6544,6 +6546,142 @@ test("applyWorldAction rejects invalid movement before mutating world state", ()
   assert.equal(next, initial);
   assert.deepEqual(next.heroes[0]?.position, { x: 0, y: 0 });
   assert.equal(next.heroes[0]?.move.remaining, 1);
+});
+
+test("precheckWorldAction returns structured rejection for out-of-range movement", () => {
+  const hero = createHero({
+    id: "hero-blocked",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 0, y: 0 },
+    move: { total: 6, remaining: 1 }
+  });
+  const initial = createWorldState({
+    width: 3,
+    height: 1,
+    heroes: [hero],
+    tiles: [createTile(0, 0), createTile(1, 0), createTile(2, 0)]
+  });
+
+  const result = precheckWorldAction(initial, {
+    type: "hero.move",
+    heroId: "hero-blocked",
+    destination: { x: 2, y: 0 }
+  });
+
+  assert.equal(result.state, initial);
+  assert.deepEqual(result.validation, {
+    valid: false,
+    reason: "not_enough_move_points"
+  });
+  assert.deepEqual(result.rejection, {
+    scope: "world",
+    actionType: "hero.move",
+    reason: "not_enough_move_points"
+  });
+});
+
+test("precheckWorldAction returns structured rejection for insufficient gold recruitment", () => {
+  const hero = createHero({
+    id: "hero-1",
+    playerId: "player-1",
+    name: "凯琳",
+    position: { x: 1, y: 1 }
+  });
+  const state = createWorldState({
+    width: 3,
+    height: 2,
+    heroes: [hero],
+    resources: {
+      "player-1": {
+        gold: 0,
+        wood: 0,
+        ore: 0
+      }
+    },
+    buildings: {
+      "recruit-post-1": {
+        id: "recruit-post-1",
+        kind: "recruitment_post",
+        position: { x: 1, y: 1 },
+        label: "前线招募所",
+        unitTemplateId: "hero_guard_basic",
+        recruitCount: 4,
+        availableCount: 4,
+        cost: {
+          gold: 240,
+          wood: 0,
+          ore: 0
+        }
+      }
+    },
+    tiles: [
+      createTile(0, 0),
+      createTile(1, 0),
+      createTile(2, 0),
+      createTile(0, 1),
+      createTile(1, 1, {
+        building: {
+          id: "recruit-post-1",
+          kind: "recruitment_post",
+          position: { x: 1, y: 1 },
+          label: "前线招募所",
+          unitTemplateId: "hero_guard_basic",
+          recruitCount: 4,
+          availableCount: 4,
+          cost: {
+            gold: 240,
+            wood: 0,
+            ore: 0
+          }
+        }
+      }),
+      createTile(2, 1)
+    ]
+  });
+
+  const result = precheckWorldAction(state, {
+    type: "hero.recruit",
+    heroId: "hero-1",
+    buildingId: "recruit-post-1"
+  });
+
+  assert.deepEqual(result.validation, {
+    valid: false,
+    reason: "not_enough_resources"
+  });
+  assert.deepEqual(result.rejection, {
+    scope: "world",
+    actionType: "hero.recruit",
+    reason: "not_enough_resources"
+  });
+});
+
+test("precheckBattleAction returns structured rejection for active cooldowns", () => {
+  const initial = createDemoBattleState();
+  initial.activeUnitId = "pikeman-a";
+  initial.turnOrder = ["pikeman-a", "wolf-d"];
+  initial.unitCooldowns["pikeman-a"] = {
+    ...initial.unitCooldowns["pikeman-a"],
+    power_shot: 1
+  };
+
+  const result = precheckBattleAction(initial, {
+    type: "battle.skill",
+    unitId: "pikeman-a",
+    skillId: "power_shot",
+    targetId: "wolf-d"
+  });
+
+  assert.deepEqual(result.validation, {
+    valid: false,
+    reason: "skill_on_cooldown"
+  });
+  assert.deepEqual(result.rejection, {
+    scope: "battle",
+    actionType: "battle.skill",
+    reason: "skill_on_cooldown"
+  });
 });
 
 test("applyBattleAction resolves wait plus turn-start poison death and cooldown ticking", () => {


### PR DESCRIPTION
## Summary
- add shared action precheck rejection metadata for world and battle actions, and mirror the shared changes into the Cocos project-shared runtime
- route authoritative room replies through the shared precheck result so invalid actions return a structured rejection payload to the originating client
- stop broadcasting invalid action replies to other clients and add shared plus room lifecycle regression coverage for move-range, resource-cost, and cooldown rejections

## Root cause
The repo already had validation helpers, but invalid action handling still collapsed to unchanged state plus a string reason in some paths, and room handlers still performed side effects like peer broadcasts around rejected actions.

## Validation
- `node --import tsx --test ./packages/shared/test/shared-core.test.ts`
- `node --import tsx --test ./apps/server/test/colyseus-room-lifecycle.test.ts`
- `node --import tsx --test ./packages/shared/test/client-payload-contracts.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `npm run typecheck:client:h5`
- `npm run typecheck:cocos`

Closes #980
