### PR TITLE
test: refresh cocos inventory action label

### DIFF
--- a/apps/cocos-client/test/cocos-primary-client-journey.test.ts
+++ b/apps/cocos-client/test/cocos-primary-client-journey.test.ts
@@ -874,7 +874,7 @@ test("primary cocos client journey renders actionable HUD and battle-panel contr
   );
   assert.equal(
     readNodeLabel(hudActionsNode?.getChildByName("HudInventory")?.getChildByName("Label")),
-    "装备背包"
+    "整理装备背包"
   );
 
   room.emitPush(createJourneyBattleUpdate(roomId, playerId));


### PR DESCRIPTION
Closes #1535

## Summary
- refresh the primary journey baseline to match the current inventory CTA copy

## Testing
- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test apps/cocos-client/test/cocos-primary-client-journey.test.ts