### PR TITLE
refactor: split VeilRoot panel orchestration

### DIFF
--- a/apps/cocos-client/assets/scripts/VeilRoot.ts
+++ b/apps/cocos-client/assets/scripts/VeilRoot.ts
@@ -26,17 +26,11 @@ import {
   type CocosAccountReviewState
 } from "./cocos-account-review.ts";
 import {
-  attemptCocosDailyDungeonFloor,
-  completeCocosCampaignMission,
   loadCocosCampaignSummary,
-  claimCocosSeasonTier,
-  claimCocosDailyDungeonRunReward,
   claimCocosDailyQuest,
   claimAllCocosMailboxMessages,
   claimCocosMailboxMessage,
   submitCocosSupportTicket,
-  type CocosCampaignMissionCompleteResult,
-  type CocosCampaignMissionStartResult,
   type CocosCampaignSummary,
   type CocosLaunchAnnouncement,
   type CocosMaintenanceModeSnapshot,
@@ -47,8 +41,6 @@ import {
   createCocosGuestPlayerId,
   loadCocosAnnouncements,
   loadCocosBattleReplayHistoryPage,
-  loadCocosActiveSeasonalEvents,
-  loadCocosDailyDungeon,
   createCocosLobbyPreferences,
   loadCocosLobbyRooms,
   loadCocosMaintenanceMode,
@@ -56,7 +48,6 @@ import {
   loadCocosPlayerAchievementProgress,
   loadCocosPlayerEventHistory,
   loadCocosPlayerProgressionSnapshot,
-  loadCocosSeasonProgress,
   loginCocosGuestAuthSession,
   loginCocosWechatAuthSession,
   logoutCurrentCocosAuthSession,
@@ -68,7 +59,6 @@ import {
   requestCocosPasswordRecovery,
   resolveCocosConfigCenterUrl,
   saveCocosLobbyPreferences,
-  startCocosCampaignMission,
   submitCocosSeasonalEventProgress,
   syncCurrentCocosAuthSession,
   updateCocosTutorialProgress,
@@ -162,11 +152,8 @@ import {
   type CocosAuthProvider
 } from "./cocos-session-launch.ts";
 import { buildCocosShopPanelView, type ShopProduct } from "./cocos-shop-panel.ts";
-import { buildCocosEventLeaderboardPanelView } from "./cocos-event-leaderboard-panel.ts";
 import { resolveCocosClientVersion } from "./cocos-client-version.ts";
 import {
-  buildCocosBattlePassPanelView,
-  buildCocosDailyDungeonPanelView,
   type CocosDailyDungeonSummary,
   type CocosSeasonProgress
 } from "./cocos-progression-panel.ts";
@@ -204,10 +191,7 @@ import { buildCocosWorldFocusView } from "./cocos-world-focus.ts";
 import { cocosPresentationConfig } from "./cocos-presentation-config.ts";
 import { cocosPresentationReadiness } from "./cocos-presentation-readiness.ts";
 import { getPixelSpriteLoadStatus, loadPixelSpriteAssets } from "./cocos-pixel-sprites.ts";
-import {
-  type CocosCampaignDialogueState,
-  resolveCampaignPanelMission
-} from "./cocos-campaign-panel.ts";
+import { type CocosCampaignDialogueState } from "./cocos-campaign-panel.ts";
 import {
   buildPrimaryClientTelemetryFromUpdate,
   createPrimaryClientTelemetryEvent,
@@ -244,8 +228,12 @@ import {
   collapseAdjacentEntries,
   connectSessionForRoot,
   createSessionOptionsForRoot,
+  claimGameplayDailyDungeonRunForRoot,
+  claimGameplaySeasonTierForRoot,
+  completeGameplayCampaignMissionForRoot,
   DEFAULT_MAP_HEIGHT_TILES,
   DEFAULT_MAP_WIDTH_TILES,
+  describeCampaignErrorForRoot,
   describeSessionErrorForRoot,
   disposeCurrentSessionForRoot,
   EQUIPMENT_PANEL_NODE_NAME,
@@ -260,14 +248,37 @@ import {
   isActiveSessionEpochForRoot,
   LOBBY_NODE_NAME,
   MAP_NODE_NAME,
+  openLobbyPvePanelForRoot,
+  purchaseGameplaySeasonPremiumForRoot,
   refreshSnapshotForRoot,
+  refreshActiveSeasonalEventForRoot,
+  refreshDailyDungeonPanelForRoot,
+  refreshGameplayCampaignForRoot,
+  refreshSeasonProgressForRoot,
+  renderGameplayAccountReviewPanelForRoot,
+  renderGameplayCampaignPanelForRoot,
+  renderGameplayEquipmentPanelForRoot,
+  resolveSelectedGameplayCampaignMissionForRoot,
   resetSessionViewportForRoot,
   resolveVeilRootRuntime,
   SETTINGS_BUTTON_NODE_NAME,
   SETTINGS_PANEL_NODE_NAME,
+  selectGameplayCampaignMissionForRoot,
+  snapshotSeasonProgressFromProfileForRoot,
+  startGameplayCampaignDialogueForRoot,
+  startGameplayCampaignMissionForRoot,
+  syncGameplayCampaignSelectionForRoot,
   TIMELINE_NODE_NAME,
+  toggleGameplayAccountReviewPanelForRoot,
+  toggleGameplayBattlePassPanelForRoot,
+  toggleGameplayCampaignPanelForRoot,
+  toggleGameplayDailyDungeonPanelForRoot,
+  toggleGameplayEquipmentPanelForRoot,
+  toggleGameplaySeasonalEventPanelForRoot,
   TUTORIAL_OVERLAY_NODE_NAME,
   advanceTutorialFlowForRoot,
+  advanceGameplayCampaignDialogueForRoot,
+  attemptGameplayDailyDungeonFloorForRoot,
   type BattleSettlementSnapshot,
   bindGlobalErrorBoundaryForRoot,
   buildTutorialOverlayViewForRoot,
@@ -1534,102 +1545,15 @@ export class VeilRoot extends Component {
   }
 
   private renderGameplayEquipmentPanel(): void {
-    const panelNode = this.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
-    if (!panelNode) {
-      return;
-    }
-
-    if (!this.gameplayEquipmentPanelOpen) {
-      panelNode.active = false;
-      return;
-    }
-
-    panelNode.active = true;
-    this.gameplayEquipmentPanel?.render({
-      hero: this.activeHero(),
-      recentEventLog: this.lobbyAccountProfile.recentEventLog,
-      recentSessionEvents: (this.lastUpdate?.events ?? []).filter(
-        (event): event is Extract<NonNullable<SessionUpdate["events"]>[number], { type: "hero.equipmentFound" }> =>
-          event.type === "hero.equipmentFound"
-      )
-    });
+    renderGameplayEquipmentPanelForRoot(this as unknown as Record<string, any>);
   }
 
   private renderGameplayCampaignPanel(): void {
-    const panelNode = this.node.getChildByName(CAMPAIGN_PANEL_NODE_NAME);
-    if (!panelNode) {
-      return;
-    }
-
-    if (!this.gameplayCampaignPanelOpen) {
-      panelNode.active = false;
-      return;
-    }
-
-    panelNode.active = true;
-    this.gameplayCampaignPanel?.render({
-      campaign: this.gameplayCampaign,
-      selectedMissionId: this.gameplayCampaignSelectedMissionId,
-      activeMissionId: this.gameplayCampaignActiveMissionId,
-      dialogue: this.gameplayCampaignDialogue,
-      statusMessage: this.gameplayCampaignStatus,
-      loading: this.gameplayCampaignLoading,
-      pendingAction: this.gameplayCampaignPendingAction
-    });
+    renderGameplayCampaignPanelForRoot(this as unknown as Record<string, any>);
   }
 
   private renderGameplayAccountReviewPanel(): void {
-    const panelNode = this.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
-    if (!panelNode) {
-      return;
-    }
-
-    if (!this.gameplayAccountReviewPanelOpen && !this.gameplayBattlePassPanelOpen && !this.gameplayDailyDungeonPanelOpen && !this.gameplaySeasonalEventPanelOpen) {
-      panelNode.active = false;
-      return;
-    }
-
-    panelNode.active = true;
-    if (this.gameplayDailyDungeonPanelOpen) {
-      this.gameplayAccountReviewPanel?.render({
-        dailyDungeon: buildCocosDailyDungeonPanelView({
-          dailyDungeon: this.dailyDungeonSummary,
-          activeEvent: null,
-          seasonProgress: this.seasonProgress,
-          currentPlayerId: this.playerId,
-          pendingFloor: this.pendingDailyDungeonFloor,
-          pendingClaimRunId: this.pendingDailyDungeonClaimRunId,
-          statusLabel: this.dailyDungeonStatus
-        })
-      });
-      return;
-    }
-    if (this.gameplayBattlePassPanelOpen) {
-      this.gameplayAccountReviewPanel?.render({
-        battlePass: buildCocosBattlePassPanelView({
-          progress: this.seasonProgress,
-          pendingClaimTier: this.pendingSeasonClaimTier,
-          pendingPremiumPurchase: this.seasonPremiumPurchaseInFlight,
-          statusLabel: this.seasonProgressStatus
-        })
-      });
-      return;
-    }
-
-    if (this.gameplaySeasonalEventPanelOpen) {
-      this.gameplayAccountReviewPanel?.render({
-        eventLeaderboard: buildCocosEventLeaderboardPanelView({
-          event: this.activeSeasonalEvent,
-          playerId: this.playerId,
-          statusLabel: this.seasonalEventStatus
-        })
-      });
-      return;
-    }
-
-    this.gameplayAccountReviewPanel?.render({
-      page: buildCocosAccountReviewPage(this.lobbyAccountReviewState)
-    });
+    renderGameplayAccountReviewPanelForRoot(this as unknown as Record<string, any>);
   }
 
   private formatLobbyVaultSummary(): string {
@@ -2101,221 +2025,39 @@ export class VeilRoot extends Component {
   }
 
   private async toggleGameplayAccountReviewPanel(forceOpen?: boolean): Promise<void> {
-    const nextOpen = forceOpen ?? !this.gameplayAccountReviewPanelOpen;
-    this.gameplayBattlePassPanelOpen = false;
-    this.gameplayDailyDungeonPanelOpen = false;
-    this.gameplaySeasonalEventPanelOpen = false;
-    this.gameplayCampaignPanelOpen = false;
-    this.gameplayAccountReviewPanelOpen = nextOpen;
-    if (!nextOpen) {
-      this.renderView();
-      return;
-    }
-
-    this.renderView();
-    await this.refreshActiveAccountReviewSection();
+    await toggleGameplayAccountReviewPanelForRoot(this as unknown as Record<string, any>, forceOpen);
   }
 
   private async toggleGameplayBattlePassPanel(forceOpen?: boolean): Promise<void> {
-    if (this.lastUpdate?.featureFlags?.battle_pass_enabled !== true) {
-      this.gameplayBattlePassPanelOpen = false;
-      this.seasonProgressStatus = "battle_pass_enabled = false";
-      this.renderView();
-      return;
-    }
-
-    const nextOpen = forceOpen ?? !this.gameplayBattlePassPanelOpen;
-    this.gameplayAccountReviewPanelOpen = false;
-    this.gameplayDailyDungeonPanelOpen = false;
-    this.gameplaySeasonalEventPanelOpen = false;
-    this.gameplayCampaignPanelOpen = false;
-    this.gameplayBattlePassPanelOpen = nextOpen;
-    if (!nextOpen) {
-      this.renderView();
-      return;
-    }
-
-    this.announceGameplayPanelSwitch("成长目标", "正在同步赛季通行证、长期成长与下一解锁目标。");
-    this.seasonProgress = this.snapshotSeasonProgressFromProfile();
-    this.renderView();
-    await this.refreshSeasonProgress();
+    await toggleGameplayBattlePassPanelForRoot(this as unknown as Record<string, any>, forceOpen);
   }
 
   private async toggleGameplayDailyDungeonPanel(forceOpen?: boolean): Promise<void> {
-    const nextOpen = forceOpen ?? !this.gameplayDailyDungeonPanelOpen;
-    this.gameplayAccountReviewPanelOpen = false;
-    this.gameplayBattlePassPanelOpen = false;
-    this.gameplaySeasonalEventPanelOpen = false;
-    this.gameplayCampaignPanelOpen = false;
-    this.gameplayDailyDungeonPanelOpen = nextOpen;
-    if (!nextOpen) {
-      this.renderView();
-      return;
-    }
-
-    this.announceGameplayPanelSwitch("今日地城", "正在同步今日轮换、剩余次数与可领取奖励。");
-    this.renderView();
-    await this.refreshDailyDungeonPanel();
+    await toggleGameplayDailyDungeonPanelForRoot(this as unknown as Record<string, any>, forceOpen);
   }
 
   private async openLobbyPvePanel(target: "campaign" | "daily-dungeon" | "battle-pass"): Promise<void> {
-    if (this.authMode !== "account" || !this.authToken) {
-      this.lobbyStatus = target === "campaign"
-        ? "主线章节需要正式账号会话。"
-        : target === "daily-dungeon"
-          ? "每日地城需要正式账号会话。"
-          : "赛季通行证需要正式账号会话。";
-      this.renderView();
-      return;
-    }
-
-    if (this.showLobby) {
-      await this.enterLobbyRoom();
-      if (this.showLobby) {
-        return;
-      }
-    }
-
-    if (target === "campaign") {
-      await this.toggleGameplayCampaignPanel(true);
-      return;
-    }
-
-    if (target === "battle-pass") {
-      await this.toggleGameplayBattlePassPanel(true);
-      return;
-    }
-
-    await this.toggleGameplayDailyDungeonPanel(true);
+    await openLobbyPvePanelForRoot(this as unknown as Record<string, any>, target);
   }
 
   private async refreshDailyDungeonPanel(successStatus?: string): Promise<void> {
-    const storage = this.readWebStorage();
-    const authSession = this.currentLobbyAuthSession();
-    if (!authSession?.token) {
-      this.dailyDungeonSummary = null;
-
-      this.dailyDungeonStatus = "每日地城需要有效账号会话。";
-      this.renderView();
-      return;
-    }
-
-    this.dailyDungeonStatus = "正在同步每日地城...";
-    this.dailyDungeonLoading = true;
-    this.renderView();
-    let dailyDungeon: CocosDailyDungeonSummary | null = null;
-    try {
-      dailyDungeon = await resolveVeilRootRuntime().loadDailyDungeon(this.remoteUrl, {
-        storage,
-        authSession,
-        throwOnError: true
-      });
-    } catch (error) {
-      this.dailyDungeonSummary = null;
-
-      this.dailyDungeonStatus = error instanceof Error ? error.message : "daily_dungeon_unavailable";
-      this.renderView();
-      return;
-    } finally {
-      this.dailyDungeonLoading = false;
-    }
-
-    this.dailyDungeonSummary = dailyDungeon;
-    if (successStatus?.trim()) {
-      this.dailyDungeonStatus = successStatus.trim();
-    } else if (!dailyDungeon) {
-      this.dailyDungeonStatus = "当前无法读取每日地城配置。";
-    } else {
-      this.dailyDungeonStatus = `剩余 ${dailyDungeon.attemptsRemaining} 次挑战。`;
-    }
-    this.renderView();
+    await refreshDailyDungeonPanelForRoot(this as unknown as Record<string, any>, successStatus);
   }
 
   private async toggleGameplaySeasonalEventPanel(forceOpen?: boolean): Promise<void> {
-    const nextOpen = forceOpen ?? !this.gameplaySeasonalEventPanelOpen;
-    this.gameplayAccountReviewPanelOpen = false;
-    this.gameplayBattlePassPanelOpen = false;
-    this.gameplayDailyDungeonPanelOpen = false;
-    this.gameplayCampaignPanelOpen = false;
-    this.gameplaySeasonalEventPanelOpen = nextOpen;
-    if (!nextOpen) {
-      this.renderView();
-      return;
-    }
-
-    this.renderView();
-    await this.refreshActiveSeasonalEvent();
+    await toggleGameplaySeasonalEventPanelForRoot(this as unknown as Record<string, any>, forceOpen);
   }
 
   private snapshotSeasonProgressFromProfile(): CocosSeasonProgress {
-    return {
-      battlePassEnabled: this.lastUpdate?.featureFlags?.battle_pass_enabled === true,
-      seasonXp: Math.max(0, Math.floor(this.lobbyAccountProfile.seasonXp ?? 0)),
-      seasonPassTier: Math.max(1, Math.floor(this.lobbyAccountProfile.seasonPassTier ?? 1)),
-      seasonPassPremium: this.lobbyAccountProfile.seasonPassPremium === true,
-      seasonPassClaimedTiers: this.lobbyAccountProfile.seasonPassClaimedTiers ?? []
-    };
+    return snapshotSeasonProgressFromProfileForRoot(this as unknown as Record<string, any>);
   }
 
   private async refreshSeasonProgress(): Promise<void> {
-    const storage = this.readWebStorage();
-    const authSession = this.currentLobbyAuthSession();
-    if (!authSession?.token) {
-      this.seasonProgressStatus = "赛季进度需要有效账号会话。";
-      this.renderView();
-      return;
-    }
-
-    this.seasonProgressStatus = "正在同步赛季进度...";
-    this.renderView();
-    try {
-      this.seasonProgress = await resolveVeilRootRuntime().loadSeasonProgress(this.remoteUrl, {
-        storage,
-        authSession,
-        throwOnError: true
-      });
-      this.seasonProgressStatus = this.seasonProgress.seasonPassPremium
-        ? "高级通行证已激活，可领取高级轨道奖励。"
-        : "点击金色按钮可购买高级通行证。";
-    } catch (error) {
-      this.seasonProgressStatus = error instanceof Error ? error.message : "season_progress_unavailable";
-    }
-    this.renderView();
+    await refreshSeasonProgressForRoot(this as unknown as Record<string, any>);
   }
 
   private async refreshActiveSeasonalEvent(): Promise<void> {
-    if (!this.remoteUrl?.trim()) {
-      this.activeSeasonalEvent = null;
-      this.seasonalEventStatus = "赛季活动服务地址未配置。";
-      this.renderView();
-      return;
-    }
-
-    const storage = this.readWebStorage();
-    const authSession = this.currentLobbyAuthSession();
-    if (!authSession?.token) {
-      this.activeSeasonalEvent = null;
-      this.seasonalEventStatus = "赛季活动需要有效账号会话。";
-      this.renderView();
-      return;
-    }
-
-    this.seasonalEventStatus = "正在同步赛季活动...";
-    this.renderView();
-    try {
-      const [event] = await resolveVeilRootRuntime().loadActiveSeasonalEvents(this.remoteUrl, {
-        storage,
-        authSession,
-        throwOnError: true
-      });
-      this.activeSeasonalEvent = event ?? null;
-      this.seasonalEventStatus = event
-        ? `已同步 ${event.name} · 当前积分 ${event.player.points}`
-        : "当前没有进行中的赛季活动。";
-    } catch (error) {
-      this.seasonalEventStatus = error instanceof Error ? error.message : "seasonal_event_unavailable";
-    }
-    this.renderView();
+    await refreshActiveSeasonalEventForRoot(this as unknown as Record<string, any>);
   }
 
   private async submitBattleProgressForActiveEvents(update: SessionUpdate): Promise<void> {
@@ -2441,392 +2183,63 @@ export class VeilRoot extends Component {
   }
 
   private async claimGameplaySeasonTier(tier: number): Promise<void> {
-    const storage = this.readWebStorage();
-    const authSession = this.currentLobbyAuthSession();
-    if (!authSession?.token || this.pendingSeasonClaimTier != null) {
-      return;
-    }
-
-    this.pendingSeasonClaimTier = Math.max(1, Math.floor(tier));
-    this.seasonProgressStatus = `正在领取 T${this.pendingSeasonClaimTier} 奖励...`;
-    this.renderView();
-    try {
-      await resolveVeilRootRuntime().claimSeasonTier(this.remoteUrl, this.pendingSeasonClaimTier, {
-        storage,
-        authSession
-      });
-      await this.refreshLobbyAccountProfile();
-      await this.refreshSeasonProgress();
-      this.seasonProgressStatus = `T${this.pendingSeasonClaimTier} 奖励已领取。`;
-    } catch (error) {
-      this.seasonProgressStatus = error instanceof Error ? error.message : "season_claim_failed";
-    } finally {
-      this.pendingSeasonClaimTier = null;
-      this.renderView();
-    }
+    await claimGameplaySeasonTierForRoot(this as unknown as Record<string, any>, tier);
   }
 
   private async purchaseGameplaySeasonPremium(): Promise<void> {
-    if (this.seasonPremiumPurchaseInFlight) {
-      return;
-    }
-
-    const premiumProduct =
-      this.lobbyShopProducts.find((entry) => entry.type === "season_pass_premium" && entry.enabled)
-      ?? this.lobbyShopProducts.find((entry) => entry.productId === "season-pass-premium");
-    if (!premiumProduct) {
-      this.seasonProgressStatus = "未找到高级通行证商品配置。";
-      this.renderView();
-      return;
-    }
-
-    this.seasonPremiumPurchaseInFlight = true;
-    this.pendingShopProductId = premiumProduct.productId;
-    this.seasonProgressStatus = `正在购买 ${premiumProduct.name}...`;
-    this.renderView();
-    try {
-      this.trackPurchaseInitiated(premiumProduct, "battle_pass");
-      await resolveVeilRootRuntime().purchaseShopProduct(this.remoteUrl, premiumProduct.productId, {
-        getAuthToken: () => this.authToken
-      });
-      await this.refreshLobbyAccountProfile();
-      await this.refreshSeasonProgress();
-      this.seasonProgressStatus = "高级通行证已解锁。";
-    } catch (error) {
-      this.seasonProgressStatus = this.describeShopError(error);
-    } finally {
-      this.seasonPremiumPurchaseInFlight = false;
-      this.pendingShopProductId = null;
-      this.renderView();
-    }
+    await purchaseGameplaySeasonPremiumForRoot(this as unknown as Record<string, any>);
   }
 
   private async attemptGameplayDailyDungeonFloor(floor: number): Promise<void> {
-    const storage = this.readWebStorage();
-    const authSession = this.currentLobbyAuthSession();
-    if (!authSession?.token || this.pendingDailyDungeonFloor != null || this.pendingDailyDungeonClaimRunId != null) {
-      return;
-    }
-
-    this.pendingDailyDungeonFloor = Math.max(1, Math.floor(floor));
-    this.dailyDungeonStatus = `正在记录第 ${this.pendingDailyDungeonFloor} 层挑战...`;
-    this.renderView();
-    try {
-      await resolveVeilRootRuntime().attemptDailyDungeonFloor(this.remoteUrl, this.pendingDailyDungeonFloor, {
-        storage,
-        authSession
-      });
-      await this.refreshLobbyAccountProfile();
-      await this.refreshDailyDungeonPanel(`第 ${this.pendingDailyDungeonFloor} 层挑战已记录，可领取对应奖励。`);
-    } catch (error) {
-      this.dailyDungeonStatus = error instanceof Error ? error.message : "daily_dungeon_attempt_failed";
-    } finally {
-      this.pendingDailyDungeonFloor = null;
-      this.renderView();
-    }
+    await attemptGameplayDailyDungeonFloorForRoot(this as unknown as Record<string, any>, floor);
   }
 
   private async claimGameplayDailyDungeonRun(runId: string): Promise<void> {
-    const storage = this.readWebStorage();
-    const authSession = this.currentLobbyAuthSession();
-    const normalizedRunId = runId.trim();
-    if (!authSession?.token || !normalizedRunId || this.pendingDailyDungeonFloor != null || this.pendingDailyDungeonClaimRunId != null) {
-      return;
-    }
-
-    this.pendingDailyDungeonClaimRunId = normalizedRunId;
-    this.dailyDungeonStatus = "正在领取每日地城奖励...";
-    this.renderView();
-    try {
-      await resolveVeilRootRuntime().claimDailyDungeonRunReward(this.remoteUrl, normalizedRunId, {
-        storage,
-        authSession
-      });
-      await this.refreshLobbyAccountProfile();
-      await this.refreshDailyDungeonPanel("每日地城奖励已领取，活动积分已刷新。");
-    } catch (error) {
-      this.dailyDungeonStatus = error instanceof Error ? error.message : "daily_dungeon_claim_failed";
-    } finally {
-      this.pendingDailyDungeonClaimRunId = null;
-      this.renderView();
-    }
+    await claimGameplayDailyDungeonRunForRoot(this as unknown as Record<string, any>, runId);
   }
 
   private toggleGameplayEquipmentPanel(forceOpen?: boolean): void {
-    this.gameplayEquipmentPanelOpen = forceOpen ?? !this.gameplayEquipmentPanelOpen;
-    if (this.gameplayEquipmentPanelOpen) {
-      this.gameplayCampaignPanelOpen = false;
-      this.announceGameplayPanelSwitch("装备背包", "可以整理战利品、查看穿戴收益并准备下一次推进。");
-    }
-    this.renderView();
+    toggleGameplayEquipmentPanelForRoot(this as unknown as Record<string, any>, forceOpen);
   }
 
   private async toggleGameplayCampaignPanel(forceOpen?: boolean): Promise<void> {
-    const nextOpen = forceOpen ?? !this.gameplayCampaignPanelOpen;
-    this.gameplayCampaignPanelOpen = nextOpen;
-    if (!nextOpen) {
-      this.gameplayCampaignDialogue = null;
-      this.gameplayCampaignPendingAction = null;
-      this.renderView();
-      return;
-    }
-
-    this.gameplayAccountReviewPanelOpen = false;
-    this.gameplayBattlePassPanelOpen = false;
-    this.gameplaySeasonalEventPanelOpen = false;
-    this.gameplayEquipmentPanelOpen = false;
-    this.announceGameplayPanelSwitch("主线任务", "正在同步当前章节、下一任务和路线建议。");
-    this.renderView();
-    await this.refreshGameplayCampaign();
+    await toggleGameplayCampaignPanelForRoot(this as unknown as Record<string, any>, forceOpen);
   }
 
   private resolveSelectedGameplayCampaignMission() {
-    return resolveCampaignPanelMission(
-      this.gameplayCampaign,
-      this.gameplayCampaignSelectedMissionId,
-      this.gameplayCampaignActiveMissionId
-    );
+    return resolveSelectedGameplayCampaignMissionForRoot(this as unknown as Record<string, any>);
   }
 
   private syncGameplayCampaignSelection(preferredMissionId?: string | null): void {
-    const missions = this.gameplayCampaign?.missions ?? [];
-    const preferredId = preferredMissionId?.trim() || null;
-    const campaignNextMissionId = this.gameplayCampaign?.nextMissionId ?? null;
-    const nextMissionId =
-      (preferredId && missions.find((mission) => mission.id === preferredId)?.id)
-      ?? (this.gameplayCampaignActiveMissionId && missions.find((mission) => mission.id === this.gameplayCampaignActiveMissionId)?.id)
-      ?? (campaignNextMissionId && missions.find((mission) => mission.id === campaignNextMissionId)?.id)
-      ?? missions[0]?.id
-      ?? null;
-    this.gameplayCampaignSelectedMissionId = nextMissionId;
+    syncGameplayCampaignSelectionForRoot(this as unknown as Record<string, any>, preferredMissionId);
   }
 
   private selectGameplayCampaignMission(direction: "previous" | "next" | "next-available"): void {
-    const missions = this.gameplayCampaign?.missions ?? [];
-    if (missions.length === 0) {
-      return;
-    }
-
-    if (direction === "next-available") {
-      const nextAvailableMissionId = this.gameplayCampaign?.nextMissionId;
-      if (nextAvailableMissionId) {
-        this.gameplayCampaignSelectedMissionId = nextAvailableMissionId;
-        this.gameplayCampaignDialogue = null;
-        this.renderView();
-      }
-      return;
-    }
-
-    const selectedMission = this.resolveSelectedGameplayCampaignMission();
-    const currentIndex = selectedMission ? missions.findIndex((mission) => mission.id === selectedMission.id) : 0;
-    if (currentIndex < 0) {
-      return;
-    }
-
-    const nextIndex = direction === "previous" ? Math.max(0, currentIndex - 1) : Math.min(missions.length - 1, currentIndex + 1);
-    this.gameplayCampaignSelectedMissionId = missions[nextIndex]?.id ?? this.gameplayCampaignSelectedMissionId;
-    this.gameplayCampaignDialogue = null;
-    this.renderView();
+    selectGameplayCampaignMissionForRoot(this as unknown as Record<string, any>, direction);
   }
 
   private async refreshGameplayCampaign(preferredMissionId?: string | null): Promise<void> {
-    if (!this.authToken || this.authMode !== "account") {
-      this.gameplayCampaign = null;
-      this.gameplayCampaignSelectedMissionId = null;
-      this.gameplayCampaignActiveMissionId = null;
-      this.gameplayCampaignDialogue = null;
-      this.gameplayCampaignStatus = "战役模式需要正式账号会话。";
-      this.renderView();
-      return;
-    }
-
-    this.gameplayCampaignLoading = true;
-    this.gameplayCampaignStatus = "正在同步战役任务...";
-    this.renderView();
-    try {
-      this.gameplayCampaign = await resolveVeilRootRuntime().loadCampaignSummary(this.remoteUrl, {
-        authSession: this.authToken
-          ? {
-              token: this.authToken,
-              playerId: this.playerId,
-              displayName: this.displayName || this.playerId,
-              authMode: this.authMode,
-              provider: this.authProvider,
-              ...(this.loginId ? { loginId: this.loginId } : {}),
-              source: "remote"
-            }
-          : null
-      });
-      if (this.gameplayCampaignActiveMissionId) {
-        const activeMission = this.gameplayCampaign.missions.find((mission) => mission.id === this.gameplayCampaignActiveMissionId) ?? null;
-        if (!activeMission || activeMission.status === "completed") {
-          this.gameplayCampaignActiveMissionId = null;
-          this.gameplayCampaignDialogue = null;
-        }
-      }
-      this.syncGameplayCampaignSelection(preferredMissionId);
-      this.gameplayCampaignStatus =
-        this.gameplayCampaign.nextMissionId
-          ? `下一可用任务 ${this.gameplayCampaign.nextMissionId}`
-          : "当前战役线已全部完成。";
-    } catch (error) {
-      this.gameplayCampaignStatus = this.describeCampaignError(error);
-    } finally {
-      this.gameplayCampaignLoading = false;
-      this.renderView();
-    }
+    await refreshGameplayCampaignForRoot(this as unknown as Record<string, any>, preferredMissionId);
   }
 
   private startGameplayCampaignDialogue(missionId: string, sequence: "intro" | "outro"): void {
-    this.gameplayCampaignDialogue = {
-      missionId,
-      sequence,
-      lineIndex: 0
-    };
+    startGameplayCampaignDialogueForRoot(this as unknown as Record<string, any>, missionId, sequence);
   }
 
   private advanceGameplayCampaignDialogue(): void {
-    const dialogue = this.gameplayCampaignDialogue;
-    if (!dialogue) {
-      return;
-    }
-
-    const mission = this.gameplayCampaign?.missions.find((entry) => entry.id === dialogue.missionId) ?? null;
-    const lines = dialogue.sequence === "outro" ? mission?.outroDialogue ?? [] : mission?.introDialogue ?? [];
-    const currentLine = lines[Math.min(Math.max(0, dialogue.lineIndex), lines.length - 1)] ?? null;
-    if (currentLine && this.session) {
-      void this.session.acknowledgeCampaignDialogue(dialogue.missionId, dialogue.sequence, currentLine.id).catch(() => undefined);
-    }
-    if (lines.length === 0 || dialogue.lineIndex >= lines.length - 1) {
-      this.gameplayCampaignDialogue = null;
-      if (dialogue.sequence === "outro") {
-        this.gameplayCampaignActiveMissionId = null;
-        this.syncGameplayCampaignSelection(this.gameplayCampaign?.nextMissionId);
-        this.gameplayCampaignStatus = mission ? `${mission.name} 已完成并结算。` : "任务已完成。";
-      } else {
-        this.gameplayCampaignPanelOpen = false;
-        this.gameplayCampaignStatus = mission ? `${mission.name} 已进入执行阶段。` : "任务已开始。";
-      }
-      this.renderView();
-      return;
-    }
-
-    this.gameplayCampaignDialogue = {
-      ...dialogue,
-      lineIndex: dialogue.lineIndex + 1
-    };
-    this.renderView();
+    advanceGameplayCampaignDialogueForRoot(this as unknown as Record<string, any>);
   }
 
   private async startGameplayCampaignMission(): Promise<void> {
-    const mission = this.resolveSelectedGameplayCampaignMission();
-    if (!mission || !this.authToken || this.authMode !== "account") {
-      return;
-    }
-
-    this.gameplayCampaignPendingAction = "start";
-    this.gameplayCampaignStatus = `正在启动 ${mission.name}...`;
-    this.renderView();
-    try {
-      const result: CocosCampaignMissionStartResult = await resolveVeilRootRuntime().startCampaignMission(
-        this.remoteUrl,
-        mission.chapterId,
-        mission.id,
-        {
-          authSession: {
-            token: this.authToken,
-            playerId: this.playerId,
-            displayName: this.displayName || this.playerId,
-            authMode: this.authMode,
-            provider: this.authProvider,
-            ...(this.loginId ? { loginId: this.loginId } : {}),
-            source: "remote"
-          }
-        }
-      );
-      this.gameplayCampaignActiveMissionId = result.mission.id;
-      this.gameplayCampaignSelectedMissionId = result.mission.id;
-      if ((result.mission.introDialogue?.length ?? 0) > 0) {
-        this.startGameplayCampaignDialogue(result.mission.id, "intro");
-      } else {
-        this.gameplayCampaignDialogue = null;
-        this.gameplayCampaignPanelOpen = false;
-      }
-      this.trackClientAnalyticsEvent("mission_started", {
-        campaignId: result.mission.chapterId,
-        missionId: result.mission.id,
-        mapId: result.mission.mapId,
-        chapterOrder: Number.parseInt(result.mission.chapterId.replace(/^chapter/i, ""), 10) || 1
-      });
-      await this.refreshGameplayCampaign(result.mission.id);
-      this.gameplayCampaignStatus =
-        (result.mission.introDialogue?.length ?? 0) > 0
-          ? `${result.mission.name} 开场对话已载入。`
-          : `${result.mission.name} 已开始。`;
-    } catch (error) {
-      this.gameplayCampaignStatus = this.describeCampaignError(error);
-    } finally {
-      this.gameplayCampaignPendingAction = null;
-      this.renderView();
-    }
+    await startGameplayCampaignMissionForRoot(this as unknown as Record<string, any>);
   }
 
   private async completeGameplayCampaignMission(): Promise<void> {
-    const mission = this.resolveSelectedGameplayCampaignMission();
-    if (!mission || !this.authToken || this.authMode !== "account" || this.gameplayCampaignActiveMissionId !== mission.id) {
-      return;
-    }
-
-    this.gameplayCampaignPendingAction = "complete";
-    this.gameplayCampaignStatus = `正在提交 ${mission.name} 结算...`;
-    this.renderView();
-    try {
-      const result: CocosCampaignMissionCompleteResult = await resolveVeilRootRuntime().completeCampaignMission(this.remoteUrl, mission.id, {
-        authSession: {
-          token: this.authToken,
-          playerId: this.playerId,
-          displayName: this.displayName || this.playerId,
-          authMode: this.authMode,
-          provider: this.authProvider,
-          ...(this.loginId ? { loginId: this.loginId } : {}),
-          source: "remote"
-        }
-      });
-      this.gameplayCampaign = result.campaign;
-      this.gameplayCampaignSelectedMissionId = result.mission.id;
-      if ((result.mission.outroDialogue?.length ?? 0) > 0) {
-        this.startGameplayCampaignDialogue(result.mission.id, "outro");
-        this.gameplayCampaignStatus = `${result.mission.name} 结算完成，进入收尾对话。`;
-      } else {
-        this.gameplayCampaignActiveMissionId = null;
-        this.syncGameplayCampaignSelection(result.campaign.nextMissionId);
-        this.gameplayCampaignStatus = `${result.mission.name} 已完成。`;
-      }
-    } catch (error) {
-      this.gameplayCampaignStatus = this.describeCampaignError(error);
-    } finally {
-      this.gameplayCampaignPendingAction = null;
-      this.renderView();
-    }
+    await completeGameplayCampaignMissionForRoot(this as unknown as Record<string, any>);
   }
 
   private describeCampaignError(error: unknown): string {
-    if (!(error instanceof Error)) {
-      return "战役请求失败。";
-    }
-    if (error.message.includes("campaign_mission_locked")) {
-      return "任务尚未解锁，请先满足章节条件。";
-    }
-    if (error.message.includes("campaign_mission_already_completed")) {
-      return "任务已完成，无需重复结算。";
-    }
-    if (error.message.includes("campaign_persistence_unavailable")) {
-      return "服务端未启用战役持久化。";
-    }
-    if (error.message.includes("cocos_request_failed:401:")) {
-      return "战役会话已过期，请重新登录正式账号。";
-    }
-    return error.message || "战役请求失败。";
+    return describeCampaignErrorForRoot(error);
   }
 
   private syncGameplayCampaignBattleOutcome(update: SessionUpdate): void {

--- a/apps/cocos-client/assets/scripts/root/index.ts
+++ b/apps/cocos-client/assets/scripts/root/index.ts
@@ -4,5 +4,6 @@ export * from "./runtime";
 export * from "./formatters";
 export * from "./session-helpers";
 export * from "./session-lifecycle";
+export * from "./panel-orchestration";
 export * from "./telemetry-hooks";
 export * from "./tutorial-orchestrator";

--- a/apps/cocos-client/assets/scripts/root/panel-orchestration.ts
+++ b/apps/cocos-client/assets/scripts/root/panel-orchestration.ts
@@ -1,0 +1,771 @@
+import type { SessionUpdate } from "../VeilCocosSession.ts";
+import { buildCocosAccountReviewPage } from "../cocos-account-review.ts";
+import { resolveCampaignPanelMission } from "../cocos-campaign-panel.ts";
+import { buildCocosEventLeaderboardPanelView } from "../cocos-event-leaderboard-panel.ts";
+import type {
+  CocosCampaignMissionCompleteResult,
+  CocosCampaignMissionStartResult
+} from "../cocos-lobby.ts";
+import {
+  buildCocosBattlePassPanelView,
+  buildCocosDailyDungeonPanelView
+} from "../cocos-progression-panel.ts";
+import {
+  ACCOUNT_REVIEW_PANEL_NODE_NAME,
+  CAMPAIGN_PANEL_NODE_NAME,
+  EQUIPMENT_PANEL_NODE_NAME
+} from "./constants";
+import { resolveVeilRootRuntime } from "./runtime";
+
+type VeilRootPanelState = any;
+
+function buildRemoteAccountSessionForRoot(state: VeilRootPanelState) {
+  if (!state.authToken || state.authMode !== "account") {
+    return null;
+  }
+
+  return {
+    token: state.authToken,
+    playerId: state.playerId,
+    displayName: state.displayName || state.playerId,
+    authMode: state.authMode,
+    provider: state.authProvider,
+    ...(state.loginId ? { loginId: state.loginId } : {}),
+    source: "remote" as const
+  };
+}
+
+function closeGameplayProgressionPanelsForRoot(state: VeilRootPanelState): void {
+  state.gameplayAccountReviewPanelOpen = false;
+  state.gameplayBattlePassPanelOpen = false;
+  state.gameplayDailyDungeonPanelOpen = false;
+  state.gameplaySeasonalEventPanelOpen = false;
+}
+
+export function renderGameplayEquipmentPanelForRoot(state: VeilRootPanelState): void {
+  const panelNode = state.node.getChildByName(EQUIPMENT_PANEL_NODE_NAME);
+  if (!panelNode) {
+    return;
+  }
+
+  if (!state.gameplayEquipmentPanelOpen) {
+    panelNode.active = false;
+    return;
+  }
+
+  panelNode.active = true;
+  state.gameplayEquipmentPanel?.render({
+    hero: state.activeHero(),
+    recentEventLog: state.lobbyAccountProfile.recentEventLog,
+    recentSessionEvents: (state.lastUpdate?.events ?? []).filter(
+      (
+        event: NonNullable<SessionUpdate["events"]>[number]
+      ): event is Extract<NonNullable<SessionUpdate["events"]>[number], { type: "hero.equipmentFound" }> =>
+        event.type === "hero.equipmentFound"
+    )
+  });
+}
+
+export function renderGameplayCampaignPanelForRoot(state: VeilRootPanelState): void {
+  const panelNode = state.node.getChildByName(CAMPAIGN_PANEL_NODE_NAME);
+  if (!panelNode) {
+    return;
+  }
+
+  if (!state.gameplayCampaignPanelOpen) {
+    panelNode.active = false;
+    return;
+  }
+
+  panelNode.active = true;
+  state.gameplayCampaignPanel?.render({
+    campaign: state.gameplayCampaign,
+    selectedMissionId: state.gameplayCampaignSelectedMissionId,
+    activeMissionId: state.gameplayCampaignActiveMissionId,
+    dialogue: state.gameplayCampaignDialogue,
+    statusMessage: state.gameplayCampaignStatus,
+    loading: state.gameplayCampaignLoading,
+    pendingAction: state.gameplayCampaignPendingAction
+  });
+}
+
+export function renderGameplayAccountReviewPanelForRoot(state: VeilRootPanelState): void {
+  const panelNode = state.node.getChildByName(ACCOUNT_REVIEW_PANEL_NODE_NAME);
+  if (!panelNode) {
+    return;
+  }
+
+  if (
+    !state.gameplayAccountReviewPanelOpen
+    && !state.gameplayBattlePassPanelOpen
+    && !state.gameplayDailyDungeonPanelOpen
+    && !state.gameplaySeasonalEventPanelOpen
+  ) {
+    panelNode.active = false;
+    return;
+  }
+
+  panelNode.active = true;
+  if (state.gameplayDailyDungeonPanelOpen) {
+    state.gameplayAccountReviewPanel?.render({
+      dailyDungeon: buildCocosDailyDungeonPanelView({
+        dailyDungeon: state.dailyDungeonSummary,
+        activeEvent: null,
+        seasonProgress: state.seasonProgress,
+        currentPlayerId: state.playerId,
+        pendingFloor: state.pendingDailyDungeonFloor,
+        pendingClaimRunId: state.pendingDailyDungeonClaimRunId,
+        statusLabel: state.dailyDungeonStatus
+      })
+    });
+    return;
+  }
+
+  if (state.gameplayBattlePassPanelOpen) {
+    state.gameplayAccountReviewPanel?.render({
+      battlePass: buildCocosBattlePassPanelView({
+        progress: state.seasonProgress,
+        pendingClaimTier: state.pendingSeasonClaimTier,
+        pendingPremiumPurchase: state.seasonPremiumPurchaseInFlight,
+        statusLabel: state.seasonProgressStatus
+      })
+    });
+    return;
+  }
+
+  if (state.gameplaySeasonalEventPanelOpen) {
+    state.gameplayAccountReviewPanel?.render({
+      eventLeaderboard: buildCocosEventLeaderboardPanelView({
+        event: state.activeSeasonalEvent,
+        playerId: state.playerId,
+        statusLabel: state.seasonalEventStatus
+      })
+    });
+    return;
+  }
+
+  state.gameplayAccountReviewPanel?.render({
+    page: buildCocosAccountReviewPage(state.lobbyAccountReviewState)
+  });
+}
+
+export async function toggleGameplayAccountReviewPanelForRoot(
+  state: VeilRootPanelState,
+  forceOpen?: boolean
+): Promise<void> {
+  const nextOpen = forceOpen ?? !state.gameplayAccountReviewPanelOpen;
+  state.gameplayBattlePassPanelOpen = false;
+  state.gameplayDailyDungeonPanelOpen = false;
+  state.gameplaySeasonalEventPanelOpen = false;
+  state.gameplayCampaignPanelOpen = false;
+  state.gameplayAccountReviewPanelOpen = nextOpen;
+  if (!nextOpen) {
+    state.renderView();
+    return;
+  }
+
+  state.renderView();
+  await state.refreshActiveAccountReviewSection();
+}
+
+export function snapshotSeasonProgressFromProfileForRoot(state: VeilRootPanelState) {
+  return {
+    battlePassEnabled: state.lastUpdate?.featureFlags?.battle_pass_enabled === true,
+    seasonXp: Math.max(0, Math.floor(state.lobbyAccountProfile.seasonXp ?? 0)),
+    seasonPassTier: Math.max(1, Math.floor(state.lobbyAccountProfile.seasonPassTier ?? 1)),
+    seasonPassPremium: state.lobbyAccountProfile.seasonPassPremium === true,
+    seasonPassClaimedTiers: state.lobbyAccountProfile.seasonPassClaimedTiers ?? []
+  };
+}
+
+export async function toggleGameplayBattlePassPanelForRoot(
+  state: VeilRootPanelState,
+  forceOpen?: boolean
+): Promise<void> {
+  if (state.lastUpdate?.featureFlags?.battle_pass_enabled !== true) {
+    state.gameplayBattlePassPanelOpen = false;
+    state.seasonProgressStatus = "battle_pass_enabled = false";
+    state.renderView();
+    return;
+  }
+
+  const nextOpen = forceOpen ?? !state.gameplayBattlePassPanelOpen;
+  state.gameplayAccountReviewPanelOpen = false;
+  state.gameplayDailyDungeonPanelOpen = false;
+  state.gameplaySeasonalEventPanelOpen = false;
+  state.gameplayCampaignPanelOpen = false;
+  state.gameplayBattlePassPanelOpen = nextOpen;
+  if (!nextOpen) {
+    state.renderView();
+    return;
+  }
+
+  state.announceGameplayPanelSwitch("成长目标", "正在同步赛季通行证、长期成长与下一解锁目标。");
+  state.seasonProgress = snapshotSeasonProgressFromProfileForRoot(state);
+  state.renderView();
+  await state.refreshSeasonProgress();
+}
+
+export async function toggleGameplayDailyDungeonPanelForRoot(
+  state: VeilRootPanelState,
+  forceOpen?: boolean
+): Promise<void> {
+  const nextOpen = forceOpen ?? !state.gameplayDailyDungeonPanelOpen;
+  state.gameplayAccountReviewPanelOpen = false;
+  state.gameplayBattlePassPanelOpen = false;
+  state.gameplaySeasonalEventPanelOpen = false;
+  state.gameplayCampaignPanelOpen = false;
+  state.gameplayDailyDungeonPanelOpen = nextOpen;
+  if (!nextOpen) {
+    state.renderView();
+    return;
+  }
+
+  state.announceGameplayPanelSwitch("今日地城", "正在同步今日轮换、剩余次数与可领取奖励。");
+  state.renderView();
+  await state.refreshDailyDungeonPanel();
+}
+
+export async function openLobbyPvePanelForRoot(
+  state: VeilRootPanelState,
+  target: "campaign" | "daily-dungeon" | "battle-pass"
+): Promise<void> {
+  if (state.authMode !== "account" || !state.authToken) {
+    state.lobbyStatus = target === "campaign"
+      ? "主线章节需要正式账号会话。"
+      : target === "daily-dungeon"
+        ? "每日地城需要正式账号会话。"
+        : "赛季通行证需要正式账号会话。";
+    state.renderView();
+    return;
+  }
+
+  if (state.showLobby) {
+    await state.enterLobbyRoom();
+    if (state.showLobby) {
+      return;
+    }
+  }
+
+  if (target === "campaign") {
+    await state.toggleGameplayCampaignPanel(true);
+    return;
+  }
+
+  if (target === "battle-pass") {
+    await state.toggleGameplayBattlePassPanel(true);
+    return;
+  }
+
+  await state.toggleGameplayDailyDungeonPanel(true);
+}
+
+export async function refreshDailyDungeonPanelForRoot(
+  state: VeilRootPanelState,
+  successStatus?: string
+): Promise<void> {
+  const storage = state.readWebStorage();
+  const authSession = state.currentLobbyAuthSession();
+  if (!authSession?.token) {
+    state.dailyDungeonSummary = null;
+    state.dailyDungeonStatus = "每日地城需要有效账号会话。";
+    state.renderView();
+    return;
+  }
+
+  state.dailyDungeonStatus = "正在同步每日地城...";
+  state.dailyDungeonLoading = true;
+  state.renderView();
+  let dailyDungeon = null;
+  try {
+    dailyDungeon = await resolveVeilRootRuntime().loadDailyDungeon(state.remoteUrl, {
+      storage,
+      authSession,
+      throwOnError: true
+    });
+  } catch (error) {
+    state.dailyDungeonSummary = null;
+    state.dailyDungeonStatus = error instanceof Error ? error.message : "daily_dungeon_unavailable";
+    state.renderView();
+    return;
+  } finally {
+    state.dailyDungeonLoading = false;
+  }
+
+  state.dailyDungeonSummary = dailyDungeon;
+  if (successStatus?.trim()) {
+    state.dailyDungeonStatus = successStatus.trim();
+  } else if (!dailyDungeon) {
+    state.dailyDungeonStatus = "当前无法读取每日地城配置。";
+  } else {
+    state.dailyDungeonStatus = `剩余 ${dailyDungeon.attemptsRemaining} 次挑战。`;
+  }
+  state.renderView();
+}
+
+export async function toggleGameplaySeasonalEventPanelForRoot(
+  state: VeilRootPanelState,
+  forceOpen?: boolean
+): Promise<void> {
+  const nextOpen = forceOpen ?? !state.gameplaySeasonalEventPanelOpen;
+  state.gameplayAccountReviewPanelOpen = false;
+  state.gameplayBattlePassPanelOpen = false;
+  state.gameplayDailyDungeonPanelOpen = false;
+  state.gameplayCampaignPanelOpen = false;
+  state.gameplaySeasonalEventPanelOpen = nextOpen;
+  if (!nextOpen) {
+    state.renderView();
+    return;
+  }
+
+  state.renderView();
+  await state.refreshActiveSeasonalEvent();
+}
+
+export async function refreshSeasonProgressForRoot(state: VeilRootPanelState): Promise<void> {
+  const storage = state.readWebStorage();
+  const authSession = state.currentLobbyAuthSession();
+  if (!authSession?.token) {
+    state.seasonProgressStatus = "赛季进度需要有效账号会话。";
+    state.renderView();
+    return;
+  }
+
+  state.seasonProgressStatus = "正在同步赛季进度...";
+  state.renderView();
+  try {
+    state.seasonProgress = await resolveVeilRootRuntime().loadSeasonProgress(state.remoteUrl, {
+      storage,
+      authSession,
+      throwOnError: true
+    });
+    state.seasonProgressStatus = state.seasonProgress.seasonPassPremium
+      ? "高级通行证已激活，可领取高级轨道奖励。"
+      : "点击金色按钮可购买高级通行证。";
+  } catch (error) {
+    state.seasonProgressStatus = error instanceof Error ? error.message : "season_progress_unavailable";
+  }
+  state.renderView();
+}
+
+export async function refreshActiveSeasonalEventForRoot(state: VeilRootPanelState): Promise<void> {
+  if (!state.remoteUrl?.trim()) {
+    state.activeSeasonalEvent = null;
+    state.seasonalEventStatus = "赛季活动服务地址未配置。";
+    state.renderView();
+    return;
+  }
+
+  const storage = state.readWebStorage();
+  const authSession = state.currentLobbyAuthSession();
+  if (!authSession?.token) {
+    state.activeSeasonalEvent = null;
+    state.seasonalEventStatus = "赛季活动需要有效账号会话。";
+    state.renderView();
+    return;
+  }
+
+  state.seasonalEventStatus = "正在同步赛季活动...";
+  state.renderView();
+  try {
+    const [event] = await resolveVeilRootRuntime().loadActiveSeasonalEvents(state.remoteUrl, {
+      storage,
+      authSession,
+      throwOnError: true
+    });
+    state.activeSeasonalEvent = event ?? null;
+    state.seasonalEventStatus = event
+      ? `已同步 ${event.name} · 当前积分 ${event.player.points}`
+      : "当前没有进行中的赛季活动。";
+  } catch (error) {
+    state.seasonalEventStatus = error instanceof Error ? error.message : "seasonal_event_unavailable";
+  }
+  state.renderView();
+}
+
+export async function claimGameplaySeasonTierForRoot(state: VeilRootPanelState, tier: number): Promise<void> {
+  const storage = state.readWebStorage();
+  const authSession = state.currentLobbyAuthSession();
+  if (!authSession?.token || state.pendingSeasonClaimTier != null) {
+    return;
+  }
+
+  state.pendingSeasonClaimTier = Math.max(1, Math.floor(tier));
+  state.seasonProgressStatus = `正在领取 T${state.pendingSeasonClaimTier} 奖励...`;
+  state.renderView();
+  try {
+    await resolveVeilRootRuntime().claimSeasonTier(state.remoteUrl, state.pendingSeasonClaimTier, {
+      storage,
+      authSession
+    });
+    await state.refreshLobbyAccountProfile();
+    await state.refreshSeasonProgress();
+    state.seasonProgressStatus = `T${state.pendingSeasonClaimTier} 奖励已领取。`;
+  } catch (error) {
+    state.seasonProgressStatus = error instanceof Error ? error.message : "season_claim_failed";
+  } finally {
+    state.pendingSeasonClaimTier = null;
+    state.renderView();
+  }
+}
+
+export async function purchaseGameplaySeasonPremiumForRoot(state: VeilRootPanelState): Promise<void> {
+  if (state.seasonPremiumPurchaseInFlight) {
+    return;
+  }
+
+  const premiumProduct =
+    state.lobbyShopProducts.find((entry: { type: string; enabled: boolean }) => entry.type === "season_pass_premium" && entry.enabled)
+    ?? state.lobbyShopProducts.find((entry: { productId: string }) => entry.productId === "season-pass-premium");
+  if (!premiumProduct) {
+    state.seasonProgressStatus = "未找到高级通行证商品配置。";
+    state.renderView();
+    return;
+  }
+
+  state.seasonPremiumPurchaseInFlight = true;
+  state.pendingShopProductId = premiumProduct.productId;
+  state.seasonProgressStatus = `正在购买 ${premiumProduct.name}...`;
+  state.renderView();
+  try {
+    state.trackPurchaseInitiated(premiumProduct, "battle_pass");
+    await resolveVeilRootRuntime().purchaseShopProduct(state.remoteUrl, premiumProduct.productId, {
+      getAuthToken: () => state.authToken
+    });
+    await state.refreshLobbyAccountProfile();
+    await state.refreshSeasonProgress();
+    state.seasonProgressStatus = "高级通行证已解锁。";
+  } catch (error) {
+    state.seasonProgressStatus = state.describeShopError(error);
+  } finally {
+    state.seasonPremiumPurchaseInFlight = false;
+    state.pendingShopProductId = null;
+    state.renderView();
+  }
+}
+
+export async function attemptGameplayDailyDungeonFloorForRoot(state: VeilRootPanelState, floor: number): Promise<void> {
+  const storage = state.readWebStorage();
+  const authSession = state.currentLobbyAuthSession();
+  if (!authSession?.token || state.pendingDailyDungeonFloor != null || state.pendingDailyDungeonClaimRunId != null) {
+    return;
+  }
+
+  state.pendingDailyDungeonFloor = Math.max(1, Math.floor(floor));
+  state.dailyDungeonStatus = `正在记录第 ${state.pendingDailyDungeonFloor} 层挑战...`;
+  state.renderView();
+  try {
+    await resolveVeilRootRuntime().attemptDailyDungeonFloor(state.remoteUrl, state.pendingDailyDungeonFloor, {
+      storage,
+      authSession
+    });
+    await state.refreshLobbyAccountProfile();
+    await state.refreshDailyDungeonPanel(`第 ${state.pendingDailyDungeonFloor} 层挑战已记录，可领取对应奖励。`);
+  } catch (error) {
+    state.dailyDungeonStatus = error instanceof Error ? error.message : "daily_dungeon_attempt_failed";
+  } finally {
+    state.pendingDailyDungeonFloor = null;
+    state.renderView();
+  }
+}
+
+export async function claimGameplayDailyDungeonRunForRoot(state: VeilRootPanelState, runId: string): Promise<void> {
+  const storage = state.readWebStorage();
+  const authSession = state.currentLobbyAuthSession();
+  const normalizedRunId = runId.trim();
+  if (
+    !authSession?.token
+    || !normalizedRunId
+    || state.pendingDailyDungeonFloor != null
+    || state.pendingDailyDungeonClaimRunId != null
+  ) {
+    return;
+  }
+
+  state.pendingDailyDungeonClaimRunId = normalizedRunId;
+  state.dailyDungeonStatus = "正在领取每日地城奖励...";
+  state.renderView();
+  try {
+    await resolveVeilRootRuntime().claimDailyDungeonRunReward(state.remoteUrl, normalizedRunId, {
+      storage,
+      authSession
+    });
+    await state.refreshLobbyAccountProfile();
+    await state.refreshDailyDungeonPanel("每日地城奖励已领取，活动积分已刷新。");
+  } catch (error) {
+    state.dailyDungeonStatus = error instanceof Error ? error.message : "daily_dungeon_claim_failed";
+  } finally {
+    state.pendingDailyDungeonClaimRunId = null;
+    state.renderView();
+  }
+}
+
+export function toggleGameplayEquipmentPanelForRoot(state: VeilRootPanelState, forceOpen?: boolean): void {
+  state.gameplayEquipmentPanelOpen = forceOpen ?? !state.gameplayEquipmentPanelOpen;
+  if (state.gameplayEquipmentPanelOpen) {
+    state.gameplayCampaignPanelOpen = false;
+    state.announceGameplayPanelSwitch("装备背包", "可以整理战利品、查看穿戴收益并准备下一次推进。");
+  }
+  state.renderView();
+}
+
+export async function toggleGameplayCampaignPanelForRoot(
+  state: VeilRootPanelState,
+  forceOpen?: boolean
+): Promise<void> {
+  const nextOpen = forceOpen ?? !state.gameplayCampaignPanelOpen;
+  state.gameplayCampaignPanelOpen = nextOpen;
+  if (!nextOpen) {
+    state.gameplayCampaignDialogue = null;
+    state.gameplayCampaignPendingAction = null;
+    state.renderView();
+    return;
+  }
+
+  closeGameplayProgressionPanelsForRoot(state);
+  state.gameplayEquipmentPanelOpen = false;
+  state.announceGameplayPanelSwitch("主线任务", "正在同步当前章节、下一任务和路线建议。");
+  state.renderView();
+  await state.refreshGameplayCampaign();
+}
+
+export function resolveSelectedGameplayCampaignMissionForRoot(state: VeilRootPanelState) {
+  return resolveCampaignPanelMission(
+    state.gameplayCampaign,
+    state.gameplayCampaignSelectedMissionId,
+    state.gameplayCampaignActiveMissionId
+  );
+}
+
+export function syncGameplayCampaignSelectionForRoot(
+  state: VeilRootPanelState,
+  preferredMissionId?: string | null
+): void {
+  const missions = state.gameplayCampaign?.missions ?? [];
+  const preferredId = preferredMissionId?.trim() || null;
+  const campaignNextMissionId = state.gameplayCampaign?.nextMissionId ?? null;
+  const nextMissionId =
+    (preferredId && missions.find((mission: { id: string }) => mission.id === preferredId)?.id)
+    ?? (state.gameplayCampaignActiveMissionId
+      && missions.find((mission: { id: string }) => mission.id === state.gameplayCampaignActiveMissionId)?.id)
+    ?? (campaignNextMissionId && missions.find((mission: { id: string }) => mission.id === campaignNextMissionId)?.id)
+    ?? missions[0]?.id
+    ?? null;
+  state.gameplayCampaignSelectedMissionId = nextMissionId;
+}
+
+export function selectGameplayCampaignMissionForRoot(
+  state: VeilRootPanelState,
+  direction: "previous" | "next" | "next-available"
+): void {
+  const missions = state.gameplayCampaign?.missions ?? [];
+  if (missions.length === 0) {
+    return;
+  }
+
+  if (direction === "next-available") {
+    const nextAvailableMissionId = state.gameplayCampaign?.nextMissionId;
+    if (nextAvailableMissionId) {
+      state.gameplayCampaignSelectedMissionId = nextAvailableMissionId;
+      state.gameplayCampaignDialogue = null;
+      state.renderView();
+    }
+    return;
+  }
+
+  const selectedMission = resolveSelectedGameplayCampaignMissionForRoot(state);
+  const currentIndex = selectedMission ? missions.findIndex((mission: { id: string }) => mission.id === selectedMission.id) : 0;
+  if (currentIndex < 0) {
+    return;
+  }
+
+  const nextIndex = direction === "previous"
+    ? Math.max(0, currentIndex - 1)
+    : Math.min(missions.length - 1, currentIndex + 1);
+  state.gameplayCampaignSelectedMissionId = missions[nextIndex]?.id ?? state.gameplayCampaignSelectedMissionId;
+  state.gameplayCampaignDialogue = null;
+  state.renderView();
+}
+
+export async function refreshGameplayCampaignForRoot(
+  state: VeilRootPanelState,
+  preferredMissionId?: string | null
+): Promise<void> {
+  const authSession = buildRemoteAccountSessionForRoot(state);
+  if (!authSession) {
+    state.gameplayCampaign = null;
+    state.gameplayCampaignSelectedMissionId = null;
+    state.gameplayCampaignActiveMissionId = null;
+    state.gameplayCampaignDialogue = null;
+    state.gameplayCampaignStatus = "战役模式需要正式账号会话。";
+    state.renderView();
+    return;
+  }
+
+  state.gameplayCampaignLoading = true;
+  state.gameplayCampaignStatus = "正在同步战役任务...";
+  state.renderView();
+  try {
+    state.gameplayCampaign = await resolveVeilRootRuntime().loadCampaignSummary(state.remoteUrl, {
+      authSession
+    });
+    if (state.gameplayCampaignActiveMissionId) {
+      const activeMission =
+        state.gameplayCampaign.missions.find((mission: { id: string }) => mission.id === state.gameplayCampaignActiveMissionId) ?? null;
+      if (!activeMission || activeMission.status === "completed") {
+        state.gameplayCampaignActiveMissionId = null;
+        state.gameplayCampaignDialogue = null;
+      }
+    }
+    syncGameplayCampaignSelectionForRoot(state, preferredMissionId);
+    state.gameplayCampaignStatus = state.gameplayCampaign.nextMissionId
+      ? `下一可用任务 ${state.gameplayCampaign.nextMissionId}`
+      : "当前战役线已全部完成。";
+  } catch (error) {
+    state.gameplayCampaignStatus = describeCampaignErrorForRoot(error);
+  } finally {
+    state.gameplayCampaignLoading = false;
+    state.renderView();
+  }
+}
+
+export function startGameplayCampaignDialogueForRoot(
+  state: VeilRootPanelState,
+  missionId: string,
+  sequence: "intro" | "outro"
+): void {
+  state.gameplayCampaignDialogue = {
+    missionId,
+    sequence,
+    lineIndex: 0
+  };
+}
+
+export function advanceGameplayCampaignDialogueForRoot(state: VeilRootPanelState): void {
+  const dialogue = state.gameplayCampaignDialogue;
+  if (!dialogue) {
+    return;
+  }
+
+  const mission = state.gameplayCampaign?.missions.find((entry: { id: string }) => entry.id === dialogue.missionId) ?? null;
+  const lines = dialogue.sequence === "outro" ? mission?.outroDialogue ?? [] : mission?.introDialogue ?? [];
+  const currentLine = lines[Math.min(Math.max(0, dialogue.lineIndex), lines.length - 1)] ?? null;
+  if (currentLine && state.session) {
+    void state.session.acknowledgeCampaignDialogue(dialogue.missionId, dialogue.sequence, currentLine.id).catch(() => undefined);
+  }
+  if (lines.length === 0 || dialogue.lineIndex >= lines.length - 1) {
+    state.gameplayCampaignDialogue = null;
+    if (dialogue.sequence === "outro") {
+      state.gameplayCampaignActiveMissionId = null;
+      syncGameplayCampaignSelectionForRoot(state, state.gameplayCampaign?.nextMissionId);
+      state.gameplayCampaignStatus = mission ? `${mission.name} 已完成并结算。` : "任务已完成。";
+    } else {
+      state.gameplayCampaignPanelOpen = false;
+      state.gameplayCampaignStatus = mission ? `${mission.name} 已进入执行阶段。` : "任务已开始。";
+    }
+    state.renderView();
+    return;
+  }
+
+  state.gameplayCampaignDialogue = {
+    ...dialogue,
+    lineIndex: dialogue.lineIndex + 1
+  };
+  state.renderView();
+}
+
+export async function startGameplayCampaignMissionForRoot(state: VeilRootPanelState): Promise<void> {
+  const mission = resolveSelectedGameplayCampaignMissionForRoot(state);
+  const authSession = buildRemoteAccountSessionForRoot(state);
+  if (!mission || !authSession) {
+    return;
+  }
+
+  state.gameplayCampaignPendingAction = "start";
+  state.gameplayCampaignStatus = `正在启动 ${mission.name}...`;
+  state.renderView();
+  try {
+    const result: CocosCampaignMissionStartResult = await resolveVeilRootRuntime().startCampaignMission(
+      state.remoteUrl,
+      mission.chapterId,
+      mission.id,
+      { authSession }
+    );
+    state.gameplayCampaignActiveMissionId = result.mission.id;
+    state.gameplayCampaignSelectedMissionId = result.mission.id;
+    if ((result.mission.introDialogue?.length ?? 0) > 0) {
+      startGameplayCampaignDialogueForRoot(state, result.mission.id, "intro");
+    } else {
+      state.gameplayCampaignDialogue = null;
+      state.gameplayCampaignPanelOpen = false;
+    }
+    state.trackClientAnalyticsEvent("mission_started", {
+      campaignId: result.mission.chapterId,
+      missionId: result.mission.id,
+      mapId: result.mission.mapId,
+      chapterOrder: Number.parseInt(result.mission.chapterId.replace(/^chapter/i, ""), 10) || 1
+    });
+    await refreshGameplayCampaignForRoot(state, result.mission.id);
+    state.gameplayCampaignStatus = (result.mission.introDialogue?.length ?? 0) > 0
+      ? `${result.mission.name} 开场对话已载入。`
+      : `${result.mission.name} 已开始。`;
+  } catch (error) {
+    state.gameplayCampaignStatus = describeCampaignErrorForRoot(error);
+  } finally {
+    state.gameplayCampaignPendingAction = null;
+    state.renderView();
+  }
+}
+
+export async function completeGameplayCampaignMissionForRoot(state: VeilRootPanelState): Promise<void> {
+  const mission = resolveSelectedGameplayCampaignMissionForRoot(state);
+  const authSession = buildRemoteAccountSessionForRoot(state);
+  if (!mission || !authSession || state.gameplayCampaignActiveMissionId !== mission.id) {
+    return;
+  }
+
+  state.gameplayCampaignPendingAction = "complete";
+  state.gameplayCampaignStatus = `正在提交 ${mission.name} 结算...`;
+  state.renderView();
+  try {
+    const result: CocosCampaignMissionCompleteResult = await resolveVeilRootRuntime().completeCampaignMission(
+      state.remoteUrl,
+      mission.id,
+      { authSession }
+    );
+    state.gameplayCampaign = result.campaign;
+    state.gameplayCampaignSelectedMissionId = result.mission.id;
+    if ((result.mission.outroDialogue?.length ?? 0) > 0) {
+      startGameplayCampaignDialogueForRoot(state, result.mission.id, "outro");
+      state.gameplayCampaignStatus = `${result.mission.name} 结算完成，进入收尾对话。`;
+    } else {
+      state.gameplayCampaignActiveMissionId = null;
+      syncGameplayCampaignSelectionForRoot(state, result.campaign.nextMissionId);
+      state.gameplayCampaignStatus = `${result.mission.name} 已完成。`;
+    }
+  } catch (error) {
+    state.gameplayCampaignStatus = describeCampaignErrorForRoot(error);
+  } finally {
+    state.gameplayCampaignPendingAction = null;
+    state.renderView();
+  }
+}
+
+export function describeCampaignErrorForRoot(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return "战役请求失败。";
+  }
+  if (error.message.includes("campaign_mission_locked")) {
+    return "任务尚未解锁，请先满足章节条件。";
+  }
+  if (error.message.includes("campaign_mission_already_completed")) {
+    return "任务已完成，无需重复结算。";
+  }
+  if (error.message.includes("campaign_persistence_unavailable")) {
+    return "服务端未启用战役持久化。";
+  }
+  if (error.message.includes("cocos_request_failed:401:")) {
+    return "战役会话已过期，请重新登录正式账号。";
+  }
+  return error.message || "战役请求失败。";
+}

--- a/apps/cocos-client/test/root-panel-orchestration.test.ts
+++ b/apps/cocos-client/test/root-panel-orchestration.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  advanceGameplayCampaignDialogueForRoot,
+  describeCampaignErrorForRoot,
+  openLobbyPvePanelForRoot,
+  resolveSelectedGameplayCampaignMissionForRoot,
+  syncGameplayCampaignSelectionForRoot,
+  toggleGameplayBattlePassPanelForRoot
+} from "../assets/scripts/root/panel-orchestration.ts";
+
+function createCampaignState() {
+  return {
+    nextMissionId: "chapter1-ember-watch",
+    missions: [
+      {
+        id: "chapter1-ember-watch",
+        name: "余烬哨站",
+        status: "available",
+        objectives: [],
+        introDialogue: [
+          {
+            id: "intro-1",
+            text: "守住火线。"
+          }
+        ],
+        outroDialogue: [
+          {
+            id: "outro-1",
+            text: "哨站重新亮灯了。"
+          }
+        ]
+      },
+      {
+        id: "chapter1-thornwall-road",
+        name: "荆墙驿路",
+        status: "locked",
+        objectives: [],
+        introDialogue: [],
+        outroDialogue: []
+      }
+    ]
+  };
+}
+
+test("describeCampaignErrorForRoot maps known campaign failures to player-facing copy", () => {
+  assert.match(describeCampaignErrorForRoot(new Error("campaign_mission_locked")), /尚未解锁/);
+  assert.match(describeCampaignErrorForRoot(new Error("campaign_mission_already_completed")), /已完成/);
+  assert.match(describeCampaignErrorForRoot(new Error("cocos_request_failed:401:expired")), /重新登录正式账号/);
+});
+
+test("toggleGameplayBattlePassPanelForRoot closes sibling panels and snapshots season progress before refresh", async () => {
+  let refreshCalls = 0;
+  let renderCalls = 0;
+  let announced: { title: string; detail: string } | null = null;
+  const state = {
+    lastUpdate: {
+      featureFlags: {
+        battle_pass_enabled: true
+      }
+    },
+    lobbyAccountProfile: {
+      seasonXp: 128,
+      seasonPassTier: 4,
+      seasonPassPremium: true,
+      seasonPassClaimedTiers: [1, 2]
+    },
+    gameplayAccountReviewPanelOpen: true,
+    gameplayBattlePassPanelOpen: false,
+    gameplayDailyDungeonPanelOpen: true,
+    gameplaySeasonalEventPanelOpen: true,
+    gameplayCampaignPanelOpen: true,
+    seasonProgress: null,
+    seasonProgressStatus: "",
+    announceGameplayPanelSwitch(title: string, detail: string) {
+      announced = { title, detail };
+    },
+    renderView() {
+      renderCalls += 1;
+    },
+    async refreshSeasonProgress() {
+      refreshCalls += 1;
+    }
+  };
+
+  await toggleGameplayBattlePassPanelForRoot(state);
+
+  assert.equal(state.gameplayBattlePassPanelOpen, true);
+  assert.equal(state.gameplayAccountReviewPanelOpen, false);
+  assert.equal(state.gameplayDailyDungeonPanelOpen, false);
+  assert.equal(state.gameplaySeasonalEventPanelOpen, false);
+  assert.equal(state.gameplayCampaignPanelOpen, false);
+  assert.deepEqual(state.seasonProgress, {
+    battlePassEnabled: true,
+    seasonXp: 128,
+    seasonPassTier: 4,
+    seasonPassPremium: true,
+    seasonPassClaimedTiers: [1, 2]
+  });
+  assert.equal(refreshCalls, 1);
+  assert.ok(renderCalls >= 1);
+  assert.deepEqual(announced, {
+    title: "成长目标",
+    detail: "正在同步赛季通行证、长期成长与下一解锁目标。"
+  });
+});
+
+test("openLobbyPvePanelForRoot blocks guest sessions with clear lobby copy", async () => {
+  let renderCalls = 0;
+  const state = {
+    authMode: "guest",
+    authToken: null,
+    lobbyStatus: "",
+    renderView() {
+      renderCalls += 1;
+    }
+  };
+
+  await openLobbyPvePanelForRoot(state, "campaign");
+
+  assert.match(state.lobbyStatus, /正式账号会话/);
+  assert.equal(renderCalls, 1);
+});
+
+test("syncGameplayCampaignSelectionForRoot and resolveSelectedGameplayCampaignMissionForRoot prefer the active mission", () => {
+  const state = {
+    gameplayCampaign: createCampaignState(),
+    gameplayCampaignSelectedMissionId: "missing",
+    gameplayCampaignActiveMissionId: "chapter1-ember-watch"
+  };
+
+  syncGameplayCampaignSelectionForRoot(state);
+
+  assert.equal(state.gameplayCampaignSelectedMissionId, "chapter1-ember-watch");
+  assert.equal(resolveSelectedGameplayCampaignMissionForRoot(state)?.id, "chapter1-ember-watch");
+});
+
+test("advanceGameplayCampaignDialogueForRoot acknowledges lines and clears intro or outro flows", async () => {
+  const acknowledgements: Array<{ missionId: string; sequence: string; lineId: string }> = [];
+  let renderCalls = 0;
+  const state = {
+    gameplayCampaign: createCampaignState(),
+    gameplayCampaignDialogue: {
+      missionId: "chapter1-ember-watch",
+      sequence: "intro",
+      lineIndex: 0
+    },
+    gameplayCampaignPanelOpen: true,
+    gameplayCampaignStatus: "",
+    gameplayCampaignActiveMissionId: "chapter1-ember-watch",
+    gameplayCampaignSelectedMissionId: "chapter1-ember-watch",
+    session: {
+      async acknowledgeCampaignDialogue(missionId: string, sequence: string, lineId: string) {
+        acknowledgements.push({ missionId, sequence, lineId });
+      }
+    },
+    renderView() {
+      renderCalls += 1;
+    }
+  };
+
+  advanceGameplayCampaignDialogueForRoot(state);
+  assert.equal(state.gameplayCampaignDialogue, null);
+  assert.equal(state.gameplayCampaignPanelOpen, false);
+  assert.match(String(state.gameplayCampaignStatus), /执行阶段|已开始/);
+
+  state.gameplayCampaignDialogue = {
+    missionId: "chapter1-ember-watch",
+    sequence: "outro",
+    lineIndex: 0
+  };
+  state.gameplayCampaignPanelOpen = true;
+  state.gameplayCampaign.nextMissionId = "chapter1-thornwall-road";
+
+  advanceGameplayCampaignDialogueForRoot(state);
+  assert.equal(state.gameplayCampaignDialogue, null);
+  assert.equal(state.gameplayCampaignActiveMissionId, null);
+  assert.equal(state.gameplayCampaignSelectedMissionId, "chapter1-thornwall-road");
+  assert.match(String(state.gameplayCampaignStatus), /已完成并结算/);
+  assert.equal(renderCalls, 2);
+  assert.deepEqual(acknowledgements, [
+    {
+      missionId: "chapter1-ember-watch",
+      sequence: "intro",
+      lineId: "intro-1"
+    },
+    {
+      missionId: "chapter1-ember-watch",
+      sequence: "outro",
+      lineId: "outro-1"
+    }
+  ]);
+});

--- a/progress.md
+++ b/progress.md
@@ -2235,3 +2235,14 @@ Original prompt: 你先学习下当前项目并给出开发的计划
   - `npm run typecheck:cocos`
   - `node --import ./node_modules/tsx/dist/loader.mjs --test ./apps/cocos-client/test/root-session-lifecycle.test.ts ./apps/cocos-client/test/root-telemetry-hooks.test.ts ./apps/cocos-client/test/root-tutorial-orchestrator.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts`
   - `npm run smoke:cocos:canonical-journey`
+
+- 同一轮继续把 `gameplay panel orchestration` 抽进了 `root/`：
+  - `apps/cocos-client/assets/scripts/root/panel-orchestration.ts`
+    - 收拢 `campaign / battle pass / daily dungeon / seasonal event / account review / equipment` 的 panel 渲染、切换和主线任务动作
+- `apps/cocos-client/assets/scripts/VeilRoot.ts`
+  - 对应 panel 方法已经改成轻量委托层，主文件从 `6232` 行继续降到 `5661` 行
+- 新增模块级测试：
+  - `apps/cocos-client/test/root-panel-orchestration.test.ts`
+- 本轮补充验证已通过：
+  - `npm run typecheck:cocos`
+  - `node --import ./node_modules/tsx/dist/loader.mjs --test ./apps/cocos-client/test/root-panel-orchestration.test.ts ./apps/cocos-client/test/root-session-lifecycle.test.ts ./apps/cocos-client/test/root-telemetry-hooks.test.ts ./apps/cocos-client/test/root-tutorial-orchestrator.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts`


### PR DESCRIPTION
## Summary\n- extract gameplay panel rendering, switching, and campaign actions into root/panel-orchestration\n- add focused panel orchestration tests alongside the existing VeilRoot orchestration coverage\n- continue shrinking VeilRoot while keeping issue #1561 open for the remaining render-state/prefetch splits\n\n## Testing\n- npm run typecheck:cocos\n- node --import ./node_modules/tsx/dist/loader.mjs --test ./apps/cocos-client/test/root-panel-orchestration.test.ts ./apps/cocos-client/test/root-session-lifecycle.test.ts ./apps/cocos-client/test/root-telemetry-hooks.test.ts ./apps/cocos-client/test/root-tutorial-orchestrator.test.ts ./apps/cocos-client/test/cocos-veil-root.test.ts ./apps/cocos-client/test/cocos-root-orchestration.test.ts\n- npm run smoke:cocos:canonical-journey