### PR TITLE
feat: extend onboarding funnel telemetry stages

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -2835,6 +2835,12 @@ export class VeilRoot extends Component {
         this.gameplayCampaignDialogue = null;
         this.gameplayCampaignPanelOpen = false;
       }
+      this.trackClientAnalyticsEvent("mission_started", {
+        campaignId: result.mission.chapterId,
+        missionId: result.mission.id,
+        mapId: result.mission.mapId,
+        chapterOrder: Number.parseInt(result.mission.chapterId.replace(/^chapter/i, ""), 10) || 1
+      });
       await this.refreshGameplayCampaign(result.mission.id);
       this.gameplayCampaignStatus =
         (result.mission.introDialogue?.length ?? 0) > 0
@@ -3529,6 +3535,7 @@ export class VeilRoot extends Component {
     | "session_start"
     | "battle_start"
     | "battle_end"
+    | "mission_started"
     | "quest_complete"
     | "tutorial_step"
     | "experiment_exposure"

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -342,6 +342,17 @@ test("VeilRoot loads campaign state and advances the manual campaign dialogue/st
   root.authMode = "account";
   root.authProvider = "account-password";
   root.authToken = "signed.token";
+  const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
+  configureClientAnalyticsRuntimeDependencies({
+    getNodeEnv: () => "production",
+    fetch: async (input, init) => {
+      fetchCalls.push({ input, init });
+      return {
+        ok: true,
+        status: 202
+      };
+    }
+  });
   const dialogueAcks: Array<{ missionId: string; sequence: "intro" | "outro"; dialogueLineId: string }> = [];
   root.session = {
     async acknowledgeCampaignDialogue(missionId, sequence, dialogueLineId) {
@@ -490,12 +501,21 @@ test("VeilRoot loads campaign state and advances the manual campaign dialogue/st
   assert.equal(loadCalls, 1);
 
   await root.startGameplayCampaignMission();
+  await flushClientAnalyticsEventsForTest();
   assert.equal(root.gameplayCampaignActiveMissionId, "chapter1-ember-watch");
   assert.deepEqual(root.gameplayCampaignDialogue, {
     missionId: "chapter1-ember-watch",
     sequence: "intro",
     lineIndex: 0
   });
+  const events = parseCapturedAnalyticsEvents(fetchCalls);
+  const missionStartedEvent = assertCapturedAnalyticsEvent(
+    events,
+    "mission_started",
+    (event) => event.payload.missionId === "chapter1-ember-watch"
+  );
+  assert.equal(missionStartedEvent.payload.campaignId, "chapter1");
+  assert.equal(missionStartedEvent.payload.chapterOrder, 1);
 
   root.advanceGameplayCampaignDialogue();
   assert.equal(root.gameplayCampaignDialogue, null);

--- a/apps/server/src/player-accounts.ts
+++ b/apps/server/src/player-accounts.ts
@@ -2076,6 +2076,17 @@ export function registerPlayerAccountRoutes(
         return;
       }
 
+      emitAnalyticsEvent("mission_started", {
+        playerId: account.playerId,
+        roomId: mission.mapId,
+        payload: {
+          campaignId: mission.chapterId,
+          missionId,
+          mapId: mission.mapId,
+          chapterOrder: Number.parseInt(mission.chapterId.replace(/^chapter/i, ""), 10) || 1
+        }
+      });
+
       sendJson(response, 200, {
         started: true,
         mission

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -81,6 +81,17 @@ export const ANALYTICS_EVENT_CATALOG = {
       }
     }
   ),
+  mission_started: defineAnalyticsEvent(
+    "mission_started",
+    1,
+    "Campaign mission started by the player after the chapter handoff.",
+    {
+      campaignId: "chapter1",
+      missionId: "chapter1-ember-watch",
+      mapId: "veil-frontier",
+      chapterOrder: 1
+    }
+  ),
   daily_login: defineAnalyticsEvent("daily_login", 1, "Daily first-login reward was issued to the player.", {
     dateKey: "2026-04-11",
     streak: 3,

--- a/packages/shared/src/onboarding-funnel.ts
+++ b/packages/shared/src/onboarding-funnel.ts
@@ -37,6 +37,24 @@ export const ONBOARDING_FUNNEL_STAGES: readonly OnboardingFunnelStageDefinition[
     label: "Onboarding Completed",
     successCriteria: "The player finishes onboarding and unlocks normal post-onboarding progression.",
     evidenceNotes: "Maps to `tutorial_step` analytics with `payload.stepId = tutorial_completed`."
+  },
+  {
+    id: "first_campaign_mission_started",
+    label: "First Campaign Mission Started",
+    successCriteria: "The player starts the first guided campaign mission after the tutorial handoff.",
+    evidenceNotes: "Maps to `mission_started` analytics for the first available chapter-one campaign mission."
+  },
+  {
+    id: "first_battle_settled",
+    label: "First Battle Settled",
+    successCriteria: "The player resolves the first battle after onboarding and the result is recorded.",
+    evidenceNotes: "Maps to `battle_end` analytics emitted from the first owned encounter resolution."
+  },
+  {
+    id: "first_reward_claimed",
+    label: "First Reward Claimed",
+    successCriteria: "The player successfully claims the first post-onboarding reward from a canonical reward surface.",
+    evidenceNotes: "Maps to `quest_complete`, `seasonal_event_reward_claimed`, or equivalent first-session reward-claim analytics."
   }
 ] as const;
 

--- a/packages/shared/test/analytics-events.test.ts
+++ b/packages/shared/test/analytics-events.test.ts
@@ -246,6 +246,22 @@ test("createAnalyticsEvent: quest_complete event carries correct payload structu
   assert.equal(event.payload.reward.gems, 5);
 });
 
+test("createAnalyticsEvent: mission_started event carries campaign handoff payload", () => {
+  const event = createAnalyticsEvent("mission_started", {
+    playerId: "player-1",
+    payload: {
+      campaignId: "chapter1",
+      missionId: "chapter1-ember-watch",
+      mapId: "veil-frontier",
+      chapterOrder: 1
+    }
+  });
+  assert.equal(event.payload.campaignId, "chapter1");
+  assert.equal(event.payload.missionId, "chapter1-ember-watch");
+  assert.equal(event.payload.mapId, "veil-frontier");
+  assert.equal(event.payload.chapterOrder, 1);
+});
+
 test("createAnalyticsEvent: daily_login event carries streak and reward payload", () => {
   const event = createAnalyticsEvent("daily_login", {
     playerId: "player-1",

--- a/packages/shared/test/onboarding-funnel.test.ts
+++ b/packages/shared/test/onboarding-funnel.test.ts
@@ -25,8 +25,20 @@ test("getOnboardingFunnelStageIndex returns 4 for onboarding_completed", () => {
   assert.equal(getOnboardingFunnelStageIndex("onboarding_completed"), 4);
 });
 
-test("ONBOARDING_FUNNEL_STAGES has exactly 5 entries", () => {
-  assert.equal(ONBOARDING_FUNNEL_STAGES.length, 5);
+test("getOnboardingFunnelStageIndex returns 5 for first_campaign_mission_started", () => {
+  assert.equal(getOnboardingFunnelStageIndex("first_campaign_mission_started"), 5);
+});
+
+test("getOnboardingFunnelStageIndex returns 6 for first_battle_settled", () => {
+  assert.equal(getOnboardingFunnelStageIndex("first_battle_settled"), 6);
+});
+
+test("getOnboardingFunnelStageIndex returns 7 for first_reward_claimed", () => {
+  assert.equal(getOnboardingFunnelStageIndex("first_reward_claimed"), 7);
+});
+
+test("ONBOARDING_FUNNEL_STAGES has exactly 8 entries", () => {
+  assert.equal(ONBOARDING_FUNNEL_STAGES.length, 8);
 });
 
 test("all stage IDs are unique", () => {
@@ -35,7 +47,7 @@ test("all stage IDs are unique", () => {
   assert.equal(uniqueIds.size, ids.length);
 });
 
-test("stages are in ascending index order (0..4)", () => {
+test("stages are in ascending index order (0..7)", () => {
   for (let i = 0; i < ONBOARDING_FUNNEL_STAGES.length; i++) {
     const stageId = ONBOARDING_FUNNEL_STAGES[i].id as Parameters<typeof getOnboardingFunnelStageIndex>[0];
     assert.equal(getOnboardingFunnelStageIndex(stageId), i);

--- a/scripts/onboarding-funnel-report.ts
+++ b/scripts/onboarding-funnel-report.ts
@@ -335,6 +335,21 @@ function collectParticipants(events: RawAnalyticsEvent[], diagnosticFailures: Di
       continue;
     }
 
+    if (event.name === "mission_started" || event.name === "mission_complete") {
+      markStage(participant, "first_campaign_mission_started", event.at, { inferPreviousStages: true });
+      continue;
+    }
+
+    if (event.name === "battle_end") {
+      markStage(participant, "first_battle_settled", event.at, { inferPreviousStages: true });
+      continue;
+    }
+
+    if (event.name === "quest_complete" || event.name === "seasonal_event_reward_claimed") {
+      markStage(participant, "first_reward_claimed", event.at, { inferPreviousStages: true });
+      continue;
+    }
+
     if (event.name !== "tutorial_step") {
       continue;
     }

--- a/scripts/test/fixtures/onboarding-funnel-events.json
+++ b/scripts/test/fixtures/onboarding-funnel-events.json
@@ -54,6 +54,51 @@
     },
     {
       "schemaVersion": 1,
+      "name": "mission_started",
+      "version": 1,
+      "at": "2026-04-01T10:05:00.000Z",
+      "playerId": "player-complete-fast",
+      "source": "server",
+      "payload": {
+        "campaignId": "chapter1",
+        "missionId": "chapter1-ember-watch",
+        "mapId": "veil-frontier",
+        "chapterOrder": 1
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "battle_end",
+      "version": 1,
+      "at": "2026-04-01T10:08:00.000Z",
+      "playerId": "player-complete-fast",
+      "source": "server",
+      "payload": {
+        "roomId": "veil-frontier",
+        "battleId": "battle-fast-1",
+        "result": "attacker_victory",
+        "heroId": "hero-1",
+        "battleKind": "neutral"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "quest_complete",
+      "version": 1,
+      "at": "2026-04-01T10:10:00.000Z",
+      "playerId": "player-complete-fast",
+      "source": "server",
+      "payload": {
+        "roomId": "veil-frontier",
+        "questId": "daily_explore_frontier",
+        "reward": {
+          "gems": 5,
+          "gold": 60
+        }
+      }
+    },
+    {
+      "schemaVersion": 1,
       "name": "session_start",
       "version": 1,
       "at": "2026-04-01T11:00:00.000Z",
@@ -100,6 +145,35 @@
       "payload": {
         "stepId": "tutorial_completed",
         "status": "completed"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "mission_started",
+      "version": 1,
+      "at": "2026-04-01T11:12:00.000Z",
+      "playerId": "player-complete-slow",
+      "source": "server",
+      "payload": {
+        "campaignId": "chapter1",
+        "missionId": "chapter1-ember-watch",
+        "mapId": "veil-frontier",
+        "chapterOrder": 1
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "battle_end",
+      "version": 1,
+      "at": "2026-04-01T11:20:00.000Z",
+      "playerId": "player-complete-slow",
+      "source": "server",
+      "payload": {
+        "roomId": "veil-frontier",
+        "battleId": "battle-slow-1",
+        "result": "attacker_victory",
+        "heroId": "hero-2",
+        "battleKind": "neutral"
       }
     },
     {

--- a/scripts/test/onboarding-funnel-report.test.ts
+++ b/scripts/test/onboarding-funnel-report.test.ts
@@ -79,6 +79,10 @@ test("onboarding funnel report aggregates completion, timings, drop-off, and fai
   assert.equal(report.stageReports.find((stage) => stage.id === "tutorial_step_2_seen")?.reachedCount, 4);
   assert.equal(report.stageReports.find((stage) => stage.id === "tutorial_step_3_seen")?.dropOffCount, 1);
   assert.equal(report.stageReports.find((stage) => stage.id === "onboarding_completed")?.dropOffCount, 1);
+  assert.equal(report.stageReports.find((stage) => stage.id === "first_campaign_mission_started")?.reachedCount, 2);
+  assert.equal(report.stageReports.find((stage) => stage.id === "first_battle_settled")?.reachedCount, 2);
+  assert.equal(report.stageReports.find((stage) => stage.id === "first_reward_claimed")?.reachedCount, 1);
+  assert.equal(report.stageReports.find((stage) => stage.id === "first_reward_claimed")?.dropOffCount, 1);
   assert.deepEqual(
     report.topFailureReasons.map((failure) => [failure.reason, failure.count, failure.playerCount]),
     [
@@ -96,6 +100,8 @@ test("onboarding funnel report aggregates completion, timings, drop-off, and fai
   const markdown = fs.readFileSync(markdownOutputPath, "utf8");
   assert.match(markdown, /## Canonical Stages/);
   assert.match(markdown, /Completion rate: 33\.3%/);
+  assert.match(markdown, /First Campaign Mission Started/);
+  assert.match(markdown, /First Reward Claimed/);
   assert.match(markdown, /`disconnect` count=1/);
   assert.match(markdown, /Failure reason coverage: 4\/6 entrants/);
 });


### PR DESCRIPTION
## Summary
- extend onboarding funnel stages through campaign start, first battle settlement, and first reward claim
- add mission start analytics catalog coverage and Cocos/server emission points
- teach the onboarding funnel report to map the new telemetry events

## Validation
- node --import tsx --test ./apps/cocos-client/test/cocos-root-orchestration.test.ts ./packages/shared/test/onboarding-funnel.test.ts ./packages/shared/test/analytics-events.test.ts ./scripts/test/onboarding-funnel-report.test.ts
- npm run typecheck:cocos
- npm run typecheck:server

Closes #1475