### PR TITLE
feat: sharpen pvp replay motivation

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-feedback.ts
@@ -90,7 +90,7 @@ export function buildBattleTransitionFeedback(
     return {
       title: isPvp ? "PVP 对抗已展开" : "PVE 遭遇已展开",
       detail: isPvp
-        ? `对手 ${battle.defenderHeroId ?? "未知"} · 遭遇会话 ${update.world.meta.roomId}/${battle.id} 已建立`
+        ? `对手 ${battle.defenderHeroId ?? "未知"} · 房间 ${update.world.meta.roomId}/${battle.id} 已锁定，胜负会直接回写房间态`
         : battle.log[battle.log.length - 1] ?? "战斗开始",
       badge: "ENGAGE",
       tone: "action"
@@ -407,10 +407,10 @@ function describeSettlementEncounterState(
 
   const didWin = didHeroWinResolution(resolved, heroId);
   if (didWin === true) {
-    return `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇`;
+    return `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇，房间会保留这场对抗结果`;
   }
   if (didWin === false) {
-    return `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在房间地图上`;
+    return `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在当前房间，可回图后继续对抗`;
   }
 
   const heroCamp = resolveHeroCamp(previousBattle, heroId);
@@ -421,8 +421,8 @@ function describeSettlementEncounterState(
         ? countAliveUnits(previousBattle, "defender") >= countAliveUnits(previousBattle, "attacker")
         : true;
   return didHoldField
-    ? `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇`
-    : `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在房间地图上`;
+    ? `PVP 结算：对手 ${previousBattle.defenderHeroId} 已退出当前遭遇，房间会保留这场对抗结果`
+    : `PVP 结算：对手 ${previousBattle.defenderHeroId} 仍保留在当前房间，可回图后继续对抗`;
 }
 
 function buildSettlementHandoffLabel(
@@ -431,13 +431,18 @@ function buildSettlementHandoffLabel(
   didWin: boolean | null
 ): string {
   if (previousBattle?.defenderHeroId) {
+    const opponentLabel = previousBattle.defenderHeroId;
     if (didWin === true) {
-      return resolved ? "下一步：等待房间回写后返回世界地图" : "下一步：等待房间确认胜负并回写 PVP 世界态";
+      return resolved
+        ? `下一步：返回世界地图，趁 ${opponentLabel} 还在同房间继续施压`
+        : `下一步：等待房间回写胜负、名次与 ${opponentLabel} 的位置`;
     }
     if (didWin === false) {
-      return resolved ? "下一步：等待房间回写后再调整对抗" : "下一步：等待房间确认胜负并回写 PVP 世界态";
+      return resolved
+        ? `下一步：回到世界地图补兵换技，再向 ${opponentLabel} 发起复仇`
+        : `下一步：等待房间回写胜负、名次与 ${opponentLabel} 的位置`;
     }
-    return resolved ? "下一步：等待房间确认胜负并回写 PVP 世界态" : "下一步：等待房间确认胜负并回写 PVP 世界态";
+    return `下一步：等待房间回写胜负、名次与 ${opponentLabel} 的位置`;
   }
 
   if (didWin === true) {

--- a/apps/cocos-client/assets/scripts/cocos-battle-replay-center.ts
+++ b/apps/cocos-client/assets/scripts/cocos-battle-replay-center.ts
@@ -401,25 +401,34 @@ function buildBattleReplayMotivationLines(
   replay: PlayerBattleReplaySummary | null
 ): string[] {
   const controlProfile = summarizeReplayControlProfile(replay);
+  const opponentLabel = report.opponentHeroId?.trim() || "当前对手";
   const stepLabel = replay
     ? `手动 ${controlProfile.playerSteps} 步 / 自动 ${controlProfile.automatedSteps} 步`
     : `${report.turnCount} 回合 / ${report.actionCount} 步`;
   const rewardRollup = report.rewards.map((reward) => formatBattleReportRewardChip(reward)).filter(Boolean);
   const reviewLine = report.result === "victory"
     ? controlProfile.playerSteps > 0
-      ? `复盘提示：本局 ${stepLabel}，开场节奏已经成型，下一局可以继续沿用这套先手。`
+      ? report.battleKind === "hero"
+        ? `复盘提示：本局 ${stepLabel}，你已经压住 ${opponentLabel} 的开场节奏，下一局可以继续沿用这套先手。`
+        : `复盘提示：本局 ${stepLabel}，开场节奏已经成型，下一局可以继续沿用这套先手。`
       : `复盘提示：本局主要靠自动结算收尾，下一局可以主动调一轮技能与集火顺序。`
     : controlProfile.playerSteps > 0
-      ? `复盘提示：本局 ${stepLabel}，建议先回看开场两步的站位和技能顺序。`
-      : `复盘提示：本局 ${stepLabel}，建议先回看敌方先手后的掉员节点。`;
+      ? report.battleKind === "hero"
+        ? `复盘提示：本局 ${stepLabel}，建议先回看 ${opponentLabel} 的开场压制点，再决定下一局怎么反打。`
+        : `复盘提示：本局 ${stepLabel}，建议先回看开场两步的站位和技能顺序。`
+      : report.battleKind === "hero"
+        ? `复盘提示：本局 ${stepLabel}，建议先回看 ${opponentLabel} 先手后的掉员节点。`
+        : `复盘提示：本局 ${stepLabel}，建议先回看敌方先手后的掉员节点。`;
   const nextRunLine = report.result === "victory"
     ? rewardRollup.length > 0
-      ? `下一局：把 ${rewardRollup.slice(0, 2).join(" / ")} 转成成长后，再开一局继续推进。`
+      ? report.battleKind === "hero"
+        ? `下一局：先把 ${rewardRollup.slice(0, 2).join(" / ")} 转成成长，再回到房间里继续向 ${opponentLabel} 抢分。`
+        : `下一局：把 ${rewardRollup.slice(0, 2).join(" / ")} 转成成长后，再开一局继续推进。`
       : report.battleKind === "hero"
-        ? "下一局：趁对局节奏还熟，再打一场 PVP 继续验证这套阵容。"
+        ? `下一局：趁 ${opponentLabel} 还在同房间，立刻再开一场 PVP 继续抢分。`
         : "下一局：趁胜继续推进下一场 PVE，把今天的收益链滚起来。"
     : report.battleKind === "hero"
-      ? "下一局：先补兵、换技能，再回到 PVP 复盘这场交锋。"
+      ? `下一局：先补兵、换技能，再回到房间里找 ${opponentLabel} 复仇。`
       : "下一局：先回主线或地城补强，再回来挑战这支守军。";
   return [reviewLine, nextRunLine];
 }
@@ -427,15 +436,20 @@ function buildBattleReplayMotivationLines(
 function buildReplayOnlyMotivationLines(replay: PlayerBattleReplaySummary): string[] {
   const controlProfile = summarizeReplayControlProfile(replay);
   const playerWon = formatReplayResultBadge(replay) === "胜利";
+  const opponentLabel = replay.opponentHeroId?.trim() || "当前对手";
   const reviewLine = controlProfile.playerSteps > 0
-    ? `复盘提示：本局手动 ${controlProfile.playerSteps} 步 / 自动 ${controlProfile.automatedSteps} 步，可以回看第一轮操作确认节奏。`
-    : "复盘提示：本局以自动结算为主，下一局可以主动尝试技能与集火顺序。";
+    ? replay.battleKind === "hero"
+      ? `复盘提示：本局手动 ${controlProfile.playerSteps} 步 / 自动 ${controlProfile.automatedSteps} 步，可以回看与 ${opponentLabel} 的第一轮换手。`
+      : `复盘提示：本局手动 ${controlProfile.playerSteps} 步 / 自动 ${controlProfile.automatedSteps} 步，可以回看第一轮操作确认节奏。`
+    : replay.battleKind === "hero"
+      ? `复盘提示：本局以自动结算为主，下一局可以主动调整技能顺序去压 ${opponentLabel}。`
+      : "复盘提示：本局以自动结算为主，下一局可以主动尝试技能与集火顺序。";
   const nextRunLine = playerWon
     ? replay.battleKind === "hero"
-      ? "下一局：趁节奏还熟，再打一场 PVP 继续验证阵容。"
+      ? `下一局：趁 ${opponentLabel} 还在同房间，再打一场 PVP 继续验证阵容。`
       : "下一局：趁胜继续推进下一场 PVE，把这轮收益链滚起来。"
     : replay.battleKind === "hero"
-      ? "下一局：先补兵或调整技能，再回来打一场新的 PVP。"
+      ? `下一局：先补兵或调整技能，再回来向 ${opponentLabel} 复仇。`
       : "下一局：先回主线补强，再回来挑战这支守军。";
   return [reviewLine, nextRunLine];
 }

--- a/apps/cocos-client/test/cocos-battle-feedback.test.ts
+++ b/apps/cocos-client/test/cocos-battle-feedback.test.ts
@@ -203,7 +203,7 @@ test("battle feedback summarizes action, progress, and outcome", () => {
   assert.equal(victoryFeedback?.tone, "victory");
   assert.equal(victoryFeedback?.badge, "WIN");
   assert.match(victoryFeedback?.detail ?? "", /战线：我方剩余 1 队 \/ 对方剩余 0 队/);
-  assert.match(victoryFeedback?.detail ?? "", /准备返回世界地图/);
+  assert.match(victoryFeedback?.detail ?? "", /返回世界地图继续推进当前回合/);
 
   const defeatFeedback = buildBattleTransitionFeedback(createResolvedUpdate("defender_victory"), "hero-1", battle);
   assert.equal(defeatFeedback?.tone, "defeat");
@@ -252,7 +252,8 @@ test("battle feedback calls out pvp encounter identity and settlement state", ()
     "hero-1"
   );
   assert.equal(pvpEnter?.title, "PVP 对抗已展开");
-  assert.match(pvpEnter?.detail ?? "", /room-alpha\/battle-pvp/);
+  assert.match(pvpEnter?.detail ?? "", /房间 room-alpha\/battle-pvp 已锁定/);
+  assert.match(pvpEnter?.detail ?? "", /胜负会直接回写房间态/);
 
   const pvpSettlement = buildBattleTransitionFeedback(
     {
@@ -264,7 +265,7 @@ test("battle feedback calls out pvp encounter identity and settlement state", ()
   );
   assert.equal(pvpSettlement?.title, "PVP 结果回写中");
   assert.match(pvpSettlement?.detail ?? "", /PVP 结算：对手 hero-9/);
-  assert.match(pvpSettlement?.detail ?? "", /等待房间确认胜负并回写 PVP 世界态/);
+  assert.match(pvpSettlement?.detail ?? "", /等待房间回写胜负、名次与 hero-9 的位置/);
 });
 
 test("battle transition feedback summarizes settlement rewards and field state", () => {

--- a/apps/cocos-client/test/cocos-battle-replay-center.test.ts
+++ b/apps/cocos-client/test/cocos-battle-replay-center.test.ts
@@ -203,11 +203,11 @@ test("buildCocosBattleReplayCenterView adds next-run motivation when only summar
     roomId: replay.roomId,
     playerId: replay.playerId,
     battleId: replay.battleId,
-    battleKind: replay.battleKind,
+    battleKind: "hero",
     playerCamp: replay.playerCamp,
     heroId: replay.heroId,
-    opponentHeroId: replay.opponentHeroId,
-    neutralArmyId: replay.neutralArmyId,
+    opponentHeroId: "hero-9",
+    neutralArmyId: undefined,
     startedAt: replay.startedAt,
     completedAt: replay.completedAt,
     result: "defeat",
@@ -226,8 +226,8 @@ test("buildCocosBattleReplayCenterView adds next-run motivation when only summar
   });
 
   assert.equal(view.state, "ready");
-  assert.match(view.detailLines.join("\n"), /复盘提示：本局 3 回合 \/ 5 步/);
-  assert.match(view.detailLines.join("\n"), /下一局：先回主线或地城补强，再回来挑战这支守军。/);
+  assert.match(view.detailLines.join("\n"), /复盘提示：本局 3 回合 \/ 5 步，建议先回看 hero-9 先手后的掉员节点。/);
+  assert.match(view.detailLines.join("\n"), /下一局：先补兵、换技能，再回到房间里找 hero-9 复仇。/);
 });
 
 test("buildCocosBattleReplayCenterView updates controls across playing, stepped, completed and reset playback states", () => {


### PR DESCRIPTION
## Summary
- strengthen PVP-specific battle feedback around opponent, room writeback, and next steps
- enrich replay-center rematch motivation for PVP reports and replay-only states
- extend PVP-focused tests for replay and transition copy

Closes #1502

## Validation
- PATH=/Users/grace/Documents/project/codex/ProjectVeil/node_modules/.bin:$PATH node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test ./apps/cocos-client/test/cocos-battle-feedback.test.ts ./apps/cocos-client/test/cocos-battle-replay-center.test.ts