### PR TITLE
Add 32x32 frontier-expanded validation coverage

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -1610,10 +1610,16 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         continue;
       }
 
+      const snapshot = this.worldRoom.getSnapshot(playerId).state;
+      const mapBounds = resolveFocusedMapBounds(snapshot);
+
       sendMessage(client, "session.state", {
         requestId: "push",
         delivery: "push",
-        payload: this.buildStatePayload(playerId, extras)
+        payload: this.buildStatePayload(playerId, extras, {
+          mapBounds,
+          snapshot
+        })
       });
     }
   }

--- a/apps/server/test/colyseus-large-map-sync.test.ts
+++ b/apps/server/test/colyseus-large-map-sync.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client, type Room as ColyseusRoom } from "@colyseus/sdk";
+import { Server, WebSocketTransport } from "colyseus";
+import type { ClientMessage, ServerMessage } from "../../../packages/shared/src/index";
+import { configureRoomSnapshotStore, VeilColyseusRoom } from "../src/colyseus-room";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+
+let requestCounter = 0;
+
+function nextRequestId(prefix: string): string {
+  requestCounter += 1;
+  return `${prefix}-${requestCounter}`;
+}
+
+async function wait(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function startServer(port: number): Promise<Server> {
+  configureRoomSnapshotStore(new MemoryRoomSnapshotStore());
+  const server = new Server({
+    transport: new WebSocketTransport()
+  });
+
+  server.define("veil", VeilColyseusRoom).filterBy(["logicalRoomId"]);
+  await server.listen(port, "127.0.0.1");
+  return server;
+}
+
+async function joinRoomWithRetry(port: number, roomId: string, playerId: string): Promise<ColyseusRoom> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const client = new Client(`http://127.0.0.1:${port}`);
+      return await client.joinOrCreate("veil", {
+        logicalRoomId: roomId,
+        playerId,
+        seed: 1001
+      });
+    } catch (error) {
+      lastError = error;
+      await wait(150);
+    }
+  }
+
+  throw lastError;
+}
+
+async function sendRequest<T extends ServerMessage["type"]>(
+  room: ColyseusRoom,
+  message: ClientMessage,
+  expectedType: T
+): Promise<Extract<ServerMessage, { type: T }>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`Timed out waiting for ${expectedType}`));
+    }, 5_000);
+
+    const unsubscribe = room.onMessage("*", (type, payload) => {
+      if (typeof type !== "string") {
+        return;
+      }
+
+      const incoming = { type, ...(payload as object) } as ServerMessage;
+      if (!("requestId" in incoming) || incoming.requestId !== message.requestId) {
+        return;
+      }
+
+      clearTimeout(timeout);
+      unsubscribe();
+
+      if (incoming.type === "error") {
+        reject(new Error(incoming.reason));
+        return;
+      }
+
+      if (incoming.type !== expectedType) {
+        reject(new Error(`Unexpected response type: ${incoming.type}`));
+        return;
+      }
+
+      resolve(incoming as Extract<ServerMessage, { type: T }>);
+    });
+
+    room.send(message.type, message);
+  });
+}
+
+async function waitForPushState(room: ColyseusRoom): Promise<Extract<ServerMessage, { type: "session.state" }>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(new Error("Timed out waiting for push session.state"));
+    }, 5_000);
+
+    const unsubscribe = room.onMessage("*", (type, payload) => {
+      if (type !== "session.state") {
+        return;
+      }
+
+      const incoming = { type, ...(payload as object) } as ServerMessage;
+      if (incoming.type !== "session.state" || incoming.delivery !== "push") {
+        return;
+      }
+
+      clearTimeout(timeout);
+      unsubscribe();
+      resolve(incoming);
+    });
+  });
+}
+
+test("colyseus room push snapshots stay chunk-focused on the 32x32 frontier-expanded map for distant heroes", async (t) => {
+  const roomId = `chunk-push-frontier-expanded-${Date.now()}[map:phase2_frontier_expanded]`;
+  const port = 39000 + Math.floor(Math.random() * 1000);
+  const server = await startServer(port);
+  let sourceRoom: ColyseusRoom | null = null;
+  let observerRoom: ColyseusRoom | null = null;
+
+  t.after(async () => {
+    configureRoomSnapshotStore(null);
+    if (observerRoom) {
+      observerRoom.removeAllListeners();
+      observerRoom.connection.close();
+    }
+    if (sourceRoom) {
+      sourceRoom.removeAllListeners();
+      sourceRoom.connection.close();
+    }
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  sourceRoom = await joinRoomWithRetry(port, roomId, "player-1");
+  observerRoom = await joinRoomWithRetry(port, roomId, "player-2");
+
+  await sendRequest(
+    sourceRoom,
+    {
+      type: "connect",
+      requestId: nextRequestId("connect-expanded-source"),
+      roomId,
+      playerId: "player-1"
+    },
+    "session.state"
+  );
+  await sendRequest(
+    observerRoom,
+    {
+      type: "connect",
+      requestId: nextRequestId("connect-expanded-observer"),
+      roomId,
+      playerId: "player-2"
+    },
+    "session.state"
+  );
+
+  const observerPushPromise = waitForPushState(observerRoom);
+  await sendRequest(
+    sourceRoom,
+    {
+      type: "world.action",
+      requestId: nextRequestId("expanded-move"),
+      action: {
+        type: "hero.move",
+        heroId: "hero-1",
+        destination: { x: 3, y: 2 }
+      }
+    },
+    "session.state"
+  );
+
+  const observerPush = await observerPushPromise;
+  assert.equal(observerPush.payload.world.map.width, 32);
+  assert.equal(observerPush.payload.world.map.height, 32);
+  assert.deepEqual(observerPush.payload.world.map.encodedTiles?.bounds, {
+    x: 16,
+    y: 16,
+    width: 16,
+    height: 16
+  });
+  assert.ok((observerPush.payload.world.map.encodedTiles?.bounds.width ?? 32) < 32);
+  assert.ok((observerPush.payload.world.map.encodedTiles?.bounds.height ?? 32) < 32);
+});

--- a/configs/phase2-frontier-expanded.json
+++ b/configs/phase2-frontier-expanded.json
@@ -1,0 +1,131 @@
+{
+  "width": 32,
+  "height": 32,
+  "heroes": [
+    {
+      "id": "hero-1",
+      "playerId": "player-1",
+      "name": "凯琳",
+      "position": {
+        "x": 2,
+        "y": 2
+      },
+      "vision": 3,
+      "move": {
+        "total": 8,
+        "remaining": 8
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "militia_pike",
+          "vanguard_blade",
+          "padded_gambeson",
+          "scout_compass"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 12
+    },
+    {
+      "id": "hero-2",
+      "playerId": "player-2",
+      "name": "罗安",
+      "position": {
+        "x": 29,
+        "y": 29
+      },
+      "vision": 3,
+      "move": {
+        "total": 8,
+        "remaining": 8
+      },
+      "stats": {
+        "attack": 2,
+        "defense": 2,
+        "power": 1,
+        "knowledge": 1,
+        "hp": 30,
+        "maxHp": 30
+      },
+      "progression": {
+        "level": 1,
+        "experience": 0,
+        "battlesWon": 0,
+        "neutralBattlesWon": 0,
+        "pvpBattlesWon": 0
+      },
+      "loadout": {
+        "inventory": [
+          "oak_longbow",
+          "tower_shield_mail",
+          "scribe_charm",
+          "captains_insignia"
+        ]
+      },
+      "armyTemplateId": "hero_guard_basic",
+      "armyCount": 10
+    }
+  ],
+  "resourceSpawn": {
+    "goldChance": 0.03,
+    "woodChance": 0.04,
+    "oreChance": 0.04
+  },
+  "terrainOverrides": [
+    { "position": { "x": 7, "y": 6 }, "terrain": "sand" },
+    { "position": { "x": 8, "y": 6 }, "terrain": "sand" },
+    { "position": { "x": 9, "y": 6 }, "terrain": "sand" },
+    { "position": { "x": 10, "y": 6 }, "terrain": "sand" },
+    { "position": { "x": 22, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 23, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 24, "y": 7 }, "terrain": "swamp" },
+    { "position": { "x": 15, "y": 8 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 9 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 10 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 11 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 12 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 13 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 14 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 17 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 18 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 19 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 20 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 21 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 22 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 23 }, "terrain": "water" },
+    { "position": { "x": 15, "y": 24 }, "terrain": "water" },
+    { "position": { "x": 11, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 12, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 13, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 14, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 16, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 17, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 18, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 19, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 20, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 21, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 22, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 23, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 24, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 25, "y": 15 }, "terrain": "swamp" },
+    { "position": { "x": 16, "y": 24 }, "terrain": "sand" },
+    { "position": { "x": 17, "y": 24 }, "terrain": "sand" },
+    { "position": { "x": 18, "y": 24 }, "terrain": "sand" },
+    { "position": { "x": 19, "y": 24 }, "terrain": "sand" }
+  ]
+}

--- a/configs/phase2-map-objects-frontier-expanded.json
+++ b/configs/phase2-map-objects-frontier-expanded.json
@@ -1,0 +1,176 @@
+{
+  "neutralArmies": [
+    {
+      "id": "neutral-frontier-gate",
+      "position": {
+        "x": 12,
+        "y": 14
+      },
+      "reward": {
+        "kind": "gold",
+        "amount": 280
+      },
+      "stacks": [
+        {
+          "templateId": "wolf_pack",
+          "count": 6
+        },
+        {
+          "templateId": "moss_stalker",
+          "count": 4
+        }
+      ],
+      "behavior": {
+        "mode": "guard",
+        "detectionRadius": 3,
+        "chaseDistance": 5,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-river-watch",
+      "position": {
+        "x": 18,
+        "y": 16
+      },
+      "reward": {
+        "kind": "ore",
+        "amount": 7
+      },
+      "stacks": [
+        {
+          "templateId": "iron_walker",
+          "count": 4
+        },
+        {
+          "templateId": "hero_guard_basic",
+          "count": 4
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolPath": [
+          { "x": 18, "y": 16 },
+          { "x": 19, "y": 16 },
+          { "x": 19, "y": 17 },
+          { "x": 18, "y": 17 }
+        ],
+        "detectionRadius": 4,
+        "chaseDistance": 6,
+        "speed": 1
+      }
+    },
+    {
+      "id": "neutral-southern-pickets",
+      "position": {
+        "x": 24,
+        "y": 26
+      },
+      "reward": {
+        "kind": "wood",
+        "amount": 9
+      },
+      "stacks": [
+        {
+          "templateId": "moss_stalker",
+          "count": 5
+        }
+      ],
+      "behavior": {
+        "mode": "patrol",
+        "patrolRadius": 1,
+        "detectionRadius": 3,
+        "chaseDistance": 4,
+        "speed": 1
+      }
+    }
+  ],
+  "guaranteedResources": [
+    {
+      "position": {
+        "x": 6,
+        "y": 4
+      },
+      "resource": {
+        "kind": "wood",
+        "amount": 7
+      }
+    },
+    {
+      "position": {
+        "x": 14,
+        "y": 16
+      },
+      "resource": {
+        "kind": "gold",
+        "amount": 240
+      }
+    },
+    {
+      "position": {
+        "x": 26,
+        "y": 27
+      },
+      "resource": {
+        "kind": "ore",
+        "amount": 5
+      }
+    }
+  ],
+  "buildings": [
+    {
+      "id": "recruit-post-frontier-expanded-1",
+      "kind": "recruitment_post",
+      "position": {
+        "x": 4,
+        "y": 8
+      },
+      "label": "前沿募兵站",
+      "unitTemplateId": "wild_hawk_rider",
+      "recruitCount": 4,
+      "cost": {
+        "gold": 220,
+        "wood": 1,
+        "ore": 0
+      },
+      "maxTier": 3
+    },
+    {
+      "id": "shrine-frontier-expanded-1",
+      "kind": "attribute_shrine",
+      "position": {
+        "x": 10,
+        "y": 11
+      },
+      "label": "远拓圣坛",
+      "bonus": {
+        "attack": 1,
+        "defense": 0,
+        "power": 1,
+        "knowledge": 0
+      }
+    },
+    {
+      "id": "mine-frontier-expanded-1",
+      "kind": "resource_mine",
+      "position": {
+        "x": 20,
+        "y": 20
+      },
+      "label": "峡口矿脉",
+      "resourceKind": "ore",
+      "income": 4,
+      "maxTier": 2
+    },
+    {
+      "id": "watchtower-frontier-expanded-1",
+      "kind": "watchtower",
+      "position": {
+        "x": 27,
+        "y": 23
+      },
+      "label": "边境瞭望塔",
+      "visionBonus": 2
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "validate:content-smoke": "node --import tsx ./scripts/content-smoke-gate.ts",
     "validate:content-pack": "node --import tsx ./scripts/validate-content-pack.ts",
     "validate:map-object-visuals": "node --import tsx ./scripts/validate-map-object-visuals.ts",
-    "validate:content-pack:all": "npm run validate:map-object-visuals && node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack stonewatch-fork --map-pack ridgeway-crossing --map-pack highland-reach --map-pack amber-fields --map-pack ironpass-gorge --map-pack splitrock-canyon --map-pack bogfen-crossing --map-pack murkveil-delta --map-pack frostwatch-ridge --map-pack ashpeak-ascent --map-pack thornwall-divide --map-pack phase2",
+    "validate:content-pack:all": "npm run validate:map-object-visuals && node --import tsx ./scripts/validate-content-pack.ts --map-pack frontier-basin --map-pack stonewatch-fork --map-pack ridgeway-crossing --map-pack highland-reach --map-pack amber-fields --map-pack ironpass-gorge --map-pack splitrock-canyon --map-pack bogfen-crossing --map-pack murkveil-delta --map-pack frostwatch-ridge --map-pack ashpeak-ascent --map-pack thornwall-divide --map-pack phase2 --map-pack phase2-frontier-expanded",
     "validate:analytics-schema": "node --import tsx ./scripts/validate-analytics-schema.ts",
     "validate:quickstart:contract": "node ./scripts/run-contributor-quickstart-contract.mjs",
     "analytics:onboarding:funnel": "node --import tsx ./scripts/onboarding-funnel-report.ts",

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -745,10 +745,18 @@ function getPlayerNeighbors(view: PlayerWorldView, position: Vec2): Vec2[] {
   return candidates.filter((item) => item.x >= 0 && item.y >= 0 && item.x < view.map.width && item.y < view.map.height);
 }
 
-function isBlockedForPlayerView(view: PlayerWorldView, heroId: string, position: Vec2, destination: Vec2): boolean {
+function isBlockedForPlayerView(
+  view: PlayerWorldView,
+  heroId: string,
+  position: Vec2,
+  destination: Vec2,
+  hero?: Pick<HeroState, "id" | "armyTemplateId" | "position">,
+  canFly?: boolean
+): boolean {
   const tile = findPlayerTile(view, position);
-  const hero = view.ownHeroes.find((item) => item.id === heroId);
-  if (!tile || !hero || tile.fog === "hidden" || !isTraversableTile(tile, heroCanFlyOverWater(hero))) {
+  const effectiveHero = hero ?? view.ownHeroes.find((item) => item.id === heroId);
+  const effectiveCanFly = canFly ?? (effectiveHero ? heroCanFlyOverWater(effectiveHero) : false);
+  if (!tile || !effectiveHero || tile.fog === "hidden" || !isTraversableTile(tile, effectiveCanFly)) {
     return true;
   }
 
@@ -850,6 +858,25 @@ function reconstructPath(cameFrom: Map<string, Vec2>, current: Vec2): Vec2[] {
   return path;
 }
 
+function popLowestScoreNode(openSet: Vec2[], fScore: Map<string, number>): Vec2 | undefined {
+  if (openSet.length === 0) {
+    return undefined;
+  }
+
+  let bestIndex = 0;
+  let bestScore = fScore.get(tileKey(openSet[0]!)) ?? Number.POSITIVE_INFINITY;
+  for (let index = 1; index < openSet.length; index += 1) {
+    const candidate = openSet[index]!;
+    const candidateScore = fScore.get(tileKey(candidate)) ?? Number.POSITIVE_INFINITY;
+    if (candidateScore < bestScore) {
+      bestIndex = index;
+      bestScore = candidateScore;
+    }
+  }
+
+  return openSet.splice(bestIndex, 1)[0];
+}
+
 function getNeighbors(map: WorldMapState, position: Vec2): Vec2[] {
   const candidates = [
     { x: position.x + 1, y: position.y },
@@ -861,10 +888,18 @@ function getNeighbors(map: WorldMapState, position: Vec2): Vec2[] {
   return candidates.filter((item) => inBounds(map, item));
 }
 
-function isBlockedForHero(state: WorldState, heroId: string, position: Vec2, destination: Vec2): boolean {
+function isBlockedForHero(
+  state: WorldState,
+  heroId: string,
+  position: Vec2,
+  destination: Vec2,
+  hero?: HeroState,
+  canFly?: boolean
+): boolean {
   const tile = findTile(state.map, position);
-  const hero = findHero(state, heroId);
-  if (!tile || !hero || !isTraversableTile(tile, heroCanFlyOverWater(hero))) {
+  const effectiveHero = hero ?? findHero(state, heroId);
+  const effectiveCanFly = canFly ?? (effectiveHero ? heroCanFlyOverWater(effectiveHero) : false);
+  if (!tile || !effectiveHero || !isTraversableTile(tile, effectiveCanFly)) {
     return true;
   }
 
@@ -950,17 +985,14 @@ function getNeutralMovementPath(
   }
 
   const openSet: Vec2[] = [start];
+  const openSetKeys = new Set<string>([tileKey(start)]);
   const cameFrom = new Map<string, Vec2>();
   const gScore = new Map<string, number>([[tileKey(start), 0]]);
   const fScore = new Map<string, number>([[tileKey(start), distance(start, destination)]]);
 
   while (openSet.length > 0) {
-    openSet.sort(
-      (a, b) =>
-        (fScore.get(tileKey(a)) ?? Number.POSITIVE_INFINITY) -
-        (fScore.get(tileKey(b)) ?? Number.POSITIVE_INFINITY)
-    );
-    const current = openSet.shift()!;
+    const current = popLowestScoreNode(openSet, fScore)!;
+    openSetKeys.delete(tileKey(current));
     if (samePosition(current, destination)) {
       return reconstructPath(cameFrom, current);
     }
@@ -975,11 +1007,13 @@ function getNeutralMovementPath(
         continue;
       }
 
-      cameFrom.set(tileKey(neighbor), current);
-      gScore.set(tileKey(neighbor), tentative);
-      fScore.set(tileKey(neighbor), tentative + distance(neighbor, destination));
-      if (!openSet.some((item) => samePosition(item, neighbor))) {
+      const neighborKey = tileKey(neighbor);
+      cameFrom.set(neighborKey, current);
+      gScore.set(neighborKey, tentative);
+      fScore.set(neighborKey, tentative + distance(neighbor, destination));
+      if (!openSetKeys.has(neighborKey)) {
         openSet.push(neighbor);
+        openSetKeys.add(neighborKey);
       }
     }
   }
@@ -1005,14 +1039,16 @@ function getMovementPlan(state: WorldState, heroId: string, destination: Vec2): 
       };
   }
 
+  const canFly = heroCanFlyOverWater(hero);
   const openSet: Vec2[] = [hero.position];
+  const openSetKeys = new Set<string>([tileKey(hero.position)]);
   const cameFrom = new Map<string, Vec2>();
   const gScore = new Map<string, number>([[tileKey(hero.position), 0]]);
   const fScore = new Map<string, number>([[tileKey(hero.position), distance(hero.position, destination)]]);
 
   while (openSet.length > 0) {
-    openSet.sort((a, b) => (fScore.get(tileKey(a)) ?? Number.POSITIVE_INFINITY) - (fScore.get(tileKey(b)) ?? Number.POSITIVE_INFINITY));
-    const current = openSet.shift()!;
+    const current = popLowestScoreNode(openSet, fScore)!;
+    openSetKeys.delete(tileKey(current));
     if (samePosition(current, destination)) {
       const path = reconstructPath(cameFrom, current);
       const destinationTile = findTile(state.map, destination);
@@ -1041,22 +1077,27 @@ function getMovementPlan(state: WorldState, heroId: string, destination: Vec2): 
     }
 
     for (const neighbor of getNeighbors(state.map, current)) {
-      if (isBlockedForHero(state, heroId, neighbor, destination)) {
+      const tile = findTile(state.map, neighbor);
+      if (!tile || !isTraversableTile(tile, canFly)) {
+        continue;
+      }
+      if (isBlockedForHero(state, heroId, neighbor, destination, hero, canFly)) {
         continue;
       }
 
-      const neighborTile = findTile(state.map, neighbor);
       const tentative =
-        (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + terrainMoveCost(neighborTile?.terrain ?? "grass");
+        (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + terrainMoveCost(tile.terrain);
       if (tentative >= (gScore.get(tileKey(neighbor)) ?? Number.POSITIVE_INFINITY)) {
         continue;
       }
 
-      cameFrom.set(tileKey(neighbor), current);
-      gScore.set(tileKey(neighbor), tentative);
-      fScore.set(tileKey(neighbor), tentative + distance(neighbor, destination));
-      if (!openSet.some((item) => samePosition(item, neighbor))) {
+      const neighborKey = tileKey(neighbor);
+      cameFrom.set(neighborKey, current);
+      gScore.set(neighborKey, tentative);
+      fScore.set(neighborKey, tentative + distance(neighbor, destination));
+      if (!openSetKeys.has(neighborKey)) {
         openSet.push(neighbor);
+        openSetKeys.add(neighborKey);
       }
     }
   }
@@ -1369,14 +1410,16 @@ export function planPlayerViewMovement(
     return undefined;
   }
 
+  const canFly = heroCanFlyOverWater(hero);
   const openSet: Vec2[] = [hero.position];
+  const openSetKeys = new Set<string>([tileKey(hero.position)]);
   const cameFrom = new Map<string, Vec2>();
   const gScore = new Map<string, number>([[tileKey(hero.position), 0]]);
   const fScore = new Map<string, number>([[tileKey(hero.position), distance(hero.position, destination)]]);
 
   while (openSet.length > 0) {
-    openSet.sort((a, b) => (fScore.get(tileKey(a)) ?? Number.POSITIVE_INFINITY) - (fScore.get(tileKey(b)) ?? Number.POSITIVE_INFINITY));
-    const current = openSet.shift()!;
+    const current = popLowestScoreNode(openSet, fScore)!;
+    openSetKeys.delete(tileKey(current));
     if (samePosition(current, destination)) {
       const path = reconstructPath(cameFrom, current);
       const encounterKind =
@@ -1404,22 +1447,27 @@ export function planPlayerViewMovement(
     }
 
     for (const neighbor of getPlayerNeighbors(view, current)) {
-      if (isBlockedForPlayerView(view, heroId, neighbor, destination)) {
+      const tile = findPlayerTile(view, neighbor);
+      if (!tile || tile.fog === "hidden" || !isTraversableTile(tile, canFly)) {
+        continue;
+      }
+      if (isBlockedForPlayerView(view, heroId, neighbor, destination, hero, canFly)) {
         continue;
       }
 
-      const neighborTile = findPlayerTile(view, neighbor);
       const tentative =
-        (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + terrainMoveCost(neighborTile?.terrain ?? "grass");
+        (gScore.get(tileKey(current)) ?? Number.POSITIVE_INFINITY) + terrainMoveCost(tile.terrain);
       if (tentative >= (gScore.get(tileKey(neighbor)) ?? Number.POSITIVE_INFINITY)) {
         continue;
       }
 
-      cameFrom.set(tileKey(neighbor), current);
-      gScore.set(tileKey(neighbor), tentative);
-      fScore.set(tileKey(neighbor), tentative + distance(neighbor, destination));
-      if (!openSet.some((item) => samePosition(item, neighbor))) {
+      const neighborKey = tileKey(neighbor);
+      cameFrom.set(neighborKey, current);
+      gScore.set(neighborKey, tentative);
+      fScore.set(neighborKey, tentative + distance(neighbor, destination));
+      if (!openSetKeys.has(neighborKey)) {
         openSet.push(neighbor);
+        openSetKeys.add(neighborKey);
       }
     }
   }

--- a/packages/shared/src/world-config.ts
+++ b/packages/shared/src/world-config.ts
@@ -4,6 +4,7 @@ import defaultBossEncounterTemplatesConfig from "../../../configs/boss-encounter
 import defaultBuildingUpgradeConfig from "../../../configs/building-upgrades.json";
 import defaultHeroSkillTreesConfig from "../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
+import frontierExpandedMapObjectsConfig from "../../../configs/phase2-map-objects-frontier-expanded.json";
 import amberFieldsMapObjectsConfig from "../../../configs/phase1-map-objects-amber-fields.json";
 import ashpeakAscentMapObjectsConfig from "../../../configs/phase1-map-objects-ashpeak-ascent.json";
 import bogfenCrossingMapObjectsConfig from "../../../configs/phase1-map-objects-bogfen-crossing.json";
@@ -22,6 +23,7 @@ import amberFieldsWorldConfig from "../../../configs/phase1-world-amber-fields.j
 import ashpeakAscentWorldConfig from "../../../configs/phase1-world-ashpeak-ascent.json";
 import bogfenCrossingWorldConfig from "../../../configs/phase1-world-bogfen-crossing.json";
 import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
+import frontierExpandedWorldConfig from "../../../configs/phase2-frontier-expanded.json";
 import frontierBasinWorldConfig from "../../../configs/phase1-world-frontier-basin.json";
 import frostwatchRidgeWorldConfig from "../../../configs/phase1-world-frostwatch-ridge.json";
 import highlandReachWorldConfig from "../../../configs/phase1-world-highland-reach.json";
@@ -80,6 +82,7 @@ export const FROSTWATCH_RIDGE_MAP_VARIANT_ID = "frostwatch_ridge";
 export const ASHPEAK_ASCENT_MAP_VARIANT_ID = "ashpeak_ascent";
 export const THORNWALL_DIVIDE_MAP_VARIANT_ID = "thornwall_divide";
 export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
+export const PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID = "phase2_frontier_expanded";
 
 export interface RuntimeConfigBundle {
   world: WorldGenerationConfig;
@@ -954,7 +957,8 @@ function getAvailableMapVariantIds(): string[] {
     FROSTWATCH_RIDGE_MAP_VARIANT_ID,
     ASHPEAK_ASCENT_MAP_VARIANT_ID,
     THORNWALL_DIVIDE_MAP_VARIANT_ID,
-    CONTESTED_BASIN_MAP_VARIANT_ID
+    CONTESTED_BASIN_MAP_VARIANT_ID,
+    PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
   ];
 }
 
@@ -981,7 +985,8 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     requested === FROSTWATCH_RIDGE_MAP_VARIANT_ID ||
     requested === ASHPEAK_ASCENT_MAP_VARIANT_ID ||
     requested === THORNWALL_DIVIDE_MAP_VARIANT_ID ||
-    requested === CONTESTED_BASIN_MAP_VARIANT_ID
+    requested === CONTESTED_BASIN_MAP_VARIANT_ID ||
+    requested === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
   ) {
     return requested;
   }
@@ -1021,6 +1026,8 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneWorldConfig(thornwallDivideWorldConfig as WorldGenerationConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
+      : mapVariantId === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
+        ? cloneWorldConfig(frontierExpandedWorldConfig as WorldGenerationConfig)
         : getDefaultWorldConfig();
   const mapObjects =
     mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
@@ -1049,6 +1056,8 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneMapObjectsConfig(thornwallDivideMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(frontierExpandedMapObjectsConfig as MapObjectsConfig)
         : getDefaultMapObjectsConfig();
 
   validateWorldConfig(world);

--- a/packages/shared/test/map-pathfinding-performance.test.ts
+++ b/packages/shared/test/map-pathfinding-performance.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { performance } from "node:perf_hooks";
+import test from "node:test";
+import { createInitialWorldState, findPath } from "../src/index.ts";
+
+test("phase2 frontier expanded runtime config creates a 32x32 world", () => {
+  const state = createInitialWorldState(1001, "perf-frontier-expanded[map:phase2_frontier_expanded]");
+
+  assert.equal(state.meta.mapVariantId, "phase2_frontier_expanded");
+  assert.equal(state.map.width, 32);
+  assert.equal(state.map.height, 32);
+  assert.deepEqual(state.heroes.map((hero) => hero.position), [
+    { x: 2, y: 2 },
+    { x: 29, y: 29 }
+  ]);
+});
+
+test("A* pathfinding stays under 50ms per query on the 32x32 frontier-expanded map", () => {
+  const state = createInitialWorldState(1001, "perf-frontier-expanded[map:phase2_frontier_expanded]");
+  const destination = { x: 28, y: 28 };
+
+  for (let warmup = 0; warmup < 5; warmup += 1) {
+    const warmupPath = findPath(state, "hero-1", destination);
+    assert.ok(warmupPath && warmupPath.length > 0);
+  }
+
+  const runs = 200;
+  let totalMs = 0;
+  for (let index = 0; index < runs; index += 1) {
+    const startedAt = performance.now();
+    const path = findPath(state, "hero-1", destination);
+    totalMs += performance.now() - startedAt;
+    assert.ok(path && path.length > 0);
+  }
+
+  const averageMs = totalMs / runs;
+  assert.ok(
+    averageMs < 50,
+    `expected A* average query time under 50ms on the 32x32 frontier-expanded map, received ${averageMs.toFixed(2)}ms`
+  );
+});

--- a/scripts/content-pack-map-packs.ts
+++ b/scripts/content-pack-map-packs.ts
@@ -105,6 +105,13 @@ export const EXTRA_CONTENT_PACK_MAP_PACKS: ContentPackMapPackDefinition[] = [
     mapObjectsFileName: "phase2-map-objects-contested-basin.json",
     phase: "phase2",
     aliases: ["contested-basin", "contested_basin", "phase2-contested-basin"]
+  },
+  {
+    id: "phase2-frontier-expanded",
+    worldFileName: "phase2-frontier-expanded.json",
+    mapObjectsFileName: "phase2-map-objects-frontier-expanded.json",
+    phase: "phase2",
+    aliases: ["phase2_frontier_expanded", "frontier-expanded", "frontier_expanded"]
   }
 ];
 

--- a/scripts/test/validate-content-pack.test.ts
+++ b/scripts/test/validate-content-pack.test.ts
@@ -38,6 +38,8 @@ async function seedContentPackRoot(tempDir: string): Promise<void> {
       "phase1-map-objects-splitrock-canyon.json",
       "phase2-contested-basin.json",
       "phase2-map-objects-contested-basin.json",
+      "phase2-frontier-expanded.json",
+      "phase2-map-objects-frontier-expanded.json",
       "units.json",
       "battle-skills.json",
       "battle-balance.json",
@@ -73,12 +75,14 @@ test("validate-content-pack validates all shipped map packs with CLI presets", a
       "--map-pack",
       "splitrock-canyon",
       "--map-pack",
-      "phase2"
+      "phase2",
+      "--map-pack",
+      "phase2-frontier-expanded"
     ],
     { cwd: repoRoot }
   );
 
-  assert.match(stdout, /Bundles: 9/);
+  assert.match(stdout, /Bundles: 10/);
   assert.match(stdout, /Bundle: frontier-basin/);
   assert.match(stdout, /Bundle: stonewatch-fork/);
   assert.match(stdout, /Bundle: ridgeway-crossing/);
@@ -87,6 +91,7 @@ test("validate-content-pack validates all shipped map packs with CLI presets", a
   assert.match(stdout, /Bundle: ironpass-gorge/);
   assert.match(stdout, /Bundle: splitrock-canyon/);
   assert.match(stdout, /Bundle: phase2/);
+  assert.match(stdout, /Bundle: phase2-frontier-expanded/);
   assert.match(stdout, /Result: PASS/);
 });
 

--- a/scripts/validate-content-pack.ts
+++ b/scripts/validate-content-pack.ts
@@ -111,7 +111,7 @@ function parseArgs(argv: string[]): {
       const definition = resolveContentPackMapPack(presetId);
       if (!definition) {
         throw new Error(
-          `Unknown map pack "${presetId}". Supported values: default, frontier-basin, stonewatch-fork, ridgeway-crossing, highland-reach, amber-fields, ironpass-gorge, splitrock-canyon, bogfen-crossing, murkveil-delta, frostwatch-ridge, ashpeak-ascent, thornwall-divide, phase2.`
+          `Unknown map pack "${presetId}". Supported values: default, frontier-basin, stonewatch-fork, ridgeway-crossing, highland-reach, amber-fields, ironpass-gorge, splitrock-canyon, bogfen-crossing, murkveil-delta, frostwatch-ridge, ashpeak-ascent, thornwall-divide, phase2, phase2-frontier-expanded.`
         );
       }
       if (definition.id !== DEFAULT_CONTENT_PACK_MAP_PACK.id) {


### PR DESCRIPTION
## Summary
- add the shipped `phase2-frontier-expanded` 32x32 world and map-object config bundle, and include it in `validate:content-pack:all`
- add a shared perf test that locks 32x32 A* pathfinding under 50ms/query and tighten the pathfinder hot path to satisfy it
- add a Colyseus large-map sync smoke test and keep pushed session snapshots chunk-bounded for large maps

## Validation
- `npm run validate:content-pack:all`
- `node --import tsx --test packages/shared/test/map-pathfinding-performance.test.ts`
- `node --import tsx --test apps/server/test/colyseus-large-map-sync.test.ts`
- `node --import tsx --test scripts/test/validate-content-pack.test.ts`

Closes #1005.