### PR TITLE
test: cover progression next-goal summary

### DIFF
--- a/apps/client/test/player-account-storage.test.ts
+++ b/apps/client/test/player-account-storage.test.ts
@@ -1388,6 +1388,11 @@ test("player progression loader normalizes summary, achievements, and limited ev
       latestUnlockedAchievementId: "first_battle",
       latestUnlockedAchievementTitle: "初次交锋",
       latestUnlockedAt: "2026-03-27T12:00:00.000Z",
+      nextGoalAchievementId: "world_explorer",
+      nextGoalAchievementTitle: "踏勘全境",
+      nextGoalCurrent: 0,
+      nextGoalTarget: 1,
+      nextGoalRemaining: 1,
       recentEventCount: 1,
       latestEventAt: "2026-03-27T12:03:00.000Z"
     });


### PR DESCRIPTION
Closes #1533

## Summary
- update the progression snapshot baseline to include the V1.0 next-goal fields
- keep the normalized summary contract aligned with the current runtime output

## Testing
- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test apps/client/test/player-account-storage.test.ts