### PR TITLE
feat: add launch grafana oncall bundle

### DIFF
--- a/docs/monitoring-setup.md
+++ b/docs/monitoring-setup.md
@@ -5,11 +5,16 @@ This repository now ships a minimal Prometheus + Alertmanager + Grafana stack un
 ## Files
 
 - `infra/prometheus.yml`: Prometheus scrape and alerting configuration.
-- `infra/alertmanager.yml`: Alertmanager routing and Slack notification receiver.
+- `infra/alertmanager.yml`: Alertmanager routing, PagerDuty receiver, and Slack fallback receiver.
 - `infra/docker-compose.monitoring.yml`: local monitoring stack for Prometheus, Alertmanager, and Grafana.
 - `infra/grafana/dashboard-overview.json`: overview dashboard covering DAU proxy, active rooms, battle duration P95, and error rate.
+- `infra/grafana/dashboard-live-ops-overview.json`: live-ops overview for DAU proxy, active rooms, matchmaking pressure, and server analytics flush.
+- `infra/grafana/dashboard-customer-service.json`: support / moderation board for tickets, reports, and social moderation signals.
+- `infra/grafana/dashboard-payment-health.json`: payment health board for completed / failed purchases plus runtime payment errors.
 - `infra/grafana/provisioning/...`: Grafana datasource and dashboard provisioning.
 - `docs/alerting-rules.yml`: alert rules evaluated by Prometheus.
+- `docs/oncall-roster.md`: on-call rotation template for LAUNCH-P2.
+- `scripts/oncall-ack-audit.ts`: MTTA / MTTR audit helper for latest alert export.
 
 ## Prerequisites
 
@@ -19,6 +24,12 @@ This repository now ships a minimal Prometheus + Alertmanager + Grafana stack un
 ```bash
 mkdir -p infra/secrets
 printf '%s' 'https://hooks.slack.com/services/REPLACE/ME' > infra/secrets/slack-webhook-url
+```
+
+3. Export the PagerDuty routing key before booting Alertmanager:
+
+```bash
+export PAGERDUTY_ROUTING_KEY=replace-me
 ```
 
 3. If the server is not running on the Docker host at port `2567`, update `infra/prometheus.yml` target `host.docker.internal:2567`.
@@ -35,7 +46,12 @@ After startup:
 - Alertmanager: `http://127.0.0.1:9093`
 - Grafana: `http://127.0.0.1:3000` (`admin` / `admin`)
 
-Grafana auto-provisions the Prometheus datasource and imports `Project Veil Monitoring Overview`.
+Grafana auto-provisions the Prometheus datasource and imports:
+
+- `Project Veil Monitoring Overview`
+- `Project Veil Live Ops Overview`
+- `Project Veil Customer Service`
+- `Project Veil Payment Health`
 
 ## What The Dashboard Shows
 
@@ -61,7 +77,7 @@ histogram_quantile(0.95, sum(rate(veil_battle_duration_seconds_bucket[30m])) by 
 
 ## Validate Notification Delivery
 
-The `ops-slack` receiver is selected when an alert carries `notify="ops-slack"`. Critical Project Veil alerts in `docs/alerting-rules.yml` now include that label.
+The `ops-slack` receiver is selected when an alert carries `notify="ops-slack"`. Critical Project Veil alerts can instead carry `notify="ops-pagerduty"`, which routes to PagerDuty and mirrors the alert to Slack as fallback context.
 
 To verify end-to-end delivery without waiting for a real incident, post a synthetic alert directly to Alertmanager:
 
@@ -90,6 +106,7 @@ Expected result:
 
 - Alert appears in `http://127.0.0.1:9093/#/alerts`
 - Slack channel receives a formatted alert message
+- PagerDuty receives a new incident when `notify="ops-pagerduty"` is used
 - Alert resolves automatically when the posted alert expires or is withdrawn
 
 Record the drill in your deployment log with timestamp, receiver channel, and screenshot or copied Alertmanager event JSON.
@@ -98,5 +115,19 @@ Record the drill in your deployment log with timestamp, receiver channel, and sc
 
 - Set `SENTRY_DSN` on the server runtime if you want uncaught exceptions and structured server error events forwarded to Sentry. Leaving `SENTRY_DSN` empty keeps runtime diagnostics and Prometheus metrics active without external delivery.
 - Replace the Slack webhook secret with a production-managed secret mount.
+- Inject `PAGERDUTY_ROUTING_KEY` through your deployment environment and keep the Slack fallback enabled for human context.
 - For Kubernetes or a VM-based deployment, keep `infra/prometheus.yml` and `infra/alertmanager.yml` unchanged and translate only the runtime wrapper from Docker Compose into your platform manifests.
 - If the organization prefers PagerDuty, DingTalk, or WeCom robots, keep the same Prometheus rule labels and swap the Alertmanager receiver to a webhook bridge that transforms Alertmanager payloads into the provider-specific target.
+
+## On-call audit
+
+Export the latest incident sample into JSON and run:
+
+```bash
+node --import ./node_modules/tsx/dist/loader.mjs ./scripts/oncall-ack-audit.ts \
+  --input artifacts/ops/incidents.json \
+  --output artifacts/ops/oncall-ack-audit.json \
+  --markdown-output artifacts/ops/oncall-ack-audit.md
+```
+
+Review median MTTA / MTTR and any breach rows during weekly launch handoff.

--- a/docs/oncall-roster.md
+++ b/docs/oncall-roster.md
@@ -1,0 +1,18 @@
+# Project Veil On-call Roster
+
+Use this template to publish the current LAUNCH-P2 duty rotation. Keep one active row per role and update the `handoffNotes` field when coverage changes mid-shift.
+
+| role | primary | secondary | timezone | handoffNotes |
+| --- | --- | --- | --- | --- |
+| `ops-oncall` | `grace` | `backup-ops` | `Asia/Shanghai` | `Owns Grafana, Alertmanager, launch dashboards, and MTTA/MTTR follow-up.` |
+| `server-oncall` | `runtime-owner` | `backend-backup` | `Asia/Shanghai` | `Owns room health, reconnects, maintenance mode, and rollback drills.` |
+| `commerce-oncall` | `payments-owner` | `risk-backup` | `Asia/Shanghai` | `Owns WeChat/Apple/Google purchase incidents and compensations.` |
+| `support-oncall` | `support-lead` | `moderation-backup` | `Asia/Shanghai` | `Owns tickets, reports, bans, mailbox comms, and GM escalations.` |
+| `release-owner` | `release-oncall` | `qa-oncall` | `Asia/Shanghai` | `Owns go/no-go packet, incident bridge, and final sign-off.` |
+
+## Weekly handoff checklist
+
+1. Confirm each role has one reachable primary and one reachable backup.
+2. Re-run `scripts/oncall-ack-audit.ts` against the latest incident export and review MTTA / MTTR drift.
+3. Update PagerDuty schedule links, Slack channel links, and escalation aliases if they changed.
+4. Record the handoff timestamp in the release log or incident channel.

--- a/infra/alertmanager.yml
+++ b/infra/alertmanager.yml
@@ -3,7 +3,7 @@ global:
   slack_api_url_file: /etc/alertmanager/secrets/slack-webhook-url
 
 route:
-  receiver: null
+  receiver: ops-slack
   group_by:
     - alertname
     - service
@@ -13,13 +13,15 @@ route:
   repeat_interval: 3h
   routes:
     - matchers:
+        - notify="ops-pagerduty"
+      receiver: ops-pagerduty
+      continue: false
+    - matchers:
         - notify="ops-slack"
       receiver: ops-slack
       continue: false
 
 receivers:
-  - name: null
-
   - name: ops-slack
     slack_configs:
       - channel: '#ops-alerts'
@@ -30,6 +32,26 @@ receivers:
         text: >-
           {{ range .Alerts -}}
           *service:* {{ .Labels.service }}
+          *summary:* {{ .Annotations.summary }}
+          *description:* {{ .Annotations.description }}
+          *runbook:* {{ .Annotations.runbook_url }}
+          {{ end }}
+
+  - name: ops-pagerduty
+    pagerduty_configs:
+      - routing_key: ${PAGERDUTY_ROUTING_KEY}
+        severity: '{{ .CommonLabels.severity }}'
+        description: '{{ .CommonLabels.alertname }}'
+        send_resolved: true
+    slack_configs:
+      - channel: '#ops-alerts'
+        send_resolved: true
+        title: >-
+          [PAGERDUTY FALLBACK][{{ .CommonLabels.severity | toUpper }}]
+          {{ .CommonLabels.alertname }}
+        text: >-
+          PagerDuty route triggered for {{ .CommonLabels.service }}.
+          {{ range .Alerts -}}
           *summary:* {{ .Annotations.summary }}
           *description:* {{ .Annotations.description }}
           *runbook:* {{ .Annotations.runbook_url }}

--- a/infra/docker-compose.monitoring.yml
+++ b/infra/docker-compose.monitoring.yml
@@ -16,8 +16,11 @@ services:
     image: prom/alertmanager:v0.28.1
     command:
       - --config.file=/etc/alertmanager/alertmanager.yml
+      - --config.expand-env
     ports:
       - "9093:9093"
+    environment:
+      PAGERDUTY_ROUTING_KEY: ${PAGERDUTY_ROUTING_KEY:-local-dev-routing-key}
     volumes:
       - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - ./secrets:/etc/alertmanager/secrets:ro
@@ -35,3 +38,6 @@ services:
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
       - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ./grafana/dashboard-overview.json:/var/lib/grafana/dashboards/project-veil-overview.json:ro
+      - ./grafana/dashboard-live-ops-overview.json:/var/lib/grafana/dashboards/project-veil-live-ops-overview.json:ro
+      - ./grafana/dashboard-customer-service.json:/var/lib/grafana/dashboards/project-veil-customer-service.json:ro
+      - ./grafana/dashboard-payment-health.json:/var/lib/grafana/dashboards/project-veil-payment-health.json:ro

--- a/infra/grafana/dashboard-customer-service.json
+++ b/infra/grafana/dashboard-customer-service.json
@@ -1,0 +1,73 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [{ "expr": "sum(veil_support_ticket_open_total)", "refId": "A" }],
+      "title": "Open Tickets",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [{ "expr": "sum(rate(veil_player_reports_total[1h]))", "refId": "A" }],
+      "title": "Player Reports / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 7 },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_runtime_error_events_total{feature_area=\"support\"}[15m])) by (error_code)",
+          "legendFormat": "{{error_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Support Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 7 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_runtime_error_events_total{feature_area=\"guild\"}[15m])) by (error_code)",
+          "legendFormat": "{{error_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Guild / Social Moderation Signals",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["launch-p2", "ops", "support"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "title": "Project Veil Customer Service",
+  "uid": "project-veil-customer-service",
+  "version": 1
+}

--- a/infra/grafana/dashboard-live-ops-overview.json
+++ b/infra/grafana/dashboard-live-ops-overview.json
@@ -1,0 +1,152 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(veil_auth_guest_logins_total[24h])) + sum(increase(veil_auth_account_logins_total[24h]))",
+          "refId": "A"
+        }
+      ],
+      "title": "DAU Proxy (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "veil_active_rooms_total",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Rooms",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(veil_matchmaking_rate_limited_total[15m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Matchmaking Rate Limits / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 7 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "sum by (name) (rate(veil_analytics_events_flushed_total{source=\"server\"}[30m]))",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Server Analytics Flush Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 7 },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_runtime_error_events_total[15m])) by (feature_area,severity)",
+          "legendFormat": "{{feature_area}} / {{severity}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Runtime Error Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["launch-p2", "ops"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timezone": "",
+  "title": "Project Veil Live Ops Overview",
+  "uid": "project-veil-live-ops-overview",
+  "version": 1
+}

--- a/infra/grafana/dashboard-payment-health.json
+++ b/infra/grafana/dashboard-payment-health.json
@@ -1,0 +1,73 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [{ "expr": "sum(increase(veil_analytics_events_flushed_total{name=\"purchase_completed\"}[24h]))", "refId": "A" }],
+      "title": "Purchases Completed (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [{ "expr": "sum(increase(veil_analytics_events_flushed_total{name=\"purchase_failed\"}[24h]))", "refId": "A" }],
+      "title": "Purchases Failed (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 7 },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_runtime_error_events_total{feature_area=\"payment\"}[15m])) by (error_code)",
+          "legendFormat": "{{error_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Payment Runtime Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 7 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_analytics_events_flushed_total{name=~\"purchase_(completed|failed)|payment_fraud_signal\"}[15m])) by (name)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Payment Funnel / Fraud Signals",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["launch-p2", "ops", "payments"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "title": "Project Veil Payment Health",
+  "uid": "project-veil-payment-health",
+  "version": 1
+}

--- a/scripts/oncall-ack-audit.ts
+++ b/scripts/oncall-ack-audit.ts
@@ -1,0 +1,231 @@
+import fs from "node:fs";
+import path from "node:path";
+
+interface Args {
+  inputPath: string;
+  outputPath?: string;
+  markdownOutputPath?: string;
+}
+
+interface IncidentRecord {
+  id: string;
+  service: string;
+  severity: string;
+  owner: string;
+  openedAt: string;
+  acknowledgedAt?: string;
+  resolvedAt?: string;
+}
+
+interface IncidentAuditInput {
+  incidents: IncidentRecord[];
+}
+
+interface AckAuditReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  totals: {
+    incidentCount: number;
+    acknowledgedCount: number;
+    resolvedCount: number;
+  };
+  timing: {
+    medianAckMinutes: number | null;
+    medianResolveMinutes: number | null;
+    averageAckMinutes: number | null;
+    averageResolveMinutes: number | null;
+  };
+  byOwner: Array<{
+    owner: string;
+    incidentCount: number;
+    acknowledgedCount: number;
+    resolvedCount: number;
+  }>;
+  breaches: Array<{
+    incidentId: string;
+    owner: string;
+    reason: string;
+  }>;
+}
+
+function parseArgs(argv: string[]): Args {
+  let inputPath = "";
+  let outputPath: string | undefined;
+  let markdownOutputPath: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const current = argv[index];
+    const next = argv[index + 1];
+    if (current === "--input" && next) {
+      inputPath = next;
+      index += 1;
+      continue;
+    }
+    if (current === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (current === "--markdown-output" && next) {
+      markdownOutputPath = next;
+      index += 1;
+      continue;
+    }
+    if (current === "--help") {
+      console.log("Usage: tsx scripts/oncall-ack-audit.ts --input incidents.json [--output report.json] [--markdown-output report.md]");
+      process.exit(0);
+    }
+    throw new Error(`Unknown or incomplete argument: ${current}`);
+  }
+
+  if (!inputPath) {
+    throw new Error("Pass --input <path>.");
+  }
+
+  return { inputPath, outputPath, markdownOutputPath };
+}
+
+function ensureDirectory(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function readJson(filePath: string): IncidentAuditInput {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as IncidentAuditInput;
+}
+
+function minutesBetween(start: string, end: string | undefined): number | null {
+  if (!end) {
+    return null;
+  }
+  const diffMs = Date.parse(end) - Date.parse(start);
+  if (!Number.isFinite(diffMs)) {
+    return null;
+  }
+  return Math.max(0, Number((diffMs / 60_000).toFixed(2)));
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? null;
+  }
+  return Number((((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2).toFixed(2));
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  return Number((values.reduce((sum, value) => sum + value, 0) / values.length).toFixed(2));
+}
+
+export function buildAckAuditReport(input: IncidentAuditInput, generatedAt = new Date().toISOString()): AckAuditReport {
+  const ackDurations = input.incidents.map((incident) => minutesBetween(incident.openedAt, incident.acknowledgedAt)).filter((value): value is number => value !== null);
+  const resolveDurations = input.incidents
+    .map((incident) => minutesBetween(incident.openedAt, incident.resolvedAt))
+    .filter((value): value is number => value !== null);
+
+  const ownerMap = new Map<string, { incidentCount: number; acknowledgedCount: number; resolvedCount: number }>();
+  const breaches: AckAuditReport["breaches"] = [];
+
+  for (const incident of input.incidents) {
+    const current = ownerMap.get(incident.owner) ?? { incidentCount: 0, acknowledgedCount: 0, resolvedCount: 0 };
+    current.incidentCount += 1;
+    if (incident.acknowledgedAt) current.acknowledgedCount += 1;
+    if (incident.resolvedAt) current.resolvedCount += 1;
+    ownerMap.set(incident.owner, current);
+
+    const ackMinutes = minutesBetween(incident.openedAt, incident.acknowledgedAt);
+    const resolveMinutes = minutesBetween(incident.openedAt, incident.resolvedAt);
+    if (ackMinutes === null) {
+      breaches.push({ incidentId: incident.id, owner: incident.owner, reason: "missing_acknowledgement" });
+    } else if (ackMinutes > 10) {
+      breaches.push({ incidentId: incident.id, owner: incident.owner, reason: "ack_over_10m" });
+    }
+    if (resolveMinutes !== null && resolveMinutes > 60) {
+      breaches.push({ incidentId: incident.id, owner: incident.owner, reason: "resolve_over_60m" });
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    totals: {
+      incidentCount: input.incidents.length,
+      acknowledgedCount: input.incidents.filter((incident) => incident.acknowledgedAt).length,
+      resolvedCount: input.incidents.filter((incident) => incident.resolvedAt).length
+    },
+    timing: {
+      medianAckMinutes: median(ackDurations),
+      medianResolveMinutes: median(resolveDurations),
+      averageAckMinutes: average(ackDurations),
+      averageResolveMinutes: average(resolveDurations)
+    },
+    byOwner: [...ownerMap.entries()]
+      .map(([owner, summary]) => ({
+        owner,
+        incidentCount: summary.incidentCount,
+        acknowledgedCount: summary.acknowledgedCount,
+        resolvedCount: summary.resolvedCount
+      }))
+      .sort((left, right) => left.owner.localeCompare(right.owner)),
+    breaches
+  };
+}
+
+export function renderAckAuditMarkdown(report: AckAuditReport): string {
+  const lines = [
+    "# On-call Ack Audit",
+    "",
+    `Generated at: \`${report.generatedAt}\``,
+    "",
+    `Incidents: ${report.totals.incidentCount}`,
+    `Acknowledged: ${report.totals.acknowledgedCount}`,
+    `Resolved: ${report.totals.resolvedCount}`,
+    `Median MTTA: ${report.timing.medianAckMinutes ?? "n/a"} min`,
+    `Median MTTR: ${report.timing.medianResolveMinutes ?? "n/a"} min`,
+    "",
+    "## Owners",
+    "",
+    "| Owner | Incidents | Acked | Resolved |",
+    "| --- | ---: | ---: | ---: |",
+    ...report.byOwner.map(
+      (entry) => `| \`${entry.owner}\` | ${entry.incidentCount} | ${entry.acknowledgedCount} | ${entry.resolvedCount} |`
+    ),
+    "",
+    "## Breaches",
+    ""
+  ];
+
+  if (report.breaches.length === 0) {
+    lines.push("No MTTA / MTTR breaches.");
+  } else {
+    lines.push("| Incident | Owner | Reason |", "| --- | --- | --- |");
+    for (const breach of report.breaches) {
+      lines.push(`| \`${breach.incidentId}\` | \`${breach.owner}\` | \`${breach.reason}\` |`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const report = buildAckAuditReport(readJson(path.resolve(args.inputPath)));
+  const outputPath = path.resolve(args.outputPath ?? path.join("artifacts", "ops", "oncall-ack-audit.json"));
+  const markdownOutputPath = path.resolve(args.markdownOutputPath ?? outputPath.replace(/\.json$/i, ".md"));
+  ensureDirectory(outputPath);
+  ensureDirectory(markdownOutputPath);
+  fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  fs.writeFileSync(markdownOutputPath, renderAckAuditMarkdown(report), "utf8");
+  console.log(`Wrote on-call ack audit JSON: ${path.relative(process.cwd(), outputPath)}`);
+  console.log(`Wrote on-call ack audit Markdown: ${path.relative(process.cwd(), markdownOutputPath)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/test/oncall-ack-audit.test.ts
+++ b/scripts/test/oncall-ack-audit.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+test("oncall ack audit summarizes MTTA / MTTR and breach rows", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-oncall-audit-"));
+  const inputPath = path.join(workspace, "incidents.json");
+  const outputPath = path.join(workspace, "ack-audit.json");
+  const markdownOutputPath = path.join(workspace, "ack-audit.md");
+
+  fs.writeFileSync(
+    inputPath,
+    JSON.stringify(
+      {
+        incidents: [
+          {
+            id: "alert-1",
+            service: "payments",
+            severity: "critical",
+            owner: "commerce-oncall",
+            openedAt: "2026-04-17T00:00:00.000Z",
+            acknowledgedAt: "2026-04-17T00:06:00.000Z",
+            resolvedAt: "2026-04-17T00:35:00.000Z"
+          },
+          {
+            id: "alert-2",
+            service: "runtime",
+            severity: "critical",
+            owner: "ops-oncall",
+            openedAt: "2026-04-17T01:00:00.000Z",
+            acknowledgedAt: "2026-04-17T01:18:00.000Z",
+            resolvedAt: "2026-04-17T02:20:00.000Z"
+          }
+        ]
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  const result = spawnSync(
+    "node",
+    [
+      "--import",
+      path.join(repoRoot, "node_modules/tsx/dist/loader.mjs"),
+      "./scripts/oncall-ack-audit.ts",
+      "--input",
+      inputPath,
+      "--output",
+      outputPath,
+      "--markdown-output",
+      markdownOutputPath
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 0, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    totals: { incidentCount: number; acknowledgedCount: number; resolvedCount: number };
+    timing: { medianAckMinutes: number | null; medianResolveMinutes: number | null };
+    breaches: Array<{ incidentId: string; reason: string }>;
+  };
+  assert.deepEqual(report.totals, {
+    incidentCount: 2,
+    acknowledgedCount: 2,
+    resolvedCount: 2
+  });
+  assert.equal(report.timing.medianAckMinutes, 12);
+  assert.equal(report.timing.medianResolveMinutes, 57.5);
+  assert.deepEqual(
+    report.breaches.map((breach) => [breach.incidentId, breach.reason]),
+    [
+      ["alert-2", "ack_over_10m"],
+      ["alert-2", "resolve_over_60m"]
+    ]
+  );
+
+  const markdown = fs.readFileSync(markdownOutputPath, "utf8");
+  assert.match(markdown, /Median MTTA: 12 min/);
+  assert.match(markdown, /`alert-2`/);
+});


### PR DESCRIPTION
## Summary
- add launch-p2 grafana dashboards for live ops, customer service, and payment health
- add on-call roster documentation and alertmanager routing
- add ack audit script and test coverage for MTTA/MTTR summaries

Closes #1548