### PR TITLE
fix: remove k8s config placeholders

### DIFF
--- a/apps/server/src/analytics.ts
+++ b/apps/server/src/analytics.ts
@@ -172,6 +172,15 @@ function recordFlushFailure(message: string): void {
   analyticsPipelineCounters.lastErrorMessage = message;
 }
 
+function usesExampleHostname(value: string): boolean {
+  try {
+    const hostname = new URL(value).hostname.trim().toLowerCase();
+    return hostname === "example" || hostname.endsWith(".example");
+  } catch {
+    return /\.example($|\/|:)/.test(value.trim().toLowerCase());
+  }
+}
+
 function resolveAnalyticsPipelineConfig(env: NodeJS.ProcessEnv = process.env): AnalyticsPipelineConfig {
   const requestedSink = env.ANALYTICS_SINK?.trim().toLowerCase();
   const configuredEndpoint = env.ANALYTICS_ENDPOINT?.trim() || env.ANALYTICS_HTTP_ENDPOINT?.trim() || null;
@@ -186,6 +195,10 @@ function resolveAnalyticsPipelineConfig(env: NodeJS.ProcessEnv = process.env): A
   if (sink === "http" && !configuredEndpoint) {
     alerts.push("ANALYTICS_SINK=http but ANALYTICS_ENDPOINT is not configured; falling back to stdout.");
     sink = "stdout";
+  }
+
+  if (configuredEndpoint && usesExampleHostname(configuredEndpoint)) {
+    alerts.push("ANALYTICS_ENDPOINT uses a .example hostname; analytics delivery is still pointed at a placeholder endpoint.");
   }
 
   return {

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { Server, WebSocketTransport } from "colyseus";
 import { config as loadEnv } from "dotenv";
 import { registerAuthRoutes } from "./auth";
-import { registerAnalyticsRoutes } from "./analytics";
+import { getAnalyticsPipelineSnapshot, registerAnalyticsRoutes } from "./analytics";
 import { validateBackupStorageOnStartup, type BackupStorageValidationResult } from "./backup-storage";
 import { registerClientErrorRoutes } from "./client-error";
 import {
@@ -446,6 +446,10 @@ export async function startDevServer(
     );
   } else {
     deps.logger.log("Error monitoring: SENTRY_DSN not configured; external delivery skipped");
+  }
+
+  for (const alert of getAnalyticsPipelineSnapshot().alerts) {
+    deps.logger.warn(`ANALYTICS WARNING: ${alert}`);
   }
 
   let snapshotCleanupTimer: CleanupTimerHandle | null = null;

--- a/apps/server/test/analytics.test.ts
+++ b/apps/server/test/analytics.test.ts
@@ -218,6 +218,18 @@ test("getAnalyticsPipelineSnapshot warns when http sink is requested without an 
   assert.match(snapshot.alerts[0] ?? "", /ANALYTICS_ENDPOINT/);
 });
 
+test("getAnalyticsPipelineSnapshot warns when ANALYTICS_ENDPOINT still uses a .example hostname", () => {
+  const snapshot = getAnalyticsPipelineSnapshot({
+    ANALYTICS_SINK: "http",
+    ANALYTICS_ENDPOINT: "https://analytics.projectveil.example/ingest"
+  });
+
+  assert.equal(snapshot.status, "warn");
+  assert.equal(snapshot.sink, "http");
+  assert.equal(snapshot.endpoint, "https://analytics.projectveil.example/ingest");
+  assert.match(snapshot.alerts[0] ?? "", /ANALYTICS_ENDPOINT uses a \.example hostname/);
+});
+
 test("registerAnalyticsRoutes rejects malformed analytics payloads", async () => {
   let handler:
     | ((request: never, response: TestResponse) => void | Promise<void>)

--- a/apps/server/test/dev-server.test.ts
+++ b/apps/server/test/dev-server.test.ts
@@ -1386,3 +1386,76 @@ test("dev server emits a prominent production warning when SENTRY_DSN is absent"
     "OBSERVABILITY WARNING: SENTRY_DSN is not configured for production startup; runtime errors will not be delivered to Sentry."
   ]);
 });
+
+test("dev server warns at startup when ANALYTICS_ENDPOINT still points at a .example host", async () => {
+  resetRuntimeObservability();
+  const base = createBaseDependencies();
+  const configCenterStore = createConfigCenterStore("filesystem");
+  const memoryStore = createMemoryStore();
+  const originalAnalyticsSink = process.env.ANALYTICS_SINK;
+  const originalAnalyticsEndpoint = process.env.ANALYTICS_ENDPOINT;
+  process.env.ANALYTICS_SINK = "http";
+  process.env.ANALYTICS_ENDPOINT = "https://analytics.projectveil.example/ingest";
+
+  try {
+    await startDevServer(3113, "127.0.0.1", {
+      readMySqlPersistenceConfig: () => null,
+      createFileSystemConfigCenterStore: () => configCenterStore,
+      createMemoryRoomSnapshotStore: () => memoryStore,
+      configureRoomSnapshotStore: () => undefined,
+      createTransport: () => base.transport,
+      readRedisUrl: () => null,
+      createRedisPresence: () => {
+        throw new Error("createRedisPresence should not be used without REDIS_URL");
+      },
+      createRedisDriver: () => {
+        throw new Error("createRedisDriver should not be used without REDIS_URL");
+      },
+      registerAuthRoutes: () => undefined,
+      registerConfigCenterRoutes: () => undefined,
+      registerConfigViewerRoutes: () => undefined,
+      registerGuildRoutes: () => undefined,
+      registerPlayerAccountRoutes: () => undefined,
+      registerShopRoutes: () => undefined,
+      registerWechatPayRoutes: () => undefined,
+      registerLobbyRoutes: () => undefined,
+      registerMatchmakingRoutes: () => undefined,
+      registerMinorProtectionRoutes: () => undefined,
+      registerPrometheusMetricsMiddleware: () => undefined,
+      registerHttpRateLimitMiddleware: () => undefined,
+      registerPrometheusMetricsRoute: () => undefined,
+      registerLeaderboardRoutes: () => undefined,
+      registerSeasonRoutes: () => undefined,
+      registerRuntimeObservabilityRoutes: () => undefined,
+      validateBackupStorage: async () => backupValidationSkipped(),
+      registerAdminRoutes: () => undefined,
+      createGameServer: (_transport, realtimeOptions) => {
+        base.gameServer.realtimeOptions.push(realtimeOptions);
+        return base.gameServer;
+      },
+      logger: base.logger,
+      process: base.process,
+      setInterval: () => {
+        throw new Error("setInterval should not be used for in-memory startup");
+      },
+      clearInterval: () => undefined,
+      isMySqlSnapshotStore: () => false
+    });
+  } finally {
+    if (originalAnalyticsSink === undefined) {
+      delete process.env.ANALYTICS_SINK;
+    } else {
+      process.env.ANALYTICS_SINK = originalAnalyticsSink;
+    }
+
+    if (originalAnalyticsEndpoint === undefined) {
+      delete process.env.ANALYTICS_ENDPOINT;
+    } else {
+      process.env.ANALYTICS_ENDPOINT = originalAnalyticsEndpoint;
+    }
+  }
+
+  assert.deepEqual(base.logger.warnings, [
+    "ANALYTICS WARNING: ANALYTICS_ENDPOINT uses a .example hostname; analytics delivery is still pointed at a placeholder endpoint."
+  ]);
+});

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -40,6 +40,7 @@ Create a `Secret` named `project-veil-server-secrets` with the sensitive keys do
 - `SUPPORT_SUPERVISOR_SECRET`
 - `VEIL_ADMIN_TOKEN`
 - `VEIL_MYSQL_PASSWORD`
+- `SENTRY_DSN`
 
 The deployment uses `envFrom` so the secret keys should match the runtime env var names exactly.
 

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -18,7 +18,6 @@ data:
   VEIL_AWS_SECRETS_MANAGER_REGION: us-east-1
   VEIL_BACKUP_S3_BUCKET: project-veil-prod-backups
   VEIL_BACKUP_S3_PREFIX: backups/mysql
-  VEIL_BACKUP_S3_ENDPOINT: https://s3.example.com
   VEIL_BACKUP_S3_REGION: us-east-1
   VEIL_BACKUP_AWS_PROFILE: project-veil-production
   VEIL_BACKUP_KEEP_DAILY_DAYS: "30"
@@ -41,4 +40,3 @@ data:
   VEIL_AUTH_GUEST_TTL_SECONDS: "604800"
   VEIL_MATCHMAKING_QUEUE_TTL_SECONDS: "300"
   ANALYTICS_ENDPOINT: https://analytics.projectveil.internal/ingest
-  SENTRY_DSN: https://public@o123456.ingest.sentry.io/42

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -18,6 +18,12 @@ spec:
         - name: server
           image: ghcr.io/dannagrace/projectveil-server
           imagePullPolicy: IfNotPresent
+          env:
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: project-veil-server-secrets
+                  key: SENTRY_DSN
           envFrom:
             - configMapRef:
                 name: project-veil-server-config


### PR DESCRIPTION
## Summary
- remove the remaining placeholder-backed values from `k8s/configmap.yaml`
- source `SENTRY_DSN` from `project-veil-server-secrets` via `secretKeyRef`
- warn during startup and through runtime observability when `ANALYTICS_ENDPOINT` still points at a `.example` host

## Validation
- `npm run validate:k8s-configmap`
- `node --import tsx --test ./scripts/test/validate-k8s-configmap-placeholders.test.ts`
- `node --import tsx --test ./apps/server/test/analytics.test.ts ./apps/server/test/dev-server.test.ts`

Closes #1433