### PR TITLE
[OPS] Add config publish diff preview guard

### DIFF
--- a/apps/client/src/config-center-controller.ts
+++ b/apps/client/src/config-center-controller.ts
@@ -73,6 +73,49 @@ interface ConfigDiff {
   entries: ConfigDiffEntry[];
 }
 
+interface ConfigDiffPreviewAddedEntry {
+  key: string;
+  after: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+interface ConfigDiffPreviewModifiedEntry {
+  key: string;
+  before: string;
+  after: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+interface ConfigDiffPreviewRemovedEntry {
+  key: string;
+  before: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+interface ConfigDiffPreview {
+  documentId: ConfigDocumentId;
+  hash: string;
+  stageHash: string;
+  changeCount: number;
+  structuralChangeCount: number;
+  added: ConfigDiffPreviewAddedEntry[];
+  modified: ConfigDiffPreviewModifiedEntry[];
+  removed: ConfigDiffPreviewRemovedEntry[];
+  impactSummary: ConfigImpactSummary | null;
+}
+
 type ConfigImpactRiskLevel = "low" | "medium" | "high";
 
 interface ConfigImpactSummary {
@@ -152,6 +195,7 @@ interface ConfigStageState {
   updatedAt: string;
   documents: ConfigStageDocumentSummary[];
   valid: boolean;
+  previewHash: string | null;
 }
 
 type TerrainType = "grass" | "dirt" | "sand" | "water";
@@ -281,6 +325,9 @@ interface AppState {
   publishAuditFilterRevision: string;
   publishStage: ConfigStageState | null;
   publishStageLoading: boolean;
+  publishDiffPreviews: Partial<Record<ConfigDocumentId, ConfigDiffPreview>>;
+  publishDiffStageHash: string | null;
+  publishDiffLoading: boolean;
 }
 
 interface ConfigCenterControllerOptions {
@@ -316,6 +363,18 @@ function labelForDiffKind(kind: ConfigDiffChangeKind): string {
 
 function structuralDiffEntries(diff: ConfigDiff | null): ConfigDiffEntry[] {
   return diff?.entries.filter((entry) => entry.kind !== "value") ?? [];
+}
+
+function stagePreviewCoverageReady(
+  stage: ConfigStageState | null,
+  previews: Partial<Record<ConfigDocumentId, ConfigDiffPreview>>,
+  stageHash: string | null
+): boolean {
+  if (!stage || stage.documents.length === 0 || !stageHash) {
+    return false;
+  }
+
+  return stage.documents.every((document) => previews[document.id]?.stageHash === stageHash);
 }
 
 function buildDiffConfirmationMessage(snapshotId: string, diff: ConfigDiff | null): string {
@@ -411,7 +470,10 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     publishAuditFilterCandidate: "",
     publishAuditFilterRevision: "",
     publishStage: null,
-    publishStageLoading: false
+    publishStageLoading: false,
+    publishDiffPreviews: {},
+    publishDiffStageHash: null,
+    publishDiffLoading: false
   };
 
   let previewRequestVersion = 0;
@@ -657,11 +719,53 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       }>("/api/config-center/publish-stage");
       state.storageMode = response.storage;
       state.publishStage = response.stage ?? null;
+      state.publishDiffPreviews = {};
+      state.publishDiffStageHash = null;
+      if (response.stage?.documents.length) {
+        await loadPublishDiffPreviews(response.stage);
+      }
     } catch (error) {
       state.statusTone = "error";
       state.statusMessage = error instanceof Error ? error.message : "加载发布草稿失败";
     } finally {
       state.publishStageLoading = false;
+      notify();
+    }
+  }
+
+  async function loadPublishDiffPreviews(stage = state.publishStage): Promise<void> {
+    if (!stage || stage.documents.length === 0) {
+      state.publishDiffPreviews = {};
+      state.publishDiffStageHash = null;
+      notify();
+      return;
+    }
+
+    state.publishDiffLoading = true;
+    notify();
+    try {
+      const previews: Partial<Record<ConfigDocumentId, ConfigDiffPreview>> = {};
+      let sharedStageHash: string | null = null;
+
+      for (const document of stage.documents) {
+        const response = await requestJson<{
+          storage: "filesystem" | "mysql";
+          preview: ConfigDiffPreview;
+        }>(`/api/config-center/configs/${document.id}/diff-preview`);
+        state.storageMode = response.storage;
+        previews[document.id] = response.preview;
+        sharedStageHash = response.preview.stageHash;
+      }
+
+      state.publishDiffPreviews = previews;
+      state.publishDiffStageHash = sharedStageHash;
+    } catch (error) {
+      state.publishDiffPreviews = {};
+      state.publishDiffStageHash = null;
+      state.statusTone = "error";
+      state.statusMessage = error instanceof Error ? error.message : "加载发布差异预览失败";
+    } finally {
+      state.publishDiffLoading = false;
       notify();
     }
   }
@@ -756,6 +860,11 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       });
       state.storageMode = response.storage;
       state.publishStage = response.stage ?? null;
+      state.publishDiffPreviews = {};
+      state.publishDiffStageHash = null;
+      if (response.stage?.documents.length) {
+        await loadPublishDiffPreviews(response.stage);
+      }
       state.statusTone = "success";
       state.statusMessage = successMessage;
     } catch (error) {
@@ -833,6 +942,13 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
       return;
     }
 
+    if (!stagePreviewCoverageReady(stage, state.publishDiffPreviews, state.publishDiffStageHash)) {
+      state.statusTone = "error";
+      state.statusMessage = "请先加载最新 diff-preview，再执行发布。";
+      notify();
+      return;
+    }
+
     const author = promptImpl("发布人（用于记录到历史）", "ConfigOps")?.trim();
     if (!author) {
       state.statusTone = "neutral";
@@ -878,11 +994,14 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
           author,
           summary,
           candidate,
-          revision
+          revision,
+          confirmedDiffHash: state.publishDiffStageHash
         })
       });
       state.storageMode = response.storage;
       state.publishStage = response.stage ?? null;
+      state.publishDiffPreviews = {};
+      state.publishDiffStageHash = null;
       state.statusTone = "success";
       state.statusMessage = `已发布 ${response.publish.changes.length} 个草稿，并刷新运行时配置。`;
       await loadPublishAuditHistory();
@@ -1502,6 +1621,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
     loadSnapshotDiff,
     computeDiff,
     loadPublishStage,
+    loadPublishDiffPreviews,
     loadPublishAuditHistory,
     loadWorldPreview,
     applyHotloadPreview,
@@ -1532,6 +1652,7 @@ export function createConfigCenterController(options: ConfigCenterControllerOpti
 export type {
   AppState,
   ConfigDiff,
+  ConfigDiffPreview,
   ConfigDocument,
   ConfigDocumentId,
   ConfigDocumentSummary,

--- a/apps/client/src/config-center.ts
+++ b/apps/client/src/config-center.ts
@@ -134,6 +134,49 @@ interface ConfigDiff {
   entries: ConfigDiffEntry[];
 }
 
+interface ConfigDiffPreviewAddedEntry {
+  key: string;
+  after: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+interface ConfigDiffPreviewModifiedEntry {
+  key: string;
+  before: string;
+  after: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+interface ConfigDiffPreviewRemovedEntry {
+  key: string;
+  before: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+interface ConfigDiffPreview {
+  documentId: ConfigDocumentId;
+  hash: string;
+  stageHash: string;
+  changeCount: number;
+  structuralChangeCount: number;
+  added: ConfigDiffPreviewAddedEntry[];
+  modified: ConfigDiffPreviewModifiedEntry[];
+  removed: ConfigDiffPreviewRemovedEntry[];
+  impactSummary: ConfigImpactSummary | null;
+}
+
 type ConfigImpactRiskLevel = "low" | "medium" | "high";
 
 interface ConfigImpactSummary {
@@ -213,6 +256,7 @@ interface ConfigStageState {
   updatedAt: string;
   documents: ConfigStageDocumentSummary[];
   valid: boolean;
+  previewHash: string | null;
 }
 
 interface WorldConfigPreviewTile {
@@ -338,6 +382,9 @@ interface AppState {
   publishAuditFilterRevision: string;
   publishStage: ConfigStageState | null;
   publishStageLoading: boolean;
+  publishDiffPreviews: Partial<Record<ConfigDocumentId, ConfigDiffPreview>>;
+  publishDiffStageHash: string | null;
+  publishDiffLoading: boolean;
 }
 
 const WORLD_PREVIEW_DEBOUNCE_MS = 260;
@@ -376,6 +423,22 @@ function sortDiffEntries(entries: ConfigDiffEntry[]): ConfigDiffEntry[] {
 
 function countStructuralEntries(diff: ConfigDiff): number {
   return diff.entries.filter(isStructuralDiff).length;
+}
+
+function isStructuralPreviewEntry(
+  entry: ConfigDiffPreviewAddedEntry | ConfigDiffPreviewModifiedEntry | ConfigDiffPreviewRemovedEntry
+): boolean {
+  return entry.kind !== "value";
+}
+
+function sortPreviewEntries<T extends { key: string; kind: ConfigDiffChangeKind }>(entries: T[]): T[] {
+  return [...entries].sort((left, right) => {
+    const riskDelta = Number(right.kind !== "value") - Number(left.kind !== "value");
+    if (riskDelta !== 0) {
+      return riskDelta;
+    }
+    return left.key.localeCompare(right.key);
+  });
 }
 
 function impactRiskLabel(riskLevel: ConfigImpactRiskLevel): string {
@@ -806,6 +869,7 @@ let loadSnapshots!: ReturnType<typeof createConfigCenterController>["loadSnapsho
 let loadPresets!: ReturnType<typeof createConfigCenterController>["loadPresets"];
 let loadSnapshotDiff!: ReturnType<typeof createConfigCenterController>["loadSnapshotDiff"];
 let loadPublishStage!: ReturnType<typeof createConfigCenterController>["loadPublishStage"];
+let loadPublishDiffPreviews!: ReturnType<typeof createConfigCenterController>["loadPublishDiffPreviews"];
 let loadPublishAuditHistory!: ReturnType<typeof createConfigCenterController>["loadPublishAuditHistory"];
 let loadWorldPreview!: ReturnType<typeof createConfigCenterController>["loadWorldPreview"];
 let loadValidation!: ReturnType<typeof createConfigCenterController>["loadValidation"];
@@ -863,6 +927,7 @@ function initializeConfigCenterRuntime(): void {
     loadPresets,
     loadSnapshotDiff,
     loadPublishStage,
+    loadPublishDiffPreviews,
     loadPublishAuditHistory,
     loadWorldPreview,
     loadValidation,
@@ -1611,6 +1676,11 @@ function renderPublishStageSection(): string {
   const activeDocumentId = state.current?.id ?? null;
   const isCurrentInStage = documents.some((document) => document.id === activeDocumentId);
   const limitReached = !isCurrentInStage && stagedCount >= MAX_STAGE_DOCUMENTS;
+  const previewReady =
+    !!stage &&
+    !!state.publishDiffStageHash &&
+    documents.length > 0 &&
+    documents.every((document) => state.publishDiffPreviews[document.id]?.stageHash === state.publishDiffStageHash);
   const stageMeta = stage
     ? `${stagedCount}/${MAX_STAGE_DOCUMENTS} 个草稿 · ${stage.valid ? "全部通过校验" : "存在阻塞"}`
     : `0/${MAX_STAGE_DOCUMENTS} 个草稿`;
@@ -1625,8 +1695,20 @@ function renderPublishStageSection(): string {
       <div class="history-actions">
         <button class="config-button is-secondary config-button-compact" data-action="stage-current" ${state.current && !limitReached && !state.publishStageLoading ? "" : "disabled"}>${state.publishStageLoading ? "同步中..." : "将当前草稿加入队列"}</button>
         <button class="config-button is-secondary config-button-compact" data-action="clear-stage" ${stage && stagedCount > 0 && !state.publishStageLoading ? "" : "disabled"}>清空草稿</button>
-        <button class="config-button config-button-compact" data-action="publish-stage" ${stage && stage.valid && stagedCount > 0 && !state.publishStageLoading ? "" : "disabled"}>${state.publishStageLoading ? "处理中..." : "发布草稿"}</button>
+        <button class="config-button is-secondary config-button-compact" data-action="refresh-stage-preview" ${stage && stagedCount > 0 && !state.publishStageLoading && !state.publishDiffLoading ? "" : "disabled"}>${state.publishDiffLoading ? "加载 diff..." : "刷新 diff-preview"}</button>
+        <button class="config-button config-button-compact" data-action="publish-stage" ${stage && stage.valid && stagedCount > 0 && previewReady && !state.publishStageLoading ? "" : "disabled"}>${state.publishStageLoading ? "处理中..." : "发布草稿"}</button>
       </div>
+      <p class="config-hint">
+        ${
+          stagedCount === 0
+            ? "先将草稿加入队列。"
+            : state.publishDiffLoading
+              ? "正在拉取 staged draft 与 live 配置的 diff-preview，发布按钮会在全部草稿预览完成后启用。"
+              : previewReady
+                ? "diff-preview 已同步，当前可发布。"
+                : "发布前必须先查看最新 diff-preview；草稿或 live 配置发生漂移时需要重新刷新。"
+        }
+      </p>
       ${
         state.publishStageLoading && stagedCount === 0
           ? `<div class="world-preview-empty">正在加载发布草稿...</div>`
@@ -1644,6 +1726,45 @@ function renderPublishStageSection(): string {
                     <small>最近同步：${formatTime(document.updatedAt)}</small>
                   </div>
                   <button class="config-button is-secondary config-button-compact" data-action="remove-stage-doc" data-doc-id="${document.id}">移除</button>
+                  ${
+                    state.publishDiffPreviews[document.id]
+                      ? (() => {
+                          const preview = state.publishDiffPreviews[document.id]!;
+                          const previewEntries = [
+                            ...sortPreviewEntries(preview.modified),
+                            ...sortPreviewEntries(preview.added),
+                            ...sortPreviewEntries(preview.removed)
+                          ].slice(0, 6);
+                          return `
+                            <div class="publish-diff-summary">
+                              ${
+                                previewEntries.length > 0
+                                  ? previewEntries
+                                      .map((entry) => {
+                                        const from = "before" in entry ? serializeDisplayValue(entry.before) : "新增";
+                                        const to = "after" in entry ? serializeDisplayValue(entry.after) : "删除";
+                                        return `
+                                          <span class="publish-diff-chip">
+                                            ${escapeHtml(entry.key)} · ${escapeHtml(diffKindLabel(entry.kind))} · ${escapeHtml(from)} → ${escapeHtml(to)}
+                                          </span>
+                                        `;
+                                      })
+                                      .join("")
+                                  : `<span class="publish-diff-chip">无字段差异</span>`
+                              }
+                            </div>
+                            <small class="config-meta">
+                              ${preview.changeCount} 项差异${preview.structuralChangeCount ? ` · ${preview.structuralChangeCount} 项结构风险` : ""}
+                            </small>
+                            ${
+                              preview.impactSummary
+                                ? `<small class="diff-blast">影响：${preview.impactSummary.impactedModules.map((label) => `<span>${escapeHtml(label)}</span>`).join(" / ")}</small>`
+                                : ""
+                            }
+                          `;
+                        })()
+                      : `<small class="config-meta">尚未加载 diff-preview</small>`
+                  }
                 </article>
               `
             )
@@ -2108,6 +2229,10 @@ function bindPublishStageControls(): void {
 
   document.querySelector<HTMLButtonElement>("[data-action='clear-stage']")?.addEventListener("click", () => {
     void clearPublishStage();
+  });
+
+  document.querySelector<HTMLButtonElement>("[data-action='refresh-stage-preview']")?.addEventListener("click", () => {
+    void loadPublishDiffPreviews();
   });
 
   document.querySelector<HTMLButtonElement>("[data-action='publish-stage']")?.addEventListener("click", () => {

--- a/apps/client/test/config-center.test.ts
+++ b/apps/client/test/config-center.test.ts
@@ -1002,6 +1002,7 @@ test("config center publish stage sends optional candidate and revision metadata
     createdAt: "2026-03-30T05:00:00.000Z",
     updatedAt: "2026-03-30T05:00:00.000Z",
     valid: true,
+    previewHash: "stage-hash-1",
     documents: [
       {
         id: "world",
@@ -1012,6 +1013,31 @@ test("config center publish stage sends optional candidate and revision metadata
         validation: createValidationReport(true)
       }
     ]
+  };
+  controller.state.publishDiffStageHash = "stage-hash-1";
+  controller.state.publishDiffPreviews = {
+    world: {
+      documentId: "world",
+      hash: "preview-world-1",
+      stageHash: "stage-hash-1",
+      changeCount: 1,
+      structuralChangeCount: 0,
+      added: [],
+      modified: [
+        {
+          key: "width",
+          before: "8",
+          after: "10",
+          kind: "value",
+          required: true,
+          fieldType: "integer",
+          description: "地图宽度",
+          blastRadius: ["世界预览"]
+        }
+      ],
+      removed: [],
+      impactSummary: null
+    }
   };
 
   await controller.publishStageDrafts();
@@ -1024,7 +1050,8 @@ test("config center publish stage sends optional candidate and revision metadata
     author: "ConfigOps",
     summary: "扩图并补资源",
     candidate: "phase1-rc",
-    revision: "abc1234"
+    revision: "abc1234",
+    confirmedDiffHash: "stage-hash-1"
   });
 });
 

--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { resolve } from "node:path";
@@ -152,6 +153,49 @@ export interface ConfigDiff {
   entries: ConfigDiffEntry[];
 }
 
+export interface ConfigDiffPreviewAddedEntry {
+  key: string;
+  after: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+export interface ConfigDiffPreviewModifiedEntry {
+  key: string;
+  before: string;
+  after: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+export interface ConfigDiffPreviewRemovedEntry {
+  key: string;
+  before: string;
+  kind: ConfigDiffChangeKind;
+  required: boolean;
+  fieldType: string;
+  description: string;
+  blastRadius: string[];
+}
+
+export interface ConfigDiffPreview {
+  documentId: ConfigDocumentId;
+  hash: string;
+  stageHash: string;
+  changeCount: number;
+  structuralChangeCount: number;
+  added: ConfigDiffPreviewAddedEntry[];
+  modified: ConfigDiffPreviewModifiedEntry[];
+  removed: ConfigDiffPreviewRemovedEntry[];
+  impactSummary: ConfigImpactSummary | null;
+}
+
 export type ConfigImpactRiskLevel = "low" | "medium" | "high";
 
 export interface ConfigImpactSummary {
@@ -253,6 +297,7 @@ export interface ConfigStageState {
   updatedAt: string;
   documents: ConfigStageDocumentSummary[];
   valid: boolean;
+  previewHash: string | null;
 }
 
 export interface WorldConfigPreviewTile {
@@ -359,11 +404,13 @@ export interface ConfigCenterStore {
   importDocumentFromWorkbook(id: ConfigDocumentId, workbook: Buffer): Promise<ConfigDocument>;
   getStagedDraft(): Promise<ConfigStageState | null>;
   saveStagedDraft(documents: ConfigStageDocumentInput[]): Promise<ConfigStageState | null>;
+  previewStagedDiff(id: ConfigDocumentId): Promise<ConfigDiffPreview>;
   publishStagedDraft(metadata: {
     author: string;
     summary: string;
     candidate?: string | null;
     revision?: string | null;
+    confirmedDiffHash?: string | null;
   }): Promise<{
     stage: ConfigStageState | null;
     publish: ConfigPublishEventSummary;
@@ -433,6 +480,7 @@ interface ConfigStageRecord {
   createdAt: string;
   updatedAt: string;
   documents: ConfigStageDocumentRecord[];
+  previewHash: string | null;
 }
 
 interface ConfigCenterLibraryState {
@@ -1231,6 +1279,59 @@ function buildConfigDiffEntries(
         }
       ];
     });
+}
+
+function createConfigDiffPreview(entries: ConfigDiffEntry[]): Pick<
+  ConfigDiffPreview,
+  "added" | "modified" | "removed" | "changeCount" | "structuralChangeCount"
+> {
+  const added: ConfigDiffPreviewAddedEntry[] = [];
+  const modified: ConfigDiffPreviewModifiedEntry[] = [];
+  const removed: ConfigDiffPreviewRemovedEntry[] = [];
+
+  for (const entry of entries) {
+    const base = {
+      kind: entry.kind,
+      required: entry.required,
+      fieldType: entry.fieldType,
+      description: entry.description,
+      blastRadius: [...entry.blastRadius]
+    };
+    if (entry.change === "added") {
+      added.push({
+        key: entry.path,
+        after: entry.nextValue,
+        ...base
+      });
+      continue;
+    }
+    if (entry.change === "removed") {
+      removed.push({
+        key: entry.path,
+        before: entry.previousValue,
+        ...base
+      });
+      continue;
+    }
+    modified.push({
+      key: entry.path,
+      before: entry.previousValue,
+      after: entry.nextValue,
+      ...base
+    });
+  }
+
+  return {
+    added,
+    modified,
+    removed,
+    changeCount: entries.length,
+    structuralChangeCount: entries.filter((entry) => entry.kind !== "value").length
+  };
+}
+
+function createConfigHash(input: unknown): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
 }
 
 function typeLabelForSchema(node: JsonSchemaNode): string {
@@ -3272,6 +3373,14 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
 
   async getStagedDraft(): Promise<ConfigStageState | null> {
     const state = await this.readLibraryState();
+    if (!state.stagedDraft) {
+      return null;
+    }
+    const previewHash = await this.computeStagePreviewHash(state.stagedDraft);
+    if (state.stagedDraft.previewHash !== previewHash) {
+      state.stagedDraft.previewHash = previewHash;
+      await this.writeLibraryState(state);
+    }
     return this.mapStageRecordToState(state.stagedDraft);
   }
 
@@ -3294,6 +3403,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
     summary: string;
     candidate?: string | null;
     revision?: string | null;
+    confirmedDiffHash?: string | null;
   }): Promise<{
     stage: ConfigStageState | null;
     publish: ConfigPublishEventSummary;
@@ -3306,6 +3416,11 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
 
     if (staged.documents.some((entry) => !entry.validation.valid)) {
       throw new Error("存在未通过校验的草稿，发布前请先修复。");
+    }
+
+    const previewHash = await this.computeStagePreviewHash(staged);
+    if (metadata.confirmedDiffHash?.trim() && metadata.confirmedDiffHash.trim() !== previewHash) {
+      throw new Error("发布前差异预览已漂移，请先刷新 diff-preview 再重试。");
     }
 
     const publishId = createId("publish");
@@ -3498,7 +3613,44 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
           validation: document.validation
         };
       }),
-      valid: stage.documents.every((document) => document.validation.valid)
+      valid: stage.documents.every((document) => document.validation.valid),
+      previewHash: stage.previewHash
+    };
+  }
+
+  async previewStagedDiff(id: ConfigDocumentId): Promise<ConfigDiffPreview> {
+    const state = await this.readLibraryState();
+    const staged = state.stagedDraft;
+    if (!staged || staged.documents.length === 0) {
+      throw new Error("当前没有待发布的草稿。");
+    }
+
+    const stagedDocument = staged.documents.find((document) => document.id === id);
+    if (!stagedDocument) {
+      throw new Error("当前配置未加入发布草稿。");
+    }
+
+    const current = await this.loadDocument(id);
+    const diffEntries = buildConfigDiffEntries(id, current.content, stagedDocument.content);
+    const grouped = createConfigDiffPreview(diffEntries);
+    const definition = configDefinitionFor(id);
+    const documentHash = createConfigHash({
+      id,
+      current: normalizeJsonContent(JSON.parse(current.content) as ParsedConfigDocument),
+      staged: stagedDocument.content
+    });
+    const stageHash = await this.computeStagePreviewHash(staged);
+
+    return {
+      documentId: id,
+      hash: documentHash,
+      stageHash,
+      changeCount: grouped.changeCount,
+      structuralChangeCount: grouped.structuralChangeCount,
+      added: grouped.added,
+      modified: grouped.modified,
+      removed: grouped.removed,
+      impactSummary: buildConfigImpactSummary(id, definition?.title ?? id, diffEntries)
     };
   }
 
@@ -3535,7 +3687,8 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
       id: existing?.id ?? createId("stage"),
       createdAt: existing?.createdAt ?? timestamp,
       updatedAt: timestamp,
-      documents: []
+      documents: [],
+      previewHash: null
     };
 
     for (const normalized of normalizedDocuments) {
@@ -3547,7 +3700,22 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
       });
     }
 
+    stageRecord.previewHash = await this.computeStagePreviewHash(stageRecord);
+
     return stageRecord;
+  }
+
+  private async computeStagePreviewHash(stage: ConfigStageRecord): Promise<string> {
+    const hashInput = [];
+    for (const document of [...stage.documents].sort((left, right) => left.id.localeCompare(right.id))) {
+      const current = await this.loadDocument(document.id);
+      hashInput.push({
+        id: document.id,
+        current: normalizeJsonContent(JSON.parse(current.content) as ParsedConfigDocument),
+        staged: document.content
+      });
+    }
+    return createConfigHash(hashInput);
   }
 
   async listPresets(id: ConfigDocumentId): Promise<ConfigPresetSummary[]> {
@@ -3895,6 +4063,24 @@ export function registerConfigCenterRoutes(
     }
   });
 
+  app.get("/api/config-center/configs/:id/diff-preview", async (request, response) => {
+    const configId = request.params.id;
+    const definition = configId ? configDefinitionFor(configId) : undefined;
+    if (!definition) {
+      sendNotFound(response);
+      return;
+    }
+
+    try {
+      sendJson(response, 200, {
+        storage: store.mode,
+        preview: await store.previewStagedDiff(definition.id)
+      });
+    } catch (error) {
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
   app.post("/api/config-center/configs/:id/preview", async (request, response) => {
     const configId = request.params.id;
     if (configId !== "world") {
@@ -4052,6 +4238,7 @@ export function registerConfigCenterRoutes(
         summary?: string;
         candidate?: string | null;
         revision?: string | null;
+        confirmedDiffHash?: string | null;
       };
       if (typeof body.author !== "string" || !body.author.trim() || typeof body.summary !== "string" || !body.summary.trim()) {
         sendJson(response, 400, {
@@ -4067,7 +4254,8 @@ export function registerConfigCenterRoutes(
         author: body.author.trim(),
         summary: body.summary.trim(),
         candidate: typeof body.candidate === "string" ? body.candidate : null,
-        revision: typeof body.revision === "string" ? body.revision : null
+        revision: typeof body.revision === "string" ? body.revision : null,
+        confirmedDiffHash: typeof body.confirmedDiffHash === "string" ? body.confirmedDiffHash : null
       });
       sendJson(response, 200, {
         storage: store.mode,

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -780,6 +780,106 @@ test("config center staged publish blocks invalid drafts", async () => {
   );
 });
 
+test("config center staged diff preview returns grouped added, modified, and removed entries with a stable stage hash", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  const live = {
+    ...MAP_OBJECTS_CONFIG,
+    buildings: MAP_OBJECTS_CONFIG.buildings.map((building) =>
+      building.kind === "resource_mine"
+        ? {
+            ...building,
+            lastHarvestDay: 2
+          }
+        : building
+    )
+  };
+  await store.saveDocument("mapObjects", JSON.stringify(live));
+
+  const staged = {
+    ...live,
+    buildings: live.buildings.map((building) => {
+      if (building.kind === "resource_mine") {
+        const { lastHarvestDay: _lastHarvestDay, ...rest } = building;
+        return {
+          ...rest,
+          income: building.income + 1
+        };
+      }
+      if (building.kind === "attribute_shrine") {
+        return {
+          ...building,
+          lastUsedDay: 3
+        };
+      }
+      return building;
+    })
+  };
+  await store.saveStagedDraft([
+    {
+      id: "mapObjects",
+      content: JSON.stringify(staged)
+    }
+  ]);
+
+  const preview = await store.previewStagedDiff("mapObjects");
+
+  assert.equal(preview.documentId, "mapObjects");
+  assert.equal(typeof preview.hash, "string");
+  assert.equal(typeof preview.stageHash, "string");
+  assert.ok(preview.stageHash.length > 0);
+  assert.equal(preview.added.some((entry) => entry.key === "buildings[1].lastUsedDay" && entry.after === "3"), true);
+  assert.equal(
+    preview.modified.some(
+      (entry) => entry.key === "buildings[2].income" && entry.before === "2" && entry.after === "3"
+    ),
+    true
+  );
+  assert.equal(
+    preview.removed.some((entry) => entry.key === "buildings[2].lastHarvestDay" && entry.before === "2"),
+    true
+  );
+});
+
+test("config center staged publish rejects confirmed diff hashes after staged drift", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  await store.saveStagedDraft([
+    {
+      id: "world",
+      content: JSON.stringify({
+        ...WORLD_CONFIG,
+        width: WORLD_CONFIG.width + 1
+      })
+    }
+  ]);
+  const preview = await store.previewStagedDiff("world");
+
+  await store.saveStagedDraft([
+    {
+      id: "world",
+      content: JSON.stringify({
+        ...WORLD_CONFIG,
+        width: WORLD_CONFIG.width + 2
+      })
+    }
+  ]);
+
+  await assert.rejects(
+    () =>
+      store.publishStagedDraft({
+        author: "ConfigOps",
+        summary: "stale preview",
+        confirmedDiffHash: preview.stageHash
+      }),
+    /漂移.*diff-preview|diff-preview.*漂移/
+  );
+});
+
 test("config center delays hot reload while battles are active and applies it once rooms are safe", async () => {
   const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
   await seedConfigRoot(rootDir);

--- a/docs/config-deployment-safety.md
+++ b/docs/config-deployment-safety.md
@@ -11,9 +11,10 @@ Recommended operator workflow:
 1. Prefer the low-traffic deployment window between 03:00 and 05:00 local server time.
 2. Confirm no high-priority live event, tournament, or guided playtest is running.
 3. Check active room count and active battle count before publishing.
-4. Publish config changes through Config Center staged publish rather than ad hoc file edits.
-5. Watch room/runtime errors for at least the configured rollback window after the update clears the battle gate.
-6. If the publish remains pending because battles are still active, wait for settlement instead of forcing a room restart.
+4. In Config Center, load the staged `diff-preview` for every document in the publish bundle and confirm the grouped `added / modified / removed` blast radius before enabling publish.
+5. Publish config changes through Config Center staged publish rather than ad hoc file edits. The publish request should carry the latest `confirmedDiffHash` so drift between preview and publish is rejected.
+6. Watch room/runtime errors for at least the configured rollback window after the update clears the battle gate.
+7. If the publish remains pending because battles are still active, wait for settlement instead of forcing a room restart.
 
 Rollback guidance:
 


### PR DESCRIPTION
## Summary
- add a staged diff-preview route that returns grouped added, modified, and removed entries plus a stable preview hash
- require confirmedDiffHash on staged publish and block H5 publish until fresh diff previews are loaded for every staged document
- document the diff-preview workflow and cover preview grouping, hash drift rejection, and rollback-window behavior in tests

## Validation
- `node --import tsx --test apps/server/test/config-center.test.ts`
- `npm run test:client:config-center`
- `npm run typecheck:server`
- `npm run typecheck:client:h5`

Closes #1378
