### PR TITLE
[UX] Boss encounter phase transition UI

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilBattlePanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilBattlePanel.ts
@@ -5,6 +5,7 @@ import {
   type BattlePanelActionView,
   type BattlePanelInput,
   type BattleCamp,
+  type BattlePanelPhaseBannerView,
   type BattlePanelStageView
 } from "./cocos-battle-panel-model.ts";
 import type { CocosBattleFeedbackTone } from "./project-shared/index.ts";
@@ -52,6 +53,8 @@ const IDLE_HINT_NODE_NAME = "BattleIdleHint";
 const IDLE_BADGE_NODE_NAME = "BattleIdleBadge";
 const SECTION_CARD_PREFIX = "BattleSectionCard";
 const STAGE_BANNER_NODE_NAME = "BattleStageBanner";
+const PHASE_BANNER_NODE_NAME = "BattlePhaseBanner";
+const PHASE_TRACKER_NODE_NAME = "BattlePhaseTracker";
 const BADGE_BACKGROUND_SUFFIX = "-Background";
 const UNIT_ART_SIZE = 34;
 const UNIT_FRAME_SIZE = 38;
@@ -88,6 +91,19 @@ interface BattleStageBannerNodes {
   terrainOpacity: UIOpacity;
 }
 
+interface BattlePhaseBannerNodes {
+  node: Node;
+  title: Label;
+  meta: Label;
+  badge: Label;
+}
+
+interface BattlePhaseTrackerNodes {
+  node: Node;
+  title: Label;
+  meta: Label;
+}
+
 export interface VeilBattlePanelState extends BattlePanelInput {}
 
 export interface VeilBattlePanelOptions {
@@ -113,7 +129,12 @@ export class VeilBattlePanel extends Component {
   private headerIconSprite: Sprite | null = null;
   private headerIconOpacity: UIOpacity | null = null;
   private stageBanner: BattleStageBannerNodes | null = null;
+  private phaseBanner: BattlePhaseBannerNodes | null = null;
+  private phaseTracker: BattlePhaseTrackerNodes | null = null;
   private currentState: VeilBattlePanelState | null = null;
+  private activePhaseBanner: BattlePanelPhaseBannerView | null = null;
+  private phaseBannerTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private phaseBannerExpiresAtMs = 0;
   private requestedIcons = false;
   private requestedStageTerrain = false;
   private onSelectTarget: ((unitId: string) => void) | undefined;
@@ -128,6 +149,10 @@ export class VeilBattlePanel extends Component {
   }
 
   onDestroy(): void {
+    if (this.phaseBannerTimeoutId) {
+      clearTimeout(this.phaseBannerTimeoutId);
+      this.phaseBannerTimeoutId = null;
+    }
     if (this.placeholderAssetsRetained) {
       releasePlaceholderSpriteAssets("battle");
       this.placeholderAssetsRetained = false;
@@ -153,6 +178,8 @@ export class VeilBattlePanel extends Component {
 
     if (model.idle) {
       this.hideStageBanner();
+      this.hidePhaseBanner();
+      this.hidePhaseTracker();
       cursorY = this.renderBattleFeedback(model.feedback, cursorY - 4);
       cursorY = this.renderCardTextBlock(
         this.summaryLabel,
@@ -180,7 +207,9 @@ export class VeilBattlePanel extends Component {
 
     this.syncIdleBadge(false, 0, "");
     cursorY = this.renderBattleFeedback(model.feedback, cursorY - 4);
+    cursorY = this.renderPhaseBanner(model.phaseBanner, cursorY - 2);
     cursorY = this.renderStageBanner(model.stage, cursorY - 2);
+    cursorY = this.renderPhaseTracker(model.bossPhaseTracker, cursorY - 2);
     cursorY = this.renderCardTextBlock(this.summaryLabel, "Summary", model.summaryLines, cursorY, 14, 18, 14);
     cursorY = this.renderTextBlock(this.orderLabel, ["行动顺序"], cursorY, 14, 18, 6);
     cursorY = this.renderOrderItems(model.orderItems, cursorY);
@@ -203,6 +232,8 @@ export class VeilBattlePanel extends Component {
       ENEMY_HEADER_NODE_NAME,
       ACTION_HEADER_NODE_NAME,
       STAGE_BANNER_NODE_NAME,
+      PHASE_BANNER_NODE_NAME,
+      PHASE_TRACKER_NODE_NAME,
       HEADER_ICON_NODE_NAME,
       WATERMARK_NODE_NAME,
       IDLE_HINT_NODE_NAME,
@@ -731,6 +762,66 @@ export class VeilBattlePanel extends Component {
     return topY - height - gap;
   }
 
+  private renderPhaseBanner(banner: BattlePanelPhaseBannerView | null, topY: number): number {
+    if (banner && banner.key !== this.activePhaseBanner?.key) {
+      this.activePhaseBanner = banner;
+      this.phaseBannerExpiresAtMs = Date.now() + 2000;
+      if (this.phaseBannerTimeoutId) {
+        clearTimeout(this.phaseBannerTimeoutId);
+      }
+      this.phaseBannerTimeoutId = setTimeout(() => {
+        this.phaseBannerTimeoutId = null;
+        if (this.currentState) {
+          this.render(this.currentState);
+        }
+      }, 2000);
+    }
+
+    if (!this.activePhaseBanner || Date.now() >= this.phaseBannerExpiresAtMs) {
+      this.hidePhaseBanner();
+      return topY;
+    }
+
+    const phaseBanner = this.ensurePhaseBanner();
+    const height = 60;
+    const gap = 10;
+    const transform = phaseBanner.node.getComponent(UITransform) ?? phaseBanner.node.addComponent(UITransform);
+    transform.setContentSize(PANEL_CONTENT_WIDTH, height);
+    phaseBanner.node.setPosition(-PANEL_WIDTH / 2 + PANEL_PADDING + PANEL_CONTENT_WIDTH / 2, topY - height / 2, 0.38);
+    phaseBanner.node.active = true;
+    phaseBanner.title.string = this.activePhaseBanner.title;
+    phaseBanner.meta.string = this.activePhaseBanner.detail;
+    phaseBanner.badge.string = this.activePhaseBanner.badge;
+    this.stylePhaseBanner(phaseBanner.node, phaseBanner.title, phaseBanner.meta, phaseBanner.badge);
+    return topY - height - gap;
+  }
+
+  private renderPhaseTracker(
+    tracker: {
+      title: string;
+      detail: string;
+      markers: Array<{ label: string; thresholdPercent: number; active: boolean; reached: boolean }>;
+    } | null,
+    topY: number
+  ): number {
+    if (!tracker) {
+      this.hidePhaseTracker();
+      return topY;
+    }
+
+    const phaseTracker = this.ensurePhaseTracker();
+    const height = 54;
+    const gap = 10;
+    const transform = phaseTracker.node.getComponent(UITransform) ?? phaseTracker.node.addComponent(UITransform);
+    transform.setContentSize(PANEL_CONTENT_WIDTH, height);
+    phaseTracker.node.setPosition(-PANEL_WIDTH / 2 + PANEL_PADDING + PANEL_CONTENT_WIDTH / 2, topY - height / 2, 0.34);
+    phaseTracker.node.active = true;
+    phaseTracker.title.string = tracker.title;
+    phaseTracker.meta.string = tracker.detail;
+    this.stylePhaseTracker(phaseTracker.node, phaseTracker.title, phaseTracker.meta, tracker.markers);
+    return topY - height - gap;
+  }
+
   private hideStageBanner(): void {
     if (!this.stageBanner) {
       return;
@@ -747,6 +838,27 @@ export class VeilBattlePanel extends Component {
       null,
       0
     );
+  }
+
+  private hidePhaseBanner(): void {
+    if (!this.phaseBanner) {
+      return;
+    }
+
+    this.phaseBanner.node.active = false;
+    this.phaseBanner.title.string = "";
+    this.phaseBanner.meta.string = "";
+    this.phaseBanner.badge.string = "";
+  }
+
+  private hidePhaseTracker(): void {
+    if (!this.phaseTracker) {
+      return;
+    }
+
+    this.phaseTracker.node.active = false;
+    this.phaseTracker.title.string = "";
+    this.phaseTracker.meta.string = "";
   }
 
   private ensureStageBanner(): BattleStageBannerNodes {
@@ -826,6 +938,120 @@ export class VeilBattlePanel extends Component {
     return this.stageBanner;
   }
 
+  private ensurePhaseBanner(): BattlePhaseBannerNodes {
+    if (this.phaseBanner) {
+      return this.phaseBanner;
+    }
+
+    const node = new Node(PHASE_BANNER_NODE_NAME);
+    node.parent = this.node;
+    assignUiLayer(node);
+    const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+    transform.setContentSize(PANEL_CONTENT_WIDTH, 60);
+
+    const titleNode = new Node(`${PHASE_BANNER_NODE_NAME}-title`);
+    titleNode.parent = node;
+    assignUiLayer(titleNode);
+    const titleTransform = titleNode.getComponent(UITransform) ?? titleNode.addComponent(UITransform);
+    titleTransform.setContentSize(PANEL_CONTENT_WIDTH - 86, 18);
+    titleNode.setPosition(-20, 12, 1);
+    const title = titleNode.getComponent(Label) ?? titleNode.addComponent(Label);
+    title.fontSize = 13;
+    title.lineHeight = 16;
+    title.horizontalAlign = H_ALIGN_LEFT;
+    title.verticalAlign = V_ALIGN_CENTER;
+    title.overflow = OVERFLOW_RESIZE_HEIGHT;
+    title.enableWrapText = false;
+    title.string = "";
+
+    const metaNode = new Node(`${PHASE_BANNER_NODE_NAME}-meta`);
+    metaNode.parent = node;
+    assignUiLayer(metaNode);
+    const metaTransform = metaNode.getComponent(UITransform) ?? metaNode.addComponent(UITransform);
+    metaTransform.setContentSize(PANEL_CONTENT_WIDTH - 34, 16);
+    metaNode.setPosition(0, -12, 1);
+    const meta = metaNode.getComponent(Label) ?? metaNode.addComponent(Label);
+    meta.fontSize = 10;
+    meta.lineHeight = 12;
+    meta.horizontalAlign = H_ALIGN_LEFT;
+    meta.verticalAlign = V_ALIGN_CENTER;
+    meta.overflow = OVERFLOW_RESIZE_HEIGHT;
+    meta.enableWrapText = false;
+    meta.string = "";
+
+    const badgeNode = new Node(`${PHASE_BANNER_NODE_NAME}-badge`);
+    badgeNode.parent = node;
+    assignUiLayer(badgeNode);
+    const badgeTransform = badgeNode.getComponent(UITransform) ?? badgeNode.addComponent(UITransform);
+    badgeTransform.setContentSize(38, 22);
+    badgeNode.setPosition(PANEL_CONTENT_WIDTH / 2 - 30, 12, 1);
+    const badge = badgeNode.getComponent(Label) ?? badgeNode.addComponent(Label);
+    badge.fontSize = 10;
+    badge.lineHeight = 12;
+    badge.horizontalAlign = H_ALIGN_CENTER;
+    badge.verticalAlign = V_ALIGN_CENTER;
+    badge.overflow = OVERFLOW_RESIZE_HEIGHT;
+    badge.enableWrapText = false;
+    badge.string = "";
+
+    this.phaseBanner = {
+      node,
+      title,
+      meta,
+      badge
+    };
+    return this.phaseBanner;
+  }
+
+  private ensurePhaseTracker(): BattlePhaseTrackerNodes {
+    if (this.phaseTracker) {
+      return this.phaseTracker;
+    }
+
+    const node = new Node(PHASE_TRACKER_NODE_NAME);
+    node.parent = this.node;
+    assignUiLayer(node);
+    const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+    transform.setContentSize(PANEL_CONTENT_WIDTH, 54);
+
+    const titleNode = new Node(`${PHASE_TRACKER_NODE_NAME}-title`);
+    titleNode.parent = node;
+    assignUiLayer(titleNode);
+    const titleTransform = titleNode.getComponent(UITransform) ?? titleNode.addComponent(UITransform);
+    titleTransform.setContentSize(PANEL_CONTENT_WIDTH - 24, 18);
+    titleNode.setPosition(0, 12, 1);
+    const title = titleNode.getComponent(Label) ?? titleNode.addComponent(Label);
+    title.fontSize = 12;
+    title.lineHeight = 14;
+    title.horizontalAlign = H_ALIGN_LEFT;
+    title.verticalAlign = V_ALIGN_CENTER;
+    title.overflow = OVERFLOW_RESIZE_HEIGHT;
+    title.enableWrapText = false;
+    title.string = "";
+
+    const metaNode = new Node(`${PHASE_TRACKER_NODE_NAME}-meta`);
+    metaNode.parent = node;
+    assignUiLayer(metaNode);
+    const metaTransform = metaNode.getComponent(UITransform) ?? metaNode.addComponent(UITransform);
+    metaTransform.setContentSize(PANEL_CONTENT_WIDTH - 24, 16);
+    metaNode.setPosition(0, -12, 1);
+    const meta = metaNode.getComponent(Label) ?? metaNode.addComponent(Label);
+    meta.fontSize = 10;
+    meta.lineHeight = 12;
+    meta.horizontalAlign = H_ALIGN_LEFT;
+    meta.verticalAlign = V_ALIGN_CENTER;
+    meta.overflow = OVERFLOW_RESIZE_HEIGHT;
+    meta.enableWrapText = false;
+    meta.string = "";
+
+    this.phaseTracker = {
+      node,
+      title,
+      meta
+    };
+    return this.phaseTracker;
+  }
+
   private resolveStageTerrainFrame(terrain: BattlePanelStageView["terrain"]): Sprite["spriteFrame"] {
     const terrainFrames = getPixelSpriteAssets()?.tiles[terrain] ?? [];
     const frame = terrainFrames.find((entry) => Boolean(entry)) ?? null;
@@ -874,6 +1100,63 @@ export class VeilBattlePanel extends Component {
     meta.color = new Color(201, 214, 229, 220);
     badge.color = new Color(36, 28, 14, 255);
     this.styleBadgeNode(badge.node, new Color(accent.r, accent.g, accent.b, 224));
+  }
+
+  private stylePhaseBanner(node: Node, title: Label, meta: Label, badge: Label): void {
+    const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+    const width = transform.width;
+    const height = transform.height;
+    const graphics = node.getComponent(Graphics) ?? node.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = new Color(78, 34, 26, 214);
+    graphics.strokeColor = new Color(244, 176, 113, 240);
+    graphics.lineWidth = 2;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 16);
+    graphics.fill();
+    graphics.stroke();
+    graphics.fillColor = new Color(255, 244, 221, 30);
+    graphics.roundRect(-width / 2 + 10, height / 2 - 16, width - 20, 5, 3);
+    graphics.fill();
+    title.color = new Color(255, 238, 214, 255);
+    meta.color = new Color(255, 221, 188, 224);
+    badge.color = new Color(69, 34, 17, 255);
+    this.styleBadgeNode(badge.node, new Color(245, 184, 116, 236));
+  }
+
+  private stylePhaseTracker(
+    node: Node,
+    title: Label,
+    meta: Label,
+    markers: Array<{ label: string; thresholdPercent: number; active: boolean; reached: boolean }>
+  ): void {
+    const transform = node.getComponent(UITransform) ?? node.addComponent(UITransform);
+    const width = transform.width;
+    const height = transform.height;
+    const graphics = node.getComponent(Graphics) ?? node.addComponent(Graphics);
+    graphics.clear();
+    graphics.fillColor = new Color(34, 42, 58, 152);
+    graphics.strokeColor = new Color(143, 166, 196, 136);
+    graphics.lineWidth = 1.5;
+    graphics.roundRect(-width / 2, -height / 2, width, height, 12);
+    graphics.fill();
+    graphics.stroke();
+    const stripY = height / 2 - 22;
+    graphics.fillColor = new Color(73, 87, 110, 168);
+    graphics.roundRect(-width / 2 + 12, stripY - 4, width - 24, 8, 4);
+    graphics.fill();
+    const stripWidth = width - 24;
+    markers.forEach((marker) => {
+      const markerX = -width / 2 + 12 + stripWidth * (1 - marker.thresholdPercent / 100);
+      graphics.fillColor = marker.active
+        ? new Color(240, 188, 109, 255)
+        : marker.reached
+          ? new Color(173, 206, 235, 224)
+          : new Color(103, 115, 136, 192);
+      graphics.roundRect(markerX - 2, stripY - 7, 4, 14, 2);
+      graphics.fill();
+    });
+    title.color = new Color(232, 239, 247, 255);
+    meta.color = new Color(193, 205, 221, 224);
   }
 
   private ensureLabelNode(name: string, fontSize: number, lineHeight: number, height: number): Label {

--- a/apps/cocos-client/assets/scripts/VeilCocosSession.ts
+++ b/apps/cocos-client/assets/scripts/VeilCocosSession.ts
@@ -382,6 +382,14 @@ export interface BattleState {
   neutralArmyId?: string;
   defenderHeroId?: string;
   encounterPosition?: Vec2;
+  battlefieldTerrain?: TerrainType;
+  bossEncounter?: {
+    templateId: string;
+    bossUnitId: string;
+    activePhaseId: string;
+    maxBossHp: number;
+    triggeredAbilityKeys: string[];
+  };
 }
 
 export interface MovementPlan {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -5921,6 +5921,11 @@ export class VeilRoot extends Component {
     }
     this.syncSelectedBattleTarget();
     this.renderView();
+    if (presentation.pauseDurationMs) {
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, presentation.pauseDurationMs ?? 0);
+      });
+    }
     this.playMapFeedbackForUpdate(update);
     this.maybeShowHeroProgressNotice(update);
     this.setBattleFeedback(presentation.feedback, presentation.feedbackDurationMs ?? BATTLE_FEEDBACK_DURATION_MS);

--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -1,5 +1,6 @@
 import type { CocosBattleFeedbackTone } from "./project-shared/index.ts";
 import type { BattleAction, BattleState, SessionUpdate } from "./VeilCocosSession.ts";
+import type { CocosBossPhaseTransitionEvent } from "./cocos-boss-phase-ui.ts";
 
 export interface CocosBattleFeedbackView {
   title: string;
@@ -184,6 +185,15 @@ export function buildBattleProgressFeedback(
         tone: "neutral"
       }
     : null;
+}
+
+export function buildBossPhaseTransitionFeedback(event: CocosBossPhaseTransitionEvent): CocosBattleFeedbackView {
+  return {
+    title: `${event.bossName} 进入 ${event.nextPhaseLabel}`,
+    detail: event.bannerDetail,
+    badge: `P${event.nextPhaseIndex + 1}`,
+    tone: "skill"
+  };
 }
 
 export function analyzeBattleProgress(

--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -2,6 +2,12 @@ import type { CocosBattleFeedbackTone } from "./project-shared/index.ts";
 import type { BattleAction, BattleState, SessionUpdate, TerrainType, Vec2 } from "./VeilCocosSession.ts";
 import type { CocosBattleFeedbackView } from "./cocos-battle-feedback.ts";
 import type { CocosBattlePresentationState } from "./cocos-battle-presentation-controller.ts";
+import {
+  buildBossPhaseDescriptor,
+  buildBossPhaseTracker,
+  type CocosBossPhaseTrackerView,
+  type CocosBossPhaseTransitionEvent
+} from "./cocos-boss-phase-ui.ts";
 
 export type BattleCamp = "attacker" | "defender";
 
@@ -64,9 +70,18 @@ export interface BattlePanelStageView {
   badge: string;
 }
 
+export interface BattlePanelPhaseBannerView {
+  key: string;
+  title: string;
+  detail: string;
+  badge: string;
+}
+
 export interface BattlePanelViewModel {
   title: string;
   stage: BattlePanelStageView | null;
+  phaseBanner: BattlePanelPhaseBannerView | null;
+  bossPhaseTracker: CocosBossPhaseTrackerView | null;
   feedback: CocosBattleFeedbackView | null;
   summaryLines: string[];
   orderLines: string[];
@@ -80,6 +95,8 @@ export interface BattlePanelViewModel {
 
 export interface BattlePanelSections {
   stage: BattlePanelStageView | null;
+  phaseBanner: BattlePanelPhaseBannerView | null;
+  bossPhaseTracker: CocosBossPhaseTrackerView | null;
   orderItems: BattlePanelOrderItem[];
   friendlyItems: BattlePanelFriendlyItem[];
   enemyTargets: BattlePanelUnitView[];
@@ -102,6 +119,8 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
     return {
       title: state.recovery ? "结算恢复" : state.presentationState?.phase === "resolution" ? "战斗结算" : "战斗面板",
       stage: null,
+      phaseBanner: null,
+      bossPhaseTracker: null,
       feedback: state.recovery
         ? {
             title: state.recovery.title,
@@ -190,15 +209,26 @@ export function buildBattlePanelViewModel(state: BattlePanelInput): BattlePanelV
   const skillSummaryLines = activeUnit ? buildSkillSummaryLines(activeUnit) : [];
   const statusSummary = activeUnit ? buildStatusSummary(activeUnit) : "无异常";
   const stage = buildBattleStageView(state.update, battle);
+  const phaseBanner = buildPhaseBannerView(state.presentationState?.phaseTransitionEvent ?? null);
+  const bossPhaseTracker = buildBossPhaseTracker(battle);
+  const bossPhaseDescriptor = buildBossPhaseDescriptor(battle);
   const presentationLines = buildBattlePresentationContextLines(state.update, battle, state.presentationState, canAct, state.actionPending);
 
   return {
     title: resolveBattlePanelTitle(state.presentationState),
     stage,
+    phaseBanner,
+    bossPhaseTracker,
     feedback: state.feedback,
     summaryLines: [
       `${battle.id} · 第 ${battle.round} 回合`,
       ...presentationLines,
+      ...(bossPhaseDescriptor
+        ? [
+            `首领阶段：${bossPhaseDescriptor.phaseLabel} · 阈值 ${bossPhaseDescriptor.thresholdPercent}% HP`,
+            `阶段提示：${bossPhaseDescriptor.detail}`
+          ]
+        : []),
       ...(state.presentationState?.summaryLines ?? []),
       `阵营：${controlLabel}`,
       `阶段：${turnLabel}`,
@@ -236,11 +266,26 @@ export function buildBattlePanelSections(state: BattlePanelInput): BattlePanelSe
   const model = buildBattlePanelViewModel(state);
   return {
     stage: model.stage,
+    phaseBanner: model.phaseBanner,
+    bossPhaseTracker: model.bossPhaseTracker,
     orderItems: model.orderItems,
     friendlyItems: model.friendlyItems,
     enemyTargets: model.enemyTargets,
     actions: model.actions,
     idle: model.idle
+  };
+}
+
+function buildPhaseBannerView(event: CocosBossPhaseTransitionEvent | null): BattlePanelPhaseBannerView | null {
+  if (!event) {
+    return null;
+  }
+
+  return {
+    key: event.key,
+    title: event.bannerTitle,
+    detail: event.bannerDetail,
+    badge: `P${event.nextPhaseIndex + 1}`
   };
 }
 

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation-controller.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation-controller.ts
@@ -1,5 +1,6 @@
 import type { CocosBattleFeedbackTone } from "./project-shared/index.ts";
 import type { BattleAction, BattleState, SessionUpdate } from "./VeilCocosSession.ts";
+import type { CocosBossPhaseTransitionEvent } from "./cocos-boss-phase-ui.ts";
 import {
   buildBattleActionPresentation,
   buildBattlePresentationPlan,
@@ -17,6 +18,7 @@ export interface CocosBattlePresentationState {
   tone: CocosBattleFeedbackTone;
   result: "victory" | "defeat" | null;
   summaryLines: string[];
+  phaseTransitionEvent: CocosBossPhaseTransitionEvent | null;
   feedbackLayer: {
     animation: CocosBattlePresentationPlan["animation"];
     cue: CocosBattlePresentationPlan["cue"];
@@ -26,6 +28,7 @@ export interface CocosBattlePresentationState {
         : null
       : null;
     durationMs: number | null;
+    pauseDurationMs: number | null;
   };
 }
 
@@ -46,11 +49,13 @@ const IDLE_STATE: CocosBattlePresentationState = {
   tone: "neutral",
   result: null,
   summaryLines: [],
+  phaseTransitionEvent: null,
   feedbackLayer: {
     animation: "idle",
     cue: null,
     transition: null,
-    durationMs: null
+    durationMs: null,
+    pauseDurationMs: null
   }
 };
 

--- a/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-presentation.ts
@@ -4,12 +4,14 @@ import { buildBattleEnterCopy, buildBattleExitCopy, type BattleTransitionCopy } 
 import {
   analyzeBattleProgress,
   buildBattleActionFeedback,
+  buildBossPhaseTransitionFeedback,
   buildBattleSettlementLines,
   buildBattleProgressFeedback,
   buildBattleTransitionFeedback,
   type CocosBattleFeedbackView
 } from "./cocos-battle-feedback.ts";
 import type { CocosBattlePresentationState } from "./cocos-battle-presentation-controller.ts";
+import { buildBossPhaseTransitionEvent, type CocosBossPhaseTransitionEvent } from "./cocos-boss-phase-ui.ts";
 
 export type CocosBattlePresentationPhase = "idle" | "command" | "enter" | "impact" | "active" | "resolution";
 export type CocosBattlePresentationAnimation = "idle" | "attack" | "hit" | "victory" | "defeat";
@@ -37,14 +39,17 @@ export interface CocosBattlePresentationPlan {
   phase: CocosBattlePresentationPhase;
   feedback: CocosBattleFeedbackView | null;
   feedbackDurationMs: number | null;
+  pauseDurationMs: number | null;
   cue: CocosAudioCue | null;
   animation: CocosBattlePresentationAnimation;
   transition: CocosBattlePresentationTransition | null;
   moment: CocosBattlePresentationMoment;
+  phaseTransitionEvent: CocosBossPhaseTransitionEvent | null;
   state: CocosBattlePresentationState;
 }
 
 const RESOLUTION_FEEDBACK_DURATION_MS = 4200;
+const BOSS_PHASE_TRANSITION_PAUSE_MS = 900;
 
 export function buildBattleActionPresentation(
   action: BattleAction,
@@ -63,6 +68,7 @@ export function buildBattleActionPresentation(
     phase: "command",
     feedback,
     feedbackDurationMs: null,
+    pauseDurationMs: null,
     cue: action.type === "battle.attack" ? "attack" : action.type === "battle.skill" ? "skill" : null,
     animation:
       action.type === "battle.attack" || (action.type === "battle.skill" && action.targetId && action.targetId !== action.unitId)
@@ -70,6 +76,7 @@ export function buildBattleActionPresentation(
         : "idle",
     transition: null,
     moment,
+    phaseTransitionEvent: null,
     state: buildPresentationState("command", moment, battle?.id ?? null, feedback, null, {
       cue: action.type === "battle.attack" ? "attack" : action.type === "battle.skill" ? "skill" : null,
       animation:
@@ -78,6 +85,8 @@ export function buildBattleActionPresentation(
           : "idle",
       transition: null,
       durationMs: null,
+      pauseDurationMs: null,
+      phaseTransitionEvent: null,
       summaryLines: []
     })
   };
@@ -96,6 +105,7 @@ export function buildBattlePresentationPlan(
       phase: "enter",
       feedback,
       feedbackDurationMs: null,
+      pauseDurationMs: null,
       cue: null,
       animation: "attack",
       transition: {
@@ -103,11 +113,14 @@ export function buildBattlePresentationPlan(
         copy: buildBattleEnterCopy(update)
       },
       moment: "battle_enter",
+      phaseTransitionEvent: null,
       state: buildPresentationState("enter", "battle_enter", nextBattle.id, feedback, null, {
         cue: null,
         animation: "attack",
         transition: "enter",
         durationMs: null,
+        pauseDurationMs: null,
+        phaseTransitionEvent: null,
         summaryLines: []
       })
     };
@@ -125,6 +138,7 @@ export function buildBattlePresentationPlan(
       phase: "resolution",
       feedback,
       feedbackDurationMs: RESOLUTION_FEEDBACK_DURATION_MS,
+      pauseDurationMs: null,
       cue,
       animation,
       transition: resolution === null ? null : {
@@ -132,11 +146,14 @@ export function buildBattlePresentationPlan(
         copy: buildBattleExitCopy(previousBattle, update, resolution === "victory")
       },
       moment,
+      phaseTransitionEvent: null,
       state: buildPresentationState("resolution", moment, previousBattle.id, feedback, result, {
         cue,
         animation,
         transition: resolution === null ? null : "exit",
         durationMs: RESOLUTION_FEEDBACK_DURATION_MS,
+        pauseDurationMs: null,
+        phaseTransitionEvent: null,
         summaryLines: buildBattleSettlementLines(previousBattle, update, heroId)
       })
     };
@@ -144,28 +161,35 @@ export function buildBattlePresentationPlan(
 
   if (previousBattle && nextBattle) {
     const analysis = analyzeBattleProgress(previousBattle, nextBattle);
+    const phaseTransitionEvent = buildBossPhaseTransitionEvent(previousBattle, nextBattle);
     const impactDetected = detectBattleImpact(previousBattle, nextBattle);
     const defeatedUnitDetected = Boolean(analysis && analysis.defeatedUnits.length > 0);
     const skillDetected = Boolean(analysis?.skillTriggered);
     const moment = defeatedUnitDetected ? "impact_death" : impactDetected ? "impact_hit" : skillDetected ? "active_skill" : "active";
     const phase = defeatedUnitDetected || impactDetected ? "impact" : "active";
-    const cue = defeatedUnitDetected || impactDetected ? "hit" : skillDetected ? "skill" : null;
+    const cue = defeatedUnitDetected || impactDetected ? "hit" : skillDetected || phaseTransitionEvent ? "skill" : null;
     const animation = defeatedUnitDetected || impactDetected ? "hit" : "idle";
-    const feedback = buildBattleProgressFeedback(previousBattle, nextBattle);
+    const feedback = phaseTransitionEvent
+      ? buildBossPhaseTransitionFeedback(phaseTransitionEvent)
+      : buildBattleProgressFeedback(previousBattle, nextBattle);
     return {
       phase,
       feedback,
       feedbackDurationMs: null,
+      pauseDurationMs: phaseTransitionEvent ? BOSS_PHASE_TRANSITION_PAUSE_MS : null,
       cue,
       animation,
       transition: null,
       moment,
+      phaseTransitionEvent,
       state: buildPresentationState(phase, moment, nextBattle.id, feedback, null, {
         cue,
         animation,
         transition: null,
         durationMs: null,
-        summaryLines: []
+        pauseDurationMs: phaseTransitionEvent ? BOSS_PHASE_TRANSITION_PAUSE_MS : null,
+        phaseTransitionEvent,
+        summaryLines: phaseTransitionEvent ? phaseTransitionEvent.summaryLines : []
       })
     };
   }
@@ -174,15 +198,19 @@ export function buildBattlePresentationPlan(
     phase: "idle",
     feedback: null,
     feedbackDurationMs: null,
+    pauseDurationMs: null,
     cue: null,
     animation: "idle",
     transition: null,
     moment: "idle",
+    phaseTransitionEvent: null,
     state: buildPresentationState("idle", "idle", null, null, null, {
       cue: null,
       animation: "idle",
       transition: null,
       durationMs: null,
+      pauseDurationMs: null,
+      phaseTransitionEvent: null,
       summaryLines: []
     })
   };
@@ -226,7 +254,10 @@ function buildPresentationState(
   battleId: string | null,
   feedback: CocosBattleFeedbackView | null,
   result: CocosBattlePresentationState["result"],
-  feedbackLayer: CocosBattlePresentationState["feedbackLayer"] & { summaryLines: string[] }
+  feedbackLayer: CocosBattlePresentationState["feedbackLayer"] & {
+    summaryLines: string[];
+    phaseTransitionEvent: CocosBossPhaseTransitionEvent | null;
+  }
 ): CocosBattlePresentationState {
   if (!feedback) {
     return {
@@ -239,6 +270,7 @@ function buildPresentationState(
       tone: phase === "idle" ? "neutral" : "action",
       result,
       summaryLines: buildPresentationSummaryLines(null, feedbackLayer),
+      phaseTransitionEvent: feedbackLayer.phaseTransitionEvent,
       feedbackLayer
     };
   }
@@ -253,13 +285,17 @@ function buildPresentationState(
     tone: feedback.tone,
     result,
     summaryLines: buildPresentationSummaryLines(feedback, feedbackLayer),
+    phaseTransitionEvent: feedbackLayer.phaseTransitionEvent,
     feedbackLayer
   };
 }
 
 function buildPresentationSummaryLines(
   feedback: CocosBattleFeedbackView | null,
-  feedbackLayer: CocosBattlePresentationState["feedbackLayer"] & { summaryLines: string[] }
+  feedbackLayer: CocosBattlePresentationState["feedbackLayer"] & {
+    summaryLines: string[];
+    phaseTransitionEvent: CocosBossPhaseTransitionEvent | null;
+  }
 ): string[] {
   const lines: string[] = [];
   const layerParts = [`动画 ${formatAnimationLabel(feedbackLayer.animation)}`];

--- a/apps/cocos-client/assets/scripts/cocos-boss-phase-ui.ts
+++ b/apps/cocos-client/assets/scripts/cocos-boss-phase-ui.ts
@@ -1,0 +1,190 @@
+import { getDefaultBossEncounterTemplateCatalog } from "../../../../packages/shared/src/world-config.ts";
+import type { BossEncounterPhaseConfig } from "../../../../packages/shared/src/models.ts";
+import type { BattleState } from "./VeilCocosSession.ts";
+
+export interface CocosBossPhaseDescriptor {
+  key: string;
+  templateId: string;
+  bossUnitId: string;
+  bossName: string;
+  phaseId: string;
+  phaseLabel: string;
+  phaseIndex: number;
+  totalPhases: number;
+  thresholdPercent: number;
+  detail: string;
+  nextThresholdPercent: number | null;
+}
+
+export interface CocosBossPhaseTransitionEvent {
+  key: string;
+  templateId: string;
+  bossUnitId: string;
+  bossName: string;
+  previousPhaseId: string;
+  previousPhaseLabel: string;
+  nextPhaseId: string;
+  nextPhaseLabel: string;
+  nextPhaseIndex: number;
+  totalPhases: number;
+  thresholdPercent: number;
+  bannerTitle: string;
+  bannerDetail: string;
+  summaryLines: string[];
+}
+
+export interface CocosBossPhaseTrackerMarker {
+  key: string;
+  label: string;
+  thresholdPercent: number;
+  active: boolean;
+  reached: boolean;
+}
+
+export interface CocosBossPhaseTrackerView {
+  title: string;
+  detail: string;
+  markers: CocosBossPhaseTrackerMarker[];
+}
+
+export function buildBossPhaseDescriptor(battle: BattleState | null): CocosBossPhaseDescriptor | null {
+  if (!battle?.bossEncounter) {
+    return null;
+  }
+
+  const template = getBossTemplate(battle.bossEncounter.templateId);
+  const phaseIndex = template.phases.findIndex((phase) => phase.id === battle.bossEncounter?.activePhaseId);
+  if (phaseIndex < 0) {
+    return null;
+  }
+
+  const phase = template.phases[phaseIndex]!;
+  const bossUnit = battle.units[battle.bossEncounter.bossUnitId];
+  const bossName = bossUnit?.stackName ?? template.name;
+  const nextPhase = template.phases[phaseIndex + 1] ?? null;
+  return {
+    key: `${battle.id}:${phase.id}`,
+    templateId: template.id,
+    bossUnitId: battle.bossEncounter.bossUnitId,
+    bossName,
+    phaseId: phase.id,
+    phaseLabel: formatBossPhaseLabel(phase.id, phaseIndex),
+    phaseIndex,
+    totalPhases: template.phases.length,
+    thresholdPercent: toPercent(phase.hpThreshold),
+    detail: buildBossPhaseDetail(phase),
+    nextThresholdPercent: nextPhase ? toPercent(nextPhase.hpThreshold) : null
+  };
+}
+
+export function buildBossPhaseTransitionEvent(
+  previousBattle: BattleState | null,
+  nextBattle: BattleState | null
+): CocosBossPhaseTransitionEvent | null {
+  if (!previousBattle?.bossEncounter || !nextBattle?.bossEncounter) {
+    return null;
+  }
+
+  if (previousBattle.bossEncounter.templateId !== nextBattle.bossEncounter.templateId) {
+    return null;
+  }
+
+  if (previousBattle.bossEncounter.activePhaseId === nextBattle.bossEncounter.activePhaseId) {
+    return null;
+  }
+
+  const previousDescriptor = buildBossPhaseDescriptor(previousBattle);
+  const nextDescriptor = buildBossPhaseDescriptor(nextBattle);
+  if (!previousDescriptor || !nextDescriptor) {
+    return null;
+  }
+
+  return {
+    key: `${nextBattle.id}:${previousDescriptor.phaseId}->${nextDescriptor.phaseId}`,
+    templateId: nextDescriptor.templateId,
+    bossUnitId: nextDescriptor.bossUnitId,
+    bossName: nextDescriptor.bossName,
+    previousPhaseId: previousDescriptor.phaseId,
+    previousPhaseLabel: previousDescriptor.phaseLabel,
+    nextPhaseId: nextDescriptor.phaseId,
+    nextPhaseLabel: nextDescriptor.phaseLabel,
+    nextPhaseIndex: nextDescriptor.phaseIndex,
+    totalPhases: nextDescriptor.totalPhases,
+    thresholdPercent: nextDescriptor.thresholdPercent,
+    bannerTitle: `${nextDescriptor.bossName} · ${nextDescriptor.phaseLabel}`,
+    bannerDetail: `血线跌破 ${nextDescriptor.thresholdPercent}% · ${nextDescriptor.detail}`,
+    summaryLines: [
+      `首领阶段切换：${previousDescriptor.phaseLabel} -> ${nextDescriptor.phaseLabel}`,
+      `阈值：${nextDescriptor.thresholdPercent}% HP · ${nextDescriptor.detail}`
+    ]
+  };
+}
+
+export function buildBossPhaseTracker(battle: BattleState | null): CocosBossPhaseTrackerView | null {
+  const descriptor = buildBossPhaseDescriptor(battle);
+  if (!descriptor || !battle?.bossEncounter) {
+    return null;
+  }
+
+  const template = getBossTemplate(descriptor.templateId);
+  const bossUnit = battle.units[battle.bossEncounter.bossUnitId];
+  const currentHp = bossUnit?.currentHp ?? 0;
+  const maxHp = battle.bossEncounter.maxBossHp;
+  const markers = template.phases.map((phase, index) => ({
+    key: phase.id,
+    label: formatBossPhaseLabel(phase.id, index),
+    thresholdPercent: toPercent(phase.hpThreshold),
+    active: phase.id === descriptor.phaseId,
+    reached: currentHp <= Math.ceil(maxHp * phase.hpThreshold) || phase.id === descriptor.phaseId
+  }));
+  const nextThreshold =
+    descriptor.nextThresholdPercent === null ? "已进入最终阶段" : `下一次切换 ${descriptor.nextThresholdPercent}%`;
+  return {
+    title: `${descriptor.bossName} · ${descriptor.phaseLabel}`,
+    detail: `当前血量 ${currentHp}/${maxHp} HP · ${nextThreshold} · ${descriptor.detail}`,
+    markers
+  };
+}
+
+function getBossTemplate(templateId: string) {
+  const template = getDefaultBossEncounterTemplateCatalog().templates.find((entry) => entry.id === templateId);
+  if (!template) {
+    throw new Error(`Missing boss encounter template for Cocos phase UI: ${templateId}`);
+  }
+  return template;
+}
+
+function formatBossPhaseLabel(phaseId: string, phaseIndex: number): string {
+  return `阶段 ${phaseIndex + 1} · ${formatToken(phaseId.replace(/^phase-\d+-/, ""))}`;
+}
+
+function buildBossPhaseDetail(phase: BossEncounterPhaseConfig): string {
+  const environment = phase.environmentalEffects?.[0];
+  if (environment?.description) {
+    return environment.description;
+  }
+  if (environment?.name) {
+    return `环境变化：${environment.name}`;
+  }
+  const scriptedAbility = phase.scriptedAbilities?.[0];
+  if (scriptedAbility) {
+    return `脚本能力：${formatToken(scriptedAbility.id)}`;
+  }
+  const skillIds = phase.skillOverrides?.replaceSkillIds ?? [];
+  if (skillIds.length > 0) {
+    return `技能组：${skillIds.map(formatToken).join(" / ")}`;
+  }
+  return "首领正在重构当前战斗节奏。";
+}
+
+function formatToken(value: string): string {
+  return value
+    .split(/[-_]/)
+    .filter((part) => part.length > 0)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function toPercent(value: number): number {
+  return Math.round(value * 100);
+}

--- a/apps/cocos-client/test/cocos-battle-panel.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel.test.ts
@@ -14,6 +14,45 @@ function createBattleUpdate(): SessionUpdate {
   return createBattleUpdateFixture();
 }
 
+function createBossBattleUpdate(): SessionUpdate {
+  const update = createBattleUpdateFixture();
+  if (!update.battle) {
+    return update;
+  }
+
+  update.battle.units["neutral-1-stack"] = {
+    ...update.battle.units["neutral-1-stack"]!,
+    templateId: "shadow_hexer",
+    stackName: "Shadow Warden",
+    currentHp: 5,
+    maxHp: 10
+  };
+  update.battle.bossEncounter = {
+    templateId: "boss-shadow-warden",
+    bossUnitId: "neutral-1-stack",
+    activePhaseId: "phase-2-warden-grip",
+    maxBossHp: 10,
+    triggeredAbilityKeys: []
+  };
+  update.battle.environment = [
+    {
+      id: "phase-2-snare",
+      lane: 0,
+      kind: "trap",
+      effect: "slow",
+      name: "Veil Snare",
+      description: "Mist-woven chains drag the front line down.",
+      damage: 0,
+      charges: 2,
+      revealed: true,
+      triggered: false,
+      grantedStatusId: "slowed",
+      triggeredByCamp: "attacker"
+    }
+  ];
+  return update;
+}
+
 test("buildBattlePanelSections groups ally, enemy and queue rows from a battle state", () => {
   const sections = buildBattlePanelSections({
     update: createBattleUpdate(),
@@ -49,6 +88,57 @@ test("battle panel stage banner derives the PVE terrain title from the encounter
     subtitle: "坐标 (1,1) · 无额外障碍",
     badge: "PVE"
   });
+});
+
+test("battle panel exposes boss phase banner and hp threshold markers", () => {
+  const sections = buildBattlePanelSections({
+    update: createBossBattleUpdate(),
+    timelineEntries: [],
+    controlledCamp: "attacker",
+    selectedTargetId: "neutral-1-stack",
+    actionPending: false,
+    feedback: null,
+    presentationState: {
+      battleId: "battle-1",
+      phase: "impact",
+      moment: "impact_hit",
+      label: "首领阶段切换",
+      detail: "血线跌破 55% · Mist-woven chains drag the front line down.",
+      badge: "P2",
+      tone: "skill",
+      result: null,
+      summaryLines: ["首领阶段切换：阶段 1 · Veil -> 阶段 2 · Warden Grip"],
+      phaseTransitionEvent: {
+        key: "battle-1:phase-1-veil->phase-2-warden-grip",
+        templateId: "boss-shadow-warden",
+        bossUnitId: "neutral-1-stack",
+        bossName: "Shadow Warden",
+        previousPhaseId: "phase-1-veil",
+        previousPhaseLabel: "阶段 1 · Veil",
+        nextPhaseId: "phase-2-warden-grip",
+        nextPhaseLabel: "阶段 2 · Warden Grip",
+        nextPhaseIndex: 1,
+        totalPhases: 3,
+        thresholdPercent: 55,
+        bannerTitle: "Shadow Warden · 阶段 2 · Warden Grip",
+        bannerDetail: "血线跌破 55% · Mist-woven chains drag the front line down.",
+        summaryLines: ["首领阶段切换：阶段 1 · Veil -> 阶段 2 · Warden Grip"]
+      },
+      feedbackLayer: {
+        animation: "hit",
+        cue: "hit",
+        transition: null,
+        durationMs: null,
+        pauseDurationMs: 900
+      }
+    }
+  });
+
+  assert.equal(sections.phaseBanner?.badge, "P2");
+  assert.match(sections.phaseBanner?.title ?? "", /Warden Grip/);
+  assert.equal(sections.bossPhaseTracker?.markers.length, 3);
+  assert.equal(sections.bossPhaseTracker?.markers[1]?.active, true);
+  assert.equal(sections.bossPhaseTracker?.markers[2]?.thresholdPercent, 25);
 });
 
 test("battle panel actions disable when it is not the controlled camp's turn", () => {
@@ -116,11 +206,13 @@ test("VeilBattlePanel preserves settlement feedback after battle resolution", ()
           "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 战利品：金币 +12 · 准备返回世界地图",
           "战利品：金币 +12"
         ],
+        phaseTransitionEvent: null,
         feedbackLayer: {
           animation: "victory",
           cue: "victory",
           transition: "exit",
-          durationMs: 4200
+          durationMs: 4200,
+          pauseDurationMs: null
         }
       }
     })
@@ -151,5 +243,61 @@ test("VeilBattlePanel rerenders from an active turn into a pending-resolution st
   component.render(createBattlePanelState({ actionPending: true }));
 
   assert.match(String((statefulComponent.summaryLabel as { string: string } | null)?.string ?? ""), /阶段：正在结算行动/);
+  component.onDestroy();
+});
+
+test("VeilBattlePanel renders the transient boss phase banner and threshold tracker", () => {
+  const { component } = createComponentHarness(VeilBattlePanel, { name: "BattlePanelRoot", width: 272, height: 560 });
+
+  component.configure({});
+  component.render(
+    createBattlePanelState({
+      update: createBossBattleUpdate(),
+      presentationState: {
+        battleId: "battle-1",
+        phase: "impact",
+        moment: "impact_hit",
+        label: "首领阶段切换",
+        detail: "血线跌破 55% · Mist-woven chains drag the front line down.",
+        badge: "P2",
+        tone: "skill",
+        result: null,
+        summaryLines: ["首领阶段：阶段 2 · Warden Grip · 阈值 55% HP"],
+        phaseTransitionEvent: {
+          key: "battle-1:phase-1-veil->phase-2-warden-grip",
+          templateId: "boss-shadow-warden",
+          bossUnitId: "neutral-1-stack",
+          bossName: "Shadow Warden",
+          previousPhaseId: "phase-1-veil",
+          previousPhaseLabel: "阶段 1 · Veil",
+          nextPhaseId: "phase-2-warden-grip",
+          nextPhaseLabel: "阶段 2 · Warden Grip",
+          nextPhaseIndex: 1,
+          totalPhases: 3,
+          thresholdPercent: 55,
+          bannerTitle: "Shadow Warden · 阶段 2 · Warden Grip",
+          bannerDetail: "血线跌破 55% · Mist-woven chains drag the front line down.",
+          summaryLines: ["首领阶段切换：阶段 1 · Veil -> 阶段 2 · Warden Grip"]
+        },
+        feedbackLayer: {
+          animation: "hit",
+          cue: "hit",
+          transition: null,
+          durationMs: null,
+          pauseDurationMs: 900
+        }
+      }
+    })
+  );
+
+  const statefulComponent = component as VeilBattlePanel & Record<string, unknown>;
+  const phaseBanner = statefulComponent.phaseBanner as { title: { string: string }; meta: { string: string }; badge: { string: string } } | null;
+  const phaseTracker = statefulComponent.phaseTracker as { title: { string: string }; meta: { string: string } } | null;
+
+  assert.match(String(phaseBanner?.title.string ?? ""), /Warden Grip/);
+  assert.match(String(phaseBanner?.meta.string ?? ""), /55%/);
+  assert.equal(String(phaseBanner?.badge.string ?? ""), "P2");
+  assert.match(String(phaseTracker?.title.string ?? ""), /Shadow Warden/);
+  assert.match(String(phaseTracker?.meta.string ?? ""), /当前血量 5\/10 HP/);
   component.onDestroy();
 });

--- a/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
+++ b/apps/cocos-client/test/cocos-battle-presentation-controller.test.ts
@@ -73,6 +73,29 @@ function createBattleState(): BattleState {
   };
 }
 
+function createBossBattleState(): BattleState {
+  return {
+    ...createBattleState(),
+    units: {
+      ...createBattleState().units,
+      "neutral-1-stack": {
+        ...createBattleState().units["neutral-1-stack"]!,
+        templateId: "shadow_hexer",
+        stackName: "Shadow Warden",
+        currentHp: 10,
+        maxHp: 10
+      }
+    },
+    bossEncounter: {
+      templateId: "boss-shadow-warden",
+      bossUnitId: "neutral-1-stack",
+      activePhaseId: "phase-1-veil",
+      maxBossHp: 10,
+      triggeredAbilityKeys: []
+    }
+  };
+}
+
 function createUpdate(battle: BattleState | null, events: SessionUpdate["events"] = []): SessionUpdate {
   return {
     world: {
@@ -262,4 +285,50 @@ test("battle presentation controller formalizes command, casualty, and result fl
   });
   assert.equal(controller.getState().badge, "SETTLE");
   assert.equal(controller.getState().feedbackLayer.transition, null);
+});
+
+test("battle presentation controller inserts a boss phase transition pause when the active phase changes", () => {
+  const controller = createCocosBattlePresentationController();
+  const opening = createBossBattleState();
+  const phaseTwo: BattleState = {
+    ...opening,
+    units: {
+      ...opening.units,
+      "neutral-1-stack": {
+        ...opening.units["neutral-1-stack"]!,
+        currentHp: 5
+      }
+    },
+    bossEncounter: {
+      ...opening.bossEncounter!,
+      activePhaseId: "phase-2-warden-grip"
+    },
+    environment: [
+      {
+        id: "phase-2-snare",
+        lane: 0,
+        kind: "trap",
+        name: "Veil Snare",
+        revealed: true,
+        remainingTurns: 2,
+        effect: "slow",
+        damage: 0,
+        charges: 2,
+        grantedStatusId: "slowed",
+        triggeredByCamp: "attacker",
+        sourceUnitId: "neutral-1-stack"
+      }
+    ],
+    log: opening.log.concat("Shadow Warden 进入 phase-2-warden-grip")
+  };
+
+  const plan = controller.applyUpdate(opening, createUpdate(phaseTwo), "hero-1");
+
+  assert.equal(plan.pauseDurationMs, 900);
+  assert.equal(plan.phaseTransitionEvent?.previousPhaseId, "phase-1-veil");
+  assert.equal(plan.phaseTransitionEvent?.nextPhaseId, "phase-2-warden-grip");
+  assert.equal(plan.feedback?.badge, "P2");
+  assert.equal(controller.getState().phaseTransitionEvent?.nextPhaseLabel, "阶段 2 · Warden Grip");
+  assert.equal(controller.getState().feedbackLayer.pauseDurationMs, 900);
+  assert.equal(controller.getState().summaryLines.some((line) => /阶段 2 · Warden Grip/.test(line)), true);
 });


### PR DESCRIPTION
## Summary
- add boss phase transition detection and a short pause in the Cocos battle presentation flow
- render a transient phase banner plus boss HP threshold markers in the battle panel
- cover the presentation pause path and panel phase UI with targeted tests

Closes #1006