### PR TITLE
docs: add incident response runbook

### DIFF
--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -11,7 +11,7 @@ groups:
         annotations:
           summary: Project Veil connected player count is elevated
           description: veil_connected_players has been above 150 for 10 minutes. Add capacity or shed test traffic before matchmaking and room latency degrade.
-          runbook_url: ./alerting-runbook.md#alert-veilconnectedplayershigh
+          runbook_url: ./incident-response-runbook.md#alert-veilconnectedplayershigh
 
       - alert: VeilRoomsHot
         expr: (veil_connected_players / clamp_min(veil_active_rooms, 1)) > 12
@@ -22,7 +22,7 @@ groups:
         annotations:
           summary: Project Veil room density is high
           description: Average connected players per active room has stayed above 12 for 10 minutes, which indicates hot shards or uneven room placement.
-          runbook_url: ./alerting-runbook.md#alert-veilroomshot
+          runbook_url: ./incident-response-runbook.md#alert-veilroomshot
 
       - alert: VeilBattleDurationP95High
         expr: histogram_quantile(0.95, sum(rate(veil_battle_duration_seconds_bucket[30m])) by (le)) > 180
@@ -33,7 +33,7 @@ groups:
         annotations:
           summary: Project Veil battles are taking too long to resolve
           description: The 95th percentile battle duration has exceeded 180 seconds for 15 minutes, which usually means turn processing stalls or players are stuck in combat loops.
-          runbook_url: ./alerting-runbook.md#alert-veilbattledurationp95high
+          runbook_url: ./incident-response-runbook.md#alert-veilbattledurationp95high
 
       - alert: VeilActionValidationFailuresHigh
         expr: sum(rate(veil_action_validation_failures_total[15m])) > 0.5
@@ -44,7 +44,7 @@ groups:
         annotations:
           summary: Project Veil is rejecting gameplay actions at an abnormal rate
           description: veil_action_validation_failures_total is averaging more than 0.5 rejected actions per second over 15 minutes. Check recent deploys, protocol drift, and client desync.
-          runbook_url: ./alerting-runbook.md#alert-veilactionvalidationfailureshigh
+          runbook_url: ./incident-response-runbook.md#alert-veilactionvalidationfailureshigh
 
       - alert: VeilHttpRequestLatencyP95High
         expr: histogram_quantile(0.95, sum(rate(veil_http_request_duration_seconds_bucket[15m])) by (le)) > 0.75
@@ -55,7 +55,7 @@ groups:
         annotations:
           summary: Project Veil HTTP latency is elevated
           description: The 95th percentile HTTP request latency has exceeded 750ms for 10 minutes. Inspect runtime saturation, downstream auth/config dependencies, and noisy operators.
-          runbook_url: ./alerting-runbook.md#alert-veilhttprequestlatencyp95high
+          runbook_url: ./incident-response-runbook.md#alert-veilhttprequestlatencyp95high
 
       - alert: VeilMySqlPoolPressureHigh
         expr: max(veil_mysql_pool_queue_depth{pool=~"room_snapshot|config_center"}) > 0 or max(veil_mysql_pool_connection_utilization_ratio{pool=~"room_snapshot|config_center"}) > 0.8
@@ -66,7 +66,7 @@ groups:
         annotations:
           summary: Project Veil MySQL connection pools are under sustained pressure
           description: Either the MySQL pool queue is non-zero or pool utilization has exceeded 80 percent for 10 minutes. Expect persistence/config requests to back up before user-facing latency fully degrades.
-          runbook_url: ./alerting-runbook.md#alert-veilmysqlpoolpressurehigh
+          runbook_url: ./incident-response-runbook.md#alert-veilmysqlpoolpressurehigh
 
       - alert: VeilMySqlReplicationLagHigh
         expr: max(mysql_slave_status_seconds_behind_master{service="project-veil-mysql"}) > 30
@@ -77,7 +77,7 @@ groups:
         annotations:
           summary: Project Veil MySQL replica lag is above the RPO target
           description: Replica lag has exceeded 30 seconds for 10 minutes. Freeze failover and backup promotion decisions until replication catches up or a deliberate recovery point is chosen.
-          runbook_url: ./alerting-runbook.md#alert-veilmysqlreplicationlaghigh
+          runbook_url: ./incident-response-runbook.md#alert-veilmysqlreplicationlaghigh
 
       - alert: VeilWechatPaymentFraudSignalsHigh
         expr: increase(veil_runtime_error_events_total{feature_area="payment",error_code="payment_fraud_signal"}[15m]) > 0
@@ -87,8 +87,8 @@ groups:
           service: project-veil-server
         annotations:
           summary: Project Veil is detecting WeChat payment fraud or integrity anomalies
-          description: `payment_fraud_signal` fired within the last 15 minutes. Freeze risky compensation/refund actions, inspect duplicate callbacks or payer mismatches, and review the current candidate before continuing rollout.
-          runbook_url: ./wechat-pay-ops-runbook.md#payment-fraud-signal-alert
+          description: "`payment_fraud_signal` fired within the last 15 minutes. Freeze risky compensation/refund actions, inspect duplicate callbacks or payer mismatches, and review the current candidate before continuing rollout."
+          runbook_url: ./incident-response-runbook.md#alert-veilwechatpaymentfraudsignalshigh
 
       - alert: VeilFeatureFlagConfigStale
         expr: max(veil_feature_flag_config_stale) > 0
@@ -99,8 +99,8 @@ groups:
           feature_flag: battle_pass_enabled
         annotations:
           summary: Feature flag config is stale on at least one Project Veil node
-          description: A node has not re-checked or reloaded `configs/feature-flags.json` inside the allowed freshness window. Freeze rollout promotion and compare `/api/runtime/feature-flags` checksums across nodes before proceeding.
-          runbook_url: ./feature-flag-experiments-runbook.md#audit-and-consistency
+          description: "A node has not re-checked or reloaded `configs/feature-flags.json` inside the allowed freshness window. Freeze rollout promotion and compare `/api/runtime/feature-flags` checksums across nodes before proceeding."
+          runbook_url: ./incident-response-runbook.md#alert-veilfeatureflagconfigstale
 
       - alert: VeilFeatureFlagBattlePassSessionFailuresHigh
         expr: (increase(veil_auth_session_failures_total[15m]) / clamp_min(increase(veil_auth_session_checks_total[15m]), 1)) > 0.01 and max(veil_feature_flag_rollout_ratio{flag="battle_pass_enabled"}) > 0
@@ -111,8 +111,8 @@ groups:
           feature_flag: battle_pass_enabled
         annotations:
           summary: Battle pass gray rollout is causing elevated session failures
-          description: Session failure rate has exceeded 1% for 10 minutes while `battle_pass_enabled` is live. Hold rollout promotion and roll back to the previous safe percentage if the error does not self-resolve immediately.
-          runbook_url: ./feature-flag-experiments-runbook.md#gray-release-sop
+          description: "Session failure rate has exceeded 1% for 10 minutes while `battle_pass_enabled` is live. Hold rollout promotion and roll back to the previous safe percentage if the error does not self-resolve immediately."
+          runbook_url: ./incident-response-runbook.md#alert-veilfeatureflagbattlepasssessionfailureshigh
 
       - alert: VeilFeatureFlagBattlePassErrorRateHigh
         expr: (increase(veil_action_validation_failures_total[15m]) / clamp_min(increase(veil_gameplay_action_messages_total[15m]), 1)) > 0.02 and max(veil_feature_flag_rollout_ratio{flag="battle_pass_enabled"}) > 0
@@ -124,7 +124,7 @@ groups:
         annotations:
           summary: Battle pass gray rollout is exceeding gameplay error budget
           description: Gameplay action validation failures have exceeded 2% for 10 minutes during a live battle pass rollout. Treat this as the generic rollout error-rate tripwire when a battle-pass-specific signal is not yet available.
-          runbook_url: ./feature-flag-experiments-runbook.md#gray-release-sop
+          runbook_url: ./incident-response-runbook.md#alert-veilfeatureflagbattlepasserrorratehigh
 
       - alert: VeilFeatureFlagBattlePassPaymentFailuresHigh
         expr: (increase(veil_runtime_error_events_total{feature_area="payment",severity="error"}[15m]) / clamp_min(increase(veil_runtime_error_events_total{feature_area="payment"}[15m]), 1)) > 0.02 and max(veil_feature_flag_rollout_ratio{flag="battle_pass_enabled"}) > 0
@@ -135,5 +135,5 @@ groups:
           feature_flag: battle_pass_enabled
         annotations:
           summary: Battle pass gray rollout is triggering payment-related runtime errors
-          description: Payment runtime error ratio has exceeded 2% for 10 minutes while `battle_pass_enabled` is active. Roll back to the previous safe stage and verify the payment callback / reward-claim path before retrying.
-          runbook_url: ./feature-flag-experiments-runbook.md#gray-release-sop
+          description: "Payment runtime error ratio has exceeded 2% for 10 minutes while `battle_pass_enabled` is active. Roll back to the previous safe stage and verify the payment callback / reward-claim path before retrying."
+          runbook_url: ./incident-response-runbook.md#alert-veilfeatureflagbattlepasspaymentfailureshigh

--- a/docs/incident-response-runbook.md
+++ b/docs/incident-response-runbook.md
@@ -1,0 +1,357 @@
+# Incident Response Runbook
+
+本手册回答生产环境最关键的三个问题：
+
+- 事故属于哪个级别，首次响应和升级时限是多少
+- 第一响应者在 5 分钟内该先跑哪些命令
+- 什么时候应该回滚，什么时候应该止血后热修
+
+它补充 [`docs/operational-entry-point-repo-map.md`](./operational-entry-point-repo-map.md) 的入口索引，不替代更细分的支付、配置或数据库专用文档。
+
+## Severity And SLA
+
+| Level | Typical impact | First response SLA | Escalation SLA | Status update cadence | Exit condition |
+| --- | --- | --- | --- | --- | --- |
+| `P0` | 全服不可用、登录完全失败、支付或核心战斗链路全量不可用、无法安全恢复数据 | `<= 15 min` | `<= 5 min` 内拉起 incident commander、runtime owner、release owner | 每 15 分钟 | 服务恢复或已完成受控回滚，并确认无继续扩散 |
+| `P1` | 关键链路显著异常但存在降级路径，例如支付回调失败、登录高失败率、MySQL 连接池耗尽、灰度放量导致大面积断线 | `<= 15 min` | `<= 15 min` 内补齐对应 owner | 每 30 分钟 | 风险被隔离，错误率回到阈值内 |
+| `P2` | 部分功能降级、局部热点房间、单一地图/单一配置文档回退、可接受范围内的流量抖动 | `<= 60 min` | `<= 30 min` 内通知负责子系统 owner | 每 60 分钟 | 已恢复或已有明确后续修复排期 |
+
+分级规则：
+
+- 满足更高级别条件时，按更高级别处理，不允许“先当 P2 看看”
+- 事故一旦涉及数据一致性、支付金额、错误补偿、或 failover/restore 决策，至少按 `P1`
+- 正在放量或发版窗口内出现同类问题时，默认比平时上调一个优先级
+
+## Roles And Escalation Path
+
+| Role | Responsibility | Default trigger |
+| --- | --- | --- |
+| `primary on-call` | 接警、建群、执行 5 分钟快诊、决定是否宣告事故 | 所有告警与人工报障 |
+| `incident commander` | 决策升级范围、状态同步、协调回滚或流量管控 | 所有 `P0`，以及 15 分钟内未稳定的 `P1` |
+| `runtime owner` | 处理服务端宕机、房间热点、登录/会话、灰度配置异常 | Runtime / gameplay / feature flag 相关事故 |
+| `database owner` | 处理连接池耗尽、复制延迟、恢复点选择 | MySQL 压力、复制、恢复相关事故 |
+| `commerce owner` | 处理支付回调、重复扣款、补偿/退款冻结 | WeChat Pay 相关事故 |
+| `release owner` | 暂停放量、冻结 candidate、决定 go/no-go | 发版窗口内的任何 `P0/P1` |
+
+升级路径：
+
+1. `primary on-call` 在接警后 5 分钟内完成快诊，并给出 `P0/P1/P2` 初判。
+2. `P0` 立即拉 `incident commander + runtime owner + release owner`，并暂停继续发版、灰度或高风险补偿动作。
+3. `P1` 按事故类型补齐 owner：
+   - 服务端宕机 / 登录异常 / 大面积断线: `runtime owner`
+   - MySQL 连接池 / 复制延迟 / 恢复点选择: `database owner`
+   - WeChat Pay / 重复回调 / 欺诈信号: `commerce owner`
+4. 任何 `P1` 在 15 分钟后仍无缓解趋势，升级到 `incident commander`。
+5. 任何事故一旦需要回滚、failover、手工补偿、公告玩家，必须通知 `release owner`。
+
+## On-Call Contact Template
+
+将以下模板放到值班表、群公告、或事故频道固定消息中：
+
+| Field | Template |
+| --- | --- |
+| Primary on-call | `<name> / <slack-wecom> / <phone>` |
+| Secondary on-call | `<name> / <slack-wecom> / <phone>` |
+| Incident commander | `<name> / <slack-wecom> / <phone>` |
+| Runtime owner | `<name> / <slack-wecom> / <phone>` |
+| Database owner | `<name> / <slack-wecom> / <phone>` |
+| Commerce owner | `<name> / <slack-wecom> / <phone>` |
+| Release owner | `<name> / <slack-wecom> / <phone>` |
+| Status page / war room link | `<url>` |
+
+交接最少字段：
+
+- 当前事故级别
+- 最新状态更新时间
+- 已执行命令与结果
+- 下一步动作与 owner
+- 是否已冻结发版 / 灰度 / 补偿
+
+## Five-Minute Triage
+
+先设定目标环境：
+
+```bash
+export VEIL_RUNTIME_URL="${VEIL_RUNTIME_URL:-http://127.0.0.1:2567}"
+export VEIL_MYSQL_EXPORTER_METRICS_URL="${VEIL_MYSQL_EXPORTER_METRICS_URL:-http://127.0.0.1:9104/metrics}"
+export VEIL_MYSQL_REPLICA_HOST="${VEIL_MYSQL_REPLICA_HOST:-127.0.0.1}"
+export VEIL_MYSQL_REPLICA_PORT="${VEIL_MYSQL_REPLICA_PORT:-3306}"
+export VEIL_MYSQL_REPLICA_USER="${VEIL_MYSQL_REPLICA_USER:-root}"
+export VEIL_MYSQL_REPLICA_PASSWORD="${VEIL_MYSQL_REPLICA_PASSWORD:-change_me}"
+```
+
+5 分钟快诊命令集：
+
+```bash
+date -u
+curl -fsS "$VEIL_RUNTIME_URL/metrics" > /tmp/project-veil.metrics
+curl -fsS "$VEIL_RUNTIME_URL/api/runtime/health" | jq .
+curl -fsS "$VEIL_RUNTIME_URL/api/runtime/auth-readiness" | jq .
+curl -fsS "$VEIL_RUNTIME_URL/api/runtime/diagnostic-snapshot" | jq '.diagnostics.errorSummary'
+curl -fsS "$VEIL_RUNTIME_URL/api/runtime/slo-summary?format=text"
+grep -E '^(veil_connected_players|veil_active_rooms|veil_http_request_duration_seconds|veil_action_validation_failures_total|veil_feature_flag_config_stale|veil_mysql_pool_|veil_runtime_error_events_total) ' /tmp/project-veil.metrics
+```
+
+5 分钟内必须回答：
+
+1. 是单节点/单 shard，还是全环境广泛故障。
+2. 是刚刚变更后出现，还是已有一段时间累积放大。
+3. 是否影响登录、支付、核心战斗、或数据一致性。
+4. 是否需要立刻停止发版、灰度、补偿、或 failover。
+5. 是回滚更安全，还是可以在不扩大影响的前提下热修。
+
+如果 `metrics`、`health`、`auth-readiness` 任一无法访问，先按“服务端宕机”处理，不要先深挖次级告警。
+
+## Rollback Decision Tree
+
+按下面顺序做决定：
+
+1. 问题是否由最近 30 分钟内的 deploy、config publish、feature flag 放量触发。
+2. 回滚是否能在 15 分钟内恢复到已知安全状态，且不会引入更大的数据偏差。
+3. 当前是否已经出现支付、持久化、或复制延迟，导致“继续写入”风险高于“回滚风险”。
+4. 热修是否只改局部且无需继续放量验证。
+
+选择规则：
+
+- 优先回滚：
+  - 发布后立刻出现全服不可用、登录雪崩、广泛断线、支付回调异常
+  - `VeilFeatureFlag*` 告警与大面积会话失败同时出现
+  - MySQL 池耗尽或复制延迟导致写入安全性无法确认
+- 优先热修：
+  - 影响范围稳定在单节点、单房间、单配置文档
+  - 已经通过摘流、暂停灰度、冻结补偿把扩散面压住
+  - 热修无需修改数据库结构、支付资金流、或核心协议
+- 禁止盲目回滚：
+  - 已经发生不可逆数据迁移且没有验证过回滚路径
+  - 复制延迟过高，无法确认一致恢复点
+  - 支付订单状态已部分落库但补偿/退款路径未冻结
+
+## Scenario Playbooks
+
+### Runtime Unavailable
+
+适用信号：
+
+- `/api/runtime/health` 无响应
+- 多个运行时告警同时触发
+- 玩家报告无法登录或所有房间断开
+
+处置步骤：
+
+1. 先确认是进程不可达、依赖不可达、还是负载导致探活超时。
+2. 冻结当前 deploy、灰度和高频诊断脚本。
+3. 抓取 `health`、`auth-readiness`、`metrics` 的失败现象并记录时间点。
+4. 若最近有 deploy 或 config publish，优先回滚到最近已知安全版本或快照。
+5. 若无明确变更，先摘除故障节点或拉起替代容量，再继续排查。
+
+推荐命令：
+
+```bash
+curl -v "$VEIL_RUNTIME_URL/api/runtime/health"
+curl -v "$VEIL_RUNTIME_URL/api/runtime/auth-readiness"
+curl -fsS "$VEIL_RUNTIME_URL/metrics" | head -n 40
+```
+
+升级条件：
+
+- 任何全服不可用默认 `P0`
+- 15 分钟内无法恢复探活，升级到 `incident commander`
+
+### Database Pool Exhaustion
+
+适用信号：
+
+- `VeilMySqlPoolPressureHigh`
+- HTTP 延迟上升，伴随持久化或配置写入堆积
+
+处置步骤：
+
+1. 先看 `queue_depth` 是否大于 `0`，确认调用方已经在等待。
+2. 区分 `room_snapshot` 和 `config_center`，不要把配置写入问题当成全局数据库故障。
+3. 如果复制延迟也在恶化，暂停 failover、恢复演练和高风险批量写入。
+4. 若 MySQL 本身健康但池长期逼近上限，谨慎提高 `VEIL_MYSQL_POOL_CONNECTION_LIMIT`，并同步记录变更。
+5. 若是最近发版后开始恶化，优先回滚相关版本，而不是只扩池掩盖问题。
+
+推荐命令：
+
+```bash
+grep '^veil_mysql_pool_' /tmp/project-veil.metrics | sort
+curl -fsS "$VEIL_RUNTIME_URL/api/runtime/health" | jq '{activeRoomCount: .runtime.activeRoomCount, connectionCount: .runtime.connectionCount, activeBattleCount: .runtime.activeBattleCount}'
+curl -fsS "$VEIL_MYSQL_EXPORTER_METRICS_URL" | grep '^mysql_slave_status_seconds_behind_master'
+```
+
+升级条件：
+
+- 连接池等待持续 10 分钟以上按 `P1`
+- 如果已影响支付、登录或回滚安全性，提升为 `P0`
+
+### Config Push Or Feature Flag Rollout Causing Disconnects
+
+适用信号：
+
+- `VeilFeatureFlagConfigStale`
+- `VeilFeatureFlagBattlePassSessionFailuresHigh`
+- `VeilFeatureFlagBattlePassErrorRateHigh`
+- `VeilFeatureFlagBattlePassPaymentFailuresHigh`
+- 玩家在放量或 config publish 后出现大面积断线/失败
+
+处置步骤：
+
+1. 立即暂停继续放量，不要一边排查一边扩大暴露面。
+2. 对比 `/api/runtime/feature-flags` 或诊断摘要中的 checksum，确认是否有节点拿到过期配置。
+3. 如果知道故障来源于某次 publish，使用 `npm run config-center:restore -- --document <id> --publish-id <publish-id>` 回退对应文档。
+4. 如果故障来源于灰度比例，先回退到上一个安全 rollout 比例或直接置零。
+5. 如果已经出现广泛断线，按 `P0/P1` 同步 `runtime owner + release owner`，并补跑 [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md)。
+
+推荐命令：
+
+```bash
+grep '^veil_feature_flag_' /tmp/project-veil.metrics
+curl -fsS "$VEIL_RUNTIME_URL/api/runtime/diagnostic-snapshot" | jq '.runtime.featureFlags'
+npm run config-center:restore -- --help
+```
+
+升级条件：
+
+- 配置不一致但尚未影响玩家，按 `P1`
+- 已造成大面积会话失败、支付失败或断线，按 `P0`
+
+### WeChat Payment Callback Failure
+
+适用信号：
+
+- `VeilWechatPaymentFraudSignalsHigh`
+- 支付成功但未到账、重复扣款、回调重放怀疑
+- 灰度期间 battle pass 支付错误率升高
+
+处置步骤：
+
+1. 先冻结高风险补偿、退款和继续放量，避免把对账面扩大。
+2. 确认是 `payment_fraud_signal`、重复 `out_trade_no`、签名异常，还是候选版本逻辑回归。
+3. 单玩家异常先隔离玩家；候选版本级异常立即暂停该版本。
+4. 涉及资金、错发、或重复扣款时，必须拉 `commerce owner`。
+5. 详细支付补偿、退款和反欺诈操作继续遵循 [`docs/wechat-pay-ops-runbook.md`](./wechat-pay-ops-runbook.md)。
+
+推荐命令：
+
+```bash
+grep 'payment_fraud_signal' /tmp/project-veil.metrics
+curl -fsS "$VEIL_RUNTIME_URL/api/runtime/diagnostic-snapshot" | jq '.diagnostics.errorSummary'
+```
+
+升级条件：
+
+- 单玩家风控信号且可隔离，按 `P1`
+- 候选版本级支付异常、重复扣款或大面积未到账，按 `P0`
+
+## Alert Routing Index
+
+### Alert-VeilConnectedPlayersHigh
+
+先执行 [Five-Minute Triage](#five-minute-triage)，再检查热点房间与容量。若伴随 HTTP 延迟或房间密度恶化，按 [Runtime Unavailable](#runtime-unavailable) 处理；否则按 `P2/P1` 进行扩容或摘除测试流量。
+
+### Alert-VeilRoomsHot
+
+先检查是否是局部热点房间。若只影响单 shard，优先摘流和重建房间；若多房间同时恶化并伴随断线或 battle 卡住，升级到 [Runtime Unavailable](#runtime-unavailable)。
+
+### Alert-VeilBattleDurationP95High
+
+优先判断是热点房间、战斗循环卡死、还是版本回归。若为发版后广泛回归，套用 [Rollback Decision Tree](#rollback-decision-tree) 并通知 `runtime owner`。
+
+### Alert-VeilActionValidationFailuresHigh
+
+把它视为协议漂移或 gameplay desync 的强信号。先暂停可疑 rollout；若同一窗口内也有 feature flag 或会话失败，直接跳到 [Config Push Or Feature Flag Rollout Causing Disconnects](#config-push-or-feature-flag-rollout-causing-disconnects)。
+
+### Alert-VeilHttpRequestLatencyP95High
+
+结合 `auth-readiness` 和连接数判断是否为服务整体饱和。若探活和诊断接口同时退化，走 [Runtime Unavailable](#runtime-unavailable)；若主要由 MySQL 背压带来，走 [Database Pool Exhaustion](#database-pool-exhaustion)。
+
+### Alert-VeilMySqlPoolPressureHigh
+
+直接使用 [Database Pool Exhaustion](#database-pool-exhaustion)。如果复制延迟同时升高，不要做 failover 或恢复点切换。
+
+### Alert-VeilMySqlReplicationLagHigh
+
+先确认 exporter 不是误报，再暂停 failover、恢复演练和备份提升。若 lag 持续扩大或线程停摆，至少按 `P1` 拉起 `database owner`，并参考 [`docs/db-restore-runbook.md`](./db-restore-runbook.md) 做恢复点选择。
+
+### Alert-VeilWechatPaymentFraudSignalsHigh
+
+直接使用 [WeChat Payment Callback Failure](#wechat-payment-callback-failure)，并继续打开 [`docs/wechat-pay-ops-runbook.md`](./wechat-pay-ops-runbook.md) 完成支付专属核查。
+
+### Alert-VeilFeatureFlagConfigStale
+
+直接使用 [Config Push Or Feature Flag Rollout Causing Disconnects](#config-push-or-feature-flag-rollout-causing-disconnects)。如果只是单节点 stale 但玩家未受影响，先阻止继续放量，不要立刻扩大操作面。
+
+### Alert-VeilFeatureFlagBattlePassSessionFailuresHigh
+
+这是灰度导致会话层面失败的明确信号。立即停止放量，必要时把 battle pass rollout 比例降回 `0`，然后按 [Config Push Or Feature Flag Rollout Causing Disconnects](#config-push-or-feature-flag-rollout-causing-disconnects) 执行。
+
+### Alert-VeilFeatureFlagBattlePassErrorRateHigh
+
+把它当作 gameplay 回归或配置不兼容。先冻结 rollout，再判断是版本回滚更快还是仅需单文档回退。
+
+### Alert-VeilFeatureFlagBattlePassPaymentFailuresHigh
+
+同时涉及灰度和支付，默认至少 `P1`。先停 rollout，再按 [WeChat Payment Callback Failure](#wechat-payment-callback-failure) 与 [Config Push Or Feature Flag Rollout Causing Disconnects](#config-push-or-feature-flag-rollout-causing-disconnects) 双线处理。
+
+## Post-Mortem Template
+
+事故关闭后 24 小时内至少补齐下面内容：
+
+```md
+# Post-Mortem: <incident title>
+
+- Incident level: P0 | P1 | P2
+- Incident commander: <name>
+- Date: <YYYY-MM-DD>
+- Start time: <ISO-8601>
+- End time: <ISO-8601>
+- Detection: <alert name / user report / release gate>
+- Impact summary: <who was affected and how>
+- Player impact window: <duration>
+- Affected systems: <runtime / mysql / config / payment / release>
+- Release context: <candidate / branch / deploy / config publish id>
+
+## Timeline
+
+| Time | Event | Owner |
+| --- | --- | --- |
+| 00:00 | Alert fired | monitoring |
+| 00:05 | Incident declared P1 | primary on-call |
+
+## Root Cause
+
+- Technical root cause:
+- Trigger:
+- Why existing guardrails did not stop it:
+
+## Mitigation
+
+- What stopped the impact:
+- Why rollback or hotfix was chosen:
+- Residual risk after restore:
+
+## Corrective Actions
+
+| Action | Owner | Due date | Tracking issue |
+| --- | --- | --- | --- |
+| Add guardrail | <owner> | <date> | #1234 |
+
+## Evidence
+
+- Metrics / logs:
+- Commands run:
+- Artifacts / PR / dashboard links:
+```
+
+演练要求：
+
+- 新流程首次启用后一周内，至少用一次值班演练或桌面推演回填上面的模板
+- 演练也要记录时间线和改进项，不允许只写“流程通过”
+
+## Closeout Checklist
+
+- 记录事故级别、触发时间、恢复时间、影响范围
+- 记录是否执行了回滚、配置回退、补偿冻结、或 failover 冻结
+- 链接相关 PR、issue、artifact、dashboard、war room
+- 为后续修复或演练创建跟踪 issue，再关闭事故

--- a/docs/operational-entry-point-repo-map.md
+++ b/docs/operational-entry-point-repo-map.md
@@ -9,6 +9,7 @@ For detailed release sequencing, keep [`docs/same-revision-release-evidence-runb
 | Need | Primary command or entry point | Canonical docs |
 | --- | --- | --- |
 | Local contributor sanity check | `npm run validate:quickstart` | [`README.md`](../README.md), [`docs/verification-matrix.md`](./verification-matrix.md) |
+| Respond to a live production incident | Start with the 5-minute triage in [`docs/incident-response-runbook.md`](./incident-response-runbook.md) | [`docs/incident-response-runbook.md`](./incident-response-runbook.md), [`docs/alerting-rules.yml`](./alerting-rules.yml) |
 | Pick the smallest sufficient PR verification | [`docs/verification-matrix.md`](./verification-matrix.md) | [`docs/verification-matrix.md`](./verification-matrix.md) |
 | Turn changed paths into a minimal validation plan | `npm run plan:validation:minimal -- --branch origin/main` | [`docs/verification-matrix.md`](./verification-matrix.md) |
 | Confirm the current primary client surface | `npm run client:primary` | [`README.md`](../README.md), [`docs/cocos-primary-client-delivery.md`](./cocos-primary-client-delivery.md) |
@@ -57,6 +58,7 @@ For detailed release sequencing, keep [`docs/same-revision-release-evidence-runb
 | Need | Primary command or entry point | Canonical docs |
 | --- | --- | --- |
 | Probe live runtime health and auth readiness for a candidate environment | `GET /api/runtime/health`, `GET /api/runtime/auth-readiness`, `GET /api/runtime/metrics` | [`docs/wechat-runtime-observability-signoff.md`](./wechat-runtime-observability-signoff.md), [`docs/release-readiness-dashboard.md`](./release-readiness-dashboard.md). Reviewer notes usually land in `artifacts/wechat-release/` or `artifacts/release-readiness/`. |
+| Route a production incident by severity, owner, and rollback decision | [`docs/incident-response-runbook.md`](./incident-response-runbook.md) | [`docs/incident-response-runbook.md`](./incident-response-runbook.md), [`docs/alerting-runbook.md`](./alerting-runbook.md), [`docs/wechat-pay-ops-runbook.md`](./wechat-pay-ops-runbook.md) |
 | Run reconnect or multiplayer governance checks | `npm run test:e2e:multiplayer:smoke`, `npm run test:sync-governance:matrix`, `npm run stress:rooms:reconnect-soak` | [`docs/sync-governance-matrix.md`](./sync-governance-matrix.md), [`docs/reconnect-smoke-gate.md`](./reconnect-smoke-gate.md), [`docs/reconnect-soak-gate.md`](./reconnect-soak-gate.md) |
 | Run room stress or runtime regression comparisons | `npm run stress:rooms:baseline`, `npm run perf:runtime:compare` | [`docs/runtime-regression-baseline.md`](./runtime-regression-baseline.md). Generated runtime metrics and comparison reports usually land in `artifacts/release-readiness/`. |
 | Review or validate MySQL persistence expectations | `npm run db:migrate`, `npm run db:migrate:rollback`, `npm run test:phase1-release-persistence` | [`docs/mysql-persistence.md`](./mysql-persistence.md). The release-facing regression artifact usually lands in `artifacts/release-readiness/phase1-release-persistence-regression-*.json`. |

--- a/docs/release-go-no-go-decision-packet.md
+++ b/docs/release-go-no-go-decision-packet.md
@@ -17,6 +17,8 @@ Use the packet when the release owner, QA owner, or operator needs one final dec
 
 Use the PR-visible summary when reviewers only need the verdict, counts, and artifact pointers in the pull request itself. Use the full packet artifact when release operators need the complete blocker, warning, and manual-review drill-down.
 
+If the candidate is blocked by a live production incident, route the operator response through [`docs/incident-response-runbook.md`](./incident-response-runbook.md) first. The go/no-go packet is the decision artifact; the incident runbook owns severity, escalation, rollback, and post-mortem handling while the incident is active.
+
 ## What It Emits
 
 The command writes both of these under `artifacts/release-readiness/`:
@@ -94,5 +96,6 @@ Those errors are intentional. The packet is the last-mile reviewer artifact, so 
 6. Run `npm run release:pr-summary -- --release-gate-summary <path> --release-health-summary <path> --go-no-go-packet <path>` to render the concise PR-visible summary markdown when you need to preview the exact reviewer digest locally.
 7. In CI pull-request runs, the `Build go/no-go decision packet artifact` plus `Comment PR with release summary` steps publish or update the single bot comment in place, so reruns refresh the same PR-visible summary instead of creating duplicates.
 8. Attach or inspect the Markdown packet itself when the release owner needs the full operator record.
+9. If any blocker is an active `P0/P1` incident, link the active war room, incident level, and rollback/hotfix decision from [`docs/incident-response-runbook.md`](./incident-response-runbook.md) in the packet review notes before resuming release review.
 
 If the packet still shows blocker items, clear those upstream artifacts first and regenerate the packet instead of editing the packet by hand.


### PR DESCRIPTION
## Summary
- add `docs/incident-response-runbook.md` with incident severity, escalation paths, on-call SLA, 5-minute triage, rollback guidance, scenario playbooks, and a post-mortem template
- link the operational repo map and release go/no-go packet docs back to the new incident response flow
- point every alert in `docs/alerting-rules.yml` at the matching runbook section and normalize quoted descriptions so the YAML parses cleanly

## Verification
- `git diff --check`
- `python - <<'PY' ... yaml.safe_load("docs/alerting-rules.yml") ... PY`
- `npm run config-center:restore -- --help`

Closes #1228