### PR TITLE
refactor: introduce payment gateway domain registry

### DIFF
--- a/apps/server/src/adapters/apple-iap.ts
+++ b/apps/server/src/adapters/apple-iap.ts
@@ -1,14 +1,22 @@
-import { createPrivateKey, createSign, createVerify, randomUUID, X509Certificate } from "node:crypto";
+import { createPrivateKey, createSign, createVerify, X509Certificate } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { emitAnalyticsEvent } from "../analytics";
 import { validateAuthSessionFromRequest } from "../auth";
 import {
-  recordPaymentDeadLetter,
-  recordRuntimeErrorEvent,
-  setPaymentGrantDeadLetterCount,
-  setPaymentGrantQueueCount,
-  setPaymentGrantQueueLatency
-} from "../observability";
+  CallbackDeadLetterQueue,
+  normalizePaymentGrantRetryPolicy as normalizeSharedPaymentGrantRetryPolicy,
+  refreshPaymentGrantObservability as refreshSharedPaymentGrantObservability
+} from "../domain/payment/CallbackDeadLetterQueue";
+import {
+  OrderIdempotencyStore,
+  isAcceptedPaymentOrderStatus as isSharedAcceptedPaymentOrderStatus,
+  isFinalizedPaymentOrderStatus as isSharedFinalizedPaymentOrderStatus,
+  isPaymentOpsStoreReady as isSharedPaymentOpsStoreReady,
+  isPaymentStoreReady as isSharedPaymentStoreReady
+} from "../domain/payment/OrderIdempotencyStore";
+import { PurchaseAuditLog } from "../domain/payment/PurchaseAuditLog";
+import { type PaymentGateway, unsupportedPaymentGatewayOperation } from "../domain/payment/PaymentGateway";
+import type { PaymentGatewayRegistration } from "../domain/payment/PaymentGatewayRegistry";
 import type { PaymentOrderSnapshot, RoomSnapshotStore } from "../persistence";
 import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct, type ShopProductGrant } from "../shop";
 
@@ -95,8 +103,12 @@ interface AppleTransactionLookupResponse {
 }
 
 const MAX_JSON_BODY_BYTES = 64 * 1024;
-const DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS = 5;
-const DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS = 60_000;
+const applePurchaseAuditLog = new PurchaseAuditLog({
+  surface: "apple-iap",
+  paymentMethod: "apple_iap",
+  defaultRoute: "/api/payments/apple/verify",
+  defaultTags: ["apple-iap"]
+});
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -217,61 +229,20 @@ async function requireAuthSession(request: IncomingMessage, response: ServerResp
   return result.session;
 }
 
-function isPaymentStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
-  Required<
-    Pick<
-      RoomSnapshotStore,
-      "createPaymentOrder" | "completePaymentOrder" | "loadPaymentOrder" | "loadPaymentReceiptByOrderId" | "countVerifiedPaymentReceiptsSince"
-    >
-  > {
-  return Boolean(
-    store?.createPaymentOrder &&
-      store.completePaymentOrder &&
-      store.loadPaymentOrder &&
-      store.loadPaymentReceiptByOrderId &&
-      store.countVerifiedPaymentReceiptsSince
-  );
+function isPaymentStoreReady(store: RoomSnapshotStore | null) {
+  return isSharedPaymentStoreReady(store);
 }
 
-function isPaymentOpsStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
-  Required<Pick<RoomSnapshotStore, "listPaymentOrders">> {
-  return Boolean(store?.listPaymentOrders);
+function isPaymentOpsStoreReady(store: RoomSnapshotStore | null) {
+  return isSharedPaymentOpsStoreReady(store);
 }
 
 function normalizePaymentGrantRetryPolicy(): { maxAttempts: number; baseDelayMs: number } {
-  return {
-    maxAttempts: DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS,
-    baseDelayMs: DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS
-  };
+  return normalizeSharedPaymentGrantRetryPolicy();
 }
 
 async function refreshPaymentGrantObservability(store: RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPaymentOrders">>, now: Date) {
-  const [pendingOrders, deadLetterOrders] = await Promise.all([
-    store.listPaymentOrders({ statuses: ["grant_pending"], limit: 200 }),
-    store.listPaymentOrders({ statuses: ["dead_letter"], limit: 200 })
-  ]);
-
-  setPaymentGrantQueueCount(pendingOrders.length);
-  setPaymentGrantDeadLetterCount(deadLetterOrders.length);
-
-  const pendingRetryTimes = pendingOrders
-    .map((order) => (order.nextGrantRetryAt ? new Date(order.nextGrantRetryAt).getTime() : null))
-    .filter((value): value is number => value != null && Number.isFinite(value))
-    .sort((left, right) => left - right);
-
-  const oldestQueuedLatencyMs =
-    pendingOrders.length === 0
-      ? null
-      : pendingOrders
-          .map((order) => (order.lastGrantAttemptAt ? Math.max(0, now.getTime() - new Date(order.lastGrantAttemptAt).getTime()) : 0))
-          .reduce((max, value) => Math.max(max, value), 0);
-  const nextPendingRetryTime = pendingRetryTimes[0];
-  const nextAttemptDelayMs = nextPendingRetryTime != null ? Math.max(0, nextPendingRetryTime - now.getTime()) : null;
-
-  setPaymentGrantQueueLatency({
-    oldestQueuedLatencyMs,
-    nextAttemptDelayMs
-  });
+  return refreshSharedPaymentGrantObservability(store, now);
 }
 
 function normalizeApplePaymentProduct(product: ShopProduct | undefined): ShopProduct & { grant: ShopProductGrant } {
@@ -328,11 +299,11 @@ function resolveAppleOrderAmount(product: ShopProduct): number {
 }
 
 function isFinalizedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
-  return status === "settled" || status === "dead_letter";
+  return isSharedFinalizedPaymentOrderStatus(status);
 }
 
 function isAcceptedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
-  return status !== "created";
+  return isSharedAcceptedPaymentOrderStatus(status);
 }
 
 function emitPurchaseCompletedEvent(input: {
@@ -343,16 +314,7 @@ function emitPurchaseCompletedEvent(input: {
   quantity: number;
   totalPrice: number;
 }): void {
-  emitAnalyticsEvent("purchase_completed", {
-    playerId: input.playerId,
-    payload: {
-      purchaseId: input.purchaseId,
-      productId: input.productId,
-      paymentMethod: input.paymentMethod,
-      quantity: input.quantity,
-      totalPrice: input.totalPrice
-    }
-  });
+  applePurchaseAuditLog.emitCompleted(input);
 }
 
 function emitPurchaseFailedEvent(input: {
@@ -363,16 +325,7 @@ function emitPurchaseFailedEvent(input: {
   failureReason: string;
   orderStatus: PaymentOrderSnapshot["status"] | "failed";
 }): void {
-  emitAnalyticsEvent("purchase_failed", {
-    playerId: input.playerId,
-    payload: {
-      purchaseId: input.purchaseId,
-      productId: input.productId,
-      paymentMethod: input.paymentMethod,
-      failureReason: input.failureReason,
-      orderStatus: input.orderStatus
-    }
-  });
+  applePurchaseAuditLog.emitFailed(input);
 }
 
 function emitPaymentFraudSignal(
@@ -384,44 +337,12 @@ function emitPaymentFraudSignal(
     [key: string]: unknown;
   }
 ): void {
-  try {
-    emitAnalyticsEvent("payment_fraud_signal", {
-      playerId,
-      payload: {
-        signal,
-        ...payload
-      }
-    });
-  } catch {
-    // Fraud logging must not break payment handling.
-  }
-
-  recordRuntimeErrorEvent({
-    id: randomUUID(),
-    recordedAt: new Date().toISOString(),
-    source: "server",
-    surface: "apple-iap",
-    candidateRevision: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null,
-    featureArea: "payment",
-    ownerArea: "commerce",
-    severity: "warn",
-    errorCode: "payment_fraud_signal",
-    message: `Apple IAP fraud signal triggered: ${signal}`,
-    tags: ["apple-iap", signal],
-    context: {
-      roomId: null,
-      playerId,
-      requestId: null,
-      route: "/api/payments/apple/verify",
-      action: null,
-      statusCode: null,
-      crash: false,
-      detail: JSON.stringify({
-        orderId: payload.orderId,
-        productId: payload.productId,
-        signal
-      })
-    }
+  applePurchaseAuditLog.emitFraudSignal({
+    playerId,
+    signal,
+    orderId: payload.orderId,
+    productId: payload.productId,
+    details: payload
   });
 }
 
@@ -857,6 +778,7 @@ export function registerApplePaymentRoutes(
       });
       return;
     }
+    const paymentStore = new OrderIdempotencyStore(store);
 
     let orderId = "";
     let productId = "";
@@ -880,7 +802,7 @@ export function registerApplePaymentRoutes(
       orderId = `apple:${verified.transactionId}`;
       productId = product.productId;
 
-      let order = await store.loadPaymentOrder(orderId);
+      let order = await paymentStore.loadOrder(orderId);
       if (order && order.playerId !== authSession.playerId) {
         emitPaymentFraudSignal(authSession.playerId, "transaction_claimed_by_another_player", {
           orderId,
@@ -900,7 +822,7 @@ export function registerApplePaymentRoutes(
 
       if (!order) {
         try {
-          order = await store.createPaymentOrder({
+          order = await paymentStore.createOrder({
             orderId,
             playerId: authSession.playerId,
             productId: product.productId,
@@ -912,7 +834,7 @@ export function registerApplePaymentRoutes(
           if (!/duplicate/i.test(message)) {
             throw error;
           }
-          order = await store.loadPaymentOrder(orderId);
+          order = await paymentStore.loadOrder(orderId);
         }
       }
 
@@ -926,7 +848,7 @@ export function registerApplePaymentRoutes(
         });
       }
 
-      const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+      const existingReceipt = await paymentStore.loadReceiptByOrderId(order.orderId);
       if (isAcceptedPaymentOrderStatus(order.status) || existingReceipt) {
         emitPaymentFraudSignal(order.playerId, "duplicate_transaction_id", {
           orderId: order.orderId,
@@ -944,7 +866,7 @@ export function registerApplePaymentRoutes(
         return;
       }
 
-      const settlement = await store.completePaymentOrder(order.orderId, {
+      const settlement = await paymentStore.completeOrder(order.orderId, {
         wechatOrderId: verified.transactionId,
         paidAt: verified.purchaseDate,
         verifiedAt: now().toISOString(),
@@ -953,11 +875,10 @@ export function registerApplePaymentRoutes(
         retryPolicy: normalizePaymentGrantRetryPolicy()
       });
 
-      if (settlement.order.status === "dead_letter") {
-        recordPaymentDeadLetter();
-      }
+      const deadLetterQueue = new CallbackDeadLetterQueue(isPaymentOpsStoreReady(store) ? store : null, now);
+      deadLetterQueue.recordSettlement(settlement.order);
       if (isPaymentOpsStoreReady(store)) {
-        await refreshPaymentGrantObservability(store, now());
+        await deadLetterQueue.refresh();
       }
       if (!settlement.credited) {
         emitPurchaseFailedEvent({
@@ -1001,7 +922,7 @@ export function registerApplePaymentRoutes(
         });
       }
 
-      const recentVerifiedCount = await store.countVerifiedPaymentReceiptsSince(
+      const recentVerifiedCount = await paymentStore.countVerifiedReceiptsSince(
         order.playerId,
         new Date(now().getTime() - 60_000).toISOString()
       );
@@ -1045,3 +966,33 @@ export function registerApplePaymentRoutes(
     }
   });
 }
+
+const applePaymentGateway: PaymentGateway = {
+  channel: "apple",
+  supportedOperations: ["grantRewards"],
+  createOrder: (input) =>
+    unsupportedPaymentGatewayOperation(
+      "apple",
+      "createOrder",
+      `Apple IAP orders are created client-side; server settlement begins at receipt verification for ${input.productId}.`
+    ),
+  verifyCallback: () =>
+    unsupportedPaymentGatewayOperation(
+      "apple",
+      "verifyCallback",
+      "Apple IAP uses signed transaction verification instead of a server callback contract."
+    ),
+  grantRewards: () =>
+    unsupportedPaymentGatewayOperation(
+      "apple",
+      "grantRewards",
+      "Use the Apple payment route adapter to settle verified StoreKit transactions against persistence."
+    ),
+  issueRefund: () =>
+    unsupportedPaymentGatewayOperation("apple", "issueRefund", "Apple refunds are handled outside the current server runtime.")
+};
+
+export const applePaymentGatewayRegistration: PaymentGatewayRegistration = {
+  gateway: applePaymentGateway,
+  registerRoutes: (app, store) => registerApplePaymentRoutes(app as HttpApp, store)
+};

--- a/apps/server/src/adapters/google-play.ts
+++ b/apps/server/src/adapters/google-play.ts
@@ -1,14 +1,22 @@
-import { createHash, createSign, randomUUID } from "node:crypto";
+import { createHash, createSign } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { emitAnalyticsEvent } from "../analytics";
 import { validateAuthSessionFromRequest } from "../auth";
 import {
-  recordPaymentDeadLetter,
-  recordRuntimeErrorEvent,
-  setPaymentGrantDeadLetterCount,
-  setPaymentGrantQueueCount,
-  setPaymentGrantQueueLatency
-} from "../observability";
+  CallbackDeadLetterQueue,
+  normalizePaymentGrantRetryPolicy as normalizeSharedPaymentGrantRetryPolicy,
+  refreshPaymentGrantObservability as refreshSharedPaymentGrantObservability
+} from "../domain/payment/CallbackDeadLetterQueue";
+import {
+  OrderIdempotencyStore,
+  isAcceptedPaymentOrderStatus as isSharedAcceptedPaymentOrderStatus,
+  isFinalizedPaymentOrderStatus as isSharedFinalizedPaymentOrderStatus,
+  isPaymentOpsStoreReady as isSharedPaymentOpsStoreReady,
+  isPaymentStoreReady as isSharedPaymentStoreReady
+} from "../domain/payment/OrderIdempotencyStore";
+import { PurchaseAuditLog } from "../domain/payment/PurchaseAuditLog";
+import { type PaymentGateway, unsupportedPaymentGatewayOperation } from "../domain/payment/PaymentGateway";
+import type { PaymentGatewayRegistration } from "../domain/payment/PaymentGatewayRegistry";
 import type { PaymentOrderSnapshot, RoomSnapshotStore } from "../persistence";
 import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct, type ShopProductGrant } from "../shop";
 
@@ -98,9 +106,13 @@ interface GoogleProductPurchaseResponse {
 }
 
 const MAX_JSON_BODY_BYTES = 64 * 1024;
-const DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS = 5;
-const DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS = 60_000;
 const GOOGLE_PLAY_ANDROID_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+const googlePurchaseAuditLog = new PurchaseAuditLog({
+  surface: "google-play",
+  paymentMethod: "google_play",
+  defaultRoute: "/api/payments/google/verify",
+  defaultTags: ["google-play"]
+});
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
   response.statusCode = statusCode;
@@ -220,61 +232,20 @@ async function requireAuthSession(request: IncomingMessage, response: ServerResp
   return result.session;
 }
 
-function isPaymentStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
-  Required<
-    Pick<
-      RoomSnapshotStore,
-      "createPaymentOrder" | "completePaymentOrder" | "loadPaymentOrder" | "loadPaymentReceiptByOrderId" | "countVerifiedPaymentReceiptsSince"
-    >
-  > {
-  return Boolean(
-    store?.createPaymentOrder &&
-      store.completePaymentOrder &&
-      store.loadPaymentOrder &&
-      store.loadPaymentReceiptByOrderId &&
-      store.countVerifiedPaymentReceiptsSince
-  );
+function isPaymentStoreReady(store: RoomSnapshotStore | null) {
+  return isSharedPaymentStoreReady(store);
 }
 
-function isPaymentOpsStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
-  Required<Pick<RoomSnapshotStore, "listPaymentOrders">> {
-  return Boolean(store?.listPaymentOrders);
+function isPaymentOpsStoreReady(store: RoomSnapshotStore | null) {
+  return isSharedPaymentOpsStoreReady(store);
 }
 
 function normalizePaymentGrantRetryPolicy(): { maxAttempts: number; baseDelayMs: number } {
-  return {
-    maxAttempts: DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS,
-    baseDelayMs: DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS
-  };
+  return normalizeSharedPaymentGrantRetryPolicy();
 }
 
 async function refreshPaymentGrantObservability(store: RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPaymentOrders">>, now: Date) {
-  const [pendingOrders, deadLetterOrders] = await Promise.all([
-    store.listPaymentOrders({ statuses: ["grant_pending"], limit: 200 }),
-    store.listPaymentOrders({ statuses: ["dead_letter"], limit: 200 })
-  ]);
-
-  setPaymentGrantQueueCount(pendingOrders.length);
-  setPaymentGrantDeadLetterCount(deadLetterOrders.length);
-
-  const pendingRetryTimes = pendingOrders
-    .map((order) => (order.nextGrantRetryAt ? new Date(order.nextGrantRetryAt).getTime() : null))
-    .filter((value): value is number => value != null && Number.isFinite(value))
-    .sort((left, right) => left - right);
-
-  const oldestQueuedLatencyMs =
-    pendingOrders.length === 0
-      ? null
-      : pendingOrders
-          .map((order) => (order.lastGrantAttemptAt ? Math.max(0, now.getTime() - new Date(order.lastGrantAttemptAt).getTime()) : 0))
-          .reduce((max, value) => Math.max(max, value), 0);
-  const nextPendingRetryTime = pendingRetryTimes[0];
-  const nextAttemptDelayMs = nextPendingRetryTime != null ? Math.max(0, nextPendingRetryTime - now.getTime()) : null;
-
-  setPaymentGrantQueueLatency({
-    oldestQueuedLatencyMs,
-    nextAttemptDelayMs
-  });
+  return refreshSharedPaymentGrantObservability(store, now);
 }
 
 function normalizeGooglePaymentProduct(product: ShopProduct | undefined): ShopProduct & { grant: ShopProductGrant; googlePriceCents: number } {
@@ -326,11 +297,11 @@ function findProductForGooglePurchase(products: ShopProduct[], googleProductId: 
 }
 
 function isFinalizedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
-  return status === "settled" || status === "dead_letter";
+  return isSharedFinalizedPaymentOrderStatus(status);
 }
 
 function isAcceptedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
-  return status !== "created";
+  return isSharedAcceptedPaymentOrderStatus(status);
 }
 
 function emitPurchaseCompletedEvent(input: {
@@ -341,16 +312,7 @@ function emitPurchaseCompletedEvent(input: {
   quantity: number;
   totalPrice: number;
 }): void {
-  emitAnalyticsEvent("purchase_completed", {
-    playerId: input.playerId,
-    payload: {
-      purchaseId: input.purchaseId,
-      productId: input.productId,
-      paymentMethod: input.paymentMethod,
-      quantity: input.quantity,
-      totalPrice: input.totalPrice
-    }
-  });
+  googlePurchaseAuditLog.emitCompleted(input);
 }
 
 function emitPurchaseFailedEvent(input: {
@@ -361,16 +323,7 @@ function emitPurchaseFailedEvent(input: {
   failureReason: string;
   orderStatus: PaymentOrderSnapshot["status"] | "failed";
 }): void {
-  emitAnalyticsEvent("purchase_failed", {
-    playerId: input.playerId,
-    payload: {
-      purchaseId: input.purchaseId,
-      productId: input.productId,
-      paymentMethod: input.paymentMethod,
-      failureReason: input.failureReason,
-      orderStatus: input.orderStatus
-    }
-  });
+  googlePurchaseAuditLog.emitFailed(input);
 }
 
 function emitPaymentFraudSignal(
@@ -382,44 +335,12 @@ function emitPaymentFraudSignal(
     [key: string]: unknown;
   }
 ): void {
-  try {
-    emitAnalyticsEvent("payment_fraud_signal", {
-      playerId,
-      payload: {
-        signal,
-        ...payload
-      }
-    });
-  } catch {
-    // Fraud logging must not break payment handling.
-  }
-
-  recordRuntimeErrorEvent({
-    id: randomUUID(),
-    recordedAt: new Date().toISOString(),
-    source: "server",
-    surface: "google-play",
-    candidateRevision: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null,
-    featureArea: "payment",
-    ownerArea: "commerce",
-    severity: "warn",
-    errorCode: "payment_fraud_signal",
-    message: `Google Play Billing fraud signal triggered: ${signal}`,
-    tags: ["google-play", signal],
-    context: {
-      roomId: null,
-      playerId,
-      requestId: null,
-      route: "/api/payments/google/verify",
-      action: null,
-      statusCode: null,
-      crash: false,
-      detail: JSON.stringify({
-        orderId: payload.orderId,
-        productId: payload.productId,
-        signal
-      })
-    }
+  googlePurchaseAuditLog.emitFraudSignal({
+    playerId,
+    signal,
+    orderId: payload.orderId,
+    productId: payload.productId,
+    details: payload
   });
 }
 
@@ -781,6 +702,7 @@ export function registerGooglePlayRoutes(
       });
       return;
     }
+    const paymentStore = new OrderIdempotencyStore(store);
 
     let orderId = "";
     let productId = "";
@@ -816,7 +738,7 @@ export function registerGooglePlayRoutes(
       productId = product.productId;
       const googleProductId = product.googleProductId ?? product.productId;
 
-      let order = await store.loadPaymentOrder(orderId);
+      let order = await paymentStore.loadOrder(orderId);
       if (order && order.playerId !== authSession.playerId) {
         emitPaymentFraudSignal(authSession.playerId, "purchase_token_claimed_by_another_player", {
           orderId,
@@ -836,7 +758,7 @@ export function registerGooglePlayRoutes(
 
       if (!order) {
         try {
-          order = await store.createPaymentOrder({
+          order = await paymentStore.createOrder({
             orderId,
             playerId: authSession.playerId,
             productId: product.productId,
@@ -848,7 +770,7 @@ export function registerGooglePlayRoutes(
           if (!/duplicate/i.test(message)) {
             throw error;
           }
-          order = await store.loadPaymentOrder(orderId);
+          order = await paymentStore.loadOrder(orderId);
         }
       }
 
@@ -862,7 +784,7 @@ export function registerGooglePlayRoutes(
         });
       }
 
-      const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+      const existingReceipt = await paymentStore.loadReceiptByOrderId(order.orderId);
       if (isAcceptedPaymentOrderStatus(order.status) || existingReceipt) {
         emitPaymentFraudSignal(order.playerId, "duplicate_purchase_token", {
           orderId: order.orderId,
@@ -912,7 +834,7 @@ export function registerGooglePlayRoutes(
         });
       }
 
-      const settlement = await store.completePaymentOrder(order.orderId, {
+      const settlement = await paymentStore.completeOrder(order.orderId, {
         wechatOrderId: purchaseTokenHash,
         paidAt: verified.purchaseDate,
         verifiedAt: now().toISOString(),
@@ -921,11 +843,10 @@ export function registerGooglePlayRoutes(
         retryPolicy: normalizePaymentGrantRetryPolicy()
       });
 
-      if (settlement.order.status === "dead_letter") {
-        recordPaymentDeadLetter();
-      }
+      const deadLetterQueue = new CallbackDeadLetterQueue(isPaymentOpsStoreReady(store) ? store : null, now);
+      deadLetterQueue.recordSettlement(settlement.order);
       if (isPaymentOpsStoreReady(store)) {
-        await refreshPaymentGrantObservability(store, now());
+        await deadLetterQueue.refresh();
       }
       if (!settlement.credited) {
         emitPurchaseFailedEvent({
@@ -993,7 +914,7 @@ export function registerGooglePlayRoutes(
         });
       }
 
-      const recentVerifiedCount = await store.countVerifiedPaymentReceiptsSince(
+      const recentVerifiedCount = await paymentStore.countVerifiedReceiptsSince(
         order.playerId,
         new Date(now().getTime() - 60_000).toISOString()
       );
@@ -1037,3 +958,33 @@ export function registerGooglePlayRoutes(
     }
   });
 }
+
+const googlePlayPaymentGateway: PaymentGateway = {
+  channel: "google",
+  supportedOperations: ["grantRewards"],
+  createOrder: (input) =>
+    unsupportedPaymentGatewayOperation(
+      "google",
+      "createOrder",
+      `Google Play orders are created client-side; server settlement begins at purchase token verification for ${input.productId}.`
+    ),
+  verifyCallback: () =>
+    unsupportedPaymentGatewayOperation(
+      "google",
+      "verifyCallback",
+      "Google Play Billing uses purchase-token verification instead of a server callback contract."
+    ),
+  grantRewards: () =>
+    unsupportedPaymentGatewayOperation(
+      "google",
+      "grantRewards",
+      "Use the Google Play route adapter to settle verified purchases against persistence."
+    ),
+  issueRefund: () =>
+    unsupportedPaymentGatewayOperation("google", "issueRefund", "Google Play refunds are handled outside the current server runtime.")
+};
+
+export const googlePlayPaymentGatewayRegistration: PaymentGatewayRegistration = {
+  gateway: googlePlayPaymentGateway,
+  registerRoutes: (app, store) => registerGooglePlayRoutes(app as HttpApp, store)
+};

--- a/apps/server/src/adapters/wechat-pay.ts
+++ b/apps/server/src/adapters/wechat-pay.ts
@@ -2,14 +2,26 @@ import { createCipheriv, createDecipheriv, createSign, createVerify, randomBytes
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { emitAnalyticsEvent } from "../analytics";
 import { validateAuthSessionFromRequest } from "../auth";
+import { recordPaymentGrantRetry } from "../observability";
 import {
-  recordPaymentDeadLetter,
-  recordPaymentGrantRetry,
-  recordRuntimeErrorEvent,
-  setPaymentGrantDeadLetterCount,
-  setPaymentGrantQueueCount,
-  setPaymentGrantQueueLatency
-} from "../observability";
+  CallbackDeadLetterQueue,
+  buildPaymentGrantRuntimePayload as buildSharedPaymentGrantRuntimePayload,
+  normalizePaymentGrantRetryPolicy as normalizeSharedPaymentGrantRetryPolicy,
+  refreshPaymentGrantObservability as refreshSharedPaymentGrantObservability
+} from "../domain/payment/CallbackDeadLetterQueue";
+import {
+  OrderIdempotencyStore,
+  isAcceptedPaymentOrderStatus as isSharedAcceptedPaymentOrderStatus,
+  isFinalizedPaymentOrderStatus as isSharedFinalizedPaymentOrderStatus,
+  isPaymentRetryOpsStoreReady,
+  isPaymentStoreReady as isSharedPaymentStoreReady
+} from "../domain/payment/OrderIdempotencyStore";
+import { PurchaseAuditLog } from "../domain/payment/PurchaseAuditLog";
+import {
+  type PaymentGateway,
+  unsupportedPaymentGatewayOperation
+} from "../domain/payment/PaymentGateway";
+import type { PaymentGatewayRegistration } from "../domain/payment/PaymentGatewayRegistry";
 import type { PaymentOrderSnapshot, RoomSnapshotStore } from "../persistence";
 import { readRuntimeSecret } from "../runtime-secrets";
 import { resolveShopProducts, type RegisterShopRoutesOptions, type ShopProduct, type ShopProductGrant } from "../shop";
@@ -89,9 +101,13 @@ interface WechatPayCallbackTransaction {
 
 const MAX_JSON_BODY_BYTES = 64 * 1024;
 const MAX_CALLBACK_TIMESTAMP_SKEW_SECONDS = 5 * 60;
-const DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS = 5;
-const DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS = 60_000;
 const SUCCESS_CALLBACK_BODY = { code: "SUCCESS", message: "success" };
+const wechatPurchaseAuditLog = new PurchaseAuditLog({
+  surface: "wechat-pay",
+  paymentMethod: "wechat_pay",
+  defaultRoute: "/api/payments/wechat/verify",
+  defaultTags: ["wechat-pay"]
+});
 
 function emitPurchaseCompletedEvent(input: {
   playerId: string;
@@ -101,16 +117,7 @@ function emitPurchaseCompletedEvent(input: {
   quantity: number;
   totalPrice: number;
 }): void {
-  emitAnalyticsEvent("purchase_completed", {
-    playerId: input.playerId,
-    payload: {
-      purchaseId: input.purchaseId,
-      productId: input.productId,
-      paymentMethod: input.paymentMethod,
-      quantity: input.quantity,
-      totalPrice: input.totalPrice
-    }
-  });
+  wechatPurchaseAuditLog.emitCompleted(input);
 }
 
 function emitPurchaseFailedEvent(input: {
@@ -121,16 +128,7 @@ function emitPurchaseFailedEvent(input: {
   failureReason: string;
   orderStatus: PaymentOrderSnapshot["status"] | "failed";
 }): void {
-  emitAnalyticsEvent("purchase_failed", {
-    playerId: input.playerId,
-    payload: {
-      purchaseId: input.purchaseId,
-      productId: input.productId,
-      paymentMethod: input.paymentMethod,
-      failureReason: input.failureReason,
-      orderStatus: input.orderStatus
-    }
-  });
+  wechatPurchaseAuditLog.emitFailed(input);
 }
 
 function sendJson(response: ServerResponse, statusCode: number, payload: unknown): void {
@@ -310,44 +308,13 @@ function emitPaymentFraudSignal(
   },
   route: "/api/payments/wechat/verify" | "/api/payments/wechat/callback"
 ): void {
-  try {
-    emitAnalyticsEvent("payment_fraud_signal", {
-      playerId,
-      payload: {
-        signal,
-        ...payload
-      }
-    });
-  } catch {
-    // Fraud logging must not break legitimate payment handling.
-  }
-
-  recordRuntimeErrorEvent({
-    id: randomUUID(),
-    recordedAt: new Date().toISOString(),
-    source: "server",
-    surface: "wechat-pay",
-    candidateRevision: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null,
-    featureArea: "payment",
-    ownerArea: "commerce",
-    severity: "warn",
-    errorCode: "payment_fraud_signal",
-    message: `WeChat Pay fraud signal triggered: ${signal}`,
-    tags: ["wechat-pay", signal],
-    context: {
-      roomId: null,
-      playerId,
-      requestId: null,
-      route,
-      action: null,
-      statusCode: null,
-      crash: false,
-      detail: JSON.stringify({
-        orderId: payload.orderId,
-        productId: payload.productId,
-        signal
-      })
-    }
+  wechatPurchaseAuditLog.emitFraudSignal({
+    playerId,
+    signal,
+    orderId: payload.orderId,
+    productId: payload.productId,
+    route,
+    details: payload
   });
 }
 
@@ -453,25 +420,12 @@ function sendCallbackResponse(response: ServerResponse, statusCode: number, payl
   response.end(JSON.stringify(payload));
 }
 
-function isPaymentStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
-  Required<
-    Pick<
-      RoomSnapshotStore,
-      "createPaymentOrder" | "completePaymentOrder" | "loadPaymentOrder" | "loadPaymentReceiptByOrderId" | "countVerifiedPaymentReceiptsSince"
-    >
-  > {
-  return Boolean(
-    store?.createPaymentOrder &&
-      store.completePaymentOrder &&
-      store.loadPaymentOrder &&
-      store.loadPaymentReceiptByOrderId &&
-      store.countVerifiedPaymentReceiptsSince
-  );
+function isPaymentStoreReady(store: RoomSnapshotStore | null) {
+  return isSharedPaymentStoreReady(store);
 }
 
-function isPaymentOpsStoreReady(store: RoomSnapshotStore | null): store is RoomSnapshotStore &
-  Required<Pick<RoomSnapshotStore, "listPaymentOrders" | "retryPaymentOrderGrant">> {
-  return Boolean(store?.listPaymentOrders && store.retryPaymentOrderGrant);
+function isPaymentOpsStoreReady(store: RoomSnapshotStore | null) {
+  return isPaymentRetryOpsStoreReady(store);
 }
 
 function readAdminToken(): string | null {
@@ -485,67 +439,26 @@ function isAdminRequest(request: IncomingMessage): boolean {
 }
 
 function normalizePaymentGrantRetryPolicy(): { maxAttempts: number; baseDelayMs: number } {
-  return {
-    maxAttempts: DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS,
-    baseDelayMs: DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS
-  };
+  return normalizeSharedPaymentGrantRetryPolicy();
 }
 
 function isFinalizedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
-  return status === "settled" || status === "dead_letter";
+  return isSharedFinalizedPaymentOrderStatus(status);
 }
 
 function isAcceptedPaymentOrderStatus(status: PaymentOrderSnapshot["status"]): boolean {
-  return status !== "created";
+  return isSharedAcceptedPaymentOrderStatus(status);
 }
 
 async function refreshPaymentGrantObservability(store: RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPaymentOrders">>, now: Date) {
-  const [pendingOrders, deadLetterOrders] = await Promise.all([
-    store.listPaymentOrders({ statuses: ["grant_pending"], limit: 200 }),
-    store.listPaymentOrders({ statuses: ["dead_letter"], limit: 200 })
-  ]);
-
-  setPaymentGrantQueueCount(pendingOrders.length);
-  setPaymentGrantDeadLetterCount(deadLetterOrders.length);
-
-  const pendingRetryTimes = pendingOrders
-    .map((order) => (order.nextGrantRetryAt ? new Date(order.nextGrantRetryAt).getTime() : null))
-    .filter((value): value is number => value != null && Number.isFinite(value))
-    .sort((left, right) => left - right);
-
-  const oldestQueuedLatencyMs =
-    pendingOrders.length === 0
-      ? null
-      : pendingOrders
-          .map((order) => (order.lastGrantAttemptAt ? Math.max(0, now.getTime() - new Date(order.lastGrantAttemptAt).getTime()) : 0))
-          .reduce((max, value) => Math.max(max, value), 0);
-  const nextPendingRetryTime = pendingRetryTimes[0];
-  const nextAttemptDelayMs =
-    nextPendingRetryTime != null ? Math.max(0, nextPendingRetryTime - now.getTime()) : null;
-
-  setPaymentGrantQueueLatency({
-    oldestQueuedLatencyMs,
-    nextAttemptDelayMs
-  });
-
-  return {
-    pendingOrders,
-    deadLetterOrders
-  };
+  return refreshSharedPaymentGrantObservability(store, now);
 }
 
 async function buildPaymentGrantRuntimePayload(
   store: RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPaymentOrders">>,
   now: Date
 ) {
-  const { pendingOrders, deadLetterOrders } = await refreshPaymentGrantObservability(store, now);
-  return {
-    checkedAt: now.toISOString(),
-    queueCount: pendingOrders.length,
-    deadLetterCount: deadLetterOrders.length,
-    pendingOrders,
-    deadLetterOrders
-  };
+  return buildSharedPaymentGrantRuntimePayload(store, now);
 }
 
 function findProduct(products: ShopProduct[], productId: string): ShopProduct | undefined {
@@ -710,6 +623,7 @@ export function registerWechatPayRoutes(
       });
       return;
     }
+    const paymentStore = new OrderIdempotencyStore(store);
 
     try {
       const body = (await readJsonBody(request)) as { productId?: string | null };
@@ -727,7 +641,7 @@ export function registerWechatPayRoutes(
         return;
       }
 
-      const order = await store.createPaymentOrder({
+      const order = await paymentStore.createOrder({
         orderId: orderIdGenerator(),
         playerId: authSession.playerId,
         productId: product.productId,
@@ -830,6 +744,7 @@ export function registerWechatPayRoutes(
       });
       return;
     }
+    const paymentStore = new OrderIdempotencyStore(store);
 
     let order: PaymentOrderSnapshot | null = null;
     try {
@@ -845,7 +760,7 @@ export function registerWechatPayRoutes(
         return;
       }
 
-      order = await store.loadPaymentOrder(orderId);
+      order = await paymentStore.loadOrder(orderId);
       if (!order || order.playerId !== authSession.playerId) {
         sendJson(response, 404, {
           error: {
@@ -856,7 +771,7 @@ export function registerWechatPayRoutes(
         return;
       }
 
-      const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+      const existingReceipt = await paymentStore.loadReceiptByOrderId(order.orderId);
       if (isAcceptedPaymentOrderStatus(order.status) || existingReceipt) {
         emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
           orderId: order.orderId,
@@ -907,7 +822,7 @@ export function registerWechatPayRoutes(
         return;
       }
 
-      const settlement = await store.completePaymentOrder(order.orderId, {
+      const settlement = await paymentStore.completeOrder(order.orderId, {
         wechatOrderId: verified.transaction_id,
         paidAt: verified.success_time,
         verifiedAt: now().toISOString(),
@@ -915,11 +830,10 @@ export function registerWechatPayRoutes(
         grant: product.grant,
         retryPolicy: normalizePaymentGrantRetryPolicy()
       });
-      if (settlement.order.status === "dead_letter") {
-        recordPaymentDeadLetter();
-      }
+      const deadLetterQueue = new CallbackDeadLetterQueue(isPaymentOpsStoreReady(store) ? store : null, now);
+      deadLetterQueue.recordSettlement(settlement.order);
       if (isPaymentOpsStoreReady(store)) {
-        await refreshPaymentGrantObservability(store, now());
+        await deadLetterQueue.refresh();
       }
       if (!settlement.credited) {
         emitPurchaseFailedEvent({
@@ -966,7 +880,7 @@ export function registerWechatPayRoutes(
         });
       }
 
-      const recentVerifiedCount = await store.countVerifiedPaymentReceiptsSince(
+      const recentVerifiedCount = await paymentStore.countVerifiedReceiptsSince(
         order.playerId,
         new Date(now().getTime() - 60_000).toISOString()
       );
@@ -1031,6 +945,7 @@ export function registerWechatPayRoutes(
       });
       return;
     }
+    const paymentStore = new OrderIdempotencyStore(store);
 
     try {
       const rawBody = await readRawBody(request);
@@ -1077,7 +992,7 @@ export function registerWechatPayRoutes(
         return;
       }
 
-      const order = await store.loadPaymentOrder(orderId);
+      const order = await paymentStore.loadOrder(orderId);
       if (!order) {
         sendCallbackResponse(response, 404, {
           code: "FAIL",
@@ -1096,7 +1011,7 @@ export function registerWechatPayRoutes(
         return;
       }
 
-      const existingReceipt = await store.loadPaymentReceiptByOrderId(order.orderId);
+      const existingReceipt = await paymentStore.loadReceiptByOrderId(order.orderId);
       if (isAcceptedPaymentOrderStatus(order.status) || existingReceipt) {
         emitPaymentFraudSignal(order.playerId, "duplicate_out_trade_no", {
           orderId: order.orderId,
@@ -1134,7 +1049,7 @@ export function registerWechatPayRoutes(
         }, "/api/payments/wechat/callback");
       }
 
-      const settlement = await store.completePaymentOrder(order.orderId, {
+      const settlement = await paymentStore.completeOrder(order.orderId, {
         wechatOrderId: verified.transaction_id,
         paidAt: verified.success_time,
         verifiedAt: now().toISOString(),
@@ -1142,11 +1057,10 @@ export function registerWechatPayRoutes(
         grant: product.grant,
         retryPolicy: normalizePaymentGrantRetryPolicy()
       });
-      if (settlement.order.status === "dead_letter") {
-        recordPaymentDeadLetter();
-      }
+      const deadLetterQueue = new CallbackDeadLetterQueue(isPaymentOpsStoreReady(store) ? store : null, now);
+      deadLetterQueue.recordSettlement(settlement.order);
       if (isPaymentOpsStoreReady(store)) {
-        await refreshPaymentGrantObservability(store, now());
+        await deadLetterQueue.refresh();
       }
       if (settlement.credited) {
         emitAnalyticsEvent("purchase", {
@@ -1309,9 +1223,10 @@ export function registerWechatPayRoutes(
           retryPolicy,
           allowDeadLetter: body.includeDeadLetter === true
         });
-        if (currentOrder.status !== "dead_letter" && settlement.order.status === "dead_letter") {
-          recordPaymentDeadLetter();
-        }
+        new CallbackDeadLetterQueue(isPaymentOpsStoreReady(store) ? store : null, () => processedAt).recordDeadLetterTransition(
+          currentOrder.status,
+          settlement.order.status
+        );
         if (settlement.credited) {
           emitAnalyticsEvent("purchase", {
             playerId: settlement.order.playerId,
@@ -1372,9 +1287,10 @@ export function registerWechatPayRoutes(
             retriedAt: processedAt.toISOString(),
             retryPolicy
           });
-          if (pendingOrder.status !== "dead_letter" && settlement.order.status === "dead_letter") {
-            recordPaymentDeadLetter();
-          }
+          new CallbackDeadLetterQueue(isPaymentOpsStoreReady(store) ? store : null, () => processedAt).recordDeadLetterTransition(
+            pendingOrder.status,
+            settlement.order.status
+          );
           if (settlement.credited) {
             emitAnalyticsEvent("purchase", {
               playerId: settlement.order.playerId,
@@ -1461,5 +1377,35 @@ export function signWechatCallbackForTest(privateKey: string, timestamp: string,
   signer.end();
   return signer.sign(privateKey, "base64");
 }
+
+const wechatPaymentGateway: PaymentGateway = {
+  channel: "wechat",
+  supportedOperations: ["createOrder", "verifyCallback", "grantRewards"],
+  createOrder: (input) =>
+    unsupportedPaymentGatewayOperation(
+      "wechat",
+      "createOrder",
+      `Use the WeChat route adapter to create runtime-bound JSAPI orders for ${input.productId}.`
+    ),
+  verifyCallback: () =>
+    unsupportedPaymentGatewayOperation(
+      "wechat",
+      "verifyCallback",
+      "Use the WeChat route adapter to verify callback envelopes with request headers and runtime keys."
+    ),
+  grantRewards: () =>
+    unsupportedPaymentGatewayOperation(
+      "wechat",
+      "grantRewards",
+      "Use the WeChat route adapter to settle verified orders against persistence and grant queues."
+    ),
+  issueRefund: () =>
+    unsupportedPaymentGatewayOperation("wechat", "issueRefund", "WeChat refunds are not implemented in the current server runtime.")
+};
+
+export const wechatPaymentGatewayRegistration: PaymentGatewayRegistration = {
+  gateway: wechatPaymentGateway,
+  registerRoutes: (app, store) => registerWechatPayRoutes(app as HttpApp, store)
+};
 
 export type { RegisterWechatPayRoutesOptions, WechatPayRuntimeConfig, PaymentOrderSnapshot };

--- a/apps/server/src/dev-server.ts
+++ b/apps/server/src/dev-server.ts
@@ -52,9 +52,7 @@ import { formatSchemaMigrationWarning, getSchemaMigrationStatus } from "./infra/
 import { registerAdminRoutes } from "./admin-console";
 import { registerSeasonRoutes } from "./seasons";
 import { registerShopRoutes } from "./shop";
-import { registerApplePaymentRoutes } from "./adapters/apple-iap";
-import { registerGooglePlayRoutes } from "./adapters/google-play";
-import { registerWechatPayRoutes } from "./adapters/wechat-pay";
+import { createDefaultPaymentGatewayRegistry } from "./domain/payment/DefaultPaymentGatewayRegistry";
 import { captureServerError, isErrorMonitoringEnabled } from "./error-monitoring";
 import { recordRuntimeErrorEvent } from "./observability";
 import { readBattleReplayRetentionPolicy, type BattleReplayRetentionPolicy } from "./battle-replay-retention";
@@ -216,6 +214,7 @@ export function registerPrometheusMetricsRoute(app: DevServerHttpApp): void {
 }
 
 function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDependencies {
+  const paymentGatewayRegistry = createDefaultPaymentGatewayRegistry();
   return {
     loadRuntimeSecrets: () => loadRuntimeSecrets(),
     readMySqlPersistenceConfig,
@@ -239,9 +238,12 @@ function createDefaultDevServerBootstrapDependencies(): DevServerBootstrapDepend
     registerGuildRoutes: (app, store) => registerGuildRoutes(app as never, store as RoomSnapshotStore),
     registerPlayerAccountRoutes: (app, store) => registerPlayerAccountRoutes(app as never, store as RoomSnapshotStore),
     registerShopRoutes: (app, store) => registerShopRoutes(app as never, store as RoomSnapshotStore),
-    registerApplePaymentRoutes: (app, store) => registerApplePaymentRoutes(app as never, store as RoomSnapshotStore),
-    registerGooglePlayRoutes: (app, store) => registerGooglePlayRoutes(app as never, store as RoomSnapshotStore),
-    registerWechatPayRoutes: (app, store) => registerWechatPayRoutes(app as never, store as RoomSnapshotStore),
+    registerApplePaymentRoutes: (app, store) =>
+      paymentGatewayRegistry.get("apple").registerRoutes(app as never, store as RoomSnapshotStore),
+    registerGooglePlayRoutes: (app, store) =>
+      paymentGatewayRegistry.get("google").registerRoutes(app as never, store as RoomSnapshotStore),
+    registerWechatPayRoutes: (app, store) =>
+      paymentGatewayRegistry.get("wechat").registerRoutes(app as never, store as RoomSnapshotStore),
     registerLobbyRoutes: (app, dependencies) => registerLobbyRoutes(app as never, dependencies),
     registerLaunchRuntimeRoutes: (app) => registerLaunchRuntimeRoutes(app as never),
     registerMatchmakingRoutes: (app, dependencies) =>

--- a/apps/server/src/domain/payment/CallbackDeadLetterQueue.ts
+++ b/apps/server/src/domain/payment/CallbackDeadLetterQueue.ts
@@ -1,0 +1,93 @@
+import { recordPaymentDeadLetter, setPaymentGrantDeadLetterCount, setPaymentGrantQueueCount, setPaymentGrantQueueLatency } from "../../observability";
+import type { PaymentGrantRetryPolicy, PaymentOrderSnapshot } from "../../persistence";
+import type { PaymentOpsStore } from "./OrderIdempotencyStore";
+
+const DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS = 5;
+const DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS = 60_000;
+
+export function normalizePaymentGrantRetryPolicy(policy: PaymentGrantRetryPolicy = {}): { maxAttempts: number; baseDelayMs: number } {
+  return {
+    maxAttempts: Math.max(1, Math.floor(policy.maxAttempts ?? DEFAULT_PAYMENT_GRANT_MAX_ATTEMPTS)),
+    baseDelayMs: Math.max(1_000, Math.floor(policy.baseDelayMs ?? DEFAULT_PAYMENT_GRANT_BASE_DELAY_MS))
+  };
+}
+
+export async function refreshPaymentGrantObservability(store: PaymentOpsStore, now: Date) {
+  const [pendingOrders, deadLetterOrders] = await Promise.all([
+    store.listPaymentOrders({ statuses: ["grant_pending"], limit: 200 }),
+    store.listPaymentOrders({ statuses: ["dead_letter"], limit: 200 })
+  ]);
+
+  setPaymentGrantQueueCount(pendingOrders.length);
+  setPaymentGrantDeadLetterCount(deadLetterOrders.length);
+
+  const pendingRetryTimes = pendingOrders
+    .map((order) => (order.nextGrantRetryAt ? new Date(order.nextGrantRetryAt).getTime() : null))
+    .filter((value): value is number => value != null && Number.isFinite(value))
+    .sort((left, right) => left - right);
+
+  const oldestQueuedLatencyMs =
+    pendingOrders.length === 0
+      ? null
+      : pendingOrders
+          .map((order) => (order.lastGrantAttemptAt ? Math.max(0, now.getTime() - new Date(order.lastGrantAttemptAt).getTime()) : 0))
+          .reduce((max, value) => Math.max(max, value), 0);
+
+  const nextPendingRetryTime = pendingRetryTimes[0];
+  const nextAttemptDelayMs =
+    nextPendingRetryTime != null ? Math.max(0, nextPendingRetryTime - now.getTime()) : null;
+
+  setPaymentGrantQueueLatency({
+    oldestQueuedLatencyMs,
+    nextAttemptDelayMs
+  });
+
+  return {
+    pendingOrders,
+    deadLetterOrders
+  };
+}
+
+export async function buildPaymentGrantRuntimePayload(store: PaymentOpsStore, now: Date) {
+  const { pendingOrders, deadLetterOrders } = await refreshPaymentGrantObservability(store, now);
+  return {
+    checkedAt: now.toISOString(),
+    queueCount: pendingOrders.length,
+    deadLetterCount: deadLetterOrders.length,
+    pendingOrders,
+    deadLetterOrders
+  };
+}
+
+export class CallbackDeadLetterQueue {
+  constructor(
+    private readonly store: PaymentOpsStore | null,
+    private readonly now: () => Date
+  ) {}
+
+  async refresh() {
+    if (!this.store) {
+      throw new Error("payment_dead_letter_queue_unavailable");
+    }
+    return refreshPaymentGrantObservability(this.store, this.now());
+  }
+
+  async buildRuntimePayload() {
+    if (!this.store) {
+      throw new Error("payment_dead_letter_queue_unavailable");
+    }
+    return buildPaymentGrantRuntimePayload(this.store, this.now());
+  }
+
+  recordSettlement(order: Pick<PaymentOrderSnapshot, "status">): void {
+    if (order.status === "dead_letter") {
+      recordPaymentDeadLetter();
+    }
+  }
+
+  recordDeadLetterTransition(previousStatus: PaymentOrderSnapshot["status"], nextStatus: PaymentOrderSnapshot["status"]): void {
+    if (previousStatus !== "dead_letter" && nextStatus === "dead_letter") {
+      recordPaymentDeadLetter();
+    }
+  }
+}

--- a/apps/server/src/domain/payment/DefaultPaymentGatewayRegistry.ts
+++ b/apps/server/src/domain/payment/DefaultPaymentGatewayRegistry.ts
@@ -1,0 +1,12 @@
+import { applePaymentGatewayRegistration } from "../../adapters/apple-iap";
+import { googlePlayPaymentGatewayRegistration } from "../../adapters/google-play";
+import { wechatPaymentGatewayRegistration } from "../../adapters/wechat-pay";
+import { PaymentGatewayRegistry } from "./PaymentGatewayRegistry";
+
+export function createDefaultPaymentGatewayRegistry(): PaymentGatewayRegistry {
+  return new PaymentGatewayRegistry([
+    applePaymentGatewayRegistration,
+    googlePlayPaymentGatewayRegistration,
+    wechatPaymentGatewayRegistration
+  ]);
+}

--- a/apps/server/src/domain/payment/OrderIdempotencyStore.ts
+++ b/apps/server/src/domain/payment/OrderIdempotencyStore.ts
@@ -1,0 +1,79 @@
+import type {
+  PaymentOrderCompleteInput,
+  PaymentOrderCreateInput,
+  PaymentOrderGrantRetryInput,
+  PaymentOrderSnapshot,
+  PaymentOrderStatus,
+  PaymentReceiptSnapshot,
+  RoomSnapshotStore
+} from "../../persistence";
+
+export type PaymentReadyStore = RoomSnapshotStore &
+  Required<
+    Pick<
+      RoomSnapshotStore,
+      "createPaymentOrder" | "completePaymentOrder" | "loadPaymentOrder" | "loadPaymentReceiptByOrderId" | "countVerifiedPaymentReceiptsSince"
+    >
+  >;
+
+export type PaymentOpsStore = RoomSnapshotStore & Required<Pick<RoomSnapshotStore, "listPaymentOrders">>;
+
+export type PaymentRetryOpsStore = RoomSnapshotStore &
+  Required<Pick<RoomSnapshotStore, "listPaymentOrders" | "retryPaymentOrderGrant">>;
+
+export function isPaymentStoreReady(store: RoomSnapshotStore | null): store is PaymentReadyStore {
+  return Boolean(
+    store?.createPaymentOrder &&
+      store.completePaymentOrder &&
+      store.loadPaymentOrder &&
+      store.loadPaymentReceiptByOrderId &&
+      store.countVerifiedPaymentReceiptsSince
+  );
+}
+
+export function isPaymentOpsStoreReady(store: RoomSnapshotStore | null): store is PaymentOpsStore {
+  return Boolean(store?.listPaymentOrders);
+}
+
+export function isPaymentRetryOpsStoreReady(store: RoomSnapshotStore | null): store is PaymentRetryOpsStore {
+  return Boolean(store?.listPaymentOrders && store.retryPaymentOrderGrant);
+}
+
+export function isFinalizedPaymentOrderStatus(status: PaymentOrderStatus): boolean {
+  return status === "settled" || status === "dead_letter";
+}
+
+export function isAcceptedPaymentOrderStatus(status: PaymentOrderStatus): boolean {
+  return status !== "created";
+}
+
+export class OrderIdempotencyStore {
+  constructor(private readonly store: PaymentReadyStore) {}
+
+  createOrder(input: PaymentOrderCreateInput) {
+    return this.store.createPaymentOrder(input);
+  }
+
+  completeOrder(orderId: string, input: PaymentOrderCompleteInput) {
+    return this.store.completePaymentOrder(orderId, input);
+  }
+
+  loadOrder(orderId: string): Promise<PaymentOrderSnapshot | null> {
+    return this.store.loadPaymentOrder(orderId);
+  }
+
+  loadReceiptByOrderId(orderId: string): Promise<PaymentReceiptSnapshot | null> {
+    return this.store.loadPaymentReceiptByOrderId(orderId);
+  }
+
+  countVerifiedReceiptsSince(playerId: string, since: string): Promise<number> {
+    return this.store.countVerifiedPaymentReceiptsSince(playerId, since);
+  }
+
+  retryGrant(orderId: string, input: PaymentOrderGrantRetryInput) {
+    if (!("retryPaymentOrderGrant" in this.store) || !this.store.retryPaymentOrderGrant) {
+      throw new Error("payment_retry_unavailable");
+    }
+    return this.store.retryPaymentOrderGrant(orderId, input);
+  }
+}

--- a/apps/server/src/domain/payment/PaymentGateway.ts
+++ b/apps/server/src/domain/payment/PaymentGateway.ts
@@ -1,0 +1,107 @@
+export type PaymentChannel = "wechat" | "apple" | "google";
+
+export type PaymentGatewayOperation = "createOrder" | "verifyCallback" | "grantRewards" | "issueRefund";
+
+export interface CreateOrderInput {
+  playerId: string;
+  productId: string;
+  amount: number;
+  currency?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OrderDescriptor {
+  channel: PaymentChannel;
+  orderId: string;
+  amount: number;
+  currency: string;
+  status: "created" | "pending";
+  externalOrderId?: string;
+  clientPayload?: Record<string, unknown>;
+}
+
+export interface CallbackPayload {
+  headers?: Record<string, string | string[] | undefined>;
+  body?: unknown;
+  rawBody?: string;
+}
+
+export interface CallbackRejection {
+  accepted: false;
+  reason: string;
+  statusCode?: number;
+}
+
+export interface VerifiedCallback {
+  accepted: true;
+  orderId: string;
+  externalOrderId: string;
+  paidAt?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface VerifiedOrder {
+  channel: PaymentChannel;
+  orderId: string;
+  playerId: string;
+  productId: string;
+  amount: number;
+  externalOrderId?: string;
+  paidAt?: string;
+  verifiedAt?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface GrantResult {
+  granted: boolean;
+  reason?: string;
+  receiptId?: string;
+}
+
+export interface RefundReason {
+  code: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RefundResult {
+  refunded: boolean;
+  reason?: string;
+  externalRefundId?: string;
+}
+
+export interface PaymentGateway {
+  channel: PaymentChannel;
+  supportedOperations: readonly PaymentGatewayOperation[];
+  createOrder(input: CreateOrderInput): Promise<OrderDescriptor>;
+  verifyCallback(raw: CallbackPayload): Promise<VerifiedCallback | CallbackRejection>;
+  grantRewards(order: VerifiedOrder): Promise<GrantResult>;
+  issueRefund(order: VerifiedOrder, reason: RefundReason): Promise<RefundResult>;
+}
+
+export class PaymentGatewayOperationUnsupportedError extends Error {
+  readonly channel: PaymentChannel;
+  readonly operation: PaymentGatewayOperation;
+
+  constructor(channel: PaymentChannel, operation: PaymentGatewayOperation, detail?: string) {
+    super(detail ?? `${channel} gateway does not support ${operation}`);
+    this.name = "payment_gateway_operation_unsupported";
+    this.channel = channel;
+    this.operation = operation;
+  }
+}
+
+export function isPaymentGatewayOperationSupported(
+  gateway: Pick<PaymentGateway, "supportedOperations">,
+  operation: PaymentGatewayOperation
+): boolean {
+  return gateway.supportedOperations.includes(operation);
+}
+
+export function unsupportedPaymentGatewayOperation<T>(
+  channel: PaymentChannel,
+  operation: PaymentGatewayOperation,
+  detail?: string
+): Promise<T> {
+  return Promise.reject(new PaymentGatewayOperationUnsupportedError(channel, operation, detail));
+}

--- a/apps/server/src/domain/payment/PaymentGatewayRegistry.ts
+++ b/apps/server/src/domain/payment/PaymentGatewayRegistry.ts
@@ -1,0 +1,50 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { RoomSnapshotStore } from "../../persistence";
+import type { PaymentChannel, PaymentGateway } from "./PaymentGateway";
+
+export interface PaymentGatewayHttpApp {
+  use(handler: (request: IncomingMessage, response: ServerResponse, next: () => void) => void): void;
+  get?(path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>): void;
+  post(path: string, handler: (request: IncomingMessage, response: ServerResponse) => void | Promise<void>): void;
+}
+
+export interface PaymentGatewayRegistration {
+  gateway: PaymentGateway;
+  registerRoutes(app: PaymentGatewayHttpApp, store: RoomSnapshotStore | null): void;
+}
+
+export class PaymentGatewayRegistry {
+  readonly #registrations = new Map<PaymentChannel, PaymentGatewayRegistration>();
+
+  constructor(registrations: PaymentGatewayRegistration[] = []) {
+    for (const registration of registrations) {
+      this.register(registration);
+    }
+  }
+
+  register(registration: PaymentGatewayRegistration): this {
+    if (this.#registrations.has(registration.gateway.channel)) {
+      throw new Error(`payment_gateway_already_registered:${registration.gateway.channel}`);
+    }
+    this.#registrations.set(registration.gateway.channel, registration);
+    return this;
+  }
+
+  get(channel: PaymentChannel): PaymentGatewayRegistration {
+    const registration = this.#registrations.get(channel);
+    if (!registration) {
+      throw new Error(`payment_gateway_not_registered:${channel}`);
+    }
+    return registration;
+  }
+
+  list(): PaymentGatewayRegistration[] {
+    return [...this.#registrations.values()].sort((left, right) => left.gateway.channel.localeCompare(right.gateway.channel));
+  }
+
+  registerAll(app: PaymentGatewayHttpApp, store: RoomSnapshotStore | null): void {
+    for (const registration of this.list()) {
+      registration.registerRoutes(app, store);
+    }
+  }
+}

--- a/apps/server/src/domain/payment/PurchaseAuditLog.ts
+++ b/apps/server/src/domain/payment/PurchaseAuditLog.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import { emitAnalyticsEvent } from "../../analytics";
+import { recordRuntimeErrorEvent } from "../../observability";
+import type { PaymentOrderSnapshot } from "../../persistence";
+
+interface PurchaseAuditLogConfig {
+  surface: string;
+  paymentMethod: string;
+  defaultRoute: string;
+  defaultTags?: string[];
+}
+
+interface PurchaseCompletedInput {
+  playerId: string;
+  purchaseId: string;
+  productId: string;
+  quantity: number;
+  totalPrice: number;
+}
+
+interface PurchaseFailedInput {
+  playerId: string;
+  purchaseId: string;
+  productId: string;
+  failureReason: string;
+  orderStatus: PaymentOrderSnapshot["status"] | "failed";
+}
+
+interface FraudSignalInput {
+  playerId: string;
+  signal: string;
+  orderId: string;
+  productId: string;
+  route?: string;
+  tags?: string[];
+  details?: Record<string, unknown>;
+}
+
+export class PurchaseAuditLog {
+  constructor(private readonly config: PurchaseAuditLogConfig) {}
+
+  emitCompleted(input: PurchaseCompletedInput): void {
+    emitAnalyticsEvent("purchase_completed", {
+      playerId: input.playerId,
+      payload: {
+        purchaseId: input.purchaseId,
+        productId: input.productId,
+        paymentMethod: this.config.paymentMethod,
+        quantity: input.quantity,
+        totalPrice: input.totalPrice
+      }
+    });
+  }
+
+  emitFailed(input: PurchaseFailedInput): void {
+    emitAnalyticsEvent("purchase_failed", {
+      playerId: input.playerId,
+      payload: {
+        purchaseId: input.purchaseId,
+        productId: input.productId,
+        paymentMethod: this.config.paymentMethod,
+        failureReason: input.failureReason,
+        orderStatus: input.orderStatus
+      }
+    });
+  }
+
+  emitFraudSignal(input: FraudSignalInput): void {
+    try {
+      emitAnalyticsEvent("payment_fraud_signal", {
+        playerId: input.playerId,
+        payload: {
+          signal: input.signal,
+          orderId: input.orderId,
+          productId: input.productId,
+          ...(input.details ?? {})
+        }
+      });
+    } catch {
+      // Fraud logging must not break payment handling.
+    }
+
+    recordRuntimeErrorEvent({
+      id: randomUUID(),
+      recordedAt: new Date().toISOString(),
+      source: "server",
+      surface: this.config.surface,
+      candidateRevision: process.env.VERCEL_GIT_COMMIT_SHA?.trim() || null,
+      featureArea: "payment",
+      ownerArea: "commerce",
+      severity: "warn",
+      errorCode: "payment_fraud_signal",
+      message: `${this.config.surface} fraud signal triggered: ${input.signal}`,
+      tags: [...new Set([this.config.surface, input.signal, ...(this.config.defaultTags ?? []), ...(input.tags ?? [])])],
+      context: {
+        roomId: null,
+        playerId: input.playerId,
+        requestId: null,
+        route: input.route ?? this.config.defaultRoute,
+        action: null,
+        statusCode: null,
+        crash: false,
+        detail: JSON.stringify({
+          orderId: input.orderId,
+          productId: input.productId,
+          signal: input.signal,
+          ...(input.details ?? {})
+        })
+      }
+    });
+  }
+}

--- a/tests/e2e/payment-gateway-contract.spec.ts
+++ b/tests/e2e/payment-gateway-contract.spec.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { test } from "@playwright/test";
+import { createDefaultPaymentGatewayRegistry } from "../../apps/server/src/domain/payment/DefaultPaymentGatewayRegistry.ts";
+import { PaymentGatewayOperationUnsupportedError } from "../../apps/server/src/domain/payment/PaymentGateway.ts";
+
+class ContractTestApp {
+  readonly middlewares: Array<unknown> = [];
+  readonly gets: string[] = [];
+  readonly posts: string[] = [];
+
+  use(handler: unknown): void {
+    this.middlewares.push(handler);
+  }
+
+  get(path: string, _handler?: unknown): void {
+    this.gets.push(path);
+  }
+
+  post(path: string, _handler?: unknown): void {
+    this.posts.push(path);
+  }
+}
+
+test("payment gateway registry exposes the three launch payment channels", async () => {
+  const registry = createDefaultPaymentGatewayRegistry();
+  const registrations = registry.list();
+
+  assert.deepEqual(
+    registrations.map((registration) => registration.gateway.channel),
+    ["apple", "google", "wechat"]
+  );
+
+  assert.deepEqual(registry.get("apple").gateway.supportedOperations, ["grantRewards"]);
+  assert.deepEqual(registry.get("google").gateway.supportedOperations, ["grantRewards"]);
+  assert.deepEqual(registry.get("wechat").gateway.supportedOperations, ["createOrder", "verifyCallback", "grantRewards"]);
+});
+
+test("payment gateway registry wires route adapters for each channel", async () => {
+  const registry = createDefaultPaymentGatewayRegistry();
+  const app = new ContractTestApp();
+
+  registry.registerAll(app, null);
+
+  assert.ok(app.middlewares.length >= 3);
+  assert.deepEqual(
+    app.posts.sort(),
+    [
+      "/api/payments/apple/verify",
+      "/api/payments/google/verify",
+      "/api/admin/payments/wechat/retry",
+      "/api/payments/wechat/callback",
+      "/api/payments/wechat/create",
+      "/api/payments/wechat/verify"
+    ].sort()
+  );
+  assert.deepEqual(app.gets.sort(), ["/api/admin/payments/wechat/orders", "/api/runtime/wechat-payment-grants"].sort());
+});
+
+test("payment gateways reject unsupported unbound operations with explicit errors", async () => {
+  const registry = createDefaultPaymentGatewayRegistry();
+
+  await assert.rejects(
+    registry.get("apple").gateway.createOrder({
+      playerId: "player-1",
+      productId: "gem-pack-ios",
+      amount: 499
+    }),
+    (error) =>
+      error instanceof PaymentGatewayOperationUnsupportedError &&
+      error.channel === "apple" &&
+      error.operation === "createOrder"
+  );
+
+  await assert.rejects(
+    registry.get("google").gateway.verifyCallback({
+      body: { purchaseToken: "token-1" }
+    }),
+    (error) =>
+      error instanceof PaymentGatewayOperationUnsupportedError &&
+      error.channel === "google" &&
+      error.operation === "verifyCallback"
+  );
+
+  await assert.rejects(
+    registry.get("wechat").gateway.issueRefund(
+      {
+        channel: "wechat",
+        orderId: "wechat-order-1",
+        playerId: "player-1",
+        productId: "gem-pack-premium",
+        amount: 600
+      },
+      {
+        code: "manual_review",
+        message: "Manual refund review is required"
+      }
+    ),
+    (error) =>
+      error instanceof PaymentGatewayOperationUnsupportedError &&
+      error.channel === "wechat" &&
+      error.operation === "issueRefund"
+  );
+});


### PR DESCRIPTION
## Summary
- add a shared domain/payment layer for gateway contracts, idempotency, dead-letter queue refresh, audit logging, and gateway registry
- register apple/google/wechat payment routes through the default payment gateway registry in the dev server bootstrap
- add a payment gateway contract spec that locks the three-channel registry and route surface

## Testing
- node --import ./node_modules/tsx/dist/loader.mjs --test apps/server/test/wechat-pay-routes.test.ts apps/server/test/apple-iap-routes.test.ts apps/server/test/google-play-routes.test.ts
- node --import ./node_modules/tsx/dist/loader.mjs --test apps/server/test/dev-server.test.ts
- npx playwright test tests/e2e/payment-gateway-contract.spec.ts

Closes #1567