### PR TITLE
Implement #1373 dialogue ack and tutorial progress handlers

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -3,6 +3,7 @@ import { Room, type Client as ColyseusClient } from "colyseus";
 import {
   classifyReconnectFailure,
   DEFAULT_MIN_SUPPORTED_CLIENT_VERSION,
+  DEFAULT_TUTORIAL_STEP,
   isClientVersionSupported,
   createInitialWorldState,
   createPlayerWorldView,
@@ -57,6 +58,7 @@ import {
 import { applyPlayerEventLogAndAchievements } from "./player-achievements";
 import { validateGuestAuthToken, type GuestAuthSession } from "./auth";
 import { buildMinorProtectionBlockDetails, deriveMinorProtectionState, readMinorProtectionConfig } from "./minor-protection";
+import { acknowledgeCampaignDialogueLine, resolveCampaignConfig } from "./pve-content";
 import {
   recordBattleActionMessage,
   recordAntiCheatAlert,
@@ -78,6 +80,7 @@ import { sendWechatSubscribeMessage, type WechatSubscribeTemplateKey } from "./w
 import { resolveFeatureFlagsForPlayer } from "./feature-flags";
 import { captureServerError } from "./error-monitoring";
 import { settleLeaderboardMatch } from "./leaderboard-anti-abuse";
+import { normalizeTutorialProgressAction, toTutorialAnalyticsPayload } from "./tutorial-progress";
 
 type MessageOfType<T extends ServerMessage["type"]> = Omit<Extract<ServerMessage, { type: T }>, "type">;
 
@@ -999,6 +1002,108 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
           error instanceof Error && error.message === "duplicate_player_report"
             ? "duplicate_player_report"
             : "report_submit_failed";
+        sendMessage(client, "error", { requestId: message.requestId, reason });
+      }
+    });
+
+    this.onMessage("tutorial.progress", async (client, message: Extract<ClientMessage, { type: "tutorial.progress" }>) => {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "not_connected" });
+        return;
+      }
+      if (!configuredRoomSnapshotStore) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "tutorial_persistence_unavailable" });
+        return;
+      }
+
+      try {
+        const account =
+          (await configuredRoomSnapshotStore.loadPlayerAccount(playerId)) ??
+          (await configuredRoomSnapshotStore.ensurePlayerAccount({
+            playerId,
+            displayName: playerId,
+            lastRoomId: logicalRoomId
+          }));
+        const action = normalizeTutorialProgressAction(
+          message.action,
+          account.tutorialStep ?? DEFAULT_TUTORIAL_STEP
+        );
+        await configuredRoomSnapshotStore.savePlayerAccountProgress(playerId, {
+          tutorialStep: action.step
+        });
+        emitAnalyticsEvent("tutorial_step", {
+          playerId,
+          roomId: logicalRoomId,
+          payload: toTutorialAnalyticsPayload(action)
+        });
+        sendMessage(client, "session.state", {
+          requestId: message.requestId,
+          delivery: "reply",
+          payload: this.buildStatePayload(playerId, {
+            events: [],
+            movementPlan: null
+          })
+        });
+      } catch (error) {
+        const reason =
+          error instanceof Error
+            ? error.message === "tutorial_skip_locked"
+              ? "tutorial_skip_locked"
+              : error.message === "tutorial_progress_invalid_step"
+                ? "tutorial_progress_invalid_step"
+                : error.message === "tutorial_progress_out_of_order"
+                  ? "tutorial_progress_out_of_order"
+                  : "tutorial_progress_failed"
+            : "tutorial_progress_failed";
+        sendMessage(client, "error", { requestId: message.requestId, reason });
+      }
+    });
+
+    this.onMessage("campaign.dialogue.ack", async (client, message: Extract<ClientMessage, { type: "campaign.dialogue.ack" }>) => {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "not_connected" });
+        return;
+      }
+      if (!configuredRoomSnapshotStore) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "campaign_persistence_unavailable" });
+        return;
+      }
+
+      try {
+        const account =
+          (await configuredRoomSnapshotStore.loadPlayerAccount(playerId)) ??
+          (await configuredRoomSnapshotStore.ensurePlayerAccount({
+            playerId,
+            displayName: playerId,
+            lastRoomId: logicalRoomId
+          }));
+        const campaignProgress = acknowledgeCampaignDialogueLine(
+          resolveCampaignConfig(),
+          account.campaignProgress,
+          message.action
+        );
+        await configuredRoomSnapshotStore.savePlayerAccountProgress(playerId, {
+          campaignProgress
+        });
+        sendMessage(client, "session.state", {
+          requestId: message.requestId,
+          delivery: "reply",
+          payload: this.buildStatePayload(playerId, {
+            events: [],
+            movementPlan: null
+          })
+        });
+      } catch (error) {
+        const reason =
+          error instanceof Error
+            ? error.message === "campaign_mission_not_found"
+              ? "campaign_mission_not_found"
+              : error.message === "campaign_dialogue_line_not_found"
+                ? "campaign_dialogue_line_not_found"
+                : "campaign_dialogue_ack_failed"
+            : "campaign_dialogue_ack_failed";
         sendMessage(client, "error", { requestId: message.requestId, reason });
       }
     });
@@ -2580,7 +2685,7 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
   private async validateReconnectSession(playerId: string): Promise<{ session: GuestAuthSession | null; errorCode?: string }> {
     const authSession = this.authSessionByPlayerId.get(playerId);
     if (!authSession?.token) {
-      return { session: null, errorCode: undefined };
+      return { session: null };
     }
 
     return await validateGuestAuthToken(authSession.token, configuredRoomSnapshotStore);

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -4,7 +4,6 @@ import {
   applyBattleReplayPlaybackCommand,
   buildPlayerBattleReportCenter,
   buildPlayerProgressionSnapshot,
-  canSkipTutorial,
   DEFAULT_TUTORIAL_STEP,
   findPlayerBattleReplaySummary,
   getRankDivisionForRating,
@@ -19,8 +18,7 @@ import {
   summarizePlayerMailbox,
   type BattleReplayPlaybackCommand,
   type PlayerBattleReplaySummary,
-  type SeasonalEventState,
-  type TutorialProgressAction
+  type SeasonalEventState
 } from "../../../packages/shared/src/index";
 import {
   createDailyQuestClaimEventLogEntry,
@@ -74,6 +72,7 @@ import {
   validateGroupChallengeToken
 } from "./wechat-social";
 import { normalizePlayerMailboxMessage } from "./player-mailbox";
+import { normalizeTutorialProgressAction, toTutorialAnalyticsPayload } from "./tutorial-progress";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -400,28 +399,6 @@ async function withDailyQuestBoard(
       new Date(),
       enabled && isTutorialComplete(account.tutorialStep)
     )
-  };
-}
-
-function normalizeTutorialProgressAction(input: unknown, currentStep?: number | null): TutorialProgressAction {
-  const raw = input as Partial<TutorialProgressAction> | null | undefined;
-  const reason =
-    raw?.reason === "skip" || raw?.reason === "complete" || raw?.reason === "advance" ? raw.reason : "advance";
-  const step = raw?.step == null ? null : Math.floor(raw.step);
-
-  if (step !== null && (!Number.isFinite(step) || step <= 0)) {
-    throw new Error("tutorial_progress_invalid_step");
-  }
-  if (reason === "skip" && !canSkipTutorial(currentStep)) {
-    throw new Error("tutorial_skip_locked");
-  }
-  if (reason === "advance" && step === null) {
-    throw new Error("tutorial_progress_invalid_step");
-  }
-
-  return {
-    step,
-    reason
   };
 }
 
@@ -1847,15 +1824,7 @@ export function registerPlayerAccountRoutes(
       emitAnalyticsEvent("tutorial_step", {
         playerId: account.playerId,
         roomId: account.lastRoomId ?? "lobby",
-        payload: {
-          stepId:
-            action.step == null
-              ? action.reason === "skip"
-                ? "tutorial_skipped"
-                : "tutorial_completed"
-              : `step_${action.step}`,
-          status: action.reason === "skip" ? "skipped" : action.step == null ? "completed" : "active"
-        }
+        payload: toTutorialAnalyticsPayload(action)
       });
 
       sendJson(response, 200, {
@@ -1877,6 +1846,15 @@ export function registerPlayerAccountRoutes(
           error: {
             code: "tutorial_progress_invalid_step",
             message: "Tutorial progress payload is invalid"
+          }
+        });
+        return;
+      }
+      if (error instanceof Error && error.message === "tutorial_progress_out_of_order") {
+        sendJson(response, 409, {
+          error: {
+            code: "tutorial_progress_out_of_order",
+            message: "Tutorial progress must advance in order"
           }
         });
         return;
@@ -1908,6 +1886,51 @@ export function registerPlayerAccountRoutes(
       sendJson(response, 200, {
         campaign: toCampaignResponse(account, accessContext)
       });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/campaigns/missions/:id", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    const missionId = request.params.id?.trim();
+    if (!missionId) {
+      sendNotFound(response);
+      return;
+    }
+
+    try {
+      const account = store
+        ? ((await store.loadPlayerAccount(authSession.playerId)) ??
+          (await store.ensurePlayerAccount({
+            playerId: authSession.playerId,
+            displayName: authSession.displayName
+          })))
+        : createLocalModeAccount({
+            playerId: authSession.playerId,
+            displayName: authSession.displayName,
+            ...(authSession.loginId ? { loginId: authSession.loginId } : {})
+          });
+      const accessContext = await loadCampaignAccessContext(store, account);
+      const mission = buildCampaignMissionStates(resolveCampaignConfig(), account.campaignProgress, accessContext).find(
+        (entry) => entry.id === missionId
+      );
+
+      if (!mission) {
+        sendJson(response, 404, {
+          error: {
+            code: "campaign_mission_not_found",
+            message: "Campaign mission was not found"
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 200, { mission });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/src/pve-content.ts
+++ b/apps/server/src/pve-content.ts
@@ -399,6 +399,9 @@ export function buildCampaignMissionStates(
       ...mission,
       missionId: mission.id,
       attempts: Math.max(0, progress?.attempts ?? 0),
+      ...(progress?.acknowledgedDialogueLineIds?.length
+        ? { acknowledgedDialogueLineIds: progress.acknowledgedDialogueLineIds }
+        : {}),
       ...(progress?.completedAt ? { completedAt: progress.completedAt } : {}),
       ...(unlockRequirements.length > 0 ? { unlockRequirements } : {}),
       status: completed ? "completed" : unlocked ? "available" : "locked"
@@ -425,9 +428,13 @@ export function completeCampaignMission(
   }
 
   const progressByMissionId = new Map((campaignProgress?.missions ?? []).map((progress) => [progress.missionId, progress] as const));
+  const existingProgress = progressByMissionId.get(missionId);
   progressByMissionId.set(missionId, {
     missionId,
-    attempts: Math.max(0, progressByMissionId.get(missionId)?.attempts ?? 0) + 1,
+    attempts: Math.max(0, existingProgress?.attempts ?? 0) + 1,
+    ...(existingProgress?.acknowledgedDialogueLineIds?.length
+      ? { acknowledgedDialogueLineIds: existingProgress.acknowledgedDialogueLineIds }
+      : {}),
     completedAt
   });
 
@@ -435,6 +442,9 @@ export function completeCampaignMission(
     mission: {
       ...mission,
       attempts: Math.max(0, mission.attempts) + 1,
+      ...(mission.acknowledgedDialogueLineIds?.length
+        ? { acknowledgedDialogueLineIds: mission.acknowledgedDialogueLineIds }
+        : {}),
       completedAt,
       status: "completed"
     },
@@ -442,6 +452,43 @@ export function completeCampaignMission(
       missions: Array.from(progressByMissionId.values()).sort((left, right) => left.missionId.localeCompare(right.missionId))
     },
     reward: mission.reward
+  };
+}
+
+export function acknowledgeCampaignDialogueLine(
+  missions: CampaignMission[],
+  campaignProgress: CampaignProgressState | undefined,
+  input: {
+    missionId: string;
+    sequence: "intro" | "outro";
+    dialogueLineId: string;
+  }
+): CampaignProgressState {
+  const mission = missions.find((entry) => entry.id === input.missionId);
+  if (!mission) {
+    throw new Error("campaign_mission_not_found");
+  }
+
+  const dialogue = input.sequence === "intro" ? mission.introDialogue ?? [] : mission.outroDialogue ?? [];
+  if (!dialogue.some((line) => line.id === input.dialogueLineId)) {
+    throw new Error("campaign_dialogue_line_not_found");
+  }
+
+  const progressByMissionId = new Map((campaignProgress?.missions ?? []).map((progress) => [progress.missionId, progress] as const));
+  const existing = progressByMissionId.get(input.missionId);
+  const acknowledgedDialogueLineIds = Array.from(
+    new Set([...(existing?.acknowledgedDialogueLineIds ?? []), input.dialogueLineId])
+  ).sort((left, right) => left.localeCompare(right));
+
+  progressByMissionId.set(input.missionId, {
+    missionId: input.missionId,
+    attempts: Math.max(0, existing?.attempts ?? 0),
+    ...(acknowledgedDialogueLineIds.length > 0 ? { acknowledgedDialogueLineIds } : {}),
+    ...(existing?.completedAt ? { completedAt: existing.completedAt } : {})
+  });
+
+  return {
+    missions: Array.from(progressByMissionId.values()).sort((left, right) => left.missionId.localeCompare(right.missionId))
   };
 }
 

--- a/apps/server/src/tutorial-progress.ts
+++ b/apps/server/src/tutorial-progress.ts
@@ -1,0 +1,46 @@
+import { canSkipTutorial, type TutorialProgressAction } from "../../../packages/shared/src/index";
+
+export function normalizeTutorialProgressAction(input: unknown, currentStep?: number | null): TutorialProgressAction {
+  const raw = input as Partial<TutorialProgressAction> | null | undefined;
+  const reason =
+    raw?.reason === "skip" || raw?.reason === "complete" || raw?.reason === "advance" ? raw.reason : "advance";
+  const step = raw?.step == null ? null : Math.floor(raw.step);
+  const normalizedCurrentStep = currentStep == null ? null : Math.max(1, Math.floor(currentStep));
+
+  if (step !== null && (!Number.isFinite(step) || step <= 0)) {
+    throw new Error("tutorial_progress_invalid_step");
+  }
+  if (reason === "skip" && !canSkipTutorial(normalizedCurrentStep)) {
+    throw new Error("tutorial_skip_locked");
+  }
+  if (reason === "advance" && step === null) {
+    throw new Error("tutorial_progress_invalid_step");
+  }
+  if (reason === "advance" && normalizedCurrentStep !== null && step !== normalizedCurrentStep + 1) {
+    throw new Error("tutorial_progress_out_of_order");
+  }
+  if (reason === "complete" && normalizedCurrentStep !== null && step !== null) {
+    throw new Error("tutorial_progress_invalid_step");
+  }
+  if (reason === "complete" && normalizedCurrentStep !== null && normalizedCurrentStep < 3) {
+    throw new Error("tutorial_progress_out_of_order");
+  }
+
+  return {
+    step,
+    reason
+  };
+}
+
+export function toTutorialAnalyticsPayload(action: TutorialProgressAction): { stepId: string; status: string; reason: string } {
+  return {
+    stepId:
+      action.step == null
+        ? action.reason === "skip"
+          ? "tutorial_skipped"
+          : "tutorial_completed"
+        : `step_${action.step}`,
+    status: action.reason === "skip" ? "skipped" : action.step == null ? "completed" : "active",
+    reason: action.reason ?? "advance"
+  };
+}

--- a/apps/server/test/issue-1373-handlers.test.ts
+++ b/apps/server/test/issue-1373-handlers.test.ts
@@ -1,0 +1,363 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ClientState, matchMaker } from "colyseus";
+import type { Client as ColyseusClient } from "colyseus";
+import type { ServerMessage } from "../../../packages/shared/src/index";
+import { configureAnalyticsRuntimeDependencies, flushAnalyticsEventsForTest, resetAnalyticsRuntimeDependencies } from "../src/analytics";
+import { issueAccountAuthSession } from "../src/auth";
+import {
+  configureRoomSnapshotStore,
+  resetLobbyRoomRegistry,
+  resetRoomRuntimeDependencies,
+  VeilColyseusRoom
+} from "../src/colyseus-room";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import { registerPlayerAccountRoutes } from "../src/player-accounts";
+
+interface FakeClient extends ColyseusClient {
+  sent: ServerMessage[];
+  leaveCalls: Array<{ code?: number; reason?: string }>;
+}
+
+function createFakeClient(sessionId: string): FakeClient {
+  return {
+    sessionId,
+    state: ClientState.JOINED,
+    sent: [],
+    leaveCalls: [],
+    ref: {
+      removeAllListeners() {},
+      removeListener() {},
+      once() {}
+    },
+    send(type: string | number, payload?: unknown) {
+      this.sent.push({ type, ...(payload as object) } as ServerMessage);
+    },
+    leave(code?: number, reason?: string) {
+      this.leaveCalls.push({ code, reason });
+    },
+    enqueueRaw() {},
+    raw() {}
+  } as FakeClient;
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function createTestRoom(logicalRoomId: string, seed = 1001): Promise<VeilColyseusRoom> {
+  await matchMaker.setup(
+    undefined,
+    {
+      async update() {},
+      async remove() {},
+      async persist() {}
+    } as never,
+    "http://127.0.0.1"
+  );
+
+  const room = new VeilColyseusRoom();
+  const internalRoom = room as VeilColyseusRoom & {
+    __init(): void;
+    _listing: Record<string, unknown>;
+    _internalState: number;
+  };
+
+  internalRoom.roomId = logicalRoomId;
+  internalRoom.roomName = "veil";
+  internalRoom._listing = {
+    roomId: logicalRoomId,
+    clients: 0,
+    locked: false,
+    private: false,
+    unlisted: false,
+    metadata: {}
+  };
+
+  internalRoom.__init();
+  await room.onCreate({ logicalRoomId, seed });
+  internalRoom._internalState = 1;
+  return room;
+}
+
+function cleanupRoom(room: VeilColyseusRoom): void {
+  const internalRoom = room as VeilColyseusRoom & {
+    _autoDisposeTimeout?: NodeJS.Timeout;
+    _events: { emit(event: string): void };
+  };
+
+  if (internalRoom._autoDisposeTimeout) {
+    clearTimeout(internalRoom._autoDisposeTimeout);
+    internalRoom._autoDisposeTimeout = undefined;
+  }
+
+  internalRoom._events.emit("dispose");
+  room.clock.clear();
+  room.clock.stop();
+}
+
+async function emitRoomMessage(room: VeilColyseusRoom, type: string, client: FakeClient, payload: object): Promise<void> {
+  const internalRoom = room as VeilColyseusRoom & {
+    onMessageEvents: {
+      emit(event: string, ...args: unknown[]): void;
+    };
+  };
+
+  internalRoom.onMessageEvents.emit(type, client, payload);
+  await flushAsyncWork();
+}
+
+async function connectPlayer(
+  room: VeilColyseusRoom,
+  client: FakeClient,
+  playerId: string,
+  requestId: string
+): Promise<void> {
+  room.clients.push(client as never);
+  room.onJoin(client as never, { playerId });
+  await emitRoomMessage(room, "connect", client, {
+    type: "connect",
+    requestId,
+    roomId: room.roomId,
+    playerId
+  });
+}
+
+function createRouteRegistryApp(): {
+  use(handler: (request: any, response: any, next: () => void) => void): void;
+  get(path: string, handler: (request: any, response: any) => Promise<void> | void): void;
+  post(path: string, handler: (request: any, response: any) => Promise<void> | void): void;
+  put(path: string, handler: (request: any, response: any) => Promise<void> | void): void;
+  delete(path: string, handler: (request: any, response: any) => Promise<void> | void): void;
+  middleware: Array<(request: any, response: any, next: () => void) => void>;
+  routes: Map<string, (request: any, response: any) => Promise<void> | void>;
+} {
+  const routes = new Map<string, (request: any, response: any) => Promise<void> | void>();
+  const middleware: Array<(request: any, response: any, next: () => void) => void> = [];
+
+  return {
+    use(handler) {
+      middleware.push(handler);
+    },
+    get(path, handler) {
+      routes.set(`GET ${path}`, handler);
+    },
+    post(path, handler) {
+      routes.set(`POST ${path}`, handler);
+    },
+    put(path, handler) {
+      routes.set(`PUT ${path}`, handler);
+    },
+    delete(path, handler) {
+      routes.set(`DELETE ${path}`, handler);
+    },
+    middleware,
+    routes
+  };
+}
+
+async function invokeRoute(
+  app: ReturnType<typeof createRouteRegistryApp>,
+  key: string,
+  request: {
+    url: string;
+    method: string;
+    headers?: Record<string, string>;
+    params?: Record<string, string>;
+  }
+): Promise<{ statusCode: number; body: unknown }> {
+  const handler = app.routes.get(key);
+  if (!handler) {
+    throw new Error(`route_not_found:${key}`);
+  }
+
+  let bodyText = "";
+  const response = {
+    statusCode: 200,
+    setHeader() {},
+    end(chunk?: string) {
+      bodyText = chunk ?? "";
+    }
+  };
+
+  for (const middleware of app.middleware) {
+    let nextCalled = false;
+    middleware(request, response, () => {
+      nextCalled = true;
+    });
+    if (!nextCalled || bodyText) {
+      break;
+    }
+  }
+  if (bodyText) {
+    return {
+      statusCode: response.statusCode,
+      body: bodyText ? JSON.parse(bodyText) : null
+    };
+  }
+
+  await handler(request, response);
+  return {
+    statusCode: response.statusCode,
+    body: bodyText ? JSON.parse(bodyText) : null
+  };
+}
+
+test("issue 1373: mission detail route reflects acknowledged dialogue lines", async (t) => {
+  const store = new MemoryRoomSnapshotStore();
+  const app = createRouteRegistryApp();
+  registerPlayerAccountRoutes(app as never, store);
+  await store.ensurePlayerAccount({
+    playerId: "campaign-dialogue-player",
+    displayName: "Dialogue Scout"
+  });
+  await store.savePlayerAccountProgress("campaign-dialogue-player", {
+    campaignProgress: {
+      missions: [
+        {
+          missionId: "chapter1-ember-watch",
+          attempts: 0,
+          acknowledgedDialogueLineIds: ["c1m1-intro-1"]
+        }
+      ]
+    }
+  });
+  const session = issueAccountAuthSession({
+    playerId: "campaign-dialogue-player",
+    displayName: "Dialogue Scout",
+    loginId: "campaign-dialogue-player"
+  });
+
+  t.after(() => {
+    resetLobbyRoomRegistry();
+  });
+
+  const response = await invokeRoute(app, "GET /api/campaigns/missions/:id", {
+    method: "GET",
+    url: "/api/campaigns/missions/chapter1-ember-watch",
+    headers: {
+      authorization: `Bearer ${session.token}`
+    },
+    params: {
+      id: "chapter1-ember-watch"
+    }
+  });
+  const payload = response.body as {
+    mission: {
+      id: string;
+      acknowledgedDialogueLineIds?: string[];
+    };
+  };
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.mission.id, "chapter1-ember-watch");
+  assert.deepEqual(payload.mission.acknowledgedDialogueLineIds, ["c1m1-intro-1"]);
+});
+
+test("issue 1373: websocket handlers persist dialogue acks idempotently and tutorial progress in order", async (t) => {
+  resetLobbyRoomRegistry();
+  resetAnalyticsRuntimeDependencies();
+  const analyticsLogs: string[] = [];
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  configureAnalyticsRuntimeDependencies({
+    log: (message) => {
+      analyticsLogs.push(message);
+    }
+  });
+
+  const room = await createTestRoom(`issue-1373-${Date.now()}`);
+  const client = createFakeClient("issue-1373-session");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetAnalyticsRuntimeDependencies();
+    resetRoomRuntimeDependencies();
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, client, "player-1", "connect-issue-1373");
+  client.sent.length = 0;
+
+  await emitRoomMessage(room, "campaign.dialogue.ack", client, {
+    type: "campaign.dialogue.ack",
+    requestId: "ack-1",
+    action: {
+      missionId: "chapter1-ember-watch",
+      sequence: "intro",
+      dialogueLineId: "c1m1-intro-1"
+    }
+  });
+  await emitRoomMessage(room, "campaign.dialogue.ack", client, {
+    type: "campaign.dialogue.ack",
+    requestId: "ack-2",
+    action: {
+      missionId: "chapter1-ember-watch",
+      sequence: "intro",
+      dialogueLineId: "c1m1-intro-1"
+    }
+  });
+
+  const acknowledgedMission = (await store.loadPlayerAccount("player-1"))?.campaignProgress?.missions.find(
+    (mission) => mission.missionId === "chapter1-ember-watch"
+  );
+  assert.deepEqual(acknowledgedMission?.acknowledgedDialogueLineIds, ["c1m1-intro-1"]);
+
+  await emitRoomMessage(room, "tutorial.progress", client, {
+    type: "tutorial.progress",
+    requestId: "tutorial-out-of-order",
+    action: {
+      step: 3,
+      reason: "advance"
+    }
+  });
+  assert.equal(client.sent.findLast((message) => message.type === "error")?.reason, "tutorial_progress_out_of_order");
+
+  await emitRoomMessage(room, "tutorial.progress", client, {
+    type: "tutorial.progress",
+    requestId: "tutorial-step-2",
+    action: {
+      step: 2,
+      reason: "advance"
+    }
+  });
+  await emitRoomMessage(room, "tutorial.progress", client, {
+    type: "tutorial.progress",
+    requestId: "tutorial-step-3",
+    action: {
+      step: 3,
+      reason: "advance"
+    }
+  });
+  await emitRoomMessage(room, "tutorial.progress", client, {
+    type: "tutorial.progress",
+    requestId: "tutorial-complete",
+    action: {
+      step: null,
+      reason: "complete"
+    }
+  });
+  await flushAnalyticsEventsForTest({ ANALYTICS_SINK: "stdout" });
+
+  const account = await store.loadPlayerAccount("player-1");
+  assert.equal(account?.tutorialStep ?? null, null);
+
+  const tutorialEvents = analyticsLogs
+    .filter((entry) => entry.startsWith("[Analytics] {"))
+    .map((entry) => JSON.parse(entry.slice("[Analytics] ".length)) as {
+      events: Array<{ name: string; payload: { stepId?: string; reason?: string } }>;
+    })
+    .flatMap((entry) => entry.events)
+    .filter((event) => event.name === "tutorial_step");
+
+  assert.deepEqual(
+    tutorialEvents.map((event) => event.payload.stepId),
+    ["step_2", "step_3", "tutorial_completed"]
+  );
+  assert.deepEqual(
+    tutorialEvents.map((event) => event.payload.reason),
+    ["advance", "advance", "complete"]
+  );
+});

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -119,7 +119,8 @@ export const ANALYTICS_EVENT_CATALOG = {
   }),
   tutorial_step: defineAnalyticsEvent("tutorial_step", 1, "Tutorial milestone advanced by the player.", {
     stepId: "movement_intro",
-    status: "completed"
+    status: "completed",
+    reason: "advance"
   }),
   experiment_exposure: defineAnalyticsEvent("experiment_exposure", 1, "Experiment assignment was exposed to a player in a product surface.", {
     experimentKey: "account_portal_copy",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -1390,6 +1390,7 @@ export interface CampaignMissionProgress {
   missionId: string;
   attempts: number;
   completedAt?: string;
+  acknowledgedDialogueLineIds?: string[];
 }
 
 export interface CampaignProgressState {

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -637,6 +637,17 @@ function normalizeCampaignProgressState(
             {
               missionId,
               attempts: Math.max(0, Math.floor(mission.attempts ?? 0)),
+              ...(Array.isArray(mission.acknowledgedDialogueLineIds)
+                ? {
+                    acknowledgedDialogueLineIds: Array.from(
+                      new Set(
+                        mission.acknowledgedDialogueLineIds
+                          .map((lineId) => lineId?.trim())
+                          .filter((lineId): lineId is string => Boolean(lineId))
+                      )
+                    ).sort((left, right) => left.localeCompare(right))
+                  }
+                : {}),
               ...(normalizeTimestamp(mission.completedAt) ? { completedAt: normalizeTimestamp(mission.completedAt) } : {})
             }
           ] as const;


### PR DESCRIPTION
## Summary
- add WebSocket handlers for  and 
- persist acknowledged campaign dialogue lines and ordered tutorial progression
- add focused regression coverage for the new handlers and mission detail route

Closes #1373