### PR TITLE
[TEST] by claude: shared battle-replay.ts state machine unit tests

### DIFF
--- a/apps/server/test/shop.test.ts
+++ b/apps/server/test/shop.test.ts
@@ -1,0 +1,467 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveShopProducts } from "../src/shop";
+
+// resolveShopProducts — happy path using default config
+
+test("resolveShopProducts returns an array of shop products from the default config", () => {
+  const products = resolveShopProducts();
+  assert.ok(Array.isArray(products));
+  assert.ok(products.length > 0);
+});
+
+test("resolveShopProducts every product has a non-empty productId and name", () => {
+  const products = resolveShopProducts();
+  for (const product of products) {
+    assert.ok(product.productId.length > 0, `productId should not be empty`);
+    assert.ok(product.name.length > 0, `name for ${product.productId} should not be empty`);
+  }
+});
+
+test("resolveShopProducts every product has a valid type", () => {
+  const validTypes = new Set(["gem_pack", "equipment", "resource_bundle", "season_pass_premium", "cosmetic"]);
+  const products = resolveShopProducts();
+  for (const product of products) {
+    assert.ok(validTypes.has(product.type), `product ${product.productId} has invalid type: ${product.type}`);
+  }
+});
+
+test("resolveShopProducts every product price is a non-negative integer", () => {
+  const products = resolveShopProducts();
+  for (const product of products) {
+    assert.ok(Number.isInteger(product.price), `price for ${product.productId} should be an integer`);
+    assert.ok(product.price >= 0, `price for ${product.productId} should be non-negative`);
+  }
+});
+
+test("resolveShopProducts every product has an enabled boolean field", () => {
+  const products = resolveShopProducts();
+  for (const product of products) {
+    assert.equal(typeof product.enabled, "boolean");
+  }
+});
+
+test("resolveShopProducts includes the resource-bundle-starter product", () => {
+  const products = resolveShopProducts();
+  const starter = products.find((p) => p.productId === "resource-bundle-starter");
+  assert.ok(starter, "resource-bundle-starter should be present");
+  assert.equal(starter?.type, "resource_bundle");
+  assert.equal(starter?.price, 25);
+  assert.equal(starter?.enabled, true);
+});
+
+test("resolveShopProducts resource-bundle-starter grant has expected resources", () => {
+  const products = resolveShopProducts();
+  const starter = products.find((p) => p.productId === "resource-bundle-starter");
+  assert.ok(starter?.grant.resources, "grant.resources should be present");
+  assert.equal(starter?.grant.resources?.gold, 250);
+  assert.equal(starter?.grant.resources?.wood, 40);
+  assert.equal(starter?.grant.resources?.ore, 20);
+});
+
+test("resolveShopProducts includes the gem-pack-scout product and is disabled", () => {
+  const products = resolveShopProducts();
+  const gemPack = products.find((p) => p.productId === "gem-pack-scout");
+  assert.ok(gemPack, "gem-pack-scout should be present");
+  assert.equal(gemPack?.type, "gem_pack");
+  assert.equal(gemPack?.enabled, false);
+  assert.ok((gemPack?.grant.gems ?? 0) > 0, "gem pack should have gems in grant");
+});
+
+test("resolveShopProducts gem-pack-scout has wechatPriceFen set", () => {
+  const products = resolveShopProducts();
+  const gemPack = products.find((p) => p.productId === "gem-pack-scout");
+  assert.ok(gemPack?.wechatPriceFen != null, "gem-pack-scout should have wechatPriceFen");
+  assert.equal(gemPack?.wechatPriceFen, 600);
+});
+
+test("resolveShopProducts includes the season-pass-premium product", () => {
+  const products = resolveShopProducts();
+  const pass = products.find((p) => p.productId === "season-pass-premium");
+  assert.ok(pass, "season-pass-premium should be present");
+  assert.equal(pass?.type, "season_pass_premium");
+  assert.equal(pass?.grant.seasonPassPremium, true);
+});
+
+test("resolveShopProducts includes the equipment-sunforged-kit product", () => {
+  const products = resolveShopProducts();
+  const kit = products.find((p) => p.productId === "equipment-sunforged-kit");
+  assert.ok(kit, "equipment-sunforged-kit should be present");
+  assert.equal(kit?.type, "equipment");
+  assert.ok(Array.isArray(kit?.grant.equipmentIds));
+  assert.ok((kit?.grant.equipmentIds?.length ?? 0) > 0, "equipment grant must include equipmentIds");
+});
+
+// resolveShopProducts — with custom options
+
+test("resolveShopProducts with empty options.products returns empty array", () => {
+  const products = resolveShopProducts({ products: [] });
+  assert.deepEqual(products, []);
+});
+
+test("resolveShopProducts with explicit null options.products falls back to default config", () => {
+  const defaultProducts = resolveShopProducts();
+  const products = resolveShopProducts({ products: undefined });
+  assert.equal(products.length, defaultProducts.length);
+});
+
+test("resolveShopProducts with custom gem_pack product returns normalized product", () => {
+  const products = resolveShopProducts({
+    products: [
+      {
+        productId: "  test-gem-pack  ",
+        name: "  Test Gem Pack  ",
+        type: "gem_pack",
+        price: 10,
+        enabled: true,
+        grant: { gems: 50 }
+      }
+    ]
+  });
+  assert.equal(products.length, 1);
+  const product = products[0]!;
+  assert.equal(product.productId, "test-gem-pack");
+  assert.equal(product.name, "Test Gem Pack");
+  assert.equal(product.type, "gem_pack");
+  assert.equal(product.price, 10);
+  assert.equal(product.enabled, true);
+  assert.equal(product.grant.gems, 50);
+});
+
+test("resolveShopProducts with custom resource_bundle product returns normalized resources", () => {
+  const products = resolveShopProducts({
+    products: [
+      {
+        productId: "custom-bundle",
+        name: "Custom Bundle",
+        type: "resource_bundle",
+        price: 0,
+        enabled: true,
+        grant: { resources: { gold: 100.9, wood: 50.1, ore: 25.7 } }
+      }
+    ]
+  });
+  const product = products[0]!;
+  assert.equal(product.grant.resources?.gold, 100);
+  assert.equal(product.grant.resources?.wood, 50);
+  assert.equal(product.grant.resources?.ore, 25);
+});
+
+test("resolveShopProducts normalizes fractional price by flooring", () => {
+  const products = resolveShopProducts({
+    products: [
+      {
+        productId: "cheap-bundle",
+        name: "Cheap Bundle",
+        type: "resource_bundle",
+        price: 9.9,
+        enabled: true,
+        grant: { resources: { gold: 10 } }
+      }
+    ]
+  });
+  assert.equal(products[0]!.price, 9);
+});
+
+test("resolveShopProducts enabled defaults to true when not specified", () => {
+  const products = resolveShopProducts({
+    products: [
+      {
+        productId: "no-enabled-flag",
+        name: "No Enabled Flag",
+        type: "resource_bundle",
+        price: 5,
+        grant: { resources: { gold: 10 } }
+      }
+    ]
+  });
+  assert.equal(products[0]!.enabled, true);
+});
+
+test("resolveShopProducts season_pass_premium product with seasonPassPremium true", () => {
+  const products = resolveShopProducts({
+    products: [
+      {
+        productId: "pass-premium",
+        name: "Pass Premium",
+        type: "season_pass_premium",
+        price: 99,
+        enabled: true,
+        grant: { seasonPassPremium: true }
+      }
+    ]
+  });
+  assert.equal(products[0]!.grant.seasonPassPremium, true);
+});
+
+// resolveShopProducts — validation errors
+
+test("resolveShopProducts throws if productId is missing", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            name: "Missing ID",
+            type: "gem_pack",
+            price: 10,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /productId is required/
+  );
+});
+
+test("resolveShopProducts throws if productId is whitespace-only", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "   ",
+            name: "Whitespace ID",
+            type: "gem_pack",
+            price: 10,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /productId is required/
+  );
+});
+
+test("resolveShopProducts throws if name is missing", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "some-product",
+            type: "gem_pack",
+            price: 10,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /name is required/
+  );
+});
+
+test("resolveShopProducts throws if type is invalid", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "bad-type",
+            name: "Bad Type",
+            type: "invalid_type" as never,
+            price: 10,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /type must be/
+  );
+});
+
+test("resolveShopProducts throws if gem_pack has no gems in grant (empty grant)", () => {
+  // When gems is absent or zero the grant is considered empty, which is caught first
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "bad-gem-pack",
+            name: "Bad Gem Pack",
+            type: "gem_pack",
+            price: 10,
+            grant: {}
+          }
+        ]
+      }),
+    /grant must not be empty/
+  );
+});
+
+test("resolveShopProducts throws if equipment product has no equipmentIds", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "bad-equipment",
+            name: "Bad Equipment",
+            type: "equipment",
+            price: 10,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /equipment grants must include equipmentIds/
+  );
+});
+
+test("resolveShopProducts throws if cosmetic product has no cosmeticIds", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "bad-cosmetic",
+            name: "Bad Cosmetic",
+            type: "cosmetic",
+            price: 10,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /cosmetic grants must include cosmeticIds/
+  );
+});
+
+test("resolveShopProducts throws if resource_bundle has no resources", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "bad-bundle",
+            name: "Bad Bundle",
+            type: "resource_bundle",
+            price: 5,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /resource bundles must include resources/
+  );
+});
+
+test("resolveShopProducts throws if season_pass_premium grant does not set seasonPassPremium", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "bad-pass",
+            name: "Bad Pass",
+            type: "season_pass_premium",
+            price: 10,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /season pass premium grants must set seasonPassPremium/
+  );
+});
+
+test("resolveShopProducts throws if grant references an unknown equipment id", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "unknown-equip",
+            name: "Unknown Equip",
+            type: "equipment",
+            price: 10,
+            grant: { equipmentIds: ["totally_nonexistent_item_xyz"] }
+          }
+        ]
+      }),
+    /unknown equipment/
+  );
+});
+
+test("resolveShopProducts throws if grant references an unknown cosmetic id", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "unknown-cosmetic",
+            name: "Unknown Cosmetic",
+            type: "cosmetic",
+            price: 10,
+            grant: { cosmeticIds: ["cosmetic-does-not-exist-xyz" as never] }
+          }
+        ]
+      }),
+    /unknown cosmetic/
+  );
+});
+
+test("resolveShopProducts throws if grant is entirely empty", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "empty-grant",
+            name: "Empty Grant",
+            type: "gem_pack",
+            price: 10,
+            grant: {}
+          }
+        ]
+      }),
+    /grant must not be empty/
+  );
+});
+
+test("resolveShopProducts throws if price is NaN", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "nan-price",
+            name: "NaN Price",
+            type: "gem_pack",
+            price: Number.NaN,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /non-negative integer/
+  );
+});
+
+test("resolveShopProducts throws if price is negative", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "neg-price",
+            name: "Negative Price",
+            type: "gem_pack",
+            price: -1,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /non-negative integer/
+  );
+});
+
+test("resolveShopProducts throws if wechatPriceFen is zero", () => {
+  assert.throws(
+    () =>
+      resolveShopProducts({
+        products: [
+          {
+            productId: "zero-wechat",
+            name: "Zero WeChat Price",
+            type: "gem_pack",
+            price: 5,
+            wechatPriceFen: 0,
+            grant: { gems: 5 }
+          }
+        ]
+      }),
+    /positive integer/
+  );
+});

--- a/packages/shared/test/battle-replay.test.ts
+++ b/packages/shared/test/battle-replay.test.ts
@@ -1,0 +1,365 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createBattleReplayPlaybackState,
+  playBattleReplayPlayback,
+  pauseBattleReplayPlayback,
+  stepBattleReplayPlayback,
+  resetBattleReplayPlayback,
+  normalizePlayerBattleReplaySummaries,
+  queryPlayerBattleReplaySummaries,
+  buildBattleReplayTimeline
+} from "../src/battle-replay.ts";
+import type { PlayerBattleReplaySummary } from "../src/battle-replay.ts";
+import type { BattleState } from "../src/models.ts";
+
+// ---------------------------------------------------------------------------
+// Minimal fixtures
+// ---------------------------------------------------------------------------
+
+function makeInitialState(): BattleState {
+  return {
+    id: "battle-1",
+    round: 1,
+    lanes: 3,
+    activeUnitId: null,
+    turnOrder: [],
+    units: {},
+    unitCooldowns: {},
+    environment: [],
+    log: [],
+    rng: { seed: 42, cursor: 0 }
+  };
+}
+
+function makeReplay(overrides: Partial<PlayerBattleReplaySummary> = {}): PlayerBattleReplaySummary {
+  return {
+    id: "replay-1",
+    roomId: "room-1",
+    playerId: "player-1",
+    battleId: "battle-1",
+    battleKind: "neutral",
+    playerCamp: "attacker",
+    heroId: "hero-1",
+    startedAt: "2024-01-01T00:00:00.000Z",
+    completedAt: "2024-01-01T00:05:00.000Z",
+    initialState: makeInitialState(),
+    steps: [],
+    result: "attacker_victory",
+    ...overrides
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createBattleReplayPlaybackState
+// ---------------------------------------------------------------------------
+
+test("createBattleReplayPlaybackState returns initial state at frame 0 with paused status", () => {
+  // A replay with at least one step is needed so totalSteps > 0 and status stays "paused"
+  // (when totalSteps === 0, resolvePlaybackStatus treats it as completed immediately)
+  const step = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step] });
+  const playback = createBattleReplayPlaybackState(replay);
+
+  assert.equal(playback.currentStepIndex, 0);
+  assert.equal(playback.status, "paused");
+  assert.equal(playback.speed, 1);
+  assert.equal(playback.totalSteps, 1);
+  assert.equal(playback.currentStep, null);
+  assert.deepEqual(playback.nextStep, step);
+  assert.deepEqual(playback.replay, replay);
+});
+
+test("createBattleReplayPlaybackState with 0 steps resolves to completed status immediately", () => {
+  const replay = makeReplay(); // 0 steps
+  const playback = createBattleReplayPlaybackState(replay);
+
+  assert.equal(playback.currentStepIndex, 0);
+  // 0 >= 0 so resolvePlaybackStatus marks it as completed
+  assert.equal(playback.status, "completed");
+  assert.equal(playback.totalSteps, 0);
+});
+
+test("createBattleReplayPlaybackState with steps reflects correct totalSteps and nextStep", () => {
+  const step = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step] });
+  const playback = createBattleReplayPlaybackState(replay);
+
+  assert.equal(playback.totalSteps, 1);
+  assert.equal(playback.currentStepIndex, 0);
+  assert.deepEqual(playback.nextStep, step);
+  assert.equal(playback.currentStep, null);
+});
+
+// ---------------------------------------------------------------------------
+// playBattleReplayPlayback
+// ---------------------------------------------------------------------------
+
+test("playBattleReplayPlayback transitions status from paused to playing when steps remain", () => {
+  const step = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step] });
+  const playback = createBattleReplayPlaybackState(replay);
+  assert.equal(playback.status, "paused");
+
+  const playing = playBattleReplayPlayback(playback);
+  assert.equal(playing.status, "playing");
+});
+
+test("playBattleReplayPlayback returns completed status when already at end", () => {
+  const replay = makeReplay(); // 0 steps
+  const playback = createBattleReplayPlaybackState(replay);
+  // currentStepIndex (0) >= totalSteps (0), so play marks as completed
+  const result = playBattleReplayPlayback(playback);
+  assert.equal(result.status, "completed");
+});
+
+// ---------------------------------------------------------------------------
+// pauseBattleReplayPlayback
+// ---------------------------------------------------------------------------
+
+test("pauseBattleReplayPlayback transitions from playing to paused", () => {
+  const step = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step] });
+  const playback = playBattleReplayPlayback(createBattleReplayPlaybackState(replay));
+  assert.equal(playback.status, "playing");
+
+  const paused = pauseBattleReplayPlayback(playback);
+  assert.equal(paused.status, "paused");
+});
+
+test("pauseBattleReplayPlayback returns same object when status is completed", () => {
+  const replay = makeReplay();
+  const playback = { ...createBattleReplayPlaybackState(replay), status: "completed" as const };
+
+  const result = pauseBattleReplayPlayback(playback);
+  assert.strictEqual(result, playback);
+});
+
+// ---------------------------------------------------------------------------
+// stepBattleReplayPlayback
+// ---------------------------------------------------------------------------
+
+test("stepBattleReplayPlayback advances currentStepIndex by 1", () => {
+  const step = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step] });
+  const playback = createBattleReplayPlaybackState(replay);
+  assert.equal(playback.currentStepIndex, 0);
+
+  const stepped = stepBattleReplayPlayback(playback);
+  assert.equal(stepped.currentStepIndex, 1);
+});
+
+test("stepBattleReplayPlayback returns completed when no nextStep", () => {
+  const replay = makeReplay(); // 0 steps
+  const playback = createBattleReplayPlaybackState(replay);
+  // nextStep is null
+
+  const result = stepBattleReplayPlayback(playback);
+  assert.equal(result.status, "completed");
+});
+
+test("stepBattleReplayPlayback preserves playing status when called while playing", () => {
+  const step1 = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const step2 = { index: 2, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step1, step2] });
+  const playback = playBattleReplayPlayback(createBattleReplayPlaybackState(replay));
+  assert.equal(playback.status, "playing");
+
+  const stepped = stepBattleReplayPlayback(playback);
+  assert.equal(stepped.status, "playing");
+  assert.equal(stepped.currentStepIndex, 1);
+});
+
+test("stepBattleReplayPlayback preserves paused status when called while paused", () => {
+  // Two steps needed so stepping from index 0 -> 1 still has remaining steps and stays paused
+  const step1 = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const step2 = { index: 2, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step1, step2] });
+  const playback = createBattleReplayPlaybackState(replay);
+  assert.equal(playback.status, "paused");
+
+  const stepped = stepBattleReplayPlayback(playback);
+  assert.equal(stepped.status, "paused");
+  assert.equal(stepped.currentStepIndex, 1);
+});
+
+// ---------------------------------------------------------------------------
+// resetBattleReplayPlayback
+// ---------------------------------------------------------------------------
+
+test("resetBattleReplayPlayback resets frame index to 0 and status to paused", () => {
+  const step = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step] });
+  const playback = stepBattleReplayPlayback(playBattleReplayPlayback(createBattleReplayPlaybackState(replay)));
+  // after stepping through one step we should be at index 1
+  assert.equal(playback.currentStepIndex, 1);
+
+  const reset = resetBattleReplayPlayback(playback);
+  assert.equal(reset.currentStepIndex, 0);
+  assert.equal(reset.status, "paused");
+});
+
+test("resetBattleReplayPlayback preserves speed from previous playback state", () => {
+  const replay = makeReplay();
+  const playback = { ...createBattleReplayPlaybackState(replay), speed: 2 as const };
+
+  const reset = resetBattleReplayPlayback(playback);
+  assert.equal(reset.speed, 2);
+});
+
+// ---------------------------------------------------------------------------
+// normalizePlayerBattleReplaySummaries
+// ---------------------------------------------------------------------------
+
+test("normalizePlayerBattleReplaySummaries returns empty array for null/undefined input", () => {
+  assert.deepEqual(normalizePlayerBattleReplaySummaries(null), []);
+  assert.deepEqual(normalizePlayerBattleReplaySummaries(undefined), []);
+  assert.deepEqual(normalizePlayerBattleReplaySummaries([]), []);
+});
+
+test("normalizePlayerBattleReplaySummaries filters out items missing required fields", () => {
+  const result = normalizePlayerBattleReplaySummaries([
+    { id: "r1" } // missing roomId, playerId, etc.
+  ]);
+  assert.deepEqual(result, []);
+});
+
+test("normalizePlayerBattleReplaySummaries returns a valid normalized replay", () => {
+  const replay = makeReplay();
+  const result = normalizePlayerBattleReplaySummaries([replay]);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.id, "replay-1");
+  assert.equal(result[0]?.battleKind, "neutral");
+  assert.equal(result[0]?.playerCamp, "attacker");
+  assert.equal(result[0]?.result, "attacker_victory");
+});
+
+test("normalizePlayerBattleReplaySummaries deduplicates by id keeping most recent completedAt", () => {
+  const older = makeReplay({
+    id: "replay-1",
+    completedAt: "2024-01-01T00:00:00.000Z"
+  });
+  const newer = makeReplay({
+    id: "replay-1",
+    completedAt: "2024-06-01T00:00:00.000Z"
+  });
+
+  const result = normalizePlayerBattleReplaySummaries([older, newer]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.id, "replay-1");
+});
+
+test("normalizePlayerBattleReplaySummaries sorts by completedAt descending", () => {
+  const first = makeReplay({ id: "r-a", completedAt: "2024-03-01T00:00:00.000Z" });
+  const second = makeReplay({ id: "r-b", completedAt: "2024-01-01T00:00:00.000Z" });
+
+  const result = normalizePlayerBattleReplaySummaries([second, first]);
+  assert.equal(result[0]?.id, "r-a");
+  assert.equal(result[1]?.id, "r-b");
+});
+
+test("normalizePlayerBattleReplaySummaries rejects invalid battleKind", () => {
+  const replay = { ...makeReplay(), battleKind: "invalid" } as unknown as PlayerBattleReplaySummary;
+  const result = normalizePlayerBattleReplaySummaries([replay]);
+  assert.deepEqual(result, []);
+});
+
+// ---------------------------------------------------------------------------
+// queryPlayerBattleReplaySummaries
+// ---------------------------------------------------------------------------
+
+test("queryPlayerBattleReplaySummaries returns all replays when query is empty", () => {
+  const replays = [
+    makeReplay({ id: "r-1" }),
+    makeReplay({ id: "r-2", completedAt: "2024-06-01T00:00:00.000Z" })
+  ];
+  const result = queryPlayerBattleReplaySummaries(replays, {});
+  assert.equal(result.length, 2);
+});
+
+test("queryPlayerBattleReplaySummaries filters by roomId", () => {
+  const inRoom = makeReplay({ id: "r-1", roomId: "room-A" });
+  const otherRoom = makeReplay({ id: "r-2", roomId: "room-B", completedAt: "2024-06-01T00:00:00.000Z" });
+  const result = queryPlayerBattleReplaySummaries([inRoom, otherRoom], { roomId: "room-A" });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.id, "r-1");
+});
+
+test("queryPlayerBattleReplaySummaries filters by result", () => {
+  const win = makeReplay({ id: "r-1", result: "attacker_victory" });
+  const loss = makeReplay({ id: "r-2", result: "defender_victory", completedAt: "2024-06-01T00:00:00.000Z" });
+  const result = queryPlayerBattleReplaySummaries([win, loss], { result: "defender_victory" });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.id, "r-2");
+});
+
+test("queryPlayerBattleReplaySummaries filters by battleKind", () => {
+  const neutral = makeReplay({ id: "r-1", battleKind: "neutral" });
+  const hero = makeReplay({ id: "r-2", battleKind: "hero", completedAt: "2024-06-01T00:00:00.000Z" });
+  const result = queryPlayerBattleReplaySummaries([neutral, hero], { battleKind: "hero" });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.id, "r-2");
+});
+
+test("queryPlayerBattleReplaySummaries respects limit and offset", () => {
+  const replays = [
+    makeReplay({ id: "r-1", completedAt: "2024-03-01T00:00:00.000Z" }),
+    makeReplay({ id: "r-2", completedAt: "2024-02-01T00:00:00.000Z" }),
+    makeReplay({ id: "r-3", completedAt: "2024-01-01T00:00:00.000Z" })
+  ];
+
+  const limited = queryPlayerBattleReplaySummaries(replays, { limit: 2 });
+  assert.equal(limited.length, 2);
+
+  const offset = queryPlayerBattleReplaySummaries(replays, { offset: 1, limit: 2 });
+  assert.equal(offset.length, 2);
+  assert.equal(offset[0]?.id, "r-2");
+});
+
+test("queryPlayerBattleReplaySummaries returns empty array for null input", () => {
+  const result = queryPlayerBattleReplaySummaries(null, {});
+  assert.deepEqual(result, []);
+});
+
+// ---------------------------------------------------------------------------
+// buildBattleReplayTimeline
+// ---------------------------------------------------------------------------
+
+test("buildBattleReplayTimeline returns empty array for replay with no steps", () => {
+  const replay = makeReplay();
+  const timeline = buildBattleReplayTimeline(replay);
+
+  assert.ok(Array.isArray(timeline));
+  assert.equal(timeline.length, 0);
+});
+
+test("buildBattleReplayTimeline returns one entry per step", () => {
+  const step1 = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const step2 = { index: 2, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step1, step2] });
+  const timeline = buildBattleReplayTimeline(replay);
+
+  assert.equal(timeline.length, 2);
+});
+
+test("buildBattleReplayTimeline entry has expected shape", () => {
+  const step = { index: 1, source: "player" as const, action: { type: "battle.wait" as const, unitId: "u1" } };
+  const replay = makeReplay({ steps: [step] });
+  const timeline = buildBattleReplayTimeline(replay);
+
+  assert.equal(timeline.length, 1);
+  const entry = timeline[0]!;
+  assert.ok("step" in entry);
+  assert.ok("round" in entry);
+  assert.ok("resultingRound" in entry);
+  assert.ok("state" in entry);
+  assert.ok("outcome" in entry);
+  assert.ok("changes" in entry);
+  assert.ok(Array.isArray(entry.changes));
+  assert.deepEqual(entry.step, step);
+});


### PR DESCRIPTION
Closes #1164

Adds unit tests for createBattleReplayPlaybackState, play/pause/step/reset transitions, buildBattleReplayTimeline, normalizePlayerBattleReplaySummaries, queryPlayerBattleReplaySummaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)