### PR TITLE
feat: add long-term growth agenda summaries for V0.7

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-account-review.ts
+++ b/apps/cocos-client/assets/scripts/cocos-account-review.ts
@@ -4,6 +4,7 @@ import {
   formatAchievementLabel,
   formatWorldEventTypeLabel,
   getLatestProgressedAchievement,
+  getNextProgressionGoalAchievement,
   getLatestUnlockedAchievement,
   type EventLogEntry,
   type PlayerBattleReportCenter,
@@ -367,8 +368,25 @@ function buildProgressionItems(snapshot: PlayerProgressionSnapshot): CocosAccoun
   const summary = snapshot.summary;
   const latestUnlocked = getLatestUnlockedAchievement(snapshot.achievements);
   const latestProgressed = getLatestProgressedAchievement(snapshot.achievements);
+  const nextGoal = getNextProgressionGoalAchievement(snapshot.achievements);
 
   const items: CocosAccountReviewItem[] = [
+    {
+      title: nextGoal ? `下一解锁目标 · ${nextGoal.title}` : "成长路线",
+      detail: nextGoal
+        ? `还差 ${Math.max(0, nextGoal.target - nextGoal.current)} 点进度 · 当前 ${nextGoal.current}/${nextGoal.target} · ${nextGoal.description}`
+        : "已解锁全部成就，接下来重点把战报、活动奖励和长期成长条线一起收满。",
+      footnote: nextGoal
+        ? latestUnlocked
+          ? `最近刚解锁 ${latestUnlocked.title} · 继续推进会更快滚起下一层成长目标`
+          : nextGoal.progressUpdatedAt
+            ? `最近推进 ${formatReviewTimestamp(nextGoal.progressUpdatedAt)}`
+            : "继续完成主线、战斗和奖励领取可稳步推高长期成长"
+        : summary.latestEventAt
+          ? `最近活跃 ${formatReviewTimestamp(summary.latestEventAt)}`
+          : "当前成长路线已全部完成",
+      emphasis: nextGoal ? "positive" : "neutral"
+    },
     {
       title: "成长概览",
       detail: formatProgressionHeadline(snapshot),

--- a/apps/cocos-client/assets/scripts/project-shared/event-log.ts
+++ b/apps/cocos-client/assets/scripts/project-shared/event-log.ts
@@ -96,6 +96,12 @@ export interface PlayerProgressionSummary {
   latestUnlockedAchievementId?: AchievementId;
   latestUnlockedAchievementTitle?: string;
   latestUnlockedAt?: string;
+  nextGoalAchievementId?: AchievementId;
+  nextGoalAchievementTitle?: string;
+  nextGoalCurrent?: number;
+  nextGoalTarget?: number;
+  nextGoalRemaining?: number;
+  nextGoalUpdatedAt?: string;
   recentEventCount: number;
   latestEventAt?: string;
 }
@@ -139,6 +145,41 @@ export function getLatestProgressedAchievement(
     progressed.sort((left, right) => {
       const progressOrder = String(right.progressUpdatedAt).localeCompare(String(left.progressUpdatedAt));
       return progressOrder || left.id.localeCompare(right.id);
+    })[0] ?? null
+  );
+}
+
+export function getNextProgressionGoalAchievement(
+  progress?: Partial<PlayerAchievementProgress>[] | null
+): PlayerAchievementProgress | null {
+  const locked = normalizeAchievementProgress(progress).filter((entry) => !entry.unlocked);
+  if (locked.length === 0) {
+    return null;
+  }
+
+  return (
+    locked.sort((left, right) => {
+      const startedOrder = Number(right.current > 0) - Number(left.current > 0);
+      if (startedOrder !== 0) {
+        return startedOrder;
+      }
+
+      const remainingOrder = Math.max(0, left.target - left.current) - Math.max(0, right.target - right.current);
+      if (remainingOrder !== 0) {
+        return remainingOrder;
+      }
+
+      const progressOrder = String(right.progressUpdatedAt ?? "").localeCompare(String(left.progressUpdatedAt ?? ""));
+      if (progressOrder !== 0) {
+        return progressOrder;
+      }
+
+      const targetOrder = left.target - right.target;
+      if (targetOrder !== 0) {
+        return targetOrder;
+      }
+
+      return left.id.localeCompare(right.id);
     })[0] ?? null
   );
 }
@@ -805,6 +846,7 @@ export function buildPlayerProgressionSnapshot(
   const normalizedRecentEventLog = normalizeEventLogEntries(recentEventLog).slice(0, Math.max(1, Math.floor(eventLimit)));
   const latestProgressed = getLatestProgressedAchievement(normalizedAchievements);
   const latestUnlocked = getLatestUnlockedAchievement(normalizedAchievements);
+  const nextGoal = getNextProgressionGoalAchievement(normalizedAchievements);
   const unlockedAchievements = normalizedAchievements.filter((entry) => entry.unlocked).length;
 
   return {
@@ -824,6 +866,16 @@ export function buildPlayerProgressionSnapshot(
             latestUnlockedAchievementId: latestUnlocked.id,
             latestUnlockedAchievementTitle: latestUnlocked.title,
             latestUnlockedAt: latestUnlocked.unlockedAt
+          }
+        : {}),
+      ...(nextGoal
+        ? {
+            nextGoalAchievementId: nextGoal.id,
+            nextGoalAchievementTitle: nextGoal.title,
+            nextGoalCurrent: nextGoal.current,
+            nextGoalTarget: nextGoal.target,
+            nextGoalRemaining: Math.max(0, nextGoal.target - nextGoal.current),
+            ...(nextGoal.progressUpdatedAt ? { nextGoalUpdatedAt: nextGoal.progressUpdatedAt } : {})
           }
         : {}),
       recentEventCount: normalizedRecentEventLog.length,

--- a/apps/cocos-client/test/cocos-account-review.test.ts
+++ b/apps/cocos-client/test/cocos-account-review.test.ts
@@ -178,10 +178,12 @@ test("buildCocosAccountReviewPage formats the progression surface from the lates
   assert.equal(review.section, "progression");
   assert.equal(review.title, "账号成长");
   assert.equal(review.pageLabel, "1/1");
-  assert.match(review.items[0]?.detail ?? "", /^成就 1\/5 已解锁 · 最新 初次交锋$/);
-  assert.equal(review.items[1]?.title, "最新解锁 · 初次交锋");
+  assert.equal(review.items[0]?.title, "下一解锁目标 · 猎敌者");
+  assert.match(review.items[0]?.detail ?? "", /还差 1 点进度 · 当前 2\/3/);
+  assert.match(review.items[1]?.detail ?? "", /^成就 1\/5 已解锁 · 最新 初次交锋$/);
+  assert.equal(review.items[2]?.title, "最新解锁 · 初次交锋");
   assert.equal(review.items.at(-1)?.title, "最近事件");
-  assert.equal(review.tabs.map((tab) => `${tab.label}:${tab.count}`).join(" | "), "成长:3 | 战报:2 | 事件:3 | 成就:3");
+  assert.equal(review.tabs.map((tab) => `${tab.label}:${tab.count}`).join(" | "), "成长:4 | 战报:2 | 事件:3 | 成就:3");
 });
 
 test("transitionCocosAccountReviewState exposes loading and error banners for paged history sections", () => {

--- a/packages/shared/src/event-log.ts
+++ b/packages/shared/src/event-log.ts
@@ -96,6 +96,12 @@ export interface PlayerProgressionSummary {
   latestUnlockedAchievementId?: AchievementId;
   latestUnlockedAchievementTitle?: string;
   latestUnlockedAt?: string;
+  nextGoalAchievementId?: AchievementId;
+  nextGoalAchievementTitle?: string;
+  nextGoalCurrent?: number;
+  nextGoalTarget?: number;
+  nextGoalRemaining?: number;
+  nextGoalUpdatedAt?: string;
   recentEventCount: number;
   latestEventAt?: string;
 }
@@ -139,6 +145,41 @@ export function getLatestProgressedAchievement(
     progressed.sort((left, right) => {
       const progressOrder = String(right.progressUpdatedAt).localeCompare(String(left.progressUpdatedAt));
       return progressOrder || left.id.localeCompare(right.id);
+    })[0] ?? null
+  );
+}
+
+export function getNextProgressionGoalAchievement(
+  progress?: Partial<PlayerAchievementProgress>[] | null
+): PlayerAchievementProgress | null {
+  const locked = normalizeAchievementProgress(progress).filter((entry) => !entry.unlocked);
+  if (locked.length === 0) {
+    return null;
+  }
+
+  return (
+    locked.sort((left, right) => {
+      const startedOrder = Number(right.current > 0) - Number(left.current > 0);
+      if (startedOrder !== 0) {
+        return startedOrder;
+      }
+
+      const remainingOrder = Math.max(0, left.target - left.current) - Math.max(0, right.target - right.current);
+      if (remainingOrder !== 0) {
+        return remainingOrder;
+      }
+
+      const progressOrder = String(right.progressUpdatedAt ?? "").localeCompare(String(left.progressUpdatedAt ?? ""));
+      if (progressOrder !== 0) {
+        return progressOrder;
+      }
+
+      const targetOrder = left.target - right.target;
+      if (targetOrder !== 0) {
+        return targetOrder;
+      }
+
+      return left.id.localeCompare(right.id);
     })[0] ?? null
   );
 }
@@ -805,6 +846,7 @@ export function buildPlayerProgressionSnapshot(
   const normalizedRecentEventLog = normalizeEventLogEntries(recentEventLog).slice(0, Math.max(1, Math.floor(eventLimit)));
   const latestProgressed = getLatestProgressedAchievement(normalizedAchievements);
   const latestUnlocked = getLatestUnlockedAchievement(normalizedAchievements);
+  const nextGoal = getNextProgressionGoalAchievement(normalizedAchievements);
   const unlockedAchievements = normalizedAchievements.filter((entry) => entry.unlocked).length;
 
   return {
@@ -824,6 +866,16 @@ export function buildPlayerProgressionSnapshot(
             latestUnlockedAchievementId: latestUnlocked.id,
             latestUnlockedAchievementTitle: latestUnlocked.title,
             latestUnlockedAt: latestUnlocked.unlockedAt
+          }
+        : {}),
+      ...(nextGoal
+        ? {
+            nextGoalAchievementId: nextGoal.id,
+            nextGoalAchievementTitle: nextGoal.title,
+            nextGoalCurrent: nextGoal.current,
+            nextGoalTarget: nextGoal.target,
+            nextGoalRemaining: Math.max(0, nextGoal.target - nextGoal.current),
+            ...(nextGoal.progressUpdatedAt ? { nextGoalUpdatedAt: nextGoal.progressUpdatedAt } : {})
           }
         : {}),
       recentEventCount: normalizedRecentEventLog.length,

--- a/packages/shared/test/shared-core.test.ts
+++ b/packages/shared/test/shared-core.test.ts
@@ -1373,6 +1373,12 @@ test("player progression snapshot summarizes unlocked achievements and recent ev
     latestUnlockedAchievementId: "first_battle",
     latestUnlockedAchievementTitle: "初次交锋",
     latestUnlockedAt: "2026-03-27T10:00:00.000Z",
+    nextGoalAchievementId: "enemy_slayer",
+    nextGoalAchievementTitle: "猎敌者",
+    nextGoalCurrent: 2,
+    nextGoalTarget: 3,
+    nextGoalRemaining: 1,
+    nextGoalUpdatedAt: "2026-03-27T10:04:00.000Z",
     recentEventCount: 1,
     latestEventAt: "2026-03-27T10:05:00.000Z"
   });


### PR DESCRIPTION
## Summary
- extend progression snapshots with a next-goal summary for the nearest long-term unlock
- surface that next-goal agenda in the Cocos account review progression page
- lock the new snapshot fields and account-review copy with shared/Cocos tests

## Testing
- ./node_modules/.bin/tsx --test /Users/grace/Documents/project/codex/worktrees/ProjectVeil-issue-1490/apps/cocos-client/test/cocos-account-review.test.ts /Users/grace/Documents/project/codex/worktrees/ProjectVeil-issue-1490/packages/shared/test/shared-core.test.ts

Closes #1490
