### PR TITLE
Surface WeChat external-launch verification in release summary

### DIFF
--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -16,6 +16,8 @@ The summary now also records one explicit `targetSurface` contract. That contrac
 
 For reviewer handoff, treat the WeChat RC checklist and blocker register as the human-readable mirror of that same contract, not as optional notes. They should carry the same surface, revision, freshness, owner, blocker, and waiver story that the JSON report enforces.
 
+When the target surface is `wechat`, the summary also auto-discovers the latest `codex.wechat.commercial-verification-<short-sha>.json` from the selected WeChat artifacts dir and surfaces it as an advisory warning when it is missing, stale, or blocked. This does not change the hard technical gate semantics, but it keeps the external-launch checklist visible in the same handoff artifact instead of leaving it implicit in a separate PR comment or release note.
+
 ## Usage
 
 Use the latest local artifacts under `artifacts/release-readiness/` and `artifacts/wechat-release/`:
@@ -128,6 +130,14 @@ When `--manual-evidence-ledger` is present, the summary now parses the ledger ta
 - row-level freshness or revision drift for the current candidate
 
 Those row-level findings are promoted into both the `Target Surface Contract` and the top-level `Triage Summary`, so reviewers can tell from the generated gate summary whether the candidate still has manual evidence handoff work outstanding before the release call.
+
+For `wechat`, the generated Markdown `Selected Inputs` section also records the currently selected commercial-verification artifact path, and the `Warnings` section will call out missing or blocked external-launch verification. Use that warning as the trigger to run:
+
+```bash
+npm run release:wechat:commercial-verification -- --artifacts-dir <wechat-artifacts-dir>
+```
+
+That warning stays advisory on purpose: it is there to prevent a technically green RC packet from being mistaken for an externally launch-ready packet.
 
 For `wechat`, the required surface evidence is:
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -66,6 +66,8 @@
 
 `npm run release:gate:summary -- --target-surface wechat` 的 `Target Surface Contract` 会显式列出 WeChat package、verify、smoke、candidate summary 与 manual review 的 `passed` / `failed` / `pending` 状态；只要 required manual review 仍是 `pending`，Phase 1 sign-off 就保持 blocked。
 
+同一个 summary 现在还会自动发现当前 artifacts dir 下最新的 `codex.wechat.commercial-verification-<short-sha>.json`。如果目标已经进入“外部放量 / 提审 / 正式商运”检查阶段，但这份 artifact 仍缺失、过旧或处于 `blocked`，`Warnings` 会直接提示补跑 `npm run release:wechat:commercial-verification -- --artifacts-dir <release-artifacts-dir>`，避免技术 RC 绿色被误读成“可以直接外放”。
+
 WeChat checklist / blockers 至少要覆盖以下证据面：
 
 - package / verify / RC validation 产物

--- a/scripts/release-gate-summary.ts
+++ b/scripts/release-gate-summary.ts
@@ -15,6 +15,7 @@ interface Args {
   wechatRcValidationPath?: string;
   wechatCandidateSummaryPath?: string;
   wechatSmokeReportPath?: string;
+  wechatCommercialVerificationPath?: string;
   wechatArtifactsDir?: string;
   manualEvidenceLedgerPath?: string;
   configCenterLibraryPath?: string;
@@ -251,6 +252,23 @@ interface ReconnectSoakArtifact {
   };
 }
 
+interface WechatCommercialVerificationReport {
+  generatedAt?: string;
+  candidate?: {
+    revision?: string | null;
+    status?: "ready" | "blocked";
+  };
+  summary?: {
+    status?: "ready" | "blocked";
+    blockerCount?: number;
+    requiredPendingChecks?: number;
+    requiredFailedChecks?: number;
+    requiredMetadataFailures?: number;
+    acceptedRiskCount?: number;
+    conclusion?: string;
+  };
+}
+
 type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
 type ConfigRiskLevel = "low" | "medium" | "high";
 
@@ -356,6 +374,7 @@ interface ReleaseGateSummaryReport {
     wechatRcValidationPath?: string;
     wechatCandidateSummaryPath?: string;
     wechatSmokeReportPath?: string;
+    wechatCommercialVerificationPath?: string;
     wechatArtifactsDir?: string;
     manualEvidenceLedgerPath?: string;
     configCenterLibraryPath?: string;
@@ -372,7 +391,14 @@ interface ReleaseGateSummaryReport {
 const HEX_REVISION_PATTERN = /^[a-f0-9]+$/i;
 const MAX_PHASE1_EVIDENCE_TIMESTAMP_DRIFT_MS = 1000 * 60 * 60 * 72;
 const MAX_TARGET_SURFACE_REVIEW_AGE_MS = 1000 * 60 * 60 * 72;
+const MAX_COMMERCIAL_VERIFICATION_AGE_MS = 1000 * 60 * 60 * 24;
 const LEDGER_PENDING_STATUSES = new Set(["pending", "in-review"]);
+const COMMERCIAL_VERIFICATION_FILE_PREFIX = "codex.wechat.commercial-verification-";
+const COMMERCIAL_REVIEW_LEGACY_FILENAMES = [
+  "codex.wechat.commercial-review.json",
+  "wechat-commercial-review.json",
+  "commercial-review.json"
+] as const;
 const RISK_PRIORITY: Record<ConfigRiskLevel, number> = {
   low: 1,
   medium: 2,
@@ -469,6 +495,7 @@ function parseArgs(argv: string[]): Args {
   let wechatRcValidationPath: string | undefined;
   let wechatCandidateSummaryPath: string | undefined;
   let wechatSmokeReportPath: string | undefined;
+  let wechatCommercialVerificationPath: string | undefined;
   let wechatArtifactsDir: string | undefined;
   let manualEvidenceLedgerPath: string | undefined;
   let configCenterLibraryPath: string | undefined;
@@ -507,6 +534,11 @@ function parseArgs(argv: string[]): Args {
     }
     if (arg === "--wechat-smoke-report" && next) {
       wechatSmokeReportPath = next;
+      index += 1;
+      continue;
+    }
+    if (arg === "--wechat-commercial-verification" && next) {
+      wechatCommercialVerificationPath = next;
       index += 1;
       continue;
     }
@@ -554,6 +586,7 @@ function parseArgs(argv: string[]): Args {
     ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
     ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
+    ...(wechatCommercialVerificationPath ? { wechatCommercialVerificationPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
     ...(configCenterLibraryPath ? { configCenterLibraryPath } : {}),
@@ -736,6 +769,29 @@ function resolveWechatSmokeReportPath(args: Args, wechatArtifactsDir?: string): 
   }
   const candidate = path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json");
   return fs.existsSync(candidate) ? candidate : undefined;
+}
+
+function resolveWechatCommercialVerificationPath(args: Args, wechatArtifactsDir?: string): string | undefined {
+  if (args.wechatCommercialVerificationPath) {
+    return path.resolve(args.wechatCommercialVerificationPath);
+  }
+  if (!wechatArtifactsDir || !fs.existsSync(wechatArtifactsDir)) {
+    return undefined;
+  }
+  const verificationReport = resolveLatestFile(
+    wechatArtifactsDir,
+    (entry) => entry.startsWith(COMMERCIAL_VERIFICATION_FILE_PREFIX) && entry.endsWith(".json")
+  );
+  if (verificationReport) {
+    return verificationReport;
+  }
+  for (const fileName of COMMERCIAL_REVIEW_LEGACY_FILENAMES) {
+    const candidate = path.join(wechatArtifactsDir, fileName);
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
 }
 
 function resolveConfigCenterLibraryPath(args: Args): string | undefined {
@@ -1413,6 +1469,7 @@ function buildReleaseSurfaceContract(
   h5SmokePath: string | undefined,
   reconnectSoakPath: string | undefined,
   wechatCandidateSummaryPath: string | undefined,
+  wechatCommercialVerificationPath: string | undefined,
   manualEvidenceLedgerPath: string | undefined
 ): ReleaseSurfaceContract {
   const evidence: ReleaseSurfaceEvidenceItem[] = [];
@@ -1587,6 +1644,56 @@ function buildReleaseSurfaceContract(
             artifactPath: check.artifactPath,
             blockerIds: check.blockerIds ?? [],
             waiverReason: check.waiver?.reason
+          })
+        );
+      }
+
+      if (!wechatCommercialVerificationPath || !fs.existsSync(wechatCommercialVerificationPath)) {
+        evidence.push(
+          createSurfaceEvidenceItem({
+            id: "wechat-commercial-verification",
+            label: "WeChat commercial verification",
+            required: false,
+            status: "pending",
+            summary:
+              "External-launch commercial verification is not attached yet. Run release:wechat:commercial-verification before submission or external rollout review."
+          })
+        );
+      } else {
+        const commercialVerification = readJsonFile<WechatCommercialVerificationReport>(wechatCommercialVerificationPath);
+        const freshness = evaluateFreshness(commercialVerification.generatedAt, MAX_COMMERCIAL_VERIFICATION_AGE_MS);
+        const metadataFailures = [
+          !commitsMatch(commercialVerification.candidate?.revision ?? undefined, candidateRevision)
+            ? `revision ${commercialVerification.candidate?.revision?.trim() || "<missing>"} != ${candidateRevision}`
+            : "",
+          freshness !== "fresh" ? `freshness=${freshness}` : ""
+        ].filter((value) => value.length > 0);
+        const blocked =
+          commercialVerification.summary?.status !== "ready" ||
+          metadataFailures.length > 0 ||
+          (commercialVerification.summary?.blockerCount ?? 0) > 0 ||
+          (commercialVerification.summary?.requiredPendingChecks ?? 0) > 0 ||
+          (commercialVerification.summary?.requiredFailedChecks ?? 0) > 0 ||
+          (commercialVerification.summary?.requiredMetadataFailures ?? 0) > 0;
+
+        evidence.push(
+          createSurfaceEvidenceItem({
+            id: "wechat-commercial-verification",
+            label: "WeChat commercial verification",
+            required: false,
+            status: blocked ? "failed" : "passed",
+            summary: blocked
+              ? commercialVerification.summary?.conclusion?.trim() ||
+                `Commercial verification is blocked: ${
+                  metadataFailures[0] ??
+                  `blockers=${commercialVerification.summary?.blockerCount ?? 0}, pending=${commercialVerification.summary?.requiredPendingChecks ?? 0}, failed=${commercialVerification.summary?.requiredFailedChecks ?? 0}`
+                }.`
+              : commercialVerification.summary?.conclusion?.trim() ||
+                `Commercial verification is ready with ${commercialVerification.summary?.acceptedRiskCount ?? 0} accepted risk(s).`,
+            freshness,
+            observedAt: commercialVerification.generatedAt,
+            revision: commercialVerification.candidate?.revision ?? undefined,
+            artifactPath: wechatCommercialVerificationPath
           })
         );
       }
@@ -2089,8 +2196,34 @@ function buildReleaseGateTriage(
     }));
 
   const blockers = [...gateBlockers, ...manualEvidenceBlockers];
-
-  const warnings: ReleaseGateTriageEntry[] =
+  const warnings: ReleaseGateTriageEntry[] = [
+    ...(
+      targetSurface === "wechat"
+        ? releaseSurface.evidence
+            .filter(
+              (entry) =>
+                entry.id === "wechat-commercial-verification" &&
+                (entry.status !== "passed" ||
+                  entry.freshness === "stale" ||
+                  entry.freshness === "missing_timestamp" ||
+                  entry.freshness === "invalid_timestamp")
+            )
+            .map((entry) => ({
+              id: "wechat-commercial-verification:warning",
+              severity: "warning" as const,
+              gateId: "wechat-release" as const,
+              title: entry.label,
+              impactedSurface: targetSurface,
+              summary: `${entry.label} is not ready for external launch review: ${entry.summary}`,
+              nextStep:
+                `Run \`npm run release:wechat:commercial-verification -- --artifacts-dir ${
+                  inputs.wechatArtifactsDir ? relativeReportPath(inputs.wechatArtifactsDir) : "artifacts/wechat-release"
+                }\`, then rerun \`npm run release:gate:summary -- --target-surface ${targetSurface}\`.`,
+              artifacts: createTriageArtifactReference(entry.label, entry.artifactPath)
+            }))
+        : []
+    ),
+    ...(
     configChangeRisk.status === "available" &&
     (configChangeRisk.overallRisk === "medium" ||
       configChangeRisk.overallRisk === "high" ||
@@ -2113,7 +2246,9 @@ function buildReleaseGateTriage(
             artifacts: createTriageArtifactReference("Config publish audit", configChangeRisk.source?.path)
           }
         ]
-      : [];
+      : []
+    )
+  ];
 
   return { blockers, warnings };
 }
@@ -2126,6 +2261,7 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
   const wechatRcValidationPath = resolveWechatRcValidationPath(args, wechatArtifactsDir);
   const wechatCandidateSummaryPath = resolveWechatCandidateSummaryPath(args, wechatArtifactsDir);
   const wechatSmokeReportPath = resolveWechatSmokeReportPath(args, wechatArtifactsDir);
+  const wechatCommercialVerificationPath = resolveWechatCommercialVerificationPath(args, wechatArtifactsDir);
   const manualEvidenceLedgerPath = args.manualEvidenceLedgerPath ? resolveManualEvidenceLedgerPath(args) : undefined;
   const configCenterLibraryPath = resolveConfigCenterLibraryPath(args);
   const releaseSurface = buildReleaseSurfaceContract(
@@ -2135,6 +2271,7 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
     h5SmokePath,
     reconnectSoakPath,
     wechatCandidateSummaryPath,
+    wechatCommercialVerificationPath,
     manualEvidenceLedgerPath
   );
 
@@ -2163,6 +2300,7 @@ export function buildReleaseGateSummaryReport(args: Args, revision: GitRevision)
     ...(wechatRcValidationPath ? { wechatRcValidationPath } : {}),
     ...(wechatCandidateSummaryPath ? { wechatCandidateSummaryPath } : {}),
     ...(wechatSmokeReportPath ? { wechatSmokeReportPath } : {}),
+    ...(wechatCommercialVerificationPath ? { wechatCommercialVerificationPath } : {}),
     ...(wechatArtifactsDir ? { wechatArtifactsDir } : {}),
     ...(manualEvidenceLedgerPath ? { manualEvidenceLedgerPath } : {}),
     ...(configCenterLibraryPath ? { configCenterLibraryPath } : {})
@@ -2213,6 +2351,9 @@ export function renderMarkdown(report: ReleaseGateSummaryReport): string {
     `- WeChat candidate summary: \`${report.inputs.wechatCandidateSummaryPath ? relativeReportPath(report.inputs.wechatCandidateSummaryPath) : "<missing>"}\``
   );
   lines.push(`- WeChat smoke fallback: \`${report.inputs.wechatSmokeReportPath ? relativeReportPath(report.inputs.wechatSmokeReportPath) : "<missing>"}\``);
+  lines.push(
+    `- WeChat commercial verification: \`${report.inputs.wechatCommercialVerificationPath ? relativeReportPath(report.inputs.wechatCommercialVerificationPath) : "<missing>"}\``
+  );
   lines.push(`- WeChat artifacts dir: \`${report.inputs.wechatArtifactsDir ? relativeReportPath(report.inputs.wechatArtifactsDir) : "<missing>"}\``);
   lines.push(`- Manual evidence ledger: \`${report.inputs.manualEvidenceLedgerPath ? relativeReportPath(report.inputs.manualEvidenceLedgerPath) : "<missing>"}\``);
   lines.push(`- Config audit: \`${report.inputs.configCenterLibraryPath ? relativeReportPath(report.inputs.configCenterLibraryPath) : "<missing>"}\``);

--- a/scripts/test/release-gate-summary.test.ts
+++ b/scripts/test/release-gate-summary.test.ts
@@ -40,6 +40,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   const wechatArtifactsDir = path.join(workspace, "artifacts", "wechat-release");
   const wechatRcValidationPath = path.join(wechatArtifactsDir, "codex.wechat.rc-validation-report.json");
   const wechatCandidateSummaryPath = path.join(wechatArtifactsDir, "codex.wechat.release-candidate-summary.json");
+  const wechatCommercialVerificationPath = path.join(wechatArtifactsDir, "codex.wechat.commercial-verification-abc123.json");
   const configCenterLibraryPath = path.join(workspace, "configs", ".config-center-library.json");
 
   writeJson(snapshotPath, {
@@ -181,6 +182,22 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
     },
     blockers: []
   });
+  writeJson(wechatCommercialVerificationPath, {
+    generatedAt: isoHoursAgo(1),
+    candidate: {
+      revision: "abc123",
+      status: "ready"
+    },
+    summary: {
+      status: "ready",
+      blockerCount: 0,
+      requiredPendingChecks: 0,
+      requiredFailedChecks: 0,
+      requiredMetadataFailures: 0,
+      acceptedRiskCount: 1,
+      conclusion: "Commercial verification is ready for external launch review."
+    }
+  });
   writeJson(configCenterLibraryPath, {
     publishAuditHistory: [
       {
@@ -276,6 +293,7 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /colyseus-reconnect-soak-summary-pass\.json/);
   assert.match(renderMarkdown(report), /Reconnect soak evidence is present and passing for this candidate/);
   assert.match(renderMarkdown(report), /codex\.wechat\.release-candidate-summary\.json/);
+  assert.match(renderMarkdown(report), /codex\.wechat\.commercial-verification-abc123\.json/);
   assert.match(renderMarkdown(report), /manual-release-evidence-owner-ledger-abc123\.md/);
   assert.match(renderMarkdown(report), /### Manual Evidence Ownership/);
   assert.match(renderMarkdown(report), /owner=release-oncall/);
@@ -283,8 +301,141 @@ test("buildReleaseGateSummaryReport marks all gates passed when snapshot, H5 smo
   assert.match(renderMarkdown(report), /WeChat package evidence: ok \[required=yes status=passed/);
   assert.match(renderMarkdown(report), /WeChat verify evidence: ok \[required=yes status=passed/);
   assert.match(renderMarkdown(report), /WeChat smoke evidence: ok \[required=yes status=passed/);
+  assert.match(
+    renderMarkdown(report),
+    /WeChat commercial verification: Commercial verification is ready for external launch review\. \[required=no status=passed/
+  );
   assert.match(renderMarkdown(report), /Config Change Risk Summary/);
   assert.match(renderMarkdown(report), /Recommend rehearsal: yes/);
+});
+
+test("buildReleaseGateSummaryReport warns when WeChat commercial verification is missing for the current candidate", () => {
+  const workspace = createTempWorkspace();
+  const snapshotPath = path.join(workspace, "artifacts", "release-readiness", "release-readiness-pass.json");
+  const h5SmokePath = path.join(workspace, "artifacts", "release-readiness", "client-release-candidate-smoke-pass.json");
+  const reconnectSoakPath = path.join(workspace, "artifacts", "release-readiness", "colyseus-reconnect-soak-summary-pass.json");
+  const wechatArtifactsDir = path.join(workspace, "artifacts", "wechat-release");
+  const wechatCandidateSummaryPath = path.join(wechatArtifactsDir, "codex.wechat.release-candidate-summary.json");
+
+  writeJson(snapshotPath, {
+    generatedAt: isoHoursAgo(1),
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    },
+    summary: {
+      status: "passed",
+      requiredFailed: 0,
+      requiredPending: 0
+    }
+  });
+  writeJson(h5SmokePath, {
+    generatedAt: isoHoursAgo(1),
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    execution: {
+      status: "passed",
+      exitCode: 0,
+      finishedAt: isoHoursAgo(1)
+    },
+    summary: {
+      total: 2,
+      passed: 2,
+      failed: 0
+    }
+  });
+  writeJson(reconnectSoakPath, {
+    generatedAt: isoHoursAgo(1),
+    revision: {
+      commit: "abc123",
+      shortCommit: "abc123"
+    },
+    status: "passed",
+    summary: {
+      failedScenarios: 0,
+      scenarioNames: ["reconnect_soak"]
+    },
+    soakSummary: {
+      reconnectAttempts: 12,
+      invariantChecks: 48
+    },
+    results: [
+      {
+        scenario: "reconnect_soak",
+        failedRooms: 0,
+        runtimeHealthAfterCleanup: {
+          activeRoomCount: 0,
+          connectionCount: 0,
+          activeBattleCount: 0,
+          heroCount: 0
+        }
+      }
+    ]
+  });
+  writeJson(wechatCandidateSummaryPath, {
+    generatedAt: isoHoursAgo(1),
+    candidate: {
+      revision: "abc123",
+      status: "ready"
+    },
+    evidence: {
+      package: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: path.join(wechatArtifactsDir, "codex.wechat.package.json")
+      },
+      validation: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: path.join(wechatArtifactsDir, "codex.wechat.rc-validation-report.json")
+      },
+      smoke: {
+        status: "passed",
+        summary: "ok",
+        artifactPath: path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json")
+      },
+      manualReview: {
+        status: "ready",
+        requiredPendingChecks: 0,
+        requiredFailedChecks: 0,
+        requiredMetadataFailures: 0,
+        checks: []
+      }
+    },
+    blockers: []
+  });
+
+  const report = buildReleaseGateSummaryReport(
+    {
+      snapshotPath,
+      h5SmokePath,
+      reconnectSoakPath,
+      wechatArtifactsDir,
+      targetSurface: "wechat"
+    },
+    {
+      commit: "abc123",
+      shortCommit: "abc123",
+      branch: "test-branch",
+      dirty: false
+    }
+  );
+
+  assert.equal(report.summary.status, "passed");
+  assert.ok(report.triage.warnings.some((entry) => entry.id === "wechat-commercial-verification:warning"));
+  assert.match(
+    report.triage.warnings.find((entry) => entry.id === "wechat-commercial-verification:warning")?.summary ?? "",
+    /not ready for external launch review/
+  );
+  assert.match(renderMarkdown(report), /WeChat commercial verification: `<missing>`/);
+  assert.match(
+    renderMarkdown(report),
+    /WeChat commercial verification: External-launch commercial verification is not attached yet\./
+  );
 });
 
 test("buildReleaseGateSummaryReport discovers nested candidate rehearsal evidence for wechat surface", () => {


### PR DESCRIPTION
## Summary
- surface WeChat commercial-verification artifacts inside `release:gate:summary` as an advisory input and warning
- add coverage for the new warning path in `release-gate-summary` tests
- document the external-launch handoff behavior in the release summary and WeChat release docs

## Testing
- node --import tsx --test scripts/test/release-gate-summary.test.ts

Closes #1171