### PR TITLE
feat: surface dungeon rotation chase cues for V0.7

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilProgressionPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilProgressionPanel.ts
@@ -464,6 +464,22 @@ export class VeilProgressionPanel extends Component {
     );
 
     cursorY = this.renderCard(
+      "DailyDungeonRotation",
+      0,
+      cursorY,
+      contentWidth,
+      Math.max(78, 34 + (view.rotationLines.length + 1) * 15),
+      [view.rotationTitle, ...view.rotationLines],
+      {
+        fill: CARD_FILL,
+        stroke: new Color(220, 230, 244, 56)
+      },
+      null,
+      12,
+      15
+    );
+
+    cursorY = this.renderCard(
       "DailyDungeonEvent",
       0,
       cursorY,
@@ -473,6 +489,22 @@ export class VeilProgressionPanel extends Component {
       {
         fill: CARD_FILL,
         stroke: new Color(220, 230, 244, 56)
+      },
+      null,
+      12,
+      15
+    );
+
+    cursorY = this.renderCard(
+      "DailyDungeonChase",
+      0,
+      cursorY,
+      contentWidth,
+      Math.max(78, 34 + (view.chaseLines.length + 1) * 15),
+      ["今日追逐", ...view.chaseLines],
+      {
+        fill: CARD_HIGHLIGHT_FILL,
+        stroke: new Color(244, 236, 208, 82)
       },
       null,
       12,
@@ -897,7 +929,17 @@ export class VeilProgressionPanel extends Component {
   }
 
   private hideDailyDungeonNodes(): void {
-    this.hideNodesByPrefix(["DailyDungeonHeader", "DailyDungeonEvent", "DailyDungeonRefresh", "DailyDungeonClose", "DailyDungeonFloor-", "DailyDungeonLeaderboard", "DailyDungeonMyRank"]);
+    this.hideNodesByPrefix([
+      "DailyDungeonHeader",
+      "DailyDungeonRotation",
+      "DailyDungeonEvent",
+      "DailyDungeonChase",
+      "DailyDungeonRefresh",
+      "DailyDungeonClose",
+      "DailyDungeonFloor-",
+      "DailyDungeonLeaderboard",
+      "DailyDungeonMyRank"
+    ]);
   }
 
   private hideEventLeaderboardNodes(): void {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -1737,6 +1737,7 @@ export class VeilRoot extends Component {
         dailyDungeon: buildCocosDailyDungeonPanelView({
           dailyDungeon: this.dailyDungeonSummary,
           activeEvent: null,
+          seasonProgress: this.seasonProgress,
           currentPlayerId: this.playerId,
           pendingFloor: this.pendingDailyDungeonFloor,
           pendingClaimRunId: this.pendingDailyDungeonClaimRunId,

--- a/apps/cocos-client/assets/scripts/cocos-progression-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-progression-panel.ts
@@ -1,4 +1,5 @@
 import { getBattlePassConfig, type BattlePassRewardConfig, type BattlePassTierConfig } from "./project-shared/world-config.ts";
+import dailyDungeonsConfigDocument from "../../../../configs/daily-dungeons.json";
 import type {
   DailyDungeonDefinition,
   DailyDungeonReward,
@@ -122,6 +123,9 @@ export interface CocosDailyDungeonPanelView {
   title: string;
   subtitle: string;
   attemptSummaryLabel: string;
+  rotationTitle: string;
+  rotationLines: string[];
+  chaseLines: string[];
   statusLabel: string;
   floors: CocosDailyDungeonFloorView[];
   eventTitle: string;
@@ -133,11 +137,14 @@ export interface CocosDailyDungeonPanelView {
 export interface BuildCocosDailyDungeonPanelInput {
   dailyDungeon: CocosDailyDungeonSummary | null;
   activeEvent: CocosDailyDungeonEvent | null;
+  seasonProgress?: CocosSeasonProgress | null;
   currentPlayerId: string;
   pendingFloor: number | null;
   pendingClaimRunId: string | null;
   statusLabel: string;
 }
+
+const DAILY_DUNGEON_ROTATIONS = (dailyDungeonsConfigDocument as { dungeons: DailyDungeonDefinition[] }).dungeons;
 
 function formatRewardLabel(reward: BattlePassRewardConfig): string {
   if ((reward.gems ?? 0) > 0) {
@@ -199,6 +206,34 @@ function formatDurationLabel(remainingMs: number): string {
   return `${hours} 小时`;
 }
 
+function formatActiveWindowLabel(dungeon: Partial<DailyDungeonDefinition>): string {
+  const startDate = dungeon.activeWindow?.startDate?.trim();
+  const endDate = dungeon.activeWindow?.endDate?.trim();
+  if (!startDate || !endDate) {
+    return "轮换窗口待同步";
+  }
+
+  return `${startDate} 至 ${endDate}`;
+}
+
+function resolveNextDungeonRotation(dungeonId: string): DailyDungeonDefinition | null {
+  const currentIndex = DAILY_DUNGEON_ROTATIONS.findIndex((entry) => entry.id === dungeonId);
+  if (currentIndex < 0) {
+    return DAILY_DUNGEON_ROTATIONS[0] ?? null;
+  }
+
+  return DAILY_DUNGEON_ROTATIONS[(currentIndex + 1) % DAILY_DUNGEON_ROTATIONS.length] ?? null;
+}
+
+function resolveDailyDungeonPeakRewardLabel(dungeon: DailyDungeonDefinition): string {
+  const finalFloor = dungeon.floors[dungeon.floors.length - 1] ?? dungeon.floors[0];
+  if (!finalFloor) {
+    return "奖励待同步";
+  }
+
+  return formatDailyDungeonRewardLabel(finalFloor.reward);
+}
+
 function resolveLatestRunByFloor(runs: DailyDungeonRunRecord[]): Map<number, DailyDungeonRunRecord> {
   const byFloor = new Map<number, DailyDungeonRunRecord>();
   for (const run of [...runs].sort((left, right) => right.startedAt.localeCompare(left.startedAt))) {
@@ -221,6 +256,69 @@ function resolveRewardProgressLabel(event: CocosDailyDungeonEvent): string {
   }
 
   return `下一奖励 ${formatSeasonalEventRewardLabel(nextReward)}`;
+}
+
+function resolveBattlePassChaseLabel(progress: CocosSeasonProgress | null | undefined): string {
+  if (!progress || !progress.battlePassEnabled) {
+    return "战令追逐 当前赛季通行证未开启。";
+  }
+
+  const config = getBattlePassConfig();
+  const nextTier = config.tiers.find((tier) => tier.tier === progress.seasonPassTier + 1) ?? null;
+  if (!nextTier) {
+    return `战令追逐 当前已达 T${progress.seasonPassTier} 顶点，后续重点改为清掉未领取奖励。`;
+  }
+
+  const xpGap = Math.max(0, nextTier.xpRequired - Math.max(0, progress.seasonXp));
+  return `战令追逐 T${progress.seasonPassTier} -> T${nextTier.tier} · 还差 ${xpGap} XP · ${resolveNextRewardLabel(config, progress)}`;
+}
+
+function buildDailyDungeonRotationLines(dailyDungeon: CocosDailyDungeonSummary): string[] {
+  const current = dailyDungeon.dungeon;
+  const nextRotation = resolveNextDungeonRotation(current.id);
+  const recommendedLevels = current.floors.map((floor) => floor.recommendedHeroLevel);
+  const minLevel = recommendedLevels.length > 0 ? Math.min(...recommendedLevels) : 1;
+  const maxLevel = recommendedLevels.length > 0 ? Math.max(...recommendedLevels) : minLevel;
+
+  return [
+    `本周轮换 ${current.name} · ${formatActiveWindowLabel(current)}`,
+    nextRotation
+      ? `下轮预告 ${nextRotation.name} · ${nextRotation.activeWindow?.startDate?.trim() || "时间待同步"} 开启`
+      : "下轮预告 后续轮换待同步",
+    `难度递进 Lv${minLevel} -> Lv${maxLevel} · 峰值奖励 ${resolveDailyDungeonPeakRewardLabel(current)}`
+  ];
+}
+
+function buildDailyDungeonChaseLines(
+  dailyDungeon: CocosDailyDungeonSummary,
+  activeEvent: CocosDailyDungeonEvent | null,
+  seasonProgress: CocosSeasonProgress | null | undefined
+): string[] {
+  const unclaimedRuns = dailyDungeon.runs.filter((run) => !run.rewardClaimedAt).length;
+  const highestAttemptedFloor = dailyDungeon.runs.reduce((highest, run) => Math.max(highest, run.floor), 0);
+  const recommendedNextFloor = Math.min(
+    dailyDungeon.dungeon.floors.length,
+    Math.max(1, highestAttemptedFloor + (unclaimedRuns > 0 ? 0 : 1))
+  );
+  const lines = [
+    unclaimedRuns > 0
+      ? `今日建议 先领取 ${unclaimedRuns} 份已完成层奖励，再继续冲击更高层。`
+      : `今日建议 继续推进到第 ${recommendedNextFloor} 层，把每日次数换成赛季收益。`
+  ];
+
+  if (activeEvent) {
+    const claimableRewards = activeEvent.rewards.filter((reward) => activeEvent.player.claimableRewardIds.includes(reward.id));
+    lines.push(
+      claimableRewards.length > 0
+        ? `活动追逐 ${activeEvent.name} · 当前 ${activeEvent.player.points} 分 · 可领取 ${claimableRewards.map((reward) => reward.name).join(" / ")}`
+        : `活动追逐 ${activeEvent.name} · 当前 ${activeEvent.player.points} 分 · ${resolveRewardProgressLabel(activeEvent)}`
+    );
+  } else {
+    lines.push("活动追逐 当前没有与每日地城联动的活动，先把本周轮换奖励清干净。");
+  }
+
+  lines.push(resolveBattlePassChaseLabel(seasonProgress ?? null));
+  return lines;
 }
 
 function buildLeaderboardRows(
@@ -419,6 +517,9 @@ export function buildCocosDailyDungeonPanelView(input: BuildCocosDailyDungeonPan
       title: "每日地城",
       subtitle: "需要先同步账号会话后才能查看当日地城。",
       attemptSummaryLabel: "暂无地城数据",
+      rotationTitle: "轮换与追逐",
+      rotationLines: ["轮换待同步", "登录后会展示本周地城与下一轮预告。"],
+      chaseLines: ["追逐待同步", "登录后会显示活动与战令推进建议。"],
       statusLabel: input.statusLabel,
       floors: [],
       eventTitle: "赛季活动",
@@ -471,6 +572,9 @@ export function buildCocosDailyDungeonPanelView(input: BuildCocosDailyDungeonPan
       title: "每日地城",
       subtitle: `${dailyDungeon.dungeon.name} · ${dailyDungeon.dungeon.description}`,
       attemptSummaryLabel: `今日 ${dailyDungeon.dateKey} · 已用 ${dailyDungeon.attemptsUsed}/${dailyDungeon.dungeon.attemptLimit} 次`,
+      rotationTitle: "轮换与追逐",
+      rotationLines: buildDailyDungeonRotationLines(dailyDungeon),
+      chaseLines: buildDailyDungeonChaseLines(dailyDungeon, null, input.seasonProgress ?? null),
       statusLabel: input.statusLabel,
       floors,
       eventTitle: "赛季活动",
@@ -486,6 +590,9 @@ export function buildCocosDailyDungeonPanelView(input: BuildCocosDailyDungeonPan
     title: "每日地城",
     subtitle: `${dailyDungeon.dungeon.name} · ${dailyDungeon.dungeon.description}`,
     attemptSummaryLabel: `今日 ${dailyDungeon.dateKey} · 已用 ${dailyDungeon.attemptsUsed}/${dailyDungeon.dungeon.attemptLimit} 次 · 剩余 ${dailyDungeon.attemptsRemaining} 次`,
+    rotationTitle: "轮换与追逐",
+    rotationLines: buildDailyDungeonRotationLines(dailyDungeon),
+    chaseLines: buildDailyDungeonChaseLines(dailyDungeon, input.activeEvent, input.seasonProgress ?? null),
     statusLabel: input.statusLabel,
     floors,
     eventTitle: `${input.activeEvent.name} · 剩余 ${formatDurationLabel(input.activeEvent.remainingMs)}`,

--- a/apps/cocos-client/test/cocos-progression-panel.test.ts
+++ b/apps/cocos-client/test/cocos-progression-panel.test.ts
@@ -149,6 +149,10 @@ test("buildCocosDailyDungeonPanelView surfaces claimable runs and leaderboard st
         name: "Shadow Archives",
         description: "A rotating solo dungeon.",
         attemptLimit: 3,
+        activeWindow: {
+          startDate: "2026-04-06",
+          endDate: "2026-04-12"
+        },
         floors: [
           {
             floor: 1,
@@ -217,6 +221,13 @@ test("buildCocosDailyDungeonPanelView surfaces claimable runs and leaderboard st
         topThree: []
       }
     },
+    seasonProgress: {
+      battlePassEnabled: true,
+      seasonXp: 1200,
+      seasonPassTier: 3,
+      seasonPassPremium: false,
+      seasonPassClaimedTiers: [1]
+    },
     currentPlayerId: "player-1",
     pendingFloor: null,
     pendingClaimRunId: null,
@@ -225,6 +236,10 @@ test("buildCocosDailyDungeonPanelView surfaces claimable runs and leaderboard st
 
   assert.equal(view.floors[1]?.actionKind, "claim");
   assert.equal(view.floors[1]?.runId, "run-2");
+  assert.match(view.rotationLines.join("\n"), /本周轮换 Shadow Archives · 2026-04-06 至 2026-04-12/);
+  assert.match(view.rotationLines.join("\n"), /下轮预告 Ember Forge · 2026-04-13 开启/);
+  assert.match(view.chaseLines.join("\n"), /活动追逐 Defend the Bridge · 当前 40 分 · 可领取 Ration Cache/);
+  assert.match(view.chaseLines.join("\n"), /战令追逐 T3 -> T4 · 还差 300 XP/);
   assert.match(view.eventSummaryLabel, /可领取/);
   assert.equal(view.leaderboardRows[1]?.isCurrentPlayer, true);
   assert.match(view.myRankSummary, /#2/);
@@ -260,6 +275,10 @@ test("VeilProgressionPanel renders daily dungeon actions and refresh control", (
           name: "Shadow Archives",
           description: "A rotating solo dungeon.",
           attemptLimit: 3,
+          activeWindow: {
+            startDate: "2026-04-06",
+            endDate: "2026-04-12"
+          },
           floors: [
             {
               floor: 1,
@@ -292,6 +311,13 @@ test("VeilProgressionPanel renders daily dungeon actions and refresh control", (
         ]
       },
       activeEvent: null,
+      seasonProgress: {
+        battlePassEnabled: true,
+        seasonXp: 900,
+        seasonPassTier: 2,
+        seasonPassPremium: false,
+        seasonPassClaimedTiers: [1]
+      },
       currentPlayerId: "player-1",
       pendingFloor: null,
       pendingClaimRunId: null,
@@ -300,6 +326,8 @@ test("VeilProgressionPanel renders daily dungeon actions and refresh control", (
   });
 
   assert.match(readCardLabel(node, "DailyDungeonHeader"), /每日地城/);
+  assert.match(readCardLabel(node, "DailyDungeonRotation"), /下轮预告 Ember Forge/);
+  assert.match(readCardLabel(node, "DailyDungeonChase"), /战令追逐 T2 -> T3/);
   assert.match(readCardLabel(node, "DailyDungeonFloor-0"), /开始挑战/);
   assert.match(readCardLabel(node, "DailyDungeonFloor-1"), /领取奖励/);
 


### PR DESCRIPTION
## Summary
- add daily-dungeon rotation and chase summaries so the Cocos progression panel explains why today's run matters
- connect battle pass progress into the daily-dungeon chase summary and render dedicated rotation/chase cards
- cover the new rotation/chase UI plus the updated root wiring with focused tests

## Testing
- ./node_modules/.bin/tsx --test /Users/grace/Documents/project/codex/worktrees/ProjectVeil-issue-1489/apps/cocos-client/test/cocos-progression-panel.test.ts /Users/grace/Documents/project/codex/worktrees/ProjectVeil-issue-1489/apps/cocos-client/test/cocos-root-orchestration.test.ts

Closes #1489
