### PR TITLE
[OBSERVABILITY] Add room lifecycle metrics and summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 - 运行时健康检查：`GET http://127.0.0.1:2567/api/runtime/health`
 - 鉴权就绪摘要：`GET http://127.0.0.1:2567/api/runtime/auth-readiness`
 - 运行时指标抓取：`GET http://127.0.0.1:2567/api/runtime/metrics`
+- 房间 / 重连 / 战斗生命周期摘要：`GET http://127.0.0.1:2567/api/runtime/room-lifecycle-summary`（可加 `?format=text` 输出适合告警或 artifact 留档的紧凑文本）
 - 终端逻辑演示：`npm run demo:flow`
 - 主客户端入口说明：`npm run client:primary`
 - Cocos 主客户端类型检查：`npm run typecheck:client`
@@ -185,7 +186,7 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 - Same-revision 发布证据组装 runbook：`docs/same-revision-release-evidence-runbook.md`
 - Candidate-level 发布证据 freshness / consistency audit：`npm run release:candidate:evidence-audit -- --candidate <candidate-name> --candidate-revision <git-sha> --target-surface <auto|h5|wechat>`（输出 candidate-scoped JSON / Markdown 审计，汇总 blocking vs warning 结论，并校验 revision mismatch、artifact staleness、runtime observability evidence / gate、WeChat manual checks、owner ledger freshness；兼容旧别名 `release:same-candidate:evidence-audit`）
 - 统一发布门禁汇总：`npm run release:gate:summary`
-- Candidate-scoped runtime observability evidence：`npm run release:runtime-observability:evidence -- --candidate <candidate-name> --candidate-revision <git-sha> --target-surface <h5|wechat> --target-environment <env-name> --server-url <base-url>`（抓取 `/api/runtime/health`、`/api/runtime/auth-readiness`、`/api/runtime/metrics` 的同一候选包证据，并在 `artifacts/release-readiness/` 输出 candidate+revision 命名的 JSON / Markdown）
+- Candidate-scoped runtime observability evidence：`npm run release:runtime-observability:evidence -- --candidate <candidate-name> --candidate-revision <git-sha> --target-surface <h5|wechat> --target-environment <env-name> --server-url <base-url>`（抓取 `/api/runtime/health`、`/api/runtime/auth-readiness`、`/api/runtime/metrics`，必要时补抓 `/api/runtime/room-lifecycle-summary` 作为 battle / reconnect triage companion evidence，并在 `artifacts/release-readiness/` 输出 candidate+revision 命名的 JSON / Markdown）
 - Candidate-scoped runtime observability gate：`npm run release:runtime-observability:gate -- --candidate <candidate-name> --candidate-revision <git-sha> --capture-report <runtime-observability-evidence.json>`（基于已捕获的 runtime evidence 生成 pass/fail gate；也可直接传 `--server-url` 让 gate 即时采样）
 - Candidate-level reconnect soak：`npm run release:reconnect-soak -- --candidate <candidate-name> --candidate-revision <git-sha>`（输出 candidate+revision 命名的 reconnect soak JSON / Markdown，并供 release gate / dossier 直接引用）
 - 发布健康度聚合摘要：`npm run release:health:summary`

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -45,7 +45,10 @@ import { resolveGuestAuthSession } from "./auth";
 import { deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
 import {
   recordBattleActionMessage,
+  recordBattleLifecycleResolved,
   recordConnectMessage,
+  recordRoomCreated,
+  recordRoomDisposed,
   recordReconnectWindowOpened,
   recordReconnectWindowResolved,
   recordRuntimeRoom,
@@ -319,6 +322,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
   private turnTimerHandle: RoomTimerHandle | null = null;
   private turnOwnerPlayerId: string | null = null;
   private turnTimerTickInFlight = false;
+  private roomRetired = false;
 
   async onCreate(options: JoinOptions): Promise<void> {
     const logicalRoomId = options.logicalRoomId ?? "room-alpha";
@@ -354,6 +358,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
 
     await this.persistRoomState();
     this.publishLobbyRoomSummary();
+    recordRoomCreated(logicalRoomId);
     this.ensureTurnTimerLoop();
 
     this.unsubscribeConfigUpdate = registerConfigUpdateListener((bundle) => {
@@ -724,7 +729,10 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       recordReconnectWindowOpened();
       reconnectWindowOpen = true;
       const reconnectedClient = await this.allowReconnection(client, RECONNECTION_WINDOW_SECONDS);
-      recordReconnectWindowResolved("success");
+      recordReconnectWindowResolved("success", {
+        roomId: this.metadata.logicalRoomId,
+        playerId
+      });
       reconnectWindowOpen = false;
       if (configuredRoomSnapshotStore?.loadPlayerBan) {
         const ban = await configuredRoomSnapshotStore.loadPlayerBan(playerId);
@@ -753,7 +761,11 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       });
     } catch {
       if (reconnectWindowOpen) {
-        recordReconnectWindowResolved("failure");
+        recordReconnectWindowResolved("failure", {
+          roomId: this.metadata.logicalRoomId,
+          playerId,
+          reason: "reconnect_window_expired"
+        });
       }
       this.playerIdBySessionId.delete(client.sessionId);
       this.ensureTurnTimerState();
@@ -784,10 +796,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       return;
     }
 
-    lobbyRoomOwnerTokens.delete(this.metadata.logicalRoomId);
-    lobbyRoomSummaries.delete(this.metadata.logicalRoomId);
-    activeRoomInstances.delete(this.metadata.logicalRoomId);
-    removeRuntimeRoom(this.metadata.logicalRoomId);
+    this.retireRoom("dispose");
   }
 
   private restoreWorldRoom(snapshot: RoomPersistenceSnapshot): void {
@@ -1469,8 +1478,30 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       }
     }
     this.clients.splice(0, this.clients.length);
+    this.retireRoom(reason);
+  }
+
+  private retireRoom(reason: string): void {
+    if (this.roomRetired) {
+      return;
+    }
+
+    this.roomRetired = true;
+
+    for (const battle of this.worldRoom.getActiveBattles()) {
+      recordBattleLifecycleResolved({
+        roomId: this.metadata.logicalRoomId,
+        battleId: battle.id,
+        outcome: "aborted",
+        reason
+      });
+    }
+
+    recordRoomDisposed(this.metadata.logicalRoomId, reason);
+    lobbyRoomOwnerTokens.delete(this.metadata.logicalRoomId);
     lobbyRoomSummaries.delete(this.metadata.logicalRoomId);
     activeRoomInstances.delete(this.metadata.logicalRoomId);
+    removeRuntimeRoom(this.metadata.logicalRoomId);
   }
 
   private resolveReportTargetPlayerId(playerId: string, requestedTargetPlayerId: string): string | null {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -63,11 +63,18 @@ export interface RoomPersistenceSnapshot {
 
 interface AuthoritativeRoomTelemetry {
   recordBattleDuration(durationSeconds: number): void;
+  recordBattleResolved(input: {
+    roomId: string;
+    battleId: string;
+    outcome: "completed" | "aborted";
+    reason?: string;
+  }): void;
   recordActionValidationFailure(scope: "world" | "battle", reason: string): void;
 }
 
 const defaultAuthoritativeRoomTelemetry: AuthoritativeRoomTelemetry = {
   recordBattleDuration: () => {},
+  recordBattleResolved: () => {},
   recordActionValidationFailure: () => {}
 };
 
@@ -296,6 +303,12 @@ export class AuthoritativeWorldRoom {
       if (outcome.status !== "in_progress") {
         this.finalizeBattleReplay(battle, outcome);
         this.recordCompletedBattleDuration(battle.id);
+        authoritativeRoomTelemetry.recordBattleResolved({
+          roomId: this.state.meta.roomId,
+          battleId: battle.id,
+          outcome: "completed",
+          reason: outcome.status
+        });
         if (battle.worldHeroId) {
           const worldOutcome = applyBattleOutcomeToWorld(
             this.state,

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -112,6 +112,30 @@ interface ReconnectObservabilityCounters {
   failuresTotal: number;
 }
 
+interface RoomLifecycleObservabilityCounters {
+  roomCreatesTotal: number;
+  roomDisposalsTotal: number;
+  battleCompletionsTotal: number;
+  battleAbortsTotal: number;
+}
+
+type RoomLifecycleEventKind =
+  | "room.created"
+  | "room.disposed"
+  | "reconnect.succeeded"
+  | "reconnect.failed"
+  | "battle.completed"
+  | "battle.aborted";
+
+export interface RoomLifecycleEvent {
+  timestamp: string;
+  kind: RoomLifecycleEventKind;
+  roomId: string;
+  playerId?: string;
+  battleId?: string;
+  reason?: string;
+}
+
 interface RuntimeObservabilityState {
   startedAt: number;
   rooms: Map<string, RuntimeRoomSnapshot>;
@@ -126,6 +150,10 @@ interface RuntimeObservabilityState {
   reconnect: {
     pendingWindowCount: number;
     counters: ReconnectObservabilityCounters;
+  };
+  roomLifecycle: {
+    counters: RoomLifecycleObservabilityCounters;
+    recentEvents: RoomLifecycleEvent[];
   };
   matchmaking: {
     counters: MatchmakingObservabilityCounters;
@@ -180,6 +208,10 @@ interface RuntimeHealthPayload {
         failureReasons: Record<AuthTokenDeliveryFailureReason, number>;
       };
     };
+    roomLifecycle: {
+      counters: RoomLifecycleObservabilityCounters;
+      recentEventsTracked: number;
+    };
     matchmaking: {
       counters: MatchmakingObservabilityCounters;
     };
@@ -211,7 +243,22 @@ interface AuthTokenDeliveryPayload {
   };
 }
 
+export interface RoomLifecycleSummaryPayload {
+  status: "ok" | "warn";
+  service: string;
+  checkedAt: string;
+  headline: string;
+  alerts: string[];
+  summary: {
+    activeRoomCount: number;
+    pendingReconnectCount: number;
+    counters: RoomLifecycleObservabilityCounters;
+    recentEvents: RoomLifecycleEvent[];
+  };
+}
+
 const RECENT_TOKEN_DELIVERY_ATTEMPTS_LIMIT = 25;
+const RECENT_ROOM_LIFECYCLE_EVENTS_LIMIT = 25;
 const BATTLE_DURATION_SECONDS_BUCKETS = [1, 5, 10, 30, 60, 120, 300, 600];
 const HTTP_REQUEST_DURATION_SECONDS_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
 
@@ -295,12 +342,28 @@ const runtimeObservability: RuntimeObservabilityState = {
       failuresTotal: 0
     }
   },
+  roomLifecycle: {
+    counters: {
+      roomCreatesTotal: 0,
+      roomDisposalsTotal: 0,
+      battleCompletionsTotal: 0,
+      battleAbortsTotal: 0
+    },
+    recentEvents: []
+  },
   matchmaking: {
     counters: {
       rateLimitedTotal: 0
     }
   }
 };
+
+function pushRoomLifecycleEvent(event: RoomLifecycleEvent): void {
+  runtimeObservability.roomLifecycle.recentEvents.unshift(event);
+  if (runtimeObservability.roomLifecycle.recentEvents.length > RECENT_ROOM_LIFECYCLE_EVENTS_LIMIT) {
+    runtimeObservability.roomLifecycle.recentEvents.length = RECENT_ROOM_LIFECYCLE_EVENTS_LIMIT;
+  }
+}
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -423,6 +486,10 @@ function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPaylo
           failureReasons: { ...runtimeObservability.auth.tokenDeliveryFailureReasons }
         }
       },
+      roomLifecycle: {
+        counters: { ...runtimeObservability.roomLifecycle.counters },
+        recentEventsTracked: runtimeObservability.roomLifecycle.recentEvents.length
+      },
       matchmaking: {
         counters: { ...runtimeObservability.matchmaking.counters }
       }
@@ -514,6 +581,67 @@ function buildAuthTokenDeliveryPayload(service = "project-veil-server"): AuthTok
       recentAttempts
     }
   };
+}
+
+export function buildRoomLifecycleSummaryPayload(service = "project-veil-server"): RoomLifecycleSummaryPayload {
+  const health = buildHealthPayload(service);
+  const recentEvents = runtimeObservability.roomLifecycle.recentEvents.map((event) => ({ ...event }));
+  const alerts: string[] = [];
+
+  if (health.runtime.auth.reconnect.pendingWindowCount > 0) {
+    alerts.push(`${health.runtime.auth.reconnect.pendingWindowCount} reconnect window(s) still pending`);
+  }
+
+  const recentBattleAbort = recentEvents.find((event) => event.kind === "battle.aborted");
+  if (recentBattleAbort) {
+    alerts.push(`recent battle abort recorded for room ${recentBattleAbort.roomId}`);
+  }
+
+  return {
+    status: alerts.length > 0 ? "warn" : "ok",
+    service,
+    checkedAt: health.checkedAt,
+    headline:
+      `rooms=${health.runtime.activeRoomCount} ` +
+      `reconnectPending=${health.runtime.auth.reconnect.pendingWindowCount} ` +
+      `created=${health.runtime.roomLifecycle.counters.roomCreatesTotal} ` +
+      `disposed=${health.runtime.roomLifecycle.counters.roomDisposalsTotal} ` +
+      `battleCompleted=${health.runtime.roomLifecycle.counters.battleCompletionsTotal} ` +
+      `battleAborted=${health.runtime.roomLifecycle.counters.battleAbortsTotal}`,
+    alerts,
+    summary: {
+      activeRoomCount: health.runtime.activeRoomCount,
+      pendingReconnectCount: health.runtime.auth.reconnect.pendingWindowCount,
+      counters: { ...health.runtime.roomLifecycle.counters },
+      recentEvents
+    }
+  };
+}
+
+export function renderRoomLifecycleSummaryText(report: RoomLifecycleSummaryPayload): string {
+  const header =
+    `room_lifecycle status=${report.status}` +
+    ` | rooms=${report.summary.activeRoomCount}` +
+    ` | reconnect_pending=${report.summary.pendingReconnectCount}` +
+    ` | room_creates=${report.summary.counters.roomCreatesTotal}` +
+    ` | room_disposals=${report.summary.counters.roomDisposalsTotal}` +
+    ` | battle_completed=${report.summary.counters.battleCompletionsTotal}` +
+    ` | battle_aborted=${report.summary.counters.battleAbortsTotal}`;
+  const eventLines = report.summary.recentEvents.map((event) => {
+    const parts = [`${event.timestamp}`, event.kind, `room=${event.roomId}`];
+    if (event.playerId) {
+      parts.push(`player=${event.playerId}`);
+    }
+    if (event.battleId) {
+      parts.push(`battle=${event.battleId}`);
+    }
+    if (event.reason) {
+      parts.push(`reason=${event.reason}`);
+    }
+    return parts.join(" | ");
+  });
+
+  return `${[header, ...eventLines].join("\n")}\n`;
 }
 
 function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): RuntimeDiagnosticsSnapshot {
@@ -678,6 +806,18 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_reconnect_failures_total Total reconnect windows that expired or failed.",
     "# TYPE veil_reconnect_failures_total counter",
     `veil_reconnect_failures_total ${health.runtime.auth.reconnect.counters.failuresTotal}`,
+    "# HELP veil_room_creates_total Total logical room instances created successfully.",
+    "# TYPE veil_room_creates_total counter",
+    `veil_room_creates_total ${health.runtime.roomLifecycle.counters.roomCreatesTotal}`,
+    "# HELP veil_room_disposals_total Total logical room instances retired or disposed.",
+    "# TYPE veil_room_disposals_total counter",
+    `veil_room_disposals_total ${health.runtime.roomLifecycle.counters.roomDisposalsTotal}`,
+    "# HELP veil_battle_completions_total Total battles that resolved to a gameplay outcome.",
+    "# TYPE veil_battle_completions_total counter",
+    `veil_battle_completions_total ${health.runtime.roomLifecycle.counters.battleCompletionsTotal}`,
+    "# HELP veil_battle_aborts_total Total battles aborted because a room was retired before resolution.",
+    "# TYPE veil_battle_aborts_total counter",
+    `veil_battle_aborts_total ${health.runtime.roomLifecycle.counters.battleAbortsTotal}`,
     "# HELP veil_auth_guest_sessions Active guest auth sessions tracked by this process.",
     "# TYPE veil_auth_guest_sessions gauge",
     `veil_auth_guest_sessions ${health.runtime.auth.activeGuestSessionCount}`,
@@ -1153,6 +1293,46 @@ export function recordBattleDuration(durationSeconds: number): void {
   observeHistogram(runtimeObservability.prometheus.battleDurationSeconds, durationSeconds);
 }
 
+export function recordRoomCreated(roomId: string): void {
+  runtimeObservability.roomLifecycle.counters.roomCreatesTotal += 1;
+  pushRoomLifecycleEvent({
+    timestamp: new Date().toISOString(),
+    kind: "room.created",
+    roomId
+  });
+}
+
+export function recordRoomDisposed(roomId: string, reason = "dispose"): void {
+  runtimeObservability.roomLifecycle.counters.roomDisposalsTotal += 1;
+  pushRoomLifecycleEvent({
+    timestamp: new Date().toISOString(),
+    kind: "room.disposed",
+    roomId,
+    reason
+  });
+}
+
+export function recordBattleLifecycleResolved(input: {
+  roomId: string;
+  battleId: string;
+  outcome: "completed" | "aborted";
+  reason?: string;
+}): void {
+  if (input.outcome === "completed") {
+    runtimeObservability.roomLifecycle.counters.battleCompletionsTotal += 1;
+  } else {
+    runtimeObservability.roomLifecycle.counters.battleAbortsTotal += 1;
+  }
+
+  pushRoomLifecycleEvent({
+    timestamp: new Date().toISOString(),
+    kind: input.outcome === "completed" ? "battle.completed" : "battle.aborted",
+    roomId: input.roomId,
+    battleId: input.battleId,
+    ...(input.reason ? { reason: input.reason } : {})
+  });
+}
+
 export function recordActionValidationFailure(scope: ActionValidationScope, reason: string): void {
   const normalizedReason = reason.trim() || "unknown";
   const key = `${scope}::${normalizedReason}`;
@@ -1164,6 +1344,7 @@ export function recordActionValidationFailure(scope: ActionValidationScope, reas
 
 configureAuthoritativeRoomTelemetry({
   recordBattleDuration,
+  recordBattleResolved: recordBattleLifecycleResolved,
   recordActionValidationFailure
 });
 
@@ -1341,13 +1522,30 @@ export function recordReconnectWindowOpened(): void {
   runtimeObservability.reconnect.counters.attemptsTotal += 1;
 }
 
-export function recordReconnectWindowResolved(outcome: "success" | "failure"): void {
+export function recordReconnectWindowResolved(
+  outcome: "success" | "failure",
+  details?: {
+    roomId?: string;
+    playerId?: string;
+    reason?: string;
+  }
+): void {
   runtimeObservability.reconnect.pendingWindowCount = Math.max(0, runtimeObservability.reconnect.pendingWindowCount - 1);
   if (outcome === "success") {
     runtimeObservability.reconnect.counters.successesTotal += 1;
-    return;
+  } else {
+    runtimeObservability.reconnect.counters.failuresTotal += 1;
   }
-  runtimeObservability.reconnect.counters.failuresTotal += 1;
+
+  if (details?.roomId) {
+    pushRoomLifecycleEvent({
+      timestamp: new Date().toISOString(),
+      kind: outcome === "success" ? "reconnect.succeeded" : "reconnect.failed",
+      roomId: details.roomId,
+      ...(details.playerId ? { playerId: details.playerId } : {}),
+      ...(details.reason ? { reason: details.reason } : {})
+    });
+  }
 }
 
 export function resetRuntimeObservability(): void {
@@ -1404,6 +1602,11 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.reconnect.counters.attemptsTotal = 0;
   runtimeObservability.reconnect.counters.successesTotal = 0;
   runtimeObservability.reconnect.counters.failuresTotal = 0;
+  runtimeObservability.roomLifecycle.counters.roomCreatesTotal = 0;
+  runtimeObservability.roomLifecycle.counters.roomDisposalsTotal = 0;
+  runtimeObservability.roomLifecycle.counters.battleCompletionsTotal = 0;
+  runtimeObservability.roomLifecycle.counters.battleAbortsTotal = 0;
+  runtimeObservability.roomLifecycle.recentEvents.length = 0;
   runtimeObservability.matchmaking.counters.rateLimitedTotal = 0;
 }
 
@@ -1448,6 +1651,24 @@ export function registerRuntimeObservabilityRoutes(
       response.statusCode = 200;
       response.setHeader("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
       response.end(`${buildPrometheusMetricsDocument()}\n`);
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/runtime/room-lifecycle-summary", async (request, response) => {
+    try {
+      const summary = buildRoomLifecycleSummaryPayload(serviceName);
+      const url = new URL(request.url ?? "/api/runtime/room-lifecycle-summary", "http://runtime.local");
+
+      if (url.searchParams.get("format") === "text") {
+        response.statusCode = 200;
+        response.setHeader("Content-Type", "text/plain; charset=utf-8");
+        response.end(renderRoomLifecycleSummaryText(summary));
+        return;
+      }
+
+      sendJson(response, 200, summary);
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../src/colyseus-room";
 import { createRoom, type RoomPersistenceSnapshot } from "../src/index";
 import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import { buildRoomLifecycleSummaryPayload, resetRuntimeObservability } from "../src/observability";
 import type { PlayerAccountEnsureInput, PlayerAccountProgressPatch, PlayerAccountSnapshot } from "../src/persistence";
 
 interface FakeClient extends Client {
@@ -459,6 +460,7 @@ test("connect logs player account initialization failures instead of silently sw
 test("client reconnect within the window restores room state and records reconnectedAt", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
+  resetRuntimeObservability();
   const room = await createTestRoom(`lifecycle-reconnect-${Date.now()}`);
   const originalClient = createFakeClient("session-original");
   const reconnectedClient = createFakeClient("session-reconnected");
@@ -475,6 +477,7 @@ test("client reconnect within the window restores room state and records reconne
     cleanupRoom(room);
     resetLobbyRoomRegistry();
     configureRoomSnapshotStore(null);
+    resetRuntimeObservability();
   });
 
   room.clients.push(originalClient);
@@ -507,6 +510,15 @@ test("client reconnect within the window restores room state and records reconne
   const reconnectedAt = internalRoom.reconnectedAtByPlayerId.get("player-1");
   assert.ok(reconnectedAt);
   assert.equal(new Date(reconnectedAt).toISOString(), reconnectedAt);
+
+  const summary = buildRoomLifecycleSummaryPayload();
+  assert.equal(summary.summary.counters.roomCreatesTotal, 1);
+  assert.equal(summary.summary.counters.roomDisposalsTotal, 0);
+  assert.equal(summary.summary.recentEvents.some((event) => event.kind === "reconnect.succeeded"), true);
+  assert.equal(
+    summary.summary.recentEvents.find((event) => event.kind === "reconnect.succeeded")?.playerId,
+    "player-1"
+  );
 });
 
 test("reconnect preserves lobby registration counts while other players stay connected", async (t) => {
@@ -577,6 +589,7 @@ test("stale leave after a successful reconnect does not clear the resumed player
 test("client that misses the reconnect window is cleaned up from the player slot map", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
+  resetRuntimeObservability();
   const room = await createTestRoom(`lifecycle-reconnect-timeout-${Date.now()}`);
   const client = createFakeClient("session-timeout");
   const internalRoom = room as VeilColyseusRoom & {
@@ -588,6 +601,7 @@ test("client that misses the reconnect window is cleaned up from the player slot
     cleanupRoom(room);
     resetLobbyRoomRegistry();
     configureRoomSnapshotStore(null);
+    resetRuntimeObservability();
   });
 
   room.clients.push(client);
@@ -607,6 +621,14 @@ test("client that misses the reconnect window is cleaned up from the player slot
 
   assert.equal(internalRoom.playerIdBySessionId.has("session-timeout"), false);
   assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 0);
+
+  const summary = buildRoomLifecycleSummaryPayload();
+  assert.equal(summary.summary.counters.roomCreatesTotal, 1);
+  assert.equal(summary.summary.recentEvents.some((event) => event.kind === "reconnect.failed"), true);
+  assert.equal(
+    summary.summary.recentEvents.find((event) => event.kind === "reconnect.failed")?.reason,
+    "reconnect_window_expired"
+  );
 });
 
 test("failed reconnect cleanup removes only the expired session and preserves other connected players", async (t) => {
@@ -645,6 +667,7 @@ test("failed reconnect cleanup removes only the expired session and preserves ot
 test("room disposal after the last client leaves removes it from the active room list", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
+  resetRuntimeObservability();
   const room = await createTestRoom(`lifecycle-dispose-${Date.now()}`);
   const client = createFakeClient("session-dispose");
 
@@ -652,6 +675,7 @@ test("room disposal after the last client leaves removes it from the active room
     cleanupRoom(room);
     resetLobbyRoomRegistry();
     configureRoomSnapshotStore(null);
+    resetRuntimeObservability();
   });
 
   room.clients.push(client);
@@ -660,6 +684,12 @@ test("room disposal after the last client leaves removes it from the active room
   room.onDispose();
 
   assert.equal(listLobbyRooms().some((entry) => entry.roomId === room.roomId), false);
+
+  const summary = buildRoomLifecycleSummaryPayload();
+  assert.equal(summary.summary.counters.roomCreatesTotal, 1);
+  assert.equal(summary.summary.counters.roomDisposalsTotal, 1);
+  assert.equal(summary.summary.recentEvents[0]?.kind, "room.disposed");
+  assert.equal(summary.summary.recentEvents[0]?.reason, "dispose");
 });
 
 test("stale room disposal cannot unregister a replacement room with the same logical id", async (t) => {
@@ -926,6 +956,81 @@ test("battle replay persistence runs once at settlement and is drained from the 
   assert.equal(replaySaves.length, 1);
   assert.equal(replaySaves[0]?.patch.recentBattleReplays?.[0]?.id, replay?.id);
   assert.deepEqual(internalRoom.worldRoom.consumeCompletedBattleReplays(), []);
+});
+
+test("battle settlement increments lifecycle completion metrics", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  resetRuntimeObservability();
+  const room = await createTestRoom(`lifecycle-battle-metrics-${Date.now()}`);
+  const client = createFakeClient("session-battle-metrics");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+    resetRuntimeObservability();
+  });
+
+  await connectPlayer(room, client, "player-1", "connect-battle-metrics");
+  await emitRoomMessage(room, "world.action", client, {
+    type: "world.action",
+    requestId: "move-battle-metrics",
+    action: {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 5, y: 4 }
+    }
+  });
+
+  const steps = await resolveBattleThroughRoom(room, client, "player-1");
+  const summary = buildRoomLifecycleSummaryPayload();
+
+  assert.ok(steps > 0);
+  assert.equal(summary.summary.counters.battleCompletionsTotal, 1);
+  assert.equal(summary.summary.counters.battleAbortsTotal, 0);
+  assert.equal(summary.summary.recentEvents.some((event) => event.kind === "battle.completed"), true);
+  assert.equal(
+    summary.summary.recentEvents.find((event) => event.kind === "battle.completed")?.roomId,
+    room.roomId
+  );
+});
+
+test("disposing a room with an active battle records a battle abort", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  resetRuntimeObservability();
+  const room = await createTestRoom(`lifecycle-battle-abort-${Date.now()}`);
+  const client = createFakeClient("session-battle-abort");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+    resetRuntimeObservability();
+  });
+
+  await connectPlayer(room, client, "player-1", "connect-battle-abort");
+  await emitRoomMessage(room, "world.action", client, {
+    type: "world.action",
+    requestId: "move-battle-abort",
+    action: {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 5, y: 4 }
+    }
+  });
+
+  assert.ok(getBattleForPlayer(room, "player-1"));
+  room.onDispose();
+
+  const summary = buildRoomLifecycleSummaryPayload();
+  assert.equal(summary.summary.counters.battleCompletionsTotal, 0);
+  assert.equal(summary.summary.counters.battleAbortsTotal, 1);
+  assert.equal(summary.summary.counters.roomDisposalsTotal, 1);
+  assert.equal(summary.summary.recentEvents[0]?.kind, "room.disposed");
+  assert.equal(summary.summary.recentEvents[1]?.kind, "battle.aborted");
+  assert.equal(summary.summary.recentEvents[1]?.reason, "dispose");
 });
 
 test("invalid world actions return a structured rejection only to the originating client", async (t) => {

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -265,10 +265,57 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(metricsText, /^veil_connect_messages_total 1$/m);
   assert.match(metricsText, /^veil_world_actions_total 1$/m);
   assert.match(metricsText, /^veil_gameplay_action_messages_total 1$/m);
+  assert.match(metricsText, /^veil_room_creates_total 1$/m);
+  assert.match(metricsText, /^veil_room_disposals_total 0$/m);
+  assert.match(metricsText, /^veil_battle_completions_total 0$/m);
+  assert.match(metricsText, /^veil_battle_aborts_total 0$/m);
   assert.match(metricsText, /^veil_auth_guest_sessions 0$/m);
   assert.match(metricsText, /^veil_auth_account_sessions 0$/m);
   assert.match(metricsText, /^veil_auth_session_checks_total 0$/m);
   assert.match(metricsText, /^veil_matchmaking_rate_limited_total 2$/m);
+
+  const roomLifecycleResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/room-lifecycle-summary`);
+  const roomLifecyclePayload = (await roomLifecycleResponse.json()) as {
+    status: string;
+    headline: string;
+    summary: {
+      activeRoomCount: number;
+      pendingReconnectCount: number;
+      counters: {
+        roomCreatesTotal: number;
+        roomDisposalsTotal: number;
+        battleCompletionsTotal: number;
+        battleAbortsTotal: number;
+      };
+      recentEvents: Array<{
+        kind: string;
+        roomId: string;
+      }>;
+    };
+  };
+
+  assert.equal(roomLifecycleResponse.status, 200);
+  assert.equal(roomLifecyclePayload.status, "ok");
+  assert.match(roomLifecyclePayload.headline, /created=1/);
+  assert.equal(roomLifecyclePayload.summary.activeRoomCount, 1);
+  assert.equal(roomLifecyclePayload.summary.pendingReconnectCount, 0);
+  assert.equal(roomLifecyclePayload.summary.counters.roomCreatesTotal, 1);
+  assert.equal(roomLifecyclePayload.summary.counters.roomDisposalsTotal, 0);
+  assert.equal(roomLifecyclePayload.summary.counters.battleCompletionsTotal, 0);
+  assert.equal(roomLifecyclePayload.summary.counters.battleAbortsTotal, 0);
+  assert.equal(roomLifecyclePayload.summary.recentEvents[0]?.kind, "room.created");
+  assert.equal(roomLifecyclePayload.summary.recentEvents[0]?.roomId, "room-observability-alpha");
+
+  const roomLifecycleTextResponse = await fetch(
+    `http://127.0.0.1:${port}/api/runtime/room-lifecycle-summary?format=text`
+  );
+  const roomLifecycleText = await roomLifecycleTextResponse.text();
+
+  assert.equal(roomLifecycleTextResponse.status, 200);
+  assert.match(roomLifecycleTextResponse.headers.get("content-type") ?? "", /^text\/plain/);
+  assert.match(roomLifecycleText, /^room_lifecycle status=ok/m);
+  assert.match(roomLifecycleText, /room_creates=1/);
+  assert.match(roomLifecycleText, /room\.created/);
 
   const prometheusResponse = await fetch(`http://127.0.0.1:${port}/metrics`);
   const prometheusText = await prometheusResponse.text();

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -139,8 +139,8 @@
 
 `P0 blocker`
 
-- [ ] `/api/runtime/health`、`/api/runtime/auth-readiness`、`/api/runtime/metrics` 在候选包对应环境可访问。
-- [ ] 至少能看到活跃房间数、连接数、世界 / 战斗 action 计数，以及鉴权会话摘要。
+- [ ] `/api/runtime/health`、`/api/runtime/auth-readiness`、`/api/runtime/metrics`、`/api/runtime/room-lifecycle-summary` 在候选包对应环境可访问。
+- [ ] 至少能看到活跃房间数、连接数、世界 / 战斗 action 计数、房间 create/dispose、reconnect success/failure、battle completion/abort，以及鉴权会话摘要。
 - [ ] 日志或接口输出足以区分登录失败、进房失败、同步失败和资源 / 配置失败。
 - [ ] WeChat release candidate / shipping candidate 已回填 candidate-scoped runtime observability sign-off，并记录 reviewer、`recordedAt`、target revision 与结论。
 
@@ -157,6 +157,7 @@
 - 手动抓取：`GET /api/runtime/health`
 - 手动抓取：`GET /api/runtime/auth-readiness`
 - 手动抓取：`GET /api/runtime/metrics`
+- 手动抓取：`GET /api/runtime/room-lifecycle-summary?format=text`
 - `docs/release-evidence/wechat-runtime-observability-signoff.template.md`
 
 ## 当前顶级发布风险


### PR DESCRIPTION
## Summary
- add room create/dispose, reconnect outcome, and battle completion/abort observability counters plus recent lifecycle event tracking
- expose `/api/runtime/room-lifecycle-summary` with JSON and compact text output for alerting and release evidence
- cover the metrics contract and lifecycle event wiring with targeted server tests, and document how to use the new signals during triage

## Testing
- `node --import tsx --test ./apps/server/test/runtime-observability-routes.test.ts ./apps/server/test/colyseus-room-lifecycle.test.ts`
- `npm run typecheck:server`

Closes #991