### PR TITLE
feat: unlock pve daily dungeon by default

### DIFF
--- a/configs/feature-flags.json
+++ b/configs/feature-flags.json
@@ -17,8 +17,8 @@
     },
     "pve_enabled": {
       "type": "boolean",
-      "value": false,
-      "defaultValue": false,
+      "value": true,
+      "defaultValue": true,
       "enabled": true,
       "rollout": 1
     },

--- a/packages/shared/src/feature-flags.ts
+++ b/packages/shared/src/feature-flags.ts
@@ -88,7 +88,7 @@ export interface ResolvedFeatureEntitlements {
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   quest_system_enabled: true,
   battle_pass_enabled: false,
-  pve_enabled: false,
+  pve_enabled: true,
   tutorial_enabled: true
 };
 
@@ -111,8 +111,8 @@ export const DEFAULT_FEATURE_FLAG_CONFIG: FeatureFlagConfigDocument = {
     },
     pve_enabled: {
       type: "boolean",
-      value: false,
-      defaultValue: false,
+      value: true,
+      defaultValue: true,
       enabled: true,
       rollout: DEFAULT_ROLLOUT
     },

--- a/packages/shared/test/feature-flags.test.ts
+++ b/packages/shared/test/feature-flags.test.ts
@@ -52,6 +52,11 @@ test("feature flags fall back to defaults when disabled", () => {
   assert.equal(evaluateFeatureFlags("player-1", config).tutorial_enabled, false);
 });
 
+test("default feature flags keep pve enabled", () => {
+  const flags = evaluateFeatureFlags("player-1", DEFAULT_FEATURE_FLAG_CONFIG);
+  assert.equal(flags.pve_enabled, true);
+});
+
 test("experiments assign stable buckets, respect whitelist, and fall back outside allocation", () => {
   const config = normalizeFeatureFlagConfigDocument({
     schemaVersion: 1,

--- a/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
+++ b/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
@@ -332,7 +332,7 @@
       "featureFlags": {
         "quest_system_enabled": true,
         "battle_pass_enabled": false,
-        "pve_enabled": false,
+        "pve_enabled": true,
         "tutorial_enabled": true
       },
       "reason": "battle.started"

--- a/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
+++ b/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
@@ -327,7 +327,7 @@
   "featureFlags": {
     "quest_system_enabled": true,
     "battle_pass_enabled": false,
-    "pve_enabled": false,
+    "pve_enabled": true,
     "tutorial_enabled": true
   },
   "reason": "battle.started"


### PR DESCRIPTION
Closes #1195

## Summary
- enable `pve_enabled` in the shared default feature flag config and bundled runtime config
- keep default client/session fixtures aligned with the unlocked PVE entitlement
- add a focused regression test that asserts default feature flags keep PVE enabled

## Validation
- `node --import tsx --test packages/shared/test/feature-flags.test.ts`
- `node --import tsx --test apps/server/test/feature-flags.test.ts`
- manual API E2E against `npm run dev:server`: reset store, guest login, get daily dungeon, attempt floors 1/2/3, claim final reward, verify repeat attempt returns `daily_dungeon_already_completed`
