### PR TITLE
feat: add go/no-go packets to wechat rehearsal

### DIFF
--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -45,7 +45,7 @@ Relevant scripts: 49
 | `release:same-candidate:evidence-audit` | release | `artifacts/release-readiness/candidate-evidence-audit-<candidate>-<short-sha>.json` |
 | `release:wechat:commercial-verification` | release | `codex.wechat.commercial-verification-<short-sha>.json` in the selected artifacts directory. |
 | `release:wechat:install-launch-evidence` | release | `codex.wechat.install-launch-evidence.json` in the selected artifacts directory. |
-| `release:wechat:rehearsal` | release | Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, and upload artifacts they reference. |
+| `release:wechat:rehearsal` | release | Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, go/no-go packet, and upload artifacts they reference. |
 | `smoke:client:boot-room` | smoke | `artifacts/release-readiness/client-boot-room-smoke-<short-sha>.json` when an explicit output path is used, or console smoke verdict output by default. |
 | `smoke:client:release-candidate` | smoke | `artifacts/release-readiness/client-release-candidate-smoke-<short-sha>-<timestamp>.json` |
 | `smoke:cocos:canonical-journey` | smoke | `artifacts/release-readiness/cocos-primary-journey-evidence-<candidate>-<short-sha>.json` |
@@ -404,11 +404,11 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/wechat-release-rehearsal.ts`
-- Purpose: Run the WeChat release rehearsal flow that chains prepare, package, verify, validate, and optional commercial verification steps into one summary.
+- Purpose: Run the WeChat release rehearsal flow that chains prepare, package, verify, validate, and optional commercial verification plus go/no-go packet steps into one summary.
 - Required inputs:
-  - A WeChat build directory plus an artifacts directory; optional config/summary path overrides, install/smoke/manual-review inputs, and `--run-commercial-verification` / `--commercial-checks` when the rehearsal should also emit the commercial verification artifact.
+  - A WeChat build directory plus an artifacts directory; optional config/summary path overrides, install/smoke/manual-review inputs, `--run-commercial-verification` / `--commercial-checks` for the commercial verification artifact, and `--run-go-no-go-packet` plus dossier/release-gate paths when the rehearsal should also emit the final decision packet.
 - Produced artifacts:
-  - Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, and upload artifacts they reference.
+  - Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, go/no-go packet, and upload artifacts they reference.
 
 ## `smoke:client:boot-room`
 

--- a/docs/wechat-minigame-release.md
+++ b/docs/wechat-minigame-release.md
@@ -31,7 +31,7 @@
 - 记录 candidate-scoped 安装/启动证据：`npm run release:wechat:install-launch-evidence -- --artifacts-dir <release-artifacts-dir> --candidate <candidate-name> --environment <wechat-devtools|device-lab|qa-phone> --operator <name> --status <passed|failed> [--candidate-revision <git-sha>] [--summary <text>] [--evidence <path-or-note>]`
 - 聚合校验 RC artifact：`npm run validate:wechat-rc -- --artifacts-dir <release-artifacts-dir> [--expected-revision <git-sha>] [--version <wechat-version>] [--require-smoke-report] [--manual-checks docs/release-evidence/wechat-release-manual-review.example.json]`
 - 聚合商运闭环验证：`npm run release:wechat:commercial-verification -- --artifacts-dir <release-artifacts-dir> [--checks docs/release-evidence/wechat-commercial-verification.example.json] [--candidate <candidate-name>] [--candidate-revision <git-sha>]`
-- 发布彩排与汇总：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> [--summary <json>] [--markdown <md>] [--candidate <candidate-name> --environment wechat-devtools --operator <name> --status <passed|failed> --evidence <capture-or-note> --runtime-evidence <runtime-evidence.json> --manual-checks <manual-review.json> --run-commercial-verification --commercial-checks <commercial-review.json>]`（顺序执行 prepare / package / verify，并可选补 install/launch evidence、smoke report、validate、commercial verification，输出结构化 + Markdown 摘要）
+- 发布彩排与汇总：`npm run release:wechat:rehearsal -- --build-dir <wechatgame-build-dir> --artifacts-dir <release-artifacts-dir> [--summary <json>] [--markdown <md>] [--candidate <candidate-name> --environment wechat-devtools --operator <name> --status <passed|failed> --evidence <capture-or-note> --runtime-evidence <runtime-evidence.json> --manual-checks <manual-review.json> --run-commercial-verification --commercial-checks <commercial-review.json> --run-go-no-go-packet --dossier <phase1-dossier.json> --release-gate-summary <release-gate-summary.json>]`（顺序执行 prepare / package / verify，并可选补 install/launch evidence、smoke report、validate、commercial verification、go/no-go packet，输出结构化 + Markdown 摘要）
 - 上传已打包产物：`npm run upload:wechat-release -- --artifacts-dir <release-artifacts-dir> --version <wechat-version> [--desc <upload-desc>]`
 - 按 SHA 下载 CI artifact：`npm run download:wechat-release -- --sha <git-sha> [--output-dir artifacts/downloaded/wechat-release-<git-sha>]`
 - 验收已下载 artifact：`npm run verify:wechat-release -- --artifacts-dir <downloaded-artifact-dir> [--expected-revision <git-sha>]`
@@ -144,9 +144,10 @@ WeChat checklist / blockers 至少要覆盖以下证据面：
 - 当传入 `--runtime-evidence <json>` 时，会额外执行 `smoke:wechat-release -- --force`，直接生成同 revision 的 `codex.wechat.smoke-report.json`。
 - 当传入 `--manual-checks <json>` 时，最终 `validate:wechat-rc` 会复用这份 manual review JSON 生成 ready/blocked 的 candidate summary，而不是只停在 pending 模板。
 - 当传入 `--run-commercial-verification` 时，会在 `validate` 之后追加 `release:wechat:commercial-verification`；若再传 `--commercial-checks <json>`，会直接复用这份商运复核 contract。
+- 当传入 `--run-go-no-go-packet` 时，会在已有 candidate summary / commercial verification 之后追加 `release:go-no-go-packet`；推荐同时显式传入 `--dossier <phase1-dossier.json>` 与 `--release-gate-summary <release-gate-summary.json>`，这样 final decision packet 会稳定绑定到同一候选 revision。
 - 结构化摘要默认写到 `artifacts/wechat-release/wechat-release-rehearsal-<short-sha>.json`，Markdown 摘要写到同名 `.md`；可通过 `--summary` / `--markdown` 改写路径。
 - JSON 摘要包含阶段命令、耗时、stdout / stderr tail 以及首个失败阶段的诊断，Markdown 版本可直接贴到 CI Summary 或 PR。
-- `## Artifacts` 现在会自动列出 install/launch evidence、smoke report、candidate summary、commercial verification 等关键证据，方便 reviewer 直接校对同一个候选 revision。
+- `## Artifacts` 现在会自动列出 install/launch evidence、smoke report、candidate summary、commercial verification、go/no-go packet 等关键证据，方便 reviewer 直接校对同一个候选 revision。
 - `--source-revision`、`--expected-revision`、`--package-name`、`--version`、`--require-smoke-report` 会透传给对应脚本，方便对齐真实提审参数。
 - 适合在本地 release rehearsal、或在 CI 下载模板导出夹具时，一次性确认整个链路仍能跑通。
 

--- a/progress.md
+++ b/progress.md
@@ -1594,3 +1594,27 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 本轮定向验证结果：
   - `npm run typecheck:ops` 通过
   - `node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`7/7`）
+
+## Issue #1190 - WeChat rehearsal go/no-go packet stage - 2026-04-10
+
+- 本轮继续把 `release:wechat:rehearsal` 往最终决策附件推进了一步：
+  - `scripts/wechat-release-rehearsal.ts`
+    - 新增 `--run-go-no-go-packet`
+    - 新增 `--dossier <path>` 与 `--release-gate-summary <path>`，用于把同一 candidate revision 的 Phase 1 dossier 和 release gate summary 显式透传给 go/no-go packet
+    - 当启用该阶段时，rehearsal 会在 `commercial-verification` 之后追加 `release:go-no-go-packet`
+    - 产物固定收口到当前 artifacts dir 下：
+      - `codex.wechat.go-no-go-decision-packet.json`
+      - `codex.wechat.go-no-go-decision-packet.md`
+    - `DetectedArtifacts` 与 Markdown summary 现在也会自动列出 go/no-go packet
+- 文档与 inventory 已同步：
+  - `docs/wechat-minigame-release.md`
+    - 更新 `release:wechat:rehearsal` 的命令示例与发布彩排摘要，明确可选追加最终决策 packet
+  - `scripts/release-script-inventory.ts` / `docs/release-script-inventory.md`
+    - 更新 `release:wechat:rehearsal` 的职责与产物说明，包含 go/no-go packet
+- 测试收口：
+  - `scripts/test/wechat-release-rehearsal.test.ts`
+    - 新增“rehearsal 可追加 go/no-go packet”的完整覆盖
+    - 锁住阶段序列：`prepare -> package -> verify -> install-launch-evidence -> smoke -> validate -> commercial-verification -> go-no-go-packet`
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`13/13`）

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -342,12 +342,12 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
     ],
   },
   "release:wechat:rehearsal": {
-    purpose: "Run the WeChat release rehearsal flow that chains prepare, package, verify, validate, and optional commercial verification steps into one summary.",
+    purpose: "Run the WeChat release rehearsal flow that chains prepare, package, verify, validate, and optional commercial verification plus go/no-go packet steps into one summary.",
     requiredInputs: [
-      "A WeChat build directory plus an artifacts directory; optional config/summary path overrides, install/smoke/manual-review inputs, and `--run-commercial-verification` / `--commercial-checks` when the rehearsal should also emit the commercial verification artifact.",
+      "A WeChat build directory plus an artifacts directory; optional config/summary path overrides, install/smoke/manual-review inputs, `--run-commercial-verification` / `--commercial-checks` for the commercial verification artifact, and `--run-go-no-go-packet` plus dossier/release-gate paths when the rehearsal should also emit the final decision packet.",
     ],
     producedArtifacts: [
-      "Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, and upload artifacts they reference.",
+      "Summary files under the selected artifacts dir, typically `artifacts/wechat-release/wechat-release-rehearsal-<candidate>.json` and `.md`, alongside the package, validation, smoke, commercial verification, go/no-go packet, and upload artifacts they reference.",
     ],
   },
   "smoke:client:release-candidate": {

--- a/scripts/test/wechat-release-rehearsal.test.ts
+++ b/scripts/test/wechat-release-rehearsal.test.ts
@@ -555,3 +555,393 @@ test("release:wechat:rehearsal can append commercial verification artifacts", ()
   const markdown = fs.readFileSync(markdownPath, "utf8");
   assert.match(markdown, /Commercial Verification \(JSON\)/);
 });
+
+test("release:wechat:rehearsal can append a go/no-go packet", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-wechat-rehearsal-gonogo-"));
+  const buildDir = path.join(workspace, "build");
+  const artifactsDir = path.join(workspace, "artifacts");
+  const releaseReadinessDir = path.join(workspace, "release-readiness");
+  const summaryPath = path.join(workspace, "summary.json");
+  const markdownPath = path.join(workspace, "summary.md");
+  const runtimeEvidencePath = path.join(workspace, "runtime-evidence.json");
+  const manualChecksPath = path.join(workspace, "manual-review.json");
+  const commercialChecksPath = path.join(workspace, "commercial-checks.json");
+  const dossierPath = path.join(releaseReadinessDir, "phase1-candidate-dossier.json");
+  const releaseGateSummaryPath = path.join(releaseReadinessDir, "release-gate-summary.json");
+  const recordedAt = new Date().toISOString();
+
+  fs.cpSync(fixtureBuildDir, buildDir, { recursive: true });
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  fs.mkdirSync(releaseReadinessDir, { recursive: true });
+
+  fs.writeFileSync(
+    runtimeEvidencePath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        buildTemplatePlatform: "wechatgame",
+        artifact: {
+          archiveFileName: "project-veil-wechatgame-release.tar.gz",
+          sourceRevision: "abc1234"
+        },
+        execution: {
+          tester: "codex-bot",
+          device: "iPhone 15 Pro / WeChat 8.0.50",
+          clientVersion: "8.0.50",
+          executedAt: recordedAt,
+          result: "passed",
+          summary: "Imported runtime evidence from the rehearsal lane."
+        },
+        cases: [
+          { id: "startup", status: "passed", evidence: ["startup.mp4"] },
+          { id: "lobby-entry", status: "passed", evidence: ["lobby.png"] },
+          { id: "room-entry", status: "passed", evidence: ["room-entry.png"] },
+          {
+            id: "reconnect-recovery",
+            status: "passed",
+            evidence: ["reconnect.mp4"],
+            requiredEvidence: {
+              roomId: "room-alpha",
+              reconnectPrompt: "连接已恢复",
+              restoredState: "Restored room-alpha with the same hero state and lobby context."
+            }
+          },
+          {
+            id: "share-roundtrip",
+            status: "not_applicable",
+            evidence: ["share-roundtrip.txt"],
+            requiredEvidence: {
+              shareScene: "lobby",
+              shareQuery: "roomId=room-alpha&inviterId=player-7",
+              roundtripState: "Not executed in this rehearsal lane."
+            }
+          },
+          { id: "key-assets", status: "passed", evidence: ["assets.log"] }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "runtime-observability-signoff.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "checklist-review.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed",
+        blockerIds: ["none"]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(artifactsDir, "device-runtime-review.json"),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        candidate: "phase1-rc",
+        targetRevision: "abc1234",
+        reviewer: "release-oncall",
+        recordedAt,
+        status: "passed"
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    manualChecksPath,
+    `${JSON.stringify(
+      [
+        {
+          id: "wechat-devtools-export-review",
+          title: "Candidate-scoped WeChat package install/launch verification recorded",
+          status: "passed",
+          required: true,
+          notes: "Generated install/launch verification during the rehearsal.",
+          evidence: [path.join(artifactsDir, "codex.wechat.install-launch-evidence.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "codex.wechat.install-launch-evidence.json")
+        },
+        {
+          id: "wechat-device-runtime-review",
+          title: "Physical-device WeChat runtime validated for this candidate",
+          status: "passed",
+          required: true,
+          notes: "Attached the smoke report and capture set from the rehearsal runtime pass.",
+          evidence: [
+            path.join(artifactsDir, "codex.wechat.smoke-report.json"),
+            path.join(artifactsDir, "device-runtime-review.json")
+          ],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "device-runtime-review.json")
+        },
+        {
+          id: "wechat-runtime-observability-signoff",
+          title: "WeChat runtime observability reviewed for this candidate",
+          status: "passed",
+          required: true,
+          notes: "Captured health/auth-readiness/metrics evidence for the release environment.",
+          evidence: [path.join(artifactsDir, "runtime-observability-signoff.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "runtime-observability-signoff.json")
+        },
+        {
+          id: "wechat-release-checklist",
+          title: "WeChat RC checklist and blockers reviewed",
+          status: "passed",
+          required: true,
+          notes: "Checklist and blockers resolved for the packaged candidate.",
+          evidence: [path.join(artifactsDir, "checklist-review.json")],
+          owner: "release-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: path.join(artifactsDir, "checklist-review.json")
+        }
+      ],
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    commercialChecksPath,
+    `${JSON.stringify(
+      [
+        {
+          id: "wechat-payment-e2e",
+          title: "WeChat payment end-to-end verified",
+          status: "passed",
+          owner: "commerce-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/payment-e2e-review.md"
+        },
+        {
+          id: "wechat-subscribe-delivery",
+          title: "WeChat subscribe-message delivery verified",
+          status: "passed",
+          owner: "growth-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/subscribe-delivery-review.md"
+        },
+        {
+          id: "wechat-analytics-acceptance",
+          title: "Commercial analytics acceptance verified",
+          status: "passed",
+          owner: "data-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/analytics-review.md"
+        },
+        {
+          id: "wechat-compliance-review",
+          title: "Commercial compliance and submission material reviewed",
+          status: "passed",
+          owner: "compliance-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/compliance-review.md"
+        },
+        {
+          id: "wechat-device-experience-review",
+          title: "Physical-device experience reviewed",
+          status: "passed",
+          owner: "qa-oncall",
+          recordedAt,
+          revision: "abc1234",
+          artifactPath: "artifacts/wechat-release/device-experience-review.md"
+        }
+      ],
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    dossierPath,
+    `${JSON.stringify(
+      {
+        generatedAt: recordedAt,
+        candidate: {
+          name: "phase1-rc",
+          revision: "abc1234",
+          shortRevision: "abc1234",
+          branch: "main",
+          dirty: false,
+          targetSurface: "wechat"
+        },
+        summary: {
+          status: "passed",
+          totalSections: 1,
+          requiredFailed: [],
+          requiredPending: [],
+          acceptedRiskCount: 0
+        },
+        phase1ExitEvidenceGate: {
+          result: "passed",
+          summary: "All required evidence passed.",
+          blockingSections: [],
+          pendingSections: [],
+          acceptedRiskSections: []
+        },
+        sections: [
+          {
+            id: "release-readiness",
+            label: "Release readiness",
+            required: true,
+            result: "passed",
+            summary: "Automated release readiness checks passed.",
+            artifactPath: path.join(releaseReadinessDir, "release-readiness-snapshot.json"),
+            freshness: "fresh"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    releaseGateSummaryPath,
+    `${JSON.stringify(
+      {
+        generatedAt: recordedAt,
+        targetSurface: "wechat",
+        summary: {
+          status: "passed",
+          failedGateIds: []
+        },
+        inputs: {
+          wechatArtifactsDir: artifactsDir,
+          wechatCandidateSummaryPath: path.join(artifactsDir, "codex.wechat.release-candidate-summary.json")
+        },
+        triage: {
+          blockers: [],
+          warnings: []
+        },
+        releaseSurface: {
+          status: "passed",
+          summary: "Release surface evidence is passing for the selected wechat target.",
+          evidence: []
+        }
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const output = execFileSync(
+    "node",
+    [
+      "--import",
+      "tsx",
+      "./scripts/wechat-release-rehearsal.ts",
+      "--config",
+      defaultConfigPath,
+      "--build-dir",
+      buildDir,
+      "--artifacts-dir",
+      artifactsDir,
+      "--summary",
+      summaryPath,
+      "--markdown",
+      markdownPath,
+      "--source-revision",
+      "abc1234",
+      "--expected-revision",
+      "abc1234",
+      "--candidate",
+      "phase1-rc",
+      "--environment",
+      "wechat-devtools",
+      "--operator",
+      "release-oncall",
+      "--status",
+      "passed",
+      "--verification-summary",
+      "Candidate rehearsal package import and first launch passed.",
+      "--evidence",
+      "devtools-import-capture.png",
+      "--runtime-evidence",
+      runtimeEvidencePath,
+      "--manual-checks",
+      manualChecksPath,
+      "--run-commercial-verification",
+      "--commercial-checks",
+      commercialChecksPath,
+      "--run-go-no-go-packet",
+      "--dossier",
+      dossierPath,
+      "--release-gate-summary",
+      releaseGateSummaryPath,
+      "--require-smoke-report"
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe"
+    }
+  );
+
+  assert.match(output, /WeChat release rehearsal PASSED/);
+  const report = JSON.parse(fs.readFileSync(summaryPath, "utf8")) as {
+    summary: { status: string; artifacts: Record<string, string | undefined> };
+    stages: Array<{ id: string; status: string }>;
+  };
+
+  assert.equal(report.summary.status, "passed");
+  assert.deepEqual(
+    report.stages.map((stage) => stage.id),
+    [
+      "prepare",
+      "package",
+      "verify",
+      "install-launch-evidence",
+      "smoke",
+      "validate",
+      "commercial-verification",
+      "go-no-go-packet"
+    ]
+  );
+  assert.ok(
+    report.summary.artifacts.goNoGoPacketJsonPath?.endsWith("codex.wechat.go-no-go-decision-packet.json")
+  );
+  assert.ok(
+    report.summary.artifacts.goNoGoPacketMarkdownPath?.endsWith("codex.wechat.go-no-go-decision-packet.md")
+  );
+  const markdown = fs.readFileSync(markdownPath, "utf8");
+  assert.match(markdown, /Go\/No-Go Packet \(JSON\)/);
+});

--- a/scripts/wechat-release-rehearsal.ts
+++ b/scripts/wechat-release-rehearsal.ts
@@ -32,6 +32,9 @@ interface Args {
   runCommercialVerification: boolean;
   commercialChecksPath?: string;
   commercialFreshnessHours?: number;
+  runGoNoGoPacket: boolean;
+  dossierPath?: string;
+  releaseGateSummaryPath?: string;
   evidence: string[];
 }
 
@@ -92,6 +95,8 @@ interface DetectedArtifacts {
   candidateSummaryMarkdownPath?: string;
   commercialVerificationJsonPath?: string;
   commercialVerificationMarkdownPath?: string;
+  goNoGoPacketJsonPath?: string;
+  goNoGoPacketMarkdownPath?: string;
 }
 
 const OUTPUT_LIMIT = 4000;
@@ -133,6 +138,9 @@ function parseArgs(argv: string[]): Args {
   let runCommercialVerification = false;
   let commercialChecksPath: string | undefined;
   let commercialFreshnessHours: number | undefined;
+  let runGoNoGoPacket = false;
+  let dossierPath: string | undefined;
+  let releaseGateSummaryPath: string | undefined;
   const evidence: string[] = [];
 
   for (let index = 2; index < argv.length; index += 1) {
@@ -272,6 +280,22 @@ function parseArgs(argv: string[]): Args {
       index += 1;
       continue;
     }
+    if (arg === "--run-go-no-go-packet") {
+      runGoNoGoPacket = true;
+      continue;
+    }
+    if (arg === "--dossier" && next) {
+      dossierPath = next.trim() || undefined;
+      runGoNoGoPacket = true;
+      index += 1;
+      continue;
+    }
+    if (arg === "--release-gate-summary" && next) {
+      releaseGateSummaryPath = next.trim() || undefined;
+      runGoNoGoPacket = true;
+      index += 1;
+      continue;
+    }
     if (arg === "--evidence" && next) {
       const value = next.trim();
       if (value) {
@@ -311,6 +335,9 @@ function parseArgs(argv: string[]): Args {
     runCommercialVerification,
     ...(commercialChecksPath ? { commercialChecksPath } : {}),
     ...(commercialFreshnessHours ? { commercialFreshnessHours } : {}),
+    runGoNoGoPacket,
+    ...(dossierPath ? { dossierPath } : {}),
+    ...(releaseGateSummaryPath ? { releaseGateSummaryPath } : {}),
     evidence
   };
 }
@@ -447,6 +474,8 @@ function detectArtifacts(artifactsDir: string): DetectedArtifacts {
   const installLaunchEvidenceMarkdown = entries.find((entry) => entry === "codex.wechat.install-launch-evidence.md");
   const candidateSummaryJson = entries.find((entry) => entry === "codex.wechat.release-candidate-summary.json");
   const candidateSummaryMarkdown = entries.find((entry) => entry === "codex.wechat.release-candidate-summary.md");
+  const goNoGoPacketJson = entries.find((entry) => entry === "codex.wechat.go-no-go-decision-packet.json");
+  const goNoGoPacketMarkdown = entries.find((entry) => entry === "codex.wechat.go-no-go-decision-packet.md");
   const commercialVerificationJson = entries
     .filter((entry) => entry.startsWith("codex.wechat.commercial-verification-") && entry.endsWith(".json"))
     .sort()[0];
@@ -465,6 +494,8 @@ function detectArtifacts(artifactsDir: string): DetectedArtifacts {
     ...(candidateSummaryMarkdown
       ? { candidateSummaryMarkdownPath: path.join(artifactsDir, candidateSummaryMarkdown) }
       : {}),
+    ...(goNoGoPacketJson ? { goNoGoPacketJsonPath: path.join(artifactsDir, goNoGoPacketJson) } : {}),
+    ...(goNoGoPacketMarkdown ? { goNoGoPacketMarkdownPath: path.join(artifactsDir, goNoGoPacketMarkdown) } : {}),
     ...(commercialVerificationJson
       ? { commercialVerificationJsonPath: path.join(artifactsDir, commercialVerificationJson) }
       : {}),
@@ -527,6 +558,12 @@ function renderMarkdown(summary: RehearsalSummary): string {
   if (artifacts.candidateSummaryMarkdownPath) {
     artifactLines.push(`- Candidate Summary (Markdown): \`${artifacts.candidateSummaryMarkdownPath}\``);
   }
+  if (artifacts.goNoGoPacketJsonPath) {
+    artifactLines.push(`- Go/No-Go Packet (JSON): \`${artifacts.goNoGoPacketJsonPath}\``);
+  }
+  if (artifacts.goNoGoPacketMarkdownPath) {
+    artifactLines.push(`- Go/No-Go Packet (Markdown): \`${artifacts.goNoGoPacketMarkdownPath}\``);
+  }
   if (artifacts.commercialVerificationJsonPath) {
     artifactLines.push(`- Commercial Verification (JSON): \`${artifacts.commercialVerificationJsonPath}\``);
   }
@@ -554,10 +591,14 @@ function main(): void {
   const resolvedRuntimeEvidencePath = args.runtimeEvidencePath ? path.resolve(repoRoot, args.runtimeEvidencePath) : undefined;
   const resolvedManualChecksPath = args.manualChecksPath ? path.resolve(repoRoot, args.manualChecksPath) : undefined;
   const resolvedCommercialChecksPath = args.commercialChecksPath ? path.resolve(repoRoot, args.commercialChecksPath) : undefined;
+  const resolvedDossierPath = args.dossierPath ? path.resolve(repoRoot, args.dossierPath) : undefined;
+  const resolvedReleaseGateSummaryPath = args.releaseGateSummaryPath ? path.resolve(repoRoot, args.releaseGateSummaryPath) : undefined;
   const summaryBaseName = revision.shortCommit ? `wechat-release-rehearsal-${revision.shortCommit}` : `wechat-release-rehearsal`;
   const summaryPath = path.resolve(repoRoot, args.summaryPath ?? path.join(args.artifactsDir, `${summaryBaseName}.json`));
   const markdownPath = path.resolve(repoRoot, args.markdownPath ?? path.join(args.artifactsDir, `${summaryBaseName}.md`));
   const smokeReportPath = path.join(resolvedArtifactsDir, "codex.wechat.smoke-report.json");
+  const goNoGoPacketJsonPath = path.join(resolvedArtifactsDir, "codex.wechat.go-no-go-decision-packet.json");
+  const goNoGoPacketMarkdownPath = path.join(resolvedArtifactsDir, "codex.wechat.go-no-go-decision-packet.md");
 
   const hasInstallLaunchOptions =
     Boolean(
@@ -729,6 +770,31 @@ function main(): void {
           ? ["--candidate-revision", (args.candidateRevision ?? expectedRevision)!.trim()]
           : []),
         ...(args.commercialFreshnessHours ? ["--freshness-hours", String(args.commercialFreshnessHours)] : [])
+      ]
+    });
+  }
+
+  if (args.runGoNoGoPacket) {
+    stageDefinitions.push({
+      id: "go-no-go-packet",
+      title: "Generate go/no-go decision packet",
+      command: [
+        nodeExec,
+        "--import",
+        "tsx",
+        "./scripts/release-go-no-go-decision-packet.ts",
+        "--wechat-artifacts-dir",
+        resolvedArtifactsDir,
+        ...(args.candidate?.trim() ? ["--candidate", args.candidate.trim()] : []),
+        ...((args.candidateRevision ?? expectedRevision)?.trim()
+          ? ["--candidate-revision", (args.candidateRevision ?? expectedRevision)!.trim()]
+          : []),
+        ...(resolvedDossierPath ? ["--dossier", resolvedDossierPath] : []),
+        ...(resolvedReleaseGateSummaryPath ? ["--release-gate-summary", resolvedReleaseGateSummaryPath] : []),
+        "--output",
+        goNoGoPacketJsonPath,
+        "--markdown-output",
+        goNoGoPacketMarkdownPath
       ]
     });
   }


### PR DESCRIPTION
## Summary
- let release:wechat:rehearsal optionally generate a final go/no-go packet
- surface go/no-go packet artifacts in the rehearsal summary and markdown
- document the new one-shot rehearsal -> final decision path and add regression coverage

## Testing
- npm run typecheck:ops
- node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts

Closes #1190