### PR TITLE
feat: add live ops analytics dashboards

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -3633,6 +3633,7 @@ export class VeilRoot extends Component {
     | "experiment_exposure"
     | "shop_open"
     | "purchase_initiated"
+    | "purchase_attempt"
     | "asset_load_failed"
     | "client_perf_degraded"
     | "client_runtime_error"
@@ -3850,14 +3851,16 @@ export class VeilRoot extends Component {
 
   private trackPurchaseInitiated(product: ShopProduct, surface: "lobby" | "battle_pass"): void {
     const price = Math.max(0, Math.floor(product.wechatPriceFen ?? product.price ?? 0));
-    this.trackClientAnalyticsEvent("purchase_initiated", {
+    const payload = {
       roomId: this.roomId,
       productId: product.productId,
       productType: product.type,
       currency: product.wechatPriceFen ? "wechat_fen" : "gems",
       price,
       surface
-    });
+    };
+    this.trackClientAnalyticsEvent("purchase_initiated", payload);
+    this.trackClientAnalyticsEvent("purchase_attempt", payload);
   }
 
   private setBattleFeedback(feedback: CocosBattleFeedbackView | null, durationMs = BATTLE_FEEDBACK_DURATION_MS): void {

--- a/docs/analytics-pipeline-runbook.md
+++ b/docs/analytics-pipeline-runbook.md
@@ -83,6 +83,7 @@ Notes:
 | Event | Payload fields | Notes |
 | --- | --- | --- |
 | `session_end` | `roomId`, `disconnectReason`, `sessionDurationMs` | Emitted when a room transport closes or the room disposes. |
+| `purchase_attempt` | `productId`, `productType`, `currency`, `price`, `surface` | Emitted when the client presses a monetized CTA and enters the purchase funnel. |
 | `purchase_completed` | `purchaseId`, `productId`, `paymentMethod`, `quantity`, `totalPrice` | Emitted only after rewards are granted successfully. |
 | `purchase_failed` | `purchaseId`, `productId`, `paymentMethod`, `failureReason`, `orderStatus` | Emitted when a purchase cannot grant rewards or fails before completion. |
 | `tutorial_step` | `stepId`, `status` | Tutorial completion remains `tutorial_step` with `stepId = tutorial_completed`; no standalone `tutorial_completed` event is introduced in this change. |
@@ -226,3 +227,20 @@ If delivery health degrades:
 2. Check `/metrics` for `veil_analytics_flush_failures_total`, `veil_analytics_events_buffered`, and whether `session_start` / `payment_fraud_signal` counters are still moving.
 3. If the sink is `stdout` unexpectedly, treat that as a config drift incident and restore `ANALYTICS_SINK=http` plus `ANALYTICS_ENDPOINT`.
 4. If the gateway is down, keep the runtime buffer under review, pause dashboards that assume freshness, and escalate via the alerts in [`docs/alerting-rules.yml`](/home/gpt/project/ProjectVeil/docs/alerting-rules.yml).
+
+## Daily live-ops digest
+
+When growth / monetization needs a concise business-facing summary, generate a daily digest from the curated KPI export:
+
+```bash
+node --import ./node_modules/tsx/dist/loader.mjs ./scripts/live-ops-daily-digest.ts \
+  --input artifacts/analytics/live-ops-daily-digest-input.json \
+  --output artifacts/analytics/live-ops-daily-digest.json \
+  --markdown-output artifacts/analytics/live-ops-daily-digest.md
+```
+
+The digest answers three quick questions:
+
+1. Did DAU and retention hold?
+2. Did the purchase funnel convert?
+3. Which SKU carried the day?

--- a/infra/grafana/dashboard-dau-retention.json
+++ b/infra/grafana/dashboard-dau-retention.json
@@ -1,0 +1,44 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [{ "expr": "sum(increase(veil_auth_guest_logins_total[24h])) + sum(increase(veil_auth_account_logins_total[24h]))", "refId": "A" }],
+      "title": "DAU Proxy",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 10, "w": 16, "x": 8, "y": 0 },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_analytics_events_flushed_total{name=~\"daily_login|session_start\"}[1d])) by (name)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Retention Proxy Signals",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["launch-p2", "analytics"],
+  "templating": { "list": [] },
+  "time": { "from": "now-7d", "to": "now" },
+  "title": "Project Veil DAU / Retention",
+  "uid": "project-veil-dau-retention",
+  "version": 1
+}

--- a/infra/grafana/dashboard-monetization-ltv.json
+++ b/infra/grafana/dashboard-monetization-ltv.json
@@ -1,0 +1,44 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "targets": [{ "expr": "sum(increase(veil_analytics_events_flushed_total{name=\"purchase_completed\"}[24h])) * 6", "refId": "A" }],
+      "title": "GMV Proxy (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 10, "w": 16, "x": 8, "y": 0 },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_analytics_events_flushed_total{name=~\"purchase_attempt|purchase_completed|purchase_failed\"}[6h])) by (name)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Monetization Funnel Events",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["launch-p2", "analytics", "monetization"],
+  "templating": { "list": [] },
+  "time": { "from": "now-7d", "to": "now" },
+  "title": "Project Veil Monetization / LTV",
+  "uid": "project-veil-monetization-ltv",
+  "version": 1
+}

--- a/infra/grafana/dashboard-payment-funnel.json
+++ b/infra/grafana/dashboard-payment-funnel.json
@@ -1,0 +1,43 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_analytics_events_flushed_total{name=~\"shop_open|purchase_attempt|purchase_completed|purchase_failed\"}[15m])) by (name)",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Payment Funnel Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum(rate(veil_runtime_error_events_total{feature_area=\"payment\"}[15m])) by (error_code)",
+          "legendFormat": "{{error_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Payment Error Breakdown",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["launch-p2", "analytics", "payments"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "title": "Project Veil Payment Funnel",
+  "uid": "project-veil-payment-funnel",
+  "version": 1
+}

--- a/packages/shared/src/analytics-events.ts
+++ b/packages/shared/src/analytics-events.ts
@@ -121,6 +121,14 @@ export const ANALYTICS_EVENT_CATALOG = {
     currency: "wechat_fen",
     price: 600
   }),
+  purchase_attempt: defineAnalyticsEvent("purchase_attempt", 1, "Player attempted a shop purchase from the client.", {
+    roomId: "room-contract",
+    productId: "gem_pack_small",
+    productType: "gem_pack",
+    currency: "wechat_fen",
+    price: 600,
+    surface: "lobby"
+  }),
   purchase_completed: defineAnalyticsEvent(
     "purchase_completed",
     1,

--- a/packages/shared/test/analytics-events.test.ts
+++ b/packages/shared/test/analytics-events.test.ts
@@ -219,6 +219,24 @@ test("createAnalyticsEvent: purchase_completed event carries monetization funnel
   assert.equal(event.payload.totalPrice, 600);
 });
 
+test("createAnalyticsEvent: purchase_attempt carries surface and pricing fields", () => {
+  const event = createAnalyticsEvent("purchase_attempt", {
+    playerId: "player-1",
+    payload: {
+      roomId: "room-1",
+      productId: "gem_pack_small",
+      productType: "gem_pack",
+      currency: "wechat_fen",
+      price: 600,
+      surface: "lobby"
+    }
+  });
+
+  assert.equal(event.payload.productId, "gem_pack_small");
+  assert.equal(event.payload.surface, "lobby");
+  assert.equal(event.payload.price, 600);
+});
+
 test("createAnalyticsEvent: purchase_failed event carries failure reason and status", () => {
   const event = createAnalyticsEvent("purchase_failed", {
     playerId: "player-1",

--- a/scripts/live-ops-daily-digest.ts
+++ b/scripts/live-ops-daily-digest.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs";
+import path from "node:path";
+
+interface Args {
+  inputPath: string;
+  outputPath?: string;
+  markdownOutputPath?: string;
+}
+
+interface LiveOpsDigestInput {
+  generatedAt?: string;
+  dau: number;
+  retainedD1: number;
+  retainedD7: number;
+  purchaseAttempts: number;
+  purchaseCompleted: number;
+  gmvFen: number;
+  topSkus: Array<{ productId: string; revenueFen: number }>;
+}
+
+interface LiveOpsDigestReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  retention: {
+    dau: number;
+    retainedD1: number;
+    retainedD7: number;
+    d1Rate: number;
+    d7Rate: number;
+  };
+  monetization: {
+    purchaseAttempts: number;
+    purchaseCompleted: number;
+    conversionRate: number;
+    gmvFen: number;
+  };
+  topSkus: Array<{ productId: string; revenueFen: number }>;
+  headlines: string[];
+}
+
+function parseArgs(argv: string[]): Args {
+  let inputPath = "";
+  let outputPath: string | undefined;
+  let markdownOutputPath: string | undefined;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const current = argv[index];
+    const next = argv[index + 1];
+    if (current === "--input" && next) {
+      inputPath = next;
+      index += 1;
+      continue;
+    }
+    if (current === "--output" && next) {
+      outputPath = next;
+      index += 1;
+      continue;
+    }
+    if (current === "--markdown-output" && next) {
+      markdownOutputPath = next;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown or incomplete argument: ${current}`);
+  }
+
+  if (!inputPath) {
+    throw new Error("Pass --input <path>.");
+  }
+
+  return { inputPath, outputPath, markdownOutputPath };
+}
+
+function ensureDirectory(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+export function buildLiveOpsDailyDigest(input: LiveOpsDigestInput): LiveOpsDigestReport {
+  const d1Rate = input.dau > 0 ? Number((input.retainedD1 / input.dau).toFixed(4)) : 0;
+  const d7Rate = input.dau > 0 ? Number((input.retainedD7 / input.dau).toFixed(4)) : 0;
+  const conversionRate = input.purchaseAttempts > 0 ? Number((input.purchaseCompleted / input.purchaseAttempts).toFixed(4)) : 0;
+  return {
+    schemaVersion: 1,
+    generatedAt: input.generatedAt ?? new Date().toISOString(),
+    retention: {
+      dau: input.dau,
+      retainedD1: input.retainedD1,
+      retainedD7: input.retainedD7,
+      d1Rate,
+      d7Rate
+    },
+    monetization: {
+      purchaseAttempts: input.purchaseAttempts,
+      purchaseCompleted: input.purchaseCompleted,
+      conversionRate,
+      gmvFen: input.gmvFen
+    },
+    topSkus: input.topSkus.slice(0, 5),
+    headlines: [
+      `DAU ${input.dau}, D1 ${(d1Rate * 100).toFixed(1)}%, D7 ${(d7Rate * 100).toFixed(1)}%`,
+      `Purchase funnel ${(conversionRate * 100).toFixed(1)}% (${input.purchaseCompleted}/${input.purchaseAttempts})`,
+      `Top SKU ${input.topSkus[0]?.productId ?? "n/a"}`
+    ]
+  };
+}
+
+export function renderLiveOpsDailyDigestMarkdown(report: LiveOpsDigestReport): string {
+  return [
+    "# Live Ops Daily Digest",
+    "",
+    `Generated at: \`${report.generatedAt}\``,
+    "",
+    "## Headlines",
+    "",
+    ...report.headlines.map((line) => `- ${line}`),
+    "",
+    "## Retention",
+    "",
+    `DAU: ${report.retention.dau}`,
+    `D1: ${(report.retention.d1Rate * 100).toFixed(1)}%`,
+    `D7: ${(report.retention.d7Rate * 100).toFixed(1)}%`,
+    "",
+    "## Monetization",
+    "",
+    `Attempts: ${report.monetization.purchaseAttempts}`,
+    `Completed: ${report.monetization.purchaseCompleted}`,
+    `Conversion: ${(report.monetization.conversionRate * 100).toFixed(1)}%`,
+    `GMV (fen): ${report.monetization.gmvFen}`,
+    "",
+    "## Top SKUs",
+    "",
+    "| SKU | Revenue (fen) |",
+    "| --- | ---: |",
+    ...report.topSkus.map((sku) => `| \`${sku.productId}\` | ${sku.revenueFen} |`)
+  ].join("\n").concat("\n");
+}
+
+function main(): void {
+  const args = parseArgs(process.argv);
+  const input = JSON.parse(fs.readFileSync(path.resolve(args.inputPath), "utf8")) as LiveOpsDigestInput;
+  const report = buildLiveOpsDailyDigest(input);
+  const outputPath = path.resolve(args.outputPath ?? path.join("artifacts", "analytics", "live-ops-daily-digest.json"));
+  const markdownOutputPath = path.resolve(args.markdownOutputPath ?? outputPath.replace(/\.json$/i, ".md"));
+  ensureDirectory(outputPath);
+  ensureDirectory(markdownOutputPath);
+  fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  fs.writeFileSync(markdownOutputPath, renderLiveOpsDailyDigestMarkdown(report), "utf8");
+  console.log(`Wrote live-ops daily digest JSON: ${path.relative(process.cwd(), outputPath)}`);
+  console.log(`Wrote live-ops daily digest Markdown: ${path.relative(process.cwd(), markdownOutputPath)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/test/live-ops-daily-digest.test.ts
+++ b/scripts/test/live-ops-daily-digest.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = path.resolve(__dirname, "../..");
+
+test("live-ops daily digest renders retention and monetization headlines", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "veil-live-ops-digest-"));
+  const inputPath = path.join(workspace, "digest-input.json");
+  const outputPath = path.join(workspace, "digest.json");
+  const markdownOutputPath = path.join(workspace, "digest.md");
+
+  fs.writeFileSync(
+    inputPath,
+    JSON.stringify(
+      {
+        generatedAt: "2026-04-17T08:00:00.000Z",
+        dau: 1000,
+        retainedD1: 420,
+        retainedD7: 180,
+        purchaseAttempts: 160,
+        purchaseCompleted: 64,
+        gmvFen: 128000,
+        topSkus: [
+          { productId: "gem_pack_small", revenueFen: 64000 },
+          { productId: "battle_pass", revenueFen: 32000 }
+        ]
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  const result = spawnSync(
+    "node",
+    [
+      "--import",
+      path.join(repoRoot, "node_modules/tsx/dist/loader.mjs"),
+      "./scripts/live-ops-daily-digest.ts",
+      "--input",
+      inputPath,
+      "--output",
+      outputPath,
+      "--markdown-output",
+      markdownOutputPath
+    ],
+    {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }
+  );
+
+  assert.equal(result.status, 0, `stdout=${result.stdout}\nstderr=${result.stderr}`);
+  const report = JSON.parse(fs.readFileSync(outputPath, "utf8")) as {
+    retention: { d1Rate: number; d7Rate: number };
+    monetization: { conversionRate: number; gmvFen: number };
+    headlines: string[];
+  };
+  assert.equal(report.retention.d1Rate, 0.42);
+  assert.equal(report.retention.d7Rate, 0.18);
+  assert.equal(report.monetization.conversionRate, 0.4);
+  assert.equal(report.monetization.gmvFen, 128000);
+  assert.match(report.headlines[0] ?? "", /DAU 1000, D1 42\.0%, D7 18\.0%/);
+  assert.match(report.headlines[1] ?? "", /Purchase funnel 40\.0%/);
+
+  const markdown = fs.readFileSync(markdownOutputPath, "utf8");
+  assert.match(markdown, /## Monetization/);
+  assert.match(markdown, /`gem_pack_small`/);
+});


### PR DESCRIPTION
## Summary
- add launch-p2 grafana dashboards for dau/retention, ltv, and payment funnels
- add a live ops daily digest script and tests
- expand analytics catalog coverage for launch-p2 summaries

Closes #1550