### PR TITLE
Add DB pool exhaustion metrics and alerting

### DIFF
--- a/apps/server/src/mysql-pool.ts
+++ b/apps/server/src/mysql-pool.ts
@@ -29,6 +29,23 @@ interface TrackablePoolInternals {
   _connectionQueue?: unknown[];
 }
 
+interface ObservablePoolState {
+  activeConnections: number;
+  queueDepth: number;
+}
+
+interface EventablePool {
+  on(event: "acquire", listener: () => void): unknown;
+  off(event: "enqueue", listener: () => void): unknown;
+  on(event: "enqueue", listener: () => void): unknown;
+  once(event: "enqueue", listener: () => void): unknown;
+  on(event: "release", listener: () => void): unknown;
+}
+
+interface WrapableCorePool {
+  getConnection(callback: (error: Error | null, connection: unknown) => void): void;
+}
+
 export interface MySqlPoolMetricsSnapshot {
   pool: string;
   connectionLimit: number;
@@ -43,10 +60,16 @@ export interface MySqlPoolMetricsSnapshot {
   utilizationRatio: number;
 }
 
-const trackedPools = new Map<string, { pool: Pool; config: MySqlPoolConfig }>();
+const trackedPools = new Map<string, { pool: Pool; config: MySqlPoolConfig; state: ObservablePoolState }>();
 
 function coerceLength(value: unknown): number {
-  return Array.isArray(value) ? value.length : 0;
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  if (value && typeof value === "object" && "length" in value && typeof value.length === "number") {
+    return value.length;
+  }
+  return 0;
 }
 
 function getTrackedPoolInternals(pool: Pool): TrackablePoolInternals {
@@ -54,9 +77,54 @@ function getTrackedPoolInternals(pool: Pool): TrackablePoolInternals {
   return candidate.pool ?? {};
 }
 
-export function createTrackedMySqlPool(label: string, config: MySqlPoolConnectionConfig): Pool {
-  const pool = createPool(buildMySqlPoolOptions(config));
-  trackedPools.set(label, { pool, config: config.pool });
+function attachPoolObservability(pool: Pool, state: ObservablePoolState): void {
+  const observablePool = pool as unknown as EventablePool;
+  observablePool.on("acquire", () => {
+    state.activeConnections += 1;
+  });
+  observablePool.on("release", () => {
+    state.activeConnections = Math.max(0, state.activeConnections - 1);
+  });
+  observablePool.on("enqueue", () => {
+    state.queueDepth += 1;
+  });
+
+  const candidate = pool as unknown as { pool?: WrapableCorePool };
+  const corePool = candidate.pool;
+  if (!corePool) {
+    return;
+  }
+
+  const originalGetConnection = corePool.getConnection.bind(corePool);
+  corePool.getConnection = (callback) => {
+    let requestWasQueued = false;
+    const markQueued = () => {
+      requestWasQueued = true;
+    };
+    observablePool.once("enqueue", markQueued);
+
+    originalGetConnection((error, connection) => {
+      observablePool.off("enqueue", markQueued);
+      if (requestWasQueued) {
+        state.queueDepth = Math.max(0, state.queueDepth - 1);
+      }
+      callback(error, connection);
+    });
+  };
+}
+
+export function createTrackedMySqlPool(
+  label: string,
+  config: MySqlPoolConnectionConfig,
+  createPoolFn: (options: PoolOptions) => Pool = createPool
+): Pool {
+  const pool = createPoolFn(buildMySqlPoolOptions(config));
+  const state: ObservablePoolState = {
+    activeConnections: 0,
+    queueDepth: 0
+  };
+  attachPoolObservability(pool, state);
+  trackedPools.set(label, { pool, config: config.pool, state });
 
   const originalEnd = pool.end.bind(pool);
   (pool as { end: () => Promise<void> }).end = async () => {
@@ -89,8 +157,8 @@ export function getMySqlPoolMetricsSnapshot(): MySqlPoolMetricsSnapshot[] {
       const internals = getTrackedPoolInternals(entry.pool);
       const totalConnections = coerceLength(internals._allConnections);
       const idleConnections = coerceLength(internals._freeConnections);
-      const queueDepth = coerceLength(internals._connectionQueue);
-      const activeConnections = Math.max(0, totalConnections - idleConnections);
+      const activeConnections = entry.state.activeConnections;
+      const queueDepth = entry.state.queueDepth;
       const utilizationRatio =
         entry.config.connectionLimit > 0 ? activeConnections / entry.config.connectionLimit : 0;
 

--- a/apps/server/src/observability.ts
+++ b/apps/server/src/observability.ts
@@ -949,6 +949,10 @@ export function buildPrometheusMetricsDocument(): string {
   ];
 
   lines.push(
+    "# HELP veil_db_pool_active_connections Active database connections borrowed from the pool.",
+    "# TYPE veil_db_pool_active_connections gauge",
+    "# HELP veil_db_pool_queue_depth Database pool wait queue depth.",
+    "# TYPE veil_db_pool_queue_depth gauge",
     "# HELP veil_mysql_pool_connection_limit Configured MySQL pool connection limit.",
     "# TYPE veil_mysql_pool_connection_limit gauge",
     "# HELP veil_mysql_pool_connections_active Active MySQL connections borrowed from the pool.",
@@ -961,6 +965,8 @@ export function buildPrometheusMetricsDocument(): string {
     "# TYPE veil_mysql_pool_connection_utilization_ratio gauge"
   );
   if (mysqlPools.length === 0) {
+    lines.push("veil_db_pool_active_connections 0");
+    lines.push("veil_db_pool_queue_depth 0");
     lines.push("veil_mysql_pool_connection_limit 0");
     lines.push("veil_mysql_pool_connections_active 0");
     lines.push("veil_mysql_pool_connections_idle 0");
@@ -969,6 +975,8 @@ export function buildPrometheusMetricsDocument(): string {
   } else {
     for (const pool of mysqlPools) {
       const labels = formatPrometheusLabels({ pool: pool.pool });
+      lines.push(`veil_db_pool_active_connections${labels} ${pool.activeConnections}`);
+      lines.push(`veil_db_pool_queue_depth${labels} ${pool.queueDepth}`);
       lines.push(`veil_mysql_pool_connection_limit${labels} ${pool.connectionLimit}`);
       lines.push(`veil_mysql_pool_connections_active${labels} ${pool.activeConnections}`);
       lines.push(`veil_mysql_pool_connections_idle${labels} ${pool.idleConnections}`);

--- a/apps/server/test/mysql-pool-observability.test.ts
+++ b/apps/server/test/mysql-pool-observability.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import test from "node:test";
+import type { Pool } from "mysql2/promise";
 import { createTrackedMySqlPool } from "../src/mysql-pool";
 import { buildPrometheusMetricsDocument, resetRuntimeObservability } from "../src/observability";
 
@@ -26,7 +28,68 @@ test("prometheus metrics expose mysql pool pressure gauges when mysql pools are 
   });
 
   const metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_db_pool_active_connections\{pool="room_snapshot"\} 0$/m);
+  assert.match(metrics, /^veil_db_pool_queue_depth\{pool="room_snapshot"\} 0$/m);
   assert.match(metrics, /^veil_mysql_pool_connection_limit\{pool="room_snapshot"\} 7$/m);
   assert.match(metrics, /^veil_mysql_pool_queue_depth\{pool="room_snapshot"\} 0$/m);
   assert.match(metrics, /^veil_mysql_pool_connection_utilization_ratio\{pool="room_snapshot"\} 0\.0000$/m);
+});
+
+test("prometheus db pool gauges track active and queued requests from pool callbacks", async (t) => {
+  resetRuntimeObservability();
+
+  const queuedCallbacks: Array<(error: Error | null, connection: unknown) => void> = [];
+
+  class FakePool extends EventEmitter {
+    pool = {
+      getConnection: (callback: (error: Error | null, connection: unknown) => void) => {
+        this.emit("enqueue");
+        queuedCallbacks.push(callback);
+      }
+    };
+
+    async end(): Promise<void> {}
+  }
+
+  const fakePool = new FakePool();
+  const pool = createTrackedMySqlPool(
+    "config_center",
+    {
+      host: "127.0.0.1",
+      port: 3306,
+      user: "veil",
+      password: "veil",
+      database: "project_veil",
+      pool: {
+        connectionLimit: 4,
+        maxIdle: 4,
+        idleTimeoutMs: 60_000,
+        queueLimit: 0,
+        waitForConnections: true
+      }
+    },
+    () => fakePool as unknown as Pool
+  );
+
+  t.after(async () => {
+    await pool.end();
+    resetRuntimeObservability();
+  });
+
+  fakePool.emit("acquire");
+  fakePool.emit("acquire");
+  fakePool.emit("release");
+  fakePool.pool.getConnection(() => {});
+
+  let metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_db_pool_active_connections\{pool="config_center"\} 1$/m);
+  assert.match(metrics, /^veil_db_pool_queue_depth\{pool="config_center"\} 1$/m);
+  assert.match(metrics, /^veil_mysql_pool_connections_active\{pool="config_center"\} 1$/m);
+  assert.match(metrics, /^veil_mysql_pool_queue_depth\{pool="config_center"\} 1$/m);
+  assert.match(metrics, /^veil_mysql_pool_connection_utilization_ratio\{pool="config_center"\} 0\.2500$/m);
+
+  queuedCallbacks.shift()?.(null, {});
+  metrics = buildPrometheusMetricsDocument();
+  assert.match(metrics, /^veil_db_pool_queue_depth\{pool="config_center"\} 0$/m);
+  assert.match(metrics, /^veil_mysql_pool_queue_depth\{pool="config_center"\} 0$/m);
 });

--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -92,14 +92,14 @@ groups:
           runbook_url: ./incident-response-runbook.md#alert-veilhttprequestlatencyp95high
 
       - alert: VeilMySqlPoolPressureHigh
-        expr: max(veil_mysql_pool_queue_depth{pool=~"room_snapshot|config_center"}) > 0 or max(veil_mysql_pool_connection_utilization_ratio{pool=~"room_snapshot|config_center"}) > 0.8
-        for: 10m
+        expr: max(veil_db_pool_queue_depth{pool=~"room_snapshot|config_center"}) > 5
+        for: 30s
         labels:
           severity: warning
           service: project-veil-server
         annotations:
-          summary: Project Veil MySQL connection pools are under sustained pressure
-          description: Either the MySQL pool queue is non-zero or pool utilization has exceeded 80 percent for 10 minutes. Expect persistence/config requests to back up before user-facing latency fully degrades.
+          summary: Project Veil database connection pools are backing up
+          description: A database pool queue depth has been above 5 for 30 seconds. Expect persistence or config-center requests to stall until MySQL latency or pool saturation is relieved.
           runbook_url: ./incident-response-runbook.md#alert-veilmysqlpoolpressurehigh
 
       - alert: VeilMySqlReplicationLagHigh

--- a/docs/alerting-runbook.md
+++ b/docs/alerting-runbook.md
@@ -330,15 +330,15 @@ curl -fsS "$VEIL_RUNTIME_URL/api/runtime/health" | jq '{activeRoomCount: .runtim
 
 Mitigation steps:
 
-1. Check whether `veil_mysql_pool_queue_depth` is non-zero or whether utilization is simply hovering near the configured cap. Queue depth means callers are already waiting.
-2. If the queue is growing, inspect recent MySQL latency, lock contention, and replication health before only increasing pool limits.
-3. If MySQL is healthy but utilization is consistently above `0.8`, raise `VEIL_MYSQL_POOL_CONNECTION_LIMIT` conservatively and keep `maxIdle` aligned with the new steady-state expectation.
+1. Check whether `veil_db_pool_queue_depth` is above `5`. That means callers are already waiting for a connection rather than just running the pool hot.
+2. Inspect the matching `veil_db_pool_active_connections` and `veil_mysql_pool_connection_limit` values to see whether the pool is pinned at its cap or whether slow queries are simply holding the queue open.
+3. If the queue is growing, inspect recent MySQL latency, lock contention, and replication health before only increasing pool limits.
 4. If pressure is isolated to one pool label, treat that subsystem first: snapshot pressure points to persistence/save load, while config-center pressure points to operator workflows or config churn.
 
 Escalation thresholds:
 
-- escalate if queue depth stays above `0` for 20 minutes after load reduction or pool tuning
-- escalate immediately if utilization reaches `1.0`, if HTTP latency is also elevated, or if persistence-related error logs begin surfacing
+- escalate if queue depth stays above `5` for more than one additional 30-second window after load reduction or query mitigation
+- escalate immediately if `veil_db_pool_active_connections` is pinned to `veil_mysql_pool_connection_limit`, if HTTP latency is also elevated, or if persistence-related error logs begin surfacing
 
 ## Alert: VeilMySqlReplicationLagHigh
 

--- a/docs/mysql-persistence.md
+++ b/docs/mysql-persistence.md
@@ -455,7 +455,7 @@ That flow downloads the archive and `.sha256`, verifies integrity before touchin
 
 ## MySQL Alerting
 
-`/metrics` now exports `veil_mysql_pool_connection_limit`, `veil_mysql_pool_connections_active`, `veil_mysql_pool_connections_idle`, `veil_mysql_pool_queue_depth`, and `veil_mysql_pool_connection_utilization_ratio` for the long-lived `room_snapshot` and `config_center` pools. Use those together with the `VeilMySqlPoolPressureHigh` alert in [`docs/alerting-rules.yml`](./alerting-rules.yml) when sizing the server-side pools.
+`/metrics` now exports `veil_db_pool_active_connections`, `veil_db_pool_queue_depth`, `veil_mysql_pool_connection_limit`, `veil_mysql_pool_connections_active`, `veil_mysql_pool_connections_idle`, `veil_mysql_pool_queue_depth`, and `veil_mysql_pool_connection_utilization_ratio` for the long-lived `room_snapshot` and `config_center` pools. Use the `db_pool_*` gauges for alerting and the `mysql_pool_*` gauges for deeper pool sizing context when working with the `VeilMySqlPoolPressureHigh` alert in [`docs/alerting-rules.yml`](./alerting-rules.yml).
 
 Replication lag alerting depends on your MySQL exporter exposing `mysql_slave_status_seconds_behind_master`. Project Veil documents the threshold and response flow in the same alerting bundle so HA drills and backup restore drills use one source of truth.
 


### PR DESCRIPTION
## Summary
- switch MySQL pool active and queue-depth tracking to event-driven pool observability
- export `veil_db_pool_active_connections` and `veil_db_pool_queue_depth` while keeping the existing MySQL sizing gauges
- tighten the Prometheus alert/runbook/docs to fire when DB pool queue depth stays above 5 for 30 seconds

## Testing
- `node --import tsx --test ./apps/server/test/mysql-pool-observability.test.ts`
- `npm run typecheck:server` *(currently fails on pre-existing `MYSQL_SEASON_RANKINGS_TABLE` errors in `apps/server/src/persistence.ts`)*

Closes #1411