### PR TITLE
feat: unify go/no-go packets with commercial verification

### DIFF
--- a/docs/release-go-no-go-decision-packet.md
+++ b/docs/release-go-no-go-decision-packet.md
@@ -10,6 +10,8 @@ Use it after the lower-level evidence has already been generated. This command d
   - CI-facing pass/fail gate report and triage list.
 - `npm run validate:wechat-rc`
   - WeChat candidate summary, smoke/manual-review state, and blocker list.
+- `npm run release:wechat:commercial-verification`
+  - Candidate-scoped commercial verification report for payment, delivery, analytics, compliance, and device experience.
 
 Use the packet when the release owner, QA owner, or operator needs one final decision attachment instead of reading those artifacts separately.
 
@@ -51,7 +53,7 @@ npm run release:go-no-go-packet -- \
   --dossier artifacts/release-readiness/phase1-candidate-dossier-phase1-wechat-rc-abc1234/phase1-candidate-dossier.json \
   --release-gate-summary artifacts/release-readiness/release-gate-summary-abc1234.json \
   --wechat-candidate-summary artifacts/wechat-release/codex.wechat.release-candidate-summary.json \
-  --commercial-review artifacts/wechat-release/codex.wechat.commercial-review.json
+  --commercial-verification artifacts/wechat-release/codex.wechat.commercial-verification-abc1234.json
 ```
 
 Write to explicit output files:
@@ -72,12 +74,13 @@ The packet fails closed when required upstream evidence is missing:
 - release gate summary
 - WeChat candidate summary when the target surface is `wechat`
 
-When you are preparing an external WeChat release decision instead of a purely technical RC verdict, also attach a commercial review file:
+When you are preparing an external WeChat release decision instead of a purely technical RC verdict, also attach commercial verification evidence:
 
-- `docs/release-evidence/wechat-commercial-review.example.json`
-- recommended artifact path: `artifacts/wechat-release/codex.wechat.commercial-review.json`
+- preferred command: `npm run release:wechat:commercial-verification -- --artifacts-dir <release-artifacts-dir>`
+- preferred artifact path: `artifacts/wechat-release/codex.wechat.commercial-verification-<short-sha>.json`
+- legacy compatibility input remains supported: `artifacts/wechat-release/codex.wechat.commercial-review.json`
 
-This review captures payment, subscription reachability, analytics, compliance, and device-experience conclusions for the same candidate revision. When present, unresolved required commercial checks are folded into the final packet decision.
+The packet will auto-discover a current `commercial-verification` artifact from the WeChat artifacts dir before falling back to the legacy `commercial-review` file. When present, unresolved required commercial checks are folded into the final packet decision.
 
 Those errors are intentional. The packet is the last-mile reviewer artifact, so it should not invent partial state when the underlying evidence set is incomplete.
 
@@ -86,7 +89,7 @@ Those errors are intentional. The packet is the last-mile reviewer artifact, so 
 1. Generate or refresh the underlying candidate evidence for one fixed revision.
 2. Build the candidate dossier and release gate summary for that same revision.
 3. Refresh the WeChat candidate summary and manual-review metadata when the target surface is `wechat`.
-4. For external release calls, copy `docs/release-evidence/wechat-commercial-review.example.json` into the candidate artifacts dir, fill in the current candidate revision, owner, timestamps, and evidence links, then pass it via `--commercial-review`.
+4. For external release calls, run `npm run release:wechat:commercial-verification -- --artifacts-dir <release-artifacts-dir> [--candidate <candidate-name>] [--candidate-revision <git-sha>]` to generate the formal commercial verification report for the same candidate revision.
 5. Run `npm run release:go-no-go-packet`.
 6. Run `npm run release:pr-summary -- --release-gate-summary <path> --release-health-summary <path> --go-no-go-packet <path>` to render the concise PR-visible summary markdown when you need to preview the exact reviewer digest locally.
 7. In CI pull-request runs, the `Build go/no-go decision packet artifact` plus `Comment PR with release summary` steps publish or update the single bot comment in place, so reruns refresh the same PR-visible summary instead of creating duplicates.

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -178,9 +178,9 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/release-go-no-go-decision-packet.ts`
-- Purpose: Build the final go/no-go decision packet for a candidate by combining the dossier, gate summary, and WeChat summary.
+- Purpose: Build the final go/no-go decision packet for a candidate by combining the dossier, gate summary, WeChat summary, and optional commercial verification evidence.
 - Required inputs:
-  - Phase 1 candidate dossier plus matching release-gate and WeChat candidate-summary artifacts, either auto-discovered or passed explicitly.
+  - Phase 1 candidate dossier plus matching release-gate and WeChat candidate-summary artifacts, either auto-discovered or passed explicitly; commercial verification evidence is auto-discovered from the WeChat artifacts dir when available.
 - Produced artifacts:
   - `artifacts/release-readiness/go-no-go-decision-packet-<candidate>-<short-sha>.json`
   - `artifacts/release-readiness/go-no-go-decision-packet-<candidate>-<short-sha>.md`

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -132,6 +132,7 @@ WeChat checklist / blockers 至少要覆盖以下证据面：
     - required checks 都要求 `owner`、`recordedAt`、`revision`、`artifactPath`；缺失、超 24h freshness window 或 revision 不匹配都会继续阻塞。
     - 输出固定为 `codex.wechat.commercial-verification-<short-sha>.json` 和 `.md`，便于在 PR、提审记录或 release call 里直接引用。
     - `acceptedRisks[]` 会被原样汇总进摘要，用来记录“可接受但需持续观察”的外放风险，而不是把它们埋在 notes 里。
+19. 生成商运验证产物后，直接运行 `npm run release:go-no-go-packet -- --candidate <candidate-name> --candidate-revision <git-sha>`；脚本会优先自动发现同一 artifacts dir 下最新的 `codex.wechat.commercial-verification-<short-sha>.json`，不需要再额外手填一份独立的 `commercial-review` 文件。
 
 ## 发布彩排摘要
 
@@ -181,6 +182,7 @@ WeChat checklist / blockers 至少要覆盖以下证据面：
 - 会把 required check 的 `status`、owner/timestamp/revision/artifactPath 元数据、freshness、accepted risks 一起收口到一个 JSON / Markdown 摘要
 - 只要 required check 仍是 `pending` / `failed`，或者 evidence metadata 不完整 / 不新鲜，最终结论就保持 `blocked`
 - 适合把支付、触达、埋点、合规、真机体验这几类商运项统一挂到同一个 release call 记录里
+- `release:go-no-go-packet` 现在会优先自动消费这份 `commercial-verification` 产物，并仅在缺失时回退到旧的 `commercial-review` 文件兼容路径
 
 同时 `validate:wechat-rc` 现在会为 reviewer 生成一份 candidate summary：
 

--- a/progress.md
+++ b/progress.md
@@ -1549,3 +1549,27 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 本轮定向验证结果：
   - `npm run typecheck:ops` 通过
   - `node --import tsx --test ./scripts/test/release-go-no-go-decision-packet.test.ts` 通过（`4/4`）
+
+## Issue #1185 - Unify go/no-go packet with commercial verification artifacts - 2026-04-10
+
+- 本轮把 go/no-go packet 的商运输入统一到了正式产物链路：
+  - `scripts/release-go-no-go-decision-packet.ts`
+    - 新增 `--commercial-verification <path>`，同时继续兼容旧的 `--commercial-review <path>`
+    - 自动发现逻辑现在会优先读取 `codex.wechat.commercial-verification-<short-sha>.json`，缺失时才回退到旧 `commercial-review` 文件
+    - packet 可以直接解析 `release:wechat:commercial-verification` 的正式 JSON 产物，并把它归一到现有的 `commercialReadinessSummary / unresolvedCommercialChecks / blockerSummary`
+    - 对 verification report 中已有的 `metadataFailures` 继续原样吸收，避免 packet 侧再丢掉 `stale recordedAt` 这类商运阻塞信号
+- 文档主链路也改成了同一个来源：
+  - `docs/release-go-no-go-decision-packet.md`
+    - 改为推荐先跑 `npm run release:wechat:commercial-verification`
+    - 显式说明 go/no-go packet 会优先自动发现 `commercial-verification` 产物
+  - `docs/wechat-minigame-release.md`
+    - 在商运验证步骤后补上了 go/no-go packet 的直接消费说明，不再建议额外手填独立 review 文件
+  - `docs/release-script-inventory.md` 与 `scripts/release-script-inventory.ts`
+    - 同步更新 `release:go-no-go-packet` 的职责说明，避免 inventory 再回滚成旧描述
+- 测试收口：
+  - `scripts/test/release-go-no-go-decision-packet.test.ts`
+    - 新增自动发现 `codex.wechat.commercial-verification-abc1234.json` 的覆盖
+    - 旧 `commercial-review` 路径的兼容用例继续保留
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `node --import tsx --test ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`10/10`）

--- a/scripts/release-go-no-go-decision-packet.ts
+++ b/scripts/release-go-no-go-decision-packet.ts
@@ -15,6 +15,7 @@ interface Args {
   releaseGateSummaryPath?: string;
   wechatArtifactsDir?: string;
   wechatCandidateSummaryPath?: string;
+  commercialVerificationPath?: string;
   commercialReviewPath?: string;
   outputPath?: string;
   markdownOutputPath?: string;
@@ -174,6 +175,7 @@ interface CommercialReviewCheck {
   revision?: string;
   artifactPath?: string;
   notes?: string;
+  metadataFailures?: string[];
   waiver?: {
     approvedBy?: string;
     approvedAt?: string;
@@ -290,9 +292,74 @@ interface GoNoGoDecisionPacket {
   };
 }
 
+interface CommercialVerificationAcceptedRisk {
+  id: string;
+  checkId: string;
+  summary: string;
+  owner?: string;
+  expiresAt?: string;
+  artifactPath?: string;
+}
+
+interface CommercialVerificationCheck {
+  id: string;
+  title: string;
+  status: ManualCheckStatus;
+  required: boolean;
+  notes: string;
+  evidence: string[];
+  owner?: string;
+  recordedAt?: string;
+  revision?: string;
+  artifactPath?: string;
+  blockerIds: string[];
+  acceptedRisks: CommercialVerificationAcceptedRisk[];
+  freshness: "fresh" | "stale" | "missing_timestamp" | "invalid_timestamp";
+  metadataStatus: "passed" | "failed";
+  metadataFailures: string[];
+}
+
+interface CommercialVerificationReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  candidate: {
+    name: string;
+    revision: string | null;
+    shortRevision: string | null;
+    version: string | null;
+    status: "ready" | "blocked";
+  };
+  technicalGate: {
+    status: "ready" | "blocked";
+    summary: string;
+    artifactPath: string;
+    blockerCount: number;
+  };
+  summary: {
+    status: "ready" | "blocked";
+    totalChecks: number;
+    completedRequiredChecks: number;
+    requiredPendingChecks: number;
+    requiredFailedChecks: number;
+    requiredMetadataFailures: number;
+    blockerCount: number;
+    acceptedRiskCount: number;
+    conclusion: string;
+  };
+  blockers: Array<{
+    id: string;
+    summary: string;
+    artifactPath?: string;
+    nextStep?: string;
+  }>;
+  acceptedRisks: CommercialVerificationAcceptedRisk[];
+  checks: CommercialVerificationCheck[];
+}
+
 const DEFAULT_RELEASE_READINESS_DIR = path.resolve("artifacts", "release-readiness");
 const DEFAULT_WECHAT_ARTIFACTS_DIR = path.resolve("artifacts", "wechat-release");
-const COMMERCIAL_REVIEW_FILENAMES = [
+const COMMERCIAL_VERIFICATION_FILE_PREFIX = "codex.wechat.commercial-verification";
+const COMMERCIAL_REVIEW_LEGACY_FILENAMES = [
   "codex.wechat.commercial-review.json",
   "wechat-commercial-review.json",
   "commercial-review.json"
@@ -309,6 +376,7 @@ function parseArgs(argv: string[]): Args {
   let releaseGateSummaryPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let wechatCandidateSummaryPath: string | undefined;
+  let commercialVerificationPath: string | undefined;
   let commercialReviewPath: string | undefined;
   let outputPath: string | undefined;
   let markdownOutputPath: string | undefined;
@@ -347,6 +415,11 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--commercial-verification" && next) {
+      commercialVerificationPath = next;
+      index += 1;
+      continue;
+    }
     if (arg === "--commercial-review" && next) {
       commercialReviewPath = next;
       index += 1;
@@ -373,6 +446,7 @@ function parseArgs(argv: string[]): Args {
     ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
+    ...(commercialVerificationPath ? { commercialVerificationPath } : {}),
     ...(commercialReviewPath ? { commercialReviewPath } : {}),
     ...(outputPath ? { outputPath } : {}),
     ...(markdownOutputPath ? { markdownOutputPath } : {})
@@ -541,12 +615,19 @@ function resolveWechatCandidateSummaryPath(
   return undefined;
 }
 
-function resolveCommercialReviewPath(args: Args, releaseGateSummaryPath: string): string | undefined {
+function resolveCommercialEvidencePath(args: Args, releaseGateSummaryPath: string): string | undefined {
+  if (args.commercialVerificationPath) {
+    return requireExistingFile(
+      args.commercialVerificationPath,
+      "Commercial verification evidence",
+      "Pass a valid `--commercial-verification <path>` or place `codex.wechat.commercial-verification-<short-sha>.json` under the WeChat artifacts dir."
+    );
+  }
   if (args.commercialReviewPath) {
     return requireExistingFile(
       args.commercialReviewPath,
-      "Commercial review evidence",
-      "Pass a valid `--commercial-review <path>` or place `codex.wechat.commercial-review.json` under the WeChat artifacts dir."
+      "Commercial evidence",
+      "Pass a valid `--commercial-review <path>` or `--commercial-verification <path>`, or place the generated commercial verification/report file under the WeChat artifacts dir."
     );
   }
 
@@ -555,7 +636,16 @@ function resolveCommercialReviewPath(args: Args, releaseGateSummaryPath: string)
     return undefined;
   }
 
-  for (const fileName of COMMERCIAL_REVIEW_FILENAMES) {
+  const verificationReport = resolveLatestFile(
+    wechatArtifactsDir,
+    (_entryPath, entryName) =>
+      entryName.startsWith(COMMERCIAL_VERIFICATION_FILE_PREFIX) && entryName.endsWith(".json")
+  );
+  if (verificationReport) {
+    return verificationReport;
+  }
+
+  for (const fileName of COMMERCIAL_REVIEW_LEGACY_FILENAMES) {
     const candidate = path.join(wechatArtifactsDir, fileName);
     if (fs.existsSync(candidate)) {
       return candidate;
@@ -628,6 +718,81 @@ function normalizeCheckCategory(check: CommercialReviewCheck): string {
   }
 }
 
+function inferCommercialCategory(input: { id?: string; title?: string; category?: CommercialReviewCheck["category"] }): CommercialReviewCheck["category"] {
+  if (input.category) {
+    return input.category;
+  }
+
+  const haystack = `${input.id ?? ""} ${input.title ?? ""}`.toLowerCase();
+  if (haystack.includes("payment")) {
+    return "payment";
+  }
+  if (haystack.includes("subscribe") || haystack.includes("subscription")) {
+    return "subscription";
+  }
+  if (haystack.includes("analytics") || haystack.includes("funnel") || haystack.includes("retention")) {
+    return "analytics";
+  }
+  if (haystack.includes("compliance") || haystack.includes("minor") || haystack.includes("privacy")) {
+    return "compliance";
+  }
+  if (haystack.includes("device") || haystack.includes("audio") || haystack.includes("memory") || haystack.includes("frame")) {
+    return "device_experience";
+  }
+  return undefined;
+}
+
+function isCommercialVerificationReport(payload: CommercialReviewDocument | CommercialVerificationReport): payload is CommercialVerificationReport {
+  return Array.isArray((payload as CommercialVerificationReport).checks) && "technicalGate" in payload && "summary" in payload;
+}
+
+function normalizeCommercialEvidence(
+  payload: CommercialReviewDocument | CommercialVerificationReport
+): CommercialReviewDocument {
+  if (!isCommercialVerificationReport(payload)) {
+    return payload;
+  }
+
+  return {
+    generatedAt: payload.generatedAt,
+    candidate: {
+      revision: payload.candidate.revision,
+      version: payload.candidate.version,
+      status: payload.candidate.status
+    },
+    summary: {
+      status: payload.summary.status,
+      requiredPendingChecks: payload.summary.requiredPendingChecks,
+      requiredFailedChecks: payload.summary.requiredFailedChecks,
+      requiredMetadataFailures: payload.summary.requiredMetadataFailures
+    },
+    checks: payload.checks.map((check) => ({
+      id: check.id,
+      title: check.title,
+      category: inferCommercialCategory(check),
+      required: check.required,
+      status: check.status,
+      owner: check.owner,
+      recordedAt: check.recordedAt,
+      revision: check.revision,
+      artifactPath: check.artifactPath,
+      notes: [
+        check.notes?.trim() || null,
+        check.evidence.length > 0 ? `Evidence: ${check.evidence.join("; ")}` : null
+      ]
+        .filter((entry): entry is string => Boolean(entry))
+        .join(" "),
+      metadataFailures: check.metadataFailures
+    })),
+    blockers: payload.blockers.map((blocker) => ({
+      id: blocker.id,
+      summary: blocker.summary,
+      artifactPath: blocker.artifactPath,
+      nextCommand: blocker.nextStep
+    }))
+  };
+}
+
 function collectCommercialMetadataFailures(
   check: CommercialReviewCheck,
   candidateRevision: string
@@ -635,6 +800,9 @@ function collectCommercialMetadataFailures(
   const failures: string[] = [];
   if (check.required === false) {
     return failures;
+  }
+  if (Array.isArray(check.metadataFailures) && check.metadataFailures.length > 0) {
+    return [...check.metadataFailures];
   }
   if (!check.owner?.trim()) {
     failures.push("missing owner");
@@ -688,8 +856,10 @@ export function buildGoNoGoDecisionPacket(args: Args): GoNoGoDecisionPacket {
   const wechatCandidateSummary = wechatCandidateSummaryPath
     ? readJsonFile<WechatCandidateSummary>(wechatCandidateSummaryPath)
     : undefined;
-  const commercialReviewPath = resolveCommercialReviewPath(args, releaseGateSummaryPath);
-  const commercialReview = commercialReviewPath ? readJsonFile<CommercialReviewDocument>(commercialReviewPath) : undefined;
+  const commercialReviewPath = resolveCommercialEvidencePath(args, releaseGateSummaryPath);
+  const commercialReview = commercialReviewPath
+    ? normalizeCommercialEvidence(readJsonFile<CommercialReviewDocument | CommercialVerificationReport>(commercialReviewPath))
+    : undefined;
 
   const passing: PacketItem[] = [];
   const warnings: PacketItem[] = [];
@@ -1004,7 +1174,7 @@ export function renderMarkdown(packet: GoNoGoDecisionPacket): string {
     lines.push(`- WeChat candidate summary: \`${toDisplayPath(packet.inputs.wechatCandidateSummaryPath)}\``);
   }
   if (packet.inputs.commercialReviewPath) {
-    lines.push(`- Commercial review evidence: \`${toDisplayPath(packet.inputs.commercialReviewPath)}\``);
+    lines.push(`- Commercial evidence: \`${toDisplayPath(packet.inputs.commercialReviewPath)}\``);
   }
   lines.push(`- Dossier generated at: \`${packet.sections.candidateMetadata.dossierGeneratedAt}\``);
   lines.push(`- Release gate generated at: \`${packet.sections.candidateMetadata.releaseGateGeneratedAt}\``);

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -99,9 +99,9 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
     ],
   },
   "release:go-no-go-packet": {
-    purpose: "Build the final go/no-go decision packet for a candidate by combining the dossier, gate summary, and WeChat summary.",
+    purpose: "Build the final go/no-go decision packet for a candidate by combining the dossier, gate summary, WeChat summary, and optional commercial verification evidence.",
     requiredInputs: [
-      "Phase 1 candidate dossier plus matching release-gate and WeChat candidate-summary artifacts, either auto-discovered or passed explicitly.",
+      "Phase 1 candidate dossier plus matching release-gate and WeChat candidate-summary artifacts, either auto-discovered or passed explicitly; commercial verification evidence is auto-discovered from the WeChat artifacts dir when available.",
     ],
     producedArtifacts: [
       "`artifacts/release-readiness/go-no-go-decision-packet-<candidate>-<short-sha>.json`",

--- a/scripts/test/release-go-no-go-decision-packet.test.ts
+++ b/scripts/test/release-go-no-go-decision-packet.test.ts
@@ -350,6 +350,170 @@ test("buildGoNoGoDecisionPacket folds commercial review blockers into the final 
   assert.match(markdown, /支付 - 支付链路端到端验证/);
 });
 
+test("buildGoNoGoDecisionPacket auto-detects wechat commercial verification artifacts", () => {
+  const workspace = createTempWorkspace();
+  const releaseDir = path.join(workspace, "artifacts", "release-readiness");
+  const dossierDir = path.join(releaseDir, "phase1-candidate-dossier-phase1-rc-abc1234");
+  const wechatDir = path.join(workspace, "artifacts", "wechat-release");
+  const dossierPath = path.join(dossierDir, "phase1-candidate-dossier.json");
+  const releaseGateSummaryPath = path.join(releaseDir, "release-gate-summary-abc1234.json");
+  const wechatCandidateSummaryPath = path.join(wechatDir, "codex.wechat.release-candidate-summary.json");
+  const commercialVerificationPath = path.join(wechatDir, "codex.wechat.commercial-verification-abc1234.json");
+
+  writeJson(dossierPath, {
+    generatedAt: "2026-04-10T10:00:00.000Z",
+    candidate: {
+      name: "phase1-rc",
+      revision: "abc1234def5678",
+      shortRevision: "abc1234",
+      branch: "release/phase1",
+      dirty: false,
+      targetSurface: "wechat"
+    },
+    summary: {
+      status: "passed",
+      totalSections: 1,
+      requiredFailed: [],
+      requiredPending: [],
+      acceptedRiskCount: 0
+    },
+    phase1ExitEvidenceGate: {
+      result: "passed",
+      summary: "All required evidence passed.",
+      blockingSections: [],
+      pendingSections: [],
+      acceptedRiskSections: []
+    },
+    sections: [
+      {
+        id: "release-readiness",
+        label: "Release readiness",
+        required: true,
+        result: "passed",
+        summary: "Automated release readiness checks passed.",
+        artifactPath: path.join(releaseDir, "release-readiness-abc1234.json"),
+        freshness: "fresh"
+      }
+    ]
+  });
+
+  writeJson(releaseGateSummaryPath, {
+    generatedAt: "2026-04-10T10:05:00.000Z",
+    targetSurface: "wechat",
+    summary: {
+      status: "passed",
+      failedGateIds: []
+    },
+    inputs: {
+      wechatArtifactsDir: wechatDir,
+      wechatCandidateSummaryPath
+    },
+    triage: {
+      blockers: [],
+      warnings: []
+    },
+    releaseSurface: {
+      status: "passed",
+      summary: "Release surface evidence is passing for the selected wechat target.",
+      evidence: []
+    }
+  });
+
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: "2026-04-10T10:10:00.000Z",
+    candidate: {
+      revision: "abc1234def5678",
+      version: "1.2.3",
+      status: "ready"
+    },
+    evidence: {
+      manualReview: {
+        status: "ready",
+        requiredPendingChecks: 0,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: []
+      }
+    },
+    blockers: []
+  });
+
+  writeJson(commercialVerificationPath, {
+    schemaVersion: 1,
+    generatedAt: "2026-04-10T10:12:00.000Z",
+    candidate: {
+      name: "phase1-rc",
+      revision: "abc1234def5678",
+      shortRevision: "abc1234",
+      version: "1.2.3",
+      status: "blocked"
+    },
+    technicalGate: {
+      status: "ready",
+      summary: "WeChat candidate summary is ready.",
+      artifactPath: "artifacts/wechat-release/codex.wechat.release-candidate-summary.json",
+      blockerCount: 0
+    },
+    summary: {
+      status: "blocked",
+      totalChecks: 5,
+      completedRequiredChecks: 4,
+      requiredPendingChecks: 1,
+      requiredFailedChecks: 0,
+      requiredMetadataFailures: 0,
+      blockerCount: 1,
+      acceptedRiskCount: 0,
+      conclusion: "Commercial verification is incomplete or blocked; do not use this candidate for external rollout yet."
+    },
+    blockers: [
+      {
+        id: "wechat-payment-e2e-pending",
+        summary: "WeChat payment end-to-end verified is still pending.",
+        artifactPath: "artifacts/wechat-release/payment-e2e.md",
+        nextStep: "Record owner, revision, artifact path, and the final verification result."
+      }
+    ],
+    acceptedRisks: [],
+    checks: [
+      {
+        id: "wechat-payment-e2e",
+        title: "WeChat payment end-to-end verified",
+        status: "pending",
+        required: true,
+        notes: "Waiting on live payment callback proof.",
+        evidence: ["payment order create evidence"],
+        owner: "release-commerce",
+        recordedAt: "2026-04-10T10:11:00.000Z",
+        revision: "abc1234def5678",
+        artifactPath: "artifacts/wechat-release/payment-e2e.md",
+        blockerIds: [],
+        acceptedRisks: [],
+        freshness: "fresh",
+        metadataStatus: "passed",
+        metadataFailures: []
+      }
+    ]
+  });
+
+  const packet = buildGoNoGoDecisionPacket({
+    dossierPath,
+    releaseGateSummaryPath,
+    wechatCandidateSummaryPath
+  });
+
+  assert.equal(packet.decision.status, "no_go");
+  assert.equal(packet.inputs.commercialReviewPath, commercialVerificationPath);
+  assert.equal(packet.sections.commercialReadinessSummary.status, "blocked");
+  assert.equal(packet.sections.commercialReadinessSummary.requiredPendingChecks, 1);
+  assert.equal(packet.sections.unresolvedCommercialChecks.length, 1);
+  assert.equal(packet.sections.blockerSummary.blockers.some((item) => item.id === "commercial:wechat-payment-e2e"), true);
+  assert.equal(packet.sections.blockerSummary.blockers.some((item) => item.id === "commercial:wechat-payment-e2e-pending"), true);
+
+  const markdown = renderMarkdown(packet);
+  assert.match(markdown, /Commercial evidence:/);
+  assert.match(markdown, /codex\.wechat\.commercial-verification-abc1234\.json/);
+});
+
 test("go/no-go packet CLI fails with an actionable error when the dossier is missing", () => {
   const workspace = createTempWorkspace();
   const result = spawnSync(


### PR DESCRIPTION
## Summary
- let release:go-no-go-packet auto-discover and consume commercial verification artifacts
- keep legacy commercial-review inputs working while switching docs to the new main path
- add regression coverage for commercial verification auto-discovery

## Testing
- npm run typecheck:ops
- node --import tsx --test ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts

Closes #1185