### PR TITLE
feat: productize first battle settlement

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilBattleTransition.ts
+++ b/apps/cocos-client/assets/scripts/VeilBattleTransition.ts
@@ -11,6 +11,7 @@ const BADGE_NODE_NAME = "ProjectVeilBattleOverlayBadge";
 const TERRAIN_NODE_NAME = "ProjectVeilBattleOverlayTerrain";
 const TITLE_NODE_NAME = "ProjectVeilBattleOverlayTitle";
 const SUBTITLE_NODE_NAME = "ProjectVeilBattleOverlaySubtitle";
+const SUMMARY_NODE_NAME = "ProjectVeilBattleOverlaySummary";
 const CHIP_CONTAINER_NODE_NAME = "ProjectVeilBattleOverlayChips";
 const CHIP_NODE_PREFIX = "ProjectVeilBattleOverlayChip";
 const H_ALIGN_LEFT = 0;
@@ -36,6 +37,7 @@ export class VeilBattleTransition extends Component {
   private terrainOpacity: UIOpacity | null = null;
   private titleLabel: Label | null = null;
   private subtitleLabel: Label | null = null;
+  private summaryLabel: Label | null = null;
   private sequenceToken = 0;
 
   onLoad(): void {
@@ -53,6 +55,7 @@ export class VeilBattleTransition extends Component {
         subtitle: "切入战斗场景",
         tone: "enter",
         terrain: null,
+        summaryLines: [],
         detailChips: []
       },
       this.enterDuration
@@ -67,6 +70,7 @@ export class VeilBattleTransition extends Component {
         subtitle: "返回世界地图",
         tone: "victory",
         terrain: null,
+        summaryLines: [],
         detailChips: []
       },
       this.exitDuration
@@ -83,7 +87,8 @@ export class VeilBattleTransition extends Component {
       !this.terrainSprite ||
       !this.terrainOpacity ||
       !this.titleLabel ||
-      !this.subtitleLabel
+      !this.subtitleLabel ||
+      !this.summaryLabel
     ) {
       return;
     }
@@ -99,6 +104,7 @@ export class VeilBattleTransition extends Component {
     this.badgeLabel.string = copy.badge;
     this.titleLabel.string = copy.title;
     this.subtitleLabel.string = copy.subtitle;
+    this.syncSummaryLines(copy);
     this.syncTerrainPreview(copy);
     this.syncDetailChips(copy);
 
@@ -136,7 +142,8 @@ export class VeilBattleTransition extends Component {
       this.terrainSprite &&
       this.terrainOpacity &&
       this.titleLabel &&
-      this.subtitleLabel
+      this.subtitleLabel &&
+      this.summaryLabel
     ) {
       return;
     }
@@ -183,6 +190,21 @@ export class VeilBattleTransition extends Component {
       V_ALIGN_TOP
     );
     subtitleLabel.node.setPosition(0, -46, 1);
+    const summaryLabel = this.ensureLabelNode(
+      panelNode,
+      SUMMARY_NODE_NAME,
+      10,
+      12,
+      panelTransform.width - 52,
+      42,
+      0,
+      -68,
+      V_ALIGN_TOP
+    );
+    summaryLabel.horizontalAlign = H_ALIGN_LEFT;
+    summaryLabel.verticalAlign = V_ALIGN_TOP;
+    summaryLabel.enableWrapText = true;
+    summaryLabel.node.setPosition(0, -72, 1);
 
     this.overlayNode = overlayNode;
     this.overlayOpacity = opacity;
@@ -194,12 +216,14 @@ export class VeilBattleTransition extends Component {
     this.terrainOpacity = terrainOpacity;
     this.titleLabel = titleLabel;
     this.subtitleLabel = subtitleLabel;
+    this.summaryLabel = summaryLabel;
     this.syncOverlayChrome({
       badge: "ENCOUNTER",
       title: "遭遇战",
       subtitle: "切入战斗场景",
       tone: "enter",
       terrain: null,
+      summaryLines: [],
       detailChips: []
     });
   }
@@ -248,7 +272,14 @@ export class VeilBattleTransition extends Component {
   }
 
   private syncTerrainPreview(copy: BattleTransitionCopy): void {
-    if (!this.panelNode || !this.terrainSprite || !this.terrainOpacity || !this.titleLabel || !this.subtitleLabel) {
+    if (
+      !this.panelNode ||
+      !this.terrainSprite ||
+      !this.terrainOpacity ||
+      !this.titleLabel ||
+      !this.subtitleLabel ||
+      !this.summaryLabel
+    ) {
       return;
     }
 
@@ -266,13 +297,27 @@ export class VeilBattleTransition extends Component {
     const panelTransform = this.panelNode.getComponent(UITransform) ?? this.panelNode.addComponent(UITransform);
     const titleTransform = this.titleLabel.node.getComponent(UITransform) ?? this.titleLabel.node.addComponent(UITransform);
     const subtitleTransform = this.subtitleLabel.node.getComponent(UITransform) ?? this.subtitleLabel.node.addComponent(UITransform);
+    const summaryTransform = this.summaryLabel.node.getComponent(UITransform) ?? this.summaryLabel.node.addComponent(UITransform);
     const hasTerrain = Boolean(terrainFrame);
     const hasChips = copy.detailChips.length > 0;
+    const hasSummary = copy.summaryLines.length > 0;
 
     titleTransform.setContentSize(hasTerrain ? panelTransform.width - 176 : panelTransform.width - 36, 54);
-    subtitleTransform.setContentSize(hasTerrain ? panelTransform.width - 192 : panelTransform.width - 52, hasChips ? 40 : 48);
+    subtitleTransform.setContentSize(hasTerrain ? panelTransform.width - 192 : panelTransform.width - 52, hasSummary ? 30 : hasChips ? 40 : 48);
     this.titleLabel.node.setPosition(hasTerrain ? 38 : 0, 8, 1);
-    this.subtitleLabel.node.setPosition(hasTerrain ? 42 : 0, hasChips ? -28 : -46, 1);
+    this.subtitleLabel.node.setPosition(hasTerrain ? 42 : 0, hasSummary ? -18 : hasChips ? -28 : -46, 1);
+    summaryTransform.setContentSize(hasTerrain ? panelTransform.width - 190 : panelTransform.width - 52, hasSummary ? 42 : 0);
+    this.summaryLabel.node.setPosition(hasTerrain ? 42 : 0, hasSummary ? -62 : -72, 1);
+  }
+
+  private syncSummaryLines(copy: BattleTransitionCopy): void {
+    if (!this.panelNode || !this.summaryLabel) {
+      return;
+    }
+
+    const summaryLines = copy.summaryLines.slice(0, 3);
+    this.summaryLabel.node.active = summaryLines.length > 0;
+    this.summaryLabel.string = summaryLines.join("\n");
   }
 
   private syncDetailChips(copy: BattleTransitionCopy): void {
@@ -288,13 +333,14 @@ export class VeilBattleTransition extends Component {
     assignUiLayer(container);
 
     const hasTerrain = copy.terrain !== null;
+    const hasSummary = copy.summaryLines.length > 0;
     const chips = copy.detailChips.slice(0, 3);
     container.active = chips.length > 0;
     const panelTransform = this.panelNode.getComponent(UITransform) ?? this.panelNode.addComponent(UITransform);
     const containerTransform = container.getComponent(UITransform) ?? container.addComponent(UITransform);
     const containerWidth = hasTerrain ? panelTransform.width - 190 : panelTransform.width - 46;
     containerTransform.setContentSize(containerWidth, 26);
-    container.setPosition(hasTerrain ? 42 : 0, -74, 1);
+    container.setPosition(hasTerrain ? 42 : 0, hasSummary ? -116 : -74, 1);
 
     const childNodes = (container as unknown as { children?: Node[] }).children ?? [];
     for (const child of [...childNodes]) {
@@ -367,7 +413,10 @@ export class VeilBattleTransition extends Component {
     const overlayTransform = this.overlayNode.getComponent(UITransform) ?? this.overlayNode.addComponent(UITransform);
     overlayTransform.setContentSize(visibleSize.width, visibleSize.height);
     const panelTransform = this.panelNode.getComponent(UITransform) ?? this.panelNode.addComponent(UITransform);
-    panelTransform.setContentSize(Math.min(440, visibleSize.width * 0.74), copy.detailChips.length > 0 ? 220 : 188);
+    panelTransform.setContentSize(
+      Math.min(440, visibleSize.width * 0.74),
+      copy.summaryLines.length > 0 ? 268 : copy.detailChips.length > 0 ? 220 : 188
+    );
 
     const accent =
       copy.tone === "victory"

--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -266,14 +266,18 @@ function buildBattleSettlementSummary(
 ): BattleSettlementSummary {
   const resolved = readBattleResolvedView(update);
   const rewards = collectSettlementRewardParts(update);
+  const didWin = didHeroWinResolution(resolved, heroId);
+  const resultStatus = describeSettlementResultState(previousBattle, didWin);
   const fieldStatus = describeSettlementFieldState(previousBattle, heroId, resolved);
   const encounterStatus = describeSettlementEncounterState(previousBattle, heroId, resolved);
-  const lines = [fieldStatus, ...rewards];
+  const handoffLabel = buildSettlementHandoffLabel(previousBattle, resolved, didWin);
+  const lines = [resultStatus, fieldStatus, ...rewards, handoffLabel];
   const detailParts = [
     encounterStatus,
+    resultStatus,
     fieldStatus,
     rewards.length > 0 ? rewards.join(" / ") : null,
-    buildSettlementHandoffLabel(previousBattle, resolved)
+    handoffLabel
   ].filter((part): part is string => Boolean(part));
 
   return {
@@ -423,13 +427,44 @@ function describeSettlementEncounterState(
 
 function buildSettlementHandoffLabel(
   previousBattle: BattleState | null,
-  resolved: BattleResolvedView | null
+  resolved: BattleResolvedView | null,
+  didWin: boolean | null
 ): string {
   if (previousBattle?.defenderHeroId) {
-    return resolved ? "房间胜负已确认，等待回写 PVP 世界态" : "等待房间确认胜负并回写 PVP 世界态";
+    if (didWin === true) {
+      return resolved ? "下一步：等待房间回写后返回世界地图" : "下一步：等待房间确认胜负并回写 PVP 世界态";
+    }
+    if (didWin === false) {
+      return resolved ? "下一步：等待房间回写后再调整对抗" : "下一步：等待房间确认胜负并回写 PVP 世界态";
+    }
+    return resolved ? "下一步：等待房间确认胜负并回写 PVP 世界态" : "下一步：等待房间确认胜负并回写 PVP 世界态";
   }
 
-  return resolved ? "奖励已确认，准备返回世界地图" : "等待世界地图确认奖励、占位与结算结果";
+  if (didWin === true) {
+    return resolved ? "下一步：返回世界地图继续推进当前回合" : "下一步：等待世界地图确认奖励、占位与结算结果";
+  }
+
+  if (didWin === false) {
+    return resolved ? "下一步：整顿部队后再尝试推进" : "下一步：等待世界地图确认奖励、占位与结算结果";
+  }
+
+  return resolved ? "下一步：返回世界地图确认奖励、占位与结算结果" : "下一步：等待世界地图确认奖励、占位与结算结果";
+}
+
+function describeSettlementResultState(previousBattle: BattleState | null, didWin: boolean | null): string {
+  if (!previousBattle) {
+    return "结果：未知";
+  }
+
+  if (didWin === true) {
+    return previousBattle.defenderHeroId ? "结果：PVP 胜利" : "结果：胜利";
+  }
+
+  if (didWin === false) {
+    return previousBattle.defenderHeroId ? "结果：PVP 失利" : "结果：失利";
+  }
+
+  return previousBattle.defenderHeroId ? "结果：PVP 结算回写中" : "结果：战果回写中";
 }
 
 function didHeroWinResolution(resolved: BattleResolvedView | null, heroId: string | null): boolean | null {

--- a/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-panel-model.ts
@@ -405,10 +405,23 @@ function buildBattlePresentationContextLines(
 function buildBattleResultContextLines(presentationState: CocosBattlePresentationState): string[] {
   const battleId = presentationState.battleId ? `会话：${presentationState.battleId} · ${presentationState.badge}` : null;
   return [
+    `结果：${resolveBattleResultLabel(presentationState)}`,
     `流程：${formatBattleJourneyLine(presentationState)}`,
     battleId,
     `下一步：${resolveBattleResultNextStepLine(presentationState)}`
   ].filter((line): line is string => Boolean(line));
+}
+
+function resolveBattleResultLabel(presentationState: CocosBattlePresentationState): string {
+  if (presentationState.result === "victory") {
+    return "胜利";
+  }
+
+  if (presentationState.result === "defeat") {
+    return "失利";
+  }
+
+  return "等待确认";
 }
 
 function formatBattleJourneyLine(presentationState: CocosBattlePresentationState | null): string {

--- a/apps/cocos-client/assets/scripts/cocos-battle-transition-copy.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-transition-copy.ts
@@ -7,6 +7,7 @@ export interface BattleTransitionCopy {
   subtitle: string;
   tone: "enter" | "victory" | "defeat";
   terrain: TerrainType | null;
+  summaryLines: string[];
   detailChips: BattleTransitionChip[];
 }
 
@@ -31,6 +32,7 @@ export function buildBattleEnterCopy(update: SessionUpdate): BattleTransitionCop
       subtitle: joinParts([terrainLabel, encounterPosition ? formatEncounterPosition(encounterPosition) : null, "切入战斗场景"]),
       tone: "enter",
       terrain,
+      summaryLines: [],
       detailChips: []
     };
   }
@@ -47,6 +49,7 @@ export function buildBattleEnterCopy(update: SessionUpdate): BattleTransitionCop
       ]),
       tone: "enter",
       terrain,
+      summaryLines: [],
       detailChips: [
         {
           icon: "hero",
@@ -70,6 +73,7 @@ export function buildBattleEnterCopy(update: SessionUpdate): BattleTransitionCop
     ]),
     tone: "enter",
     terrain,
+    summaryLines: [],
     detailChips: []
   };
 }
@@ -78,8 +82,9 @@ export function buildBattleExitCopy(previousBattle: SessionUpdate["battle"], upd
   const terrain = resolveBattleTerrainFromBattle(update, previousBattle);
   const encounterPosition = previousBattle?.encounterPosition ?? null;
   const terrainLabel = terrain ? formatBattleTerrainLabel(terrain) : null;
-  const detailChips = buildBattleExitDetailChips(update.events);
   const isPvp = Boolean(previousBattle?.defenderHeroId);
+  const summaryLines = buildBattleExitSummaryLines(previousBattle, update, didWin);
+  const detailChips = buildBattleExitDetailChips(previousBattle, update.events, didWin);
 
   if (!didWin) {
     return {
@@ -92,7 +97,8 @@ export function buildBattleExitCopy(previousBattle: SessionUpdate["battle"], upd
       ]),
       tone: "defeat",
       terrain,
-      detailChips: detailChips.slice(0, 3)
+      summaryLines,
+      detailChips
     };
   }
 
@@ -106,7 +112,8 @@ export function buildBattleExitCopy(previousBattle: SessionUpdate["battle"], upd
     ]),
     tone: "victory",
     terrain,
-    detailChips: detailChips.slice(0, 3)
+    summaryLines,
+    detailChips
   };
 }
 
@@ -138,7 +145,50 @@ function resolveBattleTerrainFromBattle(update: SessionUpdate, battle: SessionUp
   return resolveEncounterTerrain(update, battle.encounterPosition ?? null);
 }
 
-function buildBattleExitDetailChips(events: WorldEvent[]): BattleTransitionChip[] {
+function buildBattleExitSummaryLines(
+  previousBattle: SessionUpdate["battle"],
+  update: SessionUpdate,
+  didWin: boolean
+): string[] {
+  const isPvp = Boolean(previousBattle?.defenderHeroId);
+  const rewardSummary = buildBattleExitRewardSummary(update.events);
+  return [
+    isPvp ? `结果：${didWin ? "PVP 胜利" : "PVP 失利"}` : `结果：${didWin ? "胜利" : "失利"}`,
+    rewardSummary ? `奖励：${rewardSummary}` : "奖励：暂无额外掉落",
+    buildBattleExitNextStepLine(previousBattle, didWin)
+  ];
+}
+
+function buildBattleExitDetailChips(
+  previousBattle: SessionUpdate["battle"],
+  events: WorldEvent[],
+  didWin: boolean
+): BattleTransitionChip[] {
+  const rewardSummary = collectBattleExitRewardSummary(events);
+  const isPvp = Boolean(previousBattle?.defenderHeroId);
+  const chips: BattleTransitionChip[] = [
+    {
+      icon: "battle",
+      label: isPvp ? (didWin ? "PVP 胜利" : "PVP 失利") : didWin ? "胜利" : "失利"
+    }
+  ];
+
+  if (rewardSummary.label) {
+    chips.push({
+      icon: rewardSummary.icon,
+      label: rewardSummary.label
+    });
+  }
+
+  chips.push({
+    icon: "battle",
+    label: buildBattleExitNextStepChipLabel(previousBattle, didWin)
+  });
+
+  return chips.slice(0, 3);
+}
+
+function collectBattleExitRewardSummary(events: WorldEvent[]): { label: string; icon: BattleTransitionChip["icon"] } {
   const resourceTotals: Record<"gold" | "wood" | "ore", number> = {
     gold: 0,
     wood: 0,
@@ -165,55 +215,71 @@ function buildBattleExitDetailChips(events: WorldEvent[]): BattleTransitionChip[
     }
   }
 
-  const resourceChips = (["gold", "wood", "ore"] as const)
-    .filter((kind) => resourceTotals[kind] > 0)
-    .map((kind) => ({
-      icon: kind,
-      label: `${formatResourceKindLabel(kind)} +${resourceTotals[kind]}`
-    }));
-  const equipmentChip = featuredEquipment
-    ? {
-        icon: "battle" as const,
-        label: featuredEquipment.overflowed
-          ? `未拾取 ${trimChipLabel(featuredEquipment.equipmentName, 8)}`
-          : `${formatEquipmentRarityLabel(featuredEquipment.rarity)} ${trimChipLabel(featuredEquipment.equipmentName, 10)}`
-      }
-    : null;
-  const progressionChip = progressionSummary
-    ? {
-        icon: "hero" as const,
-        label:
-          progressionSummary.levelsGained > 0
-            ? `Lv ${progressionSummary.level}`
-            : `XP +${progressionSummary.experienceGained}`
-      }
-    : null;
-
-  const naturalOrder: BattleTransitionChip[] = [...resourceChips];
-  if (equipmentChip) {
-    naturalOrder.push(equipmentChip);
+  const rewardParts: string[] = [];
+  const resourceKinds = (["gold", "wood", "ore"] as const).filter((kind) => resourceTotals[kind] > 0);
+  rewardParts.push(...resourceKinds.map((kind) => `${formatResourceKindLabel(kind)} +${resourceTotals[kind]}`));
+  if (progressionSummary) {
+    rewardParts.push(
+      progressionSummary.levelsGained > 0
+        ? `Lv ${progressionSummary.level}`
+        : `XP +${progressionSummary.experienceGained}`
+    );
   }
-  if (progressionChip) {
-    naturalOrder.push(progressionChip);
-  }
-  if (naturalOrder.length <= 3) {
-    return naturalOrder;
+  if (featuredEquipment) {
+    rewardParts.push(
+      featuredEquipment.overflowed
+        ? `未拾取 ${trimChipLabel(featuredEquipment.equipmentName, 8)}`
+        : `${formatEquipmentRarityLabel(featuredEquipment.rarity)} ${trimChipLabel(featuredEquipment.equipmentName, 10)}`
+    );
   }
 
-  const prioritized: BattleTransitionChip[] = [];
-  if (equipmentChip) {
-    prioritized.push(equipmentChip);
+  return {
+    label: rewardParts.length > 0 ? rewardParts.join(" / ") : "",
+    icon: resolveBattleExitRewardIcon(resourceTotals, Boolean(progressionSummary), Boolean(featuredEquipment))
+  };
+}
+
+function buildBattleExitRewardSummary(events: WorldEvent[]): string {
+  return collectBattleExitRewardSummary(events).label;
+}
+
+function buildBattleExitNextStepLine(previousBattle: SessionUpdate["battle"], didWin: boolean): string {
+  if (previousBattle?.defenderHeroId) {
+    return didWin ? "下一步：等待房间回写后返回世界地图" : "下一步：等待房间回写后再调整对抗";
   }
-  if (progressionChip) {
-    prioritized.push(progressionChip);
+
+  return didWin ? "下一步：返回世界地图继续推进当前回合" : "下一步：整顿部队后再尝试推进";
+}
+
+function buildBattleExitNextStepChipLabel(previousBattle: SessionUpdate["battle"], didWin: boolean): string {
+  if (previousBattle?.defenderHeroId) {
+    return didWin ? "等待回写后返回世界地图" : "等待回写后再调整对抗";
   }
-  for (const chip of resourceChips) {
-    if (prioritized.length >= 3) {
-      break;
-    }
-    prioritized.push(chip);
+
+  return didWin ? "返回世界地图" : "整顿部队后再战";
+}
+
+function resolveBattleExitRewardIcon(
+  resourceTotals: Record<"gold" | "wood" | "ore", number>,
+  hasProgression: boolean,
+  hasEquipment: boolean
+): BattleTransitionChip["icon"] {
+  if (resourceTotals.gold > 0) {
+    return "gold";
   }
-  return prioritized.slice(0, 3);
+  if (resourceTotals.wood > 0) {
+    return "wood";
+  }
+  if (resourceTotals.ore > 0) {
+    return "ore";
+  }
+  if (hasProgression) {
+    return "hero";
+  }
+  if (hasEquipment) {
+    return "battle";
+  }
+  return "battle";
 }
 
 function mergeProgressionSummary(

--- a/apps/cocos-client/test/cocos-battle-panel-model.test.ts
+++ b/apps/cocos-client/test/cocos-battle-panel-model.test.ts
@@ -135,6 +135,7 @@ test("buildBattlePanelViewModel surfaces settlement and presentation layer summa
   assert.equal(view.title, "战斗结算");
   assert.deepEqual(view.summaryLines, [
     "战斗胜利",
+    "结果：胜利",
     "流程：进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 战果结算",
     "会话：battle-1 · WIN",
     "下一步：返回世界地图并继续推进当前回合",
@@ -182,9 +183,10 @@ test("buildBattlePanelViewModel keeps neutral settlement in the battle result sh
   assert.equal(view.idle, true);
   assert.equal(view.title, "战斗结算");
   assert.equal(view.summaryLines[0], "结果回写中");
-  assert.equal(view.summaryLines[1], "流程：进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 战果结算");
-  assert.equal(view.summaryLines[2], "会话：battle-1 · SETTLE");
-  assert.equal(view.summaryLines[3], "下一步：等待世界地图确认奖励、占位与最终结算");
+  assert.equal(view.summaryLines[1], "结果：等待确认");
+  assert.equal(view.summaryLines[2], "流程：进场确认 -> 指令下达 -> 受击反馈 -> 战果结算 · 当前 战果结算");
+  assert.equal(view.summaryLines[3], "会话：battle-1 · SETTLE");
+  assert.equal(view.summaryLines[4], "下一步：等待世界地图确认奖励、占位与最终结算");
 });
 
 test("buildBattlePanelViewModel shows an explicit settlement recovery path while reconnecting", () => {

--- a/apps/cocos-client/test/cocos-battle-presentation.test.ts
+++ b/apps/cocos-client/test/cocos-battle-presentation.test.ts
@@ -267,7 +267,7 @@ test("battle presentation plan formalizes command, enter, impact, and resolution
   assert.equal(resolutionPlan.transition?.copy.badge, "VICTORY");
   assert.deepEqual(resolutionPlan.state.summaryLines.slice(0, 2), [
     "反馈层：动画 胜利 / 音效 胜利 / 转场 结算",
-    "播报：PVE 遭遇已关闭 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 奖励已确认，准备返回世界地图"
+    "播报：PVE 遭遇已关闭 · 结果：胜利 · 战线：我方剩余 1 队 / 对方剩余 0 队 · 下一步：返回世界地图继续推进当前回合"
   ]);
 
   const unsettledResolutionPlan = buildBattlePresentationPlan(

--- a/apps/cocos-client/test/cocos-battle-transition-copy.test.ts
+++ b/apps/cocos-client/test/cocos-battle-transition-copy.test.ts
@@ -124,6 +124,7 @@ test("buildBattleEnterCopy distinguishes pve and pvp encounters", () => {
     subtitle: "荒地战场 · 目标 neutral-7 · 坐标 (5,4)",
     tone: "enter",
     terrain: "dirt",
+    summaryLines: [],
     detailChips: []
   });
 
@@ -147,6 +148,7 @@ test("buildBattleEnterCopy distinguishes pve and pvp encounters", () => {
     subtitle: "草野战场 · 坐标 (3,5) · room-alpha/battle-2 · 我方先手切入，多人对抗即将展开",
     tone: "enter",
     terrain: "grass",
+    summaryLines: [],
     detailChips: [
       { icon: "hero", label: "对手 hero-2" },
       { icon: "battle", label: "room-alpha/battle-2" }
@@ -176,7 +178,15 @@ test("buildBattleExitCopy distinguishes pvp settlement from pve settlement", () 
     subtitle: "草野战场 · 坐标 (3,2) · PVP 结算已回写，房间返回世界地图",
     tone: "victory",
     terrain: "grass",
-    detailChips: []
+    summaryLines: [
+      "结果：PVP 胜利",
+      "奖励：暂无额外掉落",
+      "下一步：等待房间回写后返回世界地图"
+    ],
+    detailChips: [
+      { icon: "battle", label: "PVP 胜利" },
+      { icon: "battle", label: "等待回写后返回世界地图" }
+    ]
   });
 
   assert.deepEqual(buildBattleExitCopy(update.battle, update, false), {
@@ -185,7 +195,15 @@ test("buildBattleExitCopy distinguishes pvp settlement from pve settlement", () 
     subtitle: "草野战场 · 坐标 (3,2) · 对手仍保留在房间地图上，等待世界态回写",
     tone: "defeat",
     terrain: "grass",
-    detailChips: []
+    summaryLines: [
+      "结果：PVP 失利",
+      "奖励：暂无额外掉落",
+      "下一步：等待房间回写后再调整对抗"
+    ],
+    detailChips: [
+      { icon: "battle", label: "PVP 失利" },
+      { icon: "battle", label: "等待回写后再调整对抗" }
+    ]
   });
 });
 
@@ -235,9 +253,15 @@ test("buildBattleExitCopy summarizes rewards and progression", () => {
     subtitle: "荒地战场 · 坐标 (5,4) · 返回世界地图，继续推进前线",
     tone: "victory",
     terrain: "dirt",
+    summaryLines: [
+      "结果：胜利",
+      "奖励：金币 +300 / Lv 2",
+      "下一步：返回世界地图继续推进当前回合"
+    ],
     detailChips: [
-      { icon: "gold", label: "金币 +300" },
-      { icon: "hero", label: "Lv 2" }
+      { icon: "battle", label: "胜利" },
+      { icon: "gold", label: "金币 +300 / Lv 2" },
+      { icon: "battle", label: "返回世界地图" }
     ]
   });
 
@@ -247,9 +271,15 @@ test("buildBattleExitCopy summarizes rewards and progression", () => {
     subtitle: "荒地战场 · 坐标 (5,4) · 部队需要整顿后再战",
     tone: "defeat",
     terrain: "dirt",
+    summaryLines: [
+      "结果：失利",
+      "奖励：金币 +300 / Lv 2",
+      "下一步：整顿部队后再尝试推进"
+    ],
     detailChips: [
-      { icon: "gold", label: "金币 +300" },
-      { icon: "hero", label: "Lv 2" }
+      { icon: "battle", label: "失利" },
+      { icon: "gold", label: "金币 +300 / Lv 2" },
+      { icon: "battle", label: "整顿部队后再战" }
     ]
   });
 });
@@ -323,10 +353,15 @@ test("buildBattleExitCopy prioritizes level and equipment chips when rewards ove
     subtitle: "沙原战场 · 坐标 (5,3) · 返回世界地图，继续推进前线",
     tone: "victory",
     terrain: "sand",
+    summaryLines: [
+      "结果：胜利",
+      "奖励：金币 +250 / 木材 +5 / 矿石 +3 / Lv 2 / 史诗 余烬王冠",
+      "下一步：返回世界地图继续推进当前回合"
+    ],
     detailChips: [
-      { icon: "battle", label: "史诗 余烬王冠" },
-      { icon: "hero", label: "Lv 2" },
-      { icon: "gold", label: "金币 +250" }
+      { icon: "battle", label: "胜利" },
+      { icon: "gold", label: "金币 +250 / 木材 +5 / 矿石 +3 / Lv 2 / 史诗 余烬王冠" },
+      { icon: "battle", label: "返回世界地图" }
     ]
   });
 });
@@ -365,8 +400,15 @@ test("buildBattleExitCopy marks overflowed equipment so failed pickups stay visi
     subtitle: "沙原战场 · 坐标 (5,3) · 返回世界地图，继续推进前线",
     tone: "victory",
     terrain: "sand",
+    summaryLines: [
+      "结果：胜利",
+      "奖励：未拾取 余烬王冠",
+      "下一步：返回世界地图继续推进当前回合"
+    ],
     detailChips: [
-      { icon: "battle", label: "未拾取 余烬王冠" }
+      { icon: "battle", label: "胜利" },
+      { icon: "battle", label: "未拾取 余烬王冠" },
+      { icon: "battle", label: "返回世界地图" }
     ]
   });
 });

--- a/apps/cocos-client/test/cocos-battle-transition.test.ts
+++ b/apps/cocos-client/test/cocos-battle-transition.test.ts
@@ -36,6 +36,7 @@ test("VeilBattleTransition uses pixel terrain frames for the formal battle overl
     subtitle: "切入战斗场景",
     tone: "enter",
     terrain: "sand",
+    summaryLines: [],
     detailChips: [
       { icon: "battle", label: "中立遭遇" },
       { icon: "hero", label: "Guard x12" }
@@ -50,6 +51,7 @@ test("VeilBattleTransition uses pixel terrain frames for the formal battle overl
   assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlayBadge")), "ENGAGE");
   assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlayTitle")), "遭遇中立守军");
   assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlaySubtitle")), "切入战斗场景");
+  assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlaySummary")), "");
   assert.equal(terrainNode?.active, true);
   assert.equal(terrainSprite?.spriteFrame?.name, "pixel/terrain/sand-tile");
   assert.equal(terrainOpacity?.opacity, 246);
@@ -62,13 +64,19 @@ test("VeilBattleTransition uses pixel terrain frames for the formal battle overl
     subtitle: "返回世界地图",
     tone: "victory",
     terrain: null,
-    detailChips: []
+    summaryLines: ["结果：胜利", "奖励：金币 +12", "下一步：返回世界地图继续推进当前回合"],
+    detailChips: [
+      { icon: "battle", label: "胜利" },
+      { icon: "gold", label: "金币 +12" },
+      { icon: "battle", label: "返回世界地图" }
+    ]
   });
 
   assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlayBadge")), "VICTORY");
   assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlayTitle")), "战斗胜利");
+  assert.equal(readLabelString(findNode(node, "ProjectVeilBattleOverlaySummary")), "结果：胜利\n奖励：金币 +12\n下一步：返回世界地图继续推进当前回合");
   assert.equal(terrainNode?.active, false);
   assert.equal(terrainSprite?.spriteFrame, null);
   assert.equal(terrainOpacity?.opacity, 0);
-  assert.equal(findNode(node, "ProjectVeilBattleOverlayChips")?.active, false);
+  assert.equal(findNode(node, "ProjectVeilBattleOverlayChips")?.active, true);
 });


### PR DESCRIPTION
## Summary\n- enrich the first-battle settlement transition with explicit result, reward summary, and next-step guidance\n- tighten battle panel result context so settlement reads as a clear handoff instead of a generic end state\n- expand focused Cocos battle settlement tests\n\nCloses #1470