### PR TITLE
[TEST] E2E smoke for seasonal event lifecycle

### DIFF
--- a/apps/server/src/event-engine.ts
+++ b/apps/server/src/event-engine.ts
@@ -9,6 +9,7 @@ import type {
   SeasonalEventReward,
   SeasonalEventState
 } from "../../../packages/shared/src/index";
+import { emitAnalyticsEvent } from "./analytics";
 import { validateAuthSessionFromRequest } from "./auth";
 import type { DailyQuestConfigDefinition } from "./daily-quest-config";
 import type { PlayerAccountSnapshot, PlayerQuestRotationHistoryEntry, PlayerQuestState, RoomSnapshotStore } from "./persistence";
@@ -1104,6 +1105,16 @@ export function registerEventRoutes(
             }
           : {}),
         seasonalEventStates: upsertSeasonalEventState(account.seasonalEventStates, claim.state)
+      });
+      emitAnalyticsEvent("seasonal_event_reward_claimed", {
+        playerId: account.playerId,
+        roomId: account.lastRoomId ?? `seasonal-event:${event.id}`,
+        payload: {
+          eventId: event.id,
+          rewardId: claim.reward.id,
+          rewardKind: claim.reward.kind,
+          pointsRequired: claim.reward.pointsRequired
+        }
       });
 
       sendJson(response, 200, {

--- a/apps/server/src/memory-room-snapshot-store.ts
+++ b/apps/server/src/memory-room-snapshot-store.ts
@@ -2269,6 +2269,13 @@ export class MemoryRoomSnapshotStore implements RoomSnapshotStore {
         : existing.dailyDungeonState
           ? { dailyDungeonState: structuredClone(existing.dailyDungeonState) }
           : {}),
+      ...(patch.seasonalEventStates !== undefined
+        ? patch.seasonalEventStates
+          ? { seasonalEventStates: structuredClone(patch.seasonalEventStates) }
+          : {}
+        : existing.seasonalEventStates
+          ? { seasonalEventStates: structuredClone(existing.seasonalEventStates) }
+          : {}),
       ...(patch.leaderboardAbuseState !== undefined
         ? patch.leaderboardAbuseState
           ? { leaderboardAbuseState: structuredClone(patch.leaderboardAbuseState) }

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -53,6 +53,17 @@ export const ANALYTICS_EVENT_CATALOG = {
       gold: 50
     }
   }),
+  seasonal_event_reward_claimed: defineAnalyticsEvent(
+    "seasonal_event_reward_claimed",
+    1,
+    "Seasonal event threshold reward claimed by the player.",
+    {
+      eventId: "defend-the-bridge",
+      rewardId: "bridge-relief-fund",
+      rewardKind: "gems",
+      pointsRequired: 120
+    }
+  ),
   daily_login: defineAnalyticsEvent("daily_login", 1, "Daily first-login reward was issued to the player.", {
     dateKey: "2026-04-11",
     streak: 3,

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -52,7 +52,7 @@ const DAILY_QUEST_SMOKE_ROTATIONS = JSON.stringify({
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  testMatch: /(daily-quest-claim|lobby-smoke|onboarding-funnel|reconnect-prediction-convergence)\.spec\.ts/,
+  testMatch: /(daily-quest-claim|lobby-smoke|onboarding-funnel|reconnect-prediction-convergence|seasonal-event-lifecycle)\.spec\.ts/,
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
   fullyParallel: false,
@@ -74,6 +74,7 @@ export default defineConfig({
       env: {
         ...process.env,
         ANALYTICS_ENDPOINT: "http://127.0.0.1:2567/api/analytics/events",
+        VEIL_ADMIN_TOKEN: process.env.VEIL_ADMIN_TOKEN ?? "dev-admin-token",
         VEIL_DAILY_QUESTS_ENABLED: "1",
         VEIL_DAILY_QUEST_ROTATIONS_JSON: DAILY_QUEST_SMOKE_ROTATIONS
       },

--- a/tests/e2e/seasonal-event-lifecycle.spec.ts
+++ b/tests/e2e/seasonal-event-lifecycle.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+import { pollForAnalyticsEvent } from "./analytics-helpers";
+
+const SERVER_BASE_URL = "http://127.0.0.1:2567";
+const ADMIN_TOKEN = process.env.VEIL_ADMIN_TOKEN ?? "dev-admin-token";
+const EVENT_ID = "defend-the-bridge";
+const OBJECTIVE_ACTION_TYPE = "daily_dungeon_reward_claimed";
+const OBJECTIVE_DUNGEON_ID = "shadow-archives";
+const GEMS_REWARD_ID = "bridge-relief-fund";
+const BADGE_REWARD_ID = "bridge-vanguard-badge";
+const BADGE_ID = "bridge_vanguard_2026";
+const GEMS_REWARD_AMOUNT = 35;
+
+interface GuestLoginPayload {
+  session?: {
+    token?: string;
+  };
+}
+
+interface PlayerProfilePayload {
+  account?: {
+    gems?: number;
+    seasonBadges?: string[];
+  };
+  session?: {
+    token?: string;
+  };
+}
+
+interface SeasonalEventResponse {
+  id?: string;
+  player?: {
+    points?: number;
+    claimedRewardIds?: string[];
+    claimableRewardIds?: string[];
+  };
+  leaderboard?: {
+    entries?: Array<{
+      rank?: number;
+      playerId?: string;
+      points?: number;
+    }>;
+  };
+}
+
+interface ActiveEventsPayload {
+  events?: SeasonalEventResponse[];
+}
+
+interface ProgressPayload {
+  applied?: boolean;
+  eventProgress?: {
+    eventId?: string;
+    delta?: number;
+    points?: number;
+    objectiveId?: string;
+  };
+  event?: SeasonalEventResponse;
+}
+
+interface ClaimPayload {
+  claimed?: boolean;
+  reward?: {
+    id?: string;
+    gems?: number;
+    badge?: string;
+  };
+  event?: SeasonalEventResponse;
+}
+
+function buildAuthHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`
+  };
+}
+
+async function createGuestSessionToken(request: APIRequestContext, playerId: string): Promise<string> {
+  const response = await request.post(`${SERVER_BASE_URL}/api/auth/guest-login`, {
+    data: {
+      playerId,
+      displayName: "Seasonal Event E2E",
+      privacyConsentAccepted: true
+    }
+  });
+  expect(response.status()).toBe(200);
+
+  const payload = (await response.json()) as GuestLoginPayload;
+  expect(payload.session?.token).toBeTruthy();
+  return payload.session?.token ?? "";
+}
+
+async function patchEventActiveWindow(request: APIRequestContext): Promise<void> {
+  const now = Date.now();
+  const response = await request.patch(`${SERVER_BASE_URL}/api/admin/seasonal-events/${EVENT_ID}`, {
+    headers: {
+      "Content-Type": "application/json",
+      "x-veil-admin-token": ADMIN_TOKEN
+    },
+    data: {
+      startsAt: new Date(now - 60_000).toISOString(),
+      endsAt: new Date(now + 24 * 60 * 60 * 1000).toISOString(),
+      isActive: true
+    }
+  });
+  expect(response.status()).toBe(200);
+}
+
+async function fetchActiveEvent(request: APIRequestContext, token: string): Promise<SeasonalEventResponse> {
+  const response = await request.get(`${SERVER_BASE_URL}/api/events/active`, {
+    headers: buildAuthHeaders(token)
+  });
+  expect(response.status()).toBe(200);
+
+  const payload = (await response.json()) as ActiveEventsPayload;
+  const event = payload.events?.find((entry) => entry.id === EVENT_ID);
+  expect(event).toBeTruthy();
+  return event as SeasonalEventResponse;
+}
+
+async function submitProgress(request: APIRequestContext, token: string, actionId: string): Promise<ProgressPayload> {
+  const response = await request.post(`${SERVER_BASE_URL}/api/events/${EVENT_ID}/progress`, {
+    headers: buildAuthHeaders(token),
+    data: {
+      actionId,
+      actionType: OBJECTIVE_ACTION_TYPE,
+      dungeonId: OBJECTIVE_DUNGEON_ID
+    }
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as ProgressPayload;
+}
+
+async function claimReward(request: APIRequestContext, token: string, rewardId: string): Promise<ClaimPayload> {
+  const response = await request.post(`${SERVER_BASE_URL}/api/events/claim`, {
+    headers: buildAuthHeaders(token),
+    data: {
+      eventId: EVENT_ID,
+      rewardId
+    }
+  });
+  expect(response.status()).toBe(200);
+  return (await response.json()) as ClaimPayload;
+}
+
+async function fetchProfile(
+  request: APIRequestContext,
+  token: string
+): Promise<{ account: NonNullable<PlayerProfilePayload["account"]>; token: string }> {
+  const response = await request.get(`${SERVER_BASE_URL}/api/player-accounts/me`, {
+    headers: buildAuthHeaders(token)
+  });
+  expect(response.status()).toBe(200);
+
+  const payload = (await response.json()) as PlayerProfilePayload;
+  expect(payload.account).toBeTruthy();
+  expect(payload.session?.token).toBeTruthy();
+  return {
+    account: payload.account as NonNullable<PlayerProfilePayload["account"]>,
+    token: payload.session?.token ?? token
+  };
+}
+
+test.beforeEach(async ({ request }) => {
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  expect(response.ok()).toBeTruthy();
+});
+
+test("seasonal event smoke covers progress submission, reward claim settlement, and leaderboard visibility", async ({ request }) => {
+  const playerId = `seasonal-e2e-${Date.now()}`;
+  let token = await createGuestSessionToken(request, playerId);
+  await patchEventActiveWindow(request);
+
+  const profileBeforeClaim = await fetchProfile(request, token);
+  token = profileBeforeClaim.token;
+
+  await test.step("api: active event is visible before progress", async () => {
+    const event = await fetchActiveEvent(request, token);
+    expect(event.player?.points).toBe(0);
+    expect(event.player?.claimedRewardIds ?? []).toEqual([]);
+    expect(event.player?.claimableRewardIds ?? []).toEqual([]);
+  });
+
+  await test.step("api: repeated progress submissions unlock the event rewards and place the player on the leaderboard", async () => {
+    for (let index = 1; index <= 5; index += 1) {
+      const payload = await submitProgress(request, token, `seasonal-progress-${index}`);
+      expect(payload.applied).toBe(true);
+      expect(payload.eventProgress).toEqual({
+        eventId: EVENT_ID,
+        delta: 40,
+        points: index * 40,
+        objectiveId: "bridge-dungeon-clear"
+      });
+    }
+
+    const event = await fetchActiveEvent(request, token);
+    expect(event.player?.points).toBe(200);
+    expect(event.player?.claimableRewardIds ?? []).toEqual(
+      expect.arrayContaining(["bridge-ration-cache", GEMS_REWARD_ID, BADGE_REWARD_ID])
+    );
+    expect(event.leaderboard?.entries?.[0]).toEqual(
+      expect.objectContaining({
+        rank: 1,
+        playerId,
+        points: 200
+      })
+    );
+  });
+
+  await test.step("api: reward claims settle gems and badge credits and keep the leaderboard visible", async () => {
+    const gemsClaim = await claimReward(request, token, GEMS_REWARD_ID);
+    expect(gemsClaim.claimed).toBe(true);
+    expect(gemsClaim.reward?.id).toBe(GEMS_REWARD_ID);
+    expect(gemsClaim.reward?.gems).toBe(GEMS_REWARD_AMOUNT);
+
+    const badgeClaim = await claimReward(request, token, BADGE_REWARD_ID);
+    expect(badgeClaim.claimed).toBe(true);
+    expect(badgeClaim.reward?.id).toBe(BADGE_REWARD_ID);
+    expect(badgeClaim.reward?.badge).toBe(BADGE_ID);
+
+    const profileAfterClaim = await fetchProfile(request, token);
+    token = profileAfterClaim.token;
+    expect(profileAfterClaim.account.gems).toBe((profileBeforeClaim.account.gems ?? 0) + GEMS_REWARD_AMOUNT);
+    expect(profileAfterClaim.account.seasonBadges ?? []).toContain(BADGE_ID);
+
+    const eventAfterClaim = await fetchActiveEvent(request, token);
+    expect(eventAfterClaim.player?.claimedRewardIds ?? []).toEqual(expect.arrayContaining([GEMS_REWARD_ID, BADGE_REWARD_ID]));
+    expect(eventAfterClaim.leaderboard?.entries?.[0]).toEqual(
+      expect.objectContaining({
+        rank: 1,
+        playerId,
+        points: 200
+      })
+    );
+  });
+
+  await test.step("api: seasonal claim emits analytics", async () => {
+    const claimEvent = await pollForAnalyticsEvent(
+      request,
+      "seasonal_event_reward_claimed",
+      (event) => event.payload.eventId === EVENT_ID && event.payload.rewardId === GEMS_REWARD_ID
+    );
+    expect(claimEvent.payload.rewardKind).toBe("gems");
+    expect(claimEvent.payload.pointsRequired).toBe(120);
+  });
+});


### PR DESCRIPTION
## Summary
- add a narrow Playwright smoke spec for seasonal event active fetch, progress submission, reward claim, leaderboard visibility, and claim analytics
- include the spec in the smoke config and set a default local admin token for the smoke server
- persist `seasonalEventStates` in the in-memory snapshot store so repeated progress submissions accumulate during smoke runs

## Validation
- `npm run validate:analytics-schema`
- `npm run validate:e2e:fixtures`
- `npx playwright test tests/e2e/seasonal-event-lifecycle.spec.ts --config=playwright.smoke.config.ts`

Closes #1424