### PR TITLE
Add admin player compensation and refund tooling

### DIFF
--- a/apps/client/admin.html
+++ b/apps/client/admin.html
@@ -39,6 +39,10 @@
         .report-actions button[data-status="warned"] { background: #c77b22; }
         .report-actions button[data-status="banned"] { background: #a32020; }
         #reportList { display: grid; gap: 12px; }
+        .table-wrap { overflow-x: auto; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { padding: 10px 12px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+        th { color: var(--muted); font-size: 13px; }
         .empty-state { color: var(--muted); }
     </style>
 </head>
@@ -78,6 +82,57 @@
         </div>
 
         <div class="card">
+            <h2>玩家补偿 / 退款</h2>
+            <div class="grid">
+                <div class="form-group">
+                    <label>类型</label>
+                    <select id="compensationType">
+                        <option value="add">发放</option>
+                        <option value="deduct">扣减</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label>币种</label>
+                    <select id="compensationCurrency">
+                        <option value="gems">Gems</option>
+                        <option value="gold">Gold</option>
+                        <option value="wood">Wood</option>
+                        <option value="ore">Ore</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label>数量</label>
+                    <input type="number" id="compensationAmount" value="100" min="1" />
+                </div>
+            </div>
+            <div class="form-group">
+                <label>原因</label>
+                <input type="text" id="compensationReason" value="Failed payment refund" />
+            </div>
+            <div class="report-actions">
+                <button onclick="submitCompensation()">提交补偿</button>
+                <button onclick="fetchCompensationHistory()">刷新历史</button>
+            </div>
+            <div class="table-wrap" style="margin-top: 16px;">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>时间</th>
+                            <th>类型</th>
+                            <th>币种</th>
+                            <th>数量</th>
+                            <th>余额变化</th>
+                            <th>原因</th>
+                        </tr>
+                    </thead>
+                    <tbody id="compensationHistoryBody">
+                        <tr><td colspan="6" class="empty-state">尚未加载补偿历史。</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="card">
             <h2>举报审核队列</h2>
             <div class="grid">
                 <div class="form-group">
@@ -99,6 +154,7 @@
         const statusDiv = document.getElementById('status');
         const reportFilter = document.getElementById('reportStatusFilter');
         const reportList = document.getElementById('reportList');
+        const compensationHistoryBody = document.getElementById('compensationHistoryBody');
 
         function showStatus(msg, type) {
             statusDiv.textContent = msg;
@@ -143,6 +199,85 @@
                 } else {
                     showStatus(`修改失败！\n状态码: ${res.status}\n原因: ${JSON.stringify(data.error || data)}`, 'error');
                 }
+            } catch (e) {
+                showStatus(`网络错误: ${e.message}`, 'error');
+            }
+        }
+
+        function renderCompensationHistory(items) {
+            if (!items.length) {
+                compensationHistoryBody.innerHTML = '<tr><td colspan="6" class="empty-state">当前玩家还没有补偿记录。</td></tr>';
+                return;
+            }
+
+            compensationHistoryBody.innerHTML = items.map((item) => `
+                <tr>
+                    <td>${item.createdAt}</td>
+                    <td>${item.type === 'deduct' ? '扣减' : '发放'}</td>
+                    <td>${item.currency}</td>
+                    <td>${item.amount}</td>
+                    <td>${item.previousBalance} -> ${item.balanceAfter}</td>
+                    <td>${item.reason}</td>
+                </tr>
+            `).join('');
+        }
+
+        async function fetchCompensationHistory() {
+            const pid = document.getElementById('targetPlayerId').value.trim();
+            if (!pid) {
+                compensationHistoryBody.innerHTML = '<tr><td colspan="6" class="empty-state">请先输入 Player ID。</td></tr>';
+                return;
+            }
+
+            try {
+                const res = await fetch(`/api/admin/players/${pid}/compensation/history?limit=20`, {
+                    headers: { 'x-veil-admin-secret': secretInput.value }
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    compensationHistoryBody.innerHTML = `<tr><td colspan="6" class="empty-state">加载失败：${data.error || res.status}</td></tr>`;
+                    return;
+                }
+                renderCompensationHistory(data.items || []);
+            } catch (e) {
+                compensationHistoryBody.innerHTML = `<tr><td colspan="6" class="empty-state">网络错误：${e.message}</td></tr>`;
+            }
+        }
+
+        async function submitCompensation() {
+            const pid = document.getElementById('targetPlayerId').value.trim();
+            if (!pid) {
+                showStatus('请先输入 Player ID。', 'error');
+                return;
+            }
+
+            showStatus('正在提交补偿请求...', 'success');
+
+            try {
+                const res = await fetch(`/api/admin/players/${pid}/compensation`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'x-veil-admin-secret': secretInput.value
+                    },
+                    body: JSON.stringify({
+                        type: document.getElementById('compensationType').value,
+                        currency: document.getElementById('compensationCurrency').value,
+                        amount: parseInt(document.getElementById('compensationAmount').value, 10),
+                        reason: document.getElementById('compensationReason').value
+                    })
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    showStatus(`补偿失败！\n状态码: ${res.status}\n原因: ${JSON.stringify(data.error || data)}`, 'error');
+                    return;
+                }
+
+                showStatus(
+                    `补偿成功！\nGems: ${data.balances.gems}\nGold: ${data.balances.resources.gold}\nWood: ${data.balances.resources.wood}\nOre: ${data.balances.resources.ore}\n同步到房间: ${data.syncedToRoom ? '✅ 是' : '❌ 否 (无活跃房间)'}`,
+                    'success'
+                );
+                await fetchCompensationHistory();
             } catch (e) {
                 showStatus(`网络错误: ${e.message}`, 'error');
             }
@@ -222,6 +357,7 @@
         reportFilter.addEventListener('change', () => { void fetchReports(); });
         fetchOverview();
         fetchReports();
+        fetchCompensationHistory();
     </script>
 </body>
 </html>

--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -1,9 +1,15 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { ResourceLedger, ServerMessage, WorldState } from "../../../packages/shared/src/index";
+import { appendEventLogEntries, type ResourceLedger, type ServerMessage, type WorldState } from "../../../packages/shared/src/index";
 import { GuildService } from "./guilds";
-import type { PlayerReportResolveInput, PlayerReportStatus, RoomSnapshotStore } from "./persistence";
+import type {
+  PlayerCompensationCreateInput,
+  PlayerCompensationRecord,
+  PlayerReportResolveInput,
+  PlayerReportStatus,
+  RoomSnapshotStore
+} from "./persistence";
 import { listLobbyRooms, getActiveRoomInstances } from "./colyseus-room";
 import { recordLeaderboardAbuseAlert } from "./observability";
 import { readRuntimeSecret } from "./runtime-secrets";
@@ -170,6 +176,38 @@ function hasPlayerAccountStore(
   store: RoomSnapshotStore | null
 ): store is RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "loadPlayerAccount" | "savePlayerAccountProgress">> {
   return Boolean(store?.loadPlayerAccount && store.savePlayerAccountProgress);
+}
+
+type PlayerCompensationCurrency = "gems" | keyof ResourceLedger;
+type PlayerCompensationRequest = {
+  type: PlayerCompensationCreateInput["type"];
+  currency: PlayerCompensationCurrency;
+  amount: number;
+  reason: string;
+};
+type PlayerBalanceSnapshot = {
+  gems: number;
+  resources: ResourceLedger;
+};
+
+function hasPlayerCompensationStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore &
+  Required<
+    Pick<
+      RoomSnapshotStore,
+      | "loadPlayerAccount"
+      | "ensurePlayerAccount"
+      | "savePlayerAccountProgress"
+      | "appendPlayerCompensationRecord"
+      | "listPlayerCompensationHistory"
+    >
+  > {
+  return Boolean(
+    store &&
+      store.appendPlayerCompensationRecord &&
+      store.listPlayerCompensationHistory
+  );
 }
 
 function hasBattleSnapshotHistoryStore(
@@ -339,6 +377,34 @@ function parseResourceDeltaBody(value: unknown): ResourceLedger {
   };
 }
 
+function parseCompensationBody(value: unknown): PlayerCompensationRequest {
+  const payload = readRequiredObjectBody(value);
+  const type = readOptionalTrimmedString(payload, "type");
+  const currency = readOptionalTrimmedString(payload, "currency")?.toLowerCase();
+  const reason = readOptionalTrimmedString(payload, "reason");
+  const amount = payload.amount;
+
+  if (type !== "add" && type !== "deduct") {
+    throw new InvalidAdminPayloadError('"type" must be "add" or "deduct"');
+  }
+  if (currency !== "gems" && currency !== "gold" && currency !== "wood" && currency !== "ore") {
+    throw new InvalidAdminPayloadError('"currency" must be one of "gems", "gold", "wood", or "ore"');
+  }
+  if (typeof amount !== "number" || !Number.isFinite(amount) || !Number.isInteger(amount) || amount <= 0) {
+    throw new InvalidAdminPayloadError('"amount" must be a positive integer');
+  }
+  if (!reason) {
+    throw new InvalidAdminPayloadError('"reason" must be a non-empty string');
+  }
+
+  return {
+    type,
+    currency,
+    amount,
+    reason
+  };
+}
+
 function parseBroadcastBody(value: unknown): { message: string; type: string } {
   const payload = readRequiredObjectBody(value);
   const message = payload.message;
@@ -423,6 +489,128 @@ async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   }
 }
 
+function snapshotPlayerBalances(account: {
+  gems?: number;
+  globalResources?: Partial<ResourceLedger>;
+} | null): PlayerBalanceSnapshot {
+  return {
+    gems: Math.max(0, Math.floor(account?.gems ?? 0)),
+    resources: {
+      gold: Math.max(0, Math.floor(account?.globalResources?.gold ?? 0)),
+      wood: Math.max(0, Math.floor(account?.globalResources?.wood ?? 0)),
+      ore: Math.max(0, Math.floor(account?.globalResources?.ore ?? 0))
+    }
+  };
+}
+
+function applyCompensationToBalance(
+  current: PlayerBalanceSnapshot,
+  input: PlayerCompensationRequest
+): {
+  previousBalance: number;
+  next: PlayerBalanceSnapshot;
+} {
+  const previousBalance = input.currency === "gems" ? current.gems : current.resources[input.currency];
+  const delta = input.type === "add" ? input.amount : -input.amount;
+  const balanceAfter = Math.max(0, previousBalance + delta);
+
+  return {
+    previousBalance,
+    next: {
+      gems: input.currency === "gems" ? balanceAfter : current.gems,
+      resources:
+        input.currency === "gems"
+          ? { ...current.resources }
+          : {
+              ...current.resources,
+              [input.currency]: balanceAfter
+            }
+    }
+  };
+}
+
+function renderCompensationEvent(record: PlayerCompensationRecord): string {
+  const actionLabel = record.type === "deduct" ? "扣减" : "发放";
+  return `${actionLabel} ${record.currency} ${record.amount}（原因：${record.reason}，变更前 ${record.previousBalance}，变更后 ${record.balanceAfter}）`;
+}
+
+function buildCompensationEventEntry(
+  playerId: string,
+  record: PlayerCompensationRecord,
+  balances: PlayerBalanceSnapshot
+): {
+  id: string;
+  timestamp: string;
+  roomId: string;
+  playerId: string;
+  category: "account";
+  description: string;
+  rewards: [];
+} {
+  return {
+    id: `compensation:${record.auditId}`,
+    timestamp: record.createdAt,
+    roomId: "admin-console",
+    playerId,
+    category: "account",
+    description: `${renderCompensationEvent(record)}。当前余额：gems=${balances.gems}, gold=${balances.resources.gold}, wood=${balances.resources.wood}, ore=${balances.resources.ore}`,
+    rewards: []
+  };
+}
+
+function syncPlayerBalancesToActiveRooms(playerId: string, nextResources: ResourceLedger): boolean {
+  let syncedToRoom = false;
+  const activeRooms = getActiveRoomInstances();
+
+  for (const [roomId, vRoom] of activeRooms) {
+    if (vRoom.worldRoom) {
+      const roomInternals = vRoom as unknown as {
+        getPlayerId(client: { sessionId?: string }, fallback?: string): string | undefined;
+        buildStatePayload(
+          playerId: string,
+          extras?: {
+            events?: Array<{ type: "system.announcement"; text: string; tone: "system" }>;
+            movementPlan?: null;
+            reason?: string;
+          }
+        ): ServerMessage extends { type: "session.state"; payload: infer T } ? T : never;
+      };
+      const internalState = vRoom.worldRoom.getInternalState() as WorldState & {
+        playerResources?: Record<string, ResourceLedger>;
+      };
+
+      if (internalState.resources && internalState.resources[playerId]) {
+        internalState.resources[playerId] = { ...nextResources };
+      }
+
+      if (internalState.playerResources && internalState.playerResources[playerId]) {
+        internalState.playerResources[playerId] = { ...nextResources };
+      }
+
+      console.log(`[Admin] Patched room ${roomId} for ${playerId}:`, nextResources);
+
+      const snapshot = vRoom.worldRoom.getSnapshot(playerId);
+      snapshot.state.resources = { ...nextResources };
+
+      for (const client of vRoom.clients) {
+        const clientPlayerId = roomInternals.getPlayerId(client, playerId) ?? playerId;
+        client.send("session.state", {
+          requestId: "push",
+          delivery: "push",
+          payload: roomInternals.buildStatePayload(clientPlayerId, {
+            events: [{ type: "system.announcement", text: "资源已更新", tone: "system" }],
+            movementPlan: null
+          })
+        });
+      }
+
+      syncedToRoom = true;
+    }
+  }
+
+  return syncedToRoom;
+}
+
 export function registerAdminRoutes(
   app: AdminApp,
   store: RoomSnapshotStore | null,
@@ -490,55 +678,7 @@ export function registerAdminRoutes(
       };
 
       if (store) await store.savePlayerAccountProgress(playerId, { globalResources: nextResources });
-
-      let syncedToRoom = false;
-      const activeRooms = getActiveRoomInstances();
-
-      for (const [roomId, vRoom] of activeRooms) {
-        if (vRoom.worldRoom) {
-          const roomInternals = vRoom as unknown as {
-            getPlayerId(client: { sessionId?: string }, fallback?: string): string | undefined;
-            buildStatePayload(
-              playerId: string,
-              extras?: {
-                events?: Array<{ type: "system.announcement"; text: string; tone: "system" }>;
-                movementPlan?: null;
-                reason?: string;
-              }
-            ): ServerMessage extends { type: "session.state"; payload: infer T } ? T : never;
-          };
-          const internalState = vRoom.worldRoom.getInternalState() as WorldState & {
-            playerResources?: Record<string, ResourceLedger>;
-          };
-
-          if (internalState.resources && internalState.resources[playerId]) {
-            internalState.resources[playerId] = { ...nextResources };
-          }
-
-          if (internalState.playerResources && internalState.playerResources[playerId]) {
-            internalState.playerResources[playerId] = { ...nextResources };
-          }
-
-          console.log(`[Admin] Patched room ${roomId} for ${playerId}:`, nextResources);
-
-          const snapshot = vRoom.worldRoom.getSnapshot(playerId);
-          snapshot.state.resources = { ...nextResources };
-
-          for (const client of vRoom.clients) {
-            const clientPlayerId = roomInternals.getPlayerId(client, playerId) ?? playerId;
-            client.send("session.state", {
-              requestId: "push",
-              delivery: "push",
-              payload: roomInternals.buildStatePayload(clientPlayerId, {
-                events: [{ type: "system.announcement", text: "资源已更新", tone: "system" }],
-                movementPlan: null
-              })
-            });
-          }
-
-          syncedToRoom = true;
-        }
-      }
+      const syncedToRoom = syncPlayerBalancesToActiveRooms(playerId, nextResources);
 
       sendJson(response, 200, { ok: true, resources: nextResources, syncedToRoom });
     } catch (error) {
@@ -552,6 +692,72 @@ export function registerAdminRoutes(
       }
       console.error("[Admin] Sync error:", error);
       sendJson(response, 500, { error: String(error) });
+    }
+  });
+
+  app.post("/api/admin/players/:id/compensation", async (request, response) => {
+    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
+    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!hasPlayerCompensationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request, "id");
+      const input = parseCompensationBody(await readJsonBody(request));
+      const account = (await store.loadPlayerAccount(playerId)) ?? (await store.ensurePlayerAccount({ playerId, displayName: playerId }));
+      const currentBalances = snapshotPlayerBalances(account);
+      const { previousBalance, next } = applyCompensationToBalance(currentBalances, input);
+
+      const record = await store.appendPlayerCompensationRecord(playerId, {
+        type: input.type,
+        currency: input.currency,
+        amount: input.amount,
+        reason: input.reason,
+        previousBalance,
+        balanceAfter: input.currency === "gems" ? next.gems : next.resources[input.currency]
+      });
+      const updatedAccount = await store.savePlayerAccountProgress(playerId, {
+        gems: next.gems,
+        globalResources: next.resources,
+        recentEventLog: appendEventLogEntries(account.recentEventLog, [buildCompensationEventEntry(playerId, record, next)])
+      });
+      const balances = snapshotPlayerBalances(updatedAccount);
+      const syncedToRoom = syncPlayerBalancesToActiveRooms(playerId, balances.resources);
+
+      sendJson(response, 200, {
+        ok: true,
+        compensation: record,
+        balances,
+        syncedToRoom
+      });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      console.error("[Admin] Compensation error:", error);
+      sendJson(response, 500, { error: String(error) });
+    }
+  });
+
+  app.get("/api/admin/players/:id/compensation/history", async (request, response) => {
+    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
+    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!hasPlayerCompensationStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request as AdminRequest, "id");
+      const items = await store.listPlayerCompensationHistory(playerId, { limit: readLimit(request) });
+      sendJson(response, 200, { items });
+    } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
     }
   });
 

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -52,6 +52,9 @@ import {
   type PlayerAccountListOptions,
   type PlayerAccountUnbanInput,
   type PlayerBanHistoryRecord,
+  type PlayerCompensationCreateInput,
+  type PlayerCompensationListOptions,
+  type PlayerCompensationRecord,
   type PlayerAccountWechatMiniGameIdentityInput,
   type PlayerAccountProfilePatch,
   type PlayerAccountProgressPatch,
@@ -198,6 +201,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly paymentReceiptsByOrderId = new Map<string, PaymentReceiptSnapshot>();
   private readonly paymentReceiptOrderIdByTransactionId = new Map<string, string>();
   private readonly banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
+  private readonly compensationHistoryByPlayerId = new Map<string, PlayerCompensationRecord[]>();
   private readonly authByLoginId = new Map<string, PlayerAccountAuthSnapshot>();
   private readonly authSessionsByPlayerId = new Map<string, Map<string, PlayerAccountDeviceSessionSnapshot>>();
   private readonly playerIdByWechatOpenId = new Map<string, string>();
@@ -1394,6 +1398,37 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     const normalizedPlayerId = normalizePlayerId(playerId);
     const safeLimit = Math.max(1, Math.floor(options.limit ?? 20));
     return structuredClone((this.banHistoryByPlayerId.get(normalizedPlayerId) ?? []).slice(0, safeLimit));
+  }
+
+  async appendPlayerCompensationRecord(
+    playerId: string,
+    input: PlayerCompensationCreateInput
+  ): Promise<PlayerCompensationRecord> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const record: PlayerCompensationRecord = {
+      auditId: randomUUID(),
+      playerId: normalizedPlayerId,
+      type: input.type,
+      currency: input.currency,
+      amount: Math.max(1, Math.floor(input.amount)),
+      reason: input.reason.trim().slice(0, 512),
+      previousBalance: Math.max(0, Math.floor(input.previousBalance)),
+      balanceAfter: Math.max(0, Math.floor(input.balanceAfter)),
+      createdAt: new Date(input.createdAt ?? Date.now()).toISOString()
+    };
+    const history = this.compensationHistoryByPlayerId.get(normalizedPlayerId) ?? [];
+    history.unshift(record);
+    this.compensationHistoryByPlayerId.set(normalizedPlayerId, history);
+    return structuredClone(record);
+  }
+
+  async listPlayerCompensationHistory(
+    playerId: string,
+    options: PlayerCompensationListOptions = {}
+  ): Promise<PlayerCompensationRecord[]> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const safeLimit = Math.max(1, Math.floor(options.limit ?? 20));
+    return structuredClone((this.compensationHistoryByPlayerId.get(normalizedPlayerId) ?? []).slice(0, safeLimit));
   }
 
   async savePlayerBan(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot> {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -216,6 +216,14 @@ export interface RoomSnapshotStore {
   loadPlayerAccounts(playerIds: string[]): Promise<PlayerAccountSnapshot[]>;
   listPlayerReports?(options?: PlayerReportListOptions): Promise<PlayerReportRecord[]>;
   listPlayerBanHistory?(playerId: string, options?: PlayerAccountBanHistoryListOptions): Promise<PlayerBanHistoryRecord[]>;
+  appendPlayerCompensationRecord?(
+    playerId: string,
+    input: PlayerCompensationCreateInput
+  ): Promise<PlayerCompensationRecord>;
+  listPlayerCompensationHistory?(
+    playerId: string,
+    options?: PlayerCompensationListOptions
+  ): Promise<PlayerCompensationRecord[]>;
   loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerAccountAuthByPlayerId(playerId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerHeroArchives(playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]>;
@@ -427,6 +435,18 @@ interface PlayerNameHistoryRow extends RowDataPacket {
   display_name: string;
   normalized_name: string;
   changed_at: Date | string;
+  created_at: Date | string;
+}
+
+interface PlayerCompensationHistoryRow extends RowDataPacket {
+  audit_id: string;
+  player_id: string;
+  type: PlayerCompensationType;
+  currency: PlayerCompensationRecord["currency"];
+  amount: number;
+  reason: string;
+  previous_balance: number;
+  balance_after: number;
   created_at: Date | string;
 }
 
@@ -1027,6 +1047,34 @@ export interface PlayerAccountBanHistoryListOptions {
   limit?: number;
 }
 
+export type PlayerCompensationType = "add" | "deduct";
+
+export interface PlayerCompensationRecord {
+  auditId: string;
+  playerId: string;
+  type: PlayerCompensationType;
+  currency: "gems" | keyof ResourceLedger;
+  amount: number;
+  reason: string;
+  previousBalance: number;
+  balanceAfter: number;
+  createdAt: string;
+}
+
+export interface PlayerCompensationCreateInput {
+  type: PlayerCompensationType;
+  currency: "gems" | keyof ResourceLedger;
+  amount: number;
+  reason: string;
+  previousBalance: number;
+  balanceAfter: number;
+  createdAt?: string;
+}
+
+export interface PlayerCompensationListOptions {
+  limit?: number;
+}
+
 export interface PlayerRoomProfileListOptions {
   limit?: number;
   roomId?: string;
@@ -1059,6 +1107,8 @@ export const MYSQL_PLAYER_ACCOUNT_SESSION_TABLE = "player_account_sessions";
 export const MYSQL_PLAYER_ACCOUNT_SESSION_PLAYER_LAST_USED_INDEX = "idx_player_account_sessions_player_last_used";
 export const MYSQL_PLAYER_BAN_HISTORY_TABLE = "player_ban_history";
 export const MYSQL_PLAYER_BAN_HISTORY_PLAYER_CREATED_INDEX = "idx_player_ban_history_player_created";
+export const MYSQL_PLAYER_COMPENSATION_HISTORY_TABLE = "player_compensation_history";
+export const MYSQL_PLAYER_COMPENSATION_HISTORY_PLAYER_CREATED_INDEX = "idx_player_compensation_history_player_created";
 export const MYSQL_PLAYER_NAME_HISTORY_TABLE = "player_name_history";
 export const MYSQL_PLAYER_NAME_HISTORY_PLAYER_CHANGED_INDEX = "idx_player_name_history_player_changed";
 export const MYSQL_PLAYER_NAME_HISTORY_NORMALIZED_CHANGED_INDEX = "idx_player_name_history_normalized_changed";
@@ -2677,6 +2727,19 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_BAN_HISTORY_TABLE}\` (
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_COMPENSATION_HISTORY_TABLE}\` (
+  audit_id VARCHAR(191) NOT NULL,
+  player_id VARCHAR(191) NOT NULL,
+  type VARCHAR(16) NOT NULL,
+  currency VARCHAR(16) NOT NULL,
+  amount INT NOT NULL,
+  reason VARCHAR(512) NOT NULL,
+  previous_balance INT NOT NULL,
+  balance_after INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (audit_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_EVENT_HISTORY_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
   event_id VARCHAR(191) NOT NULL,
@@ -3874,6 +3937,24 @@ PREPARE veil_player_ban_history_idx_stmt FROM @veil_player_ban_history_idx_sql;
 EXECUTE veil_player_ban_history_idx_stmt;
 DEALLOCATE PREPARE veil_player_ban_history_idx_stmt;
 
+SET @veil_player_compensation_history_idx_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = '${MYSQL_PLAYER_COMPENSATION_HISTORY_TABLE}'
+    AND INDEX_NAME = '${MYSQL_PLAYER_COMPENSATION_HISTORY_PLAYER_CREATED_INDEX}'
+);
+
+SET @veil_player_compensation_history_idx_sql := IF(
+  @veil_player_compensation_history_idx_exists = 0,
+  'CREATE INDEX \`${MYSQL_PLAYER_COMPENSATION_HISTORY_PLAYER_CREATED_INDEX}\` ON \`${MYSQL_PLAYER_COMPENSATION_HISTORY_TABLE}\` (player_id, created_at DESC)',
+  'SELECT 1'
+);
+
+PREPARE veil_player_compensation_history_idx_stmt FROM @veil_player_compensation_history_idx_sql;
+EXECUTE veil_player_compensation_history_idx_stmt;
+DEALLOCATE PREPARE veil_player_compensation_history_idx_stmt;
+
 CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_HERO_ARCHIVE_TABLE}\` (
   player_id VARCHAR(191) NOT NULL,
   hero_id VARCHAR(191) NOT NULL,
@@ -4350,6 +4431,32 @@ function toPlayerBanHistoryRecord(row: PlayerBanHistoryRow): PlayerBanHistoryRec
   };
 }
 
+function normalizePlayerCompensationCurrency(value: string): PlayerCompensationRecord["currency"] {
+  if (value === "gems" || value === "gold" || value === "wood" || value === "ore") {
+    return value;
+  }
+  throw new Error("player compensation currency must be gems, gold, wood, or ore");
+}
+
+function toPlayerCompensationRecord(row: PlayerCompensationHistoryRow): PlayerCompensationRecord {
+  const createdAt = formatTimestamp(row.created_at);
+  if (!createdAt) {
+    throw new Error("player compensation history created_at must be present");
+  }
+
+  return {
+    auditId: row.audit_id,
+    playerId: normalizePlayerId(row.player_id),
+    type: row.type === "deduct" ? "deduct" : "add",
+    currency: normalizePlayerCompensationCurrency(row.currency),
+    amount: Math.max(0, Math.floor(row.amount)),
+    reason: row.reason.trim(),
+    previousBalance: Math.max(0, Math.floor(row.previous_balance)),
+    balanceAfter: Math.max(0, Math.floor(row.balance_after)),
+    createdAt
+  };
+}
+
 function toPlayerNameHistoryRecord(row: PlayerNameHistoryRow): PlayerNameHistoryRecord {
   const changedAt = formatTimestamp(row.changed_at) ?? formatTimestamp(row.created_at);
   if (!changedAt) {
@@ -4500,6 +4607,58 @@ async function appendPlayerBanHistoryEntry(
      VALUES (?, ?, ?, ?, ?)`,
     [playerId, entry.action, entry.banStatus, banExpiry, entry.banReason ?? null]
   );
+}
+
+async function appendPlayerCompensationHistoryEntry(
+  queryable: Pick<Pool, "query"> | Pick<PoolConnection, "query">,
+  playerId: string,
+  input: PlayerCompensationCreateInput
+): Promise<PlayerCompensationRecord> {
+  const auditId = randomUUID();
+  const createdAt = new Date(input.createdAt ?? Date.now());
+  if (Number.isNaN(createdAt.getTime())) {
+    throw new Error("createdAt must be a valid ISO timestamp");
+  }
+
+  const record: PlayerCompensationRecord = {
+    auditId,
+    playerId: normalizePlayerId(playerId),
+    type: input.type,
+    currency: input.currency,
+    amount: Math.max(1, Math.floor(input.amount)),
+    reason: input.reason.trim().slice(0, 512),
+    previousBalance: Math.max(0, Math.floor(input.previousBalance)),
+    balanceAfter: Math.max(0, Math.floor(input.balanceAfter)),
+    createdAt: createdAt.toISOString()
+  };
+
+  await queryable.query(
+    `INSERT INTO \`${MYSQL_PLAYER_COMPENSATION_HISTORY_TABLE}\` (
+       audit_id,
+       player_id,
+       type,
+       currency,
+       amount,
+       reason,
+       previous_balance,
+       balance_after,
+       created_at
+     )
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      record.auditId,
+      record.playerId,
+      record.type,
+      record.currency,
+      record.amount,
+      record.reason,
+      record.previousBalance,
+      record.balanceAfter,
+      createdAt
+    ]
+  );
+
+  return record;
 }
 
 async function appendPlayerNameHistoryEntry(
@@ -6030,6 +6189,40 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     );
 
     return rows.map((row) => toPlayerBanHistoryRecord(row));
+  }
+
+  async appendPlayerCompensationRecord(
+    playerId: string,
+    input: PlayerCompensationCreateInput
+  ): Promise<PlayerCompensationRecord> {
+    return appendPlayerCompensationHistoryEntry(this.pool, normalizePlayerId(playerId), input);
+  }
+
+  async listPlayerCompensationHistory(
+    playerId: string,
+    options: PlayerCompensationListOptions = {}
+  ): Promise<PlayerCompensationRecord[]> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const safeLimit = Math.max(1, Math.floor(options.limit ?? 20));
+    const [rows] = await this.pool.query<PlayerCompensationHistoryRow[]>(
+      `SELECT
+         audit_id,
+         player_id,
+         type,
+         currency,
+         amount,
+         reason,
+         previous_balance,
+         balance_after,
+         created_at
+       FROM \`${MYSQL_PLAYER_COMPENSATION_HISTORY_TABLE}\`
+       WHERE player_id = ?
+       ORDER BY created_at DESC, audit_id DESC
+       LIMIT ?`,
+      [normalizedPlayerId, safeLimit]
+    );
+
+    return rows.map((row) => toPlayerCompensationRecord(row));
   }
 
   async listPlayerNameHistory(

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import test, { type TestContext } from "node:test";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { readFile } from "node:fs/promises";
 import { normalizeGuildState, type GuildState } from "../../../packages/shared/src/index";
 import { registerAdminRoutes } from "../src/admin-console";
 import { getActiveRoomInstances } from "../src/colyseus-room";
-import type { PlayerBanHistoryRecord, RoomSnapshotStore } from "../src/persistence";
+import type { PlayerBanHistoryRecord, PlayerCompensationRecord, RoomSnapshotStore } from "../src/persistence";
 
 type RouteHandler = (request: any, response: ServerResponse) => void | Promise<void>;
 
@@ -137,6 +138,7 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     ])
   );
   const banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
+  const compensationHistoryByPlayerId = new Map<string, PlayerCompensationRecord[]>();
   const reports = new Map<string, {
     reportId: string;
     reporterId: string;
@@ -280,8 +282,10 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     async savePlayerAccountProgress(
       playerId: string,
       patch: {
+        gems?: number;
         globalResources?: { gold: number; wood: number; ore: number };
         leaderboardModerationState?: Record<string, unknown>;
+        recentEventLog?: Array<Record<string, unknown>>;
       }
     ) {
       const account =
@@ -290,6 +294,9 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
           playerId,
           displayName: playerId
         }));
+      if (patch.gems !== undefined) {
+        account.gems = patch.gems;
+      }
       account.globalResources = { ...account.globalResources, ...patch.globalResources };
       if (patch.leaderboardModerationState) {
         account.leaderboardModerationState = {
@@ -297,8 +304,41 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
           ...patch.leaderboardModerationState
         };
       }
+      if (patch.recentEventLog) {
+        account.recentEventLog = [...patch.recentEventLog];
+      }
       saveCalls.push({ playerId, globalResources: { ...account.globalResources } });
       return account;
+    },
+    async appendPlayerCompensationRecord(
+      playerId: string,
+      input: {
+        type: "add" | "deduct";
+        currency: "gems" | "gold" | "wood" | "ore";
+        amount: number;
+        reason: string;
+        previousBalance: number;
+        balanceAfter: number;
+      }
+    ) {
+      const history = compensationHistoryByPlayerId.get(playerId) ?? [];
+      const record = {
+        auditId: `comp-${history.length + 1}`,
+        playerId,
+        type: input.type,
+        currency: input.currency,
+        amount: input.amount,
+        reason: input.reason,
+        previousBalance: input.previousBalance,
+        balanceAfter: input.balanceAfter,
+        createdAt: new Date().toISOString()
+      } satisfies PlayerCompensationRecord;
+      history.unshift(record);
+      compensationHistoryByPlayerId.set(playerId, history);
+      return record;
+    },
+    async listPlayerCompensationHistory(playerId: string, options: { limit?: number } = {}) {
+      return (compensationHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
     },
     async savePlayerBan(playerId: string, input: { banStatus: "temporary" | "permanent"; banReason: string; banExpiry?: string }) {
       const account =
@@ -404,6 +444,8 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     | "savePlayerBan"
     | "clearPlayerBan"
     | "listPlayerBanHistory"
+    | "appendPlayerCompensationRecord"
+    | "listPlayerCompensationHistory"
     | "listBattleSnapshotsForPlayer"
     | "listPlayerReports"
     | "resolvePlayerReport"
@@ -667,6 +709,225 @@ test("POST /api/admin/players/:id/resources adds and clamps resources and syncs 
   assert.deepEqual(buildStatePayloadCalls, ["player-1", "player-2"]);
   assert.equal(sentMessages.length, 2);
   assert.equal(sentMessages[0]?.type, "session.state");
+});
+
+test("POST /api/admin/players/:id/compensation returns 400 for invalid payloads", async (t) => {
+  const secret = withAdminSecret(t);
+  const { posts } = registerRoutes(createStore() as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/compensation");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-1" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({ type: "grant", currency: "credits", amount: 0, reason: "" })
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), { error: '"type" must be "add" or "deduct"' });
+});
+
+test("POST /api/admin/players/:id/compensation adds gems, writes audit history, and returns balances", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore({
+    "player-1": { gold: 10, wood: 4, ore: 1 }
+  });
+  const existing = await store.ensurePlayerAccount({ playerId: "player-1", displayName: "player-1" });
+  existing.gems = 25;
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/compensation");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-1" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({
+        type: "add",
+        currency: "gems",
+        amount: 40,
+        reason: "Failed payment refund"
+      })
+    }),
+    response
+  );
+
+  const payload = JSON.parse(response.body) as {
+    ok: true;
+    compensation: PlayerCompensationRecord;
+    balances: { gems: number; resources: { gold: number; wood: number; ore: number } };
+    syncedToRoom: boolean;
+  };
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.compensation.type, "add");
+  assert.equal(payload.compensation.currency, "gems");
+  assert.equal(payload.compensation.amount, 40);
+  assert.equal(payload.compensation.previousBalance, 25);
+  assert.equal(payload.compensation.balanceAfter, 65);
+  assert.equal(payload.compensation.reason, "Failed payment refund");
+  assert.equal(payload.balances.gems, 65);
+  assert.deepEqual(payload.balances.resources, { gold: 10, wood: 4, ore: 1 });
+  assert.equal(payload.syncedToRoom, false);
+
+  const history = await store.listPlayerCompensationHistory("player-1");
+  assert.equal(history.length, 1);
+  assert.equal(history[0]?.reason, "Failed payment refund");
+  assert.equal((await store.loadPlayerAccount("player-1"))?.recentEventLog?.[0]?.category, "account");
+  assert.match((await store.loadPlayerAccount("player-1"))?.recentEventLog?.[0]?.description ?? "", /Failed payment refund/);
+});
+
+test("POST /api/admin/players/:id/compensation deducts resources with clamping and syncs rooms", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore({
+    "player-1": { gold: 10, wood: 4, ore: 1 }
+  });
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/compensation");
+  assert.ok(handler);
+
+  const internalState = {
+    resources: {
+      "player-1": { gold: 10, wood: 4, ore: 1 }
+    },
+    playerResources: {
+      "player-1": { gold: 10, wood: 4, ore: 1 }
+    }
+  };
+  const snapshot = {
+    state: {
+      resources: { gold: 10, wood: 4, ore: 1 }
+    }
+  };
+
+  getActiveRoomInstances().set("room-alpha", {
+    getPlayerId() {
+      return "player-1";
+    },
+    buildStatePayload() {
+      return {
+        world: {
+          playerId: "player-1",
+          resources: { gold: 0, wood: 4, ore: 1 }
+        },
+        battle: null,
+        events: [{ type: "system.announcement", text: "资源已更新", tone: "system" }],
+        movementPlan: null,
+        reachableTiles: [],
+        featureFlags: {
+          quest_system_enabled: false,
+          battle_pass_enabled: false,
+          pve_enabled: true,
+          tutorial_enabled: false
+        }
+      };
+    },
+    worldRoom: {
+      getInternalState() {
+        return internalState;
+      },
+      getSnapshot() {
+        return snapshot;
+      }
+    },
+    clients: [
+      {
+        send() {}
+      }
+    ]
+  } as never);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-1" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      body: JSON.stringify({
+        type: "deduct",
+        currency: "gold",
+        amount: 25,
+        reason: "Reverse erroneous grant"
+      })
+    }),
+    response
+  );
+
+  const payload = JSON.parse(response.body) as {
+    balances: { gems: number; resources: { gold: number; wood: number; ore: number } };
+    syncedToRoom: boolean;
+  };
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(payload.balances.resources, { gold: 0, wood: 4, ore: 1 });
+  assert.equal(payload.syncedToRoom, true);
+  assert.deepEqual(internalState.resources["player-1"], { gold: 0, wood: 4, ore: 1 });
+  assert.deepEqual(snapshot.state.resources, { gold: 0, wood: 4, ore: 1 });
+});
+
+test("GET /api/admin/players/:id/compensation/history returns compensation audit records", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore({
+    "player-1": { gold: 10, wood: 4, ore: 1 }
+  });
+  await store.appendPlayerCompensationRecord("player-1", {
+    type: "add",
+    currency: "gold",
+    amount: 15,
+    reason: "Outage compensation",
+    previousBalance: 10,
+    balanceAfter: 25
+  });
+  await store.appendPlayerCompensationRecord("player-1", {
+    type: "deduct",
+    currency: "gems",
+    amount: 5,
+    reason: "Chargeback reversal",
+    previousBalance: 20,
+    balanceAfter: 15
+  });
+
+  const { gets } = registerRoutes(store as RoomSnapshotStore);
+  const handler = gets.get("/api/admin/players/:id/compensation/history");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      params: { id: "player-1" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      url: "/api/admin/players/player-1/compensation/history?limit=2"
+    }),
+    response
+  );
+
+  const payload = JSON.parse(response.body) as { items: PlayerCompensationRecord[] };
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.items.length, 2);
+  assert.equal(payload.items[0]?.reason, "Chargeback reversal");
+  assert.equal(payload.items[1]?.reason, "Outage compensation");
+});
+
+test("admin console html includes compensation form and history table", async () => {
+  const html = await readFile("/home/gpt/project/ProjectVeil/apps/client/admin.html", "utf8");
+  assert.match(html, /玩家补偿 \/ 退款/);
+  assert.match(html, /compensationHistoryBody/);
+  assert.match(html, /submitCompensation/);
+  assert.match(html, /fetchCompensationHistory/);
 });
 
 test("POST /api/admin/broadcast returns 401 without a valid admin secret", async (t) => {


### PR DESCRIPTION
## Summary
- add admin compensation and refund endpoints with persisted audit history
- update the admin console html to submit compensation actions and render history
- cover add, deduct, history, and admin html behavior with focused tests

## Testing
- node --import tsx --test apps/server/test/admin-console.test.ts
- npm run typecheck:server

Closes #1331