### PR TITLE
fix: attribute mission_complete analytics to mission mapId not stale lastRoomId (by claude)

### DIFF
--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -2056,6 +2056,15 @@ export function registerPlayerAccountRoutes(
         });
         return;
       }
+      if (mission.status === "completed") {
+        sendJson(response, 409, {
+          error: {
+            code: "campaign_mission_already_completed",
+            message: "Campaign mission has already been completed"
+          }
+        });
+        return;
+      }
       if (mission.status === "locked") {
         sendJson(response, 403, {
           error: {
@@ -2114,6 +2123,15 @@ export function registerPlayerAccountRoutes(
         globalResources: rewardMutation.globalResources
       });
       const accessContext = await loadCampaignAccessContext(store, nextAccount);
+      emitAnalyticsEvent("mission_complete", {
+        playerId: account.playerId,
+        roomId: result.mission.mapId,
+        payload: {
+          campaignId: result.mission.chapterId,
+          missionId: result.mission.id,
+          reward: result.reward
+        }
+      });
 
       sendJson(response, 200, {
         completed: true,

--- a/apps/server/test/player-account-routes.test.ts
+++ b/apps/server/test/player-account-routes.test.ts
@@ -4415,7 +4415,7 @@ test("campaign mission completion unlocks the next chapter 1 mission and grants 
   };
 
   assert.equal(initialResponse.status, 200);
-  assert.equal(initialPayload.campaign.totalMissions, 27);
+  assert.equal(initialPayload.campaign.totalMissions, 41);
   assert.equal(initialPayload.campaign.nextMissionId, "chapter1-ember-watch");
   assert.equal(initialPayload.campaign.missions[0]?.status, "available");
   assert.equal(initialPayload.campaign.missions[1]?.status, "locked");
@@ -4548,6 +4548,59 @@ test("campaign mission start returns 403 unlock requirements until chapter gates
   assert.equal(unlockedPayload.started, true);
   assert.equal(unlockedPayload.mission.id, "chapter4-basin-breach");
   assert.equal(unlockedPayload.mission.chapterId, "chapter4");
+});
+
+test("completed campaign mission returns 409 for both restart and re-completion attempts", async (t) => {
+  const port = 44992 + Math.floor(Math.random() * 100);
+  const store = new MemoryPlayerAccountStore();
+  store.seedAccount({
+    playerId: "completed-mission-player",
+    displayName: "Campaign Finisher",
+    rankDivision: "unranked",
+    gems: 0,
+    globalResources: { gold: 0, wood: 0, ore: 0 },
+    achievements: [],
+    recentEventLog: [],
+    recentBattleReplays: [],
+    campaignProgress: {
+      missions: [{ missionId: "chapter1-ember-watch", attempts: 1, completedAt: "2026-04-01T00:00:00.000Z" }]
+    },
+    tutorialStep: DEFAULT_TUTORIAL_STEP,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString()
+  });
+  const server = await startAccountRouteServer(port, store);
+  const session = issueAccountAuthSession({
+    playerId: "completed-mission-player",
+    displayName: "Campaign Finisher",
+    loginId: "completed-mission-player"
+  });
+
+  t.after(async () => {
+    await server.gracefullyShutdown(false).catch(() => undefined);
+  });
+
+  const restartResponse = await fetch(
+    `http://127.0.0.1:${port}/api/campaigns/chapter1/missions/chapter1-ember-watch/start`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${session.token}` }
+    }
+  );
+  const restartPayload = (await restartResponse.json()) as { error: { code: string } };
+  assert.equal(restartResponse.status, 409);
+  assert.equal(restartPayload.error.code, "campaign_mission_already_completed");
+
+  const reCompleteResponse = await fetch(
+    `http://127.0.0.1:${port}/api/player-accounts/me/campaign/chapter1-ember-watch/complete`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${session.token}` }
+    }
+  );
+  const reCompletePayload = (await reCompleteResponse.json()) as { error: { code: string } };
+  assert.equal(reCompleteResponse.status, 409);
+  assert.equal(reCompletePayload.error.code, "campaign_mission_already_completed");
 });
 
 test("daily dungeon attempts are capped per day and rewards can only be claimed once per run", async (t) => {

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -1,3 +1,5 @@
+import type { CampaignReward } from "./models";
+
 export const ANALYTICS_SCHEMA_VERSION = 1 as const;
 
 interface AnalyticsEventDefinition<Name extends string, Payload extends Record<string, unknown>> {
@@ -62,6 +64,21 @@ export const ANALYTICS_EVENT_CATALOG = {
       rewardId: "bridge-relief-fund",
       rewardKind: "gems",
       pointsRequired: 120
+    }
+  ),
+  mission_complete: defineAnalyticsEvent<"mission_complete", { campaignId: string; missionId: string; reward: CampaignReward }>(
+    "mission_complete",
+    1,
+    "Campaign mission completed and rewards settled for the player.",
+    {
+      campaignId: "chapter1",
+      missionId: "chapter1-ember-watch",
+      reward: {
+        gems: 12,
+        resources: {
+          gold: 140
+        }
+      }
     }
   ),
   daily_login: defineAnalyticsEvent("daily_login", 1, "Daily first-login reward was issued to the player.", {

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -52,7 +52,8 @@ const DAILY_QUEST_SMOKE_ROTATIONS = JSON.stringify({
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  testMatch: /(daily-quest-claim|lobby-smoke|onboarding-funnel|reconnect-prediction-convergence|seasonal-event-lifecycle)\.spec\.ts/,
+  testMatch:
+    /(campaign-mission-flow|daily-quest-claim|lobby-smoke|onboarding-funnel|reconnect-prediction-convergence|seasonal-event-lifecycle)\.spec\.ts/,
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
   fullyParallel: false,

--- a/tests/e2e/campaign-mission-flow.spec.ts
+++ b/tests/e2e/campaign-mission-flow.spec.ts
@@ -1,0 +1,287 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+import { pollForAnalyticsEvent } from "./analytics-helpers";
+
+const SERVER_BASE_URL = "http://127.0.0.1:2567";
+const FIRST_MISSION_ID = "chapter1-ember-watch";
+const FIRST_MISSION_MAP_ID = "amber-fields";
+const FIRST_CHAPTER_ID = "chapter1";
+const CHAPTER_TWO_FIRST_MISSION_ID = "chapter2-highland-muster";
+const CHAPTER_ONE_MISSION_IDS = [
+  "chapter1-ember-watch",
+  "chapter1-thornwall-road",
+  "chapter1-stonewatch",
+  "chapter1-ridgeway",
+  "chapter1-ironpass",
+  "chapter1-defend-bridge"
+] as const;
+
+interface GuestLoginPayload {
+  session?: {
+    token?: string;
+  };
+}
+
+interface PlayerProfilePayload {
+  account?: {
+    gems?: number;
+    globalResources?: {
+      gold?: number;
+      wood?: number;
+      ore?: number;
+    };
+  };
+  session?: {
+    token?: string;
+  };
+}
+
+interface CampaignMissionPayload {
+  id: string;
+  chapterId: string;
+  name?: string;
+  status?: string;
+  introDialogue?: Array<{ id?: string; text?: string }>;
+  objectives?: Array<{ id?: string; description?: string }>;
+  unlockRequirements?: Array<{
+    type?: string;
+    missionId?: string;
+    satisfied?: boolean;
+  }>;
+}
+
+interface CampaignSummaryPayload {
+  campaign?: {
+    completedCount?: number;
+    totalMissions?: number;
+    nextMissionId?: string | null;
+    missions?: CampaignMissionPayload[];
+  };
+}
+
+interface CampaignMissionDetailPayload {
+  mission?: CampaignMissionPayload;
+}
+
+interface CampaignMissionStartPayload {
+  started?: boolean;
+  mission?: CampaignMissionPayload;
+  error?: {
+    code?: string;
+  };
+}
+
+interface CampaignMissionCompletePayload {
+  completed?: boolean;
+  mission?: CampaignMissionPayload;
+  reward?: {
+    gems?: number;
+    resources?: {
+      gold?: number;
+      wood?: number;
+      ore?: number;
+    };
+  };
+  campaign?: {
+    completedCount?: number;
+    nextMissionId?: string | null;
+    missions?: CampaignMissionPayload[];
+  };
+  error?: {
+    code?: string;
+  };
+}
+
+function refreshAuthStateFromProfile(
+  payload: PlayerProfilePayload,
+  currentToken: string
+): { token: string; authHeaders: Record<string, string> } {
+  const nextToken = payload.session?.token?.trim() || currentToken;
+  return {
+    token: nextToken,
+    authHeaders: buildAuthHeaders(nextToken)
+  };
+}
+
+function buildAuthHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`
+  };
+}
+
+async function createGuestSessionToken(request: APIRequestContext, playerId: string): Promise<string> {
+  const response = await request.post(`${SERVER_BASE_URL}/api/auth/guest-login`, {
+    data: {
+      playerId,
+      displayName: "Campaign Mission E2E",
+      privacyConsentAccepted: true
+    }
+  });
+  expect(response.status()).toBe(200);
+
+  const payload = (await response.json()) as GuestLoginPayload;
+  expect(payload.session?.token).toBeTruthy();
+  return payload.session?.token ?? "";
+}
+
+async function completeMission(request: APIRequestContext, token: string, missionId: string): Promise<CampaignMissionCompletePayload> {
+  const response = await request.post(`${SERVER_BASE_URL}/api/player-accounts/me/campaign/${missionId}/complete`, {
+    headers: buildAuthHeaders(token)
+  });
+  expect(response.status(), `expected ${missionId} completion to succeed`).toBe(200);
+  return (await response.json()) as CampaignMissionCompletePayload;
+}
+
+test.beforeEach(async ({ request }) => {
+  const response = await request.post(`${SERVER_BASE_URL}/api/test/reset-store`);
+  expect(response.ok()).toBeTruthy();
+});
+
+test("campaign mission smoke covers mission start, reward settlement, unlock progression, and completed replay guards", async ({
+  request
+}) => {
+  const playerId = `campaign-mission-e2e-${Date.now()}`;
+  let token = await createGuestSessionToken(request, playerId);
+  let authHeaders = buildAuthHeaders(token);
+
+  let gemsBeforeCompletion = 0;
+  let goldBeforeCompletion = 0;
+
+  await test.step("api: campaign summary exposes chapter 1 start and chapter 2 remains locked", async () => {
+    const profileResponse = await request.get(`${SERVER_BASE_URL}/api/player-accounts/me`, {
+      headers: authHeaders
+    });
+    expect(profileResponse.ok()).toBeTruthy();
+    const profilePayload = (await profileResponse.json()) as PlayerProfilePayload;
+    ({ token, authHeaders } = refreshAuthStateFromProfile(profilePayload, token));
+    gemsBeforeCompletion = profilePayload.account?.gems ?? 0;
+    goldBeforeCompletion = profilePayload.account?.globalResources?.gold ?? 0;
+
+    const summaryResponse = await request.get(`${SERVER_BASE_URL}/api/player-accounts/me/campaign`, {
+      headers: authHeaders
+    });
+    expect(summaryResponse.status()).toBe(200);
+
+    const summaryPayload = (await summaryResponse.json()) as CampaignSummaryPayload;
+    expect(summaryPayload.campaign?.totalMissions).toBeGreaterThanOrEqual(27);
+    expect(summaryPayload.campaign?.nextMissionId).toBe(FIRST_MISSION_ID);
+    expect(summaryPayload.campaign?.missions?.find((mission) => mission.id === FIRST_MISSION_ID)?.status).toBe("available");
+    expect(summaryPayload.campaign?.missions?.find((mission) => mission.id === CHAPTER_TWO_FIRST_MISSION_ID)?.status).toBe("locked");
+    expect(
+      summaryPayload.campaign?.missions
+        ?.find((mission) => mission.id === CHAPTER_TWO_FIRST_MISSION_ID)
+        ?.unlockRequirements?.some(
+          (requirement) => requirement.type === "mission_complete" && requirement.missionId === "chapter1-defend-bridge"
+        )
+    ).toBe(true);
+  });
+
+  await test.step("api: mission detail exposes dialogue and objective content for the first chapter 1 mission", async () => {
+    const detailResponse = await request.get(`${SERVER_BASE_URL}/api/campaigns/missions/${FIRST_MISSION_ID}`, {
+      headers: authHeaders
+    });
+    expect(detailResponse.status()).toBe(200);
+
+    const detailPayload = (await detailResponse.json()) as CampaignMissionDetailPayload;
+    expect(detailPayload.mission?.id).toBe(FIRST_MISSION_ID);
+    expect(detailPayload.mission?.chapterId).toBe(FIRST_CHAPTER_ID);
+    expect(detailPayload.mission?.introDialogue?.length ?? 0).toBeGreaterThan(0);
+    expect(detailPayload.mission?.introDialogue?.[0]?.text).toBeTruthy();
+    expect(detailPayload.mission?.objectives?.length ?? 0).toBeGreaterThan(0);
+    expect(detailPayload.mission?.objectives?.[0]?.description).toBeTruthy();
+  });
+
+  await test.step("api: starting and completing the first mission settles rewards and advances campaign state", async () => {
+    const startResponse = await request.post(
+      `${SERVER_BASE_URL}/api/campaigns/${FIRST_CHAPTER_ID}/missions/${FIRST_MISSION_ID}/start`,
+      {
+        headers: authHeaders
+      }
+    );
+    expect(startResponse.status()).toBe(200);
+
+    const startPayload = (await startResponse.json()) as CampaignMissionStartPayload;
+    expect(startPayload.started).toBe(true);
+    expect(startPayload.mission?.id).toBe(FIRST_MISSION_ID);
+    expect(startPayload.mission?.status).toBe("available");
+
+    const completePayload = await completeMission(request, token, FIRST_MISSION_ID);
+    expect(completePayload.completed).toBe(true);
+    expect(completePayload.mission?.id).toBe(FIRST_MISSION_ID);
+    expect(completePayload.mission?.status).toBe("completed");
+    expect(completePayload.reward).toEqual({
+      gems: 12,
+      resources: {
+        gold: 140
+      }
+    });
+    expect(completePayload.campaign?.completedCount).toBe(1);
+    expect(completePayload.campaign?.nextMissionId).toBe("chapter1-thornwall-road");
+    expect(
+      completePayload.campaign?.missions?.find((mission) => mission.id === "chapter1-thornwall-road")?.status
+    ).toBe("available");
+
+    const profileAfterCompletionResponse = await request.get(`${SERVER_BASE_URL}/api/player-accounts/me`, {
+      headers: authHeaders
+    });
+    expect(profileAfterCompletionResponse.ok()).toBeTruthy();
+    const profileAfterCompletion = (await profileAfterCompletionResponse.json()) as PlayerProfilePayload;
+    ({ token, authHeaders } = refreshAuthStateFromProfile(profileAfterCompletion, token));
+    expect(profileAfterCompletion.account?.gems).toBe(gemsBeforeCompletion + 12);
+    expect(profileAfterCompletion.account?.globalResources?.gold).toBe(goldBeforeCompletion + 140);
+
+    const missionCompleteEvent = await pollForAnalyticsEvent(
+      request,
+      "mission_complete",
+      (event) => event.payload.missionId === FIRST_MISSION_ID
+    );
+    expect(missionCompleteEvent.payload.campaignId).toBe(FIRST_CHAPTER_ID);
+    expect(missionCompleteEvent.payload.reward).toEqual({
+      gems: 12,
+      resources: {
+        gold: 140
+      }
+    });
+    // Verify attribution uses the mission's mapId, not the stale account.lastRoomId
+    expect(missionCompleteEvent.roomId).toBe(FIRST_MISSION_MAP_ID);
+  });
+
+  await test.step("api: completed missions reject both restart and re-completion attempts", async () => {
+    const repeatStartResponse = await request.post(
+      `${SERVER_BASE_URL}/api/campaigns/${FIRST_CHAPTER_ID}/missions/${FIRST_MISSION_ID}/start`,
+      {
+        headers: authHeaders
+      }
+    );
+    expect(repeatStartResponse.status()).toBe(409);
+    const repeatStartPayload = (await repeatStartResponse.json()) as CampaignMissionStartPayload;
+    expect(repeatStartPayload.error?.code).toBe("campaign_mission_already_completed");
+
+    const repeatCompleteResponse = await request.post(
+      `${SERVER_BASE_URL}/api/player-accounts/me/campaign/${FIRST_MISSION_ID}/complete`,
+      {
+        headers: authHeaders
+      }
+    );
+    expect(repeatCompleteResponse.status()).toBe(409);
+    const repeatCompletePayload = (await repeatCompleteResponse.json()) as CampaignMissionCompletePayload;
+    expect(repeatCompletePayload.error?.code).toBe("campaign_mission_already_completed");
+  });
+
+  await test.step("api: clearing the rest of chapter 1 unlocks chapter 2", async () => {
+    for (const missionId of CHAPTER_ONE_MISSION_IDS.slice(1)) {
+      await completeMission(request, token, missionId);
+    }
+
+    const chapterUnlockResponse = await request.get(`${SERVER_BASE_URL}/api/player-accounts/me/campaign`, {
+      headers: authHeaders
+    });
+    expect(chapterUnlockResponse.status()).toBe(200);
+
+    const chapterUnlockPayload = (await chapterUnlockResponse.json()) as CampaignSummaryPayload;
+    expect(chapterUnlockPayload.campaign?.completedCount).toBe(CHAPTER_ONE_MISSION_IDS.length);
+    expect(chapterUnlockPayload.campaign?.nextMissionId).toBe(CHAPTER_TWO_FIRST_MISSION_ID);
+    expect(
+      chapterUnlockPayload.campaign?.missions?.find((mission) => mission.id === CHAPTER_TWO_FIRST_MISSION_ID)?.status
+    ).toBe("available");
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `mission_complete` analytics event (added in PR #1452) used `account.lastRoomId ?? result.mission.mapId` as the event envelope `roomId`, meaning if a player had a prior PvP room in their account, campaign mission completions would be attributed to that stale room ID instead of the actual mission map
- **Fix**: Use `result.mission.mapId` directly — the correct context for a campaign mission completion
- Also adds the 409 guard on the `/campaigns/:campaignId/missions/:missionId/start` endpoint when a mission is already completed (required by the E2E smoke test)
- Defines the `mission_complete` analytics event type in the shared catalog

## Changes

- `packages/shared/src/analytics-events.ts` — adds `mission_complete` catalog entry with correct `CampaignReward` payload type
- `apps/server/src/player-accounts.ts` — emits `mission_complete` event with `roomId: result.mission.mapId`; adds 409 guard for completed-mission restart attempts
- `apps/server/test/player-account-routes.test.ts` — adds unit test for 409 on restart/re-complete; fixes stale `totalMissions` assertion (27→41 after chapter expansion)
- `tests/e2e/campaign-mission-flow.spec.ts` — new Playwright smoke spec asserting correct `roomId` attribution in the analytics event
- `playwright.smoke.config.ts` — includes `campaign-mission-flow` in smoke test suite

## Test plan

- [x] `node --import tsx --test --test-name-pattern="campaign mission" apps/server/test/player-account-routes.test.ts` — 3 tests pass
- [x] `node --import tsx --test apps/server/test/pve-content.test.ts` — 7 tests pass
- [x] `node --import tsx --test apps/server/test/analytics.test.ts` — 3 tests pass
- [ ] E2E smoke: `npx playwright test tests/e2e/campaign-mission-flow.spec.ts --config=playwright.smoke.config.ts` (requires running dev server)

## Relationship to #1452

PR #1452 (branch `codex/issue-1425-campaign-mission-smoke-0413-1350`) introduced the analytics event with the `lastRoomId` misattribution bug. This PR fixes that bug from a clean `main` base, incorporating the same 409 guard and E2E test coverage but with the `roomId` correctly set to `result.mission.mapId`.

Closes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)