### PR TITLE
test: fix cocos wechat loader path resolution

### DIFF
--- a/apps/cocos-client/test/cocos-wechat-build.test.ts
+++ b/apps/cocos-client/test/cocos-wechat-build.test.ts
@@ -13,7 +13,11 @@ import {
 } from "../tooling/cocos-wechat-build.ts";
 
 function resolveMainRepoTsxLoaderPath(): string {
-  return path.resolve(__dirname, "../../../../../ProjectVeil/node_modules/tsx/dist/loader.mjs");
+  const loaderPath = path.resolve(__dirname, "../../../node_modules/tsx/dist/loader.mjs");
+  if (!fs.existsSync(loaderPath)) {
+    throw new Error(`Unable to resolve tsx loader from current workspace: ${loaderPath}`);
+  }
+  return loaderPath;
 }
 
 function createPackagedWechatReleaseArtifact(): {


### PR DESCRIPTION
## Summary
- resolve the tsx loader relative to the active workspace instead of a hardcoded absolute path
- fail fast with a clear message if the loader cannot be found
- re-run the WeChat packaging and hotfix tests against the current checkout

Closes #1574