### PR TITLE
[codex] stage phase1 rehearsal freshness guard

### DIFF
--- a/docs/phase1-candidate-rehearsal.md
+++ b/docs/phase1-candidate-rehearsal.md
@@ -41,7 +41,7 @@ The bundle contains:
 - stable generated summaries such as `release-gate-summary-phase1-mainline-<short-sha>.json`
 - one same-revision evidence bundle manifest plus the paired drift-gate JSON / Markdown
 - the same-revision bundle's manual evidence owner ledger and release-readiness dashboard restaged at the rehearsal bundle top level
-- one candidate-level evidence audit plus its owner-reminder and freshness-history companions, along with one current release evidence index, so reviewers have a front-door into the packet
+- one candidate-level evidence audit plus the dedicated freshness guard, its owner-reminder and freshness-history companions, along with one current release evidence index, so reviewers have a front-door into the packet
 - one Phase 1 exit audit plus the paired exit-dossier freshness gate so the final reviewer call stays in the same candidate packet
 - one reviewer-facing runtime observability bundle directory with the staged evidence and gate files for the target environment
 - the candidate-scoped Cocos RC bundle, Phase 1 dossier, and final go/no-go packet
@@ -81,6 +81,6 @@ npm run release:phase1:candidate-rehearsal -- \
   --target-surface h5
 ```
 
-Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file has a dedicated reviewer front-door section for the current release evidence index, candidate evidence audit, candidate owner reminder, candidate freshness history, restaged release-readiness dashboard, and manual evidence owner ledger, then records the release gate, release health, dossier, exit audit, exit-dossier freshness gate, and final go/no-go packet outcomes for the candidate revision.
+Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file has a dedicated reviewer front-door section for the current release evidence index, candidate evidence audit, candidate freshness guard, candidate owner reminder, candidate freshness history, restaged release-readiness dashboard, and manual evidence owner ledger, then records the release gate, release health, dossier, exit audit, exit-dossier freshness gate, and final go/no-go packet outcomes for the candidate revision.
 
 For the standalone CI guard and explicit GitHub Actions inputs, see [`docs/phase1-release-evidence-drift-gate.md`](./phase1-release-evidence-drift-gate.md).

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -29,7 +29,7 @@ Relevant scripts: 49
 | `release:health:trend-baseline` | release | `artifacts/release-readiness/release-health-trend-baseline.json` |
 | `release:health:trend-compare` | release | `artifacts/release-readiness/release-health-trend-compare.json` |
 | `release:phase1:candidate-dossier` | release | Bundle directory `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/` with `phase1-candidate-dossier.json/.md`, `runtime-observability-dossier.json/.md`, `release-gate-summary.json/.md`, and `release-health-summary.json/.md`. |
-| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`. |
+| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`. |
 | `release:phase1:evidence-drift-gate` | release | `artifacts/release-readiness/phase1-release-evidence-drift-gate-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-audit` | release | `artifacts/release-readiness/phase1-exit-audit-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-dossier-freshness-gate` | release | `artifacts/release-readiness/phase1-exit-dossier-freshness-gate-<candidate>-<short-sha>.json` |
@@ -232,11 +232,11 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/phase1-candidate-rehearsal.ts`
-- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, and the final go/no-go packet, into one release-readiness bundle directory.
+- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the dedicated freshness guard, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, and the final go/no-go packet, into one release-readiness bundle directory.
 - Required inputs:
   - Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.
 - Produced artifacts:
-  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`.
+  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`.
 
 ## `release:phase1:evidence-drift-gate`
 

--- a/progress.md
+++ b/progress.md
@@ -1720,3 +1720,25 @@ Original prompt: 你先学习下当前项目并给出开发的计划
   - `npm run typecheck:ops` 通过
   - `npm run docs:release-script-inventory` 通过
   - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`4/4`）
+
+## Issue #1245 - Phase 1 rehearsal freshness guard - 2026-04-11
+
+- 本轮把 `release:phase1:candidate-rehearsal` 的 authoritative same-candidate gate 也收进了同一个 reviewer packet：
+  - `scripts/phase1-candidate-rehearsal.ts`
+    - 新增 `candidate-evidence-freshness-guard` 阶段
+    - rehearsal artifacts 现在会显式登记：
+      - `candidateEvidenceFreshnessGuardPath`
+      - `candidateEvidenceFreshnessGuardMarkdownPath`
+    - `SUMMARY.md` 的 reviewer front door 现在会直接列出 candidate freshness guard
+- 文档与 inventory 已同步：
+  - `docs/phase1-candidate-rehearsal.md`
+    - 明确 rehearsal reviewer front door 现在包含 candidate freshness guard
+  - `scripts/release-script-inventory.ts` / `docs/release-script-inventory.md`
+    - 同步更新 `release:phase1:candidate-rehearsal` 的职责与产物说明，包含 dedicated freshness guard
+- 测试收口：
+  - `scripts/test/phase1-candidate-rehearsal.test.ts`
+    - 锁住 freshness guard 阶段、artifact path 与 summary 呈现
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `npm run docs:release-script-inventory` 通过
+  - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`4/4`）

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -97,6 +97,8 @@ interface RehearsalArtifacts {
   releaseReadinessDashboardMarkdownPath?: string;
   candidateEvidenceAuditPath?: string;
   candidateEvidenceAuditMarkdownPath?: string;
+  candidateEvidenceFreshnessGuardPath?: string;
+  candidateEvidenceFreshnessGuardMarkdownPath?: string;
   candidateEvidenceOwnerReminderPath?: string;
   candidateEvidenceOwnerReminderMarkdownPath?: string;
   candidateEvidenceFreshnessHistoryPath?: string;
@@ -512,6 +514,9 @@ function renderMarkdown(report: RehearsalReport): string {
   if (report.artifacts.candidateEvidenceAuditPath) {
     lines.push(`- Candidate evidence audit: \`${report.artifacts.candidateEvidenceAuditPath}\``);
   }
+  if (report.artifacts.candidateEvidenceFreshnessGuardPath) {
+    lines.push(`- Candidate freshness guard: \`${report.artifacts.candidateEvidenceFreshnessGuardPath}\``);
+  }
   if (report.artifacts.candidateEvidenceOwnerReminderPath) {
     lines.push(`- Candidate owner reminder: \`${report.artifacts.candidateEvidenceOwnerReminderPath}\``);
   }
@@ -610,6 +615,14 @@ async function main(): Promise<void> {
   const manualEvidenceLedgerPath = path.join(outputDir, `manual-release-evidence-owner-ledger-${candidateSlug}-${revision.shortCommit}.md`);
   const candidateEvidenceAuditPath = path.join(outputDir, `candidate-evidence-audit-${candidateSlug}-${revision.shortCommit}.json`);
   const candidateEvidenceAuditMarkdownPath = path.join(outputDir, `candidate-evidence-audit-${candidateSlug}-${revision.shortCommit}.md`);
+  const candidateEvidenceFreshnessGuardPath = path.join(
+    outputDir,
+    `candidate-evidence-freshness-guard-${candidateSlug}-${revision.shortCommit}.json`
+  );
+  const candidateEvidenceFreshnessGuardMarkdownPath = path.join(
+    outputDir,
+    `candidate-evidence-freshness-guard-${candidateSlug}-${revision.shortCommit}.md`
+  );
   const candidateEvidenceOwnerReminderPath = path.join(
     outputDir,
     `candidate-evidence-owner-reminder-report-${candidateSlug}-${revision.shortCommit}.json`
@@ -661,6 +674,8 @@ async function main(): Promise<void> {
   artifacts.phase1ReleaseEvidenceDriftGateMarkdownPath = toRelative(phase1ReleaseEvidenceDriftGateMarkdownPath);
   artifacts.candidateEvidenceAuditPath = toRelative(candidateEvidenceAuditPath);
   artifacts.candidateEvidenceAuditMarkdownPath = toRelative(candidateEvidenceAuditMarkdownPath);
+  artifacts.candidateEvidenceFreshnessGuardPath = toRelative(candidateEvidenceFreshnessGuardPath);
+  artifacts.candidateEvidenceFreshnessGuardMarkdownPath = toRelative(candidateEvidenceFreshnessGuardMarkdownPath);
   artifacts.candidateEvidenceOwnerReminderPath = toRelative(candidateEvidenceOwnerReminderPath);
   artifacts.candidateEvidenceOwnerReminderMarkdownPath = toRelative(candidateEvidenceOwnerReminderMarkdownPath);
   artifacts.candidateEvidenceFreshnessHistoryPath = toRelative(candidateEvidenceFreshnessHistoryPath);
@@ -676,6 +691,25 @@ async function main(): Promise<void> {
   artifacts.goNoGoPacketMarkdownPath = toRelative(goNoGoPacketMarkdownPath);
   artifacts.summaryPath = toRelative(summaryPath);
   artifacts.markdownPath = toRelative(markdownPath);
+
+  const buildCandidateEvidenceReport = () =>
+    buildSameCandidateEvidenceAuditReport({
+      candidate: args.candidate,
+      candidateRevision: revision.commit,
+      targetSurface: args.targetSurface,
+      snapshotPath: releaseReadinessSnapshotPath,
+      releaseGateSummaryPath,
+      cocosRcBundlePath:
+        findFirstMatching(outputDir, "cocos-rc-evidence-bundle-", ".json") ?? path.join(outputDir, "missing-cocos-bundle.json"),
+      ...(fs.existsSync(runtimeObservabilityEvidencePath) ? { runtimeObservabilityEvidencePath } : {}),
+      ...(fs.existsSync(runtimeObservabilityGatePath) ? { runtimeObservabilityGatePath } : {}),
+      manualEvidenceLedgerPath,
+      ...(artifacts.stableWechatArtifactsDir ? { wechatArtifactsDir: stableWechatArtifactsDir } : {}),
+      ...(artifacts.wechatCandidateSummaryPath
+        ? { wechatCandidateSummaryPath: path.resolve(artifacts.wechatCandidateSummaryPath) }
+        : {}),
+      maxAgeHours: 72
+    });
 
   const stageDefinitions: StageDefinition[] = [
     {
@@ -1080,25 +1114,7 @@ async function main(): Promise<void> {
           };
         }
 
-        const report = buildSameCandidateEvidenceAuditReport({
-          candidate: args.candidate,
-          candidateRevision: revision.commit,
-          targetSurface: args.targetSurface,
-          snapshotPath: releaseReadinessSnapshotPath,
-          releaseGateSummaryPath,
-          cocosRcBundlePath:
-            findFirstMatching(outputDir, "cocos-rc-evidence-bundle-", ".json") ?? path.join(outputDir, "missing-cocos-bundle.json"),
-          ...(fs.existsSync(runtimeObservabilityEvidencePath) ? { runtimeObservabilityEvidencePath } : {}),
-          ...(fs.existsSync(runtimeObservabilityGatePath) ? { runtimeObservabilityGatePath } : {}),
-          manualEvidenceLedgerPath,
-          ...(artifacts.stableWechatArtifactsDir ? { wechatArtifactsDir: stableWechatArtifactsDir } : {}),
-          ...(artifacts.wechatCandidateSummaryPath
-            ? { wechatCandidateSummaryPath: path.resolve(artifacts.wechatCandidateSummaryPath) }
-            : {}),
-          outputPath: candidateEvidenceAuditPath,
-          markdownOutputPath: candidateEvidenceAuditMarkdownPath,
-          maxAgeHours: 72
-        });
+        const report = buildCandidateEvidenceReport();
 
         writeJsonFile(candidateEvidenceAuditPath, report);
         writeFile(candidateEvidenceAuditMarkdownPath, renderCandidateEvidenceAuditMarkdown(report));
@@ -1119,6 +1135,33 @@ async function main(): Promise<void> {
             candidateEvidenceOwnerReminderMarkdownPath,
             candidateEvidenceFreshnessHistoryPath
           ].map(toRelative)
+        };
+      }
+    },
+    {
+      id: "candidate-evidence-freshness-guard",
+      title: "Build candidate evidence freshness guard",
+      run: () => {
+        if (!fs.existsSync(candidateEvidenceAuditPath)) {
+          return {
+            id: "candidate-evidence-freshness-guard",
+            title: "Build candidate evidence freshness guard",
+            status: "failed",
+            summary: "Candidate evidence audit must exist before the dedicated freshness guard can be staged.",
+            outputs: [candidateEvidenceFreshnessGuardPath, candidateEvidenceFreshnessGuardMarkdownPath].map(toRelative)
+          };
+        }
+
+        const report = buildCandidateEvidenceReport();
+        writeJsonFile(candidateEvidenceFreshnessGuardPath, report);
+        writeFile(candidateEvidenceFreshnessGuardMarkdownPath, renderCandidateEvidenceAuditMarkdown(report));
+
+        return {
+          id: "candidate-evidence-freshness-guard",
+          title: "Build candidate evidence freshness guard",
+          status: "passed",
+          summary: `Freshness guard verdict ${report.summary.status}; reviewer gate artifact generated successfully.`,
+          outputs: [candidateEvidenceFreshnessGuardPath, candidateEvidenceFreshnessGuardMarkdownPath].map(toRelative)
         };
       }
     },
@@ -1348,6 +1391,8 @@ async function main(): Promise<void> {
     phase1ReleaseEvidenceDriftGateMarkdownPath,
     candidateEvidenceAuditPath,
     candidateEvidenceAuditMarkdownPath,
+    candidateEvidenceFreshnessGuardPath,
+    candidateEvidenceFreshnessGuardMarkdownPath,
     candidateEvidenceOwnerReminderPath,
     candidateEvidenceOwnerReminderMarkdownPath,
     candidateEvidenceFreshnessHistoryPath,

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -149,12 +149,12 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
   },
   "release:phase1:candidate-rehearsal": {
     purpose:
-      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, and the final go/no-go packet, into one release-readiness bundle directory.",
+      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the dedicated freshness guard, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, and the final go/no-go packet, into one release-readiness bundle directory.",
     requiredInputs: [
       "Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.",
     ],
     producedArtifacts: [
-      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`.",
+      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and a top-level `SUMMARY.md`.",
     ],
   },
   "release:phase1:evidence-drift-gate": {

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -172,6 +172,7 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.equal(report.stages.find((stage) => stage.id === "phase1-same-revision-evidence-bundle")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "phase1-release-evidence-drift-gate")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "candidate-evidence-audit")?.status, "passed");
+  assert.equal(report.stages.find((stage) => stage.id === "candidate-evidence-freshness-guard")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "release-evidence-index")?.status, "passed");
   assert.match(report.artifacts.runtimeObservabilityBundlePath ?? "", /runtime-observability-bundle-phase1-mainline-/);
   assert.equal(report.stages.find((stage) => stage.id === "phase1-candidate-dossier")?.status, "passed");
@@ -185,6 +186,8 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(report.artifacts.manualEvidenceLedgerPath ?? "", /manual-release-evidence-owner-ledger-phase1-mainline-/);
   assert.match(report.artifacts.releaseReadinessDashboardPath ?? "", /release-readiness-dashboard-phase1-mainline-/);
   assert.match(report.artifacts.candidateEvidenceAuditPath ?? "", /candidate-evidence-audit-phase1-mainline-/);
+  assert.match(report.artifacts.candidateEvidenceFreshnessGuardPath ?? "", /candidate-evidence-freshness-guard-phase1-mainline-/);
+  assert.match(report.artifacts.candidateEvidenceFreshnessGuardMarkdownPath ?? "", /candidate-evidence-freshness-guard-phase1-mainline-/);
   assert.match(report.artifacts.candidateEvidenceOwnerReminderPath ?? "", /candidate-evidence-owner-reminder-report-phase1-mainline-/);
   assert.match(report.artifacts.candidateEvidenceOwnerReminderMarkdownPath ?? "", /candidate-evidence-owner-reminder-report-phase1-mainline-/);
   assert.match(report.artifacts.candidateEvidenceFreshnessHistoryPath ?? "", /candidate-evidence-freshness-history-phase1-mainline\.json/);
@@ -203,11 +206,13 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /## Reviewer Front Door/);
   assert.match(markdown, /Current release evidence index:/);
   assert.match(markdown, /Candidate evidence audit:/);
+  assert.match(markdown, /Candidate freshness guard:/);
   assert.match(markdown, /Candidate owner reminder:/);
   assert.match(markdown, /Candidate freshness history:/);
   assert.match(markdown, /Release readiness dashboard:/);
   assert.match(markdown, /Manual evidence owner ledger:/);
   assert.match(markdown, /candidateEvidenceAuditPath:/);
+  assert.match(markdown, /candidateEvidenceFreshnessGuardPath:/);
   assert.match(markdown, /candidateEvidenceOwnerReminderPath:/);
   assert.match(markdown, /candidateEvidenceFreshnessHistoryPath:/);
   assert.match(markdown, /releaseEvidenceIndexPath:/);


### PR DESCRIPTION
## Summary
- stage the dedicated candidate evidence freshness guard in `release:phase1:candidate-rehearsal`
- surface the new reviewer front-door link in `SUMMARY.md`, docs, and release script inventory
- extend rehearsal test coverage for the new stage and artifact paths

## Validation
- `npm run typecheck:ops`
- `npm run docs:release-script-inventory`
- `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-script-inventory.test.ts`

Closes #1245
