### PR TITLE
[codex] stage phase1 rehearsal primary diagnostics

### DIFF
--- a/docs/phase1-candidate-rehearsal.md
+++ b/docs/phase1-candidate-rehearsal.md
@@ -40,6 +40,7 @@ The bundle contains:
 - stable copied inputs such as `client-release-candidate-smoke-phase1-mainline-<short-sha>.json`
 - stable generated summaries such as `release-gate-summary-phase1-mainline-<short-sha>.json`
 - one same-revision evidence bundle manifest plus the paired drift-gate JSON / Markdown
+- one Cocos primary-client diagnostic snapshot pair so the runtime milestone packet is staged with the candidate bundle
 - the same-revision bundle's manual evidence owner ledger and release-readiness dashboard restaged at the rehearsal bundle top level
 - one candidate-level evidence audit plus the dedicated freshness guard, its owner-reminder and freshness-history companions, along with one current release evidence index, so reviewers have a front-door into the packet
 - one Phase 1 exit audit plus the paired exit-dossier freshness gate so the final reviewer call stays in the same candidate packet
@@ -82,6 +83,6 @@ npm run release:phase1:candidate-rehearsal -- \
   --target-surface h5
 ```
 
-Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file has a dedicated reviewer front-door section for the current release evidence index, candidate evidence audit, candidate freshness guard, candidate owner reminder, candidate freshness history, restaged release-readiness dashboard, manual evidence owner ledger, and release PR summary, then records the release gate, release health, dossier, exit audit, exit-dossier freshness gate, and final go/no-go packet outcomes for the candidate revision.
+Open `artifacts/release-readiness/phase1-candidate-rehearsal-local/SUMMARY.md` first. That file has a dedicated reviewer front-door section for the current release evidence index, candidate evidence audit, candidate freshness guard, candidate owner reminder, candidate freshness history, restaged release-readiness dashboard, manual evidence owner ledger, Cocos primary diagnostics, and release PR summary, then records the release gate, release health, dossier, exit audit, exit-dossier freshness gate, and final go/no-go packet outcomes for the candidate revision.
 
 For the standalone CI guard and explicit GitHub Actions inputs, see [`docs/phase1-release-evidence-drift-gate.md`](./phase1-release-evidence-drift-gate.md).

--- a/docs/release-script-inventory.md
+++ b/docs/release-script-inventory.md
@@ -29,7 +29,7 @@ Relevant scripts: 49
 | `release:health:trend-baseline` | release | `artifacts/release-readiness/release-health-trend-baseline.json` |
 | `release:health:trend-compare` | release | `artifacts/release-readiness/release-health-trend-compare.json` |
 | `release:phase1:candidate-dossier` | release | Bundle directory `artifacts/release-readiness/phase1-candidate-dossier-<candidate>-<short-sha>/` with `phase1-candidate-dossier.json/.md`, `runtime-observability-dossier.json/.md`, `release-gate-summary.json/.md`, and `release-health-summary.json/.md`. |
-| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, the reviewer-facing release PR summary, and a top-level `SUMMARY.md`. |
+| `release:phase1:candidate-rehearsal` | release | Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including Cocos primary diagnostics, the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, the reviewer-facing release PR summary, and a top-level `SUMMARY.md`. |
 | `release:phase1:evidence-drift-gate` | release | `artifacts/release-readiness/phase1-release-evidence-drift-gate-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-audit` | release | `artifacts/release-readiness/phase1-exit-audit-<candidate>-<short-sha>.json` |
 | `release:phase1:exit-dossier-freshness-gate` | release | `artifacts/release-readiness/phase1-exit-dossier-freshness-gate-<candidate>-<short-sha>.json` |
@@ -232,11 +232,11 @@ Relevant scripts: 49
 
 - Family: `release`
 - Command: `node --import tsx ./scripts/phase1-candidate-rehearsal.ts`
-- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the dedicated freshness guard, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and the reviewer-facing release PR summary, into one release-readiness bundle directory.
+- Purpose: Run the full candidate rehearsal flow and stage reviewer front-door outputs, including Cocos primary diagnostics, the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the dedicated freshness guard, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and the reviewer-facing release PR summary, into one release-readiness bundle directory.
 - Required inputs:
   - Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.
 - Produced artifacts:
-  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, the reviewer-facing release PR summary, and a top-level `SUMMARY.md`.
+  - Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including Cocos primary diagnostics, the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, the reviewer-facing release PR summary, and a top-level `SUMMARY.md`.
 
 ## `release:phase1:evidence-drift-gate`
 

--- a/progress.md
+++ b/progress.md
@@ -1763,3 +1763,25 @@ Original prompt: 你先学习下当前项目并给出开发的计划
   - `npm run typecheck:ops` 通过
   - `npm run docs:release-script-inventory` 通过
   - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`4/4`）
+
+## Issue #1249 - Phase 1 rehearsal primary diagnostics - 2026-04-11
+
+- 本轮把 `release:cocos:primary-diagnostics` 也收进了 `release:phase1:candidate-rehearsal` 的 candidate packet：
+  - `scripts/phase1-candidate-rehearsal.ts`
+    - 新增 `cocos-primary-diagnostics` 阶段
+    - rehearsal artifacts 现在会显式登记：
+      - `cocosPrimaryDiagnosticsPath`
+      - `cocosPrimaryDiagnosticsMarkdownPath`
+    - `SUMMARY.md` 的 reviewer front door 现在会直接列出 Cocos primary diagnostics
+- 文档与 inventory 已同步：
+  - `docs/phase1-candidate-rehearsal.md`
+    - 明确 rehearsal packet 现在包含 Cocos primary-client diagnostic snapshots
+  - `scripts/release-script-inventory.ts` / `docs/release-script-inventory.md`
+    - 同步更新 `release:phase1:candidate-rehearsal` 的职责与产物说明，包含 Cocos primary diagnostics
+- 测试收口：
+  - `scripts/test/phase1-candidate-rehearsal.test.ts`
+    - 锁住 `cocos-primary-diagnostics` 阶段、artifact path 与 summary 呈现
+- 本轮定向验证结果：
+  - `npm run typecheck:ops` 通过
+  - `npm run docs:release-script-inventory` 通过
+  - `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-script-inventory.test.ts` 通过（`4/4`）

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -80,6 +80,8 @@ interface RehearsalArtifacts {
   wechatCandidateSummaryPath?: string;
   wechatCandidateMarkdownPath?: string;
   persistencePath?: string;
+  cocosPrimaryDiagnosticsPath?: string;
+  cocosPrimaryDiagnosticsMarkdownPath?: string;
   cocosBundlePath?: string;
   cocosBundleMarkdownPath?: string;
   releaseGateSummaryPath?: string;
@@ -530,6 +532,9 @@ function renderMarkdown(report: RehearsalReport): string {
   if (report.artifacts.manualEvidenceLedgerPath) {
     lines.push(`- Manual evidence owner ledger: \`${report.artifacts.manualEvidenceLedgerPath}\``);
   }
+  if (report.artifacts.cocosPrimaryDiagnosticsPath) {
+    lines.push(`- Cocos primary diagnostics: \`${report.artifacts.cocosPrimaryDiagnosticsPath}\``);
+  }
   if (report.artifacts.releasePrCommentPath) {
     lines.push(`- Release PR summary: \`${report.artifacts.releasePrCommentPath}\``);
   }
@@ -594,6 +599,14 @@ async function main(): Promise<void> {
   const stableWechatArtifactsDir = path.join(outputDir, `wechat-release-${candidateSlug}-${revision.shortCommit}`);
   const releaseReadinessSnapshotPath = path.join(outputDir, `release-readiness-${candidateSlug}-${revision.shortCommit}.json`);
   const persistencePath = path.join(outputDir, `phase1-release-persistence-regression-${candidateSlug}-${revision.shortCommit}.json`);
+  const cocosPrimaryDiagnosticsPath = path.join(
+    outputDir,
+    `cocos-primary-client-diagnostic-snapshots-${revision.shortCommit}-${candidateSlug}.json`
+  );
+  const cocosPrimaryDiagnosticsMarkdownPath = path.join(
+    outputDir,
+    `cocos-primary-client-diagnostic-snapshots-${revision.shortCommit}-${candidateSlug}.md`
+  );
   const releaseGateSummaryPath = path.join(outputDir, `release-gate-summary-${candidateSlug}-${revision.shortCommit}.json`);
   const releaseGateMarkdownPath = path.join(outputDir, `release-gate-summary-${candidateSlug}-${revision.shortCommit}.md`);
   const ciTrendSummaryPath = path.join(outputDir, `ci-trend-summary-${candidateSlug}-${revision.shortCommit}.json`);
@@ -661,6 +674,8 @@ async function main(): Promise<void> {
 
   artifacts.releaseReadinessSnapshotPath = toRelative(releaseReadinessSnapshotPath);
   artifacts.persistencePath = toRelative(persistencePath);
+  artifacts.cocosPrimaryDiagnosticsPath = toRelative(cocosPrimaryDiagnosticsPath);
+  artifacts.cocosPrimaryDiagnosticsMarkdownPath = toRelative(cocosPrimaryDiagnosticsMarkdownPath);
   artifacts.runtimeObservabilityBundlePath = toRelative(runtimeObservabilityBundlePath);
   artifacts.runtimeObservabilityBundleMarkdownPath = toRelative(runtimeObservabilityBundleMarkdownPath);
   artifacts.runtimeObservabilityEvidencePath = toRelative(runtimeObservabilityEvidencePath);
@@ -826,6 +841,21 @@ async function main(): Promise<void> {
           "--output",
           persistencePath
         ], [persistencePath])
+    },
+    {
+      id: "cocos-primary-diagnostics",
+      title: "Build Cocos primary diagnostics",
+      run: () =>
+        runCommandStage("cocos-primary-diagnostics", "Build Cocos primary diagnostics", [
+          nodeExec,
+          "--import",
+          "tsx",
+          "./scripts/cocos-primary-client-diagnostic-snapshots.ts",
+          "--output",
+          cocosPrimaryDiagnosticsPath,
+          "--markdown-output",
+          cocosPrimaryDiagnosticsMarkdownPath
+        ], [cocosPrimaryDiagnosticsPath, cocosPrimaryDiagnosticsMarkdownPath])
     },
     {
       id: "cocos-rc-bundle",
@@ -1404,6 +1434,8 @@ async function main(): Promise<void> {
   const requiredArtifacts = [
     releaseReadinessSnapshotPath,
     persistencePath,
+    cocosPrimaryDiagnosticsPath,
+    cocosPrimaryDiagnosticsMarkdownPath,
     releaseGateSummaryPath,
     releaseGateMarkdownPath,
     ciTrendSummaryPath,

--- a/scripts/release-script-inventory.ts
+++ b/scripts/release-script-inventory.ts
@@ -149,12 +149,12 @@ const INVENTORY_METADATA: Record<string, InventoryMetadata> = {
   },
   "release:phase1:candidate-rehearsal": {
     purpose:
-      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the dedicated freshness guard, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and the reviewer-facing release PR summary, into one release-readiness bundle directory.",
+      "Run the full candidate rehearsal flow and stage reviewer front-door outputs, including Cocos primary diagnostics, the same-revision bundle's owner ledger/dashboard, the candidate evidence audit, the dedicated freshness guard, its owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, and the reviewer-facing release PR summary, into one release-readiness bundle directory.",
     requiredInputs: [
       "Pass `--candidate` and optionally `--server-url`, target-surface settings, or prebuilt artifact paths to avoid rerunning every stage.",
     ],
     producedArtifacts: [
-      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, the reviewer-facing release PR summary, and a top-level `SUMMARY.md`.",
+      "Bundle directory under `artifacts/release-readiness/phase1-candidate-rehearsal/` with staged JSON/Markdown outputs, including Cocos primary diagnostics, the restaged release-readiness dashboard and manual evidence owner ledger, the candidate evidence audit, the candidate evidence freshness guard, the candidate owner reminder and freshness history companions, the current evidence index, the Phase 1 exit audit, the exit-dossier freshness gate, the final go/no-go packet, the reviewer-facing release PR summary, and a top-level `SUMMARY.md`.",
     ],
   },
   "release:phase1:evidence-drift-gate": {

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -167,6 +167,7 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.deepEqual(report.summary.missingArtifacts, []);
   assert.equal(report.stages.find((stage) => stage.id === "release-readiness-snapshot")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "wechat-candidate-summary")?.status, "passed");
+  assert.equal(report.stages.find((stage) => stage.id === "cocos-primary-diagnostics")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "cocos-rc-bundle")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "runtime-observability-bundle")?.status, "skipped");
   assert.equal(report.stages.find((stage) => stage.id === "phase1-same-revision-evidence-bundle")?.status, "passed");
@@ -181,6 +182,8 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.equal(report.stages.find((stage) => stage.id === "go-no-go-packet")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "release-pr-summary")?.status, "passed");
   assert.match(report.artifacts.releaseReadinessSnapshotPath ?? "", /release-readiness-phase1-mainline-/);
+  assert.match(report.artifacts.cocosPrimaryDiagnosticsPath ?? "", /cocos-primary-client-diagnostic-snapshots-/);
+  assert.match(report.artifacts.cocosPrimaryDiagnosticsMarkdownPath ?? "", /cocos-primary-client-diagnostic-snapshots-/);
   assert.match(report.artifacts.runtimeObservabilityGatePath ?? "", /runtime-observability-gate-phase1-mainline-/);
   assert.match(report.artifacts.sameRevisionEvidenceBundleManifestPath ?? "", /phase1-same-revision-evidence-bundle-phase1-mainline-/);
   assert.match(report.artifacts.phase1ReleaseEvidenceDriftGatePath ?? "", /phase1-release-evidence-drift-gate-phase1-mainline-/);
@@ -213,7 +216,9 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /Candidate freshness history:/);
   assert.match(markdown, /Release readiness dashboard:/);
   assert.match(markdown, /Manual evidence owner ledger:/);
+  assert.match(markdown, /Cocos primary diagnostics:/);
   assert.match(markdown, /Release PR summary:/);
+  assert.match(markdown, /cocosPrimaryDiagnosticsPath:/);
   assert.match(markdown, /candidateEvidenceAuditPath:/);
   assert.match(markdown, /candidateEvidenceFreshnessGuardPath:/);
   assert.match(markdown, /candidateEvidenceOwnerReminderPath:/);


### PR DESCRIPTION
## Summary
- stage `release:cocos:primary-diagnostics` inside `release:phase1:candidate-rehearsal`
- surface the new Cocos diagnostics link in `SUMMARY.md`, docs, and release script inventory
- extend rehearsal test coverage for the new stage and artifact paths

## Validation
- `npm run typecheck:ops`
- `npm run docs:release-script-inventory`
- `node --import tsx --test ./scripts/test/phase1-candidate-rehearsal.test.ts ./scripts/test/release-script-inventory.test.ts`

Closes #1249
