### PR TITLE
[codex] Enforce JSON payload size limits on leaderboard and admin routes

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -29,6 +29,13 @@ class InvalidAdminPayloadError extends Error {
   }
 }
 
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
 type AdminRequest = IncomingMessage & { params: Record<string, string> };
 type AdminMiddleware = (request: IncomingMessage, response: ServerResponse, next: () => void) => void;
 type AdminRouteHandler = (request: AdminRequest, response: ServerResponse) => void | Promise<void>;
@@ -43,6 +50,8 @@ type BanApproval = {
   approvedBy: string;
   approvalReference: string;
 };
+
+const MAX_JSON_BODY_BYTES = 32 * 1024;
 
 function readAdminSecret(): string | null {
   const secret = readRuntimeSecret("ADMIN_SECRET");
@@ -230,6 +239,31 @@ function sendInvalidJson(response: ServerResponse): void {
 
 function sendInvalidPayload(response: ServerResponse, message: string): void {
   sendJson(response, 400, { error: message });
+}
+
+function sendPayloadTooLarge(response: ServerResponse, error: PayloadTooLargeError): void {
+  sendJson(response, 413, {
+    error: {
+      code: error.name,
+      message: error.message
+    }
+  });
+}
+
+function sendAdminRequestBodyError(response: ServerResponse, error: unknown): boolean {
+  if (error instanceof PayloadTooLargeError) {
+    sendPayloadTooLarge(response, error);
+    return true;
+  }
+  if (error instanceof InvalidAdminJsonError) {
+    sendInvalidJson(response);
+    return true;
+  }
+  if (error instanceof InvalidAdminPayloadError) {
+    sendInvalidPayload(response, error.message);
+    return true;
+  }
+  return false;
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
@@ -673,9 +707,23 @@ function requireSupportRole(response: ServerResponse, request: IncomingMessage, 
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    if (typeof request.resume === "function") {
+      request.resume();
+    }
+    throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+  }
+
   const chunks: Buffer[] = [];
+  let totalBytes = 0;
   for await (const chunk of request) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+    }
+    chunks.push(buffer);
   }
   const raw = Buffer.concat(chunks).toString("utf8").trim();
   if (!raw) {
@@ -888,12 +936,7 @@ export function registerAdminRoutes(
 
       sendJson(response, 200, { ok: true, resources: nextResources, syncedToRoom });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       console.error("[Admin] Sync error:", error);
@@ -936,12 +979,7 @@ export function registerAdminRoutes(
         syncedToRoom
       });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       console.error("[Admin] Compensation error:", error);
@@ -959,8 +997,7 @@ export function registerAdminRoutes(
       const items = await store.listPlayerCompensationHistory(playerId, { limit: readLimit(request) });
       sendJson(response, 200, { items });
     } catch (error) {
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -998,8 +1035,7 @@ export function registerAdminRoutes(
         ...(itemId ? { itemId } : {})
       });
     } catch (error) {
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1017,12 +1053,7 @@ export function registerAdminRoutes(
       }
       sendJson(response, 200, { ok: true });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 500, { error: String(error) });
@@ -1051,12 +1082,7 @@ export function registerAdminRoutes(
       }
       sendJson(response, 200, { ok: true, account, disconnectedClients });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1079,12 +1105,7 @@ export function registerAdminRoutes(
       const account = await store.clearPlayerBan(playerId, input);
       sendJson(response, 200, { ok: true, account });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1101,8 +1122,7 @@ export function registerAdminRoutes(
       const currentBan = await store.loadPlayerBan(playerId);
       sendJson(response, 200, { items, currentBan });
     } catch (error) {
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1118,8 +1138,7 @@ export function registerAdminRoutes(
       const items = await store.listPlayerReports({ status, limit: readLimit(request, 50) });
       sendJson(response, 200, { items, status });
     } catch (error) {
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1157,12 +1176,7 @@ export function registerAdminRoutes(
 
       sendJson(response, 200, { ok: true, report, disconnectedClients });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1200,8 +1214,7 @@ export function registerAdminRoutes(
         battleHistory
       });
     } catch (error) {
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1245,12 +1258,7 @@ export function registerAdminRoutes(
       });
       sendJson(response, 200, { ok: true, account: updatedAccount });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1276,8 +1284,7 @@ export function registerAdminRoutes(
         alertHistory: buildLeaderboardAlertHistory(account)
       });
     } catch (error) {
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1330,12 +1337,7 @@ export function registerAdminRoutes(
         }
       });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1377,8 +1379,7 @@ export function registerAdminRoutes(
         ...(flagType ? { flagType } : {})
       });
     } catch (error) {
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1405,12 +1406,7 @@ export function registerAdminRoutes(
       });
       sendJson(response, 200, { ok: true, account: updatedAccount });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1427,8 +1423,7 @@ export function registerAdminRoutes(
       const audit = await guildService.listGuildAuditLogs(guildId, readLimit(request, 50));
       sendJson(response, 200, { guild, audit });
     } catch (error) {
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1446,12 +1441,7 @@ export function registerAdminRoutes(
       const guild = await guildService.hideGuild(guildId, `${role}:admin-console`, input.reason);
       sendJson(response, 200, { ok: true, guild });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1469,12 +1459,7 @@ export function registerAdminRoutes(
       const guild = await guildService.unhideGuild(guildId, `${role}:admin-console`, input.reason);
       sendJson(response, 200, { ok: true, guild });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });
@@ -1492,12 +1477,7 @@ export function registerAdminRoutes(
       await guildService.deleteGuildAsAdmin(guildId, `${role}:admin-console`, input.reason);
       sendJson(response, 200, { ok: true, guildId });
     } catch (error) {
-      if (error instanceof InvalidAdminJsonError) {
-        sendInvalidJson(response);
-        return;
-      }
-      if (error instanceof InvalidAdminPayloadError) {
-        sendInvalidPayload(response, error.message);
+      if (sendAdminRequestBodyError(response, error)) {
         return;
       }
       sendJson(response, 400, { error: String(error) });

--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -18,6 +18,15 @@ function toErrorPayload(error: unknown): { code: string; message: string } {
   };
 }
 
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+const MAX_JSON_BODY_BYTES = 32 * 1024;
+
 const TIER_THRESHOLDS = [
   { tier: "bronze", minRating: 0, maxRating: 1099 },
   { tier: "silver", minRating: 1100, maxRating: 1299 },
@@ -49,9 +58,21 @@ function readLimit(request: IncomingMessage, fallback = 100): number {
 
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
+    const declaredLength = Number(request.headers["content-length"]);
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+      if (typeof request.resume === "function") {
+        request.resume();
+      }
+      reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+      return;
+    }
+
     let body = "";
     request.on("data", (chunk: Buffer) => {
       body += chunk.toString();
+      if (Buffer.byteLength(body, "utf8") > MAX_JSON_BODY_BYTES) {
+        reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+      }
     });
     request.on("end", () => {
       try {
@@ -115,6 +136,10 @@ export function registerLeaderboardRoutes(
 
       sendJson(response, 200, { players });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });
@@ -131,6 +156,10 @@ export function registerLeaderboardRoutes(
       const { current, previous } = getCurrentAndPreviousWeeklyEntries(accounts);
       sendJson(response, 200, { current, previous });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });
@@ -151,6 +180,10 @@ export function registerLeaderboardRoutes(
       const account = await store.loadPlayerAccount(playerId);
       sendJson(response, 200, { history: account?.seasonHistory ?? [] });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });
@@ -248,6 +281,10 @@ export function registerLeaderboardRoutes(
         summary: closeSummary
       });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });

--- a/apps/server/src/seasons.ts
+++ b/apps/server/src/seasons.ts
@@ -15,6 +15,15 @@ function toErrorPayload(error: unknown): { code: string; message: string } {
   };
 }
 
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
+const MAX_JSON_BODY_BYTES = 32 * 1024;
+
 function isAdminAuthorized(request: IncomingMessage): boolean {
   const adminToken = readRuntimeSecret("VEIL_ADMIN_TOKEN");
   if (!adminToken) {
@@ -26,9 +35,21 @@ function isAdminAuthorized(request: IncomingMessage): boolean {
 
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   return new Promise((resolve, reject) => {
+    const declaredLength = Number(request.headers["content-length"]);
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+      if (typeof request.resume === "function") {
+        request.resume();
+      }
+      reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+      return;
+    }
+
     let body = "";
     request.on("data", (chunk: Buffer) => {
       body += chunk.toString();
+      if (Buffer.byteLength(body, "utf8") > MAX_JSON_BODY_BYTES) {
+        reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+      }
     });
     request.on("end", () => {
       try {
@@ -94,6 +115,10 @@ export function registerSeasonRoutes(
       const season = await store.getCurrentSeason();
       sendJson(response, 200, { season });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });
@@ -115,6 +140,10 @@ export function registerSeasonRoutes(
       });
       sendJson(response, 200, { seasons });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });
@@ -145,6 +174,10 @@ export function registerSeasonRoutes(
       });
       sendJson(response, 200, { seasons });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });
@@ -171,6 +204,10 @@ export function registerSeasonRoutes(
       const season = await store.createSeason(seasonId || `season_${Date.now()}`);
       sendJson(response, 201, { season });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -1804,6 +1804,39 @@ test("POST /api/admin/players/:id/leaderboard/freeze freezes leaderboard movemen
   assert.ok(payload.account.leaderboardModerationState?.frozenAt);
 });
 
+test("POST /api/admin/players/:id/leaderboard/freeze rejects oversized JSON bodies with 413", async (t) => {
+  const { moderator } = withSupportSecrets(t);
+  const store = createStore();
+  const { posts } = registerRoutes(store as RoomSnapshotStore);
+  const handler = posts.get("/api/admin/players/:id/leaderboard/freeze");
+  const response = createResponse();
+  const oversizedBody = JSON.stringify({
+    reason: "x".repeat(2 * 1024 * 1024)
+  });
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-freeze" },
+      body: oversizedBody,
+      headers: {
+        "content-length": String(Buffer.byteLength(oversizedBody, "utf8")),
+        "x-veil-admin-secret": moderator
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 413);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: {
+      code: "payload_too_large",
+      message: "Request body exceeds 32768 bytes"
+    }
+  });
+});
+
 test("GET /api/admin/players/:id/leaderboard/abuse-state returns structured abuse state and alert history", async (t) => {
   const { moderator } = withSupportSecrets(t);
   const store = createStore({

--- a/apps/server/test/leaderboard-routes.test.ts
+++ b/apps/server/test/leaderboard-routes.test.ts
@@ -636,6 +636,43 @@ test("POST /api/admin/leaderboard/season-rollover is idempotent for the same sea
   assert.equal((await store.getCurrentSeason())?.seasonId, "season-12");
 });
 
+test("POST /api/admin/leaderboard/season-rollover rejects oversized JSON bodies with 413", async (t) => {
+  const token = withAdminToken(t);
+  const { posts, store } = registerRoutes();
+  const handler = posts.get("/api/admin/leaderboard/season-rollover");
+  const response = createResponse();
+  const oversizedBody = JSON.stringify({
+    seasonId: "season-12",
+    nextSeasonId: "season-13",
+    notes: "x".repeat(2 * 1024 * 1024)
+  });
+
+  await store.createSeason("season-12");
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      url: "/api/admin/leaderboard/season-rollover",
+      headers: {
+        "content-length": String(Buffer.byteLength(oversizedBody, "utf8")),
+        "x-veil-admin-token": token
+      },
+      body: oversizedBody
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 413);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: {
+      code: "payload_too_large",
+      message: "Request body exceeds 32768 bytes"
+    }
+  });
+  assert.equal((await store.getCurrentSeason())?.seasonId, "season-12");
+});
+
 test("GET /api/matchmaking/tiers returns the published tier thresholds", async () => {
   const { gets } = registerRoutes();
   const handler = gets.get("/api/matchmaking/tiers");

--- a/apps/server/test/season-routes.test.ts
+++ b/apps/server/test/season-routes.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import test, { type TestContext } from "node:test";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { registerSeasonRoutes } from "../src/seasons";
@@ -29,12 +30,19 @@ function createRequest(options: {
   method?: string;
   headers?: Record<string, string | undefined>;
   url?: string;
+  body?: string;
 } = {}): IncomingMessage {
-  const request = {} as IncomingMessage;
+  const request = new EventEmitter() as IncomingMessage & EventEmitter;
   Object.assign(request, {
     method: options.method ?? "GET",
     headers: options.headers ?? {},
     url: options.url ?? "/"
+  });
+  queueMicrotask(() => {
+    if (options.body !== undefined) {
+      request.emit("data", Buffer.from(options.body, "utf8"));
+    }
+    request.emit("end");
   });
   return request;
 }
@@ -288,5 +296,38 @@ test("POST /api/admin/seasons/close returns the reward distribution summary", as
     seasonId: "season-9",
     playersRewarded: 2,
     totalGemsGranted: 75
+  });
+});
+
+test("POST /api/admin/seasons/create rejects oversized JSON bodies with 413", async (t) => {
+  const token = withAdminToken(t);
+  const store = createSeasonStore([], []);
+  const { posts } = registerRoutes(store);
+  const handler = posts.get("/api/admin/seasons/create");
+  const response = createResponse();
+  const oversizedBody = JSON.stringify({
+    seasonId: `season-${"x".repeat(2 * 1024 * 1024)}`
+  });
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      url: "/api/admin/seasons/create",
+      headers: {
+        "content-length": String(Buffer.byteLength(oversizedBody, "utf8")),
+        "x-veil-admin-token": token
+      },
+      body: oversizedBody
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 413);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: {
+      code: "payload_too_large",
+      message: "Request body exceeds 32768 bytes"
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add `MAX_JSON_BODY_BYTES = 32 * 1024` guards to the leaderboard season-rollover route, the admin seasons create route, and admin-console JSON mutation routes
- return the existing `payload_too_large` 413 shape when oversized JSON bodies are declared via `content-length` or exceed the limit while streaming
- add regression coverage that posts a 2 MB JSON body to leaderboard, seasons-admin, and admin-console endpoints and asserts HTTP 413

## Root Cause
These routes called `readJsonBody()` without a byte cap, so large request bodies could be buffered unbounded in memory.

## Validation
- `node --import tsx --test apps/server/test/leaderboard-routes.test.ts apps/server/test/season-routes.test.ts apps/server/test/admin-console.test.ts`
- attempted `npm run typecheck:server` but it currently fails on unrelated existing `apps/server/src/persistence.ts` references to `MYSQL_SEASON_RANKINGS_TABLE`

Closes #1409