### PR TITLE
test: cover VeilRoot and colyseus-room critical paths

### DIFF
--- a/apps/cocos-client/test/cocos-veil-root.test.ts
+++ b/apps/cocos-client/test/cocos-veil-root.test.ts
@@ -439,6 +439,74 @@ test("VeilRoot connect promotes cached replay boot state into an authoritative l
   assert.equal(root.predictionStatus, "");
 });
 
+test("VeilRoot connect starts a fresh session and adopts the authoritative snapshot", async () => {
+  const root = createVeilRootHarness();
+  root.roomId = "room-live";
+  root.playerId = "account-player";
+  root.seed = 2024;
+  root.authMode = "account";
+  root.authToken = "live.token";
+  root.sessionSource = "remote";
+  root.applySessionUpdate = VeilRoot.prototype.applySessionUpdate.bind(root);
+  root.syncWechatShareBridge = () => ({
+    available: false,
+    menuEnabled: false,
+    handlerRegistered: false,
+    canShareDirectly: false,
+    immediateShared: false,
+    payload: null,
+    message: "disabled"
+  });
+
+  const liveUpdate = createSessionUpdate(4, "room-live", "account-player");
+  const freshSession = {
+    async snapshot() {
+      return liveUpdate;
+    },
+    async dispose() {}
+  };
+  const createCalls: Array<{
+    roomId: string;
+    playerId: string;
+    seed: number;
+    authToken: string | null;
+  }> = [];
+  let gameplayProfileRefreshes = 0;
+  root.refreshGameplayAccountProfile = async () => {
+    gameplayProfileRefreshes += 1;
+  };
+
+  installVeilRootRuntime({
+    createSession: async (roomId, playerId, seed, options) => {
+      createCalls.push({
+        roomId,
+        playerId,
+        seed,
+        authToken: options.getAuthToken?.() ?? null
+      });
+      return freshSession as never;
+    }
+  });
+
+  await root.connect();
+  await flushMicrotasks();
+
+  assert.equal(root.session, freshSession);
+  assert.equal(root.lastUpdate?.world.meta.day, 4);
+  assert.equal(root.diagnosticsConnectionStatus, "connected");
+  assert.equal(root.lastRoomUpdateSource, "session");
+  assert.equal(root.lastRoomUpdateReason, "snapshot");
+  assert.deepEqual(createCalls, [
+    {
+      roomId: "room-live",
+      playerId: "account-player",
+      seed: 2024,
+      authToken: "live.token"
+    }
+  ]);
+  assert.equal(gameplayProfileRefreshes, 1);
+});
+
 test("VeilRoot memory warnings request GC and surface the warning in HUD state", () => {
   const root = createVeilRootHarness();
   let memoryWarningHandler: ((payload?: { level?: number } | null) => void) | null = null;
@@ -461,6 +529,34 @@ test("VeilRoot memory warnings request GC and surface the warning in HUD state",
   assert.equal(root.runtimeMemoryNotice, "收到内存告警 L2，已请求 GC");
   assert.equal(root.logLines[0], "收到内存告警 L2，已请求 GC");
   assert.match(String(root.describeRuntimeMemoryHealth()), /收到内存告警 L2，已请求 GC/);
+});
+
+test("VeilRoot prediction rollback restores the last authoritative snapshot", () => {
+  const root = createVeilRootHarness();
+  const authoritativeUpdate = createSessionUpdate(3, "room-prediction", "player-1");
+  root.lastUpdate = authoritativeUpdate;
+
+  root.applyPrediction(
+    {
+      type: "hero.move",
+      heroId: "hero-1",
+      destination: { x: 1, y: 0 }
+    },
+    "正在预测移动..."
+  );
+
+  assert.deepEqual(root.lastUpdate?.world.ownHeroes[0]?.position, { x: 1, y: 0 });
+  assert.equal(root.predictionStatus, "正在预测移动...");
+  assert.ok(root.pendingPrediction);
+
+  root.rollbackPrediction("移动失败。");
+
+  assert.deepEqual(root.lastUpdate?.world.ownHeroes[0]?.position, { x: 0, y: 0 });
+  assert.equal(root.lastUpdate?.world.meta.roomId, authoritativeUpdate.world.meta.roomId);
+  assert.equal(root.lastUpdate?.world.meta.day, authoritativeUpdate.world.meta.day);
+  assert.equal(root.pendingPrediction, null);
+  assert.equal(root.predictionStatus, "");
+  assert.equal(root.logLines[0], "移动失败。");
 });
 
 test("VeilRoot reconnect failure updates the lobby-facing error status", () => {
@@ -757,4 +853,26 @@ test("VeilRoot onDestroy stops matchmaking polling to avoid timer leaks", () => 
 
   assert.equal(pollStops, 1);
   assert.equal(root.matchmakingPollController, null);
+});
+
+test("VeilRoot onDestroy disposes the active session and unregisters runtime memory warnings", () => {
+  const root = createVeilRootHarness();
+  let disposeCalls = 0;
+  let stopMemoryWarningCalls = 0;
+
+  root.session = {
+    async dispose() {
+      disposeCalls += 1;
+    }
+  } as never;
+  root.stopRuntimeMemoryWarnings = () => {
+    stopMemoryWarningCalls += 1;
+  };
+
+  root.onDestroy();
+
+  assert.equal(root.session, null);
+  assert.equal(root.stopRuntimeMemoryWarnings, null);
+  assert.equal(disposeCalls, 1);
+  assert.equal(stopMemoryWarningCalls, 1);
 });

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -664,6 +664,35 @@ test("failed reconnect cleanup removes only the expired session and preserves ot
   assert.equal(lastSessionState(steadyClient, "reply").payload.world.ownHeroes[0]?.playerId, "player-steady");
 });
 
+test("player leave keeps the disconnected timestamp for the departed player and preserves connected peers", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-leave-bookkeeping-${Date.now()}`);
+  const leavingClient = createFakeClient("session-leave-bookkeeping");
+  const steadyClient = createFakeClient("session-leave-steady");
+  const internalRoom = room as VeilColyseusRoom & {
+    playerIdBySessionId: Map<string, string>;
+    disconnectedAtByPlayerId: Map<string, string>;
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, leavingClient, "player-leaving", "connect-leaving");
+  await connectPlayer(room, steadyClient, "player-steady", "connect-steady");
+
+  room.onLeave(leavingClient);
+
+  assert.equal(internalRoom.playerIdBySessionId.has("session-leave-bookkeeping"), false);
+  assert.equal(internalRoom.playerIdBySessionId.get("session-leave-steady"), "player-steady");
+  assert.ok(internalRoom.disconnectedAtByPlayerId.get("player-leaving"));
+  assert.equal(internalRoom.disconnectedAtByPlayerId.has("player-steady"), false);
+  assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 1);
+});
+
 test("room disposal after the last client leaves removes it from the active room list", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
@@ -1664,6 +1693,42 @@ test("surrender settles the room with the surrendering player as loser and persi
   assert.equal(winnerPush.payload.reason, "surrender");
   assert.equal(loserAccount?.eloRating, expectedRatings.loserRating);
   assert.equal(winnerAccount?.eloRating, expectedRatings.winnerRating);
+  assert.equal(await store.load(room.roomId), null);
+});
+
+test("pvp settlement cleanup retires the room and clears connected player session state", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new InstrumentedRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-pvp-settlement-cleanup-${Date.now()}`);
+  const surrenderingClient = createFakeClient("session-pvp-cleanup-loser");
+  const opponentClient = createFakeClient("session-pvp-cleanup-winner");
+  const internalRoom = room as VeilColyseusRoom & {
+    playerIdBySessionId: Map<string, string>;
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, surrenderingClient, "player-1", "connect-pvp-cleanup-loser");
+  await connectPlayer(room, opponentClient, "player-2", "connect-pvp-cleanup-winner");
+
+  await emitRoomMessage(room, "world.action", surrenderingClient, {
+    type: "world.action",
+    requestId: "surrender-pvp-cleanup",
+    action: {
+      type: "world.surrender",
+      heroId: "hero-1"
+    }
+  });
+
+  assert.equal(internalRoom.playerIdBySessionId.size, 0);
+  assert.equal(room.clients.length, 0);
+  assert.equal(listLobbyRooms().some((entry) => entry.roomId === room.roomId), false);
+  assert.equal(getActiveRoomInstances().has(room.roomId), false);
   assert.equal(await store.load(room.roomId), null);
 });
 


### PR DESCRIPTION
## Summary
- add direct VeilRoot tests for fresh session startup, prediction rollback, and session teardown cleanup
- extend colyseus-room lifecycle coverage for explicit leave bookkeeping and PvP settlement room cleanup
- keep scope limited to focused unit coverage for the high-risk paths in #1023

## Validation
- node --import tsx --test ./apps/cocos-client/test/cocos-veil-root.test.ts
- node --import tsx --test ./apps/server/test/colyseus-room-lifecycle.test.ts
- npm run typecheck:cocos
- npm run typecheck:server

Closes #1023