### PR TITLE
fix: stop silently falling back to in-memory persistence after DB migration/bootstrap failures

### DIFF
--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -21,7 +21,8 @@ import { registerMinorProtectionPreviewRoutes } from "./minor-protection-preview
 import {
   buildPrometheusMetricsDocument,
   recordHttpRequestDuration,
-  registerRuntimeObservabilityRoutes
+  registerRuntimeObservabilityRoutes,
+  type RuntimePersistenceHealth
 } from "./observability";
 import { type MySqlPersistenceConfig, MySqlRoomSnapshotStore, type RoomSnapshotStore, readMySqlPersistenceConfig, type SnapshotRetentionPolicy } from "./persistence";
 import { registerPlayerAccountRoutes } from "./player-accounts";
@@ -123,7 +124,10 @@ export interface DevServerBootstrapDependencies {
   registerMinorProtectionPreviewRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerLeaderboardRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerSeasonRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
-  registerRuntimeObservabilityRoutes(app: unknown, options?: { store?: DevServerRoomSnapshotStore }): void;
+  registerRuntimeObservabilityRoutes(
+    app: unknown,
+    options?: { store?: DevServerRoomSnapshotStore; persistence?: RuntimePersistenceHealth }
+  ): void;
   registerRetentionSummaryRoute(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerPrometheusMetricsMiddleware(app: unknown): void;
   registerPrometheusMetricsRoute(app: unknown): void;
@@ -225,18 +229,65 @@ export async function startDevServer(
     ...createDefaultDevServerBootstrapDependencies(),
     ...dependencies
   };
+  const isProductionEnvironment = process.env.NODE_ENV?.trim().toLowerCase() === "production";
 
   const mysqlConfig = deps.readMySqlPersistenceConfig();
   let snapshotStore: DevServerMySqlSnapshotStore | null = null;
   let configCenterStore = deps.createFileSystemConfigCenterStore();
+  let persistenceHealth: RuntimePersistenceHealth = {
+    status: "degraded",
+    storage: "memory",
+    message: "In-memory room persistence active; room data will not survive process restarts."
+  };
+
+  const failStartup = async (message: string, error?: unknown): Promise<never> => {
+    deps.logger.error(message, error ?? new Error(message));
+    await configCenterStore.close().catch((closeError) => {
+      deps.logger.error("Failed to close config center store during startup abort", closeError);
+    });
+    deps.process.exit(1);
+    throw error instanceof Error ? error : new Error(message);
+  };
 
   if (mysqlConfig) {
-    const migrationStatus = await deps.getSchemaMigrationStatus(mysqlConfig);
-    if (migrationStatus.pending.length > 0) {
-      deps.logger.warn(deps.formatSchemaMigrationWarning(migrationStatus));
-    } else {
-      snapshotStore = await deps.createMySqlRoomSnapshotStore(mysqlConfig);
-      configCenterStore = await deps.createMySqlConfigCenterStore(mysqlConfig);
+    try {
+      const migrationStatus = await deps.getSchemaMigrationStatus(mysqlConfig);
+      if (migrationStatus.pending.length > 0) {
+        const warning = deps.formatSchemaMigrationWarning(migrationStatus);
+        if (isProductionEnvironment) {
+          await failStartup(
+            "Refusing to start with in-memory persistence in production while schema migrations are pending",
+            new Error(warning)
+          );
+        }
+        deps.logger.warn(warning);
+      } else {
+        const mysqlSnapshotStore = await deps.createMySqlRoomSnapshotStore(mysqlConfig);
+        try {
+          const mysqlConfigCenterStore = await deps.createMySqlConfigCenterStore(mysqlConfig);
+          snapshotStore = mysqlSnapshotStore;
+          configCenterStore = mysqlConfigCenterStore;
+          persistenceHealth = {
+            status: "ok",
+            storage: "mysql",
+            message: "MySQL room persistence active."
+          };
+        } catch (error) {
+          await mysqlSnapshotStore.close().catch((closeError) => {
+            deps.logger.error("Failed to close MySQL snapshot store after startup error", closeError);
+          });
+          throw error;
+        }
+      }
+    } catch (error) {
+      if (isProductionEnvironment) {
+        await failStartup("MySQL migration/bootstrap failed during production startup", error);
+      }
+      deps.logger.warn(
+        `MySQL migration/bootstrap failed; falling back to in-memory room persistence in non-production mode: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 
@@ -267,7 +318,10 @@ export async function startDevServer(
   deps.registerMinorProtectionPreviewRoutes(expressApp, effectiveSnapshotStore);
   deps.registerLeaderboardRoutes(expressApp, effectiveSnapshotStore);
   deps.registerSeasonRoutes(expressApp, effectiveSnapshotStore);
-  deps.registerRuntimeObservabilityRoutes(expressApp, { store: effectiveSnapshotStore });
+  deps.registerRuntimeObservabilityRoutes(expressApp, {
+    store: effectiveSnapshotStore,
+    persistence: persistenceHealth
+  });
   if ("get" in (expressApp as object)) {
     deps.registerRetentionSummaryRoute(expressApp, effectiveSnapshotStore);
   }
@@ -303,9 +357,10 @@ export async function startDevServer(
     deps.logger.log("Local in-memory Colyseus presence/driver enabled");
   }
   if (snapshotStore) {
-    deps.logger.log("MySQL room persistence enabled");
+    deps.logger.log("Persistence mode: production/mysql");
   } else {
-    deps.logger.log("Local in-memory room persistence enabled");
+    deps.logger.log("Persistence mode: degraded/in-memory");
+    deps.logger.log(persistenceHealth.message);
   }
 
   let cleanupTimer: CleanupTimerHandle | null = null;

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -171,13 +171,20 @@ interface RuntimeObservabilityState {
   };
 }
 
+export interface RuntimePersistenceHealth {
+  status: "ok" | "degraded";
+  storage: "memory" | "mysql";
+  message: string;
+}
+
 interface RuntimeHealthPayload {
-  status: "ok";
+  status: "ok" | "warn";
   service: string;
   checkedAt: string;
   startedAt: string;
   uptimeSeconds: number;
   runtime: {
+    persistence: RuntimePersistenceHealth;
     activeRoomCount: number;
     connectionCount: number;
     activeBattleCount: number;
@@ -468,7 +475,14 @@ function renderHistogramMetric(name: string, help: string, state: HistogramMetri
   return lines;
 }
 
-function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPayload {
+function buildHealthPayload(
+  service = "project-veil-server",
+  persistence: RuntimePersistenceHealth = {
+    status: "ok",
+    storage: "mysql",
+    message: "Persistent room storage available."
+  }
+): RuntimeHealthPayload {
   const roomSnapshots = Array.from(runtimeObservability.rooms.values());
   const activeRoomCount = roomSnapshots.length;
   const connectionCount = roomSnapshots.reduce((total, room) => total + room.connectedPlayers, 0);
@@ -485,12 +499,13 @@ function buildHealthPayload(service = "project-veil-server"): RuntimeHealthPaylo
   );
 
   return {
-    status: "ok",
+    status: persistence.status === "degraded" ? "warn" : "ok",
     service,
     checkedAt: new Date().toISOString(),
     startedAt: new Date(runtimeObservability.startedAt).toISOString(),
     uptimeSeconds: Number(((Date.now() - runtimeObservability.startedAt) / 1_000).toFixed(3)),
     runtime: {
+      persistence: { ...persistence },
       activeRoomCount,
       connectionCount,
       activeBattleCount,
@@ -1802,10 +1817,12 @@ export function registerRuntimeObservabilityRoutes(
   options?: {
     serviceName?: string;
     store?: { clearAll?: () => void };
+    persistence?: RuntimePersistenceHealth;
   }
 ): void {
   const serviceName = options?.serviceName ?? "project-veil-server";
   const store = options?.store;
+  const persistence = options?.persistence;
 
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
@@ -1823,7 +1840,8 @@ export function registerRuntimeObservabilityRoutes(
 
   app.get("/api/runtime/health", async (_request, response) => {
     try {
-      sendJson(response, 200, buildHealthPayload(serviceName));
+      const payload = buildHealthPayload(serviceName, persistence);
+      sendJson(response, payload.status === "ok" ? 200 : 503, payload);
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { listLobbyRooms } from "../src/colyseus-room";
 import { startDevServer, type DevServerBootstrapDependencies } from "../src/dev-server";
+import type { RuntimePersistenceHealth } from "../src/observability";
 import type { MySqlPersistenceConfig, SnapshotRetentionPolicy } from "../src/persistence";
 
 interface TestLogger {
@@ -182,6 +183,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
   let playerAccountStore: unknown;
   let matchmakingStore: unknown;
   let lobbyListRooms: unknown;
+  let persistenceHealth: RuntimePersistenceHealth | undefined;
 
   await startDevServer(3101, "0.0.0.0", {
     readMySqlPersistenceConfig: () => null,
@@ -264,8 +266,9 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
       assert.equal(app, base.expressApp);
       base.routeCalls.push("seasons");
     },
-    registerRuntimeObservabilityRoutes: (app) => {
+    registerRuntimeObservabilityRoutes: (app, options) => {
       assert.equal(app, base.expressApp);
+      persistenceHealth = options?.persistence;
       base.routeCalls.push("runtime-observability");
     },
     registerAdminRoutes: (app, store, gameServer) => {
@@ -320,6 +323,11 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
   assert.equal(configCenterStore.initializeCalls, 1);
   assert.equal(base.logger.warnings.length, 0);
   assert.equal(base.logger.errors.length, 0);
+  assert.deepEqual(persistenceHealth, {
+    status: "degraded",
+    storage: "memory",
+    message: "In-memory room persistence active; room data will not survive process restarts."
+  });
   assertStartupLogIncludes(base.logger, [
     /Project Veil Colyseus dev server listening on ws:\/\/0\.0\.0\.0:3101/,
     /Guild API available at http:\/\/0\.0\.0\.0:3101\/api\/guilds/,
@@ -331,7 +339,8 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
     /Runtime metrics available at http:\/\/0\.0\.0\.0:3101\/api\/runtime\/metrics/,
     /Config center storage: filesystem/,
     /Local in-memory Colyseus presence\/driver enabled/,
-    /Local in-memory room persistence enabled/
+    /Persistence mode: degraded\/in-memory/,
+    /In-memory room persistence active; room data will not survive process restarts\./
   ]);
   assert.ok(base.process.handlers.SIGINT);
   assert.ok(base.process.handlers.SIGTERM);
@@ -498,6 +507,7 @@ test("dev server falls back to in-memory persistence and warns when schema migra
   };
   let mysqlStoreCreated = false;
   let mysqlConfigStoreCreated = false;
+  let persistenceHealth: RuntimePersistenceHealth | undefined;
 
   await startDevServer(3202, "127.0.0.1", {
     readMySqlPersistenceConfig: () => mysqlConfig,
@@ -536,7 +546,9 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     registerPrometheusMetricsRoute: () => undefined,
     registerLeaderboardRoutes: () => undefined,
     registerSeasonRoutes: () => undefined,
-    registerRuntimeObservabilityRoutes: () => undefined,
+    registerRuntimeObservabilityRoutes: (_app, options) => {
+      persistenceHealth = options?.persistence;
+    },
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
       base.gameServer.realtimeOptions.push(realtimeOptions);
@@ -556,6 +568,11 @@ test("dev server falls back to in-memory persistence and warns when schema migra
   assert.equal(configCenterStore.initializeCalls, 1);
   assert.deepEqual(base.logger.warnings, ["pending migration warning"]);
   assert.equal(base.logger.errors.length, 0);
+  assert.deepEqual(persistenceHealth, {
+    status: "degraded",
+    storage: "memory",
+    message: "In-memory room persistence active; room data will not survive process restarts."
+  });
   assertStartupLogIncludes(base.logger, [
     /Runtime health available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/auth-readiness/,
@@ -564,8 +581,101 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     /Runtime metrics available at http:\/\/127\.0\.0\.1:3202\/api\/runtime\/metrics/,
     /Config center storage: filesystem/,
     /Local in-memory Colyseus presence\/driver enabled/,
-    /Local in-memory room persistence enabled/
+    /Persistence mode: degraded\/in-memory/,
+    /In-memory room persistence active; room data will not survive process restarts\./
   ]);
+});
+
+test("dev server exits non-zero in production when MySQL bootstrap fails instead of falling back to memory", async () => {
+  const base = createBaseDependencies();
+  const configCenterStore = createConfigCenterStore("filesystem");
+  const mysqlConfig: MySqlPersistenceConfig = {
+    host: "127.0.0.1",
+    port: 3306,
+    user: "veil",
+    password: "veil",
+    database: "project_veil",
+    pool: {
+      connectionLimit: 4,
+      maxIdle: 4,
+      idleTimeoutMs: 60_000,
+      queueLimit: 0,
+      waitForConnections: true
+    },
+    retention: {
+      ttlHours: 24,
+      cleanupIntervalMinutes: 30
+    }
+  };
+  const originalNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+  let memoryStoreCreated = false;
+
+  try {
+    await assert.rejects(
+      startDevServer(3203, "127.0.0.1", {
+        readMySqlPersistenceConfig: () => mysqlConfig,
+        getSchemaMigrationStatus: async () => ({ pending: [] }),
+        createFileSystemConfigCenterStore: () => configCenterStore,
+        createMySqlRoomSnapshotStore: async () => {
+          throw new Error("connect ETIMEDOUT");
+        },
+        createMemoryRoomSnapshotStore: () => {
+          memoryStoreCreated = true;
+          return createMemoryStore();
+        },
+        configureRoomSnapshotStore: () => undefined,
+        createTransport: () => base.transport,
+        readRedisUrl: () => null,
+        createRedisPresence: () => {
+          throw new Error("createRedisPresence should not be used without REDIS_URL");
+        },
+        createRedisDriver: () => {
+          throw new Error("createRedisDriver should not be used without REDIS_URL");
+        },
+        registerAuthRoutes: () => undefined,
+        registerConfigCenterRoutes: () => undefined,
+        registerConfigViewerRoutes: () => undefined,
+        registerGuildRoutes: () => undefined,
+        registerPlayerAccountRoutes: () => undefined,
+        registerShopRoutes: () => undefined,
+        registerWechatPayRoutes: () => undefined,
+        registerLobbyRoutes: () => undefined,
+        registerMatchmakingRoutes: () => undefined,
+        registerMinorProtectionPreviewRoutes: () => undefined,
+        registerPrometheusMetricsMiddleware: () => undefined,
+        registerPrometheusMetricsRoute: () => undefined,
+        registerLeaderboardRoutes: () => undefined,
+        registerSeasonRoutes: () => undefined,
+        registerRuntimeObservabilityRoutes: () => undefined,
+        registerAdminRoutes: () => undefined,
+        createGameServer: () => base.gameServer,
+        logger: base.logger,
+        process: base.process,
+        setInterval: () => {
+          throw new Error("setInterval should not be used when startup fails");
+        },
+        clearInterval: () => undefined,
+        isMySqlSnapshotStore: () => false
+      }),
+      /connect ETIMEDOUT/
+    );
+  } finally {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  }
+
+  assert.equal(memoryStoreCreated, false);
+  assert.equal(configCenterStore.initializeCalls, 0);
+  assert.equal(configCenterStore.closeCalls, 1);
+  assert.deepEqual(base.gameServer.listenCalls, []);
+  assert.deepEqual(base.process.exitCodes, [1]);
+  assert.equal(base.logger.warnings.length, 0);
+  assert.equal(base.logger.errors.length, 1);
+  assert.equal(base.logger.errors[0]?.message, "MySQL migration/bootstrap failed during production startup");
 });
 
 test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL is set", async () => {
@@ -670,6 +780,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
   const scheduledTimers: TestTimer[] = [];
   const clearedTimers: TestTimer[] = [];
   let memoryStoreCreated = false;
+  let persistenceHealth: RuntimePersistenceHealth | undefined;
 
   await startDevServer(3303, "127.0.0.2", {
     readMySqlPersistenceConfig: () => mysqlConfig,
@@ -706,7 +817,9 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     registerPrometheusMetricsRoute: () => undefined,
     registerLeaderboardRoutes: () => undefined,
     registerSeasonRoutes: () => undefined,
-    registerRuntimeObservabilityRoutes: () => undefined,
+    registerRuntimeObservabilityRoutes: (_app, options) => {
+      persistenceHealth = options?.persistence;
+    },
     registerAdminRoutes: () => undefined,
     createGameServer: (_transport, realtimeOptions) => {
       base.gameServer.realtimeOptions.push(realtimeOptions);
@@ -736,6 +849,11 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
   assert.equal(configCenterStore.initializeCalls, 1);
   assert.equal(mysqlStore.pruneCalls, 1);
   assert.equal(base.logger.warnings.length, 0);
+  assert.deepEqual(persistenceHealth, {
+    status: "ok",
+    storage: "mysql",
+    message: "MySQL room persistence active."
+  });
   assertStartupLogIncludes(base.logger, [
     /Runtime health available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/health/,
     /Auth readiness available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/auth-readiness/,
@@ -744,7 +862,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     /Runtime metrics available at http:\/\/127\.0\.0\.2:3303\/api\/runtime\/metrics/,
     /Config center storage: mysql/,
     /Local in-memory Colyseus presence\/driver enabled/,
-    /MySQL room persistence enabled/,
+    /Persistence mode: production\/mysql/,
     /Snapshot retention: ttl=48h \/ cleanup=15m/,
     /Pruned 2 expired room snapshot\(s\)/
   ]);

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -10,6 +10,7 @@ import {
   recordRuntimeErrorEvent,
   recordMatchmakingRateLimited,
   registerRuntimeObservabilityRoutes,
+  type RuntimePersistenceHealth,
   resetRuntimeObservability
 } from "../src/observability";
 
@@ -17,7 +18,7 @@ async function wait(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function startObservabilityServer(port: number): Promise<Server> {
+async function startObservabilityServer(port: number, persistence?: RuntimePersistenceHealth): Promise<Server> {
   configureRoomSnapshotStore(null);
   resetLobbyRoomRegistry();
   resetAccountTokenDeliveryState();
@@ -27,12 +28,44 @@ async function startObservabilityServer(port: number): Promise<Server> {
   const app = transport.getExpressApp() as never;
   registerPrometheusMetricsMiddleware(app);
   registerPrometheusMetricsRoute(app);
-  registerRuntimeObservabilityRoutes(app);
+  registerRuntimeObservabilityRoutes(app, persistence ? { persistence } : undefined);
   const server = new Server({ transport });
   server.define("veil", VeilColyseusRoom).filterBy(["logicalRoomId"]);
   await server.listen(port, "127.0.0.1");
   return server;
 }
+
+test("runtime health returns 503 when persistence is degraded to memory mode", async (t) => {
+  const port = 45000 + Math.floor(Math.random() * 1000);
+  const server = await startObservabilityServer(port, {
+    status: "degraded",
+    storage: "memory",
+    message: "In-memory room persistence active; room data will not survive process restarts."
+  });
+
+  t.after(async () => {
+    resetLobbyRoomRegistry();
+    resetRuntimeObservability();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const healthResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/health`);
+  const healthPayload = (await healthResponse.json()) as {
+    status: string;
+    runtime: {
+      persistence: {
+        status: string;
+        storage: string;
+        message: string;
+      };
+    };
+  };
+
+  assert.equal(healthResponse.status, 503);
+  assert.equal(healthPayload.status, "warn");
+  assert.equal(healthPayload.runtime.persistence.status, "degraded");
+  assert.equal(healthPayload.runtime.persistence.storage, "memory");
+});
 
 async function joinRoom(port: number, logicalRoomId: string, playerId: string): Promise<ColyseusRoom> {
   const client = new Client(`http://127.0.0.1:${port}`);

--- a/docs/db-restore-runbook.md
+++ b/docs/db-restore-runbook.md
@@ -158,6 +158,15 @@ Validation is complete when:
 - Record the restored backup timestamp, object key, and validation output in the incident log.
 - Only repoint application traffic after the restored instance has passed the regression above.
 
+## Migration Failure Handling
+
+If a production rollout fails during DB migration/bootstrap, the server must not stay up in in-memory mode.
+
+- Treat startup failure plus a non-zero exit code as the expected safeguard, not as a transient warning to ignore.
+- Confirm `/api/runtime/health` is not reporting a degraded in-memory persistence status before reopening traffic.
+- Fix MySQL reachability or apply the missing migration, then restart the service and recheck health.
+- If the release window is at risk, roll back to the previous good build and continue recovery from a controlled host.
+
 ## Estimated RTO
 
 Estimated RTO for a routine restore:


### PR DESCRIPTION
## Summary
- fail server startup in production when MySQL migration/bootstrap cannot complete instead of silently falling back to in-memory persistence
- report degraded in-memory persistence through `/api/runtime/health` as HTTP 503 and expose persistence mode in the health payload
- add targeted regression coverage for production startup failure and degraded health behavior, and document the ops response in the DB restore runbook

## Root Cause
The dev server boot path treated any unsuccessful MySQL startup path as an implicit in-memory mode, which allowed the service to keep serving traffic even when persistent storage was unavailable.

## Validation
- `node --import tsx --test ./apps/server/test/dev-server.test.ts`
- `node --import tsx --test ./apps/server/test/runtime-observability-routes.test.ts`
- `npm run typecheck:server`

Closes #1231