### PR TITLE
[codex] Harden deterministic RNG battle coverage

### DIFF
--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -26,7 +26,7 @@ import {
   validateAction,
   type ActionPrecheckResult
 } from "./action-precheck.ts";
-import { nextDeterministicRandom } from "./deterministic-rng.ts";
+import { nextDeterministicRandom, normalizeDeterministicSeed } from "./deterministic-rng.ts";
 import { createHeroEquipmentBonusSummary } from "./equipment.ts";
 import { grantedHeroBattleSkillIds } from "./hero-skills.ts";
 import { requireValue, withOptionalProperty } from "./invariant.ts";
@@ -88,7 +88,7 @@ function hazardsOf(state: BattleState): BattleHazardState[] {
 function normalizeBattleRngState(state: BattleState): BattleState["rng"] {
   const rng = state.rng;
   return {
-    seed: Number.isFinite(rng?.seed) ? Math.floor(rng.seed) >>> 0 : 1,
+    seed: normalizeDeterministicSeed(rng?.seed ?? 1),
     cursor: Number.isFinite(rng?.cursor) ? Math.max(0, Math.floor(rng.cursor)) : 0
   };
 }

--- a/packages/shared/src/deterministic-rng.ts
+++ b/packages/shared/src/deterministic-rng.ts
@@ -3,10 +3,36 @@ export interface DeterministicRandomStep {
   value: number;
 }
 
+const LCG_MULTIPLIER = 1664525;
+const LCG_INCREMENT = 1013904223;
+const UINT32_RANGE = 0x100000000;
+const DEFAULT_DETERMINISTIC_SEED = 1;
+
+export function normalizeDeterministicSeed(seed: number, fallback = DEFAULT_DETERMINISTIC_SEED): number {
+  if (!Number.isFinite(seed)) {
+    return fallback >>> 0;
+  }
+
+  return Math.floor(seed) >>> 0;
+}
+
+function advanceSeed(seed: number): number {
+  return (Math.imul(seed, LCG_MULTIPLIER) + LCG_INCREMENT) >>> 0;
+}
+
 export function nextDeterministicRandom(seed: number): DeterministicRandomStep {
-  const nextSeed = (seed * 1664525 + 1013904223) >>> 0;
+  const nextSeed = advanceSeed(normalizeDeterministicSeed(seed));
   return {
     nextSeed,
-    value: nextSeed / 0x100000000
+    value: nextSeed / UINT32_RANGE
+  };
+}
+
+export function createDeterministicRandomGenerator(seed: number): () => number {
+  let nextSeed = normalizeDeterministicSeed(seed);
+  return () => {
+    const step = nextDeterministicRandom(nextSeed);
+    nextSeed = step.nextSeed;
+    return step.value;
   };
 }

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -33,6 +33,7 @@ import {
   validateAction,
   type ActionPrecheckResult
 } from "./action-precheck.ts";
+import { createDeterministicRandomGenerator } from "./deterministic-rng.ts";
 import { applyHeroSkillSelection, validateHeroSkillSelection } from "./hero-skills.ts";
 import {
   applyHeroEquipmentChange,
@@ -55,11 +56,7 @@ import {
 export type WorldActionPrecheckResult = ActionPrecheckResult<WorldState>;
 
 function makeRng(seed: number): () => number {
-  let value = seed >>> 0;
-  return () => {
-    value = (value * 1664525 + 1013904223) >>> 0;
-    return value / 0x100000000;
-  };
+  return createDeterministicRandomGenerator(seed);
 }
 
 function hashSeed(base: number, value: string): number {

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -51,6 +51,7 @@ import {
   createHeroProgressMeterView,
   createBattleEnvironmentState,
   createBattleReplayPlaybackState,
+  createDeterministicRandomGenerator,
   createDemoBattleState,
   nextDeterministicRandom,
   createEmptyBattleState,
@@ -5504,6 +5505,17 @@ test("nextDeterministicRandom is repeatable for the same seed", () => {
     firstRun.map((step) => step.value),
     [0.8800653687212616, 0.04393873084336519, 0.35202502529136837]
   );
+});
+
+test("createDeterministicRandomGenerator advances the same deterministic sequence as manual seed stepping", () => {
+  const generator = createDeterministicRandomGenerator(4242);
+  const generated = [generator(), generator(), generator()];
+
+  const firstStep = nextDeterministicRandom(4242);
+  const secondStep = nextDeterministicRandom(firstStep.nextSeed);
+  const thirdStep = nextDeterministicRandom(secondStep.nextSeed);
+
+  assert.deepEqual(generated, [firstStep.value, secondStep.value, thirdStep.value]);
 });
 
 test("applyBattleAction repeats battle damage variance for the same seed", () => {

--- a/tests/e2e/pvp-hero-encounter.spec.ts
+++ b/tests/e2e/pvp-hero-encounter.spec.ts
@@ -1,6 +1,41 @@
 import { expect, test, type Page } from "@playwright/test";
 import { expectHeroMoveSpent } from "./smoke-helpers";
 
+function extractUnitSnapshot(text: string) {
+  const countMatch = text.match(/x(\d+)/);
+  const hpMatch = text.match(/HP (\d+)\/(\d+)/);
+
+  return {
+    count: Number(countMatch?.[1] ?? -1),
+    currentHp: Number(hpMatch?.[1] ?? -1),
+    maxHp: Number(hpMatch?.[2] ?? -1),
+    dead: text.includes("已阵亡")
+  };
+}
+
+async function readBattleSnapshot(page: Page) {
+  const [log, heroOne, heroTwo] = await Promise.all([
+    page.getByTestId("battle-log").innerText(),
+    page.getByTestId("battle-unit-hero-1-stack").innerText(),
+    page.getByTestId("battle-unit-hero-2-stack").innerText()
+  ]);
+
+  return {
+    log: log.trim(),
+    units: {
+      "hero-1-stack": extractUnitSnapshot(heroOne),
+      "hero-2-stack": extractUnitSnapshot(heroTwo)
+    }
+  };
+}
+
+async function expectSynchronizedBattleDamage(pageOne: Page, pageTwo: Page): Promise<void> {
+  await expect.poll(async () => {
+    const [first, second] = await Promise.all([readBattleSnapshot(pageOne), readBattleSnapshot(pageTwo)]);
+    return first.log === second.log && JSON.stringify(first.units) === JSON.stringify(second.units);
+  }).toBe(true);
+}
+
 async function pressTile(page: Page, x: number, y: number): Promise<void> {
   await page.locator(`[data-x="${x}"][data-y="${y}"]`).dispatchEvent("pointerdown", {
     button: 0
@@ -51,21 +86,27 @@ test("two players can enter a hero-vs-hero battle and resolve it with correct tu
   await expect(playerTwoPage.getByTestId("room-next-action")).toHaveAttribute("data-tone", "action");
   await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
   await expect(playerOnePage.getByTestId("battle-actions")).toContainText("等待对手操作");
+  await expectSynchronizedBattleDamage(playerOnePage, playerTwoPage);
 
   await attackOnce(playerTwoPage);
   await expect(playerOnePage.getByTestId("battle-attack")).toBeVisible();
   await expect(playerTwoPage.getByTestId("battle-actions")).toContainText("等待对手操作");
+  await expectSynchronizedBattleDamage(playerOnePage, playerTwoPage);
 
   await attackOnce(playerOnePage);
   await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
+  await expectSynchronizedBattleDamage(playerOnePage, playerTwoPage);
 
   await attackOnce(playerTwoPage);
   await expect(playerOnePage.getByTestId("battle-attack")).toBeVisible();
+  await expectSynchronizedBattleDamage(playerOnePage, playerTwoPage);
 
   await attackOnce(playerOnePage);
   await expect(playerTwoPage.getByTestId("battle-attack")).toBeVisible();
+  await expectSynchronizedBattleDamage(playerOnePage, playerTwoPage);
 
   await attackOnce(playerTwoPage);
+  await expectSynchronizedBattleDamage(playerOnePage, playerTwoPage);
 
   await expect(playerOnePage.getByTestId("battle-modal-title")).toHaveText("战斗胜利");
   await expect(playerOnePage.getByTestId("battle-modal-body")).toContainText("你已击败敌方英雄");


### PR DESCRIPTION
## Summary
- expand `packages/shared/src/deterministic-rng.ts` into a reusable seeded LCG utility with explicit seed normalization and generator state advancement
- route battle RNG normalization and other shared seeded call sites through the common deterministic RNG helper to keep combat rolls on the same deterministic sequence
- add regression coverage for generator stepping and strengthen the PvP multiplayer Playwright spec to assert both clients observe identical battle logs and damage state after each attack

## Why
- deterministic battle outcomes depend on a single shared seeded RNG contract
- centralizing the seeded generator removes duplicated ad hoc implementations and hardens battle seed normalization
- the PvP spec now explicitly checks client/server convergence for damage outcomes instead of only checking turn ownership and final settlement

## Validation
- `node --import tsx --test --test-name-pattern='nextDeterministicRandom|createDeterministicRandomGenerator|applyBattleAction repeats battle damage variance|applyBattleAction uses deterministic damage and retaliation flow|applyBattleAction normalizes missing rng state' packages/shared/test/shared-core.test.ts`
- `node --import tsx --test apps/server/test/room-persistence.test.ts`
- `npm run typecheck:shared`
- `npx playwright test tests/e2e/pvp-hero-encounter.spec.ts --config=playwright.multiplayer.config.ts` *(blocked in this environment: Chromium could not start because `libatk-bridge-2.0.so.0` is missing)*

Closes #979