### PR TITLE
[codex] Add guild chat MVP

### DIFF
--- a/apps/server/src/guilds.ts
+++ b/apps/server/src/guilds.ts
@@ -2,17 +2,21 @@ import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   createGuild,
+  normalizeGuildChatMessageContent,
   createGuildRosterView,
   createGuildSummaryView,
   findDisplayNameModerationViolation,
   joinGuild,
   leaveGuild,
+  type GuildChatMessage,
+  type GuildChatSendAction,
   type GuildCreateAction,
   type GuildState,
-  type GuildMembershipEvent,
+  type GuildMembershipEvent
 } from "../../../packages/shared/src/index";
 import { validateAuthSessionFromRequest } from "./auth";
-import type { GuildAuditLogRecord, RoomSnapshotStore } from "./persistence";
+import { recordHttpRateLimited } from "./observability";
+import type { GuildAuditLogRecord, GuildChatMessageRecord, RoomSnapshotStore } from "./persistence";
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -30,6 +34,128 @@ class PayloadTooLargeError extends Error {
 const MAX_JSON_BODY_BYTES = 16 * 1024;
 const GUILD_CREATE_WINDOW_MS = 24 * 60 * 60 * 1000;
 const GUILD_CREATE_MAX_PER_WINDOW = 2;
+const DEFAULT_GUILD_CHAT_HISTORY_LIMIT = 50;
+const MAX_GUILD_CHAT_HISTORY_LIMIT = 50;
+const DEFAULT_GUILD_CHAT_MESSAGE_RATE_LIMIT_WINDOW_MS = 60_000;
+const DEFAULT_GUILD_CHAT_MESSAGE_RATE_LIMIT_MAX = 10;
+const DEFAULT_GUILD_CHAT_MESSAGE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface RateLimitResult {
+  allowed: boolean;
+  retryAfterSeconds?: number;
+}
+
+interface GuildChatEventEnvelope {
+  type: "guild.chat.message" | "guild.chat.deleted";
+  guildId: string;
+  message?: GuildChatMessage;
+  messageId?: string;
+}
+
+function readGuildChatMessageRateLimitWindowMs(env: NodeJS.ProcessEnv = process.env): number {
+  const value = Number(env.VEIL_GUILD_CHAT_RATE_LIMIT_WINDOW_MS);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : DEFAULT_GUILD_CHAT_MESSAGE_RATE_LIMIT_WINDOW_MS;
+}
+
+function readGuildChatMessageRateLimitMax(env: NodeJS.ProcessEnv = process.env): number {
+  const value = Number(env.VEIL_GUILD_CHAT_RATE_LIMIT_MAX);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : DEFAULT_GUILD_CHAT_MESSAGE_RATE_LIMIT_MAX;
+}
+
+function readGuildChatMessageTtlMs(env: NodeJS.ProcessEnv = process.env): number {
+  const ttlDays = Number(env.VEIL_GUILD_CHAT_TTL_DAYS);
+  if (Number.isFinite(ttlDays) && ttlDays > 0) {
+    return Math.floor(ttlDays * 24 * 60 * 60 * 1000);
+  }
+
+  const ttlMs = Number(env.VEIL_GUILD_CHAT_TTL_MS);
+  return Number.isFinite(ttlMs) && ttlMs > 0 ? Math.floor(ttlMs) : DEFAULT_GUILD_CHAT_MESSAGE_TTL_MS;
+}
+
+function parseChatLimit(request: IncomingMessage): number {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const value = Number(url.searchParams.get("limit"));
+  if (!Number.isFinite(value)) {
+    return DEFAULT_GUILD_CHAT_HISTORY_LIMIT;
+  }
+
+  return Math.max(1, Math.min(MAX_GUILD_CHAT_HISTORY_LIMIT, Math.floor(value)));
+}
+
+function parseChatBeforeCursor(request: IncomingMessage): string | undefined {
+  const url = new URL(request.url ?? "/", "http://127.0.0.1");
+  const value = url.searchParams.get("before")?.trim();
+  return value ? value : undefined;
+}
+
+function encodeGuildChatCursor(message: Pick<GuildChatMessage, "createdAt" | "messageId">): string {
+  return `${message.createdAt}|${message.messageId}`;
+}
+
+function toGuildChatMessage(record: GuildChatMessageRecord): GuildChatMessage {
+  return { ...record };
+}
+
+function resolveRequestIp(request: Pick<IncomingMessage, "headers" | "socket">): string {
+  const forwardedFor = request.headers["x-forwarded-for"];
+  const headerValue = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
+  const normalizedHeader = headerValue?.split(",")[0]?.trim();
+  const rawIp = normalizedHeader || request.socket.remoteAddress?.trim() || "unknown";
+  return rawIp.startsWith("::ffff:") ? rawIp.slice("::ffff:".length) : rawIp;
+}
+
+class GuildChatRateLimiter {
+  private readonly counters = new Map<string, number[]>();
+  private readonly windowMs = readGuildChatMessageRateLimitWindowMs();
+  private readonly max = readGuildChatMessageRateLimitMax();
+
+  consume(playerId: string, request: Pick<IncomingMessage, "headers" | "socket">): RateLimitResult {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+    const key = `${playerId.trim()}:${resolveRequestIp(request)}`;
+    const timestamps = (this.counters.get(key) ?? []).filter((timestamp) => timestamp > windowStart);
+    if (timestamps.length >= this.max) {
+      this.counters.set(key, timestamps);
+      const oldestTimestamp = timestamps[0] ?? now;
+      return {
+        allowed: false,
+        retryAfterSeconds: Math.max(1, Math.ceil((oldestTimestamp + this.windowMs - now) / 1000))
+      };
+    }
+
+    timestamps.push(now);
+    this.counters.set(key, timestamps);
+    return { allowed: true };
+  }
+}
+
+class GuildChatRealtimeHub {
+  private readonly subscribers = new Map<string, Set<(event: GuildChatEventEnvelope) => void>>();
+
+  subscribe(guildId: string, listener: (event: GuildChatEventEnvelope) => void): () => void {
+    const normalizedGuildId = guildId.trim();
+    const listeners = this.subscribers.get(normalizedGuildId) ?? new Set<(event: GuildChatEventEnvelope) => void>();
+    listeners.add(listener);
+    this.subscribers.set(normalizedGuildId, listeners);
+    return () => {
+      const activeListeners = this.subscribers.get(normalizedGuildId);
+      if (!activeListeners) {
+        return;
+      }
+
+      activeListeners.delete(listener);
+      if (activeListeners.size === 0) {
+        this.subscribers.delete(normalizedGuildId);
+      }
+    };
+  }
+
+  publish(event: GuildChatEventEnvelope): void {
+    for (const listener of this.subscribers.get(event.guildId.trim()) ?? []) {
+      listener(event);
+    }
+  }
+}
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
@@ -103,7 +229,7 @@ function mapGuildError(error: unknown): { status: number; code: string; message:
 
   if (
     error instanceof SyntaxError ||
-    /guild_create_.*required|guild_create_.*blocked|guild_join_player_required|guild_leave_player_required|payload_too_large|Unexpected token/.test(
+    /guild_create_.*required|guild_create_.*blocked|guild_join_player_required|guild_leave_player_required|guild_chat_message_required|guild_chat_message_too_long|guild_chat_message_html_not_allowed|beforeCursor|payload_too_large|Unexpected token/.test(
       message
     )
   ) {
@@ -111,6 +237,12 @@ function mapGuildError(error: unknown): { status: number; code: string; message:
   }
   if (/guild_not_found/.test(message)) {
     return { status: 404, code: "guild_not_found", message };
+  }
+  if (/guild_chat_message_not_found/.test(message)) {
+    return { status: 404, code: "guild_chat_message_not_found", message };
+  }
+  if (/guild_chat_forbidden|guild_chat_delete_forbidden/.test(message)) {
+    return { status: 403, code: "guild_chat_forbidden", message };
   }
   if (/guild_member_not_found|guild_leave_member_not_found/.test(message)) {
     return { status: 409, code: "guild_membership_invalid", message };
@@ -123,6 +255,9 @@ function mapGuildError(error: unknown): { status: number; code: string; message:
   }
   if (/guild_create_rate_limited/.test(message)) {
     return { status: 429, code: "guild_create_rate_limited", message };
+  }
+  if (/guild_chat_rate_limited/.test(message)) {
+    return { status: 429, code: "guild_chat_rate_limited", message };
   }
 
   return { status: 500, code: "guild_error", message };
@@ -140,6 +275,10 @@ function ensureGuildPubliclyVisible(guild: GuildState): GuildState {
 }
 
 function validateGuildCreateModeration(action: GuildCreateAction): void {
+  if (!action.name.trim() || !action.tag.trim()) {
+    return;
+  }
+
   const nameViolation = findDisplayNameModerationViolation(action.name);
   if (nameViolation) {
     throw new Error(`guild_create_name_blocked: Guild name contains blocked content (${nameViolation.term})`);
@@ -151,7 +290,10 @@ function validateGuildCreateModeration(action: GuildCreateAction): void {
 }
 
 export class GuildService {
-  constructor(private readonly store: RoomSnapshotStore | null) {}
+  constructor(
+    private readonly store: RoomSnapshotStore | null,
+    private readonly guildChatRateLimiter = new GuildChatRateLimiter()
+  ) {}
 
   private requireStore(): {
     ensurePlayerAccount: RoomSnapshotStore["ensurePlayerAccount"];
@@ -188,6 +330,30 @@ export class GuildService {
     };
   }
 
+  private requireChatStore(): {
+    createGuildChatMessage: NonNullable<RoomSnapshotStore["createGuildChatMessage"]>;
+    deleteGuildChatMessage: NonNullable<RoomSnapshotStore["deleteGuildChatMessage"]>;
+    listGuildChatMessages: NonNullable<RoomSnapshotStore["listGuildChatMessages"]>;
+    loadGuildChatMessage: NonNullable<RoomSnapshotStore["loadGuildChatMessage"]>;
+  } {
+    if (
+      !this.store ||
+      !this.store.createGuildChatMessage ||
+      !this.store.deleteGuildChatMessage ||
+      !this.store.listGuildChatMessages ||
+      !this.store.loadGuildChatMessage
+    ) {
+      throw new Error("guild_store_unavailable");
+    }
+
+    return {
+      createGuildChatMessage: this.store.createGuildChatMessage.bind(this.store),
+      deleteGuildChatMessage: this.store.deleteGuildChatMessage.bind(this.store),
+      listGuildChatMessages: this.store.listGuildChatMessages.bind(this.store),
+      loadGuildChatMessage: this.store.loadGuildChatMessage.bind(this.store)
+    };
+  }
+
   async listGuilds(limit?: number): Promise<GuildState[]> {
     const store = this.requireStore();
     return (await store.listGuilds({ ...(limit != null ? { limit } : {}) })).filter((guild) => !isGuildHidden(guild));
@@ -219,6 +385,98 @@ export class GuildService {
       guildId,
       ...(limit != null ? { limit } : {})
     });
+  }
+
+  private async requireGuildMembership(guildId: string, playerId: string): Promise<GuildState> {
+    const store = this.requireStore();
+    const guild = await store.loadGuild(guildId);
+    if (!guild) {
+      throw new Error("guild_not_found");
+    }
+
+    ensureGuildPubliclyVisible(guild);
+    if (!guild.members.some((member) => member.playerId === playerId.trim())) {
+      throw new Error("guild_chat_forbidden");
+    }
+
+    return guild;
+  }
+
+  async listGuildChatMessagesForPlayer(
+    authSession: { playerId: string; displayName: string },
+    guildId: string,
+    options: { beforeCursor?: string; limit?: number } = {}
+  ): Promise<{ items: GuildChatMessage[]; nextCursor?: string }> {
+    const store = this.requireChatStore();
+    await this.requireGuildMembership(guildId, authSession.playerId);
+    const items = (
+      await store.listGuildChatMessages({
+        guildId,
+        ...(options.beforeCursor ? { beforeCursor: options.beforeCursor } : {}),
+        ...(options.limit != null ? { limit: options.limit } : {})
+      })
+    ).map((record) => toGuildChatMessage(record));
+
+    const lastMessage = items.at(-1);
+    return {
+      items,
+      ...(lastMessage ? { nextCursor: encodeGuildChatCursor(lastMessage) } : {})
+    };
+  }
+
+  async createGuildChatMessageForPlayer(
+    authSession: { playerId: string; displayName: string },
+    guildId: string,
+    action: GuildChatSendAction,
+    request: Pick<IncomingMessage, "headers" | "socket">
+  ): Promise<GuildChatMessage> {
+    const store = this.requireChatStore();
+    const baseStore = this.requireStore();
+    await baseStore.ensurePlayerAccount({
+      playerId: authSession.playerId,
+      displayName: authSession.displayName
+    });
+    const guild = await this.requireGuildMembership(guildId, authSession.playerId);
+    const normalizedContent = normalizeGuildChatMessageContent(typeof action.content === "string" ? action.content : "");
+    const rateLimitResult = this.guildChatRateLimiter.consume(authSession.playerId, request);
+    if (!rateLimitResult.allowed) {
+      throw new Error(`guild_chat_rate_limited: retry after ${rateLimitResult.retryAfterSeconds ?? 1} seconds`);
+    }
+
+    const message = await store.createGuildChatMessage({
+      guildId: guild.id,
+      authorPlayerId: authSession.playerId,
+      authorDisplayName: authSession.displayName,
+      content: normalizedContent,
+      expiresAt: new Date(Date.now() + readGuildChatMessageTtlMs()).toISOString()
+    });
+    return toGuildChatMessage(message);
+  }
+
+  async deleteGuildChatMessageForPlayer(
+    authSession: { playerId: string; displayName: string },
+    guildId: string,
+    messageId: string
+  ): Promise<{ messageId: string }> {
+    const store = this.requireChatStore();
+    const guild = await this.requireGuildMembership(guildId, authSession.playerId);
+    const message = await store.loadGuildChatMessage(guild.id, messageId);
+    if (!message) {
+      throw new Error("guild_chat_message_not_found");
+    }
+
+    const actorMembership = guild.members.find((member) => member.playerId === authSession.playerId);
+    const canDelete = actorMembership?.role === "owner" || message.authorPlayerId === authSession.playerId;
+    if (!canDelete) {
+      throw new Error("guild_chat_delete_forbidden");
+    }
+
+    const deleted = await store.deleteGuildChatMessage(guild.id, message.messageId);
+    if (!deleted) {
+      throw new Error("guild_chat_message_not_found");
+    }
+
+    return { messageId: message.messageId };
   }
 
   async createGuildForPlayer(
@@ -405,6 +663,7 @@ export function registerGuildRoutes(
   store: RoomSnapshotStore | null
 ): void {
   const service = new GuildService(store);
+  const guildChatHub = new GuildChatRealtimeHub();
 
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
@@ -452,6 +711,67 @@ export function registerGuildRoutes(
       sendJson(response, 200, {
         roster: createGuildRosterView(guild)
       });
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.get("/api/guilds/:guildId/chat", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const guildId = request.params.guildId ?? "";
+      const beforeCursor = parseChatBeforeCursor(request);
+      const result = await service.listGuildChatMessagesForPlayer(authSession, guildId, {
+        limit: parseChatLimit(request),
+        ...(beforeCursor ? { beforeCursor } : {})
+      });
+      sendJson(response, 200, result);
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.get("/api/guilds/:guildId/chat/stream", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const guildId = request.params.guildId ?? "";
+      await service.listGuildChatMessagesForPlayer(authSession, guildId, { limit: 1 });
+      response.statusCode = 200;
+      response.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+      response.setHeader("Cache-Control", "no-cache, no-transform");
+      response.setHeader("Connection", "keep-alive");
+      response.setHeader("X-Accel-Buffering", "no");
+      response.flushHeaders?.();
+
+      const writeEvent = (event: GuildChatEventEnvelope): void => {
+        response.write(`event: ${event.type}\n`);
+        response.write(`data: ${JSON.stringify(event)}\n\n`);
+      };
+
+      response.write(": connected\n\n");
+      const unsubscribe = guildChatHub.subscribe(guildId, writeEvent);
+      const heartbeat = setInterval(() => {
+        response.write(": keepalive\n\n");
+      }, 25_000);
+      heartbeat.unref?.();
+
+      const close = (): void => {
+        clearInterval(heartbeat);
+        unsubscribe();
+      };
+
+      request.once("close", close);
+      response.once("close", close);
     } catch (error) {
       const mapped = mapGuildError(error);
       sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
@@ -521,6 +841,53 @@ export function registerGuildRoutes(
               deleted: false
             }
       );
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.post("/api/guilds/:guildId/chat", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const guildId = request.params.guildId ?? "";
+      const payload = (await readJsonBody(request)) as GuildChatSendAction;
+      const message = await service.createGuildChatMessageForPlayer(authSession, guildId, payload, request);
+      guildChatHub.publish({
+        type: "guild.chat.message",
+        guildId,
+        message
+      });
+      sendJson(response, 201, { message });
+    } catch (error) {
+      const mapped = mapGuildError(error);
+      if (mapped.status === 429) {
+        recordHttpRateLimited();
+      }
+      sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });
+    }
+  });
+
+  app.post("/api/guilds/:guildId/chat/:messageId/delete", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+
+    try {
+      const guildId = request.params.guildId ?? "";
+      const messageId = request.params.messageId ?? "";
+      const deleted = await service.deleteGuildChatMessageForPlayer(authSession, guildId, messageId);
+      guildChatHub.publish({
+        type: "guild.chat.deleted",
+        guildId,
+        messageId: deleted.messageId
+      });
+      sendJson(response, 200, { deleted: true, ...deleted });
     } catch (error) {
       const mapped = mapGuildError(error);
       sendJson(response, mapped.status, { error: { code: mapped.code, message: mapped.message } });

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -20,6 +20,9 @@ import {
 import {
   createPlayerAccountsFromWorldState,
   type GuildAuditLogCreateInput,
+  type GuildChatMessageCreateInput,
+  type GuildChatMessageListOptions,
+  type GuildChatMessageRecord,
   type GuildAuditLogListOptions,
   type GuildAuditLogRecord,
   type GuildListOptions,
@@ -148,6 +151,30 @@ function normalizeDisplayNameLookup(displayName: string): string {
   return normalized.slice(0, 191);
 }
 
+function parseGuildChatCursor(cursor?: string): { createdAt: string; messageId: string } | null {
+  const normalized = cursor?.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const separatorIndex = normalized.indexOf("|");
+  if (separatorIndex <= 0 || separatorIndex === normalized.length - 1) {
+    throw new Error("beforeCursor must be formatted as createdAt|messageId");
+  }
+
+  const createdAt = normalized.slice(0, separatorIndex);
+  const messageId = normalized.slice(separatorIndex + 1).trim();
+  const createdAtDate = new Date(createdAt);
+  if (Number.isNaN(createdAtDate.getTime()) || !messageId) {
+    throw new Error("beforeCursor is invalid");
+  }
+
+  return {
+    createdAt: createdAtDate.toISOString(),
+    messageId
+  };
+}
+
 function normalizeAvatarUrl(avatarUrl?: string | null): string | undefined {
   const normalized = avatarUrl?.trim();
   return normalized ? normalized.slice(0, MAX_PLAYER_AVATAR_URL_LENGTH) : undefined;
@@ -194,6 +221,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   private readonly guilds = new Map<string, GuildState>();
   private readonly guildIdByPlayerId = new Map<string, string>();
   private readonly guildAuditLogs: GuildAuditLogRecord[] = [];
+  private readonly guildMessages = new Map<string, GuildChatMessageRecord[]>();
   private readonly nameHistoryByPlayerId = new Map<string, Array<{
     id: number;
     playerId: string;
@@ -313,6 +341,68 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
     };
     this.guildAuditLogs.push(entry);
     return structuredClone(entry);
+  }
+
+  async listGuildChatMessages(options: GuildChatMessageListOptions): Promise<GuildChatMessageRecord[]> {
+    const safeLimit = Math.max(1, Math.min(50, Math.floor(options.limit ?? 50)));
+    const cursor = parseGuildChatCursor(options.beforeCursor);
+    const items = (this.guildMessages.get(options.guildId.trim()) ?? [])
+      .filter((message) => new Date(message.expiresAt).getTime() > Date.now())
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.messageId.localeCompare(left.messageId))
+      .filter((message) => {
+        if (!cursor) {
+          return true;
+        }
+
+        return (
+          message.createdAt < cursor.createdAt ||
+          (message.createdAt === cursor.createdAt && message.messageId < cursor.messageId)
+        );
+      })
+      .slice(0, safeLimit);
+
+    return items.map((message) => structuredClone(message));
+  }
+
+  async loadGuildChatMessage(guildId: string, messageId: string): Promise<GuildChatMessageRecord | null> {
+    const item = (this.guildMessages.get(guildId.trim()) ?? []).find((message) => message.messageId === messageId.trim());
+    if (!item || new Date(item.expiresAt).getTime() <= Date.now()) {
+      return null;
+    }
+
+    return structuredClone(item);
+  }
+
+  async createGuildChatMessage(input: GuildChatMessageCreateInput): Promise<GuildChatMessageRecord> {
+    const record: GuildChatMessageRecord = {
+      messageId: randomUUID(),
+      guildId: input.guildId.trim(),
+      authorPlayerId: normalizePlayerId(input.authorPlayerId),
+      authorDisplayName: normalizeDisplayName(input.authorPlayerId, input.authorDisplayName),
+      content: input.content.trim().slice(0, 500),
+      createdAt: new Date(input.createdAt ?? Date.now()).toISOString(),
+      expiresAt: new Date(input.expiresAt).toISOString()
+    };
+    const existing = this.guildMessages.get(record.guildId) ?? [];
+    existing.push(structuredClone(record));
+    this.guildMessages.set(record.guildId, existing);
+    return structuredClone(record);
+  }
+
+  async deleteGuildChatMessage(guildId: string, messageId: string): Promise<boolean> {
+    const normalizedGuildId = guildId.trim();
+    const existing = this.guildMessages.get(normalizedGuildId) ?? [];
+    const next = existing.filter((message) => message.messageId !== messageId.trim());
+    if (next.length === existing.length) {
+      return false;
+    }
+
+    if (next.length === 0) {
+      this.guildMessages.delete(normalizedGuildId);
+    } else {
+      this.guildMessages.set(normalizedGuildId, next);
+    }
+    return true;
   }
 
   async loadPaymentOrder(orderId: string): Promise<PaymentOrderSnapshot | null> {
@@ -2326,6 +2416,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       this.guildIdByPlayerId.delete(member.playerId);
     }
     this.guilds.delete(normalizedGuildId);
+    this.guildMessages.delete(normalizedGuildId);
   }
 
   async pruneExpired(): Promise<number> {
@@ -2345,6 +2436,19 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
           updatedAt: now.toISOString()
         })
       );
+    }
+
+    for (const [guildId, messages] of this.guildMessages.entries()) {
+      const nextMessages = messages.filter((message) => new Date(message.expiresAt).getTime() > now.getTime());
+      removedCount += messages.length - nextMessages.length;
+      if (nextMessages.length === 0) {
+        this.guildMessages.delete(guildId);
+      } else if (nextMessages.length !== messages.length) {
+        this.guildMessages.set(
+          guildId,
+          nextMessages.map((message) => structuredClone(message))
+        );
+      }
     }
     return removedCount;
   }

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -210,6 +210,8 @@ export interface RoomSnapshotStore {
   loadGuild?(guildId: string): Promise<GuildState | null>;
   loadGuildByMemberPlayerId?(playerId: string): Promise<GuildState | null>;
   listGuildAuditLogs?(options?: GuildAuditLogListOptions): Promise<GuildAuditLogRecord[]>;
+  listGuildChatMessages?(options: GuildChatMessageListOptions): Promise<GuildChatMessageRecord[]>;
+  loadGuildChatMessage?(guildId: string, messageId: string): Promise<GuildChatMessageRecord | null>;
   loadPaymentOrder?(orderId: string): Promise<PaymentOrderSnapshot | null>;
   listPaymentOrders?(options?: PaymentOrderListOptions): Promise<PaymentOrderSnapshot[]>;
   loadPaymentReceiptByOrderId?(orderId: string): Promise<PaymentReceiptSnapshot | null>;
@@ -249,6 +251,8 @@ export interface RoomSnapshotStore {
   ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot>;
   saveGuild?(guild: GuildState): Promise<GuildState>;
   appendGuildAuditLog?(input: GuildAuditLogCreateInput): Promise<GuildAuditLogRecord>;
+  createGuildChatMessage?(input: GuildChatMessageCreateInput): Promise<GuildChatMessageRecord>;
+  deleteGuildChatMessage?(guildId: string, messageId: string): Promise<boolean>;
   savePlayerBan?(playerId: string, input: PlayerAccountBanInput): Promise<PlayerAccountSnapshot>;
   clearPlayerBan?(playerId: string, input?: PlayerAccountUnbanInput): Promise<PlayerAccountSnapshot>;
   bindPlayerAccountCredentials(
@@ -590,6 +594,16 @@ interface GuildAuditLogRow extends RowDataPacket {
   reason: string | null;
 }
 
+interface GuildChatMessageRow extends RowDataPacket {
+  message_id: string;
+  guild_id: string;
+  author_player_id: string;
+  author_display_name: string;
+  content: string;
+  created_at: Date | string;
+  expires_at: Date | string;
+}
+
 interface PlayerReportRow extends RowDataPacket {
   report_id: string | number;
   reporter_id: string;
@@ -719,6 +733,16 @@ export interface GuildAuditLogRecord {
   reason?: string;
 }
 
+export interface GuildChatMessageRecord {
+  messageId: string;
+  guildId: string;
+  authorPlayerId: string;
+  authorDisplayName: string;
+  content: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
 export interface GuildAuditLogCreateInput {
   guildId: string;
   action: GuildAuditAction;
@@ -734,6 +758,21 @@ export interface GuildAuditLogListOptions {
   actorPlayerId?: string;
   since?: string;
   limit?: number;
+}
+
+export interface GuildChatMessageListOptions {
+  guildId: string;
+  beforeCursor?: string;
+  limit?: number;
+}
+
+export interface GuildChatMessageCreateInput {
+  guildId: string;
+  authorPlayerId: string;
+  authorDisplayName: string;
+  content: string;
+  createdAt?: string;
+  expiresAt: string;
 }
 
 export type GemLedgerReason = "purchase" | "reward" | "spend";
@@ -1183,6 +1222,9 @@ export const MYSQL_GUILD_MEMBERSHIP_PLAYER_INDEX = "uidx_guild_memberships_playe
 export const MYSQL_GUILD_AUDIT_LOG_TABLE = "guild_audit_logs";
 export const MYSQL_GUILD_AUDIT_LOG_GUILD_OCCURRED_INDEX = "idx_guild_audit_logs_guild_occurred";
 export const MYSQL_GUILD_AUDIT_LOG_ACTOR_OCCURRED_INDEX = "idx_guild_audit_logs_actor_occurred";
+export const MYSQL_GUILD_MESSAGE_TABLE = "guild_messages";
+export const MYSQL_GUILD_MESSAGE_GUILD_CREATED_INDEX = "idx_guild_messages_guild_created";
+export const MYSQL_GUILD_MESSAGE_EXPIRES_AT_INDEX = "idx_guild_messages_expires_at";
 export const MYSQL_CONFIG_DOCUMENT_TABLE = "config_documents";
 export const MYSQL_CONFIG_DOCUMENT_UPDATED_AT_INDEX = "idx_config_documents_updated_at";
 export const MYSQL_SEASON_TABLE = "veil_seasons";
@@ -1419,6 +1461,57 @@ function normalizeGuildAuditReason(reason?: string | null): string | undefined {
   return normalized ? normalized.slice(0, 200) : undefined;
 }
 
+function normalizeGuildChatMessageId(messageId: string): string {
+  const normalized = messageId.trim();
+  if (!normalized) {
+    throw new Error("messageId must not be empty");
+  }
+
+  return normalized.slice(0, 191);
+}
+
+function normalizeGuildChatAuthorDisplayName(displayName: string): string {
+  const normalized = displayName.trim();
+  if (!normalized) {
+    throw new Error("authorDisplayName must not be empty");
+  }
+
+  return normalized.slice(0, 40);
+}
+
+function normalizeGuildChatContent(content: string): string {
+  const normalized = content.trim();
+  if (!normalized) {
+    throw new Error("content must not be empty");
+  }
+
+  return normalized.slice(0, 500);
+}
+
+function parseGuildChatCursor(cursor?: string | null): { createdAt: string; messageId: string } | null {
+  const normalized = cursor?.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const separatorIndex = normalized.indexOf("|");
+  if (separatorIndex <= 0 || separatorIndex === normalized.length - 1) {
+    throw new Error("beforeCursor must be formatted as createdAt|messageId");
+  }
+
+  const createdAt = normalized.slice(0, separatorIndex);
+  const messageId = normalized.slice(separatorIndex + 1);
+  const createdAtDate = new Date(createdAt);
+  if (Number.isNaN(createdAtDate.getTime())) {
+    throw new Error("beforeCursor createdAt must be a valid ISO timestamp");
+  }
+
+  return {
+    createdAt: createdAtDate.toISOString(),
+    messageId: normalizeGuildChatMessageId(messageId)
+  };
+}
+
 function toGuildAuditLogRecord(row: GuildAuditLogRow): GuildAuditLogRecord {
   const action = row.action === "created" || row.action === "hidden" || row.action === "unhidden" || row.action === "deleted"
     ? row.action
@@ -1432,6 +1525,18 @@ function toGuildAuditLogRecord(row: GuildAuditLogRow): GuildAuditLogRecord {
     name: row.name.trim().slice(0, 40),
     tag: row.tag.trim().toUpperCase().slice(0, 4),
     ...(row.reason?.trim() ? { reason: row.reason.trim() } : {})
+  };
+}
+
+function toGuildChatMessageRecord(row: GuildChatMessageRow): GuildChatMessageRecord {
+  return {
+    messageId: normalizeGuildChatMessageId(row.message_id),
+    guildId: normalizeGuildId(row.guild_id),
+    authorPlayerId: normalizePlayerId(row.author_player_id),
+    authorDisplayName: normalizeGuildChatAuthorDisplayName(row.author_display_name),
+    content: normalizeGuildChatContent(row.content),
+    createdAt: formatTimestamp(row.created_at) ?? new Date().toISOString(),
+    expiresAt: formatTimestamp(row.expires_at) ?? new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
   };
 }
 
@@ -5387,6 +5492,60 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     return rows.map((row) => toGuildAuditLogRecord(row));
   }
 
+  async listGuildChatMessages(options: GuildChatMessageListOptions): Promise<GuildChatMessageRecord[]> {
+    const safeLimit = Math.max(1, Math.min(50, Math.floor(options.limit ?? 50)));
+    const cursor = parseGuildChatCursor(options.beforeCursor);
+    const params: Array<string | Date | number> = [normalizeGuildId(options.guildId)];
+    let cursorClause = "";
+
+    if (cursor) {
+      cursorClause = "AND (created_at < ? OR (created_at = ? AND message_id < ?))";
+      params.push(new Date(cursor.createdAt), new Date(cursor.createdAt), cursor.messageId);
+    }
+
+    const [rows] = await this.pool.query<GuildChatMessageRow[]>(
+      `SELECT
+         message_id,
+         guild_id,
+         author_player_id,
+         author_display_name,
+         content,
+         created_at,
+         expires_at
+       FROM \`${MYSQL_GUILD_MESSAGE_TABLE}\`
+       WHERE guild_id = ?
+         AND expires_at > CURRENT_TIMESTAMP
+         ${cursorClause}
+       ORDER BY created_at DESC, message_id DESC
+       LIMIT ?`,
+      [...params, safeLimit]
+    );
+
+    return rows.map((row) => toGuildChatMessageRecord(row));
+  }
+
+  async loadGuildChatMessage(guildId: string, messageId: string): Promise<GuildChatMessageRecord | null> {
+    const [rows] = await this.pool.query<GuildChatMessageRow[]>(
+      `SELECT
+         message_id,
+         guild_id,
+         author_player_id,
+         author_display_name,
+         content,
+         created_at,
+         expires_at
+       FROM \`${MYSQL_GUILD_MESSAGE_TABLE}\`
+       WHERE guild_id = ?
+         AND message_id = ?
+         AND expires_at > CURRENT_TIMESTAMP
+       LIMIT 1`,
+      [normalizeGuildId(guildId), normalizeGuildChatMessageId(messageId)]
+    );
+
+    const row = rows[0];
+    return row ? toGuildChatMessageRecord(row) : null;
+  }
+
   async appendGuildAuditLog(input: GuildAuditLogCreateInput): Promise<GuildAuditLogRecord> {
     const auditId = randomUUID();
     const occurredAt = new Date(input.occurredAt ?? Date.now());
@@ -5429,6 +5588,62 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     );
 
     return record;
+  }
+
+  async createGuildChatMessage(input: GuildChatMessageCreateInput): Promise<GuildChatMessageRecord> {
+    const messageId = randomUUID();
+    const createdAt = new Date(input.createdAt ?? Date.now());
+    const expiresAt = new Date(input.expiresAt);
+    if (Number.isNaN(createdAt.getTime())) {
+      throw new Error("createdAt must be a valid ISO timestamp");
+    }
+    if (Number.isNaN(expiresAt.getTime())) {
+      throw new Error("expiresAt must be a valid ISO timestamp");
+    }
+
+    const record: GuildChatMessageRecord = {
+      messageId,
+      guildId: normalizeGuildId(input.guildId),
+      authorPlayerId: normalizePlayerId(input.authorPlayerId),
+      authorDisplayName: normalizeGuildChatAuthorDisplayName(input.authorDisplayName),
+      content: normalizeGuildChatContent(input.content),
+      createdAt: createdAt.toISOString(),
+      expiresAt: expiresAt.toISOString()
+    };
+
+    await this.pool.query(
+      `INSERT INTO \`${MYSQL_GUILD_MESSAGE_TABLE}\` (
+         message_id,
+         guild_id,
+         author_player_id,
+         author_display_name,
+         content,
+         created_at,
+         expires_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        record.messageId,
+        record.guildId,
+        record.authorPlayerId,
+        record.authorDisplayName,
+        record.content,
+        new Date(record.createdAt),
+        new Date(record.expiresAt)
+      ]
+    );
+
+    return record;
+  }
+
+  async deleteGuildChatMessage(guildId: string, messageId: string): Promise<boolean> {
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `DELETE FROM \`${MYSQL_GUILD_MESSAGE_TABLE}\`
+       WHERE guild_id = ?
+         AND message_id = ?`,
+      [normalizeGuildId(guildId), normalizeGuildChatMessageId(messageId)]
+    );
+
+    return result.affectedRows > 0;
   }
 
   async loadPlayerAccount(playerId: string): Promise<PlayerAccountSnapshot | null> {
@@ -8943,6 +9158,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     try {
       await connection.beginTransaction();
+      await connection.query(`DELETE FROM \`${MYSQL_GUILD_MESSAGE_TABLE}\` WHERE guild_id = ?`, [normalizedGuildId]);
       await connection.query(`DELETE FROM \`${MYSQL_GUILD_MEMBERSHIP_TABLE}\` WHERE guild_id = ?`, [normalizedGuildId]);
       await connection.query(`DELETE FROM \`${MYSQL_GUILD_TABLE}\` WHERE guild_id = ?`, [normalizedGuildId]);
       await connection.commit();
@@ -8955,13 +9171,14 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
   }
 
   async pruneExpired(referenceTime = new Date()): Promise<number> {
-    const [roomCount, profileCount, mailboxCount] = await Promise.all([
+    const [roomCount, profileCount, mailboxCount, guildMessageCount] = await Promise.all([
       this.pruneExpiredRoomSnapshots(referenceTime),
       this.pruneExpiredPlayerProfiles(referenceTime),
-      this.pruneExpiredPlayerMailboxEntries(referenceTime)
+      this.pruneExpiredPlayerMailboxEntries(referenceTime),
+      this.pruneExpiredGuildChatMessages(referenceTime)
     ]);
 
-    return roomCount + profileCount + mailboxCount;
+    return roomCount + profileCount + mailboxCount + guildMessageCount;
   }
 
   async pruneExpiredRoomSnapshots(referenceTime = new Date()): Promise<number> {
@@ -9020,6 +9237,16 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
     }
 
     return removedCount;
+  }
+
+  async pruneExpiredGuildChatMessages(referenceTime = new Date()): Promise<number> {
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `DELETE FROM \`${MYSQL_GUILD_MESSAGE_TABLE}\`
+       WHERE expires_at <= ?`,
+      [referenceTime]
+    );
+
+    return result.affectedRows;
   }
 
   async pruneExpiredBattleReplays(referenceTime = new Date()): Promise<number> {

--- a/apps/server/test/guild-routes.test.ts
+++ b/apps/server/test/guild-routes.test.ts
@@ -14,6 +14,48 @@ async function startGuildRouteServer(store: RoomSnapshotStore, port: number): Pr
   return server;
 }
 
+async function readSseEvent(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs = 5_000
+): Promise<{ event: string; data: unknown }> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const remainingMs = Math.max(1, deadline - Date.now());
+    const chunk = await Promise.race([
+      reader.read(),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("sse_timeout")), remainingMs))
+    ]);
+    if (chunk.done) {
+      throw new Error("sse_stream_closed");
+    }
+
+    buffer += decoder.decode(chunk.value, { stream: true });
+    const separatorIndex = buffer.indexOf("\n\n");
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const rawEvent = buffer.slice(0, separatorIndex);
+    buffer = buffer.slice(separatorIndex + 2);
+    const lines = rawEvent.split("\n");
+    const event = lines.find((line) => line.startsWith("event:"))?.slice("event:".length).trim();
+    const dataLine = lines.find((line) => line.startsWith("data:"))?.slice("data:".length).trim();
+    if (!event || !dataLine) {
+      continue;
+    }
+
+    return {
+      event,
+      data: JSON.parse(dataLine)
+    };
+  }
+
+  throw new Error("sse_timeout");
+}
+
 test("guild routes create, list, fetch, and expose rosters", async (t) => {
   resetGuestAuthSessions();
   const store = createMemoryRoomSnapshotStore();
@@ -725,4 +767,309 @@ test("guild routes reject duplicate tags, invalid joins, and invalid leaves", as
   const outsiderLeavePayload = (await outsiderLeave.json()) as { error: { code: string } };
   assert.equal(outsiderLeave.status, 409);
   assert.equal(outsiderLeavePayload.error.code, "guild_membership_invalid");
+});
+
+test("guild chat routes send messages, page history, and enforce delete authorization", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 44500 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const founderSession = issueGuestAuthSession({ playerId: "chat-founder", displayName: "Chat Founder" });
+  const recruitSession = issueGuestAuthSession({ playerId: "chat-recruit", displayName: "Chat Recruit" });
+  const outsiderSession = issueGuestAuthSession({ playerId: "chat-outsider", displayName: "Chat Outsider" });
+
+  t.after(async () => {
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const created = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ name: "Chat Ops", tag: "CHAT" })
+  });
+  const createdPayload = (await created.json()) as { guild: { guildId: string } };
+  assert.equal(created.status, 201);
+
+  const joined = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/join`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${recruitSession.token}`
+    }
+  });
+  assert.equal(joined.status, 200);
+
+  const founderMessageResponse = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ content: "Hold the west gate." })
+  });
+  const founderMessagePayload = (await founderMessageResponse.json()) as { message: { messageId: string; content: string } };
+  assert.equal(founderMessageResponse.status, 201);
+  assert.equal(founderMessagePayload.message.content, "Hold the west gate.");
+
+  const recruitMessageResponse = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${recruitSession.token}`
+    },
+    body: JSON.stringify({ content: "Reinforcements are two minutes out." })
+  });
+  const recruitMessagePayload = (await recruitMessageResponse.json()) as { message: { messageId: string } };
+  assert.equal(recruitMessageResponse.status, 201);
+
+  const latestMessageResponse = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ content: "Fallback to the inner wall if needed." })
+  });
+  assert.equal(latestMessageResponse.status, 201);
+
+  const firstPage = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat?limit=2`, {
+    headers: {
+      Authorization: `Bearer ${founderSession.token}`
+    }
+  });
+  const firstPagePayload = (await firstPage.json()) as {
+    items: Array<{ messageId: string; content: string }>;
+    nextCursor?: string;
+  };
+  assert.equal(firstPage.status, 200);
+  assert.equal(firstPagePayload.items.length, 2);
+  assert.deepEqual(firstPagePayload.items.map((message) => message.content), [
+    "Fallback to the inner wall if needed.",
+    "Reinforcements are two minutes out."
+  ]);
+  assert.equal(typeof firstPagePayload.nextCursor, "string");
+
+  const secondPage = await fetch(
+    `http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat?before=${encodeURIComponent(firstPagePayload.nextCursor ?? "")}&limit=2`,
+    {
+      headers: {
+        Authorization: `Bearer ${founderSession.token}`
+      }
+    }
+  );
+  const secondPagePayload = (await secondPage.json()) as { items: Array<{ content: string }> };
+  assert.equal(secondPage.status, 200);
+  assert.deepEqual(secondPagePayload.items.map((message) => message.content), ["Hold the west gate."]);
+
+  const forbiddenDelete = await fetch(
+    `http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat/${founderMessagePayload.message.messageId}/delete`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${recruitSession.token}`
+      }
+    }
+  );
+  const forbiddenDeletePayload = (await forbiddenDelete.json()) as { error: { code: string } };
+  assert.equal(forbiddenDelete.status, 403);
+  assert.equal(forbiddenDeletePayload.error.code, "guild_chat_forbidden");
+
+  const outsiderHistory = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    headers: {
+      Authorization: `Bearer ${outsiderSession.token}`
+    }
+  });
+  assert.equal(outsiderHistory.status, 403);
+
+  const ownerDelete = await fetch(
+    `http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat/${recruitMessagePayload.message.messageId}/delete`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${founderSession.token}`
+      }
+    }
+  );
+  assert.equal(ownerDelete.status, 200);
+
+  const ownDelete = await fetch(
+    `http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat/${founderMessagePayload.message.messageId}/delete`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${founderSession.token}`
+      }
+    }
+  );
+  assert.equal(ownDelete.status, 200);
+});
+
+test("guild chat routes validate messages and rate limit bursts", async (t) => {
+  resetGuestAuthSessions();
+  const previousRateLimitMax = process.env.VEIL_GUILD_CHAT_RATE_LIMIT_MAX;
+  process.env.VEIL_GUILD_CHAT_RATE_LIMIT_MAX = "2";
+  const store = createMemoryRoomSnapshotStore();
+  const port = 44600 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const founderSession = issueGuestAuthSession({ playerId: "chat-rate-founder", displayName: "Rate Founder" });
+
+  t.after(async () => {
+    if (previousRateLimitMax == null) {
+      delete process.env.VEIL_GUILD_CHAT_RATE_LIMIT_MAX;
+    } else {
+      process.env.VEIL_GUILD_CHAT_RATE_LIMIT_MAX = previousRateLimitMax;
+    }
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const created = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ name: "Rate Chat", tag: "RATE" })
+  });
+  const createdPayload = (await created.json()) as { guild: { guildId: string } };
+  assert.equal(created.status, 201);
+
+  const invalidHtml = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ content: "<script>alert('x')</script>" })
+  });
+  assert.equal(invalidHtml.status, 400);
+
+  const tooLong = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ content: "x".repeat(501) })
+  });
+  assert.equal(tooLong.status, 400);
+
+  for (const content of ["Alpha", "Bravo"]) {
+    const response = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${founderSession.token}`
+      },
+      body: JSON.stringify({ content })
+    });
+    assert.equal(response.status, 201);
+  }
+
+  const rateLimited = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ content: "Charlie" })
+  });
+  const rateLimitedPayload = (await rateLimited.json()) as { error: { code: string; message: string } };
+  assert.equal(rateLimited.status, 429);
+  assert.equal(rateLimitedPayload.error.code, "guild_chat_rate_limited");
+  assert.match(rateLimitedPayload.error.message, /retry after/i);
+});
+
+test("guild chat stream pushes live message and delete events to online guild members", async (t) => {
+  resetGuestAuthSessions();
+  const store = createMemoryRoomSnapshotStore();
+  const port = 44700 + Math.floor(Math.random() * 1000);
+  const server = await startGuildRouteServer(store, port);
+  const founderSession = issueGuestAuthSession({ playerId: "chat-stream-founder", displayName: "Stream Founder" });
+  const recruitSession = issueGuestAuthSession({ playerId: "chat-stream-recruit", displayName: "Stream Recruit" });
+  const controller = new AbortController();
+
+  t.after(async () => {
+    controller.abort();
+    resetGuestAuthSessions();
+    await store.close();
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const created = await fetch(`http://127.0.0.1:${port}/api/guilds`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ name: "Stream Chat", tag: "LIVE" })
+  });
+  const createdPayload = (await created.json()) as { guild: { guildId: string } };
+  assert.equal(created.status, 201);
+
+  const joined = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/join`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${recruitSession.token}`
+    }
+  });
+  assert.equal(joined.status, 200);
+
+  const streamResponse = await fetch(
+    `http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat/stream`,
+    {
+      headers: {
+        Authorization: `Bearer ${recruitSession.token}`,
+        Accept: "text/event-stream"
+      },
+      signal: controller.signal
+    }
+  );
+  assert.equal(streamResponse.status, 200);
+  assert.ok(streamResponse.body);
+  const reader = streamResponse.body.getReader();
+  t.after(async () => {
+    await reader.cancel().catch(() => undefined);
+  });
+
+  const createdMessage = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ content: "All squads report in." })
+  });
+  const createdMessagePayload = (await createdMessage.json()) as { message: { messageId: string; content: string } };
+  assert.equal(createdMessage.status, 201);
+
+  const pushedMessage = await readSseEvent(reader);
+  assert.equal(pushedMessage.event, "guild.chat.message");
+  assert.equal(
+    (pushedMessage.data as { message?: { content?: string } }).message?.content,
+    "All squads report in."
+  );
+
+  const deletedMessage = await fetch(
+    `http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat/${createdMessagePayload.message.messageId}/delete`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${founderSession.token}`
+      }
+    }
+  );
+  assert.equal(deletedMessage.status, 200);
+
+  const pushedDelete = await readSseEvent(reader);
+  assert.equal(pushedDelete.event, "guild.chat.deleted");
+  assert.equal(
+    (pushedDelete.data as { messageId?: string }).messageId,
+    createdMessagePayload.message.messageId
+  );
 });

--- a/packages/shared/src/guild-chat.ts
+++ b/packages/shared/src/guild-chat.ts
@@ -1,0 +1,41 @@
+const DEFAULT_GUILD_CHAT_MAX_MESSAGE_LENGTH = 500;
+
+export const GUILD_CHAT_MAX_MESSAGE_LENGTH = DEFAULT_GUILD_CHAT_MAX_MESSAGE_LENGTH;
+
+export interface GuildChatMessage {
+  messageId: string;
+  guildId: string;
+  authorPlayerId: string;
+  authorDisplayName: string;
+  content: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+export interface GuildChatSendAction {
+  content: string;
+}
+
+export interface GuildChatHistoryPage {
+  items: GuildChatMessage[];
+  nextCursor?: string;
+}
+
+const HTML_TAG_PATTERN = /<\/?[a-zA-Z][^>]*>/;
+
+export function normalizeGuildChatMessageContent(content: string, maxLength = GUILD_CHAT_MAX_MESSAGE_LENGTH): string {
+  const normalized = content.trim();
+  if (!normalized) {
+    throw new Error("guild_chat_message_required");
+  }
+
+  if (Array.from(normalized).length > maxLength) {
+    throw new Error(`guild_chat_message_too_long: max ${maxLength} characters`);
+  }
+
+  if (HTML_TAG_PATTERN.test(normalized)) {
+    throw new Error("guild_chat_message_html_not_allowed");
+  }
+
+  return normalized;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -23,6 +23,7 @@ export * from "./event-log.ts";
 export * from "./feature-flags.ts";
 export * from "./feedback.ts";
 export * from "./guilds.ts";
+export * from "./guild-chat.ts";
 export * from "./hero-skills.ts";
 export * from "./hero-progression.ts";
 export * from "./map.ts";

--- a/packages/shared/test/guild-chat.test.ts
+++ b/packages/shared/test/guild-chat.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { GUILD_CHAT_MAX_MESSAGE_LENGTH, normalizeGuildChatMessageContent } from "../src/guild-chat";
+
+test("normalizeGuildChatMessageContent trims valid messages", () => {
+  assert.equal(normalizeGuildChatMessageContent("  Rally at dusk  "), "Rally at dusk");
+});
+
+test("normalizeGuildChatMessageContent rejects empty messages", () => {
+  assert.throws(() => normalizeGuildChatMessageContent("   "), /guild_chat_message_required/);
+});
+
+test("normalizeGuildChatMessageContent rejects raw HTML", () => {
+  assert.throws(() => normalizeGuildChatMessageContent("<b>attack now</b>"), /guild_chat_message_html_not_allowed/);
+});
+
+test("normalizeGuildChatMessageContent rejects messages longer than the limit", () => {
+  assert.throws(
+    () => normalizeGuildChatMessageContent("x".repeat(GUILD_CHAT_MAX_MESSAGE_LENGTH + 1)),
+    /guild_chat_message_too_long/
+  );
+});

--- a/scripts/migrations/0023_add_guild_chat_messages.ts
+++ b/scripts/migrations/0023_add_guild_chat_messages.ts
@@ -1,0 +1,52 @@
+import {
+  dropIndexIfExists,
+  dropTableIfExists,
+  ensureIndexExists,
+  ensureTableExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import {
+  MYSQL_GUILD_MESSAGE_EXPIRES_AT_INDEX,
+  MYSQL_GUILD_MESSAGE_GUILD_CREATED_INDEX,
+  MYSQL_GUILD_MESSAGE_TABLE
+} from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureTableExists(
+    connection,
+    MYSQL_GUILD_MESSAGE_TABLE,
+    `CREATE TABLE IF NOT EXISTS \`${MYSQL_GUILD_MESSAGE_TABLE}\` (
+      message_id VARCHAR(191) NOT NULL,
+      guild_id VARCHAR(191) NOT NULL,
+      author_player_id VARCHAR(191) NOT NULL,
+      author_display_name VARCHAR(40) NOT NULL,
+      content VARCHAR(500) NOT NULL,
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      expires_at TIMESTAMP NOT NULL,
+      PRIMARY KEY (message_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`
+  );
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_GUILD_MESSAGE_TABLE,
+    MYSQL_GUILD_MESSAGE_GUILD_CREATED_INDEX,
+    `CREATE INDEX \`${MYSQL_GUILD_MESSAGE_GUILD_CREATED_INDEX}\` ON \`${MYSQL_GUILD_MESSAGE_TABLE}\` (guild_id, created_at, message_id)`
+  );
+  await ensureIndexExists(
+    connection,
+    database,
+    MYSQL_GUILD_MESSAGE_TABLE,
+    MYSQL_GUILD_MESSAGE_EXPIRES_AT_INDEX,
+    `CREATE INDEX \`${MYSQL_GUILD_MESSAGE_EXPIRES_AT_INDEX}\` ON \`${MYSQL_GUILD_MESSAGE_TABLE}\` (expires_at)`
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+  await dropIndexIfExists(connection, database, MYSQL_GUILD_MESSAGE_TABLE, MYSQL_GUILD_MESSAGE_EXPIRES_AT_INDEX);
+  await dropIndexIfExists(connection, database, MYSQL_GUILD_MESSAGE_TABLE, MYSQL_GUILD_MESSAGE_GUILD_CREATED_INDEX);
+  await dropTableIfExists(connection, MYSQL_GUILD_MESSAGE_TABLE);
+}


### PR DESCRIPTION
## Summary
- add a guild chat MVP with authenticated send, paginated history, delete authorization, and live online push via SSE
- persist guild chat messages in memory and MySQL, including TTL-based cleanup and a new `guild_messages` migration
- add shared guild chat validation plus route coverage for pagination, moderation, rate limiting, and live delivery

## Validation
- `npm run typecheck:shared`
- `npm run typecheck:server`
- `node --import tsx --test --test-force-exit packages/shared/test/guild-chat.test.ts apps/server/test/guild-routes.test.ts`

## Notes
- live delivery is implemented as an authenticated server-sent event stream at `GET /api/guilds/:guildId/chat/stream`, which fits the current HTTP-first guild architecture without coupling guild chat to Colyseus battle rooms
- rate limiting uses the existing in-process sliding-window pattern, keyed by player and request IP

Closes #1377