### PR TITLE
[COCOS] Add main-journey replay evidence gate for primary client

### DIFF
--- a/docs/cocos-primary-client-delivery.md
+++ b/docs/cocos-primary-client-delivery.md
@@ -86,9 +86,17 @@ Keep these manual items short and attach evidence through the existing release e
 3. Run `npm run release:cocos-rc:bundle -- --candidate <candidate-name> --build-surface <surface>` and keep the generated `cocos-presentation-signoff-<candidate>-<short-sha>.json/.md` with the rest of the candidate bundle.
    Review that artifact using [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md), starting from the maintained Phase 1 fallback inventory there, and classify each presentation row as `pass`, `waived-controlled-test`, or `fail` so reviewers can distinguish functional RC pass from presentation risk.
    The same candidate evidence should explicitly show one polished battle journey covering encounter entry, at least one command/impact beat, and a stable victory or defeat settlement state before reconnect review.
+   The bundle now also emits `cocos-main-journey-replay-gate-<candidate>-<short-sha>.json/.md`; use that gate as the reviewer-facing proof that the primary-client journey evidence, RC snapshot, bundle manifest, checklist, and blocker log still point at the same candidate revision.
 4. Copy and fill the RC checklist/template files in [`docs/release-evidence`](./release-evidence/), reusing the generated presentation sign-off artifact instead of free-form PR notes.
 5. Record any open risk in the blocker template before sign-off.
 6. Confirm the release candidate still matches the intended commit/revision.
+
+Reviewer workflow for the candidate packet:
+
+1. Open the generated `cocos-main-journey-replay-gate-<candidate>-<short-sha>.md` first.
+2. Treat `Infrastructure Failures` or `Evidence Drift` there as a stop-ship signal for the candidate revision.
+3. Treat `Presentation Blockers` there as a separate sign-off track, then continue into [`docs/cocos-phase1-presentation-signoff.md`](./cocos-phase1-presentation-signoff.md) for the visual/debt decision.
+4. If the gate passes, use the linked bundle summary, checkpoint ledger, checklist, and blocker log for the full reviewer packet.
 
 ## Related Commands
 

--- a/docs/cocos-release-evidence-template.md
+++ b/docs/cocos-release-evidence-template.md
@@ -27,14 +27,18 @@
    - 同一 bundle 的人类可读摘要，直接列出主链路 pass/fail/pending 状态
 5. `artifacts/release-readiness/cocos-rc-snapshot-<candidate>-<short-sha>.json`
    - `npm run release:cocos-rc:snapshot` 生成并回填的结构化 RC 证据
-6. `artifacts/release-readiness/cocos-rc-checklist-<candidate>-<short-sha>.md`
+6. `artifacts/release-readiness/cocos-main-journey-replay-gate-<candidate>-<short-sha>.json`
+   - candidate-scoped main-journey evidence gate，固定校验 primary journey evidence、RC snapshot、bundle manifest、checklist、blockers 是否仍绑定同一 revision，并把 presentation blockers 与 infrastructure failures 分开汇总
+7. `artifacts/release-readiness/cocos-main-journey-replay-gate-<candidate>-<short-sha>.md`
+   - 对应 gate 的 reviewer 摘要，默认包含 `Reviewer Workflow`，用于在 PR / release issue 中快速判定这份 packet 是否还能作为主客户端主链路证据
+8. `artifacts/release-readiness/cocos-rc-checklist-<candidate>-<short-sha>.md`
    - 从模板复制并预填 candidate / revision 的人工检查清单
-7. `artifacts/release-readiness/cocos-rc-blockers-<candidate>-<short-sha>.md`
+9. `artifacts/release-readiness/cocos-rc-blockers-<candidate>-<short-sha>.md`
    - 从模板复制并预填 candidate / revision 的 blocker 记录
 
-其中 5 是权威 machine-readable RC 记录，1/2 则是自动化 primary journey 的原始证据面，3/4/6/7 是 reviewer / release owner 快速扫读和留档的补充视图。不要为同一个 RC 另外发明独立格式。
+其中 5 是权威 machine-readable RC 记录，1/2 则是自动化 primary journey 的原始证据面，6/7 是 candidate-scoped main-journey 守门摘要，3/4/8/9 是 reviewer / release owner 快速扫读和留档的补充视图。不要为同一个 RC 另外发明独立格式。
 
-在 release review 中，先读 primary journey Markdown 里的 `Blocker Drill-Down`，再按 `Checkpoint Ledger` 打开对应 milestone JSON。只有当 reviewer 需要跨 surface 或同 candidate 聚合视图时，才继续展开 RC bundle / snapshot / checklist / blockers。
+在 release review 中，先读 `cocos-main-journey-replay-gate-<candidate>-<short-sha>.md` 里的 `Infrastructure Failures` / `Evidence Drift` / `Presentation Blockers`，再按需要展开 primary journey Markdown 的 `Blocker Drill-Down` 与 `Checkpoint Ledger`。只有当 reviewer 需要跨 surface 或同 candidate 聚合视图时，才继续展开 RC bundle / snapshot / checklist / blockers。
 
 ## 标准流程
 

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -103,7 +103,7 @@ Relevant scripts: 45
 - Required inputs:
   - Pass `--candidate`; optionally supply build-surface, snapshot inputs, and WeChat smoke/report paths when bundling non-default evidence.
 - Produced artifacts:
-  - Bundle files under `artifacts/release-readiness/`, including `cocos-rc-evidence-bundle-<candidate>-<short-sha>.json` and companion Markdown/checklist/blocker artifacts.
+  - Bundle files under `artifacts/release-readiness/`, including `cocos-rc-evidence-bundle-<candidate>-<short-sha>.json`, `cocos-main-journey-replay-gate-<candidate>-<short-sha>.json`, and companion Markdown/checklist/blocker artifacts.
 
 ## `release:cocos-rc:snapshot`
 
@@ -136,6 +136,17 @@ Relevant scripts: 45
 - Produced artifacts:
   - `artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.json`
   - `artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.md`
+
+## `release:cocos:main-journey-replay-gate`
+
+- Family: `release`
+- Command: `node --import tsx ./scripts/cocos-main-journey-replay-gate.ts`
+- Purpose: Validate that the primary-client main-journey evidence covers the required candidate-scoped steps and that the RC snapshot, bundle, checklist, and blocker log still point at the same candidate revision.
+- Required inputs:
+  - Pass `--candidate`; optionally pin the journey evidence, RC snapshot, bundle manifest, presentation sign-off, checklist, and blocker paths.
+- Produced artifacts:
+  - `artifacts/release-readiness/cocos-main-journey-replay-gate-<candidate>-<short-sha>.json`
+  - `artifacts/release-readiness/cocos-main-journey-replay-gate-<candidate>-<short-sha>.md`
 
 ## `release:evidence:index`
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "release:cocos-rc:snapshot": "node --import tsx ./scripts/cocos-release-candidate-snapshot.ts",
     "release:cocos-rc:bundle": "node --import tsx ./scripts/cocos-rc-evidence-bundle.ts",
     "release:cocos:primary-journey-evidence": "node --import tsx ./scripts/cocos-primary-client-journey-evidence.ts",
+    "release:cocos:main-journey-replay-gate": "node --import tsx ./scripts/cocos-main-journey-replay-gate.ts",
     "smoke:cocos:canonical-journey": "node --import tsx ./scripts/cocos-primary-client-journey-evidence.ts",
     "release:cocos:primary-diagnostics": "node --import tsx ./scripts/cocos-primary-client-diagnostic-snapshots.ts",
     "audit:cocos-primary-delivery": "node --import tsx ./scripts/audit-cocos-primary-delivery.ts",

--- a/scripts/cocos-main-journey-replay-gate.ts
+++ b/scripts/cocos-main-journey-replay-gate.ts
@@ -1,0 +1,863 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type GateStatus = "passed" | "failed";
+type PresentationStatus = "approved" | "approved-for-controlled-test" | "hold" | "missing";
+type FindingCode =
+  | "missing"
+  | "candidate_mismatch"
+  | "revision_mismatch"
+  | "linked_artifact_mismatch"
+  | "missing_step"
+  | "non_passing_step"
+  | "functional_failure";
+
+interface Args {
+  candidate: string;
+  expectedRevision?: string;
+  primaryJourneyEvidencePath?: string;
+  cocosRcSnapshotPath?: string;
+  cocosRcBundlePath?: string;
+  presentationSignoffPath?: string;
+  checklistPath?: string;
+  blockersPath?: string;
+  outputPath?: string;
+  markdownOutputPath?: string;
+}
+
+interface PrimaryJourneyEvidenceArtifact {
+  candidate?: {
+    name?: string;
+    commit?: string;
+    shortCommit?: string;
+  };
+  execution?: {
+    overallStatus?: "passed" | "failed";
+    completedAt?: string;
+    summary?: string;
+  };
+  journey?: Array<{
+    id?: string;
+    title?: string;
+    status?: string;
+    summary?: string;
+  }>;
+}
+
+interface CocosRcSnapshot {
+  candidate?: {
+    name?: string;
+    commit?: string;
+    shortCommit?: string;
+  };
+  execution?: {
+    executedAt?: string;
+  };
+  linkedEvidence?: {
+    primaryJourneyEvidence?: {
+      path?: string;
+    };
+  };
+}
+
+interface CocosRcBundleManifest {
+  bundle?: {
+    generatedAt?: string;
+    candidate?: string;
+    commit?: string;
+    shortCommit?: string;
+  };
+  artifacts?: {
+    primaryJourneyEvidence?: string;
+    snapshot?: string;
+    presentationSignoff?: string;
+    checklistMarkdown?: string;
+    blockersMarkdown?: string;
+  };
+  review?: {
+    functionalEvidence?: {
+      status?: string;
+      summary?: string;
+    };
+    presentationSignoff?: {
+      status?: PresentationStatus;
+      summary?: string;
+    };
+  };
+}
+
+interface PresentationSignoffArtifact {
+  candidate?: {
+    name?: string;
+    commit?: string;
+    shortCommit?: string;
+  };
+  signoff?: {
+    status?: PresentationStatus;
+    summary?: string;
+    blockingItems?: string[];
+    controlledTestGaps?: string[];
+  };
+}
+
+interface GateFinding {
+  code: FindingCode;
+  summary: string;
+  artifactPath?: string;
+}
+
+interface ArtifactCheck {
+  id: "primary-journey-evidence" | "cocos-rc-snapshot" | "cocos-rc-bundle" | "presentation-signoff" | "checklist" | "blockers";
+  label: string;
+  artifactPath?: string;
+  candidate?: string;
+  revision?: string;
+  status: GateStatus;
+  findings: GateFinding[];
+}
+
+interface JourneyCoverageEntry {
+  id: string;
+  title: string;
+  status: string;
+  summary: string;
+}
+
+interface MainJourneyReplayGateReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  candidate: {
+    name: string;
+    expectedRevision: string;
+  };
+  summary: {
+    status: GateStatus;
+    infrastructureFailureCount: number;
+    evidenceDriftCount: number;
+    presentationBlockerCount: number;
+    summary: string;
+  };
+  inputs: {
+    primaryJourneyEvidencePath?: string;
+    cocosRcSnapshotPath?: string;
+    cocosRcBundlePath?: string;
+    presentationSignoffPath?: string;
+    checklistPath?: string;
+    blockersPath?: string;
+  };
+  coverage: {
+    requiredSteps: JourneyCoverageEntry[];
+  };
+  artifacts: ArtifactCheck[];
+  triage: {
+    infrastructureFailures: GateFinding[];
+    evidenceDrift: GateFinding[];
+    presentationBlockers: string[];
+    controlledTestGaps: string[];
+    functionalStatus: string;
+    functionalSummary: string;
+    presentationStatus: PresentationStatus;
+    presentationSummary: string;
+  };
+}
+
+const DEFAULT_OUTPUT_DIR = path.resolve("artifacts", "release-readiness");
+const REQUIRED_STEPS: Array<{ id: string; title: string }> = [
+  { id: "lobby-entry", title: "Lobby / login" },
+  { id: "room-join", title: "Room join" },
+  { id: "map-explore", title: "Map exploration" },
+  { id: "first-battle", title: "Encounter battle" },
+  { id: "battle-settlement", title: "Settlement" },
+  { id: "reconnect-restore", title: "Reconnect / session recovery" }
+];
+const HEX_REVISION_PATTERN = /^[a-f0-9]+$/i;
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parseArgs(argv: string[]): Args {
+  let candidate = "";
+  let expectedRevision: string | undefined;
+  let primaryJourneyEvidencePath: string | undefined;
+  let cocosRcSnapshotPath: string | undefined;
+  let cocosRcBundlePath: string | undefined;
+  let presentationSignoffPath: string | undefined;
+  let checklistPath: string | undefined;
+  let blockersPath: string | undefined;
+  let outputPath: string | undefined;
+  let markdownOutputPath: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === "--candidate" && next) {
+      candidate = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--expected-revision" && next) {
+      expectedRevision = next.trim();
+      index += 1;
+      continue;
+    }
+    if (arg === "--primary-journey-evidence" && next) {
+      primaryJourneyEvidencePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--cocos-rc-snapshot" && next) {
+      cocosRcSnapshotPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--cocos-rc-bundle" && next) {
+      cocosRcBundlePath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--presentation-signoff" && next) {
+      presentationSignoffPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--checklist" && next) {
+      checklistPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--blockers" && next) {
+      blockersPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--markdown-output" && next) {
+      markdownOutputPath = next;
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  if (!candidate) {
+    fail("Missing required argument: --candidate");
+  }
+
+  return {
+    candidate,
+    ...(expectedRevision ? { expectedRevision } : {}),
+    ...(primaryJourneyEvidencePath ? { primaryJourneyEvidencePath } : {}),
+    ...(cocosRcSnapshotPath ? { cocosRcSnapshotPath } : {}),
+    ...(cocosRcBundlePath ? { cocosRcBundlePath } : {}),
+    ...(presentationSignoffPath ? { presentationSignoffPath } : {}),
+    ...(checklistPath ? { checklistPath } : {}),
+    ...(blockersPath ? { blockersPath } : {}),
+    ...(outputPath ? { outputPath } : {}),
+    ...(markdownOutputPath ? { markdownOutputPath } : {})
+  };
+}
+
+function readGitValue(args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    fail(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+function readJsonFile<T>(filePath: string): T {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function writeJsonFile(filePath: string, payload: unknown): void {
+  writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function toRelativePath(filePath: string): string {
+  return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
+}
+
+function slugifyCandidate(candidate: string): string {
+  return candidate
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function normalizeRevision(revision: string | undefined | null): string | undefined {
+  const trimmed = revision?.trim().toLowerCase();
+  return trimmed && HEX_REVISION_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
+function revisionsMatch(left: string | undefined | null, right: string | undefined | null): boolean {
+  const normalizedLeft = normalizeRevision(left);
+  const normalizedRight = normalizeRevision(right);
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+  return normalizedLeft === normalizedRight || normalizedLeft.startsWith(normalizedRight) || normalizedRight.startsWith(normalizedLeft);
+}
+
+function resolveLatestFile(
+  dirPath: string,
+  matcher: (entry: string) => boolean,
+  preferredMatcher?: (entry: string) => boolean
+): string | undefined {
+  if (!fs.existsSync(dirPath)) {
+    return undefined;
+  }
+  const entries = fs
+    .readdirSync(dirPath)
+    .filter((entry) => matcher(entry))
+    .sort((left, right) => {
+      const leftPath = path.join(dirPath, left);
+      const rightPath = path.join(dirPath, right);
+      return fs.statSync(rightPath).mtimeMs - fs.statSync(leftPath).mtimeMs;
+    });
+  if (preferredMatcher) {
+    const preferred = entries.find((entry) => preferredMatcher(entry));
+    if (preferred) {
+      return path.join(dirPath, preferred);
+    }
+  }
+  return entries[0] ? path.join(dirPath, entries[0]) : undefined;
+}
+
+function resolveInputPath(
+  explicitPath: string | undefined,
+  dirMatcher: (entry: string) => boolean,
+  preferredMatcher?: (entry: string) => boolean
+): string | undefined {
+  if (explicitPath) {
+    return path.resolve(explicitPath);
+  }
+  return resolveLatestFile(DEFAULT_OUTPUT_DIR, dirMatcher, preferredMatcher);
+}
+
+function parseMarkdownHeader(filePath: string): { candidate?: string; revision?: string } {
+  const content = fs.readFileSync(filePath, "utf8");
+  const candidate = content.match(/^- Candidate:\s+`([^`]+)`/m)?.[1];
+  const revision = content.match(/^- Commit:\s+`([^`]+)`/m)?.[1];
+  return {
+    ...(candidate ? { candidate } : {}),
+    ...(revision ? { revision } : {})
+  };
+}
+
+function buildMissingArtifact(id: ArtifactCheck["id"], label: string): ArtifactCheck {
+  return {
+    id,
+    label,
+    status: "failed",
+    findings: [{ code: "missing", summary: `${label} is missing.` }]
+  };
+}
+
+function compareLinkedArtifact(expectedPath: string | undefined, actualPath: string | undefined, source: string, artifactPath: string): GateFinding | null {
+  if (!expectedPath || !actualPath) {
+    return null;
+  }
+  const normalizedExpected = path.resolve(expectedPath);
+  const normalizedActual = path.resolve(actualPath);
+  if (normalizedExpected === normalizedActual) {
+    return null;
+  }
+  return {
+    code: "linked_artifact_mismatch",
+    summary: `${source} links ${toRelativePath(normalizedActual)}, expected ${toRelativePath(normalizedExpected)}.`,
+    artifactPath
+  };
+}
+
+export function buildMainJourneyReplayGateReport(args: Args): MainJourneyReplayGateReport {
+  const expectedRevision = args.expectedRevision ?? readGitValue(["rev-parse", "HEAD"]);
+  const candidateSlug = slugifyCandidate(args.candidate);
+  const primaryJourneyEvidencePath = resolveInputPath(
+    args.primaryJourneyEvidencePath,
+    (entry) => entry.startsWith("cocos-primary-journey-evidence-") && entry.endsWith(".json"),
+    (entry) => entry.includes(`cocos-primary-journey-evidence-${candidateSlug}-`)
+  );
+  const cocosRcSnapshotPath = resolveInputPath(
+    args.cocosRcSnapshotPath,
+    (entry) => entry.startsWith("cocos-rc-snapshot-") && entry.endsWith(".json"),
+    (entry) => entry.includes(`cocos-rc-snapshot-${candidateSlug}-`)
+  );
+  const cocosRcBundlePath = resolveInputPath(
+    args.cocosRcBundlePath,
+    (entry) => entry.startsWith("cocos-rc-evidence-bundle-") && entry.endsWith(".json"),
+    (entry) => entry.includes(`cocos-rc-evidence-bundle-${candidateSlug}-`)
+  );
+  const presentationSignoffPath = resolveInputPath(
+    args.presentationSignoffPath,
+    (entry) => entry.startsWith("cocos-presentation-signoff-") && entry.endsWith(".json"),
+    (entry) => entry.includes(`cocos-presentation-signoff-${candidateSlug}-`)
+  );
+  const checklistPath = resolveInputPath(
+    args.checklistPath,
+    (entry) => entry.startsWith("cocos-rc-checklist-") && entry.endsWith(".md"),
+    (entry) => entry.includes(`cocos-rc-checklist-${candidateSlug}-`)
+  );
+  const blockersPath = resolveInputPath(
+    args.blockersPath,
+    (entry) => entry.startsWith("cocos-rc-blockers-") && entry.endsWith(".md"),
+    (entry) => entry.includes(`cocos-rc-blockers-${candidateSlug}-`)
+  );
+
+  const artifacts: ArtifactCheck[] = [];
+  const evidenceDrift: GateFinding[] = [];
+  const infrastructureFailures: GateFinding[] = [];
+  let functionalStatus = "missing";
+  let functionalSummary = "Primary-client journey evidence is missing.";
+  let presentationStatus: PresentationStatus = "missing";
+  let presentationSummary = "Presentation sign-off is missing.";
+  let presentationBlockers: string[] = [];
+  let controlledTestGaps: string[] = [];
+  const requiredSteps = REQUIRED_STEPS.map((step) => ({
+    id: step.id,
+    title: step.title,
+    status: "missing",
+    summary: "Step is missing from primary journey evidence."
+  }));
+
+  if (!primaryJourneyEvidencePath || !fs.existsSync(primaryJourneyEvidencePath)) {
+    artifacts.push(buildMissingArtifact("primary-journey-evidence", "Primary journey evidence"));
+    evidenceDrift.push({ code: "missing", summary: "Primary journey evidence is missing.", artifactPath: primaryJourneyEvidencePath });
+    for (const step of requiredSteps) {
+      infrastructureFailures.push({
+        code: "missing_step",
+        summary: `Primary journey evidence is missing required step ${step.id}.`,
+        artifactPath: primaryJourneyEvidencePath
+      });
+    }
+  } else {
+    const artifact = readJsonFile<PrimaryJourneyEvidenceArtifact>(primaryJourneyEvidencePath);
+    const findings: GateFinding[] = [];
+    if (artifact.candidate?.name !== args.candidate) {
+      findings.push({
+        code: "candidate_mismatch",
+        summary: `Primary journey evidence reports candidate ${artifact.candidate?.name ?? "<missing>"}, expected ${args.candidate}.`,
+        artifactPath: primaryJourneyEvidencePath
+      });
+    }
+    if (!revisionsMatch(artifact.candidate?.commit ?? artifact.candidate?.shortCommit, expectedRevision)) {
+      findings.push({
+        code: "revision_mismatch",
+        summary: `Primary journey evidence reports revision ${artifact.candidate?.commit ?? artifact.candidate?.shortCommit ?? "<missing>"}, expected ${expectedRevision}.`,
+        artifactPath: primaryJourneyEvidencePath
+      });
+    }
+    functionalStatus = artifact.execution?.overallStatus ?? "missing";
+    functionalSummary = artifact.execution?.summary ?? functionalSummary;
+    if (artifact.execution?.overallStatus !== "passed") {
+      infrastructureFailures.push({
+        code: "functional_failure",
+        summary: `Primary journey evidence is ${artifact.execution?.overallStatus ?? "missing"}: ${artifact.execution?.summary ?? "No summary provided."}`,
+        artifactPath: primaryJourneyEvidencePath
+      });
+    }
+
+    const journeyEntries = new Map((artifact.journey ?? []).map((entry) => [entry.id ?? "", entry]));
+    for (const step of requiredSteps) {
+      const journeyEntry = journeyEntries.get(step.id);
+      if (!journeyEntry) {
+        step.status = "missing";
+        step.summary = "Step is missing from primary journey evidence.";
+        infrastructureFailures.push({
+          code: "missing_step",
+          summary: `Primary journey evidence does not include required step ${step.id}.`,
+          artifactPath: primaryJourneyEvidencePath
+        });
+        continue;
+      }
+      step.status = journeyEntry.status ?? "missing";
+      step.summary = journeyEntry.summary ?? "";
+      if (journeyEntry.status !== "passed") {
+        infrastructureFailures.push({
+          code: "non_passing_step",
+          summary: `Primary journey step ${step.id} is ${journeyEntry.status ?? "missing"}${journeyEntry.summary ? `: ${journeyEntry.summary}` : "."}`,
+          artifactPath: primaryJourneyEvidencePath
+        });
+      }
+    }
+    artifacts.push({
+      id: "primary-journey-evidence",
+      label: "Primary journey evidence",
+      artifactPath: primaryJourneyEvidencePath,
+      candidate: artifact.candidate?.name,
+      revision: artifact.candidate?.commit ?? artifact.candidate?.shortCommit,
+      status: findings.length === 0 ? "passed" : "failed",
+      findings
+    });
+    evidenceDrift.push(...findings);
+  }
+
+  if (!cocosRcSnapshotPath || !fs.existsSync(cocosRcSnapshotPath)) {
+    artifacts.push(buildMissingArtifact("cocos-rc-snapshot", "Cocos RC snapshot"));
+    evidenceDrift.push({ code: "missing", summary: "Cocos RC snapshot is missing.", artifactPath: cocosRcSnapshotPath });
+  } else {
+    const snapshot = readJsonFile<CocosRcSnapshot>(cocosRcSnapshotPath);
+    const findings: GateFinding[] = [];
+    if (snapshot.candidate?.name !== args.candidate) {
+      findings.push({
+        code: "candidate_mismatch",
+        summary: `Cocos RC snapshot reports candidate ${snapshot.candidate?.name ?? "<missing>"}, expected ${args.candidate}.`,
+        artifactPath: cocosRcSnapshotPath
+      });
+    }
+    if (!revisionsMatch(snapshot.candidate?.commit ?? snapshot.candidate?.shortCommit, expectedRevision)) {
+      findings.push({
+        code: "revision_mismatch",
+        summary: `Cocos RC snapshot reports revision ${snapshot.candidate?.commit ?? snapshot.candidate?.shortCommit ?? "<missing>"}, expected ${expectedRevision}.`,
+        artifactPath: cocosRcSnapshotPath
+      });
+    }
+    const journeyLinkFinding = compareLinkedArtifact(
+      primaryJourneyEvidencePath,
+      snapshot.linkedEvidence?.primaryJourneyEvidence?.path,
+      "Cocos RC snapshot",
+      cocosRcSnapshotPath
+    );
+    if (journeyLinkFinding) {
+      findings.push(journeyLinkFinding);
+    }
+    artifacts.push({
+      id: "cocos-rc-snapshot",
+      label: "Cocos RC snapshot",
+      artifactPath: cocosRcSnapshotPath,
+      candidate: snapshot.candidate?.name,
+      revision: snapshot.candidate?.commit ?? snapshot.candidate?.shortCommit,
+      status: findings.length === 0 ? "passed" : "failed",
+      findings
+    });
+    evidenceDrift.push(...findings);
+  }
+
+  if (!cocosRcBundlePath || !fs.existsSync(cocosRcBundlePath)) {
+    artifacts.push(buildMissingArtifact("cocos-rc-bundle", "Cocos RC bundle"));
+    evidenceDrift.push({ code: "missing", summary: "Cocos RC bundle is missing.", artifactPath: cocosRcBundlePath });
+  } else {
+    const bundle = readJsonFile<CocosRcBundleManifest>(cocosRcBundlePath);
+    const findings: GateFinding[] = [];
+    if (bundle.bundle?.candidate !== args.candidate) {
+      findings.push({
+        code: "candidate_mismatch",
+        summary: `Cocos RC bundle reports candidate ${bundle.bundle?.candidate ?? "<missing>"}, expected ${args.candidate}.`,
+        artifactPath: cocosRcBundlePath
+      });
+    }
+    if (!revisionsMatch(bundle.bundle?.commit ?? bundle.bundle?.shortCommit, expectedRevision)) {
+      findings.push({
+        code: "revision_mismatch",
+        summary: `Cocos RC bundle reports revision ${bundle.bundle?.commit ?? bundle.bundle?.shortCommit ?? "<missing>"}, expected ${expectedRevision}.`,
+        artifactPath: cocosRcBundlePath
+      });
+    }
+    for (const finding of [
+      compareLinkedArtifact(primaryJourneyEvidencePath, bundle.artifacts?.primaryJourneyEvidence, "Cocos RC bundle", cocosRcBundlePath),
+      compareLinkedArtifact(cocosRcSnapshotPath, bundle.artifacts?.snapshot, "Cocos RC bundle", cocosRcBundlePath),
+      compareLinkedArtifact(presentationSignoffPath, bundle.artifacts?.presentationSignoff, "Cocos RC bundle", cocosRcBundlePath),
+      compareLinkedArtifact(checklistPath, bundle.artifacts?.checklistMarkdown, "Cocos RC bundle", cocosRcBundlePath),
+      compareLinkedArtifact(blockersPath, bundle.artifacts?.blockersMarkdown, "Cocos RC bundle", cocosRcBundlePath)
+    ]) {
+      if (finding) {
+        findings.push(finding);
+      }
+    }
+    functionalStatus = bundle.review?.functionalEvidence?.status ?? functionalStatus;
+    functionalSummary = bundle.review?.functionalEvidence?.summary ?? functionalSummary;
+    presentationStatus = bundle.review?.presentationSignoff?.status ?? presentationStatus;
+    presentationSummary = bundle.review?.presentationSignoff?.summary ?? presentationSummary;
+    artifacts.push({
+      id: "cocos-rc-bundle",
+      label: "Cocos RC bundle",
+      artifactPath: cocosRcBundlePath,
+      candidate: bundle.bundle?.candidate,
+      revision: bundle.bundle?.commit ?? bundle.bundle?.shortCommit,
+      status: findings.length === 0 ? "passed" : "failed",
+      findings
+    });
+    evidenceDrift.push(...findings);
+  }
+
+  if (!presentationSignoffPath || !fs.existsSync(presentationSignoffPath)) {
+    artifacts.push(buildMissingArtifact("presentation-signoff", "Presentation sign-off"));
+  } else {
+    const signoff = readJsonFile<PresentationSignoffArtifact>(presentationSignoffPath);
+    const findings: GateFinding[] = [];
+    if (signoff.candidate?.name && signoff.candidate.name !== args.candidate) {
+      findings.push({
+        code: "candidate_mismatch",
+        summary: `Presentation sign-off reports candidate ${signoff.candidate.name}, expected ${args.candidate}.`,
+        artifactPath: presentationSignoffPath
+      });
+    }
+    if (
+      signoff.candidate?.commit || signoff.candidate?.shortCommit
+        ? !revisionsMatch(signoff.candidate?.commit ?? signoff.candidate?.shortCommit, expectedRevision)
+        : false
+    ) {
+      findings.push({
+        code: "revision_mismatch",
+        summary: `Presentation sign-off reports revision ${signoff.candidate?.commit ?? signoff.candidate?.shortCommit ?? "<missing>"}, expected ${expectedRevision}.`,
+        artifactPath: presentationSignoffPath
+      });
+    }
+    presentationStatus = signoff.signoff?.status ?? presentationStatus;
+    presentationSummary = signoff.signoff?.summary ?? presentationSummary;
+    presentationBlockers = signoff.signoff?.blockingItems ?? presentationBlockers;
+    controlledTestGaps = signoff.signoff?.controlledTestGaps ?? controlledTestGaps;
+    artifacts.push({
+      id: "presentation-signoff",
+      label: "Presentation sign-off",
+      artifactPath: presentationSignoffPath,
+      candidate: signoff.candidate?.name,
+      revision: signoff.candidate?.commit ?? signoff.candidate?.shortCommit,
+      status: findings.length === 0 ? "passed" : "failed",
+      findings
+    });
+    evidenceDrift.push(...findings);
+  }
+
+  for (const [id, label, filePath] of [
+    ["checklist", "RC checklist", checklistPath],
+    ["blockers", "RC blockers", blockersPath]
+  ] as const) {
+    if (!filePath || !fs.existsSync(filePath)) {
+      artifacts.push(buildMissingArtifact(id, label));
+      evidenceDrift.push({ code: "missing", summary: `${label} is missing.`, artifactPath: filePath });
+      continue;
+    }
+    const header = parseMarkdownHeader(filePath);
+    const findings: GateFinding[] = [];
+    if (header.candidate !== args.candidate) {
+      findings.push({
+        code: "candidate_mismatch",
+        summary: `${label} reports candidate ${header.candidate ?? "<missing>"}, expected ${args.candidate}.`,
+        artifactPath: filePath
+      });
+    }
+    if (!revisionsMatch(header.revision, expectedRevision)) {
+      findings.push({
+        code: "revision_mismatch",
+        summary: `${label} reports revision ${header.revision ?? "<missing>"}, expected ${expectedRevision}.`,
+        artifactPath: filePath
+      });
+    }
+    artifacts.push({
+      id,
+      label,
+      artifactPath: filePath,
+      candidate: header.candidate,
+      revision: header.revision,
+      status: findings.length === 0 ? "passed" : "failed",
+      findings
+    });
+    evidenceDrift.push(...findings);
+  }
+
+  const status: GateStatus = infrastructureFailures.length === 0 && evidenceDrift.length === 0 ? "passed" : "failed";
+  const summary =
+    status === "passed"
+      ? presentationBlockers.length > 0
+        ? `Main-journey replay evidence passed for ${args.candidate} at ${expectedRevision}; presentation blockers remain tracked separately.`
+        : `Main-journey replay evidence passed for ${args.candidate} at ${expectedRevision}.`
+      : `Main-journey replay evidence failed: ${(infrastructureFailures[0] ?? evidenceDrift[0])?.summary ?? "unknown failure"}`;
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    candidate: {
+      name: args.candidate,
+      expectedRevision
+    },
+    summary: {
+      status,
+      infrastructureFailureCount: infrastructureFailures.length,
+      evidenceDriftCount: evidenceDrift.length,
+      presentationBlockerCount: presentationBlockers.length,
+      summary
+    },
+    inputs: {
+      ...(primaryJourneyEvidencePath ? { primaryJourneyEvidencePath } : {}),
+      ...(cocosRcSnapshotPath ? { cocosRcSnapshotPath } : {}),
+      ...(cocosRcBundlePath ? { cocosRcBundlePath } : {}),
+      ...(presentationSignoffPath ? { presentationSignoffPath } : {}),
+      ...(checklistPath ? { checklistPath } : {}),
+      ...(blockersPath ? { blockersPath } : {})
+    },
+    coverage: {
+      requiredSteps
+    },
+    artifacts,
+    triage: {
+      infrastructureFailures,
+      evidenceDrift,
+      presentationBlockers,
+      controlledTestGaps,
+      functionalStatus,
+      functionalSummary,
+      presentationStatus,
+      presentationSummary
+    }
+  };
+}
+
+export function renderMarkdown(report: MainJourneyReplayGateReport): string {
+  const lines: string[] = [];
+  lines.push("# Cocos Main-Journey Replay Gate");
+  lines.push("");
+  lines.push(`- Generated at: \`${report.generatedAt}\``);
+  lines.push(`- Candidate: \`${report.candidate.name}\``);
+  lines.push(`- Expected revision: \`${report.candidate.expectedRevision}\``);
+  lines.push(`- Overall status: **${report.summary.status.toUpperCase()}**`);
+  lines.push(`- Summary: ${report.summary.summary}`);
+  lines.push("");
+  lines.push("## Inputs");
+  lines.push("");
+  lines.push(`- Primary journey evidence: \`${report.inputs.primaryJourneyEvidencePath ? toRelativePath(report.inputs.primaryJourneyEvidencePath) : "<missing>"}\``);
+  lines.push(`- Cocos RC snapshot: \`${report.inputs.cocosRcSnapshotPath ? toRelativePath(report.inputs.cocosRcSnapshotPath) : "<missing>"}\``);
+  lines.push(`- Cocos RC bundle: \`${report.inputs.cocosRcBundlePath ? toRelativePath(report.inputs.cocosRcBundlePath) : "<missing>"}\``);
+  lines.push(`- Presentation sign-off: \`${report.inputs.presentationSignoffPath ? toRelativePath(report.inputs.presentationSignoffPath) : "<missing>"}\``);
+  lines.push(`- RC checklist: \`${report.inputs.checklistPath ? toRelativePath(report.inputs.checklistPath) : "<missing>"}\``);
+  lines.push(`- RC blockers: \`${report.inputs.blockersPath ? toRelativePath(report.inputs.blockersPath) : "<missing>"}\``);
+  lines.push("");
+  lines.push("## Required Main Journey Coverage");
+  lines.push("");
+  lines.push("| Step | Status | Summary |");
+  lines.push("| --- | --- | --- |");
+  for (const step of report.coverage.requiredSteps) {
+    lines.push(`| ${step.title} | \`${step.status}\` | ${step.summary || "_none_"} |`);
+  }
+  lines.push("");
+  lines.push("## Triage");
+  lines.push("");
+  lines.push(`- Functional evidence status: \`${report.triage.functionalStatus}\``);
+  lines.push(`- Functional evidence summary: ${report.triage.functionalSummary}`);
+  lines.push(`- Presentation status: \`${report.triage.presentationStatus}\``);
+  lines.push(`- Presentation summary: ${report.triage.presentationSummary}`);
+  lines.push("");
+  lines.push("### Infrastructure Failures");
+  lines.push("");
+  if (report.triage.infrastructureFailures.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const finding of report.triage.infrastructureFailures) {
+      lines.push(`- \`${finding.code}\` ${finding.summary}${finding.artifactPath ? ` (\`${toRelativePath(finding.artifactPath)}\`)` : ""}`);
+    }
+  }
+  lines.push("");
+  lines.push("### Evidence Drift");
+  lines.push("");
+  if (report.triage.evidenceDrift.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const finding of report.triage.evidenceDrift) {
+      lines.push(`- \`${finding.code}\` ${finding.summary}${finding.artifactPath ? ` (\`${toRelativePath(finding.artifactPath)}\`)` : ""}`);
+    }
+  }
+  lines.push("");
+  lines.push("### Presentation Blockers");
+  lines.push("");
+  if (report.triage.presentationBlockers.length === 0) {
+    lines.push("- None.");
+  } else {
+    for (const blocker of report.triage.presentationBlockers) {
+      lines.push(`- ${blocker}`);
+    }
+  }
+  if (report.triage.controlledTestGaps.length > 0) {
+    lines.push("");
+    lines.push("### Controlled-Test Gaps");
+    lines.push("");
+    for (const gap of report.triage.controlledTestGaps) {
+      lines.push(`- ${gap}`);
+    }
+  }
+  lines.push("");
+  lines.push("## Artifact Checks");
+  lines.push("");
+  for (const artifact of report.artifacts) {
+    lines.push(`### ${artifact.label}`);
+    lines.push("");
+    lines.push(`- Status: **${artifact.status.toUpperCase()}**`);
+    lines.push(`- Artifact: \`${artifact.artifactPath ? toRelativePath(artifact.artifactPath) : "<missing>"}\``);
+    lines.push(`- Candidate: \`${artifact.candidate ?? "<missing>"}\``);
+    lines.push(`- Revision: \`${artifact.revision ?? "<missing>"}\``);
+    if (artifact.findings.length === 0) {
+      lines.push("- Findings: none.");
+    } else {
+      lines.push("- Findings:");
+      for (const finding of artifact.findings) {
+        lines.push(`  - \`${finding.code}\` ${finding.summary}`);
+      }
+    }
+    lines.push("");
+  }
+  lines.push("## Reviewer Workflow");
+  lines.push("");
+  lines.push("1. Confirm the six required journey steps are all `passed` before using this packet as primary-client release evidence.");
+  lines.push("2. Treat `Infrastructure Failures` and `Evidence Drift` as gate failures for the candidate revision.");
+  lines.push("3. Treat `Presentation Blockers` as a separate sign-off track; they do not replace failed journey coverage or mixed-revision evidence.");
+  lines.push("4. Attach this Markdown with the bundle manifest when reviewers need one candidate-scoped summary for the main journey.");
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function defaultOutputPath(args: Args, expectedRevision: string): string {
+  if (args.outputPath) {
+    return path.resolve(args.outputPath);
+  }
+  return path.resolve(
+    DEFAULT_OUTPUT_DIR,
+    `cocos-main-journey-replay-gate-${slugifyCandidate(args.candidate)}-${expectedRevision.slice(0, 12)}.json`
+  );
+}
+
+function defaultMarkdownOutputPath(args: Args, expectedRevision: string): string {
+  if (args.markdownOutputPath) {
+    return path.resolve(args.markdownOutputPath);
+  }
+  return path.resolve(
+    DEFAULT_OUTPUT_DIR,
+    `cocos-main-journey-replay-gate-${slugifyCandidate(args.candidate)}-${expectedRevision.slice(0, 12)}.md`
+  );
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const report = buildMainJourneyReplayGateReport(args);
+  const outputPath = defaultOutputPath(args, report.candidate.expectedRevision);
+  const markdownOutputPath = defaultMarkdownOutputPath(args, report.candidate.expectedRevision);
+
+  writeJsonFile(outputPath, report);
+  writeFile(markdownOutputPath, renderMarkdown(report));
+
+  console.log(`Wrote Cocos main-journey replay gate JSON: ${toRelativePath(outputPath)}`);
+  console.log(`Wrote Cocos main-journey replay gate Markdown: ${toRelativePath(markdownOutputPath)}`);
+
+  if (report.summary.status === "failed") {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/cocos-rc-evidence-bundle.ts
+++ b/scripts/cocos-rc-evidence-bundle.ts
@@ -187,6 +187,8 @@ interface BundleManifest {
     primaryJourneyEvidenceMarkdown: string;
     mainJourneyManifest: string;
     mainJourneyManifestMarkdown: string;
+    mainJourneyReplayGate: string;
+    mainJourneyReplayGateMarkdown: string;
     snapshot: string;
     summaryMarkdown: string;
     presentationSignoff: string;
@@ -226,6 +228,11 @@ interface BundleManifest {
       status: SnapshotResult;
       summary: string;
     };
+    mainJourneyReplayGate: {
+      status: "passed" | "failed";
+      summary: string;
+      presentationStatus: "approved" | "approved-for-controlled-test" | "hold" | "missing";
+    };
     presentationSignoff: {
       status: PresentationSignoffStatus;
       summary: string;
@@ -243,6 +250,16 @@ interface PresentationChecklistItem {
   evidence: string[];
   owner: string;
   followUp: string;
+}
+
+interface MainJourneyReplayGateReport {
+  summary: {
+    status: "passed" | "failed";
+    summary: string;
+  };
+  triage: {
+    presentationStatus: "approved" | "approved-for-controlled-test" | "hold" | "missing";
+  };
 }
 
 interface PresentationSignoffArtifact {
@@ -518,6 +535,55 @@ function runPrimaryJourneyEvidenceCommand(args: Args, outputPath: string, markdo
   }
 }
 
+function runMainJourneyReplayGateCommand(
+  args: Args,
+  artifacts: Pick<
+    BundleManifest["artifacts"],
+    "primaryJourneyEvidence" | "snapshot" | "presentationSignoff" | "checklistMarkdown" | "blockersMarkdown"
+  >,
+  bundleManifestPath: string,
+  outputPath: string,
+  markdownOutputPath: string
+): MainJourneyReplayGateReport {
+  const commandArgs = [
+    "--import",
+    "tsx",
+    "./scripts/cocos-main-journey-replay-gate.ts",
+    "--candidate",
+    args.candidate,
+    "--expected-revision",
+    getGitValue(["rev-parse", "HEAD"]),
+    "--primary-journey-evidence",
+    artifacts.primaryJourneyEvidence,
+    "--cocos-rc-snapshot",
+    artifacts.snapshot,
+    "--cocos-rc-bundle",
+    bundleManifestPath,
+    "--presentation-signoff",
+    artifacts.presentationSignoff,
+    "--checklist",
+    artifacts.checklistMarkdown,
+    "--blockers",
+    artifacts.blockersMarkdown,
+    "--output",
+    outputPath,
+    "--markdown-output",
+    markdownOutputPath
+  ];
+
+  const result = spawnSync(process.execPath, commandArgs, {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+  if (result.status !== 0 && result.status !== 1) {
+    fail(result.stderr.trim() || result.stdout.trim() || "Failed to generate main-journey replay gate.");
+  }
+  if (!fs.existsSync(outputPath)) {
+    fail("Main-journey replay gate did not write the expected JSON output.");
+  }
+  return readJsonFile<MainJourneyReplayGateReport>(outputPath);
+}
+
 function readJsonFile<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
 }
@@ -633,6 +699,8 @@ function renderBundleMarkdown(snapshot: CocosReleaseCandidateSnapshot, artifacts
   lines.push(`- Primary journey markdown: \`${toRepoRelative(artifacts.primaryJourneyEvidenceMarkdown)}\``);
   lines.push(`- Main-journey manifest: \`${toRepoRelative(artifacts.mainJourneyManifest)}\``);
   lines.push(`- Main-journey manifest markdown: \`${toRepoRelative(artifacts.mainJourneyManifestMarkdown)}\``);
+  lines.push(`- Main-journey replay gate JSON: \`${toRepoRelative(artifacts.mainJourneyReplayGate)}\``);
+  lines.push(`- Main-journey replay gate markdown: \`${toRepoRelative(artifacts.mainJourneyReplayGateMarkdown)}\``);
   lines.push(`- Snapshot: \`${toRepoRelative(artifacts.snapshot)}\``);
   lines.push(`- Presentation sign-off JSON: \`${toRepoRelative(artifacts.presentationSignoff)}\``);
   lines.push(`- Presentation sign-off markdown: \`${toRepoRelative(artifacts.presentationSignoffMarkdown)}\``);
@@ -722,6 +790,16 @@ function buildFunctionalEvidenceReview(snapshot: CocosReleaseCandidateSnapshot):
   return {
     status: snapshot.execution.overallStatus,
     summary: snapshot.execution.summary
+  };
+}
+
+function buildMainJourneyReplayGateReview(
+  report: Pick<MainJourneyReplayGateReport, "summary" | "triage">
+): BundleManifest["review"]["mainJourneyReplayGate"] {
+  return {
+    status: report.summary.status,
+    summary: report.summary.summary,
+    presentationStatus: report.triage.presentationStatus
   };
 }
 
@@ -967,7 +1045,12 @@ function toRepoRelative(filePath: string): string {
   return path.relative(process.cwd(), filePath).replace(/\\/g, "/");
 }
 
-function buildManifest(snapshot: CocosReleaseCandidateSnapshot, artifacts: BundleManifest["artifacts"], outputDir: string): BundleManifest {
+function buildManifest(
+  snapshot: CocosReleaseCandidateSnapshot,
+  artifacts: BundleManifest["artifacts"],
+  outputDir: string,
+  mainJourneyReplayGate: Pick<MainJourneyReplayGateReport, "summary" | "triage">
+): BundleManifest {
   return {
     schemaVersion: 1,
     bundle: {
@@ -1017,6 +1100,7 @@ function buildManifest(snapshot: CocosReleaseCandidateSnapshot, artifacts: Bundl
       attachHint:
         "Attach the markdown bundle summary and presentation sign-off summary to CI artifacts or PR comments, and keep the JSON manifest alongside the snapshot.",
       functionalEvidence: buildFunctionalEvidenceReview(snapshot),
+      mainJourneyReplayGate: buildMainJourneyReplayGateReview(mainJourneyReplayGate),
       presentationSignoff: buildPresentationSignoffReview(snapshot)
     },
     failureSummary: snapshot.failureSummary
@@ -1037,6 +1121,8 @@ function main(): void {
   const manifestPath = path.join(outputDir, `cocos-rc-evidence-bundle-${baseName}.json`);
   const mainJourneyManifestPath = path.join(outputDir, `cocos-main-journey-manifest-${baseName}.json`);
   const mainJourneyManifestMarkdownPath = path.join(outputDir, `cocos-main-journey-manifest-${baseName}.md`);
+  const mainJourneyReplayGatePath = path.join(outputDir, `cocos-main-journey-replay-gate-${baseName}.json`);
+  const mainJourneyReplayGateMarkdownPath = path.join(outputDir, `cocos-main-journey-replay-gate-${baseName}.md`);
   const presentationSignoffPath = path.join(outputDir, `cocos-presentation-signoff-${baseName}.json`);
   const presentationSignoffSummaryPath = path.join(outputDir, `cocos-presentation-signoff-${baseName}.md`);
   const checklistPath = path.join(outputDir, `cocos-rc-checklist-${baseName}.md`);
@@ -1055,6 +1141,8 @@ function main(): void {
     primaryJourneyEvidenceMarkdown: path.resolve(primaryJourneyEvidenceMarkdownPath),
     mainJourneyManifest: path.resolve(mainJourneyManifestPath),
     mainJourneyManifestMarkdown: path.resolve(mainJourneyManifestMarkdownPath),
+    mainJourneyReplayGate: path.resolve(mainJourneyReplayGatePath),
+    mainJourneyReplayGateMarkdown: path.resolve(mainJourneyReplayGateMarkdownPath),
     snapshot: path.resolve(snapshotPath),
     summaryMarkdown: path.resolve(summaryMarkdownPath),
     presentationSignoff: path.resolve(presentationSignoffPath),
@@ -1067,12 +1155,33 @@ function main(): void {
 
   writeJsonFile(mainJourneyManifestPath, mainJourneyManifest, args.force);
   writeTextFile(mainJourneyManifestMarkdownPath, renderMainJourneyManifestMarkdown(mainJourneyManifest), args.force);
-  writeTextFile(summaryMarkdownPath, renderBundleMarkdown(snapshot, artifacts), args.force);
   writeJsonFile(presentationSignoffPath, presentationSignoff, args.force);
   writeTextFile(presentationSignoffSummaryPath, renderPresentationSignoffSummary(snapshot, artifacts), args.force);
   writeTextFile(checklistPath, renderChecklist(snapshot, artifacts), args.force);
   writeTextFile(blockersPath, renderBlockers(snapshot, artifacts), args.force);
-  writeJsonFile(manifestPath, buildManifest(snapshot, artifacts, outputDir), args.force);
+  writeJsonFile(
+    manifestPath,
+    buildManifest(snapshot, artifacts, outputDir, {
+      summary: { status: "passed", summary: "Main-journey replay gate pending." },
+      triage: { presentationStatus: "missing" }
+    }),
+    args.force
+  );
+  const mainJourneyReplayGate = runMainJourneyReplayGateCommand(
+    args,
+    {
+      primaryJourneyEvidence: artifacts.primaryJourneyEvidence,
+      snapshot: artifacts.snapshot,
+      presentationSignoff: artifacts.presentationSignoff,
+      checklistMarkdown: artifacts.checklistMarkdown,
+      blockersMarkdown: artifacts.blockersMarkdown
+    },
+    manifestPath,
+    mainJourneyReplayGatePath,
+    mainJourneyReplayGateMarkdownPath
+  );
+  writeTextFile(summaryMarkdownPath, renderBundleMarkdown(snapshot, artifacts), args.force);
+  writeJsonFile(manifestPath, buildManifest(snapshot, artifacts, outputDir, mainJourneyReplayGate), true);
 
   console.log(`Wrote Cocos RC evidence bundle: ${toRepoRelative(manifestPath)}`);
   console.log(`  Candidate: ${snapshot.candidate.name}`);

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -36,7 +36,7 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
       "Pass `--candidate`; optionally supply build-surface, snapshot inputs, and WeChat smoke/report paths when bundling non-default evidence.",
     ],
     producedArtifacts: [
-      "Bundle files under `artifacts/release-readiness/`, including `cocos-rc-evidence-bundle-<candidate>-<short-sha>.json` and companion Markdown/checklist/blocker artifacts.",
+      "Bundle files under `artifacts/release-readiness/`, including `cocos-rc-evidence-bundle-<candidate>-<short-sha>.json`, `cocos-main-journey-replay-gate-<candidate>-<short-sha>.json`, and companion Markdown/checklist/blocker artifacts.",
     ],
   },
   "release:cocos-rc:snapshot": {
@@ -66,6 +66,16 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
     producedArtifacts: [
       "`artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.json`",
       "`artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.md`",
+    ],
+  },
+  "release:cocos:main-journey-replay-gate": {
+    purpose: "Validate candidate-scoped main-journey coverage and same-revision linkage across the Cocos RC packet.",
+    requiredInputs: [
+      "Pass `--candidate`; optionally pin the journey evidence, RC snapshot, bundle manifest, presentation sign-off, checklist, and blocker paths.",
+    ],
+    producedArtifacts: [
+      "`artifacts/release-readiness/cocos-main-journey-replay-gate-<candidate>-<short-sha>.json`",
+      "`artifacts/release-readiness/cocos-main-journey-replay-gate-<candidate>-<short-sha>.md`",
     ],
   },
   "release:evidence:index": {

--- a/scripts/test/cocos-main-journey-replay-gate.test.ts
+++ b/scripts/test/cocos-main-journey-replay-gate.test.ts
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const REPO_ROOT = process.cwd();
+
+function createTempWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "veil-cocos-main-journey-gate-"));
+}
+
+function writeJson(filePath: string, payload: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+function writeMarkdown(filePath: string, candidate: string, revision: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `# Artifact\n\n- Candidate: \`${candidate}\`\n- Commit: \`${revision}\`\n`,
+    "utf8"
+  );
+}
+
+function runGate(args: string[], cwd: string): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync("node", ["--import", "tsx", "./scripts/cocos-main-journey-replay-gate.ts", ...args], {
+      cwd,
+      encoding: "utf8",
+      stdio: "pipe"
+    });
+    return { stdout, status: 0 };
+  } catch (error) {
+    const execError = error as NodeJS.ErrnoException & { stdout?: string; status?: number };
+    return {
+      stdout: execError.stdout ?? "",
+      status: execError.status ?? 1
+    };
+  }
+}
+
+test("main-journey replay gate passes aligned candidate evidence while separating presentation blockers", () => {
+  const workspace = createTempWorkspace();
+  const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
+  const candidate = "phase1-cocos-rc";
+  const revision = "abc1234";
+  const primaryJourneyEvidencePath = path.join(artifactsDir, `cocos-primary-journey-evidence-${candidate}-${revision}.json`);
+  const snapshotPath = path.join(artifactsDir, `cocos-rc-snapshot-${candidate}-${revision}.json`);
+  const bundlePath = path.join(artifactsDir, `cocos-rc-evidence-bundle-${candidate}-${revision}.json`);
+  const signoffPath = path.join(artifactsDir, `cocos-presentation-signoff-${candidate}-${revision}.json`);
+  const checklistPath = path.join(artifactsDir, `cocos-rc-checklist-${candidate}-${revision}.md`);
+  const blockersPath = path.join(artifactsDir, `cocos-rc-blockers-${candidate}-${revision}.md`);
+
+  writeJson(primaryJourneyEvidencePath, {
+    candidate: {
+      name: candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    execution: {
+      overallStatus: "passed",
+      completedAt: "2026-04-08T10:00:00.000Z",
+      summary: "Headless primary-client journey evidence passed."
+    },
+    journey: [
+      { id: "lobby-entry", title: "Lobby entry", status: "passed", summary: "ok" },
+      { id: "room-join", title: "Room join", status: "passed", summary: "ok" },
+      { id: "map-explore", title: "Map explore", status: "passed", summary: "ok" },
+      { id: "first-battle", title: "First battle", status: "passed", summary: "ok" },
+      { id: "battle-settlement", title: "Battle settlement", status: "passed", summary: "ok" },
+      { id: "reconnect-restore", title: "Reconnect restore", status: "passed", summary: "ok" },
+      { id: "return-to-world", title: "Return to world", status: "passed", summary: "ok" }
+    ]
+  });
+  writeJson(snapshotPath, {
+    candidate: {
+      name: candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    execution: {
+      executedAt: "2026-04-08T10:05:00.000Z"
+    },
+    linkedEvidence: {
+      primaryJourneyEvidence: {
+        path: primaryJourneyEvidencePath
+      }
+    }
+  });
+  writeJson(signoffPath, {
+    candidate: {
+      name: candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    signoff: {
+      status: "hold",
+      summary: "Presentation sign-off remains on hold.",
+      blockingItems: ["Pixel art / scene visuals"],
+      controlledTestGaps: ["Audio"]
+    }
+  });
+  writeMarkdown(checklistPath, candidate, revision);
+  writeMarkdown(blockersPath, candidate, revision);
+  writeJson(bundlePath, {
+    bundle: {
+      generatedAt: "2026-04-08T10:10:00.000Z",
+      candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    artifacts: {
+      primaryJourneyEvidence: primaryJourneyEvidencePath,
+      snapshot: snapshotPath,
+      presentationSignoff: signoffPath,
+      checklistMarkdown: checklistPath,
+      blockersMarkdown: blockersPath
+    },
+    review: {
+      functionalEvidence: {
+        status: "passed",
+        summary: "Headless primary-client journey evidence passed."
+      },
+      presentationSignoff: {
+        status: "hold",
+        summary: "Presentation sign-off remains on hold."
+      }
+    }
+  });
+
+  const outputPath = path.join(workspace, "main-journey-gate.json");
+  const markdownOutputPath = path.join(workspace, "main-journey-gate.md");
+  const result = runGate(
+    [
+      "--candidate",
+      candidate,
+      "--expected-revision",
+      revision,
+      "--primary-journey-evidence",
+      primaryJourneyEvidencePath,
+      "--cocos-rc-snapshot",
+      snapshotPath,
+      "--cocos-rc-bundle",
+      bundlePath,
+      "--presentation-signoff",
+      signoffPath,
+      "--checklist",
+      checklistPath,
+      "--blockers",
+      blockersPath,
+      "--output",
+      outputPath,
+      "--markdown-output",
+      markdownOutputPath
+    ],
+    REPO_ROOT
+  );
+
+  assert.equal(result.status, 0);
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    summary: { status: string; infrastructureFailureCount: number; evidenceDriftCount: number; presentationBlockerCount: number };
+    coverage: { requiredSteps: Array<{ id: string; status: string }> };
+    triage: { presentationStatus: string; presentationBlockers: string[]; infrastructureFailures: unknown[] };
+  };
+  assert.equal(report.summary.status, "passed");
+  assert.equal(report.summary.infrastructureFailureCount, 0);
+  assert.equal(report.summary.evidenceDriftCount, 0);
+  assert.equal(report.summary.presentationBlockerCount, 1);
+  assert.deepEqual(
+    report.coverage.requiredSteps.map((step) => step.id),
+    ["lobby-entry", "room-join", "map-explore", "first-battle", "battle-settlement", "reconnect-restore"]
+  );
+  assert.equal(report.coverage.requiredSteps.every((step) => step.status === "passed"), true);
+  assert.equal(report.triage.presentationStatus, "hold");
+  assert.deepEqual(report.triage.presentationBlockers, ["Pixel art / scene visuals"]);
+  assert.equal(report.triage.infrastructureFailures.length, 0);
+
+  const markdown = fs.readFileSync(markdownOutputPath, "utf8");
+  assert.match(markdown, /Cocos Main-Journey Replay Gate/);
+  assert.match(markdown, /Presentation Blockers/);
+  assert.match(markdown, /Pixel art \/ scene visuals/);
+  assert.match(markdown, /Reviewer Workflow/);
+});
+
+test("main-journey replay gate fails when required coverage and revision consistency drift", () => {
+  const workspace = createTempWorkspace();
+  const artifactsDir = path.join(workspace, "artifacts", "release-readiness");
+  const candidate = "phase1-cocos-rc";
+  const revision = "abc1234";
+  const primaryJourneyEvidencePath = path.join(artifactsDir, `cocos-primary-journey-evidence-${candidate}-${revision}.json`);
+  const snapshotPath = path.join(artifactsDir, `cocos-rc-snapshot-${candidate}-${revision}.json`);
+  const bundlePath = path.join(artifactsDir, `cocos-rc-evidence-bundle-${candidate}-${revision}.json`);
+  const signoffPath = path.join(artifactsDir, `cocos-presentation-signoff-${candidate}-${revision}.json`);
+  const checklistPath = path.join(artifactsDir, `cocos-rc-checklist-${candidate}-${revision}.md`);
+  const blockersPath = path.join(artifactsDir, `cocos-rc-blockers-${candidate}-${revision}.md`);
+
+  writeJson(primaryJourneyEvidencePath, {
+    candidate: {
+      name: candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    execution: {
+      overallStatus: "failed",
+      completedAt: "2026-04-08T10:00:00.000Z",
+      summary: "Primary-client journey evidence failed during battle settlement."
+    },
+    journey: [
+      { id: "lobby-entry", title: "Lobby entry", status: "passed", summary: "ok" },
+      { id: "room-join", title: "Room join", status: "passed", summary: "ok" },
+      { id: "map-explore", title: "Map explore", status: "passed", summary: "ok" },
+      { id: "first-battle", title: "First battle", status: "passed", summary: "ok" },
+      { id: "reconnect-restore", title: "Reconnect restore", status: "passed", summary: "ok" }
+    ]
+  });
+  writeJson(snapshotPath, {
+    candidate: {
+      name: candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    execution: {
+      executedAt: "2026-04-08T10:05:00.000Z"
+    },
+    linkedEvidence: {
+      primaryJourneyEvidence: {
+        path: primaryJourneyEvidencePath
+      }
+    }
+  });
+  writeJson(signoffPath, {
+    candidate: {
+      name: candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    signoff: {
+      status: "approved",
+      summary: "approved",
+      blockingItems: [],
+      controlledTestGaps: []
+    }
+  });
+  writeMarkdown(checklistPath, candidate, "deadbeef");
+  writeMarkdown(blockersPath, candidate, revision);
+  writeJson(bundlePath, {
+    bundle: {
+      generatedAt: "2026-04-08T10:10:00.000Z",
+      candidate,
+      commit: revision,
+      shortCommit: revision
+    },
+    artifacts: {
+      primaryJourneyEvidence: primaryJourneyEvidencePath,
+      snapshot: snapshotPath,
+      presentationSignoff: signoffPath,
+      checklistMarkdown: checklistPath,
+      blockersMarkdown: blockersPath
+    },
+    review: {
+      functionalEvidence: {
+        status: "failed",
+        summary: "Primary-client journey evidence failed during battle settlement."
+      },
+      presentationSignoff: {
+        status: "approved",
+        summary: "approved"
+      }
+    }
+  });
+
+  const outputPath = path.join(workspace, "main-journey-gate.json");
+  const result = runGate(
+    [
+      "--candidate",
+      candidate,
+      "--expected-revision",
+      revision,
+      "--primary-journey-evidence",
+      primaryJourneyEvidencePath,
+      "--cocos-rc-snapshot",
+      snapshotPath,
+      "--cocos-rc-bundle",
+      bundlePath,
+      "--presentation-signoff",
+      signoffPath,
+      "--checklist",
+      checklistPath,
+      "--blockers",
+      blockersPath,
+      "--output",
+      outputPath
+    ],
+    REPO_ROOT
+  );
+
+  assert.equal(result.status, 1);
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    summary: { status: string };
+    triage: { infrastructureFailures: Array<{ code: string }>; evidenceDrift: Array<{ code: string }> };
+  };
+  assert.equal(report.summary.status, "failed");
+  assert.deepEqual(
+    report.triage.infrastructureFailures.map((finding) => finding.code),
+    ["functional_failure", "missing_step"]
+  );
+  assert.deepEqual(report.triage.evidenceDrift.map((finding) => finding.code), ["revision_mismatch"]);
+});

--- a/scripts/test/cocos-rc-evidence-bundle.test.ts
+++ b/scripts/test/cocos-rc-evidence-bundle.test.ts
@@ -89,6 +89,8 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   const snapshotFile = files.find((entry) => entry.startsWith("cocos-rc-snapshot-") && entry.endsWith(".json"));
   const mainJourneyManifestFile = files.find((entry) => entry.startsWith("cocos-main-journey-manifest-") && entry.endsWith(".json"));
   const mainJourneyManifestMarkdownFile = files.find((entry) => entry.startsWith("cocos-main-journey-manifest-") && entry.endsWith(".md"));
+  const mainJourneyReplayGateFile = files.find((entry) => entry.startsWith("cocos-main-journey-replay-gate-") && entry.endsWith(".json"));
+  const mainJourneyReplayGateMarkdownFile = files.find((entry) => entry.startsWith("cocos-main-journey-replay-gate-") && entry.endsWith(".md"));
   const presentationSignoffFile = files.find((entry) => entry.startsWith("cocos-presentation-signoff-") && entry.endsWith(".json"));
   const presentationSignoffMarkdownFile = files.find((entry) => entry.startsWith("cocos-presentation-signoff-") && entry.endsWith(".md"));
   const checklistFile = files.find((entry) => entry.startsWith("cocos-rc-checklist-") && entry.endsWith(".md"));
@@ -101,6 +103,8 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.ok(snapshotFile);
   assert.ok(mainJourneyManifestFile);
   assert.ok(mainJourneyManifestMarkdownFile);
+  assert.ok(mainJourneyReplayGateFile);
+  assert.ok(mainJourneyReplayGateMarkdownFile);
   assert.ok(presentationSignoffFile);
   assert.ok(presentationSignoffMarkdownFile);
   assert.ok(checklistFile);
@@ -121,6 +125,8 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
       primaryJourneyEvidenceMarkdown: string;
       mainJourneyManifest: string;
       mainJourneyManifestMarkdown: string;
+      mainJourneyReplayGate: string;
+      mainJourneyReplayGateMarkdown: string;
       snapshot: string;
       summaryMarkdown: string;
       presentationSignoff: string;
@@ -130,6 +136,7 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
     };
     review: {
       functionalEvidence: { status: string; summary: string };
+      mainJourneyReplayGate: { status: string; summary: string; presentationStatus: string };
       presentationSignoff: { status: string; summary: string };
     };
     journey: Array<{ id: string; status: string }>;
@@ -146,6 +153,8 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.equal(path.basename(manifest.artifacts.primaryJourneyEvidenceMarkdown), primaryJourneyMarkdownFile);
   assert.equal(path.basename(manifest.artifacts.mainJourneyManifest), mainJourneyManifestFile);
   assert.equal(path.basename(manifest.artifacts.mainJourneyManifestMarkdown), mainJourneyManifestMarkdownFile);
+  assert.equal(path.basename(manifest.artifacts.mainJourneyReplayGate), mainJourneyReplayGateFile);
+  assert.equal(path.basename(manifest.artifacts.mainJourneyReplayGateMarkdown), mainJourneyReplayGateMarkdownFile);
   assert.equal(manifest.journey.find((entry) => entry.id === "lobby-entry")?.status, "passed");
   assert.equal(manifest.checkpointLedger?.entryCount, 7);
   assert.ok((manifest.checkpointLedger?.entries.find((entry) => entry.id === "battle-settlement")?.telemetryCheckpointCount ?? -1) >= 0);
@@ -159,6 +168,9 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.equal(path.basename(manifest.artifacts.blockersMarkdown), blockersFile);
   assert.equal(manifest.review.functionalEvidence.status, "passed");
   assert.match(manifest.review.functionalEvidence.summary, /lobby, room, and reconnect/);
+  assert.equal(manifest.review.mainJourneyReplayGate.status, "passed");
+  assert.equal(manifest.review.mainJourneyReplayGate.presentationStatus, "hold");
+  assert.match(manifest.review.mainJourneyReplayGate.summary, /presentation blockers remain tracked separately/);
   assert.equal(manifest.review.presentationSignoff.status, "hold");
   assert.match(manifest.review.presentationSignoff.summary, /presentation sign-off remains on hold/);
   assert.equal(manifest.failureSummary.summary, "No regressions or evidence gaps recorded.");
@@ -172,6 +184,8 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   assert.match(summaryMarkdown, /Overall status: `passed`/);
   assert.match(summaryMarkdown, /Primary journey evidence:/);
   assert.match(summaryMarkdown, /Main-journey manifest:/);
+  assert.match(summaryMarkdown, /Main-journey replay gate JSON:/);
+  assert.match(summaryMarkdown, /Main-journey replay gate markdown:/);
   assert.match(summaryMarkdown, /Presentation sign-off JSON:/);
   assert.match(summaryMarkdown, /Presentation sign-off markdown:/);
   assert.match(summaryMarkdown, /Functional evidence status: `passed`/);
@@ -225,4 +239,18 @@ test("release:cocos-rc:bundle generates candidate-scoped summary, snapshot, and 
   const blockersMarkdown = fs.readFileSync(path.join(outputDir, blockersFile!), "utf8");
   assert.match(blockersMarkdown, /Candidate: `rc-issue-507`/);
   assert.match(blockersMarkdown, /cocos-rc-snapshot-rc-issue-507-/);
+
+  const mainJourneyReplayGate = JSON.parse(fs.readFileSync(path.join(outputDir, mainJourneyReplayGateFile!), "utf8")) as {
+    summary: { status: string; presentationBlockerCount: number };
+    triage: { presentationStatus: string; presentationBlockers: string[]; infrastructureFailures: unknown[] };
+  };
+  assert.equal(mainJourneyReplayGate.summary.status, "passed");
+  assert.ok(mainJourneyReplayGate.summary.presentationBlockerCount >= 1);
+  assert.equal(mainJourneyReplayGate.triage.presentationStatus, "hold");
+  assert.equal(mainJourneyReplayGate.triage.infrastructureFailures.length, 0);
+  assert.ok(mainJourneyReplayGate.triage.presentationBlockers.includes("Pixel art / scene visuals"));
+
+  const mainJourneyReplayGateMarkdown = fs.readFileSync(path.join(outputDir, mainJourneyReplayGateMarkdownFile!), "utf8");
+  assert.match(mainJourneyReplayGateMarkdown, /# Cocos Main-Journey Replay Gate/);
+  assert.match(mainJourneyReplayGateMarkdown, /Reviewer Workflow/);
 });


### PR DESCRIPTION
## Summary
- add a candidate-scoped Cocos main-journey replay gate that validates required journey coverage and same-revision linkage across the RC packet
- generate the new gate artifacts from the RC bundle and surface the gate result in the bundle manifest
- document the reviewer workflow and cover the new gate with focused script tests

Closes #1002