### PR TITLE
Add HTTP request correlation IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ npm run dev:client:h5
 - 匹配队列默认会把断线玩家 5 分钟后清理掉，可用 `VEIL_MATCHMAKING_QUEUE_TTL_SECONDS`（默认 `300` 秒）覆盖
 - 设置 `REDIS_URL` 后，Colyseus presence/driver 和 matchmaking 队列都会自动切到 Redis-backed 实现
 
+服务端 HTTP 路由现在会为每个请求返回 `x-correlation-id`。排查失败请求时可直接复用调用方传入的同名 header，或从 5xx 响应 / 服务端错误日志 / `/api/runtime/diagnostic-snapshot` 里的 `requestId` 交叉定位同一次请求。
+
 如果你要启用 MySQL 持久化，再复制 `.env.example` 到 `.env`，填入 `VEIL_MYSQL_*`，然后执行 `npm run db:migrate`。更多说明见 `docs/mysql-persistence.md`。
 
 如果你要把 MySQL 备份自动上传到兼容 S3 的对象存储，再补充 `VEIL_BACKUP_*`，执行 `./scripts/db-backup.sh` 做一次手动演练，并按 `ops/mysql-backup.cron.example` 安装每 6 小时备份一次、每周一次 `./scripts/db-restore-test.sh` 的 cron。服务端启动时会校验该 S3 目标是否可达，并把最近一次成功备份时间暴露为 Prometheus 指标 `veil_db_backup_last_success_timestamp`；恢复步骤见 `docs/db-restore-runbook.md`。

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -14,6 +14,7 @@ import { configureRoomSnapshotStore, listLobbyRooms, VeilColyseusRoom } from "./
 import { registerConfigViewerRoutes } from "./config-viewer";
 import { registerEventRoutes } from "./event-engine";
 import { registerGuildRoutes } from "./guilds";
+import { installHttpRequestObservability } from "./http-request-context";
 import { registerLeaderboardRoutes } from "./leaderboard";
 import { registerLobbyRoutes } from "./lobby";
 import { registerMatchmakingRoutes } from "./matchmaking";
@@ -311,6 +312,7 @@ export async function startDevServer(
 
   const transport = deps.createTransport();
   const expressApp = transport.getExpressApp();
+  installHttpRequestObservability(expressApp as unknown as Parameters<typeof installHttpRequestObservability>[0], deps.logger);
   deps.registerPrometheusMetricsMiddleware(expressApp);
   deps.registerPrometheusMetricsRoute(expressApp);
   deps.registerAuthRoutes(expressApp, effectiveSnapshotStore);

--- a/apps/server/src/http-request-context.ts
+++ b/apps/server/src/http-request-context.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RuntimeDiagnosticsFeatureArea } from "../../../packages/shared/src/index";
+import { recordRuntimeErrorEvent } from "./observability";
+
+export const REQUEST_CORRELATION_ID_HEADER = "x-correlation-id";
+const REQUEST_ID_FALLBACK_HEADER = "x-request-id";
+const MAX_CORRELATION_ID_LENGTH = 128;
+const CORRELATION_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
+const ROUTE_FAILURE_ERROR_CODE = "http_route_failed";
+const VEIL_CORRELATION_ID_KEY = "__veilCorrelationId";
+const VEIL_ROUTE_PATTERN_KEY = "__veilRoutePattern";
+
+interface ObservedRequestContext {
+  [VEIL_CORRELATION_ID_KEY]?: string;
+  [VEIL_ROUTE_PATTERN_KEY]?: string;
+}
+
+interface HttpRouteObservabilityLogger {
+  error(message: string, error: unknown): void;
+}
+
+interface HttpRouteObservabilityApp {
+  use?: (...args: unknown[]) => unknown;
+  get?: (...args: unknown[]) => unknown;
+  post?: (...args: unknown[]) => unknown;
+  put?: (...args: unknown[]) => unknown;
+  delete?: (...args: unknown[]) => unknown;
+  patch?: (...args: unknown[]) => unknown;
+  options?: (...args: unknown[]) => unknown;
+  head?: (...args: unknown[]) => unknown;
+}
+
+type HttpHandler = (...args: unknown[]) => unknown;
+
+type AppMethodName = "use" | "get" | "post" | "put" | "delete" | "patch" | "options" | "head";
+
+const ROUTE_METHOD_NAMES: AppMethodName[] = ["get", "post", "put", "delete", "patch", "options", "head"];
+
+function readHeaderValue(value: string | string[] | undefined): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.find((entry) => entry.trim().length > 0) ?? null;
+  }
+
+  return null;
+}
+
+function sanitizeCorrelationId(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized || normalized.length > MAX_CORRELATION_ID_LENGTH || !CORRELATION_ID_PATTERN.test(normalized)) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function buildCorrelationId(): string {
+  return `req-${randomUUID()}`;
+}
+
+function readRequestPathname(request: IncomingMessage): string | null {
+  if (!request.url) {
+    return null;
+  }
+
+  try {
+    return new URL(request.url, "http://project-veil.local").pathname;
+  } catch {
+    return request.url.split("?")[0] ?? null;
+  }
+}
+
+function readRoutePattern(request: IncomingMessage): string | null {
+  return (request as IncomingMessage & ObservedRequestContext)[VEIL_ROUTE_PATTERN_KEY] ?? null;
+}
+
+function setRoutePattern(request: IncomingMessage, routePattern: string | null): void {
+  if (!routePattern) {
+    return;
+  }
+
+  (request as IncomingMessage & ObservedRequestContext)[VEIL_ROUTE_PATTERN_KEY] = routePattern;
+}
+
+export function getRequestCorrelationId(request: IncomingMessage): string | null {
+  return (request as IncomingMessage & ObservedRequestContext)[VEIL_CORRELATION_ID_KEY] ?? null;
+}
+
+export function ensureRequestCorrelationId(request: IncomingMessage, response: ServerResponse): string {
+  const requestWithContext = request as IncomingMessage & ObservedRequestContext;
+  const existing = requestWithContext[VEIL_CORRELATION_ID_KEY];
+  if (existing) {
+    response.setHeader(REQUEST_CORRELATION_ID_HEADER, existing);
+    return existing;
+  }
+
+  const correlationId =
+    sanitizeCorrelationId(readHeaderValue(request.headers[REQUEST_CORRELATION_ID_HEADER])) ??
+    sanitizeCorrelationId(readHeaderValue(request.headers[REQUEST_ID_FALLBACK_HEADER])) ??
+    buildCorrelationId();
+
+  requestWithContext[VEIL_CORRELATION_ID_KEY] = correlationId;
+  response.setHeader(REQUEST_CORRELATION_ID_HEADER, correlationId);
+  return correlationId;
+}
+
+function inferFeatureArea(routePattern: string | null, pathname: string | null): RuntimeDiagnosticsFeatureArea {
+  const route = (routePattern ?? pathname ?? "").toLowerCase();
+  if (route.startsWith("/api/auth")) {
+    return "login";
+  }
+  if (route.startsWith("/api/payments")) {
+    return "payment";
+  }
+  if (route.startsWith("/api/guild")) {
+    return "guild";
+  }
+  if (route.startsWith("/api/shop")) {
+    return "shop";
+  }
+  if (route.startsWith("/api/season")) {
+    return "season";
+  }
+  if (route.includes("quest")) {
+    return "quests";
+  }
+  return "runtime";
+}
+
+function inferOwnerArea(featureArea: RuntimeDiagnosticsFeatureArea): string {
+  switch (featureArea) {
+    case "payment":
+      return "commerce";
+    case "guild":
+      return "multiplayer";
+    default:
+      return "platform";
+  }
+}
+
+function serializeErrorDetail(input: Record<string, unknown>): string {
+  return JSON.stringify(input, (_key, value) => {
+    if (typeof value === "string" && value.length > 1200) {
+      return `${value.slice(0, 1197)}...`;
+    }
+    return value;
+  });
+}
+
+function reportRouteError(
+  logger: HttpRouteObservabilityLogger,
+  request: IncomingMessage,
+  response: ServerResponse,
+  methodName: string,
+  error: unknown
+): void {
+  const correlationId = ensureRequestCorrelationId(request, response);
+  const pathname = readRequestPathname(request);
+  const routePattern = readRoutePattern(request);
+  const statusCode = response.statusCode >= 400 ? response.statusCode : 500;
+  const featureArea = inferFeatureArea(routePattern, pathname);
+  const errorName = error instanceof Error ? error.name : typeof error;
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const detail = {
+    method: request.method ?? methodName.toUpperCase(),
+    path: pathname,
+    routePattern,
+    correlationId,
+    errorName,
+    errorMessage,
+    stack: error instanceof Error ? error.stack ?? null : null
+  };
+
+  logger.error(`HTTP route handler failed for ${request.method ?? methodName.toUpperCase()} ${pathname ?? routePattern ?? "<unknown>"}`, detail);
+  recordRuntimeErrorEvent({
+    id: randomUUID(),
+    recordedAt: new Date().toISOString(),
+    source: "server",
+    surface: "http-route",
+    candidateRevision: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null,
+    featureArea,
+    ownerArea: inferOwnerArea(featureArea),
+    severity: "error",
+    errorCode: ROUTE_FAILURE_ERROR_CODE,
+    message: `HTTP route handler failed for ${request.method ?? methodName.toUpperCase()} ${pathname ?? routePattern ?? "<unknown>"}`,
+    tags: ["http-route", methodName.toLowerCase(), featureArea],
+    context: {
+      roomId: null,
+      playerId: null,
+      requestId: correlationId,
+      route: routePattern ?? pathname,
+      action: request.method ?? methodName.toUpperCase(),
+      statusCode,
+      crash: false,
+      detail: serializeErrorDetail(detail)
+    }
+  });
+}
+
+function sendInternalError(response: ServerResponse, correlationId: string): void {
+  if (response.headersSent) {
+    response.end();
+    return;
+  }
+
+  response.statusCode = 500;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(
+    JSON.stringify({
+      error: "internal_server_error",
+      correlationId
+    })
+  );
+}
+
+function wrapHandler(
+  value: unknown,
+  logger: HttpRouteObservabilityLogger,
+  methodName: string,
+  routePattern?: string
+): unknown {
+  if (typeof value !== "function") {
+    return value;
+  }
+
+  const handler = value as HttpHandler;
+  return function observedHandler(request: IncomingMessage, response: ServerResponse, next?: () => void): unknown {
+    ensureRequestCorrelationId(request, response);
+    if (routePattern) {
+      setRoutePattern(request, routePattern);
+    }
+
+    try {
+      const result = handler(request, response, next);
+      if (result && typeof (result as PromiseLike<unknown>).then === "function") {
+        return Promise.resolve(result).catch((error) => {
+          reportRouteError(logger, request, response, methodName, error);
+          sendInternalError(response, ensureRequestCorrelationId(request, response));
+        });
+      }
+      return result;
+    } catch (error) {
+      reportRouteError(logger, request, response, methodName, error);
+      sendInternalError(response, ensureRequestCorrelationId(request, response));
+      return undefined;
+    }
+  };
+}
+
+function wrapUseArguments(logger: HttpRouteObservabilityLogger, args: unknown[]): unknown[] {
+  if (args.length === 0) {
+    return args;
+  }
+
+  if (typeof args[0] === "string") {
+    return [args[0], ...args.slice(1).map((value) => wrapHandler(value, logger, "use"))];
+  }
+
+  return args.map((value) => wrapHandler(value, logger, "use"));
+}
+
+export function installHttpRequestObservability(
+  app: HttpRouteObservabilityApp,
+  logger: HttpRouteObservabilityLogger
+): void {
+  const originalUse = app.use?.bind(app);
+  if (originalUse) {
+    app.use = (...args: unknown[]) => originalUse(...wrapUseArguments(logger, args));
+    app.use((request: IncomingMessage, response: ServerResponse, next: () => void) => {
+      ensureRequestCorrelationId(request, response);
+      next();
+    });
+  }
+
+  for (const methodName of ROUTE_METHOD_NAMES) {
+    const originalMethod = app[methodName]?.bind(app);
+    if (!originalMethod) {
+      continue;
+    }
+
+    app[methodName] = ((path: string, ...handlers: unknown[]) =>
+      originalMethod(path, ...handlers.map((handler) => wrapHandler(handler, logger, methodName, path)))) as never;
+  }
+}

--- a/apps/server/test/http-request-context.test.ts
+++ b/apps/server/test/http-request-context.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Server, WebSocketTransport } from "colyseus";
+import {
+  getRequestCorrelationId,
+  installHttpRequestObservability,
+  REQUEST_CORRELATION_ID_HEADER
+} from "../src/http-request-context";
+import { registerRuntimeObservabilityRoutes, resetRuntimeObservability } from "../src/observability";
+
+interface TestLoggerEntry {
+  message: string;
+  error: unknown;
+}
+
+interface TestLogger {
+  errors: TestLoggerEntry[];
+  error(message: string, error: unknown): void;
+}
+
+function createLogger(): TestLogger {
+  return {
+    errors: [],
+    error(message, error) {
+      this.errors.push({ message, error });
+    }
+  };
+}
+
+function sendJson(response: { statusCode: number; setHeader(name: string, value: string): void; end(body: string): void }, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+async function startRequestObservabilityServer(port: number) {
+  resetRuntimeObservability();
+  const logger = createLogger();
+  const transport = new WebSocketTransport();
+  const app = transport.getExpressApp() as {
+    use(handler: (request: never, response: never, next: () => void) => void): void;
+    get(path: string, handler: (request: never, response: never) => void | Promise<void>): void;
+  };
+
+  installHttpRequestObservability(app, logger);
+  app.get("/api/test/correlation", (request, response) => {
+    sendJson(response, 200, {
+      correlationId: getRequestCorrelationId(request)
+    });
+  });
+  app.get("/api/test/failure", async () => {
+    throw new Error("intentional route failure");
+  });
+  registerRuntimeObservabilityRoutes(app);
+
+  const server = new Server({ transport });
+  await server.listen(port, "127.0.0.1");
+
+  return { logger, server };
+}
+
+test("http request observability attaches generated and caller-supplied correlation ids", async (t) => {
+  const port = 45100 + Math.floor(Math.random() * 1000);
+  const { server } = await startRequestObservabilityServer(port);
+
+  t.after(async () => {
+    resetRuntimeObservability();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const generatedResponse = await fetch(`http://127.0.0.1:${port}/api/test/correlation`);
+  const generatedPayload = (await generatedResponse.json()) as { correlationId: string };
+  const generatedHeader = generatedResponse.headers.get(REQUEST_CORRELATION_ID_HEADER);
+  assert.ok(generatedHeader);
+  assert.match(generatedHeader, /^req-[0-9a-f-]+$/);
+  assert.equal(generatedPayload.correlationId, generatedHeader);
+
+  const callerCorrelationId = "client-supplied-123";
+  const forwardedResponse = await fetch(`http://127.0.0.1:${port}/api/test/correlation`, {
+    headers: {
+      [REQUEST_CORRELATION_ID_HEADER]: callerCorrelationId
+    }
+  });
+  const forwardedPayload = (await forwardedResponse.json()) as { correlationId: string };
+  assert.equal(forwardedResponse.headers.get(REQUEST_CORRELATION_ID_HEADER), callerCorrelationId);
+  assert.equal(forwardedPayload.correlationId, callerCorrelationId);
+});
+
+test("http request observability logs structured route failures and records them in diagnostics", async (t) => {
+  const port = 46100 + Math.floor(Math.random() * 1000);
+  const { logger, server } = await startRequestObservabilityServer(port);
+
+  t.after(async () => {
+    resetRuntimeObservability();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const failedResponse = await fetch(`http://127.0.0.1:${port}/api/test/failure`);
+  const failedPayload = (await failedResponse.json()) as { error: string; correlationId: string };
+  assert.equal(failedResponse.status, 500);
+  assert.equal(failedPayload.error, "internal_server_error");
+  assert.equal(failedResponse.headers.get(REQUEST_CORRELATION_ID_HEADER), failedPayload.correlationId);
+
+  assert.equal(logger.errors.length, 1);
+  assert.match(logger.errors[0]?.message ?? "", /HTTP route handler failed/);
+  const loggedError = logger.errors[0]?.error as {
+    method: string;
+    path: string;
+    routePattern: string;
+    correlationId: string;
+    errorName: string;
+    errorMessage: string;
+    stack: string | null;
+  };
+  assert.equal(loggedError.method, "GET");
+  assert.equal(loggedError.path, "/api/test/failure");
+  assert.equal(loggedError.routePattern, "/api/test/failure");
+  assert.equal(loggedError.correlationId, failedPayload.correlationId);
+  assert.equal(loggedError.errorName, "Error");
+  assert.equal(loggedError.errorMessage, "intentional route failure");
+  assert.match(loggedError.stack ?? "", /intentional route failure/);
+
+  const diagnosticsResponse = await fetch(`http://127.0.0.1:${port}/api/runtime/diagnostic-snapshot`);
+  const diagnosticsPayload = (await diagnosticsResponse.json()) as {
+    diagnostics: {
+      errorEvents: Array<{
+        errorCode: string;
+        context: {
+          requestId: string | null;
+          route: string | null;
+          action: string | null;
+          statusCode: number | null;
+        };
+      }>;
+    };
+  };
+  const routeFailureEvent = diagnosticsPayload.diagnostics.errorEvents.find(
+    (event) => event.errorCode === "http_route_failed"
+  );
+
+  assert.ok(routeFailureEvent);
+  assert.equal(routeFailureEvent?.context.requestId, failedPayload.correlationId);
+  assert.equal(routeFailureEvent?.context.route, "/api/test/failure");
+  assert.equal(routeFailureEvent?.context.action, "GET");
+  assert.equal(routeFailureEvent?.context.statusCode, 500);
+});


### PR DESCRIPTION
## Summary
- add a bootstrap-level HTTP request observability wrapper that propagates `x-correlation-id` and preserves caller-supplied IDs
- centrally capture unexpected route failures into structured logs and runtime diagnostics with request/route/status context
- add an integration test for correlation ID propagation and route-failure diagnostics, plus a README note for operators

## Testing
- node --import tsx --test ./apps/server/test/http-request-context.test.ts ./apps/server/test/dev-server.test.ts
- npm run typecheck:server

Closes #1303