### PR TITLE
Add daily quest board panel to the Cocos lobby

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -11,6 +11,7 @@ import type { CocosLobbyRoomSummary, CocosPlayerAccountProfile } from "./cocos-l
 import { getPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
 import { assignUiLayer } from "./cocos-ui-layer.ts";
 import { buildCocosBattleReplayTimelineView } from "./cocos-battle-replay-timeline.ts";
+import { buildCocosDailyQuestPanelView } from "./cocos-daily-quest-panel.ts";
 import { buildCocosShopPanelView, type CocosShopPanelView } from "./cocos-shop-panel.ts";
 import {
   buildCocosBattleReplayCenterView,
@@ -154,6 +155,7 @@ export interface VeilLobbyRenderState {
   shop: CocosShopPanelView;
   shopStatus: string;
   shopLoading?: boolean;
+  dailyQuestClaimingId?: string | null;
   mailboxClaimingMessageId?: string | null;
   mailboxClaimAllBusy?: boolean;
 }
@@ -188,6 +190,7 @@ export interface VeilLobbyPanelOptions {
   onCloseLobbySkillPanel?: () => void;
   onLearnLobbySkill?: (skillId: string) => void;
   onPurchaseShopProduct?: (productId: string) => void;
+  onClaimDailyQuest?: (questId: string) => void;
   onClaimMailboxMessage?: (messageId: string) => void;
   onClaimAllMailbox?: () => void;
 }
@@ -234,6 +237,7 @@ export class VeilLobbyPanel extends Component {
   private onCloseLobbySkillPanel: (() => void) | undefined;
   private onLearnLobbySkill: ((skillId: string) => void) | undefined;
   private onPurchaseShopProduct: ((productId: string) => void) | undefined;
+  private onClaimDailyQuest: ((questId: string) => void) | undefined;
   private onClaimMailboxMessage: ((messageId: string) => void) | undefined;
   private onClaimAllMailbox: (() => void) | undefined;
   private replayPlayback: BattleReplayPlaybackState | null = null;
@@ -241,6 +245,7 @@ export class VeilLobbyPanel extends Component {
   private replayPlaybackStatus = "选择一场最近战斗，即可查看逐步回放。";
   private replayPlaybackTimer: ReturnType<typeof setInterval> | null = null;
   private showSkillPanel = false;
+  private showDailyQuestPanel = false;
 
   onDestroy(): void {
     this.stopReplayPlaybackLoop();
@@ -277,6 +282,7 @@ export class VeilLobbyPanel extends Component {
     this.onCloseLobbySkillPanel = options.onCloseLobbySkillPanel;
     this.onLearnLobbySkill = options.onLearnLobbySkill;
     this.onPurchaseShopProduct = options.onPurchaseShopProduct;
+    this.onClaimDailyQuest = options.onClaimDailyQuest;
     this.onClaimMailboxMessage = options.onClaimMailboxMessage;
     this.onClaimAllMailbox = options.onClaimAllMailbox;
   }
@@ -633,9 +639,11 @@ export class VeilLobbyPanel extends Component {
 
     if (this.showAccountReview) {
       this.showSkillPanel = false;
+      this.showDailyQuestPanel = false;
       this.hideAccountFlowPanel();
       this.hideHeroSection();
       this.hideSkillPanelModal();
+      this.hideDailyQuestPanelModal();
       const review = state.accountReview;
       const hasBattleReplays = state.battleReplayItems.length > 0;
       const unlockedCount = state.account.achievements.filter((achievement) => achievement.unlocked).length;
@@ -772,18 +780,21 @@ export class VeilLobbyPanel extends Component {
       this.hideLeaderboardCards();
     } else if (state.accountFlow) {
       this.showSkillPanel = false;
+      this.showDailyQuestPanel = false;
       this.hideAccountReviewCards();
       this.hideBattleReplayTimelineCard();
       this.hideLobbyRooms();
       this.hideLeaderboardCards();
       this.hideHeroSection();
       this.hideSkillPanelModal();
+      this.hideDailyQuestPanelModal();
       this.renderAccountFlowPanel(rightX, rightCursorY, rightWidth, state.accountFlow, state.entering);
     } else {
       this.hideAccountFlowPanel();
       this.hideAccountReviewCards();
       this.hideBattleReplayTimelineCard();
       rightCursorY = this.renderHeroSection(rightX, rightCursorY, rightWidth, state, skillPanelBusy);
+      rightCursorY = this.renderDailyQuestSection(rightX, rightCursorY, rightWidth, state);
       rightCursorY = this.renderMailboxSection(rightX, rightCursorY, rightWidth, state);
       rightCursorY = this.renderLeaderboardSection(rightX, rightCursorY, rightWidth, state);
       rightCursorY = this.renderShopSection(rightX, rightCursorY, rightWidth, state);
@@ -872,6 +883,71 @@ export class VeilLobbyPanel extends Component {
     } else {
       this.hideSkillPanelModal();
     }
+
+    if (this.showDailyQuestPanel) {
+      this.renderDailyQuestPanelModal(width, height, state);
+    } else {
+      this.hideDailyQuestPanelModal();
+    }
+  }
+
+  private renderDailyQuestSection(centerX: number, topY: number, width: number, state: VeilLobbyRenderState): number {
+    const board = state.account.dailyQuestBoard;
+    const pendingRewards = board?.pendingRewards ?? { gems: 0, gold: 0 };
+    const pendingRewardLabel =
+      pendingRewards.gems > 0 || pendingRewards.gold > 0
+        ? [
+            pendingRewards.gems > 0 ? `宝石 x${pendingRewards.gems}` : null,
+            pendingRewards.gold > 0 ? `金币 x${pendingRewards.gold}` : null
+          ]
+            .filter((entry): entry is string => Boolean(entry))
+            .join(" · ")
+        : "暂无待领取奖励";
+    const nextY = this.renderCard(
+      "LobbyDailyQuestSummary",
+      centerX,
+      topY,
+      width,
+      84,
+      [
+        "每日任务",
+        board?.enabled ? `可领取 ${board.availableClaims} · 今日任务 ${board.quests.length}` : "任务板暂未开启",
+        board?.enabled ? pendingRewardLabel : "完成或跳过引导后，这里会显示今日任务。"
+      ],
+      {
+        fill: new Color(54, 72, 96, 190),
+        stroke: new Color(230, 238, 252, 68),
+        accent: board?.availableClaims ? new Color(238, 184, 94, 220) : new Color(124, 176, 226, 204)
+      },
+      null,
+      13,
+      17
+    );
+
+    this.renderActionButton(
+      "LobbyDailyQuestOpen",
+      centerX,
+      nextY - 16,
+      width,
+      28,
+      board?.availableClaims ? `打开任务板 · ${board.availableClaims} 项可领取` : "打开任务板",
+      {
+        fill: board?.availableClaims ? ACTION_ACCOUNT_REVIEW_ACTIVE : ACTION_ACCOUNT,
+        stroke: new Color(228, 236, 248, 120),
+        accent: new Color(220, 230, 244, 112)
+      },
+      state.entering
+        ? null
+        : () => {
+            this.showSkillPanel = false;
+            this.showDailyQuestPanel = true;
+            if (this.currentState) {
+              this.render(this.currentState);
+            }
+          }
+    );
+
+    return nextY - 50;
   }
 
   private renderShopSection(centerX: number, topY: number, width: number, state: VeilLobbyRenderState): number {
@@ -1193,7 +1269,7 @@ export class VeilLobbyPanel extends Component {
   }
 
   private hideHeroSection(): void {
-    for (const name of ["LobbyHeroSummary", "LobbyHeroSkillButton"]) {
+    for (const name of ["LobbyHeroSummary", "LobbyHeroSkillButton", "LobbyDailyQuestSummary", "LobbyDailyQuestOpen"]) {
       const node = this.node.getChildByName(name);
       if (node) {
         node.active = false;
@@ -1254,7 +1330,13 @@ export class VeilLobbyPanel extends Component {
     const modalCenterX = 0;
     let topY = height / 2 - 54;
 
-    this.renderBackdrop("LobbySkillPanelBackdrop", width, height);
+    this.renderBackdrop("LobbySkillPanelBackdrop", width, height, () => {
+      this.showSkillPanel = false;
+      this.onCloseLobbySkillPanel?.();
+      if (this.currentState) {
+        this.render(this.currentState);
+      }
+    });
     topY = this.renderCard(
       "LobbySkillPanelHeader",
       modalCenterX,
@@ -1351,7 +1433,131 @@ export class VeilLobbyPanel extends Component {
     );
   }
 
-  private renderBackdrop(name: string, width: number, height: number): void {
+  private renderDailyQuestPanelModal(width: number, height: number, state: VeilLobbyRenderState): void {
+    const modalWidth = Math.min(620, width - 48);
+    const modalCenterX = 0;
+    let topY = height / 2 - 54;
+    const view = buildCocosDailyQuestPanelView({
+      board: state.account.dailyQuestBoard ?? null,
+      pendingQuestId: state.dailyQuestClaimingId ?? null
+    });
+
+    this.renderBackdrop("LobbyDailyQuestBackdrop", width, height, () => {
+      this.showDailyQuestPanel = false;
+      if (this.currentState) {
+        this.render(this.currentState);
+      }
+    });
+    topY = this.renderCard(
+      "LobbyDailyQuestHeader",
+      modalCenterX,
+      topY,
+      modalWidth,
+      96,
+      [view.title, `${view.subtitle} · ${view.claimableCountLabel}`, `${view.pendingRewardsLabel} · ${view.resetLabel}`],
+      {
+        fill: TITLE_FILL,
+        stroke: new Color(236, 228, 198, 72),
+        accent: new Color(214, 175, 112, 194)
+      },
+      null,
+      13,
+      17
+    );
+
+    if (view.emptyLabel) {
+      topY = this.renderCard(
+        "LobbyDailyQuestEmpty",
+        modalCenterX,
+        topY,
+        modalWidth,
+        86,
+        ["今日任务", view.emptyLabel, "刷新账号资料后将同步最新任务板。"],
+        {
+          fill: MUTED_FILL,
+          stroke: new Color(214, 224, 238, 42),
+          accent: new Color(128, 146, 170, 156)
+        },
+        null,
+        13,
+        17
+      );
+      this.hideExtraCards("LobbyDailyQuestQuest-", 0);
+      this.hideExtraCards("LobbyDailyQuestClaim-", 0);
+    } else {
+      const emptyNode = this.node.getChildByName("LobbyDailyQuestEmpty");
+      if (emptyNode) {
+        emptyNode.active = false;
+      }
+
+      view.quests.slice(0, 4).forEach((quest, index) => {
+        topY = this.renderCard(
+          `LobbyDailyQuestQuest-${index}`,
+          modalCenterX,
+          topY,
+          modalWidth,
+          94,
+          [
+            `${quest.title} · ${quest.stateLabel}`,
+            `${quest.detail} · 进度 ${quest.progressLabel}`,
+            quest.rewardLabel
+          ],
+          {
+            fill: quest.action?.enabled ? new Color(52, 76, 84, 190) : ROOM_FILL,
+            stroke: new Color(220, 232, 244, 52),
+            accent:
+              quest.stateLabel === "可领取"
+                ? new Color(238, 184, 94, 220)
+                : quest.stateLabel === "已领取"
+                  ? new Color(132, 186, 142, 186)
+                  : new Color(132, 168, 214, 186)
+          },
+          null,
+          13,
+          17
+        );
+        this.renderActionButton(
+          `LobbyDailyQuestClaim-${index}`,
+          modalCenterX,
+          topY + 18,
+          modalWidth,
+          28,
+          quest.action?.label ?? `${quest.stateLabel} · ${quest.progressLabel}`,
+          {
+            fill: quest.action?.enabled ? ACTION_ACCOUNT_REVIEW_ACTIVE : MUTED_FILL,
+            stroke: new Color(228, 244, 229, 124),
+            accent: new Color(226, 244, 230, 116)
+          },
+          quest.action?.enabled ? () => this.onClaimDailyQuest?.(quest.questId) : null
+        );
+        topY -= 28;
+      });
+      this.hideExtraCards("LobbyDailyQuestQuest-", Math.min(4, view.quests.length));
+      this.hideExtraCards("LobbyDailyQuestClaim-", Math.min(4, view.quests.length));
+    }
+
+    this.renderActionButton(
+      "LobbyDailyQuestClose",
+      modalCenterX,
+      topY - 8,
+      modalWidth,
+      28,
+      "收起任务板",
+      {
+        fill: ACTION_LOGOUT,
+        stroke: new Color(247, 232, 226, 118),
+        accent: new Color(250, 234, 228, 110)
+      },
+      () => {
+        this.showDailyQuestPanel = false;
+        if (this.currentState) {
+          this.render(this.currentState);
+        }
+      }
+    );
+  }
+
+  private renderBackdrop(name: string, width: number, height: number, onPress: (() => void) | null): void {
     let backdrop = this.node.getChildByName(name);
     if (!backdrop) {
       backdrop = new Node(name);
@@ -1367,13 +1573,7 @@ export class VeilLobbyPanel extends Component {
     graphics.fillColor = new Color(4, 7, 12, 184);
     graphics.rect(-width / 2, -height / 2, width, height);
     graphics.fill();
-    this.bindPress(backdrop, () => {
-      this.showSkillPanel = false;
-      this.onCloseLobbySkillPanel?.();
-      if (this.currentState) {
-        this.render(this.currentState);
-      }
-    });
+    this.bindPress(backdrop, onPress);
   }
 
   private hideExtraSkillBranchCards(visibleCount: number): void {
@@ -1403,6 +1603,17 @@ export class VeilLobbyPanel extends Component {
     }
     this.hideExtraSkillBranchCards(0);
     this.hideExtraSkillActionButtons(0);
+  }
+
+  private hideDailyQuestPanelModal(): void {
+    for (const name of ["LobbyDailyQuestBackdrop", "LobbyDailyQuestHeader", "LobbyDailyQuestEmpty", "LobbyDailyQuestClose"]) {
+      const node = this.node.getChildByName(name);
+      if (node) {
+        node.active = false;
+      }
+    }
+    this.hideExtraCards("LobbyDailyQuestQuest-", 0);
+    this.hideExtraCards("LobbyDailyQuestClaim-", 0);
   }
 
   private renderCard(

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -31,6 +31,7 @@ import {
   loadCocosCampaignSummary,
   claimCocosSeasonTier,
   claimCocosDailyDungeonRunReward,
+  claimCocosDailyQuest,
   claimAllCocosMailboxMessages,
   claimCocosMailboxMessage,
   type CocosCampaignMissionCompleteResult,
@@ -273,6 +274,7 @@ interface VeilRootRuntime {
   loadShopProducts: typeof VeilCocosSession.fetchShopProducts;
   purchaseShopProduct: typeof VeilCocosSession.purchaseShopProduct;
   equipShopCosmetic: typeof VeilCocosSession.equipShopCosmetic;
+  claimDailyQuest: typeof claimCocosDailyQuest;
 }
 
 const defaultVeilRootRuntime: VeilRootRuntime = {
@@ -308,7 +310,8 @@ const defaultVeilRootRuntime: VeilRootRuntime = {
   deletePlayerAccount: (...args) => deleteCurrentCocosPlayerAccount(...args),
   loadShopProducts: (...args) => VeilCocosSession.fetchShopProducts(...args),
   purchaseShopProduct: (...args) => VeilCocosSession.purchaseShopProduct(...args),
-  equipShopCosmetic: (...args) => VeilCocosSession.equipShopCosmetic(...args)
+  equipShopCosmetic: (...args) => VeilCocosSession.equipShopCosmetic(...args),
+  claimDailyQuest: (...args) => claimCocosDailyQuest(...args)
 };
 
 let testVeilRootRuntimeOverrides: Partial<VeilRootRuntime> | null = null;
@@ -426,6 +429,7 @@ export class VeilRoot extends Component {
   private pendingSeasonalEventBattleIds = new Set<string>();
   private pendingSeasonClaimTier: number | null = null;
   private seasonPremiumPurchaseInFlight = false;
+  private dailyQuestClaimingId: string | null = null;
   private mailboxClaimingMessageId: string | null = null;
   private mailboxClaimAllInFlight = false;
   private lobbyAccountReviewState: CocosAccountReviewState = createCocosAccountReviewState(this.lobbyAccountProfile);
@@ -1080,6 +1084,9 @@ export class VeilRoot extends Component {
       onPurchaseShopProduct: (productId) => {
         void this.purchaseLobbyShopProduct(productId);
       },
+      onClaimDailyQuest: (questId) => {
+        void this.claimLobbyDailyQuest(questId);
+      },
       onClaimMailboxMessage: (messageId) => {
         void this.claimLobbyMailboxMessage(messageId);
       },
@@ -1474,6 +1481,7 @@ export class VeilRoot extends Component {
         }),
         shopStatus: this.lobbyShopStatus,
         shopLoading: this.lobbyShopLoading,
+        dailyQuestClaimingId: this.dailyQuestClaimingId,
         mailboxClaimingMessageId: this.mailboxClaimingMessageId,
         mailboxClaimAllBusy: this.mailboxClaimAllInFlight
       });
@@ -1903,6 +1911,40 @@ export class VeilRoot extends Component {
       this.lobbyStatus = error instanceof Error ? error.message : "mailbox_claim_failed";
     } finally {
       this.mailboxClaimingMessageId = null;
+      this.renderView();
+    }
+  }
+
+  private async claimLobbyDailyQuest(questId: string): Promise<void> {
+    const storage = this.readWebStorage();
+    const authSession = readStoredCocosAuthSession(storage);
+    if (!authSession?.token) {
+      this.lobbyStatus = "每日任务领取需要先登录云端账号或游客会话。";
+      this.renderView();
+      return;
+    }
+
+    this.dailyQuestClaimingId = questId;
+    this.lobbyStatus = "正在领取每日任务奖励...";
+    this.renderView();
+    try {
+      const payload = await resolveVeilRootRuntime().claimDailyQuest(this.remoteUrl, questId, {
+        authSession,
+        storage
+      });
+      this.lobbyStatus =
+        payload.claimed
+          ? "每日任务奖励已领取，正在同步任务板。"
+          : payload.reason === "already_claimed"
+            ? "该每日任务奖励已经领取过。"
+            : payload.reason === "quest_incomplete"
+              ? "任务尚未完成，暂时无法领取奖励。"
+              : "每日任务领取失败，请稍后重试。";
+      await this.refreshLobbyAccountProfile();
+    } catch (error) {
+      this.lobbyStatus = error instanceof Error ? error.message : "daily_quest_claim_failed";
+    } finally {
+      this.dailyQuestClaimingId = null;
       this.renderView();
     }
   }

--- a/apps/cocos-client/assets/scripts/cocos-daily-quest-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-daily-quest-panel.ts
@@ -1,0 +1,126 @@
+import type { DailyQuestBoard, DailyQuestProgress } from "./project-shared/daily-quests.ts";
+
+export interface CocosDailyQuestActionView {
+  questId: string;
+  label: string;
+  enabled: boolean;
+}
+
+export interface CocosDailyQuestLineView {
+  questId: string;
+  title: string;
+  detail: string;
+  progressLabel: string;
+  rewardLabel: string;
+  stateLabel: string;
+  action: CocosDailyQuestActionView | null;
+}
+
+export interface CocosDailyQuestPanelView {
+  title: string;
+  subtitle: string;
+  claimableCountLabel: string;
+  pendingRewardsLabel: string;
+  resetLabel: string;
+  emptyLabel: string | null;
+  quests: CocosDailyQuestLineView[];
+}
+
+export interface BuildCocosDailyQuestPanelInput {
+  board?: DailyQuestBoard | null;
+  pendingQuestId: string | null;
+}
+
+function formatRewardLabel(quest: DailyQuestProgress): string {
+  const parts = [
+    quest.reward.gems > 0 ? `宝石 x${quest.reward.gems}` : null,
+    quest.reward.gold > 0 ? `金币 x${quest.reward.gold}` : null
+  ].filter((entry): entry is string => Boolean(entry));
+  return parts.length > 0 ? parts.join(" · ") : "奖励待同步";
+}
+
+function formatPendingRewardsLabel(board: DailyQuestBoard | null | undefined): string {
+  const pendingGems = Math.max(0, Math.floor(board?.pendingRewards.gems ?? 0));
+  const pendingGold = Math.max(0, Math.floor(board?.pendingRewards.gold ?? 0));
+  if (pendingGems === 0 && pendingGold === 0) {
+    return "待领取奖励 0";
+  }
+
+  const parts = [
+    pendingGems > 0 ? `宝石 x${pendingGems}` : null,
+    pendingGold > 0 ? `金币 x${pendingGold}` : null
+  ].filter((entry): entry is string => Boolean(entry));
+  return `待领取奖励 ${parts.join(" · ")}`;
+}
+
+function buildQuestLineView(quest: DailyQuestProgress, pendingQuestId: string | null): CocosDailyQuestLineView {
+  const progressLabel = `${Math.max(0, Math.floor(quest.current))}/${Math.max(1, Math.floor(quest.target))}`;
+  const rewardLabel = formatRewardLabel(quest);
+  if (pendingQuestId === quest.id) {
+    return {
+      questId: quest.id,
+      title: quest.title,
+      detail: quest.description,
+      progressLabel,
+      rewardLabel,
+      stateLabel: "领取中...",
+      action: {
+        questId: quest.id,
+        label: "领取中...",
+        enabled: false
+      }
+    };
+  }
+
+  if (quest.claimed) {
+    return {
+      questId: quest.id,
+      title: quest.title,
+      detail: quest.description,
+      progressLabel,
+      rewardLabel,
+      stateLabel: "已领取",
+      action: null
+    };
+  }
+
+  if (quest.completed) {
+    return {
+      questId: quest.id,
+      title: quest.title,
+      detail: quest.description,
+      progressLabel,
+      rewardLabel,
+      stateLabel: "可领取",
+      action: {
+        questId: quest.id,
+        label: "领取奖励",
+        enabled: true
+      }
+    };
+  }
+
+  return {
+    questId: quest.id,
+    title: quest.title,
+    detail: quest.description,
+    progressLabel,
+    rewardLabel,
+    stateLabel: "进行中",
+    action: null
+  };
+}
+
+export function buildCocosDailyQuestPanelView(input: BuildCocosDailyQuestPanelInput): CocosDailyQuestPanelView {
+  const board = input.board?.enabled === true ? input.board : null;
+  const quests = (board?.quests ?? []).map((quest) => buildQuestLineView(quest, input.pendingQuestId));
+  return {
+    title: "每日任务板",
+    subtitle: board?.cycleKey ? `轮换 ${board.cycleKey}` : "完成今日目标并领取奖励",
+    claimableCountLabel: `可领取 ${Math.max(0, Math.floor(board?.availableClaims ?? 0))}`,
+    pendingRewardsLabel: formatPendingRewardsLabel(board),
+    resetLabel: board?.resetAt ? `重置 ${board.resetAt.slice(11, 16)} UTC` : "重置时间待同步",
+    emptyLabel: quests.length === 0 ? "今日任务暂未开放或尚未下发。" : null,
+    quests
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-lobby-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby-panel-model.ts
@@ -86,6 +86,7 @@ export function createLobbyPanelTestAccount(
     recentEventLog: overrides.recentEventLog ?? [],
     recentBattleReplays: overrides.recentBattleReplays ?? [],
     source: overrides.source ?? "local",
+    ...(overrides.dailyQuestBoard ? { dailyQuestBoard: overrides.dailyQuestBoard } : {}),
     ...(overrides.battleReportCenter ? { battleReportCenter: overrides.battleReportCenter } : {}),
     ...(overrides.avatarUrl ? { avatarUrl: overrides.avatarUrl } : {}),
     ...(overrides.mailbox ? { mailbox: overrides.mailbox } : {}),

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -152,6 +152,17 @@ interface PlayerMailboxApiPayload {
   reason?: string;
 }
 
+interface DailyQuestClaimApiPayload {
+  claimed?: boolean;
+  reason?: string;
+  questId?: string;
+  reward?: {
+    gems?: number;
+    gold?: number;
+  };
+  dailyQuestBoard?: PlayerAccountReadModel["dailyQuestBoard"];
+}
+
 interface DailyClaimApiPayload {
   claimed?: boolean;
   reason?: string;
@@ -1060,6 +1071,29 @@ export async function claimCocosMailboxMessage(
       ...(options.storage !== undefined ? { storage: options.storage } : {})
     }
   )) as PlayerMailboxApiPayload;
+}
+
+export async function claimCocosDailyQuest(
+  remoteUrl: string,
+  questId: string,
+  options: {
+    authSession: CocosStoredAuthSession;
+    fetchImpl?: FetchLike;
+    storage?: Pick<Storage, "removeItem"> | null;
+  }
+): Promise<DailyQuestClaimApiPayload> {
+  return (await fetchCocosAuthJson(
+    remoteUrl,
+    `${resolveCocosApiBaseUrl(remoteUrl)}/api/player-accounts/me/daily-quests/${encodeURIComponent(questId)}/claim`,
+    {
+      method: "POST"
+    },
+    options.authSession,
+    {
+      ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+      ...(options.storage !== undefined ? { storage: options.storage } : {})
+    }
+  )) as DailyQuestClaimApiPayload;
 }
 
 export async function claimAllCocosMailboxMessages(

--- a/apps/cocos-client/test/cocos-daily-quest-panel.test.ts
+++ b/apps/cocos-client/test/cocos-daily-quest-panel.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCocosDailyQuestPanelView } from "../assets/scripts/cocos-daily-quest-panel.ts";
+
+test("buildCocosDailyQuestPanelView renders progress, claimable, and claimed quest lines", () => {
+  const view = buildCocosDailyQuestPanelView({
+    pendingQuestId: null,
+    board: {
+      enabled: true,
+      cycleKey: "2026-04-08",
+      resetAt: "2026-04-08T23:59:59.999Z",
+      availableClaims: 1,
+      pendingRewards: {
+        gems: 12,
+        gold: 50
+      },
+      quests: [
+        {
+          id: "move-1",
+          title: "巡视边境",
+          description: "移动英雄 3 次。",
+          target: 3,
+          current: 1,
+          completed: false,
+          claimed: false,
+          reward: {
+            gems: 4,
+            gold: 0
+          }
+        },
+        {
+          id: "collect-1",
+          title: "补给征收",
+          description: "收集资源 2 次。",
+          target: 2,
+          current: 2,
+          completed: true,
+          claimed: false,
+          reward: {
+            gems: 8,
+            gold: 50
+          }
+        },
+        {
+          id: "battle-1",
+          title: "压制前线",
+          description: "赢得 1 场战斗。",
+          target: 1,
+          current: 1,
+          completed: true,
+          claimed: true,
+          reward: {
+            gems: 5,
+            gold: 20
+          }
+        }
+      ]
+    }
+  });
+
+  assert.equal(view.title, "每日任务板");
+  assert.equal(view.subtitle, "轮换 2026-04-08");
+  assert.equal(view.claimableCountLabel, "可领取 1");
+  assert.equal(view.pendingRewardsLabel, "待领取奖励 宝石 x12 · 金币 x50");
+  assert.equal(view.resetLabel, "重置 23:59 UTC");
+  assert.equal(view.emptyLabel, null);
+  assert.deepEqual(view.quests, [
+    {
+      questId: "move-1",
+      title: "巡视边境",
+      detail: "移动英雄 3 次。",
+      progressLabel: "1/3",
+      rewardLabel: "宝石 x4",
+      stateLabel: "进行中",
+      action: null
+    },
+    {
+      questId: "collect-1",
+      title: "补给征收",
+      detail: "收集资源 2 次。",
+      progressLabel: "2/2",
+      rewardLabel: "宝石 x8 · 金币 x50",
+      stateLabel: "可领取",
+      action: {
+        questId: "collect-1",
+        label: "领取奖励",
+        enabled: true
+      }
+    },
+    {
+      questId: "battle-1",
+      title: "压制前线",
+      detail: "赢得 1 场战斗。",
+      progressLabel: "1/1",
+      rewardLabel: "宝石 x5 · 金币 x20",
+      stateLabel: "已领取",
+      action: null
+    }
+  ]);
+});
+
+test("buildCocosDailyQuestPanelView disables the action for a pending claim", () => {
+  const view = buildCocosDailyQuestPanelView({
+    pendingQuestId: "collect-1",
+    board: {
+      enabled: true,
+      cycleKey: "2026-04-08",
+      resetAt: "2026-04-08T23:59:59.999Z",
+      availableClaims: 1,
+      pendingRewards: {
+        gems: 8,
+        gold: 50
+      },
+      quests: [
+        {
+          id: "collect-1",
+          title: "补给征收",
+          description: "收集资源 2 次。",
+          target: 2,
+          current: 2,
+          completed: true,
+          claimed: false,
+          reward: {
+            gems: 8,
+            gold: 50
+          }
+        }
+      ]
+    }
+  });
+
+  assert.deepEqual(view.quests[0]?.action, {
+    questId: "collect-1",
+    label: "领取中...",
+    enabled: false
+  });
+  assert.equal(view.quests[0]?.stateLabel, "领取中...");
+});
+
+test("buildCocosDailyQuestPanelView reports the empty state when no quests are available", () => {
+  const view = buildCocosDailyQuestPanelView({
+    pendingQuestId: null,
+    board: {
+      enabled: true,
+      cycleKey: "2026-04-08",
+      resetAt: "2026-04-08T23:59:59.999Z",
+      availableClaims: 0,
+      pendingRewards: {
+        gems: 0,
+        gold: 0
+      },
+      quests: []
+    }
+  });
+
+  assert.equal(view.claimableCountLabel, "可领取 0");
+  assert.equal(view.pendingRewardsLabel, "待领取奖励 0");
+  assert.equal(view.emptyLabel, "今日任务暂未开放或尚未下发。");
+  assert.deepEqual(view.quests, []);
+});

--- a/apps/cocos-client/test/cocos-lobby-panel.test.ts
+++ b/apps/cocos-client/test/cocos-lobby-panel.test.ts
@@ -323,6 +323,115 @@ test("VeilLobbyPanel opens the lobby skill modal and wires skill selections", ()
   component.onDestroy();
 });
 
+test("VeilLobbyPanel opens the daily quest board panel and wires quest claims", () => {
+  const { node, component } = createComponentHarness(VeilLobbyPanel, { name: "LobbyPanelRoot", width: 760, height: 620 });
+  const claimedQuestIds: string[] = [];
+
+  component.configure({
+    onClaimDailyQuest: (questId) => {
+      claimedQuestIds.push(questId);
+    }
+  });
+  component.scheduleOnce = () => undefined;
+  component.render(
+    createLobbyState({
+      account: createLobbyPanelTestAccount({
+        dailyQuestBoard: {
+          enabled: true,
+          cycleKey: "2026-04-08",
+          resetAt: "2026-04-08T23:59:59.999Z",
+          availableClaims: 1,
+          pendingRewards: {
+            gems: 8,
+            gold: 50
+          },
+          quests: [
+            {
+              id: "quest-progress",
+              title: "巡视边境",
+              description: "移动英雄 3 次。",
+              target: 3,
+              current: 1,
+              completed: false,
+              claimed: false,
+              reward: {
+                gems: 2,
+                gold: 0
+              }
+            },
+            {
+              id: "quest-claimable",
+              title: "补给征收",
+              description: "收集资源 2 次。",
+              target: 2,
+              current: 2,
+              completed: true,
+              claimed: false,
+              reward: {
+                gems: 8,
+                gold: 50
+              }
+            },
+            {
+              id: "quest-claimed",
+              title: "压制前线",
+              description: "赢得 1 场战斗。",
+              target: 1,
+              current: 1,
+              completed: true,
+              claimed: true,
+              reward: {
+                gems: 5,
+                gold: 20
+              }
+            }
+          ]
+        }
+      })
+    })
+  );
+
+  assert.match(readCardLabel(node, "LobbyDailyQuestSummary"), /可领取 1 · 今日任务 3/);
+  pressNode(findNode(node, "LobbyDailyQuestOpen"));
+  assert.match(readCardLabel(node, "LobbyDailyQuestHeader"), /每日任务板/);
+  assert.match(readCardLabel(node, "LobbyDailyQuestQuest-0"), /巡视边境 · 进行中/);
+  assert.match(readCardLabel(node, "LobbyDailyQuestQuest-1"), /补给征收 · 可领取/);
+  assert.match(readCardLabel(node, "LobbyDailyQuestQuest-2"), /压制前线 · 已领取/);
+  assert.match(readCardLabel(node, "LobbyDailyQuestClaim-1"), /领取奖励/);
+
+  pressNode(findNode(node, "LobbyDailyQuestClaim-1"));
+  assert.deepEqual(claimedQuestIds, ["quest-claimable"]);
+  component.onDestroy();
+});
+
+test("VeilLobbyPanel renders the daily quest board empty state when no quests are available", () => {
+  const { node, component } = createComponentHarness(VeilLobbyPanel, { name: "LobbyPanelRoot", width: 760, height: 620 });
+
+  component.configure({});
+  component.scheduleOnce = () => undefined;
+  component.render(
+    createLobbyState({
+      account: createLobbyPanelTestAccount({
+        dailyQuestBoard: {
+          enabled: true,
+          cycleKey: "2026-04-08",
+          resetAt: "2026-04-08T23:59:59.999Z",
+          availableClaims: 0,
+          pendingRewards: {
+            gems: 0,
+            gold: 0
+          },
+          quests: []
+        }
+      })
+    })
+  );
+
+  pressNode(findNode(node, "LobbyDailyQuestOpen"));
+  assert.match(readCardLabel(node, "LobbyDailyQuestEmpty"), /今日任务暂未开放或尚未下发/);
+  component.onDestroy();
+});
+
 test("VeilLobbyPanel renders mailbox compensation copy and wires claim actions", () => {
   const { node, component } = createComponentHarness(VeilLobbyPanel, { name: "LobbyPanelRoot", width: 760, height: 620 });
   const claimedMessageIds: string[] = [];

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -3595,6 +3595,25 @@ test("daily quest claim grants rewards once and returns already_claimed on repea
   assert.equal(repeatPayload.reason, "already_claimed");
   assert.equal(repeatPayload.dailyQuestBoard.availableClaims, claimPayload.dailyQuestBoard.availableClaims);
 
+  const refreshedBoardResponse = await fetch(`http://127.0.0.1:${port}/api/player-accounts/me/daily-quests`, {
+    headers: {
+      Authorization: `Bearer ${session.token}`
+    }
+  });
+  const refreshedBoardPayload = (await refreshedBoardResponse.json()) as {
+    dailyQuestBoard: {
+      availableClaims: number;
+      quests: Array<{ id: string; claimed: boolean }>;
+    };
+  };
+
+  assert.equal(refreshedBoardResponse.status, 200);
+  assert.equal(refreshedBoardPayload.dailyQuestBoard.availableClaims, claimPayload.dailyQuestBoard.availableClaims);
+  assert.equal(
+    refreshedBoardPayload.dailyQuestBoard.quests.find((quest) => quest.id === claimableQuest.id)?.claimed,
+    true
+  );
+
   const account = await store.loadPlayerAccount("daily-quest-claim");
   const questState = await store.loadPlayerQuestState("daily-quest-claim");
   assert.equal(account?.gems, claimableQuest.reward.gems);


### PR DESCRIPTION
## Summary
- add a dedicated Cocos daily quest panel view builder and focused tests for progress, claimable, claimed, pending, and empty states
- wire the daily quest board into the lobby as a navigable sub-panel with claim actions backed by the existing player account flow
- extend the player account route coverage to verify claimed quest state persists on the `/api/player-accounts/me/daily-quests` GET response after claiming

## Validation
- `npm run typecheck:cocos`
- `node --import tsx --test apps/cocos-client/test/cocos-daily-quest-panel.test.ts`
- `node --import tsx --test --test-name-pattern "daily quest" apps/cocos-client/test/cocos-lobby-panel.test.ts`
- `node --import tsx --test --test-name-pattern "daily quest claim" apps/server/test/player-account-routes.test.ts`

Closes #1009