### PR TITLE
[TEST] by claude: shared player-account.ts mailbox helper unit tests

### DIFF
--- a/packages/shared/test/player-account-mailbox.test.ts
+++ b/packages/shared/test/player-account-mailbox.test.ts
@@ -131,3 +131,24 @@ test("summarizePlayerMailbox: mixed mailbox with 2 unread + 1 expired + 1 claima
   assert.equal(summary.claimableCount, 1); // msg-4 has grant
   assert.equal(summary.expiredCount, 1); // msg-3
 });
+
+test("summarizePlayerMailbox: all-expired mailbox → expiredCount equals totalCount, unread=0, claimable=0", () => {
+  const messages = [
+    makeMsg({ id: "msg-1", expiresAt: PAST }),
+    makeMsg({ id: "msg-2", expiresAt: PAST, grant: { gems: 50 } }),
+    makeMsg({ id: "msg-3", expiresAt: PAST })
+  ];
+  const summary = summarizePlayerMailbox(messages, NOW);
+  assert.equal(summary.totalCount, 3);
+  assert.equal(summary.expiredCount, 3);
+  assert.equal(summary.unreadCount, 0);
+  assert.equal(summary.claimableCount, 0);
+});
+
+test("summarizePlayerMailbox: message without expiresAt never expires → counted as non-expired", () => {
+  const messages = [makeMsg({ id: "msg-1" })]; // no expiresAt
+  const summary = summarizePlayerMailbox(messages, NOW);
+  assert.equal(summary.totalCount, 1);
+  assert.equal(summary.expiredCount, 0);
+  assert.equal(summary.unreadCount, 1);
+});


### PR DESCRIPTION
Closes #1165

Adds unit tests for `isPlayerMailboxMessageExpired` and `summarizePlayerMailbox` in `packages/shared/test/player-account-mailbox.test.ts`.

Covers:
- `isPlayerMailboxMessageExpired`: no expiresAt (never expires), future/past/boundary timestamps, invalid date strings
- `summarizePlayerMailbox`: empty/null mailbox, unread, read, claimed, expired, claimable, all-expired, and mixed mailbox scenarios

17 tests total, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)