### PR TITLE
Pseudonymize retained financial records on GDPR delete

### DIFF
--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -2082,6 +2082,10 @@ function normalizePlayerId(playerId: string): string {
   return normalized;
 }
 
+function createDeletedFinancialRecordPseudonym(): string {
+  return `deleted-financial-${randomUUID()}`;
+}
+
 function normalizeBattleSnapshotStatus(status: BattleSnapshotStatus): BattleSnapshotStatus {
   if (status !== "active" && status !== "resolved" && status !== "compensated" && status !== "aborted") {
     throw new Error("battle snapshot status is invalid");
@@ -8485,6 +8489,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
 
     const deletedAt = normalizePrivacyConsentAt(input.deletedAt) ?? new Date().toISOString();
     const anonymizedDisplayName = `deleted-${normalizedPlayerId}`;
+    const retainedFinancialPlayerToken = createDeletedFinancialRecordPseudonym();
 
     const connection = await this.pool.getConnection();
     try {
@@ -8541,7 +8546,7 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         [normalizedPlayerId, normalizedPlayerId]
       );
       await connection.query(
-        `DELETE FROM \`${MYSQL_SEASON_RANKINGS_TABLE}\`
+        `DELETE FROM \`${MYSQL_LEADERBOARD_SEASON_ARCHIVE_TABLE}\`
          WHERE player_id = ?`,
         [normalizedPlayerId]
       );
@@ -8549,6 +8554,18 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         `DELETE FROM \`${MYSQL_SEASON_REWARD_LOG_TABLE}\`
          WHERE player_id = ?`,
         [normalizedPlayerId]
+      );
+      await connection.query(
+        `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+         SET player_id = ?
+         WHERE player_id = ?`,
+        [retainedFinancialPlayerToken, normalizedPlayerId]
+      );
+      await connection.query(
+        `UPDATE \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+         SET player_id = ?
+         WHERE player_id = ?`,
+        [retainedFinancialPlayerToken, normalizedPlayerId]
       );
 
       const verificationChecks = [
@@ -8603,13 +8620,23 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
           params: [normalizedPlayerId, normalizedPlayerId]
         },
         {
-          label: MYSQL_SEASON_RANKINGS_TABLE,
-          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_SEASON_RANKINGS_TABLE}\` WHERE player_id = ?`,
+          label: MYSQL_LEADERBOARD_SEASON_ARCHIVE_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_LEADERBOARD_SEASON_ARCHIVE_TABLE}\` WHERE player_id = ?`,
           params: [normalizedPlayerId]
         },
         {
           label: MYSQL_SEASON_REWARD_LOG_TABLE,
           sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_SEASON_REWARD_LOG_TABLE}\` WHERE player_id = ?`,
+          params: [normalizedPlayerId]
+        },
+        {
+          label: MYSQL_PAYMENT_ORDER_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_PAYMENT_ORDER_TABLE}\` WHERE player_id = ?`,
+          params: [normalizedPlayerId]
+        },
+        {
+          label: MYSQL_PAYMENT_RECEIPT_TABLE,
+          sql: `SELECT COUNT(*) AS total FROM \`${MYSQL_PAYMENT_RECEIPT_TABLE}\` WHERE player_id = ?`,
           params: [normalizedPlayerId]
         }
       ];

--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -8556,16 +8556,21 @@ export class MySqlRoomSnapshotStore implements RoomSnapshotStore {
         [normalizedPlayerId]
       );
       await connection.query(
-        `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
-         SET player_id = ?
-         WHERE player_id = ?`,
-        [retainedFinancialPlayerToken, normalizedPlayerId]
+        `UPDATE \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+         INNER JOIN \`${MYSQL_PAYMENT_ORDER_TABLE}\`
+           ON \`${MYSQL_PAYMENT_ORDER_TABLE}\`.order_id = \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`.order_id
+         SET \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`.player_id = ?
+         WHERE \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`.player_id = ?
+           AND \`${MYSQL_PAYMENT_ORDER_TABLE}\`.player_id = ?
+           AND \`${MYSQL_PAYMENT_ORDER_TABLE}\`.status IN (?, ?)`,
+        [retainedFinancialPlayerToken, normalizedPlayerId, normalizedPlayerId, "settled", "dead_letter"]
       );
       await connection.query(
-        `UPDATE \`${MYSQL_PAYMENT_RECEIPT_TABLE}\`
+        `UPDATE \`${MYSQL_PAYMENT_ORDER_TABLE}\`
          SET player_id = ?
-         WHERE player_id = ?`,
-        [retainedFinancialPlayerToken, normalizedPlayerId]
+         WHERE player_id = ?
+           AND status IN (?, ?)`,
+        [retainedFinancialPlayerToken, normalizedPlayerId, "settled", "dead_letter"]
       );
 
       const verificationChecks = [

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -661,9 +661,11 @@ test("deletePlayerAccount deletes dependent rows, verifies cascade cleanup, and 
   assert.ok(retainedOrderUpdate);
   assert.equal(retainedOrderUpdate?.params[1], "player-1");
   assert.match(String(retainedOrderUpdate?.params[0] ?? ""), /^deleted-financial-/);
+  assert.deepEqual(retainedOrderUpdate?.params.slice(2), ["settled", "dead_letter"]);
   const retainedReceiptUpdate = queries.find((entry) => /UPDATE `payment_receipts`/.test(entry.sql));
   assert.ok(retainedReceiptUpdate);
-  assert.deepEqual(retainedReceiptUpdate?.params, retainedOrderUpdate?.params);
+  assert.equal(retainedReceiptUpdate?.params[0], retainedOrderUpdate?.params[0]);
+  assert.deepEqual(retainedReceiptUpdate?.params.slice(1), ["player-1", "player-1", "settled", "dead_letter"]);
   assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 14);
   const updateQuery = queries.find((entry) => /UPDATE `player_accounts`/.test(entry.sql));
   assert.ok(updateQuery);
@@ -729,7 +731,7 @@ test("deletePlayerAccount rolls back when post-delete verification finds remaini
   assert.ok(queries.every((entry) => !/UPDATE `player_accounts`/.test(entry.sql)));
 });
 
-test("deletePlayerAccount rolls back when orders verification still finds a raw player id", async () => {
+test("deletePlayerAccount rolls back when unsettled orders keep a raw player id", async () => {
   const existingAccount = createExistingAccount({
     displayName: "Veil Ranger",
     loginId: "veil-ranger"
@@ -784,7 +786,68 @@ test("deletePlayerAccount rolls back when orders verification still finds a raw 
   assert.ok(retainedOrderUpdate);
   assert.equal(retainedOrderUpdate?.params[1], "player-1");
   assert.match(String(retainedOrderUpdate?.params[0] ?? ""), /^deleted-financial-/);
+  assert.deepEqual(retainedOrderUpdate?.params.slice(2), ["settled", "dead_letter"]);
   assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `orders`/.test(entry.sql)));
+  assert.ok(queries.every((entry) => !/UPDATE `player_accounts`/.test(entry.sql)));
+});
+
+test("deletePlayerAccount rolls back when payment receipts verification still finds a raw player id", async () => {
+  const existingAccount = createExistingAccount({
+    displayName: "Veil Ranger",
+    loginId: "veil-ranger"
+  });
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  let committed = false;
+  let rolledBack = false;
+  const connection = {
+    async beginTransaction() {},
+    async query(sql: string, params: unknown[] = []) {
+      queries.push({ sql, params });
+      if (/FROM `payment_receipts`/.test(sql) && /SELECT COUNT\(\*\) AS total/.test(sql)) {
+        return [[{ total: 1 }]];
+      }
+      if (/SELECT COUNT\(\*\) AS total/.test(sql)) {
+        return [[{ total: 0 }]];
+      }
+
+      return [{ affectedRows: 1 }];
+    },
+    async commit() {
+      committed = true;
+    },
+    async rollback() {
+      rolledBack = true;
+    },
+    release() {}
+  };
+
+  const store = createStoreHarness();
+  store.loadPlayerAccount = async () => existingAccount;
+  store.loadPlayerAccountByLoginId = async () => null;
+  store.ensurePlayerAccount = async () => existingAccount;
+  store.pool = {
+    query: async () => {
+      throw new Error("pool.query should not be used by deletePlayerAccount");
+    },
+    getConnection: async () => connection
+  };
+
+  await assert.rejects(
+    () =>
+      store.deletePlayerAccount("player-1", {
+        deletedAt: "2026-03-21T00:00:00.000Z"
+      }),
+    /gdpr_delete_verification_failed:payment_receipts/
+  );
+
+  assert.equal(committed, false);
+  assert.equal(rolledBack, true);
+  const retainedReceiptUpdate = queries.find((entry) => /UPDATE `payment_receipts`/.test(entry.sql));
+  assert.ok(retainedReceiptUpdate);
+  assert.equal(retainedReceiptUpdate?.params[1], "player-1");
+  assert.equal(retainedReceiptUpdate?.params[2], "player-1");
+  assert.deepEqual(retainedReceiptUpdate?.params.slice(3), ["settled", "dead_letter"]);
+  assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `payment_receipts`/.test(entry.sql)));
   assert.ok(queries.every((entry) => !/UPDATE `player_accounts`/.test(entry.sql)));
 });
 

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -655,9 +655,16 @@ test("deletePlayerAccount deletes dependent rows, verifies cascade cleanup, and 
   assert.ok(queries.some((entry) => /DELETE FROM `player_compensation_history`/.test(entry.sql)));
   assert.ok(queries.some((entry) => /DELETE FROM `guild_memberships`/.test(entry.sql)));
   assert.ok(queries.some((entry) => /DELETE FROM `battle_snapshots`/.test(entry.sql)));
-  assert.ok(queries.some((entry) => /DELETE FROM `veil_season_rankings`/.test(entry.sql)));
+  assert.ok(queries.some((entry) => /DELETE FROM `leaderboard_season_archives`/.test(entry.sql)));
   assert.ok(queries.some((entry) => /DELETE FROM `season_reward_log`/.test(entry.sql)));
-  assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 12);
+  const retainedOrderUpdate = queries.find((entry) => /UPDATE `orders`/.test(entry.sql));
+  assert.ok(retainedOrderUpdate);
+  assert.equal(retainedOrderUpdate?.params[1], "player-1");
+  assert.match(String(retainedOrderUpdate?.params[0] ?? ""), /^deleted-financial-/);
+  const retainedReceiptUpdate = queries.find((entry) => /UPDATE `payment_receipts`/.test(entry.sql));
+  assert.ok(retainedReceiptUpdate);
+  assert.deepEqual(retainedReceiptUpdate?.params, retainedOrderUpdate?.params);
+  assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 14);
   const updateQuery = queries.find((entry) => /UPDATE `player_accounts`/.test(entry.sql));
   assert.ok(updateQuery);
   assert.equal(updateQuery?.params[0], "deleted-player-1");

--- a/apps/server/test/persistence-account-credentials.test.ts
+++ b/apps/server/test/persistence-account-credentials.test.ts
@@ -729,6 +729,65 @@ test("deletePlayerAccount rolls back when post-delete verification finds remaini
   assert.ok(queries.every((entry) => !/UPDATE `player_accounts`/.test(entry.sql)));
 });
 
+test("deletePlayerAccount rolls back when orders verification still finds a raw player id", async () => {
+  const existingAccount = createExistingAccount({
+    displayName: "Veil Ranger",
+    loginId: "veil-ranger"
+  });
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  let committed = false;
+  let rolledBack = false;
+  const connection = {
+    async beginTransaction() {},
+    async query(sql: string, params: unknown[] = []) {
+      queries.push({ sql, params });
+      if (/FROM `orders`/.test(sql) && /SELECT COUNT\(\*\) AS total/.test(sql)) {
+        return [[{ total: 1 }]];
+      }
+      if (/SELECT COUNT\(\*\) AS total/.test(sql)) {
+        return [[{ total: 0 }]];
+      }
+
+      return [{ affectedRows: 1 }];
+    },
+    async commit() {
+      committed = true;
+    },
+    async rollback() {
+      rolledBack = true;
+    },
+    release() {}
+  };
+
+  const store = createStoreHarness();
+  store.loadPlayerAccount = async () => existingAccount;
+  store.loadPlayerAccountByLoginId = async () => null;
+  store.ensurePlayerAccount = async () => existingAccount;
+  store.pool = {
+    query: async () => {
+      throw new Error("pool.query should not be used by deletePlayerAccount");
+    },
+    getConnection: async () => connection
+  };
+
+  await assert.rejects(
+    () =>
+      store.deletePlayerAccount("player-1", {
+        deletedAt: "2026-03-21T00:00:00.000Z"
+      }),
+    /gdpr_delete_verification_failed:orders/
+  );
+
+  assert.equal(committed, false);
+  assert.equal(rolledBack, true);
+  const retainedOrderUpdate = queries.find((entry) => /UPDATE `orders`/.test(entry.sql));
+  assert.ok(retainedOrderUpdate);
+  assert.equal(retainedOrderUpdate?.params[1], "player-1");
+  assert.match(String(retainedOrderUpdate?.params[0] ?? ""), /^deleted-financial-/);
+  assert.ok(queries.some((entry) => /SELECT COUNT\(\*\) AS total FROM `orders`/.test(entry.sql)));
+  assert.ok(queries.every((entry) => !/UPDATE `player_accounts`/.test(entry.sql)));
+});
+
 test("creditGems updates balance and appends a ledger entry in one transaction", async () => {
   const store = createStoreHarness();
   const queries: Array<{ sql: string; params: unknown[] }> = [];

--- a/apps/server/test/persistence-account-delete-gdpr-cascade.test.ts
+++ b/apps/server/test/persistence-account-delete-gdpr-cascade.test.ts
@@ -116,7 +116,7 @@ test("deletePlayerAccount removes GDPR-linked name history, guild chat, and refe
       (entry) => /SELECT COUNT\(\*\) AS total FROM `referrals` WHERE referrer_id = \? OR new_player_id = \?/.test(entry.sql)
     )
   );
-  assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 12);
+  assert.equal(queries.filter((entry) => /SELECT COUNT\(\*\) AS total/.test(entry.sql)).length, 14);
 });
 
 test("deletePlayerAccount rolls back when guild chat rows remain after author cleanup", async () => {

--- a/docs/gdpr-delete-runbook.md
+++ b/docs/gdpr-delete-runbook.md
@@ -33,12 +33,20 @@ SELECT 'battle_snapshots', COUNT(*)
 FROM battle_snapshots
 WHERE attacker_player_id = :player_id OR defender_player_id = :player_id
 UNION ALL
-SELECT 'veil_season_rankings', COUNT(*)
-FROM veil_season_rankings
+SELECT 'leaderboard_season_archives', COUNT(*)
+FROM leaderboard_season_archives
 WHERE player_id = :player_id
 UNION ALL
 SELECT 'season_reward_log', COUNT(*)
 FROM season_reward_log
+WHERE player_id = :player_id
+UNION ALL
+SELECT 'orders (raw player_id removed)', COUNT(*)
+FROM orders
+WHERE player_id = :player_id
+UNION ALL
+SELECT 'payment_receipts (raw player_id removed)', COUNT(*)
+FROM payment_receipts
 WHERE player_id = :player_id;
 ```
 

--- a/docs/gdpr-delete-runbook.md
+++ b/docs/gdpr-delete-runbook.md
@@ -25,9 +25,21 @@ SELECT 'player_event_history', COUNT(*)
 FROM player_event_history
 WHERE player_id = :player_id
 UNION ALL
+SELECT 'player_name_history', COUNT(*)
+FROM player_name_history
+WHERE player_id = :player_id
+UNION ALL
 SELECT 'guild_memberships', COUNT(*)
 FROM guild_memberships
 WHERE player_id = :player_id
+UNION ALL
+SELECT 'guild_messages', COUNT(*)
+FROM guild_messages
+WHERE author_player_id = :player_id
+UNION ALL
+SELECT 'referrals', COUNT(*)
+FROM referrals
+WHERE referrer_id = :player_id OR new_player_id = :player_id
 UNION ALL
 SELECT 'battle_snapshots', COUNT(*)
 FROM battle_snapshots


### PR DESCRIPTION
Fixes #1423

## Summary
- pseudonymize retained financial rows during GDPR account deletion by replacing raw `player_id` in `orders` and `payment_receipts` with a single non-reversible token generated inside the deletion transaction
- keep the retained financial rows linkable to each other within the same deletion event while removing direct linkage back to the deleted player id
- extend delete verification and the GDPR runbook so raw `player_id` is confirmed absent from retained financial tables after deletion
- align the delete path and verification with the actual archived leaderboard table present in this repo: `leaderboard_season_archives`

## Validation
- `node --import tsx --test ./apps/server/test/persistence-account-credentials.test.ts ./apps/server/test/player-account-delete-routes.test.ts`
- `npm run typecheck:server`