### PR TITLE
ops: harden config hot reload safety window

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -44,7 +44,11 @@ import {
   type RoomSnapshotStore,
   type PlayerAccountSnapshot,
 } from "./persistence";
-import { registerConfigUpdateListener } from "./config-center";
+import {
+  configureConfigRuntimeStatusProvider,
+  flushPendingConfigUpdate,
+  registerConfigUpdateListener
+} from "./config-center";
 import { applyPlayerEventLogAndAchievements } from "./player-achievements";
 import { resolveGuestAuthSession } from "./auth";
 import { deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
@@ -99,6 +103,20 @@ const lobbyRoomOwnerTokens = new Map<string, number>();
 const activeRoomInstances = new Map<string, VeilColyseusRoom>();
 let nextLobbyRoomOwnerToken = 1;
 let zombieRoomCleanupHandle: RoomTimerHandle | null = null;
+
+configureConfigRuntimeStatusProvider(() => {
+  const rooms = Array.from(activeRoomInstances.values())
+    .map((room) => ({
+      roomId: room.roomId,
+      activeBattles: room.worldRoom?.getActiveBattles().length ?? 0
+    }))
+    .filter((room) => room.activeBattles > 0);
+
+  return {
+    rooms,
+    activeBattleCount: rooms.reduce((sum, room) => sum + room.activeBattles, 0)
+  };
+});
 
 interface RoomTimerHandle {
   unref?(): void;
@@ -1669,6 +1687,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     };
     lobbyRoomSummaries.set(this.metadata.logicalRoomId, summary);
     recordRuntimeRoom(summary);
+    flushPendingConfigUpdate();
   }
 
   private refreshEmptyRoomTracking(now = roomRuntimeDependencies.now()): void {
@@ -1732,6 +1751,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       lobbyRoomSummaries.delete(this.metadata.logicalRoomId);
       removeRuntimeRoom(this.metadata.logicalRoomId);
     }
+
+    flushPendingConfigUpdate();
   }
 
   private hasPlayerBeenDisconnectedLongEnough(playerId: string): boolean {

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -53,6 +53,7 @@ import {
   readMySqlPersistenceConfig
 } from "./persistence";
 import { createTrackedMySqlPool } from "./mysql-pool";
+import { countRuntimeErrorEventsSince } from "./observability";
 
 export type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
 
@@ -463,9 +464,50 @@ interface JsonSchemaNode {
   minItems?: number;
 }
 
+interface ConfigHotReloadRoomState {
+  roomId: string;
+  activeBattles: number;
+}
+
+interface ConfigHotReloadRuntimeSnapshot {
+  rooms: ConfigHotReloadRoomState[];
+  activeBattleCount: number;
+}
+
+interface ConfigCenterTimerHandle {
+  unref?(): void;
+}
+
+interface ConfigCenterRuntimeDependencies {
+  now(): number;
+  setTimeout(handler: () => void, delayMs: number): ConfigCenterTimerHandle;
+  clearTimeout(handle: ConfigCenterTimerHandle): void;
+}
+
+interface ConfigRuntimeApplyResult {
+  status: "applied" | "pending";
+  message: string;
+}
+
+interface PendingRuntimeBundleState {
+  bundle: RuntimeConfigBundle;
+  queuedAt: string;
+  previousBundle: RuntimeConfigBundle | null;
+  delayedRooms: ConfigHotReloadRoomState[];
+}
+
+interface ConfigRollbackMonitorState {
+  previousBundle: RuntimeConfigBundle;
+  appliedAtMs: number;
+  appliedAt: string;
+  handle: ConfigCenterTimerHandle;
+}
+
 const CONFIG_CENTER_LIBRARY_FILE = ".config-center-library.json";
 const MAX_STAGE_DOCUMENTS = 5;
 const MAX_PUBLISH_HISTORY_ENTRIES = 20;
+const CONFIG_HOT_RELOAD_MONITOR_WINDOW_MS = 30_000;
+const CONFIG_HOT_RELOAD_ERROR_THRESHOLD = 3;
 const BUILTIN_DIFFICULTY_PRESET_IDS = ["easy", "normal", "hard"] as const;
 const BUILTIN_WORLD_LAYOUT_PRESETS = [
   "layout_phase1",
@@ -2228,6 +2270,156 @@ function buildRuntimeConfigBundle(
 }
 
 const configUpdateListeners = new Set<(bundle: RuntimeConfigBundle) => void>();
+const defaultConfigCenterRuntimeDependencies: ConfigCenterRuntimeDependencies = {
+  now: () => Date.now(),
+  setTimeout: (handler, delayMs) => globalThis.setTimeout(handler, delayMs),
+  clearTimeout: (handle) => globalThis.clearTimeout(handle as ReturnType<typeof globalThis.setTimeout>)
+};
+
+let configCenterRuntimeDependencies = defaultConfigCenterRuntimeDependencies;
+let configHotReloadRuntimeSnapshotProvider: () => ConfigHotReloadRuntimeSnapshot = () => ({
+  rooms: [],
+  activeBattleCount: 0
+});
+let appliedRuntimeBundle: RuntimeConfigBundle | null = null;
+let pendingRuntimeBundleState: PendingRuntimeBundleState | null = null;
+let configRollbackMonitorState: ConfigRollbackMonitorState | null = null;
+let lastConfigRuntimeApplyResult: ConfigRuntimeApplyResult | null = null;
+
+function serializeBundleDocument(bundle: RuntimeConfigBundle, id: ConfigDocumentId): string {
+  return normalizeJsonContent(contentForDocumentId(bundle, id));
+}
+
+function runtimeRoomsWithActiveBattles(): ConfigHotReloadRoomState[] {
+  const snapshot = configHotReloadRuntimeSnapshotProvider();
+  return snapshot.rooms.filter((room) => room.activeBattles > 0);
+}
+
+function clearConfigRollbackMonitor(): void {
+  if (!configRollbackMonitorState) {
+    return;
+  }
+
+  configCenterRuntimeDependencies.clearTimeout(configRollbackMonitorState.handle);
+  configRollbackMonitorState = null;
+}
+
+function notifyConfigUpdateListeners(bundle: RuntimeConfigBundle): void {
+  for (const listener of configUpdateListeners) {
+    try {
+      listener(bundle);
+    } catch (error) {
+      console.error("[config-center] Error notifying config update listener", error);
+    }
+  }
+}
+
+function rollbackRuntimeBundleIfNeeded(): void {
+  if (!configRollbackMonitorState) {
+    return;
+  }
+
+  const monitor = configRollbackMonitorState;
+  configRollbackMonitorState = null;
+  const recentErrorCount = countRuntimeErrorEventsSince(monitor.appliedAtMs, {
+    ownerArea: "multiplayer",
+    severity: "error"
+  });
+  if (recentErrorCount < CONFIG_HOT_RELOAD_ERROR_THRESHOLD) {
+    return;
+  }
+
+  pendingRuntimeBundleState = null;
+  appliedRuntimeBundle = monitor.previousBundle;
+  replaceRuntimeConfigs(monitor.previousBundle);
+  notifyConfigUpdateListeners(monitor.previousBundle);
+  lastConfigRuntimeApplyResult = {
+    status: "applied",
+    message: `热更新后 30 秒内捕获 ${recentErrorCount} 个房间错误，已自动回滚到上一版本。`
+  };
+  console.error("[config-center] Rolled back config hot reload after runtime error spike", {
+    appliedAt: monitor.appliedAt,
+    recentErrorCount
+  });
+}
+
+function startConfigRollbackMonitor(previousBundle: RuntimeConfigBundle | null): void {
+  clearConfigRollbackMonitor();
+  if (!previousBundle) {
+    return;
+  }
+
+  const appliedAtMs = configCenterRuntimeDependencies.now();
+  const handle = configCenterRuntimeDependencies.setTimeout(
+    () => rollbackRuntimeBundleIfNeeded(),
+    CONFIG_HOT_RELOAD_MONITOR_WINDOW_MS
+  );
+  handle.unref?.();
+  configRollbackMonitorState = {
+    previousBundle,
+    appliedAtMs,
+    appliedAt: new Date(appliedAtMs).toISOString(),
+    handle
+  };
+}
+
+function assertRuntimeBundleHotReloadCompatible(bundle: RuntimeConfigBundle): void {
+  if (!appliedRuntimeBundle) {
+    return;
+  }
+
+  const currentBundle = appliedRuntimeBundle;
+  const incompatibleEntries = (["world", "mapObjects", "units", "battleSkills", "battleBalance"] as const)
+    .flatMap((documentId) =>
+      buildConfigDiffEntries(
+        documentId,
+        serializeBundleDocument(currentBundle, documentId),
+        serializeBundleDocument(bundle, documentId)
+      )
+        .filter((entry) => ["field_removed", "type_changed", "enum_changed"].includes(entry.kind))
+        .map((entry) => ({ documentId, entry }))
+    );
+
+  if (incompatibleEntries.length === 0) {
+    return;
+  }
+
+  const summary = incompatibleEntries
+    .slice(0, 3)
+    .map(({ documentId, entry }) => `${documentId}.${entry.path} (${entry.kind})`)
+    .join("、");
+  throw new Error(`配置热更新被拒绝：检测到不兼容的 Schema 变更：${summary}`);
+}
+
+function applyRuntimeBundle(bundle: RuntimeConfigBundle): ConfigRuntimeApplyResult {
+  const roomsWithActiveBattles = runtimeRoomsWithActiveBattles();
+  if (roomsWithActiveBattles.length > 0) {
+    pendingRuntimeBundleState = {
+      bundle,
+      queuedAt: new Date(configCenterRuntimeDependencies.now()).toISOString(),
+      previousBundle: appliedRuntimeBundle,
+      delayedRooms: roomsWithActiveBattles
+    };
+    clearConfigRollbackMonitor();
+    lastConfigRuntimeApplyResult = {
+      status: "pending",
+      message: `检测到 ${roomsWithActiveBattles.length} 个进行中房间，配置已延迟到战斗结束后应用。`
+    };
+    return lastConfigRuntimeApplyResult;
+  }
+
+  pendingRuntimeBundleState = null;
+  const previousBundle = appliedRuntimeBundle;
+  appliedRuntimeBundle = bundle;
+  replaceRuntimeConfigs(bundle);
+  notifyConfigUpdateListeners(bundle);
+  startConfigRollbackMonitor(previousBundle);
+  lastConfigRuntimeApplyResult = {
+    status: "applied",
+    message: "运行时配置已刷新。"
+  };
+  return lastConfigRuntimeApplyResult;
+}
 
 export function registerConfigUpdateListener(
   callback: (bundle: RuntimeConfigBundle) => void
@@ -2238,15 +2430,53 @@ export function registerConfigUpdateListener(
   };
 }
 
-function applyRuntimeBundle(bundle: RuntimeConfigBundle): void {
-  replaceRuntimeConfigs(bundle);
-  for (const listener of configUpdateListeners) {
-    try {
-      listener(bundle);
-    } catch (error) {
-      console.error("[config-center] Error notifying config update listener", error);
-    }
+export function configureConfigRuntimeStatusProvider(provider: () => ConfigHotReloadRuntimeSnapshot): void {
+  configHotReloadRuntimeSnapshotProvider = provider;
+}
+
+export function configureConfigCenterRuntimeDependencies(overrides: Partial<ConfigCenterRuntimeDependencies>): void {
+  configCenterRuntimeDependencies = {
+    ...configCenterRuntimeDependencies,
+    ...overrides
+  };
+}
+
+export function resetConfigCenterRuntimeDependencies(): void {
+  clearConfigRollbackMonitor();
+  configCenterRuntimeDependencies = defaultConfigCenterRuntimeDependencies;
+}
+
+export function resetConfigHotReloadState(): void {
+  clearConfigRollbackMonitor();
+  pendingRuntimeBundleState = null;
+  appliedRuntimeBundle = null;
+  lastConfigRuntimeApplyResult = null;
+}
+
+export function flushPendingConfigUpdate(): ConfigRuntimeApplyResult | null {
+  if (!pendingRuntimeBundleState) {
+    return null;
   }
+
+  if (runtimeRoomsWithActiveBattles().length > 0) {
+    return lastConfigRuntimeApplyResult;
+  }
+
+  const pendingBundle = pendingRuntimeBundleState.bundle;
+  pendingRuntimeBundleState = null;
+  return applyRuntimeBundle(pendingBundle);
+}
+
+function synchronizePendingRuntimeBundle(bundle: RuntimeConfigBundle): void {
+  if (!pendingRuntimeBundleState) {
+    return;
+  }
+
+  pendingRuntimeBundleState.bundle = bundle;
+}
+
+function currentConfigRuntimeApplyResult(): ConfigRuntimeApplyResult | null {
+  return lastConfigRuntimeApplyResult;
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
@@ -2881,7 +3111,15 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
       ) as Partial<RuntimeConfigBundle>
     );
 
-    applyRuntimeBundle(bundle);
+    clearConfigRollbackMonitor();
+    pendingRuntimeBundleState = null;
+    appliedRuntimeBundle = bundle;
+    replaceRuntimeConfigs(bundle);
+    notifyConfigUpdateListeners(bundle);
+    lastConfigRuntimeApplyResult = {
+      status: "applied",
+      message: "运行时配置已初始化。"
+    };
     await Promise.all([
       this.exportDocumentToFile("world", normalizeJsonContent(bundle.world)),
       this.exportDocumentToFile("mapObjects", normalizeJsonContent(bundle.mapObjects)),
@@ -3068,6 +3306,10 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
           diffEntries
         )
       });
+
+      assertRuntimeBundleHotReloadCompatible(
+        buildRuntimeBundleWithParsedDocument(stagedDocument.id, parseConfigDocument(stagedDocument.id, stagedDocument.content))
+      );
     }
 
     try {
@@ -3081,8 +3323,6 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         const toVersion = saved.version ?? auditChange.fromVersion;
 
         auditChange.toVersion = toVersion;
-        auditChange.runtimeStatus = "applied";
-        auditChange.runtimeMessage = "运行时已刷新";
         publishChanges.push({
           documentId: auditChange.documentId,
           title: auditChange.title,
@@ -3106,6 +3346,19 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         });
       }
 
+      if (auditChanges.length > 1 && currentConfigRuntimeApplyResult()?.status === "pending") {
+        synchronizePendingRuntimeBundle(await this.loadRuntimeBundleFromStore());
+      }
+
+      const runtimeApplyResult = currentConfigRuntimeApplyResult();
+      const runtimeStatus = runtimeApplyResult?.status === "pending" ? "pending" : "applied";
+      const runtimeMessage =
+        runtimeApplyResult?.message ?? (runtimeStatus === "pending" ? "等待运行时应用" : "运行时已刷新");
+      for (const auditChange of auditChanges) {
+        auditChange.runtimeStatus = runtimeStatus;
+        auditChange.runtimeMessage = runtimeMessage;
+      }
+
       state.stagedDraft = null;
       state.publishHistory = state.publishHistory ?? {};
       for (const entry of historyEntries) {
@@ -3120,7 +3373,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         revision,
         publishedAt,
         resultStatus: "applied",
-        resultMessage: "运行时配置已刷新",
+        resultMessage: runtimeMessage,
         changes: auditChanges
       };
       state.publishAuditHistory = [appliedAuditEvent, ...(state.publishAuditHistory ?? [])].slice(
@@ -3333,6 +3586,15 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
   async importDocumentFromWorkbook(id: ConfigDocumentId, workbook: Buffer): Promise<ConfigDocument> {
     const content = parseWorkbookToContent(workbook);
     return this.saveDocument(id, content);
+  }
+
+  protected async loadRuntimeBundleFromStore(): Promise<RuntimeConfigBundle> {
+    const documents = await Promise.all(CONFIG_DEFINITIONS.map((definition) => this.loadDocument(definition.id)));
+    return buildRuntimeConfigBundle(
+      Object.fromEntries(
+        documents.map((document) => [document.id, parseConfigDocument(document.id, document.content)])
+      ) as Partial<RuntimeConfigBundle>
+    );
   }
 
   abstract loadDocument(id: ConfigDocumentId): Promise<ConfigDocument>;

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -1513,6 +1513,32 @@ export function recordRuntimeErrorEvent(
   );
 }
 
+export function countRuntimeErrorEventsSince(
+  sinceMs: number,
+  filters: Partial<Pick<RuntimeDiagnosticsErrorEvent, "featureArea" | "ownerArea" | "severity">> = {}
+): number {
+  return runtimeObservability.errorEvents.filter((event) => {
+    const recordedAtMs = Date.parse(event.recordedAt);
+    if (!Number.isFinite(recordedAtMs) || recordedAtMs < sinceMs) {
+      return false;
+    }
+
+    if (filters.featureArea && event.featureArea !== filters.featureArea) {
+      return false;
+    }
+
+    if (filters.ownerArea && event.ownerArea !== filters.ownerArea) {
+      return false;
+    }
+
+    if (filters.severity && event.severity !== filters.severity) {
+      return false;
+    }
+
+    return true;
+  }).length;
+}
+
 export function removeRuntimeRoom(roomId: string): void {
   runtimeObservability.rooms.delete(roomId);
 }

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -1,10 +1,22 @@
 import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { ClientState, matchMaker } from "colyseus";
 import type { Client } from "colyseus";
-import { applyEloMatchResult, decodePlayerWorldView } from "../../../packages/shared/src/index";
+import {
+  applyEloMatchResult,
+  createNeutralBattleState,
+  decodePlayerWorldView,
+  getBattleBalanceConfig,
+  getDefaultBattleSkillCatalog,
+  getDefaultWorldConfig,
+  resetRuntimeConfigs
+} from "../../../packages/shared/src/index";
 import type { BattleState, ServerMessage, WorldEvent } from "../../../packages/shared/src/index";
 import { resolveBattlePassConfig } from "../src/battle-pass";
+import { FileSystemConfigCenterStore, resetConfigHotReloadState } from "../src/config-center";
 import {
   VeilColyseusRoom,
   configureRoomRuntimeDependencies,
@@ -38,6 +50,11 @@ class InstrumentedRoomSnapshotStore extends MemoryRoomSnapshotStore {
     return super.savePlayerAccountProgress(playerId, patch);
   }
 }
+
+test.afterEach(() => {
+  resetConfigHotReloadState();
+  resetRuntimeConfigs();
+});
 
 class FailingBootstrapSaveStore extends MemoryRoomSnapshotStore {
   override async save(_roomId: string, _snapshot: RoomPersistenceSnapshot): Promise<void> {
@@ -132,6 +149,93 @@ function createManualRoomTimer(startAtMs = 0): {
       await flushAsyncWork();
     }
   };
+}
+
+const HOT_RELOAD_TEST_WORLD_CONFIG = {
+  width: 8,
+  height: 8,
+  heroes: [
+    {
+      id: "hero-1",
+      playerId: "player-1",
+      name: "凯琳",
+      position: { x: 1, y: 1 },
+      vision: 2,
+      move: { total: 6, remaining: 6 },
+      stats: {
+        attack: 2,
+        defense: 2,
+        power: 1,
+        knowledge: 1,
+        hp: 30,
+        maxHp: 30
+      },
+      progression: {
+        level: 1,
+        experience: 0,
+        battlesWon: 0,
+        neutralBattlesWon: 0,
+        pvpBattlesWon: 0
+      },
+      armyTemplateId: "hero_guard_basic",
+      armyCount: 24
+    }
+  ],
+  resourceSpawn: {
+    goldChance: 0.06,
+    woodChance: 0.06,
+    oreChance: 0.06
+  }
+};
+
+const HOT_RELOAD_TEST_MAP_OBJECTS_CONFIG = {
+  neutralArmies: [
+    {
+      id: "neutral-1",
+      position: { x: 5, y: 4 },
+      reward: { kind: "gold" as const, amount: 300 },
+      stacks: [{ templateId: "wolf_pack", count: 1 }]
+    }
+  ],
+  guaranteedResources: [],
+  buildings: []
+};
+
+const HOT_RELOAD_TEST_UNIT_CONFIG = {
+  templates: [
+    {
+      id: "hero_guard_basic",
+      stackName: "枪兵",
+      faction: "crown",
+      rarity: "common",
+      initiative: 6,
+      attack: 4,
+      defense: 4,
+      minDamage: 1,
+      maxDamage: 3,
+      maxHp: 10
+    },
+    {
+      id: "wolf_pack",
+      stackName: "恶狼",
+      faction: "wild",
+      rarity: "common",
+      initiative: 8,
+      attack: 5,
+      defense: 3,
+      minDamage: 2,
+      maxDamage: 4,
+      maxHp: 7
+    }
+  ]
+};
+
+async function seedConfigRootFromRuntime(rootDir: string): Promise<void> {
+  await writeFile(join(rootDir, "phase1-world.json"), `${JSON.stringify(HOT_RELOAD_TEST_WORLD_CONFIG, null, 2)}\n`, "utf8");
+  await writeFile(join(rootDir, "phase1-map-objects.json"), `${JSON.stringify(HOT_RELOAD_TEST_MAP_OBJECTS_CONFIG, null, 2)}\n`, "utf8");
+  await writeFile(join(rootDir, "units.json"), `${JSON.stringify(HOT_RELOAD_TEST_UNIT_CONFIG, null, 2)}\n`, "utf8");
+  await writeFile(join(rootDir, "battle-skills.json"), `${JSON.stringify(getDefaultBattleSkillCatalog(), null, 2)}\n`, "utf8");
+  await writeFile(join(rootDir, "battle-balance.json"), `${JSON.stringify(getBattleBalanceConfig(), null, 2)}\n`, "utf8");
 }
 
 async function createTestRoom(logicalRoomId: string, seed = 1001): Promise<VeilColyseusRoom> {
@@ -1166,6 +1270,66 @@ test("battle replay persistence runs once at settlement and is drained from the 
   assert.equal(replaySaves.length, 1);
   assert.equal(replaySaves[0]?.patch.recentBattleReplays?.[0]?.id, replay?.id);
   assert.deepEqual(internalRoom.worldRoom.consumeCompletedBattleReplays(), []);
+});
+
+test("config hot reload waits for an in-progress battle before notifying the room", async (t) => {
+  resetLobbyRoomRegistry();
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-hot-reload-"));
+  await seedConfigRootFromRuntime(rootDir);
+  const configStore = new FileSystemConfigCenterStore(rootDir);
+  await configStore.initializeRuntimeConfigs();
+  const baselineWidth = getDefaultWorldConfig().width;
+  const logicalRoomId = `lifecycle-config-hot-reload-${Date.now()}`;
+  const seededBattleRoom = createRoom(logicalRoomId, 1001);
+  const seededState = seededBattleRoom.getInternalState();
+  const hero = seededState.heroes.find((entry) => entry.playerId === "player-1");
+  const neutralArmy = Object.values(seededState.neutralArmies)[0];
+  assert.ok(hero);
+  assert.ok(neutralArmy);
+  const seededBattle = createNeutralBattleState(hero, neutralArmy, 1001, seededState);
+
+  const snapshotStore = new MemoryRoomSnapshotStore();
+  await snapshotStore.save(logicalRoomId, {
+    state: seededState,
+    battles: [seededBattle]
+  });
+  configureRoomSnapshotStore(snapshotStore);
+
+  const room = await createTestRoom(logicalRoomId);
+  const client = createFakeClient("session-config-hot-reload");
+  const internalRoom = room as VeilColyseusRoom & {
+    worldRoom: ReturnType<typeof createRoom>;
+    publishLobbyRoomSummary(): void;
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, client, "player-1", "connect-config-hot-reload");
+  assert.ok(getBattleForPlayer(room, "player-1"));
+
+  await configStore.saveDocument(
+    "world",
+    JSON.stringify({
+      ...getDefaultWorldConfig(),
+      width: baselineWidth + 2
+    })
+  );
+
+  assert.equal(getDefaultWorldConfig().width, baselineWidth);
+  assert.equal(client.sent.filter((message) => message.type === "config.update").length, 0);
+
+  internalRoom.worldRoom = createRoom(logicalRoomId, 1001, {
+    state: structuredClone(internalRoom.worldRoom.getInternalState()),
+    battles: []
+  });
+  internalRoom.publishLobbyRoomSummary();
+
+  assert.equal(getDefaultWorldConfig().width, baselineWidth + 2);
+  assert.equal(client.sent.filter((message) => message.type === "config.update").length, 1);
 });
 
 test("battle settlement increments lifecycle completion metrics", async (t) => {

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -11,10 +11,16 @@ import {
   resetRuntimeConfigs
 } from "../../../packages/shared/src/index";
 import {
+  configureConfigCenterRuntimeDependencies,
+  configureConfigRuntimeStatusProvider,
   createWorldConfigPreview,
-  FileSystemConfigCenterStore
+  FileSystemConfigCenterStore,
+  flushPendingConfigUpdate,
+  resetConfigCenterRuntimeDependencies,
+  resetConfigHotReloadState
 } from "../src/config-center";
 import type { WorldConfigPreview } from "../src/config-center";
+import { recordRuntimeErrorEvent, resetRuntimeObservability } from "../src/observability";
 
 const WORLD_CONFIG = {
   width: 8,
@@ -169,6 +175,13 @@ async function seedConfigRoot(rootDir: string): Promise<void> {
 
 test.afterEach(() => {
   resetRuntimeConfigs();
+  resetConfigHotReloadState();
+  resetConfigCenterRuntimeDependencies();
+  configureConfigRuntimeStatusProvider(() => ({
+    rooms: [],
+    activeBattleCount: 0
+  }));
+  resetRuntimeObservability();
 });
 
 test("config center lists seeded config documents", async () => {
@@ -764,4 +777,118 @@ test("config center staged publish blocks invalid drafts", async () => {
     () => store.publishStagedDraft({ author: "Ops", summary: "bad publish" }),
     /未通过校验|修复/
   );
+});
+
+test("config center delays hot reload while battles are active and applies it once rooms are safe", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+  await store.initializeRuntimeConfigs();
+
+  let activeBattles = 1;
+  configureConfigRuntimeStatusProvider(() => ({
+    rooms: activeBattles > 0 ? [{ roomId: "room-battle", activeBattles }] : [],
+    activeBattleCount: activeBattles
+  }));
+
+  const nextWorld = {
+    ...WORLD_CONFIG,
+    width: 10
+  };
+
+  await store.saveDocument("world", JSON.stringify(nextWorld));
+  assert.equal(getDefaultWorldConfig().width, WORLD_CONFIG.width);
+
+  activeBattles = 0;
+  const result = flushPendingConfigUpdate();
+
+  assert.equal(result?.status, "applied");
+  assert.equal(getDefaultWorldConfig().width, 10);
+});
+
+test("config center rejects schema-incompatible staged publishes with an explicit error", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+  await store.initializeRuntimeConfigs();
+
+  const incompatibleBalance = {
+    ...BATTLE_BALANCE_CONFIG,
+    environment: {
+      ...BATTLE_BALANCE_CONFIG.environment
+    }
+  } as typeof BATTLE_BALANCE_CONFIG & {
+    environment: Omit<typeof BATTLE_BALANCE_CONFIG.environment, "trapGrantedStatusId">;
+  };
+  delete incompatibleBalance.environment.trapGrantedStatusId;
+
+  await store.saveStagedDraft([
+    {
+      id: "battleBalance",
+      content: JSON.stringify(incompatibleBalance)
+    }
+  ]);
+
+  await assert.rejects(
+    () => store.publishStagedDraft({ author: "Ops", summary: "incompatible hot reload" }),
+    /不兼容的 Schema 变更/
+  );
+});
+
+test("config center rolls back hot reloads after a room error spike within the safety window", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+  await store.initializeRuntimeConfigs();
+
+  let scheduledHandler: (() => void) | null = null;
+  const baselineMs = Date.parse("2026-04-11T16:15:00.000Z");
+  configureConfigCenterRuntimeDependencies({
+    now: () => baselineMs,
+    setTimeout: (handler) => {
+      scheduledHandler = handler;
+      return {};
+    },
+    clearTimeout: () => {
+      scheduledHandler = null;
+    }
+  });
+
+  await store.saveDocument(
+    "world",
+    JSON.stringify({
+      ...WORLD_CONFIG,
+      width: 10
+    })
+  );
+  assert.equal(getDefaultWorldConfig().width, 10);
+  assert.ok(scheduledHandler);
+
+  for (let index = 0; index < 3; index += 1) {
+    recordRuntimeErrorEvent({
+      id: `hot-reload-error-${index}`,
+      recordedAt: new Date(baselineMs + 1_000 + index).toISOString(),
+      source: "server",
+      surface: "server",
+      candidateRevision: "workspace",
+      featureArea: "runtime",
+      ownerArea: "multiplayer",
+      severity: "error",
+      errorCode: "room_hot_reload_crash",
+      message: "Synthetic room crash after hot reload.",
+      context: {
+        roomId: `room-${index}`,
+        playerId: null,
+        requestId: null,
+        route: null,
+        action: null,
+        statusCode: null,
+        crash: true,
+        detail: "test spike"
+      }
+    });
+  }
+
+  scheduledHandler?.();
+  assert.equal(getDefaultWorldConfig().width, WORLD_CONFIG.width);
 });

--- a/docs/config-deployment-safety.md
+++ b/docs/config-deployment-safety.md
@@ -1,0 +1,22 @@
+# Config Deployment Safety
+
+Use config hot reload only inside a planned safety window. The current runtime behavior is:
+
+- schema-incompatible hot reloads are rejected before persistence with an explicit error
+- compatible updates are delayed while any room still has an in-progress battle
+- once the update applies, the server watches the next 30 seconds for multiplayer runtime error spikes and rolls back automatically if the threshold is crossed
+
+Recommended operator workflow:
+
+1. Prefer the low-traffic deployment window between 03:00 and 05:00 local server time.
+2. Confirm no high-priority live event, tournament, or guided playtest is running.
+3. Check active room count and active battle count before publishing.
+4. Publish config changes through Config Center staged publish rather than ad hoc file edits.
+5. Watch room/runtime errors for at least 30 seconds after the update clears the battle gate.
+6. If the publish remains pending because battles are still active, wait for settlement instead of forcing a room restart.
+
+Rollback guidance:
+
+- treat repeated room retirement, reconnect failure, or battle abort errors during the 30 second watch window as a release blocker
+- if auto-rollback triggers, stop further config publishes until the failing diff is isolated
+- capture the rejected or rolled-back publish id in the release calendar so the next window starts from the last known good snapshot

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -8,6 +8,8 @@ If you want a single human-readable Phase 1 dashboard on top of the snapshot plu
 
 If you want a CI-oriented pass/fail summary that also folds in packaged H5 smoke and WeChat release evidence, use `npm run release:gate:summary` and see `docs/release-gate-summary.md`.
 
+For config publishes, follow [`docs/config-deployment-safety.md`](./config-deployment-safety.md): prefer the 03:00-05:00 low-traffic window, verify active battles are drained or allow the runtime gate to defer the apply, and watch the 30 second rollback window before treating the deploy as complete.
+
 The default automated checks are:
 
 - `npm test`


### PR DESCRIPTION
## Summary
- add a config hot-reload safety gate that queues compatible runtime updates while active battles are in progress and flushes them once rooms go idle
- reject schema-incompatible staged config publishes with explicit errors and auto-rollback applied updates when multiplayer runtime errors spike inside the 30 second watch window
- document the deployment safety window and add server tests for delayed apply, incompatibility rejection, rollback, and the in-progress battle room flow

## Validation
- `node --import tsx --test ./apps/server/test/config-center.test.ts`
- `node --import tsx --test --test-name-pattern "config hot reload waits for an in-progress battle before notifying the room" ./apps/server/test/colyseus-room-lifecycle.test.ts`
- `npm run typecheck:server`

Closes #1225