### PR TITLE
[codex] Add ranked leaderboard season E2E coverage

### DIFF
--- a/playwright.multiplayer.config.ts
+++ b/playwright.multiplayer.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests/e2e",
   testMatch:
-    /(multiplayer-sync|multiplayer-stress|reconnect-recovery|pvp-hero-encounter|pvp-reconnect-recovery|pvp-postbattle-reconnect|pvp-postbattle-continue|pvp-matchmaking-lifecycle|battle-replay-smoke)\.spec\.ts/,
+    /(multiplayer-sync|multiplayer-stress|reconnect-recovery|pvp-hero-encounter|pvp-reconnect-recovery|pvp-postbattle-reconnect|pvp-postbattle-continue|pvp-matchmaking-lifecycle|leaderboard-ranked-season|battle-replay-smoke)\.spec\.ts/,
   timeout: 30_000,
   fullyParallel: false,
   workers: 1,

--- a/tests/e2e/leaderboard-ranked-season.spec.ts
+++ b/tests/e2e/leaderboard-ranked-season.spec.ts
@@ -1,0 +1,264 @@
+import { expect, test } from "@playwright/test";
+import {
+  applyEloMatchResult,
+  getRankDivisionForRating,
+  getTierForRating,
+  type PlayerBattleReplaySummary
+} from "../../packages/shared/src/index";
+import { attackOnce, buildRoomId, expectHeroMoveSpent, fullMoveTextPattern, openRoom, pressTile } from "./smoke-helpers";
+
+const SERVER_BASE_URL = "http://127.0.0.1:2567";
+
+interface GuestLoginPayload {
+  session?: {
+    token?: string;
+  };
+}
+
+interface MatchmakingStatusPayload {
+  status: string;
+  roomId?: string;
+  playerIds?: [string, string];
+}
+
+interface PlayerAccountPayload {
+  account?: {
+    playerId?: string;
+    displayName?: string;
+    eloRating?: number;
+    rankDivision?: string;
+    rankedWeeklyProgress?: {
+      currentWeekBattles?: number;
+      currentWeekWins?: number;
+    };
+    lastRoomId?: string;
+  };
+}
+
+interface PlayerBattleReplayListPayload {
+  items?: Array<Partial<PlayerBattleReplaySummary>>;
+}
+
+interface LeaderboardPayload {
+  players?: Array<{
+    playerId?: string;
+    displayName?: string;
+    eloRating?: number;
+    tier?: string;
+    division?: string;
+  }>;
+}
+
+async function resetStore(): Promise<void> {
+  const response = await fetch(`${SERVER_BASE_URL}/api/test/reset-store`, {
+    method: "POST"
+  });
+  if (!response.ok) {
+    throw new Error(`reset_store_failed:${response.status}`);
+  }
+}
+
+async function loginGuest(playerId: string, displayName: string): Promise<string> {
+  const response = await fetch(`${SERVER_BASE_URL}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId,
+      displayName
+    })
+  });
+  if (!response.ok) {
+    throw new Error(`guest_login_failed:${playerId}:${response.status}`);
+  }
+
+  const payload = (await response.json()) as GuestLoginPayload;
+  const token = payload.session?.token?.trim();
+  if (!token) {
+    throw new Error(`guest_login_missing_token:${playerId}`);
+  }
+  return token;
+}
+
+async function enqueuePlayer(token: string): Promise<void> {
+  const response = await fetch(`${SERVER_BASE_URL}/api/matchmaking/enqueue`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+  if (!response.ok) {
+    throw new Error(`matchmaking_enqueue_failed:${response.status}`);
+  }
+}
+
+async function fetchMatchmakingStatus(token: string): Promise<MatchmakingStatusPayload> {
+  const response = await fetch(`${SERVER_BASE_URL}/api/matchmaking/status`, {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  });
+  if (!response.ok) {
+    throw new Error(`matchmaking_status_failed:${response.status}`);
+  }
+  return (await response.json()) as MatchmakingStatusPayload;
+}
+
+async function fetchPlayerAccount(playerId: string): Promise<Required<PlayerAccountPayload>["account"]> {
+  const response = await fetch(`${SERVER_BASE_URL}/api/player-accounts/${encodeURIComponent(playerId)}`);
+  if (!response.ok) {
+    throw new Error(`player_account_failed:${playerId}:${response.status}`);
+  }
+  const payload = (await response.json()) as PlayerAccountPayload;
+  if (!payload.account) {
+    throw new Error(`player_account_missing:${playerId}`);
+  }
+  return payload.account;
+}
+
+async function fetchLatestReplay(playerId: string): Promise<Partial<PlayerBattleReplaySummary> | null> {
+  const response = await fetch(
+    `${SERVER_BASE_URL}/api/player-accounts/${encodeURIComponent(playerId)}/battle-replays?limit=1`
+  );
+  if (!response.ok) {
+    throw new Error(`player_replays_failed:${playerId}:${response.status}`);
+  }
+  const payload = (await response.json()) as PlayerBattleReplayListPayload;
+  return payload.items?.[0] ?? null;
+}
+
+async function fetchLeaderboard(): Promise<LeaderboardPayload> {
+  const response = await fetch(`${SERVER_BASE_URL}/api/leaderboard?limit=10`);
+  if (!response.ok) {
+    throw new Error(`leaderboard_failed:${response.status}`);
+  }
+  return (await response.json()) as LeaderboardPayload;
+}
+
+test("ranked leaderboard query reflects post-battle elo, division, and weekly progress", async ({ browser }) => {
+  await resetStore();
+
+  const playerOneToken = await loginGuest("player-1", "One");
+  const playerTwoToken = await loginGuest("player-2", "Two");
+  const playerOneContext = await browser.newContext();
+  const playerTwoContext = await browser.newContext();
+  const playerOnePage = await playerOneContext.newPage();
+  const playerTwoPage = await playerTwoContext.newPage();
+  const seedRoomOne = buildRoomId("leaderboard-seed-player-1");
+  const seedRoomTwo = buildRoomId("leaderboard-seed-player-2");
+  const expectedRatings = applyEloMatchResult(1000, 1000);
+  const expectedWinnerDivision = getRankDivisionForRating(expectedRatings.winnerRating);
+  const expectedLoserDivision = getRankDivisionForRating(expectedRatings.loserRating);
+
+  try {
+    await Promise.all([
+      openRoom(playerOnePage, {
+        roomId: seedRoomOne,
+        playerId: "player-1",
+        expectedMoveText: fullMoveTextPattern("player-1")
+      }),
+      openRoom(playerTwoPage, {
+        roomId: seedRoomTwo,
+        playerId: "player-2",
+        expectedMoveText: fullMoveTextPattern("player-2")
+      })
+    ]);
+
+    await expect.poll(async () => (await fetchPlayerAccount("player-1")).lastRoomId).toBe(seedRoomOne);
+    await expect.poll(async () => (await fetchPlayerAccount("player-2")).lastRoomId).toBe(seedRoomTwo);
+
+    await enqueuePlayer(playerOneToken);
+    await enqueuePlayer(playerTwoToken);
+
+    let matchedRoomId: string | null = null;
+    await expect
+      .poll(async () => {
+        const [playerOneStatus, playerTwoStatus] = await Promise.all([
+          fetchMatchmakingStatus(playerOneToken),
+          fetchMatchmakingStatus(playerTwoToken)
+        ]);
+        if (playerOneStatus.status !== "matched" || playerTwoStatus.status !== "matched") {
+          return null;
+        }
+
+        if (playerOneStatus.roomId !== playerTwoStatus.roomId) {
+          return null;
+        }
+
+        matchedRoomId = playerOneStatus.roomId ?? null;
+        return {
+          roomId: matchedRoomId,
+          playerIds: playerOneStatus.playerIds ?? null
+        };
+      })
+      .toMatchObject({
+        roomId: expect.stringMatching(/^pvp-match-/),
+        playerIds: ["player-1", "player-2"]
+      });
+
+    if (!matchedRoomId) {
+      throw new Error("matched_room_missing");
+    }
+
+    await Promise.all([
+      openRoom(playerOnePage, {
+        roomId: matchedRoomId,
+        playerId: "player-1",
+        expectedMoveText: fullMoveTextPattern("player-1")
+      }),
+      openRoom(playerTwoPage, {
+        roomId: matchedRoomId,
+        playerId: "player-2",
+        expectedMoveText: fullMoveTextPattern("player-2")
+      })
+    ]);
+
+    await pressTile(playerOnePage, 3, 4);
+    await expectHeroMoveSpent(playerOnePage, 5, "player-1");
+    await pressTile(playerTwoPage, 3, 4);
+
+    await attackOnce(playerTwoPage);
+    await attackOnce(playerOnePage);
+    await attackOnce(playerTwoPage);
+    await attackOnce(playerOnePage);
+    await attackOnce(playerTwoPage);
+    await attackOnce(playerOnePage);
+
+    await expect(playerOnePage.getByTestId("battle-modal-title")).toHaveText("战斗胜利");
+    await expect(playerTwoPage.getByTestId("battle-modal-title")).toHaveText("战斗失败");
+
+    await expect.poll(async () => (await fetchPlayerAccount("player-1")).eloRating).toBe(expectedRatings.winnerRating);
+    await expect.poll(async () => (await fetchPlayerAccount("player-2")).eloRating).toBe(expectedRatings.loserRating);
+    await expect.poll(async () => (await fetchPlayerAccount("player-1")).rankDivision ?? null).toBe(expectedWinnerDivision);
+    await expect.poll(async () => (await fetchPlayerAccount("player-2")).rankDivision ?? null).toBe(expectedLoserDivision);
+    await expect.poll(async () => (await fetchPlayerAccount("player-1")).rankedWeeklyProgress?.currentWeekBattles ?? null).toBe(1);
+    await expect.poll(async () => (await fetchPlayerAccount("player-1")).rankedWeeklyProgress?.currentWeekWins ?? null).toBe(1);
+    await expect.poll(async () => (await fetchPlayerAccount("player-2")).rankedWeeklyProgress?.currentWeekBattles ?? null).toBe(1);
+    await expect.poll(async () => (await fetchPlayerAccount("player-2")).rankedWeeklyProgress?.currentWeekWins ?? null).toBe(0);
+    await expect.poll(async () => (await fetchLatestReplay("player-1"))?.roomId ?? null).toBe(matchedRoomId);
+    await expect.poll(async () => (await fetchLatestReplay("player-2"))?.roomId ?? null).toBe(matchedRoomId);
+
+    await expect
+      .poll(async () => (await fetchLeaderboard()).players?.slice(0, 2) ?? [])
+      .toEqual([
+        {
+          playerId: "player-1",
+          displayName: "One",
+          eloRating: expectedRatings.winnerRating,
+          tier: getTierForRating(expectedRatings.winnerRating),
+          division: expectedWinnerDivision
+        },
+        {
+          playerId: "player-2",
+          displayName: "Two",
+          eloRating: expectedRatings.loserRating,
+          tier: getTierForRating(expectedRatings.loserRating),
+          division: expectedLoserDivision
+        }
+      ]);
+  } finally {
+    await playerOneContext.close();
+    await playerTwoContext.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add a multiplayer Playwright E2E spec covering ranked leaderboard updates after a post-battle result
- assert account elo/division, weekly progress, replay linkage, and leaderboard ordering for both players
- wire the new spec into the multiplayer Playwright config

## Validation
- `npm run validate:e2e:fixtures`
- `node --import tsx --test apps/server/test/leaderboard-routes.test.ts`
- `npx playwright test tests/e2e/leaderboard-ranked-season.spec.ts --config=playwright.multiplayer.config.ts --list`
- attempted `npx playwright test tests/e2e/leaderboard-ranked-season.spec.ts --config=playwright.multiplayer.config.ts` *(blocked in this host because Chromium cannot launch: missing system library `libatk-bridge-2.0.so.0`)*

Closes #1101
