### PR TITLE
Add Kubernetes production deployment manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  kubernetes-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.33.1
+
+      - name: Setup kind
+        uses: engineerd/setup-kind@v0.6.2
+        with:
+          version: v0.24.0
+
+      - name: Dry-run Kubernetes manifests
+        run: kubectl apply --dry-run=client -k k8s
+
   readme-script-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim AS base
+FROM node:22-bookworm-slim AS build
 WORKDIR /app
 
 ENV npm_config_update_notifier=false
@@ -12,13 +12,32 @@ RUN npm ci --no-audit --no-fund
 
 COPY . .
 
+RUN npm run build:server
+
+FROM node:22-bookworm-slim AS runtime
+WORKDIR /app
+
 ENV NODE_ENV=production
+ENV npm_config_update_notifier=false
 ENV HOST=0.0.0.0
 ENV PORT=2567
+ENV VEIL_MIGRATIONS_PATH=/app/dist/scripts/migrations
+
+COPY package.json package-lock.json ./
+COPY apps/client/package.json ./apps/client/package.json
+COPY apps/cocos-client/package.json ./apps/cocos-client/package.json
+COPY packages/cc-runtime-stub/package.json ./packages/cc-runtime-stub/package.json
+COPY packages/cc-runtime-stub/index.js ./packages/cc-runtime-stub/index.js
+
+RUN npm ci --omit=dev --no-audit --no-fund
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/configs ./configs
+COPY --from=build /app/apps/client/admin.html ./apps/client/admin.html
 
 EXPOSE 2567
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
   CMD node -e "fetch('http://127.0.0.1:2567/api/runtime/health').then((res) => { if (!res.ok) process.exit(1); }).catch(() => process.exit(1));"
 
-CMD ["node", "--import", "tsx", "./apps/server/src/dev-server.ts"]
+CMD ["node", "./dist/server/server.mjs"]

--- a/apps/server/src/schema-migrations.ts
+++ b/apps/server/src/schema-migrations.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -65,8 +66,22 @@ export interface SchemaMigrationStatusOptions extends SchemaMigrationLoaderOptio
 }
 
 const SCHEMA_MIGRATIONS_TABLE = "schema_migrations";
-const MIGRATION_FILE_PATTERN = /^(\d{4})_(.+)\.ts$/;
-const MIGRATIONS_DIRECTORY = resolve(dirname(fileURLToPath(import.meta.url)), "../../../scripts/migrations");
+const MIGRATION_FILE_PATTERN = /^(\d{4})_(.+)\.(?:ts|js|mjs)$/;
+const MIGRATIONS_DIRECTORY = resolveDefaultMigrationsDirectory();
+
+function resolveDefaultMigrationsDirectory(): string {
+  const configured = process.env.VEIL_MIGRATIONS_PATH?.trim();
+  if (configured) {
+    return resolve(configured);
+  }
+
+  const compiledDirectory = resolve(process.cwd(), "dist/scripts/migrations");
+  if (existsSync(compiledDirectory)) {
+    return compiledDirectory;
+  }
+
+  return resolve(dirname(fileURLToPath(import.meta.url)), "../../../scripts/migrations");
+}
 
 export function schemaMigrationTableName(): string {
   return SCHEMA_MIGRATIONS_TABLE;

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,7 +49,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: ["npm", "run", "db:migrate"]
+    command: ["node", "./dist/scripts/migrate.mjs"]
 
   server:
     build:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,42 @@
+# Kubernetes Production Manifests
+
+This directory provides a production-oriented baseline for the Project Veil server runtime.
+
+## Included resources
+
+- `Deployment` with probes and production resource sizing
+- `Service` and `Ingress` for HTTP plus long-lived WebSocket traffic on the same backend
+- `ConfigMap` for the non-secret env contract from `ops/env/production.env.example`
+- `HorizontalPodAutoscaler` keyed to the thresholds published in `docs/ops/capacity-planning.md`
+
+## External stateful services
+
+These manifests assume managed backing services instead of in-cluster MySQL:
+
+- `VEIL_MYSQL_HOST` points at an external RDS endpoint
+- `REDIS_URL` points at an external Redis endpoint or dedicated Redis service
+- no MySQL `PersistentVolumeClaim` is included because the database is expected to live outside the cluster
+
+If you decide to run MySQL in-cluster instead, add a StatefulSet and PVC, then replace `VEIL_MYSQL_HOST` with the MySQL Service DNS name.
+
+## Secrets
+
+Create a `Secret` named `project-veil-server-secrets` with the sensitive keys documented in `docs/ops/secrets-inventory.md`, including at minimum:
+
+- `VEIL_AUTH_SECRET`
+- `ADMIN_SECRET`
+- `SUPPORT_MODERATOR_SECRET`
+- `SUPPORT_SUPERVISOR_SECRET`
+- `VEIL_ADMIN_TOKEN`
+- `VEIL_MYSQL_PASSWORD`
+
+The deployment uses `envFrom` so the secret keys should match the runtime env var names exactly.
+
+## HPA assumptions
+
+The current in-repo capacity evidence was published on `2026-04-11` in `docs/ops/capacity-planning.md`:
+
+- scale out when `veil_active_rooms_total > 8` per pod
+- scale out when `veil_matchmaking_queue_depth > 50`
+
+The HPA encodes those thresholds directly and also keeps a CPU fallback metric at `70%` average utilization. The custom metrics require a Prometheus-compatible metrics adapter such as Prometheus Adapter or KEDA.

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: project-veil-server-config
+data:
+  NODE_ENV: production
+  HOST: 0.0.0.0
+  PORT: "2567"
+  REDIS_URL: redis://project-veil-redis:6379/0
+  VEIL_MYSQL_HOST: project-veil-prod.cluster-abcdefghijkl.us-east-1.rds.amazonaws.com
+  VEIL_MYSQL_PORT: "3306"
+  VEIL_MYSQL_USER: project_veil
+  VEIL_MYSQL_DATABASE: project_veil
+  VEIL_MYSQL_SNAPSHOT_TTL_HOURS: "72"
+  VEIL_MYSQL_SNAPSHOT_CLEANUP_INTERVAL_MINUTES: "30"
+  VEIL_SECRET_PROVIDER: aws-secrets-manager
+  VEIL_AWS_SECRETS_MANAGER_SECRET_ID: projectveil/production/server
+  VEIL_AWS_SECRETS_MANAGER_REGION: us-east-1
+  VEIL_BACKUP_S3_BUCKET: project-veil-prod-backups
+  VEIL_BACKUP_S3_PREFIX: backups/mysql
+  VEIL_BACKUP_S3_ENDPOINT: https://s3.example.com
+  VEIL_BACKUP_S3_REGION: us-east-1
+  VEIL_BACKUP_AWS_PROFILE: project-veil-production
+  VEIL_BACKUP_KEEP_DAILY_DAYS: "30"
+  VEIL_BACKUP_KEEP_WEEKLY_DAYS: "183"
+  VEIL_BACKUP_WEEKLY_DAY: "7"
+  VEIL_RATE_LIMIT_AUTH_WINDOW_MS: "60000"
+  VEIL_RATE_LIMIT_AUTH_MAX: "10"
+  VEIL_RATE_LIMIT_WS_ACTION_WINDOW_MS: "1000"
+  VEIL_RATE_LIMIT_WS_ACTION_MAX: "8"
+  VEIL_AUTH_LOCKOUT_THRESHOLD: "10"
+  VEIL_AUTH_LOCKOUT_DURATION_MINUTES: "15"
+  VEIL_MAX_GUEST_SESSIONS: "10000"
+  VEIL_AUTH_ACCESS_TTL_SECONDS: "3600"
+  VEIL_AUTH_REFRESH_TTL_SECONDS: "2592000"
+  VEIL_AUTH_GUEST_TTL_SECONDS: "604800"
+  VEIL_MATCHMAKING_QUEUE_TTL_SECONDS: "300"
+  ANALYTICS_ENDPOINT: https://analytics.projectveil.example/ingest
+  SENTRY_DSN: https://public@example.ingest.sentry.io/42

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: project-veil-server
+spec:
+  replicas: 2
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: project-veil-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: project-veil-server
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: server
+          image: ghcr.io/dannagrace/projectveil-server:latest
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: project-veil-server-config
+            - secretRef:
+                name: project-veil-server-secrets
+          ports:
+            - name: http
+              containerPort: 2567
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /api/runtime/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /api/runtime/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 4

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,50 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: project-veil-server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: project-veil-server
+  minReplicas: 2
+  maxReplicas: 6
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+  metrics:
+    # docs/ops/capacity-planning.md publishes 8 active rooms/node as the
+    # scale-out warning threshold and 10 rooms/node as the current ceiling.
+    - type: Pods
+      pods:
+        metric:
+          name: veil_active_rooms_total
+        target:
+          type: AverageValue
+          averageValue: "8"
+    # The same capacity plan publishes matchmaking queue depth > 50 for 30s as
+    # the second scale-out trigger. This requires a metrics adapter that
+    # surfaces the Prometheus series as an external metric.
+    - type: External
+      external:
+        metric:
+          name: veil_matchmaking_queue_depth
+        target:
+          type: Value
+          value: "50"
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: project-veil-server
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: game.projectveil.example
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: project-veil-server
+                port:
+                  name: http

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: project-veil
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - hpa.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: project-veil

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: project-veil-server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: project-veil-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev:server": "node --import tsx ./apps/server/src/dev-server.ts",
+    "build:server": "node ./scripts/build-server.mjs",
     "client:primary": "node --eval \"console.log('Primary runtime: open apps/cocos-client in Cocos Creator 3.8.x and preview the VeilRoot scene. H5 debug shell: npm run dev:client:h5')\"",
     "dev:client": "npm run dev:client:h5",
     "dev:client:h5": "vite --config apps/client/vite.config.ts",

--- a/scripts/build-server.mjs
+++ b/scripts/build-server.mjs
@@ -1,0 +1,57 @@
+import { mkdir, readdir } from "node:fs/promises";
+import path from "node:path";
+import { build } from "esbuild";
+
+const repoRoot = process.cwd();
+const distDir = path.join(repoRoot, "dist");
+const migrationsDir = path.join(repoRoot, "scripts", "migrations");
+
+const packageJson = await import(path.join(repoRoot, "package.json"), {
+  with: { type: "json" }
+});
+
+const externalPackages = [
+  ...Object.keys(packageJson.default.dependencies ?? {}),
+  ...Object.keys(packageJson.default.optionalDependencies ?? {})
+];
+
+const migrationEntries = (await readdir(migrationsDir))
+  .filter((entry) => entry.endsWith(".ts"))
+  .map((entry) => path.join(migrationsDir, entry));
+
+await mkdir(distDir, { recursive: true });
+
+await build({
+  absWorkingDir: repoRoot,
+  bundle: true,
+  entryPoints: {
+    "server/server": "apps/server/src/dev-server.ts",
+    "scripts/migrate": "scripts/migrate.ts",
+    "scripts/migrate-rollback": "scripts/migrate-rollback.ts"
+  },
+  external: externalPackages,
+  format: "esm",
+  logLevel: "info",
+  outdir: distDir,
+  outExtension: { ".js": ".mjs" },
+  platform: "node",
+  sourcemap: false,
+  target: "node22",
+  tsconfig: "tsconfig.base.json"
+});
+
+await build({
+  absWorkingDir: repoRoot,
+  bundle: true,
+  entryPoints: migrationEntries,
+  external: externalPackages,
+  format: "esm",
+  logLevel: "info",
+  outbase: migrationsDir,
+  outdir: path.join(distDir, "scripts", "migrations"),
+  outExtension: { ".js": ".mjs" },
+  platform: "node",
+  sourcemap: false,
+  target: "node22",
+  tsconfig: "tsconfig.base.json"
+});


### PR DESCRIPTION
## Summary
- add a `k8s/` production baseline for the server deployment, service, ingress, config map, and HPA using the capacity thresholds documented in `docs/ops/capacity-planning.md`
- switch `Dockerfile.server` to a multi-stage compiled runtime image and point production compose migrations at the compiled migration CLI
- add CI smoke validation in `.github/workflows/ci.yml` that provisions `kind` and runs `kubectl apply --dry-run=client -k k8s`

## Validation
- `npm run build:server`
- `npm run typecheck:server`
- `/tmp/kubectl kustomize k8s > /tmp/projectveil-k8s.yaml`
- `NODE_ENV=production PORT=3567 timeout 15s node ./dist/server/server.mjs` (server booted; `/api/runtime/health` reported `status: warn` because no MySQL env was configured in local validation)

Closes #1332