### PR TITLE
[codex] ops: reject invalid terrain-locked battle skills

### DIFF
--- a/apps/server/test/authoritative-room.test.ts
+++ b/apps/server/test/authoritative-room.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { createDemoBattleState } from "../../../packages/shared/src/index";
 import { createRoom } from "../src/index";
 import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "../src/observability";
 
@@ -127,16 +128,17 @@ test("player battle actions are followed by automated defender turns until contr
 test("server rejects battle actions sent for non-player-controlled defender units", () => {
   resetRuntimeObservability();
   const room = createRoom("room-control-check", 1001);
-  room.dispatch("player-1", {
-    type: "hero.move",
-    heroId: "hero-1",
-    destination: { x: 5, y: 4 }
-  });
+  const battle = createDemoBattleState();
+  battle.id = "battle-control-check";
+  battle.worldHeroId = "hero-1";
+  battle.activeUnitId = "pikeman-a";
+  battle.turnOrder = ["pikeman-a", "wolf-d"];
+  (room as ReturnType<typeof createRoom> & { setBattle(battleState: typeof battle): void }).setBattle(battle);
 
   const result = room.dispatchBattle("player-1", {
     type: "battle.attack",
-    attackerId: "neutral-1-stack-1",
-    defenderId: "hero-1-stack"
+    attackerId: "wolf-d",
+    defenderId: "pikeman-a"
   });
 
   assert.equal(result.ok, false);
@@ -145,6 +147,58 @@ test("server rejects battle actions sent for non-player-controlled defender unit
   assert.match(
     buildPrometheusMetricsDocument(),
     /^veil_action_validation_failures_total\{reason="unit_not_player_controlled",scope="battle"\} 1$/m
+  );
+});
+
+test("server rejects terrain-locked battle skills before mutating authoritative battle state", () => {
+  resetRuntimeObservability();
+  const room = createRoom("room-terrain-locked-skill", 1001);
+  const battle = createDemoBattleState();
+  battle.id = "battle-terrain-locked-skill";
+  battle.worldHeroId = "hero-1";
+  battle.activeUnitId = "pikeman-a";
+  battle.turnOrder = ["pikeman-a", "wolf-d"];
+  battle.battlefieldTerrain = "grass";
+  battle.log = [];
+  const playerUnit = battle.units["pikeman-a"];
+  const opposingUnit = battle.units["wolf-d"];
+
+  assert.ok(battle);
+  assert.ok(playerUnit);
+  assert.ok(opposingUnit);
+
+  battle.units[playerUnit.id] = {
+    ...playerUnit,
+    skills: [
+      ...(playerUnit.skills ?? []),
+      {
+        id: "bog_ambush",
+        name: "泥沼伏袭",
+        description: "只有在水泽地形中才能发动，伤害显著提升。",
+        kind: "active",
+        target: "enemy",
+        cooldown: 3,
+        remainingCooldown: 0
+      }
+    ]
+  };
+  (room as ReturnType<typeof createRoom> & { setBattle(battleState: typeof battle): void }).setBattle(battle);
+
+  const result = room.dispatchBattle("player-1", {
+    type: "battle.skill",
+    unitId: playerUnit.id,
+    skillId: "bog_ambush",
+    targetId: opposingUnit.id
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "skill_requires_water_terrain");
+  assert.ok(result.battle);
+  assert.equal(result.battle?.log.includes("Action rejected: skill_requires_water_terrain"), false);
+  assert.equal(result.battle?.units[opposingUnit.id]?.count, opposingUnit.count);
+  assert.match(
+    buildPrometheusMetricsDocument(),
+    /^veil_action_validation_failures_total\{reason="skill_requires_water_terrain",scope="battle"\} 1$/m
   );
 });
 

--- a/packages/shared/src/battle.ts
+++ b/packages/shared/src/battle.ts
@@ -1823,10 +1823,11 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
       return { valid: false, reason: "skill_disabled" };
     }
 
+    const skillDefinition = skillDefinitionFor(skill.id, getBattleCatalogIndex());
     if (normalizedCooldownValue(state.unitCooldowns[action.unitId]?.[action.skillId]) > 0) {
       return { valid: false, reason: "skill_on_cooldown" };
     }
-    if (!isSkillAvailableThisRound(skillDefinitionFor(skill.id, getBattleCatalogIndex()), state.round)) {
+    if (!isSkillAvailableThisRound(skillDefinition, state.round)) {
       return { valid: false, reason: "skill_round_expired" };
     }
 
@@ -1835,6 +1836,10 @@ export function validateBattleAction(state: BattleState, action: BattleAction): 
       if (skill.target !== "enemy" || action.targetId !== forcedTargetId) {
         return { valid: false, reason: "taunted_must_attack_source" };
       }
+    }
+
+    if (skillDefinition.id === "bog_ambush" && battlefieldTerrainOf(state) !== "water") {
+      return { valid: false, reason: "skill_requires_water_terrain" };
     }
 
     if (skill.target === "self") {

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -6499,6 +6499,43 @@ test("validateBattleAction covers wait and skill rejection branches", () => {
     }
   );
 
+  const terrainLockedSkillState = {
+    ...cloneBattleState(initial),
+    activeUnitId: "pikeman-a",
+    turnOrder: ["pikeman-a", "wolf-d"],
+    battlefieldTerrain: "grass" as const,
+    units: {
+      ...cloneBattleState(initial).units,
+      "pikeman-a": {
+        ...cloneBattleState(initial).units["pikeman-a"]!,
+        skills: [
+          {
+            id: "bog_ambush",
+            name: "泥沼伏袭",
+            description: "只有在水泽地形中才能发动，伤害显著提升。",
+            kind: "active" as const,
+            target: "enemy" as const,
+            cooldown: 3,
+            remainingCooldown: 0
+          }
+        ]
+      }
+    }
+  };
+
+  assert.deepEqual(
+    validateBattleAction(terrainLockedSkillState, {
+      type: "battle.skill",
+      unitId: "pikeman-a",
+      skillId: "bog_ambush",
+      targetId: "wolf-d"
+    }),
+    {
+      valid: false,
+      reason: "skill_requires_water_terrain"
+    }
+  );
+
   assert.deepEqual(
     validateBattleAction(
       {


### PR DESCRIPTION
## Summary
- reject `bog_ambush` during authoritative battle validation when the battlefield terrain is not water
- keep deterministic server-side battle actions in the structured rejection path instead of treating them as successful executions with log-only rejection text
- add focused shared and authoritative-room regressions for terrain-locked skill validation

## Validation
- `npm run typecheck:server`
- `node --import tsx --test --test-name-pattern "battle terrain mastery and bog ambush react to battlefield terrain" ./packages/shared/test/shared-core.test.ts`
- `node --import tsx --test --test-name-pattern "server rejects terrain-locked battle skills before mutating authoritative battle state|server rejects battle actions sent for non-player-controlled defender units" ./apps/server/test/authoritative-room.test.ts`

## Scope
This is a focused partial slice for #1222. It tightens deterministic server-side battle-action validation for a terrain-locked skill path, but does not yet complete the remaining movement-path validation or broader battle settlement scope from the issue.

References #1222
