### PR TITLE
[codex] Harden auth credential stuffing guard for #1201

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -14,6 +14,7 @@ import {
   recordAuthAccountBinding,
   recordAuthAccountLogin,
   recordAuthAccountRegistration,
+  recordAuthCredentialStuffingBlocked,
   recordAuthGuestLogin,
   recordAuthInvalidCredentials,
   recordAuthLogout,
@@ -24,6 +25,7 @@ import {
   recordAuthSessionFailure,
   removeAuthAccountSessionsForPlayer,
   setAuthAccountLockCount,
+  setAuthCredentialStuffingSourceCount,
   setAuthGuestSessionCount,
   setPendingAuthRecoveryCount,
   setPendingAuthRegistrationCount,
@@ -77,6 +79,9 @@ interface AuthRuntimeConfig {
   rateLimitMax: number;
   lockoutThreshold: number;
   lockoutDurationMs: number;
+  credentialStuffingWindowMs: number;
+  credentialStuffingDistinctLoginIdThreshold: number;
+  credentialStuffingBlockDurationMs: number;
   maxGuestSessions: number;
   accessTtlSeconds: number;
   refreshTtlSeconds: number;
@@ -97,6 +102,11 @@ interface RateLimitResult {
 interface AccountLockoutState {
   failedAttempts: number[];
   lockedUntil?: number;
+}
+
+interface CredentialStuffingState {
+  failedAttempts: Array<{ at: number; loginId: string }>;
+  blockedUntil?: number;
 }
 
 interface WechatMiniGameLoginConfig {
@@ -152,6 +162,9 @@ const DEFAULT_RATE_LIMIT_AUTH_WINDOW_MS = 60_000;
 const DEFAULT_RATE_LIMIT_AUTH_MAX = 10;
 const DEFAULT_AUTH_LOCKOUT_THRESHOLD = 10;
 const DEFAULT_AUTH_LOCKOUT_DURATION_MINUTES = 15;
+const DEFAULT_AUTH_CREDENTIAL_STUFFING_WINDOW_MS = 5 * 60_000;
+const DEFAULT_AUTH_CREDENTIAL_STUFFING_DISTINCT_LOGIN_ID_THRESHOLD = 5;
+const DEFAULT_AUTH_CREDENTIAL_STUFFING_BLOCK_DURATION_MINUTES = 15;
 const DEFAULT_MAX_GUEST_SESSIONS = 10_000;
 const DEFAULT_AUTH_ACCESS_TTL_SECONDS = 60 * 60;
 const DEFAULT_AUTH_REFRESH_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -161,6 +174,7 @@ const DEFAULT_PASSWORD_RECOVERY_TTL_MINUTES = 15;
 
 const authRateLimitCounters = new Map<string, number[]>();
 const accountLockoutStateByLoginId = new Map<string, AccountLockoutState>();
+const credentialStuffingStateByIp = new Map<string, CredentialStuffingState>();
 const guestSessionsById = new Map<string, GuestAuthSession>();
 const accountAuthStateByPlayerId = new Map<string, AccountAuthSessionState>();
 const accountRegistrationStateByLoginId = new Map<string, AccountRegistrationState>();
@@ -184,9 +198,28 @@ function countActiveAccountLockouts(): number {
   return count;
 }
 
+function countActiveCredentialStuffingBlocks(): number {
+  const currentTime = nowMs();
+  let count = 0;
+
+  for (const [ip, state] of credentialStuffingStateByIp.entries()) {
+    if (state.blockedUntil && state.blockedUntil > currentTime) {
+      count += 1;
+      continue;
+    }
+
+    if (state.failedAttempts.length === 0) {
+      credentialStuffingStateByIp.delete(ip);
+    }
+  }
+
+  return count;
+}
+
 function syncAuthStateTelemetry(): void {
   setAuthGuestSessionCount(guestSessionsById.size);
   setAuthAccountLockCount(countActiveAccountLockouts());
+  setAuthCredentialStuffingSourceCount(countActiveCredentialStuffingBlocks());
   setPendingAuthRegistrationCount(accountRegistrationStateByLoginId.size);
   setPendingAuthRecoveryCount(passwordRecoveryStateByLoginId.size);
 }
@@ -227,6 +260,30 @@ function readAuthRuntimeConfig(env: NodeJS.ProcessEnv = process.env): AuthRuntim
       parseEnvNumber(env.VEIL_AUTH_LOCKOUT_DURATION_MINUTES, DEFAULT_AUTH_LOCKOUT_DURATION_MINUTES, {
         minimum: 1 / 60_000
       }) * 60_000,
+    credentialStuffingWindowMs: parseEnvNumber(
+      env.VEIL_AUTH_CREDENTIAL_STUFFING_WINDOW_MS,
+      DEFAULT_AUTH_CREDENTIAL_STUFFING_WINDOW_MS,
+      {
+        minimum: 1,
+        integer: true
+      }
+    ),
+    credentialStuffingDistinctLoginIdThreshold: parseEnvNumber(
+      env.VEIL_AUTH_CREDENTIAL_STUFFING_DISTINCT_LOGIN_IDS,
+      DEFAULT_AUTH_CREDENTIAL_STUFFING_DISTINCT_LOGIN_ID_THRESHOLD,
+      {
+        minimum: 2,
+        integer: true
+      }
+    ),
+    credentialStuffingBlockDurationMs:
+      parseEnvNumber(
+        env.VEIL_AUTH_CREDENTIAL_STUFFING_BLOCK_DURATION_MINUTES,
+        DEFAULT_AUTH_CREDENTIAL_STUFFING_BLOCK_DURATION_MINUTES,
+        {
+          minimum: 1 / 60_000
+        }
+      ) * 60_000,
     maxGuestSessions: parseEnvNumber(env.VEIL_MAX_GUEST_SESSIONS, DEFAULT_MAX_GUEST_SESSIONS, {
       minimum: 1,
       integer: true
@@ -1680,6 +1737,51 @@ function clearAccountLoginFailures(loginId: string): void {
   syncAuthStateTelemetry();
 }
 
+function pruneCredentialStuffingState(ip: string, config = readAuthRuntimeConfig()): CredentialStuffingState {
+  const currentTime = nowMs();
+  const windowStart = currentTime - config.credentialStuffingWindowMs;
+  const existingState = credentialStuffingStateByIp.get(ip) ?? { failedAttempts: [] };
+  const nextState: CredentialStuffingState = {
+    failedAttempts: existingState.failedAttempts.filter((attempt) => attempt.at > windowStart),
+    ...(existingState.blockedUntil && existingState.blockedUntil > currentTime
+      ? { blockedUntil: existingState.blockedUntil }
+      : {})
+  };
+
+  if (nextState.failedAttempts.length === 0 && !nextState.blockedUntil) {
+    credentialStuffingStateByIp.delete(ip);
+    syncAuthStateTelemetry();
+    return nextState;
+  }
+
+  credentialStuffingStateByIp.set(ip, nextState);
+  syncAuthStateTelemetry();
+  return nextState;
+}
+
+function getCredentialStuffingBlockedUntil(ip: string): number | null {
+  return pruneCredentialStuffingState(ip).blockedUntil ?? null;
+}
+
+function recordCredentialStuffingFailure(ip: string, loginId: string, config = readAuthRuntimeConfig()): number | null {
+  const currentTime = nowMs();
+  const nextState = pruneCredentialStuffingState(ip, config);
+  nextState.failedAttempts.push({
+    at: currentTime,
+    loginId
+  });
+  const distinctLoginIdCount = new Set(nextState.failedAttempts.map((attempt) => attempt.loginId)).size;
+  if (distinctLoginIdCount >= config.credentialStuffingDistinctLoginIdThreshold) {
+    nextState.blockedUntil = Math.max(
+      nextState.blockedUntil ?? 0,
+      currentTime + config.credentialStuffingBlockDurationMs
+    );
+  }
+  credentialStuffingStateByIp.set(ip, nextState);
+  syncAuthStateTelemetry();
+  return nextState.blockedUntil ?? null;
+}
+
 function sendAccountLocked(response: ServerResponse, lockedUntilMs: number): void {
   const retryAfterSeconds = Math.max(1, Math.ceil((lockedUntilMs - nowMs()) / 1000));
   response.setHeader("Retry-After", String(retryAfterSeconds));
@@ -1688,6 +1790,20 @@ function sendAccountLocked(response: ServerResponse, lockedUntilMs: number): voi
       code: "account_locked",
       message: "Account login is temporarily locked",
       lockedUntil: new Date(lockedUntilMs).toISOString()
+    }
+  });
+}
+
+function sendCredentialStuffingBlocked(response: ServerResponse, blockedUntilMs: number): void {
+  const retryAfterSeconds = Math.max(1, Math.ceil((blockedUntilMs - nowMs()) / 1000));
+  recordAuthRateLimited();
+  recordAuthCredentialStuffingBlocked();
+  response.setHeader("Retry-After", String(retryAfterSeconds));
+  sendJson(response, 429, {
+    error: {
+      code: "credential_stuffing_blocked",
+      message: "Too many failed login attempts across multiple accounts from this source",
+      blockedUntil: new Date(blockedUntilMs).toISOString()
     }
   });
 }
@@ -1733,6 +1849,7 @@ export function revokeGuestAuthSession(sessionId: string): boolean {
 export function resetGuestAuthSessions(): void {
   authRateLimitCounters.clear();
   accountLockoutStateByLoginId.clear();
+  credentialStuffingStateByIp.clear();
   guestSessionsById.clear();
   accountAuthStateByPlayerId.clear();
   accountRegistrationStateByLoginId.clear();
@@ -2083,6 +2200,13 @@ export function registerAuthRoutes(
 
       const loginId = normalizeAccountLoginId(body.loginId);
       const password = normalizeAccountPassword(body.password);
+      const requestIp = resolveRequestIp(request);
+
+      const sourceBlockedUntil = getCredentialStuffingBlockedUntil(requestIp);
+      if (sourceBlockedUntil) {
+        sendCredentialStuffingBlocked(response, sourceBlockedUntil);
+        return;
+      }
 
       // 后端 Debug Bypass 逻辑
       if (password === "debug-bypass") {
@@ -2125,8 +2249,11 @@ export function registerAuthRoutes(
       const authAccount = await store.loadPlayerAccountAuthByLoginId(loginId);
       if (!authAccount || !verifyAccountPassword(password, authAccount.passwordHash)) {
         recordAuthInvalidCredentials();
+        const credentialStuffingBlockedUntil = recordCredentialStuffingFailure(requestIp, loginId);
         const nextLockedUntil = recordAccountLoginFailure(loginId);
-        if (nextLockedUntil) {
+        if (credentialStuffingBlockedUntil) {
+          sendCredentialStuffingBlocked(response, credentialStuffingBlockedUntil);
+        } else if (nextLockedUntil) {
           sendAccountLocked(response, nextLockedUntil);
         } else {
           sendJson(response, 401, {

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -43,6 +43,7 @@ interface AuthObservabilityCounters {
   refreshesTotal: number;
   logoutsTotal: number;
   rateLimitedTotal: number;
+  credentialStuffingBlockedTotal: number;
   invalidCredentialsTotal: number;
   tokenDeliveryRequestsTotal: number;
   tokenDeliverySuccessesTotal: number;
@@ -102,6 +103,7 @@ interface AuthObservabilityState {
   activeGuestSessionCount: number;
   activeAccountSessions: Map<string, { playerId: string; provider: string }>;
   activeAccountLockCount: number;
+  activeCredentialStuffingSourceCount: number;
   pendingRegistrationCount: number;
   pendingRecoveryCount: number;
   sessionFailureReasons: Record<AuthSessionFailureReason, number>;
@@ -197,6 +199,7 @@ interface RuntimeHealthPayload {
       activeAccountSessionCount: number;
       activeAccountSessionByProvider: Record<string, number>;
       activeAccountLockCount: number;
+      activeCredentialStuffingSourceCount: number;
       pendingRegistrationCount: number;
       pendingRecoveryCount: number;
       counters: AuthObservabilityCounters;
@@ -338,6 +341,7 @@ const runtimeObservability: RuntimeObservabilityState = {
       refreshesTotal: 0,
       logoutsTotal: 0,
       rateLimitedTotal: 0,
+      credentialStuffingBlockedTotal: 0,
       invalidCredentialsTotal: 0,
       tokenDeliveryRequestsTotal: 0,
       tokenDeliverySuccessesTotal: 0,
@@ -348,6 +352,7 @@ const runtimeObservability: RuntimeObservabilityState = {
     activeGuestSessionCount: 0,
     activeAccountSessions: new Map<string, { playerId: string; provider: string }>(),
     activeAccountLockCount: 0,
+    activeCredentialStuffingSourceCount: 0,
     pendingRegistrationCount: 0,
     pendingRecoveryCount: 0,
     sessionFailureReasons: {
@@ -507,6 +512,7 @@ function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPaylo
         activeAccountSessionCount: runtimeObservability.auth.activeAccountSessions.size,
         activeAccountSessionByProvider,
         activeAccountLockCount: runtimeObservability.auth.activeAccountLockCount,
+        activeCredentialStuffingSourceCount: runtimeObservability.auth.activeCredentialStuffingSourceCount,
         pendingRegistrationCount: runtimeObservability.auth.pendingRegistrationCount,
         pendingRecoveryCount: runtimeObservability.auth.pendingRecoveryCount,
         counters: { ...runtimeObservability.auth.counters },
@@ -566,6 +572,10 @@ function buildAuthReadinessPayload(service = "project-veil-server"): AuthReadine
     alerts.push(`${health.runtime.auth.activeAccountLockCount} account lockout(s) active`);
   }
 
+  if (health.runtime.auth.activeCredentialStuffingSourceCount > 0) {
+    alerts.push(`${health.runtime.auth.activeCredentialStuffingSourceCount} credential-stuffing source block(s) active`);
+  }
+
   if (health.runtime.auth.pendingRecoveryCount > 10) {
     alerts.push(`${health.runtime.auth.pendingRecoveryCount} password recovery tokens pending`);
   }
@@ -594,6 +604,7 @@ function buildAuthReadinessPayload(service = "project-veil-server"): AuthReadine
       `auth ready; guest=${health.runtime.auth.activeGuestSessionCount} ` +
       `account=${health.runtime.auth.activeAccountSessionCount} ` +
       `lockouts=${health.runtime.auth.activeAccountLockCount} ` +
+      `sourceBlocks=${health.runtime.auth.activeCredentialStuffingSourceCount} ` +
       `wechat=${wechatMode}/${wechatCredentialsStatus}`,
     alerts,
     auth: {
@@ -966,6 +977,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_auth_account_locks Active account login lockouts.",
     "# TYPE veil_auth_account_locks gauge",
     `veil_auth_account_locks ${health.runtime.auth.activeAccountLockCount}`,
+    "# HELP veil_auth_credential_stuffing_sources Active source-IP blocks triggered by credential-stuffing detection.",
+    "# TYPE veil_auth_credential_stuffing_sources gauge",
+    `veil_auth_credential_stuffing_sources ${health.runtime.auth.activeCredentialStuffingSourceCount}`,
     "# HELP veil_auth_pending_registrations Pending account registration tokens.",
     "# TYPE veil_auth_pending_registrations gauge",
     `veil_auth_pending_registrations ${health.runtime.auth.pendingRegistrationCount}`,
@@ -999,6 +1013,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_auth_rate_limited_total Total auth requests rejected by rate limiting.",
     "# TYPE veil_auth_rate_limited_total counter",
     `veil_auth_rate_limited_total ${health.runtime.auth.counters.rateLimitedTotal}`,
+    "# HELP veil_auth_credential_stuffing_blocked_total Total auth requests rejected by credential-stuffing source blocks.",
+    "# TYPE veil_auth_credential_stuffing_blocked_total counter",
+    `veil_auth_credential_stuffing_blocked_total ${health.runtime.auth.counters.credentialStuffingBlockedTotal}`,
     "# HELP veil_matchmaking_rate_limited_total Total matchmaking requests rejected by rate limiting.",
     "# TYPE veil_matchmaking_rate_limited_total counter",
     `veil_matchmaking_rate_limited_total ${health.runtime.matchmaking.counters.rateLimitedTotal}`,
@@ -1557,6 +1574,10 @@ export function setAuthAccountLockCount(count: number): void {
   runtimeObservability.auth.activeAccountLockCount = Math.max(0, Math.floor(count));
 }
 
+export function setAuthCredentialStuffingSourceCount(count: number): void {
+  runtimeObservability.auth.activeCredentialStuffingSourceCount = Math.max(0, Math.floor(count));
+}
+
 export function setPendingAuthRegistrationCount(count: number): void {
   runtimeObservability.auth.pendingRegistrationCount = Math.max(0, Math.floor(count));
 }
@@ -1600,6 +1621,10 @@ export function recordAuthLogout(): void {
 
 export function recordAuthRateLimited(): void {
   runtimeObservability.auth.counters.rateLimitedTotal += 1;
+}
+
+export function recordAuthCredentialStuffingBlocked(): void {
+  runtimeObservability.auth.counters.credentialStuffingBlockedTotal += 1;
 }
 
 export function recordMatchmakingRateLimited(): void {
@@ -1725,6 +1750,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.auth.counters.refreshesTotal = 0;
   runtimeObservability.auth.counters.logoutsTotal = 0;
   runtimeObservability.auth.counters.rateLimitedTotal = 0;
+  runtimeObservability.auth.counters.credentialStuffingBlockedTotal = 0;
   runtimeObservability.auth.counters.invalidCredentialsTotal = 0;
   runtimeObservability.auth.counters.tokenDeliveryRequestsTotal = 0;
   runtimeObservability.auth.counters.tokenDeliverySuccessesTotal = 0;
@@ -1734,6 +1760,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.auth.activeGuestSessionCount = 0;
   runtimeObservability.auth.activeAccountSessions.clear();
   runtimeObservability.auth.activeAccountLockCount = 0;
+  runtimeObservability.auth.activeCredentialStuffingSourceCount = 0;
   runtimeObservability.auth.pendingRegistrationCount = 0;
   runtimeObservability.auth.pendingRecoveryCount = 0;
   runtimeObservability.auth.sessionFailureReasons.unauthorized = 0;

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -1860,6 +1860,132 @@ test("account login lockout expires after the configured duration", async (t) =>
   assert.equal(payload.session.loginId, "expiry-ranger");
 });
 
+test("account login blocks suspected credential stuffing across distinct login IDs and surfaces it in auth observability", async (t) => {
+  const cleanup: Array<() => void> = [];
+  withEnvOverrides(
+    {
+      VEIL_AUTH_CREDENTIAL_STUFFING_DISTINCT_LOGIN_IDS: "2",
+      VEIL_AUTH_CREDENTIAL_STUFFING_BLOCK_DURATION_MINUTES: "0.003"
+    },
+    cleanup
+  );
+
+  const port = 44710 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+
+  await store.ensurePlayerAccount({
+    playerId: "credential-stuffing-player",
+    displayName: "守望者"
+  });
+  await store.bindPlayerAccountCredentials("credential-stuffing-player", {
+    loginId: "credential-stuffing-real",
+    passwordHash: hashAccountPassword("hunter2")
+  });
+
+  t.after(async () => {
+    cleanup.reverse().forEach((fn) => fn());
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstFailureResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "credential-stuffing-a",
+      password: "wrong-password",
+      privacyConsentAccepted: true
+    })
+  });
+  const firstFailurePayload = (await firstFailureResponse.json()) as { error: { code: string } };
+  assert.equal(firstFailureResponse.status, 401);
+  assert.equal(firstFailurePayload.error.code, "invalid_credentials");
+
+  const blockTriggerResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "credential-stuffing-b",
+      password: "wrong-password",
+      privacyConsentAccepted: true
+    })
+  });
+  const blockTriggerPayload = (await blockTriggerResponse.json()) as {
+    error: { code: string; blockedUntil?: string };
+  };
+  assert.equal(blockTriggerResponse.status, 429);
+  assert.equal(blockTriggerPayload.error.code, "credential_stuffing_blocked");
+  assert.ok(blockTriggerPayload.error.blockedUntil);
+  assert.ok(blockTriggerResponse.headers.get("Retry-After"));
+
+  const blockedLegitimateResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "credential-stuffing-real",
+      password: "hunter2",
+      privacyConsentAccepted: true
+    })
+  });
+  const blockedLegitimatePayload = (await blockedLegitimateResponse.json()) as {
+    error: { code: string; blockedUntil?: string };
+  };
+  assert.equal(blockedLegitimateResponse.status, 429);
+  assert.equal(blockedLegitimatePayload.error.code, "credential_stuffing_blocked");
+  assert.ok(blockedLegitimatePayload.error.blockedUntil);
+
+  const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
+  const readinessPayload = (await readinessResponse.json()) as {
+    status: string;
+    headline: string;
+    alerts: string[];
+    auth: {
+      activeCredentialStuffingSourceCount: number;
+      counters: {
+        credentialStuffingBlockedTotal: number;
+      };
+    };
+  };
+  assert.equal(readinessResponse.status, 200);
+  assert.equal(readinessPayload.status, "warn");
+  assert.match(readinessPayload.headline, /sourceBlocks=1/);
+  assert.deepEqual(readinessPayload.alerts, ["1 credential-stuffing source block(s) active"]);
+  assert.equal(readinessPayload.auth.activeCredentialStuffingSourceCount, 1);
+  assert.equal(readinessPayload.auth.counters.credentialStuffingBlockedTotal, 2);
+
+  const metricsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/metrics`);
+  const metricsText = await metricsResponse.text();
+  assert.equal(metricsResponse.status, 200);
+  assert.match(metricsText, /^veil_auth_credential_stuffing_sources 1$/m);
+  assert.match(metricsText, /^veil_auth_credential_stuffing_blocked_total 2$/m);
+
+  await sleep(250);
+
+  const successfulLoginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      loginId: "credential-stuffing-real",
+      password: "hunter2",
+      privacyConsentAccepted: true
+    })
+  });
+  const successfulLoginPayload = (await successfulLoginResponse.json()) as {
+    account: { playerId: string };
+  };
+  assert.equal(successfulLoginResponse.status, 200);
+  assert.equal(successfulLoginPayload.account.playerId, "credential-stuffing-player");
+});
+
 test("guest auth session LRU eviction invalidates the oldest idle guest token", async (t) => {
   const cleanup: Array<() => void> = [];
   withEnvOverrides(
@@ -3468,7 +3594,7 @@ test("banned accounts are blocked on account-login and subsequent session checks
 
   await store.savePlayerBan("banned-player", {
     banStatus: "temporary",
-    banExpiry: "2026-04-06T00:00:00.000Z",
+    banExpiry: "2026-04-16T00:00:00.000Z",
     banReason: "Harassment"
   });
 
@@ -3483,7 +3609,7 @@ test("banned accounts are blocked on account-login and subsequent session checks
   assert.equal(sessionResponse.status, 403);
   assert.equal(sessionPayload.error.code, "account_banned");
   assert.equal(sessionPayload.error.reason, "Harassment");
-  assert.equal(sessionPayload.error.expiry, "2026-04-06T00:00:00.000Z");
+  assert.equal(sessionPayload.error.expiry, "2026-04-16T00:00:00.000Z");
 
   const reloginResponse = await fetch(`http://127.0.0.1:${port}/api/auth/account-login`, {
     method: "POST",
@@ -3502,7 +3628,7 @@ test("banned accounts are blocked on account-login and subsequent session checks
   assert.equal(reloginResponse.status, 403);
   assert.equal(reloginPayload.error.code, "account_banned");
   assert.equal(reloginPayload.error.reason, "Harassment");
-  assert.equal(reloginPayload.error.expiry, "2026-04-06T00:00:00.000Z");
+  assert.equal(reloginPayload.error.expiry, "2026-04-16T00:00:00.000Z");
 });
 
 test("guest login requires privacy consent before issuing the first session", async (t) => {

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -19,6 +19,13 @@
 2. 需要长期登录时，再把当前游客档绑定到 `loginId + password`。
 3. 后续账号登录会继续复用同一份英雄长期档、全局资源仓库和账号事件历史。
 
+## `#1201` 当前切片进度
+
+- [x] `POST /api/auth/account-login` 现在会按来源 IP 聚合短窗口内的跨账号口令失败；同一来源连续命中多个不同 `loginId` 失败后，会临时封禁该来源并返回 `429 credential_stuffing_blocked`。
+- [x] `/api/runtime/auth-readiness` 与 `/api/runtime/metrics` 已补充撞库源封禁态势，便于 ops 区分“单账号锁定”与“同源多账号扫描”。
+- [ ] 更外层的 DDoS 缓解仍属于 CDN / WAF / 基础设施侧工作，本次仓库切片未覆盖。
+- [ ] 未成年人保护沿用现有微信实名 / minor protection 读模型，本次切片未改动夜间限制与累计时长策略。
+
 ## 微信小游戏 code2session
 
 - `POST /api/auth/wechat-login` 会用服务端环境变量 `WECHAT_APP_ID` / `WECHAT_APP_SECRET` 调用微信 `jscode2session`。
@@ -43,8 +50,9 @@
   - 当前进程内活跃游客会话：`veil_auth_guest_sessions`
   - 当前进程内活跃正式账号设备会话：`veil_auth_account_sessions`
   - 当前登录锁定数：`veil_auth_account_locks`
+  - 当前处于撞库源封禁中的来源数：`veil_auth_credential_stuffing_sources`
   - 待确认注册 / 找回令牌：`veil_auth_pending_registrations`、`veil_auth_pending_recoveries`
-  - 会话校验、游客登录、账号登录、绑定、注册确认、刷新、退出、限流、口令错误等累计计数：`veil_auth_*_total`
+  - 会话校验、游客登录、账号登录、绑定、注册确认、刷新、退出、限流、撞库源封禁、口令错误等累计计数：`veil_auth_*_total`
   - 账号令牌投递队列 / dead-letter gauge：`veil_auth_token_delivery_queue_count`、`veil_auth_token_delivery_dead_letter_count`
   - 账号令牌投递请求量、成功、失败、重试、耗尽累计计数：`veil_auth_token_delivery_requests_total`、`veil_auth_token_delivery_successes_total`、`veil_auth_token_delivery_failures_total`、`veil_auth_token_delivery_retries_total`、`veil_auth_token_delivery_dead_letters_total`
   - 账号令牌投递失败原因累计计数：`veil_auth_token_delivery_failures_timeout_total`、`veil_auth_token_delivery_failures_network_total`、`veil_auth_token_delivery_failures_smtp_4xx_total`、`veil_auth_token_delivery_failures_smtp_5xx_total`、`veil_auth_token_delivery_failures_smtp_protocol_total`、`veil_auth_token_delivery_failures_webhook_4xx_total`、`veil_auth_token_delivery_failures_webhook_429_total`、`veil_auth_token_delivery_failures_webhook_5xx_total`
@@ -215,6 +223,12 @@
   - 默认 `60000`
 - `VEIL_RATE_LIMIT_AUTH_MAX`
   - 默认 `10`
+- `VEIL_AUTH_CREDENTIAL_STUFFING_WINDOW_MS`
+  - 默认 `300000`；按来源 IP 聚合 `account-login` 失败的观测窗口
+- `VEIL_AUTH_CREDENTIAL_STUFFING_DISTINCT_LOGIN_IDS`
+  - 默认 `5`；同一来源在窗口内命中多少个不同 `loginId` 失败后，触发临时撞库源封禁
+- `VEIL_AUTH_CREDENTIAL_STUFFING_BLOCK_DURATION_MINUTES`
+  - 默认 `15`；撞库源封禁持续时间，期间 `account-login` 会直接返回 `429 credential_stuffing_blocked`
 
 ## SMTP / Webhook 投递契约与失败处理
 


### PR DESCRIPTION
## Summary

Implements a focused security-hardening slice for #1201 around password auth abuse resistance and operator visibility.

### What changed

- added a dedicated `account-login` credential-stuffing guard keyed by source IP plus distinct failed `loginId` attempts
- introduced configurable source-block window / threshold / duration env vars
- exposed active source blocks and cumulative block totals through `/api/runtime/auth-readiness` and `/api/runtime/metrics`
- added targeted auth regression coverage for trigger, observability, and expiry behavior
- documented the slice and its current acceptance progress in `docs/account-auth-lifecycle.md`

### Why

The repo already had a generic per-IP auth rate limit and per-account lockout, but it did not specifically detect one source rapidly failing across multiple different accounts. That left a gap for credential-stuffing patterns that stay under single-account lock thresholds while still creating operational risk.

### Acceptance progress for #1201

Completed in this slice:

- `account-login` now blocks suspicious multi-account password guessing from one source
- ops can distinguish account lockouts from source-level stuffing blocks in readiness and metrics
- docs and tests cover the new behavior

Still out of scope for this slice:

- CDN / WAF / edge-side DDoS controls
- broader auth-route hardening outside this focused password-login path
- new minor-protection policy changes

## Validation

- `npm run typecheck:server`
- `node --import tsx --test apps/server/test/auth-guest-login.test.ts apps/server/test/runtime-observability-routes.test.ts`
- `npm run validate:quickstart`

Closes #1201