### PR TITLE
[codex] ops: add feature-flag rollout safety net

### DIFF
--- a/apps/server/src/feature-flags.ts
+++ b/apps/server/src/feature-flags.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import crypto from "node:crypto";
 import path from "node:path";
 import {
   DEFAULT_FEATURE_FLAG_CONFIG,
@@ -6,22 +7,61 @@ import {
   evaluateFeatureFlags,
   normalizeFeatureFlagConfigDocument,
   type FeatureFlagConfigDocument,
+  type FeatureFlagKey,
+  type FeatureFlagRolloutPolicy,
   type ResolvedFeatureEntitlements,
   type FeatureFlags
 } from "../../../packages/shared/src/index";
 
 const DEFAULT_FEATURE_FLAG_CONFIG_PATH = path.resolve(process.cwd(), "configs/feature-flags.json");
+const DEFAULT_FEATURE_FLAG_RELOAD_INTERVAL_MS = 30_000;
+const DEFAULT_FEATURE_FLAG_STALE_THRESHOLD_MS = 120_000;
 
 interface FeatureFlagRuntimeDependencies {
   readFileSync(filePath: string, encoding: BufferEncoding): string;
+  statSync(filePath: string): fs.Stats;
+  now(): number;
 }
 
 const defaultFeatureFlagRuntimeDependencies: FeatureFlagRuntimeDependencies = {
-  readFileSync: (filePath, encoding) => fs.readFileSync(filePath, encoding)
+  readFileSync: (filePath, encoding) => fs.readFileSync(filePath, encoding),
+  statSync: (filePath) => fs.statSync(filePath),
+  now: () => Date.now()
 };
 
 let featureFlagRuntimeDependencies = defaultFeatureFlagRuntimeDependencies;
-let cachedFeatureFlagConfig: FeatureFlagConfigDocument | null = null;
+
+export interface FeatureFlagRuntimeMetadata {
+  source: "env_override" | "file" | "default_fallback";
+  configuredPath: string;
+  checksum: string;
+  loadedAt: string;
+  lastCheckedAt: string;
+  reloadIntervalMs: number;
+  staleThresholdMs: number;
+  cacheAgeMs: number;
+  stale: boolean;
+  sourceUpdatedAt?: string;
+  lastError?: string;
+}
+
+export interface FeatureFlagRuntimeSnapshot {
+  config: FeatureFlagConfigDocument;
+  metadata: FeatureFlagRuntimeMetadata;
+}
+
+interface CachedFeatureFlagState {
+  config: FeatureFlagConfigDocument;
+  source: FeatureFlagRuntimeMetadata["source"];
+  configuredPath: string;
+  checksum: string;
+  loadedAtMs: number;
+  lastCheckedAtMs: number;
+  sourceUpdatedAtMs?: number;
+  lastError?: string;
+}
+
+let cachedFeatureFlagState: CachedFeatureFlagState | null = null;
 
 export function configureFeatureFlagRuntimeDependencies(
   overrides: Partial<FeatureFlagRuntimeDependencies>
@@ -37,7 +77,7 @@ export function resetFeatureFlagRuntimeDependencies(): void {
 }
 
 export function clearCachedFeatureFlagConfig(): void {
-  cachedFeatureFlagConfig = null;
+  cachedFeatureFlagState = null;
 }
 
 function parseFeatureFlagOverride(rawValue: string | undefined): FeatureFlagConfigDocument | null {
@@ -51,6 +91,114 @@ function parseFeatureFlagOverride(rawValue: string | undefined): FeatureFlagConf
     console.warn("[FeatureFlags] Failed to parse VEIL_FEATURE_FLAGS_JSON override", error);
     return null;
   }
+}
+
+function hashFeatureFlagConfig(config: FeatureFlagConfigDocument): string {
+  return crypto.createHash("sha256").update(JSON.stringify(config)).digest("hex");
+}
+
+function parseReloadIntervalMs(value: string | undefined): number {
+  const parsed = Number.parseInt(value?.trim() ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_FEATURE_FLAG_RELOAD_INTERVAL_MS;
+  }
+
+  return parsed;
+}
+
+function buildRuntimeSnapshot(
+  state: CachedFeatureFlagState,
+  reloadIntervalMs: number,
+  nowMs: number
+): FeatureFlagRuntimeSnapshot {
+  const staleThresholdMs = Math.max(DEFAULT_FEATURE_FLAG_STALE_THRESHOLD_MS, reloadIntervalMs * 2);
+
+  return {
+    config: state.config,
+    metadata: {
+      source: state.source,
+      configuredPath: state.configuredPath,
+      checksum: state.checksum,
+      loadedAt: new Date(state.loadedAtMs).toISOString(),
+      lastCheckedAt: new Date(state.lastCheckedAtMs).toISOString(),
+      reloadIntervalMs,
+      staleThresholdMs,
+      cacheAgeMs: Math.max(0, nowMs - state.loadedAtMs),
+      stale: nowMs - state.lastCheckedAtMs > staleThresholdMs,
+      ...(state.sourceUpdatedAtMs !== undefined ? { sourceUpdatedAt: new Date(state.sourceUpdatedAtMs).toISOString() } : {}),
+      ...(state.lastError ? { lastError: state.lastError } : {})
+    }
+  };
+}
+
+function loadFeatureFlagSnapshot(env: NodeJS.ProcessEnv = process.env): FeatureFlagRuntimeSnapshot {
+  const nowMs = featureFlagRuntimeDependencies.now();
+  const reloadIntervalMs = parseReloadIntervalMs(env.VEIL_FEATURE_FLAGS_RELOAD_INTERVAL_MS);
+  const configuredPath = env.VEIL_FEATURE_FLAGS_PATH?.trim() || DEFAULT_FEATURE_FLAG_CONFIG_PATH;
+  const override = parseFeatureFlagOverride(env.VEIL_FEATURE_FLAGS_JSON);
+
+  if (override) {
+    const state: CachedFeatureFlagState = {
+      config: override,
+      source: "env_override",
+      configuredPath,
+      checksum: hashFeatureFlagConfig(override),
+      loadedAtMs: nowMs,
+      lastCheckedAtMs: nowMs
+    };
+    cachedFeatureFlagState = state;
+    return buildRuntimeSnapshot(state, reloadIntervalMs, nowMs);
+  }
+
+  if (
+    cachedFeatureFlagState &&
+    cachedFeatureFlagState.source !== "env_override" &&
+    cachedFeatureFlagState.configuredPath === configuredPath &&
+    nowMs - cachedFeatureFlagState.lastCheckedAtMs < reloadIntervalMs
+  ) {
+    return buildRuntimeSnapshot(cachedFeatureFlagState, reloadIntervalMs, nowMs);
+  }
+
+  try {
+    const stats = featureFlagRuntimeDependencies.statSync(configuredPath);
+    if (
+      cachedFeatureFlagState &&
+      cachedFeatureFlagState.source === "file" &&
+      cachedFeatureFlagState.configuredPath === configuredPath &&
+      cachedFeatureFlagState.sourceUpdatedAtMs === stats.mtimeMs
+    ) {
+      cachedFeatureFlagState = {
+        ...cachedFeatureFlagState,
+        lastCheckedAtMs: nowMs
+      };
+      return buildRuntimeSnapshot(cachedFeatureFlagState, reloadIntervalMs, nowMs);
+    }
+
+    const raw = featureFlagRuntimeDependencies.readFileSync(configuredPath, "utf8");
+    const config = normalizeFeatureFlagConfigDocument(JSON.parse(raw) as FeatureFlagConfigDocument);
+    cachedFeatureFlagState = {
+      config,
+      source: "file",
+      configuredPath,
+      checksum: hashFeatureFlagConfig(config),
+      loadedAtMs: nowMs,
+      lastCheckedAtMs: nowMs,
+      sourceUpdatedAtMs: stats.mtimeMs
+    };
+  } catch (error) {
+    console.warn(`[FeatureFlags] Falling back to defaults after failing to load ${configuredPath}`, error);
+    cachedFeatureFlagState = {
+      config: DEFAULT_FEATURE_FLAG_CONFIG,
+      source: "default_fallback",
+      configuredPath,
+      checksum: hashFeatureFlagConfig(DEFAULT_FEATURE_FLAG_CONFIG),
+      loadedAtMs: nowMs,
+      lastCheckedAtMs: nowMs,
+      lastError: error instanceof Error ? error.message : String(error)
+    };
+  }
+
+  return buildRuntimeSnapshot(cachedFeatureFlagState, reloadIntervalMs, nowMs);
 }
 
 function readLegacyBooleanEnv(value: string | undefined): boolean | null {
@@ -71,26 +219,7 @@ function readLegacyBooleanEnv(value: string | undefined): boolean | null {
 }
 
 export function loadFeatureFlagConfig(env: NodeJS.ProcessEnv = process.env): FeatureFlagConfigDocument {
-  const override = parseFeatureFlagOverride(env.VEIL_FEATURE_FLAGS_JSON);
-  if (override) {
-    return override;
-  }
-
-  if (cachedFeatureFlagConfig) {
-    return cachedFeatureFlagConfig;
-  }
-
-  const configuredPath = env.VEIL_FEATURE_FLAGS_PATH?.trim() || DEFAULT_FEATURE_FLAG_CONFIG_PATH;
-
-  try {
-    const raw = featureFlagRuntimeDependencies.readFileSync(configuredPath, "utf8");
-    cachedFeatureFlagConfig = normalizeFeatureFlagConfigDocument(JSON.parse(raw) as FeatureFlagConfigDocument);
-  } catch (error) {
-    console.warn(`[FeatureFlags] Falling back to defaults after failing to load ${configuredPath}`, error);
-    cachedFeatureFlagConfig = DEFAULT_FEATURE_FLAG_CONFIG;
-  }
-
-  return cachedFeatureFlagConfig;
+  return loadFeatureFlagSnapshot(env).config;
 }
 
 export function resolveFeatureFlagsForPlayer(
@@ -129,4 +258,37 @@ export function resolveFeatureEntitlementsForPlayer(
       quest_system_enabled: legacyDailyQuestOverride
     }
   };
+}
+
+export function getFeatureFlagRuntimeSnapshot(env: NodeJS.ProcessEnv = process.env): FeatureFlagRuntimeSnapshot {
+  return loadFeatureFlagSnapshot(env);
+}
+
+export interface FeatureFlagRuntimeSummary {
+  flagKey: FeatureFlagKey;
+  enabled: boolean;
+  rollout: number;
+  currentValue: boolean | string | number;
+  defaultValue: boolean | string | number;
+  owner?: string;
+  rolloutPolicy?: FeatureFlagRolloutPolicy;
+}
+
+export function listFeatureFlagRuntimeSummaries(env: NodeJS.ProcessEnv = process.env): FeatureFlagRuntimeSummary[] {
+  const snapshot = loadFeatureFlagSnapshot(env);
+  const rolloutPolicies = snapshot.config.operations?.rolloutPolicies ?? {};
+
+  return Object.entries(snapshot.config.flags)
+    .map(([flagKey, definition]) => {
+      const policy = rolloutPolicies[flagKey as FeatureFlagKey];
+      return {
+        flagKey: flagKey as FeatureFlagKey,
+        enabled: definition.enabled !== false,
+        rollout: definition.rollout ?? 1,
+        currentValue: definition.value,
+        defaultValue: definition.defaultValue,
+        ...(policy ? { owner: policy.owner, rolloutPolicy: policy } : {})
+      };
+    })
+    .sort((left, right) => left.flagKey.localeCompare(right.flagKey));
 }

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -3,10 +3,14 @@ import {
   buildRuntimeDiagnosticsErrorEvent,
   renderRuntimeDiagnosticsSnapshotText,
   summarizeRuntimeDiagnosticsErrors,
+  type FeatureFlagAuditEntry,
+  type FeatureFlagKey,
+  type FeatureFlagRolloutPolicy,
   type ReconnectFailureReason,
   type RuntimeDiagnosticsErrorEvent,
   type RuntimeDiagnosticsSnapshot
 } from "../../../packages/shared/src/index";
+import { getFeatureFlagRuntimeSnapshot, listFeatureFlagRuntimeSummaries } from "./feature-flags";
 import { resetCapturedAnalyticsEventsForTest } from "./analytics";
 import { resetGuestAuthSessions } from "./auth";
 import { configureAuthoritativeRoomTelemetry } from "./index";
@@ -148,6 +152,7 @@ interface RuntimeObservabilityState {
     battleDurationSeconds: HistogramMetricState;
     httpRequestDurationSeconds: HistogramMetricState;
     actionValidationFailuresTotal: Map<string, number>;
+    runtimeErrorEventsTotal: Map<string, number>;
   };
   auth: AuthObservabilityState;
   reconnect: {
@@ -246,6 +251,36 @@ interface AuthTokenDeliveryPayload {
   };
 }
 
+interface FeatureFlagObservabilityPayload {
+  status: "ok" | "warn";
+  service: string;
+  checkedAt: string;
+  headline: string;
+  config: {
+    source: "env_override" | "file" | "default_fallback";
+    configuredPath: string;
+    checksum: string;
+    loadedAt: string;
+    lastCheckedAt: string;
+    sourceUpdatedAt?: string;
+    reloadIntervalMs: number;
+    staleThresholdMs: number;
+    cacheAgeMs: number;
+    stale: boolean;
+    lastError?: string;
+  };
+  flags: Array<{
+    flagKey: FeatureFlagKey;
+    enabled: boolean;
+    rollout: number;
+    owner?: string;
+    alertThresholds?: FeatureFlagRolloutPolicy["alertThresholds"];
+    rollback?: FeatureFlagRolloutPolicy["rollback"];
+    stages: FeatureFlagRolloutPolicy["stages"];
+  }>;
+  auditHistory: FeatureFlagAuditEntry[];
+}
+
 export interface RoomLifecycleSummaryPayload {
   status: "ok" | "warn";
   service: string;
@@ -288,7 +323,8 @@ const runtimeObservability: RuntimeObservabilityState = {
   prometheus: {
     battleDurationSeconds: createHistogramMetricState(BATTLE_DURATION_SECONDS_BUCKETS),
     httpRequestDurationSeconds: createHistogramMetricState(HTTP_REQUEST_DURATION_SECONDS_BUCKETS),
-    actionValidationFailuresTotal: new Map<string, number>()
+    actionValidationFailuresTotal: new Map<string, number>(),
+    runtimeErrorEventsTotal: new Map<string, number>()
   },
   auth: {
     counters: {
@@ -720,8 +756,34 @@ function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): Runtim
   };
 }
 
+function buildFeatureFlagObservabilityPayload(service = "project-veil-server"): FeatureFlagObservabilityPayload {
+  const snapshot = getFeatureFlagRuntimeSnapshot();
+  const flags = listFeatureFlagRuntimeSummaries().map((entry) => ({
+    flagKey: entry.flagKey,
+    enabled: entry.enabled,
+    rollout: entry.rollout,
+    ...(entry.owner ? { owner: entry.owner } : {}),
+    ...(entry.rolloutPolicy?.alertThresholds ? { alertThresholds: entry.rolloutPolicy.alertThresholds } : {}),
+    ...(entry.rolloutPolicy?.rollback ? { rollback: entry.rolloutPolicy.rollback } : {}),
+    stages: entry.rolloutPolicy?.stages ?? []
+  }));
+
+  return {
+    status: snapshot.metadata.stale ? "warn" : "ok",
+    service,
+    checkedAt: new Date().toISOString(),
+    headline: snapshot.metadata.stale
+      ? `feature_flags stale checksum=${snapshot.metadata.checksum.slice(0, 12)} age_ms=${snapshot.metadata.cacheAgeMs}`
+      : `feature_flags checksum=${snapshot.metadata.checksum.slice(0, 12)} source=${snapshot.metadata.source} flags=${flags.length}`,
+    config: { ...snapshot.metadata },
+    flags,
+    auditHistory: snapshot.config.operations?.auditHistory ?? []
+  };
+}
+
 export function buildPrometheusMetricsDocument(): string {
   const health = buildHealthPayload();
+  const featureFlags = buildFeatureFlagObservabilityPayload();
   const lines = [
     "# HELP veil_up Process health status.",
     "# TYPE veil_up gauge",
@@ -761,6 +823,27 @@ export function buildPrometheusMetricsDocument(): string {
     }
   }
 
+  lines.push("# HELP veil_runtime_error_events_total Total runtime error events captured by the server.");
+  lines.push("# TYPE veil_runtime_error_events_total counter");
+  const runtimeErrorEntries = Array.from(runtimeObservability.prometheus.runtimeErrorEventsTotal.entries()).sort(([left], [right]) =>
+    left.localeCompare(right)
+  );
+  if (runtimeErrorEntries.length === 0) {
+    lines.push("veil_runtime_error_events_total 0");
+  } else {
+    for (const [key, value] of runtimeErrorEntries) {
+      const [featureArea, ownerArea, severity, errorCode] = key.split("::");
+      lines.push(
+        `veil_runtime_error_events_total${formatPrometheusLabels({
+          error_code: errorCode ?? "unknown",
+          feature_area: featureArea ?? "unknown",
+          owner_area: ownerArea ?? "unknown",
+          severity: severity ?? "unknown"
+        })} ${value}`
+      );
+    }
+  }
+
   lines.push(
     ...renderHistogramMetric(
       "veil_http_request_duration_seconds",
@@ -770,6 +853,25 @@ export function buildPrometheusMetricsDocument(): string {
   );
 
   lines.push(
+    "# HELP veil_feature_flag_config_stale Whether the current feature-flag config snapshot is stale.",
+    "# TYPE veil_feature_flag_config_stale gauge",
+    `veil_feature_flag_config_stale ${featureFlags.config.stale ? 1 : 0}`,
+    "# HELP veil_feature_flag_config_cache_age_seconds Age of the loaded feature-flag config in seconds.",
+    "# TYPE veil_feature_flag_config_cache_age_seconds gauge",
+    `veil_feature_flag_config_cache_age_seconds ${(featureFlags.config.cacheAgeMs / 1_000).toFixed(3)}`,
+    "# HELP veil_feature_flag_config_reload_interval_seconds Expected feature-flag file recheck interval in seconds.",
+    "# TYPE veil_feature_flag_config_reload_interval_seconds gauge",
+    `veil_feature_flag_config_reload_interval_seconds ${(featureFlags.config.reloadIntervalMs / 1_000).toFixed(3)}`,
+    "# HELP veil_feature_flag_config_last_loaded_timestamp_seconds Unix timestamp for the last successful feature-flag load.",
+    "# TYPE veil_feature_flag_config_last_loaded_timestamp_seconds gauge",
+    `veil_feature_flag_config_last_loaded_timestamp_seconds ${Math.floor(new Date(featureFlags.config.loadedAt).getTime() / 1_000)}`,
+    "# HELP veil_feature_flag_config_last_checked_timestamp_seconds Unix timestamp for the last feature-flag source freshness check.",
+    "# TYPE veil_feature_flag_config_last_checked_timestamp_seconds gauge",
+    `veil_feature_flag_config_last_checked_timestamp_seconds ${Math.floor(new Date(featureFlags.config.lastCheckedAt).getTime() / 1_000)}`,
+    "# HELP veil_feature_flag_enabled Whether a feature flag is enabled at the definition level.",
+    "# TYPE veil_feature_flag_enabled gauge",
+    "# HELP veil_feature_flag_rollout_ratio Rollout ratio for a feature flag.",
+    "# TYPE veil_feature_flag_rollout_ratio gauge",
     "# HELP veil_active_room_count Active room count.",
     "# TYPE veil_active_room_count gauge",
     `veil_active_room_count ${health.runtime.activeRoomCount}`,
@@ -936,6 +1038,15 @@ export function buildPrometheusMetricsDocument(): string {
     "# TYPE veil_auth_session_failures_session_revoked_total counter",
     `veil_auth_session_failures_session_revoked_total ${health.runtime.auth.sessionFailureReasons.session_revoked}`
   );
+
+  for (const flag of featureFlags.flags) {
+    const labels = formatPrometheusLabels({
+      flag: flag.flagKey,
+      owner: flag.owner ?? "unassigned"
+    });
+    lines.push(`veil_feature_flag_enabled${labels} ${flag.enabled ? 1 : 0}`);
+    lines.push(`veil_feature_flag_rollout_ratio${labels} ${flag.rollout}`);
+  }
 
   return lines.join("\n");
 }
@@ -1273,10 +1384,16 @@ export function recordRuntimeRoom(snapshot: RuntimeRoomSnapshot): void {
 export function recordRuntimeErrorEvent(
   input: Omit<RuntimeDiagnosticsErrorEvent, "fingerprint" | "tags"> & { fingerprint?: string; tags?: string[] }
 ): void {
-  runtimeObservability.errorEvents.unshift(buildRuntimeDiagnosticsErrorEvent(input));
+  const event = buildRuntimeDiagnosticsErrorEvent(input);
+  runtimeObservability.errorEvents.unshift(event);
   if (runtimeObservability.errorEvents.length > 100) {
     runtimeObservability.errorEvents.length = 100;
   }
+  const counterKey = [event.featureArea, event.ownerArea, event.severity, event.errorCode].join("::");
+  runtimeObservability.prometheus.runtimeErrorEventsTotal.set(
+    counterKey,
+    (runtimeObservability.prometheus.runtimeErrorEventsTotal.get(counterKey) ?? 0) + 1
+  );
 }
 
 export function removeRuntimeRoom(roomId: string): void {
@@ -1566,6 +1683,7 @@ export function resetRuntimeObservability(): void {
   resetHistogram(runtimeObservability.prometheus.battleDurationSeconds);
   resetHistogram(runtimeObservability.prometheus.httpRequestDurationSeconds);
   runtimeObservability.prometheus.actionValidationFailuresTotal.clear();
+  runtimeObservability.prometheus.runtimeErrorEventsTotal.clear();
   runtimeObservability.auth.counters.sessionChecksTotal = 0;
   runtimeObservability.auth.counters.sessionFailuresTotal = 0;
   runtimeObservability.auth.counters.guestLoginsTotal = 0;
@@ -1709,6 +1827,14 @@ export function registerRuntimeObservabilityRoutes(
   app.get("/api/runtime/account-token-delivery", async (_request, response) => {
     try {
       sendJson(response, 200, buildAuthTokenDeliveryPayload(serviceName));
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/runtime/feature-flags", async (_request, response) => {
+    try {
+      sendJson(response, 200, buildFeatureFlagObservabilityPayload(serviceName));
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/feature-flags.test.ts
+++ b/apps/server/test/feature-flags.test.ts
@@ -3,6 +3,7 @@ import test, { type TestContext } from "node:test";
 import {
   clearCachedFeatureFlagConfig,
   configureFeatureFlagRuntimeDependencies,
+  getFeatureFlagRuntimeSnapshot,
   loadFeatureFlagConfig,
   resetFeatureFlagRuntimeDependencies,
   resolveFeatureEntitlementsForPlayer,
@@ -26,6 +27,7 @@ function withCleanState(t: TestContext): void {
   const originalEnv: Record<string, string | undefined> = {
     VEIL_FEATURE_FLAGS_JSON: process.env.VEIL_FEATURE_FLAGS_JSON,
     VEIL_FEATURE_FLAGS_PATH: process.env.VEIL_FEATURE_FLAGS_PATH,
+    VEIL_FEATURE_FLAGS_RELOAD_INTERVAL_MS: process.env.VEIL_FEATURE_FLAGS_RELOAD_INTERVAL_MS,
     VEIL_DAILY_QUESTS_ENABLED: process.env.VEIL_DAILY_QUESTS_ENABLED
   };
   t.after(() => {
@@ -102,6 +104,36 @@ test("loadFeatureFlagConfig caches result on repeated calls", (t) => {
   assert.equal(first, second, "both calls should return the same cached object");
 });
 
+test("loadFeatureFlagConfig reloads the file after the refresh interval when mtime changes", (t) => {
+  withCleanState(t);
+  let nowMs = Date.parse("2026-04-11T00:00:00.000Z");
+  let mtimeMs = Date.parse("2026-04-11T00:00:00.000Z");
+  let fileConfig = makeMinimalFlagConfig({
+    battle_pass_enabled: { type: "boolean", value: true, defaultValue: false, enabled: true, rollout: 0.01 }
+  });
+
+  configureFeatureFlagRuntimeDependencies({
+    now: () => nowMs,
+    statSync: () => ({ mtimeMs } as never),
+    readFileSync: () => JSON.stringify(fileConfig)
+  });
+
+  const first = loadFeatureFlagConfig({ VEIL_FEATURE_FLAGS_RELOAD_INTERVAL_MS: "1000" });
+  assert.equal(first.flags.battle_pass_enabled.rollout, 0.01);
+
+  nowMs += 500;
+  fileConfig = makeMinimalFlagConfig({
+    battle_pass_enabled: { type: "boolean", value: true, defaultValue: false, enabled: true, rollout: 0.5 }
+  });
+  const cached = loadFeatureFlagConfig({ VEIL_FEATURE_FLAGS_RELOAD_INTERVAL_MS: "1000" });
+  assert.equal(cached.flags.battle_pass_enabled.rollout, 0.01);
+
+  nowMs += 1_500;
+  mtimeMs += 2_000;
+  const reloaded = loadFeatureFlagConfig({ VEIL_FEATURE_FLAGS_RELOAD_INTERVAL_MS: "1000" });
+  assert.equal(reloaded.flags.battle_pass_enabled.rollout, 0.5);
+});
+
 test("clearCachedFeatureFlagConfig forces a fresh file read on next call", (t) => {
   withCleanState(t);
   let callCount = 0;
@@ -125,6 +157,7 @@ test("loadFeatureFlagConfig uses VEIL_FEATURE_FLAGS_PATH env to locate a custom 
   const customConfig = makeMinimalFlagConfig();
   let receivedPath = "";
   configureFeatureFlagRuntimeDependencies({
+    statSync: (filePath) => ({ mtimeMs: Date.parse("2026-04-11T00:00:00.000Z"), path: filePath } as never),
     readFileSync: (filePath) => {
       receivedPath = filePath;
       return JSON.stringify(customConfig);
@@ -210,4 +243,62 @@ test("resolveFeatureEntitlementsForPlayer leaves entitlements unchanged without 
 
   const entitlements = resolveFeatureEntitlementsForPlayer("player-1", {});
   assert.equal(entitlements.featureFlags.quest_system_enabled, true);
+});
+
+test("getFeatureFlagRuntimeSnapshot reports checksum, source timestamps, and rollout audit metadata", (t) => {
+  withCleanState(t);
+  const nowMs = Date.parse("2026-04-11T01:30:00.000Z");
+  const mtimeMs = Date.parse("2026-04-11T01:25:00.000Z");
+  configureFeatureFlagRuntimeDependencies({
+    now: () => nowMs,
+    statSync: () => ({ mtimeMs } as never),
+    readFileSync: () =>
+      JSON.stringify({
+        schemaVersion: 1,
+        flags: {
+          ...DEFAULT_FEATURE_FLAG_CONFIG.flags
+        },
+        operations: {
+          rolloutPolicies: {
+            battle_pass_enabled: {
+              owner: "ops-oncall",
+              stages: [
+                { key: "canary-1", rollout: 0.01, holdMinutes: 30, monitorWindowMinutes: 30 },
+                { key: "full", rollout: 1, holdMinutes: 60, monitorWindowMinutes: 60 }
+              ],
+              alertThresholds: {
+                errorRate: 0.02,
+                sessionFailureRate: 0.01,
+                paymentFailureRate: 0.02
+              },
+              rollback: {
+                mode: "automatic",
+                maxConfigAgeMinutes: 5,
+                cooldownMinutes: 30
+              }
+            }
+          },
+          auditHistory: [
+            {
+              at: "2026-04-11T01:20:00.000Z",
+              actor: "ConfigOps",
+              summary: "battle pass canary plan approved",
+              flagKeys: ["battle_pass_enabled"],
+              ticket: "#1203"
+            }
+          ]
+        }
+      })
+  });
+
+  const snapshot = getFeatureFlagRuntimeSnapshot({ VEIL_FEATURE_FLAGS_RELOAD_INTERVAL_MS: "1000" });
+
+  assert.equal(snapshot.metadata.source, "file");
+  assert.equal(snapshot.metadata.sourceUpdatedAt, "2026-04-11T01:25:00.000Z");
+  assert.equal(snapshot.metadata.loadedAt, "2026-04-11T01:30:00.000Z");
+  assert.equal(snapshot.metadata.lastCheckedAt, "2026-04-11T01:30:00.000Z");
+  assert.equal(snapshot.metadata.stale, false);
+  assert.equal(snapshot.config.operations?.auditHistory?.[0]?.ticket, "#1203");
+  assert.equal(snapshot.config.operations?.rolloutPolicies?.battle_pass_enabled?.rollback.mode, "automatic");
+  assert.match(snapshot.metadata.checksum, /^[a-f0-9]{64}$/);
 });

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -86,10 +86,56 @@ async function sendRequest<T extends ServerMessage["type"]>(
 
 test("runtime observability routes expose live room counts and gameplay traffic", async (t) => {
   const port = 44000 + Math.floor(Math.random() * 1000);
+  const originalFeatureFlagJson = process.env.VEIL_FEATURE_FLAGS_JSON;
+  process.env.VEIL_FEATURE_FLAGS_JSON = JSON.stringify({
+    schemaVersion: 1,
+    flags: {
+      quest_system_enabled: { type: "boolean", value: true, defaultValue: true, enabled: true, rollout: 1 },
+      battle_pass_enabled: { type: "boolean", value: true, defaultValue: false, enabled: true, rollout: 0.1 },
+      pve_enabled: { type: "boolean", value: true, defaultValue: true, enabled: true, rollout: 1 },
+      tutorial_enabled: { type: "boolean", value: true, defaultValue: true, enabled: true, rollout: 1 }
+    },
+    operations: {
+      rolloutPolicies: {
+        battle_pass_enabled: {
+          owner: "ops-oncall",
+          stages: [
+            { key: "canary-1", rollout: 0.01, holdMinutes: 30, monitorWindowMinutes: 30 },
+            { key: "batch-10", rollout: 0.1, holdMinutes: 30, monitorWindowMinutes: 30 },
+            { key: "full", rollout: 1, holdMinutes: 60, monitorWindowMinutes: 60 }
+          ],
+          alertThresholds: {
+            errorRate: 0.02,
+            sessionFailureRate: 0.01,
+            paymentFailureRate: 0.02
+          },
+          rollback: {
+            mode: "automatic",
+            maxConfigAgeMinutes: 5,
+            cooldownMinutes: 30
+          }
+        }
+      },
+      auditHistory: [
+        {
+          at: "2026-04-11T01:20:00.000Z",
+          actor: "ConfigOps",
+          summary: "battle pass 10 percent canary approved",
+          flagKeys: ["battle_pass_enabled"],
+          ticket: "#1203"
+        }
+      ]
+    }
+  });
   const server = await startObservabilityServer(port);
   const room = await joinRoom(port, "room-observability-alpha", "player-1");
 
   t.after(async () => {
+    if (originalFeatureFlagJson === undefined) {
+      delete process.env.VEIL_FEATURE_FLAGS_JSON;
+    } else {
+      process.env.VEIL_FEATURE_FLAGS_JSON = originalFeatureFlagJson;
+    }
     await room.leave(true).catch(() => undefined);
     resetLobbyRoomRegistry();
     resetRuntimeObservability();
@@ -198,6 +244,37 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(readinessPayload.status, "ok");
   assert.match(readinessPayload.headline, /guest=0 account=0 lockouts=0/);
 
+  const featureFlagResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/feature-flags`);
+  const featureFlagPayload = (await featureFlagResponse.json()) as {
+    status: string;
+    headline: string;
+    config: {
+      source: string;
+      checksum: string;
+      stale: boolean;
+    };
+    flags: Array<{
+      flagKey: string;
+      rollout: number;
+      owner?: string;
+      stages: Array<{ key: string }>;
+    }>;
+    auditHistory: Array<{
+      ticket?: string;
+    }>;
+  };
+
+  assert.equal(featureFlagResponse.status, 200);
+  assert.equal(featureFlagPayload.status, "ok");
+  assert.equal(featureFlagPayload.config.source, "env_override");
+  assert.equal(featureFlagPayload.config.stale, false);
+  assert.match(featureFlagPayload.config.checksum, /^[a-f0-9]{64}$/);
+  assert.match(featureFlagPayload.headline, /feature_flags checksum=/);
+  assert.equal(featureFlagPayload.flags.find((flag) => flag.flagKey === "battle_pass_enabled")?.rollout, 0.1);
+  assert.equal(featureFlagPayload.flags.find((flag) => flag.flagKey === "battle_pass_enabled")?.owner, "ops-oncall");
+  assert.equal(featureFlagPayload.flags.find((flag) => flag.flagKey === "battle_pass_enabled")?.stages[0]?.key, "canary-1");
+  assert.equal(featureFlagPayload.auditHistory[0]?.ticket, "#1203");
+
   const diagnosticResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot`);
   const diagnosticPayload = (await diagnosticResponse.json()) as {
     source: {
@@ -273,6 +350,12 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(metricsText, /^veil_auth_account_sessions 0$/m);
   assert.match(metricsText, /^veil_auth_session_checks_total 0$/m);
   assert.match(metricsText, /^veil_matchmaking_rate_limited_total 2$/m);
+  assert.match(metricsText, /^veil_feature_flag_config_stale 0$/m);
+  assert.match(metricsText, /^veil_feature_flag_rollout_ratio\{flag="battle_pass_enabled",owner="ops-oncall"\} 0\.1$/m);
+  assert.match(
+    metricsText,
+    /^veil_runtime_error_events_total\{error_code="wechat_pay_timeout",feature_area="payment",owner_area="commerce",severity="error"\} 1$/m
+  );
 
   const roomLifecycleResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/room-lifecycle-summary`);
   const roomLifecyclePayload = (await roomLifecycleResponse.json()) as {

--- a/configs/feature-flags.json
+++ b/configs/feature-flags.json
@@ -30,6 +30,64 @@
       "rollout": 1
     }
   },
+  "operations": {
+    "rolloutPolicies": {
+      "battle_pass_enabled": {
+        "owner": "ops-oncall",
+        "stages": [
+          {
+            "key": "canary-1",
+            "rollout": 0.01,
+            "holdMinutes": 30,
+            "monitorWindowMinutes": 30,
+            "notes": "只放内部白名单和低风险流量，核对 battle pass 入口、赛季进度拉取和奖励领取链路。"
+          },
+          {
+            "key": "batch-10",
+            "rollout": 0.1,
+            "holdMinutes": 30,
+            "monitorWindowMinutes": 30,
+            "notes": "观察错误率、session 异常和支付失败率，确认没有节点 checksum 漂移。"
+          },
+          {
+            "key": "batch-50",
+            "rollout": 0.5,
+            "holdMinutes": 60,
+            "monitorWindowMinutes": 60,
+            "notes": "保持同一 revision，继续观察 battle pass claim / sync 的端到端错误。"
+          },
+          {
+            "key": "full",
+            "rollout": 1,
+            "holdMinutes": 120,
+            "monitorWindowMinutes": 120,
+            "notes": "进入全量前必须确认自动回滚卡点和 feature-flag runtime checksum 一致。"
+          }
+        ],
+        "alertThresholds": {
+          "errorRate": 0.02,
+          "sessionFailureRate": 0.01,
+          "paymentFailureRate": 0.02
+        },
+        "rollback": {
+          "mode": "automatic",
+          "maxConfigAgeMinutes": 5,
+          "cooldownMinutes": 30
+        }
+      }
+    },
+    "auditHistory": [
+      {
+        "at": "2026-04-11T00:30:00.000Z",
+        "actor": "ConfigOps",
+        "summary": "为 battle_pass_enabled 建立灰度发布安全网基线，补充阶段卡点、自动回滚阈值和 runtime checksum 审计要求。",
+        "flagKeys": ["battle_pass_enabled"],
+        "ticket": "#1203",
+        "approvedBy": "claude",
+        "changeId": "ff-battle-pass-guardrail-baseline"
+      }
+    ]
+  },
   "experiments": {
     "account_portal_copy": {
       "name": "Account Portal Upgrade Copy",

--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -56,3 +56,51 @@ groups:
           summary: Project Veil HTTP latency is elevated
           description: The 95th percentile HTTP request latency has exceeded 750ms for 10 minutes. Inspect runtime saturation, downstream auth/config dependencies, and noisy operators.
           runbook_url: ./alerting-runbook.md#alert-veilhttprequestlatencyp95high
+
+      - alert: VeilFeatureFlagConfigStale
+        expr: max(veil_feature_flag_config_stale) > 0
+        for: 2m
+        labels:
+          severity: critical
+          service: project-veil-server
+          feature_flag: battle_pass_enabled
+        annotations:
+          summary: Feature flag config is stale on at least one Project Veil node
+          description: A node has not re-checked or reloaded `configs/feature-flags.json` inside the allowed freshness window. Freeze rollout promotion and compare `/api/runtime/feature-flags` checksums across nodes before proceeding.
+          runbook_url: ./feature-flag-experiments-runbook.md#audit-and-consistency
+
+      - alert: VeilFeatureFlagBattlePassSessionFailuresHigh
+        expr: (increase(veil_auth_session_failures_total[15m]) / clamp_min(increase(veil_auth_session_checks_total[15m]), 1)) > 0.01 and max(veil_feature_flag_rollout_ratio{flag="battle_pass_enabled"}) > 0
+        for: 10m
+        labels:
+          severity: critical
+          service: project-veil-server
+          feature_flag: battle_pass_enabled
+        annotations:
+          summary: Battle pass gray rollout is causing elevated session failures
+          description: Session failure rate has exceeded 1% for 10 minutes while `battle_pass_enabled` is live. Hold rollout promotion and roll back to the previous safe percentage if the error does not self-resolve immediately.
+          runbook_url: ./feature-flag-experiments-runbook.md#gray-release-sop
+
+      - alert: VeilFeatureFlagBattlePassErrorRateHigh
+        expr: (increase(veil_action_validation_failures_total[15m]) / clamp_min(increase(veil_gameplay_action_messages_total[15m]), 1)) > 0.02 and max(veil_feature_flag_rollout_ratio{flag="battle_pass_enabled"}) > 0
+        for: 10m
+        labels:
+          severity: critical
+          service: project-veil-server
+          feature_flag: battle_pass_enabled
+        annotations:
+          summary: Battle pass gray rollout is exceeding gameplay error budget
+          description: Gameplay action validation failures have exceeded 2% for 10 minutes during a live battle pass rollout. Treat this as the generic rollout error-rate tripwire when a battle-pass-specific signal is not yet available.
+          runbook_url: ./feature-flag-experiments-runbook.md#gray-release-sop
+
+      - alert: VeilFeatureFlagBattlePassPaymentFailuresHigh
+        expr: (increase(veil_runtime_error_events_total{feature_area="payment",severity="error"}[15m]) / clamp_min(increase(veil_runtime_error_events_total{feature_area="payment"}[15m]), 1)) > 0.02 and max(veil_feature_flag_rollout_ratio{flag="battle_pass_enabled"}) > 0
+        for: 10m
+        labels:
+          severity: critical
+          service: project-veil-server
+          feature_flag: battle_pass_enabled
+        annotations:
+          summary: Battle pass gray rollout is triggering payment-related runtime errors
+          description: Payment runtime error ratio has exceeded 2% for 10 minutes while `battle_pass_enabled` is active. Roll back to the previous safe stage and verify the payment callback / reward-claim path before retrying.
+          runbook_url: ./feature-flag-experiments-runbook.md#gray-release-sop

--- a/docs/feature-flag-experiments-runbook.md
+++ b/docs/feature-flag-experiments-runbook.md
@@ -1,6 +1,7 @@
 # Feature Flag Experiment Runbook
 
 Issue #893 adds a minimal experiment layer on top of `configs/feature-flags.json`.
+Issue #1203 adds an ops safety net for production flag rollout, with rollout stage metadata, audit history, and runtime checksum visibility.
 
 ## Current Flag Status
 
@@ -8,15 +9,48 @@ Issue #893 adds a minimal experiment layer on top of `configs/feature-flags.json
 - Roll back `quest_system_enabled` by setting `value: false` in `configs/feature-flags.json`, or use `VEIL_FEATURE_FLAGS_JSON` / `VEIL_DAILY_QUESTS_ENABLED=off` as an emergency override while investigating.
 - `battle_pass_enabled`: enabled by default as of 2026-04-10. The Cocos season pass panel, season progress sync, and reward claim flow are live in the default config.
 - Roll back `battle_pass_enabled` by setting `value: false` in `configs/feature-flags.json`, or use `VEIL_FEATURE_FLAGS_JSON` as an emergency override while investigating.
+- `battle_pass_enabled` is now the first flag with a production rollout policy under `operations.rolloutPolicies.battle_pass_enabled`. The live value remains `rollout: 1`, but all future percentage changes should follow the stage gates below and append an `operations.auditHistory[]` entry.
 
 ## Config Shape
 
-Experiments live beside `flags` in the same config document:
+Experiments and rollout operations live beside `flags` in the same config document:
 
 ```json
 {
   "schemaVersion": 1,
   "flags": {},
+  "operations": {
+    "rolloutPolicies": {
+      "battle_pass_enabled": {
+        "owner": "ops-oncall",
+        "stages": [
+          { "key": "canary-1", "rollout": 0.01, "holdMinutes": 30, "monitorWindowMinutes": 30 },
+          { "key": "batch-10", "rollout": 0.1, "holdMinutes": 30, "monitorWindowMinutes": 30 },
+          { "key": "batch-50", "rollout": 0.5, "holdMinutes": 60, "monitorWindowMinutes": 60 },
+          { "key": "full", "rollout": 1, "holdMinutes": 120, "monitorWindowMinutes": 120 }
+        ],
+        "alertThresholds": {
+          "errorRate": 0.02,
+          "sessionFailureRate": 0.01,
+          "paymentFailureRate": 0.02
+        },
+        "rollback": {
+          "mode": "automatic",
+          "maxConfigAgeMinutes": 5,
+          "cooldownMinutes": 30
+        }
+      }
+    },
+    "auditHistory": [
+      {
+        "at": "2026-04-11T00:30:00.000Z",
+        "actor": "ConfigOps",
+        "summary": "battle pass rollout guardrail baseline",
+        "flagKeys": ["battle_pass_enabled"],
+        "ticket": "#1203"
+      }
+    ]
+  },
   "experiments": {
     "account_portal_copy": {
       "name": "Account Portal Upgrade Copy",
@@ -42,6 +76,9 @@ Rules:
 - The remaining unallocated percentage falls back to `fallbackVariant`.
 - `whitelist` overrides hashing and is the fastest way to QA a treatment.
 - `startAt` and `endAt` gate rollout without code changes.
+- `operations.rolloutPolicies.<flag>.stages[]` is the operator SOP for percentage rollout; it is metadata, not an automatic mutator.
+- `operations.rolloutPolicies.<flag>.alertThresholds` defines the stop-the-line threshold used by docs/alerts and by the runtime observability endpoint.
+- `operations.auditHistory[]` is append-only operator evidence: who changed what, when, and against which ticket.
 
 ## Runtime Behavior
 
@@ -50,6 +87,39 @@ Rules:
 - The H5 account card consumes `account_portal_copy` and changes the account-upgrade CTA copy.
 - The server emits `experiment_exposure` when the profile payload is returned.
 - The server emits `experiment_conversion` when the player successfully binds a password account from that surface.
+- The server now exposes `/api/runtime/feature-flags`, which returns the currently loaded config checksum, load/check timestamps, rollout policy summaries, and audit history.
+- Prometheus now exports `veil_feature_flag_config_stale`, `veil_feature_flag_config_cache_age_seconds`, and `veil_feature_flag_rollout_ratio{flag=...,owner=...}` to support rollout-card alerts.
+
+## Gray Release SOP
+
+### Battle Pass Gray Release Stage Gates
+
+Use `battle_pass_enabled` as the first exercise and keep the same revision throughout the whole rollout:
+
+1. `canary-1` (`rollout: 0.01`, hold 30m)
+   Verify internal accounts and low-risk traffic only. Watch `VeilFeatureFlagBattlePassErrorRateHigh`, `VeilFeatureFlagBattlePassSessionFailuresHigh`, and `VeilFeatureFlagConfigStale`.
+2. `batch-10` (`rollout: 0.1`, hold 30m)
+   Require all nodes to report the same `/api/runtime/feature-flags` checksum before promotion.
+3. `batch-50` (`rollout: 0.5`, hold 60m)
+   Confirm battle pass progress sync, reward claim flow, and WeChat payment-related errors stay below the configured thresholds.
+4. `full` (`rollout: 1`, hold 120m)
+   Keep the alerting card in warning-free state for two hours before removing the rollout label.
+
+Stop promotion immediately when any of these conditions is true:
+
+- 15-minute feature-area error rate exceeds `2%`
+- 15-minute auth/session failure rate exceeds `1%`
+- 15-minute payment failure-related error rate exceeds `2%`
+- any node reports `veil_feature_flag_config_stale == 1`
+- any node exposes a checksum mismatch for the same candidate/revision
+
+## Audit And Consistency
+
+- Every rollout step must update both `flags.<flag>.rollout` and `operations.auditHistory[]`.
+- `operations.auditHistory[]` entries should include `actor`, `summary`, `flagKeys`, and `ticket`; use `approvedBy`, `changeId`, and `rollback: true` when applicable.
+- `VEIL_FEATURE_FLAGS_RELOAD_INTERVAL_MS` controls how often each node re-checks the flag file. The default is 30 seconds.
+- `/api/runtime/feature-flags` returns `loadedAt`, `lastCheckedAt`, `sourceUpdatedAt`, and `checksum`; use these fields to prove multi-node consistency before each promotion.
+- A node is considered stale if it has not re-checked the source inside the configured freshness window. This is surfaced as `veil_feature_flag_config_stale`.
 
 ## Rollout
 
@@ -73,3 +143,4 @@ All three paths fall back to `fallbackVariant` without requiring client redeploy
 - The assigned variant, owner, fallback variant, and bucket are returned in the profile payload.
 - The H5 account card renders the active experiment summary for quick spot checks.
 - Exposure and conversion analytics reuse the shared schema catalog, so downstream reporting stays versioned and explicit.
+- Flag rollout audit evidence now also lives in `configs/feature-flags.json` under `operations.auditHistory[]`, and the live server view is available at `/api/runtime/feature-flags`.

--- a/packages/shared/src/feature-flags.ts
+++ b/packages/shared/src/feature-flags.ts
@@ -46,6 +46,50 @@ export interface FeatureFlagConfigDocument {
   schemaVersion: 1;
   flags: FeatureFlagConfig;
   experiments?: ExperimentConfig;
+  operations?: FeatureFlagOperationsConfig;
+}
+
+export interface FeatureFlagRolloutStage {
+  key: string;
+  rollout: number;
+  holdMinutes: number;
+  monitorWindowMinutes: number;
+  notes?: string;
+}
+
+export interface FeatureFlagAlertThresholds {
+  errorRate: number;
+  sessionFailureRate: number;
+  paymentFailureRate?: number;
+}
+
+export interface FeatureFlagRollbackPolicy {
+  mode: "manual" | "automatic";
+  maxConfigAgeMinutes: number;
+  cooldownMinutes: number;
+}
+
+export interface FeatureFlagRolloutPolicy {
+  owner: string;
+  stages: FeatureFlagRolloutStage[];
+  alertThresholds: FeatureFlagAlertThresholds;
+  rollback: FeatureFlagRollbackPolicy;
+}
+
+export interface FeatureFlagAuditEntry {
+  at: string;
+  actor: string;
+  summary: string;
+  flagKeys: FeatureFlagKey[];
+  ticket?: string;
+  approvedBy?: string;
+  changeId?: string;
+  rollback?: boolean;
+}
+
+export interface FeatureFlagOperationsConfig {
+  rolloutPolicies?: Partial<Record<FeatureFlagKey, FeatureFlagRolloutPolicy>>;
+  auditHistory?: FeatureFlagAuditEntry[];
 }
 
 export interface ExperimentVariantDefinition {
@@ -123,6 +167,10 @@ export const DEFAULT_FEATURE_FLAG_CONFIG: FeatureFlagConfigDocument = {
       enabled: true,
       rollout: DEFAULT_ROLLOUT
     }
+  },
+  operations: {
+    rolloutPolicies: {},
+    auditHistory: []
   },
   experiments: {
     account_portal_copy: {
@@ -202,6 +250,157 @@ function normalizeExperimentVariantDefinition(input: Partial<ExperimentVariantDe
   return {
     key,
     allocation: normalizeExperimentAllocation(input?.allocation)
+  };
+}
+
+function normalizeFeatureFlagRolloutStage(
+  input: Partial<FeatureFlagRolloutStage> | undefined,
+  fallbackKey: string,
+  fallbackRollout: number
+): FeatureFlagRolloutStage | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+
+  const key = input.key?.trim() || fallbackKey;
+  if (!key) {
+    return null;
+  }
+
+  const holdMinutes = Number.isFinite(input.holdMinutes) ? Math.max(0, Math.floor(input.holdMinutes ?? 0)) : 0;
+  const monitorWindowMinutes = Number.isFinite(input.monitorWindowMinutes)
+    ? Math.max(0, Math.floor(input.monitorWindowMinutes ?? 0))
+    : holdMinutes;
+  const notes = input.notes?.trim();
+
+  return {
+    key,
+    rollout: clampRollout(input.rollout ?? fallbackRollout),
+    holdMinutes,
+    monitorWindowMinutes,
+    ...(notes ? { notes } : {})
+  };
+}
+
+function normalizeFeatureFlagAlertThresholds(
+  input: Partial<FeatureFlagAlertThresholds> | undefined
+): FeatureFlagAlertThresholds {
+  const normalizeRatio = (value: number | undefined, fallback: number): number => {
+    if (!Number.isFinite(value)) {
+      return fallback;
+    }
+    return Math.min(1, Math.max(0, Number(value ?? fallback)));
+  };
+
+  const paymentFailureRate = Number.isFinite(input?.paymentFailureRate)
+    ? normalizeRatio(input?.paymentFailureRate, 0.02)
+    : undefined;
+
+  return {
+    errorRate: normalizeRatio(input?.errorRate, 0.02),
+    sessionFailureRate: normalizeRatio(input?.sessionFailureRate, 0.01),
+    ...(paymentFailureRate !== undefined ? { paymentFailureRate } : {})
+  };
+}
+
+function normalizeFeatureFlagRollbackPolicy(
+  input: Partial<FeatureFlagRollbackPolicy> | undefined
+): FeatureFlagRollbackPolicy {
+  const mode = input?.mode === "automatic" ? "automatic" : "manual";
+  return {
+    mode,
+    maxConfigAgeMinutes: Number.isFinite(input?.maxConfigAgeMinutes)
+      ? Math.max(1, Math.floor(input?.maxConfigAgeMinutes ?? 5))
+      : 5,
+    cooldownMinutes: Number.isFinite(input?.cooldownMinutes) ? Math.max(0, Math.floor(input?.cooldownMinutes ?? 30)) : 30
+  };
+}
+
+function normalizeFeatureFlagRolloutPolicy(
+  input: Partial<FeatureFlagRolloutPolicy> | undefined
+): FeatureFlagRolloutPolicy | undefined {
+  if (!input || typeof input !== "object") {
+    return undefined;
+  }
+
+  const owner = input.owner?.trim();
+  if (!owner) {
+    return undefined;
+  }
+
+  const stages = Array.isArray(input.stages)
+    ? input.stages
+        .map((stage, index) => normalizeFeatureFlagRolloutStage(stage, `stage-${index + 1}`, stage?.rollout ?? 0))
+        .filter((stage): stage is FeatureFlagRolloutStage => Boolean(stage))
+        .sort((left, right) => left.rollout - right.rollout)
+    : [];
+
+  return {
+    owner,
+    stages,
+    alertThresholds: normalizeFeatureFlagAlertThresholds(input.alertThresholds),
+    rollback: normalizeFeatureFlagRollbackPolicy(input.rollback)
+  };
+}
+
+function normalizeFeatureFlagAuditEntry(input: Partial<FeatureFlagAuditEntry> | undefined): FeatureFlagAuditEntry | null {
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+
+  const actor = input.actor?.trim();
+  const summary = input.summary?.trim();
+  const timestamp = normalizeTimestamp(input.at);
+  const flagKeys = Array.isArray(input.flagKeys)
+    ? input.flagKeys.filter((flagKey): flagKey is FeatureFlagKey => typeof flagKey === "string" && flagKey in DEFAULT_FEATURE_FLAG_CONFIG.flags)
+    : [];
+
+  if (!actor || !summary || !timestamp || flagKeys.length === 0) {
+    return null;
+  }
+
+  const ticket = input.ticket?.trim();
+  const approvedBy = input.approvedBy?.trim();
+  const changeId = input.changeId?.trim();
+
+  return {
+    at: timestamp,
+    actor,
+    summary,
+    flagKeys,
+    ...(ticket ? { ticket } : {}),
+    ...(approvedBy ? { approvedBy } : {}),
+    ...(changeId ? { changeId } : {}),
+    ...(input.rollback === true ? { rollback: true } : {})
+  };
+}
+
+function normalizeFeatureFlagOperationsConfig(input: Partial<FeatureFlagOperationsConfig> | undefined): FeatureFlagOperationsConfig {
+  const rolloutPolicies = isPlainRecord(input?.rolloutPolicies)
+    ? Object.fromEntries(
+        Object.entries(DEFAULT_FEATURE_FLAG_CONFIG.flags)
+          .map(([flagKey]) => {
+            const policy = normalizeFeatureFlagRolloutPolicy(
+              isPlainRecord(input?.rolloutPolicies?.[flagKey as FeatureFlagKey])
+                ? (input?.rolloutPolicies?.[flagKey as FeatureFlagKey] as Partial<FeatureFlagRolloutPolicy>)
+                : undefined
+            );
+            return [flagKey, policy];
+          })
+          .filter(([, policy]) => Boolean(policy))
+      )
+    : {};
+  const auditHistory = Array.isArray(input?.auditHistory)
+    ? input.auditHistory
+        .map((entry) => normalizeFeatureFlagAuditEntry(entry))
+        .filter((entry): entry is FeatureFlagAuditEntry => Boolean(entry))
+        .sort((left, right) => right.at.localeCompare(left.at))
+        .slice(0, 25)
+    : [];
+
+  return {
+    rolloutPolicies,
+    auditHistory
   };
 }
 
@@ -322,6 +521,9 @@ export function normalizeFeatureFlagConfigDocument(
         DEFAULT_FEATURE_FLAG_CONFIG.flags.tutorial_enabled
       )
     },
+    operations: normalizeFeatureFlagOperationsConfig(
+      isPlainRecord(input?.operations) ? (input.operations as Partial<FeatureFlagOperationsConfig>) : undefined
+    ),
     experiments: {
       account_portal_copy: normalizeExperimentDefinition(
         isPlainRecord(experiments?.account_portal_copy) ? (experiments.account_portal_copy as Partial<ExperimentDefinition>) : undefined,

--- a/packages/shared/test/feature-flags.test.ts
+++ b/packages/shared/test/feature-flags.test.ts
@@ -124,6 +124,57 @@ test("normalize experiment assignments drops malformed records", () => {
   );
 });
 
+test("feature flag config normalizes rollout policies and audit history", () => {
+  const config = normalizeFeatureFlagConfigDocument({
+    schemaVersion: 1,
+    flags: DEFAULT_FEATURE_FLAG_CONFIG.flags,
+    operations: {
+      rolloutPolicies: {
+        battle_pass_enabled: {
+          owner: "ops-oncall",
+          stages: [
+            { key: "full", rollout: 1, holdMinutes: 60, monitorWindowMinutes: 60 },
+            { key: "canary", rollout: 0.01, holdMinutes: 30, monitorWindowMinutes: 30 }
+          ],
+          alertThresholds: {
+            errorRate: 2,
+            sessionFailureRate: -1,
+            paymentFailureRate: 0.02
+          },
+          rollback: {
+            mode: "automatic",
+            maxConfigAgeMinutes: 0,
+            cooldownMinutes: -5
+          }
+        }
+      },
+      auditHistory: [
+        {
+          at: "2026-04-11T01:00:00.000Z",
+          actor: "ConfigOps",
+          summary: "approved canary rollout",
+          flagKeys: ["battle_pass_enabled"],
+          ticket: "#1203"
+        },
+        {
+          at: "invalid",
+          actor: "",
+          summary: "",
+          flagKeys: []
+        }
+      ]
+    }
+  });
+
+  assert.equal(config.operations?.rolloutPolicies?.battle_pass_enabled?.stages[0]?.key, "canary");
+  assert.equal(config.operations?.rolloutPolicies?.battle_pass_enabled?.alertThresholds.errorRate, 1);
+  assert.equal(config.operations?.rolloutPolicies?.battle_pass_enabled?.alertThresholds.sessionFailureRate, 0);
+  assert.equal(config.operations?.rolloutPolicies?.battle_pass_enabled?.rollback.maxConfigAgeMinutes, 1);
+  assert.equal(config.operations?.rolloutPolicies?.battle_pass_enabled?.rollback.cooldownMinutes, 0);
+  assert.equal(config.operations?.auditHistory?.length, 1);
+  assert.equal(config.operations?.auditHistory?.[0]?.ticket, "#1203");
+});
+
 test("analytics event catalog validates", () => {
   assert.deepEqual(validateAnalyticsEventCatalog(), {
     valid: true,


### PR DESCRIPTION
## Summary
- add rollout operations metadata and audit history to `configs/feature-flags.json` and the shared feature-flag schema
- expose server-side feature-flag checksum, reload freshness, rollout summaries, and Prometheus metrics for rollout/card monitoring
- document the `battle_pass_enabled` gray-release SOP and add alert rules for config staleness, session failures, gameplay error rate, and payment-related runtime errors

## Validation
- `npm ci --no-audit --no-fund`
- `node --import tsx --test ./packages/shared/test/feature-flags.test.ts`
- `node --import tsx --test ./apps/server/test/feature-flags.test.ts`
- `node --import tsx --test ./apps/server/test/runtime-observability-routes.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`

Closes #1203.