### PR TITLE
[codex] Pin Kubernetes deployment image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,22 @@ jobs:
         with:
           version: v1.33.1
 
+      - name: Setup kustomize
+        uses: imranismail/setup-kustomize@v2
+
+      - name: Pin Kubernetes image tag for validation
+        run: |
+          cp -R k8s "${RUNNER_TEMP}/k8s"
+          cd "${RUNNER_TEMP}/k8s"
+          kustomize edit set image ghcr.io/dannagrace/projectveil-server=ghcr.io/dannagrace/projectveil-server:${GITHUB_SHA}
+
       - name: Setup kind
         uses: engineerd/setup-kind@v0.6.2
         with:
           version: v0.24.0
 
       - name: Dry-run Kubernetes manifests
-        run: kubectl apply --dry-run=client -k k8s
+        run: kubectl apply --dry-run=client -k "${RUNNER_TEMP}/k8s"
 
   readme-script-gate:
     runs-on: ubuntu-latest

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: server
-          image: ghcr.io/dannagrace/projectveil-server:latest
+          image: ghcr.io/dannagrace/projectveil-server
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -8,3 +8,6 @@ resources:
   - service.yaml
   - ingress.yaml
   - hpa.yaml
+images:
+  - name: ghcr.io/dannagrace/projectveil-server
+    newTag: v0.0.0


### PR DESCRIPTION
## Summary
- remove the hard-coded `:latest` tag from the Kubernetes Deployment and manage the image through `kustomization.yaml`
- pin the base manifest to an explicit semver placeholder tag so production rollouts are deterministic until CI injects the build-specific tag
- update CI to run `kustomize edit set image ...:${GITHUB_SHA}` before the Kubernetes dry-run so manifest validation uses a concrete image tag

## Validation
- `npm run validate:k8s-configmap`
- local `kustomize edit set image ghcr.io/dannagrace/projectveil-server=ghcr.io/dannagrace/projectveil-server:${GITHUB_SHA:-local-sha}` followed by `kustomize build`

Closes #1434