### PR TITLE
Stage candidate evidence front door in phase1 rehearsal

### DIFF
--- a/docs/phase1-candidate-rehearsal.md
+++ b/docs/phase1-candidate-rehearsal.md
@@ -38,6 +38,7 @@ The bundle contains:
 - stable copied inputs such as `client-release-candidate-smoke-phase1-mainline-<short-sha>.json`
 - stable generated summaries such as `release-gate-summary-phase1-mainline-<short-sha>.json`
 - one same-revision evidence bundle manifest plus the paired drift-gate JSON / Markdown
+- the same-revision bundle's manual evidence owner ledger and release-readiness dashboard restaged at the rehearsal bundle top level
 - one candidate-level evidence audit and one current release evidence index so reviewers have a front-door into the packet
 - one reviewer-facing runtime observability bundle directory with the staged evidence and gate files for the target environment
 - the candidate-scoped Cocos RC bundle, Phase 1 dossier, and final go/no-go packet
@@ -77,6 +78,6 @@ npm run release:phase1:candidate-rehearsal -- \
   --target-surface h5
 ```
 
-Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file links the stable artifact paths used for the rehearsal and records the reviewer front-door evidence index, candidate evidence audit, release gate, release health, dossier, and final go/no-go packet outcomes for the candidate revision.
+Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file has a dedicated reviewer front-door section for the current release evidence index, candidate evidence audit, restaged release-readiness dashboard, and manual evidence owner ledger, then records the release gate, release health, dossier, and final go/no-go packet outcomes for the candidate revision.
 
 For the standalone CI guard and explicit GitHub Actions inputs, see [`docs/phase1-release-evidence-drift-gate.md`](./phase1-release-evidence-drift-gate.md).

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -29,7 +29,7 @@ Relevant scripts: 49
 | `release:health:trend-baseline` | release | `artifacts/release-readiness/release-health-trend-baseline.json` |
 | `release:health:trend-compare` | release | `artifacts/release-readiness/release-health-trend-compare.json` |
 | `release:phase1:candidate-dossier` | release | Bundle directory `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/` with `phase1-candidate-dossier.json/.md`, `runtime-observability-dossier.json/.md`, `release-gate-summary.json/.md`, and `release-health-summary.json/.md`. |
-| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the candidate evidence audit, current evidence index, final go/no-go packet, and a top-level `SUMMARY.md`. |
+| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the current evidence index, the final go/no-go packet, and a top-level `SUMMARY.md`. |
 | `release:phase1:evidence-drift-gate` | release | `artifacts/release-readiness/phase1-release-evidence-drift-gate-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-audit` | release | `artifacts/release-readiness/phase1-exit-audit-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-dossier-freshness-gate` | release | `artifacts/release-readiness/phase1-exit-dossier-freshness-gate-<candidate>-<short-sha>.json` |
@@ -232,11 +232,11 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/phase1-candidate-rehearsal.ts`
-- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the candidate evidence audit, current evidence index, and final go/no-go packet, into one release-readiness bundle directory.
+- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the current evidence index, and the final go/no-go packet, into one release-readiness bundle directory.
 - Required inputs:
   - Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.
 - Produced artifacts:
-  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the candidate evidence audit, current evidence index, final go/no-go packet, and a top-level `SUMMARY.md`.
+  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the current evidence index, the final go/no-go packet, and a top-level `SUMMARY.md`.
 
 ## `release:phase1:evidence-drift-gate`
 

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -82,6 +82,7 @@ interface RehearsalArtifacts {
   phase1ReleaseEvidenceDriftGateMarkdownPath?: string;
   manualEvidenceLedgerPath?: string;
   releaseReadinessDashboardPath?: string;
+  releaseReadinessDashboardMarkdownPath?: string;
   candidateEvidenceAuditPath?: string;
   candidateEvidenceAuditMarkdownPath?: string;
   releaseEvidenceIndexPath?: string;
@@ -461,6 +462,21 @@ function renderMarkdown(report: RehearsalReport): string {
     lines.push("");
   }
 
+  lines.push("## Reviewer Front Door", "");
+  if (report.artifacts.releaseEvidenceIndexPath) {
+    lines.push(`- Current release evidence index: \`${report.artifacts.releaseEvidenceIndexPath}\``);
+  }
+  if (report.artifacts.candidateEvidenceAuditPath) {
+    lines.push(`- Candidate evidence audit: \`${report.artifacts.candidateEvidenceAuditPath}\``);
+  }
+  if (report.artifacts.releaseReadinessDashboardPath) {
+    lines.push(`- Release readiness dashboard: \`${report.artifacts.releaseReadinessDashboardPath}\``);
+  }
+  if (report.artifacts.manualEvidenceLedgerPath) {
+    lines.push(`- Manual evidence owner ledger: \`${report.artifacts.manualEvidenceLedgerPath}\``);
+  }
+  lines.push("");
+
   lines.push("## Generated Outputs", "");
   const artifactEntries = Object.entries(report.artifacts)
     .filter(([, value]) => typeof value === "string" && value.length > 0)
@@ -527,6 +543,7 @@ function main(): void {
   const releaseHealthSummaryPath = path.join(outputDir, `release-health-summary-${candidateSlug}-${revision.shortCommit}.json`);
   const releaseHealthMarkdownPath = path.join(outputDir, `release-health-summary-${candidateSlug}-${revision.shortCommit}.md`);
   const syntheticDashboardPath = path.join(outputDir, `release-readiness-dashboard-${candidateSlug}-${revision.shortCommit}.json`);
+  const releaseReadinessDashboardMarkdownPath = syntheticDashboardPath.replace(/\.json$/, ".md");
   const sameRevisionEvidenceBundleDir = path.join(outputDir, `phase1-same-revision-evidence-bundle-${candidateSlug}-${revision.shortCommit}`);
   const sameRevisionEvidenceBundleManifestPath = path.join(
     sameRevisionEvidenceBundleDir,
@@ -958,7 +975,12 @@ function main(): void {
           artifacts.manualEvidenceLedgerPath = toRelative(manualEvidenceLedgerPath);
         }
         if (releaseReadinessDashboardPath) {
-          artifacts.releaseReadinessDashboardPath = toRelative(releaseReadinessDashboardPath);
+          copyFileIfPresent(releaseReadinessDashboardPath, syntheticDashboardPath);
+          artifacts.releaseReadinessDashboardPath = toRelative(syntheticDashboardPath);
+          const sourceDashboardMarkdownPath = releaseReadinessDashboardPath.replace(/\.json$/, ".md");
+          if (copyFileIfPresent(sourceDashboardMarkdownPath, releaseReadinessDashboardMarkdownPath)) {
+            artifacts.releaseReadinessDashboardMarkdownPath = toRelative(releaseReadinessDashboardMarkdownPath);
+          }
         }
 
         if (!sourceManualEvidenceLedgerPath || !fs.existsSync(sourceManualEvidenceLedgerPath)) {
@@ -1143,6 +1165,7 @@ function main(): void {
     phase1ReleaseEvidenceDriftGateMarkdownPath,
     candidateEvidenceAuditPath,
     candidateEvidenceAuditMarkdownPath,
+    syntheticDashboardPath,
     releaseEvidenceIndexPath,
     releaseEvidenceIndexMarkdownPath,
     phase1CandidateDossierPath,
@@ -1164,6 +1187,9 @@ function main(): void {
   if (artifacts.stableWechatArtifactsDir) {
     requiredArtifacts.push(path.join(stableWechatArtifactsDir, "codex.wechat.release-candidate-summary.json"));
     requiredArtifacts.push(path.join(stableWechatArtifactsDir, "codex.wechat.release-candidate-summary.md"));
+  }
+  if (artifacts.releaseReadinessDashboardMarkdownPath) {
+    requiredArtifacts.push(releaseReadinessDashboardMarkdownPath);
   }
   if (cocosBundlePath) {
     requiredArtifacts.push(cocosBundlePath);

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -149,12 +149,12 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
   },
   "release:phase1:candidate-rehearsal": {
     purpose:
-      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the candidate evidence audit, current evidence index, and final go/no-go packet, into one release-readiness bundle directory.",
+      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the current evidence index, and the final go/no-go packet, into one release-readiness bundle directory.",
     requiredInputs: [
       "Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.",
     ],
     producedArtifacts: [
-      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the candidate evidence audit, current evidence index, final go/no-go packet, and a top-level `SUMMARY.md`.",
+      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the current evidence index, the final go/no-go packet, and a top-level `SUMMARY.md`.",
     ],
   },
   "release:phase1:evidence-drift-gate": {

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -181,6 +181,7 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(report.artifacts.sameRevisionEvidenceBundleManifestPath ?? "", /phase1-same-revision-evidence-bundle-phase1-mainline-/);
   assert.match(report.artifacts.phase1ReleaseEvidenceDriftGatePath ?? "", /phase1-release-evidence-drift-gate-phase1-mainline-/);
   assert.match(report.artifacts.manualEvidenceLedgerPath ?? "", /manual-release-evidence-owner-ledger-phase1-mainline-/);
+  assert.match(report.artifacts.releaseReadinessDashboardPath ?? "", /release-readiness-dashboard-phase1-mainline-/);
   assert.match(report.artifacts.candidateEvidenceAuditPath ?? "", /candidate-evidence-audit-phase1-mainline-/);
   assert.match(report.artifacts.releaseEvidenceIndexPath ?? "", /current-release-evidence-index-phase1-mainline-/);
   assert.match(report.artifacts.phase1CandidateDossierPath ?? "", /phase1-candidate-dossier-phase1-mainline-/);
@@ -192,6 +193,11 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /# Phase 1 Candidate Rehearsal/);
   assert.match(markdown, /Release gate summary: `passed`/);
   assert.match(markdown, /Phase 1 dossier summary: `passed`/);
+  assert.match(markdown, /## Reviewer Front Door/);
+  assert.match(markdown, /Current release evidence index:/);
+  assert.match(markdown, /Candidate evidence audit:/);
+  assert.match(markdown, /Release readiness dashboard:/);
+  assert.match(markdown, /Manual evidence owner ledger:/);
   assert.match(markdown, /candidateEvidenceAuditPath:/);
   assert.match(markdown, /releaseEvidenceIndexPath:/);
   assert.match(markdown, /goNoGoPacketPath:/);


### PR DESCRIPTION
## Summary
- restage the same-revision bundle dashboard at the rehearsal bundle top level alongside the owner ledger
- add an explicit reviewer front-door section in the rehearsal summary for the evidence index, candidate audit, dashboard, and ledger
- update the rehearsal test and release-script inventory/docs to reflect the staged reviewer entrypoints

## Testing
- npm run test:phase1-candidate-rehearsal
- npm run test:release-script-inventory

Closes #1197