### PR TITLE
[OPS] Add config center fallback metric

### DIFF
--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -27,6 +27,7 @@ import {
   buildPrometheusMetricsDocument,
   recordHttpRequestDuration,
   registerRuntimeObservabilityRoutes,
+  setConfigCenterStoreType,
   setDbBackupLastSuccessTimestamp,
   type RuntimePersistenceHealth
 } from "./observability";
@@ -287,6 +288,12 @@ export async function startDevServer(
   }
 
   const mysqlConfig = deps.readMySqlPersistenceConfig();
+  const logNonProductionMySqlFallback = (error: unknown): void => {
+    deps.logger.error(
+      "MySQL bootstrap failed; falling back to in-memory room persistence and filesystem config center in non-production mode",
+      error
+    );
+  };
 
   if (mysqlConfig) {
     let migrationStatus;
@@ -297,11 +304,7 @@ export async function startDevServer(
       if (isProductionEnvironment) {
         await failStartup("MySQL migration/bootstrap failed during production startup", error);
       }
-      deps.logger.warn(
-        `MySQL migration/bootstrap failed; falling back to in-memory room persistence in non-production mode: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
+      logNonProductionMySqlFallback(error);
     }
 
     if ((migrationStatus?.pending.length ?? 0) > 0 && migrationStatus) {
@@ -332,17 +335,14 @@ export async function startDevServer(
         if (isProductionEnvironment) {
           await failStartup("MySQL migration/bootstrap failed during production startup", error);
         }
-        deps.logger.warn(
-          `MySQL migration/bootstrap failed; falling back to in-memory room persistence in non-production mode: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
+        logNonProductionMySqlFallback(error);
       }
     }
   }
 
   const effectiveSnapshotStore = snapshotStore ?? deps.createMemoryRoomSnapshotStore();
   deps.configureRoomSnapshotStore(effectiveSnapshotStore);
+  setConfigCenterStoreType(configCenterStore.mode);
   await configCenterStore.initializeRuntimeConfigs();
   const backupStorage = await deps.validateBackupStorage();
   setDbBackupLastSuccessTimestamp(backupStorage.lastSuccessTimestamp);

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -190,6 +190,7 @@ interface RuntimeObservabilityState {
   errorEvents: RuntimeDiagnosticsErrorEvent[];
   counters: RuntimeObservabilityCounters;
   prometheus: {
+    configCenterStoreType: 0 | 1;
     dbBackupLastSuccessTimestamp: number | null;
     battleDurationSeconds: HistogramMetricState;
     httpRequestDurationSeconds: HistogramMetricState;
@@ -404,6 +405,7 @@ const runtimeObservability: RuntimeObservabilityState = {
     socialShareActivityRequestsTotal: 0
   },
   prometheus: {
+    configCenterStoreType: 1,
     dbBackupLastSuccessTimestamp: null,
     battleDurationSeconds: createHistogramMetricState(BATTLE_DURATION_SECONDS_BUCKETS),
     httpRequestDurationSeconds: createHistogramMetricState(HTTP_REQUEST_DURATION_SECONDS_BUCKETS),
@@ -976,6 +978,9 @@ export function buildPrometheusMetricsDocument(): string {
   }
 
   lines.push(
+    "# HELP veil_config_center_store_type Config center storage backend for this process (0=mysql, 1=filesystem).",
+    "# TYPE veil_config_center_store_type gauge",
+    `veil_config_center_store_type ${runtimeObservability.prometheus.configCenterStoreType}`,
     "# HELP veil_db_backup_last_success_timestamp Unix timestamp of the latest verified database backup success marker.",
     "# TYPE veil_db_backup_last_success_timestamp gauge",
     `veil_db_backup_last_success_timestamp ${runtimeObservability.prometheus.dbBackupLastSuccessTimestamp ?? 0}`,
@@ -2036,6 +2041,10 @@ export function recordReconnectWindowResolved(
   }
 }
 
+export function setConfigCenterStoreType(mode: "mysql" | "filesystem"): void {
+  runtimeObservability.prometheus.configCenterStoreType = mode === "mysql" ? 0 : 1;
+}
+
 export function setDbBackupLastSuccessTimestamp(timestampSeconds: number | null): void {
   runtimeObservability.prometheus.dbBackupLastSuccessTimestamp =
     timestampSeconds != null && Number.isFinite(timestampSeconds) ? Math.max(0, Math.floor(timestampSeconds)) : null;
@@ -2051,6 +2060,7 @@ export function resetRuntimeObservability(): void {
   runtimeObservability.counters.battleActionsTotal = 0;
   runtimeObservability.counters.websocketActionRateLimitedTotal = 0;
   runtimeObservability.counters.websocketActionKickTotal = 0;
+  runtimeObservability.prometheus.configCenterStoreType = 1;
   runtimeObservability.prometheus.dbBackupLastSuccessTimestamp = null;
   resetHistogram(runtimeObservability.prometheus.battleDurationSeconds);
   resetHistogram(runtimeObservability.prometheus.httpRequestDurationSeconds);

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -378,6 +378,7 @@ test("dev server startup wires the in-memory bootstrap path and closes stores on
   assert.equal(memoryStore.closeCalls, 1);
   assert.equal(configCenterStore.closeCalls, 1);
   assert.deepEqual(base.process.exitCodes, [0]);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_config_center_store_type 1$/m);
 });
 
 test("dev server loads runtime secrets before reading persistence config", async () => {
@@ -882,6 +883,118 @@ test("dev server exits non-zero in production when MySQL bootstrap fails instead
   assert.equal(base.logger.errors[0]?.message, "MySQL migration/bootstrap failed during production startup");
 });
 
+test("dev server logs and exports filesystem config center fallback when MySQL config center bootstrap fails in non-production", async () => {
+  resetRuntimeObservability();
+  const base = createBaseDependencies();
+  const filesystemConfigCenterStore = createConfigCenterStore("filesystem");
+  const memoryStore = createMemoryStore();
+  const mysqlStore = createMySqlStore(
+    {
+      ttlHours: 24,
+      cleanupIntervalMinutes: 30
+    },
+    async () => 0
+  );
+  const mysqlConfig: MySqlPersistenceConfig = {
+    host: "127.0.0.1",
+    port: 3306,
+    user: "veil",
+    password: "veil",
+    database: "project_veil",
+    pool: {
+      connectionLimit: 4,
+      maxIdle: 4,
+      idleTimeoutMs: 60_000,
+      queueLimit: 0,
+      waitForConnections: true
+    },
+    retention: {
+      ttlHours: 24,
+      cleanupIntervalMinutes: 30
+    }
+  };
+  const bootstrapError = new Error("config center access denied");
+
+  await startDevServer(3204, "127.0.0.1", {
+    readMySqlPersistenceConfig: () => mysqlConfig,
+    getSchemaMigrationStatus: async () => ({ pending: [] }),
+    createFileSystemConfigCenterStore: () => filesystemConfigCenterStore,
+    createMySqlRoomSnapshotStore: async () => mysqlStore,
+    createMySqlConfigCenterStore: async () => {
+      throw bootstrapError;
+    },
+    createMemoryRoomSnapshotStore: () => memoryStore,
+    configureRoomSnapshotStore: (store) => {
+      assert.equal(store, memoryStore);
+    },
+    createTransport: () => base.transport,
+    readRedisUrl: () => null,
+    createRedisPresence: () => {
+      throw new Error("createRedisPresence should not be used without REDIS_URL");
+    },
+    createRedisDriver: () => {
+      throw new Error("createRedisDriver should not be used without REDIS_URL");
+    },
+    registerAuthRoutes: () => undefined,
+    registerAnalyticsRoutes: () => undefined,
+    registerConfigCenterRoutes: (_app, store) => {
+      assert.equal(store, filesystemConfigCenterStore);
+    },
+    registerConfigViewerRoutes: (_app, store) => {
+      assert.equal(store, filesystemConfigCenterStore);
+    },
+    registerEventRoutes: () => undefined,
+    registerGuildRoutes: () => undefined,
+    registerPlayerAccountRoutes: () => undefined,
+    registerShopRoutes: () => undefined,
+    registerApplePaymentRoutes: () => undefined,
+    registerGooglePlayRoutes: () => undefined,
+    registerWechatPayRoutes: () => undefined,
+    registerLobbyRoutes: () => undefined,
+    registerMatchmakingRoutes: (_app, dependencies) => {
+      assert.equal(dependencies.store, memoryStore);
+    },
+    registerMinorProtectionRoutes: () => undefined,
+    registerLeaderboardRoutes: () => undefined,
+    registerSeasonRoutes: () => undefined,
+    registerRuntimeObservabilityRoutes: () => undefined,
+    validateBackupStorage: async () => backupValidationSkipped(),
+    registerRetentionSummaryRoute: () => undefined,
+    registerPrometheusMetricsMiddleware: () => undefined,
+    registerHttpRateLimitMiddleware: () => undefined,
+    registerPrometheusMetricsRoute: () => undefined,
+    registerAdminRoutes: (_app, store) => {
+      assert.equal(store, memoryStore);
+    },
+    createGameServer: (_transport, realtimeOptions) => {
+      base.gameServer.realtimeOptions.push(realtimeOptions);
+      return base.gameServer;
+    },
+    logger: base.logger,
+    process: base.process,
+    setInterval: () => {
+      throw new Error("setInterval should not be used for in-memory startup");
+    },
+    clearInterval: () => undefined,
+    isMySqlSnapshotStore: () => false
+  });
+
+  assert.equal(mysqlStore.closeCalls, 1);
+  assert.equal(filesystemConfigCenterStore.initializeCalls, 1);
+  assert.deepEqual(base.logger.warnings, []);
+  assert.deepEqual(base.logger.errors, [
+    {
+      message: "MySQL bootstrap failed; falling back to in-memory room persistence and filesystem config center in non-production mode",
+      error: bootstrapError
+    }
+  ]);
+  assertStartupLogIncludes(base.logger, [
+    /Config center storage: filesystem/,
+    /Persistence mode: degraded\/in-memory/
+  ]);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_config_center_store_type 1$/m);
+});
+
 test("dev server enables Redis-backed Colyseus scaling resources when REDIS_URL is set", async () => {
   resetRuntimeObservability();
   const base = createBaseDependencies();
@@ -1099,6 +1212,7 @@ test("dev server starts MySQL persistence, runs retention cleanup, schedules pru
   assert.equal(scheduledTimers[0]?.unrefCalls, 1);
   assert.equal(scheduledTimers[1]?.delayMs, 60 * 60 * 1000);
   assert.equal(scheduledTimers[1]?.unrefCalls, 1);
+  assert.match(buildPrometheusMetricsDocument(), /^veil_config_center_store_type 0$/m);
 
   scheduledTimers[0]?.callback();
   scheduledTimers[1]?.callback();

--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -114,6 +114,18 @@ groups:
           description: Replica lag has exceeded 30 seconds for 10 minutes. Freeze failover and backup promotion decisions until replication catches up or a deliberate recovery point is chosen.
           runbook_url: ./incident-response-runbook.md#alert-veilmysqlreplicationlaghigh
 
+      - alert: VeilConfigCenterFilesystemFallback
+        expr: max(veil_config_center_store_type) > 0
+        for: 2m
+        labels:
+          severity: critical
+          service: project-veil-server
+          notify: ops-slack
+        annotations:
+          summary: Project Veil config center is running on filesystem fallback
+          description: At least one Project Veil server process is exporting `veil_config_center_store_type=1`, which means config-center writes are not durable in MySQL and can be lost on restart or deploy.
+          runbook_url: ./alerting-runbook.md#alert-veilconfigcenterfilesystemfallback
+
       - alert: VeilWechatPaymentFraudSignalsHigh
         expr: increase(veil_runtime_error_events_total{feature_area="payment",error_code="payment_fraud_signal"}[15m]) > 0
         for: 5m


### PR DESCRIPTION
## Summary
- export a `veil_config_center_store_type` startup gauge so Prometheus can tell whether config center is using MySQL or filesystem storage
- log non-production MySQL bootstrap fallback at `error` level and explicitly mention the filesystem config center fallback
- add a production alert rule when any server process reports filesystem fallback

Closes #1414

## Validation
- `node --import tsx --test ./apps/server/test/dev-server.test.ts`
- `npm run typecheck:server` *(currently fails in untouched `apps/server/src/persistence.ts` because `MYSQL_SEASON_RANKINGS_TABLE` is undefined at lines 8528, 8575, and 8576)*