### PR TITLE
ops: 公会系统内容审核与创建限流

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ResourceLedger, ServerMessage, WorldState } from "../../../packages/shared/src/index";
+import { GuildService } from "./guilds";
 import type { PlayerReportResolveInput, PlayerReportStatus, RoomSnapshotStore } from "./persistence";
 import { listLobbyRooms, getActiveRoomInstances } from "./colyseus-room";
 
@@ -135,6 +136,32 @@ function hasPlayerReportStore(
 ): store is RoomSnapshotStore &
   Required<Pick<RoomSnapshotStore, "createPlayerReport" | "listPlayerReports" | "resolvePlayerReport">> {
   return Boolean(store?.createPlayerReport && store.listPlayerReports && store.resolvePlayerReport);
+}
+
+function hasGuildModerationStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore &
+  Required<
+    Pick<
+      RoomSnapshotStore,
+      | "loadGuild"
+      | "loadGuildByMemberPlayerId"
+      | "listGuilds"
+      | "saveGuild"
+      | "deleteGuild"
+      | "appendGuildAuditLog"
+      | "listGuildAuditLogs"
+    >
+  > {
+  return Boolean(
+    store?.loadGuild &&
+      store.loadGuildByMemberPlayerId &&
+      store.listGuilds &&
+      store.saveGuild &&
+      store.deleteGuild &&
+      store.appendGuildAuditLog &&
+      store.listGuildAuditLogs
+  );
 }
 
 function sendInvalidJson(response: ServerResponse): void {
@@ -271,6 +298,15 @@ function parseUnbanBody(value: unknown): { reason?: string } {
   return reason ? { reason } : {};
 }
 
+function parseGuildModerationBody(value: unknown): { reason?: string } {
+  if (value === undefined || value === null || value === "") {
+    return {};
+  }
+  const payload = readRequiredObjectBody(value);
+  const reason = readOptionalTrimmedString(payload, "reason");
+  return reason ? { reason } : {};
+}
+
 function readLimit(request: IncomingMessage, fallback = 20): number {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
   const parsed = Number(url.searchParams.get("limit"));
@@ -378,6 +414,7 @@ export function registerAdminRoutes(
   store: RoomSnapshotStore | null,
   _gameServer?: unknown
 ): void {
+  const guildService = new GuildService(store);
   app.use((request, response, next) => {
     if (request.method === "OPTIONS") {
       response.setHeader("Access-Control-Allow-Origin", "*");
@@ -694,6 +731,93 @@ export function registerAdminRoutes(
         }
       });
     } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.get("/api/admin/guilds/:id", async (request, response) => {
+    if (!requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"])) return;
+    if (!hasGuildModerationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const guildId = readRequiredParam(request, "id");
+      const guild = await guildService.getGuildForAdmin(guildId);
+      const audit = await guildService.listGuildAuditLogs(guildId, readLimit(request, 50));
+      sendJson(response, 200, { guild, audit });
+    } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/guilds/:id/hide", async (request, response) => {
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
+    if (!hasGuildModerationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const guildId = readRequiredParam(request, "id");
+      const input = parseGuildModerationBody(await readJsonBody(request));
+      const guild = await guildService.hideGuild(guildId, `${role}:admin-console`, input.reason);
+      sendJson(response, 200, { ok: true, guild });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/guilds/:id/unhide", async (request, response) => {
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
+    if (!hasGuildModerationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const guildId = readRequiredParam(request, "id");
+      const input = parseGuildModerationBody(await readJsonBody(request));
+      const guild = await guildService.unhideGuild(guildId, `${role}:admin-console`, input.reason);
+      sendJson(response, 200, { ok: true, guild });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/guilds/:id/delete", async (request, response) => {
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
+    if (!hasGuildModerationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const guildId = readRequiredParam(request, "id");
+      const input = parseGuildModerationBody(await readJsonBody(request));
+      await guildService.deleteGuildAsAdmin(guildId, `${role}:admin-console`, input.reason);
+      sendJson(response, 200, { ok: true, guildId });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
       if (error instanceof InvalidAdminPayloadError) {
         sendInvalidPayload(response, error.message);
         return;

--- a/apps/server/src/guilds.ts
+++ b/apps/server/src/guilds.ts
@@ -4,14 +4,15 @@ import {
   createGuild,
   createGuildRosterView,
   createGuildSummaryView,
+  findDisplayNameModerationViolation,
   joinGuild,
   leaveGuild,
   type GuildCreateAction,
+  type GuildState,
   type GuildMembershipEvent,
-  type GuildState
 } from "../../../packages/shared/src/index";
 import { validateAuthSessionFromRequest } from "./auth";
-import type { RoomSnapshotStore } from "./persistence";
+import type { GuildAuditLogRecord, RoomSnapshotStore } from "./persistence";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -27,6 +28,8 @@ class PayloadTooLargeError extends Error {
 }
 
 const MAX_JSON_BODY_BYTES = 16 * 1024;
+const GUILD_CREATE_WINDOW_MS = 24 * 60 * 60 * 1000;
+const GUILD_CREATE_MAX_PER_WINDOW = 2;
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
@@ -100,7 +103,7 @@ function mapGuildError(error: unknown): { status: number; code: string; message:
 
   if (
     error instanceof SyntaxError ||
-    /guild_create_.*required|guild_join_player_required|guild_leave_player_required|payload_too_large|Unexpected token/.test(
+    /guild_create_.*required|guild_create_.*blocked|guild_join_player_required|guild_leave_player_required|payload_too_large|Unexpected token/.test(
       message
     )
   ) {
@@ -118,15 +121,42 @@ function mapGuildError(error: unknown): { status: number; code: string; message:
   if (/guild_store_unavailable/.test(message)) {
     return { status: 503, code: "guild_store_unavailable", message };
   }
+  if (/guild_create_rate_limited/.test(message)) {
+    return { status: 429, code: "guild_create_rate_limited", message };
+  }
 
   return { status: 500, code: "guild_error", message };
 }
 
-class GuildService {
+function isGuildHidden(guild: GuildState): boolean {
+  return guild.moderation?.isHidden === true;
+}
+
+function ensureGuildPubliclyVisible(guild: GuildState): GuildState {
+  if (isGuildHidden(guild)) {
+    throw new Error("guild_not_found");
+  }
+  return guild;
+}
+
+function validateGuildCreateModeration(action: GuildCreateAction): void {
+  const nameViolation = findDisplayNameModerationViolation(action.name);
+  if (nameViolation) {
+    throw new Error(`guild_create_name_blocked: Guild name contains blocked content (${nameViolation.term})`);
+  }
+  const tagViolation = findDisplayNameModerationViolation(action.tag);
+  if (tagViolation) {
+    throw new Error(`guild_create_tag_blocked: Guild tag contains blocked content (${tagViolation.term})`);
+  }
+}
+
+export class GuildService {
   constructor(private readonly store: RoomSnapshotStore | null) {}
 
   private requireStore(): {
     ensurePlayerAccount: RoomSnapshotStore["ensurePlayerAccount"];
+    appendGuildAuditLog: NonNullable<RoomSnapshotStore["appendGuildAuditLog"]>;
+    listGuildAuditLogs: NonNullable<RoomSnapshotStore["listGuildAuditLogs"]>;
     loadGuild: NonNullable<RoomSnapshotStore["loadGuild"]>;
     loadGuildByMemberPlayerId: NonNullable<RoomSnapshotStore["loadGuildByMemberPlayerId"]>;
     listGuilds: NonNullable<RoomSnapshotStore["listGuilds"]>;
@@ -135,6 +165,8 @@ class GuildService {
   } {
     if (
       !this.store ||
+      !this.store.appendGuildAuditLog ||
+      !this.store.listGuildAuditLogs ||
       !this.store.loadGuild ||
       !this.store.loadGuildByMemberPlayerId ||
       !this.store.listGuilds ||
@@ -146,6 +178,8 @@ class GuildService {
 
     return {
       ensurePlayerAccount: this.store.ensurePlayerAccount.bind(this.store),
+      appendGuildAuditLog: this.store.appendGuildAuditLog.bind(this.store),
+      listGuildAuditLogs: this.store.listGuildAuditLogs.bind(this.store),
       loadGuild: this.store.loadGuild.bind(this.store),
       loadGuildByMemberPlayerId: this.store.loadGuildByMemberPlayerId.bind(this.store),
       listGuilds: this.store.listGuilds.bind(this.store),
@@ -156,7 +190,7 @@ class GuildService {
 
   async listGuilds(limit?: number): Promise<GuildState[]> {
     const store = this.requireStore();
-    return store.listGuilds({ ...(limit != null ? { limit } : {}) });
+    return (await store.listGuilds({ ...(limit != null ? { limit } : {}) })).filter((guild) => !isGuildHidden(guild));
   }
 
   async getGuild(guildId: string): Promise<GuildState> {
@@ -166,7 +200,25 @@ class GuildService {
       throw new Error("guild_not_found");
     }
 
+    return ensureGuildPubliclyVisible(guild);
+  }
+
+  async getGuildForAdmin(guildId: string): Promise<GuildState> {
+    const store = this.requireStore();
+    const guild = await store.loadGuild(guildId);
+    if (!guild) {
+      throw new Error("guild_not_found");
+    }
+
     return guild;
+  }
+
+  async listGuildAuditLogs(guildId: string, limit?: number): Promise<GuildAuditLogRecord[]> {
+    const store = this.requireStore();
+    return store.listGuildAuditLogs({
+      guildId,
+      ...(limit != null ? { limit } : {})
+    });
   }
 
   async createGuildForPlayer(
@@ -174,6 +226,7 @@ class GuildService {
     action: GuildCreateAction
   ): Promise<GuildState> {
     const store = this.requireStore();
+    validateGuildCreateModeration(action);
     await store.ensurePlayerAccount({
       playerId: authSession.playerId,
       displayName: authSession.displayName
@@ -182,6 +235,18 @@ class GuildService {
     const existingGuild = await store.loadGuildByMemberPlayerId(authSession.playerId);
     if (existingGuild) {
       throw new Error("guild_already_member");
+    }
+
+    const recentCreations = await store.listGuildAuditLogs({
+      actorPlayerId: authSession.playerId,
+      since: new Date(Date.now() - GUILD_CREATE_WINDOW_MS).toISOString(),
+      limit: GUILD_CREATE_MAX_PER_WINDOW + 1
+    });
+    const createCount = recentCreations.filter((entry) => entry.action === "created").length;
+    if (createCount >= GUILD_CREATE_MAX_PER_WINDOW) {
+      throw new Error(
+        `guild_create_rate_limited: Guild creation is limited to ${GUILD_CREATE_MAX_PER_WINDOW} per 24 hours`
+      );
     }
 
     const existingTag = (await store.listGuilds({ limit: 200 })).find(
@@ -201,7 +266,16 @@ class GuildService {
       ...(action.memberLimit != null ? { memberLimit: action.memberLimit } : {})
     });
 
-    return store.saveGuild(created.guild);
+    const saved = await store.saveGuild(created.guild);
+    await store.appendGuildAuditLog({
+      guildId: saved.id,
+      action: "created",
+      actorPlayerId: authSession.playerId,
+      occurredAt: saved.createdAt,
+      name: saved.name,
+      tag: saved.tag
+    });
+    return saved;
   }
 
   async joinGuildForPlayer(authSession: { playerId: string; displayName: string }, guildId: string): Promise<GuildState> {
@@ -223,6 +297,7 @@ class GuildService {
     if (!guild) {
       throw new Error("guild_not_found");
     }
+    ensureGuildPubliclyVisible(guild);
 
     const joined = joinGuild(guild, {
       playerId: authSession.playerId,
@@ -259,6 +334,65 @@ class GuildService {
       events: result.events,
       deleted: false
     };
+  }
+
+  async hideGuild(guildId: string, actorPlayerId: string, reason?: string): Promise<GuildState> {
+    const store = this.requireStore();
+    const guild = await this.getGuildForAdmin(guildId);
+    const nextGuild: GuildState = {
+      ...guild,
+      moderation: {
+        isHidden: true,
+        hiddenAt: new Date().toISOString(),
+        hiddenByPlayerId: actorPlayerId.trim(),
+        ...(reason?.trim() ? { hiddenReason: reason.trim() } : {})
+      }
+    };
+    const saved = await store.saveGuild(nextGuild);
+    await store.appendGuildAuditLog({
+      guildId: saved.id,
+      action: "hidden",
+      actorPlayerId,
+      name: saved.name,
+      tag: saved.tag,
+      ...(reason?.trim() ? { reason: reason.trim() } : {})
+    });
+    return saved;
+  }
+
+  async unhideGuild(guildId: string, actorPlayerId: string, reason?: string): Promise<GuildState> {
+    const store = this.requireStore();
+    const guild = await this.getGuildForAdmin(guildId);
+    const nextGuild: GuildState = {
+      ...guild,
+      moderation: {
+        isHidden: false
+      }
+    };
+    const saved = await store.saveGuild(nextGuild);
+    await store.appendGuildAuditLog({
+      guildId: saved.id,
+      action: "unhidden",
+      actorPlayerId,
+      name: saved.name,
+      tag: saved.tag,
+      ...(reason?.trim() ? { reason: reason.trim() } : {})
+    });
+    return saved;
+  }
+
+  async deleteGuildAsAdmin(guildId: string, actorPlayerId: string, reason?: string): Promise<void> {
+    const store = this.requireStore();
+    const guild = await this.getGuildForAdmin(guildId);
+    await store.appendGuildAuditLog({
+      guildId: guild.id,
+      action: "deleted",
+      actorPlayerId,
+      name: guild.name,
+      tag: guild.tag,
+      ...(reason?.trim() ? { reason: reason.trim() } : {})
+    });
+    await store.deleteGuild(guild.id);
   }
 }
 

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   appendEventLogEntries,
   DEFAULT_TUTORIAL_STEP,
@@ -16,6 +17,9 @@ import {
 } from "../../../packages/shared/src/index";
 import {
   createPlayerAccountsFromWorldState,
+  type GuildAuditLogCreateInput,
+  type GuildAuditLogListOptions,
+  type GuildAuditLogRecord,
   type GuildListOptions,
   MAX_PLAYER_AVATAR_URL_LENGTH,
   MAX_PLAYER_DISPLAY_NAME_LENGTH,
@@ -131,6 +135,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
   private readonly guilds = new Map<string, GuildState>();
   private readonly guildIdByPlayerId = new Map<string, string>();
+  private readonly guildAuditLogs: GuildAuditLogRecord[] = [];
   private readonly paymentOrders = new Map<string, PaymentOrderSnapshot>();
   private readonly paymentReceiptsByOrderId = new Map<string, PaymentReceiptSnapshot>();
   private readonly paymentReceiptOrderIdByTransactionId = new Map<string, string>();
@@ -169,6 +174,34 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     }
 
     return this.loadGuild(guildId);
+  }
+
+  async listGuildAuditLogs(options: GuildAuditLogListOptions = {}): Promise<GuildAuditLogRecord[]> {
+    const sinceMs =
+      options.since && !Number.isNaN(new Date(options.since).getTime()) ? new Date(options.since).getTime() : null;
+    const safeLimit = Math.max(1, Math.floor(options.limit ?? 50));
+    return this.guildAuditLogs
+      .filter((entry) => !options.guildId || entry.guildId === options.guildId.trim())
+      .filter((entry) => !options.actorPlayerId || entry.actorPlayerId === normalizePlayerId(options.actorPlayerId))
+      .filter((entry) => sinceMs === null || new Date(entry.occurredAt).getTime() >= sinceMs)
+      .sort((left, right) => right.occurredAt.localeCompare(left.occurredAt) || right.auditId.localeCompare(left.auditId))
+      .slice(0, safeLimit)
+      .map((entry) => structuredClone(entry));
+  }
+
+  async appendGuildAuditLog(input: GuildAuditLogCreateInput): Promise<GuildAuditLogRecord> {
+    const entry: GuildAuditLogRecord = {
+      auditId: randomUUID(),
+      guildId: input.guildId.trim(),
+      action: input.action,
+      actorPlayerId: normalizePlayerId(input.actorPlayerId),
+      occurredAt: new Date(input.occurredAt ?? Date.now()).toISOString(),
+      name: input.name.trim().slice(0, 40),
+      tag: input.tag.trim().toUpperCase().slice(0, 4),
+      ...(input.reason?.trim() ? { reason: input.reason.trim().slice(0, 200) } : {})
+    };
+    this.guildAuditLogs.push(entry);
+    return structuredClone(entry);
   }
 
   async loadPaymentOrder(orderId: string): Promise<PaymentOrderSnapshot | null> {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -109,6 +109,7 @@ export interface RoomSnapshotStore {
   loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null>;
   loadGuild?(guildId: string): Promise<GuildState | null>;
   loadGuildByMemberPlayerId?(playerId: string): Promise<GuildState | null>;
+  listGuildAuditLogs?(options?: GuildAuditLogListOptions): Promise<GuildAuditLogRecord[]>;
   loadPaymentOrder?(orderId: string): Promise<PaymentOrderSnapshot | null>;
   loadPaymentReceiptByOrderId?(orderId: string): Promise<PaymentReceiptSnapshot | null>;
   countVerifiedPaymentReceiptsSince?(playerId: string, since: string): Promise<number>;
@@ -128,6 +129,7 @@ export interface RoomSnapshotStore {
   listGuilds?(options?: GuildListOptions): Promise<GuildState[]>;
   ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot>;
   saveGuild?(guild: GuildState): Promise<GuildState>;
+  appendGuildAuditLog?(input: GuildAuditLogCreateInput): Promise<GuildAuditLogRecord>;
   savePlayerBan?(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot>;
   clearPlayerBan?(playerId: string, input?: PlayerAccountUnbanInput): Promise<PlayerAccountSnapshot>;
   bindPlayerAccountCredentials(
@@ -407,6 +409,17 @@ interface GuildRow extends RowDataPacket {
   updated_at: Date | string;
 }
 
+interface GuildAuditLogRow extends RowDataPacket {
+  audit_id: string;
+  guild_id: string;
+  action: string;
+  actor_player_id: string;
+  occurred_at: Date | string;
+  name: string;
+  tag: string;
+  reason: string | null;
+}
+
 interface PlayerReportRow extends RowDataPacket {
   report_id: string | number;
   reporter_id: string;
@@ -495,6 +508,36 @@ export interface PlayerAccountEnsureInput {
 export interface GuildListOptions {
   limit?: number;
   playerId?: string;
+}
+
+export type GuildAuditAction = "created" | "hidden" | "unhidden" | "deleted";
+
+export interface GuildAuditLogRecord {
+  auditId: string;
+  guildId: string;
+  action: GuildAuditAction;
+  actorPlayerId: string;
+  occurredAt: string;
+  name: string;
+  tag: string;
+  reason?: string;
+}
+
+export interface GuildAuditLogCreateInput {
+  guildId: string;
+  action: GuildAuditAction;
+  actorPlayerId: string;
+  occurredAt?: string;
+  name: string;
+  tag: string;
+  reason?: string;
+}
+
+export interface GuildAuditLogListOptions {
+  guildId?: string;
+  actorPlayerId?: string;
+  since?: string;
+  limit?: number;
 }
 
 export type GemLedgerReason = "purchase" | "reward" | "spend";
@@ -809,6 +852,9 @@ export const MYSQL_GUILD_UPDATED_AT_INDEX = "idx_guilds_updated_at";
 export const MYSQL_GUILD_TAG_INDEX = "uidx_guilds_tag";
 export const MYSQL_GUILD_MEMBERSHIP_TABLE = "guild_memberships";
 export const MYSQL_GUILD_MEMBERSHIP_PLAYER_INDEX = "uidx_guild_memberships_player";
+export const MYSQL_GUILD_AUDIT_LOG_TABLE = "guild_audit_logs";
+export const MYSQL_GUILD_AUDIT_LOG_GUILD_OCCURRED_INDEX = "idx_guild_audit_logs_guild_occurred";
+export const MYSQL_GUILD_AUDIT_LOG_ACTOR_OCCURRED_INDEX = "idx_guild_audit_logs_actor_occurred";
 export const MYSQL_CONFIG_DOCUMENT_TABLE = "config_documents";
 export const MYSQL_CONFIG_DOCUMENT_UPDATED_AT_INDEX = "idx_config_documents_updated_at";
 export const MYSQL_SEASON_TABLE = "veil_seasons";
@@ -991,6 +1037,27 @@ function normalizeGuildId(guildId: string): string {
   }
 
   return normalized.slice(0, 191);
+}
+
+function normalizeGuildAuditReason(reason?: string | null): string | undefined {
+  const normalized = reason?.trim();
+  return normalized ? normalized.slice(0, 200) : undefined;
+}
+
+function toGuildAuditLogRecord(row: GuildAuditLogRow): GuildAuditLogRecord {
+  const action = row.action === "created" || row.action === "hidden" || row.action === "unhidden" || row.action === "deleted"
+    ? row.action
+    : "created";
+  return {
+    auditId: row.audit_id,
+    guildId: normalizeGuildId(row.guild_id),
+    action,
+    actorPlayerId: normalizePlayerId(row.actor_player_id),
+    occurredAt: formatTimestamp(row.occurred_at) ?? new Date().toISOString(),
+    name: row.name.trim().slice(0, 40),
+    tag: row.tag.trim().toUpperCase().slice(0, 4),
+    ...(row.reason?.trim() ? { reason: row.reason.trim() } : {})
+  };
 }
 
 function toGuildState(row: GuildRow): GuildState {
@@ -4091,6 +4158,93 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const row = rows[0];
     return row ? toGuildState(row) : null;
+  }
+
+  async listGuildAuditLogs(options: GuildAuditLogListOptions = {}): Promise<GuildAuditLogRecord[]> {
+    const clauses: string[] = [];
+    const params: Array<string | Date | number> = [];
+    const safeLimit = Math.max(1, Math.min(200, Math.floor(options.limit ?? 50)));
+
+    if (options.guildId?.trim()) {
+      clauses.push("guild_id = ?");
+      params.push(normalizeGuildId(options.guildId));
+    }
+    if (options.actorPlayerId?.trim()) {
+      clauses.push("actor_player_id = ?");
+      params.push(normalizePlayerId(options.actorPlayerId));
+    }
+    if (options.since?.trim()) {
+      const since = new Date(options.since);
+      if (Number.isNaN(since.getTime())) {
+        throw new Error("since must be a valid ISO timestamp");
+      }
+      clauses.push("occurred_at >= ?");
+      params.push(since);
+    }
+
+    const whereClause = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const [rows] = await this.pool.query<GuildAuditLogRow[]>(
+      `SELECT
+         audit_id,
+         guild_id,
+         action,
+         actor_player_id,
+         occurred_at,
+         name,
+         tag,
+         reason
+       FROM \`${MYSQL_GUILD_AUDIT_LOG_TABLE}\`
+       ${whereClause}
+       ORDER BY occurred_at DESC, audit_id DESC
+       LIMIT ?`,
+      [...params, safeLimit]
+    );
+
+    return rows.map((row) => toGuildAuditLogRecord(row));
+  }
+
+  async appendGuildAuditLog(input: GuildAuditLogCreateInput): Promise<GuildAuditLogRecord> {
+    const auditId = randomUUID();
+    const occurredAt = new Date(input.occurredAt ?? Date.now());
+    const normalizedReason = normalizeGuildAuditReason(input.reason);
+    if (Number.isNaN(occurredAt.getTime())) {
+      throw new Error("occurredAt must be a valid ISO timestamp");
+    }
+    const record: GuildAuditLogRecord = {
+      auditId,
+      guildId: normalizeGuildId(input.guildId),
+      action: input.action,
+      actorPlayerId: normalizePlayerId(input.actorPlayerId),
+      occurredAt: occurredAt.toISOString(),
+      name: input.name.trim().slice(0, 40),
+      tag: input.tag.trim().toUpperCase().slice(0, 4),
+      ...(normalizedReason ? { reason: normalizedReason } : {})
+    };
+
+    await this.pool.query(
+      `INSERT INTO \`${MYSQL_GUILD_AUDIT_LOG_TABLE}\` (
+         audit_id,
+         guild_id,
+         action,
+         actor_player_id,
+         occurred_at,
+         name,
+         tag,
+         reason
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        record.auditId,
+        record.guildId,
+        record.action,
+        record.actorPlayerId,
+        occurredAt,
+        record.name,
+        record.tag,
+        record.reason ?? null
+      ]
+    );
+
+    return record;
   }
 
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test, { type TestContext } from "node:test";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { normalizeGuildState, type GuildState } from "../../../packages/shared/src/index";
 import { registerAdminRoutes } from "../src/admin-console";
 import { getActiveRoomInstances } from "../src/colyseus-room";
 import type { PlayerBanHistoryRecord, RoomSnapshotStore } from "../src/persistence";
@@ -147,6 +148,17 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     createdAt: string;
     resolvedAt?: string;
   }>();
+  const guilds = new Map<string, GuildState>();
+  const guildAuditLogs: Array<{
+    auditId: string;
+    guildId: string;
+    action: "created" | "hidden" | "unhidden" | "deleted";
+    actorPlayerId: string;
+    occurredAt: string;
+    name: string;
+    tag: string;
+    reason?: string;
+  }> = [];
   const saveCalls: Array<{ playerId: string; globalResources: { gold: number; wood: number; ore: number } }> = [];
   let nextReportId = 1;
 
@@ -209,6 +221,54 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
       };
       accounts.set(input.playerId, created);
       return created;
+    },
+    async loadGuild(guildId: string) {
+      return guilds.get(guildId) ? normalizeGuildState(guilds.get(guildId)) : null;
+    },
+    async loadGuildByMemberPlayerId(playerId: string) {
+      const match = Array.from(guilds.values()).find((guild) => guild.members.some((member) => member.playerId === playerId));
+      return match ? normalizeGuildState(match) : null;
+    },
+    async listGuilds(options: { limit?: number } = {}) {
+      return Array.from(guilds.values())
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+        .slice(0, Math.max(1, Math.floor(options.limit ?? 50)))
+        .map((guild) => normalizeGuildState(guild));
+    },
+    async saveGuild(guild: GuildState) {
+      const normalized = normalizeGuildState(guild);
+      guilds.set(normalized.id, normalized);
+      return normalizeGuildState(normalized);
+    },
+    async deleteGuild(guildId: string) {
+      guilds.delete(guildId);
+    },
+    async appendGuildAuditLog(input: {
+      guildId: string;
+      action: "created" | "hidden" | "unhidden" | "deleted";
+      actorPlayerId: string;
+      occurredAt?: string;
+      name: string;
+      tag: string;
+      reason?: string;
+    }) {
+      const entry = {
+        auditId: `${guildAuditLogs.length + 1}`,
+        guildId: input.guildId,
+        action: input.action,
+        actorPlayerId: input.actorPlayerId,
+        occurredAt: input.occurredAt ?? new Date().toISOString(),
+        name: input.name,
+        tag: input.tag,
+        ...(input.reason ? { reason: input.reason } : {})
+      };
+      guildAuditLogs.unshift(entry);
+      return entry;
+    },
+    async listGuildAuditLogs(options: { guildId?: string; limit?: number } = {}) {
+      return guildAuditLogs
+        .filter((entry) => !options.guildId || entry.guildId === options.guildId)
+        .slice(0, Math.max(1, Math.floor(options.limit ?? 50)));
     },
     async savePlayerAccountProgress(playerId: string, patch: { globalResources?: { gold: number; wood: number; ore: number } }) {
       const account =
@@ -295,7 +355,23 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
 
   return store as Pick<
     RoomSnapshotStore,
-    "loadPlayerAccount" | "createPlayerReport" | "loadPlayerBan" | "ensurePlayerAccount" | "savePlayerAccountProgress" | "savePlayerBan" | "clearPlayerBan" | "listPlayerBanHistory" | "listPlayerReports" | "resolvePlayerReport"
+    | "loadPlayerAccount"
+    | "createPlayerReport"
+    | "loadPlayerBan"
+    | "ensurePlayerAccount"
+    | "loadGuild"
+    | "loadGuildByMemberPlayerId"
+    | "listGuilds"
+    | "saveGuild"
+    | "deleteGuild"
+    | "appendGuildAuditLog"
+    | "listGuildAuditLogs"
+    | "savePlayerAccountProgress"
+    | "savePlayerBan"
+    | "clearPlayerBan"
+    | "listPlayerBanHistory"
+    | "listPlayerReports"
+    | "resolvePlayerReport"
   > & {
     saveCalls: Array<{ playerId: string; globalResources: { gold: number; wood: number; ore: number } }>;
   };
@@ -1257,4 +1333,152 @@ test("GET /api/admin/players/:id/export returns account data for support workflo
   assert.deepEqual(payload.account.globalResources, { gold: 9, wood: 4, ore: 2 });
   assert.equal(payload.moderation.currentBan.banStatus, "temporary");
   assert.equal(payload.moderation.banHistory[0]?.action, "ban");
+});
+
+test("support moderators can hide and inspect guild moderation audit", async (t) => {
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  await store.saveGuild(
+    normalizeGuildState({
+      id: "guild-admin-1",
+      name: "Nightwatch",
+      tag: "NW",
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      memberLimit: 20,
+      level: 1,
+      xp: 0,
+      members: [{ playerId: "founder-1", displayName: "Founder", role: "owner", joinedAt: "2026-04-11T00:00:00.000Z" }],
+      joinRequests: [],
+      invites: []
+    })
+  );
+  await store.appendGuildAuditLog({
+    guildId: "guild-admin-1",
+    action: "created",
+    actorPlayerId: "founder-1",
+    occurredAt: "2026-04-11T00:00:00.000Z",
+    name: "Nightwatch",
+    tag: "NW"
+  });
+  const { gets, posts } = registerRoutes(store as RoomSnapshotStore);
+  const hideHandler = posts.get("/api/admin/guilds/:id/hide");
+  const getHandler = gets.get("/api/admin/guilds/:id");
+  assert.ok(hideHandler);
+  assert.ok(getHandler);
+
+  const hideResponse = createResponse();
+  await hideHandler(
+    createRequest({
+      method: "POST",
+      params: { id: "guild-admin-1" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      },
+      body: JSON.stringify({ reason: "违规名称巡检下架" })
+    }),
+    hideResponse
+  );
+
+  assert.equal(hideResponse.statusCode, 200);
+  const hiddenPayload = JSON.parse(hideResponse.body) as { guild: GuildState };
+  assert.equal(hiddenPayload.guild.moderation?.isHidden, true);
+  assert.equal(hiddenPayload.guild.moderation?.hiddenReason, "违规名称巡检下架");
+
+  const getResponse = createResponse();
+  await getHandler(
+    createRequest({
+      params: { id: "guild-admin-1" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    getResponse
+  );
+
+  assert.equal(getResponse.statusCode, 200);
+  const getPayload = JSON.parse(getResponse.body) as {
+    guild: GuildState;
+    audit: Array<{ action: string; actorPlayerId: string; reason?: string; guildId: string; name: string; tag: string }>;
+  };
+  assert.equal(getPayload.guild.moderation?.isHidden, true);
+  assert.equal(getPayload.audit[0]?.action, "hidden");
+  assert.equal(getPayload.audit[0]?.actorPlayerId, "support-moderator:admin-console");
+  assert.equal(getPayload.audit[0]?.reason, "违规名称巡检下架");
+  assert.equal(getPayload.audit[0]?.guildId, "guild-admin-1");
+  assert.equal(getPayload.audit[0]?.name, "Nightwatch");
+  assert.equal(getPayload.audit[0]?.tag, "NW");
+  const audit = await store.listGuildAuditLogs({ guildId: "guild-admin-1" });
+  assert.equal(audit[0]?.action, "hidden");
+  assert.equal(audit[1]?.action, "created");
+  assert.equal(audit[1]?.actorPlayerId, "founder-1");
+});
+
+test("support moderators can delete guilds without removing audit history", async (t) => {
+  withAdminSecret(t);
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  await store.saveGuild(
+    normalizeGuildState({
+      id: "guild-admin-delete",
+      name: "Spammy",
+      tag: "SPM",
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      memberLimit: 20,
+      level: 1,
+      xp: 0,
+      members: [{ playerId: "founder-delete", displayName: "Founder Delete", role: "owner", joinedAt: "2026-04-11T00:00:00.000Z" }],
+      joinRequests: [],
+      invites: []
+    })
+  );
+  await store.appendGuildAuditLog({
+    guildId: "guild-admin-delete",
+    action: "created",
+    actorPlayerId: "founder-delete",
+    occurredAt: "2026-04-11T00:00:00.000Z",
+    name: "Spammy",
+    tag: "SPM"
+  });
+  const { posts, gets } = registerRoutes(store as RoomSnapshotStore);
+  const deleteHandler = posts.get("/api/admin/guilds/:id/delete");
+  const getHandler = gets.get("/api/admin/guilds/:id");
+  assert.ok(deleteHandler);
+  assert.ok(getHandler);
+
+  const deleteResponse = createResponse();
+  await deleteHandler(
+    createRequest({
+      method: "POST",
+      params: { id: "guild-admin-delete" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      },
+      body: JSON.stringify({ reason: "spam cleanup" })
+    }),
+    deleteResponse
+  );
+
+  assert.equal(deleteResponse.statusCode, 200);
+  assert.equal((await store.loadGuild("guild-admin-delete")) === null, true);
+
+  const getResponse = createResponse();
+  await getHandler(
+    createRequest({
+      params: { id: "guild-admin-delete" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    getResponse
+  );
+
+  assert.equal(getResponse.statusCode, 400);
+  assert.match(getResponse.body, /guild_not_found/);
+  const audit = await store.listGuildAuditLogs({ guildId: "guild-admin-delete" });
+  assert.equal(audit[0]?.action, "deleted");
+  assert.equal(audit[0]?.reason, "spam cleanup");
+  assert.equal(audit[1]?.action, "created");
 });

--- a/apps/server/test/guild-routes.test.ts
+++ b/apps/server/test/guild-routes.test.ts
@@ -437,6 +437,159 @@ test("guild routes reject unauthorized and banned create requests", async (t) =>
   assert.equal(bannedPayload.error.expiry, "2026-05-05T00:00:00.000Z");
 });
 
+test("guild routes reject blocked guild names and tags", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 45200 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const session = issueGuestAuthSession({ playerId: "founder-moderation", displayName: "Founder Moderation" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const blockedName = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      name: "fuck squad",
+      tag: "OK"
+    })
+  });
+
+  assert.equal(blockedName.status, 400);
+  const blockedNamePayload = (await blockedName.json()) as { error: { code: string; message: string } };
+  assert.equal(blockedNamePayload.error.code, "invalid_request");
+  assert.match(blockedNamePayload.error.message, /guild_create_name_blocked/);
+
+  const blockedTag = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      name: "Valid Guild",
+      tag: "gm"
+    })
+  });
+
+  assert.equal(blockedTag.status, 400);
+  const blockedTagPayload = (await blockedTag.json()) as { error: { code: string; message: string } };
+  assert.equal(blockedTagPayload.error.code, "invalid_request");
+  assert.match(blockedTagPayload.error.message, /guild_create_tag_blocked/);
+});
+
+test("guild routes rate limit repeated guild creation per player over 24 hours", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 45300 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const session = issueGuestAuthSession({ playerId: "guild-rate-founder", displayName: "Guild Rate Founder" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  for (const [name, tag] of [
+    ["Guild One", "G1"],
+    ["Guild Two", "G2"]
+  ] as const) {
+    const createResponse = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.token}`
+      },
+      body: JSON.stringify({ name, tag })
+    });
+    assert.equal(createResponse.status, 201);
+    const payload = (await createResponse.json()) as { guild: { guildId: string } };
+    const leaveResponse = await fetch(`http://127.0.0.1:${port}/api/guilds/${payload.guild.guildId}/leave`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.token}`
+      }
+    });
+    assert.equal(leaveResponse.status, 200);
+  }
+
+  const thirdCreate = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({ name: "Guild Three", tag: "G3" })
+  });
+
+  assert.equal(thirdCreate.status, 429);
+  const payload = (await thirdCreate.json()) as { error: { code: string; message: string } };
+  assert.equal(payload.error.code, "guild_create_rate_limited");
+  assert.match(payload.error.message, /2 per 24 hours/);
+});
+
+test("hidden guilds disappear from public list/detail/join routes", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 45400 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const founderSession = issueGuestAuthSession({ playerId: "hidden-founder", displayName: "Hidden Founder" });
+  const recruitSession = issueGuestAuthSession({ playerId: "hidden-recruit", displayName: "Hidden Recruit" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const created = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ name: "Hidden Ops", tag: "HOP" })
+  });
+  assert.equal(created.status, 201);
+  const createdPayload = (await created.json()) as { guild: { guildId: string } };
+
+  const guild = await store.loadGuild(createdPayload.guild.guildId);
+  assert.ok(guild);
+  await store.saveGuild({
+    ...guild,
+    moderation: {
+      isHidden: true,
+      hiddenAt: "2026-04-11T01:00:00.000Z",
+      hiddenByPlayerId: "support-moderator:admin-console",
+      hiddenReason: "违规名称巡检下架"
+    }
+  });
+
+  const listed = await fetch(`http://127.0.0.1:${port}/api/guilds`);
+  const listedPayload = (await listed.json()) as { items: Array<{ guildId: string }> };
+  assert.equal(listed.status, 200);
+  assert.deepEqual(listedPayload.items, []);
+
+  const detail = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}`);
+  assert.equal(detail.status, 404);
+
+  const join = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/join`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${recruitSession.token}`
+    }
+  });
+  assert.equal(join.status, 404);
+});
+
 test("guild routes map malformed payloads and store outages to actionable errors", async (t) => {
   resetGuestAuthSessions();
   const store = createMemoryRoomSnapshotStore();

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -11,6 +11,7 @@ The current persistence scope is:
 - Per-player room progress snapshot
 - Per-player account progression snapshot
 - Per-player append-only event history read model
+- Guild roster snapshots plus guild moderation audit history
 - Config center documents for `world`, `mapObjects`, and `units`
 
 Snapshots are stored as serialized JSON strings for compatibility with older MySQL versions.
@@ -131,6 +132,63 @@ The server appends only newly seen `recentEventLog` entries into this table when
 The event history routes support the existing `category` / `heroId` / `achievementId` / `worldEventType` filters, plus optional inclusive `since` and `until` ISO-8601 timestamps. MySQL-backed queries push those time-range predicates down into SQL so player history views can page within a bounded time window without scanning unrelated rows.
 
 Issue #27 follow-up note: event-log and achievement history queries now share a single normalization contract in `packages/shared/src/event-log.ts`. Route handlers and MySQL persistence both reuse that helper so trimming, pagination clamping, and ISO timestamp coercion stay consistent before full event-log persistence and richer achievement views land.
+
+### Table: `guilds`
+
+| Column | Type | Nullable | Default | Description |
+| --- | --- | --- | --- | --- |
+| `guild_id` | `VARCHAR(191)` | No | - | Guild id, primary key |
+| `name` | `VARCHAR(80)` | No | - | Latest guild name snapshot |
+| `tag` | `VARCHAR(8)` | No | - | Latest guild tag snapshot |
+| `description` | `VARCHAR(160)` | Yes | `NULL` | Latest guild description snapshot |
+| `owner_player_id` | `VARCHAR(191)` | Yes | `NULL` | Current owner player id |
+| `member_count` | `INT` | No | `0` | Current member count |
+| `state_json` | `LONGTEXT` | No | - | Serialized `GuildState`, including hidden moderation state |
+| `created_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | First persistence time |
+| `updated_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | Last persistence time |
+
+Recommended indexes:
+
+- `idx_guilds_updated_at` on `updated_at`
+- `uidx_guilds_tag` unique on `tag`
+
+### Table: `guild_memberships`
+
+| Column | Type | Nullable | Default | Description |
+| --- | --- | --- | --- | --- |
+| `guild_id` | `VARCHAR(191)` | No | - | Guild id |
+| `player_id` | `VARCHAR(191)` | No | - | Member player id |
+| `role` | `VARCHAR(16)` | No | - | Persisted guild role snapshot |
+| `created_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | Membership row creation time |
+
+Primary key:
+
+- `(guild_id, player_id)`
+
+Recommended indexes:
+
+- `uidx_guild_memberships_player` unique on `player_id`
+
+### Table: `guild_audit_logs`
+
+Guild moderation and guild-create rate limits rely on an append-only audit table instead of mutable counters. The server counts recent `created` entries per `actor_player_id` to enforce the “2 creations per 24h” policy and keeps moderation actions after a guild is hidden or deleted.
+
+| Column | Type | Nullable | Default | Description |
+| --- | --- | --- | --- | --- |
+| `audit_id` | `VARCHAR(191)` | No | - | Audit row id, primary key |
+| `guild_id` | `VARCHAR(191)` | No | - | Guild id referenced by the action |
+| `action` | `VARCHAR(32)` | No | - | One of `created`, `hidden`, `unhidden`, `deleted` |
+| `actor_player_id` | `VARCHAR(191)` | No | - | Moderator or creator actor id |
+| `occurred_at` | `DATETIME` | No | - | Logical action time |
+| `name` | `VARCHAR(80)` | No | - | Guild name snapshot at action time |
+| `tag` | `VARCHAR(8)` | No | - | Guild tag snapshot at action time |
+| `reason` | `VARCHAR(200)` | Yes | `NULL` | Optional moderation reason |
+| `created_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | Row insertion time |
+
+Recommended indexes:
+
+- `idx_guild_audit_logs_guild_occurred` on `(guild_id, occurred_at DESC)`
+- `idx_guild_audit_logs_actor_occurred` on `(actor_player_id, occurred_at DESC)`
 
 ### Table: `config_documents`
 

--- a/docs/mysql-persistence.sql
+++ b/docs/mysql-persistence.sql
@@ -252,6 +252,55 @@ PREPARE veil_guild_memberships_player_idx_stmt FROM @veil_guild_memberships_play
 EXECUTE veil_guild_memberships_player_idx_stmt;
 DEALLOCATE PREPARE veil_guild_memberships_player_idx_stmt;
 
+CREATE TABLE IF NOT EXISTS `guild_audit_logs` (
+  audit_id VARCHAR(191) NOT NULL,
+  guild_id VARCHAR(191) NOT NULL,
+  action VARCHAR(32) NOT NULL,
+  actor_player_id VARCHAR(191) NOT NULL,
+  occurred_at DATETIME NOT NULL,
+  name VARCHAR(80) NOT NULL,
+  tag VARCHAR(8) NOT NULL,
+  reason VARCHAR(200) NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (audit_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET @veil_guild_audit_logs_guild_occurred_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'guild_audit_logs'
+    AND INDEX_NAME = 'idx_guild_audit_logs_guild_occurred'
+);
+
+SET @veil_guild_audit_logs_guild_occurred_idx_sql := IF(
+  @veil_guild_audit_logs_guild_occurred_idx_exists = 0,
+  'CREATE INDEX `idx_guild_audit_logs_guild_occurred` ON `guild_audit_logs` (guild_id, occurred_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_guild_audit_logs_guild_occurred_idx_stmt FROM @veil_guild_audit_logs_guild_occurred_idx_sql;
+EXECUTE veil_guild_audit_logs_guild_occurred_idx_stmt;
+DEALLOCATE PREPARE veil_guild_audit_logs_guild_occurred_idx_stmt;
+
+SET @veil_guild_audit_logs_actor_occurred_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'guild_audit_logs'
+    AND INDEX_NAME = 'idx_guild_audit_logs_actor_occurred'
+);
+
+SET @veil_guild_audit_logs_actor_occurred_idx_sql := IF(
+  @veil_guild_audit_logs_actor_occurred_idx_exists = 0,
+  'CREATE INDEX `idx_guild_audit_logs_actor_occurred` ON `guild_audit_logs` (actor_player_id, occurred_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_guild_audit_logs_actor_occurred_idx_stmt FROM @veil_guild_audit_logs_actor_occurred_idx_sql;
+EXECUTE veil_guild_audit_logs_actor_occurred_idx_stmt;
+DEALLOCATE PREPARE veil_guild_audit_logs_actor_occurred_idx_stmt;
+
 CREATE TABLE IF NOT EXISTS `config_documents` (
   document_id VARCHAR(64) NOT NULL,
   content_json LONGTEXT NOT NULL,

--- a/packages/shared/src/display-name-validation.ts
+++ b/packages/shared/src/display-name-validation.ts
@@ -1,0 +1,37 @@
+export interface DisplayNameModerationViolation {
+  term: string;
+  reason: "reserved" | "profanity";
+}
+
+const BLOCKED_DISPLAY_NAME_TERMS: Array<DisplayNameModerationViolation> = [
+  { term: "admin", reason: "reserved" },
+  { term: "gm", reason: "reserved" },
+  { term: "mod", reason: "reserved" },
+  { term: "fuck", reason: "profanity" },
+  { term: "shit", reason: "profanity" },
+  { term: "傻逼", reason: "profanity" },
+  { term: "操你妈", reason: "profanity" }
+];
+
+export function normalizeTextForModeration(value: string): string {
+  return value.normalize("NFKC").toLowerCase().replace(/[\s\p{P}\p{S}_]+/gu, "");
+}
+
+export function findDisplayNameModerationViolation(value: string): DisplayNameModerationViolation | null {
+  const normalized = normalizeTextForModeration(value);
+  if (!normalized) {
+    return null;
+  }
+
+  for (const term of BLOCKED_DISPLAY_NAME_TERMS) {
+    if (normalized.includes(normalizeTextForModeration(term.term))) {
+      return term;
+    }
+  }
+
+  return null;
+}
+
+export function isDisplayNameAllowed(value: string): boolean {
+  return findDisplayNameModerationViolation(value) === null;
+}

--- a/packages/shared/src/guilds.ts
+++ b/packages/shared/src/guilds.ts
@@ -3,6 +3,7 @@ import type {
   GuildInviteStatus,
   GuildJoinRequestState,
   GuildJoinRequestStatus,
+  GuildModerationState,
   GuildMemberState,
   GuildRole,
   GuildState
@@ -257,6 +258,27 @@ function normalizeGuildInvite(invite: Partial<GuildInviteState>): GuildInviteSta
   };
 }
 
+function normalizeGuildModeration(input?: Partial<GuildModerationState> | null): GuildModerationState | undefined {
+  if (!input) {
+    return undefined;
+  }
+
+  const isHidden = input.isHidden === true;
+  const hiddenAt = isHidden ? normalizeTimestamp(input.hiddenAt) : undefined;
+  const hiddenByPlayerId = isHidden ? input.hiddenByPlayerId?.trim() : undefined;
+  const hiddenReason = isHidden ? input.hiddenReason?.trim() : undefined;
+  if (!isHidden && !hiddenAt && !hiddenByPlayerId && !hiddenReason) {
+    return undefined;
+  }
+
+  return {
+    isHidden,
+    ...(hiddenAt ? { hiddenAt } : {}),
+    ...(hiddenByPlayerId ? { hiddenByPlayerId } : {}),
+    ...(hiddenReason ? { hiddenReason: hiddenReason.slice(0, 200) } : {})
+  };
+}
+
 export function normalizeGuildState(input?: Partial<GuildState> | null): GuildState {
   const id = input?.id?.trim() ?? "";
   const name = input?.name?.trim() ?? id;
@@ -289,6 +311,7 @@ export function normalizeGuildState(input?: Partial<GuildState> | null): GuildSt
         .map((invite) => [invite.inviteId, invite] as const)
     ).values()
   ).sort((left, right) => left.createdAt.localeCompare(right.createdAt) || left.inviteId.localeCompare(right.inviteId));
+  const moderation = normalizeGuildModeration(input?.moderation);
 
   return {
     id,
@@ -300,6 +323,7 @@ export function normalizeGuildState(input?: Partial<GuildState> | null): GuildSt
     xp: Math.max(0, Math.floor(input?.xp ?? 0)),
     createdAt: normalizeTimestamp(input?.createdAt),
     updatedAt: normalizeTimestamp(input?.updatedAt),
+    ...(moderation ? { moderation } : {}),
     members,
     joinRequests,
     invites

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -15,6 +15,7 @@ export * from "./daily-quests.ts";
 export * from "./daily-dungeons.ts";
 export * from "./daily-quest-rotation.ts";
 export * from "./deterministic-rng.ts";
+export * from "./display-name-validation.ts";
 export * from "./equipment.ts";
 export * from "./event-log.ts";
 export * from "./feature-flags.ts";

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -47,6 +47,13 @@ export interface GuildInviteState {
   respondedAt?: string;
 }
 
+export interface GuildModerationState {
+  isHidden: boolean;
+  hiddenAt?: string;
+  hiddenByPlayerId?: string;
+  hiddenReason?: string;
+}
+
 export interface GuildState {
   id: string;
   name: string;
@@ -57,6 +64,7 @@ export interface GuildState {
   xp: number;
   createdAt: string;
   updatedAt: string;
+  moderation?: GuildModerationState;
   members: GuildMemberState[];
   joinRequests: GuildJoinRequestState[];
   invites: GuildInviteState[];

--- a/packages/shared/test/display-name-validation.test.ts
+++ b/packages/shared/test/display-name-validation.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  findDisplayNameModerationViolation,
+  isDisplayNameAllowed,
+  normalizeTextForModeration
+} from "../src/display-name-validation.ts";
+
+test("display-name moderation normalizes punctuation and spacing before matching blocked terms", () => {
+  assert.equal(normalizeTextForModeration(" G.M! "), "gm");
+  assert.deepEqual(findDisplayNameModerationViolation("G.M!"), {
+    term: "gm",
+    reason: "reserved"
+  });
+});
+
+test("display-name moderation allows ordinary names", () => {
+  assert.equal(isDisplayNameAllowed("Nightwatch"), true);
+  assert.equal(findDisplayNameModerationViolation("Nightwatch"), null);
+});


### PR DESCRIPTION
## Summary
- add shared guild name/tag moderation checks and enforce a 2-per-24h guild creation cap from persisted audit history
- hide moderated guilds from public list/detail/join flows and add admin guild hide/unhide/delete endpoints with audit visibility
- persist guild moderation audit records in memory/MySQL-backed stores and document the new audit table design

## Validation
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `node --import tsx --test packages/shared/test/display-name-validation.test.ts`
- `node --import tsx --test --test-force-exit apps/server/test/guild-routes.test.ts`
- `node --import tsx --test apps/server/test/admin-console.test.ts`

Closes #1237