### PR TITLE
fix(k8s): add ingress TLS for production host

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -3,13 +3,18 @@ kind: Ingress
 metadata:
   name: project-veil-server
   annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - game.projectveil.prod
+      secretName: project-veil-server-tls
   rules:
-    - host: game.projectveil.example
+    - host: game.projectveil.prod
       http:
         paths:
           - path: /


### PR DESCRIPTION
## Summary
- add nginx ingress TLS configuration for the production game host
- force HTTP to HTTPS redirects at the ingress layer
- replace the placeholder ingress host with `game.projectveil.prod`

## Validation
- `npm run validate:k8s-configmap`
- `python3` YAML assertion for `k8s/ingress.yaml`

## Notes
- The repo did not define a concrete production game hostname outside placeholder `.example` values, so this PR uses the clearly named fallback host `game.projectveil.prod`.

Closes #1435