### PR TITLE
[codex] ops: add season and battle pass runbook

### DIFF
--- a/configs/.config-center-library.json
+++ b/configs/.config-center-library.json
@@ -1,0 +1,172 @@
+{
+  "filesystemVersions": {},
+  "filesystemExports": {},
+  "snapshots": {
+    "world": [
+      {
+        "id": "snapshot-mnsqv9h6-w37cjv",
+        "label": "世界配置 v1（发布前回滚点）",
+        "createdAt": "2026-04-10T10:09:45.390Z",
+        "version": 1,
+        "content": "{\n  \"width\": 8,\n  \"height\": 8,\n  \"heroes\": [\n    {\n      \"id\": \"hero-1\",\n      \"playerId\": \"player-1\",\n      \"name\": \"凯琳\",\n      \"position\": {\n        \"x\": 1,\n        \"y\": 1\n      },\n      \"vision\": 2,\n      \"move\": {\n        \"total\": 6,\n        \"remaining\": 6\n      },\n      \"stats\": {\n        \"attack\": 2,\n        \"defense\": 2,\n        \"power\": 1,\n        \"knowledge\": 1,\n        \"hp\": 30,\n        \"maxHp\": 30\n      },\n      \"progression\": {\n        \"level\": 1,\n        \"experience\": 0,\n        \"battlesWon\": 0,\n        \"neutralBattlesWon\": 0,\n        \"pvpBattlesWon\": 0\n      },\n      \"loadout\": {\n        \"inventory\": [\n          \"militia_pike\",\n          \"vanguard_blade\",\n          \"padded_gambeson\",\n          \"scout_compass\"\n        ]\n      },\n      \"armyTemplateId\": \"hero_guard_basic\",\n      \"armyCount\": 12\n    },\n    {\n      \"id\": \"hero-2\",\n      \"playerId\": \"player-2\",\n      \"name\": \"罗安\",\n      \"position\": {\n        \"x\": 6,\n        \"y\": 6\n      },\n      \"vision\": 2,\n      \"move\": {\n        \"total\": 6,\n        \"remaining\": 6\n      },\n      \"stats\": {\n        \"attack\": 2,\n        \"defense\": 2,\n        \"power\": 1,\n        \"knowledge\": 1,\n        \"hp\": 30,\n        \"maxHp\": 30\n      },\n      \"progression\": {\n        \"level\": 1,\n        \"experience\": 0,\n        \"battlesWon\": 0,\n        \"neutralBattlesWon\": 0,\n        \"pvpBattlesWon\": 0\n      },\n      \"loadout\": {\n        \"inventory\": [\n          \"oak_longbow\",\n          \"tower_shield_mail\",\n          \"scribe_charm\",\n          \"captains_insignia\"\n        ]\n      },\n      \"armyTemplateId\": \"hero_guard_basic\",\n      \"armyCount\": 10\n    }\n  ],\n  \"resourceSpawn\": {\n    \"goldChance\": 0.06,\n    \"woodChance\": 0.06,\n    \"oreChance\": 0.06\n  }\n}\n"
+      }
+    ],
+    "mapObjects": [
+      {
+        "id": "snapshot-mnsqv9h7-4d1z8i",
+        "label": "地图物件 v1（发布前回滚点）",
+        "createdAt": "2026-04-10T10:09:45.390Z",
+        "version": 1,
+        "content": "{\n  \"neutralArmies\": [\n    {\n      \"id\": \"neutral-1\",\n      \"position\": {\n        \"x\": 5,\n        \"y\": 4\n      },\n      \"reward\": {\n        \"kind\": \"gold\",\n        \"amount\": 300\n      },\n      \"stacks\": [\n        {\n          \"templateId\": \"wolf_pack\",\n          \"count\": 8\n        }\n      ],\n      \"behavior\": {\n        \"mode\": \"patrol\",\n        \"patrolRadius\": 4,\n        \"detectionRadius\": 5,\n        \"chaseDistance\": 10,\n        \"speed\": 2\n      }\n    }\n  ],\n  \"guaranteedResources\": [\n    {\n      \"position\": {\n        \"x\": 2,\n        \"y\": 1\n      },\n      \"resource\": {\n        \"kind\": \"wood\",\n        \"amount\": 5\n      }\n    }\n  ],\n  \"buildings\": [\n    {\n      \"id\": \"recruit-post-1\",\n      \"kind\": \"recruitment_post\",\n      \"position\": {\n        \"x\": 1,\n        \"y\": 3\n      },\n      \"label\": \"前线招募所\",\n      \"unitTemplateId\": \"hero_guard_basic\",\n      \"recruitCount\": 4,\n      \"cost\": {\n        \"gold\": 240,\n        \"wood\": 0,\n        \"ore\": 0\n      },\n      \"maxTier\": 3\n    },\n    {\n      \"id\": \"shrine-attack-1\",\n      \"kind\": \"attribute_shrine\",\n      \"position\": {\n        \"x\": 3,\n        \"y\": 2\n      },\n      \"label\": \"战旗圣坛\",\n      \"bonus\": {\n        \"attack\": 2,\n        \"defense\": 0,\n        \"power\": 0,\n        \"knowledge\": 0\n      }\n    },\n    {\n      \"id\": \"mine-wood-1\",\n      \"kind\": \"resource_mine\",\n      \"position\": {\n        \"x\": 3,\n        \"y\": 1\n      },\n      \"label\": \"前线伐木场\",\n      \"resourceKind\": \"wood\",\n      \"income\": 5,\n      \"maxTier\": 2\n    }\n  ]\n}\n"
+      }
+    ],
+    "units": [
+      {
+        "id": "snapshot-mnsqv9h9-cwxrje",
+        "label": "兵种配置 v1（发布前回滚点）",
+        "createdAt": "2026-04-10T10:09:45.390Z",
+        "version": 1,
+        "content": "{\n  \"templates\": [\n    {\n      \"id\": \"hero_guard_basic\",\n      \"stackName\": \"凯琳卫队\",\n      \"faction\": \"crown\",\n      \"rarity\": \"common\",\n      \"initiative\": 9,\n      \"attack\": 4,\n      \"defense\": 4,\n      \"minDamage\": 2,\n      \"maxDamage\": 4,\n      \"maxHp\": 10,\n      \"battleSkills\": [\n        \"power_shot\",\n        \"armor_spell\",\n        \"battle_focus\",\n        \"sundering_spear\"\n      ]\n    },\n    {\n      \"id\": \"crown_heavy_cavalry\",\n      \"stackName\": \"皇家重骑\",\n      \"faction\": \"crown\",\n      \"rarity\": \"elite\",\n      \"initiative\": 6,\n      \"attack\": 7,\n      \"defense\": 6,\n      \"minDamage\": 3,\n      \"maxDamage\": 6,\n      \"maxHp\": 16,\n      \"battleSkills\": [\n        \"royal_charge\",\n        \"guardian_oath\"\n      ]\n    },\n    {\n      \"id\": \"crown_field_chaplain\",\n      \"stackName\": \"战场牧师\",\n      \"faction\": \"crown\",\n      \"rarity\": \"common\",\n      \"initiative\": 8,\n      \"attack\": 3,\n      \"defense\": 4,\n      \"minDamage\": 1,\n      \"maxDamage\": 3,\n      \"maxHp\": 11,\n      \"battleSkills\": [\n        \"field_mending\",\n        \"rally_morale\"\n      ]\n    },\n    {\n      \"id\": \"crown_crossbowman\",\n      \"stackName\": \"十字弩手\",\n      \"faction\": \"crown\",\n      \"rarity\": \"common\",\n      \"initiative\": 8,\n      \"attack\": 6,\n      \"defense\": 3,\n      \"minDamage\": 3,\n      \"maxDamage\": 5,\n      \"attackRange\": 2,\n      \"maxHp\": 8,\n      \"battleSkills\": [\n        \"power_shot\",\n        \"sundering_spear\"\n      ]\n    },\n    {\n      \"id\": \"crown_light_outrider\",\n      \"stackName\": \"轻骑斥候\",\n      \"faction\": \"crown\",\n      \"rarity\": \"common\",\n      \"initiative\": 12,\n      \"attack\": 4,\n      \"defense\": 3,\n      \"minDamage\": 1,\n      \"maxDamage\": 2,\n      \"maxHp\": 8,\n      \"battleSkills\": [\n        \"pinning_javelin\",\n        \"battle_focus\"\n      ]\n    },\n    {\n      \"id\": \"wolf_pack\",\n      \"stackName\": \"恶狼\",\n      \"faction\": \"wild\",\n      \"rarity\": \"elite\",\n      \"initiative\": 10,\n      \"attack\": 6,\n      \"defense\": 4,\n      \"minDamage\": 2,\n      \"maxDamage\": 4,\n      \"maxHp\": 8,\n      \"battleSkills\": [\n        \"venomous_fangs\",\n        \"crippling_howl\"\n      ]\n    },\n    {\n      \"id\": \"moss_stalker\",\n      \"stackName\": \"苔痕潜猎者\",\n      \"faction\": \"wild\",\n      \"rarity\": \"elite\",\n      \"initiative\": 11,\n      \"attack\": 5,\n      \"defense\": 3,\n      \"minDamage\": 2,\n      \"maxDamage\": 5,\n      \"maxHp\": 7,\n      \"battleSkills\": [\n        \"ambush_pounce\",\n        \"bog_veil\"\n      ]\n    },\n    {\n      \"id\": \"iron_walker\",\n      \"stackName\": \"铁卫行者\",\n      \"faction\": \"wild\",\n      \"rarity\": \"elite\",\n      \"initiative\": 7,\n      \"attack\": 6,\n      \"defense\": 7,\n      \"minDamage\": 3,\n      \"maxDamage\": 5,\n      \"maxHp\": 14,\n      \"battleSkills\": [\n        \"shield_bash\",\n        \"watcher_stance\"\n      ]\n    },\n    {\n      \"id\": \"wild_cave_bear\",\n      \"stackName\": \"洞穴巨熊\",\n      \"faction\": \"wild\",\n      \"rarity\": \"elite\",\n      \"initiative\": 6,\n      \"attack\": 7,\n      \"defense\": 5,\n      \"minDamage\": 3,\n      \"maxDamage\": 6,\n      \"maxHp\": 18,\n      \"battleSkills\": [\n        \"cave_bear_cleave\"\n      ]\n    },\n    {\n      \"id\": \"wild_serpent\",\n      \"stackName\": \"毒蛇猎手\",\n      \"faction\": \"wild\",\n      \"rarity\": \"common\",\n      \"initiative\": 14,\n      \"attack\": 6,\n      \"defense\": 2,\n      \"minDamage\": 2,\n      \"maxDamage\": 4,\n      \"maxHp\": 6,\n      \"battleSkills\": [\n        \"serpent_venom\"\n      ]\n    },\n    {\n      \"id\": \"wild_hawk_rider\",\n      \"stackName\": \"鹰击骑兵\",\n      \"faction\": \"wild\",\n      \"rarity\": \"elite\",\n      \"initiative\": 13,\n      \"attack\": 5,\n      \"defense\": 4,\n      \"minDamage\": 2,\n      \"maxDamage\": 4,\n      \"maxHp\": 9,\n      \"battleSkills\": [\n        \"skybound\",\n        \"pinning_javelin\"\n      ]\n    },\n    {\n      \"id\": \"wild_cave_troll\",\n      \"stackName\": \"洞穴巨魔\",\n      \"faction\": \"wild\",\n      \"rarity\": \"elite\",\n      \"initiative\": 5,\n      \"attack\": 5,\n      \"defense\": 8,\n      \"minDamage\": 3,\n      \"maxDamage\": 5,\n      \"maxHp\": 20,\n      \"battleSkills\": [\n        \"taunt_shout\",\n        \"watcher_stance\"\n      ]\n    },\n    {\n      \"id\": \"shadow_skeleton\",\n      \"stackName\": \"枯骨兵\",\n      \"faction\": \"shadow\",\n      \"rarity\": \"common\",\n      \"initiative\": 8,\n      \"attack\": 4,\n      \"defense\": 3,\n      \"minDamage\": 2,\n      \"maxDamage\": 3,\n      \"maxHp\": 9,\n      \"battleSkills\": [\n        \"death_resilience\"\n      ]\n    },\n    {\n      \"id\": \"shadow_wraith\",\n      \"stackName\": \"幽灵游侠\",\n      \"faction\": \"shadow\",\n      \"rarity\": \"common\",\n      \"initiative\": 11,\n      \"attack\": 5,\n      \"defense\": 3,\n      \"minDamage\": 2,\n      \"maxDamage\": 4,\n      \"attackRange\": 2,\n      \"maxHp\": 7,\n      \"battleSkills\": [\n        \"power_shot\",\n        \"armor_pierce\"\n      ]\n    },\n    {\n      \"id\": \"shadow_hexer\",\n      \"stackName\": \"尸巫\",\n      \"faction\": \"shadow\",\n      \"rarity\": \"elite\",\n      \"initiative\": 7,\n      \"attack\": 4,\n      \"defense\": 4,\n      \"minDamage\": 2,\n      \"maxDamage\": 4,\n      \"maxHp\": 10,\n      \"battleSkills\": [\n        \"grave_silence\",\n        \"crippling_howl\"\n      ]\n    },\n    {\n      \"id\": \"shadow_death_knight\",\n      \"stackName\": \"影魔骑士\",\n      \"faction\": \"shadow\",\n      \"rarity\": \"elite\",\n      \"initiative\": 9,\n      \"attack\": 8,\n      \"defense\": 6,\n      \"minDamage\": 4,\n      \"maxDamage\": 7,\n      \"maxHp\": 17,\n      \"battleSkills\": [\n        \"battle_focus\",\n        \"life_drain\"\n      ]\n    }\n  ]\n}\n"
+      }
+    ],
+    "battleBalance": [
+      {
+        "id": "snapshot-mnsqv9hb-gqfl16",
+        "label": "战斗平衡 v1（发布前回滚点）",
+        "createdAt": "2026-04-10T10:09:45.390Z",
+        "version": 1,
+        "content": "{\n  \"damage\": {\n    \"defendingDefenseBonus\": 5,\n    \"offenseAdvantageStep\": 0.05,\n    \"minimumOffenseMultiplier\": 0.3,\n    \"varianceBase\": 0.9,\n    \"varianceRange\": 0.2\n  },\n  \"environment\": {\n    \"blockerSpawnThreshold\": 0.62,\n    \"blockerDurability\": 1,\n    \"trapSpawnThreshold\": 0.58,\n    \"trapDamage\": 1,\n    \"trapCharges\": 1,\n    \"trapGrantedStatusId\": \"weakened\"\n  },\n  \"turnTimerSeconds\": 90,\n  \"afkStrikesBeforeForfeit\": 2,\n  \"pvp\": {\n    \"eloK\": 32\n  }\n}\n"
+      }
+    ]
+  },
+  "presets": {},
+  "stagedDraft": null,
+  "publishHistory": {
+    "world": [
+      {
+        "id": "publish-mnsqv9gu-nmjr5m",
+        "documentId": "world",
+        "author": "codex",
+        "summary": "Align valid config-center documents with issue #1175 candidate evidence for HEAD revision.",
+        "candidate": "issue-1175-cocos-rc",
+        "revision": "d96e22a047cbcce902ff9c536565fdfee3fd8878",
+        "publishedAt": "2026-04-10T10:09:45.390Z",
+        "fromVersion": 1,
+        "toVersion": 1,
+        "changeCount": 0,
+        "structuralChangeCount": 0
+      }
+    ],
+    "mapObjects": [
+      {
+        "id": "publish-mnsqv9gu-nmjr5m",
+        "documentId": "mapObjects",
+        "author": "codex",
+        "summary": "Align valid config-center documents with issue #1175 candidate evidence for HEAD revision.",
+        "candidate": "issue-1175-cocos-rc",
+        "revision": "d96e22a047cbcce902ff9c536565fdfee3fd8878",
+        "publishedAt": "2026-04-10T10:09:45.390Z",
+        "fromVersion": 1,
+        "toVersion": 1,
+        "changeCount": 0,
+        "structuralChangeCount": 0
+      }
+    ],
+    "units": [
+      {
+        "id": "publish-mnsqv9gu-nmjr5m",
+        "documentId": "units",
+        "author": "codex",
+        "summary": "Align valid config-center documents with issue #1175 candidate evidence for HEAD revision.",
+        "candidate": "issue-1175-cocos-rc",
+        "revision": "d96e22a047cbcce902ff9c536565fdfee3fd8878",
+        "publishedAt": "2026-04-10T10:09:45.390Z",
+        "fromVersion": 1,
+        "toVersion": 1,
+        "changeCount": 0,
+        "structuralChangeCount": 0
+      }
+    ],
+    "battleBalance": [
+      {
+        "id": "publish-mnsqv9gu-nmjr5m",
+        "documentId": "battleBalance",
+        "author": "codex",
+        "summary": "Align valid config-center documents with issue #1175 candidate evidence for HEAD revision.",
+        "candidate": "issue-1175-cocos-rc",
+        "revision": "d96e22a047cbcce902ff9c536565fdfee3fd8878",
+        "publishedAt": "2026-04-10T10:09:45.390Z",
+        "fromVersion": 1,
+        "toVersion": 1,
+        "changeCount": 0,
+        "structuralChangeCount": 0
+      }
+    ]
+  },
+  "publishAuditHistory": [
+    {
+      "id": "publish-mnsqv9gu-nmjr5m",
+      "author": "codex",
+      "summary": "Align valid config-center documents with issue #1175 candidate evidence for HEAD revision.",
+      "candidate": "issue-1175-cocos-rc",
+      "revision": "d96e22a047cbcce902ff9c536565fdfee3fd8878",
+      "publishedAt": "2026-04-10T10:09:45.390Z",
+      "resultStatus": "applied",
+      "resultMessage": "运行时配置已刷新",
+      "changes": [
+        {
+          "documentId": "world",
+          "title": "世界配置",
+          "fromVersion": 1,
+          "toVersion": 1,
+          "changeCount": 0,
+          "structuralChangeCount": 0,
+          "snapshotId": "snapshot-mnsqv9h6-w37cjv",
+          "runtimeStatus": "applied",
+          "runtimeMessage": "运行时已刷新",
+          "diffSummary": [],
+          "impactSummary": null
+        },
+        {
+          "documentId": "mapObjects",
+          "title": "地图物件",
+          "fromVersion": 1,
+          "toVersion": 1,
+          "changeCount": 0,
+          "structuralChangeCount": 0,
+          "snapshotId": "snapshot-mnsqv9h7-4d1z8i",
+          "runtimeStatus": "applied",
+          "runtimeMessage": "运行时已刷新",
+          "diffSummary": [],
+          "impactSummary": null
+        },
+        {
+          "documentId": "units",
+          "title": "兵种配置",
+          "fromVersion": 1,
+          "toVersion": 1,
+          "changeCount": 0,
+          "structuralChangeCount": 0,
+          "snapshotId": "snapshot-mnsqv9h9-cwxrje",
+          "runtimeStatus": "applied",
+          "runtimeMessage": "运行时已刷新",
+          "diffSummary": [],
+          "impactSummary": null
+        },
+        {
+          "documentId": "battleBalance",
+          "title": "战斗平衡",
+          "fromVersion": 1,
+          "toVersion": 1,
+          "changeCount": 0,
+          "structuralChangeCount": 0,
+          "snapshotId": "snapshot-mnsqv9hb-gqfl16",
+          "runtimeStatus": "applied",
+          "runtimeMessage": "运行时已刷新",
+          "diffSummary": [],
+          "impactSummary": null
+        }
+      ]
+    }
+  ]
+}

--- a/docs/season-ops-runbook.md
+++ b/docs/season-ops-runbook.md
@@ -1,0 +1,186 @@
+# Season And Battle Pass Operations Runbook
+
+Issue: `#1206`
+
+This runbook is the operational gate for season cadence and battle-pass rollout work. Use it before changing season dates, before closing a live season, and before promoting `battle_pass_enabled` for any new season/reward table revision.
+
+## Scope And Owners
+
+- Product ops: season calendar, reward theme, push copy, and the final go/no-go call on start and close windows.
+- Server on-call: `/api/admin/seasons/*` execution, runtime health checks, and rollback if close/start fails.
+- Economy owner: `configs/battle-pass.json` XP pacing and reward value review.
+- CS / community ops: player-facing reminder copy, outage notices, and mailbox compensation delivery when policy requires it.
+
+## Operational Artifacts
+
+- Battle-pass config: [configs/battle-pass.json](/home/gpt/project/ProjectVeil/configs/battle-pass.json)
+- Season admin routes: [apps/server/src/seasons.ts](/home/gpt/project/ProjectVeil/apps/server/src/seasons.ts)
+- Season reward close implementation: [apps/server/src/persistence.ts](/home/gpt/project/ProjectVeil/apps/server/src/persistence.ts#L6927)
+- Battle-pass config normalization: [apps/server/src/battle-pass.ts](/home/gpt/project/ProjectVeil/apps/server/src/battle-pass.ts)
+- Compensation delivery path: [docs/player-mailbox-compensation.md](/home/gpt/project/ProjectVeil/docs/player-mailbox-compensation.md)
+- XP pacing helper: [scripts/battle-pass-xp-balance.ts](/home/gpt/project/ProjectVeil/scripts/battle-pass-xp-balance.ts)
+
+## Season Lifecycle SOP
+
+### T-14 To T-7 Content Lock
+
+1. Freeze the season theme, premium reward set, and season length.
+2. Update `configs/battle-pass.json`, then run:
+
+```bash
+node --import tsx ./scripts/battle-pass-xp-balance.ts \
+  --season-days=28 \
+  --matches-per-day=8 \
+  --win-rate=0.55 \
+  --daily-login-days=28
+```
+
+3. Review the output with product ops and economy owner.
+   The working target is that the final tier lands inside the final week for a regular player cohort, not only for whales or only-perfect win rates.
+4. Record the chosen assumptions and the projected final-tier day in the season ticket or launch note.
+
+### T-72h Reminder Planning
+
+1. Lock the outbound reminder cadence and owners.
+2. Schedule one reminder at `season_end - 72h` and one at `season_end - 24h`.
+3. Both reminders must contain:
+   - season end timestamp in UTC and CN local time
+   - current tier / XP CTA
+   - premium purchase CTA if premium is still on sale
+   - reward-claim CTA if the player already has unlocked but unclaimed tiers
+4. Confirm CS has the compensation macro and mailbox script ready before the 72h send.
+
+### T-24h Final Readiness
+
+1. Re-run the pacing script if XP sources changed after T-72h.
+2. Confirm `/api/seasons/current` returns the expected live `seasonId`.
+3. Confirm `/api/runtime/feature-flags` checksum consistency if `battle_pass_enabled` rollout is changing with the season event.
+4. Freeze battle-pass config edits after the final reminder unless there is a production incident.
+
+### D0 Season Start
+
+1. Verify there is no stray active season:
+
+```bash
+curl -sS "$VEIL_SERVER_URL/api/admin/seasons?status=all" \
+  -H "x-veil-admin-token: $VEIL_ADMIN_TOKEN"
+```
+
+2. Create the new season only after the battle-pass config revision is deployed everywhere:
+
+```bash
+curl -sS -X POST "$VEIL_SERVER_URL/api/admin/seasons/create" \
+  -H "content-type: application/json" \
+  -H "x-veil-admin-token: $VEIL_ADMIN_TOKEN" \
+  -d '{"seasonId":"season-2026-q2"}'
+```
+
+3. Validate `GET /api/seasons/current` and one reward-claim smoke test on a seeded QA account.
+4. Append rollout evidence and the season ID to the release log for the same revision.
+
+### In-Season Weekly Review
+
+1. Sample current XP pacing against the original assumptions.
+2. Do not change XP numbers mid-season unless the economy owner and server on-call both approve.
+3. If XP tuning is unavoidable, announce the effective date and re-send the 72h/24h reminders using the revised pacing.
+
+### Season Close
+
+1. Announce a content freeze for the final 24h.
+2. At the close window, run:
+
+```bash
+curl -sS -X POST "$VEIL_SERVER_URL/api/admin/seasons/close" \
+  -H "x-veil-admin-token: $VEIL_ADMIN_TOKEN"
+```
+
+3. Expected behavior:
+   - `closeSeason()` snapshots standings if needed, grants ranked-season rewards once, and marks the season closed.
+   - Re-running the same close is idempotent and should return zero newly rewarded players.
+4. Immediately verify:
+   - `/api/admin/seasons?status=all` shows the season as `closed`
+   - the close response contains the expected `playersRewarded` and `totalGemsGranted`
+   - no second reward distribution occurs on a repeated close call
+
+## Battle-Pass XP Balancing Template
+
+Use the script output as the planning template. Record these four assumptions every season:
+
+- `seasonDays`
+- `matchesPerDay`
+- `winRate`
+- `dailyLoginDays`
+
+Operator interpretation:
+
+- `expectedDailyXp` is the regular-cohort pacing baseline.
+- `projectedSeasonXp` and `projectedTier` show where that cohort lands by season end.
+- `finalTierTarget` should typically land between `D(seasonDays - 7)` and `D(seasonDays)` for the core cohort.
+- If final tier lands far earlier, reduce XP income or add more tiers/rewards.
+- If final tier is unreachable without near-perfect play, reduce tier thresholds or add extra XP sources before launch.
+
+## Season Close Rehearsal
+
+Run one rehearsal for every new reward table or close-flow change.
+
+Checklist:
+
+1. Seed a dev or staging environment with at least 25 ranked accounts.
+2. Create a rehearsal season ID.
+3. Call the close route once and save the JSON response.
+4. Call the close route a second time and verify idempotency.
+5. Capture `GET /api/admin/seasons?status=all` before and after close.
+6. Save the evidence links in the issue or release packet.
+
+Current automated rehearsal anchors already in-repo:
+
+- [apps/server/test/memory-room-snapshot-store.test.ts](/home/gpt/project/ProjectVeil/apps/server/test/memory-room-snapshot-store.test.ts#L203) covers reward distribution once plus double-close protection.
+- [apps/server/test/persistence-account-credentials.test.ts](/home/gpt/project/ProjectVeil/apps/server/test/persistence-account-credentials.test.ts#L314) covers MySQL-backed close behavior and reward log idempotency.
+
+## Expired Unclaimed Reward Compensation Policy
+
+Current behavior is split by reward type:
+
+- Ranked-season rewards are granted during `closeSeason()` and do not require player claim afterward.
+- Battle-pass tier rewards are still player-claimed; there is no automatic end-of-season sweep for unlocked but unclaimed tiers.
+
+Policy:
+
+1. No compensation for pure player inactivity.
+2. Compensation is required when a service incident, emergency maintenance, or forced early close removed a reasonable claim window.
+3. Premium purchasers get priority handling because money changed hands. If a paid player loses claim access due to service failure, grant the missed premium value manually.
+4. Use mailbox compensation, not direct account edits, so the recovery is auditable and player-visible.
+
+Compensation procedure:
+
+1. Build the affected-player list and missed reward summary.
+2. Send one mailbox message per incident using [scripts/send-player-mailbox-compensation.ts](/home/gpt/project/ProjectVeil/scripts/send-player-mailbox-compensation.ts).
+3. Set `expiresAt` to `incident_resolved_at + 7 days`.
+4. Use a stable compensation ID such as `bp-comp-2026-q2-close-incident`.
+5. Include the incident reference in the internal ops note and CS macro.
+
+## Reminder Plan Template
+
+- `T-72h`: broad reminder to all active season participants, plus premium upsell if applicable.
+- `T-24h`: urgency reminder to players with unclaimed unlocked tiers and players within one tier of a premium chase reward.
+- `T-0`: optional maintenance/close notice only if the season close requires a visible service window.
+
+Minimum planning fields:
+
+- audience
+- send time
+- owner
+- copy link
+- fallback channel
+- success metric
+- incident rollback note
+
+## Release Gate
+
+Do not promote a new season or a new battle-pass revision until all of the following are true:
+
+- battle-pass config reviewed with the XP pacing script
+- 72h and 24h reminders scheduled
+- season close rehearsal evidence linked
+- compensation owner named
+- server on-call has the admin token, close command, and rollback path ready

--- a/scripts/battle-pass-xp-balance.ts
+++ b/scripts/battle-pass-xp-balance.ts
@@ -1,0 +1,139 @@
+import battlePassConfigDocument from "../configs/battle-pass.json";
+import { resolveBattlePassConfig, resolveBattlePassTierForXp, type BattlePassConfig } from "../apps/server/src/battle-pass";
+
+export interface BattlePassBalanceAssumptions {
+  seasonDays: number;
+  matchesPerDay: number;
+  winRate: number;
+  dailyLoginDays: number;
+}
+
+export interface BattlePassBalanceMilestone {
+  tier: number;
+  xpRequired: number;
+  estimatedDay: number;
+}
+
+export interface BattlePassBalancePlan {
+  assumptions: BattlePassBalanceAssumptions;
+  dailyMatchXp: number;
+  dailyLoginXp: number;
+  expectedDailyXp: number;
+  projectedSeasonXp: number;
+  projectedTier: number;
+  finalTierTargetDay: number;
+  milestones: BattlePassBalanceMilestone[];
+}
+
+function normalizeNonNegativeInteger(value: number, field: string): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative number`);
+  }
+  return Math.floor(value);
+}
+
+function normalizeWinRate(value: number): number {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error("winRate must be between 0 and 1");
+  }
+  return value;
+}
+
+export function buildBattlePassBalancePlan(
+  config: BattlePassConfig,
+  assumptions: BattlePassBalanceAssumptions
+): BattlePassBalancePlan {
+  const seasonDays = Math.max(1, normalizeNonNegativeInteger(assumptions.seasonDays, "seasonDays"));
+  const matchesPerDay = normalizeNonNegativeInteger(assumptions.matchesPerDay, "matchesPerDay");
+  const dailyLoginDays = Math.min(
+    seasonDays,
+    normalizeNonNegativeInteger(assumptions.dailyLoginDays, "dailyLoginDays")
+  );
+  const winRate = normalizeWinRate(assumptions.winRate);
+
+  const expectedMatchXp = matchesPerDay * (
+    (winRate * config.seasonXpPerWin) +
+    ((1 - winRate) * config.seasonXpPerLoss)
+  );
+  const dailyMatchXp = Math.round(expectedMatchXp);
+  const dailyLoginXp = dailyLoginDays > 0 ? Math.round((dailyLoginDays / seasonDays) * config.seasonXpDailyLoginBonus) : 0;
+  const expectedDailyXp = dailyMatchXp + dailyLoginXp;
+  const projectedSeasonXp = expectedDailyXp * seasonDays;
+  const projectedTier = resolveBattlePassTierForXp(config, projectedSeasonXp);
+  const finalTier = config.tiers[config.tiers.length - 1];
+  const finalTierTargetDay = expectedDailyXp > 0 ? Math.ceil(finalTier.xpRequired / expectedDailyXp) : Number.POSITIVE_INFINITY;
+
+  return {
+    assumptions: {
+      seasonDays,
+      matchesPerDay,
+      winRate,
+      dailyLoginDays
+    },
+    dailyMatchXp,
+    dailyLoginXp,
+    expectedDailyXp,
+    projectedSeasonXp,
+    projectedTier,
+    finalTierTargetDay,
+    milestones: config.tiers.map((tier) => ({
+      tier: tier.tier,
+      xpRequired: tier.xpRequired,
+      estimatedDay: expectedDailyXp > 0 ? Math.ceil(tier.xpRequired / expectedDailyXp) : Number.POSITIVE_INFINITY
+    }))
+  };
+}
+
+export function formatBattlePassBalancePlan(plan: BattlePassBalancePlan): string {
+  const finalTierDay = Number.isFinite(plan.finalTierTargetDay) ? `D${plan.finalTierTargetDay}` : "unreachable";
+  const milestoneLines = plan.milestones
+    .filter((milestone) => milestone.tier === 1 || milestone.tier % 5 === 0)
+    .map((milestone) => {
+      const day = Number.isFinite(milestone.estimatedDay) ? `D${milestone.estimatedDay}` : "unreachable";
+      return `T${milestone.tier}\t${milestone.xpRequired}\t${day}`;
+    });
+
+  return [
+    "Battle Pass XP Balance Plan",
+    `seasonDays=${plan.assumptions.seasonDays} matchesPerDay=${plan.assumptions.matchesPerDay} winRate=${plan.assumptions.winRate.toFixed(2)} dailyLoginDays=${plan.assumptions.dailyLoginDays}`,
+    `dailyMatchXp=${plan.dailyMatchXp} dailyLoginXp=${plan.dailyLoginXp} expectedDailyXp=${plan.expectedDailyXp}`,
+    `projectedSeasonXp=${plan.projectedSeasonXp} projectedTier=${plan.projectedTier} finalTierTarget=${finalTierDay}`,
+    "",
+    "milestone\txpRequired\testimatedDay",
+    ...milestoneLines
+  ].join("\n");
+}
+
+function readNumericFlag(name: string, fallback: number): number {
+  const prefix = `--${name}=`;
+  const raw = process.argv.find((value) => value.startsWith(prefix));
+  if (!raw) {
+    return fallback;
+  }
+
+  const parsed = Number(raw.slice(prefix.length));
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`--${name} must be numeric`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const config = resolveBattlePassConfig(battlePassConfigDocument);
+  const plan = buildBattlePassBalancePlan(config, {
+    seasonDays: readNumericFlag("season-days", 28),
+    matchesPerDay: readNumericFlag("matches-per-day", 8),
+    winRate: readNumericFlag("win-rate", 0.55),
+    dailyLoginDays: readNumericFlag("daily-login-days", 28)
+  });
+
+  process.stdout.write(`${formatBattlePassBalancePlan(plan)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test/battle-pass-xp-balance.test.ts
+++ b/scripts/test/battle-pass-xp-balance.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildBattlePassBalancePlan, formatBattlePassBalancePlan } from "../battle-pass-xp-balance";
+
+test("buildBattlePassBalancePlan projects tier pacing from season assumptions", () => {
+  const plan = buildBattlePassBalancePlan(
+    {
+      seasonXpPerWin: 100,
+      seasonXpPerLoss: 40,
+      seasonXpDailyLoginBonus: 20,
+      tiers: [
+        { tier: 1, xpRequired: 0, freeReward: {}, premiumReward: {} },
+        { tier: 2, xpRequired: 500, freeReward: {}, premiumReward: {} },
+        { tier: 3, xpRequired: 1000, freeReward: {}, premiumReward: {} },
+        { tier: 4, xpRequired: 1500, freeReward: {}, premiumReward: {} }
+      ]
+    },
+    {
+      seasonDays: 10,
+      matchesPerDay: 5,
+      winRate: 0.6,
+      dailyLoginDays: 10
+    }
+  );
+
+  assert.equal(plan.dailyMatchXp, 380);
+  assert.equal(plan.dailyLoginXp, 20);
+  assert.equal(plan.expectedDailyXp, 400);
+  assert.equal(plan.projectedSeasonXp, 4000);
+  assert.equal(plan.projectedTier, 4);
+  assert.equal(plan.finalTierTargetDay, 4);
+  assert.deepEqual(plan.milestones.map((entry) => entry.estimatedDay), [0, 2, 3, 4]);
+});
+
+test("formatBattlePassBalancePlan renders operator-facing summary lines", () => {
+  const output = formatBattlePassBalancePlan({
+    assumptions: {
+      seasonDays: 28,
+      matchesPerDay: 8,
+      winRate: 0.55,
+      dailyLoginDays: 28
+    },
+    dailyMatchXp: 586,
+    dailyLoginXp: 20,
+    expectedDailyXp: 606,
+    projectedSeasonXp: 16968,
+    projectedTier: 30,
+    finalTierTargetDay: 24,
+    milestones: [
+      { tier: 1, xpRequired: 0, estimatedDay: 0 },
+      { tier: 5, xpRequired: 2000, estimatedDay: 4 },
+      { tier: 10, xpRequired: 4500, estimatedDay: 8 }
+    ]
+  });
+
+  assert.match(output, /projectedSeasonXp=16968 projectedTier=30 finalTierTarget=D24/);
+  assert.match(output, /T5\t2000\tD4/);
+  assert.match(output, /T10\t4500\tD8/);
+});


### PR DESCRIPTION
## Summary
- add a season and battle-pass operations runbook covering lifecycle checks, reminders, close rehearsal, and compensation policy
- add a battle-pass XP pacing helper CLI plus unit tests so ops can project tier completion before launch
- capture the current config-center export library snapshot used by the latest release evidence flow

## Validation
- \
- \

Closes #1206