### PR TITLE
[codex] Add config center editor test coverage for save, preview, and snapshot drift

### DIFF
--- a/apps/client/test/config-center-render.test.ts
+++ b/apps/client/test/config-center-render.test.ts
@@ -196,3 +196,52 @@ test("config center render prioritizes structural snapshot diffs in rollback rev
   assert.match(html, /删除字段/);
   assert.match(html, /世界预览/);
 });
+
+test("config center render shows field drift against the persisted snapshot baseline", () => {
+  const html = renderConfigCenterSnapshotDiffPanel({
+    selectedSnapshotId: "snapshot-world-3",
+    snapshotDiff: {
+      entries: [
+        {
+          path: "height",
+          change: "updated",
+          previousValue: "8",
+          nextValue: "10",
+          kind: "value",
+          required: true,
+          fieldType: "integer",
+          description: "地图高度",
+          blastRadius: ["世界预览"]
+        },
+        {
+          path: "width",
+          change: "updated",
+          previousValue: "8",
+          nextValue: "10",
+          kind: "value",
+          required: true,
+          fieldType: "integer",
+          description: "地图宽度",
+          blastRadius: ["配置台编辑器", "世界预览"]
+        }
+      ]
+    }
+  });
+
+  assert.match(html, /当前展示 2 \/ 2 条差异/);
+  assert.match(html, /width/);
+  assert.match(html, /height/);
+  assert.match(html, /8 → 10/);
+  assert.match(html, /字段值变更/);
+});
+
+test("config center render marks snapshot comparison as in sync when there is no baseline drift", () => {
+  const html = renderConfigCenterSnapshotDiffPanel({
+    selectedSnapshotId: "snapshot-world-3",
+    snapshotDiff: {
+      entries: []
+    }
+  });
+
+  assert.match(html, /当前版本与该快照没有差异/);
+});

--- a/apps/client/test/config-center.test.ts
+++ b/apps/client/test/config-center.test.ts
@@ -267,6 +267,84 @@ test("config center save flow calls the config API with the edited draft body", 
   assert.equal(controller.state.lastSavedImpactSummary?.impactedModules.includes("招募库存"), true);
 });
 
+test("config center world save refreshes the preview from the persisted draft", async () => {
+  const savedDocument = createDocument("world", "{\n  \"width\": 10,\n  \"height\": 8\n}\n", { version: 3 });
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world" && request.method === "PUT") {
+      return new Response(
+        JSON.stringify({
+          storage: "filesystem",
+          document: savedDocument
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    }
+
+    if (request.url === "/api/config-center/configs") {
+      return new Response(JSON.stringify({ storage: "filesystem", items: [savedDocument] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots") {
+      return new Response(JSON.stringify({ storage: "filesystem", snapshots: [], publishHistory: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/presets") {
+      return new Response(JSON.stringify({ storage: "filesystem", presets: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/preview" && request.method === "POST") {
+      return new Response(JSON.stringify({ storage: "filesystem", preview: createWorldPreview() }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8,\n  \"height\": 8\n}\n", { version: 2 });
+  controller.state.validation = createValidationReport(true);
+  controller.setDraft("{\n  \"width\": 10,\n  \"height\": 8\n}\n");
+
+  await controller.saveCurrentDocument();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  const previewRequest = requests.find(
+    (request) => request.url === "/api/config-center/configs/world/preview" && request.method === "POST"
+  );
+  assert.ok(previewRequest);
+  assert.deepEqual(JSON.parse(previewRequest.body ?? "{}"), {
+    content: "{\n  \"width\": 10,\n  \"height\": 8\n}\n",
+    seed: 1001
+  });
+  assert.equal(controller.state.current?.content, "{\n  \"width\": 10,\n  \"height\": 8\n}\n");
+  assert.equal(controller.state.worldPreview?.roomId, "preview-room");
+  assert.equal(controller.state.previewError, "");
+});
+
 test("config center save is blocked when validation has already failed", async () => {
   const { fetch, requests } = createFetchStub((request) => {
     throw new Error(`Unexpected request: ${request.method} ${request.url}`);
@@ -424,6 +502,46 @@ test("config center snapshot flow saves the current draft and refreshes the snap
   assert.deepEqual(controller.state.snapshots, [snapshot]);
   assert.equal(controller.state.selectedSnapshotId, "snapshot-world-4");
   assert.equal(controller.state.snapshotDiff?.entries[0]?.path, "width");
+});
+
+test("config center preview flow posts the current draft with the selected seed and blocks invalid JSON locally", async () => {
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/preview" && request.method === "POST") {
+      return new Response(JSON.stringify({ storage: "filesystem", preview: createWorldPreview() }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8,\n  \"height\": 8\n}\n");
+  controller.state.previewSeed = 2026;
+  controller.setDraft("{\n  \"width\": 10,\n  \"height\": 8\n}\n");
+
+  await controller.loadWorldPreview();
+
+  const previewRequest = requests.find(
+    (request) => request.url === "/api/config-center/configs/world/preview" && request.method === "POST"
+  );
+  assert.ok(previewRequest);
+  assert.deepEqual(JSON.parse(previewRequest.body ?? "{}"), {
+    content: "{\n  \"width\": 10,\n  \"height\": 8\n}\n",
+    seed: 2026
+  });
+  assert.equal(controller.state.worldPreview?.seed, 1001);
+
+  controller.setDraft("{\n  \"width\": \n}\n");
+
+  await controller.loadWorldPreview();
+
+  assert.equal(requests.filter((request) => request.url.endsWith("/preview")).length, 1);
+  assert.equal(controller.state.worldPreview, null);
+  assert.match(controller.state.previewError, /JSON 语法无效/);
 });
 
 test("config center snapshot diff exposes non-empty changes for an edited field", async () => {


### PR DESCRIPTION
Closes #1115

## Summary
- expand `apps/client/test/config-center.test.ts` coverage for persisted save behavior and world preview request handling
- add client preview-flow assertions for selected seed usage and local invalid-JSON blocking
- extend `apps/client/test/config-center-render.test.ts` coverage for snapshot baseline drift rendering and in-sync empty-state output

## Validation
- `node --import tsx --test apps/client/test/config-center-render.test.ts apps/client/test/config-center.test.ts`