### PR TITLE
[codex] close WeChat release gate evidence gaps

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1150,12 +1150,14 @@ export function issueNextAuthSession(
   }
 
   const nextGuestSessionId = input.sessionId ?? currentSession?.sessionId;
-  return issueGuestAccessSession({
+  const nextGuestSession = issueGuestAccessSession({
     playerId: input.playerId,
     displayName: input.displayName,
     provider: currentSession?.provider ?? "guest",
     ...(nextGuestSessionId !== undefined ? { sessionId: nextGuestSessionId } : {})
   });
+  registerGuestSession(nextGuestSession);
+  return nextGuestSession;
 }
 
 function resolveAuthSession(token: string): GuestAuthSession | null {

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -837,8 +837,10 @@ test("auth session route resolves a bearer token into the current guest session"
     })
   });
   const loginPayload = (await loginResponse.json()) as { session: GuestAuthSession };
+  const room = await joinRoom(port, "session-refresh-room", "spoofed-player");
 
   t.after(async () => {
+    await room.leave(true).catch(() => undefined);
     resetGuestAuthSessions();
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
@@ -855,6 +857,19 @@ test("auth session route resolves a bearer token into the current guest session"
   assert.equal(sessionPayload.session.displayName, "回声旅人");
   assert.equal(sessionPayload.session.provider, "guest");
   assert.match(sessionPayload.session.token, /\./);
+
+  const connectPayload = await sendRequest(
+    room,
+    {
+      type: "connect",
+      requestId: "session-refresh-connect",
+      roomId: "session-refresh-room",
+      playerId: "spoofed-player",
+      authToken: sessionPayload.session.token
+    },
+    "session.state"
+  );
+  assert.equal(connectPayload.payload.world.playerId, "player-session");
 });
 
 test("connect message prefers auth token identity over a spoofed playerId", async (t) => {

--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -24,6 +24,8 @@ Use the latest local artifacts under `artifacts/release-readiness/` and `artifac
 npm run release:gate:summary
 ```
 
+When the current working set lives inside a candidate rehearsal bundle rather than the top-level artifact roots, the command now also scans nested directories under `artifacts/release-readiness/` and reuses the newest matching snapshot / H5 smoke / reconnect soak / WeChat evidence set from that bundle.
+
 Pick the release target surface explicitly when needed:
 
 ```bash
@@ -60,6 +62,8 @@ If you do not pass output flags, the script writes:
 
 - `artifacts/release-readiness/release-gate-summary-<short-sha>.json`
 - `artifacts/release-readiness/release-gate-summary-<short-sha>.md`
+
+Default input discovery remains intentionally conservative about artifact families, but it is now recursive for release-readiness working-set files. That means a prior `release:phase1:candidate-rehearsal` run can feed a later top-level `release:gate:summary` call without having to re-pass every nested path explicitly.
 
 ## Triage Summary
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -168,6 +168,7 @@ WeChat checklist / blockers 至少要覆盖以下证据面：
 - `codex.wechat.release-candidate-summary.md`：可直接贴进 PR、CI summary 或提审记录的精简摘要；会额外展开 WeChat 设备/runtime 执行人、设备、执行时间、五个 smoke case 状态，以及 reconnect/share 的结构化字段
 - `blockers`：显式列出缺失 smoke report、失败校验、待完成 manual review，以及对应 artifact / next command；若 smoke report 的 `execution.executedAt` 缺失、非法或早于 summary 生成时间 24h，也会直接阻塞 candidate
 - `--manual-checks <json>`：读取显式 manual review 状态；推荐直接从 `docs/release-evidence/wechat-release-manual-review.example.json` 复制当次 candidate 文件
+- 当 artifacts 目录里已经包含 `codex.wechat.manual-review.json`、`wechat-manual-review.json` 或 `wechat-manual-checks.json` 时，`npm run validate:wechat-rc` 会自动复用它；这让 `release:phase1:candidate-rehearsal` 在复制候选包证据目录后，仍能重建同一套 manual review 状态而不丢失 owner / revision / timestamp 元数据。
 - `--manual-check <id>:<title>`：临时追加一条 pending manual review
 - `npm run release:wechat:rehearsal` 的 `## Artifacts` 区块会自动列出 `codex.wechat.release-candidate-summary.json` / `.md`，方便 reviewer 或 PR 作者直接复制 `.md` 文件内容到评论区，并将 `.json` 作为结构化证据随 artifact 一起上传
 

--- a/progress.md
+++ b/progress.md
@@ -1473,3 +1473,35 @@ Original prompt: 你先学习下当前项目并给出开发的计划
   - `node --import tsx --test ./apps/cocos-client/test/cocos-ui-formatters.test.ts` 通过
   - `npm run typecheck:cocos` 通过
   - `npm test` 通过（`424/424`）
+
+## Issue #1173 - WeChat release gate evidence chain - 2026-04-10
+
+- 本轮补齐了同一候选 revision 的 WeChat release gate 证据链，并收掉了两个真实阻塞点：
+  - `apps/server/src/auth.ts`
+    - 修复 guest 会话在 `/api/auth/session` 刷新后没有重新注册到 `guestSessionsById` 的问题
+    - 之前 H5 packaged RC smoke 会在“恢复缓存会话 -> 重新进房”时拿着新 token 被服务端判成 `unauthorized`
+    - 现在 refresh token 后会同步注册新的 guest session，房间连接可继续复用刷新后的 bearer token
+  - `scripts/release-gate-summary.ts`
+    - release gate 汇总现在支持递归发现 `artifacts/release-readiness/**` 下的 rehearsal 证据目录
+    - 修掉了顶层汇总把 `release-readiness-dashboard-*.json` 误当成正式 snapshot 的问题，避免明明候选包已通过却仍被总门禁判成 failed
+  - `scripts/validate-wechat-release-candidate.ts`
+    - WeChat RC 校验现在会自动识别候选包目录中的 `codex.wechat.manual-review.json / wechat-manual-review.json / wechat-manual-checks.json`
+    - 这样 `release:phase1:candidate-rehearsal` 复制 artifacts 后，能继续复用同一份人工验收结论，不会重建成 pending/blocked 候选摘要
+- E2E / smoke 辅助链路也做了配套收口：
+  - `tests/e2e/fixtures.ts`
+    - 改成先在同源页面清空 `localStorage/sessionStorage`，避免 Playwright 在无 origin 状态下静默失败，污染 RC smoke
+  - `tests/e2e/smoke-helpers.ts` 与多条 H5 smoke spec
+    - 新增 `acceptLobbyPrivacyConsent()`，把隐私同意流程纳进自动化链路
+    - release-candidate smoke 不再强依赖 diagnostics panel，以匹配打包版 H5 的真实 UI 形态
+  - `tsconfig.base.json` / `tsconfig.json`
+    - 为 `tsx` 路径解析补上根级 tsconfig 和 `cc` stub 映射，避免 release/ops 脚本在仓库根目录运行时吃不到统一配置
+- 本轮已拿到的同 revision 证据：
+  - `npm run smoke:client:release-candidate` 通过
+  - `npm run release:reconnect-soak` 通过
+  - `npm run release:phase1:candidate-rehearsal -- --target-surface wechat` 通过
+  - `npm run release:gate:summary -- --target-surface wechat` 通过
+  - 顶层 release gate 当前结论为 `status = passed`，摘要为 `Target surface wechat has current required evidence.`
+- 本轮定向验证结果：
+  - `npm run typecheck:server` 通过
+  - `npm run typecheck:ops` 通过
+  - `node --import tsx --test ./scripts/test/wechat-release-artifacts.test.ts ./scripts/test/release-gate-summary.test.ts ./scripts/test/phase1-candidate-rehearsal.test.ts` 通过

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -369,9 +369,6 @@ interface ReleaseGateSummaryReport {
   configChangeRisk: ConfigChangeRiskSummary;
 }
 
-const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
-const DEFAULT_WECHAT_ARTIFACTS_DIR = path.resolve("artifacts", "wechat-release");
-const DEFAULT_CONFIG_CENTER_LIBRARY_PATH = path.resolve("configs", ".config-center-library.json");
 const HEX_REVISION_PATTERN = /^[a-f0-9]+$/i;
 const MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS = 1000 * 60 * 60 * 72;
 const MAX_TARGET_SURFACE_REVIEW_AGE_MS = 1000 * 60 * 60 * 72;
@@ -579,18 +576,46 @@ function writeJsonFile(filePath: string, payload: unknown): void {
   writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
-function resolveLatestFile(dirPath: string, matcher: (entry: string) => boolean): string | undefined {
+function getDefaultReleaseReadinessDir(): string {
+  return path.resolve("artifacts", "release-readiness");
+}
+
+function getDefaultWechatArtifactsDir(): string {
+  return path.resolve("artifacts", "wechat-release");
+}
+
+function getDefaultConfigCenterLibraryPath(): string {
+  return path.resolve("configs", ".config-center-library.json");
+}
+
+function collectMatchingFiles(
+  dirPath: string,
+  matcher: (entry: string) => boolean,
+  maxDepth: number,
+  currentDepth = 0
+): string[] {
   if (!fs.existsSync(dirPath)) {
-    return undefined;
+    return [];
   }
 
-  const candidates = fs
-    .readdirSync(dirPath)
-    .filter((entry) => matcher(entry))
-    .map((entry) => path.join(dirPath, entry))
-    .filter((entry) => fs.statSync(entry).isFile())
-    .sort((left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs);
+  const matches: string[] = [];
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isFile() && matcher(entry.name)) {
+      matches.push(fullPath);
+      continue;
+    }
+    if (entry.isDirectory() && currentDepth < maxDepth) {
+      matches.push(...collectMatchingFiles(fullPath, matcher, maxDepth, currentDepth + 1));
+    }
+  }
+  return matches;
+}
 
+function resolveLatestFile(dirPath: string, matcher: (entry: string) => boolean, maxDepth = 0): string | undefined {
+  const candidates = collectMatchingFiles(dirPath, matcher, maxDepth).sort(
+    (left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs
+  );
   return candidates[0];
 }
 
@@ -598,41 +623,86 @@ function resolveSnapshotPath(args: Args): string | undefined {
   if (args.snapshotPath) {
     return path.resolve(args.snapshotPath);
   }
-  return resolveLatestFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
-    entry.startsWith("release-readiness-") && entry.endsWith(".json")
-  );
+  return resolveLatestFile(getDefaultReleaseReadinessDir(), (entry) =>
+    entry.startsWith("release-readiness-") && !entry.startsWith("release-readiness-dashboard-") && entry.endsWith(".json")
+  , 3);
 }
 
 function resolveH5SmokePath(args: Args): string | undefined {
   if (args.h5SmokePath) {
     return path.resolve(args.h5SmokePath);
   }
-  return resolveLatestFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
+  return resolveLatestFile(getDefaultReleaseReadinessDir(), (entry) =>
     entry.startsWith("client-release-candidate-smoke-") && entry.endsWith(".json")
-  );
+  , 3);
 }
 
 function resolveReconnectSoakPath(args: Args): string | undefined {
   if (args.reconnectSoakPath) {
     return path.resolve(args.reconnectSoakPath);
   }
-  const fixedCandidate = path.join(DEFAULT_RELEASE_READINESS_DIR, "colyseus-reconnect-soak-summary.json");
+  const fixedCandidate = path.join(getDefaultReleaseReadinessDir(), "colyseus-reconnect-soak-summary.json");
   if (fs.existsSync(fixedCandidate)) {
     return fixedCandidate;
   }
-  return resolveLatestFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
+  return resolveLatestFile(getDefaultReleaseReadinessDir(), (entry) =>
     entry.startsWith("colyseus-reconnect-soak-summary") && entry.endsWith(".json")
+  , 3);
+}
+
+function directoryContainsWechatEvidence(dirPath: string): boolean {
+  if (!fs.existsSync(dirPath) || !fs.statSync(dirPath).isDirectory()) {
+    return false;
+  }
+  return [
+    "codex.wechat.release-candidate-summary.json",
+    "codex.wechat.rc-validation-report.json",
+    "codex.wechat.smoke-report.json"
+  ].some((entry) => fs.existsSync(path.join(dirPath, entry)));
+}
+
+function collectMatchingDirectories(
+  dirPath: string,
+  predicate: (fullPath: string) => boolean,
+  maxDepth: number,
+  currentDepth = 0
+): string[] {
+  if (!fs.existsSync(dirPath)) {
+    return [];
+  }
+
+  const matches: string[] = [];
+  for (const entry of fs.readdirSync(dirPath, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const fullPath = path.join(dirPath, entry.name);
+    if (predicate(fullPath)) {
+      matches.push(fullPath);
+    }
+    if (currentDepth < maxDepth) {
+      matches.push(...collectMatchingDirectories(fullPath, predicate, maxDepth, currentDepth + 1));
+    }
+  }
+  return matches;
+}
+
+function resolveLatestWechatArtifactsDir(rootDir: string): string | undefined {
+  const candidates = collectMatchingDirectories(rootDir, directoryContainsWechatEvidence, 3).sort(
+    (left, right) => fs.statSync(right).mtimeMs - fs.statSync(left).mtimeMs
   );
+  return candidates[0];
 }
 
 function resolveWechatArtifactsDir(args: Args): string | undefined {
   if (args.wechatArtifactsDir) {
     return path.resolve(args.wechatArtifactsDir);
   }
-  if (fs.existsSync(DEFAULT_WECHAT_ARTIFACTS_DIR)) {
-    return DEFAULT_WECHAT_ARTIFACTS_DIR;
+  const defaultDir = getDefaultWechatArtifactsDir();
+  if (directoryContainsWechatEvidence(defaultDir)) {
+    return defaultDir;
   }
-  return undefined;
+  return resolveLatestWechatArtifactsDir(getDefaultReleaseReadinessDir());
 }
 
 function resolveWechatRcValidationPath(args: Args, wechatArtifactsDir?: string): string | undefined {
@@ -671,7 +741,7 @@ function resolveWechatSmokeReportPath(args: Args, wechatArtifactsDir?: string): 
 function resolveConfigCenterLibraryPath(args: Args): string | undefined {
   const candidate = args.configCenterLibraryPath
     ? path.resolve(args.configCenterLibraryPath)
-    : DEFAULT_CONFIG_CENTER_LIBRARY_PATH;
+    : getDefaultConfigCenterLibraryPath();
   return fs.existsSync(candidate) ? candidate : undefined;
 }
 
@@ -679,9 +749,9 @@ function resolveManualEvidenceLedgerPath(args: Args): string | undefined {
   if (args.manualEvidenceLedgerPath) {
     return path.resolve(args.manualEvidenceLedgerPath);
   }
-  return resolveLatestFile(DEFAULT_RELEASE_READINESS_DIR, (entry) =>
+  return resolveLatestFile(getDefaultReleaseReadinessDir(), (entry) =>
     entry.includes("manual-release-evidence-owner-ledger") && entry.endsWith(".md")
-  );
+  , 3);
 }
 
 function readGitValue(args: string[]): string {
@@ -2034,7 +2104,7 @@ function buildReleaseGateTriage(
             title: "Config change risk summary",
             impactedSurface: targetSurface,
             summary: `Config changes are ${configChangeRisk.overallRisk?.toUpperCase() ?? "UNKNOWN"} risk for ${targetSurface} and stay advisory until the suggested validation is complete.`,
-            nextStep: `Open \`${relativeReportPath(configChangeRisk.source?.path ?? DEFAULT_CONFIG_CENTER_LIBRARY_PATH)}\` and run ${(
+            nextStep: `Open \`${relativeReportPath(configChangeRisk.source?.path ?? getDefaultConfigCenterLibraryPath())}\` and run ${(
               configChangeRisk.suggestedValidationActions ?? []
             )
               .slice(0, 3)
@@ -2277,14 +2347,14 @@ function defaultOutputPath(args: Args, shortCommit: string): string {
   if (args.outputPath) {
     return path.resolve(args.outputPath);
   }
-  return path.resolve(DEFAULT_RELEASE_READINESS_DIR, `release-gate-summary-${shortCommit}.json`);
+  return path.resolve(getDefaultReleaseReadinessDir(), `release-gate-summary-${shortCommit}.json`);
 }
 
 function defaultMarkdownOutputPath(args: Args, shortCommit: string): string {
   if (args.markdownOutputPath) {
     return path.resolve(args.markdownOutputPath);
   }
-  return path.resolve(DEFAULT_RELEASE_READINESS_DIR, `release-gate-summary-${shortCommit}.md`);
+  return path.resolve(getDefaultReleaseReadinessDir(), `release-gate-summary-${shortCommit}.md`);
 }
 
 function main(): void {

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -287,6 +287,197 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /Recommend rehearsal: yes/);
 });
 
+test("buildReleaseGateSummaryReport discovers nested candidate rehearsal evidence for wechat surface", () => {
+  const workspace = createTempWorkspace();
+  const rehearsalDir = path.join(workspace, "artifacts", "release-readiness", "phase1-candidate-rehearsal-local");
+  const snapshotPath = path.join(rehearsalDir, "release-readiness-phase1-mainline-abc123.json");
+  const dashboardPath = path.join(rehearsalDir, "release-readiness-dashboard-phase1-mainline-abc123.json");
+  const h5SmokePath = path.join(rehearsalDir, "client-release-candidate-smoke-phase1-mainline-abc123.json");
+  const reconnectSoakPath = path.join(rehearsalDir, "colyseus-reconnect-soak-summary-phase1-mainline-abc123.json");
+  const wechatArtifactsDir = path.join(rehearsalDir, "wechat-release-phase1-mainline-abc123");
+  const wechatRcValidationPath = path.join(wechatArtifactsDir, "codex.wechat.rc-validation-report.json");
+  const wechatCandidateSummaryPath = path.join(wechatArtifactsDir, "codex.wechat.release-candidate-summary.json");
+  const wechatSmokeReportPath = path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: isoHoursAgo(1),
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
+    summary: {
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
+    }
+  });
+  writeJson(dashboardPath, {
+    generatedAt: new Date().toISOString(),
+    summary: {
+      status: "warning"
+    }
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: isoHoursAgo(1),
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    execution: {
+      status: "passed",
+      exitCode: 0,
+      finishedAt: isoHoursAgo(1)
+    },
+    summary: {
+      total: 2,
+      passed: 2,
+      failed: 0
+    }
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: isoHoursAgo(1),
+    candidate: {
+      name: "phase1-mainline",
+      revision: "abc123"
+    },
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    status: "passed",
+    verdict: {
+      status: "passed",
+      summary: "same-revision reconnect soak ok"
+    },
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 96,
+      invariantChecks: 512
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
+  writeJson(wechatRcValidationPath, {
+    generatedAt: isoHoursAgo(1),
+    commit: "abc123",
+    summary: {
+      status: "passed",
+      failedChecks: 0,
+      failureSummary: []
+    }
+  });
+  writeJson(wechatSmokeReportPath, {
+    artifact: {
+      sourceRevision: "abc123"
+    },
+    execution: {
+      executedAt: isoHoursAgo(1),
+      result: "passed",
+      summary: "same-revision smoke ok"
+    },
+    cases: [
+      {
+        id: "wechat-launch",
+        required: true,
+        status: "passed"
+      }
+    ]
+  });
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: isoHoursAgo(1),
+    candidate: {
+      revision: "abc123",
+      status: "ready"
+    },
+    evidence: {
+      package: {
+        status: "passed",
+        summary: "package ok",
+        artifactPath: path.join(wechatArtifactsDir, "codex.wechat.package.json")
+      },
+      validation: {
+        status: "passed",
+        summary: "validation ok",
+        artifactPath: wechatRcValidationPath
+      },
+      smoke: {
+        status: "passed",
+        summary: "smoke ok",
+        artifactPath: wechatSmokeReportPath
+      },
+      manualReview: {
+        status: "ready",
+        requiredPendingChecks: 0,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: [
+          {
+            id: "wechat-devtools-export-review",
+            title: "Candidate-scoped WeChat package install/launch verification recorded",
+            required: true,
+            status: "passed",
+            owner: "release-oncall",
+            recordedAt: isoHoursAgo(1),
+            revision: "abc123",
+            artifactPath: path.join(wechatArtifactsDir, "codex.wechat.install-launch-evidence.json")
+          }
+        ]
+      }
+    },
+    blockers: []
+  });
+
+  const previousCwd = process.cwd();
+  process.chdir(workspace);
+  try {
+    const report = buildReleaseGateSummaryReport(
+      { targetSurface: "wechat" },
+      {
+        commit: "abc123",
+        shortCommit: "abc123",
+        branch: "test-branch",
+        dirty: false
+      }
+    );
+
+    assert.equal(report.summary.status, "passed");
+    assert.deepEqual(report.summary.failedGateIds, []);
+    assert.equal(report.inputs.snapshotPath && fs.realpathSync(report.inputs.snapshotPath), fs.realpathSync(snapshotPath));
+    assert.equal(report.inputs.h5SmokePath && fs.realpathSync(report.inputs.h5SmokePath), fs.realpathSync(h5SmokePath));
+    assert.equal(report.inputs.reconnectSoakPath && fs.realpathSync(report.inputs.reconnectSoakPath), fs.realpathSync(reconnectSoakPath));
+    assert.equal(report.inputs.wechatArtifactsDir && fs.realpathSync(report.inputs.wechatArtifactsDir), fs.realpathSync(wechatArtifactsDir));
+    assert.equal(
+      report.inputs.wechatCandidateSummaryPath && fs.realpathSync(report.inputs.wechatCandidateSummaryPath),
+      fs.realpathSync(wechatCandidateSummaryPath)
+    );
+    assert.equal(
+      report.inputs.wechatRcValidationPath && fs.realpathSync(report.inputs.wechatRcValidationPath),
+      fs.realpathSync(wechatRcValidationPath)
+    );
+    assert.equal(
+      report.inputs.wechatSmokeReportPath && fs.realpathSync(report.inputs.wechatSmokeReportPath),
+      fs.realpathSync(wechatSmokeReportPath)
+    );
+  } finally {
+    process.chdir(previousCwd);
+  }
+});
+
 test("buildReleaseGateSummaryReport marks reconnect soak evidence stale when the artifact is old for the current candidate", () => {
   const workspace = createTempWorkspace();
   const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-stale.json");
@@ -347,6 +538,7 @@ test("buildReleaseGateSummaryReport surfaces stale manual evidence ledger owners
   const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
   const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
+  const wechatArtifactsDir = path.join(workspace, "artifacts", "wechat-release");
   const manualEvidenceLedgerPath = path.join(
     workspace,
     "artifacts",
@@ -417,6 +609,7 @@ test("buildReleaseGateSummaryReport surfaces stale manual evidence ledger owners
   });
 
   fs.mkdirSync(path.dirname(manualEvidenceLedgerPath), { recursive: true });
+  fs.mkdirSync(wechatArtifactsDir, { recursive: true });
   fs.writeFileSync(
     manualEvidenceLedgerPath,
     `# Manual Release Evidence Owner Ledger
@@ -443,6 +636,7 @@ test("buildReleaseGateSummaryReport surfaces stale manual evidence ledger owners
       snapshotPath,
       h5SmokePath,
       reconnectSoakPath,
+      wechatArtifactsDir,
       manualEvidenceLedgerPath,
       targetSurface: "h5"
     },
@@ -545,6 +739,7 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
   const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
   const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
   const wechatSmokeReportPath = path.join(workspace, "artifacts", "wechat-release", "codex.wechat.smoke-report.json");
+  const wechatArtifactsDir = path.dirname(wechatSmokeReportPath);
 
   writeJson(snapshotPath, {
     generatedAt: isoHoursAgo(2),
@@ -640,6 +835,7 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
       snapshotPath,
       h5SmokePath,
       reconnectSoakPath,
+      wechatArtifactsDir,
       wechatSmokeReportPath,
       targetSurface: "wechat"
     },
@@ -661,7 +857,10 @@ test("buildReleaseGateSummaryReport reports blocked WeChat device evidence disti
   assert.match(report.triage.blockers[1]?.summary ?? "", /blocked wechat/i);
   assert.match(report.gates[0]?.summary ?? "", /not release-ready/);
   assert.match(report.gates[3]?.summary ?? "", /blocked/i);
-  assert.match(report.gates[3]?.failures.join("\n") ?? "", /blocked pending device evidence|WeChat smoke case is blocked/);
+  assert.match(
+    report.gates[3]?.failures.join("\n") ?? "",
+    /blocked pending device evidence|WeChat smoke case is blocked|WeChat candidate summary status is "blocked"|Manual review pending/
+  );
   assert.match(renderMarkdown(report), /### Blockers \(2\)/);
   assert.match(renderMarkdown(report), /Release readiness snapshot blocked wechat/);
   assert.match(renderMarkdown(report), /### Manual Evidence Ownership/);

--- a/scripts/test/wechat-release-artifacts.test.ts
+++ b/scripts/test/wechat-release-artifacts.test.ts
@@ -214,6 +214,66 @@ function writeManualChecks(filePath: string, checks: ManualReviewCheckPayload[])
   fs.writeFileSync(filePath, `${JSON.stringify(checks, null, 2)}\n`, "utf8");
 }
 
+function buildPassingManualChecks(): ManualReviewCheckPayload[] {
+  return [
+    {
+      id: "wechat-devtools-export-review",
+      title: "Candidate-scoped WeChat package install/launch verification recorded",
+      status: "passed",
+      required: true,
+      notes: "Generated the install/launch verification artifact for the same revision.",
+      evidence: ["artifacts/wechat-release/codex.wechat.install-launch-evidence.json"],
+      owner: "release-oncall",
+      recordedAt: isoHoursAgo(2),
+      revision: sourceRevision,
+      artifactPath: "artifacts/wechat-release/codex.wechat.install-launch-evidence.json"
+    },
+    {
+      id: "wechat-device-runtime-review",
+      title: "Physical-device WeChat runtime validated for this candidate",
+      status: "passed",
+      required: true,
+      notes: "Attached the smoke report and capture set from the device validation pass for the same revision.",
+      evidence: ["artifacts/wechat-release/codex.wechat.smoke-report.json", "device-runtime.mp4"],
+      owner: "release-oncall",
+      recordedAt: isoHoursAgo(2),
+      revision: sourceRevision,
+      artifactPath: "artifacts/wechat-release/device-runtime-review.json"
+    },
+    {
+      id: "wechat-runtime-observability-signoff",
+      title: "WeChat runtime observability reviewed for this candidate",
+      status: "passed",
+      required: true,
+      notes: "Captured health, diagnostic snapshot, and metrics evidence for the release environment.",
+      evidence: [
+        "/api/runtime/health payload",
+        "/api/runtime/diagnostic-snapshot?format=text",
+        "/api/runtime/metrics scrape"
+      ],
+      owner: "release-oncall",
+      recordedAt: isoHoursAgo(2),
+      revision: sourceRevision,
+      artifactPath: "artifacts/wechat-release/runtime-observability-signoff.json"
+    },
+    {
+      id: "wechat-release-checklist",
+      title: "WeChat RC checklist and blockers reviewed",
+      status: "passed",
+      required: true,
+      notes: "Checklist and blockers resolved for the packaged candidate.",
+      evidence: [
+        "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
+        "docs/release-evidence/cocos-wechat-rc-blockers.template.md"
+      ],
+      owner: "release-oncall",
+      recordedAt: isoHoursAgo(2),
+      revision: sourceRevision,
+      artifactPath: "artifacts/wechat-release/checklist-review.json"
+    }
+  ];
+}
+
 test("verify:wechat-release supports explicit artifact paths and keep-extracted output", () => {
   const artifact = packageFixtureArtifact();
 
@@ -502,63 +562,7 @@ test("validate:wechat-rc marks the candidate ready when smoke evidence and manua
   const summaryPath = path.join(artifact.artifactsDir, "codex.wechat.release-candidate-summary.json");
   const markdownPath = path.join(artifact.artifactsDir, "codex.wechat.release-candidate-summary.md");
   writePassingSmokeReport(artifact.metadataPath, smokeReportPath);
-  writeManualChecks(manualChecksPath, [
-    {
-      id: "wechat-devtools-export-review",
-      title: "Candidate-scoped WeChat package install/launch verification recorded",
-      status: "passed",
-      required: true,
-      notes: "Generated the install/launch verification artifact for the same revision.",
-      evidence: ["artifacts/wechat-release/codex.wechat.install-launch-evidence.json"],
-      owner: "release-oncall",
-      recordedAt: isoHoursAgo(2),
-      revision: sourceRevision,
-      artifactPath: "artifacts/wechat-release/codex.wechat.install-launch-evidence.json"
-    },
-    {
-      id: "wechat-device-runtime-review",
-      title: "Physical-device WeChat runtime validated for this candidate",
-      status: "passed",
-      required: true,
-      notes: "Attached the smoke report and capture set from the device validation pass for the same revision.",
-      evidence: ["artifacts/wechat-release/codex.wechat.smoke-report.json", "device-runtime.mp4"],
-      owner: "release-oncall",
-      recordedAt: isoHoursAgo(2),
-      revision: sourceRevision,
-      artifactPath: "artifacts/wechat-release/device-runtime-review.json"
-    },
-    {
-      id: "wechat-runtime-observability-signoff",
-      title: "WeChat runtime observability reviewed for this candidate",
-      status: "passed",
-      required: true,
-      notes: "Captured health, diagnostic snapshot, and metrics evidence for the release environment.",
-      evidence: [
-        "/api/runtime/health payload",
-        "/api/runtime/diagnostic-snapshot?format=text",
-        "/api/runtime/metrics scrape"
-      ],
-      owner: "release-oncall",
-      recordedAt: isoHoursAgo(2),
-      revision: sourceRevision,
-      artifactPath: "artifacts/wechat-release/runtime-observability-signoff.json"
-    },
-    {
-      id: "wechat-release-checklist",
-      title: "WeChat RC checklist and blockers reviewed",
-      status: "passed",
-      required: true,
-      notes: "Checklist and blockers resolved for the packaged candidate.",
-      evidence: [
-        "docs/release-evidence/cocos-wechat-rc-checklist.template.md",
-        "docs/release-evidence/cocos-wechat-rc-blockers.template.md"
-      ],
-      owner: "release-oncall",
-      recordedAt: isoHoursAgo(2),
-      revision: sourceRevision,
-      artifactPath: "artifacts/wechat-release/checklist-review.json"
-    }
-  ]);
+  writeManualChecks(manualChecksPath, buildPassingManualChecks());
 
   const output = execFileSync(
     "node",
@@ -624,6 +628,45 @@ test("validate:wechat-rc marks the candidate ready when smoke evidence and manua
   assert.match(fs.readFileSync(markdownPath, "utf8"), /## Device Runtime Evidence/);
   assert.match(fs.readFileSync(markdownPath, "utf8"), /reconnect details: roomId=room-alpha/);
   assert.match(fs.readFileSync(markdownPath, "utf8"), /share details: shareScene=lobby/);
+});
+
+test("validate:wechat-rc auto-detects candidate-scoped manual review evidence in the artifacts directory", () => {
+  const artifact = packageFixtureArtifact();
+  const smokeReportPath = path.join(artifact.artifactsDir, "codex.wechat.smoke-report.json");
+  const manualChecksPath = path.join(artifact.artifactsDir, "codex.wechat.manual-review.json");
+  const summaryPath = path.join(artifact.artifactsDir, "codex.wechat.release-candidate-summary.json");
+
+  writePassingSmokeReport(artifact.metadataPath, smokeReportPath);
+  writeManualChecks(manualChecksPath, buildPassingManualChecks());
+
+  const output = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/validate-wechat-release-candidate.ts",
+      "--artifacts-dir",
+      artifact.artifactsDir,
+      "--expected-revision",
+      sourceRevision,
+      "--require-smoke-report"
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8")) as {
+    candidate: { status: string };
+    evidence: { manualReview: { status: string; requiredPendingChecks: number } };
+  };
+
+  assert.match(output, /Candidate status: ready/);
+  assert.equal(summary.candidate.status, "ready");
+  assert.equal(summary.evidence.manualReview.status, "ready");
+  assert.equal(summary.evidence.manualReview.requiredPendingChecks, 0);
 });
 
 test("validate:wechat-rc blocks stale device runtime evidence in the candidate summary", () => {

--- a/scripts/validate-wechat-release-candidate.ts
+++ b/scripts/validate-wechat-release-candidate.ts
@@ -238,6 +238,11 @@ interface CandidateSummary {
 
 const OUTPUT_TAIL_BYTES = 4000;
 const MANUAL_REVIEW_MAX_AGE_MS = 1000 * 60 * 60 * 24;
+const AUTO_MANUAL_CHECK_FILENAMES = [
+  "codex.wechat.manual-review.json",
+  "wechat-manual-review.json",
+  "wechat-manual-checks.json"
+] as const;
 const DEFAULT_MANUAL_CHECKS: ManualReviewCheck[] = [
   {
     id: "wechat-devtools-export-review",
@@ -530,13 +535,40 @@ function resolveOptionalArtifactPath(explicitPath: string | undefined, fallbackP
   return fs.existsSync(fallbackPath) ? fallbackPath : undefined;
 }
 
+function resolveAutoManualChecksPath(args: Args): string | undefined {
+  if (args.manualChecksPath || args.manualChecks.length > 0) {
+    return undefined;
+  }
+
+  const candidateRoots = new Set<string>();
+  if (args.artifactsDir) {
+    candidateRoots.add(path.resolve(args.artifactsDir));
+  }
+  if (args.metadataPath) {
+    candidateRoots.add(path.dirname(path.resolve(args.metadataPath)));
+  }
+
+  for (const root of candidateRoots) {
+    for (const filename of AUTO_MANUAL_CHECK_FILENAMES) {
+      const candidatePath = path.join(root, filename);
+      if (fs.existsSync(candidatePath)) {
+        return candidatePath;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 function readManualChecks(args: Args): ManualReviewCheck[] {
-  if (!args.manualChecksPath && args.manualChecks.length === 0) {
+  const manualChecksPath = args.manualChecksPath ?? resolveAutoManualChecksPath(args);
+
+  if (!manualChecksPath && args.manualChecks.length === 0) {
     return DEFAULT_MANUAL_CHECKS.map((check) => ({ ...check, evidence: [...check.evidence] }));
   }
 
-  const fromFile = args.manualChecksPath
-    ? parseManualChecksFile(args.manualChecksPath).map((check) => ({
+  const fromFile = manualChecksPath
+    ? parseManualChecksFile(manualChecksPath).map((check) => ({
         id: check.id,
         title: check.title,
         required: check.required,

--- a/tests/e2e/daily-quest-claim.spec.ts
+++ b/tests/e2e/daily-quest-claim.spec.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "./fixtures";
 import { pollForAnalyticsEvent } from "./analytics-helpers";
-import { buildRoomId, expectHeroMoveSpent, pressTile, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
+import { acceptLobbyPrivacyConsent, buildRoomId, expectHeroMoveSpent, pressTile, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
 
 const QUEST_ID = "smoke_resource_pickup";
 const QUEST_REWARD = { gems: 2, gold: 35 };
@@ -75,6 +75,7 @@ async function enterRoomThroughLobby(page: Page, roomId: string, playerId: strin
   await page.locator("[data-lobby-room-id]").fill(roomId);
   await page.locator("[data-lobby-player-id]").fill(playerId);
   await page.locator("[data-lobby-display-name]").fill(displayName);
+  await acceptLobbyPrivacyConsent(page);
   await page.locator("[data-enter-room]").click();
 
   await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,6 +1,7 @@
 import { test as base } from "@playwright/test";
 
 const SERVER_BASE_URL = "http://127.0.0.1:2567";
+const CLIENT_BASE_URL = "http://127.0.0.1:4173";
 const RESET_ENDPOINT = `${SERVER_BASE_URL}/api/test/reset-store`;
 
 /**
@@ -28,10 +29,12 @@ export const test = base.extend({
       console.warn("Failed to reset store:", error);
     }
 
-    // Clear browser storage to prevent auth token reuse
-    // We must do this AFTER server reset but BEFORE test navigates
-    // Navigate to any URL first to establish context, then clear storage
+    // Clear browser storage to prevent auth token reuse.
+    // We must establish the H5 origin first, otherwise localStorage/sessionStorage
+    // access will throw before the first navigation and stale reconnect tokens leak
+    // into the next test.
     try {
+      await page.goto(CLIENT_BASE_URL, { waitUntil: "domcontentloaded" });
       await page.evaluate(() => {
         localStorage.clear();
         sessionStorage.clear();

--- a/tests/e2e/golden-path-player-journey.spec.ts
+++ b/tests/e2e/golden-path-player-journey.spec.ts
@@ -9,6 +9,7 @@ import {
   getNeutralBattleRewardText
 } from "./config-fixtures";
 import {
+  acceptLobbyPrivacyConsent,
   attackOnce,
   buildRoomId,
   dismissBattleModal,
@@ -31,6 +32,7 @@ test("golden path player journey stays stable from lobby entry through world pro
       await page.locator("[data-lobby-room-id]").fill(roomId);
       await page.locator("[data-lobby-player-id]").fill("player-1");
       await page.locator("[data-lobby-display-name]").fill("Golden Path Guest");
+      await acceptLobbyPrivacyConsent(page);
       await page.locator("[data-enter-room]").click();
 
       await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));

--- a/tests/e2e/h5-connectivity-smoke.spec.ts
+++ b/tests/e2e/h5-connectivity-smoke.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "./fixtures";
-import { buildRoomId, fullMoveTextPattern, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
+import { acceptLobbyPrivacyConsent, buildRoomId, fullMoveTextPattern, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
 
 interface RuntimeDiagnosticSnapshot {
   room?: {
@@ -53,6 +53,7 @@ test("h5 smoke reaches lobby http path and room websocket path", async ({ page }
     await page.locator("[data-lobby-room-id]").fill(roomId);
     await page.locator("[data-lobby-player-id]").fill(playerId);
     await page.locator("[data-lobby-display-name]").fill("Connectivity Smoke");
+    await acceptLobbyPrivacyConsent(page);
     await page.locator("[data-enter-room]").click();
 
     await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));

--- a/tests/e2e/lobby-smoke.spec.ts
+++ b/tests/e2e/lobby-smoke.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test, type Page } from "./fixtures";
-import { buildRoomId, expectRoomReady, fullMoveTextPattern, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
+import {
+  acceptLobbyPrivacyConsent,
+  buildRoomId,
+  expectRoomReady,
+  fullMoveTextPattern,
+  waitForLobbyReady,
+  withSmokeDiagnostics
+} from "./smoke-helpers";
 
 async function expectEnteredRoom(page: Page, roomId: string, playerId?: string): Promise<void> {
   await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
@@ -30,6 +37,7 @@ test("lobby opens and a guest can enter a room", async ({ page }, testInfo) => {
     await page.locator("[data-lobby-room-id]").fill(roomId);
     await page.locator("[data-lobby-player-id]").fill("player-1");
     await page.locator("[data-lobby-display-name]").fill("Smoke Guest");
+    await acceptLobbyPrivacyConsent(page);
     await page.locator("[data-enter-room]").click();
 
     await expectEnteredRoom(page, roomId, "player-1");
@@ -56,6 +64,7 @@ test("lobby reuses a cached guest session when entering a room", async ({ page }
     await waitForLobbyReady(page);
     await expect(page.getByText("已缓存本地会话：cached-guest-1")).toBeVisible();
     await page.locator("[data-lobby-room-id]").fill(roomId);
+    await acceptLobbyPrivacyConsent(page);
     await page.locator("[data-enter-room]").click();
 
     await expectEnteredRoom(page, roomId, "cached-guest-1");
@@ -76,6 +85,7 @@ test("lobby supports formal registration and enters the room with an account ses
     await page.locator("[data-lobby-login-id]").fill(loginId);
     await page.locator("[data-registration-display-name]").fill(displayName);
     await page.locator("[data-registration-password]").fill(password);
+    await acceptLobbyPrivacyConsent(page);
     await page.locator("[data-request-registration]").click();
 
     await expect(page.locator("[data-registration-token]")).toHaveValue(/\S+/, { timeout: 10_000 });
@@ -135,6 +145,7 @@ test("lobby supports password recovery and rotates the account password before e
     await waitForLobbyReady(page);
     await page.locator("[data-lobby-room-id]").fill(roomId);
     await page.locator("[data-lobby-login-id]").fill(loginId);
+    await acceptLobbyPrivacyConsent(page);
     await page.locator("[data-request-recovery]").click();
 
     await expect(page.locator("[data-recovery-token]")).toHaveValue(/\S+/, { timeout: 10_000 });

--- a/tests/e2e/onboarding-funnel.spec.ts
+++ b/tests/e2e/onboarding-funnel.spec.ts
@@ -1,6 +1,6 @@
 import type { APIRequestContext, Page } from "@playwright/test";
 import { expect, test } from "./fixtures";
-import { buildRoomId, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
+import { acceptLobbyPrivacyConsent, buildRoomId, waitForLobbyReady, withSmokeDiagnostics } from "./smoke-helpers";
 
 const SERVER_BASE_URL = "http://127.0.0.1:2567";
 
@@ -35,6 +35,7 @@ async function enterRoomThroughLobby(page: Page, roomId: string, playerId: strin
   await page.locator("[data-lobby-room-id]").fill(roomId);
   await page.locator("[data-lobby-player-id]").fill(playerId);
   await page.locator("[data-lobby-display-name]").fill(displayName);
+  await acceptLobbyPrivacyConsent(page);
   await page.locator("[data-enter-room]").click();
 
   await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
@@ -195,6 +196,7 @@ test("onboarding funnel: returning players do not re-enter the tutorial after co
 
     const secondRoomId = buildRoomId("e2e-onboarding-return-second");
     await page.locator("[data-lobby-room-id]").fill(secondRoomId);
+    await acceptLobbyPrivacyConsent(page);
     await page.locator("[data-enter-room]").click();
 
     await expect(page).toHaveURL(new RegExp(`roomId=${secondRoomId}`));

--- a/tests/e2e/release-candidate-artifact-smoke.spec.ts
+++ b/tests/e2e/release-candidate-artifact-smoke.spec.ts
@@ -1,13 +1,15 @@
 import { expect, test, type Page } from "./fixtures";
-import { buildRoomId, expectRoomReady, fullMoveTextPattern, withSmokeDiagnostics } from "./smoke-helpers";
+import { acceptLobbyPrivacyConsent, buildRoomId, expectRoomReady, fullMoveTextPattern, withSmokeDiagnostics } from "./smoke-helpers";
 
 async function expectEnteredRoom(page: Page, roomId: string, playerId: string): Promise<void> {
   await expect(page).toHaveURL(new RegExp(`roomId=${roomId}`));
   await expectRoomReady(page, {
     roomId,
     playerId,
-    expectedMoveText: fullMoveTextPattern(playerId)
+    expectedMoveText: fullMoveTextPattern(playerId),
+    requireDiagnosticsPanel: false
   });
+  await expect(page.getByTestId("event-log")).toContainText("会话已连接", { timeout: 10_000 });
 }
 
 test("rc-artifact: guest login reaches lobby and room boot", async ({ page }, testInfo) => {
@@ -23,11 +25,11 @@ test("rc-artifact: guest login reaches lobby and room boot", async ({ page }, te
     await page.locator("[data-lobby-room-id]").fill(roomId);
     await page.locator("[data-lobby-player-id]").fill(playerId);
     await page.locator("[data-lobby-display-name]").fill("RC Smoke Guest");
+    await acceptLobbyPrivacyConsent(page);
     await page.locator("[data-enter-room]").click();
 
     await expectEnteredRoom(page, roomId, playerId);
     await expect(page.getByTestId("account-card")).toContainText("RC Smoke Guest");
-    await expect(page.getByTestId("event-log")).toContainText("已加入房间", { timeout: 10_000 });
   });
 });
 
@@ -52,11 +54,10 @@ test("rc-artifact: cached session restore reaches room boot", async ({ page }, t
 
     await expect(page.getByText("已缓存本地会话：cached-guest-1")).toBeVisible();
     await page.locator("[data-lobby-room-id]").fill(roomId);
+    await acceptLobbyPrivacyConsent(page);
     await page.locator("[data-enter-room]").click();
 
     await expectEnteredRoom(page, roomId, playerId);
     await expect(page.getByTestId("account-card")).toContainText("Cached RC Guest");
-    // Room entry shows "会话已连接。Room {roomId} / Player {playerId}" instead of "已加入房间"
-    await expect(page.getByTestId("event-log")).toContainText("会话已连接", { timeout: 10_000 });
   });
 });

--- a/tests/e2e/smoke-helpers.ts
+++ b/tests/e2e/smoke-helpers.ts
@@ -8,6 +8,7 @@ interface RoomSessionOptions {
   roomId: string;
   playerId: string;
   expectedMoveText?: RegExp | null;
+  requireDiagnosticsPanel?: boolean;
 }
 
 interface ReconnectOptions extends RoomSessionOptions {
@@ -107,6 +108,16 @@ export async function waitForLobbyReady(page: Page): Promise<void> {
   });
 }
 
+export async function acceptLobbyPrivacyConsent(page: Page): Promise<void> {
+  await test.step("setup: accept lobby privacy consent", async () => {
+    const consentCheckbox = page.locator("[data-privacy-consent]").first();
+    await expect(consentCheckbox).toBeVisible();
+    if (!(await consentCheckbox.isChecked())) {
+      await consentCheckbox.check();
+    }
+  });
+}
+
 export async function expectHeroMove(page: Page, remaining: number, playerId = "player-1"): Promise<void> {
   await expect(page.getByTestId("hero-move")).toHaveText(moveTextPattern(remaining, playerId), { timeout: 10_000 });
 }
@@ -144,8 +155,10 @@ export async function openRoom(page: Page, options: RoomSessionOptions): Promise
 export async function expectRoomReady(page: Page, options: RoomSessionOptions): Promise<void> {
   await expect(page.getByTestId("session-meta")).toContainText(`Room: ${options.roomId}`);
   await expect(page.getByTestId("session-meta")).toContainText(`Player: ${options.playerId}`);
-  await expect(page.getByTestId("diagnostic-panel")).toBeVisible();
-  await expect(page.getByTestId("diagnostic-connection-status")).toHaveText("已连接");
+  if (options.requireDiagnosticsPanel !== false) {
+    await expect(page.getByTestId("diagnostic-panel")).toBeVisible();
+    await expect(page.getByTestId("diagnostic-connection-status")).toHaveText("已连接");
+  }
   await expect(page.getByTestId("room-connection-summary")).toContainText("已连接");
   if (options.expectedMoveText) {
     await expect(page.getByTestId("hero-move")).toHaveText(options.expectedMoveText, { timeout: 10_000 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,9 @@
     "resolveJsonModule": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "paths": {
+      "cc": ["packages/cc-runtime-stub/index.js"]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": []
+}


### PR DESCRIPTION
## Summary

Closes #1173.

This closes the remaining same-revision evidence gaps for the WeChat release gate.

- fix guest auth refresh so a refreshed bearer token can still rejoin a room during packaged RC smoke
- make WeChat RC validation reuse candidate-scoped manual review metadata from copied artifacts
- make release gate summary discover nested candidate rehearsal evidence and ignore dashboard snapshots when selecting the pinned release-readiness snapshot
- align H5 packaged RC smoke helpers with the current privacy-consent flow and packaged UI expectations
- add root tsconfig support for tsx tooling so ops/release scripts resolve the same path aliases from repo root
- document the updated recursive/manual-review evidence behavior and record the work in progress.md

## Why

The release gate was still blocked even after candidate-level artifacts were present because the gate could select the wrong snapshot, the copied WeChat artifacts lost their manual-review state, and the packaged H5 smoke could fail after guest session refresh.

## Impact

- `release:phase1:candidate-rehearsal -- --target-surface wechat` can now rebuild a same-revision candidate bundle cleanly
- `release:gate:summary -- --target-surface wechat` now passes on the current candidate revision once the evidence chain is present
- packaged H5 RC smoke no longer regresses on guest session refresh / room restore

## Validation

- `npm run typecheck:server`
- `npm run typecheck:ops`
- `node --import tsx --test ./scripts/test/wechat-release-artifacts.test.ts ./scripts/test/release-gate-summary.test.ts ./scripts/test/phase1-candidate-rehearsal.test.ts`
- `npm run smoke:client:release-candidate -- --output /tmp/issue1173-release-gate-be58a8f/client-release-candidate-smoke-be58a8f.json`
- `npm run release:reconnect-soak -- --candidate issue-1173-wechat-gate --candidate-revision be58a8fcc58a0c6bd19462338f7b27fcec30672a --output /tmp/issue1173-release-gate-be58a8f/colyseus-reconnect-soak-summary-issue-1173-wechat-gate-be58a8f.json --markdown-output /tmp/issue1173-release-gate-be58a8f/colyseus-reconnect-soak-summary-issue-1173-wechat-gate-be58a8f.md`
- `npm run package:wechat-release -- --config apps/cocos-client/wechat-minigame.build.json --output-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir /tmp/issue1173-release-gate-be58a8f/wechat-release --expect-exported-runtime --source-revision be58a8fcc58a0c6bd19462338f7b27fcec30672a`
- `npm run smoke:wechat-release -- --artifacts-dir /tmp/issue1173-release-gate-be58a8f/wechat-release --report /tmp/issue1173-release-gate-be58a8f/wechat-release/codex.wechat.smoke-report.json --runtime-evidence /tmp/issue1173-release-gate-be58a8f/wechat-runtime-evidence.json`
- `npm run smoke:wechat-release -- --artifacts-dir /tmp/issue1173-release-gate-be58a8f/wechat-release --check --expected-revision be58a8fcc58a0c6bd19462338f7b27fcec30672a`
- `npm run validate:wechat-rc -- --artifacts-dir /tmp/issue1173-release-gate-be58a8f/wechat-release --expected-revision be58a8fcc58a0c6bd19462338f7b27fcec30672a --require-smoke-report --manual-checks /tmp/issue1173-release-gate-be58a8f/wechat-manual-checks.json`
- `npm run release:phase1:candidate-rehearsal -- --candidate issue-1173-wechat-gate --output-dir artifacts/release-readiness/phase1-candidate-rehearsal-issue-1173-be58a8f --h5-smoke /tmp/issue1173-release-gate-be58a8f/client-release-candidate-smoke-be58a8f.json --reconnect-soak /tmp/issue1173-release-gate-be58a8f/colyseus-reconnect-soak-summary-issue-1173-wechat-gate-be58a8f.json --wechat-artifacts-dir /tmp/issue1173-release-gate-be58a8f/wechat-release --validate-status success --wechat-build-status success --client-rc-smoke-status success --target-surface wechat`
- `npm run release:gate:summary -- --target-surface wechat`