### PR TITLE
[codex] Add client error reporting endpoint

### DIFF
--- a/apps/server/src/client-error.ts
+++ b/apps/server/src/client-error.ts
@@ -1,0 +1,392 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { GuestAuthSession } from "./auth";
+import { readGuestAuthTokenFromRequest, validateGuestAuthToken } from "./auth";
+import { captureClientError } from "./error-monitoring";
+import { getRequestCorrelationId } from "./http-request-context";
+import { recordHttpRateLimited, recordRuntimeErrorEvent } from "./observability";
+import type { RoomSnapshotStore } from "./persistence";
+
+const MAX_JSON_BODY_BYTES = 64 * 1024;
+const MAX_PLATFORM_LENGTH = 64;
+const MAX_VERSION_LENGTH = 64;
+const MAX_ERROR_MESSAGE_LENGTH = 2_000;
+const MAX_STACK_LENGTH = 16_000;
+const MAX_CONTEXT_DETAIL_LENGTH = 8_000;
+const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
+const DEFAULT_RATE_LIMIT_PLAYER_MAX = 10;
+const DEFAULT_RATE_LIMIT_IP_MAX = 20;
+
+interface ClientErrorRuntimeConfig {
+  rateLimitWindowMs: number;
+  rateLimitPlayerMax: number;
+  rateLimitIpMax: number;
+}
+
+interface ClientErrorReportPayload {
+  platform: string;
+  version: string;
+  errorMessage: string;
+  stack?: string | undefined;
+  context?: Record<string, unknown> | undefined;
+}
+
+interface RateLimitResult {
+  allowed: boolean;
+  retryAfterSeconds?: number;
+}
+
+interface ClientErrorRouteRuntimeDependencies {
+  now(): number;
+  captureClientError: typeof captureClientError;
+  recordRuntimeErrorEvent: typeof recordRuntimeErrorEvent;
+  recordHttpRateLimited: typeof recordHttpRateLimited;
+}
+
+const defaultClientErrorRouteRuntimeDependencies: ClientErrorRouteRuntimeDependencies = {
+  now: () => Date.now(),
+  captureClientError,
+  recordRuntimeErrorEvent,
+  recordHttpRateLimited
+};
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+class PayloadValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "invalid_client_error_payload";
+  }
+}
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+function parseEnvNumber(
+  value: string | undefined,
+  fallback: number,
+  options: { minimum?: number; integer?: boolean } = {}
+): number {
+  const parsed = Number(value?.trim());
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  const normalized = options.integer ? Math.floor(parsed) : parsed;
+  if (options.minimum != null && normalized < options.minimum) {
+    return fallback;
+  }
+
+  return normalized;
+}
+
+function readClientErrorRuntimeConfig(env: NodeJS.ProcessEnv = process.env): ClientErrorRuntimeConfig {
+  return {
+    rateLimitWindowMs: parseEnvNumber(env.VEIL_RATE_LIMIT_CLIENT_ERROR_WINDOW_MS, DEFAULT_RATE_LIMIT_WINDOW_MS, {
+      minimum: 1,
+      integer: true
+    }),
+    rateLimitPlayerMax: parseEnvNumber(env.VEIL_RATE_LIMIT_CLIENT_ERROR_PLAYER_MAX, DEFAULT_RATE_LIMIT_PLAYER_MAX, {
+      minimum: 1,
+      integer: true
+    }),
+    rateLimitIpMax: parseEnvNumber(env.VEIL_RATE_LIMIT_CLIENT_ERROR_IP_MAX, DEFAULT_RATE_LIMIT_IP_MAX, {
+      minimum: 1,
+      integer: true
+    })
+  };
+}
+
+function readHeaderValue(value: string | string[] | undefined): string | null {
+  return Array.isArray(value) ? value[0]?.trim() || null : value?.trim() || null;
+}
+
+function readHeaderCsvValue(value: string | string[] | undefined): string | null {
+  const headerValue = readHeaderValue(value);
+  return headerValue?.split(",")[0]?.trim() || null;
+}
+
+function resolveRequestIp(request: Pick<IncomingMessage, "headers" | "socket">): string {
+  const forwardedFor = readHeaderCsvValue(request.headers["x-forwarded-for"]);
+  const rawIp = forwardedFor || request.socket.remoteAddress?.trim() || "unknown";
+  return rawIp.startsWith("::ffff:") ? rawIp.slice("::ffff:".length) : rawIp;
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    request.resume();
+    throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+    }
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function normalizeRequiredString(value: unknown, fieldName: string, maxLength: number): string {
+  if (typeof value !== "string") {
+    throw new PayloadValidationError(`${fieldName} must be a string`);
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new PayloadValidationError(`${fieldName} is required`);
+  }
+  if (normalized.length > maxLength) {
+    throw new PayloadValidationError(`${fieldName} exceeds ${maxLength} characters`);
+  }
+
+  return normalized;
+}
+
+function normalizeOptionalString(value: unknown, fieldName: string, maxLength: number): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new PayloadValidationError(`${fieldName} must be a string`);
+  }
+  if (value.length > maxLength) {
+    throw new PayloadValidationError(`${fieldName} exceeds ${maxLength} characters`);
+  }
+  return value;
+}
+
+function normalizeContext(value: unknown): Record<string, unknown> | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new PayloadValidationError("context must be an object");
+  }
+
+  const serialized = JSON.stringify(value);
+  if (serialized.length > MAX_CONTEXT_DETAIL_LENGTH) {
+    throw new PayloadValidationError(`context exceeds ${MAX_CONTEXT_DETAIL_LENGTH} characters`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function normalizeClientErrorPayload(payload: unknown): ClientErrorReportPayload {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new PayloadValidationError("body must be a JSON object");
+  }
+
+  const typedPayload = payload as Record<string, unknown>;
+  const stack = normalizeOptionalString(typedPayload.stack, "stack", MAX_STACK_LENGTH);
+  const context = normalizeContext(typedPayload.context);
+  return {
+    platform: normalizeRequiredString(typedPayload.platform, "platform", MAX_PLATFORM_LENGTH),
+    version: normalizeRequiredString(typedPayload.version, "version", MAX_VERSION_LENGTH),
+    errorMessage: normalizeRequiredString(typedPayload.errorMessage, "errorMessage", MAX_ERROR_MESSAGE_LENGTH),
+    ...(stack != null ? { stack } : {}),
+    ...(context != null ? { context } : {})
+  };
+}
+
+function consumeSlidingWindowRateLimit(
+  counters: Map<string, number[]>,
+  key: string,
+  now: number,
+  config: Pick<ClientErrorRuntimeConfig, "rateLimitWindowMs">,
+  max: number
+): RateLimitResult {
+  const windowStart = now - config.rateLimitWindowMs;
+  const timestamps = (counters.get(key) ?? []).filter((timestamp) => timestamp > windowStart);
+  if (timestamps.length >= max) {
+    counters.set(key, timestamps);
+    const oldestTimestamp = timestamps[0] ?? now;
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((oldestTimestamp + config.rateLimitWindowMs - now) / 1000))
+    };
+  }
+
+  timestamps.push(now);
+  counters.set(key, timestamps);
+  return { allowed: true };
+}
+
+function sendRateLimited(response: ServerResponse, retryAfterSeconds: number): void {
+  response.setHeader("Retry-After", String(retryAfterSeconds));
+  sendJson(response, 429, {
+    error: {
+      code: "rate_limited",
+      message: "Too many client error reports, please retry later"
+    }
+  });
+}
+
+function serializeContextDetail(context: Record<string, unknown> | undefined, authenticated: boolean): string | null {
+  if (!authenticated || !context) {
+    return null;
+  }
+  return JSON.stringify(context);
+}
+
+async function resolveOptionalSession(
+  request: Pick<IncomingMessage, "headers">,
+  store: RoomSnapshotStore | null
+): Promise<GuestAuthSession | null> {
+  const token = readGuestAuthTokenFromRequest(request);
+  if (!token) {
+    return null;
+  }
+
+  const result = await validateGuestAuthToken(token, store);
+  return result.session;
+}
+
+export function registerClientErrorRoutes(
+  app: {
+    use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
+    post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+  },
+  store: RoomSnapshotStore | null,
+  runtimeDependencies: Partial<ClientErrorRouteRuntimeDependencies> = {}
+): void {
+  const deps = {
+    ...defaultClientErrorRouteRuntimeDependencies,
+    ...runtimeDependencies
+  };
+  const ipCounters = new Map<string, number[]>();
+  const playerCounters = new Map<string, number[]>();
+
+  app.use((request, response, next) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth, X-Correlation-Id");
+
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    next();
+  });
+
+  app.post("/api/client-error", async (request, response) => {
+    try {
+      const payload = normalizeClientErrorPayload(await readJsonBody(request));
+      const session = await resolveOptionalSession(request, store);
+      const config = readClientErrorRuntimeConfig();
+      const now = deps.now();
+      const ipAddress = resolveRequestIp(request);
+      const ipLimit = consumeSlidingWindowRateLimit(ipCounters, ipAddress, now, config, config.rateLimitIpMax);
+      if (!ipLimit.allowed) {
+        deps.recordHttpRateLimited();
+        sendRateLimited(response, ipLimit.retryAfterSeconds ?? 1);
+        return;
+      }
+
+      if (session?.playerId) {
+        const playerLimit = consumeSlidingWindowRateLimit(
+          playerCounters,
+          session.playerId,
+          now,
+          config,
+          config.rateLimitPlayerMax
+        );
+        if (!playerLimit.allowed) {
+          deps.recordHttpRateLimited();
+          sendRateLimited(response, playerLimit.retryAfterSeconds ?? 1);
+          return;
+        }
+      }
+
+      const requestId = getRequestCorrelationId(request) ?? null;
+      const authenticated = session != null;
+      const candidateRevision = process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null;
+      deps.recordRuntimeErrorEvent({
+        id: randomUUID(),
+        recordedAt: new Date(now).toISOString(),
+        source: "client",
+        surface: "client-error-report",
+        candidateRevision,
+        featureArea: "runtime",
+        ownerArea: "client",
+        severity: "error",
+        errorCode: "client_error_boundary_triggered",
+        message: payload.errorMessage,
+        context: {
+          roomId: null,
+          playerId: session?.playerId ?? null,
+          requestId,
+          route: "/api/client-error",
+          action: payload.platform,
+          statusCode: null,
+          crash: true,
+          detail: serializeContextDetail(payload.context, authenticated)
+        },
+        tags: [payload.platform, payload.version, authenticated ? "authenticated" : "anonymous"]
+      });
+
+      await deps.captureClientError({
+        platform: payload.platform,
+        version: payload.version,
+        errorMessage: payload.errorMessage,
+        authenticated,
+        ...(payload.stack != null ? { stack: payload.stack } : {}),
+        context: {
+          playerId: session?.playerId ?? null,
+          requestId,
+          clientVersion: payload.version,
+          detail: serializeContextDetail(payload.context, authenticated)
+        }
+      });
+
+      sendJson(response, 202, { accepted: true });
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, {
+          error: {
+            code: error.name,
+            message: error.message
+          }
+        });
+        return;
+      }
+
+      if (error instanceof PayloadValidationError || error instanceof SyntaxError) {
+        sendJson(response, 400, {
+          error: {
+            code: error instanceof SyntaxError ? "invalid_json" : error.name,
+            message: error instanceof SyntaxError ? "Request body must be valid JSON" : error.message
+          }
+        });
+        return;
+      }
+
+      sendJson(response, 500, {
+        error: {
+          code: error instanceof Error ? error.name || "error" : "error",
+          message: error instanceof Error ? error.message : String(error)
+        }
+      });
+    }
+  });
+}

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -5,6 +5,7 @@ import { config as loadEnv } from "dotenv";
 import { registerAuthRoutes } from "./auth";
 import { registerAnalyticsRoutes } from "./analytics";
 import { validateBackupStorageOnStartup, type BackupStorageValidationResult } from "./backup-storage";
+import { registerClientErrorRoutes } from "./client-error";
 import {
   FileSystemConfigCenterStore,
   MySqlConfigCenterStore,
@@ -124,6 +125,7 @@ export interface DevServerBootstrapDependencies {
   createRedisDriver(redisUrl: string): { shutdown(): Promise<void> | void };
   registerAuthRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerAnalyticsRoutes(app: unknown): void;
+  registerClientErrorRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerConfigCenterRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerConfigViewerRoutes(app: unknown, store: DevServerConfigCenterStore): void;
   registerEventRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
@@ -205,6 +207,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     createRedisDriver,
     registerAuthRoutes: (app, store) => registerAuthRoutes(app as never, store as RoomSnapshotStore),
     registerAnalyticsRoutes: (app) => registerAnalyticsRoutes(app as never),
+    registerClientErrorRoutes: (app, store) => registerClientErrorRoutes(app as never, store as RoomSnapshotStore | null),
     registerConfigCenterRoutes: (app, store) => registerConfigCenterRoutes(app as never, store as ConfigCenterStore),
     registerConfigViewerRoutes: (app, store) => registerConfigViewerRoutes(app as never, store as ConfigCenterStore),
     registerEventRoutes: (app, store) => registerEventRoutes(app as never, store as RoomSnapshotStore | null),
@@ -354,6 +357,7 @@ export async function startDevServer(
   deps.registerPrometheusMetricsRoute(expressApp);
   deps.registerAuthRoutes(expressApp, effectiveSnapshotStore);
   deps.registerAnalyticsRoutes(expressApp);
+  deps.registerClientErrorRoutes(expressApp, effectiveSnapshotStore);
   deps.registerConfigCenterRoutes(expressApp, configCenterStore);
   deps.registerConfigViewerRoutes(expressApp, configCenterStore);
   if ("use" in (expressApp as object) && "get" in (expressApp as object)) {

--- a/apps/server/src/error-monitoring.ts
+++ b/apps/server/src/error-monitoring.ts
@@ -31,6 +31,13 @@ export interface ServerErrorMonitoringContext {
   detail?: string | null;
 }
 
+export interface ClientErrorMonitoringContext {
+  playerId?: string | null;
+  requestId?: string | null;
+  clientVersion?: string | null;
+  detail?: string | null;
+}
+
 interface CaptureServerErrorInput {
   errorCode: StructuredErrorCode | string;
   message: string;
@@ -41,6 +48,31 @@ interface CaptureServerErrorInput {
   surface?: string;
   tags?: string[];
   context?: ServerErrorMonitoringContext;
+}
+
+interface SentryEventInput {
+  errorCode: StructuredErrorCode | string;
+  message: string;
+  error?: unknown;
+  severity?: MonitoringSeverity;
+  featureArea?: string;
+  ownerArea?: string;
+  surface?: string;
+  tags?: string[];
+  tagValues?: Record<string, string>;
+  context?: ServerErrorMonitoringContext;
+  platform?: string;
+  logger?: string;
+  serverName?: string;
+}
+
+export interface CaptureClientErrorInput {
+  platform: string;
+  version: string;
+  errorMessage: string;
+  stack?: string | null;
+  context?: ClientErrorMonitoringContext;
+  authenticated?: boolean;
 }
 
 const defaultErrorMonitoringRuntimeDependencies: ErrorMonitoringRuntimeDependencies = {
@@ -104,7 +136,7 @@ function normalizeError(error: unknown): { type: string; value: string; stack?: 
 }
 
 function buildSentryEvent(
-  input: CaptureServerErrorInput,
+  input: SentryEventInput,
   env: NodeJS.ProcessEnv
 ): { endpoint: string; body: string } | null {
   const parsedDsn = parseSentryDsn(env.SENTRY_DSN);
@@ -123,10 +155,10 @@ function buildSentryEvent(
   const payload = {
     event_id: eventId,
     timestamp,
-    platform: "node",
+    platform: input.platform ?? "node",
     level: severity === "warn" ? "warning" : severity,
-    logger: "project-veil-server",
-    server_name: "project-veil-server",
+    logger: input.logger ?? "project-veil-server",
+    server_name: input.serverName ?? "project-veil-server",
     environment: env.NODE_ENV?.trim() || "development",
     release: candidateRevision ?? undefined,
     message: {
@@ -152,7 +184,8 @@ function buildSentryEvent(
       owner_area: ownerArea,
       surface: input.surface ?? "server",
       ...(input.context?.route ? { route: input.context.route } : {}),
-      ...(input.context?.action ? { action: input.context.action } : {})
+      ...(input.context?.action ? { action: input.context.action } : {}),
+      ...input.tagValues
     },
     fingerprint: [
       input.surface ?? "server",
@@ -212,6 +245,67 @@ export async function captureServerError(
   env: NodeJS.ProcessEnv = process.env
 ): Promise<void> {
   const event = buildSentryEvent(input, env);
+  if (!event) {
+    return;
+  }
+
+  try {
+    const response = await errorMonitoringRuntimeDependencies.fetch(event.endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-sentry-envelope"
+      },
+      body: event.body
+    });
+    if (!response.ok) {
+      errorMonitoringRuntimeDependencies.error(`[ErrorMonitoring] Failed to deliver Sentry envelope: ${response.status}`);
+    }
+  } catch (error) {
+    errorMonitoringRuntimeDependencies.error("[ErrorMonitoring] Failed to deliver Sentry envelope", error);
+  }
+}
+
+function normalizeClientStack(errorMessage: string, stack: string | null | undefined): Error {
+  const error = new Error(errorMessage);
+  if (stack?.trim()) {
+    error.stack = stack.trim().includes(errorMessage)
+      ? stack.trim()
+      : `${error.name}: ${errorMessage}\n${stack.trim()}`;
+  }
+  return error;
+}
+
+export async function captureClientError(
+  input: CaptureClientErrorInput,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<void> {
+  const event = buildSentryEvent(
+    {
+      errorCode: "client_error_boundary_triggered",
+      message: `Client error reported from ${input.platform} ${input.version}: ${input.errorMessage}`,
+      error: normalizeClientStack(input.errorMessage, input.stack),
+      severity: "error",
+      featureArea: "runtime",
+      ownerArea: "client",
+      surface: "client-error-report",
+      platform: "javascript",
+      logger: "project-veil-client",
+      serverName: "project-veil-client",
+      tagValues: {
+        client_platform: input.platform,
+        client_version: input.version,
+        auth: input.authenticated ? "authenticated" : "anonymous"
+      },
+      context: {
+        playerId: input.context?.playerId ?? null,
+        requestId: input.context?.requestId ?? null,
+        route: "/api/client-error",
+        clientVersion: input.context?.clientVersion ?? input.version,
+        detail: input.context?.detail ?? null
+      }
+    },
+    env
+  );
   if (!event) {
     return;
   }

--- a/apps/server/test/client-error-routes.test.ts
+++ b/apps/server/test/client-error-routes.test.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import test from "node:test";
+import { issueGuestAuthSession } from "../src/auth";
+import { registerClientErrorRoutes } from "../src/client-error";
+
+interface TestResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  ended: boolean;
+  setHeader(name: string, value: string): void;
+  end(body?: string): void;
+}
+
+function createResponse(): TestResponse {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: "",
+    ended: false,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    end(body = "") {
+      this.body = body;
+      this.ended = true;
+    }
+  };
+}
+
+function createRequest(method: string, body?: string, headers: Record<string, string> = {}): Readable & {
+  method: string;
+  headers: Record<string, string>;
+  socket: { remoteAddress?: string };
+  resume(): void;
+} {
+  const request = Readable.from(body == null ? [] : [body]) as Readable & {
+    method: string;
+    headers: Record<string, string>;
+    socket: { remoteAddress?: string };
+    resume(): void;
+  };
+  request.method = method;
+  request.headers = {
+    ...(body == null ? {} : { "content-length": Buffer.byteLength(body).toString() }),
+    ...headers
+  };
+  request.socket = { remoteAddress: "203.0.113.7" };
+  request.resume = () => {
+    request.read();
+  };
+  return request;
+}
+
+function registerRoute(
+  overrides: {
+    now?: () => number;
+  } = {}
+): {
+  middleware: (request: never, response: TestResponse, next: () => void) => void;
+  handler: (request: never, response: TestResponse) => void | Promise<void>;
+  captureCalls: Array<unknown>;
+  runtimeEvents: Array<unknown>;
+  rateLimitedCount: number;
+} {
+  let middleware:
+    | ((request: never, response: TestResponse, next: () => void) => void)
+    | undefined;
+  let handler:
+    | ((request: never, response: TestResponse) => void | Promise<void>)
+    | undefined;
+  const captureCalls: Array<unknown> = [];
+  const runtimeEvents: Array<unknown> = [];
+  let rateLimitedCount = 0;
+
+  registerClientErrorRoutes(
+    {
+      use(nextMiddleware) {
+        middleware = nextMiddleware as never;
+      },
+      post(path, nextHandler) {
+        assert.equal(path, "/api/client-error");
+        handler = nextHandler as never;
+      }
+    },
+    null,
+    {
+      now: overrides.now ?? (() => Date.now()),
+      captureClientError: async (input) => {
+        captureCalls.push(input);
+      },
+      recordRuntimeErrorEvent: (input) => {
+        runtimeEvents.push(input);
+      },
+      recordHttpRateLimited: () => {
+        rateLimitedCount += 1;
+      }
+    }
+  );
+
+  assert(middleware);
+  assert(handler);
+
+  return {
+    middleware,
+    handler,
+    captureCalls,
+    runtimeEvents,
+    get rateLimitedCount() {
+      return rateLimitedCount;
+    }
+  };
+}
+
+test("client error route rejects invalid payloads", async () => {
+  const { middleware, handler, captureCalls, runtimeEvents } = registerRoute();
+  const request = createRequest("POST", JSON.stringify({ version: "1.2.3", errorMessage: "boom" }));
+  const response = createResponse();
+
+  let nextCalled = false;
+  middleware(request as never, response, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true);
+  await handler(request as never, response);
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: {
+      code: "invalid_client_error_payload",
+      message: "platform must be a string"
+    }
+  });
+  assert.equal(captureCalls.length, 0);
+  assert.equal(runtimeEvents.length, 0);
+});
+
+test("client error route forwards authenticated reports into monitoring", async () => {
+  const { handler, captureCalls, runtimeEvents } = registerRoute({ now: () => Date.parse("2026-04-12T12:00:00.000Z") });
+  const session = issueGuestAuthSession({ playerId: "player-42", displayName: "Ranger" });
+  const request = createRequest(
+    "POST",
+    JSON.stringify({
+      platform: "cocos",
+      version: "1.2.3",
+      errorMessage: "UI exploded",
+      stack: "TypeError: UI exploded\n at battle.ts:42:3",
+      context: {
+        scene: "battle",
+        roomId: "room-9"
+      }
+    }),
+    {
+      authorization: `Bearer ${session.token}`
+    }
+  );
+  const response = createResponse();
+
+  await handler(request as never, response);
+
+  assert.equal(response.statusCode, 202);
+  assert.deepEqual(JSON.parse(response.body), { accepted: true });
+  assert.equal(captureCalls.length, 1);
+  assert.deepEqual(captureCalls[0], {
+    platform: "cocos",
+    version: "1.2.3",
+    errorMessage: "UI exploded",
+    stack: "TypeError: UI exploded\n at battle.ts:42:3",
+    authenticated: true,
+    context: {
+      playerId: "player-42",
+      requestId: null,
+      clientVersion: "1.2.3",
+      detail: JSON.stringify({
+        scene: "battle",
+        roomId: "room-9"
+      })
+    }
+  });
+  assert.equal(runtimeEvents.length, 1);
+  assert.deepEqual(runtimeEvents[0], {
+    id: runtimeEvents[0] && typeof runtimeEvents[0] === "object" ? (runtimeEvents[0] as { id: string }).id : null,
+    recordedAt: "2026-04-12T12:00:00.000Z",
+    source: "client",
+    surface: "client-error-report",
+    candidateRevision: null,
+    featureArea: "runtime",
+    ownerArea: "client",
+    severity: "error",
+    errorCode: "client_error_boundary_triggered",
+    message: "UI exploded",
+    context: {
+      roomId: null,
+      playerId: "player-42",
+      requestId: null,
+      route: "/api/client-error",
+      action: "cocos",
+      statusCode: null,
+      crash: true,
+      detail: JSON.stringify({
+        scene: "battle",
+        roomId: "room-9"
+      })
+    },
+    tags: ["cocos", "1.2.3", "authenticated"]
+  });
+});
+
+test("client error route rate limits repeated reports per player and ip", async () => {
+  const originalWindow = process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_WINDOW_MS;
+  const originalPlayerMax = process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_PLAYER_MAX;
+  const originalIpMax = process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_IP_MAX;
+  process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_WINDOW_MS = "60000";
+  process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_PLAYER_MAX = "1";
+  process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_IP_MAX = "2";
+
+  try {
+    const route = registerRoute({ now: () => Date.parse("2026-04-12T12:00:00.000Z") });
+    const session = issueGuestAuthSession({ playerId: "player-7", displayName: "Knight" });
+    const requestBody = JSON.stringify({
+      platform: "h5",
+      version: "9.9.9",
+      errorMessage: "render failed"
+    });
+
+    const firstResponse = createResponse();
+    await route.handler(
+      createRequest("POST", requestBody, {
+        authorization: `Bearer ${session.token}`
+      }) as never,
+      firstResponse
+    );
+    assert.equal(firstResponse.statusCode, 202);
+
+    const secondResponse = createResponse();
+    await route.handler(
+      createRequest("POST", requestBody, {
+        authorization: `Bearer ${session.token}`
+      }) as never,
+      secondResponse
+    );
+
+    assert.equal(secondResponse.statusCode, 429);
+    assert.equal(secondResponse.headers["Retry-After"], "60");
+    assert.deepEqual(JSON.parse(secondResponse.body), {
+      error: {
+        code: "rate_limited",
+        message: "Too many client error reports, please retry later"
+      }
+    });
+    assert.equal(route.rateLimitedCount, 1);
+    assert.equal(route.captureCalls.length, 1);
+  } finally {
+    if (originalWindow === undefined) {
+      delete process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_WINDOW_MS;
+    } else {
+      process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_WINDOW_MS = originalWindow;
+    }
+
+    if (originalPlayerMax === undefined) {
+      delete process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_PLAYER_MAX;
+    } else {
+      process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_PLAYER_MAX = originalPlayerMax;
+    }
+
+    if (originalIpMax === undefined) {
+      delete process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_IP_MAX;
+    } else {
+      process.env.VEIL_RATE_LIMIT_CLIENT_ERROR_IP_MAX = originalIpMax;
+    }
+  }
+});

--- a/apps/server/test/error-monitoring.test.ts
+++ b/apps/server/test/error-monitoring.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test, { afterEach } from "node:test";
 import {
+  captureClientError,
   captureServerError,
   configureErrorMonitoringRuntimeDependencies,
   isErrorMonitoringEnabled,
@@ -111,6 +112,74 @@ test("error monitoring posts a Sentry envelope with structured Project Veil cont
       battleId: "battle-1",
       heroId: "hero-2",
       clientVersion: null
+    }
+  });
+});
+
+test("client error monitoring posts a javascript Sentry envelope with client platform tags", async () => {
+  const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
+  configureErrorMonitoringRuntimeDependencies({
+    fetch: async (input, init) => {
+      fetchCalls.push({ input, init });
+      return { ok: true, status: 202 };
+    }
+  });
+
+  await captureClientError(
+    {
+      platform: "cocos",
+      version: "1.2.3",
+      errorMessage: "global crash",
+      stack: "TypeError: global crash\n at app.js:1:1",
+      authenticated: true,
+      context: {
+        playerId: "player-2",
+        requestId: "req-client-1",
+        clientVersion: "1.2.3",
+        detail: "{\"scene\":\"lobby\"}"
+      }
+    },
+    {
+      ...process.env,
+      NODE_ENV: "production",
+      VERCEL_GIT_COMMIT_SHA: "abc1234",
+      SENTRY_DSN: "https://public@example.ingest.sentry.io/42"
+    }
+  );
+
+  assert.equal(fetchCalls.length, 1);
+  const rawBody = String(fetchCalls[0]?.init?.body);
+  const [, , payload] = rawBody.split("\n");
+  const parsedPayload = JSON.parse(payload ?? "{}") as Record<string, unknown>;
+
+  assert.equal(parsedPayload.platform, "javascript");
+  assert.equal(parsedPayload.logger, "project-veil-client");
+  assert.deepEqual(parsedPayload.tags, {
+    error_code: "client_error_boundary_triggered",
+    feature_area: "runtime",
+    owner_area: "client",
+    surface: "client-error-report",
+    route: "/api/client-error",
+    client_platform: "cocos",
+    client_version: "1.2.3",
+    auth: "authenticated"
+  });
+  assert.deepEqual(parsedPayload.user, {
+    id: "player-2"
+  });
+  assert.deepEqual(parsedPayload.contexts, {
+    project_veil: {
+      candidateRevision: "abc1234",
+      roomId: null,
+      playerId: "player-2",
+      requestId: "req-client-1",
+      action: null,
+      route: "/api/client-error",
+      statusCode: null,
+      roomDay: null,
+      battleId: null,
+      heroId: null,
+      clientVersion: "1.2.3"
     }
   });
 });


### PR DESCRIPTION
## Summary
- add  with payload validation, anonymous/auth-aware forwarding, and per-player/IP rate limiting
- forward client crash reports into Sentry envelopes with client platform/version tags
- cover the new route registration and monitoring behavior with focused server tests

## Testing
- /usr/local/bin/node --import tsx --test apps/server/test/client-error-routes.test.ts apps/server/test/error-monitoring.test.ts apps/server/test/dev-server.test.ts

Closes #1370.