### PR TITLE
Add direct config-center controller unit coverage

### DIFF
--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -260,6 +260,7 @@ interface AppState {
   statusMessage: string;
   lastSavedImpactSummary: ConfigImpactSummary | null;
   draft: string;
+  previewApplied: boolean;
   previewSeed: number;
   worldPreview: WorldConfigPreview | null;
   previewLoading: boolean;
@@ -390,6 +391,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     statusMessage: "正在加载配置中心...",
     lastSavedImpactSummary: null,
     draft: "",
+    previewApplied: false,
     previewSeed: 1001,
     worldPreview: null,
     previewLoading: false,
@@ -416,6 +418,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
   let previewDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   let validationRequestVersion = 0;
   let validationDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  const documentLocks = new Map<ConfigDocumentId, ReturnType<typeof setTimeout> | null>();
 
   function isWorldDocumentSelected(): boolean {
     return state.current?.id === "world";
@@ -516,6 +519,38 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     state.draft = nextDraft;
   }
 
+  function lockDocument(documentId = state.current?.id ?? null, timeoutMs = 5_000): boolean {
+    if (!documentId || documentLocks.has(documentId)) {
+      return false;
+    }
+
+    const timer =
+      timeoutMs > 0
+        ? setTimer(() => {
+            documentLocks.delete(documentId);
+          }, timeoutMs)
+        : null;
+    documentLocks.set(documentId, timer);
+    return true;
+  }
+
+  function unlockDocument(documentId = state.current?.id ?? null): boolean {
+    if (!documentId) {
+      return false;
+    }
+
+    const timer = documentLocks.get(documentId);
+    if (timer === undefined) {
+      return false;
+    }
+
+    if (timer != null) {
+      clearTimer(timer);
+    }
+    documentLocks.delete(documentId);
+    return true;
+  }
+
   async function loadList(): Promise<void> {
     const response = await requestJson<{
       storage: "filesystem" | "mysql";
@@ -593,6 +628,10 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       notify();
     }
     return response.diff;
+  }
+
+  async function computeDiff(snapshotId = state.selectedSnapshotId): Promise<ConfigDiff | null> {
+    return loadSnapshotDiff(snapshotId);
   }
 
   async function ensureSnapshotDiff(snapshotId: string): Promise<ConfigDiff | null> {
@@ -1039,6 +1078,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       state.current = response.document;
       state.selectedId = response.document.id;
       state.draft = response.document.content;
+      state.previewApplied = false;
       state.validation = null;
       state.lastSavedImpactSummary = null;
       state.snapshots = [];
@@ -1107,6 +1147,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       state.current = response.document;
       state.lastSavedImpactSummary = response.impactSummary ?? null;
       state.draft = response.document.content;
+      state.previewApplied = false;
       state.statusTone = "success";
       state.statusMessage = `${response.document.title} 已保存，并同步刷新服务端运行时配置`;
       await loadList();
@@ -1135,6 +1176,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     }
 
     state.draft = state.current.content;
+    state.previewApplied = false;
     state.statusTone = "neutral";
     state.statusMessage = `${state.current.title} 已恢复到上次加载内容`;
 
@@ -1151,12 +1193,11 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     void loadValidation();
   }
 
-  async function createSnapshot(): Promise<void> {
+  async function commitSnapshot(label = ""): Promise<ConfigSnapshotSummary | null> {
     if (!state.current) {
-      return;
+      return null;
     }
 
-    const label = promptImpl("快照名称（可选）", `${state.current.title} v${state.current.version ?? 1}`) ?? "";
     try {
       const response = await requestJson<{
         storage: "filesystem" | "mysql";
@@ -1172,15 +1213,27 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
         })
       });
       state.storageMode = response.storage;
+      state.previewApplied = false;
       state.statusTone = "success";
       state.statusMessage = `已保存快照 ${response.snapshot.label}`;
       await loadSnapshots(state.current.id);
       notify();
+      return response.snapshot;
     } catch (error) {
       state.statusTone = "error";
       state.statusMessage = error instanceof Error ? error.message : "保存快照失败";
       notify();
+      return null;
     }
+  }
+
+  async function createSnapshot(): Promise<void> {
+    if (!state.current) {
+      return;
+    }
+
+    const label = promptImpl("快照名称（可选）", `${state.current.title} v${state.current.version ?? 1}`) ?? "";
+    await commitSnapshot(label);
   }
 
   async function rollbackSnapshot(snapshotId: string): Promise<void> {
@@ -1220,6 +1273,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       state.storageMode = response.storage;
       state.current = response.document;
       state.draft = response.document.content;
+      state.previewApplied = false;
       state.statusTone = "success";
       state.statusMessage = `已回滚到快照 ${snapshotId}`;
       await loadList();
@@ -1251,6 +1305,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       state.storageMode = response.storage;
       state.current = response.document;
       state.draft = response.document.content;
+      state.previewApplied = false;
       state.statusTone = "success";
       state.statusMessage = `已应用预设 ${presetId}，运行时配置已刷新`;
       await loadList();
@@ -1353,6 +1408,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       state.storageMode = response.storage;
       state.current = response.document;
       state.draft = response.document.content;
+      state.previewApplied = false;
       state.statusTone = "success";
       state.statusMessage = `已从 ${file.name} 导入并覆盖当前配置`;
       await loadList();
@@ -1369,24 +1425,93 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     }
   }
 
+  async function applyHotloadPreview(): Promise<WorldConfigPreview | null> {
+    if (!isWorldDocumentSelected()) {
+      state.previewApplied = false;
+      clearWorldPreview();
+      notify();
+      return null;
+    }
+
+    const parseState = getDraftParseState();
+    if (!parseState.valid) {
+      state.previewApplied = false;
+      state.previewLoading = false;
+      state.worldPreview = null;
+      state.previewError = `JSON 语法无效：${parseState.detail}`;
+      notify();
+      return null;
+    }
+
+    state.previewApplied = true;
+    await loadWorldPreview();
+    return state.worldPreview;
+  }
+
+  async function validateAndSave(): Promise<{ saved: boolean; validation: ValidationReport | null }> {
+    if (!state.current) {
+      return {
+        saved: false,
+        validation: null
+      };
+    }
+
+    if (!lockDocument(state.current.id)) {
+      state.statusTone = "error";
+      state.statusMessage = `${state.current.title} 当前已被锁定，请稍后重试`;
+      notify();
+      return {
+        saved: false,
+        validation: state.validation
+      };
+    }
+
+    try {
+      await loadValidation();
+      if (!state.validation?.valid) {
+        state.statusTone = "error";
+        state.statusMessage = "当前配置存在校验问题，已阻止保存";
+        notify();
+        return {
+          saved: false,
+          validation: state.validation
+        };
+      }
+
+      await saveCurrentDocument();
+      return {
+        saved: state.statusTone === "success",
+        validation: state.validation
+      };
+    } finally {
+      unlockDocument(state.current.id);
+    }
+  }
+
   return {
     state,
     getDraftParseState,
     normalizePreviewSeed,
     setDraft,
+    lockDocument,
+    unlockDocument,
     clearWorldPreview,
     loadList,
     loadSnapshots,
     loadPresets,
     loadSnapshotDiff,
+    computeDiff,
     loadPublishStage,
     loadPublishAuditHistory,
     loadWorldPreview,
+    applyHotloadPreview,
     loadValidation,
     scheduleWorldPreview,
     loadDocument,
     saveCurrentDocument,
+    validateAndSave,
     restoreCurrentDocument,
+    commitSnapshot,
     createSnapshot,
     rollbackSnapshot,
     applyPreset,

--- a/apps/client/test/config-center-controller.test.ts
+++ b/apps/client/test/config-center-controller.test.ts
@@ -1,0 +1,618 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createConfigCenterController } from "../src/config-center-controller";
+
+type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
+
+interface RequestRecord {
+  url: string;
+  method: string;
+  body: string | null;
+}
+
+function createDocument(id: ConfigDocumentId, content: string, overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id,
+    title: overrides.title ?? `${id} title`,
+    description: overrides.description ?? `${id} description`,
+    fileName: overrides.fileName ?? `${id}.json`,
+    updatedAt: overrides.updatedAt ?? "2026-04-12T04:00:00.000Z",
+    summary: overrides.summary ?? `${id} summary`,
+    content,
+    ...(overrides.version != null ? { version: overrides.version } : {})
+  };
+}
+
+function createValidationReport(valid = true) {
+  return {
+    valid,
+    summary: valid ? "Schema 校验通过" : "发现字段错误",
+    issues: valid
+      ? []
+      : [
+          {
+            path: "$.width",
+            severity: "error" as const,
+            message: "width must be >= 1",
+            suggestion: "修正地图宽度后重试。",
+            line: 2
+          }
+        ],
+    schema: {
+      id: "project-veil.config-center.world",
+      title: "World Schema",
+      version: "1",
+      description: "World config schema",
+      required: ["width", "height"]
+    },
+    contentPack: {
+      schemaVersion: 1 as const,
+      valid,
+      summary: valid ? "Content-pack consistency passed" : "Found content-pack issues",
+      issueCount: valid ? 0 : 1,
+      checkedDocuments: ["world", "mapObjects", "units", "battleSkills", "battleBalance"] as const,
+      issues: []
+    }
+  };
+}
+
+function createWorldPreview() {
+  return {
+    seed: 1001,
+    roomId: "preview-room",
+    width: 8,
+    height: 8,
+    counts: {
+      walkable: 50,
+      blocked: 14,
+      terrain: {
+        grass: 30,
+        dirt: 12,
+        sand: 10,
+        water: 12
+      },
+      resourceTiles: {
+        gold: 3,
+        wood: 2,
+        ore: 1
+      },
+      resourceAmounts: {
+        gold: 600,
+        wood: 10,
+        ore: 5
+      },
+      guaranteedResources: 3,
+      randomResources: 3,
+      heroes: 2,
+      neutralArmies: 4,
+      buildings: 3
+    },
+    tiles: [
+      {
+        position: { x: 0, y: 0 },
+        terrain: "grass" as const,
+        walkable: true
+      }
+    ]
+  };
+}
+
+function createFetchStub(
+  handler: (request: RequestRecord) => Response | Promise<Response>
+): { fetch: typeof fetch; requests: RequestRecord[] } {
+  const requests: RequestRecord[] = [];
+
+  const fetch = (async (input, init) => {
+    const request = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: typeof init?.body === "string" ? init.body : init?.body ? String(init.body) : null
+    };
+    requests.push(request);
+    return handler(request);
+  }) as typeof globalThis.fetch;
+
+  return {
+    fetch,
+    requests
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json"
+    }
+  });
+}
+
+function createManualClock() {
+  let nextId = 1;
+  const timers = new Map<number, () => void>();
+
+  return {
+    setTimeout: ((callback: TimerHandler) => {
+      const id = nextId++;
+      timers.set(id, callback as () => void);
+      return id as unknown as ReturnType<typeof globalThis.setTimeout>;
+    }) as typeof globalThis.setTimeout,
+    clearTimeout: ((timerId: ReturnType<typeof globalThis.setTimeout>) => {
+      timers.delete(Number(timerId));
+    }) as typeof globalThis.clearTimeout,
+    runNext(): void {
+      const next = timers.keys().next();
+      if (next.done) {
+        return;
+      }
+      const callback = timers.get(next.value);
+      timers.delete(next.value);
+      callback?.();
+    }
+  };
+}
+
+test("lockDocument acquires and unlockDocument releases the document lock", () => {
+  const controller = createConfigCenterController();
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n");
+
+  assert.equal(controller.lockDocument(), true);
+  assert.equal(controller.unlockDocument(), true);
+  assert.equal(controller.lockDocument(), true);
+});
+
+test("lockDocument rejects a second lock while the document is already held", () => {
+  const controller = createConfigCenterController();
+  controller.state.current = createDocument("mapObjects", "{\n  \"neutralArmies\": []\n}\n");
+
+  assert.equal(controller.lockDocument(), true);
+  assert.equal(controller.lockDocument(), false);
+  assert.equal(controller.unlockDocument(), true);
+});
+
+test("lockDocument releases automatically after the configured timeout", () => {
+  const clock = createManualClock();
+  const controller = createConfigCenterController({
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout
+  });
+  controller.state.current = createDocument("units", "{\n  \"items\": []\n}\n");
+
+  assert.equal(controller.lockDocument("units", 25), true);
+  assert.equal(controller.lockDocument("units", 25), false);
+
+  clock.runNext();
+
+  assert.equal(controller.lockDocument("units", 25), true);
+});
+
+test("computeDiff returns null when no document or snapshot is selected", async () => {
+  const { fetch, requests } = createFetchStub(() => {
+    throw new Error("computeDiff should not fetch without an active document");
+  });
+  const controller = createConfigCenterController({ fetch });
+
+  const diff = await controller.computeDiff();
+
+  assert.equal(diff, null);
+  assert.equal(requests.length, 0);
+});
+
+test("computeDiff returns an empty diff for identical documents", async () => {
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/diff" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        diff: {
+          entries: []
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n");
+  controller.state.selectedSnapshotId = "snapshot-world-1";
+
+  const diff = await controller.computeDiff();
+
+  assert.deepEqual(diff, { entries: [] });
+  assert.deepEqual(JSON.parse(requests[0]?.body ?? "{}"), {
+    snapshotId: "snapshot-world-1"
+  });
+});
+
+test("computeDiff preserves field and array reorder patch entries from the diff API", async () => {
+  const { fetch } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/mapObjects/diff" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        diff: {
+          entries: [
+            {
+              path: "resourceNodes[0].amount",
+              change: "updated",
+              previousValue: "100",
+              nextValue: "150",
+              kind: "value",
+              required: true,
+              fieldType: "integer",
+              description: "Resource amount",
+              blastRadius: ["world-preview"]
+            },
+            {
+              path: "neutralArmies",
+              change: "updated",
+              previousValue: "[\"a\",\"b\"]",
+              nextValue: "[\"b\",\"a\"]",
+              kind: "value",
+              required: true,
+              fieldType: "array",
+              description: "Neutral army ordering",
+              blastRadius: ["world-preview", "spawn-order"]
+            }
+          ]
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("mapObjects", "{\n  \"neutralArmies\": [\"a\", \"b\"]\n}\n");
+  controller.state.selectedSnapshotId = "snapshot-map-2";
+
+  const diff = await controller.computeDiff();
+
+  assert.equal(diff?.entries.length, 2);
+  assert.equal(diff?.entries[0]?.path, "resourceNodes[0].amount");
+  assert.equal(diff?.entries[1]?.nextValue, "[\"b\",\"a\"]");
+});
+
+test("commitSnapshot writes the current draft and returns the new snapshot version", async () => {
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/snapshots" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        snapshot: {
+          id: "snapshot-world-3",
+          label: "World v3",
+          createdAt: "2026-04-12T04:10:00.000Z",
+          version: 3
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots" && request.method === "GET") {
+      return jsonResponse({
+        storage: "filesystem",
+        snapshots: [
+          {
+            id: "snapshot-world-3",
+            label: "World v3",
+            createdAt: "2026-04-12T04:10:00.000Z",
+            version: 3
+          }
+        ]
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/diff" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        diff: {
+          entries: []
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n", { version: 2 });
+  controller.setDraft("{\n  \"width\": 10\n}\n");
+  controller.state.previewApplied = true;
+
+  const snapshot = await controller.commitSnapshot("World v3");
+
+  assert.equal(snapshot?.version, 3);
+  assert.equal(controller.state.previewApplied, false);
+  assert.equal(controller.state.snapshots[0]?.id, "snapshot-world-3");
+  assert.deepEqual(JSON.parse(requests[0]?.body ?? "{}"), {
+    content: "{\n  \"width\": 10\n}\n",
+    label: "World v3"
+  });
+});
+
+test("commitSnapshot returns null when no current document is loaded", async () => {
+  const controller = createConfigCenterController();
+
+  const snapshot = await controller.commitSnapshot("unused");
+
+  assert.equal(snapshot, null);
+});
+
+test("rollbackSnapshot restores the previous snapshot content", async () => {
+  const { fetch } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/diff" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        diff: {
+          entries: [
+            {
+              path: "width",
+              change: "updated",
+              previousValue: "10",
+              nextValue: "8",
+              kind: "value",
+              required: true,
+              fieldType: "integer",
+              description: "地图宽度",
+              blastRadius: ["world-preview"]
+            }
+          ]
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/rollback" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        document: createDocument("world", "{\n  \"width\": 8\n}\n", { version: 2 })
+      });
+    }
+
+    if (request.url === "/api/config-center/configs" && request.method === "GET") {
+      return jsonResponse({
+        storage: "filesystem",
+        items: [createDocument("world", "{\n  \"width\": 8\n}\n", { version: 2 })]
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots" && request.method === "GET") {
+      return jsonResponse({
+        storage: "filesystem",
+        snapshots: [
+          {
+            id: "snapshot-world-2",
+            label: "World v2",
+            createdAt: "2026-04-12T04:20:00.000Z",
+            version: 2
+          }
+        ]
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/presets" && request.method === "GET") {
+      return jsonResponse({
+        storage: "filesystem",
+        presets: []
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/validate" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        validation: createValidationReport(true)
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/preview" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        preview: createWorldPreview()
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch, confirm: () => true });
+  controller.state.current = createDocument("world", "{\n  \"width\": 10\n}\n", { version: 3 });
+  controller.setDraft("{\n  \"width\": 10\n}\n");
+
+  await controller.rollbackSnapshot("snapshot-world-2");
+
+  assert.equal(controller.state.current?.content, "{\n  \"width\": 8\n}\n");
+  assert.equal(controller.state.draft, "{\n  \"width\": 8\n}\n");
+});
+
+test("applyHotloadPreview sets previewApplied and keeps production content unchanged", async () => {
+  const { fetch } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/preview" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        preview: createWorldPreview()
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n");
+  controller.setDraft("{\n  \"width\": 10\n}\n");
+
+  const preview = await controller.applyHotloadPreview();
+
+  assert.equal(controller.state.previewApplied, true);
+  assert.equal(preview?.roomId, "preview-room");
+  assert.equal(controller.state.current?.content, "{\n  \"width\": 8\n}\n");
+  assert.equal(controller.state.draft, "{\n  \"width\": 10\n}\n");
+});
+
+test("applyHotloadPreview rejects invalid JSON without mutating preview state", async () => {
+  const controller = createConfigCenterController();
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n");
+  controller.setDraft("{\n  \"width\": \n}\n");
+
+  const preview = await controller.applyHotloadPreview();
+
+  assert.equal(preview, null);
+  assert.equal(controller.state.previewApplied, false);
+  assert.match(controller.state.previewError, /JSON/);
+});
+
+test("applyHotloadPreview clears preview mode when a snapshot commit succeeds", async () => {
+  const { fetch } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/preview" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        preview: createWorldPreview()
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        snapshot: {
+          id: "snapshot-world-4",
+          label: "World v4",
+          createdAt: "2026-04-12T04:30:00.000Z",
+          version: 4
+        }
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/snapshots" && request.method === "GET") {
+      return jsonResponse({
+        storage: "filesystem",
+        snapshots: [
+          {
+            id: "snapshot-world-4",
+            label: "World v4",
+            createdAt: "2026-04-12T04:30:00.000Z",
+            version: 4
+          }
+        ]
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/world/diff" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        diff: {
+          entries: []
+        }
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n", { version: 3 });
+  controller.setDraft("{\n  \"width\": 10\n}\n");
+
+  await controller.applyHotloadPreview();
+  assert.equal(controller.state.previewApplied, true);
+
+  await controller.commitSnapshot("World v4");
+
+  assert.equal(controller.state.previewApplied, false);
+});
+
+test("validateAndSave rejects a document that fails validation", async () => {
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/mapObjects/validate" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        validation: createValidationReport(false)
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("mapObjects", "{\n  \"neutralArmies\": [1]\n}\n", { version: 2 });
+  controller.setDraft("{\n  \"neutralArmies\": [1, 2]\n}\n");
+
+  const result = await controller.validateAndSave();
+
+  assert.equal(result.saved, false);
+  assert.equal(result.validation?.valid, false);
+  assert.equal(requests.some((request) => request.method === "PUT"), false);
+  assert.equal(controller.state.statusMessage, "当前配置存在校验问题，已阻止保存");
+});
+
+test("validateAndSave persists the document when validation passes", async () => {
+  const savedDocument = createDocument("mapObjects", "{\n  \"neutralArmies\": []\n}\n", { version: 3 });
+  const { fetch, requests } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/mapObjects/validate" && request.method === "POST") {
+      return jsonResponse({
+        storage: "filesystem",
+        validation: createValidationReport(true)
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/mapObjects" && request.method === "PUT") {
+      return jsonResponse({
+        storage: "filesystem",
+        document: savedDocument,
+        impactSummary: null
+      });
+    }
+
+    if (request.url === "/api/config-center/configs" && request.method === "GET") {
+      return jsonResponse({
+        storage: "filesystem",
+        items: [savedDocument]
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/mapObjects/snapshots" && request.method === "GET") {
+      return jsonResponse({
+        storage: "filesystem",
+        snapshots: []
+      });
+    }
+
+    if (request.url === "/api/config-center/configs/mapObjects/presets" && request.method === "GET") {
+      return jsonResponse({
+        storage: "filesystem",
+        presets: []
+      });
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("mapObjects", "{\n  \"neutralArmies\": [1]\n}\n", { version: 2 });
+  controller.setDraft("{\n  \"neutralArmies\": []\n}\n");
+
+  const result = await controller.validateAndSave();
+
+  assert.equal(result.saved, true);
+  assert.equal(controller.state.current?.version, 3);
+  const saveRequest = requests.find((request) => request.url === "/api/config-center/configs/mapObjects" && request.method === "PUT");
+  assert.ok(saveRequest);
+  assert.deepEqual(JSON.parse(saveRequest.body ?? "{}"), {
+    content: "{\n  \"neutralArmies\": []\n}\n"
+  });
+});
+
+test("validateAndSave surfaces validation errors in the expected format when the API rejects malformed JSON", async () => {
+  const { fetch } = createFetchStub((request) => {
+    if (request.url === "/api/config-center/configs/world/validate" && request.method === "POST") {
+      return jsonResponse(
+        {
+          error: {
+            message: "invalid json payload"
+          }
+        },
+        400
+      );
+    }
+
+    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+  });
+  const controller = createConfigCenterController({ fetch });
+  controller.state.current = createDocument("world", "{\n  \"width\": 8\n}\n");
+  controller.setDraft("{\n  \"width\": \n}\n");
+
+  const result = await controller.validateAndSave();
+
+  assert.equal(result.saved, false);
+  assert.equal(result.validation?.valid, false);
+  assert.equal(result.validation?.summary, "invalid json payload");
+  assert.equal(result.validation?.issues[0]?.path, "$");
+  assert.equal(result.validation?.issues[0]?.suggestion, "检查 JSON 语法和字段格式后重试。");
+});

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "test:db-restore-rehearsal": "node --import tsx --test ./scripts/test/db-restore-rehearsal.test.ts",
     "test:db-restore-test": "node --import tsx --test ./scripts/test/db-restore-test.test.ts",
     "test:player-names:scan": "node --import tsx --test ./scripts/test/scan-player-display-names.test.ts",
-    "test:client:config-center": "node --import tsx --test ./apps/client/test/config-center.test.ts ./apps/client/test/config-center-render.test.ts",
+    "test:client:config-center": "node --import tsx --test ./apps/client/test/config-center-controller.test.ts ./apps/client/test/config-center.test.ts ./apps/client/test/config-center-render.test.ts",
     "test:shared": "node --import tsx --test \"packages/shared/test/**/*.test.ts\"",
     "test:contracts": "node --import tsx --test ./packages/shared/test/client-payload-contracts.test.ts",
     "typecheck:ci": "npm run typecheck:shared && npm run typecheck:server && npm run typecheck:client:h5 && npm run typecheck:cocos",


### PR DESCRIPTION
## Summary
- add a dedicated `config-center-controller` unit suite covering lock/unlock, diff loading, snapshot lifecycle, preview apply, and validate/save flows
- expose thin controller helpers for the stale issue API names without changing existing callers
- include the new controller suite in `test:client:config-center`

## Testing
- `npm run test:client:config-center`
- `npm run typecheck:client:h5`

Closes #1338