### PR TITLE
[codex] Add WeChat Pay refund and fraud runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ REDIS_URL=redis://127.0.0.1:6379/0 npm run validate:redis-scaling
 - PR 最小验证速查表（按常见改动类型查看 must run / recommended / can skip）：`docs/verification-matrix.md#contributor-quick-reference`
 - 多人同步治理矩阵说明：`docs/sync-governance-matrix.md`
 - 共享 contract 快照说明：`docs/shared-contract-snapshots.md`
+- WeChat Pay 退款 / 争议 / 防欺诈运营手册：`docs/wechat-pay-ops-runbook.md`
 - Codex automation 分支审计与清理 runbook：`docs/codex-automation-branch-maintenance.md`
 - GitHub issue intake fallback runbook：`docs/github-issue-intake-fallback.md`
 - GitHub issue intake fallback smoke checklist：`docs/github-issue-intake-fallback-smoke-checklist.md`

--- a/apps/server/src/wechat-pay.ts
+++ b/apps/server/src/wechat-pay.ts
@@ -2,6 +2,7 @@ import { createCipheriv, createDecipheriv, createSign, createVerify, randomBytes
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { emitAnalyticsEvent } from "./analytics";
 import { validateAuthSessionFromRequest } from "./auth";
+import { recordRuntimeErrorEvent } from "./observability";
 import type { PaymentOrderSnapshot, RoomSnapshotStore } from "./persistence";
 import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct, type ShopProductGrant } from "./shop";
 
@@ -78,6 +79,7 @@ interface WechatPayCallbackTransaction {
 }
 
 const MAX_JSON_BODY_BYTES = 64 * 1024;
+const MAX_CALLBACK_TIMESTAMP_SKEW_SECONDS = 5 * 60;
 const SUCCESS_CALLBACK_BODY = { code: "SUCCESS", message: "success" };
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -253,7 +255,8 @@ function emitPaymentFraudSignal(
     orderId: string;
     productId: string;
     [key: string]: unknown;
-  }
+  },
+  route: "/api/payments/wechat/verify" | "/api/payments/wechat/callback"
 ): void {
   try {
     emitAnalyticsEvent("payment_fraud_signal", {
@@ -266,6 +269,34 @@ function emitPaymentFraudSignal(
   } catch {
     // Fraud logging must not break legitimate payment handling.
   }
+
+  recordRuntimeErrorEvent({
+    id: randomUUID(),
+    recordedAt: new Date().toISOString(),
+    source: "server",
+    surface: "wechat-pay",
+    candidateRevision: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null,
+    featureArea: "payment",
+    ownerArea: "commerce",
+    severity: "warn",
+    errorCode: "payment_fraud_signal",
+    message: `WeChat Pay fraud signal triggered: ${signal}`,
+    tags: ["wechat-pay", signal],
+    context: {
+      roomId: null,
+      playerId,
+      requestId: null,
+      route,
+      action: null,
+      statusCode: null,
+      crash: false,
+      detail: JSON.stringify({
+        orderId: payload.orderId,
+        productId: payload.productId,
+        signal
+      })
+    }
+  });
 }
 
 function verifyWechatCallbackSignature(
@@ -291,6 +322,20 @@ function verifyWechatCallbackSignature(
   verifier.update(`${timestamp}\n${nonce}\n${body}\n`);
   verifier.end();
   return verifier.verify(config.platformPublicKey, signature, "base64");
+}
+
+function isWechatCallbackTimestampFresh(headers: IncomingMessage["headers"], now: Date): boolean {
+  const timestamp = headers["wechatpay-timestamp"];
+  if (typeof timestamp !== "string") {
+    return false;
+  }
+
+  const parsedSeconds = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(parsedSeconds)) {
+    return false;
+  }
+
+  return Math.abs(Math.floor(now.getTime() / 1000) - parsedSeconds) <= MAX_CALLBACK_TIMESTAMP_SKEW_SECONDS;
 }
 
 function decryptWechatCallbackResource(config: WechatPayRuntimeConfig, envelope: WechatPayCallbackEnvelope): WechatPayCallbackTransaction {
@@ -664,7 +709,7 @@ export function registerWechatPayRoutes(
         emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
           orderId: order.orderId,
           productId: order.productId
-        });
+        }, "/api/payments/wechat/verify");
         sendJson(response, 409, {
           error: {
             code: "payment_already_verified",
@@ -700,7 +745,7 @@ export function registerWechatPayRoutes(
           expectedOpenId,
           receivedOpenId: verified.payerOpenId,
           transactionId: verified.transaction_id
-        });
+        }, "/api/payments/wechat/verify");
         sendJson(response, 409, {
           error: {
             code: "wechat_payment_openid_mismatch",
@@ -722,7 +767,7 @@ export function registerWechatPayRoutes(
           orderId: order.orderId,
           productId: order.productId,
           transactionId: verified.transaction_id
-        });
+        }, "/api/payments/wechat/verify");
         sendJson(response, 409, {
           error: {
             code: "payment_already_verified",
@@ -751,7 +796,7 @@ export function registerWechatPayRoutes(
           orderId: order.orderId,
           productId: order.productId,
           recentVerifiedCount
-        });
+        }, "/api/payments/wechat/verify");
       }
 
       sendJson(response, 200, {
@@ -779,7 +824,7 @@ export function registerWechatPayRoutes(
           orderId: order.orderId,
           productId: order.productId,
           expectedAmount: order.amount
-        });
+        }, "/api/payments/wechat/verify");
       }
       sendJson(response, statusCode, {
         error: {
@@ -809,6 +854,13 @@ export function registerWechatPayRoutes(
     try {
       const rawBody = await readRawBody(request);
       const bodyText = rawBody.toString("utf8");
+      if (!isWechatCallbackTimestampFresh(request.headers, now())) {
+        sendCallbackResponse(response, 401, {
+          code: "FAIL",
+          message: "callback timestamp is outside the allowed replay window"
+        });
+        return;
+      }
       if (!verifyWechatCallbackSignature(runtimeConfig, request.headers, bodyText)) {
         sendCallbackResponse(response, 401, {
           code: "FAIL",
@@ -868,7 +920,7 @@ export function registerWechatPayRoutes(
         emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
           orderId: order.orderId,
           productId: order.productId
-        });
+        }, "/api/payments/wechat/callback");
         sendCallbackResponse(response, 200);
         return;
       }
@@ -887,7 +939,7 @@ export function registerWechatPayRoutes(
           expectedOpenId,
           callbackOpenId: transaction.payer?.openid?.trim() || "",
           verifiedOpenId: verified.payerOpenId
-        });
+        }, "/api/payments/wechat/callback");
         sendCallbackResponse(response, 200);
         return;
       }
@@ -898,7 +950,7 @@ export function registerWechatPayRoutes(
           productId: order.productId,
           expectedAmount: order.amount,
           receivedAmount: resolveVerifiedPaidAmount(transaction.amount)
-        });
+        }, "/api/payments/wechat/callback");
       }
 
       const settlement = await store.completePaymentOrder(order.orderId, {

--- a/apps/server/test/wechat-pay-routes.test.ts
+++ b/apps/server/test/wechat-pay-routes.test.ts
@@ -5,6 +5,7 @@ import { Readable } from "node:stream";
 import test from "node:test";
 import { issueAccountAuthSession } from "../src/auth";
 import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "../src/observability";
 import {
   encryptWechatCallbackResourceForTest,
   registerWechatPayRoutes,
@@ -26,6 +27,10 @@ const TEST_PRODUCTS: Partial<ShopProduct>[] = [
     }
   }
 ];
+
+function buildFreshCallbackNow(): Date {
+  return new Date("2024-04-04T02:22:00Z");
+}
 
 class TestResponse extends EventEmitter {
   statusCode = 200;
@@ -392,6 +397,7 @@ test("wechat pay verify route grants a successful verified payment and stores th
   registerWechatPayRoutes(app as never, store, {
     products: TEST_PRODUCTS,
     runtimeConfig,
+    now: buildFreshCallbackNow,
     fetchImpl: buildVerifyFetch({
       out_trade_no: order.orderId
     })
@@ -458,6 +464,7 @@ test("wechat pay verify route rejects failed verification without granting rewar
 });
 
 test("wechat pay verify route rejects duplicate submissions with 409 and does not double-credit", async () => {
+  resetRuntimeObservability();
   const app = new TestApp();
   const store = await createVerifiedTestStore();
   const runtimeConfig = createWechatPayConfig();
@@ -471,6 +478,7 @@ test("wechat pay verify route rejects duplicate submissions with 409 and does no
   registerWechatPayRoutes(app as never, store, {
     products: TEST_PRODUCTS,
     runtimeConfig,
+    now: buildFreshCallbackNow,
     fetchImpl: buildVerifyFetch({
       out_trade_no: order.orderId
     })
@@ -497,11 +505,13 @@ test("wechat pay verify route rejects duplicate submissions with 409 and does no
   });
   const duplicatePayload = secondResponse.json as { error: { code: string } };
   const account = await store.loadPlayerAccount("wechat-player");
+  const metrics = buildPrometheusMetricsDocument();
 
-  assert.equal(firstResponse.statusCode, 200);
+  assert.equal(firstResponse.statusCode, 200, JSON.stringify(firstResponse));
   assert.equal(secondResponse.statusCode, 409);
   assert.equal(duplicatePayload.error.code, "payment_already_verified");
   assert.equal(account?.gems, 120);
+  assert.match(metrics, /veil_runtime_error_events_total\{error_code="payment_fraud_signal",feature_area="payment",owner_area="commerce",severity="warn"\} 1/);
 });
 
 test("wechat pay verify route rejects amount mismatches", async () => {
@@ -556,6 +566,7 @@ test("wechat pay verify route rejects payer openid mismatches without granting r
   registerWechatPayRoutes(app as never, store, {
     products: TEST_PRODUCTS,
     runtimeConfig,
+    now: buildFreshCallbackNow,
     fetchImpl: buildVerifyFetch({
       out_trade_no: order.orderId,
       openid: "wx-openid-other-player"
@@ -681,6 +692,7 @@ test("wechat pay callback verifies, credits once, and ignores duplicate notifica
   registerWechatPayRoutes(app as never, store, {
     products: TEST_PRODUCTS,
     runtimeConfig,
+    now: buildFreshCallbackNow,
     fetchImpl: buildVerifyFetch({
       out_trade_no: order.orderId
     })
@@ -711,12 +723,14 @@ test("wechat pay callback verifies, credits once, and ignores duplicate notifica
     resource_type: "encrypt-resource",
     resource
   });
-  const timestamp = "1712197200";
-  const nonce = "signature-nonce-1";
-  const signature = signWechatCallbackForTest(runtimeConfig.platformPrivateKey, timestamp, nonce, body);
+  let callbackAttempt = 0;
+  const sendCallback = async () => {
+    const timestamp = String(Math.floor(buildFreshCallbackNow().getTime() / 1000) + callbackAttempt);
+    const nonce = `signature-nonce-${callbackAttempt + 1}`;
+    const signature = signWechatCallbackForTest(runtimeConfig.platformPrivateKey, timestamp, nonce, body);
+    callbackAttempt += 1;
 
-  const sendCallback = async () =>
-    app.invoke("/api/payments/wechat/callback", {
+    return app.invoke("/api/payments/wechat/callback", {
       headers: {
         "content-type": "application/json",
         "wechatpay-timestamp": timestamp,
@@ -726,6 +740,7 @@ test("wechat pay callback verifies, credits once, and ignores duplicate notifica
       },
       body
     });
+  };
 
   const firstResponse = await sendCallback();
   const secondResponse = await sendCallback();
@@ -755,6 +770,7 @@ test("wechat pay callback logs payer mismatches and does not grant rewards", asy
   registerWechatPayRoutes(app as never, store, {
     products: TEST_PRODUCTS,
     runtimeConfig,
+    now: buildFreshCallbackNow,
     fetchImpl: buildVerifyFetch({
       out_trade_no: order.orderId,
       openid: "wx-openid-other-player"
@@ -786,7 +802,7 @@ test("wechat pay callback logs payer mismatches and does not grant rewards", asy
     resource_type: "encrypt-resource",
     resource
   });
-  const timestamp = "1712197201";
+  const timestamp = String(Math.floor(buildFreshCallbackNow().getTime() / 1000));
   const nonce = "signature-nonce-2";
   const signature = signWechatCallbackForTest(runtimeConfig.platformPrivateKey, timestamp, nonce, body);
 
@@ -816,7 +832,8 @@ test("wechat pay callback rejects invalid signatures", async () => {
   const runtimeConfig = createWechatPayConfig();
   registerWechatPayRoutes(app as never, store, {
     products: TEST_PRODUCTS,
-    runtimeConfig
+    runtimeConfig,
+    now: buildFreshCallbackNow
   });
 
   const response = await app.invoke("/api/payments/wechat/callback", {
@@ -841,6 +858,43 @@ test("wechat pay callback rejects invalid signatures", async () => {
   assert.match(payload.message, /signature verification failed/);
 });
 
+test("wechat pay callback rejects timestamps outside the replay window", async () => {
+  const app = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  const runtimeConfig = createWechatPayConfig();
+  registerWechatPayRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    runtimeConfig,
+    now: () => new Date("2026-04-11T01:01:00Z")
+  });
+
+  const body = JSON.stringify({
+    id: "evt-stale",
+    event_type: "TRANSACTION.SUCCESS",
+    resource_type: "encrypt-resource",
+    resource: null
+  });
+  const staleTimestamp = String(Math.floor(new Date("2026-04-11T00:50:00Z").getTime() / 1000));
+  const nonce = "stale-signature-nonce";
+  const signature = signWechatCallbackForTest(runtimeConfig.platformPrivateKey, staleTimestamp, nonce, body);
+
+  const response = await app.invoke("/api/payments/wechat/callback", {
+    headers: {
+      "content-type": "application/json",
+      "wechatpay-timestamp": staleTimestamp,
+      "wechatpay-nonce": nonce,
+      "wechatpay-serial": runtimeConfig.platformCertificateSerial,
+      "wechatpay-signature": signature
+    },
+    body
+  });
+  const payload = response.json as { code: string; message: string };
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(payload.code, "FAIL");
+  assert.match(payload.message, /replay window/);
+});
+
 test("wechat pay callback rejects unsupported trade states", async () => {
   const store = new MemoryRoomSnapshotStore();
   const runtimeConfig = createWechatPayConfig();
@@ -848,6 +902,7 @@ test("wechat pay callback rejects unsupported trade states", async () => {
   registerWechatPayRoutes(callbackApp as never, store, {
     products: TEST_PRODUCTS,
     runtimeConfig,
+    now: buildFreshCallbackNow,
     fetchImpl: buildVerifyFetch({})
   });
 
@@ -905,6 +960,7 @@ test("wechat pay callback rejects merchant mismatches", async () => {
   registerWechatPayRoutes(callbackApp as never, store, {
     products: TEST_PRODUCTS,
     runtimeConfig,
+    now: buildFreshCallbackNow,
     fetchImpl: buildVerifyFetch({})
   });
 
@@ -962,6 +1018,7 @@ test("wechat pay callback rejects missing order ids, missing orders, and missing
   registerWechatPayRoutes(callbackApp as never, store, {
     products: TEST_PRODUCTS,
     runtimeConfig,
+    now: buildFreshCallbackNow,
     fetchImpl: buildVerifyFetch({})
   });
 

--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -57,6 +57,17 @@ groups:
           description: The 95th percentile HTTP request latency has exceeded 750ms for 10 minutes. Inspect runtime saturation, downstream auth/config dependencies, and noisy operators.
           runbook_url: ./alerting-runbook.md#alert-veilhttprequestlatencyp95high
 
+      - alert: VeilWechatPaymentFraudSignalsHigh
+        expr: increase(veil_runtime_error_events_total{feature_area="payment",error_code="payment_fraud_signal"}[15m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+          service: project-veil-server
+        annotations:
+          summary: Project Veil is detecting WeChat payment fraud or integrity anomalies
+          description: `payment_fraud_signal` fired within the last 15 minutes. Freeze risky compensation/refund actions, inspect duplicate callbacks or payer mismatches, and review the current candidate before continuing rollout.
+          runbook_url: ./wechat-pay-ops-runbook.md#payment-fraud-signal-alert
+
       - alert: VeilFeatureFlagConfigStale
         expr: max(veil_feature_flag_config_stale) > 0
         for: 2m

--- a/docs/core-gameplay-release-readiness.md
+++ b/docs/core-gameplay-release-readiness.md
@@ -29,6 +29,7 @@
 - Cocos / WeChat RC blocker 模板：`docs/release-evidence/cocos-wechat-rc-blockers.template.md`
 - WeChat runtime observability 签核模板：`docs/release-evidence/wechat-runtime-observability-signoff.template.md`
 - 微信小游戏提审前冒烟：`docs/wechat-minigame-release.md`
+- WeChat Pay 退款 / 争议 / 防欺诈运营手册：`docs/wechat-pay-ops-runbook.md`
 
 ## 发布判断规则
 
@@ -143,6 +144,7 @@
 - [ ] 至少能看到活跃房间数、连接数、世界 / 战斗 action 计数、房间 create/dispose、reconnect success/failure、battle completion/abort，以及鉴权会话摘要。
 - [ ] 日志或接口输出足以区分登录失败、进房失败、同步失败和资源 / 配置失败。
 - [ ] WeChat release candidate / shipping candidate 已回填 candidate-scoped runtime observability sign-off，并记录 reviewer、`recordedAt`、target revision 与结论。
+- [ ] 如候选包承载 WeChat Pay，`payment_fraud_signal` 告警与退款 / 补偿值班流程已按 `docs/wechat-pay-ops-runbook.md` 确认，且至少演练一次未到账补偿或重复回调幂等路径。
 
 `P1 follow-up`
 

--- a/docs/release-evidence/wechat-commercial-verification.example.json
+++ b/docs/release-evidence/wechat-commercial-verification.example.json
@@ -4,7 +4,7 @@
     "title": "WeChat payment end-to-end verified",
     "status": "pending",
     "required": true,
-    "notes": "Verify payment initiation, callback,到账、失败补偿和风控/完整性事件记录 against the packaged candidate revision.",
+    "notes": "Verify payment initiation, callback,到账、失败补偿、退款/争议 handoff 和风控/完整性事件记录 against the packaged candidate revision.",
     "owner": "<commerce-owner>",
     "recordedAt": "<2026-04-10T09:00:00.000Z>",
     "revision": "<git-sha>",
@@ -13,6 +13,7 @@
       "payment order create evidence",
       "callback / receipt evidence",
       "compensation / retry evidence",
+      "refund / dispute handoff note referencing docs/wechat-pay-ops-runbook.md",
       "payment_fraud_signal analytics capture"
     ],
     "acceptedRisks": [

--- a/docs/wechat-pay-ops-runbook.md
+++ b/docs/wechat-pay-ops-runbook.md
@@ -1,0 +1,125 @@
+# WeChat Pay 退款 / 争议处理与防欺诈运营手册
+
+适用范围：
+
+- `apps/server/src/wechat-pay.ts` 提供的 WeChat Pay 下单、验单、回调链路
+- `packages/shared/src/analytics-events.ts` 中的 `payment_fraud_signal`
+- `docs/alerting-rules.yml` 中的 `VeilWechatPaymentFraudSignalsHigh` 告警
+
+在以下情况打开本手册：
+
+- 玩家反馈未到账、重复扣款、错商品到账
+- WeChat Pay 退款或争议单需要运营审批
+- `payment_fraud_signal` 被触发，或 Prometheus 告警命中支付风控信号
+- 怀疑回调被重放、签名异常、订单号重复使用
+
+## 值班与时限
+
+| 事件类型 | 值班 owner | 首次响应目标 | 完成目标 |
+| --- | --- | --- | --- |
+| 玩家未到账 / 重复扣款 | commerce on-call | 15 分钟 | 4 小时内给出补偿或退款结论 |
+| WeChat Pay 退款申请 | commerce approver + finance reviewer | 30 分钟 | 1 个工作日内完成审批与执行 |
+| 争议 / 欺诈信号 / 回调重放怀疑 | commerce on-call + backend on-call | 15 分钟 | 2 小时内完成隔离、审计与升级 |
+
+升级规则：
+
+- 同一玩家 15 分钟内出现 2 次以上 `payment_fraud_signal`，直接升级到 backend on-call。
+- 同一候选版本 15 分钟内出现 1 次以上 `VeilWechatPaymentFraudSignalsHigh`，暂停该版本继续放量或提审。
+- 涉及重复扣款、批量未到账、或疑似恶意回调重放时，必须同时通知 finance reviewer。
+
+## 退款与争议处理
+
+审批矩阵：
+
+| 场景 | 审批人 | 执行人 | 必备证据 |
+| --- | --- | --- | --- |
+| 未到账但微信侧已扣款 | commerce approver | commerce on-call | `payment_orders`、`payment_receipts`、玩家工单、补偿记录 |
+| 重复扣款 | finance reviewer | commerce on-call | 同一 `playerId` / `productId` / 交易时间窗内的多笔订单与回调记录 |
+| 商品错发 / 金额不符 | commerce approver + backend on-call | commerce on-call | 订单金额、商品配置、`payment_fraud_signal` 或验单错误记录 |
+| 用户主动退款 / 第三方争议 | finance reviewer | commerce on-call | 工单、微信商户后台截图、内部审计日志 |
+
+操作步骤：
+
+1. 先在 `payment_orders` 和 `payment_receipts` 中按 `orderId`、`playerId`、`transactionId` 检索交易事实，不要仅凭工单文本做判断。
+2. 再核对 `apps/server/src/wechat-pay.ts` 当前版本是否已把该订单标记为 `paid`，以及是否已经完成发货。
+3. 若微信已扣款但游戏未到账，优先走补偿 SOP；只有补偿风险高、证据不一致或玩家明确要求原路退回时才发起退款。
+4. 若确认重复扣款，先冻结该玩家的后续人工补单，再按 finance reviewer 审批结果执行退款。
+5. 若为争议单，必须记录内部结论、审批人、执行人、执行时间、外部单号，并在 1 个工作日内回填工单。
+
+## 未到账 / 重复扣款补偿 SOP
+
+未到账：
+
+1. 用 `/api/payments/wechat/verify` 或回调对应的 `out_trade_no` 查明是否已验单成功。
+2. 如果微信订单成功、`payment_receipts` 缺失、且商品金额与 `openid` 一致，先由 backend on-call 确认是否可以安全重试补偿。
+3. 重试成功后，在工单和审计日志中记录补偿方式、操作者、时间、关联 `orderId`。
+4. 若 30 分钟内无法安全补偿，转为退款审批流。
+
+重复扣款：
+
+1. 检查同一玩家是否存在多个不同 `orderId` 指向相同支付动作，或同一 `orderId` 被重复回调。
+2. 如果只是相同 `out_trade_no` 的重复通知，当前服务端会幂等返回成功，不做二次发货。
+3. 如果是两笔真实成功交易且只应成交一次，按退款审批流处理，并把重复交易窗口内的所有 `transactionId` 记入审计日志。
+
+## 回调重放攻击检测与防御
+
+当前代码面的最低防线：
+
+- 平台证书序列号必须匹配 `VEIL_WECHAT_PAY_PLATFORM_SERIAL`
+- 回调签名必须通过 `wechatpay-signature` 校验
+- 回调时间戳必须落在 5 分钟 replay window 内
+- `out_trade_no` 已支付或已有 receipt 时，只做幂等处理并上报 `duplicate_out_trade_no`
+- 回调到账后仍会再次向微信查询订单状态，校验 `appid`、`mchid`、金额、`openid`
+
+运营检查项：
+
+1. 如果发现回调时间戳超窗、序列号不匹配或签名异常，立即视为潜在重放/伪造流量。
+2. 保留原始请求头里的 `wechatpay-timestamp`、`wechatpay-nonce`、`wechatpay-serial`，不要只截图响应结果。
+3. 同一 `orderId` 在短时间内重复出现时，结合 `payment_fraud_signal` 和 `payment_receipts` 判断是正常重试还是恶意重放。
+4. 如怀疑平台证书泄露或配置漂移，立即轮换 `VEIL_WECHAT_PAY_PLATFORM_PUBLIC_KEY` / `VEIL_WECHAT_PAY_PLATFORM_SERIAL` 并冻结继续放量。
+
+## Payment Fraud Signal Alert
+
+`docs/alerting-rules.yml` 已将 `payment_fraud_signal` 接到 `VeilWechatPaymentFraudSignalsHigh`。
+
+收到告警后执行：
+
+1. 抓取 `/metrics`，确认 `veil_runtime_error_events_total{feature_area="payment",error_code="payment_fraud_signal"}` 的增长窗口和数量。
+2. 打开 `/api/runtime/diagnostic-snapshot`，检查最近的 payment runtime error 与相关 `playerId`。
+3. 在 analytics 或日志侧按 `signal` 聚合，优先识别 `duplicate_out_trade_no`、`openid_mismatch`、`amount_mismatch`、`high_velocity_purchases`。
+4. 若是单个玩家异常，先冻结该玩家的人工补偿和高风险道具发放。
+5. 若是候选版本级异常，暂停该 candidate 的继续提审 / 放量，并要求 backend on-call 审核最近支付变更。
+
+## 支付流水审计日志格式
+
+每次退款、争议、补偿、风控升级都必须至少记录以下字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `recordedAt` | 处理时间，ISO-8601 |
+| `operator` | 操作人 |
+| `reviewer` | 审批人；无审批则写 `n/a` |
+| `playerId` | 玩家 ID |
+| `orderId` | 内部 `out_trade_no` |
+| `transactionId` | 微信交易单号；未知时写 `pending` |
+| `productId` | 商品 ID |
+| `amountFen` | 金额，分 |
+| `reason` | 退款、补偿、争议、风控升级原因 |
+| `action` | `refund_requested` / `refund_completed` / `compensation_granted` / `dispute_opened` / `fraud_escalated` |
+| `evidence` | 工单、截图、SQL 查询、artifact 路径 |
+
+## 保留策略
+
+- `payment_orders` 与 `payment_receipts` 不应接入 snapshot TTL 清理。
+- 带支付环境的备份保留必须至少覆盖 3 年；最小要求是把 `VEIL_BACKUP_KEEP_WEEKLY_DAYS` 提升到 `1095` 或使用等效的冷归档策略。
+- 审计日志、退款审批记录、争议证据与补偿记录必须与支付流水一起保留至少 3 年。
+- 不允许只保留截图。最终留存必须能回溯到 `orderId`、`transactionId` 和审批结论。
+
+## Release Checklist 挂钩
+
+进入 WeChat release candidate / shipping candidate 前，额外确认：
+
+- `docs/core-gameplay-release-readiness.md` 中的支付运维检查项已回填
+- `docs/release-evidence/wechat-commercial-verification.example.json` 对应的 payment check 已附上本手册要求的证据
+- `payment_fraud_signal` 告警路由和值班 owner 已确认
+- 本次候选版本涉及支付改动时，至少演练一次“未到账补偿”或“重复回调幂等”路径


### PR DESCRIPTION
## Summary
- add `docs/wechat-pay-ops-runbook.md` covering refund approval, dispute handling, compensation SOP, replay-attack response, audit fields, and a 3-year retention strategy for payment-bearing environments
- wire `payment_fraud_signal` into runtime error metrics and add a Prometheus alert in `docs/alerting-rules.yml`
- add a 5-minute callback replay window check in `apps/server/src/wechat-pay.ts` and extend the WeChat Pay route tests for the new guard and fraud metric surface
- link the runbook into the release checklist and WeChat commercial verification example

## Validation
- `npm run typecheck:server`
- `node --import tsx --test ./apps/server/test/wechat-pay-routes.test.ts`
- `npm run test:wechat-commercial-verification`

Closes #1199
