### PR TITLE
feat: add campaign route guidance cards

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-campaign-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-campaign-panel.ts
@@ -35,6 +35,98 @@ export interface CocosCampaignPanelView {
   actions: CocosCampaignPanelActionView[];
 }
 
+function parseCampaignChapterOrder(chapterId: string | null | undefined): number | null {
+  const matched = /chapter-?(\d+)/i.exec(chapterId?.trim() ?? "");
+  if (!matched) {
+    return null;
+  }
+
+  const value = Number(matched[1]);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function formatCampaignChapterLabel(chapterId: string | null | undefined): string {
+  const order = parseCampaignChapterOrder(chapterId);
+  return order ? `第 ${order} 章` : (chapterId?.trim() || "未知章节");
+}
+
+function resolveCurrentChapterMissions(
+  campaign: CocosCampaignSummary | null,
+  mission: CampaignMissionState | null
+): CampaignMissionState[] {
+  const chapterId = mission?.chapterId ?? null;
+  if (!campaign || !chapterId) {
+    return [];
+  }
+  return campaign.missions.filter((entry) => entry.chapterId === chapterId);
+}
+
+function resolveNextRouteMission(
+  campaign: CocosCampaignSummary | null,
+  mission: CampaignMissionState | null
+): CampaignMissionState | null {
+  if (!campaign || !mission) {
+    return null;
+  }
+
+  const missions = campaign.missions;
+  const nextMission = campaign.nextMissionId
+    ? missions.find((entry) => entry.id === campaign.nextMissionId) ?? null
+    : null;
+  if (nextMission) {
+    return nextMission;
+  }
+
+  const currentIndex = missions.findIndex((entry) => entry.id === mission.id);
+  if (currentIndex >= 0) {
+    return missions.slice(currentIndex + 1).find((entry) => entry.status !== "completed") ?? null;
+  }
+
+  return missions.find((entry) => entry.status !== "completed") ?? null;
+}
+
+function formatUnlockRequirementSummary(mission: CampaignMissionState | null): string | null {
+  const unmet = mission?.unlockRequirements?.filter((entry) => entry.satisfied !== true) ?? [];
+  if (unmet.length === 0) {
+    return null;
+  }
+  return unmet.map((entry) => entry.description).join(" / ");
+}
+
+function buildCampaignRouteLines(
+  campaign: CocosCampaignSummary | null,
+  mission: CampaignMissionState | null,
+  activeMission: CampaignMissionState | null
+): string[] {
+  if (!campaign || !mission) {
+    return ["战役数据未加载", "请稍后重试。"];
+  }
+
+  const currentChapterMissions = resolveCurrentChapterMissions(campaign, mission);
+  const completedInChapter = currentChapterMissions.filter((entry) => entry.status === "completed").length;
+  const nextRouteMission = resolveNextRouteMission(campaign, mission);
+  const lockedFollowupMission =
+    currentChapterMissions.find((entry) => entry.order > mission.order && entry.status === "locked")
+    ?? campaign.missions.find(
+      (entry) =>
+        entry.status === "locked"
+        && parseCampaignChapterOrder(entry.chapterId) != null
+        && (parseCampaignChapterOrder(entry.chapterId) ?? 0) >= (parseCampaignChapterOrder(mission.chapterId) ?? 0)
+    )
+    ?? null;
+
+  return [
+    `${formatCampaignChapterLabel(mission.chapterId)} · 已完成 ${completedInChapter}/${Math.max(1, currentChapterMissions.length)}`,
+    nextRouteMission
+      ? `路线下一步 ${formatCampaignChapterLabel(nextRouteMission.chapterId)} / ${nextRouteMission.name}`
+      : "路线下一步 当前战役线已全部完成",
+    lockedFollowupMission
+      ? `后续解锁 ${lockedFollowupMission.name} · ${formatUnlockRequirementSummary(lockedFollowupMission) ?? "满足前置后开启"}`
+      : "后续解锁 当前章节之后暂无额外门槛",
+    activeMission ? `进行中 ${activeMission.name}` : "进行中 当前没有已启动任务"
+  ];
+}
+
 function formatMissionStatus(status: CampaignMissionState["status"]): string {
   switch (status) {
     case "completed":
@@ -109,11 +201,9 @@ export function buildCocosCampaignPanelView(input: CocosCampaignPanelInput): Coc
       : "需要正式账号会话才能读取战役进度。";
 
   const progressLines = input.campaign
-    ? [
-        input.campaign.nextMissionId ? `下一任务 ${input.campaign.nextMissionId}` : "下一任务 当前战役线已全部完成",
-        activeMission ? `进行中 ${activeMission.name}` : "进行中 当前没有已启动任务",
-        mission ? `聚焦 ${mission.chapterId} / ${mission.name}` : "聚焦 等待任务数据"
-      ]
+    ? mission
+      ? [...buildCampaignRouteLines(input.campaign, mission, activeMission), `聚焦 ${mission.chapterId} / ${mission.name}`]
+      : ["战役数据未加载", input.statusMessage || "请稍后重试。"]
     : ["战役数据未加载", input.statusMessage || "请稍后重试。"];
 
   const missionLines = mission

--- a/apps/cocos-client/assets/scripts/cocos-lobby-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby-panel-model.ts
@@ -100,6 +100,30 @@ function resolveNextCampaignMission(campaign: CocosCampaignSummary | null) {
   );
 }
 
+function parseCampaignChapterOrder(chapterId: string | null | undefined): number | null {
+  const matched = /chapter-?(\d+)/i.exec(chapterId?.trim() ?? "");
+  if (!matched) {
+    return null;
+  }
+
+  const value = Number(matched[1]);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function formatCampaignChapterLabel(chapterId: string | null | undefined): string {
+  const order = parseCampaignChapterOrder(chapterId);
+  return order ? `第 ${order} 章` : (chapterId?.trim() || "未知章节");
+}
+
+function formatUnlockRequirementSummary(mission: CocosCampaignSummary["missions"][number] | null): string | null {
+  const unmet = mission?.unlockRequirements?.filter((entry) => entry.satisfied !== true) ?? [];
+  if (unmet.length === 0) {
+    return null;
+  }
+
+  return unmet.map((entry) => entry.description).join(" / ");
+}
+
 function countUnclaimedDailyDungeonRuns(dailyDungeon: CocosDailyDungeonSummary | null): number {
   return dailyDungeon?.runs.filter((run) => !run.rewardClaimedAt).length ?? 0;
 }
@@ -124,9 +148,19 @@ export function buildLobbyPveFrontdoorView(
   }
 
   const nextMission = resolveNextCampaignMission(state.campaign ?? null);
+  const currentChapterMissions =
+    nextMission && state.campaign ? state.campaign.missions.filter((mission) => mission.chapterId === nextMission.chapterId) : [];
+  const completedInCurrentChapter = currentChapterMissions.filter((mission) => mission.status === "completed").length;
+  const lockedFollowupMission =
+    state.campaign?.missions.find(
+      (mission) =>
+        mission.status === "locked"
+        && parseCampaignChapterOrder(mission.chapterId) != null
+        && (parseCampaignChapterOrder(mission.chapterId) ?? 0) >= (parseCampaignChapterOrder(nextMission?.chapterId) ?? 0)
+    ) ?? null;
   const unclaimedDailyDungeonRuns = countUnclaimedDailyDungeonRuns(state.dailyDungeon ?? null);
   const campaignSummary = nextMission
-    ? `主线 ${nextMission.chapterId} · ${nextMission.name} · 推荐等级 ${nextMission.recommendedHeroLevel}`
+    ? `${formatCampaignChapterLabel(nextMission.chapterId)} · 已完成 ${completedInCurrentChapter}/${Math.max(1, currentChapterMissions.length)} · 下一任务 ${nextMission.name} · 推荐等级 ${nextMission.recommendedHeroLevel}`
     : state.campaign
       ? `主线已推进 ${state.campaign.completedCount}/${state.campaign.totalMissions}，当前章节暂时没有新的可用任务。`
       : `主线待同步 · ${state.campaignStatus || "正在读取章节进度..."}`;
@@ -137,6 +171,8 @@ export function buildLobbyPveFrontdoorView(
     : `每日地城待同步 · ${state.dailyDungeonStatus || "正在读取今日配置..."}`;
   const focusSummary = unclaimedDailyDungeonRuns > 0
     ? `今日焦点：先领取地城奖励，再推进 ${nextMission?.name ?? "当前主线"}。`
+    : lockedFollowupMission
+      ? `章节路线：完成 ${nextMission?.name ?? "当前任务"} 后可解锁 ${lockedFollowupMission.name}${formatUnlockRequirementSummary(lockedFollowupMission) ? ` · ${formatUnlockRequirementSummary(lockedFollowupMission)}` : ""}。`
     : nextMission && state.dailyDungeon
       ? `今日焦点：推进 ${nextMission.name}，顺手清掉 ${state.dailyDungeon.dungeon.name}。`
       : nextMission

--- a/apps/cocos-client/test/VeilCampaignPanel.test.ts
+++ b/apps/cocos-client/test/VeilCampaignPanel.test.ts
@@ -117,6 +117,7 @@ test("VeilCampaignPanel renders campaign cards and routes enabled mission action
   component.render(state);
 
   assert.match(readCardLabel(node, "CampaignPanelHeader"), /战役任务/);
+  assert.match(readCardLabel(node, "CampaignPanelHeader"), /第 1 章 · 已完成 0\/2/);
   assert.match(readCardLabel(node, "CampaignPanelMission"), /余烬哨站 · 可进行/);
   assert.match(readCardLabel(node, "CampaignPanelObjectives"), /守住南门两回合/);
   assert.match(readCardLabel(node, "CampaignPanelReward"), /宝石 \+25/);
@@ -156,6 +157,7 @@ test("VeilCampaignPanel disables unavailable actions after mission start and kee
   component.render(state);
 
   assert.match(readCardLabel(node, "CampaignPanelDialogue"), /开场对话 1\/1/);
+  assert.match(readCardLabel(node, "CampaignPanelHeader"), /后续解锁 荆墙驿路/);
   assert.match(readCardLabel(node, "CampaignPanelStatus"), /任务序号 1\/2/);
 
   pressNode(findNode(node, "CampaignPanelAction-start"));

--- a/apps/cocos-client/test/cocos-campaign-panel.test.ts
+++ b/apps/cocos-client/test/cocos-campaign-panel.test.ts
@@ -121,6 +121,9 @@ test("buildCocosCampaignPanelView exposes start action for an available mission 
   const view = buildCocosCampaignPanelView(createInput());
 
   assert.match(view.subtitle, /完成 0\/2/);
+  assert.match(view.progressLines.join("\n"), /第 1 章 · 已完成 0\/2/);
+  assert.match(view.progressLines.join("\n"), /路线下一步 第 1 章 \/ 余烬哨站/);
+  assert.match(view.progressLines.join("\n"), /后续解锁 荆墙驿路 · Complete 余烬哨站\./);
   assert.match(view.missionLines.join("\n"), /余烬哨站/);
   assert.deepEqual(
     view.actions.find((action) => action.id === "start"),
@@ -222,7 +225,7 @@ test("buildCocosCampaignPanelView resolves completed active missions and pending
 
   const view = buildCocosCampaignPanelView(input);
 
-  assert.match(view.progressLines.join("\n"), /下一任务 当前战役线已全部完成/);
+  assert.match(view.progressLines.join("\n"), /路线下一步 第 1 章 \/ 荆墙驿路/);
   assert.match(view.progressLines.join("\n"), /进行中 余烬哨站/);
   assert.match(view.missionLines.join("\n"), /完成于 2026-04-05T10:00:00.000Z/);
   assert.match(view.statusLines.join("\n"), /正在提交任务完成/);

--- a/apps/cocos-client/test/cocos-lobby-panel.test.ts
+++ b/apps/cocos-client/test/cocos-lobby-panel.test.ts
@@ -171,6 +171,7 @@ test("PVE frontdoor view surfaces the next campaign mission and claimable daily 
   );
 
   assert.match(view.campaignSummary, /前哨侦察/);
+  assert.match(view.campaignSummary, /第 1 章/);
   assert.match(view.dailyDungeonSummary, /余烬熔炉/);
   assert.match(view.dailyDungeonSummary, /1 份奖励待领取/);
   assert.match(view.focusSummary, /先领取地城奖励/);
@@ -334,6 +335,7 @@ test("VeilLobbyPanel renders the PVE frontdoor and wires campaign plus daily dun
 
   assert.match(readCardLabel(node, "LobbyPveFrontdoor"), /今日 PVE 路线/);
   assert.match(readCardLabel(node, "LobbyPveFrontdoor"), /前哨侦察/);
+  assert.match(readCardLabel(node, "LobbyPveFrontdoor"), /第 1 章/);
   assert.match(readCardLabel(node, "LobbyPveFrontdoor"), /余烬熔炉/);
 
   pressNode(findNode(node, "LobbyPveCampaignAction"));


### PR DESCRIPTION
## Summary
- strengthen campaign chapter progress copy with clearer route and unlock guidance
- surface next-route mission context in the lobby PVE front door
- extend campaign/lobby tests around route-card handoff behavior

Closes #1482