### PR TITLE
[codex] complete cocos equipment loot loop

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilEquipmentPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilEquipmentPanel.ts
@@ -3,12 +3,16 @@ import type { EventLogEntry } from "./project-shared/index.ts";
 import type { HeroView } from "./VeilCocosSession.ts";
 import {
   buildEquipmentInspectItems,
+  buildInventorySummaryView,
   buildHeroEquipmentActionRows,
   formatEquipmentInspectLines,
+  formatEquipmentSlotLabel,
+  formatLootSpotlightLines,
   formatEquipmentOverviewLines,
   formatEquipmentStatSummary,
-  formatInventorySummaryLines,
   formatRecentLootLines,
+  type CocosEquipmentInventoryFilter,
+  type CocosEquipmentInventorySort,
   type CocosEquipmentActionRow,
   type CocosEquipmentInspectItem
 } from "./cocos-hero-equipment.ts";
@@ -108,6 +112,8 @@ export class VeilEquipmentPanel extends Component {
   private currentState: VeilEquipmentPanelRenderState | null = null;
   private inspectedItemId: string | null = null;
   private inspectedItemSource: CocosEquipmentInspectItem["source"] | null = null;
+  private inventoryFilter: CocosEquipmentInventoryFilter = "all";
+  private inventorySort: CocosEquipmentInventorySort = "slot";
 
   configure(options: VeilEquipmentPanelOptions): void {
     this.onClose = options.onClose;
@@ -125,6 +131,10 @@ export class VeilEquipmentPanel extends Component {
     const rows = buildHeroEquipmentActionRows(hero);
     const inspectItems = buildEquipmentInspectItems(hero);
     const selectedInspectItem = this.resolveInspectedItem(inspectItems);
+    const inventoryView = buildInventorySummaryView(hero, {
+      filter: this.inventoryFilter,
+      sort: this.inventorySort
+    });
     const buttons = buildActionButtons(
       inspectItems,
       rows,
@@ -134,8 +144,13 @@ export class VeilEquipmentPanel extends Component {
     );
     const bonusSummary = formatEquipmentStatSummary(hero);
     const loadoutLines = formatEquipmentOverviewLines(hero);
-    const inventoryLines = formatInventorySummaryLines(hero);
+    const inventoryLines = inventoryView.lines;
     const inspectLines = formatEquipmentInspectLines(selectedInspectItem);
+    const spotlightLines = formatLootSpotlightLines(
+      state.recentSessionEvents ?? [],
+      hero?.id,
+      hero?.name
+    );
     const lootLines = formatRecentLootLines(
       state.recentEventLog,
       hero?.id,
@@ -184,6 +199,47 @@ export class VeilEquipmentPanel extends Component {
     );
 
     cursorY = this.renderCard(
+      "EquipmentPanelControls",
+      0,
+      cursorY,
+      contentWidth,
+      60,
+      [
+        "筛选与排序",
+        `筛选 当前 ${this.describeInventoryFilter(this.inventoryFilter)} · 排序 当前 ${this.describeInventorySort(this.inventorySort)}`
+      ],
+      {
+        fill: CARD_FILL,
+        stroke: new Color(220, 230, 244, 56)
+      },
+      null,
+      12,
+      15
+    );
+
+    this.renderInventoryControlButtons(contentWidth, cursorY + 4);
+
+    cursorY -= 44;
+
+    if ((state.recentSessionEvents?.length ?? 0) > 0) {
+      cursorY = this.renderCard(
+        "EquipmentPanelLootSpotlight",
+        0,
+        cursorY,
+        contentWidth,
+        76,
+        spotlightLines,
+        {
+          fill: CARD_HIGHLIGHT_FILL,
+          stroke: new Color(244, 236, 208, 82)
+        },
+        null,
+        12,
+        16
+      );
+    }
+
+    cursorY = this.renderCard(
       "EquipmentPanelLoadout",
       0,
       cursorY,
@@ -204,7 +260,7 @@ export class VeilEquipmentPanel extends Component {
       0,
       cursorY,
       contentWidth,
-      Math.max(110, 34 + inventoryLines.length * 16),
+      Math.max(122, 34 + inventoryLines.length * 16),
       ["背包清单", ...inventoryLines],
       {
         fill: CARD_FILL,
@@ -258,6 +314,20 @@ export class VeilEquipmentPanel extends Component {
     }
   }
 
+  private setInventoryFilter(filter: CocosEquipmentInventoryFilter): void {
+    this.inventoryFilter = filter;
+    if (this.currentState) {
+      this.render(this.currentState);
+    }
+  }
+
+  private setInventorySort(sort: CocosEquipmentInventorySort): void {
+    this.inventorySort = sort;
+    if (this.currentState) {
+      this.render(this.currentState);
+    }
+  }
+
   private resolveInspectedItem(items: CocosEquipmentInspectItem[]): CocosEquipmentInspectItem | null {
     const matchedItem = items.find(
       (item) => item.itemId === this.inspectedItemId && item.source === this.inspectedItemSource
@@ -270,6 +340,14 @@ export class VeilEquipmentPanel extends Component {
     this.inspectedItemId = nextItem?.itemId ?? null;
     this.inspectedItemSource = nextItem?.source ?? null;
     return nextItem ?? null;
+  }
+
+  private describeInventoryFilter(filter: CocosEquipmentInventoryFilter): string {
+    return filter === "all" ? "全部" : formatEquipmentSlotLabel(filter);
+  }
+
+  private describeInventorySort(sort: CocosEquipmentInventorySort): string {
+    return sort === "slot" ? "槽位" : sort === "rarity" ? "稀有度" : "名称";
   }
 
   private syncChrome(width: number, height: number): void {
@@ -454,6 +532,64 @@ export class VeilEquipmentPanel extends Component {
       if (
         (child.name.startsWith("EquipmentPanelAction-") || child.name.startsWith("EquipmentPanelInspect-")) &&
         !actionButtons.some((button) => button.name === child.name)
+      ) {
+        child.active = false;
+      }
+    }
+  }
+
+  private renderInventoryControlButtons(contentWidth: number, centerY: number): void {
+    const buttonWidth = Math.floor((contentWidth - 18) / 4);
+    const buttonHeight = 20;
+    const gap = 6;
+    const filterButtons: Array<{ name: string; label: string; filter: CocosEquipmentInventoryFilter }> = [
+      { name: "EquipmentPanelFilter-all", label: "全部", filter: "all" },
+      { name: "EquipmentPanelFilter-weapon", label: "武器", filter: "weapon" },
+      { name: "EquipmentPanelFilter-armor", label: "护甲", filter: "armor" },
+      { name: "EquipmentPanelFilter-accessory", label: "饰品", filter: "accessory" }
+    ];
+    filterButtons.forEach((button, index) => {
+      this.renderButton(
+        button.name,
+        -contentWidth / 2 + buttonWidth / 2 + index * (buttonWidth + gap),
+        centerY,
+        buttonWidth,
+        buttonHeight,
+        button.label,
+        {
+          fill: this.inventoryFilter === button.filter ? CARD_HIGHLIGHT_FILL : BUTTON_FILL,
+          stroke: new Color(230, 238, 246, 106)
+        },
+        () => this.setInventoryFilter(button.filter)
+      );
+    });
+
+    const sortButtons: Array<{ name: string; label: string; sort: CocosEquipmentInventorySort }> = [
+      { name: "EquipmentPanelSort-slot", label: "槽位", sort: "slot" },
+      { name: "EquipmentPanelSort-rarity", label: "稀有", sort: "rarity" },
+      { name: "EquipmentPanelSort-name", label: "名称", sort: "name" }
+    ];
+    sortButtons.forEach((button, index) => {
+      this.renderButton(
+        button.name,
+        -contentWidth / 2 + buttonWidth / 2 + index * (buttonWidth + gap),
+        centerY - 24,
+        buttonWidth,
+        buttonHeight,
+        button.label,
+        {
+          fill: this.inventorySort === button.sort ? CARD_HIGHLIGHT_FILL : BUTTON_FILL,
+          stroke: new Color(230, 238, 246, 106)
+        },
+        () => this.setInventorySort(button.sort)
+      );
+    });
+
+    for (const child of this.node.children) {
+      if (
+        (child.name.startsWith("EquipmentPanelFilter-") || child.name.startsWith("EquipmentPanelSort-")) &&
+        !filterButtons.some((button) => button.name === child.name) &&
+        !sortButtons.some((button) => button.name === child.name)
       ) {
         child.active = false;
       }

--- a/apps/cocos-client/assets/scripts/cocos-hero-equipment.ts
+++ b/apps/cocos-client/assets/scripts/cocos-hero-equipment.ts
@@ -16,10 +16,22 @@ export interface CocosEquipmentInventoryItem {
   itemId: string;
   slot: EquipmentType;
   name: string;
+  rarity: EquipmentRarity;
   rarityLabel: string;
   bonusSummary: string;
   description: string;
   count: number;
+}
+
+export type CocosEquipmentInventoryFilter = "all" | EquipmentType;
+export type CocosEquipmentInventorySort = "slot" | "rarity" | "name";
+
+export interface CocosEquipmentInventoryView {
+  filter: CocosEquipmentInventoryFilter;
+  sort: CocosEquipmentInventorySort;
+  totalCount: number;
+  visibleKinds: number;
+  lines: string[];
 }
 
 export interface CocosEquipmentActionRow {
@@ -143,9 +155,11 @@ export function formatEquipmentSlotLabel(slot: EquipmentType): string {
 }
 
 function compareInventoryItems(left: CocosEquipmentInventoryItem, right: CocosEquipmentInventoryItem): number {
+  const rarityOrder: Record<EquipmentRarity, number> = { epic: 0, rare: 1, common: 2 };
   const slotOrder = { weapon: 0, armor: 1, accessory: 2 };
   return (
     slotOrder[left.slot] - slotOrder[right.slot] ||
+    rarityOrder[left.rarity] - rarityOrder[right.rarity] ||
     left.name.localeCompare(right.name, "zh-Hans-CN")
   );
 }
@@ -176,6 +190,7 @@ function buildInventoryItems(
         itemId,
         slot: definition.type,
         name: definition.name,
+        rarity: definition.rarity,
         rarityLabel: formatEquipmentRarityLabel(definition.rarity),
         bonusSummary: formatEquipmentBonusSummary(definition.bonuses),
         description: definition.description,
@@ -192,6 +207,47 @@ export function inventoryItemsForSlot(hero: HeroView, slot: EquipmentType): Coco
 
 export function inventoryItemsForHero(hero: HeroView): CocosEquipmentInventoryItem[] {
   return buildInventoryItems(hero);
+}
+
+function compareInventoryItemsByRarity(left: CocosEquipmentInventoryItem, right: CocosEquipmentInventoryItem): number {
+  const rarityOrder: Record<EquipmentRarity, number> = { epic: 0, rare: 1, common: 2 };
+  const slotOrder = { weapon: 0, armor: 1, accessory: 2 };
+  return (
+    rarityOrder[left.rarity] - rarityOrder[right.rarity] ||
+    slotOrder[left.slot] - slotOrder[right.slot] ||
+    left.name.localeCompare(right.name, "zh-Hans-CN")
+  );
+}
+
+function compareInventoryItemsByName(left: CocosEquipmentInventoryItem, right: CocosEquipmentInventoryItem): number {
+  const rarityOrder: Record<EquipmentRarity, number> = { epic: 0, rare: 1, common: 2 };
+  const slotOrder = { weapon: 0, armor: 1, accessory: 2 };
+  return (
+    left.name.localeCompare(right.name, "zh-Hans-CN") ||
+    rarityOrder[left.rarity] - rarityOrder[right.rarity] ||
+    slotOrder[left.slot] - slotOrder[right.slot]
+  );
+}
+
+function formatInventoryFilterLabel(filter: CocosEquipmentInventoryFilter): string {
+  return filter === "all" ? "全部" : formatEquipmentSlotLabel(filter);
+}
+
+function formatInventorySortLabel(sort: CocosEquipmentInventorySort): string {
+  return sort === "slot" ? "槽位" : sort === "rarity" ? "稀有度" : "名称";
+}
+
+function sortInventoryItems(
+  items: CocosEquipmentInventoryItem[],
+  sort: CocosEquipmentInventorySort
+): CocosEquipmentInventoryItem[] {
+  const comparator =
+    sort === "rarity"
+      ? compareInventoryItemsByRarity
+      : sort === "name"
+        ? compareInventoryItemsByName
+        : compareInventoryItems;
+  return [...items].sort(comparator);
 }
 
 export function buildEquipmentInspectItems(hero: HeroView | null): CocosEquipmentInspectItem[] {
@@ -268,33 +324,93 @@ export function formatEquipmentInspectLines(item: CocosEquipmentInspectItem | nu
   ];
 }
 
-export function formatInventorySummaryLines(hero: HeroView | null): string[] {
+export function buildInventorySummaryView(
+  hero: HeroView | null,
+  options?: {
+    filter?: CocosEquipmentInventoryFilter;
+    sort?: CocosEquipmentInventorySort;
+  }
+): CocosEquipmentInventoryView {
   if (!hero) {
-    return ["背包 等待房间状态..."];
+    return {
+      filter: options?.filter ?? "all",
+      sort: options?.sort ?? "slot",
+      totalCount: 0,
+      visibleKinds: 0,
+      lines: ["背包 等待房间状态..."]
+    };
   }
 
+  const filter = options?.filter ?? "all";
+  const sort = options?.sort ?? "slot";
   const items = inventoryItemsForHero(hero);
   const totalCount = hero.loadout.inventory.length;
+  const visibleItems = sortInventoryItems(
+    items.filter((item) => filter === "all" || item.slot === filter),
+    sort
+  );
+  const summaryPrefix = `筛选 ${formatInventoryFilterLabel(filter)} · 排序 ${formatInventorySortLabel(sort)}`;
+
   if (items.length === 0) {
-    return totalCount >= HERO_EQUIPMENT_INVENTORY_CAPACITY
-      ? [
-          `背包 ${totalCount}/${HERO_EQUIPMENT_INVENTORY_CAPACITY} 件`,
-          "背包已满，新的战利品会溢出",
-          "暂无可装备物品"
-        ]
-      : ["背包 暂无可装备物品"];
+    return {
+      filter,
+      sort,
+      totalCount,
+      visibleKinds: 0,
+      lines:
+        totalCount >= HERO_EQUIPMENT_INVENTORY_CAPACITY
+          ? [
+              summaryPrefix,
+              `背包 ${totalCount}/${HERO_EQUIPMENT_INVENTORY_CAPACITY} 件`,
+              "背包已满，新的战利品会溢出",
+              "暂无可装备物品"
+            ]
+          : [summaryPrefix, "背包 暂无可装备物品"]
+    };
   }
 
-  const detailLines = items.map((item) => {
+  if (visibleItems.length === 0) {
+    return {
+      filter,
+      sort,
+      totalCount,
+      visibleKinds: 0,
+      lines: [
+        summaryPrefix,
+        `背包 ${totalCount}/${HERO_EQUIPMENT_INVENTORY_CAPACITY} 件（0 类）`,
+        `当前筛选下暂无${formatInventoryFilterLabel(filter)}装备`
+      ]
+    };
+  }
+
+  const detailLines = visibleItems.map((item) => {
     const countLabel = item.count > 1 ? ` x${item.count}` : "";
     return `${formatEquipmentSlotLabel(item.slot)} ${item.rarityLabel} ${item.name}${countLabel} · ${item.bonusSummary}`;
   });
 
-  return [
-    `背包 ${totalCount}/${HERO_EQUIPMENT_INVENTORY_CAPACITY} 件（${items.length} 类）`,
-    ...(totalCount >= HERO_EQUIPMENT_INVENTORY_CAPACITY ? ["背包已满，新的战利品会溢出"] : []),
-    ...detailLines
-  ];
+  return {
+    filter,
+    sort,
+    totalCount,
+    visibleKinds: visibleItems.length,
+    lines: [
+      summaryPrefix,
+      `背包 ${totalCount}/${HERO_EQUIPMENT_INVENTORY_CAPACITY} 件`,
+      ...(filter === "all" ? [`已展开 ${visibleItems.length} 类物品`] : [`当前筛选 ${visibleItems.length} 类物品`]),
+      ...(totalCount >= HERO_EQUIPMENT_INVENTORY_CAPACITY ? ["背包已满，新的战利品会溢出"] : []),
+      ...detailLines
+    ]
+  };
+}
+
+export function formatInventorySummaryLines(
+  hero: HeroView | null,
+  options?: {
+    filter?: CocosEquipmentInventoryFilter;
+    sort?: CocosEquipmentInventorySort;
+  }
+): string[] {
+  return buildInventorySummaryView(hero, options).lines;
 }
 
 export function formatEquipmentStatSummary(hero: HeroView | null): CocosEquipmentStatSummaryLine[] {
@@ -390,6 +506,28 @@ export function formatRecentLootLines(
   }
 
   return [`战利品 最近 ${mergedDescriptions.length} 条`, ...visibleEntries];
+}
+
+export function formatLootSpotlightLines(
+  recentSessionEvents: CocosRecentLootEvent[],
+  heroId?: string | null,
+  heroName?: string
+): string[] {
+  const normalizedHeroId = heroId?.trim();
+  const ownedLoot = recentSessionEvents.filter(
+    (event) => event.type === "hero.equipmentFound" && (!normalizedHeroId || event.heroId === normalizedHeroId)
+  );
+  if (ownedLoot.length === 0) {
+    return ["战斗结算 暂无新的装备掉落"];
+  }
+
+  const latestEvent = ownedLoot[0]!;
+  const headline = latestEvent.overflowed ? "战斗结算 背包已满" : "战斗结算 获得新装备";
+  return [
+    headline,
+    formatSessionLootDescription(latestEvent, heroName),
+    ...(ownedLoot.length > 1 ? [`本次结算共记录 ${ownedLoot.length} 条掉落。`] : [])
+  ];
 }
 
 export function buildHeroEquipmentActionRows(hero: HeroView | null): CocosEquipmentActionRow[] {

--- a/apps/cocos-client/test/cocos-equipment-panel.test.ts
+++ b/apps/cocos-client/test/cocos-equipment-panel.test.ts
@@ -27,13 +27,23 @@ test("VeilEquipmentPanel renders loadout, inventory, and recent loot in a dedica
         worldEventType: "hero.equipmentFound",
         heroId: "hero-1"
       }
+    ],
+    recentSessionEvents: [
+      {
+        type: "hero.equipmentFound",
+        heroId: "hero-1",
+        equipmentName: "斥候罗盘",
+        rarity: "common"
+      }
     ]
   });
 
   assert.match(readCardLabel(node, "EquipmentPanelHeader"), /凯琳 的装备背包/);
+  assert.match(readCardLabel(node, "EquipmentPanelLootSpotlight"), /战斗结算 获得新装备/);
   assert.match(readCardLabel(node, "EquipmentPanelLoadout"), /武器 先锋战刃/);
+  assert.match(readCardLabel(node, "EquipmentPanelInventory"), /筛选 全部 · 排序 槽位/);
   assert.match(readCardLabel(node, "EquipmentPanelInventory"), /背包 2\/6 件/);
-  assert.match(readCardLabel(node, "EquipmentPanelLoot"), /战利品 最近 1 条/);
+  assert.match(readCardLabel(node, "EquipmentPanelLoot"), /战利品 最近 2 条/);
 });
 
 test("VeilEquipmentPanel routes close and equip actions through rendered buttons", () => {
@@ -96,4 +106,28 @@ test("VeilEquipmentPanel supports inspecting equipped and bag items in a dedicat
   assert.match(readCardLabel(node, "EquipmentPanelInspect"), /来源 背包中 2 件/);
   assert.match(readCardLabel(node, "EquipmentPanelInspect"), /扩大战术容错/);
   assert.match(readCardLabel(node, "EquipmentPanelInspect"), /说明 帮助英雄更快判断战场破绽/);
+});
+
+test("VeilEquipmentPanel lets the player filter and sort bag entries from the dedicated controls", () => {
+  const { component, node } = createComponentHarness(VeilEquipmentPanel, {
+    name: "EquipmentPanelRoot",
+    width: 420,
+    height: 520
+  });
+  const update = createSessionUpdate();
+  const hero = update.world.ownHeroes[0]!;
+  hero.loadout.inventory = ["militia_pike", "sun_medallion", "scout_compass", "tower_shield_mail"];
+
+  component.render({
+    hero,
+    recentEventLog: []
+  });
+
+  pressNode(findNode(node, "EquipmentPanelFilter-accessory"));
+  pressNode(findNode(node, "EquipmentPanelSort-rarity"));
+
+  const inventoryLabel = readCardLabel(node, "EquipmentPanelInventory");
+  assert.match(inventoryLabel, /筛选 饰品 · 排序 稀有度/);
+  assert.match(inventoryLabel, /曜日勋章/);
+  assert.doesNotMatch(inventoryLabel, /民兵长枪/);
 });

--- a/apps/cocos-client/test/cocos-hero-equipment.test.ts
+++ b/apps/cocos-client/test/cocos-hero-equipment.test.ts
@@ -2,11 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildEquipmentInspectItems,
+  buildInventorySummaryView,
   buildHeroEquipmentActionRows,
   formatEquipmentActionReason,
   formatEquipmentInspectLines,
   formatEquipmentOverviewLines,
   formatInventorySummaryLines,
+  formatLootSpotlightLines,
   formatRecentLootLines,
   inventoryItemsForSlot
 } from "../assets/scripts/cocos-hero-equipment";
@@ -142,7 +144,9 @@ test("formatInventorySummaryLines exposes the current backpack as grouped readab
       })
     ),
     [
-      "背包 4/6 件（3 类）",
+      "筛选 全部 · 排序 槽位",
+      "背包 4/6 件",
+      "已展开 3 类物品",
       "武器 普通 民兵长枪 x2 · 攻击 +6%",
       "护甲 普通 厚绗布甲 · 防御 +6% / 生命上限 +2",
       "饰品 普通 斥候罗盘 · 攻击 +3% / 知识 +1"
@@ -171,14 +175,43 @@ test("formatInventorySummaryLines warns when the backpack has reached capacity",
       })
     ),
     [
-      "背包 6/6 件（6 类）",
+      "筛选 全部 · 排序 槽位",
+      "背包 6/6 件",
+      "已展开 6 类物品",
       "背包已满，新的战利品会溢出",
       "武器 普通 民兵长枪 · 攻击 +6%",
       "武器 普通 橡木长弓 · 攻击 +4% / 知识 +1",
       "护甲 普通 厚绗布甲 · 防御 +6% / 生命上限 +2",
       "护甲 普通 塔盾链甲 · 防御 +8%",
-      "饰品 普通 斥候罗盘 · 攻击 +3% / 知识 +1",
-      "饰品 史诗 曜日勋章 · 攻击 +8% / 防御 +8% / 力量 +1"
+      "饰品 史诗 曜日勋章 · 攻击 +8% / 防御 +8% / 力量 +1",
+      "饰品 普通 斥候罗盘 · 攻击 +3% / 知识 +1"
+    ]
+  );
+});
+
+test("buildInventorySummaryView supports slot filtering and rarity sorting for the Cocos bag panel", () => {
+  assert.deepEqual(
+    buildInventorySummaryView(
+      createHero({
+        loadout: {
+          learnedSkills: [],
+          equipment: {
+            trinketIds: []
+          },
+          inventory: ["militia_pike", "sun_medallion", "scout_compass", "tower_shield_mail"]
+        }
+      }),
+      {
+        filter: "accessory",
+        sort: "rarity"
+      }
+    ).lines,
+    [
+      "筛选 饰品 · 排序 稀有度",
+      "背包 4/6 件",
+      "当前筛选 2 类物品",
+      "饰品 史诗 曜日勋章 · 攻击 +8% / 防御 +8% / 力量 +1",
+      "饰品 普通 斥候罗盘 · 攻击 +3% / 知识 +1"
     ]
   );
 });
@@ -379,6 +412,31 @@ test("formatRecentLootLines prioritizes authoritative session loot before accoun
       "战利品 最近 2 条",
       "凯琳 在战斗后发现了史诗装备 守誓圣铠，但背包已满，未能拾取。",
       "凯琳在战斗后获得了普通装备 塔盾链甲。"
+    ]
+  );
+});
+
+test("formatLootSpotlightLines highlights the newest owned loot settlement for the equipment panel", () => {
+  assert.deepEqual(
+    formatLootSpotlightLines(
+      [
+        {
+          type: "hero.equipmentFound",
+          heroId: "hero-1",
+          battleId: "battle-1",
+          battleKind: "neutral",
+          equipmentId: "warden_aegis",
+          equipmentName: "守誓圣铠",
+          rarity: "epic",
+          overflowed: true
+        }
+      ],
+      "hero-1",
+      "凯琳"
+    ),
+    [
+      "战斗结算 背包已满",
+      "凯琳 在战斗后发现了史诗装备 守誓圣铠，但背包已满，未能拾取。"
     ]
   );
 });

--- a/apps/cocos-client/test/cocos-primary-client-journey.test.ts
+++ b/apps/cocos-client/test/cocos-primary-client-journey.test.ts
@@ -992,6 +992,10 @@ test("primary cocos client journey closes the loot, inventory, and equip loop af
 
   const inventoryTextBeforeEquip = readNodeLabel(findNode(rootNode, "EquipmentPanelInventory")?.getChildByName("Label"));
   const lootTextBeforeEquip = readNodeLabel(findNode(rootNode, "EquipmentPanelLoot")?.getChildByName("Label"));
+  const spotlightTextBeforeEquip = readNodeLabel(findNode(rootNode, "EquipmentPanelLootSpotlight")?.getChildByName("Label"));
+  assert.match(String(spotlightTextBeforeEquip), /战斗结算 获得新装备/);
+  assert.match(String(spotlightTextBeforeEquip), /斥候罗盘/);
+  assert.match(String(inventoryTextBeforeEquip), /筛选 全部 · 排序 槽位/);
   assert.match(String(inventoryTextBeforeEquip), /斥候罗盘/);
   assert.match(String(lootTextBeforeEquip), /斥候罗盘/);
 

--- a/docs/cocos-equipment-loot-validation.md
+++ b/docs/cocos-equipment-loot-validation.md
@@ -8,7 +8,7 @@
 - Cocos session layer: `apps/cocos-client/assets/scripts/VeilCocosSession.ts` already sends `hero.equip` / `hero.unequip` requests and caches the returned `SessionUpdate`.
 - Cocos prediction/HUD layer: `apps/cocos-client/assets/scripts/cocos-prediction.ts`, `apps/cocos-client/assets/scripts/cocos-hero-equipment.ts`, and `apps/cocos-client/assets/scripts/VeilHudPanel.ts` present hero loadout state, grouped inventory choices, recent loot, and visible stat changes inside the primary runtime.
 
-## Implemented Slice For #683
+## Implemented Slice For #1018
 
 - Runtime entry points for this loop:
   - `apps/cocos-client/assets/scripts/VeilRoot.ts`: opens/closes the gameplay equipment panel, routes equip/unequip actions, and feeds recent session loot plus account event log state into the panel.
@@ -24,8 +24,11 @@
   - recent loot lines from the Cocos-visible account event log
 - Primary client `装备背包` panel now provides a dedicated runtime surface for the same loop:
   - open it from the left HUD chrome without leaving the main scene
+  - highlight the latest authoritative combat drop in a dedicated `战斗结算` loot spotlight card as soon as settlement lands
   - inspect one concrete equipped or backpack item at a time from a dedicated `物品详情` card
   - inspect equipped slots, grouped backpack contents, and recent loot in one place
+  - filter the backpack by `全部 / 武器 / 护甲 / 饰品`
+  - sort the backpack by `槽位 / 稀有度 / 名称`
   - execute equip / unequip actions from the panel and reuse the existing prediction plus authoritative reconciliation path
 - Existing equip/unequip buttons remain the interaction surface and continue to drive prediction plus server reconciliation.
 - The hero summary card now renders equipment-adjusted totals from shared progression math, so stat changes are visible during prediction and after reconciliation instead of only after a secondary refresh path.
@@ -46,14 +49,16 @@
 3. Enter a room and move until you trigger at least one neutral battle.
 4. Win a battle that grants equipment.
 5. Click `装备背包` in the left HUD chrome and confirm the dedicated panel opens.
-6. Confirm the panel `最近战利品` section shows the new drop and the `背包清单` section shows the item with rarity and stat summary.
-7. Click a `查看 ...` button in the panel and confirm the `物品详情` card updates to show the selected item's rarity, source, stat bonuses, and description.
-8. Fill the inventory to 6 items and trigger another equipment drop.
-9. Confirm the panel, HUD, and event log clearly state the backpack was full and the overflowed drop was not picked up.
-10. While the backpack is full, try to unequip an item and confirm the action is rejected with a full-inventory message.
-11. Free one slot, then click an equip action button inside the `装备背包` panel.
-12. Confirm the hero stat lines in the HUD update immediately after prediction/reconciliation.
-13. Click the matching unequip action in the same panel and confirm the item returns to inventory and the stat gain line rolls back.
+6. Confirm the panel `战斗结算` 卡片会高亮展示刚掉落的装备，并且 `最近战利品` / `背包清单` 同时包含该物品。
+7. 切换 `全部 / 武器 / 护甲 / 饰品` 过滤按钮，并确认 `背包清单` 只显示对应分类。
+8. 切换 `槽位 / 稀有度 / 名称` 排序按钮，并确认 `背包清单` 顺序立即变化。
+9. Click a `查看 ...` button in the panel and confirm the `物品详情` card updates to show the selected item's rarity, source, stat bonuses, and description.
+10. Fill the inventory to 6 items and trigger another equipment drop.
+11. Confirm the panel, HUD, and event log clearly state the backpack was full and the overflowed drop was not picked up.
+12. While the backpack is full, try to unequip an item and confirm the action is rejected with a full-inventory message.
+13. Free one slot, then click an equip action button inside the `装备背包` panel.
+14. Confirm the hero stat lines in the HUD update immediately after prediction/reconciliation.
+15. Click the matching unequip action in the same panel and confirm the item returns to inventory and the stat gain line rolls back.
 
 ## Temporary Assumptions
 


### PR DESCRIPTION
## Summary
- add Cocos equipment bag filter/sort controls and a battle-settlement loot spotlight card
- keep equip/unequip on the existing authoritative room flow while making stat changes visible in-panel and in the HUD
- extend equipment helper/panel/journey tests and refresh the local validation doc for the completed loop

## Validation
- node --import tsx --test apps/cocos-client/test/cocos-hero-equipment.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-equipment-panel.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-root-orchestration.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-hud-panel.test.ts
- node --import tsx --test apps/cocos-client/test/cocos-primary-client-journey.test.ts

Closes #1018
