### PR TITLE
[codex] add Apple App Store IAP verification #1367

### DIFF
--- a/apps/server/src/apple-iap.ts
+++ b/apps/server/src/apple-iap.ts
@@ -1,0 +1,1047 @@
+import { createPrivateKey, createSign, createVerify, randomUUID, X509Certificate } from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { emitAnalyticsEvent } from "./analytics";
+import { validateAuthSessionFromRequest } from "./auth";
+import {
+  recordPaymentDeadLetter,
+  recordRuntimeErrorEvent,
+  setPaymentGrantDeadLetterCount,
+  setPaymentGrantQueueCount,
+  setPaymentGrantQueueLatency
+} from "./observability";
+import type { PaymentOrderSnapshot, RoomSnapshotStore } from "./persistence";
+import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct, type ShopProductGrant } from "./shop";
+
+interface HttpApp {
+  use: (handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void) => void;
+  post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
+}
+
+export interface AppleIapRuntimeConfig {
+  bundleId: string;
+  issuerId: string;
+  keyId: string;
+  privateKey: string;
+  productionApiUrl: string;
+  sandboxApiUrl: string;
+}
+
+export interface AppleVerifiedTransaction {
+  transactionId: string;
+  originalTransactionId?: string;
+  productId: string;
+  environment: "Production" | "Sandbox";
+  bundleId: string;
+  purchaseDate: string;
+  appAccountToken?: string;
+}
+
+export interface AppleIapVerificationErrorShape {
+  code: string;
+  message: string;
+  retryable: boolean;
+  statusCode: number;
+  category: "invalid_request" | "verification" | "configuration" | "upstream";
+}
+
+export class AppleIapVerificationError extends Error {
+  readonly retryable: boolean;
+  readonly statusCode: number;
+  readonly category: AppleIapVerificationErrorShape["category"];
+
+  constructor(input: AppleIapVerificationErrorShape) {
+    super(input.message);
+    this.name = input.code;
+    this.retryable = input.retryable;
+    this.statusCode = input.statusCode;
+    this.category = input.category;
+  }
+
+  toResponseBody() {
+    return {
+      error: {
+        code: this.name,
+        message: this.message,
+        retryable: this.retryable,
+        category: this.category
+      }
+    };
+  }
+}
+
+export interface AppleStoreKitVerificationAdapter {
+  verifyTransaction(input: { signedTransactionInfo: string }): Promise<AppleVerifiedTransaction>;
+}
+
+interface RegisterApplePaymentRoutesOptions extends RegisterShopRoutesOptions {
+  adapter?: AppleStoreKitVerificationAdapter;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  runtimeConfig?: AppleIapRuntimeConfig | null;
+}
+
+interface AppleTransactionPayload {
+  transactionId?: string | number;
+  originalTransactionId?: string | number;
+  productId?: string;
+  bundleId?: string;
+  environment?: string;
+  purchaseDate?: string | number;
+  appAccountToken?: string;
+}
+
+interface AppleTransactionLookupResponse {
+  signedTransactionInfo?: string;
+}
+
+const MAX_JSON_BODY_BYTES = 64 * 1024;
+const DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS = 5;
+const DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS = 60_000;
+
+function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(payload));
+}
+
+function normalizePemValue(value: string): string {
+  return value.replace(/\\n/g, "\n").trim();
+}
+
+function readPemValue(env: NodeJS.ProcessEnv, key: string): string | null {
+  const direct = env[key]?.trim();
+  if (direct) {
+    return normalizePemValue(direct);
+  }
+
+  const base64Value = env[`${key}_BASE64`]?.trim();
+  if (!base64Value) {
+    return null;
+  }
+
+  return normalizePemValue(Buffer.from(base64Value, "base64").toString("utf8"));
+}
+
+export function readAppleIapRuntimeConfig(env: NodeJS.ProcessEnv = process.env): AppleIapRuntimeConfig | null {
+  const bundleId = env.VEIL_APPLE_IAP_BUNDLE_ID?.trim();
+  const issuerId = env.VEIL_APPLE_IAP_ISSUER_ID?.trim();
+  const keyId = env.VEIL_APPLE_IAP_KEY_ID?.trim();
+  const privateKey = readPemValue(env, "VEIL_APPLE_IAP_PRIVATE_KEY");
+
+  if (!bundleId || !issuerId || !keyId || !privateKey) {
+    return null;
+  }
+
+  return {
+    bundleId,
+    issuerId,
+    keyId,
+    privateKey,
+    productionApiUrl: env.VEIL_APPLE_IAP_PRODUCTION_API_URL?.trim() || "https://api.storekit.itunes.apple.com",
+    sandboxApiUrl: env.VEIL_APPLE_IAP_SANDBOX_API_URL?.trim() || "https://api.storekit-sandbox.itunes.apple.com"
+  };
+}
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+async function readRawBody(request: IncomingMessage): Promise<Buffer> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    request.resume();
+    throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+    }
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const body = await readRawBody(request);
+  return body.byteLength > 0 ? JSON.parse(body.toString("utf8")) : {};
+}
+
+function sendUnauthorized(
+  response: ServerResponse,
+  errorCode: "unauthorized" | "token_expired" | "token_kind_invalid" | "session_revoked" = "unauthorized"
+): void {
+  sendJson(response, 401, {
+    error: {
+      code: errorCode,
+      message:
+        errorCode === "token_expired"
+          ? "Auth token has expired"
+          : errorCode === "session_revoked"
+            ? "Auth session has been revoked"
+            : "Guest auth session is missing or invalid"
+    }
+  });
+}
+
+function sendAccountBanned(response: ServerResponse, ban?: { banReason?: string; banExpiry?: string } | null): void {
+  sendJson(response, 403, {
+    error: {
+      code: "account_banned",
+      message: "Account is banned",
+      reason: ban?.banReason ?? "No reason provided",
+      ...(ban?.banExpiry ? { expiry: ban.banExpiry } : {})
+    }
+  });
+}
+
+async function requireAuthSession(request: IncomingMessage, response: ServerResponse, store: RoomSnapshotStore | null) {
+  const result = await validateAuthSessionFromRequest(request, store);
+  if (!result.session) {
+    if (result.errorCode === "account_banned") {
+      sendAccountBanned(response, result.ban);
+      return null;
+    }
+    sendUnauthorized(response, result.errorCode ?? "unauthorized");
+    return null;
+  }
+
+  return result.session;
+}
+
+function isPaymentStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
+  Required<
+    Pick<
+      RoomSnapshotStore,
+      "createPaymentOrder" | "completePaymentOrder" | "loadPaymentOrder" | "loadPaymentReceiptByOrderId" | "countVerifiedPaymentReceiptsSince"
+    >
+  > {
+  return Boolean(
+    store?.createPaymentOrder &&
+      store.completePaymentOrder &&
+      store.loadPaymentOrder &&
+      store.loadPaymentReceiptByOrderId &&
+      store.countVerifiedPaymentReceiptsSince
+  );
+}
+
+function isPaymentOpsStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
+  Required<Pick<RoomSnapshotStore, "listPaymentOrders">> {
+  return Boolean(store?.listPaymentOrders);
+}
+
+function normalizePaymentGrantRetryPolicy(): { maxAttempts: number; baseDelayMs: number } {
+  return {
+    maxAttempts: DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS,
+    baseDelayMs: DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS
+  };
+}
+
+async function refreshPaymentGrantObservability(store: RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPaymentOrders">>, now: Date) {
+  const [pendingOrders, deadLetterOrders] = await Promise.all([
+    store.listPaymentOrders({ statuses: ["grant_pending"], limit: 200 }),
+    store.listPaymentOrders({ statuses: ["dead_letter"], limit: 200 })
+  ]);
+
+  setPaymentGrantQueueCount(pendingOrders.length);
+  setPaymentGrantDeadLetterCount(deadLetterOrders.length);
+
+  const pendingRetryTimes = pendingOrders
+    .map((order) => (order.nextGrantRetryAt ? new Date(order.nextGrantRetryAt).getTime() : null))
+    .filter((value): value is number => value != null && Number.isFinite(value))
+    .sort((left, right) => left - right);
+
+  const oldestQueuedLatencyMs =
+    pendingOrders.length === 0
+      ? null
+      : pendingOrders
+          .map((order) => (order.lastGrantAttemptAt ? Math.max(0, now.getTime() - new Date(order.lastGrantAttemptAt).getTime()) : 0))
+          .reduce((max, value) => Math.max(max, value), 0);
+  const nextPendingRetryTime = pendingRetryTimes[0];
+  const nextAttemptDelayMs = nextPendingRetryTime != null ? Math.max(0, nextPendingRetryTime - now.getTime()) : null;
+
+  setPaymentGrantQueueLatency({
+    oldestQueuedLatencyMs,
+    nextAttemptDelayMs
+  });
+}
+
+function normalizeApplePaymentProduct(product: ShopProduct | undefined): ShopProduct & { grant: ShopProductGrant } {
+  if (!product) {
+    throw new AppleIapVerificationError({
+      code: "apple_product_not_found",
+      message: "Verified Apple transaction does not map to a configured shop product",
+      retryable: false,
+      statusCode: 400,
+      category: "invalid_request"
+    });
+  }
+  if (product.type !== "gem_pack" && product.type !== "season_pass_premium") {
+    throw new AppleIapVerificationError({
+      code: "apple_product_unsupported",
+      message: "Apple IAP only supports gem packs and season pass premium products",
+      retryable: false,
+      statusCode: 400,
+      category: "invalid_request"
+    });
+  }
+  if ((product.grant.gems ?? 0) <= 0 && product.grant.seasonPassPremium !== true) {
+    throw new AppleIapVerificationError({
+      code: "apple_product_grant_not_configured",
+      message: "Apple IAP product grant is not configured",
+      retryable: false,
+      statusCode: 500,
+      category: "configuration"
+    });
+  }
+
+  return product as ShopProduct & { grant: ShopProductGrant };
+}
+
+function findProductForAppleTransaction(products: ShopProduct[], appleProductId: string): ShopProduct | undefined {
+  const normalizedAppleProductId = appleProductId.trim();
+  return products.find(
+    (product) => product.productId === normalizedAppleProductId || product.appleProductId === normalizedAppleProductId
+  );
+}
+
+function resolveAppleOrderAmount(product: ShopProduct): number {
+  const amount = Math.max(0, Math.floor(product.applePriceCents ?? product.price ?? 0));
+  if (amount <= 0) {
+    throw new AppleIapVerificationError({
+      code: "apple_product_price_not_configured",
+      message: "Apple IAP product price is not configured",
+      retryable: false,
+      statusCode: 500,
+      category: "configuration"
+    });
+  }
+  return amount;
+}
+
+function isFinalizedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
+  return status === "settled" || status === "dead_letter";
+}
+
+function isAcceptedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
+  return status !== "created";
+}
+
+function emitPurchaseCompletedEvent(input: {
+  playerId: string;
+  purchaseId: string;
+  productId: string;
+  paymentMethod: "apple_iap";
+  quantity: number;
+  totalPrice: number;
+}): void {
+  emitAnalyticsEvent("purchase_completed", {
+    playerId: input.playerId,
+    payload: {
+      purchaseId: input.purchaseId,
+      productId: input.productId,
+      paymentMethod: input.paymentMethod,
+      quantity: input.quantity,
+      totalPrice: input.totalPrice
+    }
+  });
+}
+
+function emitPurchaseFailedEvent(input: {
+  playerId: string;
+  purchaseId: string;
+  productId: string;
+  paymentMethod: "apple_iap";
+  failureReason: string;
+  orderStatus: PaymentOrderSnapshot["status"] | "failed";
+}): void {
+  emitAnalyticsEvent("purchase_failed", {
+    playerId: input.playerId,
+    payload: {
+      purchaseId: input.purchaseId,
+      productId: input.productId,
+      paymentMethod: input.paymentMethod,
+      failureReason: input.failureReason,
+      orderStatus: input.orderStatus
+    }
+  });
+}
+
+function emitPaymentFraudSignal(
+  playerId: string,
+  signal: string,
+  payload: {
+    orderId: string;
+    productId: string;
+    [key: string]: unknown;
+  }
+): void {
+  try {
+    emitAnalyticsEvent("payment_fraud_signal", {
+      playerId,
+      payload: {
+        signal,
+        ...payload
+      }
+    });
+  } catch {
+    // Fraud logging must not break payment handling.
+  }
+
+  recordRuntimeErrorEvent({
+    id: randomUUID(),
+    recordedAt: new Date().toISOString(),
+    source: "server",
+    surface: "apple-iap",
+    candidateRevision: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null,
+    featureArea: "payment",
+    ownerArea: "commerce",
+    severity: "warn",
+    errorCode: "payment_fraud_signal",
+    message: `Apple IAP fraud signal triggered: ${signal}`,
+    tags: ["apple-iap", signal],
+    context: {
+      roomId: null,
+      playerId,
+      requestId: null,
+      route: "/api/payments/apple/verify",
+      action: null,
+      statusCode: null,
+      crash: false,
+      detail: JSON.stringify({
+        orderId: payload.orderId,
+        productId: payload.productId,
+        signal
+      })
+    }
+  });
+}
+
+function base64UrlEncode(value: Buffer | string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function derToJoseEcdsaSignature(signature: Buffer, size: number): Buffer {
+  const firstByte = signature[0];
+  const secondByte = signature[1];
+  if (signature.length < 8 || firstByte == null || secondByte == null || firstByte !== 0x30) {
+    throw new Error("invalid_ecdsa_der_signature");
+  }
+
+  let offset = 2;
+  if ((secondByte & 0x80) !== 0) {
+    offset = 2 + (secondByte & 0x7f);
+  }
+
+  const integerMarker = signature[offset];
+  const rLength = signature[offset + 1];
+  if (integerMarker == null || rLength == null || integerMarker !== 0x02) {
+    throw new Error("invalid_ecdsa_der_signature");
+  }
+  const r = signature.subarray(offset + 2, offset + 2 + rLength);
+  offset += 2 + rLength;
+  const secondIntegerMarker = signature[offset];
+  const sLength = signature[offset + 1];
+  if (secondIntegerMarker == null || sLength == null || secondIntegerMarker !== 0x02) {
+    throw new Error("invalid_ecdsa_der_signature");
+  }
+  const s = signature.subarray(offset + 2, offset + 2 + sLength);
+
+  const output = Buffer.alloc(size * 2);
+  r.copy(output, size - Math.min(size, r.length), Math.max(0, r.length - size));
+  s.copy(output, size * 2 - Math.min(size, s.length), Math.max(0, s.length - size));
+  return output;
+}
+
+function joseToDerEcdsaSignature(signature: Buffer): Buffer {
+  const size = signature.length / 2;
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new Error("invalid_ecdsa_jose_signature");
+  }
+
+  const trimInteger = (value: Buffer) => {
+    let trimmed = value;
+    while (trimmed.length > 1 && trimmed[0] != null && trimmed[1] != null && trimmed[0] === 0x00 && (trimmed[1] & 0x80) === 0) {
+      trimmed = trimmed.subarray(1);
+    }
+    if (trimmed[0] != null && (trimmed[0] & 0x80) !== 0) {
+      trimmed = Buffer.concat([Buffer.from([0x00]), trimmed]);
+    }
+    return trimmed;
+  };
+
+  const r = trimInteger(signature.subarray(0, size));
+  const s = trimInteger(signature.subarray(size));
+  const totalLength = 2 + r.length + 2 + s.length;
+
+  return Buffer.concat([Buffer.from([0x30, totalLength, 0x02, r.length]), r, Buffer.from([0x02, s.length]), s]);
+}
+
+function createJwtToken(config: AppleIapRuntimeConfig, now: Date): string {
+  const header = {
+    alg: "ES256",
+    kid: config.keyId,
+    typ: "JWT"
+  };
+  const issuedAt = Math.floor(now.getTime() / 1000);
+  const payload = {
+    iss: config.issuerId,
+    iat: issuedAt,
+    exp: issuedAt + 300,
+    aud: "appstoreconnect-v1",
+    bid: config.bundleId
+  };
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signer = createSign("SHA256");
+  signer.update(signingInput);
+  signer.end();
+  const derSignature = signer.sign(createPrivateKey(config.privateKey));
+  const joseSignature = derToJoseEcdsaSignature(derSignature, 32);
+
+  return `${signingInput}.${base64UrlEncode(joseSignature)}`;
+}
+
+function decodeCompactJwsPart(value: string): string {
+  try {
+    return Buffer.from(value, "base64url").toString("utf8");
+  } catch {
+    throw new AppleIapVerificationError({
+      code: "apple_jws_malformed",
+      message: "signedTransactionInfo is not a valid JWS",
+      retryable: false,
+      statusCode: 400,
+      category: "invalid_request"
+    });
+  }
+}
+
+function normalizeAppleEnvironment(value?: string): "Production" | "Sandbox" {
+  if (value === "Production" || value === "Sandbox") {
+    return value;
+  }
+  throw new AppleIapVerificationError({
+    code: "apple_environment_invalid",
+    message: "Apple transaction environment is invalid or missing",
+    retryable: false,
+    statusCode: 400,
+    category: "verification"
+  });
+}
+
+function normalizeAppleTransactionPayload(payload: AppleTransactionPayload, expectedBundleId: string): AppleVerifiedTransaction {
+  const transactionId = String(payload.transactionId ?? "").trim();
+  const productId = payload.productId?.trim() || "";
+  const bundleId = payload.bundleId?.trim() || "";
+  const purchaseDateValue = payload.purchaseDate;
+  const purchaseDate =
+    typeof purchaseDateValue === "number"
+      ? new Date(purchaseDateValue).toISOString()
+      : typeof purchaseDateValue === "string" && purchaseDateValue.trim()
+        ? new Date(purchaseDateValue).toISOString()
+        : "";
+
+  if (!transactionId || !productId || !bundleId || !purchaseDate || Number.isNaN(new Date(purchaseDate).getTime())) {
+    throw new AppleIapVerificationError({
+      code: "apple_transaction_payload_invalid",
+      message: "Apple transaction payload is incomplete",
+      retryable: false,
+      statusCode: 400,
+      category: "verification"
+    });
+  }
+  if (bundleId !== expectedBundleId) {
+    throw new AppleIapVerificationError({
+      code: "apple_bundle_id_mismatch",
+      message: "Apple transaction bundleId does not match this server",
+      retryable: false,
+      statusCode: 400,
+      category: "verification"
+    });
+  }
+
+  return {
+    transactionId,
+    ...(payload.originalTransactionId != null ? { originalTransactionId: String(payload.originalTransactionId).trim() } : {}),
+    productId,
+    environment: normalizeAppleEnvironment(payload.environment),
+    bundleId,
+    purchaseDate,
+    ...(payload.appAccountToken?.trim() ? { appAccountToken: payload.appAccountToken.trim() } : {})
+  };
+}
+
+function verifySignedTransactionWithCertificateChain(
+  signedTransactionInfo: string,
+  config: AppleIapRuntimeConfig,
+  now: Date
+): AppleVerifiedTransaction {
+  const [encodedHeader, encodedPayload, encodedSignature] = signedTransactionInfo.split(".");
+  if (!encodedHeader || !encodedPayload || !encodedSignature) {
+    throw new AppleIapVerificationError({
+      code: "apple_jws_malformed",
+      message: "signedTransactionInfo is not a valid compact JWS",
+      retryable: false,
+      statusCode: 400,
+      category: "invalid_request"
+    });
+  }
+
+  const header = JSON.parse(decodeCompactJwsPart(encodedHeader)) as { alg?: string; x5c?: string[] };
+  if (header.alg !== "ES256" || !Array.isArray(header.x5c) || header.x5c.length === 0) {
+    throw new AppleIapVerificationError({
+      code: "apple_signature_header_invalid",
+      message: "Apple transaction JWS header is invalid",
+      retryable: false,
+      statusCode: 400,
+      category: "verification"
+    });
+  }
+
+  const leafCertificateDer = header.x5c[0];
+  if (!leafCertificateDer) {
+    throw new AppleIapVerificationError({
+      code: "apple_signature_header_invalid",
+      message: "Apple transaction JWS header is invalid",
+      retryable: false,
+      statusCode: 400,
+      category: "verification"
+    });
+  }
+  const leafCertificatePem = `-----BEGIN CERTIFICATE-----\n${leafCertificateDer.match(/.{1,64}/g)?.join("\n") ?? leafCertificateDer}\n-----END CERTIFICATE-----`;
+  const leafCertificate = new X509Certificate(leafCertificatePem);
+  const validFrom = new Date(leafCertificate.validFrom);
+  const validTo = new Date(leafCertificate.validTo);
+  if (Number.isNaN(validFrom.getTime()) || Number.isNaN(validTo.getTime()) || now < validFrom || now > validTo) {
+    throw new AppleIapVerificationError({
+      code: "apple_certificate_invalid",
+      message: "Apple transaction signing certificate is not currently valid",
+      retryable: false,
+      statusCode: 400,
+      category: "verification"
+    });
+  }
+
+  const verifier = createVerify("SHA256");
+  verifier.update(`${encodedHeader}.${encodedPayload}`);
+  verifier.end();
+  const signature = joseToDerEcdsaSignature(Buffer.from(encodedSignature, "base64url"));
+  if (!verifier.verify(leafCertificate.publicKey, signature)) {
+    throw new AppleIapVerificationError({
+      code: "apple_signature_invalid",
+      message: "Apple transaction signature validation failed",
+      retryable: false,
+      statusCode: 400,
+      category: "verification"
+    });
+  }
+
+  const payload = JSON.parse(decodeCompactJwsPart(encodedPayload)) as AppleTransactionPayload;
+  return normalizeAppleTransactionPayload(payload, config.bundleId);
+}
+
+function isAppleTransactionNotFound(statusCode: number, payload: unknown): boolean {
+  if (statusCode !== 404) {
+    return false;
+  }
+  if (!payload || typeof payload !== "object") {
+    return true;
+  }
+  const errorCode = "errorCode" in payload ? String((payload as { errorCode?: unknown }).errorCode ?? "") : "";
+  return errorCode === "" || errorCode === "4040010";
+}
+
+async function fetchAppleTransactionFromEnvironment(input: {
+  config: AppleIapRuntimeConfig;
+  fetchImpl: typeof fetch;
+  now: Date;
+  transactionId: string;
+  environment: "Production" | "Sandbox";
+}): Promise<{ environment: "Production" | "Sandbox"; signedTransactionInfo: string }> {
+  const baseUrl = input.environment === "Sandbox" ? input.config.sandboxApiUrl : input.config.productionApiUrl;
+  const response = await input.fetchImpl(`${baseUrl}/inApps/v1/transactions/${encodeURIComponent(input.transactionId)}`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${createJwtToken(input.config, input.now)}`
+    }
+  });
+
+  let payload: AppleTransactionLookupResponse | { errorCode?: string | number; errorMessage?: string } | null = null;
+  try {
+    payload = (await response.json()) as AppleTransactionLookupResponse;
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok) {
+    if (isAppleTransactionNotFound(response.status, payload)) {
+      throw new AppleIapVerificationError({
+        code: "apple_transaction_not_found",
+        message: "Apple transaction is not available yet",
+        retryable: true,
+        statusCode: 502,
+        category: "upstream"
+      });
+    }
+    throw new AppleIapVerificationError({
+      code: "apple_verification_upstream_failed",
+      message:
+        payload && typeof payload === "object" && "errorMessage" in payload && typeof payload.errorMessage === "string"
+          ? payload.errorMessage
+          : `Apple verification request failed with status ${response.status}`,
+      retryable: response.status >= 500 || response.status === 429,
+      statusCode: response.status >= 500 ? 502 : 400,
+      category: response.status >= 500 || response.status === 429 ? "upstream" : "verification"
+    });
+  }
+
+  const signedTransactionInfo = payload && typeof payload === "object" && "signedTransactionInfo" in payload ? payload.signedTransactionInfo : "";
+  if (!signedTransactionInfo || typeof signedTransactionInfo !== "string") {
+    throw new AppleIapVerificationError({
+      code: "apple_verification_response_invalid",
+      message: "Apple verification response did not include signedTransactionInfo",
+      retryable: true,
+      statusCode: 502,
+      category: "upstream"
+    });
+  }
+
+  return {
+    environment: input.environment,
+    signedTransactionInfo
+  };
+}
+
+export function createAppleStoreKitVerificationAdapter(input: {
+  config: AppleIapRuntimeConfig;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+  verifySignedTransaction?: (signedTransactionInfo: string, config: AppleIapRuntimeConfig, now: Date) => AppleVerifiedTransaction;
+}): AppleStoreKitVerificationAdapter {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const now = input.now ?? (() => new Date());
+  const verifySignedTransaction = input.verifySignedTransaction ?? verifySignedTransactionWithCertificateChain;
+
+  return {
+    async verifyTransaction({ signedTransactionInfo }) {
+      const verifiedClientTransaction = verifySignedTransaction(signedTransactionInfo, input.config, now());
+      const preferredEnvironment = verifiedClientTransaction.environment;
+
+      try {
+        const upstream = await fetchAppleTransactionFromEnvironment({
+          config: input.config,
+          fetchImpl,
+          now: now(),
+          transactionId: verifiedClientTransaction.transactionId,
+          environment: preferredEnvironment
+        });
+        const verifiedServerTransaction = verifySignedTransaction(upstream.signedTransactionInfo, input.config, now());
+        if (verifiedServerTransaction.transactionId !== verifiedClientTransaction.transactionId) {
+          throw new AppleIapVerificationError({
+            code: "apple_transaction_mismatch",
+            message: "Apple verification response returned a different transactionId",
+            retryable: false,
+            statusCode: 400,
+            category: "verification"
+          });
+        }
+        if (verifiedServerTransaction.productId !== verifiedClientTransaction.productId) {
+          throw new AppleIapVerificationError({
+            code: "apple_product_mismatch",
+            message: "Apple verification response returned a different productId",
+            retryable: false,
+            statusCode: 400,
+            category: "verification"
+          });
+        }
+        return verifiedServerTransaction;
+      } catch (error) {
+        if (
+          error instanceof AppleIapVerificationError &&
+          error.name === "apple_transaction_not_found" &&
+          preferredEnvironment === "Production"
+        ) {
+          const upstream = await fetchAppleTransactionFromEnvironment({
+            config: input.config,
+            fetchImpl,
+            now: now(),
+            transactionId: verifiedClientTransaction.transactionId,
+            environment: "Sandbox"
+          });
+          const verifiedServerTransaction = verifySignedTransaction(upstream.signedTransactionInfo, input.config, now());
+          if (verifiedServerTransaction.transactionId !== verifiedClientTransaction.transactionId) {
+            throw new AppleIapVerificationError({
+              code: "apple_transaction_mismatch",
+              message: "Apple verification response returned a different transactionId",
+              retryable: false,
+              statusCode: 400,
+              category: "verification"
+            });
+          }
+          return verifiedServerTransaction;
+        }
+
+        throw error;
+      }
+    }
+  };
+}
+
+export function registerApplePaymentRoutes(
+  app: HttpApp,
+  store: RoomSnapshotStore | null,
+  options: RegisterApplePaymentRoutesOptions = {}
+): void {
+  const products = resolveShopProducts(options);
+  const now = options.now ?? (() => new Date());
+  const runtimeConfig = options.runtimeConfig ?? readAppleIapRuntimeConfig();
+  const adapter =
+    options.adapter ??
+    (runtimeConfig
+      ? createAppleStoreKitVerificationAdapter({
+          config: runtimeConfig,
+          ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+          now
+        })
+      : null);
+
+  app.use((request, response, next) => {
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Veil-Auth");
+
+    if (request.method === "OPTIONS") {
+      response.statusCode = 204;
+      response.end();
+      return;
+    }
+
+    next();
+  });
+
+  app.post("/api/payments/apple/verify", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+    if (!adapter) {
+      sendJson(response, 503, {
+        error: {
+          code: "apple_iap_not_configured",
+          message: "Apple IAP runtime configuration is incomplete",
+          retryable: false,
+          category: "configuration"
+        }
+      });
+      return;
+    }
+    if (!isPaymentStoreReady(store)) {
+      sendJson(response, 503, {
+        error: {
+          code: "payment_persistence_unavailable",
+          message: "Payment verification requires configured persistence storage",
+          retryable: true,
+          category: "configuration"
+        }
+      });
+      return;
+    }
+
+    let orderId = "";
+    let productId = "";
+
+    try {
+      const body = (await readJsonBody(request)) as { signedTransactionInfo?: string | null };
+      const signedTransactionInfo = body.signedTransactionInfo?.trim();
+      if (!signedTransactionInfo) {
+        throw new AppleIapVerificationError({
+          code: "apple_signed_transaction_required",
+          message: "signedTransactionInfo is required",
+          retryable: false,
+          statusCode: 400,
+          category: "invalid_request"
+        });
+      }
+
+      const verified = await adapter.verifyTransaction({ signedTransactionInfo });
+      const product = normalizeApplePaymentProduct(findProductForAppleTransaction(products, verified.productId));
+      const amount = resolveAppleOrderAmount(product);
+      orderId = `apple:${verified.transactionId}`;
+      productId = product.productId;
+
+      let order = await store.loadPaymentOrder(orderId);
+      if (order && order.playerId !== authSession.playerId) {
+        emitPaymentFraudSignal(authSession.playerId, "transaction_claimed_by_another_player", {
+          orderId,
+          productId: product.productId,
+          transactionId: verified.transactionId
+        });
+        sendJson(response, 409, {
+          error: {
+            code: "payment_already_verified",
+            message: "Payment order has already been verified",
+            retryable: false,
+            category: "verification"
+          }
+        });
+        return;
+      }
+
+      if (!order) {
+        try {
+          order = await store.createPaymentOrder({
+            orderId,
+            playerId: authSession.playerId,
+            productId: product.productId,
+            amount,
+            gemAmount: product.grant.gems ?? 0
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!/duplicate/i.test(message)) {
+            throw error;
+          }
+          order = await store.loadPaymentOrder(orderId);
+        }
+      }
+
+      if (!order || order.playerId !== authSession.playerId) {
+        throw new AppleIapVerificationError({
+          code: "payment_order_not_found",
+          message: "Payment order was not found",
+          retryable: false,
+          statusCode: 404,
+          category: "verification"
+        });
+      }
+
+      const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+      if (isAcceptedPaymentOrderStatus(order.status) || existingReceipt) {
+        emitPaymentFraudSignal(order.playerId, "duplicate_transaction_id", {
+          orderId: order.orderId,
+          productId: order.productId,
+          transactionId: verified.transactionId
+        });
+        sendJson(response, 409, {
+          error: {
+            code: "payment_already_verified",
+            message: "Payment order has already been verified",
+            retryable: false,
+            category: "verification"
+          }
+        });
+        return;
+      }
+
+      const settlement = await store.completePaymentOrder(order.orderId, {
+        wechatOrderId: verified.transactionId,
+        paidAt: verified.purchaseDate,
+        verifiedAt: now().toISOString(),
+        productName: product.name,
+        grant: product.grant,
+        retryPolicy: normalizePaymentGrantRetryPolicy()
+      });
+
+      if (settlement.order.status === "dead_letter") {
+        recordPaymentDeadLetter();
+      }
+      if (isPaymentOpsStoreReady(store)) {
+        await refreshPaymentGrantObservability(store, now());
+      }
+      if (!settlement.credited) {
+        emitPurchaseFailedEvent({
+          playerId: order.playerId,
+          purchaseId: order.orderId,
+          productId: order.productId,
+          paymentMethod: "apple_iap",
+          failureReason: settlement.order.lastGrantError ?? "grant_failed",
+          orderStatus: settlement.order.status
+        });
+      }
+      if (!settlement.credited && isFinalizedPaymentOrderStatus(settlement.order.status)) {
+        sendJson(response, 409, {
+          error: {
+            code: "payment_already_verified",
+            message: "Payment order has already been verified",
+            retryable: false,
+            category: "verification"
+          }
+        });
+        return;
+      }
+
+      emitAnalyticsEvent("purchase", {
+        playerId: order.playerId,
+        payload: {
+          purchaseId: order.orderId,
+          productId: order.productId,
+          quantity: 1,
+          totalPrice: order.amount
+        }
+      });
+      if (settlement.credited) {
+        emitPurchaseCompletedEvent({
+          playerId: order.playerId,
+          purchaseId: order.orderId,
+          productId: order.productId,
+          paymentMethod: "apple_iap",
+          quantity: 1,
+          totalPrice: order.amount
+        });
+      }
+
+      const recentVerifiedCount = await store.countVerifiedPaymentReceiptsSince(
+        order.playerId,
+        new Date(now().getTime() - 60_000).toISOString()
+      );
+      if (recentVerifiedCount > 3) {
+        emitPaymentFraudSignal(order.playerId, "high_velocity_purchases", {
+          orderId: order.orderId,
+          productId: order.productId,
+          transactionId: verified.transactionId,
+          recentVerifiedCount
+        });
+      }
+
+      sendJson(response, 200, {
+        orderId: settlement.order.orderId,
+        status: settlement.order.status,
+        credited: settlement.credited,
+        paidAt: settlement.order.paidAt,
+        transactionId: verified.transactionId,
+        environment: verified.environment,
+        ...(verified.originalTransactionId ? { originalTransactionId: verified.originalTransactionId } : {}),
+        ...(settlement.order.nextGrantRetryAt ? { nextGrantRetryAt: settlement.order.nextGrantRetryAt } : {}),
+        ...(settlement.order.lastGrantError ? { lastGrantError: settlement.order.lastGrantError } : {}),
+        gemsBalance: settlement.account.gems ?? 0,
+        seasonPassPremium: settlement.account.seasonPassPremium === true
+      });
+    } catch (error) {
+      if (error instanceof AppleIapVerificationError) {
+        sendJson(response, error.statusCode, error.toResponseBody());
+        return;
+      }
+
+      const message = error instanceof Error ? error.message : String(error);
+      sendJson(response, 502, {
+        error: {
+          code: "apple_iap_verification_failed",
+          message,
+          retryable: true,
+          category: "upstream"
+        }
+      });
+    }
+  });
+}

--- a/apps/server/src/client-error.ts
+++ b/apps/server/src/client-error.ts
@@ -371,11 +371,21 @@ export function registerClientErrorRoutes(
         return;
       }
 
-      if (error instanceof PayloadValidationError || error instanceof SyntaxError) {
+      if (error instanceof PayloadValidationError) {
         sendJson(response, 400, {
           error: {
-            code: error instanceof SyntaxError ? "invalid_json" : error.name,
-            message: error instanceof SyntaxError ? "Request body must be valid JSON" : error.message
+            code: error.name,
+            message: error.message
+          }
+        });
+        return;
+      }
+
+      if (error instanceof SyntaxError) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_json",
+            message: "Request body must be valid JSON"
           }
         });
         return;

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -39,6 +39,7 @@ import { formatSchemaMigrationWarning, getSchemaMigrationStatus } from "./schema
 import { registerAdminRoutes } from "./admin-console";
 import { registerSeasonRoutes } from "./seasons";
 import { registerShopRoutes } from "./shop";
+import { registerApplePaymentRoutes } from "./apple-iap";
 import { registerWechatPayRoutes } from "./wechat-pay";
 import { captureServerError, isErrorMonitoringEnabled } from "./error-monitoring";
 import { recordRuntimeErrorEvent } from "./observability";
@@ -132,6 +133,7 @@ export interface DevServerBootstrapDependencies {
   registerGuildRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerPlayerAccountRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerShopRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
+  registerApplePaymentRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerWechatPayRoutes(app: unknown, store: DevServerRoomSnapshotStore): void;
   registerLobbyRoutes(app: unknown, dependencies: { listRooms: typeof listLobbyRooms }): void;
   registerMatchmakingRoutes(app: unknown, dependencies: { store: DevServerRoomSnapshotStore }): void;
@@ -214,6 +216,7 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerGuildRoutes: (app, store) => registerGuildRoutes(app as never, store as RoomSnapshotStore),
     registerPlayerAccountRoutes: (app, store) => registerPlayerAccountRoutes(app as never, store as RoomSnapshotStore),
     registerShopRoutes: (app, store) => registerShopRoutes(app as never, store as RoomSnapshotStore),
+    registerApplePaymentRoutes: (app, store) => registerApplePaymentRoutes(app as never, store as RoomSnapshotStore),
     registerWechatPayRoutes: (app, store) => registerWechatPayRoutes(app as never, store as RoomSnapshotStore),
     registerLobbyRoutes: (app, dependencies) => registerLobbyRoutes(app as never, dependencies),
     registerMatchmakingRoutes: (app, dependencies) =>
@@ -366,6 +369,7 @@ export async function startDevServer(
   deps.registerGuildRoutes(expressApp, effectiveSnapshotStore);
   deps.registerPlayerAccountRoutes(expressApp, effectiveSnapshotStore);
   deps.registerShopRoutes(expressApp, effectiveSnapshotStore);
+  deps.registerApplePaymentRoutes(expressApp, effectiveSnapshotStore);
   deps.registerWechatPayRoutes(expressApp, effectiveSnapshotStore);
   deps.registerLobbyRoutes(expressApp, { listRooms: listLobbyRooms });
   deps.registerMatchmakingRoutes(expressApp, { store: effectiveSnapshotStore });
@@ -397,6 +401,7 @@ export async function startDevServer(
   deps.logger.log(`Guild API available at http://${host}:${port}/api/guilds`);
   deps.logger.log(`Guest auth API available at http://${host}:${port}/api/auth/guest-login`);
   deps.logger.log(`WeChat auth API available at http://${host}:${port}/api/auth/wechat-login`);
+  deps.logger.log(`Apple IAP verify API available at http://${host}:${port}/api/payments/apple/verify`);
   deps.logger.log(`WeChat Pay API available at http://${host}:${port}/api/payments/wechat/create`);
   deps.logger.log(`Lobby API available at http://${host}:${port}/api/lobby/rooms`);
   deps.logger.log(`Matchmaking API available at http://${host}:${port}/api/matchmaking/status`);

--- a/apps/server/src/shop.ts
+++ b/apps/server/src/shop.ts
@@ -30,6 +30,8 @@ export interface ShopProduct {
   type: ShopProductType;
   price: number;
   wechatPriceFen?: number;
+  appleProductId?: string;
+  applePriceCents?: number;
   enabled: boolean;
   grant: ShopProductGrant;
 }
@@ -273,6 +275,10 @@ function normalizeShopProducts(rawProducts?: Partial<ShopProduct>[] | null): Sho
       price: normalizePositiveInteger(rawProduct.price ?? Number.NaN, `shop product ${productId} price`, true),
       ...(rawProduct.wechatPriceFen != null
         ? { wechatPriceFen: normalizePositiveInteger(rawProduct.wechatPriceFen, `shop product ${productId} wechatPriceFen`) }
+        : {}),
+      ...(rawProduct.appleProductId?.trim() ? { appleProductId: rawProduct.appleProductId.trim() } : {}),
+      ...(rawProduct.applePriceCents != null
+        ? { applePriceCents: normalizePositiveInteger(rawProduct.applePriceCents, `shop product ${productId} applePriceCents`) }
         : {}),
       enabled: rawProduct.enabled !== false,
       grant

--- a/apps/server/test/apple-iap-routes.test.ts
+++ b/apps/server/test/apple-iap-routes.test.ts
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { generateKeyPairSync } from "node:crypto";
+import { Readable } from "node:stream";
+import test from "node:test";
+import { issueAccountAuthSession } from "../src/auth";
+import {
+  AppleIapVerificationError,
+  createAppleStoreKitVerificationAdapter,
+  registerApplePaymentRoutes,
+  type AppleIapRuntimeConfig,
+  type AppleVerifiedTransaction
+} from "../src/apple-iap";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import type { ShopProduct } from "../src/shop";
+
+const TEST_PRODUCTS: Partial<ShopProduct>[] = [
+  {
+    productId: "gem-pack-ios",
+    appleProductId: "com.projectveil.gems.ios",
+    applePriceCents: 499,
+    name: "iOS Gem Cache",
+    type: "gem_pack",
+    price: 5,
+    enabled: true,
+    grant: {
+      gems: 60
+    }
+  }
+];
+
+class TestResponse extends EventEmitter {
+  statusCode = 200;
+  readonly headers = new Map<string, string>();
+  body = "";
+
+  setHeader(name: string, value: string): void {
+    this.headers.set(name.toLowerCase(), value);
+  }
+
+  end(chunk?: string | Buffer): void {
+    if (chunk != null) {
+      this.body += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+    }
+    this.emit("finish");
+  }
+}
+
+class TestApp {
+  private readonly middlewares: Array<(request: never, response: never, next: () => void) => void> = [];
+  private readonly postHandlers = new Map<string, (request: never, response: never) => void | Promise<void>>();
+
+  use(handler: (request: never, response: never, next: () => void) => void): void {
+    this.middlewares.push(handler);
+  }
+
+  post(path: string, handler: (request: never, response: never) => void | Promise<void>): void {
+    this.postHandlers.set(path, handler);
+  }
+
+  async invoke(path: string, options: { body?: string; headers?: Record<string, string>; method?: "POST" | "OPTIONS" } = {}) {
+    const method = options.method ?? "POST";
+    const routePath = new URL(path, "http://test.local").pathname;
+    const routeHandler = this.postHandlers.get(routePath);
+    if (!routeHandler) {
+      throw new Error(`No ${method} handler registered for ${routePath}`);
+    }
+
+    const request = Readable.from(options.body ? [Buffer.from(options.body, "utf8")] : []) as Readable & {
+      headers: Record<string, string>;
+      method: string;
+      url: string;
+    };
+    request.headers = Object.fromEntries(Object.entries(options.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value]));
+    request.method = method;
+    request.url = path;
+
+    const response = new TestResponse();
+    const handlers = [...this.middlewares, async (req: never, res: never) => routeHandler(req, res)];
+    let index = 0;
+
+    const next = (): void => {
+      const handler = handlers[index];
+      index += 1;
+      if (!handler) {
+        return;
+      }
+      void handler(request as never, response as never, next);
+    };
+
+    next();
+    await EventEmitter.once(response, "finish");
+
+    return {
+      statusCode: response.statusCode,
+      headers: response.headers,
+      json: response.body ? (JSON.parse(response.body) as unknown) : null
+    };
+  }
+}
+
+function issueSession() {
+  return issueAccountAuthSession({
+    playerId: "ios-player",
+    displayName: "App Store Ranger",
+    loginId: "ios-player",
+    provider: "account-password"
+  });
+}
+
+function createVerifiedTransaction(overrides: Partial<AppleVerifiedTransaction> = {}): AppleVerifiedTransaction {
+  return {
+    transactionId: "1000001234567890",
+    productId: "com.projectveil.gems.ios",
+    environment: "Production",
+    bundleId: "com.projectveil.app",
+    purchaseDate: "2026-04-13T01:17:00.000Z",
+    ...overrides
+  };
+}
+
+function createAppleRuntimeConfig(): AppleIapRuntimeConfig {
+  const signingKeys = generateKeyPairSync("ec", {
+    namedCurve: "prime256v1"
+  });
+
+  return {
+    bundleId: "com.projectveil.app",
+    issuerId: "11111111-2222-3333-4444-555555555555",
+    keyId: "ABC123DEFG",
+    privateKey: signingKeys.privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    productionApiUrl: "https://apple.example.test",
+    sandboxApiUrl: "https://apple-sandbox.example.test"
+  };
+}
+
+test("apple verify settles a StoreKit 2 transaction through the shared payment flow", async () => {
+  const app = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  const session = issueSession();
+
+  registerApplePaymentRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    adapter: {
+      verifyTransaction: async () => createVerifiedTransaction()
+    }
+  });
+
+  const response = await app.invoke("/api/payments/apple/verify", {
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      signedTransactionInfo: "client-jws"
+    })
+  });
+
+  const payload = response.json as {
+    orderId: string;
+    status: string;
+    credited: boolean;
+    transactionId: string;
+    environment: string;
+    gemsBalance: number;
+  };
+  const order = await store.loadPaymentOrder(payload.orderId);
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(payload.orderId, "apple:1000001234567890");
+  assert.equal(payload.status, "settled");
+  assert.equal(payload.credited, true);
+  assert.equal(payload.transactionId, "1000001234567890");
+  assert.equal(payload.environment, "Production");
+  assert.equal(payload.gemsBalance, 60);
+  assert.equal(order?.status, "settled");
+  assert.equal(order?.wechatOrderId, "1000001234567890");
+});
+
+test("apple verify rejects duplicate transaction ids through the shared idempotency guard", async () => {
+  const app = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  const session = issueSession();
+
+  registerApplePaymentRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    adapter: {
+      verifyTransaction: async () => createVerifiedTransaction()
+    }
+  });
+
+  const firstResponse = await app.invoke("/api/payments/apple/verify", {
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      signedTransactionInfo: "client-jws"
+    })
+  });
+  const secondResponse = await app.invoke("/api/payments/apple/verify", {
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      signedTransactionInfo: "client-jws"
+    })
+  });
+
+  const errorPayload = secondResponse.json as { error: { code: string; retryable: boolean } };
+  assert.equal(firstResponse.statusCode, 200);
+  assert.equal(secondResponse.statusCode, 409);
+  assert.equal(errorPayload.error.code, "payment_already_verified");
+  assert.equal(errorPayload.error.retryable, false);
+});
+
+test("apple verify returns a permanent structured error when signature validation fails", async () => {
+  const app = new TestApp();
+  const store = new MemoryRoomSnapshotStore();
+  const session = issueSession();
+
+  registerApplePaymentRoutes(app as never, store, {
+    products: TEST_PRODUCTS,
+    adapter: {
+      verifyTransaction: async () => {
+        throw new AppleIapVerificationError({
+          code: "apple_signature_invalid",
+          message: "Apple transaction signature validation failed",
+          retryable: false,
+          statusCode: 400,
+          category: "verification"
+        });
+      }
+    }
+  });
+
+  const response = await app.invoke("/api/payments/apple/verify", {
+    headers: {
+      authorization: `Bearer ${session.token}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      signedTransactionInfo: "bad-client-jws"
+    })
+  });
+
+  const payload = response.json as { error: { code: string; retryable: boolean; category: string } };
+  assert.equal(response.statusCode, 400);
+  assert.equal(payload.error.code, "apple_signature_invalid");
+  assert.equal(payload.error.retryable, false);
+  assert.equal(payload.error.category, "verification");
+});
+
+test("apple adapter retries sandbox after a production transaction lookup miss", async () => {
+  const runtimeConfig = createAppleRuntimeConfig();
+  const seenUrls: string[] = [];
+  const adapter = createAppleStoreKitVerificationAdapter({
+    config: runtimeConfig,
+    fetchImpl: (async (input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      seenUrls.push(url);
+      if (url.startsWith(runtimeConfig.productionApiUrl)) {
+        return new Response(
+          JSON.stringify({
+            errorCode: "4040010",
+            errorMessage: "TransactionIdNotFound"
+          }),
+          {
+            status: 404,
+            headers: {
+              "Content-Type": "application/json"
+            }
+          }
+        );
+      }
+
+      return new Response(JSON.stringify({ signedTransactionInfo: "sandbox-jws" }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json"
+        }
+      });
+    }) as typeof fetch,
+    verifySignedTransaction: (signedTransactionInfo, config) => {
+      assert.equal(config.bundleId, "com.projectveil.app");
+      if (signedTransactionInfo === "client-jws") {
+        return createVerifiedTransaction({
+          environment: "Production"
+        });
+      }
+      if (signedTransactionInfo === "sandbox-jws") {
+        return createVerifiedTransaction({
+          environment: "Sandbox"
+        });
+      }
+      throw new Error(`Unexpected token ${signedTransactionInfo}`);
+    }
+  });
+
+  const verified = await adapter.verifyTransaction({
+    signedTransactionInfo: "client-jws"
+  });
+
+  assert.equal(verified.environment, "Sandbox");
+  assert.deepEqual(seenUrls, [
+    "https://apple.example.test/inApps/v1/transactions/1000001234567890",
+    "https://apple-sandbox.example.test/inApps/v1/transactions/1000001234567890"
+  ]);
+});


### PR DESCRIPTION
## Summary
- add Apple StoreKit transaction verification routes and adapter wiring for `/api/payments/apple/verify`
- route verified Apple purchases through the existing shop reward/idempotency flow with sandbox fallback and structured errors
- cover happy path, duplicate transaction, invalid signature, and sandbox retry behavior with focused tests

## Validation
- `node --import tsx --test apps/server/test/apple-iap-routes.test.ts`

Closes #1367
