### PR TITLE
[codex] 游戏资源加载容错：CDN 故障时占位图与重试机制

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -177,6 +177,11 @@ import {
   type CocosBattlePresentationState
 } from "./cocos-battle-presentation-controller.ts";
 import { createCocosAudioRuntime } from "./cocos-audio-runtime.ts";
+import {
+  setAssetLoadFailureReporter,
+  subscribeAssetLoadFailures,
+  type AssetLoadFailureEvent
+} from "./cocos-asset-load-resilience.ts";
 import { createCocosAudioAssetBridge } from "./cocos-audio-resources.ts";
 import {
   applySettingsUpdate,
@@ -489,6 +494,7 @@ export class VeilRoot extends Component {
   private emittedExperimentExposureKeys = new Set<string>();
   private emittedShopOpenSessionId: string | null = null;
   private stopRuntimeMemoryWarnings: (() => void) | null = null;
+  private stopAssetLoadFailureSubscription: (() => void) | null = null;
   private battlePresentation = createCocosBattlePresentationController();
   private lastBattleSettlementSnapshot: BattleSettlementSnapshot | null = null;
   private reportDialogOpen = false;
@@ -499,9 +505,17 @@ export class VeilRoot extends Component {
   private surrenderStatusMessage: string | null = null;
   private launchReferrerId: string | null = null;
   private lastReferralClaimKey: string | null = null;
+  private lastAssetFailureNoticeKey: string | null = null;
 
   onLoad(): void {
     this.audioRuntime.dispose();
+    this.stopAssetLoadFailureSubscription?.();
+    setAssetLoadFailureReporter((event) => {
+      this.trackAssetLoadFailureAnalytics(event);
+    });
+    this.stopAssetLoadFailureSubscription = subscribeAssetLoadFailures((event) => {
+      this.handleAssetLoadFailure(event);
+    });
     this.audioRuntime = createCocosAudioRuntime(cocosPresentationConfig.audio, {
       assetBridge: createCocosAudioAssetBridge(this.node),
       onStateChange: () => {
@@ -538,6 +552,9 @@ export class VeilRoot extends Component {
     this.unscheduleAllCallbacks();
     this.stopMatchmakingPolling();
     this.audioRuntime.dispose();
+    this.stopAssetLoadFailureSubscription?.();
+    this.stopAssetLoadFailureSubscription = null;
+    setAssetLoadFailureReporter(null);
     this.stopRuntimeMemoryWarnings?.();
     this.stopRuntimeMemoryWarnings = null;
     if (this.hudActionBinding) {
@@ -3468,12 +3485,45 @@ export class VeilRoot extends Component {
     | "experiment_exposure"
     | "shop_open"
     | "purchase_initiated"
+    | "asset_load_failed"
   >(
     name: Name,
     payload: Record<string, unknown>,
     roomId = this.roomId
   ): void {
     emitClientAnalyticsEvent(name, this.createClientAnalyticsContext(roomId), payload as never);
+  }
+
+  private trackAssetLoadFailureAnalytics(event: AssetLoadFailureEvent): void {
+    this.trackClientAnalyticsEvent("asset_load_failed", {
+      assetType: event.assetType,
+      assetPath: event.assetPath,
+      retryCount: event.retryCount,
+      critical: event.critical,
+      finalFailure: event.finalFailure,
+      errorMessage: event.errorMessage
+    });
+  }
+
+  private handleAssetLoadFailure(event: AssetLoadFailureEvent): void {
+    if (!event.finalFailure || !event.critical) {
+      return;
+    }
+
+    const noticeKey = `${event.assetType}:${event.assetPath}`;
+    if (this.lastAssetFailureNoticeKey === noticeKey) {
+      return;
+    }
+
+    this.lastAssetFailureNoticeKey = noticeKey;
+    this.achievementNotice = {
+      eventId: noticeKey,
+      title: "资源加载异常",
+      detail: "部分资源加载失败，建议重新进入游戏",
+      expiresAt: Date.now() + 6000
+    };
+    this.pushLog(`资源加载失败：${event.assetPath}（已重试 ${event.retryCount} 次）`);
+    this.renderView();
   }
 
   private createTelemetryContext(heroId?: string | null): { roomId: string; playerId: string; heroId?: string } {

--- a/apps/cocos-client/assets/scripts/cocos-asset-load-resilience.ts
+++ b/apps/cocos-client/assets/scripts/cocos-asset-load-resilience.ts
@@ -1,0 +1,104 @@
+export interface AssetLoadFailureEvent {
+  assetType: "sprite" | "audio";
+  assetPath: string;
+  retryCount: number;
+  maxRetryCount: number;
+  critical: boolean;
+  finalFailure: boolean;
+  errorMessage: string;
+}
+
+interface AssetLoadResilienceRuntimeDependencies {
+  setTimeout(handler: () => void, delayMs: number): ReturnType<typeof globalThis.setTimeout>;
+  clearTimeout(handle: ReturnType<typeof globalThis.setTimeout>): void;
+}
+
+interface RetryAssetLoadOptions<T> {
+  assetType: AssetLoadFailureEvent["assetType"];
+  assetPath: string;
+  critical: boolean;
+  load: () => Promise<T>;
+  fallback?: (() => Promise<T | null>) | undefined;
+}
+
+const RETRY_DELAYS_MS = [1000, 2000, 4000] as const;
+
+const defaultRuntimeDependencies: AssetLoadResilienceRuntimeDependencies = {
+  setTimeout: (handler, delayMs) => globalThis.setTimeout(handler, delayMs),
+  clearTimeout: (handle) => globalThis.clearTimeout(handle)
+};
+
+let runtimeDependencies = defaultRuntimeDependencies;
+let failureReporter: ((event: AssetLoadFailureEvent) => void) | null = null;
+const failureListeners = new Set<(event: AssetLoadFailureEvent) => void>();
+
+export function configureAssetLoadResilienceRuntimeDependencies(
+  overrides: Partial<AssetLoadResilienceRuntimeDependencies>
+): void {
+  runtimeDependencies = {
+    ...runtimeDependencies,
+    ...overrides
+  };
+}
+
+export function setAssetLoadFailureReporter(
+  reporter: ((event: AssetLoadFailureEvent) => void) | null
+): void {
+  failureReporter = reporter;
+}
+
+export function subscribeAssetLoadFailures(
+  listener: (event: AssetLoadFailureEvent) => void
+): () => void {
+  failureListeners.add(listener);
+  return () => {
+    failureListeners.delete(listener);
+  };
+}
+
+export function resetAssetLoadResilienceRuntimeForTests(): void {
+  runtimeDependencies = defaultRuntimeDependencies;
+  failureReporter = null;
+  failureListeners.clear();
+}
+
+export async function retryAssetLoad<T>(options: RetryAssetLoadOptions<T>): Promise<T | null> {
+  const maxRetryCount = options.critical ? RETRY_DELAYS_MS.length : 0;
+
+  for (let retryCount = 0; retryCount <= maxRetryCount; retryCount += 1) {
+    try {
+      return await options.load();
+    } catch (error) {
+      const event: AssetLoadFailureEvent = {
+        assetType: options.assetType,
+        assetPath: options.assetPath,
+        retryCount,
+        maxRetryCount,
+        critical: options.critical,
+        finalFailure: retryCount >= maxRetryCount,
+        errorMessage: error instanceof Error ? error.message : String(error)
+      };
+      failureReporter?.(event);
+      for (const listener of failureListeners) {
+        listener(event);
+      }
+
+      if (retryCount >= maxRetryCount) {
+        return options.fallback ? await options.fallback() : null;
+      }
+
+      const retryDelayMs = RETRY_DELAYS_MS[retryCount] ?? 4000;
+      await waitFor(retryDelayMs);
+    }
+  }
+
+  return options.fallback ? await options.fallback() : null;
+}
+
+function waitFor(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    runtimeDependencies.setTimeout(() => {
+      resolve();
+    }, delayMs);
+  });
+}

--- a/apps/cocos-client/assets/scripts/cocos-audio-resources.ts
+++ b/apps/cocos-client/assets/scripts/cocos-audio-resources.ts
@@ -1,4 +1,5 @@
 import { AudioClip, AudioSource, Node, resources } from "cc";
+import { retryAssetLoad } from "./cocos-asset-load-resilience.ts";
 import type { CocosAudioAssetBridge, CocosAudioAssetClip } from "./cocos-audio-runtime.ts";
 
 const MUSIC_NODE_NAME = "ProjectVeilMusicAudio";
@@ -21,18 +22,29 @@ export function createCocosAudioAssetBridge(hostNode: Node): CocosAudioAssetBrid
         return cached;
       }
 
-      const promise = new Promise<CocosManagedAudioClip>((resolve, reject) => {
-        resources.load(path, AudioClip, (err, clip) => {
-          if (err || !clip) {
-            reject(err ?? new Error(`Failed to load audio clip: ${path}`));
-            return;
-          }
+      const promise = retryAssetLoad({
+        assetType: "audio",
+        assetPath: path,
+        critical: path === "audio/explore-loop" || path === "audio/battle-loop",
+        load: () =>
+          new Promise<CocosManagedAudioClip>((resolve, reject) => {
+            resources.load(path, AudioClip, (err, clip) => {
+              if (err || !clip) {
+                reject(err ?? new Error(`Failed to load audio clip: ${path}`));
+                return;
+              }
 
-          resolve({
-            path,
-            clip
-          });
-        });
+              resolve({
+                path,
+                clip
+              });
+            });
+          })
+      }).then((clip) => {
+        if (!clip) {
+          throw new Error(`Failed to load audio clip: ${path}`);
+        }
+        return clip;
       });
 
       clipCache.set(path, promise);

--- a/apps/cocos-client/assets/scripts/cocos-pixel-sprites.ts
+++ b/apps/cocos-client/assets/scripts/cocos-pixel-sprites.ts
@@ -1,4 +1,6 @@
 import { ImageAsset, SpriteFrame, resources } from "cc";
+import { retryAssetLoad } from "./cocos-asset-load-resilience.ts";
+import { getPlaceholderSpriteAssets, loadPlaceholderSpriteAssets } from "./cocos-placeholder-sprites.ts";
 import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
 import {
   pixelSpriteManifest,
@@ -295,24 +297,153 @@ function loadSpriteFrame(path: string): Promise<SpriteFrame | null> {
     return inflight;
   }
 
-  const promise = new Promise<SpriteFrame | null>((resolve) => {
-    resources.load(path, ImageAsset, (err, asset) => {
-      if (err) {
-        loadedFrames.set(path, null);
-        inflightFrameLoads.delete(path);
-        syncLoadStatusCollections();
-        resolve(null);
-        return;
-      }
+  const promise = retryAssetLoad({
+    assetType: "sprite",
+    assetPath: path,
+    critical: isCriticalPixelSpritePath(path),
+    load: () =>
+      new Promise<SpriteFrame>((resolve, reject) => {
+        resources.load(path, ImageAsset, (err, asset) => {
+          if (err) {
+            reject(err);
+            return;
+          }
 
-      const frame = SpriteFrame.createWithImage(asset);
-      loadedFrames.set(path, frame);
-      inflightFrameLoads.delete(path);
-      syncLoadStatusCollections();
-      resolve(frame);
-    });
+          resolve(SpriteFrame.createWithImage(asset));
+        });
+      }),
+    fallback: () => resolveFallbackSpriteFrame(path)
+  }).then((frame) => {
+    loadedFrames.set(path, frame);
+    inflightFrameLoads.delete(path);
+    syncLoadStatusCollections();
+    return frame;
   });
 
   inflightFrameLoads.set(path, promise);
   return promise;
+}
+
+function isCriticalPixelSpritePath(path: string): boolean {
+  return (
+    Object.values(pixelSpriteManifest.tiles).some((variants) => variants.includes(path))
+    || Object.values(pixelSpriteManifest.heroes).includes(path)
+  );
+}
+
+async function resolveFallbackSpriteFrame(path: string): Promise<SpriteFrame | null> {
+  const scope = resolveFallbackScope(path);
+  const assets = getPlaceholderSpriteAssets() ?? (await loadPlaceholderSpriteAssets(scope));
+  return mapPlaceholderFrame(path, assets);
+}
+
+function resolveFallbackScope(path: string): "map" | "hud" | "timeline" {
+  if (path === pixelSpriteManifest.icons.timeline) {
+    return "timeline";
+  }
+
+  if (
+    Object.values(pixelSpriteManifest.tiles).some((variants) => variants.includes(path))
+    || Object.values(pixelSpriteManifest.showcaseTerrain).includes(path)
+    || path === pixelSpriteManifest.icons.wood
+    || path === pixelSpriteManifest.icons.gold
+    || path === pixelSpriteManifest.icons.ore
+    || path === pixelSpriteManifest.icons.neutral
+    || path === pixelSpriteManifest.icons.recruitment
+    || path === pixelSpriteManifest.icons.shrine
+    || path === pixelSpriteManifest.icons.mine
+  ) {
+    return "map";
+  }
+
+  return "hud";
+}
+
+function mapPlaceholderFrame(
+  path: string,
+  assets: NonNullable<ReturnType<typeof getPlaceholderSpriteAssets>>
+): SpriteFrame | null {
+  const terrainEntry = (
+    Object.entries(pixelSpriteManifest.tiles) as Array<[keyof PixelTileSprites, string[]]>
+  ).find(([, variants]) => variants.includes(path));
+  if (terrainEntry) {
+    const [kind, variants] = terrainEntry;
+    const fallbackFrames = assets.tiles[kind];
+    const variantIndex = Math.max(0, variants.indexOf(path));
+    return fallbackFrames[variantIndex % fallbackFrames.length] ?? fallbackFrames[0] ?? null;
+  }
+
+  if (path === pixelSpriteManifest.icons.wood) {
+    return assets.icons.wood;
+  }
+  if (path === pixelSpriteManifest.icons.gold) {
+    return assets.icons.gold;
+  }
+  if (path === pixelSpriteManifest.icons.ore) {
+    return assets.icons.ore;
+  }
+  if (path === pixelSpriteManifest.icons.neutral) {
+    return assets.icons.neutral;
+  }
+  if (path === pixelSpriteManifest.icons.hero) {
+    return assets.icons.hero;
+  }
+  if (path === pixelSpriteManifest.icons.recruitment) {
+    return assets.icons.recruitment;
+  }
+  if (path === pixelSpriteManifest.icons.shrine) {
+    return assets.icons.shrine;
+  }
+  if (path === pixelSpriteManifest.icons.mine || path === pixelSpriteManifest.icons.tower) {
+    return assets.icons.mine;
+  }
+  if (path === pixelSpriteManifest.icons.hud || path === pixelSpriteManifest.icons.battle) {
+    return assets.icons.hud;
+  }
+  if (path === pixelSpriteManifest.icons.timeline) {
+    return assets.icons.timeline;
+  }
+
+  if (Object.values(pixelSpriteManifest.heroes).includes(path)) {
+    return assets.icons.hero;
+  }
+
+  if (
+    Object.values(pixelSpriteManifest.units).some((unit) =>
+      [unit.idle, unit.selected, unit.hit, unit.frame].includes(path)
+    )
+    || Object.values(pixelSpriteManifest.showcaseUnits).some((unit) =>
+      [unit.idle, unit.selected, unit.hit, unit.frame].includes(path)
+    )
+  ) {
+    return assets.icons.hero;
+  }
+
+  const showcaseTerrainId = Object.entries(pixelSpriteManifest.showcaseTerrain).find(([, assetPath]) => assetPath === path)?.[0];
+  if (showcaseTerrainId && showcaseTerrainId in assets.tiles) {
+    return assets.tiles[showcaseTerrainId as keyof PixelTileSprites][0] ?? assets.tiles.unknown[0] ?? null;
+  }
+
+  const showcaseBuildingId = Object.entries(pixelSpriteManifest.showcaseBuildings).find(([, assetPath]) => assetPath === path)?.[0] ?? "";
+  if (showcaseBuildingId.includes("mine") || showcaseBuildingId.includes("tower")) {
+    return assets.icons.mine;
+  }
+  if (showcaseBuildingId.includes("shrine")) {
+    return assets.icons.shrine;
+  }
+  if (showcaseBuildingId.length > 0) {
+    return assets.icons.recruitment;
+  }
+
+  if (Object.values(pixelSpriteManifest.badges.factions).includes(path)) {
+    return assets.icons.hero;
+  }
+  if (Object.values(pixelSpriteManifest.badges.rarities).includes(path)) {
+    return assets.icons.gold;
+  }
+  if (Object.values(pixelSpriteManifest.badges.interactions).includes(path)) {
+    return assets.icons.neutral;
+  }
+
+  return assets.icons.hero ?? assets.icons.hud ?? null;
 }

--- a/apps/cocos-client/test/cocos-asset-load-resilience.test.ts
+++ b/apps/cocos-client/test/cocos-asset-load-resilience.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test, { afterEach } from "node:test";
+import {
+  configureAssetLoadResilienceRuntimeDependencies,
+  resetAssetLoadResilienceRuntimeForTests,
+  retryAssetLoad,
+  setAssetLoadFailureReporter,
+  subscribeAssetLoadFailures
+} from "../assets/scripts/cocos-asset-load-resilience.ts";
+
+afterEach(() => {
+  resetAssetLoadResilienceRuntimeForTests();
+});
+
+test("retryAssetLoad retries critical assets with exponential backoff and reports the final failure", async () => {
+  const events: Array<{ retryCount: number; finalFailure: boolean; path: string }> = [];
+  const delays: number[] = [];
+  configureAssetLoadResilienceRuntimeDependencies({
+    setTimeout: (handler, delayMs) => {
+      delays.push(delayMs);
+      handler();
+      return { delayMs } as ReturnType<typeof globalThis.setTimeout>;
+    },
+    clearTimeout: () => {}
+  });
+  const unsubscribe = subscribeAssetLoadFailures((event) => {
+    events.push({
+      retryCount: event.retryCount,
+      finalFailure: event.finalFailure,
+      path: event.assetPath
+    });
+  });
+
+  let attempts = 0;
+  const result = await retryAssetLoad({
+    assetType: "sprite",
+    assetPath: "pixel/terrain/grass-1",
+    critical: true,
+    load: async () => {
+      attempts += 1;
+      throw new Error(`missing-${attempts}`);
+    },
+    fallback: async () => "placeholder-frame"
+  });
+  unsubscribe();
+
+  assert.equal(result, "placeholder-frame");
+  assert.equal(attempts, 4);
+  assert.deepEqual(delays, [1000, 2000, 4000]);
+  assert.deepEqual(events, [
+    { retryCount: 0, finalFailure: false, path: "pixel/terrain/grass-1" },
+    { retryCount: 1, finalFailure: false, path: "pixel/terrain/grass-1" },
+    { retryCount: 2, finalFailure: false, path: "pixel/terrain/grass-1" },
+    { retryCount: 3, finalFailure: true, path: "pixel/terrain/grass-1" }
+  ]);
+});
+
+test("retryAssetLoad reports non-critical failures once without scheduling retries", async () => {
+  const reported: Array<{ retryCount: number; finalFailure: boolean }> = [];
+  setAssetLoadFailureReporter((event) => {
+    reported.push({
+      retryCount: event.retryCount,
+      finalFailure: event.finalFailure
+    });
+  });
+
+  let attempts = 0;
+  const result = await retryAssetLoad({
+    assetType: "audio",
+    assetPath: "audio/hit",
+    critical: false,
+    load: async () => {
+      attempts += 1;
+      throw new Error("asset missing");
+    }
+  });
+
+  assert.equal(result, null);
+  assert.equal(attempts, 1);
+  assert.deepEqual(reported, [{ retryCount: 0, finalFailure: true }]);
+});

--- a/apps/cocos-client/test/cocos-audio-resources.test.ts
+++ b/apps/cocos-client/test/cocos-audio-resources.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { AudioClip, AudioSource, Node, resources } from "cc";
+import {
+  configureAssetLoadResilienceRuntimeDependencies,
+  resetAssetLoadResilienceRuntimeForTests
+} from "../assets/scripts/cocos-asset-load-resilience.ts";
 import { createCocosAudioAssetBridge } from "../assets/scripts/cocos-audio-resources";
 
 function getAudioSource(hostNode: Node, name: string): AudioSource {
@@ -64,7 +68,7 @@ test("audio asset bridge surfaces resource load failures", async () => {
       callback(new Error("asset missing"), null);
     }) as typeof resources.load;
 
-    await assert.rejects(bridge.loadClip("audio/missing"), /asset missing/);
+    await assert.rejects(bridge.loadClip("audio/missing"), /Failed to load audio clip: audio\/missing/);
 
     resources.load = ((_path, _Type, callback) => {
       callback(null, null);
@@ -73,6 +77,38 @@ test("audio asset bridge surfaces resource load failures", async () => {
     await assert.rejects(bridge.loadClip("audio/empty"), /Failed to load audio clip: audio\/empty/);
   } finally {
     resources.load = originalLoad;
+    resetAssetLoadResilienceRuntimeForTests();
+  }
+});
+
+test("audio asset bridge retries critical loop assets before rejecting", async () => {
+  const hostNode = new Node("Host");
+  const bridge = createCocosAudioAssetBridge(hostNode);
+  const originalLoad = resources.load;
+  const retryDelays: number[] = [];
+  let attempts = 0;
+
+  configureAssetLoadResilienceRuntimeDependencies({
+    setTimeout: (handler, delayMs) => {
+      retryDelays.push(delayMs);
+      handler();
+      return { delayMs } as ReturnType<typeof globalThis.setTimeout>;
+    },
+    clearTimeout: () => {}
+  });
+
+  try {
+    resources.load = ((_path, _Type, callback) => {
+      attempts += 1;
+      callback(new Error(`asset missing ${attempts}`), null);
+    }) as typeof resources.load;
+
+    await assert.rejects(bridge.loadClip("audio/explore-loop"), /Failed to load audio clip: audio\/explore-loop/);
+    assert.equal(attempts, 4);
+    assert.deepEqual(retryDelays, [1000, 2000, 4000]);
+  } finally {
+    resources.load = originalLoad;
+    resetAssetLoadResilienceRuntimeForTests();
   }
 });
 

--- a/apps/cocos-client/test/cocos-pixel-sprites.test.ts
+++ b/apps/cocos-client/test/cocos-pixel-sprites.test.ts
@@ -2,6 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { ImageAsset, SpriteFrame, resources } from "cc";
 import {
+  configureAssetLoadResilienceRuntimeDependencies,
+  resetAssetLoadResilienceRuntimeForTests
+} from "../assets/scripts/cocos-asset-load-resilience.ts";
+import { resetPlaceholderSpriteAssetsForTests } from "../assets/scripts/cocos-placeholder-sprites.ts";
+import {
   getPixelSpriteAssets,
   getPixelSpriteLoadStatus,
   loadPixelSpriteAssets,
@@ -29,6 +34,8 @@ function installFrameFactoryDouble(): void {
 function restoreCcDoubles(): void {
   resources.load = originalLoad;
   SpriteFrame.createWithImage = originalCreateWithImage;
+  resetAssetLoadResilienceRuntimeForTests();
+  resetPlaceholderSpriteAssetsForTests();
   resetPixelSpriteRuntimeForTests();
 }
 
@@ -104,7 +111,7 @@ test("loadPixelSpriteAssets reuses inflight and cached boot loads", async (t) =>
   assert.equal(loadCallCount, bootPaths.length);
 });
 
-test("loadPixelSpriteAssets caches failed loads as null fallbacks", async (t) => {
+test("loadPixelSpriteAssets replaces failed non-critical sprites with placeholder frames", async (t) => {
   const failedPath = pixelSpriteManifest.icons.hud;
   let loadCallCount = 0;
   resources.load = ((path: string, _type: typeof ImageAsset, callback: PendingLoad["callback"]) => {
@@ -124,13 +131,47 @@ test("loadPixelSpriteAssets caches failed loads as null fallbacks", async (t) =>
   const bootPaths = resolvePixelSpritePreloadPaths("boot");
 
   const firstAssets = await loadPixelSpriteAssets("boot");
-  assert.equal(firstAssets.icons.hud, null);
-  assert.equal(getPixelSpriteAssets()?.icons.hud, null);
+  assert.equal(firstAssets.icons.hud?.name, "placeholder/icons/hud");
+  assert.equal(getPixelSpriteAssets()?.icons.hud?.name, "placeholder/icons/hud");
 
   const readyStatus = getPixelSpriteLoadStatus();
   assert.equal(readyStatus.phase, "ready");
   assert.equal(readyStatus.loadedResourceCount, bootPaths.length);
 
   await loadPixelSpriteAssets("boot");
-  assert.equal(loadCallCount, bootPaths.length);
+  assert.equal(loadCallCount, bootPaths.length + 2);
+});
+
+test("loadPixelSpriteAssets retries critical sprite loads before falling back to placeholders", async (t) => {
+  const failedPath = pixelSpriteManifest.tiles.grass[0]!;
+  const attempts = new Map<string, number>();
+  const retryDelays: number[] = [];
+  configureAssetLoadResilienceRuntimeDependencies({
+    setTimeout: (handler, delayMs) => {
+      retryDelays.push(delayMs);
+      handler();
+      return { delayMs } as ReturnType<typeof globalThis.setTimeout>;
+    },
+    clearTimeout: () => {}
+  });
+  resources.load = ((path: string, _type: typeof ImageAsset, callback: PendingLoad["callback"]) => {
+    const nextAttempt = (attempts.get(path) ?? 0) + 1;
+    attempts.set(path, nextAttempt);
+    if (path === failedPath && nextAttempt <= 4) {
+      callback(new Error(`missing sprite ${nextAttempt}`), new ImageAsset());
+      return;
+    }
+
+    const asset = new ImageAsset();
+    asset.name = path;
+    callback(null, asset);
+  }) as typeof resources.load;
+  installFrameFactoryDouble();
+  t.after(restoreCcDoubles);
+
+  const assets = await loadPixelSpriteAssets("boot");
+
+  assert.equal(attempts.get(failedPath), 4);
+  assert.deepEqual(retryDelays, [1000, 2000, 4000]);
+  assert.equal((assets.tiles.grass[0]?.texture as ImageAsset | undefined)?.name, "placeholder/tiles/grass-1");
 });

--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -137,3 +137,14 @@ groups:
           summary: Battle pass gray rollout is triggering payment-related runtime errors
           description: "Payment runtime error ratio has exceeded 2% for 10 minutes while `battle_pass_enabled` is active. Roll back to the previous safe stage and verify the payment callback / reward-claim path before retrying."
           runbook_url: ./incident-response-runbook.md#alert-veilfeatureflagbattlepasspaymentfailureshigh
+
+      - alert: VeilAssetLoadFailuresHigh
+        expr: (increase(veil_analytics_events_total{name="asset_load_failed"}[15m]) / clamp_min(increase(veil_analytics_events_total{name="session_start"}[15m]), 1)) > 0.01
+        for: 10m
+        labels:
+          severity: warning
+          service: project-veil-client
+        annotations:
+          summary: Project Veil client asset load failures exceed the 1% budget
+          description: Client `asset_load_failed` analytics have exceeded 1% of session starts over 15 minutes. Check CDN availability, asset manifest drift, and recent client revisions before widening rollout.
+          runbook_url: ./incident-response-runbook.md#alert-veilassetloadfailureshigh

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -112,7 +112,15 @@ export const ANALYTICS_EVENT_CATALOG = {
       conversion: "account_bound",
       owner: "growth"
     }
-  )
+  ),
+  asset_load_failed: defineAnalyticsEvent("asset_load_failed", 1, "Client asset load failed after one or more attempts.", {
+    assetType: "sprite",
+    assetPath: "pixel/terrain/grass-1",
+    retryCount: 3,
+    critical: true,
+    finalFailure: true,
+    errorMessage: "missing sprite"
+  }),
 } as const;
 
 export type AnalyticsEventName = keyof typeof ANALYTICS_EVENT_CATALOG;

--- a/packages/shared/test/analytics-events.test.ts
+++ b/packages/shared/test/analytics-events.test.ts
@@ -219,3 +219,23 @@ test("createAnalyticsEvent: experiment_exposure event carries all required field
   assert.equal(event.payload.variant, "control");
   assert.equal(event.payload.bucket, 17);
 });
+
+test("createAnalyticsEvent: asset_load_failed includes retry metadata and path", () => {
+  const event = createAnalyticsEvent("asset_load_failed", {
+    playerId: "player-1",
+    source: "cocos-client",
+    payload: {
+      assetType: "sprite",
+      assetPath: "pixel/terrain/grass-1",
+      retryCount: 3,
+      critical: true,
+      finalFailure: true,
+      errorMessage: "missing sprite"
+    }
+  });
+
+  assert.equal(event.payload.assetPath, "pixel/terrain/grass-1");
+  assert.equal(event.payload.retryCount, 3);
+  assert.equal(event.payload.finalFailure, true);
+  assert.equal(event.source, "cocos-client");
+});


### PR DESCRIPTION
## Summary
- add a shared Cocos asset-load resilience runtime that records failures, retries critical assets with 1s/2s/4s backoff, and exposes final-failure notifications
- make pixel sprite loading fall back to existing placeholder art instead of returning blank frames, and retry critical terrain/hero sprite assets before degrading
- wire audio clip loading into the same failure reporting path, retry critical loop assets, add `asset_load_failed` analytics schema coverage, and document a 1% failure-rate alert

## Validation
- `node --import tsx --test ./apps/cocos-client/test/cocos-asset-load-resilience.test.ts ./apps/cocos-client/test/cocos-pixel-sprites.test.ts ./apps/cocos-client/test/cocos-audio-resources.test.ts ./packages/shared/test/analytics-events.test.ts`
- `npm run typecheck:cocos`
- `npm run typecheck:shared`

Closes #1235
