### PR TITLE
[codex] Harden GDPR account deletion cascade

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -2532,7 +2532,12 @@ export function registerPlayerAccountRoutes(
         }
       });
     } catch (error) {
-      sendJson(response, 500, { error: toErrorPayload(error) });
+      sendJson(response, 500, {
+        error: {
+          code: "gdpr_delete_failed",
+          message: error instanceof Error ? error.message : String(error)
+        }
+      });
     }
   });
 

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -667,6 +667,9 @@ test("deletePlayerAccount deletes dependent rows, verifies cascade cleanup, and 
   assert.equal(retainedReceiptUpdate?.params[0], retainedOrderUpdate?.params[0]);
   assert.deepEqual(retainedReceiptUpdate?.params.slice(1), ["player-1", "player-1", "settled", "dead_letter"]);
   assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 14);
+  assert.ok(
+    queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `leaderboard_season_archives`/.test(entry.sql))
+  );
   const updateQuery = queries.find((entry) => /UPDATE `player_accounts`/.test(entry.sql));
   assert.ok(updateQuery);
   assert.equal(updateQuery?.params[0], "deleted-player-1");

--- a/apps/server/test/player-account-delete-routes.test.ts
+++ b/apps/server/test/player-account-delete-routes.test.ts
@@ -171,6 +171,6 @@ test("delete route returns 500 when cascade verification fails", async (t) => {
   };
 
   assert.equal(deleteResponse.status, 500);
-  assert.equal(deletePayload.error.code, "Error");
+  assert.equal(deletePayload.error.code, "gdpr_delete_failed");
   assert.equal(deletePayload.error.message, "gdpr_delete_verification_failed:guild_memberships");
 });

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -3379,7 +3379,7 @@ test("delete route returns a 500 payload when cascade verification fails", async
   };
 
   assert.equal(deleteResponse.status, 500);
-  assert.equal(deletePayload.error.code, "Error");
+  assert.equal(deletePayload.error.code, "gdpr_delete_failed");
   assert.equal(deletePayload.error.message, "gdpr_delete_verification_failed:guild_memberships");
 });
 

--- a/docs/gdpr-delete-runbook.md
+++ b/docs/gdpr-delete-runbook.md
@@ -1,6 +1,6 @@
 # GDPR Delete Verification Runbook
 
-Use this query after `/api/players/me/delete` to confirm the server removed the player from the dependent tables that are not protected by foreign-key cascade.
+Use this query after `/api/players/me/delete` to confirm the server removed the player from the dependent tables that are not protected by foreign-key cascade and scrubbed the remaining `player_accounts` row.
 
 Replace `:player_id` with the deleted player id before running it in MySQL:
 
@@ -8,6 +8,20 @@ Replace `:player_id` with the deleted player id before running it in MySQL:
 SELECT 'player_account_sessions' AS table_name, COUNT(*) AS remaining
 FROM player_account_sessions
 WHERE player_id = :player_id
+UNION ALL
+SELECT 'player_accounts_scrubbed', COUNT(*)
+FROM player_accounts
+WHERE player_id = :player_id
+  AND (
+    mailbox_json IS NOT NULL
+    OR seasonal_event_states_json IS NOT NULL
+    OR daily_dungeon_state_json IS NOT NULL
+    OR JSON_LENGTH(COALESCE(recent_battle_replays_json, JSON_ARRAY())) > 0
+    OR JSON_LENGTH(COALESCE(recent_event_log_json, JSON_ARRAY())) > 0
+    OR elo_rating IS NOT NULL
+    OR rank_division IS NOT NULL
+    OR peak_rank_division IS NOT NULL
+  )
 UNION ALL
 SELECT 'player_hero_archives', COUNT(*)
 FROM player_hero_archives


### PR DESCRIPTION
## Summary
- replace the stale leaderboard cleanup target in `deletePlayerAccount()` with the real `leaderboard_season_archives` table and verify those rows are gone before the delete transaction commits
- make `/api/players/me/delete` return an explicit `gdpr_delete_failed` error payload when any sub-deletion or cascade verification step fails
- update server tests and the GDPR ops runbook so post-delete audits check both dependent rows and the scrubbed `player_accounts` row

## Root Cause
`deletePlayerAccount()` was still trying to delete and verify a non-existent `veil_season_rankings` table, so leaderboard archive rows were not part of the GDPR cleanup contract.

## Validation
- `node --import tsx --test ./apps/server/test/persistence-account-credentials.test.ts`
- `node --import tsx --test --test-name-pattern="delete route" ./apps/server/test/player-account-delete-routes.test.ts ./apps/server/test/player-account-routes.test.ts`
- `npm run typecheck:server`

Closes #1371