### PR TITLE
Add Cocos account registration and WeChat bind UI

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -40,6 +40,7 @@ import type {
   CocosAccountLifecyclePanelView,
   CocosAccountReadinessStatus
 } from "./cocos-account-lifecycle.ts";
+import type { CocosAccountRegistrationPanelView } from "./cocos-account-registration.ts";
 import {
   createBattleReplayPlaybackState,
   findPlayerBattleReplaySummary,
@@ -112,6 +113,12 @@ function formatAccountReadinessStatus(status: CocosAccountReadinessStatus): stri
   return "MISSING";
 }
 
+function isRegistrationFlowView(
+  flow: CocosAccountLifecyclePanelView | CocosAccountRegistrationPanelView
+): flow is CocosAccountRegistrationPanelView {
+  return Array.isArray((flow as CocosAccountRegistrationPanelView).identities);
+}
+
 export interface VeilLobbyRenderState {
   playerId: string;
   displayName: string;
@@ -146,7 +153,7 @@ export interface VeilLobbyRenderState {
   matchmakingSearching?: boolean;
   matchmakingBusy?: boolean;
   rooms: CocosLobbyRoomSummary[];
-  accountFlow: CocosAccountLifecyclePanelView | null;
+  accountFlow: CocosAccountLifecyclePanelView | CocosAccountRegistrationPanelView | null;
   presentationReadiness: CocosPresentationReadiness;
   activeHero: HeroView | null;
   lobbySkillPanel: LobbySkillPanelView | null;
@@ -176,6 +183,8 @@ export interface VeilLobbyPanelOptions {
   onEditAccountFlowField?: (field: CocosAccountLifecycleFieldView["key"]) => void;
   onRequestAccountFlow?: () => void;
   onConfirmAccountFlow?: () => void;
+  onToggleAccountMinorProtection?: () => void;
+  onBindWechatAccount?: () => void;
   onCancelAccountFlow?: () => void;
   onOpenCampaign?: () => void;
   onOpenConfigCenter?: () => void;
@@ -223,6 +232,8 @@ export class VeilLobbyPanel extends Component {
   private onEditAccountFlowField: ((field: CocosAccountLifecycleFieldView["key"]) => void) | undefined;
   private onRequestAccountFlow: (() => void) | undefined;
   private onConfirmAccountFlow: (() => void) | undefined;
+  private onToggleAccountMinorProtection: (() => void) | undefined;
+  private onBindWechatAccount: (() => void) | undefined;
   private onCancelAccountFlow: (() => void) | undefined;
   private onOpenCampaign: (() => void) | undefined;
   private onOpenConfigCenter: (() => void) | undefined;
@@ -268,6 +279,8 @@ export class VeilLobbyPanel extends Component {
     this.onEditAccountFlowField = options.onEditAccountFlowField;
     this.onRequestAccountFlow = options.onRequestAccountFlow;
     this.onConfirmAccountFlow = options.onConfirmAccountFlow;
+    this.onToggleAccountMinorProtection = options.onToggleAccountMinorProtection;
+    this.onBindWechatAccount = options.onBindWechatAccount;
     this.onCancelAccountFlow = options.onCancelAccountFlow;
     this.onOpenCampaign = options.onOpenCampaign;
     this.onOpenConfigCenter = options.onOpenConfigCenter;
@@ -2227,20 +2240,22 @@ export class VeilLobbyPanel extends Component {
     centerX: number,
     topY: number,
     width: number,
-    flow: CocosAccountLifecyclePanelView,
+    flow: CocosAccountLifecyclePanelView | CocosAccountRegistrationPanelView,
     entering: boolean
   ): void {
+    const registrationFlow = isRegistrationFlowView(flow) ? flow : null;
     let cursorY = this.renderCard(
       "LobbyAccountFlowHeader",
       centerX,
       topY,
       width,
-      118,
+      registrationFlow?.status ? 142 : 118,
       [
         flow.title,
         flow.intro,
         `就绪状态 ${formatAccountReadinessStatus(flow.readiness.status)} · ${flow.readiness.summary}`,
-        `${flow.readiness.detail} ${flow.deliveryHint}`.trim()
+        `${flow.readiness.detail} ${flow.deliveryHint}`.trim(),
+        ...(registrationFlow?.status ? [registrationFlow.status.message] : [])
       ],
       {
         fill: TITLE_FILL,
@@ -2275,6 +2290,82 @@ export class VeilLobbyPanel extends Component {
       );
     });
 
+    if (registrationFlow) {
+      registrationFlow.identities.forEach((identity, index) => {
+        cursorY = this.renderCard(
+          `LobbyAccountFlowIdentity-${index}`,
+          centerX,
+          cursorY,
+          width,
+          70,
+          [identity.label, identity.status.toUpperCase(), identity.detail],
+          {
+            fill: FIELD_FILL,
+            stroke: new Color(224, 235, 246, 52),
+            accent:
+              identity.status === "bound"
+                ? new Color(128, 192, 152, 204)
+                : identity.status === "available"
+                  ? new Color(118, 164, 224, 204)
+                  : new Color(176, 142, 108, 196)
+          },
+          null,
+          13,
+          17
+        );
+      });
+      this.hideExtraCards("LobbyAccountFlowIdentity-", registrationFlow.identities.length);
+
+      if (registrationFlow.minorProtection) {
+        cursorY = this.renderCard(
+          "LobbyAccountFlowMinorProtection",
+          centerX,
+          cursorY,
+          width,
+          70,
+          [
+            registrationFlow.minorProtection.label,
+            registrationFlow.minorProtection.value,
+            registrationFlow.minorProtection.detail
+          ],
+          {
+            fill: FIELD_FILL,
+            stroke: new Color(224, 235, 246, 52),
+            accent: new Color(132, 180, 162, 204)
+          },
+          entering ? null : this.onToggleAccountMinorProtection ?? null,
+          13,
+          17
+        );
+
+        this.renderActionButton(
+          "LobbyAccountFlowMinorProtectionToggle",
+          centerX,
+          cursorY - 16,
+          width,
+          28,
+          registrationFlow.minorProtectionAction?.label ?? "切换年龄声明",
+          {
+            fill: ACTION_ACCOUNT,
+            stroke: new Color(228, 236, 248, 120),
+            accent: new Color(220, 230, 244, 112)
+          },
+          entering ? null : this.onToggleAccountMinorProtection ?? null
+        );
+        cursorY -= 50;
+      }
+    } else {
+      this.hideExtraCards("LobbyAccountFlowIdentity-", 0);
+      const minorProtectionNode = this.node.getChildByName("LobbyAccountFlowMinorProtection");
+      if (minorProtectionNode) {
+        minorProtectionNode.active = false;
+      }
+      const minorProtectionToggleNode = this.node.getChildByName("LobbyAccountFlowMinorProtectionToggle");
+      if (minorProtectionToggleNode) {
+        minorProtectionToggleNode.active = false;
+      }
+    }
+
     this.renderActionButton(
       "LobbyAccountFlowRequest",
       centerX,
@@ -2304,9 +2395,23 @@ export class VeilLobbyPanel extends Component {
       entering ? null : this.onConfirmAccountFlow ?? null
     );
     this.renderActionButton(
-      "LobbyAccountFlowCancel",
+      "LobbyAccountFlowBindWechat",
       centerX,
       cursorY - 84,
+      width,
+      28,
+      registrationFlow ? registrationFlow.bindWechatAction.label : "当前流程不支持微信绑定",
+      {
+        fill: ACTION_ACCOUNT_REVIEW_ACTIVE,
+        stroke: new Color(228, 244, 229, 124),
+        accent: new Color(226, 244, 230, 116)
+      },
+      registrationFlow && !entering && registrationFlow.bindWechatAction.enabled ? this.onBindWechatAccount ?? null : null
+    );
+    this.renderActionButton(
+      "LobbyAccountFlowCancel",
+      centerX,
+      cursorY - 118,
       width,
       28,
       "收起流程面板",
@@ -2324,11 +2429,16 @@ export class VeilLobbyPanel extends Component {
       "LobbyAccountFlowHeader",
       "LobbyAccountFlowRequest",
       "LobbyAccountFlowConfirm",
+      "LobbyAccountFlowBindWechat",
       "LobbyAccountFlowCancel",
+      "LobbyAccountFlowMinorProtection",
+      "LobbyAccountFlowMinorProtectionToggle",
       "LobbyAccountFlowField-loginId",
       "LobbyAccountFlowField-displayName",
       "LobbyAccountFlowField-token",
-      "LobbyAccountFlowField-password"
+      "LobbyAccountFlowField-password",
+      "LobbyAccountFlowIdentity-0",
+      "LobbyAccountFlowIdentity-1"
     ];
     names.forEach((name) => {
       const node = this.node.getChildByName(name);

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -53,6 +53,7 @@ import {
   loadCocosPlayerProgressionSnapshot,
   loadCocosSeasonProgress,
   loginCocosGuestAuthSession,
+  loginCocosWechatAuthSession,
   logoutCurrentCocosAuthSession,
   postCocosPlayerReferral,
   readPreferredCocosDisplayName,
@@ -105,8 +106,14 @@ import {
   buildCocosAccountLifecyclePanelView,
   type CocosAccountLifecycleDeliveryMode,
   type CocosAccountLifecycleDraft,
-  type CocosAccountLifecycleKind
+  type CocosAccountLifecycleKind,
+  type CocosAccountLifecyclePanelView
 } from "./cocos-account-lifecycle.ts";
+import {
+  buildCocosAccountRegistrationPanelView,
+  type CocosAccountRegistrationPanelView,
+  type CocosWechatMinorProtectionSelection
+} from "./cocos-account-registration.ts";
 import { VeilMapBoard } from "./VeilMapBoard.ts";
 import { buildMapFeedbackEntriesFromUpdate, buildObjectPulseEntriesFromUpdate } from "./cocos-map-visuals.ts";
 import { getPlaceholderSpriteAssetUsageSummary } from "./cocos-placeholder-sprites.ts";
@@ -458,6 +465,7 @@ export class VeilRoot extends Component {
   private registrationPassword = "";
   private registrationDeliveryMode: CocosAccountLifecycleDeliveryMode = "idle";
   private registrationExpiresAt = "";
+  private wechatMinorProtectionSelection: CocosWechatMinorProtectionSelection = "unknown";
   private recoveryToken = "";
   private recoveryPassword = "";
   private recoveryDeliveryMode: CocosAccountLifecycleDeliveryMode = "idle";
@@ -1031,6 +1039,12 @@ export class VeilRoot extends Component {
       },
       onConfirmAccountFlow: () => {
         void this.confirmActiveAccountFlow();
+      },
+      onToggleAccountMinorProtection: () => {
+        this.toggleWechatMinorProtectionSelection();
+      },
+      onBindWechatAccount: () => {
+        void this.bindWechatIdentityFromLobbyAccountFlow();
       },
       onCancelAccountFlow: () => {
         this.closeLobbyAccountFlow();
@@ -4518,21 +4532,17 @@ export class VeilRoot extends Component {
     this.renderView();
 
     try {
-      const authSession = await loginWithCocosProvider(
-        this.remoteUrl,
-        {
-          provider: "wechat-mini-game",
-          playerId: this.playerId,
-          displayName: this.displayName || this.playerId
-        },
-        {
-          storage,
-          wx: (globalThis as { wx?: { login?: ((options: unknown) => void) | undefined } }).wx ?? null,
-          config: this.loginRuntimeConfig,
-          authToken: this.authToken,
-          privacyConsentAccepted: this.privacyConsentAccepted
-        }
-      );
+      const authSession = await loginCocosWechatAuthSession(this.remoteUrl, this.playerId, this.displayName || this.playerId, {
+        storage,
+        wx: (globalThis as { wx?: { login?: ((options: unknown) => void) | undefined } }).wx ?? null,
+        exchangePath: this.loginRuntimeConfig.wechatMiniGame.exchangePath,
+        ...(this.loginRuntimeConfig.wechatMiniGame.mockCode ? { mockCode: this.loginRuntimeConfig.wechatMiniGame.mockCode } : {}),
+        ...(this.authToken ? { authToken: this.authToken } : {}),
+        ...(this.privacyConsentAccepted ? { privacyConsentAccepted: true } : {}),
+        ...(this.activeAccountFlow === "registration" && this.wechatMinorProtectionSelection !== "unknown"
+          ? { minorProtection: { isAdult: this.wechatMinorProtectionSelection === "adult" } }
+          : {})
+      });
       this.authToken = authSession.token ?? null;
       this.playerId = authSession.playerId;
       this.displayName = authSession.displayName;
@@ -4540,6 +4550,10 @@ export class VeilRoot extends Component {
       this.authProvider = authSession.provider ?? "wechat-mini-game";
       this.loginId = authSession.loginId ?? "";
       this.sessionSource = authSession.source;
+      if (this.activeAccountFlow === "registration") {
+        this.activeAccountFlow = null;
+        this.wechatMinorProtectionSelection = "unknown";
+      }
       this.syncWechatShareBridge();
       this.lobbyStatus = "微信小游戏登录已连通，正在同步会话并进入房间...";
       saveCocosLobbyPreferences(authSession.playerId, this.roomId, undefined, storage);
@@ -4766,10 +4780,52 @@ export class VeilRoot extends Component {
     await this.syncLobbyBootstrap();
   }
 
-  private buildActiveAccountFlowPanelView() {
+  private buildActiveAccountFlowPanelView(): CocosAccountLifecyclePanelView | CocosAccountRegistrationPanelView | null {
     const draft = this.buildActiveAccountLifecycleDraft();
     if (!draft) {
       return null;
+    }
+
+    if (draft.kind === "registration") {
+      const registrationDraft: CocosAccountLifecycleDraft & { kind: "registration" } = {
+        ...draft,
+        kind: "registration"
+      };
+      const wechatProvider = this.loginProviders.find((provider) => provider.id === "wechat-mini-game");
+      const registeredAccount =
+        this.authMode === "account" || Boolean(this.lobbyAccountProfile.credentialBoundAt)
+          ? {
+              ...(this.lobbyAccountProfile.loginId ?? this.loginId
+                ? { loginId: this.lobbyAccountProfile.loginId ?? this.loginId }
+                : {}),
+              ...(this.lobbyAccountProfile.credentialBoundAt
+                ? { credentialBoundAt: this.lobbyAccountProfile.credentialBoundAt }
+                : {}),
+              provider: this.authProvider
+            }
+          : null;
+      return buildCocosAccountRegistrationPanelView({
+        draft: registrationDraft,
+        privacyConsentAccepted: this.privacyConsentAccepted,
+        submitState: this.lobbyEntering
+          ? this.activeAccountFlow === "registration" && this.authProvider === "wechat-mini-game"
+            ? "binding-wechat"
+            : this.registrationToken && this.registrationPassword
+              ? "confirming-registration"
+              : "requesting-token"
+          : this.authMode === "account" && !this.activeAccountFlow
+            ? "success"
+            : "idle",
+        statusMessage: this.lobbyStatus,
+        showValidationErrors: false,
+        ...(registeredAccount ? { registeredAccount } : {}),
+        wechat: {
+          supported: this.runtimePlatform === "wechat-game",
+          available: wechatProvider?.available === true,
+          bound: this.authProvider === "wechat-mini-game",
+          minorProtectionSelection: this.wechatMinorProtectionSelection
+        }
+      });
     }
 
     return buildCocosAccountLifecyclePanelView(draft);
@@ -4806,6 +4862,7 @@ export class VeilRoot extends Component {
     this.loginId = this.loginId.trim().toLowerCase();
     if (kind === "registration" && !this.registrationDisplayName.trim()) {
       this.registrationDisplayName = this.displayName || this.loginId;
+      this.wechatMinorProtectionSelection = "unknown";
     }
     this.lobbyStatus =
       kind === "registration"
@@ -4815,9 +4872,44 @@ export class VeilRoot extends Component {
   }
 
   private closeLobbyAccountFlow(): void {
+    this.wechatMinorProtectionSelection = "unknown";
     this.activeAccountFlow = null;
     this.lobbyStatus = "已收起账号生命周期面板。";
     this.renderView();
+  }
+
+  private toggleWechatMinorProtectionSelection(): void {
+    if (this.activeAccountFlow !== "registration") {
+      return;
+    }
+
+    this.wechatMinorProtectionSelection =
+      this.wechatMinorProtectionSelection === "unknown"
+        ? "adult"
+        : this.wechatMinorProtectionSelection === "adult"
+          ? "minor"
+          : "adult";
+    this.lobbyStatus =
+      this.wechatMinorProtectionSelection === "adult"
+        ? "已声明为成年人，绑定微信时将按成年人策略提交。"
+        : "已声明为未成年人，绑定微信时将按未成年人策略提交。";
+    this.renderView();
+  }
+
+  private async bindWechatIdentityFromLobbyAccountFlow(): Promise<void> {
+    if (this.activeAccountFlow !== "registration" || this.authMode !== "account") {
+      this.lobbyStatus = "需先完成正式注册或登录正式账号，才能绑定微信身份。";
+      this.renderView();
+      return;
+    }
+
+    if (this.wechatMinorProtectionSelection === "unknown") {
+      this.lobbyStatus = "绑定微信身份前，请先设置未成年人保护声明。";
+      this.renderView();
+      return;
+    }
+
+    await this.loginLobbyWechatMiniGame();
   }
 
   private togglePrivacyConsent(): void {

--- a/apps/cocos-client/assets/scripts/cocos-account-registration.ts
+++ b/apps/cocos-client/assets/scripts/cocos-account-registration.ts
@@ -1,0 +1,283 @@
+import {
+  validateAccountLifecycleConfirm,
+  validateAccountLifecycleRequest,
+  type AccountLifecycleValidationError
+} from "../../../../packages/shared/src/index.ts";
+import {
+  buildCocosAccountLifecyclePanelView,
+  type CocosAccountLifecycleDraft,
+  type CocosAccountLifecyclePanelView
+} from "./cocos-account-lifecycle.ts";
+
+export type CocosAccountRegistrationSubmitState =
+  | "idle"
+  | "requesting-token"
+  | "confirming-registration"
+  | "binding-wechat"
+  | "success";
+
+export type CocosWechatMinorProtectionSelection = "unknown" | "adult" | "minor";
+
+export interface CocosAccountRegistrationIdentityView {
+  id: "account-password" | "wechat-mini-game";
+  label: string;
+  status: "bound" | "available" | "blocked";
+  detail: string;
+}
+
+export interface CocosAccountRegistrationMinorProtectionView {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+export interface CocosAccountRegistrationStatusView {
+  tone: "neutral" | "positive" | "negative";
+  message: string;
+}
+
+export interface CocosAccountRegistrationActionView {
+  label: string;
+  enabled: boolean;
+  detail: string;
+}
+
+export interface CocosAccountRegistrationPanelView extends CocosAccountLifecyclePanelView {
+  identities: CocosAccountRegistrationIdentityView[];
+  validationError: AccountLifecycleValidationError | null;
+  status: CocosAccountRegistrationStatusView | null;
+  minorProtection: CocosAccountRegistrationMinorProtectionView | null;
+  minorProtectionAction: CocosAccountRegistrationActionView | null;
+  bindWechatAction: CocosAccountRegistrationActionView;
+}
+
+export interface CocosAccountRegistrationPanelInput {
+  draft: CocosAccountLifecycleDraft & { kind: "registration" };
+  privacyConsentAccepted: boolean;
+  submitState?: CocosAccountRegistrationSubmitState;
+  statusMessage?: string | null;
+  showValidationErrors?: boolean;
+  registeredAccount?: {
+    loginId?: string;
+    credentialBoundAt?: string;
+    provider?: "guest" | "account-password" | "wechat-mini-game";
+  };
+  wechat?: {
+    supported: boolean;
+    available: boolean;
+    bound: boolean;
+    minorProtectionSelection?: CocosWechatMinorProtectionSelection;
+  };
+}
+
+function resolveValidationError(input: CocosAccountRegistrationPanelInput): AccountLifecycleValidationError | null {
+  if (!input.showValidationErrors) {
+    return null;
+  }
+
+  return (
+    validateAccountLifecycleConfirm("registration", {
+      loginId: input.draft.loginId,
+      token: input.draft.token,
+      password: input.draft.password,
+      privacyConsentAccepted: input.privacyConsentAccepted
+    }) ?? validateAccountLifecycleRequest("registration", input.draft.loginId)
+  );
+}
+
+function resolveStatus(input: CocosAccountRegistrationPanelInput): CocosAccountRegistrationStatusView | null {
+  const submitState = input.submitState ?? "idle";
+  const trimmedStatus = input.statusMessage?.trim();
+  const validationError = resolveValidationError(input);
+
+  if (submitState === "requesting-token") {
+    return {
+      tone: "neutral",
+      message: "正在申请注册令牌..."
+    };
+  }
+
+  if (submitState === "confirming-registration") {
+    return {
+      tone: "neutral",
+      message: "正在确认正式注册并创建账号会话..."
+    };
+  }
+
+  if (submitState === "binding-wechat") {
+    return {
+      tone: "neutral",
+      message: "正在绑定微信小游戏身份..."
+    };
+  }
+
+  if (submitState === "success") {
+    return {
+      tone: "positive",
+      message: trimmedStatus || "正式账号流程已完成，可继续进入房间或查看已绑定身份。"
+    };
+  }
+
+  if (validationError) {
+    return {
+      tone: "negative",
+      message: validationError.message
+    };
+  }
+
+  if (trimmedStatus) {
+    return {
+      tone: "neutral",
+      message: trimmedStatus
+    };
+  }
+
+  return null;
+}
+
+function buildIdentityViews(input: CocosAccountRegistrationPanelInput): CocosAccountRegistrationIdentityView[] {
+  const registeredLoginId = input.registeredAccount?.loginId?.trim().toLowerCase();
+  const draftLoginId = input.draft.loginId.trim().toLowerCase();
+  const credentialBoundAt = input.registeredAccount?.credentialBoundAt?.trim();
+  const wechatBound = input.wechat?.bound === true;
+
+  return [
+    {
+      id: "account-password",
+      label: "口令账号",
+      status: registeredLoginId ? "bound" : "available",
+      detail: registeredLoginId
+        ? `当前正式账号为 ${registeredLoginId}${credentialBoundAt ? ` · 绑定于 ${credentialBoundAt}` : ""}。`
+        : draftLoginId
+          ? `已草拟登录 ID ${draftLoginId}，填写注册令牌和口令后即可创建正式账号。`
+          : "填写登录 ID、注册令牌和口令后即可创建正式账号。"
+    },
+    {
+      id: "wechat-mini-game",
+      label: "微信小游戏身份",
+      status: wechatBound
+        ? "bound"
+        : input.wechat?.available
+          ? "available"
+          : "blocked",
+      detail: wechatBound
+        ? "当前会话已识别到微信小游戏身份接入。"
+        : !input.wechat?.supported
+          ? "仅微信小游戏运行时支持绑定微信身份。"
+          : !input.wechat?.available
+            ? "当前运行壳未暴露 wx.login()，暂时无法完成微信绑定。"
+            : !registeredLoginId
+              ? "需先完成正式注册，之后即可把当前微信小游戏身份绑定到该账号。"
+              : "可把当前微信小游戏身份绑定到这份正式账号，后续可直接使用微信进入。"
+    }
+  ];
+}
+
+function buildMinorProtectionView(
+  input: CocosAccountRegistrationPanelInput
+): Pick<CocosAccountRegistrationPanelView, "minorProtection" | "minorProtectionAction"> {
+  if (!input.wechat?.available || input.wechat.bound) {
+    return {
+      minorProtection: null,
+      minorProtectionAction: null
+    };
+  }
+
+  const selection = input.wechat.minorProtectionSelection ?? "unknown";
+  return {
+    minorProtection: {
+      label: "未成年人保护声明",
+      value:
+        selection === "adult"
+          ? "已声明为成年人"
+          : selection === "minor"
+            ? "已声明为未成年人"
+            : "尚未声明",
+      detail:
+        selection === "unknown"
+          ? "绑定微信身份前，需要声明是否为成年人；该信息会一并提交给服务端的防沉迷策略。"
+          : "再次点击可切换成年人 / 未成年人声明。"
+    },
+    minorProtectionAction: {
+      label:
+        selection === "adult"
+          ? "切换为未成年人"
+          : selection === "minor"
+            ? "切换为成年人"
+            : "设置年龄声明",
+      enabled: input.submitState !== "binding-wechat",
+      detail: "用于微信小游戏身份绑定时的未成年人保护信息。"
+    }
+  };
+}
+
+function buildBindWechatAction(input: CocosAccountRegistrationPanelInput): CocosAccountRegistrationActionView {
+  if (input.wechat?.bound) {
+    return {
+      label: "微信身份已绑定",
+      enabled: false,
+      detail: "当前小游戏身份已经接入这份账号。"
+    };
+  }
+
+  if (!input.wechat?.supported) {
+    return {
+      label: "仅小游戏环境可绑定微信",
+      enabled: false,
+      detail: "浏览器调试壳不支持 wx.login()。"
+    };
+  }
+
+  if (!input.wechat.available) {
+    return {
+      label: "当前壳未暴露微信登录",
+      enabled: false,
+      detail: "需要微信小游戏壳提供 wx.login()。"
+    };
+  }
+
+  const registeredLoginId = input.registeredAccount?.loginId?.trim().toLowerCase();
+  if (!registeredLoginId) {
+    return {
+      label: "注册后再绑定微信",
+      enabled: false,
+      detail: "需先创建正式账号。"
+    };
+  }
+
+  if ((input.wechat.minorProtectionSelection ?? "unknown") === "unknown") {
+    return {
+      label: "先设置年龄声明",
+      enabled: false,
+      detail: "绑定微信身份前需完成未成年人保护声明。"
+    };
+  }
+
+  return {
+    label: input.submitState === "binding-wechat" ? "绑定中..." : "绑定当前微信身份",
+    enabled: input.submitState !== "binding-wechat",
+    detail: "完成后可直接用微信小游戏身份进入当前账号。"
+  };
+}
+
+export function buildCocosAccountRegistrationPanelView(
+  input: CocosAccountRegistrationPanelInput
+): CocosAccountRegistrationPanelView {
+  const base = buildCocosAccountLifecyclePanelView(input.draft);
+  const status = resolveStatus(input);
+  const validationError = resolveValidationError(input);
+  const identities = buildIdentityViews(input);
+  const { minorProtection, minorProtectionAction } = buildMinorProtectionView(input);
+  const bindWechatAction = buildBindWechatAction(input);
+
+  return {
+    ...base,
+    intro: "先创建正式账号，再按需绑定当前微信小游戏身份；已绑定身份会在这里汇总展示。",
+    identities,
+    validationError,
+    status,
+    minorProtection,
+    minorProtectionAction,
+    bindWechatAction
+  };
+}

--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -2054,6 +2054,9 @@ export async function loginCocosWechatAuthSession(
     mockCode?: string;
     authToken?: string | null;
     privacyConsentAccepted?: boolean;
+    minorProtection?: {
+      isAdult: boolean;
+    };
   }
 ): Promise<CocosStoredAuthSession> {
   const normalizedPlayerId = normalizePlayerId(playerId) || createCocosGuestPlayerId();
@@ -2088,7 +2091,8 @@ export async function loginCocosWechatAuthSession(
         playerId: normalizedPlayerId,
         displayName: profile.displayName,
         ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : {}),
-        ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {})
+        ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {}),
+        ...(options?.minorProtection ? { isAdult: options.minorProtection.isAdult } : {})
       })
     },
     options?.fetchImpl

--- a/apps/cocos-client/test/cocos-account-registration.test.ts
+++ b/apps/cocos-client/test/cocos-account-registration.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCocosAccountRegistrationPanelView } from "../assets/scripts/cocos-account-registration.ts";
+
+function createDraft(overrides: Partial<Parameters<typeof buildCocosAccountRegistrationPanelView>[0]["draft"]> = {}) {
+  return {
+    kind: "registration" as const,
+    loginId: "",
+    displayName: "",
+    token: "",
+    password: "",
+    deliveryMode: "idle" as const,
+    ...overrides
+  };
+}
+
+test("buildCocosAccountRegistrationPanelView reports the empty registration form", () => {
+  const view = buildCocosAccountRegistrationPanelView({
+    draft: createDraft(),
+    privacyConsentAccepted: false,
+    showValidationErrors: true,
+    wechat: {
+      supported: true,
+      available: true,
+      bound: false,
+      minorProtectionSelection: "unknown"
+    }
+  });
+
+  assert.equal(view.readiness.status, "missing");
+  assert.equal(view.validationError?.field, "loginId");
+  assert.equal(view.status?.tone, "negative");
+  assert.match(view.status?.message ?? "", /登录 ID/);
+  assert.equal(view.identities[0]?.status, "available");
+  assert.equal(view.bindWechatAction.enabled, false);
+});
+
+test("buildCocosAccountRegistrationPanelView surfaces validation errors for malformed registration drafts", () => {
+  const view = buildCocosAccountRegistrationPanelView({
+    draft: createDraft({
+      loginId: "BAD ID",
+      token: "dev-registration-token",
+      password: "hunter2"
+    }),
+    privacyConsentAccepted: true,
+    showValidationErrors: true,
+    wechat: {
+      supported: true,
+      available: true,
+      bound: false,
+      minorProtectionSelection: "adult"
+    }
+  });
+
+  assert.equal(view.validationError?.field, "loginId");
+  assert.match(view.validationError?.message ?? "", /3-40 位小写字母/);
+  assert.equal(view.status?.tone, "negative");
+});
+
+test("buildCocosAccountRegistrationPanelView disables submission actions while work is in progress", () => {
+  const view = buildCocosAccountRegistrationPanelView({
+    draft: createDraft({
+      loginId: "veil-ranger",
+      displayName: "暮潮守望",
+      token: "dev-registration-token",
+      password: "hunter2",
+      deliveryMode: "dev-token"
+    }),
+    privacyConsentAccepted: true,
+    submitState: "binding-wechat",
+    registeredAccount: {
+      loginId: "veil-ranger",
+      credentialBoundAt: "2026-04-10T07:00:00.000Z",
+      provider: "account-password"
+    },
+    wechat: {
+      supported: true,
+      available: true,
+      bound: false,
+      minorProtectionSelection: "minor"
+    }
+  });
+
+  assert.equal(view.status?.tone, "neutral");
+  assert.match(view.status?.message ?? "", /绑定微信小游戏身份/);
+  assert.equal(view.minorProtectionAction?.enabled, false);
+  assert.equal(view.bindWechatAction.enabled, false);
+  assert.equal(view.bindWechatAction.label, "绑定中...");
+});
+
+test("buildCocosAccountRegistrationPanelView exposes bound identities after registration succeeds", () => {
+  const view = buildCocosAccountRegistrationPanelView({
+    draft: createDraft({
+      loginId: "veil-ranger",
+      displayName: "暮潮守望",
+      token: "dev-registration-token",
+      password: "hunter2",
+      deliveryMode: "dev-token"
+    }),
+    privacyConsentAccepted: true,
+    submitState: "success",
+    statusMessage: "正式账号注册成功，微信身份已绑定。",
+    registeredAccount: {
+      loginId: "veil-ranger",
+      credentialBoundAt: "2026-04-10T07:00:00.000Z",
+      provider: "wechat-mini-game"
+    },
+    wechat: {
+      supported: true,
+      available: true,
+      bound: true,
+      minorProtectionSelection: "adult"
+    }
+  });
+
+  assert.equal(view.status?.tone, "positive");
+  assert.equal(view.identities.map((identity) => identity.status).join(","), "bound,bound");
+  assert.equal(view.bindWechatAction.label, "微信身份已绑定");
+  assert.equal(view.minorProtection, null);
+});

--- a/apps/cocos-client/test/cocos-wechat-account-bind.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-account-bind.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loginCocosWechatAuthSession } from "../assets/scripts/cocos-lobby.ts";
+
+test("cocos wechat auth helper forwards minor-protection age declaration when binding identity", async () => {
+  let requestedBody = "";
+
+  await loginCocosWechatAuthSession("http://127.0.0.1:2567", "wechat-player", "雾桥旅人", {
+    fetchImpl: async (_input, init) => {
+      requestedBody = String(init?.body ?? "");
+      return new Response(
+        JSON.stringify({
+          session: {
+            token: "wechat.token",
+            playerId: "wechat-player",
+            displayName: "雾桥旅人",
+            authMode: "account",
+            provider: "wechat-mini-game",
+            loginId: "veil-ranger"
+          }
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      );
+    },
+    authToken: "account.token",
+    privacyConsentAccepted: true,
+    minorProtection: {
+      isAdult: false
+    },
+    wx: {
+      login: ({ success }) => {
+        success?.({ code: "wx-dev-code" });
+      }
+    }
+  });
+
+  assert.match(requestedBody, /"privacyConsentAccepted":true/);
+  assert.match(requestedBody, /"isAdult":false/);
+});


### PR DESCRIPTION
## Summary
- add a dedicated Cocos account registration view model and surface it from the primary lobby panel
- expose current bound identities plus an explicit WeChat identity bind action in the primary client
- wire a minor-protection age declaration into the WeChat bind request and cover the new registration states with focused tests

Closes #1111

## Validation
- `node --import tsx --test ./apps/cocos-client/test/cocos-account-registration.test.ts ./apps/cocos-client/test/cocos-wechat-account-bind.test.ts ./apps/cocos-client/test/cocos-account-lifecycle.test.ts`
- `npm run typecheck:cocos`