### PR TITLE
[codex] Add leaderboard abuse admin endpoints

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { appendEventLogEntries, type ResourceLedger, type ServerMessage, type WorldState } from "../../../packages/shared/src/index";
+import { appendEventLogEntries, type EventLogEntry, type ResourceLedger, type ServerMessage, type WorldState } from "../../../packages/shared/src/index";
 import { GuildService } from "./guilds";
 import type {
   PlayerCompensationCreateInput,
@@ -35,6 +35,7 @@ type AdminApp = {
   use: (handler: AdminMiddleware) => void;
   get: (path: string, handler: AdminRouteHandler) => void;
   post: (path: string, handler: AdminRouteHandler) => void;
+  delete: (path: string, handler: AdminRouteHandler) => void;
 };
 type AdminRole = "admin" | "support-moderator" | "support-supervisor";
 type BanApproval = {
@@ -105,7 +106,7 @@ function sendJson(response: ServerResponse, statusCode: number, payload: unknown
   response.statusCode = statusCode;
   response.setHeader("Content-Type", "application/json; charset=utf-8");
   response.setHeader("Access-Control-Allow-Origin", "*");
-  response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+  response.setHeader("Access-Control-Allow-Methods", "GET,POST,DELETE,OPTIONS");
   response.setHeader("Access-Control-Allow-Headers", "Content-Type, x-veil-admin-secret");
   response.end(JSON.stringify(payload));
 }
@@ -368,6 +369,187 @@ function readLimit(request: IncomingMessage, fallback = 20): number {
   return Math.max(1, Math.floor(parsed));
 }
 
+function readPage(request: IncomingMessage, fallback = 1): number {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const parsed = Number(url.searchParams.get("page"));
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(parsed));
+}
+
+type LeaderboardQueueFlagType =
+  | "daily_gain_cap_hit"
+  | "repeated_opponent_gain_cap_hit"
+  | "repeated_opponent_watch"
+  | "watch"
+  | "flagged"
+  | "frozen";
+
+const LEADERBOARD_QUEUE_FLAG_TYPES = new Set<LeaderboardQueueFlagType>([
+  "daily_gain_cap_hit",
+  "repeated_opponent_gain_cap_hit",
+  "repeated_opponent_watch",
+  "watch",
+  "flagged",
+  "frozen"
+]);
+
+function readLeaderboardQueueFlagType(request: IncomingMessage): LeaderboardQueueFlagType | undefined {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const raw = url.searchParams.get("flagType")?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  if (!LEADERBOARD_QUEUE_FLAG_TYPES.has(raw as LeaderboardQueueFlagType)) {
+    throw new InvalidAdminPayloadError(
+      '"flagType" must be one of "daily_gain_cap_hit", "repeated_opponent_gain_cap_hit", "repeated_opponent_watch", "watch", "flagged", or "frozen"'
+    );
+  }
+  return raw as LeaderboardQueueFlagType;
+}
+
+function getLeaderboardQueueFlagTypes(account: {
+  leaderboardAbuseState?: {
+    status?: "clear" | "watch" | "flagged";
+    lastAlertReasons?: string[];
+  };
+  leaderboardModerationState?: {
+    frozenAt?: string;
+  };
+}): LeaderboardQueueFlagType[] {
+  const flags = new Set<LeaderboardQueueFlagType>();
+  for (const reason of account.leaderboardAbuseState?.lastAlertReasons ?? []) {
+    if (LEADERBOARD_QUEUE_FLAG_TYPES.has(reason as LeaderboardQueueFlagType)) {
+      flags.add(reason as LeaderboardQueueFlagType);
+    }
+  }
+  if (account.leaderboardAbuseState?.status === "watch" || account.leaderboardAbuseState?.status === "flagged") {
+    flags.add(account.leaderboardAbuseState.status);
+  }
+  if (account.leaderboardModerationState?.frozenAt) {
+    flags.add("frozen");
+  }
+  return Array.from(flags);
+}
+
+function getLeaderboardQueueLastFlagAt(account: {
+  leaderboardAbuseState?: { lastAlertAt?: string };
+  leaderboardModerationState?: { frozenAt?: string };
+  updatedAt?: string;
+}): string {
+  return (
+    [account.leaderboardAbuseState?.lastAlertAt, account.leaderboardModerationState?.frozenAt, account.updatedAt]
+      .filter((value): value is string => Boolean(value))
+      .sort((left, right) => right.localeCompare(left))[0] ?? new Date(0).toISOString()
+  );
+}
+
+function mapAbuseReasonToAlertType(reason: string): string {
+  switch (reason) {
+    case "daily_gain_cap_hit":
+      return "leaderboard_daily_gain_cap";
+    case "repeated_opponent_gain_cap_hit":
+      return "leaderboard_repeated_opponent_gain_cap";
+    case "repeated_opponent_watch":
+      return "leaderboard_repeated_opponent_watch";
+    default:
+      return reason;
+  }
+}
+
+function describeLeaderboardAbuseReason(reason: string): string {
+  switch (reason) {
+    case "daily_gain_cap_hit":
+      return "Player hit the leaderboard daily ELO gain cap.";
+    case "repeated_opponent_gain_cap_hit":
+      return "Player hit the repeated-opponent ELO gain cap.";
+    case "repeated_opponent_watch":
+      return "Player was flagged for repeated-opponent farming watch.";
+    case "frozen_match_skipped":
+      return "A leaderboard settlement was skipped because the player was frozen.";
+    default:
+      return reason;
+  }
+}
+
+function buildLeaderboardModerationEventEntry(input: {
+  playerId: string;
+  action: "frozen" | "freeze_cleared";
+  actorPlayerId: string;
+  occurredAt: string;
+  reason?: string | undefined;
+}): EventLogEntry {
+  const actionLabel = input.action === "frozen" ? "冻结排行榜结算" : "解除排行榜冻结";
+  return {
+    id: `leaderboard:${input.action}:${input.occurredAt}:${input.playerId}`,
+    timestamp: input.occurredAt,
+    roomId: "admin-console",
+    playerId: input.playerId,
+    category: "account",
+    description: `${actionLabel}（操作人：${input.actorPlayerId}${input.reason ? `，原因：${input.reason}` : ""}）`,
+    rewards: []
+  };
+}
+
+function buildLeaderboardAlertHistory(account: {
+  playerId: string;
+  leaderboardAbuseState?: {
+    lastAlertAt?: string;
+    lastAlertReasons?: string[];
+  };
+  leaderboardModerationState?: {
+    frozenAt?: string;
+    frozenByPlayerId?: string;
+    freezeReason?: string;
+  };
+  recentEventLog?: EventLogEntry[];
+}): Array<{
+  type: string;
+  at: string;
+  detail: string;
+  source: "abuse-state" | "event-log" | "moderation-state";
+}> {
+  const history: Array<{
+    type: string;
+    at: string;
+    detail: string;
+    source: "abuse-state" | "event-log" | "moderation-state";
+  }> = (account.recentEventLog ?? [])
+    .filter((entry) => entry.id.startsWith("leaderboard:"))
+    .map((entry) => {
+      const action = entry.id.split(":")[1] ?? "event";
+      return {
+        type: action,
+        at: entry.timestamp,
+        detail: entry.description,
+        source: "event-log" as const
+      };
+    });
+
+  if (account.leaderboardModerationState?.frozenAt) {
+    history.push({
+      type: "frozen",
+      at: account.leaderboardModerationState.frozenAt,
+      detail: `Leaderboard frozen by ${account.leaderboardModerationState.frozenByPlayerId ?? "unknown"}${
+        account.leaderboardModerationState.freezeReason ? ` (${account.leaderboardModerationState.freezeReason})` : ""
+      }.`,
+      source: "moderation-state"
+    });
+  }
+
+  for (const reason of account.leaderboardAbuseState?.lastAlertReasons ?? []) {
+    history.push({
+      type: mapAbuseReasonToAlertType(reason),
+      at: account.leaderboardAbuseState?.lastAlertAt ?? new Date(0).toISOString(),
+      detail: describeLeaderboardAbuseReason(reason),
+      source: "abuse-state"
+    });
+  }
+
+  return history.sort((left, right) => right.at.localeCompare(left.at) || right.type.localeCompare(left.type));
+}
+
 function parseResourceDeltaBody(value: unknown): ResourceLedger {
   const payload = readRequiredObjectBody(value);
   return {
@@ -482,8 +664,12 @@ async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   for await (const chunk of request) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
+  const raw = Buffer.concat(chunks).toString("utf8").trim();
+  if (!raw) {
+    return undefined;
+  }
   try {
-    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    return JSON.parse(raw);
   } catch (error) {
     throw new InvalidAdminJsonError();
   }
@@ -609,6 +795,13 @@ function syncPlayerBalancesToActiveRooms(playerId: string, nextResources: Resour
   }
 
   return syncedToRoom;
+}
+
+function hasLeaderboardModerationQueueStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore &
+  Required<Pick<RoomSnapshotStore, "listPlayerAccounts">> {
+  return Boolean(store?.listPlayerAccounts);
 }
 
 export function registerAdminRoutes(
@@ -972,20 +1165,31 @@ export function registerAdminRoutes(
       const playerId = readRequiredParam(request, "id");
       const input = parseGuildModerationBody(await readJsonBody(request));
       const account = (await store.loadPlayerAccount(playerId)) ?? (await store.ensurePlayerAccount({ playerId }));
+      const frozenAt = new Date().toISOString();
+      const actorPlayerId = `${role}:admin-console`;
       const leaderboardModerationState = {
         ...(account.leaderboardModerationState ?? {}),
-        frozenAt: new Date().toISOString(),
-        frozenByPlayerId: `${role}:admin-console`,
+        frozenAt,
+        frozenByPlayerId: actorPlayerId,
         ...(input.reason ? { freezeReason: input.reason } : {})
       };
       const updatedAccount = await store.savePlayerAccountProgress(playerId, {
-        leaderboardModerationState
+        leaderboardModerationState,
+        recentEventLog: appendEventLogEntries(account.recentEventLog, [
+          buildLeaderboardModerationEventEntry({
+            playerId,
+            action: "frozen",
+            actorPlayerId,
+            occurredAt: frozenAt,
+            reason: input.reason
+          })
+        ])
       });
       recordLeaderboardAbuseAlert({
         type: "leaderboard_frozen_player_match",
         playerId,
         at: leaderboardModerationState.frozenAt,
-        detail: `Leaderboard frozen by ${role}:admin-console${input.reason ? ` (${input.reason})` : ""}.`
+        detail: `Leaderboard frozen by ${actorPlayerId}${input.reason ? ` (${input.reason})` : ""}.`
       });
       sendJson(response, 200, { ok: true, account: updatedAccount });
     } catch (error) {
@@ -993,6 +1197,134 @@ export function registerAdminRoutes(
         sendInvalidJson(response);
         return;
       }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.get("/api/admin/players/:id/leaderboard/abuse-state", async (request, response) => {
+    if (!requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"])) return;
+    if (!hasPlayerAccountStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request, "id");
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, { error: "Player account not found" });
+        return;
+      }
+
+      sendJson(response, 200, {
+        playerId,
+        abuseState: account.leaderboardAbuseState ?? { status: "clear" },
+        moderationState: account.leaderboardModerationState ?? {},
+        alertHistory: buildLeaderboardAlertHistory(account)
+      });
+    } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.delete("/api/admin/players/:id/leaderboard/freeze", async (request, response) => {
+    const role = requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"]);
+    if (!role) return;
+    if (!hasPlayerAccountStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request, "id");
+      const account = await store.loadPlayerAccount(playerId);
+      if (!account) {
+        sendJson(response, 404, { error: "Player account not found" });
+        return;
+      }
+
+      const input = parseGuildModerationBody(await readJsonBody(request));
+      const clearedAt = new Date().toISOString();
+      const actorPlayerId = `${role}:admin-console`;
+      const previousModerationState = account.leaderboardModerationState ?? {};
+      const leaderboardModerationState = {
+        ...(previousModerationState.hiddenAt ? { hiddenAt: previousModerationState.hiddenAt } : {}),
+        ...(previousModerationState.hiddenByPlayerId ? { hiddenByPlayerId: previousModerationState.hiddenByPlayerId } : {}),
+        ...(previousModerationState.hiddenReason ? { hiddenReason: previousModerationState.hiddenReason } : {})
+      };
+      const updatedAccount = await store.savePlayerAccountProgress(playerId, {
+        leaderboardModerationState,
+        recentEventLog: appendEventLogEntries(account.recentEventLog, [
+          buildLeaderboardModerationEventEntry({
+            playerId,
+            action: "freeze_cleared",
+            actorPlayerId,
+            occurredAt: clearedAt,
+            reason: input.reason
+          })
+        ])
+      });
+
+      sendJson(response, 200, {
+        ok: true,
+        account: updatedAccount,
+        audit: {
+          action: "freeze_cleared",
+          actorPlayerId,
+          occurredAt: clearedAt,
+          ...(input.reason ? { reason: input.reason } : {})
+        }
+      });
+    } catch (error) {
+      if (error instanceof InvalidAdminJsonError) {
+        sendInvalidJson(response);
+        return;
+      }
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.get("/api/admin/leaderboard/moderation-queue", async (request, response) => {
+    if (!requireSupportRole(response, request, ["admin", "support-moderator", "support-supervisor"])) return;
+    if (!hasLeaderboardModerationQueueStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const limit = readLimit(request, 20);
+      const page = readPage(request, 1);
+      const flagType = readLeaderboardQueueFlagType(request);
+      const accounts = await store.listPlayerAccounts({ limit: 10_000, offset: 0 });
+      const queue = accounts
+        .map((account) => ({
+          playerId: account.playerId,
+          displayName: account.displayName,
+          eloRating: account.eloRating ?? 1000,
+          abuseState: account.leaderboardAbuseState ?? { status: "clear" as const },
+          moderationState: account.leaderboardModerationState ?? {},
+          flagTypes: getLeaderboardQueueFlagTypes(account),
+          lastFlagAt: getLeaderboardQueueLastFlagAt(account)
+        }))
+        .filter((item) => item.flagTypes.length > 0)
+        .filter((item) => !flagType || item.flagTypes.includes(flagType))
+        .sort((left, right) => right.lastFlagAt.localeCompare(left.lastFlagAt) || left.playerId.localeCompare(right.playerId));
+
+      const total = queue.length;
+      const totalPages = Math.max(1, Math.ceil(total / limit));
+      const offset = (page - 1) * limit;
+      sendJson(response, 200, {
+        items: queue.slice(offset, offset + limit),
+        page,
+        limit,
+        total,
+        totalPages,
+        ...(flagType ? { flagType } : {})
+      });
+    } catch (error) {
       if (error instanceof InvalidAdminPayloadError) {
         sendInvalidPayload(response, error.message);
         return;

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -12,6 +12,7 @@ type RouteHandler = (request: any, response: ServerResponse) => void | Promise<v
 function createTestApp() {
   const gets = new Map<string, RouteHandler>();
   const posts = new Map<string, RouteHandler>();
+  const deletes = new Map<string, RouteHandler>();
 
   return {
     app: {
@@ -21,10 +22,14 @@ function createTestApp() {
       },
       post(path: string, handler: RouteHandler) {
         posts.set(path, handler);
+      },
+      delete(path: string, handler: RouteHandler) {
+        deletes.set(path, handler);
       }
     },
     gets,
-    posts
+    posts,
+    deletes
   };
 }
 
@@ -121,9 +126,9 @@ function withSupportSecrets(
 }
 
 function registerRoutes(store: RoomSnapshotStore | null = null) {
-  const { app, gets, posts } = createTestApp();
+  const { app, gets, posts, deletes } = createTestApp();
   registerAdminRoutes(app, store);
-  return { gets, posts };
+  return { gets, posts, deletes };
 }
 
 function createStore(initialResourcesByPlayer: Record<string, { gold: number; wood: number; ore: number }> = {}) {
@@ -175,6 +180,14 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     saveCalls,
     async loadPlayerAccount(playerId: string) {
       return accounts.get(playerId) ?? null;
+    },
+    async listPlayerAccounts(options: { limit?: number; offset?: number } = {}) {
+      const safeLimit = Math.max(1, Math.floor(options.limit ?? 20));
+      const safeOffset = Math.max(0, Math.floor(options.offset ?? 0));
+      return Array.from(accounts.values())
+        .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")))
+        .slice(safeOffset, safeOffset + safeLimit)
+        .map((account) => structuredClone(account));
     },
     async createPlayerReport(input: {
       reporterId: string;
@@ -284,6 +297,7 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
       patch: {
         gems?: number;
         globalResources?: { gold: number; wood: number; ore: number };
+        leaderboardAbuseState?: Record<string, unknown>;
         leaderboardModerationState?: Record<string, unknown>;
         recentEventLog?: Array<Record<string, unknown>>;
       }
@@ -298,15 +312,22 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
         account.gems = patch.gems;
       }
       account.globalResources = { ...account.globalResources, ...patch.globalResources };
-      if (patch.leaderboardModerationState) {
+      if (patch.leaderboardAbuseState !== undefined) {
+        account.leaderboardAbuseState =
+          Object.keys(patch.leaderboardAbuseState).length > 0 ? { ...patch.leaderboardAbuseState } : undefined;
+      }
+      if (patch.leaderboardModerationState !== undefined) {
         account.leaderboardModerationState = {
-          ...(account.leaderboardModerationState ?? {}),
           ...patch.leaderboardModerationState
         };
+        if (Object.keys(account.leaderboardModerationState).length === 0) {
+          delete account.leaderboardModerationState;
+        }
       }
       if (patch.recentEventLog) {
         account.recentEventLog = [...patch.recentEventLog];
       }
+      account.updatedAt = new Date().toISOString();
       saveCalls.push({ playerId, globalResources: { ...account.globalResources } });
       return account;
     },
@@ -430,6 +451,7 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
   return store as Pick<
     RoomSnapshotStore,
     | "loadPlayerAccount"
+    | "listPlayerAccounts"
     | "createPlayerReport"
     | "loadPlayerBan"
     | "ensurePlayerAccount"
@@ -1683,6 +1705,248 @@ test("POST /api/admin/players/:id/leaderboard/freeze freezes leaderboard movemen
   assert.equal(payload.account.leaderboardModerationState?.frozenByPlayerId, "support-moderator:admin-console");
   assert.equal(payload.account.leaderboardModerationState?.freezeReason, "Suspicious ELO spike");
   assert.ok(payload.account.leaderboardModerationState?.frozenAt);
+});
+
+test("GET /api/admin/players/:id/leaderboard/abuse-state returns structured abuse state and alert history", async (t) => {
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore({
+    "player-abuse": { gold: 0, wood: 0, ore: 0 }
+  });
+  await store.savePlayerAccountProgress("player-abuse", {
+    leaderboardAbuseState: {
+      currentDay: "2026-04-12",
+      dailyEloGain: 120,
+      dailyEloLoss: 0,
+      status: "flagged",
+      lastAlertAt: "2026-04-12T08:00:00.000Z",
+      lastAlertReasons: ["daily_gain_cap_hit", "repeated_opponent_watch"]
+    },
+    leaderboardModerationState: {
+      frozenAt: "2026-04-12T08:05:00.000Z",
+      frozenByPlayerId: "support-moderator:admin-console",
+      freezeReason: "Manual review"
+    },
+    recentEventLog: [
+      {
+        id: "leaderboard:freeze_cleared:2026-04-12T09:00:00.000Z:player-abuse",
+        timestamp: "2026-04-12T09:00:00.000Z",
+        roomId: "admin-console",
+        playerId: "player-abuse",
+        category: "account",
+        description: "解除排行榜冻结（操作人：support-moderator:admin-console，原因：False positive）",
+        rewards: []
+      }
+    ]
+  });
+  const { gets } = registerRoutes(store as RoomSnapshotStore);
+  const handler = gets.get("/api/admin/players/:id/leaderboard/abuse-state");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      params: { id: "player-abuse" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    response
+  );
+
+  const payload = JSON.parse(response.body) as {
+    playerId: string;
+    abuseState: { status?: string; lastAlertReasons?: string[] };
+    moderationState: { frozenByPlayerId?: string };
+    alertHistory: Array<{ type: string; source: string; detail: string }>;
+  };
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.playerId, "player-abuse");
+  assert.equal(payload.abuseState.status, "flagged");
+  assert.deepEqual(payload.abuseState.lastAlertReasons, ["daily_gain_cap_hit", "repeated_opponent_watch"]);
+  assert.equal(payload.moderationState.frozenByPlayerId, "support-moderator:admin-console");
+  assert.equal(payload.alertHistory.some((entry) => entry.type === "freeze_cleared" && entry.source === "event-log"), true);
+  assert.equal(payload.alertHistory.some((entry) => entry.type === "leaderboard_daily_gain_cap" && entry.source === "abuse-state"), true);
+  assert.equal(payload.alertHistory.some((entry) => /Manual review/.test(entry.detail)), true);
+});
+
+test("GET /api/admin/players/:id/leaderboard/abuse-state returns 404 for unknown players", async (t) => {
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  const { gets } = registerRoutes(store as RoomSnapshotStore);
+  const handler = gets.get("/api/admin/players/:id/leaderboard/abuse-state");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      params: { id: "missing-player" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 404);
+  assert.deepEqual(JSON.parse(response.body), { error: "Player account not found" });
+});
+
+test("DELETE /api/admin/players/:id/leaderboard/freeze clears frozen state and appends an audit record", async (t) => {
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore({
+    "player-clear-freeze": { gold: 0, wood: 0, ore: 0 }
+  });
+  await store.savePlayerAccountProgress("player-clear-freeze", {
+    leaderboardModerationState: {
+      frozenAt: "2026-04-12T08:00:00.000Z",
+      frozenByPlayerId: "support-moderator:admin-console",
+      freezeReason: "Suspicious ELO spike"
+    },
+    recentEventLog: []
+  });
+  const { deletes } = registerRoutes(store as RoomSnapshotStore);
+  const handler = deletes.get("/api/admin/players/:id/leaderboard/freeze");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "DELETE",
+      params: { id: "player-clear-freeze" },
+      body: JSON.stringify({ reason: "Investigation complete" }),
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    response
+  );
+
+  const payload = JSON.parse(response.body) as {
+    ok: boolean;
+    account: { leaderboardModerationState?: { frozenAt?: string; freezeReason?: string } };
+    audit: { action: string; actorPlayerId: string; reason?: string };
+  };
+  const updatedAccount = await store.loadPlayerAccount("player-clear-freeze");
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.audit.action, "freeze_cleared");
+  assert.equal(payload.audit.actorPlayerId, "support-moderator:admin-console");
+  assert.equal(payload.audit.reason, "Investigation complete");
+  assert.deepEqual(payload.account.leaderboardModerationState ?? {}, {});
+  assert.deepEqual(updatedAccount?.leaderboardModerationState ?? {}, {});
+  assert.equal(updatedAccount?.recentEventLog?.[0]?.id.startsWith("leaderboard:freeze_cleared:"), true);
+  assert.match(updatedAccount?.recentEventLog?.[0]?.description ?? "", /Investigation complete/);
+});
+
+test("DELETE /api/admin/players/:id/leaderboard/freeze returns 404 for unknown players", async (t) => {
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  const { deletes } = registerRoutes(store as RoomSnapshotStore);
+  const handler = deletes.get("/api/admin/players/:id/leaderboard/freeze");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "DELETE",
+      params: { id: "missing-player" },
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 404);
+  assert.deepEqual(JSON.parse(response.body), { error: "Player account not found" });
+});
+
+test("GET /api/admin/leaderboard/moderation-queue paginates and filters by flag type", async (t) => {
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore({
+    "player-queue-flagged": { gold: 0, wood: 0, ore: 0 },
+    "player-queue-watch": { gold: 0, wood: 0, ore: 0 },
+    "player-queue-frozen": { gold: 0, wood: 0, ore: 0 }
+  });
+  await store.savePlayerAccountProgress("player-queue-flagged", {
+    leaderboardAbuseState: {
+      currentDay: "2026-04-12",
+      dailyEloGain: 120,
+      dailyEloLoss: 0,
+      status: "flagged",
+      lastAlertAt: "2026-04-12T10:00:00.000Z",
+      lastAlertReasons: ["daily_gain_cap_hit"]
+    }
+  });
+  await store.savePlayerAccountProgress("player-queue-watch", {
+    leaderboardAbuseState: {
+      currentDay: "2026-04-12",
+      dailyEloGain: 40,
+      dailyEloLoss: 0,
+      status: "watch",
+      lastAlertAt: "2026-04-12T09:00:00.000Z",
+      lastAlertReasons: ["repeated_opponent_watch"]
+    }
+  });
+  await store.savePlayerAccountProgress("player-queue-frozen", {
+    leaderboardModerationState: {
+      frozenAt: "2026-04-12T08:00:00.000Z",
+      frozenByPlayerId: "support-moderator:admin-console",
+      freezeReason: "Manual hold"
+    }
+  });
+  const { gets } = registerRoutes(store as RoomSnapshotStore);
+  const handler = gets.get("/api/admin/leaderboard/moderation-queue");
+  const filteredResponse = createResponse();
+  const paginatedResponse = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      url: "/api/admin/leaderboard/moderation-queue?flagType=repeated_opponent_watch&limit=10&page=1",
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    filteredResponse
+  );
+  await handler(
+    createRequest({
+      url: "/api/admin/leaderboard/moderation-queue?limit=1&page=2",
+      headers: {
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    paginatedResponse
+  );
+
+  const filteredPayload = JSON.parse(filteredResponse.body) as {
+    items: Array<{ playerId: string; flagTypes: string[] }>;
+    total: number;
+    flagType?: string;
+  };
+  const paginatedPayload = JSON.parse(paginatedResponse.body) as {
+    items: Array<{ playerId: string; lastFlagAt: string }>;
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+
+  assert.equal(filteredResponse.statusCode, 200);
+  assert.equal(filteredPayload.flagType, "repeated_opponent_watch");
+  assert.equal(filteredPayload.total, 1);
+  assert.deepEqual(filteredPayload.items.map((item) => item.playerId), ["player-queue-watch"]);
+  assert.deepEqual(filteredPayload.items[0]?.flagTypes, ["repeated_opponent_watch", "watch"]);
+
+  assert.equal(paginatedResponse.statusCode, 200);
+  assert.equal(paginatedPayload.page, 2);
+  assert.equal(paginatedPayload.limit, 1);
+  assert.equal(paginatedPayload.total, 3);
+  assert.equal(paginatedPayload.totalPages, 3);
+  assert.deepEqual(paginatedPayload.items.map((item) => item.playerId), ["player-queue-watch"]);
 });
 
 test("POST /api/admin/players/:id/leaderboard/remove hides a player from leaderboard output", async (t) => {


### PR DESCRIPTION
## Summary
Add leaderboard anti-abuse admin inspection and recovery endpoints.

## What Changed
- add `GET /api/admin/players/:id/leaderboard/abuse-state` with structured abuse and alert history output
- add `DELETE /api/admin/players/:id/leaderboard/freeze` to clear freeze state and persist an audit entry
- add `GET /api/admin/leaderboard/moderation-queue` with pagination and `flagType` filtering
- extend admin-console tests to cover the new routes and unknown-player `404` cases

## Validation
- `npm run typecheck:server`
- `node --import tsx --test apps/server/test/admin-console.test.ts apps/server/test/leaderboard-anti-abuse.test.ts`

Closes #1334.