### PR TITLE
feat: add commercial review go/no-go evidence packet

### DIFF
--- a/docs/release-evidence/wechat-commercial-review.example.json
+++ b/docs/release-evidence/wechat-commercial-review.example.json
@@ -1,0 +1,84 @@
+{
+  "generatedAt": "2026-04-10T18:30:00.000Z",
+  "candidate": {
+    "revision": "abc1234def5678",
+    "version": "1.2.3",
+    "status": "blocked"
+  },
+  "summary": {
+    "status": "blocked",
+    "requiredPendingChecks": 2,
+    "requiredFailedChecks": 0,
+    "requiredMetadataFailures": 0
+  },
+  "checks": [
+    {
+      "id": "payment-e2e",
+      "title": "支付链路端到端验证",
+      "category": "payment",
+      "required": true,
+      "status": "pending",
+      "owner": "release-commerce",
+      "recordedAt": "2026-04-10T18:10:00.000Z",
+      "revision": "abc1234def5678",
+      "artifactPath": "artifacts/wechat-release/commercial-payment-review.json",
+      "notes": "待补真实支付发起、回调、到账与失败补偿证据。"
+    },
+    {
+      "id": "subscription-reachability",
+      "title": "订阅消息与触达验证",
+      "category": "subscription",
+      "required": true,
+      "status": "pending",
+      "owner": "release-growth",
+      "recordedAt": "2026-04-10T18:12:00.000Z",
+      "revision": "abc1234def5678",
+      "artifactPath": "artifacts/wechat-release/commercial-subscribe-review.json",
+      "notes": "待补授权、触发条件与失败兜底证据。"
+    },
+    {
+      "id": "analytics-funnel-audit",
+      "title": "核心漏斗与付费埋点验收",
+      "category": "analytics",
+      "required": true,
+      "status": "passed",
+      "owner": "release-analytics",
+      "recordedAt": "2026-04-10T18:14:00.000Z",
+      "revision": "abc1234def5678",
+      "artifactPath": "artifacts/analytics/onboarding-funnel-report.json",
+      "notes": "核心漏斗与错误事件已可用。"
+    },
+    {
+      "id": "compliance-materials",
+      "title": "隐私/未成年人/提审物料复核",
+      "category": "compliance",
+      "required": true,
+      "status": "passed",
+      "owner": "release-compliance",
+      "recordedAt": "2026-04-10T18:16:00.000Z",
+      "revision": "abc1234def5678",
+      "artifactPath": "artifacts/wechat-release/commercial-compliance-review.json",
+      "notes": "隐私协议、未成年人限制、客服入口与提审说明已复核。"
+    },
+    {
+      "id": "device-experience-review",
+      "title": "真机体验复核",
+      "category": "device_experience",
+      "required": true,
+      "status": "pending",
+      "owner": "release-qa",
+      "recordedAt": "2026-04-10T18:18:00.000Z",
+      "revision": "abc1234def5678",
+      "artifactPath": "artifacts/wechat-release/commercial-device-review.json",
+      "notes": "待补弱网、断网恢复、音频、帧率、内存与安全区结论。"
+    }
+  ],
+  "blockers": [
+    {
+      "id": "commercial-signoff-missing",
+      "summary": "商运外放复核尚未形成 complete sign-off。",
+      "artifactPath": "artifacts/wechat-release/codex.wechat.commercial-review.json",
+      "nextCommand": "补齐 payment / subscription / device review 结论后重新生成 go/no-go packet。"
+    }
+  ]
+}

--- a/docs/release-go-no-go-decision-packet.md
+++ b/docs/release-go-no-go-decision-packet.md
@@ -26,9 +26,11 @@ The packet always includes these operator-facing sections:
 
 - candidate metadata
 - validation summary
+- commercial readiness summary
 - blocker summary
 - runtime observability sign-off links
 - unresolved manual checks
+- unresolved commercial checks
 
 Pass, warning, and blocker items are normalized into one summary so the final reviewer can distinguish accepted risk from true release blockers.
 
@@ -48,7 +50,8 @@ Pin explicit artifact paths when CI already produced the exact files you want to
 npm run release:go-no-go-packet -- \
   --dossier artifacts/release-readiness/phase1-candidate-dossier-phase1-wechat-rc-abc1234/phase1-candidate-dossier.json \
   --release-gate-summary artifacts/release-readiness/release-gate-summary-abc1234.json \
-  --wechat-candidate-summary artifacts/wechat-release/codex.wechat.release-candidate-summary.json
+  --wechat-candidate-summary artifacts/wechat-release/codex.wechat.release-candidate-summary.json \
+  --commercial-review artifacts/wechat-release/codex.wechat.commercial-review.json
 ```
 
 Write to explicit output files:
@@ -69,6 +72,13 @@ The packet fails closed when required upstream evidence is missing:
 - release gate summary
 - WeChat candidate summary when the target surface is `wechat`
 
+When you are preparing an external WeChat release decision instead of a purely technical RC verdict, also attach a commercial review file:
+
+- `docs/release-evidence/wechat-commercial-review.example.json`
+- recommended artifact path: `artifacts/wechat-release/codex.wechat.commercial-review.json`
+
+This review captures payment, subscription reachability, analytics, compliance, and device-experience conclusions for the same candidate revision. When present, unresolved required commercial checks are folded into the final packet decision.
+
 Those errors are intentional. The packet is the last-mile reviewer artifact, so it should not invent partial state when the underlying evidence set is incomplete.
 
 ## Operator Workflow
@@ -76,9 +86,10 @@ Those errors are intentional. The packet is the last-mile reviewer artifact, so 
 1. Generate or refresh the underlying candidate evidence for one fixed revision.
 2. Build the candidate dossier and release gate summary for that same revision.
 3. Refresh the WeChat candidate summary and manual-review metadata when the target surface is `wechat`.
-4. Run `npm run release:go-no-go-packet`.
-5. Run `npm run release:pr-summary -- --release-gate-summary <path> --release-health-summary <path> --go-no-go-packet <path>` to render the concise PR-visible summary markdown when you need to preview the exact reviewer digest locally.
-6. In CI pull-request runs, the `Build go/no-go decision packet artifact` plus `Comment PR with release summary` steps publish or update the single bot comment in place, so reruns refresh the same PR-visible summary instead of creating duplicates.
-7. Attach or inspect the Markdown packet itself when the release owner needs the full operator record.
+4. For external release calls, copy `docs/release-evidence/wechat-commercial-review.example.json` into the candidate artifacts dir, fill in the current candidate revision, owner, timestamps, and evidence links, then pass it via `--commercial-review`.
+5. Run `npm run release:go-no-go-packet`.
+6. Run `npm run release:pr-summary -- --release-gate-summary <path> --release-health-summary <path> --go-no-go-packet <path>` to render the concise PR-visible summary markdown when you need to preview the exact reviewer digest locally.
+7. In CI pull-request runs, the `Build go/no-go decision packet artifact` plus `Comment PR with release summary` steps publish or update the single bot comment in place, so reruns refresh the same PR-visible summary instead of creating duplicates.
+8. Attach or inspect the Markdown packet itself when the release owner needs the full operator record.
 
 If the packet still shows blocker items, clear those upstream artifacts first and regenerate the packet instead of editing the packet by hand.

--- a/progress.md
+++ b/progress.md
@@ -1524,3 +1524,28 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 本轮定向验证结果：
   - `npm run typecheck:ops` 通过
   - `node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/wechat-release-artifacts.test.ts` 通过
+
+## Issue #1183 - Commercial review go/no-go packet - 2026-04-10
+
+- 本轮给 `release:go-no-go-packet` 补上了商运外放结论的正式输入面：
+  - `scripts/release-go-no-go-decision-packet.ts`
+    - 新增 `--commercial-review <path>` 参数，支持显式传入商运复核证据
+    - 默认也会从 WeChat artifacts 目录自动发现 `codex.wechat.commercial-review.json / wechat-commercial-review.json / commercial-review.json`
+    - packet 里新增 `commercialReadinessSummary` 与 `unresolvedCommercialChecks`
+    - 必填商运检查会对 `owner / recordedAt / revision / artifactPath` 做元数据完整性校验，缺失时直接作为 blocker 纳入最终 go/no-go 结论
+    - Markdown 输出新增 `Commercial Readiness Summary` 和 `Unresolved Commercial Checks` 两段，方便 release reviewer 直接查看支付、订阅、埋点、合规、真机体验的阻塞项
+- 为了让人工填写格式稳定下来，新增了商运复核模板：
+  - `docs/release-evidence/wechat-commercial-review.example.json`
+    - 覆盖 `payment / subscription / analytics / compliance / device_experience` 五类复核项
+    - 约定了 `summary / checks / blockers` 的 JSON 契约，供后续候选包沿用
+- 说明文档也同步到了：
+  - `docs/release-go-no-go-decision-packet.md`
+    - 新增 `--commercial-review` 用法示例
+    - 明确要求在跑 go/no-go packet 前附带商运复核文件
+- 测试收口：
+  - `scripts/test/release-go-no-go-decision-packet.test.ts`
+    - 新增商运 blocker 会把最终结论压成 `no_go` 的覆盖
+    - 同时修正 CLI 用例的仓库根路径解析，避免环境相关的假失败
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `node --import tsx --test ./scripts/test/release-go-no-go-decision-packet.test.ts` 通过（`4/4`）

--- a/scripts/release-go-no-go-decision-packet.ts
+++ b/scripts/release-go-no-go-decision-packet.ts
@@ -15,6 +15,7 @@ interface Args {
   releaseGateSummaryPath?: string;
   wechatArtifactsDir?: string;
   wechatCandidateSummaryPath?: string;
+  commercialReviewPath?: string;
   outputPath?: string;
   markdownOutputPath?: string;
 }
@@ -162,12 +163,53 @@ interface WechatManualReviewCheck {
   };
 }
 
+interface CommercialReviewCheck {
+  id?: string;
+  title?: string;
+  category?: "payment" | "subscription" | "analytics" | "compliance" | "device_experience";
+  required?: boolean;
+  status?: ManualCheckStatus;
+  owner?: string;
+  recordedAt?: string;
+  revision?: string;
+  artifactPath?: string;
+  notes?: string;
+  waiver?: {
+    approvedBy?: string;
+    approvedAt?: string;
+    reason?: string;
+    expiresAt?: string;
+  };
+}
+
+interface CommercialReviewDocument {
+  generatedAt?: string;
+  candidate?: {
+    revision?: string | null;
+    version?: string | null;
+    status?: "ready" | "blocked";
+  };
+  summary?: {
+    status?: "ready" | "blocked";
+    requiredPendingChecks?: number;
+    requiredFailedChecks?: number;
+    requiredMetadataFailures?: number;
+  };
+  checks?: CommercialReviewCheck[];
+  blockers?: Array<{
+    id?: string;
+    summary?: string;
+    artifactPath?: string;
+    nextCommand?: string;
+  }>;
+}
+
 interface PacketItem {
   id: string;
   title: string;
   severity: PacketSeverity;
   summary: string;
-  source: "candidate-dossier" | "release-gate-summary" | "wechat-manual-review";
+  source: "candidate-dossier" | "release-gate-summary" | "wechat-manual-review" | "commercial-review";
   artifactPath?: string;
   nextStep?: string;
 }
@@ -216,17 +258,26 @@ interface GoNoGoDecisionPacket {
     runtimeObservabilityDossierPath?: string;
     releaseGateSummaryPath: string;
     wechatCandidateSummaryPath?: string;
+    commercialReviewPath?: string;
   };
   sections: {
     candidateMetadata: {
       dossierGeneratedAt: string;
       releaseGateGeneratedAt: string;
       wechatCandidateSummaryGeneratedAt?: string;
+      commercialReviewGeneratedAt?: string;
     };
     validationSummary: {
       releaseGateStatus: GateStatus;
       phase1ExitEvidenceGate: DossierResult;
       summary: string;
+    };
+    commercialReadinessSummary: {
+      status: "not_provided" | "ready" | "blocked";
+      summary: string;
+      requiredPendingChecks: number;
+      requiredFailedChecks: number;
+      requiredMetadataFailures: number;
     };
     blockerSummary: {
       blockers: PacketItem[];
@@ -235,11 +286,17 @@ interface GoNoGoDecisionPacket {
     };
     runtimeObservabilitySignoffLinks: RuntimeObservabilityLink[];
     unresolvedManualChecks: UnresolvedManualCheck[];
+    unresolvedCommercialChecks: UnresolvedManualCheck[];
   };
 }
 
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
 const DEFAULT_WECHAT_ARTIFACTS_DIR = path.resolve("artifacts", "wechat-release");
+const COMMERCIAL_REVIEW_FILENAMES = [
+  "codex.wechat.commercial-review.json",
+  "wechat-commercial-review.json",
+  "commercial-review.json"
+] as const;
 
 function fail(message: string): never {
   throw new Error(message);
@@ -252,6 +309,7 @@ function parseArgs(argv: string[]): Args {
   let releaseGateSummaryPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let wechatCandidateSummaryPath: string | undefined;
+  let commercialReviewPath: string | undefined;
   let outputPath: string | undefined;
   let markdownOutputPath: string | undefined;
 
@@ -289,6 +347,11 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--commercial-review" && next) {
+      commercialReviewPath = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--output" && next) {
       outputPath = next;
       index += 1;
@@ -310,6 +373,7 @@ function parseArgs(argv: string[]): Args {
     ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
+    ...(commercialReviewPath ? { commercialReviewPath } : {}),
     ...(outputPath ? { outputPath } : {}),
     ...(markdownOutputPath ? { markdownOutputPath } : {})
   };
@@ -477,6 +541,30 @@ function resolveWechatCandidateSummaryPath(
   return undefined;
 }
 
+function resolveCommercialReviewPath(args: Args, releaseGateSummaryPath: string): string | undefined {
+  if (args.commercialReviewPath) {
+    return requireExistingFile(
+      args.commercialReviewPath,
+      "Commercial review evidence",
+      "Pass a valid `--commercial-review <path>` or place `codex.wechat.commercial-review.json` under the WeChat artifacts dir."
+    );
+  }
+
+  const wechatArtifactsDir = resolveWechatArtifactsDir(args, releaseGateSummaryPath);
+  if (!wechatArtifactsDir) {
+    return undefined;
+  }
+
+  for (const fileName of COMMERCIAL_REVIEW_FILENAMES) {
+    const candidate = path.join(wechatArtifactsDir, fileName);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
 function toPacketSeverity(result: DossierResult | GateStatus): PacketSeverity {
   if (result === "failed") {
     return "blocker";
@@ -497,8 +585,72 @@ function manualCheckSeverity(check: WechatManualReviewCheck): PacketSeverity {
   return "pass";
 }
 
+function commercialCheckSeverity(check: CommercialReviewCheck, metadataFailures: string[]): PacketSeverity {
+  if (metadataFailures.length > 0) {
+    return "blocker";
+  }
+  if (check.status === "failed") {
+    return "blocker";
+  }
+  if (check.status === "pending") {
+    return check.required === false ? "warning" : "blocker";
+  }
+  if (check.status === "not_applicable") {
+    if (check.required === false) {
+      return "pass";
+    }
+    return check.waiver?.reason ? "warning" : "blocker";
+  }
+  if (check.waiver?.reason) {
+    return "warning";
+  }
+  return "pass";
+}
+
 function normalizeItemId(input: string): string {
   return input.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function normalizeCheckCategory(check: CommercialReviewCheck): string {
+  switch (check.category) {
+    case "payment":
+      return "支付";
+    case "subscription":
+      return "订阅消息";
+    case "analytics":
+      return "埋点/分析";
+    case "compliance":
+      return "合规";
+    case "device_experience":
+      return "真机体验";
+    default:
+      return "商运";
+  }
+}
+
+function collectCommercialMetadataFailures(
+  check: CommercialReviewCheck,
+  candidateRevision: string
+): string[] {
+  const failures: string[] = [];
+  if (check.required === false) {
+    return failures;
+  }
+  if (!check.owner?.trim()) {
+    failures.push("missing owner");
+  }
+  if (!check.recordedAt?.trim()) {
+    failures.push("missing recordedAt");
+  }
+  if (!check.revision?.trim()) {
+    failures.push("missing revision");
+  } else if (check.revision !== candidateRevision) {
+    failures.push(`revision mismatch (${check.revision})`);
+  }
+  if (!check.artifactPath?.trim()) {
+    failures.push("missing artifactPath");
+  }
+  return failures;
 }
 
 function summarizeValidation(dossier: Phase1CandidateDossier, releaseGate: ReleaseGateSummaryReport): string {
@@ -536,6 +688,8 @@ export function buildGoNoGoDecisionPacket(args: Args): GoNoGoDecisionPacket {
   const wechatCandidateSummary = wechatCandidateSummaryPath
     ? readJsonFile<WechatCandidateSummary>(wechatCandidateSummaryPath)
     : undefined;
+  const commercialReviewPath = resolveCommercialReviewPath(args, releaseGateSummaryPath);
+  const commercialReview = commercialReviewPath ? readJsonFile<CommercialReviewDocument>(commercialReviewPath) : undefined;
 
   const passing: PacketItem[] = [];
   const warnings: PacketItem[] = [];
@@ -671,6 +825,94 @@ export function buildGoNoGoDecisionPacket(args: Args): GoNoGoDecisionPacket {
       notes: check.notes
     }));
 
+  const commercialChecks = commercialReview?.checks ?? [];
+  const unresolvedCommercialChecks: UnresolvedManualCheck[] = [];
+  let commercialRequiredPendingChecks = 0;
+  let commercialRequiredFailedChecks = 0;
+  let commercialRequiredMetadataFailures = 0;
+
+  for (const check of commercialChecks) {
+    const metadataFailures = collectCommercialMetadataFailures(check, dossier.candidate.revision);
+    if (check.required !== false) {
+      if (check.status === "pending") {
+        commercialRequiredPendingChecks += 1;
+      }
+      if (check.status === "failed") {
+        commercialRequiredFailedChecks += 1;
+      }
+      if (metadataFailures.length > 0) {
+        commercialRequiredMetadataFailures += 1;
+      }
+    }
+
+    const category = normalizeCheckCategory(check);
+    const severity = commercialCheckSeverity(check, metadataFailures);
+    const detailSummary = [
+      `${category}检查状态为 ${check.status ?? "pending"}.`,
+      check.notes?.trim() ?? null,
+      metadataFailures.length > 0 ? `Metadata: ${metadataFailures.join(", ")}.` : null,
+      check.waiver?.reason ? `Waiver: ${check.waiver.reason}` : null
+    ]
+      .filter((entry): entry is string => Boolean(entry))
+      .join(" ");
+
+    const item: PacketItem = {
+      id: check.id ? `commercial:${check.id}` : `commercial:${normalizeItemId(check.title ?? category)}`,
+      title: `${category} - ${check.title ?? check.id ?? "商业化复核项"}`,
+      severity,
+      summary: detailSummary,
+      source: "commercial-review",
+      artifactPath: check.artifactPath
+    };
+
+    if (severity === "blocker") {
+      blockers.push(item);
+    } else if (severity === "warning") {
+      warnings.push(item);
+    } else {
+      passing.push(item);
+    }
+
+    if (severity !== "pass") {
+      unresolvedCommercialChecks.push({
+        id: check.id ?? "commercial-check",
+        title: `${category} - ${check.title ?? check.id ?? "商业化复核项"}`,
+        status: check.status ?? "pending",
+        owner: check.owner,
+        recordedAt: check.recordedAt,
+        revision: check.revision,
+        artifactPath: check.artifactPath,
+        notes: detailSummary,
+        waiverReason: check.waiver?.reason
+      });
+    }
+  }
+
+  for (const blocker of commercialReview?.blockers ?? []) {
+    blockers.push({
+      id: blocker.id ? `commercial:${blocker.id}` : "commercial:blocker",
+      title: blocker.id ?? "Commercial blocker",
+      severity: "blocker",
+      summary: blocker.summary ?? "Commercial review reported a blocker.",
+      source: "commercial-review",
+      artifactPath: blocker.artifactPath,
+      nextStep: blocker.nextCommand
+    });
+  }
+
+  const commercialReadinessStatus =
+    !commercialReview
+      ? "not_provided"
+      : commercialRequiredPendingChecks > 0 || commercialRequiredFailedChecks > 0 || commercialRequiredMetadataFailures > 0 || (commercialReview.blockers?.length ?? 0) > 0
+        ? "blocked"
+        : "ready";
+  const commercialReadinessSummary =
+    commercialReadinessStatus === "not_provided"
+      ? "No commercial review evidence was attached to this packet."
+      : commercialReadinessStatus === "ready"
+        ? "Commercial release review is ready for this candidate."
+        : `Commercial release review is blocked: pending=${commercialRequiredPendingChecks}, failed=${commercialRequiredFailedChecks}, metadataFailures=${commercialRequiredMetadataFailures}, explicitBlockers=${commercialReview?.blockers?.length ?? 0}.`;
+
   const decision: PacketDecision = blockers.length > 0 ? "no_go" : "go";
   const decisionSummary =
     decision === "go"
@@ -697,18 +939,27 @@ export function buildGoNoGoDecisionPacket(args: Args): GoNoGoDecisionPacket {
       dossierPath,
       ...(runtimeObservabilityDossierPath ? { runtimeObservabilityDossierPath } : {}),
       releaseGateSummaryPath,
-      ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {})
+      ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
+      ...(commercialReviewPath ? { commercialReviewPath } : {})
     },
     sections: {
       candidateMetadata: {
         dossierGeneratedAt: dossier.generatedAt,
         releaseGateGeneratedAt: releaseGate.generatedAt,
-        ...(wechatCandidateSummary?.generatedAt ? { wechatCandidateSummaryGeneratedAt: wechatCandidateSummary.generatedAt } : {})
+        ...(wechatCandidateSummary?.generatedAt ? { wechatCandidateSummaryGeneratedAt: wechatCandidateSummary.generatedAt } : {}),
+        ...(commercialReview?.generatedAt ? { commercialReviewGeneratedAt: commercialReview.generatedAt } : {})
       },
       validationSummary: {
         releaseGateStatus: releaseGate.summary.status,
         phase1ExitEvidenceGate: dossier.phase1ExitEvidenceGate.result,
         summary: summarizeValidation(dossier, releaseGate)
+      },
+      commercialReadinessSummary: {
+        status: commercialReadinessStatus,
+        summary: commercialReadinessSummary,
+        requiredPendingChecks: commercialRequiredPendingChecks,
+        requiredFailedChecks: commercialRequiredFailedChecks,
+        requiredMetadataFailures: commercialRequiredMetadataFailures
       },
       blockerSummary: {
         blockers,
@@ -716,7 +967,8 @@ export function buildGoNoGoDecisionPacket(args: Args): GoNoGoDecisionPacket {
         passing
       },
       runtimeObservabilitySignoffLinks,
-      unresolvedManualChecks
+      unresolvedManualChecks,
+      unresolvedCommercialChecks
     }
   };
 }
@@ -751,10 +1003,16 @@ export function renderMarkdown(packet: GoNoGoDecisionPacket): string {
   if (packet.inputs.wechatCandidateSummaryPath) {
     lines.push(`- WeChat candidate summary: \`${toDisplayPath(packet.inputs.wechatCandidateSummaryPath)}\``);
   }
+  if (packet.inputs.commercialReviewPath) {
+    lines.push(`- Commercial review evidence: \`${toDisplayPath(packet.inputs.commercialReviewPath)}\``);
+  }
   lines.push(`- Dossier generated at: \`${packet.sections.candidateMetadata.dossierGeneratedAt}\``);
   lines.push(`- Release gate generated at: \`${packet.sections.candidateMetadata.releaseGateGeneratedAt}\``);
   if (packet.sections.candidateMetadata.wechatCandidateSummaryGeneratedAt) {
     lines.push(`- WeChat candidate summary generated at: \`${packet.sections.candidateMetadata.wechatCandidateSummaryGeneratedAt}\``);
+  }
+  if (packet.sections.candidateMetadata.commercialReviewGeneratedAt) {
+    lines.push(`- Commercial review generated at: \`${packet.sections.candidateMetadata.commercialReviewGeneratedAt}\``);
   }
   lines.push("");
   lines.push("## Validation Summary");
@@ -762,6 +1020,14 @@ export function renderMarkdown(packet: GoNoGoDecisionPacket): string {
   lines.push(`- Phase 1 exit evidence gate: \`${packet.sections.validationSummary.phase1ExitEvidenceGate}\``);
   lines.push(`- Release gate status: \`${packet.sections.validationSummary.releaseGateStatus}\``);
   lines.push(`- Summary: ${packet.sections.validationSummary.summary}`);
+  lines.push("");
+  lines.push("## Commercial Readiness Summary");
+  lines.push("");
+  lines.push(`- Status: \`${packet.sections.commercialReadinessSummary.status}\``);
+  lines.push(`- Required pending checks: \`${packet.sections.commercialReadinessSummary.requiredPendingChecks}\``);
+  lines.push(`- Required failed checks: \`${packet.sections.commercialReadinessSummary.requiredFailedChecks}\``);
+  lines.push(`- Required metadata failures: \`${packet.sections.commercialReadinessSummary.requiredMetadataFailures}\``);
+  lines.push(`- Summary: ${packet.sections.commercialReadinessSummary.summary}`);
   lines.push("");
   lines.push(`## Blocker Summary (${packet.sections.blockerSummary.blockers.length})`);
   lines.push("");
@@ -829,6 +1095,32 @@ export function renderMarkdown(packet: GoNoGoDecisionPacket): string {
     lines.push("No unresolved required manual checks.");
   } else {
     for (const check of packet.sections.unresolvedManualChecks) {
+      lines.push(`- ${check.title}: \`${check.status}\``);
+      if (check.owner) {
+        lines.push(`  Owner: \`${check.owner}\``);
+      }
+      if (check.recordedAt) {
+        lines.push(`  Recorded at: \`${check.recordedAt}\``);
+      }
+      if (check.artifactPath) {
+        lines.push(`  Artifact: \`${check.artifactPath}\``);
+      }
+      if (check.notes) {
+        lines.push(`  Notes: ${check.notes}`);
+      }
+      if (check.waiverReason) {
+        lines.push(`  Waiver: ${check.waiverReason}`);
+      }
+    }
+  }
+
+  lines.push("");
+  lines.push(`## Unresolved Commercial Checks (${packet.sections.unresolvedCommercialChecks.length})`);
+  lines.push("");
+  if (packet.sections.unresolvedCommercialChecks.length === 0) {
+    lines.push("No unresolved commercial checks.");
+  } else {
+    for (const check of packet.sections.unresolvedCommercialChecks) {
       lines.push(`- ${check.title}: \`${check.status}\``);
       if (check.owner) {
         lines.push(`  Owner: \`${check.owner}\``);

--- a/scripts/test/release-go-no-go-decision-packet.test.ts
+++ b/scripts/test/release-go-no-go-decision-packet.test.ts
@@ -7,6 +7,8 @@ import test from "node:test";
 
 import { buildGoNoGoDecisionPacket, renderMarkdown } from "../release-go-no-go-decision-packet.ts";
 
+const repoRoot = path.resolve(__dirname, "../..");
+
 function writeJson(filePath: string, payload: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
@@ -196,13 +198,165 @@ test("buildGoNoGoDecisionPacket aggregates candidate, gate, and manual review ev
   assert.match(markdown, /## Unresolved Manual Checks \(1\)/);
 });
 
+test("buildGoNoGoDecisionPacket folds commercial review blockers into the final decision", () => {
+  const workspace = createTempWorkspace();
+  const releaseDir = path.join(workspace, "artifacts", "release-readiness");
+  const dossierDir = path.join(releaseDir, "phase1-candidate-dossier-phase1-rc-abc1234");
+  const wechatDir = path.join(workspace, "artifacts", "wechat-release");
+  const dossierPath = path.join(dossierDir, "phase1-candidate-dossier.json");
+  const releaseGateSummaryPath = path.join(releaseDir, "release-gate-summary-abc1234.json");
+  const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
+  const commercialReviewPath = path.join(wechatDir, "codex.wechat.commercial-review.json");
+
+  writeJson(dossierPath, {
+    generatedAt: "2026-04-10T09:00:00.000Z",
+    candidate: {
+      name: "phase1-rc",
+      revision: "abc1234def5678",
+      shortRevision: "abc1234",
+      branch: "release/phase1",
+      dirty: false,
+      targetSurface: "wechat"
+    },
+    summary: {
+      status: "passed",
+      totalSections: 1,
+      requiredFailed: [],
+      requiredPending: [],
+      acceptedRiskCount: 0
+    },
+    phase1ExitEvidenceGate: {
+      result: "passed",
+      summary: "All required evidence passed.",
+      blockingSections: [],
+      pendingSections: [],
+      acceptedRiskSections: []
+    },
+    sections: [
+      {
+        id: "release-readiness",
+        label: "Release readiness",
+        required: true,
+        result: "passed",
+        summary: "Automated release readiness checks passed.",
+        artifactPath: path.join(releaseDir, "release-readiness-abc1234.json"),
+        freshness: "fresh"
+      }
+    ]
+  });
+
+  writeJson(releaseGateSummaryPath, {
+    generatedAt: "2026-04-10T09:05:00.000Z",
+    targetSurface: "wechat",
+    summary: {
+      status: "passed",
+      failedGateIds: []
+    },
+    inputs: {
+      wechatArtifactsDir: wechatDir,
+      wechatCandidateSummaryPath
+    },
+    triage: {
+      blockers: [],
+      warnings: []
+    },
+    releaseSurface: {
+      status: "passed",
+      summary: "Release surface evidence is passing for the selected wechat target.",
+      evidence: []
+    }
+  });
+
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: "2026-04-10T09:10:00.000Z",
+    candidate: {
+      revision: "abc1234def5678",
+      version: "1.2.3",
+      status: "ready"
+    },
+    evidence: {
+      manualReview: {
+        status: "ready",
+        requiredPendingChecks: 0,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: []
+      }
+    },
+    blockers: []
+  });
+
+  writeJson(commercialReviewPath, {
+    generatedAt: "2026-04-10T09:12:00.000Z",
+    candidate: {
+      revision: "abc1234def5678",
+      version: "1.2.3",
+      status: "blocked"
+    },
+    checks: [
+      {
+        id: "payment-e2e",
+        title: "支付链路端到端验证",
+        category: "payment",
+        required: true,
+        status: "pending",
+        owner: "release-commerce",
+        recordedAt: "2026-04-10T09:11:00.000Z",
+        revision: "abc1234def5678",
+        artifactPath: "artifacts/wechat-release/commercial-payment-review.json",
+        notes: "Waiting on live payment callback proof."
+      },
+      {
+        id: "analytics-funnel-audit",
+        title: "核心漏斗与付费埋点验收",
+        category: "analytics",
+        required: true,
+        status: "passed",
+        owner: "release-analytics",
+        recordedAt: "2026-04-10T09:11:30.000Z",
+        revision: "abc1234def5678",
+        artifactPath: "artifacts/analytics/onboarding-funnel-report.json",
+        notes: "Funnel and payment events are available."
+      }
+    ],
+    blockers: [
+      {
+        id: "commercial-signoff-missing",
+        summary: "Commercial sign-off is still blocked by unfinished payment verification.",
+        artifactPath: "artifacts/wechat-release/codex.wechat.commercial-review.json",
+        nextCommand: "Complete the payment review and regenerate the packet."
+      }
+    ]
+  });
+
+  const packet = buildGoNoGoDecisionPacket({
+    dossierPath,
+    releaseGateSummaryPath,
+    wechatCandidateSummaryPath,
+    commercialReviewPath
+  });
+
+  assert.equal(packet.decision.status, "no_go");
+  assert.equal(packet.inputs.commercialReviewPath, commercialReviewPath);
+  assert.equal(packet.sections.commercialReadinessSummary.status, "blocked");
+  assert.equal(packet.sections.commercialReadinessSummary.requiredPendingChecks, 1);
+  assert.equal(packet.sections.unresolvedCommercialChecks.length, 1);
+  assert.equal(packet.sections.blockerSummary.blockers.some((item) => item.id === "commercial:payment-e2e"), true);
+  assert.equal(packet.sections.blockerSummary.blockers.some((item) => item.id === "commercial:commercial-signoff-missing"), true);
+
+  const markdown = renderMarkdown(packet);
+  assert.match(markdown, /## Commercial Readiness Summary/);
+  assert.match(markdown, /## Unresolved Commercial Checks \(1\)/);
+  assert.match(markdown, /支付 - 支付链路端到端验证/);
+});
+
 test("go/no-go packet CLI fails with an actionable error when the dossier is missing", () => {
   const workspace = createTempWorkspace();
   const result = spawnSync(
     "node",
     ["--import", "tsx", "./scripts/release-go-no-go-decision-packet.ts", "--dossier", path.join(workspace, "missing.json")],
     {
-      cwd: "/home/gpt/project/ProjectVeil",
+      cwd: repoRoot,
       encoding: "utf8"
     }
   );
@@ -317,7 +471,7 @@ test("go/no-go packet CLI writes the default packet outputs", () => {
     [
       "--import",
       "tsx",
-      "/home/gpt/project/ProjectVeil/scripts/release-go-no-go-decision-packet.ts",
+      path.join(repoRoot, "scripts", "release-go-no-go-decision-packet.ts"),
       "--dossier",
       dossierPath,
       "--release-gate-summary",
@@ -330,7 +484,7 @@ test("go/no-go packet CLI writes the default packet outputs", () => {
       markdownOutputPath
     ],
     {
-      cwd: "/home/gpt/project/ProjectVeil",
+      cwd: repoRoot,
       encoding: "utf8"
     }
   );


### PR DESCRIPTION
## Summary
- add commercial review evidence support to release go/no-go packets
- surface unresolved commercial checks and metadata blockers in the packet markdown
- add a reusable WeChat commercial review example plus regression coverage

## Testing
- npm run typecheck:ops
- node --import tsx --test ./scripts/test/release-go-no-go-decision-packet.test.ts

Closes #1183