### PR TITLE
feat: sharpen V1.0 seasonal leaderboard chase copy

### DIFF
--- a/apps/cocos-client/assets/scripts/cocos-event-leaderboard-panel.ts
+++ b/apps/cocos-client/assets/scripts/cocos-event-leaderboard-panel.ts
@@ -38,6 +38,10 @@ export interface BuildCocosEventLeaderboardPanelInput {
   now?: Date;
 }
 
+function formatRankWindowLabel(rankStart: number, rankEnd: number): string {
+  return rankStart === rankEnd ? `#${rankStart}` : `#${rankStart}-#${rankEnd}`;
+}
+
 function formatDuration(ms: number): string {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000));
   const days = Math.floor(totalSeconds / 86400);
@@ -53,6 +57,87 @@ function formatRewardLabel(tier: CocosSeasonalEvent["leaderboard"]["rewardTiers"
   const parts = [tier.badge?.trim() ? `徽记 ${tier.badge.trim()}` : null, tier.cosmeticId?.trim() ? `外观 ${tier.cosmeticId.trim()}` : null]
     .filter((entry): entry is string => Boolean(entry));
   return parts.length > 0 ? parts.join(" / ") : "奖励待同步";
+}
+
+function resolveRewardTierForRank(
+  rewardTiers: CocosSeasonalEvent["leaderboard"]["rewardTiers"],
+  rank: number | null
+): CocosSeasonalEvent["leaderboard"]["rewardTiers"][number] | null {
+  if (!rank) {
+    return null;
+  }
+
+  return rewardTiers.find((tier) => tier.rankStart <= rank && rank <= tier.rankEnd) ?? null;
+}
+
+function resolveNextRewardTier(
+  rewardTiers: CocosSeasonalEvent["leaderboard"]["rewardTiers"],
+  rank: number | null
+): CocosSeasonalEvent["leaderboard"]["rewardTiers"][number] | null {
+  if (!rank) {
+    return rewardTiers[0] ?? null;
+  }
+
+  const betterTiers = rewardTiers
+    .filter((tier) => tier.rankEnd < rank)
+    .sort((left, right) => right.rankEnd - left.rankEnd);
+  return betterTiers[0] ?? null;
+}
+
+function resolveRankPressureLabel(
+  entries: CocosSeasonalEvent["leaderboard"]["entries"],
+  playerId: string
+): string {
+  const myRow = entries.find((entry) => entry.playerId === playerId) ?? null;
+  if (!myRow) {
+    const cutoff = entries[entries.length - 1] ?? null;
+    if (!cutoff) {
+      return "追榜压力 榜单暂未形成，先刷出第一笔活动积分。";
+    }
+    return `追榜压力 先冲进 ${formatRankWindowLabel(cutoff.rank, cutoff.rank)} · 还差 ${Math.max(0, cutoff.points + 1)} 分`;
+  }
+
+  const above = entries.find((entry) => entry.rank === myRow.rank - 1) ?? null;
+  if (above) {
+    return `追榜压力 距前一名 ${above.displayName.trim() || above.playerId} 还差 ${Math.max(0, above.points - myRow.points + 1)} 分`;
+  }
+
+  const below = entries.find((entry) => entry.rank === myRow.rank + 1) ?? null;
+  if (below) {
+    return `守榜压力 当前领先 #${below.rank} ${Math.max(0, myRow.points - below.points)} 分`;
+  }
+
+  return "守榜压力 当前已在榜首，继续完成活动目标就能稳住奖励档。";
+}
+
+function resolveRewardChaseLabel(
+  event: CocosSeasonalEvent,
+  playerId: string
+): { playerRankLabel: string; leaderboardTitle: string; statusLabel: string } {
+  const myRow = event.leaderboard.entries.find((entry) => entry.playerId === playerId) ?? null;
+  const currentTier = resolveRewardTierForRank(event.leaderboard.rewardTiers, myRow?.rank ?? null);
+  const nextTier = resolveNextRewardTier(event.leaderboard.rewardTiers, myRow?.rank ?? null);
+  const currentTierLabel = currentTier
+    ? `当前奖励档 ${currentTier.title}`
+    : "当前奖励档 未上榜";
+  const nextTierLabel = nextTier
+    ? `下一档 ${nextTier.title} · 冲进 ${formatRankWindowLabel(nextTier.rankStart, nextTier.rankEnd)}`
+    : currentTier
+      ? `当前已在最高奖励档 ${currentTier.title}`
+      : "当前奖励档待同步";
+  const claimableRewards = event.rewards.filter((reward) => event.player.claimableRewardIds.includes(reward.id));
+  const actionLabel =
+    claimableRewards.length > 0
+      ? `先领 ${claimableRewards.map((reward) => reward.name).join(" / ")}，再把活动积分滚到更高奖励档。`
+      : nextTier
+        ? `继续刷活动目标，把积分抬到 ${nextTier.title} 档。`
+        : "继续守住当前排名，把本期奖励稳稳收下。";
+
+  return {
+    playerRankLabel: myRow ? `当前排名 #${myRow.rank} · ${currentTierLabel}` : `当前排名 未上榜 · ${currentTierLabel}`,
+    leaderboardTitle: `本期追逐 · ${nextTierLabel}`,
+    statusLabel: `${resolveRankPressureLabel(event.leaderboard.entries, playerId)} · ${actionLabel}`
+  };
 }
 
 export function buildCocosEventLeaderboardPanelView(
@@ -77,6 +162,7 @@ export function buildCocosEventLeaderboardPanelView(
   const nowMs = input.now?.getTime() ?? Date.now();
   const myRow = event.leaderboard.entries.find((entry) => entry.playerId === input.playerId) ?? null;
   const remainingMs = Math.max(0, new Date(event.endsAt).getTime() - nowMs);
+  const chase = resolveRewardChaseLabel(event, input.playerId);
   const topRows = event.leaderboard.entries.slice(0, 10).map<CocosEventLeaderboardRowView>((entry) => ({
     rank: entry.rank,
     rankLabel: `#${entry.rank}`,
@@ -90,12 +176,12 @@ export function buildCocosEventLeaderboardPanelView(
   return {
     visible: true,
     title: event.name,
-    subtitle: event.bannerText || event.description || "赛季活动排行榜",
+    subtitle: `${event.bannerText || event.description || "赛季活动排行榜"} · ${resolveRankPressureLabel(event.leaderboard.entries, input.playerId)}`,
     countdownLabel: remainingMs > 0 ? `剩余 ${formatDuration(remainingMs)}` : "活动已结束，奖励将通过邮箱发放",
     playerScoreLabel: `个人积分 ${event.player.points}`,
-    playerRankLabel: myRow ? `当前排名 #${myRow.rank}` : "当前排名 未上榜",
-    leaderboardTitle: `前 ${Math.min(10, Math.max(1, event.leaderboard.entries.length || 10))} 名排行榜`,
-    statusLabel: input.statusLabel,
+    playerRankLabel: chase.playerRankLabel,
+    leaderboardTitle: chase.leaderboardTitle,
+    statusLabel: `${input.statusLabel} · ${chase.statusLabel}`,
     topRows,
     rewardTiers: event.leaderboard.rewardTiers.map((tier) => {
       const unlocked = Boolean(myRow && tier.rankStart <= myRow.rank && myRow.rank <= tier.rankEnd);
@@ -103,7 +189,11 @@ export function buildCocosEventLeaderboardPanelView(
         title: tier.title,
         rankLabel: tier.rankStart === tier.rankEnd ? `排名 #${tier.rankStart}` : `排名 #${tier.rankStart}-#${tier.rankEnd}`,
         rewardLabel: formatRewardLabel(tier),
-        stateLabel: unlocked ? "已解锁" : myRow ? "未达成" : "未上榜",
+        stateLabel: unlocked
+          ? "已进入该奖励档"
+          : myRow
+            ? `还需冲进 ${formatRankWindowLabel(tier.rankStart, tier.rankEnd)}`
+            : `先冲进 ${formatRankWindowLabel(tier.rankStart, tier.rankEnd)}`,
         unlocked
       };
     })

--- a/apps/cocos-client/test/cocos-event-leaderboard-panel.test.ts
+++ b/apps/cocos-client/test/cocos-event-leaderboard-panel.test.ts
@@ -71,9 +71,13 @@ test("buildCocosEventLeaderboardPanelView formats player standing and reward tie
   assert.equal(view.visible, true);
   assert.match(view.playerScoreLabel, /160/);
   assert.match(view.playerRankLabel, /#2/);
+  assert.match(view.playerRankLabel, /Frontier Defender/);
+  assert.match(view.leaderboardTitle, /Bridge Champion/);
+  assert.match(view.statusLabel, /距前一名 Lyra 还差 61 分/);
   assert.equal(view.topRows[1]?.isCurrentPlayer, true);
   assert.equal(view.rewardTiers[1]?.unlocked, true);
   assert.equal(view.rewardTiers[0]?.unlocked, false);
+  assert.match(view.rewardTiers[0]?.stateLabel ?? "", /还需冲进 #1/);
 });
 
 test("buildCocosEventLeaderboardPanelView hides itself without an active event", () => {


### PR DESCRIPTION
## Summary
- upgrade seasonal leaderboard copy to explain current reward tier and next chase target
- add rank pressure messaging so players can read the event race faster
- extend the leaderboard unit test coverage for the new chase framing

Closes #1508