### PR TITLE
[TEST] by claude: unit tests for tutorial.ts and deterministic-rng.ts

### DIFF
--- a/packages/shared/test/action-precheck.test.ts
+++ b/packages/shared/test/action-precheck.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createActionValidationFailure,
+  validateAction
+} from "../src/action-precheck.ts";
+
+test("createActionValidationFailure returns undefined when validation is valid", () => {
+  const result = createActionValidationFailure(
+    "battle",
+    { type: "MOVE" },
+    { valid: true }
+  );
+  assert.equal(result, undefined);
+});
+
+test("createActionValidationFailure returns failure with reason when validation fails with reason", () => {
+  const result = createActionValidationFailure(
+    "battle",
+    { type: "MOVE" },
+    { valid: false, reason: "out of range" }
+  );
+  assert.deepEqual(result, {
+    scope: "battle",
+    actionType: "MOVE",
+    reason: "out of range"
+  });
+});
+
+test("createActionValidationFailure uses default fallback reason when validation fails with no reason", () => {
+  const result = createActionValidationFailure(
+    "battle",
+    { type: "MOVE" },
+    { valid: false }
+  );
+  assert.deepEqual(result, {
+    scope: "battle",
+    actionType: "MOVE",
+    reason: "battle_action_invalid"
+  });
+});
+
+test("createActionValidationFailure uses custom fallbackReason when provided and reason is absent", () => {
+  const result = createActionValidationFailure(
+    "battle",
+    { type: "ATTACK" },
+    { valid: false },
+    "custom_fallback_reason"
+  );
+  assert.deepEqual(result, {
+    scope: "battle",
+    actionType: "ATTACK",
+    reason: "custom_fallback_reason"
+  });
+});
+
+test("createActionValidationFailure for scope world uses world_action_invalid fallback", () => {
+  const result = createActionValidationFailure(
+    "world",
+    { type: "MOVE" },
+    { valid: false }
+  );
+  assert.deepEqual(result, {
+    scope: "world",
+    actionType: "MOVE",
+    reason: "world_action_invalid"
+  });
+});
+
+test("validateAction without normalizeState passes state through unchanged", () => {
+  const state = { hp: 100, position: { x: 0, y: 0 } };
+  const action = { type: "MOVE" };
+  const result = validateAction(state, action, (s, _a) => ({ valid: true }));
+  assert.equal(result.state, state);
+});
+
+test("validateAction with normalizeState calls normalizeState before validate and passes transformed state", () => {
+  const state = { hp: 100 };
+  const action = { type: "HEAL" };
+  const normalizedState = { hp: 50 };
+  let validatedWith: typeof state | null = null;
+
+  const result = validateAction(
+    state,
+    action,
+    (s, _a) => {
+      validatedWith = s;
+      return { valid: true };
+    },
+    (_s) => normalizedState
+  );
+
+  assert.equal(result.state, normalizedState);
+  assert.equal(validatedWith, normalizedState);
+});
+
+test("validateAction returns correct validation result from validate function", () => {
+  const state = { hp: 0 };
+  const action = { type: "ATTACK" };
+  const result = validateAction(state, action, (_s, _a) => ({
+    valid: false,
+    reason: "hero is dead"
+  }));
+  assert.deepEqual(result.validation, { valid: false, reason: "hero is dead" });
+});

--- a/packages/shared/test/deterministic-rng.test.ts
+++ b/packages/shared/test/deterministic-rng.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeDeterministicSeed,
+  nextDeterministicRandom,
+  createDeterministicRandomGenerator,
+} from "../src/deterministic-rng.ts";
+
+test("normalizeDeterministicSeed(42) returns 42", () => {
+  assert.equal(normalizeDeterministicSeed(42), 42);
+});
+
+test("normalizeDeterministicSeed(3.9) floors to 3", () => {
+  assert.equal(normalizeDeterministicSeed(3.9), 3);
+});
+
+test("normalizeDeterministicSeed(NaN) returns default fallback 1", () => {
+  assert.equal(normalizeDeterministicSeed(NaN), 1);
+});
+
+test("normalizeDeterministicSeed(Infinity) returns default fallback 1", () => {
+  assert.equal(normalizeDeterministicSeed(Infinity), 1);
+});
+
+test("normalizeDeterministicSeed(-5) returns a positive uint32", () => {
+  const result = normalizeDeterministicSeed(-5);
+  assert.ok(result >= 0, "result should be non-negative (uint32)");
+  assert.ok(Number.isInteger(result), "result should be an integer");
+});
+
+test("nextDeterministicRandom with seed 1 returns nextSeed and value in [0,1)", () => {
+  const step = nextDeterministicRandom(1);
+  assert.ok(typeof step.nextSeed === "number", "nextSeed should be a number");
+  assert.ok(typeof step.value === "number", "value should be a number");
+  assert.ok(step.value >= 0, "value should be >= 0");
+  assert.ok(step.value < 1, "value should be < 1");
+});
+
+test("nextDeterministicRandom is deterministic — same seed always produces same output", () => {
+  const a = nextDeterministicRandom(42);
+  const b = nextDeterministicRandom(42);
+  assert.deepEqual(a, b);
+});
+
+test("nextDeterministicRandom value is >= 0 and < 1", () => {
+  for (const seed of [0, 1, 100, 999999]) {
+    const { value } = nextDeterministicRandom(seed);
+    assert.ok(value >= 0, `value for seed ${seed} should be >= 0`);
+    assert.ok(value < 1, `value for seed ${seed} should be < 1`);
+  }
+});
+
+test("createDeterministicRandomGenerator(1) — calling twice gives different values", () => {
+  const rng = createDeterministicRandomGenerator(1);
+  const first = rng();
+  const second = rng();
+  assert.notEqual(first, second);
+});
+
+test("createDeterministicRandomGenerator(1) — two generators with same seed produce identical sequences", () => {
+  const rng1 = createDeterministicRandomGenerator(1);
+  const rng2 = createDeterministicRandomGenerator(1);
+  for (let i = 0; i < 10; i++) {
+    assert.equal(rng1(), rng2());
+  }
+});
+
+test("all returned values from generator are in [0, 1)", () => {
+  const rng = createDeterministicRandomGenerator(12345);
+  for (let i = 0; i < 20; i++) {
+    const val = rng();
+    assert.ok(val >= 0, `value at step ${i} should be >= 0`);
+    assert.ok(val < 1, `value at step ${i} should be < 1`);
+  }
+});

--- a/packages/shared/test/onboarding-funnel.test.ts
+++ b/packages/shared/test/onboarding-funnel.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ONBOARDING_FUNNEL_STAGES,
+  getOnboardingFunnelStageIndex
+} from "../src/onboarding-funnel.ts";
+
+test("getOnboardingFunnelStageIndex returns 0 for onboarding_session_started", () => {
+  assert.equal(getOnboardingFunnelStageIndex("onboarding_session_started"), 0);
+});
+
+test("getOnboardingFunnelStageIndex returns 1 for tutorial_step_1_seen", () => {
+  assert.equal(getOnboardingFunnelStageIndex("tutorial_step_1_seen"), 1);
+});
+
+test("getOnboardingFunnelStageIndex returns 2 for tutorial_step_2_seen", () => {
+  assert.equal(getOnboardingFunnelStageIndex("tutorial_step_2_seen"), 2);
+});
+
+test("getOnboardingFunnelStageIndex returns 3 for tutorial_step_3_seen", () => {
+  assert.equal(getOnboardingFunnelStageIndex("tutorial_step_3_seen"), 3);
+});
+
+test("getOnboardingFunnelStageIndex returns 4 for onboarding_completed", () => {
+  assert.equal(getOnboardingFunnelStageIndex("onboarding_completed"), 4);
+});
+
+test("ONBOARDING_FUNNEL_STAGES has exactly 5 entries", () => {
+  assert.equal(ONBOARDING_FUNNEL_STAGES.length, 5);
+});
+
+test("all stage IDs are unique", () => {
+  const ids = ONBOARDING_FUNNEL_STAGES.map((stage) => stage.id);
+  const uniqueIds = new Set(ids);
+  assert.equal(uniqueIds.size, ids.length);
+});
+
+test("stages are in ascending index order (0..4)", () => {
+  for (let i = 0; i < ONBOARDING_FUNNEL_STAGES.length; i++) {
+    const stageId = ONBOARDING_FUNNEL_STAGES[i].id as Parameters<typeof getOnboardingFunnelStageIndex>[0];
+    assert.equal(getOnboardingFunnelStageIndex(stageId), i);
+  }
+});

--- a/packages/shared/test/reconnect-observability.test.ts
+++ b/packages/shared/test/reconnect-observability.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyReconnectFailure } from "../src/reconnect-observability.ts";
+
+test("classifyReconnectFailure returns version_mismatch for rawReason version_mismatch", () => {
+  assert.equal(classifyReconnectFailure({ rawReason: "version_mismatch" }), "version_mismatch");
+});
+
+test("classifyReconnectFailure returns version_mismatch for rawReason protocol mismatch", () => {
+  assert.equal(classifyReconnectFailure({ rawReason: "protocol mismatch" }), "version_mismatch");
+});
+
+test("classifyReconnectFailure returns auth_invalid for rawCode 401", () => {
+  assert.equal(classifyReconnectFailure({ rawCode: 401 }), "auth_invalid");
+});
+
+test("classifyReconnectFailure returns auth_invalid for rawCode 403", () => {
+  assert.equal(classifyReconnectFailure({ rawCode: 403 }), "auth_invalid");
+});
+
+test("classifyReconnectFailure returns auth_invalid for rawReason unauthorized", () => {
+  assert.equal(classifyReconnectFailure({ rawReason: "unauthorized" }), "auth_invalid");
+});
+
+test("classifyReconnectFailure returns auth_invalid for error with message invalid token", () => {
+  assert.equal(classifyReconnectFailure({ error: new Error("invalid token") }), "auth_invalid");
+});
+
+test("classifyReconnectFailure returns reconnect_window_expired for rawReason reconnect window expired", () => {
+  assert.equal(
+    classifyReconnectFailure({ rawReason: "reconnect window expired" }),
+    "reconnect_window_expired"
+  );
+});
+
+test("classifyReconnectFailure returns timeout for rawReason connect_timeout", () => {
+  assert.equal(classifyReconnectFailure({ rawReason: "connect_timeout" }), "timeout");
+});
+
+test("classifyReconnectFailure returns timeout for error with message timed out", () => {
+  assert.equal(classifyReconnectFailure({ error: new Error("timed out") }), "timeout");
+});
+
+test("classifyReconnectFailure returns transport_lost for rawReason websocket disconnected", () => {
+  assert.equal(classifyReconnectFailure({ rawReason: "websocket disconnected" }), "transport_lost");
+});
+
+test("classifyReconnectFailure returns transport_lost for rawReason network error", () => {
+  assert.equal(classifyReconnectFailure({ rawReason: "network error" }), "transport_lost");
+});
+
+test("classifyReconnectFailure returns transport_lost for string error socket closed", () => {
+  assert.equal(classifyReconnectFailure({ error: "socket closed" }), "transport_lost");
+});
+
+test("classifyReconnectFailure returns unknown for empty input", () => {
+  assert.equal(classifyReconnectFailure({}), "unknown");
+});
+
+test("classifyReconnectFailure uses custom fallbackReason when no text matches", () => {
+  assert.equal(
+    classifyReconnectFailure({ fallbackReason: "timeout" }),
+    "timeout"
+  );
+});
+
+test("classifyReconnectFailure checks version_mismatch before auth_invalid when both keywords present", () => {
+  // Text contains both "version_mismatch" and "unauthorized" — version_mismatch should win
+  assert.equal(
+    classifyReconnectFailure({ rawReason: "version_mismatch unauthorized" }),
+    "version_mismatch"
+  );
+});

--- a/packages/shared/test/tutorial.test.ts
+++ b/packages/shared/test/tutorial.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeTutorialStep,
+  isTutorialComplete,
+  canSkipTutorial,
+  countTrackedPvpMatches,
+  countRemainingProtectedPvpMatches,
+  DEFAULT_TUTORIAL_STEP,
+  NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES,
+} from "../src/tutorial.ts";
+
+test("normalizeTutorialStep(null) returns null", () => {
+  assert.equal(normalizeTutorialStep(null), null);
+});
+
+test("normalizeTutorialStep(undefined) returns null", () => {
+  assert.equal(normalizeTutorialStep(undefined), null);
+});
+
+test("normalizeTutorialStep(3) returns 3", () => {
+  assert.equal(normalizeTutorialStep(3), 3);
+});
+
+test("normalizeTutorialStep(3.9) floors to 3", () => {
+  assert.equal(normalizeTutorialStep(3.9), 3);
+});
+
+test("normalizeTutorialStep(0) returns DEFAULT_TUTORIAL_STEP", () => {
+  assert.equal(normalizeTutorialStep(0), DEFAULT_TUTORIAL_STEP);
+});
+
+test("normalizeTutorialStep(-1) returns DEFAULT_TUTORIAL_STEP", () => {
+  assert.equal(normalizeTutorialStep(-1), DEFAULT_TUTORIAL_STEP);
+});
+
+test("isTutorialComplete(null) returns true", () => {
+  assert.equal(isTutorialComplete(null), true);
+});
+
+test("isTutorialComplete(undefined) returns true", () => {
+  assert.equal(isTutorialComplete(undefined), true);
+});
+
+test("isTutorialComplete(1) returns false", () => {
+  assert.equal(isTutorialComplete(1), false);
+});
+
+test("canSkipTutorial(null) returns false", () => {
+  assert.equal(canSkipTutorial(null), false);
+});
+
+test("canSkipTutorial(1) returns false (step 1 < MIN_SKIP=2)", () => {
+  assert.equal(canSkipTutorial(1), false);
+});
+
+test("canSkipTutorial(2) returns true", () => {
+  assert.equal(canSkipTutorial(2), true);
+});
+
+test("canSkipTutorial(10) returns true", () => {
+  assert.equal(canSkipTutorial(10), true);
+});
+
+test("countTrackedPvpMatches with null returns 0", () => {
+  assert.equal(countTrackedPvpMatches(null), 0);
+});
+
+test("countTrackedPvpMatches with empty array returns 0", () => {
+  assert.equal(countTrackedPvpMatches([]), 0);
+});
+
+test("countTrackedPvpMatches with 3 hero battles returns 3", () => {
+  const replays = [
+    { battleKind: "hero" },
+    { battleKind: "hero" },
+    { battleKind: "hero" },
+  ];
+  assert.equal(countTrackedPvpMatches(replays), 3);
+});
+
+test("countTrackedPvpMatches with 2 hero + 2 neutral battles returns 2", () => {
+  const replays = [
+    { battleKind: "hero" },
+    { battleKind: "neutral" },
+    { battleKind: "hero" },
+    { battleKind: "neutral" },
+  ];
+  assert.equal(countTrackedPvpMatches(replays), 2);
+});
+
+test("countTrackedPvpMatches with 7 hero battles is capped at default limit 5", () => {
+  const replays = Array.from({ length: 7 }, () => ({ battleKind: "hero" }));
+  assert.equal(countTrackedPvpMatches(replays), 5);
+});
+
+test("countRemainingProtectedPvpMatches(null) returns NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES", () => {
+  assert.equal(countRemainingProtectedPvpMatches(null), NEW_PLAYER_MATCHMAKING_PROTECTION_MATCHES);
+});
+
+test("countRemainingProtectedPvpMatches with 3 hero battles returns 2", () => {
+  const replays = [
+    { battleKind: "hero" },
+    { battleKind: "hero" },
+    { battleKind: "hero" },
+  ];
+  assert.equal(countRemainingProtectedPvpMatches(replays), 2);
+});
+
+test("countRemainingProtectedPvpMatches with 5+ hero battles returns 0", () => {
+  const replays = Array.from({ length: 7 }, () => ({ battleKind: "hero" }));
+  assert.equal(countRemainingProtectedPvpMatches(replays), 0);
+});


### PR DESCRIPTION
Closes #1138

## Summary
- tutorial.ts: 21 tests covering normalizeTutorialStep, isTutorialComplete, canSkipTutorial, countTrackedPvpMatches, countRemainingProtectedPvpMatches
- deterministic-rng.ts: 11 tests covering normalizeDeterministicSeed, nextDeterministicRandom, createDeterministicRandomGenerator

🤖 Generated with [Claude Code](https://claude.com/claude-code)