### PR TITLE
[codex] Add player support infrastructure slice

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -27,9 +27,24 @@ type AdminApp = {
   get: (path: string, handler: AdminRouteHandler) => void;
   post: (path: string, handler: AdminRouteHandler) => void;
 };
+type AdminRole = "admin" | "support-moderator" | "support-supervisor";
+type BanApproval = {
+  approvedBy: string;
+  approvalReference: string;
+};
 
 function readAdminSecret(): string | null {
   const secret = process.env.ADMIN_SECRET?.trim();
+  return secret ? secret : null;
+}
+
+function readSupportModeratorSecret(): string | null {
+  const secret = process.env.SUPPORT_MODERATOR_SECRET?.trim();
+  return secret ? secret : null;
+}
+
+function readSupportSupervisorSecret(): string | null {
+  const secret = process.env.SUPPORT_SUPERVISOR_SECRET?.trim();
   return secret ? secret : null;
 }
 
@@ -37,9 +52,44 @@ function isAdminSecretConfigured(): boolean {
   return readAdminSecret() !== null;
 }
 
+function isSupportSecretConfigured(): boolean {
+  return Boolean(readAdminSecret() || readSupportModeratorSecret() || readSupportSupervisorSecret());
+}
+
+function readHeaderSecret(request: IncomingMessage): string | null {
+  const header = request.headers["x-veil-admin-secret"];
+  if (typeof header === "string") {
+    const trimmed = header.trim();
+    return trimmed ? trimmed : null;
+  }
+  return null;
+}
+
 function isAuthorized(request: IncomingMessage): boolean {
   const adminSecret = readAdminSecret();
-  return adminSecret !== null && request.headers["x-veil-admin-secret"] === adminSecret;
+  return adminSecret !== null && readHeaderSecret(request) === adminSecret;
+}
+
+function readAdminRole(request: IncomingMessage): AdminRole | null {
+  const requestSecret = readHeaderSecret(request);
+  if (!requestSecret) {
+    return null;
+  }
+
+  if (requestSecret === readAdminSecret()) {
+    return "admin";
+  }
+  if (requestSecret === readSupportSupervisorSecret()) {
+    return "support-supervisor";
+  }
+  if (requestSecret === readSupportModeratorSecret()) {
+    return "support-moderator";
+  }
+  return null;
+}
+
+function hasRequiredRole(role: AdminRole | null, allowedRoles: AdminRole[]): boolean {
+  return role !== null && allowedRoles.includes(role);
 }
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -59,8 +109,18 @@ function sendAdminSecretNotConfigured(response: ServerResponse): void {
   sendJson(response, 503, { error: "ADMIN_SECRET is not configured" });
 }
 
+function sendSupportSecretNotConfigured(response: ServerResponse): void {
+  sendJson(response, 503, {
+    error: "Player support secrets are not configured"
+  });
+}
+
 function sendStoreUnavailable(response: ServerResponse): void {
   sendJson(response, 503, { error: "Player moderation requires configured room persistence storage" });
+}
+
+function sendForbiddenRole(response: ServerResponse, message: string): void {
+  sendJson(response, 403, { error: message });
 }
 
 function hasBanModerationStore(
@@ -135,7 +195,41 @@ function parseIsoTimestamp(value: string, key: string): string {
   return parsed.toISOString();
 }
 
-function parseBanBody(value: unknown): { banStatus: "temporary" | "permanent"; banReason: string; banExpiry?: string } {
+function parseApproval(
+  payload: Record<string, unknown>,
+  key = "approval",
+  required = false
+): BanApproval | undefined {
+  const value = payload[key];
+  if (value === undefined || value === null) {
+    if (required) {
+      throw new InvalidAdminPayloadError(`"${key}" is required`);
+    }
+    return undefined;
+  }
+
+  const approval = readRequiredObjectBody(value);
+  const approvedBy = readOptionalTrimmedString(approval, "approvedBy");
+  const approvalReference = readOptionalTrimmedString(approval, "approvalReference");
+  if (!approvedBy) {
+    throw new InvalidAdminPayloadError(`"${key}.approvedBy" must be a non-empty string`);
+  }
+  if (!approvalReference) {
+    throw new InvalidAdminPayloadError(`"${key}.approvalReference" must be a non-empty string`);
+  }
+  return { approvedBy, approvalReference };
+}
+
+function withApprovalSuffix(banReason: string, approval?: BanApproval): string {
+  if (!approval) {
+    return banReason;
+  }
+  return `${banReason} [approvedBy=${approval.approvedBy}; approvalReference=${approval.approvalReference}]`;
+}
+
+function parseBanBody(
+  value: unknown
+): { banStatus: "temporary" | "permanent"; banReason: string; banExpiry?: string; approval?: BanApproval } {
   const payload = readRequiredObjectBody(value);
   const banStatus = readOptionalTrimmedString(payload, "banStatus");
   const banReason = readOptionalTrimmedString(payload, "banReason");
@@ -158,7 +252,14 @@ function parseBanBody(value: unknown): { banStatus: "temporary" | "permanent"; b
     return { banStatus, banReason, banExpiry: normalizedExpiry };
   }
 
-  return { banStatus, banReason };
+  return {
+    banStatus,
+    banReason,
+    ...(() => {
+      const approval = parseApproval(payload, "approval", true);
+      return approval ? { approval } : {};
+    })()
+  };
 }
 
 function parseUnbanBody(value: unknown): { reason?: string } {
@@ -219,19 +320,45 @@ function parseReportStatus(value: string | null | undefined, fallback: PlayerRep
   throw new InvalidAdminPayloadError('"status" must be "pending", "dismissed", "warned", or "banned"');
 }
 
-function parseResolveReportBody(value: unknown): PlayerReportResolveInput {
+function parseResolveReportBody(value: unknown): PlayerReportResolveInput & { approval?: BanApproval } {
   const payload = readRequiredObjectBody(value);
   const status = parseReportStatus(readOptionalTrimmedString(payload, "status"), "pending");
   if (status === "pending") {
     throw new InvalidAdminPayloadError('"status" must be "dismissed", "warned", or "banned"');
   }
 
-  return { status };
+  return {
+    status,
+    ...(status === "banned"
+      ? (() => {
+          const approval = parseApproval(payload, "approval", true);
+          return approval ? { approval } : {};
+        })()
+      : {})
+  };
 }
 
 function readReportStatusFilter(request: IncomingMessage): PlayerReportStatus {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
   return parseReportStatus(url.searchParams.get("status"), "pending");
+}
+
+function requireSupportRole(response: ServerResponse, request: IncomingMessage, allowedRoles: AdminRole[]): AdminRole | null {
+  if (!isSupportSecretConfigured()) {
+    sendSupportSecretNotConfigured(response);
+    return null;
+  }
+
+  const role = readAdminRole(request);
+  if (!role) {
+    sendUnauthorized(response);
+    return null;
+  }
+  if (!hasRequiredRole(role, allowedRoles)) {
+    sendForbiddenRole(response, "Forbidden: support role does not allow this action");
+    return null;
+  }
+  return role;
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
@@ -401,14 +528,21 @@ export function registerAdminRoutes(
   });
 
   app.post("/api/admin/players/:id/ban", async (request, response) => {
-    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
-    if (!isAuthorized(request)) return sendUnauthorized(response);
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
     if (!hasBanModerationStore(store)) return sendStoreUnavailable(response);
 
     try {
       const playerId = readRequiredParam(request, "id");
       const input = parseBanBody(await readJsonBody(request));
-      const account = await store.savePlayerBan(playerId, input);
+      if (input.banStatus === "permanent" && !hasRequiredRole(role, ["admin", "support-supervisor"])) {
+        sendForbiddenRole(response, "Forbidden: permanent bans require support-supervisor or admin credentials");
+        return;
+      }
+      const account = await store.savePlayerBan(playerId, {
+        ...input,
+        banReason: withApprovalSuffix(input.banReason, input.approval)
+      });
       let disconnectedClients = 0;
       for (const room of getActiveRoomInstances().values()) {
         disconnectedClients += room.disconnectPlayer(playerId, "account_banned");
@@ -428,12 +562,17 @@ export function registerAdminRoutes(
   });
 
   app.post("/api/admin/players/:id/unban", async (request, response) => {
-    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
-    if (!isAuthorized(request)) return sendUnauthorized(response);
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
     if (!hasBanModerationStore(store)) return sendStoreUnavailable(response);
 
     try {
       const playerId = readRequiredParam(request, "id");
+      const currentBan = await store.loadPlayerBan(playerId);
+      if (currentBan?.banStatus === "permanent" && !hasRequiredRole(role, ["admin", "support-supervisor"])) {
+        sendForbiddenRole(response, "Forbidden: permanent-ban reversals require support-supervisor or admin credentials");
+        return;
+      }
       const input = parseUnbanBody(await readJsonBody(request));
       const account = await store.clearPlayerBan(playerId, input);
       sendJson(response, 200, { ok: true, account });
@@ -451,8 +590,7 @@ export function registerAdminRoutes(
   });
 
   app.get("/api/admin/players/:id/ban-history", async (request, response) => {
-    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
-    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"])) return;
     if (!hasBanModerationStore(store)) return sendStoreUnavailable(response);
 
     try {
@@ -470,8 +608,7 @@ export function registerAdminRoutes(
   });
 
   app.get("/api/admin/reports", async (request, response) => {
-    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
-    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"])) return;
     if (!hasPlayerReportStore(store)) return sendStoreUnavailable(response);
 
     try {
@@ -488,13 +625,17 @@ export function registerAdminRoutes(
   });
 
   app.post("/api/admin/reports/:id/resolve", async (request, response) => {
-    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
-    if (!isAuthorized(request)) return sendUnauthorized(response);
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
     if (!hasPlayerReportStore(store)) return sendStoreUnavailable(response);
 
     try {
       const reportId = readRequiredParam(request, "id");
       const input = parseResolveReportBody(await readJsonBody(request));
+      if (input.status === "banned" && !hasRequiredRole(role, ["admin", "support-supervisor"])) {
+        sendForbiddenRole(response, "Forbidden: permanent bans require support-supervisor or admin credentials");
+        return;
+      }
       const report = await store.resolvePlayerReport(reportId, input);
       if (!report) {
         sendJson(response, 404, { error: "Report not found" });
@@ -505,7 +646,7 @@ export function registerAdminRoutes(
       if (input.status === "banned" && hasBanModerationStore(store)) {
         await store.savePlayerBan(report.targetId, {
           banStatus: "permanent",
-          banReason: `Resolved from player report ${report.reportId}`
+          banReason: withApprovalSuffix(`Resolved from player report ${report.reportId}`, input.approval)
         });
         for (const room of getActiveRoomInstances().values()) {
           disconnectedClients += room.disconnectPlayer(report.targetId, "account_banned");
@@ -518,6 +659,41 @@ export function registerAdminRoutes(
         sendInvalidJson(response);
         return;
       }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.get("/api/admin/players/:id/export", async (request, response) => {
+    if (!requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"])) return;
+    if (!store?.loadPlayerAccount) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request, "id");
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, { error: "Player account not found" });
+        return;
+      }
+
+      const currentBan = hasBanModerationStore(store) ? await store.loadPlayerBan(playerId) : null;
+      const banHistory = hasBanModerationStore(store)
+        ? await store.listPlayerBanHistory(playerId, { limit: readLimit(request, 100) })
+        : [];
+
+      sendJson(response, 200, {
+        playerId,
+        exportedAt: new Date().toISOString(),
+        account,
+        moderation: {
+          currentBan,
+          banHistory
+        }
+      });
+    } catch (error) {
       if (error instanceof InvalidAdminPayloadError) {
         sendInvalidPayload(response, error.message);
         return;

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -90,6 +90,34 @@ function withAdminSecret(t: TestContext, secret = "test-admin-secret"): string {
   return secret;
 }
 
+function withSupportSecrets(
+  t: TestContext,
+  options: {
+    moderator?: string;
+    supervisor?: string;
+  } = {}
+): { moderator: string; supervisor: string } {
+  const moderator = options.moderator ?? "test-support-moderator-secret";
+  const supervisor = options.supervisor ?? "test-support-supervisor-secret";
+  const originalModeratorSecret = process.env.SUPPORT_MODERATOR_SECRET;
+  const originalSupervisorSecret = process.env.SUPPORT_SUPERVISOR_SECRET;
+  process.env.SUPPORT_MODERATOR_SECRET = moderator;
+  process.env.SUPPORT_SUPERVISOR_SECRET = supervisor;
+  t.after(() => {
+    if (originalModeratorSecret === undefined) {
+      delete process.env.SUPPORT_MODERATOR_SECRET;
+    } else {
+      process.env.SUPPORT_MODERATOR_SECRET = originalModeratorSecret;
+    }
+    if (originalSupervisorSecret === undefined) {
+      delete process.env.SUPPORT_SUPERVISOR_SECRET;
+    } else {
+      process.env.SUPPORT_SUPERVISOR_SECRET = originalSupervisorSecret;
+    }
+  });
+  return { moderator, supervisor };
+}
+
 function registerRoutes(store: RoomSnapshotStore | null = null) {
   const { app, gets, posts } = createTestApp();
   registerAdminRoutes(app, store);
@@ -654,7 +682,8 @@ test("POST /api/admin/broadcast returns 400 for invalid payload types", async (t
 });
 
 test("POST /api/admin/players/:id/ban bans the player and POST /unban clears it", async (t) => {
-  const secret = withAdminSecret(t);
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
   const store = createStore({
     "player-7": { gold: 1, wood: 2, ore: 3 }
   });
@@ -670,7 +699,7 @@ test("POST /api/admin/players/:id/ban bans the player and POST /unban clears it"
       method: "POST",
       params: { id: "player-7" },
       headers: {
-        "x-veil-admin-secret": secret
+        "x-veil-admin-secret": moderator
       },
       body: JSON.stringify({
         banStatus: "temporary",
@@ -699,7 +728,7 @@ test("POST /api/admin/players/:id/ban bans the player and POST /unban clears it"
       method: "POST",
       params: { id: "player-7" },
       headers: {
-        "x-veil-admin-secret": secret
+        "x-veil-admin-secret": moderator
       },
       body: JSON.stringify({ reason: "Appeal approved" })
     }),
@@ -718,7 +747,8 @@ test("POST /api/admin/players/:id/ban bans the player and POST /unban clears it"
 });
 
 test("GET /api/admin/players/:id/ban-history returns current ban state and history records", async (t) => {
-  const secret = withAdminSecret(t);
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
   const store = createStore();
   await store.savePlayerBan("player-history", {
     banStatus: "permanent",
@@ -736,7 +766,7 @@ test("GET /api/admin/players/:id/ban-history returns current ban state and histo
     createRequest({
       params: { id: "player-history" },
       headers: {
-        "x-veil-admin-secret": secret
+        "x-veil-admin-secret": moderator
       }
     }),
     response
@@ -754,7 +784,8 @@ test("GET /api/admin/players/:id/ban-history returns current ban state and histo
 });
 
 test("GET /api/admin/reports returns filtered player reports", async (t) => {
-  const secret = withAdminSecret(t);
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
   const store = createStore();
   await store.createPlayerReport({
     reporterId: "player-1",
@@ -779,7 +810,7 @@ test("GET /api/admin/reports returns filtered player reports", async (t) => {
     createRequest({
       url: "/api/admin/reports?status=pending",
       headers: {
-        "x-veil-admin-secret": secret
+        "x-veil-admin-secret": moderator
       }
     }),
     response
@@ -797,7 +828,8 @@ test("GET /api/admin/reports returns filtered player reports", async (t) => {
 });
 
 test("POST /api/admin/reports/:id/resolve marks a report resolved", async (t) => {
-  const secret = withAdminSecret(t);
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
   const store = createStore();
   const report = await store.createPlayerReport({
     reporterId: "player-1",
@@ -816,7 +848,7 @@ test("POST /api/admin/reports/:id/resolve marks a report resolved", async (t) =>
       method: "POST",
       params: { id: report.reportId },
       headers: {
-        "x-veil-admin-secret": secret
+        "x-veil-admin-secret": moderator
       },
       body: JSON.stringify({ status: "warned" })
     }),
@@ -871,6 +903,7 @@ test("GET /admin serves admin.html with text/html content-type", async (t) => {
 
 test("POST /api/admin/players/:id/unban returns 401 without a valid admin secret", async (t) => {
   withAdminSecret(t);
+  withSupportSecrets(t);
   const store = createStore();
   const { posts } = registerRoutes(store as RoomSnapshotStore);
   const handler = posts.get("/api/admin/players/:id/unban");
@@ -890,9 +923,13 @@ test("POST /api/admin/players/:id/unban returns 401 without a valid admin secret
   assert.deepEqual(JSON.parse(response.body), { error: "Unauthorized: Invalid Admin Secret" });
 });
 
-test("POST /api/admin/players/:id/unban returns 503 when ADMIN_SECRET is not configured", async () => {
+test("POST /api/admin/players/:id/unban returns 503 when support secrets are not configured", async () => {
   const original = process.env.ADMIN_SECRET;
+  const originalModeratorSecret = process.env.SUPPORT_MODERATOR_SECRET;
+  const originalSupervisorSecret = process.env.SUPPORT_SUPERVISOR_SECRET;
   delete process.env.ADMIN_SECRET;
+  delete process.env.SUPPORT_MODERATOR_SECRET;
+  delete process.env.SUPPORT_SUPERVISOR_SECRET;
   try {
     const { posts } = registerRoutes();
     const handler = posts.get("/api/admin/players/:id/unban");
@@ -905,19 +942,33 @@ test("POST /api/admin/players/:id/unban returns 503 when ADMIN_SECRET is not con
     );
 
     assert.equal(response.statusCode, 503);
-    assert.deepEqual(JSON.parse(response.body), { error: "ADMIN_SECRET is not configured" });
+    assert.deepEqual(JSON.parse(response.body), { error: "Player support secrets are not configured" });
   } finally {
     if (original === undefined) {
       delete process.env.ADMIN_SECRET;
     } else {
       process.env.ADMIN_SECRET = original;
     }
+    if (originalModeratorSecret === undefined) {
+      delete process.env.SUPPORT_MODERATOR_SECRET;
+    } else {
+      process.env.SUPPORT_MODERATOR_SECRET = originalModeratorSecret;
+    }
+    if (originalSupervisorSecret === undefined) {
+      delete process.env.SUPPORT_SUPERVISOR_SECRET;
+    } else {
+      process.env.SUPPORT_SUPERVISOR_SECRET = originalSupervisorSecret;
+    }
   }
 });
 
-test("GET /api/admin/players/:id/ban-history returns 503 when ADMIN_SECRET is not configured", async () => {
+test("GET /api/admin/players/:id/ban-history returns 503 when support secrets are not configured", async () => {
   const original = process.env.ADMIN_SECRET;
+  const originalModeratorSecret = process.env.SUPPORT_MODERATOR_SECRET;
+  const originalSupervisorSecret = process.env.SUPPORT_SUPERVISOR_SECRET;
   delete process.env.ADMIN_SECRET;
+  delete process.env.SUPPORT_MODERATOR_SECRET;
+  delete process.env.SUPPORT_SUPERVISOR_SECRET;
   try {
     const store = createStore();
     const { gets } = registerRoutes(store as RoomSnapshotStore);
@@ -928,19 +979,33 @@ test("GET /api/admin/players/:id/ban-history returns 503 when ADMIN_SECRET is no
     await handler(createRequest({ params: { id: "player-1" } }), response);
 
     assert.equal(response.statusCode, 503);
-    assert.deepEqual(JSON.parse(response.body), { error: "ADMIN_SECRET is not configured" });
+    assert.deepEqual(JSON.parse(response.body), { error: "Player support secrets are not configured" });
   } finally {
     if (original === undefined) {
       delete process.env.ADMIN_SECRET;
     } else {
       process.env.ADMIN_SECRET = original;
     }
+    if (originalModeratorSecret === undefined) {
+      delete process.env.SUPPORT_MODERATOR_SECRET;
+    } else {
+      process.env.SUPPORT_MODERATOR_SECRET = originalModeratorSecret;
+    }
+    if (originalSupervisorSecret === undefined) {
+      delete process.env.SUPPORT_SUPERVISOR_SECRET;
+    } else {
+      process.env.SUPPORT_SUPERVISOR_SECRET = originalSupervisorSecret;
+    }
   }
 });
 
-test("GET /api/admin/reports returns 503 when ADMIN_SECRET is not configured", async () => {
+test("GET /api/admin/reports returns 503 when support secrets are not configured", async () => {
   const original = process.env.ADMIN_SECRET;
+  const originalModeratorSecret = process.env.SUPPORT_MODERATOR_SECRET;
+  const originalSupervisorSecret = process.env.SUPPORT_SUPERVISOR_SECRET;
   delete process.env.ADMIN_SECRET;
+  delete process.env.SUPPORT_MODERATOR_SECRET;
+  delete process.env.SUPPORT_SUPERVISOR_SECRET;
   try {
     const store = createStore();
     const { gets } = registerRoutes(store as RoomSnapshotStore);
@@ -951,19 +1016,33 @@ test("GET /api/admin/reports returns 503 when ADMIN_SECRET is not configured", a
     await handler(createRequest({ url: "/api/admin/reports" }), response);
 
     assert.equal(response.statusCode, 503);
-    assert.deepEqual(JSON.parse(response.body), { error: "ADMIN_SECRET is not configured" });
+    assert.deepEqual(JSON.parse(response.body), { error: "Player support secrets are not configured" });
   } finally {
     if (original === undefined) {
       delete process.env.ADMIN_SECRET;
     } else {
       process.env.ADMIN_SECRET = original;
     }
+    if (originalModeratorSecret === undefined) {
+      delete process.env.SUPPORT_MODERATOR_SECRET;
+    } else {
+      process.env.SUPPORT_MODERATOR_SECRET = originalModeratorSecret;
+    }
+    if (originalSupervisorSecret === undefined) {
+      delete process.env.SUPPORT_SUPERVISOR_SECRET;
+    } else {
+      process.env.SUPPORT_SUPERVISOR_SECRET = originalSupervisorSecret;
+    }
   }
 });
 
-test("POST /api/admin/reports/:id/resolve returns 503 when ADMIN_SECRET is not configured", async () => {
+test("POST /api/admin/reports/:id/resolve returns 503 when support secrets are not configured", async () => {
   const original = process.env.ADMIN_SECRET;
+  const originalModeratorSecret = process.env.SUPPORT_MODERATOR_SECRET;
+  const originalSupervisorSecret = process.env.SUPPORT_SUPERVISOR_SECRET;
   delete process.env.ADMIN_SECRET;
+  delete process.env.SUPPORT_MODERATOR_SECRET;
+  delete process.env.SUPPORT_SUPERVISOR_SECRET;
   try {
     const store = createStore();
     const { posts } = registerRoutes(store as RoomSnapshotStore);
@@ -977,18 +1056,29 @@ test("POST /api/admin/reports/:id/resolve returns 503 when ADMIN_SECRET is not c
     );
 
     assert.equal(response.statusCode, 503);
-    assert.deepEqual(JSON.parse(response.body), { error: "ADMIN_SECRET is not configured" });
+    assert.deepEqual(JSON.parse(response.body), { error: "Player support secrets are not configured" });
   } finally {
     if (original === undefined) {
       delete process.env.ADMIN_SECRET;
     } else {
       process.env.ADMIN_SECRET = original;
     }
+    if (originalModeratorSecret === undefined) {
+      delete process.env.SUPPORT_MODERATOR_SECRET;
+    } else {
+      process.env.SUPPORT_MODERATOR_SECRET = originalModeratorSecret;
+    }
+    if (originalSupervisorSecret === undefined) {
+      delete process.env.SUPPORT_SUPERVISOR_SECRET;
+    } else {
+      process.env.SUPPORT_SUPERVISOR_SECRET = originalSupervisorSecret;
+    }
   }
 });
 
 test("POST /api/admin/reports/:id/resolve with banned also bans the reported player", async (t) => {
-  const secret = withAdminSecret(t);
+  withAdminSecret(t);
+  const { supervisor } = withSupportSecrets(t);
   const store = createStore();
   const report = await store.createPlayerReport({
     reporterId: "player-1",
@@ -1007,9 +1097,15 @@ test("POST /api/admin/reports/:id/resolve with banned also bans the reported pla
       method: "POST",
       params: { id: report.reportId },
       headers: {
-        "x-veil-admin-secret": secret
+        "x-veil-admin-secret": supervisor
       },
-      body: JSON.stringify({ status: "banned" })
+      body: JSON.stringify({
+        status: "banned",
+        approval: {
+          approvedBy: "ops-lead",
+          approvalReference: "SUP-204"
+        }
+      })
     }),
     response
   );
@@ -1026,4 +1122,139 @@ test("POST /api/admin/reports/:id/resolve with banned also bans the reported pla
   assert.equal(payload.disconnectedClients, 0);
   assert.equal(currentBan?.banStatus, "permanent");
   assert.match(currentBan?.banReason ?? "", /player report/);
+  assert.match(currentBan?.banReason ?? "", /approvedBy=ops-lead/);
+});
+
+test("POST /api/admin/players/:id/ban rejects permanent bans from support moderators", async (t) => {
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/ban");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-9" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      },
+      body: JSON.stringify({
+        banStatus: "permanent",
+        banReason: "Confirmed botting",
+        approval: {
+          approvedBy: "ops-lead",
+          approvalReference: "SUP-205"
+        }
+      })
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "Forbidden: permanent bans require support-supervisor or admin credentials"
+  });
+});
+
+test("POST /api/admin/players/:id/ban requires approval metadata for permanent bans", async (t) => {
+  withAdminSecret(t);
+  const { supervisor } = withSupportSecrets(t);
+  const store = createStore();
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/ban");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-10" },
+      headers: {
+        "x-veil-admin-secret": supervisor
+      },
+      body: JSON.stringify({
+        banStatus: "permanent",
+        banReason: "Chargeback fraud"
+      })
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), { error: "\"approval\" is required" });
+});
+
+test("POST /api/admin/players/:id/unban rejects permanent-ban reversal from support moderators", async (t) => {
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  await store.savePlayerBan("player-11", {
+    banStatus: "permanent",
+    banReason: "Severe abuse"
+  });
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/unban");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-11" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      },
+      body: JSON.stringify({ reason: "appeal approved" })
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "Forbidden: permanent-ban reversals require support-supervisor or admin credentials"
+  });
+});
+
+test("GET /api/admin/players/:id/export returns account data for support workflows", async (t) => {
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore({
+    "player-export": { gold: 9, wood: 4, ore: 2 }
+  });
+  await store.savePlayerBan("player-export", {
+    banStatus: "temporary",
+    banReason: "Spam",
+    banExpiry: "2026-05-10T00:00:00.000Z"
+  });
+  const { gets } = registerRoutes(store as RoomSnapshotStore);
+  const handler = gets.get("/api/admin/players/:id/export");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      params: { id: "player-export" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body) as {
+    playerId: string;
+    exportedAt: string;
+    account: { playerId: string; globalResources: { gold: number; wood: number; ore: number } };
+    moderation: { currentBan: { banStatus: string }; banHistory: Array<{ action: string }> };
+  };
+  assert.equal(payload.playerId, "player-export");
+  assert.ok(Number.isFinite(Date.parse(payload.exportedAt)));
+  assert.equal(payload.account.playerId, "player-export");
+  assert.deepEqual(payload.account.globalResources, { gold: 9, wood: 4, ore: 2 });
+  assert.equal(payload.moderation.currentBan.banStatus, "temporary");
+  assert.equal(payload.moderation.banHistory[0]?.action, "ban");
 });

--- a/docs/ban-policy.md
+++ b/docs/ban-policy.md
@@ -1,0 +1,83 @@
+# Player Ban Policy
+
+This document defines the minimum moderation standard for the current support slice.
+
+## Enforcement Levels
+
+### Warning
+
+Use a warning when the behavior is disruptive but low-severity or first-time:
+
+- abusive chat without targeted threats
+- repeated AFK or surrender griefing
+- spam reports that are not coordinated abuse
+
+Actions:
+
+- resolve the player report as `warned`
+- add the case reference in the support system
+- do not suspend account access
+
+### Temporary Ban
+
+Use a temporary ban when the behavior is repeated, harmful, or materially degrades matches:
+
+- repeat harassment after warning
+- repeated AFK griefing across multiple matches
+- exploit abuse without clear automation
+- payment abuse that looks reversible or under review
+
+Suggested durations:
+
+- 24 hours for first confirmed repeat offense
+- 72 hours for second offense in 30 days
+- 7 days for severe disruption without clear cheating evidence
+
+Requirements:
+
+- `support-moderator`, `support-supervisor`, or `admin` credentials may apply the ban
+- temporary bans must include a clear `banReason`
+- the player should receive the appeal entrypoint and expected SLA
+
+### Permanent Ban
+
+Use a permanent ban only for high-confidence, account-level abuse:
+
+- confirmed botting or scripted automation
+- chargeback fraud or account theft
+- targeted harassment, threats, or severe repeated abuse
+- ban evasion after prior enforcement
+
+Requirements:
+
+- only `support-supervisor` or `admin` credentials may apply the ban
+- the request must include `approval.approvedBy` and `approval.approvalReference`
+- the approval record should point to the internal ticket, chat thread, or case note that captured the second review
+
+Current limitation:
+
+- this slice records approval details inside the saved ban reason and response payload, but it does not yet provide a separate audited approval ledger
+
+## Report Review Threshold
+
+Automatic player reports should trigger manual review when either condition is met:
+
+- 3 unique reporters target the same player within 24 hours
+- 5 pending reports target the same player across 7 days
+
+The current server stores reports and exposes them through `/api/admin/reports`; threshold-based queueing is still an operational workflow, not an automated gate.
+
+## Appeals
+
+- Primary intake: in-game support entry or WeChat service account
+- Fallback intake: support email alias managed by operations
+- First response SLA: 48 hours
+- Final disposition target: 5 business days
+
+Appeal outcomes:
+
+- `uphold`: keep the enforcement and send rationale
+- `reduce`: convert permanent to temporary or shorten duration
+- `revoke`: remove the ban and restore access
+
+Permanent-ban revocations must be handled by `support-supervisor` or `admin`.

--- a/docs/player-support-runbook.md
+++ b/docs/player-support-runbook.md
@@ -1,0 +1,138 @@
+# Player Support Runbook
+
+This runbook describes the smallest workable player-support flow shipped for issue `#1204`.
+
+## Roles
+
+### `admin`
+
+Full operational access. Use for infrastructure and emergency actions only.
+
+### `support-moderator`
+
+Scope:
+
+- review player reports
+- issue warnings
+- apply temporary bans
+- remove temporary bans
+- export player account data
+
+Credential:
+
+- server env: `SUPPORT_MODERATOR_SECRET`
+- request header: `x-veil-admin-secret`
+
+### `support-supervisor`
+
+Scope:
+
+- everything a moderator can do
+- approve and apply permanent bans
+- reverse permanent bans
+
+Credential:
+
+- server env: `SUPPORT_SUPERVISOR_SECRET`
+- request header: `x-veil-admin-secret`
+
+## Supported API Surface
+
+### Review reports
+
+- `GET /api/admin/reports?status=pending`
+- `POST /api/admin/reports/:id/resolve`
+
+For `status=banned`, the request must include:
+
+```json
+{
+  "status": "banned",
+  "approval": {
+    "approvedBy": "ops-lead",
+    "approvalReference": "SUP-204"
+  }
+}
+```
+
+### Ban history
+
+- `GET /api/admin/players/:id/ban-history`
+
+Use this before any escalation or appeal resolution.
+
+### Temporary ban
+
+- `POST /api/admin/players/:id/ban`
+
+Example:
+
+```json
+{
+  "banStatus": "temporary",
+  "banReason": "Repeat harassment after warning",
+  "banExpiry": "2026-05-05T00:00:00.000Z"
+}
+```
+
+### Permanent ban
+
+Only `support-supervisor` or `admin` may execute this.
+
+```json
+{
+  "banStatus": "permanent",
+  "banReason": "Confirmed automation",
+  "approval": {
+    "approvedBy": "ops-lead",
+    "approvalReference": "SUP-205"
+  }
+}
+```
+
+### Unban
+
+- `POST /api/admin/players/:id/unban`
+
+Moderators may reverse temporary bans. Permanent-ban reversals require `support-supervisor` or `admin`.
+
+### Player data export
+
+- `GET /api/admin/players/:id/export`
+
+Returns:
+
+- raw account snapshot currently stored by the server
+- current ban state
+- ban history
+- `exportedAt` timestamp for case attachments
+
+Use this route for privacy/data-access responses. Before sending anything externally:
+
+- confirm the requester controls the account
+- redact internal-only annotations if they are not required for the request
+- attach the case ID used to fulfill the export
+
+## Appeal Workflow
+
+1. Check `/api/admin/players/:id/ban-history`.
+2. Review matching reports in `/api/admin/reports`.
+3. Respond to the player within 48 hours.
+4. If the enforcement stands, send the final rationale and close the case.
+5. If the enforcement changes, apply `/unban` or a shorter temporary ban and note the case reference.
+
+## Account Deletion
+
+Player self-service deletion already exists at `POST /api/players/me/delete`.
+
+Support handling:
+
+- verify account ownership
+- direct the player to the in-product deletion path when possible
+- if manual intervention is required, record the reason and confirm the resulting anonymized account state
+
+## Operational Gaps
+
+- no dedicated approval ledger beyond the approval reference captured in the ban reason
+- no automated report-threshold queue yet
+- no dedicated support UI; the slice is API-first plus runbook


### PR DESCRIPTION
## Summary

This lands a practical first slice for player support infrastructure around the existing admin moderation routes.

Changes:
- add `docs/player-support-runbook.md` with operator flow, role boundaries, appeals, export handling, and deletion handling
- add `docs/ban-policy.md` with warning / temporary ban / permanent ban criteria and SLA expectations
- add support-role authorization to the admin console using `SUPPORT_MODERATOR_SECRET` and `SUPPORT_SUPERVISOR_SECRET`
- require supervisor-or-admin credentials plus approval metadata for permanent bans and report resolutions that escalate to permanent bans
- restrict permanent-ban reversals to supervisor-or-admin credentials
- add `GET /api/admin/players/:id/export` for support-facing account data export with moderation state
- extend admin console tests to cover the new support role boundary and export flow

## Validation

- `node --import tsx --test ./apps/server/test/admin-console.test.ts`
- `npm run typecheck:server`
- `git diff --check`

## Gap / Follow-up

This intentionally does not build a full audited dual-approval system or support UI. The current slice enforces supervisor approval metadata and role separation, but the approval record is still stored in the ban reason rather than a dedicated immutable ledger.

Closes #1204