### PR TITLE
Enforce production minor protection on room join

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-lobby.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby.ts
@@ -2055,7 +2055,8 @@ export async function loginCocosWechatAuthSession(
     authToken?: string | null;
     privacyConsentAccepted?: boolean;
     minorProtection?: {
-      isAdult: boolean;
+      birthdate?: string;
+      isAdult?: boolean;
     };
   }
 ): Promise<CocosStoredAuthSession> {
@@ -2092,7 +2093,8 @@ export async function loginCocosWechatAuthSession(
         displayName: profile.displayName,
         ...(profile.avatarUrl ? { avatarUrl: profile.avatarUrl } : {}),
         ...(options?.privacyConsentAccepted ? { privacyConsentAccepted: true } : {}),
-        ...(options?.minorProtection ? { isAdult: options.minorProtection.isAdult } : {})
+        ...(options?.minorProtection?.birthdate ? { birthdate: options.minorProtection.birthdate } : {}),
+        ...(options?.minorProtection?.isAdult !== undefined ? { isAdult: options.minorProtection.isAdult } : {})
       })
     },
     options?.fetchImpl

--- a/apps/cocos-client/assets/scripts/project-shared/protocol.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/protocol.ts
@@ -124,6 +124,27 @@ export type ServerMessage =
       type: "error";
       requestId: string;
       reason: string;
+      minorProtection?: {
+        enforced: boolean;
+        localDate: string;
+        normalizedDailyPlayMinutes: number;
+        dailyLimitMinutes: number;
+        restrictedHours: boolean;
+        dailyLimitReached: boolean;
+        wouldBlock: boolean;
+        reason: "minor_restricted_hours" | "minor_daily_limit_reached" | null;
+        currentServerTime: string;
+        currentLocalTime: string;
+        timeZone: string;
+        restrictedWindow: {
+          startHour: number;
+          endHour: number;
+        };
+        remainingDailyMinutes: number;
+        nextAllowedAt: string | null;
+        nextAllowedLocalTime: string | null;
+        nextAllowedCountdownSeconds: number | null;
+      };
     }
   | {
       type: "report.player";

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1010,6 +1010,7 @@ async function handleWechatLogin(
     avatarUrl?: string | null;
     migrationChoice?: string | null;
     privacyConsentAccepted?: boolean | null;
+    birthdate?: string | null;
     ageVerified?: boolean | null;
     isAdult?: boolean | null;
     ageRange?: string | null;
@@ -1085,6 +1086,16 @@ async function handleWechatLogin(
     return;
   }
 
+  if (body.birthdate !== undefined && body.birthdate !== null && typeof body.birthdate !== "string") {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: "Expected optional string field: birthdate"
+      }
+    });
+    return;
+  }
+
   if (body.isAdult !== undefined && body.isAdult !== null && typeof body.isAdult !== "boolean") {
     sendJson(response, 400, {
       error: {
@@ -1122,11 +1133,24 @@ async function handleWechatLogin(
     });
     return;
   }
-  const minorProtection = deriveWechatMinorProtection({
-    ...(body.ageVerified !== undefined ? { ageVerified: body.ageVerified } : {}),
-    ...(body.isAdult !== undefined ? { isAdult: body.isAdult } : {}),
-    ...(body.ageRange !== undefined ? { ageRange: body.ageRange } : {})
-  });
+  const now = new Date();
+  let minorProtection: ReturnType<typeof deriveWechatMinorProtection>;
+  try {
+    minorProtection = deriveWechatMinorProtection({
+      ...(body.birthdate !== undefined ? { birthdate: body.birthdate } : {}),
+      ...(body.ageVerified !== undefined ? { ageVerified: body.ageVerified } : {}),
+      ...(body.isAdult !== undefined ? { isAdult: body.isAdult } : {}),
+      ...(body.ageRange !== undefined ? { ageRange: body.ageRange } : {})
+    }, now);
+  } catch (error) {
+    sendJson(response, 400, {
+      error: {
+        code: "invalid_payload",
+        message: error instanceof Error ? error.message : String(error)
+      }
+    });
+    return;
+  }
   const wechatConfig = readWechatMiniGameLoginConfig();
 
   let identity: WechatMiniGameIdentity;

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -51,7 +51,7 @@ import {
 } from "./config-center";
 import { applyPlayerEventLogAndAchievements } from "./player-achievements";
 import { resolveGuestAuthSession } from "./auth";
-import { deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
+import { buildMinorProtectionBlockDetails, deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
 import {
   recordBattleActionMessage,
   recordAntiCheatAlert,
@@ -1547,15 +1547,23 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     }
 
     const syncedAccount = await this.syncMinorProtectionAccount(playerId, account);
-    const state = deriveMinorProtectionState(syncedAccount, new Date(), this.minorProtectionConfig);
-    if (state.restrictedHours) {
-      sendMessage(client, "error", { requestId, reason: "minor_restricted_hours" });
+    const details = buildMinorProtectionBlockDetails(syncedAccount, new Date(), this.minorProtectionConfig);
+    if (details.restrictedHours) {
+      sendMessage(client, "error", {
+        requestId,
+        reason: "minor_restricted_hours",
+        minorProtection: details
+      });
       client.leave(CloseCode.WITH_ERROR, "minor_restricted_hours");
       return true;
     }
 
-    if (state.dailyLimitReached) {
-      sendMessage(client, "error", { requestId, reason: "minor_daily_limit_reached" });
+    if (details.dailyLimitReached) {
+      sendMessage(client, "error", {
+        requestId,
+        reason: "minor_daily_limit_reached",
+        minorProtection: details
+      });
       client.leave(CloseCode.WITH_ERROR, "minor_daily_limit_reached");
       return true;
     }

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -19,7 +19,7 @@ import { registerLeaderboardRoutes } from "./leaderboard";
 import { registerLobbyRoutes } from "./lobby";
 import { registerMatchmakingRoutes } from "./matchmaking";
 import { createMemoryRoomSnapshotStore } from "./memory-room-snapshot-store";
-import { registerMinorProtectionPreviewRoutes } from "./minor-protection-preview";
+import { registerMinorProtectionRoutes } from "./minor-protection-routes";
 import {
   buildPrometheusMetricsDocument,
   recordHttpRequestDuration,
@@ -124,7 +124,7 @@ export interface DevServerBootstrapDependencies {
   registerWechatPayRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerLobbyRoutes(app: unknown, dependencies: { listRooms: typeof listLobbyRooms }): void;
   registerMatchmakingRoutes(app: unknown, dependencies: { store: DevServerRoomSnapshotStore }): void;
-  registerMinorProtectionPreviewRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
+  registerMinorProtectionRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerLeaderboardRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerSeasonRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerRuntimeObservabilityRoutes(
@@ -199,8 +199,8 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerLobbyRoutes: (app, dependencies) => registerLobbyRoutes(app as never, dependencies),
     registerMatchmakingRoutes: (app, dependencies) =>
       registerMatchmakingRoutes(app as never, { store: dependencies.store as RoomSnapshotStore }),
-    registerMinorProtectionPreviewRoutes: (app, store) =>
-      registerMinorProtectionPreviewRoutes(app as never, store as RoomSnapshotStore | null),
+    registerMinorProtectionRoutes: (app, store) =>
+      registerMinorProtectionRoutes(app as never, store as RoomSnapshotStore | null),
     registerLeaderboardRoutes: (app, store) => registerLeaderboardRoutes(app as never, store as RoomSnapshotStore | null),
     registerSeasonRoutes: (app, store) => registerSeasonRoutes(app as never, store as RoomSnapshotStore | null),
     registerRuntimeObservabilityRoutes: (app, options) => registerRuntimeObservabilityRoutes(app as never, options),
@@ -328,7 +328,7 @@ export async function startDevServer(
   deps.registerWechatPayRoutes(expressApp, effectiveSnapshotStore);
   deps.registerLobbyRoutes(expressApp, { listRooms: listLobbyRooms });
   deps.registerMatchmakingRoutes(expressApp, { store: effectiveSnapshotStore });
-  deps.registerMinorProtectionPreviewRoutes(expressApp, effectiveSnapshotStore);
+  deps.registerMinorProtectionRoutes(expressApp, effectiveSnapshotStore);
   deps.registerLeaderboardRoutes(expressApp, effectiveSnapshotStore);
   deps.registerSeasonRoutes(expressApp, effectiveSnapshotStore);
   deps.registerRuntimeObservabilityRoutes(expressApp, {

--- a/apps/server/src/minor-protection-routes.ts
+++ b/apps/server/src/minor-protection-routes.ts
@@ -1,8 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { evaluateMinorProtectionState, getMinorProtectionDateKey, readMinorProtectionConfig } from "./minor-protection";
+import { buildMinorProtectionBlockDetails, getMinorProtectionDateKey, readMinorProtectionConfig } from "./minor-protection";
 import type { PlayerAccountSnapshot, RoomSnapshotStore } from "./persistence";
 
-interface PreviewApp {
+interface MinorProtectionApp {
   use(handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void): void;
   get(path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>): void;
 }
@@ -52,7 +52,7 @@ function readOptionalIntegerQueryParam(request: IncomingMessage, key: string): n
   return Math.max(0, Math.floor(parsed));
 }
 
-export function registerMinorProtectionPreviewRoutes(app: PreviewApp, store: RoomSnapshotStore | null): void {
+export function registerMinorProtectionRoutes(app: MinorProtectionApp, store: RoomSnapshotStore | null): void {
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
     response.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
@@ -67,7 +67,7 @@ export function registerMinorProtectionPreviewRoutes(app: PreviewApp, store: Roo
     next();
   });
 
-  app.get("/api/admin/minor-protection/preview", async (request, response) => {
+  const handleMinorProtectionRequest = async (request: IncomingMessage, response: ServerResponse) => {
     try {
       if (!isAdminAuthorized(request)) {
         sendJson(response, 401, {
@@ -109,9 +109,7 @@ export function registerMinorProtectionPreviewRoutes(app: PreviewApp, store: Roo
         evaluationInput.lastPlayDate = effectiveLastPlayDate;
       }
 
-      const evaluation = evaluateMinorProtectionState(evaluationInput, at, config);
-
-      sendJson(response, 200, evaluation);
+      sendJson(response, 200, buildMinorProtectionBlockDetails(evaluationInput, at, config));
     } catch (error) {
       sendJson(response, 400, {
         error: {
@@ -120,5 +118,8 @@ export function registerMinorProtectionPreviewRoutes(app: PreviewApp, store: Roo
         }
       });
     }
-  });
+  };
+
+  app.get("/api/admin/minor-protection", handleMinorProtectionRequest);
+  app.get("/api/admin/minor-protection/preview", handleMinorProtectionRequest);
 }

--- a/apps/server/src/minor-protection.ts
+++ b/apps/server/src/minor-protection.ts
@@ -29,6 +29,20 @@ export interface MinorProtectionEvaluation extends MinorProtectionState {
   reason: "minor_restricted_hours" | "minor_daily_limit_reached" | null;
 }
 
+export interface MinorProtectionBlockDetails extends MinorProtectionEvaluation {
+  currentServerTime: string;
+  currentLocalTime: string;
+  timeZone: string;
+  restrictedWindow: {
+    startHour: number;
+    endHour: number;
+  };
+  remainingDailyMinutes: number;
+  nextAllowedAt: string | null;
+  nextAllowedLocalTime: string | null;
+  nextAllowedCountdownSeconds: number | null;
+}
+
 function parseEnvInteger(value: string | undefined, fallback: number, minimum: number, maximum?: number): number {
   const parsed = Number(value?.trim());
   if (!Number.isFinite(parsed)) {
@@ -74,6 +88,17 @@ function getHourInTimeZone(date: Date, timeZone: string): number {
   return Number(hourPart ?? "0");
 }
 
+function getMinuteInTimeZone(date: Date, timeZone: string): number {
+  const minutePart = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    minute: "2-digit"
+  })
+    .formatToParts(date)
+    .find((part) => part.type === "minute")?.value;
+
+  return Number(minutePart ?? "0");
+}
+
 function getWeekdayInTimeZone(date: Date, timeZone: string): string {
   return new Intl.DateTimeFormat("en-US", {
     timeZone,
@@ -84,6 +109,72 @@ function getWeekdayInTimeZone(date: Date, timeZone: string): string {
 function normalizeDateKey(value?: string | null): string | undefined {
   const normalized = value?.trim();
   return normalized && /^\d{4}-\d{2}-\d{2}$/.test(normalized) ? normalized : undefined;
+}
+
+function formatLocalTime(date: Date, timeZone: string): string {
+  const hour = String(getHourInTimeZone(date, timeZone)).padStart(2, "0");
+  const minute = String(getMinuteInTimeZone(date, timeZone)).padStart(2, "0");
+  return `${hour}:${minute}`;
+}
+
+function parseBirthdate(value: string): { year: number; month: number; day: number } | null {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return null;
+  }
+
+  const candidate = new Date(Date.UTC(year, month - 1, day));
+  if (
+    candidate.getUTCFullYear() !== year ||
+    candidate.getUTCMonth() !== month - 1 ||
+    candidate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return { year, month, day };
+}
+
+function getNumericDateParts(date: Date, timeZone: string): { year: number; month: number; day: number } {
+  const parts = getDateParts(date, timeZone);
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day)
+  };
+}
+
+function compareDateParts(
+  left: { year: number; month: number; day: number },
+  right: { year: number; month: number; day: number }
+): number {
+  if (left.year !== right.year) {
+    return left.year - right.year;
+  }
+  if (left.month !== right.month) {
+    return left.month - right.month;
+  }
+  return left.day - right.day;
+}
+
+function deriveAgeFromBirthdate(
+  birthdate: { year: number; month: number; day: number },
+  now: Date,
+  timeZone: string
+): number {
+  const today = getNumericDateParts(now, timeZone);
+  let age = today.year - birthdate.year;
+  if (today.month < birthdate.month || (today.month === birthdate.month && today.day < birthdate.day)) {
+    age -= 1;
+  }
+  return age;
 }
 
 function isMinorAgeRange(ageRange: string): boolean | undefined {
@@ -196,11 +287,94 @@ export function evaluateMinorProtectionState(
   };
 }
 
-export function deriveWechatMinorProtection(input: {
-  ageVerified?: boolean | null;
-  isAdult?: boolean | null;
-  ageRange?: string | null;
-}): { ageVerified?: boolean; isMinor?: boolean } {
+export function normalizeMinorProtectionBirthdate(
+  value: string,
+  now = new Date(),
+  config = readMinorProtectionConfig()
+): string {
+  const normalized = value.trim();
+  const birthdate = parseBirthdate(normalized);
+  if (!birthdate) {
+    throw new Error('Expected optional string field: birthdate in "YYYY-MM-DD" format');
+  }
+
+  const today = getNumericDateParts(now, config.timeZone);
+  if (compareDateParts(birthdate, today) > 0) {
+    throw new Error("birthdate cannot be in the future");
+  }
+
+  const age = deriveAgeFromBirthdate(birthdate, now, config.timeZone);
+  if (age > 120) {
+    throw new Error("birthdate must be within the past 120 years");
+  }
+
+  return normalized;
+}
+
+export function findNextAllowedMinorProtectionTime(
+  account: Pick<PlayerAccountSnapshot, "isMinor" | "dailyPlayMinutes" | "lastPlayDate">,
+  now = new Date(),
+  config = readMinorProtectionConfig()
+): Date | null {
+  const current = evaluateMinorProtectionState(account, now, config);
+  if (!current.wouldBlock) {
+    return now;
+  }
+
+  for (let minutes = 1; minutes <= 48 * 60; minutes += 1) {
+    const candidate = new Date(now.getTime() + minutes * 60_000);
+    if (!evaluateMinorProtectionState(account, candidate, config).wouldBlock) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function buildMinorProtectionBlockDetails(
+  account: Pick<PlayerAccountSnapshot, "isMinor" | "dailyPlayMinutes" | "lastPlayDate">,
+  now = new Date(),
+  config = readMinorProtectionConfig()
+): MinorProtectionBlockDetails {
+  const evaluation = evaluateMinorProtectionState(account, now, config);
+  const nextAllowedAt = evaluation.wouldBlock ? findNextAllowedMinorProtectionTime(account, now, config) : now;
+
+  return {
+    ...evaluation,
+    currentServerTime: now.toISOString(),
+    currentLocalTime: formatLocalTime(now, config.timeZone),
+    timeZone: config.timeZone,
+    restrictedWindow: {
+      startHour: config.restrictedStartHour,
+      endHour: config.restrictedEndHour
+    },
+    remainingDailyMinutes: Math.max(0, evaluation.dailyLimitMinutes - evaluation.normalizedDailyPlayMinutes),
+    nextAllowedAt: nextAllowedAt?.toISOString() ?? null,
+    nextAllowedLocalTime: nextAllowedAt ? formatLocalTime(nextAllowedAt, config.timeZone) : null,
+    nextAllowedCountdownSeconds:
+      nextAllowedAt == null ? null : Math.max(0, Math.ceil((nextAllowedAt.getTime() - now.getTime()) / 1000))
+  };
+}
+
+export function deriveWechatMinorProtection(
+  input: {
+    birthdate?: string | null;
+    ageVerified?: boolean | null;
+    isAdult?: boolean | null;
+    ageRange?: string | null;
+  },
+  now = new Date(),
+  config = readMinorProtectionConfig()
+): { ageVerified?: boolean; isMinor?: boolean } {
+  if (typeof input.birthdate === "string") {
+    const normalizedBirthdate = normalizeMinorProtectionBirthdate(input.birthdate, now, config);
+    const birthdate = parseBirthdate(normalizedBirthdate);
+    return {
+      ageVerified: true,
+      isMinor: birthdate != null && deriveAgeFromBirthdate(birthdate, now, config.timeZone) < 18
+    };
+  }
+
   if (typeof input.isAdult === "boolean") {
     return {
       ageVerified: true,

--- a/apps/server/test/auth-guest-login.test.ts
+++ b/apps/server/test/auth-guest-login.test.ts
@@ -3791,6 +3791,60 @@ test("wechat mini game login stores verified minor status when age data is provi
   assert.equal(storedAccount?.isMinor, true);
 });
 
+test("wechat mini game login derives minor status from self-declared birthdate", { concurrency: false }, async (t) => {
+  const port = 45010 + Math.floor(Math.random() * 1000);
+  const store = new MemoryAuthStore();
+  const server = await startAuthServer(port, store);
+  const originalFetch = globalThis.fetch;
+
+  t.after(async () => {
+    globalThis.fetch = originalFetch;
+    delete process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE;
+    delete process.env.WECHAT_APP_ID;
+    delete process.env.WECHAT_APP_SECRET;
+    delete process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL;
+    resetGuestAuthSessions();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  process.env.VEIL_WECHAT_MINIGAME_LOGIN_MODE = "production";
+  process.env.WECHAT_APP_ID = "wx-prod-app";
+  process.env.WECHAT_APP_SECRET = "wx-prod-secret";
+  process.env.VEIL_WECHAT_MINIGAME_CODE2SESSION_URL = "https://wechat.example.test/code2session";
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        openid: "wx-openid-birthdate-minor",
+        session_key: "session-key"
+      }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      }
+    );
+
+  const response = await originalFetch(`http://127.0.0.1:${port}/api/auth/wechat-login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      code: "wx-prod-code",
+      playerId: "wechat-birthdate-minor",
+      displayName: "晨训学员",
+      birthdate: "2012-01-01",
+      privacyConsentAccepted: true
+    })
+  });
+
+  assert.equal(response.status, 200);
+  const storedAccount = await store.loadPlayerAccount("wechat-birthdate-minor");
+  assert.equal(storedAccount?.ageVerified, true);
+  assert.equal(storedAccount?.isMinor, true);
+});
+
 test("wechat mini game login reuses the bound player even when later requests spoof another playerId", { concurrency: false }, async (t) => {
   const port = 45050 + Math.floor(Math.random() * 1000);
   const store = new MemoryAuthStore();

--- a/apps/server/test/colyseus-room-ban-enforcement.test.ts
+++ b/apps/server/test/colyseus-room-ban-enforcement.test.ts
@@ -211,6 +211,10 @@ test("room connect rejects minors during restricted hours", async (t) => {
     ageVerified: true,
     isMinor: true
   });
+  await store.savePlayerAccountProgress("minor-player", {
+    dailyPlayMinutes: 10,
+    lastPlayDate: "2026-04-03"
+  });
   const room = await createTestRoom(`minor-hours-${Date.now()}`);
   const client = createFakeClient("minor-hours-session");
 
@@ -229,7 +233,31 @@ test("room connect rejects minors during restricted hours", async (t) => {
     playerId: "minor-player"
   });
 
-  assert.equal(client.sent.some((message) => message.type === "error" && message.reason === "minor_restricted_hours"), true);
+  const curfewError = client.sent.find(
+    (message) => message.type === "error" && message.reason === "minor_restricted_hours"
+  );
+  assert.ok(curfewError);
+  assert.deepEqual(curfewError.minorProtection, {
+    enforced: true,
+    localDate: "2026-04-03",
+    normalizedDailyPlayMinutes: 10,
+    dailyLimitMinutes: 90,
+    restrictedHours: true,
+    dailyLimitReached: false,
+    wouldBlock: true,
+    reason: "minor_restricted_hours",
+    currentServerTime: "2026-04-03T14:30:00.000Z",
+    currentLocalTime: "22:30",
+    timeZone: "Asia/Shanghai",
+    restrictedWindow: {
+      startHour: 22,
+      endHour: 8
+    },
+    remainingDailyMinutes: 80,
+    nextAllowedAt: "2026-04-04T00:00:00.000Z",
+    nextAllowedLocalTime: "08:00",
+    nextAllowedCountdownSeconds: 34200
+  });
   assert.equal(client.sent.some((message) => message.type === "session.state"), false);
 });
 
@@ -327,9 +355,30 @@ test("room timer kicks minors after reaching the daily playtime limit and blocks
     playerId: "minor-limit"
   });
 
-  assert.equal(
-    secondClient.sent.some((message) => message.type === "error" && message.reason === "minor_daily_limit_reached"),
-    true
+  const limitError = secondClient.sent.find(
+    (message) => message.type === "error" && message.reason === "minor_daily_limit_reached"
   );
+  assert.ok(limitError);
+  assert.deepEqual(limitError.minorProtection, {
+    enforced: true,
+    localDate: "2026-04-03",
+    normalizedDailyPlayMinutes: 90,
+    dailyLimitMinutes: 90,
+    restrictedHours: false,
+    dailyLimitReached: true,
+    wouldBlock: true,
+    reason: "minor_daily_limit_reached",
+    currentServerTime: "2026-04-03T01:01:00.000Z",
+    currentLocalTime: "09:01",
+    timeZone: "Asia/Shanghai",
+    restrictedWindow: {
+      startHour: 22,
+      endHour: 8
+    },
+    remainingDailyMinutes: 0,
+    nextAllowedAt: "2026-04-04T00:00:00.000Z",
+    nextAllowedLocalTime: "08:00",
+    nextAllowedCountdownSeconds: 82740
+  });
   assert.equal(secondClient.sent.some((message) => message.type === "session.state"), false);
 });

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -254,10 +254,10 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
       matchmakingStore = dependencies.store;
       base.routeCalls.push("matchmaking");
     },
-    registerMinorProtectionPreviewRoutes: (app, store) => {
+    registerMinorProtectionRoutes: (app, store) => {
       assert.equal(app, base.expressApp);
       assert.equal(store, memoryStore);
-      base.routeCalls.push("minor-protection-preview");
+      base.routeCalls.push("minor-protection");
     },
     registerPrometheusMetricsMiddleware: (app) => {
       assert.equal(app, base.expressApp);
@@ -320,7 +320,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
     "wechat-pay",
     "lobby",
     "matchmaking",
-    "minor-protection-preview",
+    "minor-protection",
     "leaderboard",
     "seasons",
     "runtime-observability",
@@ -395,7 +395,7 @@ test("dev server logs process-level failures, closes stores, and exits non-zero"
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerMinorProtectionRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
     registerPrometheusMetricsRoute: () => undefined,
     registerLeaderboardRoutes: () => undefined,
@@ -461,7 +461,7 @@ test("dev server logs uncaught exceptions, closes stores, and exits non-zero", a
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerMinorProtectionRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
     registerPrometheusMetricsRoute: () => undefined,
     registerLeaderboardRoutes: () => undefined,
@@ -557,7 +557,7 @@ test("dev server falls back to in-memory persistence and warns when schema migra
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerMinorProtectionRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
     registerPrometheusMetricsRoute: () => undefined,
     registerLeaderboardRoutes: () => undefined,
@@ -661,7 +661,7 @@ test("dev server exits non-zero in production when MySQL bootstrap fails instead
         registerWechatPayRoutes: () => undefined,
         registerLobbyRoutes: () => undefined,
         registerMatchmakingRoutes: () => undefined,
-        registerMinorProtectionPreviewRoutes: () => undefined,
+        registerMinorProtectionRoutes: () => undefined,
         registerPrometheusMetricsMiddleware: () => undefined,
         registerPrometheusMetricsRoute: () => undefined,
         registerLeaderboardRoutes: () => undefined,
@@ -734,7 +734,7 @@ test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL 
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerMinorProtectionRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
     registerPrometheusMetricsRoute: () => undefined,
     registerLeaderboardRoutes: () => undefined,
@@ -835,7 +835,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerMinorProtectionRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
     registerPrometheusMetricsRoute: () => undefined,
     registerLeaderboardRoutes: () => undefined,
@@ -942,7 +942,7 @@ test("dev server warns loudly when backup storage is unreachable and exports the
     registerWechatPayRoutes: () => undefined,
     registerLobbyRoutes: () => undefined,
     registerMatchmakingRoutes: () => undefined,
-    registerMinorProtectionPreviewRoutes: () => undefined,
+    registerMinorProtectionRoutes: () => undefined,
     registerPrometheusMetricsMiddleware: () => undefined,
     registerPrometheusMetricsRoute: () => undefined,
     registerLeaderboardRoutes: () => undefined,

--- a/apps/server/test/minor-protection-routes.test.ts
+++ b/apps/server/test/minor-protection-routes.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { evaluateMinorProtectionState, readMinorProtectionConfig } from "../src/minor-protection";
-import { registerMinorProtectionPreviewRoutes } from "../src/minor-protection-preview";
+import { registerMinorProtectionRoutes } from "../src/minor-protection-routes";
 import type { RoomSnapshotStore } from "../src/persistence";
 
 type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void | Promise<void>;
@@ -126,7 +126,7 @@ test("evaluateMinorProtectionState applies holiday override", () => {
   assert.equal(evaluation.reason, null);
 });
 
-test("GET /api/admin/minor-protection/preview requires the admin token", async (t) => {
+test("GET /api/admin/minor-protection requires the admin token", async (t) => {
   const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
   process.env.VEIL_ADMIN_TOKEN = "preview-token";
   t.after(() => {
@@ -138,14 +138,14 @@ test("GET /api/admin/minor-protection/preview requires the admin token", async (
   });
 
   const { app, gets } = createTestApp();
-  registerMinorProtectionPreviewRoutes(app, null);
-  const handler = gets.get("/api/admin/minor-protection/preview");
+  registerMinorProtectionRoutes(app, null);
+  const handler = gets.get("/api/admin/minor-protection");
   assert.ok(handler);
 
   const response = createResponse();
   await handler(
     createRequest({
-      url: "/api/admin/minor-protection/preview?playerId=minor-player"
+      url: "/api/admin/minor-protection?playerId=minor-player"
     }),
     response
   );
@@ -159,7 +159,7 @@ test("GET /api/admin/minor-protection/preview requires the admin token", async (
   });
 });
 
-test("GET /api/admin/minor-protection/preview returns 400 when playerId is missing", async (t) => {
+test("GET /api/admin/minor-protection returns 400 when playerId is missing", async (t) => {
   const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
   process.env.VEIL_ADMIN_TOKEN = "preview-token";
   t.after(() => {
@@ -171,8 +171,8 @@ test("GET /api/admin/minor-protection/preview returns 400 when playerId is missi
   });
 
   const { app, gets } = createTestApp();
-  registerMinorProtectionPreviewRoutes(app, null);
-  const handler = gets.get("/api/admin/minor-protection/preview");
+  registerMinorProtectionRoutes(app, null);
+  const handler = gets.get("/api/admin/minor-protection");
   assert.ok(handler);
 
   const response = createResponse();
@@ -181,7 +181,7 @@ test("GET /api/admin/minor-protection/preview returns 400 when playerId is missi
       headers: {
         "x-veil-admin-token": "preview-token"
       },
-      url: "/api/admin/minor-protection/preview"
+      url: "/api/admin/minor-protection"
     }),
     response
   );
@@ -195,7 +195,7 @@ test("GET /api/admin/minor-protection/preview returns 400 when playerId is missi
   });
 });
 
-test("GET /api/admin/minor-protection/preview honors at and dailyPlayMinutes overrides", async (t) => {
+test("GET /api/admin/minor-protection honors at and dailyPlayMinutes overrides", async (t) => {
   const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
   process.env.VEIL_ADMIN_TOKEN = "preview-token";
   t.after(() => {
@@ -218,8 +218,8 @@ test("GET /api/admin/minor-protection/preview honors at and dailyPlayMinutes ove
   } as Pick<RoomSnapshotStore, "loadPlayerAccount"> as RoomSnapshotStore;
 
   const { app, gets } = createTestApp();
-  registerMinorProtectionPreviewRoutes(app, store);
-  const handler = gets.get("/api/admin/minor-protection/preview");
+  registerMinorProtectionRoutes(app, store);
+  const handler = gets.get("/api/admin/minor-protection");
   assert.ok(handler);
 
   const response = createResponse();
@@ -228,7 +228,7 @@ test("GET /api/admin/minor-protection/preview honors at and dailyPlayMinutes ove
       headers: {
         "x-veil-admin-token": "preview-token"
       },
-      url: "/api/admin/minor-protection/preview?playerId=minor-player&at=2026-04-03T14:30:00.000Z&dailyPlayMinutes=90"
+      url: "/api/admin/minor-protection?playerId=minor-player&at=2026-04-03T14:30:00.000Z&dailyPlayMinutes=90"
     }),
     response
   );
@@ -242,11 +242,22 @@ test("GET /api/admin/minor-protection/preview honors at and dailyPlayMinutes ove
     restrictedHours: true,
     dailyLimitReached: true,
     wouldBlock: true,
-    reason: "minor_restricted_hours"
+    reason: "minor_restricted_hours",
+    currentServerTime: "2026-04-03T14:30:00.000Z",
+    currentLocalTime: "22:30",
+    timeZone: "Asia/Shanghai",
+    restrictedWindow: {
+      startHour: 22,
+      endHour: 8
+    },
+    remainingDailyMinutes: 0,
+    nextAllowedAt: "2026-04-04T00:00:00.000Z",
+    nextAllowedLocalTime: "08:00",
+    nextAllowedCountdownSeconds: 34200
   });
 });
 
-test("GET /api/admin/minor-protection/preview returns pass-through and allowed states", async (t) => {
+test("GET /api/admin/minor-protection returns pass-through and allowed states", async (t) => {
   const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
   process.env.VEIL_ADMIN_TOKEN = "preview-token";
   t.after(() => {
@@ -278,8 +289,8 @@ test("GET /api/admin/minor-protection/preview returns pass-through and allowed s
   } as Pick<RoomSnapshotStore, "loadPlayerAccount"> as RoomSnapshotStore;
 
   const { app, gets } = createTestApp();
-  registerMinorProtectionPreviewRoutes(app, store);
-  const handler = gets.get("/api/admin/minor-protection/preview");
+  registerMinorProtectionRoutes(app, store);
+  const handler = gets.get("/api/admin/minor-protection");
   assert.ok(handler);
 
   const adultResponse = createResponse();
@@ -288,7 +299,7 @@ test("GET /api/admin/minor-protection/preview returns pass-through and allowed s
       headers: {
         "x-veil-admin-token": "preview-token"
       },
-      url: "/api/admin/minor-protection/preview?playerId=adult-player&at=2026-04-03T14:30:00.000Z"
+      url: "/api/admin/minor-protection?playerId=adult-player&at=2026-04-03T14:30:00.000Z"
     }),
     adultResponse
   );
@@ -302,7 +313,18 @@ test("GET /api/admin/minor-protection/preview returns pass-through and allowed s
     restrictedHours: true,
     dailyLimitReached: true,
     wouldBlock: false,
-    reason: null
+    reason: null,
+    currentServerTime: "2026-04-03T14:30:00.000Z",
+    currentLocalTime: "22:30",
+    timeZone: "Asia/Shanghai",
+    restrictedWindow: {
+      startHour: 22,
+      endHour: 8
+    },
+    remainingDailyMinutes: 0,
+    nextAllowedAt: "2026-04-03T14:30:00.000Z",
+    nextAllowedLocalTime: "22:30",
+    nextAllowedCountdownSeconds: 0
   });
 
   const allowedResponse = createResponse();
@@ -311,7 +333,7 @@ test("GET /api/admin/minor-protection/preview returns pass-through and allowed s
       headers: {
         "x-veil-admin-token": "preview-token"
       },
-      url: "/api/admin/minor-protection/preview?playerId=minor-player&at=2026-04-03T01:00:00.000Z"
+      url: "/api/admin/minor-protection?playerId=minor-player&at=2026-04-03T01:00:00.000Z"
     }),
     allowedResponse
   );
@@ -325,6 +347,47 @@ test("GET /api/admin/minor-protection/preview returns pass-through and allowed s
     restrictedHours: false,
     dailyLimitReached: false,
     wouldBlock: false,
-    reason: null
+    reason: null,
+    currentServerTime: "2026-04-03T01:00:00.000Z",
+    currentLocalTime: "09:00",
+    timeZone: "Asia/Shanghai",
+    restrictedWindow: {
+      startHour: 22,
+      endHour: 8
+    },
+    remainingDailyMinutes: 45,
+    nextAllowedAt: "2026-04-03T01:00:00.000Z",
+    nextAllowedLocalTime: "09:00",
+    nextAllowedCountdownSeconds: 0
   });
+});
+
+test("GET /api/admin/minor-protection/preview remains as a compatibility alias", async (t) => {
+  const originalAdminToken = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = "preview-token";
+  t.after(() => {
+    if (originalAdminToken === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+      return;
+    }
+    process.env.VEIL_ADMIN_TOKEN = originalAdminToken;
+  });
+
+  const { app, gets } = createTestApp();
+  registerMinorProtectionRoutes(app, null);
+  const handler = gets.get("/api/admin/minor-protection/preview");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      headers: {
+        "x-veil-admin-token": "preview-token"
+      },
+      url: "/api/admin/minor-protection/preview?playerId=minor-player"
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
 });

--- a/apps/server/test/minor-protection.test.ts
+++ b/apps/server/test/minor-protection.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildMinorProtectionBlockDetails,
   deriveMinorProtectionState,
   deriveWechatMinorProtection,
   evaluateMinorProtectionState,
+  findNextAllowedMinorProtectionTime,
   getMinorProtectionDateKey,
+  normalizeMinorProtectionBirthdate,
   readMinorProtectionConfig
 } from "../src/minor-protection";
 
@@ -161,7 +164,32 @@ test("evaluateMinorProtectionState prefers restricted-hours reason when both rul
   assert.equal(evaluation.reason, "minor_restricted_hours");
 });
 
-test("deriveWechatMinorProtection prioritizes isAdult over other fields", () => {
+test("normalizeMinorProtectionBirthdate rejects impossible or future dates", () => {
+  assert.throws(() => normalizeMinorProtectionBirthdate("2026-02-30", new Date("2026-04-03T00:00:00.000Z")), {
+    message: 'Expected optional string field: birthdate in "YYYY-MM-DD" format'
+  });
+  assert.throws(() => normalizeMinorProtectionBirthdate("2026-04-04", new Date("2026-04-03T00:00:00.000Z")), {
+    message: "birthdate cannot be in the future"
+  });
+});
+
+test("deriveWechatMinorProtection derives minor status from self-declared birthdate", () => {
+  assert.deepEqual(
+    deriveWechatMinorProtection(
+      {
+        birthdate: "2009-04-04",
+        isAdult: true
+      },
+      new Date("2026-04-03T16:00:00.000Z")
+    ),
+    {
+      ageVerified: true,
+      isMinor: true
+    }
+  );
+});
+
+test("deriveWechatMinorProtection prioritizes isAdult over legacy fields", () => {
   assert.deepEqual(
     deriveWechatMinorProtection({
       ageVerified: false,
@@ -188,4 +216,62 @@ test("deriveWechatMinorProtection derives minor status from supported age ranges
     ageVerified: true
   });
   assert.deepEqual(deriveWechatMinorProtection({}), {});
+});
+
+test("findNextAllowedMinorProtectionTime resolves the next local 08:00 window during curfew", () => {
+  const config = readMinorProtectionConfig({
+    VEIL_MINOR_PROTECTION_TIME_ZONE: "Asia/Shanghai",
+    VEIL_MINOR_PROTECTION_HOLIDAY_DATES: ""
+  });
+
+  const nextAllowedAt = findNextAllowedMinorProtectionTime(
+    {
+      isMinor: true,
+      dailyPlayMinutes: 20,
+      lastPlayDate: "2026-04-03"
+    },
+    new Date("2026-04-03T14:30:00.000Z"),
+    config
+  );
+
+  assert.equal(nextAllowedAt?.toISOString(), "2026-04-04T00:00:00.000Z");
+});
+
+test("buildMinorProtectionBlockDetails includes countdown metadata", () => {
+  const config = readMinorProtectionConfig({
+    VEIL_MINOR_PROTECTION_TIME_ZONE: "Asia/Shanghai",
+    VEIL_MINOR_PROTECTION_HOLIDAY_DATES: ""
+  });
+
+  const details = buildMinorProtectionBlockDetails(
+    {
+      isMinor: true,
+      dailyPlayMinutes: 20,
+      lastPlayDate: "2026-04-03"
+    },
+    new Date("2026-04-03T14:30:00.000Z"),
+    config
+  );
+
+  assert.deepEqual(details, {
+    enforced: true,
+    localDate: "2026-04-03",
+    normalizedDailyPlayMinutes: 20,
+    dailyLimitMinutes: 90,
+    restrictedHours: true,
+    dailyLimitReached: false,
+    wouldBlock: true,
+    reason: "minor_restricted_hours",
+    currentServerTime: "2026-04-03T14:30:00.000Z",
+    currentLocalTime: "22:30",
+    timeZone: "Asia/Shanghai",
+    restrictedWindow: {
+      startHour: 22,
+      endHour: 8
+    },
+    remainingDailyMinutes: 70,
+    nextAllowedAt: "2026-04-04T00:00:00.000Z",
+    nextAllowedLocalTime: "08:00",
+    nextAllowedCountdownSeconds: 34200
+  });
 });

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -6,6 +6,8 @@
 
 - 游客登录：`POST /api/auth/guest-login`
 - 微信小游戏登录：`POST /api/auth/wechat-login`（`/api/auth/wechat-mini-game-login` 仍保留别名）
+- 微信小游戏年龄声明 / 未成年人保护：`POST /api/auth/wechat-login` 支持 `birthdate=YYYY-MM-DD` 自声明年龄校验；服务端会落库 `ageVerified/isMinor` 并在房间接入时执行未成年人限制
+- 运营与监护人说明：`docs/minor-protection-operations.md`
 - 游客档升级成口令账号：`POST /api/auth/account-bind`
 - 口令账号登录：`POST /api/auth/account-login`
 - 会话校验 / 刷新 / 退出：`GET /api/auth/session`、`POST /api/auth/refresh`、`POST /api/auth/logout`
@@ -24,7 +26,9 @@
 - [x] `POST /api/auth/account-login` 现在会按来源 IP 聚合短窗口内的跨账号口令失败；同一来源连续命中多个不同 `loginId` 失败后，会临时封禁该来源并返回 `429 credential_stuffing_blocked`。
 - [x] `/api/runtime/auth-readiness` 与 `/api/runtime/metrics` 已补充撞库源封禁态势，便于 ops 区分“单账号锁定”与“同源多账号扫描”。
 - [ ] 更外层的 DDoS 缓解仍属于 CDN / WAF / 基础设施侧工作，本次仓库切片未覆盖。
-- [ ] 未成年人保护沿用现有微信实名 / minor protection 读模型，本次切片未改动夜间限制与累计时长策略。
+- [x] 未成年人保护已接入生产命名的运营查询面 `/api/admin/minor-protection`，并在服务端按中国时区执行 `22:00-08:00` 宵禁、工作日 `90` 分钟 / 周末与节假日 `180` 分钟的累计时长限制。
+- [x] 当前仓库在缺少微信实名 SDK 脚手架时，采用 `birthdate=YYYY-MM-DD` 的自声明年龄校验作为生产兜底；服务端只持久化 `ageVerified/isMinor` 结果，不回存原始生日。
+- [ ] 仍缺少对接微信实名能力后的更强校验链路，以及面向存量账号的强制补录 / 追认流程。
 
 ## 微信小游戏 code2session
 

--- a/docs/minor-protection-operations.md
+++ b/docs/minor-protection-operations.md
@@ -1,0 +1,53 @@
+# 未成年人保护运营与监护人说明
+
+本文档描述 `#1305` 落地后的生产契约，覆盖账号年龄声明、房间准入拦截、运营查询面，以及当前仓库仍待补齐的能力。
+
+## 当前生产行为
+
+- 微信小游戏登录接口 `POST /api/auth/wechat-login` 支持客户端提交 `birthdate`，格式固定为 `YYYY-MM-DD`。
+- 当仓库内没有微信实名能力时，服务端把该字段视为“用户自声明生日”，并据此推导 `ageVerified=true` 与 `isMinor=true|false`。
+- 为降低敏感信息持久化范围，服务端当前只保存 `ageVerified` 与 `isMinor` 的归一化结果，不持久化原始 `birthdate`。
+- 旧的 `isAdult` / `ageRange` 输入仍作为兼容兜底保留，但新的生产接入应优先传 `birthdate`。
+
+## 服务端限制
+
+- 时区固定读取 `VEIL_MINOR_PROTECTION_TIME_ZONE`，默认 `Asia/Shanghai`。
+- 宵禁时段为 `22:00` 到次日 `08:00`，未成年人不能进房，也会在在线期间被定时器踢出。
+- 每日累计时长上限为：
+  - 工作日 `90` 分钟
+  - 周末与 `VEIL_MINOR_PROTECTION_HOLIDAY_DATES` 命中的节假日 `180` 分钟
+- 房间准入在 `connect/join` 前检查账号年龄状态与当前服务器时间，未成年人被拦截时返回结构化错误：
+  - `reason=minor_restricted_hours`
+  - `reason=minor_daily_limit_reached`
+  - `minorProtection.nextAllowedAt`
+  - `minorProtection.nextAllowedCountdownSeconds`
+
+## 运营查询面
+
+- 生产路由：`GET /api/admin/minor-protection`
+- 兼容别名：`GET /api/admin/minor-protection/preview`
+- 鉴权：请求头 `x-veil-admin-token: <VEIL_ADMIN_TOKEN>`
+- 常用查询参数：
+  - `playerId`: 必填
+  - `at`: 可选，ISO-8601 时间，用于按历史/演练时间点评估
+  - `dailyPlayMinutes`: 可选，覆盖当天累计分钟数做演练
+- 响应会返回：
+  - 当前是否命中宵禁 / 时长上限
+  - 中国时区下的本地日期与时间
+  - 当天剩余可玩分钟数
+  - 下一次允许游戏的时间点与倒计时秒数
+
+## 监护人/合规说明
+
+- 当前仓库只实现“自声明生日 + 服务端限制”这一最小可上线链路，适合作为无微信实名 SDK 时的兜底。
+- 若玩家自声明为未成年人，前端和运营文案应明确说明：
+  - 宵禁时间为 `22:00-08:00`
+  - 工作日每日最多 `1.5` 小时
+  - 周末 / 法定节假日每日最多 `3` 小时
+- 监护人同意、客服申诉、年龄更正等流程当前仍属于运营人工处理范围，建议保留人工审计记录并复核账号 `playerId`、设备、时间点与声明信息来源。
+
+## 已知缺口与后续
+
+- 未接入微信官方实名 / 防沉迷能力，无法证明自声明生日的真实性。
+- 未实现存量账号强制补录年龄信息的迁移流程；当前限制仅在账号已有 `isMinor=true` 时生效。
+- 未实现监护人同意凭证的持久化模型；若后续需要闭环，应新增专用 consent read-model，而不是复用 `privacyConsentAt`。

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -201,6 +201,27 @@ export type ServerMessage =
       type: "error";
       requestId: string;
       reason: string;
+      minorProtection?: {
+        enforced: boolean;
+        localDate: string;
+        normalizedDailyPlayMinutes: number;
+        dailyLimitMinutes: number;
+        restrictedHours: boolean;
+        dailyLimitReached: boolean;
+        wouldBlock: boolean;
+        reason: "minor_restricted_hours" | "minor_daily_limit_reached" | null;
+        currentServerTime: string;
+        currentLocalTime: string;
+        timeZone: string;
+        restrictedWindow: {
+          startHour: number;
+          endHour: number;
+        };
+        remainingDailyMinutes: number;
+        nextAllowedAt: string | null;
+        nextAllowedLocalTime: string | null;
+        nextAllowedCountdownSeconds: number | null;
+      };
     }
   | {
       type: "report.player";


### PR DESCRIPTION
## Summary
- promote the minor-protection admin route to production naming and keep the preview path as a compatibility alias
- add self-declared birthdate support for WeChat login, derive `ageVerified`/`isMinor`, and document the current self-declaration fallback plus follow-up gaps
- return structured room-join minor-protection errors with current server-time context and a countdown to the next allowed play window
- expand server tests for evaluator logic, admin route behavior, room enforcement, and birthdate-driven auth

## Validation
- `node --import tsx --test apps/server/test/minor-protection.test.ts apps/server/test/minor-protection-routes.test.ts apps/server/test/colyseus-room-ban-enforcement.test.ts apps/server/test/dev-server.test.ts`
- `node --import tsx --test --test-name-pattern "wechat mini game login stores verified minor status when age data is provided|wechat mini game login derives minor status from self-declared birthdate" apps/server/test/auth-guest-login.test.ts`
- `npm run typecheck:server`
- `npm run typecheck:shared && npm run typecheck:cocos`

Closes #1305