### PR TITLE
feat: expand onboarding funnel dashboard summary

### DIFF
--- a/docs/onboarding-funnel-dashboard.md
+++ b/docs/onboarding-funnel-dashboard.md
@@ -10,13 +10,16 @@ The report is intentionally pragmatic:
 
 ## Canonical Funnel
 
-The funnel uses stable stage ids from [`packages/shared/src/onboarding-funnel.ts`](../packages/shared/src/onboarding-funnel.ts):
+The report keeps the shared onboarding stage contract from [`packages/shared/src/onboarding-funnel.ts`](../packages/shared/src/onboarding-funnel.ts) and merges in the post-tutorial focus stages used for V0.6 closeout:
 
 - `onboarding_session_started`
 - `tutorial_step_1_seen`
 - `tutorial_step_2_seen`
 - `tutorial_step_3_seen`
 - `onboarding_completed`
+- `first_campaign_mission_started`
+- `first_battle_settled`
+- `first_reward_claimed`
 
 Stage semantics:
 
@@ -30,6 +33,12 @@ Stage semantics:
   The player advanced to the final guided step before completion.
 - `onboarding_completed`
   The player finished onboarding and unlocked normal progression.
+- `first_campaign_mission_started`
+  The player was handed into the first campaign mission after tutorial completion.
+- `first_battle_settled`
+  The first chapter battle resolved and the settlement state became visible.
+- `first_reward_claimed`
+  The first post-battle reward was claimed and visible to review.
 
 ## Usage
 
@@ -65,11 +74,13 @@ npm run analytics:onboarding:funnel -- \
 The JSON report includes:
 
 - `summary`
-  entrant count, completion count, completion rate, and median completion time
+  entrant count, full-chain completion count, completion rate, and median time from onboarding start to first reward claim
+- `pmSummary`
+  a PM-facing narrative plus the post-tutorial focus chain with reach and drop-off counts
 - `canonicalStages`
   the stable stage contract with success criteria and evidence notes
 - `stageReports`
-  per-stage reach counts and drop-off counts/rates
+  per-stage reach counts and drop-off counts/rates across both the shared and supplemental funnel stages
 - `topFailureReasons`
   the most common explicit failure reasons when the source evidence contains them
 - `regressions`
@@ -85,8 +96,9 @@ Start in this order:
 
 1. Completion rate
 2. Median completion time
-3. The first stage with a large drop-off count
-4. Top failure reasons if present
+3. The PM summary focus chain
+4. The first stage with a large drop-off count
+5. Top failure reasons if present
 
 Pragmatic default thresholds are built into the script and emitted into the artifact:
 
@@ -99,5 +111,6 @@ Treat these as regression flags, not hard product truth. Tighten them once a hea
 ## Evidence Limitations
 
 - If the evidence only contains tutorial-step events, the report infers `tutorial_step_1_seen` from the onboarding session start.
+- The report accepts explicit `stageId` markers in fixtures for the post-tutorial focus chain, which is how we keep the dashboard deterministic while the shared telemetry contract is still expanding.
 - If no diagnostics or failure-coded events are supplied, abandonment still appears in stage drop-off counts but the failure reason section will stay empty.
 - The current report is player-level and de-duplicates by `playerId`. It is designed for onboarding health snapshots, not retry-cohort analysis.

--- a/scripts/onboarding-funnel-report.ts
+++ b/scripts/onboarding-funnel-report.ts
@@ -2,8 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   ONBOARDING_FUNNEL_STAGES,
-  type OnboardingFunnelStageDefinition,
-  type OnboardingFunnelStageId
+  type OnboardingFunnelStageDefinition
 } from "../packages/shared/src/index.ts";
 
 const DEFAULT_OUTPUT_DIR = path.resolve("artifacts", "analytics");
@@ -38,7 +37,7 @@ interface DiagnosticFailureRecord {
 interface OnboardingParticipant {
   playerId: string;
   firstObservedAt?: string;
-  stageTimes: Partial<Record<OnboardingFunnelStageId, string>>;
+  stageTimes: Partial<Record<ReportStageId, string>>;
   highestStageIndex: number;
   failureReasons: Array<{
     reason: string;
@@ -49,7 +48,7 @@ interface OnboardingParticipant {
 }
 
 interface StageReport {
-  id: OnboardingFunnelStageId;
+  id: ReportStageId;
   label: string;
   successCriteria: string;
   evidenceNotes: string;
@@ -94,15 +93,67 @@ interface OnboardingFunnelReport {
   };
   canonicalStages: OnboardingFunnelStageDefinition[];
   stageReports: StageReport[];
+  pmSummary: {
+    focusChainLabel: string;
+    focusStages: Array<{
+      id: ReportStageId;
+      label: string;
+      reachedCount: number;
+      dropOffCount: number;
+      dropOffRateFromPrevious: number | null;
+    }>;
+    narrative: string[];
+  };
   topFailureReasons: FailureReasonSummary[];
   participants: Array<{
     playerId: string;
     firstObservedAt?: string;
-    highestStageId?: OnboardingFunnelStageId;
+    highestStageId?: ReportStageId;
     completed: boolean;
     failureReasons: string[];
   }>;
 }
+
+interface StageDefinition {
+  id: string;
+  label: string;
+  successCriteria: string;
+  evidenceNotes: string;
+}
+
+const SUPPLEMENTAL_ONBOARDING_FUNNEL_STAGES = [
+  {
+    id: "first_campaign_mission_started",
+    label: "First Campaign Mission Started",
+    successCriteria: "The player is handed from tutorial completion into the first chapter path.",
+    evidenceNotes:
+      "Prefer an explicit `stageId` marker in fixtures. Otherwise the report infers this stage from the first chapter mission completion artifact after onboarding completion."
+  },
+  {
+    id: "first_battle_settled",
+    label: "First Battle Settled",
+    successCriteria: "The player's first chapter battle resolves and the settlement state is visible.",
+    evidenceNotes:
+      "Prefer an explicit `stageId` marker in fixtures. Otherwise the report infers this stage from the first `battle_end` artifact after chapter handoff."
+  },
+  {
+    id: "first_reward_claimed",
+    label: "First Reward Claimed",
+    successCriteria: "The player's first post-battle reward is claimed and visible to PM review.",
+    evidenceNotes:
+      "Prefer an explicit `stageId` marker in fixtures. Otherwise the report infers this stage from the first reward-claim artifact after first battle settlement."
+  }
+] as const satisfies readonly StageDefinition[];
+
+const REPORT_STAGE_DEFINITIONS = mergeStageDefinitions(ONBOARDING_FUNNEL_STAGES, SUPPLEMENTAL_ONBOARDING_FUNNEL_STAGES);
+const POST_TUTORIAL_FOCUS_STAGE_IDS = [
+  "onboarding_completed",
+  "first_campaign_mission_started",
+  "first_battle_settled",
+  "first_reward_claimed"
+] as const;
+
+type ReportStageId = (typeof REPORT_STAGE_DEFINITIONS)[number]["id"];
 
 function parseArgs(argv: string[]): Args {
   const args: Args = {
@@ -271,6 +322,22 @@ function toNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
+function mergeStageDefinitions(
+  sharedStages: readonly OnboardingFunnelStageDefinition[],
+  supplementalStages: readonly StageDefinition[]
+): readonly StageDefinition[] {
+  const merged: StageDefinition[] = [];
+  const seen = new Set<string>();
+  for (const stage of [...sharedStages, ...supplementalStages]) {
+    if (seen.has(stage.id)) {
+      continue;
+    }
+    merged.push(stage);
+    seen.add(stage.id);
+  }
+  return merged;
+}
+
 function getOrCreateParticipant(participants: Map<string, OnboardingParticipant>, playerId: string): OnboardingParticipant {
   const existing = participants.get(playerId);
   if (existing) {
@@ -287,13 +354,8 @@ function getOrCreateParticipant(participants: Map<string, OnboardingParticipant>
   return created;
 }
 
-function markStage(
-  participant: OnboardingParticipant,
-  stageId: OnboardingFunnelStageId,
-  at?: string,
-  options?: { inferPreviousStages?: boolean }
-): void {
-  const stageIndex = ONBOARDING_FUNNEL_STAGES.findIndex((stage) => stage.id === stageId);
+function markStage(participant: OnboardingParticipant, stageId: ReportStageId, at?: string, options?: { inferPreviousStages?: boolean }): void {
+  const stageIndex = REPORT_STAGE_DEFINITIONS.findIndex((stage) => stage.id === stageId);
   if (stageIndex < 0) {
     return;
   }
@@ -304,7 +366,7 @@ function markStage(
 
   if (options?.inferPreviousStages) {
     for (let index = 0; index < stageIndex; index += 1) {
-      const previousStageId = ONBOARDING_FUNNEL_STAGES[index].id;
+      const previousStageId = REPORT_STAGE_DEFINITIONS[index].id;
       participant.stageTimes[previousStageId] ??= at;
     }
   }
@@ -328,6 +390,7 @@ function collectParticipants(events: RawAnalyticsEvent[], diagnosticFailures: Di
 
   for (const event of sortedEvents) {
     const participant = getOrCreateParticipant(participants, event.playerId!);
+    const explicitStageId = resolveStageIdFromPayload(event.payload);
 
     if (event.name === "session_start" && looksLikeOnboardingSession(event.payload)) {
       markStage(participant, "onboarding_session_started", event.at);
@@ -336,6 +399,7 @@ function collectParticipants(events: RawAnalyticsEvent[], diagnosticFailures: Di
     }
 
     if (event.name !== "tutorial_step") {
+      applyPostTutorialStageMarkers(participant, event.name, event.payload, event.at, explicitStageId);
       continue;
     }
 
@@ -355,10 +419,12 @@ function collectParticipants(events: RawAnalyticsEvent[], diagnosticFailures: Di
       participant.failureReasons.push({
         reason: explicitFailureReason ?? "manual_exit",
         at: event.at,
-        stageId: resolveStageIdFromPayload(event.payload) ?? highestStageId(participant),
+        stageId: explicitStageId ?? highestStageId(participant),
         source: "analytics"
       });
     }
+
+    applyPostTutorialStageMarkers(participant, event.name, event.payload, event.at, explicitStageId);
   }
 
   for (const failure of diagnosticFailures) {
@@ -399,19 +465,59 @@ function looksLikeOnboardingSession(payload: Record<string, unknown>): boolean {
   return true;
 }
 
-function resolveStageIdFromPayload(payload: Record<string, unknown>): OnboardingFunnelStageId | undefined {
+function resolveStageIdFromPayload(payload: Record<string, unknown>): ReportStageId | undefined {
   return normalizeStageId(toNonEmptyString(payload.stageId));
 }
 
-function normalizeStageId(value?: string): OnboardingFunnelStageId | undefined {
+function normalizeStageId(value?: string): ReportStageId | undefined {
   if (!value) {
     return undefined;
   }
-  return ONBOARDING_FUNNEL_STAGES.find((stage) => stage.id === value)?.id;
+  return REPORT_STAGE_DEFINITIONS.find((stage) => stage.id === value)?.id;
 }
 
-function highestStageId(participant: OnboardingParticipant): OnboardingFunnelStageId | undefined {
-  return participant.highestStageIndex >= 0 ? ONBOARDING_FUNNEL_STAGES[participant.highestStageIndex].id : undefined;
+function highestStageId(participant: OnboardingParticipant): ReportStageId | undefined {
+  return participant.highestStageIndex >= 0 ? REPORT_STAGE_DEFINITIONS[participant.highestStageIndex].id : undefined;
+}
+
+function applyPostTutorialStageMarkers(
+  participant: OnboardingParticipant,
+  eventName: string | undefined,
+  payload: Record<string, unknown>,
+  at?: string,
+  explicitStageId?: ReportStageId
+): void {
+  const stageId = explicitStageId ?? resolveStageIdFromPayload(payload);
+  if (stageId) {
+    markStage(participant, stageId, at, stageId === "onboarding_completed" ? { inferPreviousStages: true } : undefined);
+  }
+
+  if (
+    eventName === "mission_complete" &&
+    participant.stageTimes.onboarding_completed &&
+    !participant.stageTimes.first_campaign_mission_started
+  ) {
+    const chapterId = toNonEmptyString(payload.chapterId);
+    if (chapterId === "chapter1") {
+      markStage(participant, "first_campaign_mission_started", at, { inferPreviousStages: true });
+    }
+  }
+
+  if (
+    eventName === "battle_end" &&
+    participant.stageTimes.first_campaign_mission_started &&
+    !participant.stageTimes.first_battle_settled
+  ) {
+    markStage(participant, "first_battle_settled", at, { inferPreviousStages: true });
+  }
+
+  if (
+    eventName === "quest_complete" &&
+    participant.stageTimes.first_battle_settled &&
+    !participant.stageTimes.first_reward_claimed
+  ) {
+    markStage(participant, "first_reward_claimed", at, { inferPreviousStages: true });
+  }
 }
 
 function roundRate(value: number): number {
@@ -422,7 +528,7 @@ function calculateMedianCompletionSeconds(participants: OnboardingParticipant[])
   const completedDurations = participants
     .map((participant) => {
       const startedAt = participant.stageTimes.onboarding_session_started ?? participant.firstObservedAt;
-      const completedAt = participant.stageTimes.onboarding_completed;
+      const completedAt = getFullChainCompletionAt(participant);
       if (!startedAt || !completedAt) {
         return null;
       }
@@ -476,10 +582,10 @@ function summarizeFailureReasons(participants: OnboardingParticipant[]): Failure
 function buildReport(args: Args, inputPaths: string[], diagnosticsPaths: string[], participantsMap: Map<string, OnboardingParticipant>): OnboardingFunnelReport {
   const participants = [...participantsMap.values()].sort((left, right) => left.playerId.localeCompare(right.playerId));
   const entrants = participants.length;
-  const completed = participants.filter((participant) => Boolean(participant.stageTimes.onboarding_completed)).length;
+  const completed = participants.filter((participant) => Boolean(getFullChainCompletionAt(participant))).length;
   const completionRate = entrants > 0 ? roundRate(completed / entrants) : 0;
   const medianCompletionSeconds = calculateMedianCompletionSeconds(participants);
-  const stageReports = ONBOARDING_FUNNEL_STAGES.map((stage, index) => {
+  const stageReports = REPORT_STAGE_DEFINITIONS.map((stage, index) => {
     const reachedCount = participants.filter((participant) => participant.highestStageIndex >= index).length;
     const previousReachedCount = index === 0 ? entrants : participants.filter((participant) => participant.highestStageIndex >= index - 1).length;
     const dropOffCount = index === 0 ? 0 : Math.max(0, previousReachedCount - reachedCount);
@@ -517,6 +623,14 @@ function buildReport(args: Args, inputPaths: string[], diagnosticsPaths: string[
 
   const topFailureReasons = summarizeFailureReasons(participants);
   const entrantsWithFailureEvidence = participants.filter((participant) => participant.failureReasons.length > 0).length;
+  const focusStages = POST_TUTORIAL_FOCUS_STAGE_IDS.map((stageId) => {
+    const stage = stageReports.find((entry) => entry.id === stageId);
+    if (!stage) {
+      throw new Error(`Missing focus stage definition: ${stageId}`);
+    }
+    return stage;
+  });
+  const focusNarrative = buildFocusNarrative(entrants, focusStages);
 
   return {
     schemaVersion: 1,
@@ -547,12 +661,23 @@ function buildReport(args: Args, inputPaths: string[], diagnosticsPaths: string[
     },
     canonicalStages: [...ONBOARDING_FUNNEL_STAGES],
     stageReports,
+    pmSummary: {
+      focusChainLabel: "Tutorial Completed -> First Campaign Mission Started -> First Battle Settled -> First Reward Claimed",
+      focusStages: focusStages.map((stage) => ({
+        id: stage.id,
+        label: stage.label,
+        reachedCount: stage.reachedCount,
+        dropOffCount: stage.dropOffCount,
+        dropOffRateFromPrevious: stage.dropOffRateFromPrevious
+      })),
+      narrative: focusNarrative
+    },
     topFailureReasons,
     participants: participants.map((participant) => ({
       playerId: participant.playerId,
       firstObservedAt: participant.firstObservedAt,
       highestStageId: highestStageId(participant),
-      completed: Boolean(participant.stageTimes.onboarding_completed),
+      completed: Boolean(getFullChainCompletionAt(participant)),
       failureReasons: [...new Set(participant.failureReasons.map((failure) => failure.reason))].sort()
     }))
   };
@@ -563,6 +688,13 @@ function renderMarkdown(report: OnboardingFunnelReport): string {
   lines.push("# Onboarding Funnel Dashboard");
   lines.push("");
   lines.push(`Generated at \`${report.generatedAt}\`.`);
+  lines.push("");
+  lines.push("## PM Summary");
+  lines.push("");
+  lines.push(`Focus chain: ${report.pmSummary.focusChainLabel}`);
+  for (const line of report.pmSummary.narrative) {
+    lines.push(`- ${line}`);
+  }
   lines.push("");
   lines.push("## Summary");
   lines.push("");
@@ -581,6 +713,16 @@ function renderMarkdown(report: OnboardingFunnelReport): string {
   for (const stage of report.canonicalStages) {
     lines.push(`- \`${stage.id}\` ${stage.label}: ${stage.successCriteria}`);
     lines.push(`  Evidence: ${stage.evidenceNotes}`);
+  }
+  lines.push("");
+  lines.push("## Focus Chain");
+  lines.push("");
+  for (const stage of report.pmSummary.focusStages) {
+    lines.push(
+      `- \`${stage.id}\` reached=${stage.reachedCount}, dropOff=${stage.dropOffCount}${
+        stage.dropOffRateFromPrevious == null ? "" : ` (${formatPercent(stage.dropOffRateFromPrevious)} from previous stage)`
+      }`
+    );
   }
   lines.push("");
   lines.push("## Stage Drop-Off");
@@ -620,13 +762,33 @@ function renderMarkdown(report: OnboardingFunnelReport): string {
   lines.push("## Reading Guide");
   lines.push("");
   lines.push("- Start with completion rate and median completion time for overall onboarding health.");
-  lines.push("- Then inspect the first stage with a large drop-off count or drop-off rate.");
+  lines.push("- Then inspect the PM summary focus chain to see where the tutorial-to-reward handoff leaks.");
+  lines.push("- After that, inspect the first stage with a large drop-off count or drop-off rate.");
   lines.push("- Use the failure reasons section only when explicit diagnostics were present; missing reasons mean the evidence did not explain abandonment.");
   return `${lines.join("\n")}\n`;
 }
 
 function formatPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
+}
+
+function getFullChainCompletionAt(participant: OnboardingParticipant): string | undefined {
+  return participant.stageTimes.first_reward_claimed;
+}
+
+function buildFocusNarrative(entrants: number, focusStages: Array<{ id: ReportStageId; label: string; reachedCount: number; dropOffCount: number }>): string[] {
+  if (focusStages.length === 0) {
+    return ["No post-tutorial focus stages were configured."];
+  }
+
+  const [tutorialCompleted, firstCampaignMissionStarted, firstBattleSettled, firstRewardClaimed] = focusStages;
+  const fullChainReached = firstRewardClaimed?.reachedCount ?? 0;
+
+  return [
+    `Tutorial completion to first reward claim: ${fullChainReached}/${entrants} entrants reached the full post-tutorial chain.`,
+    `Stage reach counts: ${tutorialCompleted.label} ${tutorialCompleted.reachedCount}, ${firstCampaignMissionStarted.label} ${firstCampaignMissionStarted.reachedCount}, ${firstBattleSettled.label} ${firstBattleSettled.reachedCount}, ${firstRewardClaimed.label} ${firstRewardClaimed.reachedCount}.`,
+    `Drop-off sequence: ${firstCampaignMissionStarted.dropOffCount} before ${firstCampaignMissionStarted.label}, ${firstBattleSettled.dropOffCount} before ${firstBattleSettled.label}, ${firstRewardClaimed.dropOffCount} before ${firstRewardClaimed.label}.`
+  ];
 }
 
 function ensureParentDir(filePath: string): void {

--- a/scripts/test/fixtures/onboarding-funnel-diagnostics.json
+++ b/scripts/test/fixtures/onboarding-funnel-diagnostics.json
@@ -2,21 +2,27 @@
   "schemaVersion": 1,
   "failures": [
     {
-      "playerId": "player-drop-step2",
-      "reason": "disconnect",
-      "at": "2026-04-01T12:04:00.000Z",
-      "stageId": "tutorial_step_2_seen"
-    },
-    {
-      "playerId": "player-drop-step3",
-      "reason": "validation_failure",
-      "at": "2026-04-01T13:07:00.000Z",
-      "stageId": "tutorial_step_3_seen"
-    },
-    {
-      "playerId": "player-timeout",
+      "playerId": "player-drop-handoff",
       "reason": "timeout",
-      "at": "2026-04-01T15:00:00.000Z",
+      "at": "2026-04-01T12:08:00.000Z",
+      "stageId": "first_campaign_mission_started"
+    },
+    {
+      "playerId": "player-drop-battle",
+      "reason": "disconnect",
+      "at": "2026-04-01T13:08:00.000Z",
+      "stageId": "first_campaign_mission_started"
+    },
+    {
+      "playerId": "player-drop-reward",
+      "reason": "validation_failure",
+      "at": "2026-04-01T14:10:00.000Z",
+      "stageId": "first_battle_settled"
+    },
+    {
+      "playerId": "player-skipped",
+      "reason": "manual_exit",
+      "at": "2026-04-01T15:03:00.000Z",
       "stageId": "tutorial_step_1_seen"
     }
   ]

--- a/scripts/test/fixtures/onboarding-funnel-events.json
+++ b/scripts/test/fixtures/onboarding-funnel-events.json
@@ -20,7 +20,7 @@
       "schemaVersion": 1,
       "name": "tutorial_step",
       "version": 1,
-      "at": "2026-04-01T10:01:00.000Z",
+      "at": "2026-04-01T10:00:30.000Z",
       "playerId": "player-complete-fast",
       "source": "server",
       "payload": {
@@ -32,7 +32,7 @@
       "schemaVersion": 1,
       "name": "tutorial_step",
       "version": 1,
-      "at": "2026-04-01T10:02:00.000Z",
+      "at": "2026-04-01T10:01:00.000Z",
       "playerId": "player-complete-fast",
       "source": "server",
       "payload": {
@@ -44,12 +44,64 @@
       "schemaVersion": 1,
       "name": "tutorial_step",
       "version": 1,
-      "at": "2026-04-01T10:04:00.000Z",
+      "at": "2026-04-01T10:02:00.000Z",
       "playerId": "player-complete-fast",
       "source": "server",
       "payload": {
         "stepId": "tutorial_completed",
         "status": "completed"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "mission_complete",
+      "version": 1,
+      "at": "2026-04-01T10:02:30.000Z",
+      "playerId": "player-complete-fast",
+      "source": "server",
+      "payload": {
+        "campaignId": "chapter1",
+        "missionId": "chapter1-ember-watch",
+        "stageId": "first_campaign_mission_started",
+        "reward": {
+          "gems": 12,
+          "resources": {
+            "gold": 140
+          }
+        }
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "battle_end",
+      "version": 1,
+      "at": "2026-04-01T10:03:00.000Z",
+      "playerId": "player-complete-fast",
+      "source": "server",
+      "payload": {
+        "roomId": "chapter1-map",
+        "battleId": "first-battle",
+        "stageId": "first_battle_settled",
+        "result": "attacker_victory",
+        "heroId": "hero-1",
+        "battleKind": "chapter1"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "quest_complete",
+      "version": 1,
+      "at": "2026-04-01T10:04:00.000Z",
+      "playerId": "player-complete-fast",
+      "source": "server",
+      "payload": {
+        "roomId": "chapter1-map",
+        "questId": "chapter1_first_reward_claim",
+        "stageId": "first_reward_claimed",
+        "reward": {
+          "gems": 10,
+          "gold": 100
+        }
       }
     },
     {
@@ -82,7 +134,7 @@
       "schemaVersion": 1,
       "name": "tutorial_step",
       "version": 1,
-      "at": "2026-04-01T11:06:00.000Z",
+      "at": "2026-04-01T11:04:00.000Z",
       "playerId": "player-complete-slow",
       "source": "server",
       "payload": {
@@ -94,7 +146,7 @@
       "schemaVersion": 1,
       "name": "tutorial_step",
       "version": 1,
-      "at": "2026-04-01T11:10:00.000Z",
+      "at": "2026-04-01T11:05:00.000Z",
       "playerId": "player-complete-slow",
       "source": "server",
       "payload": {
@@ -104,10 +156,62 @@
     },
     {
       "schemaVersion": 1,
+      "name": "mission_complete",
+      "version": 1,
+      "at": "2026-04-01T11:06:00.000Z",
+      "playerId": "player-complete-slow",
+      "source": "server",
+      "payload": {
+        "campaignId": "chapter1",
+        "missionId": "chapter1-ember-watch",
+        "stageId": "first_campaign_mission_started",
+        "reward": {
+          "gems": 12,
+          "resources": {
+            "gold": 140
+          }
+        }
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "battle_end",
+      "version": 1,
+      "at": "2026-04-01T11:08:00.000Z",
+      "playerId": "player-complete-slow",
+      "source": "server",
+      "payload": {
+        "roomId": "chapter1-map",
+        "battleId": "first-battle",
+        "stageId": "first_battle_settled",
+        "result": "attacker_victory",
+        "heroId": "hero-1",
+        "battleKind": "chapter1"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "quest_complete",
+      "version": 1,
+      "at": "2026-04-01T11:10:00.000Z",
+      "playerId": "player-complete-slow",
+      "source": "server",
+      "payload": {
+        "roomId": "chapter1-map",
+        "questId": "chapter1_first_reward_claim",
+        "stageId": "first_reward_claimed",
+        "reward": {
+          "gems": 10,
+          "gold": 100
+        }
+      }
+    },
+    {
+      "schemaVersion": 1,
       "name": "session_start",
       "version": 1,
       "at": "2026-04-01T12:00:00.000Z",
-      "playerId": "player-drop-step2",
+      "playerId": "player-drop-handoff",
       "source": "server",
       "payload": {
         "roomId": "lobby",
@@ -121,7 +225,7 @@
       "name": "tutorial_step",
       "version": 1,
       "at": "2026-04-01T12:01:00.000Z",
-      "playerId": "player-drop-step2",
+      "playerId": "player-drop-handoff",
       "source": "server",
       "payload": {
         "stepId": "step_2",
@@ -130,10 +234,34 @@
     },
     {
       "schemaVersion": 1,
+      "name": "tutorial_step",
+      "version": 1,
+      "at": "2026-04-01T12:03:00.000Z",
+      "playerId": "player-drop-handoff",
+      "source": "server",
+      "payload": {
+        "stepId": "step_3",
+        "status": "active"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "tutorial_step",
+      "version": 1,
+      "at": "2026-04-01T12:06:00.000Z",
+      "playerId": "player-drop-handoff",
+      "source": "server",
+      "payload": {
+        "stepId": "tutorial_completed",
+        "status": "completed"
+      }
+    },
+    {
+      "schemaVersion": 1,
       "name": "session_start",
       "version": 1,
       "at": "2026-04-01T13:00:00.000Z",
-      "playerId": "player-drop-step3",
+      "playerId": "player-drop-battle",
       "source": "server",
       "payload": {
         "roomId": "lobby",
@@ -146,8 +274,8 @@
       "schemaVersion": 1,
       "name": "tutorial_step",
       "version": 1,
-      "at": "2026-04-01T13:02:00.000Z",
-      "playerId": "player-drop-step3",
+      "at": "2026-04-01T13:01:00.000Z",
+      "playerId": "player-drop-battle",
       "source": "server",
       "payload": {
         "stepId": "step_2",
@@ -158,8 +286,8 @@
       "schemaVersion": 1,
       "name": "tutorial_step",
       "version": 1,
-      "at": "2026-04-01T13:05:00.000Z",
-      "playerId": "player-drop-step3",
+      "at": "2026-04-01T13:03:00.000Z",
+      "playerId": "player-drop-battle",
       "source": "server",
       "payload": {
         "stepId": "step_3",
@@ -168,9 +296,125 @@
     },
     {
       "schemaVersion": 1,
+      "name": "tutorial_step",
+      "version": 1,
+      "at": "2026-04-01T13:04:00.000Z",
+      "playerId": "player-drop-battle",
+      "source": "server",
+      "payload": {
+        "stepId": "tutorial_completed",
+        "status": "completed"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "mission_complete",
+      "version": 1,
+      "at": "2026-04-01T13:06:00.000Z",
+      "playerId": "player-drop-battle",
+      "source": "server",
+      "payload": {
+        "campaignId": "chapter1",
+        "missionId": "chapter1-ember-watch",
+        "stageId": "first_campaign_mission_started",
+        "reward": {
+          "gems": 12,
+          "resources": {
+            "gold": 140
+          }
+        }
+      }
+    },
+    {
+      "schemaVersion": 1,
       "name": "session_start",
       "version": 1,
       "at": "2026-04-01T14:00:00.000Z",
+      "playerId": "player-drop-reward",
+      "source": "server",
+      "payload": {
+        "roomId": "lobby",
+        "authMode": "guest",
+        "platform": "colyseus",
+        "onboarding": true
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "tutorial_step",
+      "version": 1,
+      "at": "2026-04-01T14:01:00.000Z",
+      "playerId": "player-drop-reward",
+      "source": "server",
+      "payload": {
+        "stepId": "step_2",
+        "status": "active"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "tutorial_step",
+      "version": 1,
+      "at": "2026-04-01T14:04:00.000Z",
+      "playerId": "player-drop-reward",
+      "source": "server",
+      "payload": {
+        "stepId": "step_3",
+        "status": "active"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "tutorial_step",
+      "version": 1,
+      "at": "2026-04-01T14:05:00.000Z",
+      "playerId": "player-drop-reward",
+      "source": "server",
+      "payload": {
+        "stepId": "tutorial_completed",
+        "status": "completed"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "mission_complete",
+      "version": 1,
+      "at": "2026-04-01T14:06:00.000Z",
+      "playerId": "player-drop-reward",
+      "source": "server",
+      "payload": {
+        "campaignId": "chapter1",
+        "missionId": "chapter1-ember-watch",
+        "stageId": "first_campaign_mission_started",
+        "reward": {
+          "gems": 12,
+          "resources": {
+            "gold": 140
+          }
+        }
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "battle_end",
+      "version": 1,
+      "at": "2026-04-01T14:08:00.000Z",
+      "playerId": "player-drop-reward",
+      "source": "server",
+      "payload": {
+        "roomId": "chapter1-map",
+        "battleId": "first-battle",
+        "stageId": "first_battle_settled",
+        "result": "attacker_victory",
+        "heroId": "hero-1",
+        "battleKind": "chapter1"
+      }
+    },
+    {
+      "schemaVersion": 1,
+      "name": "session_start",
+      "version": 1,
+      "at": "2026-04-01T15:00:00.000Z",
       "playerId": "player-skipped",
       "source": "server",
       "payload": {
@@ -184,7 +428,7 @@
       "schemaVersion": 1,
       "name": "tutorial_step",
       "version": 1,
-      "at": "2026-04-01T14:02:00.000Z",
+      "at": "2026-04-01T15:02:00.000Z",
       "playerId": "player-skipped",
       "source": "server",
       "payload": {

--- a/scripts/test/onboarding-funnel-report.test.ts
+++ b/scripts/test/onboarding-funnel-report.test.ts
@@ -19,10 +19,12 @@ test("onboarding funnel report aggregates completion, timings, drop-off, and fai
   const markdownOutputPath = path.join(workspace, "onboarding-funnel-report.md");
 
   const result = spawnSync(
-    "node",
+    "npm",
     [
-      "--import",
+      "exec",
+      "--yes",
       "tsx",
+      "--",
       "./scripts/onboarding-funnel-report.ts",
       "--input",
       eventsFixturePath,
@@ -58,6 +60,15 @@ test("onboarding funnel report aggregates completion, timings, drop-off, and fai
       reachedCount: number;
       dropOffCount: number;
     }>;
+    pmSummary: {
+      focusChainLabel: string;
+      focusStages: Array<{
+        id: string;
+        reachedCount: number;
+        dropOffCount: number;
+      }>;
+      narrative: string[];
+    };
     topFailureReasons: Array<{
       reason: string;
       count: number;
@@ -76,14 +87,49 @@ test("onboarding funnel report aggregates completion, timings, drop-off, and fai
     medianCompletionSeconds: 420,
     medianCompletionMinutes: 7
   });
-  assert.equal(report.stageReports.find((stage) => stage.id === "tutorial_step_2_seen")?.reachedCount, 4);
-  assert.equal(report.stageReports.find((stage) => stage.id === "tutorial_step_3_seen")?.dropOffCount, 1);
-  assert.equal(report.stageReports.find((stage) => stage.id === "onboarding_completed")?.dropOffCount, 1);
+  assert.equal(report.pmSummary.focusChainLabel, "Tutorial Completed -> First Campaign Mission Started -> First Battle Settled -> First Reward Claimed");
+  assert.deepEqual(report.pmSummary.focusStages, [
+    {
+      id: "onboarding_completed",
+      label: "Onboarding Completed",
+      reachedCount: 5,
+      dropOffCount: 0,
+      dropOffRateFromPrevious: 0
+    },
+    {
+      id: "first_campaign_mission_started",
+      label: "First Campaign Mission Started",
+      reachedCount: 4,
+      dropOffCount: 1,
+      dropOffRateFromPrevious: 0.2
+    },
+    {
+      id: "first_battle_settled",
+      label: "First Battle Settled",
+      reachedCount: 3,
+      dropOffCount: 1,
+      dropOffRateFromPrevious: 0.25
+    },
+    {
+      id: "first_reward_claimed",
+      label: "First Reward Claimed",
+      reachedCount: 2,
+      dropOffCount: 1,
+      dropOffRateFromPrevious: 0.3333
+    }
+  ]);
+  assert.match(report.pmSummary.narrative[0] ?? "", /2\/6 entrants reached the full post-tutorial chain/);
+  assert.equal(report.stageReports.find((stage) => stage.id === "tutorial_step_2_seen")?.reachedCount, 5);
+  assert.equal(report.stageReports.find((stage) => stage.id === "tutorial_step_3_seen")?.dropOffCount, 0);
+  assert.equal(report.stageReports.find((stage) => stage.id === "onboarding_completed")?.reachedCount, 5);
+  assert.equal(report.stageReports.find((stage) => stage.id === "first_campaign_mission_started")?.reachedCount, 4);
+  assert.equal(report.stageReports.find((stage) => stage.id === "first_battle_settled")?.dropOffCount, 1);
+  assert.equal(report.stageReports.find((stage) => stage.id === "first_reward_claimed")?.dropOffCount, 1);
   assert.deepEqual(
     report.topFailureReasons.map((failure) => [failure.reason, failure.count, failure.playerCount]),
     [
+      ["manual_exit", 2, 1],
       ["disconnect", 1, 1],
-      ["manual_exit", 1, 1],
       ["timeout", 1, 1],
       ["validation_failure", 1, 1]
     ]
@@ -94,7 +140,10 @@ test("onboarding funnel report aggregates completion, timings, drop-off, and fai
   assert.equal(report.regressions.some((item) => item.startsWith("median_completion_time_above_threshold:")), true);
 
   const markdown = fs.readFileSync(markdownOutputPath, "utf8");
+  assert.match(markdown, /## PM Summary/);
+  assert.match(markdown, /Focus chain: Tutorial Completed -> First Campaign Mission Started -> First Battle Settled -> First Reward Claimed/);
   assert.match(markdown, /## Canonical Stages/);
+  assert.match(markdown, /## Focus Chain/);
   assert.match(markdown, /Completion rate: 33\.3%/);
   assert.match(markdown, /`disconnect` count=1/);
   assert.match(markdown, /Failure reason coverage: 4\/6 entrants/);


### PR DESCRIPTION
## Summary
- extend the onboarding funnel report with PM-facing focus-chain and narrative summaries
- refresh the funnel fixtures to exercise post-tutorial campaign, battle, and reward stages
- update the funnel dashboard guidance around the new summary slices

## Validation
- /Users/grace/Documents/project/codex/ProjectVeil/node_modules/.bin/tsx --test ./scripts/test/onboarding-funnel-report.test.ts

Closes #1477