### PR TITLE
[TEST] by claude: redis utility unit tests

### DIFF
--- a/apps/server/test/redis-utils.test.ts
+++ b/apps/server/test/redis-utils.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { closeRedisResource, readRedisUrl } from "../src/redis";
+
+// readRedisUrl
+
+test("readRedisUrl returns the trimmed URL when REDIS_URL is set", () => {
+  const result = readRedisUrl({ REDIS_URL: "redis://localhost:6379" });
+  assert.equal(result, "redis://localhost:6379");
+});
+
+test("readRedisUrl trims leading and trailing whitespace from REDIS_URL", () => {
+  const result = readRedisUrl({ REDIS_URL: "  redis://localhost:6379  " });
+  assert.equal(result, "redis://localhost:6379");
+});
+
+test("readRedisUrl returns null when REDIS_URL is an empty string", () => {
+  const result = readRedisUrl({ REDIS_URL: "" });
+  assert.equal(result, null);
+});
+
+test("readRedisUrl returns null when REDIS_URL is whitespace only", () => {
+  const result = readRedisUrl({ REDIS_URL: "   " });
+  assert.equal(result, null);
+});
+
+test("readRedisUrl returns null when REDIS_URL is not present in env", () => {
+  const result = readRedisUrl({});
+  assert.equal(result, null);
+});
+
+// closeRedisResource
+
+test("closeRedisResource resolves without error when passed null", async () => {
+  await assert.doesNotReject(() => closeRedisResource(null));
+});
+
+test("closeRedisResource resolves without error when passed undefined", async () => {
+  await assert.doesNotReject(() => closeRedisResource(undefined));
+});
+
+test("closeRedisResource calls shutdown() when available", async () => {
+  let shutdownCalled = false;
+  const resource = {
+    shutdown: async () => {
+      shutdownCalled = true;
+    },
+    quit: async () => {
+      throw new Error("quit should not be called");
+    },
+    disconnect: () => {
+      throw new Error("disconnect should not be called");
+    }
+  };
+
+  await closeRedisResource(resource);
+  assert.equal(shutdownCalled, true, "shutdown should have been called");
+});
+
+test("closeRedisResource calls quit() when shutdown is absent", async () => {
+  let quitCalled = false;
+  const resource = {
+    quit: async () => {
+      quitCalled = true;
+    },
+    disconnect: () => {
+      throw new Error("disconnect should not be called");
+    }
+  };
+
+  await closeRedisResource(resource);
+  assert.equal(quitCalled, true, "quit should have been called");
+});
+
+test("closeRedisResource calls disconnect() when neither shutdown nor quit is present", async () => {
+  let disconnectCalled = false;
+  const resource = {
+    disconnect: () => {
+      disconnectCalled = true;
+    }
+  };
+
+  await closeRedisResource(resource);
+  assert.equal(disconnectCalled, true, "disconnect should have been called");
+});


### PR DESCRIPTION
## Summary
- Adds `apps/server/test/redis-utils.test.ts` with 10 unit tests covering `readRedisUrl` and `closeRedisResource`
- Tests run without any real Redis connection using plain mock objects
- All 10 tests pass and typecheck is clean

## Test plan
- [x] `readRedisUrl` returns trimmed URL when `REDIS_URL` is set
- [x] `readRedisUrl` trims leading/trailing whitespace
- [x] `readRedisUrl` returns `null` for empty string
- [x] `readRedisUrl` returns `null` for whitespace-only value
- [x] `readRedisUrl` returns `null` when `REDIS_URL` is absent
- [x] `closeRedisResource(null)` resolves without error
- [x] `closeRedisResource(undefined)` resolves without error
- [x] `closeRedisResource` calls `shutdown()` when available
- [x] `closeRedisResource` calls `quit()` when `shutdown` is absent
- [x] `closeRedisResource` calls `disconnect()` when neither `shutdown` nor `quit` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)