### PR TITLE
[codex] Add Colyseus cosmetic buy/equip handlers

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -16,6 +16,7 @@ import {
   planPlayerViewMovement,
   validateWorldAction,
   resolveCosmeticCatalog,
+  normalizeCosmeticInventory,
   type ActionValidationFailure,
   type PlayerWorldView,
   type PlayerBattleReplaySummary,
@@ -45,6 +46,7 @@ import { didPlayerWinBattle, resolveBattlePassConfig } from "./battle-pass";
 import {
   applyPlayerAccountsToWorldState,
   applyPlayerHeroArchivesToWorldState,
+  equipOwnedCosmetic,
   isPlayerBanActive,
   type RoomSnapshotStore,
   type PlayerAccountSnapshot,
@@ -1150,6 +1152,107 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
         action: "emote",
         ...(account.equippedCosmetics ? { equippedCosmetics: account.equippedCosmetics } : {})
       });
+    });
+
+    this.onMessage("BUY_COSMETIC", async (client, message: Extract<ClientMessage, { type: "BUY_COSMETIC" }>) => {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "not_connected" });
+        return;
+      }
+      if (!configuredRoomSnapshotStore?.purchaseShopProduct) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "cosmetics_unavailable" });
+        return;
+      }
+
+      const cosmeticId = message.cosmeticId.trim();
+      const definition = resolveCosmeticCatalog().find((entry) => entry.id === cosmeticId);
+      if (!definition) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "cosmetic_not_found" });
+        return;
+      }
+
+      try {
+        await configuredRoomSnapshotStore.purchaseShopProduct(playerId, {
+          purchaseId: `ws:${this.metadata.logicalRoomId}:${message.requestId}`,
+          productId: `cosmetic:${cosmeticId}`,
+          productName: definition.name,
+          quantity: 1,
+          unitPrice: definition.price,
+          grant: {
+            cosmeticIds: [cosmeticId]
+          }
+        });
+
+        sendMessage(client, "COSMETIC_APPLIED", {
+          requestId: message.requestId,
+          delivery: "reply",
+          playerId,
+          cosmeticId,
+          action: "purchased"
+        });
+        this.broadcastCosmeticApplied(client, {
+          playerId,
+          cosmeticId,
+          action: "purchased"
+        });
+      } catch (error) {
+        const reason =
+          error instanceof Error
+            ? error.message === "insufficient gems"
+              ? "insufficient_gems"
+              : "cosmetics_unavailable"
+            : "cosmetics_unavailable";
+        sendMessage(client, "error", { requestId: message.requestId, reason });
+      }
+    });
+
+    this.onMessage("EQUIP_COSMETIC", async (client, message: Extract<ClientMessage, { type: "EQUIP_COSMETIC" }>) => {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "not_connected" });
+        return;
+      }
+      if (!configuredRoomSnapshotStore?.loadPlayerAccount || !configuredRoomSnapshotStore.savePlayerAccountProgress) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "cosmetics_unavailable" });
+        return;
+      }
+
+      try {
+        const account = await configuredRoomSnapshotStore.loadPlayerAccount(playerId);
+        if (!account) {
+          sendMessage(client, "error", { requestId: message.requestId, reason: "player_account_not_found" });
+          return;
+        }
+
+        const cosmeticId = message.cosmeticId.trim();
+        const equippedCosmetics = equipOwnedCosmetic(account, cosmeticId);
+        const nextAccount = await configuredRoomSnapshotStore.savePlayerAccountProgress(playerId, {
+          cosmeticInventory: normalizeCosmeticInventory(account.cosmeticInventory),
+          equippedCosmetics
+        });
+
+        sendMessage(client, "COSMETIC_APPLIED", {
+          requestId: message.requestId,
+          delivery: "reply",
+          playerId,
+          cosmeticId,
+          action: "equipped",
+          ...(nextAccount.equippedCosmetics ? { equippedCosmetics: nextAccount.equippedCosmetics } : {})
+        });
+        this.broadcastCosmeticApplied(client, {
+          playerId,
+          cosmeticId,
+          action: "equipped",
+          ...(nextAccount.equippedCosmetics ? { equippedCosmetics: nextAccount.equippedCosmetics } : {})
+        });
+      } catch (error) {
+        const reason =
+          error instanceof Error && (error.message === "cosmetic_not_found" || error.message === "cosmetic_not_owned")
+            ? error.message
+            : "cosmetics_unavailable";
+        sendMessage(client, "error", { requestId: message.requestId, reason });
+      }
     });
   }
 

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -2803,6 +2803,286 @@ test("room battle emotes reply to the sender and broadcast to other participants
   );
 });
 
+test("room cosmetic purchases reply, broadcast, and persist the unlocked cosmetic", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-buy-cosmetic-${Date.now()}`);
+  const buyerClient = createFakeClient("session-buy-cosmetic-owner");
+  const watcherClient = createFakeClient("session-buy-cosmetic-watcher");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, buyerClient, "player-1", "connect-buy-cosmetic-owner");
+  await connectPlayer(room, watcherClient, "player-2", "connect-buy-cosmetic-watcher");
+  await store.savePlayerAccountProgress("player-1", {
+    gems: 100
+  });
+
+  await emitRoomMessage(room, "BUY_COSMETIC", buyerClient, {
+    type: "BUY_COSMETIC",
+    requestId: "buy-cosmetic-1",
+    cosmeticId: "border-vanguard"
+  });
+
+  assert.equal(
+    buyerClient.sent.some(
+      (message) =>
+        message.type === "COSMETIC_APPLIED" &&
+        message.requestId === "buy-cosmetic-1" &&
+        message.delivery === "reply" &&
+        message.playerId === "player-1" &&
+        message.cosmeticId === "border-vanguard" &&
+        message.action === "purchased"
+    ),
+    true
+  );
+  assert.equal(
+    watcherClient.sent.some(
+      (message) =>
+        message.type === "COSMETIC_APPLIED" &&
+        message.requestId === "push" &&
+        message.delivery === "push" &&
+        message.playerId === "player-1" &&
+        message.cosmeticId === "border-vanguard" &&
+        message.action === "purchased"
+    ),
+    true
+  );
+
+  const account = await store.loadPlayerAccount("player-1");
+  assert.equal(account?.gems, 70);
+  assert.deepEqual(account?.cosmeticInventory?.ownedIds, ["border-vanguard"]);
+});
+
+test("room cosmetic purchases return insufficient_gems when the player cannot afford the cosmetic", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-buy-cosmetic-insufficient-${Date.now()}`);
+  const buyerClient = createFakeClient("session-buy-cosmetic-insufficient");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, buyerClient, "player-1", "connect-buy-cosmetic-insufficient");
+  await store.savePlayerAccountProgress("player-1", {
+    gems: 5
+  });
+
+  await emitRoomMessage(room, "BUY_COSMETIC", buyerClient, {
+    type: "BUY_COSMETIC",
+    requestId: "buy-cosmetic-insufficient",
+    cosmeticId: "border-vanguard"
+  });
+
+  assert.equal(
+    buyerClient.sent.some(
+      (message) =>
+        message.type === "error" &&
+        message.requestId === "buy-cosmetic-insufficient" &&
+        message.reason === "insufficient_gems"
+    ),
+    true
+  );
+
+  const account = await store.loadPlayerAccount("player-1");
+  assert.equal(account?.gems, 5);
+  assert.deepEqual(account?.cosmeticInventory?.ownedIds ?? [], []);
+});
+
+test("room cosmetic handlers return cosmetics_unavailable when cosmetic persistence is not configured", async (t) => {
+  resetLobbyRoomRegistry();
+  configureRoomSnapshotStore(null);
+  const room = await createTestRoom(`lifecycle-cosmetics-unavailable-${Date.now()}`);
+  const client = createFakeClient("session-cosmetics-unavailable");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, client, "player-1", "connect-cosmetics-unavailable");
+
+  await emitRoomMessage(room, "BUY_COSMETIC", client, {
+    type: "BUY_COSMETIC",
+    requestId: "buy-cosmetics-unavailable",
+    cosmeticId: "border-vanguard"
+  });
+  await emitRoomMessage(room, "EQUIP_COSMETIC", client, {
+    type: "EQUIP_COSMETIC",
+    requestId: "equip-cosmetics-unavailable",
+    cosmeticId: "border-vanguard"
+  });
+
+  assert.equal(
+    client.sent.some(
+      (message) =>
+        message.type === "error" &&
+        message.requestId === "buy-cosmetics-unavailable" &&
+        message.reason === "cosmetics_unavailable"
+    ),
+    true
+  );
+  assert.equal(
+    client.sent.some(
+      (message) =>
+        message.type === "error" &&
+        message.requestId === "equip-cosmetics-unavailable" &&
+        message.reason === "cosmetics_unavailable"
+    ),
+    true
+  );
+});
+
+test("room cosmetic handlers return cosmetic_not_found for unknown cosmetics", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-cosmetic-not-found-${Date.now()}`);
+  const client = createFakeClient("session-cosmetic-not-found");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, client, "player-1", "connect-cosmetic-not-found");
+  await store.savePlayerAccountProgress("player-1", {
+    gems: 100
+  });
+
+  await emitRoomMessage(room, "BUY_COSMETIC", client, {
+    type: "BUY_COSMETIC",
+    requestId: "buy-cosmetic-not-found",
+    cosmeticId: "missing-cosmetic"
+  });
+  await emitRoomMessage(room, "EQUIP_COSMETIC", client, {
+    type: "EQUIP_COSMETIC",
+    requestId: "equip-cosmetic-not-found",
+    cosmeticId: "missing-cosmetic"
+  });
+
+  assert.equal(
+    client.sent.some(
+      (message) =>
+        message.type === "error" &&
+        message.requestId === "buy-cosmetic-not-found" &&
+        message.reason === "cosmetic_not_found"
+    ),
+    true
+  );
+  assert.equal(
+    client.sent.some(
+      (message) =>
+        message.type === "error" &&
+        message.requestId === "equip-cosmetic-not-found" &&
+        message.reason === "cosmetic_not_found"
+    ),
+    true
+  );
+});
+
+test("room cosmetic equips reply, broadcast, and persist equipped cosmetics", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-equip-cosmetic-${Date.now()}`);
+  const equipClient = createFakeClient("session-equip-cosmetic-owner");
+  const watcherClient = createFakeClient("session-equip-cosmetic-watcher");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, equipClient, "player-1", "connect-equip-cosmetic-owner");
+  await connectPlayer(room, watcherClient, "player-2", "connect-equip-cosmetic-watcher");
+  await store.savePlayerAccountProgress("player-1", {
+    cosmeticInventory: {
+      ownedIds: ["border-vanguard"]
+    }
+  });
+
+  await emitRoomMessage(room, "EQUIP_COSMETIC", equipClient, {
+    type: "EQUIP_COSMETIC",
+    requestId: "equip-cosmetic-1",
+    cosmeticId: "border-vanguard"
+  });
+
+  assert.equal(
+    equipClient.sent.some(
+      (message) =>
+        message.type === "COSMETIC_APPLIED" &&
+        message.requestId === "equip-cosmetic-1" &&
+        message.delivery === "reply" &&
+        message.playerId === "player-1" &&
+        message.cosmeticId === "border-vanguard" &&
+        message.action === "equipped" &&
+        message.equippedCosmetics?.profileBorderId === "border-vanguard"
+    ),
+    true
+  );
+  assert.equal(
+    watcherClient.sent.some(
+      (message) =>
+        message.type === "COSMETIC_APPLIED" &&
+        message.requestId === "push" &&
+        message.delivery === "push" &&
+        message.playerId === "player-1" &&
+        message.cosmeticId === "border-vanguard" &&
+        message.action === "equipped" &&
+        message.equippedCosmetics?.profileBorderId === "border-vanguard"
+    ),
+    true
+  );
+
+  const account = await store.loadPlayerAccount("player-1");
+  assert.equal(account?.equippedCosmetics?.profileBorderId, "border-vanguard");
+});
+
+test("room cosmetic equips return cosmetic_not_owned when the cosmetic is not unlocked", async (t) => {
+  resetLobbyRoomRegistry();
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+  const room = await createTestRoom(`lifecycle-equip-cosmetic-not-owned-${Date.now()}`);
+  const equipClient = createFakeClient("session-equip-cosmetic-not-owned");
+
+  t.after(() => {
+    cleanupRoom(room);
+    resetLobbyRoomRegistry();
+    configureRoomSnapshotStore(null);
+  });
+
+  await connectPlayer(room, equipClient, "player-1", "connect-equip-cosmetic-not-owned");
+
+  await emitRoomMessage(room, "EQUIP_COSMETIC", equipClient, {
+    type: "EQUIP_COSMETIC",
+    requestId: "equip-cosmetic-not-owned",
+    cosmeticId: "border-vanguard"
+  });
+
+  assert.equal(
+    equipClient.sent.some(
+      (message) =>
+        message.type === "error" &&
+        message.requestId === "equip-cosmetic-not-owned" &&
+        message.reason === "cosmetic_not_owned"
+    ),
+    true
+  );
+});
+
 test("room at maxClients capacity rejects a new join reservation", async (t) => {
   resetLobbyRoomRegistry();
   configureRoomSnapshotStore(null);


### PR DESCRIPTION
## Summary
- add Colyseus room handlers for `BUY_COSMETIC` and `EQUIP_COSMETIC`
- validate cosmetic existence, ownership, persistence availability, and gem balance with websocket error replies
- persist cosmetic purchases/equips and broadcast `COSMETIC_APPLIED` acknowledgements to the room
- add focused lifecycle tests for purchase/equip success paths and websocket error branches

## Validation
- `node --import tsx --test --test-name-pattern='room cosmetic|room battle emotes' apps/server/test/colyseus-room-lifecycle.test.ts`
- `npm run typecheck:server`

Closes #1360.