### PR TITLE
[codex] Wire WeChat subscribe notifications to match-found and turn-reminder triggers

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -2314,17 +2314,26 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       return;
     }
 
-    await roomRuntimeDependencies.sendWechatSubscribeMessage(
-      nextTurnOwnerPlayerId,
-      "turn_reminder",
-      {
+    try {
+      await roomRuntimeDependencies.sendWechatSubscribeMessage(
+        nextTurnOwnerPlayerId,
+        "turn_reminder",
+        {
+          roomId: this.metadata.logicalRoomId,
+          turnNumber: this.worldRoom.getInternalState().meta.day
+        },
+        {
+          store: configuredRoomSnapshotStore
+        }
+      );
+    } catch (error) {
+      console.error("[VeilRoom] Failed to send WeChat turn reminder subscribe message", {
         roomId: this.metadata.logicalRoomId,
-        turnNumber: this.worldRoom.getInternalState().meta.day
-      },
-      {
-        store: configuredRoomSnapshotStore
-      }
-    );
+        playerId: nextTurnOwnerPlayerId,
+        turnNumber: this.worldRoom.getInternalState().meta.day,
+        error
+      });
+    }
   }
 
   private getPlayerId(client: ColyseusClient, fallback?: string): string | undefined {

--- a/apps/server/src/matchmaking.ts
+++ b/apps/server/src/matchmaking.ts
@@ -31,7 +31,21 @@ interface RateLimitResult {
   retryAfterSeconds?: number;
 }
 
+interface MatchmakingRuntimeDependencies {
+  sendWechatSubscribeMessage(
+    playerId: string,
+    templateKey: "match_found",
+    data: Record<string, unknown>,
+    options?: { store?: RoomSnapshotStore | null }
+  ): Promise<boolean>;
+}
+
 const matchmakingRateLimitCounters = new Map<string, number[]>();
+const defaultMatchmakingRuntimeDependencies: MatchmakingRuntimeDependencies = {
+  sendWechatSubscribeMessage: (playerId, templateKey, data, options) =>
+    sendWechatSubscribeMessage(playerId, templateKey, data, options)
+};
+let matchmakingRuntimeDependencies: MatchmakingRuntimeDependencies = defaultMatchmakingRuntimeDependencies;
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -652,6 +666,17 @@ function compareQueuedPlayers(left: MatchmakingRequest, right: MatchmakingReques
 let configuredMatchmakingNotificationStore: RoomSnapshotStore | null = null;
 let configuredMatchmakingService: MatchmakingServiceController = createConfiguredMatchmakingService();
 
+export function configureMatchmakingRuntimeDependencies(overrides: Partial<MatchmakingRuntimeDependencies>): void {
+  matchmakingRuntimeDependencies = {
+    ...matchmakingRuntimeDependencies,
+    ...overrides
+  };
+}
+
+export function resetMatchmakingRuntimeDependencies(): void {
+  matchmakingRuntimeDependencies = defaultMatchmakingRuntimeDependencies;
+}
+
 export function resetMatchmakingService(): void {
   void configuredMatchmakingService.close?.();
   configuredMatchmakingNotificationStore = null;
@@ -701,15 +726,24 @@ async function notifyPlayersAboutMatchFound(
 
         const account = accountsByPlayerId.get(playerId);
         const opponentAccount = accountsByPlayerId.get(opponentId);
-        await sendWechatSubscribeMessage(
-          playerId,
-          "match_found",
-          {
-            mapName: describeMatchmakingMapName(account?.lastRoomId ?? result.roomId),
-            opponentName: opponentAccount?.displayName?.trim() || opponentId
-          },
-          { store }
-        );
+        try {
+          await matchmakingRuntimeDependencies.sendWechatSubscribeMessage(
+            playerId,
+            "match_found",
+            {
+              mapName: describeMatchmakingMapName(account?.lastRoomId ?? result.roomId),
+              opponentName: opponentAccount?.displayName?.trim() || opponentId
+            },
+            { store }
+          );
+        } catch (error) {
+          console.error("[matchmaking] Failed to send WeChat match-found notification", {
+            roomId: result.roomId,
+            playerId,
+            opponentId,
+            error
+          });
+        }
       })
     );
   } catch (error) {

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -2246,6 +2246,70 @@ test("turn reminder subscribe message is sent after the next player has been dis
   ]);
 });
 
+test("turn reminder subscribe failures are logged without blocking turn advancement", async (t) => {
+  resetLobbyRoomRegistry();
+  const timer = createManualRoomTimer(Date.parse("2026-04-04T00:00:00.000Z"));
+  const store = new InstrumentedRoomSnapshotStore();
+  const notificationFailure = new Error("turn reminder send exploded");
+  const errorCalls: unknown[][] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    errorCalls.push(args);
+  };
+
+  configureRoomSnapshotStore(store);
+  configureRoomRuntimeDependencies({
+    sendWechatSubscribeMessage: async () => {
+      throw notificationFailure;
+    }
+  });
+
+  const room = await createTestRoom(`lifecycle-turn-reminder-failure-${Date.now()}`);
+  const attackerClient = createFakeClient("session-turn-reminder-failure-attacker");
+  const defenderClient = createFakeClient("session-turn-reminder-failure-defender");
+
+  t.after(() => {
+    console.error = originalConsoleError;
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+    resetRoomRuntimeDependencies();
+  });
+
+  await connectPlayer(room, attackerClient, "player-1", "connect-turn-reminder-failure-attacker");
+  await connectPlayer(room, defenderClient, "player-2", "connect-turn-reminder-failure-defender");
+  await store.bindPlayerAccountWechatMiniGameIdentity("player-2", {
+    openId: "wx-open-id-player-2",
+    displayName: "Player Two"
+  });
+
+  room.onLeave(defenderClient);
+  timer.nowMs += 31_000;
+
+  await emitRoomMessage(room, "world.action", attackerClient, {
+    type: "world.action",
+    requestId: "turn-reminder-failure-end-day",
+    action: {
+      type: "turn.endDay"
+    }
+  });
+
+  const internalRoom = room as VeilColyseusRoom & {
+    worldRoom: {
+      getInternalState(): { meta: { day: number } };
+    };
+  };
+  assert.equal(internalRoom.worldRoom.getInternalState().meta.day, 2);
+  assert.equal(errorCalls.length, 1);
+  assert.equal(errorCalls[0]?.[0], "[VeilRoom] Failed to send WeChat turn reminder subscribe message");
+  assert.deepEqual(errorCalls[0]?.[1], {
+    roomId: room.roomId,
+    playerId: "player-2",
+    turnNumber: 2,
+    error: notificationFailure
+  });
+});
+
 test("two consecutive AFK strikes trigger afk_forfeit and persist surrender-path ELO deltas", async (t) => {
   resetLobbyRoomRegistry();
   const timer = createManualRoomTimer(Date.parse("2026-04-04T00:00:00.000Z"));

--- a/apps/server/test/matchmaking-routes.test.ts
+++ b/apps/server/test/matchmaking-routes.test.ts
@@ -15,7 +15,13 @@ import {
 } from "../../../packages/shared/src/index";
 import { issueGuestAuthSession, resetGuestAuthSessions } from "../src/auth";
 import { configureRoomSnapshotStore, VeilColyseusRoom } from "../src/colyseus-room";
-import { MatchmakingService, registerMatchmakingRoutes, resetMatchmakingService } from "../src/matchmaking";
+import {
+  MatchmakingService,
+  configureMatchmakingRuntimeDependencies,
+  registerMatchmakingRoutes,
+  resetMatchmakingRuntimeDependencies,
+  resetMatchmakingService
+} from "../src/matchmaking";
 import { createMemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
 import { resetRuntimeObservability } from "../src/observability";
 import type { RoomSnapshotStore } from "../src/persistence";
@@ -202,6 +208,16 @@ async function connectRoom(room: ColyseusRoom, roomId: string, playerId: string,
   );
 }
 
+async function waitFor(condition: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const startTime = Date.now();
+  while (!condition()) {
+    if (Date.now() - startTime > timeoutMs) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 test("matchmaking routes enqueue, match, report status, and dequeue cleanly", async (t) => {
   const store = createMemoryRoomSnapshotStore();
   await store.save(
@@ -294,6 +310,170 @@ test("matchmaking routes enqueue, match, report status, and dequeue cleanly", as
   });
   const dequeueOnePayload = (await dequeueOne.json()) as { status: string };
   assert.equal(dequeueOnePayload.status, "idle");
+});
+
+test("matchmaking routes send WeChat subscribe notifications when a match is created", async (t) => {
+  const store = createMemoryRoomSnapshotStore();
+  await store.save(
+    "room-frontier_basin",
+    createSnapshot("room-frontier_basin", [createHero("player-1", "hero-1"), createHero("player-2", "hero-2")])
+  );
+  await store.ensurePlayerAccount({ playerId: "player-1", displayName: "One", lastRoomId: "room-frontier_basin" });
+  await store.ensurePlayerAccount({ playerId: "player-2", displayName: "Two", lastRoomId: "room-frontier_basin" });
+  await store.bindPlayerAccountWechatMiniGameIdentity("player-1", {
+    openId: "wx-open-id-player-1",
+    displayName: "One"
+  });
+  await store.bindPlayerAccountWechatMiniGameIdentity("player-2", {
+    openId: "wx-open-id-player-2",
+    displayName: "Two"
+  });
+
+  const subscribeCalls: Array<{ playerId: string; templateKey: string; data: Record<string, unknown> }> = [];
+  configureMatchmakingRuntimeDependencies({
+    sendWechatSubscribeMessage: async (playerId, templateKey, data) => {
+      subscribeCalls.push({ playerId, templateKey, data });
+      return true;
+    }
+  });
+
+  const port = 43000 + Math.floor(Math.random() * 1000);
+  const server = await startMatchmakingServer(store, port);
+  const sessionOne = issueGuestAuthSession({ playerId: "player-1", displayName: "One" });
+  const sessionTwo = issueGuestAuthSession({ playerId: "player-2", displayName: "Two" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    resetMatchmakingRuntimeDependencies();
+    resetMatchmakingService();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  await fetch(`http://127.0.0.1:${port}/api/matchmaking/enqueue`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${sessionOne.token}`
+    }
+  });
+  await fetch(`http://127.0.0.1:${port}/api/matchmaking/enqueue`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${sessionTwo.token}`
+    }
+  });
+
+  await waitFor(() => subscribeCalls.length === 2);
+  assert.deepEqual(
+    subscribeCalls.sort((left, right) => left.playerId.localeCompare(right.playerId)),
+    [
+      {
+        playerId: "player-1",
+        templateKey: "match_found",
+        data: {
+          mapName: "Phase1",
+          opponentName: "Two"
+        }
+      },
+      {
+        playerId: "player-2",
+        templateKey: "match_found",
+        data: {
+          mapName: "Phase1",
+          opponentName: "One"
+        }
+      }
+    ]
+  );
+});
+
+test("matchmaking routes log WeChat subscribe failures without breaking match creation", async (t) => {
+  const store = createMemoryRoomSnapshotStore();
+  await store.save(
+    "room-frontier_basin",
+    createSnapshot("room-frontier_basin", [createHero("player-1", "hero-1"), createHero("player-2", "hero-2")])
+  );
+  await store.ensurePlayerAccount({ playerId: "player-1", displayName: "One", lastRoomId: "room-frontier_basin" });
+  await store.ensurePlayerAccount({ playerId: "player-2", displayName: "Two", lastRoomId: "room-frontier_basin" });
+  await store.bindPlayerAccountWechatMiniGameIdentity("player-1", {
+    openId: "wx-open-id-player-1",
+    displayName: "One"
+  });
+  await store.bindPlayerAccountWechatMiniGameIdentity("player-2", {
+    openId: "wx-open-id-player-2",
+    displayName: "Two"
+  });
+
+  const notificationFailure = new Error("match-found send exploded");
+  const errorCalls: unknown[][] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    errorCalls.push(args);
+  };
+
+  configureMatchmakingRuntimeDependencies({
+    sendWechatSubscribeMessage: async (playerId) => {
+      if (playerId === "player-2") {
+        throw notificationFailure;
+      }
+      return true;
+    }
+  });
+
+  const port = 43000 + Math.floor(Math.random() * 1000);
+  const server = await startMatchmakingServer(store, port);
+  const sessionOne = issueGuestAuthSession({ playerId: "player-1", displayName: "One" });
+  const sessionTwo = issueGuestAuthSession({ playerId: "player-2", displayName: "Two" });
+
+  t.after(async () => {
+    console.error = originalConsoleError;
+    resetGuestAuthSessions();
+    resetMatchmakingRuntimeDependencies();
+    resetMatchmakingService();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  await fetch(`http://127.0.0.1:${port}/api/matchmaking/enqueue`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${sessionOne.token}`
+    }
+  });
+  await fetch(`http://127.0.0.1:${port}/api/matchmaking/enqueue`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${sessionTwo.token}`
+    }
+  });
+
+  await waitFor(() => errorCalls.length === 1);
+  assert.equal(errorCalls[0]?.[0], "[matchmaking] Failed to send WeChat match-found notification");
+  const loggedDetails = errorCalls[0]?.[1] as {
+    roomId?: string;
+    playerId?: string;
+    opponentId?: string;
+    error?: unknown;
+  };
+  assert.match(loggedDetails.roomId ?? "", /^pvp-match-/);
+  assert.equal(loggedDetails.playerId, "player-2");
+  assert.equal(loggedDetails.opponentId, "player-1");
+  assert.equal(loggedDetails.error, notificationFailure);
+
+  const statusOne = await fetch(`http://127.0.0.1:${port}/api/matchmaking/status`, {
+    headers: {
+      Authorization: `Bearer ${sessionOne.token}`
+    }
+  });
+  const statusTwo = await fetch(`http://127.0.0.1:${port}/api/matchmaking/status`, {
+    headers: {
+      Authorization: `Bearer ${sessionTwo.token}`
+    }
+  });
+  const statusOnePayload = (await statusOne.json()) as { status: string };
+  const statusTwoPayload = (await statusTwo.json()) as { status: string };
+  assert.equal(statusOnePayload.status, "matched");
+  assert.equal(statusTwoPayload.status, "matched");
 });
 
 test("matchmaking routes can carry matched players through room join and surrender-based elo settlement", async (t) => {


### PR DESCRIPTION
## Summary
- add a testable matchmaking WeChat subscribe runtime dependency and keep match creation resilient when individual match-found notifications throw
- guard turn-reminder subscribe sends so failures are logged without interrupting turn advancement
- extend server tests to cover match-found wiring, turn-reminder wiring, and failure logging behavior

## Validation
- `node --import tsx --test --test-name-pattern "matchmaking routes .*WeChat subscribe" apps/server/test/matchmaking-routes.test.ts`
- `node --import tsx --test --test-name-pattern "turn reminder subscribe" apps/server/test/colyseus-room-lifecycle.test.ts`
- `node --import tsx --test apps/server/test/wechat-subscribe.test.ts`

Closes #1335