### PR TITLE
Support interrupted battle recovery for #1224

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -171,6 +171,12 @@ function hasPlayerAccountStore(
   return Boolean(store?.loadPlayerAccount && store.savePlayerAccountProgress);
 }
 
+function hasBattleSnapshotHistoryStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listBattleSnapshotsForPlayer">> {
+  return Boolean(store?.listBattleSnapshotsForPlayer);
+}
+
 function sendInvalidJson(response: ServerResponse): void {
   sendJson(response, 400, { error: "Invalid JSON body" });
 }
@@ -727,6 +733,9 @@ export function registerAdminRoutes(
       const banHistory = hasBanModerationStore(store)
         ? await store.listPlayerBanHistory(playerId, { limit: readLimit(request, 100) })
         : [];
+      const battleHistory = hasBattleSnapshotHistoryStore(store)
+        ? await store.listBattleSnapshotsForPlayer(playerId, { limit: readLimit(request, 50) })
+        : [];
 
       sendJson(response, 200, {
         playerId,
@@ -735,7 +744,8 @@ export function registerAdminRoutes(
         moderation: {
           currentBan,
           banHistory
-        }
+        },
+        battleHistory
       });
     } catch (error) {
       if (error instanceof InvalidAdminPayloadError) {

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -42,6 +42,7 @@ import {
   isPlayerBanActive,
   type RoomSnapshotStore,
   type PlayerAccountSnapshot,
+  type BattleSnapshotRecord
 } from "./persistence";
 import {
   configureConfigRuntimeStatusProvider,
@@ -156,6 +157,23 @@ function hasPlayerReportStore(
   store: RoomSnapshotStore | null
 ): store is RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "createPlayerReport">> {
   return Boolean(store?.createPlayerReport);
+}
+
+function hasBattleSnapshotStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore &
+  Required<
+    Pick<
+      RoomSnapshotStore,
+      "saveBattleSnapshotStart" | "saveBattleSnapshotResolution" | "settleInterruptedBattleSnapshot" | "listBattleSnapshotsForPlayer"
+    >
+  > {
+  return Boolean(
+    store?.saveBattleSnapshotStart &&
+      store.saveBattleSnapshotResolution &&
+      store.settleInterruptedBattleSnapshot &&
+      store.listBattleSnapshotsForPlayer
+  );
 }
 
 export interface LobbyRoomSummary {
@@ -496,6 +514,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         return;
       }
       await this.ensurePlayerWorldSlot(playerId, ensuredAccount);
+      await this.reconcileInterruptedBattles(playerId);
       if (this.shouldRunTurnTimer()) {
         this.ensureTurnTimerState();
         await this.persistRoomState();
@@ -597,7 +616,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         sendMessage(client, "error", { requestId: message.requestId, reason: "persistence_save_failed" });
         return;
       }
-      await this.persistPlayerAccountProgress(result.events ?? [], this.worldRoom.consumeCompletedBattleReplays());
+      const completedReplays = this.worldRoom.consumeCompletedBattleReplays();
+      await this.persistBattleSnapshots(result.events ?? [], completedReplays);
+      await this.persistPlayerAccountProgress(result.events ?? [], completedReplays);
       this.emitAnalyticsForWorldEvents(playerId, result.events ?? []);
 
       this.publishLobbyRoomSummary();
@@ -661,7 +682,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         sendMessage(client, "error", { requestId: message.requestId, reason: "persistence_save_failed" });
         return;
       }
-      await this.persistPlayerAccountProgress(result.events ?? [], this.worldRoom.consumeCompletedBattleReplays());
+      const completedReplays = this.worldRoom.consumeCompletedBattleReplays();
+      await this.persistBattleSnapshots(result.events ?? [], completedReplays);
+      await this.persistPlayerAccountProgress(result.events ?? [], completedReplays);
       this.emitAnalyticsForWorldEvents(playerId, result.events ?? []);
 
       this.publishLobbyRoomSummary();
@@ -1173,7 +1196,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       return;
     }
 
-    await this.persistPlayerAccountProgress(result.events ?? [], this.worldRoom.consumeCompletedBattleReplays());
+    const completedReplays = this.worldRoom.consumeCompletedBattleReplays();
+    await this.persistBattleSnapshots(result.events ?? [], completedReplays);
+    await this.persistPlayerAccountProgress(result.events ?? [], completedReplays);
     this.publishLobbyRoomSummary();
     this.pushSessionStateToAll({
       events: result.events ?? [],
@@ -1212,7 +1237,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       return;
     }
 
-    await this.persistPlayerAccountProgress(result.events ?? [], this.worldRoom.consumeCompletedBattleReplays());
+    const completedReplays = this.worldRoom.consumeCompletedBattleReplays();
+    await this.persistBattleSnapshots(result.events ?? [], completedReplays);
+    await this.persistPlayerAccountProgress(result.events ?? [], completedReplays);
     this.publishLobbyRoomSummary();
     this.pushSessionStateToAll({
       events: result.events ?? [],
@@ -1365,6 +1392,82 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     await configuredRoomSnapshotStore.save(this.metadata.logicalRoomId, this.worldRoom.serializePersistenceSnapshot());
   }
 
+  private async persistBattleSnapshots(
+    events: WorldEvent[],
+    completedReplays: CompletedBattleReplayCapture[]
+  ): Promise<void> {
+    const store = configuredRoomSnapshotStore;
+    if (!hasBattleSnapshotStore(store) || (events.length === 0 && completedReplays.length === 0)) {
+      return;
+    }
+
+    const replayByBattleId = new Map(completedReplays.map((replay) => [replay.battleId, replay] as const));
+    const activeBattlesById = new Map(this.worldRoom.getActiveBattles().map((battle) => [battle.id, battle] as const));
+    const internalState = this.worldRoom.getInternalState();
+
+    try {
+      for (const event of events) {
+        if (event.type === "battle.started") {
+          const battle = activeBattlesById.get(event.battleId);
+          if (!battle) {
+            continue;
+          }
+
+          const neutralArmyReward =
+            event.encounterKind === "neutral" && event.neutralArmyId
+              ? internalState.neutralArmies[event.neutralArmyId]?.reward
+              : null;
+          await store.saveBattleSnapshotStart({
+            roomId: this.metadata.logicalRoomId,
+            battleId: event.battleId,
+            heroId: event.heroId,
+            attackerPlayerId: event.attackerPlayerId,
+            ...(event.defenderPlayerId ? { defenderPlayerId: event.defenderPlayerId } : {}),
+            ...(event.defenderHeroId ? { defenderHeroId: event.defenderHeroId } : {}),
+            ...(event.neutralArmyId ? { neutralArmyId: event.neutralArmyId } : {}),
+            encounterKind: event.encounterKind,
+            ...(event.initiator ? { initiator: event.initiator } : {}),
+            path: event.path,
+            moveCost: event.moveCost,
+            playerIds: [event.attackerPlayerId, ...(event.defenderPlayerId ? [event.defenderPlayerId] : [])],
+            initialState: battle,
+            ...(neutralArmyReward
+              ? {
+                  estimatedCompensationGrant: {
+                    resources: {
+                      gold: neutralArmyReward.kind === "gold" ? neutralArmyReward.amount : 0,
+                      wood: neutralArmyReward.kind === "wood" ? neutralArmyReward.amount : 0,
+                      ore: neutralArmyReward.kind === "ore" ? neutralArmyReward.amount : 0
+                    }
+                  }
+                }
+              : {}),
+            startedAt: new Date(roomRuntimeDependencies.now()).toISOString()
+          });
+          continue;
+        }
+
+        if (event.type !== "battle.resolved") {
+          continue;
+        }
+
+        const replay = replayByBattleId.get(event.battleId);
+        await store.saveBattleSnapshotResolution({
+          roomId: this.metadata.logicalRoomId,
+          battleId: event.battleId,
+          result: event.result,
+          resolutionReason: "battle_resolved",
+          resolvedAt: replay?.completedAt ?? new Date(roomRuntimeDependencies.now()).toISOString()
+        });
+      }
+    } catch (error) {
+      console.error("[VeilRoom] Failed to persist battle snapshot state", {
+        roomId: this.metadata.logicalRoomId,
+        error
+      });
+    }
+  }
+
   private async persistPlayerAccountProgress(
     events: WorldEvent[],
     completedReplays: CompletedBattleReplayCapture[]
@@ -1479,6 +1582,76 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         error
       });
     }
+  }
+
+  private async reconcileInterruptedBattles(playerId: string): Promise<void> {
+    const store = configuredRoomSnapshotStore;
+    if (!hasBattleSnapshotStore(store)) {
+      return;
+    }
+
+    try {
+      const activeSnapshots = await store.listBattleSnapshotsForPlayer(playerId, {
+        statuses: ["active"],
+        limit: 20
+      });
+      for (const snapshot of activeSnapshots) {
+        if (this.currentRoomIncludesBattle(snapshot, playerId)) {
+          continue;
+        }
+        if (activeRoomInstances.has(snapshot.roomId)) {
+          continue;
+        }
+
+        const compensation = this.buildInterruptedBattleCompensation(snapshot);
+        await store.settleInterruptedBattleSnapshot({
+          roomId: snapshot.roomId,
+          battleId: snapshot.battleId,
+          status: snapshot.estimatedCompensationGrant ? "compensated" : "aborted",
+          resolutionReason: "room_missing_after_disconnect",
+          ...(compensation ? { compensation } : {}),
+          resolvedAt: new Date(roomRuntimeDependencies.now()).toISOString()
+        });
+      }
+    } catch (error) {
+      console.error("[VeilRoom] Failed to reconcile interrupted battles", {
+        roomId: this.metadata.logicalRoomId,
+        playerId,
+        error
+      });
+    }
+  }
+
+  private currentRoomIncludesBattle(snapshot: BattleSnapshotRecord, playerId: string): boolean {
+    const activeBattle = this.worldRoom.getBattleForPlayer(playerId);
+    if (activeBattle?.id === snapshot.battleId) {
+      return true;
+    }
+
+    return this.worldRoom.getActiveBattles().some((battle) => battle.id === snapshot.battleId);
+  }
+
+  private buildInterruptedBattleCompensation(snapshot: BattleSnapshotRecord) {
+    const grant = snapshot.estimatedCompensationGrant;
+    const messageId = `${snapshot.battleId}:disconnect-recovery`;
+    if (grant) {
+      return {
+        mailboxMessageId: messageId,
+        playerIds: [snapshot.attackerPlayerId],
+        kind: "compensation" as const,
+        title: "战斗中断补偿",
+        body: `房间 ${snapshot.roomId} 的战斗 ${snapshot.battleId} 在断线后未能恢复，系统已按开战快照补发可估算奖励。`,
+        grant
+      };
+    }
+
+    return {
+      mailboxMessageId: messageId,
+      playerIds: snapshot.playerIds,
+      kind: "system" as const,
+      title: "战斗中断通知",
+      body: `房间 ${snapshot.roomId} 的战斗 ${snapshot.battleId} 在断线后未能恢复，系统已保留记录供客服追溯。`
+    };
   }
 
   private buildPlayerBattleReplaysForAccount(

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -30,6 +30,12 @@ import {
   type PaymentOrderSettlement,
   type PaymentOrderSnapshot,
   type RoomSnapshotStore,
+  type BattleSnapshotCompensation,
+  type BattleSnapshotInterruptedSettlementInput,
+  type BattleSnapshotListOptions,
+  type BattleSnapshotRecord,
+  type BattleSnapshotResolutionInput,
+  type BattleSnapshotStartInput,
   type PlayerAccountBanHistoryListOptions,
   type PlayerAccountBanInput,
   type PlayerAccountBanSnapshot,
@@ -148,6 +154,7 @@ function normalizeResourceLedger(resources?: PlayerAccountSnapshot["globalResour
 
 export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly snapshots = new Map<string, RoomPersistenceSnapshot>();
+  private readonly battleSnapshots = new Map<string, BattleSnapshotRecord>();
   private readonly accounts = new Map<string, PlayerAccountSnapshot>();
   private readonly guilds = new Map<string, GuildState>();
   private readonly guildIdByPlayerId = new Map<string, string>();
@@ -435,6 +442,126 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
 
   async loadPlayerQuestState(playerId: string): Promise<PlayerQuestState | null> {
     return structuredClone(this.playerQuestStates.get(normalizePlayerId(playerId)) ?? null);
+  }
+
+  async saveBattleSnapshotStart(input: BattleSnapshotStartInput): Promise<BattleSnapshotRecord> {
+    const startedAt = input.startedAt ? new Date(input.startedAt) : new Date();
+    if (Number.isNaN(startedAt.getTime())) {
+      throw new Error("startedAt must be a valid ISO timestamp");
+    }
+
+    const key = `${input.roomId}:${input.battleId}`;
+    const existing = this.battleSnapshots.get(key);
+    const next: BattleSnapshotRecord = {
+      roomId: input.roomId,
+      battleId: input.battleId,
+      heroId: input.heroId,
+      attackerPlayerId: normalizePlayerId(input.attackerPlayerId),
+      ...(input.defenderPlayerId ? { defenderPlayerId: normalizePlayerId(input.defenderPlayerId) } : {}),
+      ...(input.defenderHeroId ? { defenderHeroId: input.defenderHeroId } : {}),
+      ...(input.neutralArmyId ? { neutralArmyId: input.neutralArmyId } : {}),
+      encounterKind: input.encounterKind,
+      ...(input.initiator ? { initiator: input.initiator } : {}),
+      path: structuredClone(input.path),
+      moveCost: Math.max(0, Math.floor(input.moveCost)),
+      playerIds: Array.from(new Set(input.playerIds.map((playerId) => normalizePlayerId(playerId)))),
+      initialState: structuredClone(input.initialState),
+      ...(input.estimatedCompensationGrant
+        ? { estimatedCompensationGrant: structuredClone(input.estimatedCompensationGrant) }
+        : {}),
+      status: "active",
+      startedAt: startedAt.toISOString(),
+      createdAt: existing?.createdAt ?? startedAt.toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    this.battleSnapshots.set(key, next);
+    return structuredClone(next);
+  }
+
+  async saveBattleSnapshotResolution(input: BattleSnapshotResolutionInput): Promise<BattleSnapshotRecord | null> {
+    const key = `${input.roomId}:${input.battleId}`;
+    const existing = this.battleSnapshots.get(key);
+    if (!existing) {
+      return null;
+    }
+
+    const resolvedAt = input.resolvedAt ? new Date(input.resolvedAt) : new Date();
+    if (Number.isNaN(resolvedAt.getTime())) {
+      throw new Error("resolvedAt must be a valid ISO timestamp");
+    }
+
+    const next: BattleSnapshotRecord = {
+      ...existing,
+      status: "resolved",
+      result: input.result,
+      resolutionReason: input.resolutionReason ?? "battle_resolved",
+      resolvedAt: resolvedAt.toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    delete next.compensation;
+    this.battleSnapshots.set(key, next);
+    return structuredClone(next);
+  }
+
+  async settleInterruptedBattleSnapshot(
+    input: BattleSnapshotInterruptedSettlementInput
+  ): Promise<BattleSnapshotRecord | null> {
+    const key = `${input.roomId}:${input.battleId}`;
+    const existing = this.battleSnapshots.get(key);
+    if (!existing) {
+      return null;
+    }
+
+    if (existing.status !== "active") {
+      return structuredClone(existing);
+    }
+
+    const resolvedAt = input.resolvedAt ? new Date(input.resolvedAt) : new Date();
+    if (Number.isNaN(resolvedAt.getTime())) {
+      throw new Error("resolvedAt must be a valid ISO timestamp");
+    }
+
+    if (input.compensation) {
+      await this.deliverPlayerMailbox({
+        playerIds: input.compensation.playerIds,
+        message: normalizePlayerMailboxMessage(
+          {
+            id: input.compensation.mailboxMessageId,
+            kind: input.compensation.kind,
+            title: input.compensation.title,
+            body: input.compensation.body,
+            ...(input.compensation.grant ? { grant: input.compensation.grant } : {})
+          },
+          resolvedAt
+        )
+      });
+    }
+
+    const next: BattleSnapshotRecord = {
+      ...existing,
+      status: input.status,
+      resolutionReason: input.resolutionReason,
+      ...(input.compensation ? { compensation: structuredClone(input.compensation) } : {}),
+      resolvedAt: resolvedAt.toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    this.battleSnapshots.set(key, next);
+    return structuredClone(next);
+  }
+
+  async listBattleSnapshotsForPlayer(
+    playerId: string,
+    options: BattleSnapshotListOptions = {}
+  ): Promise<BattleSnapshotRecord[]> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const statuses = options.statuses ? new Set(options.statuses) : null;
+    const limit = Math.max(1, Math.min(200, Math.floor(options.limit ?? 50)));
+
+    return Array.from(this.battleSnapshots.values())
+      .filter((record) => record.playerIds.includes(normalizedPlayerId) && (!statuses || statuses.has(record.status)))
+      .sort((left, right) => right.startedAt.localeCompare(left.startedAt) || left.battleId.localeCompare(right.battleId))
+      .slice(0, limit)
+      .map((record) => structuredClone(record));
   }
 
   async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -33,6 +33,9 @@ import {
   type PlayerAchievementProgress,
   type NotificationPreferences,
   type PlayerMailboxMessage,
+  type PlayerMailboxGrant,
+  type BattleState,
+  type Vec2,
   type RankedWeeklyProgress,
   type ResourceLedger,
   type SeasonalEventState,
@@ -108,6 +111,82 @@ export interface BattlePassClaimResult {
   granted: BattlePassRewardGrant;
   seasonPassPremiumApplied: boolean;
   account: PlayerAccountSnapshot;
+}
+
+export type BattleSnapshotStatus = "active" | "resolved" | "compensated" | "aborted";
+
+export interface BattleSnapshotCompensation {
+  mailboxMessageId: string;
+  playerIds: string[];
+  title: string;
+  body: string;
+  kind: PlayerMailboxMessage["kind"];
+  grant?: PlayerMailboxGrant;
+}
+
+export interface BattleSnapshotRecord {
+  roomId: string;
+  battleId: string;
+  heroId: string;
+  attackerPlayerId: string;
+  defenderPlayerId?: string;
+  defenderHeroId?: string;
+  neutralArmyId?: string;
+  encounterKind: "neutral" | "hero";
+  initiator?: "hero" | "neutral";
+  path: Vec2[];
+  moveCost: number;
+  playerIds: string[];
+  initialState: BattleState;
+  estimatedCompensationGrant?: PlayerMailboxGrant;
+  status: BattleSnapshotStatus;
+  result?: "attacker_victory" | "defender_victory";
+  resolutionReason?: string;
+  compensation?: BattleSnapshotCompensation;
+  startedAt: string;
+  resolvedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BattleSnapshotStartInput {
+  roomId: string;
+  battleId: string;
+  heroId: string;
+  attackerPlayerId: string;
+  defenderPlayerId?: string;
+  defenderHeroId?: string;
+  neutralArmyId?: string;
+  encounterKind: "neutral" | "hero";
+  initiator?: "hero" | "neutral";
+  path: Vec2[];
+  moveCost: number;
+  playerIds: string[];
+  initialState: BattleState;
+  estimatedCompensationGrant?: PlayerMailboxGrant;
+  startedAt?: string;
+}
+
+export interface BattleSnapshotResolutionInput {
+  roomId: string;
+  battleId: string;
+  result: "attacker_victory" | "defender_victory";
+  resolutionReason?: string;
+  resolvedAt?: string;
+}
+
+export interface BattleSnapshotInterruptedSettlementInput {
+  roomId: string;
+  battleId: string;
+  status: Extract<BattleSnapshotStatus, "compensated" | "aborted">;
+  resolutionReason: string;
+  compensation?: BattleSnapshotCompensation;
+  resolvedAt?: string;
+}
+
+export interface BattleSnapshotListOptions {
+  statuses?: BattleSnapshotStatus[];
+  limit?: number;
 }
 
 export interface RoomSnapshotStore {
@@ -189,6 +268,10 @@ export interface RoomSnapshotStore {
   resolvePlayerReport?(reportId: string, input: PlayerReportResolveInput): Promise<PlayerReportRecord | null>;
   savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot>;
   savePlayerAccountProgress(playerId: string, patch: PlayerAccountProgressPatch): Promise<PlayerAccountSnapshot>;
+  saveBattleSnapshotStart?(input: BattleSnapshotStartInput): Promise<BattleSnapshotRecord>;
+  saveBattleSnapshotResolution?(input: BattleSnapshotResolutionInput): Promise<BattleSnapshotRecord | null>;
+  settleInterruptedBattleSnapshot?(input: BattleSnapshotInterruptedSettlementInput): Promise<BattleSnapshotRecord | null>;
+  listBattleSnapshotsForPlayer?(playerId: string, options?: BattleSnapshotListOptions): Promise<BattleSnapshotRecord[]>;
   savePlayerQuestState?(playerId: string, state: PlayerQuestState): Promise<PlayerQuestState>;
   listPlayerAccounts(options?: PlayerAccountListOptions): Promise<PlayerAccountSnapshot[]>;
   getCurrentSeason(): Promise<SeasonSnapshot | null>;
@@ -465,6 +548,31 @@ interface PlayerReportRow extends RowDataPacket {
   status: string;
   created_at: Date | string;
   resolved_at: Date | string | null;
+}
+
+interface BattleSnapshotRow extends RowDataPacket {
+  room_id: string;
+  battle_id: string;
+  hero_id: string;
+  attacker_player_id: string;
+  defender_player_id: string | null;
+  defender_hero_id: string | null;
+  neutral_army_id: string | null;
+  encounter_kind: "neutral" | "hero";
+  initiator: "hero" | "neutral" | null;
+  path_json: string | Vec2[];
+  move_cost: number;
+  player_ids_json: string | string[];
+  initial_state_json: string | BattleState;
+  estimated_compensation_grant_json: string | PlayerMailboxGrant | null;
+  status: BattleSnapshotStatus;
+  result: "attacker_victory" | "defender_victory" | null;
+  resolution_reason: string | null;
+  compensation_json: string | BattleSnapshotCompensation | null;
+  started_at: Date | string;
+  resolved_at: Date | string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
 }
 
 export interface RoomSnapshotSummary {
@@ -930,6 +1038,8 @@ export const MYSQL_PLAYER_HERO_ARCHIVE_UPDATED_AT_INDEX = "idx_player_hero_archi
 export const MYSQL_PLAYER_REPORT_TABLE = "player_reports";
 export const MYSQL_PLAYER_REPORT_STATUS_CREATED_INDEX = "idx_player_reports_status_created";
 export const MYSQL_PLAYER_REPORT_ROOM_REPORTER_TARGET_INDEX = "uidx_player_reports_room_reporter_target";
+export const MYSQL_BATTLE_SNAPSHOT_TABLE = "battle_snapshots";
+export const MYSQL_BATTLE_SNAPSHOT_STATUS_UPDATED_INDEX = "idx_battle_snapshots_status_updated";
 export const MYSQL_GUILD_TABLE = "guilds";
 export const MYSQL_GUILD_UPDATED_AT_INDEX = "idx_guilds_updated_at";
 export const MYSQL_GUILD_TAG_INDEX = "uidx_guilds_tag";
@@ -1674,6 +1784,23 @@ function normalizePlayerId(playerId: string): string {
   const normalized = playerId.trim();
   if (normalized.length === 0) {
     throw new Error("playerId must not be empty");
+  }
+
+  return normalized;
+}
+
+function normalizeBattleSnapshotStatus(status: BattleSnapshotStatus): BattleSnapshotStatus {
+  if (status !== "active" && status !== "resolved" && status !== "compensated" && status !== "aborted") {
+    throw new Error("battle snapshot status is invalid");
+  }
+
+  return status;
+}
+
+function normalizeBattleSnapshotPlayerIds(playerIds: string[]): string[] {
+  const normalized = Array.from(new Set(playerIds.map((playerId) => normalizePlayerId(playerId))));
+  if (normalized.length === 0) {
+    throw new Error("battle snapshot must include at least one playerId");
   }
 
   return normalized;
@@ -2490,6 +2617,32 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_REPORT_TABLE}\` (
   UNIQUE KEY \`${MYSQL_PLAYER_REPORT_ROOM_REPORTER_TARGET_INDEX}\` (room_id, reporter_id, target_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\` (
+  room_id VARCHAR(191) NOT NULL,
+  battle_id VARCHAR(191) NOT NULL,
+  hero_id VARCHAR(191) NOT NULL,
+  attacker_player_id VARCHAR(191) NOT NULL,
+  defender_player_id VARCHAR(191) NULL,
+  defender_hero_id VARCHAR(191) NULL,
+  neutral_army_id VARCHAR(191) NULL,
+  encounter_kind VARCHAR(16) NOT NULL,
+  initiator VARCHAR(16) NULL,
+  path_json LONGTEXT NOT NULL,
+  move_cost INT NOT NULL,
+  player_ids_json LONGTEXT NOT NULL,
+  initial_state_json LONGTEXT NOT NULL,
+  estimated_compensation_grant_json LONGTEXT NULL,
+  status VARCHAR(16) NOT NULL DEFAULT 'active',
+  result VARCHAR(32) NULL,
+  resolution_reason VARCHAR(64) NULL,
+  compensation_json LONGTEXT NULL,
+  started_at DATETIME NOT NULL,
+  resolved_at DATETIME NULL DEFAULT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (room_id, battle_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 SET @veil_player_accounts_display_name_exists := (
   SELECT COUNT(*)
   FROM INFORMATION_SCHEMA.COLUMNS
@@ -2543,6 +2696,24 @@ SET @veil_player_reports_idx_sql := IF(
 PREPARE veil_player_reports_idx_stmt FROM @veil_player_reports_idx_sql;
 EXECUTE veil_player_reports_idx_stmt;
 DEALLOCATE PREPARE veil_player_reports_idx_stmt;
+
+SET @veil_battle_snapshots_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_BATTLE_SNAPSHOT_TABLE}'
+    AND INDEX_NAME = '${MYSQL_BATTLE_SNAPSHOT_STATUS_UPDATED_INDEX}'
+);
+
+SET @veil_battle_snapshots_idx_sql := IF(
+  @veil_battle_snapshots_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_BATTLE_SNAPSHOT_STATUS_UPDATED_INDEX}\` ON \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\` (status, updated_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_battle_snapshots_idx_stmt FROM @veil_battle_snapshots_idx_sql;
+EXECUTE veil_battle_snapshots_idx_stmt;
+DEALLOCATE PREPARE veil_battle_snapshots_idx_stmt;
 
 SET @veil_player_referrals_idx_exists := (
   SELECT COUNT(*)
@@ -3999,6 +4170,47 @@ function toPlayerReportRecord(row: PlayerReportRow): PlayerReportRecord {
   });
 }
 
+function toBattleSnapshotRecord(row: BattleSnapshotRow): BattleSnapshotRecord {
+  const startedAt = formatTimestamp(row.started_at);
+  const createdAt = formatTimestamp(row.created_at);
+  const updatedAt = formatTimestamp(row.updated_at);
+  if (!startedAt || !createdAt || !updatedAt) {
+    throw new Error("battle snapshot timestamps must be present");
+  }
+
+  const resolvedAt = formatTimestamp(row.resolved_at);
+  const compensation = row.compensation_json
+    ? parseJsonColumn<BattleSnapshotCompensation>(row.compensation_json)
+    : null;
+
+  return {
+    roomId: row.room_id,
+    battleId: row.battle_id,
+    heroId: row.hero_id,
+    attackerPlayerId: normalizePlayerId(row.attacker_player_id),
+    ...(row.defender_player_id ? { defenderPlayerId: normalizePlayerId(row.defender_player_id) } : {}),
+    ...(row.defender_hero_id ? { defenderHeroId: row.defender_hero_id } : {}),
+    ...(row.neutral_army_id ? { neutralArmyId: row.neutral_army_id } : {}),
+    encounterKind: row.encounter_kind,
+    ...(row.initiator ? { initiator: row.initiator } : {}),
+    path: parseJsonColumn<Vec2[]>(row.path_json),
+    moveCost: Math.max(0, Math.floor(row.move_cost)),
+    playerIds: normalizeBattleSnapshotPlayerIds(parseJsonColumn<string[]>(row.player_ids_json)),
+    initialState: parseJsonColumn<BattleState>(row.initial_state_json),
+    ...(row.estimated_compensation_grant_json
+      ? { estimatedCompensationGrant: parseJsonColumn<PlayerMailboxGrant>(row.estimated_compensation_grant_json) }
+      : {}),
+    status: normalizeBattleSnapshotStatus(row.status),
+    ...(row.result ? { result: row.result } : {}),
+    ...(row.resolution_reason ? { resolutionReason: row.resolution_reason } : {}),
+    ...(compensation ? { compensation } : {}),
+    startedAt,
+    ...(resolvedAt ? { resolvedAt } : {}),
+    createdAt,
+    updatedAt
+  };
+}
+
 async function appendPlayerEventHistoryEntries(
   queryable: Pick<Pool, "query"> | Pick<PoolConnection, "query">,
   playerId: string,
@@ -5142,6 +5354,199 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const row = rows[0];
     return row ? toPlayerQuestState(row) : null;
+  }
+
+  async saveBattleSnapshotStart(input: BattleSnapshotStartInput): Promise<BattleSnapshotRecord> {
+    const startedAt = input.startedAt ? new Date(input.startedAt) : new Date();
+    if (Number.isNaN(startedAt.getTime())) {
+      throw new Error("startedAt must be a valid ISO timestamp");
+    }
+
+    const normalizedPlayerIds = normalizeBattleSnapshotPlayerIds(input.playerIds);
+    await this.pool.query(
+      `INSERT INTO \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\` (
+         room_id,
+         battle_id,
+         hero_id,
+         attacker_player_id,
+         defender_player_id,
+         defender_hero_id,
+         neutral_army_id,
+         encounter_kind,
+         initiator,
+         path_json,
+         move_cost,
+         player_ids_json,
+         initial_state_json,
+         estimated_compensation_grant_json,
+         status,
+         started_at
+       )
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
+       ON DUPLICATE KEY UPDATE
+         hero_id = VALUES(hero_id),
+         attacker_player_id = VALUES(attacker_player_id),
+         defender_player_id = VALUES(defender_player_id),
+         defender_hero_id = VALUES(defender_hero_id),
+         neutral_army_id = VALUES(neutral_army_id),
+         encounter_kind = VALUES(encounter_kind),
+         initiator = VALUES(initiator),
+         path_json = VALUES(path_json),
+         move_cost = VALUES(move_cost),
+         player_ids_json = VALUES(player_ids_json),
+         initial_state_json = VALUES(initial_state_json),
+         estimated_compensation_grant_json = VALUES(estimated_compensation_grant_json),
+         status = 'active',
+         result = NULL,
+         resolution_reason = NULL,
+         compensation_json = NULL,
+         started_at = VALUES(started_at),
+         resolved_at = NULL`,
+      [
+        input.roomId,
+        input.battleId,
+        input.heroId,
+        normalizePlayerId(input.attackerPlayerId),
+        input.defenderPlayerId ? normalizePlayerId(input.defenderPlayerId) : null,
+        input.defenderHeroId ?? null,
+        input.neutralArmyId ?? null,
+        input.encounterKind,
+        input.initiator ?? null,
+        JSON.stringify(input.path),
+        Math.max(0, Math.floor(input.moveCost)),
+        JSON.stringify(normalizedPlayerIds),
+        JSON.stringify(input.initialState),
+        JSON.stringify(input.estimatedCompensationGrant ?? null),
+        startedAt
+      ]
+    );
+
+    const [rows] = await this.pool.query<BattleSnapshotRow[]>(
+      `SELECT *
+       FROM \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\`
+       WHERE room_id = ?
+         AND battle_id = ?
+       LIMIT 1`,
+      [input.roomId, input.battleId]
+    );
+
+    return toBattleSnapshotRecord(rows[0]!);
+  }
+
+  async saveBattleSnapshotResolution(input: BattleSnapshotResolutionInput): Promise<BattleSnapshotRecord | null> {
+    const resolvedAt = input.resolvedAt ? new Date(input.resolvedAt) : new Date();
+    if (Number.isNaN(resolvedAt.getTime())) {
+      throw new Error("resolvedAt must be a valid ISO timestamp");
+    }
+
+    await this.pool.query(
+      `UPDATE \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\`
+       SET status = 'resolved',
+           result = ?,
+           resolution_reason = ?,
+           compensation_json = NULL,
+           resolved_at = ?
+       WHERE room_id = ?
+         AND battle_id = ?`,
+      [input.result, input.resolutionReason ?? "battle_resolved", resolvedAt, input.roomId, input.battleId]
+    );
+
+    const [rows] = await this.pool.query<BattleSnapshotRow[]>(
+      `SELECT *
+       FROM \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\`
+       WHERE room_id = ?
+         AND battle_id = ?
+       LIMIT 1`,
+      [input.roomId, input.battleId]
+    );
+
+    return rows[0] ? toBattleSnapshotRecord(rows[0]) : null;
+  }
+
+  async settleInterruptedBattleSnapshot(
+    input: BattleSnapshotInterruptedSettlementInput
+  ): Promise<BattleSnapshotRecord | null> {
+    const resolvedAt = input.resolvedAt ? new Date(input.resolvedAt) : new Date();
+    if (Number.isNaN(resolvedAt.getTime())) {
+      throw new Error("resolvedAt must be a valid ISO timestamp");
+    }
+
+    if (input.compensation && this.deliverPlayerMailbox) {
+      const message: PlayerMailboxMessage = normalizePlayerMailboxMessage(
+        {
+          id: input.compensation.mailboxMessageId,
+          kind: input.compensation.kind,
+          title: input.compensation.title,
+          body: input.compensation.body,
+          ...(input.compensation.grant ? { grant: input.compensation.grant } : {})
+        },
+        resolvedAt
+      );
+      await this.deliverPlayerMailbox({
+        playerIds: input.compensation.playerIds,
+        message
+      });
+    }
+
+    await this.pool.query(
+      `UPDATE \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\`
+       SET status = ?,
+           resolution_reason = ?,
+           compensation_json = ?,
+           resolved_at = ?
+       WHERE room_id = ?
+         AND battle_id = ?
+         AND status = 'active'`,
+      [
+        normalizeBattleSnapshotStatus(input.status),
+        input.resolutionReason,
+        JSON.stringify(input.compensation ?? null),
+        resolvedAt,
+        input.roomId,
+        input.battleId
+      ]
+    );
+
+    const [rows] = await this.pool.query<BattleSnapshotRow[]>(
+      `SELECT *
+       FROM \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\`
+       WHERE room_id = ?
+         AND battle_id = ?
+       LIMIT 1`,
+      [input.roomId, input.battleId]
+    );
+
+    return rows[0] ? toBattleSnapshotRecord(rows[0]) : null;
+  }
+
+  async listBattleSnapshotsForPlayer(
+    playerId: string,
+    options: BattleSnapshotListOptions = {}
+  ): Promise<BattleSnapshotRecord[]> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const safeLimit = Math.max(1, Math.min(200, Math.floor(options.limit ?? 50)));
+    const normalizedStatuses = Array.from(
+      new Set((options.statuses ?? []).map((status) => normalizeBattleSnapshotStatus(status)))
+    );
+    const whereClauses = ["JSON_CONTAINS(player_ids_json, JSON_QUOTE(?), '$')"];
+    const params: Array<string | number> = [normalizedPlayerId];
+
+    if (normalizedStatuses.length > 0) {
+      whereClauses.push(`status IN (${normalizedStatuses.map(() => "?").join(", ")})`);
+      params.push(...normalizedStatuses);
+    }
+
+    params.push(safeLimit);
+    const [rows] = await this.pool.query<BattleSnapshotRow[]>(
+      `SELECT *
+       FROM \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\`
+       WHERE ${whereClauses.join(" AND ")}
+       ORDER BY started_at DESC, battle_id ASC
+       LIMIT ?`,
+      params
+    );
+
+    return rows.map((row) => toBattleSnapshotRecord(row));
   }
 
   async loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]> {

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -149,6 +149,13 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     resolvedAt?: string;
   }>();
   const guilds = new Map<string, GuildState>();
+  const battleHistoryByPlayerId = new Map<string, Array<{
+    roomId: string;
+    battleId: string;
+    status: "active" | "resolved" | "compensated" | "aborted";
+    encounterKind: "neutral" | "hero";
+    startedAt: string;
+  }>>();
   const guildAuditLogs: Array<{
     auditId: string;
     guildId: string;
@@ -341,6 +348,21 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     async listPlayerBanHistory(playerId: string, options: { limit?: number } = {}) {
       return (banHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
     },
+    async listBattleSnapshotsForPlayer(playerId: string, options: { limit?: number } = {}) {
+      return (battleHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 50)));
+    },
+    seedBattleHistory(
+      playerId: string,
+      items: Array<{
+        roomId: string;
+        battleId: string;
+        status: "active" | "resolved" | "compensated" | "aborted";
+        encounterKind: "neutral" | "hero";
+        startedAt: string;
+      }>
+    ) {
+      battleHistoryByPlayerId.set(playerId, items);
+    },
     async listPlayerReports(options: {
       status?: "pending" | "dismissed" | "warned" | "banned";
       limit?: number;
@@ -382,10 +404,21 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     | "savePlayerBan"
     | "clearPlayerBan"
     | "listPlayerBanHistory"
+    | "listBattleSnapshotsForPlayer"
     | "listPlayerReports"
     | "resolvePlayerReport"
   > & {
     saveCalls: Array<{ playerId: string; globalResources: { gold: number; wood: number; ore: number } }>;
+    seedBattleHistory(
+      playerId: string,
+      items: Array<{
+        roomId: string;
+        battleId: string;
+        status: "active" | "resolved" | "compensated" | "aborted";
+        encounterKind: "neutral" | "hero";
+        startedAt: string;
+      }>
+    ): void;
   };
 }
 
@@ -1317,6 +1350,15 @@ test("GET /api/admin/players/:id/export returns account data for support workflo
     banReason: "Spam",
     banExpiry: "2026-05-10T00:00:00.000Z"
   });
+  store.seedBattleHistory("player-export", [
+    {
+      roomId: "room-reconnect",
+      battleId: "battle-neutral-1",
+      status: "compensated",
+      encounterKind: "neutral",
+      startedAt: "2026-04-11T10:00:00.000Z"
+    }
+  ]);
   const { gets } = registerRoutes(store as RoomSnapshotStore);
   const handler = gets.get("/api/admin/players/:id/export");
   assert.ok(handler);
@@ -1338,6 +1380,7 @@ test("GET /api/admin/players/:id/export returns account data for support workflo
     exportedAt: string;
     account: { playerId: string; globalResources: { gold: number; wood: number; ore: number } };
     moderation: { currentBan: { banStatus: string }; banHistory: Array<{ action: string }> };
+    battleHistory: Array<{ battleId: string; status: string }>;
   };
   assert.equal(payload.playerId, "player-export");
   assert.ok(Number.isFinite(Date.parse(payload.exportedAt)));
@@ -1345,6 +1388,8 @@ test("GET /api/admin/players/:id/export returns account data for support workflo
   assert.deepEqual(payload.account.globalResources, { gold: 9, wood: 4, ore: 2 });
   assert.equal(payload.moderation.currentBan.banStatus, "temporary");
   assert.equal(payload.moderation.banHistory[0]?.action, "ban");
+  assert.equal(payload.battleHistory[0]?.battleId, "battle-neutral-1");
+  assert.equal(payload.battleHistory[0]?.status, "compensated");
 });
 
 test("POST /api/admin/players/:id/leaderboard/freeze freezes leaderboard movement for a player", async (t) => {

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -1746,6 +1746,73 @@ test("battle replay survives a reconnect mid-battle and persists once from the r
   assert.deepEqual(internalRoom.worldRoom.consumeCompletedBattleReplays(), []);
 });
 
+test("reconnect into a replacement room compensates unresolved neutral battles from a retired room", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new InstrumentedRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const retiredRoomId = `lifecycle-battle-comp-retired-${Date.now()}`;
+  const seededRoom = createRoom(retiredRoomId, 1001);
+  const seededState = seededRoom.getInternalState();
+  const hero = seededState.heroes.find((candidate) => candidate.id === "hero-1");
+  const neutralArmy = seededState.neutralArmies["neutral-1"];
+
+  t.after(() => {
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  assert.ok(hero);
+  assert.ok(neutralArmy);
+  const interruptedBattle = createNeutralBattleState(hero, neutralArmy, 1001, seededState);
+  await store.saveBattleSnapshotStart({
+    roomId: retiredRoomId,
+    battleId: interruptedBattle.id,
+    heroId: "hero-1",
+    attackerPlayerId: "player-1",
+    encounterKind: "neutral",
+    neutralArmyId: neutralArmy.id,
+    initiator: "hero",
+    path: [hero.position, neutralArmy.position],
+    moveCost: 1,
+    playerIds: ["player-1"],
+    initialState: interruptedBattle,
+    estimatedCompensationGrant: {
+      resources: {
+        gold: neutralArmy.reward?.kind === "gold" ? neutralArmy.reward.amount : 0,
+        wood: neutralArmy.reward?.kind === "wood" ? neutralArmy.reward.amount : 0,
+        ore: neutralArmy.reward?.kind === "ore" ? neutralArmy.reward.amount : 0
+      }
+    }
+  });
+
+  const replacementRoom = await createTestRoom(`lifecycle-battle-comp-replacement-${Date.now()}`);
+  const reconnectingClient = createFakeClient("session-battle-comp-replacement");
+
+  try {
+    await connectPlayer(replacementRoom, reconnectingClient, "player-1", "connect-battle-comp-replacement");
+    const account = await store.loadPlayerAccount("player-1");
+    const mailboxMessage = account?.mailbox?.find((entry) => entry.id === `${interruptedBattle.id}:disconnect-recovery`);
+    const history = await store.listBattleSnapshotsForPlayer?.("player-1", { limit: 10 });
+
+    assert.ok(
+      mailboxMessage,
+      `expected compensation mailbox message; mailbox=${JSON.stringify(account?.mailbox ?? [])} history=${JSON.stringify(history ?? [])}`
+    );
+    assert.ok(history?.[0], `expected interrupted battle history; mailbox=${JSON.stringify(account?.mailbox ?? [])}`);
+    assert.equal(mailboxMessage?.kind, "compensation");
+    assert.ok(
+      (mailboxMessage?.grant?.resources?.gold ?? 0) > 0 ||
+        (mailboxMessage?.grant?.resources?.wood ?? 0) > 0 ||
+        (mailboxMessage?.grant?.resources?.ore ?? 0) > 0
+    );
+    assert.equal(history?.[0]?.battleId, interruptedBattle.id);
+    assert.equal(history?.[0]?.status, "compensated");
+    assert.equal(history?.[0]?.resolutionReason, "room_missing_after_disconnect");
+  } finally {
+    cleanupRoom(replacementRoom);
+  }
+});
+
 test("pvp replay persistence captures both attacker and defender accounts from room settlement", async (t) => {
   resetLobbyRoomRegistry();
   const store = new InstrumentedRoomSnapshotStore();

--- a/docs/db-restore-runbook.md
+++ b/docs/db-restore-runbook.md
@@ -124,6 +124,8 @@ mysql \
   "$RESTORE_MYSQL_DATABASE" <<'SQL'
 SELECT 'room_snapshots' AS table_name, COUNT(*) AS row_count FROM room_snapshots
 UNION ALL
+SELECT 'battle_snapshots', COUNT(*) FROM battle_snapshots
+UNION ALL
 SELECT 'player_room_profiles', COUNT(*) FROM player_room_profiles
 UNION ALL
 SELECT 'player_accounts', COUNT(*) FROM player_accounts
@@ -151,6 +153,28 @@ Validation is complete when:
 - The restore loaded without MySQL errors.
 - Expected core tables are present with plausible row counts.
 - `npm run test:phase1-release-persistence -- --storage mysql` passes on the restored instance.
+
+For incident work involving mid-battle disconnect loss, also verify that unresolved combat ledgers survived restore:
+
+```bash
+mysql \
+  --host="$RESTORE_MYSQL_HOST" \
+  --port="$RESTORE_MYSQL_PORT" \
+  --user="$RESTORE_MYSQL_USER" \
+  --password="$RESTORE_MYSQL_PASSWORD" \
+  --table \
+  "$RESTORE_MYSQL_DATABASE" <<'SQL'
+SELECT room_id, battle_id, status, result, resolution_reason, started_at, resolved_at
+FROM battle_snapshots
+ORDER BY started_at DESC
+LIMIT 20;
+SQL
+```
+
+If the target player reconnected into a replacement room after the original room vanished, expect either:
+
+- `status='compensated'` with a non-null `compensation_json`
+- `status='aborted'` with a human-readable `resolution_reason`
 
 ## 5. Promote Or Hand Off
 

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -61,6 +61,43 @@ Recommended index:
 
 - `idx_room_snapshots_updated_at` on `updated_at`
 
+### Table: `battle_snapshots`
+
+| Column | Type | Nullable | Default | Description |
+| --- | --- | --- | --- | --- |
+| `room_id` | `VARCHAR(191)` | No | - | Logical room id |
+| `battle_id` | `VARCHAR(191)` | No | - | Battle id inside the room |
+| `hero_id` | `VARCHAR(191)` | No | - | Attacking hero id |
+| `attacker_player_id` | `VARCHAR(191)` | No | - | Attacker player id |
+| `defender_player_id` | `VARCHAR(191)` | Yes | `NULL` | Defender player id for PvP battles |
+| `defender_hero_id` | `VARCHAR(191)` | Yes | `NULL` | Defender hero id for PvP battles |
+| `neutral_army_id` | `VARCHAR(191)` | Yes | `NULL` | Neutral army id for PvE battles |
+| `encounter_kind` | `VARCHAR(16)` | No | - | `neutral` or `hero` |
+| `initiator` | `VARCHAR(16)` | Yes | `NULL` | Who initiated the encounter |
+| `path_json` | `LONGTEXT` | No | - | Serialized battle-start path used to enter the encounter |
+| `move_cost` | `INT` | No | - | Movement cost consumed when battle started |
+| `player_ids_json` | `LONGTEXT` | No | - | Serialized participant player id list |
+| `initial_state_json` | `LONGTEXT` | No | - | Serialized starting `BattleState` snapshot |
+| `estimated_compensation_grant_json` | `LONGTEXT` | Yes | `NULL` | Serialized conservative compensation estimate used when a neutral battle cannot be restored |
+| `status` | `VARCHAR(16)` | No | `active` | `active`, `resolved`, `compensated`, or `aborted` |
+| `result` | `VARCHAR(32)` | Yes | `NULL` | Final result when the battle settled normally |
+| `resolution_reason` | `VARCHAR(64)` | Yes | `NULL` | Why the record left `active` |
+| `compensation_json` | `LONGTEXT` | Yes | `NULL` | Serialized compensation/notice payload delivered to affected players |
+| `started_at` | `DATETIME` | No | - | Logical battle start time |
+| `resolved_at` | `DATETIME` | Yes | `NULL` | Logical settlement or compensation time |
+| `created_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | Row insertion time |
+| `updated_at` | `TIMESTAMP` | No | `CURRENT_TIMESTAMP` | Last mutation time |
+
+Primary key:
+
+- `(room_id, battle_id)`
+
+Recommended index:
+
+- `idx_battle_snapshots_status_updated` on `(status, updated_at DESC)`
+
+This table is an ops/support ledger separate from `room_snapshots`. It is written on `battle.started`, updated on `battle.resolved`, and later marked `compensated` or `aborted` if a player reconnects after the original room vanished. Support export flows can query this history to inspect both normal settlements and interrupted battles.
+
 ### Table: `player_room_profiles`
 
 | Column | Type | Nullable | Default | Description |

--- a/scripts/migrations/0022_add_battle_snapshots.ts
+++ b/scripts/migrations/0022_add_battle_snapshots.ts
@@ -1,0 +1,60 @@
+import {
+  dropIndexIfExists,
+  dropTableIfExists,
+  ensureIndexExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_BATTLE_SNAPSHOT_STATUS_UPDATED_INDEX,
+  MYSQL_BATTLE_SNAPSHOT_TABLE
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  await ensureTableExists(
+    connection,
+    MYSQL_BATTLE_SNAPSHOT_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\` (
+      room_id VARCHAR(191) NOT NULL,
+      battle_id VARCHAR(191) NOT NULL,
+      hero_id VARCHAR(191) NOT NULL,
+      attacker_player_id VARCHAR(191) NOT NULL,
+      defender_player_id VARCHAR(191) NULL,
+      defender_hero_id VARCHAR(191) NULL,
+      neutral_army_id VARCHAR(191) NULL,
+      encounter_kind VARCHAR(16) NOT NULL,
+      initiator VARCHAR(16) NULL,
+      path_json LONGTEXT NOT NULL,
+      move_cost INT NOT NULL,
+      player_ids_json LONGTEXT NOT NULL,
+      initial_state_json LONGTEXT NOT NULL,
+      estimated_compensation_grant_json LONGTEXT NULL,
+      status VARCHAR(16) NOT NULL DEFAULT 'active',
+      result VARCHAR(32) NULL,
+      resolution_reason VARCHAR(64) NULL,
+      compensation_json LONGTEXT NULL,
+      started_at DATETIME NOT NULL,
+      resolved_at DATETIME NULL DEFAULT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      PRIMARY KEY (room_id, battle_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+  await ensureIndexExists(
+    connection,
+    connection.config.database,
+    MYSQL_BATTLE_SNAPSHOT_TABLE,
+    MYSQL_BATTLE_SNAPSHOT_STATUS_UPDATED_INDEX,
+    `CREATE INDEX \`${MYSQL_BATTLE_SNAPSHOT_STATUS_UPDATED_INDEX}\` ON \`${MYSQL_BATTLE_SNAPSHOT_TABLE}\` (status, updated_at DESC)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  await dropIndexIfExists(
+    connection,
+    connection.config.database,
+    MYSQL_BATTLE_SNAPSHOT_TABLE,
+    MYSQL_BATTLE_SNAPSHOT_STATUS_UPDATED_INDEX
+  );
+  await dropTableIfExists(connection, MYSQL_BATTLE_SNAPSHOT_TABLE);
+}


### PR DESCRIPTION
## Summary
- add a dedicated `battle_snapshots` persistence ledger plus a MySQL migration and schema docs for interrupted battle tracking
- persist battle start and resolution metadata from `VeilColyseusRoom`, then reconcile unresolved snapshots on reconnect by issuing conservative compensation or a support-facing notice when the original room is gone
- expose battle history through the existing admin player export flow and cover the new reconnect/export behavior with focused tests

## Validation
- `npx tsc -p apps/server/tsconfig.json --noEmit`
- `node --import tsx --test --test-name-pattern="GET /api/admin/players/:id/export returns account data for support workflows|reconnect into a replacement room compensates unresolved neutral battles from a retired room" apps/server/test/admin-console.test.ts apps/server/test/colyseus-room-lifecycle.test.ts`

Closes #1224.
