### PR TITLE
[FIX] Revalidate WebSocket auth on reconnect and token refresh

### DIFF
--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1681,6 +1681,14 @@ async function validateAuthToken(
   }
 }
 
+export async function validateGuestAuthToken(
+  token: string,
+  store: RoomSnapshotStore | null,
+  expectedKind: "access" | "refresh" = "access"
+): Promise<ValidateAuthSessionResult> {
+  return validateAuthToken(token, store, expectedKind);
+}
+
 export async function validateAuthSessionFromRequest(
   request: Pick<IncomingMessage, "headers">,
   store: RoomSnapshotStore | null,

--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -55,7 +55,7 @@ import {
   registerConfigUpdateListener
 } from "./config-center";
 import { applyPlayerEventLogAndAchievements } from "./player-achievements";
-import { resolveGuestAuthSession } from "./auth";
+import { validateGuestAuthToken, type GuestAuthSession } from "./auth";
 import { buildMinorProtectionBlockDetails, deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
 import {
   recordBattleActionMessage,
@@ -587,6 +587,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
   private readonly minorProtectionConfig = readMinorProtectionConfig();
   private readonly lobbyRoomOwnerToken = nextLobbyRoomOwnerToken++;
   private readonly playerIdBySessionId = new Map<string, string>();
+  private readonly authSessionByPlayerId = new Map<string, GuestAuthSession>();
   private readonly analyticsSessionStartedAtBySessionId = new Map<string, number>();
   private readonly analyticsSessionDisconnectReasonBySessionId = new Map<string, string>();
   private readonly disconnectedAtByPlayerId = new Map<string, string>();
@@ -661,8 +662,12 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         return;
       }
 
-      const authSession = message.authToken ? resolveGuestAuthSession(message.authToken) : null;
+      const authValidation = message.authToken
+        ? await validateGuestAuthToken(message.authToken, configuredRoomSnapshotStore)
+        : { session: null };
+      const authSession = authValidation.session;
       if (message.authToken && !authSession) {
+        this.rejectExpiredSession(client, message.requestId, authValidation.errorCode ?? "unauthorized");
         sendMessage(client, "error", { requestId: message.requestId, reason: "unauthorized" });
         return;
       }
@@ -674,6 +679,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       }
 
       this.playerIdBySessionId.set(client.sessionId, playerId);
+      this.updatePlayerAuthSession(playerId, authSession);
       this.disconnectedAtByPlayerId.delete(playerId);
       this.refreshEmptyRoomTracking();
       let ensuredAccount: PlayerAccountSnapshot | null = null;
@@ -735,6 +741,29 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       });
       this.analyticsSessionStartedAtBySessionId.set(client.sessionId, roomRuntimeDependencies.now());
       this.analyticsSessionDisconnectReasonBySessionId.delete(client.sessionId);
+    });
+
+    this.onMessage("TOKEN_REFRESH", async (client, message: Extract<ClientMessage, { type: "TOKEN_REFRESH" }>) => {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "not_connected" });
+        return;
+      }
+
+      const authValidation = await validateGuestAuthToken(message.authToken, configuredRoomSnapshotStore);
+      const authSession = authValidation.session;
+      if (!authSession || authSession.playerId !== playerId) {
+        this.rejectExpiredSession(client, message.requestId, authValidation.errorCode ?? "unauthorized");
+        sendMessage(client, "error", { requestId: message.requestId, reason: "unauthorized" });
+        return;
+      }
+
+      this.updatePlayerAuthSession(playerId, authSession);
+      sendMessage(client, "session.state", {
+        requestId: message.requestId,
+        delivery: "reply",
+        payload: this.buildStatePayload(playerId)
+      });
     });
 
     this.onMessage("world.preview", (client, message: Extract<ClientMessage, { type: "world.preview" }>) => {
@@ -1027,6 +1056,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
 
   disconnectPlayer(playerId: string, reason = "account_banned"): number {
     let disconnected = 0;
+    this.clearPlayerAuthSession(playerId);
     for (const client of this.clients) {
       if (this.playerIdBySessionId.get(client.sessionId) !== playerId) {
         continue;
@@ -1057,6 +1087,21 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
       recordReconnectWindowOpened();
       reconnectWindowOpen = true;
       const reconnectedClient = await this.allowReconnection(client, RECONNECTION_WINDOW_SECONDS);
+      const authValidation = await this.validateReconnectSession(playerId);
+      if (authValidation.errorCode) {
+        if (reconnectWindowOpen) {
+          recordReconnectWindowResolved("failure", {
+            roomId: this.metadata.logicalRoomId,
+            playerId,
+            reason: "auth_invalid"
+          });
+          reconnectWindowOpen = false;
+        }
+        this.rejectExpiredSession(reconnectedClient, "push", authValidation.errorCode ?? "unauthorized");
+        this.clearPlayerAuthSession(playerId);
+        this.publishLobbyRoomSummary();
+        return;
+      }
       if (configuredRoomSnapshotStore?.loadPlayerBan) {
         const ban = await configuredRoomSnapshotStore.loadPlayerBan(playerId);
         if (isPlayerBanActive(ban)) {
@@ -1084,6 +1129,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         }
         this.publishLobbyRoomSummary();
         return;
+      }
+      if (authValidation.session) {
+        this.updatePlayerAuthSession(playerId, authValidation.session);
       }
       this.playerIdBySessionId.set(reconnectedClient.sessionId, playerId);
       const previousSessionStartedAtMs = this.analyticsSessionStartedAtBySessionId.get(client.sessionId);
@@ -1128,6 +1176,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         });
       }
       this.playerIdBySessionId.delete(client.sessionId);
+      this.clearPlayerAuthSession(playerId);
       this.refreshEmptyRoomTracking();
       this.ensureTurnTimerState();
       this.publishLobbyRoomSummary();
@@ -1147,6 +1196,9 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         this.analyticsSessionDisconnectReasonBySessionId.get(client.sessionId) ?? "transport_closed"
       );
     }
+    if (playerId && !this.getConnectedPlayerIds().includes(playerId) && !this.disconnectedAtByPlayerId.has(playerId)) {
+      this.clearPlayerAuthSession(playerId);
+    }
     if (playerId && !this.getConnectedPlayerIds().includes(playerId)) {
       this.disconnectedAtByPlayerId.set(playerId, new Date(roomRuntimeDependencies.now()).toISOString());
     }
@@ -1159,6 +1211,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     for (const [sessionId, playerId] of this.playerIdBySessionId.entries()) {
       this.emitSessionEndForConnection(sessionId, playerId, "room_disposed");
     }
+    this.authSessionByPlayerId.clear();
     this.unsubscribeConfigUpdate?.();
     this.unsubscribeConfigUpdate = null;
     this.wsActionTimestampsByPlayerId.clear();
@@ -2509,6 +2562,41 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     }
 
     return playerId;
+  }
+
+  private updatePlayerAuthSession(playerId: string, authSession: GuestAuthSession | null): void {
+    if (authSession) {
+      this.authSessionByPlayerId.set(playerId, authSession);
+      return;
+    }
+
+    this.authSessionByPlayerId.delete(playerId);
+  }
+
+  private clearPlayerAuthSession(playerId: string): void {
+    this.authSessionByPlayerId.delete(playerId);
+  }
+
+  private async validateReconnectSession(playerId: string): Promise<{ session: GuestAuthSession | null; errorCode?: string }> {
+    const authSession = this.authSessionByPlayerId.get(playerId);
+    if (!authSession?.token) {
+      return { session: null, errorCode: undefined };
+    }
+
+    return await validateGuestAuthToken(authSession.token, configuredRoomSnapshotStore);
+  }
+
+  private rejectExpiredSession(client: ColyseusClient, requestId: string, reason: string): void {
+    if (reason !== "token_expired") {
+      return;
+    }
+
+    sendMessage(client, "SESSION_EXPIRED", {
+      requestId,
+      delivery: "push",
+      reason
+    });
+    client.leave(CloseCode.WITH_ERROR, "session_expired");
   }
 
   private pushSessionStateToAll(extras?: {

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,6 +23,7 @@ import {
   resetAnalyticsRuntimeDependencies
 } from "../src/analytics";
 import { FileSystemConfigCenterStore, resetConfigHotReloadState } from "../src/config-center";
+import { issueAccountAuthSession, issueNextAuthSession, type GuestAuthSession } from "../src/auth";
 import {
   VeilColyseusRoom,
   configureRoomRuntimeDependencies,
@@ -312,7 +314,8 @@ async function connectPlayer(
   room: VeilColyseusRoom,
   client: FakeClient,
   playerId: string,
-  requestId: string
+  requestId: string,
+  authToken?: string
 ): Promise<void> {
   room.clients.push(client);
   room.onJoin(client, { playerId });
@@ -320,8 +323,37 @@ async function connectPlayer(
     type: "connect",
     requestId,
     roomId: room.roomId,
-    playerId
+    playerId,
+    ...(authToken ? { authToken } : {})
   });
+}
+
+function cloneSessionWithExpiresAt(session: GuestAuthSession, expiresAt: string): GuestAuthSession {
+  const [encodedPayload] = session.token.split(".");
+  assert.ok(encodedPayload, "expected a signed auth token");
+  const payload = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8")) as {
+    issuedAt: string;
+    expiresAt: string;
+  };
+  const issuedAt = new Date(Date.now() - 1_000).toISOString();
+  const nextPayload = Buffer.from(
+    JSON.stringify({
+      ...payload,
+      issuedAt,
+      expiresAt
+    })
+  ).toString("base64url");
+  const signature = createHmac("sha256", process.env.VEIL_AUTH_SECRET ?? "project-veil-dev-secret")
+    .update(nextPayload)
+    .digest("base64url");
+
+  return {
+    ...session,
+    token: `${nextPayload}.${signature}`,
+    issuedAt,
+    expiresAt,
+    lastUsedAt: new Date().toISOString()
+  };
 }
 
 function getBattleForPlayer(room: VeilColyseusRoom, playerId: string): BattleState | null {
@@ -834,6 +866,98 @@ test("stale leave after a successful reconnect does not clear the resumed player
 
   assert.equal(internalRoom.playerIdBySessionId.get("session-stale-reconnected"), "player-1");
   assert.equal(listLobbyRooms().find((entry) => entry.roomId === room.roomId)?.connectedPlayers, 1);
+});
+
+test("reconnect with an expired tracked auth token sends SESSION_EXPIRED and rejects the resumed client", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-reconnect-expired-token-${Date.now()}`);
+  const originalClient = createFakeClient("session-expired-token-original");
+  const reconnectedClient = createFakeClient("session-expired-token-resumed");
+  const expiringSession = cloneSessionWithExpiresAt(
+    issueAccountAuthSession({
+      playerId: "player-1",
+      displayName: "Player One",
+      loginId: "player-one"
+    }),
+    new Date(Date.now() + 20).toISOString()
+  );
+  const internalRoom = room as VeilColyseusRoom & {
+    playerIdBySessionId: Map<string, string>;
+    allowReconnection(client: Client, seconds: number): Promise<Client>;
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, originalClient, "player-1", "connect-expired-token", expiringSession.token);
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
+  internalRoom.allowReconnection = async () => reconnectedClient;
+  await room.onDrop(originalClient);
+
+  const expiredMessage = reconnectedClient.sent.find(
+    (message): message is Extract<ServerMessage, { type: "SESSION_EXPIRED" }> => message.type === "SESSION_EXPIRED"
+  );
+  assert.ok(expiredMessage);
+  assert.equal(expiredMessage.reason, "token_expired");
+  assert.equal(internalRoom.playerIdBySessionId.has(reconnectedClient.sessionId), false);
+  assert.equal(reconnectedClient.leaveCalls.at(-1)?.reason, "session_expired");
+  assert.equal(reconnectedClient.sent.some((message) => message.type === "session.state"), false);
+});
+
+test("TOKEN_REFRESH updates the tracked auth session so reconnect accepts the refreshed token", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-reconnect-token-refresh-${Date.now()}`);
+  const originalClient = createFakeClient("session-token-refresh-original");
+  const reconnectedClient = createFakeClient("session-token-refresh-resumed");
+  const expiringSession = cloneSessionWithExpiresAt(
+    issueAccountAuthSession({
+      playerId: "player-1",
+      displayName: "Player One",
+      loginId: "player-one"
+    }),
+    new Date(Date.now() + 20).toISOString()
+  );
+  const refreshedSession = issueNextAuthSession(
+    {
+      playerId: "player-1",
+      displayName: "Player One",
+      loginId: "player-one"
+    },
+    expiringSession
+  );
+  const internalRoom = room as VeilColyseusRoom & {
+    playerIdBySessionId: Map<string, string>;
+    allowReconnection(client: Client, seconds: number): Promise<Client>;
+  };
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, originalClient, "player-1", "connect-token-refresh", expiringSession.token);
+  await emitRoomMessage(room, "TOKEN_REFRESH", originalClient, {
+    type: "TOKEN_REFRESH",
+    requestId: "token-refresh",
+    authToken: refreshedSession.token
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30));
+
+  internalRoom.allowReconnection = async () => reconnectedClient;
+  await room.onDrop(originalClient);
+
+  assert.equal(internalRoom.playerIdBySessionId.get(reconnectedClient.sessionId), "player-1");
+  assert.equal(reconnectedClient.sent.some((message) => message.type === "SESSION_EXPIRED"), false);
+  assert.equal(reconnectedClient.leaveCalls.length, 0);
+  assert.equal(lastSessionState(originalClient, "reply").requestId, "token-refresh");
+  assert.equal(lastSessionState(reconnectedClient, "push").requestId, "push");
 });
 
 test("client that misses the reconnect window is cleaned up from the player slot map", async (t) => {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -79,6 +79,11 @@ export type ClientMessage =
       seed?: number;
     }
   | {
+      type: "TOKEN_REFRESH";
+      requestId: string;
+      authToken: string;
+    }
+  | {
       type: "world.action";
       requestId: string;
       action: WorldAction;
@@ -222,6 +227,12 @@ export type ServerMessage =
         nextAllowedLocalTime: string | null;
         nextAllowedCountdownSeconds: number | null;
       };
+    }
+  | {
+      type: "SESSION_EXPIRED";
+      requestId: string;
+      delivery: "push";
+      reason: string;
     }
   | {
       type: "report.player";


### PR DESCRIPTION
## Summary
- revalidate stored WebSocket auth on reconnect instead of trusting the original join forever
- add a `TOKEN_REFRESH` room message so clients can replace the tracked access token before reconnect
- emit `SESSION_EXPIRED` and close the resumed connection when the tracked token has expired

## Root Cause
`VeilColyseusRoom` only validated the access token during the initial `connect` message. After a transport drop, reconnect restored the player slot without re-checking whether the tracked auth token had expired or been refreshed.

## Validation
- `node --import tsx --test ./apps/server/test/colyseus-room-lifecycle.test.ts --test-name-pattern "expired tracked auth token|TOKEN_REFRESH updates"`
  - the two new auth/reconnect tests passed
  - the lifecycle file still contains unrelated pre-existing failures when run wholesale

Closes #1372
