### PR TITLE
[codex] add go/no-go packets to phase1 rehearsal

### DIFF
--- a/docs/phase1-candidate-rehearsal.md
+++ b/docs/phase1-candidate-rehearsal.md
@@ -17,6 +17,7 @@ It keeps the implementation narrow by reusing the existing evidence commands ins
 - `npm run ci:trend-summary`
 - `npm run release:health:summary`
 - `npm run release:phase1:candidate-dossier`
+- `npm run release:go-no-go-packet`
 
 ## Workflow Contract
 
@@ -36,7 +37,7 @@ The bundle contains:
 - stable generated summaries such as `release-gate-summary-phase1-mainline-<short-sha>.json`
 - one same-revision evidence bundle manifest plus the paired drift-gate JSON / Markdown
 - one reviewer-facing runtime observability bundle directory with the staged evidence and gate files for the target environment
-- the candidate-scoped Cocos RC bundle and Phase 1 dossier
+- the candidate-scoped Cocos RC bundle, Phase 1 dossier, and final go/no-go packet
 - `SUMMARY.md`, which is also appended to `GITHUB_STEP_SUMMARY`
 
 The workflow fails when an evidence-generation stage regresses, when a required rehearsal artifact is missing from the final bundle, or when the same-revision drift gate reports candidate/revision mismatch across the assembled packet.
@@ -73,6 +74,6 @@ npm run release:phase1:candidate-rehearsal -- \
   --target-surface h5
 ```
 
-Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file links the stable artifact paths used for the rehearsal and records the release gate, release health, and dossier outcomes for the candidate revision.
+Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file links the stable artifact paths used for the rehearsal and records the release gate, release health, dossier, and final go/no-go packet outcomes for the candidate revision.
 
 For the standalone CI guard and explicit GitHub Actions inputs, see [`docs/phase1-release-evidence-drift-gate.md`](./phase1-release-evidence-drift-gate.md).

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -29,7 +29,7 @@ Relevant scripts: 49
 | `release:health:trend-baseline` | release | `artifacts/release-readiness/release-health-trend-baseline.json` |
 | `release:health:trend-compare` | release | `artifacts/release-readiness/release-health-trend-compare.json` |
 | `release:phase1:candidate-dossier` | release | Bundle directory `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/` with `phase1-candidate-dossier.json/.md`, `runtime-observability-dossier.json/.md`, `release-gate-summary.json/.md`, and `release-health-summary.json/.md`. |
-| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs and a top-level `SUMMARY.md`. |
+| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the final go/no-go packet, and a top-level `SUMMARY.md`. |
 | `release:phase1:evidence-drift-gate` | release | `artifacts/release-readiness/phase1-release-evidence-drift-gate-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-audit` | release | `artifacts/release-readiness/phase1-exit-audit-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-dossier-freshness-gate` | release | `artifacts/release-readiness/phase1-exit-dossier-freshness-gate-<candidate>-<short-sha>.json` |
@@ -232,11 +232,11 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/phase1-candidate-rehearsal.ts`
-- Purpose: Run the full candidate rehearsal flow and stage outputs into one release-readiness bundle directory.
+- Purpose: Run the full candidate rehearsal flow and stage outputs, including the final go/no-go packet, into one release-readiness bundle directory.
 - Required inputs:
   - Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.
 - Produced artifacts:
-  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs and a top-level `SUMMARY.md`.
+  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the final go/no-go packet, and a top-level `SUMMARY.md`.
 
 ## `release:phase1:evidence-drift-gate`
 

--- a/progress.md
+++ b/progress.md
@@ -1618,3 +1618,28 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 本轮定向验证结果：
   - `npm run typecheck:ops` 通过
   - `node --import tsx --test ./scripts/test/wechat-release-rehearsal.test.ts ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/wechat-commercial-verification.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`13/13`）
+
+## Issue #1192 - Phase 1 candidate rehearsal go/no-go packet - 2026-04-10
+
+- 本轮把 `release:phase1:candidate-rehearsal` 继续收口成了“同一候选 revision 的最终决策彩排”：
+  - `scripts/phase1-candidate-rehearsal.ts`
+    - 在既有 `phase1-candidate-dossier` 阶段后新增 `go-no-go-packet` 阶段
+    - 该阶段会复用同一次 rehearsal 产出的 dossier 与 release gate summary，并把 stable WeChat artifacts dir 透传给 `release:go-no-go-packet`
+    - rehearsal artifacts 现在会固定记录：
+      - `goNoGoPacketPath`
+      - `goNoGoPacketMarkdownPath`
+    - staged bundle 的 `requiredArtifacts` 也追加了最终 go/no-go packet，避免 `SUMMARY.md` 只收 dossier 不收最终决策附件
+- 文档与 inventory 已同步：
+  - `docs/phase1-candidate-rehearsal.md`
+    - 明确 candidate rehearsal 现在会收口到 final go/no-go packet
+    - 补充 `release:go-no-go-packet` 属于该链路复用的核心命令
+  - `scripts/release-script-inventory.ts` / `docs/release-script-inventory.md`
+    - 同步更新 `release:phase1:candidate-rehearsal` 的职责与产物说明，包含 final go/no-go packet
+- 测试收口：
+  - `scripts/test/phase1-candidate-rehearsal.test.ts`
+    - 新增 `go-no-go-packet` 阶段断言
+    - 锁住 `goNoGoPacketPath` 与 `goNoGoPacketMarkdownPath` 两个 staged artifact
+    - 校验生成的 `SUMMARY.md` 会显式列出 go/no-go packet
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`9/9`）

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -73,6 +73,8 @@ interface RehearsalArtifacts {
   phase1ReleaseEvidenceDriftGateMarkdownPath?: string;
   phase1CandidateDossierPath?: string;
   phase1CandidateDossierMarkdownPath?: string;
+  goNoGoPacketPath?: string;
+  goNoGoPacketMarkdownPath?: string;
   summaryPath?: string;
   markdownPath?: string;
 }
@@ -508,6 +510,8 @@ function main(): void {
   );
   const phase1CandidateDossierPath = path.join(outputDir, `phase1-candidate-dossier-${candidateSlug}-${revision.shortCommit}.json`);
   const phase1CandidateDossierMarkdownPath = path.join(outputDir, `phase1-candidate-dossier-${candidateSlug}-${revision.shortCommit}.md`);
+  const goNoGoPacketPath = path.join(outputDir, `go-no-go-decision-packet-${candidateSlug}-${revision.shortCommit}.json`);
+  const goNoGoPacketMarkdownPath = path.join(outputDir, `go-no-go-decision-packet-${candidateSlug}-${revision.shortCommit}.md`);
   const summaryPath = path.join(outputDir, `phase1-candidate-rehearsal-${candidateSlug}-${revision.shortCommit}.json`);
   const markdownPath = path.join(outputDir, "SUMMARY.md");
 
@@ -531,6 +535,8 @@ function main(): void {
   artifacts.phase1ReleaseEvidenceDriftGateMarkdownPath = toRelative(phase1ReleaseEvidenceDriftGateMarkdownPath);
   artifacts.phase1CandidateDossierPath = toRelative(phase1CandidateDossierPath);
   artifacts.phase1CandidateDossierMarkdownPath = toRelative(phase1CandidateDossierMarkdownPath);
+  artifacts.goNoGoPacketPath = toRelative(goNoGoPacketPath);
+  artifacts.goNoGoPacketMarkdownPath = toRelative(goNoGoPacketMarkdownPath);
   artifacts.summaryPath = toRelative(summaryPath);
   artifacts.markdownPath = toRelative(markdownPath);
 
@@ -925,6 +931,37 @@ function main(): void {
           phase1CandidateDossierMarkdownPath
         ]);
       }
+    },
+    {
+      id: "go-no-go-packet",
+      title: "Build go/no-go decision packet",
+      run: () => {
+        const command = [
+          nodeExec,
+          "--import",
+          "tsx",
+          "./scripts/release-go-no-go-decision-packet.ts",
+          "--candidate",
+          args.candidate,
+          "--candidate-revision",
+          revision.commit,
+          "--dossier",
+          phase1CandidateDossierPath,
+          "--release-gate-summary",
+          releaseGateSummaryPath,
+          "--output",
+          goNoGoPacketPath,
+          "--markdown-output",
+          goNoGoPacketMarkdownPath
+        ];
+        if (artifacts.stableWechatArtifactsDir) {
+          command.push("--wechat-artifacts-dir", stableWechatArtifactsDir);
+        }
+        return runCommandStage("go-no-go-packet", "Build go/no-go decision packet", command, [
+          goNoGoPacketPath,
+          goNoGoPacketMarkdownPath
+        ]);
+      }
     }
   ];
 
@@ -959,7 +996,9 @@ function main(): void {
     phase1ReleaseEvidenceDriftGatePath,
     phase1ReleaseEvidenceDriftGateMarkdownPath,
     phase1CandidateDossierPath,
-    phase1CandidateDossierMarkdownPath
+    phase1CandidateDossierMarkdownPath,
+    goNoGoPacketPath,
+    goNoGoPacketMarkdownPath
   ];
   if (args.serverUrl) {
     requiredArtifacts.push(runtimeObservabilityBundlePath, runtimeObservabilityBundleMarkdownPath);

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -148,12 +148,12 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
     ],
   },
   "release:phase1:candidate-rehearsal": {
-    purpose: "Run the full candidate rehearsal flow and stage outputs into one release-readiness bundle directory.",
+    purpose: "Run the full candidate rehearsal flow and stage outputs, including the final go/no-go packet, into one release-readiness bundle directory.",
     requiredInputs: [
       "Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.",
     ],
     producedArtifacts: [
-      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs and a top-level `SUMMARY.md`.",
+      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the final go/no-go packet, and a top-level `SUMMARY.md`.",
     ],
   },
   "release:phase1:evidence-drift-gate": {

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -173,15 +173,19 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.equal(report.stages.find((stage) => stage.id === "phase1-release-evidence-drift-gate")?.status, "passed");
   assert.match(report.artifacts.runtimeObservabilityBundlePath ?? "", /runtime-observability-bundle-phase1-mainline-/);
   assert.equal(report.stages.find((stage) => stage.id === "phase1-candidate-dossier")?.status, "passed");
+  assert.equal(report.stages.find((stage) => stage.id === "go-no-go-packet")?.status, "passed");
   assert.match(report.artifacts.releaseReadinessSnapshotPath ?? "", /release-readiness-phase1-mainline-/);
   assert.match(report.artifacts.runtimeObservabilityGatePath ?? "", /runtime-observability-gate-phase1-mainline-/);
   assert.match(report.artifacts.sameRevisionEvidenceBundleManifestPath ?? "", /phase1-same-revision-evidence-bundle-phase1-mainline-/);
   assert.match(report.artifacts.phase1ReleaseEvidenceDriftGatePath ?? "", /phase1-release-evidence-drift-gate-phase1-mainline-/);
   assert.match(report.artifacts.phase1CandidateDossierPath ?? "", /phase1-candidate-dossier-phase1-mainline-/);
+  assert.match(report.artifacts.goNoGoPacketPath ?? "", /go-no-go-decision-packet-phase1-mainline-/);
+  assert.match(report.artifacts.goNoGoPacketMarkdownPath ?? "", /go-no-go-decision-packet-phase1-mainline-/);
   assert.match(report.artifacts.stableWechatArtifactsDir ?? "", /wechat-release-phase1-mainline-/);
 
   const markdown = fs.readFileSync(markdownPath, "utf8");
   assert.match(markdown, /# Phase 1 Candidate Rehearsal/);
   assert.match(markdown, /Release gate summary: `passed`/);
   assert.match(markdown, /Phase 1 dossier summary: `passed`/);
+  assert.match(markdown, /goNoGoPacketPath:/);
 });


### PR DESCRIPTION
## Summary
- add a final `go-no-go-packet` stage to `release:phase1:candidate-rehearsal`
- stage the generated go/no-go JSON and Markdown outputs into the rehearsal bundle and summary
- update the rehearsal docs, release script inventory, and progress log to match the new flow

## Why
The Phase 1 candidate rehearsal already assembled the dossier and gate outputs, but it stopped short of generating the final release decision artifact. This change makes the rehearsal bundle end at the same go/no-go packet reviewers need for release sign-off.

## Validation
- `npm run typecheck:ops`
- `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/release-script-inventory.test.ts`

Closes #1192