### PR TITLE
feat: add hpa drill and cost observability

### DIFF
--- a/docs/alerting-rules.yml
+++ b/docs/alerting-rules.yml
@@ -279,3 +279,15 @@ groups:
           summary: Project Veil client severe runtime errors are above budget
           description: Client `client_runtime_error` analytics exceeded five flushed events in 15 minutes. Check whether the spike is dominated by `session_disconnect` or `client_error_boundary_triggered` payloads before widening rollout.
           runbook_url: ./alerting-runbook.md#alert-veilclientruntimeerrorshigh
+
+      - alert: VeilDailyInfrastructureCostHigh
+        expr: sum(veil_infra_estimated_daily_cost_usd) > 180
+        for: 30m
+        labels:
+          severity: warning
+          service: project-veil-ops
+          notify: ops-pagerduty
+        annotations:
+          summary: Project Veil daily infrastructure cost exceeded the configured budget
+          description: Estimated daily infrastructure cost has remained above $180 for at least 30 minutes. Review namespace and deployment cost panels, then confirm whether HPA or live-ops traffic is responsible before the next scale change.
+          runbook_url: ./capacity-scale-drill.md#alert-veildailyinfrastructurecosthigh

--- a/docs/capacity-scale-drill.md
+++ b/docs/capacity-scale-drill.md
@@ -1,0 +1,79 @@
+# Capacity Scale Drill
+
+`LAUNCH-P3 #1556` 把 HPA 演练从“只有理论容量规划”推进成了可重复执行的 drill。
+
+## What We Added
+
+- `npm run ops:hpa-scale-drill`
+- `infra/grafana/dashboards/cost-overview.json`
+- `docs/alerting-rules.yml` 里的 `VeilDailyInfrastructureCostHigh`
+- `infra/alertmanager.yml` 里的 cost alert 路由
+
+## Input Format
+
+脚本消费一份按时间排序的 checkpoint JSON：
+
+```json
+{
+  "checkpoints": [
+    {
+      "at": "2026-04-17T09:00:00.000Z",
+      "replicas": 2,
+      "activeRooms": 10,
+      "connectedPlayers": 20,
+      "cpuUtilizationPct": 51
+    },
+    {
+      "at": "2026-04-17T09:00:20.000Z",
+      "replicas": 2,
+      "activeRooms": 16,
+      "connectedPlayers": 32,
+      "cpuUtilizationPct": 78
+    },
+    {
+      "at": "2026-04-17T09:01:05.000Z",
+      "replicas": 4,
+      "activeRooms": 24,
+      "connectedPlayers": 48,
+      "cpuUtilizationPct": 63
+    }
+  ]
+}
+```
+
+## Run
+
+```bash
+npm run ops:hpa-scale-drill -- \
+  --input ./artifacts/ops/hpa-checkpoints.json \
+  --output-dir ./artifacts/ops \
+  --threshold-active-rooms 16 \
+  --target-replicas 4
+```
+
+产物：
+
+- `hpa-scale-drill.json`
+- `hpa-scale-drill.md`
+
+## Expected Review Questions
+
+每次 drill 至少回答这 3 个问题：
+
+1. HPA 是否在阈值触发后按预期从 `N` 扩到 `2N`
+2. scale-out latency 是否还在当前可接受窗口内
+3. cost overview 面板是否能解释这次扩容带来的日成本变化
+
+## Alert: VeilDailyInfrastructureCostHigh
+
+触发条件：
+
+- `sum(veil_infra_estimated_daily_cost_usd) > 180`
+- 持续 `30m`
+
+处理顺序：
+
+1. 先看 `dashboards/cost-overview.json` 里的 namespace / deployment 成本分布
+2. 对照 HPA drill 报告，看是否是 `project-veil-server` 扩容导致
+3. 如果是活动流量抬升，再对照 live-ops calendar 和 kill-switch 状态
+4. 如果是异常放大，再考虑先降灰度或触发限流/回滚

--- a/infra/alertmanager.yml
+++ b/infra/alertmanager.yml
@@ -13,6 +13,10 @@ route:
   repeat_interval: 3h
   routes:
     - matchers:
+        - alertname="VeilDailyInfrastructureCostHigh"
+      receiver: ops-pagerduty
+      continue: false
+    - matchers:
         - notify="ops-pagerduty"
       receiver: ops-pagerduty
       continue: false

--- a/infra/grafana/dashboards/cost-overview.json
+++ b/infra/grafana/dashboards/cost-overview.json
@@ -1,0 +1,61 @@
+{
+  "title": "Project Veil Cost Overview",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5m",
+  "tags": ["launch-p3", "ops", "cost"],
+  "templating": {
+    "list": [
+      {
+        "name": "namespace",
+        "type": "query",
+        "label": "Namespace",
+        "datasource": "Prometheus",
+        "query": "label_values(veil_infra_estimated_daily_cost_usd, namespace)",
+        "includeAll": true,
+        "multi": true,
+        "refresh": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Estimated Daily Cost (USD)",
+      "gridPos": { "x": 0, "y": 0, "w": 8, "h": 5 },
+      "targets": [
+        {
+          "expr": "sum(veil_infra_estimated_daily_cost_usd{namespace=~\"$namespace\"})",
+          "legendFormat": "daily_cost"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cost By Deployment",
+      "gridPos": { "x": 8, "y": 0, "w": 16, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (deployment) (veil_infra_estimated_daily_cost_usd{namespace=~\"$namespace\"})",
+          "legendFormat": "{{deployment}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Replica Pressure vs Active Rooms",
+      "gridPos": { "x": 0, "y": 8, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum(veil_room_active_total{namespace=~\"$namespace\"})",
+          "legendFormat": "active_rooms"
+        },
+        {
+          "expr": "sum(kube_deployment_status_replicas{namespace=~\"$namespace\", deployment=\"project-veil-server\"})",
+          "legendFormat": "server_replicas"
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "stress:rooms": "node --import tsx ./scripts/stress-concurrent-rooms.ts",
     "stress:rooms:baseline": "node --import tsx ./scripts/stress-concurrent-rooms.ts --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --artifact-path=artifacts/release-readiness/stress-rooms-runtime-metrics.json",
     "stress:rooms:capacity-plan": "node --import tsx ./scripts/capacity-planning-report.ts",
+    "ops:hpa-scale-drill": "node --import tsx ./scripts/hpa-scale-drill.ts",
     "stress:rooms:reconnect-soak": "node --import tsx ./scripts/stress-concurrent-rooms.ts --scenarios=reconnect_soak --rooms=48 --connect-concurrency=12 --action-concurrency=12 --sample-interval-ms=100 --reconnect-pause-ms=150 --reconnect-cycles=8",
     "perf:runtime:compare": "node --import tsx ./scripts/compare-runtime-regression.ts --baseline ./configs/runtime-regression-baseline.json --artifact ./artifacts/release-readiness/stress-rooms-runtime-metrics.json --output ./artifacts/release-readiness/runtime-regression-report.json",
     "validate:battle": "node --import tsx ./scripts/validate-battle-balance.ts",

--- a/scripts/hpa-scale-drill.ts
+++ b/scripts/hpa-scale-drill.ts
@@ -1,0 +1,222 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface HpaScaleCheckpoint {
+  at: string;
+  replicas: number;
+  activeRooms: number;
+  connectedPlayers: number;
+  cpuUtilizationPct?: number;
+}
+
+export interface HpaScaleDrillReport {
+  schemaVersion: 1;
+  artifactType: "hpa-scale-drill";
+  generatedAt: string;
+  summary: {
+    status: "passed" | "failed";
+    scaledFromReplicas: number;
+    scaledToReplicas: number;
+    expectedTargetReplicas: number;
+    scaleOutLatencySeconds: number | null;
+    thresholdActiveRooms: number;
+    headline: string;
+  };
+  peak: {
+    activeRooms: number;
+    connectedPlayers: number;
+    cpuUtilizationPct: number;
+  };
+  checkpoints: HpaScaleCheckpoint[];
+}
+
+interface CliOptions {
+  inputPath: string;
+  outputDir: string;
+  thresholdActiveRooms: number;
+  targetReplicas: number;
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function parsePositiveInteger(value: string | undefined, flag: string): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    fail(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let inputPath = "";
+  let outputDir = path.resolve(process.cwd(), "artifacts", "ops");
+  let thresholdActiveRooms = 16;
+  let targetReplicas = 4;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const next = argv[index + 1];
+    if (argument === "--input" && next) {
+      inputPath = path.resolve(process.cwd(), next);
+      index += 1;
+      continue;
+    }
+    if (argument === "--output-dir" && next) {
+      outputDir = path.resolve(process.cwd(), next);
+      index += 1;
+      continue;
+    }
+    if (argument === "--threshold-active-rooms" && next) {
+      thresholdActiveRooms = parsePositiveInteger(next, "--threshold-active-rooms");
+      index += 1;
+      continue;
+    }
+    if (argument === "--target-replicas" && next) {
+      targetReplicas = parsePositiveInteger(next, "--target-replicas");
+      index += 1;
+      continue;
+    }
+  }
+
+  if (!inputPath) {
+    fail("Missing required --input <hpa-checkpoints.json> argument");
+  }
+
+  return {
+    inputPath,
+    outputDir,
+    thresholdActiveRooms,
+    targetReplicas
+  };
+}
+
+function normalizeCheckpoints(input: unknown): HpaScaleCheckpoint[] {
+  const raw = Array.isArray(input)
+    ? input
+    : Array.isArray((input as { checkpoints?: unknown[] } | null)?.checkpoints)
+      ? ((input as { checkpoints: unknown[] }).checkpoints ?? [])
+      : [];
+
+  return raw
+    .map((entry) => {
+      const record = entry as Partial<HpaScaleCheckpoint>;
+      const at = typeof record.at === "string" ? record.at : "";
+      const timestamp = new Date(at);
+      const replicas = Math.max(0, Math.floor(record.replicas ?? 0));
+      const activeRooms = Math.max(0, Math.floor(record.activeRooms ?? 0));
+      const connectedPlayers = Math.max(0, Math.floor(record.connectedPlayers ?? 0));
+      if (!at || Number.isNaN(timestamp.getTime()) || replicas <= 0) {
+        return null;
+      }
+      return {
+        at: timestamp.toISOString(),
+        replicas,
+        activeRooms,
+        connectedPlayers,
+        ...(Number.isFinite(record.cpuUtilizationPct) ? { cpuUtilizationPct: Number(record.cpuUtilizationPct) } : {})
+      } satisfies HpaScaleCheckpoint;
+    })
+    .filter((entry): entry is HpaScaleCheckpoint => Boolean(entry))
+    .sort((left, right) => left.at.localeCompare(right.at));
+}
+
+export function buildHpaScaleDrillReport(
+  checkpoints: HpaScaleCheckpoint[],
+  options: Pick<CliOptions, "thresholdActiveRooms" | "targetReplicas">
+): HpaScaleDrillReport {
+  if (checkpoints.length === 0) {
+    fail("At least one HPA checkpoint is required");
+  }
+
+  const thresholdCheckpoint = checkpoints.find((entry) => entry.activeRooms >= options.thresholdActiveRooms) ?? null;
+  const targetCheckpoint = checkpoints.find((entry) => entry.replicas >= options.targetReplicas) ?? null;
+  const firstCheckpoint = checkpoints[0]!;
+  const peak = checkpoints.reduce(
+    (current, checkpoint) => ({
+      activeRooms: Math.max(current.activeRooms, checkpoint.activeRooms),
+      connectedPlayers: Math.max(current.connectedPlayers, checkpoint.connectedPlayers),
+      cpuUtilizationPct: Math.max(current.cpuUtilizationPct, checkpoint.cpuUtilizationPct ?? 0)
+    }),
+    { activeRooms: 0, connectedPlayers: 0, cpuUtilizationPct: 0 }
+  );
+
+  const scaleOutLatencySeconds =
+    thresholdCheckpoint && targetCheckpoint
+      ? Math.max(0, Math.round((new Date(targetCheckpoint.at).getTime() - new Date(thresholdCheckpoint.at).getTime()) / 1000))
+      : null;
+  const status =
+    thresholdCheckpoint && targetCheckpoint && targetCheckpoint.replicas >= options.targetReplicas ? "passed" : "failed";
+
+  return {
+    schemaVersion: 1,
+    artifactType: "hpa-scale-drill",
+    generatedAt: new Date().toISOString(),
+    summary: {
+      status,
+      scaledFromReplicas: firstCheckpoint.replicas,
+      scaledToReplicas: targetCheckpoint?.replicas ?? checkpoints[checkpoints.length - 1]!.replicas,
+      expectedTargetReplicas: options.targetReplicas,
+      scaleOutLatencySeconds,
+      thresholdActiveRooms: options.thresholdActiveRooms,
+      headline:
+        status === "passed"
+          ? `HPA 在 ${scaleOutLatencySeconds ?? 0} 秒内从 ${firstCheckpoint.replicas} 扩到 ${targetCheckpoint?.replicas ?? options.targetReplicas} 副本。`
+          : `HPA 未在目标窗口内扩到 ${options.targetReplicas} 副本，需复查 autoscaling 配置或观测链路。`
+    },
+    peak,
+    checkpoints
+  };
+}
+
+export function renderHpaScaleDrillMarkdown(report: HpaScaleDrillReport): string {
+  const lines = [
+    "# Capacity Scale Drill",
+    "",
+    `Overall status: \`${report.summary.status}\``,
+    "",
+    `- Threshold active rooms: \`${report.summary.thresholdActiveRooms}\``,
+    `- Scale result: \`${report.summary.scaledFromReplicas} -> ${report.summary.scaledToReplicas}\` (target \`${report.summary.expectedTargetReplicas}\`)`,
+    `- Scale-out latency: \`${report.summary.scaleOutLatencySeconds ?? "n/a"}s\``,
+    `- Peak active rooms: \`${report.peak.activeRooms}\``,
+    `- Peak connected players: \`${report.peak.connectedPlayers}\``,
+    `- Peak CPU utilization: \`${report.peak.cpuUtilizationPct.toFixed(1)}%\``,
+    "",
+    report.summary.headline,
+    "",
+    "## Checkpoints",
+    "",
+    "| At | Replicas | Active rooms | Connected players | CPU |",
+    "| --- | ---: | ---: | ---: | ---: |"
+  ];
+
+  for (const checkpoint of report.checkpoints) {
+    lines.push(
+      `| ${checkpoint.at} | ${checkpoint.replicas} | ${checkpoint.activeRooms} | ${checkpoint.connectedPlayers} | ${(checkpoint.cpuUtilizationPct ?? 0).toFixed(1)}% |`
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export function runHpaScaleDrill(options: CliOptions): {
+  report: HpaScaleDrillReport;
+  jsonPath: string;
+  markdownPath: string;
+} {
+  const checkpoints = normalizeCheckpoints(JSON.parse(fs.readFileSync(options.inputPath, "utf8")));
+  const report = buildHpaScaleDrillReport(checkpoints, options);
+  fs.mkdirSync(options.outputDir, { recursive: true });
+  const jsonPath = path.join(options.outputDir, "hpa-scale-drill.json");
+  const markdownPath = path.join(options.outputDir, "hpa-scale-drill.md");
+  fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
+  fs.writeFileSync(markdownPath, renderHpaScaleDrillMarkdown(report));
+  return { report, jsonPath, markdownPath };
+}
+
+if (process.argv[1] && import.meta.url === new URL(process.argv[1], "file://").href) {
+  const result = runHpaScaleDrill(parseArgs(process.argv.slice(2)));
+  console.log(`Wrote HPA scale drill JSON: ${result.jsonPath}`);
+  console.log(`Wrote HPA scale drill markdown: ${result.markdownPath}`);
+}

--- a/scripts/test/hpa-scale-drill.test.ts
+++ b/scripts/test/hpa-scale-drill.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildHpaScaleDrillReport,
+  renderHpaScaleDrillMarkdown,
+  runHpaScaleDrill
+} from "../hpa-scale-drill.ts";
+
+test("buildHpaScaleDrillReport reports a passing 2x scale-out window", () => {
+  const report = buildHpaScaleDrillReport(
+    [
+      { at: "2026-04-17T09:00:00.000Z", replicas: 2, activeRooms: 10, connectedPlayers: 20, cpuUtilizationPct: 51 },
+      { at: "2026-04-17T09:00:20.000Z", replicas: 2, activeRooms: 16, connectedPlayers: 32, cpuUtilizationPct: 78 },
+      { at: "2026-04-17T09:01:05.000Z", replicas: 4, activeRooms: 24, connectedPlayers: 48, cpuUtilizationPct: 63 }
+    ],
+    {
+      thresholdActiveRooms: 16,
+      targetReplicas: 4
+    }
+  );
+
+  assert.equal(report.summary.status, "passed");
+  assert.equal(report.summary.scaledFromReplicas, 2);
+  assert.equal(report.summary.scaledToReplicas, 4);
+  assert.equal(report.summary.scaleOutLatencySeconds, 45);
+});
+
+test("renderHpaScaleDrillMarkdown includes the scale-out headline", () => {
+  const markdown = renderHpaScaleDrillMarkdown(
+    buildHpaScaleDrillReport(
+      [
+        { at: "2026-04-17T09:00:00.000Z", replicas: 2, activeRooms: 10, connectedPlayers: 20 },
+        { at: "2026-04-17T09:00:20.000Z", replicas: 2, activeRooms: 16, connectedPlayers: 32 },
+        { at: "2026-04-17T09:01:05.000Z", replicas: 4, activeRooms: 24, connectedPlayers: 48 }
+      ],
+      {
+        thresholdActiveRooms: 16,
+        targetReplicas: 4
+      }
+    )
+  );
+
+  assert.match(markdown, /Overall status: `passed`/);
+  assert.match(markdown, /HPA 在 45 秒内从 2 扩到 4 副本/);
+});
+
+test("runHpaScaleDrill writes JSON and markdown artifacts", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "hpa-scale-drill-"));
+  const inputPath = path.join(workspace, "hpa-checkpoints.json");
+  const outputDir = path.join(workspace, "artifacts");
+
+  fs.writeFileSync(
+    inputPath,
+    JSON.stringify({
+      checkpoints: [
+        { at: "2026-04-17T09:00:00.000Z", replicas: 2, activeRooms: 10, connectedPlayers: 20 },
+        { at: "2026-04-17T09:00:20.000Z", replicas: 2, activeRooms: 16, connectedPlayers: 32 },
+        { at: "2026-04-17T09:01:05.000Z", replicas: 4, activeRooms: 24, connectedPlayers: 48 }
+      ]
+    }),
+    "utf8"
+  );
+
+  const result = runHpaScaleDrill({
+    inputPath,
+    outputDir,
+    thresholdActiveRooms: 16,
+    targetReplicas: 4
+  });
+
+  assert.equal(result.report.summary.status, "passed");
+  assert.equal(fs.existsSync(result.jsonPath), true);
+  assert.equal(fs.existsSync(result.markdownPath), true);
+});


### PR DESCRIPTION
## Summary
- add a repeatable HPA scale drill script plus markdown/json reporting
- introduce Grafana cost overview artifacts and daily cost alert routing
- document the launch capacity drill workflow

Closes #1556