### PR TITLE
fix: harden smoke analytics capture isolation

### DIFF
--- a/apps/server/src/analytics.ts
+++ b/apps/server/src/analytics.ts
@@ -449,7 +449,7 @@ export function registerAnalyticsRoutes(
 ): void {
   app.use((request, response, next) => {
     response.setHeader("Access-Control-Allow-Origin", "*");
-    response.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
+    response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
     response.setHeader("Access-Control-Allow-Headers", "Content-Type");
 
     if (request.method === "OPTIONS") {
@@ -465,6 +465,31 @@ export function registerAnalyticsRoutes(
     sendJson(response, 200, {
       events: getCapturedAnalyticsEventsForTest()
     });
+  });
+
+  app.post("/api/test/analytics/events", async (request, response) => {
+    try {
+      const payload = await readJsonBody(request);
+      const events = Array.isArray((payload as { events?: unknown[] } | null)?.events)
+        ? ((payload as { events: AnalyticsEvent[] }).events ?? [])
+        : [];
+      capturedAnalyticsEvents.push(...events);
+      analyticsRuntimeDependencies.log(`[Analytics] accepted ${events.length} event(s) into test capture`);
+      sendJson(response, 202, {
+        accepted: events.length
+      });
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        sendJson(response, 413, {
+          error: toErrorPayload(error)
+        });
+        return;
+      }
+
+      sendJson(response, 400, {
+        error: toErrorPayload(error)
+      });
+    }
   });
 
   app.post("/api/analytics/events", async (request, response) => {

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -74,13 +74,18 @@ export default defineConfig({
       command: "npm run dev:server",
       env: {
         ...process.env,
-        ANALYTICS_ENDPOINT: "http://127.0.0.1:2567/api/analytics/events",
+        ANALYTICS_ENDPOINT: "http://127.0.0.1:2567/api/test/analytics/events",
+        ANALYTICS_SINK: "http",
         VEIL_ADMIN_TOKEN: process.env.VEIL_ADMIN_TOKEN ?? "dev-admin-token",
         VEIL_DAILY_QUESTS_ENABLED: "1",
-        VEIL_DAILY_QUEST_ROTATIONS_JSON: DAILY_QUEST_SMOKE_ROTATIONS
+        VEIL_DAILY_QUEST_ROTATIONS_JSON: DAILY_QUEST_SMOKE_ROTATIONS,
+        VEIL_RATE_LIMIT_AUTH_MAX: process.env.VEIL_RATE_LIMIT_AUTH_MAX ?? "120",
+        VEIL_RATE_LIMIT_HTTP_GLOBAL_MAX: process.env.VEIL_RATE_LIMIT_HTTP_GLOBAL_MAX ?? "2000",
+        VEIL_RATE_LIMIT_HTTP_ADMIN_MAX: process.env.VEIL_RATE_LIMIT_HTTP_ADMIN_MAX ?? "200",
+        VEIL_RATE_LIMIT_WS_ACTION_MAX: process.env.VEIL_RATE_LIMIT_WS_ACTION_MAX ?? "40"
       },
       port: 2567,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       stdout: "pipe",
       stderr: "pipe",
       timeout: 30_000,
@@ -92,7 +97,7 @@ export default defineConfig({
     {
       command: "npm run dev:client",
       port: 4173,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
       stdout: "pipe",
       stderr: "pipe",
       timeout: 30_000,


### PR DESCRIPTION
## Summary
- harden smoke Playwright servers with deterministic rate-limit settings and no shared server reuse
- add a dedicated analytics test capture POST route so smoke runs can collect events without recursive flushes
- keep campaign, seasonal, and onboarding smoke analytics visible while avoiding suite-level 429 noise

## Testing
- ./node_modules/.bin/playwright test tests/e2e/campaign-mission-flow.spec.ts tests/e2e/seasonal-event-lifecycle.spec.ts --config=playwright.smoke.config.ts
- ./node_modules/.bin/playwright test tests/e2e/onboarding-funnel.spec.ts -g "returning players do not re-enter the tutorial after completion" --config=playwright.smoke.config.ts