### PR TITLE
[codex] ops: leaderboard anti-abuse controls

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -5,6 +5,7 @@ import type { ResourceLedger, ServerMessage, WorldState } from "../../../package
 import { GuildService } from "./guilds";
 import type { PlayerReportResolveInput, PlayerReportStatus, RoomSnapshotStore } from "./persistence";
 import { listLobbyRooms, getActiveRoomInstances } from "./colyseus-room";
+import { recordLeaderboardAbuseAlert } from "./observability";
 
 class InvalidAdminJsonError extends Error {
   constructor() {
@@ -162,6 +163,12 @@ function hasGuildModerationStore(
       store.appendGuildAuditLog &&
       store.listGuildAuditLogs
   );
+}
+
+function hasPlayerAccountStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "loadPlayerAccount" | "savePlayerAccountProgress">> {
+  return Boolean(store?.loadPlayerAccount && store.savePlayerAccountProgress);
 }
 
 function sendInvalidJson(response: ServerResponse): void {
@@ -731,6 +738,76 @@ export function registerAdminRoutes(
         }
       });
     } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/players/:id/leaderboard/freeze", async (request, response) => {
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
+    if (!hasPlayerAccountStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request, "id");
+      const input = parseGuildModerationBody(await readJsonBody(request));
+      const account = (await store.loadPlayerAccount(playerId)) ?? (await store.ensurePlayerAccount({ playerId }));
+      const leaderboardModerationState = {
+        ...(account.leaderboardModerationState ?? {}),
+        frozenAt: new Date().toISOString(),
+        frozenByPlayerId: `${role}:admin-console`,
+        ...(input.reason ? { freezeReason: input.reason } : {})
+      };
+      const updatedAccount = await store.savePlayerAccountProgress(playerId, {
+        leaderboardModerationState
+      });
+      recordLeaderboardAbuseAlert({
+        type: "leaderboard_frozen_player_match",
+        playerId,
+        at: leaderboardModerationState.frozenAt,
+        detail: `Leaderboard frozen by ${role}:admin-console${input.reason ? ` (${input.reason})` : ""}.`
+      });
+      sendJson(response, 200, { ok: true, account: updatedAccount });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/players/:id/leaderboard/remove", async (request, response) => {
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
+    if (!hasPlayerAccountStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request, "id");
+      const input = parseGuildModerationBody(await readJsonBody(request));
+      const account = (await store.loadPlayerAccount(playerId)) ?? (await store.ensurePlayerAccount({ playerId }));
+      const leaderboardModerationState = {
+        ...(account.leaderboardModerationState ?? {}),
+        hiddenAt: new Date().toISOString(),
+        hiddenByPlayerId: `${role}:admin-console`,
+        ...(input.reason ? { hiddenReason: input.reason } : {})
+      };
+      const updatedAccount = await store.savePlayerAccountProgress(playerId, {
+        leaderboardModerationState
+      });
+      sendJson(response, 200, { ok: true, account: updatedAccount });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
       if (error instanceof InvalidAdminPayloadError) {
         sendInvalidPayload(response, error.message);
         return;

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -1,7 +1,6 @@
 import { CloseCode } from "@colyseus/shared-types";
 import { Room, type Client as ColyseusClient } from "colyseus";
 import {
-  applyEloMatchResult,
   classifyReconnectFailure,
   DEFAULT_MIN_SUPPORTED_CLIENT_VERSION,
   isClientVersionSupported,
@@ -54,6 +53,7 @@ import { resolveGuestAuthSession } from "./auth";
 import { deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
 import {
   recordBattleActionMessage,
+  recordLeaderboardAbuseAlert,
   recordBattleLifecycleResolved,
   recordConnectMessage,
   recordRoomCreated,
@@ -69,6 +69,7 @@ import {
 } from "./observability";
 import { sendWechatSubscribeMessage, type WechatSubscribeTemplateKey } from "./wechat-subscribe";
 import { resolveFeatureFlagsForPlayer } from "./feature-flags";
+import { settleLeaderboardMatch } from "./leaderboard-anti-abuse";
 
 type MessageOfType<T extends ServerMessage["type"]> = Omit<Extract<ServerMessage, { type: T }>, "type">;
 
@@ -1378,23 +1379,58 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     const accounts = await store.loadPlayerAccounts(playerIds);
     const battlePassConfig = resolveBattlePassConfig();
 
-    // Compute ELO updates for PVP (hero vs hero) battles
-    const eloUpdates = new Map<string, number>();
+    // Compute ELO updates for PVP (hero vs hero) battles with anti-abuse caps.
+    const accountStateByPlayerId = new Map(accounts.map((account) => [account.playerId, account] as const));
+    const eloUpdates = new Map<string, { eloRating: number; leaderboardAbuseState?: PlayerAccountSnapshot["leaderboardAbuseState"] }>();
     for (const replay of completedReplays) {
       if (!replay.defenderPlayerId) continue;
       const attackerPlayerId = replay.attackerPlayerId;
       const defenderPlayerId = replay.defenderPlayerId;
-      const attackerAccount = accounts.find((a) => a.playerId === attackerPlayerId);
-      const defenderAccount = accounts.find((a) => a.playerId === defenderPlayerId);
-      const attackerRating = normalizeEloRating(attackerAccount?.eloRating);
-      const defenderRating = normalizeEloRating(defenderAccount?.eloRating);
+      const attackerAccount = accountStateByPlayerId.get(attackerPlayerId);
+      const defenderAccount = accountStateByPlayerId.get(defenderPlayerId);
       const attackerWon = replay.result === "attacker_victory";
-      const { winnerRating, loserRating } = applyEloMatchResult(
-        attackerWon ? attackerRating : defenderRating,
-        attackerWon ? defenderRating : attackerRating
-      );
-      eloUpdates.set(attackerPlayerId, attackerWon ? winnerRating : loserRating);
-      eloUpdates.set(defenderPlayerId, attackerWon ? loserRating : winnerRating);
+      const winnerPlayerId = attackerWon ? attackerPlayerId : defenderPlayerId;
+      const loserPlayerId = attackerWon ? defenderPlayerId : attackerPlayerId;
+      const winnerAccount = attackerWon ? attackerAccount : defenderAccount;
+      const loserAccount = attackerWon ? defenderAccount : attackerAccount;
+      const settlement = settleLeaderboardMatch({
+        winner: {
+          playerId: winnerPlayerId,
+          eloRating: normalizeEloRating(winnerAccount?.eloRating),
+          leaderboardAbuseState: winnerAccount?.leaderboardAbuseState,
+          leaderboardModerationState: winnerAccount?.leaderboardModerationState
+        },
+        loser: {
+          playerId: loserPlayerId,
+          eloRating: normalizeEloRating(loserAccount?.eloRating),
+          leaderboardAbuseState: loserAccount?.leaderboardAbuseState,
+          leaderboardModerationState: loserAccount?.leaderboardModerationState
+        }
+      });
+      for (const alert of settlement.alerts) {
+        recordLeaderboardAbuseAlert(alert);
+      }
+
+      const nextWinnerAccount = {
+        ...(winnerAccount ?? { playerId: winnerPlayerId }),
+        eloRating: settlement.winnerRating,
+        leaderboardAbuseState: settlement.winnerAbuseState
+      } as PlayerAccountSnapshot;
+      const nextLoserAccount = {
+        ...(loserAccount ?? { playerId: loserPlayerId }),
+        eloRating: settlement.loserRating,
+        leaderboardAbuseState: settlement.loserAbuseState
+      } as PlayerAccountSnapshot;
+      accountStateByPlayerId.set(winnerPlayerId, nextWinnerAccount);
+      accountStateByPlayerId.set(loserPlayerId, nextLoserAccount);
+      eloUpdates.set(winnerPlayerId, {
+        eloRating: settlement.winnerRating,
+        leaderboardAbuseState: settlement.winnerAbuseState
+      });
+      eloUpdates.set(loserPlayerId, {
+        eloRating: settlement.loserRating,
+        leaderboardAbuseState: settlement.loserAbuseState
+      });
     }
 
     try {
@@ -1416,7 +1452,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
             applyPlayerEventLogAndAchievements(existingAccount, internalState, playerEvents),
             playerReplays
           );
-          const eloRating = eloUpdates.get(playerId);
+          const eloUpdate = eloUpdates.get(playerId);
           const seasonXpDelta = completedReplays
             .filter((replay) => replay.attackerPlayerId === playerId || replay.defenderPlayerId === playerId)
             .reduce(
@@ -1431,7 +1467,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
             achievements: nextAccount.achievements,
             recentEventLog: nextAccount.recentEventLog,
             ...(playerReplays.length > 0 ? { recentBattleReplays: nextAccount.recentBattleReplays } : {}),
-            ...(eloRating !== undefined ? { eloRating } : {}),
+            ...(eloUpdate ? { eloRating: eloUpdate.eloRating, leaderboardAbuseState: eloUpdate.leaderboardAbuseState } : {}),
             ...(seasonXpDelta > 0 ? { seasonXpDelta } : {}),
             lastRoomId: this.metadata.logicalRoomId
           });
@@ -1510,18 +1546,33 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       const accounts = await store.loadPlayerAccounts([winnerPlayerId, loserPlayerId]);
       const winnerAccount = accounts.find((account) => account.playerId === winnerPlayerId);
       const loserAccount = accounts.find((account) => account.playerId === loserPlayerId);
-      const { winnerRating, loserRating } = applyEloMatchResult(
-        normalizeEloRating(winnerAccount?.eloRating),
-        normalizeEloRating(loserAccount?.eloRating)
-      );
+      const settlement = settleLeaderboardMatch({
+        winner: {
+          playerId: winnerPlayerId,
+          eloRating: normalizeEloRating(winnerAccount?.eloRating),
+          leaderboardAbuseState: winnerAccount?.leaderboardAbuseState,
+          leaderboardModerationState: winnerAccount?.leaderboardModerationState
+        },
+        loser: {
+          playerId: loserPlayerId,
+          eloRating: normalizeEloRating(loserAccount?.eloRating),
+          leaderboardAbuseState: loserAccount?.leaderboardAbuseState,
+          leaderboardModerationState: loserAccount?.leaderboardModerationState
+        }
+      });
+      for (const alert of settlement.alerts) {
+        recordLeaderboardAbuseAlert(alert);
+      }
 
       await Promise.all([
         store.savePlayerAccountProgress(winnerPlayerId, {
-          eloRating: winnerRating,
+          eloRating: settlement.winnerRating,
+          leaderboardAbuseState: settlement.winnerAbuseState,
           lastRoomId: this.metadata.logicalRoomId
         }),
         store.savePlayerAccountProgress(loserPlayerId, {
-          eloRating: loserRating,
+          eloRating: settlement.loserRating,
+          leaderboardAbuseState: settlement.loserAbuseState,
           lastRoomId: this.metadata.logicalRoomId
         })
       ]);

--- a/apps/server/src/leaderboard-anti-abuse.ts
+++ b/apps/server/src/leaderboard-anti-abuse.ts
@@ -1,0 +1,198 @@
+import { applyEloMatchResult, type LeaderboardAbuseState, type LeaderboardModerationState } from "../../../packages/shared/src/index";
+
+export const LEADERBOARD_DAILY_ELO_GAIN_LIMIT = 120;
+export const LEADERBOARD_REPEATED_OPPONENT_ELO_GAIN_LIMIT = 40;
+export const LEADERBOARD_REPEATED_OPPONENT_ALERT_THRESHOLD = 4;
+const MAX_TRACKED_OPPONENTS = 12;
+
+export interface LeaderboardAlertEvent {
+  type:
+    | "leaderboard_daily_gain_cap"
+    | "leaderboard_repeated_opponent_gain_cap"
+    | "leaderboard_repeated_opponent_watch"
+    | "leaderboard_frozen_player_match";
+  playerId: string;
+  opponentPlayerId?: string;
+  at: string;
+  detail: string;
+}
+
+interface LeaderboardAccountSettlementInput {
+  playerId: string;
+  eloRating?: number | undefined;
+  leaderboardAbuseState?: LeaderboardAbuseState | undefined;
+  leaderboardModerationState?: LeaderboardModerationState | undefined;
+}
+
+export interface LeaderboardSettlementResult {
+  winnerRating: number;
+  loserRating: number;
+  winnerAbuseState: LeaderboardAbuseState | undefined;
+  loserAbuseState: LeaderboardAbuseState | undefined;
+  alerts: LeaderboardAlertEvent[];
+  capped: boolean;
+}
+
+function dayKey(at: string): string {
+  return at.slice(0, 10);
+}
+
+function cloneAbuseState(state?: LeaderboardAbuseState): LeaderboardAbuseState {
+  return structuredClone(state ?? {});
+}
+
+function resetDailyWindowIfNeeded(state: LeaderboardAbuseState, currentDay: string): LeaderboardAbuseState {
+  if (state.currentDay === currentDay) {
+    return state;
+  }
+
+  return {
+    ...state,
+    currentDay,
+    dailyEloGain: 0,
+    dailyEloLoss: 0
+  };
+}
+
+function updateOpponentLedger(
+  state: LeaderboardAbuseState,
+  opponentPlayerId: string,
+  at: string,
+  gainDelta: number,
+  lossDelta: number
+): LeaderboardAbuseState {
+  const existing = state.opponentStats ?? [];
+  const nextEntries = existing.filter((entry) => entry.opponentPlayerId !== opponentPlayerId);
+  const previous = existing.find((entry) => entry.opponentPlayerId === opponentPlayerId);
+  nextEntries.push({
+    opponentPlayerId,
+    matchCount: Math.max(0, Math.floor((previous?.matchCount ?? 0) + 1)),
+    eloGain: Math.max(0, Math.floor((previous?.eloGain ?? 0) + gainDelta)),
+    eloLoss: Math.max(0, Math.floor((previous?.eloLoss ?? 0) + lossDelta)),
+    lastPlayedAt: at
+  });
+  nextEntries.sort((left, right) => right.lastPlayedAt.localeCompare(left.lastPlayedAt));
+
+  return {
+    ...state,
+    opponentStats: nextEntries.slice(0, MAX_TRACKED_OPPONENTS)
+  };
+}
+
+function pushAlertReason(
+  state: LeaderboardAbuseState,
+  at: string,
+  reason: string,
+  elevatedStatus: "watch" | "flagged"
+): LeaderboardAbuseState {
+  const lastAlertReasons = Array.from(new Set([...(state.lastAlertReasons ?? []), reason])).slice(0, 8);
+
+  return {
+    ...state,
+    status: state.status === "flagged" || elevatedStatus === "flagged" ? "flagged" : "watch",
+    lastAlertAt: at,
+    lastAlertReasons
+  };
+}
+
+export function isLeaderboardFrozen(state?: LeaderboardModerationState | null): boolean {
+  return Boolean(state?.frozenAt);
+}
+
+export function isLeaderboardHidden(state?: LeaderboardModerationState | null): boolean {
+  return Boolean(state?.hiddenAt);
+}
+
+export function settleLeaderboardMatch(input: {
+  winner: LeaderboardAccountSettlementInput;
+  loser: LeaderboardAccountSettlementInput;
+  settledAt?: string;
+}): LeaderboardSettlementResult {
+  const settledAt = input.settledAt ?? new Date().toISOString();
+  const currentDay = dayKey(settledAt);
+  let winnerState = resetDailyWindowIfNeeded(cloneAbuseState(input.winner.leaderboardAbuseState), currentDay);
+  let loserState = resetDailyWindowIfNeeded(cloneAbuseState(input.loser.leaderboardAbuseState), currentDay);
+  const alerts: LeaderboardAlertEvent[] = [];
+  const winnerRating = Math.max(0, Math.floor(input.winner.eloRating ?? 1000));
+  const loserRating = Math.max(0, Math.floor(input.loser.eloRating ?? 1000));
+
+  if (isLeaderboardFrozen(input.winner.leaderboardModerationState) || isLeaderboardFrozen(input.loser.leaderboardModerationState)) {
+    const detail = `Leaderboard settlement skipped because ${input.winner.playerId} or ${input.loser.playerId} is frozen.`;
+    alerts.push({
+      type: "leaderboard_frozen_player_match",
+      playerId: input.winner.playerId,
+      opponentPlayerId: input.loser.playerId,
+      at: settledAt,
+      detail
+    });
+    return {
+      winnerRating,
+      loserRating,
+      winnerAbuseState: pushAlertReason(winnerState, settledAt, "frozen_match_skipped", "watch"),
+      loserAbuseState: loserState,
+      alerts,
+      capped: true
+    };
+  }
+
+  const raw = applyEloMatchResult(winnerRating, loserRating);
+  const rawGain = Math.max(0, raw.winnerRating - winnerRating);
+  const remainingDailyGain = Math.max(0, LEADERBOARD_DAILY_ELO_GAIN_LIMIT - Math.max(0, winnerState.dailyEloGain ?? 0));
+  const previousOpponentWinner = winnerState.opponentStats?.find((entry) => entry.opponentPlayerId === input.loser.playerId);
+  const remainingOpponentGain = Math.max(
+    0,
+    LEADERBOARD_REPEATED_OPPONENT_ELO_GAIN_LIMIT - Math.max(0, previousOpponentWinner?.eloGain ?? 0)
+  );
+  const allowedGain = Math.max(0, Math.min(rawGain, remainingDailyGain, remainingOpponentGain));
+  const capped = allowedGain < rawGain;
+
+  if (allowedGain < rawGain && remainingDailyGain < rawGain) {
+    winnerState = pushAlertReason(winnerState, settledAt, "daily_gain_cap_hit", "flagged");
+    alerts.push({
+      type: "leaderboard_daily_gain_cap",
+      playerId: input.winner.playerId,
+      opponentPlayerId: input.loser.playerId,
+      at: settledAt,
+      detail: `Winner gain capped to ${allowedGain} because the daily ELO gain limit is ${LEADERBOARD_DAILY_ELO_GAIN_LIMIT}.`
+    });
+  }
+  if (allowedGain < rawGain && remainingOpponentGain < rawGain) {
+    winnerState = pushAlertReason(winnerState, settledAt, "repeated_opponent_gain_cap_hit", "flagged");
+    alerts.push({
+      type: "leaderboard_repeated_opponent_gain_cap",
+      playerId: input.winner.playerId,
+      opponentPlayerId: input.loser.playerId,
+      at: settledAt,
+      detail:
+        `Winner gain capped to ${allowedGain} because the repeated-opponent ELO gain limit is ` +
+        `${LEADERBOARD_REPEATED_OPPONENT_ELO_GAIN_LIMIT}.`
+    });
+  }
+
+  winnerState = updateOpponentLedger(winnerState, input.loser.playerId, settledAt, allowedGain, 0);
+  loserState = updateOpponentLedger(loserState, input.winner.playerId, settledAt, 0, allowedGain);
+  winnerState.dailyEloGain = Math.max(0, Math.floor((winnerState.dailyEloGain ?? 0) + allowedGain));
+  loserState.dailyEloLoss = Math.max(0, Math.floor((loserState.dailyEloLoss ?? 0) + allowedGain));
+
+  const winnerOpponentLedger = winnerState.opponentStats?.find((entry) => entry.opponentPlayerId === input.loser.playerId);
+  if ((winnerOpponentLedger?.matchCount ?? 0) >= LEADERBOARD_REPEATED_OPPONENT_ALERT_THRESHOLD) {
+    winnerState = pushAlertReason(winnerState, settledAt, "repeated_opponent_watch", "watch");
+    alerts.push({
+      type: "leaderboard_repeated_opponent_watch",
+      playerId: input.winner.playerId,
+      opponentPlayerId: input.loser.playerId,
+      at: settledAt,
+      detail:
+        `Winner has played ${winnerOpponentLedger?.matchCount ?? 0} settled matches against the same opponent in the active window.`
+    });
+  }
+
+  return {
+    winnerRating: winnerRating + allowedGain,
+    loserRating: loserRating - allowedGain,
+    winnerAbuseState: winnerState,
+    loserAbuseState: loserState,
+    alerts,
+    capped
+  };
+}

--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { getRankDivisionForRating, getTierForRating } from "../../../packages/shared/src/index";
 import { getCurrentAndPreviousWeeklyEntries } from "./competitive-season";
 import type { RoomSnapshotStore } from "./persistence";
+import { isLeaderboardFrozen, isLeaderboardHidden } from "./leaderboard-anti-abuse";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -59,15 +60,18 @@ export function registerLeaderboardRoutes(
       }
 
       const accounts = await store.listPlayerAccounts({ limit, orderBy: "eloRating" });
-      const players = accounts.map((account) => ({
+      const players = accounts
+        .filter((account) => !isLeaderboardHidden(account.leaderboardModerationState))
+        .map((account) => ({
         playerId: account.playerId,
         displayName: account.displayName,
         eloRating: account.eloRating,
         tier: getTierForRating(account.eloRating ?? 1000),
         division: account.rankDivision ?? getRankDivisionForRating(account.eloRating ?? 1000),
+        isFrozen: isLeaderboardFrozen(account.leaderboardModerationState),
         promotionSeries: account.promotionSeries ?? null,
         demotionShield: account.demotionShield ?? null
-      }));
+        }));
 
       sendJson(response, 200, { players });
     } catch (error) {
@@ -81,7 +85,9 @@ export function registerLeaderboardRoutes(
         sendJson(response, 200, { current: [], previous: [] });
         return;
       }
-      const accounts = await store.listPlayerAccounts({ limit: 500, orderBy: "eloRating" });
+      const accounts = (await store.listPlayerAccounts({ limit: 500, orderBy: "eloRating" })).filter(
+        (account) => !isLeaderboardHidden(account.leaderboardModerationState)
+      );
       const { current, previous } = getCurrentAndPreviousWeeklyEntries(accounts);
       sendJson(response, 200, { current, previous });
     } catch (error) {

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -512,6 +512,10 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       recentEventLog: existing?.recentEventLog ?? [],
       recentBattleReplays: existing?.recentBattleReplays ?? [],
       ...(existing?.dailyDungeonState ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) } : {}),
+      ...(existing?.leaderboardAbuseState ? { leaderboardAbuseState: structuredClone(existing.leaderboardAbuseState) } : {}),
+      ...(existing?.leaderboardModerationState
+        ? { leaderboardModerationState: structuredClone(existing.leaderboardModerationState) }
+        : {}),
       ...(existing?.tutorialStep !== undefined ? { tutorialStep: existing.tutorialStep } : { tutorialStep: DEFAULT_TUTORIAL_STEP }),
       ...(input.lastRoomId?.trim()
         ? { lastRoomId: input.lastRoomId.trim() }
@@ -1538,6 +1542,20 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         : existing.dailyDungeonState
           ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) }
           : {}),
+      ...(patch.leaderboardAbuseState !== undefined
+        ? patch.leaderboardAbuseState
+          ? { leaderboardAbuseState: structuredClone(patch.leaderboardAbuseState) }
+          : {}
+        : existing.leaderboardAbuseState
+          ? { leaderboardAbuseState: structuredClone(existing.leaderboardAbuseState) }
+          : {}),
+      ...(patch.leaderboardModerationState !== undefined
+        ? patch.leaderboardModerationState
+          ? { leaderboardModerationState: structuredClone(patch.leaderboardModerationState) }
+          : {}
+        : existing.leaderboardModerationState
+          ? { leaderboardModerationState: structuredClone(existing.leaderboardModerationState) }
+          : {}),
       ...(patch.tutorialStep !== undefined
         ? { tutorialStep: patch.tutorialStep }
         : existing.tutorialStep !== undefined
@@ -1677,6 +1695,10 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         achievements: structuredClone(previous?.achievements ?? account.achievements),
         recentEventLog: structuredClone(previous?.recentEventLog ?? account.recentEventLog),
         recentBattleReplays: structuredClone(previous?.recentBattleReplays ?? account.recentBattleReplays ?? []),
+        ...(previous?.leaderboardAbuseState ? { leaderboardAbuseState: structuredClone(previous.leaderboardAbuseState) } : {}),
+        ...(previous?.leaderboardModerationState
+          ? { leaderboardModerationState: structuredClone(previous.leaderboardModerationState) }
+          : {}),
         ...(previous?.ageVerified ? { ageVerified: previous.ageVerified } : {}),
         ...(previous?.isMinor ? { isMinor: previous.isMinor } : {}),
         ...(previous?.dailyPlayMinutes ? { dailyPlayMinutes: previous.dailyPlayMinutes } : {}),

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -11,6 +11,7 @@ import {
   type RuntimeDiagnosticsSnapshot
 } from "../../../packages/shared/src/index";
 import { getFeatureFlagRuntimeSnapshot, listFeatureFlagRuntimeSummaries } from "./feature-flags";
+import type { LeaderboardAlertEvent } from "./leaderboard-anti-abuse";
 import {
   getAnalyticsPipelineSnapshot,
   renderAnalyticsPipelineSnapshotText,
@@ -58,6 +59,10 @@ interface AuthObservabilityCounters {
 
 interface MatchmakingObservabilityCounters {
   rateLimitedTotal: number;
+}
+
+interface LeaderboardAbuseObservabilityCounters {
+  alertsTotal: number;
 }
 
 type ActionValidationScope = "world" | "battle";
@@ -173,6 +178,10 @@ interface RuntimeObservabilityState {
   matchmaking: {
     counters: MatchmakingObservabilityCounters;
   };
+  leaderboardAbuse: {
+    counters: LeaderboardAbuseObservabilityCounters;
+    recentAlerts: LeaderboardAlertEvent[];
+  };
 }
 
 export interface RuntimePersistenceHealth {
@@ -237,6 +246,10 @@ interface RuntimeHealthPayload {
     };
     matchmaking: {
       counters: MatchmakingObservabilityCounters;
+    };
+    leaderboardAbuse: {
+      counters: LeaderboardAbuseObservabilityCounters;
+      alertsTracked: number;
     };
   };
 }
@@ -411,6 +424,12 @@ const runtimeObservability: RuntimeObservabilityState = {
     counters: {
       rateLimitedTotal: 0
     }
+  },
+  leaderboardAbuse: {
+    counters: {
+      alertsTotal: 0
+    },
+    recentAlerts: []
   }
 };
 
@@ -503,7 +522,7 @@ function buildHealthPayload(
   );
 
   return {
-    status: persistence.status === "degraded" ? "warn" : "ok",
+    status: persistence.status === "degraded" || runtimeObservability.leaderboardAbuse.recentAlerts.length > 0 ? "warn" : "ok",
     service,
     checkedAt: new Date().toISOString(),
     startedAt: new Date(runtimeObservability.startedAt).toISOString(),
@@ -557,6 +576,10 @@ function buildHealthPayload(
       },
       matchmaking: {
         counters: { ...runtimeObservability.matchmaking.counters }
+      },
+      leaderboardAbuse: {
+        counters: { ...runtimeObservability.leaderboardAbuse.counters },
+        alertsTracked: runtimeObservability.leaderboardAbuse.recentAlerts.length
       }
     }
   };
@@ -1088,6 +1111,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_matchmaking_rate_limited_total Total matchmaking requests rejected by rate limiting.",
     "# TYPE veil_matchmaking_rate_limited_total counter",
     `veil_matchmaking_rate_limited_total ${health.runtime.matchmaking.counters.rateLimitedTotal}`,
+    "# HELP veil_leaderboard_abuse_alerts_total Total leaderboard anti-abuse alerts emitted by this process.",
+    "# TYPE veil_leaderboard_abuse_alerts_total counter",
+    `veil_leaderboard_abuse_alerts_total ${health.runtime.leaderboardAbuse.counters.alertsTotal}`,
     "# HELP veil_auth_invalid_credentials_total Total auth requests rejected for invalid credentials.",
     "# TYPE veil_auth_invalid_credentials_total counter",
     `veil_auth_invalid_credentials_total ${health.runtime.auth.counters.invalidCredentialsTotal}`,
@@ -1726,6 +1752,14 @@ export function recordMatchmakingRateLimited(): void {
   runtimeObservability.matchmaking.counters.rateLimitedTotal += 1;
 }
 
+export function recordLeaderboardAbuseAlert(alert: LeaderboardAlertEvent): void {
+  runtimeObservability.leaderboardAbuse.counters.alertsTotal += 1;
+  runtimeObservability.leaderboardAbuse.recentAlerts.unshift({ ...alert });
+  if (runtimeObservability.leaderboardAbuse.recentAlerts.length > 20) {
+    runtimeObservability.leaderboardAbuse.recentAlerts.length = 20;
+  }
+}
+
 export function recordAuthInvalidCredentials(): void {
   runtimeObservability.auth.counters.invalidCredentialsTotal += 1;
 }
@@ -1886,6 +1920,8 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.roomLifecycle.counters.battleAbortsTotal = 0;
   runtimeObservability.roomLifecycle.recentEvents.length = 0;
   runtimeObservability.matchmaking.counters.rateLimitedTotal = 0;
+  runtimeObservability.leaderboardAbuse.counters.alertsTotal = 0;
+  runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;
 }
 
 export function registerRuntimeObservabilityRoutes(

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -276,6 +276,8 @@ interface PlayerAccountRow extends RowDataPacket {
   recent_event_log_json: string | EventLogEntry[] | null;
   recent_battle_replays_json: string | PlayerBattleReplaySummary[] | null;
   daily_dungeon_state_json: string | PlayerAccountSnapshot["dailyDungeonState"] | null;
+  leaderboard_abuse_state_json: string | PlayerAccountSnapshot["leaderboardAbuseState"] | null;
+  leaderboard_moderation_state_json: string | PlayerAccountSnapshot["leaderboardModerationState"] | null;
   tutorial_step: number | null;
   last_room_id: string | null;
   last_seen_at: Date | string | null;
@@ -736,6 +738,8 @@ export interface PlayerAccountProgressPatch {
   loginStreak?: number | null;
   lastRoomId?: string | null;
   eloRating?: number;
+  leaderboardAbuseState?: PlayerAccountSnapshot["leaderboardAbuseState"] | null;
+  leaderboardModerationState?: PlayerAccountSnapshot["leaderboardModerationState"] | null;
 }
 
 export interface PlayerAccountCredentialInput {
@@ -1870,6 +1874,8 @@ function normalizePlayerAccountSnapshot(account: {
   recentEventLog?: Partial<EventLogEntry>[] | null | undefined;
   recentBattleReplays?: Partial<PlayerBattleReplaySummary>[] | null | undefined;
   dailyDungeonState?: PlayerAccountSnapshot["dailyDungeonState"] | null | undefined;
+  leaderboardAbuseState?: PlayerAccountSnapshot["leaderboardAbuseState"] | null | undefined;
+  leaderboardModerationState?: PlayerAccountSnapshot["leaderboardModerationState"] | null | undefined;
   tutorialStep?: number | null | undefined;
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
@@ -1934,6 +1940,8 @@ function normalizePlayerAccountSnapshot(account: {
       recentEventLog: account.recentEventLog,
       recentBattleReplays: appendPlayerBattleReplaySummaries([], account.recentBattleReplays),
       dailyDungeonState: account.dailyDungeonState,
+      leaderboardAbuseState: account.leaderboardAbuseState,
+      leaderboardModerationState: account.leaderboardModerationState,
       tutorialStep: account.tutorialStep,
       lastRoomId: account.lastRoomId,
       lastSeenAt: account.lastSeenAt,
@@ -2307,6 +2315,8 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   recent_event_log_json LONGTEXT NULL,
   recent_battle_replays_json LONGTEXT NULL,
   daily_dungeon_state_json LONGTEXT NULL,
+  leaderboard_abuse_state_json LONGTEXT NULL,
+  leaderboard_moderation_state_json LONGTEXT NULL,
   tutorial_step INT NULL DEFAULT NULL,
   last_room_id VARCHAR(191) NULL,
   last_seen_at DATETIME NULL DEFAULT NULL,
@@ -2827,6 +2837,42 @@ SET @veil_player_accounts_daily_dungeon_sql := IF(
 PREPARE veil_player_accounts_daily_dungeon_stmt FROM @veil_player_accounts_daily_dungeon_sql;
 EXECUTE veil_player_accounts_daily_dungeon_stmt;
 DEALLOCATE PREPARE veil_player_accounts_daily_dungeon_stmt;
+
+SET @veil_player_accounts_leaderboard_abuse_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'leaderboard_abuse_state_json'
+);
+
+SET @veil_player_accounts_leaderboard_abuse_sql := IF(
+  @veil_player_accounts_leaderboard_abuse_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`leaderboard_abuse_state_json\` LONGTEXT NULL AFTER \`daily_dungeon_state_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_leaderboard_abuse_stmt FROM @veil_player_accounts_leaderboard_abuse_sql;
+EXECUTE veil_player_accounts_leaderboard_abuse_stmt;
+DEALLOCATE PREPARE veil_player_accounts_leaderboard_abuse_stmt;
+
+SET @veil_player_accounts_leaderboard_moderation_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'leaderboard_moderation_state_json'
+);
+
+SET @veil_player_accounts_leaderboard_moderation_sql := IF(
+  @veil_player_accounts_leaderboard_moderation_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`leaderboard_moderation_state_json\` LONGTEXT NULL AFTER \`leaderboard_abuse_state_json\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_leaderboard_moderation_stmt FROM @veil_player_accounts_leaderboard_moderation_sql;
+EXECUTE veil_player_accounts_leaderboard_moderation_stmt;
+DEALLOCATE PREPARE veil_player_accounts_leaderboard_moderation_stmt;
 
 SET @veil_player_accounts_tutorial_step_exists := (
   SELECT COUNT(*)
@@ -3725,6 +3771,16 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     dailyDungeonState:
       row.daily_dungeon_state_json != null
         ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["dailyDungeonState"]>>(row.daily_dungeon_state_json)
+        : undefined,
+    leaderboardAbuseState:
+      row.leaderboard_abuse_state_json != null
+        ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["leaderboardAbuseState"]>>(row.leaderboard_abuse_state_json)
+        : undefined,
+    leaderboardModerationState:
+      row.leaderboard_moderation_state_json != null
+        ? parseJsonColumn<NonNullable<PlayerAccountSnapshot["leaderboardModerationState"]>>(
+            row.leaderboard_moderation_state_json
+          )
         : undefined,
     ...(row.tutorial_step != null ? { tutorialStep: row.tutorial_step } : {}),
     ...(row.display_name ? { displayName: row.display_name } : {}),
@@ -6814,6 +6870,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
       seasonHistory: patch.seasonHistory ?? existing.seasonHistory,
       rankedWeeklyProgress: patch.rankedWeeklyProgress ?? competitiveProgression.rankedWeeklyProgress,
       dailyDungeonState: patch.dailyDungeonState ?? existing.dailyDungeonState,
+      leaderboardAbuseState: patch.leaderboardAbuseState ?? existing.leaderboardAbuseState,
+      leaderboardModerationState: patch.leaderboardModerationState ?? existing.leaderboardModerationState,
       tutorialStep: patch.tutorialStep !== undefined ? patch.tutorialStep : existing.tutorialStep,
       dailyPlayMinutes:
         patch.dailyPlayMinutes !== undefined ? normalizeDailyPlayMinutes(patch.dailyPlayMinutes) : existing.dailyPlayMinutes,
@@ -6859,6 +6917,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         leaderboard_abuse_state_json,
+         leaderboard_moderation_state_json,
          tutorial_step,
          last_room_id,
          last_seen_at,
@@ -6868,7 +6928,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_play_date,
          login_streak
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = COALESCE(avatar_url, VALUES(avatar_url)),
@@ -6895,6 +6955,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json = VALUES(recent_event_log_json),
          recent_battle_replays_json = VALUES(recent_battle_replays_json),
          daily_dungeon_state_json = VALUES(daily_dungeon_state_json),
+         leaderboard_abuse_state_json = VALUES(leaderboard_abuse_state_json),
+         leaderboard_moderation_state_json = VALUES(leaderboard_moderation_state_json),
          tutorial_step = VALUES(tutorial_step),
          last_room_id = VALUES(last_room_id),
          last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
@@ -6931,6 +6993,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         JSON.stringify(nextAccount.recentEventLog),
         JSON.stringify(nextAccount.recentBattleReplays),
         JSON.stringify(nextAccount.dailyDungeonState ?? null),
+        JSON.stringify(nextAccount.leaderboardAbuseState ?? null),
+        JSON.stringify(nextAccount.leaderboardModerationState ?? null),
         nextAccount.tutorialStep,
         nextAccount.lastRoomId ?? null,
         existing.lastSeenAt ? new Date(existing.lastSeenAt) : null,
@@ -7022,6 +7086,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          recent_event_log_json,
          recent_battle_replays_json,
          daily_dungeon_state_json,
+         leaderboard_abuse_state_json,
+         leaderboard_moderation_state_json,
          tutorial_step,
          last_room_id,
          last_seen_at,

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -270,7 +270,13 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
         .filter((entry) => !options.guildId || entry.guildId === options.guildId)
         .slice(0, Math.max(1, Math.floor(options.limit ?? 50)));
     },
-    async savePlayerAccountProgress(playerId: string, patch: { globalResources?: { gold: number; wood: number; ore: number } }) {
+    async savePlayerAccountProgress(
+      playerId: string,
+      patch: {
+        globalResources?: { gold: number; wood: number; ore: number };
+        leaderboardModerationState?: Record<string, unknown>;
+      }
+    ) {
       const account =
         (await this.loadPlayerAccount(playerId)) ??
         (await this.ensurePlayerAccount({
@@ -278,6 +284,12 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
           displayName: playerId
         }));
       account.globalResources = { ...account.globalResources, ...patch.globalResources };
+      if (patch.leaderboardModerationState) {
+        account.leaderboardModerationState = {
+          ...(account.leaderboardModerationState ?? {}),
+          ...patch.leaderboardModerationState
+        };
+      }
       saveCalls.push({ playerId, globalResources: { ...account.globalResources } });
       return account;
     },
@@ -1333,6 +1345,70 @@ test("GET /api/admin/players/:id/export returns account data for support workflo
   assert.deepEqual(payload.account.globalResources, { gold: 9, wood: 4, ore: 2 });
   assert.equal(payload.moderation.currentBan.banStatus, "temporary");
   assert.equal(payload.moderation.banHistory[0]?.action, "ban");
+});
+
+test("POST /api/admin/players/:id/leaderboard/freeze freezes leaderboard movement for a player", async (t) => {
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/leaderboard/freeze");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-freeze" },
+      body: JSON.stringify({ reason: "Suspicious ELO spike" }),
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    response
+  );
+
+  const payload = JSON.parse(response.body) as {
+    ok: boolean;
+    account: { leaderboardModerationState?: { frozenByPlayerId?: string; freezeReason?: string; frozenAt?: string } };
+  };
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.account.leaderboardModerationState?.frozenByPlayerId, "support-moderator:admin-console");
+  assert.equal(payload.account.leaderboardModerationState?.freezeReason, "Suspicious ELO spike");
+  assert.ok(payload.account.leaderboardModerationState?.frozenAt);
+});
+
+test("POST /api/admin/players/:id/leaderboard/remove hides a player from leaderboard output", async (t) => {
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/leaderboard/remove");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-hidden" },
+      body: JSON.stringify({ reason: "Leaderboard manipulation investigation" }),
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    response
+  );
+
+  const payload = JSON.parse(response.body) as {
+    ok: boolean;
+    account: { leaderboardModerationState?: { hiddenByPlayerId?: string; hiddenReason?: string; hiddenAt?: string } };
+  };
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.account.leaderboardModerationState?.hiddenByPlayerId, "support-moderator:admin-console");
+  assert.equal(payload.account.leaderboardModerationState?.hiddenReason, "Leaderboard manipulation investigation");
+  assert.ok(payload.account.leaderboardModerationState?.hiddenAt);
 });
 
 test("support moderators can hide and inspect guild moderation audit", async (t) => {

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -2128,6 +2128,45 @@ test("surrender settles the room with the surrendering player as loser and persi
   assert.equal(await store.load(room.roomId), null);
 });
 
+test("surrender does not change ELO when a leaderboard-frozen player is involved", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new InstrumentedRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  await store.savePlayerAccountProgress("player-2", {
+    leaderboardModerationState: {
+      frozenAt: "2026-04-11T08:00:00.000Z",
+      frozenByPlayerId: "support-moderator:admin-console"
+    }
+  });
+  const room = await createTestRoom(`lifecycle-surrender-frozen-${Date.now()}`);
+  const surrenderingClient = createFakeClient("session-surrender-frozen-loser");
+  const opponentClient = createFakeClient("session-surrender-frozen-winner");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, surrenderingClient, "player-1", "connect-surrender-frozen-loser");
+  await connectPlayer(room, opponentClient, "player-2", "connect-surrender-frozen-winner");
+
+  await emitRoomMessage(room, "world.action", surrenderingClient, {
+    type: "world.action",
+    requestId: "surrender-room-frozen",
+    action: {
+      type: "world.surrender",
+      heroId: "hero-1"
+    }
+  });
+
+  const loserAccount = await store.loadPlayerAccount("player-1");
+  const winnerAccount = await store.loadPlayerAccount("player-2");
+
+  assert.equal(loserAccount?.eloRating, 1000);
+  assert.equal(winnerAccount?.eloRating, 1000);
+});
+
 test("pvp settlement cleanup retires the room and clears connected player session state", async (t) => {
   resetLobbyRoomRegistry();
   const store = new InstrumentedRoomSnapshotStore();

--- a/apps/server/test/leaderboard-anti-abuse.test.ts
+++ b/apps/server/test/leaderboard-anti-abuse.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  LEADERBOARD_DAILY_ELO_GAIN_LIMIT,
+  LEADERBOARD_REPEATED_OPPONENT_ALERT_THRESHOLD,
+  LEADERBOARD_REPEATED_OPPONENT_ELO_GAIN_LIMIT,
+  settleLeaderboardMatch
+} from "../src/leaderboard-anti-abuse";
+
+test("settleLeaderboardMatch caps winner gain at the daily ELO limit", () => {
+  const result = settleLeaderboardMatch({
+    winner: {
+      playerId: "winner",
+      eloRating: 1000,
+      leaderboardAbuseState: {
+        currentDay: "2026-04-11",
+        dailyEloGain: LEADERBOARD_DAILY_ELO_GAIN_LIMIT - 2
+      }
+    },
+    loser: {
+      playerId: "loser",
+      eloRating: 1000
+    },
+    settledAt: "2026-04-11T08:00:00.000Z"
+  });
+
+  assert.equal(result.winnerRating, 1002);
+  assert.equal(result.loserRating, 998);
+  assert.equal(result.capped, true);
+  assert.equal(result.winnerAbuseState?.dailyEloGain, LEADERBOARD_DAILY_ELO_GAIN_LIMIT);
+  assert.match(result.alerts[0]?.type ?? "", /daily_gain_cap/);
+});
+
+test("settleLeaderboardMatch caps winner gain from repeated opponent farming", () => {
+  const result = settleLeaderboardMatch({
+    winner: {
+      playerId: "winner",
+      eloRating: 1000,
+      leaderboardAbuseState: {
+        currentDay: "2026-04-11",
+        dailyEloGain: 10,
+        opponentStats: [
+          {
+            opponentPlayerId: "loser",
+            matchCount: 2,
+            eloGain: LEADERBOARD_REPEATED_OPPONENT_ELO_GAIN_LIMIT - 2,
+            eloLoss: 0,
+            lastPlayedAt: "2026-04-11T07:00:00.000Z"
+          }
+        ]
+      }
+    },
+    loser: {
+      playerId: "loser",
+      eloRating: 1000
+    },
+    settledAt: "2026-04-11T08:00:00.000Z"
+  });
+
+  assert.equal(result.winnerRating, 1002);
+  assert.equal(result.loserRating, 998);
+  assert.equal(
+    result.winnerAbuseState?.opponentStats?.find((entry) => entry.opponentPlayerId === "loser")?.eloGain,
+    LEADERBOARD_REPEATED_OPPONENT_ELO_GAIN_LIMIT
+  );
+  assert.match(result.alerts[0]?.type ?? "", /repeated_opponent_gain_cap/);
+});
+
+test("settleLeaderboardMatch raises a repeated-opponent watch alert at the threshold", () => {
+  const result = settleLeaderboardMatch({
+    winner: {
+      playerId: "winner",
+      eloRating: 1000,
+      leaderboardAbuseState: {
+        currentDay: "2026-04-11",
+        opponentStats: [
+          {
+            opponentPlayerId: "loser",
+            matchCount: LEADERBOARD_REPEATED_OPPONENT_ALERT_THRESHOLD - 1,
+            eloGain: 20,
+            eloLoss: 0,
+            lastPlayedAt: "2026-04-11T07:00:00.000Z"
+          }
+        ]
+      }
+    },
+    loser: {
+      playerId: "loser",
+      eloRating: 1000
+    },
+    settledAt: "2026-04-11T08:00:00.000Z"
+  });
+
+  assert.equal(result.winnerAbuseState?.status, "watch");
+  assert.equal(
+    result.winnerAbuseState?.opponentStats?.find((entry) => entry.opponentPlayerId === "loser")?.matchCount,
+    LEADERBOARD_REPEATED_OPPONENT_ALERT_THRESHOLD
+  );
+  assert.equal(result.alerts.some((alert) => alert.type === "leaderboard_repeated_opponent_watch"), true);
+});
+
+test("settleLeaderboardMatch skips rating changes when a frozen leaderboard account is involved", () => {
+  const result = settleLeaderboardMatch({
+    winner: {
+      playerId: "winner",
+      eloRating: 1000,
+      leaderboardModerationState: {
+        frozenAt: "2026-04-11T08:00:00.000Z",
+        frozenByPlayerId: "support-moderator:admin-console"
+      }
+    },
+    loser: {
+      playerId: "loser",
+      eloRating: 1000
+    },
+    settledAt: "2026-04-11T08:00:00.000Z"
+  });
+
+  assert.equal(result.winnerRating, 1000);
+  assert.equal(result.loserRating, 1000);
+  assert.equal(result.capped, true);
+  assert.equal(result.alerts.some((alert) => alert.type === "leaderboard_frozen_player_match"), true);
+});

--- a/apps/server/test/leaderboard-routes.test.ts
+++ b/apps/server/test/leaderboard-routes.test.ts
@@ -127,6 +127,7 @@ test("GET /api/leaderboard returns ranked players in elo order with competitive 
         eloRating: 1650,
         tier: "platinum",
         division: "platinum_i",
+        isFrozen: false,
         promotionSeries: {
           targetDivision: "platinum_i",
           wins: 2,
@@ -145,11 +146,59 @@ test("GET /api/leaderboard returns ranked players in elo order with competitive 
         eloRating: 1050,
         tier: "bronze",
         division: "bronze_i",
+        isFrozen: false,
         promotionSeries: null,
         demotionShield: null
       }
     ]
   });
+});
+
+test("GET /api/leaderboard hides removed players and marks frozen players", async () => {
+  const { gets, store } = registerRoutes();
+  const handler = gets.get("/api/leaderboard");
+  const response = createResponse();
+
+  await store.ensurePlayerAccount({ playerId: "player-visible", displayName: "Visible" });
+  await store.savePlayerAccountProgress("player-visible", {
+    eloRating: 1510,
+    rankDivision: "platinum_i",
+    leaderboardModerationState: {
+      frozenAt: "2026-04-11T08:00:00.000Z",
+      frozenByPlayerId: "support-moderator:admin-console"
+    }
+  });
+  await store.ensurePlayerAccount({ playerId: "player-hidden", displayName: "Hidden" });
+  await store.savePlayerAccountProgress("player-hidden", {
+    eloRating: 1800,
+    rankDivision: "diamond_i",
+    leaderboardModerationState: {
+      hiddenAt: "2026-04-11T08:05:00.000Z",
+      hiddenByPlayerId: "support-moderator:admin-console"
+    }
+  });
+
+  assert.ok(handler);
+  await handler(createRequest({ url: "/api/leaderboard" }), response);
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body) as {
+    players: Array<{
+      playerId: string;
+      displayName: string;
+      eloRating: number;
+      tier: string;
+      division: string;
+      isFrozen: boolean;
+    }>;
+  };
+  assert.equal(payload.players.length, 1);
+  assert.equal(payload.players[0]?.playerId, "player-visible");
+  assert.equal(payload.players[0]?.displayName, "Visible");
+  assert.equal(payload.players[0]?.eloRating, 1510);
+  assert.equal(payload.players[0]?.tier, "platinum");
+  assert.equal(payload.players[0]?.division, "platinum_i");
+  assert.equal(payload.players[0]?.isFrozen, true);
 });
 
 test("leaderboard route middleware responds to OPTIONS and applies CORS headers", async () => {

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -69,6 +69,33 @@ export interface PlayerMailboxSummary {
   expiredCount: number;
 }
 
+export interface LeaderboardOpponentStat {
+  opponentPlayerId: string;
+  matchCount: number;
+  eloGain: number;
+  eloLoss: number;
+  lastPlayedAt: string;
+}
+
+export interface LeaderboardAbuseState {
+  currentDay?: string;
+  dailyEloGain?: number;
+  dailyEloLoss?: number;
+  opponentStats?: LeaderboardOpponentStat[];
+  status?: "clear" | "watch" | "flagged";
+  lastAlertAt?: string;
+  lastAlertReasons?: string[];
+}
+
+export interface LeaderboardModerationState {
+  frozenAt?: string;
+  frozenByPlayerId?: string;
+  freezeReason?: string;
+  hiddenAt?: string;
+  hiddenByPlayerId?: string;
+  hiddenReason?: string;
+}
+
 export interface PlayerAccountReadModel {
   playerId: string;
   displayName: string;
@@ -115,6 +142,8 @@ export interface PlayerAccountReadModel {
   banStatus?: PlayerBanStatus;
   banExpiry?: string;
   banReason?: string;
+  leaderboardAbuseState?: LeaderboardAbuseState;
+  leaderboardModerationState?: LeaderboardModerationState;
   lastRoomId?: string;
   lastSeenAt?: string;
   experiments?: ExperimentAssignment[];
@@ -166,9 +195,103 @@ export interface PlayerAccountReadModelInput {
   banStatus?: PlayerBanStatus | undefined;
   banExpiry?: string | undefined;
   banReason?: string | undefined;
+  leaderboardAbuseState?: LeaderboardAbuseState | null | undefined;
+  leaderboardModerationState?: LeaderboardModerationState | null | undefined;
   lastRoomId?: string | undefined;
   lastSeenAt?: string | undefined;
   experiments?: Partial<ExperimentAssignment>[] | null | undefined;
+}
+
+function normalizeLeaderboardOpponentStats(
+  opponentStats?: LeaderboardOpponentStat[] | null
+): LeaderboardOpponentStat[] | undefined {
+  if (!Array.isArray(opponentStats)) {
+    return undefined;
+  }
+
+  const normalized = opponentStats
+    .map((entry) => {
+      const opponentPlayerId = entry?.opponentPlayerId?.trim();
+      const lastPlayedAt = entry?.lastPlayedAt?.trim();
+      if (!opponentPlayerId || !lastPlayedAt) {
+        return null;
+      }
+
+      return {
+        opponentPlayerId,
+        matchCount: Math.max(0, Math.floor(entry.matchCount ?? 0)),
+        eloGain: Math.max(0, Math.floor(entry.eloGain ?? 0)),
+        eloLoss: Math.max(0, Math.floor(entry.eloLoss ?? 0)),
+        lastPlayedAt
+      };
+    })
+    .filter((entry): entry is LeaderboardOpponentStat => Boolean(entry))
+    .sort((left, right) => right.lastPlayedAt.localeCompare(left.lastPlayedAt))
+    .slice(0, 12);
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeLeaderboardAbuseState(
+  state?: LeaderboardAbuseState | null
+): LeaderboardAbuseState | undefined {
+  if (!state || typeof state !== "object") {
+    return undefined;
+  }
+
+  const currentDay = /^\d{4}-\d{2}-\d{2}$/.test(state.currentDay?.trim() ?? "") ? state.currentDay?.trim() : undefined;
+  const opponentStats = normalizeLeaderboardOpponentStats(state.opponentStats);
+  const lastAlertAt = state.lastAlertAt?.trim();
+  const lastAlertReasons = Array.from(
+    new Set(
+      (state.lastAlertReasons ?? [])
+        .map((reason) => reason?.trim())
+        .filter((reason): reason is string => Boolean(reason))
+    )
+  ).slice(0, 8);
+  const status = state.status === "watch" || state.status === "flagged" ? state.status : "clear";
+
+  if (!currentDay && !opponentStats && !lastAlertAt && lastAlertReasons.length === 0 && status === "clear") {
+    return undefined;
+  }
+
+  return {
+    ...(currentDay ? { currentDay } : {}),
+    ...(currentDay ? { dailyEloGain: Math.max(0, Math.floor(state.dailyEloGain ?? 0)) } : {}),
+    ...(currentDay ? { dailyEloLoss: Math.max(0, Math.floor(state.dailyEloLoss ?? 0)) } : {}),
+    ...(opponentStats ? { opponentStats } : {}),
+    ...(status !== "clear" ? { status } : {}),
+    ...(lastAlertAt ? { lastAlertAt } : {}),
+    ...(lastAlertReasons.length > 0 ? { lastAlertReasons } : {})
+  };
+}
+
+function normalizeLeaderboardModerationState(
+  state?: LeaderboardModerationState | null
+): LeaderboardModerationState | undefined {
+  if (!state || typeof state !== "object") {
+    return undefined;
+  }
+
+  const frozenAt = state.frozenAt?.trim();
+  const frozenByPlayerId = state.frozenByPlayerId?.trim();
+  const freezeReason = state.freezeReason?.trim();
+  const hiddenAt = state.hiddenAt?.trim();
+  const hiddenByPlayerId = state.hiddenByPlayerId?.trim();
+  const hiddenReason = state.hiddenReason?.trim();
+
+  if (!frozenAt && !hiddenAt) {
+    return undefined;
+  }
+
+  return {
+    ...(frozenAt ? { frozenAt } : {}),
+    ...(frozenByPlayerId ? { frozenByPlayerId } : {}),
+    ...(freezeReason ? { freezeReason } : {}),
+    ...(hiddenAt ? { hiddenAt } : {}),
+    ...(hiddenByPlayerId ? { hiddenByPlayerId } : {}),
+    ...(hiddenReason ? { hiddenReason } : {})
+  };
 }
 
 export function normalizePlayerAccountReadModel(
@@ -212,6 +335,8 @@ export function normalizePlayerAccountReadModel(
   const banStatus = account?.banStatus === "temporary" || account?.banStatus === "permanent" ? account.banStatus : "none";
   const banExpiry = account?.banExpiry?.trim();
   const banReason = account?.banReason?.trim();
+  const leaderboardAbuseState = normalizeLeaderboardAbuseState(account?.leaderboardAbuseState);
+  const leaderboardModerationState = normalizeLeaderboardModerationState(account?.leaderboardModerationState);
   const lastRoomId = account?.lastRoomId?.trim();
   const lastSeenAt = account?.lastSeenAt?.trim();
   const experiments = normalizeExperimentAssignments(account?.experiments);
@@ -331,6 +456,8 @@ export function normalizePlayerAccountReadModel(
     ...(banStatus !== "none" ? { banStatus } : {}),
     ...(banExpiry ? { banExpiry } : {}),
     ...(banReason ? { banReason } : {}),
+    ...(leaderboardAbuseState ? { leaderboardAbuseState } : {}),
+    ...(leaderboardModerationState ? { leaderboardModerationState } : {}),
     ...(lastRoomId ? { lastRoomId } : {}),
     ...(lastSeenAt ? { lastSeenAt } : {}),
     ...(experiments.length > 0 ? { experiments } : {})


### PR DESCRIPTION
## Summary
- add server-side leaderboard anti-abuse settlement rules for repeated-opponent gain caps, daily ELO gain caps, frozen accounts, and anomaly alert emission
- add admin leaderboard freeze/remove routes and hide removed accounts from public leaderboard responses
- persist the new leaderboard abuse/moderation state and cover the behavior with focused route, rule, and settlement tests

Closes #1234

## Testing
- `npm run typecheck:server`
- `node --import tsx --test apps/server/test/leaderboard-anti-abuse.test.ts apps/server/test/leaderboard-routes.test.ts apps/server/test/admin-console.test.ts`
- `node --import tsx --test --test-name-pattern "two consecutive AFK strikes|surrender settles the room|surrender does not change ELO" apps/server/test/colyseus-room-lifecycle.test.ts`
