### PR TITLE
feat: enrich pvp matchmaking and ladder copy

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
+++ b/apps/cocos-client/assets/scripts/VeilLobbyPanel.ts
@@ -1328,12 +1328,18 @@ export class VeilLobbyPanel extends Component {
     });
     const statusLines =
       leaderboardStatus === "loading"
-        ? ["排行榜", "正在同步最新天梯...", "读取前 50 名与当前账号排位。"]
+        ? ["排行榜", "正在同步最新天梯...", "读取前 50 名与当前账号排位，稍后会刷新今日冲榜焦点。"]
         : leaderboardStatus === "error"
           ? ["排行榜", "同步失败", leaderboardError?.trim() || "暂时无法读取排行榜，请稍后重试。"]
           : leaderboardView.rows.length === 0
-            ? ["排行榜", "暂时没有已结算的排名数据", "完成对局并结算后，这里会显示最新天梯名次。"]
-            : ["排行榜", `当前徽记 ${leaderboardView.tierBadge}`, `已同步 ${leaderboardView.rows.length} 名玩家 · 使用 HUD 强调当前账号。`];
+            ? ["排行榜", "暂时没有已结算的排名数据", leaderboardView.focusSummary]
+            : [
+                "排行榜",
+                leaderboardView.myRankRow
+                  ? `当前冲榜 ${leaderboardView.tierBadge} · ${leaderboardView.myRankRow.rankLabel}`
+                  : `当前冲榜 ${leaderboardView.tierBadge} · 仍未上榜`,
+                leaderboardView.focusSummary
+              ];
 
     let nextTopY = this.renderCard(
       "LobbyLeaderboardStatus",
@@ -1364,9 +1370,7 @@ export class VeilLobbyPanel extends Component {
       return nextTopY;
     }
 
-    const rows = leaderboardView.rows.slice(0, 5).map((row) =>
-      `${row.rankLabel} ${row.displayName}${row.isCurrentPlayer ? " · 我" : ""} · ${row.ratingLabel} · ${row.tierLabel}`
-    );
+    const rows = leaderboardView.rows.slice(0, 5).map((row) => `${row.summary}${row.isCurrentPlayer ? " · 我" : ""}`);
     nextTopY = this.renderCard(
       "LobbyLeaderboardList",
       centerX,
@@ -1387,10 +1391,10 @@ export class VeilLobbyPanel extends Component {
     const myRankLines = leaderboardView.myRankRow
       ? [
           "我的排名",
-          `${leaderboardView.myRankRow.rankLabel} ${leaderboardView.myRankRow.displayName}`,
-          `${leaderboardView.myRankRow.ratingLabel} · ${leaderboardView.myRankRow.tierLabel}`
+          leaderboardView.myRankRow.summary,
+          leaderboardView.focusSummary
         ]
-      : ["我的排名", "当前未进入前 50", "继续完成排位对局即可冲榜。"];
+      : ["我的排名", "当前未进入前 50", leaderboardView.focusSummary];
 
     return this.renderCard(
       "LobbyLeaderboardMyRank",

--- a/apps/cocos-client/assets/scripts/cocos-leaderboard-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-leaderboard-panel.ts
@@ -8,6 +8,7 @@ export interface LeaderboardRowView {
   ratingLabel: string;
   tierLabel: string;
   summary: string;
+  spotlight: string;
   isCurrentPlayer: boolean;
 }
 
@@ -15,6 +16,7 @@ export interface CocosLeaderboardPanelView {
   rows: LeaderboardRowView[];
   myRankRow: LeaderboardRowView | null;
   tierBadge: string;
+  focusSummary: string;
 }
 
 export interface CocosLeaderboardPanelInput {
@@ -61,11 +63,54 @@ function formatPromotionSummary(entry: LeaderboardEntry): string {
   return "";
 }
 
+function formatLeaderboardSpotlight(
+  entry: LeaderboardEntry,
+  previousEntry: LeaderboardEntry | null,
+  leadingEntry: LeaderboardEntry | null
+): string {
+  const promotionSummary = formatPromotionSummary(entry);
+  if (promotionSummary) {
+    return promotionSummary;
+  }
+
+  if (entry.rank <= 1 || !leadingEntry) {
+    return "当前领跑";
+  }
+
+  if (previousEntry) {
+    const gapToPrevious = Math.max(0, previousEntry.eloRating - entry.eloRating);
+    if (gapToPrevious > 0) {
+      return `距前一名 ${gapToPrevious} ELO`;
+    }
+  }
+
+  const gapToLeader = Math.max(0, leadingEntry.eloRating - entry.eloRating);
+  return gapToLeader > 0 ? `距榜首 ${gapToLeader} ELO` : "继续巩固当前名次";
+}
+
+function formatLeaderboardFocusSummary(rows: LeaderboardRowView[], myRankRow: LeaderboardRowView | null): string {
+  const leaderRow = rows[0] ?? null;
+  if (!leaderRow) {
+    return "先完成一场结算对局，再回来判断今天的冲榜目标。";
+  }
+
+  if (!myRankRow) {
+    return `先打一场排位进入榜单，再去追 ${leaderRow.displayName} 的当前节奏。`;
+  }
+
+  if (myRankRow.rank === 1) {
+    return `你当前领跑榜单，继续赢一局就能把优势再拉开一点。`;
+  }
+
+  return `今天的排位焦点：继续逼近 ${leaderRow.displayName}，把 ${myRankRow.spotlight} 先追回来。`;
+}
+
 export function buildCocosLeaderboardPanelView(input: CocosLeaderboardPanelInput): CocosLeaderboardPanelView {
-  const rows = input.entries.map<LeaderboardRowView>((entry) => {
+  const leadingEntry = input.entries[0] ?? null;
+  const rows = input.entries.map<LeaderboardRowView>((entry, index) => {
     const tierLabel = formatDivisionLabel(entry);
-    const promotionSummary = formatPromotionSummary(entry);
     const isCurrentPlayer = entry.playerId === input.myPlayerId;
+    const spotlight = formatLeaderboardSpotlight(entry, input.entries[index - 1] ?? null, leadingEntry);
     return {
       playerId: entry.playerId,
       rank: entry.rank,
@@ -73,7 +118,8 @@ export function buildCocosLeaderboardPanelView(input: CocosLeaderboardPanelInput
       displayName: entry.displayName.trim() || entry.playerId,
       ratingLabel: `ELO ${entry.eloRating}`,
       tierLabel,
-      summary: `#${entry.rank} ${entry.displayName.trim() || entry.playerId} · ELO ${entry.eloRating} · ${tierLabel}${promotionSummary ? ` · ${promotionSummary}` : ""}`,
+      summary: `#${entry.rank} ${entry.displayName.trim() || entry.playerId} · ELO ${entry.eloRating} · ${tierLabel} · ${spotlight}`,
+      spotlight,
       isCurrentPlayer
     };
   });
@@ -82,6 +128,7 @@ export function buildCocosLeaderboardPanelView(input: CocosLeaderboardPanelInput
   return {
     rows,
     myRankRow,
-    tierBadge: formatTierBadge(myRankRow, input.entries[0]?.tier)
+    tierBadge: formatTierBadge(myRankRow, input.entries[0]?.tier),
+    focusSummary: formatLeaderboardFocusSummary(rows, myRankRow)
   };
 }

--- a/apps/cocos-client/assets/scripts/cocos-matchmaking-status.ts
+++ b/apps/cocos-client/assets/scripts/cocos-matchmaking-status.ts
@@ -11,11 +11,16 @@ export interface MatchmakingStatusView {
 
 export function buildMatchmakingStatusView(status: CocosMatchmakingStatusResponse): MatchmakingStatusView {
   if (status.status === "queued") {
+    const queuePosition = Math.max(1, Math.floor(status.position));
+    const estimatedWaitSeconds = Math.max(0, Math.floor(status.estimatedWaitSeconds));
     return {
-      statusLabel: "正在匹配…",
-      queuePositionLabel: `位置 #${Math.max(1, Math.floor(status.position))}`,
-      waitEstimateLabel: `预计 ${Math.max(0, Math.floor(status.estimatedWaitSeconds))}s`,
-      matchedLabel: "",
+      statusLabel: "排位搜索中",
+      queuePositionLabel: queuePosition <= 1 ? "你已站到队列最前" : `前方还有 ${queuePosition - 1} 组对手`,
+      waitEstimateLabel: `预计 ${estimatedWaitSeconds}s 开赛`,
+      matchedLabel:
+        queuePosition <= 3
+          ? "保持当前阵容，配到对手后会直接拉起这局对抗。"
+          : "排队期间会保留今日冲榜势头，配到人后就能立刻开打。",
       canCancel: true,
       isMatched: false
     };
@@ -23,20 +28,20 @@ export function buildMatchmakingStatusView(status: CocosMatchmakingStatusRespons
 
   if (status.status === "matched") {
     return {
-      statusLabel: "匹配成功",
-      queuePositionLabel: "位置 -",
-      waitEstimateLabel: "预计 0s",
-      matchedLabel: `房间 ${status.roomId} · 玩家 ${status.playerIds.join(" vs ")}`,
+      statusLabel: "对手已锁定",
+      queuePositionLabel: "房间已就绪",
+      waitEstimateLabel: "现在就能开战",
+      matchedLabel: `房间 ${status.roomId} · ${status.playerIds.join(" vs ")} · 地图种子 ${status.seedOverride}`,
       canCancel: false,
       isMatched: true
     };
   }
 
   return {
-    statusLabel: "未在匹配",
-    queuePositionLabel: "位置 -",
-    waitEstimateLabel: "预计 --",
-    matchedLabel: "",
+    statusLabel: "暂未开始排位",
+    queuePositionLabel: "队列状态：空闲",
+    waitEstimateLabel: "等待你发起下一局",
+    matchedLabel: "打一场 PVP，就能刷新今日排位和社交战报。",
     canCancel: false,
     isMatched: false
   };

--- a/apps/cocos-client/test/cocos-leaderboard-panel.test.ts
+++ b/apps/cocos-client/test/cocos-leaderboard-panel.test.ts
@@ -15,7 +15,10 @@ test("buildCocosLeaderboardPanelView marks the current player and exposes a tier
   assert.equal(view.myRankRow?.playerId, "player-2");
   assert.equal(view.myRankRow?.isCurrentPlayer, true);
   assert.equal(view.tierBadge, "铂金");
+  assert.match(view.rows[0]?.summary ?? "", /当前领跑/);
   assert.match(view.rows[1]?.summary ?? "", /Bravo/);
+  assert.match(view.rows[1]?.summary ?? "", /距前一名 170 ELO/);
+  assert.match(view.focusSummary, /继续逼近 Alpha/);
 });
 
 test("buildCocosLeaderboardPanelView falls back to the leading tier badge when the player is not ranked", () => {
@@ -26,6 +29,7 @@ test("buildCocosLeaderboardPanelView falls back to the leading tier badge when t
 
   assert.equal(view.myRankRow, null);
   assert.equal(view.tierBadge, "钻石");
+  assert.match(view.focusSummary, /先打一场排位进入榜单/);
 });
 
 test("buildCocosLeaderboardPanelView returns an unranked badge for an empty ladder", () => {
@@ -37,4 +41,5 @@ test("buildCocosLeaderboardPanelView returns an unranked badge for an empty ladd
   assert.deepEqual(view.rows, []);
   assert.equal(view.myRankRow, null);
   assert.equal(view.tierBadge, "UNRANKED");
+  assert.match(view.focusSummary, /先完成一场结算对局/);
 });

--- a/apps/cocos-client/test/cocos-lobby-panel.test.ts
+++ b/apps/cocos-client/test/cocos-lobby-panel.test.ts
@@ -499,10 +499,11 @@ test("VeilLobbyPanel renders leaderboard rows and highlights the current player 
   component.scheduleOnce = () => undefined;
   component.render(state);
 
-  assert.match(readCardLabel(node, "LobbyLeaderboardStatus"), /当前徽记 铂金/);
-  assert.match(readCardLabel(node, "LobbyLeaderboardList"), /#2 Bravo · 我 · ELO 1524 · 铂金/);
+  assert.match(readCardLabel(node, "LobbyLeaderboardStatus"), /当前冲榜 铂金 · #2/);
+  assert.match(readCardLabel(node, "LobbyLeaderboardStatus"), /继续逼近 Alpha/);
+  assert.match(readCardLabel(node, "LobbyLeaderboardList"), /#2 Bravo · ELO 1524 · 铂金 · 距前一名 164 ELO · 我/);
   assert.match(readCardLabel(node, "LobbyLeaderboardMyRank"), /我的排名/);
-  assert.match(readCardLabel(node, "LobbyLeaderboardMyRank"), /#2 Bravo/);
+  assert.match(readCardLabel(node, "LobbyLeaderboardMyRank"), /#2 Bravo · ELO 1524 · 铂金 · 距前一名 164 ELO/);
   component.onDestroy();
 });
 

--- a/apps/cocos-client/test/cocos-matchmaking-status.test.ts
+++ b/apps/cocos-client/test/cocos-matchmaking-status.test.ts
@@ -10,10 +10,10 @@ test("buildMatchmakingStatusView formats queued queue position and wait labels",
   });
 
   assert.deepEqual(view, {
-    statusLabel: "正在匹配…",
-    queuePositionLabel: "位置 #4",
-    waitEstimateLabel: "预计 27s",
-    matchedLabel: "",
+    statusLabel: "排位搜索中",
+    queuePositionLabel: "前方还有 3 组对手",
+    waitEstimateLabel: "预计 27s 开赛",
+    matchedLabel: "排队期间会保留今日冲榜势头，配到人后就能立刻开打。",
     canCancel: true,
     isMatched: false
   });
@@ -27,21 +27,22 @@ test("buildMatchmakingStatusView formats matched room and player labels", () => 
     seedOverride: 1007
   });
 
-  assert.equal(view.statusLabel, "匹配成功");
-  assert.equal(view.queuePositionLabel, "位置 -");
-  assert.equal(view.waitEstimateLabel, "预计 0s");
+  assert.equal(view.statusLabel, "对手已锁定");
+  assert.equal(view.queuePositionLabel, "房间已就绪");
+  assert.equal(view.waitEstimateLabel, "现在就能开战");
   assert.match(view.matchedLabel, /房间 pvp-match-7/);
   assert.match(view.matchedLabel, /player-1 vs player-2/);
+  assert.match(view.matchedLabel, /地图种子 1007/);
   assert.equal(view.canCancel, false);
   assert.equal(view.isMatched, true);
 });
 
 test("buildMatchmakingStatusView falls back to an idle shell", () => {
   assert.deepEqual(buildMatchmakingStatusView({ status: "idle" }), {
-    statusLabel: "未在匹配",
-    queuePositionLabel: "位置 -",
-    waitEstimateLabel: "预计 --",
-    matchedLabel: "",
+    statusLabel: "暂未开始排位",
+    queuePositionLabel: "队列状态：空闲",
+    waitEstimateLabel: "等待你发起下一局",
+    matchedLabel: "打一场 PVP，就能刷新今日排位和社交战报。",
     canCancel: false,
     isMatched: false
   });


### PR DESCRIPTION
## Summary
- productize matchmaking status copy into clearer rank-chase language
- enrich leaderboard summaries with chase, lead, and pressure context
- surface the richer ladder summaries inside the Lobby leaderboard cards

Closes #1501

## Validation
- PATH=/Users/grace/Documents/project/codex/ProjectVeil/node_modules/.bin:$PATH node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test ./apps/cocos-client/test/cocos-matchmaking-status.test.ts ./apps/cocos-client/test/cocos-leaderboard-panel.test.ts ./apps/cocos-client/test/cocos-lobby-panel.test.ts