### PR TITLE
refactor(server): extract env-readers into persistence/env-readers.ts (part of #1559) by claude

### DIFF
--- a/apps/server/src/persistence.ts
+++ b/apps/server/src/persistence.ts
@@ -88,6 +88,13 @@ import {
 } from "./battle-replay-retention";
 
 import {
+  readBooleanFlag,
+  readNonNegativeInteger,
+  readOptionalPositiveNumber,
+  readPositiveInteger
+} from "./persistence/env-readers";
+
+import {
   type BattleSnapshotCompensation,
   type BattleSnapshotInterruptedSettlementInput,
   type BattleSnapshotListOptions,
@@ -1308,64 +1315,6 @@ export const MAX_PLAYER_LOGIN_ID_LENGTH = 40;
 export const MAX_PLAYER_AVATAR_URL_LENGTH = 512;
 const MYSQL_DUPLICATE_ENTRY_ERROR_CODE = "ER_DUP_ENTRY";
 const MYSQL_DUPLICATE_ENTRY_ERRNO = 1062;
-
-function readOptionalPositiveNumber(value: string | undefined, fallback: number): number | null {
-  if (value == null || value.trim() === "") {
-    return fallback;
-  }
-
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed)) {
-    return fallback;
-  }
-
-  if (parsed <= 0) {
-    return null;
-  }
-
-  return parsed;
-}
-
-function readPositiveInteger(value: string | undefined, fallback: number): number {
-  if (value == null || value.trim() === "") {
-    return fallback;
-  }
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return fallback;
-  }
-
-  return parsed;
-}
-
-function readNonNegativeInteger(value: string | undefined, fallback: number): number {
-  if (value == null || value.trim() === "") {
-    return fallback;
-  }
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return fallback;
-  }
-
-  return parsed;
-}
-
-function readBooleanFlag(value: string | undefined, fallback: boolean): boolean {
-  if (value == null || value.trim() === "") {
-    return fallback;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on") {
-    return true;
-  }
-  if (normalized === "0" || normalized === "false" || normalized === "no" || normalized === "off") {
-    return false;
-  }
-  return fallback;
-}
 
 function timestampOf(value: Date | string): number {
   return (typeof value === "string" ? new Date(value) : value).getTime();

--- a/apps/server/src/persistence/env-readers.ts
+++ b/apps/server/src/persistence/env-readers.ts
@@ -1,0 +1,57 @@
+export function readOptionalPositiveNumber(value: string | undefined, fallback: number): number | null {
+  if (value == null || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  if (parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function readPositiveInteger(value: string | undefined, fallback: number): number {
+  if (value == null || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function readNonNegativeInteger(value: string | undefined, fallback: number): number {
+  if (value == null || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function readBooleanFlag(value: string | undefined, fallback: boolean): boolean {
+  if (value == null || value.trim() === "") {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on") {
+    return true;
+  }
+  if (normalized === "0" || normalized === "false" || normalized === "no" || normalized === "off") {
+    return false;
+  }
+  return fallback;
+}

--- a/apps/server/src/persistence/index.ts
+++ b/apps/server/src/persistence/index.ts
@@ -1,1 +1,3 @@
 export * from "./mysql-tables";
+export * from "./types";
+export * from "./env-readers";


### PR DESCRIPTION
## Summary
- Extracts `readOptionalPositiveNumber`, `readPositiveInteger`, `readNonNegativeInteger`, and `readBooleanFlag` from `persistence.ts` into a new `apps/server/src/persistence/env-readers.ts` module. These are pure string-parsing helpers used by the MySQL config resolver.
- Wires `persistence/index.ts` to re-export `mysql-tables`, `types`, and `env-readers` so the subdirectory is consumable as a single entry point.
- Follow-on to #1590, #1592 — incremental progress on the directory split in #1559.

## Test plan
- [x] `npx tsc --noEmit -p apps/server/tsconfig.json` — no new errors (same 3 pre-existing unrelated errors).
- [x] `node --import tsx --test apps/server/test/persistence-retention.test.ts` — 7/7 pass.

Refs #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)