### PR TITLE
Fix guest WeChat upgrade migration

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -725,6 +725,54 @@ export function createWechatMiniGamePlayerId(openId: string): string {
   return `wechat-${createHmac("sha256", AUTH_SECRET).update(`wechat:${normalizedOpenId}`).digest("hex").slice(0, 16)}`;
 }
 
+const WECHAT_GUEST_UPGRADE_NOTICE = "您的游客进度将合并到新账号";
+
+function hasPlayerAccountProgress(account: PlayerAccountSnapshot | null | undefined): boolean {
+  if (!account) {
+    return false;
+  }
+
+  return (
+    (account.gems ?? 0) > 0 ||
+    (account.seasonXp ?? 0) > 0 ||
+    (account.loginStreak ?? 0) > 0 ||
+    (account.dailyPlayMinutes ?? 0) > 0 ||
+    (account.globalResources.gold ?? 0) > 0 ||
+    (account.globalResources.wood ?? 0) > 0 ||
+    (account.globalResources.ore ?? 0) > 0 ||
+    account.achievements.length > 0 ||
+    (account.recentBattleReplays?.length ?? 0) > 0 ||
+    (account.seasonBadges?.length ?? 0) > 0 ||
+    (account.seasonPassClaimedTiers?.length ?? 0) > 0 ||
+    (account.mailbox?.length ?? 0) > 0 ||
+    (account.cosmeticInventory?.ownedIds.length ?? 0) > 0 ||
+    account.campaignProgress !== undefined ||
+    account.dailyDungeonState !== undefined ||
+    account.seasonalEventStates !== undefined ||
+    (account.tutorialStep ?? 0) > 0
+  );
+}
+
+async function summarizeMigrationProgress(store: RoomSnapshotStore, account: PlayerAccountSnapshot): Promise<{
+  hasProgress: boolean;
+  heroCount: number;
+  hasQuestState: boolean;
+}> {
+  const [heroArchives, questState] = await Promise.all([
+    store.loadPlayerHeroArchives([account.playerId]),
+    store.loadPlayerQuestState?.(account.playerId)
+  ]);
+  return {
+    hasProgress:
+      hasPlayerAccountProgress(account) ||
+      heroArchives.length > 0 ||
+      (questState?.activeQuestIds.length ?? 0) > 0 ||
+      (questState?.rotations.length ?? 0) > 0,
+    heroCount: heroArchives.length,
+    hasQuestState: Boolean(questState && (questState.activeQuestIds.length > 0 || questState.rotations.length > 0))
+  };
+}
+
 async function exchangeWechatMiniGameCode(
   code: string,
   config: WechatMiniGameLoginConfig,
@@ -960,6 +1008,7 @@ async function handleWechatLogin(
     playerId?: string | null;
     displayName?: string | null;
     avatarUrl?: string | null;
+    migrationChoice?: string | null;
     privacyConsentAccepted?: boolean | null;
     ageVerified?: boolean | null;
     isAdult?: boolean | null;
@@ -1001,6 +1050,16 @@ async function handleWechatLogin(
       error: {
         code: "invalid_payload",
         message: "Expected optional string field: avatarUrl"
+      }
+    });
+    return;
+  }
+
+  if (body.migrationChoice !== undefined && body.migrationChoice !== null && typeof body.migrationChoice !== "string") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional string field: migrationChoice"
       }
     });
     return;
@@ -1048,6 +1107,21 @@ async function handleWechatLogin(
 
   const code = normalizeWechatMiniGameCode(body.code);
   const avatarUrl = normalizeAvatarUrl(body.avatarUrl);
+  const migrationChoice = body.migrationChoice?.trim();
+  if (
+    migrationChoice !== undefined &&
+    migrationChoice !== "" &&
+    migrationChoice !== "keep_guest" &&
+    migrationChoice !== "keep_registered"
+  ) {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "migrationChoice must be keep_guest or keep_registered"
+      }
+    });
+    return;
+  }
   const minorProtection = deriveWechatMinorProtection({
     ...(body.ageVerified !== undefined ? { ageVerified: body.ageVerified } : {}),
     ...(body.isAdult !== undefined ? { isAdult: body.isAdult } : {}),
@@ -1094,10 +1168,105 @@ async function handleWechatLogin(
   let displayName = normalizeDisplayName(playerId, body.displayName ?? authSession?.displayName);
   let loginId = authSession?.loginId;
   let rewardAccount: PlayerAccountSnapshot | null = null;
+  let accountMigration:
+    | {
+        notice: string;
+        previousGuestPlayerId: string;
+        migratedToPlayerId: string;
+        strategy: "keep_guest" | "keep_registered";
+      }
+    | undefined;
 
   if (store) {
     const boundAccount = await store.loadPlayerAccountByWechatMiniGameOpenId(identity.openId);
-    if (boundAccount && authSession && boundAccount.playerId !== authSession.playerId) {
+    const wechatIdentity = {
+      openId: identity.openId,
+      ...(identity.unionId ? { unionId: identity.unionId } : {}),
+      ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
+      ...(avatarUrl ? { avatarUrl } : {}),
+      ...minorProtection
+    };
+    if (authSession?.authMode === "guest") {
+      const guestAccount =
+        (await store.loadPlayerAccount(authSession.playerId)) ??
+        (await store.ensurePlayerAccount({
+          playerId: authSession.playerId,
+          displayName: authSession.displayName
+        }));
+      if (guestAccount.guestMigratedToPlayerId) {
+        if (authSession.sessionId) {
+          revokeGuestAuthSession(authSession.sessionId);
+        }
+        sendJson(response, 409, {
+          error: {
+            code: "guest_account_migrated",
+            message: `Guest account has already been migrated to ${guestAccount.guestMigratedToPlayerId}`
+          }
+        });
+        return;
+      }
+
+      const targetPlayerId = boundAccount?.playerId ?? createWechatMiniGamePlayerId(identity.openId);
+      if (boundAccount && boundAccount.playerId !== guestAccount.playerId) {
+        const [guestSummary, registeredSummary] = await Promise.all([
+          summarizeMigrationProgress(store, guestAccount),
+          summarizeMigrationProgress(store, boundAccount)
+        ]);
+        if (registeredSummary.hasProgress && migrationChoice !== "keep_guest" && migrationChoice !== "keep_registered") {
+          sendJson(response, 409, {
+            error: {
+              code: "wechat_guest_upgrade_conflict",
+              message: "Registered WeChat account already has progression. Choose which progression to keep."
+            },
+            migrationConflict: {
+              notice: WECHAT_GUEST_UPGRADE_NOTICE,
+              guest: {
+                playerId: guestAccount.playerId,
+                hasProgress: guestSummary.hasProgress,
+                heroCount: guestSummary.heroCount,
+                hasQuestState: guestSummary.hasQuestState
+              },
+              registered: {
+                playerId: boundAccount.playerId,
+                hasProgress: registeredSummary.hasProgress,
+                heroCount: registeredSummary.heroCount,
+                hasQuestState: registeredSummary.hasQuestState
+              },
+              choices: ["keep_registered", "keep_guest"]
+            }
+          });
+          return;
+        }
+      }
+
+      const strategy = migrationChoice === "keep_registered" ? "keep_registered" : "keep_guest";
+      let migratedAccount = (
+        await store.migrateGuestToRegistered({
+          guestPlayerId: guestAccount.playerId,
+          targetPlayerId,
+          progressSource: strategy === "keep_registered" ? "target" : "guest",
+          wechatIdentity
+        })
+      ).account;
+      const consentedAccount = await ensurePlayerPrivacyConsent(response, store, migratedAccount, body.privacyConsentAccepted);
+      if (!consentedAccount) {
+        return;
+      }
+      migratedAccount = consentedAccount;
+      if (authSession.sessionId) {
+        revokeGuestAuthSession(authSession.sessionId);
+      }
+      playerId = migratedAccount.playerId;
+      displayName = migratedAccount.displayName;
+      loginId = migratedAccount.loginId;
+      rewardAccount = migratedAccount;
+      accountMigration = {
+        notice: WECHAT_GUEST_UPGRADE_NOTICE,
+        previousGuestPlayerId: guestAccount.playerId,
+        migratedToPlayerId: migratedAccount.playerId,
+        strategy
+      };
+    } else if (boundAccount && authSession && boundAccount.playerId !== authSession.playerId) {
       sendJson(response, 409, {
         error: {
           code: "wechat_identity_already_bound",
@@ -1115,13 +1284,11 @@ async function handleWechatLogin(
       }
     }
 
-    if (boundAccount) {
+    if (rewardAccount) {
+      // Guest upgrade already migrated/bound through the atomic store path above.
+    } else if (boundAccount) {
       let syncedAccount = await store.bindPlayerAccountWechatMiniGameIdentity(boundAccount.playerId, {
-        openId: identity.openId,
-        ...(identity.unionId ? { unionId: identity.unionId } : {}),
-        ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
-        ...(avatarUrl ? { avatarUrl } : {}),
-        ...minorProtection
+        ...wechatIdentity
       });
       const consentedAccount = await ensurePlayerPrivacyConsent(response, store, syncedAccount, body.privacyConsentAccepted);
       if (!consentedAccount) {
@@ -1135,11 +1302,7 @@ async function handleWechatLogin(
     } else {
       const targetPlayerId = authSession?.playerId ?? playerId;
       let boundAccountResult = await store.bindPlayerAccountWechatMiniGameIdentity(targetPlayerId, {
-        openId: identity.openId,
-        ...(identity.unionId ? { unionId: identity.unionId } : {}),
-        ...(body.displayName?.trim() ? { displayName: body.displayName } : {}),
-        ...(avatarUrl ? { avatarUrl } : {}),
-        ...minorProtection
+        ...wechatIdentity
       });
       const consentedAccount = await ensurePlayerPrivacyConsent(response, store, boundAccountResult, body.privacyConsentAccepted);
       if (!consentedAccount) {
@@ -1188,7 +1351,8 @@ async function handleWechatLogin(
             reward: dailyLoginReward.reward
           }
         }
-      : {})
+      : {}),
+    ...(accountMigration ? { accountMigration } : {})
   });
   if (store && loginId) {
     recordAuthAccountLogin();
@@ -1392,6 +1556,14 @@ async function validateAuthToken(
       if (activeBan) {
         recordAuthSessionFailure("account_banned");
         return { session: null, errorCode: "account_banned", ban: activeBan };
+      }
+      const account = store ? await store.loadPlayerAccount(session.playerId) : null;
+      if (account?.guestMigratedToPlayerId) {
+        if (session.sessionId) {
+          revokeGuestAuthSession(session.sessionId);
+        }
+        recordAuthSessionFailure("session_revoked");
+        return { session: null, errorCode: "session_revoked" };
       }
       if (session.sessionId) {
         const touchedSession = touchGuestSession(session.sessionId, normalizedToken);
@@ -2096,6 +2268,16 @@ export function registerAuthRoutes(
       await assertDisplayNameAvailableOrThrow(store, displayName, playerId);
 
       if (store) {
+        const existingAccount = await store.loadPlayerAccount(playerId);
+        if (existingAccount?.guestMigratedToPlayerId) {
+          sendJson(response, 409, {
+            error: {
+              code: "guest_account_migrated",
+              message: `Guest account has already been migrated to ${existingAccount.guestMigratedToPlayerId}`
+            }
+          });
+          return;
+        }
         let account = await store.ensurePlayerAccount({
           playerId,
           displayName

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -39,6 +39,8 @@ import {
   type PlayerAccountDeviceSessionSnapshot,
   type PlayerAccountCredentialInput,
   type PlayerAccountEnsureInput,
+  type GuestAccountMigrationInput,
+  type GuestAccountMigrationResult,
   type PlayerAccountListOptions,
   type PlayerAccountUnbanInput,
   type PlayerBanHistoryRecord,
@@ -537,6 +539,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       ...(existing?.wechatMiniGameOpenId ? { wechatMiniGameOpenId: existing.wechatMiniGameOpenId } : {}),
       ...(existing?.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
+      ...(existing?.guestMigratedToPlayerId ? { guestMigratedToPlayerId: existing.guestMigratedToPlayerId } : {}),
       ...(existing?.credentialBoundAt ? { credentialBoundAt: existing.credentialBoundAt } : {}),
       ...(existing?.privacyConsentAt ? { privacyConsentAt: existing.privacyConsentAt } : {}),
       ...(existing?.notificationPreferences
@@ -1320,6 +1323,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
+    delete nextAccount.guestMigratedToPlayerId;
     this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     if (nextDisplayName !== existing.displayName) {
       this.appendPlayerNameHistory(normalizedPlayerId, nextDisplayName, nextAccount.updatedAt);
@@ -1335,6 +1339,113 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       }
     }
     return cloneAccount(nextAccount);
+  }
+
+  async migrateGuestToRegistered(input: GuestAccountMigrationInput): Promise<GuestAccountMigrationResult> {
+    const guestPlayerId = normalizePlayerId(input.guestPlayerId);
+    const targetPlayerId = normalizePlayerId(input.targetPlayerId);
+    const guestAccount = await this.ensurePlayerAccount({ playerId: guestPlayerId });
+    const targetAccount = await this.ensurePlayerAccount({ playerId: targetPlayerId });
+    const progressSource = input.progressSource === "target" ? targetAccount : guestAccount;
+    const nextTarget: PlayerAccountSnapshot = {
+      ...cloneAccount(targetAccount),
+      ...cloneAccount(progressSource),
+      playerId: targetPlayerId,
+      displayName: input.wechatIdentity.displayName?.trim() || progressSource.displayName,
+      ...(input.wechatIdentity.avatarUrl?.trim()
+        ? { avatarUrl: input.wechatIdentity.avatarUrl.trim() }
+        : progressSource.avatarUrl
+          ? { avatarUrl: progressSource.avatarUrl }
+          : targetAccount.avatarUrl
+            ? { avatarUrl: targetAccount.avatarUrl }
+            : {}),
+      ...(targetAccount.loginId ? { loginId: targetAccount.loginId } : {}),
+      ...(targetAccount.credentialBoundAt ? { credentialBoundAt: targetAccount.credentialBoundAt } : {}),
+      ...(targetAccount.phoneNumber ? { phoneNumber: targetAccount.phoneNumber } : {}),
+      ...(targetAccount.phoneNumberBoundAt ? { phoneNumberBoundAt: targetAccount.phoneNumberBoundAt } : {}),
+      ...(targetAccount.accountSessionVersion !== undefined ? { accountSessionVersion: targetAccount.accountSessionVersion } : {}),
+      wechatMiniGameOpenId: input.wechatIdentity.openId.trim(),
+      ...(input.wechatIdentity.unionId?.trim()
+        ? { wechatMiniGameUnionId: input.wechatIdentity.unionId.trim() }
+        : targetAccount.wechatMiniGameUnionId
+          ? { wechatMiniGameUnionId: targetAccount.wechatMiniGameUnionId }
+          : {}),
+      ...(input.wechatIdentity.ageVerified !== undefined
+        ? { ageVerified: input.wechatIdentity.ageVerified }
+        : progressSource.ageVerified !== undefined
+          ? { ageVerified: progressSource.ageVerified }
+          : {}),
+      ...(input.wechatIdentity.isMinor !== undefined
+        ? { isMinor: input.wechatIdentity.isMinor }
+        : progressSource.isMinor !== undefined
+          ? { isMinor: progressSource.isMinor }
+          : {}),
+      wechatMiniGameBoundAt: targetAccount.wechatMiniGameBoundAt ?? new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    delete nextTarget.guestMigratedToPlayerId;
+    this.accounts.set(targetPlayerId, cloneAccount(nextTarget));
+    this.playerIdByWechatOpenId.set(nextTarget.wechatMiniGameOpenId!, targetPlayerId);
+
+    if (input.progressSource === "guest") {
+      const guestArchives = await this.loadPlayerHeroArchives([guestPlayerId]);
+      for (const key of Array.from(this.heroArchives.keys())) {
+        if (key.startsWith(`${targetPlayerId}:`) || key.startsWith(`${guestPlayerId}:`)) {
+          this.heroArchives.delete(key);
+        }
+      }
+      for (const archive of guestArchives) {
+        this.heroArchives.set(`${targetPlayerId}:${archive.heroId}`, {
+          ...cloneArchive(archive),
+          playerId: targetPlayerId,
+          hero: {
+            ...structuredClone(archive.hero),
+            playerId: targetPlayerId
+          }
+        });
+      }
+      const guestQuestState = await this.loadPlayerQuestState(guestPlayerId);
+      this.playerQuestStates.delete(targetPlayerId);
+      this.playerQuestStates.delete(guestPlayerId);
+      if (guestQuestState) {
+        this.playerQuestStates.set(targetPlayerId, {
+          ...structuredClone(guestQuestState),
+          playerId: targetPlayerId
+        });
+      }
+    } else {
+      for (const key of Array.from(this.heroArchives.keys())) {
+        if (key.startsWith(`${guestPlayerId}:`)) {
+          this.heroArchives.delete(key);
+        }
+      }
+      this.playerQuestStates.delete(guestPlayerId);
+    }
+
+    const migratedGuest: PlayerAccountSnapshot = {
+      ...cloneAccount(guestAccount),
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      recentBattleReplays: [],
+      gems: 0,
+      seasonXp: 0,
+      loginStreak: 0,
+      guestMigratedToPlayerId: targetPlayerId,
+      updatedAt: new Date().toISOString()
+    };
+    delete migratedGuest.wechatMiniGameOpenId;
+    delete migratedGuest.wechatMiniGameUnionId;
+    delete migratedGuest.wechatMiniGameBoundAt;
+    delete migratedGuest.loginId;
+    delete migratedGuest.credentialBoundAt;
+    delete migratedGuest.phoneNumber;
+    delete migratedGuest.phoneNumberBoundAt;
+    this.accounts.set(guestPlayerId, cloneAccount(migratedGuest));
+
+    return {
+      account: cloneAccount(nextTarget),
+      guestAccount: cloneAccount(migratedGuest)
+    };
   }
 
   async deletePlayerAccount(

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -181,6 +181,7 @@ export interface RoomSnapshotStore {
     playerId: string,
     input: PlayerAccountWechatMiniGameIdentityInput
   ): Promise<PlayerAccountSnapshot>;
+  migrateGuestToRegistered(input: GuestAccountMigrationInput): Promise<GuestAccountMigrationResult>;
   deletePlayerAccount(
     playerId: string,
     input?: PlayerAccountDeleteInput
@@ -299,6 +300,7 @@ interface PlayerAccountRow extends RowDataPacket {
   wechat_mini_game_open_id: string | null;
   wechat_mini_game_union_id: string | null;
   wechat_mini_game_bound_at: Date | string | null;
+  guest_migrated_to_player_id: string | null;
   credential_bound_at: Date | string | null;
   privacy_consent_at: Date | string | null;
   phone_number: string | null;
@@ -490,6 +492,7 @@ export interface PlayerAccountSnapshot extends PlayerAccountReadModel {
   wechatMiniGameOpenId?: string;
   wechatMiniGameUnionId?: string;
   wechatMiniGameBoundAt?: string;
+  guestMigratedToPlayerId?: string;
   createdAt?: string;
   updatedAt?: string;
   phoneNumber?: string;
@@ -772,6 +775,18 @@ export interface PlayerAccountWechatMiniGameIdentityInput {
   avatarUrl?: string | null;
   ageVerified?: boolean;
   isMinor?: boolean;
+}
+
+export interface GuestAccountMigrationInput {
+  guestPlayerId: string;
+  targetPlayerId: string;
+  progressSource: "guest" | "target";
+  wechatIdentity: PlayerAccountWechatMiniGameIdentityInput;
+}
+
+export interface GuestAccountMigrationResult {
+  account: PlayerAccountSnapshot;
+  guestAccount: PlayerAccountSnapshot;
 }
 
 export interface PlayerAccountDeleteInput {
@@ -1891,11 +1906,15 @@ function normalizePlayerAccountSnapshot(account: {
   wechatMiniGameOpenId?: string | null | undefined;
   wechatMiniGameUnionId?: string | null | undefined;
   wechatMiniGameBoundAt?: string | undefined;
+  guestMigratedToPlayerId?: string | null | undefined;
   credentialBoundAt?: string | undefined;
   privacyConsentAt?: string | Date | null | undefined;
   phoneNumber?: string | null | undefined;
   phoneNumberBoundAt?: string | Date | null | undefined;
   notificationPreferences?: NotificationPreferences | null | undefined;
+  accountSessionVersion?: number | null | undefined;
+  refreshSessionId?: string | null | undefined;
+  refreshTokenExpiresAt?: string | Date | null | undefined;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
 }): PlayerAccountSnapshot {
@@ -1963,6 +1982,12 @@ function normalizePlayerAccountSnapshot(account: {
     ...(normalizedWechatMiniGameOpenId ? { wechatMiniGameOpenId: normalizedWechatMiniGameOpenId } : {}),
     ...(normalizedWechatMiniGameUnionId ? { wechatMiniGameUnionId: normalizedWechatMiniGameUnionId } : {}),
     ...(account.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: account.wechatMiniGameBoundAt } : {}),
+    ...(account.guestMigratedToPlayerId?.trim()
+      ? { guestMigratedToPlayerId: normalizePlayerId(account.guestMigratedToPlayerId) }
+      : {}),
+    ...(account.accountSessionVersion != null ? { accountSessionVersion: Math.max(0, Math.floor(account.accountSessionVersion)) } : {}),
+    ...(account.refreshSessionId?.trim() ? { refreshSessionId: account.refreshSessionId.trim() } : {}),
+    ...(formatTimestamp(account.refreshTokenExpiresAt) ? { refreshTokenExpiresAt: formatTimestamp(account.refreshTokenExpiresAt)! } : {}),
     ...(account.phoneNumber?.trim() ? { phoneNumber: account.phoneNumber.trim() } : {}),
     ...(phoneNumberBoundAt ? { phoneNumberBoundAt } : {}),
     ...(account.createdAt ? { createdAt: account.createdAt } : {}),
@@ -2334,6 +2359,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   wechat_mini_game_open_id VARCHAR(191) NULL,
   wechat_mini_game_union_id VARCHAR(191) NULL,
   wechat_mini_game_bound_at DATETIME NULL DEFAULT NULL,
+  guest_migrated_to_player_id VARCHAR(191) NULL,
   password_hash VARCHAR(255) NULL,
   credential_bound_at DATETIME NULL DEFAULT NULL,
   privacy_consent_at DATETIME NULL DEFAULT NULL,
@@ -3252,6 +3278,24 @@ PREPARE veil_player_accounts_wechat_bound_at_stmt FROM @veil_player_accounts_wec
 EXECUTE veil_player_accounts_wechat_bound_at_stmt;
 DEALLOCATE PREPARE veil_player_accounts_wechat_bound_at_stmt;
 
+SET @veil_player_accounts_guest_migrated_to_player_id_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_ACCOUNT_TABLE}'
+    AND COLUMN_NAME = 'guest_migrated_to_player_id'
+);
+
+SET @veil_player_accounts_guest_migrated_to_player_id_sql := IF(
+  @veil_player_accounts_guest_migrated_to_player_id_exists = 0,
+  'ALTER TABLE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` ADD COLUMN \`guest_migrated_to_player_id\` VARCHAR(191) NULL AFTER \`wechat_mini_game_bound_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_player_accounts_guest_migrated_to_player_id_stmt FROM @veil_player_accounts_guest_migrated_to_player_id_sql;
+EXECUTE veil_player_accounts_guest_migrated_to_player_id_stmt;
+DEALLOCATE PREPARE veil_player_accounts_guest_migrated_to_player_id_stmt;
+
 SET @veil_player_accounts_credential_bound_at_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.COLUMNS
@@ -3805,6 +3849,7 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(wechatUnionId ? { wechatMiniGameUnionId: wechatUnionId } : {}),
     ...(lastSeenAt ? { lastSeenAt } : {}),
     ...(wechatMiniGameBoundAt ? { wechatMiniGameBoundAt } : {}),
+    ...(row.guest_migrated_to_player_id ? { guestMigratedToPlayerId: row.guest_migrated_to_player_id } : {}),
     ...(credentialBoundAt ? { credentialBoundAt } : {}),
     ...(privacyConsentAt ? { privacyConsentAt } : {}),
     ...(row.phone_number ? { phoneNumber: row.phone_number } : {}),
@@ -4262,6 +4307,264 @@ async function savePlayerHeroArchives(
   }
 }
 
+function buildGuestMigrationTargetAccount(input: {
+  progressAccount: PlayerAccountSnapshot;
+  targetAccount: PlayerAccountSnapshot;
+  targetPlayerId: string;
+  wechatIdentity: PlayerAccountWechatMiniGameIdentityInput;
+}): PlayerAccountSnapshot {
+  const progressAccount = normalizePlayerAccountSnapshot({
+    ...input.progressAccount,
+    playerId: input.targetPlayerId
+  });
+  const targetAccount = normalizePlayerAccountSnapshot({
+    ...input.targetAccount,
+    playerId: input.targetPlayerId
+  });
+
+  return normalizePlayerAccountSnapshot({
+    ...targetAccount,
+    ...progressAccount,
+    playerId: input.targetPlayerId,
+    displayName: input.wechatIdentity.displayName?.trim() ? input.wechatIdentity.displayName : progressAccount.displayName,
+    avatarUrl:
+      input.wechatIdentity.avatarUrl !== undefined
+        ? input.wechatIdentity.avatarUrl
+        : progressAccount.avatarUrl ?? targetAccount.avatarUrl,
+    loginId: targetAccount.loginId,
+    credentialBoundAt: targetAccount.credentialBoundAt,
+    privacyConsentAt: progressAccount.privacyConsentAt ?? targetAccount.privacyConsentAt,
+    phoneNumber: targetAccount.phoneNumber,
+    phoneNumberBoundAt: targetAccount.phoneNumberBoundAt,
+    notificationPreferences: progressAccount.notificationPreferences ?? targetAccount.notificationPreferences,
+    accountSessionVersion: targetAccount.accountSessionVersion,
+    refreshSessionId: targetAccount.refreshSessionId,
+    refreshTokenExpiresAt: targetAccount.refreshTokenExpiresAt,
+    wechatMiniGameOpenId: input.wechatIdentity.openId,
+    wechatMiniGameUnionId: input.wechatIdentity.unionId ?? targetAccount.wechatMiniGameUnionId,
+    wechatMiniGameBoundAt: targetAccount.wechatMiniGameBoundAt ?? new Date().toISOString(),
+    ageVerified:
+      input.wechatIdentity.ageVerified !== undefined
+        ? input.wechatIdentity.ageVerified
+        : progressAccount.ageVerified ?? targetAccount.ageVerified,
+    isMinor:
+      input.wechatIdentity.isMinor !== undefined
+        ? input.wechatIdentity.isMinor
+        : progressAccount.isMinor ?? targetAccount.isMinor,
+    guestMigratedToPlayerId: undefined
+  });
+}
+
+function buildMigratedGuestAccountTombstone(
+  account: PlayerAccountSnapshot,
+  targetPlayerId: string
+): PlayerAccountSnapshot {
+  return normalizePlayerAccountSnapshot({
+    playerId: account.playerId,
+    displayName: account.displayName,
+    avatarUrl: account.avatarUrl,
+    globalResources: normalizeResourceLedger(),
+    achievements: [],
+    recentEventLog: account.recentEventLog,
+    recentBattleReplays: [],
+    gems: 0,
+    seasonXp: 0,
+    seasonPassTier: 1,
+    seasonPassPremium: false,
+    seasonPassClaimedTiers: [],
+    seasonBadges: [],
+    campaignProgress: undefined,
+    seasonalEventStates: undefined,
+    mailbox: undefined,
+    cosmeticInventory: { ownedIds: [] },
+    equippedCosmetics: {},
+    eloRating: normalizeEloRating(undefined),
+    rankDivision: getRankDivisionForRating(undefined),
+    peakRankDivision: getRankDivisionForRating(undefined),
+    promotionSeries: undefined,
+    demotionShield: undefined,
+    seasonHistory: [],
+    rankedWeeklyProgress: undefined,
+    dailyDungeonState: undefined,
+    leaderboardAbuseState: undefined,
+    leaderboardModerationState: undefined,
+    tutorialStep: DEFAULT_TUTORIAL_STEP,
+    lastRoomId: undefined,
+    lastSeenAt: account.lastSeenAt,
+    loginId: undefined,
+    credentialBoundAt: undefined,
+    privacyConsentAt: account.privacyConsentAt,
+    phoneNumber: undefined,
+    phoneNumberBoundAt: undefined,
+    notificationPreferences: undefined,
+    ageVerified: undefined,
+    isMinor: undefined,
+    dailyPlayMinutes: 0,
+    lastPlayDate: undefined,
+    loginStreak: 0,
+    banStatus: "none",
+    banExpiry: undefined,
+    banReason: undefined,
+    wechatMiniGameOpenId: undefined,
+    wechatMiniGameUnionId: undefined,
+    wechatMiniGameBoundAt: undefined,
+    guestMigratedToPlayerId: targetPlayerId
+  });
+}
+
+async function upsertPlayerAccountForMigration(
+  connection: PoolConnection,
+  existingAccount: PlayerAccountSnapshot,
+  nextAccount: PlayerAccountSnapshot
+): Promise<void> {
+  await connection.query(
+    `INSERT INTO \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
+       player_id,
+       display_name,
+       avatar_url,
+       elo_rating,
+       rank_division,
+       peak_rank_division,
+       promotion_series_json,
+       demotion_shield_json,
+       season_history_json,
+       ranked_weekly_progress_json,
+       gems,
+       season_xp,
+       season_pass_tier,
+       season_pass_premium,
+       season_pass_claimed_tiers_json,
+       season_badges_json,
+       campaign_progress_json,
+       seasonal_event_states_json,
+       mailbox_json,
+       cosmetic_inventory_json,
+       equipped_cosmetics_json,
+       global_resources_json,
+       achievements_json,
+       recent_event_log_json,
+       recent_battle_replays_json,
+       daily_dungeon_state_json,
+       leaderboard_abuse_state_json,
+       leaderboard_moderation_state_json,
+       tutorial_step,
+       last_room_id,
+       last_seen_at,
+       age_verified,
+       is_minor,
+       daily_play_minutes,
+       last_play_date,
+       login_streak,
+       wechat_open_id,
+       wechat_union_id,
+       wechat_mini_game_open_id,
+       wechat_mini_game_union_id,
+       wechat_mini_game_bound_at,
+       guest_migrated_to_player_id,
+       privacy_consent_at,
+       phone_number,
+       phone_number_bound_at,
+       notification_preferences_json
+     )
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+       display_name = VALUES(display_name),
+       avatar_url = VALUES(avatar_url),
+       elo_rating = VALUES(elo_rating),
+       rank_division = VALUES(rank_division),
+       peak_rank_division = VALUES(peak_rank_division),
+       promotion_series_json = VALUES(promotion_series_json),
+       demotion_shield_json = VALUES(demotion_shield_json),
+       season_history_json = VALUES(season_history_json),
+       ranked_weekly_progress_json = VALUES(ranked_weekly_progress_json),
+       gems = VALUES(gems),
+       season_xp = VALUES(season_xp),
+       season_pass_tier = VALUES(season_pass_tier),
+       season_pass_premium = VALUES(season_pass_premium),
+       season_pass_claimed_tiers_json = VALUES(season_pass_claimed_tiers_json),
+       season_badges_json = VALUES(season_badges_json),
+       campaign_progress_json = VALUES(campaign_progress_json),
+       seasonal_event_states_json = VALUES(seasonal_event_states_json),
+       mailbox_json = VALUES(mailbox_json),
+       cosmetic_inventory_json = VALUES(cosmetic_inventory_json),
+       equipped_cosmetics_json = VALUES(equipped_cosmetics_json),
+       global_resources_json = VALUES(global_resources_json),
+       achievements_json = VALUES(achievements_json),
+       recent_event_log_json = VALUES(recent_event_log_json),
+       recent_battle_replays_json = VALUES(recent_battle_replays_json),
+       daily_dungeon_state_json = VALUES(daily_dungeon_state_json),
+       leaderboard_abuse_state_json = VALUES(leaderboard_abuse_state_json),
+       leaderboard_moderation_state_json = VALUES(leaderboard_moderation_state_json),
+       tutorial_step = VALUES(tutorial_step),
+       last_room_id = VALUES(last_room_id),
+       last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
+       age_verified = VALUES(age_verified),
+       is_minor = VALUES(is_minor),
+       daily_play_minutes = VALUES(daily_play_minutes),
+       last_play_date = VALUES(last_play_date),
+       login_streak = VALUES(login_streak),
+       wechat_open_id = VALUES(wechat_open_id),
+       wechat_union_id = VALUES(wechat_union_id),
+       wechat_mini_game_open_id = VALUES(wechat_mini_game_open_id),
+       wechat_mini_game_union_id = VALUES(wechat_mini_game_union_id),
+       wechat_mini_game_bound_at = VALUES(wechat_mini_game_bound_at),
+       guest_migrated_to_player_id = VALUES(guest_migrated_to_player_id),
+       privacy_consent_at = VALUES(privacy_consent_at),
+       phone_number = VALUES(phone_number),
+       phone_number_bound_at = VALUES(phone_number_bound_at),
+       notification_preferences_json = VALUES(notification_preferences_json),
+       version = version + 1`,
+    [
+      nextAccount.playerId,
+      nextAccount.displayName,
+      nextAccount.avatarUrl ?? null,
+      nextAccount.eloRating,
+      nextAccount.rankDivision ?? null,
+      nextAccount.peakRankDivision ?? null,
+      JSON.stringify(nextAccount.promotionSeries ?? null),
+      JSON.stringify(nextAccount.demotionShield ?? null),
+      JSON.stringify(nextAccount.seasonHistory ?? []),
+      JSON.stringify(nextAccount.rankedWeeklyProgress ?? null),
+      nextAccount.gems,
+      Math.max(0, Math.floor(nextAccount.seasonXp ?? 0)),
+      Math.max(1, Math.floor(nextAccount.seasonPassTier ?? 1)),
+      nextAccount.seasonPassPremium === true ? 1 : 0,
+      JSON.stringify(nextAccount.seasonPassClaimedTiers ?? []),
+      JSON.stringify(nextAccount.seasonBadges ?? []),
+      JSON.stringify(nextAccount.campaignProgress ?? null),
+      JSON.stringify(nextAccount.seasonalEventStates ?? null),
+      JSON.stringify(nextAccount.mailbox ?? null),
+      JSON.stringify(nextAccount.cosmeticInventory ?? { ownedIds: [] }),
+      JSON.stringify(nextAccount.equippedCosmetics ?? {}),
+      JSON.stringify(nextAccount.globalResources),
+      JSON.stringify(nextAccount.achievements),
+      JSON.stringify(nextAccount.recentEventLog),
+      JSON.stringify(nextAccount.recentBattleReplays),
+      JSON.stringify(nextAccount.dailyDungeonState ?? null),
+      JSON.stringify(nextAccount.leaderboardAbuseState ?? null),
+      JSON.stringify(nextAccount.leaderboardModerationState ?? null),
+      nextAccount.tutorialStep,
+      nextAccount.lastRoomId ?? null,
+      existingAccount.lastSeenAt ? new Date(existingAccount.lastSeenAt) : null,
+      nextAccount.ageVerified === true ? 1 : 0,
+      nextAccount.isMinor === true ? 1 : 0,
+      normalizeDailyPlayMinutes(nextAccount.dailyPlayMinutes),
+      nextAccount.lastPlayDate ? new Date(nextAccount.lastPlayDate) : null,
+      normalizeLoginStreak(nextAccount.loginStreak),
+      nextAccount.wechatMiniGameOpenId ?? null,
+      nextAccount.wechatMiniGameUnionId ?? null,
+      nextAccount.wechatMiniGameOpenId ?? null,
+      nextAccount.wechatMiniGameUnionId ?? null,
+      nextAccount.wechatMiniGameBoundAt ? new Date(nextAccount.wechatMiniGameBoundAt) : null,
+      nextAccount.guestMigratedToPlayerId ?? null,
+      nextAccount.privacyConsentAt ? new Date(nextAccount.privacyConsentAt) : null,
+      nextAccount.phoneNumber ?? null,
+      nextAccount.phoneNumberBoundAt ? new Date(nextAccount.phoneNumberBoundAt) : null,
+      JSON.stringify(nextAccount.notificationPreferences ?? null)
+    ]
+  );
+}
+
 export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
   private readonly pool: Pool;
   private readonly database: string;
@@ -4658,6 +4961,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_open_id,
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
+         guest_migrated_to_player_id,
          credential_bound_at,
          privacy_consent_at,
          phone_number,
@@ -4724,6 +5028,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_open_id,
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
+         guest_migrated_to_player_id,
          credential_bound_at,
          privacy_consent_at,
          phone_number,
@@ -4893,6 +5198,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_open_id,
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
+         guest_migrated_to_player_id,
          credential_bound_at,
          privacy_consent_at,
          phone_number,
@@ -6496,6 +6802,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
              wechat_mini_game_open_id = ?,
              wechat_mini_game_union_id = COALESCE(?, wechat_mini_game_union_id),
              wechat_mini_game_bound_at = COALESCE(wechat_mini_game_bound_at, ?),
+             guest_migrated_to_player_id = NULL,
              age_verified = COALESCE(?, age_verified),
              is_minor = COALESCE(?, is_minor),
              version = version + 1
@@ -6538,6 +6845,119 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         wechatMiniGameBoundAt: boundAt
       })
     );
+  }
+
+  async migrateGuestToRegistered(input: GuestAccountMigrationInput): Promise<GuestAccountMigrationResult> {
+    const guestPlayerId = normalizePlayerId(input.guestPlayerId);
+    const targetPlayerId = normalizePlayerId(input.targetPlayerId);
+    if (!guestPlayerId.startsWith("guest-")) {
+      throw new Error("guestPlayerId must be an ephemeral guest account");
+    }
+    if (guestPlayerId === targetPlayerId) {
+      throw new Error("guestPlayerId must not match targetPlayerId");
+    }
+
+    const guestAccount = await this.loadPlayerAccount(guestPlayerId);
+    if (!guestAccount) {
+      throw new Error("guest account not found");
+    }
+    if (guestAccount.guestMigratedToPlayerId) {
+      throw new Error("guest account already migrated");
+    }
+
+    const targetAccount =
+      (await this.loadPlayerAccount(targetPlayerId)) ??
+      normalizePlayerAccountSnapshot({
+        playerId: targetPlayerId,
+        displayName: targetPlayerId,
+        globalResources: normalizeResourceLedger()
+      });
+    const guestHeroArchives = await this.loadPlayerHeroArchives([guestPlayerId]);
+    const guestQuestState = await this.loadPlayerQuestState?.(guestPlayerId);
+    const nextTargetAccount = buildGuestMigrationTargetAccount({
+      progressAccount: input.progressSource === "guest" ? guestAccount : targetAccount,
+      targetAccount,
+      targetPlayerId,
+      wechatIdentity: input.wechatIdentity
+    });
+    const migratedGuestAccount = buildMigratedGuestAccountTombstone(guestAccount, targetPlayerId);
+    const connection = await this.pool.getConnection();
+
+    try {
+      await connection.beginTransaction();
+      await upsertPlayerAccountForMigration(connection, targetAccount, nextTargetAccount);
+      await upsertPlayerAccountForMigration(connection, guestAccount, migratedGuestAccount);
+
+      await connection.query(
+        `DELETE FROM \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\`
+         WHERE player_id IN (?, ?)`,
+        [guestPlayerId, targetPlayerId]
+      );
+      if (input.progressSource === "guest" && guestHeroArchives.length > 0) {
+        await savePlayerHeroArchives(
+          connection,
+          guestHeroArchives.map((archive) => ({
+            ...archive,
+            playerId: targetPlayerId,
+            hero: {
+              ...archive.hero,
+              playerId: targetPlayerId
+            }
+          }))
+        );
+      }
+
+      await connection.query(
+        `DELETE FROM \`${MYSQL_PLAYER_QUEST_STATE_TABLE}\`
+         WHERE player_id IN (?, ?)`,
+        [guestPlayerId, targetPlayerId]
+      );
+      if (input.progressSource === "guest" && guestQuestState) {
+        const nextQuestState = normalizePlayerQuestState({
+          ...guestQuestState,
+          playerId: targetPlayerId
+        });
+        await connection.query(
+          `INSERT INTO \`${MYSQL_PLAYER_QUEST_STATE_TABLE}\` (
+             player_id,
+             current_date_key,
+             active_quest_ids_json,
+             rotations_json,
+             updated_at
+           )
+           VALUES (?, ?, ?, ?, ?)
+           ON DUPLICATE KEY UPDATE
+             current_date_key = VALUES(current_date_key),
+             active_quest_ids_json = VALUES(active_quest_ids_json),
+             rotations_json = VALUES(rotations_json),
+             updated_at = VALUES(updated_at)`,
+          [
+            nextQuestState.playerId,
+            nextQuestState.currentDateKey ?? null,
+            JSON.stringify(nextQuestState.activeQuestIds),
+            JSON.stringify(nextQuestState.rotations),
+            new Date(nextQuestState.updatedAt)
+          ]
+        );
+      }
+
+      await connection.query(
+        `DELETE FROM \`${MYSQL_PLAYER_ACCOUNT_SESSION_TABLE}\`
+         WHERE player_id = ?`,
+        [guestPlayerId]
+      );
+      await connection.commit();
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+
+    return {
+      account: (await this.loadPlayerAccount(targetPlayerId)) ?? nextTargetAccount,
+      guestAccount: (await this.loadPlayerAccount(guestPlayerId)) ?? migratedGuestAccount
+    };
   }
 
   async deletePlayerAccount(
@@ -6594,6 +7014,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
            wechat_mini_game_open_id = NULL,
            wechat_mini_game_union_id = NULL,
            wechat_mini_game_bound_at = NULL,
+           guest_migrated_to_player_id = NULL,
            version = version + 1
        WHERE player_id = ?`,
       [anonymizedDisplayName, JSON.stringify(normalizeResourceLedger()), JSON.stringify([]), normalizedPlayerId]
@@ -7104,6 +7525,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          wechat_mini_game_open_id,
          wechat_mini_game_union_id,
          wechat_mini_game_bound_at,
+         guest_migrated_to_player_id,
          credential_bound_at,
          privacy_consent_at,
          phone_number,

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -14,6 +14,7 @@ import {
   resetAnalyticsRuntimeDependencies
 } from "../src/analytics";
 import {
+  createWechatMiniGamePlayerId,
   hashAccountPassword,
   issueAccountAuthSession,
   registerAuthRoutes,
@@ -33,9 +34,12 @@ import type {
   PlayerAccountDeviceSessionSnapshot,
   PlayerAccountCredentialInput,
   PlayerAccountEnsureInput,
+  GuestAccountMigrationInput,
+  GuestAccountMigrationResult,
   PlayerEventHistoryQuery,
   PlayerEventHistorySnapshot,
   PlayerAccountListOptions,
+  PlayerQuestState,
   PlayerAccountUnbanInput,
   PlayerBanHistoryRecord,
   PlayerAccountProfilePatch,
@@ -52,6 +56,8 @@ class MemoryAuthStore implements RoomSnapshotStore {
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
+  private readonly heroArchives = new Map<string, PlayerHeroArchiveSnapshot>();
+  private readonly questStates = new Map<string, PlayerQuestState>();
 
   async load(_roomId: string): Promise<RoomPersistenceSnapshot | null> {
     return null;
@@ -160,8 +166,29 @@ class MemoryAuthStore implements RoomSnapshotStore {
     return this.authSessionsByPlayerId.get(playerId.trim())?.delete(sessionId.trim()) ?? false;
   }
 
-  async loadPlayerHeroArchives(_playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
-    return [];
+  async loadPlayerHeroArchives(playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]> {
+    const playerIdSet = new Set(playerIds.map((playerId) => playerId.trim()));
+    return Array.from(this.heroArchives.values()).filter((archive) => playerIdSet.has(archive.playerId));
+  }
+
+  async loadPlayerQuestState(playerId: string): Promise<PlayerQuestState | null> {
+    return this.questStates.get(playerId.trim()) ?? null;
+  }
+
+  async savePlayerQuestState(playerId: string, state: PlayerQuestState): Promise<PlayerQuestState> {
+    const nextState: PlayerQuestState = {
+      playerId: playerId.trim(),
+      ...(state.currentDateKey ? { currentDateKey: state.currentDateKey } : {}),
+      activeQuestIds: [...state.activeQuestIds],
+      rotations: structuredClone(state.rotations),
+      updatedAt: state.updatedAt
+    };
+    this.questStates.set(nextState.playerId, nextState);
+    return nextState;
+  }
+
+  seedHeroArchive(archive: PlayerHeroArchiveSnapshot): void {
+    this.heroArchives.set(`${archive.playerId}:${archive.heroId}`, structuredClone(archive));
   }
 
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
@@ -190,6 +217,7 @@ class MemoryAuthStore implements RoomSnapshotStore {
       ...(existing?.wechatMiniGameOpenId ? { wechatMiniGameOpenId: existing.wechatMiniGameOpenId } : {}),
       ...(existing?.wechatMiniGameUnionId ? { wechatMiniGameUnionId: existing.wechatMiniGameUnionId } : {}),
       ...(existing?.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt } : {}),
+      ...(existing?.guestMigratedToPlayerId ? { guestMigratedToPlayerId: existing.guestMigratedToPlayerId } : {}),
       ...(existing?.credentialBoundAt ? { credentialBoundAt: existing.credentialBoundAt } : {}),
       ...(existing?.privacyConsentAt ? { privacyConsentAt: existing.privacyConsentAt } : {}),
       ...(existing?.phoneNumber ? { phoneNumber: existing.phoneNumber } : {}),
@@ -385,11 +413,119 @@ class MemoryAuthStore implements RoomSnapshotStore {
       ...(input.ageVerified !== undefined ? { ageVerified: input.ageVerified } : existing.ageVerified ? { ageVerified: existing.ageVerified } : {}),
       ...(input.isMinor !== undefined ? { isMinor: input.isMinor } : existing.isMinor ? { isMinor: existing.isMinor } : {}),
       wechatMiniGameBoundAt: existing.wechatMiniGameBoundAt ?? new Date().toISOString(),
+      guestMigratedToPlayerId: undefined,
       updatedAt: new Date().toISOString()
     };
     this.accounts.set(existing.playerId, account);
     this.playerIdByWechatOpenId.set(normalizedOpenId, existing.playerId);
     return account;
+  }
+
+  async migrateGuestToRegistered(input: GuestAccountMigrationInput): Promise<GuestAccountMigrationResult> {
+    const guestPlayerId = input.guestPlayerId.trim();
+    const targetPlayerId = input.targetPlayerId.trim();
+    const guestAccount = await this.ensurePlayerAccount({ playerId: guestPlayerId });
+    const targetAccount = await this.ensurePlayerAccount({ playerId: targetPlayerId });
+    const progressSource = input.progressSource === "target" ? targetAccount : guestAccount;
+    const nextTarget: PlayerAccountSnapshot = {
+      ...targetAccount,
+      ...structuredClone(progressSource),
+      playerId: targetPlayerId,
+      displayName: input.wechatIdentity.displayName?.trim() || progressSource.displayName,
+      ...(input.wechatIdentity.avatarUrl?.trim()
+        ? { avatarUrl: input.wechatIdentity.avatarUrl.trim() }
+        : progressSource.avatarUrl
+          ? { avatarUrl: progressSource.avatarUrl }
+          : targetAccount.avatarUrl
+            ? { avatarUrl: targetAccount.avatarUrl }
+            : {}),
+      ...(targetAccount.loginId ? { loginId: targetAccount.loginId } : {}),
+      ...(targetAccount.credentialBoundAt ? { credentialBoundAt: targetAccount.credentialBoundAt } : {}),
+      ...(targetAccount.phoneNumber ? { phoneNumber: targetAccount.phoneNumber } : {}),
+      ...(targetAccount.phoneNumberBoundAt ? { phoneNumberBoundAt: targetAccount.phoneNumberBoundAt } : {}),
+      ...(targetAccount.accountSessionVersion !== undefined ? { accountSessionVersion: targetAccount.accountSessionVersion } : {}),
+      wechatMiniGameOpenId: input.wechatIdentity.openId.trim(),
+      ...(input.wechatIdentity.unionId?.trim()
+        ? { wechatMiniGameUnionId: input.wechatIdentity.unionId.trim() }
+        : targetAccount.wechatMiniGameUnionId
+          ? { wechatMiniGameUnionId: targetAccount.wechatMiniGameUnionId }
+          : {}),
+      ...(input.wechatIdentity.ageVerified !== undefined
+        ? { ageVerified: input.wechatIdentity.ageVerified }
+        : progressSource.ageVerified !== undefined
+          ? { ageVerified: progressSource.ageVerified }
+          : {}),
+      ...(input.wechatIdentity.isMinor !== undefined
+        ? { isMinor: input.wechatIdentity.isMinor }
+        : progressSource.isMinor !== undefined
+          ? { isMinor: progressSource.isMinor }
+          : {}),
+      wechatMiniGameBoundAt: targetAccount.wechatMiniGameBoundAt ?? new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    delete nextTarget.guestMigratedToPlayerId;
+    this.accounts.set(targetPlayerId, nextTarget);
+    this.playerIdByWechatOpenId.set(nextTarget.wechatMiniGameOpenId!, targetPlayerId);
+
+    if (input.progressSource === "guest") {
+      const guestArchives = await this.loadPlayerHeroArchives([guestPlayerId]);
+      for (const key of Array.from(this.heroArchives.keys())) {
+        if (key.startsWith(`${targetPlayerId}:`) || key.startsWith(`${guestPlayerId}:`)) {
+          this.heroArchives.delete(key);
+        }
+      }
+      for (const archive of guestArchives) {
+        this.heroArchives.set(`${targetPlayerId}:${archive.heroId}`, {
+          ...structuredClone(archive),
+          playerId: targetPlayerId,
+          hero: {
+            ...structuredClone(archive.hero),
+            playerId: targetPlayerId
+          }
+        });
+      }
+      const guestQuestState = await this.loadPlayerQuestState(guestPlayerId);
+      this.questStates.delete(targetPlayerId);
+      this.questStates.delete(guestPlayerId);
+      if (guestQuestState) {
+        this.questStates.set(targetPlayerId, {
+          ...structuredClone(guestQuestState),
+          playerId: targetPlayerId
+        });
+      }
+    } else {
+      for (const key of Array.from(this.heroArchives.keys())) {
+        if (key.startsWith(`${guestPlayerId}:`)) {
+          this.heroArchives.delete(key);
+        }
+      }
+      this.questStates.delete(guestPlayerId);
+    }
+
+    const migratedGuest: PlayerAccountSnapshot = {
+      ...guestAccount,
+      globalResources: { gold: 0, wood: 0, ore: 0 },
+      achievements: [],
+      recentBattleReplays: [],
+      gems: 0,
+      seasonXp: 0,
+      loginStreak: 0,
+      guestMigratedToPlayerId: targetPlayerId,
+      updatedAt: new Date().toISOString()
+    };
+    delete migratedGuest.wechatMiniGameOpenId;
+    delete migratedGuest.wechatMiniGameUnionId;
+    delete migratedGuest.wechatMiniGameBoundAt;
+    delete migratedGuest.loginId;
+    delete migratedGuest.credentialBoundAt;
+    delete migratedGuest.phoneNumber;
+    delete migratedGuest.phoneNumberBoundAt;
+    this.accounts.set(guestPlayerId, migratedGuest);
+
+    return {
+      account: nextTarget,
+      guestAccount: migratedGuest
+    };
   }
 
   async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {
@@ -3279,6 +3415,326 @@ test("wechat mini game production exchange binds code2Session identity onto an a
   assert.equal(storedAccount?.wechatMiniGameOpenId, "wx-openid-prod");
   assert.equal(storedAccount?.wechatMiniGameUnionId, "wx-union-prod");
   assert.equal(storedAccount?.loginId, "veil-ranger");
+});
+
+test("wechat mini game login migrates guest progression to a new WeChat account and revokes the guest session", { concurrency: false }, async (t) => {
+  const port = 44965 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+  const originalFetch = globalThis.fetch;
+  const guestPlayerId = "guest-upgrade-player";
+
+  t.after(async () => {
+    globalThis.fetch = originalFetch;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
+    delete process.env.WECHAT_APP_ID;
+    delete process.env.WECHAT_APP_SECRET;
+    delete process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL;
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "production";
+  process.env.WECHAT_APP_ID = "wx-prod-app";
+  process.env.WECHAT_APP_SECRET = "wx-prod-secret";
+  process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL = "https://wechat.example.test/code2session";
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        openid: "wx-openid-upgrade",
+        unionid: "wx-union-upgrade",
+        session_key: "session-key"
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+  const guestLoginResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: guestPlayerId,
+      displayName: "游客旅人",
+      privacyConsentAccepted: true
+    })
+  });
+  const guestLoginPayload = (await guestLoginResponse.json()) as { session: GuestAuthSession };
+  assert.equal(guestLoginResponse.status, 200);
+
+  await store.savePlayerAccountProgress(guestPlayerId, {
+    gems: 88,
+    globalResources: { gold: 520, wood: 140, ore: 65 },
+    achievements: [
+      {
+        achievementId: "guest-achievement",
+        progress: 1,
+        completedAt: "2026-04-10T00:00:00.000Z"
+      }
+    ],
+    loginStreak: 3
+  });
+  await store.savePlayerQuestState(guestPlayerId, {
+    playerId: guestPlayerId,
+    currentDateKey: "2026-04-11",
+    activeQuestIds: ["quest-upgrade"],
+    rotations: [],
+    updatedAt: "2026-04-11T00:00:00.000Z"
+  });
+
+  const response = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${guestLoginPayload.session.token}`
+    },
+    body: JSON.stringify({
+      code: "wx-prod-code",
+      displayName: "微信旅人",
+      privacyConsentAccepted: true
+    })
+  });
+  const payload = (await response.json()) as {
+    session: GuestAuthSession;
+    accountMigration: {
+      notice: string;
+      previousGuestPlayerId: string;
+      migratedToPlayerId: string;
+      strategy: string;
+    };
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.accountMigration.notice, "您的游客进度将合并到新账号");
+  assert.equal(payload.accountMigration.previousGuestPlayerId, guestPlayerId);
+  assert.equal(payload.accountMigration.strategy, "keep_guest");
+  assert.equal(payload.session.playerId, createWechatMiniGamePlayerId("wx-openid-upgrade"));
+
+  const migratedAccount = await store.loadPlayerAccount(payload.session.playerId);
+  assert.equal(migratedAccount?.gems, 88);
+  assert.deepEqual(migratedAccount?.globalResources, { gold: 520, wood: 140, ore: 65 });
+  assert.equal(migratedAccount?.wechatMiniGameOpenId, "wx-openid-upgrade");
+  assert.equal((await store.loadPlayerQuestState(payload.session.playerId))?.activeQuestIds[0], "quest-upgrade");
+
+  const guestAccount = await store.loadPlayerAccount(guestPlayerId);
+  assert.equal(guestAccount?.guestMigratedToPlayerId, payload.session.playerId);
+
+  const guestSessionCheck = await originalFetch(`http://127.0.0.1:${port}/api/auth/session`, {
+    headers: {
+      Authorization: `Bearer ${guestLoginPayload.session.token}`
+    }
+  });
+  const guestSessionPayload = (await guestSessionCheck.json()) as { error: { code: string } };
+  assert.equal(guestSessionCheck.status, 401);
+  assert.equal(guestSessionPayload.error.code, "session_revoked");
+
+  const reusedGuestResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: guestPlayerId,
+      displayName: "游客旅人",
+      privacyConsentAccepted: true
+    })
+  });
+  const reusedGuestPayload = (await reusedGuestResponse.json()) as { error: { code: string } };
+  assert.equal(reusedGuestResponse.status, 409);
+  assert.equal(reusedGuestPayload.error.code, "guest_account_migrated");
+});
+
+test("wechat guest upgrade returns a conflict when the bound account already has progression", { concurrency: false }, async (t) => {
+  const port = 44970 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+  const originalFetch = globalThis.fetch;
+
+  t.after(async () => {
+    globalThis.fetch = originalFetch;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
+    delete process.env.WECHAT_APP_ID;
+    delete process.env.WECHAT_APP_SECRET;
+    delete process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL;
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "production";
+  process.env.WECHAT_APP_ID = "wx-prod-app";
+  process.env.WECHAT_APP_SECRET = "wx-prod-secret";
+  process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL = "https://wechat.example.test/code2session";
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        openid: "wx-openid-conflict",
+        session_key: "session-key"
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+  await store.ensurePlayerAccount({
+    playerId: createWechatMiniGamePlayerId("wx-openid-conflict"),
+    displayName: "已绑定旅人"
+  });
+  await store.bindPlayerAccountWechatMiniGameIdentity(createWechatMiniGamePlayerId("wx-openid-conflict"), {
+    openId: "wx-openid-conflict",
+    displayName: "已绑定旅人"
+  });
+  await store.savePlayerAccountProgress(createWechatMiniGamePlayerId("wx-openid-conflict"), {
+    gems: 50,
+    globalResources: { gold: 200, wood: 50, ore: 20 }
+  });
+
+  const guestLoginResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: "guest-conflict-upgrade",
+      displayName: "冲突游客",
+      privacyConsentAccepted: true
+    })
+  });
+  const guestLoginPayload = (await guestLoginResponse.json()) as { session: GuestAuthSession };
+  await store.savePlayerAccountProgress("guest-conflict-upgrade", {
+    gems: 10,
+    globalResources: { gold: 10, wood: 0, ore: 0 }
+  });
+
+  const response = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${guestLoginPayload.session.token}`
+    },
+    body: JSON.stringify({
+      code: "wx-prod-code",
+      privacyConsentAccepted: true
+    })
+  });
+  const payload = (await response.json()) as {
+    error: { code: string };
+    migrationConflict: {
+      notice: string;
+      guest: { playerId: string };
+      registered: { playerId: string };
+      choices: string[];
+    };
+  };
+
+  assert.equal(response.status, 409);
+  assert.equal(payload.error.code, "wechat_guest_upgrade_conflict");
+  assert.equal(payload.migrationConflict.notice, "您的游客进度将合并到新账号");
+  assert.equal(payload.migrationConflict.guest.playerId, "guest-conflict-upgrade");
+  assert.equal(payload.migrationConflict.registered.playerId, createWechatMiniGamePlayerId("wx-openid-conflict"));
+  assert.deepEqual(payload.migrationConflict.choices, ["keep_registered", "keep_guest"]);
+});
+
+test("wechat guest upgrade can keep the registered progression when explicitly chosen", { concurrency: false }, async (t) => {
+  const port = 44975 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+  const originalFetch = globalThis.fetch;
+  const registeredPlayerId = createWechatMiniGamePlayerId("wx-openid-keep-registered");
+
+  t.after(async () => {
+    globalThis.fetch = originalFetch;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
+    delete process.env.WECHAT_APP_ID;
+    delete process.env.WECHAT_APP_SECRET;
+    delete process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL;
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "production";
+  process.env.WECHAT_APP_ID = "wx-prod-app";
+  process.env.WECHAT_APP_SECRET = "wx-prod-secret";
+  process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL = "https://wechat.example.test/code2session";
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        openid: "wx-openid-keep-registered",
+        session_key: "session-key"
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+  await store.ensurePlayerAccount({
+    playerId: registeredPlayerId,
+    displayName: "老账号"
+  });
+  await store.bindPlayerAccountWechatMiniGameIdentity(registeredPlayerId, {
+    openId: "wx-openid-keep-registered",
+    displayName: "老账号"
+  });
+  await store.savePlayerAccountProgress(registeredPlayerId, {
+    gems: 120,
+    globalResources: { gold: 900, wood: 300, ore: 140 }
+  });
+
+  const guestLoginResponse = await originalFetch(`http://127.0.0.1:${port}/api/auth/guest-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      playerId: "guest-keep-registered",
+      displayName: "游客候选",
+      privacyConsentAccepted: true
+    })
+  });
+  const guestLoginPayload = (await guestLoginResponse.json()) as { session: GuestAuthSession };
+  await store.savePlayerAccountProgress("guest-keep-registered", {
+    gems: 5,
+    globalResources: { gold: 5, wood: 1, ore: 0 }
+  });
+
+  const response = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${guestLoginPayload.session.token}`
+    },
+    body: JSON.stringify({
+      code: "wx-prod-code",
+      migrationChoice: "keep_registered",
+      privacyConsentAccepted: true
+    })
+  });
+  const payload = (await response.json()) as {
+    session: GuestAuthSession;
+    accountMigration: {
+      strategy: string;
+      migratedToPlayerId: string;
+    };
+  };
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.session.playerId, registeredPlayerId);
+  assert.equal(payload.accountMigration.strategy, "keep_registered");
+
+  const registeredAccount = await store.loadPlayerAccount(registeredPlayerId);
+  assert.equal(registeredAccount?.gems, 125);
+  assert.deepEqual(registeredAccount?.globalResources, { gold: 950, wood: 300, ore: 140 });
+  assert.equal((await store.loadPlayerAccount("guest-keep-registered"))?.guestMigratedToPlayerId, registeredPlayerId);
 });
 
 test("wechat mini game login stores verified minor status when age data is provided", { concurrency: false }, async (t) => {

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -31,6 +31,9 @@
 - `POST /api/auth/wechat-login` 会用服务端环境变量 `WECHAT_APP_ID` / `WECHAT_APP_SECRET` 调用微信 `jscode2session`。
 - 当同一个微信小游戏账号重复登录时，服务端会复用已经绑定过的 `playerId`，不会因为客户端再次提交不同的 `playerId` 而漂移。
 - 若当前请求已经带有正式账号会话，服务端会把该微信身份绑定到现有账号；后续该微信登录会继续命中同一个账号档。
+- 若当前请求带着游客会话，服务端会把游客进度原子迁移到微信账号档，并在响应里返回 `accountMigration.notice="您的游客进度将合并到新账号"` 供客户端展示。
+- 当同一微信号已绑定且目标账号已有进度时，接口返回 `409 wechat_guest_upgrade_conflict`，要求客户端显式传 `migrationChoice=keep_registered|keep_guest` 再继续。
+- 迁移完成后，旧游客档会记录 `guestMigratedToPlayerId`，旧游客 token 会返回 `401 session_revoked`，同一 `guest-*` ID 也不能再次通过 `POST /api/auth/guest-login` 复用。
 - 服务端只消费微信返回的 `openid` / `unionid` 做绑定，不会把 `session_key` 写入客户端响应。
 - mock code 仅保留给 `NODE_ENV=test` 的自动化测试；非测试环境即使显式配置 `VEIL_WECHAT_MINIGAME_LOGIN_MODE=mock` 也不会启用。
 

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -152,6 +152,17 @@ Recommended indexes:
 
 This append-only table records the initial display name and every subsequent rename accepted by the server. Admin/support tooling can query by `player_id` to inspect a single account timeline or by `normalized_name` to trace who previously used a suspicious name.
 
+## Guest Upgrade Transaction
+
+微信游客升级现在通过单个服务端事务完成，事务边界覆盖：
+
+- `player_accounts` 目标账号写入与旧 `guest-*` 账号 tombstone 标记（`guest_migrated_to_player_id`）
+- `player_hero_archives` 从游客档迁移到目标账号，或在保留正式档时直接清理旧游客档
+- `player_quest_states` 跟随同一策略迁移或保留
+- `player_account_sessions` 清理旧游客关联的持久化会话痕迹
+
+因此迁移失败时不会留下“账号已绑定但英雄/任务没迁完”的半完成状态。
+
 ### Table: `player_name_reservations`
 
 | Column | Type | Nullable | Default | Description |


### PR DESCRIPTION
## Summary
- add an atomic guest -> WeChat account migration path in persistence, including quest/archive transfer and guest tombstoning
- route WeChat guest upgrades through the new migration flow with conflict handling for existing bound progression
- cover the migration/conflict flows in auth integration tests and document the new lifecycle/transaction behavior

Closes #1232