### PR TITLE
[codex] Front-load runtime SLO summary in phase1 rehearsal

### DIFF
--- a/scripts/phase1-candidate-rehearsal-markdown.ts
+++ b/scripts/phase1-candidate-rehearsal-markdown.ts
@@ -18,6 +18,9 @@ export interface RehearsalArtifacts {
   cocosRcReconnectReplayPath?: string;
   cocosRcReconnectReplayMarkdownPath?: string;
   stableRuntimeReportPath?: string;
+  runtimeSloSummaryPath?: string;
+  runtimeSloSummaryMarkdownPath?: string;
+  runtimeSloSummaryTextPath?: string;
   runtimeObservabilityBundlePath?: string;
   runtimeObservabilityBundleMarkdownPath?: string;
   runtimeObservabilityEvidencePath?: string;
@@ -174,6 +177,15 @@ export function renderMarkdown(report: RehearsalReport): string {
   }
   if (report.artifacts.releaseReadinessSnapshotPath) {
     lines.push(`- Release readiness snapshot: \`${report.artifacts.releaseReadinessSnapshotPath}\``);
+  }
+  if (report.artifacts.runtimeSloSummaryMarkdownPath) {
+    lines.push(`- Runtime SLO summary markdown: \`${report.artifacts.runtimeSloSummaryMarkdownPath}\``);
+  }
+  if (report.artifacts.runtimeSloSummaryPath) {
+    lines.push(`- Runtime SLO summary: \`${report.artifacts.runtimeSloSummaryPath}\``);
+  }
+  if (report.artifacts.runtimeSloSummaryTextPath) {
+    lines.push(`- Runtime SLO summary text: \`${report.artifacts.runtimeSloSummaryTextPath}\``);
   }
   if (report.artifacts.runtimeObservabilityGatePath) {
     lines.push(`- Runtime observability gate: \`${report.artifacts.runtimeObservabilityGatePath}\``);

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -387,13 +387,6 @@ export function runOptionalFailingDiagnosticStage(id: string, title: string, com
     }
   }
 
-  // Wall-clock instant captured immediately before the subprocess starts.
-  // Used as the freshness reference instead of the pre-run mtime so that
-  // coarse-grained filesystems (FAT32 at 2 s, ext3/NFS at 1 s) cannot
-  // misclassify a freshly rewritten output as stale when the write lands in
-  // the same mtime time-bucket as the pre-run snapshot.
-  const preRunWallClockMs = Date.now();
-
   const result = spawnSync(command[0], command.slice(1), {
     cwd: process.cwd(),
     encoding: "utf8",
@@ -444,23 +437,25 @@ export function runOptionalFailingDiagnosticStage(id: string, title: string, com
   // left over from a previous run on the same candidate/revision must not mask a
   // real current-run failure.
   //
-  // Staleness is judged against the wall-clock instant we captured before
-  // spawning, not against the file's prior mtime.  Comparing mtime-to-mtime
-  // would misclassify a freshly rewritten file as stale on coarse-grained
-  // filesystems (FAT32 2 s, ext3/NFS 1 s) where the new write falls inside
-  // the same time-bucket as the pre-run snapshot.  COARSE_MTIME_TOLERANCE_MS
-  // must be larger than the coarsest bucket we expect (2 s) to ensure a file
-  // written during this invocation is always considered fresh.
+  // Freshness is determined by mtime advancement: if a file's mtime did not
+  // increase from the pre-run snapshot, it was not written by this invocation.
+  // This is the only reliable signal — a wall-clock tolerance window (e.g. 2 s)
+  // was previously used to accommodate coarse-grained filesystems (FAT32, NFS),
+  // but that window also accepted stale artifacts from very recent prior runs
+  // whose mtimes happened to fall inside the tolerance, producing false-positive
+  // passes.  Requiring a strict mtime increase eliminates that class of false
+  // positive.  On coarse filesystems where a write lands in the same mtime bucket
+  // as the prior write, we err conservatively: the stage is reported as failed
+  // (safe direction) rather than granting a spurious pass.
   if (result.status !== 0) {
-    const COARSE_MTIME_TOLERANCE_MS = 2000;
     const staleOutputs = outputs.filter((filePath) => {
       try {
         const currentMtime = fs.statSync(filePath).mtimeMs;
         const priorMtime = preRunMtimes.get(filePath);
-        // File is stale only if it existed before the run AND its mtime is
-        // clearly older than the coarse-filesystem tolerance window.  Files
-        // absent before the run (priorMtime === undefined) are always fresh.
-        return priorMtime !== undefined && currentMtime < preRunWallClockMs - COARSE_MTIME_TOLERANCE_MS;
+        // A file absent before the run is always considered fresh (new output).
+        // A file that existed before is stale unless its mtime strictly advanced,
+        // proving it was written during this invocation.
+        return priorMtime !== undefined && currentMtime <= priorMtime;
       } catch {
         return true; // Cannot stat — treat as stale/missing.
       }

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -387,6 +387,13 @@ export function runOptionalFailingDiagnosticStage(id: string, title: string, com
     }
   }
 
+  // Wall-clock instant captured immediately before the subprocess starts.
+  // Used as the freshness reference instead of the pre-run mtime so that
+  // coarse-grained filesystems (FAT32 at 2 s, ext3/NFS at 1 s) cannot
+  // misclassify a freshly rewritten output as stale when the write lands in
+  // the same mtime time-bucket as the pre-run snapshot.
+  const preRunWallClockMs = Date.now();
+
   const result = spawnSync(command[0], command.slice(1), {
     cwd: process.cwd(),
     encoding: "utf8",
@@ -436,13 +443,24 @@ export function runOptionalFailingDiagnosticStage(id: string, title: string, com
   // that every output file was freshly written by this invocation. Stale artifacts
   // left over from a previous run on the same candidate/revision must not mask a
   // real current-run failure.
+  //
+  // Staleness is judged against the wall-clock instant we captured before
+  // spawning, not against the file's prior mtime.  Comparing mtime-to-mtime
+  // would misclassify a freshly rewritten file as stale on coarse-grained
+  // filesystems (FAT32 2 s, ext3/NFS 1 s) where the new write falls inside
+  // the same time-bucket as the pre-run snapshot.  COARSE_MTIME_TOLERANCE_MS
+  // must be larger than the coarsest bucket we expect (2 s) to ensure a file
+  // written during this invocation is always considered fresh.
   if (result.status !== 0) {
+    const COARSE_MTIME_TOLERANCE_MS = 2000;
     const staleOutputs = outputs.filter((filePath) => {
       try {
         const currentMtime = fs.statSync(filePath).mtimeMs;
         const priorMtime = preRunMtimes.get(filePath);
-        // "Fresh" means the file was absent before this run, or its mtime advanced.
-        return priorMtime !== undefined && currentMtime <= priorMtime;
+        // File is stale only if it existed before the run AND its mtime is
+        // clearly older than the coarse-filesystem tolerance window.  Files
+        // absent before the run (priorMtime === undefined) are always fresh.
+        return priorMtime !== undefined && currentMtime < preRunWallClockMs - COARSE_MTIME_TOLERANCE_MS;
       } catch {
         return true; // Cannot stat — treat as stale/missing.
       }

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import {
   buildCandidateRevisionTriageDigestFromPaths,
@@ -373,7 +374,19 @@ function runCommandStage(id: string, title: string, command: string[], outputs: 
   };
 }
 
-function runOptionalFailingDiagnosticStage(id: string, title: string, command: string[], outputs: string[]): StageResult {
+export function runOptionalFailingDiagnosticStage(id: string, title: string, command: string[], outputs: string[]): StageResult {
+  // Snapshot pre-run modification times so we can detect whether outputs were
+  // freshly written by this invocation versus inherited as stale artifacts from
+  // a previous run on the same candidate/revision.
+  const preRunMtimes = new Map<string, number>();
+  for (const filePath of outputs) {
+    try {
+      preRunMtimes.set(filePath, fs.statSync(filePath).mtimeMs);
+    } catch {
+      // File does not yet exist — expected on first run.
+    }
+  }
+
   const result = spawnSync(command[0], command.slice(1), {
     cwd: process.cwd(),
     encoding: "utf8",
@@ -417,6 +430,35 @@ function runOptionalFailingDiagnosticStage(id: string, title: string, command: s
       exitCode: result.status,
       outputs: outputs.map(toRelative)
     };
+  }
+
+  // For a non-zero exit (the expected candidate_gate diagnostic code 1), verify
+  // that every output file was freshly written by this invocation. Stale artifacts
+  // left over from a previous run on the same candidate/revision must not mask a
+  // real current-run failure.
+  if (result.status !== 0) {
+    const staleOutputs = outputs.filter((filePath) => {
+      try {
+        const currentMtime = fs.statSync(filePath).mtimeMs;
+        const priorMtime = preRunMtimes.get(filePath);
+        // "Fresh" means the file was absent before this run, or its mtime advanced.
+        return priorMtime !== undefined && currentMtime <= priorMtime;
+      } catch {
+        return true; // Cannot stat — treat as stale/missing.
+      }
+    });
+    if (staleOutputs.length > 0) {
+      const summary = stderr ?? stdout ?? `Command exited with code ${result.status}.`;
+      return {
+        id,
+        title,
+        status: "failed",
+        summary: `${summary} (artifact(s) not refreshed by this invocation: ${staleOutputs.map(toRelative).join(", ")})`,
+        command: formatCommand(command),
+        exitCode: result.status,
+        outputs: outputs.map(toRelative)
+      };
+    }
   }
 
   const outputLines = `${stdout ?? ""}\n${stderr ?? ""}`
@@ -1787,7 +1829,11 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  console.error(`Phase 1 candidate rehearsal failed: ${error instanceof Error ? error.message : String(error)}`);
-  process.exitCode = 1;
-});
+const executedDirectly = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+
+if (executedDirectly) {
+  main().catch((error) => {
+    console.error(`Phase 1 candidate rehearsal failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -373,6 +373,68 @@ function runCommandStage(id: string, title: string, command: string[], outputs: 
   };
 }
 
+function runOptionalFailingDiagnosticStage(id: string, title: string, command: string[], outputs: string[]): StageResult {
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 20
+  });
+  const stdout = tailText(result.stdout);
+  const stderr = tailText(result.stderr);
+  if (result.error) {
+    return {
+      id,
+      title,
+      status: "failed",
+      summary: result.error.message,
+      command: formatCommand(command),
+      exitCode: result.status ?? 1,
+      outputs: outputs.map(toRelative)
+    };
+  }
+
+  const missingOutputs = outputs.filter((filePath) => !fs.existsSync(filePath));
+  if (missingOutputs.length > 0) {
+    return {
+      id,
+      title,
+      status: "failed",
+      summary: `Expected output(s) missing: ${missingOutputs.map(toRelative).join(", ")}`,
+      command: formatCommand(command),
+      exitCode: result.status,
+      outputs: outputs.map(toRelative)
+    };
+  }
+
+  if (result.status !== 0 && result.status !== 1) {
+    const summary = stderr ?? stdout ?? `Command exited with code ${result.status}.`;
+    return {
+      id,
+      title,
+      status: "failed",
+      summary,
+      command: formatCommand(command),
+      exitCode: result.status,
+      outputs: outputs.map(toRelative)
+    };
+  }
+
+  const outputLines = `${stdout ?? ""}\n${stderr ?? ""}`
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  return {
+    id,
+    title,
+    status: "passed",
+    summary: outputLines.at(-1) ?? "ok",
+    command: formatCommand(command),
+    exitCode: result.status,
+    outputs: outputs.map(toRelative)
+  };
+}
+
 function copyFileIfPresent(sourcePath: string | undefined, destinationPath: string): boolean {
   if (!sourcePath || !fs.existsSync(sourcePath)) {
     return false;
@@ -451,6 +513,12 @@ async function main(): Promise<void> {
   const stableReconnectSoakPath = path.join(outputDir, `colyseus-reconnect-soak-summary-${candidateSlug}-${revision.shortCommit}.json`);
   const stableRuntimeReportPath = path.join(outputDir, `runtime-regression-report-${candidateSlug}-${revision.shortCommit}.json`);
   const runtimeObservabilityBundleDir = path.join(outputDir, `runtime-observability-bundle-${candidateSlug}-${revision.shortCommit}`);
+  const runtimeSloSummaryPath = path.join(runtimeObservabilityBundleDir, `runtime-slo-summary-${candidateSlug}-${revision.shortCommit}.json`);
+  const runtimeSloSummaryMarkdownPath = path.join(
+    runtimeObservabilityBundleDir,
+    `runtime-slo-summary-${candidateSlug}-${revision.shortCommit}.md`
+  );
+  const runtimeSloSummaryTextPath = path.join(runtimeObservabilityBundleDir, `runtime-slo-summary-${candidateSlug}-${revision.shortCommit}.txt`);
   const runtimeObservabilityBundlePath = path.join(runtimeObservabilityBundleDir, "runtime-observability-bundle.json");
   const runtimeObservabilityBundleMarkdownPath = path.join(runtimeObservabilityBundleDir, "runtime-observability-bundle.md");
   const runtimeObservabilityEvidencePath = path.join(
@@ -584,6 +652,9 @@ async function main(): Promise<void> {
   artifacts.candidateRevisionTriageInputPath = toRelative(candidateRevisionTriageInputPath);
   artifacts.candidateRevisionTriageDigestPath = toRelative(candidateRevisionTriageDigestPath);
   artifacts.candidateRevisionTriageDigestMarkdownPath = toRelative(candidateRevisionTriageDigestMarkdownPath);
+  artifacts.runtimeSloSummaryPath = toRelative(runtimeSloSummaryPath);
+  artifacts.runtimeSloSummaryMarkdownPath = toRelative(runtimeSloSummaryMarkdownPath);
+  artifacts.runtimeSloSummaryTextPath = toRelative(runtimeSloSummaryTextPath);
   artifacts.runtimeObservabilityBundlePath = toRelative(runtimeObservabilityBundlePath);
   artifacts.runtimeObservabilityBundleMarkdownPath = toRelative(runtimeObservabilityBundleMarkdownPath);
   artifacts.runtimeObservabilityEvidencePath = toRelative(runtimeObservabilityEvidencePath);
@@ -872,6 +943,37 @@ async function main(): Promise<void> {
           summary: "Cocos RC bundle produced the main-journey replay gate artifacts for reviewer staging.",
           outputs: outputs.map(toRelative)
         };
+      }
+    },
+    {
+      id: "runtime-slo-summary",
+      title: "Capture runtime SLO summary",
+      run: () => {
+        if (!args.serverUrl) {
+          return {
+            id: "runtime-slo-summary",
+            title: "Capture runtime SLO summary",
+            status: "skipped",
+            summary: "No --server-url was provided, so the runtime SLO summary was skipped."
+          };
+        }
+
+        return runOptionalFailingDiagnosticStage("runtime-slo-summary", "Capture runtime SLO summary", [
+          nodeExec,
+          "--import",
+          "tsx",
+          "./scripts/runtime-slo-summary.ts",
+          "--server-url",
+          args.serverUrl,
+          "--profile",
+          "candidate_gate",
+          "--output",
+          runtimeSloSummaryPath,
+          "--markdown-output",
+          runtimeSloSummaryMarkdownPath,
+          "--text-output",
+          runtimeSloSummaryTextPath
+        ], [runtimeSloSummaryPath, runtimeSloSummaryMarkdownPath, runtimeSloSummaryTextPath]);
       }
     },
     {

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -472,6 +472,24 @@ export function runOptionalFailingDiagnosticStage(id: string, title: string, com
         outputs: outputs.map(toRelative)
       };
     }
+
+    // Distinguish expected candidate_gate diagnostic behavior (exits 1 cleanly with
+    // no stderr output after writing all artifacts) from real CLI failures that can
+    // still write artifacts before throwing.  A subprocess that crashes after writing
+    // outputs (e.g. missing profile, network error) will emit an error to stderr and
+    // exit 1 via its catch handler.  No stderr output means the exit code 1 was a
+    // deliberate gate-failure signal, not an unhandled exception.
+    if (stderr) {
+      return {
+        id,
+        title,
+        status: "failed",
+        summary: stderr,
+        command: formatCommand(command),
+        exitCode: result.status,
+        outputs: outputs.map(toRelative)
+      };
+    }
   }
 
   const outputLines = `${stdout ?? ""}\n${stderr ?? ""}`
@@ -707,9 +725,9 @@ async function main(): Promise<void> {
   artifacts.candidateRevisionTriageInputPath = toRelative(candidateRevisionTriageInputPath);
   artifacts.candidateRevisionTriageDigestPath = toRelative(candidateRevisionTriageDigestPath);
   artifacts.candidateRevisionTriageDigestMarkdownPath = toRelative(candidateRevisionTriageDigestMarkdownPath);
-  artifacts.runtimeSloSummaryPath = toRelative(runtimeSloSummaryPath);
-  artifacts.runtimeSloSummaryMarkdownPath = toRelative(runtimeSloSummaryMarkdownPath);
-  artifacts.runtimeSloSummaryTextPath = toRelative(runtimeSloSummaryTextPath);
+  // runtimeSloSummary paths are set lazily inside the runtime-slo-summary stage only
+  // when --server-url is provided and the stage actually runs and produces the files.
+  // Do NOT advertise nonexistent paths when the stage is skipped.
   artifacts.runtimeObservabilityBundlePath = toRelative(runtimeObservabilityBundlePath);
   artifacts.runtimeObservabilityBundleMarkdownPath = toRelative(runtimeObservabilityBundleMarkdownPath);
   artifacts.runtimeObservabilityEvidencePath = toRelative(runtimeObservabilityEvidencePath);
@@ -1013,7 +1031,7 @@ async function main(): Promise<void> {
           };
         }
 
-        return runOptionalFailingDiagnosticStage("runtime-slo-summary", "Capture runtime SLO summary", [
+        const sloResult = runOptionalFailingDiagnosticStage("runtime-slo-summary", "Capture runtime SLO summary", [
           nodeExec,
           "--import",
           "tsx",
@@ -1029,6 +1047,19 @@ async function main(): Promise<void> {
           "--text-output",
           runtimeSloSummaryTextPath
         ], [runtimeSloSummaryPath, runtimeSloSummaryMarkdownPath, runtimeSloSummaryTextPath]);
+
+        // Only advertise artifact paths that were actually produced by this invocation.
+        if (fs.existsSync(runtimeSloSummaryPath)) {
+          artifacts.runtimeSloSummaryPath = toRelative(runtimeSloSummaryPath);
+        }
+        if (fs.existsSync(runtimeSloSummaryMarkdownPath)) {
+          artifacts.runtimeSloSummaryMarkdownPath = toRelative(runtimeSloSummaryMarkdownPath);
+        }
+        if (fs.existsSync(runtimeSloSummaryTextPath)) {
+          artifacts.runtimeSloSummaryTextPath = toRelative(runtimeSloSummaryTextPath);
+        }
+
+        return sloResult;
       }
     },
     {

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -958,7 +958,7 @@ async function main(): Promise<void> {
           };
         }
 
-        return runOptionalFailingDiagnosticStage("runtime-slo-summary", "Capture runtime SLO summary", [
+        return runCommandStage("runtime-slo-summary", "Capture runtime SLO summary", [
           nodeExec,
           "--import",
           "tsx",

--- a/scripts/phase1-candidate-rehearsal.ts
+++ b/scripts/phase1-candidate-rehearsal.ts
@@ -958,7 +958,7 @@ async function main(): Promise<void> {
           };
         }
 
-        return runCommandStage("runtime-slo-summary", "Capture runtime SLO summary", [
+        return runOptionalFailingDiagnosticStage("runtime-slo-summary", "Capture runtime SLO summary", [
           nodeExec,
           "--import",
           "tsx",

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -201,9 +201,10 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(report.artifacts.candidateRevisionTriageInputPath ?? "", /candidate-revision-triage-input-phase1-mainline-/);
   assert.match(report.artifacts.candidateRevisionTriageDigestPath ?? "", /candidate-revision-triage-digest-phase1-mainline-/);
   assert.match(report.artifacts.candidateRevisionTriageDigestMarkdownPath ?? "", /candidate-revision-triage-digest-phase1-mainline-/);
-  assert.match(report.artifacts.runtimeSloSummaryPath ?? "", /runtime-slo-summary-phase1-mainline-/);
-  assert.match(report.artifacts.runtimeSloSummaryMarkdownPath ?? "", /runtime-slo-summary-phase1-mainline-/);
-  assert.match(report.artifacts.runtimeSloSummaryTextPath ?? "", /runtime-slo-summary-phase1-mainline-/);
+  // runtime-slo-summary stage is skipped when --server-url is absent; paths must not be advertised.
+  assert.equal(report.artifacts.runtimeSloSummaryPath, undefined);
+  assert.equal(report.artifacts.runtimeSloSummaryMarkdownPath, undefined);
+  assert.equal(report.artifacts.runtimeSloSummaryTextPath, undefined);
   assert.match(report.artifacts.cocosBundlePath ?? "", /cocos-rc-evidence-bundle-phase1-mainline-/);
   assert.match(report.artifacts.runtimeObservabilityGatePath ?? "", /runtime-observability-gate-phase1-mainline-/);
   assert.match(report.artifacts.sameRevisionEvidenceBundleManifestPath ?? "", /phase1-same-revision-evidence-bundle-phase1-mainline-/);
@@ -273,9 +274,10 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /CI trend summary:/);
   assert.match(markdown, /CI trend summary markdown:/);
   assert.match(markdown, /Release readiness snapshot:/);
-  assert.match(markdown, /Runtime SLO summary markdown:/);
-  assert.match(markdown, /Runtime SLO summary:/);
-  assert.match(markdown, /Runtime SLO summary text:/);
+  // Runtime SLO summary lines must NOT appear in the markdown when --server-url is absent.
+  assert.doesNotMatch(markdown, /Runtime SLO summary markdown:/);
+  assert.doesNotMatch(markdown, /Runtime SLO summary:/);
+  assert.doesNotMatch(markdown, /Runtime SLO summary text:/);
   assert.match(markdown, new RegExp(`- Runtime observability gate: \`${escapeRegex(report.artifacts.runtimeObservabilityGatePath ?? "")}\``));
   assert.match(markdown, /Runtime observability gate markdown:/);
   assert.match(markdown, /H5 candidate smoke:/);
@@ -312,9 +314,10 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /candidateRevisionTriageInputPath:/);
   assert.match(markdown, /candidateRevisionTriageDigestPath:/);
   assert.match(markdown, /candidateRevisionTriageDigestMarkdownPath:/);
-  assert.match(markdown, /runtimeSloSummaryPath:/);
-  assert.match(markdown, /runtimeSloSummaryMarkdownPath:/);
-  assert.match(markdown, /runtimeSloSummaryTextPath:/);
+  // runtimeSloSummary keys must NOT appear in Generated Outputs when --server-url is absent.
+  assert.doesNotMatch(markdown, /runtimeSloSummaryPath:/);
+  assert.doesNotMatch(markdown, /runtimeSloSummaryMarkdownPath:/);
+  assert.doesNotMatch(markdown, /runtimeSloSummaryTextPath:/);
   assert.match(markdown, /cocosBundlePath:/);
   assert.match(markdown, /candidateEvidenceAuditPath:/);
   assert.match(markdown, /candidateEvidenceAuditMarkdownPath:/);
@@ -346,11 +349,11 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /goNoGoPacketPath:/);
   assert.match(markdown, /releasePrCommentPath:/);
 
-  const runtimeSloMarkdownIndex = markdown.indexOf("Runtime SLO summary markdown:");
-  const runtimeObservabilityGateIndex = markdown.indexOf("Runtime observability gate:");
-  assert.notEqual(runtimeSloMarkdownIndex, -1);
-  assert.notEqual(runtimeObservabilityGateIndex, -1);
-  assert.ok(runtimeSloMarkdownIndex < runtimeObservabilityGateIndex);
+  // When --server-url is absent, "Runtime SLO summary markdown:" must not appear at all.
+  // "Runtime observability gate:" still appears because the observability paths are set
+  // unconditionally (the bundle dir path is always computed for use by downstream stages).
+  assert.equal(markdown.indexOf("Runtime SLO summary markdown:"), -1);
+  assert.notEqual(markdown.indexOf("Runtime observability gate:"), -1);
 });
 
 test("runOptionalFailingDiagnosticStage: stale artifacts from a prior run with exit code 1 are reported as failed", () => {
@@ -498,6 +501,40 @@ test("runOptionalFailingDiagnosticStage: freshly written artifacts with exit cod
 
     assert.equal(result.status, "passed", "freshly written artifacts + exit 1 must be reported as passed");
     assert.equal(result.exitCode, 1);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runOptionalFailingDiagnosticStage: exit code 1 with fresh artifacts but stderr output is reported as failed (real CLI failure)", () => {
+  // Regression: a real CLI failure (e.g. unhandled exception after writing outputs) writes
+  // fresh artifacts AND emits an error to stderr before exiting 1.  The stage must be
+  // reported as failed, not silently passed, because the artifacts may be partial/invalid.
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-optional-stage-stderr-"));
+  try {
+    const outputA = path.join(workspace, "output-a.json");
+    const outputB = path.join(workspace, "output-b.md");
+
+    // Command writes both output files (fresh), emits an error to stderr, then exits 1 —
+    // simulating a script that crashed after producing its output (e.g. profile not found).
+    const writeScript = [
+      "const fs = require('fs');",
+      `fs.writeFileSync(${JSON.stringify(outputA)}, '{}\\n');`,
+      `fs.writeFileSync(${JSON.stringify(outputB)}, '#ok\\n');`,
+      "process.stderr.write('Error: Requested profile candidate_gate is missing from the runtime SLO summary.\\n');",
+      "process.exit(1);"
+    ].join(" ");
+
+    const result = runOptionalFailingDiagnosticStage(
+      "test-stage",
+      "Test Stage",
+      [process.execPath, "-e", writeScript],
+      [outputA, outputB]
+    );
+
+    assert.equal(result.status, "failed", "fresh artifacts + exit 1 + stderr must be reported as failed (real CLI failure)");
+    assert.equal(result.exitCode, 1);
+    assert.match(result.summary, /Requested profile candidate_gate/, "summary must surface the stderr error message");
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -176,6 +176,7 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.equal(report.stages.find((stage) => stage.id === "candidate-revision-triage-digest")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "cocos-rc-bundle")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "cocos-main-journey-replay-gate")?.status, "passed");
+  assert.equal(report.stages.find((stage) => stage.id === "runtime-slo-summary")?.status, "skipped");
   assert.equal(report.stages.find((stage) => stage.id === "runtime-observability-bundle")?.status, "skipped");
   assert.equal(report.stages.find((stage) => stage.id === "phase1-same-revision-evidence-bundle")?.status, "passed");
   assert.equal(report.stages.find((stage) => stage.id === "phase1-release-evidence-drift-gate")?.status, "passed");
@@ -198,6 +199,9 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(report.artifacts.candidateRevisionTriageInputPath ?? "", /candidate-revision-triage-input-phase1-mainline-/);
   assert.match(report.artifacts.candidateRevisionTriageDigestPath ?? "", /candidate-revision-triage-digest-phase1-mainline-/);
   assert.match(report.artifacts.candidateRevisionTriageDigestMarkdownPath ?? "", /candidate-revision-triage-digest-phase1-mainline-/);
+  assert.match(report.artifacts.runtimeSloSummaryPath ?? "", /runtime-slo-summary-phase1-mainline-/);
+  assert.match(report.artifacts.runtimeSloSummaryMarkdownPath ?? "", /runtime-slo-summary-phase1-mainline-/);
+  assert.match(report.artifacts.runtimeSloSummaryTextPath ?? "", /runtime-slo-summary-phase1-mainline-/);
   assert.match(report.artifacts.cocosBundlePath ?? "", /cocos-rc-evidence-bundle-phase1-mainline-/);
   assert.match(report.artifacts.runtimeObservabilityGatePath ?? "", /runtime-observability-gate-phase1-mainline-/);
   assert.match(report.artifacts.sameRevisionEvidenceBundleManifestPath ?? "", /phase1-same-revision-evidence-bundle-phase1-mainline-/);
@@ -267,6 +271,9 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /CI trend summary:/);
   assert.match(markdown, /CI trend summary markdown:/);
   assert.match(markdown, /Release readiness snapshot:/);
+  assert.match(markdown, /Runtime SLO summary markdown:/);
+  assert.match(markdown, /Runtime SLO summary:/);
+  assert.match(markdown, /Runtime SLO summary text:/);
   assert.match(markdown, new RegExp(`- Runtime observability gate: \`${escapeRegex(report.artifacts.runtimeObservabilityGatePath ?? "")}\``));
   assert.match(markdown, /Runtime observability gate markdown:/);
   assert.match(markdown, /H5 candidate smoke:/);
@@ -303,6 +310,9 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /candidateRevisionTriageInputPath:/);
   assert.match(markdown, /candidateRevisionTriageDigestPath:/);
   assert.match(markdown, /candidateRevisionTriageDigestMarkdownPath:/);
+  assert.match(markdown, /runtimeSloSummaryPath:/);
+  assert.match(markdown, /runtimeSloSummaryMarkdownPath:/);
+  assert.match(markdown, /runtimeSloSummaryTextPath:/);
   assert.match(markdown, /cocosBundlePath:/);
   assert.match(markdown, /candidateEvidenceAuditPath:/);
   assert.match(markdown, /candidateEvidenceAuditMarkdownPath:/);
@@ -333,4 +343,10 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.match(markdown, /phase1CandidateDossierMarkdownPath:/);
   assert.match(markdown, /goNoGoPacketPath:/);
   assert.match(markdown, /releasePrCommentPath:/);
+
+  const runtimeSloMarkdownIndex = markdown.indexOf("Runtime SLO summary markdown:");
+  const runtimeObservabilityGateIndex = markdown.indexOf("Runtime observability gate:");
+  assert.notEqual(runtimeSloMarkdownIndex, -1);
+  assert.notEqual(runtimeObservabilityGateIndex, -1);
+  assert.ok(runtimeSloMarkdownIndex < runtimeObservabilityGateIndex);
 });

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -363,10 +363,7 @@ test("runOptionalFailingDiagnosticStage: stale artifacts from a prior run with e
     fs.writeFileSync(outputA, '{"stale":true}\n', "utf8");
     fs.writeFileSync(outputB, "# Stale\n", "utf8");
 
-    // Back-date the files to clearly beyond the COARSE_MTIME_TOLERANCE_MS (2 s)
-    // window so the wall-clock freshness check reliably classifies them as stale.
-    // Real stale artifacts from a prior run would have been written minutes or
-    // hours earlier; we use 5 s here to keep the test fast while staying safe.
+    // Back-date the files to simulate artifacts from an old prior run.
     const staleTime = new Date(Date.now() - 5000);
     fs.utimesSync(outputA, staleTime, staleTime);
     fs.utimesSync(outputB, staleTime, staleTime);
@@ -388,23 +385,68 @@ test("runOptionalFailingDiagnosticStage: stale artifacts from a prior run with e
   }
 });
 
-test("runOptionalFailingDiagnosticStage: freshly rewritten artifacts with same mtime are not misclassified as stale on coarse-mtime filesystems", () => {
-  // Regression: the original mtime-to-mtime comparison (`currentMtime <= priorMtime`)
-  // falsely classified a freshly rewritten file as stale when the write landed in the
-  // same coarse time-bucket as the pre-run snapshot (e.g. FAT32 at 2 s or NFS at 1 s).
-  // We simulate this by having the command rewrite the artifact and then restore its
-  // mtime to the original value via utimesSync, as a coarse filesystem would.
+test("runOptionalFailingDiagnosticStage: recent stale artifacts (within former 2s tolerance window) are not false-positive passed on quick rerun", () => {
+  // Regression: the wall-clock tolerance approach accepted stale artifacts from
+  // very recent prior runs whose mtimes fell inside the 2-second window, causing
+  // a false-positive pass when the subprocess exited with code 1 without writing.
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-optional-stage-quickrerun-"));
+  try {
+    const outputA = path.join(workspace, "output-a.json");
+    const outputB = path.join(workspace, "output-b.md");
+
+    // Pre-create artifacts with a current mtime, simulating a very recent prior run
+    // (e.g. a rerun triggered less than 2 seconds after the previous invocation).
+    // The mtime is intentionally left "recent" — no back-dating needed — because
+    // the bug was that the 2s tolerance window accepted even millisecond-old files.
+    fs.writeFileSync(outputA, '{"stale":true}\n', "utf8");
+    fs.writeFileSync(outputB, "# Stale\n", "utf8");
+    // Capture mtimes right after writing so the pre-run snapshot will match them.
+    // (No sleep needed: the subprocess will not touch these files.)
+
+    // Command exits with code 1 without refreshing the output files.
+    const result = runOptionalFailingDiagnosticStage(
+      "test-stage",
+      "Test Stage",
+      [process.execPath, "-e", "process.exit(1)"],
+      [outputA, outputB]
+    );
+
+    assert.equal(result.status, "failed", "recent stale artifacts + exit 1 must be reported as failed, not passed (quick-rerun regression)");
+    assert.equal(result.exitCode, 1);
+    assert.match(result.summary, /not refreshed by this invocation/);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runOptionalFailingDiagnosticStage: artifact rewritten in same coarse-mtime bucket is reported as failed (conservative / safe direction)", () => {
+  // On coarse-grained filesystems (FAT32 2 s, NFS 1 s), a write that lands in the
+  // same mtime bucket as the prior write produces no mtime advancement.  This is
+  // indistinguishable — from mtime alone — from a stale artifact left by a quick
+  // rerun that did NOT refresh the file.
+  //
+  // The previous approach used a 2-second wall-clock tolerance to treat
+  // "mtime unchanged but recent" as "fresh", but that same window caused
+  // false-positive passes for stale artifacts from quick reruns (the blocking
+  // review finding for #1358).
+  //
+  // We now require a strict mtime increase as proof of freshness.  When the
+  // filesystem cannot provide that (coarse bucket collision), we err conservatively:
+  // the stage is reported as failed rather than granted a spurious pass.  This is
+  // the safe direction — a false negative (unnecessary failure) is preferable to a
+  // false positive (masked real failure).  In practice, diagnostic subprocesses that
+  // take more than a fraction of a second will always produce a measurable mtime
+  // advance on Linux/ext4/NTFS/APFS, so this trade-off rarely matters in CI.
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-optional-stage-coarse-mtime-"));
   try {
     const outputA = path.join(workspace, "output-a.json");
 
-    // Pre-create the artifact with a current mtime (recent, but pre-existing).
+    // Pre-create the artifact with a current mtime.
     fs.writeFileSync(outputA, '{"old":true}\n', "utf8");
     const existingMtimeMs = fs.statSync(outputA).mtimeMs;
 
     // The command rewrites outputA but then resets its mtime back to the original
-    // value, mimicking a coarse-grained filesystem that rounds the write timestamp
-    // into the same bucket as the prior write.
+    // value, mimicking a coarse-grained filesystem bucket collision.
     const writeScript = [
       "const fs = require('fs');",
       `fs.writeFileSync(${JSON.stringify(outputA)}, '{"new":true}\\n');`,
@@ -419,12 +461,14 @@ test("runOptionalFailingDiagnosticStage: freshly rewritten artifacts with same m
       [outputA]
     );
 
+    // Conservative: mtime did not advance → reported as failed (safe direction).
     assert.equal(
       result.status,
-      "passed",
-      "freshly rewritten artifact whose mtime was not advanced by a coarse filesystem must not be misclassified as stale"
+      "failed",
+      "artifact whose mtime was not advanced (coarse bucket or untouched) must be reported as failed for safety"
     );
     assert.equal(result.exitCode, 1);
+    assert.match(result.summary, /not refreshed by this invocation/);
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { runOptionalFailingDiagnosticStage } from "../phase1-candidate-rehearsal.ts";
+
 const repoRoot = path.resolve(__dirname, "../..");
 const fixtureBuildDir = path.join(repoRoot, "apps", "cocos-client", "test", "fixtures", "wechatgame-export");
 const defaultConfigPath = path.join(repoRoot, "apps", "cocos-client", "wechat-minigame.build.json");
@@ -349,4 +351,86 @@ test("release:phase1:candidate-rehearsal assembles stable candidate-scoped rehea
   assert.notEqual(runtimeSloMarkdownIndex, -1);
   assert.notEqual(runtimeObservabilityGateIndex, -1);
   assert.ok(runtimeSloMarkdownIndex < runtimeObservabilityGateIndex);
+});
+
+test("runOptionalFailingDiagnosticStage: stale artifacts from a prior run with exit code 1 are reported as failed", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-optional-stage-stale-"));
+  try {
+    const outputA = path.join(workspace, "output-a.json");
+    const outputB = path.join(workspace, "output-b.md");
+
+    // Pre-create stale artifacts that would have been left from a previous invocation.
+    fs.writeFileSync(outputA, '{"stale":true}\n', "utf8");
+    fs.writeFileSync(outputB, "# Stale\n", "utf8");
+
+    // Command exits with code 1 but does NOT write or touch the output files,
+    // simulating a server-unreachable failure during a rerun.
+    const result = runOptionalFailingDiagnosticStage(
+      "test-stage",
+      "Test Stage",
+      [process.execPath, "-e", "process.exit(1)"],
+      [outputA, outputB]
+    );
+
+    assert.equal(result.status, "failed", "stale artifacts + exit 1 must be reported as failed, not passed");
+    assert.equal(result.exitCode, 1);
+    assert.match(result.summary, /not refreshed by this invocation/, "summary must identify the stale artifact problem");
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runOptionalFailingDiagnosticStage: freshly written artifacts with exit code 1 are reported as passed", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-optional-stage-fresh-"));
+  try {
+    const outputA = path.join(workspace, "output-a.json");
+    const outputB = path.join(workspace, "output-b.md");
+
+    // No pre-existing files — command writes them fresh and exits 1 (the expected
+    // candidate_gate diagnostic case where the gate itself fails but artifacts are produced).
+    const writeScript = [
+      "const fs = require('fs');",
+      `fs.writeFileSync(${JSON.stringify(outputA)}, '{}\\n');`,
+      `fs.writeFileSync(${JSON.stringify(outputB)}, '#ok\\n');`,
+      "process.exit(1);"
+    ].join(" ");
+
+    const result = runOptionalFailingDiagnosticStage(
+      "test-stage",
+      "Test Stage",
+      [process.execPath, "-e", writeScript],
+      [outputA, outputB]
+    );
+
+    assert.equal(result.status, "passed", "freshly written artifacts + exit 1 must be reported as passed");
+    assert.equal(result.exitCode, 1);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runOptionalFailingDiagnosticStage: exit code 2 is always reported as failed regardless of artifacts", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-optional-stage-exit2-"));
+  try {
+    const outputA = path.join(workspace, "output-a.json");
+
+    // Command writes the artifact but exits with code 2 (not 0 or 1).
+    const writeScript = [
+      "const fs = require('fs');",
+      `fs.writeFileSync(${JSON.stringify(outputA)}, '{}\\n');`,
+      "process.exit(2);"
+    ].join(" ");
+
+    const result = runOptionalFailingDiagnosticStage(
+      "test-stage",
+      "Test Stage",
+      [process.execPath, "-e", writeScript],
+      [outputA]
+    );
+
+    assert.equal(result.status, "failed", "exit code 2 must always be reported as failed");
+    assert.equal(result.exitCode, 2);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
 });

--- a/scripts/test/phase1-candidate-rehearsal.test.ts
+++ b/scripts/test/phase1-candidate-rehearsal.test.ts
@@ -363,6 +363,14 @@ test("runOptionalFailingDiagnosticStage: stale artifacts from a prior run with e
     fs.writeFileSync(outputA, '{"stale":true}\n', "utf8");
     fs.writeFileSync(outputB, "# Stale\n", "utf8");
 
+    // Back-date the files to clearly beyond the COARSE_MTIME_TOLERANCE_MS (2 s)
+    // window so the wall-clock freshness check reliably classifies them as stale.
+    // Real stale artifacts from a prior run would have been written minutes or
+    // hours earlier; we use 5 s here to keep the test fast while staying safe.
+    const staleTime = new Date(Date.now() - 5000);
+    fs.utimesSync(outputA, staleTime, staleTime);
+    fs.utimesSync(outputB, staleTime, staleTime);
+
     // Command exits with code 1 but does NOT write or touch the output files,
     // simulating a server-unreachable failure during a rerun.
     const result = runOptionalFailingDiagnosticStage(
@@ -375,6 +383,48 @@ test("runOptionalFailingDiagnosticStage: stale artifacts from a prior run with e
     assert.equal(result.status, "failed", "stale artifacts + exit 1 must be reported as failed, not passed");
     assert.equal(result.exitCode, 1);
     assert.match(result.summary, /not refreshed by this invocation/, "summary must identify the stale artifact problem");
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("runOptionalFailingDiagnosticStage: freshly rewritten artifacts with same mtime are not misclassified as stale on coarse-mtime filesystems", () => {
+  // Regression: the original mtime-to-mtime comparison (`currentMtime <= priorMtime`)
+  // falsely classified a freshly rewritten file as stale when the write landed in the
+  // same coarse time-bucket as the pre-run snapshot (e.g. FAT32 at 2 s or NFS at 1 s).
+  // We simulate this by having the command rewrite the artifact and then restore its
+  // mtime to the original value via utimesSync, as a coarse filesystem would.
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-optional-stage-coarse-mtime-"));
+  try {
+    const outputA = path.join(workspace, "output-a.json");
+
+    // Pre-create the artifact with a current mtime (recent, but pre-existing).
+    fs.writeFileSync(outputA, '{"old":true}\n', "utf8");
+    const existingMtimeMs = fs.statSync(outputA).mtimeMs;
+
+    // The command rewrites outputA but then resets its mtime back to the original
+    // value, mimicking a coarse-grained filesystem that rounds the write timestamp
+    // into the same bucket as the prior write.
+    const writeScript = [
+      "const fs = require('fs');",
+      `fs.writeFileSync(${JSON.stringify(outputA)}, '{"new":true}\\n');`,
+      `fs.utimesSync(${JSON.stringify(outputA)}, new Date(${existingMtimeMs}), new Date(${existingMtimeMs}));`,
+      "process.exit(1);"
+    ].join(" ");
+
+    const result = runOptionalFailingDiagnosticStage(
+      "test-stage",
+      "Test Stage",
+      [process.execPath, "-e", writeScript],
+      [outputA]
+    );
+
+    assert.equal(
+      result.status,
+      "passed",
+      "freshly rewritten artifact whose mtime was not advanced by a coarse filesystem must not be misclassified as stale"
+    );
+    assert.equal(result.exitCode, 1);
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }

--- a/scripts/test/runtime-slo-summary.test.ts
+++ b/scripts/test/runtime-slo-summary.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -17,6 +20,7 @@ import {
   resetRuntimeObservability,
   setAuthTokenDeliveryQueueLatency
 } from "../../apps/server/src/observability";
+import { runRuntimeSloSummaryCli } from "../runtime-slo-summary.ts";
 
 function seedRooms(count: number): void {
   for (let index = 0; index < count; index += 1) {
@@ -107,4 +111,75 @@ test("buildRuntimeSloSummaryPayload classifies backlog, latency, and error-rate 
   assert.equal(candidateGate?.checks.find((check) => check.id === "reconnect_error_rate")?.status, "fail");
   assert.equal(candidateGate?.checks.find((check) => check.id === "token_delivery_error_rate")?.status, "fail");
   assert.match(renderRuntimeSloSummaryMarkdown(report), /Alert-Friendly Diagnostics/);
+});
+
+test("runRuntimeSloSummaryCli returns exit code 1 and writes all artifacts when candidate_gate fails", async () => {
+  // Seed a failing observability state (too few rooms, no gameplay traffic)
+  resetRuntimeObservability();
+  for (let index = 0; index < 3; index += 1) {
+    recordRuntimeRoom({
+      roomId: `room-${index + 1}`,
+      day: 3,
+      connectedPlayers: 1,
+      heroCount: 2,
+      activeBattles: 0,
+      updatedAt: "2026-04-16T12:00:00.000Z"
+    });
+  }
+
+  const payload = buildRuntimeSloSummaryPayload("project-veil-test");
+  const markdown = renderRuntimeSloSummaryMarkdown(payload);
+  const text = renderRuntimeSloSummaryText(payload);
+
+  const candidateGate = payload.profiles.find((p) => p.id === "candidate_gate");
+  assert.equal(candidateGate?.status, "fail", "setup: candidate_gate must be failing for this test to be meaningful");
+
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-slo-cli-test-"));
+  const jsonPath = path.join(workspace, "slo.json");
+  const mdPath = path.join(workspace, "slo.md");
+  const txtPath = path.join(workspace, "slo.txt");
+  const serverUrl = "http://127.0.0.1:19999";
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : (input as Request).url;
+    if (url === `${serverUrl}/api/runtime/slo-summary`) {
+      return { ok: true, status: 200, json: async () => payload, text: async () => "" } as Response;
+    }
+    if (url === `${serverUrl}/api/runtime/slo-summary?format=markdown`) {
+      return { ok: true, status: 200, json: async () => ({}), text: async () => markdown } as Response;
+    }
+    if (url === `${serverUrl}/api/runtime/slo-summary?format=text`) {
+      return { ok: true, status: 200, json: async () => ({}), text: async () => text } as Response;
+    }
+    throw new Error(`Unexpected fetch in test: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const exitCode = await runRuntimeSloSummaryCli([
+      "node",
+      "scripts/runtime-slo-summary.ts",
+      "--server-url",
+      serverUrl,
+      "--profile",
+      "candidate_gate",
+      "--output",
+      jsonPath,
+      "--markdown-output",
+      mdPath,
+      "--text-output",
+      txtPath
+    ]);
+
+    assert.equal(exitCode, 1, "CLI must exit with code 1 when candidate_gate is failing");
+    assert.ok(fs.existsSync(jsonPath), "JSON artifact must be written even when candidate_gate fails");
+    assert.ok(fs.existsSync(mdPath), "markdown artifact must be written even when candidate_gate fails");
+    assert.ok(fs.existsSync(txtPath), "text artifact must be written even when candidate_gate fails");
+
+    const written = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+    assert.equal(written.profiles.find((p: { id: string }) => p.id === "candidate_gate")?.status, "fail");
+  } finally {
+    globalThis.fetch = originalFetch;
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- stage a candidate-scoped runtime SLO summary artifact set inside the phase1 candidate rehearsal bundle
- surface the runtime SLO summary markdown ahead of the runtime observability gate in `SUMMARY.md`
- cover the new front-door entry and ordering in the focused rehearsal test

## Testing
- `npm run test:phase1-candidate-rehearsal`

Closes #1358.