### PR TITLE
Add purchase controls and audit tooling

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -6,6 +6,7 @@ import { GuildService } from "./guilds";
 import type {
   PlayerCompensationCreateInput,
   PlayerCompensationRecord,
+  PlayerPurchaseHistorySnapshot,
   PlayerReportResolveInput,
   PlayerReportStatus,
   RoomSnapshotStore
@@ -211,6 +212,12 @@ function hasPlayerCompensationStore(
   );
 }
 
+function hasPlayerPurchaseHistoryStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPlayerPurchaseHistory">> {
+  return Boolean(store?.listPlayerPurchaseHistory);
+}
+
 function hasBattleSnapshotHistoryStore(
   store: RoomSnapshotStore | null
 ): store is RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listBattleSnapshotsForPlayer">> {
@@ -376,6 +383,12 @@ function readPage(request: IncomingMessage, fallback = 1): number {
     return fallback;
   }
   return Math.max(1, Math.floor(parsed));
+}
+
+function readOptionalQueryString(request: IncomingMessage, key: string): string | undefined {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const value = url.searchParams.get(key)?.trim();
+  return value ? value : undefined;
 }
 
 type LeaderboardQueueFlagType =
@@ -945,6 +958,45 @@ export function registerAdminRoutes(
       const playerId = readRequiredParam(request as AdminRequest, "id");
       const items = await store.listPlayerCompensationHistory(playerId, { limit: readLimit(request) });
       sendJson(response, 200, { items });
+    } catch (error) {
+      if (error instanceof InvalidAdminPayloadError) {
+        sendInvalidPayload(response, error.message);
+        return;
+      }
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+
+  app.get("/api/admin/players/:id/purchase-history", async (request, response) => {
+    if (!isAdminSecretConfigured()) return sendAdminSecretNotConfigured(response);
+    if (!isAuthorized(request)) return sendUnauthorized(response);
+    if (!hasPlayerPurchaseHistoryStore(store)) return sendStoreUnavailable(response);
+
+    try {
+      const playerId = readRequiredParam(request as AdminRequest, "id");
+      const limit = readLimit(request, 20);
+      const page = readPage(request, 1);
+      const offset = (page - 1) * limit;
+      const from = readOptionalQueryString(request, "from");
+      const to = readOptionalQueryString(request, "to");
+      const itemId = readOptionalQueryString(request, "itemId");
+      const history: PlayerPurchaseHistorySnapshot = await store.listPlayerPurchaseHistory(playerId, {
+        ...(from ? { from } : {}),
+        ...(to ? { to } : {}),
+        ...(itemId ? { itemId } : {}),
+        limit,
+        offset
+      });
+      sendJson(response, 200, {
+        items: history.items,
+        page,
+        limit: history.limit,
+        total: history.total,
+        totalPages: Math.max(1, Math.ceil(history.total / history.limit)),
+        ...(from ? { from } : {}),
+        ...(to ? { to } : {}),
+        ...(itemId ? { itemId } : {})
+      });
     } catch (error) {
       if (error instanceof InvalidAdminPayloadError) {
         sendInvalidPayload(response, error.message);

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -56,6 +56,9 @@ import {
   type PlayerCompensationCreateInput,
   type PlayerCompensationListOptions,
   type PlayerCompensationRecord,
+  type PlayerPurchaseHistoryQuery,
+  type PlayerPurchaseHistoryRecord,
+  type PlayerPurchaseHistorySnapshot,
   type PlayerAccountWechatMiniGameIdentityInput,
   type PlayerAccountProfilePatch,
   type PlayerAccountProgressPatch,
@@ -174,6 +177,14 @@ function normalizeResourceLedger(resources?: PlayerAccountSnapshot["globalResour
     wood: Math.max(0, Math.floor(resources?.wood ?? 0)),
     ore: Math.max(0, Math.floor(resources?.ore ?? 0))
   };
+}
+
+function normalizePurchaseHistoryDate(value: string, field: "from" | "to"): number {
+  const timestamp = new Date(value).getTime();
+  if (!Number.isFinite(timestamp)) {
+    throw new Error(`${field} must be a valid ISO timestamp`);
+  }
+  return timestamp;
 }
 
 export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
@@ -1401,6 +1412,57 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     const normalizedPlayerId = normalizePlayerId(playerId);
     const safeLimit = Math.max(1, Math.floor(options.limit ?? 20));
     return structuredClone((this.banHistoryByPlayerId.get(normalizedPlayerId) ?? []).slice(0, safeLimit));
+  }
+
+  async listPlayerPurchaseHistory(
+    playerId: string,
+    query: PlayerPurchaseHistoryQuery = {}
+  ): Promise<PlayerPurchaseHistorySnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const safeLimit = Math.max(1, Math.floor(query.limit ?? 20));
+    const safeOffset = Math.max(0, Math.floor(query.offset ?? 0));
+    const normalizedItemId = query.itemId?.trim();
+    const fromTimestamp = query.from ? normalizePurchaseHistoryDate(query.from, "from") : Number.NEGATIVE_INFINITY;
+    const toTimestamp = query.to ? normalizePurchaseHistoryDate(query.to, "to") : Number.POSITIVE_INFINITY;
+    if (fromTimestamp > toTimestamp) {
+      throw new Error("from must be earlier than or equal to to");
+    }
+
+    const items: PlayerPurchaseHistoryRecord[] = [];
+    for (const [key, purchase] of this.shopPurchases.entries()) {
+      const [entryPlayerId] = key.split(":", 1);
+      if (entryPlayerId !== normalizedPlayerId) {
+        continue;
+      }
+      if (normalizedItemId && purchase.productId !== normalizedItemId) {
+        continue;
+      }
+      const grantedAtTimestamp = new Date(purchase.processedAt).getTime();
+      if (grantedAtTimestamp < fromTimestamp || grantedAtTimestamp > toTimestamp) {
+        continue;
+      }
+      items.push({
+        purchaseId: purchase.purchaseId,
+        itemId: purchase.productId,
+        quantity: purchase.quantity,
+        currency: "gems",
+        amount: purchase.totalPrice,
+        paymentMethod: "gems",
+        grantedAt: purchase.processedAt,
+        status: "completed"
+      });
+    }
+
+    items.sort(
+      (left, right) =>
+        right.grantedAt.localeCompare(left.grantedAt) || right.purchaseId.localeCompare(left.purchaseId)
+    );
+    return {
+      items: structuredClone(items.slice(safeOffset, safeOffset + safeLimit)),
+      total: items.length,
+      limit: safeLimit,
+      offset: safeOffset
+    };
   }
 
   async appendPlayerCompensationRecord(

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -238,6 +238,10 @@ export interface RoomSnapshotStore {
     playerId: string,
     options?: PlayerCompensationListOptions
   ): Promise<PlayerCompensationRecord[]>;
+  listPlayerPurchaseHistory?(
+    playerId: string,
+    query?: PlayerPurchaseHistoryQuery
+  ): Promise<PlayerPurchaseHistorySnapshot>;
   loadPlayerAccountAuthByLoginId(loginId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerAccountAuthByPlayerId(playerId: string): Promise<PlayerAccountAuthSnapshot | null>;
   loadPlayerHeroArchives(playerIds: string[]): Promise<PlayerHeroArchiveSnapshot[]>;
@@ -529,6 +533,10 @@ interface ShopPurchaseRow extends RowDataPacket {
   total_price: number;
   result_json: string | ShopPurchaseResult;
   created_at: Date | string;
+}
+
+interface CountRow extends RowDataPacket {
+  total: number;
 }
 
 interface PaymentOrderRow extends RowDataPacket {
@@ -1088,6 +1096,32 @@ export interface PlayerCompensationCreateInput {
 
 export interface PlayerCompensationListOptions {
   limit?: number;
+}
+
+export interface PlayerPurchaseHistoryRecord {
+  purchaseId: string;
+  itemId: string;
+  quantity: number;
+  currency: "gems";
+  amount: number;
+  paymentMethod: "gems";
+  grantedAt: string;
+  status: "completed";
+}
+
+export interface PlayerPurchaseHistoryQuery {
+  from?: string;
+  to?: string;
+  itemId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PlayerPurchaseHistorySnapshot {
+  items: PlayerPurchaseHistoryRecord[];
+  total: number;
+  limit: number;
+  offset: number;
 }
 
 export interface PlayerRoomProfileListOptions {
@@ -4229,6 +4263,20 @@ function toShopPurchaseResult(row: ShopPurchaseRow): ShopPurchaseResult {
   };
 }
 
+function toPlayerPurchaseHistoryRecord(row: ShopPurchaseRow): PlayerPurchaseHistoryRecord {
+  const result = toShopPurchaseResult(row);
+  return {
+    purchaseId: result.purchaseId,
+    itemId: result.productId,
+    quantity: result.quantity,
+    currency: "gems",
+    amount: result.totalPrice,
+    paymentMethod: "gems",
+    grantedAt: result.processedAt,
+    status: "completed"
+  };
+}
+
 function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
   const lastSeenAt = formatTimestamp(row.last_seen_at);
   const banExpiry = formatTimestamp(row.ban_expiry);
@@ -6241,6 +6289,77 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     );
 
     return rows.map((row) => toPlayerCompensationRecord(row));
+  }
+
+  async listPlayerPurchaseHistory(
+    playerId: string,
+    query: PlayerPurchaseHistoryQuery = {}
+  ): Promise<PlayerPurchaseHistorySnapshot> {
+    const normalizedPlayerId = normalizePlayerId(playerId);
+    const safeLimit = Math.max(1, Math.floor(query.limit ?? 20));
+    const safeOffset = Math.max(0, Math.floor(query.offset ?? 0));
+    const filters = ["player_id = ?"];
+    const filterParams: Array<string | number | Date> = [normalizedPlayerId];
+
+    if (query.from) {
+      const fromDate = new Date(query.from);
+      if (Number.isNaN(fromDate.getTime())) {
+        throw new Error("from must be a valid ISO timestamp");
+      }
+      filters.push("created_at >= ?");
+      filterParams.push(fromDate);
+    }
+
+    if (query.to) {
+      const toDate = new Date(query.to);
+      if (Number.isNaN(toDate.getTime())) {
+        throw new Error("to must be a valid ISO timestamp");
+      }
+      filters.push("created_at <= ?");
+      filterParams.push(toDate);
+    }
+
+    if (query.from && query.to && new Date(query.from).getTime() > new Date(query.to).getTime()) {
+      throw new Error("from must be earlier than or equal to to");
+    }
+
+    if (query.itemId?.trim()) {
+      filters.push("product_id = ?");
+      filterParams.push(normalizeShopProductId(query.itemId));
+    }
+
+    const whereClause = filters.join(" AND ");
+    const [countRows] = await this.pool.query<CountRow[]>(
+      `SELECT COUNT(*) AS total
+       FROM \`${MYSQL_SHOP_PURCHASE_TABLE}\`
+       WHERE ${whereClause}`,
+      filterParams
+    );
+
+    const [rows] = await this.pool.query<ShopPurchaseRow[]>(
+      `SELECT
+         player_id,
+         purchase_id,
+         product_id,
+         quantity,
+         unit_price,
+         total_price,
+         result_json,
+         created_at
+       FROM \`${MYSQL_SHOP_PURCHASE_TABLE}\`
+       WHERE ${whereClause}
+       ORDER BY created_at DESC, purchase_id DESC
+       LIMIT ?
+       OFFSET ?`,
+      [...filterParams, safeLimit, safeOffset]
+    );
+
+    return {
+      items: rows.map((row) => toPlayerPurchaseHistoryRecord(row)),
+      total: Math.max(0, Math.floor(countRows[0]?.total ?? 0)),
+      limit: safeLimit,
+      offset: safeOffset
+    };
   }
 
   async listPlayerNameHistory(

--- a/apps/server/src/shop.ts
+++ b/apps/server/src/shop.ts
@@ -36,6 +36,7 @@ export interface ShopProduct {
 
 interface ShopConfigDocument {
   products?: Partial<ShopProduct>[] | null;
+  purchaseControls?: Partial<ShopPurchaseControlsConfigDocument> | null;
 }
 
 interface ShopProductsResponse {
@@ -43,8 +44,23 @@ interface ShopProductsResponse {
   rotation: ShopRotation;
 }
 
+interface ShopPurchaseControlsConfigDocument {
+  limitTimezone?: string | null;
+  dailyGemSpendCap?: number | null;
+  highValuePurchaseThreshold?: number | null;
+  perItemDailyQuantityLimits?: Record<string, number | null> | null;
+}
+
+export interface ShopPurchaseControls {
+  limitTimezone: string;
+  dailyGemSpendCap: number;
+  highValuePurchaseThreshold: number;
+  perItemDailyQuantityLimits: Record<string, number>;
+}
+
 export interface RegisterShopRoutesOptions {
   products?: Partial<ShopProduct>[];
+  purchaseControls?: Partial<ShopPurchaseControlsConfigDocument>;
 }
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -57,6 +73,16 @@ class PayloadTooLargeError extends Error {
   constructor(maxBytes: number) {
     super(`Request body exceeds ${maxBytes} bytes`);
     this.name = "payload_too_large";
+  }
+}
+
+class PurchaseLimitExceededError extends Error {
+  constructor(
+    readonly limitType: "daily_gem_spend_cap" | "daily_item_quantity_limit",
+    readonly resetAt: string
+  ) {
+    super(`Purchase limit exceeded: ${limitType}`);
+    this.name = "purchase_limit_exceeded";
   }
 }
 
@@ -122,6 +148,10 @@ function normalizePositiveInteger(value: number, field: string, allowZero = fals
   return normalized;
 }
 
+function normalizeNonNegativeInteger(value: number, field: string): number {
+  return normalizePositiveInteger(value, field, true);
+}
+
 function normalizeResourceLedger(resources?: Partial<ResourceLedger> | null): ResourceLedger {
   return {
     gold: Math.max(0, Math.floor(resources?.gold ?? 0)),
@@ -151,6 +181,39 @@ function normalizeGrant(rawGrant?: ShopProductGrant | null): ShopProductGrant {
     ...(cosmeticIds.length > 0 ? { cosmeticIds } : {}),
     ...(rawGrant?.resources ? { resources: normalizeResourceLedger(rawGrant.resources) } : {}),
     ...(rawGrant?.seasonPassPremium === true ? { seasonPassPremium: true } : {})
+  };
+}
+
+function normalizeTimeZone(value?: string | null): string {
+  const normalized = value?.trim() || "UTC";
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: normalized }).format(new Date());
+  } catch {
+    throw new Error(`shop purchase controls limitTimezone is invalid: ${normalized}`);
+  }
+  return normalized;
+}
+
+function normalizePerItemDailyQuantityLimits(value?: Record<string, number | null> | null): Record<string, number> {
+  const entries = Object.entries(value ?? {}).flatMap(([productId, rawLimit]) => {
+    const normalizedProductId = productId.trim();
+    if (!normalizedProductId) {
+      return [];
+    }
+    return [[normalizedProductId, normalizeNonNegativeInteger(rawLimit ?? Number.NaN, `daily quantity limit for ${normalizedProductId}`)] as const];
+  });
+  return Object.fromEntries(entries);
+}
+
+function normalizePurchaseControls(rawControls?: Partial<ShopPurchaseControlsConfigDocument> | null): ShopPurchaseControls {
+  return {
+    limitTimezone: normalizeTimeZone(rawControls?.limitTimezone),
+    dailyGemSpendCap: normalizeNonNegativeInteger(rawControls?.dailyGemSpendCap ?? 0, "shop purchase controls dailyGemSpendCap"),
+    highValuePurchaseThreshold: normalizeNonNegativeInteger(
+      rawControls?.highValuePurchaseThreshold ?? 0,
+      "shop purchase controls highValuePurchaseThreshold"
+    ),
+    perItemDailyQuantityLimits: normalizePerItemDailyQuantityLimits(rawControls?.perItemDailyQuantityLimits)
   };
 }
 
@@ -220,6 +283,11 @@ function normalizeShopProducts(rawProducts?: Partial<ShopProduct>[] | null): Sho
 export function resolveShopProducts(options?: RegisterShopRoutesOptions): ShopProduct[] {
   const configuredProducts = options?.products ?? (shopConfigDocument as ShopConfigDocument).products;
   return normalizeShopProducts(configuredProducts);
+}
+
+export function resolveShopPurchaseControls(options?: RegisterShopRoutesOptions): ShopPurchaseControls {
+  const configuredControls = options?.purchaseControls ?? (shopConfigDocument as ShopConfigDocument).purchaseControls;
+  return normalizePurchaseControls(configuredControls);
 }
 
 function buildRotationProducts(rotation = resolveWeeklyShopRotation()): ShopProduct[] {
@@ -292,6 +360,107 @@ function findProductById(products: ShopProduct[], productId: string): ShopProduc
   return products.find((product) => product.productId === normalizedProductId) ?? null;
 }
 
+function hasPurchaseHistoryStore(
+  store: RoomSnapshotStore | null
+): store is RoomSnapshotStore &
+  Required<Pick<RoomSnapshotStore, "purchaseShopProduct" | "listPlayerPurchaseHistory">> {
+  return Boolean(store?.purchaseShopProduct && store.listPlayerPurchaseHistory);
+}
+
+function parseGmtOffsetMinutes(value: string): number {
+  if (value === "GMT") {
+    return 0;
+  }
+  const match = /^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/.exec(value);
+  if (!match) {
+    throw new Error(`Unsupported GMT offset format: ${value}`);
+  }
+  const sign = match[1] === "-" ? -1 : 1;
+  const hours = Number(match[2]);
+  const minutes = Number(match[3] ?? "0");
+  return sign * (hours * 60 + minutes);
+}
+
+function getTimeZoneOffsetMinutes(at: Date, timeZone: string): number {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "shortOffset",
+    hour: "2-digit"
+  });
+  const offsetPart = formatter.formatToParts(at).find((part) => part.type === "timeZoneName")?.value;
+  if (!offsetPart) {
+    throw new Error(`Unable to resolve timezone offset for ${timeZone}`);
+  }
+  return parseGmtOffsetMinutes(offsetPart);
+}
+
+function getDatePartsInTimeZone(at: Date, timeZone: string): { year: number; month: number; day: number } {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  });
+  const parts = formatter.formatToParts(at);
+  const year = Number(parts.find((part) => part.type === "year")?.value);
+  const month = Number(parts.find((part) => part.type === "month")?.value);
+  const day = Number(parts.find((part) => part.type === "day")?.value);
+  return { year, month, day };
+}
+
+function getUtcInstantForTimeZoneMidnight(year: number, month: number, day: number, timeZone: string): Date {
+  const guess = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  const offsetMinutes = getTimeZoneOffsetMinutes(guess, timeZone);
+  return new Date(guess.getTime() - offsetMinutes * 60_000);
+}
+
+function getCurrentPurchaseLimitWindow(referenceAt: Date, timeZone: string): { from: string; resetAt: string } {
+  const { year, month, day } = getDatePartsInTimeZone(referenceAt, timeZone);
+  const start = getUtcInstantForTimeZoneMidnight(year, month, day, timeZone);
+  const reset = getUtcInstantForTimeZoneMidnight(year, month, day + 1, timeZone);
+  return {
+    from: start.toISOString(),
+    resetAt: reset.toISOString()
+  };
+}
+
+async function enforcePurchaseLimits(input: {
+  store: RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPlayerPurchaseHistory">>;
+  playerId: string;
+  productId: string;
+  quantity: number;
+  totalPrice: number;
+  controls: ShopPurchaseControls;
+}): Promise<void> {
+  const itemLimit = input.controls.perItemDailyQuantityLimits[input.productId] ?? 0;
+  if (input.controls.dailyGemSpendCap <= 0 && itemLimit <= 0) {
+    return;
+  }
+
+  const window = getCurrentPurchaseLimitWindow(new Date(), input.controls.limitTimezone);
+  const history = await input.store.listPlayerPurchaseHistory(input.playerId, {
+    from: window.from,
+    limit: 10_000,
+    offset: 0
+  });
+
+  if (input.controls.dailyGemSpendCap > 0) {
+    const currentSpend = history.items.reduce((sum, item) => sum + item.amount, 0);
+    if (currentSpend + input.totalPrice > input.controls.dailyGemSpendCap) {
+      throw new PurchaseLimitExceededError("daily_gem_spend_cap", window.resetAt);
+    }
+  }
+
+  if (itemLimit > 0) {
+    const currentQuantity = history.items
+      .filter((item) => item.itemId === input.productId)
+      .reduce((sum, item) => sum + item.quantity, 0);
+    if (currentQuantity + input.quantity > itemLimit) {
+      throw new PurchaseLimitExceededError("daily_item_quantity_limit", window.resetAt);
+    }
+  }
+}
+
 export function registerShopRoutes(
   app: {
     use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
@@ -302,6 +471,7 @@ export function registerShopRoutes(
   options: RegisterShopRoutesOptions = {}
 ): void {
   const baseProducts = resolveShopProducts(options);
+  const purchaseControls = resolveShopPurchaseControls(options);
 
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
@@ -332,7 +502,7 @@ export function registerShopRoutes(
       return;
     }
 
-    if (!store?.purchaseShopProduct) {
+    if (!hasPurchaseHistoryStore(store)) {
       sendJson(response, 503, {
         error: {
           code: "shop_persistence_unavailable",
@@ -407,6 +577,15 @@ export function registerShopRoutes(
         productId: product.productId
       };
 
+      await enforcePurchaseLimits({
+        store,
+        playerId: authSession.playerId,
+        productId: product.productId,
+        quantity,
+        totalPrice: product.price * quantity,
+        controls: purchaseControls
+      });
+
       const result = await store.purchaseShopProduct(authSession.playerId, {
         purchaseId,
         productId: product.productId,
@@ -434,6 +613,23 @@ export function registerShopRoutes(
           totalPrice: result.totalPrice
         }
       });
+      if (
+        purchaseControls.highValuePurchaseThreshold > 0 &&
+        result.totalPrice >= purchaseControls.highValuePurchaseThreshold
+      ) {
+        emitAnalyticsEvent("purchase_high_value_alert", {
+          playerId: authSession.playerId,
+          payload: {
+            purchaseId: result.purchaseId,
+            productId: result.productId,
+            quantity: result.quantity,
+            totalPrice: result.totalPrice,
+            threshold: purchaseControls.highValuePurchaseThreshold,
+            paymentMethod: "gems",
+            status: "completed"
+          }
+        });
+      }
       sendJson(response, 200, result);
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
@@ -446,6 +642,18 @@ export function registerShopRoutes(
           error: {
             code: "invalid_json",
             message: "Request body must be valid JSON"
+          }
+        });
+        return;
+      }
+
+      if (error instanceof PurchaseLimitExceededError) {
+        sendJson(response, 429, {
+          error: {
+            code: error.name,
+            message: error.message,
+            limitType: error.limitType,
+            resetAt: error.resetAt
           }
         });
         return;

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -5,7 +5,7 @@ import { readFile } from "node:fs/promises";
 import { normalizeGuildState, type GuildState } from "../../../packages/shared/src/index";
 import { registerAdminRoutes } from "../src/admin-console";
 import { getActiveRoomInstances } from "../src/colyseus-room";
-import type { PlayerBanHistoryRecord, PlayerCompensationRecord, RoomSnapshotStore } from "../src/persistence";
+import type { PlayerBanHistoryRecord, PlayerCompensationRecord, PlayerPurchaseHistoryRecord, RoomSnapshotStore } from "../src/persistence";
 
 type RouteHandler = (request: any, response: ServerResponse) => void | Promise<void>;
 
@@ -144,6 +144,7 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
   );
   const banHistoryByPlayerId = new Map<string, PlayerBanHistoryRecord[]>();
   const compensationHistoryByPlayerId = new Map<string, PlayerCompensationRecord[]>();
+  const purchaseHistoryByPlayerId = new Map<string, PlayerPurchaseHistoryRecord[]>();
   const reports = new Map<string, {
     reportId: string;
     reporterId: string;
@@ -361,6 +362,28 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     async listPlayerCompensationHistory(playerId: string, options: { limit?: number } = {}) {
       return (compensationHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
     },
+    async listPlayerPurchaseHistory(
+      playerId: string,
+      query: { from?: string; to?: string; itemId?: string; limit?: number; offset?: number } = {}
+    ) {
+      const from = query.from ? new Date(query.from).getTime() : Number.NEGATIVE_INFINITY;
+      const to = query.to ? new Date(query.to).getTime() : Number.POSITIVE_INFINITY;
+      const limit = Math.max(1, Math.floor(query.limit ?? 20));
+      const offset = Math.max(0, Math.floor(query.offset ?? 0));
+      const items = (purchaseHistoryByPlayerId.get(playerId) ?? [])
+        .filter((item) => !query.itemId || item.itemId === query.itemId)
+        .filter((item) => {
+          const grantedAt = new Date(item.grantedAt).getTime();
+          return grantedAt >= from && grantedAt <= to;
+        })
+        .sort((left, right) => right.grantedAt.localeCompare(left.grantedAt) || right.purchaseId.localeCompare(left.purchaseId));
+      return {
+        items: items.slice(offset, offset + limit),
+        total: items.length,
+        limit,
+        offset
+      };
+    },
     async savePlayerBan(playerId: string, input: { banStatus: "temporary" | "permanent"; banReason: string; banExpiry?: string }) {
       const account =
         (await this.loadPlayerAccount(playerId)) ??
@@ -411,6 +434,9 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     },
     async listBattleSnapshotsForPlayer(playerId: string, options: { limit?: number } = {}) {
       return (battleHistoryByPlayerId.get(playerId) ?? []).slice(0, Math.max(1, Math.floor(options.limit ?? 50)));
+    },
+    seedPurchaseHistory(playerId: string, items: PlayerPurchaseHistoryRecord[]) {
+      purchaseHistoryByPlayerId.set(playerId, items);
     },
     seedBattleHistory(
       playerId: string,
@@ -468,11 +494,13 @@ function createStore(initialResourcesByPlayer: Record<string, { gold: number; wo
     | "listPlayerBanHistory"
     | "appendPlayerCompensationRecord"
     | "listPlayerCompensationHistory"
+    | "listPlayerPurchaseHistory"
     | "listBattleSnapshotsForPlayer"
     | "listPlayerReports"
     | "resolvePlayerReport"
   > & {
     saveCalls: Array<{ playerId: string; globalResources: { gold: number; wood: number; ore: number } }>;
+    seedPurchaseHistory(playerId: string, items: PlayerPurchaseHistoryRecord[]): void;
     seedBattleHistory(
       playerId: string,
       items: Array<{
@@ -942,6 +970,75 @@ test("GET /api/admin/players/:id/compensation/history returns compensation audit
   assert.equal(payload.items.length, 2);
   assert.equal(payload.items[0]?.reason, "Chargeback reversal");
   assert.equal(payload.items[1]?.reason, "Outage compensation");
+});
+
+test("GET /api/admin/players/:id/purchase-history returns filtered purchase audit records", async (t) => {
+  const secret = withAdminSecret(t);
+  const store = createStore();
+  store.seedPurchaseHistory("player-1", [
+    {
+      purchaseId: "purchase-3",
+      itemId: "starter-bundle",
+      quantity: 1,
+      currency: "gems",
+      amount: 30,
+      paymentMethod: "gems",
+      grantedAt: "2026-02-03T11:00:00.000Z",
+      status: "completed"
+    },
+    {
+      purchaseId: "purchase-2",
+      itemId: "starter-bundle",
+      quantity: 2,
+      currency: "gems",
+      amount: 60,
+      paymentMethod: "gems",
+      grantedAt: "2026-02-02T10:00:00.000Z",
+      status: "completed"
+    },
+    {
+      purchaseId: "purchase-1",
+      itemId: "sunforged-spear",
+      quantity: 1,
+      currency: "gems",
+      amount: 20,
+      paymentMethod: "gems",
+      grantedAt: "2026-01-30T08:00:00.000Z",
+      status: "completed"
+    }
+  ]);
+
+  const { gets } = registerRoutes(store as RoomSnapshotStore);
+  const handler = gets.get("/api/admin/players/:id/purchase-history");
+  assert.ok(handler);
+
+  const response = createResponse();
+  await handler(
+    createRequest({
+      params: { id: "player-1" },
+      headers: {
+        "x-veil-admin-secret": secret
+      },
+      url: "/api/admin/players/player-1/purchase-history?from=2026-02-01T00:00:00.000Z&to=2026-02-28T23:59:59.999Z&itemId=starter-bundle&limit=1&page=2"
+    }),
+    response
+  );
+
+  const payload = JSON.parse(response.body) as {
+    items: PlayerPurchaseHistoryRecord[];
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.page, 2);
+  assert.equal(payload.limit, 1);
+  assert.equal(payload.total, 2);
+  assert.equal(payload.totalPages, 2);
+  assert.equal(payload.items.length, 1);
+  assert.equal(payload.items[0]?.purchaseId, "purchase-2");
+  assert.equal(payload.items[0]?.itemId, "starter-bundle");
 });
 
 test("admin console html includes compensation form and history table", async () => {
@@ -1897,6 +1994,9 @@ test("GET /api/admin/leaderboard/moderation-queue paginates and filters by flag 
       freezeReason: "Manual hold"
     }
   });
+  (await store.loadPlayerAccount("player-queue-flagged"))!.updatedAt = "2026-04-12T10:00:00.000Z";
+  (await store.loadPlayerAccount("player-queue-watch"))!.updatedAt = "2026-04-12T09:00:00.000Z";
+  (await store.loadPlayerAccount("player-queue-frozen"))!.updatedAt = "2026-04-12T08:00:00.000Z";
   const { gets } = registerRoutes(store as RoomSnapshotStore);
   const handler = gets.get("/api/admin/leaderboard/moderation-queue");
   const filteredResponse = createResponse();

--- a/apps/server/test/shop-routes.test.ts
+++ b/apps/server/test/shop-routes.test.ts
@@ -66,9 +66,21 @@ function createShopWorldSnapshot(): RoomPersistenceSnapshot {
   };
 }
 
-async function startShopRouteServer(port: number, store: MemoryRoomSnapshotStore, products: Partial<ShopProduct>[]): Promise<Server> {
+async function startShopRouteServer(
+  port: number,
+  store: MemoryRoomSnapshotStore,
+  products: Partial<ShopProduct>[],
+  options: {
+    purchaseControls?: {
+      limitTimezone?: string;
+      dailyGemSpendCap?: number;
+      highValuePurchaseThreshold?: number;
+      perItemDailyQuantityLimits?: Record<string, number>;
+    };
+  } = {}
+): Promise<Server> {
   const transport = new WebSocketTransport();
-  registerShopRoutes(transport.getExpressApp() as never, store, { products });
+  registerShopRoutes(transport.getExpressApp() as never, store, { products, purchaseControls: options.purchaseControls });
   const server = new Server({ transport });
   await server.listen(port, "127.0.0.1");
   return server;
@@ -399,4 +411,184 @@ test("shop purchase rejects insufficient gems without debiting or granting", asy
   assert.deepEqual(archives[0]?.hero.loadout.inventory, []);
   assert.equal(purchaseFailedEvent?.payload.paymentMethod, "gems");
   assert.equal(purchaseFailedEvent?.payload.failureReason, "insufficient_gems");
+});
+
+test("shop purchase enforces the configured daily gem spend cap", async (t) => {
+  const port = 42510 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  await store.save("shop-room", createShopWorldSnapshot());
+  await store.creditGems("shop-player", 200, "purchase", "seed-gems");
+  const server = await startShopRouteServer(port, store, TEST_PRODUCTS, {
+    purchaseControls: {
+      limitTimezone: "UTC",
+      dailyGemSpendCap: 50,
+      highValuePurchaseThreshold: 0
+    }
+  });
+  const session = issueAccountAuthSession({
+    playerId: "shop-player",
+    displayName: "暮潮守望",
+    loginId: "shop-player"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstResponse = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "starter-bundle",
+      quantity: 1,
+      purchaseId: "purchase-cap-1"
+    })
+  });
+
+  const secondResponse = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "starter-bundle",
+      quantity: 1,
+      purchaseId: "purchase-cap-2"
+    })
+  });
+  const secondPayload = (await secondResponse.json()) as {
+    error: {
+      limitType: string;
+      resetAt: string;
+    };
+  };
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(secondResponse.status, 429);
+  assert.equal(secondPayload.error.limitType, "daily_gem_spend_cap");
+  assert.match(secondPayload.error.resetAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("shop purchase enforces configured per-item daily quantity limits", async (t) => {
+  const port = 42530 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  await store.save("shop-room", createShopWorldSnapshot());
+  await store.creditGems("shop-player", 200, "purchase", "seed-gems");
+  const server = await startShopRouteServer(port, store, TEST_PRODUCTS, {
+    purchaseControls: {
+      limitTimezone: "UTC",
+      dailyGemSpendCap: 0,
+      highValuePurchaseThreshold: 0,
+      perItemDailyQuantityLimits: {
+        "starter-bundle": 2
+      }
+    }
+  });
+  const session = issueAccountAuthSession({
+    playerId: "shop-player",
+    displayName: "暮潮守望",
+    loginId: "shop-player"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const firstResponse = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "starter-bundle",
+      quantity: 2,
+      purchaseId: "purchase-item-limit-1"
+    })
+  });
+
+  const secondResponse = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "starter-bundle",
+      quantity: 1,
+      purchaseId: "purchase-item-limit-2"
+    })
+  });
+  const secondPayload = (await secondResponse.json()) as {
+    error: {
+      limitType: string;
+      resetAt: string;
+    };
+  };
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(secondResponse.status, 429);
+  assert.equal(secondPayload.error.limitType, "daily_item_quantity_limit");
+  assert.match(secondPayload.error.resetAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("shop purchase emits a high-value alert analytics event when configured", async (t) => {
+  const port = 42550 + Math.floor(Math.random() * 1000);
+  const store = new MemoryRoomSnapshotStore();
+  const analyticsLogs: string[] = [];
+  configureAnalyticsRuntimeDependencies({
+    log: (message) => {
+      analyticsLogs.push(message);
+    }
+  });
+  await store.save("shop-room", createShopWorldSnapshot());
+  await store.creditGems("shop-player", 200, "purchase", "seed-gems");
+  const server = await startShopRouteServer(port, store, TEST_PRODUCTS, {
+    purchaseControls: {
+      limitTimezone: "UTC",
+      dailyGemSpendCap: 0,
+      highValuePurchaseThreshold: 100
+    }
+  });
+  const session = issueAccountAuthSession({
+    playerId: "shop-player",
+    displayName: "暮潮守望",
+    loginId: "shop-player"
+  });
+
+  t.after(async () => {
+    resetAnalyticsRuntimeDependencies();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const response = await fetch(`http://127.0.0.1:${port}/api/shop/purchase`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session.token}`
+    },
+    body: JSON.stringify({
+      productId: "starter-bundle",
+      quantity: 4,
+      purchaseId: "purchase-high-value-1"
+    })
+  });
+
+  await flushAnalyticsEventsForTest({ ANALYTICS_SINK: "stdout" });
+  const analyticsEvents = analyticsLogs
+    .filter((entry) => entry.startsWith("[Analytics] {"))
+    .map((entry) => JSON.parse(entry.slice("[Analytics] ".length)) as { events: Array<{ name: string; payload: Record<string, unknown> }> })
+    .flatMap((entry) => entry.events);
+  const alertEvent = analyticsEvents.find(
+    (event) => event.name === "purchase_high_value_alert" && event.payload.purchaseId === "purchase-high-value-1"
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(alertEvent?.payload.productId, "starter-bundle");
+  assert.equal(alertEvent?.payload.totalPrice, 120);
+  assert.equal(alertEvent?.payload.threshold, 100);
 });

--- a/configs/shop-config.json
+++ b/configs/shop-config.json
@@ -1,4 +1,12 @@
 {
+  "purchaseControls": {
+    "limitTimezone": "UTC",
+    "dailyGemSpendCap": 0,
+    "highValuePurchaseThreshold": 100,
+    "perItemDailyQuantityLimits": {
+      "season-pass-premium": 1
+    }
+  },
   "products": [
     {
       "productId": "resource-bundle-starter",

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -106,6 +106,20 @@ export const ANALYTICS_EVENT_CATALOG = {
       orderStatus: "grant_pending"
     }
   ),
+  purchase_high_value_alert: defineAnalyticsEvent(
+    "purchase_high_value_alert",
+    1,
+    "High-value shop purchase exceeded the configured review threshold.",
+    {
+      purchaseId: "purchase-1",
+      productId: "gem_pack_small",
+      quantity: 1,
+      totalPrice: 600,
+      threshold: 500,
+      paymentMethod: "gems",
+      status: "completed"
+    }
+  ),
   purchase: defineAnalyticsEvent("purchase", 1, "Shop purchase completed successfully.", {
     purchaseId: "purchase-1",
     productId: "gem_pack_small",


### PR DESCRIPTION
Closes #1379.

## Summary
- add config-driven shop purchase controls for daily gem spend caps, per-item daily quantity limits, timezone-aware reset windows, and high-value purchase alerting
- add purchase-history query support in memory/MySQL persistence plus a new admin player purchase-history endpoint
- add focused server tests for purchase limit enforcement, high-value alert analytics, and admin purchase-history filtering

## Validation
- node --import tsx --test ./apps/server/test/shop-routes.test.ts ./apps/server/test/admin-console.test.ts
- npm run typecheck:server
