### PR TITLE
test: stabilize release dashboard freshness fixtures

### DIFF
--- a/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts
@@ -13,9 +13,16 @@ import {
   summarizeWechatSmoke
 } from "../../../scripts/release-readiness-dashboard.ts";
 
+function isoNowMinus(parts: { days?: number; minutes?: number } = {}): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - (parts.days ?? 0));
+  date.setUTCMinutes(date.getUTCMinutes() - (parts.minutes ?? 0));
+  return date.toISOString();
+}
+
 test("summarizeSnapshot fails when a required release-readiness check is missing from an otherwise passed snapshot", () => {
   const summary = summarizeSnapshot("/tmp/release-readiness.json", {
-    generatedAt: "2026-03-30T00:00:00.000Z",
+    generatedAt: isoNowMinus({ days: 1 }),
     revision: {
       shortCommit: "abc1234"
     },
@@ -40,7 +47,7 @@ test("summarizeSnapshot fails when a required release-readiness check is missing
 
 test("buildBuildPackageGate aggregates snapshot, package, and smoke evidence into a failing gate", () => {
   const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
-    generatedAt: "2026-03-30T00:00:00.000Z",
+    generatedAt: isoNowMinus({ days: 1 }),
     revision: {
       shortCommit: "abc1234"
     },
@@ -60,7 +67,7 @@ test("buildBuildPackageGate aggregates snapshot, package, and smoke evidence int
   const smokeSummary = summarizeWechatSmoke("/tmp/codex.wechat.smoke-report.json", {
     execution: {
       result: "failed",
-      executedAt: "2026-03-30T00:05:00.000Z"
+      executedAt: isoNowMinus({ minutes: 30 })
     },
     cases: [{ id: "login-lobby", status: "failed" }]
   });
@@ -79,8 +86,11 @@ test("buildBuildPackageGate aggregates snapshot, package, and smoke evidence int
 });
 
 test("buildCriticalEvidenceGate downgrades stale evidence to warn and preserves fresh failures", () => {
+  const staleSnapshotAt = isoNowMinus({ days: 30 });
+  const recentSmokeAt = isoNowMinus({ days: 1, minutes: 5 });
+  const recentCocosAt = isoNowMinus({ days: 1 });
   const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
-    generatedAt: "2026-03-01T00:00:00.000Z",
+    generatedAt: staleSnapshotAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -99,14 +109,14 @@ test("buildCriticalEvidenceGate downgrades stale evidence to warn and preserves 
   const smokeSummary = summarizeWechatSmoke("/tmp/codex.wechat.smoke-report.json", {
     execution: {
       result: "failed",
-      executedAt: "2026-03-30T00:05:00.000Z"
+      executedAt: recentSmokeAt
     },
     cases: [{ id: "login-lobby", status: "failed" }]
   });
   const cocosSummary = summarizeCocosRc("/tmp/cocos-rc.json", {
     execution: {
       overallStatus: "passed",
-      executedAt: "2026-03-30T00:10:00.000Z",
+      executedAt: recentCocosAt,
       summary: "RC journey passed."
     }
   });
@@ -120,7 +130,7 @@ test("buildCriticalEvidenceGate downgrades stale evidence to warn and preserves 
   assert.equal(gate.status, "fail");
   assert.match(gate.summary, /missing or includes failing signals/i);
   assert.match(gate.details[0] ?? "", /older than 14 day\(s\)/);
-  assert.match(gate.details[1] ?? "", /2026-03-30T00:05:00.000Z/);
+  assert.match(gate.details[1] ?? "", new RegExp(recentSmokeAt.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.deepEqual(gate.failReasons, ["wechat_smoke_failed"]);
   assert.deepEqual(gate.warnReasons, ["evidence_stale"]);
   assert.equal(gate.evidence[0]?.freshness, "stale");
@@ -149,7 +159,7 @@ test("buildCriticalEvidenceGate fails when a critical artifact is missing and ex
 
 test("summarizePrimaryClientDiagnostics fails incomplete checkpoint coverage", () => {
   const summary = summarizePrimaryClientDiagnostics("/tmp/cocos-primary-diagnostics.json", {
-    generatedAt: "2026-03-30T00:00:00.000Z",
+    generatedAt: isoNowMinus({ days: 1 }),
     revision: {
       shortCommit: "abc1234"
     },
@@ -180,8 +190,10 @@ test("summarizeSameCandidateAudit warns when the dashboard was not run as a cand
 });
 
 test("buildGoNoGoReport marks a candidate blocked when linked evidence revisions disagree", () => {
+  const recentSnapshotAt = isoNowMinus({ days: 1, minutes: 20 });
+  const recentSmokeAt = isoNowMinus({ days: 1, minutes: 5 });
   const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
-    generatedAt: "2026-03-30T00:00:00.000Z",
+    generatedAt: recentSnapshotAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -205,7 +217,7 @@ test("buildGoNoGoReport marks a candidate blocked when linked evidence revisions
     },
     execution: {
       result: "passed",
-      executedAt: "2026-03-30T00:05:00.000Z"
+      executedAt: recentSmokeAt
     },
     cases: [{ id: "login-lobby", status: "passed" }]
   });
@@ -233,8 +245,10 @@ test("buildGoNoGoReport marks a candidate blocked when linked evidence revisions
 });
 
 test("buildGoNoGoReport blocks explicit candidate pinning when evidence metadata is missing or stale", () => {
+  const staleSnapshotAt = isoNowMinus({ days: 30 });
+  const recentSmokeAt = isoNowMinus({ days: 1, minutes: 5 });
   const snapshotSummary = summarizeSnapshot("/tmp/release-readiness.json", {
-    generatedAt: "2026-03-01T00:00:00.000Z",
+    generatedAt: staleSnapshotAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -255,7 +269,7 @@ test("buildGoNoGoReport blocks explicit candidate pinning when evidence metadata
   const smokeSummary = summarizeWechatSmoke("/tmp/codex.wechat.smoke-report.json", {
     execution: {
       result: "passed",
-      executedAt: "2026-03-30T00:05:00.000Z"
+      executedAt: recentSmokeAt
     },
     cases: [{ id: "login-lobby", status: "passed" }]
   });

--- a/apps/cocos-client/test/release-readiness-dashboard.test.ts
+++ b/apps/cocos-client/test/release-readiness-dashboard.test.ts
@@ -27,6 +27,13 @@ function execFileAsync(command: string, args: string[], cwd: string): Promise<st
   });
 }
 
+function isoNowMinus(parts: { days?: number; minutes?: number } = {}): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - (parts.days ?? 0));
+  date.setUTCMinutes(date.getUTCMinutes() - (parts.minutes ?? 0));
+  return date.toISOString();
+}
+
 test("release:readiness:dashboard aggregates live endpoints and local evidence into a pass report", async (t) => {
   const workspaceDir = createTempDir("veil-release-dashboard-pass-");
   const outputPath = path.join(workspaceDir, "dashboard.json");
@@ -41,9 +48,16 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
   const packageMetadataPath = path.join(wechatArtifactsDir, "project-veil.package.json");
   const archivePath = path.join(wechatArtifactsDir, "project-veil.tar.gz");
   const smokeReportPath = path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json");
+  const snapshotGeneratedAt = isoNowMinus({ days: 1, minutes: 30 });
+  const smokeExecutedAt = isoNowMinus({ days: 1, minutes: 15 });
+  const diagnosticsGeneratedAt = isoNowMinus({ days: 1, minutes: 12 });
+  const cocosExecutedAt = isoNowMinus({ days: 1, minutes: 10 });
+  const reconnectGeneratedAt = isoNowMinus({ days: 1, minutes: 8 });
+  const persistenceGeneratedAt = isoNowMinus({ days: 1, minutes: 6 });
+  const runtimeCheckedAt = isoNowMinus({ days: 1, minutes: 1 });
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-03-29T08:00:00.000Z",
+    generatedAt: snapshotGeneratedAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -67,12 +81,12 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     },
     execution: {
       overallStatus: "passed",
-      executedAt: "2026-03-29T08:20:00.000Z",
+      executedAt: cocosExecutedAt,
       summary: "Canonical gameplay journey passed."
     }
   });
   writeJson(primaryClientDiagnosticsPath, {
-    generatedAt: "2026-03-29T08:18:00.000Z",
+    generatedAt: diagnosticsGeneratedAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -91,7 +105,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     checkpoints: []
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-03-29T08:22:00.000Z",
+    generatedAt: reconnectGeneratedAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -118,7 +132,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     ]
   });
   writeJson(persistencePath, {
-    generatedAt: "2026-03-29T08:24:00.000Z",
+    generatedAt: persistenceGeneratedAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -164,7 +178,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
     },
     execution: {
       result: "passed",
-      executedAt: "2026-03-29T08:15:00.000Z",
+      executedAt: smokeExecutedAt,
       tester: "codex",
       device: "iPhone 15 / WeChat 8.0.x",
       summary: "All required smoke cases passed."
@@ -184,7 +198,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
       response.end(
         JSON.stringify({
           status: "ok",
-          checkedAt: "2026-03-29T08:30:00.000Z",
+          checkedAt: runtimeCheckedAt,
           runtime: {
             activeRoomCount: 2,
             connectionCount: 3,
@@ -205,7 +219,7 @@ test("release:readiness:dashboard aggregates live endpoints and local evidence i
       response.end(
         JSON.stringify({
           status: "ok",
-          checkedAt: "2026-03-29T08:30:00.000Z",
+          checkedAt: runtimeCheckedAt,
           headline: "auth ready; guest=1 account=2 lockouts=0",
           alerts: [],
           auth: {
@@ -361,9 +375,13 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
   const wechatArtifactsDir = path.join(workspaceDir, "wechat-artifacts");
   const packageMetadataPath = path.join(wechatArtifactsDir, "project-veil.package.json");
   const smokeReportPath = path.join(wechatArtifactsDir, "codex.wechat.smoke-report.json");
+  const snapshotGeneratedAt = isoNowMinus({ days: 1, minutes: 30 });
+  const smokeExecutedAt = isoNowMinus({ days: 1, minutes: 15 });
+  const reconnectGeneratedAt = isoNowMinus({ days: 1, minutes: 8 });
+  const persistenceGeneratedAt = isoNowMinus({ days: 1, minutes: 6 });
 
   writeJson(snapshotPath, {
-    generatedAt: "2026-03-29T08:00:00.000Z",
+    generatedAt: snapshotGeneratedAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -393,14 +411,14 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
     },
     execution: {
       result: "pending",
-      executedAt: "2026-03-29T08:15:00.000Z"
+      executedAt: smokeExecutedAt
     },
     cases: [
       { id: "login-lobby", status: "pending" }
     ]
   });
   writeJson(reconnectSoakPath, {
-    generatedAt: "2026-03-29T08:22:00.000Z",
+    generatedAt: reconnectGeneratedAt,
     revision: {
       shortCommit: "abc1234"
     },
@@ -427,7 +445,7 @@ test("release:readiness:dashboard reports warns and failures when evidence is mi
     ]
   });
   writeJson(persistencePath, {
-    generatedAt: "2026-03-29T08:24:00.000Z",
+    generatedAt: persistenceGeneratedAt,
     revision: {
       shortCommit: "abc1234"
     },


### PR DESCRIPTION
Closes #1536

## Summary
- replace hard-coded March fixture timestamps with relative times in the release dashboard tests
- keep the stale-evidence aggregation expectations aligned with the current gate behavior

## Testing
- node --import /Users/grace/Documents/project/codex/ProjectVeil/node_modules/tsx/dist/loader.mjs --test apps/cocos-client/test/release-readiness-dashboard-aggregation.test.ts apps/cocos-client/test/release-readiness-dashboard.test.ts