### PR TITLE
[codex] Add WeChat Pay callback idempotency and grant retry queue

### DIFF
--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -26,6 +26,8 @@ import {
   MAX_PLAYER_DISPLAY_NAME_LENGTH,
   type PaymentOrderCompleteInput,
   type PaymentOrderCreateInput,
+  type PaymentOrderGrantRetryInput,
+  type PaymentOrderListOptions,
   type PaymentReceiptSnapshot,
   type PaymentOrderSettlement,
   type PaymentOrderSnapshot,
@@ -96,6 +98,23 @@ function cloneAccount(account: PlayerAccountSnapshot): PlayerAccountSnapshot {
 
 function cloneArchive(archive: PlayerHeroArchiveSnapshot): PlayerHeroArchiveSnapshot {
   return structuredClone(archive);
+}
+
+function normalizePaymentRetryPolicy(input?: PaymentOrderCompleteInput["retryPolicy"] | PaymentOrderGrantRetryInput["retryPolicy"]) {
+  return {
+    maxAttempts: Math.max(1, Math.floor(input?.maxAttempts ?? 5)),
+    baseDelayMs: Math.max(1_000, Math.floor(input?.baseDelayMs ?? 60_000))
+  };
+}
+
+function computePaymentRetryDelayMs(attemptCount: number, baseDelayMs: number): number {
+  const exponent = Math.max(0, Math.min(6, Math.floor(attemptCount) - 1));
+  return Math.max(1_000, baseDelayMs * 2 ** exponent);
+}
+
+function normalizePaymentGrantError(value: unknown): string {
+  const normalized = (value instanceof Error ? value.message : String(value)).trim();
+  return (normalized || "grant_failed").slice(0, 512);
 }
 
 function normalizePlayerId(playerId: string): string {
@@ -286,6 +305,26 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
 
     const order = this.paymentOrders.get(normalizedOrderId);
     return order ? structuredClone(order) : null;
+  }
+
+  async listPaymentOrders(options: PaymentOrderListOptions = {}): Promise<PaymentOrderSnapshot[]> {
+    const safeLimit = Math.max(1, Math.min(200, Math.floor(options.limit ?? 50)));
+    const statusSet = options.statuses?.length ? new Set(options.statuses) : null;
+    const dueBeforeMs =
+      options.dueBefore && !Number.isNaN(new Date(options.dueBefore).getTime()) ? new Date(options.dueBefore).getTime() : null;
+
+    return Array.from(this.paymentOrders.values())
+      .filter((order) => (statusSet ? statusSet.has(order.status) : true))
+      .filter((order) =>
+        dueBeforeMs == null ? true : order.nextGrantRetryAt != null && new Date(order.nextGrantRetryAt).getTime() <= dueBeforeMs
+      )
+      .sort((left, right) => {
+        const leftRetryAt = left.nextGrantRetryAt ? new Date(left.nextGrantRetryAt).getTime() : Number.POSITIVE_INFINITY;
+        const rightRetryAt = right.nextGrantRetryAt ? new Date(right.nextGrantRetryAt).getTime() : Number.POSITIVE_INFINITY;
+        return leftRetryAt - rightRetryAt || right.updatedAt.localeCompare(left.updatedAt) || left.orderId.localeCompare(right.orderId);
+      })
+      .slice(0, safeLimit)
+      .map((order) => structuredClone(order));
   }
 
   async loadPaymentReceiptByOrderId(orderId: string): Promise<PaymentReceiptSnapshot | null> {
@@ -878,6 +917,95 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     return result;
   }
 
+  private applyVerifiedPaymentGrant(
+    account: PlayerAccountSnapshot,
+    order: PaymentOrderSnapshot,
+    input: {
+      productName: string;
+      grant: PaymentOrderCompleteInput["grant"];
+      processedAt: string;
+    }
+  ): PlayerAccountSnapshot {
+    const normalizedGrant = {
+      gems: Math.max(0, Math.floor(input.grant.gems ?? order.gemAmount ?? 0)),
+      resources: {
+        gold: Math.max(0, Math.floor(input.grant.resources?.gold ?? 0)),
+        wood: Math.max(0, Math.floor(input.grant.resources?.wood ?? 0)),
+        ore: Math.max(0, Math.floor(input.grant.resources?.ore ?? 0))
+      },
+      seasonPassPremium: input.grant.seasonPassPremium === true,
+      cosmeticIds: (input.grant.cosmeticIds ?? []).map((cosmeticId) => {
+        const normalizedCosmeticId = cosmeticId.trim();
+        if (!normalizedCosmeticId || !resolveCosmeticCatalog().some((entry) => entry.id === normalizedCosmeticId)) {
+          throw new Error(`unknown cosmetic grant: ${cosmeticId}`);
+        }
+        return normalizedCosmeticId;
+      }),
+      equipmentIds: (input.grant.equipmentIds ?? []).map((equipmentId) => {
+        const normalizedEquipmentId = equipmentId.trim();
+        if (!normalizedEquipmentId || !getEquipmentDefinition(normalizedEquipmentId)) {
+          throw new Error(`unknown equipment grant: ${equipmentId}`);
+        }
+        return normalizedEquipmentId;
+      })
+    };
+
+    if (normalizedGrant.equipmentIds.length > 0) {
+      const currentArchive = Array.from(this.heroArchives.values())
+        .filter((archive) => archive.playerId === order.playerId)
+        .sort((left, right) => left.heroId.localeCompare(right.heroId))[0];
+      if (!currentArchive) {
+        throw new Error("player hero archive not found");
+      }
+
+      let nextInventory = [...currentArchive.hero.loadout.inventory];
+      for (const equipmentId of normalizedGrant.equipmentIds) {
+        const inventoryUpdate = tryAddEquipmentToInventory(nextInventory, equipmentId);
+        if (!inventoryUpdate.stored) {
+          throw new Error("equipment inventory full");
+        }
+        nextInventory = inventoryUpdate.inventory;
+      }
+
+      this.heroArchives.set(`${currentArchive.playerId}:${currentArchive.heroId}`, {
+        ...cloneArchive(currentArchive),
+        hero: {
+          ...cloneArchive(currentArchive).hero,
+          loadout: {
+            ...cloneArchive(currentArchive).hero.loadout,
+            inventory: nextInventory
+          }
+        }
+      });
+    }
+
+    return {
+      ...account,
+      gems: (account.gems ?? 0) + normalizedGrant.gems,
+      seasonPassPremium: account.seasonPassPremium === true || normalizedGrant.seasonPassPremium,
+      cosmeticInventory: normalizeCosmeticInventory({
+        ownedIds: [...(account.cosmeticInventory?.ownedIds ?? []), ...normalizedGrant.cosmeticIds]
+      }),
+      globalResources: normalizeResourceLedger({
+        gold: (account.globalResources.gold ?? 0) + normalizedGrant.resources.gold,
+        wood: (account.globalResources.wood ?? 0) + normalizedGrant.resources.wood,
+        ore: (account.globalResources.ore ?? 0) + normalizedGrant.resources.ore
+      }),
+      recentEventLog: appendEventLogEntries(account.recentEventLog, [
+        {
+          id: `${order.playerId}:${input.processedAt}:shop:${order.productId}:1`,
+          timestamp: input.processedAt,
+          roomId: "shop",
+          playerId: order.playerId,
+          category: "account",
+          description: `Purchased ${input.productName} x1.`,
+          rewards: []
+        }
+      ]),
+      updatedAt: input.processedAt
+    };
+  }
+
   async createPaymentOrder(input: PaymentOrderCreateInput): Promise<PaymentOrderSnapshot> {
     const orderId = input.orderId.trim();
     const playerId = normalizePlayerId(input.playerId);
@@ -903,11 +1031,12 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       orderId,
       playerId,
       productId,
-      status: "pending",
+      status: "created",
       amount,
       gemAmount,
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      grantAttemptCount: 0
     };
     this.paymentOrders.set(orderId, structuredClone(order));
     return structuredClone(order);
@@ -934,7 +1063,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
 
     const account = await this.ensurePlayerAccount({ playerId: existingOrder.playerId });
     const existingReceipt = this.paymentReceiptsByOrderId.get(normalizedOrderId);
-    if (existingOrder.status === "paid" || existingReceipt) {
+    if (existingOrder.status !== "created" || existingReceipt) {
       return {
         order: structuredClone(existingOrder),
         account,
@@ -956,49 +1085,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
 
     const paidAt = new Date(input.paidAt ?? Date.now()).toISOString();
     const verifiedAt = new Date(input.verifiedAt ?? paidAt).toISOString();
-    const normalizedGrant = {
-      gems: Math.max(0, Math.floor(input.grant.gems ?? existingOrder.gemAmount ?? 0)),
-      resources: {
-        gold: Math.max(0, Math.floor(input.grant.resources?.gold ?? 0)),
-        wood: Math.max(0, Math.floor(input.grant.resources?.wood ?? 0)),
-        ore: Math.max(0, Math.floor(input.grant.resources?.ore ?? 0))
-      },
-      seasonPassPremium: input.grant.seasonPassPremium === true,
-      cosmeticIds: (input.grant.cosmeticIds ?? []).map((cosmeticId) => cosmeticId.trim()).filter(Boolean),
-      equipmentIds: (input.grant.equipmentIds ?? []).map((equipmentId) => equipmentId.trim()).filter(Boolean)
-    };
-    const nextOrder: PaymentOrderSnapshot = {
-      ...structuredClone(existingOrder),
-      status: "paid",
-      wechatOrderId: normalizedWechatOrderId,
-      paidAt,
-      updatedAt: paidAt
-    };
-    const nextAccount: PlayerAccountSnapshot = {
-      ...account,
-      gems: (account.gems ?? 0) + normalizedGrant.gems,
-      seasonPassPremium: account.seasonPassPremium === true || normalizedGrant.seasonPassPremium,
-      cosmeticInventory: normalizeCosmeticInventory({
-        ownedIds: [...(account.cosmeticInventory?.ownedIds ?? []), ...normalizedGrant.cosmeticIds]
-      }),
-      globalResources: normalizeResourceLedger({
-        gold: (account.globalResources.gold ?? 0) + normalizedGrant.resources.gold,
-        wood: (account.globalResources.wood ?? 0) + normalizedGrant.resources.wood,
-        ore: (account.globalResources.ore ?? 0) + normalizedGrant.resources.ore
-      }),
-      recentEventLog: appendEventLogEntries(account.recentEventLog, [
-        {
-          id: `${existingOrder.playerId}:${paidAt}:shop:${existingOrder.productId}:1`,
-          timestamp: paidAt,
-          roomId: "shop",
-          playerId: existingOrder.playerId,
-          category: "account",
-          description: `Purchased ${normalizedProductName} x1.`,
-          rewards: []
-        }
-      ]),
-      updatedAt: paidAt
-    };
+    const retryPolicy = normalizePaymentRetryPolicy(input.retryPolicy);
     const receipt: PaymentReceiptSnapshot = {
       transactionId: normalizedWechatOrderId,
       orderId: normalizedOrderId,
@@ -1007,17 +1094,157 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       amount: existingOrder.amount,
       verifiedAt
     };
-    this.paymentOrders.set(normalizedOrderId, structuredClone(nextOrder));
     this.paymentReceiptsByOrderId.set(normalizedOrderId, structuredClone(receipt));
     this.paymentReceiptOrderIdByTransactionId.set(normalizedWechatOrderId, normalizedOrderId);
-    this.accounts.set(existingOrder.playerId, cloneAccount(nextAccount));
-
-    return {
-      order: structuredClone(nextOrder),
-      account: cloneAccount(nextAccount),
-      credited: true,
-      receipt: structuredClone(receipt)
+    const processingOrder: PaymentOrderSnapshot = {
+      ...structuredClone(existingOrder),
+      status: "paid",
+      wechatOrderId: normalizedWechatOrderId,
+      paidAt,
+      lastGrantAttemptAt: paidAt,
+      grantAttemptCount: 1,
+      updatedAt: paidAt
     };
+    this.paymentOrders.set(normalizedOrderId, structuredClone(processingOrder));
+
+    try {
+      const nextAccount = this.applyVerifiedPaymentGrant(account, processingOrder, {
+        productName: normalizedProductName,
+        grant: input.grant,
+        processedAt: paidAt
+      });
+      const settledOrder: PaymentOrderSnapshot = {
+        ...processingOrder,
+        status: "settled",
+        settledAt: paidAt,
+        updatedAt: paidAt
+      };
+      this.paymentOrders.set(normalizedOrderId, structuredClone(settledOrder));
+      this.accounts.set(existingOrder.playerId, cloneAccount(nextAccount));
+
+      return {
+        order: structuredClone(settledOrder),
+        account: cloneAccount(nextAccount),
+        credited: true,
+        receipt: structuredClone(receipt)
+      };
+    } catch (error) {
+      const grantError = normalizePaymentGrantError(error);
+      const deadLetter = 1 >= retryPolicy.maxAttempts;
+      const nextRetryAt = new Date(new Date(paidAt).getTime() + computePaymentRetryDelayMs(1, retryPolicy.baseDelayMs)).toISOString();
+      const nextOrder: PaymentOrderSnapshot = {
+        ...processingOrder,
+        status: deadLetter ? "dead_letter" : "grant_pending",
+        lastGrantError: grantError,
+        ...(deadLetter ? { deadLetteredAt: paidAt } : { nextGrantRetryAt: nextRetryAt }),
+        updatedAt: paidAt
+      };
+      this.paymentOrders.set(normalizedOrderId, structuredClone(nextOrder));
+
+      return {
+        order: structuredClone(nextOrder),
+        account,
+        credited: false,
+        receipt: structuredClone(receipt)
+      };
+    }
+  }
+
+  async retryPaymentOrderGrant(orderId: string, input: PaymentOrderGrantRetryInput): Promise<PaymentOrderSettlement> {
+    const normalizedOrderId = orderId.trim();
+    const normalizedProductName = input.productName.trim();
+    if (!normalizedOrderId) {
+      throw new Error("orderId must not be empty");
+    }
+    if (!normalizedProductName) {
+      throw new Error("productName must not be empty");
+    }
+
+    const existingOrder = this.paymentOrders.get(normalizedOrderId);
+    if (!existingOrder) {
+      throw new Error("payment_order_not_found");
+    }
+    if (existingOrder.status === "settled") {
+      return {
+        order: structuredClone(existingOrder),
+        account: await this.ensurePlayerAccount({ playerId: existingOrder.playerId }),
+        credited: false,
+        ...(this.paymentReceiptsByOrderId.get(normalizedOrderId)
+          ? { receipt: structuredClone(this.paymentReceiptsByOrderId.get(normalizedOrderId)!) }
+          : {})
+      };
+    }
+    if (existingOrder.status !== "grant_pending" && existingOrder.status !== "dead_letter" && existingOrder.status !== "paid") {
+      throw new Error("payment_order_not_retryable");
+    }
+    if (existingOrder.status === "dead_letter" && input.allowDeadLetter !== true) {
+      throw new Error("payment_order_retry_requires_override");
+    }
+
+    const account = await this.ensurePlayerAccount({ playerId: existingOrder.playerId });
+    const receipt = this.paymentReceiptsByOrderId.get(normalizedOrderId);
+    if (!receipt) {
+      throw new Error("payment_receipt_not_found");
+    }
+
+    const retriedAt = new Date(input.retriedAt ?? Date.now()).toISOString();
+    const retryPolicy = normalizePaymentRetryPolicy(input.retryPolicy);
+    const attemptCount = existingOrder.grantAttemptCount + 1;
+    const processingOrder: PaymentOrderSnapshot = {
+      ...structuredClone(existingOrder),
+      lastGrantAttemptAt: retriedAt,
+      grantAttemptCount: attemptCount,
+      updatedAt: retriedAt
+    };
+
+    try {
+      const nextAccount = this.applyVerifiedPaymentGrant(account, processingOrder, {
+        productName: normalizedProductName,
+        grant: input.grant,
+        processedAt: retriedAt
+      });
+      const settledOrder: PaymentOrderSnapshot = {
+        ...processingOrder,
+        status: "settled",
+        settledAt: retriedAt,
+        updatedAt: retriedAt
+      };
+      delete settledOrder.nextGrantRetryAt;
+      delete settledOrder.lastGrantError;
+      delete settledOrder.deadLetteredAt;
+      this.paymentOrders.set(normalizedOrderId, structuredClone(settledOrder));
+      this.accounts.set(existingOrder.playerId, cloneAccount(nextAccount));
+
+      return {
+        order: structuredClone(settledOrder),
+        account: cloneAccount(nextAccount),
+        credited: true,
+        receipt: structuredClone(receipt)
+      };
+    } catch (error) {
+      const grantError = normalizePaymentGrantError(error);
+      const deadLetter = attemptCount >= retryPolicy.maxAttempts;
+      const nextRetryAt = new Date(new Date(retriedAt).getTime() + computePaymentRetryDelayMs(attemptCount, retryPolicy.baseDelayMs))
+        .toISOString();
+      const nextOrder: PaymentOrderSnapshot = {
+        ...processingOrder,
+        status: deadLetter ? "dead_letter" : "grant_pending",
+        lastGrantError: grantError,
+        ...(deadLetter ? { deadLetteredAt: retriedAt } : { nextGrantRetryAt: nextRetryAt }),
+        updatedAt: retriedAt
+      };
+      if (deadLetter) {
+        delete nextOrder.nextGrantRetryAt;
+      }
+      this.paymentOrders.set(normalizedOrderId, structuredClone(nextOrder));
+
+      return {
+        order: structuredClone(nextOrder),
+        account,
+        credited: false,
+        receipt: structuredClone(receipt)
+      };
+    }
   }
 
   async purchaseShopProduct(playerId: string, input: ShopPurchaseMutationInput): Promise<ShopPurchaseResult> {

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -69,6 +69,11 @@ interface AntiCheatObservabilityCounters {
   alertsTotal: number;
 }
 
+interface PaymentGrantObservabilityCounters {
+  retriesTotal: number;
+  deadLetterTotal: number;
+}
+
 type ActionValidationScope = "world" | "battle";
 
 export interface AntiCheatAlertEvent {
@@ -202,6 +207,13 @@ interface RuntimeObservabilityState {
   antiCheat: {
     counters: AntiCheatObservabilityCounters;
     recentAlerts: AntiCheatAlertEvent[];
+  };
+  paymentGrant: {
+    queueCount: number;
+    deadLetterCount: number;
+    oldestQueuedLatencyMs: number | null;
+    nextAttemptDelayMs: number | null;
+    counters: PaymentGrantObservabilityCounters;
   };
 }
 
@@ -462,6 +474,16 @@ const runtimeObservability: RuntimeObservabilityState = {
       alertsTotal: 0
     },
     recentAlerts: []
+  },
+  paymentGrant: {
+    queueCount: 0,
+    deadLetterCount: 0,
+    oldestQueuedLatencyMs: null,
+    nextAttemptDelayMs: null,
+    counters: {
+      retriesTotal: 0,
+      deadLetterTotal: 0
+    }
   }
 };
 
@@ -1215,6 +1237,24 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_auth_token_delivery_failures_webhook_5xx_total Total token delivery failures caused by retryable 5xx webhook responses.",
     "# TYPE veil_auth_token_delivery_failures_webhook_5xx_total counter",
     `veil_auth_token_delivery_failures_webhook_5xx_total ${health.runtime.auth.tokenDelivery.failureReasons.webhook_5xx}`,
+    "# HELP veil_payment_grant_queue_count Payment orders currently queued for grant retry.",
+    "# TYPE veil_payment_grant_queue_count gauge",
+    `veil_payment_grant_queue_count ${runtimeObservability.paymentGrant.queueCount}`,
+    "# HELP veil_payment_grant_dead_letter_count Payment orders currently parked in the dead-letter set.",
+    "# TYPE veil_payment_grant_dead_letter_count gauge",
+    `veil_payment_grant_dead_letter_count ${runtimeObservability.paymentGrant.deadLetterCount}`,
+    "# HELP veil_payment_grant_oldest_queued_latency_ms Oldest queued payment grant retry age in milliseconds.",
+    "# TYPE veil_payment_grant_oldest_queued_latency_ms gauge",
+    `veil_payment_grant_oldest_queued_latency_ms ${runtimeObservability.paymentGrant.oldestQueuedLatencyMs ?? 0}`,
+    "# HELP veil_payment_grant_next_attempt_delay_ms Delay until the next queued payment grant retry attempt in milliseconds.",
+    "# TYPE veil_payment_grant_next_attempt_delay_ms gauge",
+    `veil_payment_grant_next_attempt_delay_ms ${runtimeObservability.paymentGrant.nextAttemptDelayMs ?? 0}`,
+    "# HELP veil_payment_grant_retries_total Total payment grant retries attempted by this process.",
+    "# TYPE veil_payment_grant_retries_total counter",
+    `veil_payment_grant_retries_total ${runtimeObservability.paymentGrant.counters.retriesTotal}`,
+    "# HELP veil_payment_dead_letter_total Total payment orders moved to dead-letter by this process.",
+    "# TYPE veil_payment_dead_letter_total counter",
+    `veil_payment_dead_letter_total ${runtimeObservability.paymentGrant.counters.deadLetterTotal}`,
     "# HELP veil_auth_session_failures_unauthorized_total Total auth session failures caused by missing or invalid credentials.",
     "# TYPE veil_auth_session_failures_unauthorized_total counter",
     `veil_auth_session_failures_unauthorized_total ${health.runtime.auth.sessionFailureReasons.unauthorized}`,
@@ -1858,6 +1898,32 @@ export function recordAuthTokenDeliveryDeadLetter(): void {
   runtimeObservability.auth.counters.tokenDeliveryDeadLettersTotal += 1;
 }
 
+export function setPaymentGrantQueueCount(count: number): void {
+  runtimeObservability.paymentGrant.queueCount = Math.max(0, Math.floor(count));
+}
+
+export function setPaymentGrantDeadLetterCount(count: number): void {
+  runtimeObservability.paymentGrant.deadLetterCount = Math.max(0, Math.floor(count));
+}
+
+export function setPaymentGrantQueueLatency(metrics: {
+  oldestQueuedLatencyMs: number | null;
+  nextAttemptDelayMs: number | null;
+}): void {
+  runtimeObservability.paymentGrant.oldestQueuedLatencyMs =
+    metrics.oldestQueuedLatencyMs != null ? Math.max(0, Math.floor(metrics.oldestQueuedLatencyMs)) : null;
+  runtimeObservability.paymentGrant.nextAttemptDelayMs =
+    metrics.nextAttemptDelayMs != null ? Math.max(0, Math.floor(metrics.nextAttemptDelayMs)) : null;
+}
+
+export function recordPaymentGrantRetry(): void {
+  runtimeObservability.paymentGrant.counters.retriesTotal += 1;
+}
+
+export function recordPaymentDeadLetter(): void {
+  runtimeObservability.paymentGrant.counters.deadLetterTotal += 1;
+}
+
 export function recordAuthTokenDeliveryAttempt(entry: {
   kind: "account-registration" | "password-recovery";
   loginId: string;
@@ -1985,6 +2051,12 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.leaderboardAbuse.recentAlerts.length = 0;
   runtimeObservability.antiCheat.counters.alertsTotal = 0;
   runtimeObservability.antiCheat.recentAlerts.length = 0;
+  runtimeObservability.paymentGrant.queueCount = 0;
+  runtimeObservability.paymentGrant.deadLetterCount = 0;
+  runtimeObservability.paymentGrant.oldestQueuedLatencyMs = null;
+  runtimeObservability.paymentGrant.nextAttemptDelayMs = null;
+  runtimeObservability.paymentGrant.counters.retriesTotal = 0;
+  runtimeObservability.paymentGrant.counters.deadLetterTotal = 0;
 }
 
 export function registerRuntimeObservabilityRoutes(

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -196,6 +196,7 @@ export interface RoomSnapshotStore {
   loadGuildByMemberPlayerId?(playerId: string): Promise<GuildState | null>;
   listGuildAuditLogs?(options?: GuildAuditLogListOptions): Promise<GuildAuditLogRecord[]>;
   loadPaymentOrder?(orderId: string): Promise<PaymentOrderSnapshot | null>;
+  listPaymentOrders?(options?: PaymentOrderListOptions): Promise<PaymentOrderSnapshot[]>;
   loadPaymentReceiptByOrderId?(orderId: string): Promise<PaymentReceiptSnapshot | null>;
   countVerifiedPaymentReceiptsSince?(playerId: string, since: string): Promise<number>;
   loadPlayerReport?(reportId: string): Promise<PlayerReportRecord | null>;
@@ -229,6 +230,7 @@ export interface RoomSnapshotStore {
   ): Promise<PlayerAccountSnapshot>;
   createPaymentOrder?(input: PaymentOrderCreateInput): Promise<PaymentOrderSnapshot>;
   completePaymentOrder?(orderId: string, input: PaymentOrderCompleteInput): Promise<PaymentOrderSettlement>;
+  retryPaymentOrderGrant?(orderId: string, input: PaymentOrderGrantRetryInput): Promise<PaymentOrderSettlement>;
   creditGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
   debitGems(playerId: string, amount: number, reason: GemLedgerReason, refId: string): Promise<PlayerAccountSnapshot>;
   claimPlayerReferral?(referrerId: string, newPlayerId: string, rewardGems: number): Promise<PlayerReferralClaimResult>;
@@ -503,6 +505,12 @@ interface PaymentOrderRow extends RowDataPacket {
   gem_amount: number;
   created_at: Date | string;
   paid_at: Date | string | null;
+  last_grant_attempt_at: Date | string | null;
+  next_grant_retry_at: Date | string | null;
+  settled_at: Date | string | null;
+  dead_lettered_at: Date | string | null;
+  grant_attempt_count: number;
+  last_grant_error: string | null;
   updated_at: Date | string;
 }
 
@@ -721,7 +729,7 @@ export interface ShopPurchaseResult {
   processedAt: string;
 }
 
-export type PaymentOrderStatus = "pending" | "paid";
+export type PaymentOrderStatus = "created" | "paid" | "grant_pending" | "settled" | "dead_letter";
 
 export interface PaymentOrderSnapshot {
   orderId: string;
@@ -732,8 +740,14 @@ export interface PaymentOrderSnapshot {
   gemAmount: number;
   createdAt: string;
   updatedAt: string;
+  grantAttemptCount: number;
   wechatOrderId?: string;
   paidAt?: string;
+  lastGrantAttemptAt?: string;
+  nextGrantRetryAt?: string;
+  lastGrantError?: string;
+  settledAt?: string;
+  deadLetteredAt?: string;
 }
 
 export interface PaymentOrderCreateInput {
@@ -750,6 +764,7 @@ export interface PaymentOrderCompleteInput {
   verifiedAt?: string;
   productName: string;
   grant: ShopPurchaseGrant;
+  retryPolicy?: PaymentGrantRetryPolicy;
 }
 
 export interface PaymentOrderSettlement {
@@ -766,6 +781,25 @@ export interface PaymentReceiptSnapshot {
   productId: string;
   amount: number;
   verifiedAt: string;
+}
+
+export interface PaymentGrantRetryPolicy {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+}
+
+export interface PaymentOrderListOptions {
+  statuses?: PaymentOrderStatus[];
+  limit?: number;
+  dueBefore?: string;
+}
+
+export interface PaymentOrderGrantRetryInput {
+  productName: string;
+  grant: ShopPurchaseGrant;
+  retriedAt?: string;
+  retryPolicy?: PaymentGrantRetryPolicy;
+  allowDeadLetter?: boolean;
 }
 
 export interface GemLedgerEntry {
@@ -1016,6 +1050,7 @@ export const MYSQL_SHOP_PURCHASE_TABLE = "shop_purchases";
 export const MYSQL_PAYMENT_ORDER_TABLE = "orders";
 export const MYSQL_PAYMENT_ORDER_PLAYER_CREATED_INDEX = "idx_orders_player_created";
 export const MYSQL_PAYMENT_ORDER_WECHAT_ORDER_ID_INDEX = "uidx_orders_wechat_order_id";
+export const MYSQL_PAYMENT_ORDER_STATUS_RETRY_INDEX = "idx_orders_status_next_retry";
 export const MYSQL_PAYMENT_RECEIPT_TABLE = "payment_receipts";
 export const MYSQL_PAYMENT_RECEIPT_ORDER_ID_INDEX = "uidx_payment_receipts_order_id";
 export const MYSQL_PAYMENT_RECEIPT_PLAYER_VERIFIED_INDEX = "idx_payment_receipts_player_verified";
@@ -1163,7 +1198,18 @@ function normalizePaymentOrderId(orderId: string): string {
 }
 
 function normalizePaymentOrderStatus(status?: string | null): PaymentOrderStatus {
-  return status === "paid" ? "paid" : "pending";
+  switch (status) {
+    case "created":
+    case "paid":
+    case "grant_pending":
+    case "settled":
+    case "dead_letter":
+      return status;
+    case "pending":
+      return "created";
+    default:
+      return "created";
+  }
 }
 
 function normalizeWechatOrderId(wechatOrderId: string): string {
@@ -1184,10 +1230,39 @@ function normalizePaymentAmount(amount: number): number {
   return normalized;
 }
 
+function normalizePaymentGrantAttemptCount(value?: number | null): number {
+  const normalized = Math.max(0, Math.floor(value ?? 0));
+  return Number.isFinite(normalized) ? normalized : 0;
+}
+
+function normalizePaymentGrantError(value?: string | null): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized.slice(0, 512) : undefined;
+}
+
+function normalizePaymentGrantRetryPolicy(input?: PaymentGrantRetryPolicy | null): Required<PaymentGrantRetryPolicy> {
+  const maxAttempts = Math.max(1, Math.floor(input?.maxAttempts ?? 5));
+  const baseDelayMs = Math.max(1_000, Math.floor(input?.baseDelayMs ?? 60_000));
+  return {
+    maxAttempts,
+    baseDelayMs
+  };
+}
+
+function computePaymentGrantRetryDelayMs(attemptCount: number, baseDelayMs: number): number {
+  const exponent = Math.max(0, Math.min(6, Math.floor(attemptCount) - 1));
+  return Math.max(1_000, baseDelayMs * 2 ** exponent);
+}
+
 function toPaymentOrderSnapshot(row: PaymentOrderRow): PaymentOrderSnapshot {
   const createdAt = formatTimestamp(row.created_at) ?? new Date(0).toISOString();
   const updatedAt = formatTimestamp(row.updated_at) ?? createdAt;
   const paidAt = formatTimestamp(row.paid_at);
+  const lastGrantAttemptAt = formatTimestamp(row.last_grant_attempt_at);
+  const nextGrantRetryAt = formatTimestamp(row.next_grant_retry_at);
+  const settledAt = formatTimestamp(row.settled_at);
+  const deadLetteredAt = formatTimestamp(row.dead_lettered_at);
+  const lastGrantError = normalizePaymentGrantError(row.last_grant_error);
 
   return {
     orderId: normalizePaymentOrderId(row.order_id),
@@ -1198,8 +1273,14 @@ function toPaymentOrderSnapshot(row: PaymentOrderRow): PaymentOrderSnapshot {
     gemAmount: normalizeGemAmount(row.gem_amount),
     createdAt,
     updatedAt,
+    grantAttemptCount: normalizePaymentGrantAttemptCount(row.grant_attempt_count),
     ...(row.wechat_order_id ? { wechatOrderId: normalizeWechatOrderId(row.wechat_order_id) } : {}),
-    ...(paidAt ? { paidAt } : {})
+    ...(paidAt ? { paidAt } : {}),
+    ...(lastGrantAttemptAt ? { lastGrantAttemptAt } : {}),
+    ...(nextGrantRetryAt ? { nextGrantRetryAt } : {}),
+    ...(lastGrantError ? { lastGrantError } : {}),
+    ...(settledAt ? { settledAt } : {}),
+    ...(deadLetteredAt ? { deadLetteredAt } : {})
   };
 }
 
@@ -2545,11 +2626,17 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PAYMENT_ORDER_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
   product_id VARCHAR(191) NOT NULL,
   wechat_order_id VARCHAR(191) NULL,
-  status VARCHAR(16) NOT NULL DEFAULT 'pending',
+  status VARCHAR(16) NOT NULL DEFAULT 'created',
   amount INT NOT NULL,
   gem_amount INT NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   paid_at DATETIME NULL DEFAULT NULL,
+  last_grant_attempt_at DATETIME NULL DEFAULT NULL,
+  next_grant_retry_at DATETIME NULL DEFAULT NULL,
+  settled_at DATETIME NULL DEFAULT NULL,
+  dead_lettered_at DATETIME NULL DEFAULT NULL,
+  grant_attempt_count INT NOT NULL DEFAULT 0,
+  last_grant_error VARCHAR(512) NULL DEFAULT NULL,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (order_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -3610,6 +3697,145 @@ SET @veil_payment_orders_wechat_order_idx_sql := IF(
 PREPARE veil_payment_orders_wechat_order_idx_stmt FROM @veil_payment_orders_wechat_order_idx_sql;
 EXECUTE veil_payment_orders_wechat_order_idx_stmt;
 DEALLOCATE PREPARE veil_payment_orders_wechat_order_idx_stmt;
+
+SET @veil_payment_orders_last_grant_attempt_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND COLUMN_NAME = 'last_grant_attempt_at'
+);
+
+SET @veil_payment_orders_last_grant_attempt_sql := IF(
+  @veil_payment_orders_last_grant_attempt_exists = 0,
+  'ALTER TABLE \`${MYSQL_PAYMENT_ORDER_TABLE}\` ADD COLUMN \`last_grant_attempt_at\` DATETIME NULL DEFAULT NULL AFTER \`paid_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_last_grant_attempt_stmt FROM @veil_payment_orders_last_grant_attempt_sql;
+EXECUTE veil_payment_orders_last_grant_attempt_stmt;
+DEALLOCATE PREPARE veil_payment_orders_last_grant_attempt_stmt;
+
+SET @veil_payment_orders_next_grant_retry_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND COLUMN_NAME = 'next_grant_retry_at'
+);
+
+SET @veil_payment_orders_next_grant_retry_sql := IF(
+  @veil_payment_orders_next_grant_retry_exists = 0,
+  'ALTER TABLE \`${MYSQL_PAYMENT_ORDER_TABLE}\` ADD COLUMN \`next_grant_retry_at\` DATETIME NULL DEFAULT NULL AFTER \`last_grant_attempt_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_next_grant_retry_stmt FROM @veil_payment_orders_next_grant_retry_sql;
+EXECUTE veil_payment_orders_next_grant_retry_stmt;
+DEALLOCATE PREPARE veil_payment_orders_next_grant_retry_stmt;
+
+SET @veil_payment_orders_settled_at_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND COLUMN_NAME = 'settled_at'
+);
+
+SET @veil_payment_orders_settled_at_sql := IF(
+  @veil_payment_orders_settled_at_exists = 0,
+  'ALTER TABLE \`${MYSQL_PAYMENT_ORDER_TABLE}\` ADD COLUMN \`settled_at\` DATETIME NULL DEFAULT NULL AFTER \`next_grant_retry_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_settled_at_stmt FROM @veil_payment_orders_settled_at_sql;
+EXECUTE veil_payment_orders_settled_at_stmt;
+DEALLOCATE PREPARE veil_payment_orders_settled_at_stmt;
+
+SET @veil_payment_orders_dead_lettered_at_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND COLUMN_NAME = 'dead_lettered_at'
+);
+
+SET @veil_payment_orders_dead_lettered_at_sql := IF(
+  @veil_payment_orders_dead_lettered_at_exists = 0,
+  'ALTER TABLE \`${MYSQL_PAYMENT_ORDER_TABLE}\` ADD COLUMN \`dead_lettered_at\` DATETIME NULL DEFAULT NULL AFTER \`settled_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_dead_lettered_at_stmt FROM @veil_payment_orders_dead_lettered_at_sql;
+EXECUTE veil_payment_orders_dead_lettered_at_stmt;
+DEALLOCATE PREPARE veil_payment_orders_dead_lettered_at_stmt;
+
+SET @veil_payment_orders_grant_attempt_count_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND COLUMN_NAME = 'grant_attempt_count'
+);
+
+SET @veil_payment_orders_grant_attempt_count_sql := IF(
+  @veil_payment_orders_grant_attempt_count_exists = 0,
+  'ALTER TABLE \`${MYSQL_PAYMENT_ORDER_TABLE}\` ADD COLUMN \`grant_attempt_count\` INT NOT NULL DEFAULT 0 AFTER \`dead_lettered_at\`',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_grant_attempt_count_stmt FROM @veil_payment_orders_grant_attempt_count_sql;
+EXECUTE veil_payment_orders_grant_attempt_count_stmt;
+DEALLOCATE PREPARE veil_payment_orders_grant_attempt_count_stmt;
+
+SET @veil_payment_orders_last_grant_error_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND COLUMN_NAME = 'last_grant_error'
+);
+
+SET @veil_payment_orders_last_grant_error_sql := IF(
+  @veil_payment_orders_last_grant_error_exists = 0,
+  'ALTER TABLE \`${MYSQL_PAYMENT_ORDER_TABLE}\` ADD COLUMN \`last_grant_error\` VARCHAR(512) NULL DEFAULT NULL AFTER \`grant_attempt_count\`',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_last_grant_error_stmt FROM @veil_payment_orders_last_grant_error_sql;
+EXECUTE veil_payment_orders_last_grant_error_stmt;
+DEALLOCATE PREPARE veil_payment_orders_last_grant_error_stmt;
+
+UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+SET status = 'created'
+WHERE status = 'pending';
+
+UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+SET status = 'settled',
+    settled_at = COALESCE(settled_at, paid_at, updated_at),
+    grant_attempt_count = CASE WHEN grant_attempt_count <= 0 THEN 1 ELSE grant_attempt_count END,
+    last_grant_attempt_at = COALESCE(last_grant_attempt_at, paid_at, updated_at),
+    next_grant_retry_at = NULL,
+    last_grant_error = NULL
+WHERE status = 'paid';
+
+SET @veil_payment_orders_status_retry_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PAYMENT_ORDER_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PAYMENT_ORDER_STATUS_RETRY_INDEX}'
+);
+
+SET @veil_payment_orders_status_retry_idx_sql := IF(
+  @veil_payment_orders_status_retry_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_PAYMENT_ORDER_STATUS_RETRY_INDEX}\` ON \`${MYSQL_PAYMENT_ORDER_TABLE}\` (status, next_grant_retry_at, updated_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_payment_orders_status_retry_idx_stmt FROM @veil_payment_orders_status_retry_idx_sql;
+EXECUTE veil_payment_orders_status_retry_idx_stmt;
+DEALLOCATE PREPARE veil_payment_orders_status_retry_idx_stmt;
 
 SET @veil_payment_receipts_player_verified_idx_exists := (
   SELECT COUNT(*)
@@ -4998,6 +5224,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          gem_amount,
          created_at,
          paid_at,
+         last_grant_attempt_at,
+         next_grant_retry_at,
+         settled_at,
+         dead_lettered_at,
+         grant_attempt_count,
+         last_grant_error,
          updated_at
        FROM \`${MYSQL_PAYMENT_ORDER_TABLE}\`
        WHERE order_id = ?
@@ -5007,6 +5239,55 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const row = rows[0];
     return row ? toPaymentOrderSnapshot(row) : null;
+  }
+
+  async listPaymentOrders(options: PaymentOrderListOptions = {}): Promise<PaymentOrderSnapshot[]> {
+    const normalizedStatuses = Array.from(new Set((options.statuses ?? []).map((status) => normalizePaymentOrderStatus(status))));
+    const safeLimit = Math.max(1, Math.min(200, Math.floor(options.limit ?? 50)));
+    const dueBefore =
+      options.dueBefore && !Number.isNaN(new Date(options.dueBefore).getTime()) ? new Date(options.dueBefore) : null;
+    const whereClauses = [];
+    const params: Array<string | number | Date> = [];
+
+    if (normalizedStatuses.length > 0) {
+      whereClauses.push(`status IN (${normalizedStatuses.map(() => "?").join(", ")})`);
+      params.push(...normalizedStatuses);
+    }
+    if (dueBefore) {
+      whereClauses.push("next_grant_retry_at IS NOT NULL");
+      whereClauses.push("next_grant_retry_at <= ?");
+      params.push(dueBefore);
+    }
+
+    const [rows] = await this.pool.query<PaymentOrderRow[]>(
+      `SELECT
+         order_id,
+         player_id,
+         product_id,
+         wechat_order_id,
+         status,
+         amount,
+         gem_amount,
+         created_at,
+         paid_at,
+         last_grant_attempt_at,
+         next_grant_retry_at,
+         settled_at,
+         dead_lettered_at,
+         grant_attempt_count,
+         last_grant_error,
+         updated_at
+       FROM \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+       ${whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : ""}
+       ORDER BY
+         CASE WHEN next_grant_retry_at IS NULL THEN 1 ELSE 0 END ASC,
+         next_grant_retry_at ASC,
+         updated_at DESC
+       LIMIT ?`,
+      [...params, safeLimit]
+    );
+
+    return rows.map((row) => toPaymentOrderSnapshot(row));
   }
 
   async loadPaymentReceiptByOrderId(orderId: string): Promise<PaymentReceiptSnapshot | null> {
@@ -6406,19 +6687,21 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     await this.pool.query(
       `INSERT INTO \`${MYSQL_PAYMENT_ORDER_TABLE}\`
          (order_id, player_id, product_id, status, amount, gem_amount)
-       VALUES (?, ?, ?, 'pending', ?, ?)`,
+       VALUES (?, ?, ?, 'created', ?, ?)`,
       [orderId, playerId, productId, amount, gemAmount]
     );
 
+    const now = new Date().toISOString();
     return {
       orderId,
       playerId,
       productId,
-      status: "pending",
+      status: "created",
       amount,
       gemAmount,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString()
+      createdAt: now,
+      updatedAt: now,
+      grantAttemptCount: 0
     };
   }
 
@@ -6434,6 +6717,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     if (Number.isNaN(verifiedAt.getTime())) {
       throw new Error("verifiedAt must be a valid ISO timestamp");
     }
+    const retryPolicy = normalizePaymentGrantRetryPolicy(input.retryPolicy);
 
     const connection = await this.pool.getConnection();
     try {
@@ -6450,6 +6734,12 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
            gem_amount,
            created_at,
            paid_at,
+           last_grant_attempt_at,
+           next_grant_retry_at,
+           settled_at,
+           dead_lettered_at,
+           grant_attempt_count,
+           last_grant_error,
            updated_at
          FROM \`${MYSQL_PAYMENT_ORDER_TABLE}\`
          WHERE order_id = ?
@@ -6480,7 +6770,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
               globalResources: normalizeResourceLedger()
             });
 
-      if (currentOrder.status === "paid") {
+      if (currentOrder.status !== "created") {
         const [receiptRows] = await connection.query<PaymentReceiptRow[]>(
           `SELECT
              transaction_id,
@@ -6503,7 +6793,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
           },
           account: currentAccount,
           credited: false,
-          ...(receiptRows[0] ? { receipt: toPaymentReceiptSnapshot(receiptRows[0]) } : {})
+            ...(receiptRows[0] ? { receipt: toPaymentReceiptSnapshot(receiptRows[0]) } : {})
         };
       }
 
@@ -6552,41 +6842,294 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         };
       }
 
-      const nextAccount = await applyVerifiedPaymentGrantToAccount(connection, currentAccount, {
-        playerId: currentOrder.playerId,
-        productId: currentOrder.productId,
-        productName: normalizedProductName,
-        grant: input.grant,
-        refId: currentOrder.orderId,
-        processedAt: paidAt.toISOString()
-      });
       await connection.query(
         `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
          SET wechat_order_id = ?,
              status = 'paid',
-             paid_at = ?
+             paid_at = ?,
+             last_grant_attempt_at = ?,
+             next_grant_retry_at = NULL,
+             settled_at = NULL,
+             dead_lettered_at = NULL,
+             grant_attempt_count = 1,
+             last_grant_error = NULL
          WHERE order_id = ?`,
-        [normalizedWechatOrderId, paidAt, currentOrder.orderId]
+        [normalizedWechatOrderId, paidAt, paidAt, currentOrder.orderId]
       );
 
-      await connection.commit();
+      try {
+        const nextAccount = await applyVerifiedPaymentGrantToAccount(connection, currentAccount, {
+          playerId: currentOrder.playerId,
+          productId: currentOrder.productId,
+          productName: normalizedProductName,
+          grant: input.grant,
+          refId: currentOrder.orderId,
+          processedAt: paidAt.toISOString()
+        });
 
-      const nextOrder =
-        (await this.loadPaymentOrder(currentOrder.orderId)) ??
-        ({
-          ...currentOrder,
-          status: "paid",
-          wechatOrderId: normalizedWechatOrderId,
-          paidAt: paidAt.toISOString(),
-          updatedAt: paidAt.toISOString()
-        } satisfies PaymentOrderSnapshot);
+        await connection.query(
+          `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+           SET status = 'settled',
+               settled_at = ?,
+               next_grant_retry_at = NULL,
+               dead_lettered_at = NULL,
+               last_grant_error = NULL
+           WHERE order_id = ?`,
+          [paidAt, currentOrder.orderId]
+        );
 
-      return {
-        order: nextOrder,
-        account: nextAccount,
-        credited: true,
-        receipt
-      };
+        await connection.commit();
+
+        return {
+          order: {
+            ...currentOrder,
+            status: "settled",
+            wechatOrderId: normalizedWechatOrderId,
+            paidAt: paidAt.toISOString(),
+            lastGrantAttemptAt: paidAt.toISOString(),
+            grantAttemptCount: 1,
+            settledAt: paidAt.toISOString(),
+            updatedAt: paidAt.toISOString()
+          },
+          account: nextAccount,
+          credited: true,
+          receipt
+        };
+      } catch (error) {
+        const grantError = normalizePaymentGrantError(error instanceof Error ? error.message : String(error)) ?? "grant_failed";
+        const nextDelayMs = computePaymentGrantRetryDelayMs(1, retryPolicy.baseDelayMs);
+        const nextRetryAt = new Date(paidAt.getTime() + nextDelayMs);
+        const deadLetter = 1 >= retryPolicy.maxAttempts;
+
+        await connection.query(
+          `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+           SET status = ?,
+               next_grant_retry_at = ?,
+               dead_lettered_at = ?,
+               last_grant_error = ?
+           WHERE order_id = ?`,
+          [
+            deadLetter ? "dead_letter" : "grant_pending",
+            deadLetter ? null : nextRetryAt,
+            deadLetter ? paidAt : null,
+            grantError,
+            currentOrder.orderId
+          ]
+        );
+
+        await connection.commit();
+
+        return {
+          order: {
+            ...currentOrder,
+            status: deadLetter ? "dead_letter" : "grant_pending",
+            wechatOrderId: normalizedWechatOrderId,
+            paidAt: paidAt.toISOString(),
+            lastGrantAttemptAt: paidAt.toISOString(),
+            grantAttemptCount: 1,
+            lastGrantError: grantError,
+            ...(deadLetter ? { deadLetteredAt: paidAt.toISOString() } : { nextGrantRetryAt: nextRetryAt.toISOString() }),
+            updatedAt: paidAt.toISOString()
+          },
+          account: currentAccount,
+          credited: false,
+          receipt
+        };
+      }
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  }
+
+  async retryPaymentOrderGrant(orderId: string, input: PaymentOrderGrantRetryInput): Promise<PaymentOrderSettlement> {
+    const normalizedOrderId = normalizePaymentOrderId(orderId);
+    const retriedAt = input.retriedAt ? new Date(input.retriedAt) : new Date();
+    const normalizedProductName = normalizeShopProductName(input.productName);
+    if (Number.isNaN(retriedAt.getTime())) {
+      throw new Error("retriedAt must be a valid ISO timestamp");
+    }
+    const retryPolicy = normalizePaymentGrantRetryPolicy(input.retryPolicy);
+
+    const connection = await this.pool.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      const [orderRows] = await connection.query<PaymentOrderRow[]>(
+        `SELECT
+           order_id,
+           player_id,
+           product_id,
+           wechat_order_id,
+           status,
+           amount,
+           gem_amount,
+           created_at,
+           paid_at,
+           last_grant_attempt_at,
+           next_grant_retry_at,
+           settled_at,
+           dead_lettered_at,
+           grant_attempt_count,
+           last_grant_error,
+           updated_at
+         FROM \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+         WHERE order_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [normalizedOrderId]
+      );
+      const currentOrderRow = orderRows[0];
+      if (!currentOrderRow) {
+        throw new Error("payment_order_not_found");
+      }
+
+      const currentOrder = toPaymentOrderSnapshot(currentOrderRow);
+      if (currentOrder.status === "settled") {
+        const account = (await this.loadPlayerAccount(currentOrder.playerId)) ?? (await this.ensurePlayerAccount({ playerId: currentOrder.playerId }));
+        const receipt = await this.loadPaymentReceiptByOrderId(currentOrder.orderId);
+        await connection.commit();
+        return {
+          order: currentOrder,
+          account,
+          credited: false,
+          ...(receipt ? { receipt } : {})
+        };
+      }
+      if (currentOrder.status !== "grant_pending" && currentOrder.status !== "dead_letter" && currentOrder.status !== "paid") {
+        throw new Error("payment_order_not_retryable");
+      }
+      if (currentOrder.status === "dead_letter" && input.allowDeadLetter !== true) {
+        throw new Error("payment_order_retry_requires_override");
+      }
+
+      const [accountRows] = await connection.query<PlayerAccountRow[]>(
+        `SELECT *
+         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         WHERE player_id = ?
+         LIMIT 1
+         FOR UPDATE`,
+        [currentOrder.playerId]
+      );
+      const currentAccount =
+        accountRows[0] != null
+          ? toPlayerAccountSnapshot(accountRows[0])
+          : normalizePlayerAccountSnapshot({
+              playerId: currentOrder.playerId,
+              displayName: currentOrder.playerId,
+              globalResources: normalizeResourceLedger()
+            });
+      const [receiptRows] = await connection.query<PaymentReceiptRow[]>(
+        `SELECT
+           transaction_id,
+           order_id,
+           player_id,
+           product_id,
+           amount,
+           verified_at
+         FROM \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+         WHERE order_id = ?
+         LIMIT 1`,
+        [currentOrder.orderId]
+      );
+      const receiptRow = receiptRows[0];
+      if (!receiptRow) {
+        throw new Error("payment_receipt_not_found");
+      }
+      const receipt = toPaymentReceiptSnapshot(receiptRow);
+      const attemptCount = currentOrder.grantAttemptCount + 1;
+      const {
+        nextGrantRetryAt: _previousNextGrantRetryAt,
+        lastGrantError: _previousLastGrantError,
+        deadLetteredAt: _previousDeadLetteredAt,
+        settledAt: _previousSettledAt,
+        ...retryBaseOrder
+      } = currentOrder;
+
+      try {
+        const nextAccount = await applyVerifiedPaymentGrantToAccount(connection, currentAccount, {
+          playerId: currentOrder.playerId,
+          productId: currentOrder.productId,
+          productName: normalizedProductName,
+          grant: input.grant,
+          refId: currentOrder.orderId,
+          processedAt: retriedAt.toISOString()
+        });
+
+        await connection.query(
+          `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+           SET status = 'settled',
+               last_grant_attempt_at = ?,
+               next_grant_retry_at = NULL,
+               settled_at = ?,
+               dead_lettered_at = NULL,
+               grant_attempt_count = ?,
+               last_grant_error = NULL
+           WHERE order_id = ?`,
+          [retriedAt, retriedAt, attemptCount, currentOrder.orderId]
+        );
+
+        await connection.commit();
+
+        return {
+          order: {
+            ...retryBaseOrder,
+            status: "settled",
+            lastGrantAttemptAt: retriedAt.toISOString(),
+            settledAt: retriedAt.toISOString(),
+            grantAttemptCount: attemptCount,
+            updatedAt: retriedAt.toISOString()
+          },
+          account: nextAccount,
+          credited: true,
+          receipt
+        };
+      } catch (error) {
+        const grantError = normalizePaymentGrantError(error instanceof Error ? error.message : String(error)) ?? "grant_failed";
+        const deadLetter = attemptCount >= retryPolicy.maxAttempts;
+        const nextDelayMs = computePaymentGrantRetryDelayMs(attemptCount, retryPolicy.baseDelayMs);
+        const nextRetryAt = new Date(retriedAt.getTime() + nextDelayMs);
+
+        await connection.query(
+          `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+           SET status = ?,
+               last_grant_attempt_at = ?,
+               next_grant_retry_at = ?,
+               settled_at = NULL,
+               dead_lettered_at = ?,
+               grant_attempt_count = ?,
+               last_grant_error = ?
+           WHERE order_id = ?`,
+          [
+            deadLetter ? "dead_letter" : "grant_pending",
+            retriedAt,
+            deadLetter ? null : nextRetryAt,
+            deadLetter ? retriedAt : null,
+            attemptCount,
+            grantError,
+            currentOrder.orderId
+          ]
+        );
+
+        await connection.commit();
+
+        return {
+          order: {
+            ...retryBaseOrder,
+            status: deadLetter ? "dead_letter" : "grant_pending",
+            lastGrantAttemptAt: retriedAt.toISOString(),
+            grantAttemptCount: attemptCount,
+            lastGrantError: grantError,
+            updatedAt: retriedAt.toISOString(),
+            ...(deadLetter ? { deadLetteredAt: retriedAt.toISOString() } : { nextGrantRetryAt: nextRetryAt.toISOString() })
+          },
+          account: currentAccount,
+          credited: false,
+          receipt
+        };
+      }
     } catch (error) {
       await connection.rollback();
       throw error;

--- a/apps/server/src/wechat-pay.ts
+++ b/apps/server/src/wechat-pay.ts
@@ -2,12 +2,20 @@ import { createCipheriv, createDecipheriv, createSign, createVerify, randomBytes
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { emitAnalyticsEvent } from "./analytics";
 import { validateAuthSessionFromRequest } from "./auth";
-import { recordRuntimeErrorEvent } from "./observability";
+import {
+  recordPaymentDeadLetter,
+  recordPaymentGrantRetry,
+  recordRuntimeErrorEvent,
+  setPaymentGrantDeadLetterCount,
+  setPaymentGrantQueueCount,
+  setPaymentGrantQueueLatency
+} from "./observability";
 import type { PaymentOrderSnapshot, RoomSnapshotStore } from "./persistence";
 import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct, type ShopProductGrant } from "./shop";
 
 interface HttpApp {
   use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
+  get?: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
   post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
 }
 
@@ -80,6 +88,8 @@ interface WechatPayCallbackTransaction {
 
 const MAX_JSON_BODY_BYTES = 64 * 1024;
 const MAX_CALLBACK_TIMESTAMP_SKEW_SECONDS = 5 * 60;
+const DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS = 5;
+const DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS = 60_000;
 const SUCCESS_CALLBACK_BODY = { code: "SUCCESS", message: "success" };
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -417,8 +427,108 @@ function isPaymentStoreReady(store: RoomSnapshotStore | null): store is RoomSnap
   );
 }
 
+function isPaymentOpsStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
+  Required<Pick<RoomSnapshotStore, "listPaymentOrders" | "retryPaymentOrderGrant">> {
+  return Boolean(store?.listPaymentOrders && store.retryPaymentOrderGrant);
+}
+
+function readAdminToken(): string | null {
+  const token = process.env.VEIL_ADMIN_TOKEN?.trim();
+  return token ? token : null;
+}
+
+function isAdminRequest(request: IncomingMessage): boolean {
+  const adminToken = readAdminToken();
+  return Boolean(adminToken) && request.headers["x-veil-admin-token"] === adminToken;
+}
+
+function normalizePaymentGrantRetryPolicy(): { maxAttempts: number; baseDelayMs: number } {
+  return {
+    maxAttempts: DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS,
+    baseDelayMs: DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS
+  };
+}
+
+function isFinalizedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
+  return status === "settled" || status === "dead_letter";
+}
+
+function isAcceptedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
+  return status !== "created";
+}
+
+async function refreshPaymentGrantObservability(store: RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPaymentOrders">>, now: Date) {
+  const [pendingOrders, deadLetterOrders] = await Promise.all([
+    store.listPaymentOrders({ statuses: ["grant_pending"], limit: 200 }),
+    store.listPaymentOrders({ statuses: ["dead_letter"], limit: 200 })
+  ]);
+
+  setPaymentGrantQueueCount(pendingOrders.length);
+  setPaymentGrantDeadLetterCount(deadLetterOrders.length);
+
+  const pendingRetryTimes = pendingOrders
+    .map((order) => (order.nextGrantRetryAt ? new Date(order.nextGrantRetryAt).getTime() : null))
+    .filter((value): value is number => value != null && Number.isFinite(value))
+    .sort((left, right) => left - right);
+
+  const oldestQueuedLatencyMs =
+    pendingOrders.length === 0
+      ? null
+      : pendingOrders
+          .map((order) => (order.lastGrantAttemptAt ? Math.max(0, now.getTime() - new Date(order.lastGrantAttemptAt).getTime()) : 0))
+          .reduce((max, value) => Math.max(max, value), 0);
+  const nextPendingRetryTime = pendingRetryTimes[0];
+  const nextAttemptDelayMs =
+    nextPendingRetryTime != null ? Math.max(0, nextPendingRetryTime - now.getTime()) : null;
+
+  setPaymentGrantQueueLatency({
+    oldestQueuedLatencyMs,
+    nextAttemptDelayMs
+  });
+
+  return {
+    pendingOrders,
+    deadLetterOrders
+  };
+}
+
+async function buildPaymentGrantRuntimePayload(
+  store: RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPaymentOrders">>,
+  now: Date
+) {
+  const { pendingOrders, deadLetterOrders } = await refreshPaymentGrantObservability(store, now);
+  return {
+    checkedAt: now.toISOString(),
+    queueCount: pendingOrders.length,
+    deadLetterCount: deadLetterOrders.length,
+    pendingOrders,
+    deadLetterOrders
+  };
+}
+
 function findProduct(products: ShopProduct[], productId: string): ShopProduct | undefined {
   return products.find((product) => product.productId === productId);
+}
+
+function resolvePaymentGrantRetryPayload(
+  products: ShopProduct[],
+  order: Pick<PaymentOrderSnapshot, "productId" | "gemAmount">
+): { productName: string; grant: ShopProductGrant } {
+  const product = findProduct(products, order.productId);
+  if (product) {
+    const normalizedProduct = normalizeWechatPayProduct(product);
+    return {
+      productName: normalizedProduct.name,
+      grant: normalizedProduct.grant
+    };
+  }
+
+  return {
+    productName: order.productId,
+    grant: {
+      gems: order.gemAmount
+    }
+  };
 }
 
 async function requireAuthSession(request: IncomingMessage, response: ServerResponse, store: RoomSnapshotStore | null) {
@@ -705,7 +815,7 @@ export function registerWechatPayRoutes(
       }
 
       const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
-      if (order.status === "paid" || existingReceipt) {
+      if (isAcceptedPaymentOrderStatus(order.status) || existingReceipt) {
         emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
           orderId: order.orderId,
           productId: order.productId
@@ -760,9 +870,16 @@ export function registerWechatPayRoutes(
         paidAt: verified.success_time,
         verifiedAt: now().toISOString(),
         productName: product.name,
-        grant: product.grant
+        grant: product.grant,
+        retryPolicy: normalizePaymentGrantRetryPolicy()
       });
-      if (!settlement.credited) {
+      if (settlement.order.status === "dead_letter") {
+        recordPaymentDeadLetter();
+      }
+      if (isPaymentOpsStoreReady(store)) {
+        await refreshPaymentGrantObservability(store, now());
+      }
+      if (!settlement.credited && isFinalizedPaymentOrderStatus(settlement.order.status)) {
         emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
           orderId: order.orderId,
           productId: order.productId,
@@ -804,6 +921,8 @@ export function registerWechatPayRoutes(
         status: settlement.order.status,
         credited: settlement.credited,
         paidAt: settlement.order.paidAt,
+        ...(settlement.order.nextGrantRetryAt ? { nextGrantRetryAt: settlement.order.nextGrantRetryAt } : {}),
+        ...(settlement.order.lastGrantError ? { lastGrantError: settlement.order.lastGrantError } : {}),
         gemsBalance: settlement.account.gems ?? 0,
         seasonPassPremium: settlement.account.seasonPassPremium === true
       });
@@ -916,7 +1035,7 @@ export function registerWechatPayRoutes(
       }
 
       const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
-      if (order.status === "paid" || existingReceipt) {
+      if (isAcceptedPaymentOrderStatus(order.status) || existingReceipt) {
         emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
           orderId: order.orderId,
           productId: order.productId
@@ -958,8 +1077,15 @@ export function registerWechatPayRoutes(
         paidAt: verified.success_time,
         verifiedAt: now().toISOString(),
         productName: product.name,
-        grant: product.grant
+        grant: product.grant,
+        retryPolicy: normalizePaymentGrantRetryPolicy()
       });
+      if (settlement.order.status === "dead_letter") {
+        recordPaymentDeadLetter();
+      }
+      if (isPaymentOpsStoreReady(store)) {
+        await refreshPaymentGrantObservability(store, now());
+      }
       if (settlement.credited) {
         emitAnalyticsEvent("purchase", {
           playerId: order.playerId,
@@ -976,6 +1102,221 @@ export function registerWechatPayRoutes(
       sendCallbackResponse(response, 400, {
         code: "FAIL",
         message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  });
+
+  if (app.get) {
+    app.get("/api/runtime/wechat-payment-grants", async (_request, response) => {
+      if (!isPaymentOpsStoreReady(store)) {
+        sendJson(response, 503, {
+          error: {
+            code: "payment_persistence_unavailable",
+            message: "Payment grant queue visibility requires configured persistence storage"
+          }
+        });
+        return;
+      }
+
+      try {
+        sendJson(response, 200, await buildPaymentGrantRuntimePayload(store, now()));
+      } catch (error) {
+        sendJson(response, 500, {
+          error: {
+            code: "wechat_payment_grant_runtime_unavailable",
+            message: error instanceof Error ? error.message : String(error)
+          }
+        });
+      }
+    });
+
+    app.get("/api/admin/payments/wechat/orders", async (request, response) => {
+      const adminToken = readAdminToken();
+      if (!adminToken) {
+        sendJson(response, 503, { error: { code: "admin_token_not_configured", message: "VEIL_ADMIN_TOKEN is not configured" } });
+        return;
+      }
+      if (!isAdminRequest(request)) {
+        sendJson(response, 403, { error: { code: "forbidden", message: "Invalid admin token" } });
+        return;
+      }
+      if (!isPaymentOpsStoreReady(store)) {
+        sendJson(response, 503, {
+          error: {
+            code: "payment_persistence_unavailable",
+            message: "Payment grant queue inspection requires configured persistence storage"
+          }
+        });
+        return;
+      }
+
+      try {
+        const url = new URL(request.url ?? "/api/admin/payments/wechat/orders", "http://runtime.local");
+        const rawStatuses = url.searchParams
+          .get("status")
+          ?.split(",")
+          .map((value) => value.trim())
+          .filter((value): value is PaymentOrderSnapshot["status"] =>
+            value === "created" || value === "paid" || value === "grant_pending" || value === "settled" || value === "dead_letter"
+          );
+        const limit = Math.max(1, Math.min(200, Math.floor(Number(url.searchParams.get("limit") ?? "50"))));
+        const orders = await store.listPaymentOrders({
+          ...(rawStatuses && rawStatuses.length > 0 ? { statuses: rawStatuses } : {}),
+          limit
+        });
+        await refreshPaymentGrantObservability(store, now());
+        sendJson(response, 200, {
+          checkedAt: now().toISOString(),
+          count: orders.length,
+          items: orders
+        });
+      } catch (error) {
+        sendJson(response, 500, {
+          error: {
+            code: "wechat_payment_order_list_failed",
+            message: error instanceof Error ? error.message : String(error)
+          }
+        });
+      }
+    });
+  }
+
+  app.post("/api/admin/payments/wechat/retry", async (request, response) => {
+    const adminToken = readAdminToken();
+    if (!adminToken) {
+      sendJson(response, 503, { error: { code: "admin_token_not_configured", message: "VEIL_ADMIN_TOKEN is not configured" } });
+      return;
+    }
+    if (!isAdminRequest(request)) {
+      sendJson(response, 403, { error: { code: "forbidden", message: "Invalid admin token" } });
+      return;
+    }
+    if (!isPaymentStoreReady(store) || !isPaymentOpsStoreReady(store)) {
+      sendJson(response, 503, {
+        error: {
+          code: "payment_persistence_unavailable",
+          message: "Payment grant retries require configured persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as {
+        orderId?: string | null;
+        limit?: number;
+        includeDeadLetter?: boolean;
+      };
+      const processedAt = now();
+      const retryPolicy = normalizePaymentGrantRetryPolicy();
+
+      if (body.orderId?.trim()) {
+        const currentOrder = await store.loadPaymentOrder(body.orderId);
+        if (!currentOrder) {
+          sendJson(response, 404, {
+            error: {
+              code: "payment_order_not_found",
+              message: "Payment order was not found"
+            }
+          });
+          return;
+        }
+
+        const retryPayload = resolvePaymentGrantRetryPayload(products, currentOrder);
+        recordPaymentGrantRetry();
+        const settlement = await store.retryPaymentOrderGrant(currentOrder.orderId, {
+          ...retryPayload,
+          retriedAt: processedAt.toISOString(),
+          retryPolicy,
+          allowDeadLetter: body.includeDeadLetter === true
+        });
+        if (currentOrder.status !== "dead_letter" && settlement.order.status === "dead_letter") {
+          recordPaymentDeadLetter();
+        }
+        if (settlement.credited) {
+          emitAnalyticsEvent("purchase", {
+            playerId: settlement.order.playerId,
+            payload: {
+              purchaseId: settlement.order.orderId,
+              productId: settlement.order.productId,
+              quantity: 1,
+              totalPrice: settlement.order.amount
+            }
+          });
+        }
+        await refreshPaymentGrantObservability(store, processedAt);
+        sendJson(response, 200, {
+          processedAt: processedAt.toISOString(),
+          retried: 1,
+          order: settlement.order,
+          credited: settlement.credited
+        });
+        return;
+      }
+
+      const limit = Math.max(1, Math.min(100, Math.floor(body.limit ?? 20)));
+      const dueOrders = await store.listPaymentOrders({
+        statuses: ["grant_pending"],
+        dueBefore: processedAt.toISOString(),
+        limit
+      });
+      const results: Array<{
+        orderId: string;
+        status: PaymentOrderSnapshot["status"];
+        credited: boolean;
+        error?: string;
+      }> = [];
+
+      for (const pendingOrder of dueOrders) {
+        try {
+          const retryPayload = resolvePaymentGrantRetryPayload(products, pendingOrder);
+          recordPaymentGrantRetry();
+          const settlement = await store.retryPaymentOrderGrant(pendingOrder.orderId, {
+            ...retryPayload,
+            retriedAt: processedAt.toISOString(),
+            retryPolicy
+          });
+          if (pendingOrder.status !== "dead_letter" && settlement.order.status === "dead_letter") {
+            recordPaymentDeadLetter();
+          }
+          if (settlement.credited) {
+            emitAnalyticsEvent("purchase", {
+              playerId: settlement.order.playerId,
+              payload: {
+                purchaseId: settlement.order.orderId,
+                productId: settlement.order.productId,
+                quantity: 1,
+                totalPrice: settlement.order.amount
+              }
+            });
+          }
+          results.push({
+            orderId: settlement.order.orderId,
+            status: settlement.order.status,
+            credited: settlement.credited
+          });
+        } catch (error) {
+          results.push({
+            orderId: pendingOrder.orderId,
+            status: pendingOrder.status,
+            credited: false,
+            error: error instanceof Error ? error.message : String(error)
+          });
+        }
+      }
+
+      await refreshPaymentGrantObservability(store, processedAt);
+      sendJson(response, 200, {
+        processedAt: processedAt.toISOString(),
+        retried: results.length,
+        items: results
+      });
+    } catch (error) {
+      sendJson(response, 400, {
+        error: {
+          code: "wechat_payment_retry_failed",
+          message: error instanceof Error ? error.message : String(error)
+        }
       });
     }
   });

--- a/apps/server/test/wechat-pay-routes.test.ts
+++ b/apps/server/test/wechat-pay-routes.test.ts
@@ -28,6 +28,21 @@ const TEST_PRODUCTS: Partial<ShopProduct>[] = [
   }
 ];
 
+const FAILING_GRANT_PRODUCTS: Partial<ShopProduct>[] = [
+  {
+    productId: "gem-pack-equipment-retry",
+    name: "Equipment Retry Crate",
+    type: "gem_pack",
+    price: 0,
+    wechatPriceFen: 600,
+    enabled: false,
+    grant: {
+      gems: 120,
+      equipmentIds: ["militia_pike"]
+    }
+  }
+];
+
 function buildFreshCallbackNow(): Date {
   return new Date("2024-04-04T02:22:00Z");
 }
@@ -51,20 +66,30 @@ class TestResponse extends EventEmitter {
 
 class TestApp {
   private readonly middlewares: Array<(request: never, response: never, next: () => void) => void> = [];
+  private readonly getHandlers = new Map<string, (request: never, response: never) => void | Promise<void>>();
   private readonly postHandlers = new Map<string, (request: never, response: never) => void | Promise<void>>();
 
   use(handler: (request: never, response: never, next: () => void) => void): void {
     this.middlewares.push(handler);
   }
 
+  get(path: string, handler: (request: never, response: never) => void | Promise<void>): void {
+    this.getHandlers.set(path, handler);
+  }
+
   post(path: string, handler: (request: never, response: never) => void | Promise<void>): void {
     this.postHandlers.set(path, handler);
   }
 
-  async invoke(path: string, options: { body?: string; headers?: Record<string, string> } = {}) {
-    const routeHandler = this.postHandlers.get(path);
+  async invoke(
+    path: string,
+    options: { body?: string; headers?: Record<string, string>; method?: "GET" | "POST" } = {}
+  ) {
+    const method = options.method ?? "POST";
+    const routePath = new URL(path, "http://test.local").pathname;
+    const routeHandler = (method === "GET" ? this.getHandlers : this.postHandlers).get(routePath);
     if (!routeHandler) {
-      throw new Error(`No POST handler registered for ${path}`);
+      throw new Error(`No ${method} handler registered for ${routePath}`);
     }
 
     const request = Readable.from(options.body ? [Buffer.from(options.body, "utf8")] : []) as Readable & {
@@ -75,7 +100,7 @@ class TestApp {
     request.headers = Object.fromEntries(
       Object.entries(options.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
     );
-    request.method = "POST";
+    request.method = method;
     request.url = path;
 
     const response = new TestResponse();
@@ -258,9 +283,10 @@ test("wechat pay create route creates a pending order and returns JSAPI payment 
     orderId: payload.orderId,
     playerId: "wechat-player",
     productId: "gem-pack-premium",
-    status: "pending",
+    status: "created",
     amount: 600,
     gemAmount: 120,
+    grantAttemptCount: 0,
     createdAt: order?.createdAt,
     updatedAt: order?.updatedAt
   });
@@ -419,7 +445,7 @@ test("wechat pay verify route grants a successful verified payment and stores th
 
   assert.equal(response.statusCode, 200);
   assert.equal(account?.gems, 120);
-  assert.equal(paidOrder?.status, "paid");
+  assert.equal(paidOrder?.status, "settled");
   assert.equal(paidOrder?.wechatOrderId, "wechat-transaction-123");
   assert.equal(paidOrder?.paidAt, "2026-04-04T01:02:03.000Z");
   assert.equal(receipt?.transactionId, "wechat-transaction-123");
@@ -591,7 +617,7 @@ test("wechat pay verify route rejects payer openid mismatches without granting r
   assert.equal(response.statusCode, 409);
   assert.equal(payload.error.code, "wechat_payment_openid_mismatch");
   assert.equal(account?.gems ?? 0, 0);
-  assert.equal(paidOrder?.status, "pending");
+  assert.equal(paidOrder?.status, "created");
   assert.equal(receipt, null);
 });
 
@@ -751,7 +777,7 @@ test("wechat pay callback verifies, credits once, and ignores duplicate notifica
   assert.equal(firstResponse.statusCode, 200);
   assert.equal(secondResponse.statusCode, 200);
   assert.equal(account?.gems, 120);
-  assert.equal(paidOrder?.status, "paid");
+  assert.equal(paidOrder?.status, "settled");
   assert.equal(paidOrder?.wechatOrderId, "wechat-transaction-123");
   assert.equal(receipt?.transactionId, "wechat-transaction-123");
 });
@@ -822,7 +848,7 @@ test("wechat pay callback logs payer mismatches and does not grant rewards", asy
 
   assert.equal(response.statusCode, 200);
   assert.equal(account?.gems ?? 0, 0);
-  assert.equal(paidOrder?.status, "pending");
+  assert.equal(paidOrder?.status, "created");
   assert.equal(receipt, null);
 });
 
@@ -1166,4 +1192,179 @@ test("wechat pay callback rejects missing order ids, missing orders, and missing
   const missingBindingPayload = missingBinding.json as { message: string };
   assert.equal(missingBinding.statusCode, 400);
   assert.equal(missingBindingPayload.message, "payer validation failed");
+});
+
+test("wechat pay verify persists grant_pending failures and admin retry can settle the order", async () => {
+  const previousAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = "wechat-admin-token";
+  try {
+    resetRuntimeObservability();
+    const app = new TestApp();
+    const store = await createVerifiedTestStore();
+    const runtimeConfig = createWechatPayConfig();
+    const order = await store.createPaymentOrder({
+      orderId: "wechat-order-retry",
+      playerId: "wechat-player",
+      productId: "gem-pack-equipment-retry",
+      amount: 600,
+      gemAmount: 120
+    });
+    registerWechatPayRoutes(app as never, store, {
+      products: FAILING_GRANT_PRODUCTS,
+      runtimeConfig,
+      now: buildFreshCallbackNow,
+      fetchImpl: buildVerifyFetch({
+        out_trade_no: order.orderId
+      })
+    });
+    const session = issueWechatSession();
+
+    const verifyResponse = await app.invoke("/api/payments/wechat/verify", {
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${session.token}`
+      },
+      body: JSON.stringify({
+        orderId: order.orderId
+      })
+    });
+    const verifyPayload = verifyResponse.json as { status: string; credited: boolean; nextGrantRetryAt?: string; lastGrantError?: string };
+    const queuedOrder = await store.loadPaymentOrder(order.orderId);
+    const receipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+    const accountBeforeRetry = await store.loadPlayerAccount("wechat-player");
+
+    assert.equal(verifyResponse.statusCode, 200);
+    assert.equal(verifyPayload.status, "grant_pending");
+    assert.equal(verifyPayload.credited, false);
+    assert.ok(verifyPayload.nextGrantRetryAt);
+    assert.match(String(verifyPayload.lastGrantError), /player hero archive not found/);
+    assert.equal(queuedOrder?.status, "grant_pending");
+    assert.equal(queuedOrder?.grantAttemptCount, 1);
+    assert.equal(receipt?.transactionId, "wechat-transaction-123");
+    assert.equal(accountBeforeRetry?.gems ?? 0, 0);
+
+    const runtimeBeforeRetry = await app.invoke("/api/runtime/wechat-payment-grants", { method: "GET" });
+    const runtimeBeforeRetryPayload = runtimeBeforeRetry.json as { queueCount: number; deadLetterCount: number; pendingOrders: Array<{ orderId: string }> };
+    assert.equal(runtimeBeforeRetry.statusCode, 200);
+    assert.equal(runtimeBeforeRetryPayload.queueCount, 1);
+    assert.equal(runtimeBeforeRetryPayload.deadLetterCount, 0);
+    assert.equal(runtimeBeforeRetryPayload.pendingOrders[0]?.orderId, order.orderId);
+
+    (
+      store as unknown as {
+        heroArchives: Map<string, { playerId: string; heroId: string; hero: { loadout: { inventory: unknown[] } } }>;
+      }
+    ).heroArchives.set("wechat-player:hero-1", {
+      playerId: "wechat-player",
+      heroId: "hero-1",
+      hero: {
+        loadout: {
+          inventory: []
+        }
+      }
+    });
+
+    const retryResponse = await app.invoke("/api/admin/payments/wechat/retry", {
+      headers: {
+        "content-type": "application/json",
+        "x-veil-admin-token": "wechat-admin-token"
+      },
+      body: JSON.stringify({
+        orderId: order.orderId
+      })
+    });
+    const retryPayload = retryResponse.json as { credited: boolean; order: { status: string; grantAttemptCount: number } };
+    const settledOrder = await store.loadPaymentOrder(order.orderId);
+    const accountAfterRetry = await store.loadPlayerAccount("wechat-player");
+
+    assert.equal(retryResponse.statusCode, 200);
+    assert.equal(retryPayload.credited, true);
+    assert.equal(retryPayload.order.status, "settled");
+    assert.equal(retryPayload.order.grantAttemptCount, 2);
+    assert.equal(settledOrder?.status, "settled");
+    assert.equal(accountAfterRetry?.gems, 120);
+
+    const runtimeAfterRetry = await app.invoke("/api/runtime/wechat-payment-grants", { method: "GET" });
+    const runtimeAfterRetryPayload = runtimeAfterRetry.json as { queueCount: number; deadLetterCount: number };
+    assert.equal(runtimeAfterRetryPayload.queueCount, 0);
+    assert.equal(runtimeAfterRetryPayload.deadLetterCount, 0);
+  } finally {
+    if (previousAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+    } else {
+      process.env.VEIL_ADMIN_TOKEN = previousAdminToken;
+    }
+  }
+});
+
+test("wechat pay admin retry exhausts grant failures into dead_letter and exposes metrics", async () => {
+  const previousAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = "wechat-admin-token";
+  try {
+    resetRuntimeObservability();
+    const app = new TestApp();
+    const store = await createVerifiedTestStore();
+    const runtimeConfig = createWechatPayConfig();
+    const order = await store.createPaymentOrder({
+      orderId: "wechat-order-dead-letter",
+      playerId: "wechat-player",
+      productId: "gem-pack-equipment-retry",
+      amount: 600,
+      gemAmount: 120
+    });
+    registerWechatPayRoutes(app as never, store, {
+      products: FAILING_GRANT_PRODUCTS,
+      runtimeConfig,
+      now: buildFreshCallbackNow,
+      fetchImpl: buildVerifyFetch({
+        out_trade_no: order.orderId
+      })
+    });
+    const session = issueWechatSession();
+
+    await app.invoke("/api/payments/wechat/verify", {
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${session.token}`
+      },
+      body: JSON.stringify({
+        orderId: order.orderId
+      })
+    });
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      const retryResponse = await app.invoke("/api/admin/payments/wechat/retry", {
+        headers: {
+          "content-type": "application/json",
+          "x-veil-admin-token": "wechat-admin-token"
+        },
+        body: JSON.stringify({
+          orderId: order.orderId,
+          includeDeadLetter: true
+        })
+      });
+      assert.equal(retryResponse.statusCode, 200);
+    }
+
+    const deadLetterOrder = await store.loadPaymentOrder(order.orderId);
+    const runtimePayload = (
+      await app.invoke("/api/runtime/wechat-payment-grants", {
+        method: "GET"
+      })
+    ).json as { queueCount: number; deadLetterCount: number; deadLetterOrders: Array<{ orderId: string }> };
+    const metrics = buildPrometheusMetricsDocument();
+
+    assert.equal(deadLetterOrder?.status, "dead_letter");
+    assert.equal(deadLetterOrder?.grantAttemptCount, 5);
+    assert.equal(runtimePayload.queueCount, 0);
+    assert.equal(runtimePayload.deadLetterCount, 1);
+    assert.equal(runtimePayload.deadLetterOrders[0]?.orderId, order.orderId);
+    assert.match(metrics, /veil_payment_dead_letter_total 1/);
+  } finally {
+    if (previousAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+    } else {
+      process.env.VEIL_ADMIN_TOKEN = previousAdminToken;
+    }
+  }
 });

--- a/apps/server/test/wechat-payment-flow.test.ts
+++ b/apps/server/test/wechat-payment-flow.test.ts
@@ -218,7 +218,7 @@ function createSignedCallbackRequest(
       "callback-nonce-01"
     )
   });
-  const timestamp = "1712197200";
+  const timestamp = String(Math.floor(Date.now() / 1000));
   const nonce = "signature-nonce-1";
   return {
     body,
@@ -320,7 +320,7 @@ test("wechat payment callback settles the order, emits purchase analytics, and d
   assert.ok(purchaseEvent);
   assert.equal(purchaseEvent?.payload.productId, "gem-pack-premium");
   assert.equal(purchaseEvent?.payload.totalPrice, 600);
-  assert.equal(storedOrder?.status, "paid");
+  assert.equal(storedOrder?.status, "settled");
   assert.equal(storedOrder?.wechatOrderId, "wechat-transaction-123");
   assert.equal(receipt?.transactionId, "wechat-transaction-123");
 });
@@ -375,7 +375,7 @@ test("wechat payment verify settles a created order and emits purchase analytics
   );
 
   assert.equal(verifyResponse.status, 200);
-  assert.equal(verifyPayload.status, "paid");
+  assert.equal(verifyPayload.status, "settled");
   assert.equal(verifyPayload.gemsBalance, 120);
   assert.equal(accountResponse.status, 200);
   assert.equal(accountPayload.account.gems, 120);
@@ -448,6 +448,6 @@ test("wechat payment verify returns amount mismatch without granting rewards and
   assert.equal(accountPayload.account.gems, 0);
   assert.ok(fraudEvent);
   assert.equal(purchaseEvent, undefined);
-  assert.equal(storedOrder?.status, "pending");
+  assert.equal(storedOrder?.status, "created");
   assert.equal(receipt, null);
 });

--- a/docs/wechat-pay-ops-runbook.md
+++ b/docs/wechat-pay-ops-runbook.md
@@ -41,7 +41,7 @@
 操作步骤：
 
 1. 先在 `payment_orders` 和 `payment_receipts` 中按 `orderId`、`playerId`、`transactionId` 检索交易事实，不要仅凭工单文本做判断。
-2. 再核对 `apps/server/src/wechat-pay.ts` 当前版本是否已把该订单标记为 `paid`，以及是否已经完成发货。
+2. 再核对 `apps/server/src/wechat-pay.ts` 当前版本是否已把该订单标记为 `settled`；若状态为 `grant_pending` / `dead_letter`，说明支付已确认但发货链路需要补偿或人工介入。
 3. 若微信已扣款但游戏未到账，优先走补偿 SOP；只有补偿风险高、证据不一致或玩家明确要求原路退回时才发起退款。
 4. 若确认重复扣款，先冻结该玩家的后续人工补单，再按 finance reviewer 审批结果执行退款。
 5. 若为争议单，必须记录内部结论、审批人、执行人、执行时间、外部单号，并在 1 个工作日内回填工单。
@@ -51,15 +51,48 @@
 未到账：
 
 1. 用 `/api/payments/wechat/verify` 或回调对应的 `out_trade_no` 查明是否已验单成功。
-2. 如果微信订单成功、`payment_receipts` 缺失、且商品金额与 `openid` 一致，先由 backend on-call 确认是否可以安全重试补偿。
-3. 重试成功后，在工单和审计日志中记录补偿方式、操作者、时间、关联 `orderId`。
-4. 若 30 分钟内无法安全补偿，转为退款审批流。
+2. 打开 `/api/runtime/wechat-payment-grants` 或带 `x-veil-admin-token` 的 `/api/admin/payments/wechat/orders?status=grant_pending,dead_letter`，确认订单是否已进入补偿队列或 dead-letter。
+3. 如果微信订单成功、`payment_receipts` 存在、且状态为 `grant_pending` / `dead_letter`，优先使用 `/api/admin/payments/wechat/retry` 触发单笔或批量补偿重试。
+4. 重试成功后，在工单和审计日志中记录补偿方式、操作者、时间、关联 `orderId`。
+5. 若 30 分钟内无法安全补偿，转为退款审批流。
 
 重复扣款：
 
 1. 检查同一玩家是否存在多个不同 `orderId` 指向相同支付动作，或同一 `orderId` 被重复回调。
 2. 如果只是相同 `out_trade_no` 的重复通知，当前服务端会幂等返回成功，不做二次发货。
 3. 如果是两笔真实成功交易且只应成交一次，按退款审批流处理，并把重复交易窗口内的所有 `transactionId` 记入审计日志。
+
+## 发货重试 / Dead Letter
+
+当前支付订单状态机：
+
+- `created`：已创建订单，尚未确认微信支付成功
+- `paid`：事务内已确认支付成功，准备发货；该状态只应短暂出现
+- `grant_pending`：支付成功但发货失败，已写入重试队列
+- `settled`：支付成功且发货完成
+- `dead_letter`：达到最大重试次数，需人工介入
+
+运维入口：
+
+- `GET /api/runtime/wechat-payment-grants`：查看当前 `grant_pending` / `dead_letter` 汇总与明细
+- `GET /api/admin/payments/wechat/orders?status=grant_pending,dead_letter`：管理员分页查看支付补偿队列
+- `POST /api/admin/payments/wechat/retry`：管理员触发重试
+
+`POST /api/admin/payments/wechat/retry` 常见用法：
+
+```json
+{ "orderId": "wechat-order-123" }
+```
+
+```json
+{ "limit": 20 }
+```
+
+处理要求：
+
+1. `grant_pending` 订单优先走批量重试；确认是单笔环境修复后再重试的，使用单笔 `orderId`。
+2. `dead_letter` 订单必须先确认根因，再带 `includeDeadLetter: true` 执行人工重试。
+3. 每次人工重试后都要抓取 `/api/runtime/wechat-payment-grants` 和 `/metrics`，确认队列数、dead-letter 数是否回落。
 
 ## 回调重放攻击检测与防御
 
@@ -85,10 +118,11 @@
 收到告警后执行：
 
 1. 抓取 `/metrics`，确认 `veil_runtime_error_events_total{feature_area="payment",error_code="payment_fraud_signal"}` 的增长窗口和数量。
-2. 打开 `/api/runtime/diagnostic-snapshot`，检查最近的 payment runtime error 与相关 `playerId`。
-3. 在 analytics 或日志侧按 `signal` 聚合，优先识别 `duplicate_out_trade_no`、`openid_mismatch`、`amount_mismatch`、`high_velocity_purchases`。
-4. 若是单个玩家异常，先冻结该玩家的人工补偿和高风险道具发放。
-5. 若是候选版本级异常，暂停该 candidate 的继续提审 / 放量，并要求 backend on-call 审核最近支付变更。
+2. 若是未到账类告警，同时检查 `veil_payment_grant_queue_count`、`veil_payment_grant_dead_letter_count`、`veil_payment_dead_letter_total`。
+3. 打开 `/api/runtime/diagnostic-snapshot`，检查最近的 payment runtime error 与相关 `playerId`。
+4. 在 analytics 或日志侧按 `signal` 聚合，优先识别 `duplicate_out_trade_no`、`openid_mismatch`、`amount_mismatch`、`high_velocity_purchases`。
+5. 若是单个玩家异常，先冻结该玩家的人工补偿和高风险道具发放。
+6. 若是候选版本级异常，暂停该 candidate 的继续提审 / 放量，并要求 backend on-call 审核最近支付变更。
 
 ## 支付流水审计日志格式
 


### PR DESCRIPTION
## Summary
- add a durable WeChat Pay order state machine with idempotent callback handling, persisted grant retry metadata, and dead-letter transitions
- add runtime/admin visibility plus manual and batch retry endpoints for failed WeChat payment grants
- cover the new grant-pending, retry, and dead-letter flows in server tests and document the operator recovery path

Closes #1301

## Testing
- `npm run typecheck:server`
- `node --import tsx --test ./apps/server/test/wechat-pay-routes.test.ts ./apps/server/test/wechat-payment-flow.test.ts`
