### PR TITLE
Implement leaderboard season rollover and archive flow

### DIFF
--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -3,6 +3,7 @@ import { getRankDivisionForRating, getTierForRating } from "../../../packages/sh
 import { getCurrentAndPreviousWeeklyEntries } from "./competitive-season";
 import type { RoomSnapshotStore } from "./persistence";
 import { isLeaderboardFrozen, isLeaderboardHidden } from "./leaderboard-anti-abuse";
+import { readRuntimeSecret } from "./runtime-secrets";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -25,17 +26,56 @@ const TIER_THRESHOLDS = [
   { tier: "diamond", minRating: 1800, maxRating: null }
 ] as const;
 
+function readHeaderValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) {
+    return value[0]?.trim() || null;
+  }
+  return value?.trim() || null;
+}
+
+function isAdminAuthorized(request: IncomingMessage): boolean {
+  const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
+  return Boolean(adminToken) && readHeaderValue(request.headers["x-veil-admin-token"]) === adminToken;
+}
+
+function readLimit(request: IncomingMessage, fallback = 100): number {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const rawLimit = Number(url.searchParams.get("limit"));
+  if (!Number.isFinite(rawLimit)) {
+    return fallback;
+  }
+  return Math.min(100, Math.max(1, Math.floor(rawLimit)));
+}
+
+function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    request.on("end", () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    request.on("error", reject);
+  });
+}
+
 export function registerLeaderboardRoutes(
   app: {
     use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
     get: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+    post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
   },
   store: RoomSnapshotStore | null
 ): void {
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
-    response.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
-    response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type,X-Veil-Admin-Token");
 
     if (request.method === "OPTIONS") {
       response.statusCode = 204;
@@ -110,6 +150,103 @@ export function registerLeaderboardRoutes(
       }
       const account = await store.loadPlayerAccount(playerId);
       sendJson(response, 200, { history: account?.seasonHistory ?? [] });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.get("/api/leaderboard/seasons/:seasonId", async (request, response) => {
+    try {
+      const url = request.url ?? "/";
+      const match = url.match(/\/api\/leaderboard\/seasons\/([^/?]+)/);
+      const seasonId = match?.[1] ? decodeURIComponent(match[1]) : "";
+      if (!seasonId) {
+        sendJson(response, 400, { error: { code: "invalid_season_id", message: "Season id is required" } });
+        return;
+      }
+      if (!store?.listLeaderboardSeasonArchive) {
+        sendJson(response, 200, { seasonId, rankings: [] });
+        return;
+      }
+
+      sendJson(response, 200, {
+        seasonId,
+        rankings: await store.listLeaderboardSeasonArchive(seasonId, readLimit(request))
+      });
+    } catch (error) {
+      sendJson(response, 500, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.post("/api/admin/leaderboard/season-rollover", async (request, response) => {
+    try {
+      const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
+      if (!adminToken) {
+        sendJson(response, 503, { error: { code: "not_configured", message: "Admin token not configured" } });
+        return;
+      }
+      if (!isAdminAuthorized(request)) {
+        sendJson(response, 403, { error: { code: "forbidden", message: "Invalid admin token" } });
+        return;
+      }
+      if (!store) {
+        sendJson(response, 503, { error: { code: "no_store", message: "No persistence store available" } });
+        return;
+      }
+
+      const body = await readJsonBody(request);
+      if (typeof body !== "object" || body === null || Array.isArray(body)) {
+        sendJson(response, 400, { error: { code: "invalid_request", message: "Request body must be an object" } });
+        return;
+      }
+      const seasonId = String((body as Record<string, unknown>).seasonId ?? "").trim();
+      const nextSeasonId = String((body as Record<string, unknown>).nextSeasonId ?? "").trim();
+      if (!seasonId || !nextSeasonId) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_request",
+            message: "seasonId and nextSeasonId are required"
+          }
+        });
+        return;
+      }
+      if (seasonId === nextSeasonId) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_request",
+            message: "nextSeasonId must differ from seasonId"
+          }
+        });
+        return;
+      }
+
+      const currentSeason = await store.getCurrentSeason();
+      if (!currentSeason) {
+        sendJson(response, 404, { error: { code: "no_active_season", message: "No active season found" } });
+        return;
+      }
+      if (currentSeason.seasonId !== seasonId && currentSeason.seasonId !== nextSeasonId) {
+        sendJson(response, 409, {
+          error: {
+            code: "season_rollover_conflict",
+            message: `Active season ${currentSeason.seasonId} does not match rollover request`
+          }
+        });
+        return;
+      }
+
+      const closeSummary = await store.closeSeason(seasonId);
+      const nextSeason = currentSeason.seasonId === nextSeasonId ? currentSeason : await store.createSeason(nextSeasonId);
+      sendJson(response, 200, {
+        rolledOver: currentSeason.seasonId === seasonId,
+        seasonId,
+        nextSeason,
+        archive:
+          store.listLeaderboardSeasonArchive != null
+            ? await store.listLeaderboardSeasonArchive(seasonId, 100)
+            : [],
+        summary: closeSummary
+      });
     } catch (error) {
       sendJson(response, 500, { error: toErrorPayload(error) });
     }

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TUTORIAL_STEP,
   getEquipmentDefinition,
   getTierForDivision,
+  getTierForRating,
   normalizeGuildState,
   normalizeCosmeticInventory,
   normalizeTextForModeration,
@@ -67,6 +68,7 @@ import {
   type PlayerHeroArchiveSnapshot,
   type PlayerEventHistoryQuery,
   type PlayerEventHistorySnapshot,
+  type LeaderboardSeasonArchiveEntry,
   type SeasonCloseSummary,
   type SeasonListOptions,
   type SeasonSnapshot,
@@ -210,6 +212,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly shopPurchases = new Map<string, ShopPurchaseResult>();
   private readonly reports = new Map<string, PlayerReportRecord>();
   private readonly seasons = new Map<string, SeasonSnapshot>();
+  private readonly leaderboardSeasonArchives = new Map<string, LeaderboardSeasonArchiveEntry[]>();
   private readonly seasonRewardLog = new Map<string, { gems: number; badge: string; distributedAt: string }>();
   private readonly referrals = new Set<string>();
   private nextReportId = 1;
@@ -2292,6 +2295,17 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     return this.selectSeasons(options);
   }
 
+  async listLeaderboardSeasonArchive(seasonId: string, limit = 100): Promise<LeaderboardSeasonArchiveEntry[]> {
+    const normalizedSeasonId = seasonId.trim();
+    if (!normalizedSeasonId) {
+      throw new Error("seasonId must not be empty");
+    }
+
+    return (this.leaderboardSeasonArchives.get(normalizedSeasonId) ?? [])
+      .slice(0, Math.min(100, Math.max(1, Math.floor(limit))))
+      .map((entry) => structuredClone(entry));
+  }
+
   async createSeason(seasonId: string): Promise<import("./persistence").SeasonSnapshot> {
     const season: SeasonSnapshot = {
       seasonId: seasonId.trim(),
@@ -2330,6 +2344,20 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       );
 
     const distributedAt = new Date().toISOString();
+    if (!this.leaderboardSeasonArchives.has(normalizedSeasonId)) {
+      this.leaderboardSeasonArchives.set(
+        normalizedSeasonId,
+        rankedAccounts.slice(0, 100).map((account, index) => ({
+          seasonId: normalizedSeasonId,
+          rank: index + 1,
+          playerId: account.playerId,
+          displayName: account.displayName,
+          finalRating: normalizeEloRating(account.eloRating),
+          tier: getTierForRating(normalizeEloRating(account.eloRating)),
+          archivedAt: distributedAt
+        }))
+      );
+    }
     let playersRewarded = 0;
     let totalGemsGranted = 0;
     const rewardedPlayerIds = new Set<string>();
@@ -2359,6 +2387,8 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     for (const account of rankedAccounts) {
       const current = this.accounts.get(account.playerId) ?? account;
       const decay = applySeasonSoftDecay(current);
+      const rankPosition = rankedAccounts.findIndex((entry) => entry.playerId === account.playerId) + 1;
+      const finalRating = normalizeEloRating(current.eloRating ?? account.eloRating ?? 1000);
       await this.savePlayerAccountProgress(account.playerId, {
         eloRating: decayDivisionToRating(decay.rankDivision ?? current.rankDivision ?? "bronze_i"),
         rankDivision: decay.rankDivision,
@@ -2368,11 +2398,16 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         seasonHistory: [
           {
             seasonId: normalizedSeasonId,
+            rankPosition,
+            totalPlayers: rankedAccounts.length,
+            finalRating,
             peakDivision: current.peakRankDivision ?? current.rankDivision ?? "bronze_i",
             finalDivision: current.rankDivision ?? "bronze_i",
             rewardTier: getTierForDivision(current.rankDivision ?? "bronze_i"),
+            rankPercentile: rankedAccounts.length > 0 ? rankPosition / rankedAccounts.length : 1,
             rewardClaimed: rewardedPlayerIds.has(account.playerId),
-            archivedAt: distributedAt
+            archivedAt: distributedAt,
+            ...(rewardedPlayerIds.has(account.playerId) ? { rewardsGrantedAt: distributedAt } : {})
           },
           ...(current.seasonHistory ?? [])
         ].slice(0, 20)
@@ -2405,6 +2440,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     this.heroArchives.clear();
     this.shopPurchases.clear();
     this.seasons.clear();
+    this.leaderboardSeasonArchives.clear();
     this.seasonRewardLog.clear();
   }
 

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -104,6 +104,16 @@ export interface SeasonCloseSummary {
   totalGemsGranted: number;
 }
 
+export interface LeaderboardSeasonArchiveEntry {
+  seasonId: string;
+  rank: number;
+  playerId: string;
+  displayName: string;
+  finalRating: number;
+  tier: string;
+  archivedAt: string;
+}
+
 export interface PlayerReferralClaimResult {
   claimed: boolean;
   rewardGems: number;
@@ -291,6 +301,7 @@ export interface RoomSnapshotStore {
   listPlayerAccounts(options?: PlayerAccountListOptions): Promise<PlayerAccountSnapshot[]>;
   getCurrentSeason(): Promise<SeasonSnapshot | null>;
   listSeasons?(options?: SeasonListOptions): Promise<SeasonSnapshot[]>;
+  listLeaderboardSeasonArchive?(seasonId: string, limit?: number): Promise<LeaderboardSeasonArchiveEntry[]>;
   createSeason(seasonId: string): Promise<SeasonSnapshot>;
   closeSeason(seasonId: string): Promise<SeasonCloseSummary>;
   save(roomId: string, snapshot: RoomPersistenceSnapshot): Promise<void>;
@@ -1141,8 +1152,9 @@ export const MYSQL_GUILD_AUDIT_LOG_ACTOR_OCCURRED_INDEX = "idx_guild_audit_logs_
 export const MYSQL_CONFIG_DOCUMENT_TABLE = "config_documents";
 export const MYSQL_CONFIG_DOCUMENT_UPDATED_AT_INDEX = "idx_config_documents_updated_at";
 export const MYSQL_SEASON_TABLE = "veil_seasons";
-export const MYSQL_SEASON_RANKINGS_TABLE = "veil_season_rankings";
+export const MYSQL_LEADERBOARD_SEASON_ARCHIVE_TABLE = "leaderboard_season_archives";
 export const MYSQL_SEASON_REWARD_LOG_TABLE = "season_reward_log";
+const MAX_LEADERBOARD_SEASON_ARCHIVE_SIZE = 100;
 export const DEFAULT_SNAPSHOT_TTL_HOURS = 72;
 export const DEFAULT_SNAPSHOT_CLEANUP_INTERVAL_MINUTES = 30;
 export const MAX_PLAYER_DISPLAY_NAME_LENGTH = 40;
@@ -4120,14 +4132,16 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_SEASON_TABLE}\` (
   PRIMARY KEY (\`season_id\`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE IF NOT EXISTS \`${MYSQL_SEASON_RANKINGS_TABLE}\` (
+CREATE TABLE IF NOT EXISTS \`${MYSQL_LEADERBOARD_SEASON_ARCHIVE_TABLE}\` (
   \`season_id\` VARCHAR(64) NOT NULL,
+  \`rank_position\` INT NOT NULL,
   \`player_id\` VARCHAR(64) NOT NULL,
+  \`display_name\` VARCHAR(191) NOT NULL,
   \`final_rating\` INT NOT NULL,
   \`tier\` VARCHAR(32) NOT NULL,
-  \`rank_position\` INT NOT NULL,
   \`archived_at\` DATETIME NOT NULL,
-  PRIMARY KEY (\`season_id\`, \`player_id\`)
+  PRIMARY KEY (\`season_id\`, \`rank_position\`),
+  UNIQUE KEY \`uniq_leaderboard_season_archives_player\` (\`season_id\`, \`player_id\`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 SET @veil_seasons_reward_distributed_exists := (
@@ -9067,6 +9081,33 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     };
   }
 
+  async listLeaderboardSeasonArchive(seasonId: string, limit = MAX_LEADERBOARD_SEASON_ARCHIVE_SIZE): Promise<LeaderboardSeasonArchiveEntry[]> {
+    const normalizedId = seasonId.trim();
+    if (!normalizedId) {
+      throw new Error("seasonId must not be empty");
+    }
+
+    const normalizedLimit = Math.min(MAX_LEADERBOARD_SEASON_ARCHIVE_SIZE, Math.max(1, Math.floor(limit)));
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT season_id, rank_position, player_id, display_name, final_rating, tier, archived_at
+       FROM \`${MYSQL_LEADERBOARD_SEASON_ARCHIVE_TABLE}\`
+       WHERE season_id = ?
+       ORDER BY rank_position ASC
+       LIMIT ?`,
+      [normalizedId, normalizedLimit]
+    );
+
+    return rows.map((row) => ({
+      seasonId: String(row.season_id),
+      rank: Math.max(1, Math.floor(Number(row.rank_position) || 0)),
+      playerId: String(row.player_id),
+      displayName: String(row.display_name || row.player_id),
+      finalRating: normalizeEloRating(Number(row.final_rating)),
+      tier: String(row.tier),
+      archivedAt: formatTimestamp(row.archived_at as Date | string) ?? new Date(0).toISOString()
+    }));
+  }
+
   async closeSeason(seasonId: string): Promise<SeasonCloseSummary> {
     const normalizedId = seasonId.trim();
     if (!normalizedId) {
@@ -9108,44 +9149,57 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         };
       }
 
-      const [existingRankingRows] = await connection.query<RowDataPacket[]>(
-        `SELECT player_id, final_rating, rank_position
-         FROM \`${MYSQL_SEASON_RANKINGS_TABLE}\`
+      const [existingArchiveRows] = await connection.query<RowDataPacket[]>(
+        `SELECT player_id, rank_position
+         FROM \`${MYSQL_LEADERBOARD_SEASON_ARCHIVE_TABLE}\`
          WHERE season_id = ?
-         ORDER BY final_rating DESC, rank_position ASC, player_id ASC`,
+         ORDER BY rank_position ASC`,
         [normalizedId]
       );
 
-      let rankedPlayers = existingRankingRows.map((row) => ({
-        playerId: String(row.player_id),
-        finalRating: normalizeEloRating(Number(row.final_rating)),
-        rankPosition: Math.max(1, Math.floor(Number(row.rank_position) || 0))
-      }));
+      const [accountRows] = await connection.query<RowDataPacket[]>(
+        `SELECT player_id, display_name, elo_rating
+         FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
+         WHERE elo_rating IS NOT NULL
+         ORDER BY elo_rating DESC, player_id ASC
+         FOR UPDATE`
+      );
+      const rankedPlayers = accountRows.map((row, index) => {
+        const playerId = String(row.player_id);
+        const finalRating = normalizeEloRating(Number(row.elo_rating));
+        return {
+          playerId,
+          displayName: String(row.display_name || row.player_id),
+          finalRating,
+          rankPosition: index + 1
+        };
+      });
 
-      if (rankedPlayers.length === 0) {
-        const [accountRows] = await connection.query<RowDataPacket[]>(
-          `SELECT player_id, elo_rating
-           FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
-           WHERE elo_rating IS NOT NULL
-           ORDER BY elo_rating DESC, player_id ASC
-           FOR UPDATE`
-        );
-        const rankingValues: Array<[string, string, number, string, number, Date]> = [];
-        rankedPlayers = accountRows.map((row, index) => {
-          const playerId = String(row.player_id);
-          const finalRating = normalizeEloRating(Number(row.elo_rating));
-          rankingValues.push([normalizedId, playerId, finalRating, getTierForRating(finalRating), index + 1, now]);
-          return {
-            playerId,
-            finalRating,
-            rankPosition: index + 1
-          };
-        });
+      if (existingArchiveRows.length === 0) {
+        const archiveValues: Array<[string, number, string, string, number, string, Date]> = rankedPlayers
+          .slice(0, MAX_LEADERBOARD_SEASON_ARCHIVE_SIZE)
+          .map((rankedPlayer) => [
+            normalizedId,
+            rankedPlayer.rankPosition,
+            rankedPlayer.playerId,
+            rankedPlayer.displayName,
+            rankedPlayer.finalRating,
+            getTierForRating(rankedPlayer.finalRating),
+            now
+          ]);
 
-        if (rankingValues.length > 0) {
+        if (archiveValues.length > 0) {
           await connection.query(
-            `INSERT INTO \`${MYSQL_SEASON_RANKINGS_TABLE}\` (season_id, player_id, final_rating, tier, rank_position, archived_at) VALUES ?`,
-            [rankingValues]
+            `INSERT INTO \`${MYSQL_LEADERBOARD_SEASON_ARCHIVE_TABLE}\` (
+               season_id,
+               rank_position,
+               player_id,
+               display_name,
+               final_rating,
+               tier,
+               archived_at
+             ) VALUES ?`,
+            [archiveValues]
           );
         }
       }
@@ -9229,11 +9283,16 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         const seasonHistory = [
           {
             seasonId: normalizedId,
+            rankPosition: rankedPlayer.rankPosition,
+            totalPlayers: rankedPlayers.length,
+            finalRating: rankedPlayer.finalRating,
             peakDivision,
             finalDivision: currentDivision,
             rewardTier: getTierForRating(rankedPlayer.finalRating),
+            rankPercentile: rankedPlayers.length > 0 ? rankedPlayer.rankPosition / rankedPlayers.length : 1,
             rewardClaimed: rewardedPlayerIds.has(rankedPlayer.playerId),
-            archivedAt: now.toISOString()
+            archivedAt: now.toISOString(),
+            ...(rewardedPlayerIds.has(rankedPlayer.playerId) ? { rewardsGrantedAt: now.toISOString() } : {})
           },
           ...(currentAccount.seasonHistory ?? [])
         ].slice(0, 20);

--- a/apps/server/test/leaderboard-routes.test.ts
+++ b/apps/server/test/leaderboard-routes.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { EventEmitter } from "node:events";
+import test, { type TestContext } from "node:test";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { addUtcDays, getUtcWeekStart } from "../../../packages/shared/src/index";
 import { registerLeaderboardRoutes } from "../src/leaderboard";
@@ -9,6 +10,7 @@ type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void
 
 function createTestApp() {
   const gets = new Map<string, RouteHandler>();
+  const posts = new Map<string, RouteHandler>();
   const middlewares: Array<
     (request: IncomingMessage, response: ServerResponse, next: () => void) => void
   > = [];
@@ -20,9 +22,13 @@ function createTestApp() {
       },
       get(path: string, handler: RouteHandler) {
         gets.set(path, handler);
+      },
+      post(path: string, handler: RouteHandler) {
+        posts.set(path, handler);
       }
     },
     gets,
+    posts,
     middlewares
   };
 }
@@ -31,12 +37,19 @@ function createRequest(options: {
   method?: string;
   headers?: Record<string, string | undefined>;
   url?: string;
+  body?: string;
 } = {}): IncomingMessage {
-  const request = {} as IncomingMessage;
+  const request = new EventEmitter() as IncomingMessage & EventEmitter;
   Object.assign(request, {
     method: options.method ?? "GET",
     headers: options.headers ?? {},
     url: options.url ?? "/"
+  });
+  queueMicrotask(() => {
+    if (options.body !== undefined) {
+      request.emit("data", Buffer.from(options.body, "utf8"));
+    }
+    request.emit("end");
   });
   return request;
 }
@@ -83,9 +96,22 @@ async function runMiddlewares(
 }
 
 function registerRoutes(store = createMemoryRoomSnapshotStore()) {
-  const { app, gets, middlewares } = createTestApp();
+  const { app, gets, posts, middlewares } = createTestApp();
   registerLeaderboardRoutes(app, store);
-  return { gets, middlewares, store };
+  return { gets, posts, middlewares, store };
+}
+
+function withAdminToken(t: TestContext, token = "leaderboard-admin-token"): string {
+  const original = process.env.VEIL_ADMIN_TOKEN;
+  process.env.VEIL_ADMIN_TOKEN = token;
+  t.after(() => {
+    if (original === undefined) {
+      delete process.env.VEIL_ADMIN_TOKEN;
+    } else {
+      process.env.VEIL_ADMIN_TOKEN = original;
+    }
+  });
+  return token;
 }
 
 test("GET /api/leaderboard returns ranked players in elo order with competitive progression fields", async () => {
@@ -211,8 +237,8 @@ test("leaderboard route middleware responds to OPTIONS and applies CORS headers"
   assert.equal(response.statusCode, 204);
   assert.equal(response.body, "");
   assert.equal(response.headers["Access-Control-Allow-Origin"], "*");
-  assert.equal(response.headers["Access-Control-Allow-Methods"], "GET,OPTIONS");
-  assert.equal(response.headers["Access-Control-Allow-Headers"], "Content-Type");
+  assert.equal(response.headers["Access-Control-Allow-Methods"], "GET,POST,OPTIONS");
+  assert.equal(response.headers["Access-Control-Allow-Headers"], "Content-Type,X-Veil-Admin-Token");
 });
 
 test("leaderboard route middleware continues non-OPTIONS requests after applying CORS headers", async () => {
@@ -232,8 +258,8 @@ test("leaderboard route middleware continues non-OPTIONS requests after applying
   assert.equal(nextCalled, true);
   assert.equal(response.statusCode, 200);
   assert.equal(response.headers["Access-Control-Allow-Origin"], "*");
-  assert.equal(response.headers["Access-Control-Allow-Methods"], "GET,OPTIONS");
-  assert.equal(response.headers["Access-Control-Allow-Headers"], "Content-Type");
+  assert.equal(response.headers["Access-Control-Allow-Methods"], "GET,POST,OPTIONS");
+  assert.equal(response.headers["Access-Control-Allow-Headers"], "Content-Type,X-Veil-Admin-Token");
 });
 
 test("GET /api/leaderboard returns a 500 payload when the store listing fails", async () => {
@@ -467,6 +493,147 @@ test("GET /api/player/:id/season-history returns a 500 payload when loading the 
       message: "season_history_unavailable"
     }
   });
+});
+
+test("GET /api/leaderboard/seasons/:seasonId returns archived rankings for the requested season", async () => {
+  const { gets, store } = registerRoutes();
+  const handler = gets.get("/api/leaderboard/seasons/:seasonId");
+  const response = createResponse();
+
+  await store.ensurePlayerAccount({ playerId: "player-1", displayName: "Alpha" });
+  await store.savePlayerAccountProgress("player-1", { eloRating: 1650, rankDivision: "platinum_i" });
+  await store.ensurePlayerAccount({ playerId: "player-2", displayName: "Beta" });
+  await store.savePlayerAccountProgress("player-2", { eloRating: 1400, rankDivision: "gold_i" });
+  await store.createSeason("season-archive");
+  await store.closeSeason("season-archive");
+
+  assert.ok(handler);
+  await handler(createRequest({ url: "/api/leaderboard/seasons/season-archive?limit=1" }), response);
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(JSON.parse(response.body), {
+    seasonId: "season-archive",
+    rankings: [
+      {
+        seasonId: "season-archive",
+        rank: 1,
+        playerId: "player-1",
+        displayName: "Alpha",
+        finalRating: 1650,
+        tier: "platinum",
+        archivedAt: JSON.parse(response.body).rankings[0].archivedAt
+      }
+    ]
+  });
+});
+
+test("POST /api/admin/leaderboard/season-rollover closes the current season, archives standings, and starts the next one", async (t) => {
+  const token = withAdminToken(t);
+  const { posts, store } = registerRoutes();
+  const handler = posts.get("/api/admin/leaderboard/season-rollover");
+  const response = createResponse();
+
+  await store.ensurePlayerAccount({ playerId: "player-1", displayName: "Alpha" });
+  await store.savePlayerAccountProgress("player-1", {
+    eloRating: 1650,
+    rankDivision: "platinum_i",
+    peakRankDivision: "diamond_i"
+  });
+  await store.ensurePlayerAccount({ playerId: "player-2", displayName: "Beta" });
+  await store.savePlayerAccountProgress("player-2", {
+    eloRating: 1400,
+    rankDivision: "gold_i"
+  });
+  await store.createSeason("season-9");
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      url: "/api/admin/leaderboard/season-rollover",
+      headers: { "x-veil-admin-token": token },
+      body: JSON.stringify({ seasonId: "season-9", nextSeasonId: "season-10" })
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 200);
+  const payload = JSON.parse(response.body) as {
+    rolledOver: boolean;
+    nextSeason: { seasonId: string; status: string };
+    summary: { seasonId: string; playersRewarded: number };
+    archive: Array<{ playerId: string; rank: number }>;
+  };
+  assert.equal(payload.rolledOver, true);
+  assert.equal(payload.summary.seasonId, "season-9");
+  assert.equal(payload.nextSeason.seasonId, "season-10");
+  assert.equal(payload.nextSeason.status, "active");
+  assert.deepEqual(payload.archive.map((entry) => [entry.rank, entry.playerId]), [
+    [1, "player-1"],
+    [2, "player-2"]
+  ]);
+
+  const firstAccount = await store.loadPlayerAccount("player-1");
+  assert.equal(firstAccount?.seasonHistory?.[0]?.seasonId, "season-9");
+  assert.equal(firstAccount?.seasonHistory?.[0]?.rankPosition, 1);
+  assert.equal(firstAccount?.seasonHistory?.[0]?.finalRating, 1650);
+  assert.equal(firstAccount?.seasonHistory?.[0]?.totalPlayers, 2);
+  assert.equal(firstAccount?.seasonHistory?.[0]?.rewardClaimed, true);
+  assert.equal(firstAccount?.eloRating, 1300);
+  assert.equal((await store.getCurrentSeason())?.seasonId, "season-10");
+});
+
+test("POST /api/admin/leaderboard/season-rollover is idempotent for the same season pair", async (t) => {
+  const token = withAdminToken(t);
+  const { posts, store } = registerRoutes();
+  const handler = posts.get("/api/admin/leaderboard/season-rollover");
+
+  await store.ensurePlayerAccount({ playerId: "player-1", displayName: "Alpha" });
+  await store.savePlayerAccountProgress("player-1", {
+    eloRating: 1650,
+    rankDivision: "platinum_i"
+  });
+  await store.createSeason("season-11");
+
+  assert.ok(handler);
+  const firstResponse = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      url: "/api/admin/leaderboard/season-rollover",
+      headers: { "x-veil-admin-token": token },
+      body: JSON.stringify({ seasonId: "season-11", nextSeasonId: "season-12" })
+    }),
+    firstResponse
+  );
+  const secondResponse = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      url: "/api/admin/leaderboard/season-rollover",
+      headers: { "x-veil-admin-token": token },
+      body: JSON.stringify({ seasonId: "season-11", nextSeasonId: "season-12" })
+    }),
+    secondResponse
+  );
+
+  assert.equal(firstResponse.statusCode, 200);
+  assert.equal(secondResponse.statusCode, 200);
+  const secondPayload = JSON.parse(secondResponse.body) as {
+    rolledOver: boolean;
+    summary: { playersRewarded: number; totalGemsGranted: number };
+    nextSeason: { seasonId: string };
+    archive: Array<{ playerId: string }>;
+  };
+  assert.equal(secondPayload.rolledOver, false);
+  assert.deepEqual(secondPayload.summary, {
+    seasonId: "season-11",
+    playersRewarded: 0,
+    totalGemsGranted: 0
+  });
+  assert.equal(secondPayload.nextSeason.seasonId, "season-12");
+  assert.deepEqual(secondPayload.archive.map((entry) => entry.playerId), ["player-1"]);
+  assert.equal((await store.getCurrentSeason())?.seasonId, "season-12");
 });
 
 test("GET /api/matchmaking/tiers returns the published tier thresholds", async () => {

--- a/apps/server/test/memory-room-snapshot-store.test.ts
+++ b/apps/server/test/memory-room-snapshot-store.test.ts
@@ -235,4 +235,16 @@ test("memory room snapshot store matches season reward bracket distribution and 
     totalGemsGranted: 0
   });
   assert.equal((await store.loadPlayerAccount("player-001"))?.gems, 201);
+  const archive = await store.listLeaderboardSeasonArchive?.("season-rewards", 3);
+  assert.deepEqual(archive?.map((entry) => [entry.rank, entry.playerId, entry.finalRating]), [
+    [1, "player-001", 2000],
+    [2, "player-002", 1999],
+    [3, "player-003", 1998]
+  ]);
+  const firstHistory = (await store.loadPlayerAccount("player-001"))?.seasonHistory?.[0];
+  assert.equal(firstHistory?.seasonId, "season-rewards");
+  assert.equal(firstHistory?.rankPosition, 1);
+  assert.equal(firstHistory?.totalPlayers, 100);
+  assert.equal(firstHistory?.finalRating, 2000);
+  assert.equal(firstHistory?.rewardClaimed, true);
 });

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -331,10 +331,9 @@ test("closeSeason distributes bracket rewards once and records badges in the rew
           reward_distributed_at: seasonState.rewardDistributedAt
         }]];
       }
-      if (/FROM `veil_season_rankings`/.test(sql) && /ORDER BY final_rating DESC/.test(sql)) {
+      if (/FROM `leaderboard_season_archives`/.test(sql) && /ORDER BY rank_position ASC/.test(sql)) {
         return [rankingRows.map((row) => ({
           player_id: row.playerId,
-          final_rating: row.finalRating,
           rank_position: row.rankPosition
         }))];
       }
@@ -343,13 +342,14 @@ test("closeSeason distributes bracket rewards once and records badges in the rew
           .sort((left, right) => right[1].eloRating - left[1].eloRating || left[0].localeCompare(right[0]))
           .map(([playerId, account]) => ({
             player_id: playerId,
+            display_name: playerId,
             elo_rating: account.eloRating
           }));
         return [rows];
       }
-      if (/INSERT INTO `veil_season_rankings`/.test(sql)) {
-        const values = params[0] as Array<[string, string, number, string, number]>;
-        for (const [seasonId, playerId, finalRating, tier, rankPosition] of values) {
+      if (/INSERT INTO `leaderboard_season_archives`/.test(sql)) {
+        const values = params[0] as Array<[string, number, string, string, number, string]>;
+        for (const [seasonId, rankPosition, playerId, _displayName, finalRating, tier] of values) {
           rankingRows.push({ seasonId, playerId, finalRating, tier, rankPosition });
         }
         return [{ affectedRows: values.length }];
@@ -415,6 +415,20 @@ test("closeSeason distributes bracket rewards once and records badges in the rew
           ...account,
           gems,
           seasonBadges: JSON.parse(seasonBadgesJson)
+        });
+        return [{ affectedRows: 1 }];
+      }
+      if (/UPDATE `player_accounts`/.test(sql) && /season_history_json = \?/.test(sql)) {
+        const [eloRating, rankDivision, peakRankDivision, _promotionSeriesJson, _demotionShieldJson, seasonHistoryJson, playerId] =
+          params as [number, string, string, string, string, string, string];
+        const account = accounts.get(playerId);
+        assert.ok(account);
+        accounts.set(playerId, {
+          ...account,
+          eloRating,
+          rankDivision,
+          peakRankDivision,
+          seasonHistory: JSON.parse(seasonHistoryJson)
         });
         return [{ affectedRows: 1 }];
       }

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -248,11 +248,17 @@ export interface SeasonRewardConfig {
 
 export interface SeasonArchiveEntry {
   seasonId: string;
+  rankPosition?: number;
+  totalPlayers?: number;
+  finalRating?: number;
+  peakRating?: number;
   peakDivision: RankDivisionId;
   finalDivision: RankDivisionId;
   rewardTier: PlayerTier;
+  rankPercentile?: number;
   rewardClaimed: boolean;
   archivedAt: string;
+  rewardsGrantedAt?: string;
 }
 
 export interface WeeklyLeaderboardEntry {

--- a/packages/shared/src/player-account.ts
+++ b/packages/shared/src/player-account.ts
@@ -368,11 +368,19 @@ export function normalizePlayerAccountReadModel(
     .filter((entry): entry is SeasonArchiveEntry => Boolean(entry?.seasonId && entry?.peakDivision && entry?.finalDivision))
     .map((entry) => ({
       seasonId: entry.seasonId.trim(),
+      ...(Number.isFinite(entry.rankPosition) ? { rankPosition: Math.max(1, Math.floor(entry.rankPosition!)) } : {}),
+      ...(Number.isFinite(entry.totalPlayers) ? { totalPlayers: Math.max(1, Math.floor(entry.totalPlayers!)) } : {}),
+      ...(Number.isFinite(entry.finalRating) ? { finalRating: Math.max(0, Math.floor(entry.finalRating!)) } : {}),
+      ...(Number.isFinite(entry.peakRating) ? { peakRating: Math.max(0, Math.floor(entry.peakRating!)) } : {}),
       peakDivision: entry.peakDivision,
       finalDivision: entry.finalDivision,
       rewardTier: entry.rewardTier,
+      ...(typeof entry.rankPercentile === "number" && Number.isFinite(entry.rankPercentile)
+        ? { rankPercentile: Math.max(0, Math.min(1, entry.rankPercentile)) }
+        : {}),
       rewardClaimed: entry.rewardClaimed === true,
-      archivedAt: normalizeTimestamp(entry.archivedAt) ?? new Date(0).toISOString()
+      archivedAt: normalizeTimestamp(entry.archivedAt) ?? new Date(0).toISOString(),
+      ...(normalizeTimestamp(entry.rewardsGrantedAt) ? { rewardsGrantedAt: normalizeTimestamp(entry.rewardsGrantedAt)! } : {})
     }))
     .sort((left, right) => right.archivedAt.localeCompare(left.archivedAt) || left.seasonId.localeCompare(right.seasonId));
   let rankedWeeklyProgress: RankedWeeklyProgress | undefined;


### PR DESCRIPTION
## Summary
- add admin leaderboard season rollover endpoint and archived season leaderboard read endpoint
- persist archived leaderboard standings and enrich player season history with final placement/ELO metadata
- cover rollover, archive retrieval, and persistence behavior in route and store tests

Closes #1375.