### PR TITLE
feat: add chapter atlas guidance to V0.7 campaign flow

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilCampaignPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilCampaignPanel.ts
@@ -101,6 +101,21 @@ export class VeilCampaignPanel extends Component {
     );
 
     cursorY = this.renderCard(
+      "CampaignPanelChapterAtlas",
+      0,
+      cursorY,
+      contentWidth,
+      Math.max(108, 34 + view.chapterAtlasLines.length * 16),
+      ["章节图谱", ...view.chapterAtlasLines],
+      {
+        fill: CARD_FILL,
+        stroke: new Color(220, 230, 244, 56)
+      },
+      13,
+      16
+    );
+
+    cursorY = this.renderCard(
       "CampaignPanelMission",
       0,
       cursorY,

--- a/apps/cocos-client/assets/scripts/cocos-campaign-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-campaign-panel.ts
@@ -27,6 +27,7 @@ export interface CocosCampaignPanelView {
   title: string;
   subtitle: string;
   progressLines: string[];
+  chapterAtlasLines: string[];
   missionLines: string[];
   objectiveLines: string[];
   rewardLines: string[];
@@ -91,6 +92,113 @@ function formatUnlockRequirementSummary(mission: CampaignMissionState | null): s
     return null;
   }
   return unmet.map((entry) => entry.description).join(" / ");
+}
+
+function formatObjectiveKindLabel(kind: CampaignMissionState["objectives"][number]["kind"]): string {
+  switch (kind) {
+    case "capture":
+      return "夺点";
+    case "defeat":
+      return "击破";
+    case "escort":
+      return "护送";
+    case "hold":
+      return "坚守";
+    default:
+      return kind;
+  }
+}
+
+function summarizeChapterObjectiveKinds(missions: CampaignMissionState[]): string {
+  const kinds = new Set<string>();
+  for (const mission of missions) {
+    for (const objective of mission.objectives) {
+      kinds.add(formatObjectiveKindLabel(objective.kind));
+    }
+  }
+
+  return kinds.size > 0 ? [...kinds].slice(0, 3).join(" / ") : "探索推进";
+}
+
+function summarizeChapterRewardFocus(missions: CampaignMissionState[]): string {
+  let gemCount = 0;
+  let goldCount = 0;
+  let woodCount = 0;
+  let oreCount = 0;
+  let cosmeticCount = 0;
+  for (const mission of missions) {
+    gemCount += mission.reward.gems ?? 0;
+    goldCount += mission.reward.resources?.gold ?? 0;
+    woodCount += mission.reward.resources?.wood ?? 0;
+    oreCount += mission.reward.resources?.ore ?? 0;
+    if (mission.reward.cosmeticId) {
+      cosmeticCount += 1;
+    }
+  }
+
+  const focus: string[] = [];
+  if (gemCount > 0) {
+    focus.push("宝石");
+  }
+  if (goldCount >= Math.max(woodCount, oreCount) && goldCount > 0) {
+    focus.push("金币");
+  }
+  if (woodCount > goldCount && woodCount >= oreCount) {
+    focus.push("木材");
+  }
+  if (oreCount > goldCount && oreCount > woodCount) {
+    focus.push("矿石");
+  }
+  if (cosmeticCount > 0) {
+    focus.push("外观");
+  }
+
+  return focus.length > 0 ? focus.join(" / ") : "章节奖励待同步";
+}
+
+function resolveNextChapterMission(
+  campaign: CocosCampaignSummary | null,
+  mission: CampaignMissionState | null
+): CampaignMissionState | null {
+  if (!campaign || !mission) {
+    return null;
+  }
+
+  const currentChapterOrder = parseCampaignChapterOrder(mission.chapterId) ?? 0;
+  return (
+    campaign.missions.find((entry) => (parseCampaignChapterOrder(entry.chapterId) ?? 0) > currentChapterOrder)
+    ?? null
+  );
+}
+
+function buildChapterAtlasLines(
+  campaign: CocosCampaignSummary | null,
+  mission: CampaignMissionState | null
+): string[] {
+  if (!campaign || !mission) {
+    return ["章节图谱待同步", "加载战役数据后会展示章节差异与路线密度。"];
+  }
+
+  const currentChapterMissions = resolveCurrentChapterMissions(campaign, mission);
+  const nextChapterMission = resolveNextChapterMission(campaign, mission);
+  const nextChapterMissions = nextChapterMission
+    ? campaign.missions.filter((entry) => entry.chapterId === nextChapterMission.chapterId)
+    : [];
+  const recommendedLevels = currentChapterMissions.map((entry) => entry.recommendedHeroLevel);
+  const currentMinLevel = recommendedLevels.length > 0 ? Math.min(...recommendedLevels) : mission.recommendedHeroLevel;
+  const currentMaxLevel = recommendedLevels.length > 0 ? Math.max(...recommendedLevels) : mission.recommendedHeroLevel;
+  const currentBossCount = currentChapterMissions.filter((entry) => Boolean(entry.bossEncounterName)).length;
+  const nextUnlockSummary = nextChapterMission ? formatUnlockRequirementSummary(nextChapterMission) : null;
+
+  return [
+    `${formatCampaignChapterLabel(mission.chapterId)} · ${currentChapterMissions.length} 个任务 · 推荐等级 ${currentMinLevel}-${currentMaxLevel}`,
+    `章节节奏 ${summarizeChapterObjectiveKinds(currentChapterMissions)} · ${currentBossCount > 0 ? `首领战 ${currentBossCount} 场` : "前线遭遇推进"}`,
+    `章节收益 ${summarizeChapterRewardFocus(currentChapterMissions)}`,
+    nextChapterMission
+      ? `下一章节 ${formatCampaignChapterLabel(nextChapterMission.chapterId)} · ${nextChapterMissions.length} 个任务 · 首站 ${nextChapterMission.name}`
+      : "下一章节 当前主线已推进到末端章节",
+    nextUnlockSummary ? `开启条件 ${nextUnlockSummary}` : "开启条件 当前已满足后续章节门槛"
+  ];
 }
 
 function buildCampaignRouteLines(
@@ -205,6 +313,7 @@ export function buildCocosCampaignPanelView(input: CocosCampaignPanelInput): Coc
       ? [...buildCampaignRouteLines(input.campaign, mission, activeMission), `聚焦 ${mission.chapterId} / ${mission.name}`]
       : ["战役数据未加载", input.statusMessage || "请稍后重试。"]
     : ["战役数据未加载", input.statusMessage || "请稍后重试。"];
+  const chapterAtlasLines = buildChapterAtlasLines(input.campaign, mission);
 
   const missionLines = mission
     ? [
@@ -271,6 +380,7 @@ export function buildCocosCampaignPanelView(input: CocosCampaignPanelInput): Coc
     title: "战役任务",
     subtitle,
     progressLines,
+    chapterAtlasLines,
     missionLines,
     objectiveLines,
     rewardLines: mission ? formatRewardLines(mission.reward) : ["等待任务奖励。"],

--- a/apps/cocos-client/assets/scripts/cocos-lobby-panel-model.ts
+++ b/apps/cocos-client/assets/scripts/cocos-lobby-panel-model.ts
@@ -158,9 +158,15 @@ export function buildLobbyPveFrontdoorView(
         && parseCampaignChapterOrder(mission.chapterId) != null
         && (parseCampaignChapterOrder(mission.chapterId) ?? 0) >= (parseCampaignChapterOrder(nextMission?.chapterId) ?? 0)
     ) ?? null;
+  const nextChapterMission =
+    state.campaign?.missions.find(
+      (mission) =>
+        mission !== nextMission
+        && (parseCampaignChapterOrder(mission.chapterId) ?? 0) > (parseCampaignChapterOrder(nextMission?.chapterId) ?? 0)
+    ) ?? null;
   const unclaimedDailyDungeonRuns = countUnclaimedDailyDungeonRuns(state.dailyDungeon ?? null);
   const campaignSummary = nextMission
-    ? `${formatCampaignChapterLabel(nextMission.chapterId)} · 已完成 ${completedInCurrentChapter}/${Math.max(1, currentChapterMissions.length)} · 下一任务 ${nextMission.name} · 推荐等级 ${nextMission.recommendedHeroLevel}`
+    ? `${formatCampaignChapterLabel(nextMission.chapterId)} · 已完成 ${completedInCurrentChapter}/${Math.max(1, currentChapterMissions.length)} · 下一任务 ${nextMission.name} · 推荐等级 ${nextMission.recommendedHeroLevel}${nextChapterMission ? ` · 下章预告 ${formatCampaignChapterLabel(nextChapterMission.chapterId)}` : ""}`
     : state.campaign
       ? `主线已推进 ${state.campaign.completedCount}/${state.campaign.totalMissions}，当前章节暂时没有新的可用任务。`
       : `主线待同步 · ${state.campaignStatus || "正在读取章节进度..."}`;
@@ -173,6 +179,8 @@ export function buildLobbyPveFrontdoorView(
     ? `今日焦点：先领取地城奖励，再推进 ${nextMission?.name ?? "当前主线"}。`
     : lockedFollowupMission
       ? `章节路线：完成 ${nextMission?.name ?? "当前任务"} 后可解锁 ${lockedFollowupMission.name}${formatUnlockRequirementSummary(lockedFollowupMission) ? ` · ${formatUnlockRequirementSummary(lockedFollowupMission)}` : ""}。`
+    : nextChapterMission
+      ? `章节预告：${formatCampaignChapterLabel(nextMission?.chapterId)} 之后会进入 ${formatCampaignChapterLabel(nextChapterMission.chapterId)} · ${nextChapterMission.name}。`
     : nextMission && state.dailyDungeon
       ? `今日焦点：推进 ${nextMission.name}，顺手清掉 ${state.dailyDungeon.dungeon.name}。`
       : nextMission

--- a/apps/cocos-client/test/cocos-campaign-panel.test.ts
+++ b/apps/cocos-client/test/cocos-campaign-panel.test.ts
@@ -10,7 +10,7 @@ import type { CocosCampaignSummary } from "../assets/scripts/cocos-lobby.ts";
 function createCampaignSummary(): CocosCampaignSummary {
   return {
     completedCount: 0,
-    totalMissions: 2,
+    totalMissions: 3,
     nextMissionId: "chapter1-ember-watch",
     completionPercent: 0,
     missions: [
@@ -93,6 +93,44 @@ function createCampaignSummary(): CocosCampaignSummary {
             satisfied: false
           }
         ]
+      },
+      {
+        id: "chapter2-ashwake-line",
+        missionId: "chapter2-ashwake-line",
+        chapterId: "chapter2",
+        order: 1,
+        mapId: "ashwake-line",
+        name: "灰烬烽线",
+        description: "向北推进到第二道烽烟线。",
+        recommendedHeroLevel: 5,
+        enemyArmyTemplateId: "shadow_hexer",
+        enemyArmyCount: 3,
+        enemyStatMultiplier: 1.2,
+        objectives: [
+          {
+            id: "capture-spire",
+            description: "夺下烟烽塔",
+            kind: "capture",
+            gate: "end"
+          }
+        ],
+        reward: {
+          resources: {
+            gold: 180,
+            ore: 4
+          }
+        },
+        attempts: 0,
+        status: "locked",
+        unlockRequirements: [
+          {
+            type: "mission_complete",
+            description: "Complete 荆墙驿路.",
+            missionId: "chapter1-thornwall-road",
+            chapterId: "chapter1",
+            satisfied: false
+          }
+        ]
       }
     ]
   };
@@ -120,10 +158,13 @@ test("resolveCampaignPanelMission prefers selected mission and falls back to nex
 test("buildCocosCampaignPanelView exposes start action for an available mission before dialogue begins", () => {
   const view = buildCocosCampaignPanelView(createInput());
 
-  assert.match(view.subtitle, /完成 0\/2/);
+  assert.match(view.subtitle, /完成 0\/3/);
   assert.match(view.progressLines.join("\n"), /第 1 章 · 已完成 0\/2/);
   assert.match(view.progressLines.join("\n"), /路线下一步 第 1 章 \/ 余烬哨站/);
   assert.match(view.progressLines.join("\n"), /后续解锁 荆墙驿路 · Complete 余烬哨站\./);
+  assert.match(view.chapterAtlasLines.join("\n"), /第 1 章 · 2 个任务 · 推荐等级 3-4/);
+  assert.match(view.chapterAtlasLines.join("\n"), /章节节奏 坚守 \/ 护送/);
+  assert.match(view.chapterAtlasLines.join("\n"), /下一章节 第 2 章 · 1 个任务 · 首站 灰烬烽线/);
   assert.match(view.missionLines.join("\n"), /余烬哨站/);
   assert.deepEqual(
     view.actions.find((action) => action.id === "start"),
@@ -175,6 +216,7 @@ test("buildCocosCampaignPanelView surfaces loading fallback copy before campaign
 
   assert.equal(view.subtitle, "正在同步战役面板...");
   assert.deepEqual(view.progressLines, ["战役数据未加载", "请稍后重试。"]);
+  assert.deepEqual(view.chapterAtlasLines, ["章节图谱待同步", "加载战役数据后会展示章节差异与路线密度。"]);
   assert.deepEqual(view.objectiveLines, ["等待任务目标。"]);
   assert.deepEqual(view.rewardLines, ["等待任务奖励。"]);
   assert.deepEqual(view.dialogueLines, ["等待任务对话。"]);

--- a/apps/cocos-client/test/cocos-lobby-panel.test.ts
+++ b/apps/cocos-client/test/cocos-lobby-panel.test.ts
@@ -48,10 +48,35 @@ function createCampaignSummaryFixture() {
         objectives: [],
         reward: { resources: { gold: 120 } },
         status: "available" as const
+      },
+      {
+        id: "chapter-2-breach",
+        missionId: "chapter-2-breach",
+        chapterId: "chapter-2",
+        mapId: "breach-map",
+        name: "灰脊突破口",
+        description: "撕开第二章防线。",
+        enemyArmyTemplateId: "shadow_hexer",
+        order: 1,
+        recommendedHeroLevel: 4,
+        enemyArmyCount: 14,
+        enemyStatMultiplier: 1.15,
+        objectives: [],
+        reward: { resources: { gold: 180, ore: 8 } },
+        status: "locked" as const,
+        unlockRequirements: [
+          {
+            type: "mission_complete",
+            description: "完成前哨侦察",
+            missionId: "chapter-1-scout",
+            chapterId: "chapter-1",
+            satisfied: false
+          }
+        ]
       }
     ],
     completedCount: 0,
-    totalMissions: 3,
+    totalMissions: 2,
     nextMissionId: "chapter-1-scout",
     completionPercent: 0
   };
@@ -207,11 +232,29 @@ test("PVE frontdoor view surfaces the next campaign mission and claimable daily 
 
   assert.match(view.campaignSummary, /前哨侦察/);
   assert.match(view.campaignSummary, /第 1 章/);
+  assert.match(view.campaignSummary, /下章预告 第 2 章/);
   assert.match(view.dailyDungeonSummary, /余烬熔炉/);
   assert.match(view.dailyDungeonSummary, /1 份奖励待领取/);
   assert.match(view.focusSummary, /先领取地城奖励/);
   assert.equal(view.campaignActionEnabled, true);
   assert.equal(view.dailyDungeonActionEnabled, true);
+});
+
+test("PVE frontdoor view falls back to chapter preview when there are no daily dungeon claims waiting", () => {
+  const view = buildLobbyPveFrontdoorView(
+    createLobbyState({
+      authMode: "account",
+      campaign: createCampaignSummaryFixture(),
+      campaignStatus: "战役面板已就绪。",
+      dailyDungeon: {
+        ...createDailyDungeonSummaryFixture(),
+        runs: []
+      },
+      dailyDungeonStatus: "剩余 3 次挑战。"
+    })
+  );
+
+  assert.match(view.focusSummary, /章节路线：完成 前哨侦察 后可解锁 灰脊突破口 · 完成前哨侦察。/);
 });
 
 test("showcase gallery inventory stays aligned with the configured hero, terrain, building and unit counts", () => {


### PR DESCRIPTION
## Summary
- add a chapter-atlas layer to the Cocos campaign panel so chapter density and next-chapter preview are visible
- extend the lobby PVE frontdoor campaign summary with next-chapter context
- cover the new chapter atlas and chapter preview copy with focused Cocos tests

## Testing
- node --import tsx --test ./apps/cocos-client/test/cocos-campaign-panel.test.ts ./apps/cocos-client/test/cocos-lobby-panel.test.ts

Closes #1488
