### PR TITLE
[codex] Enable battle pass UI and reward coverage

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-progression-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-progression-panel.ts
@@ -278,7 +278,10 @@ function isTrackClaimable(tier: BattlePassTierConfig, progress: CocosSeasonProgr
 }
 
 function resolveVisibleTiers(config: ReturnType<typeof getBattlePassConfig>, progress: CocosSeasonProgress): BattlePassTierConfig[] {
-  const startTier = Math.max(1, Math.min(progress.seasonPassTier, Math.max(1, config.tiers.length - 3)));
+  const earliestRelevantTier = config.tiers.find(
+    (tier) => tier.tier <= progress.seasonPassTier && !progress.seasonPassClaimedTiers.includes(tier.tier)
+  )?.tier ?? progress.seasonPassTier;
+  const startTier = Math.max(1, Math.min(earliestRelevantTier, Math.max(1, config.tiers.length - 3)));
   return config.tiers.filter((tier) => tier.tier >= startTier).slice(0, 4);
 }
 
@@ -305,7 +308,8 @@ function resolveProgressRatio(config: ReturnType<typeof getBattlePassConfig>, pr
 
 function resolveNextRewardLabel(config: ReturnType<typeof getBattlePassConfig>, progress: CocosSeasonProgress): string {
   const nextTier =
-    config.tiers.find((tier) => !progress.seasonPassClaimedTiers.includes(tier.tier) && tier.tier >= progress.seasonPassTier)
+    config.tiers.find((tier) => !progress.seasonPassClaimedTiers.includes(tier.tier) && tier.tier <= progress.seasonPassTier)
+    ?? config.tiers.find((tier) => !progress.seasonPassClaimedTiers.includes(tier.tier) && tier.tier > progress.seasonPassTier)
     ?? config.tiers.find((tier) => tier.tier > progress.seasonPassTier)
     ?? config.tiers[config.tiers.length - 1];
   if (!nextTier) {

--- a/apps/cocos-client/test/cocos-progression-panel.test.ts
+++ b/apps/cocos-client/test/cocos-progression-panel.test.ts
@@ -64,7 +64,7 @@ test("VeilProgressionPanel renders battle pass rewards and routes taps to claim 
   pressNode(findNode(node, "BattlePassTrack-0-free"));
   pressNode(findNode(node, "BattlePassPremiumAction"));
 
-  assert.deepEqual(claimedTiers, [3]);
+  assert.deepEqual(claimedTiers, [2]);
   assert.equal(premiumPurchaseCount, 1);
 });
 
@@ -97,10 +97,29 @@ test("VeilProgressionPanel disables taps while a tier claim is pending", () => {
     })
   });
 
-  assert.match(readCardLabel(node, "BattlePassTrack-0-free"), /领取中/);
-  pressNode(findNode(node, "BattlePassTrack-0-free"));
+  assert.match(readCardLabel(node, "BattlePassTrack-1-free"), /领取中/);
+  pressNode(findNode(node, "BattlePassTrack-1-free"));
 
   assert.deepEqual(claimedTiers, []);
+});
+
+test("buildCocosBattlePassPanelView keeps earlier unlocked unclaimed tiers visible and prioritized", () => {
+  const view = buildCocosBattlePassPanelView({
+    progress: {
+      battlePassEnabled: true,
+      seasonXp: 2200,
+      seasonPassTier: 5,
+      seasonPassPremium: false,
+      seasonPassClaimedTiers: [1, 2, 5]
+    },
+    pendingClaimTier: null,
+    pendingPremiumPurchase: false,
+    statusLabel: "可领取历史段位奖励。"
+  });
+
+  assert.equal(view.tiers[0]?.tier, 3);
+  assert.equal(view.tiers[0]?.freeTrack.claimable, true);
+  assert.match(view.nextRewardLabel, /下一奖励 T3/);
 });
 
 test("buildCocosDailyDungeonPanelView surfaces claimable runs and leaderboard state", () => {

--- a/apps/server/test/battle-pass.test.ts
+++ b/apps/server/test/battle-pass.test.ts
@@ -175,6 +175,42 @@ test("battle pass premium rewards are withheld until premium unlock is purchased
   assert.deepEqual(archive?.hero.loadout.inventory ?? [], []);
 });
 
+test("battle pass claim grants premium rewards and persists them to the account", async () => {
+  const store = new MemoryRoomSnapshotStore();
+  await store.save("battle-pass-room", createBattlePassWorldSnapshot());
+  await store.savePlayerAccountProgress("battle-pass-player", {
+    seasonXpDelta: 2000,
+    seasonPassPremium: true
+  });
+  const payload = (await store.claimBattlePassTier("battle-pass-player", 5)) as {
+    tier: number;
+    granted: {
+      resources: { gold: number };
+      equipmentIds: string[];
+    };
+    seasonPassPremiumApplied: boolean;
+    account: {
+      seasonPassPremium: boolean;
+      seasonPassClaimedTiers: number[];
+      globalResources: { gold: number };
+    };
+  };
+  const account = await store.loadPlayerAccount("battle-pass-player");
+  const archive = (await store.loadPlayerHeroArchives(["battle-pass-player"]))[0];
+
+  assert.equal(payload.tier, 5);
+  assert.equal(payload.seasonPassPremiumApplied, true);
+  assert.equal(payload.granted.resources.gold, 500);
+  assert.deepEqual(payload.granted.equipmentIds, ["sunforged_spear"]);
+  assert.equal(payload.account.seasonPassPremium, true);
+  assert.deepEqual(payload.account.seasonPassClaimedTiers, [5]);
+  assert.equal(payload.account.globalResources.gold, 500);
+  assert.equal(account?.seasonPassPremium, true);
+  assert.deepEqual(account?.seasonPassClaimedTiers, [5]);
+  assert.equal(account?.globalResources.gold, 500);
+  assert.deepEqual(archive?.hero.loadout.inventory ?? [], ["sunforged_spear"]);
+});
+
 test("season pass premium shop purchase unlocks premium access", async (t) => {
   const port = 42540 + Math.floor(Math.random() * 1000);
   const store = new MemoryRoomSnapshotStore();

--- a/configs/feature-flags.json
+++ b/configs/feature-flags.json
@@ -10,8 +10,8 @@
     },
     "battle_pass_enabled": {
       "type": "boolean",
-      "value": false,
-      "defaultValue": false,
+      "value": true,
+      "defaultValue": true,
       "enabled": true,
       "rollout": 1
     },

--- a/docs/feature-flag-experiments-runbook.md
+++ b/docs/feature-flag-experiments-runbook.md
@@ -6,6 +6,8 @@ Issue #893 adds a minimal experiment layer on top of `configs/feature-flags.json
 
 - `quest_system_enabled`: enabled by default as of 2026-04-08. Daily quest board, UTC daily rotation, progress tracking, and reward claims are live in the default config.
 - Roll back `quest_system_enabled` by setting `value: false` in `configs/feature-flags.json`, or use `VEIL_FEATURE_FLAGS_JSON` / `VEIL_DAILY_QUESTS_ENABLED=off` as an emergency override while investigating.
+- `battle_pass_enabled`: enabled by default as of 2026-04-10. The Cocos season pass panel, season progress sync, and reward claim flow are live in the default config.
+- Roll back `battle_pass_enabled` by setting `value: false` in `configs/feature-flags.json`, or use `VEIL_FEATURE_FLAGS_JSON` as an emergency override while investigating.
 
 ## Config Shape
 

--- a/packages/shared/src/feature-flags.ts
+++ b/packages/shared/src/feature-flags.ts
@@ -87,7 +87,7 @@ export interface ResolvedFeatureEntitlements {
 
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   quest_system_enabled: true,
-  battle_pass_enabled: false,
+  battle_pass_enabled: true,
   pve_enabled: true,
   tutorial_enabled: true
 };
@@ -104,8 +104,8 @@ export const DEFAULT_FEATURE_FLAG_CONFIG: FeatureFlagConfigDocument = {
     },
     battle_pass_enabled: {
       type: "boolean",
-      value: false,
-      defaultValue: false,
+      value: true,
+      defaultValue: true,
       enabled: true,
       rollout: DEFAULT_ROLLOUT
     },

--- a/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
+++ b/packages/shared/test/fixtures/contract-snapshots/multiplayer-server-messages.json
@@ -105,6 +105,7 @@
             "id": "hero-2",
             "playerId": "player-2",
             "name": "霜牙掠影",
+            "level": 1,
             "position": {
               "x": 2,
               "y": 1
@@ -139,6 +140,7 @@
             "defense": 5,
             "minDamage": 1,
             "maxDamage": 3,
+            "attackRange": 1,
             "count": 12,
             "currentHp": 10,
             "maxHp": 10,
@@ -197,6 +199,7 @@
             "defense": 4,
             "minDamage": 2,
             "maxDamage": 4,
+            "attackRange": 1,
             "count": 8,
             "currentHp": 8,
             "maxHp": 8,
@@ -331,7 +334,7 @@
       ],
       "featureFlags": {
         "quest_system_enabled": true,
-        "battle_pass_enabled": false,
+        "battle_pass_enabled": true,
         "pve_enabled": true,
         "tutorial_enabled": true
       },

--- a/packages/shared/test/fixtures/contract-snapshots/runtime-diagnostics-snapshot.json
+++ b/packages/shared/test/fixtures/contract-snapshots/runtime-diagnostics-snapshot.json
@@ -73,6 +73,8 @@
       {
         "id": "hero-2",
         "playerId": "player-2",
+        "name": "敌方先锋",
+        "level": 3,
         "position": {
           "x": 2,
           "y": 1

--- a/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
+++ b/packages/shared/test/fixtures/contract-snapshots/session-state-payload.json
@@ -100,6 +100,7 @@
         "id": "hero-2",
         "playerId": "player-2",
         "name": "霜牙掠影",
+        "level": 1,
         "position": {
           "x": 2,
           "y": 1
@@ -134,6 +135,7 @@
         "defense": 5,
         "minDamage": 1,
         "maxDamage": 3,
+        "attackRange": 1,
         "count": 12,
         "currentHp": 10,
         "maxHp": 10,
@@ -192,6 +194,7 @@
         "defense": 4,
         "minDamage": 2,
         "maxDamage": 4,
+        "attackRange": 1,
         "count": 8,
         "currentHp": 8,
         "maxHp": 8,
@@ -326,7 +329,7 @@
   ],
   "featureFlags": {
     "quest_system_enabled": true,
-    "battle_pass_enabled": false,
+    "battle_pass_enabled": true,
     "pve_enabled": true,
     "tutorial_enabled": true
   },


### PR DESCRIPTION
## Summary
- enable `battle_pass_enabled` by default in the shared/default feature flag configs and document the rollout state
- keep the Cocos battle pass panel anchored on the earliest unlocked unclaimed tier so older rewards stay visible and claimable
- add focused regression coverage for the Cocos panel behavior and the server-side premium reward persistence path
- refresh affected shared contract snapshots after the feature-flag default flip and current serializer output

## Validation
- `node --import tsx --test ./apps/cocos-client/test/cocos-progression-panel.test.ts`
- `node --import tsx --test ./apps/server/test/battle-pass.test.ts`
- `UPDATE_CONTRACT_SNAPSHOTS=1 npm run test:contracts`

Closes #1194