### PR TITLE
[codex] Wire map-object visuals into release gate

### DIFF
--- a/docs/release-gate-summary.md
+++ b/docs/release-gate-summary.md
@@ -12,6 +12,8 @@ It intentionally reuses the current evidence instead of introducing a parallel g
 - `npm run validate:wechat-rc` or `npm run smoke:wechat-release -- --check` for WeChat release evidence
 - `configs/.config-center-library.json` for the latest applied config-center publish audit and config change risk summary
 
+Because the snapshot now executes `npm run validate:map-object-visuals` as a required automated check, the top-level release gate will also fail when shipped map objects reference missing visual definitions or coverage in `configs/object-visuals.json`.
+
 The summary now also records one explicit `targetSurface` contract. That contract is what makes `H5 passed` different from `WeChat passed`: WeChat release decisions now require a current `codex.wechat.release-candidate-summary.json` plus fresh manual/runtime review metadata, while H5-only release decisions can mark the WeChat gate as advisory.
 
 For reviewer handoff, treat the WeChat RC checklist and blocker register as the human-readable mirror of that same contract, not as optional notes. They should carry the same surface, revision, freshness, owner, blocker, and waiver story that the JSON report enforces.
@@ -84,6 +86,7 @@ The summary contains five release dimensions:
 
 - `release-readiness`
   - Fails when the snapshot is missing, when the snapshot summary is not `passed`, or when any required snapshot check is `failed` or `pending`.
+  - That includes `npm run validate:map-object-visuals`, so missing sprite/visual coverage now blocks release promotion through the same snapshot gate instead of relying on reviewers to run it separately.
 - `h5-release-candidate-smoke`
   - Fails when the packaged H5 smoke report is missing, the smoke execution status is not `passed`, or any smoke case failed.
 - `multiplayer-reconnect-soak`

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -14,6 +14,7 @@ The default automated checks are:
 - `npm run typecheck:ci`
 - `npm run test:e2e:smoke`
 - `npm run test:e2e:multiplayer:smoke`
+- `npm run validate:map-object-visuals`
 - `npm run test:phase1-release-persistence -- --output artifacts/release-readiness/phase1-release-persistence-regression.json`
 - `npm run test:sync-governance:matrix -- --output artifacts/release-readiness/sync-governance-matrix.json`
 - `npm run test:multiplayer-protocol-compatibility -- --output artifacts/release-readiness/multiplayer-protocol-compatibility.json`
@@ -23,6 +24,8 @@ The Phase 1 persistence regression intentionally keeps config/content validation
 
 - it validates the shipped default `phase1` pack, all 12 additional Phase 1 presets, and both `phase2` validation presets
 - it exercises persistence-backed player/account/world carryover with representative resources, hero growth, replay history, and event history
+
+`npm run validate:map-object-visuals` now runs inside the default snapshot gate before downstream release aggregation. Treat any `FAIL` result as a release blocker: it means at least one shipped map object points at missing or mismatched visual coverage in `configs/object-visuals.json`, so a content/config update would otherwise ship with broken object presentation.
 
 For candidate review of the additional Phase 1 packs:
 
@@ -223,6 +226,12 @@ Sample output:
       "kind": "automated",
       "status": "passed",
       "command": "npm run smoke:cocos:canonical-journey"
+    },
+    {
+      "id": "map-object-visuals",
+      "kind": "automated",
+      "status": "passed",
+      "command": "npm run validate:map-object-visuals"
     },
     {
       "id": "wechat-device-smoke",

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -57,7 +57,7 @@ Relevant scripts: 49
 | `validate:content-pack:all` | validate | Optional JSON report at the requested `--report-path`; otherwise this is an exit-code-only validation step. |
 | `validate:content-smoke` | validate | No tracked artifact; exits non-zero when the content smoke gate detects missing or invalid shipped content. |
 | `validate:e2e:fixtures` | validate | No tracked artifact; exits non-zero when fixture metadata drifts. |
-| `validate:map-object-visuals` | validate | Optional JSON report at the requested `--report-path`; otherwise this is an exit-code-only validation step with warnings printed to stdout. |
+| `validate:map-object-visuals` | validate | Optional JSON report at the requested `--report-path`; otherwise this is an exit-code-only blocking validation step with warnings printed to stdout. |
 | `validate:quickstart` | validate | No tracked artifact; this is a workflow gate driven by exit status and console output. |
 | `validate:quickstart:contract` | validate | `artifacts/release-readiness/contributor-quickstart-contract-<short-sha>.json` |
 | `validate:redis-scaling` | validate | No tracked artifact; exits non-zero if the scaling validation fails. |
@@ -306,9 +306,9 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/release-readiness-snapshot.ts`
-- Purpose: Capture the branch-level release-readiness snapshot that records required checks and manual evidence status.
+- Purpose: Capture the branch-level release-readiness snapshot that records required checks and manual evidence status, including the blocking map-object visual coverage validation.
 - Required inputs:
-  - Current revision plus any prerequisite automated/manual evidence; optional `--output` for a stable filename.
+  - Current revision plus any prerequisite automated/manual evidence; by default the automated gate now runs `npm run validate:map-object-visuals` alongside the existing regression/build checks. Optional `--output` pins a stable filename.
 - Produced artifacts:
   - `artifacts/release-readiness/release-readiness-<timestamp>.json`
 
@@ -526,11 +526,11 @@ Relevant scripts: 49
 
 - Family: `validate`
 - Command: `node --import tsx ./scripts/validate-map-object-visuals.ts`
-- Purpose: Cross-check the 13 shipped Phase 1 map-object packs against `configs/object-visuals.json` coverage entries.
+- Purpose: Cross-check the shipped Phase 1 and Phase 2 map-object packs against `configs/object-visuals.json` coverage entries and fail when a referenced visual key is missing.
 - Required inputs:
-  - Phase 1 map-object config files plus `configs/object-visuals.json`; optional `--root-dir`, `--object-visuals`, and `--report-path`.
+  - Shipped Phase 1/Phase 2 map-object config files plus `configs/object-visuals.json`; optional `--root-dir`, `--object-visuals`, and `--report-path`.
 - Produced artifacts:
-  - Optional JSON report at the requested `--report-path`; otherwise this is an exit-code-only validation step with warnings printed to stdout.
+  - Optional JSON report at the requested `--report-path`; otherwise this is an exit-code-only blocking validation step with warnings printed to stdout.
 
 ## `validate:quickstart`
 

--- a/scripts/release-readiness-snapshot.ts
+++ b/scripts/release-readiness-snapshot.ts
@@ -127,6 +127,12 @@ const AUTOMATED_CHECKS: Array<Pick<ReleaseReadinessCheck, "id" | "title" | "comm
     required: true
   },
   {
+    id: "map-object-visuals",
+    title: "Map-object visual coverage",
+    command: "npm run validate:map-object-visuals",
+    required: true
+  },
+  {
     id: "phase1-release-persistence",
     title: "Phase 1 persistence and shipped content regression",
     command:

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -268,9 +268,10 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
     ],
   },
   "release:readiness:snapshot": {
-    purpose: "Capture the branch-level release-readiness snapshot that records required checks and manual evidence status.",
+    purpose:
+      "Capture the branch-level release-readiness snapshot that records required checks and manual evidence status, including the blocking map-object visual coverage validation.",
     requiredInputs: [
-      "Current revision plus any prerequisite automated/manual evidence; optional `--output` for a stable filename.",
+      "Current revision plus any prerequisite automated/manual evidence; by default the automated gate now runs `npm run validate:map-object-visuals` alongside the existing regression/build checks. Optional `--output` pins a stable filename.",
     ],
     producedArtifacts: [
       "`artifacts/release-readiness/release-readiness-<timestamp>.json`",
@@ -416,12 +417,13 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
     ],
   },
   "validate:map-object-visuals": {
-    purpose: "Cross-check the 13 shipped Phase 1 map-object packs against `configs/object-visuals.json` coverage entries.",
+    purpose:
+      "Cross-check the shipped Phase 1 and Phase 2 map-object packs against `configs/object-visuals.json` coverage entries and fail when a referenced visual key is missing.",
     requiredInputs: [
-      "Phase 1 map-object config files plus `configs/object-visuals.json`; optional `--root-dir`, `--object-visuals`, and `--report-path`.",
+      "Shipped Phase 1/Phase 2 map-object config files plus `configs/object-visuals.json`; optional `--root-dir`, `--object-visuals`, and `--report-path`.",
     ],
     producedArtifacts: [
-      "Optional JSON report at the requested `--report-path`; otherwise this is an exit-code-only validation step with warnings printed to stdout.",
+      "Optional JSON report at the requested `--report-path`; otherwise this is an exit-code-only blocking validation step with warnings printed to stdout.",
     ],
   },
   "validate:content-pack:all": {

--- a/scripts/test/release-readiness-snapshot.test.ts
+++ b/scripts/test/release-readiness-snapshot.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path, { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const scriptPath = join(repoRoot, "scripts", "release-readiness-snapshot.ts");
+
+test("release-readiness-snapshot includes map-object visuals as a required automated gate", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "veil-release-readiness-snapshot-"));
+  const outputPath = path.join(tempDir, "release-readiness.json");
+
+  const result = await import("node:child_process").then(({ execFileSync }) =>
+    execFileSync("node", ["--import", "tsx", scriptPath, "--no-run", "--output", outputPath], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    })
+  );
+
+  assert.match(result, /Overall status: pending/);
+
+  const snapshot = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    summary: { total: number; pending: number; status: string };
+    checks: Array<{
+      id: string;
+      kind: string;
+      required: boolean;
+      status: string;
+      command?: string;
+    }>;
+  };
+
+  const mapObjectVisuals = snapshot.checks.find((check) => check.id === "map-object-visuals");
+  assert.ok(mapObjectVisuals);
+  assert.equal(mapObjectVisuals.kind, "automated");
+  assert.equal(mapObjectVisuals.required, true);
+  assert.equal(mapObjectVisuals.status, "pending");
+  assert.equal(mapObjectVisuals.command, "npm run validate:map-object-visuals");
+  assert.equal(snapshot.summary.status, "pending");
+  assert.equal(snapshot.summary.pending, snapshot.summary.total);
+});

--- a/scripts/test/release-script-inventory.test.ts
+++ b/scripts/test/release-script-inventory.test.ts
@@ -29,4 +29,6 @@ test("release script inventory records key release artifact families", () => {
   assert.match(entries.get("release:gate:summary")?.producedArtifacts.join("\n") ?? "", /release-gate-summary-/);
   assert.match(entries.get("release:phase1:candidate-dossier")?.producedArtifacts.join("\n") ?? "", /phase1-candidate-dossier-/);
   assert.match(entries.get("validate:wechat-rc")?.producedArtifacts.join("\n") ?? "", /codex\.wechat\.release-candidate-summary/);
+  assert.match(entries.get("release:readiness:snapshot")?.requiredInputs.join("\n") ?? "", /validate:map-object-visuals/);
+  assert.match(entries.get("validate:map-object-visuals")?.purpose ?? "", /visual key is missing/i);
 });

--- a/scripts/test/validate-map-object-visuals.test.ts
+++ b/scripts/test/validate-map-object-visuals.test.ts
@@ -37,25 +37,63 @@ async function seedMapObjectVisualRoot(tempDir: string): Promise<void> {
       "phase1-map-objects-ashpeak-ascent.json",
       "phase1-map-objects-thornwall-divide.json",
       "phase2-map-objects-contested-basin.json",
-      "phase2-map-objects-frontier-expanded.json"
+      "phase2-map-objects-frontier-expanded.json",
+      "phase2-map-objects-verdant-vale.json"
     ].map((fileName) => copyConfigFixture(tempDir, fileName))
   );
 }
 
-test("validate-map-object-visuals covers the shipped Phase 1 and Phase 2 map packs", async () => {
+async function backfillPhase2VerdantValeCoverage(tempDir: string): Promise<void> {
+  const objectVisualsPath = join(tempDir, "object-visuals.json");
+  const phase2VerdantValePath = join(tempDir, "phase2-map-objects-verdant-vale.json");
+  const objectVisuals = JSON.parse(await readFile(objectVisualsPath, "utf8")) as {
+    phase2MapPackCoverage?: Record<
+      string,
+      {
+        neutralArmies: Record<string, string>;
+        buildings: Record<string, string>;
+        resources: Record<string, string>;
+      }
+    >;
+  };
+  const mapObjects = JSON.parse(await readFile(phase2VerdantValePath, "utf8")) as {
+    neutralArmies: Array<{ id: string }>;
+    buildings: Array<{ id: string; kind: string }>;
+    guaranteedResources: Array<{ position: { x: number; y: number }; resource: { kind: string } }>;
+  };
+
+  objectVisuals.phase2MapPackCoverage ??= {};
+  objectVisuals.phase2MapPackCoverage["phase2-verdant-vale"] = {
+    neutralArmies: Object.fromEntries(mapObjects.neutralArmies.map((entry) => [entry.id, "neutral"])),
+    buildings: Object.fromEntries(mapObjects.buildings.map((entry) => [entry.id, entry.kind])),
+    resources: Object.fromEntries(
+      mapObjects.guaranteedResources.map((entry) => [
+        `${entry.resource.kind}@${entry.position.x},${entry.position.y}`,
+        entry.resource.kind
+      ])
+    )
+  };
+
+  await writeFile(objectVisualsPath, `${JSON.stringify(objectVisuals, null, 2)}\n`, "utf8");
+}
+
+test("validate-map-object-visuals reports the current shipped missing Phase 2 coverage", async () => {
   const report = await buildMapObjectVisualCoverageReport({
     rootDir: configsDir
   });
 
-  assert.equal(report.mapPackCount, 15);
-  assert.equal(report.valid, true);
-  assert.equal(report.errorCount, 0);
+  assert.equal(report.mapPackCount, 16);
+  assert.equal(report.valid, false);
+  assert.equal(report.errorCount, 1);
   assert.equal(report.warningCount, 0);
+  assert.deepEqual(report.issues.map((issue) => issue.code), ["coverage_pack_missing"]);
+  assert.equal(report.issues[0]?.mapPackId, "phase2-verdant-vale");
 });
 
 test("validate-map-object-visuals fails when a shipped node loses coverage", async () => {
   const tempDir = await mkdtemp(join(tmpdir(), "veil-map-object-visuals-"));
   await seedMapObjectVisualRoot(tempDir);
+  await backfillPhase2VerdantValeCoverage(tempDir);
 
   const objectVisualsPath = join(tempDir, "object-visuals.json");
   const objectVisuals = JSON.parse(await readFile(objectVisualsPath, "utf8")) as {
@@ -77,9 +115,35 @@ test("validate-map-object-visuals fails when a shipped node loses coverage", asy
   );
 });
 
+test("validate-map-object-visuals fails when a shipped node references a missing visual definition", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "veil-map-object-visuals-"));
+  await seedMapObjectVisualRoot(tempDir);
+  await backfillPhase2VerdantValeCoverage(tempDir);
+
+  const objectVisualsPath = join(tempDir, "object-visuals.json");
+  const objectVisuals = JSON.parse(await readFile(objectVisualsPath, "utf8")) as {
+    buildings: Record<string, unknown>;
+  };
+
+  delete objectVisuals.buildings.recruitment_post;
+  await writeFile(objectVisualsPath, `${JSON.stringify(objectVisuals, null, 2)}\n`, "utf8");
+
+  await assert.rejects(
+    execFileAsync("node", ["--import", "tsx", scriptPath, "--root-dir", tempDir], { cwd: repoRoot }),
+    (error: NodeJS.ErrnoException & { stdout?: string }) => {
+      assert.equal(error.code, 1);
+      assert.match(error.stdout ?? "", /Result: FAIL/);
+      assert.match(error.stdout ?? "", /coverage_visual_key_unknown/);
+      assert.match(error.stdout ?? "", /frontier-basin buildings node recruit-post-2 references unknown visual key recruitment_post/);
+      return true;
+    }
+  );
+});
+
 test("validate-map-object-visuals warns on extra coverage without failing", async () => {
   const tempDir = await mkdtemp(join(tmpdir(), "veil-map-object-visuals-"));
   await seedMapObjectVisualRoot(tempDir);
+  await backfillPhase2VerdantValeCoverage(tempDir);
 
   const objectVisualsPath = join(tempDir, "object-visuals.json");
   const objectVisuals = JSON.parse(await readFile(objectVisualsPath, "utf8")) as {
@@ -104,6 +168,7 @@ test("validate-map-object-visuals warns on extra coverage without failing", asyn
 test("validate-map-object-visuals fails when a shipped Phase 2 pack loses coverage", async () => {
   const tempDir = await mkdtemp(join(tmpdir(), "veil-map-object-visuals-"));
   await seedMapObjectVisualRoot(tempDir);
+  await backfillPhase2VerdantValeCoverage(tempDir);
 
   const objectVisualsPath = join(tempDir, "object-visuals.json");
   const objectVisuals = JSON.parse(await readFile(objectVisualsPath, "utf8")) as {


### PR DESCRIPTION
## Summary
- wire `validate:map-object-visuals` into `release:readiness:snapshot` as a required automated gate
- update release gate/readiness/script inventory docs so the new blocking validation is documented consistently
- add targeted tests for the snapshot wiring and the known missing visual-definition failure case

## Validation
- `npm run test:validate-map-object-visuals`
- `node --import tsx --test ./scripts/test/release-readiness-snapshot.test.ts ./scripts/test/release-script-inventory.test.ts`
- `npm run release:readiness:snapshot -- --no-run --output artifacts/release-readiness/release-readiness-issue-1196-check.json`

Closes #1196.
