### PR TITLE
Add battle replay retention policy

### DIFF
--- a/apps/server/src/battle-replay-retention.ts
+++ b/apps/server/src/battle-replay-retention.ts
@@ -1,0 +1,127 @@
+import {
+  normalizePlayerBattleReplaySummaries,
+  type PlayerBattleReplaySummary
+} from "../../../packages/shared/src/index";
+
+export const DEFAULT_BATTLE_REPLAY_TTL_DAYS = 90;
+export const DEFAULT_BATTLE_REPLAY_MAX_BYTES = 512 * 1024;
+export const DEFAULT_BATTLE_REPLAY_CLEANUP_INTERVAL_MINUTES = 24 * 60;
+export const DEFAULT_BATTLE_REPLAY_CLEANUP_BATCH_SIZE = 100;
+
+export interface BattleReplayRetentionPolicy {
+  ttlDays: number | null;
+  maxBytes: number | null;
+  cleanupIntervalMinutes: number | null;
+  cleanupBatchSize: number;
+}
+
+function readOptionalPositiveNumber(value: string | undefined, fallback: number): number | null {
+  if (value == null || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  if (parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function readPositiveInteger(value: string | undefined, fallback: number): number {
+  if (value == null || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function readBattleReplayRetentionPolicy(env: NodeJS.ProcessEnv = process.env): BattleReplayRetentionPolicy {
+  return {
+    ttlDays: readOptionalPositiveNumber(env.VEIL_BATTLE_REPLAY_TTL_DAYS, DEFAULT_BATTLE_REPLAY_TTL_DAYS),
+    maxBytes: readOptionalPositiveNumber(env.VEIL_BATTLE_REPLAY_MAX_BYTES, DEFAULT_BATTLE_REPLAY_MAX_BYTES),
+    cleanupIntervalMinutes: readOptionalPositiveNumber(
+      env.VEIL_BATTLE_REPLAY_CLEANUP_INTERVAL_MINUTES,
+      DEFAULT_BATTLE_REPLAY_CLEANUP_INTERVAL_MINUTES
+    ),
+    cleanupBatchSize: readPositiveInteger(
+      env.VEIL_BATTLE_REPLAY_CLEANUP_BATCH_SIZE,
+      DEFAULT_BATTLE_REPLAY_CLEANUP_BATCH_SIZE
+    )
+  };
+}
+
+export function calculateBattleReplayExpiry(completedAt: string, ttlDays: number | null): string | undefined {
+  if (ttlDays == null) {
+    return undefined;
+  }
+
+  const completedAtMs = new Date(completedAt).getTime();
+  if (!Number.isFinite(completedAtMs)) {
+    return undefined;
+  }
+
+  return new Date(completedAtMs + ttlDays * 24 * 60 * 60 * 1000).toISOString();
+}
+
+export function measureBattleReplayPayloadBytes(replay: PlayerBattleReplaySummary): number {
+  return Buffer.byteLength(JSON.stringify(replay), "utf8");
+}
+
+export function applyBattleReplayRetentionToSummary(
+  replay: PlayerBattleReplaySummary,
+  policy: BattleReplayRetentionPolicy
+): PlayerBattleReplaySummary | null {
+  const expiresAt = replay.expiresAt ?? calculateBattleReplayExpiry(replay.completedAt, policy.ttlDays);
+  const retainedReplay = expiresAt ? { ...replay, expiresAt } : replay;
+
+  if (policy.maxBytes != null && measureBattleReplayPayloadBytes(retainedReplay) > policy.maxBytes) {
+    return null;
+  }
+
+  return retainedReplay;
+}
+
+export function prunePlayerBattleReplaysForRetention(
+  replays: Partial<PlayerBattleReplaySummary>[] | null | undefined,
+  policy: BattleReplayRetentionPolicy,
+  referenceTime = new Date()
+): { replays: PlayerBattleReplaySummary[]; removedCount: number; updatedCount: number } {
+  const normalizedReplays = normalizePlayerBattleReplaySummaries(replays);
+  const referenceTimeMs = referenceTime.getTime();
+  let removedCount = 0;
+  let updatedCount = 0;
+
+  const retainedReplays = normalizedReplays.flatMap((replay) => {
+    const expiresAt = replay.expiresAt ?? calculateBattleReplayExpiry(replay.completedAt, policy.ttlDays);
+    if (expiresAt) {
+      const expiresAtMs = new Date(expiresAt).getTime();
+      if (Number.isFinite(expiresAtMs) && expiresAtMs <= referenceTimeMs) {
+        removedCount += 1;
+        return [];
+      }
+    }
+
+    if (expiresAt && replay.expiresAt !== expiresAt) {
+      updatedCount += 1;
+      return [{ ...replay, expiresAt }];
+    }
+
+    return [replay];
+  });
+
+  return {
+    replays: retainedReplays,
+    removedCount,
+    updatedCount
+  };
+}

--- a/apps/server/src/battle-replays.ts
+++ b/apps/server/src/battle-replays.ts
@@ -10,6 +10,10 @@ import {
   type PlayerBattleReplaySummary
 } from "../../../packages/shared/src/index";
 import type { PlayerAccountSnapshot } from "./persistence";
+import {
+  applyBattleReplayRetentionToSummary,
+  readBattleReplayRetentionPolicy
+} from "./battle-replay-retention";
 
 const RECENT_BATTLE_REPLAY_LIMIT = 5;
 
@@ -99,23 +103,26 @@ export function buildPlayerBattleReplaySummary(
   heroId: string,
   playerCamp: BattleReplayCamp,
   opponentHeroId?: string
-): PlayerBattleReplaySummary {
-  return {
-    id: buildPlayerReplayId(replay, playerId),
-    roomId: replay.roomId,
-    playerId,
-    battleId: replay.battleId,
-    battleKind: battleKindOf(replay.battleState),
-    playerCamp,
-    heroId,
-    ...(opponentHeroId ? { opponentHeroId } : {}),
-    ...(replay.battleState.neutralArmyId ? { neutralArmyId: replay.battleState.neutralArmyId } : {}),
-    startedAt: replay.startedAt,
-    completedAt: replay.completedAt,
-    initialState: replay.initialState,
-    steps: replay.steps,
-    result: replay.result
-  };
+): PlayerBattleReplaySummary | null {
+  return applyBattleReplayRetentionToSummary(
+    {
+      id: buildPlayerReplayId(replay, playerId),
+      roomId: replay.roomId,
+      playerId,
+      battleId: replay.battleId,
+      battleKind: battleKindOf(replay.battleState),
+      playerCamp,
+      heroId,
+      ...(opponentHeroId ? { opponentHeroId } : {}),
+      ...(replay.battleState.neutralArmyId ? { neutralArmyId: replay.battleState.neutralArmyId } : {}),
+      startedAt: replay.startedAt,
+      completedAt: replay.completedAt,
+      initialState: replay.initialState,
+      steps: replay.steps,
+      result: replay.result
+    },
+    readBattleReplayRetentionPolicy()
+  );
 }
 
 export function buildPlayerBattleReplaySummariesForPlayer(
@@ -123,27 +130,25 @@ export function buildPlayerBattleReplaySummariesForPlayer(
   playerId: string
 ): PlayerBattleReplaySummary[] {
   if (replay.attackerPlayerId === playerId && replay.battleState.worldHeroId) {
-    return [
-      buildPlayerBattleReplaySummary(
-        replay,
-        playerId,
-        replay.battleState.worldHeroId,
-        "attacker",
-        replay.battleState.defenderHeroId
-      )
-    ];
+    const summary = buildPlayerBattleReplaySummary(
+      replay,
+      playerId,
+      replay.battleState.worldHeroId,
+      "attacker",
+      replay.battleState.defenderHeroId
+    );
+    return summary ? [summary] : [];
   }
 
   if (replay.defenderPlayerId === playerId && replay.battleState.defenderHeroId) {
-    return [
-      buildPlayerBattleReplaySummary(
-        replay,
-        playerId,
-        replay.battleState.defenderHeroId,
-        "defender",
-        replay.battleState.worldHeroId
-      )
-    ];
+    const summary = buildPlayerBattleReplaySummary(
+      replay,
+      playerId,
+      replay.battleState.defenderHeroId,
+      "defender",
+      replay.battleState.worldHeroId
+    );
+    return summary ? [summary] : [];
   }
 
   return [];

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -41,6 +41,7 @@ import { registerShopRoutes } from "./shop";
 import { registerWechatPayRoutes } from "./wechat-pay";
 import { captureServerError, isErrorMonitoringEnabled } from "./error-monitoring";
 import { recordRuntimeErrorEvent } from "./observability";
+import { readBattleReplayRetentionPolicy, type BattleReplayRetentionPolicy } from "./battle-replay-retention";
 
 loadEnv();
 
@@ -99,6 +100,7 @@ interface DevServerRoomSnapshotStore {
 
 interface DevServerMySqlSnapshotStore extends DevServerRoomSnapshotStore {
   pruneExpired(): Promise<number>;
+  pruneExpiredBattleReplays(): Promise<number>;
   getRetentionPolicy(): SnapshotRetentionPolicy;
 }
 
@@ -147,6 +149,7 @@ export interface DevServerBootstrapDependencies {
   createGameServer(transport: DevServerTransport, realtimeOptions?: DevServerRealtimeOptions): DevServerGameServer;
   logger: DevServerLogger;
   process: DevServerProcess;
+  readBattleReplayRetentionPolicy(): BattleReplayRetentionPolicy;
   setInterval(handler: () => void, delayMs: number): CleanupTimerHandle;
   clearInterval(timer: CleanupTimerHandle): void;
   isMySqlSnapshotStore(store: DevServerRoomSnapshotStore): store is DevServerMySqlSnapshotStore;
@@ -233,6 +236,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
       }),
     logger: console,
     process,
+    readBattleReplayRetentionPolicy,
     setInterval: (handler, delayMs) => setInterval(handler, delayMs),
     clearInterval: (timer) => clearInterval(timer as NodeJS.Timeout),
     isMySqlSnapshotStore: (store): store is DevServerMySqlSnapshotStore => store instanceof MySqlRoomSnapshotStore
@@ -291,7 +295,7 @@ export async function startDevServer(
       );
     }
 
-    if (migrationStatus?.pending.length > 0) {
+    if ((migrationStatus?.pending.length ?? 0) > 0 && migrationStatus) {
       const warning = deps.formatSchemaMigrationWarning(migrationStatus);
       if (isProductionEnvironment) {
         await failStartup("Schema migrations are pending during production startup", new Error(warning));
@@ -420,36 +424,61 @@ export async function startDevServer(
     deps.logger.log("Error monitoring: SENTRY_DSN not configured; external delivery skipped");
   }
 
-  let cleanupTimer: CleanupTimerHandle | null = null;
+  let snapshotCleanupTimer: CleanupTimerHandle | null = null;
+  let battleReplayCleanupTimer: CleanupTimerHandle | null = null;
   if (deps.isMySqlSnapshotStore(effectiveSnapshotStore)) {
     const retention = effectiveSnapshotStore.getRetentionPolicy();
+    const battleReplayRetention = deps.readBattleReplayRetentionPolicy();
     deps.logger.log(
       `Snapshot retention: ttl=${retention.ttlHours == null ? "disabled" : `${retention.ttlHours}h`} / cleanup=${retention.cleanupIntervalMinutes == null ? "disabled" : `${retention.cleanupIntervalMinutes}m`}`
     );
+    deps.logger.log(
+      `Battle replay retention: ttl=${battleReplayRetention.ttlDays == null ? "disabled" : `${battleReplayRetention.ttlDays}d`} / max=${battleReplayRetention.maxBytes == null ? "disabled" : `${battleReplayRetention.maxBytes}B`} / cleanup=${battleReplayRetention.cleanupIntervalMinutes == null ? "disabled" : `${battleReplayRetention.cleanupIntervalMinutes}m`} / batch=${battleReplayRetention.cleanupBatchSize}`
+    );
 
-    const runCleanup = async (): Promise<void> => {
+    const runSnapshotCleanup = async (): Promise<void> => {
       const removed = await effectiveSnapshotStore.pruneExpired();
       if (removed > 0) {
         deps.logger.log(`Pruned ${removed} expired room snapshot(s)`);
       }
     };
 
-    await runCleanup();
+    const runBattleReplayCleanup = async (): Promise<void> => {
+      const removed = await effectiveSnapshotStore.pruneExpiredBattleReplays();
+      if (removed > 0) {
+        deps.logger.log(`Pruned ${removed} expired battle replay(s)`);
+      }
+    };
+
+    await Promise.all([runSnapshotCleanup(), runBattleReplayCleanup()]);
 
     if (retention.cleanupIntervalMinutes != null) {
-      cleanupTimer = deps.setInterval(() => {
-        void runCleanup().catch((error) => {
+      snapshotCleanupTimer = deps.setInterval(() => {
+        void runSnapshotCleanup().catch((error) => {
           deps.logger.error("Failed to prune expired room snapshots", error);
         });
       }, retention.cleanupIntervalMinutes * 60 * 1000);
-      cleanupTimer.unref?.();
+      snapshotCleanupTimer.unref?.();
+    }
+
+    if (battleReplayRetention.cleanupIntervalMinutes != null) {
+      battleReplayCleanupTimer = deps.setInterval(() => {
+        void runBattleReplayCleanup().catch((error) => {
+          deps.logger.error("Failed to prune expired battle replays", error);
+        });
+      }, battleReplayRetention.cleanupIntervalMinutes * 60 * 1000);
+      battleReplayCleanupTimer.unref?.();
     }
   }
 
   const closeStore = async (): Promise<void> => {
-    if (cleanupTimer) {
-      deps.clearInterval(cleanupTimer);
-      cleanupTimer = null;
+    if (snapshotCleanupTimer) {
+      deps.clearInterval(snapshotCleanupTimer);
+      snapshotCleanupTimer = null;
+    }
+    if (battleReplayCleanupTimer) {
+      deps.clearInterval(battleReplayCleanupTimer);
+      battleReplayCleanupTimer = null;
     }
 
     if (!snapshotStore) {

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -80,6 +80,10 @@ import {
 import { applySeasonSoftDecay, decayDivisionToRating, resolveCompetitiveProgression } from "./competitive-season";
 import { readRuntimeSecret } from "./runtime-secrets";
 import { computeSeasonReward, resolveSeasonRewardConfig } from "./season-rewards";
+import {
+  prunePlayerBattleReplaysForRetention,
+  readBattleReplayRetentionPolicy
+} from "./battle-replay-retention";
 
 export interface SeasonSnapshot {
   seasonId: string;
@@ -8879,6 +8883,42 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
              version = version + 1
          WHERE player_id = ?`,
         [JSON.stringify(pruned.mailbox), row.player_id]
+      );
+    }
+
+    return removedCount;
+  }
+
+  async pruneExpiredBattleReplays(referenceTime = new Date()): Promise<number> {
+    const replayRetention = readBattleReplayRetentionPolicy();
+    if (replayRetention.ttlDays == null) {
+      return 0;
+    }
+
+    const [rows] = await this.pool.query<Array<RowDataPacket & { player_id: string; recent_battle_replays_json: string | null }>>(
+      `SELECT player_id, recent_battle_replays_json
+       FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+       WHERE recent_battle_replays_json IS NOT NULL
+       LIMIT ?`,
+      [replayRetention.cleanupBatchSize]
+    );
+
+    let removedCount = 0;
+    for (const row of rows) {
+      const replayJson = row.recent_battle_replays_json;
+      const existingReplays = replayJson ? parseJsonColumn<PlayerBattleReplaySummary[]>(replayJson) : [];
+      const pruned = prunePlayerBattleReplaysForRetention(existingReplays, replayRetention, referenceTime);
+      if (pruned.removedCount === 0 && pruned.updatedCount === 0) {
+        continue;
+      }
+
+      removedCount += pruned.removedCount;
+      await this.pool.query(
+        `UPDATE \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         SET recent_battle_replays_json = ?,
+             version = version + 1
+         WHERE player_id = ?`,
+        [JSON.stringify(pruned.replays), row.player_id]
       );
     }
 

--- a/apps/server/test/battle-replay-retention.test.ts
+++ b/apps/server/test/battle-replay-retention.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  calculateBattleReplayExpiry,
+  prunePlayerBattleReplaysForRetention,
+  readBattleReplayRetentionPolicy
+} from "../src/battle-replay-retention";
+import type { PlayerBattleReplaySummary } from "../../../packages/shared/src/index";
+
+function createReplay(overrides: Partial<PlayerBattleReplaySummary> = {}): PlayerBattleReplaySummary {
+  return {
+    id: "replay-1",
+    roomId: "room-1",
+    playerId: "player-1",
+    battleId: "battle-1",
+    battleKind: "neutral",
+    playerCamp: "attacker",
+    heroId: "hero-1",
+    startedAt: "2026-03-01T00:00:00.000Z",
+    completedAt: "2026-03-01T00:05:00.000Z",
+    initialState: {
+      id: "battle-1",
+      round: 1,
+      lanes: 3,
+      activeUnitId: null,
+      turnOrder: [],
+      units: {},
+      unitCooldowns: {},
+      environment: [],
+      log: [],
+      rng: { seed: 1, cursor: 0 }
+    },
+    steps: [],
+    result: "attacker_victory",
+    ...overrides
+  };
+}
+
+test("battle replay retention config uses defaults and allows disabling ttl, max bytes, and cleanup", () => {
+  const defaultPolicy = readBattleReplayRetentionPolicy({});
+  assert.equal(defaultPolicy.ttlDays, 90);
+  assert.equal(defaultPolicy.maxBytes, 512 * 1024);
+  assert.equal(defaultPolicy.cleanupIntervalMinutes, 24 * 60);
+  assert.equal(defaultPolicy.cleanupBatchSize, 100);
+
+  const disabledPolicy = readBattleReplayRetentionPolicy({
+    VEIL_BATTLE_REPLAY_TTL_DAYS: "0",
+    VEIL_BATTLE_REPLAY_MAX_BYTES: "-1",
+    VEIL_BATTLE_REPLAY_CLEANUP_INTERVAL_MINUTES: "0",
+    VEIL_BATTLE_REPLAY_CLEANUP_BATCH_SIZE: "25"
+  });
+  assert.equal(disabledPolicy.ttlDays, null);
+  assert.equal(disabledPolicy.maxBytes, null);
+  assert.equal(disabledPolicy.cleanupIntervalMinutes, null);
+  assert.equal(disabledPolicy.cleanupBatchSize, 25);
+});
+
+test("calculateBattleReplayExpiry returns an ISO timestamp at the ttl boundary", () => {
+  assert.equal(
+    calculateBattleReplayExpiry("2026-03-01T00:05:00.000Z", 90),
+    "2026-05-30T00:05:00.000Z"
+  );
+  assert.equal(calculateBattleReplayExpiry("2026-03-01T00:05:00.000Z", null), undefined);
+});
+
+test("battle replay retention pruning drops expired entries and backfills expiresAt for retained rows", () => {
+  const policy = readBattleReplayRetentionPolicy({
+    VEIL_BATTLE_REPLAY_TTL_DAYS: "90",
+    VEIL_BATTLE_REPLAY_CLEANUP_BATCH_SIZE: "10"
+  });
+
+  const pruned = prunePlayerBattleReplaysForRetention(
+    [
+      createReplay({
+        id: "expired",
+        completedAt: "2025-11-01T00:05:00.000Z"
+      }),
+      createReplay({
+        id: "retained",
+        completedAt: "2026-03-01T00:05:00.000Z"
+      }),
+      createReplay({
+        id: "explicit-expiry",
+        expiresAt: "2026-03-15T00:00:00.000Z"
+      })
+    ],
+    policy,
+    new Date("2026-04-01T00:00:00.000Z")
+  );
+
+  assert.equal(pruned.removedCount, 1);
+  assert.equal(pruned.updatedCount, 1);
+  assert.deepEqual(pruned.replays.map((replay) => replay.id), ["retained"]);
+  assert.equal(pruned.replays[0]?.expiresAt, "2026-05-30T00:05:00.000Z");
+});

--- a/apps/server/test/battle-replays.test.ts
+++ b/apps/server/test/battle-replays.test.ts
@@ -104,6 +104,7 @@ test("battle replay capture creates a stable player replay record from settlemen
       neutralArmyId: "neutral-1",
       startedAt: "2026-03-29T12:00:00.000Z",
       completedAt: "2026-03-29T12:01:00.000Z",
+      expiresAt: "2026-06-27T12:01:00.000Z",
       initialState: completed.initialState,
       steps: completed.steps,
       result: "attacker_victory"
@@ -167,6 +168,7 @@ test("battle replay emitted summaries stay compatible with normalized replay pay
     opponentHeroId: "hero-1",
     startedAt: "2026-03-29T13:00:00.000Z",
     completedAt: "2026-03-29T13:02:00.000Z",
+    expiresAt: "2026-06-27T13:02:00.000Z",
     initialState: completed.initialState,
     steps: [
       {
@@ -256,6 +258,51 @@ test("battle replay capture records sequential immutable steps for each action a
       unitId: "hero-stack"
     }
   });
+});
+
+test("battle replay summary rejects payloads larger than the configured byte budget", () => {
+  const previousMaxBytes = process.env.VEIL_BATTLE_REPLAY_MAX_BYTES;
+  process.env.VEIL_BATTLE_REPLAY_MAX_BYTES = "200";
+
+  try {
+    const completed = finalizeBattleReplayCapture(
+      appendBattleReplayStep(
+        createBattleReplayCapture(
+          "room-large-272",
+          createBattleState({
+            id: "battle-large-272",
+            worldHeroId: "hero-1"
+          }),
+          { attackerPlayerId: "player-1" },
+          "2026-03-29T13:00:00.000Z"
+        ),
+        {
+          type: "battle.wait",
+          unitId: "hero-stack-".repeat(32)
+        },
+        "player"
+      ),
+      createBattleState({
+        id: "battle-large-272",
+        worldHeroId: "hero-1"
+      }),
+      {
+        status: "attacker_victory",
+        survivingAttackers: ["hero-1-stack"],
+        survivingDefenders: []
+      },
+      "2026-03-29T13:02:00.000Z"
+    );
+
+    assert.ok(completed);
+    assert.equal(buildPlayerBattleReplaySummary(completed, "player-1", "hero-1", "attacker"), null);
+  } finally {
+    if (previousMaxBytes === undefined) {
+      delete process.env.VEIL_BATTLE_REPLAY_MAX_BYTES;
+    } else {
+      process.env.VEIL_BATTLE_REPLAY_MAX_BYTES = previousMaxBytes;
+    }
+  }
 });
 
 test("battle replay capture preserves structured rejections for invalid appended actions", () => {

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -91,16 +91,25 @@ function createMemoryStore() {
   };
 }
 
-function createMySqlStore(retention: SnapshotRetentionPolicy, pruneImpl: () => Promise<number>) {
+function createMySqlStore(
+  retention: SnapshotRetentionPolicy,
+  pruneImpl: () => Promise<number>,
+  pruneBattleReplaysImpl: () => Promise<number> = async () => 0
+) {
   return {
     closeCalls: 0,
     pruneCalls: 0,
+    pruneBattleReplayCalls: 0,
     async close() {
       this.closeCalls += 1;
     },
     async pruneExpired() {
       this.pruneCalls += 1;
       return pruneImpl();
+    },
+    async pruneExpiredBattleReplays() {
+      this.pruneBattleReplayCalls += 1;
+      return pruneBattleReplaysImpl();
     },
     getRetentionPolicy() {
       return retention;
@@ -953,6 +962,8 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
   };
   let pruneAttempt = 0;
   const pruneFailure = new Error("cleanup failed");
+  let pruneBattleReplayAttempt = 0;
+  const pruneBattleReplayFailure = new Error("battle replay cleanup failed");
   const mysqlStore = createMySqlStore(retention, async () => {
     pruneAttempt += 1;
     if (pruneAttempt === 1) {
@@ -960,6 +971,13 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     }
 
     throw pruneFailure;
+  }, async () => {
+    pruneBattleReplayAttempt += 1;
+    if (pruneBattleReplayAttempt === 1) {
+      return 3;
+    }
+
+    throw pruneBattleReplayFailure;
   });
   const mysqlConfig: MySqlPersistenceConfig = {
     host: "127.0.0.1",
@@ -1028,6 +1046,12 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     },
     logger: base.logger,
     process: base.process,
+    readBattleReplayRetentionPolicy: () => ({
+      ttlDays: 90,
+      maxBytes: 512 * 1024,
+      cleanupIntervalMinutes: 60,
+      cleanupBatchSize: 25
+    }),
     setInterval: (callback, delayMs) => {
       const timer: TestTimer = {
         callback,
@@ -1049,6 +1073,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
   assert.equal(memoryStoreCreated, false);
   assert.equal(configCenterStore.initializeCalls, 1);
   assert.equal(mysqlStore.pruneCalls, 1);
+  assert.equal(mysqlStore.pruneBattleReplayCalls, 1);
   assert.equal(base.logger.warnings.length, 0);
   assert.deepEqual(persistenceHealth, {
     status: "ok",
@@ -1065,20 +1090,30 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
     /Local in-memory Colyseus presence\/driver enabled/,
     /Persistence mode: production\/mysql/,
     /Snapshot retention: ttl=48h \/ cleanup=15m/,
-    /Pruned 2 expired room snapshot\(s\)/
+    /Battle replay retention: ttl=90d \/ max=524288B \/ cleanup=60m \/ batch=25/,
+    /Pruned 2 expired room snapshot\(s\)/,
+    /Pruned 3 expired battle replay\(s\)/
   ]);
-  assert.equal(scheduledTimers.length, 1);
+  assert.equal(scheduledTimers.length, 2);
   assert.equal(scheduledTimers[0]?.delayMs, 15 * 60 * 1000);
   assert.equal(scheduledTimers[0]?.unrefCalls, 1);
+  assert.equal(scheduledTimers[1]?.delayMs, 60 * 60 * 1000);
+  assert.equal(scheduledTimers[1]?.unrefCalls, 1);
 
   scheduledTimers[0]?.callback();
+  scheduledTimers[1]?.callback();
   await flushAsyncWork();
 
   assert.equal(mysqlStore.pruneCalls, 2);
+  assert.equal(mysqlStore.pruneBattleReplayCalls, 2);
   assert.deepEqual(base.logger.errors, [
     {
       message: "Failed to prune expired room snapshots",
       error: pruneFailure
+    },
+    {
+      message: "Failed to prune expired battle replays",
+      error: pruneBattleReplayFailure
     }
   ]);
 
@@ -1087,7 +1122,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
 
   assert.equal(mysqlStore.closeCalls, 1);
   assert.equal(configCenterStore.closeCalls, 1);
-  assert.deepEqual(clearedTimers, [scheduledTimers[0]]);
+  assert.deepEqual(clearedTimers, [scheduledTimers[0], scheduledTimers[1]]);
   assert.deepEqual(base.process.exitCodes, [0]);
 });
 

--- a/apps/server/test/room-persistence.test.ts
+++ b/apps/server/test/room-persistence.test.ts
@@ -268,6 +268,8 @@ test("player battle replay summaries preserve the global battle result for both 
   const attackerReplay = buildPlayerBattleReplaySummary(replay, "player-1", "hero-1", "attacker", "hero-2");
   const defenderReplay = buildPlayerBattleReplaySummary(replay, "player-2", "hero-2", "defender", "hero-1");
 
+  assert.ok(attackerReplay);
+  assert.ok(defenderReplay);
   assert.equal(attackerReplay.result, "attacker_victory");
   assert.equal(defenderReplay.result, "attacker_victory");
 });

--- a/docs/retention-ops-runbook.md
+++ b/docs/retention-ops-runbook.md
@@ -2,7 +2,7 @@
 
 Issue #1200 starts the retention surface with a narrow server-side slice: daily first-login rewards are now issued automatically on successful login, streak state is persisted on the player account, and every successful issuance emits a versioned `daily_login` analytics event.
 
-This runbook only covers the implemented slice. WeChat push, offline-reward summaries, and D1/D7 dashboard material are still out of scope for this change and need follow-up work before they should be promised as live.
+This runbook only covers the implemented slices. WeChat push, offline-reward summaries, and D1/D7 dashboard material are still out of scope for this change and need follow-up work before they should be promised as live.
 
 ## Current Scope
 
@@ -45,3 +45,36 @@ This runbook only covers the implemented slice. WeChat push, offline-reward summ
 - To reduce exposure immediately, point clients back to the existing manual claim flow operationally and avoid depending on the auth response field.
 - To change values without code rollout, update [`configs/daily-rewards.json`](/home/gpt/project/ProjectVeil/configs/daily-rewards.json).
 - If the reward logic itself is faulty, revert the server change rather than mutating player data manually without an audit trail.
+
+## Battle Replay Retention
+
+Issue `#1376` adds a second retention slice for battle replay payloads stored in `player_accounts.recent_battle_replays_json`.
+
+### Current Scope
+
+- New replay writes are rejected when the serialized replay JSON exceeds `VEIL_BATTLE_REPLAY_MAX_BYTES` (default `524288`, or `512 KB`).
+- New replay writes receive `expiresAt` based on `VEIL_BATTLE_REPLAY_TTL_DAYS` (default `90`).
+- MySQL-backed server startup runs replay cleanup immediately, then repeats on `VEIL_BATTLE_REPLAY_CLEANUP_INTERVAL_MINUTES` (default `1440`, or every 24 hours).
+- Each cleanup pass scans up to `VEIL_BATTLE_REPLAY_CLEANUP_BATCH_SIZE` account rows (default `100`) and removes expired replay entries from the embedded JSON array.
+- Cleanup activity is emitted to the server log as `Pruned N expired battle replay(s)`.
+
+### Operator Checks
+
+- Confirm startup logs include a line shaped like `Battle replay retention: ttl=90d / max=524288B / cleanup=1440m / batch=100`.
+- Confirm cleanup logs periodically emit `Pruned N expired battle replay(s)` when stale data exists.
+- When debugging an account-specific replay issue, inspect the stored `recent_battle_replays_json` payload and verify every retained replay has an `expiresAt` within the configured TTL window.
+
+### Table Sizing Guidance
+
+- Estimate replay footprint from the serialized JSON payload, not from replay count alone.
+- A safe starting alert threshold is `player_accounts.recent_battle_replays_json` averaging above `256 KB` per active player row or any single replay approaching the `512 KB` write cap, because that usually means battle steps are expanding faster than the retention window can offset.
+- If table growth remains high after cleanup is working, lower `VEIL_BATTLE_REPLAY_TTL_DAYS` first before raising the write cap.
+
+### Triage Notes
+
+- Replay missing immediately after battle:
+  Check whether the payload exceeded `VEIL_BATTLE_REPLAY_MAX_BYTES`; oversized replays are intentionally skipped instead of persisted.
+- Old replay still visible:
+  Confirm the replay has an `expiresAt` value, then check whether the server is running with MySQL persistence and whether the cleanup interval is enabled.
+- Cleanup logs missing:
+  Verify `VEIL_BATTLE_REPLAY_CLEANUP_INTERVAL_MINUTES` is positive and the process has completed at least one startup cycle since the config change.

--- a/packages/shared/src/battle-replay.ts
+++ b/packages/shared/src/battle-replay.ts
@@ -27,6 +27,7 @@ export interface PlayerBattleReplaySummary {
   neutralArmyId?: string;
   startedAt: string;
   completedAt: string;
+  expiresAt?: string;
   initialState: BattleState;
   steps: BattleReplayStep[];
   result: BattleReplayResult;
@@ -425,6 +426,7 @@ function normalizeBattleReplayStep(step: Partial<BattleReplayStep> | null | unde
 export function normalizePlayerBattleReplaySummaries(
   replays?: Partial<PlayerBattleReplaySummary>[] | null
 ): PlayerBattleReplaySummary[] {
+  const now = Date.now();
   return (replays ?? [])
     .map((replay) => {
       const id = replay?.id?.trim();
@@ -434,6 +436,7 @@ export function normalizePlayerBattleReplaySummaries(
       const heroId = replay?.heroId?.trim();
       const startedAt = normalizeTimestamp(replay?.startedAt);
       const completedAt = normalizeTimestamp(replay?.completedAt);
+      const expiresAt = normalizeTimestamp(replay?.expiresAt);
       const initialState = replay?.initialState;
       if (
         !id ||
@@ -468,12 +471,21 @@ export function normalizePlayerBattleReplaySummaries(
         ...(replay.neutralArmyId?.trim() ? { neutralArmyId: replay.neutralArmyId.trim() } : {}),
         startedAt,
         completedAt,
+        ...(expiresAt ? { expiresAt } : {}),
         initialState: cloneBattleState(initialState),
         steps,
         result: replay.result
       };
     })
     .filter((replay): replay is PlayerBattleReplaySummary => Boolean(replay))
+    .filter((replay) => {
+      if (!replay.expiresAt) {
+        return true;
+      }
+
+      const expiresAt = new Date(replay.expiresAt).getTime();
+      return !Number.isFinite(expiresAt) || expiresAt > now;
+    })
     .sort((left, right) => right.completedAt.localeCompare(left.completedAt) || left.id.localeCompare(right.id))
     .filter((replay, index, list) => index === list.findIndex((candidate) => candidate.id === replay.id));
 }

--- a/packages/shared/test/battle-replay.test.ts
+++ b/packages/shared/test/battle-replay.test.ts
@@ -260,6 +260,21 @@ test("normalizePlayerBattleReplaySummaries sorts by completedAt descending", () 
   assert.equal(result[1]?.id, "r-b");
 });
 
+test("normalizePlayerBattleReplaySummaries filters out entries whose expiresAt has passed", () => {
+  const expired = makeReplay({
+    id: "expired",
+    expiresAt: "2024-01-02T00:00:00.000Z"
+  });
+  const retained = makeReplay({
+    id: "retained",
+    expiresAt: "2999-01-01T00:00:00.000Z"
+  });
+
+  const result = normalizePlayerBattleReplaySummaries([expired, retained]);
+  assert.deepEqual(result.map((replay) => replay.id), ["retained"]);
+  assert.equal(result[0]?.expiresAt, "2999-01-01T00:00:00.000Z");
+});
+
 test("normalizePlayerBattleReplaySummaries rejects invalid battleKind", () => {
   const replay = { ...makeReplay(), battleKind: "invalid" } as unknown as PlayerBattleReplaySummary;
   const result = normalizePlayerBattleReplaySummaries([replay]);


### PR DESCRIPTION
## Summary
- add battle replay retention policy config, expiry metadata, and oversized-payload rejection for newly captured replays
- prune expired embedded replay payloads from MySQL-backed player accounts on startup and on a scheduled cleanup loop, with operator log lines
- document replay sizing/cleanup guidance and add replay retention coverage in shared/server tests

## Verification
- node --import tsx --test apps/server/test/battle-replays.test.ts apps/server/test/battle-replay-retention.test.ts apps/server/test/dev-server.test.ts packages/shared/test/battle-replay.test.ts
- npm run typecheck:server
- npm run typecheck:shared

## Notes
- replay storage currently lives inside `player_accounts.recent_battle_replays_json`, so this change stores `expiresAt` inside each replay payload and prunes the embedded array in batches rather than introducing a new replay table.

Closes #1376