### PR TITLE
feat: tighten gameplay panel navigation

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilHudPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilHudPanel.ts
@@ -1680,24 +1680,25 @@ export class VeilHudPanel extends Component {
       label: action.label,
       callback: this.onInteractionAction ? () => this.onInteractionAction?.(action.id) : null
     }));
+    const primaryFlowLabels = this.buildPrimaryFlowButtonLabels();
     const buttons: HudActionButtonState[] = [
       ...interactionButtons,
       { name: "HudNewRun", label: "新开一局", callback: this.onNewRun ?? null },
       { name: "HudRefresh", label: "刷新状态", callback: this.onRefresh ?? null },
       { name: "HudSettings", label: "设置", callback: this.onToggleSettings ?? null },
-      { name: "HudCampaign", label: "战役任务", callback: this.onToggleCampaign ?? null },
-      { name: "HudInventory", label: "装备背包", callback: this.onToggleInventory ?? null },
-      { name: "HudAchievements", label: "战报中心", callback: this.onToggleAchievements ?? null },
-      { name: "HudDailyDungeon", label: "每日地城", callback: this.onToggleDailyDungeon ?? null },
+      { name: "HudCampaign", label: primaryFlowLabels.campaign, callback: this.onToggleCampaign ?? null },
+      { name: "HudDailyDungeon", label: primaryFlowLabels.dailyDungeon, callback: this.onToggleDailyDungeon ?? null },
       {
         name: "HudBattlePass",
-        label: "赛季通行证",
+        label: primaryFlowLabels.progression,
         callback: this.onToggleProgression ?? null,
         visible: this.currentState?.battlePassEnabled ?? false
       },
+      { name: "HudAchievements", label: primaryFlowLabels.report, callback: this.onToggleAchievements ?? null },
+      { name: "HudInventory", label: "整理装备背包", callback: this.onToggleInventory ?? null },
       {
         name: "HudSeasonalEvent",
-        label: "赛季活动",
+        label: primaryFlowLabels.seasonalEvent,
         callback: this.onToggleSeasonalEvent ?? null,
         visible: this.currentState?.seasonalEventAvailable ?? false
       },
@@ -1818,6 +1819,25 @@ export class VeilHudPanel extends Component {
         node.active = false;
       }
     }
+  }
+
+  private buildPrimaryFlowButtonLabels(): {
+    campaign: string;
+    dailyDungeon: string;
+    progression: string;
+    report: string;
+    seasonalEvent: string;
+  } {
+    const recentReplay = this.currentState?.account.recentBattleReplays[0] ?? null;
+    const inBattle = Boolean(this.currentState?.update?.battle);
+    const hasInteraction = Boolean(this.currentState?.interaction);
+    return {
+      campaign: hasInteraction ? "处理当前点位后看主线" : inBattle ? "战后继续主线" : "继续主线任务",
+      dailyDungeon: inBattle ? "战后查看今日地城" : "切到今日地城",
+      progression: this.currentState?.battlePassEnabled ? "查看成长目标" : "成长入口待开启",
+      report: recentReplay ? "回看上一战" : "打开战报中心",
+      seasonalEvent: this.currentState?.seasonalEventAvailable ? "查看赛季追逐" : "赛季活动"
+    };
   }
 
   private ensureActionButton(parent: Node, name: string, labelText: string): void {

--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -2277,6 +2277,7 @@ export class VeilRoot extends Component {
       return;
     }
 
+    this.announceGameplayPanelSwitch("成长目标", "正在同步赛季通行证、长期成长与下一解锁目标。");
     this.seasonProgress = this.snapshotSeasonProgressFromProfile();
     this.renderView();
     await this.refreshSeasonProgress();
@@ -2294,6 +2295,7 @@ export class VeilRoot extends Component {
       return;
     }
 
+    this.announceGameplayPanelSwitch("今日地城", "正在同步今日轮换、剩余次数与可领取奖励。");
     this.renderView();
     await this.refreshDailyDungeonPanel();
   }
@@ -2696,6 +2698,7 @@ export class VeilRoot extends Component {
     this.gameplayEquipmentPanelOpen = forceOpen ?? !this.gameplayEquipmentPanelOpen;
     if (this.gameplayEquipmentPanelOpen) {
       this.gameplayCampaignPanelOpen = false;
+      this.announceGameplayPanelSwitch("装备背包", "可以整理战利品、查看穿戴收益并准备下一次推进。");
     }
     this.renderView();
   }
@@ -2714,6 +2717,7 @@ export class VeilRoot extends Component {
     this.gameplayBattlePassPanelOpen = false;
     this.gameplaySeasonalEventPanelOpen = false;
     this.gameplayEquipmentPanelOpen = false;
+    this.announceGameplayPanelSwitch("主线任务", "正在同步当前章节、下一任务和路线建议。");
     this.renderView();
     await this.refreshGameplayCampaign();
   }
@@ -3153,6 +3157,7 @@ export class VeilRoot extends Component {
   }
 
   private async openGameplayBattleReportCenter(): Promise<void> {
+    this.announceGameplayPanelSwitch("战报回看", "正在打开最近一战与完整战报页，方便决定下一局路线。");
     this.lobbyAccountReviewState = transitionCocosAccountReviewState(this.lobbyAccountReviewState, {
       type: "section.selected",
       section: "battle-replays"
@@ -3162,6 +3167,11 @@ export class VeilRoot extends Component {
       replayId: this.lobbyAccountProfile.battleReportCenter?.latestReportId ?? this.lobbyAccountReviewState.selectedBattleReplayId
     });
     await this.toggleGameplayAccountReviewPanel(true);
+  }
+
+  private announceGameplayPanelSwitch(title: string, detail: string): void {
+    this.predictionStatus = `已切到${title}：${detail}`;
+    this.pushLog(`已切到${title}：${detail}`);
   }
 
   private async refreshAccountReviewPage(

--- a/apps/cocos-client/test/cocos-hud-panel.test.ts
+++ b/apps/cocos-client/test/cocos-hud-panel.test.ts
@@ -329,3 +329,50 @@ test("VeilHudPanel surfaces the current world focus ahead of lower-priority diag
   assert.match(statusText, /诊断摘要：这条信息应该排在焦点之后。/);
   assert.equal(badgeText, "推进");
 });
+
+test("VeilHudPanel renames primary flow buttons to match the current gameplay context", () => {
+  const { component, node } = createComponentHarness(VeilHudPanel, { name: "HudPanelRoot", width: 320, height: 720 });
+  const state = createHudState();
+  state.interaction = {
+    title: "矿井管理",
+    detail: "当前矿井可占领并开始按天结算收益。",
+    actions: []
+  };
+  state.account.recentBattleReplays = [
+    {
+      id: "replay-1",
+      roomId: "room-alpha",
+      playerId: "player-1",
+      battleId: "battle-1",
+      battleKind: "neutral",
+      playerCamp: "attacker",
+      heroId: "hero-1",
+      neutralArmyId: "neutral-1",
+      startedAt: "2026-04-16T09:00:00.000Z",
+      completedAt: "2026-04-16T09:01:00.000Z",
+      initialState: {
+        id: "battle-1",
+        round: 1,
+        lanes: 1,
+        activeUnitId: null,
+        turnOrder: [],
+        units: {},
+        environment: [],
+        log: [],
+        rng: {
+          seed: 1001,
+          cursor: 0
+        }
+      },
+      steps: [],
+      result: "attacker_victory"
+    }
+  ];
+
+  component.render(state);
+
+  assert.equal(readLabelString(findNode(node, "HudCampaign")), "处理当前点位后看主线");
+  assert.equal(readLabelString(findNode(node, "HudDailyDungeon")), "切到今日地城");
+  assert.equal(readLabelString(findNode(node, "HudBattlePass")), "查看成长目标");
+  assert.equal(readLabelString(findNode(node, "HudAchievements")), "回看上一战");
+});

--- a/apps/cocos-client/test/cocos-root-orchestration.test.ts
+++ b/apps/cocos-client/test/cocos-root-orchestration.test.ts
@@ -706,6 +706,36 @@ test("VeilRoot completes an active campaign mission from the owned battle result
   });
 });
 
+test("VeilRoot announces gameplay panel switches for the main PVE navigation surfaces", async () => {
+  const root = createVeilRootHarness();
+  root.remoteUrl = "http://127.0.0.1:2567";
+  root.playerId = "campaign-player";
+  root.displayName = "余烬守望";
+  root.authMode = "account";
+  root.authProvider = "account-password";
+  root.authToken = "signed.token";
+  root.lastUpdate = createSessionUpdate(1);
+  root.lastUpdate.featureFlags = {
+    battle_pass_enabled: true,
+    pve_enabled: true,
+    quest_system_enabled: true,
+    tutorial_enabled: true
+  };
+
+  root.refreshGameplayCampaign = async () => undefined;
+  root.refreshDailyDungeonPanel = async () => undefined;
+  root.refreshSeasonProgress = async () => undefined;
+
+  await root.toggleGameplayCampaignPanel(true);
+  assert.match(root.predictionStatus, /已切到主线任务/);
+
+  await root.toggleGameplayDailyDungeonPanel(true);
+  assert.match(root.predictionStatus, /已切到今日地城/);
+
+  await root.toggleGameplayBattlePassPanel(true);
+  assert.match(root.predictionStatus, /已切到成长目标/);
+});
+
 test("VeilRoot settings logout routes through the auth revoke path", async () => {
   const storage = createMemoryStorage();
   (sys as unknown as { localStorage: Storage }).localStorage = storage;


### PR DESCRIPTION
## Summary
- rename primary HUD flow buttons to better match current gameplay context
- add consistent front-stage feedback when switching into campaign, daily dungeon, progression, and replay panels
- cover the new flow copy with HUD and root orchestration tests

## Testing
- /Users/grace/Documents/project/codex/ProjectVeil/node_modules/.bin/tsx --test ./apps/cocos-client/test/cocos-hud-panel.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts

Closes #1494