### PR TITLE
[codex] Implement FRIEND_LEADERBOARD_REQUEST and SHARE_ACTIVITY handlers

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -17,6 +17,8 @@ import {
   validateWorldAction,
   resolveCosmeticCatalog,
   normalizeCosmeticInventory,
+  type FriendLeaderboardEntry,
+  type GroupChallenge,
   type ActionValidationFailure,
   type PlayerWorldView,
   type PlayerBattleReplaySummary,
@@ -73,6 +75,8 @@ import {
   recordReconnectWindowOpened,
   recordReconnectWindowResolved,
   recordRuntimeRoom,
+  recordSocialFriendLeaderboardRequest,
+  recordSocialShareActivityRequest,
   recordWebSocketActionKick,
   recordWebSocketActionRateLimited,
   recordWorldActionMessage,
@@ -83,8 +87,12 @@ import { resolveFeatureFlagsForPlayer } from "./feature-flags";
 import { captureServerError } from "./error-monitoring";
 import { settleLeaderboardMatch } from "./leaderboard-anti-abuse";
 import { normalizeTutorialProgressAction, toTutorialAnalyticsPayload } from "./tutorial-progress";
+import { buildFriendLeaderboard, createGroupChallenge, encodeGroupChallengeToken } from "./wechat-social";
+import { readRuntimeSecret } from "./runtime-secrets";
 
 type MessageOfType<T extends ServerMessage["type"]> = Omit<Extract<ServerMessage, { type: T }>, "type">;
+
+const DEFAULT_GROUP_CHALLENGE_SECRET = "project-veil-local-group-challenge-secret";
 
 interface VeilRoomMetadata {
   logicalRoomId: string;
@@ -1107,6 +1115,100 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
                 : "campaign_dialogue_ack_failed"
             : "campaign_dialogue_ack_failed";
         sendMessage(client, "error", { requestId: message.requestId, reason });
+      }
+    });
+
+    this.onMessage(
+      "FRIEND_LEADERBOARD_REQUEST",
+      async (client, message: Extract<ClientMessage, { type: "FRIEND_LEADERBOARD_REQUEST" }>) => {
+        const playerId = this.getPlayerId(client);
+        if (!playerId) {
+          sendMessage(client, "error", { requestId: message.requestId, reason: "not_connected" });
+          return;
+        }
+        if (!configuredRoomSnapshotStore) {
+          sendMessage(client, "error", { requestId: message.requestId, reason: "social_persistence_unavailable" });
+          return;
+        }
+
+        recordSocialFriendLeaderboardRequest();
+
+        try {
+          const authSession = this.authSessionByPlayerId.get(playerId);
+          await configuredRoomSnapshotStore.ensurePlayerAccount({
+            playerId,
+            displayName: authSession?.displayName ?? playerId,
+            lastRoomId: logicalRoomId
+          });
+          const friendIds = Array.from(new Set((message.friendIds ?? []).map((entry) => entry.trim()).filter(Boolean)));
+          const accounts = await configuredRoomSnapshotStore.loadPlayerAccounts([playerId, ...friendIds]);
+          const items = buildFriendLeaderboard(playerId, accounts);
+          this.logSocialMessage("friend_leaderboard_ready", {
+            playerId,
+            requestId: message.requestId,
+            friendCount: friendIds.length,
+            itemCount: items.length
+          });
+          sendMessage(client, "FRIEND_LEADERBOARD_REQUEST", {
+            requestId: message.requestId,
+            items,
+            friendCount: friendIds.length
+          });
+        } catch (error) {
+          this.reportSocialHandlerFailure("friend_leaderboard_failed", playerId, message.requestId, error, {
+            action: "FRIEND_LEADERBOARD_REQUEST"
+          });
+          sendMessage(client, "error", { requestId: message.requestId, reason: "friend_leaderboard_failed" });
+        }
+      }
+    );
+
+    this.onMessage("SHARE_ACTIVITY", async (client, message: Extract<ClientMessage, { type: "SHARE_ACTIVITY" }>) => {
+      const playerId = this.getPlayerId(client);
+      if (!playerId) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "not_connected" });
+        return;
+      }
+      if (!configuredRoomSnapshotStore) {
+        sendMessage(client, "error", { requestId: message.requestId, reason: "social_persistence_unavailable" });
+        return;
+      }
+
+      recordSocialShareActivityRequest();
+
+      try {
+        const authSession = this.authSessionByPlayerId.get(playerId);
+        const account =
+          (await configuredRoomSnapshotStore.loadPlayerAccount(playerId)) ??
+          (await configuredRoomSnapshotStore.ensurePlayerAccount({
+            playerId,
+            displayName: authSession?.displayName ?? playerId,
+            lastRoomId: logicalRoomId
+          }));
+        const roomId = message.roomId?.trim() || logicalRoomId;
+        const reply = this.buildShareActivityReply({
+          playerId,
+          roomId,
+          accountDisplayName: account.displayName,
+          message
+        });
+        this.logSocialMessage("share_activity_ready", {
+          playerId,
+          requestId: message.requestId,
+          activity: message.activity,
+          roomId,
+          hasChallengeToken: Boolean(reply.challengeToken)
+        });
+        sendMessage(client, "SHARE_ACTIVITY", {
+          requestId: message.requestId,
+          ...reply
+        });
+      } catch (error) {
+        this.reportSocialHandlerFailure("share_activity_failed", playerId, message.requestId, error, {
+          action: "SHARE_ACTIVITY",
+          activity: message.activity
+        });
+        sendMessage(client, "error", { requestId: message.requestId, reason: "share_activity_failed" });
       }
     });
 
@@ -2770,6 +2872,128 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
     }
 
     return playerId;
+  }
+
+  private readGroupChallengeSecret(): string {
+    return readRuntimeSecret("VEIL_WECHAT_GROUP_CHALLENGE_SECRET") || DEFAULT_GROUP_CHALLENGE_SECRET;
+  }
+
+  private buildShareActivityReply(input: {
+    playerId: string;
+    roomId: string;
+    accountDisplayName?: string | null;
+    message: Extract<ClientMessage, { type: "SHARE_ACTIVITY" }>;
+  }): Omit<Extract<ServerMessage, { type: "SHARE_ACTIVITY" }>, "type" | "requestId"> {
+    if (input.message.activity === "group_challenge") {
+      const challenge =
+        input.message.challengeToken?.trim()
+          ? null
+          : createGroupChallenge({
+              creatorPlayerId: input.playerId,
+              creatorDisplayName: input.accountDisplayName ?? input.playerId,
+              roomId: input.roomId,
+              challengeType: "victory"
+            });
+      const challengeToken =
+        input.message.challengeToken?.trim()
+        || (challenge ? encodeGroupChallengeToken(challenge, this.readGroupChallengeSecret()) : undefined);
+      const shareUrl = this.buildSocialShareUrl({
+        roomId: input.roomId,
+        inviterId: input.playerId,
+        shareScene: "lobby",
+        ...(challengeToken ? { challengeToken } : {})
+      });
+
+      return {
+        activity: input.message.activity,
+        roomId: input.roomId,
+        shareUrl,
+        shareMessage: `${input.accountDisplayName?.trim() || input.playerId} 发起了组队挑战。`,
+        ...(challenge ? { challenge } : {}),
+        ...(challengeToken ? { challengeToken } : {})
+      };
+    }
+
+    return {
+      activity: input.message.activity,
+      roomId: input.roomId,
+      shareUrl: this.buildSocialShareUrl({
+        roomId: input.roomId,
+        referrer: input.playerId,
+        shareScene: "battle"
+      }),
+      shareMessage: `${input.accountDisplayName?.trim() || input.playerId} 分享了一场胜利战报。`
+    };
+  }
+
+  private buildSocialShareUrl(query: Record<string, string>): string {
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      const normalized = value.trim();
+      if (normalized) {
+        searchParams.set(key, normalized);
+      }
+    }
+
+    const serialized = searchParams.toString();
+    return serialized ? `?${serialized}` : "?";
+  }
+
+  private logSocialMessage(
+    event: "friend_leaderboard_ready" | "share_activity_ready",
+    detail: Record<string, string | number | boolean | null>
+  ): void {
+    console.info("[VeilRoom] Social handler processed", {
+      roomId: this.metadata.logicalRoomId,
+      event,
+      ...detail
+    });
+  }
+
+  private reportSocialHandlerFailure(
+    errorCode: "friend_leaderboard_failed" | "share_activity_failed",
+    playerId: string,
+    requestId: string,
+    error: unknown,
+    extras: Record<string, string | number | boolean | null> = {}
+  ): void {
+    const detail = Object.entries(extras)
+      .filter(([, value]) => value != null)
+      .map(([key, value]) => `${key}=${String(value)}`)
+      .join(" ");
+
+    console.error("[VeilRoom] Social handler failed", {
+      roomId: this.metadata.logicalRoomId,
+      playerId,
+      requestId,
+      errorCode,
+      extras,
+      error
+    });
+
+    recordRuntimeErrorEvent({
+      id: `${this.metadata.logicalRoomId}:${playerId}:${requestId}:${errorCode}`,
+      recordedAt: new Date().toISOString(),
+      source: "server",
+      surface: "colyseus-room",
+      candidateRevision: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || "workspace",
+      featureArea: "runtime",
+      ownerArea: "multiplayer",
+      severity: "error",
+      errorCode,
+      message: "Social websocket handler failed.",
+      tags: ["social", errorCode],
+      context: {
+        roomId: this.metadata.logicalRoomId,
+        playerId,
+        requestId,
+        route: null,
+        action: errorCode,
+        statusCode: null,
+        crash: false,
+        detail: detail || (error instanceof Error ? error.message : String(error))
+      }
+    });
   }
 
   private updatePlayerAuthSession(playerId: string, authSession: GuestAuthSession | null): void {

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -37,6 +37,8 @@ interface RuntimeObservabilityCounters {
   battleActionsTotal: number;
   websocketActionRateLimitedTotal: number;
   websocketActionKickTotal: number;
+  socialFriendLeaderboardRequestsTotal: number;
+  socialShareActivityRequestsTotal: number;
 }
 
 interface AuthObservabilityCounters {
@@ -245,13 +247,15 @@ interface RuntimeHealthPayload {
     activeBattleCount: number;
     heroCount: number;
     gameplayTraffic: {
-        connectMessagesTotal: number;
-        worldActionsTotal: number;
-        battleActionsTotal: number;
-        actionMessagesTotal: number;
-        websocketActionRateLimitedTotal: number;
-        websocketActionKickTotal: number;
-      };
+      connectMessagesTotal: number;
+      worldActionsTotal: number;
+      battleActionsTotal: number;
+      actionMessagesTotal: number;
+      websocketActionRateLimitedTotal: number;
+      websocketActionKickTotal: number;
+      socialFriendLeaderboardRequestsTotal: number;
+      socialShareActivityRequestsTotal: number;
+    };
     auth: {
       reconnect: {
         pendingWindowCount: number;
@@ -395,7 +399,9 @@ const runtimeObservability: RuntimeObservabilityState = {
     worldActionsTotal: 0,
     battleActionsTotal: 0,
     websocketActionRateLimitedTotal: 0,
-    websocketActionKickTotal: 0
+    websocketActionKickTotal: 0,
+    socialFriendLeaderboardRequestsTotal: 0,
+    socialShareActivityRequestsTotal: 0
   },
   prometheus: {
     dbBackupLastSuccessTimestamp: null,
@@ -616,7 +622,9 @@ function buildHealthPayload(
         battleActionsTotal: runtimeObservability.counters.battleActionsTotal,
         actionMessagesTotal,
         websocketActionRateLimitedTotal: runtimeObservability.counters.websocketActionRateLimitedTotal,
-        websocketActionKickTotal: runtimeObservability.counters.websocketActionKickTotal
+        websocketActionKickTotal: runtimeObservability.counters.websocketActionKickTotal,
+        socialFriendLeaderboardRequestsTotal: runtimeObservability.counters.socialFriendLeaderboardRequestsTotal,
+        socialShareActivityRequestsTotal: runtimeObservability.counters.socialShareActivityRequestsTotal
       },
       auth: {
         reconnect: {
@@ -881,6 +889,7 @@ function buildRuntimeDiagnosticSnapshot(service = "project-veil-server"): Runtim
         `service ${service} rooms=${health.runtime.activeRoomCount} connections=${health.runtime.connectionCount}`,
         `traffic connect=${health.runtime.gameplayTraffic.connectMessagesTotal} world=${health.runtime.gameplayTraffic.worldActionsTotal} battle=${health.runtime.gameplayTraffic.battleActionsTotal}`,
         `ws_action_rate_limit violations=${health.runtime.gameplayTraffic.websocketActionRateLimitedTotal} kicks=${health.runtime.gameplayTraffic.websocketActionKickTotal}`,
+        `social friend_leaderboard=${health.runtime.gameplayTraffic.socialFriendLeaderboardRequestsTotal} share_activity=${health.runtime.gameplayTraffic.socialShareActivityRequestsTotal}`,
         `auth guest=${health.runtime.auth.activeGuestSessionCount} account=${health.runtime.auth.activeAccountSessionCount} queue=${health.runtime.auth.tokenDelivery.queueCount} rateLimited=${health.runtime.auth.counters.rateLimitedTotal}`,
         `matchmaking rateLimited=${health.runtime.matchmaking.counters.rateLimitedTotal}`
       ],
@@ -1124,6 +1133,12 @@ export function buildPrometheusMetricsDocument(): string {
     "# HELP veil_ws_action_kicks_total Total client disconnects triggered by WebSocket action rate-limit violations.",
     "# TYPE veil_ws_action_kicks_total counter",
     `veil_ws_action_kicks_total ${health.runtime.gameplayTraffic.websocketActionKickTotal}`,
+    "# HELP veil_social_friend_leaderboard_requests_total Total friend leaderboard websocket requests processed.",
+    "# TYPE veil_social_friend_leaderboard_requests_total counter",
+    `veil_social_friend_leaderboard_requests_total ${health.runtime.gameplayTraffic.socialFriendLeaderboardRequestsTotal}`,
+    "# HELP veil_social_share_activity_requests_total Total share activity websocket requests processed.",
+    "# TYPE veil_social_share_activity_requests_total counter",
+    `veil_social_share_activity_requests_total ${health.runtime.gameplayTraffic.socialShareActivityRequestsTotal}`,
     "# HELP veil_reconnect_backlog_count Players currently waiting inside the Colyseus reconnection window.",
     "# TYPE veil_reconnect_backlog_count gauge",
     `veil_reconnect_backlog_count ${health.runtime.auth.reconnect.pendingWindowCount}`,
@@ -1765,6 +1780,14 @@ export function recordWebSocketActionRateLimited(): void {
 
 export function recordWebSocketActionKick(): void {
   runtimeObservability.counters.websocketActionKickTotal += 1;
+}
+
+export function recordSocialFriendLeaderboardRequest(): void {
+  runtimeObservability.counters.socialFriendLeaderboardRequestsTotal += 1;
+}
+
+export function recordSocialShareActivityRequest(): void {
+  runtimeObservability.counters.socialShareActivityRequestsTotal += 1;
 }
 
 export function setAuthGuestSessionCount(count: number): void {

--- a/apps/server/test/issue-1361-social-handlers.test.ts
+++ b/apps/server/test/issue-1361-social-handlers.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ClientState, matchMaker } from "colyseus";
+import type { Client as ColyseusClient } from "colyseus";
+import type { ServerMessage } from "../../../packages/shared/src/index";
+import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "../src/observability";
+import {
+  configureRoomSnapshotStore,
+  resetLobbyRoomRegistry,
+  resetRoomRuntimeDependencies,
+  VeilColyseusRoom
+} from "../src/colyseus-room";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+
+interface FakeClient extends ColyseusClient {
+  sent: ServerMessage[];
+  leaveCalls: Array<{ code?: number; reason?: string }>;
+}
+
+function createFakeClient(sessionId: string): FakeClient {
+  return {
+    sessionId,
+    state: ClientState.JOINED,
+    sent: [],
+    leaveCalls: [],
+    ref: {
+      removeAllListeners() {},
+      removeListener() {},
+      once() {}
+    },
+    send(type: string | number, payload?: unknown) {
+      this.sent.push({ type, ...(payload as object) } as ServerMessage);
+    },
+    leave(code?: number, reason?: string) {
+      this.leaveCalls.push({ code, reason });
+    },
+    enqueueRaw() {},
+    raw() {}
+  } as FakeClient;
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function createTestRoom(logicalRoomId: string, seed = 1001): Promise<VeilColyseusRoom> {
+  await matchMaker.setup(
+    undefined,
+    {
+      async update() {},
+      async remove() {},
+      async persist() {}
+    } as never,
+    "http://127.0.0.1"
+  );
+
+  const room = new VeilColyseusRoom();
+  const internalRoom = room as VeilColyseusRoom & {
+    __init(): void;
+    _listing: Record<string, unknown>;
+    _internalState: number;
+  };
+
+  internalRoom.roomId = logicalRoomId;
+  internalRoom.roomName = "veil";
+  internalRoom._listing = {
+    roomId: logicalRoomId,
+    clients: 0,
+    locked: false,
+    private: false,
+    unlisted: false,
+    metadata: {}
+  };
+
+  internalRoom.__init();
+  await room.onCreate({ logicalRoomId, seed });
+  internalRoom._internalState = 1;
+  return room;
+}
+
+function cleanupRoom(room: VeilColyseusRoom): void {
+  const internalRoom = room as VeilColyseusRoom & {
+    _autoDisposeTimeout?: NodeJS.Timeout;
+    _events: { emit(event: string): void };
+  };
+
+  if (internalRoom._autoDisposeTimeout) {
+    clearTimeout(internalRoom._autoDisposeTimeout);
+    internalRoom._autoDisposeTimeout = undefined;
+  }
+
+  internalRoom._events.emit("dispose");
+  room.clock.clear();
+  room.clock.stop();
+}
+
+async function emitRoomMessage(room: VeilColyseusRoom, type: string, client: FakeClient, payload: object): Promise<void> {
+  const internalRoom = room as VeilColyseusRoom & {
+    onMessageEvents: {
+      emit(event: string, ...args: unknown[]): void;
+    };
+  };
+
+  internalRoom.onMessageEvents.emit(type, client, payload);
+  await flushAsyncWork();
+}
+
+async function connectPlayer(
+  room: VeilColyseusRoom,
+  client: FakeClient,
+  playerId: string,
+  requestId: string,
+  displayName = playerId
+): Promise<void> {
+  room.clients.push(client as never);
+  room.onJoin(client as never, { playerId });
+  await emitRoomMessage(room, "connect", client, {
+    type: "connect",
+    requestId,
+    roomId: room.roomId,
+    playerId,
+    displayName
+  });
+}
+
+test("issue 1361: websocket social handlers return leaderboard snapshots and share payloads", async (t) => {
+  resetLobbyRoomRegistry();
+  resetRoomRuntimeDependencies();
+  resetRuntimeObservability();
+
+  const store = new MemoryRoomSnapshotStore();
+  configureRoomSnapshotStore(store);
+
+  await store.ensurePlayerAccount({ playerId: "player-social", displayName: "雾林司灯" });
+  await store.savePlayerAccountProgress("player-social", { eloRating: 1450 });
+  await store.ensurePlayerAccount({ playerId: "friend-1", displayName: "山岚旅人" });
+  await store.savePlayerAccountProgress("friend-1", { eloRating: 1320 });
+  await store.ensurePlayerAccount({ playerId: "friend-2", displayName: "霜港守望" });
+  await store.savePlayerAccountProgress("friend-2", { eloRating: 1510 });
+
+  const room = await createTestRoom("room-social");
+  const client = createFakeClient("session-social");
+
+  t.after(() => {
+    cleanupRoom(room);
+    configureRoomSnapshotStore(null);
+    resetLobbyRoomRegistry();
+    resetRoomRuntimeDependencies();
+    resetRuntimeObservability();
+  });
+
+  await connectPlayer(room, client, "player-social", "connect-social", "雾林司灯");
+
+  await emitRoomMessage(room, "FRIEND_LEADERBOARD_REQUEST", client, {
+    type: "FRIEND_LEADERBOARD_REQUEST",
+    requestId: "friends-1",
+    friendIds: ["friend-1", "friend-2", "friend-2"]
+  });
+
+  const leaderboardReply = client.sent.find(
+    (message): message is Extract<ServerMessage, { type: "FRIEND_LEADERBOARD_REQUEST" }> =>
+      message.type === "FRIEND_LEADERBOARD_REQUEST" && message.requestId === "friends-1"
+  );
+
+  assert.ok(leaderboardReply);
+  assert.equal(leaderboardReply.friendCount, 2);
+  assert.deepEqual(
+    leaderboardReply.items.map((item) => [item.rank, item.playerId, item.isSelf ?? false]),
+    [
+      [1, "friend-2", false],
+      [2, "player-social", true],
+      [3, "friend-1", false]
+    ]
+  );
+
+  await emitRoomMessage(room, "SHARE_ACTIVITY", client, {
+    type: "SHARE_ACTIVITY",
+    requestId: "share-1",
+    activity: "group_challenge",
+    roomId: "room-social"
+  });
+
+  const shareReply = client.sent.find(
+    (message): message is Extract<ServerMessage, { type: "SHARE_ACTIVITY" }> =>
+      message.type === "SHARE_ACTIVITY" && message.requestId === "share-1"
+  );
+
+  assert.ok(shareReply);
+  assert.equal(shareReply.activity, "group_challenge");
+  assert.equal(shareReply.roomId, "room-social");
+  assert.match(shareReply.shareUrl, /\?roomId=room-social/);
+  assert.match(shareReply.shareUrl, /shareScene=lobby/);
+  assert.match(shareReply.challengeToken ?? "", /\./);
+  assert.equal(shareReply.challenge?.creatorPlayerId, "player-social");
+
+  const metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /veil_social_friend_leaderboard_requests_total 1/);
+  assert.match(metrics, /veil_social_share_activity_requests_total 1/);
+});
+
+test("issue 1361: websocket social handlers surface persistence failures as room errors", async (t) => {
+  resetLobbyRoomRegistry();
+  resetRoomRuntimeDependencies();
+  resetRuntimeObservability();
+  configureRoomSnapshotStore(null);
+
+  const room = await createTestRoom("room-social-failure");
+  const client = createFakeClient("session-social-failure");
+
+  t.after(() => {
+    cleanupRoom(room);
+    configureRoomSnapshotStore(null);
+    resetLobbyRoomRegistry();
+    resetRoomRuntimeDependencies();
+    resetRuntimeObservability();
+  });
+
+  await connectPlayer(room, client, "player-social", "connect-failure");
+
+  await emitRoomMessage(room, "FRIEND_LEADERBOARD_REQUEST", client, {
+    type: "FRIEND_LEADERBOARD_REQUEST",
+    requestId: "friends-fail",
+    friendIds: ["friend-1"]
+  });
+  await emitRoomMessage(room, "SHARE_ACTIVITY", client, {
+    type: "SHARE_ACTIVITY",
+    requestId: "share-fail",
+    activity: "battle_victory",
+    roomId: "room-social-failure"
+  });
+
+  const friendError = client.sent.find(
+    (message): message is Extract<ServerMessage, { type: "error" }> =>
+      message.type === "error" && message.requestId === "friends-fail"
+  );
+  const shareError = client.sent.find(
+    (message): message is Extract<ServerMessage, { type: "error" }> =>
+      message.type === "error" && message.requestId === "share-fail"
+  );
+
+  assert.equal(friendError?.reason, "social_persistence_unavailable");
+  assert.equal(shareError?.reason, "social_persistence_unavailable");
+});

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -3,6 +3,8 @@ import type {
   BattleState,
   CosmeticId,
   EquippedCosmetics,
+  FriendLeaderboardEntry,
+  GroupChallenge,
   MovementPlan,
   Vec2,
   WorldAction,
@@ -269,6 +271,22 @@ export type ServerMessage =
       type: "guild.roster";
       requestId: string;
       roster: GuildRosterView;
+    }
+  | {
+      type: "FRIEND_LEADERBOARD_REQUEST";
+      requestId: string;
+      items: FriendLeaderboardEntry[];
+      friendCount: number;
+    }
+  | {
+      type: "SHARE_ACTIVITY";
+      requestId: string;
+      activity: "battle_victory" | "group_challenge";
+      roomId: string;
+      shareUrl: string;
+      shareMessage: string;
+      challenge?: GroupChallenge;
+      challengeToken?: string;
     }
   | {
       type: "COSMETIC_APPLIED";


### PR DESCRIPTION
## Summary
- add WebSocket handlers for `FRIEND_LEADERBOARD_REQUEST` and `SHARE_ACTIVITY` in the Colyseus room
- reuse the existing friend leaderboard builder and group challenge token flow for the minimal social slice
- expose lightweight observability counters and add focused room tests for success and persistence-unavailable errors

## Validation
- `npm run typecheck:server`
- `npm run typecheck:shared`
- `node --import tsx --test ./apps/server/test/issue-1361-social-handlers.test.ts`

Closes #1361
