### PR TITLE
[codex] Add server coverage for guild and WeChat Pay routes

### DIFF
--- a/apps/server/src/guilds.ts
+++ b/apps/server/src/guilds.ts
@@ -98,6 +98,7 @@ function mapGuildError(error: unknown): { status: number; code: string; message:
   const message = error instanceof Error ? error.message : String(error);
 
   if (
+    error instanceof SyntaxError ||
     /guild_create_.*required|guild_join_player_required|guild_leave_player_required|payload_too_large|Unexpected token/.test(
       message
     )

--- a/apps/server/test/guild-routes.test.ts
+++ b/apps/server/test/guild-routes.test.ts
@@ -144,3 +144,175 @@ test("guild routes support join and leave, including disband on last member leav
   const notFound = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}`);
   assert.equal(notFound.status, 404);
 });
+
+test("guild routes reject unauthorized and banned create requests", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  await store.ensurePlayerAccount({ playerId: "banned-founder", displayName: "Banned Founder" });
+  await store.savePlayerBan("banned-founder", {
+    banStatus: "temporary",
+    banReason: "Chargeback abuse",
+    banExpiry: "2026-05-05T00:00:00.000Z"
+  });
+  const port = 44100 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const bannedSession = issueGuestAuthSession({ playerId: "banned-founder", displayName: "Banned Founder" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const unauthorized = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      name: "Nightwatch",
+      tag: "NITE"
+    })
+  });
+  const unauthorizedPayload = (await unauthorized.json()) as { error: { code: string } };
+  assert.equal(unauthorized.status, 401);
+  assert.equal(unauthorizedPayload.error.code, "unauthorized");
+
+  const banned = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${bannedSession.token}`
+    },
+    body: JSON.stringify({
+      name: "Nightwatch",
+      tag: "NITE"
+    })
+  });
+  const bannedPayload = (await banned.json()) as { error: { code: string; reason: string; expiry?: string } };
+  assert.equal(banned.status, 403);
+  assert.equal(bannedPayload.error.code, "account_banned");
+  assert.equal(bannedPayload.error.reason, "Chargeback abuse");
+  assert.equal(bannedPayload.error.expiry, "2026-05-05T00:00:00.000Z");
+});
+
+test("guild routes map malformed payloads and store outages to actionable errors", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 44200 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const founderSession = issueGuestAuthSession({ playerId: "founder-invalid", displayName: "Founder Invalid" });
+
+  const unavailablePort = 44300 + Math.floor(Math.random() * 1000);
+  const unavailableServer = await startGuildRouteServer(null, unavailablePort);
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+    await unavailableServer.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const malformed = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: "{"
+  });
+  const malformedPayload = (await malformed.json()) as { error: { code: string; message: string } };
+  assert.equal(malformed.status, 400);
+  assert.equal(malformedPayload.error.code, "invalid_request");
+  assert.equal(typeof malformedPayload.error.message, "string");
+  assert.ok(malformedPayload.error.message.length > 0);
+
+  const unavailable = await fetch(`http://127.0.0.1:${unavailablePort}/api/guilds`);
+  const unavailablePayload = (await unavailable.json()) as { error: { code: string } };
+  assert.equal(unavailable.status, 503);
+  assert.equal(unavailablePayload.error.code, "guild_store_unavailable");
+});
+
+test("guild routes reject duplicate tags, invalid joins, and invalid leaves", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 44400 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const founderSession = issueGuestAuthSession({ playerId: "founder-dup", displayName: "Founder Dup" });
+  const secondFounderSession = issueGuestAuthSession({ playerId: "founder-other", displayName: "Founder Other" });
+  const recruitSession = issueGuestAuthSession({ playerId: "recruit-dup", displayName: "Recruit Dup" });
+  const outsiderSession = issueGuestAuthSession({ playerId: "outsider-dup", displayName: "Outsider Dup" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const createdOne = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({
+      name: "Nightwatch",
+      tag: "nite"
+    })
+  });
+  const createdOnePayload = (await createdOne.json()) as { guild: { guildId: string } };
+  assert.equal(createdOne.status, 201);
+
+  const duplicateTag = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${secondFounderSession.token}`
+    },
+    body: JSON.stringify({
+      name: "Nightwatch Again",
+      tag: "NITE"
+    })
+  });
+  const duplicateTagPayload = (await duplicateTag.json()) as { error: { code: string } };
+  assert.equal(duplicateTag.status, 409);
+  assert.equal(duplicateTagPayload.error.code, "guild_conflict");
+
+  const joinMissingGuild = await fetch(`http://127.0.0.1:${port}/api/guilds/missing-guild/join`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${recruitSession.token}`
+    }
+  });
+  const joinMissingGuildPayload = (await joinMissingGuild.json()) as { error: { code: string } };
+  assert.equal(joinMissingGuild.status, 404);
+  assert.equal(joinMissingGuildPayload.error.code, "guild_not_found");
+
+  const joined = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdOnePayload.guild.guildId}/join`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${recruitSession.token}`
+    }
+  });
+  assert.equal(joined.status, 200);
+
+  const joinAgain = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdOnePayload.guild.guildId}/join`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${recruitSession.token}`
+    }
+  });
+  const joinAgainPayload = (await joinAgain.json()) as { error: { code: string } };
+  assert.equal(joinAgain.status, 409);
+  assert.equal(joinAgainPayload.error.code, "guild_conflict");
+
+  const outsiderLeave = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdOnePayload.guild.guildId}/leave`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${outsiderSession.token}`
+    }
+  });
+  const outsiderLeavePayload = (await outsiderLeave.json()) as { error: { code: string } };
+  assert.equal(outsiderLeave.status, 409);
+  assert.equal(outsiderLeavePayload.error.code, "guild_membership_invalid");
+});

--- a/apps/server/test/wechat-pay-routes.test.ts
+++ b/apps/server/test/wechat-pay-routes.test.ts
@@ -261,6 +261,123 @@ test("wechat pay create route creates a pending order and returns JSAPI payment 
   });
 });
 
+test("wechat pay create route rejects missing WeChat binding and malformed product requests", async () => {
+  const app = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  const runtimeConfig = createWechatPayConfig();
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig
+  });
+  const session = issueWechatSession();
+
+  const missingOpenId = await app.invoke("/api/payments/wechat/create", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "gem-pack-premium"
+    })
+  });
+  const missingOpenIdPayload = missingOpenId.json as { error: { code: string } };
+  assert.equal(missingOpenId.statusCode, 400);
+  assert.equal(missingOpenIdPayload.error.code, "wechat_open_id_required");
+
+  const invalidProduct = await app.invoke("/api/payments/wechat/create", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "missing-product"
+    })
+  });
+  const invalidProductPayload = invalidProduct.json as { error: { message: string } };
+  assert.equal(invalidProduct.statusCode, 400);
+  assert.equal(invalidProductPayload.error.message, "product_not_found");
+
+  const malformedJson = await app.invoke("/api/payments/wechat/create", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: "{"
+  });
+  assert.equal(malformedJson.statusCode, 400);
+});
+
+test("wechat pay create route surfaces missing configuration and upstream order creation failures", async () => {
+  const session = issueWechatSession();
+
+  const configMissingApp = new TestApp();
+  const verifiedStore = await createVerifiedTestStore();
+  registerWechatPayRoutes(configMissingApp as never, verifiedStore, {
+    products: TEST_PRODUCTS,
+    runtimeConfig: null
+  });
+  const missingConfig = await configMissingApp.invoke("/api/payments/wechat/create", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "gem-pack-premium"
+    })
+  });
+  const missingConfigPayload = missingConfig.json as { error: { code: string } };
+  assert.equal(missingConfig.statusCode, 503);
+  assert.equal(missingConfigPayload.error.code, "wechat_pay_not_configured");
+
+  const upstreamFailureApp = new TestApp();
+  registerWechatPayRoutes(upstreamFailureApp as never, verifiedStore, {
+    products: TEST_PRODUCTS,
+    runtimeConfig: createWechatPayConfig(),
+    fetchImpl: async () =>
+      new Response("gateway exploded", {
+        status: 502
+      })
+  });
+  const upstreamFailure = await upstreamFailureApp.invoke("/api/payments/wechat/create", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "gem-pack-premium"
+    })
+  });
+  const upstreamFailurePayload = upstreamFailure.json as { error: { code: string; message: string } };
+  assert.equal(upstreamFailure.statusCode, 502);
+  assert.equal(upstreamFailurePayload.error.code, "wechat_order_create_failed");
+  assert.equal(upstreamFailurePayload.error.message, "gateway exploded");
+
+  const invalidResponseApp = new TestApp();
+  registerWechatPayRoutes(invalidResponseApp as never, verifiedStore, {
+    products: TEST_PRODUCTS,
+    runtimeConfig: createWechatPayConfig(),
+    fetchImpl: async () =>
+      new Response(JSON.stringify({ prepay_id: " " }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      })
+  });
+  const invalidResponse = await invalidResponseApp.invoke("/api/payments/wechat/create", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "gem-pack-premium"
+    })
+  });
+  const invalidResponsePayload = invalidResponse.json as { error: { code: string } };
+  assert.equal(invalidResponse.statusCode, 502);
+  assert.equal(invalidResponsePayload.error.code, "wechat_order_create_invalid_response");
+});
+
 test("wechat pay verify route grants a successful verified payment and stores the receipt", async () => {
   const app = new TestApp();
   const store = await createVerifiedTestStore();
@@ -467,6 +584,89 @@ test("wechat pay verify route rejects payer openid mismatches without granting r
   assert.equal(receipt, null);
 });
 
+test("wechat pay verify route validates order ownership, player bindings, and runtime config", async () => {
+  const session = issueWechatSession();
+
+  const missingConfigApp = new TestApp();
+  const readyStore = await createVerifiedTestStore();
+  registerWechatPayRoutes(missingConfigApp as never, readyStore, {
+    products: TEST_PRODUCTS,
+    runtimeConfig: null
+  });
+  const missingConfig = await missingConfigApp.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: "wechat-order-1"
+    })
+  });
+  const missingConfigPayload = missingConfig.json as { error: { code: string } };
+  assert.equal(missingConfig.statusCode, 503);
+  assert.equal(missingConfigPayload.error.code, "wechat_pay_not_configured");
+
+  const runtimeConfig = createWechatPayConfig();
+  const invalidOrderApp = new TestApp();
+  registerWechatPayRoutes(invalidOrderApp as never, readyStore, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({})
+  });
+  const invalidOrder = await invalidOrderApp.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({})
+  });
+  const invalidOrderPayload = invalidOrder.json as { error: { code: string } };
+  assert.equal(invalidOrder.statusCode, 400);
+  assert.equal(invalidOrderPayload.error.code, "invalid_order_id");
+
+  const notFound = await invalidOrderApp.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: "missing-order"
+    })
+  });
+  const notFoundPayload = notFound.json as { error: { code: string } };
+  assert.equal(notFound.statusCode, 404);
+  assert.equal(notFoundPayload.error.code, "payment_order_not_found");
+
+  const noBindingApp = new TestApp();
+  const noBindingStore = new MemoryRoomSnapshotStore();
+  const order = await noBindingStore.createPaymentOrder({
+    orderId: "wechat-order-no-openid",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  registerWechatPayRoutes(noBindingApp as never, noBindingStore, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({
+      out_trade_no: order.orderId
+    })
+  });
+  const noBinding = await noBindingApp.invoke("/api/payments/wechat/verify", {
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      orderId: order.orderId
+    })
+  });
+  const noBindingPayload = noBinding.json as { error: { code: string } };
+  assert.equal(noBinding.statusCode, 400);
+  assert.equal(noBindingPayload.error.code, "wechat_open_id_required");
+});
+
 test("wechat pay callback verifies, credits once, and ignores duplicate notifications", async () => {
   const app = new TestApp();
   const store = await createVerifiedTestStore();
@@ -639,4 +839,274 @@ test("wechat pay callback rejects invalid signatures", async () => {
   assert.equal(response.statusCode, 401);
   assert.equal(payload.code, "FAIL");
   assert.match(payload.message, /signature verification failed/);
+});
+
+test("wechat pay callback rejects unsupported trade states", async () => {
+  const store = new MemoryRoomSnapshotStore();
+  const runtimeConfig = createWechatPayConfig();
+  const callbackApp = new TestApp();
+  registerWechatPayRoutes(callbackApp as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({})
+  });
+
+  const unsupportedTradeStateTransaction = {
+    appid: runtimeConfig.appId,
+    mchid: runtimeConfig.merchantId,
+    out_trade_no: "wechat-order-unsupported",
+    transaction_id: "wechat-transaction-unsupported",
+    trade_state: "USERPAYING",
+    amount: {
+      total: 600
+    },
+    payer: {
+      openid: "wx-openid-player"
+    }
+  };
+  const unsupportedTradeStateResource = encryptWechatCallbackResourceForTest(
+    runtimeConfig.apiV3Key,
+    JSON.stringify(unsupportedTradeStateTransaction),
+    "callback-nonce-unsupported"
+  );
+  const unsupportedTradeStateBody = JSON.stringify({
+    id: "evt-unsupported",
+    event_type: "TRANSACTION.SUCCESS",
+    resource_type: "encrypt-resource",
+    resource: unsupportedTradeStateResource
+  });
+  const unsupportedTradeStateTimestamp = "1712197202";
+  const unsupportedTradeStateNonce = "signature-nonce-unsupported";
+  const unsupportedTradeStateSignature = signWechatCallbackForTest(
+    runtimeConfig.platformPrivateKey,
+    unsupportedTradeStateTimestamp,
+    unsupportedTradeStateNonce,
+    unsupportedTradeStateBody
+  );
+  const unsupportedTradeState = await callbackApp.invoke("/api/payments/wechat/callback", {
+    headers: {
+      "content-type": "application/json",
+      "wechatpay-timestamp": unsupportedTradeStateTimestamp,
+      "wechatpay-nonce": unsupportedTradeStateNonce,
+      "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+      "wechatpay-signature": unsupportedTradeStateSignature
+    },
+    body: unsupportedTradeStateBody
+  });
+  const unsupportedTradeStatePayload = unsupportedTradeState.json as { message: string };
+  assert.equal(unsupportedTradeState.statusCode, 400);
+  assert.equal(unsupportedTradeStatePayload.message, "unsupported trade state");
+});
+
+test("wechat pay callback rejects merchant mismatches", async () => {
+  const store = new MemoryRoomSnapshotStore();
+  const runtimeConfig = createWechatPayConfig();
+  const callbackApp = new TestApp();
+  registerWechatPayRoutes(callbackApp as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({})
+  });
+
+  const merchantMismatchTransaction = {
+    appid: "wrong-app",
+    mchid: runtimeConfig.merchantId,
+    out_trade_no: "wechat-order-mismatch",
+    transaction_id: "wechat-transaction-mismatch",
+    trade_state: "SUCCESS",
+    amount: {
+      total: 600
+    },
+    payer: {
+      openid: "wx-openid-player"
+    }
+  };
+  const merchantMismatchResource = encryptWechatCallbackResourceForTest(
+    runtimeConfig.apiV3Key,
+    JSON.stringify(merchantMismatchTransaction),
+    "callback-nonce-merchant"
+  );
+  const merchantMismatchBody = JSON.stringify({
+    id: "evt-merchant",
+    event_type: "TRANSACTION.SUCCESS",
+    resource_type: "encrypt-resource",
+    resource: merchantMismatchResource
+  });
+  const merchantMismatchTimestamp = "1712197203";
+  const merchantMismatchNonce = "signature-nonce-merchant";
+  const merchantMismatchSignature = signWechatCallbackForTest(
+    runtimeConfig.platformPrivateKey,
+    merchantMismatchTimestamp,
+    merchantMismatchNonce,
+    merchantMismatchBody
+  );
+  const merchantMismatch = await callbackApp.invoke("/api/payments/wechat/callback", {
+    headers: {
+      "content-type": "application/json",
+      "wechatpay-timestamp": merchantMismatchTimestamp,
+      "wechatpay-nonce": merchantMismatchNonce,
+      "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+      "wechatpay-signature": merchantMismatchSignature
+    },
+    body: merchantMismatchBody
+  });
+  const merchantMismatchPayload = merchantMismatch.json as { message: string };
+  assert.equal(merchantMismatch.statusCode, 400);
+  assert.equal(merchantMismatchPayload.message, "merchant validation failed");
+});
+
+test("wechat pay callback rejects missing order ids, missing orders, and missing payer bindings", async () => {
+  const runtimeConfig = createWechatPayConfig();
+  const callbackApp = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  registerWechatPayRoutes(callbackApp as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({})
+  });
+
+  const missingOrderIdTransaction = {
+    appid: runtimeConfig.appId,
+    mchid: runtimeConfig.merchantId,
+    out_trade_no: " ",
+    transaction_id: "wechat-transaction-no-order",
+    trade_state: "SUCCESS",
+    amount: {
+      total: 600
+    },
+    payer: {
+      openid: "wx-openid-player"
+    }
+  };
+  const missingOrderIdResource = encryptWechatCallbackResourceForTest(
+    runtimeConfig.apiV3Key,
+    JSON.stringify(missingOrderIdTransaction),
+    "callback-nonce-order-id"
+  );
+  const missingOrderIdBody = JSON.stringify({
+    id: "evt-missing-order-id",
+    event_type: "TRANSACTION.SUCCESS",
+    resource_type: "encrypt-resource",
+    resource: missingOrderIdResource
+  });
+  const missingOrderIdTimestamp = "1712197204";
+  const missingOrderIdNonce = "signature-nonce-order-id";
+  const missingOrderIdSignature = signWechatCallbackForTest(
+    runtimeConfig.platformPrivateKey,
+    missingOrderIdTimestamp,
+    missingOrderIdNonce,
+    missingOrderIdBody
+  );
+  const missingOrderId = await callbackApp.invoke("/api/payments/wechat/callback", {
+    headers: {
+      "content-type": "application/json",
+      "wechatpay-timestamp": missingOrderIdTimestamp,
+      "wechatpay-nonce": missingOrderIdNonce,
+      "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+      "wechatpay-signature": missingOrderIdSignature
+    },
+    body: missingOrderIdBody
+  });
+  const missingOrderIdPayload = missingOrderId.json as { message: string };
+  assert.equal(missingOrderId.statusCode, 400);
+  assert.equal(missingOrderIdPayload.message, "order identifiers are missing");
+
+  const missingOrderTransaction = {
+    appid: runtimeConfig.appId,
+    mchid: runtimeConfig.merchantId,
+    out_trade_no: "wechat-order-missing",
+    transaction_id: "wechat-transaction-missing",
+    trade_state: "SUCCESS",
+    amount: {
+      total: 600
+    },
+    payer: {
+      openid: "wx-openid-player"
+    }
+  };
+  const missingOrderResource = encryptWechatCallbackResourceForTest(
+    runtimeConfig.apiV3Key,
+    JSON.stringify(missingOrderTransaction),
+    "callback-nonce-missing-order"
+  );
+  const missingOrderBody = JSON.stringify({
+    id: "evt-missing-order",
+    event_type: "TRANSACTION.SUCCESS",
+    resource_type: "encrypt-resource",
+    resource: missingOrderResource
+  });
+  const missingOrderTimestamp = "1712197205";
+  const missingOrderNonce = "signature-nonce-missing-order";
+  const missingOrderSignature = signWechatCallbackForTest(
+    runtimeConfig.platformPrivateKey,
+    missingOrderTimestamp,
+    missingOrderNonce,
+    missingOrderBody
+  );
+  const missingOrder = await callbackApp.invoke("/api/payments/wechat/callback", {
+    headers: {
+      "content-type": "application/json",
+      "wechatpay-timestamp": missingOrderTimestamp,
+      "wechatpay-nonce": missingOrderNonce,
+      "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+      "wechatpay-signature": missingOrderSignature
+    },
+    body: missingOrderBody
+  });
+  const missingOrderPayload = missingOrder.json as { message: string };
+  assert.equal(missingOrder.statusCode, 404);
+  assert.equal(missingOrderPayload.message, "payment order not found");
+
+  const orderWithoutBinding = await store.createPaymentOrder({
+    orderId: "wechat-order-no-binding",
+    playerId: "wechat-player",
+    productId: "gem-pack-premium",
+    amount: 600,
+    gemAmount: 120
+  });
+  const missingBindingTransaction = {
+    appid: runtimeConfig.appId,
+    mchid: runtimeConfig.merchantId,
+    out_trade_no: orderWithoutBinding.orderId,
+    transaction_id: "wechat-transaction-no-binding",
+    trade_state: "SUCCESS",
+    amount: {
+      total: 600
+    },
+    payer: {
+      openid: "wx-openid-player"
+    }
+  };
+  const missingBindingResource = encryptWechatCallbackResourceForTest(
+    runtimeConfig.apiV3Key,
+    JSON.stringify(missingBindingTransaction),
+    "callback-nonce-no-binding"
+  );
+  const missingBindingBody = JSON.stringify({
+    id: "evt-no-binding",
+    event_type: "TRANSACTION.SUCCESS",
+    resource_type: "encrypt-resource",
+    resource: missingBindingResource
+  });
+  const missingBindingTimestamp = "1712197206";
+  const missingBindingNonce = "signature-nonce-no-binding";
+  const missingBindingSignature = signWechatCallbackForTest(
+    runtimeConfig.platformPrivateKey,
+    missingBindingTimestamp,
+    missingBindingNonce,
+    missingBindingBody
+  );
+  const missingBinding = await callbackApp.invoke("/api/payments/wechat/callback", {
+    headers: {
+      "content-type": "application/json",
+      "wechatpay-timestamp": missingBindingTimestamp,
+      "wechatpay-nonce": missingBindingNonce,
+      "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+      "wechatpay-signature": missingBindingSignature
+    },
+    body: missingBindingBody
+  });
+  const missingBindingPayload = missingBinding.json as { message: string };
+  assert.equal(missingBinding.statusCode, 400);
+  assert.equal(missingBindingPayload.message, "payer validation failed");
 });


### PR DESCRIPTION
## Summary
- add targeted guild route coverage for auth failures, malformed payload handling, store outages, and membership/tag conflict paths
- add targeted WeChat Pay route coverage for create, verify, and callback early exits and validation branches
- harden `guilds.ts` malformed JSON handling so `SyntaxError` payload failures consistently map to `400 invalid_request`

## Validation
- `node --import tsx --test --test-force-exit apps/server/test/guild-routes.test.ts apps/server/test/wechat-pay-routes.test.ts apps/server/test/matchmaking-routes.test.ts apps/server/test/matchmaking-service.test.ts apps/server/test/config-center.test.ts`
- `node --import tsx --test --test-force-exit --experimental-test-coverage --test-coverage-include='apps/server/src/guilds.ts' apps/server/test/guild-routes.test.ts`
- `node --import tsx --test --test-force-exit --experimental-test-coverage --test-coverage-include='apps/server/src/wechat-pay.ts' apps/server/test/wechat-pay-routes.test.ts`
- `npm run test:coverage:ci` currently still fails before the server suite in `release-scripts` because `scripts/test/wechat-release-artifacts.test.ts` has two existing failing cases unrelated to this change

Closes #978