### PR TITLE
Add APNs/FCM mobile push vertical slice

### DIFF
--- a/apps/server/src/colyseus-room.ts
+++ b/apps/server/src/colyseus-room.ts
@@ -82,6 +82,7 @@ import {
   recordWorldActionMessage,
   removeRuntimeRoom
 } from "./observability";
+import { sendMobilePushNotification } from "./mobile-push";
 import { sendWechatSubscribeMessage, type WechatSubscribeTemplateKey } from "./wechat-subscribe";
 import { resolveFeatureFlagsForPlayer } from "./feature-flags";
 import { captureServerError } from "./error-monitoring";
@@ -288,6 +289,12 @@ interface RoomRuntimeDependencies {
     data: Record<string, unknown>,
     options?: { store?: RoomSnapshotStore | null }
   ): Promise<boolean>;
+  sendMobilePushNotification(
+    playerId: string,
+    templateKey: WechatSubscribeTemplateKey,
+    data: Record<string, unknown>,
+    options?: { store?: RoomSnapshotStore | null }
+  ): Promise<boolean>;
 }
 
 const defaultRoomRuntimeDependencies: RoomRuntimeDependencies = {
@@ -296,7 +303,9 @@ const defaultRoomRuntimeDependencies: RoomRuntimeDependencies = {
   isMySqlSnapshotStore: (store) => Boolean(store && "getRetentionPolicy" in store),
   now: () => Date.now(),
   sendWechatSubscribeMessage: (playerId, templateKey, data, options) =>
-    sendWechatSubscribeMessage(playerId, templateKey, data, options)
+    sendWechatSubscribeMessage(playerId, templateKey, data, options),
+  sendMobilePushNotification: (playerId, templateKey, data, options) =>
+    sendMobilePushNotification(playerId, templateKey, data, options)
 };
 
 let roomRuntimeDependencies: RoomRuntimeDependencies = defaultRoomRuntimeDependencies;
@@ -2855,8 +2864,19 @@ export class VeilColyseusRoom extends Room<VeilRoomOptions> {
           store: configuredRoomSnapshotStore
         }
       );
+      await roomRuntimeDependencies.sendMobilePushNotification(
+        nextTurnOwnerPlayerId,
+        "turn_reminder",
+        {
+          roomId: this.metadata.logicalRoomId,
+          turnNumber: this.worldRoom.getInternalState().meta.day
+        },
+        {
+          store: configuredRoomSnapshotStore
+        }
+      );
     } catch (error) {
-      console.error("[VeilRoom] Failed to send WeChat turn reminder subscribe message", {
+      console.error("[VeilRoom] Failed to send turn reminder notification", {
         roomId: this.metadata.logicalRoomId,
         playerId: nextTurnOwnerPlayerId,
         turnNumber: this.worldRoom.getInternalState().meta.day,

--- a/apps/server/src/matchmaking.ts
+++ b/apps/server/src/matchmaking.ts
@@ -12,6 +12,7 @@ import {
   type MatchmakingRequest
 } from "../../../packages/shared/src/index";
 import { validateAuthSessionFromRequest } from "./auth";
+import { sendMobilePushNotification } from "./mobile-push";
 import { recordMatchmakingRateLimited, setMatchmakingQueueDepth } from "./observability";
 import type { RoomSnapshotStore } from "./persistence";
 import { createRedisClient, readRedisUrl, type RedisClientLike } from "./redis";
@@ -38,12 +39,20 @@ interface MatchmakingRuntimeDependencies {
     data: Record<string, unknown>,
     options?: { store?: RoomSnapshotStore | null }
   ): Promise<boolean>;
+  sendMobilePushNotification(
+    playerId: string,
+    templateKey: "match_found",
+    data: Record<string, unknown>,
+    options?: { store?: RoomSnapshotStore | null }
+  ): Promise<boolean>;
 }
 
 const matchmakingRateLimitCounters = new Map<string, number[]>();
 const defaultMatchmakingRuntimeDependencies: MatchmakingRuntimeDependencies = {
   sendWechatSubscribeMessage: (playerId, templateKey, data, options) =>
-    sendWechatSubscribeMessage(playerId, templateKey, data, options)
+    sendWechatSubscribeMessage(playerId, templateKey, data, options),
+  sendMobilePushNotification: (playerId, templateKey, data, options) =>
+    sendMobilePushNotification(playerId, templateKey, data, options)
 };
 let matchmakingRuntimeDependencies: MatchmakingRuntimeDependencies = defaultMatchmakingRuntimeDependencies;
 
@@ -736,8 +745,18 @@ async function notifyPlayersAboutMatchFound(
             },
             { store }
           );
+          await matchmakingRuntimeDependencies.sendMobilePushNotification(
+            playerId,
+            "match_found",
+            {
+              mapName: describeMatchmakingMapName(account?.lastRoomId ?? result.roomId),
+              opponentName: opponentAccount?.displayName?.trim() || opponentId,
+              roomId: result.roomId
+            },
+            { store }
+          );
         } catch (error) {
-          console.error("[matchmaking] Failed to send WeChat match-found notification", {
+          console.error("[matchmaking] Failed to send match-found notification", {
             roomId: result.roomId,
             playerId,
             opponentId,

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -81,6 +81,7 @@ import {
   type ShopPurchaseMutationInput,
   type ShopPurchaseResult
 } from "./persistence";
+import { normalizeMobilePushTokenRegistrations } from "./mobile-push-tokens";
 import {
   assertDisplayNameAvailableOrThrow,
   buildBannedAccountNameReservationExpiry
@@ -765,6 +766,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   async ensurePlayerAccount(input: PlayerAccountEnsureInput): Promise<PlayerAccountSnapshot> {
     const playerId = normalizePlayerId(input.playerId);
     const existing = this.accounts.get(playerId);
+    const existingPushTokens = existing?.pushTokens ? normalizeMobilePushTokenRegistrations(existing.pushTokens) : undefined;
     const nextDisplayName = normalizeDisplayName(playerId, input.displayName ?? existing?.displayName);
     if (!existing || nextDisplayName !== existing.displayName) {
       await assertDisplayNameAvailableOrThrow(this, nextDisplayName, playerId);
@@ -819,6 +821,7 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
       ...(existing?.notificationPreferences
         ? { notificationPreferences: structuredClone(existing.notificationPreferences) }
         : {}),
+      ...(existingPushTokens ? { pushTokens: existingPushTokens } : {}),
       createdAt: existing?.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     };
@@ -2069,6 +2072,14 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
   async savePlayerAccountProfile(playerId: string, patch: PlayerAccountProfilePatch): Promise<PlayerAccountSnapshot> {
     const normalizedPlayerId = normalizePlayerId(playerId);
     const existing = await this.ensurePlayerAccount({ playerId: normalizedPlayerId });
+    const nextPushTokens =
+      patch.pushTokens !== undefined
+        ? patch.pushTokens?.length
+          ? normalizeMobilePushTokenRegistrations(patch.pushTokens)
+          : undefined
+        : existing.pushTokens
+          ? normalizeMobilePushTokenRegistrations(existing.pushTokens)
+          : undefined;
     const normalizedAvatarUrl =
       patch.avatarUrl !== undefined ? normalizeAvatarUrl(patch.avatarUrl) : existing.avatarUrl;
     const nextDisplayName =
@@ -2094,8 +2105,12 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         : existing.notificationPreferences
           ? { notificationPreferences: structuredClone(existing.notificationPreferences) }
           : {}),
+      ...(nextPushTokens ? { pushTokens: nextPushTokens } : {}),
       updatedAt: new Date().toISOString()
     };
+    if (patch.pushTokens !== undefined && !nextPushTokens) {
+      delete nextAccount.pushTokens;
+    }
     this.accounts.set(normalizedPlayerId, cloneAccount(nextAccount));
     if (nextDisplayName !== existing.displayName) {
       this.appendPlayerNameHistory(normalizedPlayerId, nextDisplayName, nextAccount.updatedAt);

--- a/apps/server/src/mobile-push-tokens.ts
+++ b/apps/server/src/mobile-push-tokens.ts
@@ -1,0 +1,99 @@
+import type { MobilePushPlatform, MobilePushTokenRegistration } from "../../../packages/shared/src/index";
+
+const MAX_PUSH_TOKEN_LENGTH = 4096;
+
+function normalizeMobilePushPlatform(platform: string): MobilePushPlatform {
+  const normalized = platform.trim().toLowerCase();
+  if (normalized !== "ios" && normalized !== "android") {
+    throw new Error("platform must be ios or android");
+  }
+
+  return normalized;
+}
+
+function normalizeMobilePushTokenValue(token: string): string {
+  const normalized = token.trim();
+  if (!normalized) {
+    throw new Error("token must not be empty");
+  }
+  if (normalized.length > MAX_PUSH_TOKEN_LENGTH) {
+    throw new Error("token must be 4096 characters or fewer");
+  }
+
+  return normalized;
+}
+
+export function normalizeMobilePushTokenRegistration(
+  registration: { platform: string; token: string; registeredAt?: string; updatedAt?: string },
+  now = new Date().toISOString()
+): MobilePushTokenRegistration {
+  const registeredAt = registration.registeredAt?.trim() ? new Date(registration.registeredAt).toISOString() : now;
+  return {
+    platform: normalizeMobilePushPlatform(registration.platform),
+    token: normalizeMobilePushTokenValue(registration.token),
+    registeredAt,
+    updatedAt: registration.updatedAt?.trim() ? new Date(registration.updatedAt).toISOString() : now
+  };
+}
+
+export function normalizeMobilePushTokenRegistrations(
+  registrations?: Partial<MobilePushTokenRegistration>[] | null
+): MobilePushTokenRegistration[] | undefined {
+  if (!Array.isArray(registrations) || registrations.length === 0) {
+    return undefined;
+  }
+
+  const byPlatform = new Map<MobilePushPlatform, MobilePushTokenRegistration>();
+  for (const entry of registrations) {
+    if (!entry || typeof entry.platform !== "string" || typeof entry.token !== "string") {
+      continue;
+    }
+
+    const normalized = normalizeMobilePushTokenRegistration({
+      platform: entry.platform,
+      token: entry.token,
+      ...(entry.registeredAt ? { registeredAt: entry.registeredAt } : {}),
+      ...(entry.updatedAt ? { updatedAt: entry.updatedAt } : {})
+    });
+    byPlatform.set(normalized.platform, normalized);
+  }
+
+  const normalized = Array.from(byPlatform.values());
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function upsertMobilePushToken(
+  registrations: MobilePushTokenRegistration[] | undefined,
+  registration: { platform: string; token: string },
+  now = new Date().toISOString()
+): MobilePushTokenRegistration[] {
+  const normalized = normalizeMobilePushTokenRegistration(registration, now);
+  const existing = registrations?.find((entry) => entry.platform === normalized.platform) ?? null;
+
+  return [
+    ...(registrations ?? []).filter((entry) => entry.platform !== normalized.platform),
+    {
+      ...normalized,
+      registeredAt: existing?.registeredAt ?? normalized.registeredAt
+    }
+  ].sort((left, right) => left.platform.localeCompare(right.platform));
+}
+
+export function removeMobilePushToken(
+  registrations: MobilePushTokenRegistration[] | undefined,
+  criteria: { platform?: string | null; token?: string | null }
+): MobilePushTokenRegistration[] | undefined {
+  const normalizedPlatform = criteria.platform?.trim() ? normalizeMobilePushPlatform(criteria.platform) : null;
+  const normalizedToken = criteria.token?.trim() ? normalizeMobilePushTokenValue(criteria.token) : null;
+  const filtered = (registrations ?? []).filter((entry) => {
+    if (normalizedPlatform && entry.platform !== normalizedPlatform) {
+      return true;
+    }
+    if (normalizedToken && entry.token !== normalizedToken) {
+      return true;
+    }
+    return false;
+  });
+
+  return filtered.length > 0 ? filtered : undefined;
+}

--- a/apps/server/src/mobile-push.ts
+++ b/apps/server/src/mobile-push.ts
@@ -1,0 +1,337 @@
+import { createSign } from "node:crypto";
+import { connect } from "node:http2";
+import type { MobilePushTokenRegistration } from "../../../packages/shared/src/index";
+import type { RoomSnapshotStore } from "./persistence";
+import { removeMobilePushToken } from "./mobile-push-tokens";
+import { getNotificationPreferenceValue } from "./wechat-social";
+
+export type MobilePushTemplateKey = "match_found" | "turn_reminder";
+type MobilePushPreferenceKey = "matchFound" | "turnReminder";
+type MobilePushDeliveryResult = "sent" | "failed" | "invalid_token" | "skipped";
+
+interface MobilePushLoggerLike {
+  error(message: string, details?: unknown): void;
+}
+
+interface MobilePushNotificationMessage {
+  title: string;
+  body: string;
+  data: Record<string, string>;
+}
+
+interface ApnsRuntimeConfig {
+  keyId: string;
+  teamId: string;
+  privateKey: string;
+  topic: string;
+  host: string;
+}
+
+interface FcmRuntimeConfig {
+  serverKey: string;
+  sendUrl: string;
+}
+
+interface MobilePushRuntimeOptions {
+  store?: RoomSnapshotStore | null;
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  logger?: MobilePushLoggerLike;
+  now?: () => number;
+  connectHttp2Impl?: typeof connect;
+  sendApnsImpl?: (
+    registration: MobilePushTokenRegistration,
+    message: MobilePushNotificationMessage,
+    config: ApnsRuntimeConfig,
+    options: Required<Pick<MobilePushRuntimeOptions, "connectHttp2Impl" | "logger" | "now">>
+  ) => Promise<MobilePushDeliveryResult>;
+  sendFcmImpl?: (
+    registration: MobilePushTokenRegistration,
+    message: MobilePushNotificationMessage,
+    config: FcmRuntimeConfig,
+    options: Required<Pick<MobilePushRuntimeOptions, "fetchImpl" | "logger">>
+  ) => Promise<MobilePushDeliveryResult>;
+}
+
+function normalizeConfigValue(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function readApnsRuntimeConfig(env: NodeJS.ProcessEnv = process.env): ApnsRuntimeConfig | null {
+  const keyId = normalizeConfigValue(env.VEIL_APNS_KEY_ID);
+  const teamId = normalizeConfigValue(env.VEIL_APNS_TEAM_ID);
+  const privateKey = normalizeConfigValue(env.VEIL_APNS_PRIVATE_KEY);
+  const topic = normalizeConfigValue(env.VEIL_APNS_TOPIC);
+  if (!keyId || !teamId || !privateKey || !topic) {
+    return null;
+  }
+
+  const useSandbox = env.VEIL_APNS_USE_SANDBOX?.trim()
+    ? env.VEIL_APNS_USE_SANDBOX.trim().toLowerCase() !== "false"
+    : env.NODE_ENV !== "production";
+
+  return {
+    keyId,
+    teamId,
+    privateKey: privateKey.replace(/\\n/g, "\n"),
+    topic,
+    host: normalizeConfigValue(env.VEIL_APNS_HOST) ?? (useSandbox ? "https://api.sandbox.push.apple.com" : "https://api.push.apple.com")
+  };
+}
+
+function readFcmRuntimeConfig(env: NodeJS.ProcessEnv = process.env): FcmRuntimeConfig | null {
+  const serverKey = normalizeConfigValue(env.VEIL_FCM_SERVER_KEY);
+  if (!serverKey) {
+    return null;
+  }
+
+  return {
+    serverKey,
+    sendUrl: normalizeConfigValue(env.VEIL_FCM_SEND_URL) ?? "https://fcm.googleapis.com/fcm/send"
+  };
+}
+
+function toPreferenceKey(templateKey: MobilePushTemplateKey): MobilePushPreferenceKey {
+  return templateKey === "match_found" ? "matchFound" : "turnReminder";
+}
+
+function stringifyDataValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function buildNotificationMessage(
+  templateKey: MobilePushTemplateKey,
+  data: Record<string, unknown>
+): MobilePushNotificationMessage {
+  if (templateKey === "match_found") {
+    const opponentName = typeof data.opponentName === "string" && data.opponentName.trim() ? data.opponentName.trim() : "Opponent";
+    const mapName = typeof data.mapName === "string" && data.mapName.trim() ? data.mapName.trim() : "the arena";
+    return {
+      title: "Match Found",
+      body: `${opponentName} is ready on ${mapName}.`,
+      data: Object.fromEntries(Object.entries(data).map(([key, value]) => [key, stringifyDataValue(value)]))
+    };
+  }
+
+  const roomId = typeof data.roomId === "string" && data.roomId.trim() ? data.roomId.trim() : "your async match";
+  const turnNumber = typeof data.turnNumber === "number" ? Math.max(1, Math.floor(data.turnNumber)) : 1;
+  return {
+    title: "Your Turn",
+    body: `Turn ${turnNumber} is waiting in ${roomId}.`,
+    data: Object.fromEntries(Object.entries(data).map(([key, value]) => [key, stringifyDataValue(value)]))
+  };
+}
+
+function createApnsJwt(config: ApnsRuntimeConfig, now: number): string {
+  const encodedHeader = Buffer.from(JSON.stringify({ alg: "ES256", kid: config.keyId })).toString("base64url");
+  const encodedPayload = Buffer.from(
+    JSON.stringify({
+      iss: config.teamId,
+      iat: Math.floor(now / 1000)
+    })
+  ).toString("base64url");
+  const signer = createSign("sha256");
+  signer.update(`${encodedHeader}.${encodedPayload}`);
+  signer.end();
+  const signature = signer.sign(config.privateKey).toString("base64url");
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+async function sendApnsNotification(
+  registration: MobilePushTokenRegistration,
+  message: MobilePushNotificationMessage,
+  config: ApnsRuntimeConfig,
+  options: Required<Pick<MobilePushRuntimeOptions, "connectHttp2Impl" | "logger" | "now">>
+): Promise<MobilePushDeliveryResult> {
+  const session = options.connectHttp2Impl(config.host);
+
+  try {
+    const response = await new Promise<{ headers: Record<string, string | number | string[] | undefined>; body: string }>((resolve, reject) => {
+      const request = session.request({
+        ":method": "POST",
+        ":path": `/3/device/${encodeURIComponent(registration.token)}`,
+        authorization: `bearer ${createApnsJwt(config, options.now())}`,
+        "apns-topic": config.topic,
+        "apns-push-type": "alert",
+        "content-type": "application/json"
+      });
+
+      const chunks: Buffer[] = [];
+      let headers: Record<string, string | number | string[] | undefined> = {};
+      request.on("response", (nextHeaders) => {
+        headers = nextHeaders;
+      });
+      request.on("data", (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      request.on("end", () => {
+        resolve({
+          headers,
+          body: Buffer.concat(chunks).toString("utf8")
+        });
+      });
+      request.on("error", reject);
+      request.end(
+        JSON.stringify({
+          aps: {
+            alert: {
+              title: message.title,
+              body: message.body
+            },
+            sound: "default"
+          },
+          ...message.data
+        })
+      );
+    });
+
+    const statusCode = Number(response.headers[":status"] ?? 0);
+    if (statusCode >= 200 && statusCode < 300) {
+      return "sent";
+    }
+
+    const payload = response.body ? (JSON.parse(response.body) as { reason?: string }) : {};
+    if (payload.reason === "BadDeviceToken" || payload.reason === "Unregistered" || payload.reason === "DeviceTokenNotForTopic") {
+      return "invalid_token";
+    }
+
+    options.logger.error("[mobile-push] APNs send failed", {
+      platform: registration.platform,
+      statusCode,
+      tokenSuffix: registration.token.slice(-8),
+      payload
+    });
+    return "failed";
+  } catch (error) {
+    options.logger.error("[mobile-push] APNs send failed", {
+      platform: registration.platform,
+      tokenSuffix: registration.token.slice(-8),
+      error
+    });
+    return "failed";
+  } finally {
+    session.close();
+  }
+}
+
+async function sendFcmNotification(
+  registration: MobilePushTokenRegistration,
+  message: MobilePushNotificationMessage,
+  config: FcmRuntimeConfig,
+  options: Required<Pick<MobilePushRuntimeOptions, "fetchImpl" | "logger">>
+): Promise<MobilePushDeliveryResult> {
+  try {
+    const response = await options.fetchImpl(config.sendUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `key=${config.serverKey}`,
+        "Content-Type": "application/json; charset=utf-8"
+      },
+      body: JSON.stringify({
+        to: registration.token,
+        notification: {
+          title: message.title,
+          body: message.body
+        },
+        data: message.data,
+        priority: "high"
+      })
+    });
+    const payload = (await response.json()) as { results?: Array<{ error?: string }> };
+    const errorCode = payload.results?.[0]?.error;
+
+    if (response.ok && !errorCode) {
+      return "sent";
+    }
+    if (errorCode === "InvalidRegistration" || errorCode === "NotRegistered") {
+      return "invalid_token";
+    }
+
+    options.logger.error("[mobile-push] FCM send failed", {
+      platform: registration.platform,
+      statusCode: response.status,
+      tokenSuffix: registration.token.slice(-8),
+      payload
+    });
+    return "failed";
+  } catch (error) {
+    options.logger.error("[mobile-push] FCM send failed", {
+      platform: registration.platform,
+      tokenSuffix: registration.token.slice(-8),
+      error
+    });
+    return "failed";
+  }
+}
+
+export async function sendMobilePushNotification(
+  playerId: string,
+  templateKey: MobilePushTemplateKey,
+  data: Record<string, unknown>,
+  options: MobilePushRuntimeOptions = {}
+): Promise<boolean> {
+  const store = options.store ?? null;
+  if (!store) {
+    return false;
+  }
+
+  const logger = options.logger ?? console;
+  const account = await store.loadPlayerAccount(playerId);
+  if (!account?.pushTokens?.length) {
+    return false;
+  }
+  if (!getNotificationPreferenceValue(account.notificationPreferences, toPreferenceKey(templateKey))) {
+    return false;
+  }
+
+  const apnsConfig = readApnsRuntimeConfig(options.env);
+  const fcmConfig = readFcmRuntimeConfig(options.env);
+  const message = buildNotificationMessage(templateKey, data);
+  const sendApnsImpl = options.sendApnsImpl ?? sendApnsNotification;
+  const sendFcmImpl = options.sendFcmImpl ?? sendFcmNotification;
+  const connectHttp2Impl = options.connectHttp2Impl ?? connect;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => Date.now());
+  let anySent = false;
+  let nextPushTokens: MobilePushTokenRegistration[] | undefined = account.pushTokens;
+  let shouldPersistPrunedTokens = false;
+
+  for (const registration of account.pushTokens) {
+    let result: MobilePushDeliveryResult = "skipped";
+    if (registration.platform === "ios" && apnsConfig) {
+      result = await sendApnsImpl(registration, message, apnsConfig, { connectHttp2Impl, logger, now });
+    } else if (registration.platform === "android" && fcmConfig) {
+      result = await sendFcmImpl(registration, message, fcmConfig, { fetchImpl, logger });
+    }
+
+    if (result === "sent") {
+      anySent = true;
+    } else if (result === "invalid_token") {
+      shouldPersistPrunedTokens = true;
+      nextPushTokens = removeMobilePushToken(nextPushTokens, {
+        platform: registration.platform,
+        token: registration.token
+      });
+    }
+  }
+
+  if (shouldPersistPrunedTokens) {
+    try {
+      await store.savePlayerAccountProfile(playerId, { pushTokens: nextPushTokens ?? null });
+    } catch (error) {
+      logger.error("[mobile-push] Failed to prune invalid mobile push token", {
+        playerId,
+        error
+      });
+    }
+  }
+
+  return anySent;
+}

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -27,6 +27,7 @@ import {
   type EquipmentId,
   type GuildState,
   type HeroState,
+  type MobilePushTokenRegistration,
   type PlayerBanStatus,
   type PlayerAccountReadModel,
   type PlayerBattleReplaySummary,
@@ -42,6 +43,7 @@ import {
   type SeasonArchiveEntry,
   type WorldState
 } from "../../../packages/shared/src/index";
+import { normalizeMobilePushTokenRegistrations } from "./mobile-push-tokens";
 import {
   assertDisplayNameAvailableOrThrow,
   buildBannedAccountNameReservationExpiry,
@@ -423,6 +425,7 @@ interface PlayerAccountRow extends RowDataPacket {
   phone_number: string | null;
   phone_number_bound_at: Date | string | null;
   notification_preferences_json: string | NotificationPreferences | null;
+  push_tokens_json: string | MobilePushTokenRegistration[] | null;
   created_at: Date | string;
   updated_at: Date | string;
 }
@@ -671,6 +674,7 @@ export interface PlayerAccountSnapshot extends PlayerAccountReadModel {
   updatedAt?: string;
   phoneNumber?: string;
   phoneNumberBoundAt?: string;
+  pushTokens?: MobilePushTokenRegistration[];
 }
 
 export interface PlayerAccountBanSnapshot {
@@ -936,6 +940,7 @@ export interface PlayerAccountProfilePatch {
   phoneNumber?: string | null;
   phoneNumberBoundAt?: string | null;
   notificationPreferences?: NotificationPreferences | null;
+  pushTokens?: MobilePushTokenRegistration[] | null;
 }
 
 export interface PlayerAccountProgressPatch {
@@ -2326,6 +2331,7 @@ function normalizePlayerAccountSnapshot(account: {
   phoneNumber?: string | null | undefined;
   phoneNumberBoundAt?: string | Date | null | undefined;
   notificationPreferences?: NotificationPreferences | null | undefined;
+  pushTokens?: MobilePushTokenRegistration[] | null | undefined;
   accountSessionVersion?: number | null | undefined;
   refreshSessionId?: string | null | undefined;
   refreshTokenExpiresAt?: string | Date | null | undefined;
@@ -2340,6 +2346,7 @@ function normalizePlayerAccountSnapshot(account: {
     ? normalizeWechatMiniGameUnionId(account.wechatMiniGameUnionId)
     : undefined;
   const phoneNumberBoundAt = formatTimestamp(account.phoneNumberBoundAt);
+  const pushTokens = normalizeMobilePushTokenRegistrations(account.pushTokens);
 
   return {
     ...normalizePlayerAccountReadModel({
@@ -2396,6 +2403,7 @@ function normalizePlayerAccountSnapshot(account: {
     ...(normalizedWechatMiniGameOpenId ? { wechatMiniGameOpenId: normalizedWechatMiniGameOpenId } : {}),
     ...(normalizedWechatMiniGameUnionId ? { wechatMiniGameUnionId: normalizedWechatMiniGameUnionId } : {}),
     ...(account.wechatMiniGameBoundAt ? { wechatMiniGameBoundAt: account.wechatMiniGameBoundAt } : {}),
+    ...(pushTokens ? { pushTokens } : {}),
     ...(account.guestMigratedToPlayerId?.trim()
       ? { guestMigratedToPlayerId: normalizePlayerId(account.guestMigratedToPlayerId) }
       : {}),
@@ -2780,6 +2788,7 @@ CREATE TABLE IF NOT EXISTS \`${MYSQL_PLAYER_ACCOUNT_TABLE}\` (
   phone_number VARCHAR(32) NULL,
   phone_number_bound_at DATETIME NULL DEFAULT NULL,
   notification_preferences_json LONGTEXT NULL,
+  push_tokens_json LONGTEXT NULL,
   version BIGINT UNSIGNED NOT NULL DEFAULT 1,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -4507,6 +4516,9 @@ function toPlayerAccountSnapshot(row: PlayerAccountRow): PlayerAccountSnapshot {
     ...(row.notification_preferences_json != null
       ? { notificationPreferences: parseJsonColumn<NotificationPreferences>(row.notification_preferences_json) }
       : {}),
+    ...(row.push_tokens_json != null
+      ? { pushTokens: parseJsonColumn<MobilePushTokenRegistration[]>(row.push_tokens_json) }
+      : {}),
     ...(createdAt ? { createdAt } : {}),
     ...(updatedAt ? { updatedAt } : {})
   });
@@ -5233,9 +5245,10 @@ async function upsertPlayerAccountForMigration(
        privacy_consent_at,
        phone_number,
        phone_number_bound_at,
-       notification_preferences_json
+       notification_preferences_json,
+       push_tokens_json
      )
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON DUPLICATE KEY UPDATE
        display_name = VALUES(display_name),
        avatar_url = VALUES(avatar_url),
@@ -5282,6 +5295,7 @@ async function upsertPlayerAccountForMigration(
        phone_number = VALUES(phone_number),
        phone_number_bound_at = VALUES(phone_number_bound_at),
        notification_preferences_json = VALUES(notification_preferences_json),
+       push_tokens_json = VALUES(push_tokens_json),
        version = version + 1`,
     [
       nextAccount.playerId,
@@ -5329,7 +5343,8 @@ async function upsertPlayerAccountForMigration(
       nextAccount.privacyConsentAt ? new Date(nextAccount.privacyConsentAt) : null,
       nextAccount.phoneNumber ?? null,
       nextAccount.phoneNumberBoundAt ? new Date(nextAccount.phoneNumberBoundAt) : null,
-      JSON.stringify(nextAccount.notificationPreferences ?? null)
+      JSON.stringify(nextAccount.notificationPreferences ?? null),
+      JSON.stringify(nextAccount.pushTokens ?? null)
     ]
   );
 }
@@ -5901,6 +5916,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number,
          phone_number_bound_at,
          notification_preferences_json,
+         push_tokens_json,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -5968,6 +5984,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number,
          phone_number_bound_at,
          notification_preferences_json,
+         push_tokens_json,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -6331,6 +6348,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number,
          phone_number_bound_at,
          notification_preferences_json,
+         push_tokens_json,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`
@@ -8627,6 +8645,11 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
           : {}
         : existing.notificationPreferences
           ? { notificationPreferences: existing.notificationPreferences }
+          : {}),
+      ...(patch.pushTokens !== undefined
+        ? { pushTokens: patch.pushTokens ?? null }
+        : existing.pushTokens?.length
+          ? { pushTokens: existing.pushTokens }
           : {})
     });
 
@@ -8661,9 +8684,10 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          last_seen_at,
          phone_number,
          phone_number_bound_at,
-         notification_preferences_json
+         notification_preferences_json,
+         push_tokens_json
        )
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON DUPLICATE KEY UPDATE
          display_name = VALUES(display_name),
          avatar_url = VALUES(avatar_url),
@@ -8692,6 +8716,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number = VALUES(phone_number),
          phone_number_bound_at = VALUES(phone_number_bound_at),
          notification_preferences_json = COALESCE(VALUES(notification_preferences_json), notification_preferences_json),
+         push_tokens_json = COALESCE(VALUES(push_tokens_json), push_tokens_json),
          last_seen_at = COALESCE(last_seen_at, VALUES(last_seen_at)),
          version = version + 1`,
       [
@@ -8724,7 +8749,8 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         existing.lastSeenAt ? new Date(existing.lastSeenAt) : null,
         nextAccount.phoneNumber ?? null,
         nextAccount.phoneNumberBoundAt ? new Date(nextAccount.phoneNumberBoundAt) : null,
-        JSON.stringify(nextAccount.notificationPreferences ?? null)
+        JSON.stringify(nextAccount.notificationPreferences ?? null),
+        JSON.stringify(nextAccount.pushTokens ?? null)
       ]
     );
 
@@ -9025,6 +9051,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
          phone_number,
          phone_number_bound_at,
          notification_preferences_json,
+         push_tokens_json,
          created_at,
          updated_at
        FROM \`${MYSQL_PLAYER_ACCOUNT_TABLE}\`

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -71,6 +71,7 @@ import {
   normalizeNotificationPreferences,
   validateGroupChallengeToken
 } from "./wechat-social";
+import { removeMobilePushToken, upsertMobilePushToken } from "./mobile-push-tokens";
 import { normalizePlayerMailboxMessage } from "./player-mailbox";
 import { normalizeTutorialProgressAction, toTutorialAnalyticsPayload } from "./tutorial-progress";
 
@@ -893,6 +894,7 @@ function toPublicPlayerAccount(
   | "phoneNumberBoundAt"
   | "wechatMiniGameOpenId"
   | "wechatMiniGameUnionId"
+  | "pushTokens"
   | "banStatus"
   | "banExpiry"
   | "banReason"
@@ -906,6 +908,7 @@ function toPublicPlayerAccount(
     phoneNumberBoundAt: _phoneNumberBoundAt,
     wechatMiniGameOpenId: _wechatMiniGameOpenId,
     wechatMiniGameUnionId: _wechatMiniGameUnionId,
+    pushTokens: _pushTokens,
     banStatus: _banStatus,
     banExpiry: _banExpiry,
     banReason: _banReason,
@@ -1406,6 +1409,80 @@ export function registerPlayerAccountRoutes(
       sendJson(response, 200, {
         notificationPreferences: account.notificationPreferences ?? notificationPreferences,
         account: withBattleReportCenter(account)
+      });
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.put("/api/players/me/push-token", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+    if (!store) {
+      sendJson(response, 503, {
+        error: {
+          code: "persistence_unavailable",
+          message: "Push token registration requires configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as { platform: string; token: string };
+      const existing = await store.loadPlayerAccount(authSession.playerId);
+      const pushTokens = upsertMobilePushToken(existing?.pushTokens, body);
+      const account = await store.savePlayerAccountProfile(authSession.playerId, { pushTokens });
+      sendJson(response, 200, {
+        pushTokens: account.pushTokens ?? pushTokens
+      });
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
+      sendJson(response, 400, { error: toErrorPayload(error) });
+    }
+  });
+
+  app.delete("/api/players/me/push-token", async (request, response) => {
+    const authSession = await requireAuthSession(request, response, store);
+    if (!authSession) {
+      return;
+    }
+    if (!store) {
+      sendJson(response, 503, {
+        error: {
+          code: "persistence_unavailable",
+          message: "Push token removal requires configured room persistence storage"
+        }
+      });
+      return;
+    }
+
+    try {
+      const body = (await readJsonBody(request)) as { platform?: string; token?: string };
+      if (!body.platform?.trim() && !body.token?.trim()) {
+        sendJson(response, 400, {
+          error: {
+            code: "invalid_push_token",
+            message: "platform or token is required"
+          }
+        });
+        return;
+      }
+
+      const existing = await store.loadPlayerAccount(authSession.playerId);
+      const pushTokens = removeMobilePushToken(existing?.pushTokens, body) ?? null;
+      const account = await store.savePlayerAccountProfile(authSession.playerId, { pushTokens });
+      sendJson(response, 200, {
+        pushTokens: account.pushTokens ?? []
       });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {

--- a/apps/server/test/colyseus-room-lifecycle.test.ts
+++ b/apps/server/test/colyseus-room-lifecycle.test.ts
@@ -2336,10 +2336,15 @@ test("turn reminder subscribe message is skipped while the next player is still 
   const timer = createManualRoomTimer(Date.parse("2026-04-04T00:00:00.000Z"));
   const store = new InstrumentedRoomSnapshotStore();
   const subscribeCalls: Array<{ playerId: string; templateKey: string; data: Record<string, unknown> }> = [];
+  const pushCalls: Array<{ playerId: string; templateKey: string; data: Record<string, unknown> }> = [];
   configureRoomSnapshotStore(store);
   configureRoomRuntimeDependencies({
     sendWechatSubscribeMessage: async (playerId, templateKey, data) => {
       subscribeCalls.push({ playerId, templateKey, data });
+      return true;
+    },
+    sendMobilePushNotification: async (playerId, templateKey, data) => {
+      pushCalls.push({ playerId, templateKey, data });
       return true;
     }
   });
@@ -2371,19 +2376,25 @@ test("turn reminder subscribe message is skipped while the next player is still 
   });
 
   assert.deepEqual(subscribeCalls, []);
+  assert.deepEqual(pushCalls, []);
   assert.equal(lastSessionState(defenderClient, "push").payload.world.meta.day, 2);
   assert.equal(timer.nowMs, Date.parse("2026-04-04T00:00:00.000Z"));
 });
 
-test("turn reminder subscribe message is sent after the next player has been disconnected for over 30 seconds", async (t) => {
+test("turn reminder notifications are sent after the next player has been disconnected for over 30 seconds", async (t) => {
   resetLobbyRoomRegistry();
   const timer = createManualRoomTimer(Date.parse("2026-04-04T00:00:00.000Z"));
   const store = new InstrumentedRoomSnapshotStore();
   const subscribeCalls: Array<{ playerId: string; templateKey: string; data: Record<string, unknown> }> = [];
+  const pushCalls: Array<{ playerId: string; templateKey: string; data: Record<string, unknown> }> = [];
   configureRoomSnapshotStore(store);
   configureRoomRuntimeDependencies({
     sendWechatSubscribeMessage: async (playerId, templateKey, data) => {
       subscribeCalls.push({ playerId, templateKey, data });
+      return true;
+    },
+    sendMobilePushNotification: async (playerId, templateKey, data) => {
+      pushCalls.push({ playerId, templateKey, data });
       return true;
     }
   });
@@ -2427,9 +2438,10 @@ test("turn reminder subscribe message is sent after the next player has been dis
       }
     }
   ]);
+  assert.deepEqual(pushCalls, subscribeCalls);
 });
 
-test("turn reminder subscribe failures are logged without blocking turn advancement", async (t) => {
+test("turn reminder notification failures are logged without blocking turn advancement", async (t) => {
   resetLobbyRoomRegistry();
   const timer = createManualRoomTimer(Date.parse("2026-04-04T00:00:00.000Z"));
   const store = new InstrumentedRoomSnapshotStore();
@@ -2484,7 +2496,7 @@ test("turn reminder subscribe failures are logged without blocking turn advancem
   };
   assert.equal(internalRoom.worldRoom.getInternalState().meta.day, 2);
   assert.equal(errorCalls.length, 1);
-  assert.equal(errorCalls[0]?.[0], "[VeilRoom] Failed to send WeChat turn reminder subscribe message");
+  assert.equal(errorCalls[0]?.[0], "[VeilRoom] Failed to send turn reminder notification");
   assert.deepEqual(errorCalls[0]?.[1], {
     roomId: room.roomId,
     playerId: "player-2",

--- a/apps/server/test/matchmaking-routes.test.ts
+++ b/apps/server/test/matchmaking-routes.test.ts
@@ -312,7 +312,7 @@ test("matchmaking routes enqueue, match, report status, and dequeue cleanly", as
   assert.equal(dequeueOnePayload.status, "idle");
 });
 
-test("matchmaking routes send WeChat subscribe notifications when a match is created", async (t) => {
+test("matchmaking routes send match-found notifications when a match is created", async (t) => {
   const store = createMemoryRoomSnapshotStore();
   await store.save(
     "room-frontier_basin",
@@ -330,9 +330,14 @@ test("matchmaking routes send WeChat subscribe notifications when a match is cre
   });
 
   const subscribeCalls: Array<{ playerId: string; templateKey: string; data: Record<string, unknown> }> = [];
+  const pushCalls: Array<{ playerId: string; templateKey: string; data: Record<string, unknown> }> = [];
   configureMatchmakingRuntimeDependencies({
     sendWechatSubscribeMessage: async (playerId, templateKey, data) => {
       subscribeCalls.push({ playerId, templateKey, data });
+      return true;
+    },
+    sendMobilePushNotification: async (playerId, templateKey, data) => {
+      pushCalls.push({ playerId, templateKey, data });
       return true;
     }
   });
@@ -385,9 +390,34 @@ test("matchmaking routes send WeChat subscribe notifications when a match is cre
       }
     ]
   );
+  assert.deepEqual(
+    pushCalls.sort((left, right) => left.playerId.localeCompare(right.playerId)),
+    [
+      {
+        playerId: "player-1",
+        templateKey: "match_found",
+        data: {
+          mapName: "Phase1",
+          opponentName: "Two",
+          roomId: pushCalls[0]?.data.roomId
+        }
+      },
+      {
+        playerId: "player-2",
+        templateKey: "match_found",
+        data: {
+          mapName: "Phase1",
+          opponentName: "One",
+          roomId: pushCalls[1]?.data.roomId
+        }
+      }
+    ]
+  );
+  assert.match(String(pushCalls[0]?.data.roomId ?? ""), /^pvp-match-/);
+  assert.match(String(pushCalls[1]?.data.roomId ?? ""), /^pvp-match-/);
 });
 
-test("matchmaking routes log WeChat subscribe failures without breaking match creation", async (t) => {
+test("matchmaking routes log match-found notification failures without breaking match creation", async (t) => {
   const store = createMemoryRoomSnapshotStore();
   await store.save(
     "room-frontier_basin",
@@ -448,7 +478,7 @@ test("matchmaking routes log WeChat subscribe failures without breaking match cr
   });
 
   await waitFor(() => errorCalls.length === 1);
-  assert.equal(errorCalls[0]?.[0], "[matchmaking] Failed to send WeChat match-found notification");
+  assert.equal(errorCalls[0]?.[0], "[matchmaking] Failed to send match-found notification");
   const loggedDetails = errorCalls[0]?.[1] as {
     roomId?: string;
     playerId?: string;

--- a/apps/server/test/mobile-push.test.ts
+++ b/apps/server/test/mobile-push.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import { sendMobilePushNotification } from "../src/mobile-push";
+
+test("sendMobilePushNotification fans out to APNs and FCM for registered devices", async () => {
+  const store = new MemoryRoomSnapshotStore();
+  await store.ensurePlayerAccount({ playerId: "player-1", displayName: "Player One" });
+  await store.savePlayerAccountProfile("player-1", {
+    pushTokens: [
+      {
+        platform: "ios",
+        token: "apns-token-1",
+        registeredAt: "2026-04-13T01:46:00.000Z",
+        updatedAt: "2026-04-13T01:46:00.000Z"
+      },
+      {
+        platform: "android",
+        token: "fcm-token-1",
+        registeredAt: "2026-04-13T01:46:00.000Z",
+        updatedAt: "2026-04-13T01:46:00.000Z"
+      }
+    ]
+  });
+
+  const deliveries: Array<{ platform: string; title: string; body: string; roomId?: string }> = [];
+  const sent = await sendMobilePushNotification(
+    "player-1",
+    "match_found",
+    {
+      mapName: "Phase1",
+      opponentName: "Player Two",
+      roomId: "pvp-match-1"
+    },
+    {
+      store,
+      env: {
+        VEIL_APNS_KEY_ID: "kid",
+        VEIL_APNS_TEAM_ID: "team",
+        VEIL_APNS_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\\nkey\\n-----END PRIVATE KEY-----",
+        VEIL_APNS_TOPIC: "com.projectveil.app",
+        VEIL_FCM_SERVER_KEY: "server-key"
+      },
+      sendApnsImpl: async (registration, message) => {
+        deliveries.push({ platform: registration.platform, title: message.title, body: message.body, roomId: message.data.roomId });
+        return "sent";
+      },
+      sendFcmImpl: async (registration, message) => {
+        deliveries.push({ platform: registration.platform, title: message.title, body: message.body, roomId: message.data.roomId });
+        return "sent";
+      }
+    }
+  );
+
+  assert.equal(sent, true);
+  assert.deepEqual(
+    deliveries.sort((left, right) => left.platform.localeCompare(right.platform)),
+    [
+      {
+        platform: "android",
+        title: "Match Found",
+        body: "Player Two is ready on Phase1.",
+        roomId: "pvp-match-1"
+      },
+      {
+        platform: "ios",
+        title: "Match Found",
+        body: "Player Two is ready on Phase1.",
+        roomId: "pvp-match-1"
+      }
+    ]
+  );
+});
+
+test("sendMobilePushNotification prunes invalid registrations returned by providers", async () => {
+  const store = new MemoryRoomSnapshotStore();
+  await store.ensurePlayerAccount({ playerId: "player-2", displayName: "Player Two" });
+  await store.savePlayerAccountProfile("player-2", {
+    pushTokens: [
+      {
+        platform: "android",
+        token: "fcm-invalid",
+        registeredAt: "2026-04-13T01:46:00.000Z",
+        updatedAt: "2026-04-13T01:46:00.000Z"
+      }
+    ]
+  });
+
+  const sent = await sendMobilePushNotification(
+    "player-2",
+    "turn_reminder",
+    {
+      roomId: "room-2",
+      turnNumber: 4
+    },
+    {
+      store,
+      env: {
+        VEIL_FCM_SERVER_KEY: "server-key"
+      },
+      sendFcmImpl: async () => "invalid_token"
+    }
+  );
+
+  assert.equal(sent, false);
+  assert.equal((await store.loadPlayerAccount("player-2"))?.pushTokens, undefined);
+});

--- a/apps/server/test/player-account-social-routes.test.ts
+++ b/apps/server/test/player-account-social-routes.test.ts
@@ -48,6 +48,45 @@ test("social routes persist notification prefs and validate group challenge expi
   assert.equal(prefsPayload.notificationPreferences.matchFound, false);
   assert.equal((await store.loadPlayerAccount("player-7"))?.notificationPreferences?.matchFound, false);
 
+  const pushRegisterResponse = await fetch(`http://127.0.0.1:${port}/api/players/me/push-token`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      platform: "ios",
+      token: "apns-token-player-7"
+    })
+  });
+  const pushRegisterPayload = (await pushRegisterResponse.json()) as {
+    pushTokens: Array<{ platform: string; token: string }>;
+  };
+  assert.equal(pushRegisterResponse.status, 200);
+  assert.equal(pushRegisterPayload.pushTokens.length, 1);
+  assert.equal(pushRegisterPayload.pushTokens[0]?.platform, "ios");
+  assert.equal(pushRegisterPayload.pushTokens[0]?.token, "apns-token-player-7");
+  assert.deepEqual((await store.loadPlayerAccount("player-7"))?.pushTokens?.map((entry) => entry.token), [
+    "apns-token-player-7"
+  ]);
+
+  const pushDeleteResponse = await fetch(`http://127.0.0.1:${port}/api/players/me/push-token`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${session.token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      platform: "ios"
+    })
+  });
+  const pushDeletePayload = (await pushDeleteResponse.json()) as {
+    pushTokens: Array<{ platform: string; token: string }>;
+  };
+  assert.equal(pushDeleteResponse.status, 200);
+  assert.deepEqual(pushDeletePayload.pushTokens, []);
+  assert.equal((await store.loadPlayerAccount("player-7"))?.pushTokens, undefined);
+
   const leaderboardResponse = await fetch(
     `http://127.0.0.1:${port}/api/social/friend-leaderboard?friendIds=${encodeURIComponent("friend-1")}`,
     {

--- a/docs/account-auth-lifecycle.md
+++ b/docs/account-auth-lifecycle.md
@@ -12,6 +12,7 @@
 - 口令账号登录：`POST /api/auth/account-login`
 - 会话校验 / 刷新 / 退出：`GET /api/auth/session`、`POST /api/auth/refresh`、`POST /api/auth/logout`
 - 正式账号设备会话列表 / 撤销：`GET /api/player-accounts/me/sessions`、`DELETE /api/player-accounts/me/sessions/:sessionId`
+- 原生移动端推送令牌注册 / 注销：`PUT /api/players/me/push-token`、`DELETE /api/players/me/push-token`
 - 已登录账号修改口令：`PUT /api/player-accounts/me`
 - 迁移规则与边界场景说明：`docs/account-migration-rules.md`
 
@@ -47,6 +48,14 @@
 - `GET /api/player-accounts/me/sessions` 只返回当前账号仍然活跃的设备会话，并额外标记 `current=true` 的当前设备。
 - `DELETE /api/player-accounts/me/sessions/:sessionId` 仅允许撤销“非当前设备”的会话；被撤销的设备会话会立刻从列表消失，且旧刷新令牌随后会返回 `401 session_revoked`。
 - `POST /api/auth/logout` 与口令修改仍然属于“全量撤销”：会清空当前账号全部设备会话，并通过提升 `accountSessionVersion` 让旧访问令牌也一起失效。
+
+## 移动推送令牌
+
+- `PUT /api/players/me/push-token` 接收 `{ "platform": "ios" | "android", "token": "..." }`，按平台为当前玩家保存一个原生推送 token。
+- `DELETE /api/players/me/push-token` 接收 `{ "platform"?: "...", "token"?: "..." }`，按平台或 token 删除已登记的原生推送 token。
+- 当前服务端会把原生推送接到既有的 `match_found` 与 `turn_reminder` 事件链路；推送失败只记日志，不阻塞匹配或回合推进。
+- APNs 依赖 `VEIL_APNS_KEY_ID`、`VEIL_APNS_TEAM_ID`、`VEIL_APNS_PRIVATE_KEY`、`VEIL_APNS_TOPIC`，默认在非生产环境走 sandbox，可用 `VEIL_APNS_USE_SANDBOX=false` 或 `VEIL_APNS_HOST` 覆盖。
+- FCM 依赖 `VEIL_FCM_SERVER_KEY`，发送地址默认 `https://fcm.googleapis.com/fcm/send`，可用 `VEIL_FCM_SEND_URL` 覆盖到测试项目或代理。
 
 ## 鉴权观测面
 

--- a/docs/ops/secrets-inventory.md
+++ b/docs/ops/secrets-inventory.md
@@ -29,7 +29,15 @@ Non-sensitive values stay in env vars:
 
 - Network and infra coordinates such as `VEIL_MYSQL_HOST`, `VEIL_MYSQL_PORT`, `VEIL_BACKUP_S3_*`, `REDIS_URL`
 - Runtime tuning such as TTLs, rate limits, and feature toggles
-- Public identifiers such as `WECHAT_APP_ID`, `VEIL_WECHAT_PAY_APP_ID`, merchant ids, notify URLs, and certificate serials
+- Public identifiers such as `WECHAT_APP_ID`, `VEIL_WECHAT_PAY_APP_ID`, merchant ids, notify URLs, certificate serials, `VEIL_APNS_KEY_ID`, `VEIL_APNS_TEAM_ID`, `VEIL_APNS_TOPIC`, `VEIL_APNS_HOST`
+- Mobile push routing knobs such as `VEIL_APNS_USE_SANDBOX` and `VEIL_FCM_SEND_URL`
+
+Additional sensitive mobile-push secrets belong in the same secret bundle:
+
+| Key | Used by | Purpose | Rotation |
+| --- | --- | --- | --- |
+| `VEIL_APNS_PRIVATE_KEY` | `apps/server/src/mobile-push.ts` | APNs ES256 signing key for provider JWT auth | On compromise or Apple key rotation |
+| `VEIL_FCM_SERVER_KEY` | `apps/server/src/mobile-push.ts` | FCM server credential for Android push sends | On compromise or Firebase project key rotation |
 
 ## Rotation Policy
 

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -314,6 +314,15 @@ export interface NotificationPreferences {
   updatedAt?: string;
 }
 
+export type MobilePushPlatform = "ios" | "android";
+
+export interface MobilePushTokenRegistration {
+  platform: MobilePushPlatform;
+  token: string;
+  registeredAt: string;
+  updatedAt: string;
+}
+
 export interface HeroProgression {
   level: number;
   experience: number;

--- a/scripts/migrations/0024_add_player_account_push_tokens.ts
+++ b/scripts/migrations/0024_add_player_account_push_tokens.ts
@@ -1,0 +1,23 @@
+import {
+  ensureColumnExists,
+  dropColumnIfExists,
+  type SchemaMigrationConnection
+} from "../../apps/server/src/schema-migrations";
+import { MYSQL_PLAYER_ACCOUNT_TABLE } from "../../apps/server/src/persistence";
+
+export async function up(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+
+  await ensureColumnExists(
+    connection,
+    database,
+    MYSQL_PLAYER_ACCOUNT_TABLE,
+    "push_tokens_json",
+    "`push_tokens_json` LONGTEXT NULL AFTER `notification_preferences_json`"
+  );
+}
+
+export async function down(connection: SchemaMigrationConnection): Promise<void> {
+  const database = connection.config.database;
+  await dropColumnIfExists(connection, database, MYSQL_PLAYER_ACCOUNT_TABLE, "push_tokens_json");
+}


### PR DESCRIPTION
## Summary
- add per-player native push token registration and unregister routes for iOS and Android
- add server-side APNs and FCM dispatch with invalid-token pruning and failure-safe behavior
- wire native push into existing match-found and async turn-reminder notification hooks, with focused tests and env/docs updates

## Validation
- npm run typecheck:server
- node --import tsx --test ./apps/server/test/player-account-social-routes.test.ts ./apps/server/test/mobile-push.test.ts ./apps/server/test/matchmaking-routes.test.ts
- node --import tsx --test --test-name-pattern "turn reminder" ./apps/server/test/colyseus-room-lifecycle.test.ts

## Scope
- server-side vertical slice only: token persistence, provider dispatch, pruning, and event integration
- no client UI wiring in this PR

Closes #1369