### PR TITLE
[codex] ops: flag suspicious invalid gameplay bursts

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -54,6 +54,7 @@ import { resolveGuestAuthSession } from "./auth";
 import { deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
 import {
   recordBattleActionMessage,
+  recordAntiCheatAlert,
   recordLeaderboardAbuseAlert,
   recordBattleLifecycleResolved,
   recordConnectMessage,
@@ -93,6 +94,8 @@ const MAP_SYNC_CHUNK_SIZE = 8;
 const MAP_SYNC_CHUNK_PADDING = 1;
 const DEFAULT_WS_ACTION_RATE_LIMIT_WINDOW_MS = 1_000;
 const DEFAULT_WS_ACTION_RATE_LIMIT_MAX = 8;
+const DEFAULT_SUSPICIOUS_ACTION_WINDOW_MS = 60_000;
+const DEFAULT_SUSPICIOUS_ACTION_THRESHOLD = 5;
 const DEFAULT_PLAYER_SLOT_ID = /^player-(\d+)$/;
 const MINOR_PROTECTION_TICK_MS = 60_000;
 const TURN_TIMER_TICK_MS = 5_000;
@@ -151,6 +154,16 @@ let roomRuntimeDependencies: RoomRuntimeDependencies = defaultRoomRuntimeDepende
 interface WebSocketActionRateLimitConfig {
   windowMs: number;
   max: number;
+}
+
+interface SuspiciousActionAlertConfig {
+  windowMs: number;
+  threshold: number;
+}
+
+interface SuspiciousActionTracker {
+  timestamps: number[];
+  lastAlertAt: number | null;
 }
 
 function hasPlayerReportStore(
@@ -276,6 +289,19 @@ function readWebSocketActionRateLimitConfig(env: NodeJS.ProcessEnv = process.env
   };
 }
 
+function readSuspiciousActionAlertConfig(env: NodeJS.ProcessEnv = process.env): SuspiciousActionAlertConfig {
+  return {
+    windowMs: parseEnvNumber(env.VEIL_ANTI_CHEAT_SUSPICIOUS_ACTION_WINDOW_MS, DEFAULT_SUSPICIOUS_ACTION_WINDOW_MS, {
+      minimum: 1,
+      integer: true
+    }),
+    threshold: parseEnvNumber(env.VEIL_ANTI_CHEAT_SUSPICIOUS_ACTION_THRESHOLD, DEFAULT_SUSPICIOUS_ACTION_THRESHOLD, {
+      minimum: 1,
+      integer: true
+    })
+  };
+}
+
 function readMinimumSupportedClientVersion(env: NodeJS.ProcessEnv = process.env): string {
   return normalizeClientVersion(env.MIN_SUPPORTED_CLIENT_VERSION) ?? DEFAULT_MIN_SUPPORTED_CLIENT_VERSION;
 }
@@ -391,12 +417,14 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
 
   public worldRoom!: AuthoritativeWorldRoom;
   private readonly wsActionRateLimitConfig = readWebSocketActionRateLimitConfig();
+  private readonly suspiciousActionAlertConfig = readSuspiciousActionAlertConfig();
   private readonly minorProtectionConfig = readMinorProtectionConfig();
   private readonly lobbyRoomOwnerToken = nextLobbyRoomOwnerToken++;
   private readonly playerIdBySessionId = new Map<string, string>();
   private readonly disconnectedAtByPlayerId = new Map<string, string>();
   private readonly reconnectedAtByPlayerId = new Map<string, string>();
   private readonly wsActionTimestampsByPlayerId = new Map<string, number[]>();
+  private readonly suspiciousActionTrackerBySessionId = new Map<string, SuspiciousActionTracker>();
   private unsubscribeConfigUpdate: (() => void) | null = null;
   private turnTimerHandle: RoomTimerHandle | null = null;
   private turnOwnerPlayerId: string | null = null;
@@ -593,6 +621,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       const previousTurnOwnerPlayerId = this.turnOwnerPlayerId;
       const result = this.worldRoom.dispatch(playerId, message.action);
       if (!result.ok) {
+        this.recordSuspiciousAction(client, playerId, result.rejection);
         sendMessage(client, "session.state", {
           requestId: message.requestId,
           delivery: "reply",
@@ -659,6 +688,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       const previousTurnOwnerPlayerId = this.turnOwnerPlayerId;
       const result = this.worldRoom.dispatchBattle(playerId, message.action);
       if (!result.ok) {
+        this.recordSuspiciousAction(client, playerId, result.rejection);
         sendMessage(client, "session.state", {
           requestId: message.requestId,
           delivery: "reply",
@@ -903,6 +933,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
   onLeave(client: ColyseusClient): void {
     const playerId = this.playerIdBySessionId.get(client.sessionId);
     this.playerIdBySessionId.delete(client.sessionId);
+    this.suspiciousActionTrackerBySessionId.delete(client.sessionId);
     if (playerId && !this.getConnectedPlayerIds().includes(playerId)) {
       this.disconnectedAtByPlayerId.set(playerId, new Date(roomRuntimeDependencies.now()).toISOString());
     }
@@ -915,6 +946,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     this.unsubscribeConfigUpdate?.();
     this.unsubscribeConfigUpdate = null;
     this.wsActionTimestampsByPlayerId.clear();
+    this.suspiciousActionTrackerBySessionId.clear();
     if (this.turnTimerHandle) {
       roomRuntimeDependencies.clearInterval(this.turnTimerHandle);
       this.turnTimerHandle = null;
@@ -939,6 +971,46 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     timestamps.push(now);
     this.wsActionTimestampsByPlayerId.set(playerId, timestamps);
     return true;
+  }
+
+  private recordSuspiciousAction(
+    client: ColyseusClient,
+    playerId: string,
+    rejection?: ActionValidationFailure
+  ): void {
+    if (!rejection) {
+      return;
+    }
+
+    const now = roomRuntimeDependencies.now();
+    const windowStart = now - this.suspiciousActionAlertConfig.windowMs;
+    const tracker = this.suspiciousActionTrackerBySessionId.get(client.sessionId) ?? {
+      timestamps: [],
+      lastAlertAt: null
+    };
+    const timestamps = tracker.timestamps.filter((timestamp) => timestamp > windowStart);
+    timestamps.push(now);
+    tracker.timestamps = timestamps;
+
+    if (
+      timestamps.length >= this.suspiciousActionAlertConfig.threshold &&
+      (tracker.lastAlertAt == null || now - tracker.lastAlertAt >= this.suspiciousActionAlertConfig.windowMs)
+    ) {
+      tracker.lastAlertAt = now;
+      recordAntiCheatAlert({
+        roomId: this.metadata.logicalRoomId,
+        playerId,
+        sessionId: client.sessionId,
+        scope: rejection.scope,
+        actionType: rejection.actionType,
+        reason: rejection.reason,
+        rejectionCount: timestamps.length,
+        windowMs: this.suspiciousActionAlertConfig.windowMs,
+        recordedAt: new Date(now).toISOString()
+      });
+    }
+
+    this.suspiciousActionTrackerBySessionId.set(client.sessionId, tracker);
   }
 
   private getConnectedPlayerIds(): string[] {

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -65,7 +65,23 @@ interface LeaderboardAbuseObservabilityCounters {
   alertsTotal: number;
 }
 
+interface AntiCheatObservabilityCounters {
+  alertsTotal: number;
+}
+
 type ActionValidationScope = "world" | "battle";
+
+export interface AntiCheatAlertEvent {
+  roomId: string;
+  playerId: string;
+  sessionId: string;
+  scope: ActionValidationScope;
+  actionType: string;
+  reason: string;
+  rejectionCount: number;
+  windowMs: number;
+  recordedAt: string;
+}
 
 interface HistogramMetricState {
   buckets: number[];
@@ -182,6 +198,10 @@ interface RuntimeObservabilityState {
     counters: LeaderboardAbuseObservabilityCounters;
     recentAlerts: LeaderboardAlertEvent[];
   };
+  antiCheat: {
+    counters: AntiCheatObservabilityCounters;
+    recentAlerts: AntiCheatAlertEvent[];
+  };
 }
 
 export interface RuntimePersistenceHealth {
@@ -249,6 +269,10 @@ interface RuntimeHealthPayload {
     };
     leaderboardAbuse: {
       counters: LeaderboardAbuseObservabilityCounters;
+      alertsTracked: number;
+    };
+    antiCheat: {
+      counters: AntiCheatObservabilityCounters;
       alertsTracked: number;
     };
   };
@@ -430,6 +454,12 @@ const runtimeObservability: RuntimeObservabilityState = {
       alertsTotal: 0
     },
     recentAlerts: []
+  },
+  antiCheat: {
+    counters: {
+      alertsTotal: 0
+    },
+    recentAlerts: []
   }
 };
 
@@ -522,7 +552,12 @@ function buildHealthPayload(
   );
 
   return {
-    status: persistence.status === "degraded" || runtimeObservability.leaderboardAbuse.recentAlerts.length > 0 ? "warn" : "ok",
+    status:
+      persistence.status === "degraded" ||
+      runtimeObservability.leaderboardAbuse.recentAlerts.length > 0 ||
+      runtimeObservability.antiCheat.recentAlerts.length > 0
+        ? "warn"
+        : "ok",
     service,
     checkedAt: new Date().toISOString(),
     startedAt: new Date(runtimeObservability.startedAt).toISOString(),
@@ -580,6 +615,10 @@ function buildHealthPayload(
       leaderboardAbuse: {
         counters: { ...runtimeObservability.leaderboardAbuse.counters },
         alertsTracked: runtimeObservability.leaderboardAbuse.recentAlerts.length
+      },
+      antiCheat: {
+        counters: { ...runtimeObservability.antiCheat.counters },
+        alertsTracked: runtimeObservability.antiCheat.recentAlerts.length
       }
     }
   };
@@ -1114,6 +1153,9 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_leaderboard_abuse_alerts_total Total leaderboard anti-abuse alerts emitted by this process.",
     "# TYPE veil_leaderboard_abuse_alerts_total counter",
     `veil_leaderboard_abuse_alerts_total ${health.runtime.leaderboardAbuse.counters.alertsTotal}`,
+    "# HELP veil_anti_cheat_alerts_total Total anti-cheat alerts emitted by this process.",
+    "# TYPE veil_anti_cheat_alerts_total counter",
+    `veil_anti_cheat_alerts_total ${health.runtime.antiCheat.counters.alertsTotal}`,
     "# HELP veil_auth_invalid_credentials_total Total auth requests rejected for invalid credentials.",
     "# TYPE veil_auth_invalid_credentials_total counter",
     `veil_auth_invalid_credentials_total ${health.runtime.auth.counters.invalidCredentialsTotal}`,
@@ -1760,6 +1802,14 @@ export function recordLeaderboardAbuseAlert(alert: LeaderboardAlertEvent): void 
   }
 }
 
+export function recordAntiCheatAlert(alert: AntiCheatAlertEvent): void {
+  runtimeObservability.antiCheat.counters.alertsTotal += 1;
+  runtimeObservability.antiCheat.recentAlerts.unshift({ ...alert });
+  if (runtimeObservability.antiCheat.recentAlerts.length > 20) {
+    runtimeObservability.antiCheat.recentAlerts.length = 20;
+  }
+}
+
 export function recordAuthInvalidCredentials(): void {
   runtimeObservability.auth.counters.invalidCredentialsTotal += 1;
 }
@@ -1922,6 +1972,8 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.matchmaking.counters.rateLimitedTotal = 0;
   runtimeObservability.leaderboardAbuse.counters.alertsTotal = 0;
   runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;
+  runtimeObservability.antiCheat.counters.alertsTotal = 0;
+  runtimeObservability.antiCheat.recentAlerts.length = 0;
 }
 
 export function registerRuntimeObservabilityRoutes(

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../src/colyseus-room";
 import { createRoom, type RoomPersistenceSnapshot } from "../src/index";
 import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
-import { buildRoomLifecycleSummaryPayload, resetRuntimeObservability } from "../src/observability";
+import { buildPrometheusMetricsDocument, buildRoomLifecycleSummaryPayload, resetRuntimeObservability } from "../src/observability";
 import type { PlayerAccountEnsureInput, PlayerAccountProgressPatch, PlayerAccountSnapshot } from "../src/persistence";
 
 interface FakeClient extends Client {
@@ -1408,6 +1408,7 @@ test("disposing a room with an active battle records a battle abort", async (t) 
 });
 
 test("invalid world actions return a structured rejection only to the originating client", async (t) => {
+  resetRuntimeObservability();
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
   const room = await createTestRoom(`lifecycle-world-rejection-${Date.now()}`);
@@ -1468,7 +1469,53 @@ test("invalid world actions return a structured rejection only to the originatin
   assert.equal(observerPushCountAfter, observerPushCountBefore);
 });
 
+test("repeated rejected movement actions emit an anti-cheat alert metric", async (t) => {
+  resetRuntimeObservability();
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-anti-cheat-${Date.now()}`);
+  const client = createFakeClient("session-anti-cheat-source");
+  const internalRoom = room as VeilColyseusRoom & {
+    worldRoom: {
+      getInternalState(): {
+        heroes: Array<{
+          id: string;
+          playerId: string;
+          move: { total: number; remaining: number };
+        }>;
+      };
+    };
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, client, "player-1", "connect-anti-cheat-source");
+
+  const sourceHero = internalRoom.worldRoom.getInternalState().heroes.find((hero) => hero.playerId === "player-1");
+  assert.ok(sourceHero);
+  sourceHero.move.remaining = 0;
+
+  for (let index = 0; index < 5; index += 1) {
+    await emitRoomMessage(room, "world.action", client, {
+      type: "world.action",
+      requestId: `anti-cheat-${index}`,
+      action: {
+        type: "hero.move",
+        heroId: sourceHero.id,
+        destination: { x: 2, y: 1 }
+      }
+    });
+  }
+
+  assert.match(buildPrometheusMetricsDocument(), /^veil_anti_cheat_alerts_total 1$/m);
+});
+
 test("invalid battle actions return a structured rejection only to the originating client", async (t) => {
+  resetRuntimeObservability();
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);
   const room = await createTestRoom(`lifecycle-battle-rejection-${Date.now()}`);

--- a/apps/server/test/runtime-observability-routes.test.ts
+++ b/apps/server/test/runtime-observability-routes.test.ts
@@ -300,6 +300,12 @@ test("runtime observability routes expose live room counts and gameplay traffic"
           rateLimitedTotal: number;
         };
       };
+      antiCheat: {
+        counters: {
+          alertsTotal: number;
+        };
+        alertsTracked: number;
+      };
     };
   };
 
@@ -316,6 +322,8 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.equal(healthPayload.runtime.auth.activeAccountSessionCount, 0);
   assert.equal(healthPayload.runtime.auth.counters.sessionChecksTotal, 0);
   assert.equal(healthPayload.runtime.matchmaking.counters.rateLimitedTotal, 2);
+  assert.equal(healthPayload.runtime.antiCheat.counters.alertsTotal, 0);
+  assert.equal(healthPayload.runtime.antiCheat.alertsTracked, 0);
 
   const readinessResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/auth-readiness`);
   const readinessPayload = (await readinessResponse.json()) as {
@@ -434,6 +442,7 @@ test("runtime observability routes expose live room counts and gameplay traffic"
   assert.match(metricsText, /^veil_auth_account_sessions 0$/m);
   assert.match(metricsText, /^veil_auth_session_checks_total 0$/m);
   assert.match(metricsText, /^veil_matchmaking_rate_limited_total 2$/m);
+  assert.match(metricsText, /^veil_anti_cheat_alerts_total 0$/m);
   assert.match(metricsText, /^veil_feature_flag_config_stale 0$/m);
   assert.match(metricsText, /^veil_feature_flag_rollout_ratio\{flag="battle_pass_enabled",owner="ops-oncall"\} 0\.1$/m);
   assert.match(

--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -57,6 +57,18 @@ groups:
           description: veil_action_validation_failures_total is averaging more than 0.5 rejected actions per second over 15 minutes. Check recent deploys, protocol drift, and client desync.
           runbook_url: ./incident-response-runbook.md#alert-veilactionvalidationfailureshigh
 
+      - alert: VeilSuspiciousActionBurstDetected
+        expr: increase(veil_anti_cheat_alerts_total[15m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+          service: project-veil-server
+          notify: ops-slack
+        annotations:
+          summary: Project Veil is seeing repeated suspicious gameplay actions from at least one active session
+          description: The server emitted an anti-cheat suspicious-action alert within the last 15 minutes. Inspect recent invalid move or battle commands, identify the affected player/session, and verify whether the client is desynced or malicious.
+          runbook_url: ./incident-response-runbook.md#alert-veilsuspiciousactionburstdetected
+
       - alert: VeilHttpRequestLatencyP95High
         expr: histogram_quantile(0.95, sum(rate(veil_http_request_duration_seconds_bucket[15m])) by (le)) > 0.75
         for: 10m

--- a/docs/incident-response-runbook.md
+++ b/docs/incident-response-runbook.md
@@ -266,6 +266,10 @@ curl -fsS "$VEIL_RUNTIME_URL/api/runtime/diagnostic-snapshot" | jq '.diagnostics
 
 把它视为协议漂移或 gameplay desync 的强信号。先暂停可疑 rollout；若同一窗口内也有 feature flag 或会话失败，直接跳到 [Config Push Or Feature Flag Rollout Causing Disconnects](#config-push-or-feature-flag-rollout-causing-disconnects)。
 
+### Alert-VeilSuspiciousActionBurstDetected
+
+把它视为单个 session 或少量玩家正在持续发送异常移动/战斗指令。先从运行时指标和日志定位房间与玩家，再区分是客户端版本漂移、断线重放，还是明显作弊流量；在结论不明确前不要发补偿或人工改档。
+
 ### Alert-VeilHttpRequestLatencyP95High
 
 结合 `auth-readiness` 和连接数判断是否为服务整体饱和。若探活和诊断接口同时退化，走 [Runtime Unavailable](#runtime-unavailable)；若主要由 MySQL 背压带来，走 [Database Pool Exhaustion](#database-pool-exhaustion)。


### PR DESCRIPTION
## Summary
- add room-level suspicious action tracking for rejected `world.action` and `battle.action` requests, aggregated per session in a rolling window
- emit `veil_anti_cheat_alerts_total` and expose anti-cheat alert counts in runtime health/metrics
- add a Prometheus alert rule and runbook entry for repeated suspicious gameplay action bursts

## Validation
- `npm run typecheck:server`
- `node --import tsx --test --test-name-pattern "repeated rejected movement actions emit an anti-cheat alert metric" ./apps/server/test/colyseus-room-lifecycle.test.ts`
- `node --import tsx --test ./apps/server/test/runtime-observability-routes.test.ts`

## Scope
This is a focused partial slice for #1222. It advances server-side anti-cheat observability and suspicious-action alerting, but does not yet implement deterministic battle settlement or loot claim idempotency.

References #1222
