### PR TITLE
fix: enforce JSON payload size limits on leaderboard, seasons-admin, and admin-console routes

### DIFF
--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -672,11 +672,32 @@ function requireSupportRole(response: ServerResponse, request: IncomingMessage, 
   return role;
 }
 
-async function readJsonBody(request: IncomingMessage): Promise<unknown> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of request) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+const MAX_JSON_BODY_BYTES = 32 * 1024;
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
   }
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+  }
+
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > MAX_JSON_BODY_BYTES) {
+      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+    }
+    chunks.push(buffer);
+  }
+
   const raw = Buffer.concat(chunks).toString("utf8").trim();
   if (!raw) {
     return undefined;
@@ -888,6 +909,10 @@ export function registerAdminRoutes(
 
       sendJson(response, 200, { ok: true, resources: nextResources, syncedToRoom });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -936,6 +961,10 @@ export function registerAdminRoutes(
         syncedToRoom
       });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1017,6 +1046,10 @@ export function registerAdminRoutes(
       }
       sendJson(response, 200, { ok: true });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1051,6 +1084,10 @@ export function registerAdminRoutes(
       }
       sendJson(response, 200, { ok: true, account, disconnectedClients });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1079,6 +1116,10 @@ export function registerAdminRoutes(
       const account = await store.clearPlayerBan(playerId, input);
       sendJson(response, 200, { ok: true, account });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1157,6 +1198,10 @@ export function registerAdminRoutes(
 
       sendJson(response, 200, { ok: true, report, disconnectedClients });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1245,6 +1290,10 @@ export function registerAdminRoutes(
       });
       sendJson(response, 200, { ok: true, account: updatedAccount });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1330,6 +1379,10 @@ export function registerAdminRoutes(
         }
       });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1405,6 +1458,10 @@ export function registerAdminRoutes(
       });
       sendJson(response, 200, { ok: true, account: updatedAccount });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1446,6 +1503,10 @@ export function registerAdminRoutes(
       const guild = await guildService.hideGuild(guildId, `${role}:admin-console`, input.reason);
       sendJson(response, 200, { ok: true, guild });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1469,6 +1530,10 @@ export function registerAdminRoutes(
       const guild = await guildService.unhideGuild(guildId, `${role}:admin-console`, input.reason);
       sendJson(response, 200, { ok: true, guild });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;
@@ -1492,6 +1557,10 @@ export function registerAdminRoutes(
       await guildService.deleteGuildAsAdmin(guildId, `${role}:admin-console`, input.reason);
       sendJson(response, 200, { ok: true, guildId });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: String(error) });
+        return;
+      }
       if (error instanceof InvalidAdminJsonError) {
         sendInvalidJson(response);
         return;

--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -681,21 +681,37 @@ class PayloadTooLargeError extends Error {
   }
 }
 
+async function drainRequest(request: IncomingMessage): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ of request) {
+    // drain remaining chunks so the connection is not reset
+  }
+}
+
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
   if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    // Drain the stream before throwing so the connection is not reset
+    await drainRequest(request);
     throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
   }
 
   const chunks: Buffer[] = [];
   let totalBytes = 0;
+  let tooLarge = false;
   for await (const chunk of request) {
     const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
     totalBytes += buffer.byteLength;
     if (totalBytes > MAX_JSON_BODY_BYTES) {
-      throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
+      // Mark as too large but continue draining so the connection is not reset
+      tooLarge = true;
+    } else {
+      chunks.push(buffer);
     }
-    chunks.push(buffer);
+  }
+
+  if (tooLarge) {
+    throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
   }
 
   const raw = Buffer.concat(chunks).toString("utf8").trim();

--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -691,8 +691,10 @@ async function drainRequest(request: IncomingMessage): Promise<void> {
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
   if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
-    // Drain the stream before throwing so the connection is not reset
-    await drainRequest(request);
+    // Fail fast: reject immediately based on Content-Length alone.
+    // Drain in the background so the connection is not reset, but do NOT
+    // await it — that would keep the handler blocked (slow-loris risk).
+    void drainRequest(request).catch(() => {});
     throw new PayloadTooLargeError(MAX_JSON_BODY_BYTES);
   }
 

--- a/apps/server/src/admin-console.ts
+++ b/apps/server/src/admin-console.ts
@@ -910,7 +910,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, resources: nextResources, syncedToRoom });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -962,7 +962,7 @@ export function registerAdminRoutes(
       });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1047,7 +1047,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1085,7 +1085,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, account, disconnectedClients });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1117,7 +1117,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, account });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1199,7 +1199,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, report, disconnectedClients });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1291,7 +1291,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, account: updatedAccount });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1380,7 +1380,7 @@ export function registerAdminRoutes(
       });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1459,7 +1459,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, account: updatedAccount });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1504,7 +1504,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, guild });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1531,7 +1531,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, guild });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {
@@ -1558,7 +1558,7 @@ export function registerAdminRoutes(
       sendJson(response, 200, { ok: true, guildId });
     } catch (error) {
       if (error instanceof PayloadTooLargeError) {
-        sendJson(response, 413, { error: String(error) });
+        sendJson(response, 413, { error: (error as Error).message });
         return;
       }
       if (error instanceof InvalidAdminJsonError) {

--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -46,15 +46,41 @@ function readLimit(request: IncomingMessage, fallback = 100): number {
   return Math.min(100, Math.max(1, Math.floor(rawLimit)));
 }
 
+const MAX_JSON_BODY_BYTES = 32 * 1024;
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    request.resume();
+    return Promise.reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+  }
+
   return new Promise((resolve, reject) => {
-    let body = "";
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
     request.on("data", (chunk: Buffer) => {
-      body += chunk.toString();
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > MAX_JSON_BODY_BYTES) {
+        reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+        return;
+      }
+      chunks.push(buffer);
     });
     request.on("end", () => {
       try {
-        resolve(body ? JSON.parse(body) : {});
+        if (chunks.length === 0) {
+          resolve({});
+          return;
+        }
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
       } catch (error) {
         reject(error);
       }
@@ -261,6 +287,10 @@ export function registerLeaderboardRoutes(
         summary: closeSummary
       });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       sendJson(response, 500, { error: toErrorPayload(error) });
     }
   });

--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -57,12 +57,21 @@ class PayloadTooLargeError extends Error {
 
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
-  const initiallyTooLarge = Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES;
+
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    // Fail fast: reject immediately based on Content-Length alone.
+    // Resume the stream in the background to drain it without accumulating
+    // data, so the connection is not reset — but do NOT await it, as that
+    // would keep the handler blocked (slow-loris risk).
+    request.on("error", () => {});
+    request.resume();
+    return Promise.reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+  }
 
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalBytes = 0;
-    let tooLarge = initiallyTooLarge;
+    let tooLarge = false;
 
     request.on("data", (chunk: Buffer) => {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);

--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -57,23 +57,28 @@ class PayloadTooLargeError extends Error {
 
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
-  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
-    return Promise.reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
-  }
+  const initiallyTooLarge = Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES;
 
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalBytes = 0;
+    let tooLarge = initiallyTooLarge;
+
     request.on("data", (chunk: Buffer) => {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       totalBytes += buffer.byteLength;
-      if (totalBytes > MAX_JSON_BODY_BYTES) {
+      if (tooLarge || totalBytes > MAX_JSON_BODY_BYTES) {
+        // Mark as too large but continue draining so the connection is not reset
+        tooLarge = true;
+      } else {
+        chunks.push(buffer);
+      }
+    });
+    request.on("end", () => {
+      if (tooLarge) {
         reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
         return;
       }
-      chunks.push(buffer);
-    });
-    request.on("end", () => {
       try {
         if (chunks.length === 0) {
           resolve({});

--- a/apps/server/src/leaderboard.ts
+++ b/apps/server/src/leaderboard.ts
@@ -58,7 +58,6 @@ class PayloadTooLargeError extends Error {
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
   if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
-    request.resume();
     return Promise.reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
   }
 

--- a/apps/server/src/seasons.ts
+++ b/apps/server/src/seasons.ts
@@ -36,7 +36,6 @@ class PayloadTooLargeError extends Error {
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
   if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
-    request.resume();
     return Promise.reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
   }
 

--- a/apps/server/src/seasons.ts
+++ b/apps/server/src/seasons.ts
@@ -35,12 +35,21 @@ class PayloadTooLargeError extends Error {
 
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
-  const initiallyTooLarge = Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES;
+
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    // Fail fast: reject immediately based on Content-Length alone.
+    // Resume the stream in the background to drain it without accumulating
+    // data, so the connection is not reset — but do NOT await it, as that
+    // would keep the handler blocked (slow-loris risk).
+    request.on("error", () => {});
+    request.resume();
+    return Promise.reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+  }
 
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalBytes = 0;
-    let tooLarge = initiallyTooLarge;
+    let tooLarge = false;
 
     request.on("data", (chunk: Buffer) => {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);

--- a/apps/server/src/seasons.ts
+++ b/apps/server/src/seasons.ts
@@ -35,23 +35,28 @@ class PayloadTooLargeError extends Error {
 
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
   const declaredLength = Number(request.headers["content-length"]);
-  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
-    return Promise.reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
-  }
+  const initiallyTooLarge = Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES;
 
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     let totalBytes = 0;
+    let tooLarge = initiallyTooLarge;
+
     request.on("data", (chunk: Buffer) => {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       totalBytes += buffer.byteLength;
-      if (totalBytes > MAX_JSON_BODY_BYTES) {
+      if (tooLarge || totalBytes > MAX_JSON_BODY_BYTES) {
+        // Mark as too large but continue draining so the connection is not reset
+        tooLarge = true;
+      } else {
+        chunks.push(buffer);
+      }
+    });
+    request.on("end", () => {
+      if (tooLarge) {
         reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
         return;
       }
-      chunks.push(buffer);
-    });
-    request.on("end", () => {
       try {
         if (chunks.length === 0) {
           resolve({});

--- a/apps/server/src/seasons.ts
+++ b/apps/server/src/seasons.ts
@@ -24,15 +24,41 @@ function isAdminAuthorized(request: IncomingMessage): boolean {
   return headerToken === adminToken;
 }
 
+const MAX_JSON_BODY_BYTES = 32 * 1024;
+
+class PayloadTooLargeError extends Error {
+  constructor(maxBytes: number) {
+    super(`Request body exceeds ${maxBytes} bytes`);
+    this.name = "payload_too_large";
+  }
+}
+
 function readJsonBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers["content-length"]);
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BODY_BYTES) {
+    request.resume();
+    return Promise.reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+  }
+
   return new Promise((resolve, reject) => {
-    let body = "";
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
     request.on("data", (chunk: Buffer) => {
-      body += chunk.toString();
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > MAX_JSON_BODY_BYTES) {
+        reject(new PayloadTooLargeError(MAX_JSON_BODY_BYTES));
+        return;
+      }
+      chunks.push(buffer);
     });
     request.on("end", () => {
       try {
-        resolve(body ? JSON.parse(body) : {});
+        if (chunks.length === 0) {
+          resolve({});
+          return;
+        }
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
       } catch (error) {
         reject(error);
       }
@@ -171,6 +197,10 @@ export function registerSeasonRoutes(
       const season = await store.createSeason(seasonId || `season_${Date.now()}`);
       sendJson(response, 201, { season });
     } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, { error: toErrorPayload(error) });
+        return;
+      }
       if (error instanceof SyntaxError) {
         sendJson(response, 400, {
           error: {

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -2228,3 +2228,47 @@ test("support moderators can delete guilds without removing audit history", asyn
   assert.equal(audit[0]?.reason, "spam cleanup");
   assert.equal(audit[1]?.action, "created");
 });
+
+test("POST /api/admin/players/:id/resources returns 413 when content-length declares a 2 MB body", async (t) => {
+  const secret = withAdminSecret(t);
+  const { posts } = registerRoutes(null);
+  const handler = posts.get("/api/admin/players/:id/resources");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-413" },
+      headers: {
+        "x-veil-admin-secret": secret,
+        "content-length": String(2 * 1024 * 1024)
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error, `Request body exceeds ${32 * 1024} bytes`);
+});
+
+test("POST /api/admin/players/:id/resources returns 413 when streamed body exceeds 32 KB", async (t) => {
+  const secret = withAdminSecret(t);
+  const { posts } = registerRoutes(null);
+  const handler = posts.get("/api/admin/players/:id/resources");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      params: { id: "player-413-stream" },
+      headers: { "x-veil-admin-secret": secret },
+      body: "x".repeat(33 * 1024)
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error, `Request body exceeds ${32 * 1024} bytes`);
+});

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test, { type TestContext } from "node:test";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import { normalizeGuildState, type GuildState } from "../../../packages/shared/src/index";
 import { registerAdminRoutes } from "../src/admin-console";
 import { getActiveRoomInstances } from "../src/colyseus-room";
@@ -1042,7 +1044,8 @@ test("GET /api/admin/players/:id/purchase-history returns filtered purchase audi
 });
 
 test("admin console html includes compensation form and history table", async () => {
-  const html = await readFile("/home/gpt/project/ProjectVeil/apps/client/admin.html", "utf8");
+  const adminHtmlPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../client/admin.html");
+  const html = await readFile(adminHtmlPath, "utf8");
   assert.match(html, /玩家补偿 \/ 退款/);
   assert.match(html, /compensationHistoryBody/);
   assert.match(html, /submitCompensation/);

--- a/apps/server/test/admin-console.test.ts
+++ b/apps/server/test/admin-console.test.ts
@@ -2275,3 +2275,33 @@ test("POST /api/admin/players/:id/resources returns 413 when streamed body excee
   assert.equal(response.statusCode, 413);
   assert.equal(JSON.parse(response.body).error, `Request body exceeds ${32 * 1024} bytes`);
 });
+
+test("POST /api/admin/players/:id/resources returns 413 immediately when content-length is oversized without waiting for body stream to end", async (t) => {
+  const secret = withAdminSecret(t);
+  const { posts } = registerRoutes(null);
+  const handler = posts.get("/api/admin/players/:id/resources");
+  const response = createResponse();
+
+  assert.ok(handler);
+
+  // Create an async iterable that never ends — simulates a slow-loris upload.
+  // The handler must return 413 before the stream finishes.
+  async function* neverEndingBody() {
+    await new Promise<void>(() => {}); // hangs forever, never yields
+  }
+
+  const request = neverEndingBody() as unknown as IncomingMessage & { params: Record<string, string> };
+  Object.assign(request, {
+    method: "POST",
+    headers: {
+      "x-veil-admin-secret": secret,
+      "content-length": String(2 * 1024 * 1024)
+    },
+    params: { id: "player-413-fast" }
+  });
+
+  await handler(request, response);
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error, `Request body exceeds ${32 * 1024} bytes`);
+});

--- a/apps/server/test/leaderboard-routes.test.ts
+++ b/apps/server/test/leaderboard-routes.test.ts
@@ -44,7 +44,8 @@ function createRequest(options: {
   Object.assign(request, {
     method: options.method ?? "GET",
     headers: options.headers ?? {},
-    url: options.url ?? "/"
+    url: options.url ?? "/",
+    resume() {}
   });
   queueMicrotask(() => {
     if (options.body !== undefined) {
@@ -733,6 +734,34 @@ test("POST /api/admin/leaderboard/season-rollover returns 413 when streamed body
   queueMicrotask(() => {
     request.emit("data", Buffer.alloc(33 * 1024, "x"));
     request.emit("end");
+  });
+
+  await handler(request, response);
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error.code, "payload_too_large");
+});
+
+test("POST /api/admin/leaderboard/season-rollover returns 413 immediately when content-length is oversized without waiting for body stream to end", async (t) => {
+  const token = withAdminToken(t);
+  const { posts, store } = registerRoutes();
+  const handler = posts.get("/api/admin/leaderboard/season-rollover");
+  await store.createSeason("season-413-fast");
+
+  assert.ok(handler);
+  const response = createResponse();
+
+  // Build a stream that never emits "end" — simulates a slow-loris upload.
+  // The handler must return 413 before the stream finishes.
+  const request = new EventEmitter() as IncomingMessage & EventEmitter;
+  Object.assign(request, {
+    method: "POST",
+    headers: {
+      "x-veil-admin-token": token,
+      "content-length": String(2 * 1024 * 1024)
+    },
+    url: "/api/admin/leaderboard/season-rollover",
+    resume() {}
   });
 
   await handler(request, response);

--- a/apps/server/test/leaderboard-routes.test.ts
+++ b/apps/server/test/leaderboard-routes.test.ts
@@ -691,3 +691,52 @@ test("leaderboard routes load tier thresholds from config-center at initializati
     ]
   });
 });
+
+test("POST /api/admin/leaderboard/season-rollover returns 413 when content-length declares a 2 MB body", async (t) => {
+  const token = withAdminToken(t);
+  const { posts, store } = registerRoutes();
+  const handler = posts.get("/api/admin/leaderboard/season-rollover");
+  await store.createSeason("season-413");
+
+  assert.ok(handler);
+  const response = createResponse();
+  await handler(
+    createRequest({
+      method: "POST",
+      url: "/api/admin/leaderboard/season-rollover",
+      headers: {
+        "x-veil-admin-token": token,
+        "content-length": String(2 * 1024 * 1024)
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error.code, "payload_too_large");
+});
+
+test("POST /api/admin/leaderboard/season-rollover returns 413 when streamed body exceeds 32 KB", async (t) => {
+  const token = withAdminToken(t);
+  const { posts, store } = registerRoutes();
+  const handler = posts.get("/api/admin/leaderboard/season-rollover");
+  await store.createSeason("season-413-stream");
+
+  assert.ok(handler);
+  const response = createResponse();
+  const request = new EventEmitter() as IncomingMessage & EventEmitter;
+  Object.assign(request, {
+    method: "POST",
+    headers: { "x-veil-admin-token": token },
+    url: "/api/admin/leaderboard/season-rollover"
+  });
+  queueMicrotask(() => {
+    request.emit("data", Buffer.alloc(33 * 1024, "x"));
+    request.emit("end");
+  });
+
+  await handler(request, response);
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error.code, "payload_too_large");
+});

--- a/apps/server/test/season-routes.test.ts
+++ b/apps/server/test/season-routes.test.ts
@@ -325,3 +325,52 @@ test("POST /api/admin/seasons/create returns 400 for malformed JSON", async (t) 
     }
   });
 });
+
+test("POST /api/admin/seasons/create returns 413 when content-length declares a 2 MB body", async (t) => {
+  const token = withAdminToken(t);
+  const store = createSeasonStore([], []);
+  const { posts } = registerRoutes(store);
+  const handler = posts.get("/api/admin/seasons/create");
+  const response = createResponse();
+
+  assert.ok(handler);
+  await handler(
+    createRequest({
+      method: "POST",
+      url: "/api/admin/seasons/create",
+      headers: {
+        "x-veil-admin-token": token,
+        "content-length": String(2 * 1024 * 1024)
+      }
+    }),
+    response
+  );
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error.code, "payload_too_large");
+});
+
+test("POST /api/admin/seasons/create returns 413 when streamed body exceeds 32 KB", async (t) => {
+  const token = withAdminToken(t);
+  const store = createSeasonStore([], []);
+  const { posts } = registerRoutes(store);
+  const handler = posts.get("/api/admin/seasons/create");
+  const response = createResponse();
+
+  assert.ok(handler);
+  const request = new EventEmitter() as IncomingMessage & EventEmitter;
+  Object.assign(request, {
+    method: "POST",
+    headers: { "x-veil-admin-token": token },
+    url: "/api/admin/seasons/create"
+  });
+  queueMicrotask(() => {
+    request.emit("data", Buffer.alloc(33 * 1024, "x"));
+    request.emit("end");
+  });
+
+  await handler(request, response);
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error.code, "payload_too_large");
+});

--- a/apps/server/test/season-routes.test.ts
+++ b/apps/server/test/season-routes.test.ts
@@ -36,7 +36,8 @@ function createRequest(options: {
   Object.assign(request, {
     method: options.method ?? "GET",
     headers: options.headers ?? {},
-    url: options.url ?? "/"
+    url: options.url ?? "/",
+    resume() {}
   });
   queueMicrotask(() => {
     if (options.body !== undefined) {
@@ -367,6 +368,34 @@ test("POST /api/admin/seasons/create returns 413 when streamed body exceeds 32 K
   queueMicrotask(() => {
     request.emit("data", Buffer.alloc(33 * 1024, "x"));
     request.emit("end");
+  });
+
+  await handler(request, response);
+
+  assert.equal(response.statusCode, 413);
+  assert.equal(JSON.parse(response.body).error.code, "payload_too_large");
+});
+
+test("POST /api/admin/seasons/create returns 413 immediately when content-length is oversized without waiting for body stream to end", async (t) => {
+  const token = withAdminToken(t);
+  const store = createSeasonStore([], []);
+  const { posts } = registerRoutes(store);
+  const handler = posts.get("/api/admin/seasons/create");
+  const response = createResponse();
+
+  assert.ok(handler);
+
+  // Build a stream that never emits "end" — simulates a slow-loris upload.
+  // The handler must return 413 before the stream finishes.
+  const request = new EventEmitter() as IncomingMessage & EventEmitter;
+  Object.assign(request, {
+    method: "POST",
+    headers: {
+      "x-veil-admin-token": token,
+      "content-length": String(2 * 1024 * 1024)
+    },
+    url: "/api/admin/seasons/create",
+    resume() {}
   });
 
   await handler(request, response);


### PR DESCRIPTION
## Summary

- Added `MAX_JSON_BODY_BYTES = 32 KB` guard to `readJsonBody()` in `leaderboard.ts`, `seasons.ts`, and `admin-console.ts`
- Both the `Content-Length` fast-path check and streaming byte-count check are implemented, mirroring the pattern already in `shop.ts`
- All `PayloadTooLargeError` rejections surface as HTTP 413 with `{ error: { code: "payload_too_large", ... } }` (or `{ error: String(error) }` in admin-console, consistent with its existing style)
- **Fail-fast on Content-Length (addresses slow-loris review finding):** when `Content-Length` alone proves the body oversized, 413 is returned immediately without waiting for the body stream to finish draining. Drain runs in the background (fire-and-forget) to avoid TCP resets, but the handler is no longer blocked on it.
  - `admin-console.ts`: changed `await drainRequest(request)` → `void drainRequest(request).catch(() => {})`
  - `leaderboard.ts` / `seasons.ts`: Content-Length check extracted before the Promise constructor; rejects immediately via `Promise.reject(...)` and calls `request.resume()` to drain in background

## Test plan

- [x] `POST /api/admin/leaderboard/season-rollover` with `Content-Length: 2097152` → 413
- [x] `POST /api/admin/leaderboard/season-rollover` with 33 KB streamed body → 413
- [x] `POST /api/admin/leaderboard/season-rollover` with oversized `Content-Length` and stream that never ends → 413 without hanging (fail-fast test)
- [x] `POST /api/admin/seasons/create` with `Content-Length: 2097152` → 413
- [x] `POST /api/admin/seasons/create` with 33 KB streamed body → 413
- [x] `POST /api/admin/seasons/create` with oversized `Content-Length` and stream that never ends → 413 without hanging (fail-fast test)
- [x] `POST /api/admin/players/:id/resources` with `Content-Length: 2097152` → 413
- [x] `POST /api/admin/players/:id/resources` with 33 KB streamed body → 413
- [x] `POST /api/admin/players/:id/resources` with oversized `Content-Length` and stream that never ends → 413 without hanging (fail-fast test)
- [ ] Typecheck: no new errors introduced (`@aws-sdk/client-secrets-manager` error is pre-existing)

Closes #1409

🤖 Generated with [Claude Code](https://claude.com/claude-code)