### PR TITLE
[codex] Add missing analytics session and purchase outcome events

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -587,6 +587,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
   private readonly minorProtectionConfig = readMinorProtectionConfig();
   private readonly lobbyRoomOwnerToken = nextLobbyRoomOwnerToken++;
   private readonly playerIdBySessionId = new Map<string, string>();
+  private readonly analyticsSessionStartedAtBySessionId = new Map<string, number>();
+  private readonly analyticsSessionDisconnectReasonBySessionId = new Map<string, string>();
   private readonly disconnectedAtByPlayerId = new Map<string, string>();
   private readonly reconnectedAtByPlayerId = new Map<string, string>();
   private readonly wsActionTimestampsByPlayerId = new Map<string, number[]>();
@@ -731,6 +733,8 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
           platform: "colyseus"
         }
       });
+      this.analyticsSessionStartedAtBySessionId.set(client.sessionId, roomRuntimeDependencies.now());
+      this.analyticsSessionDisconnectReasonBySessionId.delete(client.sessionId);
     });
 
     this.onMessage("world.preview", (client, message: Extract<ClientMessage, { type: "world.preview" }>) => {
@@ -1028,6 +1032,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         continue;
       }
 
+      this.analyticsSessionDisconnectReasonBySessionId.set(client.sessionId, reason);
       sendMessage(client, "error", { requestId: "push", reason });
       client.leave(CloseCode.WITH_ERROR, reason);
       disconnected += 1;
@@ -1081,6 +1086,12 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         return;
       }
       this.playerIdBySessionId.set(reconnectedClient.sessionId, playerId);
+      const previousSessionStartedAtMs = this.analyticsSessionStartedAtBySessionId.get(client.sessionId);
+      if (previousSessionStartedAtMs != null) {
+        this.analyticsSessionStartedAtBySessionId.set(reconnectedClient.sessionId, previousSessionStartedAtMs);
+      }
+      this.analyticsSessionStartedAtBySessionId.delete(client.sessionId);
+      this.analyticsSessionDisconnectReasonBySessionId.delete(client.sessionId);
       this.disconnectedAtByPlayerId.delete(playerId);
       this.reconnectedAtByPlayerId.set(playerId, new Date().toISOString());
       this.ensureTurnTimerState();
@@ -1098,6 +1109,14 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         reconnectWindowOpen = false;
       }
     } catch (error) {
+      this.emitSessionEndForConnection(
+        client.sessionId,
+        playerId,
+        classifyReconnectFailure({
+          error,
+          fallbackReason: "reconnect_window_expired"
+        })
+      );
       if (reconnectWindowOpen) {
         recordReconnectWindowResolved("failure", {
           roomId: this.metadata.logicalRoomId,
@@ -1121,6 +1140,13 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     this.suspiciousActionTrackerBySessionId.delete(client.sessionId);
     this.completedActionRepliesBySessionId.delete(client.sessionId);
     this.pendingActionRepliesBySessionId.delete(client.sessionId);
+    if (playerId) {
+      this.emitSessionEndForConnection(
+        client.sessionId,
+        playerId,
+        this.analyticsSessionDisconnectReasonBySessionId.get(client.sessionId) ?? "transport_closed"
+      );
+    }
     if (playerId && !this.getConnectedPlayerIds().includes(playerId)) {
       this.disconnectedAtByPlayerId.set(playerId, new Date(roomRuntimeDependencies.now()).toISOString());
     }
@@ -1130,6 +1156,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
   }
 
   onDispose(): void {
+    for (const [sessionId, playerId] of this.playerIdBySessionId.entries()) {
+      this.emitSessionEndForConnection(sessionId, playerId, "room_disposed");
+    }
     this.unsubscribeConfigUpdate?.();
     this.unsubscribeConfigUpdate = null;
     this.wsActionTimestampsByPlayerId.clear();
@@ -1140,6 +1169,26 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     }
 
     this.retireRoom("dispose");
+  }
+
+  private emitSessionEndForConnection(sessionId: string, playerId: string, disconnectReason: string): void {
+    const startedAtMs = this.analyticsSessionStartedAtBySessionId.get(sessionId);
+    this.analyticsSessionStartedAtBySessionId.delete(sessionId);
+    this.analyticsSessionDisconnectReasonBySessionId.delete(sessionId);
+    if (startedAtMs == null) {
+      return;
+    }
+
+    emitAnalyticsEvent("session_end", {
+      playerId,
+      roomId: this.metadata.logicalRoomId,
+      sessionId,
+      payload: {
+        roomId: this.metadata.logicalRoomId,
+        disconnectReason,
+        sessionDurationMs: Math.max(0, roomRuntimeDependencies.now() - startedAtMs)
+      }
+    });
   }
 
   private restoreWorldRoom(snapshot: RoomPersistenceSnapshot): void {

--- a/apps/server/src/shop.ts
+++ b/apps/server/src/shop.ts
@@ -94,6 +94,25 @@ function toErrorPayload(error: unknown): { code: string; message: string } {
   };
 }
 
+function emitPurchaseFailedEvent(input: {
+  playerId: string;
+  purchaseId: string;
+  productId: string;
+  paymentMethod: "gems" | "wechat_pay";
+  failureReason: string;
+}): void {
+  emitAnalyticsEvent("purchase_failed", {
+    playerId: input.playerId,
+    payload: {
+      purchaseId: input.purchaseId,
+      productId: input.productId,
+      paymentMethod: input.paymentMethod,
+      failureReason: input.failureReason,
+      orderStatus: "failed"
+    }
+  });
+}
+
 function normalizePositiveInteger(value: number, field: string, allowZero = false): number {
   const normalized = Math.floor(value);
   if (!Number.isFinite(value) || (!allowZero && normalized <= 0) || (allowZero && normalized < 0)) {
@@ -323,6 +342,14 @@ export function registerShopRoutes(
       return;
     }
 
+    let analyticsPurchaseContext:
+      | {
+          playerId: string;
+          purchaseId: string;
+          productId: string;
+        }
+      | undefined;
+
     try {
       const body = (await readJsonBody(request)) as {
         productId?: string | null;
@@ -374,6 +401,12 @@ export function registerShopRoutes(
         return;
       }
 
+      analyticsPurchaseContext = {
+        playerId: authSession.playerId,
+        purchaseId,
+        productId: product.productId
+      };
+
       const result = await store.purchaseShopProduct(authSession.playerId, {
         purchaseId,
         productId: product.productId,
@@ -387,6 +420,16 @@ export function registerShopRoutes(
         payload: {
           purchaseId: result.purchaseId,
           productId: result.productId,
+          quantity: result.quantity,
+          totalPrice: result.totalPrice
+        }
+      });
+      emitAnalyticsEvent("purchase_completed", {
+        playerId: authSession.playerId,
+        payload: {
+          purchaseId: result.purchaseId,
+          productId: result.productId,
+          paymentMethod: "gems",
           quantity: result.quantity,
           totalPrice: result.totalPrice
         }
@@ -409,6 +452,13 @@ export function registerShopRoutes(
       }
 
       if (error instanceof Error && error.message === "insufficient gems") {
+        if (analyticsPurchaseContext) {
+          emitPurchaseFailedEvent({
+            ...analyticsPurchaseContext,
+            paymentMethod: "gems",
+            failureReason: "insufficient_gems"
+          });
+        }
         sendJson(response, 409, {
           error: {
             code: "insufficient_gems",
@@ -419,6 +469,13 @@ export function registerShopRoutes(
       }
 
       if (error instanceof Error && error.message === "equipment inventory full") {
+        if (analyticsPurchaseContext) {
+          emitPurchaseFailedEvent({
+            ...analyticsPurchaseContext,
+            paymentMethod: "gems",
+            failureReason: "equipment_inventory_full"
+          });
+        }
         sendJson(response, 409, {
           error: {
             code: "equipment_inventory_full",
@@ -429,6 +486,13 @@ export function registerShopRoutes(
       }
 
       if (error instanceof Error && error.message === "player hero archive not found") {
+        if (analyticsPurchaseContext) {
+          emitPurchaseFailedEvent({
+            ...analyticsPurchaseContext,
+            paymentMethod: "gems",
+            failureReason: "player_hero_archive_not_found"
+          });
+        }
         sendJson(response, 409, {
           error: {
             code: "player_hero_archive_not_found",
@@ -443,6 +507,13 @@ export function registerShopRoutes(
         return;
       }
 
+      if (analyticsPurchaseContext) {
+        emitPurchaseFailedEvent({
+          ...analyticsPurchaseContext,
+          paymentMethod: "gems",
+          failureReason: error instanceof Error ? error.message : "internal_error"
+        });
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });

--- a/apps/server/src/wechat-pay.ts
+++ b/apps/server/src/wechat-pay.ts
@@ -93,6 +93,46 @@ const DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS = 5;
 const DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS = 60_000;
 const SUCCESS_CALLBACK_BODY = { code: "SUCCESS", message: "success" };
 
+function emitPurchaseCompletedEvent(input: {
+  playerId: string;
+  purchaseId: string;
+  productId: string;
+  paymentMethod: "gems" | "wechat_pay";
+  quantity: number;
+  totalPrice: number;
+}): void {
+  emitAnalyticsEvent("purchase_completed", {
+    playerId: input.playerId,
+    payload: {
+      purchaseId: input.purchaseId,
+      productId: input.productId,
+      paymentMethod: input.paymentMethod,
+      quantity: input.quantity,
+      totalPrice: input.totalPrice
+    }
+  });
+}
+
+function emitPurchaseFailedEvent(input: {
+  playerId: string;
+  purchaseId: string;
+  productId: string;
+  paymentMethod: "gems" | "wechat_pay";
+  failureReason: string;
+  orderStatus: PaymentOrderSnapshot["status"] | "failed";
+}): void {
+  emitAnalyticsEvent("purchase_failed", {
+    playerId: input.playerId,
+    payload: {
+      purchaseId: input.purchaseId,
+      productId: input.productId,
+      paymentMethod: input.paymentMethod,
+      failureReason: input.failureReason,
+      orderStatus: input.orderStatus
+    }
+  });
+}
+
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
   response.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -881,6 +921,16 @@ export function registerWechatPayRoutes(
       if (isPaymentOpsStoreReady(store)) {
         await refreshPaymentGrantObservability(store, now());
       }
+      if (!settlement.credited) {
+        emitPurchaseFailedEvent({
+          playerId: order.playerId,
+          purchaseId: order.orderId,
+          productId: order.productId,
+          paymentMethod: "wechat_pay",
+          failureReason: settlement.order.lastGrantError ?? "grant_failed",
+          orderStatus: settlement.order.status
+        });
+      }
       if (!settlement.credited && isFinalizedPaymentOrderStatus(settlement.order.status)) {
         emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
           orderId: order.orderId,
@@ -905,6 +955,16 @@ export function registerWechatPayRoutes(
           totalPrice: order.amount
         }
       });
+      if (settlement.credited) {
+        emitPurchaseCompletedEvent({
+          playerId: order.playerId,
+          purchaseId: order.orderId,
+          productId: order.productId,
+          paymentMethod: "wechat_pay",
+          quantity: 1,
+          totalPrice: order.amount
+        });
+      }
 
       const recentVerifiedCount = await store.countVerifiedPaymentReceiptsSince(
         order.playerId,
@@ -1098,6 +1158,23 @@ export function registerWechatPayRoutes(
             totalPrice: order.amount
           }
         });
+        emitPurchaseCompletedEvent({
+          playerId: order.playerId,
+          purchaseId: order.orderId,
+          productId: order.productId,
+          paymentMethod: "wechat_pay",
+          quantity: 1,
+          totalPrice: order.amount
+        });
+      } else {
+        emitPurchaseFailedEvent({
+          playerId: order.playerId,
+          purchaseId: order.orderId,
+          productId: order.productId,
+          paymentMethod: "wechat_pay",
+          failureReason: settlement.order.lastGrantError ?? "grant_failed",
+          orderStatus: settlement.order.status
+        });
       }
       sendCallbackResponse(response, 200);
     } catch (error) {
@@ -1245,6 +1322,23 @@ export function registerWechatPayRoutes(
               totalPrice: settlement.order.amount
             }
           });
+          emitPurchaseCompletedEvent({
+            playerId: settlement.order.playerId,
+            purchaseId: settlement.order.orderId,
+            productId: settlement.order.productId,
+            paymentMethod: "wechat_pay",
+            quantity: 1,
+            totalPrice: settlement.order.amount
+          });
+        } else {
+          emitPurchaseFailedEvent({
+            playerId: settlement.order.playerId,
+            purchaseId: settlement.order.orderId,
+            productId: settlement.order.productId,
+            paymentMethod: "wechat_pay",
+            failureReason: settlement.order.lastGrantError ?? "grant_failed",
+            orderStatus: settlement.order.status
+          });
         }
         await refreshPaymentGrantObservability(store, processedAt);
         sendJson(response, 200, {
@@ -1290,6 +1384,23 @@ export function registerWechatPayRoutes(
                 quantity: 1,
                 totalPrice: settlement.order.amount
               }
+            });
+            emitPurchaseCompletedEvent({
+              playerId: settlement.order.playerId,
+              purchaseId: settlement.order.orderId,
+              productId: settlement.order.productId,
+              paymentMethod: "wechat_pay",
+              quantity: 1,
+              totalPrice: settlement.order.amount
+            });
+          } else {
+            emitPurchaseFailedEvent({
+              playerId: settlement.order.playerId,
+              purchaseId: settlement.order.orderId,
+              productId: settlement.order.productId,
+              paymentMethod: "wechat_pay",
+              failureReason: settlement.order.lastGrantError ?? "grant_failed",
+              orderStatus: settlement.order.status
             });
           }
           results.push({

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -16,6 +16,11 @@ import {
 } from "../../../packages/shared/src/index";
 import type { BattleState, ServerMessage, WorldEvent } from "../../../packages/shared/src/index";
 import { resolveBattlePassConfig } from "../src/battle-pass";
+import {
+  configureAnalyticsRuntimeDependencies,
+  flushAnalyticsEventsForTest,
+  resetAnalyticsRuntimeDependencies
+} from "../src/analytics";
 import { FileSystemConfigCenterStore, resetConfigHotReloadState } from "../src/config-center";
 import {
   VeilColyseusRoom,
@@ -976,6 +981,60 @@ test("player leave keeps the disconnected timestamp for the departed player and 
   assert.ok(internalRoom.disconnectedAtByPlayerId.get("player-leaving"));
   assert.equal(internalRoom.disconnectedAtByPlayerId.has("player-steady"), false);
   assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 1);
+});
+
+test("session_end analytics records transport disconnects and room disposal duration", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  resetAnalyticsRuntimeDependencies();
+  const room = await createTestRoom(`lifecycle-session-end-${Date.now()}`);
+  const leavingClient = createFakeClient("session-analytics-leave");
+  const disposedClient = createFakeClient("session-analytics-dispose");
+  const analyticsLogs: string[] = [];
+  let nowMs = 1_000;
+
+  configureRoomRuntimeDependencies({
+    now: () => nowMs
+  });
+  configureAnalyticsRuntimeDependencies({
+    log: (message) => {
+      analyticsLogs.push(message);
+    }
+  });
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetAnalyticsRuntimeDependencies();
+    resetRoomRuntimeDependencies();
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, leavingClient, "player-leaving", "connect-analytics-leave");
+  await connectPlayer(room, disposedClient, "player-disposed", "connect-analytics-dispose");
+
+  nowMs = 6_500;
+  room.onLeave(leavingClient);
+  nowMs = 9_250;
+  room.onDispose();
+  await flushAnalyticsEventsForTest({ ANALYTICS_SINK: "stdout" });
+
+  const envelope = analyticsLogs
+    .filter((entry) => entry.startsWith("[Analytics] {"))
+    .map((entry) => JSON.parse(entry.slice("[Analytics] ".length)) as { events: Array<{ name: string; sessionId?: string; payload: Record<string, unknown> }> })
+    .flatMap((entry) => entry.events);
+
+  const leaveEvent = envelope.find(
+    (event) => event.name === "session_end" && event.sessionId === "session-analytics-leave"
+  );
+  const disposeEvent = envelope.find(
+    (event) => event.name === "session_end" && event.sessionId === "session-analytics-dispose"
+  );
+
+  assert.equal(leaveEvent?.payload.disconnectReason, "transport_closed");
+  assert.equal(leaveEvent?.payload.sessionDurationMs, 5_500);
+  assert.equal(disposeEvent?.payload.disconnectReason, "room_disposed");
+  assert.equal(disposeEvent?.payload.sessionDurationMs, 8_250);
 });
 
 test("room disposal after the last client leaves removes it from the active room list", async (t) => {

--- a/apps/server/test/shop-routes.test.ts
+++ b/apps/server/test/shop-routes.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Server, WebSocketTransport } from "colyseus";
+import {
+  configureAnalyticsRuntimeDependencies,
+  flushAnalyticsEventsForTest,
+  resetAnalyticsRuntimeDependencies
+} from "../src/analytics";
 import { issueAccountAuthSession } from "../src/auth";
 import type { RoomPersistenceSnapshot } from "../src/index";
 import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
@@ -154,6 +159,12 @@ test("weekly shop rotation is deterministic within an ISO week and advances on t
 test("shop purchase debits gems and grants resource bundles", async (t) => {
   const port = 42420 + Math.floor(Math.random() * 1000);
   const store = new MemoryRoomSnapshotStore();
+  const analyticsLogs: string[] = [];
+  configureAnalyticsRuntimeDependencies({
+    log: (message) => {
+      analyticsLogs.push(message);
+    }
+  });
   await store.save("shop-room", createShopWorldSnapshot());
   await store.creditGems("shop-player", 100, "purchase", "seed-gems");
   const server = await startShopRouteServer(port, store, TEST_PRODUCTS);
@@ -164,6 +175,7 @@ test("shop purchase debits gems and grants resource bundles", async (t) => {
   });
 
   t.after(async () => {
+    resetAnalyticsRuntimeDependencies();
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
@@ -188,6 +200,14 @@ test("shop purchase debits gems and grants resource bundles", async (t) => {
   };
 
   const account = await store.loadPlayerAccount("shop-player");
+  await flushAnalyticsEventsForTest({ ANALYTICS_SINK: "stdout" });
+  const analyticsEvents = analyticsLogs
+    .filter((entry) => entry.startsWith("[Analytics] {"))
+    .map((entry) => JSON.parse(entry.slice("[Analytics] ".length)) as { events: Array<{ name: string; payload: Record<string, unknown> }> })
+    .flatMap((entry) => entry.events);
+  const purchaseCompletedEvent = analyticsEvents.find(
+    (event) => event.name === "purchase_completed" && event.payload.purchaseId === "purchase-resource-1"
+  );
 
   assert.equal(response.status, 200);
   assert.equal(payload.totalPrice, 60);
@@ -195,6 +215,8 @@ test("shop purchase debits gems and grants resource bundles", async (t) => {
   assert.deepEqual(payload.granted.resources, { gold: 240, wood: 20, ore: 10 });
   assert.deepEqual(account?.globalResources, { gold: 240, wood: 20, ore: 10 });
   assert.equal(account?.gems, 40);
+  assert.equal(purchaseCompletedEvent?.payload.paymentMethod, "gems");
+  assert.equal(purchaseCompletedEvent?.payload.totalPrice, 60);
 });
 
 test("shop purchase grants cosmetics and equip route applies an owned cosmetic", async (t) => {
@@ -321,6 +343,12 @@ test("shop purchase grants equipment and replays the original result for the sam
 test("shop purchase rejects insufficient gems without debiting or granting", async (t) => {
   const port = 42460 + Math.floor(Math.random() * 1000);
   const store = new MemoryRoomSnapshotStore();
+  const analyticsLogs: string[] = [];
+  configureAnalyticsRuntimeDependencies({
+    log: (message) => {
+      analyticsLogs.push(message);
+    }
+  });
   await store.save("shop-room", createShopWorldSnapshot());
   await store.creditGems("shop-player", 10, "purchase", "seed-gems");
   const server = await startShopRouteServer(port, store, TEST_PRODUCTS);
@@ -331,6 +359,7 @@ test("shop purchase rejects insufficient gems without debiting or granting", asy
   });
 
   t.after(async () => {
+    resetAnalyticsRuntimeDependencies();
     await server.gracefullyShutdown(false).catch(() => undefined);
   });
 
@@ -354,10 +383,20 @@ test("shop purchase rejects insufficient gems without debiting or granting", asy
 
   const account = await store.loadPlayerAccount("shop-player");
   const archives = await store.loadPlayerHeroArchives(["shop-player"]);
+  await flushAnalyticsEventsForTest({ ANALYTICS_SINK: "stdout" });
+  const analyticsEvents = analyticsLogs
+    .filter((entry) => entry.startsWith("[Analytics] {"))
+    .map((entry) => JSON.parse(entry.slice("[Analytics] ".length)) as { events: Array<{ name: string; payload: Record<string, unknown> }> })
+    .flatMap((entry) => entry.events);
+  const purchaseFailedEvent = analyticsEvents.find(
+    (event) => event.name === "purchase_failed" && event.payload.purchaseId === "purchase-fail-1"
+  );
 
   assert.equal(response.status, 409);
   assert.equal(payload.error.code, "insufficient_gems");
   assert.equal(account?.gems, 10);
   assert.deepEqual(account?.globalResources, { gold: 0, wood: 0, ore: 0 });
   assert.deepEqual(archives[0]?.hero.loadout.inventory, []);
+  assert.equal(purchaseFailedEvent?.payload.paymentMethod, "gems");
+  assert.equal(purchaseFailedEvent?.payload.failureReason, "insufficient_gems");
 });

--- a/apps/server/test/wechat-payment-flow.test.ts
+++ b/apps/server/test/wechat-payment-flow.test.ts
@@ -154,6 +154,7 @@ async function startWechatPaymentServer(input: {
   store: MemoryRoomSnapshotStore;
   runtimeConfig: WechatPayRuntimeConfig;
   fetchImpl: typeof fetch;
+  products?: Partial<ShopProduct>[];
 }): Promise<Server> {
   resetGuestAuthSessions();
   resetAnalyticsRuntimeDependencies();
@@ -165,7 +166,7 @@ async function startWechatPaymentServer(input: {
   registerPlayerAccountRoutes(app, input.store);
   registerRuntimeObservabilityRoutes(app, { store: input.store });
   registerWechatPayRoutes(app, input.store, {
-    products: TEST_PRODUCTS,
+    products: input.products ?? TEST_PRODUCTS,
     runtimeConfig: input.runtimeConfig,
     fetchImpl: input.fetchImpl
   });
@@ -308,6 +309,9 @@ test("wechat payment callback settles the order, emits purchase analytics, and d
   const purchaseEvent = analyticsEvents.find(
     (event) => event.name === "purchase" && event.payload.purchaseId === order.orderId
   );
+  const purchaseCompletedEvent = analyticsEvents.find(
+    (event) => event.name === "purchase_completed" && event.payload.purchaseId === order.orderId
+  );
   const storedOrder = await store.loadPaymentOrder(order.orderId);
   const receipt = await store.loadPaymentReceiptByOrderId(order.orderId);
 
@@ -320,6 +324,8 @@ test("wechat payment callback settles the order, emits purchase analytics, and d
   assert.ok(purchaseEvent);
   assert.equal(purchaseEvent?.payload.productId, "gem-pack-premium");
   assert.equal(purchaseEvent?.payload.totalPrice, 600);
+  assert.equal(purchaseCompletedEvent?.payload.paymentMethod, "wechat_pay");
+  assert.equal(purchaseCompletedEvent?.payload.totalPrice, 600);
   assert.equal(storedOrder?.status, "settled");
   assert.equal(storedOrder?.wechatOrderId, "wechat-transaction-123");
   assert.equal(receipt?.transactionId, "wechat-transaction-123");
@@ -373,6 +379,9 @@ test("wechat payment verify settles a created order and emits purchase analytics
   const purchaseEvent = analyticsEvents.find(
     (event) => event.name === "purchase" && event.payload.purchaseId === order.orderId
   );
+  const purchaseCompletedEvent = analyticsEvents.find(
+    (event) => event.name === "purchase_completed" && event.payload.purchaseId === order.orderId
+  );
 
   assert.equal(verifyResponse.status, 200);
   assert.equal(verifyPayload.status, "settled");
@@ -381,6 +390,7 @@ test("wechat payment verify settles a created order and emits purchase analytics
   assert.equal(accountPayload.account.gems, 120);
   assert.ok(purchaseEvent);
   assert.equal(purchaseEvent?.payload.productId, "gem-pack-premium");
+  assert.equal(purchaseCompletedEvent?.payload.paymentMethod, "wechat_pay");
 });
 
 test("wechat payment verify returns amount mismatch without granting rewards and records the fraud signal", async (t) => {
@@ -450,4 +460,68 @@ test("wechat payment verify returns amount mismatch without granting rewards and
   assert.equal(purchaseEvent, undefined);
   assert.equal(storedOrder?.status, "created");
   assert.equal(receipt, null);
+});
+
+test("wechat payment verify emits purchase_failed when settlement cannot grant rewards", async (t) => {
+  const port = 43080 + Math.floor(Math.random() * 1000);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const runtimeConfig = createWechatPayConfig();
+  const store = await createVerifiedTestStore();
+  const restoreEnv = withEnvOverrides({
+    ANALYTICS_ENDPOINT: `${baseUrl}/api/analytics/events`
+  });
+  const originalCompletePaymentOrder = store.completePaymentOrder.bind(store);
+  store.completePaymentOrder = async (orderId, input) => {
+    const settlement = await originalCompletePaymentOrder(orderId, input);
+    return {
+      ...settlement,
+      credited: false,
+      order: {
+        ...settlement.order,
+        status: "dead_letter",
+        lastGrantError: "grant_failed_for_test",
+        deadLetteredAt: settlement.order.paidAt ?? settlement.order.updatedAt
+      }
+    };
+  };
+  const server = await startWechatPaymentServer({
+    port,
+    store,
+    runtimeConfig,
+    fetchImpl: buildVerifyFetch({})
+  });
+  const session = issueWechatSession();
+
+  t.after(async () => {
+    restoreEnv();
+    resetAnalyticsRuntimeDependencies();
+    resetGuestAuthSessions();
+    resetRuntimeObservability();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const order = await createOrder(baseUrl, session.token);
+  const verifyResponse = await fetch(`${baseUrl}/api/payments/wechat/verify`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      orderId: order.orderId
+    })
+  });
+  const verifyPayload = (await verifyResponse.json()) as { error: { code: string } };
+  await flushAnalyticsEventsForTest();
+
+  const analyticsEvents = await fetchCapturedAnalytics(baseUrl);
+  const purchaseFailedEvent = analyticsEvents.find(
+    (event) => event.name === "purchase_failed" && event.payload.purchaseId === order.orderId
+  );
+
+  assert.equal(verifyResponse.status, 409);
+  assert.equal(verifyPayload.error.code, "payment_already_verified");
+  assert.equal(purchaseFailedEvent?.payload.paymentMethod, "wechat_pay");
+  assert.equal(purchaseFailedEvent?.payload.failureReason, "grant_failed_for_test");
+  assert.equal(purchaseFailedEvent?.payload.orderStatus, "dead_letter");
 });

--- a/docs/analytics-pipeline-runbook.md
+++ b/docs/analytics-pipeline-runbook.md
@@ -78,6 +78,15 @@ Notes:
 - Prefer `source='server'` for KPI queries that should not double-count matching client events.
 - Keep the raw object archive for replay/audit, but drive dashboards and alerts from the curated table.
 
+## Event Payload Reference
+
+| Event | Payload fields | Notes |
+| --- | --- | --- |
+| `session_end` | `roomId`, `disconnectReason`, `sessionDurationMs` | Emitted when a room transport closes or the room disposes. |
+| `purchase_completed` | `purchaseId`, `productId`, `paymentMethod`, `quantity`, `totalPrice` | Emitted only after rewards are granted successfully. |
+| `purchase_failed` | `purchaseId`, `productId`, `paymentMethod`, `failureReason`, `orderStatus` | Emitted when a purchase cannot grant rewards or fails before completion. |
+| `tutorial_step` | `stepId`, `status` | Tutorial completion remains `tutorial_step` with `stepId = tutorial_completed`; no standalone `tutorial_completed` event is introduced in this change. |
+
 ## Core KPI Queries
 
 ### DAU
@@ -134,7 +143,7 @@ WITH
   purchasers AS (
     SELECT uniqExact(player_id) AS players
     FROM analytics_prod.veil_analytics_events
-    WHERE name = 'purchase'
+    WHERE name = 'purchase_completed'
       AND source = 'server'
       AND event_at >= toStartOfDay(now())
   )
@@ -143,6 +152,36 @@ SELECT
   purchasers.players AS purchasers,
   round(purchasers.players / greatest(dau.players, 1), 4) AS purchase_conversion_rate
 FROM dau, purchasers;
+```
+
+### Session Duration
+
+```sql
+SELECT
+  toDate(event_at) AS day,
+  round(avg(JSONExtractFloat(payload_json, 'sessionDurationMs')) / 1000, 2) AS avg_session_duration_seconds,
+  count() AS sessions_ended
+FROM analytics_prod.veil_analytics_events
+WHERE name = 'session_end'
+  AND source = 'server'
+  AND event_at >= today() - 7
+GROUP BY day
+ORDER BY day DESC;
+```
+
+### Purchase Failures
+
+```sql
+SELECT
+  toDate(event_at) AS day,
+  JSONExtractString(payload_json, 'failureReason') AS failure_reason,
+  count() AS failures
+FROM analytics_prod.veil_analytics_events
+WHERE name = 'purchase_failed'
+  AND source = 'server'
+  AND event_at >= today() - 7
+GROUP BY day, failure_reason
+ORDER BY day DESC, failures DESC;
 ```
 
 ## Payment Fraud And Session Drop Monitoring

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -27,6 +27,11 @@ export const ANALYTICS_EVENT_CATALOG = {
     authMode: "guest",
     platform: "wechat"
   }),
+  session_end: defineAnalyticsEvent("session_end", 1, "Player session ended and recorded disconnect reason plus session duration.", {
+    roomId: "room-contract",
+    disconnectReason: "transport_closed",
+    sessionDurationMs: 12345
+  }),
   battle_start: defineAnalyticsEvent("battle_start", 1, "Player entered a battle encounter.", {
     roomId: "room-contract",
     battleId: "battle-demo",
@@ -77,6 +82,30 @@ export const ANALYTICS_EVENT_CATALOG = {
     currency: "wechat_fen",
     price: 600
   }),
+  purchase_completed: defineAnalyticsEvent(
+    "purchase_completed",
+    1,
+    "Shop purchase completed successfully after rewards were granted.",
+    {
+      purchaseId: "purchase-1",
+      productId: "gem_pack_small",
+      paymentMethod: "gems",
+      quantity: 1,
+      totalPrice: 600
+    }
+  ),
+  purchase_failed: defineAnalyticsEvent(
+    "purchase_failed",
+    1,
+    "Shop purchase failed before rewards were granted or could not finish reward settlement.",
+    {
+      purchaseId: "purchase-1",
+      productId: "gem_pack_small",
+      paymentMethod: "wechat_pay",
+      failureReason: "grant_failed",
+      orderStatus: "grant_pending"
+    }
+  ),
   purchase: defineAnalyticsEvent("purchase", 1, "Shop purchase completed successfully.", {
     purchaseId: "purchase-1",
     productId: "gem_pack_small",

--- a/packages/shared/test/analytics-events.test.ts
+++ b/packages/shared/test/analytics-events.test.ts
@@ -140,6 +140,23 @@ test("createAnalyticsEvent: sessionId is absent when not provided", () => {
   assert.ok(!("sessionId" in event), "sessionId should not be present");
 });
 
+test("createAnalyticsEvent: session_end event carries duration and reason payload", () => {
+  const event = createAnalyticsEvent("session_end", {
+    playerId: "player-1",
+    sessionId: "session-xyz",
+    payload: {
+      roomId: "room-1",
+      disconnectReason: "transport_closed",
+      sessionDurationMs: 12345
+    }
+  });
+
+  assert.equal(event.payload.roomId, "room-1");
+  assert.equal(event.payload.disconnectReason, "transport_closed");
+  assert.equal(event.payload.sessionDurationMs, 12345);
+  assert.equal(event.sessionId, "session-xyz");
+});
+
 test("createAnalyticsEvent: platform is included when provided", () => {
   const event = createAnalyticsEvent("session_start", {
     playerId: "player-1",
@@ -182,6 +199,42 @@ test("createAnalyticsEvent: payload is passed through unchanged", () => {
   const payload = { purchaseId: "p-42", productId: "gem_pack_large", quantity: 2, totalPrice: 598 };
   const event = createAnalyticsEvent("purchase", { playerId: "player-1", payload });
   assert.deepEqual(event.payload, payload);
+});
+
+test("createAnalyticsEvent: purchase_completed event carries monetization funnel fields", () => {
+  const event = createAnalyticsEvent("purchase_completed", {
+    playerId: "player-1",
+    payload: {
+      purchaseId: "purchase-42",
+      productId: "gem_pack_small",
+      paymentMethod: "wechat",
+      quantity: 1,
+      totalPrice: 600
+    }
+  });
+
+  assert.equal(event.payload.purchaseId, "purchase-42");
+  assert.equal(event.payload.paymentMethod, "wechat");
+  assert.equal(event.payload.quantity, 1);
+  assert.equal(event.payload.totalPrice, 600);
+});
+
+test("createAnalyticsEvent: purchase_failed event carries failure reason and status", () => {
+  const event = createAnalyticsEvent("purchase_failed", {
+    playerId: "player-1",
+    payload: {
+      purchaseId: "purchase-42",
+      productId: "gem_pack_small",
+      paymentMethod: "wechat_pay",
+      failureReason: "grant_failed",
+      orderStatus: "dead_letter"
+    }
+  });
+
+  assert.equal(event.payload.purchaseId, "purchase-42");
+  assert.equal(event.payload.paymentMethod, "wechat_pay");
+  assert.equal(event.payload.failureReason, "grant_failed");
+  assert.equal(event.payload.orderStatus, "dead_letter");
 });
 
 test("createAnalyticsEvent: quest_complete event carries correct payload structure", () => {


### PR DESCRIPTION
## Summary
- emit `session_end` analytics for transport disconnects, reconnect expiry, and room disposal with session duration data
- emit `purchase_completed` and `purchase_failed` analytics across gem shop and WeChat payment settlement flows
- update the shared analytics catalog, tests, and analytics runbook for the new payload schemas

## Notes
- tutorial completion remains represented by `tutorial_step` with `payload.stepId = tutorial_completed`; this PR does not introduce a standalone `tutorial_completed` event
- the PR intentionally excludes the old `#1382` branch commit and is rebuilt cleanly from current `main`

## Validation
- `node --import tsx --test --test-name-pattern='session_end analytics records transport disconnects and room disposal duration' apps/server/test/colyseus-room-lifecycle.test.ts`
- `node --import tsx --test apps/server/test/shop-routes.test.ts`
- `node --import tsx --test apps/server/test/wechat-payment-flow.test.ts`
- `node --import tsx --test packages/shared/test/analytics-events.test.ts`
- `npm run typecheck:shared`
- `npm run typecheck:server`

Closes #1380
