### PR TITLE
feat: add commercial verification to wechat rehearsal

### DIFF
--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -45,7 +45,7 @@ Relevant scripts: 49
 | `release:same-candidate:evidence-audit` | release | `artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.json` |
 | `release:wechat:commercial-verification` | release | `codex.wechat.commercial-verification-<short-sha>.json` in the selected artifacts directory. |
 | `release:wechat:install-launch-evidence` | release | `codex.wechat.install-launch-evidence.json` in the selected artifacts directory. |
-| `release:wechat:rehearsal` | release | Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, and upload artifacts it references. |
+| `release:wechat:rehearsal` | release | Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, and upload artifacts they reference. |
 | `smoke:client:boot-room` | smoke | `artifacts/release-readiness/client-boot-room-smoke-<short-sha>.json` when an explicit output path is used, or console smoke verdict output by default. |
 | `smoke:client:release-candidate` | smoke | `artifacts/release-readiness/client-release-candidate-smoke-<short-sha>-<timestamp>.json` |
 | `smoke:cocos:canonical-journey` | smoke | `artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.json` |
@@ -404,11 +404,11 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/wechat-release-rehearsal.ts`
-- Purpose: Run the WeChat release rehearsal flow that chains prepare, package, verify, and validate steps into one summary.
+- Purpose: Run the WeChat release rehearsal flow that chains prepare, package, verify, validate, and optional commercial verification steps into one summary.
 - Required inputs:
-  - A WeChat build directory plus an artifacts directory; optional config/summary path overrides.
+  - A WeChat build directory plus an artifacts directory; optional config/summary path overrides, install/smoke/manual-review inputs, and `--run-commercial-verification` / `--commercial-checks` when the rehearsal should also emit the commercial verification artifact.
 - Produced artifacts:
-  - Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, and upload artifacts it references.
+  - Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, and upload artifacts they reference.
 
 ## `smoke:client:boot-room`
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -31,7 +31,7 @@
 - 记录 candidate-scoped 安装/启动证据：`npm run release:wechat:install-launch-evidence -- --artifacts-dir <release-artifacts-dir> --candidate <candidate-name> --environment <wechat-devtools|device-lab|qa-phone> --operator <name> --status <passed|failed> [--candidate-revision <git-sha>] [--summary <text>] [--evidence <path-or-note>]`
 - 聚合校验 RC artifact：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report] [--manual-checks docs/release-evidence/wechat-release-manual-review.example.json]`
 - 聚合商运闭环验证：`npm run release:wechat:commercial-verification -- --artifacts-dir <release-artifacts-dir> [--checks docs/release-evidence/wechat-commercial-verification.example.json] [--candidate <candidate-name>] [--candidate-revision <git-sha>]`
-- 发布彩排与汇总：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> [--summary <json>] [--markdown <md>] [--candidate <candidate-name> --environment wechat-devtools --operator <name> --status <passed|failed> --evidence <capture-or-note> --runtime-evidence <runtime-evidence.json> --manual-checks <manual-review.json>]`（顺序执行 prepare / package / verify，并可选补 install/launch evidence、smoke report、validate，输出结构化 + Markdown 摘要）
+- 发布彩排与汇总：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> [--summary <json>] [--markdown <md>] [--candidate <candidate-name> --environment wechat-devtools --operator <name> --status <passed|failed> --evidence <capture-or-note> --runtime-evidence <runtime-evidence.json> --manual-checks <manual-review.json> --run-commercial-verification --commercial-checks <commercial-review.json>]`（顺序执行 prepare / package / verify，并可选补 install/launch evidence、smoke report、validate、commercial verification，输出结构化 + Markdown 摘要）
 - 上传已打包产物：`npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`
 - 按 SHA 下载 CI artifact：`npm run download:wechat-release -- --sha <git-sha> [--output-dir artifacts/downloaded/wechat-release-<git-sha>]`
 - 验收已下载 artifact：`npm run verify:wechat-release -- --artifacts-dir <downloaded-artifact-dir> [--expected-revision <git-sha>]`
@@ -143,9 +143,10 @@ WeChat checklist / blockers 至少要覆盖以下证据面：
 - 当传入 `--candidate --environment --operator --status` 时，会额外执行 `release:wechat:install-launch-evidence`，把微信开发者工具导入 / 首启结论直接挂到同一 artifacts dir。
 - 当传入 `--runtime-evidence <json>` 时，会额外执行 `smoke:wechat-release -- --force`，直接生成同 revision 的 `codex.wechat.smoke-report.json`。
 - 当传入 `--manual-checks <json>` 时，最终 `validate:wechat-rc` 会复用这份 manual review JSON 生成 ready/blocked 的 candidate summary，而不是只停在 pending 模板。
+- 当传入 `--run-commercial-verification` 时，会在 `validate` 之后追加 `release:wechat:commercial-verification`；若再传 `--commercial-checks <json>`，会直接复用这份商运复核 contract。
 - 结构化摘要默认写到 `artifacts/wechat-release/wechat-release-rehearsal-<short-sha>.json`，Markdown 摘要写到同名 `.md`；可通过 `--summary` / `--markdown` 改写路径。
 - JSON 摘要包含阶段命令、耗时、stdout / stderr tail 以及首个失败阶段的诊断，Markdown 版本可直接贴到 CI Summary 或 PR。
-- `## Artifacts` 现在会自动列出 install/launch evidence、smoke report、candidate summary 等关键证据，方便 reviewer 直接校对同一个候选 revision。
+- `## Artifacts` 现在会自动列出 install/launch evidence、smoke report、candidate summary、commercial verification 等关键证据，方便 reviewer 直接校对同一个候选 revision。
 - `--source-revision`、`--expected-revision`、`--package-name`、`--version`、`--require-smoke-report` 会透传给对应脚本，方便对齐真实提审参数。
 - 适合在本地 release rehearsal、或在 CI 下载模板导出夹具时，一次性确认整个链路仍能跑通。
 

--- a/progress.md
+++ b/progress.md
@@ -1573,3 +1573,24 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 本轮定向验证结果：
   - `npm run typecheck:ops` 通过
   - `node --import tsx --test ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`10/10`）
+
+## Issue #1187 - WeChat rehearsal commercial verification stage - 2026-04-10
+
+- 本轮把 `release:wechat:rehearsal` 从“技术候选包彩排”继续推进成“可选收口商运结论”的一键链路：
+  - `scripts/wechat-release-rehearsal.ts`
+    - 新增 `--run-commercial-verification`，用于在 rehearsal 末尾追加 `release:wechat:commercial-verification`
+    - 新增 `--commercial-checks <json>` 与 `--commercial-freshness-hours <hours>`，可直接把 candidate 专属商运复核 contract 透传给 commercial verification 阶段
+    - `DetectedArtifacts` 和 Markdown summary 现在会自动收集并展示 `codex.wechat.commercial-verification-<short-sha>.json/.md`
+    - 保持旧调用方式不变：不传上述参数时，rehearsal 仍只跑原有 `prepare / package / verify / install-launch / smoke / validate`
+- 文档与 inventory 已同步：
+  - `docs/wechat-minigame-release.md`
+    - 更新 `release:wechat:rehearsal` 的命令示例与发布彩排摘要，明确可选 commercial verification 阶段
+  - `scripts/release-script-inventory.ts` / `docs/release-script-inventory.md`
+    - 更新 `release:wechat:rehearsal` 的职责与产物说明
+- 测试收口：
+  - `scripts/test/wechat-release-rehearsal.test.ts`
+    - 新增“rehearsal 可追加 commercial verification artifacts”的完整覆盖
+    - 断言阶段序列扩展为 `prepare -> package -> verify -> install-launch-evidence -> smoke -> validate -> commercial-verification`
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`7/7`）

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -342,12 +342,12 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
     ],
   },
   "release:wechat:rehearsal": {
-    purpose: "Run the WeChat release rehearsal flow that chains prepare, package, verify, and validate steps into one summary.",
+    purpose: "Run the WeChat release rehearsal flow that chains prepare, package, verify, validate, and optional commercial verification steps into one summary.",
     requiredInputs: [
-      "A WeChat build directory plus an artifacts directory; optional config/summary path overrides.",
+      "A WeChat build directory plus an artifacts directory; optional config/summary path overrides, install/smoke/manual-review inputs, and `--run-commercial-verification` / `--commercial-checks` when the rehearsal should also emit the commercial verification artifact.",
     ],
     producedArtifacts: [
-      "Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, and upload artifacts it references.",
+      "Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, and upload artifacts they reference.",
     ],
   },
   "smoke:client:release-candidate": {

--- a/scripts/test/wechat-release-rehearsal.test.ts
+++ b/scripts/test/wechat-release-rehearsal.test.ts
@@ -256,3 +256,302 @@ test("release:wechat:rehearsal produces structured + markdown summaries", () => 
     report.summary.artifacts.candidateSummaryMarkdownPath?.endsWith("codex.wechat.release-candidate-summary.md")
   );
 });
+
+test("release:wechat:rehearsal can append commercial verification artifacts", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-rehearsal-commercial-"));
+  const buildDir = path.join(workspace, "build");
+  const artifactsDir = path.join(workspace, "artifacts");
+  const summaryPath = path.join(workspace, "summary.json");
+  const markdownPath = path.join(workspace, "summary.md");
+  const runtimeEvidencePath = path.join(workspace, "runtime-evidence.json");
+  const manualChecksPath = path.join(workspace, "manual-review.json");
+  const commercialChecksPath = path.join(workspace, "commercial-checks.json");
+  const recordedAt = new Date().toISOString();
+
+  fs.cpSync(fixtureBuildDir, buildDir, { recursive: true });
+  fs.mkdirSync(artifactsDir, { recursive: true });
+
+  fs.writeFileSync(
+    runtimeEvidencePath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        buildTemplatePlatform: "wechatgame",
+        artifact: {
+          archiveFileName: "project-veil-wechatgame-release.tar.gz",
+          sourceRevision: "abc1234"
+        },
+        execution: {
+          tester: "codex-bot",
+          device: "iPhone 15 Pro / WeChat 8.0.50",
+          clientVersion: "8.0.50",
+          executedAt: recordedAt,
+          result: "passed",
+          summary: "Imported runtime evidence from the rehearsal lane."
+        },
+        cases: [
+          { id: "startup", status: "passed", evidence: ["startup.mp4"] },
+          { id: "lobby-entry", status: "passed", evidence: ["lobby.png"] },
+          { id: "room-entry", status: "passed", evidence: ["room-entry.png"] },
+          {
+            id: "reconnect-recovery",
+            status: "passed",
+            evidence: ["reconnect.mp4"],
+            requiredEvidence: {
+              roomId: "room-alpha",
+              reconnectPrompt: "连接已恢复",
+              restoredState: "Restored room-alpha with the same hero state and lobby context."
+            }
+          },
+          {
+            id: "share-roundtrip",
+            status: "not_applicable",
+            evidence: ["share-roundtrip.txt"],
+            requiredEvidence: {
+              shareScene: "lobby",
+              shareQuery: "roomId=room-alpha&inviterId=player-7",
+              roundtripState: "Not executed in this rehearsal lane."
+            }
+          },
+          { id: "key-assets", status: "passed", evidence: ["assets.log"] }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "runtime-observability-signoff.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "checklist-review.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed",
+        blockerIds: ["none"]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "device-runtime-review.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    manualChecksPath,
+    `${JSON.stringify(
+      [
+        {
+          id: "wechat-devtools-export-review",
+          title: "Candidate-scoped WeChat package install/launch verification recorded",
+          status: "passed",
+          required: true,
+          notes: "Generated install/launch verification during the rehearsal.",
+          evidence: [path.join(artifactsDir, "codex.wechat.install-launch-evidence.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "codex.wechat.install-launch-evidence.json")
+        },
+        {
+          id: "wechat-device-runtime-review",
+          title: "Physical-device WeChat runtime validated for this candidate",
+          status: "passed",
+          required: true,
+          notes: "Attached the smoke report and capture set from the rehearsal runtime pass.",
+          evidence: [
+            path.join(artifactsDir, "codex.wechat.smoke-report.json"),
+            path.join(artifactsDir, "device-runtime-review.json")
+          ],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "device-runtime-review.json")
+        },
+        {
+          id: "wechat-runtime-observability-signoff",
+          title: "WeChat runtime observability reviewed for this candidate",
+          status: "passed",
+          required: true,
+          notes: "Captured health/auth-readiness/metrics evidence for the release environment.",
+          evidence: [path.join(artifactsDir, "runtime-observability-signoff.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "runtime-observability-signoff.json")
+        },
+        {
+          id: "wechat-release-checklist",
+          title: "WeChat RC checklist and blockers reviewed",
+          status: "passed",
+          required: true,
+          notes: "Checklist and blockers resolved for the packaged candidate.",
+          evidence: [path.join(artifactsDir, "checklist-review.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "checklist-review.json")
+        }
+      ],
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    commercialChecksPath,
+    `${JSON.stringify(
+      [
+        {
+          id: "wechat-payment-e2e",
+          title: "WeChat payment end-to-end verified",
+          status: "passed",
+          owner: "commerce-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/payment-e2e-review.md"
+        },
+        {
+          id: "wechat-subscribe-delivery",
+          title: "WeChat subscribe-message delivery verified",
+          status: "passed",
+          owner: "growth-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/subscribe-delivery-review.md"
+        },
+        {
+          id: "wechat-analytics-acceptance",
+          title: "Commercial analytics acceptance verified",
+          status: "passed",
+          owner: "data-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/analytics-review.md"
+        },
+        {
+          id: "wechat-compliance-review",
+          title: "Commercial compliance and submission material reviewed",
+          status: "passed",
+          owner: "compliance-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/compliance-review.md"
+        },
+        {
+          id: "wechat-device-experience-review",
+          title: "Physical-device experience reviewed",
+          status: "passed",
+          owner: "qa-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/device-experience-review.md"
+        }
+      ],
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const output = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/wechat-release-rehearsal.ts",
+      "--config",
+      defaultConfigPath,
+      "--build-dir",
+      buildDir,
+      "--artifacts-dir",
+      artifactsDir,
+      "--summary",
+      summaryPath,
+      "--markdown",
+      markdownPath,
+      "--source-revision",
+      "abc1234",
+      "--expected-revision",
+      "abc1234",
+      "--candidate",
+      "phase1-rc",
+      "--environment",
+      "wechat-devtools",
+      "--operator",
+      "release-oncall",
+      "--status",
+      "passed",
+      "--verification-summary",
+      "Candidate rehearsal package import and first launch passed.",
+      "--evidence",
+      "devtools-import-capture.png",
+      "--runtime-evidence",
+      runtimeEvidencePath,
+      "--manual-checks",
+      manualChecksPath,
+      "--run-commercial-verification",
+      "--commercial-checks",
+      commercialChecksPath,
+      "--require-smoke-report"
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  assert.match(output, /WeChat release rehearsal PASSED/);
+  const report = JSON.parse(fs.readFileSync(summaryPath, "utf8")) as {
+    summary: { status: string; artifacts: Record<string, string | undefined> };
+    stages: Array<{ id: string; status: string }>;
+  };
+
+  assert.equal(report.summary.status, "passed");
+  assert.deepEqual(
+    report.stages.map((stage) => stage.id),
+    ["prepare", "package", "verify", "install-launch-evidence", "smoke", "validate", "commercial-verification"]
+  );
+  assert.ok(
+    report.summary.artifacts.commercialVerificationJsonPath?.includes("codex.wechat.commercial-verification-abc1234")
+  );
+  assert.ok(
+    report.summary.artifacts.commercialVerificationMarkdownPath?.includes("codex.wechat.commercial-verification-abc1234")
+  );
+  const markdown = fs.readFileSync(markdownPath, "utf8");
+  assert.match(markdown, /Commercial Verification \(JSON\)/);
+});

--- a/scripts/wechat-release-rehearsal.ts
+++ b/scripts/wechat-release-rehearsal.ts
@@ -29,6 +29,9 @@ interface Args {
   launchSummary?: string;
   runtimeEvidencePath?: string;
   manualChecksPath?: string;
+  runCommercialVerification: boolean;
+  commercialChecksPath?: string;
+  commercialFreshnessHours?: number;
   evidence: string[];
 }
 
@@ -87,6 +90,8 @@ interface DetectedArtifacts {
   installLaunchEvidenceMarkdownPath?: string;
   candidateSummaryJsonPath?: string;
   candidateSummaryMarkdownPath?: string;
+  commercialVerificationJsonPath?: string;
+  commercialVerificationMarkdownPath?: string;
 }
 
 const OUTPUT_LIMIT = 4000;
@@ -125,6 +130,9 @@ function parseArgs(argv: string[]): Args {
   let launchSummary: string | undefined;
   let runtimeEvidencePath: string | undefined;
   let manualChecksPath: string | undefined;
+  let runCommercialVerification = false;
+  let commercialChecksPath: string | undefined;
+  let commercialFreshnessHours: number | undefined;
   const evidence: string[] = [];
 
   for (let index = 2; index < argv.length; index += 1) {
@@ -245,6 +253,25 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--run-commercial-verification") {
+      runCommercialVerification = true;
+      continue;
+    }
+    if (arg === "--commercial-checks" && next) {
+      commercialChecksPath = next.trim() || undefined;
+      runCommercialVerification = true;
+      index += 1;
+      continue;
+    }
+    if (arg === "--commercial-freshness-hours" && next) {
+      commercialFreshnessHours = Number.parseInt(next, 10);
+      if (!Number.isFinite(commercialFreshnessHours) || commercialFreshnessHours <= 0) {
+        throw new Error(`--commercial-freshness-hours must be a positive integer, received: ${next}`);
+      }
+      runCommercialVerification = true;
+      index += 1;
+      continue;
+    }
     if (arg === "--evidence" && next) {
       const value = next.trim();
       if (value) {
@@ -281,6 +308,9 @@ function parseArgs(argv: string[]): Args {
     ...(launchSummary ? { launchSummary } : {}),
     ...(runtimeEvidencePath ? { runtimeEvidencePath } : {}),
     ...(manualChecksPath ? { manualChecksPath } : {}),
+    runCommercialVerification,
+    ...(commercialChecksPath ? { commercialChecksPath } : {}),
+    ...(commercialFreshnessHours ? { commercialFreshnessHours } : {}),
     evidence
   };
 }
@@ -417,6 +447,12 @@ function detectArtifacts(artifactsDir: string): DetectedArtifacts {
   const installLaunchEvidenceMarkdown = entries.find((entry) => entry === "codex.wechat.install-launch-evidence.md");
   const candidateSummaryJson = entries.find((entry) => entry === "codex.wechat.release-candidate-summary.json");
   const candidateSummaryMarkdown = entries.find((entry) => entry === "codex.wechat.release-candidate-summary.md");
+  const commercialVerificationJson = entries
+    .filter((entry) => entry.startsWith("codex.wechat.commercial-verification-") && entry.endsWith(".json"))
+    .sort()[0];
+  const commercialVerificationMarkdown = entries
+    .filter((entry) => entry.startsWith("codex.wechat.commercial-verification-") && entry.endsWith(".md"))
+    .sort()[0];
   return {
     ...(archive ? { archivePath: path.join(artifactsDir, archive) } : {}),
     ...(metadata ? { metadataPath: path.join(artifactsDir, metadata) } : {}),
@@ -428,6 +464,12 @@ function detectArtifacts(artifactsDir: string): DetectedArtifacts {
     ...(candidateSummaryJson ? { candidateSummaryJsonPath: path.join(artifactsDir, candidateSummaryJson) } : {}),
     ...(candidateSummaryMarkdown
       ? { candidateSummaryMarkdownPath: path.join(artifactsDir, candidateSummaryMarkdown) }
+      : {}),
+    ...(commercialVerificationJson
+      ? { commercialVerificationJsonPath: path.join(artifactsDir, commercialVerificationJson) }
+      : {}),
+    ...(commercialVerificationMarkdown
+      ? { commercialVerificationMarkdownPath: path.join(artifactsDir, commercialVerificationMarkdown) }
       : {})
   };
 }
@@ -485,6 +527,12 @@ function renderMarkdown(summary: RehearsalSummary): string {
   if (artifacts.candidateSummaryMarkdownPath) {
     artifactLines.push(`- Candidate Summary (Markdown): \`${artifacts.candidateSummaryMarkdownPath}\``);
   }
+  if (artifacts.commercialVerificationJsonPath) {
+    artifactLines.push(`- Commercial Verification (JSON): \`${artifacts.commercialVerificationJsonPath}\``);
+  }
+  if (artifacts.commercialVerificationMarkdownPath) {
+    artifactLines.push(`- Commercial Verification (Markdown): \`${artifacts.commercialVerificationMarkdownPath}\``);
+  }
   if (artifactLines.length > 0) {
     lines.push("\n## Artifacts\n\n");
     lines.push(artifactLines.join("\n"));
@@ -505,6 +553,7 @@ function main(): void {
   const expectedRevision = args.expectedRevision ?? sourceRevision;
   const resolvedRuntimeEvidencePath = args.runtimeEvidencePath ? path.resolve(repoRoot, args.runtimeEvidencePath) : undefined;
   const resolvedManualChecksPath = args.manualChecksPath ? path.resolve(repoRoot, args.manualChecksPath) : undefined;
+  const resolvedCommercialChecksPath = args.commercialChecksPath ? path.resolve(repoRoot, args.commercialChecksPath) : undefined;
   const summaryBaseName = revision.shortCommit ? `wechat-release-rehearsal-${revision.shortCommit}` : `wechat-release-rehearsal`;
   const summaryPath = path.resolve(repoRoot, args.summaryPath ?? path.join(args.artifactsDir, `${summaryBaseName}.json`));
   const markdownPath = path.resolve(repoRoot, args.markdownPath ?? path.join(args.artifactsDir, `${summaryBaseName}.md`));
@@ -662,6 +711,27 @@ function main(): void {
       ]
     }
   );
+
+  if (args.runCommercialVerification) {
+    stageDefinitions.push({
+      id: "commercial-verification",
+      title: "Generate commercial verification summary",
+      command: [
+        nodeExec,
+        "--import",
+        "tsx",
+        "./scripts/wechat-commercial-verification.ts",
+        "--artifacts-dir",
+        resolvedArtifactsDir,
+        ...(resolvedCommercialChecksPath ? ["--checks", resolvedCommercialChecksPath] : []),
+        ...(args.candidate?.trim() ? ["--candidate", args.candidate.trim()] : []),
+        ...((args.candidateRevision ?? expectedRevision)?.trim()
+          ? ["--candidate-revision", (args.candidateRevision ?? expectedRevision)!.trim()]
+          : []),
+        ...(args.commercialFreshnessHours ? ["--freshness-hours", String(args.commercialFreshnessHours)] : [])
+      ]
+    });
+  }
 
   const stageResults: StageResult[] = [];
   let failureStage: StageResult | undefined;


### PR DESCRIPTION
## Summary
- let release:wechat:rehearsal optionally run commercial verification after validate
- surface commercial verification artifacts in the rehearsal summary and markdown
- document the new commercial rehearsal path and add regression coverage

## Testing
- npm run typecheck:ops
- node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts

Closes #1187