### PR TITLE
[codex] Add phase 2 frontier expanded content-pack coverage

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -4,6 +4,7 @@ import defaultBattlePassConfig from "../../../../../configs/battle-pass.json";
 import defaultBuildingUpgradeConfig from "../../../../../configs/building-upgrades.json";
 import defaultHeroSkillTreesConfig from "../../../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../../../configs/phase2-map-objects-contested-basin.json";
+import frontierExpandedMapObjectsConfig from "../../../../../configs/phase2-map-objects-frontier-expanded.json";
 import amberFieldsMapObjectsConfig from "../../../../../configs/phase1-map-objects-amber-fields.json";
 import ashpeakAscentMapObjectsConfig from "../../../../../configs/phase1-map-objects-ashpeak-ascent.json";
 import bogfenCrossingMapObjectsConfig from "../../../../../configs/phase1-map-objects-bogfen-crossing.json";
@@ -22,6 +23,7 @@ import amberFieldsWorldConfig from "../../../../../configs/phase1-world-amber-fi
 import ashpeakAscentWorldConfig from "../../../../../configs/phase1-world-ashpeak-ascent.json";
 import bogfenCrossingWorldConfig from "../../../../../configs/phase1-world-bogfen-crossing.json";
 import contestedBasinWorldConfig from "../../../../../configs/phase2-contested-basin.json";
+import frontierExpandedWorldConfig from "../../../../../configs/phase2-frontier-expanded.json";
 import frontierBasinWorldConfig from "../../../../../configs/phase1-world-frontier-basin.json";
 import frostwatchRidgeWorldConfig from "../../../../../configs/phase1-world-frostwatch-ridge.json";
 import highlandReachWorldConfig from "../../../../../configs/phase1-world-highland-reach.json";
@@ -98,6 +100,7 @@ export const FROSTWATCH_RIDGE_MAP_VARIANT_ID = "frostwatch_ridge";
 export const ASHPEAK_ASCENT_MAP_VARIANT_ID = "ashpeak_ascent";
 export const THORNWALL_DIVIDE_MAP_VARIANT_ID = "thornwall_divide";
 export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
+export const PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID = "phase2_frontier_expanded";
 
 export interface RuntimeConfigBundle {
   world: WorldGenerationConfig;
@@ -809,7 +812,8 @@ function getAvailableMapVariantIds(): string[] {
     FROSTWATCH_RIDGE_MAP_VARIANT_ID,
     ASHPEAK_ASCENT_MAP_VARIANT_ID,
     THORNWALL_DIVIDE_MAP_VARIANT_ID,
-    CONTESTED_BASIN_MAP_VARIANT_ID
+    CONTESTED_BASIN_MAP_VARIANT_ID,
+    PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
   ];
 }
 
@@ -836,7 +840,8 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     requested === FROSTWATCH_RIDGE_MAP_VARIANT_ID ||
     requested === ASHPEAK_ASCENT_MAP_VARIANT_ID ||
     requested === THORNWALL_DIVIDE_MAP_VARIANT_ID ||
-    requested === CONTESTED_BASIN_MAP_VARIANT_ID
+    requested === CONTESTED_BASIN_MAP_VARIANT_ID ||
+    requested === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
   ) {
     return requested;
   }
@@ -876,6 +881,8 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneWorldConfig(thornwallDivideWorldConfig as WorldGenerationConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
+      : mapVariantId === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
+        ? cloneWorldConfig(frontierExpandedWorldConfig as WorldGenerationConfig)
         : getDefaultWorldConfig();
   const mapObjects =
     mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
@@ -904,6 +911,8 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneMapObjectsConfig(thornwallDivideMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === CONTESTED_BASIN_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(frontierExpandedMapObjectsConfig as MapObjectsConfig)
         : getDefaultMapObjectsConfig();
 
   validateWorldConfig(world);

--- a/apps/cocos-client/test/cocos-world-config-phase2-frontier-expanded.test.ts
+++ b/apps/cocos-client/test/cocos-world-config-phase2-frontier-expanded.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID,
+  getRuntimeConfigBundleForRoom,
+  resolveMapVariantIdForRoom
+} from "../assets/scripts/project-shared/index.ts";
+
+test("cocos world config resolves the phase2 frontier-expanded map variant", () => {
+  const roomId = "preview-frontier-expanded[map:phase2_frontier_expanded]";
+
+  assert.equal(resolveMapVariantIdForRoom(roomId, 1001), PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID);
+
+  const bundle = getRuntimeConfigBundleForRoom(roomId, 1001);
+  assert.equal(bundle.mapVariantId, PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID);
+  assert.equal(bundle.world.width, 32);
+  assert.equal(bundle.world.height, 32);
+  assert.equal(bundle.mapObjects.buildings.some((building) => building.id === "watchtower-frontier-expanded-1"), true);
+  assert.equal(bundle.mapObjects.neutralArmies.some((army) => army.id === "neutral-river-watch"), true);
+});

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -19,6 +19,8 @@ import ridgewayCrossingMapObjectsConfig from "../../../configs/phase1-map-object
 import ridgewayCrossingWorldConfig from "../../../configs/phase1-world-ridgeway-crossing.json";
 import contestedBasinMapObjectsConfig from "../../../configs/phase2-map-objects-contested-basin.json";
 import contestedBasinWorldConfig from "../../../configs/phase2-contested-basin.json";
+import frontierExpandedMapObjectsConfig from "../../../configs/phase2-map-objects-frontier-expanded.json";
+import frontierExpandedWorldConfig from "../../../configs/phase2-frontier-expanded.json";
 import {
   getBattleBalanceConfig,
   createWorldStateFromConfigs,
@@ -473,7 +475,8 @@ const BUILTIN_WORLD_LAYOUT_PRESETS = [
   "layout_amber_fields",
   "layout_ironpass_gorge",
   "layout_splitrock_canyon",
-  "layout_contested_basin"
+  "layout_contested_basin",
+  "layout_phase2_frontier_expanded"
 ] as const;
 const BUILTIN_MAP_OBJECT_LAYOUT_PRESETS = [
   "layout_phase1",
@@ -484,7 +487,8 @@ const BUILTIN_MAP_OBJECT_LAYOUT_PRESETS = [
   "layout_amber_fields",
   "layout_ironpass_gorge",
   "layout_splitrock_canyon",
-  "layout_contested_basin"
+  "layout_contested_basin",
+  "layout_phase2_frontier_expanded"
 ] as const;
 const CONFIG_SCHEMA_VERSION = "2026-03-26";
 const BASE_VALUE_IMPACT = ["配置台编辑器"];
@@ -1839,6 +1843,8 @@ function buildLayoutPresetSummary(id: typeof BUILTIN_WORLD_LAYOUT_PRESETS[number
         ? "Splitrock Canyon"
       : id === "layout_contested_basin"
         ? "Contested Basin"
+      : id === "layout_phase2_frontier_expanded"
+        ? "Phase 2 Frontier Expanded"
         : "Phase 1";
   const description =
     id === "layout_frontier_basin"
@@ -1857,6 +1863,8 @@ function buildLayoutPresetSummary(id: typeof BUILTIN_WORLD_LAYOUT_PRESETS[number
         ? "切换为裂岩峡谷布局，适合验证非对称出生点与双线路径压迫。"
       : id === "layout_contested_basin"
         ? "切换为争夺盆地布局，包含新巡逻守军与瞭望塔。"
+      : id === "layout_phase2_frontier_expanded"
+        ? "切换为 Phase 2 Frontier Expanded 32×32 布局，适合验证大地图分块渲染、Boss 阶段切换与新建筑/中立怪组合。"
         : "恢复默认 Phase 1 地图布局。";
 
   return {
@@ -1916,6 +1924,9 @@ function resolveBuiltinPresetContent(id: ConfigDocumentId, currentContent: strin
     if (presetId === "layout_contested_basin") {
       return normalizeJsonContent(contestedBasinWorldConfig as WorldGenerationConfig);
     }
+    if (presetId === "layout_phase2_frontier_expanded") {
+      return normalizeJsonContent(frontierExpandedWorldConfig as WorldGenerationConfig);
+    }
   }
 
   if (id === "mapObjects") {
@@ -1945,6 +1956,9 @@ function resolveBuiltinPresetContent(id: ConfigDocumentId, currentContent: strin
     }
     if (presetId === "layout_contested_basin") {
       return normalizeJsonContent(contestedBasinMapObjectsConfig as MapObjectsConfig);
+    }
+    if (presetId === "layout_phase2_frontier_expanded") {
+      return normalizeJsonContent(frontierExpandedMapObjectsConfig as MapObjectsConfig);
     }
   }
 

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -531,13 +531,21 @@ test("config center exposes built-in layout presets for the additional map varia
   assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_splitrock_canyon"));
   assert.ok(worldPresets.some((preset) => preset.id === "layout_contested_basin"));
   assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_contested_basin"));
+  assert.ok(worldPresets.some((preset) => preset.id === "layout_phase2_frontier_expanded"));
+  assert.ok(mapObjectPresets.some((preset) => preset.id === "layout_phase2_frontier_expanded"));
 
   const highlandWorldDocument = await store.applyPreset("world", "layout_highland_reach");
   const highlandMapObjectsDocument = await store.applyPreset("mapObjects", "layout_highland_reach");
+  const frontierExpandedWorldDocument = await store.applyPreset("world", "layout_phase2_frontier_expanded");
+  const frontierExpandedMapObjectsDocument = await store.applyPreset("mapObjects", "layout_phase2_frontier_expanded");
 
   assert.match(highlandWorldDocument.content, /"width": 10/);
   assert.match(highlandWorldDocument.content, /"position": \{\s+"x": 1,\s+"y": 4/s);
   assert.match(highlandMapObjectsDocument.content, /"id": "mine-ore-1"/);
+  assert.match(frontierExpandedWorldDocument.content, /"width": 32/);
+  assert.match(frontierExpandedWorldDocument.content, /"height": 32/);
+  assert.match(frontierExpandedMapObjectsDocument.content, /"id": "watchtower-frontier-expanded-1"/);
+  assert.match(frontierExpandedMapObjectsDocument.content, /"id": "neutral-river-watch"/);
 });
 
 test("config center diff classifies added, removed, and type changes", async () => {

--- a/configs/object-visuals.json
+++ b/configs/object-visuals.json
@@ -343,5 +343,43 @@
         "gold@8,9": "gold"
       }
     }
+  },
+  "phase2MapPackCoverage": {
+    "phase2": {
+      "neutralArmies": {
+        "neutral-reed-patrol": "neutral",
+        "neutral-watch-guard": "neutral",
+        "neutral-ford-scouts": "neutral"
+      },
+      "buildings": {
+        "recruit-post-basin-1": "recruitment_post",
+        "shrine-knowledge-basin-1": "attribute_shrine",
+        "mine-ore-basin-1": "resource_mine",
+        "watchtower-basin-1": "watchtower"
+      },
+      "resources": {
+        "wood@2,1": "wood",
+        "ore@7,6": "ore",
+        "gold@4,6": "gold"
+      }
+    },
+    "phase2-frontier-expanded": {
+      "neutralArmies": {
+        "neutral-frontier-gate": "neutral",
+        "neutral-river-watch": "neutral",
+        "neutral-southern-pickets": "neutral"
+      },
+      "buildings": {
+        "recruit-post-frontier-expanded-1": "recruitment_post",
+        "shrine-frontier-expanded-1": "attribute_shrine",
+        "mine-frontier-expanded-1": "resource_mine",
+        "watchtower-frontier-expanded-1": "watchtower"
+      },
+      "resources": {
+        "wood@6,4": "wood",
+        "gold@14,16": "gold",
+        "ore@26,27": "ore"
+      }
+    }
   }
 }

--- a/scripts/test/validate-map-object-visuals.test.ts
+++ b/scripts/test/validate-map-object-visuals.test.ts
@@ -35,17 +35,19 @@ async function seedMapObjectVisualRoot(tempDir: string): Promise<void> {
       "phase1-map-objects-murkveil-delta.json",
       "phase1-map-objects-frostwatch-ridge.json",
       "phase1-map-objects-ashpeak-ascent.json",
-      "phase1-map-objects-thornwall-divide.json"
+      "phase1-map-objects-thornwall-divide.json",
+      "phase2-map-objects-contested-basin.json",
+      "phase2-map-objects-frontier-expanded.json"
     ].map((fileName) => copyConfigFixture(tempDir, fileName))
   );
 }
 
-test("validate-map-object-visuals covers the shipped 13 Phase 1 map packs", async () => {
+test("validate-map-object-visuals covers the shipped Phase 1 and Phase 2 map packs", async () => {
   const report = await buildMapObjectVisualCoverageReport({
     rootDir: configsDir
   });
 
-  assert.equal(report.mapPackCount, 13);
+  assert.equal(report.mapPackCount, 15);
   assert.equal(report.valid, true);
   assert.equal(report.errorCount, 0);
   assert.equal(report.warningCount, 0);
@@ -97,4 +99,28 @@ test("validate-map-object-visuals warns on extra coverage without failing", asyn
   assert.match(stdout, /Warnings: 1 issue\(s\)/);
   assert.match(stdout, /coverage_node_extra/);
   assert.match(stdout, /gold@99,99/);
+});
+
+test("validate-map-object-visuals fails when a shipped Phase 2 pack loses coverage", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "veil-map-object-visuals-"));
+  await seedMapObjectVisualRoot(tempDir);
+
+  const objectVisualsPath = join(tempDir, "object-visuals.json");
+  const objectVisuals = JSON.parse(await readFile(objectVisualsPath, "utf8")) as {
+    phase2MapPackCoverage: Record<string, { buildings: Record<string, string> }>;
+  };
+
+  delete objectVisuals.phase2MapPackCoverage["phase2-frontier-expanded"]!.buildings["watchtower-frontier-expanded-1"];
+  await writeFile(objectVisualsPath, `${JSON.stringify(objectVisuals, null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    execFileAsync("node", ["--import", "tsx", scriptPath, "--root-dir", tempDir], { cwd: repoRoot }),
+    (error: NodeJS.ErrnoException & { stdout?: string }) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stdout ?? "", /Result: FAIL/);
+      assert.match(error.stdout ?? "", /coverage_node_missing/);
+      assert.match(error.stdout ?? "", /phase2-frontier-expanded node watchtower-frontier-expanded-1/);
+      return true;
+    }
+  );
 });

--- a/scripts/validate-map-object-visuals.ts
+++ b/scripts/validate-map-object-visuals.ts
@@ -19,6 +19,7 @@ interface ObjectVisualsConfig {
   buildings?: Partial<Record<BuildingKind, object>>;
   resources?: Partial<Record<ResourceKind, object>>;
   phase1MapPackCoverage?: Record<string, MapPackCoverage>;
+  phase2MapPackCoverage?: Record<string, MapPackCoverage>;
 }
 
 export interface MapObjectVisualCoverageIssue {
@@ -75,8 +76,16 @@ function parseArgs(argv: string[]): {
   return { rootDir, objectVisualsPath, reportPath };
 }
 
-function getPhase1MapPackDefinitions() {
-  return [DEFAULT_CONTENT_PACK_MAP_PACK, ...EXTRA_CONTENT_PACK_MAP_PACKS.filter((definition) => definition.phase === "phase1")];
+function getMapPackDefinitions() {
+  return [DEFAULT_CONTENT_PACK_MAP_PACK, ...EXTRA_CONTENT_PACK_MAP_PACKS];
+}
+
+function getCoverageRoot(config: ObjectVisualsConfig, phase: "phase1" | "phase2"): Record<string, MapPackCoverage> {
+  return phase === "phase2" ? config.phase2MapPackCoverage ?? {} : config.phase1MapPackCoverage ?? {};
+}
+
+function getCoverageRootPath(phase: "phase1" | "phase2"): "phase1MapPackCoverage" | "phase2MapPackCoverage" {
+  return phase === "phase2" ? "phase2MapPackCoverage" : "phase1MapPackCoverage";
 }
 
 async function readJson<T>(filePath: string): Promise<T> {
@@ -91,7 +100,8 @@ export function buildGuaranteedResourceCoverageId(resource: {
 }
 
 function issuePath(mapPackId: string, category: Exclude<CoverageCategory, "mapPacks">, nodeId: string): string {
-  return `phase1MapPackCoverage.${mapPackId}.${category}.${nodeId}`;
+  const phase = mapPackId.startsWith("phase2") ? "phase2" : "phase1";
+  return `${getCoverageRootPath(phase)}.${mapPackId}.${category}.${nodeId}`;
 }
 
 function validateExpectedCoverage(options: {
@@ -102,6 +112,8 @@ function validateExpectedCoverage(options: {
 }): MapObjectVisualCoverageIssue[] {
   const { mapPackId, expected, actual, objectVisuals } = options;
   const issues: MapObjectVisualCoverageIssue[] = [];
+  const phase = mapPackId.startsWith("phase2") ? "phase2" : "phase1";
+  const coverageRootPath = getCoverageRootPath(phase);
 
   if (!actual) {
     issues.push({
@@ -109,8 +121,8 @@ function validateExpectedCoverage(options: {
       code: "coverage_pack_missing",
       mapPackId,
       category: "mapPacks",
-      path: `phase1MapPackCoverage.${mapPackId}`,
-      message: `Missing Phase 1 map-pack object visual coverage for ${mapPackId}.`
+      path: `${coverageRootPath}.${mapPackId}`,
+      message: `Missing ${phase === "phase2" ? "Phase 2" : "Phase 1"} map-pack object visual coverage for ${mapPackId}.`
     });
     return issues;
   }
@@ -190,8 +202,7 @@ export async function buildMapObjectVisualCoverageReport(options: {
   const rootDir = options.rootDir ?? resolve(process.cwd(), "configs");
   const objectVisualsPath = options.objectVisualsPath ?? resolve(rootDir, "object-visuals.json");
   const objectVisuals = await readJson<ObjectVisualsConfig>(objectVisualsPath);
-  const coverage = objectVisuals.phase1MapPackCoverage ?? {};
-  const mapPackDefinitions = getPhase1MapPackDefinitions();
+  const mapPackDefinitions = getMapPackDefinitions();
   const expectedMapPacks = new Map<string, MapPackCoverage>();
 
   for (const definition of mapPackDefinitions) {
@@ -210,24 +221,33 @@ export async function buildMapObjectVisualCoverageReport(options: {
     validateExpectedCoverage({
       mapPackId,
       expected,
-      actual: coverage[mapPackId],
+      actual: getCoverageRoot(
+        objectVisuals,
+        mapPackId.startsWith("phase2") ? "phase2" : "phase1"
+      )[mapPackId],
       objectVisuals
     })
   );
 
-  for (const mapPackId of Object.keys(coverage)) {
-    if (expectedMapPacks.has(mapPackId)) {
-      continue;
-    }
+  for (const phase of ["phase1", "phase2"] as const) {
+    const coverage = getCoverageRoot(objectVisuals, phase);
+    for (const mapPackId of Object.keys(coverage)) {
+      if (expectedMapPacks.has(mapPackId)) {
+        continue;
+      }
 
-    issues.push({
-      severity: "warning",
-      code: "coverage_pack_extra",
-      mapPackId,
-      category: "mapPacks",
-      path: `phase1MapPackCoverage.${mapPackId}`,
-      message: `Phase 1 map-pack object visual coverage includes extra map pack ${mapPackId} that is not part of the 13 shipped Phase 1 packs.`
-    });
+      issues.push({
+        severity: "warning",
+        code: "coverage_pack_extra",
+        mapPackId,
+        category: "mapPacks",
+        path: `${getCoverageRootPath(phase)}.${mapPackId}`,
+        message:
+          phase === "phase2"
+            ? `Phase 2 map-pack object visual coverage includes extra map pack ${mapPackId} that is not part of the shipped Phase 2 packs.`
+            : `Phase 1 map-pack object visual coverage includes extra map pack ${mapPackId} that is not part of the shipped Phase 1 packs.`
+      });
+    }
   }
 
   const errorCount = issues.filter((issue) => issue.severity === "error").length;
@@ -266,7 +286,7 @@ async function main(): Promise<void> {
   console.log("Project Veil map-object visual coverage validation");
   console.log(`Root: ${report.rootDir}`);
   console.log(`Object visuals: ${report.objectVisualsPath}`);
-  console.log(`Phase 1 map packs: ${report.mapPackCount}`);
+  console.log(`Map packs: ${report.mapPackCount}`);
   console.log(`Result: ${report.valid ? "PASS" : "FAIL"}`);
   printIssues("Errors", errors);
   printIssues("Warnings", warnings);


### PR DESCRIPTION
## Summary
- wire the `phase2_frontier_expanded` map variant into the Cocos runtime bundle selection path and add a focused Cocos test for the 32x32 Phase 2 bundle
- expose `layout_phase2_frontier_expanded` as a built-in config-center preset for both world and map-object documents, with assertions for the shipped Phase 2 content
- extend `validate-map-object-visuals` to cover shipped Phase 2 map packs and add `object-visuals.json` coverage entries for `phase2` and `phase2-frontier-expanded`

## Validation
- `npm run validate:map-object-visuals`
- `node --import tsx --test ./scripts/test/validate-map-object-visuals.test.ts`
- `node --import tsx --test --test-name-pattern "config center exposes built-in layout presets for the additional map variants" ./apps/server/test/config-center.test.ts`
- `node --import tsx --test ./apps/cocos-client/test/cocos-world-config-phase2-frontier-expanded.test.ts`
- `node --import tsx --test ./apps/server/test/config-center.test.ts` currently still has unrelated pre-existing failures caused by `heroSkills` referencing unknown battle skill `commanding_shout`; the new Phase 2 preset test passes in isolation

Closes #1022.