### PR TITLE
Add client perf telemetry analytics

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -210,6 +210,13 @@ import {
   type ClientAnalyticsContext
 } from "./cocos-primary-client-telemetry.ts";
 import {
+  createClientPerfTelemetryMonitorState,
+  evaluateClientPerfTelemetry,
+  readClientPerfRuntimeMetadata,
+  recordClientPerfFrame,
+  type ClientPerfRuntimeMetadata
+} from "./cocos-client-perf-telemetry.ts";
+import {
   describeAccountAuthFailure,
   normalizeTutorialStep,
   type TutorialProgressAction,
@@ -496,6 +503,11 @@ export class VeilRoot extends Component {
   private analyticsSessionId: string | null = null;
   private emittedExperimentExposureKeys = new Set<string>();
   private emittedShopOpenSessionId: string | null = null;
+  private clientPerfTelemetry = createClientPerfTelemetryMonitorState();
+  private clientPerfRuntimeMetadata: ClientPerfRuntimeMetadata = {
+    deviceModel: "unknown",
+    wechatVersion: "unknown"
+  };
   private stopRuntimeMemoryWarnings: (() => void) | null = null;
   private stopAssetLoadFailureSubscription: (() => void) | null = null;
   private battlePresentation = createCocosBattlePresentationController();
@@ -526,6 +538,7 @@ export class VeilRoot extends Component {
       }
     });
     this.hydrateRuntimePlatform();
+    this.hydrateClientPerfRuntimeMetadata();
     this.bindRuntimeMemoryWarnings();
     this.hydrateLaunchIdentity();
     this.hydrateSettings();
@@ -549,6 +562,10 @@ export class VeilRoot extends Component {
     if (this.autoConnect) {
       void this.connect();
     }
+  }
+
+  update(deltaTime: number): void {
+    this.trackClientPerfTelemetry(deltaTime);
   }
 
   onDestroy(): void {
@@ -3496,6 +3513,7 @@ export class VeilRoot extends Component {
     | "shop_open"
     | "purchase_initiated"
     | "asset_load_failed"
+    | "client_perf_degraded"
   >(
     name: Name,
     payload: Record<string, unknown>,
@@ -5467,6 +5485,14 @@ export class VeilRoot extends Component {
     }
   }
 
+  private hydrateClientPerfRuntimeMetadata(): void {
+    this.clientPerfRuntimeMetadata = readClientPerfRuntimeMetadata(globalThis as {
+      wx?: {
+        getSystemInfoSync?: (() => { model?: unknown; version?: unknown } | null | undefined) | undefined;
+      } | null;
+    });
+  }
+
   private bindRuntimeMemoryWarnings(): void {
     this.stopRuntimeMemoryWarnings?.();
     this.stopRuntimeMemoryWarnings = bindCocosRuntimeMemoryWarning((event) => {
@@ -5484,6 +5510,30 @@ export class VeilRoot extends Component {
     const snapshot = readCocosRuntimeMemorySnapshot();
     const summary = formatCocosRuntimeMemoryStatus(snapshot, getPlaceholderSpriteAssetUsageSummary());
     return this.runtimeMemoryNotice ? `${summary} · ${this.runtimeMemoryNotice}` : summary;
+  }
+
+  private trackClientPerfTelemetry(deltaTime: number): void {
+    const nowMs = Date.now();
+    recordClientPerfFrame(this.clientPerfTelemetry, deltaTime, nowMs);
+
+    const memorySnapshot = readCocosRuntimeMemorySnapshot();
+    const memoryUsageRatio =
+      memorySnapshot.heapUsedBytes != null && memorySnapshot.heapLimitBytes != null && memorySnapshot.heapLimitBytes > 0
+        ? memorySnapshot.heapUsedBytes / memorySnapshot.heapLimitBytes
+        : memorySnapshot.heapUsedBytes != null && memorySnapshot.heapTotalBytes != null && memorySnapshot.heapTotalBytes > 0
+          ? memorySnapshot.heapUsedBytes / memorySnapshot.heapTotalBytes
+          : null;
+
+    const payload = evaluateClientPerfTelemetry(this.clientPerfTelemetry, {
+      nowMs,
+      memoryUsageRatio,
+      metadata: this.clientPerfRuntimeMetadata
+    });
+    if (!payload) {
+      return;
+    }
+
+    this.trackClientAnalyticsEvent("client_perf_degraded", payload);
   }
 
   private hydrateLaunchIdentity(): void {

--- a/apps/cocos-client/assets/scripts/cocos-client-perf-telemetry.ts
+++ b/apps/cocos-client/assets/scripts/cocos-client-perf-telemetry.ts
@@ -1,0 +1,164 @@
+export const CLIENT_PERF_FPS_THRESHOLD = 20;
+export const CLIENT_PERF_MEMORY_RATIO_THRESHOLD = 0.8;
+export const CLIENT_PERF_LOW_FPS_WINDOW_MS = 5_000;
+export const CLIENT_PERF_THROTTLE_MS = 60_000;
+
+interface ClientPerfFrameSample {
+  atMs: number;
+  deltaMs: number;
+}
+
+export interface ClientPerfTelemetryMonitorState {
+  frameSamples: ClientPerfFrameSample[];
+  lowFpsSinceMs: number | null;
+  lastEmittedAtMs: number | null;
+}
+
+export interface ClientPerfRuntimeMetadata {
+  deviceModel: string;
+  wechatVersion: string;
+}
+
+export interface ClientPerfDegradedPayload extends Record<string, unknown> {
+  reason: "fps" | "memory" | "fps_and_memory";
+  fpsAvg: number;
+  latencyMsAvg: number;
+  memoryUsageRatio: number;
+  deviceModel: string;
+  wechatVersion: string;
+}
+
+interface EvaluateClientPerfTelemetryOptions {
+  nowMs: number;
+  memoryUsageRatio: number | null;
+  metadata: ClientPerfRuntimeMetadata;
+}
+
+interface WechatSystemInfoLike {
+  model?: unknown;
+  version?: unknown;
+}
+
+interface WechatPerfTelemetryRuntimeLike {
+  getSystemInfoSync?: (() => WechatSystemInfoLike | null | undefined) | undefined;
+}
+
+function roundToTenths(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function clampRatio(value: number | null): number | null {
+  if (value == null || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return Math.min(value, 1);
+}
+
+function pruneSamples(state: ClientPerfTelemetryMonitorState, nowMs: number): void {
+  const windowStartMs = nowMs - CLIENT_PERF_LOW_FPS_WINDOW_MS;
+  state.frameSamples = state.frameSamples.filter((sample) => sample.atMs >= windowStartMs);
+}
+
+function summarizeSamples(state: ClientPerfTelemetryMonitorState): { fpsAvg: number; latencyMsAvg: number } | null {
+  if (state.frameSamples.length === 0) {
+    return null;
+  }
+
+  const totalFrameTimeMs = state.frameSamples.reduce((sum, sample) => sum + sample.deltaMs, 0);
+  if (totalFrameTimeMs <= 0) {
+    return null;
+  }
+
+  const latencyMsAvg = totalFrameTimeMs / state.frameSamples.length;
+  const fpsAvg = 1000 / latencyMsAvg;
+  return {
+    fpsAvg: roundToTenths(fpsAvg),
+    latencyMsAvg: roundToTenths(latencyMsAvg)
+  };
+}
+
+export function createClientPerfTelemetryMonitorState(): ClientPerfTelemetryMonitorState {
+  return {
+    frameSamples: [],
+    lowFpsSinceMs: null,
+    lastEmittedAtMs: null
+  };
+}
+
+export function recordClientPerfFrame(
+  state: ClientPerfTelemetryMonitorState,
+  deltaSeconds: number,
+  nowMs: number
+): void {
+  if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0) {
+    return;
+  }
+
+  state.frameSamples.push({
+    atMs: nowMs,
+    deltaMs: deltaSeconds * 1000
+  });
+  pruneSamples(state, nowMs);
+}
+
+export function evaluateClientPerfTelemetry(
+  state: ClientPerfTelemetryMonitorState,
+  options: EvaluateClientPerfTelemetryOptions
+): ClientPerfDegradedPayload | null {
+  pruneSamples(state, options.nowMs);
+  const summary = summarizeSamples(state);
+  if (!summary) {
+    state.lowFpsSinceMs = null;
+    return null;
+  }
+
+  const memoryUsageRatio = clampRatio(options.memoryUsageRatio);
+  const lowFps = summary.fpsAvg < CLIENT_PERF_FPS_THRESHOLD;
+  const memoryHigh = memoryUsageRatio != null && memoryUsageRatio >= CLIENT_PERF_MEMORY_RATIO_THRESHOLD;
+
+  if (lowFps) {
+    state.lowFpsSinceMs ??= state.frameSamples[0]?.atMs ?? options.nowMs;
+  } else {
+    state.lowFpsSinceMs = null;
+  }
+
+  const sustainedLowFps =
+    lowFps && state.lowFpsSinceMs != null && options.nowMs - state.lowFpsSinceMs >= CLIENT_PERF_LOW_FPS_WINDOW_MS;
+  const reason = sustainedLowFps && memoryHigh ? "fps_and_memory" : sustainedLowFps ? "fps" : memoryHigh ? "memory" : null;
+
+  if (!reason) {
+    return null;
+  }
+
+  if (state.lastEmittedAtMs != null && options.nowMs - state.lastEmittedAtMs < CLIENT_PERF_THROTTLE_MS) {
+    return null;
+  }
+
+  state.lastEmittedAtMs = options.nowMs;
+  return {
+    reason,
+    fpsAvg: summary.fpsAvg,
+    latencyMsAvg: summary.latencyMsAvg,
+    memoryUsageRatio: roundToTenths((memoryUsageRatio ?? 0) * 100) / 100,
+    deviceModel: options.metadata.deviceModel,
+    wechatVersion: options.metadata.wechatVersion
+  };
+}
+
+export function readClientPerfRuntimeMetadata(
+  environment: { wx?: WechatPerfTelemetryRuntimeLike | null } = globalThis as { wx?: WechatPerfTelemetryRuntimeLike | null }
+): ClientPerfRuntimeMetadata {
+  const systemInfo = environment.wx?.getSystemInfoSync?.() ?? null;
+  return {
+    deviceModel: normalizeString(systemInfo?.model) ?? "unknown",
+    wechatVersion: normalizeString(systemInfo?.version) ?? "unknown"
+  };
+}

--- a/apps/cocos-client/test/cocos-client-perf-telemetry.test.ts
+++ b/apps/cocos-client/test/cocos-client-perf-telemetry.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CLIENT_PERF_LOW_FPS_WINDOW_MS,
+  CLIENT_PERF_THROTTLE_MS,
+  createClientPerfTelemetryMonitorState,
+  evaluateClientPerfTelemetry,
+  readClientPerfRuntimeMetadata,
+  recordClientPerfFrame
+} from "../assets/scripts/cocos-client-perf-telemetry.ts";
+
+test("evaluateClientPerfTelemetry emits after fps stays below threshold for 5 seconds", () => {
+  const state = createClientPerfTelemetryMonitorState();
+
+  for (let nowMs = 250; nowMs <= CLIENT_PERF_LOW_FPS_WINDOW_MS + 250; nowMs += 250) {
+    recordClientPerfFrame(state, 0.06, nowMs);
+  }
+
+  const payload = evaluateClientPerfTelemetry(state, {
+    nowMs: CLIENT_PERF_LOW_FPS_WINDOW_MS + 250,
+    memoryUsageRatio: 0.55,
+    metadata: {
+      deviceModel: "Pixel 8",
+      wechatVersion: "8.0.51"
+    }
+  });
+
+  assert.deepEqual(payload, {
+    reason: "fps",
+    fpsAvg: 16.7,
+    latencyMsAvg: 60,
+    memoryUsageRatio: 0.55,
+    deviceModel: "Pixel 8",
+    wechatVersion: "8.0.51"
+  });
+});
+
+test("evaluateClientPerfTelemetry emits immediately when memory usage crosses 80 percent and then throttles", () => {
+  const state = createClientPerfTelemetryMonitorState();
+  recordClientPerfFrame(state, 1 / 60, 1_000);
+
+  const first = evaluateClientPerfTelemetry(state, {
+    nowMs: 1_000,
+    memoryUsageRatio: 0.83,
+    metadata: {
+      deviceModel: "iPhone 15",
+      wechatVersion: "8.0.50"
+    }
+  });
+  const throttled = evaluateClientPerfTelemetry(state, {
+    nowMs: 1_000 + CLIENT_PERF_THROTTLE_MS - 1,
+    memoryUsageRatio: 0.9,
+    metadata: {
+      deviceModel: "iPhone 15",
+      wechatVersion: "8.0.50"
+    }
+  });
+  recordClientPerfFrame(state, 1 / 60, 1_000 + CLIENT_PERF_THROTTLE_MS);
+  const afterThrottle = evaluateClientPerfTelemetry(state, {
+    nowMs: 1_000 + CLIENT_PERF_THROTTLE_MS,
+    memoryUsageRatio: 0.9,
+    metadata: {
+      deviceModel: "iPhone 15",
+      wechatVersion: "8.0.50"
+    }
+  });
+
+  assert.equal(first?.reason, "memory");
+  assert.equal(first?.memoryUsageRatio, 0.83);
+  assert.equal(throttled, null);
+  assert.equal(afterThrottle?.reason, "memory");
+});
+
+test("readClientPerfRuntimeMetadata reads WeChat device model and version with unknown fallback", () => {
+  assert.deepEqual(
+    readClientPerfRuntimeMetadata({
+      wx: {
+        getSystemInfoSync: () => ({
+          model: "iPhone 13 Pro Max",
+          version: "8.0.50"
+        })
+      }
+    }),
+    {
+      deviceModel: "iPhone 13 Pro Max",
+      wechatVersion: "8.0.50"
+    }
+  );
+
+  assert.deepEqual(readClientPerfRuntimeMetadata({ wx: {} }), {
+    deviceModel: "unknown",
+    wechatVersion: "unknown"
+  });
+});

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -1055,6 +1055,62 @@ test("VeilRoot emits shop, tutorial, quest, and experiment analytics once per se
   assertCapturedAnalyticsEvent(events, "tutorial_step");
 });
 
+test("VeilRoot emits throttled client_perf_degraded analytics when runtime performance stays degraded", async () => {
+  const root = createVeilRootHarness();
+  root.roomId = "room-analytics";
+  root.playerId = "player-1";
+  root.remoteUrl = "http://127.0.0.1:2567";
+  root.clientPerfRuntimeMetadata = {
+    deviceModel: "iPhone 13 Pro Max",
+    wechatVersion: "8.0.50"
+  };
+
+  const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
+  configureClientAnalyticsRuntimeDependencies({
+    getNodeEnv: () => "production",
+    fetch: async (input, init) => {
+      fetchCalls.push({ input, init });
+      return {
+        ok: true,
+        status: 202
+      };
+    }
+  });
+
+  const originalDateNow = Date.now;
+  const originalPerformance = (globalThis as { performance?: unknown }).performance;
+  let nowMs = 0;
+  Date.now = () => nowMs;
+  (globalThis as { performance?: unknown }).performance = {
+    memory: {
+      usedJSHeapSize: 85,
+      totalJSHeapSize: 100
+    }
+  };
+
+  try {
+    for (nowMs = 250; nowMs <= 5_250; nowMs += 250) {
+      root.update(0.06);
+    }
+    nowMs = 10_000;
+    root.update(0.06);
+    nowMs = 65_500;
+    root.update(0.06);
+    await flushClientAnalyticsEventsForTest();
+  } finally {
+    Date.now = originalDateNow;
+    (globalThis as { performance?: unknown }).performance = originalPerformance;
+  }
+
+  const events = parseCapturedAnalyticsEvents(fetchCalls);
+  const perfEvents = events.filter((event) => event.name === "client_perf_degraded");
+  assert.equal(perfEvents.length, 2);
+  assert.equal(perfEvents[0]?.payload.reason, "memory");
+  assert.equal(perfEvents[0]?.payload.deviceModel, "iPhone 13 Pro Max");
+  assert.equal(perfEvents[0]?.payload.wechatVersion, "8.0.50");
+  assert.equal(perfEvents[1]?.payload.reason, "fps_and_memory");
+});
+
 test("VeilRoot gameplay account refresh uses the injected loader for remote equipment and loot updates", async () => {
   const storage = createMemoryStorage();
   (sys as unknown as { localStorage: Storage }).localStorage = storage;

--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -198,3 +198,14 @@ groups:
           summary: Project Veil client asset load failures exceed the 1% budget
           description: Client `asset_load_failed` analytics have exceeded 1% of session starts over 15 minutes. Check CDN availability, asset manifest drift, and recent client revisions before widening rollout.
           runbook_url: ./incident-response-runbook.md#alert-veilassetloadfailureshigh
+
+      - alert: VeilClientPerfDegradedHigh
+        expr: increase(veil_analytics_events_flushed_total{name="client_perf_degraded",source="cocos-client"}[15m]) > 5
+        for: 10m
+        labels:
+          severity: warning
+          service: project-veil-client
+        annotations:
+          summary: Project Veil client runtime performance degradation is above budget
+          description: Client `client_perf_degraded` analytics exceeded five flushed events in 15 minutes. Inspect the affected candidate revision, low-FPS windows, and memory pressure before expanding traffic.
+          runbook_url: ./alerting-runbook.md#alert-veilclientperfdegradedhigh

--- a/docs/alerting-runbook.md
+++ b/docs/alerting-runbook.md
@@ -313,6 +313,33 @@ Escalation thresholds:
 - escalate if lag remains above `30s` for another 15 minutes after replica recovery work starts
 - escalate immediately if lag exceeds `300s`, if replica threads stop, or if a restore/failover incident is active at the same time
 
+## Alert: VeilClientPerfDegradedHigh
+
+Likely causes:
+
+- a recent Cocos candidate introduced a render-loop regression that keeps FPS below `20` for at least 5 seconds
+- memory pressure is climbing above `80%` on one or more WeChat device classes
+- one specific handset or WeChat runtime version is overrepresented in the degraded events
+
+Immediate triage commands:
+
+```bash
+grep 'veil_analytics_events_flushed_total{name="client_perf_degraded"' /tmp/project-veil.metrics
+curl -fsS "$VEIL_RUNTIME_URL/api/runtime/analytics-pipeline" | jq '.delivery.events[] | select(.name=="client_perf_degraded")'
+```
+
+Mitigation steps:
+
+1. Confirm whether the spike lines up with one candidate revision or one rollout wave before treating it as a generic traffic increase.
+2. Break down the latest `client_perf_degraded` events by `payload.deviceModel` and `payload.wechatVersion` in the warehouse or raw sink so you can isolate a device cluster quickly.
+3. If the events are dominated by `reason="fps"`, inspect recent rendering, particle, animation, and asset changes; if they are dominated by `reason="memory"`, inspect recent bundle growth and retained asset scopes.
+4. Hold further rollout expansion until the event rate drops and the affected client build has either been fixed or scoped away from the impacted device slice.
+
+Escalation thresholds:
+
+- escalate if the alert survives one additional 15-minute window after rollout pause or traffic reduction
+- escalate immediately if the same window also shows asset-load failure growth or player-reported WeChat crashes
+
 ## Closeout Checklist
 
 - capture the alert name, environment, and exact trigger window in the incident notes or PR comments

--- a/docs/analytics-pipeline-runbook.md
+++ b/docs/analytics-pipeline-runbook.md
@@ -11,6 +11,8 @@ Production sink target:
 3. The HTTP analytics gateway persists the raw envelope into object storage at `ANALYTICS_RAW_BUCKET`, then writes flattened rows into ClickHouse table `${ANALYTICS_WAREHOUSE_DATASET}.${ANALYTICS_WAREHOUSE_EVENTS_TABLE}`.
 4. Ops, growth, and payments query the curated ClickHouse table for live KPI checks and alert investigations.
 
+Issue #1227 adds the client-side `client_perf_degraded` event for WeChat/Cocos runtime degradation. The Cocos client emits it only in production analytics mode when either FPS stays below `20` for `5s` or heap usage rises above `80%`, and it is throttled to at most one event per minute per running client session.
+
 Local/dev fallback:
 
 - If `ANALYTICS_SINK` is unset and no endpoint is configured, the runtime falls back to `stdout` and still exposes the same counters through `/api/runtime/analytics-pipeline` and `/metrics`.

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -121,6 +121,19 @@ export const ANALYTICS_EVENT_CATALOG = {
     finalFailure: true,
     errorMessage: "missing sprite"
   }),
+  client_perf_degraded: defineAnalyticsEvent(
+    "client_perf_degraded",
+    1,
+    "Client runtime performance remained degraded long enough to cross the FPS or memory budget.",
+    {
+      reason: "fps",
+      fpsAvg: 18.4,
+      latencyMsAvg: 54.3,
+      memoryUsageRatio: 0.82,
+      deviceModel: "iPhone 13 Pro Max",
+      wechatVersion: "8.0.50"
+    }
+  ),
 } as const;
 
 export type AnalyticsEventName = keyof typeof ANALYTICS_EVENT_CATALOG;

--- a/packages/shared/test/analytics-events.test.ts
+++ b/packages/shared/test/analytics-events.test.ts
@@ -239,3 +239,25 @@ test("createAnalyticsEvent: asset_load_failed includes retry metadata and path",
   assert.equal(event.payload.finalFailure, true);
   assert.equal(event.source, "cocos-client");
 });
+
+test("createAnalyticsEvent: client_perf_degraded includes fps, latency, memory, and runtime metadata", () => {
+  const event = createAnalyticsEvent("client_perf_degraded", {
+    playerId: "player-1",
+    source: "cocos-client",
+    payload: {
+      reason: "fps_and_memory",
+      fpsAvg: 16.8,
+      latencyMsAvg: 59.5,
+      memoryUsageRatio: 0.84,
+      deviceModel: "iPhone 13 Pro Max",
+      wechatVersion: "8.0.50"
+    }
+  });
+
+  assert.equal(event.payload.reason, "fps_and_memory");
+  assert.equal(event.payload.fpsAvg, 16.8);
+  assert.equal(event.payload.latencyMsAvg, 59.5);
+  assert.equal(event.payload.memoryUsageRatio, 0.84);
+  assert.equal(event.payload.deviceModel, "iPhone 13 Pro Max");
+  assert.equal(event.payload.wechatVersion, "8.0.50");
+});


### PR DESCRIPTION
## Summary
- add the `client_perf_degraded` analytics contract and a Cocos perf monitor for FPS, frame latency, and memory pressure
- emit throttled client perf degradation analytics from `VeilRoot` with WeChat device/runtime metadata, while keeping local dev default-off via production-only client analytics
- document the new signal and add alerting plus targeted tests

Closes #1227