### PR TITLE
[codex] add phase1 rehearsal evidence front-door

### DIFF
--- a/docs/phase1-candidate-rehearsal.md
+++ b/docs/phase1-candidate-rehearsal.md
@@ -11,6 +11,8 @@ It keeps the implementation narrow by reusing the existing evidence commands ins
 - `npm run smoke:client:release-candidate`
 - `npm run release:cocos-rc:bundle`
 - `npm run release:runtime-observability:bundle`
+- `npm run release:candidate:evidence-audit`
+- `npm run release:evidence:index`
 - `npm run release:gate:summary`
 - `npm run release:phase1:same-revision-evidence-bundle`
 - `npm run release:phase1:evidence-drift-gate`
@@ -36,13 +38,14 @@ The bundle contains:
 - stable copied inputs such as `client-release-candidate-smoke-phase1-mainline-<short-sha>.json`
 - stable generated summaries such as `release-gate-summary-phase1-mainline-<short-sha>.json`
 - one same-revision evidence bundle manifest plus the paired drift-gate JSON / Markdown
+- one candidate-level evidence audit and one current release evidence index so reviewers have a front-door into the packet
 - one reviewer-facing runtime observability bundle directory with the staged evidence and gate files for the target environment
 - the candidate-scoped Cocos RC bundle, Phase 1 dossier, and final go/no-go packet
 - `SUMMARY.md`, which is also appended to `GITHUB_STEP_SUMMARY`
 
 The workflow fails when an evidence-generation stage regresses, when a required rehearsal artifact is missing from the final bundle, or when the same-revision drift gate reports candidate/revision mismatch across the assembled packet.
 
-The workflow does not treat an otherwise valid dossier `pending` result as a generation failure. That pending state is expected when automation intentionally omits live runtime sampling or WeChat manual-review evidence. When `--server-url` is supplied, the rehearsal writes one stable runtime observability bundle directory, stages the raw runtime evidence and gate outputs inside it, and then feeds the staged gate into the candidate dossier instead of resampling the environment.
+The workflow does not treat an otherwise valid dossier `pending` result as a generation failure. That pending state is expected when automation intentionally omits live runtime sampling or WeChat manual-review evidence. The same rule now applies to the candidate-level evidence audit: the rehearsal stages the reviewer-facing audit artifact even when that audit still reports blocking manual sign-off debt. When `--server-url` is supplied, the rehearsal writes one stable runtime observability bundle directory, stages the raw runtime evidence and gate outputs inside it, and then feeds the staged gate into the candidate dossier instead of resampling the environment.
 
 ## Local Rerun
 
@@ -74,6 +77,6 @@ npm run release:phase1:candidate-rehearsal -- \
   --target-surface h5
 ```
 
-Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file links the stable artifact paths used for the rehearsal and records the release gate, release health, dossier, and final go/no-go packet outcomes for the candidate revision.
+Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file links the stable artifact paths used for the rehearsal and records the reviewer front-door evidence index, candidate evidence audit, release gate, release health, dossier, and final go/no-go packet outcomes for the candidate revision.
 
 For the standalone CI guard and explicit GitHub Actions inputs, see [`docs/phase1-release-evidence-drift-gate.md`](./phase1-release-evidence-drift-gate.md).

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -29,7 +29,7 @@ Relevant scripts: 49
 | `release:health:trend-baseline` | release | `artifacts/release-readiness/release-health-trend-baseline.json` |
 | `release:health:trend-compare` | release | `artifacts/release-readiness/release-health-trend-compare.json` |
 | `release:phase1:candidate-dossier` | release | Bundle directory `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/` with `phase1-candidate-dossier.json/.md`, `runtime-observability-dossier.json/.md`, `release-gate-summary.json/.md`, and `release-health-summary.json/.md`. |
-| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the final go/no-go packet, and a top-level `SUMMARY.md`. |
+| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the candidate evidence audit, current evidence index, final go/no-go packet, and a top-level `SUMMARY.md`. |
 | `release:phase1:evidence-drift-gate` | release | `artifacts/release-readiness/phase1-release-evidence-drift-gate-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-audit` | release | `artifacts/release-readiness/phase1-exit-audit-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-dossier-freshness-gate` | release | `artifacts/release-readiness/phase1-exit-dossier-freshness-gate-<candidate>-<short-sha>.json` |
@@ -232,11 +232,11 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/phase1-candidate-rehearsal.ts`
-- Purpose: Run the full candidate rehearsal flow and stage outputs, including the final go/no-go packet, into one release-readiness bundle directory.
+- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the candidate evidence audit, current evidence index, and final go/no-go packet, into one release-readiness bundle directory.
 - Required inputs:
   - Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.
 - Produced artifacts:
-  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the final go/no-go packet, and a top-level `SUMMARY.md`.
+  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the candidate evidence audit, current evidence index, final go/no-go packet, and a top-level `SUMMARY.md`.
 
 ## `release:phase1:evidence-drift-gate`
 

--- a/progress.md
+++ b/progress.md
@@ -1643,3 +1643,31 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 本轮定向验证结果：
   - `npm run typecheck:ops` 通过
   - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-go-no-go-decision-packet.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`9/9`）
+
+## Issue #1198 - Phase 1 candidate rehearsal evidence front-door - 2026-04-10
+
+- 本轮把 `release:phase1:candidate-rehearsal` 又往 reviewer 前门推进了一步：
+  - `scripts/phase1-candidate-rehearsal.ts`
+    - 复用了 `phase1-same-revision-evidence-bundle` 生成的 owner ledger，并在 rehearsal 顶层 packet 再 stage 一份稳定路径
+    - 新增 `candidate-evidence-audit` 阶段，直接生成候选级 evidence audit JSON / Markdown
+    - 新增 `release-evidence-index` 阶段，基于当前 rehearsal packet 生成 reviewer first-stop 的 current release evidence index
+    - rehearsal artifacts 现在会显式记录：
+      - `manualEvidenceLedgerPath`
+      - `candidateEvidenceAuditPath`
+      - `candidateEvidenceAuditMarkdownPath`
+      - `releaseEvidenceIndexPath`
+      - `releaseEvidenceIndexMarkdownPath`
+    - candidate evidence audit 会按“产物生成成功”收口，不会因为 manual sign-off 仍待完成就把整条 rehearsal generation 判成失败
+- 文档与 inventory 已同步：
+  - `docs/phase1-candidate-rehearsal.md`
+    - 明确 rehearsal 现在会附带 reviewer 前门的 evidence audit 与 current evidence index
+    - 补充 candidate evidence audit 在 manual sign-off 仍 pending 时属于预期信息性阻塞，不视为 generation failure
+  - `scripts/release-script-inventory.ts` / `docs/release-script-inventory.md`
+    - 同步更新 `release:phase1:candidate-rehearsal` 的职责与产物说明，包含 candidate evidence audit 与 current evidence index
+- 测试收口：
+  - `scripts/test/phase1-candidate-rehearsal.test.ts`
+    - 锁住 `candidate-evidence-audit` 与 `release-evidence-index` 两个新阶段
+    - 校验 rehearsal summary 会显式列出 reviewer 前门产物
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-evidence-index.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`6/6`）

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -2,6 +2,15 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+import {
+  buildReleaseEvidenceIndexReport,
+  renderReleaseEvidenceIndexMarkdown
+} from "./release-evidence-index.ts";
+import {
+  buildSameCandidateEvidenceAuditReport,
+  renderMarkdown as renderCandidateEvidenceAuditMarkdown
+} from "./same-candidate-evidence-audit.ts";
+
 type StageStatus = "passed" | "failed" | "skipped";
 type TargetSurface = "h5" | "wechat";
 
@@ -71,6 +80,12 @@ interface RehearsalArtifacts {
   sameRevisionEvidenceBundleMarkdownPath?: string;
   phase1ReleaseEvidenceDriftGatePath?: string;
   phase1ReleaseEvidenceDriftGateMarkdownPath?: string;
+  manualEvidenceLedgerPath?: string;
+  releaseReadinessDashboardPath?: string;
+  candidateEvidenceAuditPath?: string;
+  candidateEvidenceAuditMarkdownPath?: string;
+  releaseEvidenceIndexPath?: string;
+  releaseEvidenceIndexMarkdownPath?: string;
   phase1CandidateDossierPath?: string;
   phase1CandidateDossierMarkdownPath?: string;
   goNoGoPacketPath?: string;
@@ -102,6 +117,17 @@ interface RehearsalReport {
   artifactBundleDir: string;
   artifacts: RehearsalArtifacts;
   stages: StageResult[];
+}
+
+interface SameRevisionManifest {
+  artifacts?: {
+    manualEvidenceLedger?: {
+      path?: string;
+    };
+    releaseReadinessDashboard?: {
+      path?: string;
+    };
+  };
 }
 
 const OUTPUT_LIMIT = 4000;
@@ -384,6 +410,13 @@ function readRequiredJson<T>(filePath: string): T {
   return JSON.parse(fs.readFileSync(filePath, "utf8")) as T;
 }
 
+function resolveManifestArtifactPath(manifestPath: string, value: string | undefined): string | undefined {
+  if (!value?.trim()) {
+    return undefined;
+  }
+  return path.isAbsolute(value) ? value : path.resolve(value);
+}
+
 function findFirstMatching(outputDir: string, prefix: string, suffix: string): string | undefined {
   if (!fs.existsSync(outputDir)) {
     return undefined;
@@ -508,6 +541,14 @@ function main(): void {
     outputDir,
     `phase1-release-evidence-drift-gate-${candidateSlug}-${revision.shortCommit}.md`
   );
+  const manualEvidenceLedgerPath = path.join(outputDir, `manual-release-evidence-owner-ledger-${candidateSlug}-${revision.shortCommit}.md`);
+  const candidateEvidenceAuditPath = path.join(outputDir, `candidate-evidence-audit-${candidateSlug}-${revision.shortCommit}.json`);
+  const candidateEvidenceAuditMarkdownPath = path.join(outputDir, `candidate-evidence-audit-${candidateSlug}-${revision.shortCommit}.md`);
+  const releaseEvidenceIndexPath = path.join(outputDir, `current-release-evidence-index-${candidateSlug}-${revision.shortCommit}.json`);
+  const releaseEvidenceIndexMarkdownPath = path.join(
+    outputDir,
+    `current-release-evidence-index-${candidateSlug}-${revision.shortCommit}.md`
+  );
   const phase1CandidateDossierPath = path.join(outputDir, `phase1-candidate-dossier-${candidateSlug}-${revision.shortCommit}.json`);
   const phase1CandidateDossierMarkdownPath = path.join(outputDir, `phase1-candidate-dossier-${candidateSlug}-${revision.shortCommit}.md`);
   const goNoGoPacketPath = path.join(outputDir, `go-no-go-decision-packet-${candidateSlug}-${revision.shortCommit}.json`);
@@ -533,6 +574,10 @@ function main(): void {
   artifacts.sameRevisionEvidenceBundleMarkdownPath = toRelative(sameRevisionEvidenceBundleMarkdownPath);
   artifacts.phase1ReleaseEvidenceDriftGatePath = toRelative(phase1ReleaseEvidenceDriftGatePath);
   artifacts.phase1ReleaseEvidenceDriftGateMarkdownPath = toRelative(phase1ReleaseEvidenceDriftGateMarkdownPath);
+  artifacts.candidateEvidenceAuditPath = toRelative(candidateEvidenceAuditPath);
+  artifacts.candidateEvidenceAuditMarkdownPath = toRelative(candidateEvidenceAuditMarkdownPath);
+  artifacts.releaseEvidenceIndexPath = toRelative(releaseEvidenceIndexPath);
+  artifacts.releaseEvidenceIndexMarkdownPath = toRelative(releaseEvidenceIndexMarkdownPath);
   artifacts.phase1CandidateDossierPath = toRelative(phase1CandidateDossierPath);
   artifacts.phase1CandidateDossierMarkdownPath = toRelative(phase1CandidateDossierMarkdownPath);
   artifacts.goNoGoPacketPath = toRelative(goNoGoPacketPath);
@@ -885,6 +930,107 @@ function main(): void {
       }
     },
     {
+      id: "candidate-evidence-audit",
+      title: "Build candidate evidence audit",
+      run: () => {
+        if (!fs.existsSync(sameRevisionEvidenceBundleManifestPath)) {
+          return {
+            id: "candidate-evidence-audit",
+            title: "Build candidate evidence audit",
+            status: "failed",
+            summary: "Phase 1 same-revision evidence bundle manifest is missing, so the reviewer audit front-door could not be generated.",
+            outputs: [candidateEvidenceAuditPath, candidateEvidenceAuditMarkdownPath].map(toRelative)
+          };
+        }
+
+        const manifest = readRequiredJson<SameRevisionManifest>(sameRevisionEvidenceBundleManifestPath);
+        const sourceManualEvidenceLedgerPath = resolveManifestArtifactPath(
+          sameRevisionEvidenceBundleManifestPath,
+          manifest.artifacts?.manualEvidenceLedger?.path
+        );
+        const releaseReadinessDashboardPath = resolveManifestArtifactPath(
+          sameRevisionEvidenceBundleManifestPath,
+          manifest.artifacts?.releaseReadinessDashboard?.path
+        );
+
+        if (sourceManualEvidenceLedgerPath) {
+          copyFileIfPresent(sourceManualEvidenceLedgerPath, manualEvidenceLedgerPath);
+          artifacts.manualEvidenceLedgerPath = toRelative(manualEvidenceLedgerPath);
+        }
+        if (releaseReadinessDashboardPath) {
+          artifacts.releaseReadinessDashboardPath = toRelative(releaseReadinessDashboardPath);
+        }
+
+        if (!sourceManualEvidenceLedgerPath || !fs.existsSync(sourceManualEvidenceLedgerPath)) {
+          return {
+            id: "candidate-evidence-audit",
+            title: "Build candidate evidence audit",
+            status: "failed",
+            summary: "Phase 1 same-revision evidence bundle did not provide a manual evidence owner ledger for the reviewer audit front-door.",
+            outputs: [candidateEvidenceAuditPath, candidateEvidenceAuditMarkdownPath].map(toRelative)
+          };
+        }
+
+        const report = buildSameCandidateEvidenceAuditReport({
+          candidate: args.candidate,
+          candidateRevision: revision.commit,
+          targetSurface: args.targetSurface,
+          snapshotPath: releaseReadinessSnapshotPath,
+          releaseGateSummaryPath,
+          cocosRcBundlePath:
+            findFirstMatching(outputDir, "cocos-rc-evidence-bundle-", ".json") ?? path.join(outputDir, "missing-cocos-bundle.json"),
+          ...(fs.existsSync(runtimeObservabilityEvidencePath) ? { runtimeObservabilityEvidencePath } : {}),
+          ...(fs.existsSync(runtimeObservabilityGatePath) ? { runtimeObservabilityGatePath } : {}),
+          manualEvidenceLedgerPath,
+          ...(artifacts.stableWechatArtifactsDir ? { wechatArtifactsDir: stableWechatArtifactsDir } : {}),
+          ...(artifacts.wechatCandidateSummaryPath
+            ? { wechatCandidateSummaryPath: path.resolve(artifacts.wechatCandidateSummaryPath) }
+            : {}),
+          outputPath: candidateEvidenceAuditPath,
+          markdownOutputPath: candidateEvidenceAuditMarkdownPath,
+          maxAgeHours: 72
+        });
+
+        writeJsonFile(candidateEvidenceAuditPath, report);
+        writeFile(candidateEvidenceAuditMarkdownPath, renderCandidateEvidenceAuditMarkdown(report));
+
+        return {
+          id: "candidate-evidence-audit",
+          title: "Build candidate evidence audit",
+          status: "passed",
+          summary: `Audit verdict ${report.summary.status}; reviewer front-door artifact generated successfully.`,
+          outputs: [candidateEvidenceAuditPath, candidateEvidenceAuditMarkdownPath].map(toRelative)
+        };
+      }
+    },
+    {
+      id: "release-evidence-index",
+      title: "Build current release evidence index",
+      run: () => {
+        const report = buildReleaseEvidenceIndexReport(
+          {
+            releaseReadinessDir: outputDir,
+            wechatArtifactsDir: artifacts.stableWechatArtifactsDir ? stableWechatArtifactsDir : path.join(outputDir, "missing-wechat-artifacts"),
+            maxAgeHours: 72,
+            outputPath: releaseEvidenceIndexPath,
+            markdownOutputPath: releaseEvidenceIndexMarkdownPath
+          },
+          revision
+        );
+
+        writeJsonFile(releaseEvidenceIndexPath, report);
+        writeFile(releaseEvidenceIndexMarkdownPath, renderReleaseEvidenceIndexMarkdown(report));
+
+        return {
+          id: "release-evidence-index",
+          title: "Build current release evidence index",
+          status: report.summary.status === "failed" ? "failed" : "passed",
+          summary: `Evidence index verdict ${report.summary.status}; ${report.summary.summary}`,
+          outputs: [releaseEvidenceIndexPath, releaseEvidenceIndexMarkdownPath].map(toRelative)
+        };
+      }
+    },
+    {
       id: "phase1-candidate-dossier",
       title: "Build Phase 1 candidate dossier",
       run: () => {
@@ -995,6 +1141,10 @@ function main(): void {
     sameRevisionEvidenceBundleMarkdownPath,
     phase1ReleaseEvidenceDriftGatePath,
     phase1ReleaseEvidenceDriftGateMarkdownPath,
+    candidateEvidenceAuditPath,
+    candidateEvidenceAuditMarkdownPath,
+    releaseEvidenceIndexPath,
+    releaseEvidenceIndexMarkdownPath,
     phase1CandidateDossierPath,
     phase1CandidateDossierMarkdownPath,
     goNoGoPacketPath,

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -148,12 +148,13 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
     ],
   },
   "release:phase1:candidate-rehearsal": {
-    purpose: "Run the full candidate rehearsal flow and stage outputs, including the final go/no-go packet, into one release-readiness bundle directory.",
+    purpose:
+      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the candidate evidence audit, current evidence index, and final go/no-go packet, into one release-readiness bundle directory.",
     requiredInputs: [
       "Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.",
     ],
     producedArtifacts: [
-      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the final go/no-go packet, and a top-level `SUMMARY.md`.",
+      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the candidate evidence audit, current evidence index, final go/no-go packet, and a top-level `SUMMARY.md`.",
     ],
   },
   "release:phase1:evidence-drift-gate": {

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -171,6 +171,8 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.equal(report.stages.find((stage) => stage.id === "runtime-observability-bundle")?.status, "skipped");
   assert.equal(report.stages.find((stage) => stage.id === "phase1-same-revision-evidence-bundle")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "phase1-release-evidence-drift-gate")?.status, "passed");
+  assert.equal(report.stages.find((stage) => stage.id === "candidate-evidence-audit")?.status, "passed");
+  assert.equal(report.stages.find((stage) => stage.id === "release-evidence-index")?.status, "passed");
   assert.match(report.artifacts.runtimeObservabilityBundlePath ?? "", /runtime-observability-bundle-phase1-mainline-/);
   assert.equal(report.stages.find((stage) => stage.id === "phase1-candidate-dossier")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "go-no-go-packet")?.status, "passed");
@@ -178,6 +180,9 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(report.artifacts.runtimeObservabilityGatePath ?? "", /runtime-observability-gate-phase1-mainline-/);
   assert.match(report.artifacts.sameRevisionEvidenceBundleManifestPath ?? "", /phase1-same-revision-evidence-bundle-phase1-mainline-/);
   assert.match(report.artifacts.phase1ReleaseEvidenceDriftGatePath ?? "", /phase1-release-evidence-drift-gate-phase1-mainline-/);
+  assert.match(report.artifacts.manualEvidenceLedgerPath ?? "", /manual-release-evidence-owner-ledger-phase1-mainline-/);
+  assert.match(report.artifacts.candidateEvidenceAuditPath ?? "", /candidate-evidence-audit-phase1-mainline-/);
+  assert.match(report.artifacts.releaseEvidenceIndexPath ?? "", /current-release-evidence-index-phase1-mainline-/);
   assert.match(report.artifacts.phase1CandidateDossierPath ?? "", /phase1-candidate-dossier-phase1-mainline-/);
   assert.match(report.artifacts.goNoGoPacketPath ?? "", /go-no-go-decision-packet-phase1-mainline-/);
   assert.match(report.artifacts.goNoGoPacketMarkdownPath ?? "", /go-no-go-decision-packet-phase1-mainline-/);
@@ -187,5 +192,7 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /# Phase 1 Candidate Rehearsal/);
   assert.match(markdown, /Release gate summary: `passed`/);
   assert.match(markdown, /Phase 1 dossier summary: `passed`/);
+  assert.match(markdown, /candidateEvidenceAuditPath:/);
+  assert.match(markdown, /releaseEvidenceIndexPath:/);
   assert.match(markdown, /goNoGoPacketPath:/);
 });


### PR DESCRIPTION
## Summary
- add reviewer front-door artifacts to `release:phase1:candidate-rehearsal`
- stage a stable manual evidence ledger path, candidate evidence audit, and current release evidence index into the rehearsal bundle
- update rehearsal docs, release script inventory, and tests to match the new packet shape

## Why
The Phase 1 candidate rehearsal already produced the deeper release packet artifacts, but reviewers still had to manually dig for the first-stop evidence audit and release index. This change makes the rehearsal bundle open directly into those reviewer-facing front-door artifacts.

## Validation
- `npm run typecheck:ops`
- `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-evidence-index.test.ts ./scripts/test/release-script-inventory.test.ts`

Closes #1198