### PR TITLE
[codex] stage phase1 rehearsal owner reminders

### DIFF
--- a/docs/phase1-candidate-rehearsal.md
+++ b/docs/phase1-candidate-rehearsal.md
@@ -41,7 +41,7 @@ The bundle contains:
 - stable generated summaries such as `release-gate-summary-phase1-mainline-<short-sha>.json`
 - one same-revision evidence bundle manifest plus the paired drift-gate JSON / Markdown
 - the same-revision bundle's manual evidence owner ledger and release-readiness dashboard restaged at the rehearsal bundle top level
-- one candidate-level evidence audit and one current release evidence index so reviewers have a front-door into the packet
+- one candidate-level evidence audit plus its owner-reminder and freshness-history companions, along with one current release evidence index, so reviewers have a front-door into the packet
 - one Phase 1 exit audit plus the paired exit-dossier freshness gate so the final reviewer call stays in the same candidate packet
 - one reviewer-facing runtime observability bundle directory with the staged evidence and gate files for the target environment
 - the candidate-scoped Cocos RC bundle, Phase 1 dossier, and final go/no-go packet
@@ -81,6 +81,6 @@ npm run release:phase1:candidate-rehearsal -- \
   --target-surface h5
 ```
 
-Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file has a dedicated reviewer front-door section for the current release evidence index, candidate evidence audit, restaged release-readiness dashboard, and manual evidence owner ledger, then records the release gate, release health, dossier, exit audit, exit-dossier freshness gate, and final go/no-go packet outcomes for the candidate revision.
+Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file has a dedicated reviewer front-door section for the current release evidence index, candidate evidence audit, candidate owner reminder, candidate freshness history, restaged release-readiness dashboard, and manual evidence owner ledger, then records the release gate, release health, dossier, exit audit, exit-dossier freshness gate, and final go/no-go packet outcomes for the candidate revision.
 
 For the standalone CI guard and explicit GitHub Actions inputs, see [`docs/phase1-release-evidence-drift-gate.md`](./phase1-release-evidence-drift-gate.md).

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -29,7 +29,7 @@ Relevant scripts: 49
 | `release:health:trend-baseline` | release | `artifacts/release-readiness/release-health-trend-baseline.json` |
 | `release:health:trend-compare` | release | `artifacts/release-readiness/release-health-trend-compare.json` |
 | `release:phase1:candidate-dossier` | release | Bundle directory `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/` with `phase1-candidate-dossier.json/.md`, `runtime-observability-dossier.json/.md`, `release-gate-summary.json/.md`, and `release-health-summary.json/.md`. |
-| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`. |
+| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`. |
 | `release:phase1:evidence-drift-gate` | release | `artifacts/release-readiness/phase1-release-evidence-drift-gate-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-audit` | release | `artifacts/release-readiness/phase1-exit-audit-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-dossier-freshness-gate` | release | `artifacts/release-readiness/phase1-exit-dossier-freshness-gate-<candidate>-<short-sha>.json` |
@@ -232,11 +232,11 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/phase1-candidate-rehearsal.ts`
-- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, and the final go/no-go packet, into one release-readiness bundle directory.
+- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, and the final go/no-go packet, into one release-readiness bundle directory.
 - Required inputs:
   - Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.
 - Produced artifacts:
-  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`.
+  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`.
 
 ## `release:phase1:evidence-drift-gate`
 

--- a/progress.md
+++ b/progress.md
@@ -1696,3 +1696,27 @@ Original prompt: 你先学习下当前项目并给出开发的计划
 - 本轮定向验证结果：
   - `npm run typecheck:ops` 通过
   - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/phase1-exit-dossier-freshness-gate.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`7/7`）
+
+## Issue #1243 - Phase 1 rehearsal owner reminders - 2026-04-11
+
+- 本轮把 `release:phase1:candidate-rehearsal` 的 candidate audit companion artifacts 也收进了同一个 reviewer packet：
+  - `scripts/phase1-candidate-rehearsal.ts`
+    - `candidate-evidence-audit` 阶段现在会同步产出并登记：
+      - `candidateEvidenceOwnerReminderPath`
+      - `candidateEvidenceOwnerReminderMarkdownPath`
+      - `candidateEvidenceFreshnessHistoryPath`
+    - `SUMMARY.md` 的 reviewer front door 现在会直接列出 candidate owner reminder 与 freshness history
+  - `scripts/same-candidate-evidence-audit.ts`
+    - 导出 owner reminder / freshness history 辅助函数，供 rehearsal 直接复用同一条 candidate audit 逻辑
+- 文档与 inventory 已同步：
+  - `docs/phase1-candidate-rehearsal.md`
+    - 明确 rehearsal reviewer front door 现在包含 candidate owner reminder 与 freshness history
+  - `scripts/release-script-inventory.ts` / `docs/release-script-inventory.md`
+    - 同步更新 `release:phase1:candidate-rehearsal` 的职责与产物说明，包含 audit companion artifacts
+- 测试收口：
+  - `scripts/test/phase1-candidate-rehearsal.test.ts`
+    - 锁住 owner reminder / freshness history 的 artifact path 与 summary 呈现
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `npm run docs:release-script-inventory` 通过
+  - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`4/4`）

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -15,8 +15,12 @@ import {
   renderReleaseEvidenceIndexMarkdown
 } from "./release-evidence-index.ts";
 import {
+  appendFreshnessHistory,
+  buildOwnerReminderReport,
   buildSameCandidateEvidenceAuditReport,
-  renderMarkdown as renderCandidateEvidenceAuditMarkdown
+  parseManualEvidenceOwnerLedger,
+  renderMarkdown as renderCandidateEvidenceAuditMarkdown,
+  renderOwnerReminderMarkdown
 } from "./same-candidate-evidence-audit.ts";
 
 type StageStatus = "passed" | "failed" | "skipped";
@@ -93,6 +97,9 @@ interface RehearsalArtifacts {
   releaseReadinessDashboardMarkdownPath?: string;
   candidateEvidenceAuditPath?: string;
   candidateEvidenceAuditMarkdownPath?: string;
+  candidateEvidenceOwnerReminderPath?: string;
+  candidateEvidenceOwnerReminderMarkdownPath?: string;
+  candidateEvidenceFreshnessHistoryPath?: string;
   releaseEvidenceIndexPath?: string;
   releaseEvidenceIndexMarkdownPath?: string;
   phase1CandidateDossierPath?: string;
@@ -505,6 +512,12 @@ function renderMarkdown(report: RehearsalReport): string {
   if (report.artifacts.candidateEvidenceAuditPath) {
     lines.push(`- Candidate evidence audit: \`${report.artifacts.candidateEvidenceAuditPath}\``);
   }
+  if (report.artifacts.candidateEvidenceOwnerReminderPath) {
+    lines.push(`- Candidate owner reminder: \`${report.artifacts.candidateEvidenceOwnerReminderPath}\``);
+  }
+  if (report.artifacts.candidateEvidenceFreshnessHistoryPath) {
+    lines.push(`- Candidate freshness history: \`${report.artifacts.candidateEvidenceFreshnessHistoryPath}\``);
+  }
   if (report.artifacts.releaseReadinessDashboardPath) {
     lines.push(`- Release readiness dashboard: \`${report.artifacts.releaseReadinessDashboardPath}\``);
   }
@@ -597,6 +610,15 @@ async function main(): Promise<void> {
   const manualEvidenceLedgerPath = path.join(outputDir, `manual-release-evidence-owner-ledger-${candidateSlug}-${revision.shortCommit}.md`);
   const candidateEvidenceAuditPath = path.join(outputDir, `candidate-evidence-audit-${candidateSlug}-${revision.shortCommit}.json`);
   const candidateEvidenceAuditMarkdownPath = path.join(outputDir, `candidate-evidence-audit-${candidateSlug}-${revision.shortCommit}.md`);
+  const candidateEvidenceOwnerReminderPath = path.join(
+    outputDir,
+    `candidate-evidence-owner-reminder-report-${candidateSlug}-${revision.shortCommit}.json`
+  );
+  const candidateEvidenceOwnerReminderMarkdownPath = path.join(
+    outputDir,
+    `candidate-evidence-owner-reminder-report-${candidateSlug}-${revision.shortCommit}.md`
+  );
+  const candidateEvidenceFreshnessHistoryPath = path.join(outputDir, `candidate-evidence-freshness-history-${candidateSlug}.json`);
   const releaseEvidenceIndexPath = path.join(outputDir, `current-release-evidence-index-${candidateSlug}-${revision.shortCommit}.json`);
   const releaseEvidenceIndexMarkdownPath = path.join(
     outputDir,
@@ -639,6 +661,9 @@ async function main(): Promise<void> {
   artifacts.phase1ReleaseEvidenceDriftGateMarkdownPath = toRelative(phase1ReleaseEvidenceDriftGateMarkdownPath);
   artifacts.candidateEvidenceAuditPath = toRelative(candidateEvidenceAuditPath);
   artifacts.candidateEvidenceAuditMarkdownPath = toRelative(candidateEvidenceAuditMarkdownPath);
+  artifacts.candidateEvidenceOwnerReminderPath = toRelative(candidateEvidenceOwnerReminderPath);
+  artifacts.candidateEvidenceOwnerReminderMarkdownPath = toRelative(candidateEvidenceOwnerReminderMarkdownPath);
+  artifacts.candidateEvidenceFreshnessHistoryPath = toRelative(candidateEvidenceFreshnessHistoryPath);
   artifacts.releaseEvidenceIndexPath = toRelative(releaseEvidenceIndexPath);
   artifacts.releaseEvidenceIndexMarkdownPath = toRelative(releaseEvidenceIndexMarkdownPath);
   artifacts.phase1CandidateDossierPath = toRelative(phase1CandidateDossierPath);
@@ -1006,7 +1031,13 @@ async function main(): Promise<void> {
             title: "Build candidate evidence audit",
             status: "failed",
             summary: "Phase 1 same-revision evidence bundle manifest is missing, so the reviewer audit front-door could not be generated.",
-            outputs: [candidateEvidenceAuditPath, candidateEvidenceAuditMarkdownPath].map(toRelative)
+            outputs: [
+              candidateEvidenceAuditPath,
+              candidateEvidenceAuditMarkdownPath,
+              candidateEvidenceOwnerReminderPath,
+              candidateEvidenceOwnerReminderMarkdownPath,
+              candidateEvidenceFreshnessHistoryPath
+            ].map(toRelative)
           };
         }
 
@@ -1039,7 +1070,13 @@ async function main(): Promise<void> {
             title: "Build candidate evidence audit",
             status: "failed",
             summary: "Phase 1 same-revision evidence bundle did not provide a manual evidence owner ledger for the reviewer audit front-door.",
-            outputs: [candidateEvidenceAuditPath, candidateEvidenceAuditMarkdownPath].map(toRelative)
+            outputs: [
+              candidateEvidenceAuditPath,
+              candidateEvidenceAuditMarkdownPath,
+              candidateEvidenceOwnerReminderPath,
+              candidateEvidenceOwnerReminderMarkdownPath,
+              candidateEvidenceFreshnessHistoryPath
+            ].map(toRelative)
           };
         }
 
@@ -1065,13 +1102,23 @@ async function main(): Promise<void> {
 
         writeJsonFile(candidateEvidenceAuditPath, report);
         writeFile(candidateEvidenceAuditMarkdownPath, renderCandidateEvidenceAuditMarkdown(report));
+        const ownerReminderReport = buildOwnerReminderReport(report, parseManualEvidenceOwnerLedger(manualEvidenceLedgerPath));
+        writeJsonFile(candidateEvidenceOwnerReminderPath, ownerReminderReport);
+        writeFile(candidateEvidenceOwnerReminderMarkdownPath, renderOwnerReminderMarkdown(ownerReminderReport));
+        appendFreshnessHistory(candidateEvidenceFreshnessHistoryPath, report);
 
         return {
           id: "candidate-evidence-audit",
           title: "Build candidate evidence audit",
           status: "passed",
           summary: `Audit verdict ${report.summary.status}; reviewer front-door artifact generated successfully.`,
-          outputs: [candidateEvidenceAuditPath, candidateEvidenceAuditMarkdownPath].map(toRelative)
+          outputs: [
+            candidateEvidenceAuditPath,
+            candidateEvidenceAuditMarkdownPath,
+            candidateEvidenceOwnerReminderPath,
+            candidateEvidenceOwnerReminderMarkdownPath,
+            candidateEvidenceFreshnessHistoryPath
+          ].map(toRelative)
         };
       }
     },
@@ -1301,6 +1348,9 @@ async function main(): Promise<void> {
     phase1ReleaseEvidenceDriftGateMarkdownPath,
     candidateEvidenceAuditPath,
     candidateEvidenceAuditMarkdownPath,
+    candidateEvidenceOwnerReminderPath,
+    candidateEvidenceOwnerReminderMarkdownPath,
+    candidateEvidenceFreshnessHistoryPath,
     syntheticDashboardPath,
     releaseEvidenceIndexPath,
     releaseEvidenceIndexMarkdownPath,

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -149,12 +149,12 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
   },
   "release:phase1:candidate-rehearsal": {
     purpose:
-      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, and the final go/no-go packet, into one release-readiness bundle directory.",
+      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, and the final go/no-go packet, into one release-readiness bundle directory.",
     requiredInputs: [
       "Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.",
     ],
     producedArtifacts: [
-      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`.",
+      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`.",
     ],
   },
   "release:phase1:evidence-drift-gate": {

--- a/scripts/same-candidate-evidence-audit.ts
+++ b/scripts/same-candidate-evidence-audit.ts
@@ -679,7 +679,7 @@ function evaluateFreshness(timestamp: string | undefined, maxAgeMs: number): Fre
   return Date.now() - parsed > maxAgeMs ? "stale" : "fresh";
 }
 
-function parseManualEvidenceOwnerLedger(filePath: string): ManualEvidenceOwnerLedger {
+export function parseManualEvidenceOwnerLedger(filePath: string): ManualEvidenceOwnerLedger {
   const content = fs.readFileSync(filePath, "utf8");
   const capture = (label: string): string | undefined => {
     const match = content.match(new RegExp(`^- ${label}:\\s+\`([^\\n\`]+)\``, "m"));
@@ -1266,7 +1266,7 @@ function getReminderCondition(findings: AuditFinding[], hasOwnerAssignment: bool
   return undefined;
 }
 
-function buildOwnerReminderReport(
+export function buildOwnerReminderReport(
   auditReport: CandidateEvidenceAuditReport,
   ledger: ManualEvidenceOwnerLedger | undefined
 ): CandidateOwnerReminderReport {
@@ -1411,7 +1411,7 @@ function readFreshnessHistory(filePath: string, candidate: string): CandidateEvi
   };
 }
 
-function appendFreshnessHistory(
+export function appendFreshnessHistory(
   historyPath: string,
   report: CandidateEvidenceAuditReport
 ): CandidateEvidenceFreshnessHistoryReport {

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -185,6 +185,9 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(report.artifacts.manualEvidenceLedgerPath ?? "", /manual-release-evidence-owner-ledger-phase1-mainline-/);
   assert.match(report.artifacts.releaseReadinessDashboardPath ?? "", /release-readiness-dashboard-phase1-mainline-/);
   assert.match(report.artifacts.candidateEvidenceAuditPath ?? "", /candidate-evidence-audit-phase1-mainline-/);
+  assert.match(report.artifacts.candidateEvidenceOwnerReminderPath ?? "", /candidate-evidence-owner-reminder-report-phase1-mainline-/);
+  assert.match(report.artifacts.candidateEvidenceOwnerReminderMarkdownPath ?? "", /candidate-evidence-owner-reminder-report-phase1-mainline-/);
+  assert.match(report.artifacts.candidateEvidenceFreshnessHistoryPath ?? "", /candidate-evidence-freshness-history-phase1-mainline\.json/);
   assert.match(report.artifacts.releaseEvidenceIndexPath ?? "", /current-release-evidence-index-phase1-mainline-/);
   assert.match(report.artifacts.phase1CandidateDossierPath ?? "", /phase1-candidate-dossier-phase1-mainline-/);
   assert.match(report.artifacts.phase1ExitAuditPath ?? "", /phase1-exit-audit-phase1-mainline-/);
@@ -200,9 +203,13 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /## Reviewer Front Door/);
   assert.match(markdown, /Current release evidence index:/);
   assert.match(markdown, /Candidate evidence audit:/);
+  assert.match(markdown, /Candidate owner reminder:/);
+  assert.match(markdown, /Candidate freshness history:/);
   assert.match(markdown, /Release readiness dashboard:/);
   assert.match(markdown, /Manual evidence owner ledger:/);
   assert.match(markdown, /candidateEvidenceAuditPath:/);
+  assert.match(markdown, /candidateEvidenceOwnerReminderPath:/);
+  assert.match(markdown, /candidateEvidenceFreshnessHistoryPath:/);
   assert.match(markdown, /releaseEvidenceIndexPath:/);
   assert.match(markdown, /phase1ExitAuditPath:/);
   assert.match(markdown, /phase1ExitDossierFreshnessGatePath:/);


### PR DESCRIPTION
## Summary
- stage candidate owner reminder and freshness history artifacts in `release:phase1:candidate-rehearsal`
- surface the new reviewer front-door links in `SUMMARY.md`, docs, and release script inventory
- extend the rehearsal test coverage for the new artifact paths and summary output

## Validation
- `npm run typecheck:ops`
- `npm run docs:release-script-inventory`
- `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-script-inventory.test.ts`

Closes #1243
