### PR TITLE
Fix config-center rollback window configuration

### DIFF
--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -501,13 +501,14 @@ interface ConfigRollbackMonitorState {
   previousBundle: RuntimeConfigBundle;
   appliedAtMs: number;
   appliedAt: string;
+  windowMs: number;
   handle: ConfigCenterTimerHandle;
 }
 
 const CONFIG_CENTER_LIBRARY_FILE = ".config-center-library.json";
 const MAX_STAGE_DOCUMENTS = 5;
 const MAX_PUBLISH_HISTORY_ENTRIES = 20;
-const CONFIG_HOT_RELOAD_MONITOR_WINDOW_MS = 30_000;
+const DEFAULT_CONFIG_HOT_RELOAD_MONITOR_WINDOW_MS = 120_000;
 const CONFIG_HOT_RELOAD_ERROR_THRESHOLD = 3;
 const BUILTIN_DIFFICULTY_PRESET_IDS = ["easy", "normal", "hard"] as const;
 const BUILTIN_WORLD_LAYOUT_PRESETS = [
@@ -2296,6 +2297,15 @@ function runtimeRoomsWithActiveBattles(): ConfigHotReloadRoomState[] {
   return snapshot.rooms.filter((room) => room.activeBattles > 0);
 }
 
+function readConfigRollbackWindowMs(env: NodeJS.ProcessEnv = process.env): number {
+  const parsed = Number(env.CONFIG_ROLLBACK_WINDOW_MS?.trim());
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_CONFIG_HOT_RELOAD_MONITOR_WINDOW_MS;
+  }
+
+  return Math.floor(parsed);
+}
+
 function clearConfigRollbackMonitor(): void {
   if (!configRollbackMonitorState) {
     return;
@@ -2336,7 +2346,7 @@ function rollbackRuntimeBundleIfNeeded(): void {
   notifyConfigUpdateListeners(monitor.previousBundle);
   lastConfigRuntimeApplyResult = {
     status: "applied",
-    message: `热更新后 30 秒内捕获 ${recentErrorCount} 个房间错误，已自动回滚到上一版本。`
+    message: `热更新后 ${monitor.windowMs} ms 内捕获 ${recentErrorCount} 个房间错误，已自动回滚到上一版本。`
   };
   console.error("[config-center] Rolled back config hot reload after runtime error spike", {
     appliedAt: monitor.appliedAt,
@@ -2388,15 +2398,17 @@ function startConfigRollbackMonitor(previousBundle: RuntimeConfigBundle | null):
   }
 
   const appliedAtMs = configCenterRuntimeDependencies.now();
+  const windowMs = readConfigRollbackWindowMs();
   const handle = configCenterRuntimeDependencies.setTimeout(
     () => rollbackRuntimeBundleIfNeeded(),
-    CONFIG_HOT_RELOAD_MONITOR_WINDOW_MS
+    windowMs
   );
   handle.unref?.();
   configRollbackMonitorState = {
     previousBundle,
     appliedAtMs,
     appliedAt: new Date(appliedAtMs).toISOString(),
+    windowMs,
     handle
   };
 }

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -174,6 +174,7 @@ async function seedConfigRoot(rootDir: string): Promise<void> {
 }
 
 test.afterEach(() => {
+  delete process.env.CONFIG_ROLLBACK_WINDOW_MS;
   resetRuntimeConfigs();
   resetConfigHotReloadState();
   resetConfigCenterRuntimeDependencies();
@@ -842,15 +843,18 @@ test("config center rolls back hot reloads after a room error spike within the s
   await store.initializeRuntimeConfigs();
 
   let scheduledHandler: (() => void) | null = null;
+  let scheduledDelayMs: number | null = null;
   const baselineMs = Date.parse("2026-04-11T16:15:00.000Z");
   configureConfigCenterRuntimeDependencies({
     now: () => baselineMs,
-    setTimeout: (handler) => {
+    setTimeout: (handler, delayMs) => {
       scheduledHandler = handler;
+      scheduledDelayMs = delayMs;
       return {};
     },
     clearTimeout: () => {
       scheduledHandler = null;
+      scheduledDelayMs = null;
     }
   });
 
@@ -863,6 +867,7 @@ test("config center rolls back hot reloads after a room error spike within the s
   );
   assert.equal(getDefaultWorldConfig().width, 10);
   assert.ok(scheduledHandler);
+  assert.equal(scheduledDelayMs, 120_000);
 
   for (let index = 0; index < 3; index += 1) {
     recordRuntimeErrorEvent({
@@ -891,4 +896,34 @@ test("config center rolls back hot reloads after a room error spike within the s
 
   scheduledHandler?.();
   assert.equal(getDefaultWorldConfig().width, WORLD_CONFIG.width);
+});
+
+test("config center honors CONFIG_ROLLBACK_WINDOW_MS when scheduling the hot reload safety window", async () => {
+  process.env.CONFIG_ROLLBACK_WINDOW_MS = "45000";
+
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+  await store.initializeRuntimeConfigs();
+
+  let scheduledDelayMs: number | null = null;
+  configureConfigCenterRuntimeDependencies({
+    setTimeout: (_handler, delayMs) => {
+      scheduledDelayMs = delayMs;
+      return {};
+    },
+    clearTimeout: () => {
+      scheduledDelayMs = null;
+    }
+  });
+
+  await store.saveDocument(
+    "world",
+    JSON.stringify({
+      ...WORLD_CONFIG,
+      width: 11
+    })
+  );
+
+  assert.equal(scheduledDelayMs, 45_000);
 });

--- a/docs/config-deployment-safety.md
+++ b/docs/config-deployment-safety.md
@@ -4,7 +4,7 @@ Use config hot reload only inside a planned safety window. The current runtime b
 
 - schema-incompatible hot reloads are rejected before persistence with an explicit error
 - compatible updates are delayed while any room still has an in-progress battle
-- once the update applies, the server watches the next 30 seconds for multiplayer runtime error spikes and rolls back automatically if the threshold is crossed
+- once the update applies, the server watches the configured rollback window (`CONFIG_ROLLBACK_WINDOW_MS`, default `120000` ms) for multiplayer runtime error spikes and rolls back automatically if the threshold is crossed
 
 Recommended operator workflow:
 
@@ -12,11 +12,11 @@ Recommended operator workflow:
 2. Confirm no high-priority live event, tournament, or guided playtest is running.
 3. Check active room count and active battle count before publishing.
 4. Publish config changes through Config Center staged publish rather than ad hoc file edits.
-5. Watch room/runtime errors for at least 30 seconds after the update clears the battle gate.
+5. Watch room/runtime errors for at least the configured rollback window after the update clears the battle gate.
 6. If the publish remains pending because battles are still active, wait for settlement instead of forcing a room restart.
 
 Rollback guidance:
 
-- treat repeated room retirement, reconnect failure, or battle abort errors during the 30 second watch window as a release blocker
+- treat repeated room retirement, reconnect failure, or battle abort errors during the rollback watch window as a release blocker
 - if auto-rollback triggers, stop further config publishes until the failing diff is isolated
 - capture the rejected or rolled-back publish id in the release calendar so the next window starts from the last known good snapshot

--- a/docs/release-readiness-snapshot.md
+++ b/docs/release-readiness-snapshot.md
@@ -8,7 +8,7 @@ If you want a single human-readable Phase 1 dashboard on top of the snapshot plu
 
 If you want a CI-oriented pass/fail summary that also folds in packaged H5 smoke and WeChat release evidence, use `npm run release:gate:summary` and see `docs/release-gate-summary.md`.
 
-For config publishes, follow [`docs/config-deployment-safety.md`](./config-deployment-safety.md): prefer the 03:00-05:00 low-traffic window, verify active battles are drained or allow the runtime gate to defer the apply, and watch the 30 second rollback window before treating the deploy as complete.
+For config publishes, follow [`docs/config-deployment-safety.md`](./config-deployment-safety.md): prefer the 03:00-05:00 low-traffic window, verify active battles are drained or allow the runtime gate to defer the apply, and watch the config rollback window (`CONFIG_ROLLBACK_WINDOW_MS`, default `120000` ms) before treating the deploy as complete.
 
 The default automated checks are:
 


### PR DESCRIPTION
## Summary
- read the config-center rollback safety window from `CONFIG_ROLLBACK_WINDOW_MS`
- default the rollback safety window to `120000` ms and cover the default/override scheduling in tests
- update the rollout docs so operators watch the configured rollback window

Closes #1382