### PR TITLE
Add daily first-login rewards on auth flows

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -29,6 +29,7 @@ import {
   setPendingAuthRegistrationCount,
   upsertAuthAccountSession
 } from "./observability";
+import { issueDailyLoginReward } from "./daily-login-rewards";
 import { deriveWechatMinorProtection } from "./minor-protection";
 import {
   isPlayerBanActive,
@@ -1034,6 +1035,7 @@ async function handleWechatLogin(
   let playerId = authSession?.playerId ?? normalizePlayerId(body.playerId || createWechatMiniGamePlayerId(identity.openId));
   let displayName = normalizeDisplayName(playerId, body.displayName ?? authSession?.displayName);
   let loginId = authSession?.loginId;
+  let rewardAccount: PlayerAccountSnapshot | null = null;
 
   if (store) {
     const boundAccount = await store.loadPlayerAccountByWechatMiniGameOpenId(identity.openId);
@@ -1071,6 +1073,7 @@ async function handleWechatLogin(
       playerId = syncedAccount.playerId;
       displayName = syncedAccount.displayName;
       loginId = syncedAccount.loginId;
+      rewardAccount = syncedAccount;
     } else {
       const targetPlayerId = authSession?.playerId ?? playerId;
       let boundAccountResult = await store.bindPlayerAccountWechatMiniGameIdentity(targetPlayerId, {
@@ -1088,6 +1091,7 @@ async function handleWechatLogin(
       playerId = boundAccountResult.playerId;
       displayName = boundAccountResult.displayName;
       loginId = boundAccountResult.loginId;
+      rewardAccount = boundAccountResult;
     }
   } else if (!authSession && body.playerId?.trim()) {
     playerId = normalizePlayerId(body.playerId);
@@ -1101,6 +1105,8 @@ async function handleWechatLogin(
   }
 
   cacheWechatSessionKey(playerId, identity.sessionKey, readWechatSessionKeyTtlSeconds());
+
+  const dailyLoginReward = store && rewardAccount ? await issueDailyLoginReward(store, rewardAccount) : null;
 
   sendJson(response, 200, {
     session:
@@ -1116,7 +1122,15 @@ async function handleWechatLogin(
             playerId,
             displayName,
             ...(loginId ? { loginId } : {})
-          })
+          }),
+    ...(dailyLoginReward?.claimed
+      ? {
+          dailyLoginReward: {
+            streak: dailyLoginReward.streak,
+            reward: dailyLoginReward.reward
+          }
+        }
+      : {})
   });
   if (store && loginId) {
     recordAuthAccountLogin();
@@ -1979,6 +1993,23 @@ export function registerAuthRoutes(
         }
         playerId = account.playerId;
         displayName = account.displayName;
+        const dailyLoginReward = await issueDailyLoginReward(store, account);
+        sendJson(response, 200, {
+          session: issueGuestAuthSession({
+            playerId,
+            displayName
+          }),
+          ...(dailyLoginReward.claimed
+            ? {
+                dailyLoginReward: {
+                  streak: dailyLoginReward.streak,
+                  reward: dailyLoginReward.reward
+                }
+              }
+            : {})
+        });
+        recordAuthGuestLogin();
+        return;
       }
 
       sendJson(response, 200, {
@@ -2066,12 +2097,21 @@ export function registerAuthRoutes(
           return;
         }
         
+        const dailyLoginReward = store ? await issueDailyLoginReward(store, account) : null;
         sendJson(response, 200, {
-          account,
+          account: dailyLoginReward?.account ?? account,
           session: issueGuestAuthSession({
             playerId: account.playerId,
             displayName: account.displayName
-          })
+          }),
+          ...(dailyLoginReward?.claimed
+            ? {
+                dailyLoginReward: {
+                  streak: dailyLoginReward.streak,
+                  reward: dailyLoginReward.reward
+                }
+              }
+            : {})
         });
         return;
       }
@@ -2114,14 +2154,23 @@ export function registerAuthRoutes(
         sendAuthFailure(response, "account_banned", activeBan);
         return;
       }
+      const dailyLoginReward = await issueDailyLoginReward(store, account);
       sendJson(response, 200, {
-        account,
+        account: dailyLoginReward.account,
         session: await createAccountSessionBundle(store, {
           playerId: account.playerId,
           displayName: account.displayName,
           loginId,
           deviceLabel: resolveDeviceLabel(request)
-        })
+        }),
+        ...(dailyLoginReward.claimed
+          ? {
+              dailyLoginReward: {
+                streak: dailyLoginReward.streak,
+                reward: dailyLoginReward.reward
+              }
+            }
+          : {})
       });
       recordAuthAccountLogin();
     } catch (error) {

--- a/apps/server/src/daily-login-rewards.ts
+++ b/apps/server/src/daily-login-rewards.ts
@@ -1,0 +1,101 @@
+import { appendEventLogEntries } from "../../../packages/shared/src/index";
+import { emitAnalyticsEvent } from "./analytics";
+import { resolveBattlePassConfig } from "./battle-pass";
+import { getDailyRewardDateKey, getPreviousDailyRewardDateKey, resolveDailyRewardForStreak } from "./daily-rewards";
+import type { PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
+
+export interface DailyLoginRewardGrant {
+  gems: number;
+  gold: number;
+}
+
+export interface DailyLoginRewardResult {
+  claimed: boolean;
+  account: PlayerAccountSnapshot;
+  dateKey: string;
+  reason?: "already_claimed_today";
+  streak?: number;
+  reward?: DailyLoginRewardGrant;
+}
+
+function createDailyRewardEventLogEntry(
+  playerId: string,
+  streak: number,
+  reward: DailyLoginRewardGrant,
+  timestamp = new Date().toISOString()
+) {
+  const rewardSummary = [
+    reward.gems > 0 ? `宝石 x${reward.gems}` : null,
+    reward.gold > 0 ? `金币 x${reward.gold}` : null
+  ]
+    .filter((entry): entry is string => Boolean(entry))
+    .join("、");
+
+  return {
+    id: `${playerId}:${timestamp}:daily-login:${streak}`,
+    timestamp,
+    roomId: "daily-login",
+    playerId,
+    category: "account" as const,
+    description: `每日签到奖励：连签第 ${streak} 天，获得 ${rewardSummary || "奖励已发放"}。`,
+    rewards: [
+      ...(reward.gems > 0 ? [{ type: "resource" as const, label: "gems", amount: reward.gems }] : []),
+      ...(reward.gold > 0 ? [{ type: "resource" as const, label: "gold", amount: reward.gold }] : [])
+    ]
+  };
+}
+
+export async function issueDailyLoginReward(
+  store: RoomSnapshotStore,
+  account: PlayerAccountSnapshot,
+  options: {
+    now?: Date;
+  } = {}
+): Promise<DailyLoginRewardResult> {
+  const now = options.now ?? new Date();
+  const dateKey = getDailyRewardDateKey(now);
+
+  if (account.lastPlayDate === dateKey) {
+    return {
+      claimed: false,
+      account,
+      dateKey,
+      reason: "already_claimed_today"
+    };
+  }
+
+  const streak =
+    account.lastPlayDate === getPreviousDailyRewardDateKey(dateKey) ? Math.max(0, account.loginStreak ?? 0) + 1 : 1;
+  const reward = resolveDailyRewardForStreak(streak);
+  const eventEntry = createDailyRewardEventLogEntry(account.playerId, streak, reward, now.toISOString());
+  const nextAccount = await store.savePlayerAccountProgress(account.playerId, {
+    gems: (account.gems ?? 0) + reward.gems,
+    seasonXpDelta: resolveBattlePassConfig().seasonXpDailyLoginBonus,
+    globalResources: {
+      ...account.globalResources,
+      gold: (account.globalResources.gold ?? 0) + reward.gold
+    },
+    recentEventLog: appendEventLogEntries(account.recentEventLog, [eventEntry]),
+    lastPlayDate: dateKey,
+    dailyPlayMinutes: 0,
+    loginStreak: streak
+  });
+
+  emitAnalyticsEvent("daily_login", {
+    playerId: account.playerId,
+    roomId: "daily-login",
+    payload: {
+      dateKey,
+      streak,
+      reward
+    }
+  });
+
+  return {
+    claimed: true,
+    account: nextAccount,
+    dateKey,
+    streak,
+    reward
+  };
+}

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -26,6 +26,7 @@ import {
   createDailyQuestClaimEventLogEntry,
   loadDailyQuestBoard
 } from "./daily-quests";
+import { issueDailyLoginReward } from "./daily-login-rewards";
 import { resolveBattlePassConfig } from "./battle-pass";
 import { emitAnalyticsEvent } from "./analytics";
 import {
@@ -44,7 +45,6 @@ import type {
   PlayerEventHistoryQuery,
   RoomSnapshotStore
 } from "./persistence";
-import { getDailyRewardDateKey, getPreviousDailyRewardDateKey, resolveDailyRewardForStreak } from "./daily-rewards";
 import {
   applySeasonalEventProgress,
   buildEventLeaderboard,
@@ -861,33 +861,6 @@ function sendForbidden(response: ServerResponse): void {
   });
 }
 
-function createDailyRewardEventLogEntry(
-  playerId: string,
-  streak: number,
-  reward: { gems: number; gold: number },
-  timestamp = new Date().toISOString()
-) {
-  const rewardSummary = [
-    reward.gems > 0 ? `宝石 x${reward.gems}` : null,
-    reward.gold > 0 ? `金币 x${reward.gold}` : null
-  ]
-    .filter((entry): entry is string => Boolean(entry))
-    .join("、");
-
-  return {
-    id: `${playerId}:${timestamp}:daily-login:${streak}`,
-    timestamp,
-    roomId: "daily-login",
-    playerId,
-    category: "account" as const,
-    description: `每日签到奖励：连签第 ${streak} 天，获得 ${rewardSummary || "奖励已发放"}。`,
-    rewards: [
-      ...(reward.gems > 0 ? [{ type: "resource" as const, label: "gems", amount: reward.gems }] : []),
-      ...(reward.gold > 0 ? [{ type: "resource" as const, label: "gold", amount: reward.gold }] : [])
-    ]
-  };
-}
-
 async function requireAuthSession(
   request: IncomingMessage,
   response: ServerResponse,
@@ -1399,36 +1372,19 @@ export function registerPlayerAccountRoutes(
           playerId: authSession.playerId,
           displayName: authSession.displayName
         }));
-      const today = getDailyRewardDateKey();
-      if (account.lastPlayDate === today) {
+      const result = await issueDailyLoginReward(store, account);
+      if (!result.claimed) {
         sendJson(response, 200, {
           claimed: false,
-          reason: "already_claimed_today"
+          reason: result.reason
         });
         return;
       }
 
-      const streak = account.lastPlayDate === getPreviousDailyRewardDateKey(today) ? Math.max(0, account.loginStreak ?? 0) + 1 : 1;
-      const reward = resolveDailyRewardForStreak(streak);
-      const eventEntry = createDailyRewardEventLogEntry(account.playerId, streak, reward);
-
-      await store.savePlayerAccountProgress(account.playerId, {
-        gems: (account.gems ?? 0) + reward.gems,
-        seasonXpDelta: resolveBattlePassConfig().seasonXpDailyLoginBonus,
-        globalResources: {
-          ...account.globalResources,
-          gold: (account.globalResources.gold ?? 0) + reward.gold
-        },
-        recentEventLog: appendEventLogEntries(account.recentEventLog, [eventEntry]),
-        lastPlayDate: today,
-        dailyPlayMinutes: 0,
-        loginStreak: streak
-      });
-
       sendJson(response, 200, {
         claimed: true,
-        streak,
-        reward
+        streak: result.streak,
+        reward: result.reward
       });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -5,6 +5,7 @@ import { createServer as createNetServer } from "node:net";
 import test from "node:test";
 import { Client, type Room as ColyseusRoom } from "@colyseus/sdk";
 import { Server, WebSocketTransport } from "colyseus";
+import { getDailyRewardDateKey, getPreviousDailyRewardDateKey } from "../src/daily-rewards";
 import type { ClientMessage, ServerMessage } from "../../../packages/shared/src/index";
 import { resetAccountTokenDeliveryState } from "../src/account-token-delivery";
 import {
@@ -170,6 +171,9 @@ class MemoryAuthStore implements RoomSnapshotStore {
       playerId,
       displayName: input.displayName?.trim() || existing?.displayName || playerId,
       ...(existing?.avatarUrl ? { avatarUrl: existing.avatarUrl } : {}),
+      ...(existing?.gems ? { gems: existing.gems } : {}),
+      ...(existing?.seasonXp ? { seasonXp: existing.seasonXp } : {}),
+      ...(existing?.loginStreak ? { loginStreak: existing.loginStreak } : {}),
       globalResources: existing?.globalResources ?? { gold: 0, wood: 0, ore: 0 },
       achievements: structuredClone(existing?.achievements ?? []),
       recentEventLog: structuredClone(existing?.recentEventLog ?? []),
@@ -440,11 +444,22 @@ class MemoryAuthStore implements RoomSnapshotStore {
     const existing = await this.ensurePlayerAccount({ playerId });
     const account: PlayerAccountSnapshot = {
       ...existing,
+      ...(patch.gems !== undefined ? { gems: Math.max(0, Math.floor(patch.gems ?? 0)) } : existing.gems ? { gems: existing.gems } : {}),
+      ...(patch.seasonXpDelta !== undefined
+        ? { seasonXp: Math.max(0, Math.floor(existing.seasonXp ?? 0) + Math.floor(patch.seasonXpDelta ?? 0)) }
+        : existing.seasonXp
+          ? { seasonXp: existing.seasonXp }
+          : {}),
       globalResources: structuredClone(
         (patch.globalResources as PlayerAccountSnapshot["globalResources"] | undefined) ?? existing.globalResources
       ),
       achievements: structuredClone((patch.achievements as PlayerAccountSnapshot["achievements"] | undefined) ?? existing.achievements),
       recentEventLog: structuredClone((patch.recentEventLog as PlayerAccountSnapshot["recentEventLog"] | undefined) ?? existing.recentEventLog),
+      ...(patch.loginStreak !== undefined
+        ? { loginStreak: Math.max(0, Math.floor(patch.loginStreak ?? 0)) }
+        : existing.loginStreak
+          ? { loginStreak: existing.loginStreak }
+          : {}),
       ...(patch.dailyPlayMinutes !== undefined ? { dailyPlayMinutes: Math.max(0, Math.floor(patch.dailyPlayMinutes ?? 0)) } : existing.dailyPlayMinutes ? { dailyPlayMinutes: existing.dailyPlayMinutes } : {}),
       ...(patch.lastPlayDate !== undefined ? (patch.lastPlayDate ? { lastPlayDate: patch.lastPlayDate.trim() } : {}) : existing.lastPlayDate ? { lastPlayDate: existing.lastPlayDate } : {}),
       ...(patch.lastRoomId !== undefined
@@ -954,6 +969,78 @@ test("guest auth connect claims a default hero slot for non-template player ids"
   assert.equal((await store.loadPlayerAccount("guest-rune"))?.lastRoomId, "guest-slot-room");
 });
 
+test("guest-login issues the daily first-login reward once and emits analytics", async (t) => {
+  const port = 44490 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const analyticsLogs: string[] = [];
+  configureAnalyticsRuntimeDependencies({
+    log: (message) => {
+      analyticsLogs.push(message);
+    }
+  });
+  const server = await startAuthServer(port, store);
+
+  t.after(async () => {
+    resetAnalyticsRuntimeDependencies();
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: "retention-guest",
+      displayName: "晨雾旅人",
+      privacyConsentAccepted: true
+    })
+  });
+  const payload = (await response.json()) as {
+    session: GuestAuthSession;
+    dailyLoginReward?: {
+      streak: number;
+      reward: { gems: number; gold: number };
+    };
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.dailyLoginReward?.streak, 1);
+  assert.deepEqual(payload.dailyLoginReward?.reward, { gems: 5, gold: 50 });
+
+  const account = await store.loadPlayerAccount("retention-guest");
+  assert.equal(account?.gems, 5);
+  assert.equal(account?.globalResources.gold, 50);
+  assert.equal(account?.loginStreak, 1);
+  assert.equal(account?.lastPlayDate, getDailyRewardDateKey());
+  assert.match(account?.recentEventLog[0]?.description ?? "", /^每日签到奖励：连签第 1 天/);
+
+  await flushAnalyticsEventsForTest();
+  const dailyLoginLog = analyticsLogs.find((entry) => entry.includes("\"name\":\"daily_login\""));
+  assert.ok(dailyLoginLog);
+  assert.match(dailyLoginLog ?? "", /"streak":1/);
+  assert.match(dailyLoginLog ?? "", /"dateKey":"/);
+
+  const secondResponse = await fetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: "retention-guest",
+      displayName: "晨雾旅人",
+      privacyConsentAccepted: true
+    })
+  });
+  const secondPayload = (await secondResponse.json()) as {
+    dailyLoginReward?: unknown;
+  };
+
+  assert.equal(secondResponse.status, 200);
+  assert.equal(secondPayload.dailyLoginReward, undefined);
+});
+
 test("account bind upgrades a guest session into password login and account-login restores it", async (t) => {
   const port = 44500 + Math.floor(Math.random() * 1000);
   const store = new MemoryAuthStore();
@@ -1032,6 +1119,66 @@ test("account bind upgrades a guest session into password login and account-logi
   assert.equal(sessionPayload.session.authMode, "account");
   assert.equal(sessionPayload.session.provider, "account-password");
   assert.equal(sessionPayload.session.loginId, "veil-ranger");
+});
+
+test("account-login carries the streak from yesterday and returns the issued reward", async (t) => {
+  const port = 44505 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+  const today = getDailyRewardDateKey();
+  const yesterday = getPreviousDailyRewardDateKey(today);
+
+  await store.ensurePlayerAccount({
+    playerId: "daily-account",
+    displayName: "连签守望"
+  });
+  await store.bindPlayerAccountCredentials("daily-account", {
+    loginId: "daily-account",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+  await store.savePlayerAccountProgress("daily-account", {
+    gems: 20,
+    globalResources: { gold: 100, wood: 0, ore: 0 },
+    lastPlayDate: yesterday,
+    loginStreak: 1,
+    dailyPlayMinutes: 45
+  });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "daily-account",
+      password: "hunter2",
+      privacyConsentAccepted: true
+    })
+  });
+  const payload = (await response.json()) as {
+    account: PlayerAccountSnapshot;
+    session: GuestAuthSession;
+    dailyLoginReward?: {
+      streak: number;
+      reward: { gems: number; gold: number };
+    };
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.dailyLoginReward?.streak, 2);
+  assert.deepEqual(payload.dailyLoginReward?.reward, { gems: 5, gold: 75 });
+  assert.equal(payload.account.loginStreak, 2);
+  assert.equal(payload.account.gems, 25);
+  assert.equal(payload.account.globalResources.gold, 175);
+  assert.equal(payload.account.lastPlayDate, today);
+  assert.equal(payload.account.dailyPlayMinutes, 0);
+  assert.equal(payload.session.authMode, "account");
+  assert.equal(payload.session.provider, "account-password");
 });
 
 test("account bind emits experiment conversion analytics for the assigned variant", async (t) => {

--- a/docs/retention-ops-runbook.md
+++ b/docs/retention-ops-runbook.md
@@ -1,0 +1,47 @@
+# Retention Ops Runbook
+
+Issue #1200 starts the retention surface with a narrow server-side slice: daily first-login rewards are now issued automatically on successful login, streak state is persisted on the player account, and every successful issuance emits a versioned `daily_login` analytics event.
+
+This runbook only covers the implemented slice. WeChat push, offline-reward summaries, and D1/D7 dashboard material are still out of scope for this change and need follow-up work before they should be promised as live.
+
+## Current Scope
+
+- Successful `POST /api/auth/guest-login` issues the daily reward on the first login of the calendar day.
+- Successful `POST /api/auth/account-login` issues the same reward path for bound accounts.
+- Successful `POST /api/auth/wechat-login` and `POST /api/auth/wechat-mini-game-login` use the same reward path.
+- The legacy `POST /api/player/daily-claim` route remains available, but once a login flow has already issued today’s reward it returns `already_claimed_today`.
+- Reward amounts are read from [`configs/daily-rewards.json`](/home/gpt/project/ProjectVeil/configs/daily-rewards.json).
+- Reward issuance appends an account event-log entry and emits `daily_login` analytics with `dateKey`, `streak`, and `reward`.
+
+## Expected Behavior
+
+1. First successful login on date `YYYY-MM-DD`
+   The server checks `lastPlayDate`. If it differs from today, it grants the configured gems/gold reward, resets `dailyPlayMinutes` to `0`, updates `lastPlayDate`, and persists `loginStreak`.
+2. Consecutive login
+   If `lastPlayDate` equals yesterday, `loginStreak` increments by one and the next reward tier is granted.
+3. Gap login
+   If `lastPlayDate` is older than yesterday or missing, `loginStreak` resets to `1`.
+4. Same-day repeat login
+   No second reward is granted and no new `daily_login` analytics event is emitted.
+
+## Operator Checks
+
+- Verify the auth response includes `dailyLoginReward` on the first login of the day.
+- Verify `/api/player-accounts/me` or stored account data shows updated `gems`, `globalResources.gold`, `loginStreak`, and `lastPlayDate`.
+- Verify the latest account event log includes a `每日签到奖励` entry.
+- Verify analytics ingestion received a `daily_login` event for the same player/dateKey.
+
+## Triage Notes
+
+- Wrong streak after a gap:
+  Check the stored `lastPlayDate` and confirm it uses the same daily key boundary as the server.
+- Reward missing on login:
+  Confirm the account has not already claimed on the same day through a prior login or `/api/player/daily-claim`.
+- Analytics missing while rewards succeeded:
+  Inspect analytics pipeline logs for `daily_login` ingestion or downstream flush failures; reward issuance is not rolled back by telemetry failure.
+
+## Rollback
+
+- To reduce exposure immediately, point clients back to the existing manual claim flow operationally and avoid depending on the auth response field.
+- To change values without code rollout, update [`configs/daily-rewards.json`](/home/gpt/project/ProjectVeil/configs/daily-rewards.json).
+- If the reward logic itself is faulty, revert the server change rather than mutating player data manually without an audit trail.

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -48,6 +48,14 @@ export const ANALYTICS_EVENT_CATALOG = {
       gold: 50
     }
   }),
+  daily_login: defineAnalyticsEvent("daily_login", 1, "Daily first-login reward was issued to the player.", {
+    dateKey: "2026-04-11",
+    streak: 3,
+    reward: {
+      gems: 10,
+      gold: 100
+    }
+  }),
   QuestRotated: defineAnalyticsEvent("QuestRotated", 1, "Server rotated a new daily quest slate for the player.", {
     roomId: "daily-quests",
     dateKey: "2026-04-06",

--- a/packages/shared/test/analytics-events.test.ts
+++ b/packages/shared/test/analytics-events.test.ts
@@ -193,6 +193,16 @@ test("createAnalyticsEvent: quest_complete event carries correct payload structu
   assert.equal(event.payload.reward.gems, 5);
 });
 
+test("createAnalyticsEvent: daily_login event carries streak and reward payload", () => {
+  const event = createAnalyticsEvent("daily_login", {
+    playerId: "player-1",
+    payload: { dateKey: "2026-04-11", streak: 2, reward: { gems: 5, gold: 75 } }
+  });
+  assert.equal(event.payload.dateKey, "2026-04-11");
+  assert.equal(event.payload.streak, 2);
+  assert.equal(event.payload.reward.gold, 75);
+});
+
 test("createAnalyticsEvent: experiment_exposure event carries all required fields", () => {
   const event = createAnalyticsEvent("experiment_exposure", {
     playerId: "player-1",


### PR DESCRIPTION
## Summary
- auto-issue the daily first-login reward during guest, account-password, and WeChat login success paths using a shared server helper
- persist streak progression, append the daily reward event-log entry, and emit the new `daily_login` analytics event
- document the retention ops slice and extend auth/shared tests for reward issuance and analytics coverage

## Validation
- `node --import tsx --test ./packages/shared/test/analytics-events.test.ts`
- `node --import tsx --test --test-name-pattern "guest-login issues the daily first-login reward once and emits analytics|account-login carries the streak from yesterday and returns the issued reward" ./apps/server/test/auth-guest-login.test.ts`
- `node --import tsx --test --test-name-pattern "daily claim increments streak and grants the configured consecutive-day reward|daily claim resets the streak after a gap|daily claim cycles reward tiers after day seven|daily claim rejects duplicate claims on the same day" ./apps/server/test/player-account-routes.test.ts`
- `npm run typecheck:server`

Refs #1200