### PR TITLE
[codex] bundle WeChat RC DevTools evidence

### DIFF
--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -393,11 +393,14 @@ Relevant scripts: 48
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/wechat-release-rehearsal.ts`
-- Purpose: Run the WeChat release rehearsal flow that chains prepare, package, verify, and validate steps into one summary.
+- Purpose: Run the WeChat release rehearsal flow that chains prepare, package, verify, and optionally install/launch evidence, smoke, and RC validation into one summary.
 - Required inputs:
   - A WeChat build directory plus an artifacts directory; optional config/summary path overrides.
+  - Pass `--candidate --environment --operator --status` to record DevTools install/launch evidence during the same run.
+  - Pass `--runtime-evidence <json>` to generate `codex.wechat.smoke-report.json` during the same run.
+  - Pass `--manual-checks <json>` when the rehearsal should also emit a ready/blocked candidate summary instead of a pending template.
 - Produced artifacts:
-  - Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, and upload artifacts it references.
+  - Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, install/launch evidence, and upload artifacts it references.
 
 ## `smoke:client:boot-room`
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -30,7 +30,7 @@
 - 产出发布归档：`npm run package:wechat-release -- --output-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> --expect-exported-runtime [--source-revision <git-sha>]`
 - 记录 candidate-scoped 安装/启动证据：`npm run release:wechat:install-launch-evidence -- --artifacts-dir <release-artifacts-dir> --candidate <candidate-name> --environment <wechat-devtools|device-lab|qa-phone> --operator <name> --status <passed|failed> [--candidate-revision <git-sha>] [--summary <text>] [--evidence <path-or-note>]`
 - 聚合校验 RC artifact：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report] [--manual-checks docs/release-evidence/wechat-release-manual-review.example.json]`
-- 发布彩排与汇总：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> [--summary <json>] [--markdown <md>]`（顺序执行 prepare / package / verify / validate，并输出结构化 + Markdown 摘要）
+- 发布彩排与汇总：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> [--summary <json>] [--markdown <md>] [--candidate <candidate-name> --environment wechat-devtools --operator <name> --status <passed|failed> --evidence <capture-or-note> --runtime-evidence <runtime-evidence.json> --manual-checks <manual-review.json>]`（顺序执行 prepare / package / verify，并可选补 install/launch evidence、smoke report、validate，输出结构化 + Markdown 摘要）
 - 上传已打包产物：`npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`
 - 按 SHA 下载 CI artifact：`npm run download:wechat-release -- --sha <git-sha> [--output-dir artifacts/downloaded/wechat-release-<git-sha>]`
 - 验收已下载 artifact：`npm run verify:wechat-release -- --artifacts-dir <downloaded-artifact-dir> [--expected-revision <git-sha>]`
@@ -127,12 +127,16 @@ WeChat checklist / blockers 至少要覆盖以下证据面：
 
 ## 发布彩排摘要
 
-`npm run release:wechat:rehearsal` 用于把准备 / 打包 / 验证 / RC 聚合这四个阶段一次跑完，并把结果写成稳定的 CI 证据：
+`npm run release:wechat:rehearsal` 用于把准备 / 打包 / 验证 / RC 聚合一次跑完；当你同时传入 candidate、DevTools 证据和 runtime/manual-review 输入时，它也能直接把 WeChat RC 证据包收成一条可归档记录：
 
 - 默认读取 `apps/cocos-client/wechat-minigame.build.json`，也可用 `--build-dir` / `--artifacts-dir` 覆盖输入输出。
-- 顺序执行 `prepare:wechat-release`、`package:wechat-release`、`verify:wechat-release`、`validate:wechat-rc`，任一阶段失败后续阶段会被标记为 `skipped`。
+- 默认顺序执行 `prepare:wechat-release`、`package:wechat-release`、`verify:wechat-release`、`validate:wechat-rc`，任一阶段失败后续阶段会被标记为 `skipped`。
+- 当传入 `--candidate --environment --operator --status` 时，会额外执行 `release:wechat:install-launch-evidence`，把微信开发者工具导入 / 首启结论直接挂到同一 artifacts dir。
+- 当传入 `--runtime-evidence <json>` 时，会额外执行 `smoke:wechat-release -- --force`，直接生成同 revision 的 `codex.wechat.smoke-report.json`。
+- 当传入 `--manual-checks <json>` 时，最终 `validate:wechat-rc` 会复用这份 manual review JSON 生成 ready/blocked 的 candidate summary，而不是只停在 pending 模板。
 - 结构化摘要默认写到 `artifacts/wechat-release/wechat-release-rehearsal-<short-sha>.json`，Markdown 摘要写到同名 `.md`；可通过 `--summary` / `--markdown` 改写路径。
 - JSON 摘要包含阶段命令、耗时、stdout / stderr tail 以及首个失败阶段的诊断，Markdown 版本可直接贴到 CI Summary 或 PR。
+- `## Artifacts` 现在会自动列出 install/launch evidence、smoke report、candidate summary 等关键证据，方便 reviewer 直接校对同一个候选 revision。
 - `--source-revision`、`--expected-revision`、`--package-name`、`--version`、`--require-smoke-report` 会透传给对应脚本，方便对齐真实提审参数。
 - 适合在本地 release rehearsal、或在 CI 下载模板导出夹具时，一次性确认整个链路仍能跑通。
 

--- a/progress.md
+++ b/progress.md
@@ -1505,3 +1505,22 @@ Original prompt: 你先学习下当前项目并给出开发的计划
   - `npm run typecheck:server` 通过
   - `npm run typecheck:ops` 通过
   - `node --import tsx --test ./scripts/test/wechat-release-artifacts.test.ts ./scripts/test/release-gate-summary.test.ts ./scripts/test/phase1-candidate-rehearsal.test.ts` 通过
+
+## Issue #1174 - WeChat RC DevTools evidence bundle - 2026-04-10
+
+- 本轮把 `release:wechat:rehearsal` 从“prepare / package / verify / validate”四段式彩排，补成了能直接收口 WeChat RC 证据包的工作流：
+  - `scripts/wechat-release-rehearsal.ts`
+    - 新增可选的 `install-launch-evidence` 阶段：当传入 `--candidate --environment --operator --status` 时，会自动调用 `release:wechat:install-launch-evidence`
+    - 新增可选的 `smoke` 阶段：当传入 `--runtime-evidence <json>` 时，会自动生成同目录的 `codex.wechat.smoke-report.json`
+    - `validate` 阶段现在支持直接复用 `--manual-checks <json>`，这样同一条 rehearsal 可以把 candidate summary / RC validation / smoke / DevTools 验收记录一起收成一个 artifacts dir
+    - 摘要里的 `## Artifacts` 也补出了 `codex.wechat.install-launch-evidence.json/.md`，方便 reviewer 直接校对同一候选 revision 的开发者工具验收记录
+  - `scripts/test/wechat-release-rehearsal.test.ts`
+    - 新增“带 DevTools install-launch evidence + runtime evidence + manual review”的完整 rehearsal 覆盖
+    - 锁住新增阶段顺序、artifact 检测和 candidate summary 产出，避免以后回退到只剩 package/verify
+  - `docs/wechat-minigame-release.md`
+    - 补上了一条 one-shot 命令示例，说明如何在同一次 rehearsal 里把 DevTools 验收记录、smoke report 和 candidate summary 收到同一候选包
+  - `docs/release-script-inventory.md`
+    - 同步更新 `release:wechat:rehearsal` 的能力说明与产物列表
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/wechat-release-artifacts.test.ts` 通过

--- a/scripts/test/wechat-release-rehearsal.test.ts
+++ b/scripts/test/wechat-release-rehearsal.test.ts
@@ -15,8 +15,173 @@ test("release:wechat:rehearsal produces structured + markdown summaries", () => 
   const artifactsDir = path.join(workspace, "artifacts");
   const summaryPath = path.join(workspace, "summary.json");
   const markdownPath = path.join(workspace, "summary.md");
+  const runtimeEvidencePath = path.join(workspace, "runtime-evidence.json");
+  const manualChecksPath = path.join(workspace, "manual-review.json");
+  const recordedAt = new Date().toISOString();
 
   fs.cpSync(fixtureBuildDir, buildDir, { recursive: true });
+  fs.mkdirSync(artifactsDir, { recursive: true });
+
+  fs.writeFileSync(
+    runtimeEvidencePath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        buildTemplatePlatform: "wechatgame",
+        artifact: {
+          archiveFileName: "project-veil-wechatgame-release.tar.gz",
+          sourceRevision: "abc1234"
+        },
+        execution: {
+          tester: "codex-bot",
+          device: "iPhone 15 Pro / WeChat 8.0.50",
+          clientVersion: "8.0.50",
+          executedAt: recordedAt,
+          result: "passed",
+          summary: "Imported runtime evidence from the rehearsal lane."
+        },
+        cases: [
+          { id: "startup", status: "passed", evidence: ["startup.mp4"] },
+          { id: "lobby-entry", status: "passed", evidence: ["lobby.png"] },
+          { id: "room-entry", status: "passed", evidence: ["room-entry.png"] },
+          {
+            id: "reconnect-recovery",
+            status: "passed",
+            evidence: ["reconnect.mp4"],
+            requiredEvidence: {
+              roomId: "room-alpha",
+              reconnectPrompt: "连接已恢复",
+              restoredState: "Restored room-alpha with the same hero state and lobby context."
+            }
+          },
+          {
+            id: "share-roundtrip",
+            status: "not_applicable",
+            evidence: ["share-roundtrip.txt"],
+            requiredEvidence: {
+              shareScene: "lobby",
+              shareQuery: "roomId=room-alpha&inviterId=player-7",
+              roundtripState: "Not executed in this rehearsal lane."
+            }
+          },
+          { id: "key-assets", status: "passed", evidence: ["assets.log"] }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "runtime-observability-signoff.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "checklist-review.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed",
+        blockerIds: ["none"]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "device-runtime-review.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    manualChecksPath,
+    `${JSON.stringify(
+      [
+        {
+          id: "wechat-devtools-export-review",
+          title: "Candidate-scoped WeChat package install/launch verification recorded",
+          status: "passed",
+          required: true,
+          notes: "Generated install/launch verification during the rehearsal.",
+          evidence: [path.join(artifactsDir, "codex.wechat.install-launch-evidence.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "codex.wechat.install-launch-evidence.json")
+        },
+        {
+          id: "wechat-device-runtime-review",
+          title: "Physical-device WeChat runtime validated for this candidate",
+          status: "passed",
+          required: true,
+          notes: "Attached the smoke report and capture set from the rehearsal runtime pass.",
+          evidence: [
+            path.join(artifactsDir, "codex.wechat.smoke-report.json"),
+            path.join(artifactsDir, "device-runtime-review.json")
+          ],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "device-runtime-review.json")
+        },
+        {
+          id: "wechat-runtime-observability-signoff",
+          title: "WeChat runtime observability reviewed for this candidate",
+          status: "passed",
+          required: true,
+          notes: "Captured health/auth-readiness/metrics evidence for the release environment.",
+          evidence: [path.join(artifactsDir, "runtime-observability-signoff.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "runtime-observability-signoff.json")
+        },
+        {
+          id: "wechat-release-checklist",
+          title: "WeChat RC checklist and blockers reviewed",
+          status: "passed",
+          required: true,
+          notes: "Checklist and blockers resolved for the packaged candidate.",
+          evidence: [path.join(artifactsDir, "checklist-review.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "checklist-review.json")
+        }
+      ],
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
 
   const output = execFileSync(
     "node",
@@ -37,7 +202,26 @@ test("release:wechat:rehearsal produces structured + markdown summaries", () => 
       "--source-revision",
       "abc1234",
       "--expected-revision",
-      "abc1234"
+      "abc1234",
+      "--candidate",
+      "phase1-rc",
+      "--environment",
+      "wechat-devtools",
+      "--operator",
+      "release-oncall",
+      "--status",
+      "passed",
+      "--verification-summary",
+      "Candidate rehearsal package import and first launch passed.",
+      "--evidence",
+      "devtools-import-capture.png",
+      "--evidence",
+      "first-launch-capture.png",
+      "--runtime-evidence",
+      runtimeEvidencePath,
+      "--manual-checks",
+      manualChecksPath,
+      "--require-smoke-report"
     ],
     {
       cwd: repoRoot,
@@ -57,10 +241,14 @@ test("release:wechat:rehearsal produces structured + markdown summaries", () => 
   assert.equal(report.summary.status, "passed");
   assert.deepEqual(
     report.stages.map((stage) => stage.status),
-    ["passed", "passed", "passed", "passed"]
+    ["passed", "passed", "passed", "passed", "passed", "passed"]
   );
   assert.ok(report.summary.artifacts.archivePath?.includes(".tar.gz"));
   assert.ok(report.summary.artifacts.metadataPath?.endsWith(".package.json"));
+  assert.ok(
+    report.summary.artifacts.installLaunchEvidenceJsonPath?.endsWith("codex.wechat.install-launch-evidence.json")
+  );
+  assert.ok(report.summary.artifacts.smokeReportPath?.endsWith("codex.wechat.smoke-report.json"));
   assert.ok(
     report.summary.artifacts.candidateSummaryJsonPath?.endsWith("codex.wechat.release-candidate-summary.json")
   );

--- a/scripts/wechat-release-rehearsal.ts
+++ b/scripts/wechat-release-rehearsal.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 type StageStatus = "passed" | "failed" | "skipped";
+type VerificationStatus = "passed" | "failed";
 
 interface Args {
   configPath: string;
@@ -15,6 +16,20 @@ interface Args {
   summaryPath?: string;
   markdownPath?: string;
   requireSmokeReport: boolean;
+  candidate?: string;
+  candidateRevision?: string;
+  environment?: string;
+  operator?: string;
+  recordedAt?: string;
+  status?: VerificationStatus;
+  installStatus?: VerificationStatus;
+  launchStatus?: VerificationStatus;
+  verificationSummary?: string;
+  installSummary?: string;
+  launchSummary?: string;
+  runtimeEvidencePath?: string;
+  manualChecksPath?: string;
+  evidence: string[];
 }
 
 interface GitRevision {
@@ -68,11 +83,23 @@ interface DetectedArtifacts {
   validationReportPath?: string;
   smokeReportPath?: string;
   uploadReceiptPath?: string;
+  installLaunchEvidenceJsonPath?: string;
+  installLaunchEvidenceMarkdownPath?: string;
   candidateSummaryJsonPath?: string;
   candidateSummaryMarkdownPath?: string;
 }
 
 const OUTPUT_LIMIT = 4000;
+
+function parseStatus(value: string | undefined, flag: string): VerificationStatus | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (value === "passed" || value === "failed") {
+    return value;
+  }
+  throw new Error(`Unsupported ${flag} value: ${value}`);
+}
 
 function parseArgs(argv: string[]): Args {
   let configPath = "apps/cocos-client/wechat-minigame.build.json";
@@ -85,6 +112,20 @@ function parseArgs(argv: string[]): Args {
   let summaryPath: string | undefined;
   let markdownPath: string | undefined;
   let requireSmokeReport = false;
+  let candidate: string | undefined;
+  let candidateRevision: string | undefined;
+  let environment: string | undefined;
+  let operator: string | undefined;
+  let recordedAt: string | undefined;
+  let status: VerificationStatus | undefined;
+  let installStatus: VerificationStatus | undefined;
+  let launchStatus: VerificationStatus | undefined;
+  let verificationSummary: string | undefined;
+  let installSummary: string | undefined;
+  let launchSummary: string | undefined;
+  let runtimeEvidencePath: string | undefined;
+  let manualChecksPath: string | undefined;
+  const evidence: string[] = [];
 
   for (let index = 2; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -139,6 +180,79 @@ function parseArgs(argv: string[]): Args {
       requireSmokeReport = true;
       continue;
     }
+    if (arg === "--candidate" && next) {
+      candidate = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--candidate-revision" && next) {
+      candidateRevision = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--environment" && next) {
+      environment = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--operator" && next) {
+      operator = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--recorded-at" && next) {
+      recordedAt = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--status" && next) {
+      status = parseStatus(next.trim(), "--status");
+      index += 1;
+      continue;
+    }
+    if (arg === "--install-status" && next) {
+      installStatus = parseStatus(next.trim(), "--install-status");
+      index += 1;
+      continue;
+    }
+    if (arg === "--launch-status" && next) {
+      launchStatus = parseStatus(next.trim(), "--launch-status");
+      index += 1;
+      continue;
+    }
+    if (arg === "--verification-summary" && next) {
+      verificationSummary = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--install-summary" && next) {
+      installSummary = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--launch-summary" && next) {
+      launchSummary = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--runtime-evidence" && next) {
+      runtimeEvidencePath = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--manual-checks" && next) {
+      manualChecksPath = next.trim() || undefined;
+      index += 1;
+      continue;
+    }
+    if (arg === "--evidence" && next) {
+      const value = next.trim();
+      if (value) {
+        evidence.push(value);
+      }
+      index += 1;
+      continue;
+    }
 
     throw new Error(`Unknown argument: ${arg}`);
   }
@@ -153,7 +267,21 @@ function parseArgs(argv: string[]): Args {
     ...(packageName ? { packageName } : {}),
     ...(summaryPath ? { summaryPath } : {}),
     ...(markdownPath ? { markdownPath } : {}),
-    requireSmokeReport
+    requireSmokeReport,
+    ...(candidate ? { candidate } : {}),
+    ...(candidateRevision ? { candidateRevision } : {}),
+    ...(environment ? { environment } : {}),
+    ...(operator ? { operator } : {}),
+    ...(recordedAt ? { recordedAt } : {}),
+    ...(status ? { status } : {}),
+    ...(installStatus ? { installStatus } : {}),
+    ...(launchStatus ? { launchStatus } : {}),
+    ...(verificationSummary ? { verificationSummary } : {}),
+    ...(installSummary ? { installSummary } : {}),
+    ...(launchSummary ? { launchSummary } : {}),
+    ...(runtimeEvidencePath ? { runtimeEvidencePath } : {}),
+    ...(manualChecksPath ? { manualChecksPath } : {}),
+    evidence
   };
 }
 
@@ -285,6 +413,8 @@ function detectArtifacts(artifactsDir: string): DetectedArtifacts {
   const report = entries.find((entry) => entry === "codex.wechat.rc-validation-report.json");
   const smoke = entries.find((entry) => entry === "codex.wechat.smoke-report.json");
   const receipt = entries.find((entry) => entry.endsWith(".upload.json"));
+  const installLaunchEvidenceJson = entries.find((entry) => entry === "codex.wechat.install-launch-evidence.json");
+  const installLaunchEvidenceMarkdown = entries.find((entry) => entry === "codex.wechat.install-launch-evidence.md");
   const candidateSummaryJson = entries.find((entry) => entry === "codex.wechat.release-candidate-summary.json");
   const candidateSummaryMarkdown = entries.find((entry) => entry === "codex.wechat.release-candidate-summary.md");
   return {
@@ -293,6 +423,8 @@ function detectArtifacts(artifactsDir: string): DetectedArtifacts {
     ...(report ? { validationReportPath: path.join(artifactsDir, report) } : {}),
     ...(smoke ? { smokeReportPath: path.join(artifactsDir, smoke) } : {}),
     ...(receipt ? { uploadReceiptPath: path.join(artifactsDir, receipt) } : {}),
+    ...(installLaunchEvidenceJson ? { installLaunchEvidenceJsonPath: path.join(artifactsDir, installLaunchEvidenceJson) } : {}),
+    ...(installLaunchEvidenceMarkdown ? { installLaunchEvidenceMarkdownPath: path.join(artifactsDir, installLaunchEvidenceMarkdown) } : {}),
     ...(candidateSummaryJson ? { candidateSummaryJsonPath: path.join(artifactsDir, candidateSummaryJson) } : {}),
     ...(candidateSummaryMarkdown
       ? { candidateSummaryMarkdownPath: path.join(artifactsDir, candidateSummaryMarkdown) }
@@ -341,6 +473,12 @@ function renderMarkdown(summary: RehearsalSummary): string {
   if (artifacts.uploadReceiptPath) {
     artifactLines.push(`- Upload Receipt: \`${artifacts.uploadReceiptPath}\``);
   }
+  if (artifacts.installLaunchEvidenceJsonPath) {
+    artifactLines.push(`- Install/Launch Evidence (JSON): \`${artifacts.installLaunchEvidenceJsonPath}\``);
+  }
+  if (artifacts.installLaunchEvidenceMarkdownPath) {
+    artifactLines.push(`- Install/Launch Evidence (Markdown): \`${artifacts.installLaunchEvidenceMarkdownPath}\``);
+  }
   if (artifacts.candidateSummaryJsonPath) {
     artifactLines.push(`- Candidate Summary (JSON): \`${artifacts.candidateSummaryJsonPath}\``);
   }
@@ -365,9 +503,43 @@ function main(): void {
   const resolvedArtifactsDir = path.resolve(repoRoot, args.artifactsDir);
   const sourceRevision = args.sourceRevision ?? revision.commit ?? undefined;
   const expectedRevision = args.expectedRevision ?? sourceRevision;
+  const resolvedRuntimeEvidencePath = args.runtimeEvidencePath ? path.resolve(repoRoot, args.runtimeEvidencePath) : undefined;
+  const resolvedManualChecksPath = args.manualChecksPath ? path.resolve(repoRoot, args.manualChecksPath) : undefined;
   const summaryBaseName = revision.shortCommit ? `wechat-release-rehearsal-${revision.shortCommit}` : `wechat-release-rehearsal`;
   const summaryPath = path.resolve(repoRoot, args.summaryPath ?? path.join(args.artifactsDir, `${summaryBaseName}.json`));
   const markdownPath = path.resolve(repoRoot, args.markdownPath ?? path.join(args.artifactsDir, `${summaryBaseName}.md`));
+  const smokeReportPath = path.join(resolvedArtifactsDir, "codex.wechat.smoke-report.json");
+
+  const hasInstallLaunchOptions =
+    Boolean(
+      args.candidate ||
+        args.candidateRevision ||
+        args.environment ||
+        args.operator ||
+        args.recordedAt ||
+        args.status ||
+        args.installStatus ||
+        args.launchStatus ||
+        args.verificationSummary ||
+        args.installSummary ||
+        args.launchSummary
+    ) || args.evidence.length > 0;
+  const shouldRecordInstallLaunchEvidence = hasInstallLaunchOptions;
+
+  if (hasInstallLaunchOptions) {
+    if (!args.candidate?.trim()) {
+      throw new Error("Pass --candidate <candidate-name> when recording WeChat install/launch evidence in the rehearsal.");
+    }
+    if (!args.environment?.trim()) {
+      throw new Error("Pass --environment <wechat-devtools|device-lab|qa-phone> when recording WeChat install/launch evidence.");
+    }
+    if (!args.operator?.trim()) {
+      throw new Error("Pass --operator <name> when recording WeChat install/launch evidence.");
+    }
+    if (!args.status && !args.installStatus && !args.launchStatus) {
+      throw new Error("Pass --status <passed|failed> or explicit --install-status/--launch-status when recording WeChat install/launch evidence.");
+    }
+  }
 
   fs.mkdirSync(resolvedArtifactsDir, { recursive: true });
 
@@ -420,8 +592,60 @@ function main(): void {
         resolvedArtifactsDir,
         ...(expectedRevision ? ["--expected-revision", expectedRevision] : [])
       ]
-    },
-    {
+    }
+  ];
+
+  if (shouldRecordInstallLaunchEvidence) {
+    stageDefinitions.push({
+      id: "install-launch-evidence",
+      title: "Record WeChat install/launch evidence",
+      command: [
+        nodeExec,
+        "--import",
+        "tsx",
+        "./scripts/wechat-package-install-launch-evidence.ts",
+        "--artifacts-dir",
+        resolvedArtifactsDir,
+        "--candidate",
+        args.candidate!.trim(),
+        ...(args.candidateRevision?.trim() ? ["--candidate-revision", args.candidateRevision.trim()] : []),
+        "--environment",
+        args.environment!.trim(),
+        "--operator",
+        args.operator!.trim(),
+        ...(args.recordedAt?.trim() ? ["--recorded-at", args.recordedAt.trim()] : []),
+        ...(args.status ? ["--status", args.status] : []),
+        ...(args.installStatus ? ["--install-status", args.installStatus] : []),
+        ...(args.launchStatus ? ["--launch-status", args.launchStatus] : []),
+        ...(args.verificationSummary?.trim() ? ["--summary", args.verificationSummary.trim()] : []),
+        ...(args.installSummary?.trim() ? ["--install-summary", args.installSummary.trim()] : []),
+        ...(args.launchSummary?.trim() ? ["--launch-summary", args.launchSummary.trim()] : []),
+        ...args.evidence.flatMap((entry) => ["--evidence", entry])
+      ]
+    });
+  }
+
+  if (resolvedRuntimeEvidencePath) {
+    stageDefinitions.push({
+      id: "smoke",
+      title: "Generate WeChat smoke report",
+      command: [
+        nodeExec,
+        "--import",
+        "tsx",
+        "./scripts/smoke-wechat-minigame-release.ts",
+        "--artifacts-dir",
+        resolvedArtifactsDir,
+        "--report",
+        smokeReportPath,
+        "--runtime-evidence",
+        resolvedRuntimeEvidencePath,
+        "--force"
+      ]
+    });
+  }
+
+  stageDefinitions.push({
       id: "validate",
       title: "Validate release candidate",
       command: [
@@ -433,10 +657,11 @@ function main(): void {
         resolvedArtifactsDir,
         ...(expectedRevision ? ["--expected-revision", expectedRevision] : []),
         ...(args.version ? ["--version", args.version] : []),
-        ...(args.requireSmokeReport ? ["--require-smoke-report"] : [])
+        ...(args.requireSmokeReport ? ["--require-smoke-report"] : []),
+        ...(resolvedManualChecksPath ? ["--manual-checks", resolvedManualChecksPath] : [])
       ]
     }
-  ];
+  );
 
   const stageResults: StageResult[] = [];
   let failureStage: StageResult | undefined;


### PR DESCRIPTION
## Summary

Closes #1174.

This turns `release:wechat:rehearsal` into a candidate-evidence workflow instead of a package-only rehearsal.

- add optional `install-launch-evidence` and `smoke` stages to `release:wechat:rehearsal`
- allow the rehearsal flow to reuse `--manual-checks` so the same run can emit a ready/blocked WeChat candidate summary
- surface install/launch evidence artifacts in the rehearsal summary output
- document the one-shot DevTools evidence flow and lock the new artifact contract with tests

## Why

We already had the underlying package, smoke, validation, and install/launch scripts, but #1174 still required a manual chain of commands to stitch them into one candidate record. That made it harder to produce one archivable WeChat RC evidence bundle with a clear DevTools verification trail.

## Impact

A single rehearsal command can now assemble:

- packaged WeChat artifact + sidecar
- verify output
- DevTools install/launch evidence
- smoke report from runtime evidence
- WeChat RC validation report
- candidate summary / markdown for the same candidate revision

## Validation

- `npm run typecheck:ops`
- `node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/wechat-release-artifacts.test.ts`
- `npm run release:wechat:rehearsal -- --config apps/cocos-client/wechat-minigame.build.json --build-dir apps/cocos-client/test/fixtures/wechatgame-export --artifacts-dir /tmp/issue1174-wechat-rc-89784a2/wechat-release --summary /tmp/issue1174-wechat-rc-89784a2/wechat-release-rehearsal-89784a2.json --markdown /tmp/issue1174-wechat-rc-89784a2/wechat-release-rehearsal-89784a2.md --source-revision 89784a290d8db16cab57bd22ba86d2a1db307c0e --expected-revision 89784a290d8db16cab57bd22ba86d2a1db307c0e --candidate issue-1174-wechat-rc --environment wechat-devtools --operator codex --status passed --verification-summary 'Candidate rehearsal package import and first launch passed.' --evidence devtools-import-capture --evidence first-launch-capture --runtime-evidence /tmp/issue1174-wechat-rc-89784a2/runtime-evidence.json --manual-checks /tmp/issue1174-wechat-rc-89784a2/manual-review.json --require-smoke-report`

## Resulting Evidence

The rehearsal run produced a candidate summary with `candidate.status = ready` and a single artifacts dir containing:

- `codex.wechat.install-launch-evidence.json`
- `codex.wechat.smoke-report.json`
- `codex.wechat.rc-validation-report.json`
- `codex.wechat.release-candidate-summary.json`
- `codex.wechat.release-candidate-summary.md`
