### PR TITLE
Move leaderboard tier thresholds into config-center

### DIFF
--- a/apps/server/src/config-center.ts
+++ b/apps/server/src/config-center.ts
@@ -48,6 +48,11 @@ import {
   type WorldGenerationConfig
 } from "../../../packages/shared/src/index";
 import {
+  parseLeaderboardTierThresholdsConfigDocument,
+  validateLeaderboardTierThresholdsConfigDocument,
+  type LeaderboardTierThresholdsConfigDocument
+} from "./leaderboard-tier-thresholds";
+import {
   MYSQL_CONFIG_DOCUMENT_TABLE,
   MYSQL_CONFIG_DOCUMENT_UPDATED_AT_INDEX,
   type MySqlPersistenceConfig,
@@ -57,7 +62,15 @@ import { createTrackedMySqlPool } from "./mysql-pool";
 import { countRuntimeErrorEventsSince, recordRuntimeErrorEvent } from "./observability";
 import { captureServerError } from "./error-monitoring";
 
-export type ConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
+export type ConfigDocumentId =
+  | "world"
+  | "mapObjects"
+  | "units"
+  | "battleSkills"
+  | "battleBalance"
+  | "leaderboardTierThresholds";
+
+type RuntimeConfigDocumentId = "world" | "mapObjects" | "units" | "battleSkills" | "battleBalance";
 
 interface ConfigDefinition {
   id: ConfigDocumentId;
@@ -71,7 +84,8 @@ type ParsedConfigDocument =
   | MapObjectsConfig
   | UnitCatalogConfig
   | BattleSkillCatalogConfig
-  | BattleBalanceConfig;
+  | BattleBalanceConfig
+  | LeaderboardTierThresholdsConfigDocument;
 
 interface ErrorPayload {
   code: string;
@@ -449,8 +463,16 @@ const CONFIG_DEFINITIONS: ConfigDefinition[] = [
     fileName: "battle-balance.json",
     title: "战斗平衡",
     description: "伤害公式、战场环境和 PVP ELO 参数。"
+  },
+  {
+    id: "leaderboardTierThresholds",
+    fileName: "leaderboard-tier-thresholds.json",
+    title: "排行榜段位阈值",
+    description: "排行榜 tier 展示与运营调参使用的评分阈值。"
   }
 ];
+
+const RUNTIME_CONFIG_DOCUMENT_IDS = ["world", "mapObjects", "units", "battleSkills", "battleBalance"] as const;
 
 interface ConfigSnapshotRecord {
   id: string;
@@ -591,7 +613,8 @@ const CONFIG_RUNTIME_IMPACT: Record<ConfigDocumentId, string[]> = {
   mapObjects: ["地图对象编辑器", "世界预览"],
   units: ["战斗模拟器", "招募面板"],
   battleSkills: ["技能编辑器", "战斗模拟器"],
-  battleBalance: ["战斗平衡计算", "PVP 匹配"]
+  battleBalance: ["战斗平衡计算", "PVP 匹配"],
+  leaderboardTierThresholds: ["排行榜展示", "赛季运营调参"]
 };
 const CONFIG_IMPACT_RULES: Record<
   ConfigDocumentId,
@@ -625,6 +648,11 @@ const CONFIG_IMPACT_RULES: Record<
     defaultRisk: "high",
     impactedModules: ["战斗公式", "环境机关", "PVP ELO"],
     suggestedValidationActions: ["战斗公式回归", "PVP 结算检查"]
+  },
+  leaderboardTierThresholds: {
+    defaultRisk: "medium",
+    impactedModules: ["排行榜展示", "赛季 reset 调参", "运营阈值发布"],
+    suggestedValidationActions: ["排行榜 API smoke", "赛季阈值回归检查"]
   }
 };
 
@@ -935,6 +963,37 @@ const CONFIG_DOCUMENT_SCHEMAS: Record<ConfigDocumentId, JsonSchemaNode> = {
         required: ["eloK"],
         properties: {
           eloK: { type: "integer", minimum: 1, description: "ELO K 因子。" }
+        }
+      }
+    }
+  },
+  leaderboardTierThresholds: {
+    type: "object",
+    title: "Leaderboard Tier Thresholds",
+    description: "排行榜段位阈值配置，发布 key 为 leaderboard.tier_thresholds。",
+    required: ["key", "tiers"],
+    properties: {
+      key: {
+        type: "string",
+        enum: ["leaderboard.tier_thresholds"],
+        description: "配置中心发布 key。"
+      },
+      tiers: {
+        type: "array",
+        minItems: 5,
+        description: "按 bronze -> diamond 顺序定义的连续段位阈值。",
+        items: {
+          type: "object",
+          required: ["tier", "minRating"],
+          properties: {
+            tier: {
+              type: "string",
+              enum: ["bronze", "silver", "gold", "platinum", "diamond"],
+              description: "段位名。"
+            },
+            minRating: { type: "integer", minimum: 0, description: "该段位的最低评分。" },
+            maxRating: { type: "integer", minimum: 0, description: "该段位的最高评分；最后一档留空表示无上限。" }
+          }
         }
       }
     }
@@ -1738,8 +1797,17 @@ function buildSummary(id: ConfigDocumentId, parsed: unknown): string {
     return `${config.skills.length} skill(s) · ${config.statuses.length} status(es)`;
   }
 
+  if (id === "leaderboardTierThresholds") {
+    const config = parsed as LeaderboardTierThresholdsConfigDocument;
+    return `${config.tiers.length} tier(s) · ${config.key}`;
+  }
+
   const config = parsed as BattleBalanceConfig;
   return `damage/env/timer/pvp · ${config.turnTimerSeconds}s/${config.afkStrikesBeforeForfeit} AFK · K=${config.pvp.eloK} · trap=${config.environment.trapDamage}`;
+}
+
+function isRuntimeConfigDocumentId(id: ConfigDocumentId): id is RuntimeConfigDocumentId {
+  return (RUNTIME_CONFIG_DOCUMENT_IDS as readonly string[]).includes(id);
 }
 
 function normalizeJsonContent(
@@ -1956,6 +2024,10 @@ function applyBuiltinPresetToContent(
   content: string,
   presetId: typeof BUILTIN_DIFFICULTY_PRESET_IDS[number]
 ): string {
+  if (id === "leaderboardTierThresholds") {
+    return content;
+  }
+
   const parsed = parseConfigDocument(id, content);
   const next =
     id === "world"
@@ -2023,6 +2095,10 @@ function buildLayoutPresetSummary(id: typeof BUILTIN_WORLD_LAYOUT_PRESETS[number
 }
 
 function getBuiltinPresetSummaries(id: ConfigDocumentId): ConfigPresetSummary[] {
+  if (id === "leaderboardTierThresholds") {
+    return [];
+  }
+
   const summaries = BUILTIN_DIFFICULTY_PRESET_IDS.map((presetId) => buildBuiltinPresetSummary(presetId));
   if (id === "world") {
     summaries.push(...BUILTIN_WORLD_LAYOUT_PRESETS.map((presetId) => buildLayoutPresetSummary(presetId)));
@@ -2034,6 +2110,10 @@ function getBuiltinPresetSummaries(id: ConfigDocumentId): ConfigPresetSummary[] 
 }
 
 function resolveBuiltinPresetContent(id: ConfigDocumentId, currentContent: string, presetId: string): string | null {
+  if (id === "leaderboardTierThresholds") {
+    return null;
+  }
+
   if (BUILTIN_DIFFICULTY_PRESET_IDS.includes(presetId as typeof BUILTIN_DIFFICULTY_PRESET_IDS[number])) {
     return applyBuiltinPresetToContent(
       id,
@@ -2145,6 +2225,10 @@ function parseConfigDocument(
   id: ConfigDocumentId,
   content: string
 ): ParsedConfigDocument {
+  if (id === "leaderboardTierThresholds") {
+    return parseLeaderboardTierThresholdsConfigDocument(content);
+  }
+
   let parsed: unknown;
   try {
     parsed = JSON.parse(content);
@@ -2179,7 +2263,7 @@ function parseConfigDocument(
   return nextBattleBalance;
 }
 
-function buildRuntimeBundleWithParsedDocument(id: ConfigDocumentId, parsed: ParsedConfigDocument): RuntimeConfigBundle {
+function buildRuntimeBundleWithParsedDocument(id: RuntimeConfigDocumentId, parsed: ParsedConfigDocument): RuntimeConfigBundle {
   switch (id) {
     case "world":
       return buildRuntimeConfigBundle({ world: parsed as WorldGenerationConfig });
@@ -2194,7 +2278,7 @@ function buildRuntimeBundleWithParsedDocument(id: ConfigDocumentId, parsed: Pars
   }
 }
 
-function contentForDocumentId(bundle: RuntimeConfigBundle, id: ConfigDocumentId): ParsedConfigDocument {
+function contentForDocumentId(bundle: RuntimeConfigBundle, id: RuntimeConfigDocumentId): ParsedConfigDocument {
   switch (id) {
     case "world":
       return bundle.world;
@@ -2389,7 +2473,7 @@ let pendingRuntimeBundleState: PendingRuntimeBundleState | null = null;
 let configRollbackMonitorState: ConfigRollbackMonitorState | null = null;
 let lastConfigRuntimeApplyResult: ConfigRuntimeApplyResult | null = null;
 
-function serializeBundleDocument(bundle: RuntimeConfigBundle, id: ConfigDocumentId): string {
+function serializeBundleDocument(bundle: RuntimeConfigBundle, id: RuntimeConfigDocumentId): string {
   return normalizeJsonContent(contentForDocumentId(bundle, id));
 }
 
@@ -2520,7 +2604,7 @@ function assertRuntimeBundleHotReloadCompatible(bundle: RuntimeConfigBundle): vo
   }
 
   const currentBundle = appliedRuntimeBundle;
-  const incompatibleEntries = (["world", "mapObjects", "units", "battleSkills", "battleBalance"] as const)
+  const incompatibleEntries = RUNTIME_CONFIG_DOCUMENT_IDS
     .flatMap((documentId) =>
       buildConfigDiffEntries(
         documentId,
@@ -2741,7 +2825,7 @@ function buildValidationReportFromError(id: ConfigDocumentId, error: Error, cont
       valid: false,
       summary: "Content-pack consistency was not evaluated because the current document could not be parsed.",
       issueCount: 0,
-      checkedDocuments: ["world", "mapObjects", "units", "battleSkills", "battleBalance"],
+      checkedDocuments: [...RUNTIME_CONFIG_DOCUMENT_IDS],
       issues: []
     }
   };
@@ -3053,7 +3137,7 @@ function validateBattleBalanceDetailed(
 }
 
 function buildCandidateRuntimeBundle(
-  id: ConfigDocumentId,
+  id: RuntimeConfigDocumentId,
   parsed: ParsedConfigDocument,
   dependencies: {
     world: WorldGenerationConfig;
@@ -3091,12 +3175,12 @@ async function validateDocumentDetailed(
   try {
     const parsed = JSON.parse(content) as ParsedConfigDocument;
     const issues: ValidationIssue[] = [];
-    let contentPack: ContentPackValidationReport = {
+  let contentPack: ContentPackValidationReport = {
       schemaVersion: 1,
       valid: true,
       summary: "Content-pack consistency checks are pending.",
       issueCount: 0,
-      checkedDocuments: ["world", "mapObjects", "units", "battleSkills", "battleBalance"],
+      checkedDocuments: [...RUNTIME_CONFIG_DOCUMENT_IDS],
       issues: []
     };
     validateSchemaNode(parsed, CONFIG_DOCUMENT_SCHEMAS[id], "", issues);
@@ -3118,12 +3202,32 @@ async function validateDocumentDetailed(
                 )
               : id === "battleSkills"
                 ? validateBattleSkillsDetailed(parsed as BattleSkillCatalogConfig)
-              : validateBattleBalanceDetailed(
-                  parsed as BattleBalanceConfig,
-                  dependencies.battleSkills
-                );
+              : id === "battleBalance"
+                ? validateBattleBalanceDetailed(
+                    parsed as BattleBalanceConfig,
+                    dependencies.battleSkills
+                  )
+                : validateLeaderboardTierThresholdsConfigDocument(
+                    parsed as LeaderboardTierThresholdsConfigDocument
+                  ).map((issue) => ({
+                    path: issue.path,
+                    severity: "error" as const,
+                    message: issue.message,
+                    suggestion: "调整排行榜段位阈值为连续且无重叠的区间。"
+                  }));
       issues.push(...semanticIssues);
-      contentPack = validateContentPackConsistency(buildCandidateRuntimeBundle(id, parsed, dependencies));
+      if (isRuntimeConfigDocumentId(id)) {
+        contentPack = validateContentPackConsistency(buildCandidateRuntimeBundle(id, parsed, dependencies));
+      } else {
+        contentPack = {
+          schemaVersion: 1,
+          valid: true,
+          summary: "Content-pack consistency is not required for leaderboard threshold-only changes.",
+          issueCount: 0,
+          checkedDocuments: [...RUNTIME_CONFIG_DOCUMENT_IDS],
+          issues: []
+        };
+      }
     } catch {
       // Schema issues above already explain malformed structures; skip dependent semantic checks.
     }
@@ -3255,7 +3359,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
   }
 
   async initializeRuntimeConfigs(): Promise<void> {
-    const documents = await Promise.all(CONFIG_DEFINITIONS.map((definition) => this.loadDocument(definition.id)));
+    const documents = await Promise.all(RUNTIME_CONFIG_DOCUMENT_IDS.map((id) => this.loadDocument(id)));
     const bundle = buildRuntimeConfigBundle(
       Object.fromEntries(
         documents.map((document) => [document.id, parseConfigDocument(document.id, document.content)])
@@ -3472,9 +3576,11 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
         )
       });
 
-      assertRuntimeBundleHotReloadCompatible(
-        buildRuntimeBundleWithParsedDocument(stagedDocument.id, parseConfigDocument(stagedDocument.id, stagedDocument.content))
-      );
+      if (isRuntimeConfigDocumentId(stagedDocument.id)) {
+        assertRuntimeBundleHotReloadCompatible(
+          buildRuntimeBundleWithParsedDocument(stagedDocument.id, parseConfigDocument(stagedDocument.id, stagedDocument.content))
+        );
+      }
     }
 
     try {
@@ -3807,7 +3913,7 @@ abstract class BaseConfigCenterStore implements ConfigCenterStore {
   }
 
   protected async loadRuntimeBundleFromStore(): Promise<RuntimeConfigBundle> {
-    const documents = await Promise.all(CONFIG_DEFINITIONS.map((definition) => this.loadDocument(definition.id)));
+    const documents = await Promise.all(RUNTIME_CONFIG_DOCUMENT_IDS.map((id) => this.loadDocument(id)));
     return buildRuntimeConfigBundle(
       Object.fromEntries(
         documents.map((document) => [document.id, parseConfigDocument(document.id, document.content)])
@@ -3843,8 +3949,8 @@ export class FileSystemConfigCenterStore extends BaseConfigCenterStore {
 
   async saveDocument(id: ConfigDocumentId, content: string): Promise<ConfigDocument> {
     const parsed = parseConfigDocument(id, content);
-    const bundle = buildRuntimeBundleWithParsedDocument(id, parsed);
-    const serialized = normalizeJsonContent(contentForDocumentId(bundle, id));
+    const bundle = isRuntimeConfigDocumentId(id) ? buildRuntimeBundleWithParsedDocument(id, parsed) : null;
+    const serialized = bundle && isRuntimeConfigDocumentId(id) ? serializeBundleDocument(bundle, id) : normalizeJsonContent(parsed);
     const current = await this.loadDocument(id);
 
     if (current.content === serialized) {
@@ -3855,7 +3961,9 @@ export class FileSystemConfigCenterStore extends BaseConfigCenterStore {
 
     await this.exportDocumentToFile(id, serialized);
     await this.setFilesystemVersion(id, nextVersion);
-    applyRuntimeBundle(bundle);
+    if (bundle) {
+      applyRuntimeBundle(bundle);
+    }
 
     const saved = await this.loadDocument(id);
     await this.createAutomaticSnapshot(saved);
@@ -3917,8 +4025,8 @@ export class MySqlConfigCenterStore extends BaseConfigCenterStore {
 
   async saveDocument(id: ConfigDocumentId, content: string): Promise<ConfigDocument> {
     const parsed = parseConfigDocument(id, content);
-    const bundle = buildRuntimeBundleWithParsedDocument(id, parsed);
-    const serialized = normalizeJsonContent(contentForDocumentId(bundle, id));
+    const bundle = isRuntimeConfigDocumentId(id) ? buildRuntimeBundleWithParsedDocument(id, parsed) : null;
+    const serialized = bundle && isRuntimeConfigDocumentId(id) ? serializeBundleDocument(bundle, id) : normalizeJsonContent(parsed);
     const current = await this.loadDocument(id);
 
     if (current.content === serialized) {
@@ -3935,7 +4043,9 @@ export class MySqlConfigCenterStore extends BaseConfigCenterStore {
     );
 
     await this.exportDocumentToFile(id, serialized);
-    applyRuntimeBundle(bundle);
+    if (bundle) {
+      applyRuntimeBundle(bundle);
+    }
 
     const saved = await this.loadDocument(id);
     await this.createAutomaticSnapshot(saved);

--- a/apps/server/src/config-viewer.ts
+++ b/apps/server/src/config-viewer.ts
@@ -259,7 +259,7 @@ function buildViewerHtml(): string {
       <section class="hero">
         <p class="eyebrow">Project Veil</p>
         <h1>Config Viewer</h1>
-        <p>Read-only server page for the five runtime config documents. Each row shows the latest metadata, and expanding a row fetches the full JSON on demand.</p>
+        <p>Read-only server page for the config-center documents. Each row shows the latest metadata, and expanding a row fetches the full JSON on demand.</p>
         <div id="status" class="status" role="status" aria-live="polite">Loading config documents...</div>
       </section>
       <section id="list" class="list" aria-label="Config documents"></section>

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -93,6 +93,7 @@ interface CleanupTimerHandle {
 
 interface DevServerConfigCenterStore {
   initializeRuntimeConfigs(): Promise<void>;
+  loadDocument(id: "leaderboardTierThresholds"): Promise<{ content: string }>;
   close(): Promise<void>;
   readonly mode: "filesystem" | "mysql";
 }
@@ -141,7 +142,11 @@ export interface DevServerBootstrapDependencies {
   registerLobbyRoutes(app: unknown, dependencies: { listRooms: typeof listLobbyRooms }): void;
   registerMatchmakingRoutes(app: unknown, dependencies: { store: DevServerRoomSnapshotStore }): void;
   registerMinorProtectionRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
-  registerLeaderboardRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
+  registerLeaderboardRoutes(
+    app: unknown,
+    store: DevServerRoomSnapshotStore | null,
+    configCenterStore?: Pick<DevServerConfigCenterStore, "loadDocument">
+  ): void;
   registerSeasonRoutes(app: unknown, store: DevServerRoomSnapshotStore | null): void;
   registerRuntimeObservabilityRoutes(
     app: unknown,
@@ -227,7 +232,12 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
       registerMatchmakingRoutes(app as never, { store: dependencies.store as RoomSnapshotStore }),
     registerMinorProtectionRoutes: (app, store) =>
       registerMinorProtectionRoutes(app as never, store as RoomSnapshotStore | null),
-    registerLeaderboardRoutes: (app, store) => registerLeaderboardRoutes(app as never, store as RoomSnapshotStore | null),
+    registerLeaderboardRoutes: (app, store, configCenterStore) =>
+      registerLeaderboardRoutes(
+        app as never,
+        store as RoomSnapshotStore | null,
+        configCenterStore as Pick<ConfigCenterStore, "loadDocument"> | undefined
+      ),
     registerSeasonRoutes: (app, store) => registerSeasonRoutes(app as never, store as RoomSnapshotStore | null),
     registerRuntimeObservabilityRoutes: (app, options) => registerRuntimeObservabilityRoutes(app as never, options),
     validateBackupStorage: () => validateBackupStorageOnStartup(),
@@ -378,7 +388,7 @@ export async function startDevServer(
   deps.registerLobbyRoutes(expressApp, { listRooms: listLobbyRooms });
   deps.registerMatchmakingRoutes(expressApp, { store: effectiveSnapshotStore });
   deps.registerMinorProtectionRoutes(expressApp, effectiveSnapshotStore);
-  deps.registerLeaderboardRoutes(expressApp, effectiveSnapshotStore);
+  deps.registerLeaderboardRoutes(expressApp, effectiveSnapshotStore, configCenterStore);
   deps.registerSeasonRoutes(expressApp, effectiveSnapshotStore);
   deps.registerRuntimeObservabilityRoutes(expressApp, {
     store: effectiveSnapshotStore,

--- a/apps/server/src/leaderboard-tier-thresholds.ts
+++ b/apps/server/src/leaderboard-tier-thresholds.ts
@@ -1,0 +1,190 @@
+import { normalizeEloRating, type PlayerTier } from "../../../packages/shared/src/index";
+
+export interface LeaderboardTierThreshold {
+  tier: PlayerTier;
+  minRating: number;
+  maxRating: number | null;
+}
+
+export interface LeaderboardTierThresholdsConfigDocument {
+  key: "leaderboard.tier_thresholds";
+  tiers: LeaderboardTierThreshold[];
+}
+
+export interface LeaderboardTierThresholdValidationIssue {
+  path: string;
+  message: string;
+}
+
+export const DEFAULT_LEADERBOARD_TIER_THRESHOLDS = [
+  { tier: "bronze", minRating: 0, maxRating: 1099 },
+  { tier: "silver", minRating: 1100, maxRating: 1299 },
+  { tier: "gold", minRating: 1300, maxRating: 1499 },
+  { tier: "platinum", minRating: 1500, maxRating: 1799 },
+  { tier: "diamond", minRating: 1800, maxRating: null }
+] as const satisfies readonly LeaderboardTierThreshold[];
+
+const EXPECTED_TIER_ORDER: readonly PlayerTier[] = ["bronze", "silver", "gold", "platinum", "diamond"];
+
+function normalizeNonNegativeInteger(value: unknown, fallback: number): number {
+  const normalized = Number(value);
+  return Number.isFinite(normalized) && normalized >= 0 ? Math.floor(normalized) : fallback;
+}
+
+function normalizeNullableMaxRating(value: unknown, fallback: number | null): number | null {
+  if (value == null) {
+    return null;
+  }
+
+  const normalized = Number(value);
+  return Number.isFinite(normalized) && normalized >= 0 ? Math.floor(normalized) : fallback;
+}
+
+export function normalizeLeaderboardTierThresholdsConfigDocument(
+  input?: Partial<LeaderboardTierThresholdsConfigDocument> | null
+): LeaderboardTierThresholdsConfigDocument {
+  const tiers = Array.isArray(input?.tiers) ? input.tiers : [];
+  return {
+    key: "leaderboard.tier_thresholds",
+    tiers: tiers.map((tier, index) => {
+      const fallback = DEFAULT_LEADERBOARD_TIER_THRESHOLDS[index] ?? DEFAULT_LEADERBOARD_TIER_THRESHOLDS.at(-1)!;
+      return {
+        tier: EXPECTED_TIER_ORDER.includes(tier?.tier as PlayerTier) ? (tier?.tier as PlayerTier) : fallback.tier,
+        minRating: normalizeNonNegativeInteger(tier?.minRating, fallback.minRating),
+        maxRating: normalizeNullableMaxRating(tier?.maxRating, fallback.maxRating)
+      };
+    })
+  };
+}
+
+export function validateLeaderboardTierThresholdsConfigDocument(
+  document: LeaderboardTierThresholdsConfigDocument
+): LeaderboardTierThresholdValidationIssue[] {
+  const issues: LeaderboardTierThresholdValidationIssue[] = [];
+
+  if (document.key !== "leaderboard.tier_thresholds") {
+    issues.push({
+      path: "key",
+      message: 'key must be exactly "leaderboard.tier_thresholds".'
+    });
+  }
+
+  if (document.tiers.length !== EXPECTED_TIER_ORDER.length) {
+    issues.push({
+      path: "tiers",
+      message: `tiers must define exactly ${EXPECTED_TIER_ORDER.length} entries.`
+    });
+    return issues;
+  }
+
+  let expectedMinRating = 0;
+  for (const [index, threshold] of document.tiers.entries()) {
+    const pathPrefix = `tiers[${index}]`;
+    const expectedTier = EXPECTED_TIER_ORDER[index];
+
+    if (threshold.tier !== expectedTier) {
+      issues.push({
+        path: `${pathPrefix}.tier`,
+        message: `tier must be ${expectedTier}.`
+      });
+    }
+
+    if (!Number.isInteger(threshold.minRating) || threshold.minRating < 0) {
+      issues.push({
+        path: `${pathPrefix}.minRating`,
+        message: "minRating must be a non-negative integer."
+      });
+    }
+
+    if (threshold.maxRating !== null && (!Number.isInteger(threshold.maxRating) || threshold.maxRating < 0)) {
+      issues.push({
+        path: `${pathPrefix}.maxRating`,
+        message: "maxRating must be null or a non-negative integer."
+      });
+    }
+
+    if (threshold.minRating !== expectedMinRating) {
+      issues.push({
+        path: `${pathPrefix}.minRating`,
+        message: `minRating must be ${expectedMinRating} to keep tiers contiguous.`
+      });
+    }
+
+    if (index < document.tiers.length - 1) {
+      if (threshold.maxRating == null) {
+        issues.push({
+          path: `${pathPrefix}.maxRating`,
+          message: "Only the final tier may use a null maxRating."
+        });
+        continue;
+      }
+      if (threshold.maxRating < threshold.minRating) {
+        issues.push({
+          path: `${pathPrefix}.maxRating`,
+          message: "maxRating must be greater than or equal to minRating."
+        });
+        continue;
+      }
+      expectedMinRating = threshold.maxRating + 1;
+      continue;
+    }
+
+    if (threshold.maxRating !== null) {
+      issues.push({
+        path: `${pathPrefix}.maxRating`,
+        message: "The final tier must use a null maxRating."
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function parseLeaderboardTierThresholdsConfigDocument(content: string): LeaderboardTierThresholdsConfigDocument {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error("Config content is not valid JSON");
+  }
+
+  const record = typeof parsed === "object" && parsed !== null ? (parsed as Record<string, unknown>) : {};
+  const tiers = Array.isArray(record.tiers) ? record.tiers : [];
+  const document: LeaderboardTierThresholdsConfigDocument = {
+    key: record.key === "leaderboard.tier_thresholds" ? "leaderboard.tier_thresholds" : (String(record.key ?? "") as "leaderboard.tier_thresholds"),
+    tiers: tiers.map((tier) => {
+      const item = typeof tier === "object" && tier !== null ? (tier as Record<string, unknown>) : {};
+      return {
+        tier: String(item.tier ?? "") as PlayerTier,
+        minRating: Number.isFinite(Number(item.minRating)) ? Math.floor(Number(item.minRating)) : Number.NaN,
+        maxRating: item.maxRating == null ? null : Number.isFinite(Number(item.maxRating)) ? Math.floor(Number(item.maxRating)) : Number.NaN
+      };
+    })
+  };
+  const issues = validateLeaderboardTierThresholdsConfigDocument(document);
+  if (issues.length > 0) {
+    throw new Error(issues[0]!.message);
+  }
+  return document;
+}
+
+export function getLeaderboardTierForRating(
+  rating: number | undefined | null,
+  thresholds: readonly LeaderboardTierThreshold[] = DEFAULT_LEADERBOARD_TIER_THRESHOLDS
+): PlayerTier {
+  const normalizedRating = normalizeEloRating(rating);
+  for (const threshold of thresholds) {
+    if (threshold.maxRating == null) {
+      if (normalizedRating >= threshold.minRating) {
+        return threshold.tier;
+      }
+      continue;
+    }
+
+    if (normalizedRating >= threshold.minRating && normalizedRating <= threshold.maxRating) {
+      return threshold.tier;
+    }
+  }
+
+  return DEFAULT_LEADERBOARD_TIER_THRESHOLDS[0].tier;
+}

--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -1,6 +1,13 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { getRankDivisionForRating, getTierForRating } from "../../../packages/shared/src/index";
+import { getRankDivisionForRating } from "../../../packages/shared/src/index";
 import { getCurrentAndPreviousWeeklyEntries } from "./competitive-season";
+import type { ConfigCenterStore } from "./config-center";
+import {
+  DEFAULT_LEADERBOARD_TIER_THRESHOLDS,
+  getLeaderboardTierForRating,
+  parseLeaderboardTierThresholdsConfigDocument,
+  type LeaderboardTierThreshold
+} from "./leaderboard-tier-thresholds";
 import type { RoomSnapshotStore } from "./persistence";
 import { isLeaderboardFrozen, isLeaderboardHidden } from "./leaderboard-anti-abuse";
 import { readRuntimeSecret } from "./runtime-secrets";
@@ -17,14 +24,6 @@ function toErrorPayload(error: unknown): { code: string; message: string } {
     message: error instanceof Error ? error.message : String(error)
   };
 }
-
-const TIER_THRESHOLDS = [
-  { tier: "bronze", minRating: 0, maxRating: 1099 },
-  { tier: "silver", minRating: 1100, maxRating: 1299 },
-  { tier: "gold", minRating: 1300, maxRating: 1499 },
-  { tier: "platinum", minRating: 1500, maxRating: 1799 },
-  { tier: "diamond", minRating: 1800, maxRating: null }
-] as const;
 
 function readHeaderValue(value: string | string[] | undefined): string | null {
   if (Array.isArray(value)) {
@@ -70,8 +69,22 @@ export function registerLeaderboardRoutes(
     get: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
     post: (path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>) => void;
   },
-  store: RoomSnapshotStore | null
+  store: RoomSnapshotStore | null,
+  configCenterStore?: Pick<ConfigCenterStore, "loadDocument">
 ): void {
+  let cachedTierThresholds: readonly LeaderboardTierThreshold[] = DEFAULT_LEADERBOARD_TIER_THRESHOLDS;
+
+  if (configCenterStore) {
+    void configCenterStore
+      .loadDocument("leaderboardTierThresholds")
+      .then((document) => {
+        cachedTierThresholds = parseLeaderboardTierThresholdsConfigDocument(document.content).tiers;
+      })
+      .catch((error) => {
+        console.warn("[leaderboard] Failed to load config-center leaderboard tier thresholds; using defaults", error);
+      });
+  }
+
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
     response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
@@ -106,7 +119,7 @@ export function registerLeaderboardRoutes(
         playerId: account.playerId,
         displayName: account.displayName,
         eloRating: account.eloRating,
-        tier: getTierForRating(account.eloRating ?? 1000),
+        tier: getLeaderboardTierForRating(account.eloRating, cachedTierThresholds),
         division: account.rankDivision ?? getRankDivisionForRating(account.eloRating ?? 1000),
         isFrozen: isLeaderboardFrozen(account.leaderboardModerationState),
         promotionSeries: account.promotionSeries ?? null,
@@ -253,6 +266,6 @@ export function registerLeaderboardRoutes(
   });
 
   app.get("/api/matchmaking/tiers", (_request, response) => {
-    sendJson(response, 200, { tiers: TIER_THRESHOLDS });
+    sendJson(response, 200, { tiers: cachedTierThresholds });
   });
 }

--- a/apps/server/test/config-center.test.ts
+++ b/apps/server/test/config-center.test.ts
@@ -20,6 +20,7 @@ import {
   resetConfigHotReloadState
 } from "../src/config-center";
 import type { WorldConfigPreview } from "../src/config-center";
+import { DEFAULT_LEADERBOARD_TIER_THRESHOLDS } from "../src/leaderboard-tier-thresholds";
 import { recordRuntimeErrorEvent, resetRuntimeObservability } from "../src/observability";
 
 const WORLD_CONFIG = {
@@ -171,6 +172,11 @@ async function seedConfigRoot(rootDir: string): Promise<void> {
   await writeFile(join(rootDir, "units.json"), `${JSON.stringify(UNIT_CONFIG, null, 2)}\n`, "utf8");
   await writeFile(join(rootDir, "battle-skills.json"), `${JSON.stringify(BATTLE_SKILL_CONFIG, null, 2)}\n`, "utf8");
   await writeFile(join(rootDir, "battle-balance.json"), `${JSON.stringify(BATTLE_BALANCE_CONFIG, null, 2)}\n`, "utf8");
+  await writeFile(
+    join(rootDir, "leaderboard-tier-thresholds.json"),
+    `${JSON.stringify({ key: "leaderboard.tier_thresholds", tiers: DEFAULT_LEADERBOARD_TIER_THRESHOLDS }, null, 2)}\n`,
+    "utf8"
+  );
 }
 
 test.afterEach(() => {
@@ -194,9 +200,34 @@ test("config center lists seeded config documents", async () => {
 
   assert.deepEqual(
     items.map((item) => item.id),
-    ["world", "mapObjects", "units", "battleSkills", "battleBalance"]
+    ["world", "mapObjects", "units", "battleSkills", "battleBalance", "leaderboardTierThresholds"]
   );
   assert.match(items[0]?.summary ?? "", /8x8/);
+});
+
+test("config center validates leaderboard tier thresholds as a contiguous config key", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "veil-config-center-"));
+  await seedConfigRoot(rootDir);
+  const store = new FileSystemConfigCenterStore(rootDir);
+
+  const report = await store.validateDocument(
+    "leaderboardTierThresholds",
+    JSON.stringify({
+      key: "leaderboard.tier_thresholds",
+      tiers: [
+        { tier: "bronze", minRating: 0, maxRating: 1099 },
+        { tier: "silver", minRating: 1200, maxRating: 1299 },
+        { tier: "gold", minRating: 1300, maxRating: 1499 },
+        { tier: "platinum", minRating: 1500, maxRating: 1799 },
+        { tier: "diamond", minRating: 1800 }
+      ]
+    })
+  );
+
+  assert.equal(report.valid, false);
+  assert.equal(report.schema.id, "project-veil.config-center.leaderboardTierThresholds");
+  assert.match(report.summary, /当前文档问题/);
+  assert.match(report.issues[0]?.path ?? "", /^tiers\[1\]\.minRating$/);
 });
 
 test("config center save writes file and refreshes runtime world config", async () => {

--- a/apps/server/test/config-viewer.test.ts
+++ b/apps/server/test/config-viewer.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { Server, WebSocketTransport } from "colyseus";
+import { getDefaultBattleSkillCatalog } from "../../../packages/shared/src/index";
 import { FileSystemConfigCenterStore } from "../src/config-center";
+import { DEFAULT_LEADERBOARD_TIER_THRESHOLDS } from "../src/leaderboard-tier-thresholds";
 import { buildConfigViewerPageForTest, registerConfigViewerRoutes } from "../src/config-viewer";
 
 const WORLD_CONFIG = {
@@ -91,33 +93,7 @@ const UNIT_CONFIG = {
   ]
 };
 
-const BATTLE_SKILL_CONFIG = {
-  skills: [
-    {
-      id: "power_shot",
-      name: "Power Shot",
-      description: "Ranged hit.",
-      kind: "active" as const,
-      target: "enemy" as const,
-      cooldown: 2,
-      effects: {
-        damageMultiplier: 0.85,
-        allowRetaliation: false
-      }
-    }
-  ],
-  statuses: [
-    {
-      id: "poisoned",
-      name: "Poisoned",
-      description: "Takes damage over time.",
-      duration: 2,
-      attackModifier: 0,
-      defenseModifier: 0,
-      damagePerTurn: 2
-    }
-  ]
-};
+const BATTLE_SKILL_CONFIG = getDefaultBattleSkillCatalog();
 
 const BATTLE_BALANCE_CONFIG = {
   damage: {
@@ -148,6 +124,11 @@ async function seedConfigRoot(rootDir: string): Promise<void> {
   await writeFile(join(rootDir, "units.json"), `${JSON.stringify(UNIT_CONFIG, null, 2)}\n`, "utf8");
   await writeFile(join(rootDir, "battle-skills.json"), `${JSON.stringify(BATTLE_SKILL_CONFIG, null, 2)}\n`, "utf8");
   await writeFile(join(rootDir, "battle-balance.json"), `${JSON.stringify(BATTLE_BALANCE_CONFIG, null, 2)}\n`, "utf8");
+  await writeFile(
+    join(rootDir, "leaderboard-tier-thresholds.json"),
+    `${JSON.stringify({ key: "leaderboard.tier_thresholds", tiers: DEFAULT_LEADERBOARD_TIER_THRESHOLDS }, null, 2)}\n`,
+    "utf8"
+  );
 }
 
 async function startConfigViewerServer(port: number, rootDir: string): Promise<{ server: Server; store: FileSystemConfigCenterStore }> {
@@ -197,10 +178,10 @@ test("config viewer exposes list and detail aliases plus html page", async (t) =
   };
 
   assert.equal(listResponse.status, 200);
-  assert.equal(listPayload.items.length, 5);
+  assert.equal(listPayload.items.length, 6);
   assert.deepEqual(
     listPayload.items.map((item) => item.id),
-    ["world", "mapObjects", "units", "battleSkills", "battleBalance"]
+    ["world", "mapObjects", "units", "battleSkills", "battleBalance", "leaderboardTierThresholds"]
   );
   assert.ok(listPayload.items.every((item) => item.updatedAt && item.summary && item.storage && item.version >= 1));
 

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -73,6 +73,20 @@ function createConfigCenterStore(mode: "filesystem" | "mysql") {
     mode,
     initializeCalls: 0,
     closeCalls: 0,
+    async loadDocument() {
+      return {
+        content: JSON.stringify({
+          key: "leaderboard.tier_thresholds",
+          tiers: [
+            { tier: "bronze", minRating: 0, maxRating: 1099 },
+            { tier: "silver", minRating: 1100, maxRating: 1299 },
+            { tier: "gold", minRating: 1300, maxRating: 1499 },
+            { tier: "platinum", minRating: 1500, maxRating: 1799 },
+            { tier: "diamond", minRating: 1800 }
+          ]
+        })
+      };
+    },
     async initializeRuntimeConfigs() {
       this.initializeCalls += 1;
     },

--- a/apps/server/test/leaderboard-routes.test.ts
+++ b/apps/server/test/leaderboard-routes.test.ts
@@ -5,6 +5,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { addUtcDays, getUtcWeekStart } from "../../../packages/shared/src/index";
 import { registerLeaderboardRoutes } from "../src/leaderboard";
 import { createMemoryRoomSnapshotStore } from "../src/memory-room-snapshot-store";
+import { DEFAULT_LEADERBOARD_TIER_THRESHOLDS } from "../src/leaderboard-tier-thresholds";
 
 type RouteHandler = (request: IncomingMessage, response: ServerResponse) => void | Promise<void>;
 
@@ -95,9 +96,14 @@ async function runMiddlewares(
   await next();
 }
 
-function registerRoutes(store = createMemoryRoomSnapshotStore()) {
+function registerRoutes(
+  store = createMemoryRoomSnapshotStore(),
+  configCenterStore?: {
+    loadDocument(id: "leaderboardTierThresholds"): Promise<{ content: string }>;
+  }
+) {
   const { app, gets, posts, middlewares } = createTestApp();
-  registerLeaderboardRoutes(app, store);
+  registerLeaderboardRoutes(app, store, configCenterStore);
   return { gets, posts, middlewares, store };
 }
 
@@ -646,12 +652,42 @@ test("GET /api/matchmaking/tiers returns the published tier thresholds", async (
 
   assert.equal(response.statusCode, 200);
   assert.deepEqual(JSON.parse(response.body), {
+    tiers: DEFAULT_LEADERBOARD_TIER_THRESHOLDS
+  });
+});
+
+test("leaderboard routes load tier thresholds from config-center at initialization", async () => {
+  const { gets } = registerRoutes(createMemoryRoomSnapshotStore(), {
+    async loadDocument() {
+      return {
+        content: JSON.stringify({
+          key: "leaderboard.tier_thresholds",
+          tiers: [
+            { tier: "bronze", minRating: 0, maxRating: 999 },
+            { tier: "silver", minRating: 1000, maxRating: 1199 },
+            { tier: "gold", minRating: 1200, maxRating: 1399 },
+            { tier: "platinum", minRating: 1400, maxRating: 1599 },
+            { tier: "diamond", minRating: 1600 }
+          ]
+        })
+      };
+    }
+  });
+  const handler = gets.get("/api/matchmaking/tiers");
+  const response = createResponse();
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.ok(handler);
+  await handler(createRequest({ url: "/api/matchmaking/tiers" }), response);
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(JSON.parse(response.body), {
     tiers: [
-      { tier: "bronze", minRating: 0, maxRating: 1099 },
-      { tier: "silver", minRating: 1100, maxRating: 1299 },
-      { tier: "gold", minRating: 1300, maxRating: 1499 },
-      { tier: "platinum", minRating: 1500, maxRating: 1799 },
-      { tier: "diamond", minRating: 1800, maxRating: null }
+      { tier: "bronze", minRating: 0, maxRating: 999 },
+      { tier: "silver", minRating: 1000, maxRating: 1199 },
+      { tier: "gold", minRating: 1200, maxRating: 1399 },
+      { tier: "platinum", minRating: 1400, maxRating: 1599 },
+      { tier: "diamond", minRating: 1600, maxRating: null }
     ]
   });
 });

--- a/configs/leaderboard-tier-thresholds.json
+++ b/configs/leaderboard-tier-thresholds.json
@@ -1,0 +1,29 @@
+{
+  "key": "leaderboard.tier_thresholds",
+  "tiers": [
+    {
+      "tier": "bronze",
+      "minRating": 0,
+      "maxRating": 1099
+    },
+    {
+      "tier": "silver",
+      "minRating": 1100,
+      "maxRating": 1299
+    },
+    {
+      "tier": "gold",
+      "minRating": 1300,
+      "maxRating": 1499
+    },
+    {
+      "tier": "platinum",
+      "minRating": 1500,
+      "maxRating": 1799
+    },
+    {
+      "tier": "diamond",
+      "minRating": 1800
+    }
+  ]
+}

--- a/docs/release-ops-ownership-matrix.md
+++ b/docs/release-ops-ownership-matrix.md
@@ -15,6 +15,7 @@ Covered scripts: 54
 
 - Run `validate:season-reward-config` before pre-season promotion or any seasonal reset rehearsal so malformed `configs/season-rewards.json` changes fail before runtime.
 - Treat `configs/schemas/season-rewards.schema.json` as the contract for structural edits; changes to bracket fields or types should land with matching validator and test updates.
+- Treat config-center key `leaderboard.tier_thresholds` as a release-ops owned seasonal tuning surface; ship threshold changes with focused leaderboard API validation and publish audit evidence.
 
 ## Summary
 

--- a/scripts/config-center-restore.ts
+++ b/scripts/config-center-restore.ts
@@ -11,7 +11,14 @@ interface CliArgs {
   help: boolean;
 }
 
-const VALID_DOCUMENT_IDS: ConfigDocumentId[] = ["world", "mapObjects", "units", "battleSkills", "battleBalance"];
+const VALID_DOCUMENT_IDS: ConfigDocumentId[] = [
+  "world",
+  "mapObjects",
+  "units",
+  "battleSkills",
+  "battleBalance",
+  "leaderboardTierThresholds"
+];
 
 function printUsage(): void {
   console.log(`Usage: npm run config-center:restore -- --document <id> [--snapshot-id <snapshot>] [--publish-id <publish>]

--- a/scripts/release-ops-ownership-matrix.ts
+++ b/scripts/release-ops-ownership-matrix.ts
@@ -396,6 +396,7 @@ export function renderReleaseOpsOwnershipMarkdown(entries: ReleaseOpsOwnershipEn
     "",
     "- Run `validate:season-reward-config` before pre-season promotion or any seasonal reset rehearsal so malformed `configs/season-rewards.json` changes fail before runtime.",
     "- Treat `configs/schemas/season-rewards.schema.json` as the contract for structural edits; changes to bracket fields or types should land with matching validator and test updates.",
+    "- Treat config-center key `leaderboard.tier_thresholds` as a release-ops owned seasonal tuning surface; ship threshold changes with focused leaderboard API validation and publish audit evidence.",
     "",
     "## Summary",
     "",


### PR DESCRIPTION
Closes #1412

## Summary
- move leaderboard tier thresholds into a dedicated config-center document with filesystem/MySQL support
- load and cache thresholds during leaderboard route registration with fallback to the current defaults
- document the release-ops ownership of `leaderboard.tier_thresholds` and add focused server coverage

## Testing
- node --import tsx --test ./apps/server/test/leaderboard-routes.test.ts
- node --import tsx --test ./apps/server/test/config-center.test.ts
- node --import tsx --test ./apps/server/test/config-viewer.test.ts ./scripts/test/release-ops-ownership-matrix.test.ts
- npm run typecheck:ops

## Notes
- `npm run typecheck:server` still fails on an existing unrelated `MYSQL_SEASON_RANKINGS_TABLE` error in `apps/server/src/persistence.ts`.