### PR TITLE
[CONFIG] Enforce cross-file validation for phase1-world and hero skill data

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 
 - 安装依赖：`npm ci --no-audit --no-fund`
 - 快速校验首条贡献路径：`npm run validate:quickstart`
+- 提交配置相关 PR 前先跑跨文件配置校验：`npm run validate:content-pack:all`
 - 本地 WebSocket 服务：`npm run dev:server`
 - 仓库级 Node 单测入口：`npm test`
 - 配置中心编辑器回归：`npm run test:client:config-center`

--- a/apps/cocos-client/assets/scripts/project-shared/config-cross-file-validation.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/config-cross-file-validation.ts
@@ -1,0 +1,456 @@
+import type {
+  BattleSkillCatalogConfig,
+  HeroLearnedSkillState,
+  HeroSkillTreeConfig,
+  WorldGenerationConfig
+} from "./models.ts";
+
+export type CrossFileConfigDocumentId = "world" | "heroSkills";
+
+export interface CrossFileConfigIssue {
+  documentId: CrossFileConfigDocumentId;
+  path: string;
+  code: string;
+  message: string;
+}
+
+export class CrossFileConfigValidationError extends Error {
+  readonly issue: CrossFileConfigIssue;
+
+  constructor(issue: CrossFileConfigIssue) {
+    super(`${issue.path}: ${issue.message}`);
+    this.name = "CrossFileConfigValidationError";
+    this.issue = issue;
+  }
+}
+
+interface HeroSkillReference {
+  requiredLevel: number;
+  maxRank: number;
+  prerequisites: string[];
+}
+
+function pushIssue(
+  issues: CrossFileConfigIssue[],
+  issue: CrossFileConfigIssue
+): void {
+  issues.push(issue);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function createHeroSkillIndex(config: HeroSkillTreeConfig): Map<string, HeroSkillReference> {
+  return new Map(
+    (config.skills ?? []).flatMap((skill) =>
+      isNonEmptyString(skill?.id)
+        ? [
+            [
+              skill.id,
+              {
+                requiredLevel: skill.requiredLevel,
+                maxRank: skill.maxRank,
+                prerequisites: [...(skill.prerequisites ?? [])]
+              }
+            ] as const
+          ]
+        : []
+    )
+  );
+}
+
+export function validateHeroSkillTreeCrossReferences(
+  config: HeroSkillTreeConfig,
+  battleSkillCatalog: BattleSkillCatalogConfig
+): CrossFileConfigIssue[] {
+  const issues: CrossFileConfigIssue[] = [];
+
+  if (!Array.isArray(config.branches)) {
+    pushIssue(issues, {
+      documentId: "heroSkills",
+      path: "branches",
+      code: "hero_skill_branches_missing",
+      message: "Hero skill tree config must contain a branches array."
+    });
+  }
+  if (!Array.isArray(config.skills)) {
+    pushIssue(issues, {
+      documentId: "heroSkills",
+      path: "skills",
+      code: "hero_skill_skills_missing",
+      message: "Hero skill tree config must contain a skills array."
+    });
+  }
+  if (issues.length > 0) {
+    return issues;
+  }
+
+  const branchIds = new Set<string>();
+  for (const [branchIndex, branch] of config.branches.entries()) {
+    const branchPath = `branches[${branchIndex}]`;
+    if (!isNonEmptyString(branch.id)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${branchPath}.id`,
+        code: "hero_skill_branch_id_missing",
+        message: "Hero skill branch id must be a non-empty string."
+      });
+      continue;
+    }
+    if (branchIds.has(branch.id)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${branchPath}.id`,
+        code: "duplicate_hero_skill_branch_id",
+        message: `Duplicate hero skill branch id ${branch.id}.`
+      });
+    }
+    if (!isNonEmptyString(branch.name)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${branchPath}.name`,
+        code: "hero_skill_branch_name_missing",
+        message: `Hero skill branch ${branch.id} must define a name.`
+      });
+    }
+    if (!isNonEmptyString(branch.description)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${branchPath}.description`,
+        code: "hero_skill_branch_description_missing",
+        message: `Hero skill branch ${branch.id} must define a description.`
+      });
+    }
+    branchIds.add(branch.id);
+  }
+
+  const battleSkillIds = new Set((battleSkillCatalog.skills ?? []).map((skill) => skill.id));
+  const skillIds = new Set<string>();
+  const prerequisiteIndex = new Map<string, Array<{ prerequisite: string; path: string }>>();
+
+  for (const [skillIndex, skill] of config.skills.entries()) {
+    const skillPath = `skills[${skillIndex}]`;
+    if (!isNonEmptyString(skill.id)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.id`,
+        code: "hero_skill_id_missing",
+        message: "Hero skill id must be a non-empty string."
+      });
+      continue;
+    }
+    if (skillIds.has(skill.id)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.id`,
+        code: "duplicate_hero_skill_id",
+        message: `Duplicate hero skill id ${skill.id}.`
+      });
+    }
+    if (!branchIds.has(skill.branchId)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.branchId`,
+        code: "unknown_hero_skill_branch",
+        message: `Hero skill ${skill.id} references unknown branch ${String(skill.branchId)}.`
+      });
+    }
+    if (!isNonEmptyString(skill.name)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.name`,
+        code: "hero_skill_name_missing",
+        message: `Hero skill ${skill.id} must define a name.`
+      });
+    }
+    if (!isNonEmptyString(skill.description)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.description`,
+        code: "hero_skill_description_missing",
+        message: `Hero skill ${skill.id} must define a description.`
+      });
+    }
+    if (!isPositiveInteger(skill.requiredLevel)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.requiredLevel`,
+        code: "hero_skill_required_level_invalid",
+        message: `Hero skill ${skill.id} requiredLevel must be a positive integer.`
+      });
+    }
+    if (!isPositiveInteger(skill.maxRank)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.maxRank`,
+        code: "hero_skill_max_rank_invalid",
+        message: `Hero skill ${skill.id} maxRank must be a positive integer.`
+      });
+    }
+    if (!Array.isArray(skill.ranks) || skill.ranks.length !== skill.maxRank) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.ranks`,
+        code: "hero_skill_rank_count_mismatch",
+        message: `Hero skill ${skill.id} must define exactly ${skill.maxRank} rank entries.`
+      });
+    }
+
+    const rankIds = new Set<number>();
+    for (const [rankIndex, rank] of (skill.ranks ?? []).entries()) {
+      const rankPath = `${skillPath}.ranks[${rankIndex}]`;
+      if (!isPositiveInteger(rank.rank) || rank.rank > skill.maxRank) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: `${rankPath}.rank`,
+          code: "hero_skill_rank_invalid",
+          message: `Hero skill ${skill.id} rank must be between 1 and ${skill.maxRank}.`
+        });
+      }
+      if (rankIds.has(rank.rank)) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: `${rankPath}.rank`,
+          code: "duplicate_hero_skill_rank",
+          message: `Hero skill ${skill.id} has duplicate rank entry ${rank.rank}.`
+        });
+      }
+      if (!isNonEmptyString(rank.description)) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: `${rankPath}.description`,
+          code: "hero_skill_rank_description_missing",
+          message: `Hero skill ${skill.id} rank ${rank.rank} must define a description.`
+        });
+      }
+      for (const [battleSkillIndex, battleSkillId] of (rank.battleSkillIds ?? []).entries()) {
+        if (!battleSkillIds.has(battleSkillId)) {
+          pushIssue(issues, {
+            documentId: "heroSkills",
+            path: `${rankPath}.battleSkillIds[${battleSkillIndex}]`,
+            code: "unknown_hero_skill_battle_skill",
+            message: `Hero skill ${skill.id} rank ${rank.rank} references unknown battle skill ${battleSkillId}.`
+          });
+        }
+      }
+      rankIds.add(rank.rank);
+    }
+
+    if (skill.prerequisites !== undefined && !Array.isArray(skill.prerequisites)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.prerequisites`,
+        code: "hero_skill_prerequisites_invalid",
+        message: `Hero skill ${skill.id} prerequisites must be an array when provided.`
+      });
+    }
+
+    prerequisiteIndex.set(
+      skill.id,
+      (Array.isArray(skill.prerequisites) ? skill.prerequisites : []).map((prerequisite, prerequisiteIndexValue) => ({
+        prerequisite,
+        path: `${skillPath}.prerequisites[${prerequisiteIndexValue}]`
+      }))
+    );
+
+    skillIds.add(skill.id);
+  }
+
+  for (const [skillId, prerequisites] of prerequisiteIndex.entries()) {
+    for (const prerequisiteEntry of prerequisites) {
+      if (!skillIds.has(prerequisiteEntry.prerequisite)) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: prerequisiteEntry.path,
+          code: "unknown_hero_skill_prerequisite",
+          message: `Hero skill ${skillId} references unknown prerequisite ${prerequisiteEntry.prerequisite}.`
+        });
+      }
+      if (prerequisiteEntry.prerequisite === skillId) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: prerequisiteEntry.path,
+          code: "hero_skill_self_prerequisite",
+          message: `Hero skill ${skillId} cannot depend on itself.`
+        });
+      }
+    }
+  }
+
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const stack: string[] = [];
+
+  const detectCycles = (skillId: string): void => {
+    if (visited.has(skillId) || visiting.has(skillId)) {
+      return;
+    }
+
+    visiting.add(skillId);
+    stack.push(skillId);
+    for (const prerequisiteEntry of prerequisiteIndex.get(skillId) ?? []) {
+      if (!skillIds.has(prerequisiteEntry.prerequisite) || prerequisiteEntry.prerequisite === skillId) {
+        continue;
+      }
+      if (visiting.has(prerequisiteEntry.prerequisite)) {
+        const cycleStart = stack.indexOf(prerequisiteEntry.prerequisite);
+        const cycle = [...stack.slice(cycleStart), prerequisiteEntry.prerequisite].join(" -> ");
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: prerequisiteEntry.path,
+          code: "hero_skill_prerequisite_cycle",
+          message: `Hero skill prerequisite cycle detected: ${cycle}.`
+        });
+        continue;
+      }
+      detectCycles(prerequisiteEntry.prerequisite);
+    }
+    stack.pop();
+    visiting.delete(skillId);
+    visited.add(skillId);
+  };
+
+  for (const skillId of skillIds) {
+    detectCycles(skillId);
+  }
+
+  return issues;
+}
+
+function validateLearnedSkillEntry(
+  learnedSkill: HeroLearnedSkillState,
+  heroPath: string,
+  heroId: string,
+  heroLevel: number,
+  heroSkillIndex: Map<string, HeroSkillReference>,
+  seenSkillIds: Set<string>,
+  issues: CrossFileConfigIssue[]
+): learnedSkill is HeroLearnedSkillState & { skillId: string; rank: number } {
+  const skillId = learnedSkill?.skillId?.trim();
+  if (!skillId) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.skillId`,
+      code: "hero_skill_id_missing",
+      message: `Hero ${heroId} learned skill entry is missing a skill id.`
+    });
+    return false;
+  }
+
+  if (!isPositiveInteger(learnedSkill.rank)) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.rank`,
+      code: "hero_skill_rank_invalid",
+      message: `Hero ${heroId} learned skill ${skillId} rank must be a positive integer.`
+    });
+    return false;
+  }
+
+  if (seenSkillIds.has(skillId)) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.skillId`,
+      code: "duplicate_hero_learned_skill",
+      message: `Hero ${heroId} learns ${skillId} more than once.`
+    });
+  }
+  seenSkillIds.add(skillId);
+
+  const skill = heroSkillIndex.get(skillId);
+  if (!skill) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.skillId`,
+      code: "hero_skill_missing",
+      message: `Hero ${heroId} references unknown hero skill ${skillId}.`
+    });
+    return false;
+  }
+
+  if (learnedSkill.rank > skill.maxRank) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.rank`,
+      code: "hero_skill_rank_exceeds_max",
+      message: `Hero ${heroId} sets ${skillId} to rank ${learnedSkill.rank}, but the skill only supports rank ${skill.maxRank}.`
+    });
+  }
+
+  if (heroLevel < skill.requiredLevel) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath,
+      code: "hero_skill_level_too_low",
+      message: `Hero ${heroId} is level ${heroLevel} but ${skillId} requires level ${skill.requiredLevel}.`
+    });
+  }
+
+  return true;
+}
+
+export function validateWorldHeroSkillReferences(
+  world: WorldGenerationConfig,
+  heroSkillTree: HeroSkillTreeConfig
+): CrossFileConfigIssue[] {
+  const issues: CrossFileConfigIssue[] = [];
+  const heroSkillIndex = createHeroSkillIndex(heroSkillTree);
+
+  world.heroes.forEach((hero, heroIndex) => {
+    const learnedSkillRanks = new Map<string, number>();
+    const seenSkillIds = new Set<string>();
+    const heroLevel = hero.progression?.level ?? 1;
+
+    for (const [skillIndex, learnedSkill] of (hero.learnedSkills ?? []).entries()) {
+      const learnedSkillPath = `heroes[${heroIndex}].learnedSkills[${skillIndex}]`;
+      if (
+        !validateLearnedSkillEntry(
+          learnedSkill,
+          learnedSkillPath,
+          hero.id,
+          heroLevel,
+          heroSkillIndex,
+          seenSkillIds,
+          issues
+        )
+      ) {
+        continue;
+      }
+      learnedSkillRanks.set(learnedSkill.skillId, learnedSkill.rank);
+    }
+
+    for (const [skillIndex, learnedSkill] of (hero.learnedSkills ?? []).entries()) {
+      const definition = learnedSkill?.skillId ? heroSkillIndex.get(learnedSkill.skillId) : undefined;
+      if (!definition) {
+        continue;
+      }
+      const missingPrerequisite = definition.prerequisites.find((prerequisite) => (learnedSkillRanks.get(prerequisite) ?? 0) <= 0);
+      if (missingPrerequisite) {
+        pushIssue(issues, {
+          documentId: "world",
+          path: `heroes[${heroIndex}].learnedSkills[${skillIndex}].skillId`,
+          code: "hero_skill_prerequisite_missing",
+          message: `Hero ${hero.id} learns ${learnedSkill.skillId} without prerequisite ${missingPrerequisite}.`
+        });
+      }
+    }
+  });
+
+  return issues;
+}
+
+export function assertNoCrossFileConfigIssues(issues: CrossFileConfigIssue[]): void {
+  const firstIssue = issues[0];
+  if (firstIssue) {
+    throw new CrossFileConfigValidationError(firstIssue);
+  }
+}

--- a/apps/cocos-client/assets/scripts/project-shared/index.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/index.ts
@@ -5,6 +5,7 @@ export * from "./battle.ts";
 export * from "./battle-report.ts";
 export * from "./battle-replay.ts";
 export * from "./cosmetics.ts";
+export * from "./config-cross-file-validation.ts";
 export * from "./deterministic-rng.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";

--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -32,6 +32,11 @@ import stonewatchForkWorldConfig from "../../../../../configs/phase1-world-stone
 import thornwallDivideWorldConfig from "../../../../../configs/phase1-world-thornwall-divide.json";
 import ridgewayCrossingWorldConfig from "../../../../../configs/phase1-world-ridgeway-crossing.json";
 import defaultWorldConfig from "../../../../../configs/phase1-world.json";
+import {
+  assertNoCrossFileConfigIssues,
+  validateHeroSkillTreeCrossReferences,
+  validateWorldHeroSkillReferences
+} from "./config-cross-file-validation.ts";
 import type {
   BattleSkillCatalogConfig,
   BattleBalanceConfig,
@@ -100,6 +105,7 @@ export interface RuntimeConfigBundle {
   units: UnitCatalogConfig;
   battleSkills: BattleSkillCatalogConfig;
   battleBalance?: BattleBalanceConfig;
+  heroSkills?: HeroSkillTreeConfig;
 }
 
 export interface RoomRuntimeConfigBundle extends RuntimeConfigBundle {
@@ -437,89 +443,7 @@ export function validateHeroSkillTreeConfig(
   config: HeroSkillTreeConfig,
   battleSkillCatalog: BattleSkillCatalogConfig = runtimeBattleSkillCatalog
 ): void {
-  if (!Array.isArray(config.branches) || !Array.isArray(config.skills)) {
-    throw new Error("Hero skill tree config must contain branches and skills arrays");
-  }
-
-  const branchIds = new Set<string>();
-  for (const branch of config.branches) {
-    if (!isNonEmptyString(branch.id)) {
-      throw new Error("Hero skill branch id must be a non-empty string");
-    }
-    if (branchIds.has(branch.id)) {
-      throw new Error(`Duplicate hero skill branch id: ${branch.id}`);
-    }
-    if (!isNonEmptyString(branch.name)) {
-      throw new Error(`Hero skill branch ${branch.id} must define a name`);
-    }
-    if (!isNonEmptyString(branch.description)) {
-      throw new Error(`Hero skill branch ${branch.id} must define a description`);
-    }
-    branchIds.add(branch.id);
-  }
-
-  const battleSkillIds = new Set(battleSkillCatalog.skills.map((skill) => skill.id));
-  const skillIds = new Set<string>();
-  for (const skill of config.skills) {
-    if (!isNonEmptyString(skill.id)) {
-      throw new Error("Hero skill id must be a non-empty string");
-    }
-    if (skillIds.has(skill.id)) {
-      throw new Error(`Duplicate hero skill id: ${skill.id}`);
-    }
-    if (!branchIds.has(skill.branchId)) {
-      throw new Error(`Hero skill ${skill.id} references unknown branch: ${skill.branchId}`);
-    }
-    if (!isNonEmptyString(skill.name)) {
-      throw new Error(`Hero skill ${skill.id} must define a name`);
-    }
-    if (!isNonEmptyString(skill.description)) {
-      throw new Error(`Hero skill ${skill.id} must define a description`);
-    }
-    if (!Number.isInteger(skill.requiredLevel) || skill.requiredLevel < 1) {
-      throw new Error(`Hero skill ${skill.id} requiredLevel must be a positive integer`);
-    }
-    if (!Number.isInteger(skill.maxRank) || skill.maxRank < 1) {
-      throw new Error(`Hero skill ${skill.id} maxRank must be a positive integer`);
-    }
-    if (!Array.isArray(skill.ranks) || skill.ranks.length !== skill.maxRank) {
-      throw new Error(`Hero skill ${skill.id} must define exactly ${skill.maxRank} rank entries`);
-    }
-
-    const rankIds = new Set<number>();
-    for (const rank of skill.ranks) {
-      if (!Number.isInteger(rank.rank) || rank.rank < 1 || rank.rank > skill.maxRank) {
-        throw new Error(`Hero skill ${skill.id} has invalid rank entry: ${String(rank.rank)}`);
-      }
-      if (rankIds.has(rank.rank)) {
-        throw new Error(`Hero skill ${skill.id} has duplicate rank entry: ${rank.rank}`);
-      }
-      if (!isNonEmptyString(rank.description)) {
-        throw new Error(`Hero skill ${skill.id} rank ${rank.rank} must define a description`);
-      }
-
-      for (const battleSkillId of rank.battleSkillIds ?? []) {
-        if (!battleSkillIds.has(battleSkillId)) {
-          throw new Error(`Hero skill ${skill.id} rank ${rank.rank} references unknown battle skill: ${battleSkillId}`);
-        }
-      }
-
-      rankIds.add(rank.rank);
-    }
-
-    skillIds.add(skill.id);
-  }
-
-  for (const skill of config.skills) {
-    for (const prerequisite of skill.prerequisites ?? []) {
-      if (!skillIds.has(prerequisite)) {
-        throw new Error(`Hero skill ${skill.id} references unknown prerequisite: ${prerequisite}`);
-      }
-      if (prerequisite === skill.id) {
-        throw new Error(`Hero skill ${skill.id} cannot depend on itself`);
-      }
-    }
-  }
+  assertNoCrossFileConfigIssues(validateHeroSkillTreeCrossReferences(config, battleSkillCatalog));
 }
 
 export function validateWorldConfig(config: WorldGenerationConfig): void {
@@ -998,6 +922,7 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
 export function setWorldConfig(config: WorldGenerationConfig): void {
   const nextConfig = cloneWorldConfig(config);
   validateWorldConfig(nextConfig);
+  assertNoCrossFileConfigIssues(validateWorldHeroSkillReferences(nextConfig, runtimeHeroSkillTree));
   validateMapObjectsConfig(runtimeMapObjectsConfig, nextConfig, runtimeUnitCatalog);
   runtimeWorldConfig = nextConfig;
 }
@@ -1032,7 +957,8 @@ export function setBattleBalanceConfig(config: BattleBalanceConfig): void {
 
 export function setHeroSkillTreeConfig(config: HeroSkillTreeConfig): void {
   const nextConfig = cloneHeroSkillTreeConfig(config);
-  validateHeroSkillTreeConfig(nextConfig);
+  validateHeroSkillTreeConfig(nextConfig, runtimeBattleSkillCatalog);
+  assertNoCrossFileConfigIssues(validateWorldHeroSkillReferences(runtimeWorldConfig, nextConfig));
   runtimeHeroSkillTree = nextConfig;
 }
 
@@ -1042,18 +968,22 @@ export function replaceRuntimeConfigs(configs: RuntimeConfigBundle): void {
   const nextUnits = cloneUnitCatalog(configs.units);
   const nextBattleSkills = cloneBattleSkillCatalog(configs.battleSkills);
   const nextBattleBalance = cloneBattleBalanceConfig(configs.battleBalance ?? runtimeBattleBalanceConfig);
+  const nextHeroSkills = cloneHeroSkillTreeConfig(configs.heroSkills ?? runtimeHeroSkillTree);
 
   validateWorldConfig(nextWorld);
   validateBattleSkillCatalog(nextBattleSkills);
   validateUnitCatalog(nextUnits, nextBattleSkills);
   validateMapObjectsConfig(nextMapObjects, nextWorld, nextUnits);
   validateBattleBalanceConfig(nextBattleBalance, nextBattleSkills);
+  validateHeroSkillTreeConfig(nextHeroSkills, nextBattleSkills);
+  assertNoCrossFileConfigIssues(validateWorldHeroSkillReferences(nextWorld, nextHeroSkills));
 
   runtimeWorldConfig = nextWorld;
   runtimeMapObjectsConfig = nextMapObjects;
   runtimeUnitCatalog = nextUnits;
   runtimeBattleSkillCatalog = nextBattleSkills;
   runtimeBattleBalanceConfig = nextBattleBalance;
+  runtimeHeroSkillTree = nextHeroSkills;
 }
 
 export function resetRuntimeConfigs(): void {

--- a/packages/shared/src/config-cross-file-validation.ts
+++ b/packages/shared/src/config-cross-file-validation.ts
@@ -1,0 +1,490 @@
+import type {
+  BattleSkillCatalogConfig,
+  HeroLearnedSkillState,
+  HeroSkillTreeConfig,
+  HeroAttributeBonuses,
+  WorldGenerationConfig
+} from "./models.ts";
+
+export type CrossFileConfigDocumentId = "world" | "heroSkills";
+
+export interface CrossFileConfigIssue {
+  documentId: CrossFileConfigDocumentId;
+  path: string;
+  code: string;
+  message: string;
+}
+
+export class CrossFileConfigValidationError extends Error {
+  readonly issue: CrossFileConfigIssue;
+
+  constructor(issue: CrossFileConfigIssue) {
+    super(`${issue.path}: ${issue.message}`);
+    this.name = "CrossFileConfigValidationError";
+    this.issue = issue;
+  }
+}
+
+interface HeroSkillReference {
+  requiredLevel: number;
+  maxRank: number;
+  prerequisites: string[];
+}
+
+function pushIssue(
+  issues: CrossFileConfigIssue[],
+  issue: CrossFileConfigIssue
+): void {
+  issues.push(issue);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function createHeroSkillIndex(config: HeroSkillTreeConfig): Map<string, HeroSkillReference> {
+  return new Map(
+    (config.skills ?? []).flatMap((skill) =>
+      isNonEmptyString(skill?.id)
+        ? [
+            [
+              skill.id,
+              {
+                requiredLevel: skill.requiredLevel,
+                maxRank: skill.maxRank,
+                prerequisites: [...(skill.prerequisites ?? [])]
+              }
+            ] as const
+          ]
+        : []
+    )
+  );
+}
+
+function validateHeroSkillStatBonuses(
+  bonuses: Partial<HeroAttributeBonuses> | undefined,
+  path: string,
+  issues: CrossFileConfigIssue[]
+): void {
+  if (!bonuses) {
+    return;
+  }
+
+  const allowedKeys = new Set(["attack", "defense", "power", "knowledge", "maxHp"]);
+  for (const [key, value] of Object.entries(bonuses)) {
+    const bonusPath = `${path}.${key}`;
+    if (!allowedKeys.has(key)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: bonusPath,
+        code: "unknown_hero_skill_stat_bonus",
+        message: `Unknown hero skill stat bonus key ${key}.`
+      });
+      continue;
+    }
+    if (!isNonNegativeInteger(value)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: bonusPath,
+        code: "hero_skill_stat_bonus_invalid",
+        message: `Hero skill stat bonus ${key} must be a non-negative integer.`
+      });
+    }
+  }
+}
+
+export function validateHeroSkillTreeCrossReferences(
+  config: HeroSkillTreeConfig,
+  battleSkillCatalog: BattleSkillCatalogConfig
+): CrossFileConfigIssue[] {
+  const issues: CrossFileConfigIssue[] = [];
+
+  if (!Array.isArray(config.branches)) {
+    pushIssue(issues, {
+      documentId: "heroSkills",
+      path: "branches",
+      code: "hero_skill_branches_missing",
+      message: "Hero skill tree config must contain a branches array."
+    });
+  }
+  if (!Array.isArray(config.skills)) {
+    pushIssue(issues, {
+      documentId: "heroSkills",
+      path: "skills",
+      code: "hero_skill_skills_missing",
+      message: "Hero skill tree config must contain a skills array."
+    });
+  }
+  if (issues.length > 0) {
+    return issues;
+  }
+
+  const branchIds = new Set<string>();
+  for (const [branchIndex, branch] of config.branches.entries()) {
+    const branchPath = `branches[${branchIndex}]`;
+    if (!isNonEmptyString(branch.id)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${branchPath}.id`,
+        code: "hero_skill_branch_id_missing",
+        message: "Hero skill branch id must be a non-empty string."
+      });
+      continue;
+    }
+    if (branchIds.has(branch.id)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${branchPath}.id`,
+        code: "duplicate_hero_skill_branch_id",
+        message: `Duplicate hero skill branch id ${branch.id}.`
+      });
+    }
+    if (!isNonEmptyString(branch.name)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${branchPath}.name`,
+        code: "hero_skill_branch_name_missing",
+        message: `Hero skill branch ${branch.id} must define a name.`
+      });
+    }
+    if (!isNonEmptyString(branch.description)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${branchPath}.description`,
+        code: "hero_skill_branch_description_missing",
+        message: `Hero skill branch ${branch.id} must define a description.`
+      });
+    }
+    branchIds.add(branch.id);
+  }
+
+  const battleSkillIds = new Set((battleSkillCatalog.skills ?? []).map((skill) => skill.id));
+  const skillIds = new Set<string>();
+  const prerequisiteIndex = new Map<string, Array<{ prerequisite: string; path: string }>>();
+
+  for (const [skillIndex, skill] of config.skills.entries()) {
+    const skillPath = `skills[${skillIndex}]`;
+    if (!isNonEmptyString(skill.id)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.id`,
+        code: "hero_skill_id_missing",
+        message: "Hero skill id must be a non-empty string."
+      });
+      continue;
+    }
+    if (skillIds.has(skill.id)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.id`,
+        code: "duplicate_hero_skill_id",
+        message: `Duplicate hero skill id ${skill.id}.`
+      });
+    }
+    if (!branchIds.has(skill.branchId)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.branchId`,
+        code: "unknown_hero_skill_branch",
+        message: `Hero skill ${skill.id} references unknown branch ${String(skill.branchId)}.`
+      });
+    }
+    if (!isNonEmptyString(skill.name)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.name`,
+        code: "hero_skill_name_missing",
+        message: `Hero skill ${skill.id} must define a name.`
+      });
+    }
+    if (!isNonEmptyString(skill.description)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.description`,
+        code: "hero_skill_description_missing",
+        message: `Hero skill ${skill.id} must define a description.`
+      });
+    }
+    if (!isPositiveInteger(skill.requiredLevel)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.requiredLevel`,
+        code: "hero_skill_required_level_invalid",
+        message: `Hero skill ${skill.id} requiredLevel must be a positive integer.`
+      });
+    }
+    if (!isPositiveInteger(skill.maxRank)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.maxRank`,
+        code: "hero_skill_max_rank_invalid",
+        message: `Hero skill ${skill.id} maxRank must be a positive integer.`
+      });
+    }
+    if (!Array.isArray(skill.ranks) || skill.ranks.length !== skill.maxRank) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.ranks`,
+        code: "hero_skill_rank_count_mismatch",
+        message: `Hero skill ${skill.id} must define exactly ${skill.maxRank} rank entries.`
+      });
+    }
+
+    const rankIds = new Set<number>();
+    for (const [rankIndex, rank] of (skill.ranks ?? []).entries()) {
+      const rankPath = `${skillPath}.ranks[${rankIndex}]`;
+      if (!isPositiveInteger(rank.rank) || rank.rank > skill.maxRank) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: `${rankPath}.rank`,
+          code: "hero_skill_rank_invalid",
+          message: `Hero skill ${skill.id} rank must be between 1 and ${skill.maxRank}.`
+        });
+      }
+      if (rankIds.has(rank.rank)) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: `${rankPath}.rank`,
+          code: "duplicate_hero_skill_rank",
+          message: `Hero skill ${skill.id} has duplicate rank entry ${rank.rank}.`
+        });
+      }
+      if (!isNonEmptyString(rank.description)) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: `${rankPath}.description`,
+          code: "hero_skill_rank_description_missing",
+          message: `Hero skill ${skill.id} rank ${rank.rank} must define a description.`
+        });
+      }
+      validateHeroSkillStatBonuses(rank.statBonuses, `${rankPath}.statBonuses`, issues);
+      for (const [battleSkillIndex, battleSkillId] of (rank.battleSkillIds ?? []).entries()) {
+        if (!battleSkillIds.has(battleSkillId)) {
+          pushIssue(issues, {
+            documentId: "heroSkills",
+            path: `${rankPath}.battleSkillIds[${battleSkillIndex}]`,
+            code: "unknown_hero_skill_battle_skill",
+            message: `Hero skill ${skill.id} rank ${rank.rank} references unknown battle skill ${battleSkillId}.`
+          });
+        }
+      }
+      rankIds.add(rank.rank);
+    }
+
+    if (skill.prerequisites !== undefined && !Array.isArray(skill.prerequisites)) {
+      pushIssue(issues, {
+        documentId: "heroSkills",
+        path: `${skillPath}.prerequisites`,
+        code: "hero_skill_prerequisites_invalid",
+        message: `Hero skill ${skill.id} prerequisites must be an array when provided.`
+      });
+    }
+
+    prerequisiteIndex.set(
+      skill.id,
+      (Array.isArray(skill.prerequisites) ? skill.prerequisites : []).map((prerequisite, prerequisiteIndexValue) => ({
+        prerequisite,
+        path: `${skillPath}.prerequisites[${prerequisiteIndexValue}]`
+      }))
+    );
+
+    skillIds.add(skill.id);
+  }
+
+  for (const [skillId, prerequisites] of prerequisiteIndex.entries()) {
+    for (const prerequisiteEntry of prerequisites) {
+      if (!skillIds.has(prerequisiteEntry.prerequisite)) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: prerequisiteEntry.path,
+          code: "unknown_hero_skill_prerequisite",
+          message: `Hero skill ${skillId} references unknown prerequisite ${prerequisiteEntry.prerequisite}.`
+        });
+      }
+      if (prerequisiteEntry.prerequisite === skillId) {
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: prerequisiteEntry.path,
+          code: "hero_skill_self_prerequisite",
+          message: `Hero skill ${skillId} cannot depend on itself.`
+        });
+      }
+    }
+  }
+
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const stack: string[] = [];
+
+  const detectCycles = (skillId: string): void => {
+    if (visited.has(skillId) || visiting.has(skillId)) {
+      return;
+    }
+
+    visiting.add(skillId);
+    stack.push(skillId);
+    for (const prerequisiteEntry of prerequisiteIndex.get(skillId) ?? []) {
+      if (!skillIds.has(prerequisiteEntry.prerequisite) || prerequisiteEntry.prerequisite === skillId) {
+        continue;
+      }
+      if (visiting.has(prerequisiteEntry.prerequisite)) {
+        const cycleStart = stack.indexOf(prerequisiteEntry.prerequisite);
+        const cycle = [...stack.slice(cycleStart), prerequisiteEntry.prerequisite].join(" -> ");
+        pushIssue(issues, {
+          documentId: "heroSkills",
+          path: prerequisiteEntry.path,
+          code: "hero_skill_prerequisite_cycle",
+          message: `Hero skill prerequisite cycle detected: ${cycle}.`
+        });
+        continue;
+      }
+      detectCycles(prerequisiteEntry.prerequisite);
+    }
+    stack.pop();
+    visiting.delete(skillId);
+    visited.add(skillId);
+  };
+
+  for (const skillId of skillIds) {
+    detectCycles(skillId);
+  }
+
+  return issues;
+}
+
+function validateLearnedSkillEntry(
+  learnedSkill: HeroLearnedSkillState,
+  heroPath: string,
+  heroId: string,
+  heroLevel: number,
+  heroSkillIndex: Map<string, HeroSkillReference>,
+  seenSkillIds: Set<string>,
+  issues: CrossFileConfigIssue[]
+): learnedSkill is HeroLearnedSkillState & { skillId: string; rank: number } {
+  const skillId = learnedSkill?.skillId?.trim();
+  if (!skillId) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.skillId`,
+      code: "hero_skill_id_missing",
+      message: `Hero ${heroId} learned skill entry is missing a skill id.`
+    });
+    return false;
+  }
+
+  if (!isPositiveInteger(learnedSkill.rank)) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.rank`,
+      code: "hero_skill_rank_invalid",
+      message: `Hero ${heroId} learned skill ${skillId} rank must be a positive integer.`
+    });
+    return false;
+  }
+
+  if (seenSkillIds.has(skillId)) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.skillId`,
+      code: "duplicate_hero_learned_skill",
+      message: `Hero ${heroId} learns ${skillId} more than once.`
+    });
+  }
+  seenSkillIds.add(skillId);
+
+  const skill = heroSkillIndex.get(skillId);
+  if (!skill) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.skillId`,
+      code: "hero_skill_missing",
+      message: `Hero ${heroId} references unknown hero skill ${skillId}.`
+    });
+    return false;
+  }
+
+  if (learnedSkill.rank > skill.maxRank) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: `${heroPath}.rank`,
+      code: "hero_skill_rank_exceeds_max",
+      message: `Hero ${heroId} sets ${skillId} to rank ${learnedSkill.rank}, but the skill only supports rank ${skill.maxRank}.`
+    });
+  }
+
+  if (heroLevel < skill.requiredLevel) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: heroPath,
+      code: "hero_skill_level_too_low",
+      message: `Hero ${heroId} is level ${heroLevel} but ${skillId} requires level ${skill.requiredLevel}.`
+    });
+  }
+
+  return true;
+}
+
+export function validateWorldHeroSkillReferences(
+  world: WorldGenerationConfig,
+  heroSkillTree: HeroSkillTreeConfig
+): CrossFileConfigIssue[] {
+  const issues: CrossFileConfigIssue[] = [];
+  const heroSkillIndex = createHeroSkillIndex(heroSkillTree);
+
+  world.heroes.forEach((hero, heroIndex) => {
+    const learnedSkillRanks = new Map<string, number>();
+    const seenSkillIds = new Set<string>();
+    const heroLevel = hero.progression?.level ?? 1;
+
+    for (const [skillIndex, learnedSkill] of (hero.learnedSkills ?? []).entries()) {
+      const learnedSkillPath = `heroes[${heroIndex}].learnedSkills[${skillIndex}]`;
+      if (
+        !validateLearnedSkillEntry(
+          learnedSkill,
+          learnedSkillPath,
+          hero.id,
+          heroLevel,
+          heroSkillIndex,
+          seenSkillIds,
+          issues
+        )
+      ) {
+        continue;
+      }
+      learnedSkillRanks.set(learnedSkill.skillId, learnedSkill.rank);
+    }
+
+    for (const [skillIndex, learnedSkill] of (hero.learnedSkills ?? []).entries()) {
+      const definition = learnedSkill?.skillId ? heroSkillIndex.get(learnedSkill.skillId) : undefined;
+      if (!definition) {
+        continue;
+      }
+      const missingPrerequisite = definition.prerequisites.find((prerequisite) => (learnedSkillRanks.get(prerequisite) ?? 0) <= 0);
+      if (missingPrerequisite) {
+        pushIssue(issues, {
+          documentId: "world",
+          path: `heroes[${heroIndex}].learnedSkills[${skillIndex}].skillId`,
+          code: "hero_skill_prerequisite_missing",
+          message: `Hero ${hero.id} learns ${learnedSkill.skillId} without prerequisite ${missingPrerequisite}.`
+        });
+      }
+    }
+  });
+
+  return issues;
+}
+
+export function assertNoCrossFileConfigIssues(issues: CrossFileConfigIssue[]): void {
+  const firstIssue = issues[0];
+  if (firstIssue) {
+    throw new CrossFileConfigValidationError(firstIssue);
+  }
+}

--- a/packages/shared/src/content-pack-validation.ts
+++ b/packages/shared/src/content-pack-validation.ts
@@ -1,5 +1,8 @@
 import { getEquipmentDefinition, HERO_EQUIPMENT_INVENTORY_CAPACITY } from "./equipment.ts";
 import {
+  validateWorldHeroSkillReferences
+} from "./config-cross-file-validation.ts";
+import {
   getDefaultHeroSkillTreeConfig
 } from "./world-config.ts";
 import {
@@ -8,7 +11,7 @@ import {
   BattleSkillCatalogConfig,
   EquipmentType,
   HeroConfig,
-  HeroLearnedSkillState,
+  HeroSkillTreeConfig,
   MapObjectsConfig,
   UnitCatalogConfig,
   WorldGenerationConfig
@@ -117,8 +120,9 @@ function heroPath(heroIndex: number, suffix: string): string {
   return `heroes[${heroIndex}]${suffix}`;
 }
 
-function buildHeroSkillIndex(): Map<string, { requiredLevel: number; maxRank: number; prerequisites: string[] }> {
-  const config = getDefaultHeroSkillTreeConfig();
+function buildHeroSkillIndex(
+  config: HeroSkillTreeConfig
+): Map<string, { requiredLevel: number; maxRank: number; prerequisites: string[] }> {
   return new Map(
     config.skills.map((skill) => [
       skill.id,
@@ -200,15 +204,11 @@ function validateHeroProgression(
 
   const learnedSkills = hero.learnedSkills ?? [];
   let spentSkillPoints = 0;
-  const learnedSkillRanks = new Map<string, number>();
-
-  for (const [skillIndex, learnedSkill] of learnedSkills.entries()) {
-    if (!validateLearnedHeroSkill(hero, heroIndex, skillIndex, learnedSkill, heroSkillIndex, issues)) {
+  for (const learnedSkill of learnedSkills) {
+    if (!isPositiveInteger(learnedSkill?.rank) || !heroSkillIndex.has(learnedSkill?.skillId)) {
       continue;
     }
-
     spentSkillPoints += learnedSkill.rank;
-    learnedSkillRanks.set(learnedSkill.skillId, learnedSkill.rank);
   }
 
   if (isNonNegativeInteger(level) && isNonNegativeInteger(skillPoints)) {
@@ -223,90 +223,6 @@ function validateHeroProgression(
       });
     }
   }
-
-  for (const [skillIndex, learnedSkill] of learnedSkills.entries()) {
-    const skill = heroSkillIndex.get(learnedSkill.skillId);
-    if (!skill) {
-      continue;
-    }
-
-    const missingPrerequisite = skill.prerequisites.find((prerequisite) => (learnedSkillRanks.get(prerequisite) ?? 0) <= 0);
-    if (missingPrerequisite) {
-      pushIssue(issues, {
-        documentId: "world",
-        path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].skillId`),
-        code: "hero_skill_prerequisite_missing",
-        message: `Hero ${hero.id} learns ${learnedSkill.skillId} without prerequisite ${missingPrerequisite}.`,
-        suggestion: "Add the prerequisite skill to learnedSkills or remove the dependent skill from the authored hero archive."
-      });
-    }
-  }
-}
-
-function validateLearnedHeroSkill(
-  hero: HeroConfig,
-  heroIndex: number,
-  skillIndex: number,
-  learnedSkill: HeroLearnedSkillState,
-  heroSkillIndex: Map<string, { requiredLevel: number; maxRank: number; prerequisites: string[] }>,
-  issues: ContentPackValidationIssue[]
-): learnedSkill is HeroLearnedSkillState & { skillId: string; rank: number } {
-  const skillId = learnedSkill?.skillId?.trim();
-  if (!skillId) {
-    pushIssue(issues, {
-      documentId: "world",
-      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].skillId`),
-      code: "hero_skill_id_missing",
-      message: `Hero ${hero.id} learnedSkills[${skillIndex}] is missing a skill id.`,
-      suggestion: "Set the skillId to a valid hero skill or remove the empty entry."
-    });
-    return false;
-  }
-
-  if (!isPositiveInteger(learnedSkill.rank)) {
-    pushIssue(issues, {
-      documentId: "world",
-      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].rank`),
-      code: "hero_skill_rank_invalid",
-      message: `Hero ${hero.id} learned skill ${skillId} rank must be a positive integer.`,
-      suggestion: "Use a whole-number rank between 1 and the skill's maxRank."
-    });
-    return false;
-  }
-
-  const skill = heroSkillIndex.get(skillId);
-  if (!skill) {
-    pushIssue(issues, {
-      documentId: "world",
-      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].skillId`),
-      code: "hero_skill_missing",
-      message: `Hero ${hero.id} references unknown hero skill ${skillId}.`,
-      suggestion: "Use a skill from hero-skill-trees-full.json or remove the stale learnedSkills entry."
-    });
-    return false;
-  }
-
-  if (learnedSkill.rank > skill.maxRank) {
-    pushIssue(issues, {
-      documentId: "world",
-      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}].rank`),
-      code: "hero_skill_rank_exceeds_max",
-      message: `Hero ${hero.id} sets ${skillId} to rank ${learnedSkill.rank}, but the skill only supports rank ${skill.maxRank}.`,
-      suggestion: "Lower the authored rank so it stays within the skill tree definition."
-    });
-  }
-
-  if ((hero.progression?.level ?? 1) < skill.requiredLevel) {
-    pushIssue(issues, {
-      documentId: "world",
-      path: heroPath(heroIndex, `.learnedSkills[${skillIndex}]`),
-      code: "hero_skill_level_too_low",
-      message: `Hero ${hero.id} is level ${hero.progression?.level ?? 1} but ${skillId} requires level ${skill.requiredLevel}.`,
-      suggestion: "Raise the hero level or remove the learned skill until the prerequisite level is reached."
-    });
-  }
-
-  return true;
 }
 
 function validateHeroEquipmentLoadout(hero: HeroConfig, heroIndex: number, issues: ContentPackValidationIssue[]): void {
@@ -640,7 +556,18 @@ function buildSummary(issueCount: number): string {
 
 export function validateContentPackConsistency(bundle: RuntimeConfigBundle): ContentPackValidationReport {
   const issues: ContentPackValidationIssue[] = [];
-  const heroSkillIndex = buildHeroSkillIndex();
+  const heroSkills = bundle.heroSkills ?? getDefaultHeroSkillTreeConfig();
+  const heroSkillIndex = buildHeroSkillIndex(heroSkills);
+
+  for (const issue of validateWorldHeroSkillReferences(bundle.world, heroSkills)) {
+    pushIssue(issues, {
+      documentId: "world",
+      path: issue.path,
+      code: issue.code,
+      message: issue.message,
+      suggestion: "Update phase1-world hero progression so it matches the authored hero skill tree."
+    });
+  }
 
   validateWorldReferences(bundle.world, bundle.units, issues);
   bundle.world.heroes.forEach((hero, heroIndex) => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from "./battle-report.ts";
 export * from "./battle-replay.ts";
 export * from "./campaign.ts";
 export * from "./competitive-season.ts";
+export * from "./config-cross-file-validation.ts";
 export * from "./analytics-events.ts";
 export * from "./content-pack-validation.ts";
 export * from "./cosmetics.ts";

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -32,6 +32,11 @@ import stonewatchForkWorldConfig from "../../../configs/phase1-world-stonewatch-
 import thornwallDivideWorldConfig from "../../../configs/phase1-world-thornwall-divide.json";
 import ridgewayCrossingWorldConfig from "../../../configs/phase1-world-ridgeway-crossing.json";
 import defaultWorldConfig from "../../../configs/phase1-world.json";
+import {
+  assertNoCrossFileConfigIssues,
+  validateHeroSkillTreeCrossReferences,
+  validateWorldHeroSkillReferences
+} from "./config-cross-file-validation.ts";
 import type {
   BattleSkillCatalogConfig,
   BattleBalanceConfig,
@@ -82,6 +87,7 @@ export interface RuntimeConfigBundle {
   units: UnitCatalogConfig;
   battleSkills: BattleSkillCatalogConfig;
   battleBalance?: BattleBalanceConfig;
+  heroSkills?: HeroSkillTreeConfig;
 }
 
 export interface RoomRuntimeConfigBundle extends RuntimeConfigBundle {
@@ -580,98 +586,7 @@ export function validateHeroSkillTreeConfig(
   config: HeroSkillTreeConfig,
   battleSkillCatalog: BattleSkillCatalogConfig = runtimeBattleSkillCatalog
 ): void {
-  if (!Array.isArray(config.branches) || !Array.isArray(config.skills)) {
-    throw new Error("Hero skill tree config must contain branches and skills arrays");
-  }
-
-  const branchIds = new Set<string>();
-  for (const branch of config.branches) {
-    if (!isNonEmptyString(branch.id)) {
-      throw new Error("Hero skill branch id must be a non-empty string");
-    }
-    if (branchIds.has(branch.id)) {
-      throw new Error(`Duplicate hero skill branch id: ${branch.id}`);
-    }
-    if (!isNonEmptyString(branch.name)) {
-      throw new Error(`Hero skill branch ${branch.id} must define a name`);
-    }
-    if (!isNonEmptyString(branch.description)) {
-      throw new Error(`Hero skill branch ${branch.id} must define a description`);
-    }
-    branchIds.add(branch.id);
-  }
-
-  const battleSkillIds = new Set(battleSkillCatalog.skills.map((skill) => skill.id));
-  const skillIds = new Set<string>();
-  for (const skill of config.skills) {
-    if (!isNonEmptyString(skill.id)) {
-      throw new Error("Hero skill id must be a non-empty string");
-    }
-    if (skillIds.has(skill.id)) {
-      throw new Error(`Duplicate hero skill id: ${skill.id}`);
-    }
-    if (!branchIds.has(skill.branchId)) {
-      throw new Error(`Hero skill ${skill.id} references unknown branch: ${skill.branchId}`);
-    }
-    if (!isNonEmptyString(skill.name)) {
-      throw new Error(`Hero skill ${skill.id} must define a name`);
-    }
-    if (!isNonEmptyString(skill.description)) {
-      throw new Error(`Hero skill ${skill.id} must define a description`);
-    }
-    if (!Number.isInteger(skill.requiredLevel) || skill.requiredLevel < 1) {
-      throw new Error(`Hero skill ${skill.id} requiredLevel must be a positive integer`);
-    }
-    if (!Number.isInteger(skill.maxRank) || skill.maxRank < 1) {
-      throw new Error(`Hero skill ${skill.id} maxRank must be a positive integer`);
-    }
-    if (!Array.isArray(skill.ranks) || skill.ranks.length !== skill.maxRank) {
-      throw new Error(`Hero skill ${skill.id} must define exactly ${skill.maxRank} rank entries`);
-    }
-
-    const rankIds = new Set<number>();
-    for (const rank of skill.ranks) {
-      if (!Number.isInteger(rank.rank) || rank.rank < 1 || rank.rank > skill.maxRank) {
-        throw new Error(`Hero skill ${skill.id} has invalid rank entry: ${String(rank.rank)}`);
-      }
-      if (rankIds.has(rank.rank)) {
-        throw new Error(`Hero skill ${skill.id} has duplicate rank entry: ${rank.rank}`);
-      }
-      if (!isNonEmptyString(rank.description)) {
-        throw new Error(`Hero skill ${skill.id} rank ${rank.rank} must define a description`);
-      }
-
-      for (const [key, value] of Object.entries(rank.statBonuses ?? {})) {
-        if (!["attack", "defense", "power", "knowledge", "maxHp"].includes(key)) {
-          throw new Error(`Hero skill ${skill.id} rank ${rank.rank} has unknown stat bonus: ${key}`);
-        }
-        if (!Number.isInteger(value) || value < 0) {
-          throw new Error(`Hero skill ${skill.id} rank ${rank.rank} stat bonus ${key} must be a non-negative integer`);
-        }
-      }
-
-      for (const battleSkillId of rank.battleSkillIds ?? []) {
-        if (!battleSkillIds.has(battleSkillId)) {
-          throw new Error(`Hero skill ${skill.id} rank ${rank.rank} references unknown battle skill: ${battleSkillId}`);
-        }
-      }
-
-      rankIds.add(rank.rank);
-    }
-
-    skillIds.add(skill.id);
-  }
-
-  for (const skill of config.skills) {
-    for (const prerequisite of skill.prerequisites ?? []) {
-      if (!skillIds.has(prerequisite)) {
-        throw new Error(`Hero skill ${skill.id} references unknown prerequisite: ${prerequisite}`);
-      }
-      if (prerequisite === skill.id) {
-        throw new Error(`Hero skill ${skill.id} cannot depend on itself`);
-      }
-    }
-  }
+  assertNoCrossFileConfigIssues(validateHeroSkillTreeCrossReferences(config, battleSkillCatalog));
 }
 
 export function validateWorldConfig(config: WorldGenerationConfig): void {
@@ -1152,6 +1067,7 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
 export function setWorldConfig(config: WorldGenerationConfig): void {
   const nextConfig = cloneWorldConfig(config);
   validateWorldConfig(nextConfig);
+  assertNoCrossFileConfigIssues(validateWorldHeroSkillReferences(nextConfig, runtimeHeroSkillTree));
   validateMapObjectsConfig(runtimeMapObjectsConfig, nextConfig, runtimeUnitCatalog);
   runtimeWorldConfig = nextConfig;
 }
@@ -1186,7 +1102,8 @@ export function setBattleBalanceConfig(config: BattleBalanceConfig): void {
 
 export function setHeroSkillTreeConfig(config: HeroSkillTreeConfig): void {
   const nextConfig = cloneHeroSkillTreeConfig(config);
-  validateHeroSkillTreeConfig(nextConfig);
+  validateHeroSkillTreeConfig(nextConfig, runtimeBattleSkillCatalog);
+  assertNoCrossFileConfigIssues(validateWorldHeroSkillReferences(runtimeWorldConfig, nextConfig));
   runtimeHeroSkillTree = nextConfig;
 }
 
@@ -1196,18 +1113,22 @@ export function replaceRuntimeConfigs(configs: RuntimeConfigBundle): void {
   const nextUnits = cloneUnitCatalog(configs.units);
   const nextBattleSkills = cloneBattleSkillCatalog(configs.battleSkills);
   const nextBattleBalance = cloneBattleBalanceConfig(configs.battleBalance ?? runtimeBattleBalanceConfig);
+  const nextHeroSkills = cloneHeroSkillTreeConfig(configs.heroSkills ?? runtimeHeroSkillTree);
 
   validateWorldConfig(nextWorld);
   validateBattleSkillCatalog(nextBattleSkills);
   validateUnitCatalog(nextUnits, nextBattleSkills);
   validateMapObjectsConfig(nextMapObjects, nextWorld, nextUnits);
   validateBattleBalanceConfig(nextBattleBalance, nextBattleSkills);
+  validateHeroSkillTreeConfig(nextHeroSkills, nextBattleSkills);
+  assertNoCrossFileConfigIssues(validateWorldHeroSkillReferences(nextWorld, nextHeroSkills));
 
   runtimeWorldConfig = nextWorld;
   runtimeMapObjectsConfig = nextMapObjects;
   runtimeUnitCatalog = nextUnits;
   runtimeBattleSkillCatalog = nextBattleSkills;
   runtimeBattleBalanceConfig = nextBattleBalance;
+  runtimeHeroSkillTree = nextHeroSkills;
 }
 
 export function resetRuntimeConfigs(): void {

--- a/packages/shared/test/config-cross-file-validation.test.ts
+++ b/packages/shared/test/config-cross-file-validation.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getBattleBalanceConfig,
+  getDefaultBattleSkillCatalog,
+  getDefaultHeroSkillTreeConfig,
+  getDefaultMapObjectsConfig,
+  getDefaultUnitCatalog,
+  getDefaultWorldConfig,
+  replaceRuntimeConfigs,
+  resetRuntimeConfigs,
+  setHeroSkillTreeConfig,
+  setWorldConfig,
+  validateHeroSkillTreeConfig
+} from "../src/index.ts";
+
+test("validateHeroSkillTreeConfig reports the exact hero skill path for battle skill references", () => {
+  const heroSkills = getDefaultHeroSkillTreeConfig();
+  heroSkills.skills[0]!.ranks[0]!.battleSkillIds = ["missing_skill"];
+
+  assert.throws(
+    () => validateHeroSkillTreeConfig(heroSkills, getDefaultBattleSkillCatalog()),
+    /skills\[0\]\.ranks\[0\]\.battleSkillIds\[0\]: Hero skill .* references unknown battle skill missing_skill/
+  );
+});
+
+test("setWorldConfig rejects learned skills missing from the runtime hero skill tree", () => {
+  const world = getDefaultWorldConfig();
+  world.heroes[0] = {
+    ...world.heroes[0]!,
+    learnedSkills: [{ skillId: "missing_skill", rank: 1 }]
+  };
+
+  assert.throws(
+    () => setWorldConfig(world),
+    /heroes\[0\]\.learnedSkills\[0\]\.skillId: Hero .* references unknown hero skill missing_skill/
+  );
+
+  resetRuntimeConfigs();
+});
+
+test("setHeroSkillTreeConfig rejects trees that invalidate the runtime world", () => {
+  const world = getDefaultWorldConfig();
+  world.heroes[0] = {
+    ...world.heroes[0]!,
+    progression: {
+      ...(world.heroes[0]!.progression ?? {}),
+      level: 2
+    },
+    learnedSkills: [{ skillId: "war_banner", rank: 1 }]
+  };
+  setWorldConfig(world);
+
+  const heroSkills = getDefaultHeroSkillTreeConfig();
+  heroSkills.skills[0] = {
+    ...heroSkills.skills[0]!,
+    requiredLevel: 9999
+  };
+
+  assert.throws(
+    () => setHeroSkillTreeConfig(heroSkills),
+    /heroes\[0\]\.learnedSkills\[0\]: Hero .* is level .* but war_banner requires level 9999/
+  );
+
+  resetRuntimeConfigs();
+});
+
+test("replaceRuntimeConfigs validates world and hero skill cross-file references together", () => {
+  const world = getDefaultWorldConfig();
+  world.heroes[0] = {
+    ...world.heroes[0]!,
+    learnedSkills: [{ skillId: "war_banner", rank: 1 }]
+  };
+  const heroSkills = getDefaultHeroSkillTreeConfig();
+  heroSkills.skills[0] = {
+    ...heroSkills.skills[0]!,
+    requiredLevel: 9999
+  };
+
+  assert.throws(
+    () =>
+      replaceRuntimeConfigs({
+        world,
+        mapObjects: getDefaultMapObjectsConfig(),
+        units: getDefaultUnitCatalog(),
+        battleSkills: getDefaultBattleSkillCatalog(),
+        battleBalance: getBattleBalanceConfig(),
+        heroSkills
+      }),
+    /heroes\[0\]\.learnedSkills\[0\]: Hero .* is level .* but war_banner requires level 9999/
+  );
+
+  resetRuntimeConfigs();
+});

--- a/scripts/test/validate-content-pack.test.ts
+++ b/scripts/test/validate-content-pack.test.ts
@@ -42,7 +42,9 @@ async function seedContentPackRoot(tempDir: string): Promise<void> {
       "battle-skills.json",
       "battle-balance.json",
       "hero-skills.json",
-      "hero-skill-trees-full.json"
+      "hero-skill-trees-full.json",
+      "daily-dungeons.json",
+      "boss-encounter-templates.json"
     ].map((fileName) => copyConfigFixture(tempDir, fileName))
   );
 }
@@ -224,7 +226,40 @@ test("validate-content-pack fails on unknown hero skill battle-skill references"
       assert.equal(error.code, 1);
       assert.match(error.stdout ?? "", /Authoring config validation: 1 issue\(s\)/);
       assert.match(error.stdout ?? "", /\[heroSkills\] hero-skill-trees-full\.json/);
-      assert.match(error.stdout ?? "", /references unknown battle skill: missing_skill/);
+      assert.match(error.stdout ?? "", /references unknown battle skill missing_skill/);
+      return true;
+    }
+  );
+});
+
+test("validate-content-pack uses the authored hero skill tree for world cross-file validation", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "veil-content-pack-"));
+  await seedContentPackRoot(tempDir);
+
+  const worldPath = join(tempDir, "phase1-world.json");
+  const world = JSON.parse(await readFile(worldPath, "utf8")) as {
+    heroes: Array<{ learnedSkills?: Array<{ skillId: string; rank: number }> }>;
+  };
+  world.heroes[0] = {
+    ...world.heroes[0]!,
+    learnedSkills: [{ skillId: "war_banner", rank: 1 }]
+  };
+  await writeFile(worldPath, `${JSON.stringify(world, null, 2)}\n`, "utf8");
+
+  const heroSkillsPath = join(tempDir, "hero-skill-trees-full.json");
+  const heroSkills = JSON.parse(await readFile(heroSkillsPath, "utf8")) as {
+    skills: Array<{ id: string }>;
+  };
+
+  heroSkills.skills = heroSkills.skills.filter((skill) => skill.id !== "war_banner");
+  await writeFile(heroSkillsPath, `${JSON.stringify(heroSkills, null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    execFileAsync("node", ["--import", "tsx", scriptPath, "--root-dir", tempDir], { cwd: repoRoot }),
+    (error: NodeJS.ErrnoException & { stdout?: string }) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stdout ?? "", /\[world\] heroes\[0\]\.learnedSkills\[0\]\.skillId/);
+      assert.match(error.stdout ?? "", /references unknown hero skill war_banner/);
       return true;
     }
   );

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  CrossFileConfigValidationError,
   getDefaultEquipmentCatalog,
   getDefaultBattleBalanceConfig,
   validateBattleBalanceConfig,
@@ -134,11 +135,19 @@ function validateDocuments(bundleId: string, bundle: RuntimeConfigBundle): Docum
     try {
       callback();
     } catch (error) {
+      const precisePath =
+        error instanceof CrossFileConfigValidationError ? `${path}.${error.issue.path}` : path;
+      const message =
+        error instanceof CrossFileConfigValidationError
+          ? error.issue.message
+          : error instanceof Error
+            ? error.message
+            : "Unknown validation error";
       issues.push({
         bundleId,
         documentId,
-        path,
-        message: error instanceof Error ? error.message : "Unknown validation error"
+        path: precisePath,
+        message
       });
     }
   };
@@ -172,12 +181,13 @@ function printIssues(
 }
 
 async function loadBundle(rootDir: string, definition: ContentPackMapPackDefinition): Promise<RuntimeConfigBundle> {
-  const [world, mapObjects, units, battleSkills, battleBalance] = await Promise.all([
+  const [world, mapObjects, units, battleSkills, battleBalance, heroSkills] = await Promise.all([
     readJsonConfig<WorldGenerationConfig>(rootDir, definition.worldFileName),
     readJsonConfig<MapObjectsConfig>(rootDir, definition.mapObjectsFileName),
     readJsonConfig<UnitCatalogConfig>(rootDir, "units.json"),
     readJsonConfig<BattleSkillCatalogConfig>(rootDir, "battle-skills.json"),
-    readJsonConfig<BattleBalanceConfig>(rootDir, "battle-balance.json")
+    readJsonConfig<BattleBalanceConfig>(rootDir, "battle-balance.json"),
+    readJsonConfig<HeroSkillTreeConfig>(rootDir, "hero-skill-trees-full.json")
   ]);
 
   return {
@@ -185,7 +195,8 @@ async function loadBundle(rootDir: string, definition: ContentPackMapPackDefinit
     mapObjects,
     units,
     battleSkills,
-    battleBalance
+    battleBalance,
+    heroSkills
   };
 }
 
@@ -198,11 +209,19 @@ async function validateAuthoringConfigs(
     try {
       callback();
     } catch (error) {
+      const precisePath =
+        error instanceof CrossFileConfigValidationError ? `${path}.${error.issue.path}` : path;
+      const message =
+        error instanceof CrossFileConfigValidationError
+          ? error.issue.message
+          : error instanceof Error
+            ? error.message
+            : "Unknown validation error";
       issues.push({
         bundleId: "global",
         documentId,
-        path,
-        message: error instanceof Error ? error.message : "Unknown validation error"
+        path: precisePath,
+        message
       });
     }
   };


### PR DESCRIPTION
## Summary
- add shared cross-file config validators for hero skill trees and `phase1-world` hero skill references with exact offending config paths
- wire the stricter validation through the repo validator and shared/Cocos runtime config setters so invalid references fail locally before smoke runs
- document the contributor-facing validation command and add regression coverage for CLI and runtime validation behavior

## Validation
- `npm run typecheck:ci`
- `node --import tsx --test ./packages/shared/test/config-cross-file-validation.test.ts ./packages/shared/test/content-pack-validation.test.ts ./scripts/test/validate-content-pack.test.ts`
- `npm run validate:content-pack -- --report-path /tmp/content-pack-validation-report.json`
- `npm run validate:content-pack:all`

Closes #992