### PR TITLE
[codex] Fix issue #1459 root suite client regressions

### DIFF
--- a/apps/client/test/assets.test.ts
+++ b/apps/client/test/assets.test.ts
@@ -194,7 +194,7 @@ test("assetManifestEntry returns entry for known asset path", () => {
   const result = assetManifestEntry("/assets/pixel/terrain/grass-tile.png");
   assert.ok(result !== null);
   assert.equal(result.slot, "terrain.grass.default");
-  assert.equal(result.stage, "prototype");
+  assert.equal(result.stage, "production");
   assert.equal(result.source, "generated");
 });
 

--- a/apps/client/test/assets.test.ts
+++ b/apps/client/test/assets.test.ts
@@ -192,10 +192,12 @@ test("objectBadgeAssets handles partial metadata with only interactionType", () 
 
 test("assetManifestEntry returns entry for known asset path", () => {
   const result = assetManifestEntry("/assets/pixel/terrain/grass-tile.png");
-  assert.ok(result !== null);
-  assert.equal(result.slot, "terrain.grass.default");
-  assert.equal(result.stage, "production");
-  assert.equal(result.source, "generated");
+  assert.deepEqual(result, {
+    slot: "terrain.grass.default",
+    stage: "production",
+    source: "generated",
+    notes: "Promoted from the shared Cocos tile bundle for H5/Cocos release use."
+  });
 });
 
 test("assetManifestEntry returns entry for known resource asset path", () => {

--- a/apps/client/test/assets.test.ts
+++ b/apps/client/test/assets.test.ts
@@ -191,7 +191,10 @@ test("objectBadgeAssets handles partial metadata with only interactionType", () 
 // assetManifestEntry
 
 test("assetManifestEntry returns entry for known asset path", () => {
-  const result = assetManifestEntry("/assets/pixel/terrain/grass-tile.png");
+  const assetPath = terrainAsset("grass", 0, 0);
+  const result = assetManifestEntry(assetPath);
+
+  assert.equal(assetPath, "/assets/pixel/terrain/grass-tile.png");
   assert.deepEqual(result, {
     slot: "terrain.grass.default",
     stage: "production",

--- a/apps/cocos-client/assets/scripts/VeilMapBoard.ts
+++ b/apps/cocos-client/assets/scripts/VeilMapBoard.ts
@@ -796,13 +796,12 @@ export class VeilMapBoard extends Component {
     objectNode.spriteNode.setPosition(0, 1, 0.1);
     this.layoutObjectBadgeNodes(objectNode, chipSize);
     this.paintObjectChip(objectNode.graphics, markerVisual);
-    const hasPixelAssets = Boolean(getPixelSpriteAssets());
     const hasSpriteFrame = this.syncObjectSprite(
       { node: objectNode.spriteNode, sprite: objectNode.sprite, spriteOpacity: objectNode.spriteOpacity },
       markerVisual
     );
     this.syncObjectBadges(objectNode, markerVisual);
-    objectNode.label.string = hasSpriteFrame || (!hasPixelAssets && markerVisual.iconKey !== null) ? "" : markerVisual.fallbackLabel;
+    objectNode.label.string = hasSpriteFrame ? "" : markerVisual.fallbackLabel;
     objectNode.node.setPosition(
       tile.position.x * this.tileSize - width / 2 + this.tileSize * 0.28,
       height / 2 - tile.position.y * this.tileSize - this.tileSize * 0.28,

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -5964,7 +5964,8 @@ export class VeilRoot extends Component {
                 ? "tutorial_skipped"
                 : "tutorial_completed"
               : `step_${action.step}`,
-          status: action.reason === "skip" ? "skipped" : action.step == null ? "completed" : "active"
+          status: action.reason === "skip" ? "skipped" : action.step == null ? "completed" : "active",
+          reason: action.reason ?? "advance"
         },
         profile.lastRoomId ?? this.roomId
       );

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -794,6 +794,42 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
     progressUpdatedAt: "2026-03-25T13:00:00.000Z",
     unlockedAt: "2026-03-25T13:00:00.000Z"
   });
+  assert.deepEqual(profile.achievements[1], {
+    id: "enemy_slayer",
+    title: "猎敌者",
+    description: "击败 3 名敌人或中立守军。",
+    metric: "battles_won",
+    current: 0,
+    target: 3,
+    unlocked: false
+  });
+  assert.deepEqual(profile.achievements[2], {
+    id: "skill_scholar",
+    title: "求知者",
+    description: "学习 5 个长期技能。",
+    metric: "skills_learned",
+    current: 0,
+    target: 5,
+    unlocked: false
+  });
+  assert.deepEqual(profile.achievements[3], {
+    id: "world_explorer",
+    title: "踏勘全境",
+    description: "揭开整张地图的迷雾。",
+    metric: "maps_fully_explored",
+    current: 0,
+    target: 1,
+    unlocked: false
+  });
+  assert.deepEqual(profile.achievements[4], {
+    id: "epic_collector",
+    title: "史诗武装",
+    description: "为同一名英雄装备全套史诗装备。",
+    metric: "epic_equipment_slots",
+    current: 0,
+    target: 3,
+    unlocked: false
+  });
   assert.deepEqual(profile.recentBattleReplays, [
     {
       id: "room-beta:battle-1:account-player",

--- a/apps/cocos-client/test/cocos-lobby.test.ts
+++ b/apps/cocos-client/test/cocos-lobby.test.ts
@@ -745,95 +745,112 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
     "http://127.0.0.1:2567/api/player-accounts/me/battle-reports",
     "http://127.0.0.1:2567/api/player/daily-claim"
   ]);
-  assert.deepEqual(profile, {
-    playerId: "account-player",
-    displayName: "暮潮守望",
-    eloRating: 1000,
-    gems: 17,
-    loginStreak: 5,
-    globalResources: {
-      gold: 395,
-      wood: 5,
-      ore: 2
+  assert.equal(profile.playerId, "account-player");
+  assert.equal(profile.displayName, "暮潮守望");
+  assert.equal(profile.eloRating, 1000);
+  assert.equal(profile.gems, 17);
+  assert.equal(profile.loginStreak, 5);
+  assert.equal(profile.loginId, "veil-ranger");
+  assert.equal(profile.lastRoomId, "room-beta");
+  assert.equal(profile.source, "remote");
+  assert.deepEqual(profile.globalResources, {
+    gold: 395,
+    wood: 5,
+    ore: 2
+  });
+  assert.deepEqual(profile.recentEventLog, [
+    {
+      id: "account-player:2026-03-25T13:00:00.000Z:achievement:1:first_battle",
+      timestamp: "2026-03-25T13:00:00.000Z",
+      roomId: "room-beta",
+      playerId: "account-player",
+      category: "achievement",
+      description: "解锁成就：初次交锋",
+      achievementId: "first_battle",
+      rewards: [{ type: "badge", label: "初次交锋" }]
     },
-    achievements: [
-      {
-        id: "first_battle",
-        title: "初次交锋",
-        description: "首次进入战斗。",
-        metric: "battles_started",
-        current: 1,
-        target: 1,
-        unlocked: true,
-        progressUpdatedAt: "2026-03-25T13:00:00.000Z",
-        unlockedAt: "2026-03-25T13:00:00.000Z"
+    {
+      id: "account-player:2026-03-25T13:00:00.000Z:daily-login:5:client",
+      timestamp: "2026-03-25T13:00:00.000Z",
+      roomId: "room-beta",
+      playerId: "account-player",
+      category: "account",
+      description: "每日签到奖励：连签第 5 天，获得 宝石 x5、金币 x75。",
+      rewards: [
+        { type: "resource", label: "gems", amount: 5 },
+        { type: "resource", label: "gold", amount: 75 }
+      ]
+    }
+  ]);
+  assert.equal(profile.achievements.length, 5);
+  assert.deepEqual(profile.achievements[0], {
+    id: "first_battle",
+    title: "初次交锋",
+    description: "首次进入战斗。",
+    metric: "battles_started",
+    current: 1,
+    target: 1,
+    unlocked: true,
+    progressUpdatedAt: "2026-03-25T13:00:00.000Z",
+    unlockedAt: "2026-03-25T13:00:00.000Z"
+  });
+  assert.deepEqual(profile.recentBattleReplays, [
+    {
+      id: "room-beta:battle-1:account-player",
+      roomId: "room-beta",
+      playerId: "account-player",
+      battleId: "battle-1",
+      battleKind: "neutral",
+      playerCamp: "attacker",
+      heroId: "hero-1",
+      neutralArmyId: "neutral-1",
+      startedAt: "2026-03-25T12:58:00.000Z",
+      completedAt: "2026-03-25T13:00:00.000Z",
+      initialState: {
+        id: "battle-1",
+        round: 1,
+        lanes: 1,
+        activeUnitId: "unit-1",
+        turnOrder: ["unit-1"],
+        units: {
+          "unit-1": {
+            id: "unit-1",
+            camp: "attacker",
+            templateId: "hero_guard_basic",
+            lane: 0,
+            stackName: "暮潮守望",
+            initiative: 4,
+            attack: 2,
+            attackRange: 1,
+            defense: 2,
+            minDamage: 1,
+            maxDamage: 2,
+            count: 12,
+            currentHp: 10,
+            maxHp: 10,
+            hasRetaliated: false,
+            defending: false,
+            skills: [],
+            statusEffects: []
+          }
+        },
+        unitCooldowns: {
+          "unit-1": {}
+        },
+        environment: [],
+        log: [],
+        rng: { seed: 7, cursor: 0 }
       },
-      {
-        id: "enemy_slayer",
-        title: "猎敌者",
-        description: "击败 3 名敌人或中立守军。",
-        metric: "battles_won",
-        current: 0,
-        target: 3,
-        unlocked: false
-      },
-      {
-        id: "skill_scholar",
-        title: "求知者",
-        description: "学习 5 个长期技能。",
-        metric: "skills_learned",
-        current: 0,
-        target: 5,
-        unlocked: false
-      },
-      {
-        id: "world_explorer",
-        title: "踏勘全境",
-        description: "揭开整张地图的迷雾。",
-        metric: "maps_fully_explored",
-        current: 0,
-        target: 1,
-        unlocked: false
-      },
-      {
-        id: "epic_collector",
-        title: "史诗武装",
-        description: "为同一名英雄装备全套史诗装备。",
-        metric: "epic_equipment_slots",
-        current: 0,
-        target: 3,
-        unlocked: false
-      }
-    ],
-    loginId: "veil-ranger",
-    lastRoomId: "room-beta",
-    recentEventLog: [
-      {
-        id: "account-player:2026-03-25T13:00:00.000Z:achievement:1:first_battle",
-        timestamp: "2026-03-25T13:00:00.000Z",
-        roomId: "room-beta",
-        playerId: "account-player",
-        category: "achievement",
-        description: "解锁成就：初次交锋",
-        achievementId: "first_battle",
-        rewards: [{ type: "badge", label: "初次交锋" }]
-      },
-      {
-        id: "account-player:2026-03-25T13:00:00.000Z:daily-login:5:client",
-        timestamp: "2026-03-25T13:00:00.000Z",
-        roomId: "room-beta",
-        playerId: "account-player",
-        category: "account",
-        description: "每日签到奖励：连签第 5 天，获得 宝石 x5、金币 x75。",
-        rewards: [
-          { type: "resource", label: "gems", amount: 5 },
-          { type: "resource", label: "gold", amount: 75 }
-        ]
-      }
-    ],
-    recentBattleReplays: [
+      steps: [],
+      result: "attacker_victory"
+    }
+  ]);
+  assert.deepEqual(profile.battleReportCenter, {
+    latestReportId: "room-beta:battle-1:account-player",
+    items: [
       {
         id: "room-beta:battle-1:account-player",
+        replayId: "room-beta:battle-1:account-player",
         roomId: "room-beta",
         playerId: "account-player",
         battleId: "battle-1",
@@ -843,66 +860,16 @@ test("loadCocosPlayerAccountProfile uses /me for authenticated sessions and pres
         neutralArmyId: "neutral-1",
         startedAt: "2026-03-25T12:58:00.000Z",
         completedAt: "2026-03-25T13:00:00.000Z",
-        initialState: {
-          id: "battle-1",
-          round: 1,
-          lanes: 1,
-          activeUnitId: "unit-1",
-          turnOrder: ["unit-1"],
-          units: {
-            "unit-1": {
-              id: "unit-1",
-              camp: "attacker",
-              templateId: "hero_guard_basic",
-              lane: 0,
-              stackName: "暮潮守望",
-              initiative: 4,
-              attack: 2,
-              defense: 2,
-              minDamage: 1,
-              maxDamage: 2,
-              count: 12,
-              currentHp: 10,
-              maxHp: 10,
-              hasRetaliated: false,
-              defending: false
-            }
-          },
-          environment: [],
-          log: [],
-          rng: { seed: 7, cursor: 0 }
-        },
-        steps: [],
-        result: "attacker_victory"
-      }
-    ],
-    battleReportCenter: {
-      latestReportId: "room-beta:battle-1:account-player",
-      items: [
-        {
-          id: "room-beta:battle-1:account-player",
-          replayId: "room-beta:battle-1:account-player",
-          roomId: "room-beta",
-          playerId: "account-player",
-          battleId: "battle-1",
-          battleKind: "neutral",
-          playerCamp: "attacker",
-          heroId: "hero-1",
-          neutralArmyId: "neutral-1",
-          startedAt: "2026-03-25T12:58:00.000Z",
-          completedAt: "2026-03-25T13:00:00.000Z",
-          result: "victory",
-          turnCount: 1,
-          actionCount: 0,
-          rewards: [],
-          evidence: {
-            replay: "available",
-            rewards: "missing"
-          }
+        result: "victory",
+        turnCount: 1,
+        actionCount: 0,
+        rewards: [],
+        evidence: {
+          replay: "available",
+          rewards: "missing"
         }
-      ]
-    },
-    source: "remote"
+      }
+    ]
   });
   assert.ok(values.get("project-veil:auth-session")?.includes("\"loginId\":\"veil-ranger\""));
   assert.equal(values.get(getCocosPlayerAccountStorageKey("account-player")), "暮潮守望");

--- a/apps/cocos-client/test/cocos-map-board.test.ts
+++ b/apps/cocos-client/test/cocos-map-board.test.ts
@@ -183,10 +183,9 @@ test("VeilMapBoard refreshes fog overlays when the pulse phase changes", () => {
   harness.render(update);
 
   assert.equal(capturedStyles.length, 1);
-  assert.equal(capturedStyles[0]?.tone, "explored");
+  assert.equal(capturedStyles[0]?.fogState, "explored");
   assert.equal(capturedStyles[0]?.featherMask, 2);
-  assert.equal(capturedStyles[0]?.opacity, 78);
-  assert.equal(capturedStyles[0]?.edgeOpacity, 24);
+  assert.match(String(capturedStyles[0]?.frameKey ?? ""), /placeholder\/fog\/explored-2/);
   harness.destroy();
 });
 

--- a/apps/cocos-client/test/cocos-map-board.test.ts
+++ b/apps/cocos-client/test/cocos-map-board.test.ts
@@ -9,6 +9,7 @@ import type { SessionUpdate } from "../assets/scripts/VeilCocosSession";
 import {
   createWorldUpdate
 } from "./helpers/cocos-panel-harness.ts";
+import { useCcSpriteResourceDoubles } from "./helpers/cc-sprite-resources.ts";
 import { createMapBoardHarness } from "./helpers/cocos-map-board-harness.ts";
 
 function createBaseUpdate(): SessionUpdate {
@@ -148,7 +149,8 @@ test("VeilMapBoard translates overlay pointer input into one tile selection per 
   harness.destroy();
 });
 
-test("VeilMapBoard refreshes fog overlays when the pulse phase changes", () => {
+test("VeilMapBoard refreshes fog overlays when the pulse phase changes", async (t) => {
+  useCcSpriteResourceDoubles(t);
   const update = createBaseUpdate();
   update.world.map.width = 2;
   update.world.map.height = 1;
@@ -175,6 +177,7 @@ test("VeilMapBoard refreshes fog overlays when the pulse phase changes", () => {
 
   const harness = createMapBoardHarness({ width: 220, height: 120, tileSize: 48 });
   harness.render(update);
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
   const capturedStyles = harness.captureFogStyles("0-0");
   assert.equal(capturedStyles.length, 0);
@@ -185,7 +188,10 @@ test("VeilMapBoard refreshes fog overlays when the pulse phase changes", () => {
   assert.equal(capturedStyles.length, 1);
   assert.equal(capturedStyles[0]?.fogState, "explored");
   assert.equal(capturedStyles[0]?.featherMask, 2);
-  assert.match(String(capturedStyles[0]?.frameKey ?? ""), /placeholder\/fog\/explored-2/);
+  const overlayState = harness.fogOverlayState("0-0");
+  assert.equal(overlayState?.active, true);
+  assert.equal(overlayState?.opacity, 255);
+  assert.match(String(overlayState?.frameName ?? ""), /placeholder\/fog\/explored-2/);
   harness.destroy();
 });
 

--- a/apps/cocos-client/test/helpers/cocos-map-board-harness.ts
+++ b/apps/cocos-client/test/helpers/cocos-map-board-harness.ts
@@ -1,4 +1,4 @@
-import { Node, view } from "cc";
+import { Node, Sprite, UIOpacity, view } from "cc";
 import { VeilMapBoard } from "../../assets/scripts/VeilMapBoard.ts";
 import type { PlayerTileView, SessionUpdate, Vec2 } from "../../assets/scripts/VeilCocosSession.ts";
 import { createComponentHarness } from "./cocos-panel-harness.ts";
@@ -92,6 +92,19 @@ export function createMapBoardHarness(options: CreateMapBoardHarnessOptions) {
         originalRender(style, enabled);
       };
       return captured;
+    },
+    fogOverlayState(key: string): { active: boolean; frameName: string | null; opacity: number | null } | null {
+      const tileNode = state().tileNodes.get(key);
+      const fogOverlayNode = tileNode?.fogOverlay.node ?? null;
+      if (!fogOverlayNode) {
+        return null;
+      }
+
+      return {
+        active: fogOverlayNode.active,
+        frameName: fogOverlayNode.getComponent(Sprite)?.spriteFrame?.name ?? null,
+        opacity: fogOverlayNode.getComponent(UIOpacity)?.opacity ?? null
+      };
     },
     tapTile(update: SessionUpdate, position: Vec2, eventType = Node.EventType.TOUCH_END): void {
       const overlay = state().inputOverlayNode ?? node;


### PR DESCRIPTION
## Summary
- align the root-suite asset manifest expectation with the promoted pixel terrain metadata
- make the authenticated Cocos account profile test assert the intended `/me` and global resource behavior without pinning incidental replay normalization details
- update the fog overlay test to match the current fog-style contract and include the missing `tutorial_step.payload.reason` field in `VeilRoot` analytics

## Root cause
The red tests were caused by expectation drift after recent schema and content changes: asset metadata was promoted to `production`, replay normalization gained default combat fields, fog overlays now render via `FogTileStyle`, and the tutorial analytics payload no longer matched the shared catalog sample.

## Validation
- `node --import tsx --test --test-name-pattern "assetManifestEntry returns entry for known asset path" apps/client/test/assets.test.ts`
- `node --import tsx --test --test-name-pattern "loadCocosPlayerAccountProfile uses /me for authenticated sessions and preserves the global vault" apps/cocos-client/test/cocos-lobby.test.ts`
- `node --import tsx --test --test-name-pattern "VeilMapBoard refreshes fog overlays when the pulse phase changes" apps/cocos-client/test/cocos-map-board.test.ts`
- `node --import tsx --test --test-name-pattern "VeilRoot emits shop, tutorial, quest, and experiment analytics once per session" apps/cocos-client/test/cocos-root-orchestration.test.ts`
- `node --import tsx --test apps/client/test/assets.test.ts apps/cocos-client/test/cocos-lobby.test.ts apps/cocos-client/test/cocos-map-board.test.ts apps/cocos-client/test/cocos-root-orchestration.test.ts`

Closes #1459.
