### PR TITLE
Fix guild chat moderation handling

### DIFF
--- a/apps/server/src/guilds.ts
+++ b/apps/server/src/guilds.ts
@@ -2,10 +2,10 @@ import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   createGuild,
-  normalizeGuildChatMessageContent,
   createGuildRosterView,
   createGuildSummaryView,
   findDisplayNameModerationViolation,
+  validateGuildChatMessageContentOrThrow,
   joinGuild,
   leaveGuild,
   type GuildChatMessage,
@@ -15,6 +15,7 @@ import {
   type GuildMembershipEvent
 } from "../../../packages/shared/src/index";
 import { validateAuthSessionFromRequest } from "./auth";
+import { loadDisplayNameValidationRules } from "./display-name-rules";
 import { recordHttpRateLimited } from "./observability";
 import type { GuildAuditLogRecord, GuildChatMessageRecord, RoomSnapshotStore } from "./persistence";
 
@@ -235,6 +236,9 @@ function mapGuildError(error: unknown): { status: number; code: string; message:
   ) {
     return { status: 400, code: "invalid_request", message };
   }
+  if (error instanceof Error && error.name === "guild_chat_content_violation") {
+    return { status: 400, code: "guild_chat_content_violation", message };
+  }
   if (/guild_not_found/.test(message)) {
     return { status: 404, code: "guild_not_found", message };
   }
@@ -437,7 +441,10 @@ export class GuildService {
       displayName: authSession.displayName
     });
     const guild = await this.requireGuildMembership(guildId, authSession.playerId);
-    const normalizedContent = normalizeGuildChatMessageContent(typeof action.content === "string" ? action.content : "");
+    const normalizedContent = validateGuildChatMessageContentOrThrow(
+      typeof action.content === "string" ? action.content : "",
+      loadDisplayNameValidationRules()
+    );
     const rateLimitResult = this.guildChatRateLimiter.consume(authSession.playerId, request);
     if (!rateLimitResult.allowed) {
       throw new Error(`guild_chat_rate_limited: retry after ${rateLimitResult.retryAfterSeconds ?? 1} seconds`);

--- a/apps/server/test/guild-routes.test.ts
+++ b/apps/server/test/guild-routes.test.ts
@@ -959,6 +959,19 @@ test("guild chat routes validate messages and rate limit bursts", async (t) => {
   });
   assert.equal(tooLong.status, 400);
 
+  const moderated = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${founderSession.token}`
+    },
+    body: JSON.stringify({ content: "G.M! rally now" })
+  });
+  const moderatedPayload = (await moderated.json()) as { error: { code: string; message: string } };
+  assert.equal(moderated.status, 400);
+  assert.equal(moderatedPayload.error.code, "guild_chat_content_violation");
+  assert.match(moderatedPayload.error.message, /reserved term|banned content/i);
+
   for (const content of ["Alpha", "Bravo"]) {
     const response = await fetch(`http://127.0.0.1:${port}/api/guilds/${createdPayload.guild.guildId}/chat`, {
       method: "POST",

--- a/packages/shared/src/guild-chat.ts
+++ b/packages/shared/src/guild-chat.ts
@@ -1,3 +1,9 @@
+import {
+  findDisplayNameModerationViolation,
+  type DisplayNameModerationViolation,
+  type DisplayNameValidationRules
+} from "./display-name-validation";
+
 const DEFAULT_GUILD_CHAT_MAX_MESSAGE_LENGTH = 500;
 
 export const GUILD_CHAT_MAX_MESSAGE_LENGTH = DEFAULT_GUILD_CHAT_MAX_MESSAGE_LENGTH;
@@ -23,6 +29,16 @@ export interface GuildChatHistoryPage {
 
 const HTML_TAG_PATTERN = /<\/?[a-zA-Z][^>]*>/;
 
+export class GuildChatContentViolationError extends Error {
+  readonly violation: DisplayNameModerationViolation;
+
+  constructor(content: string, violation: DisplayNameModerationViolation) {
+    super(buildGuildChatContentViolationMessage(content, violation));
+    this.name = "guild_chat_content_violation";
+    this.violation = violation;
+  }
+}
+
 export function normalizeGuildChatMessageContent(content: string, maxLength = GUILD_CHAT_MAX_MESSAGE_LENGTH): string {
   const normalized = content.trim();
   if (!normalized) {
@@ -38,4 +54,45 @@ export function normalizeGuildChatMessageContent(content: string, maxLength = GU
   }
 
   return normalized;
+}
+
+export function findGuildChatContentModerationViolation(
+  content: string,
+  rules?: DisplayNameValidationRules
+): DisplayNameModerationViolation | null {
+  const violation = findDisplayNameModerationViolation(content, rules);
+  if (!violation || violation.reason === "game_rule") {
+    return null;
+  }
+
+  return violation;
+}
+
+export function validateGuildChatMessageContentOrThrow(
+  content: string,
+  rules?: DisplayNameValidationRules,
+  maxLength = GUILD_CHAT_MAX_MESSAGE_LENGTH
+): string {
+  const normalized = normalizeGuildChatMessageContent(content, maxLength);
+  const violation = findGuildChatContentModerationViolation(normalized, rules);
+  if (violation) {
+    throw new GuildChatContentViolationError(normalized, violation);
+  }
+
+  return normalized;
+}
+
+function buildGuildChatContentViolationMessage(
+  content: string,
+  violation: DisplayNameModerationViolation
+): string {
+  if (violation.reason === "reserved") {
+    return `Guild chat message "${content}" contains a reserved term`;
+  }
+
+  if (violation.reason === "profanity") {
+    return `Guild chat message "${content}" contains banned content`;
+  }
+
+  return `Guild chat message "${content}" violates current moderation rules`;
 }

--- a/packages/shared/test/guild-chat.test.ts
+++ b/packages/shared/test/guild-chat.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { GUILD_CHAT_MAX_MESSAGE_LENGTH, normalizeGuildChatMessageContent } from "../src/guild-chat";
+import {
+  GUILD_CHAT_MAX_MESSAGE_LENGTH,
+  GuildChatContentViolationError,
+  normalizeGuildChatMessageContent,
+  validateGuildChatMessageContentOrThrow
+} from "../src/guild-chat";
 
 test("normalizeGuildChatMessageContent trims valid messages", () => {
   assert.equal(normalizeGuildChatMessageContent("  Rally at dusk  "), "Rally at dusk");
@@ -19,4 +24,18 @@ test("normalizeGuildChatMessageContent rejects messages longer than the limit", 
     () => normalizeGuildChatMessageContent("x".repeat(GUILD_CHAT_MAX_MESSAGE_LENGTH + 1)),
     /guild_chat_message_too_long/
   );
+});
+
+test("validateGuildChatMessageContentOrThrow blocks moderated content after normalization", () => {
+  assert.throws(
+    () => validateGuildChatMessageContentOrThrow("  G.M! rally now  "),
+    (error: unknown) =>
+      error instanceof GuildChatContentViolationError &&
+      error.name === "guild_chat_content_violation" &&
+      error.violation.term === "gm"
+  );
+});
+
+test("validateGuildChatMessageContentOrThrow allows clean one-character messages", () => {
+  assert.equal(validateGuildChatMessageContentOrThrow("  a  "), "a");
 });


### PR DESCRIPTION
## Summary
- apply normalized display-name moderation rules to guild chat content while preserving chat-specific length handling
- return a structured `guild_chat_content_violation` 400 error for moderated messages
- add focused shared and guild route tests for blocked and clean chat content

## Validation
- `node --import tsx --test ./packages/shared/test/guild-chat.test.ts`
- `node --import tsx --test ./apps/server/test/guild-routes.test.ts`

Closes #1436