### PR TITLE
refactor(server): extract season and battle-snapshot types into persistence/types.ts (part of #1559) by claude

### DIFF
--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -87,123 +87,46 @@ import {
   readBattleReplayRetentionPolicy
 } from "./battle-replay-retention";
 
-export interface SeasonSnapshot {
-  seasonId: string;
-  status: "active" | "closed";
-  startedAt: string;
-  endedAt?: string;
-  rewardDistributedAt?: string;
-}
+import {
+  type BattleSnapshotCompensation,
+  type BattleSnapshotInterruptedSettlementInput,
+  type BattleSnapshotListOptions,
+  type BattleSnapshotRecord,
+  type BattleSnapshotResolutionInput,
+  type BattleSnapshotStartInput,
+  type BattleSnapshotStatus,
+  type LeaderboardSeasonArchiveEntry,
+  type PlayerNameHistoryRetentionPolicy,
+  type PlayerReferralClaimResult,
+  type SeasonCloseSummary,
+  type SeasonListOptions,
+  type SeasonSnapshot,
+  type SnapshotRetentionPolicy
+} from "./persistence/types";
+export type {
+  BattleSnapshotCompensation,
+  BattleSnapshotInterruptedSettlementInput,
+  BattleSnapshotListOptions,
+  BattleSnapshotRecord,
+  BattleSnapshotResolutionInput,
+  BattleSnapshotStartInput,
+  BattleSnapshotStatus,
+  LeaderboardSeasonArchiveEntry,
+  PlayerNameHistoryRetentionPolicy,
+  PlayerReferralClaimResult,
+  SeasonCloseSummary,
+  SeasonListOptions,
+  SeasonSnapshot,
+  SnapshotRetentionPolicy
+} from "./persistence/types";
 
-export interface SeasonListOptions {
-  status?: "active" | "closed" | "all";
-  limit?: number;
-}
 
-export interface SeasonCloseSummary {
-  seasonId: string;
-  playersRewarded: number;
-  totalGemsGranted: number;
-}
-
-export interface LeaderboardSeasonArchiveEntry {
-  seasonId: string;
-  rank: number;
-  playerId: string;
-  displayName: string;
-  finalRating: number;
-  tier: string;
-  archivedAt: string;
-}
-
-export interface PlayerReferralClaimResult {
-  claimed: boolean;
-  rewardGems: number;
-  referrerId: string;
-  newPlayerId: string;
-}
 
 export interface BattlePassClaimResult {
   tier: number;
   granted: BattlePassRewardGrant;
   seasonPassPremiumApplied: boolean;
   account: PlayerAccountSnapshot;
-}
-
-export type BattleSnapshotStatus = "active" | "resolved" | "compensated" | "aborted";
-
-export interface BattleSnapshotCompensation {
-  mailboxMessageId: string;
-  playerIds: string[];
-  title: string;
-  body: string;
-  kind: PlayerMailboxMessage["kind"];
-  grant?: PlayerMailboxGrant;
-}
-
-export interface BattleSnapshotRecord {
-  roomId: string;
-  battleId: string;
-  heroId: string;
-  attackerPlayerId: string;
-  defenderPlayerId?: string;
-  defenderHeroId?: string;
-  neutralArmyId?: string;
-  encounterKind: "neutral" | "hero";
-  initiator?: "hero" | "neutral";
-  path: Vec2[];
-  moveCost: number;
-  playerIds: string[];
-  initialState: BattleState;
-  estimatedCompensationGrant?: PlayerMailboxGrant;
-  status: BattleSnapshotStatus;
-  result?: "attacker_victory" | "defender_victory";
-  resolutionReason?: string;
-  compensation?: BattleSnapshotCompensation;
-  startedAt: string;
-  resolvedAt?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface BattleSnapshotStartInput {
-  roomId: string;
-  battleId: string;
-  heroId: string;
-  attackerPlayerId: string;
-  defenderPlayerId?: string;
-  defenderHeroId?: string;
-  neutralArmyId?: string;
-  encounterKind: "neutral" | "hero";
-  initiator?: "hero" | "neutral";
-  path: Vec2[];
-  moveCost: number;
-  playerIds: string[];
-  initialState: BattleState;
-  estimatedCompensationGrant?: PlayerMailboxGrant;
-  startedAt?: string;
-}
-
-export interface BattleSnapshotResolutionInput {
-  roomId: string;
-  battleId: string;
-  result: "attacker_victory" | "defender_victory";
-  resolutionReason?: string;
-  resolvedAt?: string;
-}
-
-export interface BattleSnapshotInterruptedSettlementInput {
-  roomId: string;
-  battleId: string;
-  status: Extract<BattleSnapshotStatus, "compensated" | "aborted">;
-  resolutionReason: string;
-  compensation?: BattleSnapshotCompensation;
-  resolvedAt?: string;
-}
-
-export interface BattleSnapshotListOptions {
-  statuses?: BattleSnapshotStatus[];
-  limit?: number;
 }
 
 export interface RoomSnapshotStore {
@@ -325,17 +248,6 @@ export interface RoomSnapshotStore {
   delete(roomId: string): Promise<void>;
   pruneExpired(referenceTime?: Date): Promise<number>;
   close(): Promise<void>;
-}
-
-export interface SnapshotRetentionPolicy {
-  ttlHours: number | null;
-  cleanupIntervalMinutes: number | null;
-}
-
-export interface PlayerNameHistoryRetentionPolicy {
-  ttlDays: number | null;
-  cleanupIntervalMinutes: number | null;
-  cleanupBatchSize: number;
 }
 
 export interface MySqlPersistenceConfig {

--- a/apps/server/src/persistence/types.ts
+++ b/apps/server/src/persistence/types.ts
@@ -1,0 +1,129 @@
+import type {
+  BattleState,
+  PlayerMailboxGrant,
+  PlayerMailboxMessage,
+  Vec2
+} from "../../../../packages/shared/src/index";
+
+export interface SeasonSnapshot {
+  seasonId: string;
+  status: "active" | "closed";
+  startedAt: string;
+  endedAt?: string;
+  rewardDistributedAt?: string;
+}
+
+export interface SeasonListOptions {
+  status?: "active" | "closed" | "all";
+  limit?: number;
+}
+
+export interface SeasonCloseSummary {
+  seasonId: string;
+  playersRewarded: number;
+  totalGemsGranted: number;
+}
+
+export interface LeaderboardSeasonArchiveEntry {
+  seasonId: string;
+  rank: number;
+  playerId: string;
+  displayName: string;
+  finalRating: number;
+  tier: string;
+  archivedAt: string;
+}
+
+export interface PlayerReferralClaimResult {
+  claimed: boolean;
+  rewardGems: number;
+  referrerId: string;
+  newPlayerId: string;
+}
+
+export type BattleSnapshotStatus = "active" | "resolved" | "compensated" | "aborted";
+
+export interface BattleSnapshotCompensation {
+  mailboxMessageId: string;
+  playerIds: string[];
+  title: string;
+  body: string;
+  kind: PlayerMailboxMessage["kind"];
+  grant?: PlayerMailboxGrant;
+}
+
+export interface BattleSnapshotRecord {
+  roomId: string;
+  battleId: string;
+  heroId: string;
+  attackerPlayerId: string;
+  defenderPlayerId?: string;
+  defenderHeroId?: string;
+  neutralArmyId?: string;
+  encounterKind: "neutral" | "hero";
+  initiator?: "hero" | "neutral";
+  path: Vec2[];
+  moveCost: number;
+  playerIds: string[];
+  initialState: BattleState;
+  estimatedCompensationGrant?: PlayerMailboxGrant;
+  status: BattleSnapshotStatus;
+  result?: "attacker_victory" | "defender_victory";
+  resolutionReason?: string;
+  compensation?: BattleSnapshotCompensation;
+  startedAt: string;
+  resolvedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BattleSnapshotStartInput {
+  roomId: string;
+  battleId: string;
+  heroId: string;
+  attackerPlayerId: string;
+  defenderPlayerId?: string;
+  defenderHeroId?: string;
+  neutralArmyId?: string;
+  encounterKind: "neutral" | "hero";
+  initiator?: "hero" | "neutral";
+  path: Vec2[];
+  moveCost: number;
+  playerIds: string[];
+  initialState: BattleState;
+  estimatedCompensationGrant?: PlayerMailboxGrant;
+  startedAt?: string;
+}
+
+export interface BattleSnapshotResolutionInput {
+  roomId: string;
+  battleId: string;
+  result: "attacker_victory" | "defender_victory";
+  resolutionReason?: string;
+  resolvedAt?: string;
+}
+
+export interface BattleSnapshotInterruptedSettlementInput {
+  roomId: string;
+  battleId: string;
+  status: Extract<BattleSnapshotStatus, "compensated" | "aborted">;
+  resolutionReason: string;
+  compensation?: BattleSnapshotCompensation;
+  resolvedAt?: string;
+}
+
+export interface BattleSnapshotListOptions {
+  statuses?: BattleSnapshotStatus[];
+  limit?: number;
+}
+
+export interface SnapshotRetentionPolicy {
+  ttlHours: number | null;
+  cleanupIntervalMinutes: number | null;
+}
+
+export interface PlayerNameHistoryRetentionPolicy {
+  ttlDays: number | null;
+  cleanupIntervalMinutes: number | null;
+  cleanupBatchSize: number;
+}


### PR DESCRIPTION
## Summary
- Extracted `SeasonSnapshot`, `SeasonListOptions`, `SeasonCloseSummary`, `LeaderboardSeasonArchiveEntry`, `PlayerReferralClaimResult`, `BattleSnapshot*` family, `SnapshotRetentionPolicy`, and `PlayerNameHistoryRetentionPolicy` from `apps/server/src/persistence.ts` into a new `apps/server/src/persistence/types.ts`.
- Re-exported the types from `persistence.ts` to preserve the public import surface.
- Follow-on to #1590 (mysql-tables scaffold), incremental progress toward the directory split in #1559.

## Test plan
- [x] `npx tsc --noEmit -p apps/server/tsconfig.json` — no new errors (3 pre-existing errors in admin-console.ts/auth.ts unchanged).
- [x] `node --import tsx --test apps/server/test/persistence-retention.test.ts` — 7/7 pass.
- [x] `node --import tsx --test apps/server/test/room-persistence.test.ts` — matches main baseline (same pre-existing failures on both branches).

Refs #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)