### PR TITLE
[codex] Add monitoring stack bootstrap and alert routing

### DIFF
--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -74,6 +74,7 @@ groups:
         labels:
           severity: critical
           service: project-veil-mysql
+          notify: ops-slack
         annotations:
           summary: Project Veil MySQL replica lag is above the RPO target
           description: Replica lag has exceeded 30 seconds for 10 minutes. Freeze failover and backup promotion decisions until replication catches up or a deliberate recovery point is chosen.
@@ -85,6 +86,7 @@ groups:
         labels:
           severity: critical
           service: project-veil-server
+          notify: ops-slack
         annotations:
           summary: Project Veil is detecting WeChat payment fraud or integrity anomalies
           description: "`payment_fraud_signal` fired within the last 15 minutes. Freeze risky compensation/refund actions, inspect duplicate callbacks or payer mismatches, and review the current candidate before continuing rollout."
@@ -97,6 +99,7 @@ groups:
           severity: critical
           service: project-veil-server
           feature_flag: battle_pass_enabled
+          notify: ops-slack
         annotations:
           summary: Feature flag config is stale on at least one Project Veil node
           description: "A node has not re-checked or reloaded `configs/feature-flags.json` inside the allowed freshness window. Freeze rollout promotion and compare `/api/runtime/feature-flags` checksums across nodes before proceeding."
@@ -109,6 +112,7 @@ groups:
           severity: critical
           service: project-veil-server
           feature_flag: battle_pass_enabled
+          notify: ops-slack
         annotations:
           summary: Battle pass gray rollout is causing elevated session failures
           description: "Session failure rate has exceeded 1% for 10 minutes while `battle_pass_enabled` is live. Hold rollout promotion and roll back to the previous safe percentage if the error does not self-resolve immediately."
@@ -121,6 +125,7 @@ groups:
           severity: critical
           service: project-veil-server
           feature_flag: battle_pass_enabled
+          notify: ops-slack
         annotations:
           summary: Battle pass gray rollout is exceeding gameplay error budget
           description: Gameplay action validation failures have exceeded 2% for 10 minutes during a live battle pass rollout. Treat this as the generic rollout error-rate tripwire when a battle-pass-specific signal is not yet available.
@@ -133,6 +138,7 @@ groups:
           severity: critical
           service: project-veil-server
           feature_flag: battle_pass_enabled
+          notify: ops-slack
         annotations:
           summary: Battle pass gray rollout is triggering payment-related runtime errors
           description: "Payment runtime error ratio has exceeded 2% for 10 minutes while `battle_pass_enabled` is active. Roll back to the previous safe stage and verify the payment callback / reward-claim path before retrying."

--- a/docs/monitoring-setup.md
+++ b/docs/monitoring-setup.md
@@ -1,0 +1,101 @@
+# Project Veil Monitoring Stack Setup
+
+This repository now ships a minimal Prometheus + Alertmanager + Grafana stack under `infra/` for scraping the server `/metrics` endpoint, loading the alert rules in `docs/alerting-rules.yml`, and delivering at least one alert route to a real notification receiver.
+
+## Files
+
+- `infra/prometheus.yml`: Prometheus scrape and alerting configuration.
+- `infra/alertmanager.yml`: Alertmanager routing and Slack notification receiver.
+- `infra/docker-compose.monitoring.yml`: local monitoring stack for Prometheus, Alertmanager, and Grafana.
+- `infra/grafana/dashboard-overview.json`: overview dashboard covering DAU proxy, active rooms, battle duration P95, and error rate.
+- `infra/grafana/provisioning/...`: Grafana datasource and dashboard provisioning.
+- `docs/alerting-rules.yml`: alert rules evaluated by Prometheus.
+
+## Prerequisites
+
+1. Start the Project Veil server so `/metrics` is reachable on `http://127.0.0.1:2567/metrics`.
+2. Create the Alertmanager secret directory and webhook file:
+
+```bash
+mkdir -p infra/secrets
+printf '%s' 'https://hooks.slack.com/services/REPLACE/ME' > infra/secrets/slack-webhook-url
+```
+
+3. If the server is not running on the Docker host at port `2567`, update `infra/prometheus.yml` target `host.docker.internal:2567`.
+
+## Bring Up The Stack
+
+```bash
+docker compose -f infra/docker-compose.monitoring.yml up -d
+```
+
+After startup:
+
+- Prometheus: `http://127.0.0.1:9090`
+- Alertmanager: `http://127.0.0.1:9093`
+- Grafana: `http://127.0.0.1:3000` (`admin` / `admin`)
+
+Grafana auto-provisions the Prometheus datasource and imports `Project Veil Monitoring Overview`.
+
+## What The Dashboard Shows
+
+- `DAU Proxy (24h Login Events)`: `increase(veil_auth_guest_logins_total[24h]) + increase(veil_auth_account_logins_total[24h])`
+- `Active Rooms`: `max(veil_active_rooms)`
+- `Battle Duration P95`: `histogram_quantile(0.95, sum(rate(veil_battle_duration_seconds_bucket[30m])) by (le))`
+- `Gameplay Error Rate`: `sum(rate(veil_action_validation_failures_total[5m])) / clamp_min(sum(rate(veil_gameplay_action_messages_total[5m])), 1)`
+
+`DAU` is represented as a login-based proxy because the current `/metrics` endpoint exposes authentication counters but not a distinct unique-user gauge.
+
+## Validate Scraping
+
+1. Open Prometheus targets and confirm `project-veil-server` is `UP`.
+2. Run these queries in Prometheus:
+
+```promql
+veil_up
+max(veil_active_rooms)
+histogram_quantile(0.95, sum(rate(veil_battle_duration_seconds_bucket[30m])) by (le))
+```
+
+3. Confirm Grafana panels render without `No data`.
+
+## Validate Notification Delivery
+
+The `ops-slack` receiver is selected when an alert carries `notify="ops-slack"`. Critical Project Veil alerts in `docs/alerting-rules.yml` now include that label.
+
+To verify end-to-end delivery without waiting for a real incident, post a synthetic alert directly to Alertmanager:
+
+```bash
+curl -X POST http://127.0.0.1:9093/api/v2/alerts \
+  -H 'Content-Type: application/json' \
+  -d '[
+    {
+      "labels": {
+        "alertname": "VeilMonitoringPipelineDrill",
+        "service": "project-veil-server",
+        "severity": "critical",
+        "notify": "ops-slack"
+      },
+      "annotations": {
+        "summary": "Project Veil monitoring pipeline drill",
+        "description": "Synthetic alert used to verify Alertmanager -> Slack delivery.",
+        "runbook_url": "./docs/monitoring-setup.md#validate-notification-delivery"
+      },
+      "startsAt": "2026-04-11T00:00:00Z"
+    }
+  ]'
+```
+
+Expected result:
+
+- Alert appears in `http://127.0.0.1:9093/#/alerts`
+- Slack channel receives a formatted alert message
+- Alert resolves automatically when the posted alert expires or is withdrawn
+
+Record the drill in your deployment log with timestamp, receiver channel, and screenshot or copied Alertmanager event JSON.
+
+## Production Notes
+
+- Replace the Slack webhook secret with a production-managed secret mount.
+- For Kubernetes or a VM-based deployment, keep `infra/prometheus.yml` and `infra/alertmanager.yml` unchanged and translate only the runtime wrapper from Docker Compose into your platform manifests.
+- If the organization prefers DingTalk or WeCom robots, keep the same Prometheus rule labels and swap the Alertmanager receiver to a webhook bridge that transforms Alertmanager payloads into the provider-specific robot format.

--- a/infra/alertmanager.yml
+++ b/infra/alertmanager.yml
@@ -1,0 +1,36 @@
+global:
+  resolve_timeout: 5m
+  slack_api_url_file: /etc/alertmanager/secrets/slack-webhook-url
+
+route:
+  receiver: null
+  group_by:
+    - alertname
+    - service
+    - severity
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 3h
+  routes:
+    - matchers:
+        - notify="ops-slack"
+      receiver: ops-slack
+      continue: false
+
+receivers:
+  - name: null
+
+  - name: ops-slack
+    slack_configs:
+      - channel: '#ops-alerts'
+        send_resolved: true
+        title: >-
+          [{{ .Status | toUpper }}][{{ .CommonLabels.severity | toUpper }}]
+          {{ .CommonLabels.alertname }}
+        text: >-
+          {{ range .Alerts -}}
+          *service:* {{ .Labels.service }}
+          *summary:* {{ .Annotations.summary }}
+          *description:* {{ .Annotations.description }}
+          *runbook:* {{ .Annotations.runbook_url }}
+          {{ end }}

--- a/infra/docker-compose.monitoring.yml
+++ b/infra/docker-compose.monitoring.yml
@@ -1,0 +1,37 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../docs/alerting-rules.yml:/etc/prometheus/rules/alerting-rules.yml:ro
+    extra_hosts:
+      - host.docker.internal:host-gateway
+
+  alertmanager:
+    image: prom/alertmanager:v0.28.1
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - ./secrets:/etc/alertmanager/secrets:ro
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboard-overview.json:/var/lib/grafana/dashboards/project-veil-overview.json:ro

--- a/infra/grafana/dashboard-overview.json
+++ b/infra/grafana/dashboard-overview.json
@@ -1,0 +1,465 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(increase(veil_auth_guest_logins_total[24h])) + sum(increase(veil_auth_account_logins_total[24h]))",
+          "legendFormat": "login events",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DAU Proxy (24h Login Events)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 32
+              },
+              {
+                "color": "red",
+                "value": 64
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(veil_active_rooms)",
+          "legendFormat": "rooms",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Rooms",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 120
+              },
+              {
+                "color": "red",
+                "value": 180
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(veil_battle_duration_seconds_bucket[30m])) by (le))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Battle Duration P95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.02
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(veil_action_validation_failures_total[5m])) / clamp_min(sum(rate(veil_gameplay_action_messages_total[5m])), 1)",
+          "legendFormat": "error ratio",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Gameplay Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(veil_active_rooms)",
+          "legendFormat": "active rooms",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "max(veil_connected_players)",
+          "legendFormat": "connected players",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Runtime Capacity",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum(rate(veil_battle_duration_seconds_bucket[30m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(veil_battle_duration_seconds_bucket[30m])) by (le))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Battle Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(veil_action_validation_failures_total[5m])) / clamp_min(sum(rate(veil_gameplay_action_messages_total[5m])), 1)",
+          "legendFormat": "validation failures",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum(rate(veil_runtime_error_events_total{severity=\"error\"}[5m])) / clamp_min(sum(rate(veil_http_request_duration_seconds_count[5m])), 1)",
+          "legendFormat": "runtime errors per request",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Error Budget Signals",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "project-veil",
+    "ops",
+    "prometheus"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Project Veil Monitoring Overview",
+  "uid": "project-veil-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/grafana/provisioning/dashboards/dashboards.yml
+++ b/infra/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Project Veil Dashboards
+    orgId: 1
+    folder: Project Veil
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/infra/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -1,0 +1,33 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 30s
+  external_labels:
+    cluster: project-veil-local
+    environment: local
+
+rule_files:
+  - /etc/prometheus/rules/alerting-rules.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - localhost:9090
+        labels:
+          service: prometheus
+
+  - job_name: project-veil-server
+    metrics_path: /metrics
+    scrape_interval: 15s
+    scrape_timeout: 10s
+    static_configs:
+      - targets:
+          - host.docker.internal:2567
+        labels:
+          service: project-veil-server


### PR DESCRIPTION
## Summary
- add a minimal Prometheus + Alertmanager + Grafana stack under \ for scraping the server metrics endpoint
- provision a monitoring overview dashboard plus datasource/dashboard auto-loading for Grafana
- document setup, Slack alert routing, and a synthetic Alertmanager drill while wiring critical alert rules to \

## Validation
- python YAML/JSON parse check for the new monitoring config and dashboard files

Closes #1236