### PR TITLE
[FEAT] by claude: wire phase2-verdant-vale into Cocos world-config

### DIFF
--- a/apps/cocos-client/assets/scripts/project-shared/world-config.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/world-config.ts
@@ -5,6 +5,7 @@ import defaultBuildingUpgradeConfig from "../../../../../configs/building-upgrad
 import defaultHeroSkillTreesConfig from "../../../../../configs/hero-skill-trees-full.json";
 import contestedBasinMapObjectsConfig from "../../../../../configs/phase2-map-objects-contested-basin.json";
 import frontierExpandedMapObjectsConfig from "../../../../../configs/phase2-map-objects-frontier-expanded.json";
+import verdantValeMapObjectsConfig from "../../../../../configs/phase2-map-objects-verdant-vale.json";
 import amberFieldsMapObjectsConfig from "../../../../../configs/phase1-map-objects-amber-fields.json";
 import ashpeakAscentMapObjectsConfig from "../../../../../configs/phase1-map-objects-ashpeak-ascent.json";
 import bogfenCrossingMapObjectsConfig from "../../../../../configs/phase1-map-objects-bogfen-crossing.json";
@@ -24,6 +25,7 @@ import ashpeakAscentWorldConfig from "../../../../../configs/phase1-world-ashpea
 import bogfenCrossingWorldConfig from "../../../../../configs/phase1-world-bogfen-crossing.json";
 import contestedBasinWorldConfig from "../../../../../configs/phase2-contested-basin.json";
 import frontierExpandedWorldConfig from "../../../../../configs/phase2-frontier-expanded.json";
+import verdantValeWorldConfig from "../../../../../configs/phase2-world-verdant-vale.json";
 import frontierBasinWorldConfig from "../../../../../configs/phase1-world-frontier-basin.json";
 import frostwatchRidgeWorldConfig from "../../../../../configs/phase1-world-frostwatch-ridge.json";
 import highlandReachWorldConfig from "../../../../../configs/phase1-world-highland-reach.json";
@@ -101,6 +103,7 @@ export const ASHPEAK_ASCENT_MAP_VARIANT_ID = "ashpeak_ascent";
 export const THORNWALL_DIVIDE_MAP_VARIANT_ID = "thornwall_divide";
 export const CONTESTED_BASIN_MAP_VARIANT_ID = "contested_basin";
 export const PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID = "phase2_frontier_expanded";
+export const PHASE2_VERDANT_VALE_MAP_VARIANT_ID = "phase2_verdant_vale";
 
 export interface RuntimeConfigBundle {
   world: WorldGenerationConfig;
@@ -820,7 +823,8 @@ function getAvailableMapVariantIds(): string[] {
     ASHPEAK_ASCENT_MAP_VARIANT_ID,
     THORNWALL_DIVIDE_MAP_VARIANT_ID,
     CONTESTED_BASIN_MAP_VARIANT_ID,
-    PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
+    PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID,
+    PHASE2_VERDANT_VALE_MAP_VARIANT_ID
   ];
 }
 
@@ -848,7 +852,8 @@ export function resolveMapVariantIdForRoom(roomId: string, seed = 1001): string 
     requested === ASHPEAK_ASCENT_MAP_VARIANT_ID ||
     requested === THORNWALL_DIVIDE_MAP_VARIANT_ID ||
     requested === CONTESTED_BASIN_MAP_VARIANT_ID ||
-    requested === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
+    requested === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID ||
+    requested === PHASE2_VERDANT_VALE_MAP_VARIANT_ID
   ) {
     return requested;
   }
@@ -890,6 +895,8 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneWorldConfig(contestedBasinWorldConfig as WorldGenerationConfig)
       : mapVariantId === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
         ? cloneWorldConfig(frontierExpandedWorldConfig as WorldGenerationConfig)
+      : mapVariantId === PHASE2_VERDANT_VALE_MAP_VARIANT_ID
+        ? cloneWorldConfig(verdantValeWorldConfig as WorldGenerationConfig)
         : getDefaultWorldConfig();
   const mapObjects =
     mapVariantId === FRONTIER_BASIN_MAP_VARIANT_ID
@@ -920,6 +927,8 @@ export function getRuntimeConfigBundleForRoom(roomId: string, seed = 1001): Room
         ? cloneMapObjectsConfig(contestedBasinMapObjectsConfig as MapObjectsConfig)
       : mapVariantId === PHASE2_FRONTIER_EXPANDED_MAP_VARIANT_ID
         ? cloneMapObjectsConfig(frontierExpandedMapObjectsConfig as MapObjectsConfig)
+      : mapVariantId === PHASE2_VERDANT_VALE_MAP_VARIANT_ID
+        ? cloneMapObjectsConfig(verdantValeMapObjectsConfig as MapObjectsConfig)
         : getDefaultMapObjectsConfig();
 
   validateWorldConfig(world);

--- a/apps/cocos-client/test/cocos-world-config-phase2-verdant-vale.test.ts
+++ b/apps/cocos-client/test/cocos-world-config-phase2-verdant-vale.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PHASE2_VERDANT_VALE_MAP_VARIANT_ID,
+  getRuntimeConfigBundleForRoom,
+  resolveMapVariantIdForRoom
+} from "../assets/scripts/project-shared/index.ts";
+
+test("cocos world config resolves the phase2 verdant-vale map variant", () => {
+  const roomId = "preview-verdant-vale[map:phase2_verdant_vale]";
+
+  assert.equal(resolveMapVariantIdForRoom(roomId, 1001), PHASE2_VERDANT_VALE_MAP_VARIANT_ID);
+
+  const bundle = getRuntimeConfigBundleForRoom(roomId, 1001);
+  assert.equal(bundle.mapVariantId, PHASE2_VERDANT_VALE_MAP_VARIANT_ID);
+  assert.equal(bundle.world.width, 12);
+  assert.equal(bundle.world.height, 10);
+  assert.equal(bundle.mapObjects.buildings.some((building) => building.id === "lumber-camp-vale-1"), true);
+  assert.equal(bundle.mapObjects.neutralArmies.some((army) => army.id === "neutral-grove-sentinels"), true);
+});
+
+test("cocos world config resolves verdant-vale for a match room ID", () => {
+  const roomId = "match-abc[map:phase2_verdant_vale]";
+  assert.equal(resolveMapVariantIdForRoom(roomId, 1001), PHASE2_VERDANT_VALE_MAP_VARIANT_ID);
+  const bundle = getRuntimeConfigBundleForRoom(roomId, 1001);
+  assert.equal(bundle.mapVariantId, PHASE2_VERDANT_VALE_MAP_VARIANT_ID);
+});


### PR DESCRIPTION
Closes #1123

## Summary
- Added imports for `phase2-world-verdant-vale.json` and `phase2-map-objects-verdant-vale.json` in `world-config.ts`
- Exported `PHASE2_VERDANT_VALE_MAP_VARIANT_ID = "phase2_verdant_vale"` constant
- Added verdant-vale to `getAvailableMapVariantIds()` (enables random map selection)
- Added `requested === PHASE2_VERDANT_VALE_MAP_VARIANT_ID` guard in `resolveMapVariantIdForRoom()`
- Added world and mapObjects branches in `getRuntimeConfigBundleForRoom()`
- 2 new tests in `cocos-world-config-phase2-verdant-vale.test.ts` verifying resolution and bundle shape (width=12, height=10, correct buildings and neutral armies)

## Test plan
- [x] `node --import tsx --test ./apps/cocos-client/test/cocos-world-config-phase2-verdant-vale.test.ts` → 2/2 pass
- [x] `npm run typecheck:cocos` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)