### PR TITLE
[TEST] by claude: unit tests for content-pack-map-packs resolvers and player-account mailbox

### DIFF
--- a/packages/shared/test/player-account-mailbox.test.ts
+++ b/packages/shared/test/player-account-mailbox.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isPlayerMailboxMessageExpired,
+  summarizePlayerMailbox,
+  type PlayerMailboxMessage
+} from "../src/index.ts";
+
+const NOW = new Date("2026-04-10T12:00:00.000Z");
+const PAST = "2026-01-01T00:00:00.000Z";
+const FUTURE = "2099-12-31T23:59:59.000Z";
+
+function makeMsg(overrides: Partial<PlayerMailboxMessage> = {}): PlayerMailboxMessage {
+  return {
+    id: "msg-1",
+    kind: "system",
+    title: "Test",
+    body: "Body",
+    sentAt: "2026-04-01T00:00:00.000Z",
+    ...overrides
+  };
+}
+
+// isPlayerMailboxMessageExpired
+
+test("isPlayerMailboxMessageExpired: no expiresAt returns false", () => {
+  assert.equal(isPlayerMailboxMessageExpired({ expiresAt: undefined }, NOW), false);
+});
+
+test("isPlayerMailboxMessageExpired: future expiresAt returns false", () => {
+  assert.equal(isPlayerMailboxMessageExpired({ expiresAt: FUTURE }, NOW), false);
+});
+
+test("isPlayerMailboxMessageExpired: past expiresAt returns true", () => {
+  assert.equal(isPlayerMailboxMessageExpired({ expiresAt: PAST }, NOW), true);
+});
+
+test("isPlayerMailboxMessageExpired: expiresAt exactly equals now returns true", () => {
+  assert.equal(isPlayerMailboxMessageExpired({ expiresAt: NOW.toISOString() }, NOW), true);
+});
+
+test("isPlayerMailboxMessageExpired: invalid date string returns false", () => {
+  assert.equal(isPlayerMailboxMessageExpired({ expiresAt: "not-a-date" }, NOW), false);
+});
+
+test("isPlayerMailboxMessageExpired: empty string expiresAt returns false", () => {
+  assert.equal(isPlayerMailboxMessageExpired({ expiresAt: "" }, NOW), false);
+});
+
+// summarizePlayerMailbox
+
+test("summarizePlayerMailbox: empty mailbox returns all zeros", () => {
+  const summary = summarizePlayerMailbox([], NOW);
+  assert.deepEqual(summary, {
+    totalCount: 0,
+    unreadCount: 0,
+    claimableCount: 0,
+    expiredCount: 0
+  });
+});
+
+test("summarizePlayerMailbox: null mailbox returns all zeros", () => {
+  const summary = summarizePlayerMailbox(null, NOW);
+  assert.deepEqual(summary, {
+    totalCount: 0,
+    unreadCount: 0,
+    claimableCount: 0,
+    expiredCount: 0
+  });
+});
+
+test("summarizePlayerMailbox: 1 unread message (no readAt, no claimedAt, no expiresAt, no grant)", () => {
+  const summary = summarizePlayerMailbox([makeMsg()], NOW);
+  assert.equal(summary.totalCount, 1);
+  assert.equal(summary.unreadCount, 1);
+  assert.equal(summary.claimableCount, 0);
+  assert.equal(summary.expiredCount, 0);
+});
+
+test("summarizePlayerMailbox: 1 read message (has readAt) gives unreadCount 0", () => {
+  const summary = summarizePlayerMailbox([makeMsg({ readAt: "2026-04-05T00:00:00.000Z" })], NOW);
+  assert.equal(summary.totalCount, 1);
+  assert.equal(summary.unreadCount, 0);
+  assert.equal(summary.expiredCount, 0);
+});
+
+test("summarizePlayerMailbox: 1 claimed message gives unreadCount 0 and claimableCount 0", () => {
+  const summary = summarizePlayerMailbox(
+    [makeMsg({ claimedAt: "2026-04-05T00:00:00.000Z", grant: { gems: 100 } })],
+    NOW
+  );
+  assert.equal(summary.totalCount, 1);
+  assert.equal(summary.unreadCount, 0);
+  assert.equal(summary.claimableCount, 0);
+});
+
+test("summarizePlayerMailbox: 1 expired message increments expiredCount and not unreadCount", () => {
+  const summary = summarizePlayerMailbox([makeMsg({ expiresAt: PAST })], NOW);
+  assert.equal(summary.totalCount, 1);
+  assert.equal(summary.expiredCount, 1);
+  assert.equal(summary.unreadCount, 0);
+  assert.equal(summary.claimableCount, 0);
+});
+
+test("summarizePlayerMailbox: 1 message with grant, not claimed, not expired is claimable", () => {
+  const summary = summarizePlayerMailbox([makeMsg({ grant: { gems: 50 } })], NOW);
+  assert.equal(summary.totalCount, 1);
+  assert.equal(summary.claimableCount, 1);
+  assert.equal(summary.expiredCount, 0);
+});
+
+test("summarizePlayerMailbox: 1 message with grant but claimed is not claimable", () => {
+  const summary = summarizePlayerMailbox(
+    [makeMsg({ grant: { gems: 50 }, claimedAt: "2026-04-05T00:00:00.000Z" })],
+    NOW
+  );
+  assert.equal(summary.claimableCount, 0);
+});
+
+test("summarizePlayerMailbox: mixed mailbox with 2 unread + 1 expired + 1 claimable", () => {
+  const messages = [
+    makeMsg({ id: "msg-1" }),
+    makeMsg({ id: "msg-2" }),
+    makeMsg({ id: "msg-3", expiresAt: PAST }),
+    makeMsg({ id: "msg-4", grant: { gems: 75 } })
+  ];
+  const summary = summarizePlayerMailbox(messages, NOW);
+  assert.equal(summary.totalCount, 4);
+  assert.equal(summary.unreadCount, 3); // msg-1, msg-2, msg-4 (unread, not expired, no claimedAt)
+  assert.equal(summary.claimableCount, 1); // msg-4 has grant
+  assert.equal(summary.expiredCount, 1); // msg-3
+});

--- a/scripts/test/content-pack-map-packs.test.ts
+++ b/scripts/test/content-pack-map-packs.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_CONTENT_PACK_MAP_PACK,
+  EXTRA_CONTENT_PACK_MAP_PACKS,
+  resolveContentPackMapPack,
+  resolveExtraContentPackMapPack
+} from "../content-pack-map-packs.ts";
+
+// resolveContentPackMapPack
+
+test("resolveContentPackMapPack returns DEFAULT_CONTENT_PACK_MAP_PACK for 'default'", () => {
+  const result = resolveContentPackMapPack("default");
+  assert.strictEqual(result, DEFAULT_CONTENT_PACK_MAP_PACK);
+});
+
+test("resolveContentPackMapPack returns DEFAULT_CONTENT_PACK_MAP_PACK for alias 'phase1'", () => {
+  const result = resolveContentPackMapPack("phase1");
+  assert.strictEqual(result, DEFAULT_CONTENT_PACK_MAP_PACK);
+});
+
+test("resolveContentPackMapPack trims and lowercases the input ('  DEFAULT  ')", () => {
+  const result = resolveContentPackMapPack("  DEFAULT  ");
+  assert.strictEqual(result, DEFAULT_CONTENT_PACK_MAP_PACK);
+});
+
+test("resolveContentPackMapPack returns frontier-basin definition by id", () => {
+  const result = resolveContentPackMapPack("frontier-basin");
+  const expected = EXTRA_CONTENT_PACK_MAP_PACKS.find((p) => p.id === "frontier-basin");
+  assert.ok(expected, "frontier-basin should exist in EXTRA_CONTENT_PACK_MAP_PACKS");
+  assert.strictEqual(result, expected);
+});
+
+test("resolveContentPackMapPack returns frontier-basin definition by alias 'frontier_basin'", () => {
+  const result = resolveContentPackMapPack("frontier_basin");
+  const expected = EXTRA_CONTENT_PACK_MAP_PACKS.find((p) => p.id === "frontier-basin");
+  assert.ok(expected);
+  assert.strictEqual(result, expected);
+});
+
+test("resolveContentPackMapPack returns stonewatch-fork by alias 'stonewatch'", () => {
+  const result = resolveContentPackMapPack("stonewatch");
+  const expected = EXTRA_CONTENT_PACK_MAP_PACKS.find((p) => p.id === "stonewatch-fork");
+  assert.ok(expected);
+  assert.strictEqual(result, expected);
+});
+
+test("resolveContentPackMapPack returns phase2 (contested-basin) by id 'phase2'", () => {
+  const result = resolveContentPackMapPack("phase2");
+  const expected = EXTRA_CONTENT_PACK_MAP_PACKS.find((p) => p.id === "phase2");
+  assert.ok(expected);
+  assert.strictEqual(result, expected);
+});
+
+test("resolveContentPackMapPack returns phase2 (contested-basin) by alias 'contested_basin'", () => {
+  const result = resolveContentPackMapPack("contested_basin");
+  const expected = EXTRA_CONTENT_PACK_MAP_PACKS.find((p) => p.id === "phase2");
+  assert.ok(expected);
+  assert.strictEqual(result, expected);
+});
+
+test("resolveContentPackMapPack returns verdant-vale pack by id 'phase2-verdant-vale'", () => {
+  const result = resolveContentPackMapPack("phase2-verdant-vale");
+  const expected = EXTRA_CONTENT_PACK_MAP_PACKS.find((p) => p.id === "phase2-verdant-vale");
+  assert.ok(expected);
+  assert.strictEqual(result, expected);
+});
+
+test("resolveContentPackMapPack returns verdant-vale pack by alias 'verdant_vale'", () => {
+  const result = resolveContentPackMapPack("verdant_vale");
+  const expected = EXTRA_CONTENT_PACK_MAP_PACKS.find((p) => p.id === "phase2-verdant-vale");
+  assert.ok(expected);
+  assert.strictEqual(result, expected);
+});
+
+test("resolveContentPackMapPack returns undefined for unknown id", () => {
+  const result = resolveContentPackMapPack("unknown-map");
+  assert.strictEqual(result, undefined);
+});
+
+// resolveExtraContentPackMapPack
+
+test("resolveExtraContentPackMapPack returns undefined for 'default'", () => {
+  const result = resolveExtraContentPackMapPack("default");
+  assert.strictEqual(result, undefined);
+});
+
+test("resolveExtraContentPackMapPack returns undefined for default alias 'phase1'", () => {
+  const result = resolveExtraContentPackMapPack("phase1");
+  assert.strictEqual(result, undefined);
+});
+
+test("resolveExtraContentPackMapPack returns frontier-basin definition", () => {
+  const result = resolveExtraContentPackMapPack("frontier-basin");
+  const expected = EXTRA_CONTENT_PACK_MAP_PACKS.find((p) => p.id === "frontier-basin");
+  assert.ok(expected);
+  assert.strictEqual(result, expected);
+});
+
+test("resolveExtraContentPackMapPack returns undefined for unknown id", () => {
+  const result = resolveExtraContentPackMapPack("unknown");
+  assert.strictEqual(result, undefined);
+});
+
+test("resolved frontier-basin has correct worldFileName and phase", () => {
+  const result = resolveContentPackMapPack("frontier-basin");
+  assert.ok(result, "frontier-basin should resolve");
+  assert.strictEqual(result.worldFileName, "phase1-world-frontier-basin.json");
+  assert.strictEqual(result.phase, "phase1");
+});


### PR DESCRIPTION
Closes #1129
Closes #1131

## Summary
- **content-pack-map-packs**: 16 tests for `resolveContentPackMapPack()` and `resolveExtraContentPackMapPack()` covering canonical IDs, aliases, case-insensitive + whitespace normalization, unknown IDs, and default exclusion
- **player-account mailbox**: 14 tests for `isPlayerMailboxMessageExpired()` (no expiry, future, past, invalid date) and `summarizePlayerMailbox()` (empty, unread, read, claimable, expired, mixed state)

## Test plan
- [x] `scripts/test/content-pack-map-packs.test.ts` → all pass
- [x] `packages/shared/test/player-account-mailbox.test.ts` → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)